### PR TITLE
memoryutils: export helpers and adopt in built-in backends

### DIFF
--- a/memory/inmemory/service.go
+++ b/memory/inmemory/service.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -139,10 +140,10 @@ func createMemoryEntry(
 		Topics:      topics,
 		LastUpdated: &now,
 	}
-	imemory.ApplyMetadata(memoryObj, ep)
+	memoryutils.ApplyMetadata(memoryObj, ep)
 
 	return &memory.Entry{
-		ID:        imemory.GenerateMemoryID(memoryObj, appName, userID), // Generate ID.
+		ID:        memoryutils.GenerateMemoryID(memoryObj, appName, userID), // Generate ID.
 		AppName:   appName,
 		UserID:    userID,
 		Memory:    memoryObj,
@@ -206,7 +207,7 @@ func (s *MemoryService) UpdateMemory(ctx context.Context, memoryKey memory.Key, 
 
 	now := time.Now()
 	ep := memory.ResolveUpdateOptions(opts)
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		memoryEntry,
 		memoryKey.AppName,
 		memoryKey.UserID,

--- a/memory/memoryutils/apply.go
+++ b/memory/memoryutils/apply.go
@@ -1,0 +1,42 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package memoryutils
+
+import (
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
+)
+
+// ApplyMetadata merges episodic metadata from memory.AddMemory options into mem,
+// then normalizes fields. External persistence backends (e.g. custom SQL adapters)
+// should use this on add paths so behavior matches built-in memory services.
+func ApplyMetadata(mem *memory.Memory, ep *memory.Metadata) {
+	imemory.ApplyMetadata(mem, ep)
+}
+
+// ApplyMetadataPatch merges update-time metadata into mem. Zero values on ep mean
+// "leave existing stored metadata unchanged" for that field.
+func ApplyMetadataPatch(mem *memory.Memory, ep *memory.Metadata) {
+	imemory.ApplyMetadataPatch(mem, ep)
+}
+
+// ApplyMemoryUpdate applies content, topics, and optional metadata in-place on
+// entry and returns the canonical memory ID after normalization (same contract as
+// the MySQL/Postgres/SQLite memory services).
+func ApplyMemoryUpdate(
+	entry *memory.Entry,
+	appName, userID, memoryStr string,
+	topics []string,
+	ep *memory.Metadata,
+	now time.Time,
+) string {
+	return imemory.ApplyMemoryUpdate(entry, appName, userID, memoryStr, topics, ep, now)
+}

--- a/memory/memoryutils/identity.go
+++ b/memory/memoryutils/identity.go
@@ -1,0 +1,40 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package memoryutils provides identity and mutation helpers for memory records:
+// stable IDs, kind normalization, participant metadata, and ApplyMetadata-style
+// entry updates shared with built-in persistence backends.
+package memoryutils
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
+)
+
+// GenerateMemoryID generates a unique ID for memory based on content,
+// user context, and canonical episodic metadata.
+// Topics are intentionally excluded so that topic drift does not change
+// identity, while event metadata is included so distinct episodes with
+// the same text do not collapse into a single upsert key.
+//
+// External persistence backends should use this function so row keys match
+// built-in memory service implementations.
+func GenerateMemoryID(mem *memory.Memory, appName, userID string) string {
+	return imemory.GenerateMemoryID(mem, appName, userID)
+}
+
+// EffectiveKind returns the runtime memory kind. Legacy records that did not
+// persist kind explicitly are treated as facts.
+func EffectiveKind(mem *memory.Memory) memory.Kind {
+	return imemory.EffectiveKind(mem)
+}
+
+// NormalizeMemory canonicalizes memory metadata for runtime use and new writes.
+func NormalizeMemory(mem *memory.Memory) {
+	imemory.NormalizeMemory(mem)
+}

--- a/memory/mysql/service.go
+++ b/memory/mysql/service.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mysql"
@@ -152,9 +153,9 @@ func (s *Service) AddMemory(ctx context.Context, userKey memory.UserKey,
 		Topics:      topics,
 		LastUpdated: &now,
 	}
-	imemory.ApplyMetadata(mem, ep)
+	memoryutils.ApplyMetadata(mem, ep)
 	entry := &memory.Entry{
-		ID:        imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID),
+		ID:        memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID),
 		AppName:   userKey.AppName,
 		Memory:    mem,
 		UserID:    userKey.UserID,
@@ -212,7 +213,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key,
 	imemory.NormalizeEntry(entry)
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,

--- a/memory/mysqlvec/service.go
+++ b/memory/mysqlvec/service.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mysql"
@@ -165,8 +166,8 @@ func (s *Service) AddMemory(
 		Topics:      topics,
 		LastUpdated: &now,
 	}
