### PR TITLE
feat(sandbox): add macOS sandbox backend

### DIFF
--- a/codeexecutor/sandbox/backend.go
+++ b/codeexecutor/sandbox/backend.go
@@ -17,6 +17,8 @@ const (
 	BackendAuto BackendType = "auto"
 	// BackendLinuxBubblewrap uses bubblewrap on Linux.
 	BackendLinuxBubblewrap BackendType = "linux-bubblewrap"
+	// BackendMacOSSandboxExec uses sandbox-exec on macOS.
+	BackendMacOSSandboxExec BackendType = "macos-sandbox-exec"
 )
 
 type commandCleanup func()

--- a/codeexecutor/sandbox/backend_macos.go
+++ b/codeexecutor/sandbox/backend_macos.go
@@ -1,0 +1,163 @@
+//go:build darwin
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+const macosSandboxExecPath = "/usr/bin/sandbox-exec"
+
+func backendCapabilities(backend BackendType, profile PermissionProfile) backendCapabilitiesInfo {
+	supported := backend == BackendAuto || backend == BackendMacOSSandboxExec
+	managed := supported && profile.enforcement() == enforcementManaged
+	return backendCapabilitiesInfo{
+		OSSandbox:          managed,
+		PTY:                false,
+		Stdin:              true,
+		NetworkIsolation:   managed,
+		DenyReadGlob:       managed,
+		Snapshot:           false,
+		Ports:              false,
+		ExternalPathGrants: managed,
+		ProtectedPathMasks: managed,
+		PerCommandGrants:   true,
+	}
+}
+
+func (r *Runtime) osSandboxCommand(
+	ctx context.Context,
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+	cwd string,
+	env []string,
+	spec codeexecutor.RunProgramSpec,
+) (*exec.Cmd, string, commandCleanup, error) {
+	seatbelt, err := r.macosPreflight()
+	if err != nil {
+		return nil, string(BackendMacOSSandboxExec), nil, err
+	}
+	policy, err := r.macosSeatbeltProfile(profile, ws)
+	if err != nil {
+		return nil, string(BackendMacOSSandboxExec), nil, err
+	}
+	profilePath, err := writeMacOSSeatbeltProfile(policy)
+	if err != nil {
+		return nil, string(BackendMacOSSandboxExec), nil, backendError(
+			ErrSetupFailed,
+			string(BackendMacOSSandboxExec),
+			err,
+		)
+	}
+	args := []string{"-f", profilePath, "--", spec.Cmd}
+	args = append(args, spec.Args...)
+	cmd := exec.CommandContext(ctx, seatbelt, args...)
+	cmd.Dir = cwd
+	cmd.Env = env
+	cleanup := func() {
+		_ = os.Remove(profilePath)
+	}
+	return cmd, string(BackendMacOSSandboxExec), cleanup, nil
+}
+
+func (r *Runtime) macosPreflight() (string, error) {
+	r.preflightOnce.Do(func() {
+		if r.backend != BackendAuto && r.backend != BackendMacOSSandboxExec {
+			r.preflightErr = backendError(
+				ErrUnsupportedBackend,
+				string(r.backend),
+				errors.New("unsupported backend on macOS"),
+			)
+			return
+		}
+		if _, err := os.Stat(macosSandboxExecPath); err != nil {
+			r.preflightErr = backendError(
+				ErrSetupFailed,
+				string(BackendMacOSSandboxExec),
+				errors.New("sandbox-exec executable not found at /usr/bin/sandbox-exec"),
+			)
+			return
+		}
+		stderr, err := runMacOSSeatbeltPreflightProbe(macosSandboxExecPath)
+		if err != nil {
+			r.preflightErr = backendError(
+				ErrSetupFailed,
+				string(BackendMacOSSandboxExec),
+				seatbeltProbeError{err: err, stderr: stderr},
+			)
+			return
+		}
+		r.seatbeltPath = macosSandboxExecPath
+	})
+	return r.seatbeltPath, r.preflightErr
+}
+
+func runMacOSSeatbeltPreflightProbe(seatbelt string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	profilePath, err := writeMacOSSeatbeltProfile(macosPreflightPolicy())
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(profilePath)
+	var stderr bytes.Buffer
+	probe := exec.CommandContext(ctx, seatbelt, "-f", profilePath, "--", "/usr/bin/true")
+	probe.Stderr = &stderr
+	err = probe.Run()
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return stderr.String(), err
+}
+
+func writeMacOSSeatbeltProfile(policy string) (string, error) {
+	f, err := os.CreateTemp("", "trpc-agent-go-seatbelt-*.sb")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	_, writeErr := f.WriteString(policy)
+	closeErr := f.Close()
+	if writeErr != nil {
+		_ = os.Remove(path)
+		return "", writeErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(path)
+		return "", closeErr
+	}
+	return filepath.Clean(path), nil
+}
+
+type seatbeltProbeError struct {
+	err    error
+	stderr string
+}
+
+func (e seatbeltProbeError) Error() string {
+	if e.stderr == "" {
+		return e.err.Error()
+	}
+	return e.err.Error() + ": " + e.stderr
+}
+
+func (e seatbeltProbeError) Unwrap() error {
+	return e.err
+}

--- a/codeexecutor/sandbox/backend_macos_test.go
+++ b/codeexecutor/sandbox/backend_macos_test.go
@@ -72,6 +72,8 @@ func TestMacOSSeatbeltProfileGeneration(t *testing.T) {
 		"(deny default)",
 		"(allow file-read* file-map-executable file-test-existence",
 		"(allow file-write*",
+		"(path-ancestors \"/tmp\")",
+		"(path-ancestors \"/var/folders\")",
 		sbplString(externalReadPolicyPath),
 		sbplString(externalWritePolicyPath),
 		"(require-not (literal " + sbplString(secretPolicyPath) + "))",
@@ -82,6 +84,84 @@ func TestMacOSSeatbeltProfileGeneration(t *testing.T) {
 		if !strings.Contains(policy, want) {
 			t.Fatalf("macOS policy missing %q:\n%s", want, policy)
 		}
+	}
+	for _, disallow := range []string{
+		`(subpath "/tmp")`,
+		`(subpath "/private/tmp")`,
+		`(subpath "/var/folders")`,
+		`(subpath "/private/var/folders")`,
+	} {
+		if strings.Contains(policy, disallow) {
+			t.Fatalf("macOS policy should not grant broad host temp read %q:\n%s", disallow, policy)
+		}
+	}
+}
+
+func TestMacOSPlatformTempMetadataPolicyOnly(t *testing.T) {
+	for _, root := range macosPlatformDefaultReadRoots() {
+		switch root {
+		case "/tmp", "/private/tmp", "/var/tmp", "/private/var/tmp", "/var/folders", "/private/var/folders":
+			t.Fatalf("platform default read roots still include host temp path %q", root)
+		}
+	}
+	if !strings.Contains(macosPlatformTempMetadataPolicy, `(path-ancestors "/tmp")`) {
+		t.Fatalf("temp metadata policy missing /tmp ancestor metadata")
+	}
+}
+
+func TestMacOSSandboxExecRejectsHostTempFileRead(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	hostTemp := filepath.Join(os.TempDir(), "trpc-agent-sandbox-host-temp-probe")
+	if err := os.WriteFile(hostTemp, []byte("host-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(hostTemp) })
+
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/host-temp", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:  "/bin/cat",
+		Args: []string{hostTemp},
+	})
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("host temp read unexpectedly succeeded: %#v", res)
+	}
+}
+
+func TestMacOSRuleTargetRejectsAbsoluteWorkspaceSymlinkGrant(t *testing.T) {
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/symlink-grant", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	link := filepath.Join(ws.Path, "work", "escape-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	profile := WorkspaceWriteProfile().WithWritePaths(link)
+	_, err = rt.macosSeatbeltProfile(profile, ws)
+	if !isKind(err, ErrPathDenied) {
+		t.Fatalf("symlink grant profile error = %v, want ErrPathDenied", err)
+	}
+	target, ok, err := rt.macosRuleTarget(
+		profile,
+		ws,
+		fileSystemRule{Kind: rulePath, Access: accessWrite, Path: link},
+	)
+	if !isKind(err, ErrPathDenied) || ok || target != "" {
+		t.Fatalf("macosRuleTarget = target=%q ok=%v err=%v, want denied", target, ok, err)
 	}
 }
 

