### PR TITLE
model/openai: use thinking object for Hunyuan

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -79,6 +79,8 @@ const (
 // thinkingValueConvertor converts ThinkingEnabled bool to the variant-specific value.
 type thinkingValueConvertor func(enabled bool) any
 
+const thinkingKey = "thinking"
+
 // defaultThinkingValueConvertor returns the bool value as-is.
 var defaultThinkingValueConvertor = func(enabled bool) any {
 	return enabled
@@ -165,7 +167,7 @@ var variantConfigs = map[Variant]variantConfig{
 		defaultBaseURL:            defaultDeepSeekBaseURL,
 		// DeepSeek v3.2+ (incl. v4-pro / v4-flash) uses
 		// {"thinking": {"type": "enabled"/"disabled"}} format.
-		thinkingEnabledKey:              "thinking",
+		thinkingEnabledKey:              thinkingKey,
 		thinkingValueConvertor:          thinkingTypeValueConvertor,
 		defaultReasoningContentBackfill: true,
 	},
@@ -217,7 +219,7 @@ var variantConfigs = map[Variant]variantConfig{
 		},
 		// TokenHub Hunyuan thinking models use
 		// {"thinking": {"type": "enabled"/"disabled"}} format.
-		thinkingEnabledKey:     "thinking",
+		thinkingEnabledKey:     thinkingKey,
 		thinkingValueConvertor: thinkingTypeValueConvertor,
 	},
 	VariantQwen: {
@@ -238,7 +240,7 @@ var variantConfigs = map[Variant]variantConfig{
 		fileDeletionMethod:                http.MethodDelete,
 		skipFileTypeInContent:             false,
 		fileDeletionBodyConvertor:         defaultFileDeletionBodyConvertor,
-		thinkingEnabledKey:                "thinking",
+		thinkingEnabledKey:                thinkingKey,
 		thinkingValueConvertor:            thinkingTypeValueConvertor,
 		reasoningContentAsContentFallback: true,
 	},

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -85,7 +85,7 @@ var defaultThinkingValueConvertor = func(enabled bool) any {
 }
 
 // thinkingTypeValueConvertor converts to the nested thinking-toggle format
-// used by providers such as DeepSeek v3.2+ and GLM.
+// used by providers such as DeepSeek v3.2+, Hunyuan, and GLM.
 var thinkingTypeValueConvertor = func(enabled bool) any {
 	const (
 		thinkingTypeEnabled  = "enabled"
@@ -215,8 +215,10 @@ var variantConfigs = map[Variant]variantConfig{
 			r.ContentLength = int64(body.Len())
 			return r, nil
 		},
-		thinkingEnabledKey:     model.ThinkingEnabledKey,
-		thinkingValueConvertor: defaultThinkingValueConvertor,
+		// TokenHub Hunyuan thinking models use
+		// {"thinking": {"type": "enabled"/"disabled"}} format.
+		thinkingEnabledKey:     "thinking",
+		thinkingValueConvertor: thinkingTypeValueConvertor,
 	},
 	VariantQwen: {
 		fileUploadPath:            "/openapi/v1/files",

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -3622,7 +3622,7 @@ func TestModel_GenerateContent_GLMThinkingPayload(t *testing.T) {
 				require.Nil(t, resp.Error)
 			}
 
-			thinking, ok := captured["thinking"].(map[string]any)
+			thinking, ok := captured[thinkingKey].(map[string]any)
 			require.True(t, ok)
 			require.Equal(t, tt.want, thinking["type"])
 			require.NotContains(t, captured, model.ThinkingEnabledKey)
@@ -3697,7 +3697,7 @@ func TestModel_GenerateContent_HunyuanThinkingPayload(t *testing.T) {
 				require.Nil(t, resp.Error)
 			}
 
-			thinking, ok := captured["thinking"].(map[string]any)
+			thinking, ok := captured[thinkingKey].(map[string]any)
 			require.True(t, ok)
 			require.Equal(t, tt.want, thinking["type"])
 			require.NotContains(t, captured, model.ThinkingEnabledKey)
@@ -7260,7 +7260,7 @@ func TestModel_buildChatRequest(t *testing.T) {
 				},
 			},
 			want1: []openaiopt.RequestOption{
-				openaiopt.WithJSONSet("thinking", map[string]string{"type": "enabled"}),
+				openaiopt.WithJSONSet(thinkingKey, map[string]string{"type": "enabled"}),
 			},
 		},
 		{
@@ -7428,14 +7428,14 @@ func TestBuildThinkingOption(t *testing.T) {
 			name:            "DeepSeek variant with thinking enabled",
 			variant:         VariantDeepSeek,
 			thinkingEnabled: &trueVal,
-			wantKeys:        []string{"thinking"},
+			wantKeys:        []string{thinkingKey},
 			wantValues:      []any{map[string]string{"type": "enabled"}},
 		},
 		{
 			name:            "DeepSeek variant with thinking disabled",
 			variant:         VariantDeepSeek,
 			thinkingEnabled: &falseVal,
-			wantKeys:        []string{"thinking"},
+			wantKeys:        []string{thinkingKey},
 			wantValues:      []any{map[string]string{"type": "disabled"}},
 		},
 		{
@@ -7443,21 +7443,21 @@ func TestBuildThinkingOption(t *testing.T) {
 			variant:         VariantDeepSeek,
 			thinkingEnabled: &trueVal,
 			thinkingTokens:  &thinkingTokens,
-			wantKeys:        []string{model.ThinkingTokensKey, "thinking"},
+			wantKeys:        []string{model.ThinkingTokensKey, thinkingKey},
 			wantValues:      []any{1024, map[string]string{"type": "enabled"}},
 		},
 		{
 			name:            "GLM variant with thinking enabled",
 			variant:         VariantGLM,
 			thinkingEnabled: &trueVal,
-			wantKeys:        []string{"thinking"},
+			wantKeys:        []string{thinkingKey},
 			wantValues:      []any{map[string]string{"type": "enabled"}},
 		},
 		{
 			name:            "Hunyuan variant with thinking enabled",
 			variant:         VariantHunyuan,
 			thinkingEnabled: &trueVal,
-			wantKeys:        []string{"thinking"},
+			wantKeys:        []string{thinkingKey},
 			wantValues:      []any{map[string]string{"type": "enabled"}},
 		},
 		{

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -3630,6 +3630,81 @@ func TestModel_GenerateContent_GLMThinkingPayload(t *testing.T) {
 	}
 }
 
+func TestModel_GenerateContent_HunyuanThinkingPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    string
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+			want:    "enabled",
+		},
+		{
+			name:    "disabled",
+			enabled: false,
+			want:    "disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured map[string]any
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprint(w, `{
+						"id": "test",
+						"object": "chat.completion",
+						"created": 1699200000,
+						"model": "hy3-preview",
+						"choices": [{
+							"index": 0,
+							"message": {
+								"role": "assistant",
+								"content": "ok"
+							},
+							"finish_reason": "stop"
+						}]
+					}`)
+				},
+			))
+			defer server.Close()
+
+			m := New(
+				"hy3-preview",
+				WithVariant(VariantHunyuan),
+				WithBaseURL(server.URL),
+				WithAPIKey("test-key"),
+			)
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					ThinkingEnabled: &tt.enabled,
+				},
+			}
+			ch, err := m.GenerateContent(context.Background(), req)
+			require.NoError(t, err)
+			for resp := range ch {
+				require.Nil(t, resp.Error)
+			}
+
+			thinking, ok := captured["thinking"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.want, thinking["type"])
+			require.NotContains(t, captured, model.ThinkingEnabledKey)
+		})
+	}
+}
+
 // TestModel_GenerateContent_NonStreaming_ToolCallNoID_Synthesized verifies that
 // when the provider omits tool_call.id in a non-streaming response, we synthesize
 // a stable ID (auto_call_<index>). This covers the non-streaming code path in
