### PR TITLE
memory/mem0: support self-hosted OSS API

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1716,6 +1716,7 @@ In short, `MemoryService` means "the framework manages memories directly", while
 | `WithAPIKey(key)` | mem0 API key. Required for hosted platform requests; optional for self-hosted OSS when auth is disabled. | required |
 | `WithHost(url)` | Override the mem0 API host/base URL. | `https://api.mem0.ai` |
 | `WithSelfHostedOSS()` | Use the self-hosted Mem0 OSS REST API (`/memories`, `/search`, `X-API-Key`). When enabled without `WithHost`, the host defaults to `http://localhost:8888`; the hosted-platform default host is rejected in OSS mode. | disabled |
+| `WithSelfHostedOSSIncludeUnscopedMemories()` | Include legacy OSS records that do not carry `metadata.trpc_app_name`; records tagged for a different app remain hidden. | disabled |
 | `WithOrgProject(orgID, projectID)` | Add hosted-platform `org_id` / `project_id`; unsupported with self-hosted OSS. | empty |
 | `WithAsyncMode(bool)` | Controls hosted-platform `async_mode`; self-hosted OSS writes are synchronous at the REST layer. | `true` |
 | `WithVersion(v)` | Sets the hosted-platform ingestion API version field. | `v2` |
@@ -1736,6 +1737,8 @@ access the OSS server's internal vector store directly.
 
 - `Tools()` exposes `memory_search` by default; `memory_load` can be enabled explicitly.
 - All reads remain scoped to the current `<appName, userID>`.
+- Self-hosted OSS app isolation uses `metadata.trpc_app_name` because the OSS API has no top-level `app_id`. Existing OSS records without this metadata are hidden by default until reingested or backfilled. Use `WithSelfHostedOSSIncludeUnscopedMemories()` only for migrations that need those legacy records visible.
+- The current OSS `GET /memories` API is capped at 1000 results and is not pageable. `ReadMemories` therefore requires a positive limit no larger than 1000.
 - Runner automatically passes session context into ingest. Custom callers can also use `session.WithIngestMetadata`, `session.WithIngestAgentID`, and `session.WithIngestRunID` when needed.
 - When mem0 metadata is available, search results can still carry structured fields such as `Topics`, `Kind`, `EventTime`, `Participants`, and `Location`.
 - Call `Close()` on the service so background workers shut down cleanly.

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1715,7 +1715,7 @@ In short, `MemoryService` means "the framework manages memories directly", while
 | ------ | ------- | ------- |
 | `WithAPIKey(key)` | mem0 API key. Required for hosted platform requests; optional for self-hosted OSS when auth is disabled. | required |
 | `WithHost(url)` | Override the mem0 API host/base URL. | `https://api.mem0.ai` |
-| `WithSelfHostedOSS()` | Use the self-hosted Mem0 OSS REST API (`/memories`, `/search`, `X-API-Key`). | disabled |
+| `WithSelfHostedOSS()` | Use the self-hosted Mem0 OSS REST API (`/memories`, `/search`, `X-API-Key`). When enabled without `WithHost`, the host defaults to `http://localhost:8888`; the hosted-platform default host is rejected in OSS mode. | disabled |
 | `WithOrgProject(orgID, projectID)` | Add hosted-platform `org_id` / `project_id`; unsupported with self-hosted OSS. | empty |
 | `WithAsyncMode(bool)` | Controls hosted-platform `async_mode`; self-hosted OSS writes are synchronous at the REST layer. | `true` |
 | `WithVersion(v)` | Sets the hosted-platform ingestion API version field. | `v2` |

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1738,7 +1738,7 @@ access the OSS server's internal vector store directly.
 - `Tools()` exposes `memory_search` by default; `memory_load` can be enabled explicitly.
 - All reads remain scoped to the current `<appName, userID>`.
 - Self-hosted OSS app isolation uses `metadata.trpc_app_name` because the OSS API has no top-level `app_id`. Existing OSS records without this metadata are hidden by default until reingested or backfilled. Use `WithSelfHostedOSSIncludeUnscopedMemories()` only for migrations that need those legacy records visible.
-- The current OSS `GET /memories` API is capped at 1000 results and is not pageable. `ReadMemories` therefore requires a positive limit no larger than 1000.
+- The current OSS `GET /memories` API is capped at 1000 user-level results, is not pageable, and cannot express `metadata.trpc_app_name` as a server-side filter. `ReadMemories` therefore requires a positive limit no larger than 1000 and applies app isolation as a best-effort local filter over the first 1000 OSS records returned for the user.
 - Runner automatically passes session context into ingest. Custom callers can also use `session.WithIngestMetadata`, `session.WithIngestAgentID`, and `session.WithIngestRunID` when needed.
 - When mem0 metadata is available, search results can still carry structured fields such as `Topics`, `Kind`, `EventTime`, `Participants`, and `Location`.
 - Call `Close()` on the service so background workers shut down cleanly.

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1713,16 +1713,24 @@ In short, `MemoryService` means "the framework manages memories directly", while
 
 | Option | Purpose | Default |
 | ------ | ------- | ------- |
-| `WithAPIKey(key)` | mem0 API key. Required for all requests. | required |
+| `WithAPIKey(key)` | mem0 API key. Required for hosted platform requests; optional for self-hosted OSS when auth is disabled. | required |
 | `WithHost(url)` | Override the mem0 API host/base URL. | `https://api.mem0.ai` |
-| `WithOrgProject(orgID, projectID)` | Add mem0 `org_id` / `project_id` to ingest and retrieval requests. | empty |
-| `WithAsyncMode(bool)` | Controls mem0's `async_mode` flag on ingest requests. | `true` |
-| `WithVersion(v)` | Sets the mem0 ingestion API version field. | `v2` |
+| `WithSelfHostedOSS()` | Use the self-hosted Mem0 OSS REST API (`/memories`, `/search`, `X-API-Key`). | disabled |
+| `WithOrgProject(orgID, projectID)` | Add hosted-platform `org_id` / `project_id`; unsupported with self-hosted OSS. | empty |
+| `WithAsyncMode(bool)` | Controls hosted-platform `async_mode`; self-hosted OSS writes are synchronous at the REST layer. | `true` |
+| `WithVersion(v)` | Sets the hosted-platform ingestion API version field. | `v2` |
 | `WithTimeout(d)` | HTTP timeout used by the client. | `10s` |
 | `WithLoadToolEnabled(bool)` | Expose `memory_load` from `Tools()`. | `false` |
 | `WithAsyncMemoryNum(n)` | Number of background ingest workers. | `1` |
 | `WithMemoryQueueSize(n)` | Queue size per ingest worker. | `10` |
 | `WithMemoryJobTimeout(d)` | Timeout for queued jobs and synchronous fallback ingest. | `30s` |
+
+For the official self-hosted OSS server, configure the server-side LLM and
+embedder independently when they use different endpoints or API keys. The OSS
+server exposes `POST /configure`; set `llm.provider=openai` with the LLM model,
+base URL, and API key, and set `embedder.provider=openai` with the embedding
+model, base URL, and API key. The Go adapter only uses the REST API and does not
+access the OSS server's internal vector store directly.
 
 ### Notes
 

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1770,7 +1770,7 @@ API key，需要在 server 侧分别配置。OSS server 提供 `POST /configure`
 - `Tools()` 默认暴露 `memory_search`；`memory_load` 可按需开启。
 - 所有读取仍然基于当前 `<appName, userID>` 做隔离。
 - 本地 OSS 没有 top-level `app_id`，适配层使用 `metadata.trpc_app_name` 做 app 隔离。已有 OSS 记录如果缺少这个 metadata，默认会被隐藏，直到重新 ingest 或回填 metadata。迁移期确实需要读取这些历史记录时，可显式开启 `WithSelfHostedOSSIncludeUnscopedMemories()`。
