### PR TITLE
fix(model): use full MIME type in image data URL construction

### DIFF
--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -674,7 +675,11 @@ func imageToURLOrBase64(image *model.Image) string {
 	if image.URL != "" {
 		return image.URL
 	}
-	return "data:image/" + image.Format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
+	format := image.Format
+	if strings.HasPrefix(format, "image/") {
+		return "data:" + format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
+	}
+	return "data:image/" + format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
 }
 
 func audioToBase64(audio *model.Audio) string {

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -1462,6 +1462,14 @@ func TestImageToURLOrBase64(t *testing.T) {
 			},
 			want: "data:image/png;base64,dGVzdA==",
 		},
+		{
+			name: "with full MIME format",
+			image: &model.Image{
+				Format: "image/png",
+				Data:   []byte("test"),
+			},
+			want: "data:image/png;base64,dGVzdA==",
+		},
 	}
 
 	for _, tt := range tests {

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1335,7 +1335,11 @@ func imageToURLOrBase64(image *model.Image) string {
 	if image.URL != "" {
 		return image.URL
 	}
-	return "data:image/" + image.Format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
+	format := image.Format
+	if strings.HasPrefix(format, "image/") {
+		return "data:" + format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
+	}
+	return "data:image/" + format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
 }
 
 func isProviderFileID(fileID string) bool {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -9761,3 +9761,42 @@ func TestModel_GenerateContentIter_EmbeddedErrorHTTP200(t *testing.T) {
 	assert.Equal(t, model.ErrorTypeAPIError, resp.Error.Type)
 	assert.True(t, resp.Done)
 }
+
+func TestImageToURLOrBase64(t *testing.T) {
+	tests := []struct {
+		name  string
+		image *model.Image
+		want  string
+	}{
+		{
+			name: "with URL",
+			image: &model.Image{
+				URL: "http://example.com/image.jpg",
+			},
+			want: "http://example.com/image.jpg",
+		},
+		{
+			name: "with extension format",
+			image: &model.Image{
+				Format: "png",
+				Data:   []byte("test"),
+			},
+			want: "data:image/png;base64,dGVzdA==",
+		},
+		{
+			name: "with full MIME format",
+			image: &model.Image{
+				Format: "image/png",
+				Data:   []byte("test"),
+			},
+			want: "data:image/png;base64,dGVzdA==",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := imageToURLOrBase64(tt.image)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Use the full MIME type string (e.g. `image/png`) when building `data:` URLs for multimodal image parts in OpenAI and Hunyuan converters, without prepending `image/` when the format already includes it.

Fixes #2092

## Related

- Fork: sks/trpc-agent-go#6

## Test plan

- [x] `go test ./model/openai/... ./model/hunyuan/... -race`

Made with [Cursor](https://cursor.com)