### PR TITLE
model/internal/model: add MiniMax-M3 context window

### DIFF
--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -526,6 +526,7 @@ var ModelContextWindows = map[string]int{
 	"moonshot-v1-128k-vision-preview": 131072,
 
 	// MiniMax — https://platform.minimax.io/docs/guides/text-generation
+	"minimax-m3":             1000000,
 	"minimax-m2.7":           204800,
 	"minimax-m2.7-highspeed": 204800,
 	"minimax-m2.5":           204800,

--- a/model/internal/model/model_info_test.go
+++ b/model/internal/model/model_info_test.go
@@ -207,6 +207,11 @@ func TestResolveContextWindow(t *testing.T) {
 			expected:  128000,
 		},
 		{
+			name:      "exact match - MiniMax M3",
+			modelName: "minimax-m3",
+			expected:  1000000,
+		},
+		{
 			name:      "exact match - MiniMax M2.7",
 			modelName: "minimax-m2.7",
 			expected:  204800,


### PR DESCRIPTION
## Summary
Add `MiniMax-M3` to the known model context windows.

## Changes
- Add `MiniMax-m3` (1,000,000 tokens) to `ModelContextWindows` in `model/internal/model/model_info.go`, alongside the existing MiniMax M2.x entries
- Add an exact-match test case for `MiniMax-m3` in `model_info_test.go`

## Why
MiniMax-M3 is the new flagship model with a 1M-token context window. Without an entry it falls back to the default 128k window, so `ResolveContextWindow` under-reports the usable context for M3.

## Testing
- `go test ./model/internal/model/` passing