### PR TITLE
{runner/trpcagent, server/trpcagent}: add integration hooks

### DIFF
--- a/runner/trpcagent/http_client.go
+++ b/runner/trpcagent/http_client.go
@@ -1,0 +1,53 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trpcagent
+
+import "net/http"
+
+// HTTPClient is the interface for the HTTP client used by the runner.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// HTTPClientNewFunc is the function type for creating a new HTTP client.
+type HTTPClientNewFunc func(opts ...HTTPClientOption) HTTPClient
+
+// DefaultNewHTTPClient creates the default HTTP client used by the runner.
+var DefaultNewHTTPClient HTTPClientNewFunc = func(opts ...HTTPClientOption) HTTPClient {
+	options := &HTTPClientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	return &http.Client{
+		Transport: options.Transport,
+	}
+}
+
+// HTTPClientOption configures the HTTP client used by the runner.
+type HTTPClientOption func(*HTTPClientOptions)
+
+// WithHTTPClientName sets the logical HTTP client name.
+func WithHTTPClientName(name string) HTTPClientOption {
+	return func(options *HTTPClientOptions) {
+		options.Name = name
+	}
+}
+
+// WithHTTPClientTransport sets the HTTP transport.
+func WithHTTPClientTransport(transport http.RoundTripper) HTTPClientOption {
+	return func(options *HTTPClientOptions) {
+		options.Transport = transport
+	}
+}
+
+// HTTPClientOptions stores HTTP client construction options.
+type HTTPClientOptions struct {
+	Name      string
+	Transport http.RoundTripper
+}

--- a/runner/trpcagent/http_client_test.go
+++ b/runner/trpcagent/http_client_test.go
@@ -1,0 +1,118 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trpcagent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultNewHTTPClientWithOptions(t *testing.T) {
+	transport := &http.Transport{}
+	client := DefaultNewHTTPClient(
+		WithHTTPClientName("trpc-agent-client"),
+		WithHTTPClientTransport(transport),
+	)
+	require.IsType(t, &http.Client{}, client)
+	httpClient := client.(*http.Client)
+	assert.Same(t, transport, httpClient.Transport)
+}
+
+func TestWithHTTPClientOptionsUsesDefaultBuilder(t *testing.T) {
+	originalBuilder := DefaultNewHTTPClient
+	t.Cleanup(func() { DefaultNewHTTPClient = originalBuilder })
+	transport := &http.Transport{}
+	builtClient := &http.Client{}
+	var gotOptions HTTPClientOptions
+	DefaultNewHTTPClient = func(opts ...HTTPClientOption) HTTPClient {
+		for _, opt := range opts {
+			opt(&gotOptions)
+		}
+		return builtClient
+	}
+	options := newOptions(
+		WithHTTPClientOptions(
+			WithHTTPClientName("trpc-agent-client"),
+			WithHTTPClientTransport(transport),
+		),
+	)
+	require.Same(t, builtClient, options.httpClient)
+	assert.Equal(t, "trpc-agent-client", gotOptions.Name)
+	assert.Same(t, transport, gotOptions.Transport)
+}
+
+func TestNewUsesDefaultHTTPClientBuilder(t *testing.T) {
+	originalBuilder := DefaultNewHTTPClient
+	t.Cleanup(func() { DefaultNewHTTPClient = originalBuilder })
+	var gotOptions HTTPClientOptions
+	var gotRequest *http.Request
+	DefaultNewHTTPClient = func(opts ...HTTPClientOption) HTTPClient {
+		for _, opt := range opts {
+			opt(&gotOptions)
+		}
+		return &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			gotRequest = request
+			body, err := json.Marshal(structureResponse{Structure: testStructureSnapshot()})
+			require.NoError(t, err)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(string(body))),
+				Request:    request,
+			}, nil
+		})}
+	}
+	runner, err := New(
+		"sports-agent",
+		WithTarget("polaris://trpc.foo.bar"),
+		WithHTTPClientOptions(WithHTTPClientName("agent-http")),
+	)
+	require.NoError(t, err)
+	_, err = runner.Describe(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "agent-http", gotOptions.Name)
+	require.NotNil(t, gotRequest)
+	assert.Equal(t, "polaris", gotRequest.URL.Scheme)
+	assert.Equal(t, "/trpc-agent/v1/apps/sports-agent/structure", gotRequest.URL.Path)
+}
+
+func TestWithHTTPClientOverridesDefaultBuilder(t *testing.T) {
+	originalBuilder := DefaultNewHTTPClient
+	t.Cleanup(func() { DefaultNewHTTPClient = originalBuilder })
+	explicitClient := &http.Client{}
+	called := false
+	DefaultNewHTTPClient = func(opts ...HTTPClientOption) HTTPClient {
+		called = true
+		return &http.Client{}
+	}
+	options := newOptions(
+		WithHTTPClientOptions(WithHTTPClientName("unused")),
+		WithHTTPClient(explicitClient),
+	)
+	require.Same(t, explicitClient, options.httpClient)
+	assert.False(t, called)
+}
+
+func TestHTTPClientOptionMerge(t *testing.T) {
+	transport := &http.Transport{}
+	options := &HTTPClientOptions{}
+	WithHTTPClientName("first")(options)
+	WithHTTPClientName("second")(options)
+	WithHTTPClientTransport(transport)(options)
+	assert.Equal(t, "second", options.Name)
+	assert.Same(t, transport, options.Transport)
+}

