### PR TITLE
Fix/issue 2019 1995

### DIFF
--- a/memory/mysql/service.go
+++ b/memory/mysql/service.go
@@ -212,7 +212,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 	imemory.NormalizeEntry(entry)
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -221,6 +221,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 		ep,
 		now,
 	)
+	entry.ID = memoryKey.MemoryID
 
 	updated, err := json.Marshal(entry)
 	if err != nil {
@@ -228,18 +229,18 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 	}
 
 	updateQuery := fmt.Sprintf(
-		"UPDATE %s SET memory_id = ?, memory_data = ?, updated_at = ? WHERE app_name = ? AND user_id = ? AND memory_id = ?",
+		"UPDATE %s SET memory_data = ?, updated_at = ? WHERE app_name = ? AND user_id = ? AND memory_id = ?",
 		s.tableName,
 	)
 	if s.opts.softDelete {
 		updateQuery += " AND deleted_at IS NULL"
 	}
-	_, err = s.db.Exec(ctx, updateQuery, newID, updated, now, memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID)
+	_, err = s.db.Exec(ctx, updateQuery, updated, now, memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID)
 	if err != nil {
 		return fmt.Errorf("update memory entry failed: %w", err)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 	return nil
 }

--- a/memory/mysql/service_test.go
+++ b/memory/mysql/service_test.go
@@ -691,7 +691,7 @@ func TestUpdateMemory_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(entryJSON))
 
 	mock.ExpectExec("UPDATE").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := s.UpdateMemory(ctx, memKey, "updated memory", []string{"new"})
@@ -730,8 +730,8 @@ func TestUpdateMemory_SoftDeleteFalse(t *testing.T) {
 		WithArgs("app", "user", "mem123").
 		WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(existingJSON))
 
