### PR TITLE
tool/file: allow absolute reads under base dir

### DIFF
--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -321,11 +321,24 @@ func (f *fileToolSet) matchBaseDir(absPath string) bool {
 	}
 	candidate := filepath.Clean(absPath)
 	base := filepath.Clean(f.baseDir)
-	candidateInBase := isPathWithinRoot(candidate, base)
 	evaluatedCandidate, resolvedPath := evalPathWithExistingParent(candidate)
-	evaluatedInBase := resolvedPath &&
-		isPathWithinRoot(evaluatedCandidate, base)
-	return candidateInBase && (!resolvedPath || evaluatedInBase)
+	evaluatedBase, resolvedBase := evalPathWithExistingParent(base)
+	roots := []string{base}
+	if resolvedBase && evaluatedBase != base {
+		roots = append(roots, evaluatedBase)
+	}
+	for _, root := range roots {
+		candidateInBase := isPathWithinRoot(candidate, root)
+		evaluatedInBase := resolvedPath &&
+			isPathWithinRoot(evaluatedCandidate, root)
+		if candidateInBase && (!resolvedPath || evaluatedInBase) {
+			return true
+		}
+		if !candidateInBase && evaluatedInBase {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *fileToolSet) matchExtraReadRoot(absPath string) (string, bool) {

--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -300,6 +300,9 @@ func (f *fileToolSet) resolveReadPath(requestPath string) (string, error) {
 		return f.resolvePath(requestPath)
 	}
 	clean := filepath.Clean(raw)
+	if f.matchBaseDir(clean) {
+		return clean, nil
+	}
 	if _, ok := f.matchExtraReadRoot(clean); ok {
 		return clean, nil
 	}
@@ -310,6 +313,19 @@ func (f *fileToolSet) resolveReadPath(requestPath string) (string, error) {
 		extraReadRootGuidance,
 		relativePathGuidance,
 	)
+}
+
+func (f *fileToolSet) matchBaseDir(absPath string) bool {
+	if f == nil || strings.TrimSpace(f.baseDir) == "" {
+		return false
+	}
+	candidate := filepath.Clean(absPath)
+	base := filepath.Clean(f.baseDir)
+	candidateInBase := isPathWithinRoot(candidate, base)
+	evaluatedCandidate, resolvedPath := evalPathWithExistingParent(candidate)
+	evaluatedInBase := resolvedPath &&
+		isPathWithinRoot(evaluatedCandidate, base)
+	return candidateInBase && (!resolvedPath || evaluatedInBase)
 }
 
 func (f *fileToolSet) matchExtraReadRoot(absPath string) (string, bool) {

--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -320,14 +320,8 @@ func (f *fileToolSet) matchBaseDir(absPath string) bool {
 		return false
 	}
 	candidate := filepath.Clean(absPath)
-	base := filepath.Clean(f.baseDir)
 	evaluatedCandidate, resolvedPath := evalPathWithExistingParent(candidate)
-	evaluatedBase, resolvedBase := evalPathWithExistingParent(base)
-	roots := []string{base}
-	if resolvedBase && evaluatedBase != base {
-		roots = append(roots, evaluatedBase)
-	}
-	for _, root := range roots {
+	for _, root := range rootPathCandidates(f.baseDir) {
 		candidateInBase := isPathWithinRoot(candidate, root)
 		evaluatedInBase := resolvedPath &&
 			isPathWithinRoot(evaluatedCandidate, root)
@@ -339,6 +333,33 @@ func (f *fileToolSet) matchBaseDir(absPath string) bool {
 		}
 	}
 	return false
+}
+
+func rootPathCandidates(root string) []string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil
+	}
+	seen := make(map[string]struct{}, 3)
+	var roots []string
+	add := func(candidate string) {
+		candidate = filepath.Clean(candidate)
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		roots = append(roots, candidate)
+	}
+	add(root)
+	if abs, err := filepath.Abs(root); err == nil {
+		add(abs)
+	}
+	for _, candidate := range append([]string(nil), roots...) {
+		if resolved, ok := evalPathWithExistingParent(candidate); ok {
+			add(resolved)
+		}
+	}
+	return roots
 }
 
 func (f *fileToolSet) matchExtraReadRoot(absPath string) (string, bool) {

--- a/tool/file/file_test.go
+++ b/tool/file/file_test.go
@@ -242,6 +242,22 @@ func TestResolveReadPath_BaseDirAbsolute(t *testing.T) {
 	assert.Equal(t, allowed, p)
 }
 
+func TestResolveReadPath_RelativeBaseDirAbsolute(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	dir := t.TempDir()
+	relDir, err := filepath.Rel(cwd, dir)
+	assert.NoError(t, err)
+	set, err := NewToolSet(WithBaseDir(relDir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	allowed := filepath.Join(dir, "a.txt")
+	p, err := fts.resolveReadPath(allowed)
+	assert.NoError(t, err)
+	assert.Equal(t, allowed, p)
+}
+
 func TestMatchBaseDir_Empty(t *testing.T) {
 	var nilSet *fileToolSet
 	assert.False(t, nilSet.matchBaseDir("/tmp/a.txt"))

--- a/tool/file/file_test.go
+++ b/tool/file/file_test.go
@@ -230,6 +230,24 @@ func TestResolveReadPath_ExtraReadRoot(t *testing.T) {
 	assert.Contains(t, err.Error(), relativePathGuidance)
 }
 
+func TestResolveReadPath_BaseDirAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(dir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	allowed := filepath.Join(dir, "a.txt")
+	p, err := fts.resolveReadPath(allowed)
+	assert.NoError(t, err)
+	assert.Equal(t, allowed, p)
+}
+
+func TestMatchBaseDir_Empty(t *testing.T) {
+	var nilSet *fileToolSet
+	assert.False(t, nilSet.matchBaseDir("/tmp/a.txt"))
+	assert.False(t, (&fileToolSet{}).matchBaseDir("/tmp/a.txt"))
+}
+
 func TestResolvePath_Empty(t *testing.T) {
 	dir := t.TempDir()
 	set, err := NewToolSet(WithBaseDir(dir))

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -67,6 +67,29 @@ func TestFileTool_ReadFile_AbsolutePathUnderBaseDir(t *testing.T) {
 	assert.Equal(t, "derived", rsp.Contents)
 }
 
+func TestFileTool_ReadFile_AbsolutePathUnderSymlinkedBaseDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on windows")
+	}
+	realBase := t.TempDir()
+	parent := t.TempDir()
+	baseLink := filepath.Join(parent, "base")
+	assert.NoError(t, os.Symlink(realBase, baseLink))
+	fileName := filepath.Join(baseLink, "derived.txt")
+	assert.NoError(t, os.WriteFile(fileName, []byte("derived"), 0o644))
+
+	toolSet, err := NewToolSet(WithBaseDir(baseLink))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: fileName},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "derived", rsp.Contents)
+}
+
 func TestFileTool_ReadFile_BlocksSymlinkEscapeFromBaseDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink permissions vary on windows")

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -50,6 +50,47 @@ func TestFileTool_ReadFile(t *testing.T) {
 	assert.Equal(t, testContent, rsp.Contents)
 }
 
+func TestFileTool_ReadFile_AbsolutePathUnderBaseDir(t *testing.T) {
+	base := t.TempDir()
+	fileName := filepath.Join(base, "derived.txt")
+	assert.NoError(t, os.WriteFile(fileName, []byte("derived"), 0o644))
+
+	toolSet, err := NewToolSet(WithBaseDir(base))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: fileName},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "derived", rsp.Contents)
+}
+
+func TestFileTool_ReadFile_BlocksSymlinkEscapeFromBaseDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on windows")
+	}
+	base := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	assert.NoError(t, os.WriteFile(secret, []byte("secret"), 0o644))
+	link := filepath.Join(base, "link.txt")
+	assert.NoError(t, os.Symlink(secret, link))
+
+	toolSet, err := NewToolSet(WithBaseDir(base))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: link},
+	)
+	assert.Error(t, err)
+	assert.Empty(t, rsp.Contents)
+	assert.Contains(t, err.Error(), "outside configured read-only roots")
+}
+
 func TestFileTool_ReadFile_AbsolutePathUnderExtraReadRoot(t *testing.T) {
 	base := t.TempDir()
 	extra := t.TempDir()

--- a/tool/file/readmultiplefiles_test.go
+++ b/tool/file/readmultiplefiles_test.go
@@ -199,6 +199,25 @@ func TestReadMultipleFiles(t *testing.T) {
 	}
 }
 
