### PR TITLE
feat(telemetry): add invoke skill observability

### DIFF
--- a/docs/mkdocs/en/observability.md
+++ b/docs/mkdocs/en/observability.md
@@ -66,6 +66,16 @@ You can view tracing data in the Langfuse console.
 
 For message payload compatibility and the recommended OTel `role + parts` fields, see [Multimodal Telemetry Messages](telemetry-multimodal.md).
 
+#### Skill Observability
+
+When `skill_load` activates a skill, tRPC-Agent-Go emits a Galileo-compatible `invoke_skill {skill.name}` INTERNAL child span under the existing `execute_tool skill_load` span. The `invoke_skill` span represents skill activation/materialization: validating the selected skill and materializing `SKILL.md` content into agent context. It does not cover later `chat`, `workspace_exec`, `skill_run`, `skill_exec`, or other tool execution.
+
+The same activation also records `gen_ai.request_cnt` and `gen_ai.client.operation.duration` on the `trpc_agent_go.internal.invoke_skill` meter. Metric attributes are limited to low-cardinality fields such as `gen_ai.operation.name`, `gen_ai.skill.name`, `gen_ai.skill.id`, `gen_ai.user.id`, `gen_ai.agent.id`, optional `gen_ai.agent.name`, optional `gen_ai.skill.version`, and `error.type` on failures. Paths, content hashes, document lists, tool call IDs, and prompt content are not metric attributes.
+
+By default, the Langfuse exporter drops `invoke_skill` spans so existing Langfuse observation types, tree shape, and token accounting stay unchanged. Galileo and generic OTel exporters can still consume the span and metrics.
+
+For privacy, the `gen_ai.invoke_skill_request` / `gen_ai.invoke_skill_response` span attributes use safe path/content summaries by default: a compact path representation, SHA-256 hashes, byte sizes, and a truncated content preview. Galileo exporters may convert these attributes into platform events for display. Use the span attribute policy to drop, omit, or further truncate these attributes when exporting sensitive skill repositories.
+
 ##### Integration Code Description
 Langfuse supports receiving Trace data via the `/api/public/otel` (OTLP) endpoint, supporting HTTP/protobuf only, not gRPC.
 The above code integrates with Langfuse by setting `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.

--- a/docs/mkdocs/zh/observability.md
+++ b/docs/mkdocs/zh/observability.md
@@ -68,6 +68,16 @@ go run .
 
 消息 payload 的兼容策略以及推荐使用的 OTel `role + parts` 字段，见 [多模态遥测消息](telemetry-multimodal.md)。
 
+#### Skill 可观测
+
+当 `skill_load` 激活 skill 时，tRPC-Agent-Go 会在已有的 `execute_tool skill_load` span 下创建 Galileo 兼容的 `invoke_skill {skill.name}` INTERNAL 子 span。`invoke_skill` 表示 skill activation/materialization：确认被选中的 skill，并把 `SKILL.md` 内容物化进 Agent 上下文。它不覆盖后续的 `chat`、`workspace_exec`、`skill_run`、`skill_exec` 或其他 tool 执行。
+
+同一次激活也会在 `trpc_agent_go.internal.invoke_skill` meter 上记录 `gen_ai.request_cnt` 和 `gen_ai.client.operation.duration`。Metric attributes 只包含低基数字段，例如 `gen_ai.operation.name`、`gen_ai.skill.name`、`gen_ai.skill.id`、`gen_ai.user.id`、`gen_ai.agent.id`、可选的 `gen_ai.agent.name`、可选的 `gen_ai.skill.version`，以及失败时的 `error.type`。路径、content hash、doc 列表、tool call id 和提示词内容不会进入 metric attributes。
+
+Langfuse exporter 默认会 drop `invoke_skill` spans，因此已有 Langfuse observation 类型、树结构和 token 统计保持不变。Galileo 和通用 OTel exporter 仍可消费该 span 和 metrics。
+
+出于隐私考虑，`gen_ai.invoke_skill_request` / `gen_ai.invoke_skill_response` span attributes 默认使用安全的路径和内容摘要：紧凑路径表示、SHA-256 hash、字节数以及截断后的内容预览。Galileo exporter 可在导出侧把这些 attributes 转换为平台事件展示。导出敏感 skill repository 时，可通过 span attribute policy 进一步 drop、omit 或 truncate 这些 attributes。
+
 ##### 接入代码说明
 Langfuse 支持通过 `/api/public/otel` (OTLP) 接口接收 Trace 数据，仅支持 HTTP/protobuf，不支持 gRPC。
 上述代码通过设置 `OTEL_EXPORTER_OTLP_HEADERS` 和 `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` 来接入 langfuse。

--- a/internal/telemetry/metric_invoke_skill.go
+++ b/internal/telemetry/metric_invoke_skill.go
@@ -1,0 +1,86 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/metric/histogram"
+	"trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/metrics"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
+)
+
+const unknownMetricValue = "_unknown"
+
+var (
+	// InvokeSkillMeter is the meter used for recording skill activation metrics.
+	InvokeSkillMeter metric.Meter = MeterProvider.Meter(metrics.MeterNameInvokeSkill)
+
+	// InvokeSkillMetricGenAIRequestCnt records the number of skill activations.
+	InvokeSkillMetricGenAIRequestCnt metric.Int64Counter
+	// InvokeSkillMetricGenAIClientOperationDuration records skill activation/materialization durations in seconds.
+	InvokeSkillMetricGenAIClientOperationDuration *histogram.DynamicFloat64Histogram
+)
+
+// InvokeSkillMetricAttributes contains metric attributes for skill activation.
+type InvokeSkillMetricAttributes struct {
+	SkillName    string
+	SkillID      string
+	SkillVersion string
+	UserID       string
+	AgentID      string
+	AgentName    string
+	Error        error
+	ErrorType    string
+}
+
+func (a InvokeSkillMetricAttributes) toAttributes() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeSkill),
+		attribute.String(semconvtrace.KeyGenAISkillName, nonEmpty(a.SkillName)),
+		attribute.String(semconvtrace.KeyGenAISkillID, nonEmpty(a.SkillID)),
+		attribute.String(semconvtrace.KeyGenAIUserID, nonEmpty(a.UserID)),
+		attribute.String(semconvtrace.KeyGenAIAgentID, nonEmpty(a.AgentID)),
+	}
+	if a.AgentName != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAgentName, a.AgentName))
+	}
+	if a.SkillVersion != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAISkillVersion, a.SkillVersion))
+	}
+	if a.ErrorType != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, a.ErrorType))
+	} else if a.Error != nil {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyErrorType, ToErrorType(a.Error, semconvtrace.ValueDefaultErrorType)))
+	}
+	return attrs
+}
+
+// ReportInvokeSkillMetrics reports skill activation/materialization metrics.
+func ReportInvokeSkillMetrics(ctx context.Context, attrs InvokeSkillMetricAttributes, duration time.Duration) {
+	as := attrs.toAttributes()
+	if InvokeSkillMetricGenAIRequestCnt != nil {
+		InvokeSkillMetricGenAIRequestCnt.Add(ctx, 1, metric.WithAttributes(as...))
+	}
+	if InvokeSkillMetricGenAIClientOperationDuration != nil {
+		InvokeSkillMetricGenAIClientOperationDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(as...))
+	}
+}
+
+func nonEmpty(value string) string {
+	if value == "" {
+		return unknownMetricValue
+	}
+	return value
+}

--- a/internal/telemetry/metric_invoke_skill_test.go
+++ b/internal/telemetry/metric_invoke_skill_test.go
@@ -1,0 +1,69 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package telemetry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
+)
+
+func TestInvokeSkillMetricAttributes(t *testing.T) {
+	attrs := InvokeSkillMetricAttributes{
+		SkillName: "code_review",
+		SkillID:   "skill_123",
+		UserID:    "user-1",
+		AgentID:   "agent-1",
+		AgentName: "review-agent",
+		Error:     errors.New("boom"),
+	}.toAttributes()
+
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAIOperationName, OperationInvokeSkill)
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAISkillName, "code_review")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAISkillID, "skill_123")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAIUserID, "user-1")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAIAgentID, "agent-1")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAIAgentName, "review-agent")
+	requireMetricAttr(t, attrs, semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType)
+	requireNoMetricAttr(t, attrs, semconvtrace.KeyGenAIConversationID)
+	requireNoMetricAttr(t, attrs, semconvtrace.KeyGenAIAppName)
+	requireNoMetricAttr(t, attrs, semconvtrace.KeyGenAIInvokeSkillRequest)
+	requireNoMetricAttr(t, attrs, semconvtrace.KeyGenAIInvokeSkillResponse)
+}
+
+func TestInvokeSkillMetricAttributes_UnknownRequiredDimensions(t *testing.T) {
+	attrs := InvokeSkillMetricAttributes{}.toAttributes()
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAISkillName, "_unknown")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAISkillID, "_unknown")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAIUserID, "_unknown")
+	requireMetricAttr(t, attrs, semconvtrace.KeyGenAIAgentID, "_unknown")
+}
+
+func requireMetricAttr(t *testing.T, attrs []attribute.KeyValue, key, value string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			require.Equal(t, value, attr.Value.AsString())
+			return
+		}
+	}
+	t.Fatalf("missing metric attribute %s", key)
+}
+
+func requireNoMetricAttr(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, attr := range attrs {
+		require.NotEqual(t, key, string(attr.Key))
+	}
+}

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -51,6 +51,7 @@ const (
 	OperationCreateAgent     = "create_agent"
 	OperationEmbeddings      = "embeddings"
 	OperationWorkflow        = "workflow"
+	OperationInvokeSkill     = "invoke_skill"
 )
 
 // NewChatSpanName creates a new chat span name.
@@ -61,6 +62,14 @@ func NewChatSpanName(requestModel string) string {
 // NewExecuteToolSpanName creates a new execute tool span name.
 func NewExecuteToolSpanName(toolName string) string {
 	return OperationExecuteTool + " " + toolName
+}
+
+// NewInvokeSkillSpanName creates a new invoke skill span name.
+func NewInvokeSkillSpanName(skillName string) string {
+	if skillName == "" {
+		return OperationInvokeSkill
+	}
+	return OperationInvokeSkill + " " + skillName
 }
 
 // WorkflowType is the normalized type vocabulary used by workflow spans.
@@ -92,9 +101,105 @@ type Workflow struct {
 	Error    error
 }
 
+// InvokeSkillAttributes contains the attributes for an invoke_skill span.
+//
+// In trpc-agent-go, invoke_skill represents skill activation/materialization:
+// the framework has selected a skill and materialized its SKILL.md/docs into
+// agent context. It deliberately does not cover later chat/tool execution.
+type InvokeSkillAttributes struct {
+	Invocation       *agent.Invocation
+	SkillName        string
+	SkillID          string
+	SkillVersion     string
+	SkillDescription string
+	Phase            string
+	Request          string
+	Response         string
+	Error            error
+	ErrorType        string
+}
+
 // NewWorkflowSpanName creates a new workflow span name.
 func NewWorkflowSpanName(workflowName string) string {
 	return OperationWorkflow + " " + workflowName
+}
+
+// TraceInvokeSkill traces skill activation/materialization.
+func TraceInvokeSkill(span trace.Span, attrs *InvokeSkillAttributes) {
+	if !span.IsRecording() {
+		return
+	}
+	kvs := []attribute.KeyValue{
+		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeSkill),
+	}
+	if attrs == nil {
+		span.SetAttributes(kvs...)
+		return
+	}
+	kvs = append(kvs,
+		attribute.String(semconvtrace.KeyGenAISkillName, attrs.SkillName),
+		attribute.String(semconvtrace.KeyGenAISkillID, attrs.SkillID),
+	)
+	if attrs.SkillVersion != "" {
+		kvs = append(kvs, attribute.String(semconvtrace.KeyGenAISkillVersion, attrs.SkillVersion))
+	}
+	if attrs.SkillDescription != "" {
+		kvs = append(kvs, attribute.String(semconvtrace.KeyGenAISkillDescription, attrs.SkillDescription))
+	}
+	if attrs.Phase != "" {
+		kvs = append(kvs, attribute.String(semconvtrace.KeyGenAISkillPhase, attrs.Phase))
+	}
+	kvs = append(kvs, buildInvokeSkillInvocationAttributes(attrs.Invocation)...)
+	if attrs.ErrorType != "" {
+		kvs = append(kvs, attribute.String(semconvtrace.KeyErrorType, attrs.ErrorType))
+	} else if attrs.Error != nil {
+		kvs = append(kvs, attribute.String(semconvtrace.KeyErrorType, ToErrorType(attrs.Error, semconvtrace.ValueDefaultErrorType)))
+	}
+	if attrs.Error != nil {
+		kvs = append(kvs, attribute.String(semconvtrace.KeyErrorMessage, attrs.Error.Error()))
+		span.SetStatus(codes.Error, attrs.Error.Error())
+		span.RecordError(attrs.Error)
+	}
+	if attrs.Request != "" {
+		kvs = appendStringAttribute(kvs, OperationInvokeSkill, semconvtrace.KeyGenAIInvokeSkillRequest, "", func() ([]byte, error) {
+			return []byte(attrs.Request), nil
+		})
+	}
+	if attrs.Response != "" {
+		kvs = appendStringAttribute(kvs, OperationInvokeSkill, semconvtrace.KeyGenAIInvokeSkillResponse, "", func() ([]byte, error) {
+			return []byte(attrs.Response), nil
+		})
+	}
+	span.SetAttributes(kvs...)
+}
+
+func buildInvokeSkillInvocationAttributes(inv *agent.Invocation) []attribute.KeyValue {
+	if inv == nil {
+		return nil
+	}
+	var attrs []attribute.KeyValue
+	agentName, agentID := resolveInvocationAgentIdentity(inv)
+	if agentName != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAgentName, agentName))
+	}
+	if agentID != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAgentID, agentID))
+	}
+	if inv.Session != nil {
+		if inv.Session.ID != "" {
+			attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIConversationID, inv.Session.ID))
+		}
+		if inv.Session.AppName != "" {
+			attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAppName, inv.Session.AppName))
+		}
+		if inv.Session.UserID != "" {
+			attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIUserID, inv.Session.UserID))
+		}
+	} else if inv.RunOptions.AppName != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAIAppName, inv.RunOptions.AppName))
+	}
+	return attrs
 }
 
 type telemetryMessage struct {

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -202,7 +202,6 @@ func TestTraceInvokeSkill(t *testing.T) {
 	require.Len(t, span.recordedErrors, 1)
 	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIInvokeSkillRequest, `{"safe_path":"code_review/SKILL.md"}`))
 	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIInvokeSkillResponse, `{"content_sha256":"abc"}`))
-	require.Empty(t, span.events)
 }
 
 func TestTraceInvokeSkill_AttributePolicy(t *testing.T) {
@@ -225,7 +224,6 @@ func TestTraceInvokeSkill_AttributePolicy(t *testing.T) {
 	got, ok := attrStringValue(span.attrs, semconvtrace.KeyGenAIInvokeSkillResponse)
 	require.True(t, ok)
 	require.Contains(t, got, `"omitted":true`)
-	require.Empty(t, span.events)
 }
 
 func TestTraceWorkflow(t *testing.T) {

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -75,9 +76,15 @@ func newStubSpan() *stubSpan {
 type recordingSpan struct {
 	trace.Span
 	attrs          []attribute.KeyValue
+	events         []recordedEvent
 	status         codes.Code
 	statusDesc     string
 	recordedErrors []error
+}
+
+type recordedEvent struct {
+	name  string
+	attrs []attribute.KeyValue
 }
 
 func (s *recordingSpan) IsRecording() bool {
@@ -96,6 +103,11 @@ func (s *recordingSpan) SetStatus(c codes.Code, msg string) {
 func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	s.recordedErrors = append(s.recordedErrors, err)
 	s.Span.RecordError(err, opts...)
+}
+func (s *recordingSpan) AddEvent(name string, opts ...trace.EventOption) {
+	cfg := trace.NewEventConfig(opts...)
+	s.events = append(s.events, recordedEvent{name: name, attrs: cfg.Attributes()})
+	s.Span.AddEvent(name, opts...)
 }
 func newRecordingSpan() *recordingSpan {
 	_, sp := trace.NewNoopTracerProvider().Tracer("test").Start(context.Background(), "op")
@@ -146,6 +158,74 @@ func attrStringValue(attrs []attribute.KeyValue, key string) (string, bool) {
 
 func TestNewWorkflowSpanName(t *testing.T) {
 	require.Equal(t, "workflow myflow", NewWorkflowSpanName("myflow"))
+}
+
+func TestNewInvokeSkillSpanName(t *testing.T) {
+	require.Equal(t, "invoke_skill code_review", NewInvokeSkillSpanName("code_review"))
+	require.Equal(t, "invoke_skill", NewInvokeSkillSpanName(""))
+}
+
+func TestTraceInvokeSkill(t *testing.T) {
+	err := errors.New("boom")
+	span := newRecordingSpan()
+	TraceInvokeSkill(span, &InvokeSkillAttributes{
+		Invocation: &agent.Invocation{
+			AgentName: "agent-a",
+			Session: &session.Session{
+				ID:      "sess-1",
+				AppName: "app-a",
+				UserID:  "user-a",
+			},
+		},
+		SkillName:        "code_review",
+		SkillID:          "skill_123",
+		SkillDescription: "review code",
+		Phase:            "materialize",
+		Request:          `{"safe_path":"code_review/SKILL.md"}`,
+		Response:         `{"content_sha256":"abc"}`,
+		Error:            err,
+	})
+
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIOperationName, OperationInvokeSkill))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAISkillName, "code_review"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAISkillID, "skill_123"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAISkillDescription, "review code"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAISkillPhase, "materialize"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAgentName, "agent-a"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAgentID, "agent-a"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIConversationID, "sess-1"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIAppName, "app-a"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIUserID, "user-a"))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyErrorType, semconvtrace.ValueDefaultErrorType))
+	require.Equal(t, codes.Error, span.status)
+	require.Equal(t, "boom", span.statusDesc)
+	require.Len(t, span.recordedErrors, 1)
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIInvokeSkillRequest, `{"safe_path":"code_review/SKILL.md"}`))
+	require.True(t, hasAttr(span.attrs, semconvtrace.KeyGenAIInvokeSkillResponse, `{"content_sha256":"abc"}`))
+	require.Empty(t, span.events)
+}
+
+func TestTraceInvokeSkill_AttributePolicy(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+	SetSpanAttributePolicy(AppendAttributeRule(SpanAttributePolicy{}, AttributeRule{
+		Operation: OperationInvokeSkill,
+		Key:       semconvtrace.KeyGenAIInvokeSkillResponse,
+		Action:    AttributeOmit,
+		MaxBytes:  8,
+	}))
+
+	span := newRecordingSpan()
+	TraceInvokeSkill(span, &InvokeSkillAttributes{
+		SkillName: "review",
+		SkillID:   "skill_1",
+		Request:   `{"safe_path":"review/SKILL.md"}`,
+		Response:  strings.Repeat("x", 32),
+	})
+
+	got, ok := attrStringValue(span.attrs, semconvtrace.KeyGenAIInvokeSkillResponse)
+	require.True(t, ok)
+	require.Contains(t, got, `"omitted":true`)
+	require.Empty(t, span.events)
 }
 
 func TestTraceWorkflow(t *testing.T) {

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -75,17 +75,39 @@ func transform(ss []*tracepb.ResourceSpans) []*tracepb.ResourceSpans {
 				continue
 			}
 
+			filtered := scopeSpans.Spans[:0]
 			for _, span := range scopeSpans.Spans {
 				if span == nil {
+					filtered = append(filtered, span)
+					continue
+				}
+				if spanOperationName(span) == itelemetry.OperationInvokeSkill {
 					continue
 				}
 
 				transformSpan(span)
+				filtered = append(filtered, span)
 			}
+			scopeSpans.Spans = filtered
 		}
 	}
 
 	return ss
+}
+
+func spanOperationName(span *tracepb.Span) string {
+	if span == nil {
+		return ""
+	}
+	for _, attr := range span.Attributes {
+		if attr.Key != semconvtrace.KeyGenAIOperationName {
+			continue
+		}
+		if attr.Value != nil && attr.Value.GetStringValue() != "" {
+			return attr.Value.GetStringValue()
+		}
+	}
+	return ""
 }
 
 // transformSpan applies langfuse-specific transformations to a span
@@ -95,15 +117,7 @@ func transformSpan(span *tracepb.Span) {
 	}
 
 	// Find the operation name
-	var operationName string
-	for _, attr := range span.Attributes {
-		if attr.Key == semconvtrace.KeyGenAIOperationName {
-			if attr.Value != nil && attr.Value.GetStringValue() != "" {
-				operationName = attr.Value.GetStringValue()
-				break
-			}
-		}
-	}
+	operationName := spanOperationName(span)
 
 	switch operationName {
 	case itelemetry.OperationInvokeAgent:

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -122,6 +122,41 @@ func TestTransform(t *testing.T) {
 	}
 }
 
+func TestTransform_DropsInvokeSkillSpans(t *testing.T) {
+	input := []*tracepb.ResourceSpans{{
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Spans: []*tracepb.Span{
+				{
+					Name:   "invoke_skill code_review",
+					SpanId: []byte("invoke-skill"),
+					Attributes: []*commonpb.KeyValue{{
+						Key: semconvtrace.KeyGenAIOperationName,
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_StringValue{StringValue: itelemetry.OperationInvokeSkill},
+						},
+					}},
+				},
+				{
+					Name:   "plain-span",
+					SpanId: []byte("plain-span"),
+					Attributes: []*commonpb.KeyValue{{
+						Key: semconvtrace.KeyGenAIOperationName,
+						Value: &commonpb.AnyValue{
+							Value: &commonpb.AnyValue_StringValue{StringValue: "plain"},
+						},
+					}},
+				},
+			},
+		}},
+	}}
+
+	got := transform(input)
+	require.Len(t, got, 1)
+	require.Len(t, got[0].ScopeSpans, 1)
+	require.Len(t, got[0].ScopeSpans[0].Spans, 1)
+	require.Equal(t, "plain-span", got[0].ScopeSpans[0].Spans[0].Name)
+}
+
 func TestTransformSpan(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -126,6 +126,7 @@ func TestTransform_DropsInvokeSkillSpans(t *testing.T) {
 	input := []*tracepb.ResourceSpans{{
 		ScopeSpans: []*tracepb.ScopeSpans{{
 			Spans: []*tracepb.Span{
+				nil,
 				{
 					Name:   "invoke_skill code_review",
 					SpanId: []byte("invoke-skill"),
@@ -153,8 +154,9 @@ func TestTransform_DropsInvokeSkillSpans(t *testing.T) {
 	got := transform(input)
 	require.Len(t, got, 1)
 	require.Len(t, got[0].ScopeSpans, 1)
-	require.Len(t, got[0].ScopeSpans[0].Spans, 1)
-	require.Equal(t, "plain-span", got[0].ScopeSpans[0].Spans[0].Name)
+	require.Len(t, got[0].ScopeSpans[0].Spans, 2)
+	require.Nil(t, got[0].ScopeSpans[0].Spans[0])
+	require.Equal(t, "plain-span", got[0].ScopeSpans[0].Spans[1].Name)
 }
 
 func TestTransformSpan(t *testing.T) {

--- a/telemetry/metric/metric.go
+++ b/telemetry/metric/metric.go
@@ -118,6 +118,9 @@ func InitMeterProvider(mp metric.MeterProvider) error {
 	if err := initInvokeAgentMetrics(mp); err != nil {
 		return err
 	}
+	if err := initInvokeSkillMetrics(mp); err != nil {
+		return err
+	}
 	if err := initWorkflowMetrics(mp); err != nil {
 		return err
 	}
@@ -141,6 +144,8 @@ func SetHistogramBuckets(meterName string, metricName string, boundaries []float
 		return setExecuteToolHistogramBuckets(metricName, boundaries)
 	case metrics.MeterNameInvokeAgent:
 		return setInvokeAgentHistogramBuckets(metricName, boundaries)
+	case metrics.MeterNameInvokeSkill:
+		return setInvokeSkillHistogramBuckets(metricName, boundaries)
 	case metrics.MeterNameWorkflow:
 		return setWorkflowHistogramBuckets(metricName, boundaries)
 	default:
@@ -236,6 +241,18 @@ func setWorkflowHistogramBuckets(metricName string, boundaries []float64) error 
 	}
 }
 
+func setInvokeSkillHistogramBuckets(metricName string, boundaries []float64) error {
+	switch metricName {
+	case metrics.MetricGenAIClientOperationDuration:
+		if itelemetry.InvokeSkillMetricGenAIClientOperationDuration == nil {
+			return fmt.Errorf("invoke skill metric %s not initialized", metricName)
+		}
+		return itelemetry.InvokeSkillMetricGenAIClientOperationDuration.SetBuckets(boundaries)
+	default:
+		return fmt.Errorf("unknown or unsupported invoke skill histogram metric: %s", metricName)
+	}
+}
+
 func initInvokeAgentMetrics(mp metric.MeterProvider) error {
 	if mp == nil {
 		return fmt.Errorf("invoke agent meter provider is nil")
@@ -274,6 +291,34 @@ func initInvokeAgentMetrics(mp metric.MeterProvider) error {
 		metrics.MeterNameInvokeAgent,
 		metrics.MetricGenAIClientOperationDuration,
 		metric.WithDescription("Duration of client operation"),
+		metric.WithUnit("s"),
+	); err != nil {
+		return fmt.Errorf("failed to create %s metric %s: %w", meterName, metrics.MetricGenAIClientOperationDuration, err)
+	}
+
+	return nil
+}
+
+func initInvokeSkillMetrics(mp metric.MeterProvider) error {
+	if mp == nil {
+		return fmt.Errorf("invoke skill meter provider is nil")
+	}
+
+	itelemetry.InvokeSkillMeter = mp.Meter(metrics.MeterNameInvokeSkill)
+	meterName := metrics.MeterNameInvokeSkill
+	var err error
+	if itelemetry.InvokeSkillMetricGenAIRequestCnt, err = itelemetry.InvokeSkillMeter.Int64Counter(
+		metrics.MetricGenAIRequestCnt,
+		metric.WithDescription("Total number of invoke skill requests"),
+		metric.WithUnit("1"),
+	); err != nil {
+		return fmt.Errorf("failed to create %s metric %s: %w", meterName, metrics.MetricGenAIRequestCnt, err)
+	}
+	if itelemetry.InvokeSkillMetricGenAIClientOperationDuration, err = histogram.NewDynamicFloat64Histogram(
+		mp,
+		metrics.MeterNameInvokeSkill,
+		metrics.MetricGenAIClientOperationDuration,
+		metric.WithDescription("Duration of skill activation/materialization"),
 		metric.WithUnit("s"),
 	); err != nil {
 		return fmt.Errorf("failed to create %s metric %s: %w", meterName, metrics.MetricGenAIClientOperationDuration, err)

--- a/telemetry/metric/metric_test.go
+++ b/telemetry/metric/metric_test.go
@@ -351,6 +351,15 @@ func TestInitMeterProvider(t *testing.T) {
 	if itelemetry.ExecuteToolMetricGenAIClientOperationDuration == nil {
 		t.Error("ExecuteToolMetricGenAIClientOperationDuration was not created")
 	}
+	if itelemetry.InvokeSkillMeter == nil {
+		t.Error("InvokeSkillMeter was not created")
+	}
+	if itelemetry.InvokeSkillMetricGenAIRequestCnt == nil {
+		t.Error("InvokeSkillMetricGenAIRequestCnt was not created")
+	}
+	if itelemetry.InvokeSkillMetricGenAIClientOperationDuration == nil {
+		t.Error("InvokeSkillMetricGenAIClientOperationDuration was not created")
+	}
 	if itelemetry.WorkflowMeter == nil {
 		t.Error("WorkflowMeter was not created")
 	}
@@ -442,6 +451,7 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 	origInvokeTTFT := itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken
 	origInvokeTokenUsage := itelemetry.InvokeAgentMetricGenAIClientTokenUsage
 	origInvokeOpDur := itelemetry.InvokeAgentMetricGenAIClientOperationDuration
+	origInvokeSkillOpDur := itelemetry.InvokeSkillMetricGenAIClientOperationDuration
 	origWorkflowOpDur := itelemetry.WorkflowMetricGenAIClientOperationDuration
 	origWorkflowElapsed := itelemetry.WorkflowMetricGenAIWorkflowElapsedTime
 	defer func() {
@@ -456,6 +466,7 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 		itelemetry.InvokeAgentMetricGenAIClientTimeToFirstToken = origInvokeTTFT
 		itelemetry.InvokeAgentMetricGenAIClientTokenUsage = origInvokeTokenUsage
 		itelemetry.InvokeAgentMetricGenAIClientOperationDuration = origInvokeOpDur
+		itelemetry.InvokeSkillMetricGenAIClientOperationDuration = origInvokeSkillOpDur
 		itelemetry.WorkflowMetricGenAIClientOperationDuration = origWorkflowOpDur
 		itelemetry.WorkflowMetricGenAIWorkflowElapsedTime = origWorkflowElapsed
 	}()
@@ -507,6 +518,16 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 				itelemetry.InvokeAgentMetricGenAIClientTokenUsage = nil
 			case metrics.MetricGenAIClientOperationDuration:
 				itelemetry.InvokeAgentMetricGenAIClientOperationDuration = nil
+			}
+		}
+	}
+
+	nilInvokeSkillMetric := func(metricName string) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Helper()
+			switch metricName {
+			case metrics.MetricGenAIClientOperationDuration:
+				itelemetry.InvokeSkillMetricGenAIClientOperationDuration = nil
 			}
 		}
 	}
@@ -595,6 +616,13 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 			metricName: metrics.MetricGenAIClientOperationDuration,
 			boundaries: []float64{0.1, 1, 10},
 		},
+		// --- Invoke-skill success ---
+		{
+			name:       "invoke-skill: operation duration",
+			meterName:  metrics.MeterNameInvokeSkill,
+			metricName: metrics.MetricGenAIClientOperationDuration,
+			boundaries: []float64{0.1, 1, 10},
+		},
 		// --- Execute-workflow success ---
 		{
 			name:       "workflow: operation duration",
@@ -641,6 +669,14 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 			boundaries:  []float64{1},
 			wantErr:     true,
 			errContains: "unknown or unsupported invoke agent histogram metric",
+		},
+		{
+			name:        "unsupported invoke-skill metric",
+			meterName:   metrics.MeterNameInvokeSkill,
+			metricName:  "unknown.metric",
+			boundaries:  []float64{1},
+			wantErr:     true,
+			errContains: "unknown or unsupported invoke skill histogram metric",
 		},
 		{
 			name:        "unsupported workflow metric",
@@ -739,6 +775,15 @@ func TestSetHistogramBuckets_RoutingAndErrors(t *testing.T) {
 			metricName:  metrics.MetricGenAIClientOperationDuration,
 			boundaries:  []float64{1},
 			before:      nilInvokeAgentMetric(metrics.MetricGenAIClientOperationDuration),
+			wantErr:     true,
+			errContains: "not initialized",
+		},
+		{
+			name:        "invoke-skill operation duration not initialized",
+			meterName:   metrics.MeterNameInvokeSkill,
+			metricName:  metrics.MetricGenAIClientOperationDuration,
+			boundaries:  []float64{1},
+			before:      nilInvokeSkillMetric(metrics.MetricGenAIClientOperationDuration),
 			wantErr:     true,
 			errContains: "not initialized",
 		},

--- a/telemetry/semconv/metrics/metrics.go
+++ b/telemetry/semconv/metrics/metrics.go
@@ -39,6 +39,8 @@ const (
 
 	// MetricGenAIClientOperationDuration represents the duration of client operation.
 	MetricGenAIClientOperationDuration = "gen_ai.client.operation.duration"
+	// MetricGenAIRequestCnt represents the request count for GenAI operations.
+	MetricGenAIRequestCnt = "gen_ai.request_cnt"
 	// MetricGenAIWorkflowElapsedTime represents workflow elapsed time between two lifecycle points.
 	MetricGenAIWorkflowElapsedTime = "gen_ai.workflow.elapsed_time"
 	// KeyGenAIWorkflowElapsedFrom represents the lifecycle point elapsed time is measured from.
@@ -79,4 +81,6 @@ const (
 	MeterNameWorkflow = "trpc_agent_go.internal.workflow"
 	// MeterNameInvokeAgent is the meter name for invoke agent operations.
 	MeterNameInvokeAgent = "trpc_agent_go.internal.invoke_agent"
+	// MeterNameInvokeSkill is the meter name for invoke skill operations.
+	MeterNameInvokeSkill = "trpc_agent_go.internal.invoke_skill"
 )

--- a/telemetry/semconv/trace/trace.go
+++ b/telemetry/semconv/trace/trace.go
@@ -140,6 +140,21 @@ const (
 	// KeyGenAIRequestToolDefinitions is the attribute key for tool definitions.
 	KeyGenAIRequestToolDefinitions = "gen_ai.request.tool.definitions"
 
+	// KeyGenAISkillName is the attribute key for skill name.
+	KeyGenAISkillName = "gen_ai.skill.name"
+	// KeyGenAISkillID is the attribute key for skill id.
+	KeyGenAISkillID = "gen_ai.skill.id"
+	// KeyGenAISkillVersion is the attribute key for skill version.
+	KeyGenAISkillVersion = "gen_ai.skill.version"
+	// KeyGenAISkillDescription is the attribute key for skill description.
+	KeyGenAISkillDescription = "gen_ai.skill.description"
+	// KeyGenAISkillPhase is the attribute key for skill lifecycle phase.
+	KeyGenAISkillPhase = "gen_ai.skill.phase"
+	// KeyGenAIInvokeSkillRequest is the attribute key for skill request.
+	KeyGenAIInvokeSkillRequest = "gen_ai.invoke_skill_request"
+	// KeyGenAIInvokeSkillResponse is the attribute key for skill response.
+	KeyGenAIInvokeSkillResponse = "gen_ai.invoke_skill_response"
+
 	// KeyErrorType is the attribute key for error type.
 	// Reference: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/recording-errors.md#recording-errors-on-spans
 	KeyErrorType = "error.type"

--- a/telemetry/trace/span_attribute_policy.go
+++ b/telemetry/trace/span_attribute_policy.go
@@ -25,6 +25,8 @@ const (
 	OperationWorkflow SpanOperation = itelemetry.OperationWorkflow
 	// OperationExecuteTool is the tool execution operation.
 	OperationExecuteTool SpanOperation = itelemetry.OperationExecuteTool
+	// OperationInvokeSkill is the skill activation/materialization operation.
+	OperationInvokeSkill SpanOperation = itelemetry.OperationInvokeSkill
 )
 
 // AttributeKey identifies a span attribute key for policy rules.
@@ -43,6 +45,10 @@ const (
 	AttrOutputMessages AttributeKey = semconvtrace.KeyGenAIOutputMessages
 	// AttrOutputMessagesOTel is the OTel output messages attribute key.
 	AttrOutputMessagesOTel AttributeKey = semconvtrace.KeyGenAIOutputMessagesOTel
+	// AttrInvokeSkillRequest is the invoke skill request attribute key.
+	AttrInvokeSkillRequest AttributeKey = semconvtrace.KeyGenAIInvokeSkillRequest
+	// AttrInvokeSkillResponse is the invoke skill response attribute key.
+	AttrInvokeSkillResponse AttributeKey = semconvtrace.KeyGenAIInvokeSkillResponse
 )
 
 // SpanAttributePolicy controls production-side span attribute behavior.

--- a/tool/skill/load.go
+++ b/tool/skill/load.go
@@ -13,10 +13,22 @@ package skill
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
+	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -90,6 +102,22 @@ type loadInput struct {
 	IncludeAllDocs bool     `json:"include_all_docs,omitempty"`
 }
 
+type invokeSkillRequestDetail struct {
+	SkillName  string `json:"skill_name"`
+	SkillID    string `json:"skill_id"`
+	SafePath   string `json:"safe_path,omitempty"`
+	PathSHA256 string `json:"path_sha256,omitempty"`
+	PathBytes  int    `json:"path_bytes,omitempty"`
+}
+
+type invokeSkillResponseDetail struct {
+	SkillName      string `json:"skill_name"`
+	SkillID        string `json:"skill_id"`
+	ContentSHA256  string `json:"content_sha256,omitempty"`
+	ContentBytes   int    `json:"content_bytes,omitempty"`
+	ContentPreview string `json:"content_preview,omitempty"`
+}
+
 // Declaration implements tool.Tool.
 func (t *LoadTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{
@@ -124,21 +152,250 @@ func (t *LoadTool) Declaration() *tool.Declaration {
 }
 
 // Call validates and returns a message for user feedback.
-func (t *LoadTool) Call(ctx context.Context, args []byte) (any, error) {
+func (t *LoadTool) Call(ctx context.Context, args []byte) (result any, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var invocation *agent.Invocation
+	if inv, ok := agent.InvocationFromContext(ctx); ok {
+		invocation = inv
+	}
 	var in loadInput
 	if err := json.Unmarshal(args, &in); err != nil {
+		t.traceInvokeSkill(ctx, invocation, "", nil, "", "", time.Now(), err)
 		return nil, fmt.Errorf("invalid args: %w", err)
 	}
+	in.Skill = strings.TrimSpace(in.Skill)
+	tracker := t.startInvokeSkill(ctx, invocation, in.Skill)
 	if in.Skill == "" {
+		err := fmt.Errorf("skill is required")
+		tracker.finish(nil, "", "", err)
 		return nil, fmt.Errorf("skill is required")
 	}
+	var loadedSkill *skill.Skill
 	if t.repo != nil {
 		// validate existence
-		if _, err := skill.GetForContext(ctx, t.repo, in.Skill); err != nil {
-			return nil, fmt.Errorf("unknown skill: %s", in.Skill)
+		loadedSkill, err = skill.GetForContext(ctx, t.repo, in.Skill)
+		if err != nil {
+			err = fmt.Errorf("unknown skill: %s", in.Skill)
+			tracker.finish(nil, "", "", err)
+			return nil, err
 		}
 	}
+	skillPath, skillContent := t.skillMaterial(ctx, in.Skill, loadedSkill)
+	tracker.finish(loadedSkill, skillPath, skillContent, nil)
 	return fmt.Sprintf("loaded: %s", in.Skill), nil
+}
+
+type invokeSkillTracker struct {
+	ctx        context.Context
+	invocation *agent.Invocation
+	repo       skill.Repository
+	span       trace.Span
+	started    bool
+	start      time.Time
+	skillName  string
+	skillID    string
+}
+
+func (t *LoadTool) startInvokeSkill(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	skillName string,
+) *invokeSkillTracker {
+	skillName = strings.TrimSpace(skillName)
+	skillID := stableSkillID(t.repo, skillName)
+	spanName := itelemetry.NewInvokeSkillSpanName(skillName)
+	_, span, started := itrace.StartSpan(ctx, invocation, spanName)
+	return &invokeSkillTracker{
+		ctx:        ctx,
+		invocation: invocation,
+		repo:       t.repo,
+		span:       span,
+		started:    started,
+		start:      time.Now(),
+		skillName:  skillName,
+		skillID:    skillID,
+	}
+}
+
+func (t *LoadTool) traceInvokeSkill(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	skillName string,
+	loadedSkill *skill.Skill,
+	skillPath string,
+	skillContent string,
+	start time.Time,
+	err error,
+) {
+	tracker := t.startInvokeSkill(ctx, invocation, skillName)
+	tracker.start = start
+	tracker.finish(loadedSkill, skillPath, skillContent, err)
+}
+
+func (t *invokeSkillTracker) finish(
+	loadedSkill *skill.Skill,
+	skillPath string,
+	skillContent string,
+	err error,
+) {
+	if t == nil {
+		return
+	}
+	skillName := t.skillName
+	description := ""
+	if loadedSkill != nil {
+		if loadedSkill.Summary.Name != "" {
+			skillName = loadedSkill.Summary.Name
+		}
+		description = loadedSkill.Summary.Description
+	}
+	if skillName == "" {
+		skillName = t.skillName
+	}
+	if skillName == "" {
+		skillName = "_unknown"
+	}
+	if t.started {
+		itelemetry.TraceInvokeSkill(t.span, &itelemetry.InvokeSkillAttributes{
+			Invocation:       t.invocation,
+			SkillName:        skillName,
+			SkillID:          t.skillID,
+			SkillDescription: description,
+			Phase:            "materialize",
+			Request:          invokeSkillRequestJSON(skillName, t.skillID, skillPath),
+			Response:         invokeSkillResponseJSON(skillName, t.skillID, skillContent),
+			Error:            err,
+		})
+		t.span.End()
+	}
+	itelemetry.ReportInvokeSkillMetrics(t.ctx, itelemetry.InvokeSkillMetricAttributes{
+		SkillName: skillName,
+		SkillID:   t.skillID,
+		UserID:    invocationUserID(t.invocation),
+		AgentID:   invocationAgentID(t.invocation),
+		AgentName: invocationAgentName(t.invocation),
+		Error:     err,
+	}, time.Since(t.start))
+}
+
+func (t *LoadTool) skillMaterial(
+	ctx context.Context,
+	skillName string,
+	loadedSkill *skill.Skill,
+) (string, string) {
+	var content string
+	if loadedSkill != nil {
+		content = loadedSkill.Body
+	}
+	if t.repo == nil {
+		return "", content
+	}
+	dir, err := t.repo.Path(skillName)
+	if err != nil || dir == "" {
+		return "", content
+	}
+	path := filepath.Join(dir, skill.SkillFile)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.WarnfContext(ctx, "skill_load telemetry read failed for %s: %v", skillName, err)
+		return path, content
+	}
+	return path, string(b)
+}
+
+func invokeSkillRequestJSON(skillName, skillID, path string) string {
+	detail := invokeSkillRequestDetail{
+		SkillName: skillName,
+		SkillID:   skillID,
+	}
+	if path != "" {
+		detail.SafePath = safeSkillPath(path)
+		detail.PathSHA256 = sha256Hex(path)
+		detail.PathBytes = len(path)
+	}
+	return mustJSON(detail)
+}
+
+func invokeSkillResponseJSON(skillName, skillID, content string) string {
+	detail := invokeSkillResponseDetail{
+		SkillName: skillName,
+		SkillID:   skillID,
+	}
+	if content != "" {
+		detail.ContentSHA256 = sha256Hex(content)
+		detail.ContentBytes = len(content)
+		detail.ContentPreview = truncateUTF8(content, 1024)
+	}
+	return mustJSON(detail)
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+func safeSkillPath(path string) string {
+	file := filepath.Base(path)
+	dir := filepath.Base(filepath.Dir(path))
+	if dir == "." || dir == string(filepath.Separator) || dir == "" {
+		return file
+	}
+	return filepath.Join(dir, file)
+}
+
+func stableSkillID(repo skill.Repository, skillName string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(fmt.Sprintf("%T\n", repo)))
+	if rooted, ok := repo.(skill.RootedRepository); ok {
+		roots := rooted.Roots()
+		sort.Strings(roots)
+		for _, root := range roots {
+			_, _ = h.Write([]byte(sha256Hex(root)))
+			_, _ = h.Write([]byte{'\n'})
+		}
+	}
+	_, _ = h.Write([]byte(strings.TrimSpace(skillName)))
+	sum := h.Sum(nil)
+	return "skill_" + hex.EncodeToString(sum[:8])
+}
+
+func sha256Hex(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func truncateUTF8(value string, maxBytes int) string {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.ValidString(value[:cut]) {
+		cut--
+	}
+	return value[:cut]
+}
+
+func invocationUserID(inv *agent.Invocation) string {
+	if inv == nil || inv.Session == nil {
+		return ""
+	}
+	return inv.Session.UserID
+}
+
+func invocationAgentName(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	return inv.AgentName
+}
+
+func invocationAgentID(inv *agent.Invocation) string {
+	return invocationAgentName(inv)
 }
 
 // StateDelta builds delta keys to mark loaded skill and doc selection.

--- a/tool/skill/load.go
+++ b/tool/skill/load.go
@@ -292,7 +292,7 @@ func (t *LoadTool) skillMaterial(
 	if t.repo == nil {
 		return "", content
 	}
-	dir, err := t.repo.Path(skillName)
+	dir, err := skill.PathForContext(ctx, t.repo, skillName)
 	if err != nil || dir == "" {
 		return "", content
 	}
@@ -436,6 +436,7 @@ func (t *LoadTool) stateDelta(
 		log.Warnf("skill_load state parse failed: %v", err)
 		return nil, ""
 	}
+	in.Skill = strings.TrimSpace(in.Skill)
 	if in.Skill == "" {
 		return nil, ""
 	}

--- a/tool/skill/load_test.go
+++ b/tool/skill/load_test.go
@@ -14,13 +14,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
+	telemetrytrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 )
 
 type mockRepo struct {
@@ -235,6 +243,95 @@ func TestLoadTool_Call_ContextAwareRepoHonorsFilter(t *testing.T) {
 
 	_, err = lt.Call(ctx, []byte(`{"skill":"beta"}`))
 	require.ErrorContains(t, err, "unknown skill: beta")
+}
+
+func TestLoadTool_Call_EmitsInvokeSkillChildSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	originalProvider := telemetrytrace.TracerProvider
+	originalTracer := telemetrytrace.Tracer
+	telemetrytrace.TracerProvider = provider
+	telemetrytrace.Tracer = provider.Tracer("skill-load-test")
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		telemetrytrace.TracerProvider = originalProvider
+		telemetrytrace.Tracer = originalTracer
+	})
+
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "code_review")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	skillContent := `---
+name: code_review
+description: Review code changes.
+---
+Use careful code review practices.`
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, skill.SkillFile), []byte(skillContent), 0o644))
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	lt := NewLoadTool(repo)
+	inv := &agent.Invocation{
+		AgentName: "review-agent",
+		Session: &session.Session{
+			ID:      "sess-1",
+			AppName: "app-1",
+			UserID:  "user-1",
+		},
+	}
+	var ctx context.Context = agent.NewInvocationContext(context.Background(), inv)
+	ctx, parent := telemetrytrace.Tracer.Start(ctx, itelemetry.NewExecuteToolSpanName("skill_load"))
+	out, err := lt.Call(ctx, []byte(`{"skill":"code_review"}`))
+	parent.End()
+	require.NoError(t, err)
+	require.Equal(t, "loaded: code_review", out)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 2)
+	var invokeSpan, parentSpan sdktrace.ReadOnlySpan
+	for _, sp := range spans {
+		switch sp.Name() {
+		case itelemetry.NewInvokeSkillSpanName("code_review"):
+			invokeSpan = sp
+		case itelemetry.NewExecuteToolSpanName("skill_load"):
+			parentSpan = sp
+		}
+	}
+	require.NotNil(t, parentSpan)
+	require.NotNil(t, invokeSpan)
+	require.Equal(t, parentSpan.SpanContext().SpanID(), invokeSpan.Parent().SpanID())
+	requireSpanAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIOperationName, itelemetry.OperationInvokeSkill)
+	requireSpanAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAISkillName, "code_review")
+	requireSpanAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIAgentID, "review-agent")
+	requireSpanAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIUserID, "user-1")
+	require.Empty(t, invokeSpan.Events())
+	requestDetail := spanStringAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIInvokeSkillRequest)
+	require.Contains(t, requestDetail, `"safe_path":"code_review/SKILL.md"`)
+	require.NotContains(t, requestDetail, root)
+	responseDetail := spanStringAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIInvokeSkillResponse)
+	require.Contains(t, responseDetail, `"content_sha256"`)
+	require.Contains(t, responseDetail, "Use careful code review practices.")
+}
+
+func requireSpanAttr(t *testing.T, attrs []attribute.KeyValue, key, value string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			require.Equal(t, value, attr.Value.AsString())
+			return
+		}
+	}
+	t.Fatalf("missing attribute %s", key)
+}
+
+func spanStringAttr(t *testing.T, attrs []attribute.KeyValue, key string) string {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	t.Fatalf("missing span attribute %s", key)
+	return ""
 }
 
 func TestSkillNameEnum_ContextAwareRepoReturnsNil(t *testing.T) {

--- a/tool/skill/load_test.go
+++ b/tool/skill/load_test.go
@@ -45,6 +45,52 @@ func (m *mockRepo) Get(name string) (*skill.Skill, error) {
 }
 func (m *mockRepo) Path(name string) (string, error) { return "", nil }
 
+type contextPathRepo struct {
+	name        string
+	defaultDir  string
+	contextDir  string
+	contextBody string
+}
+
+func (r *contextPathRepo) Summaries() []skill.Summary {
+	return []skill.Summary{{Name: r.name}}
+}
+
+func (r *contextPathRepo) Get(name string) (*skill.Skill, error) {
+	if name != r.name {
+		return nil, errors.New("not found")
+	}
+	return &skill.Skill{Summary: skill.Summary{Name: name}}, nil
+}
+
+func (r *contextPathRepo) Path(name string) (string, error) {
+	if name != r.name {
+		return "", errors.New("not found")
+	}
+	return r.defaultDir, nil
+}
+
+func (r *contextPathRepo) SummariesForContext(context.Context) []skill.Summary {
+	return r.Summaries()
+}
+
+func (r *contextPathRepo) GetForContext(_ context.Context, name string) (*skill.Skill, error) {
+	if name != r.name {
+		return nil, errors.New("not found")
+	}
+	return &skill.Skill{
+		Summary: skill.Summary{Name: name},
+		Body:    r.contextBody,
+	}, nil
+}
+
+func (r *contextPathRepo) PathForContext(_ context.Context, name string) (string, error) {
+	if name != r.name {
+		return "", errors.New("not found")
+	}
+	return r.contextDir, nil
+}
+
 func TestLoadTool_Call_ValidatesAndDelta(t *testing.T) {
 	repo := &mockRepo{ok: map[string]bool{"calc": true}}
 	lt := NewLoadTool(repo)
@@ -94,6 +140,26 @@ func TestLoadTool_Call_ValidatesAndDelta(t *testing.T) {
 		`["calc"]`,
 		string(delta[skill.LoadedOrderKey("tester")]),
 	)
+}
+
+func TestLoadTool_StateDelta_TrimsSkillName(t *testing.T) {
+	repo := &mockRepo{ok: map[string]bool{"calc": true}}
+	lt := NewLoadTool(repo)
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Session:   &session.Session{State: session.StateMap{}},
+	}
+
+	delta := lt.StateDeltaForInvocation(
+		inv,
+		"call-1",
+		[]byte(`{"skill":" calc ","docs":["A.md"]}`),
+		nil,
+	)
+
+	require.Equal(t, []byte("1"), delta[skill.LoadedKey("tester", "calc")])
+	require.Equal(t, []byte(`["A.md"]`), delta[skill.DocsKey("tester", "calc")])
+	require.Equal(t, `["calc"]`, string(delta[skill.LoadedOrderKey("tester")]))
 }
 
 func TestLoadTool_Call_Errors(t *testing.T) {
@@ -310,6 +376,68 @@ Use careful code review practices.`
 	responseDetail := spanStringAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIInvokeSkillResponse)
 	require.Contains(t, responseDetail, `"content_sha256"`)
 	require.Contains(t, responseDetail, "Use careful code review practices.")
