### PR TITLE
session/recall: accept current session aliases

### DIFF
--- a/internal/session/tool/recall/helpers_test.go
+++ b/internal/session/tool/recall/helpers_test.go
@@ -76,9 +76,18 @@ func TestInvocationHelpers(t *testing.T) {
 	sessionKey, err := currentSessionKey(inv, "")
 	require.NoError(t, err)
 	assert.Equal(t, "sess", sessionKey.SessionID)
+	sessionKey, err = currentSessionKey(inv, " current ")
+	require.NoError(t, err)
+	assert.Equal(t, "sess", sessionKey.SessionID)
+	sessionKey, err = currentSessionKey(inv, "active-session")
+	require.NoError(t, err)
+	assert.Equal(t, "sess", sessionKey.SessionID)
 	sessionKey, err = currentSessionKey(inv, "other")
 	require.NoError(t, err)
 	assert.Equal(t, "other", sessionKey.SessionID)
+	assert.True(t, isCurrentSessionAlias("current_session"))
+	assert.True(t, isCurrentSessionAlias("self"))
+	assert.False(t, isCurrentSessionAlias("other"))
 
 	_, err = currentUserKey(nil)
 	require.Error(t, err)
@@ -467,6 +476,62 @@ func TestLoadToolFallsBackToToolCallIDWhenEventIDIsStale(t *testing.T) {
 	assert.Equal(t, []string{"stale-event", "evt-tool-result"}, anchors)
 	require.Len(t, resp.Messages, 1)
 	assert.Equal(t, "lookup: fresh result", resp.Messages[0].Content)
+}
+
+func TestLoadToolCurrentSessionAliasFindsToolCallID(t *testing.T) {
+	sess := session.NewSession("app", "user", "sess")
+	sess.Events = []event.Event{
+		{
+			ID: "evt-tool-result",
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:     model.RoleTool,
+						ToolID:   "call-1",
+						ToolName: "lookup",
+						Content:  "fresh result",
+					},
+				}},
+			},
+		},
+	}
+
+	var windowKeys []string
+	svc := &mockSessionService{
+		Service: sessioninmemory.NewSessionService(),
+		windowFunc: func(
+			req session.EventWindowRequest,
+		) (*session.EventWindow, error) {
+			windowKeys = append(windowKeys, req.Key.SessionID)
+			return &session.EventWindow{
+				SessionKey:    req.Key,
+				AnchorEventID: req.AnchorEventID,
+				Entries: []session.EventWindowEntry{{
+					Event:     sess.Events[0],
+					CreatedAt: time.Date(2025, 4, 7, 11, 0, 0, 0, time.UTC),
+				}},
+			}, nil
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	args, err := json.Marshal(&LoadSessionRequest{
+		SessionID:  "current",
+		ToolCallID: "call-1",
+	})
+	require.NoError(t, err)
+	result, err := NewLoadTool().Call(ctx, args)
+	require.NoError(t, err)
+
+	resp, ok := result.(*LoadSessionResponse)
+	require.True(t, ok)
+	assert.Equal(t, "sess", resp.SessionID)
+	assert.Equal(t, "evt-tool-result", resp.EventID)
+	assert.Equal(t, []string{"sess"}, windowKeys)
 }
 
 func TestLoadToolKeepsStaleEventErrorWhenToolCallIDMissing(t *testing.T) {

--- a/internal/session/tool/recall/types.go
+++ b/internal/session/tool/recall/types.go
@@ -104,7 +104,7 @@ type SearchSessionResponse struct {
 
 // LoadSessionRequest is the input for session_load.
 type LoadSessionRequest struct {
-	SessionID string `json:"session_id,omitempty" jsonschema:"description=Target session ID. Defaults to the current session when omitted."`
+	SessionID string `json:"session_id,omitempty" jsonschema:"description=Target session ID. Defaults to the current session when omitted or set to current."`
 	EventID   string `json:"event_id,omitempty" jsonschema:"description=Anchor event ID to load around. Prefer this when available."`
 	// ToolCallID is a current-session fallback when event_id is unavailable.
 	ToolCallID string `json:"tool_call_id,omitempty" jsonschema:"description=Optional fallback tool call ID when event_id is unavailable."`
@@ -243,7 +243,7 @@ func currentSessionKey(
 		return session.Key{}, errSessionRequired
 	}
 	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
+	if sessionID == "" || isCurrentSessionAlias(sessionID) {
 		sessionID = inv.Session.ID
 	}
 	key := session.Key{
@@ -255,6 +255,21 @@ func currentSessionKey(
 		return session.Key{}, err
 	}
 	return key, nil
+}
+
+func isCurrentSessionAlias(sessionID string) bool {
+	switch strings.ToLower(strings.TrimSpace(sessionID)) {
+	case "current",
+		"current_session",
+		"current-session",
+		"active",
+		"active_session",
+		"active-session",
+		"self":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeScope(scope string) string {


### PR DESCRIPTION
## Summary

- Treat explicit current-session aliases as the active invocation session in `session_load`.
- Document that omitting `session_id` or setting it to `current` targets the current session.
- Add coverage for alias resolution through the actual `session_load` tool path.

## Why

Long-running agents sometimes emit `session_id: "current"` when asking to reload compacted current-session tool results. Previously that value was treated as a literal session ID, so `tool_call_id` fallback lookup could miss tool results that were still present in the active invocation session.

## Validation

- `go test ./internal/session/tool/recall -run 'TestInvocationHelpers|TestLoadTool(CurrentSessionAliasFindsToolCallID|FallsBackToToolCallIDWhenEventIDIsStale)' -count=1`
- `go test ./internal/session/tool/recall -count=1`
