### PR TITLE
server/openai: map request tools to external tools run option

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -2295,6 +2295,14 @@ existing tool wins; the external declaration does not override or intercept it.
 This includes tools registered on the Agent and tools added with
 `WithAdditionalTools`.
 
+The `server/openai` adapter only implements `tool_choice: "none"` (skip
+exposing tools to the model) and `tool_choice: "auto"` or an omitted value
+(let the model decide, which is the only behavior the adapter can offer since
+it never executes tools itself). `tool_choice: "required"` and forced-function
+tool choice (`{"type":"function","function":{"name":"..."}}`) are rejected
+with an HTTP 400 when the request also includes `tools`, instead of being
+silently treated as `"auto"`.
+
 **Complete example:** `examples/toolinterrupt/`
 
 ```go

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -2287,7 +2287,10 @@ and only its per-run execution policy should change, continue to use
 `agent.WithToolExecutionFilter(...)`. `WithExternalTools` is better for AG-UI,
 browser, mobile, or upstream-service callers that declare tools dynamically on
 each request. The AG-UI runner maps request `input.Tools` to `WithExternalTools`
-by default. If an external tool has the same name as an existing tool, the
+by default; the OpenAI Chat Completions adapter (`server/openai`) maps request
+`tools` to `WithExternalTools` as well. The server does not execute those tools;
+callers run them after receiving `tool_calls` and resume with `role=tool`
+messages. If an external tool has the same name as an existing tool, the
 existing tool wins; the external declaration does not override or intercept it.
 This includes tools registered on the Agent and tools added with
 `WithAdditionalTools`.

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -2171,6 +2171,8 @@ ch, err = r.Run(ctx, userID, sessionID, toolMsg,
 工具的场景。AG-UI runner 默认会把请求里的 `input.Tools` 映射为
 `WithExternalTools`；OpenAI Chat Completions adapter（`server/openai`）同样会把请求里的 `tools` 映射为 `WithExternalTools`，服务端不执行这些工具，由调用方在收到 `tool_calls` 后外部执行并用 `role=tool` 消息续聊。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
 
+`server/openai` adapter 目前只实现了 `tool_choice: "none"`（不把 tools 暴露给模型）和 `tool_choice: "auto"` 或省略该字段（由模型自行决定，这也是该 adapter 能提供的唯一行为，因为它自身从不执行工具）。当请求同时带有 `tools` 时，`tool_choice: "required"` 以及强制指定函数的写法（`{"type":"function","function":{"name":"..."}}`）会被拒绝并返回 HTTP 400，而不会被静默当作 `"auto"` 处理。
+
 **完整示例：** `examples/toolinterrupt/`
 
 ```go

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -2169,7 +2169,7 @@ ch, err = r.Run(ctx, userID, sessionID, toolMsg,
 运行中改成由调用方执行，可以继续使用 `agent.WithToolExecutionFilter(...)`。
 `WithExternalTools` 更适合 AG-UI、浏览器、移动端或上游服务在每次请求中动态声明
 工具的场景。AG-UI runner 默认会把请求里的 `input.Tools` 映射为
-`WithExternalTools`。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
+`WithExternalTools`；OpenAI Chat Completions adapter（`server/openai`）同样会把请求里的 `tools` 映射为 `WithExternalTools`，服务端不执行这些工具，由调用方在收到 `tool_calls` 后外部执行并用 `role=tool` 消息续聊。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
 
 **完整示例：** `examples/toolinterrupt/`
 

--- a/server/openai/external_tool_integration_test.go
+++ b/server/openai/external_tool_integration_test.go
@@ -1,0 +1,269 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+const (
+	integrationToolName    = "client_search"
+	integrationToolCallID  = "call-1"
+	integrationSessionID   = "thread-integration"
+	integrationUserMessage = "search go"
+	integrationToolResult  = `{"items":["go docs"]}`
+)
+
+type recordedModelRequest struct {
+	messages  []model.Message
+	toolNames []string
+}
+
+type recordingModel struct {
+	responses []*model.Response
+
+	mu       sync.Mutex
+	requests []recordedModelRequest
+	nextIdx  int
+}
+
+func (m *recordingModel) GenerateContent(
+	_ context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if req != nil {
+		toolNames := make([]string, 0, len(req.Tools))
+		for name := range req.Tools {
+			toolNames = append(toolNames, name)
+		}
+		sort.Strings(toolNames)
+		m.requests = append(m.requests, recordedModelRequest{
+			messages:  append([]model.Message(nil), req.Messages...),
+			toolNames: toolNames,
+		})
+	}
+
+	if m.nextIdx >= len(m.responses) {
+		return nil, fmt.Errorf("unexpected model call %d", m.nextIdx)
+	}
+	resp := m.responses[m.nextIdx]
+	m.nextIdx++
+
+	ch := make(chan *model.Response, 1)
+	ch <- resp
+	close(ch)
+	return ch, nil
+}
+
+func (m *recordingModel) Info() model.Info {
+	return model.Info{Name: "recording-model"}
+}
+
+func (m *recordingModel) Requests() []recordedModelRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]recordedModelRequest(nil), m.requests...)
+}
+
+func nonSystemMessages(messages []model.Message) []model.Message {
+	filtered := make([]model.Message, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Role == model.RoleSystem {
+			continue
+		}
+		filtered = append(filtered, msg)
+	}
+	return filtered
+}
+
+func TestOpenAIExternalToolFlowThroughRealRunner(t *testing.T) {
+	toolCallFinishReason := finishReasonToolCalls
+	modelStub := &recordingModel{
+		responses: []*model.Response{
+			{
+				Done: true,
+				Choices: []model.Choice{
+					{
+						Message: model.Message{
+							Role: model.RoleAssistant,
+							ToolCalls: []model.ToolCall{
+								{
+									ID:   integrationToolCallID,
+									Type: "function",
+									Function: model.FunctionDefinitionParam{
+										Name:      integrationToolName,
+										Arguments: []byte(`{"query":"go"}`),
+									},
+								},
+							},
+						},
+						FinishReason: &toolCallFinishReason,
+					},
+				},
+			},
+			{
+				Done: true,
+				Choices: []model.Choice{
+					{
+						Message: model.NewAssistantMessage("final answer"),
+					},
+				},
+			},
+		},
+	}
+
+	const appName = "openai-integration-app"
+	sessionService := inmemory.NewSessionService()
+	ag := llmagent.New("integration-agent", llmagent.WithModel(modelStub))
+	baseRunner := trunner.NewRunner(
+		appName,
+		ag,
+		trunner.WithSessionService(sessionService),
+	)
+	t.Cleanup(func() {
+		require.NoError(t, baseRunner.Close())
+	})
+
+	s, err := New(
+		WithRunner(baseRunner),
+		WithAppName(appName),
+		WithSessionService(sessionService),
+	)
+	require.NoError(t, err)
+
+	round1Body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: integrationUserMessage},
+		},
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:        integrationToolName,
+					Description: "Search a frontend-owned source.",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	round1Req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(round1Body),
+	)
+	round1Req.Header.Set(headerSessionID, integrationSessionID)
+	round1W := httptest.NewRecorder()
+	s.handleChatCompletions(round1W, round1Req)
+
+	require.Equal(t, http.StatusOK, round1W.Code)
+	var round1Resp openAIResponse
+	require.NoError(t, json.NewDecoder(round1W.Body).Decode(&round1Resp))
+	require.NotNil(t, round1Resp.Choices[0].FinishReason)
+	assert.Equal(t, finishReasonToolCalls, *round1Resp.Choices[0].FinishReason)
+	require.Len(t, round1Resp.Choices[0].Message.ToolCalls, 1)
+	assert.Equal(t, integrationToolCallID, round1Resp.Choices[0].Message.ToolCalls[0].ID)
+
+	round1Requests := modelStub.Requests()
+	require.Len(t, round1Requests, 1)
+	assert.Equal(t, []string{integrationToolName}, round1Requests[0].toolNames)
+	round1Messages := nonSystemMessages(round1Requests[0].messages)
+	require.Len(t, round1Messages, 1)
+	assert.Equal(t, integrationUserMessage, round1Messages[0].Content)
+
+	round2Body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: integrationUserMessage},
+			{
+				Role:    "assistant",
+				Content: "",
+				ToolCalls: []openAIToolCall{
+					{
+						ID:   integrationToolCallID,
+						Type: "function",
+						Function: openAIToolCallFunction{
+							Name:      integrationToolName,
+							Arguments: `{"query":"go"}`,
+						},
+					},
+				},
+			},
+			{
+				Role:       "tool",
+				ToolCallID: integrationToolCallID,
+				Name:       integrationToolName,
+				Content:    integrationToolResult,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	round2Req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(round2Body),
+	)
+	round2Req.Header.Set(headerSessionID, integrationSessionID)
+	round2W := httptest.NewRecorder()
+	s.handleChatCompletions(round2W, round2Req)
+
+	require.Equal(t, http.StatusOK, round2W.Code)
+	var round2Resp openAIResponse
+	require.NoError(t, json.NewDecoder(round2W.Body).Decode(&round2Resp))
+	assert.Equal(t, "final answer", round2Resp.Choices[0].Message.Content)
+
+	round2Requests := modelStub.Requests()
+	require.Len(t, round2Requests, 2)
+	round2Messages := nonSystemMessages(round2Requests[1].messages)
+	require.Len(t, round2Messages, 3)
+	assert.Equal(t, model.RoleUser, round2Messages[0].Role)
+	assert.Equal(t, integrationUserMessage, round2Messages[0].Content)
+	assert.Equal(t, model.RoleAssistant, round2Messages[1].Role)
+	require.Len(t, round2Messages[1].ToolCalls, 1)
+	assert.Equal(t, integrationToolCallID, round2Messages[1].ToolCalls[0].ID)
+	assert.Equal(t, model.RoleTool, round2Messages[2].Role)
+	assert.Equal(t, integrationToolResult, round2Messages[2].Content)
+	assert.Equal(t, integrationToolCallID, round2Messages[2].ToolID)
+
+	sess, err := sessionService.GetSession(
+		context.Background(),
+		session.Key{
+			AppName:   appName,
+			UserID:    defaultUserID,
+			SessionID: integrationSessionID,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.GreaterOrEqual(t, len(sess.Events), 4)
+}

--- a/server/openai/external_tools.go
+++ b/server/openai/external_tools.go
@@ -1,0 +1,129 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	// openAIToolTypeFunction is the only tool type currently supported by
+	// the OpenAI Chat Completions adapter for external tools.
+	openAIToolTypeFunction = "function"
+
+	// jsonSchemaTypeObject is the default JSON Schema type used when the
+	// caller omits function.parameters.
+	jsonSchemaTypeObject = "object"
+
+	errOpenAIToolAt              = "openai tool[%d]: %s"
+	errOpenAIToolWithNameAt      = "openai tool[%d] %q: parse function.parameters: %w"
+	errOpenAIToolFunctionName    = "function.name is required"
+	errOpenAIToolUnsupportedType = "unsupported tool type %q"
+)
+
+// appendExternalToolRunOption converts req.Tools into caller-executed tools
+// and appends an agent.WithExternalTools run option when any are present.
+//
+// External tools are declaration-only: the framework exposes them to the
+// model but never executes them. When the model calls one, the run ends
+// with a tool_call assistant message and the caller is expected to execute
+// the tool externally and continue with a role="tool" message.
+func appendExternalToolRunOption(
+	opts []agent.RunOption,
+	req *openAIRequest,
+) ([]agent.RunOption, error) {
+	externalTools, err := externalToolsFromOpenAIRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if len(externalTools) == 0 {
+		return opts, nil
+	}
+	return append(opts, agent.WithExternalTools(externalTools)), nil
+}
+
+// externalToolsFromOpenAIRequest converts req.Tools into framework tools.
+// Only tools with type="function" and a non-empty function.name are accepted.
+func externalToolsFromOpenAIRequest(req *openAIRequest) ([]agenttool.Tool, error) {
+	if req == nil || len(req.Tools) == 0 {
+		return nil, nil
+	}
+	tools := make([]agenttool.Tool, 0, len(req.Tools))
+	for i, t := range req.Tools {
+		// OpenAI requires type="function", but several client SDKs omit the field.
+		// Treat empty type as function for compatibility.
+		if t.Type != "" && t.Type != openAIToolTypeFunction {
+			return nil, fmt.Errorf(
+				errOpenAIToolAt,
+				i,
+				fmt.Sprintf(errOpenAIToolUnsupportedType, t.Type),
+			)
+		}
+		if t.Function.Name == "" {
+			return nil, fmt.Errorf(
+				errOpenAIToolAt,
+				i,
+				errOpenAIToolFunctionName,
+			)
+		}
+		schema, err := openAIToolParametersToSchema(t.Function.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf(
+				errOpenAIToolWithNameAt,
+				i,
+				t.Function.Name,
+				err,
+			)
+		}
+		tools = append(tools, &declarationOnlyTool{
+			declaration: &agenttool.Declaration{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				InputSchema: schema,
+			},
+		})
+	}
+	return tools, nil
+}
+
+// openAIToolParametersToSchema converts the raw JSON parameters field of an
+// OpenAI tool definition into a framework tool schema. Empty or nil inputs
+// yield the default {"type":"object"} schema.
+func openAIToolParametersToSchema(params json.RawMessage) (*agenttool.Schema, error) {
+	trimmed := bytes.TrimSpace(params)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return &agenttool.Schema{Type: jsonSchemaTypeObject}, nil
+	}
+	var schema agenttool.Schema
+	if err := json.Unmarshal(trimmed, &schema); err != nil {
+		return nil, err
+	}
+	if schema.Type == "" {
+		schema.Type = jsonSchemaTypeObject
+	}
+	return &schema, nil
+}
+
+// declarationOnlyTool is a framework tool that only exposes its declaration
+// to the model. It intentionally does not implement CallableTool so the
+// framework never executes it; the caller runs the tool externally.
+type declarationOnlyTool struct {
+	declaration *agenttool.Declaration
+}
+
+// Declaration returns the tool metadata visible to the model.
+func (t *declarationOnlyTool) Declaration() *agenttool.Declaration {
+	return t.declaration
+}

