### PR TITLE
openclaw: bound host exec sessions and waits

### DIFF
--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -689,6 +689,48 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 					},
 				),
 				adminRuntimeTextField(
+					"tools.host_exec_max_timeout",
+					"Host Exec Max Timeout",
+					"Maximum timeout for host exec_command calls, "+
+						"including timeout_sec requested by the model. "+
+						"Empty or 0 disables this cap.",
+					"",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"host_exec_max_timeout",
+							"hostExecMaxTimeout",
+						),
+					},
+					func(opts runOptions) string {
+						if opts.HostExecMaxTimeout <= 0 {
+							return ""
+						}
+						return opts.HostExecMaxTimeout.String()
+					},
+				),
+				adminRuntimeTextField(
+					"tools.host_exec_max_yield",
+					"Host Exec Max Yield",
+					"Maximum wait before exec_command or write_stdin "+
+						"returns interim output. Empty or 0 disables "+
+						"this cap.",
+					"",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("tools"),
+						adminRuntimeKey(
+							"host_exec_max_yield",
+							"hostExecMaxYield",
+						),
+					},
+					func(opts runOptions) string {
+						if opts.HostExecMaxYield <= 0 {
+							return ""
+						}
+						return opts.HostExecMaxYield.String()
+					},
+				),
+				adminRuntimeTextField(
 					"tools.defer_direct_tools",
 					"Deferred Direct Tools",
 					"Comma-separated additional tool names to keep "+

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -1269,6 +1269,8 @@ func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
 			"  defer_to_dynamic_agent_threshold_chars: 1234\n"+
 			"  dynamic_agent_timeout: 3m\n"+
 			"  host_exec_default_timeout: 60s\n"+
+			"  host_exec_max_timeout: 45s\n"+
+			"  host_exec_max_yield: 2s\n"+
 			"  defer_direct_tools: [exec_command]\n"+
 			"  defer_default_direct_tools: false\n",
 	)
@@ -1279,6 +1281,8 @@ func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
 	opts.DeferToolSurfaceDefaultDirectTools = false
 	opts.DynamicAgentTimeout = 3 * time.Minute
 	opts.HostExecDefaultTimeout = time.Minute