-	mock.ExpectExec("UPDATE.*SET memory_id = .*memory_data").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
+	mock.ExpectExec("UPDATE.*SET memory_data").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err := s.UpdateMemory(ctx, memKey, "new memory", []string{"new"})
@@ -810,7 +810,7 @@ func TestUpdateMemory_UpdateError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(entryJSON))
 
 	mock.ExpectExec("UPDATE").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "app", "user", "mem123").
 		WillReturnError(errors.New("update error"))
 
 	err := s.UpdateMemory(ctx, memKey, "updated memory", []string{"new"})

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -372,7 +372,7 @@ func (s *Service) UpdateMemory(
 
 	now := time.Now()
 	vector := pgvector.NewVector(convertToFloat32(embedding))
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -384,9 +384,9 @@ func (s *Service) UpdateMemory(
 	ef := resolveMetadata(entry.Memory)
 
 	updateQuery := fmt.Sprintf(
-		"UPDATE %s SET memory_id = $1, memory_content = $2, topics = $3, embedding = $4, "+
-			"memory_kind = $5, event_time = $6, participants = $7, location = $8, updated_at = $9 "+
-			"WHERE memory_id = $10 AND app_name = $11 AND user_id = $12",
+		"UPDATE %s SET memory_content = $1, topics = $2, embedding = $3, "+
+			"memory_kind = $4, event_time = $5, participants = $6, location = $7, updated_at = $8 "+
+			"WHERE memory_id = $9 AND app_name = $10 AND user_id = $11",
 		s.tableName,
 	)
 	if s.opts.softDelete {
@@ -395,7 +395,6 @@ func (s *Service) UpdateMemory(
 	res, err := s.db.ExecContext(
 		ctx,
 		updateQuery,
-		newID,
 		memoryStr,
 		pq.Array(topics),
 		vector,
@@ -419,7 +418,7 @@ func (s *Service) UpdateMemory(
 		return fmt.Errorf("memory with id %s not found", memoryKey.MemoryID)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 
 	return nil

--- a/memory/pgvector/service_test.go
+++ b/memory/pgvector/service_test.go
@@ -841,9 +841,8 @@ func TestService_UpdateMemory_WithoutMetadataDoesNotOverwriteMetadataColumns(t *
 		"Kyoto",
 	)
 
-	mock.ExpectExec(`UPDATE .* SET memory_id = \$1, memory_content = \$2, topics = \$3, embedding = \$4, memory_kind = \$5, event_time = \$6, participants = \$7, location = \$8, updated_at = \$9 WHERE memory_id = \$10 AND app_name = \$11 AND user_id = \$12`).
+	mock.ExpectExec(`UPDATE .* SET memory_content = \$1, topics = \$2, embedding = \$3, memory_kind = \$4, event_time = \$5, participants = \$6, location = \$7, updated_at = \$8 WHERE memory_id = \$9 AND app_name = \$10 AND user_id = \$11`).
 		WithArgs(
-			sqlmock.AnyArg(),
 			"updated memory",
 			pq.Array([]string{"new-topic"}),
 			sqlmock.AnyArg(),
@@ -887,9 +886,8 @@ func TestService_UpdateMemory_PartialMetadataPatchOnlyUpdatesProvidedColumns(t *
 		"Kyoto",
 	)
 
-	mock.ExpectExec(`UPDATE .* SET memory_id = \$1, memory_content = \$2, topics = \$3, embedding = \$4, memory_kind = \$5, event_time = \$6, participants = \$7, location = \$8, updated_at = \$9 WHERE memory_id = \$10 AND app_name = \$11 AND user_id = \$12`).
+	mock.ExpectExec(`UPDATE .* SET memory_content = \$1, topics = \$2, embedding = \$3, memory_kind = \$4, event_time = \$5, participants = \$6, location = \$7, updated_at = \$8 WHERE memory_id = \$9 AND app_name = \$10 AND user_id = \$11`).
 		WithArgs(
-			sqlmock.AnyArg(),
 			"updated memory",
 			pq.Array([]string{"new-topic"}),
 			sqlmock.AnyArg(),

--- a/memory/postgres/service.go
+++ b/memory/postgres/service.go
@@ -280,7 +280,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 
 	now := time.Now()
 	ep := memory.ResolveUpdateOptions(opts)
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -289,6 +289,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 		ep,
 		now,
 	)
+	entry.ID = memoryKey.MemoryID
 
 	updated, err := json.Marshal(entry)
 	if err != nil {
@@ -297,22 +298,22 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 	}
 
 	updateQuery := fmt.Sprintf(
-		"UPDATE %s SET memory_id = $1, memory_data = $2, updated_at = $3 "+
-			"WHERE memory_id = $4 AND app_name = $5 "+
-			"AND user_id = $6",
+		"UPDATE %s SET memory_data = $1, updated_at = $2 "+
+			"WHERE memory_id = $3 AND app_name = $4 "+
+			"AND user_id = $5",
 		s.tableName,
 	)
 	if s.opts.softDelete {
 		updateQuery += " AND deleted_at IS NULL"
 	}
-	_, err = s.db.ExecContext(ctx, updateQuery, newID, updated, now,
+	_, err = s.db.ExecContext(ctx, updateQuery, updated, now,
 		memoryKey.MemoryID, memoryKey.AppName, memoryKey.UserID)
 	if err != nil {
 		return fmt.Errorf(
 			"update memory entry failed: %w", err)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 	return nil
 }

--- a/memory/postgres/service_test.go
+++ b/memory/postgres/service_test.go
@@ -1177,7 +1177,7 @@ func TestService_UpdateMemory_Success(t *testing.T) {
 	entryData, _ := json.Marshal(entry)
 
 	mock.ExpectQuery("SELECT memory_data").WillReturnRows(sqlmock.NewRows([]string{"memory_data"}).AddRow(entryData))
-	mock.ExpectExec("UPDATE.*SET memory_id = .*memory_data").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE.*SET memory_data").WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := svc.UpdateMemory(ctx, memoryKey, "new content", []string{"new"})
 	require.NoError(t, err)
@@ -1817,7 +1817,7 @@ func TestService_UpdateMemory_UpdateError(t *testing.T) {
 	mock.ExpectQuery("SELECT memory_data").WillReturnRows(
 		sqlmock.NewRows([]string{"memory_data"}).AddRow(entryData),
 	)
-	mock.ExpectExec("UPDATE.*SET memory_id = .*memory_data").WillReturnError(fmt.Errorf("update failed"))
+	mock.ExpectExec("UPDATE.*SET memory_data").WillReturnError(fmt.Errorf("update failed"))
 
 	err := svc.UpdateMemory(ctx, memoryKey, "new content", []string{"new"})
 	require.Error(t, err)

--- a/memory/sqlite/service.go
+++ b/memory/sqlite/service.go
@@ -260,7 +260,7 @@ func (s *Service) UpdateMemory(
 	}
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -269,6 +269,7 @@ func (s *Service) UpdateMemory(
 		ep,
 		now,
 	)
+	entry.ID = memoryKey.MemoryID
 
 	updated, err := json.Marshal(entry)
 	if err != nil {
@@ -276,11 +277,11 @@ func (s *Service) UpdateMemory(
 	}
 
 	const updateSQL = `UPDATE %s
-SET memory_id = ?, memory_data = ?, updated_at = ?
+SET memory_data = ?, updated_at = ?
 WHERE app_name = ? AND user_id = ? AND memory_id = ?`
 	query := fmt.Sprintf(updateSQL, s.tableName)
 	args := []any{
-		newID, updated, now.UTC().UnixNano(),
+		updated, now.UTC().UnixNano(),
 		memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID,
 	}
 	if s.opts.softDelete {
@@ -292,7 +293,7 @@ WHERE app_name = ? AND user_id = ? AND memory_id = ?`
 		return fmt.Errorf("update memory entry: %w", err)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 	return nil
 }

--- a/memory/sqlite/service_test.go
+++ b/memory/sqlite/service_test.go
@@ -87,6 +87,7 @@ func TestService_CRUD_HardDelete(t *testing.T) {
 	updateResult := &memory.UpdateResult{}
 	require.NoError(t,
 		svc.UpdateMemory(ctx, memKey, "Alice likes Go and SQL", nil, memory.WithUpdateResult(updateResult)))
+	require.Equal(t, memID, updateResult.MemoryID)
 	memKey.MemoryID = updateResult.MemoryID
 
 	results, err := svc.SearchMemories(ctx, userKey, "sql")

--- a/memory/sqlitevec/service.go
+++ b/memory/sqlitevec/service.go
@@ -413,7 +413,7 @@ FROM %s WHERE app_name = ? AND user_id = ? AND memory_id = ?`
 
 	now := time.Now()
 	updatedAtNs := now.UTC().UnixNano()
-	newID := imemory.ApplyMemoryUpdate(
+	imemory.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -450,80 +450,19 @@ WHERE app_name = ? AND user_id = ? AND memory_id = ?`,
 	if s.opts.softDelete {
 		query += fmt.Sprintf(" AND deleted_at = %d", notDeletedAtNs)
 	}
-	if newID == memoryKey.MemoryID {
-		res, err := s.db.ExecContext(ctx, query, args...)
-		if err != nil {
-			return fmt.Errorf("update memory: %w", err)
-		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("update memory rows affected: %w", err)
-		}
-		if affected == 0 {
-			return fmt.Errorf("memory with id %s not found", memoryKey.MemoryID)
-		}
-	} else {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin transaction: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		deleteQuery := fmt.Sprintf(
-			"DELETE FROM %s WHERE app_name = ? AND user_id = ? AND memory_id = ?",
-			s.tableName,
-		)
-		deleteArgs := []any{memoryKey.AppName, memoryKey.UserID, memoryKey.MemoryID}
-		if s.opts.softDelete {
-			deleteQuery += fmt.Sprintf(" AND deleted_at = %d", notDeletedAtNs)
-		}
-		res, err := tx.ExecContext(ctx, deleteQuery, deleteArgs...)
-		if err != nil {
-			return fmt.Errorf("delete rotated memory: %w", err)
-		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("delete rotated memory rows affected: %w", err)
-		}
-		if affected == 0 {
-			return fmt.Errorf("memory with id %s not found", memoryKey.MemoryID)
-		}
-
-		insertQuery := fmt.Sprintf(
-			`INSERT INTO %s (
-memory_id, embedding, app_name, user_id,
-created_at, updated_at, deleted_at,
-memory_content, topics, memory_kind, event_time,
-participants, location
-) VALUES (?, `+sqlVectorFromBlob+`, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			s.tableName,
-		)
-		_, err = tx.ExecContext(
-			ctx,
-			insertQuery,
-			newID,
-			blob,
-			memoryKey.AppName,
-			memoryKey.UserID,
-			entry.CreatedAt.UTC().UnixNano(),
-			updatedAtNs,
-			notDeletedAtNs,
-			memoryStr,
-			string(topicsJSON),
-			string(entry.Memory.Kind),
-			metadataEventTimeNS(entry.Memory.EventTime),
-			participantsJSON,
-			metadataLocationValue(entry.Memory.Location),
-		)
-		if err != nil {
-			return fmt.Errorf("insert rotated memory: %w", err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit rotated memory: %w", err)
-		}
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("update memory: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update memory rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("memory with id %s not found", memoryKey.MemoryID)
 	}
 	if result := memory.ResolveUpdateResult(opts); result != nil {
-		result.MemoryID = newID
+		result.MemoryID = memoryKey.MemoryID
 	}
 
 	return nil

--- a/memory/sqlitevec/service_test.go
+++ b/memory/sqlitevec/service_test.go
@@ -184,6 +184,7 @@ func TestService_CRUD_HardDelete(t *testing.T) {
 	updateResult := &memory.UpdateResult{}
 	require.NoError(t,
 		svc.UpdateMemory(ctx, memKey, "gamma", []string{"updated"}, memory.WithUpdateResult(updateResult)))
+	require.Equal(t, memKey.MemoryID, updateResult.MemoryID)
 	memKey.MemoryID = updateResult.MemoryID
 
 	results, err := svc.SearchMemories(ctx, userKey, "gamma")

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5084,6 +5084,38 @@ func TestCompletionUsageToModelUsage(t *testing.T) {
 		assert.Equal(t, 0, result.PromptTokensDetails.CachedTokens, "expected cached tokens to be 0")
 		assert.Equal(t, 0, result.CompletionTokensDetails.ReasoningTokens, "expected reasoning tokens to be 0")
 	})
+
+	t.Run("uses DeepSeek prompt cache hit tokens fallback", func(t *testing.T) {
+		var openaiUsage openai.CompletionUsage
+		err := json.Unmarshal([]byte(`{
+			"prompt_tokens": 200,
+			"completion_tokens": 75,
+			"total_tokens": 275,
+			"prompt_cache_hit_tokens": 42,
+			"prompt_cache_miss_tokens": 158
+		}`), &openaiUsage)
+		require.NoError(t, err)
+
+		result := completionUsageToModelUsage(openaiUsage)
+
+		assert.Equal(t, 42, result.PromptTokensDetails.CachedTokens, "expected DeepSeek cache hit tokens")
+	})
+
+	t.Run("standard cached tokens take precedence over DeepSeek fallback", func(t *testing.T) {
+		var openaiUsage openai.CompletionUsage
+		err := json.Unmarshal([]byte(`{
+			"prompt_tokens": 200,
+			"completion_tokens": 75,
+			"total_tokens": 275,
+			"prompt_tokens_details": {"cached_tokens": 30},
+			"prompt_cache_hit_tokens": 42
+		}`), &openaiUsage)
+		require.NoError(t, err)
+
+		result := completionUsageToModelUsage(openaiUsage)
+
+		assert.Equal(t, 30, result.PromptTokensDetails.CachedTokens, "expected standard cached tokens")
+	})
 }
 
 // TestWithChannelBufferSize_EdgeCases tests WithChannelBufferSize with edge cases.

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -12,6 +12,7 @@ package openai
 
 import (
 	"context"
+	"strconv"
 
 	openai "github.com/openai/openai-go"
 	openaiopt "github.com/openai/openai-go/option"
@@ -408,17 +409,33 @@ func inverseOpenAISDKAddChunkUsage(u model.Usage, delta model.Usage) model.Usage
 
 // completionUsageToModelUsage converts openai.CompletionUsage to model.Usage.
 func completionUsageToModelUsage(usage openai.CompletionUsage) model.Usage {
+	cachedTokens := completionUsageCachedTokens(usage)
 	return model.Usage{
 		PromptTokens:     int(usage.PromptTokens),
 		CompletionTokens: int(usage.CompletionTokens),
 		TotalTokens:      int(usage.TotalTokens),
 		PromptTokensDetails: model.PromptTokensDetails{
-			CachedTokens: int(usage.PromptTokensDetails.CachedTokens),
+			CachedTokens: cachedTokens,
 		},
 		CompletionTokensDetails: model.CompletionTokensDetails{
 			ReasoningTokens: int(usage.CompletionTokensDetails.ReasoningTokens),
 		},
 	}
+}
+
+func completionUsageCachedTokens(usage openai.CompletionUsage) int {
+	if usage.PromptTokensDetails.CachedTokens != 0 {
+		return int(usage.PromptTokensDetails.CachedTokens)
+	}
+	field, ok := usage.JSON.ExtraFields["prompt_cache_hit_tokens"]
+	if !ok {
+		return 0
+	}
+	hitTokens, err := strconv.ParseInt(field.Raw(), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return int(hitTokens)
 }
 
 // modelUsageToCompletionUsage converts model.Usage to openai.CompletionUsage.


### PR DESCRIPTION
## 变更内容

本 PR 修复两个 issue，并拆分为两个独立提交：

1. 修复 #2019：`UpdateMemory` 更新记忆内容时不再修改主键 `memory_id`。
   - 覆盖 mysql、postgres、pgvector、sqlite、sqlitevec 后端。
   - `UpdateResult.MemoryID` 保持返回原始 memory ID。
   - 避免内容更新后重新生成 ID 导致主键冲突或并发更新失败。

2. 修复 #1995：DeepSeek 缓存命中 token 统计不再丢失。
   - 当 OpenAI 兼容响应没有 `prompt_tokens_details.cached_tokens` 时，从 DeepSeek 顶层字段 `prompt_cache_hit_tokens` 回填到 `model.Usage.PromptTokensDetails.CachedTokens`。
   - 标准 OpenAI 字段仍然优先。

## 原因

#2019 中，`UpdateMemory` 原先会根据更新后的内容重新计算 `memory_id`，并在 SQL UPDATE 中修改主键。这会在新 ID 已存在或并发更新时触发重复键冲突。

#1995 中，DeepSeek 通过 OpenAI 兼容接口返回缓存命中数时使用的是 `prompt_cache_hit_tokens`，不是 OpenAI 标准的 `prompt_tokens_details.cached_tokens`，导致下游看到的 `CachedTokens` 一直为 0。