--- a/server/openai/external_tools.go
+++ b/server/openai/external_tools.go
@@ -23,6 +23,10 @@ const (
 	// the OpenAI Chat Completions adapter for external tools.
 	openAIToolTypeFunction = "function"
 
+	// openAIToolChoiceNone disables tool calling per the OpenAI Chat
+	// Completions API even when tools are present in the request.
+	openAIToolChoiceNone = "none"
+
 	// jsonSchemaTypeObject is the default JSON Schema type used when the
 	// caller omits function.parameters.
 	jsonSchemaTypeObject = "object"
@@ -44,6 +48,9 @@ func appendExternalToolRunOption(
 	opts []agent.RunOption,
 	req *openAIRequest,
 ) ([]agent.RunOption, error) {
+	if openAIToolChoiceDisablesTools(req) {
+		return opts, nil
+	}
 	externalTools, err := externalToolsFromOpenAIRequest(req)
 	if err != nil {
 		return nil, err
@@ -52,6 +59,17 @@ func appendExternalToolRunOption(
 		return opts, nil
 	}
 	return append(opts, agent.WithExternalTools(externalTools)), nil
+}
+
+// openAIToolChoiceDisablesTools reports whether the request's tool_choice
+// disables tool calling. Per OpenAI Chat Completions API, "none" means the
+// model must not call tools even when tools are present in the request.
+func openAIToolChoiceDisablesTools(req *openAIRequest) bool {
+	if req == nil || req.ToolChoice == nil {
+		return false
+	}
+	choice, ok := req.ToolChoice.(string)
+	return ok && choice == openAIToolChoiceNone
 }
 
 // externalToolsFromOpenAIRequest converts req.Tools into framework tools.

--- a/server/openai/external_tools.go
+++ b/server/openai/external_tools.go
@@ -27,14 +27,29 @@ const (
 	// Completions API even when tools are present in the request.
 	openAIToolChoiceNone = "none"
 
+	// openAIToolChoiceAuto lets the model decide whether to call a tool.
+	// This is the only non-"none" tool_choice semantics this adapter
+	// implements; it is also the default OpenAI behavior when tools are
+	// present and tool_choice is omitted.
+	openAIToolChoiceAuto = "auto"
+
+	// openAIToolChoiceRequired forces the model to call at least one tool.
+	// This adapter does not implement that constraint (see
+	// openAIToolChoiceRequiresUnsupportedSemantics) and rejects it instead
+	// of silently degrading to "auto".
+	openAIToolChoiceRequired = "required"
+
 	// jsonSchemaTypeObject is the default JSON Schema type used when the
 	// caller omits function.parameters.
 	jsonSchemaTypeObject = "object"
 
-	errOpenAIToolAt              = "openai tool[%d]: %s"
-	errOpenAIToolWithNameAt      = "openai tool[%d] %q: parse function.parameters: %w"
-	errOpenAIToolFunctionName    = "function.name is required"
-	errOpenAIToolUnsupportedType = "unsupported tool type %q"
+	errOpenAIToolAt                = "openai tool[%d]: %s"
+	errOpenAIToolWithNameAt        = "openai tool[%d] %q: parse function.parameters: %w"
+	errOpenAIToolFunctionName      = "function.name is required"
+	errOpenAIToolUnsupportedType   = "unsupported tool type %q"
+	errOpenAIToolChoiceUnsupported = "unsupported tool_choice %v: this server only " +
+		"supports \"none\" or \"auto\" (omitted defaults to \"auto\"); " +
+		"\"required\" and forced-function tool_choice are not implemented"
 )
 
 // appendExternalToolRunOption converts req.Tools into caller-executed tools
@@ -50,6 +65,9 @@ func appendExternalToolRunOption(
 ) ([]agent.RunOption, error) {
 	if openAIToolChoiceDisablesTools(req) {
 		return opts, nil
+	}
+	if openAIToolChoiceRequiresUnsupportedSemantics(req) {
+		return nil, fmt.Errorf(errOpenAIToolChoiceUnsupported, req.ToolChoice)
 	}
 	externalTools, err := externalToolsFromOpenAIRequest(req)
 	if err != nil {
@@ -70,6 +88,40 @@ func openAIToolChoiceDisablesTools(req *openAIRequest) bool {
 	}
 	choice, ok := req.ToolChoice.(string)
 	return ok && choice == openAIToolChoiceNone
+}
+
+// openAIToolChoiceRequiresUnsupportedSemantics reports whether req.ToolChoice
+// requests OpenAI-compatible behavior that this adapter does not implement:
+// "required" (must call at least one tool) or a forced-function object
+// (e.g. {"type":"function","function":{"name":"foo"}}). Only checked when
+// req.Tools is non-empty, since tool_choice is meaningless without tools.
+//
+// The adapter exposes request tools to the model via WithExternalTools and
+// always lets the model freely decide whether to call one, which matches
+// "auto" but not "required" or a forced function. Rather than silently
+// treating those unsupported values as "auto" — which could make a caller
+// relying on forced tool selection believe its request succeeded while
+// receiving a plain assistant reply instead — appendExternalToolRunOption
+// rejects them with an error that the server surfaces as HTTP 400.
+func openAIToolChoiceRequiresUnsupportedSemantics(req *openAIRequest) bool {
+	if req == nil || req.ToolChoice == nil || len(req.Tools) == 0 {
+		return false
+	}
+	choice, ok := req.ToolChoice.(string)
+	if !ok {
+		// A non-string tool_choice is a forced-function selection object.
+		return true
+	}
+	switch choice {
+	case openAIToolChoiceNone, openAIToolChoiceAuto:
+		return false
+	case openAIToolChoiceRequired:
+		return true
+	default:
+		// Unrecognized string values are rejected the same as "required"
+		// rather than silently falling back to "auto".
+		return true
+	}
 }
 
 // externalToolsFromOpenAIRequest converts req.Tools into framework tools.

--- a/server/openai/external_tools_test.go
+++ b/server/openai/external_tools_test.go
@@ -1,0 +1,253 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+func TestExternalToolsFromOpenAIRequest_ValidFunction(t *testing.T) {
+	const (
+		toolName        = "client_search"
+		toolDescription = "Search a frontend-owned source."
+		argName         = "query"
+		argType         = "string"
+	)
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:        toolName,
+					Description: toolDescription,
+					Parameters: json.RawMessage(`{
+						"type": "object",
+						"properties": {"query": {"type": "string"}},
+						"required": ["query"]
+					}`),
+				},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	decl := tools[0].Declaration()
+	require.NotNil(t, decl)
+	assert.Equal(t, toolName, decl.Name)
+	assert.Equal(t, toolDescription, decl.Description)
+	require.NotNil(t, decl.InputSchema)
+	assert.Equal(t, jsonSchemaTypeObject, decl.InputSchema.Type)
+	require.Contains(t, decl.InputSchema.Properties, argName)
+	assert.Equal(t, argType, decl.InputSchema.Properties[argName].Type)
+	assert.Equal(t, []string{argName}, decl.InputSchema.Required)
+}
+
+func TestExternalToolsFromOpenAIRequest_EmptyRequest(t *testing.T) {
+	tools, err := externalToolsFromOpenAIRequest(nil)
+	require.NoError(t, err)
+	assert.Nil(t, tools)
+
+	tools, err = externalToolsFromOpenAIRequest(&openAIRequest{})
+	require.NoError(t, err)
+	assert.Nil(t, tools)
+}
+
+func TestExternalToolsFromOpenAIRequest_DefaultsNilParameters(t *testing.T) {
+	const toolName = "client_notify"
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name: toolName,
+				},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	decl := tools[0].Declaration()
+	require.NotNil(t, decl)
+	require.NotNil(t, decl.InputSchema)
+	assert.Equal(t, toolName, decl.Name)
+	assert.Equal(t, jsonSchemaTypeObject, decl.InputSchema.Type)
+}
+
+func TestExternalToolsFromOpenAIRequest_DefaultsExplicitNullParameters(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:       "client_null",
+					Parameters: json.RawMessage("null"),
+				},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	require.NotNil(t, tools[0].Declaration().InputSchema)
+	assert.Equal(t, jsonSchemaTypeObject, tools[0].Declaration().InputSchema.Type)
+}
+
+func TestExternalToolsFromOpenAIRequest_DefaultsMissingSchemaType(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:       "client_no_type",
+					Parameters: json.RawMessage(`{"properties": {"q": {"type": "string"}}}`),
+				},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, jsonSchemaTypeObject, tools[0].Declaration().InputSchema.Type)
+}
+
+func TestExternalToolsFromOpenAIRequest_AcceptsEmptyType(t *testing.T) {
+	// OpenAI schema requires "type": "function" but be permissive when the
+	// caller omits it entirely, matching common client SDK behaviour.
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Function: openAIFunction{Name: "client_default_type"},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "client_default_type", tools[0].Declaration().Name)
+}
+
+func TestExternalToolsFromOpenAIRequest_RejectsUnsupportedType(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type:     "code_interpreter",
+				Function: openAIFunction{Name: "irrelevant"},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.Error(t, err)
+	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, "openai tool[0]")
+	assert.ErrorContains(t, err, "code_interpreter")
+}
+
+func TestExternalToolsFromOpenAIRequest_RejectsMissingName(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type:     "function",
+				Function: openAIFunction{Description: "no name"},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.Error(t, err)
+	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, "openai tool[0]")
+	assert.ErrorContains(t, err, errOpenAIToolFunctionName)
+}
+
+func TestExternalToolsFromOpenAIRequest_RejectsInvalidParametersJSON(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:       "bad_params",
+					Parameters: json.RawMessage(`{"type": 123}`),
+				},
+			},
+		},
+	}
+
+	tools, err := externalToolsFromOpenAIRequest(req)
+
+	require.Error(t, err)
+	assert.Nil(t, tools)
+	assert.ErrorContains(t, err, "openai tool[0]")
+	assert.ErrorContains(t, err, "bad_params")
+	assert.ErrorContains(t, err, "parse function.parameters")
+}
+
+func TestAppendExternalToolRunOption_NoTools(t *testing.T) {
+	existing := []agent.RunOption{agent.WithModelName("existing")}
+	got, err := appendExternalToolRunOption(existing, &openAIRequest{})
+	require.NoError(t, err)
+	// The slice should be returned unchanged: same length, same contents.
+	require.Len(t, got, len(existing))
+	opts := agent.NewRunOptions(got...)
+	assert.Empty(t, opts.ExternalTools)
+	assert.Equal(t, "existing", opts.ModelName)
+}
+
+func TestAppendExternalToolRunOption_AppendsExternalTools(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:        "client_search",
+					Description: "search",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+		},
+	}
+	got, err := appendExternalToolRunOption(nil, req)
+	require.NoError(t, err)
+	opts := agent.NewRunOptions(got...)
+	require.Len(t, opts.ExternalTools, 1)
+	assert.Equal(t, "client_search", opts.ExternalTools[0].Declaration().Name)
+	// The framework must not treat declaration-only tools as executable.
+	assert.False(t, opts.ShouldExecuteTool(nil, opts.ExternalTools[0]))
+}
+
+func TestAppendExternalToolRunOption_PropagatesError(t *testing.T) {
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{Type: "function", Function: openAIFunction{}},
+		},
+	}
+	got, err := appendExternalToolRunOption(nil, req)
+	require.Error(t, err)
+	assert.Nil(t, got)
+}

