### PR TITLE
dynamicworkflow: add dynamic workflow orchestration

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -64,6 +64,9 @@ const (
 	// session after the function-call processor clones the invocation
 	// session for state-delta isolation.
 	liveSessionStateKey = "__live_session__"
+	// forwardEventStateKey is the invocation state key used by internal
+	// eventstream attachment (see internal/state/eventstream).
+	forwardEventStateKey = "__forward_event__"
 
 	// streamHubStateKey is the invocation state key used by the graph to
 	// share ephemeral streams across node invocations within the same run.
@@ -102,6 +105,9 @@ const (
 	// TriggerTypeTransfer indicates the child invocation was created because
 	// the parent agent invoked the transfer_to_agent tool (handoff pattern).
 	TriggerTypeTransfer = event.TriggerTypeTransfer
+	// TriggerTypeDynamicWorkflow indicates the child invocation was created by
+	// a dynamic workflow script calling a registered child agent.
+	TriggerTypeDynamicWorkflow = event.TriggerTypeDynamicWorkflow
 )
 
 // ParentInvocationMetadata describes how a child invocation was triggered by
@@ -1699,6 +1705,7 @@ func isCloneStateKey(key string) bool {
 		barrierStateKey,
 		appenderStateKey,
 		liveSessionStateKey,
+		forwardEventStateKey,
 		streamHubStateKey,
 		surfaceRootNodeIDStateKey,
 		teamMemberTraceRootStateKey:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - Agent:
           - Agent: agent.md
           - Multi Agent: multiagent.md
+          - Dynamic Workflow: dynamic-workflow.md
           - Task Run Runtime: taskrun.md
           - Team: team.md
           - Graph Agent: graph.md
@@ -111,6 +112,7 @@ plugins:
                 - Agent:
                     - Agent: agent.md
                     - Multi Agent: multiagent.md
+                    - 动态工作流: dynamic-workflow.md
                     - Task Run 运行时: taskrun.md
                     - Team: team.md
                     - Graph Agent: graph.md

--- a/docs/mkdocs/en/dynamic-workflow.md
+++ b/docs/mkdocs/en/dynamic-workflow.md
@@ -1,0 +1,407 @@
+# Dynamic Workflow
+
+Dynamic Workflow lets a regular `LLMAgent` temporarily run workflow code for a
+complex request and use that workflow to orchestrate child Agents. The built-in
+`LocalRunner` currently executes Python workflow code.
+
+Application developers usually do not write this workflow code ahead of time.
+Your application only needs to:
+
+1. Prepare one or more base Agents that the workflow may call.
+2. Create the `run_workflow` tool.
+3. Attach `run_workflow` to the root Agent.
+
+If you only want to get started, read "Minimal setup" and "A complete example"
+first. The later sections explain tool calls, concurrency, event streams, and
+safety boundaries.
+
+At runtime, the flow looks like this:
+
+```text
+user request
+  ↓
+root Agent
+  ├─ simple task: answer directly
+  └─ complex task: call run_workflow
+        ↓
+      model generates temporary workflow code
+        ↓
+      workflow sends agent(...) calls through the bridge/RPC
+        ↓
+      registered base Agents run inside the Go process
+        ↓
+      child Agent events still enter Runner event stream / Session Service
+        ↓
+      workflow returns the combined result to the root Agent
+```
+
+Dynamic Workflow is useful when a task needs temporary roles, for example:
+
+```text
+analyze a plan → ask a reviewer to check it → revise with feedback → review again
+```
+
+Stable, deterministic, strongly constrained business processes should still be
+application Go code. For loops, branches, or JSON conversion across ordinary
+tools, prefer the lighter `execute_tool_code` capability.
+
+Python is the engineering choice of the current built-in runtime, not the core
+constraint of Dynamic Workflow. Workflow code is not an ordinary script that
+breaks away from the framework, and it does not directly call an Agent SDK from
+inside the script. It always crosses an explicit bridge/RPC back into the Go
+process, where registered Agents and tools continue to run. Using Go as the
+workflow language would therefore not provide direct access to in-process host
+objects.
+
+## Minimal setup
+
+The minimal setup registers one neutral base Agent and attaches `run_workflow`
+to the root Agent.
+
+Registering one base Agent is common. Many temporary roles only need different
+instructions, while the model, tools, and permission boundary can stay the
+same. Register multiple base Agents only when those boundaries really need to
+differ.
+
+Place this fragment in your application's Agent setup code:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+    "trpc.group/trpc-go/trpc-agent-go/tool/dynamicworkflow"
+)
+
+// The root Agent and workflow-local child Agents may share one model instance.
+modelInstance := openai.New("gpt-5")
+
+// Register one base Agent. Workflow code will call it through agent(...).
+// This base Agent fixes the model, tools, and permission boundary; each call's
+// instruction defines the temporary role.
+general := llmagent.New(
+    "general_agent",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithDescription("Base agent for workflow-local roles."),
+    llmagent.WithInstruction(
+        "Follow the dynamic instruction supplied for this workflow-local role.",
+    ),
+)
+
+// Create the run_workflow tool.
+// LocalRunner starts a local Python process and is only for development or
+// already-isolated environments.
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.LocalRunner{},
+    []agent.Agent{general},
+)
+if err != nil {
+    panic(err) // handle the error in production code
+}
+
+// Attach run_workflow to the root Agent.
+root := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithInstruction(
+        "Answer simple requests directly. Use run_workflow for tasks that " +
+            "need temporary child-agent collaboration.",
+    ),
+    llmagent.WithTools([]tool.Tool{workflow}),
+)
+```
+
+This exposes only `run_workflow` to the root Agent. The root Agent's other
+tools are not automatically available inside the workflow. This keeps the
+workflow boundary explicit and avoids accidental access to writes,
+credentials, shell execution, or control-plane tools.
+
+## `agent(...)` in the current Python workflow
+
+Think of `agent(...)` as: run one Go-registered base Agent once.
+
+If `NewTool` registered exactly one base Agent, the workflow can call it
+directly:
+
+```python
+result = await agent(
+    "Review this production change.",
+    instruction="You are a strict production reviewer.",
+)
+return result["text"]
+```
+
+If multiple base Agents are registered, the workflow must select one by name:
+
+```python
+result = await agent(
+    "Review this production change.",
+    template="reviewer",
+)
+```
+
+The `template` field is only the selector for "which base Agent to call". It
+is not a separate template system.
+
+One `agent(...)` call can define a temporary role:
+
+```python
+review = await agent(
+    {"draft": draft},
+    instruction="Review the draft and return approval plus feedback.",
+    tools=[],
+    structured_output={
+        "type": "object",
+        "properties": {
+            "approved": {"type": "boolean"},
+            "feedback": {"type": "string"},
+        },
+    },
+)
+```
+
+The common options are:
+
+- `instruction`: the temporary role instruction for this child Agent call.
+- `tools` / `skills`: omitted means inherit from the base Agent; `[]` disables
+  that capability for this call; a non-empty list narrows the base Agent's
+  existing capabilities.
+- `structured_output` / `schema`: asks this child Agent to return structured
+  JSON.
+- `instance_id`: reuses the same child Agent history within one workflow.
+
+When `instance_id` is omitted, each `agent(...)` call creates an independent
+child Agent history, which is the right default for parallel branches. Passing
+the same `instance_id` explicitly means the calls share one child history; if
+those calls happen concurrently, they are serialized to avoid concurrent reads
+and writes to the same conversation branch.
+
+These options affect only the current child Agent call. A workflow cannot use
+them to change the model, permission policy, or add host capabilities that the
+base Agent did not already have.
+
+## A complete example
+
+Assume the user asks:
+
+> Review the production change "Enable a new cache for the product catalog":
+> first analyze risk and rationale, then make an approval decision.
+
+The root Agent may call `run_workflow`. The model may generate and execute this
+workflow code:
+
+```python
+analysis = await agent(
+    "Analyze the production change: Enable a new cache for the product catalog.",
+    instruction="You are a technical analyst reviewing a production change.",
+    structured_output={
+        "type": "object",
+        "properties": {
+            "risks": {"type": "array", "items": {"type": "string"}},
+            "rationale": {"type": "string"},
+        },
+    },
+)
+
+review = await agent(
+    {
+        "change": "Enable a new cache for the product catalog",
+        "analysis": analysis["structured"],
+    },
+    instruction="You are a senior engineering reviewer for production changes.",
+    structured_output={
+        "type": "object",
+        "properties": {
+            "approved": {"type": "boolean"},
+            "next_steps": {"type": "array", "items": {"type": "string"}},
+        },
+    },
+)
+
+return {
+    "analysis": analysis["structured"],
+    "decision": review["structured"],
+}
+```
+
+This workflow code is usually generated temporarily by the model; this example
+uses Python. It is not business logic that the application pre-writes in Go.
+
+The first `agent(...)` call makes the base Agent temporarily act as a technical
+analyst and return structured risk data. The second `agent(...)` call passes
+that structured result into the same base Agent acting as a senior reviewer.
+The final result may look like this:
+
+```json
+{
+  "analysis": {
+    "risks": [
+      "Cache invalidation can expose stale product information.",
+      "Concurrent updates can introduce data-consistency issues."
+    ],
+    "rationale": "Caching reduces database load for a read-heavy catalog."
+  },
+  "decision": {
+    "approved": true,
+    "next_steps": [
+      "Define cache invalidation and TTL policies.",
+      "Add cache metrics and run a phased rollout."
+    ]
+  }
+}
+```
+
+If later code needs stable fields, prefer reading `result["structured"]`. The
+framework does not infer field names, units, or business meaning from natural
+language. If the model service does not support JSON Schema response formats,
+this structured call may fail; if stable fields are unnecessary, omit
+`structured_output`.
+
+## Concurrency and batch work
+
+Use `parallel` when independent branches can run at the same time. Results are
+returned in input order:
+
+```python
+reviews = await parallel([
+    lambda: agent({"plan": plan}, instruction="Review security risk."),
+    lambda: agent({"plan": plan}, instruction="Review operational risk."),
+])
+```
+
+`parallel` results are ordered like the input list, but the event stream is
+real-time. Partial outputs, tool calls, and final events from concurrent child
+Agents may be interleaved. Consumers should group events by fields such as
+`InvocationID`, `ParentMetadata`, and `FilterKey` instead of relying on the
+global event order.
+
+Use `pipeline(items, stage1, stage2, ...)` for repeated multi-stage work over a
+batch of items. Each item moves through the stages in order. Once one item's
+previous stage finishes, it can enter the next stage without waiting for the
+whole batch.
+
+```python
+async def analyze(previous, original, index):
+    return await agent({"file": original}, instruction="Analyze this file.")
+
+async def verify(analysis, original, index):
+    return await agent(
+        {"file": original, "analysis": analysis["structured"]},
+        instruction="Verify the analysis.",
+    )
+
+results = await pipeline(files, analyze, verify)
+```
+
+## Calling tools from workflow code: `WithCodeCallableTools` and `call_tool`
+
+The minimal setup does not need `dynamicworkflow.WithCodeCallableTools`. In
+that setup, workflow code mainly orchestrates child Agents through
+`agent(...)`.
+
+If workflow code really needs to call ordinary business tools directly,
+explicitly pass those tools when creating `run_workflow`:
+
+```go
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.LocalRunner{},
+    []agent.Agent{general},
+    dynamicworkflow.WithCodeCallableTools(searchCatalog, createQuote),
+)
+```
+
+Then workflow code can call:
+
+```python
+facts = await call_tool("search_catalog", query="trail backpack")
+```
+
+`call_tool` can only call tools explicitly passed through
+`WithCodeCallableTools`. It does not automatically see the root Agent's tools.
+
+Do not put execution tools, `run_workflow` itself, `execute_tool_code`,
+`transfer_to_agent`, `await_user_reply`, workspace tools, or AgentTools into
+`WithCodeCallableTools`. They create recursive or mixed control-flow
+boundaries. Workflows should call child Agents through `agent(...)`.
+
+## Events, Session, and execution boundary
+
+The first version of Dynamic Workflow is foreground and one-shot. Workflow code
+only expresses the orchestration logic; the actual child Agent execution still
+happens inside the Go process. In other words, `agent(...)` is not an ordinary
+SDK call from a disconnected script. It is a bridge/RPC call back into the
+host-side Agent runtime.
+
+Implementation-wise, each child Agent is derived from the parent invocation as
+a new invocation: it reuses the parent execution's Session, SessionService,
+Plugins, and event-forwarding path, but receives a new InvocationID, input
+Message, ParentMetadata, and independent event filter key. Therefore the child
+Agent's LLM context and event branch remain isolated instead of being simply
+merged into the root Agent's current prompt context.
+
+Therefore, child Agent output events are still sent through the current Runner
+event stream:
+
+- Frontends can observe child Agent output and tool-call progress from the same
+  event stream.
+- The configured Session Service persists those events.
+- `parallel` branch events may appear interleaved; this is real-time stream
+  semantics and does not change that `parallel(...)` results are returned in
+  input order.
+
+This is the key difference from asking the model to write and run an ordinary
+standalone script: the temporary workflow gets code-level flexibility, while
+Agent execution, tool boundaries, event streaming, and Session persistence
+remain controlled by the Go framework.
+
+`dynamicworkflow.LocalRunner` starts a local Python process. It is not a
+security sandbox. In production, provide your own `dynamicworkflow.Runtime`,
+such as a container, microVM, or remote sandbox, and enforce filesystem,
+network, process, dependency, and resource limits there.
+
+Generated workflow code should call host tools rather than direct HTTP APIs.
+Authentication, authorization, retries, idempotency, audit, rate limiting, and
+API-version policy should remain controlled by business tools on the Go side.
+
+## Choosing the right capability
+
+| Need | Recommended approach |
+| --- | --- |
+| Stable, known, strongly constrained business process | application Go code |
+| Loops, branches, or JSON conversion across ordinary tools | `execute_tool_code` |
+| Temporary child-Agent roles, review, parallel analysis, iterative revision | `run_workflow` |
+
+Do not expose both `execute_tool_code` and `run_workflow` to the same root
+Agent by default. Both are Python orchestration paths, and exposing both makes
+the model's choice harder.
+
+See the runnable
+[Dynamic Workflow Agent example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/dynamicworkflow).
+
+## Roadmap note: file-backed workflows
+
+This section is a future-design note. Most users can skip it.
+
+The current version is one-shot: the model passes inline workflow code to
+`run_workflow` and runs it immediately.
+
+A future extension may support file-backed execution, where workflow scripts
+can be written, edited, reviewed, and re-run as normal workspace files. This
+should be a source-selection extension of `run_workflow`, not a full workflow
+management system in this package.
+
+Key constraints:
+
+- Future inputs should choose exactly one of inline `code` or workspace `file`,
+  with optional JSON `args`.
+- File paths should be workspace-relative, not arbitrary host paths.
+- The file resolver should reuse the parent invocation's `codeexecutor`
+  workspace.
+- The workflow tool should run existing scripts, not provide a script-authoring
+  API.
+- File-backed workflows persist script source, not execution state; resume,
+  checkpoints, publishing, and cross-node storage need separate designs.
+- The file-backed version should preserve the current Runtime boundary: it may
+  orchestrate registered Agents and explicitly granted host tools, but it
+  should not gain unrestricted filesystem or shell access.

--- a/docs/mkdocs/zh/dynamic-workflow.md
+++ b/docs/mkdocs/zh/dynamic-workflow.md
@@ -1,0 +1,358 @@
+# 动态工作流
+
+动态工作流让一个普通 `LLMAgent` 在遇到复杂任务时，临时运行一段 workflow
+代码去编排多个子 Agent。当前内置 `LocalRunner` 执行的是 Python workflow。
+
+业务开发者通常不需要提前写这段 workflow 代码。你要做的是：
+
+1. 准备一个或多个可被 workflow 调用的基础 Agent。
+2. 创建 `run_workflow` 工具。
+3. 把 `run_workflow` 挂到根 Agent 上。
+
+如果只想先跑起来，读完“最小接入”和“一个完整例子”就够了。后面的章节主要解释
+工具调用、并发、事件流和安全边界。
+
+运行时大致是这样：
+
+```text
+用户请求
+  ↓
+根 Agent
+  ├─ 简单任务：直接回答
+  └─ 复杂任务：调用 run_workflow
+        ↓
+      模型生成临时 workflow 代码
+        ↓
+      workflow 通过 bridge/RPC 发起 agent(...) 调用
+        ↓
+      Go 进程内运行已注册的基础 Agent
+        ↓
+      子 Agent 事件继续进入 Runner event stream / Session Service
+        ↓
+      汇总结果并返回给根 Agent
+```
+
+适合动态工作流的任务通常需要临时拆分角色，例如：
+
+```text
+分析方案 → 让 reviewer 审核 → 按反馈修改 → 再次审核
+```
+
+如果流程稳定、确定、强业务约束，应直接写应用 Go 代码。如果只是普通工具之间的
+循环、分支或 JSON 转换，应优先使用更轻量的 `execute_tool_code`。
+
+Python 是当前内置运行时的工程选择，不是动态工作流的本质约束。workflow 代码不是
+一段脱离框架的普通脚本，也不是在脚本里直接调用某个 Agent SDK；它始终通过显式
+bridge/RPC 回到 Go 进程，由 Go 侧继续运行已注册的 Agent 和工具。因此使用 Go 作为
+workflow 语言也不会获得直接访问宿主进程对象的优势。
+
+## 最小接入
+
+下面是最小接入方式：注册一个中性的基础 Agent，然后把 `run_workflow`
+挂到根 Agent 上。
+
+只注册一个基础 Agent 是常见做法。因为很多临时角色只是 instruction 不同，
+模型、工具和权限边界都可以共用。只有这些边界真的不同时，才需要注册多个基础
+Agent。
+
+把下面片段放进应用自己的 Agent setup 代码里：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+    "trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+    "trpc.group/trpc-go/trpc-agent-go/tool"
+    "trpc.group/trpc-go/trpc-agent-go/tool/dynamicworkflow"
+)
+
+// 根 Agent 和 workflow 内的子 Agent 可以共用同一个模型实例。
+modelInstance := openai.New("gpt-5")
+
+// 注册一个基础 Agent。workflow 代码后续会通过 agent(...) 调用它。
+// 这个基础 Agent 固定模型、工具、权限等边界；临时角色由每次调用的 instruction 决定。
+general := llmagent.New(
+    "general_agent",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithDescription("Base agent for workflow-local roles."),
+    llmagent.WithInstruction(
+        "Follow the dynamic instruction supplied for this workflow-local role.",
+    ),
+)
+
+// 创建 run_workflow 工具。
+// LocalRunner 会启动本地 Python 进程，只适合开发或已隔离的环境。
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.LocalRunner{},
+    []agent.Agent{general},
+)
+if err != nil {
+    panic(err) // 生产代码中应按需处理错误
+}
+
+// 把 run_workflow 挂到根 Agent 上。
+root := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithInstruction(
+        "Answer simple requests directly. Use run_workflow for tasks that " +
+            "need temporary child-agent collaboration.",
+    ),
+    llmagent.WithTools([]tool.Tool{workflow}),
+)
+```
+
+这段代码只把 `run_workflow` 暴露给根 Agent。根 Agent 的其他工具不会自动进入
+workflow。这样可以避免 workflow 意外获得写操作、凭证、shell 执行或控制面工具。
+
+## 当前 Python workflow 里的 `agent(...)`
+
+`agent(...)` 可以理解成：运行一次 Go 侧已注册的基础 Agent。
+
+如果 `NewTool` 只注册了一个基础 Agent，workflow 可以直接调用：
+
+```python
+result = await agent(
+    "Review this production change.",
+    instruction="You are a strict production reviewer.",
+)
+return result["text"]
+```
+
+如果注册了多个基础 Agent，workflow 需要指定名字：
+
+```python
+result = await agent(
+    "Review this production change.",
+    template="reviewer",
+)
+```
+
+这里的 `template` 只是“选择哪个基础 Agent”的字段名，不是一套额外的模板系统。
+
+一次 `agent(...)` 调用可以临时指定角色：
+
+```python
+review = await agent(
+    {"draft": draft},
+    instruction="Review the draft and return approval plus feedback.",
+    tools=[],
+    structured_output={
+        "type": "object",
+        "properties": {
+            "approved": {"type": "boolean"},
+            "feedback": {"type": "string"},
+        },
+    },
+)
+```
+
+常用选项只有几个：
+
+- `instruction`：这次子 Agent 的临时角色说明。
+- `tools` / `skills`：省略表示继承基础 Agent；`[]` 表示这次禁用；非空列表表示在基础 Agent 已有能力上收窄。
+- `structured_output` / `schema`：要求这次子 Agent 返回结构化 JSON。
+- `instance_id`：同一个 workflow 内多次调用复用同一个子 Agent 历史。
+
+默认不传 `instance_id` 时，每次 `agent(...)` 调用都会创建独立的子 Agent
+历史，适合并发分支。显式传相同 `instance_id` 表示复用同一条子历史；
+并发调用同一个 `instance_id` 会被串行执行，避免同时读写同一段会话历史。
+
+这些选项只影响当前这次子 Agent 调用。workflow 不能借它改变模型、权限策略，
+也不能新增基础 Agent 本来没有的宿主能力。
+
+## 一个完整例子
+
+假设用户要求：
+
+> Review the production change “Enable a new cache for the product catalog”:
+> first analyze risk and rationale, then make an approval decision.
+
+根 Agent 可以调用 `run_workflow`。模型可能生成并执行下面这段 workflow 代码：
+
+```python
+analysis = await agent(
+    "Analyze the production change: Enable a new cache for the product catalog.",
+    instruction="You are a technical analyst reviewing a production change.",
+    structured_output={
+        "type": "object",
+        "properties": {
+            "risks": {"type": "array", "items": {"type": "string"}},
+            "rationale": {"type": "string"},
+        },
+    },
+)
+
+review = await agent(
+    {
+        "change": "Enable a new cache for the product catalog",
+        "analysis": analysis["structured"],
+    },
+    instruction="You are a senior engineering reviewer for production changes.",
+    structured_output={
+        "type": "object",
+        "properties": {
+            "approved": {"type": "boolean"},
+            "next_steps": {"type": "array", "items": {"type": "string"}},
+        },
+    },
+)
+
+return {
+    "analysis": analysis["structured"],
+    "decision": review["structured"],
+}
+```
+
+注意：这段 workflow 代码通常是模型临时生成的；当前示例使用 Python。它不是业务预先
+写死在 Go 里的代码。
+
+第一次 `agent(...)` 让基础 Agent 临时扮演“技术分析员”，返回结构化风险分析。
+第二次 `agent(...)` 把第一步的结构化结果作为输入，让同一个基础 Agent 临时扮演
+“资深 reviewer”。最终返回值类似：
+
+```json
+{
+  "analysis": {
+    "risks": [
+      "Cache invalidation can expose stale product information.",
+      "Concurrent updates can introduce data-consistency issues."
+    ],
+    "rationale": "Caching reduces database load for a read-heavy catalog."
+  },
+  "decision": {
+    "approved": true,
+    "next_steps": [
+      "Define cache invalidation and TTL policies.",
+      "Add cache metrics and run a phased rollout."
+    ]
+  }
+}
+```
+
+如果后续代码要稳定读取字段，应优先使用 `result["structured"]`。框架不会从自然语言
+里猜字段、单位或业务含义。如果模型服务不支持 JSON Schema 响应格式，这次结构化
+调用可能失败；不需要稳定字段时，可以不传 `structured_output`。
+
+## 并发与批处理
+
+`parallel` 用于同时执行互不依赖的分支，并按输入顺序返回结果：
+
+```python
+reviews = await parallel([
+    lambda: agent({"plan": plan}, instruction="Review security risk."),
+    lambda: agent({"plan": plan}, instruction="Review operational risk."),
+])
+```
+
+注意，`parallel` 的返回值按输入顺序排列，但 event stream 是实时完成顺序。
+两个并发子 Agent 的 partial、tool call 和 final 事件可能交错出现。前端或
+消费者应通过 `InvocationID`、`ParentMetadata`、`FilterKey` 等字段把事件
+归到对应分支，而不是依赖全局事件顺序。
+
+`pipeline(items, stage1, stage2, ...)` 用于对一批对象执行重复的多阶段处理。
+每个 item 会按 stage 顺序前进；一个 item 完成前一阶段后，就可以进入下一阶段，
+不需要等待整批 item。
+
+```python
+async def analyze(previous, original, index):
+    return await agent({"file": original}, instruction="Analyze this file.")
+
+async def verify(analysis, original, index):
+    return await agent(
+        {"file": original, "analysis": analysis["structured"]},
+        instruction="Verify the analysis.",
+    )
+
+results = await pipeline(files, analyze, verify)
+```
+
+## 在 workflow 代码里调用工具：`WithCodeCallableTools` 与 `call_tool`
+
+最小接入不需要 `dynamicworkflow.WithCodeCallableTools`。此时 workflow 代码主要通过
+`agent(...)` 编排子 Agent。
+
+如果确实需要让 workflow 代码直接调用普通业务工具，可以在创建工具时显式传入：
+
+```go
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.LocalRunner{},
+    []agent.Agent{general},
+    dynamicworkflow.WithCodeCallableTools(searchCatalog, createQuote),
+)
+```
+
+然后 workflow 代码可以调用：
+
+```python
+facts = await call_tool("search_catalog", query="trail backpack")
+```
+
+`call_tool` 只能调用 `WithCodeCallableTools` 显式传入的工具。它不会自动看到根 Agent 的工具。
+
+不要把执行类工具、`run_workflow` 自身、`execute_tool_code`、`transfer_to_agent`、
+`await_user_reply`、workspace 工具或 AgentTool 放进 `WithCodeCallableTools`。这些工具容易形成
+递归或混合控制流边界；workflow 调用子 Agent 应使用 `agent(...)`。
+
+## 事件、Session 与执行边界
+
+Dynamic Workflow 第一版是前台、一次性执行。workflow 代码只负责表达编排逻辑；
+真正的子 Agent 执行仍发生在 Go 进程里。`agent(...)` 不是脚本里断开框架联系的
+一次普通 SDK 调用，而是一次通过 bridge/RPC 回到宿主侧的 Agent 调用。
+
+实现上，子 Agent 会从父 invocation 派生出新的 invocation：它复用父执行里的
+Session、SessionService、Plugin 和事件转发通道，但拥有新的 InvocationID、输入
+Message、ParentMetadata 和独立的 event filter key。因此，子 Agent 的 LLM 上下文和
+事件分支仍然是隔离的，不会简单混进根 Agent 的当前提示词上下文。
+
+因此，子 Agent 的输出事件会继续回到当前 Runner 的事件流里：
+
+- 前端可以从同一个 event stream 看到子 Agent 输出和工具调用进度。
+- 配置的 Session Service 会持久化这些事件。
+- `parallel` 分支的事件可能交错出现；这是实时流语义，不影响
+  `parallel(...)` 返回值仍按输入顺序排列。
+
+这也是 Dynamic Workflow 和“让模型写一个普通脚本自己跑完”的关键区别：临时
+workflow 具备代码的灵活性，但 Agent 执行、工具边界、事件流和 Session 持久化仍由
+Go 框架掌控。
+
+`dynamicworkflow.LocalRunner` 会启动本地 Python 进程。它不是安全 sandbox。
+生产环境应提供自己的 `dynamicworkflow.Runtime`，例如容器、microVM 或远端 sandbox，
+并在里面落实文件系统、网络、进程、依赖和资源限制。
+
+生成的 workflow 代码应该调用宿主工具，而不是直接调用 HTTP API。认证、授权、
+重试、幂等、审计、限流和 API 版本适配仍应由业务工具在 Go 侧掌控。
+
+## 如何选择能力
+
+| 需求 | 推荐方式 |
+| --- | --- |
+| 稳定、已知、强业务约束的流程 | 应用 Go 代码 |
+| 普通工具之间的循环、分支、JSON 转换 | `execute_tool_code` |
+| 临时子 Agent 分工、审核、并发分析、反复修改 | `run_workflow` |
+
+默认不要向同一个根 Agent 同时暴露 `execute_tool_code` 和 `run_workflow`。
+两者都是代码编排路径，同时暴露会增加模型选择难度。
+
+完整可运行代码见 [Dynamic Workflow Agent 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/dynamicworkflow)。
+
+## 后续计划：文件化 workflow
+
+这一节是后续设计备忘，普通使用者可以跳过。
+
+当前版本是一次性的：模型把 inline workflow 代码传给 `run_workflow` 并立即执行。
+
+后续可以扩展文件化执行，让 workflow 脚本像普通 workspace 文件一样被写入、
+编辑、review 和重复运行。这个方向应作为 `run_workflow` 的 source 选择扩展，
+而不是在本包里引入完整的 workflow 管理系统。
+
+关键约束：
+
+- 未来入参应在 inline `code` 与 workspace `file` 中二选一，并可加 JSON `args`。
+- 文件路径应是 workspace 相对路径，不是任意宿主机路径。
+- file resolver 应复用父 invocation 的 `codeexecutor` workspace。
+- workflow 工具只负责运行已有脚本，不负责提供脚本创作 API。
+- 文件化 workflow 持久化的是脚本源码，不是执行状态；resume、checkpoint、发布、
+  跨节点存储都需要单独设计。
+- 文件化版本仍应保留当前 Runtime 边界：只能编排已注册 Agent 和显式授权的宿主工具，
+  不能因此获得无边界文件系统或 shell 访问。

--- a/event/event.go
+++ b/event/event.go
@@ -67,6 +67,9 @@ const (
 	// TriggerTypeTransfer indicates the child invocation was created because
 	// the parent agent invoked the transfer_to_agent tool (handoff pattern).
 	TriggerTypeTransfer = "transfer"
+	// TriggerTypeDynamicWorkflow indicates the child invocation was created by
+	// one dynamic workflow script calling a registered child agent.
+	TriggerTypeDynamicWorkflow = "dynamic_workflow"
 )
 
 // ParentInvocationMetadata describes how a child invocation was triggered by