@@ -7374,6 +7449,13 @@ func TestBuildThinkingOption(t *testing.T) {
 		{
 			name:            "GLM variant with thinking enabled",
 			variant:         VariantGLM,
+			thinkingEnabled: &trueVal,
+			wantKeys:        []string{"thinking"},
+			wantValues:      []any{map[string]string{"type": "enabled"}},
+		},
+		{
+			name:            "Hunyuan variant with thinking enabled",
+			variant:         VariantHunyuan,
 			thinkingEnabled: &trueVal,
 			wantKeys:        []string{"thinking"},
 			wantValues:      []any{map[string]string{"type": "enabled"}},


### PR DESCRIPTION
## Summary

- Update the OpenAI-compatible Hunyuan variant to serialize `ThinkingEnabled` as `thinking: {"type":"enabled"|"disabled"}`.
- Keep `reasoning_effort` on the existing generic Chat Completions path; this change does not conflate effort with the thinking toggle.
- Add request-payload coverage for Hunyuan enabled and disabled thinking modes.

## Root Cause

TokenHub Hunyuan thinking models expect the nested `thinking.type` request format, but the Hunyuan variant was still using the generic `thinking_enabled` boolean key. The server could therefore ignore the intended thinking toggle.

## Validation

- `go test ./model/openai -run 'TestModel_GenerateContent_HunyuanThinkingPayload|TestBuildThinkingOption' -count=1`
- `go test ./model/openai -count=1`
- `go test ./... -count=1` was also run, but failed in unrelated existing paths: `tool/hostexec` Darwin build failure around `SysProcAttr.Pdeathsig`, `runner` real LLM test returned 403, and `tool/duckduckgo` failed to bind its Unix socket in this environment.
