### PR TITLE
openclaw/browser-server: accept press key aliases

### DIFF
--- a/openclaw/browser-server/src/act-kind.js
+++ b/openclaw/browser-server/src/act-kind.js
@@ -1,0 +1,13 @@
+export function normalizeActKind(kind) {
+  const value = `${kind || ""}`.trim();
+  switch (value.toLowerCase()) {
+    case "key":
+    case "key/press":
+    case "keyboard.press":
+    case "press/key":
+    case "presskey":
+      return "press";
+    default:
+      return value;
+  }
+}

--- a/openclaw/browser-server/src/host-profile.js
+++ b/openclaw/browser-server/src/host-profile.js
@@ -5,6 +5,7 @@ import {
   chromium,
   devices as playwrightDevices
 } from "playwright";
+import { normalizeActKind } from "./act-kind.js";
 import { snapshotDOM } from "./dom-tools.js";
 import { validateNavigationURL } from "./ssrf.js";
 
@@ -808,7 +809,7 @@ export class HostProfile {
   async act(targetId, request) {
     const page = this.requirePageOrCurrent(targetId);
     const ref = `${request.ref || ""}`.trim();
-    switch (`${request.kind || ""}`.trim()) {
+    switch (normalizeActKind(request.kind)) {
       case "click":
         await this.click(page, request, ref);
         return textContent(`Clicked ${ref}.`);

--- a/openclaw/browser-server/src/host-profile.test.js
+++ b/openclaw/browser-server/src/host-profile.test.js
@@ -193,6 +193,27 @@ test("HostProfile upload supports file chooser refs", async () => {
   assert.equal(result.content[0].text, "Uploaded 1 file(s).");
 });
 
+test("HostProfile act accepts press/key as a press alias", async () => {
+  const calls = [];
+  const page = {
+    keyboard: {
+      async press(key, options) {
+        calls.push({ key, options });
+      }
+    }
+  };
+
+  const profile = profileForPage(page);
+  const result = await profile.act("tab-1", {
+    kind: "press/key",
+    key: "End",
+    delayMs: 25
+  });
+
+  assert.deepEqual(calls, [{ key: "End", options: { delay: 25 } }]);
+  assert.equal(result.content[0].text, "Pressed End.");
+});
+
 test("HostProfile download clicks a ref and saves the file", async () => {
   const calls = [];
   const download = {

--- a/openclaw/browser-server/src/runtime.js
+++ b/openclaw/browser-server/src/runtime.js
@@ -1,4 +1,5 @@
 import { WebSocketServer } from "ws";
+import { normalizeActKind } from "./act-kind.js";
 import { ChromeRelay } from "./chrome-relay.js";
 import { HostProfile } from "./host-profile.js";
 
@@ -365,7 +366,7 @@ export class BrowserRuntime {
     if (profile === "chrome") {
       return this.chromeRelay.execute(
         payload.targetId || payload.request?.targetId,
-        payload.request?.kind || payload.kind,
+        normalizeActKind(payload.request?.kind || payload.kind),
         payload.request || payload
       );
     }

--- a/openclaw/browser-server/src/runtime.test.js
+++ b/openclaw/browser-server/src/runtime.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { BrowserRuntime } from "./runtime.js";
+
+test("BrowserRuntime normalizes press/key for chrome relay acts", async () => {
+  const runtime = new BrowserRuntime({ policy: {} });
+  const calls = [];
+  runtime.chromeRelay.execute = async (targetId, action, args) => {
+    calls.push({ targetId, action, args });
+    return { content: [{ type: "text", text: "ok" }] };
+  };
+
+  const result = await runtime.act("chrome", {
+    targetId: "tab-1",
+    request: {
+      kind: "press/key",
+      key: "End"
+    }
+  });
+
+  assert.equal(result.content[0].text, "ok");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].targetId, "tab-1");
+  assert.equal(calls[0].action, "press");
+  assert.deepEqual(calls[0].args, {
+    kind: "press/key",
+    key: "End"
+  });
+});


### PR DESCRIPTION
## What changed
- Normalize common keyboard press aliases such as `press/key` to the existing browser `press` action.
- Apply the normalization to both the local Playwright host profile path and the Chrome relay path.
- Add browser-server tests for the host profile and runtime relay routing.

## Why
Some model providers emit keyboard actions as `press/key` even though OpenClaw's browser runtime already supports the equivalent `press` action. Treating this as an alias avoids unnecessary browser tool failures without changing the semantics of existing actions.

## Validation
- `cd openclaw/browser-server && npm test`