--- a/examples/dynamicworkflow/README.md
+++ b/examples/dynamicworkflow/README.md
@@ -1,0 +1,301 @@
+# Dynamic Workflow Example
+
+This example shows the flexible form of Dynamic Workflow: the application
+registers one neutral `general_agent` base agent, while workflow code calls it
+one or more times with different temporary roles.
+
+```text
+workflow_assistant
+└── run_workflow
+    └── registered base agent: general_agent
+        ├── tool: lookup_policy
+        ├── dynamic instance: producer / researcher / writer / planner
+        └── dynamic instance: reviewer / critic / verifier
+```
+
+The registered base agent fixes the model, executor, callbacks, and permission
+boundary. Each `agent(...)` call can supply a role-specific `instruction`,
+`instance_id`, optional narrowed tools/skills, and `structured_output`. It does
+not grant new host capabilities.
+
+This example deliberately keeps the root agent prompt lean. The
+`run_workflow` tool declaration teaches the current Python workflow DSL itself (`await agent`,
+`parallel`, `pipeline`, `schema`, direct `return`, and the no-wrapper rules),
+while the example's root prompt focuses only on when to call
+`run_workflow` and how to constrain `lookup_policy`. If you copy this
+example into an application, keep that layering: put workflow-language rules in
+the tool description, and keep the root prompt focused on task-routing policy
+and capability boundaries.
+
+The `general_agent` base agent also has one ordinary child-agent tool,
+`lookup_policy`. It is not exposed to the root agent and is not exposed as a
+Python `call_tool`; it is available only when a workflow-created child Agent
+uses its own tool surface. This makes the example show that child Agent tool
+call events are forwarded through the same Runner event stream.
+Workflow code should narrow this tool explicitly, for example
+`tools=["lookup_policy"]`, only for a child role that reviews, approves, or
+rejects something against a team collaboration guideline. Ordinary summaries,
+generic analysis, operational-risk review, and non-policy pipeline stages
+should pass `tools=[]` so the base agent's default tool surface is not inherited.
+
+For `structured_output`, a bare JSON Schema is the concise form, for example
+`{"type": "object", "properties": {...}}`. Use the richer
+`{"name": ..., "schema": {...}, "strict": ...}` form only when the workflow
+needs output metadata.
+
+The shortest calls are `await agent(input, {"instruction": "..."})` and
+`await agent(input, instruction="...")`: because this example has one
+base agent, `general_agent` is selected automatically.
+Omitted `tools` and `skills` inherit the base agent's eligible user tools and
+configured skills. Use `[]` only when a role must have none; use a non-empty
+list only when a role needs a narrower capability set.
+
+The example deliberately does not configure `dynamicworkflow.WithCodeCallableTools`, so
+the workflow code sees only the Agent-oriented DSL. An application that
+explicitly configures `dynamicworkflow.WithCodeCallableTools` also exposes direct Python
+`call_tool`, but that is a separate tool-orchestration surface.
+
+## Prerequisites
+
+- Go 1.24.4 or later
+- Python 3 available as `python3` (the demo uses `dynamicworkflow.LocalRunner`)
+- An OpenAI-compatible model endpoint
+
+```bash
+export OPENAI_API_KEY="<your-api-key>"
+# Optional for a compatible endpoint:
+export OPENAI_BASE_URL="https://your-endpoint/v1"
+```
+
+## Run
+
+```bash
+cd examples
+go run ./dynamicworkflow -model gpt-5
+```
+
+With no `-prompt`, the example starts an interactive chat loop and keeps one
+Runner session open until you type `/new` or `/exit`.
+
+Commands:
+
+- `/new`: start a fresh session
+- `/exit`: quit the demo
+
+For a single-turn run, pass `-prompt`:
+
+```bash
+go run ./dynamicworkflow -model gpt-5 \
+  -prompt 'Build a temporary team: propose a collaboration plan for a remote team, have a reviewer check it against the team collaboration guideline using lookup_policy, and revise the plan with the feedback.'
+```
+
+The example prints the model-generated workflow source by default. Disable it
+with `-show-workflow-code=false`.
+
+The event printer also monitors Runner events for child Agent tool calls. A
+typical run includes lines like:
+
+```text
+[general_agent via dynamic_workflow] tool call: lookup_policy (id: call_...) args: {"topic":"remote_collaboration"}
+[general_agent via dynamic_workflow] tool result: lookup_policy (id: call_...) {"topic":"remote_collaboration","guidelines":[...]}
+```
+
+Those lines come from the child Agent's own event stream and are forwarded
+through the active Runner loop, the same path used for normal streaming output.
+For a child role that must demonstrate tool use, prefer returning text from
+that child instead of also requesting `structured_output`; some providers tend
+to satisfy a strict structured response directly instead of calling a tool.
+
+## End-to-end walkthrough
+
+For this request:
+
+> Build a temporary two-role workflow to review the production change “Enable
+> a new cache for the product catalog.” First analyze risk and rationale, then
+> have a reviewer approve or reject it with next steps.
+
+In a real run, the model generated and executed this equivalent, simplified
+workflow body:
+
+```python
+analysis = await agent(
+    "Analyze the production change: Enable a new cache for the product catalog.",
+    instruction="You are a technical analyst reviewing a production change.",
+    structured_output={
+        "type": "object",
+        "properties": {
+            "risks": {"type": "array", "items": {"type": "string"}},
+            "rationale": {"type": "string"},
+        },
+        "required": ["risks", "rationale"],
+    },
+)
+
+review = await agent(
+    {
+        "change": "Enable a new cache for the product catalog",
+        "analysis": analysis["structured"],
+    },
+    instruction="You are a senior engineering reviewer for production changes.",
+    structured_output={
+        "type": "object",
+        "properties": {
+            "approved": {"type": "boolean"},
+            "next_steps": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["approved", "next_steps"],
+    },
+)
+
+return {
+    "change": "Enable a new cache for the product catalog",
+    "analysis": analysis["structured"],
+    "decision": review["structured"],
+}
+```
+
+The two `agent` calls create separate workflow-local instances of the same
+`general_agent` base agent. Their model, executor, callbacks, and capability
+boundary remain fixed by Go; only their role instruction and response schema
+are temporary. The returned value has this shape:
+
+```json
+{
+  "change": "Enable a new cache for the product catalog",
+  "analysis": {
+    "risks": [
+      "Cache invalidation can expose stale product information.",
+      "Concurrent updates can introduce data-consistency issues."
+    ],
+    "rationale": "Caching reduces database load for a read-heavy catalog."
+  },
+  "decision": {
+    "approved": true,
+    "next_steps": [
+      "Define cache invalidation and TTL policies.",
+      "Add cache metrics and run a phased rollout."
+    ]
+  }
+}
+```
+
+The exact prose and recommendations are model-generated; the stable contract
+is the workflow code, its declared schemas, and the returned JSON shape.
+
+## Expected workflow shape
+
+The exact roles and schemas are model-generated. A revision workflow should
+look like this:
+
+```python
+draft = await agent({"task": task}, {
+    "instance_id": "producer",
+    "instruction": (
+        "Act as the task's producing specialist. Produce a concrete draft. "
+        "When feedback is supplied, revise the prior draft against every item."
+    ),
+    "structured_output": {
+        "name": "draft",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "required": ["content"],
+            "properties": {"content": {"type": "string"}},
+        },
+    },
+})
+
+for round_index in range(3):
+    review = await agent({"draft": draft["structured"]["content"]}, {
+        "instance_id": "reviewer",
+        "instruction": "Review the draft strictly and return actionable feedback.",
+        "structured_output": {
+            "name": "review",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "required": ["approved", "feedback"],
+                "properties": {
+                    "approved": {"type": "boolean"},
+                    "feedback": {"type": "string"},
+                },
+            },
+        },
+    })
+
+    if review["structured"]["approved"]:
+        return {"draft": draft, "review": review}
+
+    draft = await agent({
+        "draft": draft["structured"]["content"],
+        "feedback": review["structured"]["feedback"],
+    }, {
+        "instance_id": "producer",
+        "instruction": "Revise the draft using every review comment.",
+        "structured_output": {
+            "name": "draft",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "required": ["content"],
+                "properties": {"content": {"type": "string"}},
+            },
+        },
+    })
+
+return {"draft": draft, "review": review}
+```
+
+`agent` returns an envelope with `text`, `structured`, session metadata,
+and an invocation ID. Prefer `result["structured"]["field"]` for a role's
+typed result. For workflow ergonomics, missing `result["field"]` and
+`result.get("field")` fall back to `structured`; envelope keys take
+precedence. With `strict: True`, object schemas are completed with
+`additionalProperties: False` and every declared property is made required for
+OpenAI-compatible strict response formats. Model an optional value as nullable
+when needed.
+
+## Concurrent and pipeline work
+
+Use `parallel` only when independent roles may run at the same time. It keeps
+result order and returns `None` for a failed branch:
+
+```python
+perspectives = await parallel([
+    lambda: agent({"plan": plan}, {"instruction": "Review security risks."}),
+    lambda: agent({"plan": plan}, {"instruction": "Review operational risks."}),
+])
+```
+
+For a repeated per-item process, use `pipeline`. Each item advances to its next
+stage as soon as its own previous stage completes; it does not wait for every
+item in the batch. Its returned list contains each item's final-stage result,
+so a later stage must explicitly retain earlier data needed by the final
+summary:
+
+```python
+async def analyze(previous, original, index):
+    return await agent({"file": previous}, {"instruction": "Analyze this file."})
+
+async def verify(analysis, original, index):
+    return await agent(
+        {"file": original, "analysis": analysis["structured"]},
+        {"instruction": "Verify the analysis."},
+    )
+
+results = await pipeline(files, analyze, verify)
+```
+
+## Runtime and session behavior
+
+The workflow is foreground and one-shot. Child roles run from clones of the
+parent Invocation rather than recursively calling `Runner.Run`. `parallel`
+branches run concurrently (up to the framework's per-workflow limit) with
+distinct child instances by default. Their output events are persisted by the
+configured Session Service and forwarded through the same caller-visible event
+stream as the root run.
+
+`LocalRunner` starts a local Python process and is not a security sandbox. In
+production, provide a `dynamicworkflow.Runtime` backed by a container, microVM,
+or remote sandbox, and apply filesystem, network, process, dependency, and
+resource policy there.

--- a/examples/dynamicworkflow/main.go
+++ b/examples/dynamicworkflow/main.go
@@ -43,7 +43,7 @@ var (
 	)
 	showWorkflowCode = flag.Bool(
 		"show-workflow-code",
-		true,
+		false,
 		"Print the generated Python workflow code before executing it",
 	)
 )
@@ -121,6 +121,7 @@ func (c *dynamicWorkflowChat) printBanner() {
 
 func (c *dynamicWorkflowChat) startChat(ctx context.Context) error {
 	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for {
 		fmt.Print("You: ")
 		if !scanner.Scan() {
@@ -329,7 +330,10 @@ func printToolResults(evt *event.Event) {
 		}
 		content := strings.TrimSpace(msg.Content)
 		if len(content) > 240 {
-			content = content[:240] + "..."
+			runes := []rune(content)
+			if len(runes) > 240 {
+				content = string(runes[:240]) + "..."
+			}
 		}
 		fmt.Printf("[%s] tool result: %s (id: %s) %s\n", eventLabel(evt), name, msg.ToolID, content)
 	}

--- a/examples/dynamicworkflow/main.go
+++ b/examples/dynamicworkflow/main.go
@@ -1,0 +1,350 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates a normal LLMAgent that may create one temporary
+// dynamic workflow. One neutral registered template can become multiple
+// workflow-local roles through dynamic AgentSpecs while the root remains in
+// control.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/dynamicworkflow"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+var (
+	modelName = flag.String("model", "gpt-5", "Model name for the OpenAI-compatible endpoint")
+	prompt    = flag.String(
+		"prompt",
+		"",
+		"Optional single-turn prompt. If empty, start interactive chat.",
+	)
+	showWorkflowCode = flag.Bool(
+		"show-workflow-code",
+		true,
+		"Print the generated Python workflow code before executing it",
+	)
+)
+
+func main() {
+	flag.Parse()
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Fprintln(os.Stderr, "OPENAI_API_KEY is required (OPENAI_BASE_URL is optional).")
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	modelInstance := openai.New(*modelName)
+	workflowTool, err := buildWorkflowTool(modelInstance)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build workflow tool: %v\n", err)
+		os.Exit(1)
+	}
+	if *showWorkflowCode {
+		workflowTool = debugWorkflowCodeTool{inner: workflowTool}
+	}
+
+	root := llmagent.New(
+		"workflow_assistant",
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription("Creates temporary, role-based workflows for tasks that need collaboration or revision."),
+		llmagent.WithInstruction(`Answer simple requests directly. For tasks that require role delegation, multi-step collaboration, concurrent analysis, or conditional iteration, call run_workflow exactly once and do not answer with Python source. This example registers one neutral general_agent template, so template is usually omitted. Use agent(...) to create workflow-local roles; the template fixes model, executor, tools, and permissions, while each dynamic instruction defines the temporary business role. For ordinary drafting, analysis, summaries, and non-policy pipeline stages, pass tools=[]. Only when a child is explicitly reviewing, approving, or rejecting against a team collaboration guideline should it use tools=["lookup_policy"] and be instructed to call lookup_policy before deciding. If a child must visibly demonstrate the policy lookup, prefer plain text output over structured_output for that child.`),
+		llmagent.WithTools([]tool.Tool{workflowTool}),
+	)
+	r := runner.NewRunner("dynamic-workflow-example", root)
+	defer r.Close()
+
+	chat := &dynamicWorkflowChat{
+		runner:    r,
+		userID:    "demo-user",
+		sessionID: newSessionID(),
+		modelName: *modelName,
+	}
+	if strings.TrimSpace(*prompt) != "" {
+		if err := chat.processMessage(ctx, *prompt); err != nil {
+			fmt.Fprintf(os.Stderr, "run agent: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	chat.printBanner()
+	if err := chat.startChat(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "interactive chat failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type dynamicWorkflowChat struct {
+	runner    runner.Runner
+	userID    string
+	sessionID string
+	modelName string
+}
+
+func newSessionID() string {
+	return fmt.Sprintf("dynamic-workflow-%d", time.Now().UnixNano())
+}
+
+func (c *dynamicWorkflowChat) printBanner() {
+	fmt.Printf("Dynamic Workflow Example\n")
+	fmt.Printf("Model: %s\n", c.modelName)
+	fmt.Printf("Session: %s\n", c.sessionID)
+	fmt.Println("Type '/new' to start a new session or '/exit' to quit.")
+	fmt.Println("Sample prompts:")
+	fmt.Println("  Use a temporary reviewer to check whether replacing daily status meetings with async updates and one weekly decision meeting follows the team collaboration guideline.")
+	fmt.Println("  Build a temporary team: propose a collaboration plan for a remote team, have a reviewer check it against the team collaboration guideline, and revise the plan with the feedback.")
+	fmt.Println("  Use run_workflow once. Use pipeline over two plans: plan A is daily status meetings, plan B is async written updates plus one weekly decision meeting. Stage 1 asks a child agent to analyze the plan. Stage 2 asks a child agent to make a final recommendation based on stage 1.")
+	fmt.Println(strings.Repeat("=", 72))
+}
+
+func (c *dynamicWorkflowChat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+		switch strings.ToLower(userInput) {
+		case "/exit":
+			fmt.Println("Goodbye.")
+			return nil
+		case "/new":
+			c.sessionID = newSessionID()
+			fmt.Printf("Started new session: %s\n\n", c.sessionID)
+			continue
+		}
+		if err := c.processMessage(ctx, userInput); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *dynamicWorkflowChat) processMessage(
+	ctx context.Context,
+	userMessage string,
+) error {
+	events, err := c.runner.Run(
+		ctx,
+		c.userID,
+		c.sessionID,
+		model.NewUserMessage(userMessage),
+	)
+	if err != nil {
+		return fmt.Errorf("run agent: %w", err)
+	}
+	printEvents(events)
+	return nil
+}
+
+func buildWorkflowTool(m model.Model) (tool.CallableTool, error) {
+	policyTool := function.NewFunctionTool(
+		lookupPolicy,
+		function.WithName("lookup_policy"),
+		function.WithDescription("Look up the team collaboration guideline for an explicit review, approval, or rejection decision. Use topic \"remote_collaboration\"."),
+	)
+	generalAgent := llmagent.New(
+		"general_agent",
+		llmagent.WithModel(m),
+		llmagent.WithDescription("A neutral execution template for one workflow-local role defined by its dynamic instruction."),
+		llmagent.WithInstruction(`Follow the dynamic instance instruction as the complete definition of your current role. Treat the input as JSON context. Do not assume a business domain from this template. Use lookup_policy only when your dynamic instruction explicitly asks you to review, approve, or reject something against a team collaboration guideline, or explicitly tells you to call lookup_policy. Do not use lookup_policy for ordinary summaries, generic analysis, operational-risk review, or pipeline stages that are not policy reviews. When a structured output contract is requested, return data that conforms to it.`),
+		llmagent.WithTools([]tool.Tool{policyTool}),
+	)
+
+	return dynamicworkflow.NewTool(
+		dynamicworkflow.LocalRunner{},
+		[]agent.Agent{generalAgent},
+	)
+}
+
+type policyLookupRequest struct {
+	Topic string `json:"topic" jsonschema:"description=Policy topic to look up, for example remote_collaboration."`
+}
+
+type policyLookupResult struct {
+	Topic      string   `json:"topic"`
+	Guidelines []string `json:"guidelines"`
+}
+
+func lookupPolicy(_ context.Context, req policyLookupRequest) (policyLookupResult, error) {
+	topic := strings.TrimSpace(req.Topic)
+	if topic == "" {
+		topic = "remote_collaboration"
+	}
+	switch topic {
+	case "remote_collaboration", "meeting_load", "async_updates":
+		return policyLookupResult{
+			Topic: "remote_collaboration",
+			Guidelines: []string{
+				"Prefer asynchronous written updates for routine status sharing.",
+				"Keep recurring meetings below three hours per person per week unless explicitly justified.",
+				"Every recurring meeting should have an owner, agenda, decision log, and cancellation rule.",
+				"Escalate blockers with a clear owner and deadline instead of adding broad status meetings.",
+			},
+		}, nil
+	default:
+		return policyLookupResult{
+			Topic: topic,
+			Guidelines: []string{
+				"No specific policy exists for this topic; ask for explicit approval before making a high-impact change.",
+			},
+		}, nil
+	}
+}
+
+type debugWorkflowCodeTool struct {
+	inner tool.CallableTool
+}
+
+func (t debugWorkflowCodeTool) Declaration() *tool.Declaration {
+	return t.inner.Declaration()
+}
+
+func (t debugWorkflowCodeTool) Call(ctx context.Context, raw []byte) (any, error) {
+	var input struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &input); err == nil &&
+		strings.TrimSpace(input.Code) != "" {
+		fmt.Fprintln(os.Stderr, "\n===== generated dynamic workflow code =====")
+		fmt.Fprintln(os.Stderr, input.Code)
+		fmt.Fprintln(os.Stderr, "===== end generated dynamic workflow code =====")
+		fmt.Fprintln(os.Stderr)
+	}
+	return t.inner.Call(ctx, raw)
+}
+
+func printEvents(events <-chan *event.Event) {
+	eventCount := 0
+	for evt := range events {
+		if evt == nil {
+			continue
+		}
+		eventCount++
+		if evt.Response != nil && evt.Response.Error != nil {
+			fmt.Fprintf(os.Stderr, "[%s] error: %s\n", evt.Author, evt.Response.Error.Message)
+			continue
+		}
+		if printToolEvent(evt) {
+			continue
+		}
+		if evt.StructuredOutput != nil {
+			if raw, err := json.Marshal(evt.StructuredOutput); err == nil {
+				fmt.Printf("[%s] structured: %s\n", eventLabel(evt), raw)
+			}
+		}
+		if evt.Response == nil {
+			continue
+		}
+		if len(evt.Response.Choices) == 0 {
+			continue
+		}
+		choice := evt.Response.Choices[0]
+		content := choice.Delta.Content
+		if content == "" {
+			content = choice.Message.Content
+		}
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		fmt.Printf("[%s] %s\n", eventLabel(evt), content)
+	}
+	if eventCount == 0 {
+		fmt.Fprintln(os.Stderr, "no events were emitted")
+	}
+}
+
+func printToolEvent(evt *event.Event) bool {
+	if evt == nil || evt.Response == nil {
+		return false
+	}
+	if evt.Response.IsToolCallResponse() {
+		printToolCalls(evt)
+		return true
+	}
+	if evt.Response.IsToolResultResponse() {
+		printToolResults(evt)
+		return true
+	}
+	return false
+}
+
+func printToolCalls(evt *event.Event) {
+	for _, choice := range evt.Response.Choices {
+		for _, call := range append(choice.Message.ToolCalls, choice.Delta.ToolCalls...) {
+			fmt.Printf("[%s] tool call: %s", eventLabel(evt), call.Function.Name)
+			if call.ID != "" {
+				fmt.Printf(" (id: %s)", call.ID)
+			}
+			if len(call.Function.Arguments) > 0 {
+				fmt.Printf(" args: %s", string(call.Function.Arguments))
+			}
+			fmt.Println()
+		}
+	}
+}
+
+func printToolResults(evt *event.Event) {
+	for _, choice := range evt.Response.Choices {
+		msg := choice.Message
+		if msg.ToolID == "" && choice.Delta.ToolID != "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID == "" {
+			continue
+		}
+		name := msg.ToolName
+		if name == "" {
+			name = "tool"
+		}
+		content := strings.TrimSpace(msg.Content)
+		if len(content) > 240 {
+			content = content[:240] + "..."
+		}
+		fmt.Printf("[%s] tool result: %s (id: %s) %s\n", eventLabel(evt), name, msg.ToolID, content)
+	}
+}
+
+func eventLabel(evt *event.Event) string {
+	if evt == nil {
+		return "unknown"
+	}
+	label := evt.Author
+	if label == "" {
+		label = "unknown"
+	}
+	if evt.ParentMetadata != nil && evt.ParentMetadata.TriggerType != "" {
+		label += " via " + evt.ParentMetadata.TriggerType
+	}
+	return label
+}

--- a/internal/state/eventstream/eventstream.go
+++ b/internal/state/eventstream/eventstream.go
@@ -1,0 +1,89 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go
+// available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package eventstream lets components that execute nested work outside the
+// root agent event channel forward events through the active Runner loop.
+package eventstream
+
+import (
+	"context"
+	"sync"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+)
+
+// StateKeyForwardEvent is the invocation state key used by Attach.
+const StateKeyForwardEvent = "__forward_event__"
+
+// Forwarder forwards one event through the active Runner event loop. A
+// successful return means the event has been processed by that loop, including
+// its session persistence and caller-visible emission steps.
+type Forwarder func(context.Context, *event.Event) error
+
+type holder struct {
+	mu sync.RWMutex
+	fn Forwarder
+}
+
+func (h *holder) set(fn Forwarder) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.fn = fn
+}
+
+func (h *holder) get() Forwarder {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.fn
+}
+
+func (h *holder) clear() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.fn = nil
+}
+
+// Attach binds an event forwarder to inv. Invocation clones retain the holder
+// so nested agent execution can use the same Runner event loop.
+func Attach(inv *agent.Invocation, fn Forwarder) {
+	if inv == nil {
+		return
+	}
+	if h, ok := agent.GetStateValue[*holder](inv, StateKeyForwardEvent); ok && h != nil {
+		h.set(fn)
+		return
+	}
+	inv.SetState(StateKeyForwardEvent, &holder{fn: fn})
+}
+
+// Invoke forwards evt when a Runner forwarder is available. The boolean result
+// reports whether a forwarder was attached.
+func Invoke(ctx context.Context, inv *agent.Invocation, evt *event.Event) (bool, error) {
+	h, ok := agent.GetStateValue[*holder](inv, StateKeyForwardEvent)
+	if !ok || h == nil {
+		return false, nil
+	}
+	fn := h.get()
+	if fn == nil {
+		return false, nil
+	}
+	return true, fn(ctx, evt)
+}
+
+// Clear disables any forwarder attached to inv.
+func Clear(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	if h, ok := agent.GetStateValue[*holder](inv, StateKeyForwardEvent); ok && h != nil {
+		h.clear()
+	}
+	inv.DeleteState(StateKeyForwardEvent)
+}

--- a/runner/diagnostics.go
+++ b/runner/diagnostics.go
@@ -166,11 +166,19 @@ func runnerEventAttrs(evt *event.Event) []attribute.KeyValue {
 	if evt == nil {
 		return nil
 	}
+	object := ""
+	partial := false
+	done := false
+	if evt.Response != nil {
+		object = evt.Object
+		partial = evt.IsPartial
+		done = evt.Done
+	}
 	attrs := []attribute.KeyValue{
 		attribute.String("runner.event.id", evt.ID),
-		attribute.String("runner.event.object", evt.Object),
-		attribute.Bool("runner.event.partial", evt.IsPartial),
-		attribute.Bool("runner.event.done", evt.Done),
+		attribute.String("runner.event.object", object),
+		attribute.Bool("runner.event.partial", partial),
+		attribute.Bool("runner.event.done", done),
 		attribute.Bool("runner.event.requires_completion", evt.RequiresCompletion),
 		attribute.Int("runner.event.state_delta_keys", len(evt.StateDelta)),
 	}

--- a/runner/eventstream_test.go
+++ b/runner/eventstream_test.go
@@ -128,6 +128,37 @@ func TestRunnerForwardedEventDoesNotOverrideRootCompletion(t *testing.T) {
 	require.Equal(t, []string{"child result", "root result"}, sessionAssistantContents(sess))
 }
 
+func TestRunnerForwarderIsAvailableDuringAgentRun(t *testing.T) {
+	service := sessioninmemory.NewSessionService()
+	ag := &synchronousEventForwardingAgent{}
+	r := NewRunner("event-forwarding-sync", ag, WithSessionService(service))
+	defer r.Close()
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("start"),
+	)
+	require.NoError(t, err)
+
+	var authors []string
+	for evt := range events {
+		if evt != nil {
+			authors = append(authors, evt.Author)
+		}
+	}
+	require.True(t, ag.forwarded)
+	require.Contains(t, authors, "child-agent")
+	require.Contains(t, authors, "root-agent")
+
+	sess, err := service.GetSession(context.Background(), session.Key{
+		AppName: "event-forwarding-sync", UserID: "user", SessionID: "session",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"child result", "root result"}, sessionAssistantContents(sess))
+}
+
 func TestForwardedEventIsExcludedFromRootCompletionCapture(t *testing.T) {
 	r := &runner{}
 	rootSession := session.NewSession("app", "user", "session")
@@ -235,6 +266,43 @@ func (a *eventForwardingChildAgent) Info() agent.Info {
 }
 func (a *eventForwardingChildAgent) SubAgents() []agent.Agent { return nil }
 func (a *eventForwardingChildAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+type synchronousEventForwardingAgent struct {
+	forwarded bool
+}
+
+func (a *synchronousEventForwardingAgent) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	child := inv.Clone(
+		agent.WithInvocationAgent(&eventForwardingChildAgent{}),
+		agent.WithInvocationEventFilterKey(inv.GetEventFilterKey()+"/child-agent"),
+	)
+	childEvent := eventstreamResponseEvent(child.InvocationID, "child-agent", "child result")
+	agent.InjectIntoEvent(child, childEvent)
+	forwarded, err := eventstream.Invoke(ctx, child, childEvent)
+	if err != nil {
+		return nil, err
+	}
+	a.forwarded = forwarded
+
+	ch := make(chan *event.Event, 1)
+	rootEvent := eventstreamResponseEvent(inv.InvocationID, "root-agent", "root result")
+	agent.InjectIntoEvent(inv, rootEvent)
+	ch <- rootEvent
+	close(ch)
+	return ch, nil
+}
+
+func (a *synchronousEventForwardingAgent) Tools() []tool.Tool { return nil }
+func (a *synchronousEventForwardingAgent) Info() agent.Info {
+	return agent.Info{Name: "root-agent"}
+}
+func (a *synchronousEventForwardingAgent) SubAgents() []agent.Agent { return nil }
+func (a *synchronousEventForwardingAgent) FindSubAgent(string) agent.Agent {
 	return nil
 }
 

--- a/runner/eventstream_test.go
+++ b/runner/eventstream_test.go
@@ -207,6 +207,39 @@ func TestRunnerForwardedEventsDoNotBlockRunReturn(t *testing.T) {
 	require.GreaterOrEqual(t, len(sessionAssistantContents(sess)), ag.count)
 }
 
+func TestRunnerEventEmitterClosesAfterCancellationWithoutReader(t *testing.T) {
+	service := sessioninmemory.NewSessionService()
+	ag := &burstSynchronousEventForwardingAgent{
+		count: defaultRunnerEventBufferSize + 8,
+	}
+	r := NewRunner("event-forwarding-cancel", ag, WithSessionService(service))
+	defer r.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events, err := r.Run(
+		ctx,
+		"user",
+		"session",
+		model.NewUserMessage("start"),
+	)
+	require.NoError(t, err)
+
+	// Cancel before consuming from the returned event channel. The emitter must
+	// stop waiting on caller backpressure and close the channel during cleanup.
+	cancel()
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		for range events {
+		}
+	}()
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner event stream did not close after cancellation")
+	}
+}
+
 func TestForwardedEventIsExcludedFromRootCompletionCapture(t *testing.T) {
 	r := &runner{}
 	rootSession := session.NewSession("app", "user", "session")

--- a/runner/eventstream_test.go
+++ b/runner/eventstream_test.go
@@ -1,0 +1,293 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/eventstream"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestRunnerEventStreamUnusedPreservesRootRun(t *testing.T) {
+	service := sessioninmemory.NewSessionService()
+	ag := &rootOnlyEventAgent{name: "root-agent", content: "root result"}
+	r := NewRunner("eventstream-unused", ag, WithSessionService(service))
+	defer r.Close()
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("start"),
+	)
+	require.NoError(t, err)
+
+	var assistantContents []string
+	for evt := range events {
+		if content := eventAssistantContent(evt); content != "" {
+			assistantContents = append(assistantContents, content)
+		}
+	}
+	require.Equal(t, []string{"root result"}, assistantContents)
+
+	sess, err := service.GetSession(context.Background(), session.Key{
+		AppName: "eventstream-unused", UserID: "user", SessionID: "session",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"root result"}, sessionAssistantContents(sess))
+}
+
+func TestRunnerForwardsNestedEventsThroughMainEventLoop(t *testing.T) {
+	service := sessioninmemory.NewSessionService()
+	ag := &eventForwardingTestAgent{start: make(chan struct{})}
+	r := NewRunner("event-forwarding", ag, WithSessionService(service))
+	defer r.Close()
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("start"),
+	)
+	require.NoError(t, err)
+	close(ag.start)
+
+	var authors []string
+	for evt := range events {
+		if evt != nil {
+			authors = append(authors, evt.Author)
+		}
+	}
+	require.Contains(t, authors, "child-agent")
+	require.Contains(t, authors, "root-agent")
+
+	sess, err := service.GetSession(context.Background(), session.Key{
+		AppName: "event-forwarding", UserID: "user", SessionID: "session",
+	})
+	require.NoError(t, err)
+	var childStored bool
+	for _, evt := range sess.GetEvents() {
+		if evt.Author == "child-agent" {
+			childStored = true
+			break
+		}
+	}
+	require.True(t, childStored, "forwarded child event must use the normal session persistence path")
+}
+
+func TestRunnerForwardedEventDoesNotOverrideRootCompletion(t *testing.T) {
+	service := sessioninmemory.NewSessionService()
+	ag := &eventForwardingTestAgent{start: make(chan struct{})}
+	r := NewRunner("event-forwarding-completion", ag, WithSessionService(service))
+	defer r.Close()
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("start"),
+	)
+	require.NoError(t, err)
+	close(ag.start)
+
+	var runnerCompletion *event.Event
+	var assistantContents []string
+	for evt := range events {
+		if evt != nil && evt.IsRunnerCompletion() {
+			runnerCompletion = evt
+			continue
+		}
+		if content := eventAssistantContent(evt); content != "" {
+			assistantContents = append(assistantContents, content)
+		}
+	}
+	require.Equal(t, []string{"child result", "root result"}, assistantContents)
+	require.NotNil(t, runnerCompletion)
+	require.NotEqual(t, "child result", eventAssistantContent(runnerCompletion))
+
+	sess, err := service.GetSession(context.Background(), session.Key{
+		AppName: "event-forwarding-completion", UserID: "user", SessionID: "session",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"child result", "root result"}, sessionAssistantContents(sess))
+}
+
+func TestForwardedEventIsExcludedFromRootCompletionCapture(t *testing.T) {
+	r := &runner{}
+	rootSession := session.NewSession("app", "user", "session")
+	loop := &eventLoopContext{
+		sess:                     rootSession,
+		processingForwardedEvent: true,
+	}
+	childEvent := eventstreamResponseEvent("child-invocation", "child-agent", "child result")
+
+	exclude := shouldExcludeRootCompletion(loop, rootSession, false)
+	require.True(t, exclude)
+	r.captureRootCompletion(loop, childEvent, exclude)
+	require.Empty(t, loop.fallbackChoices)
+	require.Empty(t, loop.fallbackResponseID)
+
+	loop.processingForwardedEvent = false
+	rootEvent := eventstreamResponseEvent("root-invocation", "root-agent", "root result")
+	exclude = shouldExcludeRootCompletion(loop, rootSession, false)
+	require.False(t, exclude)
+	r.captureRootCompletion(loop, rootEvent, exclude)
+	require.Equal(t, "root result", assistantChoicePrimaryContent(loop.fallbackChoices))
+}
+
+func TestEventStreamClearDisablesInheritedForwarder(t *testing.T) {
+	root := agent.NewInvocation(agent.WithInvocationAgent(&rootOnlyEventAgent{name: "root"}))
+	var forwarded []*event.Event
+	eventstream.Attach(root, func(_ context.Context, evt *event.Event) error {
+		forwarded = append(forwarded, evt)
+		return nil
+	})
+	child := root.Clone(agent.WithInvocationAgent(&eventForwardingChildAgent{}))
+	evt := event.New(child.InvocationID, "child")
+
+	ok, err := eventstream.Invoke(context.Background(), child, evt)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, forwarded, 1)
+
+	eventstream.Clear(root)
+
+	ok, err = eventstream.Invoke(context.Background(), child, evt)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Len(t, forwarded, 1)
+}
+
+func TestRunnerEventStatsAllowNilResponseEvent(t *testing.T) {
+	loop := &eventLoopContext{}
+
+	require.NotPanics(t, func() {
+		recordRunnerEventStats(loop, &event.Event{})
+	})
+	require.Equal(t, 1, loop.processedEventCount)
+	require.Zero(t, loop.partialEventCount)
+	require.Zero(t, loop.doneEventCount)
+}
+
+type eventForwardingTestAgent struct {
+	start chan struct{}
+}
+
+func (a *eventForwardingTestAgent) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	out := make(chan *event.Event, 1)
+	go func() {
+		defer close(out)
+		<-a.start
+
+		child := inv.Clone(
+			agent.WithInvocationAgent(&eventForwardingChildAgent{}),
+			agent.WithInvocationEventFilterKey(inv.GetEventFilterKey()+"/child-agent"),
+		)
+		childEvent := eventstreamResponseEvent(child.InvocationID, "child-agent", "child result")
+		agent.InjectIntoEvent(child, childEvent)
+		if _, err := eventstream.Invoke(ctx, child, childEvent); err != nil {
+			return
+		}
+
+		rootEvent := eventstreamResponseEvent(inv.InvocationID, "root-agent", "root result")
+		agent.InjectIntoEvent(inv, rootEvent)
+		out <- rootEvent
+	}()
+	return out, nil
+}
+
+func (a *eventForwardingTestAgent) Tools() []tool.Tool { return nil }
+func (a *eventForwardingTestAgent) Info() agent.Info {
+	return agent.Info{Name: "root-agent"}
+}
+func (a *eventForwardingTestAgent) SubAgents() []agent.Agent { return nil }
+func (a *eventForwardingTestAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+type eventForwardingChildAgent struct{}
+
+func (a *eventForwardingChildAgent) Run(context.Context, *agent.Invocation) (<-chan *event.Event, error) {
+	return nil, nil
+}
+func (a *eventForwardingChildAgent) Tools() []tool.Tool { return nil }
+func (a *eventForwardingChildAgent) Info() agent.Info {
+	return agent.Info{Name: "child-agent"}
+}
+func (a *eventForwardingChildAgent) SubAgents() []agent.Agent { return nil }
+func (a *eventForwardingChildAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+type rootOnlyEventAgent struct {
+	name    string
+	content string
+}
+
+func (a *rootOnlyEventAgent) Run(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event, 1)
+	evt := eventstreamResponseEvent(inv.InvocationID, a.name, a.content)
+	agent.InjectIntoEvent(inv, evt)
+	ch <- evt
+	close(ch)
+	return ch, nil
+}
+func (a *rootOnlyEventAgent) Tools() []tool.Tool { return nil }
+func (a *rootOnlyEventAgent) Info() agent.Info {
+	return agent.Info{Name: a.name}
+}
+func (a *rootOnlyEventAgent) SubAgents() []agent.Agent        { return nil }
+func (a *rootOnlyEventAgent) FindSubAgent(string) agent.Agent { return nil }
+
+func eventstreamResponseEvent(invocationID, author, content string) *event.Event {
+	return event.NewResponseEvent(invocationID, author, &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: model.Message{Role: model.RoleAssistant, Content: content},
+		}},
+	})
+}
+
+func eventAssistantContent(evt *event.Event) string {
+	if evt == nil || evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return ""
+	}
+	message := evt.Response.Choices[0].Message
+	if message.Role == model.RoleAssistant {
+		return message.Content
+	}
+	return ""
+}
+
+func sessionAssistantContents(sess *session.Session) []string {
+	if sess == nil {
+		return nil
+	}
+	var contents []string
+	for _, evt := range sess.GetEvents() {
+		if content := eventAssistantContent(&evt); content != "" {
+			contents = append(contents, content)
+		}
+	}
+	return contents
+}

