### PR TITLE
openclaw,tool/agent: improve browser, media, exec, and stream timeout handling

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -230,6 +230,14 @@ func New(name string, opts ...Option) *LLMAgent {
 	toolCallProcessorOptions := []processor.FunctionCallResponseProcessorOption{
 		processor.WithToolCallRetryPolicy(options.ToolCallRetryPolicy),
 	}
+	if options.ToolResultAttachmentBudget > 0 {
+		toolCallProcessorOptions = append(
+			toolCallProcessorOptions,
+			processor.WithToolResultAttachmentBudget(
+				options.ToolResultAttachmentBudget,
+			),
+		)
+	}
 	if len(options.toolActivationRules) > 0 {
 		toolCallProcessorOptions = append(
 			toolCallProcessorOptions,

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -311,6 +311,10 @@ type Options struct {
 	ModelCallbacks *model.Callbacks
 	// ToolCallbacks contains callbacks for tool operations.
 	ToolCallbacks *tool.Callbacks
+	// ToolResultAttachmentBudget limits callback-managed attachments across
+	// one tool response processing pass. Non-positive values preserve the
+	// default unlimited behavior.
+	ToolResultAttachmentBudget int
 	// ToolCallRetryPolicy configures retry behavior for callable tool calls.
 	ToolCallRetryPolicy *tool.RetryPolicy
 	// Knowledge is the knowledge base for the agent.
@@ -1419,6 +1423,15 @@ func WithModelCallbacks(callbacks *model.Callbacks) Option {
 func WithToolCallbacks(callbacks *tool.Callbacks) Option {
 	return func(opts *Options) {
 		opts.ToolCallbacks = callbacks
+	}
+}
+
+// WithToolResultAttachmentBudget limits callback-managed attachments across
+// one tool response processing pass. Non-positive values preserve the default
+// unlimited behavior.
+func WithToolResultAttachmentBudget(maxAttachments int) Option {
+	return func(opts *Options) {
+		opts.ToolResultAttachmentBudget = maxAttachments
 	}
 }
 

--- a/agent/llmagent/option_test.go
+++ b/agent/llmagent/option_test.go
@@ -524,6 +524,15 @@ func TestWithToolCallRetryPolicy_OnOptions(t *testing.T) {
 	require.Same(t, policy, opts.ToolCallRetryPolicy)
 }
 
+func TestWithToolResultAttachmentBudget_OnOptionsAndAgent(t *testing.T) {
+	opts := &Options{}
+	WithToolResultAttachmentBudget(3)(opts)
+	require.Equal(t, 3, opts.ToolResultAttachmentBudget)
+
+	a := New("budget-agent", WithToolResultAttachmentBudget(3))
+	require.Equal(t, 3, a.option.ToolResultAttachmentBudget)
+}
+
 func TestWithPreloadMemory(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -117,6 +117,7 @@ type FunctionCallResponseProcessor struct {
 	toolCallbacks       *tool.Callbacks
 	toolRetryPolicy     *tool.RetryPolicy
 	postToolResultHooks []PostToolResultHook
+	attachmentBudget    int
 }
 
 // FunctionCallResponseProcessorOption configures a function-call response processor.
@@ -149,6 +150,17 @@ func WithPostToolResultHook(
 			return
 		}
 		p.postToolResultHooks = append(p.postToolResultHooks, hook)
+	}
+}
+
+// WithToolResultAttachmentBudget limits callback-managed attachments across
+// one tool response processing pass. Non-positive values preserve the legacy
+// unlimited behavior.
+func WithToolResultAttachmentBudget(
+	maxAttachments int,
+) FunctionCallResponseProcessorOption {
+	return func(p *FunctionCallResponseProcessor) {
+		p.attachmentBudget = maxAttachments
 	}
 }
 
@@ -396,6 +408,12 @@ func (p *FunctionCallResponseProcessor) handleFunctionCallsWithRequest(
 	tools map[string]tool.Tool,
 	eventChan chan<- *event.Event,
 ) (*event.Event, error) {
+	if p.attachmentBudget > 0 {
+		ctx = tool.WithToolResultAttachmentBudget(
+			ctx,
+			p.attachmentBudget,
+		)
+	}
 	toolCalls := llmResponse.Choices[0].Message.ToolCalls
 
 	// If parallel tools are enabled AND multiple tool calls, execute concurrently
@@ -2400,8 +2418,9 @@ func (p *FunctionCallResponseProcessor) executeCallableTool(
 	toolCall model.ToolCall,
 	tl tool.CallableTool,
 ) (context.Context, any, error) {
+	callCtx := tool.WithoutToolResultAttachmentBudget(ctx)
 	if p.toolRetryPolicy == nil {
-		result, err := tl.Call(ctx, toolCall.Function.Arguments)
+		result, err := tl.Call(callCtx, toolCall.Function.Arguments)
 		if err != nil {
 			log.ErrorfContext(
 				ctx,
@@ -2418,7 +2437,9 @@ func (p *FunctionCallResponseProcessor) executeCallableTool(
 		ToolCallID: toolCall.ID,
 		Arguments:  toolCall.Function.Arguments,
 		Policy:     p.toolRetryPolicy,
-		Call:       tl.Call,
+		Call: func(_ context.Context, args []byte) (any, error) {
+			return tl.Call(callCtx, args)
+		},
 		ResultError: func(result any) bool {
 			return extractResultError(result)
 		},
@@ -2534,7 +2555,10 @@ func (f *FunctionCallResponseProcessor) executeStreamableTool(
 	eventChan chan<- *event.Event,
 ) (context.Context, any, bool, error) {
 	reader, err := tl.StreamableCall(
-		streamableToolCallContext(ctx, tl),
+		streamableToolCallContext(
+			tool.WithoutToolResultAttachmentBudget(ctx),
+			tl,
+		),
 		toolCall.Function.Arguments,
 	)
 	if err != nil {

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -1911,6 +1911,377 @@ func TestExecuteToolCall_ToolResultMessagesCallback_Nil_NoOverride(t *testing.T)
 	assert.Equal(t, string(wantBytes), choices[0].Message.Content)
 }
 
+func TestProcessResponse_ToolResultMessagesNoAttachmentBudgetByDefault(
+	t *testing.T,
+) {
+	ctx := context.Background()
+
+	tools := map[string]tool.Tool{
+		"first": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "first"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		"second": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "second"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+	}
+
+	var grants []int
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterToolResultMessages(func(
+		ctx context.Context,
+		_ *tool.ToolResultMessagesInput,
+	) (any, error) {
+		grants = append(
+			grants,
+			tool.ReserveToolResultAttachments(ctx, 4),
+		)
+		return nil, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(false, callbacks)
+	inv := &agent.Invocation{
+		InvocationID: "inv-1",
+		AgentName:    "echo-agent",
+	}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{
+					{
+						ID: "call-1",
+						Function: model.FunctionDefinitionParam{
+							Name:      "first",
+							Arguments: []byte(`{}`),
+						},
+					},
+					{
+						ID: "call-2",
+						Function: model.FunctionDefinitionParam{
+							Name:      "second",
+							Arguments: []byte(`{}`),
+						},
+					},
+				},
+			},
+		}},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	require.Equal(t, []int{4, 4}, grants)
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected merged tool response event")
+	}
+}
+
+func TestProcessResponse_ToolResultMessagesShareAttachmentBudget(
+	t *testing.T,
+) {
+	ctx := context.Background()
+
+	tools := map[string]tool.Tool{
+		"first": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "first"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		"second": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "second"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+	}
+
+	var grants []int
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterToolResultMessages(func(
+		ctx context.Context,
+		_ *tool.ToolResultMessagesInput,
+	) (any, error) {
+		grants = append(
+			grants,
+			tool.ReserveToolResultAttachments(ctx, 4),
+		)
+		return nil, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(
+		false,
+		callbacks,
+		WithToolResultAttachmentBudget(6),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv-1",
+		AgentName:    "echo-agent",
+	}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{
+					{
+						ID: "call-1",
+						Function: model.FunctionDefinitionParam{
+							Name:      "first",
+							Arguments: []byte(`{}`),
+						},
+					},
+					{
+						ID: "call-2",
+						Function: model.FunctionDefinitionParam{
+							Name:      "second",
+							Arguments: []byte(`{}`),
+						},
+					},
+				},
+			},
+		}},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	require.Equal(t, []int{4, 2}, grants)
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected merged tool response event")
+	}
+}
+
+func TestProcessResponse_ToolResultMessagesBudgetIsPerPass(
+	t *testing.T,
+) {
+	ctx := tool.WithToolResultAttachmentBudget(context.Background(), 1)
+	require.Equal(t, 1, tool.ReserveToolResultAttachments(ctx, 1))
+
+	tools := map[string]tool.Tool{
+		"first": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "first"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		"second": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "second"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+	}
+
+	var grants []int
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterToolResultMessages(func(
+		ctx context.Context,
+		_ *tool.ToolResultMessagesInput,
+	) (any, error) {
+		grants = append(
+			grants,
+			tool.ReserveToolResultAttachments(ctx, 4),
+		)
+		return nil, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(
+		false,
+		callbacks,
+		WithToolResultAttachmentBudget(6),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv-1",
+		AgentName:    "echo-agent",
+	}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{
+					{
+						ID: "call-1",
+						Function: model.FunctionDefinitionParam{
+							Name:      "first",
+							Arguments: []byte(`{}`),
+						},
+					},
+					{
+						ID: "call-2",
+						Function: model.FunctionDefinitionParam{
+							Name:      "second",
+							Arguments: []byte(`{}`),
+						},
+					},
+				},
+			},
+		}},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	require.Equal(t, []int{4, 2}, grants)
+	require.Equal(t, 0, tool.ReserveToolResultAttachments(ctx, 1))
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected merged tool response event")
+	}
+}
+
+func TestProcessResponse_ToolExecutionDoesNotInheritAttachmentBudget(
+	t *testing.T,
+) {
+	ctx := context.Background()
+
+	var callGrant int
+	tools := map[string]tool.Tool{
+		"media": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "media"},
+			callFn: func(ctx context.Context, _ []byte) (any, error) {
+				callGrant = tool.ReserveToolResultAttachments(ctx, 2)
+				return map[string]any{"ok": true}, nil
+			},
+		},
+	}
+
+	var callbackGrant int
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterToolResultMessages(func(
+		ctx context.Context,
+		_ *tool.ToolResultMessagesInput,
+	) (any, error) {
+		callbackGrant = tool.ReserveToolResultAttachments(ctx, 2)
+		return nil, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(
+		false,
+		callbacks,
+		WithToolResultAttachmentBudget(1),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv-1",
+		AgentName:    "echo-agent",
+	}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID: "call-1",
+					Function: model.FunctionDefinitionParam{
+						Name:      "media",
+						Arguments: []byte(`{}`),
+					},
+				}},
+			},
+		}},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	require.Equal(t, 2, callGrant)
+	require.Equal(t, 1, callbackGrant)
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected merged tool response event")
+	}
+}
+
+func TestProcessResponse_ParallelToolResultMessagesShareAttachmentBudget(
+	t *testing.T,
+) {
+	ctx := context.Background()
+
+	tools := map[string]tool.Tool{
+		"first": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "first"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+		"second": &mockCallableTool{
+			declaration: &tool.Declaration{Name: "second"},
+			callFn: func(_ context.Context, _ []byte) (any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+	}
+
+	var total atomic.Int64
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterToolResultMessages(func(
+		ctx context.Context,
+		_ *tool.ToolResultMessagesInput,
+	) (any, error) {
+		granted := tool.ReserveToolResultAttachments(ctx, 4)
+		total.Add(int64(granted))
+		return nil, nil
+	})
+
+	p := NewFunctionCallResponseProcessor(
+		true,
+		callbacks,
+		WithToolResultAttachmentBudget(6),
+	)
+	inv := &agent.Invocation{
+		InvocationID: "inv-1",
+		AgentName:    "echo-agent",
+	}
+	req := &model.Request{Tools: tools}
+	rsp := &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{
+					{
+						ID: "call-1",
+						Function: model.FunctionDefinitionParam{
+							Name:      "first",
+							Arguments: []byte(`{}`),
+						},
+					},
+					{
+						ID: "call-2",
+						Function: model.FunctionDefinitionParam{
+							Name:      "second",
+							Arguments: []byte(`{}`),
+						},
+					},
+				},
+			},
+		}},
+	}
+	ch := make(chan *event.Event, 1)
+
+	p.ProcessResponse(ctx, inv, req, rsp, ch)
+
+	require.Equal(t, int64(6), total.Load())
+	select {
+	case <-ch:
+	default:
+		t.Fatal("expected merged tool response event")
+	}
+}
+
 func TestExecuteToolCall_ToolResultMessagesCallback_OverrideWithSingleMessage(t *testing.T) {
 	ctx := context.Background()
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -1038,6 +1038,17 @@ go run ./cmd/openclaw bootstrap deps \
   -apply
 ```
 
+Some specialized toolchains are intentionally opt-in. For example,
+`chess` checks for a Stockfish-compatible UCI engine and installs Python
+board-analysis helpers for chess-position tasks:
+
+```bash
+cd openclaw
+go run ./cmd/openclaw bootstrap deps \
+  -profile chess \
+  -apply
+```
+
 The bootstrap command never runs automatically on startup. Startup logs may
 print a suggested `bootstrap deps` command when optional file tools are
 missing, but installation is always explicit. The managed Python environment
@@ -1050,7 +1061,9 @@ Go, npm, managed-Python, and asset download install actions. Explicit
 default dependency profiles automatically. `bootstrap deps --apply` is
 best-effort: user-space installs and downloads run first, while root-only
 steps are reported as deferred instead of aborting the entire run. Download
-actions store assets under `<state_dir>/tools/<skill>/...`.
+actions store assets under `<state_dir>/tools/<skill>/...` and may link
+selected executables into the managed toolchain `bin` directory when their
+metadata declares `links`.
 
 ### 5) Send a message
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -270,10 +270,27 @@ const (
 		"Do not call exec_command just to print OPENCLAW_* upload " +
 		"vars or inspect recent upload metadata when a matching " +
 		"chat file is already available. For other general local " +
-		"shell work, use exec_command. For interactive follow-up " +
+		"shell work, use exec_command. Do not use host system package " +
+		"managers such as apt, yum, dnf, apk, pacman, zypper, or brew " +
+		"from chat; use preconfigured dependencies or ask for an " +
+		"explicit setup flow. For interactive follow-up " +
 		"input, use " +
 		"write_stdin and kill_session when needed. Use message " +
 		"to send to the current chat or an explicit target. " +
+		"When a web search tool such as duckduckgo_search is " +
+		"present, use it for general web search before using " +
+		"browser automation or web_fetch against search engine " +
+		"result pages. Use web_fetch for known result URLs. Use " +
+		"browser only when a page requires JavaScript rendering, " +
+		"interaction, download handling, screenshots, or visual " +
+		"verification; do not drive Google, Bing, or DuckDuckGo " +
+		"result pages through browser when a search tool is " +
+		"available. If a public site repeatedly blocks access " +
+		"with sign-in, bot-check, CAPTCHA, or anti-automation " +
+		"errors and the user has not provided credentials, stop " +
+		"retrying that blocked path; use search, fetch, metadata, " +
+		"or the evidence already available to complete the task or " +
+		"state the exact blocker. " +
 		artifactCompletionRule + " " +
 		"Use the available tool path to complete the request " +
 		"in this turn. " +
@@ -340,8 +357,11 @@ const (
 		"absolute image paths on their own lines. OpenClaw can " +
 		"reattach those generated images to the model for direct " +
 		"visual inspection, so inspect the image before assuming " +
-		"OCR failed. If you intentionally " +
-		"use that directive path, keep the visible prose separate " +
+		"OCR failed. Do not open local files through browser " +
+		"`file://` URLs or ad hoc localhost/127.0.0.1 servers; " +
+		"normal browser policy blocks those paths and wastes " +
+		"tool calls. If you intentionally " +
+		"use the MEDIA directive path, keep the visible prose separate " +
 		"from the `MEDIA:` lines. If a compatible audio reply " +
 		"should arrive as a Telegram voice bubble instead of a " +
 		"generic audio file, call message with as_voice=true or " +
@@ -398,7 +418,11 @@ const (
 		"field. Use `dynamic_agent` for broader " +
 		"files, uploads, browser automation, shell work, messaging, " +
 		"cron, memory, skills, knowledge, external tools, or " +
-		"verification. Give the sub-agent a self-contained request " +
+		"verification. For public web research, include search and " +
+		"fetch tools with browser workers when those tools are " +
+		"available; avoid browser-only workers for search-engine " +
+		"lookup or static page fetches. Give the sub-agent a " +
+		"self-contained request " +
 		"and ask it to complete the concrete action or return the " +
 		"exact blocker. Answer directly only when no tool work is " +
 		"needed."
@@ -416,7 +440,16 @@ const (
 		"verification matters, and keep using the same targetId " +
 		"after tabs or snapshot calls. When the user mentions " +
 		"their current browser tab, relay, or extension attach " +
-		"flow, use profile=\"chrome\" when that profile exists."
+		"flow, use profile=\"chrome\" when that profile exists. " +
+		"Do not use browser as a substitute for web search or " +
+		"fetching known static URLs; if a worker needs those " +
+		"capabilities but they are unavailable, return the exact " +
+		"missing search/fetch blocker. " +
+		"Do not use browser to open local or generated files " +
+		"through file://, data:, or ad hoc localhost/127.0.0.1 " +
+		"URLs unless the runtime explicitly exposes that server; " +
+		"use file/document/exec tools and MEDIA or MEDIA_DIR " +
+		"outputs for local media inspection."
 
 	agentTypeLLM        = "llm"
 	agentTypeClaudeCode = "claude-code"
@@ -424,6 +457,8 @@ const (
 	openAIVariantAuto = "auto"
 
 	defaultOpenAIVariant = openAIVariantAuto
+
+	defaultExecResultOutputChars = 20_000
 
 	deepSeekAPIHost = "api.deepseek.com"
 	qwenAPIHost     = "dashscope.aliyuncs.com"
@@ -708,6 +743,7 @@ type Runtime struct {
 	cronSvc           closeFunc
 	subagentSvc       closeFunc
 	skillsWatch       closeFunc
+	tools             []tool.Tool
 	evolutionService  evolution.Service
 	toolSets          []tool.ToolSet
 	telemetryShutdown func(context.Context) error
@@ -1084,11 +1120,12 @@ func NewRuntimeWithOptions(
 	extraTools = append(extraTools, openClawTools.tools...)
 
 	var (
-		toolSets    []tool.ToolSet
-		ag          agent.Agent
-		skillsRepo  *ocskills.Repository
-		skillsProv  skill.RepositoryProvider
-		skillsWatch *ocskills.WatchService
+		toolSets     []tool.ToolSet
+		runtimeTools []tool.Tool
+		ag           agent.Agent
+		skillsRepo   *ocskills.Repository
+		skillsProv   skill.RepositoryProvider
+		skillsWatch  *ocskills.WatchService
 	)
 	if agentType == agentTypeClaudeCode {
 		ag, err = newClaudeCodeAgent(opts)
@@ -1175,6 +1212,9 @@ func NewRuntimeWithOptions(
 		cwd, _ := os.Getwd()
 		skillsProv = newScopedSkillRepositoryProvider(cwd, agentCfg)
 		agentCfg.SkillRepositoryProvider = skillsProv
+		agentCfg.ownedToolsSink = func(tools []tool.Tool) {
+			runtimeTools = tools
+		}
 		ag, skillsRepo, err = newAgent(
 			mdl,
 			agentCfg,
@@ -1190,6 +1230,7 @@ func NewRuntimeWithOptions(
 		}
 	}
 	if err != nil {
+		closeTools(runtimeTools)
 		closeToolSets(toolSets)
 		return nil, &exitError{
 			Code: 1,
@@ -1202,6 +1243,7 @@ func NewRuntimeWithOptions(
 		prompts.SystemPrompt,
 	)
 	rt.toolSets = toolSets
+	rt.tools = runtimeTools
 	rt.skillsWatch = skillsWatch
 
 	bridgedSessionSvc := conversationscope.WrapSessionService(sessionSvc)
@@ -1491,6 +1533,7 @@ func (r *Runtime) Close() error {
 			errs = append(errs, err)
 		}
 	}
+	closeTools(r.tools)
 	closeToolSets(r.toolSets)
 	closeMemoryService(r.memorySvc)
 	closeSessionService(r.sessionSvc)
@@ -1688,13 +1731,15 @@ func run(
 	extraTools = append(extraTools, openClawTools.tools...)
 
 	var (
-		toolSets    []tool.ToolSet
-		ag          agent.Agent
-		skillsRepo  *ocskills.Repository
-		skillsProv  skill.RepositoryProvider
-		skillsWatch *ocskills.WatchService
+		toolSets     []tool.ToolSet
+		runtimeTools []tool.Tool
+		ag           agent.Agent
+		skillsRepo   *ocskills.Repository
+		skillsProv   skill.RepositoryProvider
+		skillsWatch  *ocskills.WatchService
 	)
 	defer func() {
+		closeTools(runtimeTools)
 		closeToolSets(toolSets)
 	}()
 	defer func() {
@@ -1789,6 +1834,9 @@ func run(
 		cwd, _ := os.Getwd()
 		skillsProv = newScopedSkillRepositoryProvider(cwd, agentCfg)
 		agentCfg.SkillRepositoryProvider = skillsProv
+		agentCfg.ownedToolsSink = func(tools []tool.Tool) {
+			runtimeTools = tools
+		}
 		ag, skillsRepo, err = newAgent(
 			mdl,
 			agentCfg,
@@ -2226,6 +2274,24 @@ func closeMemoryService(svc closeFunc) {
 	}
 	if err := svc.Close(); err != nil {
 		log.Warnf("close memory service failed: %v", err)
+	}
+}
+
+func closeTools(tools []tool.Tool) {
+	for _, tl := range tools {
+		closer, ok := tl.(closeFunc)
+		if !ok || closer == nil {
+			continue
+		}
+		name := "unknown"
+		if decl := tl.Declaration(); decl != nil {
+			if toolName := strings.TrimSpace(decl.Name); toolName != "" {
+				name = toolName
+			}
+		}
+		if err := closer.Close(); err != nil {
+			log.Warnf("close tool %q failed: %v", name, err)
+		}
 	}
 }
 
@@ -2714,6 +2780,9 @@ func newAgent(
 		}
 		tools = append(tools, extra...)
 	}
+	if cfg.ownedToolsSink != nil {
+		cfg.ownedToolsSink(append([]tool.Tool(nil), tools...))
+	}
 
 	deferToolSurface, directTools, err := resolveDeferredToolSurface(
 		cfg,
@@ -2988,13 +3057,19 @@ func buildOpenClawToolingGuidance(cfg agentConfig) string {
 	}
 	guidance = strings.Replace(
 		guidance,
-		"For other general local shell work, use exec_command. For interactive follow-up "+
-			"input, use write_stdin and kill_session when needed. Use message "+
+		"For other general local shell work, use exec_command. "+
+			"Do not use host system package managers such as apt, yum, dnf, "+
+			"apk, pacman, zypper, or brew from chat; use preconfigured "+
+			"dependencies or ask for an explicit setup flow. For interactive "+
+			"follow-up input, use write_stdin and kill_session when needed. Use message "+
 			"to send to the current chat or an explicit target. ",
 		"For other general local shell work, use exec_command. In sandbox mode, "+
 			"exec_command only supports foreground non-interactive commands; "+
 			"write_stdin, kill_session, background execution, TTY allocation, "+
-			"and session continuation are unavailable. Use message to send to "+
+			"and session continuation are unavailable. Do not use host system "+
+			"package managers such as apt, yum, dnf, apk, pacman, zypper, "+
+			"or brew from chat; use preconfigured dependencies or ask for an "+
+			"explicit setup flow. Use message to send to "+
 			"the current chat or an explicit target. ",
 		1,
 	)
@@ -3092,6 +3167,7 @@ func toolsFromProviders(
 			Config: spec.Config,
 		})
 		if err != nil {
+			closeTools(out)
 			return nil, fmt.Errorf(
 				"tool provider %s failed: %w",
 				typeName,
@@ -3260,6 +3336,8 @@ type agentConfig struct {
 
 	ToolSets []pluginSpec
 
+	ownedToolsSink func([]tool.Tool)
+
 	RefreshToolSetsOnRun               bool
 	DeferToolSurface                   bool
 	DeferToolSurfaceMode               string
@@ -3375,6 +3453,9 @@ func buildOpenClawTools(
 			octool.WithBaseEnv(deps.ToolEnv(stateDir)),
 			octool.WithCommandPolicy(commandPolicy),
 			octool.WithOutputRedactor(outputRedactor),
+			octool.WithMaxResultOutputChars(
+				defaultExecResultOutputChars,
+			),
 		}
 		if hostExecDefaultTimeout > 0 {
 			mgrOpts = append(

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -281,6 +281,14 @@ const (
 		"present, use it for general web search before using " +
 		"browser automation or web_fetch against search engine " +
 		"result pages. Use web_fetch for known result URLs. Use " +
+		"the returned web_fetch content as primary evidence when " +
+		"it has status 200; search or parse that returned content " +
+		"before switching to browser automation, downloading large " +
+		"exports, or retrying alternate mirrors. If a successful " +
+		"fetch result is too long, truncated, or hidden behind " +
+		"history compaction, use session_load with content_limit " +
+		"and content_offset around that tool result instead of " +
+		"refetching the same static page through browser. Use " +
 		"browser only when a page requires JavaScript rendering, " +
 		"interaction, download handling, screenshots, or visual " +
 		"verification; do not drive Google, Bing, or DuckDuckGo " +
@@ -422,6 +430,9 @@ const (
 		"fetch tools with browser workers when those tools are " +
 		"available; avoid browser-only workers for search-engine " +
 		"lookup or static page fetches. Give the sub-agent a " +
+		"clear instruction to inspect successful web_fetch results " +
+		"first and to report when a result is truncated instead " +
+		"of looping through browser snapshots. Give the sub-agent a " +
 		"self-contained request " +
 		"and ask it to complete the concrete action or return the " +
 		"exact blocker. Answer directly only when no tool work is " +
@@ -445,6 +456,12 @@ const (
 		"fetching known static URLs; if a worker needs those " +
 		"capabilities but they are unavailable, return the exact " +
 		"missing search/fetch blocker. " +
+		"Browser snapshots are for current page structure and " +
+		"interactive state, not bulk extraction of long static " +
+		"documents; when static page text is needed, prefer " +
+		"web_fetch or file/document tools and use browser only " +
+		"for the specific rendered or visual evidence those tools " +
+		"cannot provide. " +
 		"Do not use browser to open local or generated files " +
 		"through file://, data:, or ad hoc localhost/127.0.0.1 " +
 		"URLs unless the runtime explicitly exposes that server; " +

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -2558,6 +2558,11 @@ func TestNewAgent_SandboxOpenClawToolingGuidanceMatchesTools(t *testing.T) {
 		content,
 		"does not automatically mount host paths",
 	)
+	require.Contains(
+		t,
+		content,
+		"Do not use host system package managers",
+	)
 	require.NotContains(
 		t,
 		content,
@@ -2595,6 +2600,11 @@ func TestNewAgent_BrowserToolingGuidance_Applied(t *testing.T) {
 		t,
 		sys,
 		"For real browser automation, use browser.",
+	)
+	require.Contains(
+		t,
+		sys,
+		"Do not use browser as a substitute for web search",
 	)
 }
 
@@ -2645,6 +2655,11 @@ func TestNewAgent_BrowserToolingGuidance_FromToolProvider(
 		t,
 		sys,
 		"For real browser automation, use browser.",
+	)
+	require.Contains(
+		t,
+		sys,
+		"missing search/fetch blocker",
 	)
 }
 
@@ -2731,6 +2746,88 @@ func TestOpenClawToolingGuidanceKeepsSecretBanAbsolute(t *testing.T) {
 		t,
 		openClawToolingGuidance,
 		"secrets, or large transcripts in memory files unless",
+	)
+}
+
+func TestOpenClawToolingGuidanceAvoidsLocalBrowserMedia(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"Do not open local files through browser",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"normal browser policy blocks those paths",
+	)
+	require.Contains(
+		t,
+		browserToolingGuidance,
+		"Do not use browser to open local or generated files",
+	)
+	require.Contains(
+		t,
+		browserToolingGuidance,
+		"MEDIA or MEDIA_DIR",
+	)
+}
+
+func TestOpenClawToolingGuidancePrefersSearchTools(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"When a web search tool such as duckduckgo_search is present",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"Use web_fetch for known result URLs",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"do not drive Google, Bing, or DuckDuckGo result pages",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"stop retrying that blocked path",
+	)
+}
+
+func TestOpenClawDeferredToolingGuidancePairsBrowserWithSearch(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	require.Contains(
+		t,
+		openClawDeferredToolingGuidance,
+		"include search and fetch tools with browser workers",
+	)
+	require.Contains(
+		t,
+		openClawDeferredToolingGuidance,
+		"avoid browser-only workers for search-engine lookup",
+	)
+}
+
+func TestOpenClawToolingGuidanceAvoidsSystemPackageManagers(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"Do not use host system package managers",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"use preconfigured dependencies or ask for an explicit setup flow",
 	)
 }
 
@@ -4877,6 +4974,23 @@ func (t stubTool) Declaration() *tool.Declaration {
 	}
 }
 
+type stubCloseTool struct {
+	name     string
+	closeErr error
+	closed   *bool
+}
+
+func (t *stubCloseTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
+
+func (t *stubCloseTool) Close() error {
+	if t.closed != nil {
+		*t.closed = true
+	}
+	return t.closeErr
+}
+
 type nilDeclTool struct{}
 
 func (t nilDeclTool) Declaration() *tool.Declaration {
@@ -5031,6 +5145,22 @@ func TestCloseToolSets_CloseErrorDoesNotPanic(t *testing.T) {
 	require.True(t, toolSetClosed)
 }
 
+func TestCloseTools_CloseErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	toolClosed := false
+	closeTools([]tool.Tool{
+		nil,
+		&stubCloseTool{
+			name:     "stub",
+			closeErr: errors.New("boom"),
+			closed:   &toolClosed,
+		},
+		stubTool{name: "plain"},
+	})
+	require.True(t, toolClosed)
+}
+
 func TestRuntime_Close_ReturnsRunnerCloseError(t *testing.T) {
 	t.Parallel()
 
@@ -5046,6 +5176,23 @@ func TestRuntime_Close_ReturnsRunnerCloseError(t *testing.T) {
 
 	require.ErrorIs(t, rt.Close(), closeErr)
 	require.True(t, runnerClosed)
+}
+
+func TestRuntime_Close_ClosesTools(t *testing.T) {
+	t.Parallel()
+
+	toolClosed := false
+	rt := &Runtime{
+		tools: []tool.Tool{
+			&stubCloseTool{
+				name:   "browser",
+				closed: &toolClosed,
+			},
+		},
+	}
+
+	require.NoError(t, rt.Close())
+	require.True(t, toolClosed)
 }
 
 func TestRuntime_Close_ClosesEvolutionService(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -2606,6 +2606,11 @@ func TestNewAgent_BrowserToolingGuidance_Applied(t *testing.T) {
 		sys,
 		"Do not use browser as a substitute for web search",
 	)
+	require.Contains(
+		t,
+		sys,
+		"Browser snapshots are for current page structure",
+	)
 }
 
 func TestNewAgent_BrowserToolingGuidance_FromToolProvider(
@@ -2790,6 +2795,16 @@ func TestOpenClawToolingGuidancePrefersSearchTools(t *testing.T) {
 	require.Contains(
 		t,
 		openClawToolingGuidance,
+		"Use the returned web_fetch content as primary evidence",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"session_load with content_limit",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
 		"do not drive Google, Bing, or DuckDuckGo result pages",
 	)
 	require.Contains(
@@ -2813,6 +2828,11 @@ func TestOpenClawDeferredToolingGuidancePairsBrowserWithSearch(
 		t,
 		openClawDeferredToolingGuidance,
 		"avoid browser-only workers for search-engine lookup",
+	)
+	require.Contains(
+		t,
+		openClawDeferredToolingGuidance,
+		"inspect successful web_fetch results first",
 	)
 }
 

--- a/openclaw/app/browser_server_supervisor.go
+++ b/openclaw/app/browser_server_supervisor.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -532,6 +533,19 @@ func probeBrowserServerEndpoint(
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %s", resp.Status)
+	}
+	var payload struct {
+		Profiles []struct {
+			Name string `json:"name"`
+		} `json:"profiles"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(
+		&payload,
+	); err != nil {
+		return fmt.Errorf("decode browser server profiles: %w", err)
+	}
+	if payload.Profiles == nil {
+		return fmt.Errorf("browser server profiles response missing profiles")
 	}
 	return nil
 }

--- a/openclaw/app/browser_server_supervisor_test.go
+++ b/openclaw/app/browser_server_supervisor_test.go
@@ -517,6 +517,7 @@ func TestProbeBrowserServerEndpoint(t *testing.T) {
 		require.Equal(t, "/profiles", r.URL.Path)
 		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"profiles":[]}`)
 	}))
 	t.Cleanup(server.Close)
 
@@ -544,6 +545,23 @@ func TestProbeBrowserServerEndpoint(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected status")
+
+	htmlServer := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		_ *http.Request,
+	) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "<html>not browser server</html>")
+	}))
+	t.Cleanup(htmlServer.Close)
+
+	err = probeBrowserServerEndpoint(
+		context.Background(),
+		htmlServer.URL,
+		"",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode browser server profiles")
 }
 
 func TestBrowserServerSupervisorWaitUntilReadyExitPaths(

--- a/openclaw/app/deferred_surface_policy.go
+++ b/openclaw/app/deferred_surface_policy.go
@@ -24,12 +24,16 @@ const (
 	deferToolSurfaceModeAuto = "auto"
 
 	defaultDeferToolSurfaceThresholdChars = 4000
+	defaultDirectWebSearchTool            = "duckduckgo_search"
+	defaultDirectWebFetchTool             = "web_fetch"
 )
 
 var defaultDeferToolSurfaceDirectTools = []string{
 	configKeyExecCommand,
 	configKeyWriteStdin,
 	configKeyKillSession,
+	defaultDirectWebSearchTool,
+	defaultDirectWebFetchTool,
 }
 
 func normalizeDeferToolSurfaceMode(raw string) (string, error) {

--- a/openclaw/app/deferred_surface_policy_test.go
+++ b/openclaw/app/deferred_surface_policy_test.go
@@ -32,6 +32,8 @@ func TestDefaultedDirectToolSurfaceNames(t *testing.T) {
 		configKeyExecCommand,
 		configKeyWriteStdin,
 		configKeyKillSession,
+		defaultDirectWebSearchTool,
+		defaultDirectWebFetchTool,
 		configKeyMessage,
 	}, got)
 }
@@ -58,6 +60,8 @@ func TestResolveDeferredToolSurfaceKeepsDefaultDirectTools(
 			stubTool{name: configKeyExecCommand},
 			stubTool{name: configKeyWriteStdin},
 			stubTool{name: configKeyKillSession},
+			stubTool{name: defaultDirectWebSearchTool},
+			stubTool{name: defaultDirectWebFetchTool},
 		},
 		nil,
 	)
@@ -67,7 +71,26 @@ func TestResolveDeferredToolSurfaceKeepsDefaultDirectTools(
 		configKeyExecCommand,
 		configKeyWriteStdin,
 		configKeyKillSession,
+		defaultDirectWebSearchTool,
+		defaultDirectWebFetchTool,
 	}, testToolNames(direct))
+}
+
+func TestResolveDeferredToolSurfaceSkipsMissingDefaultDirectTools(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	enabled, direct, err := resolveDeferredToolSurface(
+		agentConfig{DeferToolSurface: true},
+		[]tool.Tool{
+			stubTool{name: configKeyExecCommand},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, enabled)
+	require.Equal(t, []string{configKeyExecCommand}, testToolNames(direct))
 }
 
 func TestResolveDeferredToolSurfaceCanDisableDefaultDirectTools(

--- a/openclaw/app/deferred_tools.go
+++ b/openclaw/app/deferred_tools.go
@@ -76,6 +76,9 @@ func baseLLMAgentOptions(
 		llmagent.WithToolResultCompactionConfig(
 			openClawToolResultCompactionConfig(),
 		),
+		llmagent.WithToolResultAttachmentBudget(
+			openClawToolResultAttachmentBudget,
+		),
 		llmagent.WithEnableParallelTools(cfg.EnableParallelTools),
 		llmagent.WithPostToolPrompt(openClawPostToolPrompt),
 		llmagent.WithSkillFilter(

--- a/openclaw/app/mcp_images.go
+++ b/openclaw/app/mcp_images.go
@@ -58,7 +58,16 @@ func mcpImageResultMessages(
 		return nil, nil
 	}
 
-	images := extractMCPImages(ctx, in.Result)
+	items := extractMCPContentItems(in.Result)
+	candidates := countMCPImageCandidates(items)
+	if candidates == 0 {
+		return nil, nil
+	}
+	allowed := tool.ReserveToolResultAttachments(ctx, candidates)
+	if allowed <= 0 {
+		return nil, nil
+	}
+	images := extractMCPImagesUpTo(ctx, items, allowed)
 	if len(images) == 0 {
 		return nil, nil
 	}
@@ -75,6 +84,16 @@ func mcpImageResultMessages(
 }
 
 func extractMCPImages(ctx context.Context, result any) []mcpImage {
+	return extractMCPImagesUpTo(
+		ctx,
+		extractMCPContentItems(result),
+		maxMCPImagesNoLimit,
+	)
+}
+
+const maxMCPImagesNoLimit = int(^uint(0) >> 1)
+
+func extractMCPContentItems(result any) []mcpContentItem {
 	payload := unwrapMCPResultContent(result)
 	if payload == nil {
 		return nil
@@ -89,8 +108,37 @@ func extractMCPImages(ctx context.Context, result any) []mcpImage {
 	if err := json.Unmarshal(body, &items); err != nil {
 		return nil
 	}
+	return items
+}
 
-	images := make([]mcpImage, 0, len(items))
+func countMCPImageCandidates(items []mcpContentItem) int {
+	var count int
+	for _, item := range items {
+		if strings.ToLower(strings.TrimSpace(item.Type)) !=
+			mcpContentTypeImage {
+			continue
+		}
+		if _, ok := mcpImageFormatFromMime(item.MimeType); ok {
+			count++
+		}
+	}
+	return count
+}
+
+func extractMCPImagesUpTo(
+	ctx context.Context,
+	items []mcpContentItem,
+	maxImages int,
+) []mcpImage {
+	if maxImages <= 0 {
+		return nil
+	}
+
+	capacity := len(items)
+	if capacity > maxImages {
+		capacity = maxImages
+	}
+	images := make([]mcpImage, 0, capacity)
 	for _, item := range items {
 		if strings.ToLower(strings.TrimSpace(item.Type)) !=
 			mcpContentTypeImage {
@@ -119,6 +167,9 @@ func extractMCPImages(ctx context.Context, result any) []mcpImage {
 			Data:   data,
 			Format: format,
 		})
+		if len(images) >= maxImages {
+			break
+		}
 	}
 
 	if len(images) == 0 {

--- a/openclaw/app/mcp_images_test.go
+++ b/openclaw/app/mcp_images_test.go
@@ -64,6 +64,48 @@ func TestMCPImageResultMessages_ReturnsImages(t *testing.T) {
 	require.Equal(t, mcpImageDetailAuto, msgs[1].ContentParts[0].Image.Detail)
 }
 
+func TestMCPImageResultMessages_ConsumesAttachmentBudget(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("fake image bytes")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	defaultMsg := model.Message{
+		Role:    model.RoleTool,
+		ToolID:  "tool-call-1",
+		Content: "[]",
+	}
+	in := &tool.ToolResultMessagesInput{
+		ToolName:           "browser_page_screenshot",
+		ToolCallID:         "tool-call-1",
+		DefaultToolMessage: defaultMsg,
+		Result: []mcpContentItem{
+			{
+				Type:     "image",
+				Data:     encoded,
+				MimeType: "image/png",
+			},
+			{
+				Type:     "image",
+				Data:     encoded,
+				MimeType: "image/png",
+			},
+		},
+	}
+	ctx := tool.WithToolResultAttachmentBudget(context.Background(), 1)
+
+	got, err := mcpImageResultMessages(ctx, in)
+	require.NoError(t, err)
+
+	msgs, ok := got.([]model.Message)
+	require.True(t, ok)
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ContentParts, 1)
+
+	got, err = mcpImageResultMessages(ctx, in)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
 func TestMCPImageResultMessages_NoImagesFallsBack(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/tool_result_media.go
+++ b/openclaw/app/tool_result_media.go
@@ -28,7 +28,9 @@ const (
 	toolResultMediaLineFile = "MEDIA:"
 	toolResultMediaLineDir  = "MEDIA_DIR:"
 
-	maxToolResultImages = 6
+	openClawToolResultAttachmentBudget = 6
+
+	maxToolResultImages = openClawToolResultAttachmentBudget
 
 	maxToolResultImageBytes int64 = 12 << 20
 
@@ -81,6 +83,13 @@ func toolResultImageMessages(
 	images := loadToolResultImages(in.Result)
 	if len(images) == 0 {
 		return nil, nil
+	}
+	allowed := tool.ReserveToolResultAttachments(ctx, len(images))
+	if allowed <= 0 {
+		return nil, nil
+	}
+	if allowed < len(images) {
+		images = images[:allowed]
 	}
 
 	recordToolResultImages(ctx, in.ToolName, images)

--- a/openclaw/app/tool_result_media_test.go
+++ b/openclaw/app/tool_result_media_test.go
@@ -138,6 +138,52 @@ func TestOpenClawToolResultMessages_RecordsTraceEvent(t *testing.T) {
 	require.Contains(t, string(data), "frame.png")
 }
 
+func TestOpenClawToolResultMessages_ConsumesAttachmentBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	root := t.TempDir()
+	pathA := writeTestFile(t, root, "a.png", []byte("a"))
+	pathB := writeTestFile(t, root, "b.png", []byte("b"))
+	defaultMsg := model.Message{
+		Role:    model.RoleTool,
+		ToolID:  "tool-1",
+		Content: "{}",
+	}
+	ctx := tool.WithToolResultAttachmentBudget(context.Background(), 1)
+
+	got, err := openClawToolResultMessages(
+		ctx,
+		&tool.ToolResultMessagesInput{
+			ToolName:           "exec_command",
+			DefaultToolMessage: defaultMsg,
+			Result: map[string]any{
+				"media_files": []string{pathA, pathB},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	msgs, ok := got.([]model.Message)
+	require.True(t, ok)
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ContentParts, 1)
+
+	got, err = openClawToolResultMessages(
+		ctx,
+		&tool.ToolResultMessagesInput{
+			ToolName:           "exec_command",
+			DefaultToolMessage: defaultMsg,
+			Result: map[string]any{
+				"media_files": []string{pathA},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
 func TestToolResultImageMessages_Guards(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/browser/driver.go
+++ b/openclaw/internal/browser/driver.go
@@ -56,6 +56,7 @@ const (
 	mcpToolInstall      = "browser_install"
 	mcpToolNavigate     = "browser_navigate"
 	mcpToolPDF          = "browser_pdf_save"
+	mcpToolMouseWheel   = "browser_mouse_wheel"
 	mcpToolPressKey     = "browser_press_key"
 	mcpToolResize       = "browser_resize"
 	mcpToolScroll       = "browser_scroll_into_view"
@@ -80,6 +81,7 @@ var supportedMCPTools = []string{
 	mcpToolInstall,
 	mcpToolNavigate,
 	mcpToolPDF,
+	mcpToolMouseWheel,
 	mcpToolPressKey,
 	mcpToolResize,
 	mcpToolScroll,

--- a/openclaw/internal/browser/result.go
+++ b/openclaw/internal/browser/result.go
@@ -88,7 +88,7 @@ func newBaseResult(
 		Profile:         profile,
 		Driver:          driverType,
 		EvaluateEnabled: evaluateEnabled,
-		Supported:       supportedActionsForDriver(driverType),
+		Supported:       visibleActionsForDriver(driverType, evaluateEnabled),
 	}
 }
 

--- a/openclaw/internal/browser/result_test.go
+++ b/openclaw/internal/browser/result_test.go
@@ -112,6 +112,14 @@ func TestNewBaseResult_DefaultsDriverType(t *testing.T) {
 	got := newBaseResult(actionSnapshot, defaultProfileName, "", false)
 	require.Equal(t, driverTypePlaywrightMCP, got.Driver)
 	require.Equal(t, actionSnapshot, got.Action)
+	require.NotContains(t, got.Supported, actionEvaluate)
+}
+
+func TestNewBaseResult_ShowsEvaluateWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	got := newBaseResult(actionSnapshot, defaultProfileName, "", true)
+	require.Contains(t, got.Supported, actionEvaluate)
 }
 
 func TestSupportedActionsForDriver_HidesServerOnlyActions(t *testing.T) {
@@ -120,11 +128,14 @@ func TestSupportedActionsForDriver_HidesServerOnlyActions(t *testing.T) {
 	mcpActions := supportedActionsForDriver(driverTypePlaywrightMCP)
 	require.Contains(t, mcpActions, actionNavigate)
 	require.Contains(t, mcpActions, actionAct)
+	require.Contains(t, mcpActions, actionEvaluate)
+	require.NotContains(t, mcpActions, actionPDF)
 	require.NotContains(t, mcpActions, actionCookies)
 	require.NotContains(t, mcpActions, actionStorage)
 	require.NotContains(t, mcpActions, actionDownload)
 
 	serverActions := supportedActionsForDriver(driverTypeBrowserServer)
+	require.Contains(t, serverActions, actionPDF)
 	require.Contains(t, serverActions, actionCookies)
 	require.Contains(t, serverActions, actionStorage)
 	require.Contains(t, serverActions, actionDownload)

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"sync"
 
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -57,8 +59,10 @@ const (
 const (
 	actClick          = "click"
 	actType           = "type"
+	actKey            = "key"
 	actPress          = "press"
 	actHover          = "hover"
+	actScroll         = "scroll"
 	actScrollIntoView = "scrollIntoView"
 	actDrag           = "drag"
 	actSelect         = "select"
@@ -76,10 +80,19 @@ const (
 )
 
 const (
+	cancelCleanupStateKey     = "__openclaw_browser_cancel_cleanup__"
+	cancelCleanupNoticePrefix = "__openclaw_browser_cancel_cleanup:"
+)
+
+const (
 	tabActionList   = "list"
 	tabActionNew    = "create"
 	tabActionSelect = "select"
 	tabActionClose  = "close"
+)
+
+const (
+	defaultScrollDeltaY = 800
 )
 
 const (
@@ -134,7 +147,6 @@ var supportedPlaywrightMCPActions = []string{
 	actionScreenshot,
 	actionNavigate,
 	actionConsole,
-	actionPDF,
 	actionUpload,
 	actionDialog,
 	actionAct,
@@ -146,6 +158,28 @@ func supportedActionsForDriver(driverType string) []string {
 		return append([]string(nil), supportedActions...)
 	}
 	return append([]string(nil), supportedPlaywrightMCPActions...)
+}
+
+func visibleActionsForDriver(
+	driverType string,
+	evaluateEnabled bool,
+) []string {
+	actions := supportedActionsForDriver(driverType)
+	if evaluateEnabled {
+		return actions
+	}
+	return filterBrowserAction(actions, actionEvaluate)
+}
+
+func filterBrowserAction(actions []string, hidden string) []string {
+	out := actions[:0]
+	for _, action := range actions {
+		if action == hidden {
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
 }
 
 type actRequest struct {
@@ -173,6 +207,10 @@ type actRequest struct {
 	Selector    string           `json:"selector,omitempty"`
 	URL         string           `json:"url,omitempty"`
 	TargetURL   string           `json:"targetUrl,omitempty"`
+	Direction   string           `json:"direction,omitempty"`
+	DeltaX      *int             `json:"deltaX,omitempty"`
+	DeltaY      *int             `json:"deltaY,omitempty"`
+	Amount      *int             `json:"amount,omitempty"`
 	LoadState   string           `json:"loadState,omitempty"`
 	TextGone    string           `json:"textGone,omitempty"`
 	TimeoutMs   *int             `json:"timeoutMs,omitempty"`
@@ -202,6 +240,10 @@ type input struct {
 	Frame          string            `json:"frame,omitempty"`
 	Labels         *bool             `json:"labels,omitempty"`
 	FullPage       *bool             `json:"fullPage,omitempty"`
+	Direction      string            `json:"direction,omitempty"`
+	DeltaX         *int              `json:"deltaX,omitempty"`
+	DeltaY         *int              `json:"deltaY,omitempty"`
+	Amount         *int              `json:"amount,omitempty"`
 	Ref            string            `json:"ref,omitempty"`
 	Element        string            `json:"element,omitempty"`
 	Type           string            `json:"type,omitempty"`
@@ -261,6 +303,11 @@ type Tool struct {
 	drivers         map[string]driver
 	serverDriversMu sync.RWMutex
 	serverDrivers   map[string]driver
+}
+
+type cancelCleanupRegistry struct {
+	mu       sync.Mutex
+	profiles map[string]struct{}
 }
 
 // NewTool creates a native browser tool backed by MCP or browser-server.
@@ -330,19 +377,74 @@ func newToolWithDrivers(
 
 func (t *Tool) Declaration() *tool.Declaration {
 	return &tool.Declaration{
-		Name: ToolName,
-		Description: "Control a real browser through OpenClaw's " +
-			"native browser contract. Prefer snapshot + act for UI " +
-			"automation. Keep using the same targetId after tabs or " +
-			"snapshot calls. Use profile=\"chrome\" when the user " +
-			"mentions a browser extension, relay, attach tab, or " +
-			"their current browser tab. Omit target for the default " +
-			"host browser. Only set target=\"sandbox\" or " +
-			"target=\"node\" when the runtime configuration exposes " +
-			"those browser servers. Avoid evaluate unless the " +
-			"task truly requires custom page JavaScript.",
-		InputSchema: browserSchema(),
+		Name:        ToolName,
+		Description: browserDescription(t.evaluateEnabled),
+		InputSchema: browserSchema(
+			t.evaluateEnabled,
+			t.driverTypeForProfile(t.defaultProfile),
+		),
 	}
+}
+
+// Close releases browser profile drivers owned by this tool.
+func (t *Tool) Close() error {
+	if t == nil {
+		return nil
+	}
+
+	var errs []error
+	for _, drv := range t.drivers {
+		if drv == nil {
+			continue
+		}
+		if err := drv.Stop(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	t.serverDriversMu.Lock()
+	serverDrivers := make([]driver, 0, len(t.serverDrivers))
+	for _, drv := range t.serverDrivers {
+		serverDrivers = append(serverDrivers, drv)
+	}
+	t.serverDrivers = make(map[string]driver)
+	t.serverDriversMu.Unlock()
+	for _, drv := range serverDrivers {
+		if drv == nil {
+			continue
+		}
+		if err := drv.Stop(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func browserDescription(evaluateEnabled bool) string {
+	description := "Control a real browser through OpenClaw's " +
+		"native browser contract. Use it for live web pages, " +
+		"public URLs, and configured browser profiles, not for " +
+		"direct inspection of local or generated files. Do not " +
+		"navigate to file://, data:, or ad hoc localhost/127.0.0.1 " +
+		"URLs unless the runtime configuration explicitly exposes " +
+		"that server; normal browser policy may block those paths. " +
+		"For local images, PDFs, audio, video, or generated " +
+		"artifacts, use file/document/exec tools and MEDIA or " +
+		"MEDIA_DIR outputs instead. Prefer snapshot + act for UI " +
+		"automation. Keep using the same targetId after tabs or " +
+		"snapshot calls. Use profile=\"chrome\" when the user " +
+		"mentions a browser extension, relay, attach tab, or " +
+		"their current browser tab. Omit target for the default " +
+		"host browser. Only set target=\"sandbox\" or " +
+		"target=\"node\" when the runtime configuration exposes " +
+		"those browser servers."
+	if evaluateEnabled {
+		return description + " Use evaluate only when the task truly " +
+			"requires custom page JavaScript."
+	}
+	return description + " The evaluate action is disabled in this " +
+		"runtime."
 }
 
 func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
@@ -384,6 +486,7 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 		return nil, err
 	}
 	driverType := t.driverTypeForInput(profileName, in)
+	t.registerCancelCleanup(ctx, profileName, drv)
 
 	switch actionKey {
 	case strings.ToLower(actionStart):
@@ -530,9 +633,100 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 	}
 }
 
-func browserSchema() *tool.Schema {
+func (t *Tool) registerCancelCleanup(
+	ctx context.Context,
+	profile string,
+	drv driver,
+) {
+	if drv == nil {
+		return
+	}
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil {
+		return
+	}
+
+	reg, ok := agent.GetStateValue[*cancelCleanupRegistry](
+		inv,
+		cancelCleanupStateKey,
+	)
+	if !ok || reg == nil {
+		reg = &cancelCleanupRegistry{
+			profiles: make(map[string]struct{}),
+		}
+		inv.SetState(cancelCleanupStateKey, reg)
+	}
+	cleanupKey := fmt.Sprintf("%s/%p", profile, drv)
+	if !reg.register(cleanupKey) {
+		return
+	}
+
+	noticeKey := cancelCleanupNoticePrefix + cleanupKey
+	ch := inv.AddNoticeChannel(ctx, noticeKey)
+	if ch == nil {
+		return
+	}
+	go func(runCtx context.Context) {
+		<-ch
+		if runCtx.Err() == nil {
+			return
+		}
+		if err := drv.Stop(); err != nil {
+			log.Warnf(
+				"close canceled browser profile %q failed: %v",
+				profile,
+				err,
+			)
+		}
+	}(ctx)
+}
+
+func (r *cancelCleanupRegistry) register(profile string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.profiles == nil {
+		r.profiles = make(map[string]struct{})
+	}
+	if _, ok := r.profiles[profile]; ok {
+		return false
+	}
+	r.profiles[profile] = struct{}{}
+	return true
+}
+
+func browserSchema(evaluateEnabled bool, driverType string) *tool.Schema {
+	actionDescription := "Browser action. Supported actions include: " +
+		strings.Join(visibleActionsForDriver(
+			driverType,
+			evaluateEnabled,
+		), ", ") + "."
+	if driverType == driverTypePlaywrightMCP {
+		actionDescription += " Some backend-dependent actions, such as " +
+			"page export, require matching browser MCP tools; check " +
+			"profiles/status supported actions before using them."
+	}
+	if !evaluateEnabled {
+		actionDescription += " evaluate is not available."
+	}
+	fnDescription := evaluateFunctionDescription(evaluateEnabled)
+	actKindDescription := "Browser act kind. Supported kinds include " +
+		"click, type, press/key, hover, scroll, scrollIntoView, " +
+		"drag, select, fill, resize, wait, navigate, evaluate, " +
+		"and close. Use press/key with key=PageDown, End, or " +
+		"Enter for keyboard input. Use scroll with direction, " +
+		"deltaX, deltaY, or amount for page scrolling; use " +
+		"scrollIntoView with ref for browser-server element scrolling."
+	waitDescription := "Wait selector. Supported by the browser-server " +
+		"driver; Playwright MCP wait supports timeMs, text, and " +
+		"textGone."
+	loadStateDescription := "Wait load state. Supported by the " +
+		"browser-server driver; with Playwright MCP use timeMs " +
+		"or snapshot after navigation."
 	requestProps := map[string]*tool.Schema{
-		"kind":        stringSchema("Browser act kind."),
+		"kind":        stringSchema(actKindDescription),
 		"targetId":    stringSchema("Tab target id from tabs output."),
 		"target":      stringSchema("Element target for browser actions."),
 		"ref":         stringSchema("Snapshot ref id."),
@@ -542,7 +736,7 @@ func browserSchema() *tool.Schema {
 		"text":        stringSchema("Text input."),
 		"submit":      boolSchema("Submit after typing."),
 		"slowly":      boolSchema("Type slowly."),
-		"key":         stringSchema("Keyboard key."),
+		"key":         stringSchema("Keyboard key for press/key."),
 		"delayMs":     numberSchema("Key delay."),
 		"startTarget": stringSchema("Drag start element target."),
 		"startRef":    stringSchema("Drag start ref."),
@@ -559,17 +753,21 @@ func browserSchema() *tool.Schema {
 		"width":     numberSchema("Viewport width."),
 		"height":    numberSchema("Viewport height."),
 		"timeMs":    numberSchema("Wait duration in milliseconds."),
-		"selector":  stringSchema("Selector for wait."),
+		"selector":  stringSchema(waitDescription),
 		"url":       stringSchema("URL for navigate or wait."),
 		"targetUrl": stringSchema("Alias for browser URL."),
-		"loadState": stringSchema("Load state for wait."),
+		"direction": stringSchema("Scroll direction: down, up, left, or right."),
+		"deltaX":    numberSchema("Horizontal scroll delta."),
+		"deltaY":    numberSchema("Vertical scroll delta."),
+		"amount":    numberSchema("Scroll amount in pixels."),
+		"loadState": stringSchema(loadStateDescription),
 		"textGone":  stringSchema("Text that must disappear."),
 		"timeoutMs": numberSchema("Timeout in milliseconds."),
-		"fn":        stringSchema("Page function for evaluate."),
+		"fn":        stringSchema(fnDescription),
 	}
 
 	properties := map[string]*tool.Schema{
-		"action": stringSchema("Browser action."),
+		"action": stringSchema(actionDescription),
 		"target": stringSchema(
 			"Browser target. Omit for default host; only use " +
 				"sandbox or node when configured.",
@@ -590,7 +788,7 @@ func browserSchema() *tool.Schema {
 		"interactive":    boolSchema("Interactive snapshot."),
 		"compact":        boolSchema("Compact snapshot."),
 		"depth":          numberSchema("Snapshot depth."),
-		"selector":       stringSchema("Wait selector."),
+		"selector":       stringSchema(waitDescription),
 		"frame":          stringSchema("Frame id."),
 		"labels":         boolSchema("Include labels."),
 		"fullPage":       boolSchema("Capture full page."),
@@ -634,7 +832,7 @@ func browserSchema() *tool.Schema {
 		"text":        stringSchema("Input text."),
 		"submit":      boolSchema("Submit after typing."),
 		"slowly":      boolSchema("Type slowly."),
-		"key":         stringSchema("Keyboard or state key."),
+		"key":         stringSchema("Keyboard key for press/key or state key."),
 		"delayMs":     numberSchema("Key delay."),
 		"startRef":    stringSchema("Drag start ref."),
 		"endRef":      stringSchema("Drag end ref."),
@@ -650,8 +848,12 @@ func browserSchema() *tool.Schema {
 		"height":    numberSchema("Viewport height."),
 		"timeMs":    numberSchema("Wait duration."),
 		"textGone":  stringSchema("Text that must disappear."),
-		"loadState": stringSchema("Wait load state."),
-		"fn":        stringSchema("Evaluate function."),
+		"direction": stringSchema("Scroll direction: down, up, left, or right."),
+		"deltaX":    numberSchema("Horizontal scroll delta."),
+		"deltaY":    numberSchema("Vertical scroll delta."),
+		"amount":    numberSchema("Scroll amount in pixels."),
+		"loadState": stringSchema(loadStateDescription),
+		"fn":        stringSchema(fnDescription),
 		"request": {
 			Type:       "object",
 			Properties: requestProps,
@@ -663,6 +865,13 @@ func browserSchema() *tool.Schema {
 		Required:   []string{"action"},
 		Properties: properties,
 	}
+}
+
+func evaluateFunctionDescription(evaluateEnabled bool) string {
+	if evaluateEnabled {
+		return "Evaluate function."
+	}
+	return "Evaluate function; evaluate is not available."
 }
 
 func stringSchema(desc string) *tool.Schema {
@@ -811,8 +1020,9 @@ func (t *Tool) handleProfiles(
 		DefaultProfile:  t.defaultProfile,
 		Driver:          ToolName,
 		EvaluateEnabled: t.evaluateEnabled,
-		Supported: supportedActionsForDriver(
+		Supported: visibleActionsForDriver(
 			t.driverTypeForProfile(t.defaultProfile),
+			t.evaluateEnabled,
 		),
 		Profiles: make([]ProfileInfo, 0, len(t.profiles)),
 	}
@@ -825,7 +1035,7 @@ func (t *Tool) handleProfiles(
 			Description: cfg.Description,
 			Default:     name == t.defaultProfile,
 			Driver:      driverType,
-			Supported:   supportedActionsForDriver(driverType),
+			Supported:   visibleActionsForDriver(driverType, t.evaluateEnabled),
 		}
 		drv := t.statusDriver(name, cfg)
 		if drv != nil {
@@ -1927,6 +2137,18 @@ func normalizeActRequest(in input) actRequest {
 		if strings.TrimSpace(req.URL) == "" {
 			req.URL = browserURL(in.URL, in.TargetURL)
 		}
+		if strings.TrimSpace(req.Direction) == "" {
+			req.Direction = in.Direction
+		}
+		if req.DeltaX == nil {
+			req.DeltaX = in.DeltaX
+		}
+		if req.DeltaY == nil {
+			req.DeltaY = in.DeltaY
+		}
+		if req.Amount == nil {
+			req.Amount = in.Amount
+		}
 		req.Kind = defaultActKind(req)
 		return req
 	}
@@ -1960,6 +2182,10 @@ func normalizeActRequest(in input) actRequest {
 		TimeMs:      in.TimeMs,
 		Selector:    in.Selector,
 		URL:         browserURL(in.URL, in.TargetURL),
+		Direction:   in.Direction,
+		DeltaX:      in.DeltaX,
+		DeltaY:      in.DeltaY,
+		Amount:      in.Amount,
 		LoadState:   in.LoadState,
 		TextGone:    in.TextGone,
 		TimeoutMs:   in.TimeoutMs,
@@ -1976,6 +2202,12 @@ func defaultActKind(req actRequest) string {
 	}
 	if browserURL(req.URL, req.TargetURL) != "" {
 		return actionNavigate
+	}
+	if strings.TrimSpace(req.Direction) != "" ||
+		req.DeltaX != nil ||
+		req.DeltaY != nil ||
+		req.Amount != nil {
+		return actScroll
 	}
 	if req.TimeMs != nil ||
 		strings.TrimSpace(req.Text) != "" ||
@@ -2017,7 +2249,7 @@ func (t *Tool) executeAct(
 	req actRequest,
 	driverType string,
 ) (any, error) {
-	kind := strings.ToLower(strings.TrimSpace(req.Kind))
+	kind := normalizeActKind(req.Kind)
 	switch kind {
 	case actClick:
 		args, err := clickArgs(req, driverType)
@@ -2037,13 +2269,7 @@ func (t *Tool) executeAct(
 		addServerTimeoutArg(args, driverType, req.TimeoutMs)
 		return drv.Call(ctx, mcpToolType, args)
 	case actPress:
-		args := map[string]any{
-			"key": strings.TrimSpace(req.Key),
-		}
-		if delay := intValue(req.DelayMs); delay > 0 {
-			args["delayMs"] = delay
-		}
-		return drv.Call(ctx, mcpToolPressKey, args)
+		return pressKey(ctx, drv, strings.TrimSpace(req.Key), req.DelayMs)
 	case actHover:
 		args, err := elementActionArgs(req, driverType)
 		if err != nil {
@@ -2063,6 +2289,8 @@ func (t *Tool) executeAct(
 		}
 		addServerTimeoutArg(args, driverType, req.TimeoutMs)
 		return drv.Call(ctx, mcpToolScroll, args)
+	case actScroll:
+		return t.executeScroll(ctx, drv, req, driverType)
 	case actDrag:
 		args, err := dragArgs(req, driverType)
 		if err != nil {
@@ -2119,6 +2347,123 @@ func (t *Tool) executeAct(
 			req.Kind,
 		)
 	}
+}
+
+func normalizeActKind(kind string) string {
+	normalized := strings.ToLower(strings.TrimSpace(kind))
+	switch normalized {
+	case actKey, "keyboard":
+		return actPress
+	case "scroll_into_view", "scroll-into-view":
+		return strings.ToLower(actScrollIntoView)
+	default:
+		return normalized
+	}
+}
+
+func pressKey(
+	ctx context.Context,
+	drv driver,
+	key string,
+	delayMs *int,
+) (any, error) {
+	if key == "" {
+		return nil, errors.New("browser press requires key")
+	}
+	args := map[string]any{
+		"key": key,
+	}
+	if delay := intValue(delayMs); delay > 0 {
+		args["delayMs"] = delay
+	}
+	return drv.Call(ctx, mcpToolPressKey, args)
+}
+
+func (t *Tool) executeScroll(
+	ctx context.Context,
+	drv driver,
+	req actRequest,
+	driverType string,
+) (any, error) {
+	if driverType == driverTypeBrowserServer &&
+		strings.TrimSpace(req.Ref) != "" {
+		args := map[string]any{"ref": strings.TrimSpace(req.Ref)}
+		addServerTimeoutArg(args, driverType, req.TimeoutMs)
+		return drv.Call(ctx, mcpToolScroll, args)
+	}
+
+	if driverType == driverTypePlaywrightMCP {
+		raw, err := drv.Call(ctx, mcpToolMouseWheel, scrollWheelArgs(req))
+		if err == nil {
+			return raw, nil
+		}
+		if !isBackendToolUnavailable(err, mcpToolMouseWheel) {
+			return nil, err
+		}
+	}
+
+	return pressKey(ctx, drv, scrollFallbackKey(req), req.DelayMs)
+}
+
+func scrollWheelArgs(req actRequest) map[string]any {
+	deltaX, deltaY := scrollDeltas(req)
+	return map[string]any{
+		"deltaX": deltaX,
+		"deltaY": deltaY,
+	}
+}
+
+func scrollDeltas(req actRequest) (int, int) {
+	deltaX := intValue(req.DeltaX)
+	deltaY := intValue(req.DeltaY)
+	if req.DeltaX != nil || req.DeltaY != nil {
+		return deltaX, deltaY
+	}
+
+	amount := intValue(req.Amount)
+	if amount < 0 {
+		amount = -amount
+	}
+	if amount == 0 {
+		amount = defaultScrollDeltaY
+	}
+
+	switch strings.ToLower(strings.TrimSpace(req.Direction)) {
+	case "up":
+		return 0, -amount
+	case "left":
+		return -amount, 0
+	case "right":
+		return amount, 0
+	default:
+		return 0, amount
+	}
+}
+
+func scrollFallbackKey(req actRequest) string {
+	if key := strings.TrimSpace(req.Key); key != "" {
+		return key
+	}
+	switch strings.ToLower(strings.TrimSpace(req.Direction)) {
+	case "up":
+		return "PageUp"
+	case "left":
+		return "ArrowLeft"
+	case "right":
+		return "ArrowRight"
+	default:
+		return "PageDown"
+	}
+}
+
+func isBackendToolUnavailable(err error, toolName string) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(
+		err.Error(),
+		fmt.Sprintf("does not expose tool %q", toolName),
+	)
 }
 
 func clickArgs(req actRequest, driverType string) (map[string]any, error) {

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -13,23 +13,29 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	toolpkg "trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 const testPNG = "image/png"
 
 type fakeDriver struct {
+	mu          sync.Mutex
 	startStatus driverStatus
 	startErr    error
 	status      driverStatus
 	statusErr   error
 	stopErr     error
+	stopCount   int
 	callResult  map[string]any
 	callErr     error
+	callErrs    map[string]error
 	calls       []fakeCall
 }
 
@@ -81,7 +87,18 @@ func (f *fakeDriver) Status(ctx context.Context) (driverStatus, error) {
 	return f.status, nil
 }
 
-func (f *fakeDriver) Stop() error { return f.stopErr }
+func (f *fakeDriver) Stop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopCount++
+	return f.stopErr
+}
+
+func (f *fakeDriver) StopCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stopCount
+}
 
 func (f *fakeDriver) Call(
 	ctx context.Context,
@@ -94,6 +111,9 @@ func (f *fakeDriver) Call(
 	})
 	if f.callErr != nil {
 		return nil, f.callErr
+	}
+	if err, ok := f.callErrs[toolName]; ok {
+		return nil, err
 	}
 	if raw, ok := f.callResult[toolName]; ok {
 		return raw, nil
@@ -584,6 +604,8 @@ func TestToolCall_UsesBrowserServerDriverForHostTarget(t *testing.T) {
 		driverTypeBrowserServer,
 		result.Profiles[0].Driver,
 	)
+	require.NotContains(t, result.Supported, actionEvaluate)
+	require.NotContains(t, result.Profiles[0].Supported, actionEvaluate)
 }
 
 func TestToolCall_StatusActionUsesHandleStatus(t *testing.T) {
@@ -764,15 +786,138 @@ func TestNewTool_DeclarationExposesSchema(t *testing.T) {
 	decl := tool.Declaration()
 	require.Equal(t, ToolName, decl.Name)
 	require.Contains(t, decl.Description, "current browser tab")
+	require.Contains(t, decl.Description, "not for direct inspection")
+	require.Contains(t, decl.Description, "file://, data:, or ad hoc localhost")
+	require.Contains(t, decl.Description, "MEDIA or MEDIA_DIR")
+	require.Contains(t, decl.Description, "evaluate action is disabled")
+	require.NotContains(t, decl.Description, "Use evaluate only")
 	require.Contains(t, decl.Description, "Omit target")
 	require.NotNil(t, decl.InputSchema)
 	require.Equal(t, "object", decl.InputSchema.Type)
 	require.Contains(t, decl.InputSchema.Properties, "action")
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"Supported actions include",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"evaluate is not available",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"pdf",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"backend-dependent",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["fn"].Description,
+		"evaluate is not available",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["fn"].
+			Description,
+		"evaluate is not available",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["kind"].
+			Description,
+		"press/key",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["kind"].
+			Description,
+		"scroll",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["selector"].
+			Description,
+		"Playwright MCP wait supports timeMs",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"act, evaluate",
+	)
 	require.Contains(t, decl.InputSchema.Properties, "request")
 	require.Contains(
 		t,
 		decl.InputSchema.Properties["target"].Description,
 		"only use sandbox or node when configured",
+	)
+}
+
+func TestNewTool_DeclarationUsesDefaultServerProfileActions(t *testing.T) {
+	t.Parallel()
+
+	tool, err := NewTool(Config{
+		Profiles: []ProfileConfig{{
+			Name:             defaultProfileName,
+			BrowserServerURL: "http://127.0.0.1:19790",
+		}},
+	})
+	require.NoError(t, err)
+
+	decl := tool.Declaration()
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"pdf",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"backend-dependent",
+	)
+}
+
+func TestNewTool_DeclarationReflectsEvaluateEnabled(t *testing.T) {
+	t.Parallel()
+
+	evaluateEnabled := true
+	tool, err := NewTool(Config{
+		EvaluateEnabled: &evaluateEnabled,
+		Profiles: []ProfileConfig{{
+			Name:      defaultProfileName,
+			Transport: transportStdio,
+			Command:   "npx",
+		}},
+	})
+	require.NoError(t, err)
+
+	decl := tool.Declaration()
+	require.Contains(t, decl.Description, "Use evaluate only")
+	require.NotContains(t, decl.Description, "evaluate action is disabled")
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"act, evaluate",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["action"].Description,
+		"evaluate is not available",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["fn"].Description,
+		"evaluate is not available",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["fn"].
+			Description,
+		"evaluate is not available",
 	)
 }
 
@@ -855,6 +1000,63 @@ func TestToolCall_StartAndStop(t *testing.T) {
 	stopped := raw.(Result)
 	require.Equal(t, actionStop, stopped.Action)
 	require.Equal(t, stateStopped, stopped.State)
+}
+
+func TestToolCall_CanceledInvocationCleanupStopsUsedDriver(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{}
+	tool := newTestTool(drv)
+	baseCtx, cancel := context.WithCancel(context.Background())
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(baseCtx, inv)
+
+	_, err := tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, drv.StopCount())
+
+	cancel()
+	inv.CleanupNotice(ctx)
+	require.Eventually(t, func() bool {
+		return drv.StopCount() == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestToolCall_SuccessfulInvocationCleanupKeepsUsedDriver(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{}
+	tool := newTestTool(drv)
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	_, err := tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+
+	inv.CleanupNotice(ctx)
+	require.Never(t, func() bool {
+		return drv.StopCount() != 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestToolCloseStopsDrivers(t *testing.T) {
+	t.Parallel()
+
+	profileDriver := &fakeDriver{}
+	serverDriver := &fakeDriver{}
+	tool := newTestTool(profileDriver)
+	tool.serverDrivers["node"] = serverDriver
+
+	require.NoError(t, tool.Close())
+	require.Equal(t, 1, profileDriver.StopCount())
+	require.Equal(t, 1, serverDriver.StopCount())
+	require.Empty(t, tool.serverDrivers)
 }
 
 func TestToolCall_FocusRefreshesTabs(t *testing.T) {
@@ -1324,6 +1526,19 @@ func TestToolCall_ActRoutesLegacyFields(t *testing.T) {
 			},
 		},
 		{
+			name: "key alias",
+			input: map[string]any{
+				"action": actionAct,
+				"kind":   actKey,
+				"key":    "End",
+			},
+			wantTool: mcpToolPressKey,
+			assertArg: func(t *testing.T, call fakeCall) {
+				t.Helper()
+				require.Equal(t, "End", call.Args["key"])
+			},
+		},
+		{
 			name: "hover",
 			input: map[string]any{
 				"action": actionAct,
@@ -1335,6 +1550,21 @@ func TestToolCall_ActRoutesLegacyFields(t *testing.T) {
 				t.Helper()
 				require.Equal(t, "e2", call.Args["target"])
 				require.Equal(t, "element e2", call.Args["element"])
+			},
+		},
+		{
+			name: "scroll",
+			input: map[string]any{
+				"action":    actionAct,
+				"kind":      actScroll,
+				"direction": "up",
+				"amount":    400,
+			},
+			wantTool: mcpToolMouseWheel,
+			assertArg: func(t *testing.T, call fakeCall) {
+				t.Helper()
+				require.Equal(t, 0, call.Args["deltaX"])
+				require.Equal(t, -400, call.Args["deltaY"])
 			},
 		},
 		{
@@ -3058,6 +3288,35 @@ func TestToolCall_ActScrollIntoViewPassesBrowserServerRef(t *testing.T) {
 	require.Equal(t, "e1", drv.calls[0].Args["ref"])
 }
 
+func TestToolCall_ActScrollPassesBrowserServerRef(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolScroll: textPayload("scrolled"),
+		},
+	}
+	tool := newBrowserServerTestTool(drv)
+
+	raw, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action": actionAct,
+			"request": map[string]any{
+				"kind": actScroll,
+				"ref":  "e1",
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	got := raw.(Result)
+	require.Equal(t, actionAct, got.Action)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolScroll, drv.calls[0].Tool)
+	require.Equal(t, "e1", drv.calls[0].Args["ref"])
+}
+
 func TestToolCall_ActScrollIntoViewRejectsMCPDriver(t *testing.T) {
 	t.Parallel()
 
@@ -3073,6 +3332,98 @@ func TestToolCall_ActScrollIntoViewRejectsMCPDriver(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "browser-server")
+}
+
+func TestToolCall_ActScrollUsesDefaultWheelDelta(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolMouseWheel: textPayload("scrolled"),
+		},
+	}
+
+	raw, err := newTestTool(drv).Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action": actionAct,
+			"request": map[string]any{
+				"kind": actScroll,
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	got := raw.(Result)
+	require.Equal(t, actionAct, got.Action)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolMouseWheel, drv.calls[0].Tool)
+	require.Equal(t, 0, drv.calls[0].Args["deltaX"])
+	require.Equal(t, defaultScrollDeltaY, drv.calls[0].Args["deltaY"])
+}
+
+func TestToolCall_ActScrollDefaultsKindFromDelta(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolMouseWheel: textPayload("scrolled"),
+		},
+	}
+
+	raw, err := newTestTool(drv).Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action": actionAct,
+			"request": map[string]any{
+				"deltaX": 12,
+				"deltaY": -24,
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	got := raw.(Result)
+	require.Equal(t, actionAct, got.Action)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolMouseWheel, drv.calls[0].Tool)
+	require.Equal(t, 12, drv.calls[0].Args["deltaX"])
+	require.Equal(t, -24, drv.calls[0].Args["deltaY"])
+}
+
+func TestToolCall_ActScrollFallsBackToPressKey(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callErrs: map[string]error{
+			mcpToolMouseWheel: fmt.Errorf(
+				"browser backend does not expose tool %q",
+				mcpToolMouseWheel,
+			),
+		},
+		callResult: map[string]any{
+			mcpToolPressKey: textPayload("pressed"),
+		},
+	}
+
+	raw, err := newTestTool(drv).Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action": actionAct,
+			"request": map[string]any{
+				"kind":      actScroll,
+				"direction": "up",
+			},
+		}),
+	)
+	require.NoError(t, err)
+
+	got := raw.(Result)
+	require.Equal(t, actionAct, got.Action)
+	require.Len(t, drv.calls, 2)
+	require.Equal(t, mcpToolMouseWheel, drv.calls[0].Tool)
+	require.Equal(t, mcpToolPressKey, drv.calls[1].Tool)
+	require.Equal(t, "PageUp", drv.calls[1].Args["key"])
 }
 
 func TestToolCall_ActPressPassesDelayMS(t *testing.T) {

--- a/openclaw/internal/deps/catalog.go
+++ b/openclaw/internal/deps/catalog.go
@@ -23,6 +23,7 @@ const (
 	ProfileVideo           = "video"
 	ProfileImage           = "image"
 	ProfileOCR             = "ocr"
+	ProfileChess           = "chess"
 	ProfileCommonFileTools = "common-file-tools"
 )
 
@@ -53,22 +54,29 @@ type Requirement struct {
 	Python  []PythonPackage `yaml:"python,omitempty" json:"python,omitempty"`
 }
 
+type InstallLink struct {
+	Source string `yaml:"source,omitempty" json:"source,omitempty"`
+	Target string `yaml:"target,omitempty" json:"target,omitempty"`
+}
+
 type InstallAction struct {
-	ID              string   `yaml:"id,omitempty" json:"id,omitempty"`
-	Kind            string   `yaml:"kind,omitempty" json:"kind,omitempty"`
-	Formula         string   `yaml:"formula,omitempty" json:"formula,omitempty"`
-	Package         string   `yaml:"package,omitempty" json:"package,omitempty"`
-	Packages        []string `yaml:"packages,omitempty" json:"packages,omitempty"`
-	Bins            []string `yaml:"bins,omitempty" json:"bins,omitempty"`
-	Label           string   `yaml:"label,omitempty" json:"label,omitempty"`
-	Tap             string   `yaml:"tap,omitempty" json:"tap,omitempty"`
-	Module          string   `yaml:"module,omitempty" json:"module,omitempty"`
-	URL             string   `yaml:"url,omitempty" json:"url,omitempty"`
-	Archive         string   `yaml:"archive,omitempty" json:"archive,omitempty"`
-	TargetDir       string   `yaml:"targetDir,omitempty" json:"target_dir,omitempty"`
-	OS              []string `yaml:"os,omitempty" json:"os,omitempty"`
-	Extract         bool     `yaml:"extract,omitempty" json:"extract,omitempty"`
-	StripComponents int      `yaml:"stripComponents,omitempty" json:"strip_components,omitempty"`
+	ID              string        `yaml:"id,omitempty" json:"id,omitempty"`
+	Kind            string        `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Formula         string        `yaml:"formula,omitempty" json:"formula,omitempty"`
+	Package         string        `yaml:"package,omitempty" json:"package,omitempty"`
+	Packages        []string      `yaml:"packages,omitempty" json:"packages,omitempty"`
+	Bins            []string      `yaml:"bins,omitempty" json:"bins,omitempty"`
+	Label           string        `yaml:"label,omitempty" json:"label,omitempty"`
+	Tap             string        `yaml:"tap,omitempty" json:"tap,omitempty"`
+	Module          string        `yaml:"module,omitempty" json:"module,omitempty"`
+	URL             string        `yaml:"url,omitempty" json:"url,omitempty"`
+	Archive         string        `yaml:"archive,omitempty" json:"archive,omitempty"`
+	TargetDir       string        `yaml:"targetDir,omitempty" json:"target_dir,omitempty"`
+	OS              []string      `yaml:"os,omitempty" json:"os,omitempty"`
+	Arch            []string      `yaml:"arch,omitempty" json:"arch,omitempty"`
+	Links           []InstallLink `yaml:"links,omitempty" json:"links,omitempty"`
+	Extract         bool          `yaml:"extract,omitempty" json:"extract,omitempty"`
+	StripComponents int           `yaml:"stripComponents,omitempty" json:"strip_components,omitempty"`
 }
 
 type Source struct {
@@ -285,6 +293,45 @@ var builtinProfiles = map[string]Profile{
 			),
 		},
 	},
+	ProfileChess: {
+		Name:        ProfileChess,
+		Description: "Chess-board analysis and UCI engine helpers.",
+		Requires: Requirement{
+			Bins: []string{"stockfish"},
+			Python: []PythonPackage{
+				{Module: "chess", Package: "python-chess"},
+				{Module: "PIL", Package: "Pillow"},
+				{Module: "numpy", Package: "numpy"},
+				{Module: "scipy", Package: "scipy"},
+			},
+		},
+		Install: []InstallAction{
+			systemInstall(
+				InstallKindBrew,
+				"stockfish",
+				"Install Stockfish engine (brew)",
+				"stockfish",
+			),
+			systemInstall(
+				InstallKindAPT,
+				"stockfish",
+				"Install Stockfish engine (apt)",
+				"stockfish",
+			),
+			systemInstall(
+				InstallKindDNF,
+				"stockfish",
+				"Install Stockfish engine (dnf)",
+				"stockfish",
+			),
+			systemInstall(
+				InstallKindYUM,
+				"stockfish",
+				"Install Stockfish engine (yum)",
+				"stockfish",
+			),
+		},
+	},
 	ProfileCommonFileTools: {
 		Name:        ProfileCommonFileTools,
 		Description: "Recommended default toolchain for common file work.",
@@ -488,7 +535,7 @@ func normalizeInstallActions(
 	actions []InstallAction,
 ) []InstallAction {
 	out := make([]InstallAction, 0, len(actions))
-	seen := map[string]struct{}{}
+	index := map[string]int{}
 	for _, raw := range actions {
 		action := InstallAction{
 			ID:              strings.TrimSpace(raw.ID),
@@ -504,6 +551,8 @@ func normalizeInstallActions(
 			Archive:         strings.ToLower(strings.TrimSpace(raw.Archive)),
 			TargetDir:       strings.TrimSpace(raw.TargetDir),
 			OS:              normalizeOSList(raw.OS),
+			Arch:            normalizeArchList(raw.Arch),
+			Links:           normalizeInstallLinks(raw.Links),
 			Extract:         raw.Extract,
 			StripComponents: raw.StripComponents,
 		}
@@ -513,28 +562,77 @@ func normalizeInstallActions(
 		if action.StripComponents < 0 {
 			action.StripComponents = 0
 		}
-		key := strings.Join([]string{
-			action.Kind,
-			action.ID,
-			action.Formula,
-			action.Package,
-			action.Tap,
-			action.Module,
-			action.URL,
-			action.Archive,
-			action.TargetDir,
-			strings.Join(action.OS, ","),
-			fmt.Sprintf("%t", action.Extract),
-			fmt.Sprintf("%d", action.StripComponents),
-			strings.Join(action.Packages, ","),
-		}, "\x00")
+		key := installActionIdentityKey(action)
+		if i, ok := index[key]; ok {
+			out[i].Bins = mergeStrings(out[i].Bins, action.Bins)
+			out[i].Links = mergeInstallLinks(out[i].Links, action.Links)
+			continue
+		}
+		index[key] = len(out)
+		out = append(out, action)
+	}
+	return out
+}
+
+func installActionIdentityKey(action InstallAction) string {
+	return strings.Join([]string{
+		action.Kind,
+		action.ID,
+		action.Formula,
+		action.Package,
+		action.Tap,
+		action.Module,
+		action.URL,
+		action.Archive,
+		action.TargetDir,
+		strings.Join(action.OS, ","),
+		strings.Join(action.Arch, ","),
+		fmt.Sprintf("%t", action.Extract),
+		fmt.Sprintf("%d", action.StripComponents),
+		strings.Join(action.Packages, ","),
+	}, "\x00")
+}
+
+func normalizeInstallLinks(links []InstallLink) []InstallLink {
+	out := make([]InstallLink, 0, len(links))
+	seen := map[string]struct{}{}
+	for _, raw := range links {
+		link := InstallLink{
+			Source: strings.TrimSpace(raw.Source),
+			Target: strings.TrimSpace(raw.Target),
+		}
+		if link.Source == "" {
+			continue
+		}
+		key := link.Source + "\x00" + link.Target
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		out = append(out, action)
+		out = append(out, link)
 	}
 	return out
+}
+
+func mergeInstallLinks(
+	left []InstallLink,
+	right []InstallLink,
+) []InstallLink {
+	links := append([]InstallLink(nil), left...)
+	links = append(links, right...)
+	return normalizeInstallLinks(links)
+}
+
+func installLinksKey(links []InstallLink) string {
+	parts := make([]string, 0, len(links))
+	for _, link := range links {
+		parts = append(parts, link.Source+"\x00"+link.Target)
+	}
+	return strings.Join(parts, "\x01")
+}
+
+func mergeStrings(left []string, right []string) []string {
+	return normalizeStrings(append(append([]string(nil), left...), right...))
 }
 
 func normalizeStrings(values []string) []string {
@@ -569,6 +667,35 @@ func normalizeOSList(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func normalizeArchList(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, raw := range values {
+		value := normalizeArchName(raw)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizeArchName(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "x86_64":
+		return "amd64"
+	case "aarch64":
+		return "arm64"
+	default:
+		return value
+	}
 }
 
 func normalizeOSName(raw string) string {

--- a/openclaw/internal/deps/catalog_test.go
+++ b/openclaw/internal/deps/catalog_test.go
@@ -33,6 +33,7 @@ func TestResolveProfiles_ExpandsAggregate(t *testing.T) {
 		ProfileImage,
 		ProfileOCR,
 	}, names)
+	require.NotContains(t, names, ProfileChess)
 }
 
 func TestSourcesForProfiles_NormalizesInstallMetadata(t *testing.T) {
@@ -44,6 +45,28 @@ func TestSourcesForProfiles_NormalizesInstallMetadata(t *testing.T) {
 	require.Equal(t, ProfilePDF, sources[0].Name)
 	require.NotEmpty(t, sources[0].Install)
 	require.Equal(t, "pypdf", sources[0].Requires.Python[0].Module)
+}
+
+func TestSourcesForProfiles_ChessProfile(t *testing.T) {
+	t.Parallel()
+
+	sources, err := SourcesForProfiles([]string{ProfileChess})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	require.Equal(t, ProfileChess, sources[0].Name)
+	require.Equal(t, []string{"stockfish"}, sources[0].Requires.Bins)
+	require.Contains(t, sources[0].Requires.Python, PythonPackage{
+		Module:  "chess",
+		Package: "python-chess",
+	})
+	require.NotEmpty(t, sources[0].Install)
+	action := sources[0].Install[0]
+	require.Equal(t, InstallKindBrew, action.Kind)
+	require.Equal(t, []string{"stockfish"}, action.Bins)
+	require.True(
+		t,
+		containsInstallActionKind(sources[0].Install, InstallKindDNF),
+	)
 }
 
 func TestCatalogHelpers(t *testing.T) {
@@ -73,20 +96,60 @@ func TestNormalizeInstallActions_NormalizesPlatformFields(t *testing.T) {
 	t.Parallel()
 
 	actions := normalizeInstallActions([]InstallAction{{
-		Kind:            "DOWNLOAD",
-		URL:             " https://example.com/a.zip ",
-		Archive:         "TGZ",
-		TargetDir:       " runtime ",
-		OS:              []string{" Linux ", "win32", "linux", ""},
+		Kind:      "DOWNLOAD",
+		URL:       " https://example.com/a.zip ",
+		Archive:   "TGZ",
+		TargetDir: " runtime ",
+		OS:        []string{" Linux ", "win32", "linux", ""},
+		Arch:      []string{" x86_64 ", "amd64", "aarch64", ""},
+		Links: []InstallLink{{
+			Source: " bin/tool ",
+			Target: " tool ",
+		}, {
+			Source: "bin/tool",
+			Target: "tool",
+		}},
 		Extract:         true,
 		StripComponents: -2,
+	}, {
+		Kind:      "DOWNLOAD",
+		URL:       " https://example.com/a.zip ",
+		Archive:   "TGZ",
+		TargetDir: " runtime ",
+		OS:        []string{"linux", "win32"},
+		Arch:      []string{"amd64", "aarch64"},
+		Bins:      []string{" second-bin "},
+		Links: []InstallLink{{
+			Source: " bin/second ",
+			Target: " second ",
+		}},
+		Extract: true,
 	}})
 	require.Len(t, actions, 1)
 	require.Equal(t, InstallKindDownload, actions[0].Kind)
 	require.Equal(t, "tgz", actions[0].Archive)
 	require.Equal(t, "runtime", actions[0].TargetDir)
 	require.Equal(t, []string{"linux", "windows"}, actions[0].OS)
+	require.Equal(t, []string{"amd64", "arm64"}, actions[0].Arch)
+	require.Equal(t, []string{"second-bin"}, actions[0].Bins)
+	require.Equal(t, []InstallLink{{
+		Source: "bin/tool",
+		Target: "tool",
+	}, {
+		Source: "bin/second",
+		Target: "second",
+	}}, actions[0].Links)
 	require.True(t, actions[0].Extract)
 	require.Equal(t, 0, actions[0].StripComponents)
 	require.Equal(t, "windows", normalizeOSName("win32"))
+	require.Equal(t, "amd64", normalizeArchName("x86_64"))
+}
+
+func containsInstallActionKind(actions []InstallAction, kind string) bool {
+	for _, action := range actions {
+		if action.Kind == kind {
+			return true
+		}
+	}
+	return false
 }

--- a/openclaw/internal/deps/download.go
+++ b/openclaw/internal/deps/download.go
@@ -15,6 +15,7 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -53,6 +55,10 @@ func downloadInstallStep(
 	if err != nil {
 		return Step{}, err
 	}
+	links, err := downloadStepLinks(toolchain, targetPath, action)
+	if err != nil {
+		return Step{}, err
+	}
 
 	return Step{
 		Label:           actionLabel(action, "Download tool assets"),
@@ -61,6 +67,7 @@ func downloadInstallStep(
 		URL:             rawURL,
 		TargetPath:      targetPath,
 		Archive:         action.Archive,
+		Links:           links,
 		Extract:         action.Extract,
 		StripComponents: action.StripComponents,
 	}, nil
@@ -88,7 +95,10 @@ func executeDownloadStep(
 		); err != nil {
 			return "", err
 		}
-		return "downloaded to " + step.TargetPath, nil
+		if err := installDownloadLinks(step.Links); err != nil {
+			return "", err
+		}
+		return downloadResultText(step.TargetPath, step.Links), nil
 	}
 
 	if err := os.MkdirAll(filepath.Dir(step.TargetPath), 0o755); err != nil {
@@ -97,7 +107,10 @@ func executeDownloadStep(
 	if err := writeDownloadFile(step.TargetPath, reader); err != nil {
 		return "", err
 	}
-	return "downloaded to " + step.TargetPath, nil
+	if err := installDownloadLinks(step.Links); err != nil {
+		return "", err
+	}
+	return downloadResultText(step.TargetPath, step.Links), nil
 }
 
 func writeDownloadFile(
@@ -195,6 +208,53 @@ func downloadCommandLine(
 	return "download " + shellQuote(rawURL) + " -> " + shellQuote(targetPath)
 }
 
+func downloadStepLinks(
+	toolchain Toolchain,
+	targetPath string,
+	action InstallAction,
+) ([]InstallLink, error) {
+	links := normalizeInstallLinks(action.Links)
+	if len(links) == 0 {
+		return nil, nil
+	}
+
+	binDir := ManagedBinDir(toolchain.StateDir)
+	if strings.TrimSpace(binDir) == "" {
+		return nil, fmt.Errorf(
+			"download install action %q cannot link binaries without state dir",
+			action.Label,
+		)
+	}
+	out := make([]InstallLink, 0, len(links))
+	for _, link := range links {
+		source, err := safeJoin(targetPath, link.Source)
+		if err != nil {
+			return nil, err
+		}
+		targetName := link.Target
+		if strings.TrimSpace(targetName) == "" {
+			targetName = filepath.Base(link.Source)
+		}
+		target, err := safeJoin(binDir, targetName)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, InstallLink{
+			Source: source,
+			Target: target,
+		})
+	}
+	return out, nil
+}
+
+func downloadResultText(targetPath string, links []InstallLink) string {
+	text := "downloaded to " + targetPath
+	if len(links) > 0 {
+		text += fmt.Sprintf("; linked %d binaries", len(links))
+	}
+	return text
+}
+
 func downloadFileName(rawURL string) string {
 	parsed, err := neturl.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
@@ -264,6 +324,8 @@ func extractArchive(
 	stripComponents int,
 ) error {
 	switch normalizeArchiveKind(archiveKind) {
+	case "tar":
+		return extractTar(reader, targetPath, stripComponents)
 	case "tar.gz":
 		gz, err := gzip.NewReader(reader)
 		if err != nil {
@@ -282,6 +344,72 @@ func extractArchive(
 	default:
 		return fmt.Errorf("unsupported archive kind %q", archiveKind)
 	}
+}
+
+func installDownloadLinks(links []InstallLink) error {
+	for _, link := range links {
+		source := strings.TrimSpace(link.Source)
+		target := strings.TrimSpace(link.Target)
+		if source == "" || target == "" {
+			continue
+		}
+		if err := installDownloadLink(source, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func installDownloadLink(source string, target string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("download link source %q is a symlink", source)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("download link source %q is a directory", source)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	_ = os.Remove(target)
+	if runtime.GOOS != "windows" {
+		if err := os.Symlink(source, target); err == nil {
+			return nil
+		}
+	}
+	return copyDownloadLink(source, target, info.Mode().Perm())
+}
+
+func copyDownloadLink(
+	source string,
+	target string,
+	perm os.FileMode,
+) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if perm == 0 {
+		perm = 0o755
+	}
+	out, err := os.OpenFile(
+		target,
+		os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
+		perm|0o111,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func normalizeArchiveKind(raw string) string {
@@ -381,6 +509,9 @@ func archiveTargetName(
 	if cleaned == "." || cleaned == "" {
 		return "", false
 	}
+	if path.IsAbs(cleaned) {
+		return "", false
+	}
 	parts := strings.Split(cleaned, "/")
 	if stripComponents >= len(parts) {
 		return "", false
@@ -401,6 +532,12 @@ func writeArchiveEntry(
 	mode os.FileMode,
 	reader io.Reader,
 ) error {
+	if !mode.IsRegular() && !mode.IsDir() {
+		return fmt.Errorf("unsupported archive entry mode %s for %q", mode, dst)
+	}
+	if err := rejectExistingSymlink(dst); err != nil {
+		return err
+	}
 	if mode.IsDir() {
 		return os.MkdirAll(dst, 0o755)
 	}
@@ -419,6 +556,20 @@ func writeArchiveEntry(
 
 	_, err = io.Copy(file, reader)
 	return err
+}
+
+func rejectExistingSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write through symlink %q", path)
+	}
+	return nil
 }
 
 func archiveEntryPerm(mode os.FileMode) os.FileMode {

--- a/openclaw/internal/deps/download_test.go
+++ b/openclaw/internal/deps/download_test.go
@@ -10,6 +10,7 @@
 package deps
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
 	"context"
@@ -19,6 +20,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -144,6 +146,89 @@ func TestExtractZip_StripsComponents(t *testing.T) {
 	name, ok := archiveTargetName("pkg/bin/tool", 3)
 	require.False(t, ok)
 	require.Empty(t, name)
+}
+
+func TestExtractTar_StripsComponents(t *testing.T) {
+	t.Parallel()
+
+	var archive bytes.Buffer
+	writer := tar.NewWriter(&archive)
+	require.NoError(t, writer.WriteHeader(&tar.Header{
+		Name: "pkg/bin/tool",
+		Mode: 0o755,
+		Size: int64(len("hello")),
+	}))
+	_, err := writer.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	target := t.TempDir()
+	err = extractArchive(bytes.NewReader(archive.Bytes()), "tar", target, 1)
+	require.NoError(t, err)
+	data, readErr := os.ReadFile(filepath.Join(target, "bin", "tool"))
+	require.NoError(t, readErr)
+	require.Equal(t, "hello", string(data))
+}
+
+func TestArchiveHelpers_RejectsUnsafeNamesAndSymlinks(t *testing.T) {
+	t.Parallel()
+
+	name, ok := archiveTargetName("/absolute/path", 0)
+	require.False(t, ok)
+	require.Empty(t, name)
+
+	name, ok = archiveTargetName("../escape", 0)
+	require.False(t, ok)
+	require.Empty(t, name)
+
+	var archive bytes.Buffer
+	writer := tar.NewWriter(&archive)
+	require.NoError(t, writer.WriteHeader(&tar.Header{
+		Name:     "pkg/bin/link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/etc/passwd",
+		Mode:     0o777,
+	}))
+	require.NoError(t, writer.Close())
+
+	err := extractArchive(
+		bytes.NewReader(archive.Bytes()),
+		"tar",
+		t.TempDir(),
+		1,
+	)
+	require.ErrorContains(t, err, "unsupported archive entry mode")
+}
+
+func TestWriteArchiveEntry_RejectsExistingSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	link := filepath.Join(root, "link")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o644))
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	err := writeArchiveEntry(link, 0o644, strings.NewReader("new"))
+	require.ErrorContains(t, err, "symlink")
+}
+
+func TestInstallDownloadLink_RejectsSymlinkSource(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	link := filepath.Join(root, "source-link")
+	target := filepath.Join(root, "bin", "tool")
+	require.NoError(t, os.WriteFile(source, []byte("tool"), 0o755))
+	if err := os.Symlink(source, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	err := installDownloadLink(link, target)
+	require.ErrorContains(t, err, "symlink")
 }
 
 func TestArchiveHelpers(t *testing.T) {

--- a/openclaw/internal/deps/install.go
+++ b/openclaw/internal/deps/install.go
@@ -52,6 +52,7 @@ type Step struct {
 	URL             string            `json:"url,omitempty"`
 	TargetPath      string            `json:"target_path,omitempty"`
 	Archive         string            `json:"archive,omitempty"`
+	Links           []InstallLink     `json:"links,omitempty"`
 	Extract         bool              `json:"extract,omitempty"`
 	StripComponents int               `json:"strip_components,omitempty"`
 }
@@ -233,6 +234,7 @@ func collectSystemPackages(
 	}
 	platform := Platform{
 		GOOS:           runtime.GOOS,
+		GOARCH:         runtime.GOARCH,
 		PackageManager: manager,
 	}
 
@@ -350,7 +352,7 @@ func selectInstallActionsForMissing(
 	satisfiedGroups := map[string]struct{}{}
 	for _, source := range sources {
 		for _, action := range normalizeInstallActions(source.Install) {
-			if !actionMatchesPlatform(action, platform.GOOS) {
+			if !actionMatchesPlanPlatform(action, platform) {
 				continue
 			}
 			if !include(action) {
@@ -453,16 +455,50 @@ func anyBinGroupKey(group []string) string {
 	return strings.Join(group, "\x00")
 }
 
-func actionMatchesPlatform(
+func actionMatchesPlatform(action InstallAction, goos string) bool {
+	return actionMatchesPlatformArch(action, goos, runtime.GOARCH)
+}
+
+func actionMatchesPlanPlatform(
+	action InstallAction,
+	platform Platform,
+) bool {
+	goos := platform.GOOS
+	if strings.TrimSpace(goos) == "" {
+		goos = runtime.GOOS
+	}
+	goarch := platform.GOARCH
+	if strings.TrimSpace(goarch) == "" {
+		goarch = runtime.GOARCH
+	}
+	return actionMatchesPlatformArch(action, goos, goarch)
+}
+
+func actionMatchesPlatformArch(
 	action InstallAction,
 	goos string,
+	goarch string,
 ) bool {
-	if len(action.OS) == 0 {
+	if len(action.OS) > 0 {
+		goos = normalizeOSName(goos)
+		osMatched := false
+		for _, allowed := range action.OS {
+			if normalizeOSName(allowed) == goos {
+				osMatched = true
+				break
+			}
+		}
+		if !osMatched {
+			return false
+		}
+	}
+
+	if len(action.Arch) == 0 {
 		return true
 	}
-	goos = normalizeOSName(goos)
-	for _, allowed := range action.OS {
-		if normalizeOSName(allowed) == goos {
+	goarch = normalizeArchName(goarch)
+	for _, allowed := range action.Arch {
+		if normalizeArchName(allowed) == goarch {
 			return true
 		}
 	}
@@ -480,8 +516,9 @@ func installActionKey(action InstallAction) string {
 		action.Archive,
 		action.TargetDir,
 		strings.Join(action.Packages, ","),
-		strings.Join(action.Bins, ","),
 		strings.Join(action.OS, ","),
+		strings.Join(action.Arch, ","),
+		installLinksKey(action.Links),
 	}, "\x00")
 }
 
@@ -646,7 +683,7 @@ func isActionCoveredByPlanner(
 	platform Platform,
 	action InstallAction,
 ) bool {
-	if !actionMatchesPlatform(action, platform.GOOS) {
+	if !actionMatchesPlanPlatform(action, platform) {
 		return false
 	}
 
@@ -884,6 +921,15 @@ func ensureStepWorkingDirs(
 		target := strings.TrimSpace(step.TargetPath)
 		if target == "" {
 			return fmt.Errorf("download step %q has empty target", step.Label)
+		}
+		for _, link := range step.Links {
+			linkTarget := strings.TrimSpace(link.Target)
+			if linkTarget == "" {
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(linkTarget), 0o755); err != nil {
+				return err
+			}
 		}
 		if step.Extract {
 			return os.MkdirAll(target, 0o755)

--- a/openclaw/internal/deps/install_test.go
+++ b/openclaw/internal/deps/install_test.go
@@ -212,6 +212,16 @@ func TestActionMatchesPlatform(t *testing.T) {
 		InstallAction{OS: []string{"darwin"}},
 		"linux",
 	))
+	require.True(t, actionMatchesPlatformArch(
+		InstallAction{OS: []string{"linux"}, Arch: []string{"x86_64"}},
+		"linux",
+		"amd64",
+	))
+	require.False(t, actionMatchesPlatformArch(
+		InstallAction{OS: []string{"linux"}, Arch: []string{"arm64"}},
+		"linux",
+		"amd64",
+	))
 }
 
 func TestSelectInstallActionsForMissing(t *testing.T) {
@@ -325,6 +335,49 @@ func TestBuildPlanForSources_DownloadActionWithoutBins(t *testing.T) {
 		),
 		plan.Steps[0].TargetPath,
 	)
+}
+
+func TestBuildPlanForSources_DownloadActionLinksBins(t *testing.T) {
+	t.Parallel()
+
+	plan, err := BuildPlanForSources(
+		t.TempDir(),
+		[]string{"engine"},
+		[]Source{{
+			Name: "engine",
+			Requires: Requirement{
+				Bins: []string{"engine"},
+			},
+			Install: []InstallAction{{
+				Kind:      InstallKindDownload,
+				URL:       "https://example.com/engine.tar",
+				Archive:   "tar",
+				Extract:   true,
+				TargetDir: "engine",
+				Bins:      []string{"engine"},
+				Links: []InstallLink{{
+					Source: "bin/engine-linux",
+					Target: "engine",
+				}},
+			}},
+		}},
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Steps, 1)
+	step := plan.Steps[0]
+	require.Equal(t, stepKindDownload, step.Kind)
+	require.Len(t, step.Links, 1)
+	require.Equal(
+		t,
+		filepath.Join(step.TargetPath, "bin", "engine-linux"),
+		step.Links[0].Source,
+	)
+	require.Equal(
+		t,
+		filepath.Join(ManagedBinDir(plan.Toolchain.StateDir), "engine"),
+		step.Links[0].Target,
+	)
+	require.Empty(t, plan.Unresolved.Bins)
 }
 
 func TestBuildPlan_ResolvesBuiltinProfiles(t *testing.T) {
@@ -445,7 +498,7 @@ func TestApplyPlan_RejectsRootOnlyStep(t *testing.T) {
 	require.Contains(t, result.Steps[0].Error, "requires root privileges")
 }
 
-func TestApplyPlan_DownloadStepExtractsArchive(t *testing.T) {
+func TestApplyPlan_DownloadStepExtractsArchiveAndLinksBin(t *testing.T) {
 	t.Parallel()
 
 	archivePath := filepath.Join(t.TempDir(), "runtime.tar.gz")
@@ -458,13 +511,20 @@ func TestApplyPlan_DownloadStepExtractsArchive(t *testing.T) {
 	)
 
 	target := filepath.Join(t.TempDir(), "out")
+	stateDir := t.TempDir()
+	binLink := filepath.Join(ManagedBinDir(stateDir), "tool")
 	result, err := ApplyPlan(context.Background(), Plan{
+		Toolchain: Toolchain{StateDir: stateDir},
 		Steps: []Step{{
-			Label:           "download runtime",
-			Kind:            stepKindDownload,
-			URL:             "file://" + archivePath,
-			TargetPath:      target,
-			Archive:         "tar.gz",
+			Label:      "download runtime",
+			Kind:       stepKindDownload,
+			URL:        "file://" + archivePath,
+			TargetPath: target,
+			Archive:    "tar.gz",
+			Links: []InstallLink{{
+				Source: filepath.Join(target, "bin", "tool"),
+				Target: binLink,
+			}},
 			Extract:         true,
 			StripComponents: 1,
 		}},
@@ -476,6 +536,10 @@ func TestApplyPlan_DownloadStepExtractsArchive(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(target, "bin", "tool"))
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(data))
+
+	info, err := os.Stat(binLink)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
 }
 
 func TestInstallHelpers(t *testing.T) {

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -43,12 +44,13 @@ type Manager struct {
 	mu       sync.Mutex
 	sessions map[string]*session
 
-	maxLines int
-	jobTTL   time.Duration
-	timeout  time.Duration
-	baseEnv  map[string]string
-	policy   CommandPolicy
-	redactor OutputRedactor
+	maxLines             int
+	jobTTL               time.Duration
+	timeout              time.Duration
+	baseEnv              map[string]string
+	policy               CommandPolicy
+	redactor             OutputRedactor
+	maxResultOutputChars int
 
 	clock func() time.Time
 
@@ -99,6 +101,16 @@ func WithCommandPolicy(policy CommandPolicy) Option {
 func WithOutputRedactor(redactor OutputRedactor) Option {
 	return func(m *Manager) {
 		m.redactor = redactor
+	}
+}
+
+// WithMaxResultOutputChars limits one-shot command output returned to the
+// model. Non-positive values preserve the legacy unlimited behavior.
+func WithMaxResultOutputChars(n int) Option {
+	return func(m *Manager) {
+		if n > 0 {
+			m.maxResultOutputChars = n
+		}
 	}
 }
 
@@ -186,6 +198,7 @@ func (m *Manager) Exec(
 			return execResult{}, err
 		}
 		out = applyOutputRedactor(redact, out)
+		out = m.limitResultOutput(out)
 		return execResult{
 			Status:   "exited",
 			Output:   out,
@@ -215,6 +228,7 @@ func (m *Manager) Exec(
 		}
 		out, code := sess.allOutput()
 		_ = m.clearFinished(sess.id)
+		out = m.limitResultOutput(out)
 		return execResult{
 			Status:   "exited",
 			Output:   out,
@@ -233,6 +247,7 @@ func (m *Manager) Exec(
 	case <-sess.doneCh:
 		out, code := sess.allOutput()
 		_ = m.clearFinished(sess.id)
+		out = m.limitResultOutput(out)
 		return execResult{
 			Status:   "exited",
 			Output:   out,
@@ -495,6 +510,45 @@ func applyOutputRedactor(
 		return output
 	}
 	return redact(output)
+}
+
+func (m *Manager) limitResultOutput(output string) string {
+	if m == nil || m.maxResultOutputChars <= 0 {
+		return output
+	}
+	return truncateResultOutput(output, m.maxResultOutputChars)
+}
+
+func truncateResultOutput(output string, maxChars int) string {
+	if maxChars <= 0 {
+		return output
+	}
+	output = strings.ToValidUTF8(output, "\uFFFD")
+	charCount := utf8.RuneCountInString(output)
+	if charCount <= maxChars {
+		return output
+	}
+	return firstRunes(output, maxChars) + fmt.Sprintf(
+		"\n\n[OpenClaw truncated command output to %d of %d chars. "+
+			"Write large outputs to a file and read only the needed "+
+			"chunks with file tools or shell commands.]",
+		maxChars,
+		charCount,
+	)
+}
+
+func firstRunes(value string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	count := 0
+	for idx := range value {
+		if count == n {
+			return value[:idx]
+		}
+		count++
+	}
+	return value
 }
 
 func currentProcessEnvMap() map[string]string {

--- a/openclaw/internal/octool/policy.go
+++ b/openclaw/internal/octool/policy.go
@@ -22,6 +22,8 @@ const (
 
 	reasonSensitivePath = "reading or modifying shell or " +
 		"credential files is not allowed in chat"
+	reasonSystemPackageInstall = "installing system packages with " +
+		"host package managers is not allowed in chat"
 
 	sensitivePathBoundaryChars = " \t\r\n\"'`=:/\\|&;()[]{}<>"
 
@@ -79,6 +81,12 @@ func NewChatCommandSafetyPolicy() CommandPolicy {
 				reasonSensitivePath,
 			)
 		}
+		if blocksSystemPackageInstall(req.Command) {
+			return fmt.Errorf(
+				errCommandPolicyRejected,
+				reasonSystemPackageInstall,
+			)
+		}
 		return nil
 	}
 }
@@ -100,6 +108,159 @@ func blocksSensitivePath(command string) bool {
 		normalizePolicyCommand(command),
 		protectedPathFragments,
 	)
+}
+
+func blocksSystemPackageInstall(command string) bool {
+	return blocksSystemPackageInstallDepth(normalizePolicyCommand(command), 0)
+}
+
+func blocksSystemPackageInstallDepth(command string, depth int) bool {
+	if command == "" || depth > 2 {
+		return false
+	}
+	words := shellPolicyWords(command)
+	if blocksSystemPackageInstallWords(words) {
+		return true
+	}
+	for i := 0; i < len(words); i++ {
+		if !isShellExecutable(policyCommandName(words[i])) {
+			continue
+		}
+		cmdArg, ok := shellCommandStringArg(words[i+1:])
+		if ok && blocksSystemPackageInstallDepth(cmdArg, depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
+func blocksSystemPackageInstallWords(words []string) bool {
+	for i, word := range words {
+		cmd := policyCommandName(word)
+		switch cmd {
+		case "apt", "apt-get", "aptitude":
+			if nextPolicyWord(words, i+1) == "install" {
+				return true
+			}
+		case "yum", "dnf", "microdnf", "zypper", "brew":
+			if nextPolicyWord(words, i+1) == "install" {
+				return true
+			}
+		case "apk":
+			if nextPolicyWord(words, i+1) == "add" {
+				return true
+			}
+		case "pacman":
+			next := nextPolicyWord(words, i+1)
+			if next == "--sync" || strings.HasPrefix(next, "-s") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func shellPolicyWords(command string) []string {
+	words := make([]string, 0, 8)
+	var b strings.Builder
+	var quote rune
+	flush := func() {
+		word := strings.TrimSpace(b.String())
+		if word != "" {
+			words = append(words, word)
+		}
+		b.Reset()
+	}
+	for _, r := range command {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			b.WriteRune(r)
+			continue
+		}
+		switch r {
+		case '\'', '"', '`':
+			quote = r
+		case ' ', '\t', '\r', '\n', ';', '|', '&', '(', ')', '<', '>':
+			flush()
+		default:
+			b.WriteRune(r)
+		}
+	}
+	flush()
+	return words
+}
+
+func nextPolicyWord(words []string, start int) string {
+	for i := start; i < len(words); i++ {
+		word := strings.TrimSpace(words[i])
+		if word == "" {
+			continue
+		}
+		if strings.Contains(word, "=") && !strings.HasPrefix(word, "-") {
+			before, _, _ := strings.Cut(word, "=")
+			if before != "" && !strings.ContainsAny(before, "/.") {
+				continue
+			}
+		}
+		if strings.HasPrefix(word, "-") &&
+			word != "--sync" &&
+			!strings.HasPrefix(word, "-s") {
+			continue
+		}
+		return word
+	}
+	return ""
+}
+
+func policyCommandName(word string) string {
+	word = strings.TrimSpace(word)
+	if word == "" {
+		return ""
+	}
+	word = strings.Trim(word, shellQuoteChars)
+	word = strings.TrimPrefix(word, "command:")
+	word = strings.TrimPrefix(word, "exec:")
+	if strings.Contains(word, "=") && !strings.HasPrefix(word, "-") {
+		before, after, _ := strings.Cut(word, "=")
+		if before != "" && after != "" && !strings.ContainsAny(before, "/.") {
+			return ""
+		}
+	}
+	word = strings.TrimRight(word, ",")
+	return filepath.Base(word)
+}
+
+func isShellExecutable(cmd string) bool {
+	switch cmd {
+	case "sh", "bash", "dash", "ksh", "zsh":
+		return true
+	default:
+		return false
+	}
+}
+
+func shellCommandStringArg(words []string) (string, bool) {
+	for i := 0; i < len(words); i++ {
+		word := strings.TrimSpace(words[i])
+		if word == "" {
+			continue
+		}
+		if word == "-c" || strings.HasSuffix(word, "c") &&
+			strings.HasPrefix(word, "-") &&
+			!strings.HasPrefix(word, "--") {
+			if i+1 < len(words) {
+				return words[i+1], true
+			}
+			return "", false
+		}
+		if !strings.HasPrefix(word, "-") {
+			return "", false
+		}
+	}
+	return "", false
 }
 
 func blocksSensitivePathRequest(req CommandRequest) bool {

--- a/openclaw/internal/octool/policy_test.go
+++ b/openclaw/internal/octool/policy_test.go
@@ -205,3 +205,90 @@ func TestChatCommandSafetyPolicy_BlocksEnvFileParentWorkdir(
 	})
 	require.ErrorContains(t, err, reasonSensitivePath)
 }
+
+func TestChatCommandSafetyPolicy_BlocksSystemPackageInstallFallback(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	err := NewChatCommandSafetyPolicy()(context.Background(), CommandRequest{
+		Command: `yum install -y stockfish 2>/dev/null || ` +
+			`dnf install -y stockfish 2>/dev/null || ` +
+			`microdnf install -y stockfish`,
+	})
+	require.ErrorContains(t, err, reasonSystemPackageInstall)
+}
+
+func TestChatCommandSafetyPolicy_BlocksSudoAptPackageInstall(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	err := NewChatCommandSafetyPolicy()(context.Background(), CommandRequest{
+		Command: `sudo apt-get -y install tesseract-ocr`,
+	})
+	require.ErrorContains(t, err, reasonSystemPackageInstall)
+}
+
+func TestChatCommandSafetyPolicy_BlocksShellWrappedPackageInstall(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	err := NewChatCommandSafetyPolicy()(context.Background(), CommandRequest{
+		Command: `bash -lc 'apk add --no-cache chromium'`,
+	})
+	require.ErrorContains(t, err, reasonSystemPackageInstall)
+}
+
+func TestChatCommandSafetyPolicy_AllowsLanguagePackageInstall(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	policy := NewChatCommandSafetyPolicy()
+	for _, command := range []string{
+		`pip install python-chess`,
+		`python -m pip install python-chess`,
+		`go install golang.org/x/tools/gopls@latest`,
+	} {
+		err := policy(context.Background(), CommandRequest{
+			Command: command,
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestBlocksSystemPackageInstall_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, blocksSystemPackageInstall(""))
+	require.False(t, blocksSystemPackageInstallDepth("apt install curl", 3))
+	require.True(t, blocksSystemPackageInstall("pacman -S stockfish"))
+	require.True(t, blocksSystemPackageInstall("pacman --sync stockfish"))
+	require.True(t, blocksSystemPackageInstall("FOO=bar brew install wget"))
+	require.True(t, blocksSystemPackageInstall("command:apt install curl"))
+	require.True(t, blocksSystemPackageInstall("exec:/usr/bin/apt-get install t"))
+	require.False(t, blocksSystemPackageInstall("alias=apt install docs"))
+}
+
+func TestShellPackageInstallParsing_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", policyCommandName(""))
+	require.Equal(t, "", policyCommandName("alias=apt"))
+
+	require.Equal(
+		t,
+		"",
+		nextPolicyWord([]string{"", "FOO=bar", "--quiet"}, 0),
+	)
+
+	arg, ok := shellCommandStringArg([]string{"", "-lc"})
+	require.False(t, ok)
+	require.Empty(t, arg)
+
+	arg, ok = shellCommandStringArg([]string{"-x", "python"})
+	require.False(t, ok)
+	require.Empty(t, arg)
+}

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -278,7 +278,13 @@ func execToolDescription(hasMemoryFile bool) string {
 			"something with host shell work, the same assistant " +
 			"message must call exec_command or the required tool.",
 		"Protected shell and credential paths may be blocked by policy.",
+		"Host system package-manager installs such as apt, yum, dnf, " +
+			"apk, pacman, zypper, and brew are blocked in chat; use " +
+			"preconfigured dependencies or ask for an explicit setup flow.",
 		"Sensitive env values may be redacted from returned output.",
+		"Large stdout/stderr may be truncated before it is returned " +
+			"to the model; write large outputs to files and read only " +
+			"the needed chunks.",
 		"Do not use this just to inspect a PDF or spreadsheet already " +
 			"in chat; prefer read_document or read_spreadsheet for that.",
 	}

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -1059,6 +1060,111 @@ func TestManager_MaxLinesTrimsOutput(t *testing.T) {
 
 	log := logAny
 	require.Equal(t, "c", strings.TrimSpace(log.Output))
+}
+
+func TestManager_MaxResultOutputCharsTruncatesForeground(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	const maxResultOutputChars = 80
+	mgr := NewManager(WithMaxResultOutputChars(maxResultOutputChars))
+	execTool := newExecCommandTool(mgr)
+
+	args := mustJSON(t, map[string]any{
+		"command":       "printf 'abcdefghijklmnopqrstuvwxyz%.0s' {1..8}",
+		"yield_time_ms": 0,
+	})
+	out, err := execTool.Call(context.Background(), args)
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	prefix, _, ok := strings.Cut(res.Output, "\n\n[OpenClaw")
+	require.True(t, ok)
+	require.Equal(t, maxResultOutputChars, utf8.RuneCountInString(prefix))
+	require.Contains(t, prefix, "abcdefghijklmnopqrstuvwxyz")
+	longChunk := strings.Repeat("abcdefghijklmnopqrstuvwxyz", 4)
+	require.NotContains(t, res.Output, longChunk)
+	requireTruncatedExecOutput(t, res.Output)
+}
+
+func TestManager_MaxResultOutputCharsTruncatesUTF8Foreground(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(WithMaxResultOutputChars(81))
+	execTool := newExecCommandTool(mgr)
+
+	args := mustJSON(t, map[string]any{
+		"command":       `printf '\303\251%.0s' {1..90}`,
+		"yield_time_ms": 0,
+	})
+	out, err := execTool.Call(context.Background(), args)
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	require.True(t, utf8.ValidString(res.Output))
+	require.Contains(t, res.Output, "\xc3\xa9")
+	requireTruncatedExecOutput(t, res.Output)
+}
+
+func TestManager_MaxResultOutputCharsHelperEdges(t *testing.T) {
+	var nilManager *Manager
+	require.Equal(t, "abc", nilManager.limitResultOutput("abc"))
+	require.Equal(t, "abc", NewManager().limitResultOutput("abc"))
+	require.Equal(t, "abc", truncateResultOutput("abc", 0))
+	require.Equal(t, "abc", truncateResultOutput("abc", 3))
+	require.Equal(t, "", firstRunes("abc", 0))
+	require.Equal(t, "abc", firstRunes("abc", 5))
+}
+
+func TestManager_MaxResultOutputCharsTruncatesSessionCompletion(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty is not supported on windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(WithMaxResultOutputChars(80))
+	execTool := newExecCommandTool(mgr)
+
+	ptyArgs := mustJSON(t, map[string]any{
+		"command":       "printf 'abcdefghijklmnopqrstuvwxyz%.0s' {1..8}",
+		"pty":           true,
+		"yield_time_ms": 0,
+	})
+	out, err := execTool.Call(context.Background(), ptyArgs)
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	requireTruncatedExecOutput(t, res.Output)
+
+	timerArgs := mustJSON(t, map[string]any{
+		"command":       "printf 'abcdefghijklmnopqrstuvwxyz%.0s' {1..8}",
+		"yield_time_ms": 1000,
+	})
+	out, err = execTool.Call(context.Background(), timerArgs)
+	require.NoError(t, err)
+
+	res = out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	requireTruncatedExecOutput(t, res.Output)
+}
+
+func requireTruncatedExecOutput(t *testing.T, output string) {
+	t.Helper()
+
+	require.Contains(t, output, "OpenClaw truncated command output")
+	require.Contains(t, output, "Write large outputs to a file")
+	require.Contains(t, output, "chars")
+	require.NotContains(t, output, "bytes")
 }
 
 func TestProcessTool_ListKillClearRemove(t *testing.T) {

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -1377,26 +1377,35 @@ func (at *Tool) forwardSubInvocationStream(
 			return
 		}
 	}
-	for ev := range wrapped {
-		if at.handleForwardedStreamEvent(
-			ctx, subInv, ev, writer, &state,
-			managePendingVisibleCompletion, emitFinalResultChunk,
-		) {
+	for {
+		select {
+		case <-ctx.Done():
+			sendStreamableCallError(ctx, writer, "agent tool run error: %w", ctx.Err())
 			return
+		case ev, ok := <-wrapped:
+			if !ok {
+				if managePendingVisibleCompletion {
+					at.flushPendingVisibleCompletionForSession(ctx, subInv, &state)
+				}
+				if emitFinalResultChunk {
+					if at.responseMode == ResponseModeFinalOnly {
+						at.emitFinalOnlyResultChunk(&state, writer)
+						return
+					}
+					at.emitPendingCompletionChunk(&state, writer)
+					return
+				}
+				at.emitPendingVisibleCompletionEvent(&state, writer)
+				return
+			}
+			if at.handleForwardedStreamEvent(
+				ctx, subInv, ev, writer, &state,
+				managePendingVisibleCompletion, emitFinalResultChunk,
+			) {
+				return
+			}
 		}
 	}
-	if managePendingVisibleCompletion {
-		at.flushPendingVisibleCompletionForSession(ctx, subInv, &state)
-	}
-	if emitFinalResultChunk {
-		if at.responseMode == ResponseModeFinalOnly {
-			at.emitFinalOnlyResultChunk(&state, writer)
-			return
-		}
-		at.emitPendingCompletionChunk(&state, writer)
-		return
-	}
-	at.emitPendingVisibleCompletionEvent(&state, writer)
 }
 
 // handleForwardedStreamEvent processes a single forwarded sub-invocation event

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -896,6 +896,40 @@ func TestCallDynamic_TimeoutBoundsSubAgent(t *testing.T) {
 	require.Less(t, time.Since(start), time.Second)
 }
 
+func TestStreamDynamic_TimeoutBoundsSubAgent(t *testing.T) {
+	t.Parallel()
+
+	main := llmagent.New("main", llmagent.WithModel(&dynBlockingModel{}))
+	at := NewDynamicTool(WithDynamicTimeout(10 * time.Millisecond))
+	sess := session.NewSession("app", "user", "session")
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(main),
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("main"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+
+	start := time.Now()
+	reader, err := at.StreamableCall(ctx, []byte(`{"request":"wait"}`))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	var sb strings.Builder
+	for {
+		chunk, recvErr := reader.Recv()
+		if recvErr == io.EOF {
+			break
+		}
+		require.NoError(t, recvErr)
+		if text, ok := chunk.Content.(string); ok {
+			sb.WriteString(text)
+		}
+	}
+
+	require.Contains(t, sb.String(), context.DeadlineExceeded.Error())
+	require.Less(t, time.Since(start), time.Second)
+}
+
 // dynRecordingModel records the set of tool names visible in each request.
 type dynRecordingModel struct {
 	name     string

--- a/tool/context.go
+++ b/tool/context.go
@@ -9,7 +9,10 @@
 
 package tool
 
-import "context"
+import (
+	"context"
+	"sync/atomic"
+)
 
 // ContextKeyToolCallID is the context key type for tool call ID.
 // It's exported so that the framework can inject tool call ID into context.
@@ -17,6 +20,12 @@ type ContextKeyToolCallID struct{}
 
 type contextKeyStructuredStreamErrors struct{}
 type contextKeyFinalResultChunks struct{}
+type contextKeyToolResultAttachmentBudget struct{}
+
+type toolResultAttachmentBudget struct {
+	max  int64
+	used atomic.Int64
+}
 
 // ToolCallIDFromContext retrieves tool call ID from context.
 // Returns the tool call ID and true if found, empty string and false
@@ -62,4 +71,96 @@ func FinalResultChunksFromContext(ctx context.Context) bool {
 	}
 	enabled, _ := ctx.Value(contextKeyFinalResultChunks{}).(bool)
 	return enabled
+}
+
+// WithToolResultAttachmentBudget limits callback-managed attachments for one
+// tool response processing pass.
+func WithToolResultAttachmentBudget(
+	ctx context.Context,
+	maxAttachments int,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	budget := &toolResultAttachmentBudget{
+		max: int64(maxAttachments),
+	}
+	return context.WithValue(
+		ctx,
+		contextKeyToolResultAttachmentBudget{},
+		budget,
+	)
+}
+
+// EnsureToolResultAttachmentBudget installs a budget only when none exists.
+func EnsureToolResultAttachmentBudget(
+	ctx context.Context,
+	maxAttachments int,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if toolResultAttachmentBudgetFromContext(ctx) != nil {
+		return ctx
+	}
+	return WithToolResultAttachmentBudget(ctx, maxAttachments)
+}
+
+// WithoutToolResultAttachmentBudget hides any inherited attachment budget.
+// This is useful when invoking a nested tool or agent from inside a tool body;
+// the outer processor can still use the original context for this tool result.
+func WithoutToolResultAttachmentBudget(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(
+		ctx,
+		contextKeyToolResultAttachmentBudget{},
+		(*toolResultAttachmentBudget)(nil),
+	)
+}
+
+// ReserveToolResultAttachments reserves up to requested attachment slots from
+// the current tool result budget. Without a budget it preserves legacy
+// behavior and grants the full request.
+func ReserveToolResultAttachments(
+	ctx context.Context,
+	requested int,
+) int {
+	if requested <= 0 {
+		return 0
+	}
+	if ctx == nil {
+		return requested
+	}
+	budget := toolResultAttachmentBudgetFromContext(ctx)
+	if budget == nil {
+		return requested
+	}
+	for {
+		used := budget.used.Load()
+		available := budget.max - used
+		if available <= 0 {
+			return 0
+		}
+		granted := int64(requested)
+		if granted > available {
+			granted = available
+		}
+		if budget.used.CompareAndSwap(used, used+granted) {
+			return int(granted)
+		}
+	}
+}
+
+func toolResultAttachmentBudgetFromContext(
+	ctx context.Context,
+) *toolResultAttachmentBudget {
+	if ctx == nil {
+		return nil
+	}
+	budget, _ := ctx.Value(
+		contextKeyToolResultAttachmentBudget{},
+	).(*toolResultAttachmentBudget)
+	return budget
 }

--- a/tool/context_test.go
+++ b/tool/context_test.go
@@ -89,3 +89,54 @@ func TestFinalResultChunksContext(t *testing.T) {
 	ctx = context.WithValue(ctx, contextKeyFinalResultChunks{}, false)
 	require.False(t, FinalResultChunksFromContext(ctx))
 }
+
+func TestToolResultAttachmentBudget(t *testing.T) {
+	require.Equal(t, 3, ReserveToolResultAttachments(nil, 3))
+	require.Equal(
+		t,
+		3,
+		ReserveToolResultAttachments(context.Background(), 3),
+	)
+	require.Equal(t, 0, ReserveToolResultAttachments(nil, 0))
+	require.Equal(t, 0, ReserveToolResultAttachments(nil, -1))
+
+	ctx := WithToolResultAttachmentBudget(context.Background(), 5)
+	require.Equal(t, 3, ReserveToolResultAttachments(ctx, 3))
+	require.Equal(t, 2, ReserveToolResultAttachments(ctx, 3))
+	require.Equal(t, 0, ReserveToolResultAttachments(ctx, 1))
+}
+
+func TestToolResultAttachmentBudget_ZeroMax(t *testing.T) {
+	ctx := WithToolResultAttachmentBudget(context.Background(), 0)
+	require.Equal(t, 0, ReserveToolResultAttachments(ctx, 1))
+}
+
+func TestEnsureToolResultAttachmentBudget_PreservesExisting(t *testing.T) {
+	ctx := WithToolResultAttachmentBudget(context.Background(), 2)
+	ctx = EnsureToolResultAttachmentBudget(ctx, 5)
+
+	require.Equal(t, 2, ReserveToolResultAttachments(ctx, 5))
+	require.Equal(t, 0, ReserveToolResultAttachments(ctx, 1))
+}
+
+func TestWithoutToolResultAttachmentBudget(t *testing.T) {
+	ctx := WithToolResultAttachmentBudget(context.Background(), 1)
+	require.Equal(t, 1, ReserveToolResultAttachments(ctx, 1))
+
+	childCtx := WithoutToolResultAttachmentBudget(ctx)
+	require.Equal(t, 2, ReserveToolResultAttachments(childCtx, 2))
+	require.Equal(t, 0, ReserveToolResultAttachments(ctx, 1))
+}
+
+func TestToolResultAttachmentBudgetNilContexts(t *testing.T) {
+	ctx := WithToolResultAttachmentBudget(nil, 2)
+	require.Equal(t, 2, ReserveToolResultAttachments(ctx, 3))
+
+	ensured := EnsureToolResultAttachmentBudget(nil, 1)
+	require.Equal(t, 1, ReserveToolResultAttachments(ensured, 2))
+
+	childCtx := WithoutToolResultAttachmentBudget(nil)
+	require.Equal(t, 2, ReserveToolResultAttachments(childCtx, 2))
+
+	require.Nil(t, toolResultAttachmentBudgetFromContext(nil))
+}


### PR DESCRIPTION
## Summary

- hide disabled browser `evaluate` actions from OpenClaw-facing browser results, declarations, and guidance
- discourage local browser `file://`, `data:`, and ad hoc localhost media workflows in OpenClaw prompts and browser tool descriptions
- add an opt-in shared tool-result attachment budget, keep the default framework behavior unlimited, and enable the budget explicitly for OpenClaw image/MCP image reattachment
- reserve MCP image attachment budget before base64 decoding so large image result sets stop decoding once granted slots are filled
- add an opt-in OpenClaw exec result output cap with UTF-8-safe truncation and guidance to write large outputs to files and read chunks
- block host system package-manager installs from OpenClaw chat exec policy while keeping language package installs available

## Validation

- `go test ./internal/flow/processor -count=1`
- `go test ./agent/llmagent -count=1`
- `go test ./tool -run 'TestToolResultAttachmentBudget|TestEnsureToolResultAttachmentBudget_PreservesExisting' -count=1`
- `cd openclaw && go test ./internal/octool -run 'TestChatCommandSafetyPolicy|TestManager_MaxResultOutputCharsTruncatesForeground' -count=1`
- `cd openclaw && go test ./internal/octool -run 'TestManager_MaxResultOutputChars|TestChatCommandSafetyPolicy' -count=1`
- `cd openclaw && go test ./internal/octool -count=1`
- `cd openclaw && go test ./app -run 'TestMCPImageResultMessages|TestExtractMCPImages|TestOpenClawToolResultMessages_ConsumesAttachmentBudget|TestOpenClawToolingGuidanceAvoidsLocalBrowserMedia|TestNewAgent_BrowserToolingGuidance|TestNewAgent_OpenClawToolsEnabled' -count=1`
- `cd openclaw && go test ./app -run 'TestNewAgent_SandboxOpenClawToolingGuidanceMatchesTools|TestOpenClawToolingGuidanceAvoidsSystemPackageManagers|TestNewAgent_BrowserToolingGuidance|TestOpenClawToolingGuidanceAvoidsLocalBrowserMedia|TestNewAgent_OpenClawToolsEnabled' -count=1`
- `cd openclaw && go test ./internal/browser -run 'TestNewTool_DeclarationExposesSchema|TestNewTool_DeclarationReflectsEvaluateEnabled' -count=1`

`cd openclaw && go test ./app -count=1` was also attempted earlier; this local environment still hits the existing browser supervisor start-failure assertions where the test expects startup to fail but the local browser server starts successfully.