### PR TITLE
model/openai: fix qwen thinking parameter

### DIFF
--- a/model/model_test.go
+++ b/model/model_test.go
@@ -78,6 +78,11 @@ func TestRequestOptions_IgnoresNilStructuredOutputInputs(t *testing.T) {
 	require.Nil(t, req.StructuredOutput)
 }
 
+func TestThinkingKeys(t *testing.T) {
+	require.Equal(t, "enable_thinking", EnableThinkingKey)
+	require.Equal(t, "enabled_thinking", EnabledThinkingKey)
+}
+
 // mockModel is a simple mock implementation for testing the interface.
 type mockModel struct{}
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -222,7 +222,7 @@ var variantConfigs = map[Variant]variantConfig{
 		apiKeyName:                qwenAPIKeyName,
 		defaultBaseURL:            defaultQwenBaseURL,
 		// refer:https://help.aliyun.com/zh/model-studio/deep-thinking
-		thinkingEnabledKey:     model.EnabledThinkingKey,
+		thinkingEnabledKey:     model.EnableThinkingKey,
 		thinkingValueConvertor: defaultThinkingValueConvertor,
 	},
 }

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -6876,7 +6876,7 @@ func TestModel_buildChatRequest(t *testing.T) {
 				},
 			},
 			want1: []openaiopt.RequestOption{
-				openaiopt.WithJSONSet(model.EnabledThinkingKey, true),
+				openaiopt.WithJSONSet(model.EnableThinkingKey, true),
 				openaiopt.WithJSONSet(model.ThinkingTokensKey, tokens),
 			},
 		},
@@ -7110,7 +7110,7 @@ func TestBuildThinkingOption(t *testing.T) {
 			name:            "Qwen variant with thinking enabled",
 			variant:         VariantQwen,
 			thinkingEnabled: &trueVal,
-			wantKeys:        []string{model.EnabledThinkingKey},
+			wantKeys:        []string{model.EnableThinkingKey},
 			wantValues:      []any{true},
 		},
 		{

--- a/model/request.go
+++ b/model/request.go
@@ -46,7 +46,7 @@ const (
 	// EnabledThinkingKey is kept for backward compatibility.
 	//
 	// Deprecated: use EnableThinkingKey.
-	EnabledThinkingKey = EnableThinkingKey
+	EnabledThinkingKey = "enabled_thinking"
 )
 
 // String returns the string representation of the role.

--- a/model/request.go
+++ b/model/request.go
@@ -41,8 +41,12 @@ const (
 	ReasoningContentKey = "reasoning_content"
 	// ReasoningContentKeyAlt is the alternative key used by some providers (e.g. Ollama).
 	ReasoningContentKeyAlt = "reasoning"
-	// EnabledThinkingKey is the key used for enabling thinking mode in API requests e.g. Qwen model.
-	EnabledThinkingKey = "enabled_thinking"
+	// EnableThinkingKey is the key used for enabling thinking mode in API requests e.g. Qwen model.
+	EnableThinkingKey = "enable_thinking"
+	// EnabledThinkingKey is kept for backward compatibility.
+	//
+	// Deprecated: use EnableThinkingKey.
+	EnabledThinkingKey = EnableThinkingKey
 )
 
 // String returns the string representation of the role.


### PR DESCRIPTION
## What
Fix the Qwen OpenAI-compatible thinking toggle request key from `enabled_thinking` to `enable_thinking`.

## Why
Qwen's OpenAI-compatible API expects `enable_thinking`. The previous Qwen variant key was ignored by the provider, so requests with `ThinkingEnabled=false` could still use the model's default thinking behavior and return `reasoning_content`.

## Details
- Add `model.EnableThinkingKey` with the provider-recognized key.
- Keep `model.EnabledThinkingKey` deprecated with its previous wire value for source and behavior compatibility.
- Update Qwen variant request construction and tests to use `enable_thinking`.

## Validation
- `go test ./model ./model/openai -count=1`
- `go test ./...` was also run; it had one local failure in `codeexecutor/sandbox` (`TestFilesystemSymlinkAndCopyHelperBranches`) due to symlink path resolution, unrelated to this model request key change.