--- a/runner/eventstream_test.go
+++ b/runner/eventstream_test.go
@@ -11,7 +11,9 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -159,6 +161,52 @@ func TestRunnerForwarderIsAvailableDuringAgentRun(t *testing.T) {
 	require.Equal(t, []string{"child result", "root result"}, sessionAssistantContents(sess))
 }
 
+func TestRunnerForwardedEventsDoNotBlockRunReturn(t *testing.T) {
+	service := sessioninmemory.NewSessionService()
+	ag := &burstSynchronousEventForwardingAgent{
+		count: defaultRunnerEventBufferSize + 8,
+	}
+	r := NewRunner("event-forwarding-burst", ag, WithSessionService(service))
+	defer r.Close()
+
+	type runResult struct {
+		events <-chan *event.Event
+		err    error
+	}
+	resultCh := make(chan runResult, 1)
+	go func() {
+		events, err := r.Run(
+			context.Background(),
+			"user",
+			"session",
+			model.NewUserMessage("start"),
+		)
+		resultCh <- runResult{events: events, err: err}
+	}()
+
+	var result runResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner Run blocked on forwarded events before returning")
+	}
+	require.NoError(t, result.err)
+
+	var childEvents int
+	for evt := range result.events {
+		if evt != nil && evt.Author == "child-agent" {
+			childEvents++
+		}
+	}
+	require.Equal(t, ag.count, childEvents)
+
+	sess, err := service.GetSession(context.Background(), session.Key{
+		AppName: "event-forwarding-burst", UserID: "user", SessionID: "session",
+	})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(sessionAssistantContents(sess)), ag.count)
+}
+
 func TestForwardedEventIsExcludedFromRootCompletionCapture(t *testing.T) {
 	r := &runner{}
 	rootSession := session.NewSession("app", "user", "session")
@@ -303,6 +351,46 @@ func (a *synchronousEventForwardingAgent) Info() agent.Info {
 }
 func (a *synchronousEventForwardingAgent) SubAgents() []agent.Agent { return nil }
 func (a *synchronousEventForwardingAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+type burstSynchronousEventForwardingAgent struct {
+	count int
+}
+
+func (a *burstSynchronousEventForwardingAgent) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	for i := 0; i < a.count; i++ {
+		child := inv.Clone(
+			agent.WithInvocationAgent(&eventForwardingChildAgent{}),
+			agent.WithInvocationEventFilterKey(fmt.Sprintf("%s/child-agent/%d", inv.GetEventFilterKey(), i)),
+		)
+		childEvent := eventstreamResponseEvent(
+			child.InvocationID,
+			"child-agent",
+			fmt.Sprintf("child result %d", i),
+		)
+		agent.InjectIntoEvent(child, childEvent)
+		if _, err := eventstream.Invoke(ctx, child, childEvent); err != nil {
+			return nil, err
+		}
+	}
+	ch := make(chan *event.Event, 1)
+	rootEvent := eventstreamResponseEvent(inv.InvocationID, "root-agent", "root result")
+	agent.InjectIntoEvent(inv, rootEvent)
+	ch <- rootEvent
+	close(ch)
+	return ch, nil
+}
+
+func (a *burstSynchronousEventForwardingAgent) Tools() []tool.Tool { return nil }
+func (a *burstSynchronousEventForwardingAgent) Info() agent.Info {
+	return agent.Info{Name: "root-agent"}
+}
+func (a *burstSynchronousEventForwardingAgent) SubAgents() []agent.Agent { return nil }
+func (a *burstSynchronousEventForwardingAgent) FindSubAgent(string) agent.Agent {
 	return nil
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -725,6 +725,19 @@ func (r *runner) Run(
 	livesession.Attach(invocation, sess)
 	barrier.Enable(invocation)
 
+	rootAgentEventCh := make(chan *event.Event, runnerEventChannelBufferSize(invocation))
+	forwardedEventCh, forwardedEventDone := attachRunnerEventForwarder(invocation)
+	processedEventCh := r.processAgentEvents(
+		execCtx,
+		sess,
+		invocation,
+		rootAgentEventCh,
+		forwardedEventCh,
+		forwardedEventDone,
+		flushChan,
+		handle,
+	)
+
 	// Run the agent and get the event channel.
 	startCtx, startSpan, startStarted := startRunnerLatencySpan(
 		execCtx,
@@ -736,6 +749,7 @@ func (r *runner) Run(
 	finishRunnerLatencySpan(startSpan, startStarted, err)
 	if err != nil {
 		r.persistAgentRunError(execCtx, currentTurnSession, invocation, ag, err)
+		close(rootAgentEventCh)
 		steer.Clear(invocation)
 		r.unregisterRun(ro.RequestID)
 		execCancel()
@@ -743,15 +757,8 @@ func (r *runner) Run(
 		return nil, err
 	}
 
-	// Process the agent events and emit them to the output channel.
-	return r.processAgentEvents(
-		execCtx,
-		sess,
-		invocation,
-		agentEventCh,
-		flushChan,
-		handle,
-	), nil
+	go forwardRootAgentEvents(execCtx, agentEventCh, rootAgentEventCh)
+	return processedEventCh, nil
 }
 
 func (r *runner) newRunInvocation(
@@ -1271,11 +1278,55 @@ func (r *runner) processAgentEvents(
 	sess *session.Session,
 	invocation *agent.Invocation,
 	agentEventCh <-chan *event.Event,
+	forwardedEventCh chan *forwardedEvent,
+	forwardedEventDone chan struct{},
 	flushChan chan *flush.FlushRequest,
 	handle *runHandle,
 ) chan *event.Event {
 	processedEventCh := make(chan *event.Event, cap(agentEventCh))
-	forwardedEventCh := make(chan *forwardedEvent, 64)
+	if cap(processedEventCh) == 0 {
+		processedEventCh = make(chan *event.Event, defaultRunnerEventBufferSize)
+	}
+	if forwardedEventCh == nil {
+		forwardedEventCh = make(chan *forwardedEvent, defaultRunnerEventBufferSize)
+	}
+	if forwardedEventDone == nil {
+		forwardedEventDone = make(chan struct{})
+	}
+	loop := &eventLoopContext{
+		sess:                      sess,
+		invocation:                invocation,
+		agentEventCh:              agentEventCh,
+		forwardedEventCh:          forwardedEventCh,
+		forwardedEventDone:        forwardedEventDone,
+		flushChan:                 flushChan,
+		processedEventCh:          processedEventCh,
+		runHandle:                 handle,
+		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
+		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
+		streamFilter: graph.NewStreamModeFilter(
+			invocation.RunOptions.StreamModeEnabled,
+			invocation.RunOptions.StreamModes,
+		),
+	}
+	runCtx := agent.CloneContext(ctx)
+	go r.runEventLoop(runCtx, loop)
+	return processedEventCh
+}
+
+const defaultRunnerEventBufferSize = 64
+
+func runnerEventChannelBufferSize(invocation *agent.Invocation) int {
+	if size := agent.GetEventChannelBufferSize(invocation); size > defaultRunnerEventBufferSize {
+		return size
+	}
+	return defaultRunnerEventBufferSize
+}
+
+func attachRunnerEventForwarder(
+	invocation *agent.Invocation,
+) (chan *forwardedEvent, chan struct{}) {
+	forwardedEventCh := make(chan *forwardedEvent, defaultRunnerEventBufferSize)
 	forwardedEventDone := make(chan struct{})
 	eventstream.Attach(invocation, func(ctx context.Context, evt *event.Event) error {
 		request := &forwardedEvent{event: evt, ack: make(chan error, 1)}
@@ -1298,25 +1349,33 @@ func (r *runner) processAgentEvents(
 			return err
 		}
 	})
-	loop := &eventLoopContext{
-		sess:                      sess,
-		invocation:                invocation,
-		agentEventCh:              agentEventCh,
-		forwardedEventCh:          forwardedEventCh,
-		forwardedEventDone:        forwardedEventDone,
-		flushChan:                 flushChan,
-		processedEventCh:          processedEventCh,
-		runHandle:                 handle,
-		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
-		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
-		streamFilter: graph.NewStreamModeFilter(
-			invocation.RunOptions.StreamModeEnabled,
-			invocation.RunOptions.StreamModes,
-		),
+	return forwardedEventCh, forwardedEventDone
+}
+
+func forwardRootAgentEvents(
+	ctx context.Context,
+	source <-chan *event.Event,
+	target chan<- *event.Event,
+) {
+	defer close(target)
+	if source == nil {
+		return
 	}
-	runCtx := agent.CloneContext(ctx)
-	go r.runEventLoop(runCtx, loop)
-	return processedEventCh
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-source:
+			if !ok {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case target <- evt:
+			}
+		}
+	}
 }
 
 // runEventLoop drives the main event processing loop for a single invocation.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1212,6 +1212,7 @@ type eventLoopContext struct {
 	forwardedEventDone                 chan struct{}
 	flushChan                          chan *flush.FlushRequest
 	processedEventCh                   chan *event.Event
+	eventEmitter                       *runnerEventEmitter
 	runHandle                          *runHandle
 	baselineFinalResponseID            string
 	priorAssistantResponseIDs          map[string]struct{}
@@ -1254,6 +1255,94 @@ type eventLoopContext struct {
 type forwardedEvent struct {
 	event *event.Event
 	ack   chan error
+}
+
+// runnerEventEmitter decouples the runner event loop from caller backpressure.
+// Nested work may emit events synchronously before Run returns the caller-facing
+// channel. The event loop must still acknowledge those nested events after
+// session persistence, even when the caller cannot consume output yet.
+type runnerEventEmitter struct {
+	out  chan<- *event.Event
+	done chan struct{}
+
+	mu     sync.Mutex
+	cond   *sync.Cond
+	queue  []runnerQueuedEvent
+	closed bool
+}
+
+type runnerQueuedEvent struct {
+	event *event.Event
+}
+
+func newRunnerEventEmitter(out chan<- *event.Event) *runnerEventEmitter {
+	emitter := &runnerEventEmitter{
+		out:  out,
+		done: make(chan struct{}),
+	}
+	emitter.cond = sync.NewCond(&emitter.mu)
+	go emitter.run()
+	return emitter
+}
+
+func (e *runnerEventEmitter) emit(ctx context.Context, evt *event.Event) error {
+	if e == nil || evt == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closed {
+		return context.Canceled
+	}
+	e.queue = append(e.queue, runnerQueuedEvent{event: evt})
+	e.cond.Signal()
+	return nil
+}
+
+func (e *runnerEventEmitter) close() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	if !e.closed {
+		e.closed = true
+		e.cond.Broadcast()
+	}
+	e.mu.Unlock()
+	<-e.done
+}
+
+func (e *runnerEventEmitter) run() {
+	defer close(e.out)
+	defer close(e.done)
+	for {
+		queued, ok := e.next()
+		if !ok {
+			return
+		}
+		if err := event.EmitEvent(context.Background(), e.out, queued.event); err != nil {
+			log.Errorf("emit runner event: %v", err)
+		}
+	}
+}
+
+func (e *runnerEventEmitter) next() (runnerQueuedEvent, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for len(e.queue) == 0 && !e.closed {
+		e.cond.Wait()
+	}
+	if len(e.queue) == 0 {
+		return runnerQueuedEvent{}, false
+	}
+	queued := e.queue[0]
+	copy(e.queue, e.queue[1:])
+	e.queue[len(e.queue)-1] = runnerQueuedEvent{}
+	e.queue = e.queue[:len(e.queue)-1]
+	return queued, true
 }
 
 type interruptedAssistantAccumulator struct {
@@ -1301,6 +1390,7 @@ func (r *runner) processAgentEvents(
 		forwardedEventDone:        forwardedEventDone,
 		flushChan:                 flushChan,
 		processedEventCh:          processedEventCh,
+		eventEmitter:              newRunnerEventEmitter(processedEventCh),
 		runHandle:                 handle,
 		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
 		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
@@ -1433,7 +1523,11 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 		livesession.Clear(loop.invocation)
 		steer.Clear(loop.invocation)
 		r.unregisterRun(loop.invocation.RunOptions.RequestID)
-		close(loop.processedEventCh)
+		if loop.eventEmitter != nil {
+			loop.eventEmitter.close()
+		} else {
+			close(loop.processedEventCh)
+		}
 		loop.invocation.CleanupNotice(ctx)
 		if loop.runHandle != nil {
 			loop.runHandle.cancel()
@@ -1651,7 +1745,13 @@ func (r *runner) emitProcessedEvent(
 			runnerEventAttrs(agentEvent)...,
 		)
 	}
-	if err := event.EmitEvent(emitCtx, loop.processedEventCh, agentEvent); err != nil {
+	var err error
+	if loop.eventEmitter != nil {
+		err = loop.eventEmitter.emit(emitCtx, agentEvent)
+	} else {
+		err = event.EmitEvent(emitCtx, loop.processedEventCh, agentEvent)
+	}
+	if err != nil {
 		if !emitStarted {
 			_, emitSpan, emitStarted = startRunnerLatencySpan(
 				ctx,
@@ -2995,8 +3095,8 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 			time.Second,
 		)
 		defer emitCancel()
-		if err := agent.EmitEvent(
-			emitCtx, loop.invocation, loop.processedEventCh, runnerCompletionEvent,
+		if err := r.emitProcessedEvent(
+			emitCtx, loop, runnerCompletionEvent, false,
 		); err != nil {
 			log.Errorf("Failed to emit runner completion event: %v", err)
 		}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1272,7 +1272,9 @@ type runnerEventEmitter struct {
 }
 
 type runnerQueuedEvent struct {
+	ctx   context.Context
 	event *event.Event
+	ack   chan error
 }
 
 func newRunnerEventEmitter(out chan<- *event.Event) *runnerEventEmitter {
@@ -1297,9 +1299,33 @@ func (e *runnerEventEmitter) emit(ctx context.Context, evt *event.Event) error {
 	if e.closed {
 		return context.Canceled
 	}
-	e.queue = append(e.queue, runnerQueuedEvent{event: evt})
+	e.queue = append(e.queue, runnerQueuedEvent{ctx: ctx, event: evt})
 	e.cond.Signal()
 	return nil
+}
+
+func (e *runnerEventEmitter) emitSync(ctx context.Context, evt *event.Event) error {
+	if e == nil || evt == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	ack := make(chan error, 1)
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return context.Canceled
+	}
+	e.queue = append(e.queue, runnerQueuedEvent{ctx: ctx, event: evt, ack: ack})
+	e.cond.Signal()
+	e.mu.Unlock()
+	select {
+	case err := <-ack:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (e *runnerEventEmitter) close() {
@@ -1323,8 +1349,14 @@ func (e *runnerEventEmitter) run() {
 		if !ok {
 			return
 		}
-		if err := event.EmitEvent(context.Background(), e.out, queued.event); err != nil {
-			log.Errorf("emit runner event: %v", err)
+		err := event.EmitEvent(queued.ctx, e.out, queued.event)
+		if queued.ack != nil {
+			queued.ack <- err
+		}
+		if err != nil {
+			if queued.ctx.Err() == nil {
+				log.Errorf("emit runner event: %v", err)
+			}
 		}
 	}
 }
@@ -3095,9 +3127,13 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 			time.Second,
 		)
 		defer emitCancel()
-		if err := r.emitProcessedEvent(
-			emitCtx, loop, runnerCompletionEvent, false,
-		); err != nil {
+		var err error
+		if loop.eventEmitter != nil {
+			err = loop.eventEmitter.emitSync(emitCtx, runnerCompletionEvent)
+		} else {
+			err = r.emitProcessedEvent(emitCtx, loop, runnerCompletionEvent, false)
+		}
+		if err != nil {
 			log.Errorf("Failed to emit runner completion event: %v", err)
 		}
 	}()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -35,6 +35,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/summaryrestore"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/appender"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/barrier"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/eventstream"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/flush"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/livesession"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
@@ -1200,6 +1201,8 @@ type eventLoopContext struct {
 	sess                               *session.Session
 	invocation                         *agent.Invocation
 	agentEventCh                       <-chan *event.Event
+	forwardedEventCh                   chan *forwardedEvent
+	forwardedEventDone                 chan struct{}
 	flushChan                          chan *flush.FlushRequest
 	processedEventCh                   chan *event.Event
 	runHandle                          *runHandle
@@ -1222,6 +1225,7 @@ type eventLoopContext struct {
 	streamFilter                       graph.StreamModeFilter
 	interruptedAssistants              map[string]*interruptedAssistantAccumulator
 	interruptedAssistantSequence       int64
+	processingForwardedEvent           bool
 	// emittedAssistantResponseIDs tracks response IDs that already produced a
 	// non-partial assistant message event during this run.
 	//
@@ -1235,6 +1239,14 @@ type eventLoopContext struct {
 	errorEventCount     int
 	emittedEventCount   int
 	detailSpanCount     int
+}
+
+// forwardedEvent is an event produced by nested work, such as a dynamic
+// workflow child agent. The sender waits for ack so child-agent session state
+// is visible before that agent proceeds to its next model turn.
+type forwardedEvent struct {
+	event *event.Event
+	ack   chan error
 }
 
 type interruptedAssistantAccumulator struct {
@@ -1263,10 +1275,35 @@ func (r *runner) processAgentEvents(
 	handle *runHandle,
 ) chan *event.Event {
 	processedEventCh := make(chan *event.Event, cap(agentEventCh))
+	forwardedEventCh := make(chan *forwardedEvent, 64)
+	forwardedEventDone := make(chan struct{})
+	eventstream.Attach(invocation, func(ctx context.Context, evt *event.Event) error {
+		request := &forwardedEvent{event: evt, ack: make(chan error, 1)}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-forwardedEventDone:
+			return context.Canceled
+		case forwardedEventCh <- request:
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-forwardedEventDone:
+			return context.Canceled
+		case err, ok := <-request.ack:
+			if !ok {
+				return nil
+			}
+			return err
+		}
+	})
 	loop := &eventLoopContext{
 		sess:                      sess,
 		invocation:                invocation,
 		agentEventCh:              agentEventCh,
+		forwardedEventCh:          forwardedEventCh,
+		forwardedEventDone:        forwardedEventDone,
 		flushChan:                 flushChan,
 		processedEventCh:          processedEventCh,
 		runHandle:                 handle,
@@ -1330,6 +1367,10 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 		// Disable further flush requests for this invocation.
 		flush.Clear(loop.invocation)
 		appender.Clear(loop.invocation)
+		if loop.forwardedEventDone != nil {
+			close(loop.forwardedEventDone)
+		}
+		eventstream.Clear(loop.invocation)
 		livesession.Clear(loop.invocation)
 		steer.Clear(loop.invocation)
 		r.unregisterRun(loop.invocation.RunOptions.RequestID)
@@ -1347,6 +1388,23 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 			}
 			if err := r.processSingleAgentEvent(ctx, loop, agentEvent); err != nil {
 				log.Errorf("process single agent event: %v", err)
+				return
+			}
+		case request, ok := <-loop.forwardedEventCh:
+			if !ok {
+				loop.forwardedEventCh = nil
+				continue
+			}
+			if request == nil {
+				continue
+			}
+			loop.processingForwardedEvent = true
+			err := r.processSingleAgentEvent(ctx, loop, request.event)
+			loop.processingForwardedEvent = false
+			request.ack <- err
+			close(request.ack)
+			if err != nil {
+				log.Errorf("process forwarded agent event: %v", err)
 				return
 			}
 		case req, ok := <-loop.flushChan:
@@ -1422,17 +1480,12 @@ func (r *runner) processSingleAgentEvent(
 		return nil
 	}
 	agentEvent = errorEventWithContent(agentEvent)
-	excludeRootCompletion := routedEvent && !sameSession(persistSession, loop.sess)
-	if excludeRootCompletion {
-		r.captureRoutedCompletionError(loop, agentEvent)
-	} else {
-		// Capture graph-level completion snapshot for final event.
-		if isGraphCompletionSnapshotEvent(agentEvent) {
-			loop.graphCompletionSeen = true
-			loop.finalStateDelta, loop.finalChoices = r.captureGraphCompletion(agentEvent)
-		}
-		r.captureCompletionFallback(loop, agentEvent)
-	}
+	excludeRootCompletion := shouldExcludeRootCompletion(
+		loop,
+		persistSession,
+		routedEvent,
+	)
+	r.captureRootCompletion(loop, agentEvent, excludeRootCompletion)
 	r.markCompletionSnapshotOnly(loop, agentEvent)
 	if shouldSuppressGraphCompletionEvent(loop, agentEvent) {
 		return nil
@@ -1484,7 +1537,50 @@ func (r *runner) processSingleAgentEvent(
 		r.recordVisibleCompletionEmission(loop, agentEvent)
 	}
 
-	// Emit event to output channel.
+	if err := r.emitProcessedEvent(ctx, loop, agentEvent, traceDetails); err != nil {
+		return err
+	}
+	loop.emittedEventCount++
+
+	return nil
+}
+
+func shouldExcludeRootCompletion(
+	loop *eventLoopContext,
+	persistSession *session.Session,
+	routedEvent bool,
+) bool {
+	// Nested work is forwarded so callers can observe it, but it must not become
+	// the root run's fallback/final assistant response. Dynamic workflows share
+	// the root session and therefore are not necessarily covered by the routed
+	// session check below.
+	return (routedEvent && !sameSession(persistSession, loop.sess)) ||
+		loop.processingForwardedEvent
+}
+
+func (r *runner) captureRootCompletion(
+	loop *eventLoopContext,
+	agentEvent *event.Event,
+	excludeRootCompletion bool,
+) {
+	if excludeRootCompletion {
+		r.captureRoutedCompletionError(loop, agentEvent)
+		return
+	}
+	// Capture graph-level completion snapshot for final event.
+	if isGraphCompletionSnapshotEvent(agentEvent) {
+		loop.graphCompletionSeen = true
+		loop.finalStateDelta, loop.finalChoices = r.captureGraphCompletion(agentEvent)
+	}
+	r.captureCompletionFallback(loop, agentEvent)
+}
+
+func (r *runner) emitProcessedEvent(
+	ctx context.Context,
+	loop *eventLoopContext,
+	agentEvent *event.Event,
+	traceDetails bool,
+) error {
 	emitCtx := ctx
 	var emitSpan oteltrace.Span
 	emitStarted := false
@@ -1508,9 +1604,7 @@ func (r *runner) processSingleAgentEvent(
 		finishRunnerLatencySpan(emitSpan, emitStarted, err)
 		return fmt.Errorf("emit event to output channel: %w", err)
 	}
-	loop.emittedEventCount++
 	finishRunnerLatencySpan(emitSpan, emitStarted, nil)
-
 	return nil
 }
 
@@ -1520,6 +1614,9 @@ func recordRunnerEventStats(loop *eventLoopContext, evt *event.Event) {
 	}
 	loop.processedEventCount++
 	if evt == nil {
+		return
+	}
+	if evt.Response == nil {
 		return
 	}
 	if evt.IsPartial {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -8852,8 +8852,17 @@ func TestProcessAgentEvents_EmitEventErrorBranch_Direct(t *testing.T) {
 
 	agentCh := make(chan *event.Event)
 	flushCh := make(chan *flush.FlushRequest)
-	// No Attach needed because processAgentEvents will attach using this channel.
-	processed := rr.processAgentEvents(ctx, sess, inv, agentCh, flushCh, nil)
+	forwardedEventCh, forwardedEventDone := attachRunnerEventForwarder(inv)
+	processed := rr.processAgentEvents(
+		ctx,
+		sess,
+		inv,
+		agentCh,
+		forwardedEventCh,
+		forwardedEventDone,
+		flushCh,
+		nil,
+	)
 	// Send one event, then close agentCh
 	go func() {
 		agentCh <- &event.Event{Response: &model.Response{Done: true, Choices: []model.Choice{{Index: 0, Message: model.NewAssistantMessage("x")}}}}

--- a/tool/dynamicworkflow/agent_spec.go
+++ b/tool/dynamicworkflow/agent_spec.go
@@ -1,0 +1,700 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
+)
+
+const maxStructuredOutputSchemaBytes = 64 << 10
+
+type agentTemplate struct {
+	name  string
+	agent agent.Agent
+	tools map[string]tool.Tool
+}
+
+type agentCallRequest struct {
+	templateName string
+	instanceID   string
+	input        json.RawMessage
+	spec         AgentSpec
+	dynamic      bool
+	newStyle     bool
+}
+
+func registerAgentTemplates(agents []agent.Agent) (map[string]agentTemplate, error) {
+	registered := make(map[string]agentTemplate, len(agents))
+	for _, candidate := range agents {
+		if candidate == nil {
+			return nil, fmt.Errorf("dynamicworkflow: agent is required")
+		}
+		name := strings.TrimSpace(candidate.Info().Name)
+		if name == "" {
+			return nil, fmt.Errorf("dynamicworkflow: agent name is required")
+		}
+		if _, exists := registered[name]; exists {
+			return nil, fmt.Errorf("dynamicworkflow: duplicate agent %q", name)
+		}
+		tools, userToolNames := templateToolSurface(context.Background(), candidate)
+		registered[name] = agentTemplate{
+			name:  name,
+			agent: candidate,
+			tools: selectableToolMap(tools, userToolNames, name),
+		}
+	}
+	return registered, nil
+}
+
+func templateToolSurface(
+	ctx context.Context,
+	candidate agent.Agent,
+) ([]tool.Tool, map[string]bool) {
+	provider, ok := candidate.(agent.InvocationToolSurfaceProvider)
+	if !ok || provider == nil {
+		return candidate.Tools(), nil
+	}
+	inv := agent.NewInvocation(agent.WithInvocationAgent(candidate))
+	return provider.InvocationToolSurface(ctx, inv)
+}
+
+func parseAgentCall(call Call) (agentCallRequest, error) {
+	var args map[string]json.RawMessage
+	if err := json.Unmarshal(call.Args, &args); err != nil {
+		return agentCallRequest{}, fmt.Errorf(
+			"dynamicworkflow: decode input for agent call: %w", err,
+		)
+	}
+	input, ok := args["input"]
+	if !ok || !json.Valid(input) {
+		return agentCallRequest{}, fmt.Errorf(
+			"dynamicworkflow: agent call requires JSON input",
+		)
+	}
+	if name := strings.TrimSpace(call.Name); name != "" {
+		return agentCallRequest{
+			templateName: name,
+			instanceID:   name,
+			input:        input,
+			spec:         AgentSpec{Template: name},
+		}, nil
+	}
+	if rawAgent, ok := args["agent"]; ok {
+		if !json.Valid(rawAgent) {
+			return agentCallRequest{}, fmt.Errorf(
+				"dynamicworkflow: agent selector must be valid JSON",
+			)
+		}
+		spec, dynamic, err := decodeAgentSelector(rawAgent)
+		if err != nil {
+			return agentCallRequest{}, err
+		}
+		instanceID := strings.TrimSpace(spec.InstanceID)
+		if instanceID == "" {
+			if dynamic {
+				instanceID = cleanPathSegment(call.ID)
+				if instanceID == "" {
+					instanceID = uuid.NewString()
+				}
+			} else {
+				instanceID = spec.Template
+			}
+		}
+		return agentCallRequest{
+			templateName: spec.Template,
+			instanceID:   instanceID,
+			input:        input,
+			spec:         spec,
+			dynamic:      dynamic,
+		}, nil
+	}
+
+	// The Python agent(input, options) DSL sends an optional options object.
+	// Template resolution happens in workflowGateway so a sole registered
+	// template can be inherited when options.template is omitted.
+	var spec AgentSpec
+	if rawOptions, ok := args["options"]; ok && strings.TrimSpace(string(rawOptions)) != "null" {
+		decoded, err := decodeAgentOptions(rawOptions)
+		if err != nil {
+			return agentCallRequest{}, err
+		}
+		spec = decoded
+	}
+	return agentCallRequest{
+		templateName: spec.Template,
+		input:        input,
+		spec:         spec,
+		newStyle:     true,
+	}, nil
+}
+
+func decodeAgentOptions(raw json.RawMessage) (AgentSpec, error) {
+	if !json.Valid(raw) {
+		return AgentSpec{}, fmt.Errorf("dynamicworkflow: agent options must be valid JSON")
+	}
+	var template string
+	if err := json.Unmarshal(raw, &template); err == nil {
+		return AgentSpec{Template: strings.TrimSpace(template)}, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		return AgentSpec{}, fmt.Errorf("dynamicworkflow: agent options must be a mapping or template name")
+	}
+	for name := range fields {
+		if !isSupportedAgentOption(name) {
+			return AgentSpec{}, fmt.Errorf("dynamicworkflow: unsupported agent option %q", name)
+		}
+	}
+	if rawStructuredOutput, ok := fields["structured_output"]; ok {
+		canonical, err := canonicalStructuredOutput(rawStructuredOutput)
+		if err != nil {
+			return AgentSpec{}, err
+		}
+		fields["structured_output"] = canonical
+	}
+	// schema is a concise options-level alias for structured_output.schema.
+	if rawSchema, ok := fields["schema"]; ok {
+		if _, hasStructuredOutput := fields["structured_output"]; !hasStructuredOutput {
+			canonical, err := json.Marshal(map[string]json.RawMessage{"schema": rawSchema})
+			if err != nil {
+				return AgentSpec{}, fmt.Errorf("dynamicworkflow: encode agent schema: %w", err)
+			}
+			fields["structured_output"] = canonical
+		}
+		delete(fields, "schema")
+	}
+	canonical, err := json.Marshal(fields)
+	if err != nil {
+		return AgentSpec{}, fmt.Errorf("dynamicworkflow: encode agent options: %w", err)
+	}
+	var spec AgentSpec
+	if err := json.Unmarshal(canonical, &spec); err != nil {
+		return AgentSpec{}, fmt.Errorf("dynamicworkflow: decode agent options: %w", err)
+	}
+	return spec, nil
+}
+
+func isSupportedAgentOption(name string) bool {
+	switch name {
+	case "template", "instance_id", "instruction", "tools", "skills", "structured_output", "schema":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalStructuredOutput(raw json.RawMessage) (json.RawMessage, error) {
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("dynamicworkflow: structured_output must be valid JSON")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		return nil, fmt.Errorf("dynamicworkflow: structured_output must be a JSON object")
+	}
+	if _, wrapped := fields["schema"]; wrapped {
+		return raw, nil
+	}
+	// A bare JSON Schema is the ergonomic form most workflow code writes:
+	// structured_output: {"type":"object", "properties": {...}}.
+	// Wrap it into the richer internal representation while preserving the
+	// existing name/strict/description form for callers that need it.
+	canonical, err := json.Marshal(map[string]json.RawMessage{"schema": raw})
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: encode structured_output schema: %w", err)
+	}
+	return canonical, nil
+}
+
+func (g *workflowGateway) resolveAgentCall(call Call) (agentCallRequest, error) {
+	req, err := parseAgentCall(call)
+	if err != nil {
+		return agentCallRequest{}, err
+	}
+	if req.newStyle {
+		if req.templateName == "" {
+			if len(g.agents) != 1 {
+				return agentCallRequest{}, fmt.Errorf(
+					"dynamicworkflow: agent options.template is required when multiple templates are registered",
+				)
+			}
+			for name := range g.agents {
+				req.templateName = name
+			}
+		}
+		req.spec.Template = req.templateName
+		if err := normalizeAgentSpec(&req.spec); err != nil {
+			return agentCallRequest{}, err
+		}
+		req.dynamic = agentSpecHasOverrides(req.spec)
+		if req.instanceID == "" {
+			req.instanceID = req.spec.InstanceID
+		}
+		if req.instanceID == "" {
+			req.instanceID = cleanPathSegment(call.ID)
+			if req.instanceID == "" {
+				req.instanceID = uuid.NewString()
+			}
+		}
+	}
+	return req, nil
+}
+
+func decodeAgentSelector(raw json.RawMessage) (AgentSpec, bool, error) {
+	var name string
+	if err := json.Unmarshal(raw, &name); err == nil {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return AgentSpec{}, false, fmt.Errorf(
+				"dynamicworkflow: agent name is required",
+			)
+		}
+		return AgentSpec{Template: name}, false, nil
+	}
+	var spec AgentSpec
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return AgentSpec{}, false, fmt.Errorf(
+			"dynamicworkflow: decode agent spec: %w", err,
+		)
+	}
+	if err := normalizeAgentSpec(&spec); err != nil {
+		return AgentSpec{}, false, err
+	}
+	return spec, agentSpecHasOverrides(spec), nil
+}
+
+func normalizeAgentSpec(spec *AgentSpec) error {
+	if spec == nil {
+		return fmt.Errorf("dynamicworkflow: agent options are required")
+	}
+	spec.Template = strings.TrimSpace(spec.Template)
+	if spec.Template == "" {
+		return fmt.Errorf("dynamicworkflow: agent spec template is required")
+	}
+	spec.InstanceID = cleanPathSegment(spec.InstanceID)
+	spec.Instruction = strings.TrimSpace(spec.Instruction)
+	spec.Tools = normalizeSelection(spec.Tools)
+	spec.Skills = normalizeSelection(spec.Skills)
+	return normalizeStructuredOutputSpec(spec.Template, spec.StructuredOutput)
+}
+
+func agentSpecHasOverrides(spec AgentSpec) bool {
+	return spec.Instruction != "" || spec.Tools != nil || spec.Skills != nil || spec.StructuredOutput != nil
+}
+
+func normalizeStructuredOutputSpec(template string, spec *StructuredOutputSpec) error {
+	if spec == nil {
+		return nil
+	}
+	spec.Name = strings.TrimSpace(spec.Name)
+	spec.Description = strings.TrimSpace(spec.Description)
+	if len(spec.Schema) == 0 {
+		return fmt.Errorf("dynamicworkflow: structured_output schema is required")
+	}
+	if len(spec.Schema) > maxStructuredOutputSchemaBytes {
+		return fmt.Errorf(
+			"dynamicworkflow: structured_output schema exceeds %d bytes",
+			maxStructuredOutputSchemaBytes,
+		)
+	}
+	if !json.Valid(spec.Schema) {
+		return fmt.Errorf("dynamicworkflow: structured_output schema must be valid JSON")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(spec.Schema, &schema); err != nil || schema == nil {
+		return fmt.Errorf("dynamicworkflow: structured_output schema must be a JSON object")
+	}
+	if spec.Name == "" {
+		spec.Name = template + "_output"
+	}
+	if spec.Strict == nil {
+		strict := true
+		spec.Strict = &strict
+	}
+	return nil
+}
+
+func normalizeSelection(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	if len(values) == 0 {
+		return []string{}
+	}
+	return dedupeNonEmpty(values)
+}
+
+func dedupeNonEmpty(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func cleanPathSegment(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	replacer := strings.NewReplacer("/", "_", "\\", "_")
+	return replacer.Replace(value)
+}
+
+func (g *workflowGateway) dynamicAgentInvocationOption(
+	ctx context.Context,
+	tmpl agentTemplate,
+	req agentCallRequest,
+) (agent.InvocationOptions, error) {
+	patch, err := g.dynamicAgentPatch(ctx, tmpl, req.spec)
+	if err != nil {
+		return nil, err
+	}
+	structuredOutput, err := dynamicStructuredOutput(req.spec.StructuredOutput)
+	if err != nil {
+		return nil, err
+	}
+	nodeID := g.toolName + "/dynamic-" + uuid.NewString()
+	return func(inv *agent.Invocation) {
+		agent.SetInvocationSurfaceRootNodeID(inv, nodeID)
+		runOpts := inv.RunOptions
+		agent.WithSurfacePatchForNode(nodeID, patch)(&runOpts)
+		sanitizeDynamicAgentRunOptions(&runOpts)
+		if structuredOutput != nil {
+			agent.WithStructuredOutputJSONSchema(
+				structuredOutput.name,
+				structuredOutput.schema,
+				structuredOutput.strict,
+				structuredOutput.description,
+			)(&runOpts)
+		}
+		inv.RunOptions = runOpts
+	}, nil
+}
+
+type resolvedStructuredOutput struct {
+	name        string
+	schema      map[string]any
+	strict      bool
+	description string
+}
+
+func dynamicStructuredOutput(spec *StructuredOutputSpec) (*resolvedStructuredOutput, error) {
+	if spec == nil {
+		return nil, nil
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(spec.Schema, &schema); err != nil || schema == nil {
+		return nil, fmt.Errorf("dynamicworkflow: structured_output schema must be a JSON object")
+	}
+	strict := true
+	if spec.Strict != nil {
+		strict = *spec.Strict
+	}
+	if strict {
+		normalizeStrictObjectSchemas(schema)
+	}
+	return &resolvedStructuredOutput{
+		name:        spec.Name,
+		schema:      schema,
+		strict:      strict,
+		description: spec.Description,
+	}, nil
+}
+
+// normalizeStrictObjectSchemas supplies the closure required by OpenAI-style
+// strict JSON Schema response formats: object schemas disallow extra fields
+// and require every declared property. The map was decoded from workflow JSON,
+// so this never mutates application-owned schema values.
+func normalizeStrictObjectSchemas(schema map[string]any) {
+	if schema == nil {
+		return
+	}
+	if schemaDeclaresObject(schema) {
+		if _, exists := schema["additionalProperties"]; !exists {
+			schema["additionalProperties"] = false
+		}
+		if properties, ok := schema["properties"].(map[string]any); ok {
+			required := make([]string, 0, len(properties))
+			for name := range properties {
+				required = append(required, name)
+			}
+			sort.Strings(required)
+			schema["required"] = required
+		}
+	}
+	for _, key := range []string{
+		"properties", "$defs", "definitions", "patternProperties", "dependentSchemas",
+	} {
+		if children, ok := schema[key].(map[string]any); ok {
+			for _, child := range children {
+				normalizeStrictSchemaValue(child)
+			}
+		}
+	}
+	for _, key := range []string{
+		"additionalProperties", "items", "contains", "not", "if", "then", "else",
+	} {
+		normalizeStrictSchemaValue(schema[key])
+	}
+	for _, key := range []string{"prefixItems", "allOf", "anyOf", "oneOf"} {
+		normalizeStrictSchemaValue(schema[key])
+	}
+}
+
+func schemaDeclaresObject(schema map[string]any) bool {
+	if schemaType, ok := schema["type"].(string); ok {
+		return schemaType == "object"
+	}
+	types, ok := schema["type"].([]any)
+	if !ok {
+		return false
+	}
+	for _, schemaType := range types {
+		if schemaType == "object" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeStrictSchemaValue(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		normalizeStrictObjectSchemas(typed)
+	case []any:
+		for _, item := range typed {
+			normalizeStrictSchemaValue(item)
+		}
+	}
+}
+
+func (g *workflowGateway) dynamicAgentPatch(
+	ctx context.Context,
+	tmpl agentTemplate,
+	spec AgentSpec,
+) (agent.SurfacePatch, error) {
+	var patch agent.SurfacePatch
+	if spec.Instruction != "" {
+		patch.SetInstruction(spec.Instruction)
+	}
+	selectedTools, err := g.selectAgentTools(ctx, tmpl, spec.Tools)
+	if err != nil {
+		return patch, err
+	}
+	patch.SetTools(selectedTools)
+	patch.SetSuppressSubAgentTransfer()
+	if spec.Skills != nil {
+		repo, err := g.selectAgentSkills(ctx, tmpl, spec.Skills)
+		if err != nil {
+			return patch, err
+		}
+		patch.SetSkillRepository(repo)
+	}
+	return patch, nil
+}
+
+func (g *workflowGateway) selectAgentTools(
+	ctx context.Context,
+	tmpl agentTemplate,
+	requested []string,
+) ([]tool.Tool, error) {
+	selectable := g.selectableAgentTools(ctx, tmpl)
+	if requested == nil {
+		return sortedTools(selectable), nil
+	}
+	if len(requested) == 0 {
+		return nil, nil
+	}
+	selected := make([]tool.Tool, 0, len(requested))
+	var missing []string
+	for _, name := range requested {
+		t, ok := selectable[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		selected = append(selected, t)
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf(
+			"dynamicworkflow: agent template %q does not allow tool(s): %s",
+			tmpl.name, strings.Join(missing, ", "),
+		)
+	}
+	return selected, nil
+}
+
+func (g *workflowGateway) selectableAgentTools(
+	ctx context.Context,
+	tmpl agentTemplate,
+) map[string]tool.Tool {
+	provider, ok := tmpl.agent.(agent.InvocationToolSurfaceProvider)
+	if !ok || provider == nil {
+		return copyToolMap(tmpl.tools)
+	}
+	parent := parentWithLiveSession(g.parent)
+	probe := parent.View(agent.WithInvocationAgent(tmpl.agent))
+	tools, userToolNames := provider.InvocationToolSurface(ctx, probe)
+	return selectableToolMap(tools, userToolNames, tmpl.name, g.toolName)
+}
+
+func (g *workflowGateway) selectAgentSkills(
+	ctx context.Context,
+	tmpl agentTemplate,
+	requested []string,
+) (skill.Repository, error) {
+	provider, ok := tmpl.agent.(agent.InvocationSkillRepositoryProvider)
+	if !ok || provider == nil {
+		if len(requested) == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"dynamicworkflow: agent template %q does not expose skills",
+			tmpl.name,
+		)
+	}
+	parent := parentWithLiveSession(g.parent)
+	probe := parent.View(agent.WithInvocationAgent(tmpl.agent))
+	repo := provider.InvocationSkillRepository(ctx, probe)
+	if repo == nil {
+		if len(requested) == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"dynamicworkflow: agent template %q does not expose skills",
+			tmpl.name,
+		)
+	}
+	if requested == nil {
+		return repo, nil
+	}
+	if len(requested) == 0 {
+		return skill.NewFilteredRepository(
+			repo,
+			func(context.Context, skill.Summary) bool { return false },
+		), nil
+	}
+	available := map[string]bool{}
+	for _, s := range skill.SummariesForContext(ctx, repo) {
+		available[s.Name] = true
+	}
+	selected := map[string]bool{}
+	var missing []string
+	for _, name := range requested {
+		if !available[name] {
+			missing = append(missing, name)
+			continue
+		}
+		selected[name] = true
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf(
+			"dynamicworkflow: agent template %q does not allow skill(s): %s",
+			tmpl.name, strings.Join(missing, ", "),
+		)
+	}
+	return skill.NewFilteredRepository(
+		repo,
+		func(_ context.Context, s skill.Summary) bool {
+			return selected[s.Name]
+		},
+	), nil
+}
+
+func sanitizeDynamicAgentRunOptions(runOpts *agent.RunOptions) {
+	if runOpts == nil {
+		return
+	}
+	runOpts.AdditionalTools = nil
+	runOpts.ExternalTools = nil
+	runOpts.ExternalToolNames = nil
+	runOpts.ToolFilter = nil
+	runOpts.Model = nil
+	runOpts.ModelName = ""
+	runOpts.ModelSelector = nil
+	runOpts.Instruction = ""
+	runOpts.GlobalInstruction = ""
+	runOpts.CodeExecutor = nil
+	runOpts.ToolExecutionFilter = nil
+	runOpts.ToolPermissionPolicy = nil
+	runOpts.StructuredOutput = nil
+	runOpts.StructuredOutputType = nil
+}
+
+func selectableToolMap(
+	tools []tool.Tool,
+	userToolNames map[string]bool,
+	excludedNames ...string,
+) map[string]tool.Tool {
+	excluded := make(map[string]bool, len(excludedNames)+1)
+	excluded[transfer.TransferToolName] = true
+	for _, name := range excludedNames {
+		if name = strings.TrimSpace(name); name != "" {
+			excluded[name] = true
+		}
+	}
+	out := make(map[string]tool.Tool, len(tools))
+	for _, candidate := range tools {
+		name := declarationName(candidate)
+		if name == "" || excluded[name] {
+			continue
+		}
+		if userToolNames != nil && !userToolNames[name] {
+			continue
+		}
+		if _, exists := out[name]; exists {
+			continue
+		}
+		out[name] = candidate
+	}
+	return out
+}
+
+func copyToolMap(in map[string]tool.Tool) map[string]tool.Tool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]tool.Tool, len(in))
+	for name, t := range in {
+		out[name] = t
+	}
+	return out
+}
+
+func sortedTools(tools map[string]tool.Tool) []tool.Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+	names := sortedNames(tools)
+	out := make([]tool.Tool, 0, len(names))
+	for _, name := range names {
+		out = append(out, tools[name])
+	}
+	return out
+}

--- a/tool/dynamicworkflow/agent_spec.go
+++ b/tool/dynamicworkflow/agent_spec.go
@@ -647,6 +647,9 @@ func sanitizeWorkflowChildRunOptions(runOpts *agent.RunOptions) {
 	runOpts.Model = nil
 	runOpts.ModelName = ""
 	runOpts.ModelSelector = nil
+	runOpts.ModelContextWindow = 0
+	runOpts.ModelRequestExtraFields = nil
+	runOpts.ModelRequestHeaders = nil
 	runOpts.Instruction = ""
 	runOpts.GlobalInstruction = ""
 	runOpts.CodeExecutor = nil

--- a/tool/dynamicworkflow/agent_spec.go
+++ b/tool/dynamicworkflow/agent_spec.go
@@ -364,12 +364,12 @@ func cleanPathSegment(value string) string {
 	return replacer.Replace(value)
 }
 
-func (g *workflowGateway) dynamicAgentInvocationOption(
+func (g *workflowGateway) workflowChildInvocationOption(
 	ctx context.Context,
 	tmpl agentTemplate,
 	req agentCallRequest,
 ) (agent.InvocationOptions, error) {
-	patch, err := g.dynamicAgentPatch(ctx, tmpl, req.spec)
+	patch, err := g.workflowChildPatch(ctx, tmpl, req.spec)
 	if err != nil {
 		return nil, err
 	}
@@ -492,21 +492,21 @@ func normalizeStrictSchemaValue(value any) {
 	}
 }
 
-func (g *workflowGateway) dynamicAgentPatch(
+func (g *workflowGateway) workflowChildPatch(
 	ctx context.Context,
 	tmpl agentTemplate,
 	spec AgentSpec,
 ) (agent.SurfacePatch, error) {
 	var patch agent.SurfacePatch
-	if spec.Instruction != "" {
-		patch.SetInstruction(spec.Instruction)
-	}
 	selectedTools, err := g.selectAgentTools(ctx, tmpl, spec.Tools)
 	if err != nil {
 		return patch, err
 	}
 	patch.SetTools(selectedTools)
 	patch.SetSuppressSubAgentTransfer()
+	if spec.Instruction != "" {
+		patch.SetInstruction(spec.Instruction)
+	}
 	if spec.Skills != nil {
 		repo, err := g.selectAgentSkills(ctx, tmpl, spec.Skills)
 		if err != nil {

--- a/tool/dynamicworkflow/agent_spec.go
+++ b/tool/dynamicworkflow/agent_spec.go
@@ -654,7 +654,6 @@ func sanitizeWorkflowChildRunOptions(runOpts *agent.RunOptions) {
 	runOpts.GlobalInstruction = ""
 	runOpts.CodeExecutor = nil
 	runOpts.ToolExecutionFilter = nil
-	runOpts.ToolPermissionPolicy = nil
 	runOpts.StructuredOutput = nil
 	runOpts.StructuredOutputType = nil
 }

--- a/tool/dynamicworkflow/agent_spec.go
+++ b/tool/dynamicworkflow/agent_spec.go
@@ -382,7 +382,7 @@ func (g *workflowGateway) dynamicAgentInvocationOption(
 		agent.SetInvocationSurfaceRootNodeID(inv, nodeID)
 		runOpts := inv.RunOptions
 		agent.WithSurfacePatchForNode(nodeID, patch)(&runOpts)
-		sanitizeDynamicAgentRunOptions(&runOpts)
+		sanitizeWorkflowChildRunOptions(&runOpts)
 		if structuredOutput != nil {
 			agent.WithStructuredOutputJSONSchema(
 				structuredOutput.name,
@@ -557,8 +557,7 @@ func (g *workflowGateway) selectableAgentTools(
 	if !ok || provider == nil {
 		return copyToolMap(tmpl.tools)
 	}
-	parent := parentWithLiveSession(g.parent)
-	probe := parent.View(agent.WithInvocationAgent(tmpl.agent))
+	probe := g.workflowChildProbe(tmpl)
 	tools, userToolNames := provider.InvocationToolSurface(ctx, probe)
 	return selectableToolMap(tools, userToolNames, tmpl.name, g.toolName)
 }
@@ -578,8 +577,7 @@ func (g *workflowGateway) selectAgentSkills(
 			tmpl.name,
 		)
 	}
-	parent := parentWithLiveSession(g.parent)
-	probe := parent.View(agent.WithInvocationAgent(tmpl.agent))
+	probe := g.workflowChildProbe(tmpl)
 	repo := provider.InvocationSkillRepository(ctx, probe)
 	if repo == nil {
 		if len(requested) == 0 {
@@ -627,7 +625,18 @@ func (g *workflowGateway) selectAgentSkills(
 	), nil
 }
 
-func sanitizeDynamicAgentRunOptions(runOpts *agent.RunOptions) {
+func (g *workflowGateway) workflowChildProbe(tmpl agentTemplate) *agent.Invocation {
+	parent := parentWithLiveSession(g.parent)
+	if parent == nil {
+		parent = agent.NewInvocation()
+	}
+	return parent.View(
+		agent.WithInvocationAgent(tmpl.agent),
+		clearInheritedWorkflowRunOptions(),
+	)
+}
+
+func sanitizeWorkflowChildRunOptions(runOpts *agent.RunOptions) {
 	if runOpts == nil {
 		return
 	}

--- a/tool/dynamicworkflow/runtime_test.go
+++ b/tool/dynamicworkflow/runtime_test.go
@@ -345,7 +345,60 @@ return {"ok": True}
 `)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"ok":true}`, string(result.Value))
-	require.Less(t, time.Since(start), 1500*time.Millisecond)
+	require.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestLocalRunnerEnforcesOutputLimits(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	})
+
+	_, err := Execute(context.Background(), LocalRunner{}, handler, fmt.Sprintf(`
+print("x" * %d)
+return None
+`, workflowGuestCapturedOutputLimit+1))
+	require.ErrorContains(t, err, "workflow stdout exceeds")
+
+	_, err = Execute(context.Background(), LocalRunner{}, handler, fmt.Sprintf(`
+return "x" * %d
+`, workflowGuestProtocolLineLimit+1))
+	require.ErrorContains(t, err, "workflow protocol message exceeds")
+
+	_, err = Execute(context.Background(), LocalRunner{}, handler, fmt.Sprintf(`
+import sys
+sys.stderr.write("x" * %d)
+return None
+`, workflowGuestCapturedOutputLimit+1))
+	require.ErrorContains(t, err, "guest stderr exceeds")
+}
+
+func TestLocalRunnerCancelsUnawaitedCallbacksAfterCompletion(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	var once sync.Once
+	handler := callHandlerFunc(func(ctx context.Context, _ Call) (json.RawMessage, error) {
+		once.Do(func() { close(started) })
+		<-ctx.Done()
+		close(cancelled)
+		return nil, ctx.Err()
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+import asyncio
+asyncio.create_task(agent("background", "reviewer"))
+await asyncio.sleep(0)
+return {"ok": True}
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, string(result.Value))
+	require.NoError(t, waitClosed(started, time.Second))
+	require.NoError(t, waitClosed(cancelled, time.Second))
 }
 
 func TestExecuteRejectsMissingRequirements(t *testing.T) {
@@ -394,6 +447,7 @@ func TestWorkflowGuestProtocolHelpers(t *testing.T) {
 		calls,
 		writeErr,
 		state,
+		nil,
 	)
 	require.True(t, stop)
 	require.ErrorContains(t, state.guestErr, "malformed guest message")
@@ -408,6 +462,7 @@ func TestWorkflowGuestProtocolHelpers(t *testing.T) {
 		calls,
 		writeErr,
 		state,
+		nil,
 	)
 	require.True(t, stop)
 	require.ErrorContains(t, state.guestErr, "non-JSON result")
@@ -422,6 +477,7 @@ func TestWorkflowGuestProtocolHelpers(t *testing.T) {
 		calls,
 		writeErr,
 		state,
+		nil,
 	)
 	require.True(t, stop)
 	require.ErrorContains(t, state.guestErr, "guest failed")
@@ -436,11 +492,29 @@ func TestWorkflowGuestProtocolHelpers(t *testing.T) {
 		calls,
 		writeErr,
 		state,
+		nil,
 	)
 	require.True(t, stop)
 	require.NoError(t, state.guestErr)
 	require.JSONEq(t, `{"ok":true}`, string(state.completed.Value))
 	require.Equal(t, "hello\n", state.completed.Stdout)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	state = &workflowGuestState{}
+	stop = handleWorkflowGuestMessage(
+		ctx,
+		protocolMessage{Type: "call", ID: "blocked"},
+		handler,
+		encoder,
+		responseMu,
+		calls,
+		writeErr,
+		state,
+		make(chan struct{}),
+	)
+	require.True(t, stop)
+	require.ErrorContains(t, state.guestErr, "acquire callback slot")
 }
 
 func TestWorkflowGuestWriteResponseRecordsFirstError(t *testing.T) {
@@ -476,4 +550,15 @@ type errorWriter struct{}
 
 func (errorWriter) Write([]byte) (int, error) {
 	return 0, errors.New("write failed")
+}
+
+func waitClosed(ch <-chan struct{}, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ch:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("timed out waiting for channel close")
+	}
 }

--- a/tool/dynamicworkflow/runtime_test.go
+++ b/tool/dynamicworkflow/runtime_test.go
@@ -1,0 +1,454 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalRunnerRoutesToolAndAgentCalls(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	var calls []Call
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		calls = append(calls, call)
+		switch call.Kind {
+		case CallKindTool:
+			require.Equal(t, "add", call.Name)
+			require.JSONEq(t, `{"a":20,"b":22}`, string(call.Args))
+			return json.RawMessage(`42`), nil
+		case CallKindAgent:
+			require.Empty(t, call.Name)
+			require.JSONEq(t, `{"input":{"answer":42},"options":{"template":"reviewer"}}`, string(call.Args))
+			return json.RawMessage(`{"text":"approved"}`), nil
+		default:
+			t.Fatalf("unexpected call kind %q", call.Kind)
+			return nil, nil
+		}
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+print("starting")
+answer = await call_tool("add", a=20, b=22)
+review = await agent({"answer": answer}, "reviewer")
+return {"answer": answer, "review": review}
+`)
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	require.JSONEq(t, `{"answer":42,"review":{"text":"approved"}}`, string(result.Value))
+	require.Equal(t, "starting\n", result.Stdout)
+}
+
+func TestLocalRunnerRoutesDynamicAgentSpec(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		require.Empty(t, call.Name)
+		require.JSONEq(t, `{
+			"options":{
+				"template":"reviewer",
+				"instance_id":"strict-review",
+				"instruction":"Be strict.",
+				"tools":["lookup"]
+			},
+			"input":{"answer":42}
+		}`, string(call.Args))
+		return json.RawMessage(`{"text":"approved"}`), nil
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+review = await agent({"answer": 42}, {
+    "template": "reviewer",
+    "instance_id": "strict-review",
+    "instruction": "Be strict.",
+    "tools": ["lookup"],
+})
+return review
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"text":"approved"}`, string(result.Value))
+}
+
+func TestLocalRunnerRoutesKeywordAgentOptions(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		require.JSONEq(t, `{
+			"input": {"answer": 42},
+			"options": {
+				"instruction": "Be strict.",
+				"structured_output": {
+					"type": "object",
+					"properties": {"approved": {"type": "boolean"}}
+				}
+			}
+		}`, string(call.Args))
+		return json.RawMessage(`{"structured":{"approved":true}}`), nil
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+review = await agent(
+    {"answer": 42},
+    instruction="Be strict.",
+    structured_output={
+        "type": "object",
+        "properties": {"approved": {"type": "boolean"}},
+    },
+)
+return review["approved"]
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `true`, string(result.Value))
+}
+
+func TestLocalRunnerRejectsUnknownKeywordAgentOption(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	_, err := Execute(context.Background(), LocalRunner{}, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	}), `
+return await agent("review", unsupported_option=True)
+`)
+	require.ErrorContains(t, err, "unsupported agent option(s): unsupported_option")
+}
+
+func TestLocalRunnerRejectsUncalledWorkflowWrapper(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	_, err := Execute(context.Background(), LocalRunner{}, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	}), `
+async def run():
+    return {"status": "not invoked"}
+`)
+	require.ErrorContains(t, err, "workflow code must contain a return statement outside nested functions or classes")
+}
+
+func TestLocalRunnerProjectsStructuredAgentFields(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		return json.RawMessage(`{
+			"text":"approved",
+			"structured":{"approved":true,"sku":"TRAIL-40"}
+		}`), nil
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+review = await agent({"sku": "TRAIL-40"}, "reviewer")
+return {
+    "explicit": review["structured"]["sku"],
+    "index": review["sku"],
+    "get": review.get("approved"),
+    "text": review["text"],
+}
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"explicit":"TRAIL-40",
+		"index":"TRAIL-40",
+		"get":true,
+		"text":"approved"
+	}`, string(result.Value))
+}
+
+func TestLocalRunnerSupportsJSONStyleLiterals(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	result, err := Execute(context.Background(), LocalRunner{}, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	}), `
+return {"enabled": true, "disabled": false, "value": null}
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"enabled":true,"disabled":false,"value":null}`, string(result.Value))
+}
+
+func TestLocalRunnerParallelRoutesAgentCallsConcurrently(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	started := make(chan struct{})
+	var startOnce sync.Once
+	var mu sync.Mutex
+	startedCount := 0
+	handler := callHandlerFunc(func(ctx context.Context, call Call) (json.RawMessage, error) {
+		if call.Kind != CallKindAgent {
+			return nil, fmt.Errorf("unexpected call kind %q", call.Kind)
+		}
+		var args struct {
+			Input struct {
+				ID string `json:"id"`
+			} `json:"input"`
+		}
+		if err := json.Unmarshal(call.Args, &args); err != nil {
+			return nil, err
+		}
+		mu.Lock()
+		startedCount++
+		if startedCount == 2 {
+			startOnce.Do(func() { close(started) })
+		}
+		mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-started:
+			return json.RawMessage(fmt.Sprintf(`{"text":%q}`, args.Input.ID)), nil
+		}
+	})
+
+	result, err := Execute(ctx, LocalRunner{}, handler, `
+results = await parallel([
+    lambda: agent({"id": "first"}, "reviewer"),
+    lambda: agent({"id": "second"}, "reviewer"),
+])
+return results
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"text":"first"},{"text":"second"}]`, string(result.Value))
+}
+
+func TestLocalRunnerParallelKeepsCompletedBranchesWhenOneFails(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		var args struct {
+			Input string `json:"input"`
+		}
+		if err := json.Unmarshal(call.Args, &args); err != nil {
+			return nil, err
+		}
+		if args.Input == "bad" {
+			return nil, errors.New("expected branch failure")
+		}
+		return json.RawMessage(`{"text":"ok"}`), nil
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+results = await parallel([
+    lambda: agent("good", "reviewer"),
+    lambda: agent("bad", "reviewer"),
+])
+return results
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"text":"ok"},null]`, string(result.Value))
+}
+
+func TestLocalRunnerPipelineStreamsEachItemWithoutBatchBarrier(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	releaseAnalysisB := make(chan struct{})
+	var releaseOnce sync.Once
+	handler := callHandlerFunc(func(ctx context.Context, call Call) (json.RawMessage, error) {
+		var args struct {
+			Input struct {
+				Stage string `json:"stage"`
+				File  string `json:"file"`
+			} `json:"input"`
+		}
+		if err := json.Unmarshal(call.Args, &args); err != nil {
+			return nil, err
+		}
+		switch {
+		case args.Input.Stage == "analyze" && args.Input.File == "a":
+			return json.RawMessage(`{"structured":{"file":"a"}}`), nil
+		case args.Input.Stage == "analyze" && args.Input.File == "b":
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-releaseAnalysisB:
+				return json.RawMessage(`{"structured":{"file":"b"}}`), nil
+			}
+		case args.Input.Stage == "review" && args.Input.File == "a":
+			releaseOnce.Do(func() { close(releaseAnalysisB) })
+			return json.RawMessage(`{"text":"reviewed-a"}`), nil
+		case args.Input.Stage == "review" && args.Input.File == "b":
+			return json.RawMessage(`{"text":"reviewed-b"}`), nil
+		default:
+			return nil, fmt.Errorf("unexpected pipeline call: %s/%s", args.Input.Stage, args.Input.File)
+		}
+	})
+
+	result, err := Execute(ctx, LocalRunner{}, handler, `
+async def analyze(previous, original, index):
+    return await agent({"stage": "analyze", "file": previous}, "reviewer")
+
+async def review(analysis, original, index):
+    return await agent({
+        "stage": "review",
+        "file": original,
+        "analysis": analysis["structured"]["file"],
+    }, "reviewer")
+
+return await pipeline(["a", "b"], analyze, review)
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"text":"reviewed-a"},{"text":"reviewed-b"}]`, string(result.Value))
+}
+
+func TestExecuteRejectsMissingRequirements(t *testing.T) {
+	_, err := Execute(context.Background(), nil, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	}), "return None")
+	require.ErrorContains(t, err, "runtime is required")
+
+	_, err = Execute(context.Background(), LocalRunner{}, nil, "return None")
+	require.ErrorContains(t, err, "call handler is required")
+
+	_, err = Execute(context.Background(), LocalRunner{}, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	}), " ")
+	require.ErrorContains(t, err, "code is required")
+}
+
+func TestLocalRunnerStartFailureIncludesPythonError(t *testing.T) {
+	_, err := Execute(
+		context.Background(),
+		LocalRunner{Python: "python-that-does-not-exist"},
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"return None",
+	)
+	require.ErrorContains(t, err, "start Python guest")
+}
+
+func TestWorkflowGuestProtocolHelpers(t *testing.T) {
+	handler := callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return json.RawMessage(`{"ok":true}`), nil
+	})
+	encoder := json.NewEncoder(io.Discard)
+	responseMu := &sync.Mutex{}
+	calls := &sync.WaitGroup{}
+	writeErr := &workflowWriteError{}
+	state := &workflowGuestState{}
+
+	stop := processWorkflowGuestMessage(
+		context.Background(),
+		[]byte(`{`),
+		handler,
+		encoder,
+		responseMu,
+		calls,
+		writeErr,
+		state,
+	)
+	require.True(t, stop)
+	require.ErrorContains(t, state.guestErr, "malformed guest message")
+
+	state = &workflowGuestState{}
+	stop = handleWorkflowGuestMessage(
+		context.Background(),
+		protocolMessage{Type: "done", Result: json.RawMessage(`not-json`)},
+		handler,
+		encoder,
+		responseMu,
+		calls,
+		writeErr,
+		state,
+	)
+	require.True(t, stop)
+	require.ErrorContains(t, state.guestErr, "non-JSON result")
+
+	state = &workflowGuestState{}
+	stop = handleWorkflowGuestMessage(
+		context.Background(),
+		protocolMessage{Type: "error", Error: "guest failed"},
+		handler,
+		encoder,
+		responseMu,
+		calls,
+		writeErr,
+		state,
+	)
+	require.True(t, stop)
+	require.ErrorContains(t, state.guestErr, "guest failed")
+
+	state = &workflowGuestState{}
+	stop = handleWorkflowGuestMessage(
+		context.Background(),
+		protocolMessage{Type: "done", Result: json.RawMessage(`{"ok":true}`), Stdout: "hello\n"},
+		handler,
+		encoder,
+		responseMu,
+		calls,
+		writeErr,
+		state,
+	)
+	require.True(t, stop)
+	require.NoError(t, state.guestErr)
+	require.JSONEq(t, `{"ok":true}`, string(state.completed.Value))
+	require.Equal(t, "hello\n", state.completed.Stdout)
+}
+
+func TestWorkflowGuestWriteResponseRecordsFirstError(t *testing.T) {
+	encoder := json.NewEncoder(errorWriter{})
+	responseMu := &sync.Mutex{}
+	writeErr := &workflowWriteError{}
+
+	writeWorkflowGuestResponse(
+		encoder,
+		responseMu,
+		writeErr,
+		protocolMessage{Type: "result", ID: "1", Result: json.RawMessage(`true`)},
+	)
+	writeWorkflowGuestResponse(
+		encoder,
+		responseMu,
+		writeErr,
+		protocolMessage{Type: "result", ID: "2", Result: json.RawMessage(`false`)},
+	)
+
+	writeErr.Lock()
+	defer writeErr.Unlock()
+	require.ErrorContains(t, writeErr.err, "write failed")
+}
+
+type callHandlerFunc func(context.Context, Call) (json.RawMessage, error)
+
+func (f callHandlerFunc) HandleWorkflowCall(ctx context.Context, call Call) (json.RawMessage, error) {
+	return f(ctx, call)
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}

--- a/tool/dynamicworkflow/runtime_test.go
+++ b/tool/dynamicworkflow/runtime_test.go
@@ -323,6 +323,31 @@ return await pipeline(["a", "b"], analyze, review)
 	require.JSONEq(t, `[{"text":"reviewed-a"},{"text":"reviewed-b"}]`, string(result.Value))
 }
 
+func TestLocalRunnerDoesNotHangWhenCompletedGuestKeepsThreadAlive(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	result, err := Execute(ctx, LocalRunner{}, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+		return nil, nil
+	}), `
+import threading
+import time
+
+def keep_alive():
+    time.sleep(30)
+
+threading.Thread(target=keep_alive).start()
+return {"ok": True}
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, string(result.Value))
+	require.Less(t, time.Since(start), 1500*time.Millisecond)
+}
+
 func TestExecuteRejectsMissingRequirements(t *testing.T) {
 	_, err := Execute(context.Background(), nil, callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
 		return nil, nil

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -26,7 +26,13 @@ import (
 
 var errWorkflowGuestExitTimeout = errors.New("dynamicworkflow: guest did not exit after completion")
 
-const workflowGuestExitGrace = 250 * time.Millisecond
+const (
+	workflowGuestExitGrace           = 250 * time.Millisecond
+	workflowGuestCallbackDrainGrace  = time.Second
+	workflowGuestCallbackConcurrency = 32
+	workflowGuestProtocolLineLimit   = 4 << 20
+	workflowGuestCapturedOutputLimit = 1 << 20
+)
 
 // LocalRunner executes workflow Python on the local host through a stdio
 // callback protocol. It is intended only for development or an environment
@@ -52,7 +58,7 @@ type workflowGuestProcess struct {
 	cmd    *exec.Cmd
 	stdin  io.WriteCloser
 	stdout io.Reader
-	stderr *bytes.Buffer
+	stderr *limitedBuffer
 }
 
 type workflowGuestState struct {
@@ -99,8 +105,8 @@ func (r LocalRunner) startWorkflowGuest(
 	if err != nil {
 		return nil, fmt.Errorf("dynamicworkflow: create guest stdout: %w", err)
 	}
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+	stderr := newLimitedBuffer(workflowGuestCapturedOutputLimit)
+	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("dynamicworkflow: start Python guest: %w", err)
 	}
@@ -108,7 +114,7 @@ func (r LocalRunner) startWorkflowGuest(
 		cmd:    cmd,
 		stdin:  stdin,
 		stdout: stdout,
-		stderr: &stderr,
+		stderr: stderr,
 	}, nil
 }
 
@@ -119,14 +125,17 @@ func runWorkflowGuest(
 ) (Result, error) {
 	encoder := json.NewEncoder(guest.stdin)
 	scanner := bufio.NewScanner(guest.stdout)
-	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), workflowGuestProtocolLineLimit)
+	callbackCtx, cancelCallbacks := context.WithCancel(ctx)
+	defer cancelCallbacks()
+	callbackSlots := make(chan struct{}, workflowGuestCallbackConcurrency)
 	responseMu := &sync.Mutex{}
 	calls := &sync.WaitGroup{}
 	writeErr := &workflowWriteError{}
 	state := &workflowGuestState{}
 	for scanner.Scan() {
 		if stop := processWorkflowGuestMessage(
-			ctx,
+			callbackCtx,
 			scanner.Bytes(),
 			handler,
 			encoder,
@@ -134,11 +143,12 @@ func runWorkflowGuest(
 			calls,
 			writeErr,
 			state,
+			callbackSlots,
 		); stop {
 			break
 		}
 	}
-	return finishWorkflowGuest(ctx, guest, scanner, calls, writeErr, state)
+	return finishWorkflowGuest(ctx, cancelCallbacks, guest, scanner, calls, writeErr, state)
 }
 
 type workflowWriteError struct {
@@ -155,13 +165,14 @@ func processWorkflowGuestMessage(
 	calls *sync.WaitGroup,
 	writeErr *workflowWriteError,
 	state *workflowGuestState,
+	callbackSlots chan struct{},
 ) bool {
 	var msg protocolMessage
 	if err := json.Unmarshal(raw, &msg); err != nil {
 		state.guestErr = fmt.Errorf("dynamicworkflow: malformed guest message: %w", err)
 		return true
 	}
-	return handleWorkflowGuestMessage(ctx, msg, handler, encoder, responseMu, calls, writeErr, state)
+	return handleWorkflowGuestMessage(ctx, msg, handler, encoder, responseMu, calls, writeErr, state, callbackSlots)
 }
 
 func handleWorkflowGuestMessage(
@@ -173,11 +184,19 @@ func handleWorkflowGuestMessage(
 	calls *sync.WaitGroup,
 	writeErr *workflowWriteError,
 	state *workflowGuestState,
+	callbackSlots chan struct{},
 ) bool {
 	switch msg.Type {
 	case "call":
+		if err := acquireWorkflowGuestCallbackSlot(ctx, callbackSlots); err != nil {
+			state.guestErr = fmt.Errorf("dynamicworkflow: acquire callback slot: %w", err)
+			return true
+		}
 		calls.Add(1)
-		go handleWorkflowGuestCall(ctx, msg, handler, encoder, responseMu, calls, writeErr)
+		go func() {
+			defer releaseWorkflowGuestCallbackSlot(callbackSlots)
+			handleWorkflowGuestCall(ctx, msg, handler, encoder, responseMu, calls, writeErr)
+		}()
 	case "done":
 		if !json.Valid(msg.Result) {
 			state.guestErr = errors.New("dynamicworkflow: guest returned non-JSON result")
@@ -188,6 +207,25 @@ func handleWorkflowGuestMessage(
 		state.guestErr = errors.New(msg.Error)
 	}
 	return state.guestErr != nil || state.completed != nil
+}
+
+func acquireWorkflowGuestCallbackSlot(ctx context.Context, slots chan struct{}) error {
+	if slots == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case slots <- struct{}{}:
+		return nil
+	}
+}
+
+func releaseWorkflowGuestCallbackSlot(slots chan struct{}) {
+	if slots == nil {
+		return
+	}
+	<-slots
 }
 
 func handleWorkflowGuestCall(
@@ -234,20 +272,32 @@ func writeWorkflowGuestResponse(
 
 func finishWorkflowGuest(
 	ctx context.Context,
+	cancelCallbacks context.CancelFunc,
 	guest *workflowGuestProcess,
 	scanner *bufio.Scanner,
 	calls *sync.WaitGroup,
 	writeErr *workflowWriteError,
 	state *workflowGuestState,
 ) (Result, error) {
-	calls.Wait()
+	if cancelCallbacks != nil {
+		cancelCallbacks()
+	}
+	if err := waitWorkflowGuestCallbacks(ctx, calls); err != nil && state.guestErr == nil {
+		state.guestErr = err
+	}
 	writeErr.Lock()
-	if writeErr.err != nil && state.guestErr == nil {
+	if writeErr.err != nil && state.guestErr == nil && state.completed == nil {
 		state.guestErr = fmt.Errorf("dynamicworkflow: write guest response: %w", writeErr.err)
 	}
 	writeErr.Unlock()
-	if scanErr := scanner.Err(); scanErr != nil && state.guestErr == nil {
-		state.guestErr = fmt.Errorf("dynamicworkflow: read guest output: %w", scanErr)
+	if scanErr := workflowGuestScannerError(scanner.Err()); scanErr != nil && state.guestErr == nil {
+		state.guestErr = scanErr
+	}
+	if guest.stderr.Exceeded() && state.guestErr == nil {
+		state.guestErr = fmt.Errorf(
+			"dynamicworkflow: guest stderr exceeds %d bytes",
+			workflowGuestCapturedOutputLimit,
+		)
 	}
 	_ = guest.stdin.Close()
 	waitErr := waitWorkflowGuest(ctx, guest)
@@ -270,6 +320,40 @@ func finishWorkflowGuest(
 		)
 	}
 	return *state.completed, nil
+}
+
+func waitWorkflowGuestCallbacks(ctx context.Context, calls *sync.WaitGroup) error {
+	done := make(chan struct{})
+	go func() {
+		calls.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(workflowGuestCallbackDrainGrace)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf(
+			"dynamicworkflow: workflow callbacks did not finish within %s after guest completion",
+			workflowGuestCallbackDrainGrace,
+		)
+	}
+}
+
+func workflowGuestScannerError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "token too long") {
+		return fmt.Errorf(
+			"dynamicworkflow: guest protocol message exceeds %d bytes",
+			workflowGuestProtocolLineLimit,
+		)
+	}
+	return fmt.Errorf("dynamicworkflow: read guest output: %w", err)
 }
 
 func waitWorkflowGuest(ctx context.Context, guest *workflowGuestProcess) error {
@@ -308,6 +392,58 @@ func guestErrorWithStderr(err error, stderr string) error {
 	return fmt.Errorf("%w: %s", err, stderr)
 }
 
+type limitedBuffer struct {
+	mu       sync.Mutex
+	limit    int
+	buf      bytes.Buffer
+	exceeded bool
+}
+
+func newLimitedBuffer(limit int) *limitedBuffer {
+	return &limitedBuffer{limit: limit}
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	if b == nil {
+		return len(p), nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = b.buf.Write(p[:remaining])
+	}
+	if remaining < len(p) {
+		b.exceeded = true
+	}
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := b.buf.String()
+	if b.exceeded {
+		out += fmt.Sprintf("\n... stderr truncated after %d bytes", b.limit)
+	}
+	return out
+}
+
+func (b *limitedBuffer) Exceeded() bool {
+	if b == nil {
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.exceeded
+}
+
 var _ Runtime = LocalRunner{}
 
 // pythonGuest is deliberately small: workflow source receives only the
@@ -324,14 +460,47 @@ import sys
 import threading
 import traceback
 
+_CAPTURED_OUTPUT_LIMIT = 1048576
+_PROTOCOL_LINE_LIMIT = 4194304
 _protocol_stdout = sys.stdout
-_captured_stdout = io.StringIO()
+
+class _LimitedStdout(io.StringIO):
+    def __init__(self, limit):
+        super().__init__()
+        self._limit = limit
+        self._size = 0
+
+    def write(self, value):
+        data = str(value)
+        encoded = data.encode("utf-8")
+        if self._size + len(encoded) > self._limit:
+            remaining = self._limit - self._size
+            if remaining > 0:
+                super().write(encoded[:remaining].decode("utf-8", errors="ignore"))
+                self._size = self._limit
+            raise RuntimeError(f"workflow stdout exceeds {self._limit} bytes")
+        self._size += len(encoded)
+        return super().write(data)
+
+_captured_stdout = _LimitedStdout(_CAPTURED_OUTPUT_LIMIT)
 sys.stdout = _captured_stdout
 _next_call_id = 0
 _bridge = None
 
 def _send(message):
-    _protocol_stdout.write(json.dumps(message, separators=(",", ":")) + "\n")
+    payload = json.dumps(message, separators=(",", ":"))
+    if len(payload.encode("utf-8")) > _PROTOCOL_LINE_LIMIT:
+        payload = json.dumps({
+            "type": "error",
+            "error": f"workflow protocol message exceeds {_PROTOCOL_LINE_LIMIT} bytes",
+            "stdout": _captured_stdout.getvalue(),
+        }, separators=(",", ":"))
+        if len(payload.encode("utf-8")) > _PROTOCOL_LINE_LIMIT:
+            payload = json.dumps({
+                "type": "error",
+                "error": f"workflow protocol message exceeds {_PROTOCOL_LINE_LIMIT} bytes",
+            }, separators=(",", ":"))
+    _protocol_stdout.write(payload + "\n")
     _protocol_stdout.flush()
 
 class _Bridge:

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -1,0 +1,510 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package dynamicworkflow
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// LocalRunner executes workflow Python on the local host through a stdio
+// callback protocol. It is intended only for development or an environment
+// that the application has already isolated; it is not a security sandbox.
+//
+// Set Python to select a specific interpreter. The default is python3.
+type LocalRunner struct {
+	Python string
+}
+
+type protocolMessage struct {
+	Type   string          `json:"type"`
+	ID     string          `json:"id,omitempty"`
+	Kind   CallKind        `json:"kind,omitempty"`
+	Name   string          `json:"name,omitempty"`
+	Args   json.RawMessage `json:"args,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Stdout string          `json:"stdout,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+type workflowGuestProcess struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.Reader
+	stderr *bytes.Buffer
+}
+
+type workflowGuestState struct {
+	completed *Result
+	guestErr  error
+}
+
+// ExecuteWorkflow implements Runtime with a fresh local Python guest.
+func (r LocalRunner) ExecuteWorkflow(
+	ctx context.Context,
+	req Request,
+	handler CallHandler,
+) (Result, error) {
+	if handler == nil {
+		return Result{}, required("call handler")
+	}
+	guest, err := r.startWorkflowGuest(ctx, req.Code)
+	if err != nil {
+		return Result{}, err
+	}
+	return runWorkflowGuest(ctx, guest, handler)
+}
+
+func (r LocalRunner) startWorkflowGuest(
+	ctx context.Context,
+	code string,
+) (*workflowGuestProcess, error) {
+	python := strings.TrimSpace(r.Python)
+	if python == "" {
+		python = "python3"
+	}
+	cmd := exec.CommandContext(
+		ctx,
+		python,
+		"-c",
+		pythonGuest,
+		base64.StdEncoding.EncodeToString([]byte(code)),
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: create guest stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: create guest stdout: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: start Python guest: %w", err)
+	}
+	return &workflowGuestProcess{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: &stderr,
+	}, nil
+}
+
+func runWorkflowGuest(
+	ctx context.Context,
+	guest *workflowGuestProcess,
+	handler CallHandler,
+) (Result, error) {
+	encoder := json.NewEncoder(guest.stdin)
+	scanner := bufio.NewScanner(guest.stdout)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	responseMu := &sync.Mutex{}
+	calls := &sync.WaitGroup{}
+	writeErr := &workflowWriteError{}
+	state := &workflowGuestState{}
+	for scanner.Scan() {
+		if stop := processWorkflowGuestMessage(
+			ctx,
+			scanner.Bytes(),
+			handler,
+			encoder,
+			responseMu,
+			calls,
+			writeErr,
+			state,
+		); stop {
+			break
+		}
+	}
+	return finishWorkflowGuest(guest, scanner, calls, writeErr, state)
+}
+
+type workflowWriteError struct {
+	sync.Mutex
+	err error
+}
+
+func processWorkflowGuestMessage(
+	ctx context.Context,
+	raw []byte,
+	handler CallHandler,
+	encoder *json.Encoder,
+	responseMu *sync.Mutex,
+	calls *sync.WaitGroup,
+	writeErr *workflowWriteError,
+	state *workflowGuestState,
+) bool {
+	var msg protocolMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		state.guestErr = fmt.Errorf("dynamicworkflow: malformed guest message: %w", err)
+		return true
+	}
+	return handleWorkflowGuestMessage(ctx, msg, handler, encoder, responseMu, calls, writeErr, state)
+}
+
+func handleWorkflowGuestMessage(
+	ctx context.Context,
+	msg protocolMessage,
+	handler CallHandler,
+	encoder *json.Encoder,
+	responseMu *sync.Mutex,
+	calls *sync.WaitGroup,
+	writeErr *workflowWriteError,
+	state *workflowGuestState,
+) bool {
+	switch msg.Type {
+	case "call":
+		calls.Add(1)
+		go handleWorkflowGuestCall(ctx, msg, handler, encoder, responseMu, calls, writeErr)
+	case "done":
+		if !json.Valid(msg.Result) {
+			state.guestErr = errors.New("dynamicworkflow: guest returned non-JSON result")
+			return true
+		}
+		state.completed = &Result{Value: msg.Result, Stdout: msg.Stdout}
+	case "error":
+		state.guestErr = errors.New(msg.Error)
+	}
+	return state.guestErr != nil || state.completed != nil
+}
+
+func handleWorkflowGuestCall(
+	ctx context.Context,
+	msg protocolMessage,
+	handler CallHandler,
+	encoder *json.Encoder,
+	responseMu *sync.Mutex,
+	calls *sync.WaitGroup,
+	writeErr *workflowWriteError,
+) {
+	defer calls.Done()
+	value, err := handler.HandleWorkflowCall(ctx, Call{
+		ID:   msg.ID,
+		Kind: msg.Kind,
+		Name: msg.Name,
+		Args: msg.Args,
+	})
+	response := protocolMessage{Type: "result", ID: msg.ID}
+	if err != nil {
+		response.Error = err.Error()
+	} else {
+		response.Result = value
+	}
+	writeWorkflowGuestResponse(encoder, responseMu, writeErr, response)
+}
+
+func writeWorkflowGuestResponse(
+	encoder *json.Encoder,
+	responseMu *sync.Mutex,
+	writeErr *workflowWriteError,
+	response protocolMessage,
+) {
+	responseMu.Lock()
+	defer responseMu.Unlock()
+	if err := encoder.Encode(response); err != nil {
+		writeErr.Lock()
+		if writeErr.err == nil {
+			writeErr.err = err
+		}
+		writeErr.Unlock()
+	}
+}
+
+func finishWorkflowGuest(
+	guest *workflowGuestProcess,
+	scanner *bufio.Scanner,
+	calls *sync.WaitGroup,
+	writeErr *workflowWriteError,
+	state *workflowGuestState,
+) (Result, error) {
+	calls.Wait()
+	writeErr.Lock()
+	if writeErr.err != nil && state.guestErr == nil {
+		state.guestErr = fmt.Errorf("dynamicworkflow: write guest response: %w", writeErr.err)
+	}
+	writeErr.Unlock()
+	if scanErr := scanner.Err(); scanErr != nil && state.guestErr == nil {
+		state.guestErr = fmt.Errorf("dynamicworkflow: read guest output: %w", scanErr)
+	}
+	_ = guest.stdin.Close()
+	waitErr := guest.cmd.Wait()
+	if state.guestErr != nil {
+		return Result{}, guestErrorWithStderr(state.guestErr, guest.stderr.String())
+	}
+	if waitErr != nil {
+		return Result{}, guestErrorWithStderr(
+			fmt.Errorf("dynamicworkflow: wait for guest: %w", waitErr),
+			guest.stderr.String(),
+		)
+	}
+	if state.completed == nil {
+		return Result{}, guestErrorWithStderr(
+			errors.New("dynamicworkflow: guest exited without a completion message"),
+			guest.stderr.String(),
+		)
+	}
+	return *state.completed, nil
+}
+
+func guestErrorWithStderr(err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, stderr)
+}
+
+var _ Runtime = LocalRunner{}
+
+// pythonGuest is deliberately small: workflow source receives only the
+// documented host callbacks. LocalRunner is not a sandbox; production runners
+// must still apply process, filesystem, and network isolation themselves.
+const pythonGuest = `
+import asyncio
+import ast
+import base64
+import inspect
+import io
+import json
+import sys
+import threading
+import traceback
+
+_protocol_stdout = sys.stdout
+_captured_stdout = io.StringIO()
+sys.stdout = _captured_stdout
+_next_call_id = 0
+_bridge = None
+
+def _send(message):
+    _protocol_stdout.write(json.dumps(message, separators=(",", ":")) + "\n")
+    _protocol_stdout.flush()
+
+class _Bridge:
+    def __init__(self, loop):
+        self._loop = loop
+        self._pending = {}
+        self._closed = False
+
+    def start(self):
+        threading.Thread(target=self._read_results, daemon=True).start()
+
+    def call(self, kind, name, args):
+        global _next_call_id
+        if self._closed:
+            raise RuntimeError("workflow bridge is closed")
+        _next_call_id += 1
+        call_id = str(_next_call_id)
+        future = self._loop.create_future()
+        self._pending[call_id] = future
+        _send({"type": "call", "id": call_id, "kind": kind, "name": name, "args": args})
+        return future
+
+    def close(self):
+        self._closed = True
+        self._fail_pending(RuntimeError("workflow bridge is closed"))
+
+    def _read_results(self):
+        try:
+            for line in sys.stdin:
+                if not line:
+                    break
+                reply = json.loads(line)
+                self._loop.call_soon_threadsafe(self._deliver, reply)
+        except Exception as exc:
+            self._notify_failure(exc)
+            return
+        self._notify_failure(RuntimeError("host closed workflow bridge"))
+
+    def _notify_failure(self, exc):
+        try:
+            self._loop.call_soon_threadsafe(self._fail_pending, exc)
+        except RuntimeError:
+            # The workflow has already completed and the event loop is closed.
+            pass
+
+    def _deliver(self, reply):
+        if reply.get("type") != "result":
+            self._fail_pending(RuntimeError("invalid workflow bridge response"))
+            return
+        future = self._pending.pop(str(reply.get("id", "")), None)
+        if future is None or future.done():
+            return
+        if reply.get("error"):
+            future.set_exception(RuntimeError(reply["error"]))
+            return
+        future.set_result(reply.get("result"))
+
+    def _fail_pending(self, exc):
+        for future in self._pending.values():
+            if not future.done():
+                future.set_exception(exc)
+        self._pending.clear()
+
+class _AgentResult(dict):
+    # Keep agent's metadata envelope while making common workflow code
+    # ergonomic: missing keys are read from a structured result when present.
+    # Envelope keys always take precedence over projected structured keys.
+    def _structured(self):
+        value = dict.get(self, "structured")
+        return value if isinstance(value, dict) else None
+
+    def __getitem__(self, key):
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError:
+            structured = self._structured()
+            if structured is not None:
+                return structured[key]
+            raise
+
+    def get(self, key, default=None):
+        if key in self:
+            return dict.get(self, key, default)
+        structured = self._structured()
+        if structured is not None:
+            return structured.get(key, default)
+        return default
+
+async def _call(kind, name, args):
+    if _bridge is None:
+        raise RuntimeError("workflow bridge is not initialized")
+    result = await _bridge.call(kind, name, args)
+    if kind == "agent" and isinstance(result, dict):
+        return _AgentResult(result)
+    return result
+
+async def call_tool(name, **kwargs):
+    return await _call("tool", name, kwargs)
+
+_AGENT_OPTION_NAMES = {
+    "template", "instance_id", "instruction", "tools", "skills",
+    "structured_output", "schema",
+}
+
+async def agent(input, options=None, **overrides):
+    # Both forms are intentional. The mapping form keeps a complete AgentSpec
+    # together, while keyword options make generated Python natural:
+    # await agent(task, instruction="review", structured_output={...}).
+    if options is None:
+        resolved = {}
+    elif isinstance(options, str):
+        resolved = {"template": options}
+    elif isinstance(options, dict):
+        resolved = dict(options)
+    else:
+        raise TypeError("agent options must be a mapping, template name, or None")
+    unknown = set(resolved).union(overrides).difference(_AGENT_OPTION_NAMES)
+    if unknown:
+        raise TypeError("unsupported agent option(s): " + ", ".join(sorted(unknown)))
+    resolved.update(overrides)
+    if not resolved:
+        return await _call("agent", "", {"input": input})
+    return await _call("agent", "", {"input": input, "options": resolved})
+
+async def parallel(thunks):
+    if not isinstance(thunks, (list, tuple)):
+        raise TypeError("parallel expects a list or tuple of zero-argument functions")
+
+    async def _run(thunk):
+        try:
+            if not callable(thunk):
+                raise TypeError("parallel expects zero-argument functions")
+            awaitable = thunk()
+            if not inspect.isawaitable(awaitable):
+                raise TypeError("parallel functions must return an awaitable")
+            return await awaitable
+        except Exception:
+            # A failed independent branch should not discard the completed
+            # branches. None is the documented failure sentinel.
+            return None
+
+    return await asyncio.gather(*[_run(thunk) for thunk in thunks])
+
+async def pipeline(items, *stages):
+    if not isinstance(items, (list, tuple)):
+        raise TypeError("pipeline expects a list or tuple of items")
+    if not stages:
+        return list(items)
+    if not all(callable(stage) for stage in stages):
+        raise TypeError("pipeline stages must be functions")
+
+    async def _run_item(item, index):
+        previous = item
+        for stage in stages:
+            if previous is None:
+                return None
+            awaitable = stage(previous, item, index)
+            if not inspect.isawaitable(awaitable):
+                raise TypeError("pipeline stages must return an awaitable")
+            previous = await awaitable
+        return previous
+
+    return await parallel([
+        lambda item=item, index=index: _run_item(item, index)
+        for index, item in enumerate(items)
+    ])
+
+def _contains_outer_return(node):
+    if isinstance(node, ast.Return):
+        return True
+    # A return nested in a helper is not a return from __workflow__. In
+    # particular, this rejects an uncalled async def run() wrapper,
+    # which otherwise completes successfully with a misleading null result.
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+        return False
+    return any(_contains_outer_return(child) for child in ast.iter_child_nodes(node))
+
+async def _main():
+    global _bridge
+    source = base64.b64decode(sys.argv[1]).decode("utf-8")
+    wrapped = "async def __workflow__():\n" + "\n".join("    " + line for line in source.splitlines())
+
+    parsed = ast.parse(wrapped, "<dynamic-workflow>", "exec")
+    workflow = parsed.body[0]
+    if not any(_contains_outer_return(statement) for statement in workflow.body):
+        raise RuntimeError(
+            "workflow code must contain a return statement outside nested functions or classes"
+        )
+    # JSON-style literals make generated AgentSpec dictionaries less brittle
+    # when a model emits JSON inside otherwise valid Python source.
+    scope = {
+        "call_tool": call_tool,
+        "agent": agent,
+        "parallel": parallel,
+        "pipeline": pipeline,
+        "true": True,
+        "false": False,
+        "null": None,
+    }
+    exec(compile(wrapped, "<dynamic-workflow>", "exec"), scope)
+    _bridge = _Bridge(asyncio.get_running_loop())
+    _bridge.start()
+    try:
+        return await scope["__workflow__"]()
+    finally:
+        _bridge.close()
+
+try:
+    value = asyncio.run(_main())
+    _send({"type": "done", "result": value, "stdout": _captured_stdout.getvalue()})
+except Exception:
+    _send({"type": "error", "error": traceback.format_exc(), "stdout": _captured_stdout.getvalue()})
+`

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -21,7 +21,12 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 )
+
+var errWorkflowGuestExitTimeout = errors.New("dynamicworkflow: guest did not exit after completion")
+
+const workflowGuestExitGrace = 250 * time.Millisecond
 
 // LocalRunner executes workflow Python on the local host through a stdio
 // callback protocol. It is intended only for development or an environment
@@ -133,7 +138,7 @@ func runWorkflowGuest(
 			break
 		}
 	}
