### PR TITLE
tool/duckduckgo: return blocker for SERP challenges

### DIFF
--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -348,6 +349,88 @@ func TestDDGTool_SERPFallbackOnChallenge(t *testing.T) {
 	require.Contains(t, result.Summary, "fallback from html")
 }
 
+func TestDDGTool_SERPBothBackendsChallengeReturnsBlocker(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+			switch r.URL.Path {
+			case "/html/", "/lite/":
+				_, _ = w.Write([]byte(`
+<html><body>
+  <div class="anomaly-modal__title">
+    Unfortunately, bots use DuckDuckGo too.
+  </div>
+</body></html>`))
+			default:
+				t.Fatalf("unexpected path %s", r.URL.Path)
+			}
+		},
+	))
+	defer server.Close()
+
+	ddgTool := &ddgTool{
+		httpClient: server.Client(),
+		baseURL:    server.URL + "/html/",
+		backend:    backendHTML,
+		userAgent:  "test-agent/1.0",
+	}
+	result, err := ddgTool.search(
+		context.Background(),
+		searchRequest{Query: "GAIA benchmark"},
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Results)
+	require.Contains(t, result.Summary, "html and lite")
+	require.Contains(t, result.Summary, "anti-bot challenge")
+	require.Contains(t, result.Summary, "direct URLs")
+}
+
+func TestDDGTool_SERPTransportAndChallengeReturnsBlocker(t *testing.T) {
+	t.Parallel()
+
+	searchTool := &ddgTool{
+		httpClient: &http.Client{Transport: roundTripFunc(
+			func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+				switch r.URL.Path {
+				case "/html/":
+					return nil, errors.New(
+						"server gave HTTP response to HTTPS client",
+					)
+				case "/lite/":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`
+<html><body>
+  <div class="anomaly-modal__title">
+    Unfortunately, bots use DuckDuckGo too.
+  </div>
+</body></html>`)),
+						Header: make(http.Header),
+					}, nil
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+					return nil, nil
+				}
+			},
+		)},
+		baseURL:   "https://example.com/html/",
+		backend:   backendHTML,
+		userAgent: "test-agent/1.0",
+	}
+	result, err := searchTool.search(
+		context.Background(),
+		searchRequest{Query: "GAIA benchmark"},
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Results)
+	require.Contains(t, result.Summary, "both unavailable")
+	require.Contains(t, result.Summary, "transport errors")
+	require.Contains(t, result.Summary, "anti-bot challenge")
+}
+
 func TestDDGTool_SERPHTTPFallbackForPlainHTTPOnHTTPS(t *testing.T) {
 	t.Parallel()
 
@@ -547,8 +630,8 @@ func TestDDGTool_SERPFallbackFailureAddsContext(t *testing.T) {
   </div>
 </body></html>`))
 			case "/lite/":
-				w.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = w.Write([]byte("temporarily unavailable"))
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("unexpected upstream failure"))
 			default:
 				t.Fatalf("unexpected path %s", r.URL.Path)
 			}

--- a/tool/duckduckgo/serp.go
+++ b/tool/duckduckgo/serp.go
@@ -12,6 +12,7 @@ package duckduckgo
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +23,10 @@ import (
 )
 
 const maxSERPBodyBytes = 512 * 1024
+
+var errSERPChallenge = errors.New(
+	"duckduckgo returned an anti-bot challenge page",
+)
 
 func (t *ddgTool) searchSERPWithFallback(
 	ctx context.Context,
@@ -72,6 +77,17 @@ func (t *ddgTool) searchSERPWithFallbackForBackend(
 			)
 		}
 		return fallback, nil
+	}
+	if isSERPRouteBlocker(err, fallbackErr) {
+		return searchResponse{
+			Query:   req.Query,
+			Results: []resultItem{},
+			Summary: "DuckDuckGo html and lite search pages are both " +
+				"unavailable for this query due to transport errors " +
+				"or anti-bot challenge pages; use direct URLs with " +
+				"web_fetch/browser or another configured search " +
+				"provider instead of immediately retrying DuckDuckGo",
+		}, nil
 	}
 	result.Summary = fmt.Sprintf(
 		"%s; fallback %s failed: %v",
@@ -180,15 +196,13 @@ func (t *ddgTool) searchSERP(
 	}
 	if isDuckDuckGoChallenge(body) {
 		return searchResponse{
-				Query:   req.Query,
-				Results: []resultItem{},
-				Summary: "DuckDuckGo returned an anti-bot challenge page; " +
-					"use direct URLs with web_fetch/browser or another " +
-					"configured search provider instead of immediately " +
-					"retrying the same query",
-			}, fmt.Errorf(
-				"duckduckgo returned an anti-bot challenge page",
-			)
+			Query:   req.Query,
+			Results: []resultItem{},
+			Summary: "DuckDuckGo returned an anti-bot challenge page; " +
+				"use direct URLs with web_fetch/browser or another " +
+				"configured search provider instead of immediately " +
+				"retrying the same query",
+		}, errSERPChallenge
 	}
 
 	results := parseSERPResults(body)
@@ -203,6 +217,29 @@ func (t *ddgTool) searchSERP(
 		Results: results,
 		Summary: summary,
 	}, nil
+}
+
+func isSERPChallengeError(err error) bool {
+	return errors.Is(err, errSERPChallenge)
+}
+
+func isSERPRouteBlocker(err error, fallbackErr error) bool {
+	return isSERPUnavailableError(err) &&
+		isSERPUnavailableError(fallbackErr) &&
+		(isSERPChallengeError(err) || isSERPChallengeError(fallbackErr))
+}
+
+func isSERPUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isSERPChallengeError(err) || shouldRetrySERPWithHTTP(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "search returned status 429") ||
+		strings.Contains(msg, "search returned status 502") ||
+		strings.Contains(msg, "search returned status 503")
 }
 
 func fallbackSERPBackend(backend string) string {


### PR DESCRIPTION
## Summary
- return a structured empty-result blocker when both DuckDuckGo html and lite SERP endpoints return anti-bot challenge pages
- keep the existing fallback behavior when either backend succeeds, and preserve hard errors for non-challenge fallback failures
- add regression coverage for the dual-challenge path

## Why
The SERP backends are equivalent search transports. When both are blocked by an anti-bot challenge, surfacing the condition as a tool execution error encourages agents to retry the same unavailable route. A structured blocker lets callers pivot to direct URLs, web fetching, browser inspection, or another configured provider.

## Validation
- go test ./tool/duckduckgo -count=1