-	imemory.ApplyMetadata(mem, ep)
-	memoryID := imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
+	memoryutils.ApplyMetadata(mem, ep)
+	memoryID := memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
 
 	topicsJSON, err := json.Marshal(topics)
 	if err != nil {
@@ -300,7 +301,7 @@ func (s *Service) UpdateMemory(
 	}
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -1141,7 +1142,7 @@ func buildEntry(
 	if location.Valid {
 		mem.Location = location.String
 	}
-	imemory.NormalizeMemory(mem)
+	memoryutils.NormalizeMemory(mem)
 
 	return &memory.Entry{
 		ID:        memoryID,
@@ -1167,7 +1168,7 @@ func resolveMetadata(mem *memory.Memory) metadataSQLFields {
 	if mem == nil {
 		return f
 	}
-	imemory.NormalizeMemory(mem)
+	memoryutils.NormalizeMemory(mem)
 	f.kind = string(mem.Kind)
 	f.eventTime = mem.EventTime
 	if len(mem.Participants) > 0 {

--- a/memory/mysqlvec/service_test.go
+++ b/memory/mysqlvec/service_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	"trpc.group/trpc-go/trpc-agent-go/memory/extractor"
-	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mysql"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -700,7 +700,7 @@ func TestService_UpdateMemory_SameID_UpdateInPlace(t *testing.T) {
 
 	// Pre-compute the ID that GenerateMemoryID will produce for this content+topics+app+user.
 	mem := &memory.Memory{Memory: "same content", Topics: []string{"same"}}
-	correctID := imemory.GenerateMemoryID(mem, "app", "u1")
+	correctID := memoryutils.GenerateMemoryID(mem, "app", "u1")
 
 	now := time.Now()
 	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: correctID}
@@ -892,7 +892,7 @@ func TestService_UpdateMemory_InPlace_SQLError(t *testing.T) {
 	defer svc.Close()
 
 	mem := &memory.Memory{Memory: "same", Topics: []string{"s"}}
-	correctID := imemory.GenerateMemoryID(mem, "app", "u1")
+	correctID := memoryutils.GenerateMemoryID(mem, "app", "u1")
 	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: correctID}
 	now := time.Now()
 	mock.ExpectQuery("SELECT memory_id").
@@ -914,7 +914,7 @@ func TestService_UpdateMemory_InPlace_RowsAffectedError(t *testing.T) {
 	defer svc.Close()
 
 	mem := &memory.Memory{Memory: "same", Topics: []string{"s"}}
-	correctID := imemory.GenerateMemoryID(mem, "app", "u1")
+	correctID := memoryutils.GenerateMemoryID(mem, "app", "u1")
 	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: correctID}
 	now := time.Now()
 	mock.ExpectQuery("SELECT memory_id").
@@ -936,7 +936,7 @@ func TestService_UpdateMemory_InPlace_ZeroRowsAffected(t *testing.T) {
 	defer svc.Close()
 
 	mem := &memory.Memory{Memory: "same", Topics: []string{"s"}}
-	correctID := imemory.GenerateMemoryID(mem, "app", "u1")
+	correctID := memoryutils.GenerateMemoryID(mem, "app", "u1")
 	key := memory.Key{AppName: "app", UserID: "u1", MemoryID: correctID}
 	now := time.Now()
 	mock.ExpectQuery("SELECT memory_id").

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/pgvector/pgvector-go"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
@@ -203,8 +204,8 @@ func (s *Service) AddMemory(
 		Topics:      topics,
 		LastUpdated: &now,
 	}
-	imemory.ApplyMetadata(mem, ep)
-	memoryID := imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
+	memoryutils.ApplyMetadata(mem, ep)
+	memoryID := memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
 
 	// Convert embedding to pgvector format.
 	vector := pgvector.NewVector(convertToFloat32(embedding))
@@ -372,7 +373,7 @@ func (s *Service) UpdateMemory(
 
 	now := time.Now()
 	vector := pgvector.NewVector(convertToFloat32(embedding))
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,
@@ -1030,7 +1031,7 @@ func buildEntry(
 	if location.Valid {
 		mem.Location = location.String
 	}
-	imemory.NormalizeMemory(mem)
+	memoryutils.NormalizeMemory(mem)
 
 	return &memory.Entry{
 		ID:        memoryID,
@@ -1068,7 +1069,7 @@ func resolveMetadata(mem *memory.Memory) metadataSQLFields {
 	if mem == nil {
 		return f
 	}
-	imemory.NormalizeMemory(mem)
+	memoryutils.NormalizeMemory(mem)
 	f.kind = string(mem.Kind)
 	f.eventTime = mem.EventTime
 	if len(mem.Participants) > 0 {

--- a/memory/postgres/service.go
+++ b/memory/postgres/service.go
@@ -20,6 +20,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
@@ -206,9 +207,9 @@ func (s *Service) AddMemory(ctx context.Context, userKey memory.UserKey, memoryS
 		LastUpdated: &now,
 	}
 	ep := memory.ResolveAddOptions(opts)
-	imemory.ApplyMetadata(mem, ep)
+	memoryutils.ApplyMetadata(mem, ep)
 	entry := &memory.Entry{
-		ID:        imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID),
+		ID:        memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID),
 		AppName:   userKey.AppName,
 		Memory:    mem,
 		UserID:    userKey.UserID,
@@ -280,7 +281,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 
 	now := time.Now()
 	ep := memory.ResolveUpdateOptions(opts)
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,

--- a/memory/redis/service.go
+++ b/memory/redis/service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/redis"
@@ -147,9 +148,9 @@ func (s *Service) AddMemory(ctx context.Context, userKey memory.UserKey, memoryS
 		LastUpdated: &now,
 	}
 	ep := memory.ResolveAddOptions(opts)
-	imemory.ApplyMetadata(mem, ep)
+	memoryutils.ApplyMetadata(mem, ep)
 	entry := &memory.Entry{
-		ID:        imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID),
+		ID:        memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID),
 		AppName:   userKey.AppName,
 		Memory:    mem,
 		UserID:    userKey.UserID,
@@ -189,7 +190,7 @@ func (s *Service) UpdateMemory(ctx context.Context, memoryKey memory.Key, memory
 	imemory.NormalizeEntry(entry)
 	now := time.Now()
 	ep := memory.ResolveUpdateOptions(opts)
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,

--- a/memory/sqlite/service.go
+++ b/memory/sqlite/service.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -122,8 +123,8 @@ func (s *Service) AddMemory(
 		Topics:      topics,
 		LastUpdated: &now,
 	}
-	imemory.ApplyMetadata(mem, ep)
-	memoryID := imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
+	memoryutils.ApplyMetadata(mem, ep)
+	memoryID := memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
 
 	if s.opts.memoryLimit > 0 {
 		deletedAt, exists, err := s.getDeletedAt(ctx, userKey, memoryID)
@@ -260,7 +261,7 @@ func (s *Service) UpdateMemory(
 	}
 
 	now := time.Now()
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,

--- a/memory/sqlitevec/service.go
+++ b/memory/sqlitevec/service.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/memoryutils"
 	imemory "trpc.group/trpc-go/trpc-agent-go/memory/internal/memory"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -165,8 +166,8 @@ func (s *Service) AddMemory(
 		Topics:      topics,
 		LastUpdated: &now,
 	}
-	imemory.ApplyMetadata(mem, ep)
-	memoryID := imemory.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
+	memoryutils.ApplyMetadata(mem, ep)
+	memoryID := memoryutils.GenerateMemoryID(mem, userKey.AppName, userKey.UserID)
 
 	topicsJSON, err := json.Marshal(topics)
 	if err != nil {
@@ -413,7 +414,7 @@ FROM %s WHERE app_name = ? AND user_id = ? AND memory_id = ?`
 
 	now := time.Now()
 	updatedAtNs := now.UTC().UnixNano()
-	newID := imemory.ApplyMemoryUpdate(
+	newID := memoryutils.ApplyMemoryUpdate(
 		entry,
 		memoryKey.AppName,
 		memoryKey.UserID,


### PR DESCRIPTION
## Summary

Export `memory/memoryutils` as the public API for memory identity and metadata helpers (`ApplyMetadata`, `ApplyMemoryUpdate`, `GenerateMemoryID`, `EffectiveKind`, `NormalizeMemory`).

Built-in persistence backends (postgres, mysql, redis, sqlite, inmemory, pgvector, mysqlvec, sqlitevec) now call `memoryutils` instead of `internal/memory` directly, so external `memory.Service` implementations (e.g. GORM/SQL adapters) use the same canonical path as in-tree services.

## Related

- Fork: sks/trpc-agent-go#10
- StackGen consumer: Genie `pkg/db/memory_store.go`

## Test plan

- [x] `go test ./memory/... -count=1`
- [x] `go test ./memory/{postgres,mysql,redis,sqlite,pgvector,mysqlvec,sqlitevec}/... -race -count=1`

Made with [Cursor](https://cursor.com)