### PR TITLE
openclaw/browser: allow configured file URL roots

### DIFF
--- a/openclaw/internal/browser/config.go
+++ b/openclaw/internal/browser/config.go
@@ -21,7 +21,8 @@ import (
 const (
 	ToolName = "browser"
 
-	defaultProfileName = "openclaw"
+	defaultProfileName  = "openclaw"
+	defaultStdioTimeout = 60 * time.Second
 
 	transportStdio      = "stdio"
 	transportSSE        = "sse"
@@ -70,6 +71,7 @@ type Config struct {
 	AllowLoopback    *bool           `yaml:"allow_loopback,omitempty"`
 	AllowPrivateNet  *bool           `yaml:"allow_private_networks,omitempty"`
 	AllowFileURLs    *bool           `yaml:"allow_file_urls,omitempty"`
+	AllowedFileRoots []string        `yaml:"allowed_file_roots,omitempty"`
 	Nodes            []NodeConfig    `yaml:"nodes,omitempty"`
 	Profiles         []ProfileConfig `yaml:"profiles,omitempty"`
 }
@@ -163,8 +165,9 @@ func resolveConfig(cfg Config) (resolvedConfig, error) {
 
 func resolveNavigationPolicy(cfg Config) navigationPolicy {
 	policy := navigationPolicy{
-		AllowedDomains: normalizeDomains(cfg.AllowedDomains),
-		BlockedDomains: normalizeDomains(cfg.BlockedDomains),
+		AllowedDomains:   normalizeDomains(cfg.AllowedDomains),
+		BlockedDomains:   normalizeDomains(cfg.BlockedDomains),
+		AllowedFileRoots: normalizeFileRoots(cfg.AllowedFileRoots),
 	}
 	if cfg.AllowLoopback != nil {
 		policy.AllowLoopback = *cfg.AllowLoopback
@@ -202,6 +205,10 @@ func resolveProfile(
 		Command:   strings.TrimSpace(cfg.Command),
 		Args:      cfg.Args,
 		Timeout:   cfg.Timeout,
+	}
+	if strings.EqualFold(conn.Transport, transportStdio) &&
+		conn.Timeout == 0 {
+		conn.Timeout = defaultStdioTimeout
 	}
 	browserServerURL := strings.TrimSpace(cfg.BrowserServerURL)
 	if browserServerURL != "" {
@@ -293,6 +300,9 @@ func resolveNodeTargets(
 }
 
 func validateConnection(cfg mcptool.ConnectionConfig) error {
+	if cfg.Timeout < 0 {
+		return errors.New("timeout must be non-negative")
+	}
 	transport := strings.ToLower(strings.TrimSpace(cfg.Transport))
 	switch transport {
 	case transportStdio:

--- a/openclaw/internal/browser/config_test.go
+++ b/openclaw/internal/browser/config_test.go
@@ -11,6 +11,7 @@ package browser
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	mcptool "trpc.group/trpc-go/trpc-agent-go/tool/mcp"
@@ -39,6 +40,37 @@ func TestResolveConfig_DefaultsFirstProfile(t *testing.T) {
 	require.Equal(t, defaultProfileName, got.DefaultProfile)
 	require.Len(t, got.Profiles, 1)
 	require.Equal(t, defaultProfileName, got.Profiles[0].Name)
+}
+
+func TestResolveConfig_DefaultsStdioTimeout(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveConfig(Config{
+		Profiles: []ProfileConfig{{
+			Transport: transportStdio,
+			Command:   "npx",
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		defaultStdioTimeout,
+		got.Profiles[0].Connection.Timeout,
+	)
+}
+
+func TestResolveConfig_PreservesConfiguredStdioTimeout(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveConfig(Config{
+		Profiles: []ProfileConfig{{
+			Transport: transportStdio,
+			Command:   "npx",
+			Timeout:   5 * time.Second,
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 5*time.Second, got.Profiles[0].Connection.Timeout)
 }
 
 func TestResolveConfig_DefaultProfileMustExist(t *testing.T) {
@@ -110,11 +142,12 @@ func TestResolveConfig_NavigationPolicyApplied(t *testing.T) {
 
 	allow := true
 	cfg := Config{
-		AllowedDomains:  []string{"example.com"},
-		BlockedDomains:  []string{"bad.example.com"},
-		AllowLoopback:   &allow,
-		AllowPrivateNet: &allow,
-		AllowFileURLs:   &allow,
+		AllowedDomains:   []string{"example.com"},
+		BlockedDomains:   []string{"bad.example.com"},
+		AllowLoopback:    &allow,
+		AllowPrivateNet:  &allow,
+		AllowFileURLs:    &allow,
+		AllowedFileRoots: []string{"/tmp/openclaw-uploads"},
 		Profiles: []ProfileConfig{{
 			Transport: transportStdio,
 			Command:   "npx",
@@ -132,6 +165,11 @@ func TestResolveConfig_NavigationPolicyApplied(t *testing.T) {
 	require.True(t, got.Navigation.AllowLoopback)
 	require.True(t, got.Navigation.AllowPrivateNet)
 	require.True(t, got.Navigation.AllowFileURLs)
+	require.Equal(
+		t,
+		normalizeFileRoots([]string{"/tmp/openclaw-uploads"}),
+		got.Navigation.AllowedFileRoots,
+	)
 }
 
 func TestResolveConfig_ServerTargetsAllowEmptyProfileTransport(t *testing.T) {
@@ -270,6 +308,17 @@ func TestValidateConnection_RequiresCommandForStdio(t *testing.T) {
 	err := validateConnection(connectionConfig(transportStdio, "", ""))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requires command")
+}
+
+func TestValidateConnection_RejectsNegativeTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg := connectionConfig(transportStdio, "", "npx")
+	cfg.Timeout = -time.Second
+
+	err := validateConnection(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout")
 }
 
 func TestResolveNodeTargets_ReturnsNilWhenEmpty(t *testing.T) {

--- a/openclaw/internal/browser/navigation_guard.go
+++ b/openclaw/internal/browser/navigation_guard.go
@@ -13,15 +13,17 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
+	"path/filepath"
 	"strings"
 )
 
 type navigationPolicy struct {
-	AllowedDomains  []string
-	BlockedDomains  []string
-	AllowLoopback   bool
-	AllowPrivateNet bool
-	AllowFileURLs   bool
+	AllowedDomains   []string
+	BlockedDomains   []string
+	AllowLoopback    bool
+	AllowPrivateNet  bool
+	AllowFileURLs    bool
+	AllowedFileRoots []string
 }
 
 func (p navigationPolicy) Validate(raw string) error {
@@ -42,6 +44,9 @@ func (p navigationPolicy) Validate(raw string) error {
 		return nil
 	case "file":
 		if p.AllowFileURLs {
+			return nil
+		}
+		if p.fileURLAllowed(u) {
 			return nil
 		}
 		return fmt.Errorf("browser file URLs are blocked: %s", raw)
@@ -99,6 +104,70 @@ func (p navigationPolicy) Validate(raw string) error {
 	return fmt.Errorf("browser domain is not allowed: %s", host)
 }
 
+func (p navigationPolicy) fileURLAllowed(u *url.URL) bool {
+	if len(p.AllowedFileRoots) == 0 {
+		return false
+	}
+	host := normalizeHost(u.Hostname())
+	if host != "" && host != "localhost" {
+		return false
+	}
+	path, err := url.PathUnescape(u.Path)
+	if err != nil || strings.TrimSpace(path) == "" {
+		return false
+	}
+	cleanPath, err := cleanFilePath(path)
+	if err != nil {
+		return false
+	}
+	for _, root := range p.AllowedFileRoots {
+		if filePathWithinRoot(cleanPath, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanFilePath(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("file path must be absolute")
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(path))
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return resolved, nil
+	}
+	var missing []string
+	current := cleaned
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return cleaned, nil
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+}
+
+func filePathWithinRoot(path, root string) bool {
+	if root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." ||
+		(rel != ".." &&
+			!strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
 func normalizeDomains(input []string) []string {
 	if len(input) == 0 {
 		return nil
@@ -116,6 +185,36 @@ func normalizeDomains(input []string) []string {
 		}
 		seen[host] = struct{}{}
 		out = append(out, host)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeFileRoots(input []string) []string {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(input))
+	seen := make(map[string]struct{}, len(input))
+	for _, raw := range input {
+		root := strings.TrimSpace(raw)
+		if root == "" {
+			continue
+		}
+		abs, err := filepath.Abs(filepath.Clean(filepath.FromSlash(root)))
+		if err != nil {
+			continue
+		}
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			abs = resolved
+		}
+		if _, ok := seen[abs]; ok {
+			continue
+		}
+		seen[abs] = struct{}{}
+		out = append(out, abs)
 	}
 	if len(out) == 0 {
 		return nil

--- a/openclaw/internal/browser/navigation_guard_test.go
+++ b/openclaw/internal/browser/navigation_guard_test.go
@@ -10,6 +10,9 @@
 package browser
 
 import (
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -65,6 +68,131 @@ func TestNavigationPolicy_AllowsFileURLWhenEnabled(t *testing.T) {
 		AllowFileURLs: true,
 	}.Validate("file:///tmp/test.html")
 	require.NoError(t, err)
+}
+
+func TestNavigationPolicy_AllowsFileURLUnderAllowedRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "image.png")
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{root}),
+	}.Validate("file://" + filepath.ToSlash(target))
+	require.NoError(t, err)
+}
+
+func TestNavigationPolicy_AllowsLocalhostFileURLUnderAllowedRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "image with space.png")
+	u := url.URL{Scheme: "file", Host: "localhost", Path: filepath.ToSlash(target)}
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{root}),
+	}.Validate(u.String())
+	require.NoError(t, err)
+}
+
+func TestNavigationPolicy_AllowsFileURLUnderSymlinkedAllowedRoot(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	require.NoError(t, os.Mkdir(realRoot, 0o700))
+	linkRoot := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realRoot, linkRoot))
+	target := filepath.Join(linkRoot, "nested", "image.png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o700))
+	require.NoError(t, os.WriteFile(target, []byte("png"), 0o600))
+
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{linkRoot}),
+	}.Validate("file://" + filepath.ToSlash(target))
+	require.NoError(t, err)
+}
+
+func TestNavigationPolicy_AllowsMissingFileURLUnderSymlinkedRoot(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	require.NoError(t, os.Mkdir(realRoot, 0o700))
+	linkRoot := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realRoot, linkRoot))
+	target := filepath.Join(linkRoot, "nested", "missing.png")
+
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{linkRoot}),
+	}.Validate("file://" + filepath.ToSlash(target))
+	require.NoError(t, err)
+}
+
+func TestNavigationPolicy_BlocksFileURLTraversalOutOfAllowedRoot(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	outside := filepath.Join(base, "outside")
+	require.NoError(t, os.MkdirAll(root, 0o700))
+	require.NoError(t, os.MkdirAll(outside, 0o700))
+	raw := "file://" + filepath.ToSlash(root) + "/../outside/image.png"
+
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{root}),
+	}.Validate(raw)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file URLs")
+}
+
+func TestNavigationPolicy_BlocksFileURLOutsideAllowedRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	other := filepath.Join(t.TempDir(), "image.png")
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{root}),
+	}.Validate("file://" + filepath.ToSlash(other))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file URLs")
+}
+
+func TestNavigationPolicy_BlocksMalformedFileURLPath(t *testing.T) {
+	t.Parallel()
+
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{t.TempDir()}),
+	}.Validate("file:///%zz")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid browser url")
+}
+
+func TestNavigationPolicy_BlocksRemoteHostFileURL(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "image.png")
+	u := url.URL{Scheme: "file", Host: "example.com", Path: filepath.ToSlash(target)}
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{root}),
+	}.Validate(u.String())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file URLs")
+}
+
+func TestNavigationPolicy_BlocksEmptyFileURLPath(t *testing.T) {
+	t.Parallel()
+
+	err := navigationPolicy{
+		AllowedFileRoots: normalizeFileRoots([]string{t.TempDir()}),
+	}.Validate("file://localhost")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "file URLs")
 }
 
 func TestNormalizeDomains_DedupesAndTrims(t *testing.T) {
@@ -151,4 +279,38 @@ func TestNavigationPolicy_AdditionalBranches(t *testing.T) {
 	}
 
 	require.True(t, isLoopbackHost("api.localhost"))
+}
+
+func TestCleanFilePathRejectsRelativePath(t *testing.T) {
+	t.Parallel()
+
+	_, err := cleanFilePath("relative/file.html")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute")
+}
+
+func TestFilePathWithinRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.False(t, filePathWithinRoot(filepath.Join(root, "file.txt"), ""))
+	require.True(t, filePathWithinRoot(root, root))
+	require.True(t, filePathWithinRoot(filepath.Join(root, "nested", "file.txt"), root))
+	require.False(t, filePathWithinRoot(filepath.Join(t.TempDir(), "file.txt"), root))
+}
+
+func TestNormalizeFileRoots(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, normalizeFileRoots(nil))
+	require.Nil(t, normalizeFileRoots([]string{"", " \t"}))
+
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	require.NoError(t, os.Mkdir(realRoot, 0o700))
+	linkRoot := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realRoot, linkRoot))
+
+	roots := normalizeFileRoots([]string{realRoot, linkRoot, realRoot})
+	require.Equal(t, []string{realRoot}, roots)
 }

