### PR TITLE
openclaw/gateway: allow large inline file requests

### DIFF
--- a/openclaw/gwclient/client_test.go
+++ b/openclaw/gwclient/client_test.go
@@ -115,6 +115,31 @@ func TestClient_SendMessage_Success(t *testing.T) {
 	require.Equal(t, "req-1", rsp.RequestID)
 }
 
+func TestClient_SendMessage_LargeInlineFile(t *testing.T) {
+	t.Parallel()
+
+	srv, err := gateway.New(&stubRunner{})
+	require.NoError(t, err)
+
+	cli, err := New(srv.Handler(), srv.MessagesPath(), srv.CancelPath())
+	require.NoError(t, err)
+
+	rsp, err := cli.SendMessage(context.Background(), MessageRequest{
+		From: "u1",
+		ContentParts: []gwproto.ContentPart{{
+			Type: gwproto.PartTypeFile,
+			File: &gwproto.FilePart{
+				Filename: "large.txt",
+				Data:     bytes.Repeat([]byte("a"), 2<<20),
+				Format:   "text/plain",
+			},
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Equal(t, "ok", rsp.Reply)
+}
+
 func TestClient_SendMessage_IncludesUsage(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -70,7 +70,9 @@ const (
 	methodPost = "POST"
 	methodGet  = "GET"
 
-	defaultMaxBodyBytes int64 = 1 << 20
+	// Enough for one default max-size binary content part after base64 JSON
+	// encoding plus normal request metadata.
+	defaultMaxBodyBytes int64 = 12 << 20
 
 	queryRequestID = "request_id"
 

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -1393,7 +1393,7 @@ func TestServer_ProcessMessage_LargeInlineData(t *testing.T) {
 	srv, err := New(r)
 	require.NoError(t, err)
 
-	data := bytes.Repeat([]byte("a"), int(defaultMaxBodyBytes))
+	data := bytes.Repeat([]byte("a"), int(defaultMaxContentPartBytes))
 	req := gwproto.MessageRequest{
 		From: "u1",
 		ContentParts: []gwproto.ContentPart{
@@ -1429,8 +1429,8 @@ func TestServer_ProcessMessage_LargeInlineData(t *testing.T) {
 	)
 	srv.Handler().ServeHTTP(rr, httpReq)
 
-	require.Equal(t, http.StatusBadRequest, rr.Code)
-	require.Contains(t, rr.Body.String(), "request body exceeds max_body_bytes")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, 2, r.Calls())
 }
 
 func TestServer_ProcessMessage_LargeBodyWithoutContentLength(t *testing.T) {


### PR DESCRIPTION
## Summary
- raise the default gateway HTTP JSON body limit so one default-size inline content part can pass over gwclient/HTTP
- return an explicit request body too large error instead of a truncated JSON EOF
- add gwclient and gateway coverage for large inline file requests

## Tests
- cd openclaw && go test ./gwclient ./internal/gateway