### PR TITLE
tool/duckduckgo: report SERP blockers as unavailable

### DIFF
--- a/tool/duckduckgo/duckduckgo.go
+++ b/tool/duckduckgo/duckduckgo.go
@@ -357,7 +357,7 @@ func (t *ddgTool) searchAPI(
 			Query:   req.Query,
 			Results: []resultItem{},
 			Summary: fmt.Sprintf("Error performing search: %v", err),
-		}, fmt.Errorf("error performing search: %v", err)
+		}, fmt.Errorf("error performing search: %w", err)
 	}
 
 	// Convert the response to our format.

--- a/tool/duckduckgo/duckduckgo.go
+++ b/tool/duckduckgo/duckduckgo.go
@@ -301,7 +301,7 @@ func (t *ddgTool) searchAPIWithSERPFallback(
 	ctx context.Context,
 	req searchRequest,
 ) (searchResponse, error) {
-	result, err := t.searchAPI(req)
+	result, err := t.searchAPI(ctx, req)
 	if err == nil || ctx.Err() != nil || !shouldFallbackFromAPIError(err) {
 		return result, err
 	}
@@ -334,18 +334,24 @@ func (t *ddgTool) searchAPIWithSERPFallback(
 	)
 }
 
-func (t *ddgTool) searchAPIWithDefaultBaseURL(req searchRequest) (searchResponse, error) {
+func (t *ddgTool) searchAPIWithDefaultBaseURL(
+	ctx context.Context,
+	req searchRequest,
+) (searchResponse, error) {
 	apiTool := *t
 	apiTool.baseURL = defaultBaseURL
 	apiTool.backend = backendAPI
 	apiTool.userAgent = defaultUserAgent
 	apiTool.client = client.New(defaultBaseURL, apiTool.userAgent, apiTool.httpClient)
-	return apiTool.searchAPI(req)
+	return apiTool.searchAPI(ctx, req)
 }
 
-func (t *ddgTool) searchAPI(req searchRequest) (searchResponse, error) {
+func (t *ddgTool) searchAPI(
+	ctx context.Context,
+	req searchRequest,
+) (searchResponse, error) {
 	// Perform the search.
-	response, err := t.client.Search(req.Query)
+	response, err := t.client.SearchContext(ctx, req.Query)
 	if err != nil {
 		return searchResponse{
 			Query:   req.Query,

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -763,6 +763,56 @@ func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
 	require.Contains(t, result.Summary, "instead of immediately retrying")
 }
 
+func TestDDGTool_SERPFallbackReportsTransportUnavailable(t *testing.T) {
+	t.Parallel()
+
+	calls := make(map[string]int)
+	ddgTool := &ddgTool{
+		httpClient: &http.Client{Transport: roundTripFunc(
+			func(r *http.Request) (*http.Response, error) {
+				calls[r.URL.Host]++
+				switch r.URL.Host {
+				case "html.duckduckgo.com":
+					return nil, errors.New(
+						"server gave HTTP response to HTTPS client",
+					)
+				case "lite.duckduckgo.com":
+					return nil, errors.New(
+						"tls: first record does not look like " +
+							"a TLS handshake",
+					)
+				case "api.duckduckgo.com":
+					return &http.Response{
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       io.NopCloser(strings.NewReader("down")),
+						Header:     make(http.Header),
+					}, nil
+				default:
+					t.Fatalf("unexpected host %s", r.URL.Host)
+					return nil, nil
+				}
+			},
+		)},
+		baseURL:   defaultHTMLBaseURL,
+		backend:   backendHTML,
+		userAgent: defaultSERPUserAgent,
+	}
+
+	result, err := ddgTool.search(
+		context.Background(),
+		searchRequest{Query: "example search topic"},
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Results)
+	require.Contains(t, result.Summary, "html and lite")
+	require.Contains(t, result.Summary, "unavailable")
+	require.GreaterOrEqual(t, calls["html.duckduckgo.com"], 1)
+	require.LessOrEqual(t, calls["html.duckduckgo.com"], 2)
+	require.GreaterOrEqual(t, calls["lite.duckduckgo.com"], 1)
+	require.LessOrEqual(t, calls["lite.duckduckgo.com"], 2)
+	require.Equal(t, 1, calls["api.duckduckgo.com"])
+}
+
 func TestDDGTool_SERPFallbackReturnsContextCancelFromAPIFallback(
 	t *testing.T,
 ) {

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -714,7 +714,9 @@ func TestDDGTool_SERPFallbackUsesAPIForDefaultDuckDuckGoURLs(t *testing.T) {
 	require.Equal(t, 1, calls["api.duckduckgo.com"])
 }
 
-func TestDDGTool_SERPFallbackReportsAPIFallbackFailure(t *testing.T) {
+func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	ddgTool := &ddgTool{
@@ -754,12 +756,11 @@ func TestDDGTool_SERPFallbackReportsAPIFallbackFailure(t *testing.T) {
 		context.Background(),
 		searchRequest{Query: "GAIA benchmark"},
 	)
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.Empty(t, result.Results)
-	require.Contains(t, result.Summary, "fallback lite failed")
-	require.Contains(t, result.Summary, "api fallback failed")
-	require.Contains(t, err.Error(), "api fallback failed")
-	require.Contains(t, err.Error(), "status 503")
+	require.Contains(t, result.Summary, "html and lite")
+	require.Contains(t, result.Summary, "Instant Answer API fallback")
+	require.Contains(t, result.Summary, "instead of immediately retrying")
 }
 
 func TestDDGTool_SERPHTTPFailures(t *testing.T) {

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -856,6 +856,53 @@ func TestDDGTool_SERPFallbackReturnsContextCancelFromAPIFallback(
 	require.Equal(t, 1, calls["api.duckduckgo.com"])
 }
 
+func TestDDGTool_SERPFallbackWrapsContextCancelAfterAPIFallbackError(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ddgTool := &ddgTool{
+		httpClient: &http.Client{Transport: roundTripFunc(
+			func(r *http.Request) (*http.Response, error) {
+				switch r.URL.Host {
+				case "html.duckduckgo.com", "lite.duckduckgo.com":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`
+<html><body>
+  <div class="anomaly-modal__title">
+    Unfortunately, bots use DuckDuckGo too.
+  </div>
+</body></html>`)),
+						Header: make(http.Header),
+					}, nil
+				case "api.duckduckgo.com":
+					cancel()
+					return &http.Response{
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       io.NopCloser(strings.NewReader("down")),
+						Header:     make(http.Header),
+					}, nil
+				default:
+					t.Fatalf("unexpected host %s", r.URL.Host)
+					return nil, nil
+				}
+			},
+		)},
+		baseURL:   defaultHTMLBaseURL,
+		backend:   backendHTML,
+		userAgent: defaultSERPUserAgent,
+	}
+
+	result, err := ddgTool.search(ctx, searchRequest{Query: "example search topic"})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, result.Results)
+	require.Contains(t, err.Error(), "api fallback failed")
+	require.Contains(t, err.Error(), "status 503")
+}
+
 func TestDDGTool_SearchAPIWrapsContextCancellation(t *testing.T) {
 	t.Parallel()
 

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -856,6 +856,28 @@ func TestDDGTool_SERPFallbackReturnsContextCancelFromAPIFallback(
 	require.Equal(t, 1, calls["api.duckduckgo.com"])
 }
 
+func TestDDGTool_SearchAPIWrapsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ddgTool := &ddgTool{
+		client: client.New(
+			defaultBaseURL,
+			defaultUserAgent,
+			http.DefaultClient,
+		),
+	}
+
+	result, err := ddgTool.searchAPI(
+		ctx,
+		searchRequest{Query: "example search topic"},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, result.Results)
+	require.Contains(t, result.Summary, "Error performing search")
+}
+
 func TestDDGTool_SERPHTTPFailures(t *testing.T) {
 	t.Parallel()
 

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -714,7 +714,7 @@ func TestDDGTool_SERPFallbackUsesAPIForDefaultDuckDuckGoURLs(t *testing.T) {
 	require.Equal(t, 1, calls["api.duckduckgo.com"])
 }
 
-func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
+func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackHasNoResults(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -737,9 +737,12 @@ func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
 					}, nil
 				case "api.duckduckgo.com":
 					return &http.Response{
-						StatusCode: http.StatusServiceUnavailable,
-						Body:       io.NopCloser(strings.NewReader("down")),
-						Header:     make(http.Header),
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+  "RelatedTopics": [],
+  "Results": []
+}`)),
+						Header: make(http.Header),
 					}, nil
 				default:
 					t.Fatalf("unexpected host %s", r.URL.Host)
@@ -763,7 +766,7 @@ func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
 	require.Contains(t, result.Summary, "instead of immediately retrying")
 }
 
-func TestDDGTool_SERPFallbackReportsTransportUnavailable(t *testing.T) {
+func TestDDGTool_SERPFallbackReturnsAPIFailure(t *testing.T) {
 	t.Parallel()
 
 	calls := make(map[string]int)
@@ -802,10 +805,11 @@ func TestDDGTool_SERPFallbackReportsTransportUnavailable(t *testing.T) {
 		context.Background(),
 		searchRequest{Query: "example search topic"},
 	)
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Empty(t, result.Results)
-	require.Contains(t, result.Summary, "html and lite")
-	require.Contains(t, result.Summary, "unavailable")
+	require.Contains(t, result.Summary, "api fallback failed")
+	require.Contains(t, err.Error(), "api fallback failed")
+	require.Contains(t, err.Error(), "status 503")
 	require.GreaterOrEqual(t, calls["html.duckduckgo.com"], 1)
 	require.LessOrEqual(t, calls["html.duckduckgo.com"], 2)
 	require.GreaterOrEqual(t, calls["lite.duckduckgo.com"], 1)

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -769,9 +769,11 @@ func TestDDGTool_SERPFallbackReturnsContextCancelFromAPIFallback(
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	calls := make(map[string]int)
 	ddgTool := &ddgTool{
 		httpClient: &http.Client{Transport: roundTripFunc(
 			func(r *http.Request) (*http.Response, error) {
+				calls[r.URL.Host]++
 				switch r.URL.Host {
 				case "html.duckduckgo.com", "lite.duckduckgo.com":
 					return &http.Response{
@@ -801,6 +803,7 @@ func TestDDGTool_SERPFallbackReturnsContextCancelFromAPIFallback(
 	result, err := ddgTool.search(ctx, searchRequest{Query: "example search topic"})
 	require.ErrorIs(t, err, context.Canceled)
 	require.Empty(t, result.Results)
+	require.Equal(t, 1, calls["api.duckduckgo.com"])
 }
 
 func TestDDGTool_SERPHTTPFailures(t *testing.T) {

--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -226,8 +226,8 @@ func TestDDGTool_SERPBackends(t *testing.T) {
 			backend: backendHTML,
 			body: `
 <html><body>
-  <a class="result__a" href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fgaia">GAIA benchmark</a>
-  <a class="result__snippet">A benchmark for general AI assistants.</a>
+  <a class="result__a" href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fexample">Example search topic</a>
+  <a class="result__snippet">A sample search result snippet.</a>
 </body></html>`,
 		},
 		{
@@ -235,7 +235,7 @@ func TestDDGTool_SERPBackends(t *testing.T) {
 			backend: backendLite,
 			body: `
 <html><body>
-  <a class="result-link" href="/l/?uddg=https%3A%2F%2Fexample.org%2Flite">Lite GAIA</a>
+  <a class="result-link" href="/l/?uddg=https%3A%2F%2Fexample.org%2Flite">Lite example</a>
   <div class="result-snippet">Lite result snippet.</div>
 </body></html>`,
 		},
@@ -245,7 +245,7 @@ func TestDDGTool_SERPBackends(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
-					require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+					require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 					w.Header().Set("Content-Type", "text/html")
 					_, _ = w.Write([]byte(tc.body))
 				},
@@ -260,11 +260,11 @@ func TestDDGTool_SERPBackends(t *testing.T) {
 			}
 			result, err := ddgTool.search(
 				context.Background(),
-				searchRequest{Query: "GAIA benchmark"},
+				searchRequest{Query: "example search topic"},
 			)
 			require.NoError(t, err)
 			require.Len(t, result.Results, 1)
-			require.Contains(t, result.Results[0].Title, "GAIA")
+			require.NotEmpty(t, result.Results[0].Title)
 			require.Contains(t, result.Results[0].URL, "example.")
 			require.NotEmpty(t, result.Results[0].Description)
 			require.Contains(t, result.Summary, tc.backend)
@@ -295,7 +295,7 @@ func TestDDGTool_SERPChallenge(t *testing.T) {
 	}
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.Error(t, err)
 	require.Empty(t, result.Results)
@@ -308,7 +308,7 @@ func TestDDGTool_SERPFallbackOnChallenge(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+			require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 			switch r.URL.Path {
 			case "/html/":
 				_, _ = w.Write([]byte(`
@@ -321,7 +321,7 @@ func TestDDGTool_SERPFallbackOnChallenge(t *testing.T) {
 				_, _ = w.Write([]byte(`
 <html><body>
   <a class="result-link"
-     href="/l/?uddg=https%3A%2F%2Fexample.org%2Fgaia">GAIA fallback</a>
+     href="/l/?uddg=https%3A%2F%2Fexample.org%2Fexample">Example fallback</a>
   <div class="result-snippet">Lite fallback snippet.</div>
 </body></html>`))
 			default:
@@ -339,12 +339,12 @@ func TestDDGTool_SERPFallbackOnChallenge(t *testing.T) {
 	}
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Results, 1)
-	require.Equal(t, "GAIA fallback", result.Results[0].Title)
-	require.Equal(t, "https://example.org/gaia", result.Results[0].URL)
+	require.Equal(t, "Example fallback", result.Results[0].Title)
+	require.Equal(t, "https://example.org/example", result.Results[0].URL)
 	require.Contains(t, result.Summary, "lite")
 	require.Contains(t, result.Summary, "fallback from html")
 }
@@ -354,7 +354,7 @@ func TestDDGTool_SERPBothBackendsChallengeReturnsBlocker(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+			require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 			switch r.URL.Path {
 			case "/html/", "/lite/":
 				_, _ = w.Write([]byte(`
@@ -378,7 +378,7 @@ func TestDDGTool_SERPBothBackendsChallengeReturnsBlocker(t *testing.T) {
 	}
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.NoError(t, err)
 	require.Empty(t, result.Results)
@@ -393,7 +393,7 @@ func TestDDGTool_SERPTransportAndChallengeReturnsBlocker(t *testing.T) {
 	searchTool := &ddgTool{
 		httpClient: &http.Client{Transport: roundTripFunc(
 			func(r *http.Request) (*http.Response, error) {
-				require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+				require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 				switch r.URL.Path {
 				case "/html/":
 					return nil, errors.New(
@@ -422,7 +422,7 @@ func TestDDGTool_SERPTransportAndChallengeReturnsBlocker(t *testing.T) {
 	}
 	result, err := searchTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.NoError(t, err)
 	require.Empty(t, result.Results)
@@ -436,7 +436,7 @@ func TestDDGTool_SERPHTTPFallbackForPlainHTTPOnHTTPS(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+			require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 			require.Equal(t, "/html/", r.URL.Path)
 			_, _ = w.Write([]byte(`
 <html><body>
@@ -461,7 +461,7 @@ func TestDDGTool_SERPHTTPFallbackForPlainHTTPOnHTTPS(t *testing.T) {
 	}
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Results, 1)
@@ -483,7 +483,7 @@ func TestDDGTool_APIFallsBackToSERPOnPlainHTTPMismatch(t *testing.T) {
 	userAgent := make(chan string, 1)
 	serpServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA paper authors", r.URL.Query().Get("q"))
+			require.Equal(t, "example paper authors", r.URL.Query().Get("q"))
 			userAgent <- r.UserAgent()
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write([]byte(`
@@ -511,7 +511,7 @@ func TestDDGTool_APIFallsBackToSERPOnPlainHTTPMismatch(t *testing.T) {
 
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA paper authors"},
+		searchRequest{Query: "example paper authors"},
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Results, 1)
@@ -532,7 +532,7 @@ func TestDDGTool_APIFallsBackToSERPOnAcceptedStatus(t *testing.T) {
 
 	serpServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA paper authors", r.URL.Query().Get("q"))
+			require.Equal(t, "example paper authors", r.URL.Query().Get("q"))
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write([]byte(`
 <html><body>
@@ -558,7 +558,7 @@ func TestDDGTool_APIFallsBackToSERPOnAcceptedStatus(t *testing.T) {
 
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA paper authors"},
+		searchRequest{Query: "example paper authors"},
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Results, 1)
@@ -580,7 +580,7 @@ func TestDDGTool_APIFallsBackToSERPOnMalformedJSON(t *testing.T) {
 
 	serpServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA paper authors", r.URL.Query().Get("q"))
+			require.Equal(t, "example paper authors", r.URL.Query().Get("q"))
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write([]byte(`
 <html><body>
@@ -606,7 +606,7 @@ func TestDDGTool_APIFallsBackToSERPOnMalformedJSON(t *testing.T) {
 
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA paper authors"},
+		searchRequest{Query: "example paper authors"},
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Results, 1)
@@ -620,7 +620,7 @@ func TestDDGTool_SERPFallbackFailureAddsContext(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+			require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 			switch r.URL.Path {
 			case "/html/":
 				_, _ = w.Write([]byte(`
@@ -647,7 +647,7 @@ func TestDDGTool_SERPFallbackFailureAddsContext(t *testing.T) {
 	}
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.Error(t, err)
 	require.Empty(t, result.Results)
@@ -663,7 +663,7 @@ func TestDDGTool_SERPFallbackUsesAPIForDefaultDuckDuckGoURLs(t *testing.T) {
 		httpClient: &http.Client{Transport: roundTripFunc(
 			func(r *http.Request) (*http.Response, error) {
 				calls[r.URL.Host]++
-				require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+				require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 				switch r.URL.Host {
 				case "html.duckduckgo.com", "lite.duckduckgo.com":
 					return &http.Response{
@@ -682,8 +682,8 @@ func TestDDGTool_SERPFallbackUsesAPIForDefaultDuckDuckGoURLs(t *testing.T) {
 						Body: io.NopCloser(strings.NewReader(`{
   "RelatedTopics": [
     {
-      "Text": "GAIA benchmark - General AI assistant benchmark.",
-      "FirstURL": "https://example.com/gaia"
+      "Text": "Example search topic - Sample search result.",
+      "FirstURL": "https://example.com/example"
     }
   ],
   "Results": []
@@ -703,11 +703,11 @@ func TestDDGTool_SERPFallbackUsesAPIForDefaultDuckDuckGoURLs(t *testing.T) {
 
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.NoError(t, err)
 	require.Len(t, result.Results, 1)
-	require.Equal(t, "https://example.com/gaia", result.Results[0].URL)
+	require.Equal(t, "https://example.com/example", result.Results[0].URL)
 	require.Contains(t, result.Summary, "fallback from html/lite")
 	require.Equal(t, 1, calls["html.duckduckgo.com"])
 	require.Equal(t, 1, calls["lite.duckduckgo.com"])
@@ -722,7 +722,7 @@ func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
 	ddgTool := &ddgTool{
 		httpClient: &http.Client{Transport: roundTripFunc(
 			func(r *http.Request) (*http.Response, error) {
-				require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+				require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 				switch r.URL.Host {
 				case "html.duckduckgo.com", "lite.duckduckgo.com":
 					return &http.Response{
@@ -754,7 +754,7 @@ func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
 
 	result, err := ddgTool.search(
 		context.Background(),
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.NoError(t, err)
 	require.Empty(t, result.Results)
@@ -763,10 +763,50 @@ func TestDDGTool_SERPFallbackReportsUnavailableWhenAPIFallbackFails(
 	require.Contains(t, result.Summary, "instead of immediately retrying")
 }
 
+func TestDDGTool_SERPFallbackReturnsContextCancelFromAPIFallback(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ddgTool := &ddgTool{
+		httpClient: &http.Client{Transport: roundTripFunc(
+			func(r *http.Request) (*http.Response, error) {
+				switch r.URL.Host {
+				case "html.duckduckgo.com", "lite.duckduckgo.com":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`
+<html><body>
+  <div class="anomaly-modal__title">
+    Unfortunately, bots use DuckDuckGo too.
+  </div>
+</body></html>`)),
+						Header: make(http.Header),
+					}, nil
+				case "api.duckduckgo.com":
+					cancel()
+					return nil, context.Canceled
+				default:
+					t.Fatalf("unexpected host %s", r.URL.Host)
+					return nil, nil
+				}
+			},
+		)},
+		baseURL:   defaultHTMLBaseURL,
+		backend:   backendHTML,
+		userAgent: defaultSERPUserAgent,
+	}
+
+	result, err := ddgTool.search(ctx, searchRequest{Query: "example search topic"})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, result.Results)
+}
+
 func TestDDGTool_SERPHTTPFailures(t *testing.T) {
 	t.Parallel()
 
-	req := searchRequest{Query: "GAIA benchmark"}
+	req := searchRequest{Query: "example search topic"}
 	searchTool := &ddgTool{httpClient: http.DefaultClient}
 	_, err := searchTool.searchSERP(
 		context.Background(),
@@ -780,7 +820,7 @@ func TestDDGTool_SERPHTTPFailures(t *testing.T) {
 	searchTool = &ddgTool{
 		httpClient: &http.Client{Transport: roundTripFunc(
 			func(r *http.Request) (*http.Response, error) {
-				require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+				require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 				require.Contains(t, r.Header.Get("Accept"), "text/html")
 				require.Equal(t, "en-US,en;q=0.9", r.Header.Get("Accept-Language"))
 				return nil, dialErr
@@ -838,7 +878,7 @@ func TestDDGTool_SERPDoesNotFallbackAfterContextCancel(t *testing.T) {
 	}
 	result, err := searchTool.searchSERPWithFallback(
 		ctx,
-		searchRequest{Query: "GAIA benchmark"},
+		searchRequest{Query: "example search topic"},
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
@@ -892,9 +932,9 @@ func TestNormalizeSERPURL(t *testing.T) {
 	require.Equal(t, "http://%zz", normalizeSERPURL("http://%zz"))
 	require.Equal(t, "https://example.com/path",
 		normalizeSERPURL("//example.com/path"))
-	require.Equal(t, "https://example.com/gaia",
+	require.Equal(t, "https://example.com/example",
 		normalizeSERPURL(
-			"https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fgaia",
+			"https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fexample",
 		))
 }
 
@@ -1080,11 +1120,11 @@ func TestNewTool_WithBackendUsesSERPBackend(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, "GAIA benchmark", r.URL.Query().Get("q"))
+			require.Equal(t, "example search topic", r.URL.Query().Get("q"))
 			require.Equal(t, "custom-agent/2.0", r.Header.Get("User-Agent"))
 			_, _ = w.Write([]byte(`
 <html><body>
-  <a class="result-link" href="/l/?uddg=https%3A%2F%2Fexample.org%2Flite">Lite GAIA</a>
+  <a class="result-link" href="/l/?uddg=https%3A%2F%2Fexample.org%2Flite">Lite example</a>
   <div class="result-snippet">Lite result snippet.</div>
 </body></html>`))
 		},
@@ -1100,7 +1140,7 @@ func TestNewTool_WithBackendUsesSERPBackend(t *testing.T) {
 	require.Contains(t, searchTool.Declaration().Description, "lite search")
 	raw, err := searchTool.Call(
 		context.Background(),
-		[]byte(`{"query":"GAIA benchmark"}`),
+		[]byte(`{"query":"example search topic"}`),
 	)
 	require.NoError(t, err)
 	result, ok := raw.(searchResponse)

--- a/tool/duckduckgo/internal/client/client.go
+++ b/tool/duckduckgo/internal/client/client.go
@@ -11,6 +11,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -114,6 +115,14 @@ type Result struct {
 
 // Search performs a search query using DuckDuckGo Instant Answer API.
 func (c *Client) Search(query string) (*Response, error) {
+	return c.SearchContext(context.Background(), query)
+}
+
+// SearchContext performs a search query using DuckDuckGo Instant Answer API.
+func (c *Client) SearchContext(
+	ctx context.Context,
+	query string,
+) (*Response, error) {
 	if strings.TrimSpace(query) == "" {
 		return nil, fmt.Errorf("query cannot be empty")
 	}
@@ -123,7 +132,7 @@ func (c *Client) Search(query string) (*Response, error) {
 		c.baseURL, url.QueryEscape(query))
 
 	// Create the HTTP request.
-	req, err := http.NewRequest("GET", reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/tool/duckduckgo/internal/client/client_test.go
+++ b/tool/duckduckgo/internal/client/client_test.go
@@ -10,7 +10,9 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -343,6 +345,21 @@ func TestClient_Search_NetworkError(t *testing.T) {
 	_, err := client.Search("test query")
 	if err == nil {
 		t.Error("Expected error for network failure")
+	}
+}
+
+func TestClient_SearchContext_Canceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client := New(
+		"http://localhost:1",
+		"test-agent/1.0",
+		&http.Client{Timeout: 30 * time.Second},
+	)
+
+	_, err := client.SearchContext(ctx, "test query")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled, got %v", err)
 	}
 }
 

--- a/tool/duckduckgo/serp.go
+++ b/tool/duckduckgo/serp.go
@@ -110,7 +110,11 @@ func (t *ddgTool) searchSERPWithFallbackForBackend(
 		if errors.Is(apiFallbackErr, ctxErr) {
 			return apiFallback, apiFallbackErr
 		}
-		return apiFallback, ctxErr
+		return apiFallback, fmt.Errorf(
+			"%w: api fallback failed: %w",
+			ctxErr,
+			apiFallbackErr,
+		)
 	}
 	if isSERPRouteBlocker(err, fallbackErr) {
 		return searchResponse{
@@ -307,7 +311,7 @@ func (t *ddgTool) searchAPIFallbackAfterSERPFailure(
 			baseURL,
 		)
 	}
-	result, err := t.searchAPIWithDefaultBaseURL(req)
+	result, err := t.searchAPIWithDefaultBaseURL(ctx, req)
 	if err != nil {
 		return searchResponse{}, err
 	}

--- a/tool/duckduckgo/serp.go
+++ b/tool/duckduckgo/serp.go
@@ -28,6 +28,10 @@ var errSERPChallenge = errors.New(
 	"duckduckgo returned an anti-bot challenge page",
 )
 
+var errAPIFallbackNoResults = errors.New(
+	"api fallback returned no results",
+)
+
 func (t *ddgTool) searchSERPWithFallback(
 	ctx context.Context,
 	req searchRequest,
@@ -116,7 +120,8 @@ func (t *ddgTool) searchSERPWithFallbackForBackend(
 			apiFallbackErr,
 		)
 	}
-	if isSERPRouteBlocker(err, fallbackErr) {
+	if isSERPRouteBlocker(err, fallbackErr) &&
+		errors.Is(apiFallbackErr, errAPIFallbackNoResults) {
 		return searchResponse{
 			Query:   req.Query,
 			Results: []resultItem{},
@@ -315,7 +320,7 @@ func (t *ddgTool) searchAPIFallbackAfterSERPFailure(
 		return searchResponse{}, err
 	}
 	if len(result.Results) == 0 {
-		return searchResponse{}, fmt.Errorf("api fallback returned no results")
+		return searchResponse{}, errAPIFallbackNoResults
 	}
 	return result, nil
 }

--- a/tool/duckduckgo/serp.go
+++ b/tool/duckduckgo/serp.go
@@ -267,8 +267,7 @@ func isSERPChallengeError(err error) bool {
 
 func isSERPRouteBlocker(err error, fallbackErr error) bool {
 	return isSERPUnavailableError(err) &&
-		isSERPUnavailableError(fallbackErr) &&
-		(isSERPChallengeError(err) || isSERPChallengeError(fallbackErr))
+		isSERPUnavailableError(fallbackErr)
 }
 
 func isSERPUnavailableError(err error) bool {

--- a/tool/duckduckgo/serp.go
+++ b/tool/duckduckgo/serp.go
@@ -106,6 +106,12 @@ func (t *ddgTool) searchSERPWithFallbackForBackend(
 		}
 		return apiFallback, nil
 	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if errors.Is(apiFallbackErr, ctxErr) {
+			return apiFallback, apiFallbackErr
+		}
+		return apiFallback, ctxErr
+	}
 	if isSERPRouteBlocker(err, fallbackErr) {
 		return searchResponse{
 			Query:   req.Query,

--- a/tool/duckduckgo/serp.go
+++ b/tool/duckduckgo/serp.go
@@ -106,6 +106,19 @@ func (t *ddgTool) searchSERPWithFallbackForBackend(
 		}
 		return apiFallback, nil
 	}
+	if isSERPRouteBlocker(err, fallbackErr) {
+		return searchResponse{
+			Query:   req.Query,
+			Results: []resultItem{},
+			Summary: "DuckDuckGo html and lite search pages are both " +
+				"unavailable for this query due to transport errors " +
+				"or anti-bot challenge pages, and the Instant Answer " +
+				"API fallback did not return web results; use direct " +
+				"URLs with web_fetch/browser or another configured " +
+				"search provider instead of immediately retrying " +
+				"DuckDuckGo",
+		}, nil
+	}
 	result.Summary = fmt.Sprintf(
 		"%s; fallback %s failed: %v; api fallback failed: %v",
 		result.Summary,


### PR DESCRIPTION
## What

- Return a non-error DuckDuckGo search response when both HTML/Lite SERP routes are blocked by transport errors or anti-bot pages and the Instant Answer API fallback has no web results.
- Keep the existing successful fallback behavior unchanged when Lite/HTML or the API fallback can return usable results.

## Why

When all DuckDuckGo routes are unavailable, surfacing the condition as a tool error encourages agents to retry the same blocked search path. A successful empty response with explicit guidance lets the agent move to direct URLs, web fetch, browser automation, or another configured search provider.

## Validation

- `go test ./tool/duckduckgo`
