### PR TITLE
openclaw: support OpenAI request headers

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -821,8 +821,11 @@ Some OpenAI-compatible gateways require additional HTTP headers. Set them with
 export OPENAI_HEADERS="X-Example-User=alice X-Example-Agent=openclaw"
 ```
 
-`OPENAI_HEADERS` is intended for simple values without spaces. Use
-`model.headers` for values containing spaces, such as a bearer token.
+Quote values that contain spaces or commas:
+
+```bash
+export OPENAI_HEADERS='X-Example-User=alice Authorization="Bearer token"'
+```
 
 You can also configure them in YAML:
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -814,6 +814,22 @@ You can override the OpenAI-compatible base URL with:
 - `-openai-base-url` (CLI flag), or
 - `model.base_url` (YAML config).
 
+Some OpenAI-compatible gateways require additional HTTP headers. Set them with
+`OPENAI_HEADERS` as space-, comma-, or newline-separated `KEY=VALUE` pairs:
+
+```bash
+export OPENAI_HEADERS="X-Example-User=alice X-Example-Agent=openclaw"
+```
+
+You can also configure them in YAML:
+
+```yaml
+model:
+  headers:
+    X-Example-User: "alice"
+    X-Example-Agent: "openclaw"
+```
+
 ### DeepSeek (OpenAI-compatible)
 
 If you use DeepSeek directly, set `DEEPSEEK_API_KEY` together with the official

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -821,6 +821,9 @@ Some OpenAI-compatible gateways require additional HTTP headers. Set them with
 export OPENAI_HEADERS="X-Example-User=alice X-Example-Agent=openclaw"
 ```
 
+`OPENAI_HEADERS` is intended for simple values without spaces. Use
+`model.headers` for values containing spaces, such as a bearer token.
+
 You can also configure them in YAML:
 
 ```yaml
@@ -828,6 +831,7 @@ model:
   headers:
     X-Example-User: "alice"
     X-Example-Agent: "openclaw"
+    X-Example-Token: "Bearer token-with-space"
 ```
 
 ### DeepSeek (OpenAI-compatible)

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -673,6 +673,9 @@ go run ./cmd/openclaw \
 export OPENAI_HEADERS="X-Example-User=alice X-Example-Agent=openclaw"
 ```
 
+`OPENAI_HEADERS` 适合不含空格的简单值。如果 header 值包含空格，
+例如 bearer token，请使用 `model.headers`。
+
 也可以写在 YAML 里：
 
 ```yaml
@@ -680,6 +683,7 @@ model:
   headers:
     X-Example-User: "alice"
     X-Example-Agent: "openclaw"
+    X-Example-Token: "Bearer token-with-space"
 ```
 
 ### DeepSeek（OpenAI 兼容）

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -666,6 +666,22 @@ go run ./cmd/openclaw \
 - `-openai-base-url`（CLI 参数），或
 - `model.base_url`（YAML 配置）。
 
+某些 OpenAI 兼容网关还要求额外 HTTP header。可以用
+`OPENAI_HEADERS` 设置，格式为空格、逗号或换行分隔的 `KEY=VALUE`：
+
+```bash
+export OPENAI_HEADERS="X-Example-User=alice X-Example-Agent=openclaw"
+```
+
+也可以写在 YAML 里：
+
+```yaml
+model:
+  headers:
+    X-Example-User: "alice"
+    X-Example-Agent: "openclaw"
+```
+
 ### DeepSeek（OpenAI 兼容）
 
 如果你直连 DeepSeek，请同时设置 `DEEPSEEK_API_KEY` 和官方

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -673,8 +673,11 @@ go run ./cmd/openclaw \
 export OPENAI_HEADERS="X-Example-User=alice X-Example-Agent=openclaw"
 ```
 
-`OPENAI_HEADERS` 适合不含空格的简单值。如果 header 值包含空格，
-例如 bearer token，请使用 `model.headers`。
+如果 header 值包含空格或逗号，请加引号：
+
+```bash
+export OPENAI_HEADERS='X-Example-User=alice Authorization="Bearer token"'
+```
 
 也可以写在 YAML 里：
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -3458,9 +3458,13 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 	if baseURL == "" {
 		baseURL = strings.TrimSpace(os.Getenv(openAIBaseURLEnvName))
 	}
