### PR TITLE
ci: speed up PR checks

### DIFF
--- a/.github/scripts/check-external-consumer.sh
+++ b/.github/scripts/check-external-consumer.sh
@@ -103,6 +103,23 @@ module_readable_name() {
 	printf '%s\n' "${rel_dir}"
 }
 
+module_path_from_go_mod() {
+	local mod_file="$1"
+	local directive module_path _
+	while read -r directive module_path _; do
+		if [[ "${directive}" == "module" ]]; then
+			if [[ -z "${module_path}" ]]; then
+				echo "empty module path in ${mod_file}" >&2
+				return 1
+			fi
+			printf '%s\n' "${module_path}"
+			return 0
+		fi
+	done <"${mod_file}"
+	echo "unable to read module path from ${mod_file}" >&2
+	return 1
+}
+
 is_external_importable_path() {
 	local import_path="$1"
 	[[ "${import_path}" != */internal ]] && [[ "${import_path}" != */internal/* ]]
@@ -149,11 +166,13 @@ write_consumer_test() {
 
 add_repository_replaces() {
 	local mod_file mod_dir module_path
+	local -a replace_args=()
 	for mod_file in "${repository_modules[@]}"; do
 		mod_dir="$(cd "$(dirname "${mod_file}")" && pwd)"
-		module_path="$(cd "${mod_dir}" && go list -m -f '{{.Path}}')"
-		go mod edit -replace "${module_path}=${mod_dir}"
+		module_path="$(module_path_from_go_mod "${mod_file}")"
+		replace_args+=("-replace" "${module_path}=${mod_dir}")
 	done
+	go mod edit "${replace_args[@]}"
 }
 
 check_module_as_external_consumer() {
@@ -161,7 +180,7 @@ check_module_as_external_consumer() {
 	local mod_dir module_path readable package_file consumer_dir status
 	mod_dir="$(cd "$(dirname "${mod_file}")" && pwd)"
 	readable="$(module_readable_name "${mod_file}")"
-	module_path="$(cd "${mod_dir}" && go list -m -f '{{.Path}}')"
+	module_path="$(module_path_from_go_mod "${mod_file}")"
 
 	echo "::group::External consumer: ${readable}"
 	echo "module path: ${module_path}"

--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
       - name: Build
         run: go build -v ./...
   discover-go-modules:
@@ -60,6 +65,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
       - name: Prepare module metadata
         id: module-info
         shell: bash
@@ -102,6 +112,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
       - name: Run e2e tests
         shell: bash
         run: |
@@ -148,10 +163,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
-      - uses: actions/checkout@v3
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -236,6 +256,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache: false
       - name: Check go.mod and go.sum are tidy
         shell: bash
         run: bash .github/scripts/check-go-mod-tidy.sh
@@ -251,6 +272,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
       - name: Check module as an external consumer
         shell: bash
         run: bash .github/scripts/check-external-consumer.sh --module "${{ matrix.module }}"
@@ -356,6 +382,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache: false
       - name: Validate module checksums via sumdb
         run: bash .github/scripts/check-go-sumdb.sh
   typos:
@@ -375,6 +402,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache-dependency-path: |
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
       # Use merge-base to only detect breaking changes introduced by this PR,
       # not changes from main that were merged after the PR branch was created.
       - name: Get merge base
@@ -411,6 +443,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "${{ env.ROOT_GO_VERSION }}"
+          cache: false
       - name: Validate go.mod version strings
         shell: bash
         run: bash .github/scripts/check-go-mod-version.sh


### PR DESCRIPTION
## What
Speed up the PR check workflow without reducing the validation scope.

## Changes
- Reuse Go module caches across all repository modules by keying `actions/setup-go` on every `go.mod` and `go.sum` file for jobs that use the default module cache.
- Disable unused `setup-go` cache restore in jobs whose scripts intentionally use an isolated temporary `GOMODCACHE`.
- Reduce external-consumer setup overhead by reading module paths directly from `go.mod` and writing all repository `replace` directives with a single `go mod edit` call.

## Before/After
Measured from GitHub Actions job `startedAt` to `completedAt`, excluding GitHub queued time.

Baseline runs:
- `28563674793` (`main` push, success)
- `28563586501` (PR, success)

This PR run:
- `28566845574` (success)

External consumer matrix (`68` jobs):

| Metric | Before run 28563674793 | Before run 28563586501 | This PR |
| --- | ---: | ---: | ---: |
| Average | 87.2s | 87.9s | 49.0s |
| p50 | 80s | 80s | 43s |
| p90 | 111s | 114s | 73s |
| Max | 228s | 276s | 231s |

Selected jobs:

| Job | Before 28563674793 | Before 28563586501 | This PR |
| --- | ---: | ---: | ---: |
| `check external consumer (go.mod)` | 99s | 103s | 45s |
| `check external consumer (evaluation/go.mod)` | 100s | 117s | 70s |
| `check external consumer (knowledge/vectorstore/elasticsearch/go.mod)` | 198s | 201s | 179s |
| `check external consumer (storage/elasticsearch/go.mod)` | 194s | 191s | 165s |
| `check external consumer (openclaw/go.mod)` | 228s | 276s | 231s |
| `check go mod tidy` | 109s | 113s | 100s |
| `check go.mod version` | 120s | 98s | 105s |

Notes:
- `go test` heavy modules such as `openclaw` are still dominated by their test workload and were not the target of this change.
- The main measurable win is the external-consumer matrix, where repeated setup work was removed from every module job.

## Validation
- `git diff --check`
- `bash -n .github/scripts/check-external-consumer.sh`
- Parsed `.github/workflows/prc.yml` as YAML
- Verified old and new generated external-consumer `replace` blocks are identical
- PR checks: 162 passed, 0 failed, 0 pending
