### PR TITLE
runner: pass cache-safe fork request to summaries

### DIFF
--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -182,10 +182,15 @@ request by:
 The request prefix remains the same as the parent request prefix, so providers
 with prompt caching can reuse more cached input. If no parent request is
 available, for example in manual or external summary calls, the summarizer
-falls back to the standalone request path. When a non-empty branch summary
-trigger also cascades to the full-session summary, the branch summary may use
-the parent request fork; the full-session cascade target is skipped instead of
-reusing a branch-scoped parent request.
+falls back to the standalone request path.
+
+One important branch-summary behavior: after `WithCacheSafeForking(true)` is
+enabled, a non-empty branch trigger may fork the current parent request for the
+branch summary, but it will not also run the cascaded full-session summary in
+that same summary pass. The framework skips that full-session target instead of
+falling back to a standalone full-session prompt or reusing the branch-scoped
+fork request. Trigger a full-session summary separately when you need an
+all-branch summary.
 
 Prompt rules:
 
@@ -1464,11 +1469,12 @@ Behavior notes:
   targets. It does not block `session.SummaryFilterKeyAllContents`.
 - `WithCascadeFullSessionSummary(...)` controls whether a non-empty branch
   trigger also refreshes the full-session summary.
-- With `WithCacheSafeForking(true)`, the branch summary target may fork the
-  current parent request. A branch-triggered full-session cascade does not reuse
-  that branch-scoped fork request, and the full-session target is skipped for
-  that summary pass. Request a full-session summary separately when you need one
-  for all branches.
+- With `WithCacheSafeForking(true)`, a branch-triggered summary pass only runs
+  the branch summary target when a parent fork request is available. The
+  full-session cascade target is skipped in that pass; it does not fall back to
+  the standalone full-session prompt and does not reuse the branch-scoped fork
+  request. Request a full-session summary separately when you need one for all
+  branches.
 - To keep only full-session summaries from branch-triggered automatic summary,
   pass an explicit empty allowlist and leave cascade enabled:
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -181,8 +181,11 @@ request by:
 
 The request prefix remains the same as the parent request prefix, so providers
 with prompt caching can reuse more cached input. If no parent request is
-available, for example in asynchronous or manual summary calls, the summarizer
-falls back to the standalone request path.
+available, for example in manual or external summary calls, the summarizer
+falls back to the standalone request path. When a non-empty branch summary
+trigger also cascades to the full-session summary, the branch summary may use
+the parent request fork; the full-session cascade target is skipped instead of
+reusing a branch-scoped parent request.
 
 Prompt rules:
 
@@ -1461,6 +1464,11 @@ Behavior notes:
   targets. It does not block `session.SummaryFilterKeyAllContents`.
 - `WithCascadeFullSessionSummary(...)` controls whether a non-empty branch
   trigger also refreshes the full-session summary.
