### PR TITLE
openclaw/app: allow browser artifact reads

### DIFF
--- a/openclaw/app/tooling_builtins.go
+++ b/openclaw/app/tooling_builtins.go
@@ -470,7 +470,10 @@ func defaultFileReadOnlyDirs(stateDir string) []string {
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		if cwd = strings.TrimSpace(cwd); cwd != "" {
-			roots = append(roots, filepath.Join(cwd, browserArtifactDirName))
+			artifactDir := filepath.Join(cwd, browserArtifactDirName)
+			if err := os.MkdirAll(artifactDir, 0o755); err == nil {
+				roots = append(roots, artifactDir)
+			}
 		}
 	}
 	if stateDir := strings.TrimSpace(stateDir); stateDir != "" {

--- a/openclaw/app/tooling_builtins.go
+++ b/openclaw/app/tooling_builtins.go
@@ -487,22 +487,34 @@ func defaultFileReadOnlyDirs(stateDir string) []string {
 }
 
 func browserArtifactReadRoot(cwd string) (string, bool) {
+	return browserArtifactReadRootWith(cwd, os.Lstat, os.MkdirAll)
+}
+
+type browserArtifactLstatFunc func(string) (os.FileInfo, error)
+
+type browserArtifactMkdirAllFunc func(string, os.FileMode) error
+
+func browserArtifactReadRootWith(
+	cwd string,
+	lstat browserArtifactLstatFunc,
+	mkdirAll browserArtifactMkdirAllFunc,
+) (string, bool) {
 	artifactDir := filepath.Join(cwd, browserArtifactDirName)
-	info, err := os.Lstat(artifactDir)
+	info, err := lstat(artifactDir)
 	switch {
 	case err == nil:
 		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 			return "", false
 		}
 	case os.IsNotExist(err):
-		if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		if err := mkdirAll(artifactDir, 0o755); err != nil {
 			return "", false
 		}
 	default:
 		return "", false
 	}
 
-	info, err = os.Lstat(artifactDir)
+	info, err = lstat(artifactDir)
 	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 		return "", false
 	}

