### PR TITLE
{agent, event, runner, internal}: add execution trace usage

### DIFF
--- a/agent/execution_trace.go
+++ b/agent/execution_trace.go
@@ -15,6 +15,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/internal/surfacepatch"
 	"trpc.group/trpc-go/trpc-agent-go/internal/tracecapture"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // WithExecutionTraceEnabled toggles execution trace recording for this run.
@@ -185,6 +186,19 @@ func SetExecutionTraceStepAppliedSurfaceIDs(inv *Invocation, stepID string) {
 		return
 	}
 	capture.SetStepAppliedSurfaceIDs(stepID, reporter.ExecutionTraceAppliedSurfaceIDs(inv))
+}
+
+// SetExecutionTraceStepUsage records token usage for one execution trace step.
+func SetExecutionTraceStepUsage(inv *Invocation, stepID string, usage *model.Usage) {
+	if inv == nil || stepID == "" || usage == nil {
+		return
+	}
+	inv.initializeExecutionTrace()
+	capture := inv.executionTraceCapture()
+	if capture == nil {
+		return
+	}
+	capture.SetStepUsage(stepID, usage)
 }
 
 // NextExecutionTracePredecessors returns the predecessor set for the next real step or child invocation.

--- a/agent/execution_trace_test.go
+++ b/agent/execution_trace_test.go
@@ -210,6 +210,7 @@ func TestExecutionTraceHelpers_HandleNilAndDisabledInvocation(t *testing.T) {
 	assert.Empty(t, StartExecutionTraceStep(nilInv, "assistant", nil, nil))
 	FinishExecutionTraceStep(nilInv, "step-1", nil, nil)
 	SetExecutionTraceStepAppliedSurfaceIDs(nilInv, "step-1")
+	SetExecutionTraceStepUsage(nilInv, "step-1", &model.Usage{TotalTokens: 1})
 	assert.Nil(t, NextExecutionTracePredecessors(nilInv))
 	assert.Nil(t, BuildExecutionTrace(nilInv, atrace.TraceStatusCompleted))
 	nilInv.ensureTraceCaptureMetadata()
@@ -223,6 +224,9 @@ func TestExecutionTraceHelpers_HandleNilAndDisabledInvocation(t *testing.T) {
 	FinishExecutionTraceStep(disabled, "step-1", nil, nil)
 	FinishExecutionTraceStep(disabled, "", nil, nil)
 	SetExecutionTraceStepAppliedSurfaceIDs(disabled, "step-1")
+	SetExecutionTraceStepUsage(disabled, "step-1", &model.Usage{TotalTokens: 1})
+	SetExecutionTraceStepUsage(disabled, "", &model.Usage{TotalTokens: 1})
+	SetExecutionTraceStepUsage(disabled, "step-1", nil)
 	assert.Nil(t, NextExecutionTracePredecessors(disabled))
 	assert.Nil(t, BuildExecutionTrace(disabled, atrace.TraceStatusCompleted))
 }
@@ -268,6 +272,30 @@ func TestExecutionTraceHelpers_RecordAppliedSurfaceIDs(t *testing.T) {
 	require.NotNil(t, executionTrace)
 	require.Len(t, executionTrace.Steps, 1)
 	assert.Equal(t, []string{"assistant#instruction", "assistant#model"}, executionTrace.Steps[0].AppliedSurfaceIDs)
+}
+
+func TestExecutionTraceHelpers_RecordStepUsage(t *testing.T) {
+	inv := NewInvocation(
+		WithInvocationAgent(&mockAgent{name: "assistant"}),
+		WithInvocationRunOptions(RunOptions{ExecutionTraceEnabled: true}),
+		WithInvocationMessage(model.NewUserMessage("hello")),
+	)
+	stepID := StartExecutionTraceStep(
+		inv,
+		InvocationTraceNodeID(inv),
+		&atrace.Snapshot{Text: "input"},
+		nil,
+	)
+	require.NotEmpty(t, stepID)
+	SetExecutionTraceStepUsage(inv, stepID, &model.Usage{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5})
+	FinishExecutionTraceStep(inv, stepID, &atrace.Snapshot{Text: "output"}, nil)
+	executionTrace := BuildExecutionTrace(inv, atrace.TraceStatusCompleted)
+	require.NotNil(t, executionTrace)
+	require.Len(t, executionTrace.Steps, 1)
+	require.NotNil(t, executionTrace.Steps[0].Usage)
+	assert.Equal(t, 5, executionTrace.Steps[0].Usage.TotalTokens)
+	require.NotNil(t, executionTrace.Usage)
+	assert.Equal(t, 5, executionTrace.Usage.TotalTokens)
 }
 
 func TestExecutionTraceHelpers_SetAppliedSurfaceIDs_IgnoresNilAgent(t *testing.T) {

--- a/agent/trace/trace.go
+++ b/agent/trace/trace.go
@@ -9,7 +9,11 @@
 // Package trace defines the public execution trace model.
 package trace
 
-import "time"
+import (
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
 
 // TraceStatus describes the overall status of a single runner.Run execution trace.
 type TraceStatus string
@@ -31,6 +35,7 @@ type Trace struct {
 	StartedAt        time.Time
 	EndedAt          time.Time
 	Status           TraceStatus
+	Usage            *model.Usage
 	Steps            []Step
 }
 
@@ -48,6 +53,7 @@ type Step struct {
 	AppliedSurfaceIDs  []string
 	Input              *Snapshot
 	Output             *Snapshot
+	Usage              *model.Usage
 	Error              string
 }
 

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -66,6 +66,21 @@ type scriptedStore struct {
 	runs            map[string]*promptiterengine.RunResult
 }
 
+type errSequenceContext struct {
+	context.Context
+	errs  []error
+	calls int
+}
+
+func (c *errSequenceContext) Err() error {
+	if c.calls >= len(c.errs) {
+		return c.errs[len(c.errs)-1]
+	}
+	err := c.errs[c.calls]
+	c.calls++
+	return err
+}
+
 func (s *scriptedStore) Create(ctx context.Context, appName string, run *promptiterengine.RunResult) error {
 	_ = ctx
 	if s.createErr != nil {
@@ -470,6 +485,39 @@ func TestManagerRunPersistsCanceledBeforeRunning(t *testing.T) {
 
 	concreteManager.run(runCtx, "run-1", &promptiterengine.RunRequest{})
 
+	current := store.runs["run-1"]
+	require.NotNil(t, current)
+	assert.Equal(t, promptiterengine.RunStatusCanceled, current.Status)
+	assert.Equal(t, "run canceled", current.ErrorMessage)
+	_, ok := concreteManager.cancelFuncs["run-1"]
+	assert.False(t, ok)
+}
+
+func TestManagerRunPersistsCanceledAfterMarkingRunning(t *testing.T) {
+	runCtx := &errSequenceContext{
+		Context: context.Background(),
+		errs:    []error{nil, context.Canceled},
+	}
+	store := &scriptedStore{
+		runs: map[string]*promptiterengine.RunResult{
+			"run-1": {
+				AppName: "demo-app",
+				ID:      "run-1",
+				Status:  promptiterengine.RunStatusQueued,
+			},
+		},
+	}
+	engineInst := &fakePromptIterEngine{
+		run: func(ctx context.Context, request *promptiterengine.RunRequest, opts ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+			t.Fatal("engine should not run after context is canceled")
+			return nil, nil
+		},
+	}
+	managerInst, err := New("demo-app", engineInst, WithStore(store))
+	require.NoError(t, err)
+	concreteManager := managerInst.(*manager)
+	concreteManager.cancelFuncs["run-1"] = func() {}
+	concreteManager.run(runCtx, "run-1", &promptiterengine.RunRequest{})
 	current := store.runs["run-1"]
 	require.NotNil(t, current)
 	assert.Equal(t, promptiterengine.RunStatusCanceled, current.Status)

--- a/event/event.go
+++ b/event/event.go
@@ -248,6 +248,7 @@ func cloneExecutionTrace(executionTrace *trace.Trace) *trace.Trace {
 		StartedAt:        executionTrace.StartedAt,
 		EndedAt:          executionTrace.EndedAt,
 		Status:           executionTrace.Status,
+		Usage:            cloneUsage(executionTrace.Usage),
 		Steps:            make([]trace.Step, 0, len(executionTrace.Steps)),
 	}
 	for _, step := range executionTrace.Steps {
@@ -276,6 +277,7 @@ func cloneExecutionTraceStep(step trace.Step) trace.Step {
 		AppliedSurfaceIDs: append([]string(nil), step.AppliedSurfaceIDs...),
 		Input:             cloneExecutionTraceSnapshot(step.Input),
 		Output:            cloneExecutionTraceSnapshot(step.Output),
+		Usage:             cloneUsage(step.Usage),
 		Error:             step.Error,
 	}
 }
@@ -285,6 +287,18 @@ func cloneExecutionTraceSnapshot(snapshot *trace.Snapshot) *trace.Snapshot {
 		return nil
 	}
 	return &trace.Snapshot{Text: snapshot.Text}
+}
+
+func cloneUsage(usage *model.Usage) *model.Usage {
+	if usage == nil {
+		return nil
+	}
+	cloned := *usage
+	if usage.TimingInfo != nil {
+		timingInfo := *usage.TimingInfo
+		cloned.TimingInfo = &timingInfo
+	}
+	return &cloned
 }
 
 // Filter checks if the event matches the specified filter key.

--- a/event/event_clone_test.go
+++ b/event/event_clone_test.go
@@ -13,6 +13,7 @@ package event
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
@@ -89,6 +90,10 @@ func TestEvent_Clone_DeepCopiesExecutionTrace(t *testing.T) {
 		ExecutionTrace: &trace.Trace{
 			RootAgentName:    "assistant",
 			RootInvocationID: "inv-1",
+			Usage: &model.Usage{
+				PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3,
+				TimingInfo: &model.TimingInfo{FirstTokenDuration: time.Second},
+			},
 			Steps: []trace.Step{
 				{
 					StepID:             "s1",
@@ -96,6 +101,10 @@ func TestEvent_Clone_DeepCopiesExecutionTrace(t *testing.T) {
 					PredecessorStepIDs: []string{"s0"},
 					Input:              &trace.Snapshot{Text: "input"},
 					Output:             &trace.Snapshot{Text: "output"},
+					Usage: &model.Usage{
+						PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3,
+						TimingInfo: &model.TimingInfo{ReasoningDuration: time.Second},
+					},
 				},
 			},
 		},
@@ -106,6 +115,32 @@ func TestEvent_Clone_DeepCopiesExecutionTrace(t *testing.T) {
 	require.NotSame(t, e.ExecutionTrace, clone.ExecutionTrace)
 	clone.ExecutionTrace.Steps[0].PredecessorStepIDs[0] = "changed"
 	clone.ExecutionTrace.Steps[0].Input.Text = "updated"
+	clone.ExecutionTrace.Steps[0].Usage.TotalTokens = 99
+	clone.ExecutionTrace.Steps[0].Usage.TimingInfo.ReasoningDuration = 2 * time.Second
+	clone.ExecutionTrace.Usage.TotalTokens = 88
+	clone.ExecutionTrace.Usage.TimingInfo.FirstTokenDuration = 3 * time.Second
 	require.Equal(t, []string{"s0"}, e.ExecutionTrace.Steps[0].PredecessorStepIDs)
 	require.Equal(t, "input", e.ExecutionTrace.Steps[0].Input.Text)
+	require.Equal(t, 3, e.ExecutionTrace.Steps[0].Usage.TotalTokens)
+	require.Equal(t, time.Second, e.ExecutionTrace.Steps[0].Usage.TimingInfo.ReasoningDuration)
+	require.Equal(t, 3, e.ExecutionTrace.Usage.TotalTokens)
+	require.Equal(t, time.Second, e.ExecutionTrace.Usage.TimingInfo.FirstTokenDuration)
+}
+
+func TestEvent_Clone_ExecutionTraceKeepsNilUsage(t *testing.T) {
+	e := &Event{
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Done:   true,
+		},
+		ExecutionTrace: &trace.Trace{
+			Steps: []trace.Step{{StepID: "s1"}},
+		},
+	}
+	clone := e.Clone()
+	require.NotNil(t, clone)
+	require.NotNil(t, clone.ExecutionTrace)
+	require.Nil(t, clone.ExecutionTrace.Usage)
+	require.Len(t, clone.ExecutionTrace.Steps, 1)
+	require.Nil(t, clone.ExecutionTrace.Steps[0].Usage)
 }

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -718,6 +718,9 @@ func (f *Flow) runOneStep(
 		startedSpan,
 	)
 	agent.FinishExecutionTraceStep(invocation, stepID, traceSnapshotFromEvent(lastEvent), err)
+	if lastEvent != nil && lastEvent.Response != nil {
+		agent.SetExecutionTraceStepUsage(invocation, stepID, lastEvent.Response.Usage)
+	}
 	return lastEvent, err
 }
 

--- a/internal/tracecapture/capture.go
+++ b/internal/tracecapture/capture.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // StartStepInput contains the metadata needed to start a new step.
@@ -182,6 +183,33 @@ func (c *Capture) SetStepAppliedSurfaceIDs(stepID string, surfaceIDs []string) {
 	c.steps[idx].AppliedSurfaceIDs = slices.Clone(surfaceIDs)
 }
 
+// SetStepUsage updates token usage for one recorded step.
+func (c *Capture) SetStepUsage(stepID string, usage *model.Usage) {
+	usage = traceStepUsage(usage)
+	if c == nil || stepID == "" || usage == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	idx, ok := c.stepIndexByID[stepID]
+	if !ok {
+		return
+	}
+	c.steps[idx].Usage = usage
+}
+
+func traceStepUsage(usage *model.Usage) *model.Usage {
+	if usage == nil {
+		return nil
+	}
+	out := *usage
+	out.TimingInfo = nil
+	if out == (model.Usage{}) {
+		return nil
+	}
+	return &out
+}
+
 // PredecessorsForInvocation returns the current invocation predecessors for the next real step.
 func (c *Capture) PredecessorsForInvocation(invocationID string, entryPredecessors []string) []string {
 	if c == nil {
@@ -230,7 +258,9 @@ func (c *Capture) Build(status trace.TraceStatus, endedAt time.Time) *trace.Trac
 		Steps:            make([]trace.Step, 0, len(c.steps)),
 	}
 	for _, step := range c.steps {
-		out.Steps = append(out.Steps, cloneStep(step))
+		clonedStep := cloneStep(step)
+		out.Steps = append(out.Steps, clonedStep)
+		out.Usage = addUsage(out.Usage, clonedStep.Usage)
 	}
 	return out
 }
@@ -300,6 +330,7 @@ func cloneStep(step trace.Step) trace.Step {
 		AppliedSurfaceIDs:  slices.Clone(step.AppliedSurfaceIDs),
 		Input:              cloneSnapshot(step.Input),
 		Output:             cloneSnapshot(step.Output),
+		Usage:              cloneUsage(step.Usage),
 		Error:              step.Error,
 	}
 }
@@ -309,4 +340,29 @@ func cloneSnapshot(snapshot *trace.Snapshot) *trace.Snapshot {
 		return nil
 	}
 	return &trace.Snapshot{Text: snapshot.Text}
+}
+
+func cloneUsage(usage *model.Usage) *model.Usage {
+	if usage == nil {
+		return nil
+	}
+	cloned := *usage
+	return &cloned
+}
+
+func addUsage(total *model.Usage, next *model.Usage) *model.Usage {
+	if next == nil {
+		return total
+	}
+	if total == nil {
+		total = &model.Usage{}
+	}
+	total.PromptTokens += next.PromptTokens
+	total.CompletionTokens += next.CompletionTokens
+	total.TotalTokens += next.TotalTokens
+	total.PromptTokensDetails.CachedTokens += next.PromptTokensDetails.CachedTokens
+	total.PromptTokensDetails.CacheCreationTokens += next.PromptTokensDetails.CacheCreationTokens
+	total.PromptTokensDetails.CacheReadTokens += next.PromptTokensDetails.CacheReadTokens
+	total.CompletionTokensDetails.ReasoningTokens += next.CompletionTokensDetails.ReasoningTokens
+	return total
 }

--- a/internal/tracecapture/capture_test.go
+++ b/internal/tracecapture/capture_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 func TestCapture_TracksFanOutJoinAndNestedInvocationPredecessors(t *testing.T) {
@@ -100,14 +101,17 @@ func TestCapture_BuildReturnsDetachedCopies(t *testing.T) {
 		Input:        &atrace.Snapshot{Text: "input"},
 	})
 	capture.FinishStep(stepID, &atrace.Snapshot{Text: "output"}, "", startedAt.Add(time.Second))
+	capture.SetStepUsage(stepID, &model.Usage{TotalTokens: 3})
 	trace := capture.Build(atrace.TraceStatusCompleted, startedAt.Add(2*time.Second))
 	require.Len(t, trace.Steps, 1)
 	trace.Steps[0].Input.Text = "mutated input"
 	trace.Steps[0].Output.Text = "mutated output"
+	trace.Steps[0].Usage.TotalTokens = 99
 	second := capture.Build(atrace.TraceStatusCompleted, startedAt.Add(3*time.Second))
 	require.Len(t, second.Steps, 1)
 	assert.Equal(t, "input", second.Steps[0].Input.Text)
 	assert.Equal(t, "output", second.Steps[0].Output.Text)
+	assert.Equal(t, 3, second.Steps[0].Usage.TotalTokens)
 }
 
 func TestCapture_AppliedSurfaceIDsAreCopiedAndUpdated(t *testing.T) {
@@ -134,6 +138,96 @@ func TestCapture_AppliedSurfaceIDsAreCopiedAndUpdated(t *testing.T) {
 	second := capture.Build(atrace.TraceStatusCompleted, startedAt.Add(2*time.Second))
 	require.Len(t, second.Steps, 1)
 	assert.Equal(t, []string{"assistant#model", "assistant#tool"}, second.Steps[0].AppliedSurfaceIDs)
+}
+
+func TestCapture_SetStepUsageIgnoresTimingOnlyUsage(t *testing.T) {
+	startedAt := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
+	capture := New("assistant", "root-inv", "session-1", startedAt)
+	stepID := capture.StartStep(StartStepInput{
+		InvocationID: "root-inv",
+		AgentName:    "assistant",
+		NodeID:       "assistant",
+		StartedAt:    startedAt,
+	})
+	capture.SetStepUsage(stepID, &model.Usage{
+		TimingInfo: &model.TimingInfo{FirstTokenDuration: time.Second},
+	})
+	trace := capture.Build(atrace.TraceStatusCompleted, startedAt.Add(time.Second))
+	require.Len(t, trace.Steps, 1)
+	assert.Nil(t, trace.Steps[0].Usage)
+	assert.Nil(t, trace.Usage)
+}
+
+func TestCapture_SetStepUsageDropsTimingInfo(t *testing.T) {
+	startedAt := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
+	capture := New("assistant", "root-inv", "session-1", startedAt)
+	stepID := capture.StartStep(StartStepInput{
+		InvocationID: "root-inv",
+		AgentName:    "assistant",
+		NodeID:       "assistant",
+		StartedAt:    startedAt,
+	})
+	capture.SetStepUsage(stepID, &model.Usage{
+		TotalTokens: 1,
+		TimingInfo:  &model.TimingInfo{FirstTokenDuration: time.Second},
+	})
+	trace := capture.Build(atrace.TraceStatusCompleted, startedAt.Add(time.Second))
+	require.Len(t, trace.Steps, 1)
+	require.NotNil(t, trace.Steps[0].Usage)
+	assert.Equal(t, 1, trace.Steps[0].Usage.TotalTokens)
+	assert.Nil(t, trace.Steps[0].Usage.TimingInfo)
+}
+
+func TestCapture_BuildAggregatesStepUsage(t *testing.T) {
+	startedAt := time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC)
+	capture := New("assistant", "root-inv", "session-1", startedAt)
+	firstStepID := capture.StartStep(StartStepInput{
+		InvocationID: "root-inv",
+		AgentName:    "assistant",
+		NodeID:       "assistant/first",
+		StartedAt:    startedAt,
+	})
+	secondStepID := capture.StartStep(StartStepInput{
+		InvocationID: "root-inv",
+		AgentName:    "assistant",
+		NodeID:       "assistant/second",
+		StartedAt:    startedAt.Add(time.Second),
+	})
+	capture.SetStepUsage(firstStepID, &model.Usage{
+		PromptTokens:     2,
+		CompletionTokens: 3,
+		TotalTokens:      5,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens:        1,
+			CacheCreationTokens: 2,
+			CacheReadTokens:     3,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: 4,
+		},
+	})
+	capture.SetStepUsage(secondStepID, &model.Usage{
+		PromptTokens:     5,
+		CompletionTokens: 7,
+		TotalTokens:      12,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens:        2,
+			CacheCreationTokens: 3,
+			CacheReadTokens:     4,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: 5,
+		},
+	})
+	trace := capture.Build(atrace.TraceStatusCompleted, startedAt.Add(2*time.Second))
+	require.NotNil(t, trace.Usage)
+	assert.Equal(t, 7, trace.Usage.PromptTokens)
+	assert.Equal(t, 10, trace.Usage.CompletionTokens)
+	assert.Equal(t, 17, trace.Usage.TotalTokens)
+	assert.Equal(t, 3, trace.Usage.PromptTokensDetails.CachedTokens)
+	assert.Equal(t, 5, trace.Usage.PromptTokensDetails.CacheCreationTokens)
+	assert.Equal(t, 7, trace.Usage.PromptTokensDetails.CacheReadTokens)
+	assert.Equal(t, 9, trace.Usage.CompletionTokensDetails.ReasoningTokens)
 }
 
 func TestCapture_PredecessorsForInvocation_UsesNestedChildTerminals(t *testing.T) {
@@ -174,6 +268,7 @@ func TestCapture_CoversNilGuardsAndMetadataFallbacks(t *testing.T) {
 	assert.Empty(t, nilCapture.StartStep(StartStepInput{InvocationID: "inv"}))
 	nilCapture.FinishStep("step-1", nil, "", time.Time{})
 	nilCapture.SetStepAppliedSurfaceIDs("step-1", []string{"assistant#instruction"})
+	nilCapture.SetStepUsage("step-1", &model.Usage{TotalTokens: 1})
 	nilCapture.SetRootAgentName("assistant")
 	nilCapture.SetSessionID("session-1")
 	nilCapture.RegisterInvocation("parent", "child")
@@ -196,6 +291,9 @@ func TestCapture_CoversNilGuardsAndMetadataFallbacks(t *testing.T) {
 	})
 	require.NotEmpty(t, stepID)
 	capture.SetStepAppliedSurfaceIDs("", []string{"assistant#instruction"})
+	capture.SetStepUsage("", &model.Usage{TotalTokens: 1})
+	capture.SetStepUsage("missing", &model.Usage{TotalTokens: 1})
+	capture.SetStepUsage(stepID, nil)
 	capture.FinishStep("missing", nil, "", time.Time{})
 	capture.FinishStep(stepID, nil, "boom", time.Time{})
 	trace := capture.Build(atrace.TraceStatusFailed, time.Time{})

--- a/runner/execution_trace_test.go
+++ b/runner/execution_trace_test.go
@@ -130,6 +130,65 @@ func TestRunnerCompletion_LLMRunProducesOneRealExecutionStep(t *testing.T) {
 	assert.Empty(t, step.Error)
 }
 
+func TestRunnerCompletion_ExecutionTraceCarriesUsage(t *testing.T) {
+	usage := &model.Usage{
+		PromptTokens:     11,
+		CompletionTokens: 7,
+		TotalTokens:      18,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens: 3,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: 2,
+		},
+	}
+	ag := llmagent.New("assistant", llmagent.WithModel(&staticModel{
+		name:    "trace-model",
+		content: "done",
+		usage:   usage,
+	}))
+	r := NewRunner("app", ag, WithSessionService(sessioninmemory.NewSessionService()))
+	eventCh, err := r.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello trace"),
+		agent.WithExecutionTraceEnabled(true),
+	)
+	require.NoError(t, err)
+	completion := collectRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.ExecutionTrace)
+	require.NotNil(t, completion.ExecutionTrace.Usage)
+	assert.Equal(t, 18, completion.ExecutionTrace.Usage.TotalTokens)
+	assert.Equal(t, 3, completion.ExecutionTrace.Usage.PromptTokensDetails.CachedTokens)
+	require.Len(t, completion.ExecutionTrace.Steps, 1)
+	require.NotNil(t, completion.ExecutionTrace.Steps[0].Usage)
+	assert.Equal(t, 18, completion.ExecutionTrace.Steps[0].Usage.TotalTokens)
+	assert.Equal(t, 2, completion.ExecutionTrace.Steps[0].Usage.CompletionTokensDetails.ReasoningTokens)
+}
+
+func TestRunnerCompletion_ExecutionTraceOmitsTimingOnlyUsage(t *testing.T) {
+	ag := llmagent.New("assistant", llmagent.WithModel(&staticModel{
+		name:    "trace-model",
+		content: "done",
+		usage:   &model.Usage{TimingInfo: &model.TimingInfo{}},
+	}))
+	r := NewRunner("app", ag, WithSessionService(sessioninmemory.NewSessionService()))
+	eventCh, err := r.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello trace"),
+		agent.WithExecutionTraceEnabled(true),
+	)
+	require.NoError(t, err)
+	completion := collectRunnerCompletionEvent(t, eventCh)
+	require.NotNil(t, completion.ExecutionTrace)
+	assert.Nil(t, completion.ExecutionTrace.Usage)
+	require.Len(t, completion.ExecutionTrace.Steps, 1)
+	assert.Nil(t, completion.ExecutionTrace.Steps[0].Usage)
+}
+
 func TestRunnerCompletion_ChainAndParallelPropagatePredecessorsToRealChildSteps(t *testing.T) {
 	fanout := parallelagent.New("fanout", parallelagent.WithSubAgents([]agent.Agent{
 		llmagent.New("worker-a", llmagent.WithModel(&staticModel{name: "worker-a-model", content: "worker-a"})),

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -186,6 +186,7 @@ func (m *capturingInvocationMessagesAgent) Tools() []tool.Tool {
 type staticModel struct {
 	name    string
 	content string
+	usage   *model.Usage
 }
 
 type unsupportedSteerRunner struct{}
@@ -226,6 +227,7 @@ func (m *staticModel) GenerateContent(
 			Index:   0,
 			Message: model.NewAssistantMessage(m.content),
 		}},
+		Usage: m.usage,
 	}
 	close(ch)
 	return ch, nil


### PR DESCRIPTION
This adds token usage fields to execution traces, records LLM response usage on trace steps, aggregates run-level usage in tracecapture, and strips timing-only metadata so traces do not expose empty usage objects.