+- With `WithCacheSafeForking(true)`, the branch summary target may fork the
+  current parent request. A branch-triggered full-session cascade does not reuse
+  that branch-scoped fork request, and the full-session target is skipped for
+  that summary pass. Request a full-session summary separately when you need one
+  for all branches.
 - To keep only full-session summaries from branch-triggered automatic summary,
   pass an explicit empty allowlist and leave cascade enabled:
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -181,9 +181,13 @@ summarizer := summary.NewSummarizer(
 
 这样摘要请求和父请求拥有相同的前缀，支持 prompt cache 的模型服务就能复用更多
 已缓存输入。如果当前没有父请求，例如手动或外部调用摘要接口，摘要器会自动
-回退到独立摘要请求。当非空 branch 触发摘要并级联刷新全量会话摘要时，branch
-摘要可以使用父请求 fork；全量会话摘要目标会被跳过，不会复用这个 branch 视角的
-父请求。
+回退到独立摘要请求。
+
+这里有一个重要的 branch 摘要行为：开启 `WithCacheSafeForking(true)` 后，非空
+branch 触发摘要时，可以用当前父请求 fork 来生成 branch 摘要；但同一轮 summary
+pass 不会再跑级联出来的全量会话摘要。框架会直接跳过这个全量摘要目标，而不是
+回退到独立的全量摘要 prompt，也不会复用这个 branch 视角的 fork request。如果
+需要覆盖所有 branch 的全量摘要，需要单独触发一次全量会话摘要。
 
 Prompt 规则：
 
@@ -1413,10 +1417,10 @@ sessionService := inmemory.NewSessionService(
   `session.SummaryFilterKeyAllContents` 这个全量摘要目标。
 - `WithCascadeFullSessionSummary(...)` 控制非空分支触发摘要时，是否同时刷新
   全量会话摘要。
-- 开启 `WithCacheSafeForking(true)` 时，branch 摘要目标可以 fork 当前父请求；
-  但 branch 触发出来的全量会话摘要不会复用这个 branch 视角的 fork request，
-  这次 summary pass 会跳过全量摘要目标。如果确实需要覆盖所有 branch 的全量摘要，
-  请单独触发一次全量会话摘要。
+- 开启 `WithCacheSafeForking(true)` 后，如果当前有父请求可 fork，branch 触发的
+  summary pass 只会生成 branch 摘要；级联出来的全量会话摘要目标会被跳过，不会
+  回退到独立的全量摘要 prompt，也不会复用这个 branch 视角的 fork request。如果
+  确实需要覆盖所有 branch 的全量摘要，请单独触发一次全量会话摘要。
 - 如果只想保留 branch 触发出来的全量摘要，不写任何 branch 摘要，可以显式传入
   空 allowlist，并保持默认 cascade 开启：
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -180,8 +180,10 @@ summarizer := summary.NewSummarizer(
 - 强制摘要调用使用非流式输出，并清掉 structured output，因为摘要调用只需要返回普通摘要文本。
 
 这样摘要请求和父请求拥有相同的前缀，支持 prompt cache 的模型服务就能复用更多
-已缓存输入。如果当前没有父请求，例如异步摘要或手动调用摘要接口，摘要器会自动
-回退到独立摘要请求。
+已缓存输入。如果当前没有父请求，例如手动或外部调用摘要接口，摘要器会自动
+回退到独立摘要请求。当非空 branch 触发摘要并级联刷新全量会话摘要时，branch
+摘要可以使用父请求 fork；全量会话摘要目标会被跳过，不会复用这个 branch 视角的
+父请求。
 
 Prompt 规则：
 
@@ -1411,6 +1413,10 @@ sessionService := inmemory.NewSessionService(
   `session.SummaryFilterKeyAllContents` 这个全量摘要目标。
 - `WithCascadeFullSessionSummary(...)` 控制非空分支触发摘要时，是否同时刷新
   全量会话摘要。
+- 开启 `WithCacheSafeForking(true)` 时，branch 摘要目标可以 fork 当前父请求；
+  但 branch 触发出来的全量会话摘要不会复用这个 branch 视角的 fork request，
+  这次 summary pass 会跳过全量摘要目标。如果确实需要覆盖所有 branch 的全量摘要，
+  请单独触发一次全量会话摘要。
 - 如果只想保留 branch 触发出来的全量摘要，不写任何 branch 摘要，可以显式传入
   空 allowlist，并保持默认 cascade 开启：
 

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -24,7 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
-	sessionsummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -76,7 +76,7 @@ func (s *contextCapturingSummaryService) CreateSessionSummary(
 	filterKey string,
 	_ bool,
 ) error {
-	parent, _ := sessionsummary.CacheSafeForkRequestFromContext(ctx)
+	parent, _ := summary.CacheSafeForkRequestFromContext(ctx)
 	s.mu.Lock()
 	s.calls++
 	s.parentRequest = parent

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -34,6 +34,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/modelcontext"
 	"trpc.group/trpc-go/trpc-agent-go/internal/responseusage"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcall"
@@ -2211,6 +2212,7 @@ func (f *Flow) callLLM(
 			yield(customResp)
 		}, nil
 	}
+	summaryfork.Attach(invocation, llmRequest)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
 	if err != nil {
 		return ctx, nil, err

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -517,8 +517,16 @@ func (f *Flow) maybeSyncSummaryIntraRun(
 		return
 	}
 
+	summaryCtx := ctx
+	if parentRequest, ok := summaryfork.Request(invocation); ok {
+		summaryCtx = sessionsummary.ContextWithCacheSafeForkRequest(
+			summaryCtx,
+			parentRequest,
+		)
+	}
+
 	err = invocation.SessionService.CreateSessionSummary(
-		ctx,
+		summaryCtx,
 		invocation.Session,
 		invocation.GetEventFilterKey(),
 		false,

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -43,7 +43,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
-	sessionsummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
 )
@@ -519,7 +519,7 @@ func (f *Flow) maybeSyncSummaryIntraRun(
 
 	summaryCtx := ctx
 	if parentRequest, ok := summaryfork.Request(invocation); ok {
-		summaryCtx = sessionsummary.ContextWithCacheSafeForkRequest(
+		summaryCtx = summary.ContextWithCacheSafeForkRequest(
 			summaryCtx,
 			parentRequest,
 		)
@@ -1527,7 +1527,7 @@ func (f *Flow) runContextCompaction(
 		latencySpanContextSummary,
 		contextCompactionAttrs(decision, req)...,
 	)
-	summaryCtx = sessionsummary.ContextWithCacheSafeForkRequest(summaryCtx, req)
+	summaryCtx = summary.ContextWithCacheSafeForkRequest(summaryCtx, req)
 	err := invocation.SessionService.CreateSessionSummary(
 		summaryCtx,
 		invocation.Session,

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -30,6 +30,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -651,6 +652,49 @@ func TestRunOneStep_RecordsExecutionTraceStepOnSuccess(t *testing.T) {
 	require.Contains(t, step.Output.Text, "ok")
 	require.Empty(t, step.PredecessorStepIDs)
 	require.Empty(t, step.Error)
+}
+
+func TestRunOneStep_AttachesCacheSafeSummaryForkRequest(t *testing.T) {
+	f := New(
+		[]flow.RequestProcessor{
+			&seedMessagesRequestProcessor{
+				messages: []model.Message{
+					model.NewSystemMessage("stable system"),
+					model.NewUserMessage("current user"),
+				},
+			},
+		},
+		nil,
+		Options{},
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationAgent(&minimalAgent{}),
+		agent.WithInvocationModel(&mockModel{
+			responses: []*model.Response{
+				{
+					Done: true,
+					Choices: []model.Choice{
+						{Message: model.NewAssistantMessage("ok")},
+					},
+				},
+			},
+		}),
+	)
+	eventChan := make(chan *event.Event, 8)
+	_, err := f.runOneStep(context.Background(), inv, eventChan)
+	require.NoError(t, err)
+
+	parent, ok := summaryfork.Request(inv)
+	require.True(t, ok)
+	require.NotNil(t, parent)
+	require.Equal(
+		t,
+		[]model.Message{
+			model.NewSystemMessage("stable system"),
+			model.NewUserMessage("current user"),
+		},
+		parent.Messages,
+	)
 }
 
 func TestRunOneStep_RecordsExecutionTraceStepErrorWhenModelFails(t *testing.T) {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -3823,6 +3823,47 @@ func TestMaybeSyncSummaryIntraRun_ErrorBranch(t *testing.T) {
 	f.maybeSyncSummaryIntraRun(ctx, inv)
 }
 
+func TestMaybeSyncSummaryIntraRun_AttachesCacheSafeForkRequest(t *testing.T) {
+	f := &Flow{syncSummaryIntraRun: true}
+	svc := &contextCapturingSummaryService{}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationSessionService(svc),
+		agent.WithInvocationEventFilterKey("branch/fork"),
+	)
+	parent := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("system"),
+			model.NewUserMessage("question"),
+		},
+	}
+	summaryfork.Attach(inv, parent)
+	parent.Messages[1].Content = "mutated"
+
+	f.maybeSyncSummaryIntraRun(context.Background(), inv)
+
+	require.Equal(t, 1, svc.Calls())
+	got := svc.ParentRequest()
+	require.NotNil(t, got)
+	require.Len(t, got.Messages, 2)
+	require.Equal(t, "question", got.Messages[1].Content)
+}
+
+func TestMaybeSyncSummaryIntraRun_FallsBackWithoutForkRequest(t *testing.T) {
+	f := &Flow{syncSummaryIntraRun: true}
+	svc := &contextCapturingSummaryService{}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationSessionService(svc),
+		agent.WithInvocationEventFilterKey("branch/fallback"),
+	)
+
+	f.maybeSyncSummaryIntraRun(context.Background(), inv)
+
+	require.Equal(t, 1, svc.Calls())
+	require.Nil(t, svc.ParentRequest())
+}
+
 func TestRun_SyncSummaryIntraRun_NilInvocation(t *testing.T) {
 	// When invocation is nil and syncSummaryIntraRun is true,
 	// the SetState guard should prevent a nil-pointer panic.

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -1,0 +1,166 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package summaryfork stores the parent model request snapshot used by
+// cache-safe asynchronous summaries.
+package summaryfork
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const stateKey = "trpc_agent.summary.cache_safe_fork_request"
+
+// Attach stores a snapshot of the parent model request on the invocation.
+func Attach(inv *agent.Invocation, req *model.Request) {
+	if inv == nil || req == nil {
+		return
+	}
+	inv.SetState(stateKey, cloneRequest(req))
+}
+
+// Request returns a snapshot of the parent model request, if one exists.
+func Request(inv *agent.Invocation) (*model.Request, bool) {
+	req, ok := agent.GetStateValue[*model.Request](inv, stateKey)
+	if !ok || req == nil {
+		return nil, false
+	}
+	return cloneRequest(req), true
+}
+
+func cloneRequest(req *model.Request) *model.Request {
+	if req == nil {
+		return nil
+	}
+
+	cloned := *req
+	cloned.Messages = cloneMessages(req.Messages)
+	cloned.GenerationConfig = cloneGenerationConfig(req.GenerationConfig)
+	cloned.StructuredOutput = cloneStructuredOutput(req.StructuredOutput)
+	cloned.ExtraFields = jsonmap.Clone(req.ExtraFields)
+	cloned.Headers = cloneHeaders(req.Headers)
+	cloned.Tools = cloneTools(req.Tools)
+	return &cloned
+}
+
+func cloneMessages(messages []model.Message) []model.Message {
+	if messages == nil {
+		return nil
+	}
+	cloned := make([]model.Message, len(messages))
+	for i := range messages {
+		cloned[i] = cloneMessage(messages[i])
+	}
+	return cloned
+}
+
+func cloneMessage(msg model.Message) model.Message {
+	cloned := msg
+	cloned.ContentParts = cloneContentParts(msg.ContentParts)
+	cloned.ToolCalls = cloneToolCalls(msg.ToolCalls)
+	return cloned
+}
+
+func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]model.ContentPart, len(parts))
+	for i := range parts {
+		cloned[i] = cloneContentPart(parts[i])
+	}
+	return cloned
+}
+
+func cloneContentPart(part model.ContentPart) model.ContentPart {
+	cloned := part
+	if part.Text != nil {
+		text := *part.Text
+		cloned.Text = &text
+	}
+	if part.Image != nil {
+		image := *part.Image
+		image.Data = append([]byte(nil), part.Image.Data...)
+		cloned.Image = &image
+	}
+	if part.Audio != nil {
+		audio := *part.Audio
+		audio.Data = append([]byte(nil), part.Audio.Data...)
+		cloned.Audio = &audio
+	}
+	if part.File != nil {
+		file := *part.File
+		file.Data = append([]byte(nil), part.File.Data...)
+		cloned.File = &file
+	}
+	return cloned
+}
+
+func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+	cloned := make([]model.ToolCall, len(toolCalls))
+	for i := range toolCalls {
+		cloned[i] = toolCalls[i]
+		cloned[i].Function.Arguments = append(
+			[]byte(nil),
+			toolCalls[i].Function.Arguments...,
+		)
+		if toolCalls[i].Index != nil {
+			index := *toolCalls[i].Index
+			cloned[i].Index = &index
+		}
+		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
+	}
+	return cloned
+}
+
+func cloneGenerationConfig(cfg model.GenerationConfig) model.GenerationConfig {
+	cloned := cfg
+	cloned.Stop = append([]string(nil), cfg.Stop...)
+	return cloned
+}
+
+func cloneStructuredOutput(out *model.StructuredOutput) *model.StructuredOutput {
+	if out == nil {
+		return nil
+	}
+	cloned := *out
+	if out.JSONSchema != nil {
+		schema := *out.JSONSchema
+		schema.Schema = jsonmap.Clone(out.JSONSchema.Schema)
+		cloned.JSONSchema = &schema
+	}
+	return &cloned
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(headers))
+	for k, v := range headers {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func cloneTools(tools map[string]tool.Tool) map[string]tool.Tool {
+	if tools == nil {
+		return nil
+	}
+	cloned := make(map[string]tool.Tool, len(tools))
+	for name, t := range tools {
+		cloned[name] = t
+	}
+	return cloned
+}

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -54,20 +54,32 @@ func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
 }
 
 func responseMessages(rsp *model.Response) []model.Message {
-	if rsp == nil {
+	choice, ok := primaryChoice(rsp)
+	if !ok {
 		return nil
 	}
-	messages := make([]model.Message, 0, len(rsp.Choices))
-	for _, choice := range rsp.Choices {
-		if messageHasPayloadForFork(choice.Message) {
-			messages = append(messages, choice.Message)
-			continue
-		}
-		if messageHasPayloadForFork(choice.Delta) {
-			messages = append(messages, choice.Delta)
-		}
+
+	var messages []model.Message
+	if messageHasPayloadForFork(choice.Message) {
+		messages = append(messages, choice.Message)
+		return messages
+	}
+	if messageHasPayloadForFork(choice.Delta) {
+		messages = append(messages, choice.Delta)
 	}
 	return messages
+}
+
+func primaryChoice(rsp *model.Response) (model.Choice, bool) {
+	if rsp == nil || len(rsp.Choices) == 0 {
+		return model.Choice{}, false
+	}
+	for _, choice := range rsp.Choices {
+		if choice.Index == 0 {
+			return choice, true
+		}
+	}
+	return rsp.Choices[0], true
 }
 
 func messageHasPayloadForFork(msg model.Message) bool {

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -36,6 +36,47 @@ func Request(inv *agent.Invocation) (*model.Request, bool) {
 	return cloneRequest(req), true
 }
 
+// AppendResponse appends persisted response messages to the stored request
+// snapshot. It is a no-op when no snapshot is present.
+func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
+	req, ok := agent.GetStateValue[*model.Request](inv, stateKey)
+	if !ok || req == nil || rsp == nil {
+		return
+	}
+	messages := responseMessages(rsp)
+	if len(messages) == 0 {
+		return
+	}
+
+	next := cloneRequest(req)
+	next.Messages = append(next.Messages, cloneMessages(messages)...)
+	inv.SetState(stateKey, next)
+}
+
+func responseMessages(rsp *model.Response) []model.Message {
+	if rsp == nil {
+		return nil
+	}
+	messages := make([]model.Message, 0, len(rsp.Choices))
+	for _, choice := range rsp.Choices {
+		if messageHasPayloadForFork(choice.Message) {
+			messages = append(messages, choice.Message)
+			continue
+		}
+		if messageHasPayloadForFork(choice.Delta) {
+			messages = append(messages, choice.Delta)
+		}
+	}
+	return messages
+}
+
+func messageHasPayloadForFork(msg model.Message) bool {
+	return model.HasPayload(msg) ||
+		len(msg.ToolCalls) > 0 ||
+		msg.ToolID != "" ||
+		msg.ToolName != ""
+}
+
 func cloneRequest(req *model.Request) *model.Request {
 	if req == nil {
 		return nil
@@ -127,7 +168,26 @@ func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
 func cloneGenerationConfig(cfg model.GenerationConfig) model.GenerationConfig {
 	cloned := cfg
 	cloned.Stop = append([]string(nil), cfg.Stop...)
+	cloned.MaxTokens = clonePtr(cfg.MaxTokens)
+	cloned.Temperature = clonePtr(cfg.Temperature)
+	cloned.TopP = clonePtr(cfg.TopP)
+	cloned.PresencePenalty = clonePtr(cfg.PresencePenalty)
+	cloned.FrequencyPenalty = clonePtr(cfg.FrequencyPenalty)
+	cloned.Logprobs = clonePtr(cfg.Logprobs)
+	cloned.TopLogprobs = clonePtr(cfg.TopLogprobs)
+	cloned.ReasoningEffort = clonePtr(cfg.ReasoningEffort)
+	cloned.ThinkingEnabled = clonePtr(cfg.ThinkingEnabled)
+	cloned.ThinkingTokens = clonePtr(cfg.ThinkingTokens)
+	cloned.ThinkingLevel = clonePtr(cfg.ThinkingLevel)
 	return cloned
+}
+
+func clonePtr[T any](v *T) *T {
+	if v == nil {
+		return nil
+	}
+	c := *v
+	return &c
 }
 
 func cloneStructuredOutput(out *model.StructuredOutput) *model.StructuredOutput {

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -1,0 +1,79 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summaryfork
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestAttachSnapshotsRequest(t *testing.T) {
+	text := "part"
+	index := 1
+	req := &model.Request{
+		Messages: []model.Message{{
+			Role: model.RoleAssistant,
+			ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeText,
+				Text: &text,
+			}},
+			ToolCalls: []model.ToolCall{{
+				Index: &index,
+				Function: model.FunctionDefinitionParam{
+					Arguments: []byte(`{"q":"original"}`),
+				},
+				ExtraFields: map[string]any{
+					"nested": map[string]any{"k": "v"},
+				},
+			}},
+		}},
+		GenerationConfig: model.GenerationConfig{
+			Stop: []string{"END"},
+		},
+		StructuredOutput: &model.StructuredOutput{
+			Type: model.StructuredOutputJSONSchema,
+			JSONSchema: &model.JSONSchemaConfig{
+				Schema: map[string]any{"type": "object"},
+			},
+		},
+		ExtraFields: map[string]any{
+			"metadata": map[string]any{"id": "one"},
+		},
+		Headers: map[string]string{"X-Trace": "one"},
+	}
+
+	inv := agent.NewInvocation()
+	Attach(inv, req)
+
+	*req.Messages[0].ContentParts[0].Text = "mutated"
+	req.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
+	req.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"] = "changed"
+	req.GenerationConfig.Stop[0] = "STOP"
+	req.StructuredOutput.JSONSchema.Schema["type"] = "array"
+	req.ExtraFields["metadata"].(map[string]any)["id"] = "two"
+	req.Headers["X-Trace"] = "two"
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.Equal(t, "part", *got.Messages[0].ContentParts[0].Text)
+	require.Equal(t, byte('{'), got.Messages[0].ToolCalls[0].Function.Arguments[0])
+	require.Equal(t, "v", got.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"])
+	require.Equal(t, "END", got.GenerationConfig.Stop[0])
+	require.Equal(t, "object", got.StructuredOutput.JSONSchema.Schema["type"])
+	require.Equal(t, "one", got.ExtraFields["metadata"].(map[string]any)["id"])
+	require.Equal(t, "one", got.Headers["X-Trace"])
+
+	got.GenerationConfig.Stop[0] = "again"
+	again, ok := Request(inv)
+	require.True(t, ok)
+	require.Equal(t, "END", again.GenerationConfig.Stop[0])
+}

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -116,3 +116,26 @@ func TestAppendResponseExtendsSnapshot(t *testing.T) {
 	require.Equal(t, model.RoleTool, got.Messages[3].Role)
 	require.Equal(t, "result", got.Messages[3].Content)
 }
+
+func TestAppendResponseKeepsPrimaryChoiceOnly(t *testing.T) {
+	inv := agent.NewInvocation()
+	Attach(inv, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+	})
+
+	AppendResponse(inv, &model.Response{Choices: []model.Choice{
+		{
+			Index:   1,
+			Message: model.NewAssistantMessage("alternative"),
+		},
+		{
+			Index:   0,
+			Message: model.NewAssistantMessage("primary"),
+		},
+	}})
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.Len(t, got.Messages, 2)
+	require.Equal(t, "primary", got.Messages[1].Content)
+}

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -14,7 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+type stubTool struct {
+	name string
+}
+
+func (t stubTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: t.name}
+}
 
 func TestAttachSnapshotsRequest(t *testing.T) {
 	text := "part"
@@ -84,6 +93,84 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 	require.Equal(t, "END", again.GenerationConfig.Stop[0])
 }
 
+func TestAttachHandlesNilAndZeroValueRequest(t *testing.T) {
+	Attach(nil, &model.Request{})
+	Attach(agent.NewInvocation(), nil)
+
+	inv := agent.NewInvocation()
+	_, ok := Request(inv)
+	require.False(t, ok)
+
+	inv.SetState(stateKey, (*model.Request)(nil))
+	_, ok = Request(inv)
+	require.False(t, ok)
+
+	Attach(inv, &model.Request{})
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.NotNil(t, got)
+	require.Nil(t, got.Messages)
+	require.Nil(t, got.StructuredOutput)
+	require.Nil(t, got.Headers)
+	require.Nil(t, got.Tools)
+}
+
+func TestAttachSnapshotsMultimodalPartsAndTools(t *testing.T) {
+	text := "text"
+	req := &model.Request{
+		Messages: []model.Message{{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{
+				{
+					Type: model.ContentTypeText,
+					Text: &text,
+				},
+				{
+					Type: model.ContentTypeImage,
+					Image: &model.Image{
+						Data: []byte{1, 2, 3},
+					},
+				},
+				{
+					Type: model.ContentTypeAudio,
+					Audio: &model.Audio{
+						Data: []byte{4, 5, 6},
+					},
+				},
+				{
+					Type: model.ContentTypeFile,
+					File: &model.File{
+						Data: []byte{7, 8, 9},
+					},
+				},
+			},
+		}},
+		Tools: map[string]tool.Tool{
+			"lookup": stubTool{name: "lookup"},
+		},
+	}
+
+	inv := agent.NewInvocation()
+	Attach(inv, req)
+
+	*req.Messages[0].ContentParts[0].Text = "changed"
+	req.Messages[0].ContentParts[1].Image.Data[0] = 9
+	req.Messages[0].ContentParts[2].Audio.Data[0] = 9
+	req.Messages[0].ContentParts[3].File.Data[0] = 9
+	req.Tools["lookup"] = stubTool{name: "changed"}
+	req.Tools["extra"] = stubTool{name: "extra"}
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	parts := got.Messages[0].ContentParts
+	require.Equal(t, "text", *parts[0].Text)
+	require.Equal(t, []byte{1, 2, 3}, parts[1].Image.Data)
+	require.Equal(t, []byte{4, 5, 6}, parts[2].Audio.Data)
+	require.Equal(t, []byte{7, 8, 9}, parts[3].File.Data)
+	require.Len(t, got.Tools, 1)
+	require.Equal(t, "lookup", got.Tools["lookup"].Declaration().Name)
+}
+
 func TestAppendResponseExtendsSnapshot(t *testing.T) {
 	inv := agent.NewInvocation()
 	Attach(inv, &model.Request{
@@ -117,6 +204,44 @@ func TestAppendResponseExtendsSnapshot(t *testing.T) {
 	require.Equal(t, "result", got.Messages[3].Content)
 }
 
+func TestAppendResponseNoopsWithoutPayload(t *testing.T) {
+	AppendResponse(nil, &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage("ignored"),
+	}}})
+	AppendResponse(agent.NewInvocation(), &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage("ignored"),
+	}}})
+
+	inv := agent.NewInvocation()
+	Attach(inv, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+	})
+
+	AppendResponse(inv, nil)
+	AppendResponse(inv, &model.Response{})
+	AppendResponse(inv, &model.Response{Choices: []model.Choice{{}}})
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.Len(t, got.Messages, 1)
+}
+
+func TestAppendResponseUsesDeltaFallback(t *testing.T) {
+	inv := agent.NewInvocation()
+	Attach(inv, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+	})
+
+	AppendResponse(inv, &model.Response{Choices: []model.Choice{{
+		Delta: model.NewAssistantMessage("streamed"),
+	}}})
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.Len(t, got.Messages, 2)
+	require.Equal(t, "streamed", got.Messages[1].Content)
+}
+
 func TestAppendResponseKeepsPrimaryChoiceOnly(t *testing.T) {
 	inv := agent.NewInvocation()
 	Attach(inv, &model.Request{
@@ -138,4 +263,27 @@ func TestAppendResponseKeepsPrimaryChoiceOnly(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, got.Messages, 2)
 	require.Equal(t, "primary", got.Messages[1].Content)
+}
+
+func TestAppendResponseFallsBackToFirstChoice(t *testing.T) {
+	inv := agent.NewInvocation()
+	Attach(inv, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+	})
+
+	AppendResponse(inv, &model.Response{Choices: []model.Choice{
+		{
+			Index:   2,
+			Message: model.NewAssistantMessage("first"),
+		},
+		{
+			Index:   3,
+			Message: model.NewAssistantMessage("second"),
+		},
+	}})
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.Len(t, got.Messages, 2)
+	require.Equal(t, "first", got.Messages[1].Content)
 }

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -19,6 +19,7 @@ import (
 func TestAttachSnapshotsRequest(t *testing.T) {
 	text := "part"
 	index := 1
+	maxTokens := 10
 	req := &model.Request{
 		Messages: []model.Message{{
 			Role: model.RoleAssistant,
@@ -37,7 +38,8 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 			}},
 		}},
 		GenerationConfig: model.GenerationConfig{
-			Stop: []string{"END"},
+			MaxTokens: &maxTokens,
+			Stop:      []string{"END"},
 		},
 		StructuredOutput: &model.StructuredOutput{
 			Type: model.StructuredOutputJSONSchema,
@@ -57,6 +59,7 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 	*req.Messages[0].ContentParts[0].Text = "mutated"
 	req.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
 	req.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"] = "changed"
+	*req.GenerationConfig.MaxTokens = 20
 	req.GenerationConfig.Stop[0] = "STOP"
 	req.StructuredOutput.JSONSchema.Schema["type"] = "array"
 	req.ExtraFields["metadata"].(map[string]any)["id"] = "two"
@@ -67,13 +70,49 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 	require.Equal(t, "part", *got.Messages[0].ContentParts[0].Text)
 	require.Equal(t, byte('{'), got.Messages[0].ToolCalls[0].Function.Arguments[0])
 	require.Equal(t, "v", got.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"])
+	require.Equal(t, 10, *got.GenerationConfig.MaxTokens)
 	require.Equal(t, "END", got.GenerationConfig.Stop[0])
 	require.Equal(t, "object", got.StructuredOutput.JSONSchema.Schema["type"])
 	require.Equal(t, "one", got.ExtraFields["metadata"].(map[string]any)["id"])
 	require.Equal(t, "one", got.Headers["X-Trace"])
 
 	got.GenerationConfig.Stop[0] = "again"
+	*got.GenerationConfig.MaxTokens = 30
 	again, ok := Request(inv)
 	require.True(t, ok)
+	require.Equal(t, 10, *again.GenerationConfig.MaxTokens)
 	require.Equal(t, "END", again.GenerationConfig.Stop[0])
+}
+
+func TestAppendResponseExtendsSnapshot(t *testing.T) {
+	inv := agent.NewInvocation()
+	Attach(inv, &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("stable system"),
+			model.NewUserMessage("question"),
+		},
+	})
+
+	AppendResponse(inv, &model.Response{Choices: []model.Choice{{
+		Message: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID: "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name: "lookup",
+				},
+			}},
+		},
+	}}})
+	AppendResponse(inv, &model.Response{Choices: []model.Choice{{
+		Message: model.NewToolMessage("call_1", "lookup", "result"),
+	}}})
+
+	got, ok := Request(inv)
+	require.True(t, ok)
+	require.Len(t, got.Messages, 4)
+	require.Equal(t, model.RoleAssistant, got.Messages[2].Role)
+	require.Len(t, got.Messages[2].ToolCalls, 1)
+	require.Equal(t, model.RoleTool, got.Messages[3].Role)
+	require.Equal(t, "result", got.Messages[3].Content)
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -46,7 +46,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
-	sessionsummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/appid"
 )
 
