### PR TITLE
{runner/trpcagent, examples, docs}: add remote runner

### DIFF
--- a/docs/mkdocs/en/runner.md
+++ b/docs/mkdocs/en/runner.md
@@ -1917,6 +1917,68 @@ Tools, plugins, Skills, MCP ToolSets, and callbacks execute during candidate run
 
 When execution trace or Graph checkpoint resume is enabled, this turn bypasses Best-of-N candidate selection and follows the original Runner flow.
 
+## Remote tRPC-Agent Runner
+
+`runner/trpcagent` turns a `Runner.Run` call into an HTTP request to the [tRPC-Agent API](trpcagent.md). It is useful when the platform and business Agent service are deployed separately: the business service exposes the real Agent through `server/trpcagent`, and the platform side uses `runner/trpcagent` like a regular Runner.
+
+Expose the [tRPC-Agent API](trpcagent.md) on the user service side first:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/trpcagent"
+)
+
+agentRunner := runner.NewRunner(appName, agent)
+defer agentRunner.Close()
+
+server, err := trpcagent.New(
+	trpcagent.WithAppName(appName),
+	trpcagent.WithAgent(agent),
+	trpcagent.WithRunner(agentRunner),
+)
+if err != nil {
+	return err
+}
+http.ListenAndServe(":8080", server.Handler())
+```
+
+Create the remote Runner on the platform side:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	trpcagentrunner "trpc.group/trpc-go/trpc-agent-go/runner/trpcagent"
+)
+
+remoteRunner, err := trpcagentrunner.New(
+	"calculator",
+	trpcagentrunner.WithTarget("http://127.0.0.1:8080"),
+)
+if err != nil {
+	return err
+}
+defer remoteRunner.Close()
+
+snapshot, err := remoteRunner.Describe(ctx)
+if err != nil {
+	return err
+}
+_ = snapshot
+
+events, err := remoteRunner.Run(
+	ctx,
+	"user1",
+	"session1",
+	model.NewUserMessage("Use the calculator to compute 12 * 7."),
+)
+if err != nil {
+	return err
+}
+```
+
+The default path is `/trpc-agent/v1/apps/{appName}`. `Describe` requests the remote structure, and `Run` requests the remote runs endpoint and restores the response into the framework-standard `event.Event` stream. For complete code, see `examples/trpcagent`.
+
 ## 📝 Summary
 
 The Runner component is a core part of the tRPC-Agent-Go framework, providing complete conversation management and Agent orchestration capabilities. By properly using session management, tool integration, and event handling, you can build powerful intelligent conversational applications.

--- a/docs/mkdocs/zh/runner.md
+++ b/docs/mkdocs/zh/runner.md
@@ -1842,6 +1842,68 @@ bestOfNOpt, err := bestofn.NewRunnerOption(
 
 开启执行链路追踪或 Graph checkpoint 恢复时，本轮会绕过 Best-of-N 候选选择，按原有 Runner 流程执行。
 
+## 远程 tRPC-Agent Runner
+
+`runner/trpcagent` 用于把一次 `Runner.Run` 调用转成 [tRPC-Agent API](trpcagent.md) HTTP 请求。它适合平台和业务 Agent 服务分离的场景：业务服务用 `server/trpcagent` 暴露真实 Agent，平台侧用 `runner/trpcagent` 像普通 Runner 一样发起运行。
+
+用户服务侧先暴露 [tRPC-Agent API](trpcagent.md)：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/trpcagent"
+)
+
+agentRunner := runner.NewRunner(appName, agent)
+defer agentRunner.Close()
+
+server, err := trpcagent.New(
+	trpcagent.WithAppName(appName),
+	trpcagent.WithAgent(agent),
+	trpcagent.WithRunner(agentRunner),
+)
+if err != nil {
+	return err
+}
+http.ListenAndServe(":8080", server.Handler())
+```
+
+平台侧创建远程 Runner：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	trpcagentrunner "trpc.group/trpc-go/trpc-agent-go/runner/trpcagent"
+)
+
+remoteRunner, err := trpcagentrunner.New(
+	"calculator",
+	trpcagentrunner.WithTarget("http://127.0.0.1:8080"),
+)
+if err != nil {
+	return err
+}
+defer remoteRunner.Close()
+
+snapshot, err := remoteRunner.Describe(ctx)
+if err != nil {
+	return err
+}
+_ = snapshot
+
+events, err := remoteRunner.Run(
+	ctx,
+	"user1",
+	"session1",
+	model.NewUserMessage("Use the calculator to compute 12 * 7."),
+)
+if err != nil {
+	return err
+}
+```
+
+默认路径为 `/trpc-agent/v1/apps/{appName}`。`Describe` 请求远端 structure，`Run` 请求远端 runs 接口并恢复为框架标准 `event.Event` 流。更多完整代码可参考 `examples/trpcagent`。
+
 ## 📝 总结
 
 Runner 组件是 tRPC-Agent-Go 框架的核心，提供了完整的对话管理和 Agent 编排能力。通过合理使用会话管理、工具集成和事件处理，可以构建强大的智能对话应用。

--- a/examples/trpcagent/README.md
+++ b/examples/trpcagent/README.md
@@ -1,0 +1,26 @@
+# tRPC-Agent API Examples
+
+These examples show the two sides of the tRPC-Agent API.
+
+- `server` exposes a local `tRPC-Agent-Go` agent as an HTTP tRPC-Agent API service.
+- `client` calls that HTTP service through `runner/trpcagent`, using the standard runner interface.
+
+## Run
+
+Start the server from the `examples` module:
+
+```bash
+go run ./trpcagent/server
+```
+
+Then run the client in another terminal:
+
+```bash
+go run ./trpcagent/client
+```
+
+Both examples default to app `calculator`, base path `/trpc-agent/v1/apps`, and target `http://127.0.0.1:8080`.
+
+The server owns the model provider configuration and needs the same environment as `model/openai`, such as `OPENAI_API_KEY` and compatible base URL variables. The client only creates a remote runner and sends one request to the default local service.
+
+See `server/README.md` and `client/README.md` for the focused usage of each side.

