### PR TITLE
openclaw: expose gateway max body size

### DIFF
--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1347,6 +1347,7 @@ func NewRuntimeWithOptions(
 		splitCSV(opts.AllowUsers),
 		opts.RequireMention,
 		mentionPatterns,
+		opts.GatewayMaxBodyBytes,
 	)
 	gwOpts = append(gwOpts, gateway.WithAppName(opts.AppName))
 	gwOpts = append(gwOpts, gateway.WithUploadStore(stores.uploads))
@@ -1971,6 +1972,7 @@ func run(
 		splitCSV(opts.AllowUsers),
 		opts.RequireMention,
 		mentionPatterns,
+		opts.GatewayMaxBodyBytes,
 	)
 	gwOpts = append(gwOpts, gateway.WithAppName(opts.AppName))
 	gwOpts = append(gwOpts, gateway.WithUploadStore(stores.uploads))
@@ -2514,8 +2516,12 @@ func makeGatewayOptions(
 	users []string,
 	requireMention bool,
 	mentionPatterns []string,
+	maxBodyBytes int64,
 ) []gateway.Option {
 	opts := make([]gateway.Option, 0, 4)
+	if maxBodyBytes > 0 {
+		opts = append(opts, gateway.WithMaxBodyBytes(maxBodyBytes))
+	}
 	if len(users) > 0 {
 		opts = append(opts, gateway.WithAllowUsers(users...))
 	}

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -5907,6 +5907,33 @@ func TestInProcGatewayClient_SendMessage_StatusError(t *testing.T) {
 	require.Equal(t, wantErr, err.Error())
 }
 
+func TestMakeGatewayOptions_MaxBodyBytes(t *testing.T) {
+	t.Parallel()
+
+	srv, err := gateway.New(
+		&inProcGWTestRunner{},
+		makeGatewayOptions(nil, false, nil, 64)...,
+	)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(gwproto.MessageRequest{
+		From: "u1",
+		Text: strings.Repeat("x", 128),
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		srv.MessagesPath(),
+		bytes.NewReader(body),
+	)
+	srv.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "request body exceeds max_body_bytes")
+}
+
 func TestInProcGatewayClient_StreamMessage_OK(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -255,10 +255,11 @@ type runOptions struct {
 	DebugRecorderDir     string
 	DebugRecorderMode    string
 
-	AllowUsers      string
-	RequireMention  bool
-	Mention         string
-	RuntimeProfiles *runtimeprofile.Config
+	AllowUsers          string
+	RequireMention      bool
+	Mention             string
+	GatewayMaxBodyBytes int64
+	RuntimeProfiles     *runtimeprofile.Config
 
 	Channels []pluginSpec
 
@@ -649,6 +650,12 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"mention",
 		"",
 		"Comma-separated mention patterns",
+	)
+	fs.Int64Var(
+		&opts.GatewayMaxBodyBytes,
+		"gateway-max-body-bytes",
+		0,
+		"Maximum JSON request body bytes for gateway endpoints (0 uses default)",
 	)
 	fs.StringVar(
 		&opts.SkillsRoot,
@@ -1257,6 +1264,7 @@ type gatewayConfig struct {
 	AllowUsers      []string `yaml:"allow_users,omitempty"`
 	RequireMention  *bool    `yaml:"require_mention,omitempty"`
 	MentionPatterns []string `yaml:"mention_patterns,omitempty"`
+	MaxBodyBytes    *int64   `yaml:"max_body_bytes,omitempty"`
 }
 
 type skillsConfig struct {
@@ -1871,6 +1879,10 @@ func (cfg *fileConfig) apply(
 				cfg.Gateway.MentionPatterns,
 				csvDelimiter,
 			)
+		}
+		if cfg.Gateway.MaxBodyBytes != nil &&
+			!flagWasSet(set, "gateway-max-body-bytes") {
+			opts.GatewayMaxBodyBytes = *cfg.Gateway.MaxBodyBytes
 		}
 	}
 	if cfg.RuntimeProfiles != nil {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -836,6 +836,7 @@ gateway:
   allow_users: ["u1","u2"]
   require_mention: true
   mention_patterns: ["@bot"]
+  max_body_bytes: 33554432
 
 channels:
   - type: "telegram"
@@ -1003,6 +1004,7 @@ memory:
 	require.Equal(t, "u1,u2", opts.AllowUsers)
 	require.True(t, opts.RequireMention)
 	require.Equal(t, "@bot", opts.Mention)
+	require.Equal(t, int64(33554432), opts.GatewayMaxBodyBytes)
 
 	require.Len(t, opts.Channels, 1)
 	require.Equal(t, telegramChannelType, opts.Channels[0].Type)

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -442,7 +443,11 @@ func (s *Server) decodeJSON(r *http.Request, target any) error {
 			maxBytes,
 		)
 	}
-	reader := &io.LimitedReader{R: r.Body, N: maxBytes + 1}
+	limit := maxBytes
+	if maxBytes < math.MaxInt64 {
+		limit = maxBytes + 1
+	}
+	reader := &io.LimitedReader{R: r.Body, N: limit}
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("read request body: %w", err)

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -20,6 +20,7 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -431,8 +432,28 @@ func (s *Server) decodeJSON(r *http.Request, target any) error {
 	if r == nil {
 		return errors.New("nil request")
 	}
-	reader := io.LimitReader(r.Body, s.maxBodyBytes)
-	decoder := json.NewDecoder(reader)
+	maxBytes := s.maxBodyBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBodyBytes
+	}
+	if r.ContentLength > maxBytes {
+		return fmt.Errorf(
+			"request body exceeds max_body_bytes (%d bytes)",
+			maxBytes,
+		)
+	}
+	reader := &io.LimitedReader{R: r.Body, N: maxBytes + 1}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("read request body: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return fmt.Errorf(
+			"request body exceeds max_body_bytes (%d bytes)",
+			maxBytes,
+		)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
 	if err := decoder.Decode(target); err != nil {
 		return fmt.Errorf("decode json: %w", err)
 	}

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -1428,6 +1428,7 @@ func TestServer_ProcessMessage_LargeInlineData(t *testing.T) {
 	srv.Handler().ServeHTTP(rr, httpReq)
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "request body exceeds max_body_bytes")
 }
 
 func TestServer_ProcessMessage_FileUploadStorePersistsHostRef(

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1457,6 +1458,32 @@ func TestServer_ProcessMessage_LargeBodyWithoutContentLength(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	require.Contains(t, rr.Body.String(), "request body exceeds max_body_bytes")
 	require.Zero(t, r.Calls())
+}
+
+func TestServer_ProcessMessage_MaxInt64BodyLimit(t *testing.T) {
+	t.Parallel()
+
+	r := &recordingRunner{}
+	srv, err := New(r, WithMaxBodyBytes(math.MaxInt64))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(gwproto.MessageRequest{
+		From: "u1",
+		Text: "hello",
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		srv.MessagesPath(),
+		bytes.NewReader(body),
+	)
+	req.ContentLength = -1
+	srv.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, 1, r.Calls())
 }
 
 func TestServer_ProcessMessage_FileUploadStorePersistsHostRef(

--- a/openclaw/internal/gateway/server_test.go
+++ b/openclaw/internal/gateway/server_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1429,6 +1430,33 @@ func TestServer_ProcessMessage_LargeInlineData(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	require.Contains(t, rr.Body.String(), "request body exceeds max_body_bytes")
+}
+
+func TestServer_ProcessMessage_LargeBodyWithoutContentLength(t *testing.T) {
+	t.Parallel()
+
+	r := &recordingRunner{}
+	srv, err := New(r, WithMaxBodyBytes(64))
+	require.NoError(t, err)
+
+	body, err := json.Marshal(gwproto.MessageRequest{
+		From: "u1",
+		Text: strings.Repeat("x", 128),
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		srv.MessagesPath(),
+		bytes.NewReader(body),
+	)
+	req.ContentLength = -1
+	srv.Handler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "request body exceeds max_body_bytes")
+	require.Zero(t, r.Calls())
 }
 
 func TestServer_ProcessMessage_FileUploadStorePersistsHostRef(


### PR DESCRIPTION
## Summary

- expose gateway JSON body size as `-gateway-max-body-bytes` and `gateway.max_body_bytes`
- pass the configured limit into the OpenClaw gateway runtime
- return a clear `request body exceeds max_body_bytes` error instead of a truncated JSON decode error

## Validation

```bash
cd openclaw
go test ./internal/gateway -run 'TestServer_ProcessMessage_LargeInlineData|TestOptions' -count=1
go test ./app -run 'TestLoadConfig|TestParseRunOptions|TestRunOptions|TestApplyConfig' -count=1
go test ./cmd/openclaw -run 'TestRunBenchmarkCommandWithIO|TestRunEvalCommandWithIOSendsFileContentParts' -count=1
```
