### PR TITLE
openclaw: configure host exec default timeout

### DIFF
--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -12,6 +12,7 @@ package recall
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -403,6 +404,65 @@ func TestLoadToolEventIDSelectsMatchingToolCallID(t *testing.T) {
 	require.Len(t, resp.Messages, 1)
 	assert.Equal(t, "234", resp.Messages[0].Content)
 	assert.Equal(t, 2, resp.Messages[0].ContentOffset)
+}
+
+func TestLoadToolFallsBackToToolCallIDWhenEventIDIsStale(t *testing.T) {
+	sess := session.NewSession("app", "user", "sess")
+	sess.Events = []event.Event{
+		{
+			ID: "evt-tool-result",
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:     model.RoleTool,
+						ToolID:   "call-1",
+						ToolName: "lookup",
+						Content:  "fresh result",
+					},
+				}},
+			},
+		},
+	}
+
+	var anchors []string
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		windowFunc: func(
+			req session.EventWindowRequest,
+		) (*session.EventWindow, error) {
+			anchors = append(anchors, req.AnchorEventID)
+			if req.AnchorEventID == "stale-event" {
+				return nil, errors.New("anchor event not found: stale-event")
+			}
+			return &session.EventWindow{
+				AnchorEventID: req.AnchorEventID,
+				Entries: []session.EventWindowEntry{{
+					Event:     sess.Events[0],
+					CreatedAt: time.Date(2025, 4, 7, 11, 0, 0, 0, time.UTC),
+				}},
+			}, nil
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&LoadSessionRequest{
+		EventID:    "stale-event",
+		ToolCallID: "call-1",
+	})
+	require.NoError(t, err)
+	result, err := NewLoadTool().Call(ctx, args)
+	require.NoError(t, err)
+
+	resp, ok := result.(*LoadSessionResponse)
+	require.True(t, ok)
+	assert.Equal(t, "evt-tool-result", resp.EventID)
+	assert.Equal(t, []string{"stale-event", "evt-tool-result"}, anchors)
+	require.Len(t, resp.Messages, 1)
+	assert.Equal(t, "lookup: fresh result", resp.Messages[0].Content)
 }
 
 func TestLoadToolReturnsSessionServiceFallbackError(t *testing.T) {

--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -12,7 +12,7 @@ package recall
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +25,10 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
+
+func anchorEventNotFoundErr(anchorEventID string) error {
+	return fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
+}
 
 func TestSupportChecks(t *testing.T) {
 	require.False(t, SupportsSearch(nil))
@@ -432,7 +436,7 @@ func TestLoadToolFallsBackToToolCallIDWhenEventIDIsStale(t *testing.T) {
 		) (*session.EventWindow, error) {
 			anchors = append(anchors, req.AnchorEventID)
 			if req.AnchorEventID == "stale-event" {
-				return nil, errors.New("anchor event not found: stale-event")
+				return nil, anchorEventNotFoundErr("stale-event")
 			}
 			return &session.EventWindow{
 				AnchorEventID: req.AnchorEventID,
@@ -466,12 +470,14 @@ func TestLoadToolFallsBackToToolCallIDWhenEventIDIsStale(t *testing.T) {
 }
 
 func TestLoadToolKeepsStaleEventErrorWhenToolCallIDMissing(t *testing.T) {
+	var anchors []string
 	svc := &mockSessionService{
 		Service: sessioninmemory.NewSessionService(),
 		windowFunc: func(
-			session.EventWindowRequest,
+			req session.EventWindowRequest,
 		) (*session.EventWindow, error) {
-			return nil, errors.New("anchor event not found: stale-event")
+			anchors = append(anchors, req.AnchorEventID)
+			return nil, anchorEventNotFoundErr("stale-event")
 		},
 	}
 	inv := agent.NewInvocation(
@@ -487,7 +493,84 @@ func TestLoadToolKeepsStaleEventErrorWhenToolCallIDMissing(t *testing.T) {
 	require.NoError(t, err)
 	_, err = NewLoadTool().Call(ctx, args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "anchor event not found")
+	assert.ErrorIs(t, err, session.ErrEventWindowAnchorNotFound)
+	assert.Equal(t, []string{"stale-event"}, anchors)
+}
+
+func TestLoadToolKeepsStaleEventErrorWhenFallbackLookupFails(t *testing.T) {
+	var anchors []string
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		windowFunc: func(
+			req session.EventWindowRequest,
+		) (*session.EventWindow, error) {
+			anchors = append(anchors, req.AnchorEventID)
+			return nil, anchorEventNotFoundErr("stale-event")
+		},
+		getSessionFunc: func(
+			session.Key,
+			...session.Option,
+		) (*session.Session, error) {
+			return nil, assert.AnError
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(session.NewSession("app", "user", "sess")),
+		agent.WithInvocationSessionService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&LoadSessionRequest{
+		EventID:    "stale-event",
+		ToolCallID: "call-1",
+	})
+	require.NoError(t, err)
+	_, err = NewLoadTool().Call(ctx, args)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, session.ErrEventWindowAnchorNotFound)
+	assert.NotErrorIs(t, err, assert.AnError)
+	assert.Equal(t, []string{"stale-event"}, anchors)
+}
+
+func TestLoadToolKeepsStaleEventErrorWhenFallbackMatchesAnchor(t *testing.T) {
+	sess := session.NewSession("app", "user", "sess")
+	sess.Events = []event.Event{{
+		ID: "stale-event",
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:   model.RoleTool,
+					ToolID: "call-1",
+				},
+			}},
+		},
+	}}
+
+	var anchors []string
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		windowFunc: func(
+			req session.EventWindowRequest,
+		) (*session.EventWindow, error) {
+			anchors = append(anchors, req.AnchorEventID)
+			return nil, anchorEventNotFoundErr("stale-event")
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&LoadSessionRequest{
+		EventID:    "stale-event",
+		ToolCallID: "call-1",
+	})
+	require.NoError(t, err)
+	_, err = NewLoadTool().Call(ctx, args)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, session.ErrEventWindowAnchorNotFound)
+	assert.Equal(t, []string{"stale-event"}, anchors)
 }
 
 func TestLoadToolReturnsFallbackWindowError(t *testing.T) {
@@ -510,7 +593,7 @@ func TestLoadToolReturnsFallbackWindowError(t *testing.T) {
 			req session.EventWindowRequest,
 		) (*session.EventWindow, error) {
 			if req.AnchorEventID == "stale-event" {
-				return nil, errors.New("anchor event not found: stale-event")
+				return nil, anchorEventNotFoundErr("stale-event")
 			}
 			return nil, assert.AnError
 		},

--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -1480,4 +1480,11 @@ func TestLoadTool_ErrorPaths(t *testing.T) {
 	_, err = NewLoadTool().Call(ctx, args)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "session load tool")
+
+	args, err = json.Marshal(&LoadSessionRequest{ToolCallID: "missing-call"})
+	require.NoError(t, err)
+	_, err = NewLoadTool().Call(ctx, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tool_call_id")
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -465,6 +465,71 @@ func TestLoadToolFallsBackToToolCallIDWhenEventIDIsStale(t *testing.T) {
 	assert.Equal(t, "lookup: fresh result", resp.Messages[0].Content)
 }
 
+func TestLoadToolKeepsStaleEventErrorWhenToolCallIDMissing(t *testing.T) {
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		windowFunc: func(
+			session.EventWindowRequest,
+		) (*session.EventWindow, error) {
+			return nil, errors.New("anchor event not found: stale-event")
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(session.NewSession("app", "user", "sess")),
+		agent.WithInvocationSessionService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&LoadSessionRequest{
+		EventID:    "stale-event",
+		ToolCallID: "missing-call",
+	})
+	require.NoError(t, err)
+	_, err = NewLoadTool().Call(ctx, args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchor event not found")
+}
+
+func TestLoadToolReturnsFallbackWindowError(t *testing.T) {
+	sess := session.NewSession("app", "user", "sess")
+	sess.Events = []event.Event{{
+		ID: "evt-tool-result",
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:   model.RoleTool,
+					ToolID: "call-1",
+				},
+			}},
+		},
+	}}
+
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		windowFunc: func(
+			req session.EventWindowRequest,
+		) (*session.EventWindow, error) {
+			if req.AnchorEventID == "stale-event" {
+				return nil, errors.New("anchor event not found: stale-event")
+			}
+			return nil, assert.AnError
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&LoadSessionRequest{
+		EventID:    "stale-event",
+		ToolCallID: "call-1",
+	})
+	require.NoError(t, err)
+	_, err = NewLoadTool().Call(ctx, args)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
 func TestLoadToolReturnsSessionServiceFallbackError(t *testing.T) {
 	svc := &mockSessionService{
 		Service: sessioninmemory.NewSessionService(),

--- a/internal/session/tool/recall/load.go
+++ b/internal/session/tool/recall/load.go
@@ -11,6 +11,7 @@ package recall
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -184,7 +185,7 @@ func shouldRetryLoadByToolCallID(err error, req *LoadSessionRequest) bool {
 	}
 	return strings.TrimSpace(req.EventID) != "" &&
 		strings.TrimSpace(req.ToolCallID) != "" &&
-		strings.Contains(err.Error(), "anchor event not found")
+		errors.Is(err, session.ErrEventWindowAnchorNotFound)
 }
 
 func resolveLoadAnchorEventID(

--- a/internal/session/tool/recall/load.go
+++ b/internal/session/tool/recall/load.go
@@ -59,6 +59,14 @@ func NewLoadTool() tool.CallableTool {
 			return nil, fmt.Errorf("session load tool: %w", err)
 		}
 		if anchorEventID == "" {
+			toolCallID := strings.TrimSpace(req.ToolCallID)
+			if toolCallID != "" {
+				return nil, fmt.Errorf(
+					"session load tool: tool_call_id %q not found in session %q",
+					toolCallID,
+					key.SessionID,
+				)
+			}
 			return nil, fmt.Errorf(
 				"session load tool: event_id is required unless tool_call_id is provided",
 			)

--- a/internal/session/tool/recall/load.go
+++ b/internal/session/tool/recall/load.go
@@ -65,19 +65,15 @@ func NewLoadTool() tool.CallableTool {
 		}
 
 		before, after := normalizeWindowSize(req.Before, req.After)
-		window, err := windowSvc.GetEventWindow(
+		window, anchorEventID, err := getLoadEventWindow(
 			ctx,
-			session.EventWindowRequest{
-				Key:           key,
-				AnchorEventID: anchorEventID,
-				Before:        before,
-				After:         after,
-				Roles: []model.Role{
-					model.RoleUser,
-					model.RoleAssistant,
-					model.RoleTool,
-				},
-			},
+			windowSvc,
+			inv,
+			key,
+			req,
+			anchorEventID,
+			before,
+			after,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -115,6 +111,74 @@ func NewLoadTool() tool.CallableTool {
 	)
 }
 
+func getLoadEventWindow(
+	ctx context.Context,
+	windowSvc session.WindowService,
+	inv *agent.Invocation,
+	key session.Key,
+	req *LoadSessionRequest,
+	anchorEventID string,
+	before, after int,
+) (*session.EventWindow, string, error) {
+	window, err := windowSvc.GetEventWindow(
+		ctx,
+		loadEventWindowRequest(key, anchorEventID, before, after),
+	)
+	if err == nil {
+		return window, anchorEventID, nil
+	}
+	if !shouldRetryLoadByToolCallID(err, req) {
+		return nil, anchorEventID, err
+	}
+
+	fallbackEventID, fallbackErr := resolveLoadAnchorEventIDByToolCallID(
+		ctx,
+		inv,
+		key,
+		req.ToolCallID,
+	)
+	if fallbackErr != nil || fallbackEventID == "" ||
+		fallbackEventID == anchorEventID {
+		return nil, anchorEventID, err
+	}
+
+	window, err = windowSvc.GetEventWindow(
+		ctx,
+		loadEventWindowRequest(key, fallbackEventID, before, after),
+	)
+	if err != nil {
+		return nil, fallbackEventID, err
+	}
+	return window, fallbackEventID, nil
+}
+
+func loadEventWindowRequest(
+	key session.Key,
+	anchorEventID string,
+	before, after int,
+) session.EventWindowRequest {
+	return session.EventWindowRequest{
+		Key:           key,
+		AnchorEventID: anchorEventID,
+		Before:        before,
+		After:         after,
+		Roles: []model.Role{
+			model.RoleUser,
+			model.RoleAssistant,
+			model.RoleTool,
+		},
+	}
+}
+
+func shouldRetryLoadByToolCallID(err error, req *LoadSessionRequest) bool {
+	if req == nil || err == nil {
+		return false
+	}
+	return strings.TrimSpace(req.EventID) != "" &&
+		strings.TrimSpace(req.ToolCallID) != "" &&
+		strings.Contains(err.Error(), "anchor event not found")
+}
+
 func resolveLoadAnchorEventID(
 	ctx context.Context,
 	inv *agent.Invocation,
@@ -128,6 +192,19 @@ func resolveLoadAnchorEventID(
 		return eventID, nil
 	}
 	toolCallID := strings.TrimSpace(req.ToolCallID)
+	if toolCallID == "" {
+		return "", nil
+	}
+	return resolveLoadAnchorEventIDByToolCallID(ctx, inv, key, toolCallID)
+}
+
+func resolveLoadAnchorEventIDByToolCallID(
+	ctx context.Context,
+	inv *agent.Invocation,
+	key session.Key,
+	toolCallID string,
+) (string, error) {
+	toolCallID = strings.TrimSpace(toolCallID)
 	if toolCallID == "" {
 		return "", nil
 	}

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -297,6 +297,9 @@ tools:
   # defer_default_direct_tools: true
   # Optional: keep a small set of tools directly callable by the parent agent.
   # defer_direct_tools: ["exec_command"]
+  # Optional: default timeout for host exec_command calls when timeout_sec is
+  # omitted. Leave unset to keep the built-in host exec default.
+  # host_exec_default_timeout: "60s"
   # Optional: configure fenced-code execution without exposing workspace_exec.
   code_executor:
     type: "sandbox" # sandbox; leave empty/unset to inherit enable_local_exec

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -282,6 +282,9 @@ tools:
   # defer_default_direct_tools: true
   # 可选：保留少量父 agent 可直接调用的工具。
   # defer_direct_tools: ["exec_command"]
+  # 可选：host exec_command 未传 timeout_sec 时使用的默认超时。
+  # 留空则沿用内置 host exec 默认值。
+  # host_exec_default_timeout: "60s"
   # 可选：配置 fenced-code 执行，但不暴露 workspace_exec。
   code_executor:
     type: "sandbox" # sandbox；留空或不设置时继承 enable_local_exec

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -667,6 +667,27 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 					},
 				),
 				adminRuntimeTextField(
+					"tools.host_exec_default_timeout",
+					"Host Exec Default Timeout",
+					"Default timeout for host exec_command calls "+
+						"when timeout_sec is omitted, for example "+
+						"60s. Empty keeps the built-in default.",
+					"",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"host_exec_default_timeout",
+							"hostExecDefaultTimeout",
+						),
+					},
+					func(opts runOptions) string {
+						if opts.HostExecDefaultTimeout <= 0 {
+							return ""
+						}
+						return opts.HostExecDefaultTimeout.String()
+					},
+				),
+				adminRuntimeTextField(
 					"tools.defer_direct_tools",
 					"Deferred Direct Tools",
 					"Comma-separated additional tool names to keep "+

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -1268,6 +1268,7 @@ func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
 			"  defer_to_dynamic_agent_mode: auto\n"+
 			"  defer_to_dynamic_agent_threshold_chars: 1234\n"+
 			"  dynamic_agent_timeout: 3m\n"+
+			"  host_exec_default_timeout: 60s\n"+
 			"  defer_direct_tools: [exec_command]\n"+
 			"  defer_default_direct_tools: false\n",
 	)
@@ -1277,6 +1278,7 @@ func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
 	opts.DeferToolSurfaceDirect = "exec_command"
 	opts.DeferToolSurfaceDefaultDirectTools = false
 	opts.DynamicAgentTimeout = 3 * time.Minute
+	opts.HostExecDefaultTimeout = time.Minute
 
 	provider, ok := buildAdminRuntimeConfigProvider(
 		opts,
@@ -1306,6 +1308,13 @@ func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
 	)
 	require.Equal(t, "3m0s", timeout.RuntimeValue)
 	require.Equal(t, "3m", timeout.ConfiguredValue)
+	hostTimeout := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.host_exec_default_timeout",
+	)
+	require.Equal(t, "1m0s", hostTimeout.RuntimeValue)
+	require.Equal(t, "60s", hostTimeout.ConfiguredValue)
 	direct := findAdminRuntimeConfigField(
 		t,
 		status,

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1078,6 +1078,7 @@ func NewRuntimeWithOptions(
 		stores.uploads,
 		fileMemoryStore,
 		sandboxExecEngine,
+		opts.HostExecDefaultTimeout,
 	)
 	extraTools := memoryServiceTools(memSvc)
 	extraTools = append(extraTools, openClawTools.tools...)
@@ -1681,6 +1682,7 @@ func run(
 		stores.uploads,
 		fileMemoryStore,
 		sandboxExecEngine,
+		opts.HostExecDefaultTimeout,
 	)
 	extraTools := memoryServiceTools(memSvc)
 	extraTools = append(extraTools, openClawTools.tools...)
@@ -3338,6 +3340,7 @@ func buildOpenClawTools(
 	uploadStore *uploads.Store,
 	memoryFileStore *memoryfile.Store,
 	sandboxExecEngine codeexecutor.Engine,
+	hostExecDefaultTimeout time.Duration,
 ) openClawToolsBundle {
 	if !enabled {
 		return openClawToolsBundle{}
@@ -3368,11 +3371,18 @@ func buildOpenClawTools(
 			outputRedactor,
 		)
 	} else {
-		mgr = octool.NewManager(
+		mgrOpts := []octool.Option{
 			octool.WithBaseEnv(deps.ToolEnv(stateDir)),
 			octool.WithCommandPolicy(commandPolicy),
 			octool.WithOutputRedactor(outputRedactor),
-		)
+		}
+		if hostExecDefaultTimeout > 0 {
+			mgrOpts = append(
+				mgrOpts,
+				octool.WithDefaultTimeout(hostExecDefaultTimeout),
+			)
+		}
+		mgr = octool.NewManager(mgrOpts...)
 		execTool = octool.NewExecCommandTool(mgr, uploadStore)
 		if memoryFileStore != nil {
 			execTool = octool.NewExecCommandToolWithMemoryFileStore(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -681,10 +681,10 @@ func TestBuildOpenClawTools_HostExecDefaultTimeout(t *testing.T) {
 	started := time.Now()
 	out, err := callable.Call(
 		context.Background(),
-		[]byte(`{"command":"sleep 1; printf done","yield_time_ms":0}`),
+		[]byte(`{"command":"sleep 5; printf done","yield_time_ms":0}`),
 	)
 	require.NoError(t, err)
-	require.Less(t, time.Since(started), 900*time.Millisecond)
+	require.Less(t, time.Since(started), 3*time.Second)
 
 	data, err := json.Marshal(out)
 	require.NoError(t, err)

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -652,7 +652,7 @@ func TestFileMemoryStoreForBackend_FileOnly(t *testing.T) {
 func TestBuildOpenClawTools_HidesMemoryFileEnvWithoutFileBackend(t *testing.T) {
 	t.Parallel()
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(
@@ -663,6 +663,42 @@ func TestBuildOpenClawTools_HidesMemoryFileEnvWithoutFileBackend(t *testing.T) {
 	require.NotContains(t, decl.Description, "OPENCLAW_MEMORY_FILE")
 }
 
+func TestBuildOpenClawTools_HostExecDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	bundle := buildOpenClawTools(
+		true,
+		t.TempDir(),
+		nil,
+		nil,
+		nil,
+		50*time.Millisecond,
+	)
+	execTool := findTool(bundle.tools, "exec_command")
+	callable, ok := execTool.(tool.CallableTool)
+	require.True(t, ok)
+
+	started := time.Now()
+	out, err := callable.Call(
+		context.Background(),
+		[]byte(`{"command":"sleep 1; printf done","yield_time_ms":0}`),
+	)
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 900*time.Millisecond)
+
+	data, err := json.Marshal(out)
+	require.NoError(t, err)
+	var got struct {
+		Status   string `json:"status"`
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, "exited", got.Status)
+	require.NotEqual(t, 0, got.ExitCode)
+	require.NotContains(t, got.Output, "done")
+}
+
 func TestBuildOpenClawTools_ExposesMemoryFileEnvForFileBackend(t *testing.T) {
 	t.Parallel()
 
@@ -671,7 +707,7 @@ func TestBuildOpenClawTools_ExposesMemoryFileEnvForFileBackend(t *testing.T) {
 	store, err := memoryfile.NewStore(root)
 	require.NoError(t, err)
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, nil)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, nil, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "OPENCLAW_MEMORY_FILE")
@@ -688,7 +724,7 @@ func TestBuildOpenClawTools_UsesSandboxExecCommand(t *testing.T) {
 	t.Parallel()
 
 	engine := codeexecutor.NewEngine(nil, nil, nil)
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, engine)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, engine, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "inside the configured sandbox")
@@ -716,7 +752,7 @@ func TestBuildOpenClawTools_UsesSandboxExecCommandWithMemoryFileStore(
 	require.NoError(t, err)
 
 	engine := codeexecutor.NewEngine(nil, nil, nil)
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, engine)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, engine, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "inside the configured sandbox")
@@ -735,7 +771,7 @@ func TestBuildOpenClawTools_IncludesConversationHistoryTool(
 ) {
 	t.Parallel()
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0)
 	decl := findToolDeclaration(bundle.tools, "conversation_history")
 	require.NotNil(t, decl)
 	require.Contains(
@@ -748,7 +784,7 @@ func TestBuildOpenClawTools_IncludesConversationHistoryTool(
 func TestBuildOpenClawTools_IncludesSubagentTools(t *testing.T) {
 	t.Parallel()
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0)
 	require.NotNil(
 		t,
 		findToolDeclaration(bundle.tools, "subagents_spawn"),

--- a/openclaw/app/browser_server_supervisor.go
+++ b/openclaw/app/browser_server_supervisor.go
@@ -69,6 +69,12 @@ var (
 	browserServerProbeFunc = probeBrowserServerEndpoint
 	browserServerWorkDir   = defaultBrowserServerWorkDir
 	browserServerCommand   = defaultBrowserServerCommand
+	browserServerSignal    = func(p *os.Process, sig os.Signal) error {
+		return p.Signal(sig)
+	}
+	browserServerKill = func(p *os.Process) error {
+		return p.Kill()
+	}
 )
 
 type browserServerPlan struct {
@@ -651,9 +657,9 @@ func (s *browserServerSup) Close() error {
 	s.state = browserServerStateStopping
 	s.mu.Unlock()
 
-	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+	if err := browserServerSignal(cmd.Process, os.Interrupt); err != nil {
 		if !isBrowserServerProcessDone(err) {
-			if killErr := cmd.Process.Kill(); killErr != nil &&
+			if killErr := browserServerKill(cmd.Process); killErr != nil &&
 				!isBrowserServerProcessDone(killErr) {
 				return fmt.Errorf(
 					"stop browser server: signal=%v kill=%v",
@@ -668,7 +674,7 @@ func (s *browserServerSup) Close() error {
 	case <-doneCh:
 		return nil
 	case <-time.After(browserServerStopTimeout):
-		if err := cmd.Process.Kill(); err != nil &&
+		if err := browserServerKill(cmd.Process); err != nil &&
 			!isBrowserServerProcessDone(err) {
 			return fmt.Errorf(
 				"kill browser server: %w",

--- a/openclaw/app/browser_server_supervisor.go
+++ b/openclaw/app/browser_server_supervisor.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -21,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/admin"
@@ -650,12 +652,15 @@ func (s *browserServerSup) Close() error {
 	s.mu.Unlock()
 
 	if err := cmd.Process.Signal(os.Interrupt); err != nil {
-		if killErr := cmd.Process.Kill(); killErr != nil {
-			return fmt.Errorf(
-				"stop browser server: signal=%v kill=%v",
-				err,
-				killErr,
-			)
+		if !isBrowserServerProcessDone(err) {
+			if killErr := cmd.Process.Kill(); killErr != nil &&
+				!isBrowserServerProcessDone(killErr) {
+				return fmt.Errorf(
+					"stop browser server: signal=%v kill=%v",
+					err,
+					killErr,
+				)
+			}
 		}
 	}
 
@@ -663,8 +668,12 @@ func (s *browserServerSup) Close() error {
 	case <-doneCh:
 		return nil
 	case <-time.After(browserServerStopTimeout):
-		if err := cmd.Process.Kill(); err != nil {
-			return fmt.Errorf("kill browser server: %w", err)
+		if err := cmd.Process.Kill(); err != nil &&
+			!isBrowserServerProcessDone(err) {
+			return fmt.Errorf(
+				"kill browser server: %w",
+				err,
+			)
 		}
 		select {
 		case <-doneCh:
@@ -673,6 +682,11 @@ func (s *browserServerSup) Close() error {
 			return fmt.Errorf("wait for browser server stop timed out")
 		}
 	}
+}
+
+func isBrowserServerProcessDone(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) ||
+		errors.Is(err, syscall.ESRCH)
 }
 
 func (s *browserServerSup) startupLines() []startupLogLine {

--- a/openclaw/app/browser_server_supervisor_test.go
+++ b/openclaw/app/browser_server_supervisor_test.go
@@ -271,6 +271,14 @@ func TestManagedBrowserServerHelpers(t *testing.T) {
 	require.False(t, isManagedBrowserServerHost("example.com"))
 }
 
+func TestBrowserServerProcessDoneError(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isBrowserServerProcessDone(os.ErrProcessDone))
+	require.True(t, isBrowserServerProcessDone(syscall.ESRCH))
+	require.False(t, isBrowserServerProcessDone(fmt.Errorf("still running")))
+}
+
 func TestBrowserServerWorkDirHelpers(t *testing.T) {
 	root := t.TempDir()
 	direct := filepath.Join(root, browserServerDirName)

--- a/openclaw/app/browser_server_supervisor_test.go
+++ b/openclaw/app/browser_server_supervisor_test.go
@@ -279,6 +279,42 @@ func TestBrowserServerProcessDoneError(t *testing.T) {
 	require.False(t, isBrowserServerProcessDone(fmt.Errorf("still running")))
 }
 
+func TestBrowserServerSupervisorCloseExitedProcess(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Wait())
+
+	doneCh := make(chan browserServerProcessExit)
+	close(doneCh)
+	sup := &browserServerSup{
+		cmd:    cmd,
+		doneCh: doneCh,
+		state:  browserServerStateRunning,
+	}
+
+	require.NoError(t, sup.Close())
+}
+
+func TestBrowserServerSupervisorCloseUnexpectedSignalError(t *testing.T) {
+	t.Parallel()
+
+	process, err := os.FindProcess(-1)
+	require.NoError(t, err)
+	sup := &browserServerSup{
+		cmd: &exec.Cmd{
+			Process: process,
+		},
+		doneCh: make(chan browserServerProcessExit),
+		state:  browserServerStateRunning,
+	}
+
+	err = sup.Close()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stop browser server")
+}
+
 func TestBrowserServerWorkDirHelpers(t *testing.T) {
 	root := t.TempDir()
 	direct := filepath.Join(root, browserServerDirName)

--- a/openclaw/app/browser_server_supervisor_test.go
+++ b/openclaw/app/browser_server_supervisor_test.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -298,10 +299,21 @@ func TestBrowserServerSupervisorCloseExitedProcess(t *testing.T) {
 }
 
 func TestBrowserServerSupervisorCloseUnexpectedSignalError(t *testing.T) {
-	t.Parallel()
-
-	process, err := os.FindProcess(-1)
+	process, err := os.FindProcess(os.Getpid())
 	require.NoError(t, err)
+	oldSignal := browserServerSignal
+	oldKill := browserServerKill
+	browserServerSignal = func(*os.Process, os.Signal) error {
+		return errors.New("interrupt failed")
+	}
+	browserServerKill = func(*os.Process) error {
+		return errors.New("kill failed")
+	}
+	t.Cleanup(func() {
+		browserServerSignal = oldSignal
+		browserServerKill = oldKill
+	})
+
 	sup := &browserServerSup{
 		cmd: &exec.Cmd{
 			Process: process,

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -138,6 +138,7 @@ const (
 	flagDeferToolSurfaceDefaultDirectTools = "defer-tools-to-dynamic-agent-default-direct-tools"
 	flagDeferToolSurfaceDirect             = "defer-tools-to-dynamic-agent-direct-tools"
 	flagDynamicAgentTimeout                = "dynamic-agent-timeout"
+	flagHostExecDefaultTimeout             = "host-exec-default-timeout"
 
 	flagAdminEnabled  = "admin-enabled"
 	flagAdminAddr     = "admin-addr"
@@ -292,6 +293,7 @@ type runOptions struct {
 	DeferToolSurfaceDefaultDirectTools bool
 	DeferToolSurfaceDirect             string
 	DynamicAgentTimeout                time.Duration
+	HostExecDefaultTimeout             time.Duration
 
 	enableOpenClawToolsExplicit  bool
 	deferToolSurfaceModeExplicit bool
@@ -954,6 +956,13 @@ func parseRunOptions(args []string) (runOptions, error) {
 		0,
 		"Maximum duration for one dynamic_agent child call (0 disables)",
 	)
+	fs.DurationVar(
+		&opts.HostExecDefaultTimeout,
+		flagHostExecDefaultTimeout,
+		0,
+		"Default timeout for OpenClaw host exec commands when timeout_sec "+
+			"is omitted (0 keeps the built-in default)",
+	)
 
 	if err := fs.Parse(args); err != nil {
 		return runOptions{}, &exitError{Code: 2, Err: err}
@@ -1279,6 +1288,8 @@ type toolsConfig struct {
 	DeferDirectToolsCamel         yamlStringList      `yaml:"deferDirectTools,omitempty"`
 	DynamicAgentTimeout           *string             `yaml:"dynamic_agent_timeout,omitempty"`
 	DynamicAgentTimeoutCamel      *string             `yaml:"dynamicAgentTimeout,omitempty"`
+	HostExecDefaultTimeout        *string             `yaml:"host_exec_default_timeout,omitempty"`
+	HostExecDefaultTimeoutCamel   *string             `yaml:"hostExecDefaultTimeout,omitempty"`
 
 	Providers []filePluginSpec `yaml:"providers,omitempty"`
 	ToolSets  []filePluginSpec `yaml:"toolsets,omitempty"`
@@ -2053,6 +2064,21 @@ func (cfg *fileConfig) apply(
 			}
 			opts.DynamicAgentTimeout = dur
 		}
+		hostExecTimeout := firstStringPtr(
+			cfg.Tools.HostExecDefaultTimeout,
+			cfg.Tools.HostExecDefaultTimeoutCamel,
+		)
+		if hostExecTimeout != nil &&
+			!flagWasSet(set, flagHostExecDefaultTimeout) {
+			dur, err := parseDuration(*hostExecTimeout)
+			if err != nil {
+				return fmt.Errorf(
+					"tools.host_exec_default_timeout: %w",
+					err,
+				)
+			}
+			opts.HostExecDefaultTimeout = dur
+		}
 		if len(cfg.Tools.Providers) > 0 {
 			opts.ToolProviders = convertPluginSpecs(cfg.Tools.Providers)
 		}
@@ -2764,6 +2790,12 @@ func finalizeRunOptions(opts *runOptions) error {
 		return fmt.Errorf(
 			"invalid dynamic agent timeout: %s",
 			opts.DynamicAgentTimeout,
+		)
+	}
+	if opts.HostExecDefaultTimeout < 0 {
+		return fmt.Errorf(
+			"invalid host exec default timeout: %s",
+			opts.HostExecDefaultTimeout,
 		)
 	}
 	opts.DeferToolSurfaceDirect = strings.Join(

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1200,6 +1200,7 @@ tools:
   defer_to_dynamic_agent_threshold_chars: 1234
   defer_direct_tools: ["exec_command", "message", "exec_command"]
   dynamic_agent_timeout: "3m"
+  host_exec_default_timeout: "60s"
 `)
 	opts, err := parseRunOptions([]string{"-config", cfgPath})
 	require.NoError(t, err)
@@ -1209,6 +1210,7 @@ tools:
 	require.Equal(t, 1234, opts.DeferToolSurfaceChars)
 	require.Equal(t, "exec_command,message", opts.DeferToolSurfaceDirect)
 	require.Equal(t, 3*time.Minute, opts.DynamicAgentTimeout)
+	require.Equal(t, time.Minute, opts.HostExecDefaultTimeout)
 }
 
 func TestParseRunOptions_DynamicAgentTimeoutFlagOverridesConfig(t *testing.T) {
@@ -1226,12 +1228,40 @@ tools:
 	require.Equal(t, 45*time.Second, opts.DynamicAgentTimeout)
 }
 
+func TestParseRunOptions_HostExecDefaultTimeoutFlagOverridesConfig(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  host_exec_default_timeout: "3m"
+`)
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-host-exec-default-timeout", "45s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 45*time.Second, opts.HostExecDefaultTimeout)
+}
+
 func TestParseRunOptions_DynamicAgentTimeoutNegativeFails(t *testing.T) {
 	t.Parallel()
 
 	_, err := parseRunOptions([]string{"-dynamic-agent-timeout", "-1s"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "dynamic agent timeout")
+}
+
+func TestParseRunOptions_HostExecDefaultTimeoutNegativeFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRunOptions([]string{
+		"-host-exec-default-timeout",
+		"-1s",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host exec default timeout")
 }
 
 func TestParseRunOptions_DeferToolSurfaceDefaultsToAuto(t *testing.T) {

--- a/openclaw/app/tool_result_media.go
+++ b/openclaw/app/tool_result_media.go
@@ -36,9 +36,9 @@ const (
 )
 
 const (
-	toolResultSingleImageText = "Generated image attached for " +
+	toolResultSingleImageText = "Image attached for " +
 		"direct inspection: %s."
-	toolResultMultiImageText = "Generated images attached for " +
+	toolResultMultiImageText = "Images attached for " +
 		"direct inspection: %s."
 )
 
@@ -342,9 +342,9 @@ func toolResultImageMessageText(images []toolResultImage) string {
 	list := strings.Join(names, ", ")
 	if list == "" {
 		if len(images) == 1 {
-			return "Generated image attached for direct inspection."
+			return "Image attached for direct inspection."
 		}
-		return "Generated images attached for direct inspection."
+		return "Images attached for direct inspection."
 	}
 	if len(images) == 1 {
 		return fmt.Sprintf(toolResultSingleImageText, list)

--- a/openclaw/app/tool_result_media_test.go
+++ b/openclaw/app/tool_result_media_test.go
@@ -310,12 +310,12 @@ func TestToolResultPathHelpers(t *testing.T) {
 	require.Equal(t, "gif", mustToolResultImageFormat(t, path))
 	require.Equal(
 		t,
-		"Generated image attached for direct inspection.",
+		"Image attached for direct inspection.",
 		toolResultImageMessageText([]toolResultImage{{}}),
 	)
 	require.Equal(
 		t,
-		"Generated images attached for direct inspection: "+
+		"Images attached for direct inspection: "+
 			"one.png, two.jpg.",
 		toolResultImageMessageText([]toolResultImage{
 			{Name: "one.png"},

--- a/openclaw/internal/browser/driver_test.go
+++ b/openclaw/internal/browser/driver_test.go
@@ -58,8 +58,5 @@ func TestMCPProfileDriver_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, extractText(raw), "Example")
 
-	err = drv.Stop()
-	if err != nil {
-		require.Contains(t, err.Error(), "process already finished")
-	}
+	require.NoError(t, drv.Stop())
 }

--- a/openclaw/internal/octool/file_tools.go
+++ b/openclaw/internal/octool/file_tools.go
@@ -40,9 +40,10 @@ const (
 	errSpreadsheetUnsupported = "unsupported spreadsheet type"
 	errSpreadsheetSheetEmpty  = "spreadsheet has no sheets"
 
-	docKindPDF  = "pdf"
-	docKindDOCX = "docx"
-	docKindText = "text"
+	docKindPDF   = "pdf"
+	docKindDOCX  = "docx"
+	docKindText  = "text"
+	docKindImage = "image"
 
 	sheetKindXLSX = "xlsx"
 	sheetKindCSV  = "csv"
@@ -72,13 +73,15 @@ type readDocumentInput struct {
 }
 
 type readDocumentResult struct {
-	Path      string `json:"path"`
-	Kind      string `json:"kind"`
-	Title     string `json:"title"`
-	PageCount int    `json:"page_count,omitempty"`
-	Page      *int   `json:"page,omitempty"`
-	Text      string `json:"text"`
-	Truncated bool   `json:"truncated,omitempty"`
+	Path       string   `json:"path"`
+	Kind       string   `json:"kind"`
+	Title      string   `json:"title"`
+	PageCount  int      `json:"page_count,omitempty"`
+	Page       *int     `json:"page,omitempty"`
+	Text       string   `json:"text,omitempty"`
+	Output     string   `json:"output,omitempty"`
+	MediaFiles []string `json:"media_files,omitempty"`
+	Truncated  bool     `json:"truncated,omitempty"`
 }
 
 type readSpreadsheetInput struct {
@@ -135,8 +138,8 @@ func (t *readDocumentTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{
 		Name: toolReadDocument,
 		Description: "Read a chat document from a stable local path. " +
-			"Use this for PDFs, DOCX files, and plain text-like " +
-			"documents already present in the chat instead of " +
+			"Use this for PDFs, DOCX files, images, and plain " +
+			"text-like documents already present in the chat instead of " +
 			"calling exec_command to inspect upload paths.",
 		InputSchema: &tool.Schema{
 			Type: schemaTypeObject,
@@ -182,6 +185,23 @@ func (t *readDocumentTool) Call(
 	}
 
 	maxChars := resolvedMaxChars(in.MaxChars, defaultReadDocumentChars)
+	if kind == docKindImage {
+		if normalizedPositive(in.Page) != nil {
+			return nil, errors.New(
+				"page is only supported for PDF files",
+			)
+		}
+		return readDocumentResult{
+			Path:  path,
+			Kind:  kind,
+			Title: filepath.Base(path),
+			Text: "Image file attached for direct inspection. " +
+				"If vision is unavailable, use image or OCR " +
+				"tools against the returned path.",
+			Output:     execOutputMediaMarker + " " + path,
+			MediaFiles: []string{path},
+		}, nil
+	}
 	text, pageCount, err := readDocumentText(path, kind, in.Page)
 	if err != nil {
 		return nil, err
@@ -476,6 +496,8 @@ func documentKindFromPath(path string) string {
 	case ".txt", ".md", ".markdown", ".json", ".csv",
 		".yaml", ".yml", ".log":
 		return docKindText
+	case ".png", ".jpg", ".jpeg", ".webp", ".gif":
+		return docKindImage
 	default:
 		return ""
 	}

--- a/openclaw/internal/octool/file_tools_test.go
+++ b/openclaw/internal/octool/file_tools_test.go
@@ -241,6 +241,36 @@ func TestReadDocumentTool_TextDocxAndErrors(t *testing.T) {
 	require.ErrorContains(t, err, "invalid args")
 }
 
+func TestReadDocumentTool_ImageReturnsMedia(t *testing.T) {
+	t.Parallel()
+
+	imagePath := filepath.Join(t.TempDir(), "chart.png")
+	require.NoError(t, os.WriteFile(
+		imagePath,
+		[]byte("not decoded by read_document"),
+		0o600,
+	))
+	tool := newReadDocumentTool()
+
+	out, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
+		"path": imagePath,
+	}))
+	require.NoError(t, err)
+
+	res := out.(readDocumentResult)
+	require.Equal(t, imagePath, res.Path)
+	require.Equal(t, docKindImage, res.Kind)
+	require.Contains(t, res.Text, "Image file attached")
+	require.Equal(t, execOutputMediaMarker+" "+imagePath, res.Output)
+	require.Equal(t, []string{imagePath}, res.MediaFiles)
+
+	_, err = tool.Call(context.Background(), mustJSON(t, map[string]any{
+		"path": imagePath,
+		"page": 1,
+	}))
+	require.ErrorContains(t, err, "page is only supported")
+}
+
 func TestReadDocumentHelpers(t *testing.T) {
 	t.Parallel()
 
@@ -270,6 +300,8 @@ func TestReadDocumentHelpers(t *testing.T) {
 
 	require.Equal(t, docKindDOCX, documentKindFromPath(docxPath))
 	require.Equal(t, docKindText, documentKindFromPath(logPath))
+	require.Equal(t, docKindImage, documentKindFromPath("chart.png"))
+	require.Equal(t, docKindImage, documentKindFromPath("photo.jpeg"))
 	require.Equal(t, "", documentKindFromPath("bad.bin"))
 
 	text, _, err := readDocumentText(logPath, docKindText, nil)

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -257,6 +257,7 @@ func runForeground(
 	defer cancel()
 
 	cmd := shellCmd(ctx, params.Command)
+	prepareCommandProcess(cmd)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(baseEnv, params.Env)
 
@@ -266,12 +267,16 @@ func runForeground(
 }
 
 func shellCmd(ctx context.Context, command string) *exec.Cmd {
-	return exec.CommandContext(
+	cmd := exec.CommandContext(
 		ctx,
 		shellProgram,
 		shellLoginFlag,
 		command,
 	)
+	cmd.Cancel = func() error {
+		return forceKillCommandProcess(cmd)
+	}
+	return cmd
 }
 
 func mergedEnv(
@@ -344,6 +349,7 @@ func (m *Manager) startBackground(
 			sess.readFrom(master)
 		}()
 	} else {
+		prepareCommandProcess(cmd)
 		stdin, stdout, stderr, err := startPipes(cmd)
 		if err != nil {
 			cancel()

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -276,6 +276,7 @@ func shellCmd(ctx context.Context, command string) *exec.Cmd {
 	cmd.Cancel = func() error {
 		return forceKillCommandProcess(cmd)
 	}
+	cmd.WaitDelay = defaultIODrain
 	return cmd
 }
 

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -45,6 +45,7 @@ type Manager struct {
 
 	maxLines int
 	jobTTL   time.Duration
+	timeout  time.Duration
 	baseEnv  map[string]string
 	policy   CommandPolicy
 	redactor OutputRedactor
@@ -68,6 +69,14 @@ func WithJobTTL(d time.Duration) Option {
 	return func(m *Manager) {
 		if d > 0 {
 			m.jobTTL = d
+		}
+	}
+}
+
+func WithDefaultTimeout(d time.Duration) Option {
+	return func(m *Manager) {
+		if d > 0 {
+			m.timeout = d
 		}
 	}
 }
@@ -98,6 +107,7 @@ func NewManager(opts ...Option) *Manager {
 		sessions:         map[string]*session{},
 		maxLines:         defaultMaxLines,
 		jobTTL:           defaultJobTTL,
+		timeout:          time.Duration(defaultTimeoutS) * time.Second,
 		clock:            time.Now,
 		shellEnvSnapshot: snapshotLoginShellEnv,
 	}
@@ -157,12 +167,13 @@ func (m *Manager) Exec(
 		yieldMs = *params.YieldMs
 	}
 
-	timeoutS := defaultTimeoutS
+	timeout := m.timeout
 	if params.TimeoutS != nil && *params.TimeoutS > 0 {
-		timeoutS = *params.TimeoutS
+		timeout = time.Duration(*params.TimeoutS) * time.Second
 	}
-
-	timeout := time.Duration(timeoutS) * time.Second
+	if timeout <= 0 {
+		timeout = time.Duration(defaultTimeoutS) * time.Second
+	}
 
 	if !params.Background && yieldMs == 0 && !params.Pty {
 		out, code, err := runForeground(

--- a/openclaw/internal/octool/process_unix.go
+++ b/openclaw/internal/octool/process_unix.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package octool
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareCommandProcess(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func terminateCommandProcess(cmd *exec.Cmd) error {
+	return signalCommandProcess(cmd, syscall.SIGTERM)
+}
+
+func forceKillCommandProcess(cmd *exec.Cmd) error {
+	return signalCommandProcess(cmd, syscall.SIGKILL)
+}
+
+func signalCommandProcess(cmd *exec.Cmd, sig os.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	sysSig, ok := sig.(syscall.Signal)
+	if !ok {
+		return cmd.Process.Signal(sig)
+	}
+	pid := cmd.Process.Pid
+	if pid <= 0 {
+		return nil
+	}
+	if pgid, err := syscall.Getpgid(pid); err == nil && pgid == pid {
+		if err := syscall.Kill(-pgid, sysSig); err == nil {
+			return nil
+		}
+	}
+	return cmd.Process.Signal(sig)
+}

--- a/openclaw/internal/octool/process_unix_test.go
+++ b/openclaw/internal/octool/process_unix_test.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package octool
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testSignal string
+
+func (s testSignal) String() string { return string(s) }
+
+func (s testSignal) Signal() {}
+
+func TestPrepareCommandProcessNil(t *testing.T) {
+	prepareCommandProcess(nil)
+}
+
+func TestSignalCommandProcessNoProcess(t *testing.T) {
+	require.NoError(t, signalCommandProcess(nil, syscall.SIGTERM))
+	require.NoError(t, signalCommandProcess(&exec.Cmd{}, syscall.SIGTERM))
+	require.NoError(
+		t,
+		signalCommandProcess(
+			&exec.Cmd{Process: &os.Process{Pid: 0}},
+			syscall.SIGTERM,
+		),
+	)
+}
+
+func TestSignalCommandProcessNonSyscallSignal(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep is not available")
+	}
+
+	cmd := exec.Command("sleep", "5")
+	require.NoError(t, cmd.Start())
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	require.Error(t, signalCommandProcess(cmd, testSignal("custom")))
+}

--- a/openclaw/internal/octool/process_unix_test.go
+++ b/openclaw/internal/octool/process_unix_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const processUnixSignalHelperEnv = "OPENCLAW_TEST_PROCESS_UNIX_SIGNAL_HELPER"
+
 type testSignal string
 
 func (s testSignal) String() string { return string(s) }
@@ -44,11 +46,8 @@ func TestSignalCommandProcessNoProcess(t *testing.T) {
 }
 
 func TestSignalCommandProcessNonSyscallSignal(t *testing.T) {
-	if _, err := exec.LookPath("sleep"); err != nil {
-		t.Skip("sleep is not available")
-	}
-
-	cmd := exec.Command("sleep", "5")
+	cmd := exec.Command(os.Args[0], "-test.run=TestProcessUnixSignalHelper")
+	cmd.Env = append(os.Environ(), processUnixSignalHelperEnv+"=1")
 	require.NoError(t, cmd.Start())
 	defer func() {
 		_ = cmd.Process.Kill()
@@ -56,4 +55,11 @@ func TestSignalCommandProcessNonSyscallSignal(t *testing.T) {
 	}()
 
 	require.Error(t, signalCommandProcess(cmd, testSignal("custom")))
+}
+
+func TestProcessUnixSignalHelper(t *testing.T) {
+	if os.Getenv(processUnixSignalHelperEnv) != "1" {
+		return
+	}
+	select {}
 }

--- a/openclaw/internal/octool/process_windows.go
+++ b/openclaw/internal/octool/process_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package octool
+
+import "os/exec"
+
+func prepareCommandProcess(cmd *exec.Cmd) {}
+
+func terminateCommandProcess(cmd *exec.Cmd) error {
+	return forceKillCommandProcess(cmd)
+}
+
+func forceKillCommandProcess(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/openclaw/internal/octool/session.go
+++ b/openclaw/internal/octool/session.go
@@ -16,11 +16,9 @@ import (
 	"errors"
 	"io"
 	"os/exec"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -342,15 +340,13 @@ func (s *session) kill(grace time.Duration) error {
 		return nil
 	}
 
-	if runtime.GOOS != "windows" {
-		_ = cmd.Process.Signal(syscall.SIGTERM)
-	}
+	_ = terminateCommandProcess(cmd)
 
 	select {
 	case <-s.doneCh:
 		return nil
 	case <-time.After(grace):
-		return cmd.Process.Kill()
+		return forceKillCommandProcess(cmd)
 	}
 }
 

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -919,6 +920,31 @@ func TestExecTool_YieldBackgroundAndPoll(t *testing.T) {
 		time.Sleep(pollInterval)
 	}
 	t.Fatalf("process did not exit; output: %s", all)
+}
+
+func TestExecTool_DefaultTimeoutKillsProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group signaling is unix-specific")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	marker := filepath.Join(t.TempDir(), "orphan-marker")
+	mgr := NewManager(WithDefaultTimeout(100 * time.Millisecond))
+	yieldZero := 0
+
+	res, err := mgr.Exec(context.Background(), execParams{
+		Command: "(sleep 0.6; echo orphan > " +
+			strconv.Quote(marker) + ") & wait",
+		YieldMs: &yieldZero,
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, 0, res.ExitCode)
+
+	time.Sleep(900 * time.Millisecond)
+	_, err = os.Stat(marker)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestProcessTool_Submit(t *testing.T) {

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -942,9 +942,14 @@ func TestExecTool_DefaultTimeoutKillsProcessGroup(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, res.ExitCode)
 
-	time.Sleep(900 * time.Millisecond)
-	_, err = os.Stat(marker)
-	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Never(t, func() bool {
+		_, err = os.Stat(marker)
+		if err == nil {
+			return true
+		}
+		require.ErrorIs(t, err, os.ErrNotExist)
+		return false
+	}, 900*time.Millisecond, 20*time.Millisecond)
 }
 
 func TestProcessTool_Submit(t *testing.T) {

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -323,6 +323,28 @@ func TestExecTool_Foreground(t *testing.T) {
 	require.Equal(t, 0, res.ExitCode)
 }
 
+func TestExecTool_UsesManagerDefaultTimeout(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(WithDefaultTimeout(50 * time.Millisecond))
+	tool := newExecCommandTool(mgr)
+
+	started := time.Now()
+	out, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
+		"command": "sleep 1; printf done",
+		"yieldMs": 0,
+	}))
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 900*time.Millisecond)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	require.NotEqual(t, 0, res.ExitCode)
+	require.NotContains(t, res.Output, "done")
+}
+
 func TestExecTool_RuntimeProfileWorkspacePolicy(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not available")

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -55,6 +55,9 @@ tools:
   # defer_direct_tools, useful for token-sensitive benchmark profiles.
   # defer_default_direct_tools: true
   # defer_direct_tools: ["exec_command"]
+  # Optional: default timeout for host exec_command calls when timeout_sec is
+  # omitted. Leave unset to keep the built-in host exec default.
+  # host_exec_default_timeout: "60s"
   # code_executor:
   #   type: "sandbox" # sandbox; leave empty/unset to inherit enable_local_exec
   #   auto_execute_code_blocks: true

--- a/session/clickhouse/window.go
+++ b/session/clickhouse/window.go
@@ -52,7 +52,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	roleFilter := sessionwindow.MakeRoleFilter(req.Roles)
@@ -67,7 +67,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if anchor == nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	beforeEntries, err := s.loadWindowNeighbors(

--- a/session/internal/window/window.go
+++ b/session/internal/window/window.go
@@ -70,7 +70,7 @@ func EventWindowFromOrderedEntries(
 		break
 	}
 	if anchorIndex < 0 {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	before := collectBefore(entries, anchorIndex, req.Before, roleFilter)

--- a/session/mongodb/window.go
+++ b/session/mongodb/window.go
@@ -62,7 +62,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	roleFilter := sessionwindow.MakeRoleFilter(req.Roles)
@@ -71,7 +71,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if anchor == nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 	beforeEntries, err := s.loadWindowNeighbors(ctx, req.Key, sessionCreatedAt, anchor, req.Before, roleFilter, true)
 	if err != nil {

--- a/session/mysql/window.go
+++ b/session/mysql/window.go
@@ -52,7 +52,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	roleFilter := sessionwindow.MakeRoleFilter(req.Roles)
@@ -67,7 +67,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if anchor == nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	beforeEntries, err := s.loadWindowNeighbors(

--- a/session/pgvector/window.go
+++ b/session/pgvector/window.go
@@ -63,7 +63,8 @@ func (s *Service) GetEventWindow(
 	}
 	if anchor == nil {
 		return nil, fmt.Errorf(
-			"anchor event not found: %s",
+			"%w: %s",
+			session.ErrEventWindowAnchorNotFound,
 			anchorEventID,
 		)
 	}

--- a/session/postgres/window.go
+++ b/session/postgres/window.go
@@ -53,7 +53,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	roleFilter := sessionwindow.MakeRoleFilter(req.Roles)
@@ -68,7 +68,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if anchor == nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	beforeEntries, err := s.loadWindowNeighbors(

--- a/session/redis/window.go
+++ b/session/redis/window.go
@@ -85,14 +85,14 @@ func (s *Service) loadHashIdxEventWindow(
 
 	anchorRaw, err := s.redisClient.HGet(ctx, eventDataKey, anchorEventID).Result()
 	if err == goredis.Nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("load redis event window anchor: %w", err)
 	}
 	anchorRank, err := s.redisClient.ZRank(ctx, eventIndexKey, anchorEventID).Result()
 	if err == goredis.Nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("load redis event window anchor rank: %w", err)
@@ -103,7 +103,7 @@ func (s *Service) loadHashIdxEventWindow(
 	}
 	if anchor.entry.Event.ID != anchorEventID ||
 		!sessionwindow.EventAllowed(&anchor.entry.Event, roleFilter) {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	beforeEntries, err := s.loadHashIdxWindowNeighbors(
@@ -243,7 +243,7 @@ func (s *Service) loadZSetEventWindow(
 		return nil, err
 	}
 	if anchor == nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	beforeEntries, err := s.loadZSetWindowNeighbors(

--- a/session/session.go
+++ b/session/session.go
@@ -51,6 +51,8 @@ var (
 	ErrTracksEmpty = errors.New("tracks is empty")
 	// ErrTrackEventsNotFound indicates the requested track has no events.
 	ErrTrackEventsNotFound = errors.New("track events not found")
+	// ErrEventWindowAnchorNotFound indicates an event-window anchor was missing.
+	ErrEventWindowAnchorNotFound = errors.New("anchor event not found")
 )
 
 // SummaryFilterKeyAllContents is the filter key representing

--- a/session/sqlite/window.go
+++ b/session/sqlite/window.go
@@ -54,7 +54,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if !ok {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	roleFilter := sessionwindow.MakeRoleFilter(req.Roles)
@@ -69,7 +69,7 @@ func (s *Service) GetEventWindow(
 		return nil, err
 	}
 	if anchor == nil {
-		return nil, fmt.Errorf("anchor event not found: %s", anchorEventID)
+		return nil, fmt.Errorf("%w: %s", session.ErrEventWindowAnchorNotFound, anchorEventID)
 	}
 
 	beforeEntries, err := s.loadWindowNeighbors(

--- a/tool/mcp/toolset.go
+++ b/tool/mcp/toolset.go
@@ -13,8 +13,10 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -38,6 +40,16 @@ var sessionReconnectErrorPatterns = []string{
 	"broken pipe",            // Broken connection
 	"HTTP 404",               // Session not found on server
 	"session not found",      // Explicit session not found error
+}
+
+const processAlreadyFinishedText = "process already finished"
+
+func isBenignMCPClientCloseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, os.ErrProcessDone) ||
+		strings.Contains(err.Error(), processAlreadyFinishedText)
 }
 
 // ToolSet implements the ToolSet interface for MCP tools.
@@ -221,7 +233,8 @@ func (m *mcpSessionManager) connect(ctx context.Context) error {
 	// Initialize the session.
 	if err := m.initialize(ctx); err != nil {
 		m.connected = false
-		if closeErr := client.Close(); closeErr != nil {
+		if closeErr := client.Close(); closeErr != nil &&
+			!isBenignMCPClientCloseError(closeErr) {
 			log.ErrorContext(ctx, "Failed to close client after initialization failure",
 				"client_close_error", closeErr, "error", err)
 		}
@@ -438,6 +451,10 @@ func (m *mcpSessionManager) close() error {
 	m.client = nil
 
 	if err != nil {
+		if isBenignMCPClientCloseError(err) {
+			log.Debug("MCP client already finished during close", "error", err)
+			return nil
+		}
 		log.Error("Failed to close MCP client", "error", err)
 		return fmt.Errorf("failed to close MCP client: %w", err)
 	}
@@ -576,8 +593,14 @@ func (m *mcpSessionManager) doRecreateSession(ctx context.Context) error {
 
 	// Close existing client if any.
 	if m.client != nil {
-		if closeErr := m.client.Close(); closeErr != nil {
-			log.WarnContext(ctx, "Failed to close old client during session recreation", "error", closeErr)
+		if closeErr := m.client.Close(); closeErr != nil &&
+			!isBenignMCPClientCloseError(closeErr) {
+			log.WarnContext(
+				ctx,
+				"Failed to close old client during session recreation",
+				"error",
+				closeErr,
+			)
 		}
 		m.client = nil
 	}
@@ -598,7 +621,8 @@ func (m *mcpSessionManager) doRecreateSession(ctx context.Context) error {
 	// Re-initialize the session.
 	if err := m.initialize(ctx); err != nil {
 		m.connected = false
-		if closeErr := client.Close(); closeErr != nil {
+		if closeErr := client.Close(); closeErr != nil &&
+			!isBenignMCPClientCloseError(closeErr) {
 			log.ErrorContext(ctx, "Failed to close client after re-initialization failure",
 				"close_error", closeErr, "init_error", err)
 		}

--- a/tool/mcp/toolset_additional_test.go
+++ b/tool/mcp/toolset_additional_test.go
@@ -12,6 +12,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -25,6 +26,21 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	mcp "trpc.group/trpc-go/trpc-mcp-go"
 )
+
+func TestIsBenignMCPClientCloseError(t *testing.T) {
+	require.False(t, isBenignMCPClientCloseError(nil))
+	require.True(t, isBenignMCPClientCloseError(os.ErrProcessDone))
+	require.True(
+		t,
+		isBenignMCPClientCloseError(
+			fmt.Errorf("close: %s", processAlreadyFinishedText),
+		),
+	)
+	require.False(
+		t,
+		isBenignMCPClientCloseError(errors.New("close failed")),
+	)
+}
 
 // TestToolSet_Close tests the Close method
 func TestToolSet_Close(t *testing.T) {

--- a/tool/mcp/toolset_additional_test.go
+++ b/tool/mcp/toolset_additional_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -2114,6 +2115,27 @@ func TestToolSet_Close_WithError(t *testing.T) {
 		if !strings.Contains(err.Error(), "failed to close MCP session") {
 			t.Errorf("Expected 'failed to close MCP session' error, got: %v", err)
 		}
+	})
+
+	t.Run("close with already finished process", func(t *testing.T) {
+		config := ConnectionConfig{
+			Transport: "stdio",
+			Command:   "echo",
+			Args:      []string{"hello"},
+		}
+		toolset := NewMCPToolSet(config)
+
+		manager := toolset.sessionManager
+		manager.mu.Lock()
+		manager.client = &stubConnector{
+			closeError: os.ErrProcessDone,
+		}
+		manager.connected = true
+		manager.initialized = true
+		manager.mu.Unlock()
+
+		require.NoError(t, toolset.Close())
+		require.False(t, manager.isConnected())
 	})
 }
 


### PR DESCRIPTION
## Summary

- Add an optional `tools.host_exec_default_timeout` / `--host-exec-default-timeout` setting for OpenClaw host `exec_command` calls.
- Keep the existing built-in host exec timeout when the setting is omitted or zero.
- Surface the setting in admin runtime config and document it in OpenClaw examples.

## Why

Long-running host shell commands can otherwise inherit the built-in 30 minute default when the model omits `timeout_sec`. Eval and benchmark profiles need a shorter generic guard without changing defaults for existing users.

## Validation

- `go test ./internal/session/tool/recall ./tool/mcp`
- `cd openclaw && go test ./app ./internal/octool`
