### PR TITLE
internal/flow: preserve loadable session recovery hints

### DIFF
--- a/internal/flow/processor/context_compact.go
+++ b/internal/flow/processor/context_compact.go
@@ -353,6 +353,7 @@ func compactIncrementEvents(
 		passEvents, passStats := applyOversizedToolResultPass(
 			ctx,
 			compacted,
+			currentKey,
 			cfg.OversizedToolResultMaxTokens,
 			cfg,
 		)
@@ -488,16 +489,26 @@ func compactHistoricalToolResultEvent(
 func applyOversizedToolResultPass(
 	ctx context.Context,
 	events []event.Event,
+	currentKey string,
 	maxTokens int,
 	cfg ContextCompactionConfig,
 ) ([]event.Event, ContextCompactionStats) {
 	var stats ContextCompactionStats
 	for i := range events {
+		sessionLoadRecoveryEnabled := cfg.SessionLoadRecoveryEnabled
+		if currentKey != "" &&
+			compactionUnitKey(
+				events[i].RequestID,
+				events[i].InvocationID,
+			) == currentKey &&
+			strings.TrimSpace(events[i].ID) == "" {
+			sessionLoadRecoveryEnabled = false
+		}
 		evt, changed, compactedCount, savedTokens := rewriteToolResultEventMessages(
 			ctx,
 			events[i],
 			maxTokens,
-			cfg.SessionLoadRecoveryEnabled,
+			sessionLoadRecoveryEnabled,
 			func(ctx context.Context, msg model.Message, maxTokens int, ref toolResultRecoveryRef) (model.Message, bool, int) {
 				if cfg.keepToolResult(msg) {
 					return msg, false, 0

--- a/internal/flow/processor/context_compact_test.go
+++ b/internal/flow/processor/context_compact_test.go
@@ -897,6 +897,141 @@ func TestCompactIncrementEvents_AddsRecoverableTruncationRef(t *testing.T) {
 	require.Contains(t, got, "tool_name=worker")
 }
 
+func TestCompactIncrementEvents_CurrentResultNoSessionLoadHint(t *testing.T) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	evt := event.Event{
+		RequestID:    "req-current",
+		InvocationID: "inv-current",
+		FilterKey:    "test-agent",
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage(
+					"tool-call-current",
+					"worker",
+					content,
+				),
+			}},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		[]event.Event{evt},
+		"req-current",
+		"inv-current",
+		ContextCompactionConfig{
+			Enabled:                      true,
+			SessionLoadRecoveryEnabled:   true,
+			OversizedToolResultMaxTokens: 80,
+		},
+	)
+
+	require.Equal(t, 1, stats.ToolResultsCompacted)
+	got := compacted[0].Response.Choices[0].Message.Content
+	require.Contains(t, got, "characters truncated from tool result")
+	require.Contains(t, got, "tool_call_id=tool-call-current")
+	require.NotContains(t, got, "session_load")
+	require.Contains(t, got, "re-run only safe read-only/idempotent tools")
+}
+
+func TestCompactIncrementEvents_CurrentResultWithEventIDHasSessionLoadHint(
+	t *testing.T,
+) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	evt := event.Event{
+		ID:           "evt-current",
+		RequestID:    "req-current",
+		InvocationID: "inv-current",
+		FilterKey:    "test-agent",
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage(
+					"tool-call-current",
+					"worker",
+					content,
+				),
+			}},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		[]event.Event{evt},
+		"req-current",
+		"inv-current",
+		ContextCompactionConfig{
+			Enabled:                      true,
+			SessionLoadRecoveryEnabled:   true,
+			OversizedToolResultMaxTokens: 80,
+		},
+	)
+
+	require.Equal(t, 1, stats.ToolResultsCompacted)
+	got := compacted[0].Response.Choices[0].Message.Content
+	require.Contains(t, got, "characters truncated from tool result")
+	require.Contains(t, got, "event_id=evt-current")
+	require.Contains(t, got, "tool_call_id=tool-call-current")
+	require.Contains(t, got, "session_load")
+}
+
+func TestCompactIncrementEvents_HistoryResultHasSessionLoadHint(t *testing.T) {
+	content := "HEAD-" + strings.Repeat("middle-", 400) + "-TAIL"
+	events := []event.Event{
+		{
+			RequestID:    "req-current",
+			InvocationID: "inv-current",
+			FilterKey:    "test-agent",
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						"tool-call-current",
+						"worker",
+						"ok",
+					),
+				}},
+			},
+		},
+		{
+			ID:           "evt-history",
+			RequestID:    "req-history",
+			InvocationID: "inv-history",
+			FilterKey:    "test-agent",
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						"tool-call-history",
+						"worker",
+						content,
+					),
+				}},
+			},
+		},
+	}
+
+	compacted, stats := compactIncrementEvents(
+		context.Background(),
+		events,
+		"req-current",
+		"inv-current",
+		ContextCompactionConfig{
+			Enabled:                      true,
+			SessionLoadRecoveryEnabled:   true,
+			OversizedToolResultMaxTokens: 80,
+		},
+	)
+
+	require.Equal(t, 1, stats.ToolResultsCompacted)
+	got := compacted[1].Response.Choices[0].Message.Content
+	require.Contains(t, got, "characters truncated from tool result")
+	require.Contains(t, got, "event_id=evt-history")
+	require.Contains(t, got, "tool_call_id=tool-call-history")
+	require.Contains(t, got, "session_load")
+}
+
 func TestCompactIncrementEvents_DoesNotTruncateSessionLoadResult(t *testing.T) {
 	content := "SESSION_LOAD_HEAD-" + strings.Repeat("loaded-history-", 300) + "-SESSION_LOAD_TAIL"
 	evt := event.Event{

--- a/internal/session/tool/recall/tool_test.go
+++ b/internal/session/tool/recall/tool_test.go
@@ -1087,6 +1087,7 @@ func TestLoadTool_LoadsToolResultByToolCallIDWithContentWindow(t *testing.T) {
 		Service: sessioninmemory.NewSessionService(),
 		windowFunc: func(req session.EventWindowRequest) (*session.EventWindow, error) {
 			require.Equal(t, "evt-tool", req.AnchorEventID)
+			require.Equal(t, "sess", req.Key.SessionID)
 			return &session.EventWindow{
 				SessionKey:    req.Key,
 				AnchorEventID: req.AnchorEventID,


### PR DESCRIPTION
## Summary

- Keep `session_load` recovery hints for compacted current-request tool results when an `event_id` is available.
- Fall back to safe re-run guidance only for current-request oversized results that lack a loadable event anchor.
- Avoid introducing a magic `session_id: "current"` alias; omitting `session_id` continues to select the active session.
- Add focused tests for current-request oversized results with and without an event anchor.

## Root Cause

Current-request tool results are persisted before the next LLM iteration, so an oversized compacted result with an `event_id` can still be recovered through `session_load`. Suppressing the hint for all current-request results hides valid recovery paths and may cause redundant tool execution.

## Validation

- `go test ./internal/session/tool/recall ./internal/flow/processor`
