### PR TITLE
feat(sandbox): add macOS network and process capability guards

### DIFF
--- a/codeexecutor/sandbox/backend_macos_test.go
+++ b/codeexecutor/sandbox/backend_macos_test.go
@@ -13,10 +13,16 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 )
@@ -109,6 +115,63 @@ func TestMacOSPlatformTempMetadataPolicyOnly(t *testing.T) {
 	}
 }
 
+func TestMacOSNetworkExtensionPolicies(t *testing.T) {
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/network-policy", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restricted, err := rt.macosSeatbeltProfile(WorkspaceWriteProfile(), ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(restricted, "com.apple.trustd.agent") ||
+		strings.Contains(restricted, "(allow network-outbound)") {
+		t.Fatalf("restricted policy unexpectedly grants broad network/trust services:\n%s", restricted)
+	}
+
+	weaker, err := rt.macosSeatbeltProfile(
+		WorkspaceWriteProfile().WithMacOSWeakerNetworkIsolation(),
+		ws,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(weaker, "com.apple.trustd.agent") {
+		t.Fatalf("weaker macOS network policy missing trustd.agent:\n%s", weaker)
+	}
+	if strings.Contains(weaker, "(allow network-outbound)") {
+		t.Fatalf("weaker macOS network policy should not grant broad network:\n%s", weaker)
+	}
+
+	socketPath := filepath.Join(t.TempDir(), "demo.sock")
+	unixSockets, err := rt.macosSeatbeltProfile(
+		WorkspaceWriteProfile().WithMacOSUnixSocketPaths(socketPath),
+		ws,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"(allow system-socket (socket-domain AF_UNIX))",
+		"(allow network-bind (local unix-socket (path-literal " + sbplString(socketPath) + ")))",
+		"(allow network-outbound (remote unix-socket (path-literal " + sbplString(socketPath) + ")))",
+	} {
+		if !strings.Contains(unixSockets, want) {
+			t.Fatalf("unix socket policy missing %q:\n%s", want, unixSockets)
+		}
+	}
+
+	_, err = rt.macosSeatbeltProfile(
+		WorkspaceWriteProfile().WithMacOSUnixSocketPaths("relative.sock"),
+		ws,
+	)
+	if !isKind(err, ErrPolicyViolation) {
+		t.Fatalf("relative Unix socket path error = %v, want ErrPolicyViolation", err)
+	}
+}
+
 func TestMacOSSandboxExecRejectsHostTempFileRead(t *testing.T) {
 	if _, err := os.Stat(macosSandboxExecPath); err != nil {
 		t.Skip("sandbox-exec not available")
@@ -162,6 +225,26 @@ func TestMacOSRuleTargetRejectsAbsoluteWorkspaceSymlinkGrant(t *testing.T) {
 	)
 	if !isKind(err, ErrPathDenied) || ok || target != "" {
 		t.Fatalf("macosRuleTarget = target=%q ok=%v err=%v, want denied", target, ok, err)
+	}
+}
+
+func TestMacOSRuleTargetRejectsSpecialWorkspaceSymlink(t *testing.T) {
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/special-symlink", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	work := filepath.Join(ws.Path, "work")
+	if err := os.RemoveAll(work); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, work); err != nil {
+		t.Fatal(err)
+	}
+	_, err = rt.macosSeatbeltProfile(WorkspaceWriteProfile(), ws)
+	if !isKind(err, ErrPathDenied) {
+		t.Fatalf("special workspace symlink profile error = %v, want ErrPathDenied", err)
 	}
 }
 
@@ -296,4 +379,176 @@ func TestMacOSSandboxExecNoAccessGlobHardDenyOverridesSpecificRead(t *testing.T)
 	if res.ExitCode == 0 {
 		t.Fatalf("glob hard deny was reopened by specific read grant: %#v", res)
 	}
+}
+
+func TestMacOSSandboxExecChildProcessInheritsSandbox(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	hostTemp := filepath.Join(os.TempDir(), "trpc-agent-sandbox-child-inherit-probe")
+	if err := os.WriteFile(hostTemp, []byte("host-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(hostTemp) })
+
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/child-inherit", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd: "/bin/sh",
+		Args: []string{
+			"-c",
+			`(cat "$1" > child.out 2>/dev/null; echo $? > child.status) & wait; cat child.status`,
+			"sh",
+			hostTemp,
+		},
+	})
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if strings.TrimSpace(res.Stdout) == "0" {
+		t.Fatalf("child process escaped sandbox and read host temp: %#v", res)
+	}
+}
+
+func TestMacOSSandboxExecAllowsConfiguredUnixSocket(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	socketDir, err := os.MkdirTemp("/tmp", "trpc-sock-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "demo.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	socketPolicyPath, err := canonicalizeExistingPath(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unixListener, ok := listener.(*net.UnixListener); ok {
+		if err := unixListener.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		_, err = conn.Write([]byte("UNIX_SOCKET_OK\n"))
+		done <- err
+	}()
+
+	rt := NewRuntime(
+		WithWorkspaceRoot(t.TempDir()),
+		WithPermissionProfile(
+			WorkspaceWriteProfile().
+				WithReadPaths(os.Args[0]).
+				WithMacOSUnixSocketPaths(socketPath),
+		),
+	)
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/unix-socket", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:     os.Args[0],
+		Args:    []string{"-test.run=TestMacOSUnixSocketClientHelper"},
+		Env:     map[string]string{"TRPC_MACOS_UNIX_SOCKET_HELPER": "1", "TRPC_MACOS_UNIX_SOCKET_PATH": socketPolicyPath},
+		Timeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if res.ExitCode != 0 || !strings.Contains(res.Stdout, "UNIX_SOCKET_OK") {
+		t.Fatalf("unix socket run = %#v, want successful socket read", res)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("unix socket server error: %v", err)
+	}
+}
+
+func TestMacOSUnixSocketClientHelper(t *testing.T) {
+	if os.Getenv("TRPC_MACOS_UNIX_SOCKET_HELPER") != "1" {
+		return
+	}
+	conn, err := net.DialTimeout("unix", os.Getenv("TRPC_MACOS_UNIX_SOCKET_PATH"), time.Second)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	data, err := io.ReadAll(conn)
+	_ = conn.Close()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(3)
+	}
+	fmt.Print(string(data))
+	os.Exit(0)
+}
+
+func TestMacOSSandboxExecTimeoutKillsProcessGroup(t *testing.T) {
+	if _, err := os.Stat(macosSandboxExecPath); err != nil {
+		t.Skip("sandbox-exec not available")
+	}
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	if _, err := rt.macosPreflight(); err != nil {
+		t.Skipf("sandbox-exec preflight unavailable: %v", err)
+	}
+	ws, err := rt.CreateWorkspace(context.Background(), "macos/process-timeout", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:     "/bin/sh",
+		Args:    []string{"-c", "sleep 30 & echo $! > child.pid; wait"},
+		Timeout: 200 * time.Millisecond,
+	})
+	if !isKind(err, ErrTimeout) || !res.TimedOut {
+		t.Fatalf("timeout run = result:%#v err:%v, want ErrTimeout", res, err)
+	}
+	pidBytes, readErr := os.ReadFile(filepath.Join(ws.Path, "work", "child.pid"))
+	if readErr != nil {
+		t.Fatalf("child pid file missing after timeout: %v", readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if parseErr != nil {
+		t.Fatalf("child pid = %q: %v", pidBytes, parseErr)
+	}
+	cleanupPID := 0
+	t.Cleanup(func() {
+		if cleanupPID == 0 {
+			return
+		}
+		_ = syscall.Kill(cleanupPID, syscall.SIGKILL)
+	})
+	for i := 0; i < 20; i++ {
+		if !processExists(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cleanupPID = pid
+	t.Fatalf("background child process %d still exists after timeout cleanup", pid)
+}
+
+func processExists(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
 }

--- a/codeexecutor/sandbox/backend_macos_test.go
+++ b/codeexecutor/sandbox/backend_macos_test.go
@@ -411,7 +411,15 @@ func TestMacOSSandboxExecChildProcessInheritsSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run error: %v", err)
 	}
-	if strings.TrimSpace(res.Stdout) == "0" {
+	statusText := strings.TrimSpace(res.Stdout)
+	if res.ExitCode != 0 || statusText == "" {
+		t.Fatalf("child status probe did not complete: %#v", res)
+	}
+	status, parseErr := strconv.Atoi(statusText)
+	if parseErr != nil {
+		t.Fatalf("child status = %q: %v", statusText, parseErr)
+	}
+	if status == 0 {
 		t.Fatalf("child process escaped sandbox and read host temp: %#v", res)
 	}
 }
@@ -518,12 +526,22 @@ func TestMacOSSandboxExecTimeoutKillsProcessGroup(t *testing.T) {
 	res, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
 		Cmd:     "/bin/sh",
 		Args:    []string{"-c", "sleep 30 & echo $! > child.pid; wait"},
-		Timeout: 200 * time.Millisecond,
+		Timeout: 2 * time.Second,
 	})
 	if !isKind(err, ErrTimeout) || !res.TimedOut {
 		t.Fatalf("timeout run = result:%#v err:%v, want ErrTimeout", res, err)
 	}
-	pidBytes, readErr := os.ReadFile(filepath.Join(ws.Path, "work", "child.pid"))
+	pidPath := filepath.Join(ws.Path, "work", "child.pid")
+	var pidBytes []byte
+	var readErr error
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, readErr = os.ReadFile(pidPath)
+		if readErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	if readErr != nil {
 		t.Fatalf("child pid file missing after timeout: %v", readErr)
 	}

--- a/codeexecutor/sandbox/docs/FILE_SYSTEM_POLICY.md
+++ b/codeexecutor/sandbox/docs/FILE_SYSTEM_POLICY.md
@@ -146,6 +146,11 @@ directories. The host view depends on the backend:
 - Default protected metadata still blocks writes to `.git`, `.agents`, and
   `.trpc-agent-sandbox` inside the workspace.
 
+The runtime creates the well-known workspace directories during workspace
+preparation. On macOS, these special directories are checked before they become
+Seatbelt roots so a retained workspace cannot replace `work`, `tmp`, `home`,
+`runs`, `out`, or `skills` with a symlink that points outside the workspace.
+
 ## Public Builders
 
 The builder API mirrors the access model:

--- a/codeexecutor/sandbox/docs/MACOS_BACKEND.md
+++ b/codeexecutor/sandbox/docs/MACOS_BACKEND.md
@@ -77,8 +77,56 @@ The network model stays binary:
 - `NetworkRestricted` does not add broad network allow rules.
 - `NetworkEnabled` adds broad outbound and inbound network allow rules.
 
-Proxy-aware routing, Unix socket allow-lists, and loopback-only network policies
-are not part of this implementation.
+This is not the same as Linux `--unshare-net`. Linux uses a network namespace
+boundary. macOS uses Seatbelt network rules plus Mach service and Unix socket
+policy. The cross-platform model remains binary, while macOS-specific extension
+fields expose IPC affordances that Linux does not claim to support.
+
+`WithMacOSWeakerNetworkIsolation` allows certificate trust services such as
+`com.apple.trustd.agent` for tools that need system TLS trust validation. This
+can be useful for Go-based CLI tools behind proxies or custom CAs, but it
+reduces isolation because Mach services can become data-exfiltration channels.
+
+`WithMacOSUnixSocketPaths` allows AF_UNIX socket bind/connect operations for
+explicit absolute socket paths. Linux keeps the namespace-level network model and
+does not provide a matching Unix socket path policy in this backend. Prefer the
+canonical macOS spelling for socket clients, for example `/private/tmp/...`
+instead of `/tmp/...`, because Seatbelt matches Unix socket paths at connect
+time.
+
+Proxy-aware routing, per-domain/IP/port allow-lists, and loopback-only network
+policies are not part of this implementation.
+
+## Process Model
+
+Seatbelt restrictions are inherited by child processes, so forked or exec'd
+descendants remain inside the same macOS sandbox boundary. The profile permits
+`process-fork` and `process-exec` so normal shell workflows can run, but the
+kernel continues to enforce the same file-system, network, Mach service, and
+Unix socket rules.
+
+macOS does not provide the Linux backend's PID namespace or bubblewrap
+`--die-with-parent` semantics. Runtime cancellation and timeouts rely on the
+shared Unix process-group cleanup used by the package. This is useful for
+terminating descendant processes, but it is not equivalent to a Linux PID
+namespace.
+
+## Capability Matrix
+
+| Capability | Linux `linux-bubblewrap` | macOS `macos-sandbox-exec` |
+| --- | --- | --- |
+| OS sandbox mechanism | `bubblewrap` namespaces and mounts | Apple Seatbelt through `/usr/bin/sandbox-exec` |
+| Host root visibility | Read-only bind of `/` | Selected platform defaults plus explicit grants |
+| Mount namespace | Supported | Not supported |
+| PID namespace | Supported with `--unshare-pid` | Not supported |
+| Parent death handling | `--die-with-parent` plus process-group cleanup | Process-group cleanup only |
+| Network boundary | Binary namespace model via `--unshare-net` | Binary Seatbelt model, with macOS IPC extensions |
+| Mach services | Not applicable | Backend-specific allow-list |
+| Unix socket path policy | Not exposed by this backend | Supported for exact absolute macOS socket paths |
+| Dynamic glob deny | Static mount masks | Dynamic Seatbelt regex hard deny |
+| Protected metadata | Read-only masks | Write allow exclusions |
+| Resource quotas | Not implemented | Not implemented |
+| PTY / ports / snapshot | Not implemented | Not implemented |
 
 ## Shell Environment
 
@@ -92,5 +140,7 @@ sanitized environment with `ShellEnvironmentPolicy` and passes it directly to th
 - macOS no-access glob enforcement is dynamic; Linux enforcement is based on
   static mount masks.
 - macOS uses Seatbelt rules instead of namespace and mount operations.
+- macOS does not provide PID or network namespaces; process and network
+  isolation are expressed through Seatbelt and process-group cleanup.
 - Linux behavior and tests remain unchanged; platform differences are documented
   rather than hidden behind new public APIs.

--- a/codeexecutor/sandbox/docs/NETWORK_POLICY.md
+++ b/codeexecutor/sandbox/docs/NETWORK_POLICY.md
@@ -32,6 +32,24 @@ The command then shares the host network namespace while still using the rest of
 the configured sandbox controls, such as user, PID, mount, environment, and
 filesystem policy.
 
+## macOS Enforcement
+
+The macOS backend keeps the same public binary model but projects it to
+Seatbelt rules instead of a network namespace:
+
+- `NetworkRestricted` does not add broad network allow rules.
+- `NetworkEnabled` adds broad `network-outbound`, `network-inbound`, and system
+  socket allowances, plus the system services needed for ordinary host network
+  use.
+
+macOS has network-adjacent IPC surfaces that Linux namespaces do not model in
+the same way. `WithMacOSWeakerNetworkIsolation` explicitly allows system trust
+services such as `com.apple.trustd.agent`, which can help Go-based CLI tools
+validate TLS certificates through custom CAs but weakens isolation.
+`WithMacOSUnixSocketPaths` allows AF_UNIX socket bind/connect operations for
+exact absolute socket paths. These are macOS backend extensions; the Linux
+backend does not claim support for equivalent path-level Unix socket policy.
+
 ## Scope
 
 This design keeps the first Linux implementation intentionally binary:

--- a/codeexecutor/sandbox/policy_test.go
+++ b/codeexecutor/sandbox/policy_test.go
@@ -94,6 +94,25 @@ func TestWorkspaceWriteProfileCanSetNetwork(t *testing.T) {
 	if !containsSpecialRule(profile, accessWrite, specialWork) {
 		t.Fatalf("workspace-write network profile missing work write grant: %#v", profile.fileSystem.Rules)
 	}
+
+	profile = WorkspaceWriteProfile().
+		WithMacOSWeakerNetworkIsolation().
+		WithMacOSUnixSocketPaths("/tmp/trpc-agent.sock")
+	if !profile.macOS.allowSystemTrustServices ||
+		len(profile.macOS.unixSocketPaths) != 1 ||
+		profile.macOS.unixSocketPaths[0] != "/tmp/trpc-agent.sock" {
+		t.Fatalf("macOS network extensions = %#v, want trust services and unix socket", profile.macOS)
+	}
+
+	profile = WorkspaceWriteProfile().
+		WithMacOSWeakerNetworkIsolation().
+		WithMacOSUnixSocketPaths("/tmp/trpc-agent.sock").
+		WithNetworkPolicy(NetworkPolicy{Mode: NetworkEnabled})
+	if profile.network.Mode != NetworkEnabled ||
+		!profile.macOS.allowSystemTrustServices ||
+		len(profile.macOS.unixSocketPaths) != 1 {
+		t.Fatalf("network/macos extension order changed profile: network=%#v macOS=%#v", profile.network, profile.macOS)
+	}
 }
 
 func TestShellEnvironmentPolicyDefaultAllInheritsHostEnv(t *testing.T) {

--- a/codeexecutor/sandbox/policy_test.go
+++ b/codeexecutor/sandbox/policy_test.go
@@ -115,6 +115,32 @@ func TestWorkspaceWriteProfileCanSetNetwork(t *testing.T) {
 	}
 }
 
+func TestWithMacOSUnixSocketPathsCopyOnWrite(t *testing.T) {
+	base := WorkspaceWriteProfile().WithMacOSUnixSocketPaths("/a.sock", "/b.sock", "/c.sock")
+	p1 := base.WithMacOSUnixSocketPaths("/d.sock")
+	p2 := base.WithMacOSUnixSocketPaths("/e.sock")
+
+	if len(base.macOS.unixSocketPaths) != 3 {
+		t.Fatalf("base socket paths = %#v, want 3 entries", base.macOS.unixSocketPaths)
+	}
+	if len(p1.macOS.unixSocketPaths) != 4 || p1.macOS.unixSocketPaths[3] != "/d.sock" {
+		t.Fatalf("p1 socket paths = %#v, want 4 entries ending with /d.sock", p1.macOS.unixSocketPaths)
+	}
+	if len(p2.macOS.unixSocketPaths) != 4 || p2.macOS.unixSocketPaths[3] != "/e.sock" {
+		t.Fatalf("p2 socket paths = %#v, want 4 entries ending with /e.sock", p2.macOS.unixSocketPaths)
+	}
+	if base.macOS.unixSocketPaths[0] != "/a.sock" || p1.macOS.unixSocketPaths[0] != "/a.sock" {
+		t.Fatalf("branched profiles mutated base socket list: base=%#v p1=%#v", base.macOS.unixSocketPaths, p1.macOS.unixSocketPaths)
+	}
+}
+
+func TestWithMacOSUnixSocketPathsSkipsEmptyPaths(t *testing.T) {
+	profile := WorkspaceWriteProfile().WithMacOSUnixSocketPaths("", "/tmp/x.sock", "")
+	if len(profile.macOS.unixSocketPaths) != 1 || profile.macOS.unixSocketPaths[0] != "/tmp/x.sock" {
+		t.Fatalf("socket paths = %#v, want only /tmp/x.sock", profile.macOS.unixSocketPaths)
+	}
+}
+
 func TestShellEnvironmentPolicyDefaultAllInheritsHostEnv(t *testing.T) {
 	t.Setenv("TRPC_SANDBOX_DEFAULT_ALL_VISIBLE", "yes")
 	rt := NewRuntime(WithPermissionProfile(DangerFullAccessProfile()))

--- a/codeexecutor/sandbox/profile.go
+++ b/codeexecutor/sandbox/profile.go
@@ -43,6 +43,15 @@ type PermissionProfile struct {
 	typ        permissionProfileType
 	fileSystem fileSystemPolicy
 	network    NetworkPolicy
+	macOS      macOSProfilePolicy
+}
+
+// macOSProfilePolicy describes macOS Seatbelt-specific controls. It is kept off
+// the public NetworkPolicy struct so the cross-platform network model stays
+// binary and existing NetworkPolicy literals remain source-compatible.
+type macOSProfilePolicy struct {
+	allowSystemTrustServices bool
+	unixSocketPaths          []string
 }
 
 // enforcement derives the execution mode from the profile.
@@ -113,6 +122,28 @@ func (p PermissionProfile) WithNetworkPolicy(policy NetworkPolicy) PermissionPro
 		policy.Mode = NetworkRestricted
 	}
 	p.network = policy
+	return p
+}
+
+// WithMacOSWeakerNetworkIsolation allows macOS system trust services such as
+// com.apple.trustd.agent inside the Seatbelt sandbox. It is useful for Go-based
+// CLI tools that validate TLS certificates through custom CAs, but weakens
+// network isolation and has no effect on non-macOS backends.
+func (p PermissionProfile) WithMacOSWeakerNetworkIsolation() PermissionProfile {
+	p.macOS.allowSystemTrustServices = true
+	return p
+}
+
+// WithMacOSUnixSocketPaths allows macOS Seatbelt access to exact AF_UNIX socket
+// paths. Linux keeps the existing namespace-level network model and does not
+// claim support for these macOS-specific paths.
+func (p PermissionProfile) WithMacOSUnixSocketPaths(paths ...string) PermissionProfile {
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		p.macOS.unixSocketPaths = append(p.macOS.unixSocketPaths, path)
+	}
 	return p
 }
 