+}
+
+func TestLoadTool_Call_InvokeSkillUsesContextAwarePath(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	originalProvider := telemetrytrace.TracerProvider
+	originalTracer := telemetrytrace.Tracer
+	telemetrytrace.TracerProvider = provider
+	telemetrytrace.Tracer = provider.Tracer("skill-load-test")
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		telemetrytrace.TracerProvider = originalProvider
+		telemetrytrace.Tracer = originalTracer
+	})
+
+	root := t.TempDir()
+	defaultDir := filepath.Join(root, "default", "context_skill")
+	contextDir := filepath.Join(root, "context", "context_skill")
+	require.NoError(t, os.MkdirAll(defaultDir, 0o755))
+	require.NoError(t, os.MkdirAll(contextDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(defaultDir, skill.SkillFile),
+		[]byte("default skill body"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(contextDir, skill.SkillFile),
+		[]byte("context skill body"),
+		0o644,
+	))
+	repo := &contextPathRepo{
+		name:        "context_skill",
+		defaultDir:  defaultDir,
+		contextDir:  contextDir,
+		contextBody: "context skill body",
+	}
+	lt := NewLoadTool(repo)
+	var ctx context.Context = agent.NewInvocationContext(
+		context.Background(),
+		&agent.Invocation{AgentName: "context-agent"},
+	)
+	ctx, parent := telemetrytrace.Tracer.Start(ctx, itelemetry.NewExecuteToolSpanName("skill_load"))
+	out, err := lt.Call(ctx, []byte(`{"skill":"context_skill"}`))
+	parent.End()
+	require.NoError(t, err)
+	require.Equal(t, "loaded: context_skill", out)
+
+	var invokeSpan sdktrace.ReadOnlySpan
+	for _, sp := range recorder.Ended() {
+		if sp.Name() == itelemetry.NewInvokeSkillSpanName("context_skill") {
+			invokeSpan = sp
+			break
+		}
+	}
+	require.NotNil(t, invokeSpan)
+	requestDetail := spanStringAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIInvokeSkillRequest)
+	responseDetail := spanStringAttr(t, invokeSpan.Attributes(), semconvtrace.KeyGenAIInvokeSkillResponse)
+	require.Contains(t, requestDetail, `"safe_path":"context_skill/SKILL.md"`)
+	require.Contains(t, requestDetail, sha256Hex(filepath.Join(contextDir, skill.SkillFile)))
+	require.NotContains(t, requestDetail, sha256Hex(filepath.Join(defaultDir, skill.SkillFile)))
+	require.Contains(t, responseDetail, sha256Hex("context skill body"))
+	require.NotContains(t, responseDetail, sha256Hex("default skill body"))
 }
 
 func requireSpanAttr(t *testing.T, attrs []attribute.KeyValue, key, value string) {


### PR DESCRIPTION
## Summary
- Add `invoke_skill` tracing for skill activation/materialization under `execute_tool skill_load`.
- Add invoke skill request/duration metrics and low-cardinality metric attributes.
- Keep Langfuse compatibility by filtering `invoke_skill` spans, and document Galileo/plugin mapping expectations.

## Test plan
- `go test ./internal/telemetry ./telemetry/metric ./telemetry/langfuse ./tool/skill`
- Galileo smoke: verified `invoke_skill ocr` span appears with `gen_ai.invoke_skill_request` and `gen_ai.invoke_skill_response` attributes.


Made with [Cursor](https://cursor.com)