--- a/server/openai/external_tools_test.go
+++ b/server/openai/external_tools_test.go
@@ -279,3 +279,101 @@ func TestOpenAIToolChoiceDisablesTools(t *testing.T) {
 	assert.True(t, openAIToolChoiceDisablesTools(&openAIRequest{ToolChoice: openAIToolChoiceNone}))
 	assert.False(t, openAIToolChoiceDisablesTools(&openAIRequest{ToolChoice: 0}))
 }
+
+func oneOpenAITool() []openAITool {
+	return []openAITool{
+		{Type: "function", Function: openAIFunction{Name: "client_search"}},
+	}
+}
+
+func TestOpenAIToolChoiceRequiresUnsupportedSemantics(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *openAIRequest
+		want bool
+	}{
+		{"nil request", nil, false},
+		{"no tool_choice, no tools", &openAIRequest{}, false},
+		{"no tool_choice, with tools", &openAIRequest{Tools: oneOpenAITool()}, false},
+		{
+			"none with no tools",
+			&openAIRequest{ToolChoice: openAIToolChoiceNone},
+			false,
+		},
+		{
+			"none with tools",
+			&openAIRequest{ToolChoice: openAIToolChoiceNone, Tools: oneOpenAITool()},
+			false,
+		},
+		{
+			"auto with tools",
+			&openAIRequest{ToolChoice: openAIToolChoiceAuto, Tools: oneOpenAITool()},
+			false,
+		},
+		{
+			"required with no tools",
+			&openAIRequest{ToolChoice: openAIToolChoiceRequired},
+			false,
+		},
+		{
+			"required with tools",
+			&openAIRequest{ToolChoice: openAIToolChoiceRequired, Tools: oneOpenAITool()},
+			true,
+		},
+		{
+			"unrecognized string with tools",
+			&openAIRequest{ToolChoice: "bogus", Tools: oneOpenAITool()},
+			true,
+		},
+		{
+			"forced-function object with tools",
+			&openAIRequest{
+				ToolChoice: map[string]any{
+					"type":     "function",
+					"function": map[string]any{"name": "client_search"},
+				},
+				Tools: oneOpenAITool(),
+			},
+			true,
+		},
+		{
+			"forced-function object with no tools",
+			&openAIRequest{
+				ToolChoice: map[string]any{
+					"type":     "function",
+					"function": map[string]any{"name": "client_search"},
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, openAIToolChoiceRequiresUnsupportedSemantics(tt.req))
+		})
+	}
+}
+
+func TestAppendExternalToolRunOption_RejectsRequiredToolChoice(t *testing.T) {
+	req := &openAIRequest{
+		ToolChoice: openAIToolChoiceRequired,
+		Tools:      oneOpenAITool(),
+	}
+	got, err := appendExternalToolRunOption(nil, req)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, "required")
+}
+
+func TestAppendExternalToolRunOption_RejectsForcedFunctionToolChoice(t *testing.T) {
+	req := &openAIRequest{
+		ToolChoice: map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "client_search"},
+		},
+		Tools: oneOpenAITool(),
+	}
+	got, err := appendExternalToolRunOption(nil, req)
+	require.Error(t, err)
+	assert.Nil(t, got)
+}

