### PR TITLE
session/summary: add trigger reports

### DIFF
--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -429,7 +429,9 @@ Advanced integrations can attach a report before entering a higher-level
 summary flow with `summary.ContextWithReport(ctx, report)` and retrieve it with
 `summary.ReportFromContext(ctx)`. The framework reuses that report for a single
 summary path; when a cascade generates multiple summaries in parallel, each
-worker receives a cloned report so branch-specific writes do not race.
+worker receives a cloned report so branch-specific writes do not race. Those
+forked reports are emitted through their per-call hooks and are not merged back
+into the root report.
 
 For private deployments, endpoint IDs, fine-tuned models, newly released
 models, or multi-tenant custom model configuration, prefer the instance or

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -423,7 +423,9 @@ The report keeps two token counts separate:
 
 For cache-safe forking, `report.Call.Mode` is `cache_safe_fork` and the request
 estimate is computed from the forked parent request plus the appended summary
-instruction. For standalone summary prompts, the mode is `standalone`.
+instruction. For standalone summary prompts, the mode is `standalone`. If a
+`BeforeModel` callback returns a custom response and no summary model request is
+sent, the mode is `custom_response` and the prompt estimate remains zero.
 
 Advanced integrations can attach a report before entering a higher-level
 summary flow with `summary.ContextWithReport(ctx, report)` and retrieve it with

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -394,6 +394,37 @@ expect summarization around 1000 tokens, pass
 `summary.WithContextThresholdMinTokens(0)` explicitly, or set it to the
 application-specific minimum you want.
 
+### Trigger and Call Reporting
+
+Use `summary.WithReportHook` when you need to observe why summary generation
+was triggered and how large the summary model request was:
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithContextThreshold(),
+    summary.WithReportHook(func(ctx context.Context, report summary.Report) {
+        triggerTokens := report.Trigger.Value
+        summaryPromptTokens := report.Call.PromptTokens
+        _ = triggerTokens
+        _ = summaryPromptTokens
+    }),
+)
+```
+
+The report keeps two token counts separate:
+
+- `report.Trigger.Value`: the checker value that triggered summarization, such
+  as estimated delta tokens after the previous summary
+- `report.Call.EstimatedPromptTokens`: the framework's local estimate for the
+  complete summary model request
+- `report.Call.PromptTokens`: the provider-reported `usage.prompt_tokens` for
+  the summary model call
+
+For cache-safe forking, `report.Call.Mode` is `cache_safe_fork` and the request
+estimate is computed from the forked parent request plus the appended summary
+instruction. For standalone summary prompts, the mode is `standalone`.
+
 For private deployments, endpoint IDs, fine-tuned models, newly released
 models, or multi-tenant custom model configuration, prefer the instance or
 per-run option so different users do not overwrite a process-wide registry

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -425,6 +425,12 @@ For cache-safe forking, `report.Call.Mode` is `cache_safe_fork` and the request
 estimate is computed from the forked parent request plus the appended summary
 instruction. For standalone summary prompts, the mode is `standalone`.
 
+Advanced integrations can attach a report before entering a higher-level
+summary flow with `summary.ContextWithReport(ctx, report)` and retrieve it with
+`summary.ReportFromContext(ctx)`. The framework reuses that report for a single
+summary path; when a cascade generates multiple summaries in parallel, each
+worker receives a cloned report so branch-specific writes do not race.
+
 For private deployments, endpoint IDs, fine-tuned models, newly released
 models, or multi-tenant custom model configuration, prefer the instance or
 per-run option so different users do not overwrite a process-wide registry

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -412,6 +412,7 @@ summarizer := summary.NewSummarizer(
 `summary.ContextWithReport(ctx, report)`，需要从 context 取出时使用
 `summary.ReportFromContext(ctx)`。单一路径会复用这个 report；cascade 并行生成多个
 summary 时，框架会给每个 worker 克隆一份 report，避免不同分支同时写同一个对象。
+这些 fork 出来的 report 会通过各自调用的 hook 发出，不会再合并回 root report。
 
 对于私有部署、endpoint ID、微调模型、新模型或多租户自定义模型配置，优先使用模型实例或单次运行 option，
 避免不同用户覆盖同一个进程级注册表：

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -407,6 +407,8 @@ summarizer := summary.NewSummarizer(
 
 开启 cache-safe forking 时，`report.Call.Mode` 为 `cache_safe_fork`，请求估算值来自 fork
 后的父请求加上追加的 summary 指令。普通独立 summary prompt 模式下，mode 为 `standalone`。
+如果 `BeforeModel` callback 返回 custom response，实际没有发送 summary 模型请求，mode 为
+`custom_response`，prompt 估算值保持为 0。
 
 高级集成如果要在高层 summary 流程前放入同一个 report，可以使用
 `summary.ContextWithReport(ctx, report)`，需要从 context 取出时使用

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -408,6 +408,11 @@ summarizer := summary.NewSummarizer(
 开启 cache-safe forking 时，`report.Call.Mode` 为 `cache_safe_fork`，请求估算值来自 fork
 后的父请求加上追加的 summary 指令。普通独立 summary prompt 模式下，mode 为 `standalone`。
 
+高级集成如果要在高层 summary 流程前放入同一个 report，可以使用
+`summary.ContextWithReport(ctx, report)`，需要从 context 取出时使用
+`summary.ReportFromContext(ctx)`。单一路径会复用这个 report；cascade 并行生成多个
+summary 时，框架会给每个 worker 克隆一份 report，避免不同分支同时写同一个对象。
+
 对于私有部署、endpoint ID、微调模型、新模型或多租户自定义模型配置，优先使用模型实例或单次运行 option，
 避免不同用户覆盖同一个进程级注册表：
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -381,6 +381,33 @@ checker 只有在估算 token 数**大于**阈值时才触发。如果把 ratio 
 例如 `0.001`，但希望 1000 token 左右就开始摘要，需要显式传入
 `summary.WithContextThresholdMinTokens(0)`，或设置成业务希望的最小值。
 
+### 触发和调用上报
+
+如果需要观察“为什么触发 summary”以及“summary 模型请求实际用了多少 token”，
+可以配置 `summary.WithReportHook`：
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithContextThreshold(),
+    summary.WithReportHook(func(ctx context.Context, report summary.Report) {
+        triggerTokens := report.Trigger.Value
+        summaryPromptTokens := report.Call.PromptTokens
+        _ = triggerTokens
+        _ = summaryPromptTokens
+    }),
+)
+```
+
+`Report` 会把两个 token 口径拆开：
+
+- `report.Trigger.Value`：触发 checker 使用的值，例如上次 summary 之后增量事件的估算 token 数
+- `report.Call.EstimatedPromptTokens`：框架在发起 summary 模型请求前，对完整请求做的本地估算
+- `report.Call.PromptTokens`：summary 模型返回的官方 `usage.prompt_tokens`
+
+开启 cache-safe forking 时，`report.Call.Mode` 为 `cache_safe_fork`，请求估算值来自 fork
+后的父请求加上追加的 summary 指令。普通独立 summary prompt 模式下，mode 为 `standalone`。
+
 对于私有部署、endpoint ID、微调模型、新模型或多租户自定义模型配置，优先使用模型实例或单次运行 option，
 避免不同用户覆盖同一个进程级注册表：
 

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -320,8 +320,12 @@ func buildSummaryInput(
 	}
 	input := prependPrevSummary(prev.text, delta, time.Now())
 	tmp := buildFilterSession(base, filterKey, input)
-	report := &summary.Report{}
-	reportCtx := summary.ContextWithReport(ctx, report)
+	report, ok := summary.ReportFromContext(ctx)
+	reportCtx := ctx
+	if !ok {
+		report = &summary.Report{}
+		reportCtx = summary.ContextWithReport(ctx, report)
+	}
 	if !shouldGenerateSummary(reportCtx, m, base, tmp, input, filterKey, force, report) {
 		return summaryInput{}, false
 	}
@@ -583,6 +587,15 @@ func PickSummaryText(
 	return "", false
 }
 
