### PR TITLE
model/openai: add GLM variant fallback

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -71,6 +71,9 @@ const (
 	VariantDeepSeek Variant = "deepseek"
 	// VariantQwen is the Qwen variant with specific base_url handling.
 	VariantQwen Variant = "qwen"
+	// VariantGLM is the GLM OpenAI-compatible variant. Some GLM gateways
+	// return the visible final answer in reasoning_content with empty content.
+	VariantGLM Variant = "glm"
 )
 
 // thinkingValueConvertor converts ThinkingEnabled bool to the variant-specific value.
@@ -81,10 +84,9 @@ var defaultThinkingValueConvertor = func(enabled bool) any {
 	return enabled
 }
 
-// deepSeekThinkingValueConvertor converts to the DeepSeek thinking-toggle
-// format introduced in v3.2 and reused by v4 (e.g. deepseek-v4-pro /
-// deepseek-v4-flash): {"type": "enabled"/"disabled"}.
-var deepSeekThinkingValueConvertor = func(enabled bool) any {
+// thinkingTypeValueConvertor converts to the nested thinking-toggle format
+// used by providers such as DeepSeek v3.2+ and GLM.
+var thinkingTypeValueConvertor = func(enabled bool) any {
 	const (
 		thinkingTypeEnabled  = "enabled"
 		thinkingTypeDisabled = "disabled"
@@ -127,6 +129,9 @@ type variantConfig struct {
 	// defaultReasoningContentBackfill controls replay-time empty
 	// reasoning_content backfill for assistant messages.
 	defaultReasoningContentBackfill bool
+	// reasoningContentAsContentFallback copies reasoning_content into
+	// content only when content is empty and the response has no tool calls.
+	reasoningContentAsContentFallback bool
 }
 type fileDeletionBodyConvertor func(body []byte, fileID string) []byte
 
@@ -161,7 +166,7 @@ var variantConfigs = map[Variant]variantConfig{
 		// DeepSeek v3.2+ (incl. v4-pro / v4-flash) uses
 		// {"thinking": {"type": "enabled"/"disabled"}} format.
 		thinkingEnabledKey:              "thinking",
-		thinkingValueConvertor:          deepSeekThinkingValueConvertor,
+		thinkingValueConvertor:          thinkingTypeValueConvertor,
 		defaultReasoningContentBackfill: true,
 	},
 	VariantHunyuan: {
@@ -224,6 +229,16 @@ var variantConfigs = map[Variant]variantConfig{
 		// refer:https://help.aliyun.com/zh/model-studio/deep-thinking
 		thinkingEnabledKey:     model.EnabledThinkingKey,
 		thinkingValueConvertor: defaultThinkingValueConvertor,
+	},
+	VariantGLM: {
+		fileUploadPath:                    "/openapi/v1/files",
+		filePurpose:                       openai.FilePurposeUserData,
+		fileDeletionMethod:                http.MethodDelete,
+		skipFileTypeInContent:             false,
+		fileDeletionBodyConvertor:         defaultFileDeletionBodyConvertor,
+		thinkingEnabledKey:                "thinking",
+		thinkingValueConvertor:            thinkingTypeValueConvertor,
+		reasoningContentAsContentFallback: true,
 	},
 }
 
@@ -2328,7 +2343,12 @@ func (m *Model) emitStreamingFinalResponse(
 					{
 						Index: 0,
 						Message: model.Message{
-							Role:             model.RoleAssistant,
+							Role: model.RoleAssistant,
+							Content: m.contentWithReasoningFallback(
+								"",
+								aggregatedReasoning,
+								false,
+							),
 							ReasoningContent: aggregatedReasoning,
 						},
 					},
@@ -2436,13 +2456,19 @@ func (m *Model) createFinalResponse(
 		if reasoningContent == "" && i == 0 && aggregatedReasoning != "" {
 			reasoningContent = aggregatedReasoning
 		}
+		choiceHasToolCalls := hasToolCall && i == 0
+		content := m.contentWithReasoningFallback(
+			choice.Message.Content,
+			reasoningContent,
+			choiceHasToolCalls,
+		)
 
 		finalResponse.Choices[i] = model.Choice{
 			Index:    int(choice.Index),
 			Logprobs: convertChatCompletionChoiceLogprobs(choice.Logprobs),
 			Message: model.Message{
 				Role:             model.RoleAssistant,
-				Content:          choice.Message.Content,
+				Content:          content,
 				ReasoningContent: reasoningContent,
 			},
 		}
@@ -2520,13 +2546,18 @@ func (m *Model) createResponseFromCompletion(chatCompletion *openai.ChatCompleti
 		for i, choice := range chatCompletion.Choices {
 			// Extract reasoning content from the message if available.
 			reasoningContent := extractReasoningContent(choice.Message.JSON.ExtraFields)
+			content := m.contentWithReasoningFallback(
+				choice.Message.Content,
+				reasoningContent,
+				len(choice.Message.ToolCalls) > 0,
+			)
 
 			response.Choices[i] = model.Choice{
 				Index:    int(choice.Index),
 				Logprobs: convertChatCompletionChoiceLogprobs(choice.Logprobs),
 				Message: model.Message{
 					Role:             model.RoleAssistant,
-					Content:          choice.Message.Content,
+					Content:          content,
 					ReasoningContent: reasoningContent,
 				},
 			}
@@ -2573,6 +2604,20 @@ func (m *Model) createResponseFromCompletion(chatCompletion *openai.ChatCompleti
 	}
 
 	return response
+}
+
+func (m *Model) contentWithReasoningFallback(
+	content string,
+	reasoningContent string,
+	hasToolCall bool,
+) string {
+	if content != "" || reasoningContent == "" || hasToolCall {
+		return content
+	}
+	if m == nil || !m.variantConfig.reasoningContentAsContentFallback {
+		return content
+	}
+	return reasoningContent
 }
 
 func convertChatCompletionChoiceLogprobs(

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -30,6 +30,7 @@ import (
 	openaigo "github.com/openai/openai-go"
 	openaiopt "github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/respjson"
+	"github.com/openai/openai-go/packages/ssestream"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -3554,6 +3555,81 @@ func TestModel_GenerateContent_WithReasoningContent_NonStreaming(t *testing.T) {
 	assert.Equalf(t, "Final answer", responses[0].Choices[0].Message.Content, "Expected content 'Final answer', got '%s'", responses[0].Choices[0].Message.Content)
 }
 
+func TestModel_GenerateContent_GLMThinkingPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    string
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+			want:    "enabled",
+		},
+		{
+			name:    "disabled",
+			enabled: false,
+			want:    "disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured map[string]any
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprint(w, `{
+						"id": "test",
+						"object": "chat.completion",
+						"created": 1699200000,
+						"model": "glm50",
+						"choices": [{
+							"index": 0,
+							"message": {
+								"role": "assistant",
+								"content": "ok"
+							},
+							"finish_reason": "stop"
+						}]
+					}`)
+				},
+			))
+			defer server.Close()
+
+			m := New(
+				"glm50",
+				WithVariant(VariantGLM),
+				WithBaseURL(server.URL),
+				WithAPIKey("test-key"),
+			)
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					ThinkingEnabled: &tt.enabled,
+				},
+			}
+			ch, err := m.GenerateContent(context.Background(), req)
+			require.NoError(t, err)
+			for resp := range ch {
+				require.Nil(t, resp.Error)
+			}
+
+			thinking, ok := captured["thinking"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.want, thinking["type"])
+			require.NotContains(t, captured, model.ThinkingEnabledKey)
+		})
+	}
+}
+
 // TestModel_GenerateContent_NonStreaming_ToolCallNoID_Synthesized verifies that
 // when the provider omits tool_call.id in a non-streaming response, we synthesize
 // a stable ID (auto_call_<index>). This covers the non-streaming code path in