--- a/server/openai/external_tools_test.go
+++ b/server/openai/external_tools_test.go
@@ -251,3 +251,31 @@ func TestAppendExternalToolRunOption_PropagatesError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, got)
 }
+
+func TestAppendExternalToolRunOption_SkipsWhenToolChoiceNone(t *testing.T) {
+	req := &openAIRequest{
+		ToolChoice: openAIToolChoiceNone,
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:        "client_search",
+					Description: "search",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+		},
+	}
+	got, err := appendExternalToolRunOption(nil, req)
+	require.NoError(t, err)
+	opts := agent.NewRunOptions(got...)
+	assert.Empty(t, opts.ExternalTools)
+}
+
+func TestOpenAIToolChoiceDisablesTools(t *testing.T) {
+	assert.False(t, openAIToolChoiceDisablesTools(nil))
+	assert.False(t, openAIToolChoiceDisablesTools(&openAIRequest{}))
+	assert.False(t, openAIToolChoiceDisablesTools(&openAIRequest{ToolChoice: "auto"}))
+	assert.True(t, openAIToolChoiceDisablesTools(&openAIRequest{ToolChoice: openAIToolChoiceNone}))
+	assert.False(t, openAIToolChoiceDisablesTools(&openAIRequest{ToolChoice: 0}))
+}

