### PR TITLE
openclaw/app: add model HTTP timeout option

### DIFF
--- a/model/anthropic/http_client.go
+++ b/model/anthropic/http_client.go
@@ -19,6 +19,8 @@ var (
 	WithHTTPClientName = model.WithHTTPClientName
 	// WithHTTPClientTransport is the option for the HTTP client transport.
 	WithHTTPClientTransport = model.WithHTTPClientTransport
+	// WithHTTPClientTimeout is the option for the HTTP client timeout.
+	WithHTTPClientTimeout = model.WithHTTPClientTimeout
 )
 
 // HTTPClientOption is the option for the HTTP client.

--- a/model/http_client.go
+++ b/model/http_client.go
@@ -10,7 +10,10 @@
 // Package model provides interfaces for working with LLMs.
 package model
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // HTTPClient is the interface for the HTTP client.
 type HTTPClient interface {
@@ -28,6 +31,7 @@ var DefaultNewHTTPClient HTTPClientNewFunc = func(opts ...HTTPClientOption) HTTP
 	}
 	return &http.Client{
 		Transport: options.Transport,
+		Timeout:   options.Timeout,
 	}
 }
 
@@ -48,8 +52,16 @@ func WithHTTPClientTransport(transport http.RoundTripper) HTTPClientOption {
 	}
 }
 
+// WithHTTPClientTimeout configures the HTTP client timeout.
+func WithHTTPClientTimeout(timeout time.Duration) HTTPClientOption {
+	return func(options *HTTPClientOptions) {
+		options.Timeout = timeout
+	}
+}
+
 // HTTPClientOptions is the options for the HTTP client.
 type HTTPClientOptions struct {
 	Name      string
 	Transport http.RoundTripper
+	Timeout   time.Duration
 }

