### PR TITLE
fix: add panic recovery to MySQL Transaction to prevent tx leak

### DIFF
--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -122,9 +122,17 @@ func (c *sqlDBClient) Transaction(ctx context.Context, fn TxFunc, opts ...TxOpti
 		return err
 	}
 
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		} else if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
 	// Execute user transaction function.
-	if err := fn(tx); err != nil {
-		_ = tx.Rollback()
+	if err = fn(tx); err != nil {
 		return err
 	}
 

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -696,6 +696,50 @@ func TestSQLDBClient_Transaction(t *testing.T) {
 		assert.Contains(t, err.Error(), "commit error")
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
+
+	t.Run("transaction with rollback on panic", func(t *testing.T) {
+		mockDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer mockDB.Close()
+
+		client := &sqlDBClient{db: mockDB}
+
+		mock.ExpectBegin()
+		// go-sqlmock does not reliably record Rollback during a panic unwind.
+		// We verify panic propagation here; the defer+rollback path is covered
+		// by the error-based rollback test above and by the code review of the
+		// defer block.
+
+		assert.PanicsWithValue(t, "test panic", func() {
+			_ = client.Transaction(context.Background(), func(tx *sql.Tx) error {
+				panic("test panic")
+			})
+		})
+
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("transaction with rollback on panic after exec", func(t *testing.T) {
+		mockDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer mockDB.Close()
+
+		client := &sqlDBClient{db: mockDB}
+
+		mock.ExpectBegin()
+		mock.ExpectExec("INSERT INTO users").WillReturnResult(sqlmock.NewResult(1, 1))
+		// Rollback expectation omitted — same reason as above.
+
+		assert.PanicsWithValue(t, "panic after exec", func() {
+			_ = client.Transaction(context.Background(), func(tx *sql.Tx) error {
+				_, _ = tx.ExecContext(context.Background(),
+					"INSERT INTO users (name) VALUES (?)", "Alice")
+				panic("panic after exec")
+			})
+		})
+
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 func TestWrapSQLDB(t *testing.T) {

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -705,11 +705,7 @@ func TestSQLDBClient_Transaction(t *testing.T) {
 		client := &sqlDBClient{db: mockDB}
 
 		mock.ExpectBegin()
-		// go-sqlmock does not reliably record Rollback during a panic unwind.
-		// We verify panic propagation here; the defer+rollback path is covered
-		// by the error-based rollback test above and by the code review of the
-		// defer block.
-
+		mock.ExpectRollback()
 		assert.PanicsWithValue(t, "test panic", func() {
 			_ = client.Transaction(context.Background(), func(tx *sql.Tx) error {
 				panic("test panic")
@@ -728,7 +724,7 @@ func TestSQLDBClient_Transaction(t *testing.T) {
 
 		mock.ExpectBegin()
 		mock.ExpectExec("INSERT INTO users").WillReturnResult(sqlmock.NewResult(1, 1))
-		// Rollback expectation omitted — same reason as above.
+		mock.ExpectRollback()
 
 		assert.PanicsWithValue(t, "panic after exec", func() {
 			_ = client.Transaction(context.Background(), func(tx *sql.Tx) error {
@@ -738,6 +734,26 @@ func TestSQLDBClient_Transaction(t *testing.T) {
 			})
 		})
 
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("transaction with rollback on err but not panic", func(t *testing.T) {
+		mockDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer mockDB.Close()
+
+		client := &sqlDBClient{db: mockDB}
+
+		mock.ExpectBegin()
+		mock.ExpectExec("INSERT INTO users").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectRollback()
+		expectedErr := errors.New("expected error")
+		err = client.Transaction(context.Background(), func(tx *sql.Tx) error {
+			_, _ = tx.ExecContext(context.Background(),
+				"INSERT INTO users (name) VALUES (?)", "Alice")
+			return expectedErr
+		})
+		assert.ErrorIs(t, err, expectedErr)
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
 }


### PR DESCRIPTION
The Transaction method did not handle panics from the user-provided TxFunc. If fn(tx) panicked, the transaction was never rolled back, leaking the connection. This adds defer+recover to rollback on panic and re-panic, matching the Postgres implementation.

## What changed

Describe the user-visible behavior, API, documentation, or example changes in
this pull request.

## Why

Explain the problem this solves and any compatibility considerations.

## Testing

List the commands or manual checks you ran. If a check is not applicable, say
why.

## Notes for reviewers

Call out areas that deserve extra attention, such as concurrency, persistence,
protocol compatibility, or public API changes.
