### PR TITLE
openclaw/browser: guard repeated backend crashes

### DIFF
--- a/openclaw/internal/browser/crash_guard.go
+++ b/openclaw/internal/browser/crash_guard.go
@@ -1,0 +1,280 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package browser
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+const (
+	browserCrashGuardStateKey = "__openclaw_browser_crash_guard__"
+	browserCrashThreshold     = 2
+	stateDegraded             = "degraded"
+)
+
+var browserCrashGuardInitMu sync.Mutex
+
+type browserCrashGuard struct {
+	mu       sync.Mutex
+	profiles map[string]browserCrashState
+}
+
+type browserCrashState struct {
+	Consecutive int
+	Reason      string
+}
+
+type crashGuardedDriver struct {
+	inner   driver
+	profile string
+}
+
+func newCrashGuardedDriver(
+	ctx context.Context,
+	profile string,
+	drv driver,
+) driver {
+	if drv == nil {
+		return nil
+	}
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil {
+		return drv
+	}
+	return &crashGuardedDriver{
+		inner:   drv,
+		profile: profile,
+	}
+}
+
+func (d *crashGuardedDriver) Start(
+	ctx context.Context,
+) (driverStatus, error) {
+	return d.inner.Start(ctx)
+}
+
+func (d *crashGuardedDriver) Status(
+	ctx context.Context,
+) (driverStatus, error) {
+	return d.inner.Status(ctx)
+}
+
+func (d *crashGuardedDriver) Stop() error {
+	return d.inner.Stop()
+}
+
+func (d *crashGuardedDriver) Call(
+	ctx context.Context,
+	toolName string,
+	args map[string]any,
+) (any, error) {
+	if state, ok := browserCrashStateForContext(ctx, d.profile); ok &&
+		state.Consecutive >= browserCrashThreshold {
+		return browserCrashBlockedContent(d.profile, state.Reason), nil
+	}
+
+	raw, err := d.inner.Call(ctx, toolName, args)
+	if err != nil {
+		if ok, reason := detectBrowserBackendCrash(err.Error()); ok {
+			recordBrowserCrash(ctx, d.profile, reason)
+		}
+		return nil, err
+	}
+
+	text := extractText(raw)
+	if ok, reason := detectBrowserBackendCrash(text); ok {
+		recordBrowserCrash(ctx, d.profile, reason)
+		return raw, nil
+	}
+	resetBrowserCrash(ctx, d.profile)
+	return raw, nil
+}
+
+func browserCrashBlockedResult(
+	ctx context.Context,
+	action string,
+	profile string,
+	driverType string,
+	evaluateEnabled bool,
+) (Result, bool) {
+	if browserCrashBypassAction(action) {
+		return Result{}, false
+	}
+	state, ok := browserCrashStateForContext(ctx, profile)
+	if !ok || state.Consecutive < browserCrashThreshold {
+		return Result{}, false
+	}
+	result := newBaseResult(action, profile, driverType, evaluateEnabled)
+	result.State = stateDegraded
+	result.Warning = browserCrashBlockedMessage(profile, state.Reason)
+	result.Text = result.Warning
+	return result, true
+}
+
+func browserCrashBypassAction(action string) bool {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case strings.ToLower(actionStart),
+		strings.ToLower(actionStop),
+		strings.ToLower(actionStatus),
+		strings.ToLower(actionProfiles):
+		return true
+	default:
+		return false
+	}
+}
+
+func browserCrashStateForContext(
+	ctx context.Context,
+	profile string,
+) (browserCrashState, bool) {
+	guard := browserCrashGuardFromContext(ctx, false)
+	if guard == nil {
+		return browserCrashState{}, false
+	}
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+	state, ok := guard.profiles[normalizeBrowserCrashProfile(profile)]
+	return state, ok
+}
+
+func recordBrowserCrash(ctx context.Context, profile string, reason string) {
+	guard := browserCrashGuardFromContext(ctx, true)
+	if guard == nil {
+		return
+	}
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+	key := normalizeBrowserCrashProfile(profile)
+	state := guard.profiles[key]
+	state.Consecutive++
+	state.Reason = strings.TrimSpace(reason)
+	guard.profiles[key] = state
+}
+
+func resetBrowserCrash(ctx context.Context, profile string) {
+	guard := browserCrashGuardFromContext(ctx, false)
+	if guard == nil {
+		return
+	}
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+	delete(guard.profiles, normalizeBrowserCrashProfile(profile))
+}
+
+func browserCrashGuardFromContext(
+	ctx context.Context,
+	create bool,
+) *browserCrashGuard {
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil {
+		return nil
+	}
+	guard, ok := agent.GetStateValue[*browserCrashGuard](
+		inv,
+		browserCrashGuardStateKey,
+	)
+	if ok && guard != nil {
+		return guard
+	}
+	if !create {
+		return nil
+	}
+	browserCrashGuardInitMu.Lock()
+	defer browserCrashGuardInitMu.Unlock()
+	guard, ok = agent.GetStateValue[*browserCrashGuard](
+		inv,
+		browserCrashGuardStateKey,
+	)
+	if ok && guard != nil {
+		return guard
+	}
+	guard = &browserCrashGuard{
+		profiles: make(map[string]browserCrashState),
+	}
+	inv.SetState(browserCrashGuardStateKey, guard)
+	return guard
+}
+
+func normalizeBrowserCrashProfile(profile string) string {
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		return defaultProfileName
+	}
+	return profile
+}
+
+func detectBrowserBackendCrash(text string) (bool, string) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false, ""
+	}
+	lower := strings.ToLower(trimmed)
+	hasErrorContext := strings.Contains(lower, "### error") ||
+		strings.Contains(lower, "error:") ||
+		strings.Contains(lower, "browser logs") ||
+		strings.Contains(lower, "call log") ||
+		strings.Contains(lower, "async initializeserver")
+	hasProcessExitLog := strings.Contains(lower, "<process did exit") ||
+		(strings.Contains(lower, "[pid=") &&
+			strings.Contains(lower, "process did exit"))
+	switch {
+	case hasErrorContext &&
+		strings.Contains(lower, "target page, context or browser has been closed"):
+		return true, "target page, context or browser has been closed"
+	case hasErrorContext && strings.Contains(lower, "browser has been closed"):
+		return true, "browser has been closed"
+	case hasErrorContext && strings.Contains(lower, "browser has disconnected"):
+		return true, "browser has disconnected"
+	case hasErrorContext && strings.Contains(lower, "browser is closed"):
+		return true, "browser is closed"
+	case (hasErrorContext || hasProcessExitLog) &&
+		strings.Contains(lower, "process did exit"):
+		return true, "browser process exited"
+	case (hasErrorContext || hasProcessExitLog) &&
+		(strings.Contains(lower, "signal=sigtrap") ||
+			strings.Contains(lower, "sigtrap")):
+		return true, "browser process exited with SIGTRAP"
+	case strings.Contains(lower, "connection closed") &&
+		strings.Contains(lower, "browser"):
+		return true, "browser connection closed"
+	default:
+		return false, ""
+	}
+}
+
+func browserCrashBlockedContent(profile string, reason string) []map[string]any {
+	return []map[string]any{{
+		"type": "text",
+		"text": browserCrashBlockedMessage(profile, reason),
+	}}
+}
+
+func browserCrashBlockedMessage(profile string, reason string) string {
+	profile = normalizeBrowserCrashProfile(profile)
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "browser backend crashed repeatedly"
+	}
+	return fmt.Sprintf(
+		"Browser backend is degraded for profile %q in this agent run "+
+			"after repeated backend crashes; last error: %s. "+
+			"This is a browser automation blocker, not a page-specific "+
+			"navigation error. Do not retry browser automation in this "+
+			"run unless the runtime configuration changes. Use "+
+			"web_fetch, search, exec, or document tools instead.",
+		profile,
+		reason,
+	)
+}

