### PR TITLE
docs(model): clarify OpenAI retry count

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1180,7 +1180,11 @@ The OpenAI SDK automatically retries the following errors:
 - **500+ Server Errors**: Internal server errors (5xx)
 - **Network Connection Errors**: No response or connection failure
 
-**Note**: SDK default maximum retry count is 2.
+**Note**: The SDK default maximum retry count is 2. This means the initial
+request can be retried up to 2 times, for a default maximum of 3 HTTP request
+attempts per call. The `n` in `openaiopt.WithMaxRetries(n)` is the retry count,
+not the total request count. Set it to `0` to disable SDK automatic retries and
+send only the initial request.
 
 ##### Retry Strategies
 
@@ -1220,6 +1224,18 @@ llm := openai.New("gpt-4o-mini",
 )
 ```
 
+**Disable Retry**:
+
+```go
+// For scenarios that must disable SDK automatic retries.
+llm := openai.New("gpt-4o-mini",
+    openai.WithOpenAIOptions(
+        openaiopt.WithMaxRetries(0),  // No retries; send one request only.
+        openaiopt.WithRequestTimeout(10*time.Second),
+    ),
+)
+```
+
 ##### How It Works
 
 Retry mechanism execution flow:
@@ -1252,6 +1268,7 @@ Key design:
 - **No Framework Retry**: Framework itself does not implement retry logic
 - **Client-level Retry**: All retry is handled by OpenAI client
 - **Configuration Pass-through**: Use `WithOpenAIOptions` to configure retry behavior
+- **Disable Retry**: Set `openaiopt.WithMaxRetries(0)` to disable SDK automatic retries
 - **Automatic Handling**: Rate limiting (429) is automatically handled without additional code
 
 ##### Usage Example

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1174,7 +1174,10 @@ OpenAI SDK 自动重试以下错误：
 - **500+ Server Errors**：服务器内部错误（5xx）
 - **网络连接错误**：无响应或连接失败
 
-**注意**：SDK 默认最大重试次数为 2 次。
+**注意**：SDK 默认最大重试次数为 2 次。这表示初始请求失败后最多再重试
+2 次，因此一次调用默认最多会发起 3 次 HTTP 请求。`openaiopt.WithMaxRetries(n)`
+中的 `n` 指重试次数，不是总请求次数；设置为 `0` 可关闭 SDK 自动重试，
+只发送初始请求。
 
 ##### 重试策略
 
@@ -1214,6 +1217,18 @@ llm := openai.New("gpt-4o-mini",
 )
 ```
 
+**关闭重试**：
+
+```go
+// 需要完全关闭 SDK 自动重试的场景
+llm := openai.New("gpt-4o-mini",
+    openai.WithOpenAIOptions(
+        openaiopt.WithMaxRetries(0),  // 不重试，只发起一次请求
+        openaiopt.WithRequestTimeout(10*time.Second),
+    ),
+)
+```
+
 ##### 工作原理
 
 重试机制的执行流程：
@@ -1246,6 +1261,7 @@ llm := openai.New("gpt-4o-mini",
 - **无框架重试**：框架本身不实现重试逻辑
 - **客户端级重试**：所有重试由 OpenAI 客户端处理
 - **配置透传**：使用 `WithOpenAIOptions` 配置重试行为
+- **关闭重试**：设置 `openaiopt.WithMaxRetries(0)` 可关闭 SDK 自动重试
 - **自动处理**：速率限制（429）自动处理，无需额外代码
 
 ##### 使用示例

--- a/examples/model/retry/README.md
+++ b/examples/model/retry/README.md
@@ -36,6 +36,11 @@ The example supports the following environment variables:
 | `-retries` | Maximum number of retries | `3`           |
 | `-timeout` | Request timeout duration  | `30s`         |
 
+`-retries` maps to `openaiopt.WithMaxRetries(n)`. The value counts retry
+attempts, not total HTTP request attempts. For example, `-retries 3` allows one
+initial request plus up to three retries. Use `-retries 0` to disable SDK
+automatic retries.
+
 ## How It Works
 
 The retry mechanism works by:
@@ -156,6 +161,17 @@ llm := openai.New("gpt-4",
 )
 ```
 
+### Disable Retry
+
+```go
+llm := openai.New("gpt-4",
+    openai.WithOpenAIOptions(
+        openaiopt.WithMaxRetries(0), // No retries; send one request only.
+        openaiopt.WithRequestTimeout(10*time.Second),
+    ),
+)
+```
+
 ## Error Handling
 
 The example includes comprehensive error handling for:
@@ -177,6 +193,7 @@ The example includes comprehensive error handling for:
 - **No Framework Retry**: The framework itself doesn't implement retry logic
 - **Client-level Retry**: All retry logic is handled by the OpenAI client
 - **Configuration Pass-through**: Use `WithOpenAIOptions` to configure retry behavior
+- **Retry Count Semantics**: `WithMaxRetries(n)` counts retries, not total request attempts
 - **Automatic Handling**: Rate limiting (429) is automatically handled with smart backoff
 - **Environment Variables**: API key and base URL are automatically read from environment
 


### PR DESCRIPTION
## Summary
- Clarify that OpenAI SDK default retries are 2 retry attempts, which means up to 3 HTTP request attempts including the initial request.
- Document that `openaiopt.WithMaxRetries(n)` counts retries, not total requests.
- Add `WithMaxRetries(0)` examples for disabling SDK automatic retries.

## Validation
- `mkdocs build --strict`