### PR TITLE
openclaw: treat JSON-LD uploads as documents

### DIFF
--- a/openclaw/internal/octool/file_tools.go
+++ b/openclaw/internal/octool/file_tools.go
@@ -493,7 +493,7 @@ func documentKindFromPath(path string) string {
 		return docKindPDF
 	case ".docx", ".doc":
 		return docKindDOCX
-	case ".txt", ".md", ".markdown", ".json", ".csv",
+	case ".txt", ".md", ".markdown", ".json", ".jsonld", ".csv",
 		".yaml", ".yml", ".log":
 		return docKindText
 	case ".png", ".jpg", ".jpeg", ".webp", ".gif":

--- a/openclaw/internal/octool/file_tools_test.go
+++ b/openclaw/internal/octool/file_tools_test.go
@@ -300,6 +300,7 @@ func TestReadDocumentHelpers(t *testing.T) {
 
 	require.Equal(t, docKindDOCX, documentKindFromPath(docxPath))
 	require.Equal(t, docKindText, documentKindFromPath(logPath))
+	require.Equal(t, docKindText, documentKindFromPath("data.jsonld"))
 	require.Equal(t, docKindImage, documentKindFromPath("chart.png"))
 	require.Equal(t, docKindImage, documentKindFromPath("photo.jpeg"))
 	require.Equal(t, "", documentKindFromPath("bad.bin"))


### PR DESCRIPTION
## Summary

- treat `.jsonld` uploads as text-like documents in `read_document`
- cover JSON-LD document kind detection in octool tests

## Validation

- go test ./internal/octool -run 'TestReadDocumentHelpers|TestReadDocumentTool_TextPDFDOCXAndErrors' -count=1
- go test ./internal/octool ./cmd/openclaw -count=1