@@ -4358,6 +4434,19 @@ func TestWithVariant(t *testing.T) {
 		WithVariant(VariantHunyuan)(opts)
 
 		assert.Equal(t, VariantHunyuan, opts.Variant, "expected variant to be VariantHunyuan")
+		assert.True(t, opts.variantSet, "expected variantSet to be true")
+	})
+
+	t.Run("glm variant", func(t *testing.T) {
+		opts := &options{}
+		WithVariant(VariantGLM)(opts)
+
+		assert.Equal(
+			t,
+			VariantGLM,
+			opts.Variant,
+			"expected variant to be VariantGLM",
+		)
 		assert.True(t, opts.variantSet, "expected variantSet to be true")
 	})
 
@@ -6110,6 +6199,196 @@ func TestCreateFinalResponseFinishReason(t *testing.T) {
 		*finalResponse.Choices[0].FinishReason)
 }
 
+func TestCreateFinalResponseGLMReasoningContentFallback(t *testing.T) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	acc := openai.ChatCompletionAccumulator{
+		ChatCompletion: openai.ChatCompletion{
+			ID:    "acc-id",
+			Model: "glm50",
+			Choices: []openai.ChatCompletionChoice{{
+				Index:        0,
+				FinishReason: "stop",
+				Message: openai.ChatCompletionMessage{
+					Content: "",
+				},
+			}},
+		},
+	}
+
+	resp := m.createFinalResponse(acc, false, nil, "收到")
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Equal(t, "收到", resp.Choices[0].Message.Content)
+	require.Equal(t, "收到", resp.Choices[0].Message.ReasoningContent)
+}
+
+func TestCreateFinalResponseGLMReasoningContentFallbackSkipsToolCall(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	acc := openai.ChatCompletionAccumulator{
+		ChatCompletion: openai.ChatCompletion{
+			ID:    "acc-id",
+			Model: "glm50",
+			Choices: []openai.ChatCompletionChoice{{
+				Index: 0,
+				Message: openai.ChatCompletionMessage{
+					Content: "",
+				},
+			}},
+		},
+	}
+
+	resp := m.createFinalResponse(
+		acc,
+		true,
+		[]model.ToolCall{{
+			ID:   "call-1",
+			Type: functionToolType,
+			Function: model.FunctionDefinitionParam{
+				Name: "lookup",
+			},
+		}},
+		"need tool",
+	)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Empty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, "need tool", resp.Choices[0].Message.ReasoningContent)
+	require.Len(t, resp.Choices[0].Message.ToolCalls, 1)
+}
+
+func TestCreateFinalResponseReasoningContentNoFallbackForOpenAI(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("gpt-5", WithVariant(VariantOpenAI))
+	acc := openai.ChatCompletionAccumulator{
+		ChatCompletion: openai.ChatCompletion{
+			ID:    "acc-id",
+			Model: "gpt-5",
+			Choices: []openai.ChatCompletionChoice{{
+				Index: 0,
+				Message: openai.ChatCompletionMessage{
+					Content: "",
+				},
+			}},
+		},
+	}
+
+	resp := m.createFinalResponse(acc, false, nil, "thinking")
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Empty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, "thinking", resp.Choices[0].Message.ReasoningContent)
+}
+
+func TestCreateResponseFromCompletionGLMReasoningContentFallback(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	var completion openai.ChatCompletion
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "completion-id",
+		"object": "chat.completion",
+		"created": 1699200000,
+		"model": "glm50",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"reasoning_content": "收到"
+			},
+			"finish_reason": "stop"
+		}]
+	}`), &completion))
+
+	resp := m.createResponseFromCompletion(&completion)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Equal(t, "收到", resp.Choices[0].Message.Content)
+	require.Equal(t, "收到", resp.Choices[0].Message.ReasoningContent)
+}
+
+func TestCreateResponseFromCompletionGLMReasoningContentSkipsToolCall(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	var completion openai.ChatCompletion
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "completion-id",
+		"object": "chat.completion",
+		"created": 1699200000,
+		"model": "glm50",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"reasoning_content": "need lookup",
+				"tool_calls": [{
+					"id": "call-1",
+					"type": "function",
+					"function": {
+						"name": "lookup",
+						"arguments": "{\"query\":\"x\"}"
+					}
+				}]
+			},
+			"finish_reason": "tool_calls"
+		}]
+	}`), &completion))
+
+	resp := m.createResponseFromCompletion(&completion)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Empty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, "need lookup",
+		resp.Choices[0].Message.ReasoningContent)
+	require.Len(t, resp.Choices[0].Message.ToolCalls, 1)
+}
+
+func TestEmitStreamingFinalResponseGLMReasoningContentFallback(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	var got *model.Response
+	m.emitStreamingFinalResponse(
+		context.Background(),
+		&ssestream.Stream[openai.ChatCompletionChunk]{},
+		openai.ChatCompletionAccumulator{
+			ChatCompletion: openai.ChatCompletion{
+				ID:    "acc-id",
+				Model: "glm50",
+			},
+		},
+		nil,
+		nil,
+		"收到",
+		func(resp *model.Response) bool {
+			got = resp
+			return true
+		},
+	)
+
+	require.NotNil(t, got)
+	require.Len(t, got.Choices, 1)
+	require.Equal(t, "收到", got.Choices[0].Message.Content)
+	require.Equal(t, "收到", got.Choices[0].Message.ReasoningContent)
+}
+
 // TestCreateFinalResponseUsageConditional verifies that Usage is only set on the
 // final response when at least one token count is non-zero. This prevents the
 // Langfuse exporter from seeing zero-valued usage attributes that get filtered