@@ -2509,7 +2509,7 @@ func (r *runner) handleEventPersistence(
 		runnerEventAttrs(agentEvent)...,
 	)
 	if parentRequest, ok := summaryfork.Request(invocation); ok {
-		summaryCtx = sessionsummary.ContextWithCacheSafeForkRequest(
+		summaryCtx = summary.ContextWithCacheSafeForkRequest(
 			summaryCtx,
 			parentRequest,
 		)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2466,6 +2466,10 @@ func (r *runner) handleEventPersistence(
 	}
 	finishRunnerLatencySpan(appendSpan, appendStarted, nil)
 
+	if shouldAppendSummaryForkResponse(agentEvent) {
+		summaryfork.AppendResponse(invocation, agentEvent.Response)
+	}
+
 	// Skip user messages, tool call events, and invalid content.
 	// These should not trigger summarization.
 	if agentEvent.IsUserMessage() ||
@@ -2523,6 +2527,17 @@ func (r *runner) handleEventPersistence(
 
 	// Note: Auto memory extraction is triggered once at runner completion,
 	// not here, to avoid redundant extraction calls.
+	return true
+}
+
+func shouldAppendSummaryForkResponse(agentEvent *event.Event) bool {
+	if agentEvent == nil ||
+		agentEvent.Response == nil ||
+		agentEvent.Response.IsPartial ||
+		agentEvent.IsUserMessage() ||
+		!agentEvent.IsValidContent() {
+		return false
+	}
 	return true
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -39,12 +39,14 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/livesession"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	sessionsummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/telemetry/appid"
 )
 
@@ -2502,6 +2504,12 @@ func (r *runner) handleEventPersistence(
 		runnerLatencySpanEnqueueSummary,
 		runnerEventAttrs(agentEvent)...,
 	)
+	if parentRequest, ok := summaryfork.Request(invocation); ok {
+		summaryCtx = sessionsummary.ContextWithCacheSafeForkRequest(
+			summaryCtx,
+			parentRequest,
+		)
+	}
 	if err := r.sessionService.EnqueueSummaryJob(
 		summaryCtx, persistSession, agentEvent.FilterKey, false,
 	); err != nil {

--- a/runner/runner_summary_test.go
+++ b/runner/runner_summary_test.go
@@ -22,7 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
-	sessionsummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -342,7 +342,7 @@ func (c *cacheSafeForkCapturingSessionService) EnqueueSummaryJob(
 	filterKey string,
 	force bool,
 ) error {
-	c.capturedParent, c.capturedOK = sessionsummary.CacheSafeForkRequestFromContext(ctx)
+	c.capturedParent, c.capturedOK = summary.CacheSafeForkRequestFromContext(ctx)
 	close(c.done)
 	return c.mockSessionService.EnqueueSummaryJob(ctx, sess, filterKey, force)
 }

--- a/runner/runner_summary_test.go
+++ b/runner/runner_summary_test.go
@@ -226,9 +226,56 @@ func TestRunner_EnqueueSummaryJob_AttachesCacheSafeForkRequest(t *testing.T) {
 		[]model.Message{
 			model.NewSystemMessage("stable system"),
 			model.NewUserMessage("parent request"),
+			model.NewAssistantMessage("final"),
 		},
 		svc.capturedParent.Messages,
 	)
+}
+
+func TestRunner_EnqueueSummaryJob_CacheSafeForkIncludesToolResult(t *testing.T) {
+	parent := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("stable system"),
+			model.NewUserMessage("use lookup"),
+		},
+	}
+	svc := &cacheSafeForkCapturingSessionService{
+		mockSessionService: &mockSessionService{},
+		done:               make(chan struct{}),
+	}
+	r := NewRunner(
+		"test-app",
+		&cacheSafeForkToolResultMockAgent{
+			name:   "fork-agent",
+			parent: parent,
+		},
+		WithSessionService(svc),
+	)
+
+	_, err := RunWithMessages(
+		context.Background(),
+		r,
+		"user1",
+		"sess1",
+		[]model.Message{{Role: model.RoleUser, Content: "hello"}},
+	)
+	require.NoError(t, err)
+
+	select {
+	case <-svc.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for context to be captured")
+	}
+
+	require.True(t, svc.capturedOK)
+	require.NotNil(t, svc.capturedParent)
+	require.Len(t, svc.capturedParent.Messages, 4)
+	require.Equal(t, model.RoleAssistant, svc.capturedParent.Messages[2].Role)
+	require.Len(t, svc.capturedParent.Messages[2].ToolCalls, 1)
+	require.Equal(t, "call_1", svc.capturedParent.Messages[2].ToolCalls[0].ID)
+	require.Equal(t, model.RoleTool, svc.capturedParent.Messages[3].Role)
+	require.Equal(t, "call_1", svc.capturedParent.Messages[3].ToolID)
+	require.Equal(t, `{"answer":"ok"}`, svc.capturedParent.Messages[3].Content)
 }
 
 func TestRunner_SummaryAwareSessionRestoreHint(t *testing.T) {
@@ -461,6 +508,78 @@ func (m *cacheSafeForkMockAgent) Run(
 		InvocationID: invocation.InvocationID,
 		Author:       m.name,
 		ID:           "evt-fork",
+		Timestamp:    time.Now(),
+	}
+	close(ch)
+	return ch, nil
+}
+
+type cacheSafeForkToolResultMockAgent struct {
+	name   string
+	parent *model.Request
+}
+
+func (m *cacheSafeForkToolResultMockAgent) Info() agent.Info {
+	return agent.Info{Name: m.name}
+}
+
+func (m *cacheSafeForkToolResultMockAgent) SubAgents() []agent.Agent {
+	return nil
+}
+
+func (m *cacheSafeForkToolResultMockAgent) FindSubAgent(string) agent.Agent {
+	return nil
+}
+
+func (m *cacheSafeForkToolResultMockAgent) Tools() []tool.Tool { return nil }
+
+func (m *cacheSafeForkToolResultMockAgent) Run(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) (<-chan *event.Event, error) {
+	summaryfork.Attach(invocation, m.parent)
+
+	ch := make(chan *event.Event, 2)
+	ch <- &event.Event{
+		Response: &model.Response{
+			ID:    "tool-call-resp",
+			Model: "test-model",
+			Done:  true,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: model.FunctionDefinitionParam{
+							Name:      "lookup",
+							Arguments: []byte(`{"q":"hello"}`),
+						},
+					}},
+				},
+			}},
+		},
+		InvocationID: invocation.InvocationID,
+		Author:       m.name,
+		ID:           "evt-tool-call",
+		Timestamp:    time.Now(),
+	}
+	ch <- &event.Event{
+		Response: &model.Response{
+			ID:    "tool-result-resp",
+			Model: "test-model",
+			Done:  true,
+			Choices: []model.Choice{{
+				Message: model.NewToolMessage(
+					"call_1",
+					"lookup",
+					`{"answer":"ok"}`,
+				),
+			}},
+		},
+		InvocationID: invocation.InvocationID,
+		Author:       "lookup",
+		ID:           "evt-tool-result",
 		Timestamp:    time.Now(),
 	}
 	close(ch)

