### PR TITLE
fix(model/gemini): fail fast when message conversion yields empty Contents

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -55,6 +55,7 @@ const (
 	queuedUserAuthor          = "user"
 
 	errMsgNoModelResponse = "no response received from model"
+	errMsgNoLLMMessages   = "no messages available for LLM call"
 
 	flowRunPanicLogFmt = log.PanicPrefix + " Flow execution panic (invocation: %s, " +
 		"agent: %s): %v\n%s"
@@ -2353,6 +2354,9 @@ func (f *Flow) generateContentSeq(
 	llmRequest *model.Request,
 	callModel model.Model,
 ) (model.Seq[*model.Response], error) {
+	if llmRequest == nil || len(llmRequest.Messages) == 0 {
+		return nil, errors.New(errMsgNoLLMMessages)
+	}
 	ctx, span, started := startLatencySpan(
 		ctx,
 		invocation,

--- a/internal/flow/llmflow/llmflow_endinvocation_test.go
+++ b/internal/flow/llmflow/llmflow_endinvocation_test.go
@@ -106,8 +106,10 @@ func (p *endOnFirstChunkProcessor) ProcessResponse(ctx context.Context, inv *age
 func TestStreaming_BreaksWhenEndInvocationSet(t *testing.T) {
 	// Arrange: model returns two chunks; response processor ends invocation on first chunk.
 	respProcs := []flow.ResponseProcessor{&endOnFirstChunkProcessor{}}
-	f := New(nil, respProcs, Options{})
-	inv := &agent.Invocation{InvocationID: "inv-stream", AgentName: "agent-stream", Model: &twoChunkModel{}}
+	f := newRunFlow(respProcs)
+	inv := runInvocationWithUserMessage(&twoChunkModel{})
+	inv.InvocationID = "inv-stream"
+	inv.AgentName = "agent-stream"
 
 	// Act
 	ch, err := f.Run(context.Background(), inv)

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -588,7 +588,9 @@ func TestProcessStreamingResponses_RepairsToolCallArgumentsWhenEnabled(t *testin
 
 func TestRunOneStep_DisableTracingSkipsSpanCreation(t *testing.T) {
 	recorder := useSpanRecorder(t)
-	f := New(nil, nil, Options{})
+	f := New([]flow.RequestProcessor{&seedMessagesRequestProcessor{
+		messages: []model.Message{model.NewUserMessage("test")},
+	}}, nil, Options{})
 	inv := agent.NewInvocation(
 		agent.WithInvocationID("inv-disable-tracing"),
 		agent.WithInvocationRunOptions(agent.RunOptions{
@@ -1823,6 +1825,35 @@ func (m *mockAgentWithTools) FindSubAgent(name string) agent.Agent {
 	return nil
 }
 
+// testLLMRequest returns a minimal request that passes the empty-messages guard.
+func testLLMRequest() *model.Request {
+	return &model.Request{
+		Messages: []model.Message{model.NewUserMessage("test")},
+	}
+}
+
+
+func newRunFlow(respProcessors []flow.ResponseProcessor, opts ...Options) *Flow {
+	opt := Options{}
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	return New(
+		[]flow.RequestProcessor{&seedMessagesRequestProcessor{
+			messages: []model.Message{model.NewUserMessage("test")},
+		}},
+		respProcessors,
+		opt,
+	)
+}
+
+func runInvocationWithUserMessage(m model.Model, opts ...agent.InvocationOptions) *agent.Invocation {
+	opts = append(opts, agent.WithInvocationModel(m))
+	inv := agent.NewInvocation(opts...)
+	inv.Message = model.NewUserMessage("test")
+	return inv
+}
+
 // mockModel implements model.Model for testing
 type mockModel struct {
 	ShouldError bool
@@ -2295,20 +2326,17 @@ func TestModelCallbacks_BeforeSetsContext_AfterSeesValue(t *testing.T) {
 			return nil, nil
 		})
 
-	llmFlow := New(nil, nil, Options{ModelCallbacks: modelCallbacks})
-	invocation := agent.NewInvocation(
-		agent.WithInvocationModel(&mockModel{
-			responses: []*model.Response{
-				{
-					Done: true,
-					Choices: []model.Choice{
-						{Message: model.NewAssistantMessage("ok")},
-					},
+	llmFlow := newRunFlow(nil, Options{ModelCallbacks: modelCallbacks})
+	invocation := runInvocationWithUserMessage(&mockModel{
+		responses: []*model.Response{
+			{
+				Done: true,
+				Choices: []model.Choice{
+					{Message: model.NewAssistantMessage("ok")},
 				},
 			},
-		}),
-		agent.WithInvocationSession(&session.Session{ID: "test-session"}),
-	)
+		},
+	}, agent.WithInvocationSession(&session.Session{ID: "test-session"}))
 
 	eventChan, err := llmFlow.Run(ctx, invocation)
 	require.NoError(t, err)
@@ -2339,13 +2367,10 @@ func TestModelCBs_AfterOverride(t *testing.T) {
 		},
 	)
 
-	llmFlow := New(nil, nil, Options{ModelCallbacks: modelCallbacks})
-	invocation := agent.NewInvocation(
-		agent.WithInvocationModel(&mockModel{
-			responses: []*model.Response{{ID: "original"}},
-		}),
-		agent.WithInvocationSession(&session.Session{ID: "test-session"}),
-	)
+	llmFlow := newRunFlow(nil, Options{ModelCallbacks: modelCallbacks})
+	invocation := runInvocationWithUserMessage(&mockModel{
+		responses: []*model.Response{{ID: "original"}},
+	}, agent.WithInvocationSession(&session.Session{ID: "test-session"}))
 	eventChan, err := llmFlow.Run(ctx, invocation)
 	require.NoError(t, err)
 	var events []*event.Event
@@ -2375,13 +2400,10 @@ func TestModelCallbacks_AfterError(t *testing.T) {
 		},
 	)
 
-	llmFlow := New(nil, nil, Options{ModelCallbacks: modelCallbacks})
-	invocation := agent.NewInvocation(
-		agent.WithInvocationModel(&mockModel{
-			responses: []*model.Response{{ID: "original"}},
-		}),
-		agent.WithInvocationSession(&session.Session{ID: "test-session"}),
-	)
+	llmFlow := newRunFlow(nil, Options{ModelCallbacks: modelCallbacks})
+	invocation := runInvocationWithUserMessage(&mockModel{
+		responses: []*model.Response{{ID: "original"}},
+	}, agent.WithInvocationSession(&session.Session{ID: "test-session"}))
 	eventChan, err := llmFlow.Run(ctx, invocation)
 	require.NoError(t, err)
 	var events []*event.Event
@@ -2591,7 +2613,7 @@ func TestFlow_GenerateContentSeq_UsesIterModel(t *testing.T) {
 	}
 	inv := agent.NewInvocation(agent.WithInvocationModel(iterModel))
 
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	require.True(t, iterModel.GenerateContentIterCalled)
 	require.False(t, iterModel.GenerateContentCalled)
@@ -2613,7 +2635,7 @@ func TestFlow_GenerateContentSeq_AssignsGeneratedIDForStreamingResponses(t *test
 			{Object: model.ObjectTypeChatCompletion, Done: true},
 		},
 	}))
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	var responses []*model.Response
 	seq(func(resp *model.Response) bool {
@@ -2633,7 +2655,7 @@ func TestFlow_GenerateContentSeq_PreservesActiveResponseIDWhenLaterChunksMissIt(
 			{Object: model.ObjectTypeChatCompletion, Done: true},
 		},
 	}))
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	var responses []*model.Response
 	seq(func(resp *model.Response) bool {
@@ -2653,7 +2675,7 @@ func TestFlow_GenerateContentSeq_KeepsGeneratedIDWhenRealIDArrivesLate(t *testin
 			{ID: "real-1", Object: model.ObjectTypeChatCompletion, Done: true},
 		},
 	}))
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	var responses []*model.Response
 	seq(func(resp *model.Response) bool {
@@ -2675,7 +2697,7 @@ func TestFlow_GenerateContentSeq_ResetsGeneratedIDAfterFinalResponse(t *testing.
 			{Object: model.ObjectTypeChatCompletion, Done: true},
 		},
 	}))
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	var responses []*model.Response
 	seq(func(resp *model.Response) bool {
@@ -2697,7 +2719,7 @@ func TestFlow_GenerateContentSeq_IterModelAssignsGeneratedIDForStreamingResponse
 		},
 	}
 	inv := agent.NewInvocation(agent.WithInvocationModel(iterModel))
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	require.True(t, iterModel.GenerateContentIterCalled)
 	var responses []*model.Response
@@ -2745,7 +2767,7 @@ func TestFlow_GenerateContentSeq_IterModelError(t *testing.T) {
 	}
 	inv := agent.NewInvocation(agent.WithInvocationModel(iterModel))
 
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.Error(t, err)
 	require.Nil(t, seq)
 	require.True(t, iterModel.GenerateContentIterCalled)
@@ -2756,7 +2778,7 @@ func TestFlow_GenerateContentSeq_NilIterModel(t *testing.T) {
 	iterModel := &mockIterModel{}
 	inv := agent.NewInvocation(agent.WithInvocationModel(iterModel))
 
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.ErrorContains(t, err, errMsgNoModelResponse)
 	require.Nil(t, seq)
 	require.True(t, iterModel.GenerateContentIterCalled)
@@ -2766,7 +2788,7 @@ func TestFlow_GenerateContentSeq_NilIterModel(t *testing.T) {
 func TestFlow_GenerateContentSeq_NoResponseModel(t *testing.T) {
 	f := New(nil, nil, Options{})
 	inv := agent.NewInvocation(agent.WithInvocationModel(&noResponseModel{}))
-	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	seq, err := f.generateContentSeq(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	require.NotNil(t, seq)
 }
@@ -2780,10 +2802,10 @@ func TestFlow_CallLLM_MaxLLMCallsExceeded(t *testing.T) {
 	)
 	inv.MaxLLMCalls = 1
 
-	_, _, err := f.callLLM(context.Background(), inv, &model.Request{}, inv.Model)
+	_, _, err := f.callLLM(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 
-	_, _, err = f.callLLM(context.Background(), inv, &model.Request{}, inv.Model)
+	_, _, err = f.callLLM(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "max LLM calls (1) exceeded")
 }
@@ -2820,10 +2842,8 @@ func (m *noResponseModel) GenerateContent(ctx context.Context, req *model.Reques
 func TestRun_NoPanicWhenModelReturnsNoResponses(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	f := New(nil, nil, Options{})
-	inv := agent.NewInvocation(
-		agent.WithInvocationModel(&noResponseModel{}),
-	)
+	f := newRunFlow(nil)
+	inv := runInvocationWithUserMessage(&noResponseModel{})
 	ch, err := f.Run(ctx, inv)
 	require.NoError(t, err)
 	var errorEvent *event.Event
@@ -2846,10 +2866,8 @@ func TestRun_NilIterModelEmitsErrorEvent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	f := New(nil, nil, Options{})
-	inv := agent.NewInvocation(
-		agent.WithInvocationModel(&mockIterModel{}),
-	)
+	f := newRunFlow(nil)
+	inv := runInvocationWithUserMessage(&mockIterModel{})
 
 	ch, err := f.Run(ctx, inv)
 	require.NoError(t, err)
@@ -3109,7 +3127,7 @@ func TestFlow_CallLLM_PluginBeforeModelCanShortCircuit(t *testing.T) {
 		Plugins:   pm,
 	}
 
-	_, ch, err := flow.callLLM(context.Background(), inv, &model.Request{}, inv.Model)
+	_, ch, err := flow.callLLM(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	ch(func(_ *model.Response) bool { return true })
 	require.True(t, plugCalled)
@@ -3152,7 +3170,7 @@ func TestFlow_CallLLM_PluginBeforeModelError(t *testing.T) {
 		Plugins:   pm,
 	}
 
-	_, ch, err := flow.callLLM(context.Background(), inv, &model.Request{}, inv.Model)
+	_, ch, err := flow.callLLM(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.Error(t, err)
 	require.Nil(t, ch)
 	require.True(t, plugCalled)
@@ -3197,7 +3215,7 @@ func TestFlow_CallLLM_PluginBeforeModelContextPropagates(t *testing.T) {
 		Plugins:   pm,
 	}
 
-	_, ch, err := flow.callLLM(context.Background(), inv, &model.Request{}, inv.Model)
+	_, ch, err := flow.callLLM(context.Background(), inv, testLLMRequest(), inv.Model)
 	require.NoError(t, err)
 	ch(func(_ *model.Response) bool { return true })
 	require.True(t, plugCalled)
@@ -3362,11 +3380,35 @@ func TestFlow_AfterModelPluginSeesResponseError(t *testing.T) {
 func TestFlow_callLLM_NoModel(t *testing.T) {
 	f := New(nil, nil, Options{})
 	inv := agent.NewInvocation()
-	req := &model.Request{}
+	req := testLLMRequest()
 
 	_, ch, err := f.callLLM(context.Background(), inv, req, inv.Model)
 	require.Error(t, err)
 	require.Nil(t, ch)
+}
+
+func TestFlow_callLLM_EmptyMessages(t *testing.T) {
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(
+		agent.WithInvocationModel(&mockModel{}),
+	)
+
+	_, ch, err := f.callLLM(context.Background(), inv, &model.Request{}, inv.Model)
+	require.Error(t, err)
+	require.EqualError(t, err, errMsgNoLLMMessages)
+	require.Nil(t, ch)
+}
+
+func TestFlow_generateContentSeq_EmptyMessages(t *testing.T) {
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(
+		agent.WithInvocationModel(&mockModel{}),
+	)
+
+	seq, err := f.generateContentSeq(context.Background(), inv, &model.Request{}, inv.Model)
+	require.Error(t, err)
+	require.EqualError(t, err, errMsgNoLLMMessages)
+	require.Nil(t, seq)
 }
 
 func TestFlow_callLLM_ModelError(t *testing.T) {
@@ -3374,7 +3416,7 @@ func TestFlow_callLLM_ModelError(t *testing.T) {
 	inv := agent.NewInvocation(
 		agent.WithInvocationModel(&mockModel{ShouldError: true}),
 	)
-	req := &model.Request{}
+	req := testLLMRequest()
 
 	_, ch, err := f.callLLM(context.Background(), inv, req, inv.Model)
 	require.Error(t, err)
@@ -3386,7 +3428,12 @@ func TestFlow_RunOneStep_ModelSelectorSelectsBeforePreprocess(t *testing.T) {
 	selectedModel := &namedFlowModel{name: "selected"}
 	processor := &captureInvocationModelNameProcessor{}
 	f := New(
-		[]flow.RequestProcessor{processor},
+		[]flow.RequestProcessor{
+			&seedMessagesRequestProcessor{
+				messages: []model.Message{model.NewUserMessage("test")},
+			},
+			processor,
+		},
 		nil,
 		Options{
 			BaseModelResolver: func(inv *agent.Invocation) ModelBaseResolution {
@@ -3486,7 +3533,7 @@ func TestFlow_CallLLM_BeforeModelCannotReplaceCallModel(t *testing.T) {
 	)
 	f := New(nil, nil, Options{ModelCallbacks: callbacks})
 	inv := agent.NewInvocation(agent.WithInvocationModel(selectedModel))
-	_, seq, err := f.callLLM(context.Background(), inv, &model.Request{}, selectedModel)
+	_, seq, err := f.callLLM(context.Background(), inv, testLLMRequest(), selectedModel)
 	require.NoError(t, err)
 	seq(func(response *model.Response) bool { return true })
 	require.True(t, selectedModel.Called())
@@ -3589,9 +3636,12 @@ func TestRun_WithResumeExecutesPendingToolCalls(t *testing.T) {
 			Resume: true,
 		}),
 	)
+	inv.Message = model.NewUserMessage("test")
 
 	llmFlow := New(
-		nil,
+		[]flow.RequestProcessor{&seedMessagesRequestProcessor{
+			messages: []model.Message{model.NewUserMessage("test")},
+		}},
 		[]flow.ResponseProcessor{
 			processor.NewFunctionCallResponseProcessor(false, nil),
 		},
@@ -3733,9 +3783,12 @@ func TestRun_SyncSummaryIntraRun_TriggersBetweenIterations(t *testing.T) {
 		agent.WithInvocationModel(modelStub),
 		agent.WithInvocationEventFilterKey("branch/agent-intra-run"),
 	)
+	inv.Message = model.NewUserMessage("test")
 
 	llmFlow := New(
-		nil,
+		[]flow.RequestProcessor{&seedMessagesRequestProcessor{
+			messages: []model.Message{model.NewUserMessage("test")},
+		}},
 		[]flow.ResponseProcessor{
 			processor.NewFunctionCallResponseProcessor(false, nil),
 		},

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -1832,7 +1832,6 @@ func testLLMRequest() *model.Request {
 	}
 }
 
-
 func newRunFlow(respProcessors []flow.ResponseProcessor, opts ...Options) *Flow {
 	opt := Options{}
 	if len(opts) > 0 {

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -177,6 +177,9 @@ func (m *Model) GenerateContent(
 	// Apply token tailoring if configured.
 	m.applyTokenTailoring(ctx, request)
 	chatRequest := m.convertMessages(request.Messages)
+	if len(chatRequest) == 0 {
+		return nil, errors.New("gemini: no content after message conversion")
+	}
 	generateConfig := m.buildChatConfig(request)
 	// Execute callback synchronously before starting the goroutine
 	// to avoid a race where the runner and HTTP handler finish

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -1394,6 +1394,20 @@ func (mr *MockModelsMockRecorder) GenerateContentStream(ctx, model, contents, co
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateContentStream", reflect.TypeOf((*MockModels)(nil).GenerateContentStream), ctx, model, contents, config)
 }
 
+func TestModel_GenerateContent_NoContentAfterConversion(t *testing.T) {
+	m := &Model{name: "gemini-test"}
+	req := &model.Request{
+		Messages: []model.Message{
+			{Role: model.RoleAssistant},
+		},
+	}
+
+	ch, err := m.GenerateContent(context.Background(), req)
+	require.Error(t, err)
+	require.EqualError(t, err, "gemini: no content after message conversion")
+	require.Nil(t, ch)
+}
+
 func TestModel_GenerateContentError(t *testing.T) {
 	subText := "subText"
 	req := &model.Request{


### PR DESCRIPTION
## Summary

Return a clear error when `convertMessages` produces zero Gemini `Contents`, and guard `llmflow.generateContentSeq` when no LLM messages remain — instead of calling Gemini and getting HTTP 400 (`contents is not specified`).

## Problem

Sub-agents after sanitization/token tailoring can end up with zero convertible messages. The provider error was opaque and hard to attribute to context pruning.

## Consumer

Genie multi-agent / reactree sub-agents with aggressive context pruning.

## Related

- Fork: sks/trpc-agent-go#16
- Rebased on `main` (includes merged #1894 thought signatures, #1526, #2080, #2093)

## Test plan

- [x] `go test ./internal/flow/llmflow/... -race`
- [x] `go test ./model/gemini/... -race`

Made with [Cursor](https://cursor.com)