--- a/server/openai/run_input.go
+++ b/server/openai/run_input.go
@@ -67,7 +67,7 @@ func toolResultRunInputFromMessages(messages []model.Message) (*runInputMessages
 		if msg.ToolID == "" {
 			return nil, errors.New(errToolMessageMissingID)
 		}
-		if msg.Content == "" && len(msg.ContentParts) > 0 {
+		if len(msg.ContentParts) > 0 {
 			return nil, fmt.Errorf("%s: multimodal tool results are not supported", errToolMessageNotString)
 		}
 		toolMessages = append(toolMessages, msg)

--- a/server/openai/run_input.go
+++ b/server/openai/run_input.go
@@ -1,0 +1,166 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	errToolMessageMissingID = "tool message missing tool call id"
+	errToolMessageNotString = "tool message content must be a string"
+)
+
+// runInputMessages describes how an OpenAI chat completion request should be
+// passed to runner.Run. It mirrors the AG-UI runner's input message splitting:
+// prior conversation history, the current-turn input message, and any trailing
+// tool results submitted in the same request.
+type runInputMessages struct {
+	inputMessage model.Message
+	history      []model.Message
+	toolMessages []model.Message
+}
+
+// runInputFromMessages splits converted framework messages into history and the
+// current run input. When the request ends with one or more role=tool messages,
+// those tool results are treated as the current turn input, matching AG-UI's
+// external tool resume semantics. All other roles keep the legacy behavior of
+// passing the last message through unchanged.
+func runInputFromMessages(messages []model.Message) (*runInputMessages, error) {
+	if len(messages) == 0 {
+		return nil, errors.New("messages cannot be empty")
+	}
+	lastMessage := messages[len(messages)-1]
+	if lastMessage.Role == model.RoleTool {
+		return toolResultRunInputFromMessages(messages)
+	}
+	history := []model.Message(nil)
+	if len(messages) > 1 {
+		history = messages[:len(messages)-1]
+	}
+	return &runInputMessages{
+		inputMessage: lastMessage,
+		history:      history,
+	}, nil
+}
+
+func toolResultRunInputFromMessages(messages []model.Message) (*runInputMessages, error) {
+	start := len(messages) - 1
+	for start >= 0 && messages[start].Role == model.RoleTool {
+		start--
+	}
+	toolMessages := make([]model.Message, 0, len(messages)-start-1)
+	for _, msg := range messages[start+1:] {
+		if msg.ToolID == "" {
+			return nil, errors.New(errToolMessageMissingID)
+		}
+		if msg.Content == "" && len(msg.ContentParts) > 0 {
+			return nil, fmt.Errorf("%s: multimodal tool results are not supported", errToolMessageNotString)
+		}
+		toolMessages = append(toolMessages, msg)
+	}
+	history := []model.Message(nil)
+	if start >= 0 {
+		history = append(history, messages[:start+1]...)
+	}
+	return &runInputMessages{
+		inputMessage: toolMessages[len(toolMessages)-1],
+		history:      history,
+		toolMessages: toolMessages,
+	}, nil
+}
+
+func withToolResultMessageRewriter(toolMessages []model.Message) agent.RunOption {
+	currentTurnMessages := append([]model.Message(nil), toolMessages...)
+	return func(opts *agent.RunOptions) {
+		if len(toolMessages) <= 1 {
+			return
+		}
+		userMessageRewriter := opts.UserMessageRewriter
+		if userMessageRewriter == nil {
+			opts.UserMessageRewriter = func(
+				context.Context,
+				*agent.UserMessageRewriteArgs,
+			) ([]model.Message, error) {
+				return append([]model.Message(nil), currentTurnMessages...), nil
+			}
+			return
+		}
+		opts.UserMessageRewriter = func(
+			ctx context.Context,
+			args *agent.UserMessageRewriteArgs,
+		) ([]model.Message, error) {
+			rewritten, err := userMessageRewriter(ctx, args)
+			if err != nil {
+				return nil, err
+			}
+			return mergeToolResultRewriteMessages(rewritten, currentTurnMessages), nil
+		}
+	}
+}
+
+func mergeToolResultRewriteMessages(
+	rewritten []model.Message,
+	toolResults []model.Message,
+) []model.Message {
+	toolResultIDs := make(map[string]struct{}, len(toolResults))
+	rewrittenToolResults := make(map[string]model.Message, len(toolResults))
+	for _, msg := range toolResults {
+		if msg.ToolID != "" {
+			toolResultIDs[msg.ToolID] = struct{}{}
+		}
+	}
+	merged := make([]model.Message, 0, len(rewritten)+len(toolResults))
+	for _, msg := range rewritten {
+		if msg.Role == model.RoleTool && msg.ToolID != "" {
+			if _, ok := toolResultIDs[msg.ToolID]; ok {
+				rewrittenToolResults[msg.ToolID] = msg
+				continue
+			}
+		}
+		merged = append(merged, msg)
+	}
+	for _, msg := range toolResults {
+		if rewrittenMsg, ok := rewrittenToolResults[msg.ToolID]; ok {
+			rewrittenMsg.Role = model.RoleTool
+			rewrittenMsg.ToolID = msg.ToolID
+			if msg.ToolName != "" {
+				rewrittenMsg.ToolName = msg.ToolName
+			}
+			merged = append(merged, rewrittenMsg)
+			continue
+		}
+		merged = append(merged, msg)
+	}
+	return merged
+}
+
+// buildRunOptions assembles the RunOptions shared by streaming and
+// non-streaming paths: prior conversation history, optional parallel tool
+// result rewriting, and any caller-declared external tools from req.Tools.
+func buildRunOptions(
+	req *openAIRequest,
+	input *runInputMessages,
+) ([]agent.RunOption, error) {
+	runOpts := []agent.RunOption{}
+	if len(input.history) > 0 {
+		runOpts = append(runOpts, agent.WithMessages(input.history))
+	}
+	if len(input.toolMessages) > 1 {
+		runOpts = append(runOpts, withToolResultMessageRewriter(input.toolMessages))
+	}
+	return appendExternalToolRunOption(runOpts, req)
+}

--- a/server/openai/run_input_test.go
+++ b/server/openai/run_input_test.go
@@ -142,6 +142,28 @@ func TestRunInputFromMessages_RejectsMultimodalToolResult(t *testing.T) {
 	assert.ErrorContains(t, err, errToolMessageNotString)
 }
 
+func TestRunInputFromMessages_RejectsMixedTextAndContentPartsToolResult(t *testing.T) {
+	text := "image caption"
+	messages := []model.Message{
+		{Role: model.RoleAssistant, Content: "calling tools"},
+		{
+			Role:    model.RoleTool,
+			ToolID:  "call-1",
+			Content: "result text",
+			ContentParts: []model.ContentPart{
+				{Type: model.ContentTypeImage, Image: &model.Image{URL: "https://example.com/a.png"}},
+				{Type: model.ContentTypeText, Text: &text},
+			},
+		},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, errToolMessageNotString)
+}
+
 func TestWithToolResultMessageRewriter_MergesParallelResults(t *testing.T) {
 	toolMessages := []model.Message{
 		{Role: model.RoleTool, ToolID: "call-1", ToolName: "search", Content: "result 1"},

--- a/server/openai/run_input_test.go
+++ b/server/openai/run_input_test.go
@@ -1,0 +1,166 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestRunInputFromMessages_UserMessage(t *testing.T) {
+	messages := []model.Message{
+		{Role: model.RoleSystem, Content: "sys"},
+		{Role: model.RoleUser, Content: "hello"},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, model.RoleUser, got.inputMessage.Role)
+	assert.Equal(t, "hello", got.inputMessage.Content)
+	require.Len(t, got.history, 1)
+	assert.Equal(t, model.RoleSystem, got.history[0].Role)
+	assert.Empty(t, got.toolMessages)
+}
+
+func TestRunInputFromMessages_AllowsAssistantLast(t *testing.T) {
+	messages := []model.Message{
+		{Role: model.RoleUser, Content: "hi"},
+		{Role: model.RoleAssistant, Content: "reply"},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, model.RoleAssistant, got.inputMessage.Role)
+	assert.Equal(t, "reply", got.inputMessage.Content)
+	require.Len(t, got.history, 1)
+	assert.Equal(t, model.RoleUser, got.history[0].Role)
+}
+
+func TestRunInputFromMessages_SingleToolResult(t *testing.T) {
+	messages := []model.Message{
+		{Role: model.RoleUser, Content: "search"},
+		{
+			Role:      model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{ID: "call-1", Function: model.FunctionDefinitionParam{Name: "search"}}},
+		},
+		{
+			Role:     model.RoleTool,
+			ToolID:   "call-1",
+			ToolName: "search",
+			Content:  "result",
+		},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, model.RoleTool, got.inputMessage.Role)
+	assert.Equal(t, "call-1", got.inputMessage.ToolID)
+	assert.Equal(t, "result", got.inputMessage.Content)
+	require.Len(t, got.history, 2)
+	require.Len(t, got.toolMessages, 1)
+}
+
+func TestRunInputFromMessages_CollectsTailToolMessages(t *testing.T) {
+	messages := []model.Message{
+		{Role: model.RoleTool, ToolID: "old-call", Content: "old"},
+		{Role: model.RoleAssistant, Content: "calling tools"},
+		{Role: model.RoleTool, ToolID: "call-1", ToolName: "search", Content: "result 1"},
+		{Role: model.RoleTool, ToolID: "call-2", ToolName: "lookup", Content: "result 2"},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "call-2", got.inputMessage.ToolID)
+	assert.Equal(t, "result 2", got.inputMessage.Content)
+	require.Len(t, got.history, 2)
+	assert.Equal(t, "old-call", got.history[0].ToolID)
+	assert.Equal(t, model.RoleAssistant, got.history[1].Role)
+	require.Len(t, got.toolMessages, 2)
+	assert.Equal(t, "call-1", got.toolMessages[0].ToolID)
+	assert.Equal(t, "call-2", got.toolMessages[1].ToolID)
+}
+
+func TestRunInputFromMessages_RejectsToolMessageMissingID(t *testing.T) {
+	messages := []model.Message{
+		{Role: model.RoleAssistant, Content: "calling tools"},
+		{Role: model.RoleTool, Content: "result"},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, errToolMessageMissingID)
+}
+
+func TestWithToolResultMessageRewriter_MergesParallelResults(t *testing.T) {
+	toolMessages := []model.Message{
+		{Role: model.RoleTool, ToolID: "call-1", ToolName: "search", Content: "result 1"},
+		{Role: model.RoleTool, ToolID: "call-2", ToolName: "lookup", Content: "result 2"},
+	}
+	opts := agent.NewRunOptions(withToolResultMessageRewriter(toolMessages))
+
+	require.NotNil(t, opts.UserMessageRewriter)
+	currentTurn, err := opts.UserMessageRewriter(
+		context.Background(),
+		&agent.UserMessageRewriteArgs{
+			OriginalMessage: toolMessages[1],
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, currentTurn, 2)
+	assert.Equal(t, "call-1", currentTurn[0].ToolID)
+	assert.Equal(t, "result 1", currentTurn[0].Content)
+	assert.Equal(t, "call-2", currentTurn[1].ToolID)
+	assert.Equal(t, "result 2", currentTurn[1].Content)
+}
+
+func TestWithToolResultMessageRewriter_SkipsSingleToolResult(t *testing.T) {
+	toolMessages := []model.Message{
+		{Role: model.RoleTool, ToolID: "call-1", Content: "result"},
+	}
+	opts := agent.NewRunOptions(withToolResultMessageRewriter(toolMessages))
+
+	assert.Nil(t, opts.UserMessageRewriter)
+}
+
+func TestBuildRunOptions_IncludesToolResultRewriter(t *testing.T) {
+	input := &runInputMessages{
+		inputMessage: model.Message{Role: model.RoleTool, ToolID: "call-2", Content: "result 2"},
+		history: []model.Message{
+			{Role: model.RoleAssistant, Content: "calling tools"},
+		},
+		toolMessages: []model.Message{
+			{Role: model.RoleTool, ToolID: "call-1", Content: "result 1"},
+			{Role: model.RoleTool, ToolID: "call-2", Content: "result 2"},
+		},
+	}
+
+	runOpts, err := buildRunOptions(&openAIRequest{}, input)
+
+	require.NoError(t, err)
+	opts := agent.NewRunOptions(runOpts...)
+	require.NotNil(t, opts.UserMessageRewriter)
+	require.Len(t, opts.Messages, 1)
+	assert.Equal(t, model.RoleAssistant, opts.Messages[0].Role)
+}

--- a/server/openai/run_input_test.go
+++ b/server/openai/run_input_test.go
@@ -11,6 +11,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,14 @@ func TestRunInputFromMessages_UserMessage(t *testing.T) {
 	require.Len(t, got.history, 1)
 	assert.Equal(t, model.RoleSystem, got.history[0].Role)
 	assert.Empty(t, got.toolMessages)
+}
+
+func TestRunInputFromMessages_RejectsEmptyMessages(t *testing.T) {
+	got, err := runInputFromMessages(nil)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, "messages cannot be empty")
 }
 
 func TestRunInputFromMessages_AllowsAssistantLast(t *testing.T) {
@@ -113,6 +122,26 @@ func TestRunInputFromMessages_RejectsToolMessageMissingID(t *testing.T) {
 	assert.ErrorContains(t, err, errToolMessageMissingID)
 }
 
+func TestRunInputFromMessages_RejectsMultimodalToolResult(t *testing.T) {
+	text := "result"
+	messages := []model.Message{
+		{Role: model.RoleAssistant, Content: "calling tools"},
+		{
+			Role:     model.RoleTool,
+			ToolID:   "call-1",
+			ContentParts: []model.ContentPart{
+				{Type: model.ContentTypeText, Text: &text},
+			},
+		},
+	}
+
+	got, err := runInputFromMessages(messages)
+
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, errToolMessageNotString)
+}
+
 func TestWithToolResultMessageRewriter_MergesParallelResults(t *testing.T) {
 	toolMessages := []model.Message{
 		{Role: model.RoleTool, ToolID: "call-1", ToolName: "search", Content: "result 1"},
@@ -144,6 +173,106 @@ func TestWithToolResultMessageRewriter_SkipsSingleToolResult(t *testing.T) {
 	assert.Nil(t, opts.UserMessageRewriter)
 }
 
+func TestWithToolResultMessageRewriter_WrapsExistingRewriter(t *testing.T) {
+	toolMessages := []model.Message{
+		{Role: model.RoleTool, ToolID: "call-1", ToolName: "search", Content: "result 1"},
+		{Role: model.RoleTool, ToolID: "call-2", ToolName: "lookup", Content: "result 2"},
+	}
+	var customRewriterCalled bool
+	opts := agent.NewRunOptions(
+		agent.WithUserMessageRewriter(func(
+			context.Context,
+			*agent.UserMessageRewriteArgs,
+		) ([]model.Message, error) {
+			customRewriterCalled = true
+			return []model.Message{
+				model.NewUserMessage("custom"),
+				model.NewToolMessage("call-2", "lookup", "rewritten duplicate"),
+			}, nil
+		}),
+		withToolResultMessageRewriter(toolMessages),
+	)
+
+	require.NotNil(t, opts.UserMessageRewriter)
+	currentTurn, err := opts.UserMessageRewriter(
+		context.Background(),
+		&agent.UserMessageRewriteArgs{
+			OriginalMessage: toolMessages[1],
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, currentTurn, 3)
+	assert.Equal(t, model.RoleUser, currentTurn[0].Role)
+	assert.Equal(t, "custom", currentTurn[0].Content)
+	assert.Equal(t, "call-1", currentTurn[1].ToolID)
+	assert.Equal(t, "result 1", currentTurn[1].Content)
+	assert.Equal(t, "call-2", currentTurn[2].ToolID)
+	assert.Equal(t, "rewritten duplicate", currentTurn[2].Content)
+	assert.True(t, customRewriterCalled)
+}
+
+func TestWithToolResultMessageRewriter_PropagatesRewriterError(t *testing.T) {
+	toolMessages := []model.Message{
+		{Role: model.RoleTool, ToolID: "call-1", Content: "result 1"},
+		{Role: model.RoleTool, ToolID: "call-2", Content: "result 2"},
+	}
+	opts := agent.NewRunOptions(
+		agent.WithUserMessageRewriter(func(
+			context.Context,
+			*agent.UserMessageRewriteArgs,
+		) ([]model.Message, error) {
+			return nil, errors.New("rewrite failed")
+		}),
+		withToolResultMessageRewriter(toolMessages),
+	)
+
+	_, err := opts.UserMessageRewriter(
+		context.Background(),
+		&agent.UserMessageRewriteArgs{OriginalMessage: toolMessages[1]},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "rewrite failed")
+}
+
+func TestMergeToolResultRewriteMessages_KeepsNonToolMessagesWithToolID(t *testing.T) {
+	rewritten := []model.Message{
+		{Role: model.RoleUser, Content: "context", ToolID: "call-1"},
+		model.NewToolMessage("call-1", "search", "rewritten duplicate"),
+	}
+	toolResults := []model.Message{
+		model.NewToolMessage("call-1", "search", "authoritative result"),
+	}
+
+	got := mergeToolResultRewriteMessages(rewritten, toolResults)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, model.RoleUser, got[0].Role)
+	assert.Equal(t, "context", got[0].Content)
+	assert.Equal(t, "call-1", got[0].ToolID)
+	assert.Equal(t, model.RoleTool, got[1].Role)
+	assert.Equal(t, "rewritten duplicate", got[1].Content)
+	assert.Equal(t, "call-1", got[1].ToolID)
+}
+
+func TestMergeToolResultRewriteMessages_AppendsUnmatchedToolResults(t *testing.T) {
+	rewritten := []model.Message{
+		model.NewUserMessage("context"),
+	}
+	toolResults := []model.Message{
+		model.NewToolMessage("call-1", "search", "result 1"),
+		model.NewToolMessage("call-2", "lookup", "result 2"),
+	}
+
+	got := mergeToolResultRewriteMessages(rewritten, toolResults)
+
+	require.Len(t, got, 3)
+	assert.Equal(t, "context", got[0].Content)
+	assert.Equal(t, "call-1", got[1].ToolID)
+	assert.Equal(t, "result 1", got[1].Content)
+	assert.Equal(t, "call-2", got[2].ToolID)
+	assert.Equal(t, "result 2", got[2].Content)
+}
+
 func TestBuildRunOptions_IncludesToolResultRewriter(t *testing.T) {
 	input := &runInputMessages{
 		inputMessage: model.Message{Role: model.RoleTool, ToolID: "call-2", Content: "result 2"},
@@ -163,4 +292,48 @@ func TestBuildRunOptions_IncludesToolResultRewriter(t *testing.T) {
 	require.NotNil(t, opts.UserMessageRewriter)
 	require.Len(t, opts.Messages, 1)
 	assert.Equal(t, model.RoleAssistant, opts.Messages[0].Role)
+}
+
+func TestBuildRunOptions_IncludesExternalTools(t *testing.T) {
+	input := &runInputMessages{
+		inputMessage: model.Message{Role: model.RoleUser, Content: "search"},
+	}
+	req := &openAIRequest{
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name: "client_search",
+				},
+			},
+		},
+	}
+
+	runOpts, err := buildRunOptions(req, input)
+
+	require.NoError(t, err)
+	opts := agent.NewRunOptions(runOpts...)
+	require.Len(t, opts.ExternalTools, 1)
+	assert.Equal(t, "client_search", opts.ExternalTools[0].Declaration().Name)
+}
+
+func TestBuildRunOptions_SkipsExternalToolsWhenToolChoiceNone(t *testing.T) {
+	input := &runInputMessages{
+		inputMessage: model.Message{Role: model.RoleUser, Content: "search"},
+	}
+	req := &openAIRequest{
+		ToolChoice: openAIToolChoiceNone,
+		Tools: []openAITool{
+			{
+				Type:     "function",
+				Function: openAIFunction{Name: "client_search"},
+			},
+		},
+	}
+
+	runOpts, err := buildRunOptions(req, input)
+
+	require.NoError(t, err)
+	opts := agent.NewRunOptions(runOpts...)
+	assert.Empty(t, opts.ExternalTools)
 }

--- a/server/openai/run_input_test.go
+++ b/server/openai/run_input_test.go
@@ -127,8 +127,8 @@ func TestRunInputFromMessages_RejectsMultimodalToolResult(t *testing.T) {
 	messages := []model.Message{
 		{Role: model.RoleAssistant, Content: "calling tools"},
 		{
-			Role:     model.RoleTool,
-			ToolID:   "call-1",
+			Role:   model.RoleTool,
+			ToolID: "call-1",
 			ContentParts: []model.ContentPart{
 				{Type: model.ContentTypeText, Text: &text},
 			},

--- a/server/openai/server.go
+++ b/server/openai/server.go
@@ -228,8 +228,12 @@ func (s *Server) handleNonStreaming(w http.ResponseWriter, r *http.Request, req 
 		s.writeError(w, errors.New("messages cannot be empty"), errorTypeInvalidRequest, http.StatusBadRequest)
 		return
 	}
-	// Get the last message (user message).
-	userMessage := messages[len(messages)-1]
+	runInput, err := runInputFromMessages(messages)
+	if err != nil {
+		log.WarnfContext(ctx, "openai: failed to build run input: %v", err)
+		s.writeError(w, err, errorTypeInvalidRequest, http.StatusBadRequest)
+		return
+	}
 	// Get session ID from header or generate one.
 	sessionID := r.Header.Get(headerSessionID)
 	if sessionID == "" {
@@ -240,17 +244,18 @@ func (s *Server) handleNonStreaming(w http.ResponseWriter, r *http.Request, req 
 	if userID == "" {
 		userID = defaultUserID
 	}
-	// Build run options with history.
-	runOpts := []agent.RunOption{}
-	if len(messages) > 1 {
-		runOpts = append(runOpts, agent.WithMessages(messages[:len(messages)-1]))
+	// Build run options with history and caller-declared external tools.
+	// Generation config (temperature, max_tokens, etc.) should be set when
+	// creating the agent, not at runtime. OpenAI API parameters are ignored
+	// here for now.
+	runOpts, err := buildRunOptions(req, runInput)
+	if err != nil {
+		log.WarnfContext(ctx, "openai: failed to build run options: %v", err)
+		s.writeError(w, err, errorTypeInvalidRequest, http.StatusBadRequest)
+		return
 	}
-	// Note: Generation config (temperature, max_tokens, etc.) should be set
-	// when creating the agent, not at runtime. OpenAI API parameters are
-	// ignored here for now. Users should configure the agent with desired
-	// generation config when creating it.
 	// Run the agent.
-	eventCh, err := s.runner.Run(ctx, userID, sessionID, userMessage, runOpts...)
+	eventCh, err := s.runner.Run(ctx, userID, sessionID, runInput.inputMessage, runOpts...)
 	if err != nil {
 		log.ErrorfContext(
 			ctx,
@@ -323,8 +328,12 @@ func (s *Server) handleStreaming(w http.ResponseWriter, r *http.Request, req *op
 		s.writeError(w, errors.New("messages cannot be empty"), errorTypeInvalidRequest, http.StatusBadRequest)
 		return
 	}
-	// Get the last message (user message).
-	userMessage := messages[len(messages)-1]
+	runInput, err := runInputFromMessages(messages)
+	if err != nil {
+		log.WarnfContext(ctx, "openai: failed to build run input: %v", err)
+		s.writeError(w, err, errorTypeInvalidRequest, http.StatusBadRequest)
+		return
+	}
 	// Get session ID from header or generate one.
 	sessionID := r.Header.Get(headerSessionID)
 	if sessionID == "" {
@@ -335,17 +344,18 @@ func (s *Server) handleStreaming(w http.ResponseWriter, r *http.Request, req *op
 	if userID == "" {
 		userID = defaultUserID
 	}
-	// Build run options with history.
-	runOpts := []agent.RunOption{}
-	if len(messages) > 1 {
-		runOpts = append(runOpts, agent.WithMessages(messages[:len(messages)-1]))
+	// Build run options with history and caller-declared external tools.
+	// Generation config (temperature, max_tokens, etc.) should be set when
+	// creating the agent, not at runtime. OpenAI API parameters are ignored
+	// here for now.
+	runOpts, err := buildRunOptions(req, runInput)
+	if err != nil {
+		log.WarnfContext(ctx, "openai: failed to build run options: %v", err)
+		s.writeError(w, err, errorTypeInvalidRequest, http.StatusBadRequest)
+		return
 	}
-	// Note: Generation config (temperature, max_tokens, etc.) should be set
-	// when creating the agent, not at runtime. OpenAI API parameters are
-	// ignored here for now. Users should configure the agent with desired
-	// generation config when creating it.
 	// Run the agent.
-	eventCh, err := s.runner.Run(ctx, userID, sessionID, userMessage, runOpts...)
+	eventCh, err := s.runner.Run(ctx, userID, sessionID, runInput.inputMessage, runOpts...)
 	if err != nil {
 		log.ErrorfContext(
 			ctx,

--- a/server/openai/server_test.go
+++ b/server/openai/server_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -1551,4 +1552,506 @@ func TestServer_handleChatCompletions_PathWithSlash(t *testing.T) {
 	s.handleChatCompletions(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// mockRunnerCapturing captures the RunOptions passed to Run and returns
+// the pre-seeded events channel.
+type mockRunnerCapturing struct {
+	events  chan *event.Event
+	gotOpts agent.RunOptions
+	gotMsg  model.Message
+}
+
+func (m *mockRunnerCapturing) Run(
+	ctx context.Context,
+	userID, sessionID string,
+	message model.Message,
+	opts ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	m.gotOpts = agent.NewRunOptions(opts...)
+	m.gotMsg = message
+	return m.events, nil
+}
+
+func (m *mockRunnerCapturing) Close() error {
+	return nil
+}
+
+// newToolCallEventsNonStreaming returns a channel with a single non-streaming
+// event carrying an assistant tool_call message with finish_reason="tool_calls".
+func newToolCallEventsNonStreaming(t *testing.T) chan *event.Event {
+	t.Helper()
+	ch := make(chan *event.Event, 1)
+	finishReason := finishReasonToolCalls
+	ch <- &event.Event{
+		ID: "evt-tool-call",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{
+								ID:   "call-1",
+								Type: "function",
+								Function: model.FunctionDefinitionParam{
+									Name:      "client_search",
+									Arguments: []byte(`{"query":"go"}`),
+								},
+							},
+						},
+					},
+					FinishReason: &finishReason,
+				},
+			},
+			Done:    true,
+			Created: time.Now().Unix(),
+			Usage: &model.Usage{
+				PromptTokens:     8,
+				CompletionTokens: 4,
+				TotalTokens:      12,
+			},
+		},
+	}
+	close(ch)
+	return ch
+}
+
+func externalToolsRequestBody(t *testing.T, stream bool) []byte {
+	t.Helper()
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "search for go"},
+		},
+		Stream: stream,
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:        "client_search",
+					Description: "Search a frontend-owned source.",
+					Parameters: json.RawMessage(
+						`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`,
+					),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return body
+}
+
+func TestServer_handleNonStreaming_InjectsExternalTools(t *testing.T) {
+	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(externalToolsRequestBody(t, false)),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, runner.gotOpts.ExternalTools, 1)
+	decl := runner.gotOpts.ExternalTools[0].Declaration()
+	require.NotNil(t, decl)
+	assert.Equal(t, "client_search", decl.Name)
+	assert.Equal(t, "Search a frontend-owned source.", decl.Description)
+	require.NotNil(t, decl.InputSchema)
+	assert.Equal(t, jsonSchemaTypeObject, decl.InputSchema.Type)
+	require.Contains(t, decl.InputSchema.Properties, "query")
+	assert.False(t, runner.gotOpts.ShouldExecuteTool(
+		context.Background(),
+		runner.gotOpts.ExternalTools[0],
+	))
+}
+
+func TestServer_handleNonStreaming_ToolCallResponse(t *testing.T) {
+	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(externalToolsRequestBody(t, false)),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp openAIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Choices, 1)
+	require.NotNil(t, resp.Choices[0].FinishReason)
+	assert.Equal(t, finishReasonToolCalls, *resp.Choices[0].FinishReason)
+	require.Len(t, resp.Choices[0].Message.ToolCalls, 1)
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	assert.Equal(t, "call-1", tc.ID)
+	assert.Equal(t, "function", tc.Type)
+	assert.Equal(t, "client_search", tc.Function.Name)
+	assert.Equal(t, `{"query":"go"}`, tc.Function.Arguments)
+}
+
+func TestServer_handleStreaming_ToolCallResponse(t *testing.T) {
+	ch := make(chan *event.Event, 2)
+	ch <- &event.Event{
+		ID: "evt-tool-delta",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Delta: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{
+							{
+								ID:   "call-1",
+								Type: "function",
+								Function: model.FunctionDefinitionParam{
+									Name:      "client_search",
+									Arguments: []byte(`{"query":"go"}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			Created: time.Now().Unix(),
+		},
+	}
+	finishReason := finishReasonToolCalls
+	ch <- &event.Event{
+		ID: "evt-tool-final",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Delta:        model.Message{},
+					FinishReason: &finishReason,
+				},
+			},
+			Done:    true,
+			Created: time.Now().Unix(),
+			Usage: &model.Usage{
+				PromptTokens:     8,
+				CompletionTokens: 4,
+				TotalTokens:      12,
+			},
+		},
+	}
+	close(ch)
+
+	runner := &mockRunnerCapturing{events: ch}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(externalToolsRequestBody(t, true)),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, runner.gotOpts.ExternalTools, 1)
+
+	chunks, done := parseSSEChunks(t, w.Body.String())
+	assert.True(t, done, "expected [DONE] marker in SSE stream")
+	// The stream should contain at least one chunk with tool_calls in delta
+	// and end with a chunk whose finish_reason is "tool_calls".
+	var sawToolCallDelta bool
+	var finalFinishReason string
+	for _, c := range chunks {
+		if len(c.Choices) == 0 {
+			continue
+		}
+		if len(c.Choices[0].Delta.ToolCalls) > 0 {
+			sawToolCallDelta = true
+			tc := c.Choices[0].Delta.ToolCalls[0]
+			assert.Equal(t, "call-1", tc.ID)
+			assert.Equal(t, "client_search", tc.Function.Name)
+			assert.Equal(t, `{"query":"go"}`, tc.Function.Arguments)
+		}
+		if c.Choices[0].FinishReason != nil {
+			finalFinishReason = *c.Choices[0].FinishReason
+		}
+	}
+	assert.True(t, sawToolCallDelta, "expected a chunk with delta.tool_calls")
+	assert.Equal(t, finishReasonToolCalls, finalFinishReason)
+}
+
+func TestServer_handleChatCompletions_InvalidToolMissingName(t *testing.T) {
+	s, err := New(WithAgent(&mockAgent{name: "test-agent"}))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "hi"},
+		},
+		Tools: []openAITool{
+			{Type: "function", Function: openAIFunction{Description: "no name"}},
+		},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp openAIError
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, errorTypeInvalidRequest, errResp.Error.Type)
+	assert.Contains(t, errResp.Error.Message, "function.name")
+}
+
+func TestServer_handleChatCompletions_InvalidToolUnsupportedType(t *testing.T) {
+	s, err := New(WithAgent(&mockAgent{name: "test-agent"}))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "hi"},
+		},
+		Stream: true,
+		Tools: []openAITool{
+			{
+				Type:     "code_interpreter",
+				Function: openAIFunction{Name: "ignored"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp openAIError
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Contains(t, errResp.Error.Message, "code_interpreter")
+}
+
+func TestServer_handleNonStreaming_ParallelToolResultResume(t *testing.T) {
+	ch := make(chan *event.Event, 1)
+	finishReason := finishReasonStop
+	ch <- &event.Event{
+		ID: "evt-final",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Message: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "combined answer",
+					},
+					FinishReason: &finishReason,
+				},
+			},
+			Done:    true,
+			Created: time.Now().Unix(),
+			Usage:   &model.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+	}
+	close(ch)
+
+	runner := &mockRunnerCapturing{events: ch}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "assistant", Content: "calling tools"},
+			{
+				Role:       "tool",
+				ToolCallID: "call-1",
+				Name:       "search",
+				Content:    "result 1",
+			},
+			{
+				Role:       "tool",
+				ToolCallID: "call-2",
+				Name:       "lookup",
+				Content:    "result 2",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, model.RoleTool, runner.gotMsg.Role)
+	assert.Equal(t, "call-2", runner.gotMsg.ToolID)
+	require.Len(t, runner.gotOpts.Messages, 1)
+	assert.Equal(t, "assistant", string(runner.gotOpts.Messages[0].Role))
+	require.NotNil(t, runner.gotOpts.UserMessageRewriter)
+
+	currentTurn, err := runner.gotOpts.UserMessageRewriter(
+		context.Background(),
+		&agent.UserMessageRewriteArgs{OriginalMessage: runner.gotMsg},
+	)
+	require.NoError(t, err)
+	require.Len(t, currentTurn, 2)
+	assert.Equal(t, "call-1", currentTurn[0].ToolID)
+	assert.Equal(t, "result 1", currentTurn[0].Content)
+	assert.Equal(t, "call-2", currentTurn[1].ToolID)
+	assert.Equal(t, "result 2", currentTurn[1].Content)
+
+	var resp openAIResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "combined answer", resp.Choices[0].Message.Content)
+}
+
+func TestServer_handleStreaming_ParallelToolResultResume(t *testing.T) {
+	ch := make(chan *event.Event, 2)
+	finishReason := finishReasonStop
+	ch <- &event.Event{
+		ID: "evt-stream",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Delta: model.Message{
+						Role:    model.RoleAssistant,
+						Content: "combined answer",
+					},
+				},
+			},
+			Created: time.Now().Unix(),
+		},
+	}
+	ch <- &event.Event{
+		ID: "evt-final",
+		Response: &model.Response{
+			Choices: []model.Choice{
+				{
+					Delta:        model.Message{},
+					FinishReason: &finishReason,
+				},
+			},
+			Done:    true,
+			Created: time.Now().Unix(),
+			Usage:   &model.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+	}
+	close(ch)
+
+	runner := &mockRunnerCapturing{events: ch}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model:  "gpt-3.5-turbo",
+		Stream: true,
+		Messages: []openAIMessage{
+			{Role: "assistant", Content: "calling tools"},
+			{
+				Role:       "tool",
+				ToolCallID: "call-1",
+				Name:       "search",
+				Content:    "result 1",
+			},
+			{
+				Role:       "tool",
+				ToolCallID: "call-2",
+				Name:       "lookup",
+				Content:    "result 2",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, contentTypeEventStream, w.Header().Get(headerContentType))
+	assert.Equal(t, model.RoleTool, runner.gotMsg.Role)
+	assert.Equal(t, "call-2", runner.gotMsg.ToolID)
+	require.Len(t, runner.gotOpts.Messages, 1)
+	require.NotNil(t, runner.gotOpts.UserMessageRewriter)
+
+	currentTurn, err := runner.gotOpts.UserMessageRewriter(
+		context.Background(),
+		&agent.UserMessageRewriteArgs{OriginalMessage: runner.gotMsg},
+	)
+	require.NoError(t, err)
+	require.Len(t, currentTurn, 2)
+	assert.Equal(t, "call-1", currentTurn[0].ToolID)
+	assert.Equal(t, "call-2", currentTurn[1].ToolID)
+
+	chunks, done := parseSSEChunks(t, w.Body.String())
+	assert.True(t, done)
+	require.NotEmpty(t, chunks)
+	var content string
+	for _, chunk := range chunks {
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		if c, ok := chunk.Choices[0].Delta.Content.(string); ok {
+			content += c
+		}
+	}
+	assert.Equal(t, "combined answer", content)
+}
+
+func TestServer_handleNonStreaming_AssistantLastMessagePrefill(t *testing.T) {
+	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "continue"},
+			{Role: "assistant", Content: "partial "},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, model.RoleAssistant, runner.gotMsg.Role)
+	assert.Equal(t, "partial ", runner.gotMsg.Content)
+	require.Len(t, runner.gotOpts.Messages, 1)
+	assert.Equal(t, model.RoleUser, runner.gotOpts.Messages[0].Role)
+}
+
+// parseSSEChunks extracts openAIChunk payloads from an SSE response body.
+// It returns the parsed chunks and whether the [DONE] marker was seen.
+func parseSSEChunks(t *testing.T, body string) ([]openAIChunk, bool) {
+	t.Helper()
+	var chunks []openAIChunk
+	var sawDone bool
+	for _, block := range strings.Split(body, sseLineEnding) {
+		line := strings.TrimPrefix(strings.TrimSpace(block), sseDataPrefix)
+		if line == "" {
+			continue
+		}
+		if line == sseDoneMarker {
+			sawDone = true
+			continue
+		}
+		var chunk openAIChunk
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			t.Fatalf("failed to unmarshal SSE chunk %q: %v", line, err)
+		}
+		chunks = append(chunks, chunk)
+	}
+	return chunks, sawDone
 }

--- a/server/openai/server_test.go
+++ b/server/openai/server_test.go
@@ -1909,7 +1909,7 @@ func TestServer_handleChatCompletions_InvalidToolMessageMissingID_Streaming(t *t
 	require.NoError(t, err)
 
 	body, err := json.Marshal(openAIRequest{
-		Model: "gpt-3.5-turbo",
+		Model:  "gpt-3.5-turbo",
 		Stream: true,
 		Messages: []openAIMessage{
 			{Role: "assistant", Content: "calling tools"},

--- a/server/openai/server_test.go
+++ b/server/openai/server_test.go
@@ -1671,6 +1671,45 @@ func TestServer_handleNonStreaming_InjectsExternalTools(t *testing.T) {
 	))
 }
 
+func TestServer_handleNonStreaming_SkipsExternalToolsWhenToolChoiceNone(t *testing.T) {
+	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "search for go"},
+		},
+		ToolChoice: openAIToolChoiceNone,
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name:        "client_search",
+					Description: "Search a frontend-owned source.",
+					Parameters: json.RawMessage(
+						`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`,
+					),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(body),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, runner.gotOpts.ExternalTools)
+}
+
 func TestServer_handleNonStreaming_ToolCallResponse(t *testing.T) {
 	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
 	s, err := New(WithRunner(runner))

--- a/server/openai/server_test.go
+++ b/server/openai/server_test.go
@@ -1880,6 +1880,54 @@ func TestServer_handleChatCompletions_InvalidToolUnsupportedType(t *testing.T) {
 	assert.Contains(t, errResp.Error.Message, "code_interpreter")
 }
 
+func TestServer_handleChatCompletions_InvalidToolMessageMissingID(t *testing.T) {
+	s, err := New(WithAgent(&mockAgent{name: "test-agent"}))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "assistant", Content: "calling tools"},
+			{Role: "tool", Content: "result without id"},
+		},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp openAIError
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Equal(t, errorTypeInvalidRequest, errResp.Error.Type)
+	assert.Contains(t, errResp.Error.Message, errToolMessageMissingID)
+}
+
+func TestServer_handleChatCompletions_InvalidToolMessageMissingID_Streaming(t *testing.T) {
+	s, err := New(WithAgent(&mockAgent{name: "test-agent"}))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Stream: true,
+		Messages: []openAIMessage{
+			{Role: "assistant", Content: "calling tools"},
+			{Role: "tool", Content: "result without id"},
+		},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var errResp openAIError
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp))
+	assert.Contains(t, errResp.Error.Message, errToolMessageMissingID)
+}
+
 func TestServer_handleNonStreaming_ParallelToolResultResume(t *testing.T) {
 	ch := make(chan *event.Event, 1)
 	finishReason := finishReasonStop

--- a/server/openai/server_test.go
+++ b/server/openai/server_test.go
@@ -1710,6 +1710,77 @@ func TestServer_handleNonStreaming_SkipsExternalToolsWhenToolChoiceNone(t *testi
 	assert.Empty(t, runner.gotOpts.ExternalTools)
 }
 
+func TestServer_handleNonStreaming_RejectsRequiredToolChoice(t *testing.T) {
+	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "search for go"},
+		},
+		ToolChoice: "required",
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name: "client_search",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(body),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestServer_handleNonStreaming_RejectsForcedFunctionToolChoice(t *testing.T) {
+	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
+	s, err := New(WithRunner(runner))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(openAIRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []openAIMessage{
+			{Role: "user", Content: "search for go"},
+		},
+		ToolChoice: map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "client_search"},
+		},
+		Tools: []openAITool{
+			{
+				Type: "function",
+				Function: openAIFunction{
+					Name: "client_search",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		bytes.NewReader(body),
+	)
+	w := httptest.NewRecorder()
+
+	s.handleChatCompletions(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestServer_handleNonStreaming_ToolCallResponse(t *testing.T) {
 	runner := &mockRunnerCapturing{events: newToolCallEventsNonStreaming(t)}
 	s, err := New(WithRunner(runner))


### PR DESCRIPTION
## What changed

- Map OpenAI Chat Completions `tools` to per-run `agent.WithExternalTools` via declaration-only tools.
- Return `tool_calls` / `finish_reason=tool_calls` without executing tools on the server.
- Support `role=tool` resume, including parallel tool results in one request (aligned with AG-UI).
- Share the same logic for streaming and non-streaming paths.

## Why

The OpenAI adapter already converted tool messages and tool-call responses, but ignored request `tools`, so clients could not declare caller-executed external tools over HTTP. This closes that gap with the same core mechanism AG-UI already uses.

Compatibility: assistant-prefill as the last message is preserved; only trailing `role=tool` messages get special resume handling.

## Testing

- `go test ./server/openai`
- `go test ./server/openai ./runner`

## Notes for reviewers

- Only `tools[].type == "function"` is supported; empty `type` is accepted for SDK compatibility.
- Out of scope: `tool_choice`, websocket/sidecar, permission policy.
- `declarationOnlyTool` / tool-result rewriter logic mirrors `server/agui/runner` and could be deduplicated later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

### New Features
- Added OpenAI `tools` translation into **declaration-only** external tools so the server **does not execute** them; tool calls return `finish_reason=tool_calls`.
- Implemented shared “run input” handling for both **non-streaming** and **streaming** chat completions.
- Added `role=tool` resume support, including **multiple parallel** tool results in a single follow-up request.
- Preserved assistant last-message prefill behavior.

### Validation / Bug Fixes
- Tightened request validation: unsupported tool types, missing `function.name`, invalid `function.parameters`, malformed `role=tool` messages, and invalid tool-result content.

### Documentation
- Updated manual tool execution docs and clarified `tool_choice` handling.

### Tests
- Expanded unit and integration coverage for tool parsing, wiring, resume flows, and streaming output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->