--- a/model/http_client_test.go
+++ b/model/http_client_test.go
@@ -13,6 +13,7 @@ package model
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ func TestDefaultNewHTTPClient_WithOptions(t *testing.T) {
 	client := DefaultNewHTTPClient(
 		WithHTTPClientName("test-client"),
 		WithHTTPClientTransport(customTransport),
+		WithHTTPClientTimeout(3*time.Second),
 	)
 
 	require.NotNil(t, client)
@@ -37,6 +39,7 @@ func TestDefaultNewHTTPClient_WithOptions(t *testing.T) {
 	httpClient, ok := client.(*http.Client)
 	require.True(t, ok)
 	assert.Same(t, customTransport, httpClient.Transport)
+	assert.Equal(t, 3*time.Second, httpClient.Timeout)
 }
 
 func TestDefaultNewHTTPClient_NoOptions(t *testing.T) {
@@ -66,15 +69,25 @@ func TestWithHTTPClientTransport(t *testing.T) {
 	assert.Same(t, customTransport, options.Transport)
 }
 
+func TestWithHTTPClientTimeout(t *testing.T) {
+	options := &HTTPClientOptions{}
+
+	WithHTTPClientTimeout(5 * time.Second)(options)
+
+	assert.Equal(t, 5*time.Second, options.Timeout)
+}
+
 func TestHTTPClientOptions_Merge(t *testing.T) {
 	customTransport := &http.Transport{}
 	options := &HTTPClientOptions{}
 
 	WithHTTPClientName("merged-client")(options)
 	WithHTTPClientTransport(customTransport)(options)
+	WithHTTPClientTimeout(7 * time.Second)(options)
 
 	assert.Equal(t, "merged-client", options.Name)
 	assert.Same(t, customTransport, options.Transport)
+	assert.Equal(t, 7*time.Second, options.Timeout)
 }
 
 func TestHTTPClientInterface(t *testing.T) {
@@ -96,6 +109,7 @@ func TestDefaultImplementationCompleteness(t *testing.T) {
 	opts := []HTTPClientOption{
 		WithHTTPClientName("complete-test"),
 		WithHTTPClientTransport(http.DefaultTransport),
+		WithHTTPClientTimeout(time.Second),
 	}
 
 	for _, opt := range opts {
@@ -104,6 +118,7 @@ func TestDefaultImplementationCompleteness(t *testing.T) {
 
 	assert.Equal(t, "complete-test", options.Name)
 	assert.Same(t, http.DefaultTransport, options.Transport)
+	assert.Equal(t, time.Second, options.Timeout)
 }
 
 func TestEdgeCases(t *testing.T) {
@@ -115,6 +130,10 @@ func TestEdgeCases(t *testing.T) {
 	WithHTTPClientTransport(nil)(options)
 	assert.Nil(t, options.Transport)
 
+	options = &HTTPClientOptions{}
+	WithHTTPClientTimeout(0)(options)
+	assert.Zero(t, options.Timeout)
+
 	client := DefaultNewHTTPClient()
 	require.NotNil(t, client)
 }
@@ -125,6 +144,9 @@ func TestMultipleOptionApplications(t *testing.T) {
 	WithHTTPClientName("first")(options)
 	WithHTTPClientName("second")(options)
 	WithHTTPClientName("third")(options)
+	WithHTTPClientTimeout(time.Second)(options)
+	WithHTTPClientTimeout(2 * time.Second)(options)
 
 	assert.Equal(t, "third", options.Name)
+	assert.Equal(t, 2*time.Second, options.Timeout)
 }

--- a/model/openai/http_client.go
+++ b/model/openai/http_client.go
@@ -19,6 +19,8 @@ var (
 	WithHTTPClientName = model.WithHTTPClientName
 	// WithHTTPClientTransport is the option for the HTTP client transport.
 	WithHTTPClientTransport = model.WithHTTPClientTransport
+	// WithHTTPClientTimeout is the option for the HTTP client timeout.
+	WithHTTPClientTimeout = model.WithHTTPClientTimeout
 )
 
 // HTTPClientOption is the option for the HTTP client.

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -35,6 +35,7 @@ import (
 	"time"
 	"unicode"
 
+	openaiopt "github.com/openai/openai-go/option"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
 	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
@@ -3808,6 +3809,25 @@ func newOpenAIModel(spec registry.ModelSpec) (model.Model, error) {
 	if apiKey := strings.TrimSpace(spec.APIKey); apiKey != "" {
 		opts = append(opts, openai.WithAPIKey(apiKey))
 	}
+	if spec.Timeout > 0 {
+		opts = append(
+			opts,
+			openai.WithHTTPClientOptions(
+				openai.WithHTTPClientTimeout(spec.Timeout),
+			),
+			openai.WithOpenAIOptions(
+				openaiopt.WithRequestTimeout(spec.Timeout),
+			),
+		)
+	}
+	if spec.MaxRetries != nil {
+		opts = append(
+			opts,
+			openai.WithOpenAIOptions(
+				openaiopt.WithMaxRetries(*spec.MaxRetries),
+			),
+		)
+	}
 	if len(spec.Headers) > 0 {
 		opts = append(opts, openai.WithHeaders(spec.Headers))
 	}
@@ -3846,11 +3866,27 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 		APIKey:                       apiKey,
 		OpenAIVariant:                opts.OpenAIVariant,
 		OpenAITextOnlyMessageContent: opts.OpenAITextOnlyMessageContent,
-		Headers:                      headers,
-		DebugRecorderEnabled:         opts.DebugRecorderEnabled,
-		Config:                       opts.ModelConfig,
+		Timeout:                      opts.OpenAITimeout,
+		MaxRetries: openAIMaxRetriesPtr(
+			opts.OpenAIMaxRetries,
+			opts.OpenAIMaxRetriesSet,
+		),
+		Headers:              headers,
+		DebugRecorderEnabled: opts.DebugRecorderEnabled,
+		Config:               opts.ModelConfig,
 	}
-	return f(spec)
+	mdl, err := f(spec)
+	if err != nil {
+		return nil, err
+	}
+	return newModelTimeoutModel(mdl, opts.OpenAITimeout), nil
+}
+
+func openAIMaxRetriesPtr(maxRetries int, set bool) *int {
+	if !set || maxRetries < 0 {
+		return nil
+	}
+	return &maxRetries
 }
 
 func resolveOpenAIHeaders(

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4863,12 +4863,15 @@ func TestNewModel_OpenAIGLMPreservesNonTextContentByDefault(t *testing.T) {
 }
 
 func TestNewModel_OpenAITimeout(t *testing.T) {
+	release := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(
 		w http.ResponseWriter,
 		r *http.Request,
 	) {
 		select {
 		case <-r.Context().Done():
+			return
+		case <-release:
 			return
 		case <-time.After(5 * time.Second):
 		}
@@ -4885,7 +4888,11 @@ func TestNewModel_OpenAITimeout(t *testing.T) {
 			}]
 		}`))
 	}))
-	defer server.Close()
+	defer func() {
+		server.CloseClientConnections()
+		server.Close()
+	}()
+	defer close(release)
 
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	mdl, err := modelFromOptions(runOptions{

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4862,6 +4862,62 @@ func TestNewModel_OpenAIGLMPreservesNonTextContentByDefault(t *testing.T) {
 	require.NotContains(t, body, "Omitted non-text attachments")
 }
 
+func TestNewModel_OpenAITimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":123,
+			"model":"glm50",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"ok"},
+				"finish_reason":"stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	mdl, err := modelFromOptions(runOptions{
+		ModelMode:           modeOpenAI,
+		OpenAIModel:         "glm50",
+		OpenAIVariant:       openAIVariantAuto,
+		OpenAIBaseURL:       server.URL,
+		OpenAITimeout:       50 * time.Millisecond,
+		OpenAIMaxRetriesSet: true,
+		OpenAIMaxRetries:    0,
+	})
+	require.NoError(t, err)
+
+	start := time.Now()
+	ch, err := mdl.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hi")},
+		GenerationConfig: model.GenerationConfig{
+			Stream: false,
+		},
+	})
+	require.NoError(t, err)
+
+	var gotErr error
+	for rsp := range ch {
+		if rsp.Error != nil {
+			gotErr = rsp.Error
+		}
+	}
+	require.Error(t, gotErr)
+	require.Less(t, time.Since(start), 2*time.Second)
+}
+
 func TestResolveOpenAIHeaders_EnvOnlyAndConfigOnly(t *testing.T) {
 	t.Setenv(
 		openAIHeadersEnvName,

--- a/openclaw/app/model_timeout.go
+++ b/openclaw/app/model_timeout.go
@@ -92,6 +92,9 @@ func (m *modelTimeoutModel) forwardResponses(
 			select {
 			case rsp, ok := <-ch:
 				if !ok {
+					if err := ctx.Err(); err != nil {
+						sendTimeoutResponse(out, m.timeout, err)
+					}
 					return
 				}
 				select {
@@ -168,6 +171,9 @@ func (m *modelTimeoutIterModel) forwardSeq(
 			select {
 			case rsp, ok := <-ch:
 				if !ok {
+					if err := ctx.Err(); err != nil {
+						yield(timeoutResponse(m.timeout, err))
+					}
 					return
 				}
 				if !yield(rsp) {

--- a/openclaw/app/model_timeout.go
+++ b/openclaw/app/model_timeout.go
@@ -1,0 +1,231 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type modelTimeoutResult struct {
+	ch  <-chan *model.Response
+	err error
+}
+
+type modelTimeoutIterResult struct {
+	seq model.Seq[*model.Response]
+	err error
+}
+
+func newModelTimeoutModel(
+	m model.Model,
+	timeout time.Duration,
+) model.Model {
+	if m == nil || timeout <= 0 {
+		return m
+	}
+	wrapped := &modelTimeoutModel{
+		model:   m,
+		timeout: timeout,
+	}
+	if iter, ok := m.(model.IterModel); ok {
+		return &modelTimeoutIterModel{
+			modelTimeoutModel: wrapped,
+			iter:              iter,
+		}
+	}
+	return wrapped
+}
+
+type modelTimeoutModel struct {
+	model   model.Model
+	timeout time.Duration
+}
+
+func (m *modelTimeoutModel) GenerateContent(
+	ctx context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	callCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	resultCh := make(chan modelTimeoutResult, 1)
+	go func() {
+		ch, err := m.model.GenerateContent(callCtx, req)
+		resultCh <- modelTimeoutResult{ch: ch, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			cancel()
+			return nil, result.err
+		}
+		return m.forwardResponses(callCtx, cancel, result.ch), nil
+	case <-callCtx.Done():
+		cancel()
+		return singleTimeoutResponse(m.timeout, callCtx.Err()), nil
+	}
+}
+
+func (m *modelTimeoutModel) forwardResponses(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	ch <-chan *model.Response,
+) <-chan *model.Response {
+	out := make(chan *model.Response, 1)
+	go func() {
+		defer close(out)
+		defer cancel()
+		for {
+			select {
+			case rsp, ok := <-ch:
+				if !ok {
+					return
+				}
+				select {
+				case out <- rsp:
+				case <-ctx.Done():
+					sendTimeoutResponse(out, m.timeout, ctx.Err())
+					return
+				}
+			case <-ctx.Done():
+				sendTimeoutResponse(out, m.timeout, ctx.Err())
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func (m *modelTimeoutModel) Info() model.Info {
+	return m.model.Info()
+}
+
+type modelTimeoutIterModel struct {
+	*modelTimeoutModel
+	iter model.IterModel
+}
+
+func (m *modelTimeoutIterModel) GenerateContentIter(
+	ctx context.Context,
+	req *model.Request,
+) (model.Seq[*model.Response], error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	callCtx, cancel := context.WithTimeout(ctx, m.timeout)
+	resultCh := make(chan modelTimeoutIterResult, 1)
+	go func() {
+		seq, err := m.iter.GenerateContentIter(callCtx, req)
+		resultCh <- modelTimeoutIterResult{seq: seq, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			cancel()
+			return nil, result.err
+		}
+		return m.forwardSeq(callCtx, cancel, result.seq), nil
+	case <-callCtx.Done():
+		cancel()
+		return timeoutSeq(m.timeout, callCtx.Err()), nil
+	}
+}
+
+func (m *modelTimeoutIterModel) forwardSeq(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	seq model.Seq[*model.Response],
+) model.Seq[*model.Response] {
+	return func(yield func(*model.Response) bool) {
+		defer cancel()
+		ch := make(chan *model.Response)
+		go func() {
+			defer close(ch)
+			seq(func(rsp *model.Response) bool {
+				select {
+				case ch <- rsp:
+					return true
+				case <-ctx.Done():
+					return false
+				}
+			})
+		}()
+		for {
+			select {
+			case rsp, ok := <-ch:
+				if !ok {
+					return
+				}
+				if !yield(rsp) {
+					return
+				}
+			case <-ctx.Done():
+				yield(timeoutResponse(m.timeout, ctx.Err()))
+				return
+			}
+		}
+	}
+}
+
+func timeoutSeq(
+	timeout time.Duration,
+	err error,
+) model.Seq[*model.Response] {
+	return func(yield func(*model.Response) bool) {
+		yield(timeoutResponse(timeout, err))
+	}
+}
+
+func singleTimeoutResponse(
+	timeout time.Duration,
+	err error,
+) <-chan *model.Response {
+	ch := make(chan *model.Response, 1)
+	ch <- timeoutResponse(timeout, err)
+	close(ch)
+	return ch
+}
+
+func sendTimeoutResponse(
+	ch chan<- *model.Response,
+	timeout time.Duration,
+	err error,
+) {
+	select {
+	case ch <- timeoutResponse(timeout, err):
+	default:
+	}
+}
+
+func timeoutResponse(
+	timeout time.Duration,
+	err error,
+) *model.Response {
+	message := fmt.Sprintf("model request timeout after %s", timeout)
+	if err != nil && err != context.DeadlineExceeded {
+		message = fmt.Sprintf("model request canceled: %v", err)
+	}
+	return &model.Response{
+		Object: model.ObjectTypeError,
+		Error: &model.ResponseError{
+			Message: message,
+			Type:    model.ErrorTypeCancelled,
+		},
+		Timestamp: time.Now(),
+		Done:      true,
+	}
+}

--- a/openclaw/app/model_timeout.go
+++ b/openclaw/app/model_timeout.go
@@ -84,7 +84,7 @@ func (m *modelTimeoutModel) forwardResponses(
 	cancel context.CancelFunc,
 	ch <-chan *model.Response,
 ) <-chan *model.Response {
-	out := make(chan *model.Response, 1)
+	out := make(chan *model.Response, 2)
 	go func() {
 		defer close(out)
 		defer cancel()
@@ -205,10 +205,7 @@ func sendTimeoutResponse(
 	timeout time.Duration,
 	err error,
 ) {
-	select {
-	case ch <- timeoutResponse(timeout, err):
-	default:
-	}
+	ch <- timeoutResponse(timeout, err)
 }
 
 func timeoutResponse(

--- a/openclaw/app/model_timeout_test.go
+++ b/openclaw/app/model_timeout_test.go
@@ -1,0 +1,216 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestNewModelTimeoutModel_DisabledReturnsOriginal(t *testing.T) {
+	t.Parallel()
+
+	underlying := &timeoutImmediateModel{}
+	require.Same(t, underlying, newModelTimeoutModel(underlying, 0))
+	require.Nil(t, newModelTimeoutModel(nil, time.Second))
+}
+
+func TestModelTimeoutModel_StopsBlockedCreation(t *testing.T) {
+	t.Parallel()
+
+	underlying := newBlockingCreationModel()
+	wrapped := newModelTimeoutModel(underlying, 10*time.Millisecond)
+	defer close(underlying.release)
+
+	ch, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.NoError(t, err)
+
+	resp := readTimeoutResponse(t, ch)
+	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+	require.Contains(t, resp.Error.Message, "model request timeout")
+}
+
+func TestModelTimeoutModel_StopsBlockedStream(t *testing.T) {
+	t.Parallel()
+
+	underlying := newBlockingStreamModel()
+	wrapped := newModelTimeoutModel(underlying, 10*time.Millisecond)
+	defer close(underlying.release)
+
+	ch, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.NoError(t, err)
+
+	resp := readTimeoutResponse(t, ch)
+	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+	require.Contains(t, resp.Error.Message, "model request timeout")
+}
+
+func TestModelTimeoutIterModel_StopsBlockedCreation(t *testing.T) {
+	t.Parallel()
+
+	underlying := newBlockingIterCreationModel()
+	wrapped := newModelTimeoutModel(underlying, 10*time.Millisecond)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+	defer close(underlying.release)
+
+	seq, err := iter.GenerateContentIter(
+		context.Background(),
+		&model.Request{},
+	)
+	require.NoError(t, err)
+
+	var resp *model.Response
+	seq(func(r *model.Response) bool {
+		resp = r
+		return false
+	})
+	require.NotNil(t, resp)
+	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+}
+
+func TestModelTimeoutIterModel_StopsBlockedSeq(t *testing.T) {
+	t.Parallel()
+
+	underlying := newBlockingIterSeqModel()
+	wrapped := newModelTimeoutModel(underlying, 10*time.Millisecond)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+	defer close(underlying.release)
+
+	seq, err := iter.GenerateContentIter(
+		context.Background(),
+		&model.Request{},
+	)
+	require.NoError(t, err)
+
+	var resp *model.Response
+	seq(func(r *model.Response) bool {
+		resp = r
+		return false
+	})
+	require.NotNil(t, resp)
+	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+}
+
+func readTimeoutResponse(
+	t *testing.T,
+	ch <-chan *model.Response,
+) *model.Response {
+	t.Helper()
+
+	select {
+	case resp, ok := <-ch:
+		require.True(t, ok)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Error)
+		return resp
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for model timeout response")
+	}
+	return nil
+}
+
+type timeoutImmediateModel struct{}
+
+func (m *timeoutImmediateModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{Done: true}
+	close(ch)
+	return ch, nil
+}
+
+func (m *timeoutImmediateModel) Info() model.Info {
+	return model.Info{Name: "timeout-immediate"}
+}
+
+type blockingCreationModel struct {
+	timeoutImmediateModel
+	release chan struct{}
+}
+
+func newBlockingCreationModel() *blockingCreationModel {
+	return &blockingCreationModel{release: make(chan struct{})}
+}
+
+func (m *blockingCreationModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	<-m.release
+	ch := make(chan *model.Response)
+	close(ch)
+	return ch, nil
+}
+
+type blockingStreamModel struct {
+	timeoutImmediateModel
+	release chan struct{}
+}
+
+func newBlockingStreamModel() *blockingStreamModel {
+	return &blockingStreamModel{release: make(chan struct{})}
+}
+
+func (m *blockingStreamModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response)
+	go func() {
+		defer close(ch)
+		<-m.release
+	}()
+	return ch, nil
+}
+
+type blockingIterCreationModel struct {
+	blockingCreationModel
+}
+
+func newBlockingIterCreationModel() *blockingIterCreationModel {
+	return &blockingIterCreationModel{
+		blockingCreationModel: *newBlockingCreationModel(),
+	}
+}
+
+func (m *blockingIterCreationModel) GenerateContentIter(
+	context.Context,
+	*model.Request,
+) (model.Seq[*model.Response], error) {
+	<-m.release
+	return func(func(*model.Response) bool) {}, nil
+}
+
+type blockingIterSeqModel struct {
+	timeoutImmediateModel
+	release chan struct{}
+}
+
+func newBlockingIterSeqModel() *blockingIterSeqModel {
+	return &blockingIterSeqModel{release: make(chan struct{})}
+}
+
+func (m *blockingIterSeqModel) GenerateContentIter(
+	context.Context,
+	*model.Request,
+) (model.Seq[*model.Response], error) {
+	return func(func(*model.Response) bool) {
+		<-m.release
+	}, nil
+}

--- a/openclaw/app/model_timeout_test.go
+++ b/openclaw/app/model_timeout_test.go
@@ -115,6 +115,24 @@ func TestModelTimeoutModel_StopsBlockedStream(t *testing.T) {
 	require.Contains(t, resp.Error.Message, "model request timeout")
 }
 
+func TestModelTimeoutModel_ReportsTimeoutWhenStreamClosesAfterContext(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&ctxClosedStreamModel{},
+		10*time.Millisecond,
+	)
+
+	ch, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.NoError(t, err)
+
+	resp := readTimeoutResponse(t, ch)
+	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+	require.Contains(t, resp.Error.Message, "model request timeout")
+}
+
 func TestModelTimeoutModel_DeliversTimeoutAfterQueuedResponses(t *testing.T) {
 	t.Parallel()
 
@@ -226,6 +244,34 @@ func TestModelTimeoutIterModel_StopsBlockedSeq(t *testing.T) {
 	})
 	require.NotNil(t, resp)
 	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+}
+
+func TestModelTimeoutIterModel_ReportsTimeoutWhenSeqClosesAfterContext(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&ctxClosedIterSeqModel{},
+		10*time.Millisecond,
+	)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+
+	seq, err := iter.GenerateContentIter(
+		context.Background(),
+		&model.Request{},
+	)
+	require.NoError(t, err)
+
+	var resp *model.Response
+	seq(func(r *model.Response) bool {
+		resp = r
+		return false
+	})
+	require.NotNil(t, resp)
+	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+	require.Contains(t, resp.Error.Message, "model request timeout")
 }
 
 func readResponse(
@@ -358,6 +404,22 @@ func (m *blockingStreamModel) GenerateContent(
 	return ch, nil
 }
 
+type ctxClosedStreamModel struct {
+	timeoutImmediateModel
+}
+
+func (m *ctxClosedStreamModel) GenerateContent(
+	ctx context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+	}()
+	return ch, nil
+}
+
 type queuedThenBlockingStreamModel struct {
 	timeoutImmediateModel
 	release chan struct{}
@@ -422,5 +484,18 @@ func (m *blockingIterSeqModel) GenerateContentIter(
 ) (model.Seq[*model.Response], error) {
 	return func(func(*model.Response) bool) {
 		<-m.release
+	}, nil
+}
+
+type ctxClosedIterSeqModel struct {
+	timeoutImmediateModel
+}
+
+func (m *ctxClosedIterSeqModel) GenerateContentIter(
+	ctx context.Context,
+	_ *model.Request,
+) (model.Seq[*model.Response], error) {
+	return func(func(*model.Response) bool) {
+		<-ctx.Done()
 	}, nil
 }

--- a/openclaw/app/model_timeout_test.go
+++ b/openclaw/app/model_timeout_test.go
@@ -115,6 +115,28 @@ func TestModelTimeoutModel_StopsBlockedStream(t *testing.T) {
 	require.Contains(t, resp.Error.Message, "model request timeout")
 }
 
+func TestModelTimeoutModel_DeliversTimeoutAfterQueuedResponses(t *testing.T) {
+	t.Parallel()
+
+	underlying := newQueuedThenBlockingStreamModel()
+	wrapped := newModelTimeoutModel(underlying, 10*time.Millisecond)
+	defer close(underlying.release)
+
+	ch, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	resp := readResponse(t, ch)
+	require.Equal(t, "partial-1", resp.Choices[0].Message.Content)
+
+	resp = readResponse(t, ch)
+	require.Equal(t, "partial-2", resp.Choices[0].Message.Content)
+
+	timeout := readTimeoutResponse(t, ch)
+	require.Equal(t, model.ErrorTypeCancelled, timeout.Error.Type)
+	require.Contains(t, timeout.Error.Message, "model request timeout")
+}
+
 func TestModelTimeoutIterModel_StopsBlockedCreation(t *testing.T) {
 	t.Parallel()
 
@@ -329,6 +351,37 @@ func (m *blockingStreamModel) GenerateContent(
 	*model.Request,
 ) (<-chan *model.Response, error) {
 	ch := make(chan *model.Response)
+	go func() {
+		defer close(ch)
+		<-m.release
+	}()
+	return ch, nil
+}
+
+type queuedThenBlockingStreamModel struct {
+	timeoutImmediateModel
+	release chan struct{}
+}
+
+func newQueuedThenBlockingStreamModel() *queuedThenBlockingStreamModel {
+	return &queuedThenBlockingStreamModel{release: make(chan struct{})}
+}
+
+func (m *queuedThenBlockingStreamModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response, 2)
+	ch <- &model.Response{
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("partial-1"),
+		}},
+	}
+	ch <- &model.Response{
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("partial-2"),
+		}},
+	}
 	go func() {
 		defer close(ch)
 		<-m.release

--- a/openclaw/app/model_timeout_test.go
+++ b/openclaw/app/model_timeout_test.go
@@ -11,6 +11,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -40,6 +41,63 @@ func TestModelTimeoutModel_StopsBlockedCreation(t *testing.T) {
 	resp := readTimeoutResponse(t, ch)
 	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
 	require.Contains(t, resp.Error.Message, "model request timeout")
+}
+
+func TestModelTimeoutModel_ForwardsImmediateResponse(t *testing.T) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&timeoutImmediateModel{},
+		time.Second,
+	)
+
+	ch, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.NoError(t, err)
+
+	resp := readResponse(t, ch)
+	require.True(t, resp.Done)
+	require.Nil(t, resp.Error)
+}
+
+func TestModelTimeoutModel_ForwardsInfo(t *testing.T) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&timeoutImmediateModel{},
+		time.Second,
+	)
+
+	require.Equal(t, "timeout-immediate", wrapped.Info().Name)
+}
+
+func TestModelTimeoutModel_ReturnsCreationError(t *testing.T) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&timeoutErrorModel{err: errTimeoutModel},
+		time.Second,
+	)
+
+	ch, err := wrapped.GenerateContent(context.Background(), &model.Request{})
+	require.ErrorIs(t, err, errTimeoutModel)
+	require.Nil(t, ch)
+}
+
+func TestModelTimeoutModel_ReportsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	underlying := newBlockingCreationModel()
+	wrapped := newModelTimeoutModel(underlying, time.Second)
+	defer close(underlying.release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch, err := wrapped.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+
+	resp := readTimeoutResponse(t, ch)
+	require.Contains(t, resp.Error.Message, "model request canceled")
 }
 
 func TestModelTimeoutModel_StopsBlockedStream(t *testing.T) {
@@ -81,6 +139,49 @@ func TestModelTimeoutIterModel_StopsBlockedCreation(t *testing.T) {
 	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
 }
 
+func TestModelTimeoutIterModel_ForwardsImmediateSeq(t *testing.T) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&timeoutImmediateIterModel{},
+		time.Second,
+	)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+
+	seq, err := iter.GenerateContentIter(
+		context.Background(),
+		&model.Request{},
+	)
+	require.NoError(t, err)
+
+	var responses []*model.Response
+	seq(func(r *model.Response) bool {
+		responses = append(responses, r)
+		return true
+	})
+	require.Len(t, responses, 1)
+	require.True(t, responses[0].Done)
+}
+
+func TestModelTimeoutIterModel_ReturnsCreationError(t *testing.T) {
+	t.Parallel()
+
+	wrapped := newModelTimeoutModel(
+		&timeoutErrorIterModel{err: errTimeoutModel},
+		time.Second,
+	)
+	iter, ok := wrapped.(model.IterModel)
+	require.True(t, ok)
+
+	seq, err := iter.GenerateContentIter(
+		context.Background(),
+		&model.Request{},
+	)
+	require.ErrorIs(t, err, errTimeoutModel)
+	require.Nil(t, seq)
+}
+
 func TestModelTimeoutIterModel_StopsBlockedSeq(t *testing.T) {
 	t.Parallel()
 
@@ -103,6 +204,23 @@ func TestModelTimeoutIterModel_StopsBlockedSeq(t *testing.T) {
 	})
 	require.NotNil(t, resp)
 	require.Equal(t, model.ErrorTypeCancelled, resp.Error.Type)
+}
+
+func readResponse(
+	t *testing.T,
+	ch <-chan *model.Response,
+) *model.Response {
+	t.Helper()
+
+	select {
+	case resp, ok := <-ch:
+		require.True(t, ok)
+		require.NotNil(t, resp)
+		return resp
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for model response")
+	}
+	return nil
 }
 
 func readTimeoutResponse(
@@ -137,6 +255,45 @@ func (m *timeoutImmediateModel) GenerateContent(
 
 func (m *timeoutImmediateModel) Info() model.Info {
 	return model.Info{Name: "timeout-immediate"}
+}
+
+var errTimeoutModel = errors.New("timeout model failed")
+
+type timeoutErrorModel struct {
+	timeoutImmediateModel
+	err error
+}
+
+func (m *timeoutErrorModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	return nil, m.err
+}
+
+type timeoutImmediateIterModel struct {
+	timeoutImmediateModel
+}
+
+func (m *timeoutImmediateIterModel) GenerateContentIter(
+	context.Context,
+	*model.Request,
+) (model.Seq[*model.Response], error) {
+	return func(yield func(*model.Response) bool) {
+		yield(&model.Response{Done: true})
+	}, nil
+}
+
+type timeoutErrorIterModel struct {
+	timeoutImmediateModel
+	err error
+}
+
+func (m *timeoutErrorIterModel) GenerateContentIter(
+	context.Context,
+	*model.Request,
+) (model.Seq[*model.Response], error) {
+	return nil, m.err
 }
 
 type blockingCreationModel struct {

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -93,6 +93,8 @@ const (
 	flagMaxHistoryRuns                                = "max-history-runs"
 	flagMaxLLMCalls                                   = "max-llm-calls"
 	flagMaxToolIterations                             = "max-tool-iterations"
+	flagOpenAIMaxRetries                              = "openai-max-retries"
+	flagOpenAITimeout                                 = "openai-timeout"
 	flagPreloadMemory                                 = "preload-memory"
 	flagToolCallArgumentsJSONRepair                   = "tool-call-arguments-json-repair"
 
@@ -224,6 +226,9 @@ type runOptions struct {
 	OpenAIVariant                string
 	OpenAIBaseURL                string
 	OpenAITextOnlyMessageContent bool
+	OpenAITimeout                time.Duration
+	OpenAIMaxRetries             int
+	OpenAIMaxRetriesSet          bool
 	OpenAIHeaders                map[string]string
 	GenerationConfig             *model.GenerationConfig
 	ModelConfig                  *yaml.Node
@@ -330,9 +335,10 @@ func parseRunOptions(args []string) (runOptions, error) {
 
 		AgentType: agentTypeLLM,
 
-		ModelMode:     modeOpenAI,
-		OpenAIModel:   defaultOpenAIModelName(),
-		OpenAIVariant: defaultOpenAIVariant,
+		ModelMode:        modeOpenAI,
+		OpenAIModel:      defaultOpenAIModelName(),
+		OpenAIVariant:    defaultOpenAIVariant,
+		OpenAIMaxRetries: -1,
 
 		SkillsWatch:         true,
 		SkillsWatchDebounce: defaultSkillsWatchDebounce,
@@ -640,6 +646,18 @@ func parseRunOptions(args []string) (runOptions, error) {
 		flagOpenAITextOnlyMessageContent,
 		false,
 		"Reduce OpenAI-compatible user message content parts to text-only",
+	)
+	fs.DurationVar(
+		&opts.OpenAITimeout,
+		flagOpenAITimeout,
+		0,
+		"OpenAI HTTP request timeout (0 disables)",
+	)
+	fs.IntVar(
+		&opts.OpenAIMaxRetries,
+		flagOpenAIMaxRetries,
+		-1,
+		"OpenAI max retries (-1 uses SDK default)",
 	)
 	fs.StringVar(
 		&opts.AllowUsers,
@@ -1033,6 +1051,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 		setFlags,
 		flagDeferToolSurfaceMode,
 	)
+	opts.OpenAIMaxRetriesSet = flagWasSet(setFlags, flagOpenAIMaxRetries)
 	if flagWasSet(setFlags, flagDeferToolSurface) &&
 		!opts.DeferToolSurface &&
 		!flagWasSet(setFlags, flagDeferToolSurfaceMode) {
@@ -1251,6 +1270,8 @@ type modelConfig struct {
 	BaseURL          *string               `yaml:"base_url,omitempty"`
 	OpenAIVariant    *string               `yaml:"openai_variant,omitempty"`
 	TextOnlyContent  *bool                 `yaml:"text_only_content,omitempty"`
+	Timeout          *string               `yaml:"timeout,omitempty"`
+	MaxRetries       *int                  `yaml:"max_retries,omitempty"`
 	Headers          map[string]string     `yaml:"headers,omitempty"`
 	GenerationConfig *generationConfigYAML `yaml:"generation_config,omitempty"`
 	Config           *rawYAMLNode          `yaml:"config,omitempty"`
@@ -1846,6 +1867,24 @@ func (cfg *fileConfig) apply(
 		if textOnly != nil &&
 			!flagWasSet(set, flagOpenAITextOnlyMessageContent) {
 			opts.OpenAITextOnlyMessageContent = *textOnly
+		}
+		if cfg.Model.Timeout != nil && !flagWasSet(set, flagOpenAITimeout) {
+			dur, err := parseDuration(*cfg.Model.Timeout)
+			if err != nil {
+				return fmt.Errorf("model.timeout: %w", err)
+			}
+			if dur < 0 {
+				return fmt.Errorf("model.timeout must be >= 0")
+			}
+			opts.OpenAITimeout = dur
+		}
+		if cfg.Model.MaxRetries != nil &&
+			!flagWasSet(set, flagOpenAIMaxRetries) {
+			if *cfg.Model.MaxRetries < 0 {
+				return fmt.Errorf("model.max_retries must be >= 0")
+			}
+			opts.OpenAIMaxRetries = *cfg.Model.MaxRetries
+			opts.OpenAIMaxRetriesSet = true
 		}
 		if len(cfg.Model.Headers) > 0 {
 			opts.OpenAIHeaders = cleanHeaderMap(cfg.Model.Headers)
@@ -2916,6 +2955,15 @@ func finalizeRunOptions(opts *runOptions) error {
 		return fmt.Errorf(
 			"invalid dynamic agent timeout: %s",
 			opts.DynamicAgentTimeout,
+		)
+	}
+	if opts.OpenAITimeout < 0 {
+		return fmt.Errorf("invalid OpenAI timeout: %s", opts.OpenAITimeout)
+	}
+	if opts.OpenAIMaxRetries < -1 {
+		return fmt.Errorf(
+			"invalid OpenAI max retries: %d",
+			opts.OpenAIMaxRetries,
 		)
 	}
 	if opts.HostExecDefaultTimeout < 0 {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -589,6 +589,78 @@ model:
 	)
 }
 
+func TestParseRunOptions_OpenAITimeoutFlagOverridesConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+model:
+  timeout: "4m"
+`)
+
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-openai-timeout", "30s",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, opts.OpenAITimeout)
+}
+
+func TestParseRunOptions_OpenAITimeoutRejectsNegative(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRunOptions([]string{"-openai-timeout", "-1s"})
+	require.ErrorContains(t, err, "invalid OpenAI timeout")
+
+	cfgPath := writeTempConfig(t, `
+model:
+  timeout: "-1s"
+`)
+	_, err = parseRunOptions([]string{"-config", cfgPath})
+	require.ErrorContains(t, err, "model.timeout must be >= 0")
+}
+
+func TestParseRunOptions_OpenAIMaxRetriesFlagOverridesConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+model:
+  max_retries: 2
+`)
+
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-openai-max-retries", "0",
+	})
+	require.NoError(t, err)
+	require.True(t, opts.OpenAIMaxRetriesSet)
+	require.Equal(t, 0, opts.OpenAIMaxRetries)
+}
+
+func TestParseRunOptions_OpenAIMaxRetriesFlagAcceptsDefaultSentinel(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	opts, err := parseRunOptions([]string{"-openai-max-retries", "-1"})
+	require.NoError(t, err)
+	require.True(t, opts.OpenAIMaxRetriesSet)
+	require.Equal(t, -1, opts.OpenAIMaxRetries)
+}
+
+func TestParseRunOptions_OpenAIMaxRetriesRejectsNegative(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRunOptions([]string{"-openai-max-retries", "-2"})
+	require.ErrorContains(t, err, "invalid OpenAI max retries")
+
+	cfgPath := writeTempConfig(t, `
+model:
+  max_retries: -1
+`)
+	_, err = parseRunOptions([]string{"-config", cfgPath})
+	require.ErrorContains(t, err, "model.max_retries must be >= 0")
+}
+
 func TestParseRunOptions_ModelGenerationConfig_PreservesFalseStream(
 	t *testing.T,
 ) {
@@ -829,6 +901,8 @@ model:
   name: "gpt-5"
   openai_variant: "openai"
   text_only_content: true
+  timeout: "4m"
+  max_retries: 0
   headers:
     X-SMG-Routing-Key: "wineguo"
     X-SMG-Agent-Name: "trpc-claw-benchmark"
@@ -998,6 +1072,9 @@ memory:
 	require.Equal(t, "gpt-5", opts.OpenAIModel)
 	require.Equal(t, "openai", opts.OpenAIVariant)
 	require.True(t, opts.OpenAITextOnlyMessageContent)
+	require.Equal(t, 4*time.Minute, opts.OpenAITimeout)
+	require.True(t, opts.OpenAIMaxRetriesSet)
+	require.Equal(t, 0, opts.OpenAIMaxRetries)
 	require.Equal(t, map[string]string{
 		"X-SMG-Routing-Key": "wineguo",
 		"X-SMG-Agent-Name":  "trpc-claw-benchmark",

--- a/openclaw/go.mod
+++ b/openclaw/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/mattn/go-sqlite3 v1.14.32
+	github.com/openai/openai-go v1.12.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.9.0
@@ -144,7 +145,6 @@ require (
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
-	github.com/openai/openai-go v1.12.0 // indirect
 	github.com/panjf2000/ants/v2 v2.10.0 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pdfcpu/pdfcpu v0.11.1 // indirect

--- a/openclaw/registry/registry.go
+++ b/openclaw/registry/registry.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -199,6 +200,8 @@ type ModelSpec struct {
 	APIKey                       string
 	OpenAIVariant                string
 	OpenAITextOnlyMessageContent bool
+	Timeout                      time.Duration
+	MaxRetries                   *int
 	Headers                      map[string]string
 	DebugRecorderEnabled         bool
 


### PR DESCRIPTION
## Summary
- add a reusable HTTP client timeout option for model clients
- expose OpenClaw `-openai-timeout` / YAML `model.timeout` for OpenAI-compatible model requests
- expose OpenClaw `-openai-max-retries` / YAML `model.max_retries` so callers can cap SDK retry amplification when using request timeouts
- keep defaults compatible: timeout stays disabled and retries use the SDK default unless configured

## Tests
- go test ./model ./model/openai -count=1
- (cd model/anthropic && go test ./... -count=1)
- (cd openclaw && go test trpc.group/trpc-go/trpc-agent-go/openclaw/app trpc.group/trpc-go/trpc-agent-go/openclaw/registry -count=1)