--- a/openclaw/internal/browser/navigation_guard_test.go
+++ b/openclaw/internal/browser/navigation_guard_test.go
@@ -310,7 +310,9 @@ func TestNormalizeFileRoots(t *testing.T) {
 	require.NoError(t, os.Mkdir(realRoot, 0o700))
 	linkRoot := filepath.Join(base, "link")
 	require.NoError(t, os.Symlink(realRoot, linkRoot))
+	resolvedRoot, err := filepath.EvalSymlinks(realRoot)
+	require.NoError(t, err)
 
 	roots := normalizeFileRoots([]string{realRoot, linkRoot, realRoot})
-	require.Equal(t, []string{realRoot}, roots)
+	require.Equal(t, []string{resolvedRoot}, roots)
 }

--- a/openclaw/internal/browser/result.go
+++ b/openclaw/internal/browser/result.go
@@ -50,32 +50,44 @@ type textContentItem struct {
 
 // Result is the normalized native browser tool result.
 type Result struct {
-	Action          string        `json:"action"`
-	Profile         string        `json:"profile,omitempty"`
-	DefaultProfile  string        `json:"defaultProfile,omitempty"`
-	Driver          string        `json:"driver,omitempty"`
-	State           string        `json:"state,omitempty"`
-	ToolCount       int           `json:"toolCount,omitempty"`
-	EvaluateEnabled bool          `json:"evaluateEnabled,omitempty"`
-	Supported       []string      `json:"supportedActions,omitempty"`
-	TargetID        string        `json:"targetId,omitempty"`
-	Profiles        []ProfileInfo `json:"profiles,omitempty"`
-	Tabs            []TabInfo     `json:"tabs,omitempty"`
-	Untrusted       bool          `json:"untrusted,omitempty"`
-	Text            string        `json:"text,omitempty"`
-	Content         any           `json:"content,omitempty"`
-	Warning         string        `json:"warning,omitempty"`
+	Action           string                `json:"action"`
+	Profile          string                `json:"profile,omitempty"`
+	DefaultProfile   string                `json:"defaultProfile,omitempty"`
+	Driver           string                `json:"driver,omitempty"`
+	State            string                `json:"state,omitempty"`
+	ToolCount        int                   `json:"toolCount,omitempty"`
+	EvaluateEnabled  bool                  `json:"evaluateEnabled,omitempty"`
+	Supported        []string              `json:"supportedActions,omitempty"`
+	NavigationPolicy *NavigationPolicyInfo `json:"navigationPolicy,omitempty"`
+	TargetID         string                `json:"targetId,omitempty"`
+	Profiles         []ProfileInfo         `json:"profiles,omitempty"`
+	Tabs             []TabInfo             `json:"tabs,omitempty"`
+	Untrusted        bool                  `json:"untrusted,omitempty"`
+	Text             string                `json:"text,omitempty"`
+	Content          any                   `json:"content,omitempty"`
+	Warning          string                `json:"warning,omitempty"`
 }
 
 // ProfileInfo describes one configured browser profile.
 type ProfileInfo struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Default     bool     `json:"default,omitempty"`
-	Driver      string   `json:"driver"`
-	State       string   `json:"state,omitempty"`
-	ToolCount   int      `json:"toolCount,omitempty"`
-	Supported   []string `json:"supportedActions,omitempty"`
+	Name             string                `json:"name"`
+	Description      string                `json:"description,omitempty"`
+	Default          bool                  `json:"default,omitempty"`
+	Driver           string                `json:"driver"`
+	State            string                `json:"state,omitempty"`
+	ToolCount        int                   `json:"toolCount,omitempty"`
+	Supported        []string              `json:"supportedActions,omitempty"`
+	NavigationPolicy *NavigationPolicyInfo `json:"navigationPolicy,omitempty"`
+}
+
+// NavigationPolicyInfo describes browser navigation gates visible to callers.
+type NavigationPolicyInfo struct {
+	AllowedDomains       []string `json:"allowedDomains,omitempty"`
+	BlockedDomains       []string `json:"blockedDomains,omitempty"`
+	AllowLoopback        bool     `json:"allowLoopback,omitempty"`
+	AllowPrivateNetworks bool     `json:"allowPrivateNetworks,omitempty"`
+	AllowFileURLs        bool     `json:"allowFileUrls,omitempty"`
+	AllowedFileRoots     []string `json:"allowedFileRoots,omitempty"`
 }
 
 // TabInfo describes one known tab.