--- a/codeexecutor/sandbox/backend_macos_test.go
+++ b/codeexecutor/sandbox/backend_macos_test.go
@@ -1,0 +1,219 @@
+//go:build darwin
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+func TestMacOSBackendCapabilities(t *testing.T) {
+	caps := backendCapabilities(BackendMacOSSandboxExec, WorkspaceWriteProfile())
+	if !caps.OSSandbox || !caps.NetworkIsolation || !caps.DenyReadGlob ||
+		!caps.ExternalPathGrants || !caps.ProtectedPathMasks {
+		t.Fatalf("managed capabilities = %#v, want macOS sandbox features", caps)
+	}
+	unsupportedCaps := backendCapabilities(BackendLinuxBubblewrap, WorkspaceWriteProfile())
+	if unsupportedCaps.OSSandbox || unsupportedCaps.NetworkIsolation ||
+		unsupportedCaps.DenyReadGlob || unsupportedCaps.ExternalPathGrants {
+		t.Fatalf("unsupported backend capabilities = %#v, want no macOS sandbox features", unsupportedCaps)
+	}
+	disabledCaps := backendCapabilities(BackendAuto, DangerFullAccessProfile())
+	if disabledCaps.OSSandbox || disabledCaps.NetworkIsolation || disabledCaps.ProtectedPathMasks {
+		t.Fatalf("disabled capabilities = %#v, want no managed sandbox features", disabledCaps)
+	}
+}
+
+func TestMacOSSeatbeltProfileGeneration(t *testing.T) {
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/profile", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalRead := t.TempDir()
+	externalWrite := t.TempDir()
+	profile := WorkspaceWriteProfile().
+		WithReadPaths(externalRead, "work/read-only").
+		WithWritePaths(externalWrite).
+		WithNoAccessPaths("work/secret").
+		WithNoAccessGlobs("work/*.env").
+		WithNetworkPolicy(NetworkPolicy{Mode: NetworkEnabled})
+	policy, err := rt.macosSeatbeltProfile(profile, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalReadPolicyPath, err := canonicalizeExistingPath(externalRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalWritePolicyPath, err := canonicalizeExistingPath(externalWrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretPolicyPath, err := canonicalizeExistingPath(filepath.Join(ws.Path, "work", "secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"(deny default)",
+		"(allow file-read* file-map-executable file-test-existence",
+		"(allow file-write*",
+		sbplString(externalReadPolicyPath),
+		sbplString(externalWritePolicyPath),
+		"(require-not (literal " + sbplString(secretPolicyPath) + "))",
+		`(deny file-read* file-map-executable file-test-existence (regex #"`,
+		`(deny file-write* (regex #"`,
+		"(allow network-outbound)",
+	} {
+		if !strings.Contains(policy, want) {
+			t.Fatalf("macOS policy missing %q:\n%s", want, policy)
+		}
+	}
+}
+
+func TestMacOSGlobRegexTranslation(t *testing.T) {
+	wsPath := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(wsPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ws := codeexecutor.Workspace{Path: wsPath}
+	regex, ok, err := macosSeatbeltRegexForWorkspaceGlob(ws, "**/*.env")
+	if err != nil || !ok {
+		t.Fatalf("glob regex err=%v ok=%v", err, ok)
+	}
+	if !strings.HasPrefix(regex, "^") || !strings.HasSuffix(regex, "$") ||
+		!strings.Contains(regex, "(.*/)?") || !strings.Contains(regex, `\.env`) {
+		t.Fatalf("glob regex = %q, want anchored doublestar .env regex", regex)
+	}
+	_, _, err = macosSeatbeltRegexForWorkspaceGlob(ws, "/tmp/*.env")
+	if !isKind(err, ErrPolicyViolation) {
+		t.Fatalf("absolute glob error = %v, want ErrPolicyViolation", err)
+	}
+	_, _, err = macosSeatbeltRegexForWorkspaceGlob(ws, "work/[")
+	if !isKind(err, ErrPolicyViolation) {
+		t.Fatalf("invalid glob error = %v, want ErrPolicyViolation", err)
+	}
+}
+
+func TestMacOSSandboxExecWorkspaceWriteIntegration(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/run", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd: "/bin/sh",
+		Args: []string{
+			"-c",
+			"echo ok > ok.txt; mkdir ../.git 2>&1; echo bad > ../.git/config 2>/dev/null",
+		},
+	})
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("protected metadata write unexpectedly succeeded: %#v", res)
+	}
+	if _, err := os.Stat(filepath.Join(ws.Path, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("protected metadata dir should remain absent: err=%v result=%#v", err, res)
+	}
+	data, err := os.ReadFile(filepath.Join(ws.Path, "work", "ok.txt"))
+	if err != nil {
+		t.Fatalf("workspace write missing: %v result=%#v", err, res)
+	}
+	if strings.TrimSpace(string(data)) != "ok" {
+		t.Fatalf("workspace write failed: %q", data)
+	}
+}
+
+func TestMacOSSandboxExecNoAccessGlobIntegration(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	rt := NewRuntime(
+		WithWorkspaceRoot(t.TempDir()),
+		WithPermissionProfile(WorkspaceWriteProfile().WithNoAccessGlobs("work/*.env")),
+	)
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/glob", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws.Path, "work", "app.env"), []byte("TOKEN=secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "cat app.env"},
+	})
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("glob no-access read unexpectedly succeeded: %#v", res)
+	}
+}
+
+func TestMacOSSandboxExecNoAccessGlobHardDenyOverridesSpecificRead(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	profile := ReadOnlyProfile().
+		WithReadPaths("work/public/secret.txt").
+		WithNoAccessGlobs("work/**")
+	rt := NewRuntime(
+		WithWorkspaceRoot(t.TempDir()),
+		WithPermissionProfile(profile),
+	)
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/glob-hard-deny", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(ws.Path, "work", "public", "secret.txt")
+	if err := os.MkdirAll(filepath.Dir(secret), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secret, []byte("visible to Go layer"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	files, err := rt.Collect(context.Background(), ws, []string{"work/public/secret.txt"})
+	if err != nil || len(files) != 1 {
+		t.Fatalf("Go-layer Collect = files:%d err:%v, want specific read grant to win", len(files), err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:  "/bin/sh",
+		Args: []string{"-c", "cat work/public/secret.txt"},
+		Cwd:  ".",
+	})
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Fatalf("glob hard deny was reopened by specific read grant: %#v", res)
+	}
+}

--- a/codeexecutor/sandbox/backend_other.go
+++ b/codeexecutor/sandbox/backend_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 //
 // Tencent is pleased to support the open source community by making

--- a/codeexecutor/sandbox/docs/FILE_SYSTEM_POLICY.md
+++ b/codeexecutor/sandbox/docs/FILE_SYSTEM_POLICY.md
@@ -23,12 +23,14 @@ The managed file-system boundary is designed around three rules:
    workspace grant. The default protected set is `.git`, `.agents`, and
    `.trpc-agent-sandbox`.
 
-This boundary is not intended to hide the entire host file system by default.
-On Linux, managed execution starts with a read-only bind mount of `/`, then adds
-writable bind mounts for the workspace and any explicit external write grants.
-Sensitive files that must not be readable should be covered by no-access
-denials, for example through `WithNoAccessPaths` or `WithNoAccessGlobs`, or kept
-outside the host paths visible to the sandbox.
+This boundary is backend-specific at the OS layer. On Linux, managed execution
+starts with a read-only bind mount of `/`, then adds writable bind mounts for the
+workspace and any explicit external write grants. On macOS, managed execution
+starts from a Seatbelt deny-default profile, adds selected platform read
+defaults required by common tools, and then grants the workspace and explicit
+external paths. Sensitive files that must not be readable should be covered by
+no-access denials, for example through `WithNoAccessPaths` or
+`WithNoAccessGlobs`, or kept outside the host paths visible to the sandbox.
 
 ## Rule Targets
 
@@ -84,6 +86,29 @@ The implementation is intentionally path-based. It supports concrete path grants
 workspace-relative glob no-access denials, and protected metadata masks, but it
 does not currently implement per-file capabilities beyond read, write, and none.
 
+## macOS Enforcement
+
+The macOS backend uses Apple Seatbelt through `/usr/bin/sandbox-exec`:
+
+- The generated SBPL starts with `(deny default)`.
+- Selected macOS platform paths are allowed read-only so common shells,
+  interpreters, dynamic libraries, and system metadata can be used.
+- Workspace and explicit external path grants are projected as Seatbelt
+  `allow` rules.
+- Exact no-access paths are carved out from broader allows with `require-not`.
+- Protected metadata paths are excluded from write allows but remain readable.
+- Workspace-relative no-access globs are translated into anchored Seatbelt
+  regular-expression denies.
+
+Unlike Linux, macOS glob denials are dynamic Seatbelt rules rather than
+startup-time mount masks. They can apply to files created after the command
+starts and to matching paths under writable roots. Linux keeps its bubblewrap
+behavior and may fail closed when a glob denial overlaps a writable mount.
+macOS no-access globs are hard OS-level denials: more-specific read or write
+grants do not reopen glob-matched paths in the child process. Avoid combining
+broad no-access globs with narrower grants when OS-level reopen semantics are
+required.
+
 ## Protected Metadata
 
 Protected metadata is a built-in write protection for sensitive directories
@@ -111,10 +136,11 @@ explicitly.
 The runtime defaults to `WorkspaceWriteProfile()`. When callers pass
 `WithPermissionProfile`, that explicit profile replaces the default.
 
-`WorkspaceWriteProfile()` starts from a read-only host view and grants writes to
-the session-owned workspace directories:
+`WorkspaceWriteProfile()` grants writes to the session-owned workspace
+directories. The host view depends on the backend:
 
-- The host root is readable, giving the sandbox a read-only host view.
+- Linux gives the sandbox a read-only host root view.
+- macOS gives the sandbox selected platform read defaults plus explicit grants.
 - The workspace root, `work`, `home`, `tmp`, `runs`, `out`, and `skills`
   directories are writable.
 - Default protected metadata still blocks writes to `.git`, `.agents`, and

--- a/codeexecutor/sandbox/docs/MACOS_BACKEND.md
+++ b/codeexecutor/sandbox/docs/MACOS_BACKEND.md
@@ -1,0 +1,90 @@
+# macOS Sandbox Backend
+
+The macOS backend provides managed local OS sandboxing through Apple Seatbelt by
+executing commands with `/usr/bin/sandbox-exec`.
+
+## Backend
+
+Use `BackendMacOSSandboxExec` or `BackendAuto` on macOS. The backend string is
+`macos-sandbox-exec`.
+
+Managed profiles fail closed when `/usr/bin/sandbox-exec` is unavailable or the
+host rejects Seatbelt profiles. The runtime does not automatically fall back to
+`DangerFullAccessProfile`.
+
+## File System Model
+
+The Go-level file-system policy resolver uses the same model as Linux:
+
+- `read` means readable but not writable.
+- `write` means readable and writable.
+- `none` means neither readable nor writable.
+- More specific rules win before `none > write > read`.
+- Protected metadata such as `.git`, `.agents`, and `.trpc-agent-sandbox` is
+  readable but never writable.
+
+The OS projection differs from Linux. Linux starts with a read-only bind mount of
+`/`. macOS starts with `(deny default)`, adds selected platform read defaults,
+and then adds workspace and explicit external path grants. The macOS OS
+projection has backend-specific behavior for no-access globs, documented below.
+
+## Platform Defaults
+
+The backend includes a curated set of read-only macOS paths needed by common
+tools, dynamic libraries, shells, interpreters, and system metadata. This is a
+Codex-style compromise: stricter than allowing the whole host root, but practical
+enough for normal command execution.
+
+The baseline currently permits broad `sysctl-read` for tool compatibility. The
+filesystem allow-list remains path-scoped; future iterations may narrow sysctl
+access if compatibility data shows a smaller allow-list is sufficient.
+
+The defaults intentionally do not grant broad access to the user's home
+directory. Use `WithReadPaths` or `WithWritePaths` for host paths outside the
+workspace that commands must access.
+
+## No-Access Globs
+
+`WithNoAccessGlobs` is supported on macOS managed runs. The backend translates
+workspace-relative glob patterns into anchored Seatbelt regular-expression
+denies, for example:
+
+```scheme
+(deny file-read* (regex #"^/path/to/work/[^/]*\.env$"))
+(deny file-write* (regex #"^/path/to/work/[^/]*\.env$"))
+```
+
+This is intentionally different from Linux. Linux uses startup-time bubblewrap
+mount masks and may fail closed when a glob overlaps a writable mount. macOS uses
+dynamic Seatbelt rules, so matching files can be denied even when they are
+created after process start or live under writable roots.
+
+No-access globs are projected as hard Seatbelt denials. A more-specific
+`WithReadPaths` or `WithWritePaths` grant is not expected to reopen a path
+matched by `WithNoAccessGlobs`. Use exact no-access paths when a profile needs
+path-level carveouts.
+
+## Network
+
+The network model stays binary:
+
+- `NetworkRestricted` does not add broad network allow rules.
+- `NetworkEnabled` adds broad outbound and inbound network allow rules.
+
+Proxy-aware routing, Unix socket allow-lists, and loopback-only network policies
+are not part of this implementation.
+
+## Shell Environment
+
+Seatbelt does not manage environment inheritance. The runtime builds the
+sanitized environment with `ShellEnvironmentPolicy` and passes it directly to the
+`sandbox-exec` child process.
+
+## Known Differences From Linux
+
+- macOS does not expose the whole host root as read-only by default.
+- macOS no-access glob enforcement is dynamic; Linux enforcement is based on
+  static mount masks.
+- macOS uses Seatbelt rules instead of namespace and mount operations.
+- Linux behavior and tests remain unchanged; platform differences are documented
+  rather than hidden behind new public APIs.

--- a/codeexecutor/sandbox/docs/MACOS_BACKEND.md
+++ b/codeexecutor/sandbox/docs/MACOS_BACKEND.md
@@ -32,12 +32,18 @@ projection has backend-specific behavior for no-access globs, documented below.
 
 The backend includes a curated set of read-only macOS paths needed by common
 tools, dynamic libraries, shells, interpreters, and system metadata. This is a
-Codex-style compromise: stricter than allowing the whole host root, but practical
-enough for normal command execution.
+practical middle ground between strict minimalism and exposing the whole host
+root, while still keeping normal command execution workable.
 
 The baseline currently permits broad `sysctl-read` for tool compatibility. The
 filesystem allow-list remains path-scoped; future iterations may narrow sysctl
 access if compatibility data shows a smaller allow-list is sufficient.
+
+Host temporary directories such as `/tmp` and `/var/folders` are not granted as
+broad read roots. The runtime injects `TMPDIR`, `TMP`, and `TEMP` into the
+workspace `tmp` directory, and the Seatbelt profile only allows ancestor
+metadata for default temp path probes. Use `WithReadPaths` when a command must
+read host temp files outside the workspace.
 
 The defaults intentionally do not grant broad access to the user's home
 directory. Use `WithReadPaths` or `WithWritePaths` for host paths outside the

--- a/codeexecutor/sandbox/docs/README.md
+++ b/codeexecutor/sandbox/docs/README.md
@@ -7,12 +7,16 @@ but they do not provide local managed sandbox enforcement on every platform.
 | Platform | Managed OS sandbox support | Backend | Notes |
 | --- | --- | --- | --- |
 | Linux | Supported | `linux-bubblewrap` | Uses `bubblewrap` with user, PID, mount, and optional network namespaces. |
-| macOS | Not implemented | N/A | Managed profiles return an unsupported-backend error. Disabled profiles run without sandboxing. |
+| macOS | Supported | `macos-sandbox-exec` | Uses Apple Seatbelt through `/usr/bin/sandbox-exec`. See [`MACOS_BACKEND.md`](MACOS_BACKEND.md) for platform differences. |
 | Windows | Not implemented | N/A | Managed profiles return an unsupported-backend error. Disabled profiles run without sandboxing. |
 
 ## Prerequisites
 
 On Linux, Sandbox Code Executor uses the `bwrap` executable found on `PATH`. If `bwrap` is unavailable, setup fails before the command starts.
+
+On macOS, managed sandbox profiles use `/usr/bin/sandbox-exec`. Managed
+execution fails closed if the tool is unavailable or the host rejects Seatbelt
+profiles.
 
 When the runtime itself runs inside Docker, Kubernetes, or a managed container
 platform, the outer container must allow the namespace and mount operations
@@ -31,7 +35,8 @@ host network access:
 - `NetworkRestricted` asks the backend to block outbound networking when it can
   enforce that boundary.
 - `NetworkEnabled` allows the command to use the host network. On Linux this
-  means the command is launched without network namespace isolation.
+  means the command is launched without network namespace isolation. On macOS
+  this means the generated Seatbelt profile includes broad network allow rules.
 
 ## File System
 

--- a/codeexecutor/sandbox/fs.go
+++ b/codeexecutor/sandbox/fs.go
@@ -730,46 +730,66 @@ func canonicalizeExistingPath(path string) (string, error) {
 
 func resolvePotentialSymlinkTarget(path string) (string, bool, error) {
 	path = filepath.Clean(path)
-	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Readlink(path)
-		if err != nil {
-			return "", false, err
-		}
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(filepath.Dir(path), target)
-		}
-		target, err = filepath.Abs(target)
-		if err != nil {
-			return "", false, err
-		}
-		return target, target != path, nil
-	} else if err != nil && !os.IsNotExist(err) {
+	if target, ok, err := resolveDirectSymlink(path); ok || err != nil {
+		return target, ok, err
+	}
+	return resolveParentSymlinkTarget(path)
+}
+
+func resolveDirectSymlink(path string) (string, bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return "", false, nil
+	}
+	if err != nil {
 		return "", false, err
 	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return "", false, nil
+	}
+	target, err := readSymlinkTarget(path)
+	return target, err == nil && target != path, err
+}
+
+func resolveParentSymlinkTarget(path string) (string, bool, error) {
 	var suffix []string
 	cur := path
 	for {
-		resolved, err := filepath.EvalSymlinks(cur)
+		info, err := os.Lstat(cur)
 		if err == nil {
-			for i := len(suffix) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, suffix[i])
+			if info.Mode()&os.ModeSymlink != 0 {
+				target, err := readSymlinkTarget(cur)
+				if err != nil {
+					return "", false, err
+				}
+				for i := len(suffix) - 1; i >= 0; i-- {
+					target = filepath.Join(target, suffix[i])
+				}
+				return target, target != path, nil
 			}
-			resolved, err = filepath.Abs(resolved)
-			if err != nil {
-				return "", false, err
+			if len(suffix) != 0 && !info.IsDir() {
+				return "", false, fmt.Errorf("%s is not a directory", cur)
 			}
-			return resolved, resolved != path, nil
+			return "", false, nil
 		}
 		if !os.IsNotExist(err) {
 			return "", false, err
 		}
 		parent := filepath.Dir(cur)
-		if parent == cur {
-			return "", false, nil
-		}
 		suffix = append(suffix, filepath.Base(cur))
 		cur = parent
 	}
+}
+
+func readSymlinkTarget(path string) (string, error) {
+	target, err := os.Readlink(path)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(path), target)
+	}
+	return filepath.Abs(target)
 }
 
 func copyPath(src, dst string) error {

--- a/codeexecutor/sandbox/runtime.go
+++ b/codeexecutor/sandbox/runtime.go
@@ -47,6 +47,7 @@ type Runtime struct {
 	preflightErr   error
 	bwrapPath      string
 	bwrapMountProc bool
+	seatbeltPath   string
 }
 
 // NewRuntime constructs a sandbox runtime.

--- a/codeexecutor/sandbox/runtime_test.go
+++ b/codeexecutor/sandbox/runtime_test.go
@@ -1164,9 +1164,28 @@ func TestFilesystemSymlinkAndCopyHelperBranches(t *testing.T) {
 	if err != nil || !changed || resolved != filepath.Join(ws.Path, "work", "target.txt") {
 		t.Fatalf("direct symlink resolved=%q changed=%v err=%v", resolved, changed, err)
 	}
+	relativeDirectLink := filepath.Join(ws.Path, "work", "relative-direct-link.txt")
+	if err := os.Symlink("target.txt", relativeDirectLink); err != nil {
+		t.Fatal(err)
+	}
+	resolved, changed, err = resolvePotentialSymlinkTarget(relativeDirectLink)
+	if err != nil || !changed || resolved != filepath.Join(ws.Path, "work", "target.txt") {
+		t.Fatalf("relative direct symlink resolved=%q changed=%v err=%v", resolved, changed, err)
+	}
 	resolved, changed, err = resolvePotentialSymlinkTarget(filepath.Join(insideLink, "nested.txt"))
 	if err != nil || !changed || resolved != filepath.Join(insideTarget, "nested.txt") {
 		t.Fatalf("parent symlink resolved=%q changed=%v err=%v", resolved, changed, err)
+	}
+	relativeInsideLink := filepath.Join(ws.Path, "work", "relative-inside-link")
+	if err := os.Symlink("inside", relativeInsideLink); err != nil {
+		t.Fatal(err)
+	}
+	resolved, changed, err = resolvePotentialSymlinkTarget(filepath.Join(relativeInsideLink, "nested.txt"))
+	if err != nil || !changed || resolved != filepath.Join(insideTarget, "nested.txt") {
+		t.Fatalf("relative parent symlink resolved=%q changed=%v err=%v", resolved, changed, err)
+	}
+	if resolved, changed, err = resolvePotentialSymlinkTarget(filepath.Join(t.TempDir(), "missing", "child.txt")); err != nil || changed || resolved != "" {
+		t.Fatalf("missing root resolved=%q changed=%v err=%v, want no target", resolved, changed, err)
 	}
 
 	if err := copyPath(filepath.Join(outside, "missing.txt"), filepath.Join(t.TempDir(), "copy.txt")); err == nil {
@@ -1183,6 +1202,19 @@ func TestFilesystemSymlinkAndCopyHelperBranches(t *testing.T) {
 	}
 	if _, _, err := resolvePotentialSymlinkTarget(filepath.Join(source, "child.txt")); err == nil {
 		t.Fatalf("resolvePotentialSymlinkTarget unexpectedly succeeded below file path")
+	}
+	if _, _, err := resolvePotentialSymlinkTarget(string([]byte{'b', 'a', 'd', 0})); err == nil {
+		t.Fatalf("resolvePotentialSymlinkTarget unexpectedly accepted invalid path")
+	}
+	if _, err := readSymlinkTarget(filepath.Join(outside, "missing-link")); err == nil {
+		t.Fatalf("readSymlinkTarget unexpectedly succeeded for missing symlink")
+	}
+	sourceParentLink := filepath.Join(outside, "source-parent-link")
+	if err := os.Symlink(source, sourceParentLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resolvePotentialSymlinkTarget(filepath.Join(sourceParentLink, "child.txt")); err == nil {
+		t.Fatalf("resolvePotentialSymlinkTarget unexpectedly succeeded below symlink-to-file parent")
 	}
 	fileParent := filepath.Join(t.TempDir(), "file-parent")
 	if err := os.WriteFile(fileParent, []byte("not a directory"), 0o600); err != nil {

--- a/codeexecutor/sandbox/seatbelt_profile_macos.go
+++ b/codeexecutor/sandbox/seatbelt_profile_macos.go
@@ -1,0 +1,566 @@
+//go:build darwin
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+const macosBaseSeatbeltPolicy = `(version 1)
+
+; Start closed-by-default. Runtime and platform allowances are appended below.
+(deny default)
+
+; Child processes inherit this sandbox.
+(allow process-exec)
+(allow process-fork)
+(allow signal (target same-sandbox))
+(allow process-info* (target same-sandbox))
+
+; Common runtime probes used by shells, Go, Python, Java, and system libraries.
+(allow sysctl-read)
+(allow sysctl-write (sysctl-name "kern.grade_cputype"))
+(allow iokit-open (iokit-registry-entry-class "RootDomainUserClient"))
+
+; Basic user, preferences, power, and logging services commonly touched at startup.
+(allow mach-lookup
+  (global-name "com.apple.PowerManagement.control")
+  (global-name "com.apple.bsd.dirhelper")
+  (global-name "com.apple.cfprefsd.agent")
+  (global-name "com.apple.cfprefsd.daemon")
+  (global-name "com.apple.system.DirectoryService.libinfo_v1")
+  (global-name "com.apple.system.opendirectoryd.libinfo")
+  (global-name "com.apple.system.opendirectoryd.membership")
+  (local-name "com.apple.cfprefsd.agent"))
+(allow user-preference-read)
+(allow ipc-posix-sem)
+(allow ipc-posix-shm-read* (ipc-posix-name-prefix "apple.cfprefs."))
+
+; Terminal and stdio basics.
+(allow pseudo-tty)
+(allow file-read* file-write* file-ioctl
+  (literal "/dev/null")
+  (literal "/dev/ptmx")
+  (literal "/dev/random")
+  (literal "/dev/tty")
+  (literal "/dev/urandom")
+  (literal "/dev/zero"))
+(allow file-read* file-write* (regex #"^/dev/fd/[0-9]+$"))
+(allow file-read* file-write* (regex #"^/dev/ttys[0-9]+$"))
+(allow file-read-metadata
+  (literal "/dev")
+  (literal "/dev/fd")
+  (literal "/dev/stdin")
+  (literal "/dev/stdout")
+  (literal "/dev/stderr")
+  (subpath "/dev"))`
+
+type macosAccessRoot struct {
+	path       string
+	exclusions []string
+}
+
+func (r *Runtime) macosSeatbeltProfile(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+) (string, error) {
+	if err := validateFileSystemRules(profile); err != nil {
+		return "", err
+	}
+	noAccessRoots, err := r.macosNoAccessRoots(profile, ws)
+	if err != nil {
+		return "", err
+	}
+	protectedRoots, err := macosProtectedRoots(profile, ws)
+	if err != nil {
+		return "", err
+	}
+	readRoots, writeRoots, err := r.macosReadWriteRoots(profile, ws)
+	if err != nil {
+		return "", err
+	}
+	explicitReadRoots := append([]string{}, readRoots...)
+	platformRoots := macosPlatformDefaultReadRoots()
+	readRoots = append(readRoots, writeRoots...)
+	readRoots = append(readRoots, platformRoots...)
+	readPolicy := macosSeatbeltAccessPolicy(
+		"file-read* file-map-executable file-test-existence",
+		macosAccessRoots(readRoots, noAccessRoots, nil),
+	)
+	writeExclusions := append([]string{}, noAccessRoots...)
+	writeExclusions = append(writeExclusions, macosStrictChildRoots(writeRoots, explicitReadRoots)...)
+	writeExclusions = append(writeExclusions, protectedRoots...)
+	writePolicy := macosSeatbeltAccessPolicy(
+		"file-write*",
+		macosAccessRoots(writeRoots, writeExclusions, protectedRoots),
+	)
+	globPolicy, err := r.macosNoAccessGlobPolicy(profile, ws)
+	if err != nil {
+		return "", err
+	}
+	sections := []string{
+		macosBaseSeatbeltPolicy,
+		macosPlatformRootLiteralPolicy,
+		macosPlatformAliasPolicy,
+		"; allow read-only file operations",
+		readPolicy,
+		"; allow writable file operations",
+		writePolicy,
+		"; deny glob-matched no-access paths",
+		globPolicy,
+		macosSeatbeltNetworkPolicy(profile.network),
+	}
+	return strings.Join(nonEmptySections(sections), "\n\n"), nil
+}
+
+func macosPreflightPolicy() string {
+	readPolicy := macosSeatbeltAccessPolicy(
+		"file-read* file-map-executable file-test-existence",
+		macosAccessRoots(macosPlatformDefaultReadRoots(), nil, nil),
+	)
+	return strings.Join(nonEmptySections([]string{
+		macosBaseSeatbeltPolicy,
+		macosPlatformRootLiteralPolicy,
+		macosPlatformAliasPolicy,
+		readPolicy,
+	}), "\n\n")
+}
+
+const macosPlatformRootLiteralPolicy = `; Allow processes to read the filesystem root itself for getcwd/path resolution.
+(allow file-read* file-test-existence (literal "/"))`
+
+const macosPlatformAliasPolicy = `; Preserve common macOS symlink spellings used by system shims such as xcode-select.
+(allow file-read* file-map-executable file-test-existence
+  (literal "/var")
+  (literal "/var/select")
+  (subpath "/var/select"))
+(allow file-read-metadata file-test-existence
+  (path-ancestors "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/bin"))`
+
+func (r *Runtime) macosReadWriteRoots(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+) ([]string, []string, error) {
+	var readRoots []string
+	var writeRoots []string
+	for _, rule := range profile.fileSystem.Rules {
+		if rule.Access != accessRead && rule.Access != accessWrite {
+			continue
+		}
+		target, ok, err := r.macosRuleTarget(profile, ws, rule)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !ok {
+			continue
+		}
+		switch rule.Access {
+		case accessRead:
+			readRoots = append(readRoots, target)
+		case accessWrite:
+			writeRoots = append(writeRoots, target)
+		}
+	}
+	return dedupeCleanAbs(readRoots), dedupeCleanAbs(writeRoots), nil
+}
+
+func (r *Runtime) macosNoAccessRoots(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+) ([]string, error) {
+	var roots []string
+	for _, rule := range profile.fileSystem.Rules {
+		if rule.Access != accessNone || rule.Kind == ruleGlob {
+			continue
+		}
+		target, ok, err := r.macosRuleTarget(profile, ws, rule)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			roots = append(roots, target)
+		}
+	}
+	return dedupeCleanAbs(roots), nil
+}
+
+func (r *Runtime) macosRuleTarget(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+	rule fileSystemRule,
+) (string, bool, error) {
+	_ = profile
+	switch rule.Kind {
+	case rulePath:
+		if rule.Path == "" {
+			return "", false, nil
+		}
+		if filepath.IsAbs(rule.Path) {
+			target, err := filepath.Abs(rule.Path)
+			if err != nil {
+				return "", false, err
+			}
+			if rule.Access != accessNone {
+				wsAbs, err := filepath.Abs(ws.Path)
+				if err != nil {
+					return "", false, err
+				}
+				if !sameOrChild(wsAbs, target) {
+					if _, err := filepath.EvalSymlinks(target); err != nil {
+						return "", false, deniedf(
+							ErrPathDenied,
+							"grant",
+							target,
+							"grant target unavailable",
+						)
+					}
+				}
+			}
+			return target, true, nil
+		}
+		target, _, err := r.resolveWorkspacePath(ws, rule.Path)
+		return target, err == nil, err
+	case ruleSpecial:
+		target, ok, err := specialPathAbs(ws, rule.Special)
+		return target, ok, err
+	default:
+		return "", false, nil
+	}
+}
+
+func macosProtectedRoots(profile PermissionProfile, ws codeexecutor.Workspace) ([]string, error) {
+	var roots []string
+	wsAbs, err := filepath.Abs(ws.Path)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range profile.fileSystem.ProtectedMetadata {
+		rel = strings.Trim(filepath.ToSlash(filepath.Clean(rel)), "/")
+		if rel == "" || rel == "." {
+			continue
+		}
+		if strings.HasPrefix(rel, "../") {
+			return nil, deniedf(ErrPathDenied, "protect", rel, "protected path escapes workspace")
+		}
+		roots = append(roots, filepath.Join(wsAbs, filepath.FromSlash(rel)))
+	}
+	return dedupeCleanAbs(roots), nil
+}
+
+func macosAccessRoots(roots []string, exclusions []string, hardDeniedRoots []string) []macosAccessRoot {
+	var accessRoots []macosAccessRoot
+	for _, root := range dedupeCleanAbs(roots) {
+		if macosRootUnderAny(root, hardDeniedRoots) {
+			continue
+		}
+		var rootExclusions []string
+		for _, exclusion := range exclusions {
+			if sameOrChild(root, exclusion) {
+				rootExclusions = append(rootExclusions, exclusion)
+			}
+		}
+		accessRoots = append(accessRoots, macosAccessRoot{
+			path:       root,
+			exclusions: dedupeCleanAbs(rootExclusions),
+		})
+	}
+	return accessRoots
+}
+
+func macosSeatbeltAccessPolicy(operations string, roots []macosAccessRoot) string {
+	if len(roots) == 0 {
+		return ""
+	}
+	var filters []string
+	for _, accessRoot := range roots {
+		root := macosSandboxPath(accessRoot.path)
+		if len(accessRoot.exclusions) == 0 {
+			filters = append(filters,
+				fmt.Sprintf("(literal %s)", sbplString(root)),
+				fmt.Sprintf("(subpath %s)", sbplString(root)),
+			)
+			continue
+		}
+		var requireNot []string
+		for _, exclusion := range accessRoot.exclusions {
+			exclusion = macosSandboxPath(exclusion)
+			requireNot = append(requireNot,
+				fmt.Sprintf("(require-not (literal %s))", sbplString(exclusion)),
+				fmt.Sprintf("(require-not (subpath %s))", sbplString(exclusion)),
+			)
+		}
+		requireNotPart := strings.Join(requireNot, " ")
+		filters = append(filters,
+			fmt.Sprintf("(require-all (literal %s) %s)", sbplString(root), requireNotPart),
+			fmt.Sprintf("(require-all (subpath %s) %s)", sbplString(root), requireNotPart),
+		)
+	}
+	return fmt.Sprintf("(allow %s\n  %s)", operations, strings.Join(filters, "\n  "))
+}
+
+func (r *Runtime) macosNoAccessGlobPolicy(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+) (string, error) {
+	// macOS glob no-access rules are hard Seatbelt denials, matching
+	// Codex's macOS behavior. More-specific read/write grants do not reopen
+	// glob-matched paths; use exact no-access paths when carveouts are needed.
+	var rules []string
+	for _, rule := range profile.fileSystem.Rules {
+		if rule.Access != accessNone || rule.Kind != ruleGlob {
+			continue
+		}
+		regex, ok, err := macosSeatbeltRegexForWorkspaceGlob(ws, rule.Glob)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			continue
+		}
+		regex = strings.ReplaceAll(regex, `"`, `\"`)
+		rules = append(rules,
+			fmt.Sprintf(`(deny file-read* file-map-executable file-test-existence (regex #"%s"))`, regex),
+			fmt.Sprintf(`(deny file-write* (regex #"%s"))`, regex),
+		)
+	}
+	return strings.Join(rules, "\n"), nil
+}
+
+func macosSeatbeltRegexForWorkspaceGlob(
+	ws codeexecutor.Workspace,
+	pattern string,
+) (string, bool, error) {
+	glob := filepath.ToSlash(filepath.Clean(strings.TrimSpace(pattern)))
+	if glob == "" || glob == "." {
+		return "", false, nil
+	}
+	if filepath.IsAbs(glob) || strings.HasPrefix(glob, "../") {
+		return "", false, deniedf(
+			ErrPolicyViolation,
+			"no-access-glob",
+			pattern,
+			"macOS backend requires workspace-relative glob denials",
+		)
+	}
+	wsAbs, err := filepath.Abs(ws.Path)
+	if err != nil {
+		return "", false, err
+	}
+	wsAbs, err = canonicalizeExistingPath(wsAbs)
+	if err != nil {
+		return "", false, err
+	}
+	absolutePattern := filepath.ToSlash(filepath.Join(wsAbs, filepath.FromSlash(glob)))
+	regex, err := macosGlobPatternToRegex(absolutePattern)
+	if err != nil {
+		return "", false, deniedf(
+			ErrPolicyViolation,
+			"no-access-glob",
+			pattern,
+			"invalid glob pattern: %v",
+			err,
+		)
+	}
+	return regex, true, nil
+}
+
+func macosGlobPatternToRegex(pattern string) (string, error) {
+	var b strings.Builder
+	b.WriteString("^")
+	sawGlob := false
+	for i := 0; i < len(pattern); i++ {
+		ch := pattern[i]
+		switch ch {
+		case '*':
+			sawGlob = true
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				i++
+				if i+1 < len(pattern) && pattern[i+1] == '/' {
+					i++
+					b.WriteString("(.*/)?")
+				} else {
+					b.WriteString(".*")
+				}
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			sawGlob = true
+			b.WriteString("[^/]")
+		case '[':
+			sawGlob = true
+			end := i + 1
+			for end < len(pattern) && pattern[end] != ']' {
+				end++
+			}
+			if end >= len(pattern) {
+				return "", fmt.Errorf("unclosed character class")
+			}
+			class := pattern[i+1 : end]
+			if class == "" {
+				return "", fmt.Errorf("empty character class")
+			}
+			b.WriteByte('[')
+			if class[0] == '!' {
+				b.WriteByte('^')
+				class = class[1:]
+			} else if class[0] == '^' {
+				b.WriteString(`\^`)
+				class = class[1:]
+			}
+			for j := 0; j < len(class); j++ {
+				if class[j] == '\\' {
+					b.WriteString(`\\`)
+					continue
+				}
+				b.WriteByte(class[j])
+			}
+			b.WriteByte(']')
+			i = end
+		case ']':
+			sawGlob = true
+			b.WriteString(`\]`)
+		default:
+			b.WriteString(regexp.QuoteMeta(string(ch)))
+		}
+	}
+	if !sawGlob {
+		b.WriteString("(/.*)?")
+	}
+	b.WriteString("$")
+	return b.String(), nil
+}
+
+func macosSeatbeltNetworkPolicy(policy NetworkPolicy) string {
+	if policy.Mode != NetworkEnabled {
+		return ""
+	}
+	return `(allow network-outbound)
+(allow network-inbound)
+(allow system-socket)
+(allow mach-lookup
+  (global-name "com.apple.SecurityServer")
+  (global-name "com.apple.SystemConfiguration.DNSConfiguration")
+  (global-name "com.apple.SystemConfiguration.configd")
+  (global-name "com.apple.networkd")
+  (global-name "com.apple.ocspd")
+  (global-name "com.apple.trustd")
+  (global-name "com.apple.trustd.agent"))`
+}
+
+func macosPlatformDefaultReadRoots() []string {
+	return []string{
+		"/Applications",
+		"/Library/Apple",
+		"/Library/Developer",
+		"/Library/Developer/CommandLineTools",
+		"/Library/Filesystems/NetFSPlugins",
+		"/Library/Preferences",
+		"/Library/Preferences/Logging",
+		"/System/Library/CoreServices",
+		"/System/Library/Frameworks",
+		"/System/Library/PrivateFrameworks",
+		"/System/Library/SubFrameworks",
+		"/bin",
+		"/etc",
+		"/opt/homebrew/lib",
+		"/private/etc",
+		"/private/tmp",
+		"/private/var/db",
+		"/private/var/folders",
+		"/private/var/select",
+		"/private/var/tmp",
+		"/sbin",
+		"/tmp",
+		"/usr/bin",
+		"/usr/lib",
+		"/usr/libexec",
+		"/usr/local/lib",
+		"/usr/sbin",
+		"/usr/share",
+		"/var/db",
+		"/var/folders",
+		"/var/select",
+		"/var/tmp",
+	}
+}
+
+func macosStrictChildRoots(roots []string, maybeChildren []string) []string {
+	var children []string
+	for _, root := range roots {
+		for _, child := range maybeChildren {
+			if root != child && sameOrChild(root, child) {
+				children = append(children, child)
+			}
+		}
+	}
+	return dedupeCleanAbs(children)
+}
+
+func macosRootUnderAny(root string, parents []string) bool {
+	for _, parent := range parents {
+		if root != parent && sameOrChild(parent, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeCleanAbs(paths []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		if normalized, err := canonicalizeExistingPath(abs); err == nil {
+			abs = normalized
+		}
+		abs = filepath.Clean(abs)
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func nonEmptySections(sections []string) []string {
+	var out []string
+	for _, section := range sections {
+		if strings.TrimSpace(section) != "" {
+			out = append(out, section)
+		}
+	}
+	return out
+}
+
+func macosSandboxPath(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func sbplString(s string) string {
+	return strconv.Quote(macosSandboxPath(s))
+}

--- a/codeexecutor/sandbox/seatbelt_profile_macos.go
+++ b/codeexecutor/sandbox/seatbelt_profile_macos.go
@@ -118,6 +118,7 @@ func (r *Runtime) macosSeatbeltProfile(
 		macosBaseSeatbeltPolicy,
 		macosPlatformRootLiteralPolicy,
 		macosPlatformAliasPolicy,
+		macosPlatformTempMetadataPolicy,
 		"; allow read-only file operations",
 		readPolicy,
 		"; allow writable file operations",
@@ -138,6 +139,7 @@ func macosPreflightPolicy() string {
 		macosBaseSeatbeltPolicy,
 		macosPlatformRootLiteralPolicy,
 		macosPlatformAliasPolicy,
+		macosPlatformTempMetadataPolicy,
 		readPolicy,
 	}), "\n\n")
 }
@@ -152,6 +154,16 @@ const macosPlatformAliasPolicy = `; Preserve common macOS symlink spellings used
   (subpath "/var/select"))
 (allow file-read-metadata file-test-existence
   (path-ancestors "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/bin"))`
+
+const macosPlatformTempMetadataPolicy = `; Allow ancestor metadata for default temp path probes without granting host temp file reads.
+; Runtime injects TMPDIR/TMP/TEMP into the workspace tmp directory.
+(allow file-read-metadata file-test-existence
+  (path-ancestors "/tmp")
+  (path-ancestors "/private/tmp")
+  (path-ancestors "/var/tmp")
+  (path-ancestors "/private/var/tmp")
+  (path-ancestors "/var/folders")
+  (path-ancestors "/private/var/folders"))`
 
 func (r *Runtime) macosReadWriteRoots(
 	profile PermissionProfile,
@@ -216,20 +228,26 @@ func (r *Runtime) macosRuleTarget(
 			if err != nil {
 				return "", false, err
 			}
-			if rule.Access != accessNone {
-				wsAbs, err := filepath.Abs(ws.Path)
+			wsAbs, err := filepath.Abs(ws.Path)
+			if err != nil {
+				return "", false, err
+			}
+			if sameOrChild(wsAbs, target) {
+				rel, err := filepath.Rel(wsAbs, target)
 				if err != nil {
 					return "", false, err
 				}
-				if !sameOrChild(wsAbs, target) {
-					if _, err := filepath.EvalSymlinks(target); err != nil {
-						return "", false, deniedf(
-							ErrPathDenied,
-							"grant",
-							target,
-							"grant target unavailable",
-						)
-					}
+				resolved, _, err := r.resolveWorkspacePath(ws, rel)
+				return resolved, err == nil, err
+			}
+			if rule.Access != accessNone {
+				if _, err := filepath.EvalSymlinks(target); err != nil {
+					return "", false, deniedf(
+						ErrPathDenied,
+						"grant",
+						target,
+						"grant target unavailable",
+					)
 				}
 			}
 			return target, true, nil
@@ -481,13 +499,9 @@ func macosPlatformDefaultReadRoots() []string {
 		"/etc",
 		"/opt/homebrew/lib",
 		"/private/etc",
-		"/private/tmp",
 		"/private/var/db",
-		"/private/var/folders",
 		"/private/var/select",
-		"/private/var/tmp",
 		"/sbin",
-		"/tmp",
 		"/usr/bin",
 		"/usr/lib",
 		"/usr/libexec",
@@ -495,9 +509,7 @@ func macosPlatformDefaultReadRoots() []string {
 		"/usr/sbin",
 		"/usr/share",
 		"/var/db",
-		"/var/folders",
 		"/var/select",
-		"/var/tmp",
 	}
 }
 

--- a/examples/sandboxcodeexecution/README.md
+++ b/examples/sandboxcodeexecution/README.md
@@ -107,22 +107,39 @@ clear message. The example never reads or prints key contents.
   placeholder mount.
 - `file-system-policy-glob-writable-reject`: verifies glob no-access rules that
   overlap writable mounts fail closed before sandbox execution.
+- `file-system-policy-glob-writable-dynamic-deny`: verifies macOS Seatbelt
+  dynamically denies glob-matched paths inside writable roots.
 - `session-workspace-id-sanitization`: verifies distinct session IDs that
   sanitize similarly, such as `user:a` and `user_a`, remain isolated.
 - `session-policy-explicit-zero`: uses a real LLMAgent to call a deterministic
   probe that verifies `SessionPolicy{}` preserves explicit per-turn/parallel
   semantics and cleans up the workspace.
 
+## Platform-specific scenarios
+
+Most scenarios exercise shared `codeexecutor/sandbox` API behavior and run on
+all supported managed backends. A few scenarios intentionally verify backend
+implementation details:
+
+- Linux-only: `file-system-policy-directory-no-access-mask`,
+  `file-system-policy-missing-no-access-mask`, and
+  `file-system-policy-glob-writable-reject`.
+- macOS-only: `file-system-policy-glob-writable-dynamic-deny`.
+
+When `-scenario all` is used, scenarios that do not apply to the current
+`runtime.GOOS` are skipped with a clear message.
+
 ## Flags
 
 ```bash
--scenario basic|agent-tool-manual-run|agent-tool-basic|agent-tool-session-persistence|agent-tool-security|agent-artifact-stage|agent-artifact-save|agent-artifact-pin|session-persistence|session-isolation|env-redaction|metadata-protection|no-access|network-restricted|network-policy-restricted|network-policy-enabled|network-policy-additional-permissions|network-policy-agent-enforcement|timeout|output-cap|additional-permissions|shell-environment-policy-default-all|shell-environment-policy-core|shell-environment-policy-none-set|shell-environment-policy-include-only|shell-environment-policy-exclude-set|shell-environment-policy-agent|file-system-policy-access-modes|file-system-policy-specificity|file-system-policy-glob-no-access|file-system-policy-agent-enforcement|file-system-policy-symlink-no-access|file-system-policy-stage-target-validation|file-system-policy-put-files-symlink-target|file-system-policy-host-stage-absolute-grant|file-system-policy-host-stage-source-symlink|file-system-policy-directory-no-access-mask|file-system-policy-missing-no-access-mask|file-system-policy-glob-writable-reject|session-workspace-id-sanitization|session-policy-explicit-zero|all
+-scenario basic|agent-tool-manual-run|agent-tool-basic|agent-tool-session-persistence|agent-tool-security|agent-artifact-stage|agent-artifact-save|agent-artifact-pin|session-persistence|session-isolation|env-redaction|metadata-protection|no-access|network-restricted|network-policy-restricted|network-policy-enabled|network-policy-additional-permissions|network-policy-agent-enforcement|timeout|output-cap|additional-permissions|shell-environment-policy-default-all|shell-environment-policy-core|shell-environment-policy-none-set|shell-environment-policy-include-only|shell-environment-policy-exclude-set|shell-environment-policy-agent|file-system-policy-access-modes|file-system-policy-specificity|file-system-policy-glob-no-access|file-system-policy-agent-enforcement|file-system-policy-symlink-no-access|file-system-policy-stage-target-validation|file-system-policy-put-files-symlink-target|file-system-policy-host-stage-absolute-grant|file-system-policy-host-stage-source-symlink|file-system-policy-directory-no-access-mask|file-system-policy-missing-no-access-mask|file-system-policy-glob-writable-reject|file-system-policy-glob-writable-dynamic-deny|session-workspace-id-sanitization|session-policy-explicit-zero|all
 -model glm-4.7-flash
 -workspace-root /tmp/my-sandbox-root
 -keep-workspace
 -require-os-sandbox=true
 ```
 
-On Linux, the managed sandbox requires `bwrap` and user namespace support. If
-the OS sandbox cannot be set up, the example reports the typed setup/backend
-error and does not fall back to local execution.
+On Linux, the managed sandbox requires `bwrap` and user namespace support. On
+macOS, the managed sandbox requires `/usr/bin/sandbox-exec` and host permission
+to apply Seatbelt profiles. If the OS sandbox cannot be set up, the example
+reports the typed setup/backend error and does not fall back to local execution.

--- a/examples/sandboxcodeexecution/file_system_policy_scenarios.go
+++ b/examples/sandboxcodeexecution/file_system_policy_scenarios.go
@@ -37,6 +37,7 @@ const (
 	fileSystemPolicyDirectoryNoAccessMarker     = "FILE_SYSTEM_POLICY_DIRECTORY_NO_ACCESS_MASK_OK"
 	fileSystemPolicyMissingNoAccessMarker       = "FILE_SYSTEM_POLICY_MISSING_NO_ACCESS_MASK_OK"
 	fileSystemPolicyGlobWritableRejectMarker    = "FILE_SYSTEM_POLICY_GLOB_WRITABLE_REJECT_OK"
+	fileSystemPolicyGlobDynamicDenyMarker       = "FILE_SYSTEM_POLICY_GLOB_WRITABLE_DYNAMIC_DENY_OK"
 	sessionPolicyExplicitZeroMarker             = "SESSION_POLICY_EXPLICIT_ZERO_OK"
 	fileSystemPolicySecretSentinel              = "FILE_SYSTEM_POLICY_SECRET_SHOULD_NOT_APPEAR"
 )
@@ -605,6 +606,44 @@ func runFileSystemPolicyGlobWritableReject(ctx context.Context, cfg config) erro
 		return fmt.Errorf("glob setup rejection still created matching file, stat err=%v", err)
 	}
 	fmt.Println(fileSystemPolicyGlobWritableRejectMarker)
+	return nil
+}
+
+func runFileSystemPolicyGlobWritableDynamicDeny(ctx context.Context, cfg config) error {
+	profile := sandbox.WorkspaceWriteProfile().WithNoAccessGlobs("work/*.env")
+	rt := newRuntime(cfg, profile, 1<<20, 3*time.Second)
+	if err := requireManagedSandbox(ctx, rt, cfg); err != nil {
+		return err
+	}
+	ws, err := rt.CreateWorkspace(ctx, "file-system-policy-glob-writable-dynamic-deny", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(ws.Path, "work", "future.env")
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		return fmt.Errorf("glob target unexpectedly exists before run, stat err=%v", err)
+	}
+	res, err := rt.RunProgram(ctx, ws, codeexecutor.RunProgramSpec{
+		Cmd: "bash",
+		Args: []string{
+			"-c",
+			"echo unexpected > future.env 2>/dev/null || echo " + fileSystemPolicyGlobDynamicDenyMarker,
+		},
+		Cwd: codeexecutor.DirWork,
+	})
+	if err != nil {
+		return err
+	}
+	if strings.Contains(res.Stdout, "unexpected") {
+		return fmt.Errorf("glob no-access write unexpectedly succeeded: result=%#v", res)
+	}
+	if err := expectContains(res.Stdout, fileSystemPolicyGlobDynamicDenyMarker); err != nil {
+		return err
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		return fmt.Errorf("glob-denied file appeared on host, stat err=%v", err)
+	}
+	fmt.Println(fileSystemPolicyGlobDynamicDenyMarker)
 	return nil
 }
 

--- a/examples/sandboxcodeexecution/main.go
+++ b/examples/sandboxcodeexecution/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -44,8 +45,25 @@ type config struct {
 }
 
 type scenario struct {
-	name string
-	run  func(context.Context, config) error
+	name      string
+	run       func(context.Context, config) error
+	platforms []string
+}
+
+func newScenario(name string, run func(context.Context, config) error, platforms ...string) scenario {
+	return scenario{name: name, run: run, platforms: platforms}
+}
+
+func (s scenario) supportsPlatform(goos string) bool {
+	if len(s.platforms) == 0 {
+		return true
+	}
+	for _, platform := range s.platforms {
+		if platform == goos {
+			return true
+		}
+	}
+	return false
 }
 
 func main() {
@@ -66,7 +84,8 @@ func main() {
 			"file-system-policy-stage-target-validation|file-system-policy-put-files-symlink-target|"+
 			"file-system-policy-host-stage-absolute-grant|file-system-policy-host-stage-source-symlink|"+
 			"file-system-policy-directory-no-access-mask|file-system-policy-missing-no-access-mask|"+
-			"file-system-policy-glob-writable-reject|session-workspace-id-sanitization|"+
+			"file-system-policy-glob-writable-reject|file-system-policy-glob-writable-dynamic-deny|"+
+			"session-workspace-id-sanitization|"+
 			"session-policy-explicit-zero|"+
 			"all",
 	)
@@ -103,47 +122,48 @@ func main() {
 
 func runScenarios(ctx context.Context, cfg config) error {
 	scenarios := []scenario{
-		{"basic", runBasic},
-		{"agent-tool-manual-run", runAgentToolManualRun}, // manual run of agent with tool to see what it can do
-		{"agent-tool-basic", runAgentToolBasic},
-		{"agent-tool-session-persistence", runAgentToolSessionPersistence},
-		{"agent-tool-security", runAgentToolSecurity},
-		{"agent-artifact-stage", runAgentArtifactStage},
-		{"agent-artifact-save", runAgentArtifactSave},
-		{"agent-artifact-pin", runAgentArtifactPin},
-		{"session-persistence", runSessionPersistence},
-		{"session-isolation", runSessionIsolation},
-		{"env-redaction", runEnvRedaction},
-		{"metadata-protection", runMetadataProtection},
-		{"no-access", runNoAccess},
-		{"network-restricted", runNetworkRestricted},
-		{"network-policy-restricted", runNetworkPolicyRestricted},
-		{"network-policy-enabled", runNetworkPolicyEnabled},
-		{"network-policy-additional-permissions", runNetworkPolicyAdditionalPermissions},
-		{"network-policy-agent-enforcement", runNetworkPolicyAgentEnforcement},
-		{"timeout", runTimeout},
-		{"output-cap", runOutputCap},
-		{"additional-permissions", runAdditionalPermissions},
-		{"shell-environment-policy-default-all", runShellEnvironmentPolicyDefaultAll},
-		{"shell-environment-policy-core", runShellEnvironmentPolicyCore},
-		{"shell-environment-policy-none-set", runShellEnvironmentPolicyNoneSet},
-		{"shell-environment-policy-include-only", runShellEnvironmentPolicyIncludeOnly},
-		{"shell-environment-policy-exclude-set", runShellEnvironmentPolicyExcludeSet},
-		{"shell-environment-policy-agent", runShellEnvironmentPolicyAgent},
-		{"file-system-policy-access-modes", runFileSystemPolicyAccessModes},
-		{"file-system-policy-specificity", runFileSystemPolicySpecificity},
-		{"file-system-policy-glob-no-access", runFileSystemPolicyGlobNoAccess},
-		{"file-system-policy-agent-enforcement", runFileSystemPolicyAgentEnforcement},
-		{"file-system-policy-symlink-no-access", runFileSystemPolicySymlinkNoAccess},
-		{"file-system-policy-stage-target-validation", runFileSystemPolicyStageTargetValidation},
-		{"file-system-policy-put-files-symlink-target", runFileSystemPolicyPutFilesSymlinkTarget},
-		{"file-system-policy-host-stage-absolute-grant", runFileSystemPolicyHostStageAbsoluteGrant},
-		{"file-system-policy-host-stage-source-symlink", runFileSystemPolicyHostStageSourceSymlink},
-		{"file-system-policy-directory-no-access-mask", runFileSystemPolicyDirectoryNoAccessMask},
-		{"file-system-policy-missing-no-access-mask", runFileSystemPolicyMissingNoAccessMask},
-		{"file-system-policy-glob-writable-reject", runFileSystemPolicyGlobWritableReject},
-		{"session-workspace-id-sanitization", runSessionWorkspaceIDSanitization},
-		{"session-policy-explicit-zero", runSessionPolicyExplicitZero},
+		newScenario("basic", runBasic),
+		newScenario("agent-tool-manual-run", runAgentToolManualRun), // manual run of agent with tool to see what it can do
+		newScenario("agent-tool-basic", runAgentToolBasic),
+		newScenario("agent-tool-session-persistence", runAgentToolSessionPersistence),
+		newScenario("agent-tool-security", runAgentToolSecurity),
+		newScenario("agent-artifact-stage", runAgentArtifactStage),
+		newScenario("agent-artifact-save", runAgentArtifactSave),
+		newScenario("agent-artifact-pin", runAgentArtifactPin),
+		newScenario("session-persistence", runSessionPersistence),
+		newScenario("session-isolation", runSessionIsolation),
+		newScenario("env-redaction", runEnvRedaction),
+		newScenario("metadata-protection", runMetadataProtection),
+		newScenario("no-access", runNoAccess),
+		newScenario("network-restricted", runNetworkRestricted),
+		newScenario("network-policy-restricted", runNetworkPolicyRestricted),
+		newScenario("network-policy-enabled", runNetworkPolicyEnabled),
+		newScenario("network-policy-additional-permissions", runNetworkPolicyAdditionalPermissions),
+		newScenario("network-policy-agent-enforcement", runNetworkPolicyAgentEnforcement),
+		newScenario("timeout", runTimeout),
+		newScenario("output-cap", runOutputCap),
+		newScenario("additional-permissions", runAdditionalPermissions),
+		newScenario("shell-environment-policy-default-all", runShellEnvironmentPolicyDefaultAll),
+		newScenario("shell-environment-policy-core", runShellEnvironmentPolicyCore),
+		newScenario("shell-environment-policy-none-set", runShellEnvironmentPolicyNoneSet),
+		newScenario("shell-environment-policy-include-only", runShellEnvironmentPolicyIncludeOnly),
+		newScenario("shell-environment-policy-exclude-set", runShellEnvironmentPolicyExcludeSet),
+		newScenario("shell-environment-policy-agent", runShellEnvironmentPolicyAgent),
+		newScenario("file-system-policy-access-modes", runFileSystemPolicyAccessModes),
+		newScenario("file-system-policy-specificity", runFileSystemPolicySpecificity),
+		newScenario("file-system-policy-glob-no-access", runFileSystemPolicyGlobNoAccess),
+		newScenario("file-system-policy-agent-enforcement", runFileSystemPolicyAgentEnforcement),
+		newScenario("file-system-policy-symlink-no-access", runFileSystemPolicySymlinkNoAccess),
+		newScenario("file-system-policy-stage-target-validation", runFileSystemPolicyStageTargetValidation),
+		newScenario("file-system-policy-put-files-symlink-target", runFileSystemPolicyPutFilesSymlinkTarget),
+		newScenario("file-system-policy-host-stage-absolute-grant", runFileSystemPolicyHostStageAbsoluteGrant),
+		newScenario("file-system-policy-host-stage-source-symlink", runFileSystemPolicyHostStageSourceSymlink),
+		newScenario("file-system-policy-directory-no-access-mask", runFileSystemPolicyDirectoryNoAccessMask, "linux"),
+		newScenario("file-system-policy-missing-no-access-mask", runFileSystemPolicyMissingNoAccessMask, "linux"),
+		newScenario("file-system-policy-glob-writable-reject", runFileSystemPolicyGlobWritableReject, "linux"),
+		newScenario("file-system-policy-glob-writable-dynamic-deny", runFileSystemPolicyGlobWritableDynamicDeny, "darwin"),
+		newScenario("session-workspace-id-sanitization", runSessionWorkspaceIDSanitization),
+		newScenario("session-policy-explicit-zero", runSessionPolicyExplicitZero),
 	}
 	selected := map[string]scenario{}
 	for _, sc := range scenarios {
@@ -161,6 +181,14 @@ func runScenarios(ctx context.Context, cfg config) error {
 	}
 	for _, sc := range toRun {
 		fmt.Printf("== %s ==\n", sc.name)
+		if !sc.supportsPlatform(runtime.GOOS) {
+			if cfg.scenario != "all" {
+				return fmt.Errorf("scenario %q is not supported on %s", sc.name, runtime.GOOS)
+			}
+			fmt.Printf("scenario is not supported on %s\n", runtime.GOOS)
+			fmt.Printf("SKIP %s\n\n", sc.name)
+			continue
+		}
 		err := sc.run(ctx, cfg)
 		switch {
 		case err == nil:

--- a/examples/sandboxcodeexecution/network_policy_scenarios.go
+++ b/examples/sandboxcodeexecution/network_policy_scenarios.go
@@ -12,6 +12,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
@@ -162,7 +164,7 @@ func expectNetworkConnected(ctx context.Context, rt *sandbox.Runtime, ws codeexe
 
 func runNetworkProbe(ctx context.Context, rt *sandbox.Runtime, ws codeexecutor.Workspace) (string, error) {
 	res, err := rt.RunProgram(ctx, ws, codeexecutor.RunProgramSpec{
-		Cmd:     "python3",
+		Cmd:     networkProbePythonCommand(),
 		Args:    []string{"-c", networkPolicyProbeScript},
 		Cwd:     codeexecutor.DirWork,
 		Timeout: 2 * time.Second,
@@ -174,4 +176,15 @@ func runNetworkProbe(ctx context.Context, rt *sandbox.Runtime, ws codeexecutor.W
 		return "", fmt.Errorf("network probe failed: stdout=%q stderr=%q", redact(res.Stdout), redact(res.Stderr))
 	}
 	return res.Stdout, nil
+}
+
+func networkProbePythonCommand() string {
+	if runtime.GOOS != "darwin" {
+		return "python3"
+	}
+	const commandLineToolsPython = "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/bin/python3"
+	if _, err := os.Stat(commandLineToolsPython); err == nil {
+		return commandLineToolsPython
+	}
+	return "python3"
 }

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -297,7 +297,7 @@ tools:
     auto_execute_code_blocks: true
     sandbox:
       workspace_root: "" # default: state_dir/sandbox
-      backend: "auto" # auto|linux-bubblewrap
+      backend: "auto" # auto|linux-bubblewrap|macos-sandbox-exec
       profile: "workspace_write" # workspace_write|read_only|disabled
       network: "restricted" # restricted|enabled
       default_timeout: "30s"

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -285,7 +285,7 @@ tools:
     auto_execute_code_blocks: true
     sandbox:
       workspace_root: "" # 默认 state_dir/sandbox
-      backend: "auto" # auto|linux-bubblewrap
+      backend: "auto" # auto|linux-bubblewrap|macos-sandbox-exec
       profile: "workspace_write" # workspace_write|read_only|disabled
       network: "restricted" # restricted|enabled
       default_timeout: "30s"

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -2805,6 +2805,8 @@ func sandboxBackendFromConfig(raw string) sandboxexec.BackendType {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case sandboxBackendLinuxBubblewrap:
 		return sandboxexec.BackendLinuxBubblewrap
+	case sandboxBackendMacOSSandbox:
+		return sandboxexec.BackendMacOSSandboxExec
 	default:
 		return sandboxexec.BackendAuto
 	}

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -6925,6 +6925,11 @@ func TestSandboxProfileAndBackendConfigBranches(t *testing.T) {
 		sandboxexec.BackendLinuxBubblewrap,
 		sandboxBackendFromConfig(" LINUX-BUBBLEWRAP "),
 	)
+	require.Equal(
+		t,
+		sandboxexec.BackendMacOSSandboxExec,
+		sandboxBackendFromConfig(" MACOS-SANDBOX-EXEC "),
+	)
 	require.Equal(t, sandboxexec.BackendAuto, sandboxBackendFromConfig("unknown"))
 
 	enabledReadOnly := sandboxPermissionProfileFromConfig(sandboxCodeExecutorOptions{

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -62,6 +62,7 @@ const (
 
 	sandboxBackendAuto            = "auto"
 	sandboxBackendLinuxBubblewrap = "linux-bubblewrap"
+	sandboxBackendMacOSSandbox    = "macos-sandbox-exec"
 
 	sandboxProfileWorkspaceWrite = "workspace_write"
 	sandboxProfileReadOnly       = "read_only"
@@ -2367,11 +2368,11 @@ func convertSandboxCodeExecutorConfig(
 	backend := strings.ToLower(strings.TrimSpace(cfg.Backend))
 	if backend != "" {
 		switch backend {
-		case sandboxBackendAuto, sandboxBackendLinuxBubblewrap:
+		case sandboxBackendAuto, sandboxBackendLinuxBubblewrap, sandboxBackendMacOSSandbox:
 			out.Backend = backend
 		default:
 			return sandboxCodeExecutorOptions{}, fmt.Errorf(
-				"sandbox.backend %q: want auto|linux-bubblewrap",
+				"sandbox.backend %q: want auto|linux-bubblewrap|macos-sandbox-exec",
 				cfg.Backend,
 			)
 		}

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1307,7 +1307,7 @@ func TestConvertSandboxCodeExecutorConfigValidationBranches(t *testing.T) {
 	maxBytes := 512
 	got, err := convertSandboxCodeExecutorConfig(&sandboxCodeExecutorConfig{
 		WorkspaceRoot:  " /tmp/sandbox ",
-		Backend:        " LINUX-BUBBLEWRAP ",
+		Backend:        " MACOS-SANDBOX-EXEC ",
 		Profile:        " READ_ONLY ",
 		Network:        " ENABLED ",
 		DefaultTimeout: "2s",
@@ -1315,11 +1315,17 @@ func TestConvertSandboxCodeExecutorConfigValidationBranches(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "/tmp/sandbox", got.WorkspaceRoot)
-	require.Equal(t, sandboxBackendLinuxBubblewrap, got.Backend)
+	require.Equal(t, sandboxBackendMacOSSandbox, got.Backend)
 	require.Equal(t, sandboxProfileReadOnly, got.Profile)
 	require.Equal(t, sandboxNetworkEnabled, got.Network)
 	require.Equal(t, 2*time.Second, got.DefaultTimeout)
 	require.Equal(t, maxBytes, got.OutputMaxBytes)
+
+	linuxBackend, err := convertSandboxCodeExecutorConfig(&sandboxCodeExecutorConfig{
+		Backend: " LINUX-BUBBLEWRAP ",
+	})
+	require.NoError(t, err)
+	require.Equal(t, sandboxBackendLinuxBubblewrap, linuxBackend.Backend)
 
 	cases := []struct {
 		name string

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -56,7 +56,7 @@ tools:
   #   auto_execute_code_blocks: true
   #   sandbox:
   #     workspace_root: "" # default: state_dir/sandbox
-  #     backend: "auto" # auto|linux-bubblewrap
+  #     backend: "auto" # auto|linux-bubblewrap|macos-sandbox-exec
   #     profile: "workspace_write" # workspace_write|read_only|disabled
   #     network: "restricted" # restricted|enabled
   #     default_timeout: "30s"


### PR DESCRIPTION
## Summary

This MR adds a macOS managed OS sandbox backend for `codeexecutor/sandbox` using
Apple Seatbelt via `/usr/bin/sandbox-exec`.

It keeps the existing sandbox public API, workspace layout,
`PermissionProfile`, `SessionPolicy`, error model, and Linux backend behavior
unchanged. The change is scoped to adding a macOS OS-backend projection.

## Changes

- Add `BackendMacOSSandboxExec` with backend string `macos-sandbox-exec`.
- Add the macOS backend implementation:
  - `backend_macos.go`
  - `seatbelt_profile_macos.go`
  - `backend_macos_test.go`
- Change the non-Linux fallback backend to `!linux && !darwin`.
- Use the fixed path `/usr/bin/sandbox-exec` for preflight and command
  execution to avoid `PATH` hijacking.
- Generate Seatbelt SBPL for:
  - deny-default baseline
  - selected macOS platform defaults
  - workspace read/write grants
  - external host path grants
  - exact no-access carveouts
  - protected metadata write protection
  - glob no-access regex hard deny
  - restricted/enabled binary network policy
- Update sandbox documentation:
  - `docs/README.md`
  - `docs/FILE_SYSTEM_POLICY.md`
  - `docs/MACOS_BACKEND.md`
- Make `examples/sandboxcodeexecution` platform-aware:
  - `all` skips scenarios that do not apply to the current `runtime.GOOS`
  - Linux-only scenarios keep bwrap mask semantics
  - add macOS-only `file-system-policy-glob-writable-dynamic-deny`
  - switch the network probe to `/usr/bin/nc` to avoid `python3` triggering
    `xcode-select` under macOS sandboxing
- Sync the OpenClaw config entry point:
  - allow `code_executor.sandbox.backend: "macos-sandbox-exec"`
  - map it to `sandboxexec.BackendMacOSSandboxExec`
  - update OpenClaw README / YAML examples

## Design

The design reuses the existing sandbox layers and only replaces the OS backend
projection:

```text
PermissionProfile / Runtime / SessionPolicy / File API
        |
        +-- Linux: PermissionProfile -> bwrap args
        |
        +-- macOS: PermissionProfile -> Seatbelt SBPL -> sandbox-exec args
```

The `RunProgram -> commandForProfile -> osSandboxCommand` call chain remains
unchanged. The macOS backend is not a new sandbox product; it is the second OS
implementation in the existing managed backend matrix.

## Linux vs macOS

### Host visibility

Linux backend starts with:

```text
--ro-bind / /
```

The child process gets a read-only host-root view, then workspace writes and explicit grants are mounted on top.

macOS backend starts with:

```scheme
(deny default)
```

Then it allows selected platform defaults, workspace grants, and explicit external grants. It does not emulate Linux's whole-host read-only view.

### No-access globs

Linux uses static bwrap mount masks:

- expands existing glob matches before process start
- masks matched files/directories
- may fail closed when glob denials overlap writable mounts

macOS uses dynamic Seatbelt regex hard deny:

```scheme
(deny file-read* (regex "..."))
(deny file-write* (regex "..."))
```

Matching paths are denied even if they are created after process start or live under writable roots. More-specific read/write grants do not reopen paths matched by `WithNoAccessGlobs`; use exact no-access paths when carveouts are required.

### Protected metadata

Linux remounts protected metadata paths such as `.git`, `.agents`, and `.trpc-agent-sandbox` read-only.

macOS excludes those paths from write allows in the Seatbelt profile. The public semantic remains: protected metadata is readable but never writable.

### Network policy

Both backends use the same public binary network model:

- `NetworkRestricted`
- `NetworkEnabled`

Linux restricted mode uses `--unshare-net`. macOS restricted mode does not add broad network allow rules; enabled mode adds broad outbound/inbound network allows.

### Preflight

Linux preflight validates `bwrap` availability and namespace/proc mount support.

macOS preflight validates `/usr/bin/sandbox-exec` and runs a minimal Seatbelt profile. If Seatbelt cannot be applied, setup fails closed with `ErrSetupFailed`; it does not fall back to `DangerFullAccessProfile`.

## Compatibility

- No public API changes.
- No `PermissionProfile` / `SessionPolicy` / workspace layout changes.
- No Linux backend behavior changes.
- No new macOS-specific public options.
- No `backendCapabilitiesInfo` expansion.
- OpenClaw only extends backend config parsing and mapping; it does not add a separate code executor.
- Examples stay in one directory and use platform-aware scenario filtering.

## Testing

Passed:

```bash
go test ./codeexecutor/sandbox
cd examples && go test ./sandboxcodeexecution
cd examples && go run ./sandboxcodeexecution -scenario all -require-os-sandbox=false
cd examples && go run ./sandboxcodeexecution -scenario file-system-policy-glob-writable-dynamic-deny
cd examples && go run ./sandboxcodeexecution -scenario session-persistence
cd openclaw && go test ./app -run 'Test.*CodeExecutor|Test.*Sandbox'
cd openclaw && go test ./app
```

Root module status:

```bash
go test ./...
```