### PR TITLE
{evaluation}: fix promptiter cancel status race

### DIFF
--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -44,6 +44,7 @@ type manager struct {
 	storedResultSlimming engine.RunResultSlimming
 	mu                   sync.Mutex
 	cancelFuncs          map[string]context.CancelFunc
+	canceledRuns         map[string]struct{}
 	closed               bool
 }
 
@@ -63,6 +64,7 @@ func New(appName string, engine engine.Engine, opts ...Option) (Manager, error) 
 		store:                options.store,
 		storedResultSlimming: options.storedResultSlimming,
 		cancelFuncs:          make(map[string]context.CancelFunc),
+		canceledRuns:         make(map[string]struct{}),
 	}, nil
 }
 
@@ -101,8 +103,11 @@ func (m *manager) Get(ctx context.Context, runID string) (*engine.RunResult, err
 // Cancel cancels one running PromptIter run.
 func (m *manager) Cancel(ctx context.Context, runID string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	cancel, ok := m.cancelFuncs[runID]
+	if ok {
+		m.canceledRuns[runID] = struct{}{}
+	}
+	m.mu.Unlock()
 	if !ok {
 		return fmt.Errorf("run %q is not running: %w", runID, os.ErrNotExist)
 	}
@@ -112,8 +117,7 @@ func (m *manager) Cancel(ctx context.Context, runID string) error {
 		return err
 	}
 	if run.Status == engine.RunStatusQueued || run.Status == engine.RunStatusRunning {
-		run.Status = engine.RunStatusCanceled
-		run.ErrorMessage = "run canceled"
+		markRunCanceled(run)
 		if err := m.store.Update(ctx, m.appName, m.slimStoredRun(run)); err != nil {
 			return err
 		}
@@ -134,6 +138,7 @@ func (m *manager) Close() error {
 		cancelFuncs = append(cancelFuncs, cancel)
 	}
 	m.cancelFuncs = make(map[string]context.CancelFunc)
+	m.canceledRuns = make(map[string]struct{})
 	m.mu.Unlock()
 	for _, cancel := range cancelFuncs {
 		cancel()
@@ -142,56 +147,63 @@ func (m *manager) Close() error {
 }
 
 func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequest) {
-	m.mu.Lock()
 	run, err := m.store.Get(context.Background(), m.appName, runID)
 	if err != nil {
-		delete(m.cancelFuncs, runID)
-		m.mu.Unlock()
+		m.clearRun(runID)
 		return
 	}
-	if ctx.Err() != nil {
+	if ctx.Err() != nil || m.isCanceled(runID) {
 		if run.Status == engine.RunStatusQueued || run.Status == engine.RunStatusRunning {
-			run.Status = engine.RunStatusCanceled
-			if run.ErrorMessage == "" {
-				run.ErrorMessage = "run canceled"
-			}
+			markRunCanceled(run)
 			_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(run))
 		}
-		delete(m.cancelFuncs, runID)
-		m.mu.Unlock()
+		m.clearRun(runID)
 		return
 	}
 	run.Status = engine.RunStatusRunning
-	if err := m.store.Update(context.Background(), m.appName, m.slimStoredRun(run)); err != nil {
-		delete(m.cancelFuncs, runID)
-		m.mu.Unlock()
+	if ctx.Err() != nil || m.isCanceled(runID) {
+		markRunCanceled(run)
+		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(run))
+		m.clearRun(runID)
 		return
 	}
-	m.mu.Unlock()
+	if err := m.store.Update(context.Background(), m.appName, m.slimStoredRun(run)); err != nil {
+		m.clearRun(runID)
+		return
+	}
+	if ctx.Err() != nil || m.isCanceled(runID) {
+		markRunCanceled(run)
+		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(run))
+		m.clearRun(runID)
+		return
+	}
 	observer := &observer{
 		manager: m,
 		run:     run,
 	}
 	result, err := m.engine.Run(ctx, request, engine.WithObserver(observer.append))
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			observer.run.Status = engine.RunStatusCanceled
-			if observer.run.ErrorMessage == "" {
-				observer.run.ErrorMessage = "run canceled"
-			}
+		if errors.Is(err, context.Canceled) || m.isCanceled(runID) {
+			markRunCanceled(observer.run)
 		} else {
 			observer.run.Status = engine.RunStatusFailed
 			observer.run.ErrorMessage = err.Error()
 		}
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
-		m.clearCancel(runID)
+		m.clearRun(runID)
+		return
+	}
+	if ctx.Err() != nil || m.isCanceled(runID) {
+		markRunCanceled(observer.run)
+		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
+		m.clearRun(runID)
 		return
 	}
 	if result == nil {
 		observer.run.Status = engine.RunStatusFailed
 		observer.run.ErrorMessage = "engine returned nil run"
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
-		m.clearCancel(runID)
+		m.clearRun(runID)
 		return
 	}
 	result.ID = runID
@@ -202,7 +214,7 @@ func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequ
 		observer.run.ErrorMessage = err.Error()
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
 	}
-	m.clearCancel(runID)
+	m.clearRun(runID)
 }
 
 func (m *manager) slimStoredRun(run *engine.RunResult) *engine.RunResult {
@@ -212,10 +224,25 @@ func (m *manager) slimStoredRun(run *engine.RunResult) *engine.RunResult {
 	return slimRunResult(run, m.storedResultSlimming)
 }
 
-func (m *manager) clearCancel(runID string) {
+func (m *manager) isCanceled(runID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.canceledRuns[runID]
+	return ok
+}
+
+func (m *manager) clearRun(runID string) {
 	m.mu.Lock()
 	delete(m.cancelFuncs, runID)
+	delete(m.canceledRuns, runID)
 	m.mu.Unlock()
+}
+
+func markRunCanceled(run *engine.RunResult) {
+	run.Status = engine.RunStatusCanceled
+	if run.ErrorMessage == "" {
+		run.ErrorMessage = "run canceled"
+	}
 }
 
 func validateRunRequest(request *engine.RunRequest) error {

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -101,8 +101,8 @@ func (m *manager) Get(ctx context.Context, runID string) (*engine.RunResult, err
 // Cancel cancels one running PromptIter run.
 func (m *manager) Cancel(ctx context.Context, runID string) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	cancel, ok := m.cancelFuncs[runID]
-	m.mu.Unlock()
 	if !ok {
 		return fmt.Errorf("run %q is not running: %w", runID, os.ErrNotExist)
 	}
@@ -142,16 +142,32 @@ func (m *manager) Close() error {
 }
 
 func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequest) {
+	m.mu.Lock()
 	run, err := m.store.Get(context.Background(), m.appName, runID)
 	if err != nil {
-		m.clearCancel(runID)
+		delete(m.cancelFuncs, runID)
+		m.mu.Unlock()
+		return
+	}
+	if ctx.Err() != nil {
+		if run.Status == engine.RunStatusQueued || run.Status == engine.RunStatusRunning {
+			run.Status = engine.RunStatusCanceled
+			if run.ErrorMessage == "" {
+				run.ErrorMessage = "run canceled"
+			}
+			_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(run))
+		}
+		delete(m.cancelFuncs, runID)
+		m.mu.Unlock()
 		return
 	}
 	run.Status = engine.RunStatusRunning
 	if err := m.store.Update(context.Background(), m.appName, m.slimStoredRun(run)); err != nil {
-		m.clearCancel(runID)
+		delete(m.cancelFuncs, runID)
+		m.mu.Unlock()
 		return
 	}
+	m.mu.Unlock()
 	observer := &observer{
 		manager: m,
 		run:     run,

--- a/evaluation/workflow/promptiter/manager/manager.go
+++ b/evaluation/workflow/promptiter/manager/manager.go
@@ -183,27 +183,26 @@ func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequ
 	}
 	result, err := m.engine.Run(ctx, request, engine.WithObserver(observer.append))
 	if err != nil {
-		if errors.Is(err, context.Canceled) || m.isCanceled(runID) {
+		canceled := m.finishRun(runID)
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil || canceled {
 			markRunCanceled(observer.run)
 		} else {
 			observer.run.Status = engine.RunStatusFailed
 			observer.run.ErrorMessage = err.Error()
 		}
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
-		m.clearRun(runID)
 		return
 	}
-	if ctx.Err() != nil || m.isCanceled(runID) {
+	canceled := m.finishRun(runID)
+	if ctx.Err() != nil || canceled {
 		markRunCanceled(observer.run)
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
-		m.clearRun(runID)
 		return
 	}
 	if result == nil {
 		observer.run.Status = engine.RunStatusFailed
 		observer.run.ErrorMessage = "engine returned nil run"
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
-		m.clearRun(runID)
 		return
 	}
 	result.ID = runID
@@ -214,7 +213,6 @@ func (m *manager) run(ctx context.Context, runID string, request *engine.RunRequ
 		observer.run.ErrorMessage = err.Error()
 		_ = m.store.Update(context.Background(), m.appName, m.slimStoredRun(observer.run))
 	}
-	m.clearRun(runID)
 }
 
 func (m *manager) slimStoredRun(run *engine.RunResult) *engine.RunResult {
@@ -236,6 +234,15 @@ func (m *manager) clearRun(runID string) {
 	delete(m.cancelFuncs, runID)
 	delete(m.canceledRuns, runID)
 	m.mu.Unlock()
+}
+
+func (m *manager) finishRun(runID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, canceled := m.canceledRuns[runID]
+	delete(m.cancelFuncs, runID)
+	delete(m.canceledRuns, runID)
+	return canceled
 }
 
 func markRunCanceled(run *engine.RunResult) {

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -62,6 +62,7 @@ type scriptedStore struct {
 	closeErr        error
 	closeCalls      int
 	updateCalls     int
+	beforeUpdate    func(appName string, run *promptiterengine.RunResult)
 	runs            map[string]*promptiterengine.RunResult
 }
 
@@ -106,6 +107,9 @@ func (s *scriptedStore) Update(ctx context.Context, appName string, run *prompti
 		s.runs = make(map[string]*promptiterengine.RunResult)
 	}
 	run.AppName = appName
+	if s.beforeUpdate != nil {
+		s.beforeUpdate(appName, run)
+	}
 	s.runs[run.ID] = run
 	return nil
 }
@@ -372,6 +376,73 @@ func TestManagerCancelTransitionsRun(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, promptiterengine.RunStatusCanceled, current.Status)
 	assert.NotEmpty(t, current.ErrorMessage)
+}
+
+func TestManagerCancelWinsOverConcurrentRunningUpdate(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	store := &scriptedStore{
+		runs: map[string]*promptiterengine.RunResult{
+			"run-1": {
+				AppName: "demo-app",
+				ID:      "run-1",
+				Status:  promptiterengine.RunStatusQueued,
+			},
+		},
+	}
+	var (
+		cancelErr    error
+		engineCalled bool
+		managerInst  Manager
+		triggered    bool
+	)
+	store.beforeUpdate = func(appName string, run *promptiterengine.RunResult) {
+		if appName != "demo-app" || run.ID != "run-1" ||
+			run.Status != promptiterengine.RunStatusRunning || triggered {
+			return
+		}
+		triggered = true
+		cancelErr = managerInst.Cancel(context.Background(), "run-1")
+		// Simulate the in-flight stale running update after Cancel persisted canceled.
+		run.Status = promptiterengine.RunStatusRunning
+		run.ErrorMessage = ""
+	}
+	engineInst := &fakePromptIterEngine{
+		run: func(ctx context.Context, request *promptiterengine.RunRequest, opts ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+			_ = ctx
+			_ = request
+			_ = opts
+			engineCalled = true
+			return &promptiterengine.RunResult{}, nil
+		},
+	}
+	var err error
+	managerInst, err = New("demo-app", engineInst, WithStore(store))
+	require.NoError(t, err)
+	concreteManager := managerInst.(*manager)
+	concreteManager.cancelFuncs["run-1"] = cancel
+
+	done := make(chan struct{})
+	go func() {
+		concreteManager.run(runCtx, "run-1", &promptiterengine.RunRequest{})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("manager run blocked while canceling during store update")
+	}
+
+	require.True(t, triggered)
+	require.NoError(t, cancelErr)
+	assert.False(t, engineCalled)
+	current := store.runs["run-1"]
+	require.NotNil(t, current)
+	assert.Equal(t, promptiterengine.RunStatusCanceled, current.Status)
+	assert.Equal(t, "run canceled", current.ErrorMessage)
+	_, ok := concreteManager.cancelFuncs["run-1"]
+	assert.False(t, ok)
+	_, ok = concreteManager.canceledRuns["run-1"]
+	assert.False(t, ok)
 }
 
 func TestRunObserverBuildsIncrementalRun(t *testing.T) {

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -445,6 +445,39 @@ func TestManagerCancelWinsOverConcurrentRunningUpdate(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestManagerRunPersistsCanceledBeforeRunning(t *testing.T) {
+	runCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	store := &scriptedStore{
+		runs: map[string]*promptiterengine.RunResult{
+			"run-1": {
+				AppName: "demo-app",
+				ID:      "run-1",
+				Status:  promptiterengine.RunStatusQueued,
+			},
+		},
+	}
+	engineInst := &fakePromptIterEngine{
+		run: func(ctx context.Context, request *promptiterengine.RunRequest, opts ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+			t.Fatal("engine should not run when context is already canceled")
+			return nil, nil
+		},
+	}
+	managerInst, err := New("demo-app", engineInst, WithStore(store))
+	require.NoError(t, err)
+	concreteManager := managerInst.(*manager)
+	concreteManager.cancelFuncs["run-1"] = func() {}
+
+	concreteManager.run(runCtx, "run-1", &promptiterengine.RunRequest{})
+
+	current := store.runs["run-1"]
+	require.NotNil(t, current)
+	assert.Equal(t, promptiterengine.RunStatusCanceled, current.Status)
+	assert.Equal(t, "run canceled", current.ErrorMessage)
+	_, ok := concreteManager.cancelFuncs["run-1"]
+	assert.False(t, ok)
+}
+
 func TestManagerCancelWinsOverTerminalUpdates(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -445,6 +445,104 @@ func TestManagerCancelWinsOverConcurrentRunningUpdate(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestManagerCancelWinsOverTerminalUpdates(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *promptiterengine.RunResult
+		err    error
+	}{
+		{
+			name:   "success",
+			result: &promptiterengine.RunResult{},
+		},
+		{
+			name: "error",
+			err:  errors.New("engine failed"),
+		},
+		{
+			name: "nil result",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtx, cancel := context.WithCancel(context.Background())
+			store := &scriptedStore{
+				runs: map[string]*promptiterengine.RunResult{
+					"run-1": {
+						AppName: "demo-app",
+						ID:      "run-1",
+						Status:  promptiterengine.RunStatusQueued,
+					},
+				},
+			}
+			var (
+				cancelErr   error
+				managerInst Manager
+			)
+			engineInst := &fakePromptIterEngine{
+				run: func(ctx context.Context, request *promptiterengine.RunRequest, opts ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+					_ = ctx
+					_ = request
+					_ = opts
+					cancelErr = managerInst.Cancel(context.Background(), "run-1")
+					return tt.result, tt.err
+				},
+			}
+			var err error
+			managerInst, err = New("demo-app", engineInst, WithStore(store))
+			require.NoError(t, err)
+			concreteManager := managerInst.(*manager)
+			concreteManager.cancelFuncs["run-1"] = cancel
+
+			concreteManager.run(runCtx, "run-1", &promptiterengine.RunRequest{})
+
+			require.NoError(t, cancelErr)
+			current := store.runs["run-1"]
+			require.NotNil(t, current)
+			assert.Equal(t, promptiterengine.RunStatusCanceled, current.Status)
+			assert.Equal(t, "run canceled", current.ErrorMessage)
+			_, ok := concreteManager.cancelFuncs["run-1"]
+			assert.False(t, ok)
+			_, ok = concreteManager.canceledRuns["run-1"]
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestManagerCancelRejectsCompletedRun(t *testing.T) {
+	store := &scriptedStore{
+		runs: map[string]*promptiterengine.RunResult{
+			"run-1": {
+				AppName: "demo-app",
+				ID:      "run-1",
+				Status:  promptiterengine.RunStatusQueued,
+			},
+		},
+	}
+	engineInst := &fakePromptIterEngine{
+		run: func(ctx context.Context, request *promptiterengine.RunRequest, opts ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+			_ = ctx
+			_ = request
+			_ = opts
+			return &promptiterengine.RunResult{}, nil
+		},
+	}
+	managerInst, err := New("demo-app", engineInst, WithStore(store))
+	require.NoError(t, err)
+	concreteManager := managerInst.(*manager)
+	_, cancel := context.WithCancel(context.Background())
+	concreteManager.cancelFuncs["run-1"] = cancel
+
+	concreteManager.run(context.Background(), "run-1", &promptiterengine.RunRequest{})
+
+	current := store.runs["run-1"]
+	require.NotNil(t, current)
+	assert.Equal(t, promptiterengine.RunStatusSucceeded, current.Status)
+	err = managerInst.Cancel(context.Background(), "run-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestRunObserverBuildsIncrementalRun(t *testing.T) {
 	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Fix a PromptIter manager race where `Cancel()` could mark a run as `canceled`, but the background `run()` goroutine could later overwrite it back to `running`.
- Make the queued/running transition and cancel status update mutually exclusive.
- Preserve canceled status when the run context is already canceled before the engine starts.

## Background

`TestManagerCancelTransitionsRun` can intermittently fail with:

```text
expected: "canceled"
actual  : "running"
```

The root cause is a status ordering race:

1. `Start()` creates a queued run and starts a background goroutine.
2. `Cancel()` may run first and persist `canceled`.
3. The background goroutine may then start and unconditionally persist `running`.
4. A status read can observe the transient regression from `canceled` back to `running`.

## Test plan

- [x] `cd evaluation && go test ./workflow/promptiter/manager -run TestManagerCancelTransitionsRun -count=100`
- [x] `cd evaluation && go test ./...`