### PR TITLE
tool/file: handle nil list and search requests

### DIFF
--- a/tool/file/listfile.go
+++ b/tool/file/listfile.go
@@ -55,8 +55,13 @@ func (f *fileToolSet) listFile(
 ) (*listFileResponse, error) {
 	rsp := &listFileResponse{
 		BaseDirectory: f.baseDir,
-		Path:          req.Path,
 	}
+	if req == nil {
+		err := fmt.Errorf("request cannot be nil")
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return rsp, err
+	}
+	rsp.Path = req.Path
 
 	ref, err := fileref.Parse(req.Path)
 	if err != nil {

--- a/tool/file/listfile_test.go
+++ b/tool/file/listfile_test.go
@@ -49,6 +49,16 @@ func TestFileTool_listFile(t *testing.T) {
 	assert.Equal(t, 0, len(rsp.Folders))
 }
 
+func TestFileTool_listFile_NilRequest(t *testing.T) {
+	fileToolSet := &fileToolSet{baseDir: t.TempDir()}
+
+	rsp, err := fileToolSet.listFile(context.Background(), nil)
+
+	assert.Error(t, err)
+	assert.NotNil(t, rsp)
+	assert.Contains(t, rsp.Message, "request cannot be nil")
+}
+
 func TestFileTool_listFile_Subdirectory(t *testing.T) {
 	// Create a temporary directory for testing.
 	tempDir := t.TempDir()

--- a/tool/file/searchfile.go
+++ b/tool/file/searchfile.go
@@ -49,9 +49,14 @@ func (f *fileToolSet) searchFile(
 ) (*searchFileResponse, error) {
 	rsp := &searchFileResponse{
 		BaseDirectory: f.baseDir,
-		Path:          req.Path,
-		Pattern:       req.Pattern,
 	}
+	if req == nil {
+		err := fmt.Errorf("request cannot be nil")
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return rsp, err
+	}
+	rsp.Path = req.Path
+	rsp.Pattern = req.Pattern
 	// Validate pattern
 	if req.Pattern == "" {
 		rsp.Message = "Error: pattern cannot be empty"

--- a/tool/file/searchfile_test.go
+++ b/tool/file/searchfile_test.go
@@ -281,6 +281,16 @@ func TestFileTool_SearchFile(t *testing.T) {
 	}
 }
 
+func TestFileTool_SearchFile_NilRequest(t *testing.T) {
+	fileToolSet := &fileToolSet{baseDir: t.TempDir()}
+
+	rsp, err := fileToolSet.searchFile(context.Background(), nil)
+
+	assert.Error(t, err)
+	assert.NotNil(t, rsp)
+	assert.Contains(t, rsp.Message, "request cannot be nil")
+}
+
 func TestFileTool_SearchFile_WorkspaceRef(t *testing.T) {
 	fileToolSet := &fileToolSet{baseDir: t.TempDir()}
 


### PR DESCRIPTION
## What changed

`list_file` and `search_file` now return the same structured nil-request error as the other file tools instead of panicking.

## Why

The handlers built their response from `req.Path` / `req.Pattern` before checking whether the request was nil.

## Testing

`go test ./tool/file`

## Notes for reviewers

Release notes: NONE