--- a/openclaw/internal/browser/crash_guard.go
+++ b/openclaw/internal/browser/crash_guard.go
@@ -229,6 +229,8 @@ func detectBrowserBackendCrash(text string) (bool, string) {
 	hasProcessExitLog := strings.Contains(lower, "<process did exit") ||
 		(strings.Contains(lower, "[pid=") &&
 			strings.Contains(lower, "process did exit"))
+	hasSIGTRAP := strings.Contains(lower, "signal=sigtrap") ||
+		strings.Contains(lower, "sigtrap")
 	switch {
 	case hasErrorContext &&
 		strings.Contains(lower, "target page, context or browser has been closed"):
@@ -240,11 +242,10 @@ func detectBrowserBackendCrash(text string) (bool, string) {
 	case hasErrorContext && strings.Contains(lower, "browser is closed"):
 		return true, "browser is closed"
 	case (hasErrorContext || hasProcessExitLog) &&
-		strings.Contains(lower, "process did exit"):
+		strings.Contains(lower, "process did exit") &&
+		!hasSIGTRAP:
 		return true, "browser process exited"
-	case (hasErrorContext || hasProcessExitLog) &&
-		(strings.Contains(lower, "signal=sigtrap") ||
-			strings.Contains(lower, "sigtrap")):
+	case hasErrorContext && hasSIGTRAP:
 		return true, "browser process exited with SIGTRAP"
 	case strings.Contains(lower, "connection closed") &&
 		strings.Contains(lower, "browser"):

--- a/openclaw/internal/browser/crash_guard.go
+++ b/openclaw/internal/browser/crash_guard.go
@@ -245,7 +245,7 @@ func detectBrowserBackendCrash(text string) (bool, string) {
 		strings.Contains(lower, "process did exit") &&
 		!hasSIGTRAP:
 		return true, "browser process exited"
-	case hasErrorContext && hasSIGTRAP:
+	case (hasErrorContext || hasProcessExitLog) && hasSIGTRAP:
 		return true, "browser process exited with SIGTRAP"
 	case strings.Contains(lower, "connection closed") &&
 		strings.Contains(lower, "browser"):

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -487,12 +487,22 @@ func (t *Tool) Call(ctx context.Context, args []byte) (any, error) {
 	}
 	driverType := t.driverTypeForInput(profileName, in)
 	t.registerCancelCleanup(ctx, profileName, drv)
+	if result, ok := browserCrashBlockedResult(
+		ctx,
+		actionKey,
+		profileName,
+		driverType,
+		t.evaluateEnabled,
+	); ok {
+		return result, nil
+	}
+	drv = newCrashGuardedDriver(ctx, profileName, drv)
 
 	switch actionKey {
 	case strings.ToLower(actionStart):
 		return t.handleStart(ctx, profileName, driverType, drv)
 	case strings.ToLower(actionStop):
-		return t.handleStop(profileName, driverType, drv)
+		return t.handleStop(ctx, profileName, driverType, drv)
 	case strings.ToLower(actionTabs):
 		return t.handleTabs(ctx, profileName, driverType, drv, in)
 	case strings.ToLower(actionOpen):
@@ -1145,6 +1155,7 @@ func (t *Tool) handleStart(
 	if err != nil {
 		return Result{}, err
 	}
+	resetBrowserCrash(ctx, profile)
 
 	result := newBaseResult(
 		actionStart,
@@ -1158,6 +1169,7 @@ func (t *Tool) handleStart(
 }
 
 func (t *Tool) handleStop(
+	ctx context.Context,
 	profile string,
 	driverType string,
 	drv driver,
@@ -1165,6 +1177,7 @@ func (t *Tool) handleStop(
 	if err := drv.Stop(); err != nil {
 		return Result{}, err
 	}
+	resetBrowserCrash(ctx, profile)
 
 	result := newBaseResult(
 		actionStop,

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -455,13 +455,18 @@ func TestDetectBrowserBackendCrash(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "sigtrap",
-			text: "<process did exit: exitCode=null, signal=SIGTRAP>",
+			name: "sigtrap with error context",
+			text: "### Error\n<process did exit: exitCode=null, signal=SIGTRAP>",
 			want: true,
 		},
 		{
 			name: "plain sigtrap page text",
 			text: "A public article mentions SIGTRAP in a debugging guide.",
+			want: false,
+		},
+		{
+			name: "plain sigtrap process text",
+			text: "<process did exit: exitCode=null, signal=SIGTRAP>",
 			want: false,
 		},
 		{

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -441,6 +441,60 @@ func TestToolCall_BrowserBackendCrashGuardIsInvocationScoped(t *testing.T) {
 	require.Len(t, drv.calls, browserCrashThreshold+1)
 }
 
+func TestCrashGuardedDriverDelegatesStatusAndRecordsCallErrors(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		status: driverStatus{
+			State: stateReady,
+		},
+		callErr: errors.New(
+			"### Error\nError: browser has disconnected",
+		),
+	}
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+	guarded := newCrashGuardedDriver(ctx, "", drv)
+	require.NotNil(t, guarded)
+
+	status, err := guarded.Status(ctx)
+	require.NoError(t, err)
+	require.Equal(t, stateReady, status.State)
+
+	_, err = guarded.Call(ctx, "browser_snapshot", nil)
+	require.Error(t, err)
+	state, ok := browserCrashStateForContext(ctx, defaultProfileName)
+	require.True(t, ok)
+	require.Equal(t, 1, state.Consecutive)
+	require.Equal(t, "browser has disconnected", state.Reason)
+}
+
+func TestNewCrashGuardedDriverSkipsWithoutInvocation(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{}
+	require.Nil(t, newCrashGuardedDriver(context.Background(), "", nil))
+	require.Same(
+		t,
+		drv,
+		newCrashGuardedDriver(context.Background(), defaultProfileName, drv),
+	)
+}
+
+func TestBrowserCrashBlockedContentUsesDefaults(t *testing.T) {
+	t.Parallel()
+
+	content := browserCrashBlockedContent("", "")
+	require.Len(t, content, 1)
+	require.Equal(t, "text", content[0]["type"])
+	text, ok := content[0]["text"].(string)
+	require.True(t, ok)
+	require.Contains(t, text, defaultProfileName)
+	require.Contains(t, text, "browser backend crashed repeatedly")
+}
+
 func TestDetectBrowserBackendCrash(t *testing.T) {
 	t.Parallel()
 
@@ -452,6 +506,31 @@ func TestDetectBrowserBackendCrash(t *testing.T) {
 		{
 			name: "target closed",
 			text: "### Error\nError: Target page, context or browser has been closed",
+			want: true,
+		},
+		{
+			name: "browser has been closed",
+			text: "### Error\nError: browser has been closed",
+			want: true,
+		},
+		{
+			name: "browser has disconnected",
+			text: "### Error\nError: browser has disconnected",
+			want: true,
+		},
+		{
+			name: "browser is closed",
+			text: "### Error\nError: browser is closed",
+			want: true,
+		},
+		{
+			name: "process did exit",
+			text: "[pid=123] <process did exit: exitCode=1>",
+			want: true,
+		},
+		{
+			name: "browser connection closed",
+			text: "browser connection closed while reading response",
 			want: true,
 		},
 		{
@@ -477,6 +556,11 @@ func TestDetectBrowserBackendCrash(t *testing.T) {
 		{
 			name: "ordinary page text",
 			text: "A post explaining why a browser has been closed",
+			want: false,
+		},
+		{
+			name: "empty",
+			text: "   ",
 			want: false,
 		},
 	}

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -158,6 +158,358 @@ func TestToolCall_SnapshotWrapsUntrustedText(t *testing.T) {
 	require.Equal(t, mcpToolSnapshot, drv.calls[0].Tool)
 }
 
+func TestToolCall_BrowserBackendCrashGuardBlocksRepeatedCrashes(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	crashText := "### Error\nError: async initializeServer: " +
+		"Target page, context or browser has been closed\n" +
+		"[pid=123] <process did exit: signal=SIGTRAP>"
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolNavigate: []map[string]any{{
+				"type": "text",
+				"text": crashText,
+			}},
+		},
+	}
+	tool := newToolWithDrivers(
+		defaultProfileName,
+		false,
+		navigationPolicy{},
+		nil,
+		nil,
+		nil,
+		map[string]ProfileConfig{
+			defaultProfileName: {Name: defaultProfileName},
+		},
+		map[string]driver{
+			defaultProfileName: drv,
+		},
+	)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+
+	for i := 0; i < browserCrashThreshold; i++ {
+		raw, err := tool.Call(
+			ctx,
+			mustJSON(t, map[string]any{
+				"action": actionNavigate,
+				"url":    "https://example.com",
+			}),
+		)
+		require.NoError(t, err)
+		got := raw.(Result)
+		require.Contains(t, got.Text, "Target page")
+		require.NotEqual(t, stateDegraded, got.State)
+	}
+
+	raw, err := tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	got := raw.(Result)
+	require.Equal(t, stateDegraded, got.State)
+	require.Contains(t, got.Text, "Browser backend is degraded")
+	require.Contains(t, got.Text, "browser automation blocker")
+	require.Contains(t, got.Text, "web_fetch")
+	require.Len(t, drv.calls, browserCrashThreshold)
+}
+
+func TestToolCall_BrowserBackendCrashGuardResetsAfterSuccessfulCall(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolNavigate: []map[string]any{{
+				"type": "text",
+				"text": "Error: Target page, context or browser has been closed",
+			}},
+		},
+	}
+	tool := newToolWithDrivers(
+		defaultProfileName,
+		false,
+		navigationPolicy{},
+		nil,
+		nil,
+		nil,
+		map[string]ProfileConfig{
+			defaultProfileName: {Name: defaultProfileName},
+		},
+		map[string]driver{
+			defaultProfileName: drv,
+		},
+	)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+
+	_, err := tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{
+			"action": actionNavigate,
+			"url":    "https://example.com",
+		}),
+	)
+	require.NoError(t, err)
+	raw, err := tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	got := raw.(Result)
+	require.NotEqual(t, stateDegraded, got.State)
+
+	_, err = tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{
+			"action": actionNavigate,
+			"url":    "https://example.com",
+		}),
+	)
+	require.NoError(t, err)
+	raw, err = tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	got = raw.(Result)
+	require.NotEqual(t, stateDegraded, got.State)
+	require.Len(t, drv.calls, 4)
+}
+
+func TestToolCall_BrowserBackendCrashGuardStartStopResetBlockedState(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolNavigate: []map[string]any{{
+				"type": "text",
+				"text": "Error: Target page, context or browser has been closed",
+			}},
+		},
+	}
+	tool := newToolWithDrivers(
+		defaultProfileName,
+		false,
+		navigationPolicy{},
+		nil,
+		nil,
+		nil,
+		map[string]ProfileConfig{
+			defaultProfileName: {Name: defaultProfileName},
+		},
+		map[string]driver{
+			defaultProfileName: drv,
+		},
+	)
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+
+	for i := 0; i < browserCrashThreshold; i++ {
+		_, err := tool.Call(
+			ctx,
+			mustJSON(t, map[string]any{
+				"action": actionNavigate,
+				"url":    "https://example.com",
+			}),
+		)
+		require.NoError(t, err)
+	}
+	_, err := tool.Call(ctx, mustJSON(t, map[string]any{"action": actionStatus}))
+	require.NoError(t, err)
+	raw, err := tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, stateDegraded, raw.(Result).State)
+	require.Len(t, drv.calls, browserCrashThreshold)
+
+	raw, err = tool.Call(ctx, mustJSON(t, map[string]any{"action": actionStart}))
+	require.NoError(t, err)
+	require.NotEqual(t, stateDegraded, raw.(Result).State)
+	raw, err = tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, stateDegraded, raw.(Result).State)
+	require.Len(t, drv.calls, browserCrashThreshold+1)
+
+	for i := 0; i < browserCrashThreshold; i++ {
+		_, err = tool.Call(
+			ctx,
+			mustJSON(t, map[string]any{
+				"action": actionNavigate,
+				"url":    "https://example.com",
+			}),
+		)
+		require.NoError(t, err)
+	}
+	_, err = tool.Call(ctx, mustJSON(t, map[string]any{"action": actionProfiles}))
+	require.NoError(t, err)
+	raw, err = tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, stateDegraded, raw.(Result).State)
+
+	raw, err = tool.Call(ctx, mustJSON(t, map[string]any{"action": actionStop}))
+	require.NoError(t, err)
+	require.Equal(t, stateStopped, raw.(Result).State)
+	require.Equal(t, 1, drv.StopCount())
+	raw, err = tool.Call(
+		ctx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, stateDegraded, raw.(Result).State)
+}
+
+func TestToolCall_BrowserBackendCrashGuardIsInvocationScoped(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolNavigate: []map[string]any{{
+				"type": "text",
+				"text": "Error: Target page, context or browser has been closed",
+			}},
+		},
+	}
+	tool := newToolWithDrivers(
+		defaultProfileName,
+		false,
+		navigationPolicy{},
+		nil,
+		nil,
+		nil,
+		map[string]ProfileConfig{
+			defaultProfileName: {Name: defaultProfileName},
+		},
+		map[string]driver{
+			defaultProfileName: drv,
+		},
+	)
+	firstCtx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+	secondCtx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+
+	for i := 0; i < browserCrashThreshold; i++ {
+		_, err := tool.Call(
+			firstCtx,
+			mustJSON(t, map[string]any{
+				"action": actionNavigate,
+				"url":    "https://example.com",
+			}),
+		)
+		require.NoError(t, err)
+	}
+	_, err := tool.Call(
+		firstCtx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	require.Len(t, drv.calls, browserCrashThreshold)
+
+	raw, err := tool.Call(
+		secondCtx,
+		mustJSON(t, map[string]any{"action": actionSnapshot}),
+	)
+	require.NoError(t, err)
+	got := raw.(Result)
+	require.NotEqual(t, stateDegraded, got.State)
+	require.Len(t, drv.calls, browserCrashThreshold+1)
+}
+
+func TestDetectBrowserBackendCrash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{
+			name: "target closed",
+			text: "### Error\nError: Target page, context or browser has been closed",
+			want: true,
+		},
+		{
+			name: "sigtrap",
+			text: "<process did exit: exitCode=null, signal=SIGTRAP>",
+			want: true,
+		},
+		{
+			name: "plain sigtrap page text",
+			text: "A public article mentions SIGTRAP in a debugging guide.",
+			want: false,
+		},
+		{
+			name: "plain process exit page text",
+			text: "The tutorial says the process did exit after cleanup.",
+			want: false,
+		},
+		{
+			name: "ordinary page text",
+			text: "A post explaining why a browser has been closed",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, _ := detectBrowserBackendCrash(tt.text)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBrowserCrashGuardFromContextConcurrentCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := agent.NewInvocationContext(
+		context.Background(),
+		agent.NewInvocation(),
+	)
+	const workers = 16
+	start := make(chan struct{})
+	results := make(chan *browserCrashGuard, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			<-start
+			results <- browserCrashGuardFromContext(ctx, true)
+		}()
+	}
+	close(start)
+
+	first := <-results
+	require.NotNil(t, first)
+	for i := 1; i < workers; i++ {
+		require.Same(t, first, <-results)
+	}
+}
+
 func TestToolCall_ActClickSelectsRequestedTab(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -465,9 +465,9 @@ func TestDetectBrowserBackendCrash(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "plain sigtrap process text",
+			name: "sigtrap process log",
 			text: "<process did exit: exitCode=null, signal=SIGTRAP>",
-			want: false,
+			want: true,
 		},
 		{
 			name: "plain process exit page text",

--- a/openclaw/internal/deps/exec_test.go
+++ b/openclaw/internal/deps/exec_test.go
@@ -110,22 +110,18 @@ func TestCombinedOutputContext(t *testing.T) {
 		t.Skip("shell assertions run on unix-like systems")
 	}
 
-	okPath := writeTestCommand(
-		t,
-		t.TempDir(),
-		"python3",
-		"printf ok",
-	)
+	shell, err := resolveExecutable("", "sh", "")
+	require.NoError(t, err)
 	out, err := combinedOutputContext(
 		nil,
-		newExecCommand(executableSpec{path: okPath}),
+		newExecCommand(shell, "-c", "printf ok"),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "ok", string(out))
 
 	out, err = combinedOutputContext(
 		context.Background(),
-		newExecCommand(executableSpec{path: okPath}),
+		newExecCommand(shell, "-c", "printf ok"),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "ok", string(out))
@@ -139,17 +135,11 @@ func TestCombinedOutputContext(t *testing.T) {
 	require.Error(t, err)
 	require.Empty(t, out)
 
-	slowPath := writeTestCommand(
-		t,
-		t.TempDir(),
-		"python3",
-		"sleep 1\nprintf late",
-	)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	out, err = combinedOutputContext(
 		ctx,
-		newExecCommand(executableSpec{path: slowPath}),
+		newExecCommand(shell, "-c", "sleep 1; printf late"),
 	)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Empty(t, out)


### PR DESCRIPTION
## What
- Track repeated browser backend crash results per agent invocation/profile.
- Return a degraded browser result after repeated backend crashes so agents can switch to fetch/search/exec instead of retrying a broken browser lane.
- Keep start/stop/status/profiles available and keep the guard invocation-scoped.

## Why
Some browser backends return Playwright/MCP crash text as a successful tool payload, which can cause agents to repeatedly retry the same failed browser action. The guard recognizes generic backend crash signals and prevents repeated retries within the same run.

## Validation
- `go test ./internal/browser -count=1`
- `go test ./internal/browser ./app -count=1`