-	headers, err := resolveOpenAIHeaders(opts.OpenAIHeaders)
-	if err != nil {
-		return nil, err
+	var headers map[string]string
+	if mode == modeOpenAI {
+		resolved, err := resolveOpenAIHeaders(opts.OpenAIHeaders)
+		if err != nil {
+			return nil, err
+		}
+		headers = resolved
 	}
 
 	spec := registry.ModelSpec{

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -421,7 +421,9 @@ const (
 	qwenAPIHost     = "dashscope.aliyuncs.com"
 	hunyuanAPIHost  = "api.hunyuan.cloud.tencent.com"
 
+	openAIAPIKeyEnvName  = "OPENAI_API_KEY"
 	openAIBaseURLEnvName = "OPENAI_BASE_URL"
+	openAIHeadersEnvName = "OPENAI_HEADERS"
 	openAIModelEnvName   = "OPENAI_MODEL"
 
 	errClaudeCodeAgentNoPrompts = "claude-code agent does not support " +
@@ -3432,6 +3434,12 @@ func newOpenAIModel(spec registry.ModelSpec) (model.Model, error) {
 	if baseURL != "" {
 		opts = append(opts, openai.WithBaseURL(baseURL))
 	}
+	if apiKey := strings.TrimSpace(spec.APIKey); apiKey != "" {
+		opts = append(opts, openai.WithAPIKey(apiKey))
+	}
+	if len(spec.Headers) > 0 {
+		opts = append(opts, openai.WithHeaders(spec.Headers))
+	}
 	return openai.New(name, opts...), nil
 }
 
@@ -3450,16 +3458,102 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 	if baseURL == "" {
 		baseURL = strings.TrimSpace(os.Getenv(openAIBaseURLEnvName))
 	}
+	headers, err := resolveOpenAIHeaders(opts.OpenAIHeaders)
+	if err != nil {
+		return nil, err
+	}
 
 	spec := registry.ModelSpec{
 		Type:                 mode,
 		Name:                 opts.OpenAIModel,
 		BaseURL:              baseURL,
+		APIKey:               strings.TrimSpace(os.Getenv(openAIAPIKeyEnvName)),
 		OpenAIVariant:        opts.OpenAIVariant,
+		Headers:              headers,
 		DebugRecorderEnabled: opts.DebugRecorderEnabled,
 		Config:               opts.ModelConfig,
 	}
 	return f(spec)
+}
+
+func resolveOpenAIHeaders(
+	config map[string]string,
+) (map[string]string, error) {
+	headers := cleanHeaderMap(config)
+	envHeaders, err := parseHeaderPairs(os.Getenv(openAIHeadersEnvName))
+	if err != nil {
+		return nil, err
+	}
+	if len(envHeaders) == 0 {
+		return headers, nil
+	}
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	for key, value := range envHeaders {
+		headers[key] = value
+	}
+	return headers, nil
+}
+
+func cleanHeaderMap(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	cleaned := make(map[string]string, len(headers))
+	for key, value := range headers {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		cleaned[key] = value
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return cleaned
+}
+
+func parseHeaderPairs(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	replacer := strings.NewReplacer(
+		",",
+		" ",
+		"\n",
+		" ",
+		"\r",
+		" ",
+	)
+	fields := strings.Fields(replacer.Replace(raw))
+	headers := make(map[string]string, len(fields))
+	for _, field := range fields {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			key, value, ok = strings.Cut(field, ":")
+		}
+		if !ok {
+			return nil, fmt.Errorf(
+				"invalid %s entry %q: want KEY=VALUE",
+				openAIHeadersEnvName,
+				field,
+			)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			return nil, fmt.Errorf(
+				"invalid %s entry %q: empty key or value",
+				openAIHeadersEnvName,
+				field,
+			)
+		}
+		headers[key] = value
+	}
+	return headers, nil
 }
 
 func parseOpenAIVariant(

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
@@ -3524,15 +3525,10 @@ func parseHeaderPairs(raw string) (map[string]string, error) {
 	if raw == "" {
 		return nil, nil
 	}
-	replacer := strings.NewReplacer(
-		",",
-		" ",
-		"\n",
-		" ",
-		"\r",
-		" ",
-	)
-	fields := strings.Fields(replacer.Replace(raw))
+	fields, err := splitHeaderFields(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", openAIHeadersEnvName, err)
+	}
 	headers := make(map[string]string, len(fields))
 	for _, field := range fields {
 		key, value, ok := strings.Cut(field, "=")
@@ -3558,6 +3554,56 @@ func parseHeaderPairs(raw string) (map[string]string, error) {
 		headers[key] = value
 	}
 	return headers, nil
+}
+
+func splitHeaderFields(raw string) ([]string, error) {
+	var fields []string
+	var field strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if s := strings.TrimSpace(field.String()); s != "" {
+			fields = append(fields, s)
+		}
+		field.Reset()
+	}
+
+	for _, r := range raw {
+		if escaped {
+			field.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if quote != 0 {
+			if quote == '"' && r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == quote {
+				quote = 0
+				continue
+			}
+			field.WriteRune(r)
+			continue
+		}
+
+		switch {
+		case r == '"' || r == '\'':
+			quote = r
+		case r == ',' || unicode.IsSpace(r):
+			flush()
+		default:
+			field.WriteRune(r)
+		}
+	}
+	if escaped {
+		return nil, errors.New("unterminated escape sequence")
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated %q quote", string(quote))
+	}
+	flush()
+	return fields, nil
 }
 
 func parseOpenAIVariant(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -3820,14 +3820,17 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 func TestResolveOpenAIHeaders_EnvOnlyAndConfigOnly(t *testing.T) {
 	t.Setenv(
 		openAIHeadersEnvName,
-		"X-One=1, X-Two:2\nX-Three=3",
+		`X-One=1, X-Two:2
+X-Three=3 X-Spaced="Bearer token value" X-Comma='a, b'`,
 	)
 	got, err := resolveOpenAIHeaders(nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string]string{
-		"X-One":   "1",
-		"X-Two":   "2",
-		"X-Three": "3",
+		"X-Comma":  "a, b",
+		"X-One":    "1",
+		"X-Spaced": "Bearer token value",
+		"X-Three":  "3",
+		"X-Two":    "2",
 	}, got)
 
 	t.Setenv(openAIHeadersEnvName, "")
@@ -3856,6 +3859,24 @@ func TestParseHeaderPairs_RejectsEmptyKeyOrValue(t *testing.T) {
 
 	_, err = parseHeaderPairs("X-Token=Bearer abc")
 	require.ErrorContains(t, err, "invalid OPENAI_HEADERS entry")
+}
+
+func TestParseHeaderPairs_QuotedValues(t *testing.T) {
+	got, err := parseHeaderPairs(
+		`Authorization="Bearer abc" X-List='a, b' ` +
+			`X-Escaped="quote \"ok\""`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"Authorization": "Bearer abc",
+		"X-Escaped":     `quote "ok"`,
+		"X-List":        "a, b",
+	}, got)
+}
+
+func TestParseHeaderPairs_RejectsUnterminatedQuote(t *testing.T) {
+	_, err := parseHeaderPairs(`Authorization="Bearer abc`)
+	require.ErrorContains(t, err, "unterminated")
 }
 
 func TestNewModel_OpenAIHeadersRejectsInvalidEnv(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -3755,6 +3755,7 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 	var agentHeader string
 	var providerHeader string
 	var authHeader string
+	var tokenHeader string
 	server := httptest.NewServer(http.HandlerFunc(func(
 		w http.ResponseWriter,
 		r *http.Request,
@@ -3764,6 +3765,7 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 		agentHeader = r.Header.Get("X-SMG-Agent-Name")
 		providerHeader = r.Header.Get("X-SMG-Provider")
 		authHeader = r.Header.Get("Authorization")
+		tokenHeader = r.Header.Get("X-Example-Token")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"id":"chatcmpl-test",
@@ -3792,6 +3794,7 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 		OpenAIHeaders: map[string]string{
 			"X-SMG-Routing-Key": "wineguo",
 			"X-SMG-Agent-Name":  "config-agent",
+			"X-Example-Token":   "Bearer config-token",
 		},
 	})
 	require.NoError(t, err)
@@ -3811,6 +3814,7 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 	require.Equal(t, "env-agent", agentHeader)
 	require.Equal(t, "venus", providerHeader)
 	require.Equal(t, "Bearer test-key", authHeader)
+	require.Equal(t, "Bearer config-token", tokenHeader)
 }
 
 func TestResolveOpenAIHeaders_EnvOnlyAndConfigOnly(t *testing.T) {
@@ -3849,6 +3853,9 @@ func TestParseHeaderPairs_RejectsEmptyKeyOrValue(t *testing.T) {
 
 	_, err = parseHeaderPairs("X-Empty=")
 	require.ErrorContains(t, err, "empty key or value")
+
+	_, err = parseHeaderPairs("X-Token=Bearer abc")
+	require.ErrorContains(t, err, "invalid OPENAI_HEADERS entry")
 }
 
 func TestNewModel_OpenAIHeadersRejectsInvalidEnv(t *testing.T) {
@@ -3859,6 +3866,14 @@ func TestNewModel_OpenAIHeadersRejectsInvalidEnv(t *testing.T) {
 		OpenAIBaseURL: "http://127.0.0.1:1",
 	})
 	require.ErrorContains(t, err, "invalid OPENAI_HEADERS entry")
+}
+
+func TestNewModel_MockIgnoresInvalidOpenAIHeadersEnv(t *testing.T) {
+	t.Setenv(openAIHeadersEnvName, "bad-header")
+	mdl, err := modelFromOptions(runOptions{ModelMode: modeMock})
+
+	require.NoError(t, err)
+	require.Equal(t, "mock-echo", mdl.Info().Name)
 }
 
 func TestNewModel_OpenAI_DebugRecorderWiresRequestCapture(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -3750,6 +3750,117 @@ func TestNewModel_OpenAI(t *testing.T) {
 	require.False(t, hasOpenAIRequestJSONCallback(t, mdl))
 }
 
+func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
+	var routingHeader string
+	var agentHeader string
+	var providerHeader string
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		require.True(t, strings.HasSuffix(r.URL.Path, "/chat/completions"))
+		routingHeader = r.Header.Get("X-SMG-Routing-Key")
+		agentHeader = r.Header.Get("X-SMG-Agent-Name")
+		providerHeader = r.Header.Get("X-SMG-Provider")
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":123,
+			"model":"glm50",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"ok"},
+				"finish_reason":"stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv(
+		openAIHeadersEnvName,
+		"X-SMG-Agent-Name=env-agent X-SMG-Provider=venus",
+	)
+	mdl, err := modelFromOptions(runOptions{
+		ModelMode:     modeOpenAI,
+		OpenAIModel:   "glm50",
+		OpenAIVariant: openAIVariantAuto,
+		OpenAIBaseURL: server.URL,
+		OpenAIHeaders: map[string]string{
+			"X-SMG-Routing-Key": "wineguo",
+			"X-SMG-Agent-Name":  "config-agent",
+		},
+	})
+	require.NoError(t, err)
+
+	ch, err := mdl.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hi")},
+		GenerationConfig: model.GenerationConfig{
+			Stream: false,
+		},
+	})
+	require.NoError(t, err)
+	for rsp := range ch {
+		require.Nil(t, rsp.Error)
+	}
+
+	require.Equal(t, "wineguo", routingHeader)
+	require.Equal(t, "env-agent", agentHeader)
+	require.Equal(t, "venus", providerHeader)
+	require.Equal(t, "Bearer test-key", authHeader)
+}
+
+func TestResolveOpenAIHeaders_EnvOnlyAndConfigOnly(t *testing.T) {
+	t.Setenv(
+		openAIHeadersEnvName,
+		"X-One=1, X-Two:2\nX-Three=3",
+	)
+	got, err := resolveOpenAIHeaders(nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"X-One":   "1",
+		"X-Two":   "2",
+		"X-Three": "3",
+	}, got)
+
+	t.Setenv(openAIHeadersEnvName, "")
+	got, err = resolveOpenAIHeaders(map[string]string{
+		" X-Config ": " value ",
+		" ":          "drop",
+		"X-Empty":    "",
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"X-Config": "value"}, got)
+}
+
+func TestCleanHeaderMap_DropsBlankEntries(t *testing.T) {
+	require.Nil(t, cleanHeaderMap(map[string]string{
+		" ":       "drop",
+		"X-Empty": "",
+	}))
+}
+
+func TestParseHeaderPairs_RejectsEmptyKeyOrValue(t *testing.T) {
+	_, err := parseHeaderPairs("=value")
+	require.ErrorContains(t, err, "empty key or value")
+
+	_, err = parseHeaderPairs("X-Empty=")
+	require.ErrorContains(t, err, "empty key or value")
+}
+
+func TestNewModel_OpenAIHeadersRejectsInvalidEnv(t *testing.T) {
+	t.Setenv(openAIHeadersEnvName, "bad-header")
+	_, err := modelFromOptions(runOptions{
+		ModelMode:     modeOpenAI,
+		OpenAIModel:   "glm50",
+		OpenAIBaseURL: "http://127.0.0.1:1",
+	})
+	require.ErrorContains(t, err, "invalid OPENAI_HEADERS entry")
+}
+
 func TestNewModel_OpenAI_DebugRecorderWiresRequestCapture(
 	t *testing.T,
 ) {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -211,6 +211,7 @@ type runOptions struct {
 	OpenAIModel           string
 	OpenAIVariant         string
 	OpenAIBaseURL         string
+	OpenAIHeaders         map[string]string
 	GenerationConfig      *model.GenerationConfig
 	ModelConfig           *yaml.Node
 	KnowledgesConfig      []knowledgeEntry
@@ -1155,6 +1156,7 @@ type modelConfig struct {
 	Name             *string               `yaml:"name,omitempty"`
 	BaseURL          *string               `yaml:"base_url,omitempty"`
 	OpenAIVariant    *string               `yaml:"openai_variant,omitempty"`
+	Headers          map[string]string     `yaml:"headers,omitempty"`
 	GenerationConfig *generationConfigYAML `yaml:"generation_config,omitempty"`
 	Config           *rawYAMLNode          `yaml:"config,omitempty"`
 }
@@ -1707,6 +1709,9 @@ func (cfg *fileConfig) apply(
 			opts.OpenAIVariant = strings.TrimSpace(
 				*cfg.Model.OpenAIVariant,
 			)
+		}
+		if len(cfg.Model.Headers) > 0 {
+			opts.OpenAIHeaders = cleanHeaderMap(cfg.Model.Headers)
 		}
 		if cfg.Model.Config != nil {
 			opts.ModelConfig = cfg.Model.Config.Node

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -779,6 +779,9 @@ model:
   mode: "mock"
   name: "gpt-5"
   openai_variant: "openai"
+  headers:
+    X-SMG-Routing-Key: "wineguo"
+    X-SMG-Agent-Name: "trpc-claw-benchmark"
 
 gateway:
   allow_users: ["u1","u2"]
@@ -940,6 +943,10 @@ memory:
 	require.Equal(t, modeMock, opts.ModelMode)
 	require.Equal(t, "gpt-5", opts.OpenAIModel)
 	require.Equal(t, "openai", opts.OpenAIVariant)
+	require.Equal(t, map[string]string{
+		"X-SMG-Routing-Key": "wineguo",
+		"X-SMG-Agent-Name":  "trpc-claw-benchmark",
+	}, opts.OpenAIHeaders)
 
 	require.Equal(t, "u1,u2", opts.AllowUsers)
 	require.True(t, opts.RequireMention)

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -20,7 +20,7 @@ model:
   openai_variant: "auto"
   # Optional static headers for OpenAI-compatible gateways. OPENAI_HEADERS
   # can also provide space-, comma-, or newline-separated KEY=VALUE pairs
-  # for simple values without spaces.
+  # and supports quoted values such as Authorization="Bearer token".
   # headers:
   #   X-Example-User: "alice"
   #   X-Example-Token: "Bearer token-with-space"

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -18,6 +18,10 @@ model:
   mode: "openai"
   name: "gpt-5"
   openai_variant: "auto"
+  # Optional static headers for OpenAI-compatible gateways. OPENAI_HEADERS
+  # can also provide space-, comma-, or newline-separated KEY=VALUE pairs.
+  # headers:
+  #   X-Example-User: "alice"
 
 # skills:
 #   extra_dirs:

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -19,9 +19,11 @@ model:
   name: "gpt-5"
   openai_variant: "auto"
   # Optional static headers for OpenAI-compatible gateways. OPENAI_HEADERS
-  # can also provide space-, comma-, or newline-separated KEY=VALUE pairs.
+  # can also provide space-, comma-, or newline-separated KEY=VALUE pairs
+  # for simple values without spaces.
   # headers:
   #   X-Example-User: "alice"
+  #   X-Example-Token: "Bearer token-with-space"
 
 # skills:
 #   extra_dirs:

--- a/openclaw/registry/registry.go
+++ b/openclaw/registry/registry.go
@@ -196,7 +196,9 @@ type ModelSpec struct {
 	Type                 string
 	Name                 string
 	BaseURL              string
+	APIKey               string
 	OpenAIVariant        string
+	Headers              map[string]string
 	DebugRecorderEnabled bool
 
 	Config *yaml.Node


### PR DESCRIPTION
## Summary

- Add OpenClaw model-level OpenAI-compatible request headers via `model.headers`.
- Add `OPENAI_HEADERS` for runtime env injection using `KEY=VALUE` pairs, including quoted values for headers that contain spaces or commas.
- Pass resolved headers into the OpenAI model provider and document the generic gateway setup.

## Validation

- `go test ./app -run 'TestResolveOpenAIHeaders|TestParseHeaderPairs|TestNewModel_OpenAIHeaders'` from `openclaw/`
- `go test ./app` from `openclaw/`
- `go test ./...` from `openclaw/`
- `git diff --check`