### PR TITLE
knowledge/source/auto: warn on unknown file_reader_type instead of silent text fallback

### DIFF
--- a/knowledge/source/auto/auto_source.go
+++ b/knowledge/source/auto/auto_source.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
@@ -30,6 +31,7 @@ import (
 	filesource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/file"
 	urlsource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/url"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/transform"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 )
 
 const (
@@ -94,8 +96,22 @@ func (s *Source) initializeReaders() {
 
 	// Override with specific reader if fileReaderType is set
 	if s.fileReaderType != "" {
-		if r, exists := reader.GetAllReaders(opts...)[string(s.fileReaderType)]; exists {
+		readers := reader.GetAllReaders(opts...)
+		if r, exists := readers[string(s.fileReaderType)]; exists {
 			s.textReader = r
+		} else {
+			// The requested reader is not registered (its package was likely not
+			// imported), so we silently kept the default text reader. Warn instead of
+			// degrading quietly, since text chunking is not format-aware.
+			available := make([]string, 0, len(readers))
+			for t := range readers {
+				available = append(available, t)
+			}
+			sort.Strings(available)
+			log.Warnf("auto source: no reader registered for file_reader_type %q; "+
+				"falling back to the text reader (chunking will not be format-aware). "+
+				"Import the corresponding reader package to register it. registered types: %v",
+				s.fileReaderType, available)
 		}
 	}
 }


### PR DESCRIPTION
## What changed

`auto.Source.initializeReaders` now logs a warning when `WithFileReaderType`
is set but no reader is registered for that type. Previously it silently kept
the default text reader. The warning lists the registered reader types. There
is no behavior change otherwise — it still falls back to the text reader.

## Why

Readers self-register via a blank import side effect. When the corresponding
reader package is not imported, `GetAllReaders()` has no entry for the requested
type, so the `if exists` check fails and `Source` keeps the default text reader.
Chunking then silently degrades to plain-text splitting, losing format-aware
behavior such as markdown structural splitting and the `markdown_header_path`
metadata. This is hard to diagnose because nothing is logged. The warning makes
the missing-import root cause discoverable.

## Testing

- `go build ./knowledge/...`
- `go vet ./knowledge/source/auto/...`
- `go test ./knowledge/source/auto/...` (all pass)

## Notes for reviewers

- Logging only; public API and chunking behavior are unchanged.
- The warning fires once per `auto.New` when an unregistered `fileReaderType`
  is requested; registered types are sorted for stable output.