--- a/examples/trpcagent/client/README.md
+++ b/examples/trpcagent/client/README.md
@@ -1,0 +1,24 @@
+# tRPC-Agent API Client
+
+This example calls a `server/trpcagent` HTTP service through the `runner/trpcagent` remote runner.
+
+It demonstrates:
+
+- Fetching the remote app structure with `Describe`.
+- Running the remote app through the standard runner interface.
+
+## Run
+
+Start the server example first:
+
+```bash
+go run ./trpcagent/server
+```
+
+Then run the client from the `examples` module:
+
+```bash
+go run ./trpcagent/client
+```
+
+The server example still owns the model provider configuration. The client only creates a remote runner and sends one request to the default local service.

--- a/examples/trpcagent/client/main.go
+++ b/examples/trpcagent/client/main.go
@@ -1,0 +1,135 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main calls a tRPC-Agent API server through the remote runner.
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	trpcagentrunner "trpc.group/trpc-go/trpc-agent-go/runner/trpcagent"
+)
+
+const (
+	target    = "http://127.0.0.1:8080"
+	appName   = "calculator"
+	userID    = "alice"
+	sessionID = "demo-session"
+	prompt    = "Use the calculator to compute 12 * 7."
+)
+
+func main() {
+	ctx := context.Background()
+	r, err := trpcagentrunner.New(appName, trpcagentrunner.WithTarget(target))
+	if err != nil {
+		log.Fatalf("failed to create tRPC-Agent runner: %v", err)
+	}
+	defer r.Close()
+	snapshot, err := r.Describe(ctx)
+	if err != nil {
+		log.Fatalf("failed to describe remote app: %v", err)
+	}
+	printStructure(snapshot)
+	events, err := r.Run(
+		ctx,
+		userID,
+		sessionID,
+		model.NewUserMessage(prompt),
+	)
+	if err != nil {
+		log.Fatalf("remote run failed: %v", err)
+	}
+	if err := printEvents(events); err != nil {
+		log.Fatalf("remote run event failed: %v", err)
+	}
+}
+
+func printStructure(snapshot *astructure.Snapshot) {
+	if snapshot == nil {
+		fmt.Println("structure: empty")
+		return
+	}
+	fmt.Printf("structure: id=%s entry=%s nodes=%d surfaces=%d\n", snapshot.StructureID, snapshot.EntryNodeID, len(snapshot.Nodes), len(snapshot.Surfaces))
+	for _, surface := range snapshot.Surfaces {
+		fmt.Printf("surface: id=%s node=%s type=%s\n", surface.SurfaceID, surface.NodeID, surface.Type)
+	}
+}
+
+func printEvents(eventCh <-chan *event.Event) error {
+	var final strings.Builder
+	streamed := false
+	for evt := range eventCh {
+		if evt == nil || evt.Response == nil {
+			continue
+		}
+		if evt.Error != nil {
+			return fmt.Errorf("runner event error: %s", evt.Error.Message)
+		}
+		if evt.IsToolCallResponse() {
+			printToolCalls(evt)
+		}
+		if evt.IsToolResultResponse() {
+			printToolResults(evt)
+		}
+		appendAssistantContent(evt, &final, &streamed)
+		if evt.IsRunnerCompletion() {
+			break
+		}
+	}
+	if final.Len() > 0 {
+		fmt.Printf("assistant: %s\n", final.String())
+	}
+	return nil
+}
+
+func appendAssistantContent(evt *event.Event, final *strings.Builder, streamed *bool) {
+	for _, choice := range evt.Choices {
+		if choice.Delta.Content != "" {
+			final.WriteString(choice.Delta.Content)
+			*streamed = true
+		}
+		if !*streamed && choice.Message.Role == model.RoleAssistant && choice.Message.Content != "" {
+			final.WriteString(choice.Message.Content)
+		}
+	}
+}
+
+func printToolCalls(evt *event.Event) {
+	for _, choice := range evt.Choices {
+		for _, toolCall := range choice.Message.ToolCalls {
+			fmt.Printf("tool call: name=%s id=%s args=%s\n", toolCall.Function.Name, toolCall.ID, compactJSON(toolCall.Function.Arguments))
+		}
+		for _, toolCall := range choice.Delta.ToolCalls {
+			fmt.Printf("tool call: name=%s id=%s args=%s\n", toolCall.Function.Name, toolCall.ID, compactJSON(toolCall.Function.Arguments))
+		}
+	}
+}
+
+func printToolResults(evt *event.Event) {
+	for _, choice := range evt.Choices {
+		if choice.Message.Role == model.RoleTool {
+			fmt.Printf("tool result: id=%s content=%s\n", choice.Message.ToolID, choice.Message.Content)
+		}
+		if choice.Delta.Role == model.RoleTool {
+			fmt.Printf("tool result: id=%s content=%s\n", choice.Delta.ToolID, choice.Delta.Content)
+		}
+	}
+}
+
+func compactJSON(raw []byte) string {
+	if len(raw) == 0 {
+		return "{}"
+	}
+	return string(raw)
+}

--- a/examples/trpcagent/server/README.md
+++ b/examples/trpcagent/server/README.md
@@ -24,6 +24,12 @@ go run ./trpcagent/server \
   -address 127.0.0.1:8080
 ```
 
+The companion client example can call this server through `runner/trpcagent`:
+
+```bash
+go run ./trpcagent/client
+```
+
 ## Fetch structure
 
 ```bash

--- a/runner/trpcagent/options.go
+++ b/runner/trpcagent/options.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trpcagent
+
+import "net/http"
+
+// Option configures a tRPC-Agent API runner.
+type Option func(*options)
+
+type options struct {
+	target     string
+	basePath   string
+	httpClient *http.Client
+	headers    http.Header
+}
+
+// WithTarget sets the tRPC-Agent API service target.
+func WithTarget(target string) Option {
+	return func(opts *options) {
+		opts.target = target
+	}
+}
+
+// WithBasePath sets the tRPC-Agent API base path.
+func WithBasePath(basePath string) Option {
+	return func(opts *options) {
+		opts.basePath = basePath
+	}
+}
+
+// WithHTTPClient sets the HTTP client used by the runner.
+// Custom transports may resolve non-http targets such as service discovery schemes.
+func WithHTTPClient(client *http.Client) Option {
+	return func(opts *options) {
+		opts.httpClient = client
+	}
+}
+
+// WithHeader sets one HTTP header on every tRPC-Agent API request.
+func WithHeader(key string, value string) Option {
+	return func(opts *options) {
+		if key == "" {
+			return
+		}
+		if opts.headers == nil {
+			opts.headers = make(http.Header)
+		}
+		opts.headers.Set(key, value)
+	}
+}
+
+func newOptions(opts ...Option) options {
+	options := options{
+		basePath:   defaultBasePath,
+		headers:    make(http.Header),
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	return options
+}

--- a/runner/trpcagent/runner.go
+++ b/runner/trpcagent/runner.go
@@ -114,6 +114,9 @@ func (r *runner) Describe(ctx context.Context) (*astructure.Snapshot, error) {
 	if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
 		return nil, fmt.Errorf("trpcagent runner: decode describe response: %w", err)
 	}
+	if response.Structure == nil {
+		return nil, errors.New("trpcagent runner: describe response structure is empty")
+	}
 	return response.Structure, nil
 }
 

