### PR TITLE
codeexecutor, agent/llmagent: make workspace registry pluggable via WorkspaceAcquirer

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -75,8 +75,8 @@ type LLMAgent struct {
 	userToolNames           map[string]bool // Names of tools explicitly registered
 	// via WithTools and WithToolSets.
 	codeExecutor         codeexecutor.CodeExecutor
-	workspaceRegistry    *codeexecutor.WorkspaceRegistry
-	workspaceRegistries  map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry
+	workspaceRegistry    codeexecutor.WorkspaceAcquirer
+	workspaceRegistries  map[workspaceRegistryKey]codeexecutor.WorkspaceAcquirer
 	planner              planner.Planner
 	subAgents            []agent.Agent // Sub-agents that can be delegated to
 	agentCallbacks       *agent.Callbacks
@@ -785,8 +785,8 @@ func initializeModels(options *Options) (model.Model, map[string]model.Model) {
 // should be stored on the agent for future reuse.
 func registerTools(
 	options *Options,
-	existingReg *codeexecutor.WorkspaceRegistry,
-) ([]tool.Tool, map[string]bool, *codeexecutor.WorkspaceRegistry) {
+	existingReg codeexecutor.WorkspaceAcquirer,
+) ([]tool.Tool, map[string]bool, codeexecutor.WorkspaceAcquirer) {
 	// Step 1: collect user-registered tools (WithTools + WithToolSets)
 	// and knowledge search tools.
 	userToolNames := collectUserToolNames(options.Tools)
@@ -811,6 +811,9 @@ func registerTools(
 	//      no skill_run needed.
 	var runTool *toolskill.RunTool
 	workspaceRegistry := existingReg
+	if workspaceRegistry == nil {
+		workspaceRegistry = options.workspaceRegistry
+	}
 	if options.skillsRepository != nil {
 		if options.codeExecutor != nil && workspaceRegistry == nil {
 			workspaceRegistry = buildWorkspaceRegistry()
@@ -940,7 +943,7 @@ func appendSkillToolsWithRepo(
 	allTools []tool.Tool,
 	options *Options,
 	repo skill.Repository,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 	runTool *toolskill.RunTool,
 ) []tool.Tool {
 	var exec codeexecutor.CodeExecutor
@@ -962,7 +965,7 @@ func appendSkillToolsWithRepoAndFlags(
 	allTools []tool.Tool,
 	options *Options,
 	repo skill.Repository,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 	runTool *toolskill.RunTool,
 	exec codeexecutor.CodeExecutor,
 	skillFlags skillprofile.Flags,
@@ -1080,7 +1083,7 @@ func mustResolveSkillToolFlagsWithExecutor(
 func appendWorkspaceExecTool(
 	allTools []tool.Tool,
 	options *Options,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 	inv *agent.Invocation,
 ) []tool.Tool {
 	var exec codeexecutor.CodeExecutor
@@ -1116,7 +1119,7 @@ func appendWorkspaceExecToolWithExecutor(
 	exec codeexecutor.CodeExecutor,
 	enabled bool,
 	sessional bool,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 	inv *agent.Invocation,
 	options *Options,
 	loadedSkillsRepo skill.Repository,
@@ -1196,7 +1199,7 @@ func appendOnDemandSessionTools(
 	return allTools
 }
 
-func buildWorkspaceRegistry() *codeexecutor.WorkspaceRegistry {
+func buildWorkspaceRegistry() codeexecutor.WorkspaceAcquirer {
 	return codeexecutor.NewWorkspaceRegistry()
 }
 
@@ -1218,8 +1221,8 @@ func workspaceRegistryKeyForExecutor(
 
 func workspaceRegistryMap(
 	exec codeexecutor.CodeExecutor,
-	reg *codeexecutor.WorkspaceRegistry,
-) map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry {
+	reg codeexecutor.WorkspaceAcquirer,
+) map[workspaceRegistryKey]codeexecutor.WorkspaceAcquirer {
 	if reg == nil {
 		return nil
 	}
@@ -1227,14 +1230,14 @@ func workspaceRegistryMap(
 	if !ok {
 		return nil
 	}
-	return map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry{
+	return map[workspaceRegistryKey]codeexecutor.WorkspaceAcquirer{
 		key: reg,
 	}
 }
 
 func (a *LLMAgent) ensureWorkspaceRegistryForExecutor(
 	exec codeexecutor.CodeExecutor,
-) (*codeexecutor.WorkspaceRegistry, bool) {
+) (codeexecutor.WorkspaceAcquirer, bool) {
 	key, ok := workspaceRegistryKeyForExecutor(exec)
 	if !ok {
 		return nil, false
@@ -1246,9 +1249,9 @@ func (a *LLMAgent) ensureWorkspaceRegistryForExecutor(
 
 func (a *LLMAgent) workspaceRegistryForKeyLocked(
 	key workspaceRegistryKey,
-) *codeexecutor.WorkspaceRegistry {
+) codeexecutor.WorkspaceAcquirer {
 	if a.workspaceRegistries == nil {
-		a.workspaceRegistries = make(map[workspaceRegistryKey]*codeexecutor.WorkspaceRegistry)
+		a.workspaceRegistries = make(map[workspaceRegistryKey]codeexecutor.WorkspaceAcquirer)
 		if a.workspaceRegistry != nil {
 			if defaultKey, ok := workspaceRegistryKeyForExecutor(a.codeExecutor); ok {
 				a.workspaceRegistries[defaultKey] = a.workspaceRegistry
@@ -1269,7 +1272,10 @@ func (a *LLMAgent) workspaceRegistryForKeyLocked(
 func (a *LLMAgent) workspaceRegistryForInvocation(
 	inv *agent.Invocation,
 	exec codeexecutor.CodeExecutor,
-) *codeexecutor.WorkspaceRegistry {
+) codeexecutor.WorkspaceAcquirer {
+	if a.option.workspaceRegistry != nil {
+		return a.option.workspaceRegistry
+	}
 	if inv == nil || inv.Session == nil || inv.Session.ID == "" {
 		return buildWorkspaceRegistry()
 	}
@@ -1316,7 +1322,7 @@ func workspacePrepOptions(
 
 func buildSkillRunTool(
 	options *Options,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 ) *toolskill.RunTool {
 	return buildSkillRunToolWithRepo(
 		options,
@@ -1329,7 +1335,7 @@ func buildSkillRunTool(
 func buildSkillRunToolWithRepo(
 	options *Options,
 	repo skill.Repository,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 	exec codeexecutor.CodeExecutor,
 ) *toolskill.RunTool {
 	if exec == nil && options != nil {

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1273,11 +1273,11 @@ func (a *LLMAgent) workspaceRegistryForInvocation(
 	inv *agent.Invocation,
 	exec codeexecutor.CodeExecutor,
 ) codeexecutor.WorkspaceAcquirer {
-	if a.option.workspaceRegistry != nil {
-		return a.option.workspaceRegistry
-	}
 	if inv == nil || inv.Session == nil || inv.Session.ID == "" {
 		return buildWorkspaceRegistry()
+	}
+	if a.option.workspaceRegistry != nil {
+		return a.option.workspaceRegistry
 	}
 	if reg, ok := a.ensureWorkspaceRegistryForExecutor(exec); ok {
 		return reg

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -812,7 +812,7 @@ func registerTools(
 	var runTool *toolskill.RunTool
 	workspaceRegistry := existingReg
 	if workspaceRegistry == nil {
-		workspaceRegistry = options.workspaceRegistry
+		workspaceRegistry = options.workspaceAcquirer
 	}
 	if options.skillsRepository != nil {
 		if options.codeExecutor != nil && workspaceRegistry == nil {
@@ -1128,7 +1128,7 @@ func appendWorkspaceExecToolWithExecutor(
 		return allTools
 	}
 	toolOpts := []func(*toolworkspaceexec.ExecTool){
-		toolworkspaceexec.WithWorkspaceRegistry(reg),
+		toolworkspaceexec.WithWorkspaceAcquirer(reg),
 	}
 	toolOpts = append(
 		toolOpts,
@@ -1276,8 +1276,8 @@ func (a *LLMAgent) workspaceRegistryForInvocation(
 	if inv == nil || inv.Session == nil || inv.Session.ID == "" {
 		return buildWorkspaceRegistry()
 	}
-	if a.option.workspaceRegistry != nil {
-		return a.option.workspaceRegistry
+	if a.option.workspaceAcquirer != nil {
+		return a.option.workspaceAcquirer
 	}
 	if reg, ok := a.ensureWorkspaceRegistryForExecutor(exec); ok {
 		return reg
@@ -1384,7 +1384,7 @@ func buildSkillRunToolWithRepo(
 		)
 	}
 	if reg != nil {
-		runOpts = append(runOpts, toolskill.WithWorkspaceRegistry(reg))
+		runOpts = append(runOpts, toolskill.WithWorkspaceAcquirer(reg))
 	}
 
 	return toolskill.NewRunTool(
@@ -1712,7 +1712,7 @@ func (a *LLMAgent) withWorkspace(
 		return ctx
 	}
 	reg := a.workspaceRegistryForInvocation(inv, exec)
-	ws := workspaceio.New(exec, reg)
+	ws := workspaceio.NewWithAcquirer(exec, reg)
 	return workspaceio.WithWorkspace(ctx, ws)
 }
 

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -495,7 +495,7 @@ func TestLLMAgent_RefreshToolsLocked_ReusesExecutorRegistry(t *testing.T) {
 	a.refreshToolsLocked()
 	key, ok := workspaceRegistryKeyForExecutor(exec)
 	refreshedReg := a.workspaceRegistry
-	var cachedReg *codeexecutor.WorkspaceRegistry
+	var cachedReg codeexecutor.WorkspaceAcquirer
 	if ok {
 		cachedReg = a.workspaceRegistries[key]
 	}
@@ -505,6 +505,57 @@ func TestLLMAgent_RefreshToolsLocked_ReusesExecutorRegistry(t *testing.T) {
 	require.Same(t, initialReg, refreshedReg)
 	require.Same(t, initialReg, cachedReg)
 	require.NotNil(t, findTool(a.Tools(), "workspace_exec"))
+}
+
+// fakeAcquirer is a WorkspaceAcquirer that records the ids it resolves and
+// delegates to an in-memory registry, used to verify WithWorkspaceRegistry
+// wiring.
+type fakeAcquirer struct {
+	inner *codeexecutor.WorkspaceRegistry
+	ids   []string
+}
+
+func (f *fakeAcquirer) Acquire(
+	ctx context.Context,
+	m codeexecutor.WorkspaceManager,
+	id string,
+) (codeexecutor.Workspace, error) {
+	f.ids = append(f.ids, id)
+	return f.inner.Acquire(ctx, m, id)
+}
+
+func TestWithWorkspaceRegistry_UsesSuppliedAcquirer(t *testing.T) {
+	exec := &stubExec{}
+	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
+
+	a := New("tester", WithCodeExecutor(exec), WithWorkspaceRegistry(custom))
+
+	// The supplied acquirer replaces the default in-memory registry both at
+	// construction and on the invocation-scoped resolution path.
+	require.Same(t, custom, a.workspaceRegistry)
+	require.Same(t, custom, a.workspaceRegistryForInvocation(nil, exec))
+}
+
+func TestWithWorkspaceRegistry_AcquireInvokedDuringRun(t *testing.T) {
+	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
+	a := New(
+		"tester",
+		WithCodeExecutor(localexec.New()),
+		WithWorkspaceRegistry(custom),
+	)
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("write")),
+		agent.WithInvocationSession(&session.Session{ID: "sess-custom"}),
+	)
+	out := callInvocationWorkspaceExec(
+		t, a, inv, "mkdir -p out && printf hi > out/x.txt",
+	)
+
+	// The supplied acquirer is the one that actually resolved the workspace,
+	// keyed by the invocation session.
+	require.Equal(t, float64(0), out["exit_code"])
+	require.Contains(t, custom.ids, "sess-custom")
 }
 
 func callInvocationWorkspaceExec(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -524,11 +524,11 @@ func (f *fakeAcquirer) Acquire(
 	return f.inner.Acquire(ctx, m, id)
 }
 
-func TestWithWorkspaceRegistry_UsesSuppliedAcquirer(t *testing.T) {
+func TestWithWorkspaceAcquirer_UsesSuppliedAcquirer(t *testing.T) {
 	exec := &stubExec{}
 	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
 
-	a := New("tester", WithCodeExecutor(exec), WithWorkspaceRegistry(custom))
+	a := New("tester", WithCodeExecutor(exec), WithWorkspaceAcquirer(custom))
 	require.Same(t, custom, a.workspaceRegistry)
 
 	inv := agent.NewInvocation(
@@ -542,12 +542,12 @@ func TestWithWorkspaceRegistry_UsesSuppliedAcquirer(t *testing.T) {
 	require.NotSame(t, noSession1, noSession2)
 }
 
-func TestWithWorkspaceRegistry_AcquireInvokedDuringRun(t *testing.T) {
+func TestWithWorkspaceAcquirer_AcquireInvokedDuringRun(t *testing.T) {
 	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
 	a := New(
 		"tester",
 		WithCodeExecutor(localexec.New()),
-		WithWorkspaceRegistry(custom),
+		WithWorkspaceAcquirer(custom),
 	)
 
 	inv := agent.NewInvocation(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -529,11 +529,13 @@ func TestWithWorkspaceRegistry_UsesSuppliedAcquirer(t *testing.T) {
 	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
 
 	a := New("tester", WithCodeExecutor(exec), WithWorkspaceRegistry(custom))
-
-	// The supplied acquirer replaces the default in-memory registry both at
-	// construction and on the invocation-scoped resolution path.
 	require.Same(t, custom, a.workspaceRegistry)
-	require.Same(t, custom, a.workspaceRegistryForInvocation(nil, exec))
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "s1"}),
+	)
+	require.Same(t, custom, a.workspaceRegistryForInvocation(inv, exec))
+	require.NotSame(t, custom, a.workspaceRegistryForInvocation(nil, exec))
 }
 
 func TestWithWorkspaceRegistry_AcquireInvokedDuringRun(t *testing.T) {
@@ -556,6 +558,30 @@ func TestWithWorkspaceRegistry_AcquireInvokedDuringRun(t *testing.T) {
 	// keyed by the invocation session.
 	require.Equal(t, float64(0), out["exit_code"])
 	require.Contains(t, custom.ids, "sess-custom")
+}
+
+func TestWithWorkspaceRegistry_NoSessionRunsStayIsolated(t *testing.T) {
+	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
+	a := New(
+		"tester",
+		WithCodeExecutor(localexec.New()),
+		WithWorkspaceRegistry(custom),
+	)
+
+	inv1 := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("write")),
+	)
+	out := callInvocationWorkspaceExec(
+		t, a, inv1, "mkdir -p out && printf leaked > out/leak.txt",
+	)
+	require.Equal(t, float64(0), out["exit_code"])
+
+	inv2 := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("read")),
+	)
+	out = callInvocationWorkspaceExec(t, a, inv2, "cat out/leak.txt")
+	require.NotEqual(t, float64(0), out["exit_code"])
+	require.NotContains(t, out["output"], "leaked")
 }
 
 func callInvocationWorkspaceExec(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -542,6 +542,18 @@ func TestWithWorkspaceAcquirer_UsesSuppliedAcquirer(t *testing.T) {
 	require.NotSame(t, noSession1, noSession2)
 }
 
+func TestWithWorkspaceAcquirer_TypedNilKeepsSharedDefault(t *testing.T) {
+	var typedNil *codeexecutor.WorkspaceRegistry
+	exec := &stubExec{}
+	a := New("tester", WithCodeExecutor(exec), WithWorkspaceAcquirer(typedNil))
+
+	// A typed-nil acquirer is normalized to a true nil, so the shared default
+	// registry that connects skill_run and workspace_exec is still built
+	// instead of leaving each tool on its own private registry.
+	require.NotNil(t, a.workspaceRegistry)
+	require.NotNil(t, a.workspaceRegistryForInvocation(nil, exec))
+}
+
 func TestWithWorkspaceAcquirer_AcquireInvokedDuringRun(t *testing.T) {
 	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
 	a := New(

--- a/agent/llmagent/llm_agent_skill_test.go
+++ b/agent/llmagent/llm_agent_skill_test.go
@@ -535,7 +535,11 @@ func TestWithWorkspaceRegistry_UsesSuppliedAcquirer(t *testing.T) {
 		agent.WithInvocationSession(&session.Session{ID: "s1"}),
 	)
 	require.Same(t, custom, a.workspaceRegistryForInvocation(inv, exec))
-	require.NotSame(t, custom, a.workspaceRegistryForInvocation(nil, exec))
+
+	noSession1 := a.workspaceRegistryForInvocation(nil, exec)
+	noSession2 := a.workspaceRegistryForInvocation(nil, exec)
+	require.NotSame(t, custom, noSession1)
+	require.NotSame(t, noSession1, noSession2)
 }
 
 func TestWithWorkspaceRegistry_AcquireInvokedDuringRun(t *testing.T) {
@@ -558,30 +562,6 @@ func TestWithWorkspaceRegistry_AcquireInvokedDuringRun(t *testing.T) {
 	// keyed by the invocation session.
 	require.Equal(t, float64(0), out["exit_code"])
 	require.Contains(t, custom.ids, "sess-custom")
-}
-
-func TestWithWorkspaceRegistry_NoSessionRunsStayIsolated(t *testing.T) {
-	custom := &fakeAcquirer{inner: codeexecutor.NewWorkspaceRegistry()}
-	a := New(
-		"tester",
-		WithCodeExecutor(localexec.New()),
-		WithWorkspaceRegistry(custom),
-	)
-
-	inv1 := agent.NewInvocation(
-		agent.WithInvocationMessage(model.NewUserMessage("write")),
-	)
-	out := callInvocationWorkspaceExec(
-		t, a, inv1, "mkdir -p out && printf leaked > out/leak.txt",
-	)
-	require.Equal(t, float64(0), out["exit_code"])
-
-	inv2 := agent.NewInvocation(
-		agent.WithInvocationMessage(model.NewUserMessage("read")),
-	)
-	out = callInvocationWorkspaceExec(t, a, inv2, "cat out/leak.txt")
-	require.NotEqual(t, float64(0), out["exit_code"])
-	require.NotContains(t, out["output"], "leaked")
 }
 
 func callInvocationWorkspaceExec(

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -574,6 +574,11 @@ type Options struct {
 	// commands run. When non-empty it is converted into a Provider
 	// and attached to workspace_exec.
 	workspaceBootstrap codeexecutor.WorkspaceBootstrapSpec
+	// workspaceRegistry, when set, resolves session workspaces for
+	// skill_run and workspace_exec instead of the default in-memory
+	// registry. Supply a shared implementation to make several agent
+	// instances resolve the same session id to the same workspace.
+	workspaceRegistry codeexecutor.WorkspaceAcquirer
 	// disableWorkspacePreparers keeps workspace_exec on the legacy
 	// StageConversationFiles-only path even when a skills repo or
 	// bootstrap spec is configured. Useful for tests and for users
@@ -1378,6 +1383,24 @@ func WithWorkspaceBootstrap(
 ) Option {
 	return func(opts *Options) {
 		opts.workspaceBootstrap = spec
+	}
+}
+
+// WithWorkspaceRegistry supplies the registry used to resolve session
+// workspaces for skill_run and workspace_exec. By default the agent uses a
+// process-local in-memory registry, which is enough for a single instance.
+//
+// Pass a shared implementation of codeexecutor.WorkspaceAcquirer when running
+// several agent instances behind a load balancer so that requests for the
+// same session resolve to the same workspace regardless of which instance
+// handles them. The supplied registry owns its cross-instance coordination;
+// the executor backend must still make the resolved workspace reachable from
+// the handling instance.
+func WithWorkspaceRegistry(
+	reg codeexecutor.WorkspaceAcquirer,
+) Option {
+	return func(opts *Options) {
+		opts.workspaceRegistry = reg
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillprofile"
 	"trpc.group/trpc-go/trpc-agent-go/internal/structuredoutput"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspacesession"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -1400,7 +1401,7 @@ func WithWorkspaceAcquirer(
 	reg codeexecutor.WorkspaceAcquirer,
 ) Option {
 	return func(opts *Options) {
-		opts.workspaceAcquirer = reg
+		opts.workspaceAcquirer = workspacesession.NormalizeAcquirer(reg)
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -574,11 +574,11 @@ type Options struct {
 	// commands run. When non-empty it is converted into a Provider
 	// and attached to workspace_exec.
 	workspaceBootstrap codeexecutor.WorkspaceBootstrapSpec
-	// workspaceRegistry, when set, resolves session workspaces for
+	// workspaceAcquirer, when set, resolves session workspaces for
 	// skill_run and workspace_exec instead of the default in-memory
 	// registry. Supply a shared implementation to make several agent
 	// instances resolve the same session id to the same workspace.
-	workspaceRegistry codeexecutor.WorkspaceAcquirer
+	workspaceAcquirer codeexecutor.WorkspaceAcquirer
 	// disableWorkspacePreparers keeps workspace_exec on the legacy
 	// StageConversationFiles-only path even when a skills repo or
 	// bootstrap spec is configured. Useful for tests and for users
@@ -1386,7 +1386,7 @@ func WithWorkspaceBootstrap(
 	}
 }
 
-// WithWorkspaceRegistry supplies the registry used to resolve session
+// WithWorkspaceAcquirer supplies the registry used to resolve session
 // workspaces for skill_run and workspace_exec. By default the agent uses a
 // process-local in-memory registry, which is enough for a single instance.
 //
@@ -1396,11 +1396,11 @@ func WithWorkspaceBootstrap(
 // handles them. The supplied registry owns its cross-instance coordination;
 // the executor backend must still make the resolved workspace reachable from
 // the handling instance.
-func WithWorkspaceRegistry(
+func WithWorkspaceAcquirer(
 	reg codeexecutor.WorkspaceAcquirer,
 ) Option {
 	return func(opts *Options) {
-		opts.workspaceRegistry = reg
+		opts.workspaceAcquirer = reg
 	}
 }
 

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -293,7 +293,7 @@ func (a *LLMAgent) InvocationToolSurface(
 		codeExecutorSupportsWorkspaceExec(effectiveExec)
 	workspaceExecSessions := workspaceExecEnabled &&
 		codeExecutorSupportsWorkspaceExecSessions(effectiveExec)
-	var workspaceRegistry *codeexecutor.WorkspaceRegistry
+	var workspaceRegistry codeexecutor.WorkspaceAcquirer
 	if effectiveSkills != nil && effectiveExec != nil {
 		workspaceRegistry = a.workspaceRegistryForInvocation(inv, effectiveExec)
 	} else if workspaceExecEnabled {

--- a/codeexecutor/registry.go
+++ b/codeexecutor/registry.go
@@ -14,8 +14,26 @@ import (
 	"sync"
 )
 
+// WorkspaceAcquirer resolves a logical id to a workspace, creating it on
+// first use and returning the same workspace for later calls with that id.
+//
+// WorkspaceRegistry is the default, process-local in-memory implementation.
+// Applications that run several agent instances behind a load balancer can
+// supply their own implementation (for example one backed by a shared store)
+// so that every instance resolves the same session id to the same workspace;
+// such an implementation owns its cross-instance coordination.
+//
+// A shared acquirer only settles the logical id -> workspace mapping. The
+// executor backend must still make the returned workspace usable from the
+// instance handling the request, for example via sticky routing or a remote
+// sandbox backend.
+type WorkspaceAcquirer interface {
+	Acquire(ctx context.Context, m WorkspaceManager, id string) (Workspace, error)
+}
+
 // WorkspaceRegistry keeps a process-level mapping of logical IDs to
-// created workspaces for reuse within a session.
+// created workspaces for reuse within a session. It is the default
+// implementation of WorkspaceAcquirer.
 type WorkspaceRegistry struct {
 	mu       sync.Mutex
 	byID     map[string]Workspace
@@ -27,6 +45,9 @@ type workspaceCreateCall struct {
 	ws   Workspace
 	err  error
 }
+
+// WorkspaceRegistry is the default WorkspaceAcquirer implementation.
+var _ WorkspaceAcquirer = (*WorkspaceRegistry)(nil)
 
 // NewWorkspaceRegistry creates a new in-memory registry.
 func NewWorkspaceRegistry() *WorkspaceRegistry {

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -132,7 +132,7 @@ type Workspace struct {
 // configured" without a panic.
 func New(
 	exec codeexecutor.CodeExecutor,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 ) *Workspace {
 	if exec == nil {
 		return nil

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -132,6 +132,20 @@ type Workspace struct {
 // configured" without a panic.
 func New(
 	exec codeexecutor.CodeExecutor,
+	reg *codeexecutor.WorkspaceRegistry,
+) *Workspace {
+	if reg == nil {
+		return NewWithAcquirer(exec, nil)
+	}
+	return NewWithAcquirer(exec, reg)
+}
+
+// NewWithAcquirer is the interface-based form of New. Pass a custom
+// codeexecutor.WorkspaceAcquirer to resolve session workspaces through it
+// instead of the default in-memory registry. Like New, it returns nil when
+// exec is nil.
+func NewWithAcquirer(
+	exec codeexecutor.CodeExecutor,
 	reg codeexecutor.WorkspaceAcquirer,
 ) *Workspace {
 	if exec == nil {

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -134,9 +134,6 @@ func New(
 	exec codeexecutor.CodeExecutor,
 	reg *codeexecutor.WorkspaceRegistry,
 ) *Workspace {
-	if reg == nil {
-		return NewWithAcquirer(exec, nil)
-	}
 	return NewWithAcquirer(exec, reg)
 }
 

--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -972,6 +972,45 @@ For lower-level (non-shell) skill execution, the equivalent knobs on
 `skill_run` are `WithSkillRunAllowedCommands` /
 `WithSkillRunDeniedCommands`; see [skill](skill.md).
 
+## Sharing a Workspace Registry Across Instances
+
+`skill_run` and `workspace_exec` resolve a session's workspace through a
+workspace registry. By default the agent uses a process-local, in-memory
+registry (`codeexecutor.WorkspaceRegistry`), which is all a single instance
+needs.
+
+When you run several agent instances behind a load balancer, an in-memory
+registry cannot coordinate across processes: if two requests for the same
+session land on different instances, each creates its own workspace. Supply a
+shared implementation of `codeexecutor.WorkspaceAcquirer` so every instance
+resolves the same session id to the same workspace:
+
+```go
+// WorkspaceAcquirer is the injection point; the default WorkspaceRegistry
+// already implements it.
+type WorkspaceAcquirer interface {
+    Acquire(ctx context.Context, m WorkspaceManager, id string) (Workspace, error)
+}
+
+agent := llmagent.New(
+    "demo",
+    llmagent.WithModel(m),
+    llmagent.WithCodeExecutor(container.New()),
+    // shared implements codeexecutor.WorkspaceAcquirer, backed by a store
+    // your application owns.
+    llmagent.WithWorkspaceRegistry(shared),
+)
+```
+
+The framework keeps `WorkspaceRegistry` as the default implementation and the
+only concrete type; the distributed implementation lives in your application,
+so no shared-store dependency is pulled into the framework.
+
+A shared registry only settles the logical session -> workspace mapping. The
+executor backend must still make the resolved workspace reachable from the
+instance handling the request — for example via sticky routing or a remote
+sandbox backend.
+
 ## Environment Variables
 
 When the executor runs in a container, on a remote worker, or in another

--- a/docs/mkdocs/en/codeexecutor.md
+++ b/docs/mkdocs/en/codeexecutor.md
@@ -998,7 +998,7 @@ agent := llmagent.New(
     llmagent.WithCodeExecutor(container.New()),
     // shared implements codeexecutor.WorkspaceAcquirer, backed by a store
     // your application owns.
-    llmagent.WithWorkspaceRegistry(shared),
+    llmagent.WithWorkspaceAcquirer(shared),
 )
 ```
 

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -891,6 +891,39 @@ deny 里。
 上对应的 `WithSkillRunAllowedCommands` / `WithSkillRunDeniedCommands`，
 参考 [skill](skill.md)。
 
+## 跨实例共享 workspace 注册表
+
+`skill_run` 和 `workspace_exec` 通过 workspace 注册表来解析会话对应的 workspace。
+默认情况下 Agent 使用进程内的内存注册表（`codeexecutor.WorkspaceRegistry`），
+单实例部署用它就够了。
+
+当你在负载均衡后面运行多个 Agent 实例时，内存注册表无法跨进程协调：如果同一会话的
+两个请求落到不同实例上，每个实例都会各自创建一个 workspace。此时可以传入一个共享的
+`codeexecutor.WorkspaceAcquirer` 实现，让每个实例都把同一个会话 id 解析到同一个
+workspace：
+
+```go
+// WorkspaceAcquirer 是注入点；默认的 WorkspaceRegistry 已经实现了它。
+type WorkspaceAcquirer interface {
+    Acquire(ctx context.Context, m WorkspaceManager, id string) (Workspace, error)
+}
+
+agent := llmagent.New(
+    "demo",
+    llmagent.WithModel(m),
+    llmagent.WithCodeExecutor(container.New()),
+    // shared 实现了 codeexecutor.WorkspaceAcquirer，其后端存储由你的应用维护。
+    llmagent.WithWorkspaceRegistry(shared),
+)
+```
+
+框架仍以 `WorkspaceRegistry` 作为默认实现，也是唯一的具体类型；分布式实现放在你的
+应用里，因此框架不会引入任何共享存储依赖。
+
+共享注册表只解决“会话 -> workspace”这层逻辑映射。执行后端仍然需要保证解析出来的
+workspace 能被处理该请求的实例访问到——例如通过会话粘连（sticky routing）或远端
+sandbox 后端。
+
 ## 环境变量与执行环境
 
 如果你的执行器运行在容器、远端或隔离环境里，通常需要显式注入环境变量。

--- a/docs/mkdocs/zh/codeexecutor.md
+++ b/docs/mkdocs/zh/codeexecutor.md
@@ -913,7 +913,7 @@ agent := llmagent.New(
     llmagent.WithModel(m),
     llmagent.WithCodeExecutor(container.New()),
     // shared 实现了 codeexecutor.WorkspaceAcquirer，其后端存储由你的应用维护。
-    llmagent.WithWorkspaceRegistry(shared),
+    llmagent.WithWorkspaceAcquirer(shared),
 )
 ```
 

--- a/internal/workspacesession/acquirer.go
+++ b/internal/workspacesession/acquirer.go
@@ -1,0 +1,37 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspacesession
+
+import (
+	"reflect"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+// NormalizeAcquirer returns nil when reg is nil or a non-nil interface value
+// whose dynamic value is nil (a typed nil, e.g. (*WorkspaceRegistry)(nil)).
+// Such a value would otherwise pass a reg == nil check and panic when Acquire
+// is called on it. Other values are returned unchanged.
+func NormalizeAcquirer(
+	reg codeexecutor.WorkspaceAcquirer,
+) codeexecutor.WorkspaceAcquirer {
+	if reg == nil {
+		return nil
+	}
+	switch v := reflect.ValueOf(reg); v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map,
+		reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		if v.IsNil() {
+			return nil
+		}
+	}
+	return reg
+}

--- a/internal/workspacesession/acquirer_test.go
+++ b/internal/workspacesession/acquirer_test.go
@@ -1,0 +1,43 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package workspacesession
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+// funcAcquirer is a non-pointer WorkspaceAcquirer used to check that typed
+// nils of a dynamic kind other than pointer also normalize to true nil.
+type funcAcquirer func()
+
+func (funcAcquirer) Acquire(
+	context.Context, codeexecutor.WorkspaceManager, string,
+) (codeexecutor.Workspace, error) {
+	return codeexecutor.Workspace{}, nil
+}
+
+func TestNormalizeAcquirer(t *testing.T) {
+	require.True(t, NormalizeAcquirer(nil) == nil)
+
+	var nilPtr *codeexecutor.WorkspaceRegistry
+	require.True(t, NormalizeAcquirer(nilPtr) == nil)
+
+	var nilFunc funcAcquirer
+	require.True(t, NormalizeAcquirer(nilFunc) == nil)
+
+	real := codeexecutor.NewWorkspaceRegistry()
+	require.Same(t, real, NormalizeAcquirer(real))
+}

--- a/internal/workspacesession/resolver.go
+++ b/internal/workspacesession/resolver.go
@@ -23,14 +23,14 @@ import (
 // that should operate on the same invocation workspace.
 type Resolver struct {
 	exec codeexecutor.CodeExecutor
-	reg  *codeexecutor.WorkspaceRegistry
+	reg  codeexecutor.WorkspaceAcquirer
 }
 
 // NewResolver creates a workspace-session resolver backed by a single
 // registry so multiple tools can share the same session workspace.
 func NewResolver(
 	exec codeexecutor.CodeExecutor,
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 ) *Resolver {
 	if reg == nil {
 		reg = codeexecutor.NewWorkspaceRegistry()

--- a/internal/workspacesession/resolver.go
+++ b/internal/workspacesession/resolver.go
@@ -32,7 +32,7 @@ func NewResolver(
 	exec codeexecutor.CodeExecutor,
 	reg codeexecutor.WorkspaceAcquirer,
 ) *Resolver {
-	if reg == nil {
+	if reg = NormalizeAcquirer(reg); reg == nil {
 		reg = codeexecutor.NewWorkspaceRegistry()
 	}
 	return &Resolver{

--- a/internal/workspacesession/resolver_test.go
+++ b/internal/workspacesession/resolver_test.go
@@ -235,3 +235,19 @@ func TestResolver_CreateWorkspace_InjectsArtifactContext(t *testing.T) {
 	require.Equal(t, "myapp/u1/sess-art", ws.ID)
 	require.True(t, probe.sawOK)
 }
+
+func TestNewResolver_TypedNilAcquirerUsesDefault(t *testing.T) {
+	var typedNil *codeexecutor.WorkspaceRegistry
+	r := NewResolver(nil, typedNil)
+	// The typed-nil acquirer is normalized to a real default registry.
+	require.NotNil(t, r.reg)
+
+	// End to end: acquiring a workspace falls back to the default registry and
+	// does not panic on a nil receiver via reg.Acquire.
+	mgr := &resolverStubMgr{}
+	eng := newResolverStubEngine(mgr)
+	ws, err := r.CreateWorkspace(context.Background(), eng, "workspace")
+	require.NoError(t, err)
+	require.Equal(t, "workspace", ws.ID)
+	require.Equal(t, []string{"workspace"}, mgr.created)
+}

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -49,7 +49,7 @@ import (
 type RunTool struct {
 	repo skill.Repository
 	exec codeexecutor.CodeExecutor
-	reg  *codeexecutor.WorkspaceRegistry
+	reg  codeexecutor.WorkspaceAcquirer
 	wsr  *workspacesession.Resolver
 	sst  *skillstage.Stager
 
@@ -221,7 +221,7 @@ func WithRequireSkillLoaded(enable bool) func(*RunTool) {
 // WithWorkspaceRegistry reuses a caller-provided workspace registry so
 // skill_run can share the same invocation workspace with other tools.
 func WithWorkspaceRegistry(
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 ) func(*RunTool) {
 	return func(t *RunTool) {
 		t.reg = reg

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -221,6 +221,19 @@ func WithRequireSkillLoaded(enable bool) func(*RunTool) {
 // WithWorkspaceRegistry reuses a caller-provided workspace registry so
 // skill_run can share the same invocation workspace with other tools.
 func WithWorkspaceRegistry(
+	reg *codeexecutor.WorkspaceRegistry,
+) func(*RunTool) {
+	if reg == nil {
+		return WithWorkspaceAcquirer(nil)
+	}
+	return WithWorkspaceAcquirer(reg)
+}
+
+// WithWorkspaceAcquirer is the interface-based form of WithWorkspaceRegistry.
+// Pass a custom codeexecutor.WorkspaceAcquirer (for example a shared,
+// distributed registry) so skill_run resolves session workspaces through it
+// instead of the default in-memory registry.
+func WithWorkspaceAcquirer(
 	reg codeexecutor.WorkspaceAcquirer,
 ) func(*RunTool) {
 	return func(t *RunTool) {

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -223,21 +223,20 @@ func WithRequireSkillLoaded(enable bool) func(*RunTool) {
 func WithWorkspaceRegistry(
 	reg *codeexecutor.WorkspaceRegistry,
 ) func(*RunTool) {
-	if reg == nil {
-		return WithWorkspaceAcquirer(nil)
-	}
 	return WithWorkspaceAcquirer(reg)
 }
 
 // WithWorkspaceAcquirer is the interface-based form of WithWorkspaceRegistry.
 // Pass a custom codeexecutor.WorkspaceAcquirer (for example a shared,
 // distributed registry) so skill_run resolves session workspaces through it
-// instead of the default in-memory registry.
+// instead of the default in-memory registry. A typed-nil acquirer is
+// normalized to a true nil so the default registry is used instead of
+// panicking.
 func WithWorkspaceAcquirer(
 	reg codeexecutor.WorkspaceAcquirer,
 ) func(*RunTool) {
 	return func(t *RunTool) {
-		t.reg = reg
+		t.reg = workspacesession.NormalizeAcquirer(reg)
 	}
 }
 

--- a/tool/workspaceexec/options_test.go
+++ b/tool/workspaceexec/options_test.go
@@ -217,3 +217,10 @@ func TestWithWorkspaceRegistry_TypedNilStaysNil(t *testing.T) {
 	// which would also accept a typed-nil wrapper).
 	require.True(t, tl.reg == nil)
 }
+
+func TestWithWorkspaceAcquirer_TypedNilStaysNil(t *testing.T) {
+	var reg *codeexecutor.WorkspaceRegistry
+	tl := &ExecTool{}
+	WithWorkspaceAcquirer(reg)(tl)
+	require.True(t, tl.reg == nil)
+}

--- a/tool/workspaceexec/options_test.go
+++ b/tool/workspaceexec/options_test.go
@@ -200,3 +200,20 @@ func TestKillSessionTool_Declaration(t *testing.T) {
 		decl.OutputSchema.Required,
 	)
 }
+
+func TestWithWorkspaceAcquirer_SetsRegistry(t *testing.T) {
+	reg := codeexecutor.NewWorkspaceRegistry()
+	tl := &ExecTool{}
+	WithWorkspaceAcquirer(reg)(tl)
+	require.Same(t, reg, tl.reg)
+}
+
+func TestWithWorkspaceRegistry_TypedNilStaysNil(t *testing.T) {
+	var reg *codeexecutor.WorkspaceRegistry
+	tl := &ExecTool{}
+	WithWorkspaceRegistry(reg)(tl)
+	// A typed-nil *WorkspaceRegistry must collapse to a true nil interface so
+	// the tool falls back to its default registry (== nil, not require.Nil,
+	// which would also accept a typed-nil wrapper).
+	require.True(t, tl.reg == nil)
+}

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -52,7 +52,7 @@ const (
 // ExecTool executes shell commands in the shared executor workspace.
 type ExecTool struct {
 	exec      codeexecutor.CodeExecutor
-	reg       *codeexecutor.WorkspaceRegistry
+	reg       codeexecutor.WorkspaceAcquirer
 	resolver  *workspacesession.Resolver
 	sessional bool
 
@@ -192,7 +192,7 @@ func NewKillSessionTool(exec *ExecTool) *KillSessionTool {
 // WithWorkspaceRegistry reuses a caller-provided workspace registry so
 // workspace_exec can share the same invocation workspace with other tools.
 func WithWorkspaceRegistry(
-	reg *codeexecutor.WorkspaceRegistry,
+	reg codeexecutor.WorkspaceAcquirer,
 ) func(*ExecTool) {
 	return func(t *ExecTool) {
 		t.reg = reg

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -194,21 +194,20 @@ func NewKillSessionTool(exec *ExecTool) *KillSessionTool {
 func WithWorkspaceRegistry(
 	reg *codeexecutor.WorkspaceRegistry,
 ) func(*ExecTool) {
-	if reg == nil {
-		return WithWorkspaceAcquirer(nil)
-	}
 	return WithWorkspaceAcquirer(reg)
 }
 
 // WithWorkspaceAcquirer is the interface-based form of WithWorkspaceRegistry.
 // Pass a custom codeexecutor.WorkspaceAcquirer (for example a shared,
 // distributed registry) so workspace_exec resolves session workspaces through
-// it instead of the default in-memory registry.
+// it instead of the default in-memory registry. A typed-nil acquirer is
+// normalized to a true nil so the default registry is used instead of
+// panicking.
 func WithWorkspaceAcquirer(
 	reg codeexecutor.WorkspaceAcquirer,
 ) func(*ExecTool) {
 	return func(t *ExecTool) {
-		t.reg = reg
+		t.reg = workspacesession.NormalizeAcquirer(reg)
 	}
 }
 

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -192,6 +192,19 @@ func NewKillSessionTool(exec *ExecTool) *KillSessionTool {
 // WithWorkspaceRegistry reuses a caller-provided workspace registry so
 // workspace_exec can share the same invocation workspace with other tools.
 func WithWorkspaceRegistry(
+	reg *codeexecutor.WorkspaceRegistry,
+) func(*ExecTool) {
+	if reg == nil {
+		return WithWorkspaceAcquirer(nil)
+	}
+	return WithWorkspaceAcquirer(reg)
+}
+
+// WithWorkspaceAcquirer is the interface-based form of WithWorkspaceRegistry.
+// Pass a custom codeexecutor.WorkspaceAcquirer (for example a shared,
+// distributed registry) so workspace_exec resolves session workspaces through
+// it instead of the default in-memory registry.
+func WithWorkspaceAcquirer(
 	reg codeexecutor.WorkspaceAcquirer,
 ) func(*ExecTool) {
 	return func(t *ExecTool) {


### PR DESCRIPTION
## What changed

- Add `codeexecutor.WorkspaceAcquirer`, a one-method interface
  (`Acquire(ctx, manager, id)`) that the existing `WorkspaceRegistry` already
  satisfies.
- Relax the tool-level `WithWorkspaceRegistry` options and the internal
  workspace-session resolver to accept the interface.
- Add `llmagent.WithWorkspaceRegistry(...)` to supply one.
- Document it in the EN and ZH codeexecutor guides.

`WorkspaceRegistry` stays the default and only concrete type, and
`NewWorkspaceRegistry()` is unchanged, so existing callers are unaffected.

## Why

Closes #2096.

`WorkspaceRegistry` is a process-local map, so with several agent instances
behind a load balancer, requests for the same session that land on different
instances create separate workspaces. A pluggable registry lets an application
supply a shared implementation without pulling that dependency into the
framework. It only settles the logical mapping — the backend must still make
the resolved workspace reachable from the handling instance.
