### PR TITLE
tool/webfetch/httpfetch: fallback empty HTML extraction

### DIFF
--- a/tool/webfetch/httpfetch/fetch.go
+++ b/tool/webfetch/httpfetch/fetch.go
@@ -13,6 +13,7 @@ package httpfetch
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,6 +36,8 @@ const (
 
 	maxHTTPErrorBodyLength = 512
 )
+
+var errNoVisibleHTMLText = errors.New("HTML response contained no visible text")
 
 // Option configures the WebFetch tool.
 type Option func(*config)
@@ -461,7 +464,14 @@ func convertHTMLToMarkdownWithOptions(
 		return "", err
 	}
 	if strings.TrimSpace(markdown) == "" {
-		return htmlVisibleTextFallback([]byte(source))
+		text, fallbackErr := htmlVisibleTextFallback([]byte(source))
+		if errors.Is(fallbackErr, errNoVisibleHTMLText) {
+			return markdown, nil
+		}
+		if fallbackErr != nil {
+			return "", fallbackErr
+		}
+		return text, nil
 	}
 
 	return markdown, nil
@@ -473,15 +483,11 @@ func htmlVisibleTextFallback(raw []byte) (string, error) {
 
 func htmlVisibleTextFallbackFromReader(
 	r io.Reader,
-	raw []byte,
+	_ []byte,
 ) (string, error) {
 	doc, err := html.Parse(r)
 	if err != nil {
-		text := strings.TrimSpace(string(raw))
-		if text == "" {
-			return "", fmt.Errorf("HTML response contained no visible text")
-		}
-		return text, nil
+		return "", fmt.Errorf("parse HTML for visible-text fallback: %w", err)
 	}
 
 	var chunks []string
@@ -495,7 +501,7 @@ func htmlVisibleTextFallbackFromReader(
 		}
 	})
 	if len(chunks) == 0 {
-		return "", fmt.Errorf("HTML response contained no visible text")
+		return "", errNoVisibleHTMLText
 	}
 	return strings.Join(chunks, "\n"), nil
 }

--- a/tool/webfetch/httpfetch/fetch.go
+++ b/tool/webfetch/httpfetch/fetch.go
@@ -455,14 +455,49 @@ func convertHTMLToMarkdownWithOptions(
 			commonmark.NewCommonmarkPlugin(),
 		),
 	)
-	markdown, err := conv.ConvertString(
-		markdownSourceHTML(bodyBytes, mainContentOnly),
-	)
+	source := markdownSourceHTML(bodyBytes, mainContentOnly)
+	markdown, err := conv.ConvertString(source)
 	if err != nil {
 		return "", err
 	}
+	if strings.TrimSpace(markdown) == "" {
+		return htmlVisibleTextFallback([]byte(source))
+	}
 
 	return markdown, nil
