### PR TITLE
openclaw/app: enforce request model call budget

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1089,6 +1089,7 @@ func NewRuntimeWithOptions(
 				Err:  fmt.Errorf("create model failed: %w", err),
 			}
 		}
+		mdl = newModelCallBudgetModel(mdl)
 	}
 
 	instanceID := runtimeInstanceID(
@@ -1364,6 +1365,10 @@ func NewRuntimeWithOptions(
 		gwOpts,
 		runtimeProfileResolver,
 		runtimeProfileRequired,
+	)
+	gwOpts = appendModelCallBudgetGatewayOption(
+		gwOpts,
+		opts.MaxLLMCalls,
 	)
 	if langfuseRT != nil && langfuseRT.runOptionResolver != nil {
 		gwOpts = append(
@@ -1708,6 +1713,7 @@ func run(
 				Err:  fmt.Errorf("create model failed: %w", err),
 			}
 		}
+		mdl = newModelCallBudgetModel(mdl)
 	}
 
 	instanceID := runtimeInstanceID(
@@ -1988,6 +1994,10 @@ func run(
 		gwOpts,
 		runtimeProfileResolver,
 		runtimeProfileRequired,
+	)
+	gwOpts = appendModelCallBudgetGatewayOption(
+		gwOpts,
+		opts.MaxLLMCalls,
 	)
 	if langfuseRT != nil && langfuseRT.runOptionResolver != nil {
 		gwOpts = append(

--- a/openclaw/app/deferred_tools.go
+++ b/openclaw/app/deferred_tools.go
@@ -55,7 +55,7 @@ func baseLLMAgentOptions(
 	genConfig model.GenerationConfig,
 	repo *ocskills.Repository,
 ) []llmagent.Option {
-	return []llmagent.Option{
+	opts := []llmagent.Option{
 		llmagent.WithModel(mdl),
 		llmagent.WithInstruction(instruction),
 		llmagent.WithGlobalInstruction(systemPrompt),
@@ -85,6 +85,12 @@ func baseLLMAgentOptions(
 			runtimeprofile.SkillVisibilityFilterForRepository(repo),
 		),
 	}
+	if cfg.MaxLLMCalls > 0 {
+		opts = append(opts, llmagent.WithModelCallbacks(
+			modelCallBudgetCallbacks(),
+		))
+	}
+	return opts
 }
 
 func appendDeferredSkillOverviewOptions(

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -1,0 +1,174 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+)
+
+type modelCallBudgetKey struct{}
+
+const modelCallBudgetRuntimeStateKey = "openclaw.model_call_budget"
+
+type modelCallBudget struct {
+	mu    sync.Mutex
+	limit int
+	count int
+}
+
+func newModelCallBudget(limit int) *modelCallBudget {
+	if limit <= 0 {
+		return nil
+	}
+	return &modelCallBudget{
+		limit: limit,
+	}
+}
+
+func withModelCallBudget(ctx context.Context, limit int) context.Context {
+	return withModelCallBudgetValue(ctx, newModelCallBudget(limit))
+}
+
+func withModelCallBudgetValue(
+	ctx context.Context,
+	budget *modelCallBudget,
+) context.Context {
+	if budget == nil {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, modelCallBudgetKey{}, budget)
+}
+
+func modelCallBudgetFromContext(ctx context.Context) *modelCallBudget {
+	if ctx == nil {
+		return nil
+	}
+	if budget, _ := ctx.Value(modelCallBudgetKey{}).(*modelCallBudget); budget != nil {
+		return budget
+	}
+	budget, _ := agent.GetRuntimeStateValueFromContext[*modelCallBudget](
+		ctx,
+		modelCallBudgetRuntimeStateKey,
+	)
+	return budget
+}
+
+func (b *modelCallBudget) use() error {
+	if b == nil || b.limit <= 0 {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.count++
+	if b.count <= b.limit {
+		return nil
+	}
+	return agent.NewStopError(
+		fmt.Sprintf("max LLM calls (%d) exceeded", b.limit),
+	)
+}
+
+func newModelCallBudgetModel(m model.Model) model.Model {
+	if m == nil {
+		return nil
+	}
+	wrapped := &modelCallBudgetModel{model: m}
+	if iter, ok := m.(model.IterModel); ok {
+		return &modelCallBudgetIterModel{
+			modelCallBudgetModel: wrapped,
+			iter:                 iter,
+		}
+	}
+	return wrapped
+}
+
+func modelCallBudgetCallbacks() *model.Callbacks {
+	return model.NewCallbacks().RegisterBeforeModel(
+		func(context.Context, *model.BeforeModelArgs) (
+			*model.BeforeModelResult,
+			error,
+		) {
+			return &model.BeforeModelResult{}, nil
+		},
+	)
+}
+
+type modelCallBudgetModel struct {
+	model model.Model
+}
+
+func (m *modelCallBudgetModel) GenerateContent(
+	ctx context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	if err := modelCallBudgetFromContext(ctx).use(); err != nil {
+		return nil, err
+	}
+	return m.model.GenerateContent(ctx, req)
+}
+
+func (m *modelCallBudgetModel) Info() model.Info {
+	return m.model.Info()
+}
+
+type modelCallBudgetIterModel struct {
+	*modelCallBudgetModel
+	iter model.IterModel
+}
+
+func (m *modelCallBudgetIterModel) GenerateContentIter(
+	ctx context.Context,
+	req *model.Request,
+) (model.Seq[*model.Response], error) {
+	if err := modelCallBudgetFromContext(ctx).use(); err != nil {
+		return nil, err
+	}
+	return m.iter.GenerateContentIter(ctx, req)
+}
+
+func appendModelCallBudgetGatewayOption(
+	opts []gateway.Option,
+	limit int,
+) []gateway.Option {
+	if limit <= 0 {
+		return opts
+	}
+	return append(opts, gateway.WithRunOptionResolver(
+		buildModelCallBudgetRunOptionResolver(limit),
+	))
+}
+
+func buildModelCallBudgetRunOptionResolver(
+	limit int,
+) gateway.RunOptionResolver {
+	return func(ctx context.Context, _ gateway.RunOptionInput) (
+		context.Context,
+		[]agent.RunOption,
+		error,
+	) {
+		budget := newModelCallBudget(limit)
+		return withModelCallBudgetValue(ctx, budget),
+			[]agent.RunOption{
+				agent.MergeRuntimeState(map[string]any{
+					modelCallBudgetRuntimeStateKey: budget,
+				}),
+			},
+			nil
+	}
+}

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -1,0 +1,301 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+)
+
+func TestModelCallBudgetModel_EnforcesPerContextLimit(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	ctx := withModelCallBudget(context.Background(), 2)
+
+	_, err := wrapped.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (2) exceeded")
+	require.EqualValues(t, 2, underlying.callCount())
+}
+
+func TestModelCallBudgetModel_NoBudgetPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+
+	_, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, underlying.callCount())
+}
+
+func TestModelCallBudgetIterModel_NoBudgetPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetIterModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+
+	seq, err := iter.GenerateContentIter(context.Background(), &model.Request{})
+	require.NoError(t, err)
+
+	var responses int
+	seq(func(*model.Response) bool {
+		responses++
+		return true
+	})
+	require.Equal(t, 1, responses)
+	require.EqualValues(t, 1, underlying.iterCallCount())
+}
+
+func TestModelCallBudgetModel_UsesInvocationRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	budget := newModelCallBudget(1)
+	inv := agent.NewInvocation(agent.WithInvocationRunOptions(
+		agent.NewRunOptions(agent.MergeRuntimeState(map[string]any{
+			modelCallBudgetRuntimeStateKey: budget,
+		})),
+	))
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	_, err := wrapped.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 1, underlying.callCount())
+}
+
+func TestModelCallBudgetIterModel_EnforcesPerContextLimit(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetIterModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+
+	ctx := withModelCallBudget(context.Background(), 1)
+	_, err := iter.GenerateContentIter(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = iter.GenerateContentIter(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 1, underlying.iterCallCount())
+}
+
+func TestModelCallBudgetModel_ConcurrentCallsShareLimit(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	ctx := withModelCallBudget(context.Background(), 3)
+
+	var wg sync.WaitGroup
+	var successes atomic.Int64
+	var failures atomic.Int64
+	errs := make(chan string, 16)
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := wrapped.GenerateContent(ctx, &model.Request{})
+			if err != nil {
+				stopErr, ok := agent.AsStopError(err)
+				if !ok || stopErr.Message !=
+					"max LLM calls (3) exceeded" {
+					errs <- err.Error()
+				}
+				failures.Add(1)
+				return
+			}
+			successes.Add(1)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for msg := range errs {
+		require.Empty(t, msg)
+	}
+	require.EqualValues(t, 3, successes.Load())
+	require.EqualValues(t, 13, failures.Load())
+	require.EqualValues(t, 3, underlying.callCount())
+}
+
+func TestModelCallBudgetModel_InfoPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+
+	require.Equal(t, underlying.Info(), wrapped.Info())
+}
+
+func TestNewModelCallBudgetModel_Nil(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, newModelCallBudgetModel(nil))
+}
+
+func TestModelCallBudget_Guards(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, newModelCallBudget(0))
+	require.Nil(t, newModelCallBudget(-1))
+	require.NoError(t, (*modelCallBudget)(nil).use())
+
+	ctx := withModelCallBudget(nil, 1)
+	require.NotNil(t, ctx)
+	require.NotNil(t, modelCallBudgetFromContext(ctx))
+
+	inv := agent.NewInvocation(agent.WithInvocationRunOptions(
+		agent.NewRunOptions(agent.MergeRuntimeState(map[string]any{
+			modelCallBudgetRuntimeStateKey: "not-a-budget",
+		})),
+	))
+	ctx = agent.NewInvocationContext(context.Background(), inv)
+	require.Nil(t, modelCallBudgetFromContext(ctx))
+}
+
+func TestModelCallBudgetCallbacks_RunBeforeModel(t *testing.T) {
+	t.Parallel()
+
+	callbacks := modelCallBudgetCallbacks()
+	require.NotNil(t, callbacks)
+	require.Len(t, callbacks.BeforeModel, 1)
+
+	result, err := callbacks.RunBeforeModel(
+		context.Background(),
+		&model.BeforeModelArgs{Request: &model.Request{}},
+	)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestBaseLLMAgentOptions_AddsModelCallBudgetCallbacks(t *testing.T) {
+	t.Parallel()
+
+	withoutBudget := baseLLMAgentOptions(
+		&countingBudgetModel{},
+		agentConfig{},
+		"",
+		"",
+		model.GenerationConfig{},
+		nil,
+	)
+	withBudget := baseLLMAgentOptions(
+		&countingBudgetModel{},
+		agentConfig{MaxLLMCalls: 1},
+		"",
+		"",
+		model.GenerationConfig{},
+		nil,
+	)
+
+	require.Len(t, withBudget, len(withoutBudget)+1)
+}
+
+func TestAppendModelCallBudgetGatewayOption_Disabled(t *testing.T) {
+	t.Parallel()
+
+	opts := appendModelCallBudgetGatewayOption(nil, 0)
+	require.Empty(t, opts)
+}
+
+func TestAppendModelCallBudgetGatewayOption_AddsRunBudget(t *testing.T) {
+	t.Parallel()
+
+	opts := appendModelCallBudgetGatewayOption(nil, 1)
+	require.Len(t, opts, 1)
+}
+
+type countingBudgetModel struct {
+	calls atomic.Int64
+}
+
+func (m *countingBudgetModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	m.calls.Add(1)
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{}
+	close(ch)
+	return ch, nil
+}
+
+func (m *countingBudgetModel) Info() model.Info {
+	return model.Info{Name: "counting"}
+}
+
+func (m *countingBudgetModel) callCount() int64 {
+	return m.calls.Load()
+}
+
+type countingBudgetIterModel struct {
+	countingBudgetModel
+	iterCalls atomic.Int64
+}
+
+func (m *countingBudgetIterModel) GenerateContentIter(
+	_ context.Context,
+	_ *model.Request,
+) (model.Seq[*model.Response], error) {
+	m.iterCalls.Add(1)
+	return func(yield func(*model.Response) bool) {
+		yield(&model.Response{})
+	}, nil
+}
+
+func (m *countingBudgetIterModel) iterCallCount() int64 {
+	return m.iterCalls.Load()
+}
+
+func TestBuildModelCallBudgetRunOptionResolverInjectsBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	resolver := buildModelCallBudgetRunOptionResolver(1)
+	ctx, runOpts, err := resolver(context.Background(), gateway.RunOptionInput{})
+	require.NoError(t, err)
+	require.Len(t, runOpts, 1)
+
+	budget := modelCallBudgetFromContext(ctx)
+	require.NotNil(t, budget)
+
+	opts := agent.NewRunOptions(runOpts...)
+	stateBudget, ok := opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudget)
+	require.True(t, ok)
+	require.Same(t, budget, stateBudget)
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 1, underlying.callCount())
+}


### PR DESCRIPTION
## Summary

- wrap OpenClaw runtime models with a per-request model-call budget
- attach the budget to each gateway run when `max-llm-calls` is configured
- keep the core agent invocation limit semantics unchanged while making the OpenClaw runtime flag cap the full request path, including delegated model calls

## Validation

- `cd openclaw && go test ./app`