--- a/runner/trpcagent/runner.go
+++ b/runner/trpcagent/runner.go
@@ -1,0 +1,263 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package trpcagent provides a remote runner for the tRPC-Agent API.
+package trpcagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/profilecompiler"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	rootrunner "trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+const (
+	defaultBasePath = "/trpc-agent/v1/apps"
+	headerAccept    = "Accept"
+	headerContent   = "Content-Type"
+	contentTypeJSON = "application/json"
+)
+
+// runner calls a tRPC-Agent API service.
+type runner struct {
+	appName    string
+	target     string
+	basePath   string
+	httpClient *http.Client
+	headers    http.Header
+}
+
+// New creates a runner that calls a tRPC-Agent API service.
+func New(appName string, opts ...Option) (*runner, error) {
+	options := newOptions(opts...)
+	if appName == "" {
+		return nil, errors.New("trpcagent runner: app name must not be empty")
+	}
+	if options.target == "" {
+		return nil, errors.New("trpcagent runner: target must not be empty")
+	}
+	return &runner{
+		appName:    appName,
+		target:     options.target,
+		basePath:   options.basePath,
+		httpClient: options.httpClient,
+		headers:    options.headers,
+	}, nil
+}
+
+func (r *runner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	runOpts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	options := agent.NewRunOptions(runOpts...)
+	if options.RequestID == "" {
+		options.RequestID = uuid.NewString()
+	}
+	request := r.newRunRequest(userID, sessionID, message, options)
+	response, err := r.postRun(ctx, request, options)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRunResponse(options, response); err != nil {
+		return nil, err
+	}
+	events := r.eventsFromWireEvents(options, response)
+	ch := make(chan *event.Event, len(events))
+	for _, evt := range events {
+		ch <- evt
+	}
+	close(ch)
+	return ch, nil
+}
+
+// Describe fetches the remote app structure.
+func (r *runner) Describe(ctx context.Context) (*astructure.Snapshot, error) {
+	endpoint, err := r.describeEndpoint()
+	if err != nil {
+		return nil, fmt.Errorf("trpcagent runner: build describe endpoint: %w", err)
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("trpcagent runner: build describe request: %w", err)
+	}
+	httpRequest.Header.Set(headerAccept, contentTypeJSON)
+	r.addHeaders(httpRequest)
+	httpResponse, err := r.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("trpcagent runner: describe: %w", err)
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
+		return nil, r.httpStatusError("describe", httpResponse)
+	}
+	var response structureResponse
+	if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("trpcagent runner: decode describe response: %w", err)
+	}
+	return response.Structure, nil
+}
+
+func (r *runner) newRunRequest(
+	userID string,
+	sessionID string,
+	message model.Message,
+	options agent.RunOptions,
+) runRequest {
+	request := runRequest{
+		Session: session{
+			UserID:    userID,
+			SessionID: sessionID,
+		},
+		Input: message,
+		RunOptions: runOptions{
+			RequestID:             options.RequestID,
+			ExecutionTraceEnabled: options.ExecutionTraceEnabled,
+		},
+	}
+	if profile := profilecompiler.ProfileFromRunOptions(options); profile != nil {
+		request.Profile = profile
+	}
+	return request
+}
+
+func (r *runner) postRun(
+	ctx context.Context,
+	request runRequest,
+	options agent.RunOptions,
+) (*runResponse, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(request); err != nil {
+		return nil, fmt.Errorf("trpcagent runner: encode run request: %w", err)
+	}
+	endpoint, err := r.runEndpoint(options)
+	if err != nil {
+		return nil, fmt.Errorf("trpcagent runner: build run endpoint: %w", err)
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return nil, fmt.Errorf("trpcagent runner: build run request: %w", err)
+	}
+	httpRequest.Header.Set(headerContent, contentTypeJSON)
+	httpRequest.Header.Set(headerAccept, contentTypeJSON)
+	r.addHeaders(httpRequest)
+	httpResponse, err := r.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("trpcagent runner: post run: %w", err)
+	}
+	defer httpResponse.Body.Close()
+	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
+		return nil, r.httpStatusError("run", httpResponse)
+	}
+	var response runResponse
+	if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("trpcagent runner: decode run response: %w", err)
+	}
+	return &response, nil
+}
+
+func (r *runner) runEndpoint(options agent.RunOptions) (string, error) {
+	appName := r.appName
+	if options.AppName != "" {
+		appName = options.AppName
+	}
+	return url.JoinPath(r.target, r.basePath, appName, "runs")
+}
+
+func (r *runner) describeEndpoint() (string, error) {
+	return url.JoinPath(r.target, r.basePath, r.appName, "structure")
+}
+
+func (r *runner) addHeaders(request *http.Request) {
+	for key, values := range r.headers {
+		for _, value := range values {
+			request.Header.Add(key, value)
+		}
+	}
+}
+
+func (r *runner) httpStatusError(operation string, response *http.Response) error {
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("trpcagent runner: %s returned %s", operation, response.Status)
+	}
+	detail := string(body)
+	if message := errorMessageFromBody(body); message != "" {
+		detail = message
+	}
+	if detail == "" {
+		return fmt.Errorf("trpcagent runner: %s returned %s", operation, response.Status)
+	}
+	return fmt.Errorf("trpcagent runner: %s returned %s: %s", operation, response.Status, detail)
+}
+
+func errorMessageFromBody(body []byte) string {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	message, ok := payload["error"].(string)
+	if !ok {
+		return ""
+	}
+	return message
+}
+
+func validateRunResponse(options agent.RunOptions, response *runResponse) error {
+	if len(response.Events) == 0 {
+		return errors.New("trpcagent runner: run response events are empty")
+	}
+	for i := range response.Events {
+		requestID := response.Events[i].RequestID
+		if requestID == "" {
+			return fmt.Errorf("trpcagent runner: event %d request id is empty", i)
+		}
+		if requestID != options.RequestID {
+			return fmt.Errorf("trpcagent runner: event %d request id %q does not match run request id %q", i, requestID, options.RequestID)
+		}
+	}
+	if !response.Events[len(response.Events)-1].IsRunnerCompletion() {
+		return errors.New("trpcagent runner: run response last event is not runner completion")
+	}
+	return nil
+}
+
+func (r *runner) eventsFromWireEvents(
+	options agent.RunOptions,
+	response *runResponse,
+) []*event.Event {
+	events := make([]*event.Event, 0, len(response.Events))
+	for i := range response.Events {
+		evt := response.Events[i]
+		if evt.IsRunnerCompletion() && evt.ExecutionTrace == nil {
+			evt.ExecutionTrace = response.ExecutionTrace
+		}
+		events = append(events, &evt)
+	}
+	return events
+}
+
+func (r *runner) Close() error {
+	return nil
+}
+
+var _ rootrunner.Runner = (*runner)(nil)