--- a/runner/runner_summary_test.go
+++ b/runner/runner_summary_test.go
@@ -19,8 +19,10 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/summaryrestore"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessionsummary "trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -185,6 +187,50 @@ func TestRunner_EnqueueSummaryJob_ContextValuePreserved(t *testing.T) {
 	assert.Equal(t, "trace-12345", contextCapturingService.capturedTraceID, "Context value should be preserved and passed to EnqueueSummaryJob")
 }
 
+func TestRunner_EnqueueSummaryJob_AttachesCacheSafeForkRequest(t *testing.T) {
+	parent := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("stable system"),
+			model.NewUserMessage("parent request"),
+		},
+	}
+	svc := &cacheSafeForkCapturingSessionService{
+		mockSessionService: &mockSessionService{},
+		done:               make(chan struct{}),
+	}
+	r := NewRunner(
+		"test-app",
+		&cacheSafeForkMockAgent{name: "fork-agent", parent: parent},
+		WithSessionService(svc),
+	)
+
+	_, err := RunWithMessages(
+		context.Background(),
+		r,
+		"user1",
+		"sess1",
+		[]model.Message{{Role: model.RoleUser, Content: "hello"}},
+	)
+	require.NoError(t, err)
+
+	select {
+	case <-svc.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for context to be captured")
+	}
+
+	require.True(t, svc.capturedOK)
+	require.NotNil(t, svc.capturedParent)
+	require.Equal(
+		t,
+		[]model.Message{
+			model.NewSystemMessage("stable system"),
+			model.NewUserMessage("parent request"),
+		},
+		svc.capturedParent.Messages,
+	)
+}
+
 func TestRunner_SummaryAwareSessionRestoreHint(t *testing.T) {
 	t.Run("passes event filter key", func(t *testing.T) {
 		svc := &mockSessionService{}
@@ -232,6 +278,26 @@ func TestRunner_SummaryAwareSessionRestoreHint(t *testing.T) {
 		assert.True(t, svc.getSessionCalls[0].restoreHintOK)
 		assert.Equal(t, "test-app", svc.getSessionCalls[0].restoreHint)
 	})
+}
+
+// cacheSafeForkCapturingSessionService captures the cache-safe fork request
+// passed to EnqueueSummaryJob.
+type cacheSafeForkCapturingSessionService struct {
+	*mockSessionService
+	capturedParent *model.Request
+	capturedOK     bool
+	done           chan struct{}
+}
+
+func (c *cacheSafeForkCapturingSessionService) EnqueueSummaryJob(
+	ctx context.Context,
+	sess *session.Session,
+	filterKey string,
+	force bool,
+) error {
+	c.capturedParent, c.capturedOK = sessionsummary.CacheSafeForkRequestFromContext(ctx)
+	close(c.done)
+	return c.mockSessionService.EnqueueSummaryJob(ctx, sess, filterKey, force)
 }
 
 // contextCapturingSessionService captures the context passed to EnqueueSummaryJob.
@@ -351,6 +417,54 @@ func (m *stateDeltaMockAgent) Run(ctx context.Context, invocation *agent.Invocat
 
 func (m *stateDeltaMockAgent) Tools() []tool.Tool {
 	return []tool.Tool{}
+}
+
+// cacheSafeForkMockAgent stores a parent request snapshot on the invocation
+// before emitting a final assistant event.
+type cacheSafeForkMockAgent struct {
+	name   string
+	parent *model.Request
+}
+
+func (m *cacheSafeForkMockAgent) Info() agent.Info {
+	return agent.Info{Name: m.name}
+}
+
+func (m *cacheSafeForkMockAgent) SubAgents() []agent.Agent { return nil }
+
+func (m *cacheSafeForkMockAgent) FindSubAgent(string) agent.Agent { return nil }
+
+func (m *cacheSafeForkMockAgent) Tools() []tool.Tool { return nil }
+
+func (m *cacheSafeForkMockAgent) Run(
+	ctx context.Context,
+	invocation *agent.Invocation,
+) (<-chan *event.Event, error) {
+	summaryfork.Attach(invocation, m.parent)
+	if len(m.parent.Messages) > 1 {
+		m.parent.Messages[1].Content = "mutated after attach"
+	}
+
+	ch := make(chan *event.Event, 1)
+	ch <- &event.Event{
+		Response: &model.Response{
+			ID:    "fork-resp",
+			Model: "test-model",
+			Done:  true,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "final",
+				},
+			}},
+		},
+		InvocationID: invocation.InvocationID,
+		Author:       m.name,
+		ID:           "evt-fork",
+		Timestamp:    time.Now(),
+	}
+	close(ch)
+	return ch, nil
 }
 
 // mockSessionService implements the session.Service interface for testing EnqueueSummaryJob calls.

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -349,6 +349,9 @@ func shouldGenerateSummary(
 	report *summary.Report,
 ) bool {
 	if force {
+		if shouldSkipBranchForkFullSessionCascade(ctx, m, tmp, filterKey) {
+			return false
+		}
 		if report != nil {
 			report.Trigger = summary.Trigger{
 				Fired:     true,
@@ -362,10 +365,31 @@ func shouldGenerateSummary(
 	checkTmp := tmp
 	if filterKey == session.SummaryFilterKeyAllContents {
 		if triggerFilterKey := summaryTriggerFilterKeyFromContext(ctx); triggerFilterKey != "" {
+			if shouldSkipBranchForkFullSessionCascade(ctx, m, tmp, filterKey) {
+				return false
+			}
 			checkTmp = buildFilterSession(base, triggerFilterKey, input)
 		}
 	}
 	return ShouldSummarize(ctx, m, checkTmp)
+}
+
+func shouldSkipBranchForkFullSessionCascade(
+	ctx context.Context,
+	m summary.SessionSummarizer,
+	tmp *session.Session,
+	filterKey string,
+) bool {
+	if filterKey != session.SummaryFilterKeyAllContents {
+		return false
+	}
+	if summaryTriggerFilterKeyFromContext(ctx) == "" {
+		return false
+	}
+	if _, ok := summary.CacheSafeForkRequestFromContext(ctx); !ok {
+		return false
+	}
+	return summary.CacheSafeForkingEnabled(ctx, m, tmp)
 }
 
 func reportFilterKey(ctx context.Context, filterKey string) string {
@@ -609,6 +633,18 @@ func contextWithForkedReport(ctx context.Context) context.Context {
 	return summary.ContextWithReport(ctx, &cloned)
 }
 
+func contextForSummaryTarget(
+	ctx context.Context,
+	triggerFilterKey string,
+	targetFilterKey string,
+) context.Context {
+	if targetFilterKey != session.SummaryFilterKeyAllContents ||
+		triggerFilterKey == session.SummaryFilterKeyAllContents {
+		return ctx
+	}
+	return contextWithSummaryTriggerFilterKey(ctx, triggerFilterKey)
+}
+
 // GetSummaryTextFromSession attempts to retrieve summary text from the session's
 // in-memory summaries using the specified filter key. It parses the provided options
 // and applies the summary selection logic. Filters out summaries with UpdatedAt before sess.CreatedAt.
@@ -717,10 +753,7 @@ func CreateSessionSummaryWithCascade(
 	}
 	if len(targets) == 1 {
 		target := targets[0]
-		if target == session.SummaryFilterKeyAllContents &&
-			filterKey != session.SummaryFilterKeyAllContents {
-			ctx = contextWithSummaryTriggerFilterKey(ctx, filterKey)
-		}
+		ctx = contextForSummaryTarget(ctx, filterKey, target)
 		return createSummaryFunc(ctx, sess, target, force)
 	}
 
@@ -750,10 +783,7 @@ func CreateSessionSummaryWithCascade(
 		callCtx := contextWithForkedReport(ctx)
 		go func(i int, fk string, callCtx context.Context) {
 			defer summaryWg.Done()
-			if fk == session.SummaryFilterKeyAllContents &&
-				filterKey != session.SummaryFilterKeyAllContents {
-				callCtx = contextWithSummaryTriggerFilterKey(callCtx, filterKey)
-			}
+			callCtx = contextForSummaryTarget(callCtx, filterKey, fk)
 			err := createSummaryFunc(callCtx, sess, fk, force)
 			if err != nil {
 				result[i] = fmt.Errorf("create session summary for filterKey %q failed: %w", fk, err)

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -389,7 +389,27 @@ func shouldSkipBranchForkFullSessionCascade(
 	if _, ok := summary.CacheSafeForkRequestFromContext(ctx); !ok {
 		return false
 	}
-	return summary.CacheSafeForkingEnabled(ctx, m, tmp)
+	return cacheSafeForkingEnabled(ctx, m, tmp)
+}
+
+type cacheSafeForkingResolver interface {
+	CacheSafeForkingEnabled(context.Context, *session.Session) bool
+}
+
+func cacheSafeForkingEnabled(
+	ctx context.Context,
+	m summary.SessionSummarizer,
+	sess *session.Session,
+) bool {
+	if m == nil {
+		return false
+	}
+	if resolver, ok := m.(cacheSafeForkingResolver); ok {
+		return resolver.CacheSafeForkingEnabled(ctx, sess)
+	}
+	metadata := m.Metadata()
+	enabled, _ := metadata["cache_safe_forking"].(bool)
+	return enabled
 }
 
 func reportFilterKey(ctx context.Context, filterKey string) string {

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -374,6 +374,9 @@ func shouldGenerateSummary(
 	return ShouldSummarize(ctx, m, checkTmp)
 }
 
+// shouldSkipBranchForkFullSessionCascade suppresses only the full-session target
+// that is explicitly marked as a branch cascade. This also applies to force=true:
+// force should not turn a branch fork request into a full-session summary.
 func shouldSkipBranchForkFullSessionCascade(
 	ctx context.Context,
 	m summary.SessionSummarizer,

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -380,6 +380,9 @@ func shouldSkipBranchForkFullSessionCascade(
 	tmp *session.Session,
 	filterKey string,
 ) bool {
+	if !skipBranchForkFullSessionCascadeFromContext(ctx) {
+		return false
+	}
 	if filterKey != session.SummaryFilterKeyAllContents {
 		return false
 	}
@@ -473,6 +476,7 @@ func selectSummaryBoundary(
 }
 
 type summaryTriggerFilterKeyContextKey struct{}
+type skipBranchForkFullSessionCascadeContextKey struct{}
 
 // summaryLockKey identifies the summary scope that must be serialized.
 type summaryLockKey struct {
@@ -566,12 +570,27 @@ func contextWithSummaryTriggerFilterKey(ctx context.Context, filterKey string) c
 	return context.WithValue(ctx, summaryTriggerFilterKeyContextKey{}, filterKey)
 }
 
+func contextWithSkipBranchForkFullSessionCascade(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, skipBranchForkFullSessionCascadeContextKey{}, true)
+}
+
 func summaryTriggerFilterKeyFromContext(ctx context.Context) string {
 	if ctx == nil {
 		return ""
 	}
 	filterKey, _ := ctx.Value(summaryTriggerFilterKeyContextKey{}).(string)
 	return filterKey
+}
+
+func skipBranchForkFullSessionCascadeFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	skip, _ := ctx.Value(skipBranchForkFullSessionCascadeContextKey{}).(bool)
+	return skip
 }
 
 func readLastIncludedTimestamp(tmp *session.Session) time.Time {
@@ -804,6 +823,10 @@ func CreateSessionSummaryWithCascade(
 		go func(i int, fk string, callCtx context.Context) {
 			defer summaryWg.Done()
 			callCtx = contextForSummaryTarget(callCtx, filterKey, fk)
+			if fk == session.SummaryFilterKeyAllContents &&
+				filterKey != session.SummaryFilterKeyAllContents {
+				callCtx = contextWithSkipBranchForkFullSessionCascade(callCtx)
+			}
 			err := createSummaryFunc(callCtx, sess, fk, force)
 			if err != nil {
 				result[i] = fmt.Errorf("create session summary for filterKey %q failed: %w", fk, err)

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -1701,6 +1701,45 @@ func TestCreateSessionSummaryWithCascade_SkipsFullTargetForDynamicCacheSafeFork(
 	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
 }
 
+func TestCreateSessionSummaryWithCascade_PreservesFullOnlyTargetForCacheSafeFork(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		Events: []event.Event{
+			makeEvent("branch", now.Add(-2*time.Minute), "user-messages"),
+			makeEvent("other", now.Add(-time.Minute), "tool-calls"),
+		},
+	}
+	parent := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("parent request")},
+	}
+	ctx := summary.ContextWithCacheSafeForkRequest(context.Background(), parent)
+
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithCacheSafeForking(true),
+	)
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		"user-messages",
+		false,
+		NewSummaryDispatchPolicy([]string{}, true),
+		func(ctx context.Context, _ *session.Session, filterKey string, _ bool) error {
+			_, err := SummarizeSession(ctx, summarizer, sess, filterKey, false)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.Nil(t, sess.Summaries["user-messages"])
+	require.NotNil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
+}
+
 func TestCreateSessionSummaryWithCascade_PreservesFullTargetWithoutCacheSafeFork(t *testing.T) {
 	now := time.Now()
 	sess := &session.Session{

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -1657,6 +1657,45 @@ func TestCreateSessionSummaryWithCascade_SkipsFullTargetForCacheSafeFork(t *test
 	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
 }
 
+func TestCreateSessionSummaryWithCascade_SkipsForcedFullTargetForCacheSafeFork(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		Events: []event.Event{
+			makeEvent("branch", now.Add(-2*time.Minute), "user-messages"),
+			makeEvent("other", now.Add(-time.Minute), "tool-calls"),
+		},
+	}
+	parent := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("parent request")},
+	}
+	ctx := summary.ContextWithCacheSafeForkRequest(context.Background(), parent)
+
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithCacheSafeForking(true),
+	)
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		"user-messages",
+		true,
+		NewSummaryDispatchPolicy(nil, true),
+		func(ctx context.Context, _ *session.Session, filterKey string, force bool) error {
+			_, err := SummarizeSession(ctx, summarizer, sess, filterKey, force)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.NotNil(t, sess.Summaries["user-messages"])
+	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
+}
+
 func TestCreateSessionSummaryWithCascade_SkipsFullTargetForDynamicCacheSafeFork(t *testing.T) {
 	now := time.Now()
 	sess := &session.Session{

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -1618,6 +1618,125 @@ func TestCreateSessionSummaryWithCascade_ForksReportForParallelTargets(t *testin
 	require.NotSame(t, reports[0], reports[1])
 }
 
+func TestCreateSessionSummaryWithCascade_SkipsFullTargetForCacheSafeFork(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		Events: []event.Event{
+			makeEvent("branch", now.Add(-2*time.Minute), "user-messages"),
+			makeEvent("other", now.Add(-time.Minute), "tool-calls"),
+		},
+	}
+	parent := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("parent request")},
+	}
+	ctx := summary.ContextWithCacheSafeForkRequest(context.Background(), parent)
+
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithCacheSafeForking(true),
+	)
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		"user-messages",
+		false,
+		NewSummaryDispatchPolicy(nil, true),
+		func(ctx context.Context, _ *session.Session, filterKey string, _ bool) error {
+			_, err := SummarizeSession(ctx, summarizer, sess, filterKey, false)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.NotNil(t, sess.Summaries["user-messages"])
+	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
+}
+
+func TestCreateSessionSummaryWithCascade_SkipsFullTargetForDynamicCacheSafeFork(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		Events: []event.Event{
+			makeEvent("branch", now.Add(-2*time.Minute), "user-messages"),
+			makeEvent("other", now.Add(-time.Minute), "tool-calls"),
+		},
+	}
+	parent := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("parent request")},
+	}
+	ctx := summary.ContextWithCacheSafeForkRequest(context.Background(), parent)
+	resolved := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithCacheSafeForking(true),
+	)
+	summarizer := summary.NewDynamicSummarizer(
+		func(context.Context, *session.Session) (summary.SessionSummarizer, error) {
+			return resolved, nil
+		},
+	)
+
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		"user-messages",
+		false,
+		NewSummaryDispatchPolicy(nil, true),
+		func(ctx context.Context, _ *session.Session, filterKey string, _ bool) error {
+			_, err := SummarizeSession(ctx, summarizer, sess, filterKey, false)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.NotNil(t, sess.Summaries["user-messages"])
+	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
+}
+
+func TestCreateSessionSummaryWithCascade_PreservesFullTargetWithoutCacheSafeFork(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		Events: []event.Event{
+			makeEvent("branch", now.Add(-2*time.Minute), "user-messages"),
+			makeEvent("other", now.Add(-time.Minute), "tool-calls"),
+		},
+	}
+	parent := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("parent request")},
+	}
+	ctx := summary.ContextWithCacheSafeForkRequest(context.Background(), parent)
+
+	summarizer := summary.NewSummarizer(&reportModel{})
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		"user-messages",
+		false,
+		NewSummaryDispatchPolicy(nil, true),
+		func(ctx context.Context, _ *session.Session, filterKey string, _ bool) error {
+			_, err := SummarizeSession(ctx, summarizer, sess, filterKey, false)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.NotNil(t, sess.Summaries["user-messages"])
+	require.NotNil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
+}
+
 func TestCreateSessionSummaryWithCascade_FullTargetUsesTriggerFilterKeyForChecks(t *testing.T) {
 	now := time.Now()
 	const (

--- a/session/summary/cache_safe_fork.go
+++ b/session/summary/cache_safe_fork.go
@@ -42,17 +42,11 @@ func CacheSafeForkRequestFromContext(ctx context.Context) (*model.Request, bool)
 	return req, ok && req != nil
 }
 
-func cacheSafeForkRequestFromContext(ctx context.Context) (*model.Request, bool) {
-	return CacheSafeForkRequestFromContext(ctx)
-}
-
 type cacheSafeForkingResolver interface {
 	CacheSafeForkingEnabled(context.Context, *session.Session) bool
 }
 
-// CacheSafeForkingEnabled reports whether the summarizer is configured to use
-// cache-safe summary forking in the current request context.
-func CacheSafeForkingEnabled(
+func cacheSafeForkingEnabled(
 	ctx context.Context,
 	s SessionSummarizer,
 	sess *session.Session,

--- a/session/summary/cache_safe_fork.go
+++ b/session/summary/cache_safe_fork.go
@@ -13,6 +13,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -43,6 +44,28 @@ func CacheSafeForkRequestFromContext(ctx context.Context) (*model.Request, bool)
 
 func cacheSafeForkRequestFromContext(ctx context.Context) (*model.Request, bool) {
 	return CacheSafeForkRequestFromContext(ctx)
+}
+
+type cacheSafeForkingResolver interface {
+	CacheSafeForkingEnabled(context.Context, *session.Session) bool
+}
+
+// CacheSafeForkingEnabled reports whether the summarizer is configured to use
+// cache-safe summary forking in the current request context.
+func CacheSafeForkingEnabled(
+	ctx context.Context,
+	s SessionSummarizer,
+	sess *session.Session,
+) bool {
+	if s == nil {
+		return false
+	}
+	if resolver, ok := s.(cacheSafeForkingResolver); ok {
+		return resolver.CacheSafeForkingEnabled(ctx, sess)
+	}
+	metadata := s.Metadata()
+	enabled, _ := metadata[metadataKeyCacheSafeForking].(bool)
+	return enabled
 }
 
 func cloneRequestForCacheSafeFork(req *model.Request) *model.Request {

--- a/session/summary/dynamic.go
+++ b/session/summary/dynamic.go
@@ -105,3 +105,19 @@ func (d *dynamicSummarizer) Metadata() map[string]any {
 		"type": metadataDynamicSummarizerType,
 	}
 }
+
+// CacheSafeForkingEnabled resolves the current summarizer and reports its
+// cache-safe forking configuration.
+func (d *dynamicSummarizer) CacheSafeForkingEnabled(
+	ctx context.Context,
+	sess *session.Session,
+) bool {
+	resolved, err := d.resolveSummarizer(ctx, sess)
+	if err != nil || resolved == nil {
+		return false
+	}
+	if nested, ok := resolved.(*dynamicSummarizer); ok && nested == d {
+		return false
+	}
+	return CacheSafeForkingEnabled(ctx, resolved, sess)
+}

--- a/session/summary/dynamic.go
+++ b/session/summary/dynamic.go
@@ -119,5 +119,5 @@ func (d *dynamicSummarizer) CacheSafeForkingEnabled(
 	if nested, ok := resolved.(*dynamicSummarizer); ok && nested == d {
 		return false
 	}
-	return CacheSafeForkingEnabled(ctx, resolved, sess)
+	return cacheSafeForkingEnabled(ctx, resolved, sess)
 }

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -971,7 +971,7 @@ func (s *sessionSummarizer) buildSummaryRequest(
 	conversationText string,
 ) (*model.Request, string, error) {
 	if s.cacheSafeForking {
-		if parent, ok := cacheSafeForkRequestFromContext(ctx); ok {
+		if parent, ok := CacheSafeForkRequestFromContext(ctx); ok {
 			request, err := s.buildCacheSafeForkRequest(parent)
 			return request, callModeCacheSafeFork, err
 		}


### PR DESCRIPTION
## Summary
- builds on #1932, which added cache-safe summary forking support in `session/summary`
- capture the parent LLM request before model calls and store it as a cache-safe summary fork snapshot
- append persisted assistant/tool response messages to the snapshot before async summary jobs advance the summary boundary
- pass the snapshot to Runner async `EnqueueSummaryJob` and sync intra-run `CreateSessionSummary`
- keep pre-LLM context compaction on its existing direct request fork path

## Relationship to cache-safe forking
- `session/summary` remains the implementation of cache-safe summary forking via `ContextWithCacheSafeForkRequest` and the summarizer fork logic added in #1932.
- `internal/state/summaryfork` is a framework-side snapshot holder for call paths that do not already have the parent request in hand when summary runs.
- Runner async summary and sync intra-run summary now use `summaryfork.Request(invocation)` to attach a parent request to summary context.
- Pre-LLM context compaction already has the live parent request, so it continues to attach that request directly without storing it through `summaryfork` first.

## Coverage and fallback
- Covered: pre-LLM context compaction, Runner async summary jobs, and sync intra-run summaries.
- Fallback: direct/manual `CreateSessionSummary` calls without a current parent model request still run standalone.
- Standalone summary paths still need summary input token limits as the hard guard for oversized history.

## Tests
- `go test ./internal/flow/llmflow ./internal/state/summaryfork ./runner`
- `go test ./internal/flow/llmflow -run 'TestMaybeSyncSummaryIntraRun|TestRun_SyncSummaryIntraRun|TestRunOneStep' -coverprofile=/tmp/llmflow_sync.cover`
- `go test ./internal/state/summaryfork -coverprofile=/tmp/summaryfork.cover`
