### PR TITLE
{evaluation, docs, examples}: add template trace bindings

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1567,8 +1567,14 @@ type TemplateVariableBinding struct {
 
 // TemplateVariableSource represents a template variable source.
 type TemplateVariableSource struct {
-	Scope TemplateVariableScope // Scope is the source scope.
-	Field TemplateVariableField // Field is the source field.
+	Scope    TemplateVariableScope     // Scope is the source scope.
+	Field    TemplateVariableField     // Field is the source field.
+	Selector *TemplateVariableSelector // Selector is the trace step selector.
+}
+
+// TemplateVariableSelector represents a template variable selector.
+type TemplateVariableSelector struct {
+	NodeID string // NodeID is the trace step node ID to read.
 }
 
 // TemplateVariableScope represents the template variable source scope.
@@ -1583,8 +1589,10 @@ const (
 type TemplateVariableField string
 
 const (
-	TemplateVariableFieldUserContent   TemplateVariableField = "userContent"
-	TemplateVariableFieldFinalResponse TemplateVariableField = "finalResponse"
+	TemplateVariableFieldUserContent     TemplateVariableField = "userContent"
+	TemplateVariableFieldFinalResponse   TemplateVariableField = "finalResponse"
+	TemplateVariableFieldTraceStepInput  TemplateVariableField = "traceStepInput"
+	TemplateVariableFieldTraceStepOutput TemplateVariableField = "traceStepOutput"
 )
 
 // Rubric represents one evaluation rubric.
@@ -1669,13 +1677,15 @@ The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in r
 
 `template.prompt` uses double-brace template syntax such as `{{question}}` and `{{answer}}`. Every placeholder must be explicitly bound in `variableBindings`. Unbound variables, unknown variables, or binding resolution failures all result in errors.
 
-`template.variableBindings` currently supports values from the current scoring turn only:
+`template.variableBindings` supports values from `actual` and `expected` in the current scoring turn:
 
 - `actual.userContent`
 - `actual.finalResponse`
+- `actual.traceStepInput`
+- `actual.traceStepOutput`
 - `expected.finalResponse`
 
-`expected.finalResponse` requires the current expected turn to contain `finalResponse`. If the template binds that field but the expected turn has only placeholder `userContent` and no `finalResponse`, evaluation fails directly.
+`actual.userContent`, `actual.finalResponse`, and `expected.finalResponse` render the current scoring turn's user input, actual final response, and expected final response respectively. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID` to specify the trace step `NodeID`; the resolver selects the last matching step from the current invocation's `executionTrace.steps` and reads `Input.Text` or `Output.Text`. When using a trace source, the evaluation call must pass `agent.WithExecutionTraceEnabled(true)`. If the current actual invocation has no `ExecutionTrace`, evaluation fails. `expected.finalResponse` requires the current expected turn to contain `finalResponse`. If the template binds that field but the expected turn has only placeholder `userContent` and no `finalResponse`, evaluation fails directly.
 
 `template.responseScorerName` specifies how judge output is parsed. The current supported values are:
 
@@ -2435,13 +2445,15 @@ The template evaluator runs as follows:
 3. `responsescorer/singlescore` or `responsescorer/rubricscores` parses the judge output.
 4. Sample aggregation defaults to `majority_vote`, and multi-turn aggregation defaults to `average`. You can override them through `template.sampleAggregatorName` and `template.invocationAggregatorName`.
 
-Variable bindings currently support only:
+Variable bindings support the following sources:
 
 - `actual.userContent`
 - `actual.finalResponse`
+- `actual.traceStepInput`
+- `actual.traceStepOutput`
 - `expected.finalResponse`
 
-Every placeholder in the template must be explicitly bound in `variableBindings`. Binding `expected.finalResponse` requires the current expected turn to contain `finalResponse`; if the template uses that field but the expected turn does not contain a final response, evaluation fails directly.
+Every placeholder in the template must be explicitly bound in `variableBindings`. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID`; the resolver selects the last step whose `NodeID` matches in the current invocation execution trace. When using a trace source, the evaluation caller must enable `agent.WithExecutionTraceEnabled(true)`. Binding `expected.finalResponse` requires the current expected turn to contain `finalResponse`; if the template uses that field but the expected turn does not contain a final response, evaluation fails directly.
 
 The template evaluator currently supports two response parsing modes:
 
@@ -2504,6 +2516,83 @@ Example template metric configuration:
 ```
 
 See [examples/evaluation/llm/template](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/llm/template) for the full example. It includes both `single_score` and `rubric_scores` template metrics.
+
+If the judge prompt needs to reference the output of a trace step from agent execution, bind variables as shown below. This kind of metric depends on execution trace, so the evaluation call must pass `agent.WithExecutionTraceEnabled(true)`.
+
+```json
+[
+  {
+    "metricName": "weather_trace_grounded_template",
+    "evaluatorName": "llm_judge_template",
+    "threshold": 1.0,
+    "criterion": {
+      "llmJudge": {
+        "judgeModel": {
+          "providerName": "openai",
+          "modelName": "gpt-5.2",
+          "baseURL": "${OPENAI_BASE_URL}",
+          "apiKey": "${OPENAI_API_KEY}",
+          "numSamples": 1,
+          "generationConfig": {
+            "max_tokens": 256,
+            "temperature": 0,
+            "stream": false
+          }
+        },
+        "template": {
+          "prompt": "You are the judge. Decide whether the candidate answer is grounded in the selected ToolNode trace step and matches the reference answer.\\n\\nUser question:\\n{{question}}\\n\\nWeather ToolNode input snapshot:\\n{{tool_input}}\\n\\nWeather ToolNode output snapshot:\\n{{tool_output}}\\n\\nReference answer:\\n{{reference}}\\n\\nCandidate answer:\\n{{answer}}\\n\\nReturn JSON:\\n- score: return 1 if the candidate answer is supported by the weather ToolNode input and output snapshots, and is factually equivalent to the reference answer.\\n- score: otherwise return 0.\\n- reason: one concise sentence.\\n\\nTreat minor wording and punctuation differences as equivalent.",
+          "responseScorerName": "single_score",
+          "variableBindings": [
+            {
+              "templateVariable": "question",
+              "source": {
+                "scope": "actual",
+                "field": "userContent"
+              }
+            },
+            {
+              "templateVariable": "answer",
+              "source": {
+                "scope": "actual",
+                "field": "finalResponse"
+              }
+            },
+            {
+              "templateVariable": "reference",
+              "source": {
+                "scope": "expected",
+                "field": "finalResponse"
+              }
+            },
+            {
+              "templateVariable": "tool_input",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepInput",
+                "selector": {
+                  "nodeID": "template-trace-agent/weather_lookup"
+                }
+              }
+            },
+            {
+              "templateVariable": "tool_output",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepOutput",
+                "selector": {
+                  "nodeID": "template-trace-agent/weather_lookup"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+]
+```
+
+See [examples/evaluation/llm/templatetrace](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/llm/templatetrace) for the full trace template example. It shows how to enable execution trace and bind template variables to the input or output of a selected trace step through `source.selector.nodeID`.
 
 ##### LLM Rubric Critic Evaluator
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1570,8 +1570,14 @@ type TemplateVariableBinding struct {
 
 // TemplateVariableSource 表示模板变量来源
 type TemplateVariableSource struct {
-	Scope TemplateVariableScope // Scope 是来源作用域
-	Field TemplateVariableField // Field 是来源字段
+	Scope    TemplateVariableScope     // Scope 是来源作用域
+	Field    TemplateVariableField     // Field 是来源字段
+	Selector *TemplateVariableSelector // Selector 是 trace step 选择器，可选
+}
+
+// TemplateVariableSelector 表示模板变量选择器
+type TemplateVariableSelector struct {
+	NodeID string // NodeID 是要读取的 trace step 节点 ID
 }
 
 // TemplateVariableScope 表示模板变量来源作用域
@@ -1586,8 +1592,10 @@ const (
 type TemplateVariableField string
 
 const (
-	TemplateVariableFieldUserContent   TemplateVariableField = "userContent"
-	TemplateVariableFieldFinalResponse TemplateVariableField = "finalResponse"
+	TemplateVariableFieldUserContent     TemplateVariableField = "userContent"
+	TemplateVariableFieldFinalResponse   TemplateVariableField = "finalResponse"
+	TemplateVariableFieldTraceStepInput  TemplateVariableField = "traceStepInput"
+	TemplateVariableFieldTraceStepOutput TemplateVariableField = "traceStepOutput"
 )
 
 // Rubric 表示一条评估细则
@@ -1667,13 +1675,15 @@ type RubricContent struct {
 
 `template.prompt` 使用双大括号模板语法，例如 `{{question}}`、`{{answer}}`。每个占位符都必须在 `variableBindings` 中显式绑定；未绑定变量、未知变量或绑定解析失败都会直接报错，不存在“可选变量”或空字符串兜底。
 
-`template.variableBindings` 当前只支持从当前评分轮的 `actual` 与 `expected` 中取值：
+`template.variableBindings` 支持从当前评分轮的 `actual` 和 `expected` 中取值：
 
 - `actual.userContent`
 - `actual.finalResponse`
+- `actual.traceStepInput`
+- `actual.traceStepOutput`
 - `expected.finalResponse`
 
-其中 `expected.finalResponse` 要求当前预期轮必须存在 `finalResponse`；如果模板绑定了该字段，但预期轮只有占位 `userContent`、没有 `finalResponse`，评估会直接报错。
+其中 `actual.userContent`、`actual.finalResponse`、`expected.finalResponse` 分别渲染当前评分轮的用户输入、实际最终回答和预期最终回答；`actual.traceStepInput` 与 `actual.traceStepOutput` 需要在 `source.selector.nodeID` 中指定 trace step 的 `NodeID`，解析器会在当前 invocation 的 `executionTrace.steps` 中选择最后一个匹配 step，并分别读取 `Input.Text` 或 `Output.Text`。使用 trace source 时，发起评估需要传入 `agent.WithExecutionTraceEnabled(true)`；如果当前 actual invocation 没有 `ExecutionTrace`，评估会报错。`expected.finalResponse` 要求当前预期轮必须存在 `finalResponse`；如果模板绑定了该字段，但预期轮只有占位 `userContent`、没有 `finalResponse`，评估会直接报错。
 
 `template.responseScorerName` 用于指定如何解析裁判输出，当前支持：
 
@@ -2432,13 +2442,15 @@ LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM
 3. `responsescorer/singlescore` 或 `responsescorer/rubricscores` 解析裁判输出。
 4. 样本聚合默认使用 `majority_vote`，多轮聚合默认使用 `average`，也可以分别通过 `template.sampleAggregatorName` 和 `template.invocationAggregatorName` 显式指定。
 
-变量绑定当前只支持以下来源：
+变量绑定支持以下来源：
 
 - `actual.userContent`
 - `actual.finalResponse`
+- `actual.traceStepInput`
+- `actual.traceStepOutput`
 - `expected.finalResponse`
 
-模板中的每个占位符都必须在 `variableBindings` 中显式绑定。`expected.finalResponse` 绑定要求当前预期轮存在 `finalResponse`；如果模板使用了该字段但预期轮没有最终回答，评估会直接报错。
+模板中的每个占位符都必须在 `variableBindings` 中显式绑定。`actual.traceStepInput` 与 `actual.traceStepOutput` 需要配置 `source.selector.nodeID`，解析器会选择当前 invocation execution trace 中最后一个 `NodeID` 匹配的 step。使用 trace source 时，评估调用方需要开启 `agent.WithExecutionTraceEnabled(true)`；`expected.finalResponse` 绑定要求当前预期轮存在 `finalResponse`，如果模板使用了该字段但预期轮没有最终回答，评估会直接报错。
 
 模板评估器当前支持两种响应解析模式：
 
@@ -2501,6 +2513,83 @@ LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM
 ```
 
 完整示例参见 [examples/evaluation/llm/template](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/llm/template)。该示例同时演示了 `single_score` 与 `rubric_scores` 两种模板评估指标。
+
+如果裁判 prompt 需要引用 agent 执行过程中的某个 trace step 输出，可以按下面方式绑定变量。该类 metric 依赖 execution trace，评估时需要传入 `agent.WithExecutionTraceEnabled(true)`。
+
+```json
+[
+  {
+    "metricName": "weather_trace_grounded_template",
+    "evaluatorName": "llm_judge_template",
+    "threshold": 1.0,
+    "criterion": {
+      "llmJudge": {
+        "judgeModel": {
+          "providerName": "openai",
+          "modelName": "gpt-5.2",
+          "baseURL": "${OPENAI_BASE_URL}",
+          "apiKey": "${OPENAI_API_KEY}",
+          "numSamples": 1,
+          "generationConfig": {
+            "max_tokens": 256,
+            "temperature": 0,
+            "stream": false
+          }
+        },
+        "template": {
+          "prompt": "你是裁判，需要判断候选回答是否基于指定的 ToolNode trace step，并且是否与参考答案一致。\\n\\n用户问题：\\n{{question}}\\n\\n天气 ToolNode 输入快照：\\n{{tool_input}}\\n\\n天气 ToolNode 输出快照：\\n{{tool_output}}\\n\\n参考答案：\\n{{reference}}\\n\\n候选回答：\\n{{answer}}\\n\\n请返回 JSON：\\n- score: 如果候选回答由天气 ToolNode 的输入和输出快照支持，并且与参考答案事实等价，则返回 1。\\n- score: 否则返回 0。\\n- reason: 用一句简洁的话说明原因。\\n\\n轻微措辞和标点差异可以视为等价。",
+          "responseScorerName": "single_score",
+          "variableBindings": [
+            {
+              "templateVariable": "question",
+              "source": {
+                "scope": "actual",
+                "field": "userContent"
+              }
+            },
+            {
+              "templateVariable": "answer",
+              "source": {
+                "scope": "actual",
+                "field": "finalResponse"
+              }
+            },
+            {
+              "templateVariable": "reference",
+              "source": {
+                "scope": "expected",
+                "field": "finalResponse"
+              }
+            },
+            {
+              "templateVariable": "tool_input",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepInput",
+                "selector": {
+                  "nodeID": "template-trace-agent/weather_lookup"
+                }
+              }
+            },
+            {
+              "templateVariable": "tool_output",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepOutput",
+                "selector": {
+                  "nodeID": "template-trace-agent/weather_lookup"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+]
+```
+
+完整 trace 模板示例参见 [examples/evaluation/llm/templatetrace](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/llm/templatetrace)。该示例演示了如何开启 execution trace，并通过 `source.selector.nodeID` 将模板变量绑定到指定 trace step 的输入或输出。
 
 ##### LLM 细则批判评估器
 

--- a/evaluation/evalresult/local/local_test.go
+++ b/evaluation/evalresult/local/local_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/epochtime"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -124,6 +125,45 @@ func TestLocalManagerSaveUsesProvidedID(t *testing.T) {
 	loaded, err := mgr.Get(ctx, "app", "custom-id")
 	require.NoError(t, err)
 	assert.Equal(t, "provided-name", loaded.EvalSetResultName)
+}
+
+func TestLocalManagerSavePersistsActualInvocationExecutionTrace(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	mgr := New(evalresult.WithBaseDir(dir)).(*manager)
+	result := &evalresult.EvalSetResult{
+		EvalSetID:       "set",
+		EvalSetResultID: "trace-result",
+		EvalCaseResults: []*evalresult.EvalCaseResult{{
+			EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+				ActualInvocation: &evalset.Invocation{
+					InvocationID: "inv-1",
+					ExecutionTrace: &agenttrace.Trace{
+						RootInvocationID: "root-1",
+						Steps: []agenttrace.Step{{
+							NodeID: "fetch_match",
+							Output: &agenttrace.Snapshot{
+								Text: "match data",
+							},
+						}},
+					},
+				},
+			}},
+		}},
+	}
+	id, err := mgr.Save(ctx, "app", result)
+	require.NoError(t, err)
+	loaded, err := mgr.Get(ctx, "app", id)
+	require.NoError(t, err)
+	perInvocation := loaded.EvalCaseResults[0].EvalMetricResultPerInvocation[0]
+	require.NotNil(t, perInvocation.ActualInvocation.ExecutionTrace)
+	assert.Equal(t, "root-1", perInvocation.ActualInvocation.ExecutionTrace.RootInvocationID)
+	if assert.Len(t, perInvocation.ActualInvocation.ExecutionTrace.Steps, 1) {
+		assert.Equal(t, "match data", perInvocation.ActualInvocation.ExecutionTrace.Steps[0].Output.Text)
+	}
+	payload, err := os.ReadFile(mgr.evalSetResultPath("app", id))
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), "executionTrace")
 }
 
 func TestLocalManagerGetInvalidContent(t *testing.T) {

--- a/evaluation/evalset/evalcase.go
+++ b/evaluation/evalset/evalcase.go
@@ -10,6 +10,7 @@
 package evalset
 
 import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/epochtime"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/toolmock"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -111,6 +112,8 @@ type Invocation struct {
 	IntermediateResponses []*model.Message `json:"intermediateResponses,omitempty"`
 	// CreationTimestamp when this invocation was created.
 	CreationTimestamp *epochtime.EpochTime `json:"creationTimestamp,omitempty"`
+	// ExecutionTrace contains the execution trace aligned with this invocation.
+	ExecutionTrace *trace.Trace `json:"executionTrace,omitempty"`
 }
 
 // Tool represents a single tool invocation and its execution result.

--- a/evaluation/evalset/evalset_test.go
+++ b/evaluation/evalset/evalset_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -165,6 +166,38 @@ func TestEvalSetJSONRoundTrip(t *testing.T) {
 	encoded, err = json.Marshal(evalSet)
 	assert.NoError(t, err)
 	assert.JSONEq(t, jsonData, string(encoded))
+}
+
+func TestInvocationExecutionTraceJSON(t *testing.T) {
+	encoded, err := json.Marshal(&Invocation{})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(encoded), "executionTrace")
+	invocation := &Invocation{
+		InvocationID: "inv-1",
+		ExecutionTrace: &agenttrace.Trace{
+			RootInvocationID: "root-1",
+			SessionID:        "session-1",
+			Status:           agenttrace.TraceStatusCompleted,
+			Steps: []agenttrace.Step{{
+				NodeID: "fetch_match",
+				Input:  &agenttrace.Snapshot{Text: "input text"},
+				Output: &agenttrace.Snapshot{Text: "output text"},
+			}},
+		},
+	}
+	encoded, err = json.Marshal(invocation)
+	assert.NoError(t, err)
+	assert.Contains(t, string(encoded), "executionTrace")
+	var decoded Invocation
+	assert.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, "root-1", decoded.ExecutionTrace.RootInvocationID)
+	assert.Equal(t, "session-1", decoded.ExecutionTrace.SessionID)
+	assert.Equal(t, agenttrace.TraceStatusCompleted, decoded.ExecutionTrace.Status)
+	if assert.Len(t, decoded.ExecutionTrace.Steps, 1) {
+		assert.Equal(t, "fetch_match", decoded.ExecutionTrace.Steps[0].NodeID)
+		assert.Equal(t, "input text", decoded.ExecutionTrace.Steps[0].Input.Text)
+		assert.Equal(t, "output text", decoded.ExecutionTrace.Steps[0].Output.Text)
+	}
 }
 
 func TestEvalSetJSONRoundTripWithActualConversation(t *testing.T) {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
@@ -116,15 +116,15 @@ func resolveBindingValue(actuals, expecteds []*evalset.Invocation,
 	}
 	switch source.Scope {
 	case metricllm.TemplateVariableScopeActual:
-		return resolveActualValue(actuals, source.Field)
+		return resolveActualValue(actuals, source)
 	case metricllm.TemplateVariableScopeExpected:
-		return resolveExpectedValue(expecteds, source.Field)
+		return resolveExpectedValue(expecteds, source)
 	default:
 		return "", fmt.Errorf("unsupported source %s.%s", source.Scope, source.Field)
 	}
 }
 
-func resolveActualValue(actuals []*evalset.Invocation, field metricllm.TemplateVariableField) (string, error) {
+func resolveActualValue(actuals []*evalset.Invocation, source *metricllm.TemplateVariableSource) (string, error) {
 	if len(actuals) == 0 {
 		return "", fmt.Errorf("actuals is empty")
 	}
@@ -132,18 +132,22 @@ func resolveActualValue(actuals []*evalset.Invocation, field metricllm.TemplateV
 	if actual == nil {
 		return "", fmt.Errorf("actual invocation is nil")
 	}
-	switch field {
+	switch source.Field {
 	case metricllm.TemplateVariableFieldUserContent:
 		return content.ExtractTextFromContent(actual.UserContent), nil
 	case metricllm.TemplateVariableFieldFinalResponse:
 		return content.ExtractTextFromContent(actual.FinalResponse), nil
+	case metricllm.TemplateVariableFieldTraceStepInput:
+		return resolveTraceStepSnapshot(actuals, source, true)
+	case metricllm.TemplateVariableFieldTraceStepOutput:
+		return resolveTraceStepSnapshot(actuals, source, false)
 	default:
 		return "", fmt.Errorf("unsupported source %s.%s",
-			metricllm.TemplateVariableScopeActual, field)
+			metricllm.TemplateVariableScopeActual, source.Field)
 	}
 }
 
-func resolveExpectedValue(expecteds []*evalset.Invocation, field metricllm.TemplateVariableField) (string, error) {
+func resolveExpectedValue(expecteds []*evalset.Invocation, source *metricllm.TemplateVariableSource) (string, error) {
 	if len(expecteds) == 0 {
 		return "", fmt.Errorf("expecteds is empty")
 	}
@@ -151,7 +155,7 @@ func resolveExpectedValue(expecteds []*evalset.Invocation, field metricllm.Templ
 	if expected == nil {
 		return "", fmt.Errorf("expected invocation is nil")
 	}
-	switch field {
+	switch source.Field {
 	case metricllm.TemplateVariableFieldFinalResponse:
 		if expected.FinalResponse == nil {
 			return "", fmt.Errorf("expected finalResponse is empty")
@@ -159,6 +163,42 @@ func resolveExpectedValue(expecteds []*evalset.Invocation, field metricllm.Templ
 		return content.ExtractTextFromContent(expected.FinalResponse), nil
 	default:
 		return "", fmt.Errorf("unsupported source %s.%s",
-			metricllm.TemplateVariableScopeExpected, field)
+			metricllm.TemplateVariableScopeExpected, source.Field)
 	}
+}
+
+func resolveTraceStepSnapshot(actuals []*evalset.Invocation, source *metricllm.TemplateVariableSource, input bool) (string, error) {
+	nodeID := ""
+	if source.Selector != nil {
+		nodeID = strings.TrimSpace(source.Selector.NodeID)
+	}
+	if nodeID == "" {
+		return "", fmt.Errorf("trace selector nodeID is required")
+	}
+	index := len(actuals) - 1
+	actual := actuals[index]
+	if actual.ExecutionTrace == nil {
+		return "", fmt.Errorf("executionTrace is empty for %s.%s at invocation index %d",
+			source.Scope, source.Field, index)
+	}
+	stepIndex := -1
+	for i := range actual.ExecutionTrace.Steps {
+		if actual.ExecutionTrace.Steps[i].NodeID == nodeID {
+			stepIndex = i
+		}
+	}
+	if stepIndex < 0 {
+		return "", fmt.Errorf("trace step not found for %s.%s nodeID %q at invocation index %d",
+			source.Scope, source.Field, nodeID, index)
+	}
+	step := actual.ExecutionTrace.Steps[stepIndex]
+	snapshot := step.Output
+	if input {
+		snapshot = step.Input
+	}
+	if snapshot == nil || strings.TrimSpace(snapshot.Text) == "" {
+		return "", fmt.Errorf("trace snapshot is empty for %s.%s nodeID %q at invocation index %d",
+			source.Scope, source.Field, nodeID, index)
+	}
+	return snapshot.Text, nil
 }

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/internal/templateresolver"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
@@ -69,6 +70,73 @@ func TestConstructMessagesRendersBoundVariables(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "What is the capital of France?")
 	assert.Contains(t, messages[0].Content, "Answer: Paris")
 	assert.Contains(t, messages[0].Content, "Reference: Paris")
+}
+
+func TestConstructMessagesRendersTraceStepOutputFromLastMatchingNode(t *testing.T) {
+	constructor := New()
+	actual := &evalset.Invocation{
+		ExecutionTrace: &agenttrace.Trace{
+			Steps: []agenttrace.Step{
+				{NodeID: "fetch_match", Output: &agenttrace.Snapshot{Text: "stale data"}},
+				{NodeID: "other", Output: &agenttrace.Snapshot{Text: "ignore me"}},
+				{NodeID: "fetch_match", Output: &agenttrace.Snapshot{Text: "fresh match data"}},
+			},
+		},
+	}
+	messages, err := constructor.ConstructMessages(
+		context.Background(),
+		[]*evalset.Invocation{actual},
+		[]*evalset.Invocation{{FinalResponse: &model.Message{Content: "reference"}}},
+		buildTemplateEvalMetric(
+			"Match data: {{match_data}}",
+			&criterionllm.TemplateVariableBinding{
+				TemplateVariable: "match_data",
+				Source: &criterionllm.TemplateVariableSource{
+					Scope: criterionllm.TemplateVariableScopeActual,
+					Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+					Selector: &criterionllm.TemplateVariableSelector{
+						NodeID: "fetch_match",
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, "fresh match data")
+	assert.NotContains(t, messages[0].Content, "stale data")
+}
+
+func TestConstructMessagesRendersTraceStepInput(t *testing.T) {
+	constructor := New()
+	actual := &evalset.Invocation{
+		ExecutionTrace: &agenttrace.Trace{
+			Steps: []agenttrace.Step{
+				{NodeID: "fetch_match", Input: &agenttrace.Snapshot{Text: "match query"}},
+			},
+		},
+	}
+	messages, err := constructor.ConstructMessages(
+		context.Background(),
+		[]*evalset.Invocation{actual},
+		[]*evalset.Invocation{{FinalResponse: &model.Message{Content: "reference"}}},
+		buildTemplateEvalMetric(
+			"Tool input: {{tool_input}}",
+			&criterionllm.TemplateVariableBinding{
+				TemplateVariable: "tool_input",
+				Source: &criterionllm.TemplateVariableSource{
+					Scope: criterionllm.TemplateVariableScopeActual,
+					Field: criterionllm.TemplateVariableFieldTraceStepInput,
+					Selector: &criterionllm.TemplateVariableSelector{
+						NodeID: "fetch_match",
+					},
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, "Tool input: match query")
 }
 
 func TestConstructMessagesRejectsDuplicateBindings(t *testing.T) {
@@ -269,34 +337,119 @@ func TestResolveBindingValueRejectsNilAndUnsupportedSource(t *testing.T) {
 }
 
 func TestResolveActualValueRejectsInvalidActualInput(t *testing.T) {
-	value, err := resolveActualValue(nil, criterionllm.TemplateVariableFieldFinalResponse)
+	value, err := resolveActualValue(nil, &criterionllm.TemplateVariableSource{
+		Field: criterionllm.TemplateVariableFieldFinalResponse,
+	})
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "actuals is empty")
-	value, err = resolveActualValue([]*evalset.Invocation{nil}, criterionllm.TemplateVariableFieldFinalResponse)
+	value, err = resolveActualValue([]*evalset.Invocation{nil}, &criterionllm.TemplateVariableSource{
+		Field: criterionllm.TemplateVariableFieldFinalResponse,
+	})
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "actual invocation is nil")
-	value, err = resolveActualValue([]*evalset.Invocation{{}}, criterionllm.TemplateVariableField("rubrics"))
-	require.Error(t, err)
-	assert.Empty(t, value)
-	assert.Contains(t, err.Error(), "unsupported source actual.rubrics")
 }
 
 func TestResolveExpectedValueRejectsInvalidExpectedInput(t *testing.T) {
-	value, err := resolveExpectedValue(nil, criterionllm.TemplateVariableFieldFinalResponse)
+	value, err := resolveExpectedValue(nil, &criterionllm.TemplateVariableSource{
+		Field: criterionllm.TemplateVariableFieldFinalResponse,
+	})
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "expecteds is empty")
-	value, err = resolveExpectedValue([]*evalset.Invocation{nil}, criterionllm.TemplateVariableFieldFinalResponse)
+	value, err = resolveExpectedValue([]*evalset.Invocation{nil}, &criterionllm.TemplateVariableSource{
+		Field: criterionllm.TemplateVariableFieldFinalResponse,
+	})
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "expected invocation is nil")
 	value, err = resolveExpectedValue([]*evalset.Invocation{{FinalResponse: &model.Message{Content: "ok"}}},
-		criterionllm.TemplateVariableFieldUserContent)
+		&criterionllm.TemplateVariableSource{Field: criterionllm.TemplateVariableFieldUserContent})
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "unsupported source expected.userContent")
+}
+
+func TestResolveTraceStepErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		actuals []*evalset.Invocation
+		source  *criterionllm.TemplateVariableSource
+		wantErr string
+	}{
+		{
+			name: "missing trace",
+			actuals: []*evalset.Invocation{{
+				InvocationID: "inv-1",
+			}},
+			source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeActual,
+				Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+				Selector: &criterionllm.TemplateVariableSelector{
+					NodeID: "fetch",
+				},
+			},
+			wantErr: "executionTrace is empty for actual.traceStepOutput at invocation index 0",
+		},
+		{
+			name:    "missing selector",
+			actuals: []*evalset.Invocation{{ExecutionTrace: &agenttrace.Trace{}}},
+			source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeActual,
+				Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+			},
+			wantErr: "trace selector nodeID is required",
+		},
+		{
+			name:    "empty node id",
+			actuals: []*evalset.Invocation{{ExecutionTrace: &agenttrace.Trace{}}},
+			source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeActual,
+				Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+				Selector: &criterionllm.TemplateVariableSelector{
+					NodeID: " ",
+				},
+			},
+			wantErr: "trace selector nodeID is required",
+		},
+		{
+			name: "no matching step",
+			actuals: []*evalset.Invocation{{
+				ExecutionTrace: &agenttrace.Trace{Steps: []agenttrace.Step{{NodeID: "other"}}},
+			}},
+			source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeActual,
+				Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+				Selector: &criterionllm.TemplateVariableSelector{
+					NodeID: "fetch",
+				},
+			},
+			wantErr: `trace step not found for actual.traceStepOutput nodeID "fetch" at invocation index 0`,
+		},
+		{
+			name: "empty snapshot",
+			actuals: []*evalset.Invocation{{
+				ExecutionTrace: &agenttrace.Trace{Steps: []agenttrace.Step{{NodeID: "fetch"}}},
+			}},
+			source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeActual,
+				Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+				Selector: &criterionllm.TemplateVariableSelector{
+					NodeID: "fetch",
+				},
+			},
+			wantErr: `trace snapshot is empty for actual.traceStepOutput nodeID "fetch" at invocation index 0`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value, err := resolveActualValue(tc.actuals, tc.source)
+			require.Error(t, err)
+			assert.Empty(t, value)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }
 
 func buildTemplateEvalMetric(promptText string,

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/epochtime"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -93,6 +94,9 @@ func TestCloneEvalMetric_DeepCopiesJudgeTemplate(t *testing.T) {
 							Source: &criterionllm.TemplateVariableSource{
 								Scope: criterionllm.TemplateVariableScopeActual,
 								Field: criterionllm.TemplateVariableFieldUserContent,
+								Selector: &criterionllm.TemplateVariableSelector{
+									NodeID: "ignored",
+								},
 							},
 						},
 					},
@@ -113,6 +117,8 @@ func TestCloneEvalMetric_DeepCopiesJudgeTemplate(t *testing.T) {
 	assert.Equal(t, "question", src.Criterion.LLMJudge.Template.VariableBindings[0].TemplateVariable)
 	dst.Criterion.LLMJudge.Template.VariableBindings[0].Source.Scope = criterionllm.TemplateVariableScopeExpected
 	assert.Equal(t, criterionllm.TemplateVariableScopeActual, src.Criterion.LLMJudge.Template.VariableBindings[0].Source.Scope)
+	dst.Criterion.LLMJudge.Template.VariableBindings[0].Source.Selector.NodeID = "changed"
+	assert.Equal(t, "ignored", src.Criterion.LLMJudge.Template.VariableBindings[0].Source.Selector.NodeID)
 }
 
 func TestCloneTemplateVariableHelpersHandleNil(t *testing.T) {
@@ -257,6 +263,34 @@ func TestCloneEvalCase_DeepCopy(t *testing.T) {
 					},
 				},
 				CreationTimestamp: &epochtime.EpochTime{Time: time.Unix(1, 0).UTC()},
+				ExecutionTrace: &agenttrace.Trace{
+					RootAgentName:    "agent",
+					RootInvocationID: "root-inv",
+					SessionID:        "session",
+					Status:           agenttrace.TraceStatusCompleted,
+					Usage: &model.Usage{
+						TotalTokens: 10,
+						TimingInfo: &model.TimingInfo{
+							FirstTokenDuration: time.Second,
+						},
+					},
+					Steps: []agenttrace.Step{
+						{
+							StepID:             "step-1",
+							NodeID:             "fetch",
+							PredecessorStepIDs: []string{"entry"},
+							AppliedSurfaceIDs:  []string{"agent#instruction"},
+							Input:              &agenttrace.Snapshot{Text: "input"},
+							Output:             &agenttrace.Snapshot{Text: "output"},
+							Usage: &model.Usage{
+								TotalTokens: 5,
+								TimingInfo: &model.TimingInfo{
+									ReasoningDuration: time.Second,
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		ActualConversation: []*evalset.Invocation{
@@ -336,6 +370,18 @@ func TestCloneEvalCase_DeepCopy(t *testing.T) {
 
 	dst.Conversation[0].IntermediateResponses[0].ContentParts[0].Audio.Data[0] = 0
 	assert.Equal(t, byte(9), src.Conversation[0].IntermediateResponses[0].ContentParts[0].Audio.Data[0])
+
+	dst.Conversation[0].ExecutionTrace.Steps[0].PredecessorStepIDs[0] = "changed"
+	assert.Equal(t, "entry", src.Conversation[0].ExecutionTrace.Steps[0].PredecessorStepIDs[0])
+
+	dst.Conversation[0].ExecutionTrace.Steps[0].Input.Text = "changed"
+	assert.Equal(t, "input", src.Conversation[0].ExecutionTrace.Steps[0].Input.Text)
+
+	dst.Conversation[0].ExecutionTrace.Steps[0].Usage.TimingInfo.ReasoningDuration = 2 * time.Second
+	assert.Equal(t, time.Second, src.Conversation[0].ExecutionTrace.Steps[0].Usage.TimingInfo.ReasoningDuration)
+
+	dst.Conversation[0].ExecutionTrace.Usage.TimingInfo.FirstTokenDuration = 2 * time.Second
+	assert.Equal(t, time.Second, src.Conversation[0].ExecutionTrace.Usage.TimingInfo.FirstTokenDuration)
 
 	dst.SessionInput.State["bytes"].([]byte)[0] = 0
 	assert.Equal(t, byte(9), src.SessionInput.State["bytes"].([]byte)[0])

--- a/evaluation/internal/clone/evalset.go
+++ b/evaluation/internal/clone/evalset.go
@@ -10,8 +10,10 @@
 package clone
 
 import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/toolmock"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // CloneEvalSet clones an eval set and all nested eval cases.
@@ -139,7 +141,46 @@ func cloneInvocation(src *evalset.Invocation) (*evalset.Invocation, error) {
 		return nil, err
 	}
 	copied.ToolMock = toolMock
+	copied.ExecutionTrace = cloneExecutionTrace(src.ExecutionTrace)
 	return &copied, nil
+}
+
+func cloneExecutionTrace(src *trace.Trace) *trace.Trace {
+	if src == nil {
+		return nil
+	}
+	cloneUsage := func(src *model.Usage) *model.Usage {
+		if src == nil {
+			return nil
+		}
+		copied := *src
+		if src.TimingInfo != nil {
+			timingInfo := *src.TimingInfo
+			copied.TimingInfo = &timingInfo
+		}
+		return &copied
+	}
+	copied := *src
+	copied.Usage = cloneUsage(src.Usage)
+	if src.Steps != nil {
+		copied.Steps = make([]trace.Step, len(src.Steps))
+		for i := range src.Steps {
+			step := src.Steps[i]
+			step.PredecessorStepIDs = cloneStringSlice(src.Steps[i].PredecessorStepIDs)
+			step.AppliedSurfaceIDs = cloneStringSlice(src.Steps[i].AppliedSurfaceIDs)
+			if src.Steps[i].Input != nil {
+				input := *src.Steps[i].Input
+				step.Input = &input
+			}
+			if src.Steps[i].Output != nil {
+				output := *src.Steps[i].Output
+				step.Output = &output
+			}
+			step.Usage = cloneUsage(src.Steps[i].Usage)
+			copied.Steps[i] = step
+		}
+	}
+	return &copied
 }
 
 func cloneToolMock(src *toolmock.ToolMock) (*toolmock.ToolMock, error) {

--- a/evaluation/internal/clone/metric.go
+++ b/evaluation/internal/clone/metric.go
@@ -219,6 +219,10 @@ func cloneTemplateVariableBinding(src *criterionllm.TemplateVariableBinding) *cr
 	copied := *src
 	if src.Source != nil {
 		source := *src.Source
+		if src.Source.Selector != nil {
+			selector := *src.Source.Selector
+			source.Selector = &selector
+		}
 		copied.Source = &source
 	}
 	return &copied

--- a/evaluation/metric/criterion/llm/llm.go
+++ b/evaluation/metric/criterion/llm/llm.go
@@ -84,8 +84,14 @@ type TemplateVariableBinding struct {
 
 // TemplateVariableSource identifies which evaluation artifact feeds a template variable.
 type TemplateVariableSource struct {
-	Scope TemplateVariableScope `json:"scope,omitempty"`
-	Field TemplateVariableField `json:"field,omitempty"`
+	Scope    TemplateVariableScope     `json:"scope,omitempty"`
+	Field    TemplateVariableField     `json:"field,omitempty"`
+	Selector *TemplateVariableSelector `json:"selector,omitempty"`
+}
+
+// TemplateVariableSelector selects one execution trace step.
+type TemplateVariableSelector struct {
+	NodeID string `json:"nodeID,omitempty"`
 }
 
 // TemplateVariableScope identifies the source object visible to template rendering.
@@ -106,6 +112,10 @@ const (
 	TemplateVariableFieldUserContent TemplateVariableField = "userContent"
 	// TemplateVariableFieldFinalResponse extracts the current final response text.
 	TemplateVariableFieldFinalResponse TemplateVariableField = "finalResponse"
+	// TemplateVariableFieldTraceStepInput extracts the selected trace step input text.
+	TemplateVariableFieldTraceStepInput TemplateVariableField = "traceStepInput"
+	// TemplateVariableFieldTraceStepOutput extracts the selected trace step output text.
+	TemplateVariableFieldTraceStepOutput TemplateVariableField = "traceStepOutput"
 )
 
 // MarshalJSON omits APIKey from JSON output while still allowing JSON input to populate it.

--- a/evaluation/metric/criterion/llm/llm_test.go
+++ b/evaluation/metric/criterion/llm/llm_test.go
@@ -102,3 +102,39 @@ func TestLLMCriterionSampleParallelismJSON(t *testing.T) {
 	assert.True(t, decoded.SampleParallelismEnabled)
 	assert.Equal(t, 3, decoded.SampleParallelism)
 }
+
+func TestTemplateVariableSourceJSONSupportsExpandedFields(t *testing.T) {
+	const payload = `{
+  "scope": "actual",
+  "field": "traceStepOutput",
+  "selector": {
+    "nodeID": "fetch_match"
+  }
+}`
+	var source TemplateVariableSource
+	err := json.Unmarshal([]byte(payload), &source)
+	require.NoError(t, err)
+	assert.Equal(t, TemplateVariableScopeActual, source.Scope)
+	assert.Equal(t, TemplateVariableFieldTraceStepOutput, source.Field)
+	require.NotNil(t, source.Selector)
+	assert.Equal(t, "fetch_match", source.Selector.NodeID)
+	data, err := json.Marshal(source)
+	require.NoError(t, err)
+	assert.JSONEq(t, payload, string(data))
+}
+
+func TestTemplateVariableSourceConstantsCoverTemplateEvaluatorSources(t *testing.T) {
+	assert.Equal(t, TemplateVariableField("traceStepInput"), TemplateVariableFieldTraceStepInput)
+	assert.Equal(t, TemplateVariableField("traceStepOutput"), TemplateVariableFieldTraceStepOutput)
+}
+
+func TestTemplateVariableSourceOldJSONShapeRemainsStable(t *testing.T) {
+	source := TemplateVariableSource{
+		Scope: TemplateVariableScopeActual,
+		Field: TemplateVariableFieldUserContent,
+	}
+	data, err := json.Marshal(source)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"scope":"actual","field":"userContent"}`, string(data))
+	assert.NotContains(t, string(data), "selector")
+}

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -660,6 +660,18 @@ func (s *local) prepareCaseEvaluationInputs(
 		return nil, fmt.Errorf("inference count %d does not match expected conversation length %d",
 			len(actuals), len(expecteds))
 	}
+	if len(inferenceResult.ExecutionTraces) > 0 {
+		if len(actuals) != len(inferenceResult.ExecutionTraces) {
+			return nil, fmt.Errorf("execution trace count %d does not match inference count %d",
+				len(inferenceResult.ExecutionTraces), len(actuals))
+		}
+		for i, actual := range actuals {
+			if actual == nil {
+				continue
+			}
+			actual.ExecutionTrace = inferenceResult.ExecutionTraces[i]
+		}
+	}
 	attachContextMessages(actuals, evalCase.ContextMessages)
 	attachContextMessages(expecteds, evalCase.ContextMessages)
 	return &caseEvaluationInputs{

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	evalresultinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -3893,6 +3894,43 @@ func TestPrepareCaseEvaluationInputsScenarioBuildsPlaceholderExpecteds(t *testin
 	}
 }
 
+func TestPrepareCaseEvaluationInputsAttachesExecutionTraces(t *testing.T) {
+	evalCase := makeEvalCase("app", "case-1", "prompt")
+	evalCase.Conversation[0].FinalResponse = &model.Message{Role: model.RoleAssistant, Content: "expected"}
+	traceOne := &agenttrace.Trace{RootInvocationID: "root-1"}
+	traceTwo := &agenttrace.Trace{RootInvocationID: "root-2"}
+	inferenceResult := makeInferenceResult("app", "set", "case-1", "session-1", []*evalset.Invocation{
+		makeActualInvocation("inv-1", "prompt", "answer"),
+		makeActualInvocation("inv-2", "prompt two", "answer two"),
+	})
+	inferenceResult.Inferences[1].UserContent = &model.Message{Role: model.RoleUser, Content: "prompt two"}
+	evalCase.Conversation = []*evalset.Invocation{
+		{UserContent: &model.Message{Role: model.RoleUser, Content: "prompt"}, FinalResponse: &model.Message{Role: model.RoleAssistant, Content: "expected"}},
+		{UserContent: &model.Message{Role: model.RoleUser, Content: "prompt two"}, FinalResponse: &model.Message{Role: model.RoleAssistant, Content: "expected two"}},
+	}
+	inferenceResult.ExecutionTraces = []*agenttrace.Trace{traceOne, traceTwo}
+	svc := &local{}
+	inputs, err := svc.prepareCaseEvaluationInputs(context.Background(), inferenceResult, evalCase, &service.Options{})
+	assert.NoError(t, err)
+	if assert.Len(t, inputs.actuals, 2) {
+		assert.Same(t, traceOne, inputs.actuals[0].ExecutionTrace)
+		assert.Same(t, traceTwo, inputs.actuals[1].ExecutionTrace)
+	}
+}
+
+func TestPrepareCaseEvaluationInputsRejectsMisalignedExecutionTraces(t *testing.T) {
+	evalCase := makeEvalCase("app", "case-1", "prompt")
+	evalCase.Conversation[0].FinalResponse = &model.Message{Role: model.RoleAssistant, Content: "expected"}
+	inferenceResult := makeInferenceResult("app", "set", "case-1", "session-1", []*evalset.Invocation{
+		makeActualInvocation("inv-1", "prompt", "answer"),
+	})
+	inferenceResult.ExecutionTraces = []*agenttrace.Trace{{RootInvocationID: "root-1"}, {RootInvocationID: "root-2"}}
+	svc := &local{}
+	inputs, err := svc.prepareCaseEvaluationInputs(context.Background(), inferenceResult, evalCase, &service.Options{})
+	assert.ErrorContains(t, err, "execution trace count 2 does not match inference count 1")
+	assert.Nil(t, inputs)
+}
+
 func TestEvaluatePerCaseScenarioRunsConfiguredMetric(t *testing.T) {
 	ctx := context.Background()
 	appName := "app"
@@ -4139,6 +4177,211 @@ func TestEvaluatePerCaseTemplateEvaluatorKeepsCaseRubricInEffectiveCriterion(t *
 		if assert.Len(t, result.OverallEvalMetricResults[0].Criterion.LLMJudge.Rubrics, 1) {
 			assert.Equal(t, "case:template", result.OverallEvalMetricResults[0].Criterion.LLMJudge.Rubrics[0].ID)
 		}
+	}
+}
+
+func TestEvaluatePerCaseTemplateTraceBindingMaterializesPromptAndPersistsActualTrace(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-template-trace"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Conversation[0].FinalResponse = &model.Message{Role: model.RoleAssistant, Content: "expected"}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: llmtemplateevaluator.EvaluatorName,
+		result: &evaluator.EvaluateResult{
+			OverallScore:         1,
+			OverallStatus:        status.EvalStatusPassed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{{Score: 1, Status: status.EvalStatusPassed}},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	executionTrace := &agenttrace.Trace{
+		RootInvocationID: "root-1",
+		Steps: []agenttrace.Step{
+			{NodeID: "fetch_match", Output: &agenttrace.Snapshot{Text: "stale data"}},
+			{NodeID: "fetch_match", Output: &agenttrace.Snapshot{Text: "fresh match data"}},
+		},
+	}
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	inferenceResult.ExecutionTraces = []*agenttrace.Trace{executionTrace}
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{
+			{
+				MetricName:    "trace_template",
+				EvaluatorName: llmtemplateevaluator.EvaluatorName,
+				Threshold:     0.5,
+				Criterion: &criterion.Criterion{
+					LLMJudge: &criterionllm.LLMCriterion{
+						Template: &criterionllm.JudgeTemplateOptions{
+							Prompt:             "Trace output: {{trace_output}}",
+							ResponseScorerName: "single_score",
+							VariableBindings: []*criterionllm.TemplateVariableBinding{
+								{
+									TemplateVariable: "trace_output",
+									Source: &criterionllm.TemplateVariableSource{
+										Scope: criterionllm.TemplateVariableScopeActual,
+										Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+										Selector: &criterionllm.TemplateVariableSelector{
+											NodeID: "fetch_match",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, &service.Options{EvalSetManager: mgr, Registry: reg})
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
+	require.NotNil(t, fakeEval.receivedActuals[0].ExecutionTrace)
+	assert.Same(t, executionTrace, fakeEval.receivedActuals[0].ExecutionTrace)
+	if assert.Len(t, result.EvalMetricResultPerInvocation, 1) {
+		perInvocation := result.EvalMetricResultPerInvocation[0]
+		require.NotNil(t, perInvocation.ActualInvocation)
+		assert.Same(t, executionTrace, perInvocation.ActualInvocation.ExecutionTrace)
+		if assert.Len(t, perInvocation.EvalMetricResults, 1) {
+			gotCriterion := perInvocation.EvalMetricResults[0].Criterion
+			require.NotNil(t, gotCriterion)
+			require.NotNil(t, gotCriterion.LLMJudge)
+			require.NotNil(t, gotCriterion.LLMJudge.Template)
+			assert.Contains(t, gotCriterion.LLMJudge.Template.Prompt, "fresh match data")
+			assert.NotContains(t, gotCriterion.LLMJudge.Template.Prompt, "stale data")
+		}
+	}
+}
+
+func TestEvaluateTemplateMetricWithoutTraceBindingAllowsEmptyExecutionTraces(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-template-no-trace"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Conversation[0].FinalResponse = &model.Message{Role: model.RoleAssistant, Content: "expected"}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: llmtemplateevaluator.EvaluatorName,
+		result: &evaluator.EvaluateResult{
+			OverallScore:         1,
+			OverallStatus:        status.EvalStatusPassed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{{Score: 1, Status: status.EvalStatusPassed}},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	result, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:          appName,
+		EvalSetID:        evalSetID,
+		InferenceResults: []*service.InferenceResult{inferenceResult},
+		EvaluateConfig: &service.EvaluateConfig{EvalMetrics: []*metric.EvalMetric{
+			{
+				MetricName:    "final_template",
+				EvaluatorName: llmtemplateevaluator.EvaluatorName,
+				Threshold:     0.5,
+				Criterion: &criterion.Criterion{
+					LLMJudge: &criterionllm.LLMCriterion{
+						Template: &criterionllm.JudgeTemplateOptions{
+							Prompt:             "Answer: {{answer}}",
+							ResponseScorerName: "single_score",
+							VariableBindings: []*criterionllm.TemplateVariableBinding{
+								{
+									TemplateVariable: "answer",
+									Source: &criterionllm.TemplateVariableSource{
+										Scope: criterionllm.TemplateVariableScopeActual,
+										Field: criterionllm.TemplateVariableFieldFinalResponse,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	})
+	assert.NoError(t, err)
+	if assert.Len(t, result.EvalCaseResults, 1) {
+		assert.Equal(t, status.EvalStatusPassed, result.EvalCaseResults[0].FinalEvalStatus)
+	}
+}
+
+func TestEvaluateTemplateTraceBindingMissingTraceReturnsFailedCaseResult(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-template-missing-trace"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Conversation[0].FinalResponse = &model.Message{Role: model.RoleAssistant, Content: "expected"}
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: llmtemplateevaluator.EvaluatorName,
+		result: &evaluator.EvaluateResult{
+			OverallScore:         1,
+			OverallStatus:        status.EvalStatusPassed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{{Score: 1, Status: status.EvalStatusPassed}},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	result, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:          appName,
+		EvalSetID:        evalSetID,
+		InferenceResults: []*service.InferenceResult{inferenceResult},
+		EvaluateConfig: &service.EvaluateConfig{EvalMetrics: []*metric.EvalMetric{
+			{
+				MetricName:    "trace_template",
+				EvaluatorName: llmtemplateevaluator.EvaluatorName,
+				Threshold:     0.5,
+				Criterion: &criterion.Criterion{
+					LLMJudge: &criterionllm.LLMCriterion{
+						Template: &criterionllm.JudgeTemplateOptions{
+							Prompt:             "Trace output: {{trace_output}}",
+							ResponseScorerName: "single_score",
+							VariableBindings: []*criterionllm.TemplateVariableBinding{
+								{
+									TemplateVariable: "trace_output",
+									Source: &criterionllm.TemplateVariableSource{
+										Scope: criterionllm.TemplateVariableScopeActual,
+										Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+										Selector: &criterionllm.TemplateVariableSelector{
+											NodeID: "fetch_match",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	})
+	assert.NoError(t, err)
+	if assert.Len(t, result.EvalCaseResults, 1) {
+		assert.Equal(t, status.EvalStatusFailed, result.EvalCaseResults[0].FinalEvalStatus)
+		assert.Contains(t, result.EvalCaseResults[0].ErrorMessage, "executionTrace is empty")
 	}
 }
 

--- a/examples/evaluation/llm/templatetrace/README.md
+++ b/examples/evaluation/llm/templatetrace/README.md
@@ -1,0 +1,57 @@
+# Template Trace LLM Judge Evaluation Example
+
+This example runs a local file-backed evaluation using `llm_judge_template` with execution trace variables.
+
+The agent is a small `GraphAgent` with one `weather_llm` node and a dedicated `weather_lookup` `ToolNode`. The LLM node calls the tool, the ToolNode runs `get_weather`, and the graph loops back to the same LLM node for the final answer. The evaluation enables execution trace recording, then the judge model scores whether the final answer is grounded in the selected `ToolNode` input and output snapshots.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for the agent and judge model. | `` |
+| `OPENAI_BASE_URL` | Optional custom endpoint for the agent and judge model. | `https://api.openai.com/v1` |
+
+The agent model is configured by the `-model` flag. The metric configuration in `data/` expands `${OPENAI_API_KEY}`, `${OPENAI_BASE_URL}` at load time and configures the judge model.
+
+## Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-data-dir` | Directory containing `.evalset.json` and `.metrics.json`. | `./data` |
+| `-output-dir` | Directory where evaluation results are written. | `./output` |
+| `-model` | Model identifier used by the agent. | `gpt-5.2` |
+| `-eval-set` | Evaluation set identifier to execute. | `template-trace-basic` |
+
+## Run
+
+```bash
+cd examples/evaluation/llm/templatetrace
+go run . \
+  -data-dir "./data" \
+  -output-dir "./output" \
+  -eval-set "template-trace-basic"
+```
+
+The evaluation call enables execution trace recording with `evaluation.WithRunOptions(agent.WithExecutionTraceEnabled(true))`, so template bindings can read the current invocation trace step snapshots.
+
+## Data Layout
+
+```text
+data/
+└── template-trace-eval-app/
+    ├── template-trace-basic.evalset.json
+    └── template-trace-basic.metrics.json
+```
+
+The metric uses:
+
+- `evaluatorName: "llm_judge_template"`
+- `template.prompt`
+- `template.variableBindings`
+- `template.responseScorerName: "single_score"`
+- `actual.traceStepInput` with `source.selector.nodeID: "template-trace-agent/weather_lookup"`
+- `actual.traceStepOutput` with `source.selector.nodeID: "template-trace-agent/weather_lookup"`
+
+## Output
+
+Results are written under `./output/template-trace-eval-app`. The console prints a short summary of overall and per-case outcomes.

--- a/examples/evaluation/llm/templatetrace/agent.go
+++ b/examples/evaluation/llm/templatetrace/agent.go
@@ -1,0 +1,87 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/graphagent"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const (
+	traceAgentName        = "template-trace-agent"
+	nodeWeatherLLM        = "weather_llm"
+	nodeWeatherLookup     = "weather_lookup"
+	weatherLLMInstruction = "Use get_weather when a question asks for current weather, then answer concisely using the weather lookup result."
+)
+
+func newTraceAgent(modelName string) (agent.Agent, error) {
+	weatherTool := function.NewFunctionTool(
+		getWeather,
+		function.WithName("get_weather"),
+		function.WithDescription("Get current weather for a city."),
+	)
+	tools := map[string]tool.Tool{
+		"get_weather": weatherTool,
+	}
+	m := openai.New(modelName)
+	maxTokens := 512
+	temperature := 1.0
+	generationConfig := model.GenerationConfig{
+		MaxTokens:   &maxTokens,
+		Temperature: &temperature,
+		Stream:      false,
+	}
+	compiled, err := graph.NewStateGraph(graph.MessagesStateSchema()).
+		AddLLMNode(
+			nodeWeatherLLM,
+			m,
+			weatherLLMInstruction,
+			tools,
+			graph.WithGenerationConfig(generationConfig),
+		).
+		AddToolsNode(nodeWeatherLookup, tools).
+		AddToolsConditionalEdges(nodeWeatherLLM, nodeWeatherLookup, graph.End).
+		AddEdge(nodeWeatherLookup, nodeWeatherLLM).
+		SetEntryPoint(nodeWeatherLLM).
+		Compile()
+	if err != nil {
+		return nil, err
+	}
+	return graphagent.New(
+		traceAgentName,
+		compiled,
+		graphagent.WithDescription("Weather graph agent for llm_judge_template trace evaluation."),
+		graphagent.WithInitialState(graph.State{}),
+	)
+}
+
+type weatherArgs struct {
+	City string `json:"city"`
+}
+
+type weatherResult struct {
+	City         string `json:"city"`
+	Condition    string `json:"condition"`
+	TemperatureF int    `json:"temperatureF"`
+}
+
+func getWeather(_ context.Context, args weatherArgs) (weatherResult, error) {
+	return weatherResult{
+		City:         args.City,
+		Condition:    "sunny",
+		TemperatureF: 72,
+	}, nil
+}

--- a/examples/evaluation/llm/templatetrace/data/template-trace-eval-app/template-trace-basic.evalset.json
+++ b/examples/evaluation/llm/templatetrace/data/template-trace-eval-app/template-trace-basic.evalset.json
@@ -1,0 +1,26 @@
+{
+  "evalSetId": "template-trace-basic",
+  "name": "template-trace-basic",
+  "evalCases": [
+    {
+      "evalId": "weather_grounded_answer",
+      "conversation": [
+        {
+          "invocationId": "weather_grounded_answer-1",
+          "userContent": {
+            "role": "user",
+            "content": "What is the weather in Seattle? Answer in one short sentence."
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Seattle weather is sunny and 72 F."
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "template-trace-eval-app",
+        "userId": "demo-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/llm/templatetrace/data/template-trace-eval-app/template-trace-basic.metrics.json
+++ b/examples/evaluation/llm/templatetrace/data/template-trace-eval-app/template-trace-basic.metrics.json
@@ -1,0 +1,70 @@
+[
+  {
+    "metricName": "weather_trace_grounded_template",
+    "evaluatorName": "llm_judge_template",
+    "threshold": 1.0,
+    "criterion": {
+      "llmJudge": {
+        "judgeModel": {
+          "providerName": "openai",
+          "modelName": "gpt-5.2",
+          "baseURL": "${OPENAI_BASE_URL}",
+          "apiKey": "${OPENAI_API_KEY}",
+          "numSamples": 1,
+          "generationConfig": {
+            "max_tokens": 256,
+            "temperature": 0,
+            "stream": false
+          }
+        },
+        "template": {
+          "prompt": "You are grading whether the candidate answer is grounded in the selected ToolNode trace step and matches the reference answer.\\n\\nUser question:\\n{{question}}\\n\\nWeather ToolNode input snapshot:\\n{{tool_input}}\\n\\nWeather ToolNode output snapshot:\\n{{tool_output}}\\n\\nReference answer:\\n{{reference}}\\n\\nCandidate answer:\\n{{answer}}\\n\\nReturn JSON with:\\n- score: 1 if the candidate answer is supported by the weather ToolNode input and output snapshots, and is factually equivalent to the reference answer.\\n- score: 0 otherwise.\\n- reason: one concise sentence.\\n\\nTreat minor wording differences and punctuation as equivalent.",
+          "responseScorerName": "single_score",
+          "variableBindings": [
+            {
+              "templateVariable": "question",
+              "source": {
+                "scope": "actual",
+                "field": "userContent"
+              }
+            },
+            {
+              "templateVariable": "answer",
+              "source": {
+                "scope": "actual",
+                "field": "finalResponse"
+              }
+            },
+            {
+              "templateVariable": "reference",
+              "source": {
+                "scope": "expected",
+                "field": "finalResponse"
+              }
+            },
+            {
+              "templateVariable": "tool_input",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepInput",
+                "selector": {
+                  "nodeID": "template-trace-agent/weather_lookup"
+                }
+              }
+            },
+            {
+              "templateVariable": "tool_output",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepOutput",
+                "selector": {
+                  "nodeID": "template-trace-agent/weather_lookup"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/examples/evaluation/llm/templatetrace/main.go
+++ b/examples/evaluation/llm/templatetrace/main.go
@@ -1,0 +1,98 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main runs a local llm_judge_template evaluation example with trace variables.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+var (
+	dataDir   = flag.String("data-dir", "./data", "Directory containing evaluation set and metric files")
+	outputDir = flag.String("output-dir", "./output", "Directory where evaluation results are stored")
+	modelName = flag.String("model", "gpt-5.2", "Model to use for the agent")
+	evalSetID = flag.String("eval-set", "template-trace-basic", "Evaluation set identifier to execute")
+)
+
+const appName = "template-trace-eval-app"
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	traceAgent, err := newTraceAgent(*modelName)
+	if err != nil {
+		log.Fatalf("create agent: %v", err)
+	}
+	run := runner.NewRunner(appName, traceAgent)
+	defer func() { _ = run.Close() }()
+	evalSetManager := evalsetlocal.New(evalset.WithBaseDir(*dataDir))
+	metricManager := metriclocal.New(metric.WithBaseDir(*dataDir))
+	evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(*outputDir))
+	reg := registry.New()
+	agentEvaluator, err := evaluation.New(
+		appName,
+		run,
+		evaluation.WithEvalSetManager(evalSetManager),
+		evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager),
+		evaluation.WithRegistry(reg),
+	)
+	if err != nil {
+		log.Fatalf("create evaluator: %v", err)
+	}
+	defer func() { _ = agentEvaluator.Close() }()
+	result, err := agentEvaluator.Evaluate(
+		ctx,
+		*evalSetID,
+		evaluation.WithRunOptions(agent.WithExecutionTraceEnabled(true)),
+	)
+	if err != nil {
+		log.Fatalf("evaluate: %v", err)
+	}
+	printSummary(result, *outputDir)
+}
+
+func printSummary(result *evaluation.EvaluationResult, outDir string) {
+	fmt.Println("Template trace evaluation completed with local storage")
+	fmt.Printf("App: %s\n", result.AppName)
+	fmt.Printf("Eval Set: %s\n", result.EvalSetID)
+	fmt.Printf("Overall Status: %s\n", result.OverallStatus)
+	runs := 0
+	if len(result.EvalCases) > 0 {
+		runs = len(result.EvalCases[0].EvalCaseResults)
+	}
+	fmt.Printf("Runs: %d\n", runs)
+	for _, caseResult := range result.EvalCases {
+		fmt.Printf("Case %s -> %s\n", caseResult.EvalCaseID, caseResult.OverallStatus)
+		for _, metricResult := range caseResult.MetricResults {
+			fmt.Printf("  Metric %s: score %.2f (threshold %.2f) => %s\n",
+				metricResult.MetricName,
+				metricResult.Score,
+				metricResult.Threshold,
+				metricResult.EvalStatus,
+			)
+		}
+		fmt.Println()
+	}
+	fmt.Printf("Results saved under: %s\n", outDir)
+}

--- a/examples/evaluation/llm/templatetrace/output/template-trace-eval-app/template-trace-eval-app_template-trace-basic_bac7b8c0-52fa-44fb-a098-1aa36eb6cc85.evalset_result.json
+++ b/examples/evaluation/llm/templatetrace/output/template-trace-eval-app/template-trace-eval-app_template-trace-basic_bac7b8c0-52fa-44fb-a098-1aa36eb6cc85.evalset_result.json
@@ -1,0 +1,326 @@
+{
+  "evalSetResultId": "template-trace-eval-app_template-trace-basic_bac7b8c0-52fa-44fb-a098-1aa36eb6cc85",
+  "evalSetResultName": "template-trace-eval-app_template-trace-basic_bac7b8c0-52fa-44fb-a098-1aa36eb6cc85",
+  "evalSetId": "template-trace-basic",
+  "evalCaseResults": [
+    {
+      "evalSetId": "template-trace-basic",
+      "evalId": "weather_grounded_answer",
+      "runId": 1,
+      "finalEvalStatus": "passed",
+      "overallEvalMetricResults": [
+        {
+          "metricName": "weather_trace_grounded_template",
+          "score": 1,
+          "evalStatus": "passed",
+          "threshold": 1,
+          "criterion": {
+            "llmJudge": {
+              "judgeModel": {
+                "providerName": "openai",
+                "modelName": "gpt-5.2",
+                "baseURL": "${OPENAI_BASE_URL}",
+                "numSamples": 1,
+                "generationConfig": {
+                  "max_tokens": 256,
+                  "temperature": 0,
+                  "stream": false
+                }
+              },
+              "template": {
+                "prompt": "You are grading whether the candidate answer is grounded in the selected ToolNode trace step and matches the reference answer.\\n\\nUser question:\\n{{question}}\\n\\nWeather ToolNode input snapshot:\\n{{tool_input}}\\n\\nWeather ToolNode output snapshot:\\n{{tool_output}}\\n\\nReference answer:\\n{{reference}}\\n\\nCandidate answer:\\n{{answer}}\\n\\nReturn JSON with:\\n- score: 1 if the candidate answer is supported by the weather ToolNode input and output snapshots, and is factually equivalent to the reference answer.\\n- score: 0 otherwise.\\n- reason: one concise sentence.\\n\\nTreat minor wording differences and punctuation as equivalent.",
+                "responseScorerName": "single_score",
+                "variableBindings": [
+                  {
+                    "templateVariable": "question",
+                    "source": {
+                      "scope": "actual",
+                      "field": "userContent"
+                    }
+                  },
+                  {
+                    "templateVariable": "answer",
+                    "source": {
+                      "scope": "actual",
+                      "field": "finalResponse"
+                    }
+                  },
+                  {
+                    "templateVariable": "reference",
+                    "source": {
+                      "scope": "expected",
+                      "field": "finalResponse"
+                    }
+                  },
+                  {
+                    "templateVariable": "tool_input",
+                    "source": {
+                      "scope": "actual",
+                      "field": "traceStepInput",
+                      "selector": {
+                        "nodeID": "template-trace-agent/weather_lookup"
+                      }
+                    }
+                  },
+                  {
+                    "templateVariable": "tool_output",
+                    "source": {
+                      "scope": "actual",
+                      "field": "traceStepOutput",
+                      "selector": {
+                        "nodeID": "template-trace-agent/weather_lookup"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "details": {
+            "reason": "The ToolNode output reports Seattle is sunny with temperature 72F, which matches the candidate sentence and is equivalent to the reference answer.",
+            "score": 1
+          }
+        }
+      ],
+      "evalMetricResultPerInvocation": [
+        {
+          "actualInvocation": {
+            "invocationId": "a3e9bc78-73bd-45c6-8198-20d58a56b174",
+            "userContent": {
+              "role": "user",
+              "content": "What is the weather in Seattle? Answer in one short sentence."
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "Seattle is sunny and 72°F."
+            },
+            "executionTrace": {
+              "RootAgentName": "template-trace-agent",
+              "RootInvocationID": "a3e9bc78-73bd-45c6-8198-20d58a56b174",
+              "SessionID": "024710d6-26f6-4ad8-9842-49771c6e0abc",
+              "StartedAt": "2026-07-06T16:27:01.062581668+08:00",
+              "EndedAt": "2026-07-06T16:27:05.923615594+08:00",
+              "Status": "completed",
+              "Usage": null,
+              "Steps": [
+                {
+                  "StepID": "s1",
+                  "InvocationID": "efeafe7d-edcd-4989-b06e-eb2c9515a187",
+                  "ParentInvocationID": "a3e9bc78-73bd-45c6-8198-20d58a56b174",
+                  "AgentName": "template-trace-agent",
+                  "Branch": "template-trace-agent/weather_llm",
+                  "NodeID": "template-trace-agent/weather_llm",
+                  "StartedAt": "2026-07-06T16:27:01.063140134+08:00",
+                  "EndedAt": "2026-07-06T16:27:03.386584049+08:00",
+                  "PredecessorStepIDs": null,
+                  "AppliedSurfaceIDs": null,
+                  "Input": {
+                    "Text": "{\"agent_input_message\":null,\"checkpoint_ns\":\"template-trace-agent\",\"last_response\":\"\",\"last_response_id\":\"\",\"last_tool_response\":\"\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Seattle? Answer in one short sentence.\"}],\"metadata\":{},\"node_responses\":{},\"user_input\":\"What is the weather in Seattle? Answer in one short sentence.\"}"
+                  },
+                  "Output": {
+                    "Text": "{\"last_response\":\"\",\"last_response_id\":\"chatcmpl-DyYxJ9eYyh57iSHMF8BT2JDfr30TU\",\"messages\":[{\"Items\":[{\"role\":\"assistant\",\"tool_calls\":[{\"type\":\"function\",\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Seattle\\\"}\",\"name\":\"get_weather\"},\"id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\"}]}]}],\"node_responses\":{\"weather_llm\":\"\"},\"user_input\":\"\"}"
+                  },
+                  "Usage": null,
+                  "Error": ""
+                },
+                {
+                  "StepID": "s2",
+                  "InvocationID": "f5319857-6109-4981-83c3-172e11fc19fb",
+                  "ParentInvocationID": "a3e9bc78-73bd-45c6-8198-20d58a56b174",
+                  "AgentName": "template-trace-agent",
+                  "Branch": "template-trace-agent/weather_lookup",
+                  "NodeID": "template-trace-agent/weather_lookup",
+                  "StartedAt": "2026-07-06T16:27:03.386801028+08:00",
+                  "EndedAt": "2026-07-06T16:27:03.387173092+08:00",
+                  "PredecessorStepIDs": [
+                    "s1"
+                  ],
+                  "AppliedSurfaceIDs": null,
+                  "Input": {
+                    "Text": "{\"agent_input_message\":null,\"checkpoint_ns\":\"template-trace-agent\",\"last_response\":\"\",\"last_response_id\":\"chatcmpl-DyYxJ9eYyh57iSHMF8BT2JDfr30TU\",\"last_tool_response\":\"\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Seattle? Answer in one short sentence.\"},{\"role\":\"assistant\",\"tool_calls\":[{\"type\":\"function\",\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Seattle\\\"}\",\"name\":\"get_weather\"},\"id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\"}]}],\"metadata\":{},\"node_responses\":{\"weather_llm\":\"\"},\"user_input\":\"\"}"
+                  },
+                  "Output": {
+                    "Text": "{\"last_tool_response\":\"{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}\",\"messages\":[{\"role\":\"tool\",\"content\":\"{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}\",\"tool_id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\",\"tool_name\":\"get_weather\"}],\"node_responses\":{\"weather_lookup\":\"[{\\\"tool_id\\\":\\\"call_0F6OGLW8nxgMLuJzyJMh5kjR\\\",\\\"tool_name\\\":\\\"get_weather\\\",\\\"output\\\":{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}}]\"}}"
+                  },
+                  "Usage": null,
+                  "Error": ""
+                },
+                {
+                  "StepID": "s3",
+                  "InvocationID": "5f604873-8d65-4939-97ce-e0fcbb433ad1",
+                  "ParentInvocationID": "a3e9bc78-73bd-45c6-8198-20d58a56b174",
+                  "AgentName": "template-trace-agent",
+                  "Branch": "template-trace-agent/weather_llm",
+                  "NodeID": "template-trace-agent/weather_llm",
+                  "StartedAt": "2026-07-06T16:27:03.387373813+08:00",
+                  "EndedAt": "2026-07-06T16:27:05.923249861+08:00",
+                  "PredecessorStepIDs": [
+                    "s2"
+                  ],
+                  "AppliedSurfaceIDs": null,
+                  "Input": {
+                    "Text": "{\"agent_input_message\":null,\"checkpoint_ns\":\"template-trace-agent\",\"last_response\":\"\",\"last_response_id\":\"chatcmpl-DyYxJ9eYyh57iSHMF8BT2JDfr30TU\",\"last_tool_response\":\"{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Seattle? Answer in one short sentence.\"},{\"role\":\"assistant\",\"tool_calls\":[{\"type\":\"function\",\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Seattle\\\"}\",\"name\":\"get_weather\"},\"id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\"}]},{\"role\":\"tool\",\"content\":\"{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}\",\"tool_id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\",\"tool_name\":\"get_weather\"}],\"metadata\":{},\"node_responses\":{\"weather_llm\":\"\",\"weather_lookup\":\"[{\\\"tool_id\\\":\\\"call_0F6OGLW8nxgMLuJzyJMh5kjR\\\",\\\"tool_name\\\":\\\"get_weather\\\",\\\"output\\\":{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}}]\"},\"user_input\":\"\"}"
+                  },
+                  "Output": {
+                    "Text": "{\"last_response\":\"Seattle is sunny and 72°F.\",\"last_response_id\":\"chatcmpl-DyYxMAh1ZNBm8ad1nUl1tTniXsPkL\",\"messages\":{\"Items\":[{\"role\":\"assistant\",\"content\":\"Seattle is sunny and 72°F.\"}]},\"node_responses\":{\"weather_llm\":\"Seattle is sunny and 72°F.\"}}"
+                  },
+                  "Usage": null,
+                  "Error": ""
+                }
+              ]
+            }
+          },
+          "expectedInvocation": {
+            "invocationId": "weather_grounded_answer-1",
+            "userContent": {
+              "role": "user",
+              "content": "What is the weather in Seattle? Answer in one short sentence."
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "Seattle weather is sunny and 72 F."
+            }
+          },
+          "evalMetricResults": [
+            {
+              "metricName": "weather_trace_grounded_template",
+              "score": 1,
+              "evalStatus": "passed",
+              "threshold": 1,
+              "criterion": {
+                "llmJudge": {
+                  "judgeModel": {
+                    "providerName": "openai",
+                    "modelName": "gpt-5.2",
+                    "baseURL": "${OPENAI_BASE_URL}",
+                    "numSamples": 1,
+                    "generationConfig": {
+                      "max_tokens": 256,
+                      "temperature": 0,
+                      "stream": false
+                    }
+                  },
+                  "template": {
+                    "prompt": "You are grading whether the candidate answer is grounded in the selected ToolNode trace step and matches the reference answer.\\n\\nUser question:\\nWhat is the weather in Seattle? Answer in one short sentence.\\n\\nWeather ToolNode input snapshot:\\n{\"agent_input_message\":null,\"checkpoint_ns\":\"template-trace-agent\",\"last_response\":\"\",\"last_response_id\":\"chatcmpl-DyYxJ9eYyh57iSHMF8BT2JDfr30TU\",\"last_tool_response\":\"\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Seattle? Answer in one short sentence.\"},{\"role\":\"assistant\",\"tool_calls\":[{\"type\":\"function\",\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Seattle\\\"}\",\"name\":\"get_weather\"},\"id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\"}]}],\"metadata\":{},\"node_responses\":{\"weather_llm\":\"\"},\"user_input\":\"\"}\\n\\nWeather ToolNode output snapshot:\\n{\"last_tool_response\":\"{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}\",\"messages\":[{\"role\":\"tool\",\"content\":\"{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}\",\"tool_id\":\"call_0F6OGLW8nxgMLuJzyJMh5kjR\",\"tool_name\":\"get_weather\"}],\"node_responses\":{\"weather_lookup\":\"[{\\\"tool_id\\\":\\\"call_0F6OGLW8nxgMLuJzyJMh5kjR\\\",\\\"tool_name\\\":\\\"get_weather\\\",\\\"output\\\":{\\\"city\\\":\\\"Seattle\\\",\\\"condition\\\":\\\"sunny\\\",\\\"temperatureF\\\":72}}]\"}}\\n\\nReference answer:\\nSeattle weather is sunny and 72 F.\\n\\nCandidate answer:\\nSeattle is sunny and 72°F.\\n\\nReturn JSON with:\\n- score: 1 if the candidate answer is supported by the weather ToolNode input and output snapshots, and is factually equivalent to the reference answer.\\n- score: 0 otherwise.\\n- reason: one concise sentence.\\n\\nTreat minor wording differences and punctuation as equivalent.",
+                    "responseScorerName": "single_score",
+                    "variableBindings": [
+                      {
+                        "templateVariable": "question",
+                        "source": {
+                          "scope": "actual",
+                          "field": "userContent"
+                        }
+                      },
+                      {
+                        "templateVariable": "answer",
+                        "source": {
+                          "scope": "actual",
+                          "field": "finalResponse"
+                        }
+                      },
+                      {
+                        "templateVariable": "reference",
+                        "source": {
+                          "scope": "expected",
+                          "field": "finalResponse"
+                        }
+                      },
+                      {
+                        "templateVariable": "tool_input",
+                        "source": {
+                          "scope": "actual",
+                          "field": "traceStepInput",
+                          "selector": {
+                            "nodeID": "template-trace-agent/weather_lookup"
+                          }
+                        }
+                      },
+                      {
+                        "templateVariable": "tool_output",
+                        "source": {
+                          "scope": "actual",
+                          "field": "traceStepOutput",
+                          "selector": {
+                            "nodeID": "template-trace-agent/weather_lookup"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "details": {
+                "reason": "The ToolNode output reports Seattle is sunny with temperature 72F, which matches the candidate sentence and is equivalent to the reference answer.",
+                "score": 1
+              }
+            }
+          ]
+        }
+      ],
+      "sessionId": "024710d6-26f6-4ad8-9842-49771c6e0abc",
+      "userId": "demo-user"
+    }
+  ],
+  "summary": {
+    "overallStatus": "passed",
+    "numRuns": 1,
+    "runStatusCounts": {
+      "passed": 1
+    },
+    "runSummaries": [
+      {
+        "runId": 1,
+        "overallStatus": "passed",
+        "caseStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "weather_trace_grounded_template",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          }
+        ]
+      }
+    ],
+    "evalCaseSummaries": [
+      {
+        "evalId": "weather_grounded_answer",
+        "overallStatus": "passed",
+        "runStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "weather_trace_grounded_template",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          }
+        ],
+        "runSummaries": [
+          {
+            "runId": 1,
+            "finalEvalStatus": "passed",
+            "metricResults": [
+              {
+                "metricName": "weather_trace_grounded_template",
+                "score": 1,
+                "evalStatus": "passed",
+                "threshold": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "creationTimestamp": 1783326428.3376973
+}


### PR DESCRIPTION
This adds template variable bindings for selected execution trace step input and output, wires trace selector cloning and local result persistence, and documents the new sources in both English and Chinese evaluation docs. It also adds a runnable LLM template trace evaluation example that enables execution trace and binds the judge prompt to a ToolNode input/output snapshot.