--- a/runner/trpcagent/http_client_test.go
+++ b/runner/trpcagent/http_client_test.go
@@ -90,23 +90,6 @@ func TestNewUsesDefaultHTTPClientBuilder(t *testing.T) {
 	assert.Equal(t, "/trpc-agent/v1/apps/sports-agent/structure", gotRequest.URL.Path)
 }
 
-func TestWithHTTPClientOverridesDefaultBuilder(t *testing.T) {
-	originalBuilder := DefaultNewHTTPClient
-	t.Cleanup(func() { DefaultNewHTTPClient = originalBuilder })
-	explicitClient := &http.Client{}
-	called := false
-	DefaultNewHTTPClient = func(opts ...HTTPClientOption) HTTPClient {
-		called = true
-		return &http.Client{}
-	}
-	options := newOptions(
-		WithHTTPClientOptions(WithHTTPClientName("unused")),
-		WithHTTPClient(explicitClient),
-	)
-	require.Same(t, explicitClient, options.httpClient)
-	assert.False(t, called)
-}
-
 func TestHTTPClientOptionMerge(t *testing.T) {
 	transport := &http.Transport{}
 	options := &HTTPClientOptions{}

--- a/runner/trpcagent/options.go
+++ b/runner/trpcagent/options.go
@@ -35,14 +35,6 @@ func WithBasePath(basePath string) Option {
 	}
 }
 
-// WithHTTPClient sets the HTTP client used by the runner.
-// Custom transports may resolve non-http targets such as service discovery schemes.
-func WithHTTPClient(client *http.Client) Option {
-	return func(opts *options) {
-		opts.httpClient = client
-	}
-}
-
 // WithHTTPClientOptions sets options for the default HTTP client builder.
 func WithHTTPClientOptions(httpOpts ...HTTPClientOption) Option {
 	return func(opts *options) {

--- a/runner/trpcagent/options.go
+++ b/runner/trpcagent/options.go
@@ -14,10 +14,11 @@ import "net/http"
 type Option func(*options)
 
 type options struct {
-	target     string
-	basePath   string
-	httpClient *http.Client
-	headers    http.Header
+	target            string
+	basePath          string
+	httpClient        HTTPClient
+	httpClientOptions []HTTPClientOption
+	headers           http.Header
 }
 
 // WithTarget sets the tRPC-Agent API service target.
@@ -42,6 +43,13 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
+// WithHTTPClientOptions sets options for the default HTTP client builder.
+func WithHTTPClientOptions(httpOpts ...HTTPClientOption) Option {
+	return func(opts *options) {
+		opts.httpClientOptions = httpOpts
+	}
+}
+
 // WithHeader sets one HTTP header on every tRPC-Agent API request.
 func WithHeader(key string, value string) Option {
 	return func(opts *options) {
@@ -57,14 +65,16 @@ func WithHeader(key string, value string) Option {
 
 func newOptions(opts ...Option) options {
 	options := options{
-		basePath:   defaultBasePath,
-		headers:    make(http.Header),
-		httpClient: http.DefaultClient,
+		basePath: defaultBasePath,
+		headers:  make(http.Header),
 	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&options)
 		}
+	}
+	if options.httpClient == nil {
+		options.httpClient = DefaultNewHTTPClient(options.httpClientOptions...)
 	}
 	return options
 }

--- a/runner/trpcagent/runner.go
+++ b/runner/trpcagent/runner.go
@@ -40,7 +40,7 @@ type runner struct {
 	appName    string
 	target     string
 	basePath   string
-	httpClient *http.Client
+	httpClient HTTPClient
 	headers    http.Header
 }
 

--- a/runner/trpcagent/runner_test.go
+++ b/runner/trpcagent/runner_test.go
@@ -307,10 +307,14 @@ func TestRunReturnsHTTPStatusError(t *testing.T) {
 }
 
 func TestRunReturnsPostClientError(t *testing.T) {
-	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		return nil, errors.New("dial failed")
-	})}
-	runner, err := New("sports-agent", WithTarget("http://example.com"), WithHTTPClient(client))
+	})
+	runner, err := New(
+		"sports-agent",
+		WithTarget("http://example.com"),
+		WithHTTPClientOptions(WithHTTPClientTransport(transport)),
+	)
 	require.NoError(t, err)
 	events, err := runner.Run(
 		context.Background(),
@@ -617,10 +621,14 @@ func TestDescribeReturnsHTTPStatusError(t *testing.T) {
 }
 
 func TestDescribeReturnsClientError(t *testing.T) {
-	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		return nil, errors.New("dial failed")
-	})}
-	runner, err := New("sports-agent", WithTarget("http://example.com"), WithHTTPClient(client))
+	})
+	runner, err := New(
+		"sports-agent",
+		WithTarget("http://example.com"),
+		WithHTTPClientOptions(WithHTTPClientTransport(transport)),
+	)
 	require.NoError(t, err)
 	got, err := runner.Describe(context.Background())
 	require.Nil(t, got)