--- a/runner/trpcagent/runner_test.go
+++ b/runner/trpcagent/runner_test.go
@@ -1,0 +1,766 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trpcagent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/profilecompiler"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	rootrunner "trpc.group/trpc-go/trpc-agent-go/runner"
+	servertrpcagent "trpc.group/trpc-go/trpc-agent-go/server/trpcagent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestRunPostsRequestAndConvertsResponseEvents(t *testing.T) {
+	var got runRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/trpc-agent/v1/apps/sports-agent/runs", r.URL.Path)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		toolCall := event.NewResponseEvent("inv-1", "writer", &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						ID:   "call-1",
+						Type: "function",
+						Function: model.FunctionDefinitionParam{
+							Name:      "fetch_match",
+							Arguments: []byte(`{"matchId":"match_001"}`),
+						},
+					}},
+				},
+			}},
+		})
+		toolResult := event.NewResponseEvent("inv-1", "writer", &model.Response{
+			Object: model.ObjectTypeToolResponse,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "fetch_match", `{"homeScore":102}`),
+			}},
+		})
+		final := event.NewResponseEvent("inv-1", "writer", &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("home team won"),
+			}},
+		})
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		w.Header().Set("Content-Type", "application/json")
+		got = writeRunResponse(t, w, r, runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{*toolCall, *toolResult, *final, *completion},
+			ExecutionTrace: &atrace.Trace{
+				RootInvocationID: "inv-1",
+				SessionID:        "session-1",
+				Status:           atrace.TraceStatusCompleted,
+			},
+		})
+	}))
+	defer server.Close()
+	runner, err := New(
+		"sports-agent",
+		WithTarget(server.URL),
+		WithHeader("Authorization", "Bearer token"),
+	)
+	require.NoError(t, err)
+	runOpts := []agent.RunOption{
+		agent.WithRequestID("req-1"),
+		agent.WithExecutionTraceEnabled(true),
+	}
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("match_001"),
+		runOpts...,
+	)
+	require.NoError(t, err)
+	gotEvents := collectEvents(events)
+	require.Len(t, gotEvents, 4)
+	assert.Equal(t, "user-1", got.Session.UserID)
+	assert.Equal(t, "session-1", got.Session.SessionID)
+	assert.Equal(t, model.NewUserMessage("match_001"), got.Input)
+	assert.Equal(t, "req-1", got.RunOptions.RequestID)
+	assert.True(t, got.RunOptions.ExecutionTraceEnabled)
+	assert.True(t, gotEvents[0].IsToolCallResponse())
+	assert.True(t, gotEvents[1].IsToolResultResponse())
+	assert.Equal(t, model.ObjectTypeChatCompletion, gotEvents[2].Object)
+	assert.Equal(t, "home team won", gotEvents[2].Choices[0].Message.Content)
+	assert.True(t, gotEvents[3].IsRunnerCompletion())
+	assert.True(t, gotEvents[3].Done)
+	assert.Equal(t, "req-1", gotEvents[3].RequestID)
+	require.NotNil(t, gotEvents[3].ExecutionTrace)
+	assert.Equal(t, "inv-1", gotEvents[3].ExecutionTrace.RootInvocationID)
+}
+
+func TestRunPreservesWireEventMetadata(t *testing.T) {
+	wireEvent := event.NewResponseEvent("child-inv", "worker", &model.Response{
+		ID:     "rsp-1",
+		Object: model.ObjectTypeChatCompletion,
+		Choices: []model.Choice{{
+			Delta: model.Message{Content: "partial"},
+		}},
+	})
+	wireEvent.ParentInvocationID = "parent-inv"
+	wireEvent.ParentMetadata = &event.ParentInvocationMetadata{
+		TriggerType: event.TriggerTypeToolCall,
+		TriggerID:   "call-1",
+		TriggerName: "worker",
+	}
+	wireEvent.Branch = "parent/worker"
+	wireEvent.StateDelta = map[string][]byte{"state": []byte(`"value"`)}
+	wireEvent.Extensions = map[string]json.RawMessage{"ext": json.RawMessage(`{"ok":true}`)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		completion := event.NewResponseEvent("child-inv", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		writeRunResponse(t, w, r, runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{
+				*wireEvent,
+				*completion,
+			},
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("input"),
+		agent.WithRequestID("req-1"),
+	)
+	require.NoError(t, err)
+	gotEvents := collectEvents(events)
+	require.Len(t, gotEvents, 2)
+	got := gotEvents[0]
+	assert.Equal(t, "req-1", got.RequestID)
+	assert.Equal(t, "child-inv", got.InvocationID)
+	assert.Equal(t, "worker", got.Author)
+	assert.Equal(t, "parent-inv", got.ParentInvocationID)
+	require.NotNil(t, got.ParentMetadata)
+	assert.Equal(t, "call-1", got.ParentMetadata.TriggerID)
+	assert.Equal(t, "parent/worker", got.Branch)
+	assert.Equal(t, []byte(`"value"`), got.StateDelta["state"])
+	assert.JSONEq(t, `{"ok":true}`, string(got.Extensions["ext"]))
+}
+
+func TestRunRejectsSuccessResponseWithoutRunnerCompletion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeRunResponse(t, w, r, runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{
+				*event.NewResponseEvent("inv-1", "writer", &model.Response{
+					Object: model.ObjectTypeChatCompletion,
+					Done:   true,
+					Choices: []model.Choice{{
+						Message: model.NewAssistantMessage("done"),
+					}},
+				}),
+			},
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("input"),
+	)
+	require.Nil(t, events)
+	require.EqualError(t, err, "trpcagent runner: run response last event is not runner completion")
+}
+
+func TestRunPostsAttachedProfile(t *testing.T) {
+	var got runRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		got = writeRunResponse(t, w, r, runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{*completion},
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	instruction := "patched prompt"
+	profile := &profilecompiler.Profile{
+		StructureID: "structure",
+		Overrides: []profilecompiler.SurfaceOverride{
+			{
+				SurfaceID: "writer#instruction",
+				NodeID:    "writer",
+				Type:      astructure.SurfaceTypeInstruction,
+				Value:     astructure.SurfaceValue{Text: &instruction},
+			},
+		},
+	}
+	runOpts, err := profilecompiler.CompileRunOptions(profile, true)
+	require.NoError(t, err)
+	runOpts = append(runOpts, profilecompiler.WithProfile(profile))
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("match_001"),
+		runOpts...,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	require.NotNil(t, got.Profile)
+	assert.True(t, got.RunOptions.ExecutionTraceEnabled)
+	require.Len(t, got.Profile.Overrides, 1)
+	assert.Equal(t, "writer#instruction", got.Profile.Overrides[0].SurfaceID)
+	assert.Equal(t, "writer", got.Profile.Overrides[0].NodeID)
+	assert.Equal(t, astructure.SurfaceTypeInstruction, got.Profile.Overrides[0].Type)
+	require.NotNil(t, got.Profile.Overrides[0].Value.Text)
+	assert.Equal(t, "patched prompt", *got.Profile.Overrides[0].Value.Text)
+}
+
+func TestRunUsesAppNameOverrideAndBasePath(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		completion := event.NewResponseEvent("inv-1", "tenant app", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		writeRunResponse(t, w, r, runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{*completion},
+		})
+	}))
+	defer server.Close()
+	runner, err := New(
+		"default-app",
+		WithTarget(server.URL),
+		WithBasePath("/custom/apps"),
+	)
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+		agent.WithAppName("tenant app"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/apps/tenant%20app/runs", gotPath)
+	gotEvents := collectEvents(events)
+	require.Len(t, gotEvents, 1)
+	assert.True(t, gotEvents[0].IsRunnerCompletion())
+	assert.Equal(t, "tenant app", gotEvents[0].Author)
+	assert.NotEmpty(t, gotEvents[0].RequestID)
+}
+
+func TestRunReturnsHTTPStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "invalid request"}))
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.Nil(t, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400 Bad Request")
+	assert.Contains(t, err.Error(), "invalid request")
+}
+
+func TestRunUsesWireRunErrorEvents(t *testing.T) {
+	trace := &atrace.Trace{
+		RootInvocationID: "inv-1",
+		SessionID:        "session-1",
+		Status:           atrace.TraceStatusFailed,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		errorEvent := event.NewErrorEvent("inv-1", "sports-agent", model.ErrorTypeRunError, "run failed")
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+			Error: &model.ResponseError{
+				Type:    model.ErrorTypeRunError,
+				Message: "run failed",
+			},
+		})
+		writeRunResponse(t, w, r, runResponse{
+			Status:         atrace.TraceStatusFailed,
+			Events:         []event.Event{*errorEvent, *completion},
+			ExecutionTrace: trace,
+			ErrorMessage:   "run failed",
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	gotEvents := collectEvents(events)
+	require.Len(t, gotEvents, 2)
+	assert.True(t, gotEvents[0].IsTerminalError())
+	assert.Equal(t, "run failed", gotEvents[0].Error.Message)
+	assert.True(t, gotEvents[1].IsRunnerCompletion())
+	assert.Equal(t, "run failed", gotEvents[1].Error.Message)
+	assert.Equal(t, trace, gotEvents[1].ExecutionTrace)
+}
+
+func TestRunRejectsResponseWithoutEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeRunResponse(t, w, r, runResponse{
+			Status:       atrace.TraceStatusFailed,
+			ErrorMessage: "run failed",
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.Nil(t, events)
+	require.EqualError(t, err, "trpcagent runner: run response events are empty")
+}
+
+func TestRunRejectsMismatchedEventRequestID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		completion.RequestID = "other-req"
+		writeRunResponse(t, w, r, runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{*completion},
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+		agent.WithRequestID("req-1"),
+	)
+	require.Nil(t, events)
+	require.EqualError(t, err, `trpcagent runner: event 0 request id "other-req" does not match run request id "req-1"`)
+}
+
+func TestRunRejectsMissingEventRequestID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		require.NoError(t, json.NewEncoder(w).Encode(runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{*completion},
+		}))
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+		agent.WithRequestID("req-1"),
+	)
+	require.Nil(t, events)
+	require.EqualError(t, err, "trpcagent runner: event 0 request id is empty")
+}
+
+func TestRunPreservesCompletedErrorMessage(t *testing.T) {
+	trace := &atrace.Trace{
+		RootInvocationID: "inv-1",
+		SessionID:        "session-1",
+		Status:           atrace.TraceStatusCompleted,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+			Error: &model.ResponseError{
+				Type:    model.ErrorTypeRunError,
+				Message: "stop requested",
+			},
+		})
+		writeRunResponse(t, w, r, runResponse{
+			Status:         atrace.TraceStatusCompleted,
+			Events:         []event.Event{*completion},
+			ExecutionTrace: trace,
+			ErrorMessage:   "stop requested",
+		})
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	gotEvents := collectEvents(events)
+	require.Len(t, gotEvents, 1)
+	assert.True(t, gotEvents[0].IsRunnerCompletion())
+	require.NotNil(t, gotEvents[0].Error)
+	assert.Equal(t, model.ErrorTypeRunError, gotEvents[0].Error.Type)
+	assert.Equal(t, "stop requested", gotEvents[0].Error.Message)
+	assert.Equal(t, atrace.TraceStatusCompleted, gotEvents[0].ExecutionTrace.Status)
+}
+
+func TestRunInteroperatesWithServerTRPCAgent(t *testing.T) {
+	completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+		Object: model.ObjectTypeRunnerCompletion,
+		Done:   true,
+	})
+	completion.ExecutionTrace = &atrace.Trace{
+		RootInvocationID: "inv-1",
+		SessionID:        "session-1",
+		Status:           atrace.TraceStatusCompleted,
+		Steps: []atrace.Step{{
+			StepID:            "step-1",
+			NodeID:            "writer",
+			AppliedSurfaceIDs: []string{"writer#instruction"},
+		}},
+	}
+	serverRunner := &fakeServerRunner{
+		events: []*event.Event{
+			event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+				Object: model.ObjectTypeChatCompletion,
+				Done:   true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage("patched reply"),
+				}},
+			}),
+			completion,
+		},
+	}
+	server, err := servertrpcagent.New(
+		servertrpcagent.WithAppName("sports-agent"),
+		servertrpcagent.WithRunner(serverRunner),
+	)
+	require.NoError(t, err)
+	httpServer := httptest.NewServer(server.Handler())
+	defer httpServer.Close()
+	apiRunner, err := New("sports-agent", WithTarget(httpServer.URL))
+	require.NoError(t, err)
+	events, err := apiRunner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("input"),
+		agent.WithExecutionTraceEnabled(true),
+	)
+	require.NoError(t, err)
+	gotEvents := collectEvents(events)
+	require.Len(t, gotEvents, 2)
+	assert.Equal(t, model.ObjectTypeChatCompletion, gotEvents[0].Object)
+	assert.True(t, gotEvents[0].IsFinalResponse())
+	assert.Equal(t, "patched reply", gotEvents[0].Choices[0].Message.Content)
+	assert.True(t, gotEvents[1].IsRunnerCompletion())
+	require.NotNil(t, gotEvents[1].ExecutionTrace)
+	assert.Equal(t, "inv-1", gotEvents[1].ExecutionTrace.RootInvocationID)
+	require.Len(t, serverRunner.runOptions, 1)
+	assert.True(t, serverRunner.runOptions[0].ExecutionTraceEnabled)
+	assert.NotEmpty(t, serverRunner.runOptions[0].RequestID)
+	assert.Equal(t, serverRunner.runOptions[0].RequestID, gotEvents[0].RequestID)
+	assert.Equal(t, "input", serverRunner.message.Content)
+}
+
+func TestDescribeFetchesStructure(t *testing.T) {
+	want := testStructureSnapshot()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/custom/apps/sports%20agent/structure", r.URL.EscapedPath())
+		require.Equal(t, "application/json", r.Header.Get("Accept"))
+		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		require.NoError(t, json.NewEncoder(w).Encode(structureResponse{Structure: want}))
+	}))
+	defer server.Close()
+	runner, err := New(
+		"sports agent",
+		WithTarget(server.URL),
+		WithBasePath("/custom/apps"),
+		WithHeader("Authorization", "Bearer token"),
+	)
+	require.NoError(t, err)
+	got, err := runner.Describe(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want.StructureID, got.StructureID)
+	assert.Equal(t, want.EntryNodeID, got.EntryNodeID)
+	assert.Equal(t, want.Nodes, got.Nodes)
+	assert.Equal(t, want.Surfaces, got.Surfaces)
+}
+
+func TestDescribeInteroperatesWithServerTRPCAgent(t *testing.T) {
+	server, err := servertrpcagent.New(
+		servertrpcagent.WithAppName("sports-agent"),
+		servertrpcagent.WithAgent(&fakeStructureAgent{snapshot: testStructureSnapshot()}),
+	)
+	require.NoError(t, err)
+	httpServer := httptest.NewServer(server.Handler())
+	defer httpServer.Close()
+	runner, err := New("sports-agent", WithTarget(httpServer.URL))
+	require.NoError(t, err)
+	got, err := runner.Describe(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.NotEmpty(t, got.StructureID)
+	assert.Equal(t, "writer", got.EntryNodeID)
+	require.Len(t, got.Surfaces, 1)
+	assert.Equal(t, "writer#instruction", got.Surfaces[0].SurfaceID)
+}
+
+func TestDescribeReturnsHTTPStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusInternalServerError)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "export structure failed"}))
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	got, err := runner.Describe(context.Background())
+	require.Nil(t, got)
+	require.EqualError(t, err, "trpcagent runner: describe returned 500 Internal Server Error: export structure failed")
+}
+
+func TestDescribeAllowsCustomTargetScheme(t *testing.T) {
+	var gotRequest *http.Request
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		gotRequest = request
+		body, err := json.Marshal(structureResponse{Structure: testStructureSnapshot()})
+		require.NoError(t, err)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(string(body))),
+			Request:    request,
+		}, nil
+	})}
+	runner, err := New("sports-agent", WithTarget("polaris://trpc.foo.bar"), WithHTTPClient(httpClient))
+	require.NoError(t, err)
+	got, err := runner.Describe(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, gotRequest)
+	assert.Equal(t, http.MethodGet, gotRequest.Method)
+	assert.Equal(t, "polaris", gotRequest.URL.Scheme)
+	assert.Equal(t, "trpc.foo.bar", gotRequest.URL.Host)
+	assert.Equal(t, "/trpc-agent/v1/apps/sports-agent/structure", gotRequest.URL.Path)
+	assert.Equal(t, "application/json", gotRequest.Header.Get("Accept"))
+}
+
+func TestNewValidation(t *testing.T) {
+	runner, err := New("", WithTarget("http://example.com"))
+	require.Nil(t, runner)
+	require.EqualError(t, err, "trpcagent runner: app name must not be empty")
+	runner, err = New("app")
+	require.Nil(t, runner)
+	require.EqualError(t, err, "trpcagent runner: target must not be empty")
+}
+
+func TestRunAllowsCustomTargetScheme(t *testing.T) {
+	var gotRequest *http.Request
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		gotRequest = request
+		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Done:   true,
+		})
+		response := runResponse{
+			Status: atrace.TraceStatusCompleted,
+			Events: []event.Event{*completion},
+		}
+		var runReq runRequest
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&runReq))
+		fillResponseRequestID(&response, runReq.RunOptions.RequestID)
+		body, err := json.Marshal(response)
+		require.NoError(t, err)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(string(body))),
+			Request:    request,
+		}, nil
+	})}
+	runner, err := New("sports-agent", WithTarget("polaris://trpc.foo.bar"), WithHTTPClient(client))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	require.NotNil(t, gotRequest)
+	assert.Equal(t, "polaris", gotRequest.URL.Scheme)
+	assert.Equal(t, "trpc.foo.bar", gotRequest.URL.Host)
+	assert.Equal(t, "/trpc-agent/v1/apps/sports-agent/runs", gotRequest.URL.Path)
+}
+
+func writeRunResponse(t *testing.T, w http.ResponseWriter, r *http.Request, response runResponse) runRequest {
+	t.Helper()
+	var request runRequest
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+	fillResponseRequestID(&response, request.RunOptions.RequestID)
+	require.NoError(t, json.NewEncoder(w).Encode(response))
+	return request
+}
+
+func fillResponseRequestID(response *runResponse, requestID string) {
+	for i := range response.Events {
+		if response.Events[i].RequestID == "" {
+			response.Events[i].RequestID = requestID
+		}
+	}
+}
+
+func collectEvents(ch <-chan *event.Event) []*event.Event {
+	events := make([]*event.Event, 0)
+	for evt := range ch {
+		events = append(events, evt)
+	}
+	return events
+}
+
+type fakeServerRunner struct {
+	message    model.Message
+	runOptions []agent.RunOptions
+	events     []*event.Event
+}
+
+func (r *fakeServerRunner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	runOpts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	r.message = message
+	options := agent.NewRunOptions(runOpts...)
+	r.runOptions = append(r.runOptions, options)
+	ch := make(chan *event.Event, len(r.events))
+	for _, evt := range r.events {
+		eventValue := *evt
+		eventValue.RequestID = options.RequestID
+		ch <- &eventValue
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (r *fakeServerRunner) Close() error {
+	return nil
+}
+
+var _ rootrunner.Runner = (*fakeServerRunner)(nil)
+
+type fakeStructureAgent struct {
+	snapshot *astructure.Snapshot
+}
+
+func (a *fakeStructureAgent) Run(context.Context, *agent.Invocation) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (a *fakeStructureAgent) Tools() []tool.Tool {
+	return nil
+}
+
+func (a *fakeStructureAgent) Info() agent.Info {
+	return agent.Info{Name: "writer"}
+}
+
+func (a *fakeStructureAgent) SubAgents() []agent.Agent {
+	return nil
+}
+
+func (a *fakeStructureAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+func (a *fakeStructureAgent) Export(context.Context, astructure.ChildExporter) (*astructure.Snapshot, error) {
+	return a.snapshot, nil
+}
+
+func testStructureSnapshot() *astructure.Snapshot {
+	instruction := "base prompt"
+	return &astructure.Snapshot{
+		StructureID: "structure",
+		EntryNodeID: "writer",
+		Nodes: []astructure.Node{
+			{NodeID: "writer", Kind: astructure.NodeKindLLM, Name: "writer"},
+		},
+		Surfaces: []astructure.Surface{
+			{
+				NodeID: "writer",
+				Type:   astructure.SurfaceTypeInstruction,
+				Value:  astructure.SurfaceValue{Text: &instruction},
+			},
+		},
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/runner/trpcagent/runner_test.go
+++ b/runner/trpcagent/runner_test.go
@@ -34,10 +34,10 @@ import (
 func TestRunPostsRequestAndConvertsResponseEvents(t *testing.T) {
 	var got runRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, "/trpc-agent/v1/apps/sports-agent/runs", r.URL.Path)
-		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
-		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/trpc-agent/v1/apps/sports-agent/runs", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
 		toolCall := event.NewResponseEvent("inv-1", "writer", &model.Response{
 			Object: model.ObjectTypeChatCompletion,
 			Choices: []model.Choice{{
@@ -289,7 +289,7 @@ func TestRunUsesAppNameOverrideAndBasePath(t *testing.T) {
 func TestRunReturnsHTTPStatusError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "invalid request"}))
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "invalid request"}))
 	}))
 	defer server.Close()
 	runner, err := New("sports-agent", WithTarget(server.URL))
@@ -328,7 +328,7 @@ func TestRunReturnsDecodeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte("{"))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 	runner, err := New("sports-agent", WithTarget(server.URL))
@@ -438,7 +438,7 @@ func TestRunRejectsMissingEventRequestID(t *testing.T) {
 			Object: model.ObjectTypeRunnerCompletion,
 			Done:   true,
 		})
