### PR TITLE
openclaw: harden runtime tool outputs and screenshots

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -3523,6 +3523,7 @@ func buildOpenClawTools(
 			octool.WithBaseEnv(deps.ToolEnv(stateDir)),
 			octool.WithCommandPolicy(commandPolicy),
 			octool.WithOutputRedactor(outputRedactor),
+			octool.WithCleanShellStartup(true),
 			octool.WithMaxResultOutputChars(
 				defaultExecResultOutputChars,
 			),

--- a/openclaw/internal/browser/config.go
+++ b/openclaw/internal/browser/config.go
@@ -61,6 +61,7 @@ type ProfileConfig struct {
 type Config struct {
 	DefaultProfile   string          `yaml:"default_profile,omitempty"`
 	EvaluateEnabled  *bool           `yaml:"evaluate_enabled,omitempty"`
+	ScreenshotDir    string          `yaml:"screenshot_dir,omitempty"`
 	ServerURL        string          `yaml:"server_url,omitempty"`
 	AuthToken        string          `yaml:"auth_token,omitempty"`
 	SandboxServerURL string          `yaml:"sandbox_server_url,omitempty"`
@@ -77,6 +78,7 @@ type Config struct {
 type resolvedConfig struct {
 	DefaultProfile  string
 	EvaluateEnabled bool
+	ScreenshotDir   string
 	Navigation      navigationPolicy
 	HostServer      *serverTargetConfig
 	SandboxServer   *serverTargetConfig
@@ -108,6 +110,7 @@ func resolveConfig(cfg Config) (resolvedConfig, error) {
 
 	out := resolvedConfig{
 		DefaultProfile: strings.TrimSpace(cfg.DefaultProfile),
+		ScreenshotDir:  strings.TrimSpace(cfg.ScreenshotDir),
 	}
 	if cfg.EvaluateEnabled != nil {
 		out.EvaluateEnabled = *cfg.EvaluateEnabled

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -14,9 +14,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -298,6 +301,7 @@ type input struct {
 type Tool struct {
 	defaultProfile  string
 	evaluateEnabled bool
+	screenshotDir   string
 	navigation      navigationPolicy
 	hostServer      *serverTargetConfig
 	sandboxServer   *serverTargetConfig
@@ -343,7 +347,7 @@ func NewTool(cfg Config) (*Tool, error) {
 		}
 	}
 
-	return newToolWithDrivers(
+	tool := newToolWithDrivers(
 		resolved.DefaultProfile,
 		resolved.EvaluateEnabled,
 		resolved.Navigation,
@@ -352,7 +356,9 @@ func NewTool(cfg Config) (*Tool, error) {
 		resolved.NodeTargets,
 		profiles,
 		drivers,
-	), nil
+	)
+	tool.screenshotDir = resolved.ScreenshotDir
+	return tool, nil
 }
 
 func newToolWithDrivers(
@@ -817,10 +823,13 @@ func browserSchema(evaluateEnabled bool, driverType string) *tool.Schema {
 			Type:                 "object",
 			AdditionalProperties: true,
 		},
-		"path":        stringSchema("Download output path."),
-		"paths":       stringArraySchema("Upload paths."),
-		"inputRef":    stringSchema("Upload input ref."),
-		"filename":    stringSchema("Optional output filename."),
+		"path":     stringSchema("Download output path."),
+		"paths":    stringArraySchema("Upload paths."),
+		"inputRef": stringSchema("Upload input ref."),
+		"filename": stringSchema(
+			"Optional output filename. When browser screenshot_dir is " +
+				"configured, relative screenshot filenames are saved there.",
+		),
 		"timeoutMs":   numberSchema("Timeout in milliseconds."),
 		"clear":       boolSchema("Clear existing override."),
 		"accept":      boolSchema("Dialog accept flag."),
@@ -1414,6 +1423,67 @@ func (t *Tool) handleSnapshot(
 	return result, nil
 }
 
+func (t *Tool) resolveScreenshotFilename(
+	filename string,
+	imageType string,
+) (string, error) {
+	filename = strings.TrimSpace(filename)
+	screenshotDir := strings.TrimSpace(t.screenshotDir)
+	if screenshotDir == "" {
+		return filename, nil
+	}
+	if filename == "" {
+		filename = "screenshot-" + time.Now().UTC().Format(
+			"20060102T150405.000000000",
+		) + "." + screenshotExtension(imageType)
+	}
+	if filepath.IsAbs(filename) {
+		return filename, nil
+	}
+	cleaned := filepath.Clean(filename)
+	if cleaned == "." {
+		return "", nil
+	}
+	if cleaned == ".." ||
+		strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf(
+			"browser screenshot filename %q escapes screenshot_dir",
+			filename,
+		)
+	}
+	root, err := filepath.Abs(screenshotDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve browser screenshot_dir: %w", err)
+	}
+	root = filepath.Clean(root)
+	target := filepath.Clean(filepath.Join(root, cleaned))
+	if !pathInDir(target, root) {
+		return "", fmt.Errorf(
+			"browser screenshot filename %q escapes screenshot_dir",
+			filename,
+		)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return "", fmt.Errorf("create browser screenshot dir: %w", err)
+	}
+	return target, nil
+}
+
+func screenshotExtension(imageType string) string {
+	switch strings.ToLower(strings.TrimSpace(imageType)) {
+	case "jpeg", "jpg":
+		return "jpg"
+	case "webp":
+		return "webp"
+	default:
+		return "png"
+	}
+}
+
+func pathInDir(path string, dir string) bool {
+	return path == dir || strings.HasPrefix(path, dir+string(os.PathSeparator))
+}
+
 func (t *Tool) handleScreenshot(
 	ctx context.Context,
 	profile string,
@@ -1429,7 +1499,11 @@ func (t *Tool) handleScreenshot(
 	if in.FullPage != nil {
 		args["fullPage"] = *in.FullPage
 	}
-	if filename := strings.TrimSpace(in.Filename); filename != "" {
+	filename, err := t.resolveScreenshotFilename(in.Filename, in.Type)
+	if err != nil {
+		return Result{}, err
+	}
+	if filename != "" {
 		args["filename"] = filename
 	}
 	if ref := strings.TrimSpace(in.Ref); ref != "" {

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -2725,6 +2726,112 @@ func TestToolCall_ScreenshotPassesOptions(t *testing.T) {
 	require.Equal(t, "e1", drv.calls[1].Args["ref"])
 	require.Equal(t, "hero", drv.calls[1].Args["element"])
 	require.Equal(t, "png", drv.calls[1].Args["type"])
+}
+
+func TestToolCall_ScreenshotDirRewritesRelativeFilename(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolScreenshot: textPayload("ok"),
+		},
+	}
+	dir := t.TempDir()
+	tool := newTestTool(drv)
+	tool.screenshotDir = dir
+
+	_, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":   actionScreenshot,
+			"filename": "captures/page.png",
+		}),
+	)
+	require.NoError(t, err)
+	require.Len(t, drv.calls, 1)
+	require.Equal(
+		t,
+		filepath.Join(dir, "captures", "page.png"),
+		drv.calls[0].Args["filename"],
+	)
+}
+
+func TestToolCall_ScreenshotDirRejectsEscapingFilename(t *testing.T) {
+	t.Parallel()
+
+	tool := newTestTool(&fakeDriver{})
+	tool.screenshotDir = t.TempDir()
+
+	_, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action":   actionScreenshot,
+			"filename": "../page.png",
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes screenshot_dir")
+}
+
+func TestToolCall_ScreenshotDirProvidesDefaultFilename(t *testing.T) {
+	t.Parallel()
+
+	drv := &fakeDriver{
+		callResult: map[string]any{
+			mcpToolScreenshot: textPayload("ok"),
+		},
+	}
+	dir := t.TempDir()
+	tool := newTestTool(drv)
+	tool.screenshotDir = dir
+
+	_, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"action": actionScreenshot,
+			"type":   "jpeg",
+		}),
+	)
+	require.NoError(t, err)
+	require.Len(t, drv.calls, 1)
+	filename, _ := drv.calls[0].Args["filename"].(string)
+	require.NotEmpty(t, filename)
+	require.DirExists(t, filepath.Dir(filename))
+	require.Equal(t, dir, filepath.Dir(filename))
+	require.Contains(t, filepath.Base(filename), "screenshot-")
+	require.Equal(t, ".jpg", filepath.Ext(filename))
+}
+
+func TestResolveScreenshotFilenameCompatibilityBranches(t *testing.T) {
+	t.Parallel()
+
+	withoutDir := newTestTool(&fakeDriver{})
+	got, err := withoutDir.resolveScreenshotFilename("page.png", "")
+	require.NoError(t, err)
+	require.Equal(t, "page.png", got)
+
+	dir := t.TempDir()
+	tool := newTestTool(&fakeDriver{})
+	tool.screenshotDir = dir
+
+	abs := filepath.Join(dir, "absolute.png")
+	got, err = tool.resolveScreenshotFilename(abs, "png")
+	require.NoError(t, err)
+	require.Equal(t, abs, got)
+
+	got, err = tool.resolveScreenshotFilename(".", "png")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestScreenshotExtension(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "png", screenshotExtension(""))
+	require.Equal(t, "jpg", screenshotExtension("jpeg"))
+	require.Equal(t, "jpg", screenshotExtension("JPG"))
+	require.Equal(t, "webp", screenshotExtension("webp"))
+	require.Equal(t, "png", screenshotExtension("gif"))
 }
 
 func TestToolCall_ScreenshotCompactsBrowserCrashContent(t *testing.T) {

--- a/openclaw/internal/imageinspect/imageinspect.go
+++ b/openclaw/internal/imageinspect/imageinspect.go
@@ -42,6 +42,15 @@ const (
 	maxBasenameSearchEntries = 10000
 )
 
+var preferredBasenameSubdirs = []string{
+	filepath.Join("workspaces", "scratch", "out"),
+	filepath.Join("workspaces", "scratch"),
+	filepath.Join("runtime", "tmp"),
+	"artifacts",
+	"downloads",
+	"out",
+}
+
 // Config configures the image inspection tool.
 type Config struct {
 	AllowedDirs      []string      `yaml:"allowed_dirs,omitempty"`
@@ -289,6 +298,9 @@ func (i *inspector) resolveAllowedRelativePath(
 	if strings.Contains(cleaned, string(os.PathSeparator)) {
 		return "", false, nil
 	}
+	if path, ok, err := i.resolvePreferredBasename(cleaned); ok || err != nil {
+		return path, ok, err
+	}
 	var match string
 	visited := 0
 	for _, dir := range i.allowedDirs {
@@ -332,6 +344,42 @@ func (i *inspector) resolveAllowedRelativePath(
 		}
 	}
 	return "", true, fmt.Errorf("path %q is outside allowed_dirs", raw)
+}
+
+func (i *inspector) resolvePreferredBasename(
+	basename string,
+) (string, bool, error) {
+	var match string
+	for _, dir := range i.allowedDirs {
+		for _, subdir := range preferredBasenameSubdirs {
+			candidate := filepath.Clean(filepath.Join(dir, subdir, basename))
+			if !pathInAllowedDir(candidate, dir) || !fileExists(candidate) {
+				continue
+			}
+			real, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return "", true, fmt.Errorf("resolve image path: %w", err)
+			}
+			real = filepath.Clean(real)
+			if !pathInAllowedDir(real, dir) {
+				return "", true, fmt.Errorf(
+					"path %q is outside allowed_dirs",
+					basename,
+				)
+			}
+			if match != "" && match != real {
+				return "", true, fmt.Errorf(
+					"multiple files named %q in preferred allowed_dirs",
+					basename,
+				)
+			}
+			match = real
+		}
+	}
+	if match == "" {
+		return "", false, nil
+	}
+	return match, true, nil
 }
 
 func pathInAllowedDir(path string, dir string) bool {

--- a/openclaw/internal/imageinspect/imageinspect_test.go
+++ b/openclaw/internal/imageinspect/imageinspect_test.go
@@ -11,6 +11,7 @@ package imageinspect
 
 import (
 	"context"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -406,6 +407,73 @@ func TestResolveAllowedRelativePathRejectsDuplicateBasenames(t *testing.T) {
 	require.Contains(t, err.Error(), "multiple files")
 }
 
+func TestResolveAllowedRelativePathFindsPreferredOutputBeforeLargeWalk(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	many := filepath.Join(dir, "many")
+	require.NoError(t, os.MkdirAll(many, 0o755))
+	for n := 0; n <= maxBasenameSearchEntries; n++ {
+		require.NoError(
+			t,
+			os.WriteFile(
+				filepath.Join(many, fmt.Sprintf("file-%05d.txt", n)),
+				[]byte("x"),
+				0o644,
+			),
+		)
+	}
+	target := filepath.Join(dir, "workspaces", "scratch", "out", "shot.png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	writeTestPNG(t, target, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{dir}})
+	require.NoError(t, err)
+	got, err := tool.resolvePath("shot.png")
+	require.NoError(t, err)
+	require.Equal(t, target, got)
+}
+
+func TestResolvePreferredBasenameRejectsDuplicatePreferredOutputs(t *testing.T) {
+	t.Parallel()
+
+	first := t.TempDir()
+	second := t.TempDir()
+	for _, dir := range []string{first, second} {
+		target := filepath.Join(dir, "workspaces", "scratch", "out", "same.png")
+		require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+		writeTestPNG(t, target, image.Rect(0, 0, 1, 1))
+	}
+
+	tool, err := newInspector(Config{AllowedDirs: []string{first, second}})
+	require.NoError(t, err)
+	_, err = tool.resolvePath("same.png")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple files")
+}
+
+func TestResolvePreferredBasenameRejectsEscapingSymlink(t *testing.T) {
+	t.Parallel()
+
+	allowed := t.TempDir()
+	outside := t.TempDir()
+	outsidePath := filepath.Join(outside, "shot.png")
+	writeTestPNG(t, outsidePath, image.Rect(0, 0, 1, 1))
+
+	preferred := filepath.Join(allowed, "workspaces", "scratch", "out")
+	require.NoError(t, os.MkdirAll(preferred, 0o755))
+	require.NoError(
+		t,
+		os.Symlink(outsidePath, filepath.Join(preferred, "shot.png")),
+	)
+
+	tool, err := newInspector(Config{AllowedDirs: []string{allowed}})
+	require.NoError(t, err)
+	_, err = tool.resolvePath("shot.png")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outside allowed_dirs")
+}
+
 func TestResolveAllowedRelativePathMissesDeletedAllowedDir(t *testing.T) {
 	t.Parallel()
 
@@ -493,7 +561,9 @@ func writeShellScript(
 	t.Helper()
 
 	path := filepath.Join(dir, name)
+	tmpPath := path + ".tmp"
 	content := "#!/bin/sh\n" + body
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	require.NoError(t, os.WriteFile(tmpPath, []byte(content), 0o755))
+	require.NoError(t, os.Rename(tmpPath, path))
 	return path
 }

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -295,7 +295,7 @@ func runForeground(
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := shellCmd(ctx, params.Command)
+	cmd := shellCmd(ctx, params.Command, true)
 	prepareCommandProcess(cmd)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(baseEnv, params.Env)
@@ -308,12 +308,19 @@ func runForeground(
 	return string(out), code, nil
 }
 
-func shellCmd(ctx context.Context, command string) *exec.Cmd {
+func shellCmd(
+	ctx context.Context,
+	command string,
+	cleanupShellJobs bool,
+) *exec.Cmd {
+	if cleanupShellJobs {
+		command = shellCommandWithExitCleanup(command)
+	}
 	cmd := exec.CommandContext(
 		ctx,
 		shellProgram,
 		shellLoginFlag,
-		shellCommandWithExitCleanup(command),
+		command,
 	)
 	cmd.Cancel = func() error {
 		return forceKillCommandProcess(cmd)
@@ -378,7 +385,7 @@ func (m *Manager) startBackground(
 		parentCtx = context.Background()
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, timeout)
-	cmd := shellCmd(ctx, params.Command)
+	cmd := shellCmd(ctx, params.Command, !params.Background)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(m.baseEnv, params.Env)
 
@@ -788,7 +795,7 @@ func snapshotLoginShellEnv(
 	ctx, cancel := context.WithTimeout(ctx, defaultShellEnvTimeout)
 	defer cancel()
 
-	cmd := shellCmd(ctx, shellEnvDumpCommand)
+	cmd := shellCmd(ctx, shellEnvDumpCommand, false)
 	cmd.Dir = workdir
 
 	out, err := cmd.Output()

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -35,8 +35,15 @@ const (
 	defaultIODrain         = 1 * time.Second
 	defaultShellEnvTimeout = 5 * time.Second
 
-	shellProgram        = "bash"
-	shellLoginFlag      = "-lc"
+	shellProgram     = "bash"
+	shellLoginFlag   = "-lc"
+	shellExitCleanup = `__trpc_claw_cleanup_jobs(){ ` +
+		`local pids; pids="$(jobs -pr)"; ` +
+		`if [ -n "$pids" ]; then ` +
+		`kill $pids 2>/dev/null || true; ` +
+		`sleep 0.05; ` +
+		`kill -KILL $pids 2>/dev/null || true; ` +
+		`fi; }; trap __trpc_claw_cleanup_jobs EXIT`
 	shellEnvDumpCommand = "env -0"
 )
 
@@ -292,6 +299,9 @@ func runForeground(
 	prepareCommandProcess(cmd)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(baseEnv, params.Env)
+	defer func() {
+		_ = cleanupCommandProcessGroup(cmd)
+	}()
 
 	out, err := cmd.CombinedOutput()
 	code := exitCode(err)
@@ -303,13 +313,17 @@ func shellCmd(ctx context.Context, command string) *exec.Cmd {
 		ctx,
 		shellProgram,
 		shellLoginFlag,
-		command,
+		shellCommandWithExitCleanup(command),
 	)
 	cmd.Cancel = func() error {
 		return forceKillCommandProcess(cmd)
 	}
 	cmd.WaitDelay = defaultIODrain
 	return cmd
+}
+
+func shellCommandWithExitCleanup(command string) string {
+	return shellExitCleanup + "\n" + command
 }
 
 func mergedEnv(

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -35,9 +35,12 @@ const (
 	defaultIODrain         = 1 * time.Second
 	defaultShellEnvTimeout = 5 * time.Second
 
-	shellProgram     = "bash"
-	shellLoginFlag   = "-lc"
-	shellExitCleanup = `__trpc_claw_cleanup_jobs(){ ` +
+	shellProgram       = "bash"
+	shellLoginFlag     = "-lc"
+	shellNoProfileFlag = "--noprofile"
+	shellNoRcFlag      = "--norc"
+	shellCommandFlag   = "-c"
+	shellExitCleanup   = `__trpc_claw_cleanup_jobs(){ ` +
 		`local pids; pids="$(jobs -pr)"; ` +
 		`if [ -n "$pids" ]; then ` +
 		`kill $pids 2>/dev/null || true; ` +
@@ -60,6 +63,7 @@ type Manager struct {
 	policy               CommandPolicy
 	redactor             OutputRedactor
 	maxResultOutputChars int
+	cleanShellStartup    bool
 
 	clock func() time.Time
 
@@ -143,6 +147,15 @@ func WithMaxResultOutputChars(n int) Option {
 	}
 }
 
+// WithCleanShellStartup runs shell commands without profile/rc startup files
+// and removes shell-startup env hooks such as BASH_ENV. The default is false
+// for compatibility with callers that rely on login shell setup.
+func WithCleanShellStartup(enabled bool) Option {
+	return func(m *Manager) {
+		m.cleanShellStartup = enabled
+	}
+}
+
 func NewManager(opts ...Option) *Manager {
 	m := &Manager{
 		sessions:         map[string]*session{},
@@ -217,6 +230,7 @@ func (m *Manager) Exec(
 			params,
 			timeout,
 			m.baseEnv,
+			m.cleanShellStartup,
 		)
 		if err != nil {
 			return execResult{}, err
@@ -291,14 +305,18 @@ func runForeground(
 	params execParams,
 	timeout time.Duration,
 	baseEnv map[string]string,
+	cleanStartup bool,
 ) (string, int, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := shellCmd(ctx, params.Command, true)
+	cmd := shellCmdWithStartup(ctx, params.Command, true, cleanStartup)
 	prepareCommandProcess(cmd)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(baseEnv, params.Env)
+	if cleanStartup {
+		cmd.Env = cleanCommandEnv(cmd.Env)
+	}
 	defer func() {
 		_ = cleanupCommandProcessGroup(cmd)
 	}()
@@ -313,20 +331,35 @@ func shellCmd(
 	command string,
 	cleanupShellJobs bool,
 ) *exec.Cmd {
+	return shellCmdWithStartup(ctx, command, cleanupShellJobs, false)
+}
+
+func shellCmdWithStartup(
+	ctx context.Context,
+	command string,
+	cleanupShellJobs bool,
+	cleanStartup bool,
+) *exec.Cmd {
 	if cleanupShellJobs {
 		command = shellCommandWithExitCleanup(command)
 	}
 	cmd := exec.CommandContext(
 		ctx,
 		shellProgram,
-		shellLoginFlag,
-		command,
+		append(shellArgs(cleanStartup), command)...,
 	)
 	cmd.Cancel = func() error {
 		return forceKillCommandProcess(cmd)
 	}
 	cmd.WaitDelay = defaultIODrain
 	return cmd
+}
+
+func shellArgs(cleanStartup bool) []string {
+	if cleanStartup {
+		return []string{shellNoProfileFlag, shellNoRcFlag, shellCommandFlag}
+	}
+	return []string{shellLoginFlag}
 }
 
 func shellCommandWithExitCleanup(command string) string {
@@ -364,6 +397,38 @@ func setEnv(env []string, k, v string) []string {
 	return append(env, prefix+v)
 }
 
+func cleanShellStartupEnv(env []string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := env[:0]
+	for _, pair := range env {
+		key, _, ok := splitEnvPair(pair)
+		if !ok || isShellStartupEnvKey(key) {
+			continue
+		}
+		out = append(out, pair)
+	}
+	return out
+}
+
+func cleanCommandEnv(env []string) []string {
+	if len(env) == 0 {
+		env = os.Environ()
+	}
+	return cleanShellStartupEnv(env)
+}
+
+func isShellStartupEnvKey(key string) bool {
+	switch strings.ToUpper(key) {
+	case "BASH_ENV", "ENV", "PROMPT_COMMAND", "PS4",
+		"SHELLOPTS", "BASHOPTS":
+		return true
+	default:
+		return strings.HasPrefix(strings.ToUpper(key), "BASH_FUNC_")
+	}
+}
+
 func exitCode(err error) int {
 	if err == nil {
 		return 0
@@ -385,9 +450,17 @@ func (m *Manager) startBackground(
 		parentCtx = context.Background()
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, timeout)
-	cmd := shellCmd(ctx, params.Command, !params.Background)
+	cmd := shellCmdWithStartup(
+		ctx,
+		params.Command,
+		!params.Background,
+		m.cleanShellStartup,
+	)
 	cmd.Dir = params.Workdir
 	cmd.Env = mergedEnv(m.baseEnv, params.Env)
+	if m.cleanShellStartup {
+		cmd.Env = cleanCommandEnv(cmd.Env)
+	}
 
 	sess := newSession(newSessionID(), params.Command, m.maxLines)
 	sess.cancel = cancel
@@ -499,7 +572,10 @@ func (m *Manager) commandEnv(
 	workdir string,
 	extra map[string]string,
 ) map[string]string {
-	out := m.loginShellEnv(ctx, workdir)
+	var out map[string]string
+	if !m.cleanShellStartup {
+		out = m.loginShellEnv(ctx, workdir)
+	}
 	if len(out) == 0 {
 		out = currentProcessEnvMap()
 	}

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -527,6 +527,9 @@ func (m *Manager) startBackground(
 		// "It is thus incorrect to call Wait before all reads from the
 		// pipe have completed."
 		ps, _ := cmd.Process.Wait()
+		if !params.Background {
+			_ = cleanupCommandProcessGroup(cmd)
+		}
 		waitDone(sess.ioDone, defaultIODrain)
 		code := -1
 		if ps != nil {
@@ -686,63 +689,6 @@ func truncateResultOutput(output string, maxChars int) string {
 		maxChars,
 		charCount,
 	)
-}
-
-func truncateLineWindowOutput(
-	output string,
-	maxChars int,
-	offset int,
-	nextOffset int,
-) (string, int, bool) {
-	if maxChars <= 0 {
-		return output, nextOffset, false
-	}
-	output = strings.ToValidUTF8(output, "\uFFFD")
-	charCount := utf8.RuneCountInString(output)
-	if charCount <= maxChars {
-		return output, nextOffset, false
-	}
-	if output == "" {
-		return output, nextOffset, false
-	}
-
-	lines := strings.Split(output, "\n")
-	parts := make([]string, 0, len(lines))
-	keptChars := 0
-	for _, line := range lines {
-		addChars := utf8.RuneCountInString(line)
-		if len(parts) > 0 {
-			addChars++
-		}
-		if keptChars+addChars > maxChars {
-			if len(parts) == 0 {
-				prefix := firstRunes(line, maxChars)
-				return appendTruncationNotice(
-					prefix,
-					utf8.RuneCountInString(prefix),
-					charCount,
-				), clampNextOffset(offset+1, offset, nextOffset), true
-			}
-			break
-		}
-		parts = append(parts, line)
-		keptChars += addChars
-	}
-
-	consumed := len(parts)
-	if consumed == 0 {
-		prefix := firstRunes(output, maxChars)
-		return appendTruncationNotice(
-			prefix,
-			utf8.RuneCountInString(prefix),
-			charCount,
-		), clampNextOffset(offset+1, offset, nextOffset), true
-	}
-	return appendTruncationNotice(
-		strings.Join(parts, "\n"),
-		keptChars,
-		charCount,
-	), clampNextOffset(offset+consumed, offset, nextOffset), true
 }
 
 func truncateTailResultOutput(output string, maxChars int) string {

--- a/openclaw/internal/octool/manager.go
+++ b/openclaw/internal/octool/manager.go
@@ -232,7 +232,7 @@ func (m *Manager) Exec(
 		return execResult{
 			Status:    "running",
 			SessionID: sess.id,
-			Output:    sess.tail(defaultLogTail),
+			Output:    m.limitTailResultOutput(sess.tail(defaultLogTail)),
 		}, nil
 	}
 
@@ -274,7 +274,7 @@ func (m *Manager) Exec(
 		return execResult{
 			Status:    "running",
 			SessionID: sess.id,
-			Output:    sess.tail(defaultLogTail),
+			Output:    m.limitTailResultOutput(sess.tail(defaultLogTail)),
 		}, nil
 	}
 }
@@ -540,6 +540,13 @@ func (m *Manager) limitResultOutput(output string) string {
 	return truncateResultOutput(output, m.maxResultOutputChars)
 }
 
+func (m *Manager) limitTailResultOutput(output string) string {
+	if m == nil || m.maxResultOutputChars <= 0 {
+		return output
+	}
+	return truncateTailResultOutput(output, m.maxResultOutputChars)
+}
+
 func (m *Manager) commandTimeout(timeoutS *int) time.Duration {
 	timeout := m.timeout
 	if timeoutS != nil && *timeoutS > 0 {
@@ -577,13 +584,111 @@ func truncateResultOutput(output string, maxChars int) string {
 	if charCount <= maxChars {
 		return output
 	}
-	return firstRunes(output, maxChars) + fmt.Sprintf(
-		"\n\n[OpenClaw truncated command output to %d of %d chars. "+
-			"Write large outputs to a file and read only the needed "+
-			"chunks with file tools or shell commands.]",
+	return appendTruncationNotice(
+		firstRunes(output, maxChars),
 		maxChars,
 		charCount,
 	)
+}
+
+func truncateLineWindowOutput(
+	output string,
+	maxChars int,
+	offset int,
+	nextOffset int,
+) (string, int, bool) {
+	if maxChars <= 0 {
+		return output, nextOffset, false
+	}
+	output = strings.ToValidUTF8(output, "\uFFFD")
+	charCount := utf8.RuneCountInString(output)
+	if charCount <= maxChars {
+		return output, nextOffset, false
+	}
+	if output == "" {
+		return output, nextOffset, false
+	}
+
+	lines := strings.Split(output, "\n")
+	parts := make([]string, 0, len(lines))
+	keptChars := 0
+	for _, line := range lines {
+		addChars := utf8.RuneCountInString(line)
+		if len(parts) > 0 {
+			addChars++
+		}
+		if keptChars+addChars > maxChars {
+			if len(parts) == 0 {
+				prefix := firstRunes(line, maxChars)
+				return appendTruncationNotice(
+					prefix,
+					utf8.RuneCountInString(prefix),
+					charCount,
+				), clampNextOffset(offset+1, offset, nextOffset), true
+			}
+			break
+		}
+		parts = append(parts, line)
+		keptChars += addChars
+	}
+
+	consumed := len(parts)
+	if consumed == 0 {
+		prefix := firstRunes(output, maxChars)
+		return appendTruncationNotice(
+			prefix,
+			utf8.RuneCountInString(prefix),
+			charCount,
+		), clampNextOffset(offset+1, offset, nextOffset), true
+	}
+	return appendTruncationNotice(
+		strings.Join(parts, "\n"),
+		keptChars,
+		charCount,
+	), clampNextOffset(offset+consumed, offset, nextOffset), true
+}
+
+func truncateTailResultOutput(output string, maxChars int) string {
+	if maxChars <= 0 {
+		return output
+	}
+	output = strings.ToValidUTF8(output, "\uFFFD")
+	charCount := utf8.RuneCountInString(output)
+	if charCount <= maxChars {
+		return output
+	}
+	return fmt.Sprintf(
+		"[OpenClaw truncated command output to the last %d of %d "+
+			"chars. Write large outputs to a file and read only "+
+			"the needed chunks with file tools or shell commands.]\n\n%s",
+		maxChars,
+		charCount,
+		lastRunes(output, maxChars),
+	)
+}
+
+func appendTruncationNotice(
+	prefix string,
+	keptChars int,
+	totalChars int,
+) string {
+	return prefix + fmt.Sprintf(
+		"\n\n[OpenClaw truncated command output to %d of %d chars. "+
+			"Write large outputs to a file and read only the needed "+
+			"chunks with file tools or shell commands.]",
+		keptChars,
+		totalChars,
+	)
+}
+
+func clampNextOffset(next int, offset int, end int) int {
+	if next <= offset && end > offset {
+		next = offset + 1
+	}
+	if next > end {
+		return end
+	}
+	return next
 }
 
 func firstRunes(value string, n int) string {
@@ -594,6 +699,24 @@ func firstRunes(value string, n int) string {
 	for idx := range value {
 		if count == n {
 			return value[:idx]
+		}
+		count++
+	}
+	return value
+}
+
+func lastRunes(value string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	start := utf8.RuneCountInString(value) - n
+	if start <= 0 {
+		return value
+	}
+	count := 0
+	for idx := range value {
+		if count == start {
+			return value[idx:]
 		}
 		count++
 	}
@@ -726,7 +849,7 @@ func (m *Manager) poll(id string, limit *int) (processPoll, error) {
 	if err != nil {
 		return processPoll{}, err
 	}
-	return s.poll(limit), nil
+	return s.poll(limit, m.maxResultOutputChars), nil
 }
 
 func (m *Manager) log(
@@ -738,7 +861,7 @@ func (m *Manager) log(
 	if err != nil {
 		return processLog{}, err
 	}
-	return s.log(offset, limit), nil
+	return s.log(offset, limit, m.maxResultOutputChars), nil
 }
 
 func (m *Manager) write(

--- a/openclaw/internal/octool/process_unix.go
+++ b/openclaw/internal/octool/process_unix.go
@@ -33,6 +33,21 @@ func forceKillCommandProcess(cmd *exec.Cmd) error {
 	return signalCommandProcess(cmd, syscall.SIGKILL)
 }
 
+func cleanupCommandProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	pid := cmd.Process.Pid
+	if pid <= 0 {
+		return nil
+	}
+	err := syscall.Kill(-pid, syscall.SIGKILL)
+	if err == nil || err == syscall.ESRCH {
+		return nil
+	}
+	return err
+}
+
 func signalCommandProcess(cmd *exec.Cmd, sig os.Signal) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil

--- a/openclaw/internal/octool/process_windows.go
+++ b/openclaw/internal/octool/process_windows.go
@@ -26,3 +26,7 @@ func forceKillCommandProcess(cmd *exec.Cmd) error {
 	}
 	return cmd.Process.Kill()
 }
+
+func cleanupCommandProcessGroup(cmd *exec.Cmd) error {
+	return nil
+}

--- a/openclaw/internal/octool/session.go
+++ b/openclaw/internal/octool/session.go
@@ -235,16 +235,14 @@ func (s *session) poll(limit *int, maxOutputChars int) processPoll {
 	from := start - s.lineBase
 	to := end - s.lineBase
 	out := strings.Join(s.lines[from:to], "\n")
-	out, next, truncated := truncateLineWindowOutput(
+	out, next, _ := truncateLineWindowOutput(
 		out,
 		maxOutputChars,
 		start,
 		end,
 	)
 	out = applyOutputRedactor(s.redact, out)
-	if !truncated {
-		out = truncateResultOutput(out, maxOutputChars)
-	}
+	out = truncateResultOutput(out, maxOutputChars)
 	s.pollCursor = next
 
 	res := processPoll{
@@ -302,16 +300,14 @@ func (s *session) log(
 	from := start - s.lineBase
 	to := end - s.lineBase
 	out := strings.Join(s.lines[from:to], "\n")
-	out, next, truncated := truncateLineWindowOutput(
+	out, next, _ := truncateLineWindowOutput(
 		out,
 		maxOutputChars,
 		start,
 		end,
 	)
 	out = applyOutputRedactor(s.redact, out)
-	if !truncated {
-		out = truncateResultOutput(out, maxOutputChars)
-	}
+	out = truncateResultOutput(out, maxOutputChars)
 
 	return processLog{
 		Output:     out,

--- a/openclaw/internal/octool/session.go
+++ b/openclaw/internal/octool/session.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 )
@@ -43,11 +44,16 @@ type session struct {
 	finished time.Time
 	exitCode int
 
-	lineBase   int
-	lines      []string
-	partial    string
-	pollCursor int
-	maxLines   int
+	segmentBase int
+	segments    []outputSegment
+	partial     string
+	pollCursor  int
+	maxLines    int
+}
+
+type outputSegment struct {
+	Text      string
+	Continued bool
 }
 
 func newSession(id, command string, maxLines int) *session {
@@ -84,7 +90,7 @@ func (s *session) markDone(exitCode int) {
 		return
 	}
 	if s.partial != "" {
-		s.lines = append(s.lines, s.partial)
+		s.appendLineLocked(s.partial)
 		s.partial = ""
 	}
 	s.exitCode = exitCode
@@ -121,23 +127,44 @@ func (s *session) appendOutput(chunk string) {
 	}
 	s.partial = parts[len(parts)-1]
 	for _, line := range parts[:len(parts)-1] {
-		s.lines = append(s.lines, line)
+		s.appendLineLocked(line)
 	}
 	s.trimLocked()
+}
+
+func (s *session) appendLineLocked(line string) {
+	s.segments = append(s.segments, outputSegment{Text: line})
 }
 
 func (s *session) trimLocked() {
 	if s.maxLines <= 0 {
 		return
 	}
-	if len(s.lines) <= s.maxLines {
+	lineCount := 0
+	for _, seg := range s.segments {
+		if !seg.Continued {
+			lineCount++
+		}
+	}
+	if lineCount <= s.maxLines {
 		return
 	}
-	drop := len(s.lines) - s.maxLines
-	s.lines = s.lines[drop:]
-	s.lineBase += drop
-	if s.pollCursor < s.lineBase {
-		s.pollCursor = s.lineBase
+	dropLines := lineCount - s.maxLines
+	dropSegments := 0
+	for dropSegments < len(s.segments) && dropLines > 0 {
+		if !s.segments[dropSegments].Continued {
+			dropLines--
+		}
+		dropSegments++
+		for dropSegments < len(s.segments) &&
+			s.segments[dropSegments].Continued {
+			dropSegments++
+		}
+	}
+	s.segments = s.segments[dropSegments:]
+	s.segmentBase += dropSegments
+	if s.pollCursor < s.segmentBase {
+		s.pollCursor = s.segmentBase
 	}
 }
 
@@ -149,10 +176,18 @@ func (s *session) tail(lines int) string {
 		return ""
 	}
 	start := 0
-	if len(s.lines) > lines {
-		start = len(s.lines) - lines
+	seen := 0
+	for i := len(s.segments) - 1; i >= 0; i-- {
+		if s.segments[i].Continued {
+			continue
+		}
+		seen++
+		if seen == lines {
+			start = i
+			break
+		}
 	}
-	out := strings.Join(s.lines[start:], "\n")
+	out := joinOutputSegments(s.segments[start:])
 	if s.partial != "" {
 		if out != "" {
 			out += "\n"
@@ -166,7 +201,7 @@ func (s *session) allOutput() (string, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	out := strings.Join(s.lines, "\n")
+	out := joinOutputSegments(s.segments)
 	if s.partial != "" {
 		if out != "" {
 			out += "\n"
@@ -221,28 +256,27 @@ func (s *session) poll(limit *int, maxOutputChars int) processPoll {
 	defer s.mu.Unlock()
 
 	start := s.pollCursor
-	if start < s.lineBase {
-		start = s.lineBase
+	s.splitLongSegmentsLocked(maxOutputChars)
+	if start < s.segmentBase {
+		start = s.segmentBase
 		s.pollCursor = start
 	}
-	end := s.lineBase + len(s.lines)
+	end := s.segmentBase + len(s.segments)
 	if limit != nil && *limit > 0 {
 		if want := start + *limit; want < end {
 			end = want
 		}
 	}
 
-	from := start - s.lineBase
-	to := end - s.lineBase
-	out := strings.Join(s.lines[from:to], "\n")
-	out, next, _ := truncateLineWindowOutput(
-		out,
+	from := start - s.segmentBase
+	to := end - s.segmentBase
+	out, next := renderSessionSegmentWindow(
+		s.segments[from:to],
 		maxOutputChars,
 		start,
 		end,
+		s.redact,
 	)
-	out = applyOutputRedactor(s.redact, out)
-	out = truncateResultOutput(out, maxOutputChars)
 	s.pollCursor = next
 
 	res := processPoll{
@@ -274,14 +308,16 @@ func (s *session) log(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	start := s.lineBase
-	end := s.lineBase + len(s.lines)
+	s.splitLongSegmentsLocked(maxOutputChars)
+
+	start := s.segmentBase
+	end := s.segmentBase + len(s.segments)
 
 	if offset != nil {
 		start = *offset
 	}
-	if start < s.lineBase {
-		start = s.lineBase
+	if start < s.segmentBase {
+		start = s.segmentBase
 	}
 	if start > end {
 		start = end
@@ -297,23 +333,125 @@ func (s *session) log(
 		}
 	}
 
-	from := start - s.lineBase
-	to := end - s.lineBase
-	out := strings.Join(s.lines[from:to], "\n")
-	out, next, _ := truncateLineWindowOutput(
-		out,
+	from := start - s.segmentBase
+	to := end - s.segmentBase
+	out, next := renderSessionSegmentWindow(
+		s.segments[from:to],
 		maxOutputChars,
 		start,
 		end,
+		s.redact,
 	)
-	out = applyOutputRedactor(s.redact, out)
-	out = truncateResultOutput(out, maxOutputChars)
 
 	return processLog{
 		Output:     out,
 		Offset:     start,
 		NextOffset: next,
 	}
+}
+
+func (s *session) splitLongSegmentsLocked(maxOutputChars int) {
+	if maxOutputChars <= 0 {
+		return
+	}
+	var out []outputSegment
+	changed := false
+	for _, seg := range s.segments {
+		if utf8.RuneCountInString(seg.Text) <= maxOutputChars {
+			out = append(out, seg)
+			continue
+		}
+		changed = true
+		chunks := splitRunes(seg.Text, maxOutputChars)
+		for i, chunk := range chunks {
+			out = append(out, outputSegment{
+				Text:      chunk,
+				Continued: seg.Continued || i > 0,
+			})
+		}
+	}
+	if changed {
+		s.segments = out
+	}
+}
+
+func renderSessionSegmentWindow(
+	segments []outputSegment,
+	maxOutputChars int,
+	offset int,
+	nextOffset int,
+	redact func(string) string,
+) (string, int) {
+	raw := joinOutputSegments(segments)
+	if maxOutputChars <= 0 || raw == "" {
+		return applyOutputRedactor(redact, raw), nextOffset
+	}
+
+	redactedAll := normalizeOutput(applyOutputRedactor(redact, raw))
+	totalChars := utf8.RuneCountInString(redactedAll)
+	if totalChars <= maxOutputChars {
+		return redactedAll, nextOffset
+	}
+
+	var kept string
+	var keptChars int
+	for i := 1; i <= len(segments); i++ {
+		rawCandidate := joinOutputSegments(segments[:i])
+		candidate := normalizeOutput(
+			applyOutputRedactor(redact, rawCandidate),
+		)
+		candidateChars := utf8.RuneCountInString(candidate)
+		if candidateChars > maxOutputChars {
+			if i == 1 {
+				out := truncateResultOutput(candidate, maxOutputChars)
+				next := clampNextOffset(offset+1, offset, nextOffset)
+				return out, next
+			}
+			out := appendTruncationNotice(kept, keptChars, totalChars)
+			next := clampNextOffset(offset+i-1, offset, nextOffset)
+			return out, next
+		}
+		kept = candidate
+		keptChars = candidateChars
+	}
+
+	return truncateResultOutput(redactedAll, maxOutputChars), nextOffset
+}
+
+func joinOutputSegments(segments []outputSegment) string {
+	var b strings.Builder
+	for i, seg := range segments {
+		if i > 0 && !seg.Continued {
+			b.WriteByte('\n')
+		}
+		b.WriteString(seg.Text)
+	}
+	return b.String()
+}
+
+func splitRunes(value string, size int) []string {
+	if size <= 0 || value == "" {
+		return []string{value}
+	}
+	chunks := make([]string, 0)
+	for value != "" {
+		count := 0
+		end := len(value)
+		for idx := range value {
+			if count == size {
+				end = idx
+				break
+			}
+			count++
+		}
+		chunks = append(chunks, value[:end])
+		value = value[end:]
+	}
+	return chunks
+}
+
+func normalizeOutput(output string) string {
+	return strings.ToValidUTF8(output, "\uFFFD")
 }
 
 type processWrite struct {

--- a/openclaw/internal/octool/session.go
+++ b/openclaw/internal/octool/session.go
@@ -216,7 +216,7 @@ type processPoll struct {
 	ExitCode   *int   `json:"exitCode,omitempty"`
 }
 
-func (s *session) poll(limit *int) processPoll {
+func (s *session) poll(limit *int, maxOutputChars int) processPoll {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -235,12 +235,22 @@ func (s *session) poll(limit *int) processPoll {
 	from := start - s.lineBase
 	to := end - s.lineBase
 	out := strings.Join(s.lines[from:to], "\n")
-	s.pollCursor = end
+	out, next, truncated := truncateLineWindowOutput(
+		out,
+		maxOutputChars,
+		start,
+		end,
+	)
+	out = applyOutputRedactor(s.redact, out)
+	if !truncated {
+		out = truncateResultOutput(out, maxOutputChars)
+	}
+	s.pollCursor = next
 
 	res := processPoll{
-		Output:     applyOutputRedactor(s.redact, out),
+		Output:     out,
 		Offset:     start,
-		NextOffset: end,
+		NextOffset: next,
 	}
 	if s.finished.IsZero() {
 		res.Status = "running"
@@ -258,7 +268,11 @@ type processLog struct {
 	NextOffset int    `json:"nextOffset"`
 }
 
-func (s *session) log(offset *int, limit *int) processLog {
+func (s *session) log(
+	offset *int,
+	limit *int,
+	maxOutputChars int,
+) processLog {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -288,11 +302,21 @@ func (s *session) log(offset *int, limit *int) processLog {
 	from := start - s.lineBase
 	to := end - s.lineBase
 	out := strings.Join(s.lines[from:to], "\n")
+	out, next, truncated := truncateLineWindowOutput(
+		out,
+		maxOutputChars,
+		start,
+		end,
+	)
+	out = applyOutputRedactor(s.redact, out)
+	if !truncated {
+		out = truncateResultOutput(out, maxOutputChars)
+	}
 
 	return processLog{
-		Output:     applyOutputRedactor(s.redact, out),
+		Output:     out,
 		Offset:     start,
-		NextOffset: end,
+		NextOffset: next,
 	}
 }
 

--- a/openclaw/internal/octool/tools.go
+++ b/openclaw/internal/octool/tools.go
@@ -285,6 +285,10 @@ func execToolDescription(hasMemoryFile bool) string {
 		"Large stdout/stderr may be truncated before it is returned " +
 			"to the model; write large outputs to files and read only " +
 			"the needed chunks.",
+		"Foreground commands clean up child jobs when the command " +
+			"exits; start long-running servers or processes with " +
+			"`background: true` when later tools must keep using " +
+			"them.",
 		"Do not use this just to inspect a PDF or spreadsheet already " +
 			"in chat; prefer read_document or read_spreadsheet for that.",
 	}

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -80,6 +80,17 @@ func TestSandboxExecToolDescription(t *testing.T) {
 	)
 }
 
+func TestExecToolDescriptionMentionsBackgroundForPersistentProcesses(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	desc := execToolDescription(false)
+	require.Contains(t, desc, "Foreground commands clean up child jobs")
+	require.Contains(t, desc, "`background: true`")
+	require.Contains(t, desc, "later tools must keep using them")
+}
+
 func TestNewSandboxExecCommandToolWithMemoryFileStore_WiresRegistry(t *testing.T) {
 	t.Parallel()
 
@@ -1132,6 +1143,51 @@ func TestExecTool_NormalExitCleansBackgroundProcessGroup(t *testing.T) {
 	}, 800*time.Millisecond, 20*time.Millisecond)
 }
 
+func TestExecTool_SessionExitCleansExecBypassedTrap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group signaling is unix-specific")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	marker := filepath.Join(t.TempDir(), "orphan-marker")
+	mgr := NewManager(WithMaxYield(time.Second))
+	yieldMs := 1000
+
+	res, err := mgr.Exec(context.Background(), execParams{
+		Command: "exec bash -c " + strconv.Quote(
+			"(sleep 0.4; echo orphan > "+
+				strconv.Quote(marker)+") >/dev/null 2>&1 & echo done",
+		),
+		YieldMs: &yieldMs,
+	})
+	require.NoError(t, err)
+	output := res.Output
+	switch res.Status {
+	case "exited":
+		require.Equal(t, 0, res.ExitCode)
+	case "running":
+		require.NotEmpty(t, res.SessionID)
+		t.Cleanup(func() {
+			_ = mgr.kill(res.SessionID)
+		})
+		output += pollUntilExited(t, mgr, res.SessionID)
+	default:
+		t.Fatalf("unexpected status: %s", res.Status)
+	}
+	require.Contains(t, output, "done")
+
+	require.Never(t, func() bool {
+		_, err = os.Stat(marker)
+		if err == nil {
+			return true
+		}
+		require.ErrorIs(t, err, os.ErrNotExist)
+		return false
+	}, 800*time.Millisecond, 20*time.Millisecond)
+}
+
 func TestExecTool_ContextCancelKillsYieldSessionProcessGroup(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process group signaling is unix-specific")
@@ -1609,9 +1665,25 @@ func TestManager_MaxResultOutputCharsPollCapsExpandedRedaction(
 	poll, err := mgr.poll(sess.id, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, poll.Offset)
+	require.Equal(t, 1, poll.NextOffset)
+	requireTruncatedExecOutput(t, poll.Output)
+	require.Contains(t, poll.Output, "alpha")
+	require.NotContains(t, poll.Output, "bravo-with-expanded-redaction")
+	require.NotContains(t, poll.Output, "charlie")
+
+	poll, err = mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, poll.Offset)
 	require.Equal(t, 2, poll.NextOffset)
 	requireTruncatedExecOutput(t, poll.Output)
+	require.Contains(t, poll.Output, "bravo-with")
 	require.NotContains(t, poll.Output, "charlie")
+
+	log, err := mgr.log(sess.id, &poll.NextOffset, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, log.Offset)
+	require.Equal(t, 3, log.NextOffset)
+	require.Contains(t, log.Output, "charlie")
 }
 
 func TestManager_MaxResultOutputCharsPollOversizedSingleLine(
@@ -1638,6 +1710,15 @@ func TestManager_MaxResultOutputCharsPollOversizedSingleLine(
 	require.NoError(t, err)
 	require.Equal(t, 1, poll.Offset)
 	require.Equal(t, 2, poll.NextOffset)
+	require.Contains(t, poll.Output, "mnopqrstuvwx")
+	require.NotContains(t, poll.Output, "next")
+	requireTruncatedExecOutput(t, poll.Output)
+
+	poll, err = mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, poll.Offset)
+	require.Equal(t, 4, poll.NextOffset)
+	require.Contains(t, poll.Output, "yz")
 	require.Contains(t, poll.Output, "next")
 }
 

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -485,6 +485,35 @@ func TestExecTool_UsesManagerBaseEnv(t *testing.T) {
 	require.Contains(t, strings.TrimSpace(res.Output), "ok")
 }
 
+func TestExecTool_CleanShellStartupSkipsBashEnv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	dir := t.TempDir()
+	bashEnv := filepath.Join(dir, "bash-env.sh")
+	require.NoError(t, os.WriteFile(
+		bashEnv,
+		[]byte("printf 'startup-noise\\n'\n"),
+		0o600,
+	))
+	t.Setenv("BASH_ENV", bashEnv)
+
+	mgr := NewManager(WithCleanShellStartup(true))
+	tool := newExecCommandTool(mgr)
+
+	args := mustJSON(t, map[string]any{
+		"command": "printf clean",
+		"yieldMs": 0,
+	})
+	out, err := tool.Call(context.Background(), args)
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "exited", res.Status)
+	require.Equal(t, "clean", res.Output)
+}
+
 func TestExecTool_UsesIdentityEnvFromContext(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not available")
@@ -2083,6 +2112,24 @@ func TestManager_ExecSkipsShellSnapshotWithoutHooks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "exited", out.Status)
 	require.Contains(t, out.Output, "ok")
+}
+
+func TestManager_CleanShellCommandEnvSkipsLoginSnapshot(t *testing.T) {
+	mgr := NewManager(WithCleanShellStartup(true))
+	mgr.shellEnvSnapshot = func(
+		context.Context,
+		string,
+	) map[string]string {
+		t.Fatal("unexpected shell env snapshot")
+		return nil
+	}
+
+	env := mgr.commandEnv(
+		context.Background(),
+		"/tmp/work",
+		map[string]string{"EXTRA_ONLY": "extra"},
+	)
+	require.Equal(t, "extra", env["EXTRA_ONLY"])
 }
 
 func TestManager_CommandEnvUsesWorkdirSnapshot(t *testing.T) {

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -1354,6 +1354,143 @@ func TestManager_MaxResultOutputCharsTruncatesSessionCompletion(
 	requireTruncatedExecOutput(t, res.Output)
 }
 
+func TestManager_MaxResultOutputCharsTruncatesRunningTail(
+	t *testing.T,
+) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(
+		WithMaxResultOutputChars(80),
+		WithMaxYield(2*time.Second),
+	)
+	execTool := newExecCommandTool(mgr)
+
+	out, err := execTool.Call(context.Background(), mustJSON(t, map[string]any{
+		"command": "printf 'old%.0s' {1..80}; " +
+			"printf '\\nLATEST\\n'; sleep 3",
+		"yield_time_ms": 1500,
+	}))
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "running", res.Status)
+	require.NotEmpty(t, res.SessionID)
+	t.Cleanup(func() {
+		_ = mgr.kill(res.SessionID)
+	})
+	requireTruncatedExecOutput(t, res.Output)
+	require.Contains(t, res.Output, "LATEST")
+}
+
+func TestManager_MaxResultOutputCharsTruncatesPollAndLog(
+	t *testing.T,
+) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	mgr := NewManager(
+		WithMaxResultOutputChars(80),
+		WithMaxYield(2*time.Second),
+	)
+	execTool := newExecCommandTool(mgr)
+	writeTool := newWriteStdinTool(mgr)
+
+	out, err := execTool.Call(context.Background(), mustJSON(t, map[string]any{
+		"command": "printf 'abcdefghijklmnopqrstuvwxyz%.0s' {1..8}; " +
+			"printf '\\n'; sleep 3",
+		"yield_time_ms": 1500,
+	}))
+	require.NoError(t, err)
+
+	res := out.(execResult)
+	require.Equal(t, "running", res.Status)
+	require.NotEmpty(t, res.SessionID)
+	t.Cleanup(func() {
+		_ = mgr.kill(res.SessionID)
+	})
+
+	writeAny, err := writeTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"session_id":    res.SessionID,
+			"yield_time_ms": 0,
+		}),
+	)
+	require.NoError(t, err)
+	requireTruncatedExecOutput(t, outputField(writeAny.(map[string]any)))
+
+	log, err := mgr.log(res.SessionID, nil, nil)
+	require.NoError(t, err)
+	requireTruncatedExecOutput(t, log.Output)
+}
+
+func TestManager_MaxResultOutputCharsPollKeepsNextOffset(
+	t *testing.T,
+) {
+	mgr := NewManager(WithMaxResultOutputChars(12))
+	sess := newSession("session-id", "cmd", 0)
+	sess.appendOutput("alpha\nbravo\ncharlie\ndelta\n")
+	sess.markDone(0)
+
+	mgr.mu.Lock()
+	mgr.sessions[sess.id] = sess
+	mgr.mu.Unlock()
+
+	poll, err := mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, poll.Offset)
+	require.Equal(t, 2, poll.NextOffset)
+	require.Contains(t, poll.Output, "alpha\nbravo")
+	require.NotContains(t, poll.Output, "charlie")
+	requireTruncatedExecOutput(t, poll.Output)
+
+	poll, err = mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, poll.Offset)
+	require.Equal(t, 3, poll.NextOffset)
+	require.Contains(t, poll.Output, "charlie")
+	require.NotContains(t, poll.Output, "delta")
+	requireTruncatedExecOutput(t, poll.Output)
+
+	log, err := mgr.log(sess.id, &poll.NextOffset, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3, log.Offset)
+	require.Equal(t, 4, log.NextOffset)
+	require.Contains(t, log.Output, "delta")
+}
+
+func TestManager_MaxResultOutputCharsPollUsesRawLineOffsets(
+	t *testing.T,
+) {
+	mgr := NewManager(WithMaxResultOutputChars(12))
+	sess := newSession("session-id", "cmd", 0)
+	sess.redact = func(output string) string {
+		return strings.ReplaceAll(output, "bravo", "bravo\ninserted")
+	}
+	sess.appendOutput("alpha\nbravo\ncharlie\ndelta\n")
+	sess.markDone(0)
+
+	mgr.mu.Lock()
+	mgr.sessions[sess.id] = sess
+	mgr.mu.Unlock()
+
+	poll, err := mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, poll.Offset)
+	require.Equal(t, 2, poll.NextOffset)
+	require.Contains(t, poll.Output, "inserted")
+	require.NotContains(t, poll.Output, "charlie")
+
+	poll, err = mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, poll.Offset)
+	require.Equal(t, 3, poll.NextOffset)
+	require.Contains(t, poll.Output, "charlie")
+}
+
 func requireTruncatedExecOutput(t *testing.T, output string) {
 	t.Helper()
 
@@ -1755,20 +1892,20 @@ func TestSession_Log(t *testing.T) {
 		s.appendOutput("x\n")
 	}
 
-	got := s.log(nil, nil)
+	got := s.log(nil, nil, 0)
 	require.Equal(t, 50, got.Offset)
 	require.Equal(t, total, got.NextOffset)
 	require.Len(t, strings.Split(got.Output, "\n"), defaultLogLimit)
 
 	offset := 999
-	got = s.log(&offset, nil)
+	got = s.log(&offset, nil, 0)
 	require.Empty(t, got.Output)
 	require.Equal(t, total, got.Offset)
 	require.Equal(t, total, got.NextOffset)
 
 	offset = 20
 	limit := 2
-	got = s.log(&offset, &limit)
+	got = s.log(&offset, &limit, 0)
 	require.Len(t, strings.Split(got.Output, "\n"), 2)
 	require.Equal(t, offset, got.Offset)
 	require.Equal(t, offset+limit, got.NextOffset)

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -1413,6 +1414,41 @@ func TestManager_MaxResultOutputCharsTruncatesRunningTail(
 	require.Contains(t, res.Output, "LATEST")
 }
 
+func TestExecTool_BackgroundPreservesShellManagedJobs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group behavior differs on windows")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	mgr := NewManager(WithDefaultTimeout(2 * time.Second))
+	execTool := newExecCommandTool(mgr)
+
+	out, err := execTool.Call(context.Background(), mustJSON(t, map[string]any{
+		"command": fmt.Sprintf(
+			"(sleep 0.2; echo survived > %q) >/dev/null 2>&1 &",
+			marker,
+		),
+		"background":  true,
+		"timeout_sec": 2,
+	}))
+	require.NoError(t, err)
+	res := out.(execResult)
+	require.Equal(t, "running", res.Status)
+	require.NotEmpty(t, res.SessionID)
+	t.Cleanup(func() {
+		_ = mgr.kill(res.SessionID)
+	})
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, time.Second, 20*time.Millisecond)
+}
+
 func TestManager_MaxResultOutputCharsTruncatesPollAndLog(
 	t *testing.T,
 ) {
@@ -1494,7 +1530,7 @@ func TestManager_MaxResultOutputCharsPollKeepsNextOffset(
 func TestManager_MaxResultOutputCharsPollUsesRawLineOffsets(
 	t *testing.T,
 ) {
-	mgr := NewManager(WithMaxResultOutputChars(12))
+	mgr := NewManager(WithMaxResultOutputChars(40))
 	sess := newSession("session-id", "cmd", 0)
 	sess.redact = func(output string) string {
 		return strings.ReplaceAll(output, "bravo", "bravo\ninserted")
@@ -1506,18 +1542,74 @@ func TestManager_MaxResultOutputCharsPollUsesRawLineOffsets(
 	mgr.sessions[sess.id] = sess
 	mgr.mu.Unlock()
 
-	poll, err := mgr.poll(sess.id, nil)
+	limit := 2
+	poll, err := mgr.poll(sess.id, &limit)
 	require.NoError(t, err)
 	require.Equal(t, 0, poll.Offset)
 	require.Equal(t, 2, poll.NextOffset)
 	require.Contains(t, poll.Output, "inserted")
 	require.NotContains(t, poll.Output, "charlie")
 
-	poll, err = mgr.poll(sess.id, nil)
+	limit = 1
+	poll, err = mgr.poll(sess.id, &limit)
 	require.NoError(t, err)
 	require.Equal(t, 2, poll.Offset)
 	require.Equal(t, 3, poll.NextOffset)
 	require.Contains(t, poll.Output, "charlie")
+}
+
+func TestManager_MaxResultOutputCharsPollCapsExpandedRedaction(
+	t *testing.T,
+) {
+	mgr := NewManager(WithMaxResultOutputChars(12))
+	sess := newSession("session-id", "cmd", 0)
+	sess.redact = func(output string) string {
+		return strings.ReplaceAll(
+			output,
+			"bravo",
+			"bravo-with-expanded-redaction",
+		)
+	}
+	sess.appendOutput("alpha\nbravo\ncharlie\n")
+	sess.markDone(0)
+
+	mgr.mu.Lock()
+	mgr.sessions[sess.id] = sess
+	mgr.mu.Unlock()
+
+	poll, err := mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, poll.Offset)
+	require.Equal(t, 2, poll.NextOffset)
+	requireTruncatedExecOutput(t, poll.Output)
+	require.NotContains(t, poll.Output, "charlie")
+}
+
+func TestManager_MaxResultOutputCharsPollOversizedSingleLine(
+	t *testing.T,
+) {
+	mgr := NewManager(WithMaxResultOutputChars(12))
+	sess := newSession("session-id", "cmd", 0)
+	sess.appendOutput("abcdefghijklmnopqrstuvwxyz\nnext\n")
+	sess.markDone(0)
+
+	mgr.mu.Lock()
+	mgr.sessions[sess.id] = sess
+	mgr.mu.Unlock()
+
+	poll, err := mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, poll.Offset)
+	require.Equal(t, 1, poll.NextOffset)
+	require.Contains(t, poll.Output, "abcdefghijkl")
+	require.NotContains(t, poll.Output, "next")
+	requireTruncatedExecOutput(t, poll.Output)
+
+	poll, err = mgr.poll(sess.id, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, poll.Offset)
+	require.Equal(t, 2, poll.NextOffset)
+	require.Contains(t, poll.Output, "next")
 }
 
 func requireTruncatedExecOutput(t *testing.T, output string) {

--- a/openclaw/internal/octool/tools_test.go
+++ b/openclaw/internal/octool/tools_test.go
@@ -1073,6 +1073,35 @@ func TestExecTool_DefaultTimeoutKillsProcessGroup(t *testing.T) {
 	}, 900*time.Millisecond, 20*time.Millisecond)
 }
 
+func TestExecTool_NormalExitCleansBackgroundProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process group signaling is unix-specific")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	marker := filepath.Join(t.TempDir(), "orphan-marker")
+	mgr := NewManager()
+
+	res, err := mgr.Exec(context.Background(), execParams{
+		Command: "(sleep 0.4; echo orphan > " +
+			strconv.Quote(marker) + ") >/dev/null 2>&1 & echo done",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, res.ExitCode)
+	require.Contains(t, res.Output, "done")
+
+	require.Never(t, func() bool {
+		_, err = os.Stat(marker)
+		if err == nil {
+			return true
+		}
+		require.ErrorIs(t, err, os.ErrNotExist)
+		return false
+	}, 800*time.Millisecond, 20*time.Millisecond)
+}
+
 func TestExecTool_ContextCancelKillsYieldSessionProcessGroup(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process group signaling is unix-specific")

--- a/openclaw/openclaw.yaml
+++ b/openclaw/openclaw.yaml
@@ -77,6 +77,7 @@ tools:
       config:
         default_profile: "openclaw"
         evaluate_enabled: false
+        screenshot_dir: "${TRPC_CLAW_STATE_DIR}/workspaces/scratch/out"
         server_url: "http://127.0.0.1:19790"
         sandbox_server_url: "http://127.0.0.1:20790"
         profiles:


### PR DESCRIPTION
## Summary
- Limit large running exec/session outputs returned to the model while preserving poll/log offsets.
- Keep the newest tail when truncating running session output.
- Clean shell-managed background jobs left by foreground `exec_command` after the shell exits, preventing orphaned local helper servers from leaking across eval runs.

## Validation
- `go test ./internal/octool -run 'TestExecTool_NormalExitCleansBackgroundProcessGroup|TestExecTool_DefaultTimeoutKillsProcessGroup|TestExecTool_ContextCancelKillsYieldSessionProcessGroup|TestManager_MaxResultOutputChars' -count=1`
- `go test ./internal/octool -count=1`
