### PR TITLE
session/mysql: bind JSON column values as string to fix error 3144

### DIFF
--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -383,7 +383,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, updatedAt, expiresAt,
+			string(updatedStateBytes), updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -394,7 +394,7 @@ func (s *Service) addEvent(ctx context.Context, key session.Key, event *event.Ev
 			_, err = tx.ExecContext(ctx,
 				fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, event, created_at, updated_at)
 				 VALUES (?, ?, ?, ?, ?, ?)`, s.tableSessionEvents),
-				key.AppName, key.UserID, key.SessionID, eventBytes, now, now)
+				key.AppName, key.UserID, key.SessionID, string(eventBytes), now, now)
 			if err != nil {
 				return fmt.Errorf("insert event failed: %w", err)
 			}
@@ -469,7 +469,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, updatedAt, expiresAt,
+			string(updatedStateBytes), updatedAt, expiresAt,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -479,7 +479,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionTracks),
-			key.AppName, key.UserID, key.SessionID, trackEvent.Track, eventBytes,
+			key.AppName, key.UserID, key.SessionID, trackEvent.Track, string(eventBytes),
 			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -12,6 +12,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -1455,6 +1456,107 @@ func TestAddEvent_ExpiredSession(t *testing.T) {
 	err = s.addEvent(ctx, key, evt)
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// stringArg matches a SQL argument only when it is bound as a string.
+// JSON columns must receive a string, not a raw []byte: go-sql-driver sends
+// []byte with the binary charset, which MySQL/TDSQL rejects for JSON columns
+// with error 3144 (ER_INVALID_JSON_CHARSET, "Cannot create a JSON value from a
+// string with CHARACTER SET 'binary'").
+type stringArg struct{}
+
+func (stringArg) Match(v driver.Value) bool {
+	_, ok := v.(string)
+	return ok
+}
+
+// TestAddEvent_BindsJSONColumnsAsString guards the JSON columns (state, event)
+// against being bound as []byte, which fails on real MySQL/TDSQL with error
+// 3144. sqlmock does not validate charset, so we assert the argument Go type.
+func TestAddEvent_BindsJSONColumnsAsString(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	key := session.Key{
+		AppName:   "test-app",
+		UserID:    "user-123",
+		SessionID: "session-456",
+	}
+
+	evt := event.New("inv-1", "author")
+	evt.Response = &model.Response{
+		Object:  model.ObjectTypeChatCompletion,
+		Done:    true,
+		Choices: []model.Choice{{Index: 0, Message: model.Message{Content: "test"}}},
+	}
+	evt.IsPartial = false
+
+	sessState := SessionState{ID: key.SessionID, State: session.StateMap{}}
+	stateBytes, _ := json.Marshal(sessState)
+
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).
+			AddRow(stateBytes, nil))
+	// state (arg 1) must be bound as a string, not []byte.
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET state = ?, updated_at = ?, expires_at = ?")).
+		WithArgs(stringArg{}, sqlmock.AnyArg(), sqlmock.AnyArg(), key.AppName, key.UserID, key.SessionID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// event (arg 4) must be bound as a string, not []byte.
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, stringArg{}, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = s.addEvent(ctx, key, evt)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestAddTrackEvent_BindsJSONColumnsAsString is the addTrackEvent counterpart of
+// TestAddEvent_BindsJSONColumnsAsString.
+func TestAddTrackEvent_BindsJSONColumnsAsString(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+
+	key := session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "session-1",
+	}
+	trackEvent := &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"payload"`),
+		Timestamp: time.Now(),
+	}
+
+	sessState := SessionState{ID: key.SessionID, State: session.StateMap{}}
+	stateBytes, _ := json.Marshal(sessState)
+
+	expectLoadSessionStateForUpdate(mock, key).
+		WillReturnRows(sqlmock.NewRows([]string{"state", "expires_at"}).
+			AddRow(stateBytes, nil))
+	// state (arg 1) must be bound as a string, not []byte.
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET state = ?, updated_at = ?, expires_at = ?")).
+		WithArgs(stringArg{}, sqlmock.AnyArg(), sqlmock.AnyArg(), key.AppName, key.UserID, key.SessionID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// event (arg 5) must be bound as a string, not []byte.
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, "alpha",
+			stringArg{}, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = s.addTrackEvent(ctx, key, trackEvent)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestAddEvent_PartialEvent(t *testing.T) {


### PR DESCRIPTION
## What

`addEvent` and `addTrackEvent` bind the marshaled session state and event payloads to the JSON columns (`state`, `event`) as raw `[]byte`. Binding `[]byte` to a MySQL `JSON` column is unsafe: when the connection uses `interpolateParams=true`, `go-sql-driver/mysql` renders the value with the `_binary` introducer, and MySQL rejects a binary-charset string for a JSON column:

```
Error 3144 (22032): Cannot create a JSON value from a string with CHARACTER SET 'binary'
```

Observed in production (TDSQL):

```
append event failed: store event failed: update session state failed:
Error 3144 (22032): Cannot create a JSON value from a string with CHARACTER SET 'binary'
```

## Reproduced on a real MySQL

MySQL 8.0.44 + `go-sql-driver/mysql v1.9.3`, binding the same marshaled payload to a `JSON` column:

| DSN | bind `[]byte` | bind `string()` |
| --- | --- | --- |
| default (`interpolateParams=false`, server-side prepared) | ✅ succeeds | ✅ succeeds |
| `interpolateParams=true` | ❌ **error 3144** | ✅ succeeds |

So the raw `[]byte` binding was latently unsafe and connection-config dependent; the production DSN (TDSQL) hits it, and `string()` is correct in both modes.

## Root cause

The other write paths for JSON columns already convert to `string` before binding:

- `createSession` → `string(sessBytes)`
- `updateSessionState` → `string(updatedStateBytes)`
- `CreateSessionSummary` → `string(summaryBytes)`

Only the two event-append paths (`addEvent`, `addTrackEvent`) passed raw `[]byte`. This is a regression from #1972, which dropped the `string(...)` conversion in these two paths to save a copy.

Not shared by the sibling backends: `session/postgres` uses the `pgx` driver (verified: raw `[]byte` → `jsonb` is accepted), and `session/sqlite` stores `state`/`event` as `BLOB`.

## Fix

Wrap the payloads with `string(...)` before binding in `addEvent` and `addTrackEvent`, matching the existing paths (4 lines).

## Tests

The existing `session/mysql` tests use sqlmock with `AnyArg()`, which does not validate the argument charset/type — that is why the regression was invisible in CI. Added two regression tests that assert the JSON-column arguments are bound as a `string` (not `[]byte`):

- `TestAddEvent_BindsJSONColumnsAsString`
- `TestAddTrackEvent_BindsJSONColumnsAsString`

Validation:

- `cd session/mysql && go test .` ✅
- `cd session/mysql && go vet .` ✅
