### PR TITLE
docs: add sanitized Agent observability and prompt cache blogs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -84,6 +84,8 @@ nav:
   - Blog:
       - "A Go Agent Framework for Building Intelligent AI Applications": blog/trpcagentgo.md
       - "Context Management Design and Evaluation for Long-Running Agents": blog/summary.md
+      - "Seeing the Agent Runtime: Observability Design in tRPC-Agent-Go": blog/observability.md
+      - "Reducing Agent Token Cost: Prompt Cache Engineering in tRPC-Agent-Go": blog/promptcache.md
       - "GraphAgent Seamlessly Combines AI Workflows and Agents": blog/graphagent.md
       - "Quickly Build AG-UI-Based Agent Services": blog/agui.md
       - "A Go-Native Implementation of the Anthropic Agent Skills Specification": blog/skill.md
@@ -184,6 +186,8 @@ plugins:
             - 博客:
                 - "构建智能 AI 应用的 Go 语言 Agent 框架": blog/trpcagentgo.md
                 - "长任务 Agent 上下文管理的设计与评测": blog/summary.md
+                - "看见 Agent 运行时：tRPC-Agent-Go 可观测的设计与取舍": blog/observability.md
+                - "降低 Agent Token 成本：tRPC-Agent-Go 的 Prompt Cache 工程实践": blog/promptcache.md
                 - "GraphAgent 让 AI 工作流与 Agent 无缝融合": blog/graphagent.md
                 - "快速构建基于 AG-UI 的 Agent 服务": blog/agui.md
                 - "Anthropic Agent Skills 规范的 Go 原生实现": blog/skill.md

--- a/docs/mkdocs/en/blog/observability.md
+++ b/docs/mkdocs/en/blog/observability.md
@@ -1,7 +1,5 @@
 # Seeing the Agent Runtime: Observability Design in tRPC-Agent-Go
 
-> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a Go framework for autonomous multi-Agent systems. It provides tool calling, session and memory management, artifact management, multi-Agent collaboration, graph orchestration, knowledge integration, and observability.
->
 > This article focuses on observability in tRPC-Agent-Go. The framework does not try to build another observability platform. Instead, it maps important Agent runtime semantics to OpenTelemetry, so traces, metrics, and GenAI semantic attributes can be consumed by different backends.
 
 When LLM applications move from Chat to Agent, observability changes in a fundamental way.