--- a/openclaw/internal/browser/result.go
+++ b/openclaw/internal/browser/result.go
@@ -87,6 +87,7 @@ type NavigationPolicyInfo struct {
 	AllowLoopback        bool     `json:"allowLoopback,omitempty"`
 	AllowPrivateNetworks bool     `json:"allowPrivateNetworks,omitempty"`
 	AllowFileURLs        bool     `json:"allowFileUrls,omitempty"`
+	AllowRootFileURLs    bool     `json:"allowRootFileUrls,omitempty"`
 	AllowedFileRoots     []string `json:"allowedFileRoots,omitempty"`
 }
 

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -1133,6 +1133,7 @@ func navigationPolicyInfo(policy navigationPolicy) *NavigationPolicyInfo {
 		AllowLoopback:        policy.AllowLoopback,
 		AllowPrivateNetworks: policy.AllowPrivateNet,
 		AllowFileURLs:        policy.AllowFileURLs,
+		AllowRootFileURLs:    len(policy.AllowedFileRoots) > 0,
 		AllowedFileRoots:     append([]string(nil), policy.AllowedFileRoots...),
 	}
 }

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -431,7 +431,7 @@ func browserDescription(evaluateEnabled bool) string {
 		"direct inspection of local or generated files. Do not " +
 		"navigate to file://, data:, or ad hoc localhost/127.0.0.1 " +
 		"URLs unless the runtime configuration explicitly exposes " +
-		"that server; normal browser policy may block those paths. " +
+		"that file root or server; normal browser policy may block those paths. " +
 		"For local images, PDFs, audio, video, or generated " +
 		"artifacts, use file/document/exec tools and MEDIA or " +
 		"MEDIA_DIR outputs instead. Prefer snapshot + act for UI " +

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -1080,10 +1080,11 @@ func (t *Tool) handleProfiles(
 	sort.Strings(names)
 
 	out := Result{
-		Action:          actionProfiles,
-		DefaultProfile:  t.defaultProfile,
-		Driver:          ToolName,
-		EvaluateEnabled: t.evaluateEnabled,
+		Action:           actionProfiles,
+		DefaultProfile:   t.defaultProfile,
+		Driver:           ToolName,
+		EvaluateEnabled:  t.evaluateEnabled,
+		NavigationPolicy: navigationPolicyInfo(t.navigation),
 		Supported: visibleActionsForDriver(
 			t.driverTypeForProfile(t.defaultProfile),
 			t.evaluateEnabled,
@@ -1095,11 +1096,12 @@ func (t *Tool) handleProfiles(
 		cfg := t.profiles[name]
 		driverType := t.driverTypeForProfile(name)
 		info := ProfileInfo{
-			Name:        name,
-			Description: cfg.Description,
-			Default:     name == t.defaultProfile,
-			Driver:      driverType,
-			Supported:   visibleActionsForDriver(driverType, t.evaluateEnabled),
+			Name:             name,
+			Description:      cfg.Description,
+			Default:          name == t.defaultProfile,
+			Driver:           driverType,
+			Supported:        visibleActionsForDriver(driverType, t.evaluateEnabled),
+			NavigationPolicy: out.NavigationPolicy,
 		}
 		drv := t.statusDriver(name, cfg)
 		if drv != nil {
@@ -1114,6 +1116,25 @@ func (t *Tool) handleProfiles(
 		out.Profiles = append(out.Profiles, info)
 	}
 	return out
+}
+
+func navigationPolicyInfo(policy navigationPolicy) *NavigationPolicyInfo {
+	if len(policy.AllowedDomains) == 0 &&
+		len(policy.BlockedDomains) == 0 &&
+		!policy.AllowLoopback &&
+		!policy.AllowPrivateNet &&
+		!policy.AllowFileURLs &&
+		len(policy.AllowedFileRoots) == 0 {
+		return nil
+	}
+	return &NavigationPolicyInfo{
+		AllowedDomains:       append([]string(nil), policy.AllowedDomains...),
+		BlockedDomains:       append([]string(nil), policy.BlockedDomains...),
+		AllowLoopback:        policy.AllowLoopback,
+		AllowPrivateNetworks: policy.AllowPrivateNet,
+		AllowFileURLs:        policy.AllowFileURLs,
+		AllowedFileRoots:     append([]string(nil), policy.AllowedFileRoots...),
+	}
 }
 
 func (t *Tool) statusDriver(

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -732,6 +732,8 @@ func TestToolCall_ProfilesAreSorted(t *testing.T) {
 		got.NavigationPolicy.BlockedDomains,
 	)
 	require.True(t, got.NavigationPolicy.AllowLoopback)
+	require.False(t, got.NavigationPolicy.AllowFileURLs)
+	require.True(t, got.NavigationPolicy.AllowRootFileURLs)
 	require.Equal(t, []string{root}, got.NavigationPolicy.AllowedFileRoots)
 	require.Equal(t, got.NavigationPolicy, got.Profiles[0].NavigationPolicy)
 	require.Equal(t, got.NavigationPolicy, got.Profiles[1].NavigationPolicy)

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -677,6 +677,7 @@ func TestToolCall_ActEvaluateDisabled(t *testing.T) {
 func TestToolCall_ProfilesAreSorted(t *testing.T) {
 	t.Parallel()
 
+	root := t.TempDir()
 	openclawDriver := &fakeDriver{
 		status: driverStatus{State: stateReady, ToolCount: 3},
 	}
@@ -687,7 +688,12 @@ func TestToolCall_ProfilesAreSorted(t *testing.T) {
 	tool := newToolWithDrivers(
 		defaultProfileName,
 		false,
-		navigationPolicy{},
+		navigationPolicy{
+			AllowedDomains:   []string{"example.com"},
+			BlockedDomains:   []string{"blocked.example"},
+			AllowLoopback:    true,
+			AllowedFileRoots: []string{root},
+		},
 		nil,
 		nil,
 		nil,
@@ -718,6 +724,17 @@ func TestToolCall_ProfilesAreSorted(t *testing.T) {
 	require.Equal(t, defaultProfileName, got.Profiles[1].Name)
 	require.Equal(t, driverTypePlaywrightMCP, got.Profiles[0].Driver)
 	require.Equal(t, driverTypePlaywrightMCP, got.Profiles[1].Driver)
+	require.NotNil(t, got.NavigationPolicy)
+	require.Equal(t, []string{"example.com"}, got.NavigationPolicy.AllowedDomains)
+	require.Equal(
+		t,
+		[]string{"blocked.example"},
+		got.NavigationPolicy.BlockedDomains,
+	)
+	require.True(t, got.NavigationPolicy.AllowLoopback)
+	require.Equal(t, []string{root}, got.NavigationPolicy.AllowedFileRoots)
+	require.Equal(t, got.NavigationPolicy, got.Profiles[0].NavigationPolicy)
+	require.Equal(t, got.NavigationPolicy, got.Profiles[1].NavigationPolicy)
 }
 
 func TestToolCall_ScreenshotPreservesContent(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `allowed_file_roots` to the OpenClaw browser provider navigation policy
- allow `file://` navigation only when the path is under a configured root, while keeping default file URL blocking unchanged
- update browser guidance and tests for local file allowlists

## Tests
- (cd openclaw && go test trpc.group/trpc-go/trpc-agent-go/openclaw/internal/browser -count=1)