-	return finishWorkflowGuest(guest, scanner, calls, writeErr, state)
+	return finishWorkflowGuest(ctx, guest, scanner, calls, writeErr, state)
 }
 
 type workflowWriteError struct {
@@ -228,6 +233,7 @@ func writeWorkflowGuestResponse(
 }
 
 func finishWorkflowGuest(
+	ctx context.Context,
 	guest *workflowGuestProcess,
 	scanner *bufio.Scanner,
 	calls *sync.WaitGroup,
@@ -244,11 +250,14 @@ func finishWorkflowGuest(
 		state.guestErr = fmt.Errorf("dynamicworkflow: read guest output: %w", scanErr)
 	}
 	_ = guest.stdin.Close()
-	waitErr := guest.cmd.Wait()
+	waitErr := waitWorkflowGuest(ctx, guest)
 	if state.guestErr != nil {
 		return Result{}, guestErrorWithStderr(state.guestErr, guest.stderr.String())
 	}
 	if waitErr != nil {
+		if errors.Is(waitErr, errWorkflowGuestExitTimeout) && state.completed != nil {
+			return *state.completed, nil
+		}
 		return Result{}, guestErrorWithStderr(
 			fmt.Errorf("dynamicworkflow: wait for guest: %w", waitErr),
 			guest.stderr.String(),
@@ -261,6 +270,34 @@ func finishWorkflowGuest(
 		)
 	}
 	return *state.completed, nil
+}
+
+func waitWorkflowGuest(ctx context.Context, guest *workflowGuestProcess) error {
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- guest.cmd.Wait()
+	}()
+	timer := time.NewTimer(workflowGuestExitGrace)
+	defer timer.Stop()
+	select {
+	case err := <-waitCh:
+		return err
+	case <-ctx.Done():
+		killWorkflowGuest(guest)
+		<-waitCh
+		return ctx.Err()
+	case <-timer.C:
+		killWorkflowGuest(guest)
+		<-waitCh
+		return errWorkflowGuestExitTimeout
+	}
+}
+
+func killWorkflowGuest(guest *workflowGuestProcess) {
+	if guest == nil || guest.cmd == nil || guest.cmd.Process == nil {
+		return
+	}
+	_ = guest.cmd.Process.Kill()
 }
 
 func guestErrorWithStderr(err error, stderr string) error {

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -293,14 +293,14 @@ func finishWorkflowGuest(
 	if scanErr := workflowGuestScannerError(scanner.Err()); scanErr != nil && state.guestErr == nil {
 		state.guestErr = scanErr
 	}
+	_ = guest.stdin.Close()
+	waitErr := waitWorkflowGuest(ctx, guest)
 	if guest.stderr.Exceeded() && state.guestErr == nil {
 		state.guestErr = fmt.Errorf(
 			"dynamicworkflow: guest stderr exceeds %d bytes",
 			workflowGuestCapturedOutputLimit,
 		)
 	}
-	_ = guest.stdin.Close()
-	waitErr := waitWorkflowGuest(ctx, guest)
 	if state.guestErr != nil {
 		return Result{}, guestErrorWithStderr(state.guestErr, guest.stderr.String())
 	}

--- a/tool/dynamicworkflow/tool.go
+++ b/tool/dynamicworkflow/tool.go
@@ -263,7 +263,7 @@ func (g *workflowGateway) callAgent(ctx context.Context, call Call) (json.RawMes
 		agent.WithInvocationAgent(candidate.agent),
 		agent.WithInvocationMessage(message),
 		agent.WithInvocationEventFilterKey(childKey),
-		clearInheritedStructuredOutput(),
+		clearInheritedWorkflowRunOptions(),
 		agent.WithInvocationParentMetadata(&agent.ParentInvocationMetadata{
 			TriggerType: agent.TriggerTypeDynamicWorkflow,
 			TriggerID:   g.workflow + "/" + call.ID,
@@ -330,18 +330,17 @@ func (g *workflowGateway) lockChildInstance(key string) func() {
 	return mu.Unlock
 }
 
-// clearInheritedStructuredOutput prevents a root run's response contract from
-// leaking into a workflow child. A child either uses its template's configured
-// output contract or, for a dynamic spec, the contract explicitly requested by
-// that spec.
-func clearInheritedStructuredOutput() agent.InvocationOptions {
+// clearInheritedWorkflowRunOptions prevents root run-scoped overrides from
+// leaking into a workflow child. A child should start from its template's
+// configured behavior and then apply only the dynamic spec requested by the
+// workflow code.
+func clearInheritedWorkflowRunOptions() agent.InvocationOptions {
 	return func(inv *agent.Invocation) {
 		if inv == nil {
 			return
 		}
 		runOpts := inv.RunOptions
-		runOpts.StructuredOutput = nil
-		runOpts.StructuredOutputType = nil
+		sanitizeWorkflowChildRunOptions(&runOpts)
 		inv.RunOptions = runOpts
 		inv.StructuredOutput = nil
 		inv.StructuredOutputType = nil
@@ -427,10 +426,10 @@ func (g *workflowGateway) collectChildResult(
 			if err := g.appendSessionEvent(ctx, inv, evt); err != nil {
 				return agentResult{}, err
 			}
-			if evt.RequiresCompletion {
-				if err := inv.NotifyCompletion(ctx, agent.GetAppendEventNoticeKey(evt.ID)); err != nil {
-					return agentResult{}, err
-				}
+		}
+		if evt.RequiresCompletion {
+			if err := inv.NotifyCompletion(ctx, agent.GetAppendEventNoticeKey(evt.ID)); err != nil {
+				return agentResult{}, err
 			}
 		}
 		content, assistant := assistantEventContent(evt)

--- a/tool/dynamicworkflow/tool.go
+++ b/tool/dynamicworkflow/tool.go
@@ -1,0 +1,577 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/appender"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/eventstream"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/flush"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/livesession"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// Option configures a run_workflow tool.
+type Option func(*config)
+
+type config struct {
+	name        string
+	description string
+	tools       []tool.CallableTool
+}
+
+const defaultMaxConcurrentAgents = 8
+
+// WithCodeCallableTools exposes host tools to workflow code. Workflow Python
+// can call them with call_tool(...). These tools are not added to any child
+// Agent and are never inferred from the root Agent.
+func WithCodeCallableTools(tools ...tool.CallableTool) Option {
+	return func(c *config) {
+		c.tools = append(c.tools, tools...)
+	}
+}
+
+// WithName changes the model-visible tool name. The default is run_workflow.
+func WithName(name string) Option {
+	return func(c *config) { c.name = name }
+}
+
+// WithDescription replaces the default model-visible description.
+func WithDescription(description string) Option {
+	return func(c *config) { c.description = description }
+}
+
+// NewTool creates a run_workflow tool. At least one sub-agent is required so
+// this capability remains distinct from execute_tool_code, which is intended
+// for tool-only orchestration.
+func NewTool(runtime Runtime, agents []agent.Agent, opts ...Option) (tool.CallableTool, error) {
+	if runtime == nil {
+		return nil, required("runtime")
+	}
+	if len(agents) == 0 {
+		return nil, fmt.Errorf("dynamicworkflow: at least one agent is required")
+	}
+	cfg := config{name: "run_workflow", description: defaultDescription}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	if strings.TrimSpace(cfg.name) == "" {
+		return nil, required("tool name")
+	}
+	agentRegistry, err := registerAgentTemplates(agents)
+	if err != nil {
+		return nil, err
+	}
+	for name, tmpl := range agentRegistry {
+		delete(tmpl.tools, cfg.name)
+		agentRegistry[name] = tmpl
+	}
+	toolRegistry, err := registerTools(cfg.tools)
+	if err != nil {
+		return nil, err
+	}
+	if _, exists := toolRegistry[cfg.name]; exists {
+		return nil, fmt.Errorf("dynamicworkflow: workflow tool %q cannot call itself", cfg.name)
+	}
+	return &workflowTool{
+		runtime: runtime,
+		agents:  agentRegistry,
+		tools:   toolRegistry,
+		cfg:     cfg,
+	}, nil
+}
+
+const defaultDescription = "Run one temporary Python workflow for tasks that need role delegation, parallel analysis, conditional iteration, or data flow between workflow-local child agents. Registered templates fix model, executor, callbacks, permissions, and other runtime policy; each agent call's dynamic instruction defines that child role's temporary business job. The code argument is executable workflow code, not a code sample. Use only declared workflow capabilities and return a JSON-compatible value."
+
+const codeCallableToolDescription = "Code-callable host tools are enabled for this workflow. Call await call_tool(\"tool_name\", **json_arguments) only for the documented allowlisted tools below. Do not parallelize mutating tool calls; use child agents for concurrent work."
+
+type workflowTool struct {
+	runtime Runtime
+	agents  map[string]agentTemplate
+	tools   map[string]tool.CallableTool
+	cfg     config
+}
+
+// Declaration implements tool.Tool.
+func (t *workflowTool) Declaration() *tool.Declaration {
+	description := t.cfg.description
+	if len(t.tools) > 0 {
+		description += "\n\n" + codeCallableToolDescription
+	}
+	if capabilities := buildCapabilityHelp(t.agents, t.tools); capabilities != "" {
+		description += "\n\nHost capabilities available inside Python:\n" + capabilities
+	}
+	codeDescription := `Write the executable workflow body itself: use await directly and finish with return. Do not assign the program to code, put it in a quoted string or Markdown fence, return Python source, define an uncalled wrapper such as async def run(), define or run main(), call asyncio.run(), import modules, or access undeclared host capabilities. Use Python True/False/None in source (JSON-style true/false/null aliases are also accepted in generated AgentSpec dictionaries). Use await agent(input, options=None) or await agent(input, **options) to create and run one child Agent. options may set template, instruction, instance_id, tools, skills, and structured_output; schema is shorthand for structured_output.schema. If exactly one template is registered, template may be omitted. Omitted tools and skills inherit eligible template capabilities; use [] to disable a capability type or a non-empty list to narrow it. Pass schema as a Python dict literal; do not import json or call json.dumps. agent returns an envelope with text and optional structured fields; prefer result["structured"], and missing result["field"] / result.get("field") fall back to structured.
+
+Canonical one-shot pattern:
+draft = await agent("Write a concise draft.", instruction="Write the first draft.", tools=[])
+for _ in range(3):
+    review = await agent({"draft": draft}, instruction="Review the draft and return approved plus feedback.", schema={"type": "object", "properties": {"approved": {"type": "boolean"}, "feedback": {"type": "string"}}})
+    if review["approved"]:
+        break
+    draft = await agent({"draft": draft, "feedback": review["feedback"]}, instruction="Revise the draft.", tools=[])
+return {"draft": draft, "review": review}
+
+Short parallel idiom: analyses = await parallel([lambda: agent("Option A", instruction="Analyze"), lambda: agent("Option B", instruction="Analyze")]). parallel([lambda: agent(...), ...]) runs independent branches concurrently and preserves input order. pipeline(items, stage1, ...) runs each item through async stages; each stage receives (previous_result, original_item, index).`
+	if len(t.tools) > 0 {
+		codeDescription += " Code-callable host tools are enabled: use await call_tool(name, **json_arguments) only for the documented allowlisted tools."
+	}
+	return &tool.Declaration{
+		Name:        t.cfg.name,
+		Description: description,
+		InputSchema: &tool.Schema{
+			Type:     "object",
+			Required: []string{"code"},
+			Properties: map[string]*tool.Schema{
+				"code": {
+					Type:        "string",
+					Description: codeDescription,
+				},
+			},
+		},
+		OutputSchema: &tool.Schema{
+			Type: "object",
+			Properties: map[string]*tool.Schema{
+				"value":  {Description: "JSON-serializable value returned by the workflow"},
+				"stdout": {Type: "string", Description: "Captured Python stdout"},
+			},
+		},
+	}
+}
+
+// Call implements tool.CallableTool.
+func (t *workflowTool) Call(ctx context.Context, raw []byte) (any, error) {
+	var input struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: decode input: %w", err)
+	}
+	parent, ok := agent.InvocationFromContext(ctx)
+	if !ok || parent == nil {
+		return nil, fmt.Errorf("dynamicworkflow: run_workflow requires a running agent invocation")
+	}
+	if parent.Session == nil {
+		return nil, fmt.Errorf("dynamicworkflow: run_workflow requires a parent session")
+	}
+	gateway := &workflowGateway{
+		parent:     parent,
+		agents:     t.agents,
+		tools:      t.tools,
+		workflow:   uuid.NewString(),
+		toolName:   t.cfg.name,
+		agentSlots: make(chan struct{}, defaultMaxConcurrentAgents),
+	}
+	if err := flush.Invoke(ctx, parent); err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: flush parent session: %w", err)
+	}
+	return Execute(ctx, t.runtime, gateway, input.Code)
+}
+
+type workflowGateway struct {
+	parent   *agent.Invocation
+	agents   map[string]agentTemplate
+	tools    map[string]tool.CallableTool
+	workflow string
+	toolName string
+
+	agentSlots    chan struct{}
+	instanceLocks sync.Map
+	appendMu      sync.Mutex
+}
+
+// HandleWorkflowCall implements CallHandler.
+func (g *workflowGateway) HandleWorkflowCall(
+	ctx context.Context,
+	call Call,
+) (json.RawMessage, error) {
+	if g == nil {
+		return nil, fmt.Errorf("dynamicworkflow: nil gateway")
+	}
+	switch call.Kind {
+	case CallKindTool:
+		return g.callTool(ctx, call)
+	case CallKindAgent:
+		return g.callAgent(ctx, call)
+	default:
+		return nil, fmt.Errorf("dynamicworkflow: unsupported call kind %q", call.Kind)
+	}
+}
+
+func (g *workflowGateway) callTool(ctx context.Context, call Call) (json.RawMessage, error) {
+	candidate, ok := g.tools[call.Name]
+	if !ok {
+		return nil, fmt.Errorf("dynamicworkflow: tool %q is not allowlisted", call.Name)
+	}
+	if !json.Valid(call.Args) {
+		return nil, fmt.Errorf("dynamicworkflow: tool %q received invalid JSON arguments", call.Name)
+	}
+	var args map[string]json.RawMessage
+	if err := json.Unmarshal(call.Args, &args); err != nil || args == nil {
+		return nil, fmt.Errorf("dynamicworkflow: tool %q requires a JSON object argument", call.Name)
+	}
+	value, err := candidate.Call(ctx, call.Args)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: call tool %q: %w", call.Name, err)
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: encode result from tool %q: %w", call.Name, err)
+	}
+	return raw, nil
+}
+
+func (g *workflowGateway) callAgent(ctx context.Context, call Call) (json.RawMessage, error) {
+	req, err := g.resolveAgentCall(call)
+	if err != nil {
+		return nil, err
+	}
+	candidate, ok := g.agents[req.templateName]
+	if !ok {
+		return nil, fmt.Errorf("dynamicworkflow: agent %q is not registered", req.templateName)
+	}
+	parent := parentWithLiveSession(g.parent)
+	childKey := workflowChildKey(parent, g.workflow, req.instanceID)
+	unlock := g.lockChildInstance(childKey)
+	defer unlock()
+	if err := g.acquireAgentSlot(ctx); err != nil {
+		return nil, err
+	}
+	defer g.releaseAgentSlot()
+	message := model.NewUserMessage(workflowInputText(req.input))
+	invocationOptions := []agent.InvocationOptions{
+		agent.WithInvocationAgent(candidate.agent),
+		agent.WithInvocationMessage(message),
+		agent.WithInvocationEventFilterKey(childKey),
+		clearInheritedStructuredOutput(),
+		agent.WithInvocationParentMetadata(&agent.ParentInvocationMetadata{
+			TriggerType: agent.TriggerTypeDynamicWorkflow,
+			TriggerID:   g.workflow + "/" + call.ID,
+			TriggerName: g.toolName,
+		}),
+	}
+	if req.dynamic {
+		dynamicOpt, err := g.dynamicAgentInvocationOption(ctx, candidate, req)
+		if err != nil {
+			return nil, err
+		}
+		invocationOptions = append(invocationOptions, dynamicOpt)
+	}
+	child := parent.Clone(invocationOptions...)
+	if err := g.appendChildUserMessage(ctx, child); err != nil {
+		return nil, err
+	}
+	childCtx := agent.NewInvocationContext(ctx, child)
+	events, err := agent.RunWithPlugins(childCtx, child, candidate.agent)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: run agent %q: %w", req.templateName, err)
+	}
+	result, err := g.collectChildResult(childCtx, child, events)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: collect agent %q: %w", req.templateName, err)
+	}
+	result.HistoryKey = childKey
+	if child.Session != nil {
+		result.SessionID = child.Session.ID
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: encode agent %q result: %w", req.templateName, err)
+	}
+	return raw, nil
+}
+
+func (g *workflowGateway) acquireAgentSlot(ctx context.Context) error {
+	if g == nil || g.agentSlots == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case g.agentSlots <- struct{}{}:
+		return nil
+	}
+}
+
+func (g *workflowGateway) releaseAgentSlot() {
+	if g == nil || g.agentSlots == nil {
+		return
+	}
+	<-g.agentSlots
+}
+
+func (g *workflowGateway) lockChildInstance(key string) func() {
+	if g == nil || key == "" {
+		return func() {}
+	}
+	value, _ := g.instanceLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// clearInheritedStructuredOutput prevents a root run's response contract from
+// leaking into a workflow child. A child either uses its template's configured
+// output contract or, for a dynamic spec, the contract explicitly requested by
+// that spec.
+func clearInheritedStructuredOutput() agent.InvocationOptions {
+	return func(inv *agent.Invocation) {
+		if inv == nil {
+			return
+		}
+		runOpts := inv.RunOptions
+		runOpts.StructuredOutput = nil
+		runOpts.StructuredOutputType = nil
+		inv.RunOptions = runOpts
+		inv.StructuredOutput = nil
+		inv.StructuredOutputType = nil
+	}
+}
+
+type agentResult struct {
+	Text         string          `json:"text"`
+	Structured   json.RawMessage `json:"structured,omitempty"`
+	SessionID    string          `json:"session_id,omitempty"`
+	HistoryKey   string          `json:"history_key"`
+	InvocationID string          `json:"invocation_id"`
+}
+
+func parentWithLiveSession(parent *agent.Invocation) *agent.Invocation {
+	if parent == nil || parent.Session == nil {
+		return parent
+	}
+	live, ok := livesession.Get(parent)
+	if !ok || live == nil || live == parent.Session {
+		return parent
+	}
+	return parent.View(agent.WithInvocationSession(live))
+}
+
+func workflowChildKey(parent *agent.Invocation, workflowID, agentName string) string {
+	prefix := "dynamic_workflow/" + workflowID + "/" + agentName
+	if parent == nil || parent.GetEventFilterKey() == "" {
+		return prefix
+	}
+	return parent.GetEventFilterKey() + agent.EventFilterKeyDelimiter + prefix
+}
+
+func workflowInputText(raw json.RawMessage) string {
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	return string(raw)
+}
+
+func (g *workflowGateway) appendChildUserMessage(ctx context.Context, inv *agent.Invocation) error {
+	if inv == nil {
+		return fmt.Errorf("dynamicworkflow: child invocation is nil")
+	}
+	userEvent := event.NewResponseEvent(inv.InvocationID, "user", &model.Response{
+		Choices: []model.Choice{{Index: 0, Message: inv.Message}},
+	})
+	agent.InjectIntoEvent(inv, userEvent)
+	if err := g.appendSessionEvent(ctx, inv, userEvent); err != nil {
+		return fmt.Errorf("dynamicworkflow: append child input: %w", err)
+	}
+	return nil
+}
+
+func (g *workflowGateway) collectChildResult(
+	ctx context.Context,
+	inv *agent.Invocation,
+	events <-chan *event.Event,
+) (agentResult, error) {
+	result := agentResult{InvocationID: inv.InvocationID}
+	var partial strings.Builder
+	for evt := range events {
+		if evt == nil {
+			continue
+		}
+		agent.InjectIntoEvent(inv, evt)
+		if evt.Response != nil && evt.Response.Error != nil {
+			return agentResult{}, errorsFromResponse(evt.Response.Error)
+		}
+		if evt.StructuredOutput != nil {
+			raw, err := json.Marshal(evt.StructuredOutput)
+			if err != nil {
+				return agentResult{}, fmt.Errorf("dynamicworkflow: encode structured output: %w", err)
+			}
+			result.Structured = json.RawMessage(raw)
+		}
+		forwarded, err := eventstream.Invoke(ctx, inv, evt)
+		if err != nil {
+			return agentResult{}, err
+		}
+		if !forwarded {
+			if err := g.appendSessionEvent(ctx, inv, evt); err != nil {
+				return agentResult{}, err
+			}
+			if evt.RequiresCompletion {
+				if err := inv.NotifyCompletion(ctx, agent.GetAppendEventNoticeKey(evt.ID)); err != nil {
+					return agentResult{}, err
+				}
+			}
+		}
+		content, assistant := assistantEventContent(evt)
+		if !assistant || content == "" {
+			continue
+		}
+		if evt.IsPartial {
+			partial.WriteString(content)
+			continue
+		}
+		result.Text = content
+		partial.Reset()
+	}
+	if result.Text == "" {
+		result.Text = partial.String()
+	}
+	if result.Structured == nil && json.Valid([]byte(result.Text)) {
+		result.Structured = json.RawMessage(append([]byte(nil), result.Text...))
+	}
+	return result, nil
+}
+
+func (g *workflowGateway) appendSessionEvent(
+	ctx context.Context,
+	inv *agent.Invocation,
+	evt *event.Event,
+) error {
+	if g == nil {
+		return appendSessionEvent(ctx, inv, evt)
+	}
+	g.appendMu.Lock()
+	defer g.appendMu.Unlock()
+	return appendSessionEvent(ctx, inv, evt)
+}
+
+func appendSessionEvent(ctx context.Context, inv *agent.Invocation, evt *event.Event) error {
+	if inv == nil || evt == nil {
+		return nil
+	}
+	attached, err := appender.Invoke(ctx, inv, evt)
+	if err != nil {
+		return err
+	}
+	if attached {
+		return nil
+	}
+	if inv.SessionService != nil && inv.Session != nil {
+		return inv.SessionService.AppendEvent(ctx, inv.Session, evt)
+	}
+	return nil
+}
+
+func assistantEventContent(evt *event.Event) (string, bool) {
+	if evt == nil || evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return "", false
+	}
+	choice := evt.Response.Choices[0]
+	if choice.Message.Role == model.RoleAssistant && choice.Message.Content != "" {
+		return choice.Message.Content, true
+	}
+	if choice.Delta.Role == model.RoleAssistant && choice.Delta.Content != "" {
+		return choice.Delta.Content, true
+	}
+	return "", false
+}
+
+func errorsFromResponse(responseErr *model.ResponseError) error {
+	if responseErr == nil {
+		return nil
+	}
+	return fmt.Errorf("agent error: %s", responseErr.Message)
+}
+
+func registerTools(tools []tool.CallableTool) (map[string]tool.CallableTool, error) {
+	registered := make(map[string]tool.CallableTool, len(tools))
+	for _, candidate := range tools {
+		if candidate == nil || candidate.Declaration() == nil {
+			return nil, fmt.Errorf("dynamicworkflow: tool declaration is required")
+		}
+		name := strings.TrimSpace(candidate.Declaration().Name)
+		if name == "" {
+			return nil, fmt.Errorf("dynamicworkflow: tool name is required")
+		}
+		if _, exists := registered[name]; exists {
+			return nil, fmt.Errorf("dynamicworkflow: duplicate tool %q", name)
+		}
+		registered[name] = candidate
+	}
+	return registered, nil
+}
+
+func declarationName(candidate tool.Tool) string {
+	if candidate == nil || candidate.Declaration() == nil {
+		return ""
+	}
+	return strings.TrimSpace(candidate.Declaration().Name)
+}
+
+func buildCapabilityHelp(agents map[string]agentTemplate, tools map[string]tool.CallableTool) string {
+	var lines []string
+	agentNames := sortedNames(agents)
+	for _, name := range agentNames {
+		tmpl := agents[name]
+		info := tmpl.agent.Info()
+		line := fmt.Sprintf("- template %q: %s", name, info.Description)
+		if toolNames := sortedNames(tmpl.tools); len(toolNames) > 0 {
+			line += "\n  Dynamic narrowing tools: " + strings.Join(toolNames, ", ")
+		}
+		if len(info.InputSchema) > 0 {
+			line += "\n  Input JSON Schema: " + marshalOrNull(info.InputSchema)
+		}
+		if len(info.OutputSchema) > 0 {
+			line += "\n  Default structured output JSON Schema: " + marshalOrNull(info.OutputSchema)
+		}
+		lines = append(lines, line)
+	}
+	for _, name := range sortedNames(tools) {
+		decl := tools[name].Declaration()
+		line := fmt.Sprintf("- call_tool(%q, **json_arguments): %s", name, decl.Description)
+		line += "\n  Input JSON Schema: " + marshalOrNull(decl.InputSchema)
+		if decl.OutputSchema != nil {
+			line += "\n  Output JSON Schema: " + marshalOrNull(decl.OutputSchema)
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func sortedNames[T any](values map[string]T) []string {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func marshalOrNull(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "null"
+	}
+	return string(raw)
+}

--- a/tool/dynamicworkflow/tool.go
+++ b/tool/dynamicworkflow/tool.go
@@ -230,6 +230,17 @@ func (g *workflowGateway) callTool(ctx context.Context, call Call) (json.RawMess
 	if err := json.Unmarshal(call.Args, &args); err != nil || args == nil {
 		return nil, fmt.Errorf("dynamicworkflow: tool %q requires a JSON object argument", call.Name)
 	}
+	permissionResult, err := g.checkToolPermission(ctx, call, candidate)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: check permission for tool %q: %w", call.Name, err)
+	}
+	if permissionResult != nil {
+		raw, err := json.Marshal(permissionResult)
+		if err != nil {
+			return nil, fmt.Errorf("dynamicworkflow: encode permission result for tool %q: %w", call.Name, err)
+		}
+		return raw, nil
+	}
 	value, err := candidate.Call(ctx, call.Args)
 	if err != nil {
 		return nil, fmt.Errorf("dynamicworkflow: call tool %q: %w", call.Name, err)
@@ -239,6 +250,52 @@ func (g *workflowGateway) callTool(ctx context.Context, call Call) (json.RawMess
 		return nil, fmt.Errorf("dynamicworkflow: encode result from tool %q: %w", call.Name, err)
 	}
 	return raw, nil
+}
+
+func (g *workflowGateway) checkToolPermission(
+	ctx context.Context,
+	call Call,
+	candidate tool.CallableTool,
+) (*tool.PermissionResult, error) {
+	req := &tool.PermissionRequest{
+		Tool:        candidate,
+		ToolName:    call.Name,
+		ToolCallID:  call.ID,
+		Declaration: candidate.Declaration(),
+		Arguments:   append([]byte(nil), call.Args...),
+		Metadata:    tool.MetadataOf(candidate),
+	}
+	if checker, ok := candidate.(tool.PermissionChecker); ok {
+		decision, err := checker.CheckPermission(ctx, req)
+		result, err := normalizeWorkflowToolPermissionResult(req, decision, err)
+		if result != nil || err != nil {
+			return result, err
+		}
+	}
+	if g == nil || g.parent == nil || g.parent.RunOptions.ToolPermissionPolicy == nil {
+		return nil, nil
+	}
+	decision, err := g.parent.RunOptions.ToolPermissionPolicy.CheckToolPermission(ctx, req)
+	return normalizeWorkflowToolPermissionResult(req, decision, err)
+}
+
+func normalizeWorkflowToolPermissionResult(
+	req *tool.PermissionRequest,
+	decision tool.PermissionDecision,
+	checkErr error,
+) (*tool.PermissionResult, error) {
+	if checkErr != nil {
+		return nil, checkErr
+	}
+	decision, err := tool.NormalizePermissionDecision(decision)
+	if err != nil {
+		return nil, err
+	}
+	if decision.Action == tool.PermissionActionAllow {
+		return nil, nil
+	}
+	result := tool.PermissionResultFor(req.ToolName, decision)
+	return &result, nil
 }
 
 func (g *workflowGateway) callAgent(ctx context.Context, call Call) (json.RawMessage, error) {
@@ -252,7 +309,10 @@ func (g *workflowGateway) callAgent(ctx context.Context, call Call) (json.RawMes
 	}
 	parent := parentWithLiveSession(g.parent)
 	childKey := workflowChildKey(parent, g.workflow, req.instanceID)
-	unlock := g.lockChildInstance(childKey)
+	unlock, err := g.lockChildInstance(ctx, childKey)
+	if err != nil {
+		return nil, err
+	}
 	defer unlock()
 	if err := g.acquireAgentSlot(ctx); err != nil {
 		return nil, err
@@ -270,13 +330,11 @@ func (g *workflowGateway) callAgent(ctx context.Context, call Call) (json.RawMes
 			TriggerName: g.toolName,
 		}),
 	}
-	if req.dynamic {
-		dynamicOpt, err := g.dynamicAgentInvocationOption(ctx, candidate, req)
-		if err != nil {
-			return nil, err
-		}
-		invocationOptions = append(invocationOptions, dynamicOpt)
+	childSurfaceOpt, err := g.workflowChildInvocationOption(ctx, candidate, req)
+	if err != nil {
+		return nil, err
 	}
+	invocationOptions = append(invocationOptions, childSurfaceOpt)
 	child := parent.Clone(invocationOptions...)
 	if err := g.appendChildUserMessage(ctx, child); err != nil {
 		return nil, err
@@ -320,14 +378,24 @@ func (g *workflowGateway) releaseAgentSlot() {
 	<-g.agentSlots
 }
 
-func (g *workflowGateway) lockChildInstance(key string) func() {
+func (g *workflowGateway) lockChildInstance(ctx context.Context, key string) (func(), error) {
 	if g == nil || key == "" {
-		return func() {}
+		return func() {}, nil
 	}
-	value, _ := g.instanceLocks.LoadOrStore(key, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
+	value, _ := g.instanceLocks.LoadOrStore(key, newChildInstanceLock())
+	lock := value.(chan struct{})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-lock:
+		return func() { lock <- struct{}{} }, nil
+	}
+}
+
+func newChildInstanceLock() chan struct{} {
+	lock := make(chan struct{}, 1)
+	lock <- struct{}{}
+	return lock
 }
 
 // clearInheritedWorkflowRunOptions prevents root run-scoped overrides from

--- a/tool/dynamicworkflow/tool_test.go
+++ b/tool/dynamicworkflow/tool_test.go
@@ -494,6 +494,71 @@ func TestWorkflowCoordinatesExplicitAgentAndTool(t *testing.T) {
 	require.Contains(t, persisted[1].FilterKey, "/reviewer")
 }
 
+func TestWorkflowCallToolHonorsPermissionBoundaries(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer"}
+
+	t.Run("tool checker deny skips execution and run policy", func(t *testing.T) {
+		sensitive := &permissionTestTool{
+			name:     "sensitive",
+			decision: tool.DenyPermission("blocked by tool"),
+		}
+		workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+			raw, err := handler.HandleWorkflowCall(ctx, Call{
+				ID: "tool-1", Kind: CallKindTool, Name: "sensitive", Args: json.RawMessage(`{"id":"42"}`),
+			})
+			return Result{Value: raw}, err
+		}}, []agent.Agent{reviewer}, WithCodeCallableTools(sensitive))
+		require.NoError(t, err)
+
+		policyCalled := false
+		parent := agent.NewInvocation(
+			agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+			agent.WithInvocationRunOptions(agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+				func(context.Context, *tool.PermissionRequest) (tool.PermissionDecision, error) {
+					policyCalled = true
+					return tool.AllowPermission(), nil
+				},
+			))),
+		)
+
+		value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+		require.NoError(t, err)
+		result := value.(Result)
+		require.JSONEq(t, `{"status":"denied","tool":"sensitive","reason":"blocked by tool"}`, string(result.Value))
+		require.False(t, sensitive.called)
+		require.False(t, policyCalled)
+	})
+
+	t.Run("run policy ask skips execution", func(t *testing.T) {
+		sensitive := &permissionTestTool{name: "sensitive", decision: tool.AllowPermission()}
+		workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+			raw, err := handler.HandleWorkflowCall(ctx, Call{
+				ID: "tool-1", Kind: CallKindTool, Name: "sensitive", Args: json.RawMessage(`{"id":"42"}`),
+			})
+			return Result{Value: raw}, err
+		}}, []agent.Agent{reviewer}, WithCodeCallableTools(sensitive))
+		require.NoError(t, err)
+
+		parent := agent.NewInvocation(
+			agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+			agent.WithInvocationRunOptions(agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+				func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+					require.Equal(t, "sensitive", req.ToolName)
+					require.Equal(t, "tool-1", req.ToolCallID)
+					require.JSONEq(t, `{"id":"42"}`, string(req.Arguments))
+					return tool.AskPermission("needs approval"), nil
+				},
+			))),
+		)
+
+		value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+		require.NoError(t, err)
+		result := value.(Result)
+		require.JSONEq(t, `{"status":"approval_required","tool":"sensitive","reason":"needs approval"}`, string(result.Value))
+		require.False(t, sensitive.called)
+	})
+}
+
 func TestWorkflowForwardsChildEventsWhenRunnerForwarderIsAttached(t *testing.T) {
 	reviewer := &testAgent{name: "reviewer", response: "done"}
 	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
@@ -643,6 +708,49 @@ func TestWorkflowDynamicAgentSpecInheritsTemplateCapabilitiesWhenOmitted(t *test
 	require.Equal(t, []string{"lookup", "search"}, toolNames(selectedTools))
 	_, overridesSkills := patch.SkillRepository()
 	require.False(t, overridesSkills, "omitted skills must inherit the template repository")
+}
+
+func TestWorkflowPlainAgentGetsCapabilityBoundaryPatch(t *testing.T) {
+	lookup := &testTool{name: "lookup"}
+	reviewer := &testAgent{
+		name: "reviewer",
+		tools: []tool.Tool{
+			lookup,
+			&testTool{name: "workspace_exec"},
+		},
+		userToolNames: map[string]bool{"lookup": true},
+		response:      "approved",
+	}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+
+	child := reviewer.lastInvocation()
+	require.NotNil(t, child)
+	rootNode := agent.InvocationSurfaceRootNodeID(child)
+	require.NotEmpty(t, rootNode)
+	patch, ok := surfacepatch.PatchForNode(child.RunOptions.CustomAgentConfigs, rootNode)
+	require.True(t, ok)
+	selectedTools, ok := patch.Tools()
+	require.True(t, ok)
+	require.Equal(t, []string{"lookup"}, toolNames(selectedTools))
+	require.True(t, patch.SuppressSubAgentTransfer())
+	_, overridesInstruction := patch.Instruction()
+	require.False(t, overridesInstruction)
 }
 
 func TestWorkflowDynamicAgentSpecSetsStructuredOutput(t *testing.T) {
@@ -1093,12 +1201,19 @@ func TestWorkflowGatewayAgentErrorBranches(t *testing.T) {
 func TestWorkflowGatewayHelperBranches(t *testing.T) {
 	require.NoError(t, (*workflowGateway)(nil).acquireAgentSlot(context.Background()))
 	(*workflowGateway)(nil).releaseAgentSlot()
-	(*workflowGateway)(nil).lockChildInstance("")()
+	unlock, err := (*workflowGateway)(nil).lockChildInstance(context.Background(), "")
+	require.NoError(t, err)
+	unlock()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	gateway := &workflowGateway{agentSlots: make(chan struct{})}
 	require.ErrorIs(t, gateway.acquireAgentSlot(ctx), context.Canceled)
+	unlock, err = gateway.lockChildInstance(context.Background(), "shared")
+	require.NoError(t, err)
+	_, err = gateway.lockChildInstance(ctx, "shared")
+	require.ErrorIs(t, err, context.Canceled)
+	unlock()
 
 	parent := agent.NewInvocation(agent.WithInvocationSession(
 		&session.Session{ID: "snapshot", AppName: "app", UserID: "user"},
@@ -1506,6 +1621,29 @@ func (t *testTool) Call(ctx context.Context, raw []byte) (any, error) {
 		return nil, fmt.Errorf("missing test tool callback")
 	}
 	return t.call(ctx, raw)
+}
+
+type permissionTestTool struct {
+	name     string
+	decision tool.PermissionDecision
+	err      error
+	called   bool
+}
+
+func (t *permissionTestTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name, Description: t.name + " tool"}
+}
+
+func (t *permissionTestTool) Call(context.Context, []byte) (any, error) {
+	t.called = true
+	return map[string]any{"ok": true}, nil
+}
+
+func (t *permissionTestTool) CheckPermission(
+	context.Context,
+	*tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	return t.decision, t.err
 }
 
 func normalizeWorkflowResult(t *testing.T, raw []byte) string {

--- a/tool/dynamicworkflow/tool_test.go
+++ b/tool/dynamicworkflow/tool_test.go
@@ -1327,6 +1327,13 @@ func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
 
 	_, err = decodeAgentOptions(json.RawMessage(`[]`))
 	require.ErrorContains(t, err, "agent options must be a mapping or template name")
+	_, err = decodeAgentOptions(json.RawMessage(`{`))
+	require.ErrorContains(t, err, "agent options must be valid JSON")
+	_, err = decodeAgentOptions(json.RawMessage(`{
+		"template": "reviewer",
+		"structured_output": "{"
+	}`))
+	require.ErrorContains(t, err, "structured_output must be a JSON object")
 
 	optSpec, err := decodeAgentOptions(json.RawMessage(`" reviewer "`))
 	require.NoError(t, err)
@@ -1351,10 +1358,15 @@ func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
 
 	_, err = canonicalStructuredOutput(json.RawMessage(`[]`))
 	require.ErrorContains(t, err, "structured_output must be a JSON object")
+	_, err = canonicalStructuredOutput(json.RawMessage(`{`))
+	require.ErrorContains(t, err, "structured_output must be valid JSON")
 
 	wrapped, err := canonicalStructuredOutput(json.RawMessage(`{"schema":{"type":"object"}}`))
 	require.NoError(t, err)
 	require.JSONEq(t, `{"schema":{"type":"object"}}`, string(wrapped))
+
+	require.ErrorContains(t, normalizeAgentSpec(nil), "agent options are required")
+	require.ErrorContains(t, normalizeAgentSpec(&AgentSpec{}), "agent spec template is required")
 
 	spec := AgentSpec{Template: " reviewer ", Tools: []string{" lookup ", "", "lookup"}, Skills: []string{}}
 	require.NoError(t, normalizeAgentSpec(&spec))
@@ -1371,7 +1383,26 @@ func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
 	selectedTools, err := gateway.selectAgentTools(context.Background(), tmpl, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"lookup"}, toolNames(selectedTools))
+	selectedTools, err = gateway.selectAgentTools(context.Background(), tmpl, []string{})
+	require.NoError(t, err)
+	require.Nil(t, selectedTools)
 
+	plain := &plainTestAgent{name: "plain", tools: []tool.Tool{&testTool{name: "plain_lookup"}}}
+	plainTools, userToolNames := templateToolSurface(context.Background(), plain)
+	require.Equal(t, []string{"plain_lookup"}, toolNames(plainTools))
+	require.Nil(t, userToolNames)
+	tmpl = agentTemplate{
+		name:  "plain",
+		agent: plain,
+		tools: map[string]tool.Tool{"plain_lookup": &testTool{name: "plain_lookup"}},
+	}
+	require.Equal(t, []string{"plain_lookup"}, sortedNames(gateway.selectableAgentTools(context.Background(), tmpl)))
+
+	tmpl = agentTemplate{
+		name:  "reviewer",
+		agent: &testAgent{name: "reviewer", tools: []tool.Tool{&testTool{name: "lookup"}}},
+		tools: map[string]tool.Tool{"lookup": &testTool{name: "lookup"}},
+	}
 	emptyRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, []string{})
 	require.NoError(t, err)
 	require.Nil(t, emptyRepo)
@@ -1384,6 +1415,9 @@ func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
 	inheritedRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, nil)
 	require.NoError(t, err)
 	require.Same(t, repo, inheritedRepo)
+	disabledRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, []string{})
+	require.NoError(t, err)
+	require.Empty(t, skill.SummariesForContext(context.Background(), disabledRepo))
 	filteredRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, []string{"risk"})
 	require.NoError(t, err)
 	require.Equal(t, []string{"risk"}, skillNames(skill.SummariesForContext(context.Background(), filteredRepo)))
