### PR TITLE
openclaw/internal/deps: avoid busy test scripts

### DIFF
--- a/openclaw/internal/deps/install_test.go
+++ b/openclaw/internal/deps/install_test.go
@@ -698,8 +698,19 @@ func writeTestCommand(
 ) string {
 	t.Helper()
 
-	path := filepath.Join(dir, name)
 	script := "#!/bin/sh\nset -eu\n" + body + "\n"
-	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	tmp, err := os.CreateTemp(dir, name+".tmp-*")
+	require.NoError(t, err)
+	tmpPath := tmp.Name()
+	t.Cleanup(func() {
+		_ = os.Remove(tmpPath)
+	})
+	_, err = tmp.Write([]byte(script))
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+	require.NoError(t, os.Chmod(tmpPath, 0o755))
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.Rename(tmpPath, path))
 	return path
 }


### PR DESCRIPTION
## Summary

- Write generated test commands through a closed temporary file before renaming them into place.
- Avoid executing a script path that may still be observed as busy by CI filesystems.
- Rebase the branch onto the latest `main` after related OpenClaw changes landed.

## Validation

- `cd openclaw && go test ./internal/deps -run 'TestCombinedOutputContext|TestPlanStepCommand|TestInstall' -count=20`
- `cd openclaw && go test ./internal/deps`
- `cd openclaw && go test ./internal/cron -run TestServiceRunNowDebugTraceRecordsDeliveryFailure -count=20`
- `git diff --check`