-		require.NoError(t, json.NewEncoder(w).Encode(runResponse{
+		assert.NoError(t, json.NewEncoder(w).Encode(runResponse{
 			Status: atrace.TraceStatusCompleted,
 			Events: []event.Event{*completion},
 		}))
@@ -560,11 +560,11 @@ func TestRunInteroperatesWithServerTRPCAgent(t *testing.T) {
 func TestDescribeFetchesStructure(t *testing.T) {
 	want := testStructureSnapshot()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "/custom/apps/sports%20agent/structure", r.URL.EscapedPath())
-		require.Equal(t, "application/json", r.Header.Get("Accept"))
-		require.Equal(t, "Bearer token", r.Header.Get("Authorization"))
-		require.NoError(t, json.NewEncoder(w).Encode(structureResponse{Structure: want}))
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/custom/apps/sports%20agent/structure", r.URL.EscapedPath())
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+		assert.NoError(t, json.NewEncoder(w).Encode(structureResponse{Structure: want}))
 	}))
 	defer server.Close()
 	runner, err := New(
@@ -604,9 +604,9 @@ func TestDescribeInteroperatesWithServerTRPCAgent(t *testing.T) {
 
 func TestDescribeReturnsHTTPStatusError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusInternalServerError)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "export structure failed"}))
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "export structure failed"}))
 	}))
 	defer server.Close()
 	runner, err := New("sports-agent", WithTarget(server.URL))
