### PR TITLE
openclaw/app: absolutize runtime file roots

### DIFF
--- a/openclaw/app/tooling_builtins.go
+++ b/openclaw/app/tooling_builtins.go
@@ -462,18 +462,29 @@ func newFileToolSet(
 }
 
 func defaultFileReadOnlyDirs(stateDir string) []string {
-	roots := []string{os.TempDir()}
+	roots := []string{absPathOrOriginal(os.TempDir())}
 	if runtime.GOOS != "windows" {
-		roots = append(roots, "/tmp")
+		roots = append(roots, absPathOrOriginal("/tmp"))
 	}
 	if stateDir := strings.TrimSpace(stateDir); stateDir != "" {
 		roots = append(
 			roots,
-			filepath.Join(stateDir, "runtime", "tmp"),
-			filepath.Join(stateDir, "workspaces", "scratch"),
+			absPathOrOriginal(filepath.Join(stateDir, "runtime", "tmp")),
+			absPathOrOriginal(filepath.Join(stateDir, "workspaces", "scratch")),
 		)
 	}
 	return roots
+}
+
+func absPathOrOriginal(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return path
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return abs
 }
 
 type openAPISpecConfig struct {

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -475,6 +475,46 @@ func TestNewFileToolSet_RuntimeReadDirsDefault(t *testing.T) {
 	require.Contains(t, string(data), `"contents":"derived"`)
 }
 
+func TestNewFileToolSet_RuntimeReadDirsRelativeStateDir(t *testing.T) {
+	cwd := t.TempDir()
+	oldwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(cwd))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldwd))
+	})
+
+	baseDir := filepath.Join(cwd, "base")
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+	scratchFile := filepath.Join(
+		cwd,
+		"state",
+		"workspaces",
+		"scratch",
+		"out",
+		"derived.txt",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(scratchFile), 0o755))
+	require.NoError(t, os.WriteFile(scratchFile, []byte("derived"), 0o644))
+
+	cfg := yamlNode(t, "base_dir: "+baseDir+"\n")
+	ts, err := newFileToolSet(
+		registry.ToolSetProviderDeps{StateDir: "state"},
+		registry.PluginSpec{Name: "fs", Config: cfg},
+	)
+	require.NoError(t, err)
+	readFile := findCallableTool(t, ts.Tools(context.Background()), "read_file")
+
+	raw, err := readFile.Call(
+		context.Background(),
+		[]byte(`{"file_name":`+strconv.Quote(scratchFile)+`}`),
+	)
+	require.NoError(t, err)
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"contents":"derived"`)
+}
+
 func TestNewFileToolSet_RuntimeReadDirsCanDisable(t *testing.T) {
 	dir := t.TempDir()
 	tmpFile := filepath.Join(t.TempDir(), "derived.txt")
@@ -509,6 +549,17 @@ func TestDefaultFileReadOnlyDirsIncludesPlatformTmp(t *testing.T) {
 	roots := defaultFileReadOnlyDirs("")
 	require.Contains(t, roots, tmp)
 	require.Contains(t, roots, "/tmp")
+}
+
+func TestDefaultFileReadOnlyDirsAbsolutizesRelativeStateDir(t *testing.T) {
+	stateRoot := filepath.Join(".", "state")
+	wantScratch, err := filepath.Abs(
+		filepath.Join(stateRoot, "workspaces", "scratch"),
+	)
+	require.NoError(t, err)
+
+	roots := defaultFileReadOnlyDirs(stateRoot)
+	require.Contains(t, roots, wantScratch)
 }
 
 func TestOverrideToolSetName_NoOpWhenEmpty(t *testing.T) {

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -562,6 +562,23 @@ func TestDefaultFileReadOnlyDirsAbsolutizesRelativeStateDir(t *testing.T) {
 	require.Contains(t, roots, wantScratch)
 }
 
+func TestAbsPathOrOriginalFallbacks(t *testing.T) {
+	require.Equal(t, "  ", absPathOrOriginal("  "))
+
+	oldwd, err := os.Getwd()
+	require.NoError(t, err)
+	tmp := t.TempDir()
+	deletedWD := filepath.Join(tmp, "deleted")
+	require.NoError(t, os.MkdirAll(deletedWD, 0o755))
+	require.NoError(t, os.Chdir(deletedWD))
+	require.NoError(t, os.RemoveAll(deletedWD))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldwd))
+	})
+
+	require.Equal(t, "relative-state", absPathOrOriginal("relative-state"))
+}
+
 func TestOverrideToolSetName_NoOpWhenEmpty(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

- Normalize OpenClaw runtime file-tool read roots to absolute paths.
- Add regression coverage for a relative `state_dir` where a tool writes a file under the runtime scratch directory and then reads it back by absolute path.

## Why

`fs_read_file` accepts absolute paths only when they are under configured read-only roots. When `state_dir` is relative, the default runtime roots were also relative, so absolute paths under `state_dir/workspaces/scratch` could be rejected even though they point inside OpenClaw-managed runtime scratch space.

## Validation

- `cd openclaw && go test ./app -run 'TestNewFileToolSet_RuntimeReadDirs|TestDefaultFileReadOnlyDirs'`