@@ -7091,6 +7370,13 @@ func TestBuildThinkingOption(t *testing.T) {
 			thinkingTokens:  &thinkingTokens,
 			wantKeys:        []string{model.ThinkingTokensKey, "thinking"},
 			wantValues:      []any{1024, map[string]string{"type": "enabled"}},
+		},
+		{
+			name:            "GLM variant with thinking enabled",
+			variant:         VariantGLM,
+			thinkingEnabled: &trueVal,
+			wantKeys:        []string{"thinking"},
+			wantValues:      []any{map[string]string{"type": "enabled"}},
 		},
 		{
 			name:            "OpenAI variant with thinking enabled",

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -380,6 +380,7 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 					"deepseek",
 					"qwen",
 					"hunyuan",
+					"glm",
 				),
 			},
 		},

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -428,6 +428,7 @@ const (
 	deepSeekAPIHost = "api.deepseek.com"
 	qwenAPIHost     = "dashscope.aliyuncs.com"
 	hunyuanAPIHost  = "api.hunyuan.cloud.tencent.com"
+	glmAPIHost      = "open.bigmodel.cn"
 
 	openAIAPIKeyEnvName  = "OPENAI_API_KEY"
 	openAIBaseURLEnvName = "OPENAI_BASE_URL"
@@ -3807,7 +3808,8 @@ func parseOpenAIVariant(
 	case openai.VariantOpenAI,
 		openai.VariantDeepSeek,
 		openai.VariantHunyuan,
-		openai.VariantQwen:
+		openai.VariantQwen,
+		openai.VariantGLM:
 		return variant, nil
 	default:
 		return "", fmt.Errorf("unsupported openai variant: %s", raw)
@@ -3826,6 +3828,8 @@ func inferOpenAIVariant(baseURL string) openai.Variant {
 		return openai.VariantQwen
 	case strings.EqualFold(host, hunyuanAPIHost):
 		return openai.VariantHunyuan
+	case strings.EqualFold(host, glmAPIHost):
+		return openai.VariantGLM
 	default:
 		return openai.VariantOpenAI
 	}

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4053,6 +4053,10 @@ func TestParseOpenAIVariant_Explicit(t *testing.T) {
 	v, err := parseOpenAIVariant(string(openai.VariantOpenAI), "")
 	require.NoError(t, err)
 	require.Equal(t, openai.VariantOpenAI, v)
+
+	v, err = parseOpenAIVariant(string(openai.VariantGLM), "")
+	require.NoError(t, err)
+	require.Equal(t, openai.VariantGLM, v)
 }
 
 func TestParseOpenAIVariant_Auto(t *testing.T) {
@@ -4081,6 +4085,11 @@ func TestInferOpenAIVariant(t *testing.T) {
 		t,
 		openai.VariantHunyuan,
 		inferOpenAIVariant("https://api.hunyuan.cloud.tencent.com/v1"),
+	)
+	require.Equal(
+		t,
+		openai.VariantGLM,
+		inferOpenAIVariant("https://open.bigmodel.cn/api/paas/v4"),
 	)
 	require.Equal(
 		t,

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -606,7 +606,8 @@ func parseRunOptions(args []string) (runOptions, error) {
 		&opts.OpenAIVariant,
 		"openai-variant",
 		defaultOpenAIVariant,
-		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan (auto uses configured base URL host)",
+		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan, "+
+			"glm (auto uses configured base URL host)",
 	)
 	fs.StringVar(
 		&opts.OpenAIBaseURL,


### PR DESCRIPTION
## Summary

- add an explicit `glm` OpenAI-compatible variant
- let the GLM variant use `reasoning_content` as visible content only when normal content is empty and no tool calls are present
- allow OpenClaw to accept `-openai-variant glm` in CLI/runtime config

## Validation

- `go test ./model/openai -run 'TestWithVariant|TestCreateFinalResponseGLMReasoningContentFallback|TestCreateFinalResponseGLMReasoningContentFallbackSkipsToolCall|TestCreateFinalResponseReasoningContentNoFallbackForOpenAI|TestCreateFinalResponseFinishReason' -count=1`\n- `go test ./model/openai -count=1`\n- `cd openclaw && go test ./app -run 'TestParseOpenAIVariant_Explicit|TestParseOpenAIVariant_Auto|TestParseOpenAIVariant_Unknown|TestInferOpenAIVariant' -count=1`\n\nNote: a local full `cd openclaw && go test ./app -count=1` run hit existing browser supervisor tests that mutate global state concurrently; the changed parser tests passed.