### PR TITLE
model/openai,openclaw: make GLM text-only content opt-in

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -239,7 +239,6 @@ var variantConfigs = map[Variant]variantConfig{
 		filePurpose:                       openai.FilePurposeUserData,
 		fileDeletionMethod:                http.MethodDelete,
 		skipFileTypeInContent:             false,
-		textOnlyMessageContent:            true,
 		fileDeletionBodyConvertor:         defaultFileDeletionBodyConvertor,
 		thinkingEnabledKey:                thinkingKey,
 		thinkingValueConvertor:            thinkingTypeValueConvertor,
@@ -332,6 +331,10 @@ func New(name string, opts ...Option) *Model {
 	if o.TailoringStrategy == nil {
 		o.TailoringStrategy = model.NewMiddleOutStrategy(o.TokenCounter)
 	}
+	variantCfg := variantConfigs[o.Variant]
+	if o.textOnlyMessageContent != nil {
+		variantCfg.textOnlyMessageContent = *o.textOnlyMessageContent
+	}
 
 	return &Model{
 		client:                     client,
@@ -348,7 +351,7 @@ func New(name string, opts ...Option) *Model {
 		chatTelemetry:              o.ChatTelemetry,
 		extraFields:                o.ExtraFields,
 		variant:                    o.Variant,
-		variantConfig:              variantConfigs[o.Variant],
+		variantConfig:              variantCfg,
 		reasoningContentBackfill:   o.ReasoningContentBackfill,
 		batchCompletionWindow:      o.BatchCompletionWindow,
 		batchMetadata:              o.BatchMetadata,

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -239,6 +239,7 @@ var variantConfigs = map[Variant]variantConfig{
 		filePurpose:                       openai.FilePurposeUserData,
 		fileDeletionMethod:                http.MethodDelete,
 		skipFileTypeInContent:             false,
+		textOnlyMessageContent:            true,
 		fileDeletionBodyConvertor:         defaultFileDeletionBodyConvertor,
 		thinkingEnabledKey:                thinkingKey,
 		thinkingValueConvertor:            thinkingTypeValueConvertor,

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -9360,10 +9360,62 @@ func TestAppendUserContentParts_FileURLWithDataSkippedForTextOnlyVariant(t *test
 	require.Empty(t, dst)
 }
 
-func TestAppendUserContentParts_GLMVariantOmitsNonTextAttachments(t *testing.T) {
+func TestAppendUserContentParts_GLMVariantPreservesNonTextByDefault(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	m := New("glm50", WithVariant(VariantGLM))
+	text := "use the attached files via tools"
+	dst := []openai.ChatCompletionContentPartUnionParam{}
+	fields := m.appendUserContentParts(&dst, []model.ContentPart{
+		{
+			Type: model.ContentTypeText,
+			Text: &text,
+		},
+		{
+			Type: model.ContentTypeImage,
+			Image: &model.Image{
+				Data:   []byte("png"),
+				Format: "png",
+			},
+		},
+		{
+			Type: model.ContentTypeFile,
+			File: &model.File{
+				Name:     "photo.jpg",
+				Data:     []byte("jpg"),
+				MimeType: "image/jpeg",
+			},
+		},
+	})
+
+	require.Nil(t, fields)
+	require.Len(t, dst, 3)
+	require.NotNil(t, dst[0].OfText)
+	require.Equal(t, text, dst[0].OfText.Text)
+	require.NotNil(t, dst[1].OfImageURL)
+	require.NotNil(t, dst[2].OfFile)
+	require.Empty(t,
+		m.omittedContentHint([]model.ContentPart{
+			{
+				Type: model.ContentTypeImage,
+				Image: &model.Image{
+					Data:   []byte("png"),
+					Format: "png",
+				},
+			},
+		}))
+}
+
+func TestAppendUserContentParts_TextOnlyOptionOmitsNonText(t *testing.T) {
+	t.Parallel()
+
+	m := New(
+		"glm50",
+		WithVariant(VariantGLM),
+		WithTextOnlyMessageContent(true),
+	)
 	text := "use the attached files via tools"
 	dst := []openai.ChatCompletionContentPartUnionParam{}
 	fields := m.appendUserContentParts(&dst, []model.ContentPart{

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -9360,6 +9360,59 @@ func TestAppendUserContentParts_FileURLWithDataSkippedForTextOnlyVariant(t *test
 	require.Empty(t, dst)
 }
 
+func TestAppendUserContentParts_GLMVariantOmitsNonTextAttachments(t *testing.T) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	text := "use the attached files via tools"
+	dst := []openai.ChatCompletionContentPartUnionParam{}
+	fields := m.appendUserContentParts(&dst, []model.ContentPart{
+		{
+			Type: model.ContentTypeText,
+			Text: &text,
+		},
+		{
+			Type: model.ContentTypeImage,
+			Image: &model.Image{
+				Data:   []byte("png"),
+				Format: "png",
+			},
+		},
+		{
+			Type: model.ContentTypeFile,
+			File: &model.File{
+				Name:     "photo.jpg",
+				Data:     []byte("jpg"),
+				MimeType: "image/jpeg",
+			},
+		},
+	})
+
+	require.Nil(t, fields)
+	require.Len(t, dst, 1)
+	require.NotNil(t, dst[0].OfText)
+	require.Equal(t, text, dst[0].OfText.Text)
+	require.Equal(t,
+		"Omitted non-text attachments for this provider: 1 image, 1 file.",
+		m.omittedContentHint([]model.ContentPart{
+			{
+				Type: model.ContentTypeImage,
+				Image: &model.Image{
+					Data:   []byte("png"),
+					Format: "png",
+				},
+			},
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name:     "photo.jpg",
+					Data:     []byte("jpg"),
+					MimeType: "image/jpeg",
+				},
+			},
+		}))
+}
+
 func TestAppendUserContentParts_FileURLPreservedForSkipFileTypeVariant(t *testing.T) {
 	m := &Model{variantConfig: variantConfig{skipFileTypeInContent: true}}
 	dst := []openai.ChatCompletionContentPartUnionParam{}

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -136,6 +136,9 @@ type options struct {
 	// This can be useful when a provider rejects file inputs in chat messages,
 	// while still keeping the file parts in-memory for downstream tools.
 	OmitFileContentParts bool
+
+	// textOnlyMessageContent overrides the variant default when set.
+	textOnlyMessageContent *bool
 }
 
 var (
@@ -325,6 +328,14 @@ func WithVariant(variant Variant) Option {
 func WithOmitFileContentParts(omit bool) Option {
 	return func(opts *options) {
 		opts.OmitFileContentParts = omit
+	}
+}
+
+// WithTextOnlyMessageContent controls whether user message content parts are
+// reduced to text-only payloads before sending them to the provider.
+func WithTextOnlyMessageContent(enabled bool) Option {
+	return func(opts *options) {
+		opts.textOnlyMessageContent = &enabled
 	}
 }
 

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -382,6 +382,20 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 					"hunyuan",
 					"glm",
 				),
+				adminRuntimeBoolField(
+					"model.text_only_content",
+					"Text-Only Message Content",
+					"Drop non-text user content parts for text-only providers.",
+					[]adminRuntimeConfigKeyRef{
+						adminRuntimeKey("model"),
+						adminRuntimeKey("text_only_content"),
+					},
+					func(opts runOptions) string {
+						return strconv.FormatBool(
+							opts.OpenAITextOnlyMessageContent,
+						)
+					},
+				),
 			},
 		},
 		{

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -660,6 +660,33 @@ func TestAdminRuntimeConfigProvider_SaveStringFieldAndEnvExpansion(
 	require.Contains(t, string(data), "base_url: https://override.example")
 }
 
+func TestBuildAdminOptions_ExposesOpenAITextOnlyField(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"model:\n  text_only_content: true\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	opts.OpenAITextOnlyMessageContent = true
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	field := findAdminRuntimeConfigField(
+		t,
+		status,
+		"model.text_only_content",
+	)
+	require.Equal(t, "true", field.RuntimeValue)
+	require.Equal(t, "true", field.ConfiguredValue)
+	require.Equal(t, adminRuntimeConfigInputSelect, field.InputType)
+	require.Len(t, field.Options, 2)
+}
+
 func TestAdminRuntimeConfigProvider_ErrorPaths(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -3774,6 +3774,9 @@ func newOpenAIModel(spec registry.ModelSpec) (model.Model, error) {
 		openai.WithVariant(variant),
 		openai.WithOmitFileContentParts(true),
 	}
+	if variant == openai.VariantGLM {
+		opts = append(opts, openai.WithTextOnlyMessageContent(true))
+	}
 	if spec.DebugRecorderEnabled {
 		opts = append(
 			opts,

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -3774,7 +3774,7 @@ func newOpenAIModel(spec registry.ModelSpec) (model.Model, error) {
 		openai.WithVariant(variant),
 		openai.WithOmitFileContentParts(true),
 	}
-	if variant == openai.VariantGLM {
+	if spec.OpenAITextOnlyMessageContent {
 		opts = append(opts, openai.WithTextOnlyMessageContent(true))
 	}
 	if spec.DebugRecorderEnabled {
@@ -3821,15 +3821,17 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 		headers = resolved
 	}
 
+	apiKey := strings.TrimSpace(os.Getenv(openAIAPIKeyEnvName))
 	spec := registry.ModelSpec{
-		Type:                 mode,
-		Name:                 opts.OpenAIModel,
-		BaseURL:              baseURL,
-		APIKey:               strings.TrimSpace(os.Getenv(openAIAPIKeyEnvName)),
-		OpenAIVariant:        opts.OpenAIVariant,
-		Headers:              headers,
-		DebugRecorderEnabled: opts.DebugRecorderEnabled,
-		Config:               opts.ModelConfig,
+		Type:                         mode,
+		Name:                         opts.OpenAIModel,
+		BaseURL:                      baseURL,
+		APIKey:                       apiKey,
+		OpenAIVariant:                opts.OpenAIVariant,
+		OpenAITextOnlyMessageContent: opts.OpenAITextOnlyMessageContent,
+		Headers:                      headers,
+		DebugRecorderEnabled:         opts.DebugRecorderEnabled,
+		Config:                       opts.ModelConfig,
 	}
 	return f(spec)
 }

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4651,7 +4651,7 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 	require.Equal(t, "Bearer config-token", tokenHeader)
 }
 
-func TestNewModel_OpenAIGLMUsesTextOnlyContent(t *testing.T) {
+func TestNewModel_OpenAIGLMUsesTextOnlyContentWhenConfigured(t *testing.T) {
 	var requestBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(
 		w http.ResponseWriter,
@@ -4678,10 +4678,11 @@ func TestNewModel_OpenAIGLMUsesTextOnlyContent(t *testing.T) {
 
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	mdl, err := modelFromOptions(runOptions{
-		ModelMode:     modeOpenAI,
-		OpenAIModel:   "glm50",
-		OpenAIVariant: string(openai.VariantGLM),
-		OpenAIBaseURL: server.URL,
+		ModelMode:                    modeOpenAI,
+		OpenAIModel:                  "glm50",
+		OpenAIVariant:                string(openai.VariantGLM),
+		OpenAIBaseURL:                server.URL,
+		OpenAITextOnlyMessageContent: true,
 	})
 	require.NoError(t, err)
 
@@ -4741,6 +4742,92 @@ func TestNewModel_OpenAIGLMUsesTextOnlyContent(t *testing.T) {
 	require.Contains(t, body, "Omitted non-text attachments")
 	require.NotContains(t, body, "data:image")
 	require.NotContains(t, body, "photo.jpg")
+}
+
+func TestNewModel_OpenAIGLMPreservesNonTextContentByDefault(t *testing.T) {
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		require.True(t, strings.HasSuffix(r.URL.Path, "/chat/completions"))
+		var err error
+		requestBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":123,
+			"model":"glm50",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"ok"},
+				"finish_reason":"stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	mdl, err := modelFromOptions(runOptions{
+		ModelMode:     modeOpenAI,
+		OpenAIModel:   "glm50",
+		OpenAIVariant: string(openai.VariantGLM),
+		OpenAIBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	textPart := "visible text"
+	msg := model.NewUserMessage("inspect attachments")
+	msg.ContentParts = []model.ContentPart{
+		{
+			Type: model.ContentTypeText,
+			Text: &textPart,
+		},
+		{
+			Type: model.ContentTypeImage,
+			Image: &model.Image{
+				Data:   []byte("png"),
+				Format: "png",
+			},
+		},
+	}
+	ch, err := mdl.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{msg},
+		GenerationConfig: model.GenerationConfig{
+			Stream: false,
+		},
+	})
+	require.NoError(t, err)
+	for rsp := range ch {
+		require.Nil(t, rsp.Error)
+	}
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(requestBody, &payload))
+	messages, ok := payload["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, messages, 1)
+	message, ok := messages[0].(map[string]any)
+	require.True(t, ok)
+	parts, ok := message["content"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, parts)
+
+	var sawImage bool
+	for _, raw := range parts {
+		part, ok := raw.(map[string]any)
+		require.True(t, ok)
+		if part["type"] == "image_url" {
+			sawImage = true
+		}
+	}
+	require.True(t, sawImage)
+	body := string(requestBody)
+	require.Contains(t, body, "visible text")
+	require.Contains(t, body, "data:image/png;base64")
+	require.NotContains(t, body, "Omitted non-text attachments")
 }
 
 func TestResolveOpenAIHeaders_EnvOnlyAndConfigOnly(t *testing.T) {

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4651,6 +4651,98 @@ func TestNewModel_OpenAIHeadersFromConfigAndEnv(t *testing.T) {
 	require.Equal(t, "Bearer config-token", tokenHeader)
 }
 
+func TestNewModel_OpenAIGLMUsesTextOnlyContent(t *testing.T) {
+	var requestBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		require.True(t, strings.HasSuffix(r.URL.Path, "/chat/completions"))
+		var err error
+		requestBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":123,
+			"model":"glm50",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"ok"},
+				"finish_reason":"stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	mdl, err := modelFromOptions(runOptions{
+		ModelMode:     modeOpenAI,
+		OpenAIModel:   "glm50",
+		OpenAIVariant: string(openai.VariantGLM),
+		OpenAIBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	textPart := "visible text"
+	msg := model.NewUserMessage("inspect attachments")
+	msg.ContentParts = []model.ContentPart{
+		{
+			Type: model.ContentTypeText,
+			Text: &textPart,
+		},
+		{
+			Type: model.ContentTypeImage,
+			Image: &model.Image{
+				Data:   []byte("png"),
+				Format: "png",
+			},
+		},
+		{
+			Type: model.ContentTypeFile,
+			File: &model.File{
+				Name:     "photo.jpg",
+				Data:     []byte("jpg"),
+				MimeType: "image/jpeg",
+			},
+		},
+	}
+	ch, err := mdl.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{msg},
+		GenerationConfig: model.GenerationConfig{
+			Stream: false,
+		},
+	})
+	require.NoError(t, err)
+	for rsp := range ch {
+		require.Nil(t, rsp.Error)
+	}
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(requestBody, &payload))
+	messages, ok := payload["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, messages, 1)
+	message, ok := messages[0].(map[string]any)
+	require.True(t, ok)
+	parts, ok := message["content"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, parts)
+	for _, raw := range parts {
+		part, ok := raw.(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "text", part["type"])
+		require.NotContains(t, part, "image_url")
+		require.NotContains(t, part, "file")
+	}
+	body := string(requestBody)
+	require.Contains(t, body, "visible text")
+	require.Contains(t, body, "Omitted non-text attachments")
+	require.NotContains(t, body, "data:image")
+	require.NotContains(t, body, "photo.jpg")
+}
+
 func TestResolveOpenAIHeaders_EnvOnlyAndConfigOnly(t *testing.T) {
 	t.Setenv(
 		openAIHeadersEnvName,

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -128,9 +128,10 @@ const (
 	flagSkillsToolResults     = "skills-loaded-content-in-tool-results"
 	flagSkillsSkipFallback    = "skills-skip-fallback-on-session-summary"
 
-	flagDebugRecorder     = "debug-recorder"
-	flagDebugRecorderDir  = "debug-recorder-dir"
-	flagDebugRecorderMode = "debug-recorder-mode"
+	flagDebugRecorder                = "debug-recorder"
+	flagDebugRecorderDir             = "debug-recorder-dir"
+	flagDebugRecorderMode            = "debug-recorder-mode"
+	flagOpenAITextOnlyMessageContent = "openai-text-only-message-content"
 
 	flagLatencyDiagnostics                 = "latency-diagnostics"
 	flagLatencyDiagnosticsEvents           = "latency-diagnostics-events"
@@ -218,32 +219,33 @@ type runOptions struct {
 	ClaudeEnv          string
 	ClaudeWorkDir      string
 
-	ModelMode             string
-	OpenAIModel           string
-	OpenAIVariant         string
-	OpenAIBaseURL         string
-	OpenAIHeaders         map[string]string
-	GenerationConfig      *model.GenerationConfig
-	ModelConfig           *yaml.Node
-	KnowledgesConfig      []knowledgeEntry
-	SkillsRoot            string
-	SkillsExtraDir        string
-	SkillsDebug           bool
-	SkillsAllowBundled    string
-	SkillConfigs          map[string]ocskills.SkillConfig
-	SkillsWatch           bool
-	SkillsWatchBundled    bool
-	SkillsWatchDebounce   time.Duration
-	SkillsSummaryCacheTTL time.Duration
-	SkillsOverviewLimit   int
-	SkillsOverviewPinned  string
-	SkillsToolProfile     string
-	SkillsLoadMode        string
-	SkillsMaxLoaded       int
-	SkillsToolResults     bool
-	SkillsSkipFallback    bool
-	SkillsToolingGuide    *string
-	StateDir              string
+	ModelMode                    string
+	OpenAIModel                  string
+	OpenAIVariant                string
+	OpenAIBaseURL                string
+	OpenAITextOnlyMessageContent bool
+	OpenAIHeaders                map[string]string
+	GenerationConfig             *model.GenerationConfig
+	ModelConfig                  *yaml.Node
+	KnowledgesConfig             []knowledgeEntry
+	SkillsRoot                   string
+	SkillsExtraDir               string
+	SkillsDebug                  bool
+	SkillsAllowBundled           string
+	SkillConfigs                 map[string]ocskills.SkillConfig
+	SkillsWatch                  bool
+	SkillsWatchBundled           bool
+	SkillsWatchDebounce          time.Duration
+	SkillsSummaryCacheTTL        time.Duration
+	SkillsOverviewLimit          int
+	SkillsOverviewPinned         string
+	SkillsToolProfile            string
+	SkillsLoadMode               string
+	SkillsMaxLoaded              int
+	SkillsToolResults            bool
+	SkillsSkipFallback           bool
+	SkillsToolingGuide           *string
+	StateDir                     string
 
 	EvolutionEnabled               bool
 	EvolutionHumanGate             string
@@ -631,6 +633,12 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"openai-base-url",
 		"",
 		"OpenAI base URL override (mode=openai, optional)",
+	)
+	fs.BoolVar(
+		&opts.OpenAITextOnlyMessageContent,
+		flagOpenAITextOnlyMessageContent,
+		false,
+		"Reduce OpenAI-compatible user message content parts to text-only",
 	)
 	fs.StringVar(
 		&opts.AllowUsers,
@@ -1235,6 +1243,7 @@ type modelConfig struct {
 	Name             *string               `yaml:"name,omitempty"`
 	BaseURL          *string               `yaml:"base_url,omitempty"`
 	OpenAIVariant    *string               `yaml:"openai_variant,omitempty"`
+	TextOnlyContent  *bool                 `yaml:"text_only_content,omitempty"`
 	Headers          map[string]string     `yaml:"headers,omitempty"`
 	GenerationConfig *generationConfigYAML `yaml:"generation_config,omitempty"`
 	Config           *rawYAMLNode          `yaml:"config,omitempty"`
@@ -1824,6 +1833,11 @@ func (cfg *fileConfig) apply(
 			opts.OpenAIVariant = strings.TrimSpace(
 				*cfg.Model.OpenAIVariant,
 			)
+		}
+		textOnly := cfg.Model.TextOnlyContent
+		if textOnly != nil &&
+			!flagWasSet(set, flagOpenAITextOnlyMessageContent) {
+			opts.OpenAITextOnlyMessageContent = *textOnly
 		}
 		if len(cfg.Model.Headers) > 0 {
 			opts.OpenAIHeaders = cleanHeaderMap(cfg.Model.Headers)

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -828,6 +828,7 @@ model:
   mode: "mock"
   name: "gpt-5"
   openai_variant: "openai"
+  text_only_content: true
   headers:
     X-SMG-Routing-Key: "wineguo"
     X-SMG-Agent-Name: "trpc-claw-benchmark"
@@ -995,6 +996,7 @@ memory:
 	require.Equal(t, modeMock, opts.ModelMode)
 	require.Equal(t, "gpt-5", opts.OpenAIModel)
 	require.Equal(t, "openai", opts.OpenAIVariant)
+	require.True(t, opts.OpenAITextOnlyMessageContent)
 	require.Equal(t, map[string]string{
 		"X-SMG-Routing-Key": "wineguo",
 		"X-SMG-Agent-Name":  "trpc-claw-benchmark",
@@ -1256,6 +1258,21 @@ tools:
 	})
 	require.NoError(t, err)
 	require.Equal(t, 45*time.Second, opts.DynamicAgentTimeout)
+}
+
+func TestParseRunOptions_OpenAITextOnlyFlagOverridesConfig(t *testing.T) {
+	t.Parallel()
+
+	cfgPath := writeTempConfig(t, `
+model:
+  text_only_content: true
+`)
+	opts, err := parseRunOptions([]string{
+		"-config", cfgPath,
+		"-openai-text-only-message-content=false",
+	})
+	require.NoError(t, err)
+	require.False(t, opts.OpenAITextOnlyMessageContent)
 }
 
 func TestParseRunOptions_HostExecDefaultTimeoutFlagOverridesConfig(

--- a/openclaw/registry/registry.go
+++ b/openclaw/registry/registry.go
@@ -193,13 +193,14 @@ type ToolSetProviderFactory func(
 
 // ModelSpec describes which model to create.
 type ModelSpec struct {
-	Type                 string
-	Name                 string
-	BaseURL              string
-	APIKey               string
-	OpenAIVariant        string
-	Headers              map[string]string
-	DebugRecorderEnabled bool
+	Type                         string
+	Name                         string
+	BaseURL                      string
+	APIKey                       string
+	OpenAIVariant                string
+	OpenAITextOnlyMessageContent bool
+	Headers                      map[string]string
+	DebugRecorderEnabled         bool
 
 	Config *yaml.Node
 }


### PR DESCRIPTION
## What changed

- Treat the OpenAI-compatible GLM variant as text-only for user message content parts.
- Keep text content, but omit image/audio/file binary content parts from the provider request so callers can rely on tool-visible attachments instead.
- Add coverage that GLM skips image and file payloads and emits the existing omitted-attachment hint.

## Why

Some GLM-compatible gateways reject OpenAI multimodal/file content parts even when the runtime has already materialized the attachment for tools. Sending those payloads can fail the request before the agent has a chance to inspect the local attachment path.

This keeps GLM request bodies compatible while preserving the existing tool-based attachment path used by OpenClaw/trpc-claw.

## Validation

- `go test ./model/openai -run 'TestAppendUserContentParts_GLMVariantOmitsNonTextAttachments|TestCreateFinalResponseGLM|TestCreateResponseFromCompletionGLM|TestAppendUserContentParts_FileURL' -count=1`
- `go test ./model/openai -count=1`