--- a/codeexecutor/sandbox/profile.go
+++ b/codeexecutor/sandbox/profile.go
@@ -138,12 +138,18 @@ func (p PermissionProfile) WithMacOSWeakerNetworkIsolation() PermissionProfile {
 // paths. Linux keeps the existing namespace-level network model and does not
 // claim support for these macOS-specific paths.
 func (p PermissionProfile) WithMacOSUnixSocketPaths(paths ...string) PermissionProfile {
+	var filtered []string
 	for _, path := range paths {
-		if path == "" {
-			continue
+		if path != "" {
+			filtered = append(filtered, path)
 		}
-		p.macOS.unixSocketPaths = append(p.macOS.unixSocketPaths, path)
 	}
+	if len(filtered) == 0 {
+		return p
+	}
+	merged := make([]string, len(p.macOS.unixSocketPaths), len(p.macOS.unixSocketPaths)+len(filtered))
+	copy(merged, p.macOS.unixSocketPaths)
+	p.macOS.unixSocketPaths = append(merged, filtered...)
 	return p
 }
 

--- a/codeexecutor/sandbox/seatbelt_profile_macos.go
+++ b/codeexecutor/sandbox/seatbelt_profile_macos.go
@@ -114,6 +114,10 @@ func (r *Runtime) macosSeatbeltProfile(
 	if err != nil {
 		return "", err
 	}
+	networkPolicy, err := macosSeatbeltNetworkPolicy(profile.network, profile.macOS)
+	if err != nil {
+		return "", err
+	}
 	sections := []string{
 		macosBaseSeatbeltPolicy,
 		macosPlatformRootLiteralPolicy,
@@ -125,7 +129,7 @@ func (r *Runtime) macosSeatbeltProfile(
 		writePolicy,
 		"; deny glob-matched no-access paths",
 		globPolicy,
-		macosSeatbeltNetworkPolicy(profile.network),
+		networkPolicy,
 	}
 	return strings.Join(nonEmptySections(sections), "\n\n"), nil
 }
@@ -256,7 +260,17 @@ func (r *Runtime) macosRuleTarget(
 		return target, err == nil, err
 	case ruleSpecial:
 		target, ok, err := specialPathAbs(ws, rule.Special)
-		return target, ok, err
+		if err != nil || !ok {
+			return "", ok, err
+		}
+		wsAbs, err := filepath.Abs(ws.Path)
+		if err != nil {
+			return "", false, err
+		}
+		if err := ensureNoSymlinkEscape(wsAbs, target); err != nil {
+			return "", false, err
+		}
+		return target, true, nil
 	default:
 		return "", false, nil
 	}
@@ -465,14 +479,27 @@ func macosGlobPatternToRegex(pattern string) (string, error) {
 	return b.String(), nil
 }
 
-func macosSeatbeltNetworkPolicy(policy NetworkPolicy) string {
-	if policy.Mode != NetworkEnabled {
-		return ""
-	}
-	return `(allow network-outbound)
+func macosSeatbeltNetworkPolicy(policy NetworkPolicy, macOS macOSProfilePolicy) (string, error) {
+	var sections []string
+	if policy.Mode == NetworkEnabled {
+		sections = append(sections, `(allow network-outbound)
 (allow network-inbound)
-(allow system-socket)
-(allow mach-lookup
+(allow system-socket)`, macosNetworkMachLookupPolicy())
+	} else if macOS.allowSystemTrustServices {
+		sections = append(sections, macosSystemTrustMachLookupPolicy())
+	}
+	unixSocketPolicy, err := macosUnixSocketPolicy(macOS.unixSocketPaths)
+	if err != nil {
+		return "", err
+	}
+	if unixSocketPolicy != "" {
+		sections = append(sections, "; allow macOS Unix domain sockets for local IPC", unixSocketPolicy)
+	}
+	return strings.Join(nonEmptySections(sections), "\n"), nil
+}
+
+func macosNetworkMachLookupPolicy() string {
+	return `(allow mach-lookup
   (global-name "com.apple.SecurityServer")
   (global-name "com.apple.SystemConfiguration.DNSConfiguration")
   (global-name "com.apple.SystemConfiguration.configd")
@@ -480,6 +507,76 @@ func macosSeatbeltNetworkPolicy(policy NetworkPolicy) string {
   (global-name "com.apple.ocspd")
   (global-name "com.apple.trustd")
   (global-name "com.apple.trustd.agent"))`
+}
+
+func macosSystemTrustMachLookupPolicy() string {
+	return `(allow mach-lookup
+  (global-name "com.apple.SecurityServer")
+  (global-name "com.apple.ocspd")
+  (global-name "com.apple.trustd")
+  (global-name "com.apple.trustd.agent"))`
+}
+
+func macosUnixSocketPolicy(paths []string) (string, error) {
+	roots, err := macosUnixSocketRoots(paths)
+	if err != nil {
+		return "", err
+	}
+	if len(roots) == 0 {
+		return "", nil
+	}
+	var rules []string
+	rules = append(rules, "(allow system-socket (socket-domain AF_UNIX))")
+	for _, root := range roots {
+		path := sbplString(root)
+		rules = append(rules,
+			fmt.Sprintf("(allow file-read* file-test-existence (literal %s))", path),
+			fmt.Sprintf("(allow network-bind (literal %s))", path),
+			fmt.Sprintf("(allow network-bind (path %s))", path),
+			fmt.Sprintf("(allow network-bind (local unix-socket (path-literal %s)))", path),
+			fmt.Sprintf("(allow network-outbound (literal %s))", path),
+			fmt.Sprintf("(allow network-outbound (path %s))", path),
+			fmt.Sprintf("(allow network-outbound (remote unix-socket (path-literal %s)))", path),
+		)
+	}
+	return strings.Join(rules, "\n"), nil
+}
+
+func macosUnixSocketRoots(paths []string) ([]string, error) {
+	seen := map[string]bool{}
+	var roots []string
+	addRoot := func(path string) {
+		path = filepath.Clean(path)
+		if seen[path] {
+			return
+		}
+		seen[path] = true
+		roots = append(roots, path)
+	}
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if !filepath.IsAbs(path) {
+			return nil, deniedf(
+				ErrPolicyViolation,
+				"unix-socket",
+				path,
+				"macOS Unix socket paths must be absolute",
+			)
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+		addRoot(abs)
+		if canonical, err := canonicalizeExistingPath(abs); err == nil {
+			addRoot(canonical)
+		}
+	}
+	sort.Strings(roots)
+	return roots, nil
 }
 
 func macosPlatformDefaultReadRoots() []string {

--- a/codeexecutor/sandbox/seatbelt_profile_macos.go
+++ b/codeexecutor/sandbox/seatbelt_profile_macos.go
@@ -554,7 +554,6 @@ func macosUnixSocketRoots(paths []string) ([]string, error) {
 		roots = append(roots, path)
 	}
 	for _, path := range paths {
-		path = strings.TrimSpace(path)
 		if path == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

This follow-up clarifies and tests macOS sandbox capability boundaries after the initial macOS backend merge.

It keeps the cross-platform `NetworkPolicy` model binary, adds opt-in macOS-specific profile builders for weaker trust-service access and Unix socket paths, and documents differences from Linux namespaces.

## Changes

- Keep `NetworkPolicy` source-compatible and store macOS-only controls in `PermissionProfile`.
- Add opt-in macOS profile builders:
  - `WithMacOSWeakerNetworkIsolation`
  - `WithMacOSUnixSocketPaths`
- Refine Seatbelt network policy generation for:
  - trustd / trust services
  - exact Unix socket paths
- Add regression coverage for:
  - restricted policy not allowing trustd by default
  - Unix socket allow-list
  - child process sandbox inheritance
  - timeout process-group cleanup
  - special workspace dir symlink escape
- Add macOS capability matrix and network/process boundary docs.

## Test

- `go test ./codeexecutor/sandbox -cover`
- `cd examples && go test ./sandboxcodeexecution`
- `cd examples && go run ./sandboxcodeexecution -scenario network-restricted -require-os-sandbox=true`
- `cd openclaw && go test ./app -run 'Test.*CodeExecutor|Test.*Sandbox'`