+func TestReadMultipleFiles_AbsolutePathUnderBaseDir(t *testing.T) {
+	base := t.TempDir()
+	fileName := filepath.Join(base, "derived.txt")
+	assert.NoError(t, os.WriteFile(fileName, []byte("derived"), 0o644))
+
+	set, err := NewToolSet(WithBaseDir(base))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	rsp, err := fts.readMultipleFiles(
+		context.Background(),
+		&readMultipleFilesRequest{Patterns: []string{fileName}},
+	)
+	assert.NoError(t, err)
+	assert.Len(t, rsp.Files, 1)
+	assert.Equal(t, fileName, rsp.Files[0].FileName)
+	assert.Equal(t, "derived", rsp.Files[0].Contents)
+}
+
 func TestReadMultipleFiles_AbsolutePathUnderExtraReadRoot(t *testing.T) {
 	base := t.TempDir()
 	extra := t.TempDir()


### PR DESCRIPTION
## Summary
- allow read-only file tools to read absolute paths when they resolve under base_directory
- keep write/replace path rules unchanged
- preserve symlink escape checks for both base_directory and extra read-only roots

## Tests
- go test ./tool/file -run 'TestFileTool_ReadFile_AbsolutePathUnderBaseDir|TestFileTool_ReadFile_BlocksSymlinkEscapeFromBaseDir|TestFileTool_ReadFile_AbsolutePathUnderExtraReadRoot|TestFileTool_ReadFile_BlocksSymlinkEscapeFromExtraReadRoot|TestReadMultipleFiles_AbsolutePathUnderBaseDir|TestReadMultipleFiles_AbsolutePathUnderExtraReadRoot|TestReadMultipleFiles_BlocksSymlinkEscapeFromExtraReadRoot' -count=1\n- go test ./tool/file -coverprofile=/tmp/tool_file_abs_base_cover2.out -covermode=count