-- 当前 OSS `GET /memories` API 最多返回 1000 条且不支持分页，因此 `ReadMemories` 要求传入大于 0 且不超过 1000 的 limit。
+- 当前 OSS `GET /memories` API 最多返回 1000 条 user 级结果，不支持分页，也不能在服务端表达 `metadata.trpc_app_name` 过滤。因此 `ReadMemories` 要求传入大于 0 且不超过 1000 的 limit，并且只会在 OSS 返回的前 1000 条 user 级记录内尽力做本地 app 隔离。
 - Runner 会自动把 session 上下文带入 ingest；如果有需要，也可以通过 `session.WithIngestMetadata`、`session.WithIngestAgentID`、`session.WithIngestRunID` 追加信息。
 - 当 mem0 返回结构化 metadata 时，检索结果仍可携带 `Topics`、`Kind`、`EventTime`、`Participants`、`Location` 等字段。
 - 使用完成后请调用 `Close()`，确保后台 worker 干净退出。

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1749,6 +1749,7 @@ defer r.Close()
 | `WithAPIKey(key)` | mem0 API Key；托管平台必填，本地 OSS 且关闭鉴权时可为空。 | 必填 |
 | `WithHost(url)` | 覆盖 mem0 API Host / Base URL。 | `https://api.mem0.ai` |
 | `WithSelfHostedOSS()` | 使用本地 Mem0 OSS REST API（`/memories`、`/search`、`X-API-Key`）。开启后如果没有设置 `WithHost`，host 默认 `http://localhost:8888`；OSS 模式会拒绝托管平台默认 host。 | 关闭 |
+| `WithSelfHostedOSSIncludeUnscopedMemories()` | 包含没有 `metadata.trpc_app_name` 的历史 OSS 记录；已标记为其他 app 的记录仍会隐藏。 | 关闭 |
 | `WithOrgProject(orgID, projectID)` | 追加托管平台的 `org_id` / `project_id`；本地 OSS 不支持。 | 空 |
 | `WithAsyncMode(bool)` | 控制托管平台 ingest 请求里的 `async_mode`；本地 OSS 在 REST 层同步写入。 | `true` |
 | `WithVersion(v)` | 设置托管平台 mem0 ingest 请求里的版本字段。 | `v2` |
@@ -1768,6 +1769,8 @@ API key，需要在 server 侧分别配置。OSS server 提供 `POST /configure`
 
 - `Tools()` 默认暴露 `memory_search`；`memory_load` 可按需开启。
 - 所有读取仍然基于当前 `<appName, userID>` 做隔离。
+- 本地 OSS 没有 top-level `app_id`，适配层使用 `metadata.trpc_app_name` 做 app 隔离。已有 OSS 记录如果缺少这个 metadata，默认会被隐藏，直到重新 ingest 或回填 metadata。迁移期确实需要读取这些历史记录时，可显式开启 `WithSelfHostedOSSIncludeUnscopedMemories()`。
+- 当前 OSS `GET /memories` API 最多返回 1000 条且不支持分页，因此 `ReadMemories` 要求传入大于 0 且不超过 1000 的 limit。
 - Runner 会自动把 session 上下文带入 ingest；如果有需要，也可以通过 `session.WithIngestMetadata`、`session.WithIngestAgentID`、`session.WithIngestRunID` 追加信息。
 - 当 mem0 返回结构化 metadata 时，检索结果仍可携带 `Topics`、`Kind`、`EventTime`、`Participants`、`Location` 等字段。
 - 使用完成后请调用 `Close()`，确保后台 worker 干净退出。

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1748,7 +1748,7 @@ defer r.Close()
 | ---- | ---- | ------ |
 | `WithAPIKey(key)` | mem0 API Key；托管平台必填，本地 OSS 且关闭鉴权时可为空。 | 必填 |
 | `WithHost(url)` | 覆盖 mem0 API Host / Base URL。 | `https://api.mem0.ai` |
-| `WithSelfHostedOSS()` | 使用本地 Mem0 OSS REST API（`/memories`、`/search`、`X-API-Key`）。 | 关闭 |
+| `WithSelfHostedOSS()` | 使用本地 Mem0 OSS REST API（`/memories`、`/search`、`X-API-Key`）。开启后如果没有设置 `WithHost`，host 默认 `http://localhost:8888`；OSS 模式会拒绝托管平台默认 host。 | 关闭 |
 | `WithOrgProject(orgID, projectID)` | 追加托管平台的 `org_id` / `project_id`；本地 OSS 不支持。 | 空 |
 | `WithAsyncMode(bool)` | 控制托管平台 ingest 请求里的 `async_mode`；本地 OSS 在 REST 层同步写入。 | `true` |
 | `WithVersion(v)` | 设置托管平台 mem0 ingest 请求里的版本字段。 | `v2` |

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1746,16 +1746,23 @@ defer r.Close()
 
 | 选项 | 作用 | 默认值 |
 | ---- | ---- | ------ |
-| `WithAPIKey(key)` | mem0 API Key，所有请求必需。 | 必填 |
+| `WithAPIKey(key)` | mem0 API Key；托管平台必填，本地 OSS 且关闭鉴权时可为空。 | 必填 |
 | `WithHost(url)` | 覆盖 mem0 API Host / Base URL。 | `https://api.mem0.ai` |
-| `WithOrgProject(orgID, projectID)` | 为 ingest 与读取请求追加 mem0 的 `org_id` / `project_id`。 | 空 |
-| `WithAsyncMode(bool)` | 控制 ingest 请求里的 `async_mode`。 | `true` |
-| `WithVersion(v)` | 设置 mem0 ingest 请求里的版本字段。 | `v2` |
+| `WithSelfHostedOSS()` | 使用本地 Mem0 OSS REST API（`/memories`、`/search`、`X-API-Key`）。 | 关闭 |
+| `WithOrgProject(orgID, projectID)` | 追加托管平台的 `org_id` / `project_id`；本地 OSS 不支持。 | 空 |
+| `WithAsyncMode(bool)` | 控制托管平台 ingest 请求里的 `async_mode`；本地 OSS 在 REST 层同步写入。 | `true` |
+| `WithVersion(v)` | 设置托管平台 mem0 ingest 请求里的版本字段。 | `v2` |
 | `WithTimeout(d)` | HTTP 客户端超时时间。 | `10s` |
 | `WithLoadToolEnabled(bool)` | 是否在 `Tools()` 里暴露 `memory_load`。 | `false` |
 | `WithAsyncMemoryNum(n)` | 后台 ingest worker 数量。 | `1` |
 | `WithMemoryQueueSize(n)` | 每个 worker 的队列长度。 | `10` |
 | `WithMemoryJobTimeout(d)` | 队列任务与同步 fallback ingest 的超时时间。 | `30s` |
+
+如果使用官方本地 Mem0 OSS server，并且 LLM 与 embedding 使用不同 endpoint 或
+API key，需要在 server 侧分别配置。OSS server 提供 `POST /configure`：
+`llm.provider=openai` 配置 LLM 的模型、base URL 和 API key，
+`embedder.provider=openai` 配置 embedding 的模型、base URL 和 API key。Go
+适配层只访问 Mem0 REST API，不直接读写 OSS server 内部的向量库。
 
 ### 注意事项
 

--- a/examples/memory/mem0/README.md
+++ b/examples/memory/mem0/README.md
@@ -46,17 +46,19 @@ ingest → mem0 extraction → memory retrieval.
 ## Prerequisites
 
 - Go 1.21 or later
