### PR TITLE
openclaw/app: harden dynamic web research

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -298,7 +298,12 @@ const (
 		"errors and the user has not provided credentials, stop " +
 		"retrying that blocked path; use search, fetch, metadata, " +
 		"or the evidence already available to complete the task or " +
-		"state the exact blocker. " +
+		"state the exact blocker. When searches return no useful " +
+		"results or a source is blocked, diversify instead of " +
+		"repeating the same constrained query: remove site/date " +
+		"filters, search distinctive entities plus the requested " +
+		"fact, and try credible mirrors, metadata, publisher, " +
+		"or press-release pages. " +
 		artifactCompletionRule + " " +
 		"Use the available tool path to complete the request " +
 		"in this turn. " +
@@ -432,7 +437,10 @@ const (
 		"lookup or static page fetches. Give the sub-agent a " +
 		"clear instruction to inspect successful web_fetch results " +
 		"first and to report when a result is truncated instead " +
-		"of looping through browser snapshots. Give the sub-agent a " +
+		"of looping through browser snapshots. For blocked or empty " +
+		"web research, ask the worker to diversify queries and " +
+		"evidence sources before returning the exact blocker. Give " +
+		"the sub-agent a " +
 		"self-contained request " +
 		"and ask it to complete the concrete action or return the " +
 		"exact blocker. Answer directly only when no tool work is " +
@@ -2853,6 +2861,7 @@ func newAgent(
 		cfg.MemoryFileStore,
 		cfg.StateDir,
 	)
+	registerDynamicAgentBlockerCallback(callbacks)
 	callbacks.RegisterToolResultMessages(openClawToolResultMessages)
 
 	exec := cfg.codeExecutor

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -2812,6 +2812,16 @@ func TestOpenClawToolingGuidancePrefersSearchTools(t *testing.T) {
 		openClawToolingGuidance,
 		"stop retrying that blocked path",
 	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"diversify instead of repeating the same constrained query",
+	)
+	require.Contains(
+		t,
+		openClawToolingGuidance,
+		"try credible mirrors, metadata, publisher, or press-release pages",
+	)
 }
 
 func TestOpenClawDeferredToolingGuidancePairsBrowserWithSearch(
@@ -2834,6 +2844,59 @@ func TestOpenClawDeferredToolingGuidancePairsBrowserWithSearch(
 		openClawDeferredToolingGuidance,
 		"inspect successful web_fetch results first",
 	)
+	require.Contains(
+		t,
+		openClawDeferredToolingGuidance,
+		"diversify queries and evidence sources",
+	)
+}
+
+func TestDynamicAgentBlockerCallbackReplacesBudgetErrors(t *testing.T) {
+	t.Parallel()
+
+	callbacks := tool.NewCallbacks()
+	registerDynamicAgentBlockerCallback(callbacks)
+	result, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{
+			ToolName: agenttool.DefaultDynamicToolName,
+			Error:    errors.New("agent error: max LLM calls (45) exceeded"),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, dynamicAgentLLMBudgetBlocker, result.CustomResult)
+}
+
+func TestDynamicAgentBlockerCallbackReplacesTimeoutErrors(t *testing.T) {
+	t.Parallel()
+
+	callbacks := tool.NewCallbacks()
+	registerDynamicAgentBlockerCallback(callbacks)
+	result, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{
+			ToolName: agenttool.DefaultDynamicToolName,
+			Error:    context.DeadlineExceeded,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, dynamicAgentTimeoutBlocker, result.CustomResult)
+}
+
+func TestDynamicAgentBlockerCallbackKeepsOtherToolErrors(t *testing.T) {
+	t.Parallel()
+
+	callbacks := tool.NewCallbacks()
+	registerDynamicAgentBlockerCallback(callbacks)
+	result, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{
+			ToolName: "web_fetch",
+			Error:    errors.New("max LLM calls (45) exceeded"),
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, result.CustomResult)
 }
 
 func TestOpenClawToolingGuidanceAvoidsSystemPackageManagers(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -2867,6 +2867,29 @@ func TestDynamicAgentBlockerCallbackReplacesBudgetErrors(t *testing.T) {
 	require.Equal(t, dynamicAgentLLMBudgetBlocker, result.CustomResult)
 }
 
+func TestDynamicAgentBlockerCallbackReplacesBudgetStopErrors(t *testing.T) {
+	t.Parallel()
+
+	callbacks := tool.NewCallbacks(tool.WithContinueOnError(true))
+	registerDynamicAgentBlockerCallback(callbacks)
+	callbacks.RegisterAfterTool(func(
+		_ context.Context,
+		_ *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		t.Fatal("budget blocker should stop later callbacks")
+		return nil, nil
+	})
+	result, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{
+			ToolName: agenttool.DefaultDynamicToolName,
+			Error:    agent.NewStopError("max LLM calls (45) exceeded"),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, dynamicAgentLLMBudgetBlocker, result.CustomResult)
+}
+
 func TestDynamicAgentBlockerCallbackReplacesTimeoutErrors(t *testing.T) {
 	t.Parallel()
 
@@ -2881,6 +2904,22 @@ func TestDynamicAgentBlockerCallbackReplacesTimeoutErrors(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, dynamicAgentTimeoutBlocker, result.CustomResult)
+}
+
+func TestDynamicAgentBlockerCallbackIgnoresNonBudgetStopErrors(t *testing.T) {
+	t.Parallel()
+
+	callbacks := tool.NewCallbacks()
+	registerDynamicAgentBlockerCallback(callbacks)
+	result, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{
+			ToolName: agenttool.DefaultDynamicToolName,
+			Error:    agent.NewStopError("worker stopped by user"),
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, result.CustomResult)
 }
 
 func TestDynamicAgentBlockerCallbackKeepsOtherToolErrors(t *testing.T) {

--- a/openclaw/app/dynamic_agent_callback.go
+++ b/openclaw/app/dynamic_agent_callback.go
@@ -1,0 +1,78 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
+)
+
+const (
+	dynamicAgentLLMBudgetBlocker = "dynamic_agent stopped before " +
+		"completing because its LLM-call budget was exhausted. Treat " +
+		"this as a recoverable tool blocker: use already collected " +
+		"evidence, narrow the request, or try direct tools; do not " +
+		"repeat the same broad worker request."
+	dynamicAgentTimeoutBlocker = "dynamic_agent stopped before completing " +
+		"because its timeout was reached. Treat this as a recoverable " +
+		"tool blocker: use already collected evidence, narrow the " +
+		"request, or try direct tools; do not repeat the same broad " +
+		"worker request."
+)
+
+func registerDynamicAgentBlockerCallback(callbacks *tool.Callbacks) {
+	if callbacks == nil {
+		return
+	}
+	callbacks.RegisterAfterTool(func(
+		_ context.Context,
+		args *tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		if args == nil ||
+			args.ToolName != agenttool.DefaultDynamicToolName ||
+			args.Error == nil {
+			return nil, nil
+		}
+		if dynamicAgentStoppedByLLMBudget(args.Error) {
+			return &tool.AfterToolResult{
+				CustomResult: dynamicAgentLLMBudgetBlocker,
+			}, nil
+		}
+		if dynamicAgentStoppedByTimeout(args.Error) {
+			return &tool.AfterToolResult{
+				CustomResult: dynamicAgentTimeoutBlocker,
+			}, nil
+		}
+		return nil, nil
+	})
+}
+
+func dynamicAgentStoppedByLLMBudget(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(
+		strings.ToLower(err.Error()),
+		"max llm calls",
+	)
+}
+
+func dynamicAgentStoppedByTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(
+		strings.ToLower(err.Error()),
+		"deadline exceeded",
+	)
+}

--- a/openclaw/app/dynamic_agent_callback.go
+++ b/openclaw/app/dynamic_agent_callback.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"strings"
 
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	agenttool "trpc.group/trpc-go/trpc-agent-go/tool/agent"
 )
@@ -60,6 +61,12 @@ func registerDynamicAgentBlockerCallback(callbacks *tool.Callbacks) {
 func dynamicAgentStoppedByLLMBudget(err error) bool {
 	if err == nil {
 		return false
+	}
+	if stopErr, ok := agent.AsStopError(err); ok {
+		return strings.Contains(
+			strings.ToLower(stopErr.Message),
+			"max llm calls",
+		)
 	}
 	return strings.Contains(
 		strings.ToLower(err.Error()),


### PR DESCRIPTION
## Summary

- add OpenClaw guidance to diversify web research when search results are empty or blocked
- convert dynamic_agent LLM-budget and timeout failures into recoverable tool blocker messages
- keep unrelated tool errors fatal so real failures are not hidden

## Validation

- (cd openclaw && go test ./app -count=1)