--- a/docs/mkdocs/en/blog/observability.md
+++ b/docs/mkdocs/en/blog/observability.md
@@ -1,0 +1,241 @@
+# Seeing the Agent Runtime: Observability Design in tRPC-Agent-Go
+
+> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a Go framework for autonomous multi-Agent systems. It provides tool calling, session and memory management, artifact management, multi-Agent collaboration, graph orchestration, knowledge integration, and observability.
+>
+> This article focuses on observability in tRPC-Agent-Go. The framework does not try to build another observability platform. Instead, it maps important Agent runtime semantics to OpenTelemetry, so traces, metrics, and GenAI semantic attributes can be consumed by different backends.
+
+When LLM applications move from Chat to Agent, observability changes in a fundamental way.
+
+In a Chat application, one user request can often be approximated as "one entry request, one model call, and one model response." Traditional service observability can still answer many questions: request rate, latency, error rate, and whether the downstream model call failed.
+
+An Agent request is different. A single user-visible answer may contain multiple model calls, tool calls, multi-Agent handoffs, Graph or Workflow execution, streaming output, token usage, prompt cache effects, and additional reasoning after a tool result is returned. From the user's point of view, there is one answer. At runtime, there is an execution tree.
+
+Agent observability therefore needs to answer more than "was the API slow or failed?" It should answer:
+
+- Which Agents, LLM calls, tools, and workflows did this request go through?
+- Why did the model trigger a tool? What were the arguments and result?
+- Which model call consumed most of the tokens?
+- If the first token was slow, was the model slow, was a tool slow, or was orchestration slow?
+- Did the error happen in the model, a tool, a workflow node, or the Agent boundary?
+- If applications use different observability backends, does the Agent core need to change?
+
+tRPC-Agent-Go telemetry is designed around these questions. Its core decision is to turn Agent runtime semantics into stable OpenTelemetry data rather than to couple the framework to one monitoring product.
+
+A typical Agent trace can be understood as:
+
+```text
+invoke_agent customer_assistant
+├── chat gpt-4o-mini
+│   └── response with tool call
+├── execute_tool search_order
+│   └── tool result
+├── chat gpt-4o-mini
+│   └── final answer
+└── workflow after_reply_summary
+```
+
+This tree decomposes one user request into runtime events that can be inspected, attributed, and aggregated.
+
+## 1. Why Traditional Service Observability Is Not Enough
+
+Traditional service observability usually looks at processes, endpoints, RPC methods, database access, and message queue consumers. These systems often have explicit inputs, outputs, and relatively stable call graphs. Agent runtimes add a layer of probabilistic decision-making.
+
+An Agent path is often not statically written in code. The model may decide whether to call a tool based on user input. The tool result may affect the next model call. A multi-Agent system may delegate work to another Agent or a subgraph. Graphs and workflows make parts of the path controllable, but each node may still contain model calls, tool calls, or streaming output.
+
+This creates three observability challenges.
+
+First, call chains are longer and more dynamic. One entry request may contain multiple LLM round trips, tool calls, and workflow node execution. If you only look at entry latency, you cannot tell where the time went.
+
+Second, cost and quality live inside the request. Token usage, prompt cache hits, completion tokens, finish reason, tool arguments, and tool results are not ordinary RPC metrics, but they directly affect cost, quality, and stability.
+
+Third, debugging needs semantic attribution. A failure may come from a model provider, a tool execution error, invalid tool arguments, a workflow node, or a framework-level cancellation or timeout. Without Agent semantics, a trace becomes a sequence of generic spans that cannot explain what the Agent actually did.
+
+Agent telemetry must therefore make Agent runtime objects first-class observability objects.
+
+## 2. Runtime Observability Design in tRPC-Agent-Go
+
+tRPC-Agent-Go telemetry does not introduce a separate observability platform. It turns runtime boundaries that the framework already understands into stable telemetry data.
+
+For long and dynamic call chains, the framework automatically instruments key Agent runtime boundaries. Applications do not need to manually create spans around every Agent, model, tool, or workflow call. tRPC-Agent-Go creates spans such as `invoke_agent`, `chat`, `execute_tool`, and `workflow` during the Agent lifecycle, so the dynamic path inside one entry request can be reconstructed as a readable tree.
+
+For cost and quality, the framework records both traces and metrics. Traces can show model name, streaming mode, input and output messages, finish reason, tool arguments, and tool results. Metrics can aggregate token usage, time to first token, operation duration, and output token speed.
+
+For semantic attribution, the telemetry model is organized around Agent concepts rather than only HTTP or RPC concepts. tRPC-Agent-Go uses attributes such as `gen_ai.operation.name`, `gen_ai.agent.name`, `gen_ai.tool.name`, and `gen_ai.workflow.name` to describe runtime context. When reading a trace, the operator can immediately tell whether a problem happened in a model call, tool execution, workflow node, or Agent invocation.
+
+For backend flexibility, the framework is based on OpenTelemetry. Traces, metrics, resources, exporters, and collectors reuse the OTel ecosystem. The core framework generates standardized telemetry data; applications decide whether to send it to Jaeger, Prometheus, Langfuse, or another OTel-compatible backend.
+
+In short, tRPC-Agent-Go telemetry is an Agent runtime semantic layer, not an observability product.
+
+## 3. Core Data Model: Traces, Metrics, and Semantic Attributes
+
+This article focuses on two categories of telemetry data: traces and metrics.
+
+Traces describe what happened inside one request. Metrics aggregate many requests into data that can be monitored, alerted on, and analyzed over time.
+
+### Traces: Turning Runtime Execution into a Tree
+
+Several span names are central in tRPC-Agent-Go:
+
+| Span | Meaning | Typical question |
+| --- | --- | --- |
+| `invoke_agent <agent>` | Lifecycle of one Agent invocation | Which Agent was slow, failed, or consumed tokens? |
+| `chat <model>` | One LLM call | Which model was slow? What was TTFT? How many tokens were used? |
+| `execute_tool <tool>` | One tool execution | Which tool was called? What were the arguments and result? Did it fail? |
+| `workflow <name>` | One Graph node or Workflow observable object | Where did the workflow stall? What was the node latency or error? |
+
+These spans are valuable because they come from Agent runtime semantics, not from infrastructure alone. A trace no longer shows only that an HTTP request called a downstream service. It shows that an Agent called a model, the model requested a tool, the tool returned data, and the model continued to generate the final answer.
+
+For a tool call, the `execute_tool` span records context such as tool name, description, arguments, result, and error type. For a model call, the `chat` span records model name, streaming mode, input and output messages, finish reason, token usage, and time to first token. For a workflow, a Graph node is adapted as a `workflow` observable object with workflow name, id, type, request, response, and error status.
+
+### Metrics: Turning Runtime Execution into Governance Signals
+
+Traces are useful for single-request debugging. Production governance also needs aggregate metrics.
+
+| Metric | Focus |
+| --- | --- |
+| `trpc_agent_go.client.request_cnt` | Request count |
+| `gen_ai.client.operation.duration` | Operation duration for LLM, Tool, Agent, Workflow, and related runtime objects |
+| `gen_ai.client.token.usage` | Input, output, and cache-related token counts |
+| `gen_ai.server.time_to_first_token` | Standard GenAI time to first token |
+| `trpc_agent_go.client.time_to_first_token` | Framework-compatible TTFT, currently reported with the same value as the standard metric |
+| `trpc_agent_go.client.time_per_output_token` | Average generation time per output token |
+| `trpc_agent_go.client.output_token_per_time` | Output token throughput |
+| `gen_ai.workflow.elapsed_time` | Relative elapsed time from `root_workflow.start` to `current_workflow.end` |
+
+There are three important details.
+
+First, tRPC-Agent-Go cares about both total duration and streaming experience. For a streaming Agent, user experience depends not only on final completion time but also on time to first token and subsequent token stability.
+
+Second, token usage is a cost signal, a performance signal, and a quality signal. A growing input token count may indicate poor context management. An unexpectedly long output may indicate prompt or tool-result drift. Cache-related tokens help evaluate whether prompt cache optimization is actually working.
+
+Third, workflow metrics distinguish node duration from relative elapsed time. `gen_ai.client.operation.duration` describes how long the current workflow or node ran. `gen_ai.workflow.elapsed_time` describes where the current observable object ended relative to the root workflow start. It is not the sum of all node durations.
+
+### Semantic Attributes: One Data Model for Different Backends
+
+Span and metric names are only part of the data model. Attributes are equally important. tRPC-Agent-Go uses OpenTelemetry GenAI semantic conventions and framework extension fields to describe context:
+
+| Attribute | Meaning |
+| --- | --- |
+| `gen_ai.operation.name` | Operation type such as `chat`, `execute_tool`, `invoke_agent`, or `workflow` |
+| `gen_ai.agent.name` / `gen_ai.agent.id` | Agent name and identifier |
+| `gen_ai.conversation.id` | Conversation or session identifier |
+| `gen_ai.request.model` / `gen_ai.response.model` | Requested and returned model |
+| `gen_ai.input.messages.otel` / `gen_ai.output.messages.otel` | OTel-aligned input and output messages |
+| `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` | Input and output token counts |
+| `gen_ai.tool.name` | Tool name |
+| `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` | Tool arguments and result |
+| `gen_ai.workflow.name` / `gen_ai.workflow.type` | Workflow name and type |
+| `error.type` / `error.message` | Error type and message |
+| `trpc.go.agent.invocation_id` | Invocation identifier inside the framework |
+| `trpc.go.agent.llm_request` / `trpc.go.agent.llm_response` | Framework-retained LLM request and response payloads |
+
+These attributes make telemetry portable. Different backends may visualize them differently, but they can build views around the same runtime facts as long as they understand OTel/GenAI semantics or map these fields.
+
+This table also raises a production question: which payloads should be reported, and which should be redacted, truncated, or disabled? Prompts, responses, tool arguments, tool results, user identifiers, `llm_request`, and `llm_response` may contain sensitive data. Long attributes increase storage cost, and high-cardinality fields can harm metric aggregation. A production integration should define payload switches, redaction rules, attribute size limits, sampling, and cardinality governance together.
+
+## 4. Debugging Example: Slow Time to First Token
+
+Suppose a user reports that a streaming answer takes a long time to start. The entry request can tell us that the request was slow, but Agent telemetry can break it down further.
+
+First, check the total duration and TTFT on `invoke_agent`. If `invoke_agent` is slow but the first `chat` span starts late, the issue is likely in Agent orchestration, a pre-processing workflow, or tool preparation.
+
+Second, expand the trace. If `execute_tool` or a `workflow` span takes most of the time, inspect tool arguments, tool results, workflow type, and error status. If the slow part is concentrated in `chat <model>`, inspect model name, input tokens, streaming mode, TTFT, and finish reason.
+
+Third, combine the trace with aggregate metrics. If only one request is slow, the trace is the primary tool. If one model's `gen_ai.server.time_to_first_token` rises across many requests, or `gen_ai.client.token.usage` shows growing input tokens, the issue may be a provider, context-management, or prompt-design problem.
+
+## 5. Data Pipeline: From Runtime to Observability Backend
+
+tRPC-Agent-Go telemetry can be described in four layers:
+
+```mermaid
+flowchart LR
+    AgentRuntime["Agent Runtime: Agent / LLM / Tool / Workflow"] --> OpenTelemetryAPI["OpenTelemetry API: Tracer / Meter"]
+    OpenTelemetryAPI --> Provider["Provider and Processor: Resource / SpanProcessor / MetricReader"]
+    Provider --> Exporter["Exporter or Collector: OTLP HTTP / OTLP gRPC"]
+    Exporter --> Backend["Backend: Langfuse / Jaeger / Prometheus / OTel-compatible systems"]
+```
+
+From an application point of view, integration usually starts by initializing a tracer provider and a meter provider. Tracing can be configured with endpoint, protocol, service name, resource attributes, headers, and related options. Metrics can be initialized through the tRPC-Agent-Go metric provider helpers. If no provider is initialized, OpenTelemetry's noop behavior avoids export overhead.
+
+From the framework point of view, the Agent runtime automatically creates spans, records attributes, and reports metrics at lifecycle boundaries. It creates `invoke_agent` when an Agent invocation starts, `chat` for model requests, `execute_tool` for tool execution, and `workflow` for Graph or Workflow nodes. These are natural boundaries known by the framework, so application code does not need to duplicate the instrumentation.
+
+From the platform point of view, the destination is not decided by the Agent core. Data can go through OTLP HTTP/gRPC to an OpenTelemetry Collector and fan out to several backends. It can also be exported directly through a backend-specific exporter or plugin. This layering keeps the tRPC-Agent-Go core stable while allowing observability deployment to evolve.
+
+## 6. Engineering Practices for Stable Agent Telemetry
+
+Many telemetry problems do not happen at the "can we create a span?" layer. They happen at the boundaries of large payloads, context propagation, metric definitions, backend limits, and adapter behavior. LLM requests, responses, tool arguments, workflow requests, and workflow responses can cause repeated `json.Marshal` work, memory spikes, or backend-side attribute truncation.
+
+| Engineering issue | Practical direction |
+| --- | --- |
+| Trace context may break across context clone or concurrent tool calls | Preserve OpenTelemetry span context and cover TraceID, SpanID, and parent-child relationships in tests |
+| Large payload collection can cause repeated `json.Marshal` and heap spikes | Use opt-in `SpanAttributePolicy` to control attributes by operation/key; prefer `Drop()` or unconditional `Omit()` when reducing memory is the goal |
+| OTel or backend attribute length limits may truncate large structured attributes | Record truncation diagnostics at the exporter layer and detect signals such as value length, configured limit, and `unexpected EOF` |
+| OTel GenAI semantics continue to evolve | Keep stable semantics in the core and move backend differences into adapters |
+| TTFT, workflow elapsed time, and token usage can drift in definition | Define from/to, success/failure/cache/retry semantics clearly and apply them consistently across `chat`, `invoke_agent`, and `workflow` |
+| Deep Graph or Agent nesting can make traces hard to read | Shape span topology around debugging needs |
+| Tool, error, or application dimensions can harm aggregation if unstable | Stabilize tool ordering and tool call IDs, normalize error labels, and use controlled dimensions for application scenarios |
+
+One subtle point is that "limiting attribute size" and "reducing memory" are different goals. `Drop()` and unconditional `Omit()` can short-circuit before `json.Marshal`, reducing heap pressure. `MaxBytes` plus `Omit()` or `Truncate()` controls the final attribute size written to spans, but JSON serialization may already have happened.
+
+The practical rule is: do not rely only on increasing backend attribute limits. First decide which attributes are worth collecting. Then handle backend limits, truncation diagnostics, and field mapping at the export or adapter layer.
+
+## 7. Tradeoffs and Evolution
+
+Looking at other Agent systems helps explain the tRPC-Agent-Go choice. This is not a ranking. It is a comparison of who records runtime facts and who consumes the data.
+
+| Type | Examples | Observability focus | Reference point for tRPC-Agent-Go |
+| --- | --- | --- | --- |
+| Platform-closed Agent framework | LangChain / LangGraph | LangSmith provides trace, debug, evaluation, monitoring, and feedback loop | Strong platform experience, but framework semantics and platform are more tightly coupled |
+| Standard-semantics Agent framework | Google ADK | Built-in logs, metrics, traces, and OpenTelemetry GenAI semantics | Shows that Agent span standardization is becoming important |
+| Data-sovereignty Agent framework | Agno | Run history, audit logs, and tracing can be stored in user-owned databases or sent through OTel | Local storage and external backend export are different tradeoffs |
+| Go ecosystem component framework | CloudWeGo / Eino | Callback, Handler, and RunInfo expose component and Graph lifecycle | Flexible callbacks need a shared semantic model from users or platform adapters |
+| Code Agent product | OpenAI Codex / Claude Code | Tool approval, command execution, organization cost, audit, and human-Agent collaboration events | Product event streams are different from business Agent service runtime telemetry |
+
+tRPC-Agent-Go is closer to "standard semantics plus server-side framework instrumentation." It does not try to provide a monitoring UI, and it does not only expose callbacks. Instead, it records stable spans, metrics, and attributes directly in the Agent runtime.
+
+This keeps the framework lightweight and backend-agnostic, but it also means applications must define sensitive-data governance for production. Prompts, responses, tool arguments, tool results, and user identifiers may contain sensitive information. Whether to report them, how to redact them, and how to control attribute size and metric cardinality should be explicit deployment decisions.
+
+Future evolution can continue in several directions:
+
+- Track OpenTelemetry GenAI semantic convention changes and reduce drift between custom and standard fields.
+- Add more Agent-level metrics, such as tool success rate, Agent step count, Graph node retry count, and recovery metrics.
+- Refine streaming statistics around reasoning, first token, useful content token, and final completion time.
+- Strengthen sensitive-data governance through payload switches, redaction, attribute size limits, and cardinality controls.
+- Support multi-backend routing through collectors or plugins so the same telemetry can feed both LLMOps and general APM backends.
+
+## Conclusion
+
+Agent observability is not just about adding more logs or wrapping a model request in a span.
+
+The important part is to make the Agent runtime visible: how one request enters an Agent, calls a model, triggers tools, moves through Graph or Workflow nodes, consumes tokens, waits for the first token, fails, and finally gets consumed by different observability backends.
+
+tRPC-Agent-Go first records these runtime semantics and then connects them to different backends through OpenTelemetry. It does not put an observability platform into the framework core, and it does not leave the entire Agent execution process for applications to instrument manually.
+
+That is the meaning of seeing the Agent runtime: not a prettier trace page, but Agent services that are explainable, debuggable, measurable, and governable in production.
+
+## References
+
+- [tRPC-Agent-Go GitHub](https://github.com/trpc-group/trpc-agent-go)
+- [tRPC-Agent-Go documentation site](https://trpc-group.github.io/trpc-agent-go/)
+- [tRPC-Agent-Go Observability documentation](https://github.com/trpc-group/trpc-agent-go/blob/main/docs/mkdocs/en/observability.md)
+- [tRPC-Agent-Go Langfuse example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/telemetry/langfuse)
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
+- [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [LangSmith Observability](https://docs.langchain.com/langsmith/observability)
+- [LangGraph Observability](https://docs.langchain.com/oss/python/langgraph/observability)
+- [LangSmith Trace with OpenTelemetry](https://docs.langchain.com/langsmith/trace-with-opentelemetry)
+- [Google ADK Observability](https://adk.dev/observability/)
+- [Google ADK Traces](https://adk.dev/observability/traces/)
+- [Google ADK Metrics](https://adk.dev/observability/metrics/)
+- [Google Cloud: Instrument ADK applications with OpenTelemetry](https://docs.cloud.google.com/stackdriver/docs/instrumentation/ai-agent-adk)
+- [Agno Tracing](https://docs.agno.com/tracing/overview)
+- [Agno Agent Observability](https://docs.agno.com/features/observability)
+- [Agno OpenTelemetry Observability](https://docs.agno.com/observability/overview)
+- [CloudWeGo Eino Callback Manual](https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/callback_manual/)
+- [CloudWeGo Eino Callback and Trace](https://www.cloudwego.io/docs/eino/quick_start/chapter_06_callback_and_trace/)
+- [CloudWeGo Eino Open Source Overview](https://www.cloudwego.io/docs/eino/overview/eino_open_source/)
+- [OpenAI Codex Advanced Configuration: Observability and Telemetry](https://developers.openai.com/codex/config-advanced)
+- [Claude Code Monitoring](https://code.claude.com/docs/en/monitoring-usage)
+- [Claude Code Agent SDK Observability](https://code.claude.com/docs/en/agent-sdk/observability)
+- [Langfuse OpenTelemetry Integration](https://langfuse.com/integrations/native/opentelemetry)
+- [Langfuse Self Hosting](https://langfuse.com/self-hosting)

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -1,7 +1,5 @@
 # Reducing Agent Token Cost: Prompt Cache Engineering in tRPC-Agent-Go
 
-> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a Go framework for autonomous multi-Agent systems. It provides tool calling, session and memory management, artifact management, multi-Agent collaboration, graph orchestration, knowledge integration, and observability.
->
 > This article focuses on Prompt Cache. Prompt Cache is not a local KV store inside the framework. It is a model-service capability that reuses stable prompt prefixes. The engineering work in tRPC-Agent-Go is to shape Agent requests as "stable prefix + dynamic suffix" whenever possible, improving cache-hit probability and reducing the cost of reusable input tokens.
 
 When LLM applications enter the Agent stage, each request becomes longer.

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -211,7 +211,7 @@ When customizing the fork prompt with `summary.WithCacheSafeForkPrompt(...)`, do
 
 **Risk**: Current time is a common Prompt Cache trap. If every request writes a full timestamp into the system message, the prefix changes every second.
 
-**Framework behavior**: tRPC-Agent-Go keeps the existing `WithAddCurrentTime` entry point but changes the default semantics to date-level context. If the model needs precise time, it can call the built-in `environment_context_current_time` tool.
+**Framework behavior**: tRPC-Agent-Go keeps the existing `WithAddCurrentTime` entry point but changes the default semantics to date-level context. When tools are available, the model can call the built-in `environment_context_current_time` tool for precise time. Legacy `WithOutputSchema` disables all tools, including this one; if you need both structured output and the exact-time tool, use `WithStructuredOutputJSONSchema` or `WithStructuredOutputJSON`.
 
 ```go
 agent := llmagent.New(
@@ -307,7 +307,7 @@ Recommended capabilities:
 | `llmagent.WithSkillsLoadedContentInToolResults(true)` | system message / tool result | Moves loaded Skill content from system message into matching tool results |
 | `summary.WithCacheSafeForking(true)` | summary generation request | Clones the parent request and appends a compaction message, reusing the parent prefix |
 | `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | near history | Reduces prefix rewrite when summary changes frequently, with trimming tradeoff |
-| `llmagent.WithAddCurrentTime(true)` default date-only | system message / time tool | Date-level context is stable; precise time is available through `environment_context_current_time` |
+| `llmagent.WithAddCurrentTime(true)` default date-only | system message / time tool | Date-level context is stable; precise time is available through `environment_context_current_time` when tools are enabled. Legacy `WithOutputSchema` disables this tool |
 | `agent.WithModelRequestExtraFields` with `prompt_cache_key` | request body | A stable key may help providers route similar long-prefix requests |
 | default `llmagent.WithReasoningContentMode` | assistant history | Drops historical reasoning content by default, reducing unnecessary input tokens |
 
@@ -456,7 +456,7 @@ This is still only an example run, not an SLA. Model output length and history m
 
 - [ ] Put current user input, tool results, temporary RAG snippets, and exact current time later in the request.
 - [ ] Control loaded Skills residency and prefer `WithSkillsLoadedContentInToolResults(true)`.
-- [ ] Use date-level current-time context by default. Use `environment_context_current_time` when precise time is needed.
+- [ ] Use date-level current-time context by default. Use `environment_context_current_time` when precise time is needed and tools are enabled; use `WithStructuredOutputJSONSchema` or `WithStructuredOutputJSON` instead of legacy `WithOutputSchema` if structured output also needs tools.
 
 ### Long Sessions
 

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -1,0 +1,527 @@
+# Reducing Agent Token Cost: Prompt Cache Engineering in tRPC-Agent-Go
+
+> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) is a Go framework for autonomous multi-Agent systems. It provides tool calling, session and memory management, artifact management, multi-Agent collaboration, graph orchestration, knowledge integration, and observability.
+>
+> This article focuses on Prompt Cache. Prompt Cache is not a local KV store inside the framework. It is a model-service capability that reuses stable prompt prefixes. The engineering work in tRPC-Agent-Go is to shape Agent requests as "stable prefix + dynamic suffix" whenever possible, improving cache-hit probability and reducing the cost of reusable input tokens.
+
+When LLM applications enter the Agent stage, each request becomes longer.
+
+In a simple Chat application, the model may only see a system prompt and a few conversation turns. In an Agent application, the request prefix often contains tool schemas, structured output schemas, Skills or RAG context, historical tool calls, and tool results. A single user request may trigger multiple model calls. These calls contain a large amount of repeated content, which is where Prompt Cache becomes valuable.
+
+This article covers four topics:
+
+- Why Prompt Cache helps Agent response latency and token cost.
+- How to understand `cached_tokens` and `prompt_cache_key` in OpenAI-compatible APIs.
+- How tRPC-Agent-Go reduces cache invalidation around system prompts, tools, Skills, summary, time, and post-tool prompts.
+- Which options are recommended and which dynamic capabilities should be used carefully.
+
+The configuration and examples mainly use OpenAI-compatible APIs as the reference shape. Anthropic's explicit `cache_control` mechanism is discussed in the appendix. An OpenAI-compatible API means a service that follows the request and response shape of OpenAI Chat Completions or similar APIs. Compatibility with the protocol does not imply that every provider supports the same Prompt Cache behavior. `cached_tokens`, `prompt_cache_key`, cache thresholds, TTL, and pricing rules should always be confirmed with the actual provider.
+
+## 1. Prompt Cache Value for Agents: Lower Latency and Lower Cost
+
+Prompt Cache has two direct values for Agents:
+
+1. When repeated prefixes are reused by the service, the Agent often sees lower time to first token or lower overall response latency.
+2. Many model services price cached input tokens lower than uncached input tokens.
+
+For example, the [DeepSeek pricing page](https://api-docs.deepseek.com/zh-cn/quick_start/pricing), checked on 2026-06-09, lists different prices for cached input, uncached input, and output tokens:
+
+| Model | Cached input | Uncached input | Output |
+| --- | --- | --- | --- |
+| `deepseek-v4-flash` | 0.02 CNY / 1M tokens | 1 CNY / 1M tokens | 2 CNY / 1M tokens |
+| `deepseek-v4-pro` | 0.025 CNY / 1M tokens | 3 CNY / 1M tokens | 6 CNY / 1M tokens |
+
+Under this pricing, cached input for `deepseek-v4-flash` is 1/50 of uncached input, and cached input for `deepseek-v4-pro` is 1/120 of uncached input. In Agent scenarios with long system prompts, stable tools, and multi-turn history, reusable prefix tokens can therefore reduce input cost significantly.
+
+Two caveats matter. First, this is only an example pricing structure showing why cached tokens can be cheaper. Other providers may use different discounts and rules. Second, Prompt Cache reduces the cost of reusable input tokens. It does not remove all input cost, and it does not change output token pricing.
+
+## 2. Prompt Cache Is Provider-Side Prefix Reuse
+
+Prompt Cache can be understood from Transformer inference. The [Hugging Face Transformers KV cache documentation](https://huggingface.co/docs/transformers/en/kv_cache) explains that autoregressive generation proceeds token by token and can reuse already computed key/value states.
+
+That explains why reusing processed prefixes is technically meaningful. At the API layer, however, Prompt Cache should not be equated with one specific KV-cache implementation. A more practical definition is:
+
+> Prompt Cache is a model-service capability that reuses already processed prompt prefixes. It may reuse intermediate states or provider-side cache results. The cache medium, matching granularity, retention time, and pricing are provider-specific.
+
+For OpenAI-compatible APIs that support Prompt Cache, the service checks whether the current prompt prefix has been processed before. If it hits, the response may include `usage.prompt_tokens_details.cached_tokens`, which reports how many prompt tokens were reused from cache. [OpenAI Prompt Caching](https://developers.openai.com/api/docs/guides/prompt-caching) also emphasizes a key practice: put static content at the beginning of the prompt and dynamic content later.
+
+This also defines the boundary of `prompt_cache_key`. It is not the cache content itself, and it is not required to enable Prompt Cache. Without `prompt_cache_key`, the service may still cache and reuse prompt prefixes automatically. `prompt_cache_key` is better understood as an auxiliary routing hint. When many requests share the same long prefix category, a stable cache key may help the provider route them in a way that improves reuse. If the key contains request IDs, trace IDs, or timestamps, it reduces reuse opportunities.
+
+[DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/) describes the same idea from another OpenAI-compatible service shape: when later requests overlap with earlier prefixes, the overlapping part may be read from cache. Multi-turn chat and long-document Q&A examples are both forms of prefix reuse.
+
+## 3. Why Agents Need Prompt Cache
+
+Agent requests naturally contain large stable prefixes. A typical LLM Agent request may include:
+
+- system prompt, global instruction, and Agent identity.
+- tool schema, function declarations, and structured output schema.
+- Skills overview, capability descriptions, or fixed workflow instructions.
+- session history, previous tool calls, and previous tool results.
+- RAG, memory, or workspace context.
+
+Multi-turn conversations naturally form "old context + new message":
+
+```text
+turn 1: system + tools + user_1
+turn 2: system + tools + user_1 + assistant_1 + user_2
+turn 3: system + tools + user_1 + assistant_1 + user_2 + assistant_2 + user_3
+```
+
+From the second turn onward, the new request includes most of the previous content. If system messages, tools, and history are not rewritten, the provider has a chance to reuse those prefixes.
+
+Tool call and ReAct flows amplify this. One user request may trigger several model calls: the first call decides which tool to call; the second call receives the tool result and continues reasoning; later calls may call more tools. Every model call repeats system prompts, tools, and accumulated context. The longer and more stable the prefix is, the larger the Prompt Cache opportunity. If dynamic content frequently interrupts the prefix, the hit rate drops.
+
+The Agent framework therefore should not implement model-side caching. Its job is to shape requests for cache-friendly prefix reuse:
+
+```text
+recommended shape:
+[stable prefix] system / instruction / tools / schema / stable skills overview
+              + session history / previous tool call / previous tool result
+[dynamic suffix] current user message / current tool result / current time / temporary context
+
+avoid:
+system / instruction being rewritten by summary, exact time, RAG snippets, or temporary user state
+```
+
+tRPC-Agent-Go Prompt Cache optimizations are built around this shape.
+
+## 4. How tRPC-Agent-Go Shapes Cache-Friendly Requests
+
+tRPC-Agent-Go does not store model KV locally and does not replace provider Prompt Cache. It organizes requests so stable content appears early and remains stable, dynamic content appears later, and ordering is deterministic.
+
+Three terms are easy to mix up:
+
+- `system prompt` means the system rules text, such as Agent identity, response style, or post-tool guidance.
+- `system message` means a request message with `role=system`.
+- `model request prefix` means the continuous prefix seen by the model service. It may include system messages, instruction, tools, schema, and stable history.
+
+The relationship is: system prompt is usually written into a system message; the system message and other stable structures form the model request prefix. Prompt Cache cares about whether the full prefix is stable, so both content and position matter.
+
+The main handling points are:
+
+| Area | What the framework does | Cache invalidation reduced |
+| --- | --- | --- |
+| Request processors | Build instruction / system / Skills overview first, then append history, tool results, and time | Avoids dynamic content entering the prefix too early |
+| Request prefix | Merge global instruction and instruction into an early prefix | Avoids rule and identity position drift |
+| Message ordering | The OpenAI-compatible adapter can move system messages to the front | Keeps stable system messages early for automatic prefix cache |
+| Tools | Cache the tools snapshot inside one invocation and sort converted tools by name | Avoids random tool ordering or map iteration effects |
+| Post-tool guidance | Inject stable post-tool guidance from the first model request when tools exist | Avoids rewriting the prefix only after the first tool result |
+| Skills | Prefer materializing loaded Skill content into tool results | Avoids dynamic Skill content polluting the prefix |
+| Summary generation | Cache-safe forking reuses the parent request prefix and appends only a compaction user message | Avoids reorganizing the summary request from scratch |
+| Summary injection | Summary can be injected near user/history messages | Avoids rewriting the prefix when summary updates frequently |
+| Current time | Date-only context by default; exact time through a tool | Avoids changing the prefix every second |
+
+### Request Processors: Stable Content First
+
+**Risk**: Agent requests are assembled from instruction, Skills, history, tool results, time, and other context. If dynamic content enters the prefix too early, later stable content can no longer be reused effectively.
+
+**Framework behavior**: `LLMAgent` constructs model requests through processors. Instruction runs early and merges global instruction / instruction into the system message. Skills overview and load state are added. Conversation and context history are appended. Post-tool guidance is injected early for tool-enabled Agents. Loaded Skill content is moved into matching tool results when possible. Time processing runs later, and the default current-time behavior uses date-level context while exact time is available through a tool.
+
+**Suggestion**: Applications should follow the same order. Stable rules, identity, tools, and capability descriptions should stay early. Current user input, tool results, temporary retrieval snippets, and precise time should stay later.
+
+### Request Prefix: Stable System Rules
+
+**Risk**: System prompt is usually part of the most valuable cache prefix. If user state, retrieval results, or precise time are written into the system message every turn, later stable history cannot be reused well.
+
+**Framework behavior**: `InstructionRequestProcessor` finds an existing system message or creates one at the beginning of `req.Messages`. It merges system prompt and instruction into that message, keeping global rules early and stable.
+
+**Suggestion**: Treat instruction as long-lived rules, not per-turn context. Per-turn information belongs later in user, history, or tool-result messages.
+
+### Message Ordering: Move System Messages to the Front
+
+**Risk**: If system messages appear in unstable positions or are interleaved with history, automatic prefix cache has less stable content to reuse.
+
+**Framework behavior**: `model/openai` provides `openai.WithOptimizeForCache`. It is enabled by default for `VariantOpenAI`. When enabled, the adapter moves system messages to the front before sending the request.
+
+**Suggestion**: This is not explicit cache creation. It is a cache-friendly request layout for OpenAI-compatible APIs. Keep it enabled unless the application strictly depends on original message order:
+
+```go
+llm := openai.New("your-model",
+    openai.WithOptimizeForCache(false),
+)
+```
+
+### Tools: Stable Tool Sets and Ordering
+
+**Risk**: Tool schemas are often large static blocks in Agent requests. Unstable tool ordering, dynamic filtering, or random map iteration can break prefix reuse.
+
+**Framework behavior**: tRPC-Agent-Go stabilizes tools at two layers. The flow layer caches the final visible tool list inside one invocation. Filtered tools are sorted by name. The OpenAI-compatible adapter also sorts tool names before converting them to the OpenAI-compatible `tools` parameter.
+
+**Suggestion**: The framework stabilizes order, but the application still controls the tool surface. Use dynamic filters, `WithRefreshToolSetsOnRun(true)`, and dynamic MCP tool lists carefully. If dynamic tools are required, bucket requests by scenario so similar requests see stable tool sets.
+
+### Post-Tool Guidance: Inject Early and Stably
+
+**Risk**: After a tool call, the model sees a `role=tool` result. A framework may add post-tool guidance to make the final answer natural. If that guidance is appended to the system message only after the first tool result, the prefix changes in the middle of the request flow.
+
+**Framework behavior**: tRPC-Agent-Go injects post-tool guidance stably from the first model request when an Agent has a potential tool surface. Later ReAct or tool-loop rounds do not rewrite the prefix just because a tool result has appeared.
+
+**Suggestion**: Use `llmagent.WithPostToolPrompt("...")` for custom guidance or `llmagent.WithEnablePostToolPrompt(false)` to disable it. Custom prompts should be stable by Agent or version. Per-request temporary requirements should go into tool results or later user/history messages.
+
+### Skills: Put Dynamic Content into Tool Results
+
+**Risk**: Loaded Skill body or selected docs often vary by task. If they are appended to the system message every turn, the request prefix changes frequently.
+
+**Framework behavior**: `llmagent.WithSkillsLoadedContentInToolResults(true)` moves loaded Skill content into matching `skill_load` or `skill_select_docs` tool results when possible, instead of adding it to the system message.
+
+**Suggestion**: This does not reduce context. It puts dynamic context in a better location. For task-specific Skill content, enable this option and control residency with `WithSkillLoadMode(...)` and `WithMaxLoadedSkills(...)`:
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithSkillsLoadedContentInToolResults(true),
+    llmagent.WithSkillLoadMode(llmagent.SkillLoadModeTurn),
+    llmagent.WithMaxLoadedSkills(8),
+)
+```
+
+### Summary Generation: Cache-Safe Forking
+
+**Risk**: Long sessions often need summary or compaction. Summary generation itself can destroy cache reuse if it sends a completely separate prompt containing the whole conversation.
+
+**Framework behavior**: tRPC-Agent-Go provides optional cache-safe summary forking. The summary request can clone the parent model request and append only a compaction user message:
+
+```text
+parent request:
+system + tools + stable context + history_1...history_N + new_user_message
+
+cache-safe compaction fork:
+system + tools + stable context + history_1...history_N + compact_user_message
+```
+
+**Suggestion**: This is opt-in to preserve compatibility and support cases where the summary model differs from the main Agent model. For long sessions using the same model and sensitive to Prompt Cache, evaluate:
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithContextThreshold(),
+    summary.WithMaxSummaryWords(200),
+    summary.WithCacheSafeForking(true),
+)
+```
+
+When customizing the fork prompt with `summary.WithCacheSafeForkPrompt(...)`, do not include `{conversation_text}` again. The parent request already contains the conversation prefix.
+
+### Summary Injection: Avoid Rewriting the Prefix
+
+**Risk**: After a summary is generated, ordinary requests still need to decide where to inject it. System injection keeps summary in the preserved head, but frequent summary updates rewrite the early prefix.
+
+**Framework behavior**: Cache-sensitive scenarios can use `WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` to place the summary near the first user/history/current message. This keeps the prefix more stable, at the cost that summary may participate in token-budget trimming.
+
+**Suggestion**: Use system injection when preserved-head authority matters more. Use user/history injection when prefix stability matters more. Cache-safe forking optimizes summary generation; injection mode optimizes ordinary requests after summary exists.
+
+### Current Time: Date-Level Context and Exact-Time Tool
+
+**Risk**: Current time is a common Prompt Cache trap. If every request writes a full timestamp into the system message, the prefix changes every second.
+
+**Framework behavior**: tRPC-Agent-Go keeps the existing `WithAddCurrentTime` entry point but changes the default semantics to date-level context. If the model needs precise time, it can call the built-in `environment_context_current_time` tool.
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithAddCurrentTime(true),
+)
+```
+
+**Suggestion**: The default date-only path is more cache-friendly. If you explicitly configure a full time format such as `WithTimeFormat("2006-01-02 15:04:05 MST")`, the old full timestamp behavior is still available, but it changes the request prefix more often.
+
+## 5. What Users Can Configure and Observe
+
+Prompt Cache hits happen on the model-service side, but users can still control request shape, pass provider-specific parameters, and observe cache effects through tRPC-Agent-Go.
+
+### Configure Cache-Friendly Request Shape
+
+With the default `VariantOpenAI` configuration, the OpenAI-compatible adapter optimizes message ordering for cache:
+
+```go
+llm := openai.New("your-model")
+```
+
+If using another provider variant, check whether `openai.WithOptimizeForCache(true)` should be enabled. If the application depends on original message order, disable it:
+
+```go
+llm := openai.New("your-model",
+    openai.WithOptimizeForCache(false),
+)
+```
+
+Dynamic Skills content should go into tool results:
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithSkillsLoadedContentInToolResults(true),
+    llmagent.WithSkillLoadMode(llmagent.SkillLoadModeTurn),
+    llmagent.WithMaxLoadedSkills(8),
+)
+```
+
+For long-session summary, consider both summary generation and summary injection:
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithContextThreshold(),
+    summary.WithMaxSummaryWords(200),
+    summary.WithCacheSafeForking(true),
+)
+```
+
+Use user/history injection when you want to avoid rewriting the first system message:
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithAddSessionSummary(true),
+    llmagent.WithSessionSummaryInjectionMode(llmagent.SessionSummaryInjectionUser),
+)
+```
+
+Memory preload and session recall preload default to system context for compatibility. Cache-sensitive scenarios can evaluate user/history modes:
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithPreloadMemory(10),
+    llmagent.WithPreloadMemoryInjectionMode(llmagent.PreloadMemoryInjectionUser),
+    llmagent.WithPreloadSessionRecall(5),
+    llmagent.WithPreloadSessionRecallInjectionMode(llmagent.PreloadSessionRecallInjectionUser),
+)
+```
+
+Post-tool guidance is stable by default when tools exist:
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithPostToolPrompt("Answer naturally based on tool results."),
+    // llmagent.WithEnablePostToolPrompt(false),
+)
+```
+
+### Prompt Cache Impact Quick Reference
+
+Recommended capabilities:
+
+| Feature / option | Main location | Reason |
+| --- | --- | --- |
+| `openai.WithOptimizeForCache` | message order | Moves system messages to the front under default `VariantOpenAI`, improving automatic prefix cache |
+| default post-tool guidance / `llmagent.WithPostToolPrompt` | system message | Injected from the first model request when tools exist; custom prompt should be stable by Agent/version |
+| `llmagent.WithSkillsLoadedContentInToolResults(true)` | system message / tool result | Moves loaded Skill content from system message into matching tool results |
+| `summary.WithCacheSafeForking(true)` | summary generation request | Clones the parent request and appends a compaction message, reusing the parent prefix |
+| `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | near history | Reduces prefix rewrite when summary changes frequently, with trimming tradeoff |
+| `llmagent.WithAddCurrentTime(true)` default date-only | system message / time tool | Date-level context is stable; precise time is available through `environment_context_current_time` |
+| `agent.WithModelRequestExtraFields` with `prompt_cache_key` | request body | A stable key may help providers route similar long-prefix requests |
+| default `llmagent.WithReasoningContentMode` | assistant history | Drops historical reasoning content by default, reducing unnecessary input tokens |
+
+Dynamic capabilities to use carefully:
+
+| Feature / option | Main location | Prompt Cache impact | Suggestion |
+| --- | --- | --- | --- |
+| `llmagent.WithToolFilter` / `agent.WithToolFilter` | tools schema | Different filter results change the tool prefix | Keep filtering deterministic; bucket similar tool sets |
+| `llmagent.WithRefreshToolSetsOnRun(true)` | tools schema | Re-fetching tools can change the visible tool surface | Fix the tool surface in cache-sensitive paths when possible |
+| `llmagent.WithSkillLoadMode` / `WithMaxLoadedSkills` | loaded Skills context | Affects how long dynamic Skill content stays in context | Control residency and size |
+| `llmagent.WithPreloadMemory` / `WithPreloadSessionRecall` | system message or history | Query-dependent recall in system message rewrites the prefix | Prefer user/history injection in cache-sensitive scenarios |
+| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message | Full timestamp changes frequently | Use only when exact time must be in system context |
+| dynamic `WithPostToolPrompt` | system message | Turns stable guidance into a dynamic prefix | Keep it stable; put temporary instructions later |
+| `agent.WithInjectedContextMessages` / `WithLateContextMessages` | near history | Injected messages can appear before stable history | Prefer late injection for temporary context |
+| `BeforeModel` / `EventMessageProjector` | any request message | Can rewrite system, tools, or history | Prefer append-only changes near the end |
+| dynamic structured output schema | schema | Schema name, order, or description changes affect prefix | Version and stabilize schemas |
+
+### Passing `prompt_cache_key`
+
+If the provider supports `prompt_cache_key`, pass it through request-level extra fields:
+
+```go
+events, err := r.Run(
+    ctx,
+    "user-001",
+    "session-001",
+    model.NewUserMessage("Hello"),
+    agent.WithModelRequestExtraFields(map[string]any{
+        "prompt_cache_key": cacheKey,
+    }),
+)
+```
+
+Request-level extra fields take precedence over model-level extra fields. The OpenAI-compatible adapter merges model-level `extraFields` first and then `request.ExtraFields`, so request-level values override matching keys.
+
+`prompt_cache_key` should describe a reusable prefix category, for example:
+
+```text
+app:customer-support:v3:tenant-basic-tools
+app:code-review:v5:go-tools
+```
+
+Do not use request IDs, trace IDs, or timestamps.
+
+### Observing Cache Hit Rate
+
+For OpenAI-compatible APIs, the main observation field is `cached_tokens`:
+
+```go
+cached := usage.PromptTokensDetails.CachedTokens
+prompt := usage.PromptTokens
+hitRate := float64(cached) / float64(prompt)
+```
+
+tRPC-Agent-Go defines provider-agnostic usage fields in the `model` package:
+
+- `model.Usage.PromptTokens`
+- `model.Usage.PromptTokensDetails.CachedTokens`
+- `model.Usage.PromptTokensDetails.CacheReadTokens`
+- `model.Usage.PromptTokensDetails.CacheCreationTokens`
+
+For OpenAI-compatible APIs, `CachedTokens` is the main field. `CacheReadTokens` and `CacheCreationTokens` primarily serve explicit cache mechanisms such as Anthropic Prompt Caching.
+
+Telemetry also splits token types:
+
+- `input`
+- `input_cached`
+- `input_cache_read`
+- `input_cache_creation`
+- `output`
+
+A simple aggregate view is:
+
+```text
+total_prompt_tokens = sum(usage.prompt_tokens)
+total_cached_tokens = sum(usage.prompt_tokens_details.cached_tokens)
+requests_with_cache = count(cached_tokens > 0)
+overall_hit_rate = total_cached_tokens / total_prompt_tokens
+```
+
+Cost savings should be estimated with the actual provider pricing and billing rules.
+
+## 6. Experiment Results and Reproduction
+
+The main repository notes that benchmark suites have moved to [trpc-agent-go-benchmark](https://github.com/trpc-group/trpc-agent-go-benchmark). Suites such as `anthropic_skills` and `summary` cover token usage, Prompt Cache, and summary behavior. For a lightweight mechanism demo, `examples/promptcache/openai` in the main repository is easier to run. To observe current-time context specifically, see `examples/promptcache/timeprocessor`.
+
+The following provider-neutral sample run illustrates how to compare requests with and without `prompt_cache_key`:
+
+```text
+case                 requests  requests_with_cache  prompt_tokens  cached_tokens  overall_cache_rate
+without cache key    6         4                    13012          8000           61.48%
+with cache key       6         5                    13918          10112          72.65%
+```
+
+The conclusion is not that "a key always improves by this amount." The useful observations are:
+
+First, Prompt Cache can hit without `prompt_cache_key`. Stable prefixes are still the foundation.
+
+Second, a stable `prompt_cache_key` may improve hit probability. In this run, hit requests increased from 4 to 5 and the overall cache rate increased from 61.48% to 72.65%.
+
+Third, tool calls do not prevent cache hits. Calculator and time-tool turns can still reuse the stable prefix made of system messages, tools, and history.
+
+Reproduction outline:
+
+- Prepare a long system prompt that exceeds the provider's cache threshold.
+- Use the same session for 6 conversation turns.
+- Mix normal Q&A, calculator tool calls, and time tool calls.
+- Record prompt tokens, cached tokens, hit rate, and whether a tool call happened on each turn.
+- Aggregate total prompt tokens, total cached tokens, hit requests, and overall hit rate.
+
+Per-turn sample without `prompt_cache_key`:
+
+```text
+turn  prompt_tokens  cached_tokens  hit_rate  note
+1     1592           0              0.00%     cache warmup
+2     2077           0              0.00%     calculator tool
+3     2167           1984           91.56%    time tool
+4     2105           1792           85.13%    normal QA
+5     2574           2048           79.56%    calculator tool
+6     2497           2176           87.14%    normal QA
+```
+
+Per-turn sample with a stable `prompt_cache_key`:
+
+```text
+turn  prompt_tokens  cached_tokens  hit_rate  note
+1     1592           0              0.00%     cache warmup
+2     2239           1152           51.45%    calculator tool
+3     2329           2112           90.68%    time tool
+4     2267           2048           90.34%    normal QA
+5     2784           2240           80.46%    calculator tool
+6     2707           2560           94.57%    normal QA
+```
+
+This is still only an example run, not an SLA. Model output length and history may differ between runs, so prompt token counts may not match exactly. Prompt Cache is a best-effort provider capability affected by routing, retention time, request frequency, cache threshold, and exact prefix stability.
+
+## 7. Practice Checklist
+
+### Stable Prefix
+
+- [ ] Keep system prompt as long-lived rules. Do not put per-turn user state, exact time, or retrieval snippets at the front of system messages.
+- [ ] Keep tool schemas, tool lists, and structured output schemas stable. Dynamic tool filtering should be deterministic for similar requests.
+- [ ] Keep post-tool guidance stable by Agent or version. Do not generate it per request.
+
+### Dynamic Content Later
+
+- [ ] Put current user input, tool results, temporary RAG snippets, and exact current time later in the request.
+- [ ] Control loaded Skills residency and prefer `WithSkillsLoadedContentInToolResults(true)`.
+- [ ] Use date-level current-time context by default. Use `environment_context_current_time` when precise time is needed.
+
+### Long Sessions
+
+- [ ] Choose summary injection based on preserved-head authority versus cache friendliness.
+- [ ] Enable `summary.WithCacheSafeForking(true)` for long sessions that can reuse the parent request prefix.
+- [ ] If memory or session recall content changes by query, evaluate user/history injection modes.
+
+### Routing and Observation
+
+- [ ] Make `prompt_cache_key` describe a reusable prefix category, not request uniqueness.
+- [ ] Observe `cached_tokens`, requests with cache, and overall hit rate. Estimate savings with provider pricing.
+- [ ] Do not overstate benefits for short sessions, low-frequency traffic, or frequently changing context.
+
+### Extension Points
+
+- [ ] Use `BeforeModel`, `EventMessageProjector`, and injected context messages carefully. Prefer append-only changes near the end of the request.
+
+## Appendix: Anthropic Explicit Cache Breakpoints
+
+Anthropic API follows the same principle: stable prefixes are reusable. The API shape is different.
+
+OpenAI-compatible APIs usually provide automatic prefix cache: the service checks prompt prefixes and reports `cached_tokens`, optionally using `prompt_cache_key` as a routing hint.
+
+Anthropic provides explicit `cache_control` breakpoints. [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) explains that cache covers the prompt from `tools` and `system` through the marked block in `messages`. Static content should be placed first, with a breakpoint at the end of reusable content.
+
+tRPC-Agent-Go's Anthropic adapter provides related options:
+
+- `anthropic.WithCacheSystemPrompt(true)`
+- `anthropic.WithCacheTools(true)`
+- `anthropic.WithCacheMessages(true)`
+
+`examples/promptcache/anthropic` can be used as an appendix experiment:
+
+| Phase | Configuration | Observation |
+| --- | --- | --- |
+| Phase 1 | `WithCacheSystemPrompt(true)` | Whether system prompt is read from cache |
+| Phase 2 | `WithCacheSystemPrompt(true)` + `WithCacheTools(true)` | Whether tool definitions enter the cache range |
+| Phase 3 | system + tools + `WithCacheMessages(true)` | Whether multi-turn message breakpoints move forward and `cache_read` grows |
+
+The appendix helps explain API differences. The main practice still uses OpenAI-compatible APIs and `cached_tokens` as the primary example shape.
+
+## References
+
+- [Hugging Face Transformers: Cache strategies / KV cache](https://huggingface.co/docs/transformers/en/kv_cache)
+- [OpenAI Prompt Caching](https://developers.openai.com/api/docs/guides/prompt-caching)
+- [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/)
+- [DeepSeek Pricing](https://api-docs.deepseek.com/zh-cn/quick_start/pricing)
+- [Lessons from building Claude Code: Prompt caching is everything](https://claude.com/blog/lessons-from-building-claude-code-prompt-caching-is-everything)
+- [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
+- [Anthropic Prompt Caching Cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/misc/prompt_caching.ipynb)
+- [DeepSeek API introduces Context Caching on Disk](https://api-docs.deepseek.com/news/news0802)
+- [trpc-agent-go-benchmark](https://github.com/trpc-group/trpc-agent-go-benchmark)
+- [tRPC-Agent-Go source](https://github.com/trpc-group/trpc-agent-go) package references:
+  - `agent/llmagent`: LLM Agent options, request processors, and Skills-related configuration.
+  - `agent`: run options and request-level extra fields.
+  - `internal/flow/processor`: instruction, content, post-tool, time, and Skills tool-result request processors.
+  - `internal/flow/llmflow`: invocation-level tool snapshots and tool-list stabilization.
+  - `model/openai`: OpenAI-compatible adapter, message cache optimization, tool conversion, and extra-field merging.
+  - `session/summary`: session summary and cache-safe summary forking.
+  - `internal/tool/currenttime`: built-in precise current-time tool.
+  - `model`: provider-agnostic usage structures.
+  - `internal/telemetry`: token usage metrics.
+  - `examples/promptcache/openai`: OpenAI-compatible Prompt Cache example.
+  - `examples/promptcache/summaryinjection`: summary and preload injection mode examples.
+  - `examples/promptcache/timeprocessor`: current-time context Prompt Cache example.
+  - `examples/promptcache/anthropic`: Anthropic Prompt Cache appendix example.

--- a/docs/mkdocs/zh/blog/observability.md
+++ b/docs/mkdocs/zh/blog/observability.md
@@ -1,0 +1,243 @@
+# 看见 Agent 运行时：tRPC-Agent-Go 可观测的设计与取舍
+
+> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) 是面向 Go 语言的自主式多 Agent 框架，具有工具调用、会话与记忆管理、制品管理、多 Agent 协同、图编排、知识库与可观测等能力。
+>
+> 本文聚焦 tRPC-Agent-Go 的可观测设计：框架不自建观测平台，而是把 Agent 运行时中的关键语义映射到 OpenTelemetry，让 Trace、Metric 和 GenAI 语义属性可以被不同后端消费。
+
+大模型应用从 Chat 走向 Agent 后，可观测性问题变得明显不一样了。
+
+在 Chat 阶段，一次用户请求通常可以粗略理解为“一次入口请求 + 一次模型调用 + 一次模型响应”。这时沿用传统服务观测方法，先看 QPS、延迟、错误率，再沿着 RPC/HTTP 调用链定位问题，很多时候还能回答“接口慢不慢、模型调用有没有失败”。
+
+但 Agent 不一样。Agent 的一次请求内部可能包含多次模型调用、多次工具调用、多 Agent 协作、Graph/Workflow 编排、流式输出、token 消耗、prompt cache 命中情况，以及工具返回后再次推理的循环。也就是说，用户看到的是“一次回答”，运行时实际发生的是“一棵执行树”。如果只看入口接口和外部 RPC/HTTP 调用链，就很难看清这棵树内部发生了什么。
+
+因此，Agent 框架的可观测性不能只回答“接口慢不慢、失败没失败”，还要回答：
+
+- 这次请求经过了哪些 Agent、LLM、Tool、Workflow？
+- 模型为什么触发了某个工具？工具参数和结果是什么？
+- token 消耗主要发生在哪一次模型调用？
+- 流式响应的首 token 慢，是模型慢、工具慢，还是编排慢？
+- 错误发生在模型、工具、工作流节点，还是 Agent 调用边界？
+- 如果要接入不同观测平台，框架核心是否需要改？
+
+tRPC-Agent-Go 的 telemetry 设计，就是围绕这些问题展开的。它的核心选择不是做一个新的观测平台，而是把 Agent 运行时中的关键语义稳定映射到 OpenTelemetry，让不同后端可以消费同一套数据。
+
+一个典型 Agent 请求的 trace 形态可以先粗略理解为：
+
+```text
+invoke_agent customer_assistant
+├── chat gpt-4o-mini
+│   └── response with tool call
+├── execute_tool search_order
+│   └── tool result
+├── chat gpt-4o-mini
+│   └── final answer
+└── workflow after_reply_summary
+```
+
+这棵树把“用户的一次请求”拆成了多个可以观察、可以归因、可以统计的运行时事件。
+
+## 一、为什么传统服务观测不够看清 Agent
+
+传统服务可观测性的默认对象通常是进程、接口、RPC 方法、数据库访问、消息队列消费。它们大多有明确的输入输出和比较稳定的调用拓扑。Agent 运行时则多了一层“不确定的智能决策”。
+
+Agent 的执行路径经常不是静态写死的。模型可能根据用户输入决定是否调用工具，工具结果又可能影响下一次模型请求，多 Agent 系统里还可能把任务交给其他 Agent 或子图。Graph/Workflow 虽然能让路径更可控，但节点内部仍然可能包含模型调用、工具调用和流式输出。
+
+这会带来三个典型的观测难点。
+
+第一，调用链更长，而且形态更动态。一个入口请求里可能有多个 LLM round trip，也可能有工具调用和工作流节点嵌套。如果只看入口接口耗时，很难知道慢在什么地方。
+
+第二，成本和质量都发生在内部步骤。token usage、prompt cache、completion tokens、模型 finish reason、工具参数、工具返回内容，这些信息不在普通 RPC 指标里，却直接影响成本、质量和稳定性。
+
+第三，排障需要“语义化归因”。同样是失败，可能是模型供应商错误、工具执行失败、工具参数生成错误、工作流节点异常，也可能是框架层取消或超时。没有 Agent 语义的 trace，最终只能看到一串普通 span，很难回答“Agent 到底做了什么”。
+
+所以，Agent 框架的 telemetry 不能停在“只观测入口接口和 HTTP/RPC 调用”。它需要把 Agent 自身的运行时对象变成一等观测对象。
+
+## 二、tRPC-Agent-Go Agent Runtime 观测的设计思路
+
+tRPC-Agent-Go 的 telemetry 设计不是另起一套观测平台，而是在框架层把上一节提到的观测难点，转化为 Agent Runtime 可以稳定产生、持续演进的 telemetry 数据。
+
+第一，针对“调用链更长、更动态”的问题，框架在 Agent runtime 的关键边界自动埋点。应用不需要在每个 Agent、Tool、Model 调用处手写 span；tRPC-Agent-Go 会在 Agent 调用、模型请求、工具执行、Graph/Workflow 节点运行等生命周期里生成 `invoke_agent`、`chat`、`execute_tool`、`workflow` 等 span。这样，一次入口请求内部的动态执行路径可以被还原成可阅读的执行树。
+
+第二，针对“成本和质量发生在内部步骤”的问题，框架同时记录 Trace 和 Metric。Trace 里可以看到模型名、是否流式、输入输出消息、finish reason、工具参数和工具结果；Metric 里可以聚合 token usage、TTFT、operation duration、输出 token 速率等指标。这样既能定位单次请求发生了什么，也能长期治理成本、性能和质量。
+
+第三，针对“排障需要语义化归因”的问题，观测对象围绕 Agent 语义，而不是只围绕 HTTP/RPC 语义。tRPC-Agent-Go 关注的是 Agent、LLM、Tool、Workflow 这些运行时概念，并用 `gen_ai.operation.name`、`gen_ai.agent.name`、`gen_ai.tool.name`、`gen_ai.workflow.name` 等属性描述上下文。读 trace 时，看到的不再只是一串基础设施 span，而是能直接判断问题发生在模型、工具、工作流节点还是 Agent 调用边界。
+
+第四，针对“不同应用会接入不同观测后端”的问题，框架基于 OpenTelemetry，不自造观测协议。Trace、Metric、Resource、Exporter、Collector 这些能力尽量复用 OTel 标准生态；框架核心负责生成标准化 telemetry 数据，数据去往哪里由 OTel provider、exporter、collector 或外部插件决定。这样应用可以把数据导入 Jaeger、Prometheus、Langfuse 或其他 OTel 兼容后端，而平台适配不会反向污染 Agent runtime 的核心抽象。
+
+换句话说，tRPC-Agent-Go telemetry 的定位是“Agent 运行时语义层”，不是“观测平台本身”。
+
+## 三、核心数据模型：Trace、Metric 与语义属性
+
+本文重点讨论两类 telemetry 数据：Trace 和 Metric。
+
+Trace 负责描述一次请求内部发生了什么，Metric 负责把大量请求聚合成可统计、可告警、可看趋势的数据。
+
+### Trace：把运行过程变成执行树
+
+tRPC-Agent-Go 中几个核心 span 名称非常重要：
+
+| Span | 含义 | 典型问题 |
+| --- | --- | --- |
+| `invoke_agent <agent>` | 一次 Agent 调用生命周期 | 哪个 Agent 慢了、失败了、消耗了多少 token |
+| `chat <model>` | 一次 LLM 调用 | 哪个模型慢、首 token 慢不慢、输入输出 token 多少 |
+| `execute_tool <tool>` | 一次工具执行 | 哪个工具被调用、参数是什么、结果是什么、是否失败 |
+| `workflow <name>` | 一次 Graph 节点或 Workflow 观测对象执行 | 工作流卡在哪个节点、节点耗时和错误如何 |
+
+这组 span 的价值在于：它不是从基础设施角度抽象出来的，而是从 Agent 运行时抽象出来的。读 trace 时，看到的不再只是“某个 HTTP 请求调用了某个外部服务”，而是可以直接看到“Agent 调用了模型，模型要求执行工具，工具返回后模型继续生成答案”。
+
+以工具调用为例，`execute_tool` span 会围绕工具名、工具描述、工具参数、工具结果、错误类型等信息记录上下文。以模型调用为例，`chat` span 会记录模型名、是否流式、输入输出消息、finish reason、token usage、TTFT 等信息。以 Workflow 为例，Graph node 会被适配为 `workflow` 观测对象，span 记录 workflow name、workflow id、workflow type、request、response 和错误状态。
+
+### Metric：把运行过程变成可治理指标
+
+Trace 更适合单次排障，但生产治理离不开聚合指标。tRPC-Agent-Go 内置指标覆盖了几个关键维度：
+
+| Metric | 关注点 |
+| --- | --- |
+| `trpc_agent_go.client.request_cnt` | 请求次数 |
+| `gen_ai.client.operation.duration` | LLM、Tool、Agent、Workflow 等操作耗时 |
+| `gen_ai.client.token.usage` | 输入、输出、缓存相关 token 统计 |
+| `gen_ai.server.time_to_first_token` | 标准 GenAI 首 token 时间 |
+| `trpc_agent_go.client.time_to_first_token` | 框架兼容首 token 时间，当前与标准 TTFT 同值上报 |
+| `trpc_agent_go.client.time_per_output_token` | 平均每个输出 token 的生成耗时 |
+| `trpc_agent_go.client.output_token_per_time` | 输出 token 速率 |
+| `gen_ai.workflow.elapsed_time` | 从 `root_workflow.start` 到 `current_workflow.end` 的相对累计耗时 |
+
+这里有三个细节值得注意。
+
+第一，tRPC-Agent-Go 同时关心总耗时和流式体验。对于流式 Agent，用户感知不只取决于最终完成时间，还取决于首 token 时间是否足够快、后续 token 生成是否稳定。因此 TTFT、time per output token、output token per time 都是很重要的信号。
+
+第二，token usage 不只是成本指标，也是质量和性能指标。输入 token 过长可能说明上下文管理有问题；输出 token 异常变长可能说明 prompt 或工具结果失控；缓存相关 token 则可以帮助分析 prompt cache 是否真正生效。
+
+第三，Workflow 指标要区分“节点自身耗时”和“相对累计耗时”。`gen_ai.client.operation.duration` 描述当前 workflow/node 自身执行了多久；`gen_ai.workflow.elapsed_time` 描述当前观测对象从 root workflow 开始到当前对象结束的到达时间，它不表示各节点耗时求和。
+
+### 语义属性：让不同后端读懂同一套数据
+
+除了 span 和 metric 名称，属性设计同样关键。tRPC-Agent-Go 会使用 OpenTelemetry GenAI 语义约定和框架扩展字段来描述上下文，例如：
+
+| 属性 | 含义 |
+| --- | --- |
+| `gen_ai.operation.name` | 操作类型，例如 `chat`、`execute_tool`、`invoke_agent`、`workflow` |
+| `gen_ai.agent.name` / `gen_ai.agent.id` | Agent 名称和标识 |
+| `gen_ai.conversation.id` | 会话或对话标识 |
+| `gen_ai.request.model` / `gen_ai.response.model` | 请求和响应模型 |
+| `gen_ai.input.messages.otel` / `gen_ai.output.messages.otel` | OTel 对齐的输入输出消息 |
+| `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` | 输入输出 token |
+| `gen_ai.tool.name` | 工具名称 |
+| `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` | 工具参数和结果 |
+| `gen_ai.workflow.name` / `gen_ai.workflow.type` | Workflow 名称和类型 |
+| `error.type` / `error.message` | 错误类型和错误消息 |
+| `trpc.go.agent.invocation_id` | 框架内一次调用的 invocation id |
+| `trpc.go.agent.llm_request` / `trpc.go.agent.llm_response` | 框架保留的 LLM 请求/响应 payload |
+
+这些属性让数据具备可迁移性。不同后端可能展示方式不同，但只要它们理解 OTel/GenAI 语义，或者能基于这些属性做映射，就可以围绕同一套运行时事实构建视图。
+
+这张表也意味着一个生产接入前必须回答的问题：哪些 payload 可以上报，哪些必须脱敏、截断或关闭。prompt、response、工具参数、工具结果、用户标识和 `llm_request` / `llm_response` 都可能包含敏感信息；同时，过长属性会增加存储成本，高基数字段也会影响指标聚合。因此接入 telemetry 时，应同步确定 payload 开关、字段脱敏、attribute size limit、采样策略和高基数字段治理。
+
+## 四、一个定位例子：首 token 慢
+
+假设用户反馈“流式回答一直不出字”，入口接口只能告诉我们这次请求慢了，但 Agent telemetry 可以继续拆开看。
+
+第一步看 `invoke_agent` 的总耗时和 TTFT。如果 `invoke_agent` 很慢，但第一个 `chat` span 很晚才开始，问题通常在 Agent 编排、前置 Workflow 或工具准备阶段。
+
+第二步展开 trace。如果 `execute_tool` 或某个 `workflow` span 占用大量时间，就可以继续看工具参数、工具结果、workflow type 和错误状态；如果慢点集中在 `chat <model>`，则进一步看模型名、输入 token、是否流式、TTFT 和 finish reason。
+
+第三步结合指标做聚合判断。如果只有单次请求慢，trace 更有用；如果一段时间内某个模型的 `gen_ai.server.time_to_first_token` 普遍升高，或者 `gen_ai.client.token.usage` 显示输入 token 明显膨胀，就可以把问题从“某次请求异常”提升为“模型供应商、上下文管理或 prompt 设计需要治理”。
+
+## 五、数据链路：运行时如何变成观测数据
+
+tRPC-Agent-Go 的 telemetry 链路可以抽象成四层：
+
+```mermaid
+flowchart LR
+    AgentRuntime["Agent Runtime: Agent / LLM / Tool / Workflow"] --> OpenTelemetryAPI["OpenTelemetry API: Tracer / Meter"]
+    OpenTelemetryAPI --> Provider["Provider and Processor: Resource / SpanProcessor / MetricReader"]
+    Provider --> Exporter["Exporter or Collector: OTLP HTTP / OTLP gRPC"]
+    Exporter --> Backend["Backend: Langfuse / Jaeger / Prometheus / OTel-compatible systems"]
+```
+
+从应用视角看，接入的第一步通常是初始化 tracer provider 和 meter provider。比如 trace 可以通过 `telemetry/trace.Start` 配置 endpoint、protocol、service name、resource attributes、headers 等；指标可以通过 `telemetry/metric.NewMeterProvider` 和 `metric.InitMeterProvider` 初始化。默认情况下，如果没有初始化 provider，OpenTelemetry 的 noop 行为会让框架埋点不产生实际导出开销。
+
+从框架视角看，Agent runtime 在关键生命周期里自动创建 span、记录属性、上报指标。例如 Agent 调用开始时建立 `invoke_agent`，模型请求时建立 `chat`，工具执行时建立 `execute_tool`，Graph/Workflow 节点运行时建立 `workflow`。这些位置是框架天然知道的边界，应用代码不需要重复感知。
+
+从平台视角看，数据最终去哪里不是由 Agent 核心决定的。它可以通过 OTLP HTTP/gRPC 到 OpenTelemetry Collector，再由 Collector fan-out 到多个后端；也可以通过特定 exporter 或插件直接进入某个观测系统。这个分层让 tRPC-Agent-Go 的核心保持稳定，也让平台接入可以按环境演进。
+
+这也是为什么本文不把“后端适配”单独作为可观测模块的核心设计来讲。平台适配是整体工程架构的一部分：开源环境可以选择 Langfuse、Jaeger、Prometheus 等后端，企业内部环境也可能选择自己的 OTel-compatible observability backend。可观测模块真正沉淀的核心，是前面这层 Agent telemetry 语义。
+
+## 六、工程实践：把 Agent telemetry 做稳
+
+从 telemetry 模块演进看，很多问题并不发生在“能不能上报 span”这一层，而是发生在大 payload、上下文传播、指标口径、后端限制和平台适配的边界处。尤其是 LLM request、response、tool arguments、workflow request/response 这类 attribute，既可能造成生产侧 marshal 内存压力，也可能在导出或后端侧被 span limits 截断。
+
+| 工程问题 | 解决思路 |
+| --- | --- |
+| Trace 上下文在 context clone、并发 tool call 中容易断链 | 保证 clone 后保留 OpenTelemetry span context，并用测试覆盖 TraceID、SpanID 和父子 span 关系 |
+| span 创建阶段采集大 payload 会带来重复 `json.Marshal` 和堆内存峰值 | 使用 opt-in 的 `SpanAttributePolicy`，按 operation/key 控制采集；降内存优先 `Drop()` 冗余 attribute 或无条件 `Omit()` |
+| OTel / 后端属性长度限制会截断大 attribute，导致结构化解析失败 | exporter 记录截断诊断日志，根据 value length、limit、`unexpected EOF` 等信号判断是否被 `AttributeValueLengthLimit` 截断 |
+| OTel GenAI 语义仍在演进，多模态、tool call schema 容易变 | 核心层保留稳定语义，兼容 OTel message role/parts 等新格式，后端差异放到 adapter 映射 |
+| TTFT、workflow elapsed、token usage 等指标口径容易不一致 | 明确定义 metric 的 from/to、成功/失败/cache/retry 口径，并让 `chat`、`invoke_agent`、`workflow` 使用一致口径 |
+| Graph / Agent 嵌套过深会让 trace 难读 | 有意识地调整 span 拓扑，让链路更贴近排障视角 |
+| tool、error、应用维度如果不稳定，会影响聚合分析 | 稳定 tool 排序和 tool_call_id，统一 error.type / error label，通过受控维度承载场景信息 |
+
+这里有一个容易混淆的点：“限长”和“降内存”不是一回事。`Drop()` 和无条件 `Omit()` 可以在 `json.Marshal` 前短路，能降低 marshal 堆峰值；`MaxBytes` + `Omit()`、`Truncate()` 更多是控制最终写入 span 的 attribute 体积。对 `chat`、`workflow`、`invoke_agent` 这类 JSON 序列化路径，通常仍要先完整 marshal 才能判断大小。
+
+这也带来一个实践原则：不要把“调大后端 attribute limit”当成唯一手段。生产侧先决定哪些 attribute 值得采集，导出侧再处理平台限长、截断诊断和字段映射；前者解决内存与冗余，后者解决展示与排障。
+
+## 七、对比、取舍与演进
+
+有了工程实践作为背景，再看其他框架的可观测设计，可以帮助我们理解 tRPC-Agent-Go 的选择。这里不是做优劣排名，而是看不同产品形态如何回答“运行时事实由谁记录、数据最终由谁消费”。
+
+| 类型 | 代表 | 可观测设计重点 | 对 tRPC-Agent-Go 的参照意义 |
+| --- | --- | --- | --- |
+| 平台闭环型 Agent 框架 | LangChain / LangGraph | 以 LangSmith 承载 trace、debug、评测、监控和反馈闭环 | 平台体验强，但框架语义和平台绑定更紧 |
+| 标准语义型 Agent 框架 | Google ADK | 内置日志、指标和 trace，并强调 OpenTelemetry GenAI 语义 | 说明 Agent span 标准化已经成为重要方向 |
+| 数据主权型 Agent 框架 | Agno | run history、audit logs 和 tracing 可写入用户自己的数据库，也支持 OTel 外送 | 本地存储和外部后端之间可以做不同取舍 |
+| Go 生态组件框架 | CloudWeGo / Eino | 通过 Callback/Handler/RunInfo 暴露组件和 Graph 生命周期 | callback 扩展灵活，但需要用户或平台侧沉淀统一语义 |
+| Code Agent 产品 | OpenAI Codex / Claude Code | 更关注工具审批、命令执行、组织成本、安全审计和人机协作事件 | 观测对象偏产品事件流，不等同于业务 Agent 服务运行时 |
+
+对比下来，tRPC-Agent-Go 的选择更像是“标准语义 + 服务端框架内建埋点”。它不追求自己提供观测平台，也不只提供 callback 扩展点，而是在 Agent runtime 中直接沉淀稳定的 span、指标和属性。
+
+这个取舍让框架保持轻量和后端解耦，但也要求应用在生产接入时明确敏感字段治理策略。prompt、response、工具参数、工具结果、用户标识都可能包含敏感信息，是否上报、如何脱敏、如何控制属性大小和指标基数，需要在具体环境中治理。
+
+未来演进可以继续围绕几个方向推进：
+
+- 跟进 OpenTelemetry GenAI semantic conventions 的变化，减少自定义字段和标准字段之间的偏差。
+- 扩展更多 Agent 维度指标，例如工具成功率、Agent step 数、Graph 节点重试和恢复指标。
+- 细化流式链路统计，例如 reasoning 阶段、首 token、有效内容 token 和最终完成时间的关系。
+- 加强敏感数据治理，例如 payload 开关、字段脱敏、attribute size limit、高基数字段控制。
+- 更好支持多后端路由，例如通过 Collector 或插件把同一套数据同时送往 LLMOps 平台和通用 APM 平台。
+
+## 结语
+
+Agent 框架的可观测性，关键不是“多打一批日志”，也不是“把模型请求包一层 span”。
+
+真正重要的是把 Agent 运行时看见：一次请求如何进入 Agent，如何调用模型，如何触发工具，如何走过 Graph/Workflow，在哪里消耗 token，在哪里等待首 token，在哪里失败，最终又如何被不同观测平台消费。
+
+tRPC-Agent-Go 的选择是先沉淀这套运行时语义，再通过 OpenTelemetry 连接不同后端。这种设计没有把观测平台塞进框架核心，也没有把 Agent 内部执行过程留给应用自己补埋点。它站在框架层，把最稳定、最关键的运行时事实记录下来。
+
+这也是“看见 Agent 运行时”的意义：不是为了多一个漂亮的 trace 页面，而是让 Agent 服务在生产环境里真正可解释、可定位、可度量、可治理。
+
+## 参考资料
+
+- [tRPC-Agent-Go GitHub](https://github.com/trpc-group/trpc-agent-go)
+- [tRPC-Agent-Go documentation site](https://trpc-group.github.io/trpc-agent-go/)
+- [tRPC-Agent-Go Observability 文档](https://github.com/trpc-group/trpc-agent-go/blob/main/docs/mkdocs/zh/observability.md)
+- [tRPC-Agent-Go Langfuse 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/telemetry/langfuse)
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
+- [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [LangSmith Observability](https://docs.langchain.com/langsmith/observability)
+- [LangGraph Observability](https://docs.langchain.com/oss/python/langgraph/observability)
+- [LangSmith Trace with OpenTelemetry](https://docs.langchain.com/langsmith/trace-with-opentelemetry)
+- [Google ADK Observability](https://adk.dev/observability/)
+- [Google ADK Traces](https://adk.dev/observability/traces/)
+- [Google ADK Metrics](https://adk.dev/observability/metrics/)
+- [Google Cloud: Instrument ADK applications with OpenTelemetry](https://docs.cloud.google.com/stackdriver/docs/instrumentation/ai-agent-adk)
+- [Agno Tracing](https://docs.agno.com/tracing/overview)
+- [Agno Agent Observability](https://docs.agno.com/features/observability)
+- [Agno OpenTelemetry Observability](https://docs.agno.com/observability/overview)
+- [CloudWeGo Eino Callback Manual](https://www.cloudwego.io/docs/eino/core_modules/chain_and_graph_orchestration/callback_manual/)
+- [CloudWeGo Eino Callback and Trace](https://www.cloudwego.io/docs/eino/quick_start/chapter_06_callback_and_trace/)
+- [CloudWeGo Eino Open Source Overview](https://www.cloudwego.io/docs/eino/overview/eino_open_source/)
+- [OpenAI Codex Advanced Configuration: Observability and Telemetry](https://developers.openai.com/codex/config-advanced)
+- [Claude Code Monitoring](https://code.claude.com/docs/en/monitoring-usage)
+- [Claude Code Agent SDK Observability](https://code.claude.com/docs/en/agent-sdk/observability)
+- [Langfuse OpenTelemetry Integration](https://langfuse.com/integrations/native/opentelemetry)
+- [Langfuse Self Hosting](https://langfuse.com/self-hosting)

--- a/docs/mkdocs/zh/blog/observability.md
+++ b/docs/mkdocs/zh/blog/observability.md
@@ -1,7 +1,5 @@
 # 看见 Agent 运行时：tRPC-Agent-Go 可观测的设计与取舍
 
-> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) 是面向 Go 语言的自主式多 Agent 框架，具有工具调用、会话与记忆管理、制品管理、多 Agent 协同、图编排、知识库与可观测等能力。
->
 > 本文聚焦 tRPC-Agent-Go 的可观测设计：框架不自建观测平台，而是把 Agent 运行时中的关键语义映射到 OpenTelemetry，让 Trace、Metric 和 GenAI 语义属性可以被不同后端消费。
 
 大模型应用从 Chat 走向 Agent 后，可观测性问题变得明显不一样了。

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -1,0 +1,549 @@
+# 降低 Agent Token 成本：tRPC-Agent-Go 的 Prompt Cache 工程实践
+
+> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) 是面向 Go 语言的自主式多 Agent 框架，具有工具调用、会话与记忆管理、制品管理、多 Agent 协同、图编排、知识库与可观测等能力。
+>
+> 本文聚焦 Prompt Cache：它不是框架在本地保存模型 KV，而是模型服务侧对稳定 prompt prefix 的复用能力。tRPC-Agent-Go 的工程实践，是把 Agent 请求尽量组织成“稳定前缀 + 动态后缀”，从而提升缓存命中概率，降低可复用输入 tokens 的成本。
+
+大模型应用进入 Agent 阶段后，一个很直观的变化是：每次请求变长了。
+
+普通 Chat 应用里，模型看到的可能只是 system prompt 加几轮对话。Agent 应用里，请求前缀往往还会包含工具 schema、结构化输出 schema、Skills/RAG 上下文、历史 tool call 和 tool result。一次用户请求如果触发多次工具调用，还会在同一轮里多次请求模型。这些请求之间有大量重复内容，也正是 Prompt Cache 能发挥作用的地方。
+
+读完本文，你会看到四件事：
+
+- Prompt Cache 对 Agent 为什么有响应速度和 token 成本价值。
+- OpenAI-compatible API 里的 `cached_tokens`、`prompt_cache_key` 应该如何理解。
+- tRPC-Agent-Go 如何在 system、tools、Skills、summary、time、post-tool prompt 等位置减少缓存破坏。
+- 哪些 option 推荐使用，哪些动态能力需要谨慎配置。
+
+文中的配置和实验主要使用 OpenAI-compatible API 作为示例口径；Anthropic 的显式 `cache_control` 机制放在附录中作为对照。OpenAI-compatible API 指的是兼容 OpenAI Chat Completions 等请求/响应协议形态的模型服务接口。它可以是 OpenAI 官方接口，也可以是其他模型厂商提供的兼容接口；但“兼容 OpenAI 协议”不等于“所有服务方都支持完全相同的 Prompt Cache 能力”。`cached_tokens`、`prompt_cache_key`、缓存门槛、TTL 和计费规则，都应以具体服务方文档为准。
+
+## 一、Prompt Cache 对 Agent 的价值：更快响应、更低成本
+
+Prompt Cache 对 Agent 的直接价值有两层：
+
+1. 重复前缀被服务端复用后，Agent 调用通常能感受到首 token 或整体响应延迟下降。
+2. 不少模型服务会把缓存命中的输入 tokens 按更低价格计费。
+
+以 [DeepSeek 模型价格页](https://api-docs.deepseek.com/zh-cn/quick_start/pricing) 在 2026-06-09 查询到的价格为例，官方价格表按“百万 tokens”为单位区分了输入缓存命中、输入缓存未命中和输出价格：
+
+| 模型 | 输入缓存命中 | 输入缓存未命中 | 输出 |
+| --- | --- | --- | --- |
+| `deepseek-v4-flash` | 0.02 元 / 百万 tokens | 1 元 / 百万 tokens | 2 元 / 百万 tokens |
+| `deepseek-v4-pro` | 0.025 元 / 百万 tokens | 3 元 / 百万 tokens | 6 元 / 百万 tokens |
+
+按这个价格表，`deepseek-v4-flash` 的缓存命中输入价格是未命中输入价格的 1/50；`deepseek-v4-pro` 的缓存命中输入价格是未命中输入价格的 1/120。也就是说，在长 system prompt、稳定 tools、多轮 history 这类重复前缀较多的 Agent 场景中，只要这些输入 tokens 能被服务端判定为 cached tokens，它们对应的输入成本就会显著下降。
+
+这里需要强调两点。第一，这只是 DeepSeek 当前价格页上的示例，用来说明“缓存命中 tokens 通常更便宜”这个成本结构；其他 OpenAI-compatible 服务的价格、折扣和规则需要看各自文档。第二，Prompt Cache 主要降低的是可复用输入 tokens 的成本，不会减少所有输入，也不会影响输出 tokens 的计费方式。
+
+## 二、Prompt Cache 是模型服务侧的前缀复用能力
+
+理解 Prompt Cache，可以先从 Transformer 推理说起。[Hugging Face Transformers 的 KV cache 文档](https://huggingface.co/docs/transformers/en/kv_cache)解释了一个基础事实：自回归生成会逐 token 推进，模型可以缓存 attention 中已经计算过的 key/value 状态，后续 token 不必反复计算前面 token 的 key/value。
+
+这说明“复用已处理前缀的中间状态”在模型推理中有明确技术背景。不过，在 API 层不应把 Prompt Cache 简单等同为某一种具体 KV cache 实现。更准确的说法是：
+
+> Prompt Cache 是模型服务侧对已处理 prompt prefix 的复用能力。它可以理解为复用前缀的中间状态或服务端缓存结果；具体缓存介质、匹配粒度、保留时间和计费规则由服务方实现决定。
+
+对支持 Prompt Cache 的 OpenAI-compatible API，服务端会检查当前 prompt 的 prefix 是否已经被处理过。如果命中，响应中的 `usage.prompt_tokens_details.cached_tokens` 会返回本次从缓存复用的 prompt tokens 数量。[OpenAI Prompt Caching 文档](https://developers.openai.com/api/docs/guides/prompt-caching)也强调了一个关键实践：把静态内容放在 prompt 开头，把每轮变化的内容放在后面。
+
+这也是 `prompt_cache_key` 的语义边界。它不是缓存内容本身，也不是启用 Prompt Cache 的必要条件；不带 `prompt_cache_key` 时，服务端仍然可以按 prompt prefix 自动缓存和命中。`prompt_cache_key` 更像 OpenAI-compatible API 中用于辅助缓存路由的请求参数：当很多请求共享同一类长前缀时，一个稳定的 cache key 可能帮助这些请求落到更容易命中缓存的位置。反过来，如果把它设置成 request id、trace id、时间戳这类每次都不同的值，就会削弱前缀复用的机会。
+
+[DeepSeek Context Caching 文档](https://api-docs.deepseek.com/guides/kv_cache/)从另一个 OpenAI-compatible 服务形态给出了相同思路：后续请求如果与之前请求有重叠前缀，重叠部分就有机会从缓存读取；它的多轮对话和长文档问答示例，本质上都是 prefix reuse。
+
+## 三、Agent 为什么特别需要 Prompt Cache
+
+Agent 请求天然包含大量稳定前缀。一个典型 LLM Agent 请求里，前部通常包括：
+
+- system prompt、global instruction、agent identity。
+- tool schema、function declaration、structured output schema。
+- Skills overview、能力说明、固定工作流说明。
+- 已发生的 session history、tool call、tool result。
+- RAG、memory 或 workspace context。
+
+多轮对话天然符合“旧上下文 + 新消息”的形态：
+
+```text
+第 1 轮: system + tools + user_1
+第 2 轮: system + tools + user_1 + assistant_1 + user_2
+第 3 轮: system + tools + user_1 + assistant_1 + user_2 + assistant_2 + user_3
+```
+
+从第二轮开始，新请求会带上上一轮的大部分内容。只要前面的 system、tools、历史消息没有被改写，模型服务侧就有机会复用这些前缀。
+
+Tool call / ReAct 场景会进一步放大这一点。一条用户请求可能触发多次 LLM 调用：第一次让模型决定调用什么工具，第二次把 tool result 追加回来继续推理，后续还可能再次调用工具。每一次模型请求都会重复 system、tools 和已经发生的上下文。稳定前缀越长，Prompt Cache 的收益空间越大；前缀被动态内容频繁打断，命中率就会下降。
+
+因此，Agent 框架的职责不是实现模型侧缓存，而是把请求组织成更适合缓存命中的结构：
+
+```text
+推荐形态:
+[稳定前缀] system / instruction / tools / schema / stable skills overview
+         + session history / previous tool call / previous tool result
+[动态后缀] current user message / current tool result / current time / temporary context
+
+需要避免:
+system / instruction 被 summary、精确时间、RAG 片段、临时用户状态频繁改写
+```
+
+tRPC-Agent-Go 的 Prompt Cache 相关优化，正是围绕这个结构展开。
+
+## 四、tRPC-Agent-Go 如何组织缓存友好的请求
+
+tRPC-Agent-Go 不在本地保存模型 KV，也不替代服务方的 Prompt Cache。它做的是请求组织：尽量让稳定内容更早、更稳定地进入请求，让动态内容靠后，并减少工具和上下文顺序的随机变化。
+
+进入框架实现前，先约定三个容易混用的概念：
+
+- `system prompt` 指系统规则文本，例如 Agent 身份、回答风格、工具后回复要求等。
+- `system message` 指请求中 `role=system` 的消息对象，它是承载 system prompt 的消息结构。
+- `model request prefix` 指模型服务最终看到的请求前缀，也就是 provider 文档中常说的 prompt prefix。它不是 HTTP 请求字段前缀，而是模型输入从开头开始连续的一段内容，可能包含 system message、instruction、tools、schema、稳定 history 等。后文简称 `request prefix`。
+
+三者的关系是：system prompt 通常会被写入 system message；system message 又和 tools、schema、稳定上下文一起构成 model request prefix。Prompt Cache 关注的是完整 request prefix 是否稳定，所以既要关心 system prompt 文本有没有变化，也要关心 system message 在请求里的位置和数量是否稳定。
+
+先用一张表概览这一节要讲的处理点：
+
+| 处理点 | 框架做了什么 | 减少哪类缓存破坏 |
+| --- | --- | --- |
+| Request processors | 先组装 instruction / system / Skills overview，再追加 history、tool result、time 等动态内容 | 避免动态内容过早进入 request prefix |
+| Request prefix | 合并 global instruction / instruction，形成靠前的 request prefix | 避免规则、身份说明在每轮请求中位置漂移 |
+| Message ordering | OpenAI-compatible adapter 可将 system messages 前置 | 让最稳定的 system messages 更靠前，更利于自动 prefix cache |
+| Tools | Invocation 内缓存 tools snapshot，工具转换时按名称排序 | 避免工具列表顺序或 map 迭代顺序破坏 prefix |
+| Post-tool guidance | 有工具面的 Agent 从第一次模型请求起稳定注入工具后提示 | 避免首次 tool result 后才改写 request prefix |
+| Skills | 已加载 Skill 内容优先物化到 tool result | 减少动态 Skill 内容污染 request prefix |
+| Summary generation | cache-safe forking 复用父请求前缀，只追加 compaction user message | 避免 summary 请求重新组织上下文导致缓存无法复用 |
+| Summary injection | 可将 summary 注入 user/history 附近 | 避免频繁更新 summary 时改写 request prefix |
+| Current time | 默认只注入日期级上下文，精确时间走工具 | 避免完整时间戳每轮改变 request prefix |
+
+### Request processors：稳定内容先组装
+
+**缓存风险**：Agent 请求不是一次性拼出来的，而是由 instruction、Skills、history、tool result、time 等多类上下文共同组成。如果动态内容过早进入 request prefix，即使后面的 system、tools、history 很稳定，也会因为前缀被打断而降低命中概率。
+
+**框架处理**：`LLMAgent` 会通过一组 request processors 逐步构造模型请求。整体处理顺序是：
+
+- Instruction processor 较早运行，把 global instruction / instruction 合并到 system message。
+- Skills processor 注入 Skills overview 和加载状态。
+- Content processor 再追加 conversation / context history。
+- Post-tool processor 对有工具面的 Agent 预先注入稳定的工具后指导，避免第一次出现 tool result 后再改写 request prefix。
+- Skills tool result processor 在 content 之后，把已加载 Skill 内容物化到相关 tool result。
+- Time processor 放在更靠后的位置；默认只注入日期级上下文，精确当前时间通过工具按需获取，避免把每秒变化的时间戳写进 system message。
+
+**使用建议**：应用侧也应延续这个顺序：规则、身份、工具、能力说明等相对稳定的内容尽量放前面；当前用户输入、工具结果、临时检索片段、精确时间等更动态的内容尽量放后面。
+
+### Request prefix：系统规则形成可复用前缀
+
+**缓存风险**：system prompt 通常会进入请求前部的 system message，也是最有价值的缓存前缀。如果每轮把用户状态、检索结果、精确时间等动态内容写进 system message，后续再长的稳定上下文也很难复用。
+
+**框架处理**：`InstructionRequestProcessor` 会查找已有 system message。如果不存在，它会创建新的 system message 并插入到 `req.Messages` 头部；如果已经存在，则把 system prompt 和 instruction 合并到这条 system message 中。这让 Agent 的全局规则进入 request prefix 中较靠前且稳定的位置。
+
+**使用建议**：把 instruction 当成“长期规则”而不是“每轮上下文”。每轮变化的用户信息、检索片段、任务临时状态，更适合放到靠后的 user/history/tool result 中。
+
+### Message ordering：system messages 前置
+
+**缓存风险**：如果 system messages 在请求中位置不稳定，或被历史消息夹在中间，服务端自动 prefix cache 更难把最稳定的 system messages 作为可复用前缀。
+
+**框架处理**：`model/openai` 包提供了 `openai.WithOptimizeForCache`。在默认 `VariantOpenAI` 下，这项优化默认开启；如果显式使用其他 provider variant，或者应用严格依赖原始 message 顺序，需要按实际配置确认是否开启。开启后，请求发送前会调用 `optimizeMessagesForCache`，把 system messages 移到 messages 前部。
+
+**使用建议**：这不是显式创建缓存，而是适配 OpenAI-compatible API 的自动前缀缓存。如果走默认 OpenAI variant，通常可以保留这项优化；只有在应用严格依赖原始 message 顺序时，才需要关闭：
+
+```go
+llm := openai.New("your-model",
+    openai.WithOptimizeForCache(false),
+)
+```
+
+### Tools：工具集合与顺序稳定
+
+**缓存风险**：Tool schema 是 Agent 请求里常见的大块静态内容，也常常是可缓存前缀的重要组成部分。工具列表顺序不稳定、动态工具过滤结果频繁变化、底层 map 迭代顺序随机，都会让 tools prefix 难以复用。
+
+**框架处理**：tRPC-Agent-Go 做了两层稳定化。第一层在 flow 层，框架会缓存一次 Invocation 内最终可见的工具列表；即使底层 ToolSet 是动态的，一次 Invocation 生命周期内发给模型的工具集合也尽量保持稳定。对于经过过滤的工具，框架会按工具名排序，避免 Go map 迭代顺序带来的随机变化破坏前缀。第二层在 OpenAI-compatible adapter，工具转换时会先抽取 tool names 并排序，再按稳定顺序转换成 OpenAI-compatible `tools` 参数。
+
+**使用建议**：工具顺序框架会尽量稳定，但工具集合本身仍由应用决定。动态工具过滤、`WithRefreshToolSetsOnRun(true)`、动态 MCP tool list 都应谨慎使用；如果确实需要动态工具面，建议按场景分桶，并让同一类请求看到稳定工具集合。
+
+### Post-tool guidance：提前稳定注入
+
+**缓存风险**：Tool call 之后，模型会看到 `role=tool` 的工具结果。为了让工具调用后的回复更自然，框架通常会补一段 post-tool guidance，提醒模型基于工具结果直接回答，不暴露“我调用了某某工具”这类过程描述。如果等请求已经出现 tool result 之后，才把 post-tool prompt append 到 system message，那么第一轮工具结果后的模型请求会在很靠前的位置新增一段 system prompt 内容，导致后面的稳定 history、tool result 等内容失去前缀复用机会。
+
+**框架处理**：tRPC-Agent-Go 把这段逻辑改成稳定注入：只要 Agent 有潜在 tool surface，默认 post-tool guidance 会从第一次模型请求起进入 system message；后续 ReAct / tool-loop 轮次不会再因为第一次出现 tool result 才改写 request prefix。纯文本 Agent 没有工具面时，框架不会为了这个能力额外创建 system message，避免无工具场景增加不必要前缀。
+
+**使用建议**：用户仍然可以通过 `llmagent.WithPostToolPrompt("...")` 自定义这段稳定指导，或通过 `llmagent.WithEnablePostToolPrompt(false)` 关闭。自定义 prompt 应按 Agent 或版本保持稳定，不要按请求动态生成；如果确实需要把“本次工具结果后的临时要求”传给模型，更适合放到 tool result 或靠后的 user/history 消息里。
+
+### Skills：动态内容进入 tool result
+
+**缓存风险**：Skills 是 Agent 能力扩展的重要来源，但已加载的 Skill body 或 selected docs 往往随任务变化。如果这些内容每轮都追加到 system message，request prefix 就会频繁变化。
+
+**框架处理**：tRPC-Agent-Go 提供了 `llmagent.WithSkillsLoadedContentInToolResults(true)`。开启后，已加载 Skill 内容会尽量追加到对应的 `skill_load` / `skill_select_docs` tool result，而不是追加到 system message。Skills tool result processor 会按稳定顺序处理已加载 Skills，优先把内容物化到匹配的 tool result；只有找不到匹配 tool result 时，才回退到 system message。
+
+**使用建议**：这不是减少上下文，而是把动态上下文放到更合适的位置，减少对 request prefix 的污染。Skill 内容随任务变化时，建议开启该选项，并配合 `WithSkillLoadMode(...)`、`WithMaxLoadedSkills(...)` 控制驻留时长和数量：
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithSkillsLoadedContentInToolResults(true),
+    llmagent.WithSkillLoadMode(llmagent.SkillLoadModeTurn),
+    llmagent.WithMaxLoadedSkills(8),
+)
+```
+
+### Summary generation：cache-safe forking
+
+**缓存风险**：长会话 Agent 通常需要 summary 或 compaction。这里容易混在一起的有两件事：一是“生成 summary 那次请求”如何组织，二是“summary 已经生成后”如何注入后续普通对话请求。生成 summary 时，如果完全换一套独立 prompt 重新发送会话内容，就很难复用父会话已经建立起来的缓存前缀。
+
+**框架处理**：tRPC-Agent-Go 提供了可选的 cache-safe summary forking 模式。生成 summary 的请求可以克隆父会话的模型请求，并只在尾部追加一条 compaction user message。
+
+可以把它理解成：
+
+```text
+父会话请求:
+system + tools + stable context + history_1...history_N + new_user_message
+
+cache-safe compaction fork:
+system + tools + stable context + history_1...history_N + compact_user_message
+```
+
+这样，compaction 本身也变成“父会话前缀 + 新动态后缀”的请求形态，更容易复用父会话已经建立起来的缓存。
+
+**使用建议**：这个能力是 opt-in 的，默认仍保留独立 summary 请求，以兼容已有使用方式以及 summary model 与主 Agent model 不同的场景。长会话、同模型 summary、对 Prompt Cache 敏感的场景，可以优先评估开启：
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithContextThreshold(),
+    summary.WithMaxSummaryWords(200),
+    summary.WithCacheSafeForking(true),
+)
+```
+
+如果需要自定义 fork 模式下追加的压缩指令，可以使用 `summary.WithCacheSafeForkPrompt(...)`。这条 prompt 可以包含 `{max_summary_words}`，但不应再包含 `{conversation_text}`，因为父请求本身已经包含完整的对话前缀。
+
+### Summary injection：避免改写 request prefix
+
+**缓存风险**：Summary 生成完成后，后续普通对话请求还需要决定把它放在哪里。默认的 `SessionSummaryInjectionSystem` 会把 summary 注入 system message，兼容“summary 必须留在 preserved head、不参与 sliding-window trimming”的场景；但如果 summary 经常更新，就会改写靠前 request prefix。
+
+**框架处理**：对 Prompt Cache 更敏感的场景，可以显式使用 `WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)`，把 summary 放到第一个 user history/current message 附近，让 request prefix 尽量不变；代价是 summary 会参与 token-budget trimming，长上下文下可能被裁掉。
+
+**使用建议**：如果应用更重视 summary 永远留在 preserved head，可以保留 system 注入；如果更重视 request prefix 稳定，可以评估 user/history 注入。因此，cache-safe forking 优化的是“生成 summary 的请求”，`WithSessionSummaryInjectionMode(...)` 优化的是“普通对话请求如何注入 summary”。两者可以配合使用。
+
+### Current time：日期级上下文 + 精确时间工具
+
+**缓存风险**：Current time 是一个很典型的 Prompt Cache 陷阱。它看起来只是很短的一行上下文，但如果每次都把完整时间戳写进 system message，那么 request prefix 每秒都可能变化，后面的稳定 instruction、tools、history 也更难被服务侧复用。
+
+对比 Codex 和 Claude Code 的做法，可以看到它们都没有把“当前时分秒”当成稳定 prompt 的一部分：它们更偏向把运行环境信息控制在日期、时区这类粗粒度信息上，让高频变化的 clock time 不进入稳定前缀。
+
+**框架处理**：tRPC-Agent-Go 沿用已有的 `WithAddCurrentTime` 入口，但调整默认语义：默认只注入日期级 system context，把它当成“今天是哪一天”这种相对稳定的环境信息；如果模型需要精确到时分秒的当前时间，则通过内置的 `environment_context_current_time` 工具按需获取。
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithAddCurrentTime(true),
+)
+```
+
+**使用建议**：默认 date-only 路径更 cache-friendly；如果显式配置完整时间格式，例如 `WithTimeFormat("2006-01-02 15:04:05 MST")`，仍然可以得到旧式完整时间戳，但需要接受 request prefix 随时间变化带来的缓存影响。
+
+## 五、用户能配置和观测什么
+
+Prompt Cache 的命中发生在模型服务侧，但用户仍然可以通过 tRPC-Agent-Go 控制请求形状、透传服务方参数，并观测命中效果。
+
+### 配置缓存友好的请求形状
+
+在默认 `VariantOpenAI` 配置下，OpenAI-compatible adapter 会进行 message cache optimization：
+
+```go
+llm := openai.New("your-model")
+```
+
+如果显式选择了其他 provider variant，可以按服务方行为确认是否需要显式配置 `openai.WithOptimizeForCache(true)`。如果应用严格依赖原始 message 顺序，可以关闭：
+
+```go
+llm := openai.New("your-model",
+    openai.WithOptimizeForCache(false),
+)
+```
+
+Skills 动态内容建议进入 tool result：
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithSkillsLoadedContentInToolResults(true),
+    llmagent.WithSkillLoadMode(llmagent.SkillLoadModeTurn),
+    llmagent.WithMaxLoadedSkills(8),
+)
+```
+
+长会话 summary 如果关注 Prompt Cache，可以同时关注 summary 生成和 summary 注入两件事。生成 summary 时可以启用 cache-safe forking：
+
+```go
+summarizer := summary.NewSummarizer(
+    summaryModel,
+    summary.WithContextThreshold(),
+    summary.WithMaxSummaryWords(200),
+    summary.WithCacheSafeForking(true),
+)
+```
+
+自定义 fork prompt 时使用 `summary.WithCacheSafeForkPrompt(...)`，不要再把 `{conversation_text}` 放进去。
+
+普通对话请求注入 summary 时，可以使用 user/history 模式避免改写首条 system：
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithAddSessionSummary(true),
+    llmagent.WithSessionSummaryInjectionMode(llmagent.SessionSummaryInjectionUser),
+)
+```
+
+Memory preload 和 session recall preload 默认仍走 system context，以兼容既有行为。Cache-sensitive 场景可以显式切到 user/history 模式：
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithPreloadMemory(10),
+    llmagent.WithPreloadMemoryInjectionMode(llmagent.PreloadMemoryInjectionUser),
+    llmagent.WithPreloadSessionRecall(5),
+    llmagent.WithPreloadSessionRecallInjectionMode(llmagent.PreloadSessionRecallInjectionUser),
+)
+```
+
+这类 user 模式更利于保持 request prefix 稳定，但对应上下文会参与 token tailoring，极长上下文下可能被裁剪。
+
+Post-tool guidance 默认在有工具面的 Agent 上稳定注入。需要自定义时，可以显式配置一段按 Agent 或版本固定的 prompt；如果应用已经有自己的稳定工具后指导，也可以关闭框架默认注入：
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithPostToolPrompt("Answer naturally based on tool results."),
+    // llmagent.WithEnablePostToolPrompt(false),
+)
+```
+
+### Prompt Cache 影响面速查
+
+从 Prompt Cache 视角看，option 影响的位置比 option 名字更重要。下面先列“推荐优先使用或保留的能力”，再列“需要谨慎使用的动态能力”。
+
+推荐优先使用或保留：
+
+| 功能 / option | 主要影响位置 | 推荐理由 |
+| --- | --- | --- |
+| `openai.WithOptimizeForCache` | messages 顺序 | 默认 `VariantOpenAI` 开启后会把 system messages 前置，更利于自动 prefix cache；严格依赖原始顺序时再关闭 |
+| 默认 post-tool guidance / `llmagent.WithPostToolPrompt` | system message | 有工具面的 Agent 会从第一次模型请求起稳定注入，避免首次 tool result 后再改写 request prefix；自定义 prompt 应按 Agent/版本固定 |
+| `llmagent.WithSkillsLoadedContentInToolResults(true)` | system message / tool result | 把已加载 Skill 内容从 system message 移到匹配 tool result，减少 request prefix 污染 |
+| `summary.WithCacheSafeForking(true)` | summary 生成请求 | 克隆父请求并追加 compaction user message，让 summary 生成也复用父会话前缀 |
+| `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | history 附近 | Summary 频繁变化时可减少对 request prefix 的改写，但需要接受可能被 token tailoring 裁剪的取舍 |
+| `llmagent.WithAddCurrentTime(true)` 默认 date-only | system message / time tool | 日期级上下文同一天内稳定；精确时间通过 `environment_context_current_time` 按需获取 |
+| `agent.WithModelRequestExtraFields` 中的 `prompt_cache_key` | request body | 对支持该参数的服务方，稳定 key 可能帮助同类长前缀请求聚合；不要使用 request id / trace id |
+| `llmagent.WithReasoningContentMode` 默认模式 | assistant history | 默认丢弃历史 reasoning content，可减少历史体积，避免无谓增加输入 tokens |
+
+需要谨慎使用的动态能力：
+
+| 功能 / option | 主要影响位置 | 对 Prompt Cache 的影响 | 建议 |
+| --- | --- | --- | --- |
+| `llmagent.WithToolFilter` / `agent.WithToolFilter` | tools schema | 每次过滤结果不同会改变工具列表和 tools prefix | 过滤逻辑保持确定性；同类工具集合配同类 `prompt_cache_key` |
+| `llmagent.WithRefreshToolSetsOnRun(true)` | tools schema | 每次 Run 重新拉取 ToolSet，适合动态 MCP，但工具面变化会降低缓存复用 | cache-sensitive 场景尽量固定工具面；动态工具按场景分桶 |
+| `llmagent.WithSkillLoadMode` / `WithMaxLoadedSkills` | loaded Skills context | 影响动态 Skill 内容驻留轮次和体积 | 控制驻留时长和数量，避免无关 Skill 长期污染前缀 |
+| `llmagent.WithPreloadMemory` / `WithPreloadSessionRecall` | system message 或 history | 召回内容随 query 变化，放 system message 会更容易改写 request prefix | cache-sensitive 场景优先评估 user/history injection mode |
+| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message | 完整时间戳会按秒变化，容易破坏 request prefix | 只有明确需要每轮 system message 内含精确时间时才使用 |
+| 动态 `WithPostToolPrompt` | system message | 如果按请求生成，会把本来稳定的 post-tool guidance 变成动态前缀 | 按 Agent/版本固定；请求级临时要求放到 tool result 或后置 user/history |
+| `agent.WithInjectedContextMessages` / `WithLateContextMessages` | history 附近的临时消息 | 前者在 session history 之前，位置更靠前；后者贴近最新用户回合 | 临时上下文优先 late 注入，避免改写稳定前缀 |
+| `BeforeModel` callback / `EventMessageProjector` | 任意 request message | 这是强扩展点，可能重写 system、tools 或 history | 遵守 append-only 思路；尽量只在靠后位置追加动态上下文 |
+| Structured output schema 动态变化 | schema | schema 名称、字段顺序和描述变化都会影响前缀 | schema 尽量版本化和稳定化，避免同一类请求频繁变更 |
+
+### 透传 prompt_cache_key
+
+如果 OpenAI-compatible 服务方支持 `prompt_cache_key`，可以通过 request-level extra fields 透传：
+
+```go
+events, err := r.Run(
+    ctx,
+    "user-001",
+    "session-001",
+    model.NewUserMessage("Hello"),
+    agent.WithModelRequestExtraFields(map[string]any{
+        "prompt_cache_key": cacheKey,
+    }),
+)
+```
+
+`agent` 包中的 `WithModelRequestExtraFields` 说明了优先级：request-level extra fields 会优先于 model-level extra fields。OpenAI-compatible adapter 在 `model/openai` 包的请求构建阶段会先合并 model-level `extraFields`，再合并 `request.ExtraFields`，因此同名 key 下请求级值会覆盖模型级值。
+
+需要注意，`prompt_cache_key` 不是 Prompt Cache 的开关。固定 system prompt、稳定 tools，并保持 request prefix 不变，本身就可能触发自动 prefix cache；`prompt_cache_key` 的价值是给服务端一个额外的路由提示，帮助相同类别的长前缀请求更稳定地聚合到同一缓存路径上。
+
+`prompt_cache_key` 应表达“可复用前缀类别”，例如：
+
+```text
+app:customer-support:v3:tenant-basic-tools
+app:code-review:v5:go-tools
+```
+
+不要把它设置成请求唯一 ID、trace ID 或时间戳。
+
+### 观测 cache hit rate
+
+OpenAI-compatible API 的主观测字段是 `cached_tokens`：
+
+```go
+cached := usage.PromptTokensDetails.CachedTokens
+prompt := usage.PromptTokens
+hitRate := float64(cached) / float64(prompt)
+```
+
+tRPC-Agent-Go 的 provider-agnostic usage 结构定义在 `model` 包中，其中包括：
+
+- `model.Usage.PromptTokens`
+- `model.Usage.PromptTokensDetails.CachedTokens`
+- `model.Usage.PromptTokensDetails.CacheReadTokens`
+- `model.Usage.PromptTokensDetails.CacheCreationTokens`
+
+对 OpenAI-compatible API，`CachedTokens` 是主要字段；`CacheReadTokens` / `CacheCreationTokens` 主要服务于 Anthropic 等显式缓存形态。
+
+Telemetry 层也会拆分 token 类型。`internal/telemetry` 包会记录：
+
+- `input`
+- `input_cached`
+- `input_cache_read`
+- `input_cache_creation`
+- `output`
+
+一个简单的统计口径是：
+
+```text
+total_prompt_tokens = sum(usage.prompt_tokens)
+total_cached_tokens = sum(usage.prompt_tokens_details.cached_tokens)
+requests_with_cache = count(cached_tokens > 0)
+overall_hit_rate = total_cached_tokens / total_prompt_tokens
+```
+
+如果要估算成本节省，应使用服务方当前价格表和计费规则。不要把某个 provider 的缓存门槛、TTL 或折扣写成所有 OpenAI-compatible 服务的统一行为。
+
+## 六、实验结果与复现方式
+
+tRPC-Agent-Go 主仓库中的 benchmark 说明已经把 benchmark suites 迁移到独立的 [trpc-agent-go-benchmark](https://github.com/trpc-group/trpc-agent-go-benchmark) 仓库，其中 `anthropic_skills`、`summary` 等 suite 覆盖了 token usage、prompt cache、summary 等评测方向。对本文这类机制说明，主仓库的 `examples/promptcache/openai` 示例更适合作为轻量复现实验；如果要单独观察当前时间上下文对 Prompt Cache 的影响，可以参考 `examples/promptcache/timeprocessor`，它对比了 baseline、date-only、full-datetime 和 precise-tool 四种模式。
+
+下面是一组 provider-neutral 的示例运行结果，用来说明是否传入 `prompt_cache_key` 的观测方式：
+
+```text
+case                 requests  requests_with_cache  prompt_tokens  cached_tokens  overall_cache_rate
+without cache key    6         4                    13012          8000           61.48%
+with cache key       6         5                    13918          10112          72.65%
+```
+
+这组结果最重要的不是“带 key 一定提升多少”，而是三点：
+
+第一，不传 `prompt_cache_key` 也可以命中 Prompt Cache。OpenAI-compatible API 的核心仍然是 prefix cache routing：只要前缀足够稳定，服务端就有机会按 prefix 自动复用。
+
+第二，传入稳定的 `prompt_cache_key` 可能提高命中概率。本次运行中，带 key 的请求从 4 次命中提升到 5 次命中，overall cache rate 从 61.48% 提升到 72.65%。这符合 `prompt_cache_key` 作为缓存路由提示的定位。
+
+第三，tool call 没有阻止缓存命中。无论是否传入 `prompt_cache_key`，计算工具和时间工具调用轮次都出现过 cached tokens，说明 system、tools 和历史上下文中的稳定前缀仍然可以被复用。
+
+实验复现思路：
+
+- 准备一个超过服务方缓存门槛的长 system prompt。
+- 使用同一个 session 连续运行 6 轮对话。
+- 混合普通问答、calculator tool call、time tool call。
+- 每轮记录 prompt tokens、cached tokens、cache hit rate、是否发生 tool call。
+- 最后汇总总 prompt tokens、总 cached tokens、命中请求数、overall hit rate。
+
+下面的 per-turn 表格主要用于诊断每轮请求的变化。
+
+不传 `prompt_cache_key` 的单次运行结果：
+
+```text
+turn  prompt_tokens  cached_tokens  hit_rate  note
+1     1592           0              0.00%     cache warmup
+2     2077           0              0.00%     calculator tool
+3     2167           1984           91.56%    time tool
+4     2105           1792           85.13%    normal QA
+5     2574           2048           79.56%    calculator tool
+6     2497           2176           87.14%    normal QA
+```
+
+传入固定 `prompt_cache_key` 的单次运行结果：
+
+```text
+turn  prompt_tokens  cached_tokens  hit_rate  note
+1     1592           0              0.00%     cache warmup
+2     2239           1152           51.45%    calculator tool
+3     2329           2112           90.68%    time tool
+4     2267           2048           90.34%    normal QA
+5     2784           2240           80.46%    calculator tool
+6     2707           2560           94.57%    normal QA
+```
+
+这仍然只是示例运行结果，不是 SLA。两组运行的模型输出长度和历史上下文会略有差异，因此 prompt tokens 不完全相同；Prompt Cache 本身也是 best-effort 能力，命中率会受服务端路由、缓存保留时间、请求频率、prompt 是否超过门槛、前缀是否完全一致等因素影响。示例程序会打印估算节省，但实际计费应以服务方当前价格和缓存计费规则为准。
+
+## 七、实践清单
+
+### 稳定前缀
+
+- [ ] System prompt 作为长期规则保持稳定，不把每轮变化的用户信息、精确时间、检索片段塞进 system message 前部。
+- [ ] Tool schema、工具列表、structured output schema 尽量稳定；动态工具过滤要保证同类请求过滤结果一致。
+- [ ] Post-tool guidance 按 Agent 或版本固定，自定义 `WithPostToolPrompt` 时不要按请求生成。
+
+### 动态后置
+
+- [ ] 当前用户输入、tool result、临时 RAG 片段、精确当前时间等动态内容放到请求后部。
+- [ ] Skills 动态加载要控制驻留，优先使用 `WithSkillsLoadedContentInToolResults(true)` 减少 request prefix 变化。
+- [ ] 当前时间默认使用日期级上下文；需要精确时间时优先用 `environment_context_current_time` 工具。
+
+### 长会话
+
+- [ ] Summary 注入区分 preserved-head 和 cache-friendly；需要保持 request prefix 稳定时，优先评估 `WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)`。
+- [ ] Summary / compaction 也要 cache-safe，长会话可以启用 `summary.WithCacheSafeForking(true)`，复用父会话稳定前缀，把压缩指令追加到后面。
+- [ ] Memory / session recall preload 开启后，如果召回内容随 query 变化，cache-sensitive 场景优先评估 user/history injection mode。
+
+### 路由与观测
+
+- [ ] `prompt_cache_key` 表达可复用前缀类别，不表达请求唯一性。
+- [ ] 观测 `cached_tokens`、requests with cache、overall hit rate，并按服务方价格估算节省；短会话、低频请求、频繁变化上下文不应夸大收益。
+
+### 扩展点
+
+- [ ] `BeforeModel`、`EventMessageProjector`、`WithInjectedContextMessages` 这类扩展点要谨慎使用，尽量 append-only，并把动态内容放到靠后位置。
+
+## 附录：Anthropic API 的显式缓存断点
+
+Anthropic API 与 OpenAI-compatible API 的核心思想相同：稳定 prefix 才能复用。不同点在 API 形态。
+
+OpenAI-compatible API 的典型形态是自动 prefix cache：服务端根据请求 prefix 自动查找和写入缓存，用户通过 `cached_tokens` 观测，通过 `prompt_cache_key` 辅助路由。
+
+Anthropic API 则提供显式 `cache_control` breakpoint。[Anthropic Prompt Caching 文档](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)说明，缓存会引用从 `tools`、`system` 到 `messages` 中被 `cache_control` 标记块为止的完整 prompt；静态内容应放在前面，并在可复用内容末尾设置 breakpoint。
+
+tRPC-Agent-Go 的 Anthropic adapter 提供了三个对应选项：
+
+- `anthropic.WithCacheSystemPrompt(true)`
+- `anthropic.WithCacheTools(true)`
+- `anthropic.WithCacheMessages(true)`
+
+`examples/promptcache/anthropic` 可以作为附录实验：
+
+| 阶段 | 配置 | 观察重点 |
+| --- | --- | --- |
+| Phase 1 | `WithCacheSystemPrompt(true)` | system prompt 是否被读取自缓存 |
+| Phase 2 | `WithCacheSystemPrompt(true)` + `WithCacheTools(true)` | tool definitions 是否进入缓存范围 |
+| Phase 3 | system + tools + `WithCacheMessages(true)` | 多轮消息断点是否随对话推进，`cache_read` 是否增长 |
+
+附录用于理解 API 形态差异。正文实践仍以 OpenAI-compatible API 和 `cached_tokens` 作为主要示例口径。
+
+## 参考资料
+
+- [Hugging Face Transformers: Cache strategies / KV cache](https://huggingface.co/docs/transformers/en/kv_cache)
+- [OpenAI Prompt Caching](https://developers.openai.com/api/docs/guides/prompt-caching)
+- [DeepSeek Context Caching](https://api-docs.deepseek.com/guides/kv_cache/)
+- [DeepSeek 模型 & 价格](https://api-docs.deepseek.com/zh-cn/quick_start/pricing)
+- [Lessons from building Claude Code: Prompt caching is everything](https://claude.com/blog/lessons-from-building-claude-code-prompt-caching-is-everything)
+- [Anthropic Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
+- [Anthropic Prompt Caching Cookbook](https://github.com/anthropics/claude-cookbooks/blob/main/misc/prompt_caching.ipynb)
+- [DeepSeek API introduces Context Caching on Disk](https://api-docs.deepseek.com/news/news0802)
+- tRPC-Agent-Go benchmark 说明：[trpc-agent-go-benchmark](https://github.com/trpc-group/trpc-agent-go-benchmark)
+- [tRPC-Agent-Go 源码](https://github.com/trpc-group/trpc-agent-go) 包引用：
+  - `agent/llmagent`：LLM Agent 选项、request processors 组装、Skills 相关配置。
+  - `agent`：Run options 与 request-level extra fields。
+  - `internal/flow/processor`：instruction、content、post-tool、time、Skills tool result 等 request processors。
+  - `internal/flow/llmflow`：Invocation 内工具快照与工具列表稳定化。
+  - `model/openai`：OpenAI-compatible adapter、message cache optimization、tool conversion、extra fields 合并。
+  - `session/summary`：session summary、cache-safe summary forking 相关配置。
+  - `internal/tool/currenttime`：内置精确当前时间工具。
+  - `model`：provider-agnostic usage 结构。
+  - `internal/telemetry`：token usage metrics。
+  - `examples/promptcache/openai`：OpenAI-compatible Prompt Cache 示例。
+  - `examples/promptcache/summaryinjection`：summary / preload 注入模式对 Prompt Cache 的影响示例。
+  - `examples/promptcache/timeprocessor`：当前时间上下文的 Prompt Cache 示例。
+  - `examples/promptcache/anthropic`：Anthropic Prompt Cache 附录示例。

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -224,7 +224,7 @@ summarizer := summary.NewSummarizer(
 
 对比 Codex 和 Claude Code 的做法，可以看到它们都没有把“当前时分秒”当成稳定 prompt 的一部分：它们更偏向把运行环境信息控制在日期、时区这类粗粒度信息上，让高频变化的 clock time 不进入稳定前缀。
 
-**框架处理**：tRPC-Agent-Go 沿用已有的 `WithAddCurrentTime` 入口，但调整默认语义：默认只注入日期级 system context，把它当成“今天是哪一天”这种相对稳定的环境信息；如果模型需要精确到时分秒的当前时间，则通过内置的 `environment_context_current_time` 工具按需获取。
+**框架处理**：tRPC-Agent-Go 沿用已有的 `WithAddCurrentTime` 入口，但调整默认语义：默认只注入日期级 system context，把它当成“今天是哪一天”这种相对稳定的环境信息。在工具可用时，如果模型需要精确到时分秒的当前时间，可以通过内置的 `environment_context_current_time` 工具按需获取。遗留的 `WithOutputSchema` 会禁用所有工具，包括这个精确时间工具；如果同时需要结构化输出和精确时间工具，应使用 `WithStructuredOutputJSONSchema` 或 `WithStructuredOutputJSON`。
 
 ```go
 agent := llmagent.New(
@@ -326,7 +326,7 @@ agent := llmagent.New(
 | `llmagent.WithSkillsLoadedContentInToolResults(true)` | system message / tool result | 把已加载 Skill 内容从 system message 移到匹配 tool result，减少 request prefix 污染 |
 | `summary.WithCacheSafeForking(true)` | summary 生成请求 | 克隆父请求并追加 compaction user message，让 summary 生成也复用父会话前缀 |
 | `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | history 附近 | Summary 频繁变化时可减少对 request prefix 的改写，但需要接受可能被 token tailoring 裁剪的取舍 |
-| `llmagent.WithAddCurrentTime(true)` 默认 date-only | system message / time tool | 日期级上下文同一天内稳定；精确时间通过 `environment_context_current_time` 按需获取 |
+| `llmagent.WithAddCurrentTime(true)` 默认 date-only | system message / time tool | 日期级上下文同一天内稳定；工具启用时可通过 `environment_context_current_time` 获取精确时间。遗留的 `WithOutputSchema` 会禁用这个工具 |
 | `agent.WithModelRequestExtraFields` 中的 `prompt_cache_key` | request body | 对支持该参数的服务方，稳定 key 可能帮助同类长前缀请求聚合；不要使用 request id / trace id |
 | `llmagent.WithReasoningContentMode` 默认模式 | assistant history | 默认丢弃历史 reasoning content，可减少历史体积，避免无谓增加输入 tokens |
 
@@ -479,7 +479,7 @@ turn  prompt_tokens  cached_tokens  hit_rate  note
 
 - [ ] 当前用户输入、tool result、临时 RAG 片段、精确当前时间等动态内容放到请求后部。
 - [ ] Skills 动态加载要控制驻留，优先使用 `WithSkillsLoadedContentInToolResults(true)` 减少 request prefix 变化。
-- [ ] 当前时间默认使用日期级上下文；需要精确时间时优先用 `environment_context_current_time` 工具。
+- [ ] 当前时间默认使用日期级上下文；需要精确时间且工具可用时，优先用 `environment_context_current_time` 工具；如果结构化输出也需要工具，使用 `WithStructuredOutputJSONSchema` 或 `WithStructuredOutputJSON`，不要使用遗留的 `WithOutputSchema`。
 
 ### 长会话
 

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -1,7 +1,5 @@
 # 降低 Agent Token 成本：tRPC-Agent-Go 的 Prompt Cache 工程实践
 
-> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go) 是面向 Go 语言的自主式多 Agent 框架，具有工具调用、会话与记忆管理、制品管理、多 Agent 协同、图编排、知识库与可观测等能力。
->
 > 本文聚焦 Prompt Cache：它不是框架在本地保存模型 KV，而是模型服务侧对稳定 prompt prefix 的复用能力。tRPC-Agent-Go 的工程实践，是把 Agent 请求尽量组织成“稳定前缀 + 动态后缀”，从而提升缓存命中概率，降低可复用输入 tokens 的成本。
 
 大模型应用进入 Agent 阶段后，一个很直观的变化是：每次请求变长了。


### PR DESCRIPTION
## What changed

Added sanitized Chinese and English blog posts for Agent observability and Prompt Cache engineering, and registered them in the MkDocs Blog navigation for both locales.

## Why

These posts make the internal technical writeups safe for the public GitHub documentation by removing internal domains, repositories, platform-specific links, internal business references, and provider-specific private deployment details.

## Testing

- Searched the new posts for internal domains, repository names, internal business identifiers, and private model/platform terms.
- Ran `uvx --with-requirements docs/mkdocs/assets/requirements.txt mkdocs build --strict -f docs/mkdocs.yml`.

## Notes for reviewers

Please review the sanitization choices, especially the provider-neutral Prompt Cache experiment wording and the observability backend generalization.


Made with [Cursor](https://cursor.com)