--- a/openclaw/app/tooling_builtins.go
+++ b/openclaw/app/tooling_builtins.go
@@ -470,8 +470,8 @@ func defaultFileReadOnlyDirs(stateDir string) []string {
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		if cwd = strings.TrimSpace(cwd); cwd != "" {
-			artifactDir := filepath.Join(cwd, browserArtifactDirName)
-			if err := os.MkdirAll(artifactDir, 0o755); err == nil {
+			artifactDir, ok := browserArtifactReadRoot(cwd)
+			if ok {
 				roots = append(roots, artifactDir)
 			}
 		}
@@ -484,6 +484,29 @@ func defaultFileReadOnlyDirs(stateDir string) []string {
 		)
 	}
 	return roots
+}
+
+func browserArtifactReadRoot(cwd string) (string, bool) {
+	artifactDir := filepath.Join(cwd, browserArtifactDirName)
+	info, err := os.Lstat(artifactDir)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", false
+		}
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+
+	info, err = os.Lstat(artifactDir)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", false
+	}
+	return artifactDir, true
 }
 
 func absPathOrOriginal(path string) string {

--- a/openclaw/app/tooling_builtins.go
+++ b/openclaw/app/tooling_builtins.go
@@ -59,6 +59,8 @@ const (
 	mcpTransportStdio      = "stdio"
 	mcpTransportSSE        = "sse"
 	mcpTransportStreamable = "streamable"
+
+	browserArtifactDirName = ".playwright-mcp"
 )
 
 func init() {
@@ -465,6 +467,11 @@ func defaultFileReadOnlyDirs(stateDir string) []string {
 	roots := []string{absPathOrOriginal(os.TempDir())}
 	if runtime.GOOS != "windows" {
 		roots = append(roots, absPathOrOriginal("/tmp"))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if cwd = strings.TrimSpace(cwd); cwd != "" {
+			roots = append(roots, filepath.Join(cwd, browserArtifactDirName))
+		}
 	}
 	if stateDir := strings.TrimSpace(stateDir); stateDir != "" {
 		roots = append(

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -558,6 +558,56 @@ func TestNewFileToolSet_RuntimeReadDirsAllowBrowserArtifacts(
 	require.Contains(t, string(data), `"contents":"title: Example`)
 }
 
+func TestNewFileToolSet_RuntimeReadDirsRejectSymlinkedBrowserArtifacts(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on windows")
+	}
+
+	oldWorkdir, err := os.Getwd()
+	require.NoError(t, err)
+	workdir, err := os.MkdirTemp(oldWorkdir, ".test-browser-artifacts-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(workdir))
+	})
+	require.NoError(t, os.Chdir(workdir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWorkdir))
+	})
+
+	outsideDir := filepath.Join(workdir, "outside")
+	require.NoError(t, os.MkdirAll(outsideDir, 0o755))
+	artifactDir := filepath.Join(workdir, browserArtifactDirName)
+	require.NoError(t, os.Symlink(outsideDir, artifactDir))
+
+	cfg := yamlNode(t, "base_dir: "+t.TempDir()+"\n")
+	ts, err := newFileToolSet(
+		registry.ToolSetProviderDeps{StateDir: t.TempDir()},
+		registry.PluginSpec{Name: "fs", Config: cfg},
+	)
+	require.NoError(t, err)
+	readFile := findCallableTool(t, ts.Tools(context.Background()), "read_file")
+
+	artifactFile := filepath.Join(outsideDir, "page.yml")
+	require.NoError(t, os.WriteFile(
+		artifactFile,
+		[]byte("title: Symlink\n"),
+		0o644,
+	))
+	_, err = readFile.Call(
+		context.Background(),
+		[]byte(`{"file_name":`+strconv.Quote(artifactFile)+`}`),
+	)
+	require.Error(t, err)
+	require.Contains(
+		t,
+		err.Error(),
+		"outside base_directory and configured read-only roots",
+	)
+}
+
 func TestNewFileToolSet_RuntimeReadDirsCanDisable(t *testing.T) {
 	dir := t.TempDir()
 	tmpFile := filepath.Join(t.TempDir(), "derived.txt")

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -515,6 +515,44 @@ func TestNewFileToolSet_RuntimeReadDirsRelativeStateDir(t *testing.T) {
 	require.Contains(t, string(data), `"contents":"derived"`)
 }
 
+func TestNewFileToolSet_RuntimeReadDirsAllowBrowserArtifacts(
+	t *testing.T,
+) {
+	workdir := t.TempDir()
+	oldWorkdir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workdir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(oldWorkdir))
+	})
+
+	artifactDir := filepath.Join(workdir, browserArtifactDirName)
+	require.NoError(t, os.MkdirAll(artifactDir, 0o755))
+	artifactFile := filepath.Join(artifactDir, "page.yml")
+	require.NoError(t, os.WriteFile(
+		artifactFile,
+		[]byte("title: Example\n"),
+		0o644,
+	))
+
+	cfg := yamlNode(t, "base_dir: "+t.TempDir()+"\n")
+	ts, err := newFileToolSet(
+		registry.ToolSetProviderDeps{StateDir: t.TempDir()},
+		registry.PluginSpec{Name: "fs", Config: cfg},
+	)
+	require.NoError(t, err)
+	readFile := findCallableTool(t, ts.Tools(context.Background()), "read_file")
+
+	raw, err := readFile.Call(
+		context.Background(),
+		[]byte(`{"file_name":`+strconv.Quote(artifactFile)+`}`),
+	)
+	require.NoError(t, err)
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"contents":"title: Example`)
+}
+
 func TestNewFileToolSet_RuntimeReadDirsCanDisable(t *testing.T) {
 	dir := t.TempDir()
 	tmpFile := filepath.Join(t.TempDir(), "derived.txt")

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -518,22 +518,20 @@ func TestNewFileToolSet_RuntimeReadDirsRelativeStateDir(t *testing.T) {
 func TestNewFileToolSet_RuntimeReadDirsAllowBrowserArtifacts(
 	t *testing.T,
 ) {
-	workdir := t.TempDir()
 	oldWorkdir, err := os.Getwd()
 	require.NoError(t, err)
+	workdir, err := os.MkdirTemp(oldWorkdir, ".test-browser-artifacts-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(workdir))
+	})
 	require.NoError(t, os.Chdir(workdir))
 	t.Cleanup(func() {
 		require.NoError(t, os.Chdir(oldWorkdir))
 	})
 
 	artifactDir := filepath.Join(workdir, browserArtifactDirName)
-	require.NoError(t, os.MkdirAll(artifactDir, 0o755))
-	artifactFile := filepath.Join(artifactDir, "page.yml")
-	require.NoError(t, os.WriteFile(
-		artifactFile,
-		[]byte("title: Example\n"),
-		0o644,
-	))
+	require.NoDirExists(t, artifactDir)
 
 	cfg := yamlNode(t, "base_dir: "+t.TempDir()+"\n")
 	ts, err := newFileToolSet(
@@ -541,8 +539,15 @@ func TestNewFileToolSet_RuntimeReadDirsAllowBrowserArtifacts(
 		registry.PluginSpec{Name: "fs", Config: cfg},
 	)
 	require.NoError(t, err)
+	require.DirExists(t, artifactDir)
 	readFile := findCallableTool(t, ts.Tools(context.Background()), "read_file")
 
+	artifactFile := filepath.Join(artifactDir, "page.yml")
+	require.NoError(t, os.WriteFile(
+		artifactFile,
+		[]byte("title: Example\n"),
+		0o644,
+	))
 	raw, err := readFile.Call(
 		context.Background(),
 		[]byte(`{"file_name":`+strconv.Quote(artifactFile)+`}`),

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -12,6 +12,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -24,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -608,6 +610,94 @@ func TestNewFileToolSet_RuntimeReadDirsRejectSymlinkedBrowserArtifacts(
 	)
 }
 
+func TestBrowserArtifactReadRootWithErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	errBoom := errors.New("boom")
+
+	tests := []struct {
+		name    string
+		lstat   browserArtifactLstatFunc
+		mkdir   browserArtifactMkdirAllFunc
+		wantDir string
+		wantOK  bool
+	}{
+		{
+			name: "lstat error",
+			lstat: func(string) (os.FileInfo, error) {
+				return nil, errBoom
+			},
+			mkdir: func(string, os.FileMode) error {
+				t.Fatal("mkdir should not be called")
+				return nil
+			},
+		},
+		{
+			name: "mkdir error",
+			lstat: func(string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			},
+			mkdir: func(string, os.FileMode) error {
+				return errBoom
+			},
+		},
+		{
+			name: "post-create lstat error",
+			lstat: lstatSequence(
+				nil,
+				os.ErrNotExist,
+				nil,
+				errBoom,
+			),
+			mkdir: func(string, os.FileMode) error {
+				return nil
+			},
+		},
+		{
+			name: "post-create symlink",
+			lstat: lstatSequence(
+				nil,
+				os.ErrNotExist,
+				browserArtifactFileInfo{
+					mode: os.ModeSymlink,
+				},
+				nil,
+			),
+			mkdir: func(string, os.FileMode) error {
+				return nil
+			},
+		},
+		{
+			name: "post-create safe directory",
+			lstat: lstatSequence(
+				nil,
+				os.ErrNotExist,
+				browserArtifactFileInfo{dir: true},
+				nil,
+			),
+			mkdir: func(string, os.FileMode) error {
+				return nil
+			},
+			wantDir: filepath.Join("cwd", browserArtifactDirName),
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotDir, gotOK := browserArtifactReadRootWith(
+				"cwd",
+				tt.lstat,
+				tt.mkdir,
+			)
+			require.Equal(t, tt.wantOK, gotOK)
+			require.Equal(t, tt.wantDir, gotDir)
+		})
+	}
+}
+
 func TestNewFileToolSet_RuntimeReadDirsCanDisable(t *testing.T) {
 	dir := t.TempDir()
 	tmpFile := filepath.Join(t.TempDir(), "derived.txt")
@@ -657,6 +747,51 @@ func TestDefaultFileReadOnlyDirsAbsolutizesRelativeStateDir(t *testing.T) {
 
 	roots := defaultFileReadOnlyDirs(stateRoot)
 	require.Contains(t, roots, wantScratch)
+}
+
+func lstatSequence(
+	firstInfo os.FileInfo,
+	firstErr error,
+	secondInfo os.FileInfo,
+	secondErr error,
+) browserArtifactLstatFunc {
+	var calls int
+	return func(string) (os.FileInfo, error) {
+		calls++
+		if calls == 1 {
+			return firstInfo, firstErr
+		}
+		return secondInfo, secondErr
+	}
+}
+
+type browserArtifactFileInfo struct {
+	mode os.FileMode
+	dir  bool
+}
+
+func (i browserArtifactFileInfo) Name() string {
+	return browserArtifactDirName
+}
+
+func (i browserArtifactFileInfo) Size() int64 {
+	return 0
+}
+
+func (i browserArtifactFileInfo) Mode() os.FileMode {
+	return i.mode
+}
+
+func (i browserArtifactFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (i browserArtifactFileInfo) IsDir() bool {
+	return i.dir
+}
+
+func (i browserArtifactFileInfo) Sys() any {
+	return nil
 }
 
 func TestAbsPathOrOriginalFallbacks(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add the Playwright MCP artifact directory under the current working directory to the default file-tool read-only roots.
- Keep the allowance scoped to `.playwright-mcp` instead of the whole workspace.
- Cover absolute reads of browser-generated artifact files with a focused test.

Validation:
- go test ./app -run 'TestNewFileToolSet_RuntimeReadDirsAllowBrowserArtifacts|TestDefaultFileReadOnlyDirsIncludesPlatformTmp|TestNewFileToolSet_RuntimeReadDirsDefault|TestNewFileToolSet_RuntimeReadDirsCanDisable' -count=1