+func contextWithForkedReport(ctx context.Context) context.Context {
+	report, ok := summary.ReportFromContext(ctx)
+	if !ok {
+		return ctx
+	}
+	cloned := report.Clone()
+	return summary.ContextWithReport(ctx, &cloned)
+}
+
 // GetSummaryTextFromSession attempts to retrieve summary text from the session's
 // in-memory summaries using the specified filter key. It parses the provided options
 // and applies the summary selection logic. Filters out summaries with UpdatedAt before sess.CreatedAt.
@@ -721,9 +734,9 @@ func CreateSessionSummaryWithCascade(
 	result := make([]error, len(targets))
 	summaryWg.Add(len(targets))
 	for i, fk := range targets {
-		go func(i int, fk string) {
+		callCtx := contextWithForkedReport(ctx)
+		go func(i int, fk string, callCtx context.Context) {
 			defer summaryWg.Done()
-			callCtx := ctx
 			if fk == session.SummaryFilterKeyAllContents &&
 				filterKey != session.SummaryFilterKeyAllContents {
 				callCtx = contextWithSummaryTriggerFilterKey(callCtx, filterKey)
@@ -732,7 +745,7 @@ func CreateSessionSummaryWithCascade(
 			if err != nil {
 				result[i] = fmt.Errorf("create session summary for filterKey %q failed: %w", fk, err)
 			}
-		}(i, fk)
+		}(i, fk, callCtx)
 	}
 	summaryWg.Wait()
 

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -354,7 +354,7 @@ func shouldGenerateSummary(
 				Fired:     true,
 				Name:      "force",
 				Metric:    "custom",
-				FilterKey: filterKey,
+				FilterKey: reportFilterKey(ctx, filterKey),
 			}
 		}
 		return true
@@ -366,6 +366,16 @@ func shouldGenerateSummary(
 		}
 	}
 	return ShouldSummarize(ctx, m, checkTmp)
+}
+
+func reportFilterKey(ctx context.Context, filterKey string) string {
+	if filterKey != session.SummaryFilterKeyAllContents {
+		return filterKey
+	}
+	if triggerFilterKey := summaryTriggerFilterKeyFromContext(ctx); triggerFilterKey != "" {
+		return triggerFilterKey
+	}
+	return filterKey
 }
 
 // writeSummary stores the generated summary under filterKey.

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -592,6 +592,9 @@ func contextWithForkedReport(ctx context.Context) context.Context {
 	if !ok {
 		return ctx
 	}
+	// Parallel cascade paths keep per-target report writes isolated. The cloned
+	// report is emitted through that target's hook and is not merged back to the
+	// caller-attached root report.
 	cloned := report.Clone()
 	return summary.ContextWithReport(ctx, &cloned)
 }

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -201,7 +201,7 @@ func SummarizeSession(
 	if !ok {
 		return false, nil
 	}
-	text, err := m.Summarize(ctx, input.session)
+	text, err := m.Summarize(input.ctx, input.session)
 	if err != nil {
 		return false, fmt.Errorf("summarize session %s failed: %w", base.ID, err)
 	}
@@ -235,6 +235,7 @@ type previousSummary struct {
 
 type summaryInput struct {
 	session        *session.Session
+	ctx            context.Context
 	latestBoundary *session.SummaryBoundary
 	hasDelta       bool
 }
@@ -319,11 +320,14 @@ func buildSummaryInput(
 	}
 	input := prependPrevSummary(prev.text, delta, time.Now())
 	tmp := buildFilterSession(base, filterKey, input)
-	if !shouldGenerateSummary(ctx, m, base, tmp, input, filterKey, force) {
+	report := &summary.Report{}
+	reportCtx := summary.ContextWithReport(ctx, report)
+	if !shouldGenerateSummary(reportCtx, m, base, tmp, input, filterKey, force, report) {
 		return summaryInput{}, false
 	}
 	return summaryInput{
 		session:        tmp,
+		ctx:            reportCtx,
 		latestBoundary: latestBoundary,
 		hasDelta:       len(delta) > 0,
 	}, true
@@ -338,8 +342,16 @@ func shouldGenerateSummary(
 	input []event.Event,
 	filterKey string,
 	force bool,
+	report *summary.Report,
 ) bool {
 	if force {
+		if report != nil {
+			report.Trigger = summary.Trigger{
+				Fired:  true,
+				Name:   "force",
+				Metric: "custom",
+			}
+		}
 		return true
 	}
 	checkTmp := tmp

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -347,9 +347,10 @@ func shouldGenerateSummary(
 	if force {
 		if report != nil {
 			report.Trigger = summary.Trigger{
-				Fired:  true,
-				Name:   "force",
-				Metric: "custom",
+				Fired:     true,
+				Name:      "force",
+				Metric:    "custom",
+				FilterKey: filterKey,
 			}
 		}
 		return true

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -433,6 +433,38 @@ func TestSummarizeSession_ForceReportIncludesFilterKey(t *testing.T) {
 	require.Equal(t, "branch", got.Trigger.FilterKey)
 }
 
+func TestCreateSessionSummaryWithCascade_ForceFullReportUsesTriggerFilterKey(t *testing.T) {
+	const branch = "app/branch"
+	var got summary.Report
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithReportHook(func(_ context.Context, report summary.Report) {
+			got = report
+		}),
+	)
+	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
+	base.Events = []event.Event{
+		makeEvent("new", time.Now(), branch),
+		makeEvent("other", time.Now(), "app/other"),
+	}
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(),
+		base,
+		branch,
+		true,
+		NewSummaryDispatchPolicy([]string{session.SummaryFilterKeyAllContents}, true),
+		func(ctx context.Context, sess *session.Session, filterKey string, force bool) error {
+			_, err := SummarizeSession(ctx, summarizer, sess, filterKey, force)
+			return err
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, got.Trigger.Fired)
+	require.Equal(t, "force", got.Trigger.Name)
+	require.Equal(t, branch, got.Trigger.FilterKey)
+}
+
 func TestSummarizeSession_ReusesCallerReport(t *testing.T) {
 	summarizer := summary.NewSummarizer(&reportModel{})
 	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -433,6 +433,24 @@ func TestSummarizeSession_ForceReportIncludesFilterKey(t *testing.T) {
 	require.Equal(t, "branch", got.Trigger.FilterKey)
 }
 
+func TestSummarizeSession_ReusesCallerReport(t *testing.T) {
+	summarizer := summary.NewSummarizer(&reportModel{})
+	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
+	base.Events = []event.Event{
+		makeEvent("new", time.Now(), "branch"),
+	}
+	report := &summary.Report{}
+	ctx := summary.ContextWithReport(context.Background(), report)
+
+	updated, err := SummarizeSession(ctx, summarizer, base, "branch", true)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.True(t, report.Trigger.Fired)
+	require.Equal(t, "force", report.Trigger.Name)
+	require.Equal(t, "branch", report.Trigger.FilterKey)
+	require.Equal(t, "standalone", report.Call.Mode)
+}
+
 func TestSummarizeSession_FullSession_SingleWrite(t *testing.T) {
 	now := time.Now()
 	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
@@ -1524,6 +1542,48 @@ func TestCreateSessionSummaryWithCascade_MethodValue(t *testing.T) {
 	defer mockSvc.mu.Unlock()
 	require.Equal(t, "summary-user-messages", mockSvc.summaries["user-messages"])
 	require.Equal(t, "summary-", mockSvc.summaries[""])
+}
+
+func TestCreateSessionSummaryWithCascade_ForksReportForParallelTargets(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		Events: []event.Event{
+			makeEvent("e1", now.Add(-2*time.Minute), "user-messages"),
+			makeEvent("e2", now.Add(-time.Minute), "tool-calls"),
+		},
+	}
+	rootReport := &summary.Report{}
+	ctx := summary.ContextWithReport(context.Background(), rootReport)
+
+	var (
+		reportsMu sync.Mutex
+		reports   []*summary.Report
+	)
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		"user-messages",
+		false,
+		NewSummaryDispatchPolicy(nil, true),
+		func(ctx context.Context, _ *session.Session, _ string, _ bool) error {
+			report, ok := summary.ReportFromContext(ctx)
+			if !ok {
+				return errors.New("missing report")
+			}
+			reportsMu.Lock()
+			reports = append(reports, report)
+			reportsMu.Unlock()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, reports, 2)
+	require.NotSame(t, rootReport, reports[0])
+	require.NotSame(t, rootReport, reports[1])
+	require.NotSame(t, reports[0], reports[1])
 }
 
 func TestCreateSessionSummaryWithCascade_FullTargetUsesTriggerFilterKeyForChecks(t *testing.T) {

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -246,6 +246,27 @@ func (f *fakeSummarizer) SetPrompt(prompt string)  {}
 func (f *fakeSummarizer) SetModel(m model.Model)   {}
 func (f *fakeSummarizer) Metadata() map[string]any { return map[string]any{} }
 
+type reportModel struct{}
+
+func (m *reportModel) Info() model.Info {
+	return model.Info{Name: "report"}
+}
+
+func (m *reportModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.Message{Content: "sum"},
+		}},
+	}
+	close(ch)
+	return ch, nil
+}
+
 type blockingSummarizer struct {
 	mu      sync.Mutex
 	calls   int
@@ -383,6 +404,33 @@ func TestSummarizeSession_FilteredKey_RespectsDeltaAndShould(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, updated)
 	require.Equal(t, "sum", base.Summaries["b1"].Summary)
+}
+
+func TestSummarizeSession_ForceReportIncludesFilterKey(t *testing.T) {
+	var got summary.Report
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithReportHook(func(_ context.Context, report summary.Report) {
+			got = report
+		}),
+	)
+	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
+	base.Events = []event.Event{
+		makeEvent("new", time.Now(), "branch"),
+	}
+
+	updated, err := SummarizeSession(
+		context.Background(),
+		summarizer,
+		base,
+		"branch",
+		true,
+	)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.True(t, got.Trigger.Fired)
+	require.Equal(t, "force", got.Trigger.Name)
+	require.Equal(t, "branch", got.Trigger.FilterKey)
 }
 
 func TestSummarizeSession_FullSession_SingleWrite(t *testing.T) {

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -34,6 +34,8 @@ type Checker func(sess *session.Session) bool
 // current request context.
 type ContextChecker func(context.Context, *session.Session) bool
 
+type checkEvaluator func(context.Context, *session.Session) Check
+
 var (
 	defaultTokenCounterMu sync.RWMutex
 	defaultTokenCounter   model.TokenCounter = model.NewSimpleTokenCounter()
@@ -185,13 +187,28 @@ func filterEventsWithExactKey(events []event.Event, filterKey string) []event.Ev
 // Full-session checks count only primary-agent activity, while branch-scoped
 // checks count the scoped branch and its descendants.
 func CheckEventThreshold(eventCount int) Checker {
+	evaluate := evaluateEventThreshold(eventCount)
 	return func(sess *session.Session) bool {
+		return evaluate(context.Background(), sess).Passed
+	}
+}
+
+func evaluateEventThreshold(eventCount int) checkEvaluator {
+	return func(_ context.Context, sess *session.Session) Check {
+		check := Check{
+			Name:      checkNameEventThreshold,
+			Metric:    metricEvents,
+			Threshold: eventCount,
+			Unit:      unitEvents,
+		}
 		delta := filterDeltaEvents(sess)
 		if len(delta) == 0 {
-			return false
+			return check
 		}
 		thresholdEvents := filterThresholdEventsForSession(delta, sess)
-		return len(thresholdEvents) > eventCount
+		check.Value = len(thresholdEvents)
+		check.Passed = check.Value > eventCount
+		return check
 	}
 }
 
@@ -200,16 +217,32 @@ func CheckEventThreshold(eventCount int) Checker {
 // branch checks use the last event in that branch subtree; full-session checks
 // use the last event in the session.
 func CheckTimeThreshold(interval time.Duration) Checker {
+	evaluate := evaluateTimeThreshold(interval)
 	return func(sess *session.Session) bool {
+		return evaluate(context.Background(), sess).Passed
+	}
+}
+
+func evaluateTimeThreshold(interval time.Duration) checkEvaluator {
+	return func(_ context.Context, sess *session.Session) Check {
+		check := Check{
+			Name:      checkNameTimeThreshold,
+			Metric:    metricDuration,
+			Threshold: int(interval / time.Millisecond),
+			Unit:      unitMilliseconds,
+		}
 		if sess == nil || len(sess.Events) == 0 {
-			return false
+			return check
 		}
 		relevant := filterSummaryInputEventsForSession(sess.Events, sess)
 		if len(relevant) == 0 {
-			return false
+			return check
 		}
 		lastEvent := relevant[len(relevant)-1]
-		return time.Since(lastEvent.Timestamp) > interval
+		elapsed := time.Since(lastEvent.Timestamp)
+		check.Value = int(elapsed / time.Millisecond)
+		check.Passed = elapsed > interval
+		return check
 	}
 }
 
@@ -219,20 +252,31 @@ func checkTokenThresholdFromMessage(
 	tokenCount int,
 	message model.Message,
 ) bool {
+	tokens, ok := countTokenThresholdMessage(ctx, message)
+	return ok && tokens > tokenCount
+}
+
+func countTokenThresholdMessage(
+	ctx context.Context,
+	message model.Message,
+) (int, bool) {
 	if strings.TrimSpace(message.Content) == "" &&
 		strings.TrimSpace(message.ReasoningContent) == "" {
-		return false
+		return 0, false
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	// SimpleTokenCounter.CountTokens currently never returns an error.
-	tokens, _ := getTokenCounter().CountTokens(
+	tokens, err := getTokenCounter().CountTokens(
 		ctx,
 		message,
 	)
-	return tokens > tokenCount
+	if err != nil {
+		log.DebugfContext(ctx, "summary token count failed: %v", err)
+		return 0, false
+	}
+	return tokens, true
 }
 
 // CheckTokenThreshold creates a checker that triggers when the estimated
@@ -260,8 +304,9 @@ func CheckTokenThreshold(tokenCount int) Checker {
 // when the estimated token count of the primary-agent events since the last
 // summary exceeds the given threshold.
 func CheckTokenThresholdContext(tokenCount int) ContextChecker {
+	evaluate := evaluateTokenThreshold(tokenCount)
 	return func(ctx context.Context, sess *session.Session) bool {
-		return checkTokenThreshold(ctx, tokenCount, sess)
+		return evaluate(ctx, sess).Passed
 	}
 }
 
@@ -270,27 +315,39 @@ func checkTokenThreshold(
 	tokenCount int,
 	sess *session.Session,
 ) bool {
-	if message, ok := getInjectedTokenThresholdMessage(sess); ok {
-		return checkTokenThresholdFromMessage(
-			ctx,
-			tokenCount,
-			message,
-		)
+	return evaluateTokenThreshold(tokenCount)(ctx, sess).Passed
+}
+
+func evaluateTokenThreshold(tokenCount int) checkEvaluator {
+	return func(ctx context.Context, sess *session.Session) Check {
+		check := Check{
+			Name:      checkNameTokenThreshold,
+			Metric:    metricTokens,
+			Threshold: tokenCount,
+			Unit:      unitTokens,
+		}
+
+		var message model.Message
+		if message, ok := getInjectedTokenThresholdMessage(sess); ok {
+			tokens, counted := countTokenThresholdMessage(ctx, message)
+			check.Value = tokens
+			check.Passed = counted && tokens > tokenCount
+			return check
+		}
+		delta := filterDeltaEvents(sess)
+		if len(delta) == 0 {
+			return check
+		}
+		thresholdEvents := filterThresholdEventsForSession(delta, sess)
+		if len(thresholdEvents) == 0 {
+			return check
+		}
+		message = extractTokenThresholdMessage(thresholdEvents)
+		tokens, counted := countTokenThresholdMessage(ctx, message)
+		check.Value = tokens
+		check.Passed = counted && tokens > tokenCount
+		return check
 	}
-	delta := filterDeltaEvents(sess)
-	if len(delta) == 0 {
-		return false
-	}
-	thresholdEvents := filterThresholdEventsForSession(delta, sess)
-	if len(thresholdEvents) == 0 {
-		return false
-	}
-	message := extractTokenThresholdMessage(thresholdEvents)
-	return checkTokenThresholdFromMessage(
-		ctx,
-		tokenCount,
-		message,
-	)
 }
 
 func getInjectedTokenThresholdMessage(sess *session.Session) (model.Message, bool) {
@@ -336,9 +393,23 @@ func ChecksAny(checks []Checker) Checker {
 	}
 }
 
-func wrapChecker(check Checker) ContextChecker {
-	return func(_ context.Context, sess *session.Session) bool {
-		return check(sess)
+func wrapChecker(check Checker) checkEvaluator {
+	return func(_ context.Context, sess *session.Session) Check {
+		return Check{
+			Name:   checkNameCustom,
+			Metric: metricCustom,
+			Passed: check(sess),
+		}
+	}
+}
+
+func wrapContextChecker(check ContextChecker) checkEvaluator {
+	return func(ctx context.Context, sess *session.Session) Check {
+		return Check{
+			Name:   checkNameCustom,
+			Metric: metricCustom,
+			Passed: check(ctx, sess),
+		}
 	}
 }
 
@@ -455,6 +526,13 @@ func WithContextThresholdMinTokens(tokens int) ContextThresholdOption {
 // the summarizer model's context window (when used via WithContextThreshold),
 // then to the configured fallbackContextWindow (default 8192).
 func CheckContextThreshold(opts ...ContextThresholdOption) ContextChecker {
+	evaluate := evaluateContextThreshold(opts...)
+	return func(ctx context.Context, sess *session.Session) bool {
+		return evaluate(ctx, sess).Passed
+	}
+}
+
+func evaluateContextThreshold(opts ...ContextThresholdOption) checkEvaluator {
 	o := contextThresholdOptions{
 		thresholdRatio:        defaultContextThresholdRatio,
 		fallbackContextWindow: defaultContextThresholdFallbackWindow,
@@ -464,7 +542,7 @@ func CheckContextThreshold(opts ...ContextThresholdOption) ContextChecker {
 		opt(&o)
 	}
 
-	return func(ctx context.Context, sess *session.Session) bool {
+	return func(ctx context.Context, sess *session.Session) Check {
 		contextWindow := resolveContextWindowFromCtx(
 			ctx, o.fallbackContextWindow,
 		)
@@ -472,7 +550,11 @@ func CheckContextThreshold(opts ...ContextThresholdOption) ContextChecker {
 		if threshold < o.minTokenThreshold {
 			threshold = o.minTokenThreshold
 		}
-		return checkTokenThreshold(ctx, threshold, sess)
+		check := evaluateTokenThreshold(threshold)(ctx, sess)
+		check.Name = checkNameContextThreshold
+		check.ContextWindow = contextWindow
+		check.ThresholdRatio = o.thresholdRatio
+		return check
 	}
 }
 

--- a/session/summary/options.go
+++ b/session/summary/options.go
@@ -131,7 +131,7 @@ func WithSkipRecent(skipFunc SkipRecentFunc) Option {
 // If you call multiple threshold options (e.g. token + event), all must pass.
 func WithTokenThreshold(tokenCount int) Option {
 	return func(s *sessionSummarizer) {
-		s.checks = append(s.checks, CheckTokenThresholdContext(tokenCount))
+		s.checks = append(s.checks, evaluateTokenThreshold(tokenCount))
 	}
 }
 
@@ -140,7 +140,7 @@ func WithTokenThreshold(tokenCount int) Option {
 // If you call multiple threshold options (e.g. token + event), all must pass.
 func WithEventThreshold(eventCount int) Option {
 	return func(s *sessionSummarizer) {
-		s.checks = append(s.checks, wrapChecker(CheckEventThreshold(eventCount)))
+		s.checks = append(s.checks, evaluateEventThreshold(eventCount))
 	}
 }
 
@@ -149,7 +149,7 @@ func WithEventThreshold(eventCount int) Option {
 // If you call multiple threshold options (e.g. event + time), all must pass.
 func WithTimeThreshold(interval time.Duration) Option {
 	return func(s *sessionSummarizer) {
-		s.checks = append(s.checks, wrapChecker(CheckTimeThreshold(interval)))
+		s.checks = append(s.checks, evaluateTimeThreshold(interval))
 	}
 }
 
@@ -176,7 +176,7 @@ func WithChecksAny(checks ...Checker) Option {
 func WithChecksAllContext(checks ...ContextChecker) Option {
 	return func(s *sessionSummarizer) {
 		if len(checks) > 0 {
-			s.checks = append(s.checks, allContextChecks(checks))
+			s.checks = append(s.checks, wrapContextChecker(allContextChecks(checks)))
 		}
 	}
 }
@@ -186,8 +186,16 @@ func WithChecksAllContext(checks ...ContextChecker) Option {
 func WithChecksAnyContext(checks ...ContextChecker) Option {
 	return func(s *sessionSummarizer) {
 		if len(checks) > 0 {
-			s.checks = append(s.checks, anyContextChecks(checks))
+			s.checks = append(s.checks, wrapContextChecker(anyContextChecks(checks)))
 		}
+	}
+}
+
+// WithReportHook observes summary trigger and model-call accounting after a
+// summary attempt finishes.
+func WithReportHook(h ReportHook) Option {
+	return func(s *sessionSummarizer) {
+		s.reportHook = h
 	}
 }
 
@@ -298,6 +306,6 @@ func WithContextThreshold(opts ...ContextThresholdOption) Option {
 				effectiveOpts = append(effectiveOpts, WithContextThresholdFallbackWindow(w))
 			}
 		}
-		s.checks = append(s.checks, CheckContextThreshold(effectiveOpts...))
+		s.checks = append(s.checks, evaluateContextThreshold(effectiveOpts...))
 	}
 }

--- a/session/summary/report.go
+++ b/session/summary/report.go
@@ -1,0 +1,109 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import "context"
+
+const (
+	checkNameAlways           = "always"
+	checkNameCustom           = "custom"
+	checkNameEventThreshold   = "event_threshold"
+	checkNameTimeThreshold    = "time_threshold"
+	checkNameTokenThreshold   = "token_threshold"
+	checkNameContextThreshold = "context_threshold"
+
+	metricCustom   = "custom"
+	metricDuration = "duration"
+	metricEvents   = "events"
+	metricTokens   = "tokens"
+
+	unitEvents       = "events"
+	unitMilliseconds = "milliseconds"
+	unitTokens       = "tokens"
+
+	callModeStandalone    = "standalone"
+	callModeCacheSafeFork = "cache_safe_fork"
+)
+
+// Report describes why summary generation was triggered and how the summary
+// model call was accounted.
+type Report struct {
+	Trigger Trigger
+	Call    Call
+	Error   error
+}
+
+// Trigger describes the check result that caused summary generation.
+type Trigger struct {
+	Fired     bool
+	Name      string
+	Metric    string
+	Value     int
+	Threshold int
+	Unit      string
+
+	ContextWindow  int
+	ThresholdRatio float64
+	FilterKey      string
+	Checks         []Check
+}
+
+// Check describes one summary trigger check.
+type Check struct {
+	Name      string
+	Passed    bool
+	Metric    string
+	Value     int
+	Threshold int
+	Unit      string
+
+	ContextWindow  int
+	ThresholdRatio float64
+}
+
+// Call describes the summary model request and returned usage.
+type Call struct {
+	Mode                  string
+	EstimatedPromptTokens int
+	PromptTokens          int
+	CachedTokens          int
+}
+
+// ReportHook observes summary trigger and model-call accounting.
+type ReportHook func(context.Context, Report)
+
+type reportContextKey struct{}
+
+// ContextWithReport attaches a mutable summary report to ctx. Framework code
+// uses this to carry trigger information from the check phase to the summary
+// model call.
+func ContextWithReport(ctx context.Context, report *Report) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if report == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, reportContextKey{}, report)
+}
+
+func reportFromContext(ctx context.Context) (*Report, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	report, ok := ctx.Value(reportContextKey{}).(*Report)
+	return report, ok && report != nil
+}
+
+func cloneReport(report Report) Report {
+	if len(report.Trigger.Checks) > 0 {
+		report.Trigger.Checks = append([]Check(nil), report.Trigger.Checks...)
+	}
+	return report
+}

--- a/session/summary/report.go
+++ b/session/summary/report.go
@@ -27,8 +27,9 @@ const (
 	unitMilliseconds = "milliseconds"
 	unitTokens       = "tokens"
 
-	callModeStandalone    = "standalone"
-	callModeCacheSafeFork = "cache_safe_fork"
+	callModeStandalone     = "standalone"
+	callModeCacheSafeFork  = "cache_safe_fork"
+	callModeCustomResponse = "custom_response"
 )
 
 // Report describes why summary generation was triggered and how the summary

--- a/session/summary/report.go
+++ b/session/summary/report.go
@@ -93,6 +93,16 @@ func ContextWithReport(ctx context.Context, report *Report) context.Context {
 	return context.WithValue(ctx, reportContextKey{}, report)
 }
 
+// ReportFromContext returns the report attached to ctx, if any.
+func ReportFromContext(ctx context.Context) (*Report, bool) {
+	return reportFromContext(ctx)
+}
+
+// Clone returns a copy of r that can be mutated independently.
+func (r Report) Clone() Report {
+	return cloneReport(r)
+}
+
 func reportFromContext(ctx context.Context) (*Report, bool) {
 	if ctx == nil {
 		return nil, false

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -1,0 +1,190 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+type reportModel struct {
+	request   *model.Request
+	usage     *model.Usage
+	responses []*model.Response
+}
+
+func (m *reportModel) Info() model.Info {
+	return model.Info{Name: "report"}
+}
+
+func (m *reportModel) GenerateContent(
+	_ context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	m.request = req
+	ch := make(chan *model.Response, 1)
+	if len(m.responses) > 0 {
+		go func() {
+			defer close(ch)
+			for _, response := range m.responses {
+				ch <- response
+			}
+		}()
+		return ch, nil
+	}
+	ch <- &model.Response{
+		Done:  true,
+		Usage: m.usage,
+		Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleAssistant, Content: "summary"},
+		}},
+	}
+	close(ch)
+	return ch, nil
+}
+
+func newReportSession() *session.Session {
+	return &session.Session{
+		ID:      "report-session",
+		AppName: "app",
+		Events: []event.Event{{
+			Author:    "user",
+			Timestamp: time.Now(),
+			FilterKey: "app",
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{Content: "hello"},
+			}}},
+		}},
+	}
+}
+
+func TestSessionSummarizer_ReportTriggerFromContextThreshold(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(testFixedTokenCounter{tokens: 5000})
+
+	s := NewSummarizer(
+		&reportModel{},
+		WithContextThreshold(
+			WithContextThresholdFallbackWindow(10000),
+			WithContextThresholdRatio(0.4),
+		),
+	)
+
+	report := &Report{}
+	ctx := ContextWithReport(context.Background(), report)
+	contextual := s.(ContextAwareSummarizer)
+	require.True(t, contextual.ShouldSummarizeWithContext(ctx, newReportSession()))
+	require.True(t, report.Trigger.Fired)
+	require.Equal(t, checkNameContextThreshold, report.Trigger.Name)
+	require.Equal(t, metricTokens, report.Trigger.Metric)
+	require.Equal(t, 5000, report.Trigger.Value)
+	require.Equal(t, 4000, report.Trigger.Threshold)
+	require.Equal(t, 10000, report.Trigger.ContextWindow)
+	require.Equal(t, 0.4, report.Trigger.ThresholdRatio)
+	require.Len(t, report.Trigger.Checks, 1)
+}
+
+func TestSessionSummarizer_ReportHookStandaloneCall(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(testFixedTokenCounter{tokens: 7})
+
+	var got Report
+	m := &reportModel{usage: &model.Usage{
+		PromptTokens: 123,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens: 45,
+		},
+	}}
+	s := NewSummarizer(
+		m,
+		WithTokenThreshold(5),
+		WithReportHook(func(_ context.Context, report Report) {
+			got = report
+		}),
+	)
+
+	report := &Report{}
+	ctx := ContextWithReport(context.Background(), report)
+	contextual := s.(ContextAwareSummarizer)
+	require.True(t, contextual.ShouldSummarizeWithContext(ctx, newReportSession()))
+
+	text, err := s.Summarize(ctx, newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "summary", text)
+	require.Equal(t, checkNameTokenThreshold, got.Trigger.Name)
+	require.Equal(t, 7, got.Trigger.Value)
+	require.Equal(t, 5, got.Trigger.Threshold)
+	require.Equal(t, callModeStandalone, got.Call.Mode)
+	require.Equal(t, 7, got.Call.EstimatedPromptTokens)
+	require.Equal(t, 123, got.Call.PromptTokens)
+	require.Equal(t, 45, got.Call.CachedTokens)
+	require.NoError(t, got.Error)
+}
+
+func TestSessionSummarizer_ReportHookCacheSafeForkCall(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(testFixedTokenCounter{tokens: 3})
+
+	var got Report
+	parent := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable system"),
+		model.NewUserMessage("conversation"),
+	}}
+	m := &reportModel{}
+	s := NewSummarizer(
+		m,
+		WithCacheSafeForking(true),
+		WithReportHook(func(_ context.Context, report Report) {
+			got = report
+		}),
+	)
+
+	ctx := ContextWithCacheSafeForkRequest(context.Background(), parent)
+	text, err := s.Summarize(ctx, newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "summary", text)
+	require.NotNil(t, m.request)
+	require.Len(t, m.request.Messages, 3)
+	require.Equal(t, callModeCacheSafeFork, got.Call.Mode)
+	require.Equal(t, 9, got.Call.EstimatedPromptTokens)
+	require.Equal(t, "manual", got.Trigger.Name)
+}
+
+func TestSessionSummarizer_ReportHookKeepsUsageFromEarlierResponse(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(testFixedTokenCounter{tokens: 1})
+
+	var got Report
+	m := &reportModel{responses: []*model.Response{
+		{
+			Usage: &model.Usage{PromptTokens: 21},
+			Choices: []model.Choice{{
+				Message: model.Message{Content: "summary"},
+			}},
+		},
+		{Done: true},
+	}}
+	s := NewSummarizer(
+		m,
+		WithReportHook(func(_ context.Context, report Report) {
+			got = report
+		}),
+	)
+
+	text, err := s.Summarize(context.Background(), newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "summary", text)
+	require.Equal(t, 21, got.Call.PromptTokens)
+}

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -162,6 +162,25 @@ func TestSessionSummarizer_ReportHookCacheSafeForkCall(t *testing.T) {
 	require.Equal(t, "manual", got.Trigger.Name)
 }
 
+func TestSessionSummarizer_ReportHookSeedsManualTriggerForPreseededReport(t *testing.T) {
+	var got Report
+	report := &Report{}
+	s := NewSummarizer(
+		&reportModel{},
+		WithReportHook(func(_ context.Context, report Report) {
+			got = report
+		}),
+	)
+
+	text, err := s.Summarize(ContextWithReport(context.Background(), report), newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "summary", text)
+	require.True(t, report.Trigger.Fired)
+	require.Equal(t, "manual", report.Trigger.Name)
+	require.True(t, got.Trigger.Fired)
+	require.Equal(t, "manual", got.Trigger.Name)
+}
+
 func TestSessionSummarizer_ReportHookEstimatesAfterBeforeModelCallback(t *testing.T) {
 	defer SetTokenCounter(nil)
 	SetTokenCounter(testFixedTokenCounter{tokens: 5})

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -10,6 +10,7 @@ package summary
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -53,6 +54,29 @@ func (m *reportModel) GenerateContent(
 	}
 	close(ch)
 	return ch, nil
+}
+
+func TestReportContextAndClone(t *testing.T) {
+	report := &Report{
+		Trigger: Trigger{
+			Name:   checkNameTokenThreshold,
+			Checks: []Check{{Name: checkNameTokenThreshold}},
+		},
+	}
+
+	ctx := ContextWithReport(nil, report)
+	got, ok := ReportFromContext(ctx)
+	require.True(t, ok)
+	require.Same(t, report, got)
+
+	got, ok = ReportFromContext(ContextWithReport(context.Background(), nil))
+	require.False(t, ok)
+	require.Nil(t, got)
+
+	cloned := report.Clone()
+	require.Equal(t, *report, cloned)
+	cloned.Trigger.Checks[0].Name = checkNameContextThreshold
+	require.Equal(t, checkNameTokenThreshold, report.Trigger.Checks[0].Name)
 }
 
 func newReportSession() *session.Session {
@@ -179,6 +203,82 @@ func TestSessionSummarizer_ReportHookSeedsManualTriggerForPreseededReport(t *tes
 	require.Equal(t, "manual", report.Trigger.Name)
 	require.True(t, got.Trigger.Fired)
 	require.Equal(t, "manual", got.Trigger.Name)
+}
+
+type rangeErrorTokenCounter struct {
+	tokens int
+}
+
+func (c rangeErrorTokenCounter) CountTokens(_ context.Context, _ model.Message) (int, error) {
+	return c.tokens, nil
+}
+
+func (c rangeErrorTokenCounter) CountTokensRange(
+	_ context.Context,
+	_ []model.Message,
+	_,
+	_ int,
+) (int, error) {
+	return 0, errors.New("range count failed")
+}
+
+func TestReportAccountingHelpers(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(rangeErrorTokenCounter{tokens: 4})
+
+	require.Zero(t, estimateRequestPromptTokens(context.Background(), nil))
+	require.Zero(t, estimateRequestPromptTokens(context.Background(), &model.Request{}))
+	require.Equal(
+		t,
+		8,
+		estimateRequestPromptTokens(
+			context.Background(),
+			&model.Request{Messages: []model.Message{
+				model.NewSystemMessage("system"),
+				model.NewUserMessage("user"),
+			}},
+		),
+	)
+
+	require.False(t, usageHasTokenCounts(nil))
+	require.False(t, usageHasTokenCounts(&model.Usage{}))
+	require.True(t, usageHasTokenCounts(&model.Usage{TotalTokens: 1}))
+	require.True(t, usageHasTokenCounts(&model.Usage{
+		PromptTokensDetails: model.PromptTokensDetails{CacheReadTokens: 1},
+	}))
+	require.True(t, usageHasTokenCounts(&model.Usage{
+		PromptTokensDetails: model.PromptTokensDetails{CacheCreationTokens: 1},
+	}))
+}
+
+type reportContextTestKey struct{}
+
+func TestInheritReportContext(t *testing.T) {
+	report := &Report{Trigger: Trigger{Name: checkNameTokenThreshold}}
+	current := ContextWithReport(context.Background(), report)
+	next := context.WithValue(context.Background(), reportContextTestKey{}, "next")
+
+	got := inheritReportContext(next, current)
+	inherited, ok := ReportFromContext(got)
+	require.True(t, ok)
+	require.Same(t, report, inherited)
+	require.Equal(t, "next", got.Value(reportContextTestKey{}))
+
+	existing := &Report{Trigger: Trigger{Name: checkNameContextThreshold}}
+	got = inheritReportContext(ContextWithReport(next, existing), current)
+	inherited, ok = ReportFromContext(got)
+	require.True(t, ok)
+	require.Same(t, existing, inherited)
+
+	got = inheritReportContext(nil, current)
+	inherited, ok = ReportFromContext(got)
+	require.True(t, ok)
+	require.Same(t, report, inherited)
+
+	got = inheritReportContext(next, context.Background())
+	_, ok = ReportFromContext(got)
+	require.False(t, ok)
+	require.Equal(t, "next", got.Value(reportContextTestKey{}))
 }
 
 func TestSessionSummarizer_ReportHookEstimatesAfterBeforeModelCallback(t *testing.T) {

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -162,6 +162,39 @@ func TestSessionSummarizer_ReportHookCacheSafeForkCall(t *testing.T) {
 	require.Equal(t, "manual", got.Trigger.Name)
 }
 
+func TestSessionSummarizer_ReportHookEstimatesAfterBeforeModelCallback(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(testFixedTokenCounter{tokens: 5})
+
+	var got Report
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		_ context.Context,
+		args *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		args.Request.Messages = append(
+			args.Request.Messages,
+			model.NewSystemMessage("callback-added"),
+		)
+		return nil, nil
+	})
+	m := &reportModel{}
+	s := NewSummarizer(
+		m,
+		WithModelCallbacks(callbacks),
+		WithReportHook(func(_ context.Context, report Report) {
+			got = report
+		}),
+	)
+
+	text, err := s.Summarize(context.Background(), newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "summary", text)
+	require.NotNil(t, m.request)
+	require.Len(t, m.request.Messages, 2)
+	require.Equal(t, 10, got.Call.EstimatedPromptTokens)
+}
+
 func TestSessionSummarizer_ReportHookKeepsUsageFromEarlierResponse(t *testing.T) {
 	defer SetTokenCounter(nil)
 	SetTokenCounter(testFixedTokenCounter{tokens: 1})

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -314,6 +314,42 @@ func TestSessionSummarizer_ReportHookEstimatesAfterBeforeModelCallback(t *testin
 	require.Equal(t, 10, got.Call.EstimatedPromptTokens)
 }
 
+func TestSessionSummarizer_ReportHookCustomResponseCall(t *testing.T) {
+	defer SetTokenCounter(nil)
+	SetTokenCounter(testFixedTokenCounter{tokens: 5})
+
+	var got Report
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		_ context.Context,
+		_ *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		return &model.BeforeModelResult{
+			CustomResponse: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.Message{Content: "callback summary"},
+				}},
+			},
+		}, nil
+	})
+	m := &reportModel{}
+	s := NewSummarizer(
+		m,
+		WithModelCallbacks(callbacks),
+		WithReportHook(func(_ context.Context, report Report) {
+			got = report
+		}),
+	)
+
+	text, err := s.Summarize(context.Background(), newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "callback summary", text)
+	require.Nil(t, m.request)
+	require.Equal(t, callModeCustomResponse, got.Call.Mode)
+	require.Zero(t, got.Call.EstimatedPromptTokens)
+}
+
 func TestSessionSummarizer_ReportHookKeepsUsageFromEarlierResponse(t *testing.T) {
 	defer SetTokenCounter(nil)
 	SetTokenCounter(testFixedTokenCounter{tokens: 1})

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -889,14 +889,16 @@ func (s *sessionSummarizer) generateSummary(
 		err = cbErr
 		return ctx, "", cbErr
 	}
-	s.recordReportCall(ctx, request, mode)
 
 	if responseChan == nil {
+		s.recordReportCall(ctx, request, mode)
 		responseChan, cbErr = s.model.GenerateContent(ctx, request)
 		if cbErr != nil {
 			err = fmt.Errorf("failed to generate summary: %w", cbErr)
 			return ctx, "", err
 		}
+	} else {
+		s.recordReportCall(ctx, nil, callModeCustomResponse)
 	}
 
 	var summaryText string

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/prompt"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummaryscope "trpc.group/trpc-go/trpc-agent-go/session/internal/summaryscope"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 )
 
@@ -215,7 +216,7 @@ type sessionSummarizer struct {
 	systemPrompt        string
 	cacheSafeForking    bool
 	cacheSafeForkPrompt string
-	checks              []ContextChecker
+	checks              []checkEvaluator
 	maxSummaryWords     int
 	skipRecentFunc      SkipRecentFunc
 
@@ -225,6 +226,8 @@ type sessionSummarizer struct {
 
 	// modelCallbacks configures before/after model callbacks for summarization.
 	modelCallbacks *model.Callbacks
+	// reportHook observes summary trigger and model-call accounting.
+	reportHook ReportHook
 
 	// toolCallFormatter customizes how tool calls are formatted in summary input.
 	toolCallFormatter ToolCallFormatter
@@ -237,7 +240,7 @@ func NewSummarizer(m model.Model, opts ...Option) SessionSummarizer {
 	s := &sessionSummarizer{
 		prompt:              "",                 // Will be set after processing options.
 		cacheSafeForkPrompt: "",                 // Will be set after processing options.
-		checks:              []ContextChecker{}, // No default checks - summarization only when explicitly configured.
+		checks:              []checkEvaluator{}, // No default checks - summarization only when explicitly configured.
 		maxSummaryWords:     0,                  // 0 means no word limit.
 		skipRecentFunc:      nil,                // nil means no events are skipped.
 	}
@@ -283,25 +286,103 @@ func (s *sessionSummarizer) ShouldSummarizeWithContext(
 	ctx context.Context,
 	sess *session.Session,
 ) bool {
+	trigger := s.evaluateTrigger(ctx, sess)
+	if report, ok := reportFromContext(ctx); ok {
+		report.Trigger = trigger
+	}
+	return trigger.Fired
+}
+
+func (s *sessionSummarizer) evaluateTrigger(
+	ctx context.Context,
+	sess *session.Session,
+) Trigger {
 	if sess == nil || len(sess.Events) == 0 {
-		return false
+		return Trigger{}
 	}
 	summaryInputEvents := filterSummaryInputEventsForSession(
 		s.filterEventsForSummary(sess.Events),
 		sess,
 	)
 	if !s.hasSummarizableContent(summaryInputEvents) {
-		return false
+		return Trigger{}
 	}
 
 	checkSess := s.buildCheckSession(sess)
-
-	for _, check := range s.checks {
-		if !check(ctx, checkSess) {
-			return false
+	if len(s.checks) == 0 {
+		return Trigger{
+			Fired:     true,
+			Name:      checkNameAlways,
+			Metric:    metricCustom,
+			FilterKey: triggerFilterKey(checkSess),
 		}
 	}
-	return true
+
+	checks := make([]Check, 0, len(s.checks))
+	for _, check := range s.checks {
+		result := check(ctx, checkSess)
+		checks = append(checks, result)
+		if !result.Passed {
+			trigger := triggerFromCheck(result)
+			trigger.Fired = false
+			trigger.FilterKey = triggerFilterKey(checkSess)
+			trigger.Checks = checks
+			return trigger
+		}
+	}
+	trigger := triggerFromCheck(preferredTriggerCheck(checks))
+	trigger.Fired = true
+	trigger.FilterKey = triggerFilterKey(checkSess)
+	trigger.Checks = checks
+	return trigger
+}
+
+func triggerFilterKey(sess *session.Session) string {
+	if sess == nil {
+		return ""
+	}
+	return isummaryscope.GetScopeFilterKey(sess)
+}
+
+func triggerFromCheck(check Check) Trigger {
+	return Trigger{
+		Fired:          check.Passed,
+		Name:           check.Name,
+		Metric:         check.Metric,
+		Value:          check.Value,
+		Threshold:      check.Threshold,
+		Unit:           check.Unit,
+		ContextWindow:  check.ContextWindow,
+		ThresholdRatio: check.ThresholdRatio,
+	}
+}
+
+func preferredTriggerCheck(checks []Check) Check {
+	for _, name := range []string{
+		checkNameContextThreshold,
+		checkNameTokenThreshold,
+		checkNameEventThreshold,
+		checkNameTimeThreshold,
+	} {
+		for _, check := range checks {
+			if check.Passed && check.Name == name {
+				return check
+			}
+		}
+	}
+	for _, check := range checks {
+		if check.Passed {
+			return check
+		}
+	}
+	if len(checks) > 0 {
+		return checks[len(checks)-1]
+	}
+	return Check{
+		Name:   checkNameAlways,
+		Metric: metricCustom,
+		Passed: true,
+	}
 }
 
 // Summarize generates a summary without modifying the session events.
@@ -312,6 +393,7 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	if len(sess.Events) == 0 {
 		return "", fmt.Errorf("no events to summarize for session %s (events=0)", sess.ID)
 	}
+	ctx = s.ensureReportContext(ctx)
 
 	// Extract conversation text from events. Use filtered events for summarization
 	// to skip recent events while ensuring proper context.
@@ -335,6 +417,11 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 		if hookErr == nil {
 			// Propagate context modifications from pre-hook to subsequent operations.
 			if hookCtx.Ctx != nil {
+				if report, ok := reportFromContext(ctx); ok {
+					if _, exists := reportFromContext(hookCtx.Ctx); !exists {
+						hookCtx.Ctx = ContextWithReport(hookCtx.Ctx, report)
+					}
+				}
 				ctx = hookCtx.Ctx
 			}
 			if hookCtx.Text != "" {
@@ -371,6 +458,22 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	}
 
 	return summaryText, nil
+}
+
+func (s *sessionSummarizer) ensureReportContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := reportFromContext(ctx); ok || s.reportHook == nil {
+		return ctx
+	}
+	return ContextWithReport(ctx, &Report{
+		Trigger: Trigger{
+			Fired:  true,
+			Name:   "manual",
+			Metric: metricCustom,
+		},
+	})
 }
 
 // recordLastIncludedBoundary records the last included summary boundary in the session state.
@@ -687,10 +790,13 @@ func (s *sessionSummarizer) generateSummary(
 	_, span := trace.Tracer.Start(ctx, itelemetry.NewChatSpanName(modelName))
 	defer span.End()
 
-	request, err := s.buildSummaryRequest(ctx, conversationText)
+	request, mode, err := s.buildSummaryRequest(ctx, conversationText)
 	if err != nil {
-		return ctx, "", fmt.Errorf("failed to build summary request: %w", err)
+		err = fmt.Errorf("failed to build summary request: %w", err)
+		s.emitReport(ctx, err)
+		return ctx, "", err
 	}
+	s.recordReportCall(ctx, request, mode)
 
 	invocation, ok := agent.InvocationFromContext(ctx)
 	if !ok || invocation == nil {
@@ -733,11 +839,14 @@ func (s *sessionSummarizer) generateSummary(
 
 	trackResponse := func(resp *model.Response) {
 		tracker.TrackResponse(resp)
+		s.recordReportUsage(ctx, resp, nil)
 		ensureTimingInfo(resp)
 	}
 
 	var finalResp *model.Response
 	defer func() {
+		s.recordReportUsage(ctx, finalResp, err)
+		s.emitReport(ctx, err)
 		if finalResp == nil {
 			return
 		}
@@ -828,10 +937,14 @@ func (s *sessionSummarizer) buildCacheSafeForkPrompt() (string, error) {
 	)
 }
 
-func (s *sessionSummarizer) buildSummaryRequest(ctx context.Context, conversationText string) (*model.Request, error) {
+func (s *sessionSummarizer) buildSummaryRequest(
+	ctx context.Context,
+	conversationText string,
+) (*model.Request, string, error) {
 	if s.cacheSafeForking {
 		if parent, ok := cacheSafeForkRequestFromContext(ctx); ok {
-			return s.buildCacheSafeForkRequest(parent)
+			request, err := s.buildCacheSafeForkRequest(parent)
+			return request, callModeCacheSafeFork, err
 		}
 		log.DebugfContext(ctx, "cache-safe summary forking requested but no parent request is available; falling back to standalone summary request")
 	}
@@ -839,7 +952,7 @@ func (s *sessionSummarizer) buildSummaryRequest(ctx context.Context, conversatio
 	messages := make([]model.Message, 0, 2)
 	systemPrompt, err := s.buildSystemPrompt()
 	if err != nil {
-		return nil, fmt.Errorf("render system prompt: %w", err)
+		return nil, "", fmt.Errorf("render system prompt: %w", err)
 	}
 	if trimmed := strings.TrimSpace(systemPrompt); trimmed != "" {
 		messages = append(messages, model.NewSystemMessage(systemPrompt))
@@ -847,10 +960,10 @@ func (s *sessionSummarizer) buildSummaryRequest(ctx context.Context, conversatio
 
 	userPrompt, err := s.buildSummaryPrompt(conversationText)
 	if err != nil {
-		return nil, fmt.Errorf("render user prompt: %w", err)
+		return nil, "", fmt.Errorf("render user prompt: %w", err)
 	}
 	messages = append(messages, model.NewUserMessage(userPrompt))
-	return newSummaryRequest(messages), nil
+	return newSummaryRequest(messages), callModeStandalone, nil
 }
 
 func (s *sessionSummarizer) buildCacheSafeForkRequest(parent *model.Request) (*model.Request, error) {
@@ -877,6 +990,89 @@ func newSummaryRequest(messages []model.Message) *model.Request {
 	}
 }
 
+func (s *sessionSummarizer) recordReportCall(
+	ctx context.Context,
+	request *model.Request,
+	mode string,
+) {
+	report, ok := reportFromContext(ctx)
+	if !ok {
+		return
+	}
+	report.Call.Mode = mode
+	report.Call.EstimatedPromptTokens = estimateRequestPromptTokens(ctx, request)
+}
+
+func (s *sessionSummarizer) recordReportUsage(
+	ctx context.Context,
+	response *model.Response,
+	err error,
+) {
+	report, ok := reportFromContext(ctx)
+	if !ok {
+		return
+	}
+	report.Error = err
+	if response == nil || response.Usage == nil {
+		return
+	}
+	if !usageHasTokenCounts(response.Usage) {
+		return
+	}
+	report.Call.PromptTokens = response.Usage.PromptTokens
+	report.Call.CachedTokens = response.Usage.PromptTokensDetails.CachedTokens
+}
+
+func usageHasTokenCounts(usage *model.Usage) bool {
+	if usage == nil {
+		return false
+	}
+	return usage.PromptTokens != 0 ||
+		usage.CompletionTokens != 0 ||
+		usage.TotalTokens != 0 ||
+		usage.PromptTokensDetails.CachedTokens != 0 ||
+		usage.PromptTokensDetails.CacheReadTokens != 0 ||
+		usage.PromptTokensDetails.CacheCreationTokens != 0
+}
+
+func (s *sessionSummarizer) emitReport(ctx context.Context, err error) {
+	if s.reportHook == nil {
+		return
+	}
+	report, ok := reportFromContext(ctx)
+	if !ok {
+		return
+	}
+	report.Error = err
+	cloned := cloneReport(*report)
+	defer func() {
+		if r := recover(); r != nil {
+			log.WarnfContext(ctx, "summary report hook panic: %v", r)
+		}
+	}()
+	s.reportHook(ctx, cloned)
+}
+
+func estimateRequestPromptTokens(ctx context.Context, request *model.Request) int {
+	if request == nil || len(request.Messages) == 0 {
+		return 0
+	}
+	counter := getTokenCounter()
+	tokens, err := counter.CountTokensRange(ctx, request.Messages, 0, len(request.Messages))
+	if err == nil {
+		return tokens
+	}
+	var total int
+	for _, message := range request.Messages {
+		tokens, err := counter.CountTokens(ctx, message)
+		if err != nil {
+			return 0
+		}
+		total += tokens
+	}
+	return total
+}
+
 func (s *sessionSummarizer) runBeforeModelCallbacks(
 	ctx context.Context,
 	request *model.Request,
@@ -893,7 +1089,7 @@ func (s *sessionSummarizer) runBeforeModelCallbacks(
 		return ctx, nil, fmt.Errorf("before model callback failed: %w", err)
 	}
 	if result != nil && result.Context != nil {
-		ctx = result.Context
+		ctx = inheritReportContext(result.Context, ctx)
 	}
 	if result == nil || result.CustomResponse == nil {
 		return ctx, nil, nil
@@ -933,12 +1129,26 @@ func (s *sessionSummarizer) runAfterModelCallbacks(
 		return ctx, nil, fmt.Errorf("after model callback failed: %w", err)
 	}
 	if result != nil && result.Context != nil {
-		ctx = result.Context
+		ctx = inheritReportContext(result.Context, ctx)
 	}
 	if result != nil && result.CustomResponse != nil {
 		response = result.CustomResponse
 	}
 	return ctx, response, nil
+}
+
+func inheritReportContext(next context.Context, current context.Context) context.Context {
+	if next == nil {
+		return current
+	}
+	report, ok := reportFromContext(current)
+	if !ok {
+		return next
+	}
+	if _, exists := reportFromContext(next); exists {
+		return next
+	}
+	return ContextWithReport(next, report)
 }
 
 func (s *sessionSummarizer) collectSummaryFromResponses(

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -796,7 +796,6 @@ func (s *sessionSummarizer) generateSummary(
 		s.emitReport(ctx, err)
 		return ctx, "", err
 	}
-	s.recordReportCall(ctx, request, mode)
 
 	invocation, ok := agent.InvocationFromContext(ctx)
 	if !ok || invocation == nil {
@@ -866,6 +865,7 @@ func (s *sessionSummarizer) generateSummary(
 		err = cbErr
 		return ctx, "", cbErr
 	}
+	s.recordReportCall(ctx, request, mode)
 
 	if responseChan == nil {
 		responseChan, cbErr = s.model.GenerateContent(ctx, request)

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -464,16 +464,40 @@ func (s *sessionSummarizer) ensureReportContext(ctx context.Context) context.Con
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if _, ok := reportFromContext(ctx); ok || s.reportHook == nil {
+	if report, ok := reportFromContext(ctx); ok {
+		seedManualTrigger(report)
 		return ctx
 	}
-	return ContextWithReport(ctx, &Report{
-		Trigger: Trigger{
-			Fired:  true,
-			Name:   "manual",
-			Metric: metricCustom,
-		},
-	})
+	if s.reportHook == nil {
+		return ctx
+	}
+	report := &Report{}
+	seedManualTrigger(report)
+	return ContextWithReport(ctx, report)
+}
+
+func seedManualTrigger(report *Report) {
+	if report == nil || !triggerIsEmpty(report.Trigger) {
+		return
+	}
+	report.Trigger = Trigger{
+		Fired:  true,
+		Name:   "manual",
+		Metric: metricCustom,
+	}
+}
+
+func triggerIsEmpty(trigger Trigger) bool {
+	return !trigger.Fired &&
+		trigger.Name == "" &&
+		trigger.Metric == "" &&
+		trigger.Value == 0 &&
+		trigger.Threshold == 0 &&
+		trigger.Unit == "" &&
+		trigger.ContextWindow == 0 &&
+		trigger.ThresholdRatio == 0 &&
+		trigger.FilterKey == "" &&
+		len(trigger.Checks) == 0
 }
 
 // recordLastIncludedBoundary records the last included summary boundary in the session state.

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -594,7 +594,7 @@ func TestSessionSummarizer_Metadata_NilModel(t *testing.T) {
 	s := &sessionSummarizer{
 		model:           nil,
 		maxSummaryWords: 100,
-		checks:          []ContextChecker{},
+		checks:          []checkEvaluator{},
 	}
 	md := s.Metadata()
 	assert.Equal(t, "", md[metadataKeyModelName])


### PR DESCRIPTION
## Summary

- add a lightweight summary report hook that separates trigger accounting from summary model call accounting
- report built-in trigger values for token, context, event, and time thresholds while keeping legacy checker APIs compatible
- carry report context through async summary generation and cache-safe forked summary requests
- document trigger tokens versus summary prompt tokens in the session summary guide

## Validation

- go test ./session/summary ./session/internal/summary ./runner ./internal/flow/llmflow
- go test ./session/...