@@ -1397,6 +1431,40 @@ func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
 	require.Nil(t, selectedRepo)
 	_, err = gateway.selectAgentSkills(context.Background(), tmpl, []string{"risk"})
 	require.ErrorContains(t, err, `does not expose skills`)
+}
+
+func TestWorkflowCapabilityHelpIncludesSchemas(t *testing.T) {
+	lookup := &schemaTestTool{
+		name: "lookup",
+		input: &tool.Schema{Type: "object", Properties: map[string]*tool.Schema{
+			"query": {Type: "string"},
+		}},
+		output: &tool.Schema{Type: "object", Properties: map[string]*tool.Schema{
+			"found": {Type: "boolean"},
+		}},
+	}
+	reviewer := &schemaTestAgent{
+		name:        "reviewer",
+		description: "reviews a plan",
+		tools:       []tool.Tool{lookup},
+		inputSchema: map[string]any{"type": "string"},
+		outputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"approved": map[string]any{"type": "boolean"}},
+		},
+	}
+	registered, err := registerAgentTemplates([]agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	help := buildCapabilityHelp(registered, map[string]tool.CallableTool{"lookup": lookup})
+	require.Contains(t, help, `template "reviewer": reviews a plan`)
+	require.Contains(t, help, "Dynamic narrowing tools: lookup")
+	require.Contains(t, help, `Input JSON Schema: {"type":"string"}`)
+	require.Contains(t, help, `Default structured output JSON Schema:`)
+	require.Contains(t, help, `call_tool("lookup", **json_arguments): lookup tool`)
+	require.Contains(t, help, `"query"`)
+	require.Contains(t, help, `Output JSON Schema:`)
+	require.Contains(t, help, `"found"`)
 }
 
 func TestStrictSchemaNormalizationBranches(t *testing.T) {
@@ -1417,6 +1485,8 @@ func TestStrictSchemaNormalizationBranches(t *testing.T) {
 	require.Equal(t, false, defs["nested"].(map[string]any)["additionalProperties"])
 	items := output.schema["items"].(map[string]any)
 	require.Equal(t, false, items["additionalProperties"])
+	normalizeStrictObjectSchemas(nil)
+	require.False(t, schemaDeclaresObject(map[string]any{"type": []any{"string", "null"}}))
 
 	_, err = dynamicStructuredOutput(&StructuredOutputSpec{Name: "bad", Schema: json.RawMessage(`[]`)})
 	require.ErrorContains(t, err, "structured_output schema must be a JSON object")
@@ -1516,6 +1586,27 @@ func (a *testAgent) lastInvocation() *agent.Invocation {
 	}
 	return a.invs[len(a.invs)-1]
 }
+
+type plainTestAgent struct {
+	name  string
+	tools []tool.Tool
+}
+
+func (a *plainTestAgent) Run(context.Context, *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (a *plainTestAgent) Tools() []tool.Tool { return a.tools }
+
+func (a *plainTestAgent) Info() agent.Info {
+	return agent.Info{Name: a.name, Description: a.name + " agent"}
+}
+
+func (a *plainTestAgent) SubAgents() []agent.Agent { return nil }
+
+func (a *plainTestAgent) FindSubAgent(string) agent.Agent { return nil }
 
 type runOptionsToolSurfaceAgent struct {
 	*testAgent
@@ -1622,6 +1713,67 @@ func (t *testTool) Call(ctx context.Context, raw []byte) (any, error) {
 	}
 	return t.call(ctx, raw)
 }
+
+type schemaTestTool struct {
+	name   string
+	input  *tool.Schema
+	output *tool.Schema
+}
+
+func (t *schemaTestTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{
+		Name:         t.name,
+		Description:  t.name + " tool",
+		InputSchema:  t.input,
+		OutputSchema: t.output,
+	}
+}
+
+func (t *schemaTestTool) Call(context.Context, []byte) (any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+type schemaTestAgent struct {
+	name         string
+	description  string
+	tools        []tool.Tool
+	inputSchema  map[string]any
+	outputSchema map[string]any
+}
+
+func (a *schemaTestAgent) Run(context.Context, *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (a *schemaTestAgent) Tools() []tool.Tool { return a.tools }
+
+func (a *schemaTestAgent) InvocationToolSurface(
+	context.Context,
+	*agent.Invocation,
+) ([]tool.Tool, map[string]bool) {
+	userToolNames := make(map[string]bool, len(a.tools))
+	for _, tl := range a.tools {
+		if name := declarationName(tl); name != "" {
+			userToolNames[name] = true
+		}
+	}
+	return a.tools, userToolNames
+}
+
+func (a *schemaTestAgent) Info() agent.Info {
+	return agent.Info{
+		Name:         a.name,
+		Description:  a.description,
+		InputSchema:  a.inputSchema,
+		OutputSchema: a.outputSchema,
+	}
+}
+
+func (a *schemaTestAgent) SubAgents() []agent.Agent { return nil }
+
+func (a *schemaTestAgent) FindSubAgent(string) agent.Agent { return nil }
 
 type permissionTestTool struct {
 	name     string

--- a/tool/dynamicworkflow/tool_test.go
+++ b/tool/dynamicworkflow/tool_test.go
@@ -84,6 +84,87 @@ func TestWorkflowAgentDefaultsToSoleTemplate(t *testing.T) {
 	require.Equal(t, "review it", reviewer.lastMessage())
 }
 
+func TestWorkflowAgentDoesNotInheritRootRunScopedOverrides(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", response: "approved"}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: reviewRaw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	rootExtra := &testTool{name: "root_extra"}
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	parent.RunOptions.ModelName = "root-model"
+	parent.RunOptions.Instruction = "root instruction"
+	parent.RunOptions.GlobalInstruction = "root global instruction"
+	parent.RunOptions.AdditionalTools = []tool.Tool{rootExtra}
+	parent.RunOptions.ExternalToolNames = map[string]bool{"external": true}
+	parent.RunOptions.ToolFilter = func(context.Context, tool.Tool) bool { return false }
+	parent.RunOptions.ToolExecutionFilter = func(context.Context, tool.Tool) bool { return false }
+	parent.RunOptions.StructuredOutput = &model.StructuredOutput{
+		Type: model.StructuredOutputJSONSchema,
+	}
+	parent.StructuredOutput = parent.RunOptions.StructuredOutput
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+
+	child := reviewer.lastInvocation()
+	require.NotNil(t, child)
+	require.Empty(t, child.RunOptions.ModelName)
+	require.Empty(t, child.RunOptions.Instruction)
+	require.Empty(t, child.RunOptions.GlobalInstruction)
+	require.Nil(t, child.RunOptions.AdditionalTools)
+	require.Nil(t, child.RunOptions.ExternalToolNames)
+	require.Nil(t, child.RunOptions.ToolFilter)
+	require.Nil(t, child.RunOptions.ToolExecutionFilter)
+	require.Nil(t, child.RunOptions.StructuredOutput)
+	require.Nil(t, child.StructuredOutput)
+}
+
+func TestWorkflowDynamicAgentToolSelectionUsesSanitizedChildProbe(t *testing.T) {
+	templateTool := &testTool{name: "template_lookup"}
+	rootExtra := &testTool{name: "root_extra"}
+	reviewer := &runOptionsToolSurfaceAgent{testAgent: &testAgent{
+		name:          "reviewer",
+		response:      "approved",
+		tools:         []tool.Tool{templateTool},
+		userToolNames: map[string]bool{"template_lookup": true},
+	}}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID:   "agent-1",
+			Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"agent":{
+					"template":"reviewer",
+					"tools":["root_extra"]
+				},
+				"input":"review it"
+			}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	parent.RunOptions.AdditionalTools = []tool.Tool{rootExtra}
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, `does not allow tool(s): root_extra`)
+}
+
 func TestWorkflowAgentRequiresTemplateWhenMultipleAreRegistered(t *testing.T) {
 	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
 		_, err := handler.HandleWorkflowCall(ctx, Call{
@@ -1076,6 +1157,36 @@ func TestWorkflowCollectChildResultErrorBranches(t *testing.T) {
 	require.ErrorContains(t, err, "forward failed")
 }
 
+func TestWorkflowCollectChildResultNotifiesForwardedEventCompletion(t *testing.T) {
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	evt := event.NewResponseEvent(inv.InvocationID, "reviewer", &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Index: 0, Message: model.Message{
+			Role: model.RoleAssistant, Content: "done",
+		}}},
+	})
+	evt.RequiresCompletion = true
+	ch := make(chan *event.Event, 1)
+	ch <- evt
+	close(ch)
+	forwarded := false
+	eventstream.Attach(inv, func(context.Context, *event.Event) error {
+		forwarded = true
+		return nil
+	})
+
+	_, err := (&workflowGateway{}).collectChildResult(context.Background(), inv, ch)
+	require.NoError(t, err)
+	require.True(t, forwarded)
+	require.NoError(t, inv.AddNoticeChannelAndWait(
+		context.Background(),
+		agent.GetAppendEventNoticeKey(evt.ID),
+		100*time.Millisecond,
+	))
+}
+
 func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
 	_, err := parseAgentCall(Call{Args: json.RawMessage(`{`)})
 	require.ErrorContains(t, err, "decode input for agent call")
@@ -1283,6 +1394,28 @@ func (a *testAgent) lastInvocation() *agent.Invocation {
 		return nil
 	}
 	return a.invs[len(a.invs)-1]
+}
+
+type runOptionsToolSurfaceAgent struct {
+	*testAgent
+}
+
+func (a *runOptionsToolSurfaceAgent) InvocationToolSurface(
+	_ context.Context,
+	inv *agent.Invocation,
+) ([]tool.Tool, map[string]bool) {
+	tools := append([]tool.Tool(nil), a.tools...)
+	userToolNames := make(map[string]bool, len(a.userToolNames)+len(inv.RunOptions.AdditionalTools))
+	for name, allowed := range a.userToolNames {
+		userToolNames[name] = allowed
+	}
+	for _, tl := range inv.RunOptions.AdditionalTools {
+		tools = append(tools, tl)
+		if name := declarationName(tl); name != "" {
+			userToolNames[name] = true
+		}
+	}
+	return tools, userToolNames
 }
 
 func testAgentPartialEvent(invocationID, author, content string) *event.Event {

--- a/tool/dynamicworkflow/tool_test.go
+++ b/tool/dynamicworkflow/tool_test.go
@@ -110,6 +110,11 @@ func TestWorkflowAgentDoesNotInheritRootRunScopedOverrides(t *testing.T) {
 	parent.RunOptions.ExternalToolNames = map[string]bool{"external": true}
 	parent.RunOptions.ToolFilter = func(context.Context, tool.Tool) bool { return false }
 	parent.RunOptions.ToolExecutionFilter = func(context.Context, tool.Tool) bool { return false }
+	parent.RunOptions.ToolPermissionPolicy = tool.PermissionPolicyFunc(
+		func(context.Context, *tool.PermissionRequest) (tool.PermissionDecision, error) {
+			return tool.AllowPermission(), nil
+		},
+	)
 	parent.RunOptions.StructuredOutput = &model.StructuredOutput{
 		Type: model.StructuredOutputJSONSchema,
 	}
@@ -131,6 +136,7 @@ func TestWorkflowAgentDoesNotInheritRootRunScopedOverrides(t *testing.T) {
 	require.Nil(t, child.RunOptions.ExternalToolNames)
 	require.Nil(t, child.RunOptions.ToolFilter)
 	require.Nil(t, child.RunOptions.ToolExecutionFilter)
+	require.NotNil(t, child.RunOptions.ToolPermissionPolicy)
 	require.Nil(t, child.RunOptions.StructuredOutput)
 	require.Nil(t, child.StructuredOutput)
 }
@@ -557,6 +563,53 @@ func TestWorkflowCallToolHonorsPermissionBoundaries(t *testing.T) {
 		require.JSONEq(t, `{"status":"approval_required","tool":"sensitive","reason":"needs approval"}`, string(result.Value))
 		require.False(t, sensitive.called)
 	})
+}
+
+func TestWorkflowChildAgentToolsHonorParentPermissionPolicy(t *testing.T) {
+	called := false
+	sensitive := &testTool{name: "sensitive", call: func(context.Context, []byte) (any, error) {
+		called = true
+		return map[string]any{"ok": true}, nil
+	}}
+	modelImpl := &toolCallingThenFinalModel{toolName: "sensitive"}
+	reviewer := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(modelImpl),
+		llmagent.WithTools([]tool.Tool{sensitive}),
+	)
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID:   "agent-1",
+			Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	policyCalled := false
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(agent.WithToolPermissionPolicyFunc(
+			func(_ context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+				policyCalled = true
+				require.Equal(t, "sensitive", req.ToolName)
+				require.Equal(t, "call-1", req.ToolCallID)
+				require.JSONEq(t, `{"id":"42"}`, string(req.Arguments))
+				return tool.DenyPermission("blocked by run policy"), nil
+			},
+		))),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.JSONEq(t, `{"text":"done","session_id":"session-1","history_key":"root/dynamic_workflow/<workflow>/agent-1","invocation_id":"<invocation-id>"}`, normalizeSingleAgentResult(t, result.Value))
+	require.True(t, policyCalled)
+	require.False(t, called)
+	require.GreaterOrEqual(t, modelImpl.callCount(), 2)
 }
 
 func TestWorkflowForwardsChildEventsWhenRunnerForwarderIsAttached(t *testing.T) {
@@ -1684,6 +1737,68 @@ func (m *structuredOutputCaptureModel) latestStructuredOutput() *model.Structure
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return cloneStructuredOutput(&model.Request{StructuredOutput: m.structuredOutput})
+}
+
+type toolCallingThenFinalModel struct {
+	toolName string
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (m *toolCallingThenFinalModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	m.mu.Lock()
+	m.calls++
+	callNumber := m.calls
+	m.mu.Unlock()
+
+	responses := make(chan *model.Response, 1)
+	if callNumber == 1 {
+		finishReason := "tool_calls"
+		responses <- &model.Response{
+			ID:   "tool-calling-model",
+			Done: true,
+			Choices: []model.Choice{{
+				Index:        0,
+				FinishReason: &finishReason,
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						Type: "function",
+						ID:   "call-1",
+						Function: model.FunctionDefinitionParam{
+							Name:      m.toolName,
+							Arguments: []byte(`{"id":"42"}`),
+						},
+					}},
+				},
+			}},
+		}
+	} else {
+		responses <- &model.Response{
+			ID:   "tool-calling-model",
+			Done: true,
+			Choices: []model.Choice{{
+				Index:   0,
+				Message: model.NewAssistantMessage("done"),
+			}},
+		}
+	}
+	close(responses)
+	return responses, nil
+}
+
+func (m *toolCallingThenFinalModel) Info() model.Info {
+	return model.Info{Name: "tool-calling-model"}
+}
+
+func (m *toolCallingThenFinalModel) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
 }
 
 func cloneStructuredOutput(request *model.Request) *model.StructuredOutput {

--- a/tool/dynamicworkflow/tool_test.go
+++ b/tool/dynamicworkflow/tool_test.go
@@ -101,6 +101,9 @@ func TestWorkflowAgentDoesNotInheritRootRunScopedOverrides(t *testing.T) {
 		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
 	)
 	parent.RunOptions.ModelName = "root-model"
+	parent.RunOptions.ModelContextWindow = 1024
+	parent.RunOptions.ModelRequestExtraFields = map[string]any{"root_only": true}
+	parent.RunOptions.ModelRequestHeaders = map[string]string{"X-Root-Only": "true"}
 	parent.RunOptions.Instruction = "root instruction"
 	parent.RunOptions.GlobalInstruction = "root global instruction"
 	parent.RunOptions.AdditionalTools = []tool.Tool{rootExtra}
@@ -119,6 +122,9 @@ func TestWorkflowAgentDoesNotInheritRootRunScopedOverrides(t *testing.T) {
 	child := reviewer.lastInvocation()
 	require.NotNil(t, child)
 	require.Empty(t, child.RunOptions.ModelName)
+	require.Zero(t, child.RunOptions.ModelContextWindow)
+	require.Nil(t, child.RunOptions.ModelRequestExtraFields)
+	require.Nil(t, child.RunOptions.ModelRequestHeaders)
 	require.Empty(t, child.RunOptions.Instruction)
 	require.Empty(t, child.RunOptions.GlobalInstruction)
 	require.Nil(t, child.RunOptions.AdditionalTools)

--- a/tool/dynamicworkflow/tool_test.go
+++ b/tool/dynamicworkflow/tool_test.go
@@ -1,0 +1,1454 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/appender"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/eventstream"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/livesession"
+	"trpc.group/trpc-go/trpc-agent-go/internal/surfacepatch"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestNewToolRequiresARegisteredAgent(t *testing.T) {
+	_, err := NewTool(scriptedRuntime{}, nil)
+	require.ErrorContains(t, err, "at least one agent is required")
+
+	_, err = NewTool(nil, []agent.Agent{&testAgent{name: "reviewer"}})
+	require.ErrorContains(t, err, "runtime is required")
+}
+
+func TestWorkflowToolOnlyExposesCallToolWhenConfigured(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer"}
+	withoutCodeCallableTools, err := NewTool(scriptedRuntime{}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+	require.NotContains(t, withoutCodeCallableTools.Declaration().Description, "call_tool")
+	require.NotContains(t, withoutCodeCallableTools.Declaration().InputSchema.Properties["code"].Description, "call_tool")
+
+	lookup := &testTool{name: "lookup", call: func(context.Context, []byte) (any, error) {
+		return map[string]any{"ok": true}, nil
+	}}
+	withCodeCallableTools, err := NewTool(scriptedRuntime{}, []agent.Agent{reviewer}, WithCodeCallableTools(lookup))
+	require.NoError(t, err)
+	require.Contains(t, withCodeCallableTools.Declaration().Description, "call_tool")
+	require.Contains(t, withCodeCallableTools.Declaration().InputSchema.Properties["code"].Description, "call_tool")
+}
+
+func TestWorkflowAgentDefaultsToSoleTemplate(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", response: "approved"}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: reviewRaw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.JSONEq(t, `{"text":"approved","session_id":"session-1","history_key":"root/dynamic_workflow/<workflow>/agent-1","invocation_id":"<invocation-id>"}`, normalizeSingleAgentResult(t, result.Value))
+	require.Equal(t, "review it", reviewer.lastMessage())
+}
+
+func TestWorkflowAgentRequiresTemplateWhenMultipleAreRegistered(t *testing.T) {
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{
+		&testAgent{name: "reviewer"},
+		&testAgent{name: "researcher"},
+	})
+	require.NoError(t, err)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, "agent options.template is required when multiple templates are registered")
+}
+
+func TestDecodeAgentOptionsRejectsUnknownField(t *testing.T) {
+	_, err := decodeAgentOptions(json.RawMessage(`{
+		"template": "reviewer",
+		"unsupported_option": true
+	}`))
+	require.ErrorContains(t, err, `unsupported agent option "unsupported_option"`)
+}
+
+func TestWorkflowParallelAgentsUseDistinctChildrenAndForwardEvents(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	var startedMu sync.Mutex
+	startedCount := 0
+	reviewer := &testAgent{name: "reviewer"}
+	reviewer.runFn = func(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+		var input struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(inv.Message.Content), &input); err != nil {
+			return nil, err
+		}
+		startedMu.Lock()
+		startedCount++
+		if startedCount == 2 {
+			startedOnce.Do(func() { close(started) })
+		}
+		startedMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-started:
+		}
+		ch := make(chan *event.Event, 1)
+		ch <- event.NewResponseEvent(inv.InvocationID, "reviewer", &model.Response{
+			Done: true,
+			Choices: []model.Choice{{Index: 0, Message: model.Message{
+				Role: model.RoleAssistant, Content: input.ID,
+			}}},
+		})
+		close(ch)
+		return ch, nil
+	}
+	workflow, err := NewTool(LocalRunner{}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	var eventsMu sync.Mutex
+	var persisted, forwarded []*event.Event
+	appender.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		persisted = append(persisted, evt)
+		return nil
+	})
+	eventstream.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		forwarded = append(forwarded, evt)
+		return nil
+	})
+
+	workflowInput, err := json.Marshal(map[string]string{"code": `
+results = await parallel([
+    lambda: agent({"id": "first"}),
+    lambda: agent({"id": "second"}),
+])
+return results
+`})
+	require.NoError(t, err)
+	value, err := workflow.Call(agent.NewInvocationContext(ctx, parent), workflowInput)
+	require.NoError(t, err)
+	result := value.(Result)
+	var agentResults []agentResult
+	require.NoError(t, json.Unmarshal(result.Value, &agentResults))
+	require.Len(t, agentResults, 2)
+	require.Equal(t, "first", agentResults[0].Text)
+	require.Equal(t, "second", agentResults[1].Text)
+	require.NotEqual(t, agentResults[0].InvocationID, agentResults[1].InvocationID)
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	require.Len(t, persisted, 2, "each child input is persisted")
+	require.Len(t, forwarded, 2, "each child output reaches the shared event stream")
+	require.NotEqual(t, forwarded[0].InvocationID, forwarded[1].InvocationID)
+}
+
+func TestWorkflowParallelStreamsInterleavedEventsAndKeepsResultOrder(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	firstPartialForwarded := make(chan struct{})
+	secondFinalForwarded := make(chan struct{})
+	var firstPartialOnce sync.Once
+	var secondFinalOnce sync.Once
+	reviewer := &testAgent{name: "reviewer"}
+	reviewer.runFn = func(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+		var input struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(inv.Message.Content), &input); err != nil {
+			return nil, err
+		}
+		ch := make(chan *event.Event, 2)
+		go func() {
+			defer close(ch)
+			switch input.ID {
+			case "first":
+				ch <- testAgentPartialEvent(inv.InvocationID, "reviewer", "first partial")
+				select {
+				case <-ctx.Done():
+					return
+				case <-secondFinalForwarded:
+				}
+				ch <- testAgentFinalEvent(inv.InvocationID, "reviewer", "first final")
+			case "second":
+				select {
+				case <-ctx.Done():
+					return
+				case <-firstPartialForwarded:
+				}
+				ch <- testAgentPartialEvent(inv.InvocationID, "reviewer", "second partial")
+				ch <- testAgentFinalEvent(inv.InvocationID, "reviewer", "second final")
+			default:
+				ch <- testAgentFinalEvent(inv.InvocationID, "reviewer", input.ID)
+			}
+		}()
+		return ch, nil
+	}
+	workflow, err := NewTool(LocalRunner{}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+	var eventsMu sync.Mutex
+	var streamed []string
+	var invocationIDs []string
+	eventstream.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		content, ok := assistantEventContent(evt)
+		if !ok || content == "" {
+			return nil
+		}
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		streamed = append(streamed, content)
+		invocationIDs = append(invocationIDs, evt.InvocationID)
+		if content == "first partial" {
+			firstPartialOnce.Do(func() { close(firstPartialForwarded) })
+		}
+		if content == "second final" {
+			secondFinalOnce.Do(func() { close(secondFinalForwarded) })
+		}
+		return nil
+	})
+
+	input, err := json.Marshal(map[string]string{"code": `
+results = await parallel([
+    lambda: agent({"id": "first"}),
+    lambda: agent({"id": "second"}),
+])
+return results
+`})
+	require.NoError(t, err)
+	value, err := workflow.Call(agent.NewInvocationContext(ctx, parent), input)
+	require.NoError(t, err)
+	result := value.(Result)
+	var agentResults []agentResult
+	require.NoError(t, json.Unmarshal(result.Value, &agentResults))
+	require.Len(t, agentResults, 2)
+	require.Equal(t, "first final", agentResults[0].Text)
+	require.Equal(t, "second final", agentResults[1].Text)
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	require.Equal(t, []string{
+		"first partial",
+		"second partial",
+		"second final",
+		"first final",
+	}, streamed)
+	require.Len(t, invocationIDs, 4)
+	require.Equal(t, invocationIDs[0], invocationIDs[3])
+	require.Equal(t, invocationIDs[1], invocationIDs[2])
+	require.NotEqual(t, invocationIDs[0], invocationIDs[1])
+}
+
+func TestWorkflowParallelSerializesSharedInstanceID(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	var activeMu sync.Mutex
+	active := 0
+	maxActive := 0
+	reviewer := &testAgent{name: "reviewer"}
+	reviewer.runFn = func(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+		activeMu.Lock()
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		activeMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+		activeMu.Lock()
+		active--
+		activeMu.Unlock()
+		ch := make(chan *event.Event, 1)
+		ch <- event.NewResponseEvent(inv.InvocationID, "reviewer", &model.Response{
+			Done: true,
+			Choices: []model.Choice{{Index: 0, Message: model.Message{
+				Role: model.RoleAssistant, Content: "done",
+			}}},
+		})
+		close(ch)
+		return ch, nil
+	}
+	workflow, err := NewTool(LocalRunner{}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+	input, err := json.Marshal(map[string]string{"code": `
+results = await parallel([
+    lambda: agent("first", {"instance_id": "shared"}),
+    lambda: agent("second", {"instance_id": "shared"}),
+])
+return results
+`})
+	require.NoError(t, err)
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), input)
+	require.NoError(t, err)
+	activeMu.Lock()
+	defer activeMu.Unlock()
+	require.Equal(t, 1, maxActive)
+}
+
+func TestWorkflowCoordinatesExplicitAgentAndTool(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", response: `{"decision":"approved"}`}
+	lookup := &testTool{name: "lookup", call: func(_ context.Context, raw []byte) (any, error) {
+		require.JSONEq(t, `{"id":"42"}`, string(raw))
+		return map[string]any{"title": "Release plan"}, nil
+	}}
+	runtime := scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		lookupRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "tool-1", Kind: CallKindTool, Name: "lookup", Args: json.RawMessage(`{"id":"42"}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent, Name: "reviewer",
+			Args: json.RawMessage(`{"input":{"document":` + string(lookupRaw) + `}}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Value: json.RawMessage(`{"review":` + string(reviewRaw) + `}`)}, nil
+	}}
+	workflow, err := NewTool(runtime, []agent.Agent{reviewer}, WithCodeCallableTools(lookup))
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+		agent.WithInvocationEventFilterKey("app"),
+	)
+	var persisted []*event.Event
+	appender.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		persisted = append(persisted, evt)
+		return nil
+	})
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result, ok := value.(Result)
+	require.True(t, ok)
+	require.JSONEq(t, `{"review":{"text":"{\"decision\":\"approved\"}","structured":{"decision":"approved"},"session_id":"session-1","history_key":"<history-key>","invocation_id":"<invocation-id>"}}`, normalizeWorkflowResult(t, result.Value))
+
+	require.Len(t, persisted, 2, "child user input and child final response are persisted")
+	require.Equal(t, model.RoleUser, persisted[0].Response.Choices[0].Message.Role)
+	require.Equal(t, model.RoleAssistant, persisted[1].Response.Choices[0].Message.Role)
+	require.Equal(t, `{"document":{"title":"Release plan"}}`, reviewer.lastMessage())
+	require.Contains(t, persisted[1].FilterKey, "/dynamic_workflow/")
+	require.Contains(t, persisted[1].FilterKey, "/reviewer")
+}
+
+func TestWorkflowForwardsChildEventsWhenRunnerForwarderIsAttached(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", response: "done"}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent, Name: "reviewer", Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: json.RawMessage(`true`)}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	var persisted, forwarded []*event.Event
+	appender.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		persisted = append(persisted, evt)
+		return nil
+	})
+	eventstream.Attach(parent, func(_ context.Context, evt *event.Event) error {
+		forwarded = append(forwarded, evt)
+		return nil
+	})
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	require.Len(t, persisted, 1, "the child input remains a session-only event")
+	require.Len(t, forwarded, 1, "child output is forwarded through the runner path")
+	require.Equal(t, "reviewer", forwarded[0].Author)
+	require.NotEqual(t, parent.InvocationID, forwarded[0].InvocationID)
+}
+
+func TestWorkflowRunsDynamicAgentSpecWithSurfacePatch(t *testing.T) {
+	lookup := &testTool{name: "lookup", call: func(context.Context, []byte) (any, error) {
+		return map[string]any{"ok": true}, nil
+	}}
+	unused := &testTool{name: "unused", call: func(context.Context, []byte) (any, error) {
+		return nil, nil
+	}}
+	reviewer := &testAgent{
+		name:     "reviewer",
+		response: "approved",
+		tools:    []tool.Tool{lookup, unused},
+		skills: &testSkillRepo{summaries: []skill.Summary{
+			{Name: "risk"},
+			{Name: "style"},
+		}},
+	}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {
+					"template": "reviewer",
+					"instance_id": "strict-review",
+					"instruction": "Be strict.",
+					"tools": ["lookup"],
+					"skills": ["risk"]
+				},
+				"input": "review it"
+			}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Value: reviewRaw}, nil
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+		agent.WithInvocationEventFilterKey("app"),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.JSONEq(t, `{"text":"approved","session_id":"session-1","history_key":"app/dynamic_workflow/<workflow>/strict-review","invocation_id":"<invocation-id>"}`, normalizeSingleAgentResult(t, result.Value))
+
+	child := reviewer.lastInvocation()
+	require.NotNil(t, child)
+	rootNode := agent.InvocationSurfaceRootNodeID(child)
+	require.NotEmpty(t, rootNode)
+	patch, ok := surfacepatch.PatchForNode(child.RunOptions.CustomAgentConfigs, rootNode)
+	require.True(t, ok)
+	instruction, ok := patch.Instruction()
+	require.True(t, ok)
+	require.Equal(t, "Be strict.", instruction)
+	selectedTools, ok := patch.Tools()
+	require.True(t, ok)
+	require.Equal(t, []string{"lookup"}, toolNames(selectedTools))
+	selectedSkills, ok := patch.SkillRepository()
+	require.True(t, ok)
+	require.Equal(t, []string{"risk"}, skillNames(skill.SummariesForContext(context.Background(), selectedSkills)))
+	require.True(t, patch.SuppressSubAgentTransfer())
+}
+
+func TestWorkflowDynamicAgentSpecInheritsTemplateCapabilitiesWhenOmitted(t *testing.T) {
+	lookup := &testTool{name: "lookup"}
+	search := &testTool{name: "search"}
+	reviewer := &testAgent{
+		name: "reviewer",
+		tools: []tool.Tool{
+			lookup,
+			search,
+			&testTool{name: "workspace_exec"},
+		},
+		userToolNames: map[string]bool{"lookup": true, "search": true},
+		skills: &testSkillRepo{summaries: []skill.Summary{
+			{Name: "risk"},
+			{Name: "style"},
+		}},
+	}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer", "instruction": "Review the plan."},
+				"input": "review it"
+			}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Value: reviewRaw}, nil
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+
+	child := reviewer.lastInvocation()
+	require.NotNil(t, child)
+	rootNode := agent.InvocationSurfaceRootNodeID(child)
+	patch, ok := surfacepatch.PatchForNode(child.RunOptions.CustomAgentConfigs, rootNode)
+	require.True(t, ok)
+	selectedTools, ok := patch.Tools()
+	require.True(t, ok)
+	require.Equal(t, []string{"lookup", "search"}, toolNames(selectedTools))
+	_, overridesSkills := patch.SkillRepository()
+	require.False(t, overridesSkills, "omitted skills must inherit the template repository")
+}
+
+func TestWorkflowDynamicAgentSpecSetsStructuredOutput(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", response: `{"approved":true}`}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {
+					"template": "reviewer",
+					"structured_output": {
+						"name": "quote_review",
+						"description": "A strict quote review.",
+						"strict": false,
+						"schema": {
+							"type": "object",
+							"required": ["approved"],
+							"properties": {"approved": {"type": "boolean"}}
+						}
+					}
+				},
+				"input": "review it"
+			}`),
+		})
+		return Result{Value: reviewRaw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	parentRunOptions := parent.RunOptions
+	agent.WithStructuredOutputJSONSchema(
+		"root_output",
+		map[string]any{"type": "object", "properties": map[string]any{"root": map[string]any{"type": "string"}}},
+		true,
+		"must not leak to child",
+	)(&parentRunOptions)
+	parent.RunOptions = parentRunOptions
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+
+	child := reviewer.lastInvocation()
+	require.NotNil(t, child)
+	require.NotNil(t, child.RunOptions.StructuredOutput)
+	require.NotNil(t, child.RunOptions.StructuredOutput.JSONSchema)
+	require.Equal(t, "quote_review", child.RunOptions.StructuredOutput.JSONSchema.Name)
+	require.False(t, child.RunOptions.StructuredOutput.JSONSchema.Strict)
+	require.Equal(t, "A strict quote review.", child.RunOptions.StructuredOutput.JSONSchema.Description)
+	require.Equal(t, map[string]any{
+		"type":       "object",
+		"required":   []any{"approved"},
+		"properties": map[string]any{"approved": map[string]any{"type": "boolean"}},
+	}, child.RunOptions.StructuredOutput.JSONSchema.Schema)
+}
+
+func TestWorkflowDynamicAgentStructuredOutputReachesModelAndResult(t *testing.T) {
+	modelImpl := &structuredOutputCaptureModel{content: `{"approved":true,"reason":"stock confirmed"}`}
+	reviewer := llmagent.New("reviewer", llmagent.WithModel(modelImpl))
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {
+					"template": "reviewer",
+					"structured_output": {
+						"type": "object",
+						"required": ["approved", "reason"],
+						"properties": {
+							"approved": {"type": "boolean"},
+							"reason": {"type": "string"}
+						}
+					}
+				},
+				"input": "review it"
+			}`),
+		})
+		return Result{Value: reviewRaw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.JSONEq(t, `{"text":"{\"approved\":true,\"reason\":\"stock confirmed\"}","structured":{"approved":true,"reason":"stock confirmed"},"session_id":"session-1","history_key":"root/dynamic_workflow/<workflow>/agent-1","invocation_id":"<invocation-id>"}`, normalizeSingleAgentResult(t, result.Value))
+
+	structuredOutput := modelImpl.latestStructuredOutput()
+	require.NotNil(t, structuredOutput)
+	require.NotNil(t, structuredOutput.JSONSchema)
+	require.Equal(t, "reviewer_output", structuredOutput.JSONSchema.Name)
+	require.True(t, structuredOutput.JSONSchema.Strict)
+	require.Equal(t, map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"approved", "reason"},
+		"properties": map[string]any{
+			"approved": map[string]any{"type": "boolean"},
+			"reason":   map[string]any{"type": "string"},
+		},
+	}, structuredOutput.JSONSchema.Schema)
+}
+
+func TestWorkflowChildDoesNotInheritParentStructuredOutput(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", response: "done"}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent, Name: "reviewer",
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: reviewRaw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	parentRunOptions := parent.RunOptions
+	agent.WithStructuredOutputJSONSchema(
+		"root_output",
+		map[string]any{"type": "object"},
+		true,
+		"must not leak to child",
+	)(&parentRunOptions)
+	parent.RunOptions = parentRunOptions
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+
+	child := reviewer.lastInvocation()
+	require.NotNil(t, child)
+	require.Nil(t, child.RunOptions.StructuredOutput)
+	require.Nil(t, child.RunOptions.StructuredOutputType)
+}
+
+func TestWorkflowUsesChildStructuredOutputEvent(t *testing.T) {
+	reviewer := &testAgent{
+		name:             "reviewer",
+		response:         `{"approved":true}`,
+		structuredOutput: map[string]any{"approved": true, "sku": "TRAIL-40"},
+	}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		reviewRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent, Name: "reviewer",
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Value: reviewRaw}, nil
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.JSONEq(t, `{"text":"{\"approved\":true}","structured":{"approved":true,"sku":"TRAIL-40"},"session_id":"session-1","history_key":"root/dynamic_workflow/<workflow>/reviewer","invocation_id":"<invocation-id>"}`, normalizeSingleAgentResult(t, result.Value))
+}
+
+func TestWorkflowRejectsUndeclaredCapabilities(t *testing.T) {
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			Kind: CallKindTool, Name: "not_allowed", Args: json.RawMessage(`{}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{&testAgent{name: "reviewer"}})
+	require.NoError(t, err)
+	parent := agent.NewInvocation(agent.WithInvocationSession(&session.Session{ID: "s", AppName: "a", UserID: "u"}))
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, `tool "not_allowed" is not allowlisted`)
+}
+
+func TestWorkflowRejectsUnknownDynamicAgentTool(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer", tools: []tool.Tool{&testTool{name: "lookup"}}}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer", "tools": ["not_allowed"]},
+				"input": "review it"
+			}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+	parent := agent.NewInvocation(agent.WithInvocationSession(&session.Session{ID: "s", AppName: "a", UserID: "u"}))
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, `agent template "reviewer" does not allow tool(s): not_allowed`)
+}
+
+func TestWorkflowRejectsInvalidDynamicStructuredOutput(t *testing.T) {
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {
+					"template": "reviewer",
+					"structured_output": {"schema": ["not", "an", "object"]}
+				},
+				"input": "review it"
+			}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{&testAgent{name: "reviewer"}})
+	require.NoError(t, err)
+	parent := agent.NewInvocation(agent.WithInvocationSession(&session.Session{ID: "s", AppName: "a", UserID: "u"}))
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, "structured_output schema must be a JSON object")
+}
+
+func TestDecodeAgentSelectorDefaultsStructuredOutput(t *testing.T) {
+	spec, dynamic, err := decodeAgentSelector(json.RawMessage(`{
+		"template": "reviewer",
+		"structured_output": {"schema": {"type": "object"}}
+	}`))
+	require.NoError(t, err)
+	require.True(t, dynamic)
+	require.NotNil(t, spec.StructuredOutput)
+	require.Equal(t, "reviewer_output", spec.StructuredOutput.Name)
+	require.NotNil(t, spec.StructuredOutput.Strict)
+	require.True(t, *spec.StructuredOutput.Strict)
+}
+
+func TestDynamicStructuredOutputCompletesStrictObjectSchemas(t *testing.T) {
+	structuredOutput, err := dynamicStructuredOutput(&StructuredOutputSpec{
+		Name: "review",
+		Schema: json.RawMessage(`{
+			"type":"object",
+			"properties": {
+				"review": {
+					"type":"object",
+					"properties":{"approved":{"type":"boolean"}}
+				}
+			}
+		}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, structuredOutput)
+	require.True(t, structuredOutput.strict)
+	require.Equal(t, false, structuredOutput.schema["additionalProperties"])
+	require.Equal(t, []string{"review"}, structuredOutput.schema["required"])
+	properties := structuredOutput.schema["properties"].(map[string]any)
+	nested := properties["review"].(map[string]any)
+	require.Equal(t, false, nested["additionalProperties"])
+	require.Equal(t, []string{"approved"}, nested["required"])
+}
+
+func TestWorkflowDynamicAgentToolsUseUserToolClassification(t *testing.T) {
+	reviewer := &testAgent{
+		name: "reviewer",
+		tools: []tool.Tool{
+			&testTool{name: "lookup"},
+			&testTool{name: "workspace_exec"},
+		},
+		userToolNames: map[string]bool{"lookup": true},
+	}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer", "tools": ["workspace_exec"]},
+				"input": "review it"
+			}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+	parent := agent.NewInvocation(agent.WithInvocationSession(&session.Session{ID: "s", AppName: "a", UserID: "u"}))
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, `agent template "reviewer" does not allow tool(s): workspace_exec`)
+}
+
+func TestWorkflowToolConfigurationValidation(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer"}
+
+	custom, err := NewTool(
+		scriptedRuntime{},
+		[]agent.Agent{reviewer},
+		WithName("run_custom_workflow"),
+		WithDescription("Custom workflow description."),
+	)
+	require.NoError(t, err)
+	decl := custom.Declaration()
+	require.Equal(t, "run_custom_workflow", decl.Name)
+	require.Contains(t, decl.Description, "Custom workflow description.")
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{reviewer}, WithName(" "))
+	require.ErrorContains(t, err, "tool name is required")
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{nil})
+	require.ErrorContains(t, err, "agent is required")
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{&testAgent{name: " "}})
+	require.ErrorContains(t, err, "agent name is required")
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{
+		&testAgent{name: "reviewer"},
+		&testAgent{name: "reviewer"},
+	})
+	require.ErrorContains(t, err, `duplicate agent "reviewer"`)
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{reviewer}, WithCodeCallableTools(nil))
+	require.ErrorContains(t, err, "tool declaration is required")
+
+	_, err = NewTool(
+		scriptedRuntime{},
+		[]agent.Agent{reviewer},
+		WithCodeCallableTools(&testTool{name: "lookup"}, &testTool{name: "lookup"}),
+	)
+	require.ErrorContains(t, err, `duplicate tool "lookup"`)
+
+	_, err = NewTool(
+		scriptedRuntime{},
+		[]agent.Agent{reviewer},
+		WithCodeCallableTools(&testTool{name: "run_workflow"}),
+	)
+	require.ErrorContains(t, err, `workflow tool "run_workflow" cannot call itself`)
+}
+
+func TestWorkflowCallValidationAndRuntimeError(t *testing.T) {
+	workflow, err := NewTool(
+		scriptedRuntime{run: func(context.Context, CallHandler) (Result, error) {
+			return Result{}, errors.New("runtime failed")
+		}},
+		[]agent.Agent{&testAgent{name: "reviewer"}},
+	)
+	require.NoError(t, err)
+
+	_, err = workflow.Call(context.Background(), []byte(`{`))
+	require.ErrorContains(t, err, "decode input")
+
+	_, err = workflow.Call(context.Background(), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, "requires a running agent invocation")
+
+	parent := agent.NewInvocation(agent.WithInvocationAgent(&testAgent{name: "root"}))
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, "requires a parent session")
+
+	parent = agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "s", AppName: "a", UserID: "u"}),
+	)
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, "runtime failed")
+}
+
+func TestWorkflowGatewayToolValidation(t *testing.T) {
+	gateway := &workflowGateway{tools: map[string]tool.CallableTool{
+		"lookup": &testTool{name: "lookup", call: func(context.Context, []byte) (any, error) {
+			return map[string]any{"ok": true}, nil
+		}},
+		"failing": &testTool{name: "failing", call: func(context.Context, []byte) (any, error) {
+			return nil, errors.New("boom")
+		}},
+		"unencodable": &testTool{name: "unencodable", call: func(context.Context, []byte) (any, error) {
+			return func() {}, nil
+		}},
+	}}
+
+	_, err := gateway.HandleWorkflowCall(context.Background(), Call{Kind: "unknown"})
+	require.ErrorContains(t, err, `unsupported call kind "unknown"`)
+
+	_, err = (*workflowGateway)(nil).HandleWorkflowCall(context.Background(), Call{})
+	require.ErrorContains(t, err, "nil gateway")
+
+	_, err = gateway.callTool(context.Background(), Call{Kind: CallKindTool, Name: "missing", Args: json.RawMessage(`{}`)})
+	require.ErrorContains(t, err, `tool "missing" is not allowlisted`)
+
+	_, err = gateway.callTool(context.Background(), Call{Kind: CallKindTool, Name: "lookup", Args: json.RawMessage(`{`)})
+	require.ErrorContains(t, err, "invalid JSON arguments")
+
+	_, err = gateway.callTool(context.Background(), Call{Kind: CallKindTool, Name: "lookup", Args: json.RawMessage(`[]`)})
+	require.ErrorContains(t, err, "requires a JSON object argument")
+
+	_, err = gateway.callTool(context.Background(), Call{Kind: CallKindTool, Name: "failing", Args: json.RawMessage(`{}`)})
+	require.ErrorContains(t, err, `call tool "failing"`)
+
+	_, err = gateway.callTool(context.Background(), Call{Kind: CallKindTool, Name: "unencodable", Args: json.RawMessage(`{}`)})
+	require.ErrorContains(t, err, `encode result from tool "unencodable"`)
+}
+
+func TestWorkflowGatewayAgentErrorBranches(t *testing.T) {
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	gateway := &workflowGateway{
+		parent:     parent,
+		agents:     map[string]agentTemplate{},
+		workflow:   "workflow-1",
+		toolName:   "run_workflow",
+		agentSlots: make(chan struct{}, 1),
+	}
+	_, err := gateway.callAgent(context.Background(), Call{
+		ID: "agent-1", Kind: CallKindAgent, Name: "missing", Args: json.RawMessage(`{"input":"hello"}`),
+	})
+	require.ErrorContains(t, err, `agent "missing" is not registered`)
+
+	gateway.agents["reviewer"] = agentTemplate{name: "reviewer", agent: &testAgent{
+		name: "reviewer",
+		runFn: func(context.Context, *agent.Invocation) (<-chan *event.Event, error) {
+			return nil, errors.New("agent start failed")
+		},
+	}}
+	_, err = gateway.callAgent(context.Background(), Call{
+		ID: "agent-1", Kind: CallKindAgent, Name: "reviewer", Args: json.RawMessage(`{"input":"hello"}`),
+	})
+	require.ErrorContains(t, err, `run agent "reviewer"`)
+
+	gateway.agents["erroring"] = agentTemplate{name: "erroring", agent: &testAgent{
+		name: "erroring",
+		runFn: func(_ context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+			ch := make(chan *event.Event, 1)
+			ch <- event.NewResponseEvent(inv.InvocationID, "erroring", &model.Response{
+				Error: &model.ResponseError{Message: "model failed"},
+			})
+			close(ch)
+			return ch, nil
+		},
+	}}
+	_, err = gateway.callAgent(context.Background(), Call{
+		ID: "agent-2", Kind: CallKindAgent, Name: "erroring", Args: json.RawMessage(`{"input":"hello"}`),
+	})
+	require.ErrorContains(t, err, `collect agent "erroring"`)
+}
+
+func TestWorkflowGatewayHelperBranches(t *testing.T) {
+	require.NoError(t, (*workflowGateway)(nil).acquireAgentSlot(context.Background()))
+	(*workflowGateway)(nil).releaseAgentSlot()
+	(*workflowGateway)(nil).lockChildInstance("")()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	gateway := &workflowGateway{agentSlots: make(chan struct{})}
+	require.ErrorIs(t, gateway.acquireAgentSlot(ctx), context.Canceled)
+
+	parent := agent.NewInvocation(agent.WithInvocationSession(
+		&session.Session{ID: "snapshot", AppName: "app", UserID: "user"},
+	))
+	require.Same(t, parent, parentWithLiveSession(parent))
+	live := &session.Session{ID: "live", AppName: "app", UserID: "user"}
+	livesession.Attach(parent, live)
+	require.Equal(t, "live", parentWithLiveSession(parent).Session.ID)
+	require.Nil(t, parentWithLiveSession(nil))
+
+	require.ErrorContains(t, gateway.appendChildUserMessage(context.Background(), nil), "child invocation is nil")
+	require.NoError(t, appendSessionEvent(context.Background(), nil, nil))
+	require.NoError(t, (*workflowGateway)(nil).appendSessionEvent(context.Background(), nil, nil))
+	require.NoError(t, gateway.appendSessionEvent(context.Background(), nil, nil))
+	require.NoError(t, appendSessionEvent(context.Background(), agent.NewInvocation(), event.New("inv", "author")))
+	require.NoError(t, errorsFromResponse(nil))
+	require.Equal(t, "", declarationName(nil))
+	require.Equal(t, "null", marshalOrNull(func() {}))
+
+	lookup := &testTool{name: "lookup"}
+	require.Nil(t, copyToolMap(nil))
+	copied := copyToolMap(map[string]tool.Tool{"lookup": lookup})
+	require.Equal(t, lookup, copied["lookup"])
+	copied["lookup"] = &testTool{name: "other"}
+	require.Equal(t, lookup, copyToolMap(map[string]tool.Tool{"lookup": lookup})["lookup"])
+
+	service := sessioninmemory.NewSessionService()
+	sess, err := service.CreateSession(context.Background(), session.Key{
+		AppName: "app", UserID: "user", SessionID: "session",
+	}, session.StateMap{})
+	require.NoError(t, err)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+	)
+	require.NoError(t, appendSessionEvent(context.Background(), inv, event.New(inv.InvocationID, "author")))
+}
+
+func TestWorkflowCollectChildResultErrorBranches(t *testing.T) {
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	ch := make(chan *event.Event, 1)
+	ch <- event.New(inv.InvocationID, "reviewer", event.WithStructuredOutputPayload(func() {}))
+	close(ch)
+	_, err := (&workflowGateway{}).collectChildResult(context.Background(), inv, ch)
+	require.ErrorContains(t, err, "encode structured output")
+
+	ch = make(chan *event.Event, 1)
+	evt := event.NewResponseEvent(inv.InvocationID, "reviewer", &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Index: 0, Message: model.Message{
+			Role: model.RoleAssistant, Content: "done",
+		}}},
+	})
+	ch <- evt
+	close(ch)
+	eventstream.Attach(inv, func(context.Context, *event.Event) error {
+		return errors.New("forward failed")
+	})
+	_, err = (&workflowGateway{}).collectChildResult(context.Background(), inv, ch)
+	require.ErrorContains(t, err, "forward failed")
+}
+
+func TestAgentSpecParsingAndSelectionBranches(t *testing.T) {
+	_, err := parseAgentCall(Call{Args: json.RawMessage(`{`)})
+	require.ErrorContains(t, err, "decode input for agent call")
+
+	_, err = parseAgentCall(Call{Args: json.RawMessage(`{"agent":"reviewer"}`)})
+	require.ErrorContains(t, err, "agent call requires JSON input")
+
+	req, err := parseAgentCall(Call{
+		ID: "call/1", Args: json.RawMessage(`{"agent":{"template":"reviewer","instance_id":"team/a"},"input":{"task":"x"}}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "reviewer", req.templateName)
+	require.Equal(t, "team_a", req.instanceID)
+
+	_, _, err = decodeAgentSelector(json.RawMessage(`""`))
+	require.ErrorContains(t, err, "agent name is required")
+
+	_, err = decodeAgentOptions(json.RawMessage(`[]`))
+	require.ErrorContains(t, err, "agent options must be a mapping or template name")
+
+	optSpec, err := decodeAgentOptions(json.RawMessage(`" reviewer "`))
+	require.NoError(t, err)
+	require.Equal(t, "reviewer", optSpec.Template)
+
+	optSpec, err = decodeAgentOptions(json.RawMessage(`{
+		"template": "reviewer",
+		"schema": {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+	}`))
+	require.NoError(t, err)
+	require.NotNil(t, optSpec.StructuredOutput)
+	require.NoError(t, normalizeAgentSpec(&optSpec))
+	require.Equal(t, "reviewer_output", optSpec.StructuredOutput.Name)
+
+	optSpec, err = decodeAgentOptions(json.RawMessage(`{
+		"template": "reviewer",
+		"schema": {"type": "object"},
+		"structured_output": {"schema": {"type": "object"}, "name": "explicit"}
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, "explicit", optSpec.StructuredOutput.Name)
+
+	_, err = canonicalStructuredOutput(json.RawMessage(`[]`))
+	require.ErrorContains(t, err, "structured_output must be a JSON object")
+
+	wrapped, err := canonicalStructuredOutput(json.RawMessage(`{"schema":{"type":"object"}}`))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"schema":{"type":"object"}}`, string(wrapped))
+
+	spec := AgentSpec{Template: " reviewer ", Tools: []string{" lookup ", "", "lookup"}, Skills: []string{}}
+	require.NoError(t, normalizeAgentSpec(&spec))
+	require.Equal(t, "reviewer", spec.Template)
+	require.Equal(t, []string{"lookup"}, spec.Tools)
+	require.Empty(t, spec.Skills)
+
+	gateway := &workflowGateway{parent: parentForAgentSpecTest(), toolName: "run_workflow"}
+	tmpl := agentTemplate{
+		name:  "reviewer",
+		agent: &testAgent{name: "reviewer", tools: []tool.Tool{&testTool{name: "lookup"}}},
+		tools: map[string]tool.Tool{"lookup": &testTool{name: "lookup"}},
+	}
+	selectedTools, err := gateway.selectAgentTools(context.Background(), tmpl, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"lookup"}, toolNames(selectedTools))
+
+	emptyRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, []string{})
+	require.NoError(t, err)
+	require.Nil(t, emptyRepo)
+
+	_, err = gateway.selectAgentSkills(context.Background(), tmpl, []string{"risk"})
+	require.ErrorContains(t, err, `agent template "reviewer" does not expose skills`)
+
+	repo := &testSkillRepo{summaries: []skill.Summary{{Name: "risk"}, {Name: "style"}}}
+	tmpl.agent = &testAgent{name: "reviewer", skills: repo}
+	inheritedRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, nil)
+	require.NoError(t, err)
+	require.Same(t, repo, inheritedRepo)
+	filteredRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, []string{"risk"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"risk"}, skillNames(skill.SummariesForContext(context.Background(), filteredRepo)))
+	_, err = gateway.selectAgentSkills(context.Background(), tmpl, []string{"missing"})
+	require.ErrorContains(t, err, `does not allow skill(s): missing`)
+
+	nilRepoAgent := &testAgent{name: "reviewer"}
+	tmpl.agent = nilRepoAgent
+	selectedRepo, err := gateway.selectAgentSkills(context.Background(), tmpl, nil)
+	require.NoError(t, err)
+	require.Nil(t, selectedRepo)
+	_, err = gateway.selectAgentSkills(context.Background(), tmpl, []string{"risk"})
+	require.ErrorContains(t, err, `does not expose skills`)
+}
+
+func TestStrictSchemaNormalizationBranches(t *testing.T) {
+	output, err := dynamicStructuredOutput(&StructuredOutputSpec{
+		Name:   "union",
+		Strict: ptrBool(true),
+		Schema: json.RawMessage(`{
+			"type":["object","null"],
+			"properties":{"item":{"anyOf":[{"type":"object","properties":{"id":{"type":"string"}}}]}},
+			"$defs":{"nested":{"type":"object","properties":{"ok":{"type":"boolean"}}}},
+			"items":{"type":"object","properties":{"value":{"type":"number"}}}
+		}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, false, output.schema["additionalProperties"])
+	require.Equal(t, []string{"item"}, output.schema["required"])
+	defs := output.schema["$defs"].(map[string]any)
+	require.Equal(t, false, defs["nested"].(map[string]any)["additionalProperties"])
+	items := output.schema["items"].(map[string]any)
+	require.Equal(t, false, items["additionalProperties"])
+
+	_, err = dynamicStructuredOutput(&StructuredOutputSpec{Name: "bad", Schema: json.RawMessage(`[]`)})
+	require.ErrorContains(t, err, "structured_output schema must be a JSON object")
+
+	err = normalizeStructuredOutputSpec("reviewer", &StructuredOutputSpec{
+		Schema: json.RawMessage(`{`),
+	})
+	require.ErrorContains(t, err, "must be valid JSON")
+	err = normalizeStructuredOutputSpec("reviewer", &StructuredOutputSpec{
+		Schema: json.RawMessage(`{"type":"object"}` + strings.Repeat(" ", maxStructuredOutputSchemaBytes)),
+	})
+	require.ErrorContains(t, err, "exceeds")
+}
+
+type scriptedRuntime struct {
+	run func(context.Context, CallHandler) (Result, error)
+}
+
+func (r scriptedRuntime) ExecuteWorkflow(ctx context.Context, _ Request, handler CallHandler) (Result, error) {
+	if r.run == nil {
+		return Result{Value: json.RawMessage(`null`)}, nil
+	}
+	return r.run(ctx, handler)
+}
+
+type testAgent struct {
+	name             string
+	response         string
+	tools            []tool.Tool
+	userToolNames    map[string]bool
+	skills           skill.Repository
+	structuredOutput any
+	runFn            func(context.Context, *agent.Invocation) (<-chan *event.Event, error)
+	mu               sync.Mutex
+	messages         []string
+	invs             []*agent.Invocation
+}
+
+func (a *testAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
+	a.mu.Lock()
+	a.messages = append(a.messages, inv.Message.Content)
+	a.invs = append(a.invs, inv)
+	runFn := a.runFn
+	a.mu.Unlock()
+	if runFn != nil {
+		return runFn(ctx, inv)
+	}
+	ch := make(chan *event.Event, 2)
+	ch <- event.NewResponseEvent(inv.InvocationID, a.name, &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Index: 0, Message: model.Message{
+			Role: model.RoleAssistant, Content: a.response,
+		}}},
+	})
+	if a.structuredOutput != nil {
+		ch <- event.New(
+			inv.InvocationID,
+			a.name,
+			event.WithStructuredOutputPayload(a.structuredOutput),
+		)
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (a *testAgent) Tools() []tool.Tool { return a.tools }
+func (a *testAgent) InvocationToolSurface(
+	context.Context,
+	*agent.Invocation,
+) ([]tool.Tool, map[string]bool) {
+	return a.tools, a.userToolNames
+}
+func (a *testAgent) Info() agent.Info {
+	return agent.Info{Name: a.name, Description: a.name + " agent"}
+}
+func (a *testAgent) SubAgents() []agent.Agent        { return nil }
+func (a *testAgent) FindSubAgent(string) agent.Agent { return nil }
+func (a *testAgent) InvocationSkillRepository(
+	context.Context,
+	*agent.Invocation,
+) skill.Repository {
+	return a.skills
+}
+func (a *testAgent) lastMessage() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.messages) == 0 {
+		return ""
+	}
+	return a.messages[len(a.messages)-1]
+}
+func (a *testAgent) lastInvocation() *agent.Invocation {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.invs) == 0 {
+		return nil
+	}
+	return a.invs[len(a.invs)-1]
+}
+
+func testAgentPartialEvent(invocationID, author, content string) *event.Event {
+	return event.NewResponseEvent(invocationID, author, &model.Response{
+		IsPartial: true,
+		Choices: []model.Choice{{Index: 0, Delta: model.Message{
+			Role: model.RoleAssistant, Content: content,
+		}}},
+	})
+}
+
+func testAgentFinalEvent(invocationID, author, content string) *event.Event {
+	return event.NewResponseEvent(invocationID, author, &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Index: 0, Message: model.Message{
+			Role: model.RoleAssistant, Content: content,
+		}}},
+	})
+}
+
+type structuredOutputCaptureModel struct {
+	content string
+
+	mu               sync.Mutex
+	structuredOutput *model.StructuredOutput
+}
+
+func (m *structuredOutputCaptureModel) GenerateContent(
+	_ context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	m.mu.Lock()
+	m.structuredOutput = cloneStructuredOutput(request)
+	m.mu.Unlock()
+
+	responses := make(chan *model.Response, 1)
+	responses <- &model.Response{
+		ID:   "structured-output-capture",
+		Done: true,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: model.NewAssistantMessage(m.content),
+		}},
+	}
+	close(responses)
+	return responses, nil
+}
+
+func (m *structuredOutputCaptureModel) Info() model.Info {
+	return model.Info{Name: "structured-output-capture"}
+}
+
+func (m *structuredOutputCaptureModel) latestStructuredOutput() *model.StructuredOutput {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return cloneStructuredOutput(&model.Request{StructuredOutput: m.structuredOutput})
+}
+
+func cloneStructuredOutput(request *model.Request) *model.StructuredOutput {
+	if request == nil || request.StructuredOutput == nil {
+		return nil
+	}
+	cloned := *request.StructuredOutput
+	if request.StructuredOutput.JSONSchema != nil {
+		jsonSchema := *request.StructuredOutput.JSONSchema
+		cloned.JSONSchema = &jsonSchema
+	}
+	return &cloned
+}
+
+type testTool struct {
+	name string
+	call func(context.Context, []byte) (any, error)
+}
+
+func (t *testTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name, Description: t.name + " tool"}
+}
+
+func (t *testTool) Call(ctx context.Context, raw []byte) (any, error) {
+	if t.call == nil {
+		return nil, fmt.Errorf("missing test tool callback")
+	}
+	return t.call(ctx, raw)
+}
+
+func normalizeWorkflowResult(t *testing.T, raw []byte) string {
+	t.Helper()
+	var value map[string]any
+	require.NoError(t, json.Unmarshal(raw, &value))
+	review := value["review"].(map[string]any)
+	review["history_key"] = "<history-key>"
+	review["invocation_id"] = "<invocation-id>"
+	normalized, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(normalized)
+}
+
+func normalizeSingleAgentResult(t *testing.T, raw []byte) string {
+	t.Helper()
+	var value map[string]any
+	require.NoError(t, json.Unmarshal(raw, &value))
+	value["history_key"] = normalizeWorkflowHistoryKey(value["history_key"].(string))
+	value["invocation_id"] = "<invocation-id>"
+	normalized, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(normalized)
+}
+
+func normalizeWorkflowHistoryKey(value string) string {
+	parts := strings.Split(value, "/")
+	for i, part := range parts {
+		if part == "dynamic_workflow" && i+1 < len(parts) {
+			parts[i+1] = "<workflow>"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func toolNames(tools []tool.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		names = append(names, declarationName(t))
+	}
+	return names
+}
+
+func skillNames(summaries []skill.Summary) []string {
+	names := make([]string, 0, len(summaries))
+	for _, s := range summaries {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func parentForAgentSpecTest() *agent.Invocation {
+	return agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "s", AppName: "a", UserID: "u"}),
+	)
+}
+
+func ptrBool(v bool) *bool { return &v }
+
+type testSkillRepo struct {
+	summaries []skill.Summary
+}
+
+func (r *testSkillRepo) Summaries() []skill.Summary {
+	return append([]skill.Summary(nil), r.summaries...)
+}
+
+func (r *testSkillRepo) Get(name string) (*skill.Skill, error) {
+	for _, summary := range r.summaries {
+		if summary.Name == name {
+			return &skill.Skill{Summary: summary}, nil
+		}
+	}
+	return nil, fmt.Errorf("skill %q not found", name)
+}
+
+func (r *testSkillRepo) Path(name string) (string, error) {
+	for _, summary := range r.summaries {
+		if summary.Name == name {
+			return "/tmp/" + name, nil
+		}
+	}
+	return "", fmt.Errorf("skill %q not found", name)
+}

--- a/tool/dynamicworkflow/types.go
+++ b/tool/dynamicworkflow/types.go
@@ -1,0 +1,116 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package dynamicworkflow exposes one-shot, code-defined orchestration of
+// explicitly registered sub-agents and host tools.
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// CallKind identifies the host capability requested by workflow code.
+type CallKind string
+
+const (
+	// CallKindTool invokes one explicitly allowlisted host tool.
+	CallKindTool CallKind = "tool"
+	// CallKindAgent invokes one explicitly registered sub-agent.
+	CallKindAgent CallKind = "agent"
+)
+
+// Request describes one workflow-code execution.
+type Request struct {
+	Code string `json:"code"`
+}
+
+// Result is the JSON-safe final value and captured stdout emitted by workflow
+// code.
+type Result struct {
+	Value  json.RawMessage `json:"value,omitempty"`
+	Stdout string          `json:"stdout,omitempty"`
+}
+
+// AgentSpec describes one workflow-created agent instance. The workflow code
+// sends this as JSON; Go resolves it against a registered template agent and
+// applies only the supported, policy-checked fields.
+//
+// Template names the registered agent template. InstanceID optionally gives
+// repeated calls within the same workflow a shared workflow-local history key.
+// Instruction overrides the child instruction for this run. When Tools or
+// Skills is omitted (or null in workflow JSON), the instance inherits the
+// template's eligible user tools or configured skills. An explicit empty list
+// disables that capability type; a non-empty list narrows it. Neither field
+// can add capabilities. StructuredOutput overrides the template's structured
+// output configuration for this workflow-local instance only.
+type AgentSpec struct {
+	Template         string                `json:"template"`
+	InstanceID       string                `json:"instance_id,omitempty"`
+	Instruction      string                `json:"instruction,omitempty"`
+	Tools            []string              `json:"tools,omitempty"`
+	Skills           []string              `json:"skills,omitempty"`
+	StructuredOutput *StructuredOutputSpec `json:"structured_output,omitempty"`
+}
+
+// StructuredOutputSpec requests model-native JSON Schema output for one
+// workflow-created AgentSpec instance. Schema must be a JSON object. If Strict
+// is omitted, it defaults to true so workflow code can safely consume the
+// returned result.Structured value.
+//
+// This is intentionally declarative data rather than a way for workflow code
+// to construct an arbitrary Go agent. The registered template still owns the
+// model, executor, callbacks, and all host capabilities.
+type StructuredOutputSpec struct {
+	Name        string          `json:"name,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+	Strict      *bool           `json:"strict,omitempty"`
+	Description string          `json:"description,omitempty"`
+}
+
+// Call is one sandbox-to-host capability invocation.
+type Call struct {
+	ID   string
+	Kind CallKind
+	Name string
+	Args json.RawMessage
+}
+
+// CallHandler is the host capability boundary. Runtimes must route every
+// sandbox-originated call through this handler rather than accessing host
+// services directly.
+type CallHandler interface {
+	HandleWorkflowCall(context.Context, Call) (json.RawMessage, error)
+}
+
+// Runtime executes workflow code and routes its host capability calls through
+// the provided handler. Applications can implement this interface with local
+// stdio, a remote sandbox, a microVM, or platform-native callbacks.
+type Runtime interface {
+	ExecuteWorkflow(context.Context, Request, CallHandler) (Result, error)
+}
+
+// Execute validates and runs one workflow program.
+func Execute(ctx context.Context, runtime Runtime, handler CallHandler, code string) (Result, error) {
+	if runtime == nil {
+		return Result{}, required("runtime")
+	}
+	if handler == nil {
+		return Result{}, required("call handler")
+	}
+	if strings.TrimSpace(code) == "" {
+		return Result{}, required("code")
+	}
+	return runtime.ExecuteWorkflow(ctx, Request{Code: code}, handler)
+}
+
+func required(name string) error {
+	return fmt.Errorf("dynamicworkflow: %s is required", name)
+}


### PR DESCRIPTION
## Summary

Add a dynamic workflow tool that lets an LLMAgent generate short-lived workflow code to orchestrate temporary child agents, parallel/pipeline execution, and optional code-callable tools.

## Changes

- Add dynamicworkflow runtime, bridge protocol, agent templates/specs, and tests.
- Forward child-agent and tool events through the normal Runner event stream.
- Add an interactive example and English/Chinese docs.

## Test

- go test ./tool/dynamicworkflow ./runner
- cd examples && go test ./dynamicworkflow