+	opts.HostExecMaxTimeout = 45 * time.Second
+	opts.HostExecMaxYield = 2 * time.Second
 
 	provider, ok := buildAdminRuntimeConfigProvider(
 		opts,
@@ -1315,6 +1319,20 @@ func TestBuildAdminOptions_ExposesDeferredToolSurfaceFields(
 	)
 	require.Equal(t, "1m0s", hostTimeout.RuntimeValue)
 	require.Equal(t, "60s", hostTimeout.ConfiguredValue)
+	hostMaxTimeout := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.host_exec_max_timeout",
+	)
+	require.Equal(t, "45s", hostMaxTimeout.RuntimeValue)
+	require.Equal(t, "45s", hostMaxTimeout.ConfiguredValue)
+	hostMaxYield := findAdminRuntimeConfigField(
+		t,
+		status,
+		"tools.host_exec_max_yield",
+	)
+	require.Equal(t, "2s", hostMaxYield.RuntimeValue)
+	require.Equal(t, "2s", hostMaxYield.ConfiguredValue)
 	direct := findAdminRuntimeConfigField(
 		t,
 		status,

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1133,6 +1133,8 @@ func NewRuntimeWithOptions(
 		fileMemoryStore,
 		sandboxExecEngine,
 		opts.HostExecDefaultTimeout,
+		opts.HostExecMaxTimeout,
+		opts.HostExecMaxYield,
 	)
 	extraTools := memoryServiceTools(memSvc)
 	extraTools = append(extraTools, openClawTools.tools...)
@@ -1744,6 +1746,8 @@ func run(
 		fileMemoryStore,
 		sandboxExecEngine,
 		opts.HostExecDefaultTimeout,
+		opts.HostExecMaxTimeout,
+		opts.HostExecMaxYield,
 	)
 	extraTools := memoryServiceTools(memSvc)
 	extraTools = append(extraTools, openClawTools.tools...)
@@ -3439,6 +3443,8 @@ func buildOpenClawTools(
 	memoryFileStore *memoryfile.Store,
 	sandboxExecEngine codeexecutor.Engine,
 	hostExecDefaultTimeout time.Duration,
+	hostExecMaxTimeout time.Duration,
+	hostExecMaxYield time.Duration,
 ) openClawToolsBundle {
 	if !enabled {
 		return openClawToolsBundle{}
@@ -3481,6 +3487,18 @@ func buildOpenClawTools(
 			mgrOpts = append(
 				mgrOpts,
 				octool.WithDefaultTimeout(hostExecDefaultTimeout),
+			)
+		}
+		if hostExecMaxTimeout > 0 {
+			mgrOpts = append(
+				mgrOpts,
+				octool.WithMaxTimeout(hostExecMaxTimeout),
+			)
+		}
+		if hostExecMaxYield > 0 {
+			mgrOpts = append(
+				mgrOpts,
+				octool.WithMaxYield(hostExecMaxYield),
 			)
 		}
 		mgr = octool.NewManager(mgrOpts...)

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -652,7 +652,7 @@ func TestFileMemoryStoreForBackend_FileOnly(t *testing.T) {
 func TestBuildOpenClawTools_HidesMemoryFileEnvWithoutFileBackend(t *testing.T) {
 	t.Parallel()
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0, 0, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(
@@ -673,6 +673,8 @@ func TestBuildOpenClawTools_HostExecDefaultTimeout(t *testing.T) {
 		nil,
 		nil,
 		50*time.Millisecond,
+		0,
+		0,
 	)
 	execTool := findTool(bundle.tools, "exec_command")
 	callable, ok := execTool.(tool.CallableTool)
@@ -699,6 +701,84 @@ func TestBuildOpenClawTools_HostExecDefaultTimeout(t *testing.T) {
 	require.NotContains(t, got.Output, "done")
 }
 
+func TestBuildOpenClawTools_HostExecMaxTimeoutAndYield(t *testing.T) {
+	t.Parallel()
+
+	bundle := buildOpenClawTools(
+		true,
+		t.TempDir(),
+		nil,
+		nil,
+		nil,
+		0,
+		50*time.Millisecond,
+		20*time.Millisecond,
+	)
+	execTool := findTool(bundle.tools, "exec_command")
+	callable, ok := execTool.(tool.CallableTool)
+	require.True(t, ok)
+
+	started := time.Now()
+	out, err := callable.Call(
+		context.Background(),
+		[]byte(
+			`{"command":"sleep 5; printf done",`+
+				`"yield_time_ms":0,"timeout_sec":5}`,
+		),
+	)
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 3*time.Second)
+
+	data, err := json.Marshal(out)
+	require.NoError(t, err)
+	var got struct {
+		Status   string `json:"status"`
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
+	}
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, "exited", got.Status)
+	require.NotEqual(t, 0, got.ExitCode)
+	require.NotContains(t, got.Output, "done")
+
+	writeTool := findTool(bundle.tools, "write_stdin")
+	writeCallable, ok := writeTool.(tool.CallableTool)
+	require.True(t, ok)
+	out, err = callable.Call(
+		context.Background(),
+		[]byte(`{"command":"sleep 1","background":true}`),
+	)
+	require.NoError(t, err)
+	data, err = json.Marshal(out)
+	require.NoError(t, err)
+	var running struct {
+		SessionID string `json:"sessionId"`
+	}
+	require.NoError(t, json.Unmarshal(data, &running))
+	require.NotEmpty(t, running.SessionID)
+	killTool := findTool(bundle.tools, "kill_session")
+	killCallable, ok := killTool.(tool.CallableTool)
+	require.True(t, ok)
+	t.Cleanup(func() {
+		if running.SessionID != "" {
+			_, _ = killCallable.Call(
+				context.Background(),
+				[]byte(
+					`{"session_id":"`+running.SessionID+`"}`,
+				),
+			)
+		}
+	})
+
+	started = time.Now()
+	_, err = writeCallable.Call(
+		context.Background(),
+		[]byte(`{"session_id":"`+running.SessionID+`","yield_time_ms":5000}`),
+	)
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+}
+
 func TestBuildOpenClawTools_ExposesMemoryFileEnvForFileBackend(t *testing.T) {
 	t.Parallel()
 
@@ -707,7 +787,7 @@ func TestBuildOpenClawTools_ExposesMemoryFileEnvForFileBackend(t *testing.T) {
 	store, err := memoryfile.NewStore(root)
 	require.NoError(t, err)
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, nil, 0)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, nil, 0, 0, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "OPENCLAW_MEMORY_FILE")
@@ -724,7 +804,7 @@ func TestBuildOpenClawTools_UsesSandboxExecCommand(t *testing.T) {
 	t.Parallel()
 
 	engine := codeexecutor.NewEngine(nil, nil, nil)
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, engine, 0)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, engine, 0, 0, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "inside the configured sandbox")
@@ -752,7 +832,7 @@ func TestBuildOpenClawTools_UsesSandboxExecCommandWithMemoryFileStore(
 	require.NoError(t, err)
 
 	engine := codeexecutor.NewEngine(nil, nil, nil)
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, engine, 0)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, store, engine, 0, 0, 0)
 	decl := findToolDeclaration(bundle.tools, "exec_command")
 	require.NotNil(t, decl)
 	require.Contains(t, decl.Description, "inside the configured sandbox")
@@ -771,7 +851,7 @@ func TestBuildOpenClawTools_IncludesConversationHistoryTool(
 ) {
 	t.Parallel()
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0, 0, 0)
 	decl := findToolDeclaration(bundle.tools, "conversation_history")
 	require.NotNil(t, decl)
 	require.Contains(
@@ -784,7 +864,7 @@ func TestBuildOpenClawTools_IncludesConversationHistoryTool(
 func TestBuildOpenClawTools_IncludesSubagentTools(t *testing.T) {
 	t.Parallel()
 
-	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0)
+	bundle := buildOpenClawTools(true, t.TempDir(), nil, nil, nil, 0, 0, 0)
 	require.NotNil(
 		t,
 		findToolDeclaration(bundle.tools, "subagents_spawn"),

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -140,6 +140,8 @@ const (
 	flagDeferToolSurfaceDirect             = "defer-tools-to-dynamic-agent-direct-tools"
 	flagDynamicAgentTimeout                = "dynamic-agent-timeout"
 	flagHostExecDefaultTimeout             = "host-exec-default-timeout"
+	flagHostExecMaxTimeout                 = "host-exec-max-timeout"
+	flagHostExecMaxYield                   = "host-exec-max-yield"
 
 	flagAdminEnabled  = "admin-enabled"
 	flagAdminAddr     = "admin-addr"
@@ -295,6 +297,8 @@ type runOptions struct {
 	DeferToolSurfaceDirect             string
 	DynamicAgentTimeout                time.Duration
 	HostExecDefaultTimeout             time.Duration
+	HostExecMaxTimeout                 time.Duration
+	HostExecMaxYield                   time.Duration
 
 	enableOpenClawToolsExplicit  bool
 	deferToolSurfaceModeExplicit bool
@@ -965,6 +969,20 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"Default timeout for OpenClaw host exec commands when timeout_sec "+
 			"is omitted (0 keeps the built-in default)",
 	)
+	fs.DurationVar(
+		&opts.HostExecMaxTimeout,
+		flagHostExecMaxTimeout,
+		0,
+		"Maximum timeout for OpenClaw host exec commands, including "+
+			"timeout_sec requested by the model (0 disables the cap)",
+	)
+	fs.DurationVar(
+		&opts.HostExecMaxYield,
+		flagHostExecMaxYield,
+		0,
+		"Maximum wait before exec_command or write_stdin returns "+
+			"interim output (0 disables the cap)",
+	)
 
 	if err := fs.Parse(args); err != nil {
 		return runOptions{}, &exitError{Code: 2, Err: err}
@@ -1292,6 +1310,10 @@ type toolsConfig struct {
 	DynamicAgentTimeoutCamel      *string             `yaml:"dynamicAgentTimeout,omitempty"`
 	HostExecDefaultTimeout        *string             `yaml:"host_exec_default_timeout,omitempty"`
 	HostExecDefaultTimeoutCamel   *string             `yaml:"hostExecDefaultTimeout,omitempty"`
+	HostExecMaxTimeout            *string             `yaml:"host_exec_max_timeout,omitempty"`
+	HostExecMaxTimeoutCamel       *string             `yaml:"hostExecMaxTimeout,omitempty"`
+	HostExecMaxYield              *string             `yaml:"host_exec_max_yield,omitempty"`
+	HostExecMaxYieldCamel         *string             `yaml:"hostExecMaxYield,omitempty"`
 
 	Providers []filePluginSpec `yaml:"providers,omitempty"`
 	ToolSets  []filePluginSpec `yaml:"toolsets,omitempty"`
@@ -2081,6 +2103,36 @@ func (cfg *fileConfig) apply(
 			}
 			opts.HostExecDefaultTimeout = dur
 		}
+		hostExecMaxTimeout := firstStringPtr(
+			cfg.Tools.HostExecMaxTimeout,
+			cfg.Tools.HostExecMaxTimeoutCamel,
+		)
+		if hostExecMaxTimeout != nil &&
+			!flagWasSet(set, flagHostExecMaxTimeout) {
+			dur, err := parseDuration(*hostExecMaxTimeout)
+			if err != nil {
+				return fmt.Errorf(
+					"tools.host_exec_max_timeout: %w",
+					err,
+				)
+			}
+			opts.HostExecMaxTimeout = dur
+		}
+		hostExecMaxYield := firstStringPtr(
+			cfg.Tools.HostExecMaxYield,
+			cfg.Tools.HostExecMaxYieldCamel,
+		)
+		if hostExecMaxYield != nil &&
+			!flagWasSet(set, flagHostExecMaxYield) {
+			dur, err := parseDuration(*hostExecMaxYield)
+			if err != nil {
+				return fmt.Errorf(
+					"tools.host_exec_max_yield: %w",
+					err,
+				)
+			}
+			opts.HostExecMaxYield = dur
+		}
 		if len(cfg.Tools.Providers) > 0 {
 			opts.ToolProviders = convertPluginSpecs(cfg.Tools.Providers)
 		}
@@ -2798,6 +2850,18 @@ func finalizeRunOptions(opts *runOptions) error {
 		return fmt.Errorf(
 			"invalid host exec default timeout: %s",
 			opts.HostExecDefaultTimeout,
+		)
+	}
+	if opts.HostExecMaxTimeout < 0 {
+		return fmt.Errorf(
+			"invalid host exec max timeout: %s",
+			opts.HostExecMaxTimeout,
+		)
+	}
+	if opts.HostExecMaxYield < 0 {
+		return fmt.Errorf(
+			"invalid host exec max yield: %s",
+			opts.HostExecMaxYield,
 		)
 	}
 	opts.DeferToolSurfaceDirect = strings.Join(

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -1201,6 +1201,8 @@ tools:
   defer_direct_tools: ["exec_command", "message", "exec_command"]
   dynamic_agent_timeout: "3m"
   host_exec_default_timeout: "60s"
+  host_exec_max_timeout: "45s"
+  host_exec_max_yield: "2s"
 `)
 	opts, err := parseRunOptions([]string{"-config", cfgPath})
 	require.NoError(t, err)
@@ -1211,6 +1213,8 @@ tools:
 	require.Equal(t, "exec_command,message", opts.DeferToolSurfaceDirect)
 	require.Equal(t, 3*time.Minute, opts.DynamicAgentTimeout)
 	require.Equal(t, time.Minute, opts.HostExecDefaultTimeout)
+	require.Equal(t, 45*time.Second, opts.HostExecMaxTimeout)
+	require.Equal(t, 2*time.Second, opts.HostExecMaxYield)
 }
 
 func TestParseRunOptions_DynamicAgentTimeoutFlagOverridesConfig(t *testing.T) {
@@ -1245,6 +1249,66 @@ tools:
 	require.Equal(t, 45*time.Second, opts.HostExecDefaultTimeout)
 }
 
+func TestParseRunOptions_HostExecMaxTimeoutFlagOverridesConfig(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  host_exec_max_timeout: "3m"
+`)
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-host-exec-max-timeout", "45s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 45*time.Second, opts.HostExecMaxTimeout)
+}
+
+func TestParseRunOptions_HostExecMaxYieldFlagOverridesConfig(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+tools:
+  host_exec_max_yield: "3m"
+`)
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-host-exec-max-yield", "45s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 45*time.Second, opts.HostExecMaxYield)
+}
+
+func TestParseRunOptions_HostExecMaxConfigInvalidDurationFails(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		key  string
+	}{
+		{name: "timeout", key: "host_exec_max_timeout"},
+		{name: "yield", key: "host_exec_max_yield"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgPath := writeTempConfig(t, fmt.Sprintf(`
+tools:
+  %s: "not-a-duration"
+`, tc.key))
+			_, err := parseRunOptions([]string{"-config", cfgPath})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "tools."+tc.key)
+		})
+	}
+}
+
 func TestParseRunOptions_DynamicAgentTimeoutNegativeFails(t *testing.T) {
 	t.Parallel()
 
@@ -1262,6 +1326,28 @@ func TestParseRunOptions_HostExecDefaultTimeoutNegativeFails(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "host exec default timeout")
+}
+
+func TestParseRunOptions_HostExecMaxTimeoutNegativeFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRunOptions([]string{
+		"-host-exec-max-timeout",
+		"-1s",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host exec max timeout")
+}
+
+func TestParseRunOptions_HostExecMaxYieldNegativeFails(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRunOptions([]string{
+		"-host-exec-max-yield",
+		"-1s",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host exec max yield")
 }
 
 func TestParseRunOptions_DeferToolSurfaceDefaultsToAuto(t *testing.T) {

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -47,6 +47,8 @@ type Manager struct {
 	maxLines             int
 	jobTTL               time.Duration
 	timeout              time.Duration
+	maxTimeout           time.Duration
+	maxYield             time.Duration
 	baseEnv              map[string]string
 	policy               CommandPolicy
 	redactor             OutputRedactor
@@ -79,6 +81,26 @@ func WithDefaultTimeout(d time.Duration) Option {
 	return func(m *Manager) {
 		if d > 0 {
 			m.timeout = d
+		}
+	}
+}
+
+// WithMaxTimeout caps command runtime, including timeout_sec requested by the
+// model. Non-positive values preserve the legacy uncapped behavior.
+func WithMaxTimeout(d time.Duration) Option {
+	return func(m *Manager) {
+		if d > 0 {
+			m.maxTimeout = d
+		}
+	}
+}
+
+// WithMaxYield caps how long exec_command and write_stdin wait before returning
+// interim output. Non-positive values preserve the legacy uncapped behavior.
+func WithMaxYield(d time.Duration) Option {
+	return func(m *Manager) {
+		if d > 0 {
+			m.maxYield = d
 		}
 	}
 }
@@ -178,14 +200,9 @@ func (m *Manager) Exec(
 	if params.YieldMs != nil && *params.YieldMs >= 0 {
 		yieldMs = *params.YieldMs
 	}
+	yieldMs = m.clampYieldMs(yieldMs)
 
-	timeout := m.timeout
-	if params.TimeoutS != nil && *params.TimeoutS > 0 {
-		timeout = time.Duration(*params.TimeoutS) * time.Second
-	}
-	if timeout <= 0 {
-		timeout = time.Duration(defaultTimeoutS) * time.Second
-	}
+	timeout := m.commandTimeout(params.TimeoutS)
 
 	if !params.Background && yieldMs == 0 && !params.Pty {
 		out, code, err := runForeground(
@@ -206,7 +223,7 @@ func (m *Manager) Exec(
 		}, nil
 	}
 
-	sess, err := m.startBackground(params, timeout, redact)
+	sess, err := m.startBackground(ctx, params, timeout, redact)
 	if err != nil {
 		return execResult{}, err
 	}
@@ -338,11 +355,15 @@ func exitCode(err error) int {
 }
 
 func (m *Manager) startBackground(
+	parentCtx context.Context,
 	params execParams,
 	timeout time.Duration,
 	redact func(string) string,
 ) (*session, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	cmd := shellCmd(ctx, params.Command)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(m.baseEnv, params.Env)
@@ -517,6 +538,34 @@ func (m *Manager) limitResultOutput(output string) string {
 		return output
 	}
 	return truncateResultOutput(output, m.maxResultOutputChars)
+}
+
+func (m *Manager) commandTimeout(timeoutS *int) time.Duration {
+	timeout := m.timeout
+	if timeoutS != nil && *timeoutS > 0 {
+		timeout = time.Duration(*timeoutS) * time.Second
+	}
+	if timeout <= 0 {
+		timeout = time.Duration(defaultTimeoutS) * time.Second
+	}
+	if m.maxTimeout > 0 && timeout > m.maxTimeout {
+		return m.maxTimeout
+	}
+	return timeout
+}
+
+func (m *Manager) clampYieldMs(yieldMs int) int {
+	if yieldMs <= 0 || m == nil || m.maxYield <= 0 {
+		return yieldMs
+	}
+	maxMs := int(m.maxYield / time.Millisecond)
+	if maxMs <= 0 {
+		maxMs = 1
+	}
+	if yieldMs > maxMs {
+		return maxMs
+	}
+	return yieldMs
 }
 
 func truncateResultOutput(output string, maxChars int) string {

--- a/openclaw/internal/octool/redaction.go
+++ b/openclaw/internal/octool/redaction.go
@@ -25,7 +25,7 @@ const (
 var (
 	sensitiveEnvNamePattern = regexp.MustCompile(
 		`(?i)\b[A-Z0-9_]*(TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|` +
-			`ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*\b`,
+			`ACCESS_KEY|PRIVATE_KEY|KEY|CREDENTIAL)[A-Z0-9_]*\b`,
 	)
 
 	sensitiveAssignmentPattern = regexp.MustCompile(

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -654,6 +654,7 @@ func (t *writeTool) Call(ctx context.Context, args []byte) (any, error) {
 		*v >= 0 {
 		yield = *v
 	}
+	yield = t.mgr.clampYieldMs(yield)
 	if yield > 0 {
 		timer := time.NewTimer(time.Duration(yield) * time.Millisecond)
 		defer timer.Stop()
@@ -914,7 +915,7 @@ func uploadEnvFromContext(
 
 	env := make(map[string]string)
 	if scope, ok := uploadScopeFromInvocation(inv); ok &&
-		store != nil {
+		store != nil && strings.TrimSpace(scope.Channel) != "" {
 		dir := strings.TrimSpace(store.ScopeDir(scope))
 		if dir != "" {
 			env[envSessionUploadsDir] = dir
@@ -1204,7 +1205,7 @@ func appendRecentUploadsFromStore(
 	if !ok {
 		return out
 	}
-	files, err := store.ListScope(scope, limit)
+	files, err := listUploadsForScope(store, scope, limit)
 	if err != nil {
 		return out
 	}
@@ -1241,6 +1242,36 @@ func appendRecentUploadsFromStore(
 		})
 	}
 	return out
+}
+
+func listUploadsForScope(
+	store *uploads.Store,
+	scope uploads.Scope,
+	limit int,
+) ([]uploads.ListedFile, error) {
+	if strings.TrimSpace(scope.Channel) != "" {
+		return store.ListScope(scope, limit)
+	}
+	files, err := store.ListAll(0)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uploads.ListedFile, 0, len(files))
+	userID := strings.TrimSpace(scope.UserID)
+	sessionID := strings.TrimSpace(scope.SessionID)
+	for _, file := range files {
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+		if strings.TrimSpace(file.Scope.UserID) != userID {
+			continue
+		}
+		if strings.TrimSpace(file.Scope.SessionID) != sessionID {
+			continue
+		}
+		out = append(out, file)
+	}
+	return out, nil
 }
 
 func uploadScopeFromInvocation(

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -347,6 +347,84 @@ func TestExecTool_UsesManagerDefaultTimeout(t *testing.T) {
 	require.NotContains(t, res.Output, "done")
 }
 
+func TestExecTool_MaxTimeoutCapsRequestedTimeout(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(WithMaxTimeout(50 * time.Millisecond))
+	tool := newExecCommandTool(mgr)
+
+	started := time.Now()
+	out, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
+		"command":     "sleep 1; printf done",
+		"yieldMs":     0,
+		"timeout_sec": 5,
+	}))
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 900*time.Millisecond)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	require.NotEqual(t, 0, res.ExitCode)
+	require.NotContains(t, res.Output, "done")
+}
+
+func TestManagerTimeoutAndYieldBranches(t *testing.T) {
+	t.Parallel()
+
+	defaultMgr := NewManager()
+	require.Equal(
+		t,
+		time.Duration(defaultTimeoutS)*time.Second,
+		defaultMgr.commandTimeout(nil),
+	)
+	zeroMgr := &Manager{}
+	require.Equal(
+		t,
+		time.Duration(defaultTimeoutS)*time.Second,
+		zeroMgr.commandTimeout(nil),
+	)
+
+	requested := 1
+	cappedMgr := NewManager(WithMaxTimeout(5 * time.Second))
+	require.Equal(t, time.Second, cappedMgr.commandTimeout(&requested))
+
+	yieldMgr := NewManager(WithMaxYield(2 * time.Second))
+	require.Equal(t, 1000, yieldMgr.clampYieldMs(1000))
+
+	tinyYieldMgr := NewManager(WithMaxYield(time.Nanosecond))
+	require.Equal(t, 1, tinyYieldMgr.clampYieldMs(5000))
+
+	var nilMgr *Manager
+	require.Equal(t, 10, nilMgr.clampYieldMs(10))
+}
+
+func TestManagerStartBackgroundUsesBackgroundForNilParentContext(
+	t *testing.T,
+) {
+	if _, err := exec.LookPath(shellProgram); err != nil {
+		t.Skip("shell is not available")
+	}
+
+	mgr := NewManager()
+	sess, err := mgr.startBackground(
+		nil,
+		execParams{Command: "printf ok"},
+		time.Second,
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = mgr.kill(sess.id)
+	})
+
+	require.Eventually(t, func() bool {
+		poll, err := mgr.poll(sess.id, nil)
+		return err == nil && poll.Status == "exited"
+	}, 3*time.Second, 20*time.Millisecond)
+}
+
 func TestExecTool_RuntimeProfileWorkspacePolicy(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not available")
@@ -608,8 +686,11 @@ func TestExecTool_RedactsSensitiveKeyValueOutput(t *testing.T) {
 
 	args := mustJSON(t, map[string]any{
 		"command": `printf 'OPENAI_API_KEY=sk-test-secret
+WECOM_ENCODING_AES_KEY=wecom-aes-secret
+SERVICE_CREDENTIAL=service-credential-secret
 SAFE_NAME=ok
 "OPENAI_API_KEY": "sk-test-secret",
+"WECOM_ENCODING_AES_KEY": "wecom-aes-secret",
 '`,
 		"yieldMs": 0,
 	})
@@ -618,9 +699,14 @@ SAFE_NAME=ok
 
 	res := out.(execResult)
 	require.Contains(t, res.Output, "OPENAI_API_KEY=[REDACTED]")
+	require.Contains(t, res.Output, "WECOM_ENCODING_AES_KEY=[REDACTED]")
+	require.Contains(t, res.Output, "SERVICE_CREDENTIAL=[REDACTED]")
 	require.Contains(t, res.Output, `OPENAI_API_KEY": "[REDACTED]"`)
+	require.Contains(t, res.Output, `WECOM_ENCODING_AES_KEY": "[REDACTED]"`)
 	require.Contains(t, res.Output, "SAFE_NAME=ok")
 	require.NotContains(t, res.Output, "sk-test-secret")
+	require.NotContains(t, res.Output, "wecom-aes-secret")
+	require.NotContains(t, res.Output, "service-credential-secret")
 }
 
 func TestExecTool_UsesMemoryFileEnvFromContext(t *testing.T) {
@@ -953,6 +1039,50 @@ func TestExecTool_DefaultTimeoutKillsProcessGroup(t *testing.T) {
 	}, 900*time.Millisecond, 20*time.Millisecond)
 }
 
+func TestExecTool_ContextCancelKillsYieldSessionProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group signaling is unix-specific")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	marker := filepath.Join(dir, "orphan-marker")
+	mgr := NewManager(WithJobTTL(10 * time.Second))
+	yieldMs := 10
+	timeoutS := 30
+	ctx, cancel := context.WithCancel(context.Background())
+
+	res, err := mgr.Exec(ctx, execParams{
+		Command: "(sleep 0.7; echo orphan > " +
+			strconv.Quote(marker) + ") & echo ready > " +
+			strconv.Quote(ready) + "; wait",
+		YieldMs:  &yieldMs,
+		TimeoutS: &timeoutS,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "running", res.Status)
+	require.NotEmpty(t, res.SessionID)
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(ready)
+		return err == nil
+	}, time.Second, 20*time.Millisecond)
+
+	cancel()
+	pollUntilExited(t, mgr, res.SessionID)
+	require.Never(t, func() bool {
+		_, err = os.Stat(marker)
+		if err == nil {
+			return true
+		}
+		require.ErrorIs(t, err, os.ErrNotExist)
+		return false
+	}, time.Second, 20*time.Millisecond)
+}
+
 func TestProcessTool_Submit(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not available")
@@ -1007,6 +1137,38 @@ func TestProcessTool_Submit(t *testing.T) {
 		t.Fatalf("process exited; output: %s", all)
 	}
 	t.Fatalf("process did not exit; output: %s", all)
+}
+
+func TestWriteStdinTool_MaxYieldCapsRequestedWait(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(
+		WithJobTTL(10*time.Second),
+		WithMaxYield(20*time.Millisecond),
+	)
+	execTool := newExecCommandTool(mgr)
+	writeTool := newWriteStdinTool(mgr)
+
+	out, err := execTool.Call(context.Background(), mustJSON(t, map[string]any{
+		"command":    "sleep 1",
+		"background": true,
+	}))
+	require.NoError(t, err)
+	res := out.(execResult)
+	t.Cleanup(func() {
+		_ = mgr.kill(res.SessionID)
+	})
+
+	started := time.Now()
+	_, err = writeTool.Call(context.Background(), mustJSON(t, map[string]any{
+		"session_id":     res.SessionID,
+		"yield_time_ms":  5_000,
+		"append_newline": false,
+	}))
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 500*time.Millisecond)
 }
 
 func TestExecTool_PTYForeground(t *testing.T) {
@@ -1954,6 +2116,145 @@ func TestUploadEnvFromContext_UsesUploadStore(t *testing.T) {
 	require.Equal(t, derived.Path, recent[0].Path)
 	require.Equal(t, uploadKindPDF, recent[0].Kind)
 	require.Equal(t, uploads.SourceDerived, recent[0].Source)
+}
+
+func TestUploadEnvFromContext_UsesUploadStoreWithoutChannelPrefix(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	store, err := uploads.NewStore(stateDir)
+	require.NoError(t, err)
+
+	scope := uploads.Scope{
+		Channel:   "admin",
+		UserID:    "u1",
+		SessionID: "eval-session-1",
+	}
+	saved, err := store.SaveWithInfo(
+		context.Background(),
+		scope,
+		"board.png",
+		uploads.FileMetadata{
+			MimeType: "image/png",
+			Source:   uploads.SourceInbound,
+		},
+		[]byte("png"),
+	)
+	require.NoError(t, err)
+
+	_, err = store.SaveWithInfo(
+		context.Background(),
+		uploads.Scope{
+			Channel:   "admin",
+			UserID:    "other-user",
+			SessionID: "eval-session-1",
+		},
+		"other.png",
+		uploads.FileMetadata{MimeType: "image/png"},
+		[]byte("other"),
+	)
+	require.NoError(t, err)
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(
+			sessionpkg.NewSession("app", "u1", "eval-session-1"),
+		),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	env := uploadEnvFromContext(ctx, store)
+	require.Equal(t, saved.Path, env[envLastUploadPath])
+	require.Equal(t, saved.HostRef, env[envLastUploadHostRef])
+	require.Equal(t, saved.Path, env[envLastImagePath])
+	require.Equal(t, saved.HostRef, env[envLastImageHostRef])
+	require.Equal(t, filepath.Dir(saved.Path), env[envSessionUploadsDir])
+
+	var recent []execUploadMeta
+	require.NoError(
+		t,
+		json.Unmarshal([]byte(env[envRecentUploadsJSON]), &recent),
+	)
+	require.Len(t, recent, 1)
+	require.Equal(t, saved.Path, recent[0].Path)
+	require.Equal(t, uploads.SourceInbound, recent[0].Source)
+}
+
+func TestListUploadsForScopeWithoutChannelFiltersAndLimits(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	store, err := uploads.NewStore(stateDir)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		scope uploads.Scope
+		name  string
+	}{
+		{
+			scope: uploads.Scope{
+				Channel:   "admin",
+				UserID:    "u1",
+				SessionID: "eval-session-1",
+			},
+			name: "first.png",
+		},
+		{
+			scope: uploads.Scope{
+				Channel:   "admin",
+				UserID:    "u1",
+				SessionID: "other-session",
+			},
+			name: "skip.png",
+		},
+		{
+			scope: uploads.Scope{
+				Channel:   "wecom",
+				UserID:    "u1",
+				SessionID: "eval-session-1",
+			},
+			name: "second.png",
+		},
+	} {
+		_, err := store.SaveWithInfo(
+			context.Background(),
+			tc.scope,
+			tc.name,
+			uploads.FileMetadata{MimeType: "image/png"},
+			[]byte(tc.name),
+		)
+		require.NoError(t, err)
+	}
+
+	scope := uploads.Scope{UserID: "u1", SessionID: "eval-session-1"}
+	files, err := listUploadsForScope(store, scope, 0)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	for _, file := range files {
+		require.Equal(t, "u1", file.Scope.UserID)
+		require.Equal(t, "eval-session-1", file.Scope.SessionID)
+	}
+
+	limited, err := listUploadsForScope(store, scope, 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+}
+
+func TestListUploadsForScopeWithoutChannelPropagatesListAllError(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	store, err := uploads.NewStore("/dev/null")
+	require.NoError(t, err)
+
+	_, err = listUploadsForScope(
+		store,
+		uploads.Scope{UserID: "u1", SessionID: "eval-session-1"},
+		0,
+	)
+	require.Error(t, err)
 }
 
 func TestUploadEnvFromContext_RewritesGeneratedUploadNames(t *testing.T) {


### PR DESCRIPTION
## Summary
- add bounded host exec runtime waits so long-running commands cannot hold an agent turn indefinitely
- clamp background session polling waits and kill timed-out process groups
- preserve admin/eval upload environment needed by spawned host commands
- extend host exec output redaction so env names containing `KEY` or `CREDENTIAL` are redacted consistently with the documented policy
- add regression coverage for timeout cleanup, wait clamping, upload env fallback, and sensitive output redaction

## Why
GAIA-style agent runs can invoke command-line tools repeatedly and sometimes start long-running subprocesses. The host exec tool should bound those waits and clean up child process groups so one stuck command does not consume the whole benchmark run.

Benchmark traces also store tool outputs. The redaction policy already covered token/secret/password/API-key style names, but missed generic `KEY` and `CREDENTIAL` env names despite the runtime documentation saying those are treated as sensitive. This patch makes the implementation match that policy.

## Validation
- cd openclaw && go test ./app -count=1
- cd openclaw && go test ./internal/octool -coverprofile=/tmp/pr2066-octool.cover -covermode=atomic
- cd openclaw && go test ./cmd/openclaw -count=1