@@ -633,7 +633,7 @@ func TestDescribeReturnsDecodeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte("{"))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 	runner, err := New("sports-agent", WithTarget(server.URL))
@@ -642,6 +642,31 @@ func TestDescribeReturnsDecodeError(t *testing.T) {
 	require.Nil(t, got)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "trpcagent runner: decode describe response")
+}
+
+func TestDescribeRejectsEmptyStructure(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing structure", body: `{}`},
+		{name: "null structure", body: `{"structure":null}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(tt.body))
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+			runner, err := New("sports-agent", WithTarget(server.URL))
+			require.NoError(t, err)
+			got, err := runner.Describe(context.Background())
+			require.Nil(t, got)
+			require.EqualError(t, err, "trpcagent runner: describe response structure is empty")
+		})
+	}
 }
 
 func TestDescribeAllowsCustomTargetScheme(t *testing.T) {
@@ -759,9 +784,12 @@ func TestRunAllowsCustomTargetScheme(t *testing.T) {
 func writeRunResponse(t *testing.T, w http.ResponseWriter, r *http.Request, response runResponse) runRequest {
 	t.Helper()
 	var request runRequest
-	require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		assert.NoError(t, err)
+		return request
+	}
 	fillResponseRequestID(&response, request.RunOptions.RequestID)
-	require.NoError(t, json.NewEncoder(w).Encode(response))
+	assert.NoError(t, json.NewEncoder(w).Encode(response))
 	return request
 }
 

--- a/runner/trpcagent/runner_test.go
+++ b/runner/trpcagent/runner_test.go
@@ -11,6 +11,7 @@ package trpcagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -305,6 +306,44 @@ func TestRunReturnsHTTPStatusError(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid request")
 }
 
+func TestRunReturnsPostClientError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial failed")
+	})}
+	runner, err := New("sports-agent", WithTarget("http://example.com"), WithHTTPClient(client))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.Nil(t, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trpcagent runner: post run:")
+	assert.Contains(t, err.Error(), "dial failed")
+}
+
+func TestRunReturnsDecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte("{"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	events, err := runner.Run(
+		context.Background(),
+		"user-1",
+		"session-1",
+		model.NewUserMessage("hello"),
+	)
+	require.Nil(t, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trpcagent runner: decode run response")
+}
+
 func TestRunUsesWireRunErrorEvents(t *testing.T) {
 	trace := &atrace.Trace{
 		RootInvocationID: "inv-1",
@@ -577,6 +616,34 @@ func TestDescribeReturnsHTTPStatusError(t *testing.T) {
 	require.EqualError(t, err, "trpcagent runner: describe returned 500 Internal Server Error: export structure failed")
 }
 
+func TestDescribeReturnsClientError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial failed")
+	})}
+	runner, err := New("sports-agent", WithTarget("http://example.com"), WithHTTPClient(client))
+	require.NoError(t, err)
+	got, err := runner.Describe(context.Background())
+	require.Nil(t, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trpcagent runner: describe:")
+	assert.Contains(t, err.Error(), "dial failed")
+}
+
+func TestDescribeReturnsDecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte("{"))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	runner, err := New("sports-agent", WithTarget(server.URL))
+	require.NoError(t, err)
+	got, err := runner.Describe(context.Background())
+	require.Nil(t, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trpcagent runner: decode describe response")
+}
+
 func TestDescribeAllowsCustomTargetScheme(t *testing.T) {
 	var gotRequest *http.Request
 	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -611,6 +678,41 @@ func TestNewValidation(t *testing.T) {
 	runner, err = New("app")
 	require.Nil(t, runner)
 	require.EqualError(t, err, "trpcagent runner: target must not be empty")
+}
+
+func TestWithHeaderIgnoresEmptyKeyAndInitializesHeaders(t *testing.T) {
+	var opts options
+	WithHeader("", "ignored")(&opts)
+	assert.Nil(t, opts.headers)
+	WithHeader("X-Test", "value")(&opts)
+	require.NotNil(t, opts.headers)
+	assert.Equal(t, "value", opts.headers.Get("X-Test"))
+}
+
+func TestHTTPStatusErrorHandlesBodyReadErrorAndEmptyBody(t *testing.T) {
+	runner, err := New("sports-agent", WithTarget("http://example.com"))
+	require.NoError(t, err)
+	err = runner.httpStatusError("run", &http.Response{
+		Status: "500 Internal Server Error",
+		Body:   errReadCloser{},
+	})
+	require.EqualError(t, err, "trpcagent runner: run returned 500 Internal Server Error")
+	err = runner.httpStatusError("describe", &http.Response{
+		Status: "404 Not Found",
+		Body:   io.NopCloser(strings.NewReader("")),
+	})
+	require.EqualError(t, err, "trpcagent runner: describe returned 404 Not Found")
+}
+
+func TestErrorMessageFromBodyRejectsMalformedPayloads(t *testing.T) {
+	assert.Empty(t, errorMessageFromBody([]byte("{")))
+	assert.Empty(t, errorMessageFromBody([]byte(`{"error":{"message":"nested"}}`)))
+}
+
+func TestCloseIsNoop(t *testing.T) {
+	runner, err := New("sports-agent", WithTarget("http://example.com"))
+	require.NoError(t, err)
+	require.NoError(t, runner.Close())
 }
 
 func TestRunAllowsCustomTargetScheme(t *testing.T) {
@@ -677,6 +779,16 @@ func collectEvents(ch <-chan *event.Event) []*event.Event {
 		events = append(events, evt)
 	}
 	return events
+}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (errReadCloser) Close() error {
+	return nil
 }
 
 type fakeServerRunner struct {

--- a/runner/trpcagent/types.go
+++ b/runner/trpcagent/types.go
@@ -1,0 +1,46 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trpcagent
+
+import (
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/profilecompiler"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type session struct {
+	UserID    string `json:"userId"`
+	SessionID string `json:"sessionId"`
+}
+
+type runOptions struct {
+	RequestID             string `json:"requestID,omitempty"`
+	ExecutionTraceEnabled bool   `json:"executionTraceEnabled,omitempty"`
+}
+
+type runRequest struct {
+	Session session       `json:"session"`
+	Input   model.Message `json:"input"`
+	// Profile must be runtime-normalized and include nodeID and type.
+	Profile    *profilecompiler.Profile `json:"profile,omitempty"`
+	RunOptions runOptions               `json:"runOptions,omitempty"`
+}
+
+type runResponse struct {
+	Status         atrace.TraceStatus `json:"status"`
+	Events         []event.Event      `json:"events,omitempty"`
+	ExecutionTrace *atrace.Trace      `json:"executionTrace,omitempty"`
+	ErrorMessage   string             `json:"errorMessage,omitempty"`
+}
+
+type structureResponse struct {
+	Structure *astructure.Snapshot `json:"structure"`
+}


### PR DESCRIPTION
Adds the platform-side tRPC-Agent remote runner that implements the existing runner interface over the tRPC-Agent API. The runner builds app-scoped run requests, forwards structured profiles and trace options to the user service, maps remote failures into runner events, and restores returned execution traces for evaluation consumers.