+}
+
+func htmlVisibleTextFallback(raw []byte) (string, error) {
+	return htmlVisibleTextFallbackFromReader(bytes.NewReader(raw), raw)
+}
+
+func htmlVisibleTextFallbackFromReader(
+	r io.Reader,
+	raw []byte,
+) (string, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		text := strings.TrimSpace(string(raw))
+		if text == "" {
+			return "", fmt.Errorf("HTML response contained no visible text")
+		}
+		return text, nil
+	}
+
+	var chunks []string
+	walkHTML(doc, func(n *html.Node) {
+		if n.Type != html.TextNode || hasInvisibleHTMLAncestor(n.Parent) {
+			return
+		}
+		text := strings.Join(strings.Fields(n.Data), " ")
+		if text != "" {
+			chunks = append(chunks, text)
+		}
+	})
+	if len(chunks) == 0 {
+		return "", fmt.Errorf("HTML response contained no visible text")
+	}
+	return strings.Join(chunks, "\n"), nil
 }
 
 func markdownSourceHTML(raw []byte, mainContentOnly bool) string {
@@ -592,9 +627,32 @@ func isNoisyHTMLNode(n *html.Node) bool {
 	if n.Type != html.ElementNode {
 		return false
 	}
+	if isInvisibleHTMLNode(n) {
+		return true
+	}
 	switch strings.ToLower(n.Data) {
-	case "script", "style", "noscript", "template", "svg",
-		"nav", "header", "footer", "form":
+	case "nav", "header", "footer", "form":
+		return true
+	}
+	return false
+}
+
+func hasInvisibleHTMLAncestor(n *html.Node) bool {
+	for n != nil {
+		if isInvisibleHTMLNode(n) {
+			return true
+		}
+		n = n.Parent
+	}
+	return false
+}
+
+func isInvisibleHTMLNode(n *html.Node) bool {
+	if n == nil || n.Type != html.ElementNode {
+		return false
+	}
+	switch strings.ToLower(n.Data) {
+	case "script", "style", "noscript", "template", "svg":
 		return true
 	}
 	if hasHTMLAttr(n, "hidden") {

--- a/tool/webfetch/httpfetch/fetch_test.go
+++ b/tool/webfetch/httpfetch/fetch_test.go
@@ -452,14 +452,15 @@ func TestHTMLVisibleTextFallbackReportsEmptyContent(t *testing.T) {
 	assert.Contains(t, err.Error(), "no visible text")
 }
 
-func TestHTMLVisibleTextFallbackReturnsRawTextWhenParseFails(t *testing.T) {
+func TestHTMLVisibleTextFallbackReportsParseFailure(t *testing.T) {
 	result, err := htmlVisibleTextFallbackFromReader(
 		errReader{},
 		[]byte("  visible fallback text  "),
 	)
 
-	require.NoError(t, err)
-	assert.Equal(t, "visible fallback text", result)
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "parse HTML for visible-text fallback")
 }
 
 func TestHTMLVisibleTextFallbackReportsParseFailureWithEmptyRawText(
@@ -469,10 +470,10 @@ func TestHTMLVisibleTextFallbackReportsParseFailureWithEmptyRawText(
 
 	require.Error(t, err)
 	assert.Empty(t, result)
-	assert.Contains(t, err.Error(), "no visible text")
+	assert.Contains(t, err.Error(), "parse HTML for visible-text fallback")
 }
 
-func TestConvertHTMLToMarkdownReportsEmptyVisibleHTML(t *testing.T) {
+func TestConvertHTMLToMarkdownKeepsEmptyVisibleHTMLSuccessful(t *testing.T) {
 	result, err := convertHTMLToMarkdown(strings.NewReader(`
 		<html>
 		<body>
@@ -481,9 +482,8 @@ func TestConvertHTMLToMarkdownReportsEmptyVisibleHTML(t *testing.T) {
 		</body>
 		</html>`))
 
-	require.Error(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, result)
-	assert.Contains(t, err.Error(), "no visible text")
 }
 
 func TestWebFetch_MainContentExtractionOption(t *testing.T) {

--- a/tool/webfetch/httpfetch/fetch_test.go
+++ b/tool/webfetch/httpfetch/fetch_test.go
@@ -23,6 +23,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type errReader struct{}
+
+func (errReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
 func TestWebFetch(t *testing.T) {
 	// Mock server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -400,6 +406,84 @@ func TestConvertHTMLToMarkdownCanPreferMainContent(t *testing.T) {
 	assert.Contains(t, result, "356,400-370,400 km")
 	assert.NotContains(t, result, "Main menu navigation")
 	assert.NotContains(t, result, "Footer links")
+}
+
+func TestHTMLVisibleTextFallbackKeepsVisiblePageText(t *testing.T) {
+	htmlContent := `
+		<html>
+		<body>
+			<header>Useful header notice</header>
+			<script>console.log("hidden")</script>
+			<style>.hidden { display: none }</style>
+			<div>Visible <span>article</span> text.</div>
+			<p hidden>Hidden paragraph.</p>
+			<p aria-hidden="true">Aria hidden paragraph.</p>
+			<p style="display: none">CSS hidden paragraph.</p>
+			<footer>Useful footer citation</footer>
+		</body>
+		</html>`
+
+	result, err := htmlVisibleTextFallback([]byte(htmlContent))
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "Useful header notice")
+	assert.Contains(t, result, "Visible")
+	assert.Contains(t, result, "article")
+	assert.Contains(t, result, "text.")
+	assert.Contains(t, result, "Useful footer citation")
+	assert.NotContains(t, result, "console.log")
+	assert.NotContains(t, result, "display: none")
+	assert.NotContains(t, result, "Hidden paragraph")
+	assert.NotContains(t, result, "Aria hidden paragraph")
+	assert.NotContains(t, result, "CSS hidden paragraph")
+}
+
+func TestHTMLVisibleTextFallbackReportsEmptyContent(t *testing.T) {
+	result, err := htmlVisibleTextFallback([]byte(`
+		<html>
+		<body>
+			<script>console.log("hidden")</script>
+			<style>body { color: red }</style>
+		</body>
+		</html>`))
+
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "no visible text")
+}
+
+func TestHTMLVisibleTextFallbackReturnsRawTextWhenParseFails(t *testing.T) {
+	result, err := htmlVisibleTextFallbackFromReader(
+		errReader{},
+		[]byte("  visible fallback text  "),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "visible fallback text", result)
+}
+
+func TestHTMLVisibleTextFallbackReportsParseFailureWithEmptyRawText(
+	t *testing.T,
+) {
+	result, err := htmlVisibleTextFallbackFromReader(errReader{}, nil)
+
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "no visible text")
+}
+
+func TestConvertHTMLToMarkdownReportsEmptyVisibleHTML(t *testing.T) {
+	result, err := convertHTMLToMarkdown(strings.NewReader(`
+		<html>
+		<body>
+			<script>console.log("hidden")</script>
+			<style>body { color: red }</style>
+		</body>
+		</html>`))
+
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "no visible text")
 }
 
 func TestWebFetch_MainContentExtractionOption(t *testing.T) {


### PR DESCRIPTION
## Summary
- fall back to visible HTML text when markdown conversion returns empty content
- report a clear error when an HTML response has no visible text
- keep full-page fetch behavior compatible by only skipping invisible nodes in the fallback path

## Tests
- go test ./... -count=1 (tool/webfetch/httpfetch)
- go test ./... -coverprofile=/tmp/webfetch_httpfetch_cover.out -covermode=count (tool/webfetch/httpfetch)