### PR TITLE
docs/mkdocs: add multi-agent boundaries blog

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - "Improving AI Agent Quality and Stability with LLM Verifier": blog/llmverifier.md
       - "Building an Enterprise-Grade, Secure, and Controllable OpenClaw Runtime": blog/openclaw.md
       - "A Complete Guide to Automated Prompt Iteration and Engineering Practice for AI Agents": blog/promptiter.md
+      - "Putting Work in the Right Boundary: Multi-Agent Design in tRPC-Agent-Go": blog/multiagent-boundaries.md
 
 plugins:
   - search
@@ -197,6 +198,7 @@ plugins:
                 - "AI Agent 高质量稳定性提升方法": blog/llmverifier.md
                 - "打造企业级安全可控的 OpenClaw Runtime": blog/openclaw.md
                 - "AI Agent 提示词自动迭代与工程实践全解析": blog/promptiter.md
+                - "把工作放到合适边界：tRPC-Agent-Go Multi-Agent 设计与选型": blog/multiagent-boundaries.md
   - git-revision-date-localized:
       enable_creation_date: true
       type: iso_datetime

--- a/docs/mkdocs/en/blog/multiagent-boundaries.md
+++ b/docs/mkdocs/en/blog/multiagent-boundaries.md
@@ -1,0 +1,204 @@
+# Putting Work in the Right Boundary: Multi-Agent Design in tRPC-Agent-Go
+
+> A multi-agent design problem is rarely just "should we add more roles?" The more useful question is: why should this piece of work leave the current Agent boundary? Context, capability surface, control flow, lifecycle, output visibility, and runtime ownership lead to different tRPC-Agent-Go mechanisms.
+>
+> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go/) is an autonomous multi-Agent framework for Go. It provides tool calling, session and memory management, artifact management, multi-Agent collaboration, graph orchestration, knowledge bases, observability, and more. tRPC-Agent-Go grows with community support. Stars are welcome.
+
+When teams integrate multi-Agent capabilities, the hard part is often not the concept. It is a set of concrete decisions:
+
+- After a specialist analyzes a large search or statistics task, should the parent Agent receive the result and continue coordinating?
+- After an entry Agent routes a user to a specialist, should the next user turn continue with that specialist or start from the entry Agent again?
+- If a generation task keeps modifying the same artifact, should the child Agent keep its own stable history?
+- In support, review, or consultation handoffs, should the target Agent receive full conversation history or only the input it needs?
+- If each request needs a different combination of tools, skills, and constraints, should the parent Agent expose more tools or create a narrower per-call execution unit?
+- If the outer workflow is already a Graph, does a node still need to delegate internally to another Agent?
+
+These questions look different on the surface, but they ask the same thing: what runtime boundary should this work move into?
+
+This article is not an API catalog. AgentTool, Dynamic AgentTool, `transfer_to_agent`, Team / Swarm, Chain / Parallel / Cycle / Graph, TaskRun, A2A / Remote Agent, and Explorer are not different names for the same idea. They change different boundaries.
+
+## 1. Start With One Agent
+
+Most Agent systems should start as a single Agent: one main Agent, a controlled set of tools, an instruction, the necessary knowledge sources, and session management. If that structure completes the task reliably, do not split it just to make the system look like a team.
+
+Multi-agent design becomes an engineering problem when one boundary of the single Agent starts to fail:
+
+- The context becomes noisy because search results, reads, retries, and tool outputs keep rolling into later turns.
+- The capability surface becomes too wide, so the model misselects tools, misses tools, or hallucinates capabilities.
+- Control should move to a specialist for the current turn instead of returning to the entry Agent.
+- The work outlives one invocation and needs wait, query, cancel, transcript, or recovery semantics.
+- Output and observability need layering: the user may not need to see the process, but the parent Agent still needs a decision-ready result.
+- The runtime is actually another model, executor, service identity, permission domain, or remote system.
+
+So the first question should not be "how many Agents do we need?" It should be "why is this work no longer a good fit for the current Agent boundary?"
+
+## 2. What an Agent Boundary Means
+
+In tRPC-Agent-Go, an Agent is best understood as a runtime boundary, not only as a prompt object. It decides who executes a piece of work, which instructions, messages, tools, skills, runtime state, and callbacks are assembled for this turn, and how events are written back to session and trace.
+
+From the model-call perspective, the model sees the current `messages` and `tools`. `session`, `memory`, runtime state, artifacts, and traces are framework-side facts. Unless they are projected into `messages` or declared as `tools`, they do not directly affect the model call.
+
+Terms such as "parent Agent", "child Agent", "current response owner", and "available tool" are not identities remembered by the model. They are runtime facts reconstructed by the framework for the current invocation.
+
+Multi-agent design is therefore boundary design. When you switch Agents, the real changes are visible information, available capabilities, control ownership, state continuity, output routing, and runtime responsibility.
+
+## 3. Six Boundary Questions
+
+Use this table as the first decision pass. A real requirement may touch several rows, but identifying the main boundary makes the API choice much easier.
+
+| Boundary | Signal | Ask First | Common Misread |
+| --- | --- | --- | --- |
+| Context | Search, read, trial, and tool results create a low-signal history tail | Does the parent need the full process or only conclusion, evidence, and references? | Isolation does not mean the parent should see nothing |
+| Capability | Too many tools, skills, or knowledge sources cause misselection or hallucinated ability | Is this just filtering inside one Agent, or a new capability boundary? | Tool visibility is not a permission boundary |
+| Control | The current turn should be continued by a specialist | Who owns this invocation, and who owns the next turn? | Call-and-return delegation is not control handoff |
+| Lifecycle | Work must be waited on, queried, canceled, or resumed after the current call | Does it need a run id, state machine, persistence, and result query? | A background task is not a longer tool call |
+| Output and Observability | Process should be visible or auditable, but not necessarily in future prompts | What does the parent receive, what does the user see, and what enters later `messages`? | Hiding UI does not remove the need for information flow |
+| Runtime | Work must run under another model, executor, identity, or remote service | Is the boundary about capability, deployment, permission, team, or state ownership? | Do not split services only because the prompt sounds like a specialist |
+
+## 4. Reading tRPC-Agent-Go Mechanisms by Boundary
+
+The table below is a boundary index, not an API reference. It shows where the request goes, what context it carries, where the result returns, and who continues the current turn by default. If the default boundary does not match the product expectation, then look for options or external coordination.
+
+| Mechanism | Default Boundary | Good Fit | Options or Extra Design |
+| --- | --- | --- | --- |
+| Single LLMAgent | One Agent advances with its own instruction and tool surface | Controlled tools and simple flow | Tool surface, context, permission, model, or runtime boundary grows |
+| AgentTool | A fixed child Agent runs as a synchronous tool; history is isolated by default; result returns as tool result | Search, review, analysis, small specialist work | Parent history, persistent child history, result trimming, inner stream forwarding, skip outer summarization |
+| Dynamic AgentTool | One `dynamic_agent` entrypoint creates a short-lived child Agent per call; isolated by default; no stable child history | Per-task narrowing of instruction, tools, or skills | Capability bounds, providers, exposed fields, timeout, response mode |
+| `transfer_to_agent` | `WithSubAgents` exposes transfer; the target Agent takes over the current invocation; the source Agent ends the turn by default | The specialist should continue answering the current turn | Default handoff message, whether to end, message projection, cross-turn owner |
+| Coordinator Team | Members are wrapped as tools; results return to the coordinator | A coordinator calls multiple members in one turn | Member history, inner events, member text visibility, coordinator summarization |
+| Swarm | Entry member starts; members hand off via transfer; the next user turn starts from entry by default | Handoff chains inside the current turn | Cross-request transfer, independent member history, custom handoff input |
+| Chain / Parallel / Cycle | Code structure carries sequential, parallel, or loop execution | Clear, repeatable, evaluable steps | Agent input/output wiring, termination condition, error handling |
+| Graph | Graph structure carries flow, routing, state, and node execution | Fixed or semi-fixed workflow with state, conditional routing, checkpoints, or recovery | Whether nodes need AgentTool or transfer internally; how Graph state enters nodes |
+| TaskRun | Control tools start a worker with a run id and child session; parent uses list / get / wait / cancel | Long-running, waitable, cancelable, queryable work | External store, queue, lease, controller, recovery |
+| A2A / Remote Agent | A remote Agent is accessed through a local proxy; local session, memory, and runtime state are not inherited automatically | Reusing Agent services owned by another deployment or team | Identity, session mapping, permissions, memory, result contract, observability |
+| Explorer | Built-in exploration Agent; by default inherits user tools, knowledge, and skills from the direct parent invocation | Read-only exploration, context discovery | Read-only is an advisory prompt constraint; use tool narrowing or permission policy for hard isolation |
+
+Graph is easy to misread. Graph owns outer flow, state, and routing. Whether a node can delegate internally depends on the Agent that runs inside that node. `graphagent.WithSubAgents` lets `AddAgentNode(id)` find the configured Agent. It does not automatically inject delegation tools into every LLM node. If a fixed specialist step is needed, use an Agent node. If an LLM node should autonomously delegate, configure AgentTool or `WithSubAgents` on that node's Agent.
+
+## 5. First Separate Three Return Paths
+
+When another Agent participates, do not start with options. First ask how the request leaves, how the result returns, and who continues the turn. In tRPC-Agent-Go, most cases fit three paths.
+
+| Path | Mechanisms | Default Mental Model |
+| --- | --- | --- |
+| Call-and-return delegation | AgentTool, Dynamic AgentTool, Coordinator member tool, Remote Agent wrapped as AgentTool | Parent sends a request; target finishes and returns a tool result to the parent |
+| Handoff | `transfer_to_agent`, Swarm handoff, Remote Agent used as sub-agent | Target Agent takes over the current invocation; output is not first returned as a tool result to the source Agent |
+| Managed run | TaskRun | Parent starts a worker, receives a run id, then manages status and result through list / get / wait / cancel |
+
+### 5.1 AgentTool: Call and Return
+
+AgentTool is for "I need a specialist result, then the parent should continue deciding." The parent model sees a normal tool. The tool internally runs the child Agent. The child result returns as a tool result, and the parent can continue with another model call.
+
+The important part is the result contract. The parent should not receive a raw transcript, and it should not receive only "done." A useful result usually contains conclusion, evidence, important actions, uncertainty, next step, and artifact references.
+
+Read common options by output path:
+
+- `WithHistoryScope(agenttool.HistoryScopeParentBranch)`: the child can inherit parent branch history. `NewTool` defaults to isolated history.
+- `WithPersistentHistory*`: a fixed AgentTool can use stable child history, useful when the same child continues work on the same artifact or thread.
+- `WithResponseMode(agenttool.ResponseModeFinalOnly)`: the tool result uses only the child's last complete assistant message.
+- `WithStreamInner(true)`: inner events are forwarded to the parent flow. This affects UI / event stream and does not mean every internal step enters the parent prompt.
+- `WithSkipSummarization(true)`: the outer post-tool summarization model call is skipped. This fits passthrough behavior, not coordinator synthesis.
+
+### 5.2 Dynamic AgentTool: Per-Call Capability Assembly
+
+Dynamic AgentTool is for tasks where each call needs a narrower instruction, tool set, or skill set. It exposes a default entrypoint named `dynamic_agent` and creates one short-lived child Agent for the current tool call.
+
+"Dynamic" does not mean the model can create arbitrary Agents. Code still defines the maximum boundary. The boundary can come from the parent invocation's effective capability surface, or from explicit options such as `WithCapabilityTools`, `WithCapabilityProvider`, `WithCapabilitySurfaceProvider`, and `WithCapabilitySkills`. The model can only select a subset within that boundary. It cannot choose arbitrary models, executors, or remote targets.
+
+This solves capability-surface narrowing, not long-term memory. `NewDynamicTool` is short-lived, and `WithPersistentHistory*` is ignored. If the requirement is "the same child should keep editing the same artifact next time," prefer a fixed AgentTool with persistent history, or put artifact state in an external object.
+
+### 5.3 transfer and Swarm: Who Owns This Turn
+
+`transfer_to_agent` answers "who should continue this invocation?" When an LLMAgent is configured with `WithSubAgents`, the framework exposes `transfer_to_agent`. The target Agent starts with its own instruction and tool surface, and by default the source Agent ends the turn after the transfer.
+
+This differs from AgentTool:
+
+- AgentTool means "the specialist returns a result to me as a tool result."
+- transfer means "the specialist continues this turn."
+
+Swarm wraps this handoff behavior in a Team abstraction. By default, each new user message starts from the entry member. If the last handoff target should own future user turns, enable `team.WithCrossRequestTransfer(true)` and reuse the same session. If members need private history, use `team.WithSwarmIndependentAgents()`. If handoff input should be built from the root input, a template, or other context, use `team.WithSwarmHandoffInputBuilder`.
+
+Therefore, "after transfer, will the next turn stay with the child?" is not answered by `sessionID` alone. The session stores events. The active member decides the next entrypoint. Message filters and projectors decide what later model requests actually see.
+
+### 5.4 TaskRun: Becoming a Managed Run
+
+TaskRun is for work that cannot be contained by the current invocation. It may take longer than the parent should wait, and later code may need to query status, wait for result, cancel it, or read a transcript.
+
+The core of TaskRun is not "a longer AgentTool." It is a run contract. `start_task_run` creates work with a run id, usually in a child session. The parent later uses `list_task_runs`, `get_task_run`, `wait_task_run`, and `cancel_task_run` to manage it. If transcript tooling is configured, the parent can also read child session fragments.
+
+`sync` mode only means the control tool waits for the child run to reach a terminal state. It still creates a run id and uses the same lifecycle. Production TaskRun needs external storage, queueing, leases, cancellation, retry, and recovery. The in-process implementation is suitable for local use, tests, and single-process adapters. Multi-node deployments should implement their own `taskrun.Controller`.
+
+### 5.5 Remote Agent: Runtime Ownership Is Elsewhere
+
+A2AAgent is a local proxy for a remote Agent and implements `agent.Agent`. It can be run by a Runner and used in other collaboration modes like a regular Agent.
+
+Remote execution does not decide the return path by itself. If an A2AAgent is wrapped as AgentTool, it is call-and-return delegation. If it is used as a sub-agent, it can participate in transfer. If it is used as a Graph node target, it is a workflow node.
+
+Remote boundaries require explicit design: identity, session mapping, permissions, memory, runtime state, artifacts, error semantics, trace correlation, and result contracts do not become consistent automatically just because both sides expose an Agent shape.
+
+## 6. Capability Boundaries: Filter, Fix, or Assemble
+
+When the capability surface grows, there are three common layers.
+
+**Filter inside the same Agent.** `agent.WithToolFilter(...)` or `llmagent.WithToolFilter(...)` is useful for stable filtering by user, session, tenant, or mode. It is low cost, but it does not create a new Agent boundary. Tool visibility is not permission; execution must still be enforced by tools, executors, and permission policies.
+
+**Create a fixed capability boundary.** AgentTool, `WithSubAgents`, Coordinator members, Swarm members, TaskRun workers, and A2AAgent can all wrap a stable set of instructions, tools, skills, model, or executor into a smaller work unit. The parent Agent no longer carries every tool directly; it sees a stable capability entrypoint.
+
+**Assemble per call.** Dynamic AgentTool is appropriate when each subtask needs a different narrower capability set. Code should define the capability pool, and the model should select a subset for the current invocation. Do not use it as a long-lived child Agent, and do not rebuild the parent Agent's tool schema on every model request. Frequent tool-schema and instruction changes usually reduce prompt-cache stability and make behavior harder to reproduce.
+
+A practical rule: use filtering for low-frequency stable narrowing; use fixed child Agents for stable division of work; use Dynamic AgentTool only when the boundary changes per task.
+
+## 7. Output and Observability: Keep Four Exits Separate
+
+After introducing a child Agent, four exits are often mixed together:
+
+| Exit | Question |
+| --- | --- |
+| What the parent receives | Which conclusion, evidence, assumptions, next step, and artifact references does it need? |
+| What the user sees | Should inner stream, progress, member output, or final answer be displayed? |
+| What trace / artifact keeps | Which process details are needed for debugging, audit, replay, or large-result storage? |
+| What later `messages` include | Which history, tool result, or foreign-Agent context enters the next model request? |
+
+Hiding inner process from the UI does not mean the parent does not need a result. Keeping the full process in traces does not mean it should be placed back into prompts. Skipping parent summarization does not remove the need for a good tool-result contract.
+
+A robust child result contract usually includes:
+
+- Conclusion: what was done and what the judgment is.
+- Evidence: where the judgment came from and whether it is traceable.
+- Assumptions and uncertainty: what was not verified and what may be wrong.
+- Key actions: important searches, checks, or edits without replaying the whole process.
+- Next step: whether to call another tool, ask the user, or finalize.
+- Artifact reference: keep large files, reports, and task state out of the prompt and pass a handle.
+
+## 8. Cases Where You Should Not Split Yet
+
+Good selection also means knowing when not to split.
+
+| Situation | More Stable Choice |
+| --- | --- |
+| You only need to adjust instructions or tool descriptions | Improve the single Agent instruction, tool descriptions, or planner |
+| Input and output are fixed and one call is enough | Wrap it as a direct tool instead of adding an Agent layer |
+| The process is fixed, such as plan -> execute -> review | Chain, Cycle, or Graph is often clearer than autonomous collaboration |
+| The parent needs key process information to decide | Do not over-isolate; return evidence, summary, or artifact references |
+| Only tool visibility differs | Use tool filter for stable visibility and permission policy for execution |
+| Trace, UI, and state management are not ready | Avoid complex async or long-lived child Agents |
+
+Parallelism and async execution can reduce end-to-end latency, but speed should not be the default reason to split Agents. In many systems, users need stable quality, clean context, and reliable tool selection more than they need a larger cast of roles.
+
+## Closing
+
+Call-and-return delegation, control handoff, cross-turn entrypoint ownership, run lifecycle, remote runtime ownership, UI / trace visibility, and `messages` projection are different boundaries.
+
+Do not ask which API "looks more multi-agent." Ask which boundary this work needs to move across. If the parent context is noisy, manage context. If the capability surface is too broad, narrow capabilities. If the current turn should be owned by another Agent, use transfer or Swarm. If the task outlives the current invocation, use TaskRun. If the process is fixed, let code, Chain, Cycle, or Graph carry the skeleton.
+
+Once the boundary is clear, the API choice becomes much less ambiguous.
+
+## References
+
+- [tRPC-Agent-Go GitHub](https://github.com/trpc-group/trpc-agent-go)
+- [Multi-Agent documentation](../multiagent.md)
+- [Team documentation](../team.md)
+- [TaskRun documentation](../taskrun.md)
+- [Graph documentation](../graph.md)
+- [A2A documentation](../a2a.md)
+- [Tool documentation](../tool.md)

--- a/docs/mkdocs/zh/blog/multiagent-boundaries.md
+++ b/docs/mkdocs/zh/blog/multiagent-boundaries.md
@@ -1,0 +1,204 @@
+# 把工作放到合适边界：tRPC-Agent-Go Multi-Agent 设计与选型
+
+> Multi-Agent 的问题，通常不是“要不要多几个角色”，而是“这段工作为什么不适合继续留在当前 Agent 的运行边界里”。上下文、能力、控制权、生命周期、输出观测和运行环境不同，应该选择的 tRPC-Agent-Go 机制也不同。
+>
+> [tRPC-Agent-Go](https://github.com/trpc-group/trpc-agent-go/) 是面向 Go 语言的自主式多 Agent 框架，提供工具调用、会话与记忆管理、制品管理、多 Agent 协作、图编排、知识库、可观测等能力。tRPC-Agent-Go 的成长离不开社区支持，欢迎 Star 项目。
+
+业务接入 Multi-Agent 能力时，真正卡住的往往不是概念，而是几个具体判断：
+
+- 分析类 Agent 把一段复杂检索或统计交给专家以后，主 Agent 是否还要拿回结果继续协调？
+- 分流类 Agent 把用户交给专家以后，下一轮用户补充信息时，应该继续进入专家，还是重新从入口开始？
+- 生成类 Agent 需要反复修改同一份产物时，子 Agent 是否应该保留自己的历史轨道？
+- 支持、审核、咨询这类接力场景里，handoff 时应该传完整历史，还是只传目标 Agent 需要的输入？
+- 一个任务每次都需要不同工具、技能或约束时，是给主 Agent 挂更多工具，还是按次创建更窄的执行单元？
+- 外层流程已经用 Graph 编排时，节点内部是否还需要委派给别的 Agent？
+
+这些问题看起来分散，本质上都在问同一件事：这段工作需要换成怎样的运行边界。
+
+本文不把 tRPC-Agent-Go 的 Multi-Agent 能力写成 API 摘要。`AgentTool`、Dynamic AgentTool、`transfer_to_agent`、Team / Swarm、Chain / Parallel / Cycle / Graph、TaskRun、A2A / Remote Agent、Explorer 不是同一种能力的不同名字；它们改变的是不同边界。
+
+## 1. 先从单 Agent 开始
+
+多数 Agent 系统的起点仍然应该是单 Agent：一个主 Agent，配一组工具、一段 instruction、必要的知识源和会话管理。只要这个结构能稳定完成任务，就不需要为了“看起来像团队”而拆成多个 Agent。
+
+Multi-Agent 真正变成工程问题，通常是因为单 Agent 的某条边界开始失效：
+
+- 上下文太脏，搜索、读取、试错、工具结果不断滚进后续轮次。
+- 能力面太宽，模型面对过多 tools、skills、knowledge，开始误选、漏选或幻觉能力。
+- 控制权需要交给专家，当前轮不应该再由入口 Agent 继续回答。
+- 生命周期超出一次调用，任务需要等待、查询、取消、读取过程或恢复。
+- 输出和观测需要分层，用户不一定要看到过程，父 Agent 却必须拿到可决策结果。
+- 运行环境本来就在另一套模型、executor、服务身份、权限或远程系统里。
+
+因此，选型时不要先问“要几个 Agent”，而要先问“为什么这段工作不能继续放在当前 Agent 里”。
+
+## 2. Agent 边界到底是什么
+
+在 tRPC-Agent-Go 里，Agent 更适合被看成一层运行边界，而不只是一个 prompt 对象。它决定一段工作由谁执行，本轮请求装配哪些 instruction、messages、tools、skills、runtime state、callbacks，以及事件如何写回 session 和 trace。
+
+用模型调用的心智看，模型真正看到的是本轮 `messages` 和 `tools`。`session`、`memory`、runtime state、artifact、trace 都是框架侧事实；除非它们被投影进本轮 `messages`，或者被声明进本轮 `tools`，否则不会直接影响这次模型调用。
+
+所谓“父 Agent”“子 Agent”“当前响应归属谁”“能不能调用某个工具”，不是模型自己记住了身份，而是框架在这一轮运行里重新构造出来的上下文事实。
+
+所以，Multi-Agent 设计不是角色设计，而是边界设计。换 Agent 时真正变化的是：可见信息、可用能力、控制权、状态延续、输出去向和运行责任。
+
+## 3. 六类边界问题
+
+下面这张表可以作为第一轮判断。一个需求经常同时碰到两三项，但先把主问题问准，后面的 API 才不容易选错。
+
+| 边界 | 业务信号 | 先问什么 | 不要误判 |
+| --- | --- | --- | --- |
+| 上下文 | 检索、读取、试错和工具结果很多，后续对话背着大量低信息密度过程 | 父 Agent 需要完整过程，还是结论、证据和必要引用 | 隔离不等于让父 Agent 什么都看不见 |
+| 能力 | tools、skills、knowledge 太多，模型开始误选、漏选或幻觉能力 | 是同一 Agent 内过滤能力，还是建立新的能力边界 | 工具可见性不是权限边界 |
+| 控制权 | 当前轮不该只拿回一个结果，而应交给专家继续处理 | 当前轮由谁接管，完成后是否回到主 Agent，下一轮入口是谁 | 调用式委派不等于控制权接管 |
+| 生命周期 | 工作离开当前调用后还要等待、查询、取消或读取过程 | 它是否需要 run id、状态机、持久化和结果查询 | 后台工作不是更长的一次 tool call |
+| 输出和观测 | 过程要被展示或审计，但不一定进入后续 prompt | 父 Agent 收到什么，用户看到什么，什么进入下一轮 `messages` | UI 隐藏不等于信息流可以断掉 |
+| 运行环境 | 任务必须在另一套模型、executor、服务身份或远程系统里运行 | 边界来自能力差异，还是部署、权限、团队和状态所有权 | 不要只因为 prompt 像“专家”就拆服务 |
+
+## 4. 用边界读 tRPC-Agent-Go 机制
+
+下面这张表不是 API 清单，而是默认边界索引：请求发给谁，带什么上下文，结果回谁，当前轮由谁继续处理。默认边界和业务预期对不上时，再看 option 或外部配套。
+
+| 机制 | 默认边界 | 适合 | 何时加 option 或配套 |
+| --- | --- | --- | --- |
+| 单 LLMAgent | 一个 Agent 用自己的 instruction 和工具面推进 | 工具面可控、链路不复杂 | 工具面过大、上下文污染、权限、模型或环境不同 |
+| AgentTool | 固定子 Agent 作为同步 tool；默认隔离历史，结果以 tool result 回父 Agent | 查一下、审一下、分析一段内容 | 继承父历史、稳定子历史、裁剪结果、转发内部 stream、跳过外层总结 |
+| Dynamic AgentTool | 一个 `dynamic_agent` 入口；按次创建短生命周期子 Agent；默认隔离，不保留稳定子历史 | 子任务需要临时收窄 instruction、tools 或 skills | 固定能力上限、能力 provider、字段暴露、超时、结果模式 |
+| `transfer_to_agent` | `WithSubAgents` 暴露 transfer；目标 Agent 接管当前 invocation；默认原 Agent 结束当前轮 | 当前轮应该由专家继续回答 | 默认交接消息、是否结束、消息投影、跨轮 owner |
+| Coordinator Team | 成员被包装成 member tools；结果回 coordinator | 协调者调用多个成员完成当前轮 | 成员历史、内部事件、成员正文展示、coordinator 是否总结 |
+| Swarm | entry member 开始；成员间 transfer 接力；默认下一轮仍从 entry 开始 | 当前轮内多专家接力 | 跨轮接管、独立成员历史、自定义 handoff 输入 |
+| Chain / Parallel / Cycle | 代码结构承载顺序、并行或循环执行 | 步骤明确、可重复、可评估 | 子 Agent 间输入输出、终止条件、错误处理 |
+| Graph | 图结构承载流程、路由、状态和节点执行 | 固定或半固定流程，且需要状态、条件路由、检查点或恢复 | 节点内部是否还需要 AgentTool / transfer，Graph 状态如何传给节点 |
+| TaskRun | 控制工具启动 worker；worker 有 run id 和 child session；父 Agent 用 list / get / wait / cancel 管理 | 长任务、可等待、可取消、可查结果 | 外部存储、队列、租约、controller、恢复策略 |
+| A2A / Remote Agent | 远程 Agent 以本地代理形态接入；不自动继承本地 session、memory、runtime state | 复用远程服务里的 Agent 或跨团队部署 | 身份、会话映射、权限、memory、结果契约、可观测性 |
+| Explorer | 内置探索 Agent；默认继承直接父 invocation 的用户工具、知识、skills 等能力面 | 只读探索、信息收集、定位上下文 | read-only 是 prompt 软约束；硬隔离要收窄工具面或加权限策略 |
+
+Graph 这一行尤其容易误读。Graph 管的是外层流程、状态和路由；节点内部是否能继续委派，要看节点实际运行的 Agent 配了什么能力。`graphagent.WithSubAgents` 让图里的 `AddAgentNode(id)` 能找到对应 Agent，不会自动给每个 LLM 节点注入委派工具。固定专家步骤可以直接建成 Agent node；如果某个 LLM 节点内部还要自主委派，需要给该节点 Agent 配 AgentTool 或 `WithSubAgents`。
+
+## 5. 先分清三种回流路径
+
+让另一个 Agent 参与时，先不要急着看 option。先问请求怎么出去、结果怎么回来、当前轮由谁继续处理。tRPC-Agent-Go 里常见路径可以先压成三类。
+
+| 路径 | 包含机制 | 默认心智 |
+| --- | --- | --- |
+| 调用式委派 | AgentTool、Dynamic AgentTool、Coordinator member tool、包成 AgentTool 的 Remote Agent | 父 Agent 发出一个 request，目标做完后以 tool result 回到父 Agent |
+| 接力式转移 | `transfer_to_agent`、Swarm handoff、作为 sub-agent 的 Remote Agent | 目标 Agent 接管当前 invocation，输出不是先回原 Agent 的 tool result |
+| 可管理 run | TaskRun | 父 Agent 启动 worker，拿回 run id，再通过 list / get / wait / cancel 管理状态或结果 |
+
+### 5.1 AgentTool：调用并返回
+
+AgentTool 适合“我需要一个专家结果，然后主 Agent 继续判断”。父 Agent 模型看到的是一个普通 tool；tool 内部运行子 Agent；子 Agent 的最终结果以 tool result 形式回到父 Agent，父 Agent 可以继续下一次模型调用。
+
+这里的关键不是子 Agent 名字，而是结果契约。父 Agent 不应该收到一大段原始过程，也不应该只收到“已完成”。更稳定的返回通常包含结论、证据、关键动作、不确定性、下一步和 artifact 引用。
+
+常见 option 要按出口理解：
+
+- `WithHistoryScope(agenttool.HistoryScopeParentBranch)`：子 Agent 可以继承父 branch 历史；默认 `NewTool` 是 isolated。
+- `WithPersistentHistory*`：固定 AgentTool 使用稳定 child history；适合同一个子 Agent 多次修改同一份产物或延续同一条工作轨道。
+- `WithResponseMode(agenttool.ResponseModeFinalOnly)`：tool result 只取子 Agent 最后一条完整 assistant message。
+- `WithStreamInner(true)`：内部事件向父流程转发，影响 UI / event stream，不等于所有过程进入父 Agent prompt。
+- `WithSkipSummarization(true)`：tool 返回后跳过外层总结型 LLM 调用，适合 passthrough 风格，不适合需要 coordinator 综合多个结果的场景。
+
+### 5.2 Dynamic AgentTool：按次装配能力
+
+Dynamic AgentTool 适合“每次子任务都要临时收窄 instruction、tools 或 skills”。它暴露一个默认名为 `dynamic_agent` 的入口，运行时按本次 tool call 创建短生命周期子 Agent。
+
+“动态”不是让模型任意创建 Agent。代码仍然定义能力上限：可以来自父 invocation 的有效能力面，也可以通过 `WithCapabilityTools`、`WithCapabilityProvider`、`WithCapabilitySurfaceProvider`、`WithCapabilitySkills` 等方式指定。模型只能在这个边界内选择子集，不能任意选择模型、executor 或远程目标。
+
+它解决的是能力面问题，不解决长期记忆问题。`NewDynamicTool` 设计上是短生命周期，`WithPersistentHistory*` 会被忽略。如果需求是“同一个子 Agent 下次继续改同一份产物”，优先考虑固定 AgentTool 的 persistent history，或者把产物状态外置成 artifact / 数据库对象。
+
+### 5.3 transfer 与 Swarm：谁接管当前轮
+
+`transfer_to_agent` 回答的是“当前 invocation 应该由谁继续处理”。当 LLMAgent 配置了 `WithSubAgents` 后，框架会暴露 `transfer_to_agent`。目标 Agent 被启动后切换到自己的 instruction 和工具面继续当前轮输出；默认情况下，原 Agent 在 transfer 后结束当前轮。
+
+这和 AgentTool 是不同心智：
+
+- AgentTool 是“专家做完，把结果作为 tool result 还给我”。
+- transfer 是“这轮交给专家继续处理”。
+
+Swarm 把这种 handoff 封装成 Team 语义。默认每个新用户消息从 entry member 开始；如果要让上一次 handoff 的目标继续拥有后续用户轮次，需要启用 `team.WithCrossRequestTransfer(true)`，并复用同一个 session。若成员需要私有历史，可以配 `team.WithSwarmIndependentAgents()`；若 handoff 输入不应该只是 `transfer_to_agent` 的 `message` 字段，可以配 `team.WithSwarmHandoffInputBuilder`。
+
+因此，“transfer 后下一轮还在不在子 Agent”不能只看 `sessionID`。`sessionID` 说明事件落在哪个会话容器里；active member 决定下一轮入口；message filter 和 projector 决定后续模型请求实际看到什么。
+
+### 5.4 TaskRun：变成可管理的 run
+
+TaskRun 适合“这段工作不能被当前 invocation 包住”。比如它可能跑得久，父 Agent 不应该一直等；后续还需要查询状态、等待结果、取消任务或读取 transcript。
+
+TaskRun 的核心不是“更久的 AgentTool”，而是 run contract。`start_task_run` 创建带 run id 的工作，通常在 child session 里执行；父 Agent 后续通过 `list_task_runs`、`get_task_run`、`wait_task_run`、`cancel_task_run` 管理它。配置 transcript 工具后，还可以读取子 session 片段。
+
+`sync` 模式只是让控制工具等待子 run 进入终态；它仍然会创建 run id，并走同一套生命周期。生产级 TaskRun 还需要外部存储、队列、租约、取消、重试和恢复策略。框架的 in-process 实现适合本地、测试和单进程适配层；多节点部署应实现自己的 `taskrun.Controller`。
+
+### 5.5 Remote Agent：运行所有权在另一侧
+
+A2AAgent 是远程 Agent 的本地代理，它实现 `agent.Agent`。这意味着它可以像普通 Agent 一样被 Runner 执行，也可以放进其他协作模式里。
+
+但 Remote Agent 只说明运行环境在另一侧，不自动决定回流路径。把 A2AAgent 包成 AgentTool，它就是调用式委派；把它作为 sub-agent，它就可以参与 transfer；把它作为 Graph 节点目标，它就是流程节点。
+
+远程边界需要额外设计：身份、会话映射、权限、memory、runtime state、artifact、错误语义、trace 关联和结果契约都不会因为“它也是 Agent”而自动一致。
+
+## 6. 能力边界：过滤、固定、按次装配
+
+能力面变大时，常见解法有三层。
+
+**同一 Agent 内过滤。** `agent.WithToolFilter(...)` 或 `llmagent.WithToolFilter(...)` 适合用户、会话、租户、模式等低频稳定过滤。它成本低，但没有建立新的 Agent 边界。工具可见性也不是权限边界；真正的执行权限仍要在工具、executor 和 permission policy 里兜住。
+
+**固定能力边界。** AgentTool、`WithSubAgents`、Coordinator member、Swarm member、TaskRun worker、A2AAgent 都可以把一组稳定的 instruction、tools、skills、model 或 executor 封成更小的工作单元。主 Agent 不必直接背所有工具，只面对稳定的能力入口。
+
+**按次装配。** Dynamic AgentTool 适合每次子任务都要临时收窄能力的场景。它应该由代码定义能力池，再让模型在本次 invocation 内选择子集。不要把它当成长期子 Agent，也不要把高频变化的工具面塞进主 Agent 的每次模型请求里；频繁改变 tool schema 和相关 instruction 往往会降低 prompt cache 命中，也会让行为更难复现。
+
+一个实用判断是：低频、稳定的收窄，先用过滤；稳定分工，用固定子 Agent 或固定目标 Agent；按次变化，再考虑 Dynamic AgentTool。
+
+## 7. 输出和观测：四个出口不要混在一起
+
+引入子 Agent 后，最容易混在一起的是四个出口：
+
+| 出口 | 需要回答的问题 |
+| --- | --- |
+| 父 Agent 收到什么 | 它后续决策需要哪些结论、证据、假设、下一步和 artifact 引用 |
+| 用户看到什么 | 是否展示内部 stream、进度、成员输出或最终回答 |
+| trace / artifact 留下什么 | 哪些过程要用于调试、审计、复现或大结果存储 |
+| 后续 `messages` 投影什么 | 下一次模型请求实际会带哪些历史、tool result 或 foreign-agent context |
+
+UI 不展示内部过程，不代表父 Agent 不需要结果；trace 里有完整过程，也不代表都要塞回 prompt；父 Agent 跳过总结，不代表 tool result 的内容契约可以省略。
+
+一个稳妥的子 Agent 返回契约通常包括：
+
+- 结论：任务完成到什么程度，判断是什么。
+- 证据：依据来自哪里，是否可追溯。
+- 假设和不确定性：哪些前提没有验证，哪里可能出错。
+- 关键动作：做过哪些重要查询、检查或修改，不必重放完整过程。
+- 下一步：应该继续调用工具、追问用户，还是可以最终回答。
+- artifact 引用：大结果、文件、报告、任务状态不塞进 prompt，只传可定位引用。
+
+## 8. 不要急着拆 Agent 的场景
+
+选型不只要判断什么时候用，也要判断什么时候先不用。
+
+| 场景 | 更稳的选择 |
+| --- | --- |
+| 只是想调整 instruction 或工具描述 | 先改单 Agent 的 instruction、tool description 或 planner |
+| 输入输出确定、单次调用就能完成 | 直接封装 tool，不必只为形式再包一层 Agent |
+| 流程固定，比如规划 -> 执行 -> 审查 | Chain、Cycle、Graph 往往比模型自主协作更清楚 |
+| 父 Agent 需要关键过程才能判断 | 不要过度隔离，至少返回关键证据、过程摘要或 artifact 引用 |
+| 只是工具可见性不同 | 低频变化用 tool filter；执行前兜底用 permission policy |
+| 没有 trace、UI 和状态管理支撑 | 不要轻易引入复杂异步或长期子 Agent |
+
+并发和异步当然可能缩短端到端耗时，但效率不应该是默认拆 Agent 的第一叙事。很多时候，用户更需要的是效果稳定、上下文干净、工具选择可靠，而不是看起来并行了多少个角色。
+
+## 结语
+
+调用式委派、控制权接管、跨轮入口、run 生命周期、远程运行所有权、UI / trace 展示和 `messages` 投影，是不同边界。
+
+所以，不要问“哪个 API 更像 Multi-Agent”，而要问：这段工作需要换哪条边界。主上下文太脏，就处理上下文；能力面太宽，就收窄能力；当前轮需要目标 Agent 接管，才讨论 transfer 或 Swarm；任务要离开当前调用，才讨论 TaskRun；如果只是固定流程，就优先用代码、Chain、Cycle 或 Graph 承载骨架。
+
+边界判断清楚以后，API 名字反而不容易选错。
+
+## 参考资料
+
+- [tRPC-Agent-Go GitHub](https://github.com/trpc-group/trpc-agent-go)
+- [Multi-Agent 文档](../multiagent.md)
+- [Team 文档](../team.md)
+- [TaskRun 文档](../taskrun.md)
+- [Graph 文档](../graph.md)
+- [A2A 文档](../a2a.md)
+- [Tool 文档](../tool.md)


### PR DESCRIPTION
## Summary

- Add sanitized Chinese and English blog posts about Multi-Agent boundary selection.
- Add the new article to the MkDocs blog navigation.

## Checks

- `git diff --check`
- Sensitive/internal term scan
- Not run: `mkdocs build` (mkdocs is unavailable locally)