@@ -671,7 +679,7 @@ func TestDescribeRejectsEmptyStructure(t *testing.T) {
 
 func TestDescribeAllowsCustomTargetScheme(t *testing.T) {
 	var gotRequest *http.Request
-	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		gotRequest = request
 		body, err := json.Marshal(structureResponse{Structure: testStructureSnapshot()})
 		require.NoError(t, err)
@@ -682,8 +690,12 @@ func TestDescribeAllowsCustomTargetScheme(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(string(body))),
 			Request:    request,
 		}, nil
-	})}
-	runner, err := New("sports-agent", WithTarget("polaris://trpc.foo.bar"), WithHTTPClient(httpClient))
+	})
+	runner, err := New(
+		"sports-agent",
+		WithTarget("polaris://trpc.foo.bar"),
+		WithHTTPClientOptions(WithHTTPClientTransport(transport)),
+	)
 	require.NoError(t, err)
 	got, err := runner.Describe(context.Background())
 	require.NoError(t, err)
@@ -742,7 +754,7 @@ func TestCloseIsNoop(t *testing.T) {
 
 func TestRunAllowsCustomTargetScheme(t *testing.T) {
 	var gotRequest *http.Request
-	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		gotRequest = request
 		completion := event.NewResponseEvent("inv-1", "sports-agent", &model.Response{
 			Object: model.ObjectTypeRunnerCompletion,
@@ -764,8 +776,12 @@ func TestRunAllowsCustomTargetScheme(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(string(body))),
 			Request:    request,
 		}, nil
-	})}
-	runner, err := New("sports-agent", WithTarget("polaris://trpc.foo.bar"), WithHTTPClient(client))
+	})
+	runner, err := New(
+		"sports-agent",
+		WithTarget("polaris://trpc.foo.bar"),
+		WithHTTPClientOptions(WithHTTPClientTransport(transport)),
+	)
 	require.NoError(t, err)
 	events, err := runner.Run(
 		context.Background(),

--- a/server/trpcagent/server.go
+++ b/server/trpcagent/server.go
@@ -76,6 +76,11 @@ func (s *Server) Handler() http.Handler {
 	return s.handler
 }
 
+// BasePath returns the base path exposed by the tRPC-Agent API server.
+func (s *Server) BasePath() string {
+	return s.basePath
+}
+
 func (s *Server) setupHandler() error {
 	mux := http.NewServeMux()
 	if s.agent != nil {

--- a/server/trpcagent/server_test.go
+++ b/server/trpcagent/server_test.go
@@ -587,6 +587,7 @@ func TestServerOptionsApplyBasePathTimeoutAndCORS(t *testing.T) {
 		WithTimeout(time.Minute),
 	)
 	require.NoError(t, err)
+	assert.Equal(t, "/api/apps", srv.BasePath())
 	req := httptest.NewRequest(http.MethodGet, "/api/apps/sports-agent/structure", nil)
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)


### PR DESCRIPTION
Adds a configurable default HTTP client builder for the tRPC-Agent remote runner so downstream integrations can inject named clients or transports without replacing the runner API, and exposes the server base path for registration helpers that mount the API under tRPC-Go HTTP muxes.