-- A valid [mem0 API key](https://app.mem0.ai/)
+- A valid [mem0 API key](https://app.mem0.ai/) for the hosted platform, or a
+  self-hosted Mem0 OSS server
 - A valid OpenAI-compatible API key (for the chat model)
 
 ## Environment Variables
 
 | Variable          | Required | Description                            | Default                 |
 | ----------------- | -------- | -------------------------------------- | ----------------------- |
-| `MEM0_API_KEY`    | Yes      | API key for mem0                       |                         |
+| `MEM0_API_KEY`    | Yes*     | API key for mem0. Optional only when `MEM0_SELF_HOSTED_OSS=true` and the server disables auth | |
 | `OPENAI_API_KEY`  | Yes      | API key for the chat model             |                         |
 | `MEM0_HOST`       | No       | mem0 API base URL                      | `https://api.mem0.ai`   |
 | `MEM0_BASE_URL`   | No       | Alias for `MEM0_HOST`                  |                         |
+| `MEM0_SELF_HOSTED_OSS` | No   | Set to `true` for the self-hosted OSS REST API | `false` |
 | `MEM0_ORG_ID`     | No       | mem0 organization ID                   |                         |
 | `MEM0_PROJECT_ID` | No       | mem0 project ID                        |                         |
 | `OPENAI_BASE_URL` | No       | Base URL for the model API endpoint    | `https://api.openai.com/v1` |
@@ -89,12 +91,30 @@ go run .
 go run . -model gpt-4o-mini
 ```
 
-### Self-hosted mem0
+### Self-hosted Mem0 OSS
 
 ```bash
-export MEM0_HOST="https://your-mem0-instance.example.com"
+export MEM0_SELF_HOSTED_OSS=true
+export MEM0_HOST="http://localhost:8888"
+# Optional when the OSS server runs with AUTH_DISABLED=true.
+export MEM0_API_KEY="your-oss-api-key"
 go run .
 ```
+
+Self-hosted OSS uses the OSS REST API paths (`/memories`, `/search`) and
+`X-API-Key` authentication. It does not support hosted-platform
+`MEM0_ORG_ID` / `MEM0_PROJECT_ID` scoping.
+
+When running the official Mem0 OSS server, configure the server-side LLM and
+embedder separately if your deployment uses different endpoints or API keys.
+For example, start the server with `AUTH_DISABLED=true` for local development,
+then call `POST /configure` on the OSS server and set:
+
+- `llm.provider=openai` with the LLM model, base URL, and API key.
+- `embedder.provider=openai` with the embedding model, base URL, and API key.
+
+The Go adapter only talks to the Mem0 REST API. It does not read or write the
+server's internal vector database directly.
 
 ### Expected Output
 
@@ -190,6 +210,7 @@ The mem0 service accepts the following options:
 | ------------------------- | ---------------------------------------------- | ---------------------- |
 | `WithAPIKey(key)`         | mem0 API key                                   | (required)             |
 | `WithHost(url)`           | mem0 API base URL                              | `https://api.mem0.ai`  |
+| `WithSelfHostedOSS()`    | Use the self-hosted Mem0 OSS REST API          | disabled               |
 | `WithOrgProject(o, p)`   | Organization and project IDs                   |                        |
 | `WithAsyncMode(bool)`    | Send ingest requests in async mode             | `true`                 |
 | `WithVersion(v)`         | mem0 ingest API version                        | `v2`                   |

--- a/examples/memory/mem0/README.md
+++ b/examples/memory/mem0/README.md
@@ -95,14 +95,16 @@ go run . -model gpt-4o-mini
 
 ```bash
 export MEM0_SELF_HOSTED_OSS=true
-export MEM0_HOST="http://localhost:8888"
+export MEM0_HOST="http://localhost:8888" # Optional; this is the OSS default.
 # Optional when the OSS server runs with AUTH_DISABLED=true.
 export MEM0_API_KEY="your-oss-api-key"
 go run .
 ```
 
 Self-hosted OSS uses the OSS REST API paths (`/memories`, `/search`) and
-`X-API-Key` authentication. It does not support hosted-platform
+`X-API-Key` authentication. When `MEM0_SELF_HOSTED_OSS=true` and `MEM0_HOST`
+is unset, the adapter defaults to `http://localhost:8888` and refuses to use
+the hosted-platform default host. It does not support hosted-platform
 `MEM0_ORG_ID` / `MEM0_PROJECT_ID` scoping.
 
 When running the official Mem0 OSS server, configure the server-side LLM and
@@ -210,7 +212,7 @@ The mem0 service accepts the following options:
 | ------------------------- | ---------------------------------------------- | ---------------------- |
 | `WithAPIKey(key)`         | mem0 API key                                   | (required)             |
 | `WithHost(url)`           | mem0 API base URL                              | `https://api.mem0.ai`  |
-| `WithSelfHostedOSS()`    | Use the self-hosted Mem0 OSS REST API          | disabled               |
+| `WithSelfHostedOSS()`    | Use the self-hosted Mem0 OSS REST API          | disabled; host defaults to `http://localhost:8888` when enabled |
 | `WithOrgProject(o, p)`   | Organization and project IDs                   |                        |
 | `WithAsyncMode(bool)`    | Send ingest requests in async mode             | `true`                 |
 | `WithVersion(v)`         | mem0 ingest API version                        | `v2`                   |

--- a/examples/memory/mem0/README.md
+++ b/examples/memory/mem0/README.md
@@ -107,6 +107,19 @@ is unset, the adapter defaults to `http://localhost:8888` and refuses to use
 the hosted-platform default host. It does not support hosted-platform
 `MEM0_ORG_ID` / `MEM0_PROJECT_ID` scoping.
 
+The adapter writes the tRPC app name to `metadata.trpc_app_name` because the
+OSS REST API does not have a top-level `app_id`. By default, reads and searches
+only return memories with matching `trpc_app_name` to preserve app isolation.
+Existing OSS memories without that metadata are hidden until they are reingested
+or backfilled. For migrations, opt in with
+`WithSelfHostedOSSIncludeUnscopedMemories()` to also include records with no
+`trpc_app_name`; records tagged for another app remain hidden.
+
+The OSS `GET /memories` endpoint is capped at 1000 results and is not pageable
+in the current server API. `ReadMemories` therefore requires a positive limit no
+larger than 1000 and fetches up to that server cap before applying the app
+metadata filter locally.
+
 When running the official Mem0 OSS server, configure the server-side LLM and
 embedder separately if your deployment uses different endpoints or API keys.
 For example, start the server with `AUTH_DISABLED=true` for local development,
@@ -213,6 +226,7 @@ The mem0 service accepts the following options:
 | `WithAPIKey(key)`         | mem0 API key                                   | (required)             |
 | `WithHost(url)`           | mem0 API base URL                              | `https://api.mem0.ai`  |
 | `WithSelfHostedOSS()`    | Use the self-hosted Mem0 OSS REST API          | disabled; host defaults to `http://localhost:8888` when enabled |
+| `WithSelfHostedOSSIncludeUnscopedMemories()` | Include legacy OSS records that lack `metadata.trpc_app_name` | disabled |
 | `WithOrgProject(o, p)`   | Organization and project IDs                   |                        |
 | `WithAsyncMode(bool)`    | Send ingest requests in async mode             | `true`                 |
 | `WithVersion(v)`         | mem0 ingest API version                        | `v2`                   |

--- a/examples/memory/mem0/README.md
+++ b/examples/memory/mem0/README.md
@@ -115,10 +115,11 @@ or backfilled. For migrations, opt in with
 `WithSelfHostedOSSIncludeUnscopedMemories()` to also include records with no
 `trpc_app_name`; records tagged for another app remain hidden.
 
-The OSS `GET /memories` endpoint is capped at 1000 results and is not pageable
-in the current server API. `ReadMemories` therefore requires a positive limit no
-larger than 1000 and fetches up to that server cap before applying the app
-metadata filter locally.
+The OSS `GET /memories` endpoint is capped at 1000 user-level results and is
+not pageable in the current server API. It also cannot express
+`metadata.trpc_app_name` as a server-side filter. `ReadMemories` therefore
+requires a positive limit no larger than 1000 and applies app isolation as a
+best-effort local filter over the first 1000 OSS records returned for the user.
 
 When running the official Mem0 OSS server, configure the server-side LLM and
 embedder separately if your deployment uses different endpoints or API keys.

--- a/examples/memory/mem0/main.go
+++ b/examples/memory/mem0/main.go
@@ -43,7 +43,7 @@ var (
 
 func main() {
 	flag.Parse()
-	if os.Getenv("MEM0_API_KEY") == "" {
+	if os.Getenv("MEM0_API_KEY") == "" && !mem0SelfHostedOSS() {
 		log.Fatal("MEM0_API_KEY is required")
 	}
 	if os.Getenv("OPENAI_API_KEY") == "" {
@@ -158,12 +158,17 @@ func summariseExtras(entry *memory.Entry) string {
 
 func newMem0Service(timeout time.Duration) (*memorymem0.Service, error) {
 	opts := []memorymem0.ServiceOpt{
-		memorymem0.WithAPIKey(os.Getenv("MEM0_API_KEY")),
 		memorymem0.WithTimeout(timeout),
 		memorymem0.WithMemoryJobTimeout(timeout),
 		memorymem0.WithAsyncMemoryNum(1),
 		memorymem0.WithMemoryQueueSize(8),
 		memorymem0.WithLoadToolEnabled(true),
+	}
+	if apiKey := os.Getenv("MEM0_API_KEY"); apiKey != "" {
+		opts = append(opts, memorymem0.WithAPIKey(apiKey))
+	}
+	if mem0SelfHostedOSS() {
+		opts = append(opts, memorymem0.WithSelfHostedOSS())
 	}
 	if host := mem0Host(); host != "" {
 		opts = append(opts, memorymem0.WithHost(host))
@@ -172,6 +177,15 @@ func newMem0Service(timeout time.Duration) (*memorymem0.Service, error) {
 		opts = append(opts, memorymem0.WithOrgProject(orgID, os.Getenv("MEM0_PROJECT_ID")))
 	}
 	return memorymem0.NewService(opts...)
+}
+
+func mem0SelfHostedOSS() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MEM0_SELF_HOSTED_OSS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func mem0Host() string {

--- a/memory/mem0/client.go
+++ b/memory/mem0/client.go
@@ -30,6 +30,7 @@ const (
 	httpHeaderAuthorization = "Authorization"
 	httpHeaderAccept        = "Accept"
 	httpHeaderContentType   = "Content-Type"
+	httpHeaderXAPIKey       = "X-API-Key"
 
 	httpContentTypeJSON = "application/json"
 
@@ -57,6 +58,7 @@ func (e *apiError) Error() string {
 type client struct {
 	host      string
 	apiKey    string
+	apiMode   apiMode
 	orgID     string
 	projectID string
 	hc        *http.Client
@@ -64,7 +66,7 @@ type client struct {
 }
 
 func newClient(opts serviceOpts) (*client, error) {
-	if opts.apiKey == "" {
+	if opts.apiMode == apiModeCloud && opts.apiKey == "" {
 		return nil, errors.New("mem0 api key is required")
 	}
 	hc := opts.client
@@ -74,6 +76,7 @@ func newClient(opts serviceOpts) (*client, error) {
 	return &client{
 		host:      strings.TrimRight(opts.host, "/"),
 		apiKey:    opts.apiKey,
+		apiMode:   opts.apiMode,
 		orgID:     opts.orgID,
 		projectID: opts.projectID,
 		hc:        hc,
@@ -159,7 +162,7 @@ func (c *client) doJSONOnce(
 	if err != nil {
 		return fmt.Errorf("mem0: build request failed: %w", err)
 	}
-	req.Header.Set(httpHeaderAuthorization, "Token "+c.apiKey)
+	c.setAuthHeader(req)
 	req.Header.Set(httpHeaderAccept, httpContentTypeJSON)
 	if payload != nil {
 		req.Header.Set(httpHeaderContentType, httpContentTypeJSON)
@@ -192,6 +195,18 @@ func (c *client) doJSONOnce(
 		return fmt.Errorf("mem0: unmarshal response failed: %w", err)
 	}
 	return nil
+}
+
+func (c *client) setAuthHeader(req *http.Request) {
+	if req == nil || c.apiKey == "" {
+		return
+	}
+	switch c.apiMode {
+	case apiModeSelfHostedOSS:
+		req.Header.Set(httpHeaderXAPIKey, c.apiKey)
+	default:
+		req.Header.Set(httpHeaderAuthorization, "Token "+c.apiKey)
+	}
 }
 
 func shouldRetry(err error) bool {

--- a/memory/mem0/client.go
+++ b/memory/mem0/client.go
@@ -30,7 +30,7 @@ const (
 	httpHeaderAuthorization = "Authorization"
 	httpHeaderAccept        = "Accept"
 	httpHeaderContentType   = "Content-Type"
-	httpHeaderXAPIKey       = "X-API-Key"
+	httpHeaderXAPIKey       = "X-API-Key" // #nosec G101 -- HTTP header name, not a credential.
 
 	httpContentTypeJSON = "application/json"
 

--- a/memory/mem0/client_test.go
+++ b/memory/mem0/client_test.go
@@ -37,6 +37,12 @@ func TestNewClient_RequiresAPIKey(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewClient_SelfHostedOSSAllowsEmptyAPIKey(t *testing.T) {
+	c, err := newClient(serviceOpts{apiMode: apiModeSelfHostedOSS, host: "http://localhost:8888"})
+	require.NoError(t, err)
+	assert.Equal(t, apiModeSelfHostedOSS, c.apiMode)
+}
+
 func TestNewClient_TrimsHostTrailingSlash(t *testing.T) {
 	c, err := newClient(serviceOpts{apiKey: "k", host: "https://api.example.com///"})
 	require.NoError(t, err)
@@ -74,6 +80,32 @@ func TestDoJSON_GetSuccess(t *testing.T) {
 	q := url.Values{"x": {"1"}}
 	require.NoError(t, c.doJSON(context.Background(), httpMethodGet, "/ping", q, nil, &out))
 	assert.True(t, out.Ok)
+}
+
+func TestDoJSON_SelfHostedOSSAuthHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Equal(t, "k", r.Header.Get("X-API-Key"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := newClient(serviceOpts{apiKey: "k", apiMode: apiModeSelfHostedOSS, host: srv.URL})
+	require.NoError(t, err)
+	require.NoError(t, c.doJSON(context.Background(), httpMethodGet, "/ping", nil, nil, nil))
+}
+
+func TestDoJSON_SelfHostedOSSEmptyAPIKeySendsNoAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("X-API-Key"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := newClient(serviceOpts{apiMode: apiModeSelfHostedOSS, host: srv.URL})
+	require.NoError(t, err)
+	require.NoError(t, c.doJSON(context.Background(), httpMethodGet, "/ping", nil, nil, nil))
 }
 
 func TestDoJSON_PostMarshalsBodyAndSetsContentType(t *testing.T) {

--- a/memory/mem0/helpers.go
+++ b/memory/mem0/helpers.go
@@ -30,18 +30,22 @@ const (
 	metadataKeyTRPCParticipants = "trpc_participants"
 	metadataKeyTRPCLocation     = "trpc_location"
 
-	pathV1Memories = "/v1/memories/"
-	pathV2Search   = "/v2/memories/search/"
+	pathV1Memories  = "/v1/memories/"
+	pathV2Search    = "/v2/memories/search/"
+	pathOSSMemories = "/memories"
+	pathOSSSearch   = "/search"
 
 	queryKeyUserID   = "user_id"
 	queryKeyAppID    = "app_id"
 	queryKeyPage     = "page"
 	queryKeyPageSize = "page_size"
+	queryKeyTopK     = "top_k"
 
 	memoryUserRole = "user"
 
 	defaultListPageSize = 100
 	defaultSearchTopK   = 20
+	maxOSSListTopK      = 1000
 )
 
 func addOrgProjectQuery(q url.Values, opts serviceOpts) {
@@ -75,6 +79,41 @@ func addOrgProjectFilter(filters map[string]any, opts serviceOpts) {
 		andList = append(andList, map[string]any{"project_id": opts.projectID})
 	}
 	filters["AND"] = andList
+}
+
+func cloudSearchFilters(userKey memory.UserKey, opts serviceOpts) map[string]any {
+	filters := map[string]any{
+		"AND": []any{
+			map[string]any{queryKeyUserID: userKey.UserID},
+			map[string]any{queryKeyAppID: userKey.AppName},
+		},
+	}
+	addOrgProjectFilter(filters, opts)
+	return filters
+}
+
+func ossSearchFilters(userKey memory.UserKey) map[string]any {
+	return map[string]any{
+		queryKeyUserID:         userKey.UserID,
+		metadataKeyTRPCAppName: userKey.AppName,
+	}
+}
+
+func withTRPCAppMetadata(meta map[string]any, appName string) map[string]any {
+	out := cloneMetadata(meta)
+	if out == nil {
+		out = make(map[string]any, 1)
+	}
+	out[metadataKeyTRPCAppName] = appName
+	return out
+}
+
+func recordMatchesTRPCApp(rec *memoryRecord, appName string) bool {
+	if rec == nil || rec.Metadata == nil {
+		return false
+	}
+	v, ok := rec.Metadata[metadataKeyTRPCAppName].(string)
+	return ok && strings.TrimSpace(v) == appName
 }
 
 func parseMem0Times(rec *memoryRecord) parsedTimes {

--- a/memory/mem0/helpers.go
+++ b/memory/mem0/helpers.go
@@ -92,11 +92,14 @@ func cloudSearchFilters(userKey memory.UserKey, opts serviceOpts) map[string]any
 	return filters
 }
 
-func ossSearchFilters(userKey memory.UserKey) map[string]any {
-	return map[string]any{
-		queryKeyUserID:         userKey.UserID,
-		metadataKeyTRPCAppName: userKey.AppName,
+func ossSearchFilters(userKey memory.UserKey, includeUnscoped bool) map[string]any {
+	filters := map[string]any{
+		queryKeyUserID: userKey.UserID,
 	}
+	if !includeUnscoped {
+		filters[metadataKeyTRPCAppName] = userKey.AppName
+	}
+	return filters
 }
 
 func withTRPCAppMetadata(meta map[string]any, appName string) map[string]any {
@@ -108,12 +111,22 @@ func withTRPCAppMetadata(meta map[string]any, appName string) map[string]any {
 	return out
 }
 
-func recordMatchesTRPCApp(rec *memoryRecord, appName string) bool {
-	if rec == nil || rec.Metadata == nil {
+func recordMatchesTRPCApp(rec *memoryRecord, appName string, includeUnscoped bool) bool {
+	if rec == nil {
 		return false
 	}
-	v, ok := rec.Metadata[metadataKeyTRPCAppName].(string)
-	return ok && strings.TrimSpace(v) == appName
+	if rec.Metadata == nil {
+		return includeUnscoped
+	}
+	v, ok := rec.Metadata[metadataKeyTRPCAppName]
+	if !ok || v == nil {
+		return includeUnscoped
+	}
+	app, ok := v.(string)
+	if !ok {
+		return includeUnscoped
+	}
+	return strings.TrimSpace(app) == appName
 }
 
 func parseMem0Times(rec *memoryRecord) parsedTimes {

--- a/memory/mem0/ingest_worker.go
+++ b/memory/mem0/ingest_worker.go
@@ -35,6 +35,7 @@ type ingestJob struct {
 type ingestWorker struct {
 	c *client
 
+	apiMode   apiMode
 	asyncMode bool
 	version   string
 
@@ -68,6 +69,7 @@ func newIngestWorker(c *client, opts serviceOpts) *ingestWorker {
 	}
 	w := &ingestWorker{
 		c:         c,
+		apiMode:   opts.apiMode,
 		asyncMode: opts.asyncMode,
 		version:   opts.version,
 		timeout:   opts.memoryJobTimeout,
@@ -183,6 +185,9 @@ func (w *ingestWorker) ingest(
 	if len(apiMsgs) == 0 {
 		return nil
 	}
+	if w.apiMode == apiModeSelfHostedOSS {
+		return w.ingestOSS(ctx, userKey, apiMsgs, reqOpts)
+	}
 	req := createMemoryRequest{
 		Messages:  apiMsgs,
 		UserID:    userKey.UserID,
@@ -201,6 +206,23 @@ func (w *ingestWorker) ingest(
 		return err
 	}
 	return w.awaitQueuedEvents(ctx, events)
+}
+
+func (w *ingestWorker) ingestOSS(
+	ctx context.Context,
+	userKey memory.UserKey,
+	messages []apiMessage,
+	reqOpts session.IngestOptions,
+) error {
+	req := ossCreateMemoryRequest{
+		Messages: messages,
+		UserID:   userKey.UserID,
+		AgentID:  reqOpts.AgentID,
+		RunID:    reqOpts.RunID,
+		Metadata: withTRPCAppMetadata(reqOpts.Metadata, userKey.AppName),
+		Infer:    true,
+	}
+	return w.c.doJSON(ctx, httpMethodPost, pathOSSMemories, nil, req, nil)
 }
 
 func (w *ingestWorker) awaitQueuedEvents(ctx context.Context, events createMemoryEvents) error {

--- a/memory/mem0/ingest_worker_test.go
+++ b/memory/mem0/ingest_worker_test.go
@@ -10,6 +10,8 @@ package mem0
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -179,6 +181,42 @@ func TestIngestWorker_Ingest_CreatesAndTerminalStatus(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&createCalls))
+}
+
+func TestIngestWorker_IngestSelfHostedOSSUsesSyncCreate(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[{"id":"x","memory":"hi"}]}`))
+	})
+	w, _ := newWorkerWithServer(t, handler, serviceOpts{
+		apiMode:          apiModeSelfHostedOSS,
+		memoryJobTimeout: time.Second,
+	})
+
+	err := w.ingest(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "u"},
+		nil,
+		[]model.Message{{Role: model.RoleUser, Content: "hi"}},
+		session.IngestOptions{Metadata: map[string]any{"k": "v"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "/memories", gotPath)
+	assert.Equal(t, "u", gotBody["user_id"])
+	assert.Equal(t, true, gotBody["infer"])
+	assert.NotContains(t, gotBody, "app_id")
+	assert.NotContains(t, gotBody, "async_mode")
+	assert.NotContains(t, gotBody, "version")
+
+	meta, ok := gotBody["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "v", meta["k"])
+	assert.Equal(t, "app", meta[metadataKeyTRPCAppName])
 }
 
 func TestIngestWorker_AwaitIngestEvent_PollsUntilSuccess(t *testing.T) {

--- a/memory/mem0/options.go
+++ b/memory/mem0/options.go
@@ -23,9 +23,17 @@ const (
 	defaultMemoryJobTimeout = 30 * time.Second
 )
 
+type apiMode int
+
+const (
+	apiModeCloud apiMode = iota
+	apiModeSelfHostedOSS
+)
+
 type serviceOpts struct {
-	host   string
-	apiKey string
+	host    string
+	apiKey  string
+	apiMode apiMode
 
 	orgID     string
 	projectID string
@@ -49,6 +57,7 @@ func (o serviceOpts) clone() serviceOpts {
 
 var defaultOptions = serviceOpts{
 	host:             defaultHost,
+	apiMode:          apiModeCloud,
 	asyncMode:        true,
 	version:          "v2",
 	timeout:          defaultTimeout,
@@ -75,6 +84,16 @@ func WithAPIKey(apiKey string) ServiceOpt {
 		if apiKey != "" {
 			opts.apiKey = apiKey
 		}
+	}
+}
+
+// WithSelfHostedOSS switches the service to the self-hosted Mem0 OSS REST API.
+//
+// The option is explicit by design: WithHost alone may point to a cloud proxy,
+// a private gateway, or a test server and must not change API semantics.
+func WithSelfHostedOSS() ServiceOpt {
+	return func(opts *serviceOpts) {
+		opts.apiMode = apiModeSelfHostedOSS
 	}
 }
 

--- a/memory/mem0/options.go
+++ b/memory/mem0/options.go
@@ -45,7 +45,8 @@ type serviceOpts struct {
 	timeout time.Duration
 	client  *http.Client
 
-	loadToolEnabled bool
+	loadToolEnabled                      bool
+	includeUnscopedSelfHostedOSSMemories bool
 
 	asyncMemoryNum   int
 	memoryQueueSize  int
@@ -98,6 +99,17 @@ func WithSelfHostedOSS() ServiceOpt {
 		if opts.host == defaultHost {
 			opts.host = defaultSelfHostedOSSHost
 		}
+	}
+}
+
+// WithSelfHostedOSSIncludeUnscopedMemories allows self-hosted OSS reads and
+// searches to include legacy memories that do not carry trpc_app_name metadata.
+//
+// This is intended for migrations from an existing Mem0 OSS store. It does not
+// include memories explicitly tagged for a different app.
+func WithSelfHostedOSSIncludeUnscopedMemories() ServiceOpt {
+	return func(opts *serviceOpts) {
+		opts.includeUnscopedSelfHostedOSSMemories = true
 	}
 }
 

--- a/memory/mem0/options.go
+++ b/memory/mem0/options.go
@@ -16,11 +16,12 @@ import (
 )
 
 const (
-	defaultHost             = "https://api.mem0.ai"
-	defaultTimeout          = 10 * time.Second
-	defaultAsyncMemoryNum   = 1
-	defaultMemoryQueueSize  = 10
-	defaultMemoryJobTimeout = 30 * time.Second
+	defaultHost              = "https://api.mem0.ai"
+	defaultSelfHostedOSSHost = "http://localhost:8888"
+	defaultTimeout           = 10 * time.Second
+	defaultAsyncMemoryNum    = 1
+	defaultMemoryQueueSize   = 10
+	defaultMemoryJobTimeout  = 30 * time.Second
 )
 
 type apiMode int
@@ -94,6 +95,9 @@ func WithAPIKey(apiKey string) ServiceOpt {
 func WithSelfHostedOSS() ServiceOpt {
 	return func(opts *serviceOpts) {
 		opts.apiMode = apiModeSelfHostedOSS
+		if opts.host == defaultHost {
+			opts.host = defaultSelfHostedOSSHost
+		}
 	}
 }
 

--- a/memory/mem0/options_test.go
+++ b/memory/mem0/options_test.go
@@ -46,6 +46,11 @@ func TestWithSelfHostedOSS(t *testing.T) {
 	assert.Equal(t, customHost, apply(WithSelfHostedOSS(), WithHost(customHost)).host)
 }
 
+func TestWithSelfHostedOSSIncludeUnscopedMemories(t *testing.T) {
+	assert.False(t, apply().includeUnscopedSelfHostedOSSMemories)
+	assert.True(t, apply(WithSelfHostedOSSIncludeUnscopedMemories()).includeUnscopedSelfHostedOSSMemories)
+}
+
 func TestWithOrgProject(t *testing.T) {
 	got := apply(WithOrgProject("o", "p"))
 	assert.Equal(t, "o", got.orgID)

--- a/memory/mem0/options_test.go
+++ b/memory/mem0/options_test.go
@@ -36,7 +36,14 @@ func TestWithAPIKey(t *testing.T) {
 
 func TestWithSelfHostedOSS(t *testing.T) {
 	assert.Equal(t, apiModeCloud, apply().apiMode)
-	assert.Equal(t, apiModeSelfHostedOSS, apply(WithSelfHostedOSS()).apiMode)
+
+	got := apply(WithSelfHostedOSS())
+	assert.Equal(t, apiModeSelfHostedOSS, got.apiMode)
+	assert.Equal(t, defaultSelfHostedOSSHost, got.host)
+
+	customHost := "http://mem0.internal:8888"
+	assert.Equal(t, customHost, apply(WithHost(customHost), WithSelfHostedOSS()).host)
+	assert.Equal(t, customHost, apply(WithSelfHostedOSS(), WithHost(customHost)).host)
 }
 
 func TestWithOrgProject(t *testing.T) {

--- a/memory/mem0/options_test.go
+++ b/memory/mem0/options_test.go
@@ -34,6 +34,11 @@ func TestWithAPIKey(t *testing.T) {
 	assert.Equal(t, "k", apply(WithAPIKey("k")).apiKey)
 }
 
+func TestWithSelfHostedOSS(t *testing.T) {
+	assert.Equal(t, apiModeCloud, apply().apiMode)
+	assert.Equal(t, apiModeSelfHostedOSS, apply(WithSelfHostedOSS()).apiMode)
+}
+
 func TestWithOrgProject(t *testing.T) {
 	got := apply(WithOrgProject("o", "p"))
 	assert.Equal(t, "o", got.orgID)

--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -188,6 +188,9 @@ func (s *Service) readOSSMemories(ctx context.Context, userKey memory.UserKey, l
 	}
 	q := url.Values{}
 	q.Set(queryKeyUserID, userKey.UserID)
+	// The current OSS GET /memories API can only scope by user_id, run_id, or
+	// agent_id, not by metadata.trpc_app_name. Fetch the server-side cap and
+	// enforce app isolation locally as a best-effort view over those candidates.
 	q.Set(queryKeyTopK, itoa(maxOSSListTopK))
 
 	var batch listMemoriesResponse

--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -38,8 +38,13 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	for _, opt := range options {
 		opt(&opts)
 	}
-	if opts.apiMode == apiModeSelfHostedOSS && (opts.orgID != "" || opts.projectID != "") {
-		return nil, errors.New("mem0: org/project identifiers are not supported by self-hosted OSS")
+	if opts.apiMode == apiModeSelfHostedOSS {
+		if isCloudDefaultHost(opts.host) {
+			return nil, errors.New("mem0: self-hosted OSS cannot use the hosted platform default host")
+		}
+		if opts.orgID != "" || opts.projectID != "" {
+			return nil, errors.New("mem0: org/project identifiers are not supported by self-hosted OSS")
+		}
 	}
 	c, err := newClient(opts)
 	if err != nil {
@@ -49,6 +54,10 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	svc.ingestWorker = newIngestWorker(c, opts)
 	svc.precomputedTools = buildReadOnlyTools(svc)
 	return svc, nil
+}
+
+func isCloudDefaultHost(host string) bool {
+	return strings.TrimRight(host, "/") == strings.TrimRight(defaultHost, "/")
 }
 
 // Tools returns the mem0 read-only tools exposed to the agent.

--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -12,6 +12,7 @@ package mem0
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -179,6 +180,12 @@ func (s *Service) ReadMemories(ctx context.Context, userKey memory.UserKey, limi
 }
 
 func (s *Service) readOSSMemories(ctx context.Context, userKey memory.UserKey, limit int) ([]*memory.Entry, error) {
+	if limit <= 0 {
+		return nil, errors.New("mem0: self-hosted OSS ReadMemories requires a positive limit")
+	}
+	if limit > maxOSSListTopK {
+		return nil, fmt.Errorf("mem0: self-hosted OSS ReadMemories limit %d exceeds maximum %d", limit, maxOSSListTopK)
+	}
 	q := url.Values{}
 	q.Set(queryKeyUserID, userKey.UserID)
 	q.Set(queryKeyTopK, itoa(maxOSSListTopK))
@@ -190,7 +197,7 @@ func (s *Service) readOSSMemories(ctx context.Context, userKey memory.UserKey, l
 	entries := make([]*memory.Entry, 0, len(batch.Results))
 	for i := range batch.Results {
 		rec := &batch.Results[i]
-		if !recordMatchesTRPCApp(rec, userKey.AppName) {
+		if !recordMatchesTRPCApp(rec, userKey.AppName, s.opts.includeUnscopedSelfHostedOSSMemories) {
 			continue
 		}
 		if entry := toEntry(userKey.AppName, userKey.UserID, rec); entry != nil {
@@ -227,7 +234,7 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 	filters := cloudSearchFilters(userKey, s.opts)
 	if s.opts.apiMode == apiModeSelfHostedOSS {
 		path = pathOSSSearch
-		filters = ossSearchFilters(userKey)
+		filters = ossSearchFilters(userKey, s.opts.includeUnscopedSelfHostedOSSMemories)
 	}
 	req := searchV2Request{
 		Query:   searchOpts.Query,
@@ -251,7 +258,8 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 		if m.UpdatedAt != nil {
 			rec.UpdatedAt = *m.UpdatedAt
 		}
-		if s.opts.apiMode == apiModeSelfHostedOSS && !recordMatchesTRPCApp(&rec, userKey.AppName) {
+		if s.opts.apiMode == apiModeSelfHostedOSS &&
+			!recordMatchesTRPCApp(&rec, userKey.AppName, s.opts.includeUnscopedSelfHostedOSSMemories) {
 			continue
 		}
 		entry := toEntry(userKey.AppName, userKey.UserID, &rec)

--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -11,6 +11,7 @@ package mem0
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"sort"
 	"strings"
@@ -36,6 +37,9 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	opts := defaultOptions.clone()
 	for _, opt := range options {
 		opt(&opts)
+	}
+	if opts.apiMode == apiModeSelfHostedOSS && (opts.orgID != "" || opts.projectID != "") {
+		return nil, errors.New("mem0: org/project identifiers are not supported by self-hosted OSS")
 	}
 	c, err := newClient(opts)
 	if err != nil {
@@ -119,6 +123,9 @@ func (s *Service) ReadMemories(ctx context.Context, userKey memory.UserKey, limi
 	if err := userKey.CheckUserKey(); err != nil {
 		return nil, err
 	}
+	if s.opts.apiMode == apiModeSelfHostedOSS {
+		return s.readOSSMemories(ctx, userKey, limit)
+	}
 	pageSize := defaultListPageSize
 	if limit > 0 && limit < pageSize {
 		pageSize = limit
@@ -162,6 +169,37 @@ func (s *Service) ReadMemories(ctx context.Context, userKey memory.UserKey, limi
 	return entries, nil
 }
 
+func (s *Service) readOSSMemories(ctx context.Context, userKey memory.UserKey, limit int) ([]*memory.Entry, error) {
+	q := url.Values{}
+	q.Set(queryKeyUserID, userKey.UserID)
+	q.Set(queryKeyTopK, itoa(maxOSSListTopK))
+
+	var batch listMemoriesResponse
+	if err := s.c.doJSON(ctx, httpMethodGet, pathOSSMemories, q, nil, &batch); err != nil {
+		return nil, err
+	}
+	entries := make([]*memory.Entry, 0, len(batch.Results))
+	for i := range batch.Results {
+		rec := &batch.Results[i]
+		if !recordMatchesTRPCApp(rec, userKey.AppName) {
+			continue
+		}
+		if entry := toEntry(userKey.AppName, userKey.UserID, rec); entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].UpdatedAt.Equal(entries[j].UpdatedAt) {
+			return entries[i].CreatedAt.After(entries[j].CreatedAt)
+		}
+		return entries[i].UpdatedAt.After(entries[j].UpdatedAt)
+	})
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries, nil
+}
+
 // SearchMemories searches memories for a user.
 func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, query string, opts ...memory.SearchOption) ([]*memory.Entry, error) {
 	if err := userKey.CheckUserKey(); err != nil {
@@ -176,20 +214,19 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 	if searchOpts.MaxResults > 0 {
 		maxResults = searchOpts.MaxResults
 	}
-	filters := map[string]any{
-		"AND": []any{
-			map[string]any{queryKeyUserID: userKey.UserID},
-			map[string]any{queryKeyAppID: userKey.AppName},
-		},
+	path := pathV2Search
+	filters := cloudSearchFilters(userKey, s.opts)
+	if s.opts.apiMode == apiModeSelfHostedOSS {
+		path = pathOSSSearch
+		filters = ossSearchFilters(userKey)
 	}
-	addOrgProjectFilter(filters, s.opts)
 	req := searchV2Request{
 		Query:   searchOpts.Query,
 		Filters: filters,
 		TopK:    searchCandidateLimit(searchOpts, maxResults),
 	}
 	var resp searchV2Response
-	if err := s.c.doJSON(ctx, httpMethodPost, pathV2Search, nil, req, &resp); err != nil {
+	if err := s.c.doJSON(ctx, httpMethodPost, path, nil, req, &resp); err != nil {
 		return nil, err
 	}
 	results := make([]*memory.Entry, 0, len(resp.Memories))
@@ -204,6 +241,9 @@ func (s *Service) SearchMemories(ctx context.Context, userKey memory.UserKey, qu
 		}
 		if m.UpdatedAt != nil {
 			rec.UpdatedAt = *m.UpdatedAt
+		}
+		if s.opts.apiMode == apiModeSelfHostedOSS && !recordMatchesTRPCApp(&rec, userKey.AppName) {
+			continue
 		}
 		entry := toEntry(userKey.AppName, userKey.UserID, &rec)
 		if entry == nil {

--- a/memory/mem0/service_test.go
+++ b/memory/mem0/service_test.go
@@ -328,6 +328,7 @@ func TestReadMemories_SelfHostedOSSFiltersByAppMetadata(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"results":[
 			{"id":"a","memory":"keep","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-01T00:00:00Z"},
+			{"id":"legacy","memory":"drop legacy without metadata","created_at":"2024-01-02T00:00:00Z"},
 			{"id":"b","memory":"drop","metadata":{"trpc_app_name":"other"},"created_at":"2024-01-02T00:00:00Z"}
 		]}`))
 	})
@@ -346,6 +347,53 @@ func TestReadMemories_SelfHostedOSSFiltersByAppMetadata(t *testing.T) {
 	assert.Equal(t, "/memories", gotPath)
 	assert.Contains(t, gotQuery, "user_id=user")
 	assert.Contains(t, gotQuery, "top_k=")
+}
+
+func TestReadMemories_SelfHostedOSSCanIncludeUnscopedMemories(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/memories", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"app","memory":"keep app","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-03T00:00:00Z"},
+			{"id":"legacy-missing","memory":"keep legacy missing","created_at":"2024-01-02T00:00:00Z"},
+			{"id":"legacy-non-string","memory":"keep legacy non string","metadata":{"trpc_app_name":123},"created_at":"2024-01-01T00:00:00Z"},
+			{"id":"other","memory":"drop other app","metadata":{"trpc_app_name":"other"},"created_at":"2024-01-04T00:00:00Z"}
+		]}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(
+		WithSelfHostedOSS(),
+		WithHost(srv.URL),
+		WithSelfHostedOSSIncludeUnscopedMemories(),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	entries, err := svc.ReadMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "app", entries[0].ID)
+	assert.Equal(t, "legacy-missing", entries[1].ID)
+	assert.Equal(t, "legacy-non-string", entries[2].ID)
+}
+
+func TestReadMemories_SelfHostedOSSRejectsUnboundedLimit(t *testing.T) {
+	svc, err := NewService(WithSelfHostedOSS(), WithHost("http://localhost:8888"))
+	require.NoError(t, err)
+	defer svc.Close()
+
+	_, err = svc.ReadMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "positive limit")
+
+	_, err = svc.ReadMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, maxOSSListTopK+1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum")
 }
 
 func TestReadMemories_SelfHostedOSSBackendErrorPropagates(t *testing.T) {
@@ -516,4 +564,42 @@ func TestSearchMemories_SelfHostedOSSUsesMetadataFilter(t *testing.T) {
 		queryKeyUserID:         "user",
 		metadataKeyTRPCAppName: "app",
 	}, gotReq.Filters)
+}
+
+func TestSearchMemories_SelfHostedOSSCanIncludeUnscopedMemories(t *testing.T) {
+	var gotReq searchV2Request
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotReq))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"app","memory":"keep app","metadata":{"trpc_app_name":"app"},"score":0.9},
+			{"id":"legacy","memory":"keep legacy","score":0.8},
+			{"id":"other","memory":"drop other app","metadata":{"trpc_app_name":"other"},"score":1}
+		]}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(
+		WithSelfHostedOSS(),
+		WithHost(srv.URL),
+		WithAPIKey("oss-key"),
+		WithSelfHostedOSSIncludeUnscopedMemories(),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	got, err := svc.SearchMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, "query")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "app", got[0].ID)
+	assert.Equal(t, "legacy", got[1].ID)
+	assert.Equal(t, map[string]any{queryKeyUserID: "user"}, gotReq.Filters)
 }

--- a/memory/mem0/service_test.go
+++ b/memory/mem0/service_test.go
@@ -10,6 +10,8 @@ package mem0
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,6 +33,23 @@ import (
 func TestNewService_FailsWithoutAPIKey(t *testing.T) {
 	_, err := NewService()
 	assert.Error(t, err, "missing api key must fail")
+}
+
+func TestNewService_SelfHostedOSSAllowsEmptyAPIKey(t *testing.T) {
+	svc, err := NewService(WithSelfHostedOSS(), WithHost("http://localhost:8888"))
+	require.NoError(t, err)
+	defer svc.Close()
+	assert.Equal(t, apiModeSelfHostedOSS, svc.opts.apiMode)
+}
+
+func TestNewService_SelfHostedOSSRejectsOrgProject(t *testing.T) {
+	_, err := NewService(
+		WithSelfHostedOSS(),
+		WithHost("http://localhost:8888"),
+		WithOrgProject("org", "project"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "org/project")
 }
 
 func TestNewService_DefaultsToolsList(t *testing.T) {
@@ -289,6 +308,86 @@ func TestReadMemories_BackendErrorPropagates(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestReadMemories_SelfHostedOSSFiltersByAppMetadata(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"a","memory":"keep","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-01T00:00:00Z"},
+			{"id":"b","memory":"drop","metadata":{"trpc_app_name":"other"},"created_at":"2024-01-02T00:00:00Z"}
+		]}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(WithSelfHostedOSS(), WithHost(srv.URL))
+	require.NoError(t, err)
+	defer svc.Close()
+
+	entries, err := svc.ReadMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "a", entries[0].ID)
+	assert.Equal(t, "/memories", gotPath)
+	assert.Contains(t, gotQuery, "user_id=user")
+	assert.Contains(t, gotQuery, "top_k=")
+}
+
+func TestReadMemories_SelfHostedOSSBackendErrorPropagates(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/memories", r.URL.Path)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"detail":"upstream unavailable"}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(WithSelfHostedOSS(), WithHost(srv.URL))
+	require.NoError(t, err)
+	defer svc.Close()
+
+	_, err = svc.ReadMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, 10)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+}
+
+func TestReadMemories_SelfHostedOSSSortsLimitsAndSkipsInvalidRecords(t *testing.T) {
+	var gotQuery string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		assert.Equal(t, "/memories", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"older-update","memory":"older update","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-05T00:00:00Z","updated_at":"2024-01-06T00:00:00Z"},
+			{"id":"newer-update","memory":"newer update","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-07T00:00:00Z"},
+			{"id":"same-update-newer-created","memory":"same update newer created","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-06T00:00:00Z","updated_at":"2024-01-06T00:00:00Z"},
+			{"id":"wrong-app","memory":"drop wrong app","metadata":{"trpc_app_name":"other"},"created_at":"2024-01-08T00:00:00Z","updated_at":"2024-01-08T00:00:00Z"},
+			{"id":"","memory":"drop empty id","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-09T00:00:00Z","updated_at":"2024-01-09T00:00:00Z"},
+			{"id":"empty-memory","memory":"","metadata":{"trpc_app_name":"app"},"created_at":"2024-01-10T00:00:00Z","updated_at":"2024-01-10T00:00:00Z"}
+		]}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(WithSelfHostedOSS(), WithHost(srv.URL))
+	require.NoError(t, err)
+	defer svc.Close()
+
+	entries, err := svc.ReadMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, 2)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "newer-update", entries[0].ID)
+	assert.Equal(t, "same-update-newer-created", entries[1].ID)
+	assert.Contains(t, gotQuery, "user_id=user")
+	assert.Contains(t, gotQuery, "top_k=1000")
+}
+
 // --- SearchMemories ---
 
 func TestSearchMemories_InvalidUserKey(t *testing.T) {
@@ -371,4 +470,39 @@ func TestSearchMemories_BackendErrorPropagates(t *testing.T) {
 	_, err := svc.SearchMemories(context.Background(),
 		memory.UserKey{AppName: "a", UserID: "u"}, "q")
 	assert.Error(t, err)
+}
+
+func TestSearchMemories_SelfHostedOSSUsesMetadataFilter(t *testing.T) {
+	var gotReq searchV2Request
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotReq))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"keep","memory":"match","metadata":{"trpc_app_name":"app"},"score":0.9},
+			{"id":"drop","memory":"wrong app","metadata":{"trpc_app_name":"other"},"score":1}
+		]}`))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	svc, err := NewService(WithSelfHostedOSS(), WithHost(srv.URL), WithAPIKey("oss-key"))
+	require.NoError(t, err)
+	defer svc.Close()
+
+	got, err := svc.SearchMemories(context.Background(),
+		memory.UserKey{AppName: "app", UserID: "user"}, "query")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "keep", got[0].ID)
+	assert.Equal(t, "query", gotReq.Query)
+	assert.Equal(t, map[string]any{
+		queryKeyUserID:         "user",
+		metadataKeyTRPCAppName: "app",
+	}, gotReq.Filters)
 }

--- a/memory/mem0/service_test.go
+++ b/memory/mem0/service_test.go
@@ -36,10 +36,21 @@ func TestNewService_FailsWithoutAPIKey(t *testing.T) {
 }
 
 func TestNewService_SelfHostedOSSAllowsEmptyAPIKey(t *testing.T) {
-	svc, err := NewService(WithSelfHostedOSS(), WithHost("http://localhost:8888"))
+	svc, err := NewService(WithSelfHostedOSS())
 	require.NoError(t, err)
 	defer svc.Close()
 	assert.Equal(t, apiModeSelfHostedOSS, svc.opts.apiMode)
+	assert.Equal(t, defaultSelfHostedOSSHost, svc.opts.host)
+}
+
+func TestNewService_SelfHostedOSSRejectsCloudDefaultHost(t *testing.T) {
+	_, err := NewService(WithSelfHostedOSS(), WithHost(defaultHost))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default host")
+
+	_, err = NewService(WithSelfHostedOSS(), WithHost(defaultHost+"/"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default host")
 }
 
 func TestNewService_SelfHostedOSSRejectsOrgProject(t *testing.T) {

--- a/memory/mem0/types.go
+++ b/memory/mem0/types.go
@@ -33,6 +33,15 @@ type createMemoryRequest struct {
 	ProjectID string         `json:"project_id,omitempty"`
 }
 
+type ossCreateMemoryRequest struct {
+	Messages []apiMessage   `json:"messages"`
+	UserID   string         `json:"user_id,omitempty"`
+	AgentID  string         `json:"agent_id,omitempty"`
+	RunID    string         `json:"run_id,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Infer    bool           `json:"infer"`
+}
+
 type createMemoryEvent struct {
 	ID      string `json:"id"`
 	EventID string `json:"event_id"`
@@ -126,12 +135,18 @@ func (r *searchV2Response) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	type rawSearchV2Response searchV2Response
-	var wrapped rawSearchV2Response
+	var wrapped struct {
+		Memories []searchMemoryRecord `json:"memories"`
+		Results  []searchMemoryRecord `json:"results"`
+	}
 	if err := json.Unmarshal(data, &wrapped); err != nil {
 		return err
 	}
-	*r = searchV2Response(wrapped)
+	if wrapped.Memories != nil {
+		r.Memories = wrapped.Memories
+		return nil
+	}
+	r.Memories = wrapped.Results
 	return nil
 }
 

--- a/memory/mem0/types_test.go
+++ b/memory/mem0/types_test.go
@@ -77,6 +77,14 @@ func TestSearchV2Response_UnmarshalWrapped(t *testing.T) {
 	require.Len(t, resp.Memories, 1)
 }
 
+func TestSearchV2Response_UnmarshalOSSResults(t *testing.T) {
+	var resp searchV2Response
+	require.NoError(t, resp.UnmarshalJSON([]byte(`{"results":[{"id":"a","memory":"m","score":0.5}]}`)))
+	require.Len(t, resp.Memories, 1)
+	assert.Equal(t, "a", resp.Memories[0].ID)
+	assert.Equal(t, "m", resp.Memories[0].Memory)
+}
+
 func TestSearchV2Response_UnmarshalInvalid(t *testing.T) {
 	var resp searchV2Response
 	assert.Error(t, resp.UnmarshalJSON([]byte(`not-json`)))


### PR DESCRIPTION
## Summary

- Add explicit `mem0.WithSelfHostedOSS()` mode for Mem0 OSS REST server.
- Route OSS ingest/read/search through OSS-compatible `/memories` and `/search` APIs.
- Support OSS auth with optional empty key for local `AUTH_DISABLED=true`, or `X-API-Key` when a key is provided.
- Emulate app isolation by writing and filtering `metadata.trpc_app_name`.
- Reject `WithOrgProject` in OSS mode because org/project isolation is cloud-only.
- Update docs and the Mem0 example for self-hosted OSS usage.

## Root Cause

Mem0 OSS is the self-hosted local deployment of Mem0. Also, this change is only enabled explicitly via mem0.WithSelfHostedOSS(), so existing Mem0 Cloud users keep the current default behavior unchanged.
This change is also intented for following changes in `trpc-agent-go-benchmark`.

## Validation

- `go test ./memory/mem0 -coverprofile=/tmp/mem0.out
- `CGO_CFLAGS=-DSQLITE_INNOCUOUS=0x000200000 GOCACHE=/tmp/go-build-cache-mem0-oss go test ./...`