### PR TITLE
openclaw/browser: harden schema and target ids

### DIFF
--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -2200,8 +2200,14 @@ func normalizeActRequest(in input) actRequest {
 		if strings.TrimSpace(req.StartTarget) == "" {
 			req.StartTarget = in.StartTarget
 		}
+		if strings.TrimSpace(req.StartRef) == "" {
+			req.StartRef = in.StartRef
+		}
 		if strings.TrimSpace(req.EndTarget) == "" {
 			req.EndTarget = in.EndTarget
+		}
+		if strings.TrimSpace(req.EndRef) == "" {
+			req.EndRef = in.EndRef
 		}
 		if strings.TrimSpace(req.URL) == "" {
 			req.URL = browserURL(in.URL, in.TargetURL)

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -220,6 +220,7 @@ type actRequest struct {
 type input struct {
 	Action         string            `json:"action"`
 	Target         string            `json:"target,omitempty"`
+	ActTarget      string            `json:"-"`
 	Node           string            `json:"node,omitempty"`
 	Profile        string            `json:"profile,omitempty"`
 	TargetURL      string            `json:"targetUrl,omitempty"`
@@ -279,7 +280,9 @@ type input struct {
 	Slowly         *bool             `json:"slowly,omitempty"`
 	Key            string            `json:"key,omitempty"`
 	DelayMs        *int              `json:"delayMs,omitempty"`
+	StartTarget    string            `json:"startTarget,omitempty"`
 	StartRef       string            `json:"startRef,omitempty"`
+	EndTarget      string            `json:"endTarget,omitempty"`
 	EndRef         string            `json:"endRef,omitempty"`
 	Values         []string          `json:"values,omitempty"`
 	Fields         []map[string]any  `json:"fields,omitempty"`
@@ -470,6 +473,7 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 		in = normalizeWaitActionInput(in)
 		actionKey = strings.ToLower(actionAct)
 	}
+	in = normalizeBrowserActionInput(in, actionKey)
 	if err := validateTargetSelection(in); err != nil {
 		return nil, err
 	}
@@ -712,13 +716,7 @@ func browserSchema(evaluateEnabled bool, driverType string) *tool.Schema {
 		actionDescription += " evaluate is not available."
 	}
 	fnDescription := evaluateFunctionDescription(evaluateEnabled)
-	actKindDescription := "Browser act kind. Supported kinds include " +
-		"click, type, press/key, hover, scroll, scrollIntoView, " +
-		"drag, select, fill, resize, wait, navigate, evaluate, " +
-		"and close. Use press/key with key=PageDown, End, or " +
-		"Enter for keyboard input. Use scroll with direction, " +
-		"deltaX, deltaY, or amount for page scrolling; use " +
-		"scrollIntoView with ref for browser-server element scrolling."
+	actKindDescription := browserActKindDescription(evaluateEnabled)
 	waitDescription := "Wait selector. Supported by the browser-server " +
 		"driver; Playwright MCP wait supports timeMs, text, and " +
 		"textGone."
@@ -874,6 +872,20 @@ func evaluateFunctionDescription(evaluateEnabled bool) string {
 	return "Evaluate function; evaluate is not available."
 }
 
+func browserActKindDescription(evaluateEnabled bool) string {
+	kinds := "click, type, press/key, hover, scroll, scrollIntoView, " +
+		"drag, select, fill, resize, wait, navigate"
+	if evaluateEnabled {
+		kinds += ", evaluate"
+	}
+	kinds += ", and close"
+	return "Browser act kind. Supported kinds include " + kinds +
+		". Use press/key with key=PageDown, End, or Enter for " +
+		"keyboard input. Use scroll with direction, deltaX, deltaY, " +
+		"or amount for page scrolling; use scrollIntoView with ref " +
+		"for browser-server element scrolling."
+}
+
 func stringSchema(desc string) *tool.Schema {
 	return &tool.Schema{Type: "string", Description: desc}
 }
@@ -896,10 +908,7 @@ func stringArraySchema(desc string) *tool.Schema {
 
 func validateTargetSelection(in input) error {
 	target := strings.ToLower(strings.TrimSpace(in.Target))
-	switch target {
-	case "", targetHost:
-	case targetSandbox, targetNode:
-	default:
+	if !isBrowserRuntimeTarget(target) {
 		return fmt.Errorf("unknown browser target %q", in.Target)
 	}
 
@@ -911,13 +920,32 @@ func validateTargetSelection(in input) error {
 	return nil
 }
 
+func normalizeBrowserActionInput(in input, actionKey string) input {
+	if actionKey != strings.ToLower(actionAct) {
+		return in
+	}
+	target := strings.TrimSpace(in.Target)
+	if target == "" || isBrowserRuntimeTarget(target) {
+		return in
+	}
+	in.ActTarget = target
+	in.Target = ""
+	return in
+}
+
+func isBrowserRuntimeTarget(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", targetHost, targetSandbox, targetNode:
+		return true
+	default:
+		return false
+	}
+}
+
 func (t *Tool) resolveDriver(
 	in input,
 ) (string, driver, error) {
-	profile := strings.TrimSpace(in.Profile)
-	if profile == "" {
-		profile = t.defaultProfile
-	}
+	profile := t.normalizeProfile(in.Profile)
 
 	targetName := strings.ToLower(strings.TrimSpace(in.Target))
 	switch targetName {
@@ -975,6 +1003,32 @@ func (t *Tool) resolveDriver(
 		)
 	}
 	return profile, drv, nil
+}
+
+func (t *Tool) normalizeProfile(raw string) string {
+	profile := strings.TrimSpace(raw)
+	if profile == "" {
+		return t.defaultProfile
+	}
+	if _, ok := t.profiles[profile]; ok {
+		return profile
+	}
+	if _, ok := t.drivers[profile]; ok {
+		return profile
+	}
+	if isDefaultProfileAlias(profile) {
+		return t.defaultProfile
+	}
+	return profile
+}
+
+func isDefaultProfileAlias(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "default", "current", "active", "browser", "chrome", "chromium":
+		return true
+	default:
+		return false
+	}
 }
 
 func (t *Tool) serverDriverForTarget(
@@ -1241,15 +1295,21 @@ func (t *Tool) handleFocus(
 	drv driver,
 	in input,
 ) (Result, error) {
-	index, err := parseTargetID(in.TargetID)
-	if err != nil {
-		return Result{}, err
+	targetID := strings.TrimSpace(in.TargetID)
+	if targetID == "" {
+		return Result{}, fmt.Errorf("targetId is empty")
 	}
-	if _, err := drv.Call(ctx, mcpToolTabs, map[string]any{
-		"action": tabActionSelect,
-		"index":  index,
-	}); err != nil {
-		return Result{}, err
+	if !isDefaultTargetID(targetID) {
+		index, err := parseTargetID(targetID)
+		if err != nil {
+			return Result{}, err
+		}
+		if _, err := drv.Call(ctx, mcpToolTabs, map[string]any{
+			"action": tabActionSelect,
+			"index":  index,
+		}); err != nil {
+			return Result{}, err
+		}
 	}
 	result, err := t.handleTabs(
 		ctx,
@@ -1273,8 +1333,8 @@ func (t *Tool) handleClose(
 	in input,
 ) (Result, error) {
 	args := map[string]any{"action": tabActionClose}
-	if strings.TrimSpace(in.TargetID) != "" {
-		index, err := parseTargetID(in.TargetID)
+	if targetID := optionalTargetID(in.TargetID); targetID != "" {
+		index, err := parseTargetID(targetID)
 		if err != nil {
 			return Result{}, err
 		}
@@ -2131,8 +2191,17 @@ func normalizeActRequest(in input) actRequest {
 		if strings.TrimSpace(req.TargetID) == "" {
 			req.TargetID = in.TargetID
 		}
+		if strings.TrimSpace(req.Target) == "" {
+			req.Target = in.ActTarget
+		}
 		if strings.TrimSpace(req.Ref) == "" {
 			req.Ref = in.Ref
+		}
+		if strings.TrimSpace(req.StartTarget) == "" {
+			req.StartTarget = in.StartTarget
+		}
+		if strings.TrimSpace(req.EndTarget) == "" {
+			req.EndTarget = in.EndTarget
 		}
 		if strings.TrimSpace(req.URL) == "" {
 			req.URL = browserURL(in.URL, in.TargetURL)
@@ -2164,6 +2233,7 @@ func normalizeActRequest(in input) actRequest {
 			LoadState: in.LoadState,
 		}),
 		TargetID:    in.TargetID,
+		Target:      in.ActTarget,
 		Ref:         in.Ref,
 		DoubleClick: in.DoubleClick,
 		Button:      in.Button,
@@ -2173,7 +2243,9 @@ func normalizeActRequest(in input) actRequest {
 		Slowly:      in.Slowly,
 		Key:         in.Key,
 		DelayMs:     in.DelayMs,
+		StartTarget: in.StartTarget,
 		StartRef:    in.StartRef,
+		EndTarget:   in.EndTarget,
 		EndRef:      in.EndRef,
 		Values:      in.Values,
 		Fields:      in.Fields,
@@ -2734,7 +2806,7 @@ func selectTarget(
 	drv driver,
 	targetID string,
 ) error {
-	trimmed := strings.TrimSpace(targetID)
+	trimmed := optionalTargetID(targetID)
 	if trimmed == "" {
 		return nil
 	}
@@ -2748,6 +2820,25 @@ func selectTarget(
 		"index":  index,
 	})
 	return err
+}
+
+func optionalTargetID(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if isDefaultTargetID(trimmed) {
+		return ""
+	}
+	return trimmed
+}
+
+func isDefaultTargetID(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "default", "current", "active",
+		"current-tab", "active-tab",
+		"current_tab", "active_tab":
+		return true
+	default:
+		return false
+	}
 }
 
 func boolValue(v *bool) bool {

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -838,6 +838,12 @@ func TestNewTool_DeclarationExposesSchema(t *testing.T) {
 			Description,
 		"scroll",
 	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["kind"].
+			Description,
+		"evaluate",
+	)
 	require.Contains(
 		t,
 		decl.InputSchema.Properties["request"].Properties["selector"].
@@ -918,6 +924,12 @@ func TestNewTool_DeclarationReflectsEvaluateEnabled(t *testing.T) {
 		decl.InputSchema.Properties["request"].Properties["fn"].
 			Description,
 		"evaluate is not available",
+	)
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["request"].Properties["kind"].
+			Description,
+		"evaluate",
 	)
 }
 
@@ -1088,6 +1100,32 @@ func TestToolCall_FocusRefreshesTabs(t *testing.T) {
 	require.Equal(t, mcpToolTabs, drv.calls[1].Tool)
 }
 
+func TestToolCall_FocusDefaultTargetRefreshesTabs(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolTabs: tabsPayload(),
+		},
+	}
+	tool := newTestTool(drv)
+
+	raw, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":   actionFocus,
+			"targetId": "default",
+		}),
+	)
+	require.NoError(t, err)
+
+	got := raw.(Result)
+	require.Equal(t, actionFocus, got.Action)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolTabs, drv.calls[0].Tool)
+	require.Equal(t, tabActionList, drv.calls[0].Args["action"])
+}
+
 func TestToolCall_CloseRefreshesTabs(t *testing.T) {
 	t.Parallel()
 
@@ -1141,6 +1179,33 @@ func TestToolCall_NavigateSelectsTarget(t *testing.T) {
 	require.Len(t, drv.calls, 2)
 	require.Equal(t, mcpToolTabs, drv.calls[0].Tool)
 	require.Equal(t, mcpToolNavigate, drv.calls[1].Tool)
+}
+
+func TestToolCall_NavigateDefaultTargetDoesNotSelect(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolNavigate: textPayload("navigated"),
+		},
+	}
+	tool := newTestTool(drv)
+
+	raw, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":   actionNavigate,
+			"targetId": "default",
+			"url":      "https://example.com",
+		}),
+	)
+	require.NoError(t, err)
+
+	got := raw.(Result)
+	require.Equal(t, actionNavigate, got.Action)
+	require.Contains(t, got.Text, "navigated")
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolNavigate, drv.calls[0].Tool)
 }
 
 func TestToolCall_NavigateAcceptsTargetURL(t *testing.T) {
@@ -1677,6 +1742,70 @@ func TestToolCall_ActClickAcceptsElementTarget(t *testing.T) {
 	)
 	require.Equal(t, "left", drv.calls[0].Args["button"])
 	require.Equal(t, []string{"Shift"}, drv.calls[0].Args["modifiers"])
+}
+
+func TestToolCall_ActClickAcceptsTopLevelElementTarget(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{}
+	tool := newTestTool(drv)
+
+	_, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":  actionAct,
+			"kind":    actClick,
+			"target":  "article",
+			"element": "article list",
+		}),
+	)
+	require.NoError(t, err)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolClick, drv.calls[0].Tool)
+	require.Equal(t, "article", drv.calls[0].Args["target"])
+	require.Equal(t, "element article", drv.calls[0].Args["element"])
+}
+
+func TestToolCall_ProfileAliasUsesDefaultProfile(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{}
+	tool := newTestTool(drv)
+
+	raw, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":  actionSnapshot,
+			"profile": "chrome",
+		}),
+	)
+	require.NoError(t, err)
+	got := raw.(Result)
+	require.Equal(t, defaultProfileName, got.Profile)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolSnapshot, drv.calls[0].Tool)
+}
+
+func TestToolCall_ActDragAcceptsTopLevelElementTargets(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{}
+	tool := newTestTool(drv)
+
+	_, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":      actionAct,
+			"kind":        actDrag,
+			"startTarget": "source-card",
+			"endTarget":   "destination-list",
+		}),
+	)
+	require.NoError(t, err)
+	require.Len(t, drv.calls, 1)
+	require.Equal(t, mcpToolDrag, drv.calls[0].Tool)
+	require.Equal(t, "source-card", drv.calls[0].Args["startTarget"])
+	require.Equal(t, "destination-list", drv.calls[0].Args["endTarget"])
 }
 
 func TestToolCall_ActPassesTimeoutToBrowserServer(t *testing.T) {
@@ -3512,6 +3641,15 @@ func TestToolCall_RejectsInvalidInputs(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported browser action")
+
+	_, err = tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action": actionFocus,
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "targetId is empty")
 
 	_, err = tool.Call(
 		context.Background(),

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -1808,6 +1808,21 @@ func TestToolCall_ActDragAcceptsTopLevelElementTargets(t *testing.T) {
 	require.Equal(t, "destination-list", drv.calls[0].Args["endTarget"])
 }
 
+func TestNormalizeActRequestBackfillsNestedDragRefs(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeActRequest(input{
+		StartRef: "source-ref",
+		EndRef:   "destination-ref",
+		Request: &actRequest{
+			Kind: actDrag,
+		},
+	})
+
+	require.Equal(t, "source-ref", got.StartRef)
+	require.Equal(t, "destination-ref", got.EndRef)
+}
+
 func TestToolCall_ActPassesTimeoutToBrowserServer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- omit the `evaluate` act kind from the browser schema when browser evaluation is disabled
- keep the existing explicit `evaluate is not available` guidance for action and function fields
- accept common `current` / `default` / `active` targetId aliases as the current browser tab for navigation, close, and focus flows
- treat top-level `target` on `act` calls as an element target unless it is an explicit browser runtime target (`host`, `sandbox`, or `node`)
- accept common default profile aliases such as `chrome` / `chromium` / `default` when no such profile is configured
- add regression coverage for disabled/enabled evaluate schema descriptions, targetId aliases, act target normalization, profile aliases, and top-level drag targets

## Why
When evaluation is disabled, the browser tool still described `evaluate` as a supported act kind. That can lead callers to choose a browser request shape that is guaranteed to fail at runtime.

Long agent runs also commonly refer to the active browser tab with generic identifiers such as `default` or `current`, and may call the default browser profile `chrome` or `chromium`. Normalizing these common aliases avoids unnecessary hard errors while preserving strict validation for missing `focus` target ids, configured runtime targets, and truly unknown profile names.

The browser schema also exposes `target` as an element field for `act`, but the implementation validated it as a browser runtime target before normalizing the act request. This made valid click-like calls fail before reaching the browser driver.

## Validation
- cd openclaw && go test ./internal/browser -count=1