### PR TITLE
openclaw: finalize on last model budget call

### DIFF
--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -406,7 +406,9 @@ func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {
 				adminRuntimeNumberField(
 					"agent.max_llm_calls",
 					"Max LLM Calls",
-					"Limit LLM calls per invocation; 0 is unlimited.",
+					"Limit agent-facing LLM calls per invocation; "+
+						"auxiliary summary and memory calls are excluded; "+
+						"0 is unlimited.",
 					[]adminRuntimeConfigKeyRef{
 						adminRuntimeKey("agent"),
 						adminRuntimeKey("max_llm_calls"),

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -1370,6 +1370,7 @@ func NewRuntimeWithOptions(
 	gwOpts = appendModelCallBudgetGatewayOption(
 		gwOpts,
 		opts.MaxLLMCalls,
+		opts.FinalizeBeforeMaxLLMCalls,
 	)
 	if langfuseRT != nil && langfuseRT.runOptionResolver != nil {
 		gwOpts = append(
@@ -2000,6 +2001,7 @@ func run(
 	gwOpts = appendModelCallBudgetGatewayOption(
 		gwOpts,
 		opts.MaxLLMCalls,
+		opts.FinalizeBeforeMaxLLMCalls,
 	)
 	if langfuseRT != nil && langfuseRT.runOptionResolver != nil {
 		gwOpts = append(

--- a/openclaw/app/backends.go
+++ b/openclaw/app/backends.go
@@ -368,7 +368,10 @@ func newSessionSummarizer(
 		)
 	}
 
-	return summary.NewSummarizer(mdl, options...), nil
+	return summary.NewSummarizer(
+		newModelCallBudgetBypassModel(mdl),
+		options...,
+	), nil
 }
 
 func parseSummaryPolicy(raw string) (string, error) {

--- a/openclaw/app/backends.go
+++ b/openclaw/app/backends.go
@@ -439,7 +439,10 @@ func newAutoMemoryExtractor(
 		}
 	}
 
-	return memextractor.NewExtractor(mdl, extOpts...), nil
+	return memextractor.NewExtractor(
+		newModelCallBudgetBypassModel(mdl),
+		extOpts...,
+	), nil
 }
 
 const summaryToolResultMaxRunes = 2000

--- a/openclaw/app/backends_test.go
+++ b/openclaw/app/backends_test.go
@@ -292,6 +292,35 @@ func TestNewAutoMemoryExtractor_DoesNotConsumeModelCallBudget(
 	require.EqualValues(t, 3, underlying.callCount())
 }
 
+func TestNewSessionSummarizer_DoesNotConsumeModelCallBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	budgeted := newModelCallBudgetModel(underlying)
+	summarizer, err := newSessionSummarizer(budgeted, runOptions{
+		SessionSummaryEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, summarizer)
+
+	ctx := withModelCallBudget(context.Background(), 1)
+	sess := session.NewSession("app", "user", "sess")
+	sess.Events = append(sess.Events, summaryTestMessageEvent())
+
+	_, err = summarizer.Summarize(ctx, sess)
+	require.NoError(t, err)
+	_, err = summarizer.Summarize(ctx, sess)
+	require.NoError(t, err)
+
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 3, underlying.callCount())
+}
+
 func TestNewAutoMemoryExtractor_PolicyAll(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/backends_test.go
+++ b/openclaw/app/backends_test.go
@@ -10,6 +10,7 @@
 package app
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -260,6 +261,35 @@ func TestNewAutoMemoryExtractor_NoCheckers(t *testing.T) {
 		Messages: make([]model.Message, 1),
 	}
 	require.True(t, ext.ShouldExtract(ctx))
+}
+
+func TestNewAutoMemoryExtractor_DoesNotConsumeModelCallBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	budgeted := newModelCallBudgetModel(underlying)
+	ext, err := newAutoMemoryExtractor(budgeted, runOptions{
+		MemoryAutoEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+	ctx := withModelCallBudget(context.Background(), 1)
+	messages := []model.Message{
+		model.NewUserMessage("Remember that I prefer tea."),
+	}
+
+	_, err = ext.Extract(ctx, messages, nil)
+	require.NoError(t, err)
+	_, err = ext.Extract(ctx, messages, nil)
+	require.NoError(t, err)
+
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 3, underlying.callCount())
 }
 
 func TestNewAutoMemoryExtractor_PolicyAll(t *testing.T) {

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -210,9 +210,12 @@ func finalModelCallRequest(req *model.Request) *model.Request {
 		"[OpenClaw Budget Notice] This is the final allowed model call "+
 			"for this run. No further tools are available now. Use only "+
 			"the existing conversation and tool results, then produce "+
-			"the final user-facing answer immediately. Do not describe "+
-			"future tool use or ask to continue. If the original task "+
-			"requires a final-answer format, follow it exactly.",
+			"the final user-facing answer immediately. Do not emit tool "+
+			"calls, function calls, JSON tool requests, XML-style tool "+
+			"markup such as <tool_call>, code blocks that ask to run "+
+			"tools, or descriptions of future tool use. Do not ask to "+
+			"continue. If the original task requires a final-answer "+
+			"format, follow it exactly.",
 	))
 	return &clone
 }

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -22,6 +22,8 @@ import (
 
 type modelCallBudgetKey struct{}
 
+type modelCallBudgetBypassKey struct{}
+
 const modelCallBudgetRuntimeStateKey = "openclaw.model_call_budget"
 
 type modelCallBudget struct {
@@ -85,8 +87,18 @@ func withModelCallBudgetValue(
 	return context.WithValue(ctx, modelCallBudgetKey{}, budget)
 }
 
+func withoutModelCallBudget(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, modelCallBudgetBypassKey{}, true)
+}
+
 func modelCallBudgetFromContext(ctx context.Context) *modelCallBudget {
 	if ctx == nil {
+		return nil
+	}
+	if bypass, _ := ctx.Value(modelCallBudgetBypassKey{}).(bool); bypass {
 		return nil
 	}
 	budget, _ := ctx.Value(modelCallBudgetKey{}).(*modelCallBudget)
@@ -174,6 +186,20 @@ func modelCallBudgetCallbacks() *model.Callbacks {
 	)
 }
 
+func newModelCallBudgetBypassModel(m model.Model) model.Model {
+	if m == nil {
+		return nil
+	}
+	wrapped := &modelCallBudgetBypassModel{model: m}
+	if iter, ok := m.(model.IterModel); ok {
+		return &modelCallBudgetBypassIterModel{
+			modelCallBudgetBypassModel: wrapped,
+			iter:                       iter,
+		}
+	}
+	return wrapped
+}
+
 type modelCallBudgetModel struct {
 	model model.Model
 }
@@ -199,6 +225,21 @@ func (m *modelCallBudgetModel) Info() model.Info {
 	return m.model.Info()
 }
 
+type modelCallBudgetBypassModel struct {
+	model model.Model
+}
+
+func (m *modelCallBudgetBypassModel) GenerateContent(
+	ctx context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	return m.model.GenerateContent(withoutModelCallBudget(ctx), req)
+}
+
+func (m *modelCallBudgetBypassModel) Info() model.Info {
+	return m.model.Info()
+}
+
 type modelCallBudgetIterModel struct {
 	*modelCallBudgetModel
 	iter model.IterModel
@@ -219,6 +260,18 @@ func (m *modelCallBudgetIterModel) GenerateContentIter(
 		req = finalModelCallRequest(req)
 	}
 	return m.iter.GenerateContentIter(ctx, req)
+}
+
+type modelCallBudgetBypassIterModel struct {
+	*modelCallBudgetBypassModel
+	iter model.IterModel
+}
+
+func (m *modelCallBudgetBypassIterModel) GenerateContentIter(
+	ctx context.Context,
+	req *model.Request,
+) (model.Seq[*model.Response], error) {
+	return m.iter.GenerateContentIter(withoutModelCallBudget(ctx), req)
 }
 
 func appendModelCallBudgetGatewayOption(

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -24,17 +24,26 @@ type modelCallBudgetKey struct{}
 const modelCallBudgetRuntimeStateKey = "openclaw.model_call_budget"
 
 type modelCallBudget struct {
-	mu    sync.Mutex
-	limit int
-	count int
+	mu             sync.Mutex
+	limit          int
+	count          int
+	finalizeOnLast bool
 }
 
-func newModelCallBudget(limit int) *modelCallBudget {
+func newModelCallBudget(
+	limit int,
+	finalizeOnLast ...bool,
+) *modelCallBudget {
 	if limit <= 0 {
 		return nil
 	}
+	finalize := false
+	if len(finalizeOnLast) > 0 {
+		finalize = finalizeOnLast[0]
+	}
 	return &modelCallBudget{
-		limit: limit,
+		limit:          limit,
+		finalizeOnLast: finalize,
 	}
 }
 
@@ -69,19 +78,19 @@ func modelCallBudgetFromContext(ctx context.Context) *modelCallBudget {
 	return budget
 }
 
-func (b *modelCallBudget) use() error {
+func (b *modelCallBudget) use() (bool, error) {
 	if b == nil || b.limit <= 0 {
-		return nil
+		return false, nil
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.count++
-	if b.count <= b.limit {
-		return nil
+	if b.count > b.limit {
+		return false, agent.NewStopError(
+			fmt.Sprintf("max LLM calls (%d) exceeded", b.limit),
+		)
 	}
-	return agent.NewStopError(
-		fmt.Sprintf("max LLM calls (%d) exceeded", b.limit),
-	)
+	return b.finalizeOnLast && b.count == b.limit, nil
 }
 
 func newModelCallBudgetModel(m model.Model) model.Model {
@@ -117,8 +126,12 @@ func (m *modelCallBudgetModel) GenerateContent(
 	ctx context.Context,
 	req *model.Request,
 ) (<-chan *model.Response, error) {
-	if err := modelCallBudgetFromContext(ctx).use(); err != nil {
+	finalize, err := modelCallBudgetFromContext(ctx).use()
+	if err != nil {
 		return nil, err
+	}
+	if finalize {
+		req = finalModelCallRequest(req)
 	}
 	return m.model.GenerateContent(ctx, req)
 }
@@ -136,8 +149,12 @@ func (m *modelCallBudgetIterModel) GenerateContentIter(
 	ctx context.Context,
 	req *model.Request,
 ) (model.Seq[*model.Response], error) {
-	if err := modelCallBudgetFromContext(ctx).use(); err != nil {
+	finalize, err := modelCallBudgetFromContext(ctx).use()
+	if err != nil {
 		return nil, err
+	}
+	if finalize {
+		req = finalModelCallRequest(req)
 	}
 	return m.iter.GenerateContentIter(ctx, req)
 }
@@ -145,24 +162,26 @@ func (m *modelCallBudgetIterModel) GenerateContentIter(
 func appendModelCallBudgetGatewayOption(
 	opts []gateway.Option,
 	limit int,
+	finalizeOnLast bool,
 ) []gateway.Option {
 	if limit <= 0 {
 		return opts
 	}
 	return append(opts, gateway.WithRunOptionResolver(
-		buildModelCallBudgetRunOptionResolver(limit),
+		buildModelCallBudgetRunOptionResolver(limit, finalizeOnLast),
 	))
 }
 
 func buildModelCallBudgetRunOptionResolver(
 	limit int,
+	finalizeOnLast bool,
 ) gateway.RunOptionResolver {
 	return func(ctx context.Context, _ gateway.RunOptionInput) (
 		context.Context,
 		[]agent.RunOption,
 		error,
 	) {
-		budget := newModelCallBudget(limit)
+		budget := newModelCallBudget(limit, finalizeOnLast)
 		return withModelCallBudgetValue(ctx, budget),
 			[]agent.RunOption{
 				agent.MergeRuntimeState(map[string]any{
@@ -171,4 +190,22 @@ func buildModelCallBudgetRunOptionResolver(
 			},
 			nil
 	}
+}
+
+func finalModelCallRequest(req *model.Request) *model.Request {
+	if req == nil {
+		req = &model.Request{}
+	}
+	clone := *req
+	clone.Tools = nil
+	clone.Messages = append([]model.Message(nil), req.Messages...)
+	clone.Messages = append(clone.Messages, model.NewUserMessage(
+		"[OpenClaw Budget Notice] This is the final allowed model call "+
+			"for this run. No further tools are available now. Use only "+
+			"the existing conversation and tool results, then produce "+
+			"the final user-facing answer immediately. Do not describe "+
+			"future tool use or ask to continue. If the original task "+
+			"requires a final-answer format, follow it exactly.",
+	))
+	return &clone
 }

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -48,6 +48,26 @@ func newModelCallBudget(
 	}
 }
 
+type modelCallBudgetFactory struct {
+	mu             sync.Mutex
+	limit          int
+	finalizeOnLast bool
+	budgets        map[string]*modelCallBudget
+}
+
+func newModelCallBudgetFactory(
+	limit int,
+	finalizeOnLast bool,
+) *modelCallBudgetFactory {
+	if limit <= 0 {
+		return nil
+	}
+	return &modelCallBudgetFactory{
+		limit:          limit,
+		finalizeOnLast: finalizeOnLast,
+	}
+}
+
 func withModelCallBudget(ctx context.Context, limit int) context.Context {
 	return withModelCallBudgetValue(ctx, newModelCallBudget(limit))
 }
@@ -69,14 +89,49 @@ func modelCallBudgetFromContext(ctx context.Context) *modelCallBudget {
 	if ctx == nil {
 		return nil
 	}
-	if budget, _ := ctx.Value(modelCallBudgetKey{}).(*modelCallBudget); budget != nil {
+	budget, _ := ctx.Value(modelCallBudgetKey{}).(*modelCallBudget)
+	if budget != nil {
 		return budget
 	}
-	budget, _ := agent.GetRuntimeStateValueFromContext[*modelCallBudget](
-		ctx,
+	inv, ok := agent.InvocationFromContext(ctx)
+	if !ok || inv == nil {
+		return nil
+	}
+	factory, _ := agent.GetRuntimeStateValue[*modelCallBudgetFactory](
+		&inv.RunOptions,
 		modelCallBudgetRuntimeStateKey,
 	)
+	if factory == nil {
+		return nil
+	}
+	return factory.budgetFor(inv)
+}
+
+func (f *modelCallBudgetFactory) budgetFor(
+	inv *agent.Invocation,
+) *modelCallBudget {
+	if f == nil || inv == nil || f.limit <= 0 {
+		return nil
+	}
+	key := modelCallBudgetInvocationKey(inv)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.budgets == nil {
+		f.budgets = make(map[string]*modelCallBudget)
+	}
+	if budget := f.budgets[key]; budget != nil {
+		return budget
+	}
+	budget := newModelCallBudget(f.limit, f.finalizeOnLast)
+	f.budgets[key] = budget
 	return budget
+}
+
+func modelCallBudgetInvocationKey(inv *agent.Invocation) string {
+	if inv.InvocationID != "" {
+		return inv.InvocationID
+	}
+	return fmt.Sprintf("%p", inv)
 }
 
 func (b *modelCallBudget) use() (bool, error) {
@@ -188,11 +243,11 @@ func buildModelCallBudgetRunOptionResolver(
 		[]agent.RunOption,
 		error,
 	) {
-		budget := newModelCallBudget(limit, finalizeOnLast)
-		return withModelCallBudgetValue(ctx, budget),
+		factory := newModelCallBudgetFactory(limit, finalizeOnLast)
+		return ctx,
 			[]agent.RunOption{
 				agent.MergeRuntimeState(map[string]any{
-					modelCallBudgetRuntimeStateKey: budget,
+					modelCallBudgetRuntimeStateKey: factory,
 				}),
 			},
 			nil

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -12,6 +12,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -126,6 +127,9 @@ func (m *modelCallBudgetModel) GenerateContent(
 	ctx context.Context,
 	req *model.Request,
 ) (<-chan *model.Response, error) {
+	if modelCallBudgetShouldSkip(req) {
+		return m.model.GenerateContent(ctx, req)
+	}
 	finalize, err := modelCallBudgetFromContext(ctx).use()
 	if err != nil {
 		return nil, err
@@ -149,6 +153,9 @@ func (m *modelCallBudgetIterModel) GenerateContentIter(
 	ctx context.Context,
 	req *model.Request,
 ) (model.Seq[*model.Response], error) {
+	if modelCallBudgetShouldSkip(req) {
+		return m.iter.GenerateContentIter(ctx, req)
+	}
 	finalize, err := modelCallBudgetFromContext(ctx).use()
 	if err != nil {
 		return nil, err
@@ -208,4 +215,15 @@ func finalModelCallRequest(req *model.Request) *model.Request {
 			"requires a final-answer format, follow it exactly.",
 	))
 	return &clone
+}
+
+func modelCallBudgetShouldSkip(req *model.Request) bool {
+	if req == nil || len(req.Messages) == 0 {
+		return false
+	}
+	first := strings.TrimSpace(req.Messages[0].Content)
+	return strings.HasPrefix(
+		first,
+		"Analyze the following conversation between a user and an assistant",
+	)
 }

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -12,6 +12,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -306,6 +307,7 @@ func finalModelCallRequest(req *model.Request) *model.Request {
 	}
 	clone := *req
 	clone.Tools = nil
+	clone.ExtraFields = finalModelCallExtraFields(req.ExtraFields)
 	clone.Messages = append([]model.Message(nil), req.Messages...)
 	clone.Messages = append(clone.Messages, model.NewUserMessage(
 		"[OpenClaw Budget Notice] This is the final allowed model call "+
@@ -319,4 +321,27 @@ func finalModelCallRequest(req *model.Request) *model.Request {
 			"format, follow it exactly.",
 	))
 	return &clone
+}
+
+func finalModelCallExtraFields(extra map[string]any) map[string]any {
+	if len(extra) == 0 {
+		return nil
+	}
+	clone := make(map[string]any, len(extra))
+	for key, value := range extra {
+		switch strings.ToLower(key) {
+		case "function_call",
+			"functions",
+			"parallel_tool_calls",
+			"tool_choice",
+			"tools":
+			continue
+		default:
+			clone[key] = value
+		}
+	}
+	if len(clone) == 0 {
+		return nil
+	}
+	return clone
 }

--- a/openclaw/app/model_call_budget.go
+++ b/openclaw/app/model_call_budget.go
@@ -12,7 +12,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -208,9 +207,6 @@ func (m *modelCallBudgetModel) GenerateContent(
 	ctx context.Context,
 	req *model.Request,
 ) (<-chan *model.Response, error) {
-	if modelCallBudgetShouldSkip(req) {
-		return m.model.GenerateContent(ctx, req)
-	}
 	finalize, err := modelCallBudgetFromContext(ctx).use()
 	if err != nil {
 		return nil, err
@@ -249,9 +245,6 @@ func (m *modelCallBudgetIterModel) GenerateContentIter(
 	ctx context.Context,
 	req *model.Request,
 ) (model.Seq[*model.Response], error) {
-	if modelCallBudgetShouldSkip(req) {
-		return m.iter.GenerateContentIter(ctx, req)
-	}
 	finalize, err := modelCallBudgetFromContext(ctx).use()
 	if err != nil {
 		return nil, err
@@ -326,15 +319,4 @@ func finalModelCallRequest(req *model.Request) *model.Request {
 			"format, follow it exactly.",
 	))
 	return &clone
-}
-
-func modelCallBudgetShouldSkip(req *model.Request) bool {
-	if req == nil || len(req.Messages) == 0 {
-		return false
-	}
-	first := strings.TrimSpace(req.Messages[0].Content)
-	return strings.HasPrefix(
-		first,
-		"Analyze the following conversation between a user and an assistant",
-	)
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -247,6 +247,12 @@ func TestModelCallBudgetModel_FinalizesOnLastAllowedCall(t *testing.T) {
 	req := &model.Request{
 		Messages: []model.Message{model.NewUserMessage("question")},
 		Tools:    map[string]tool.Tool{"search": nil},
+		ExtraFields: map[string]any{
+			"parallel_tool_calls": true,
+			"response_format":     "json",
+			"tool_choice":         "required",
+			"tools":               []string{"search"},
+		},
 	}
 
 	_, err := wrapped.GenerateContent(ctx, req)
@@ -273,6 +279,15 @@ func TestModelCallBudgetModel_FinalizesOnLastAllowedCall(t *testing.T) {
 	)
 	require.Len(t, req.Tools, 1)
 	require.Len(t, req.Messages, 1)
+	require.Equal(t, map[string]any{
+		"parallel_tool_calls": true,
+		"response_format":     "json",
+		"tool_choice":         "required",
+		"tools":               []string{"search"},
+	}, req.ExtraFields)
+	require.Equal(t, map[string]any{
+		"response_format": "json",
+	}, got.ExtraFields)
 }
 
 func TestModelCallBudgetModel_UserPromptPrefixConsumesBudget(t *testing.T) {
@@ -479,4 +494,35 @@ func TestBuildModelCallBudgetRunOptionResolverInjectsBudget(
 	_, err = wrapped.GenerateContent(childCtx, &model.Request{})
 	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
 	require.EqualValues(t, 2, underlying.callCount())
+}
+
+func TestBuildModelCallBudgetRunOptionResolverBypassesAuxiliaryCalls(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	resolver := buildModelCallBudgetRunOptionResolver(1, false)
+	_, runOpts, err := resolver(context.Background(), gateway.RunOptionInput{})
+	require.NoError(t, err)
+
+	opts := agent.NewRunOptions(runOpts...)
+	underlying := &countingBudgetModel{}
+	budgeted := newModelCallBudgetModel(underlying)
+	auxiliary := newModelCallBudgetBypassModel(budgeted)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("run"),
+		agent.WithInvocationRunOptions(opts),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	_, err = auxiliary.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = auxiliary.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 3, underlying.callCount())
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -259,6 +259,16 @@ func TestModelCallBudgetModel_FinalizesOnLastAllowedCall(t *testing.T) {
 		got.Messages[1].Content,
 		"final allowed model call",
 	)
+	require.Contains(
+		t,
+		got.Messages[1].Content,
+		"Do not emit tool calls",
+	)
+	require.Contains(
+		t,
+		got.Messages[1].Content,
+		"<tool_call>",
+	)
 	require.Len(t, req.Tools, 1)
 	require.Len(t, req.Messages, 1)
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -295,6 +295,82 @@ func TestModelCallBudgetModel_SkipsSummaryRequests(t *testing.T) {
 	require.EqualValues(t, 2, underlying.callCount())
 }
 
+func TestModelCallBudgetBypassModel_DoesNotConsumeContextBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	budgeted := newModelCallBudgetModel(underlying)
+	bypassed := newModelCallBudgetBypassModel(budgeted)
+	ctx := withModelCallBudget(context.Background(), 1)
+
+	_, err := bypassed.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = bypassed.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 3, underlying.callCount())
+}
+
+func TestModelCallBudgetBypassModel_DoesNotConsumeInvocationBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	budgeted := newModelCallBudgetModel(underlying)
+	bypassed := newModelCallBudgetBypassModel(budgeted)
+	factory := newModelCallBudgetFactory(1, false)
+	inv := agent.NewInvocation(agent.WithInvocationRunOptions(
+		agent.NewRunOptions(agent.MergeRuntimeState(map[string]any{
+			modelCallBudgetRuntimeStateKey: factory,
+		})),
+	))
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	_, err := bypassed.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = bypassed.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = budgeted.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 3, underlying.callCount())
+}
+
+func TestModelCallBudgetBypassIterModel_DoesNotConsumeContextBudget(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	underlying := &countingBudgetIterModel{}
+	budgeted := newModelCallBudgetModel(underlying)
+	bypassed := newModelCallBudgetBypassModel(budgeted)
+	bypassIter, ok := bypassed.(model.IterModel)
+	require.True(t, ok)
+	budgetedIter, ok := budgeted.(model.IterModel)
+	require.True(t, ok)
+	ctx := withModelCallBudget(context.Background(), 1)
+
+	_, err := bypassIter.GenerateContentIter(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = bypassIter.GenerateContentIter(ctx, &model.Request{})
+	require.NoError(t, err)
+
+	_, err = budgetedIter.GenerateContentIter(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = budgetedIter.GenerateContentIter(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 3, underlying.iterCallCount())
+}
+
 type countingBudgetModel struct {
 	calls atomic.Int64
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -263,6 +263,26 @@ func TestModelCallBudgetModel_FinalizesOnLastAllowedCall(t *testing.T) {
 	require.Len(t, req.Messages, 1)
 }
 
+func TestModelCallBudgetModel_SkipsSummaryRequests(t *testing.T) {
+	t.Parallel()
+
+	underlying := &countingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	ctx := withModelCallBudget(context.Background(), 1)
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage(
+		"Analyze the following conversation between a user and an assistant, " +
+			"and provide a concise summary.",
+	)}}
+
+	_, err := wrapped.GenerateContent(ctx, req)
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 2, underlying.callCount())
+}
+
 type countingBudgetModel struct {
 	calls atomic.Int64
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -70,15 +70,17 @@ func TestModelCallBudgetIterModel_NoBudgetPassesThrough(t *testing.T) {
 	require.EqualValues(t, 1, underlying.iterCallCount())
 }
 
-func TestModelCallBudgetModel_UsesInvocationRuntimeState(t *testing.T) {
+func TestModelCallBudgetModel_UsesInvocationRuntimeStateFactory(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	underlying := &countingBudgetModel{}
 	wrapped := newModelCallBudgetModel(underlying)
-	budget := newModelCallBudget(1)
+	factory := newModelCallBudgetFactory(1, false)
 	inv := agent.NewInvocation(agent.WithInvocationRunOptions(
 		agent.NewRunOptions(agent.MergeRuntimeState(map[string]any{
-			modelCallBudgetRuntimeStateKey: budget,
+			modelCallBudgetRuntimeStateKey: factory,
 		})),
 	))
 	ctx := agent.NewInvocationContext(context.Background(), inv)
@@ -373,19 +375,32 @@ func TestBuildModelCallBudgetRunOptionResolverInjectsBudget(
 	require.NoError(t, err)
 	require.Len(t, runOpts, 1)
 
-	budget := modelCallBudgetFromContext(ctx)
-	require.NotNil(t, budget)
+	require.Nil(t, modelCallBudgetFromContext(ctx))
 
 	opts := agent.NewRunOptions(runOpts...)
-	stateBudget, ok := opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudget)
+	rawFactory := opts.RuntimeState[modelCallBudgetRuntimeStateKey]
+	factory, ok := rawFactory.(*modelCallBudgetFactory)
 	require.True(t, ok)
-	require.Same(t, budget, stateBudget)
+	require.NotNil(t, factory)
 
 	underlying := &countingBudgetModel{}
 	wrapped := newModelCallBudgetModel(underlying)
-	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	parent := agent.NewInvocation(
+		agent.WithInvocationID("parent"),
+		agent.WithInvocationRunOptions(opts),
+	)
+	parentCtx := agent.NewInvocationContext(context.Background(), parent)
+	child := parent.Clone(agent.WithInvocationID("child"))
+	childCtx := agent.NewInvocationContext(context.Background(), child)
+
+	_, err = wrapped.GenerateContent(parentCtx, &model.Request{})
 	require.NoError(t, err)
-	_, err = wrapped.GenerateContent(ctx, &model.Request{})
+	_, err = wrapped.GenerateContent(parentCtx, &model.Request{})
 	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
-	require.EqualValues(t, 1, underlying.callCount())
+
+	_, err = wrapped.GenerateContent(childCtx, &model.Request{})
+	require.NoError(t, err)
+	_, err = wrapped.GenerateContent(childCtx, &model.Request{})
+	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
+	require.EqualValues(t, 2, underlying.callCount())
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -275,7 +275,7 @@ func TestModelCallBudgetModel_FinalizesOnLastAllowedCall(t *testing.T) {
 	require.Len(t, req.Messages, 1)
 }
 
-func TestModelCallBudgetModel_SkipsSummaryRequests(t *testing.T) {
+func TestModelCallBudgetModel_UserPromptPrefixConsumesBudget(t *testing.T) {
 	t.Parallel()
 
 	underlying := &countingBudgetModel{}
@@ -289,10 +289,8 @@ func TestModelCallBudgetModel_SkipsSummaryRequests(t *testing.T) {
 	_, err := wrapped.GenerateContent(ctx, req)
 	require.NoError(t, err)
 	_, err = wrapped.GenerateContent(ctx, &model.Request{})
-	require.NoError(t, err)
-	_, err = wrapped.GenerateContent(ctx, &model.Request{})
 	require.ErrorContains(t, err, "max LLM calls (1) exceeded")
-	require.EqualValues(t, 2, underlying.callCount())
+	require.EqualValues(t, 1, underlying.callCount())
 }
 
 func TestModelCallBudgetBypassModel_DoesNotConsumeContextBudget(
@@ -381,7 +379,9 @@ func (m *countingBudgetModel) GenerateContent(
 ) (<-chan *model.Response, error) {
 	m.calls.Add(1)
 	ch := make(chan *model.Response, 1)
-	ch <- &model.Response{}
+	ch <- &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage("ok"),
+	}}}
 	close(ch)
 	return ch, nil
 }

--- a/openclaw/app/model_call_budget_test.go
+++ b/openclaw/app/model_call_budget_test.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 func TestModelCallBudgetModel_EnforcesPerContextLimit(t *testing.T) {
@@ -164,7 +165,8 @@ func TestModelCallBudget_Guards(t *testing.T) {
 
 	require.Nil(t, newModelCallBudget(0))
 	require.Nil(t, newModelCallBudget(-1))
-	require.NoError(t, (*modelCallBudget)(nil).use())
+	_, err := (*modelCallBudget)(nil).use()
+	require.NoError(t, err)
 
 	ctx := withModelCallBudget(nil, 1)
 	require.NotNil(t, ctx)
@@ -220,15 +222,45 @@ func TestBaseLLMAgentOptions_AddsModelCallBudgetCallbacks(t *testing.T) {
 func TestAppendModelCallBudgetGatewayOption_Disabled(t *testing.T) {
 	t.Parallel()
 
-	opts := appendModelCallBudgetGatewayOption(nil, 0)
+	opts := appendModelCallBudgetGatewayOption(nil, 0, false)
 	require.Empty(t, opts)
 }
 
 func TestAppendModelCallBudgetGatewayOption_AddsRunBudget(t *testing.T) {
 	t.Parallel()
 
-	opts := appendModelCallBudgetGatewayOption(nil, 1)
+	opts := appendModelCallBudgetGatewayOption(nil, 1, false)
 	require.Len(t, opts, 1)
+}
+
+func TestModelCallBudgetModel_FinalizesOnLastAllowedCall(t *testing.T) {
+	t.Parallel()
+
+	underlying := &capturingBudgetModel{}
+	wrapped := newModelCallBudgetModel(underlying)
+	ctx := withModelCallBudgetValue(
+		context.Background(),
+		newModelCallBudget(1, true),
+	)
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+		Tools:    map[string]tool.Tool{"search": nil},
+	}
+
+	_, err := wrapped.GenerateContent(ctx, req)
+	require.NoError(t, err)
+
+	got := underlying.lastRequest()
+	require.NotNil(t, got)
+	require.Nil(t, got.Tools)
+	require.Len(t, got.Messages, 2)
+	require.Contains(
+		t,
+		got.Messages[1].Content,
+		"final allowed model call",
+	)
+	require.Len(t, req.Tools, 1)
+	require.Len(t, req.Messages, 1)
 }
 
 type countingBudgetModel struct {
@@ -252,6 +284,34 @@ func (m *countingBudgetModel) Info() model.Info {
 
 func (m *countingBudgetModel) callCount() int64 {
 	return m.calls.Load()
+}
+
+type capturingBudgetModel struct {
+	mu   sync.Mutex
+	last *model.Request
+}
+
+func (m *capturingBudgetModel) GenerateContent(
+	_ context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	m.mu.Lock()
+	m.last = req
+	m.mu.Unlock()
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{}
+	close(ch)
+	return ch, nil
+}
+
+func (m *capturingBudgetModel) Info() model.Info {
+	return model.Info{Name: "capturing"}
+}
+
+func (m *capturingBudgetModel) lastRequest() *model.Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.last
 }
 
 type countingBudgetIterModel struct {
@@ -278,7 +338,7 @@ func TestBuildModelCallBudgetRunOptionResolverInjectsBudget(
 ) {
 	t.Parallel()
 
-	resolver := buildModelCallBudgetRunOptionResolver(1)
+	resolver := buildModelCallBudgetRunOptionResolver(1, false)
 	ctx, runOpts, err := resolver(context.Background(), gateway.RunOptionInput{})
 	require.NoError(t, err)
 	require.Len(t, runOpts, 1)

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -1212,13 +1212,15 @@ type agentRunConfig struct {
 	EnableContextCompaction                       *bool `yaml:"enable_context_compaction,omitempty"`
 	ContextCompactionOversizedToolResultMaxTokens *int  `yaml:"context_compaction_oversized_tool_result_max_tokens,omitempty"`
 	MaxHistoryRuns                                *int  `yaml:"max_history_runs,omitempty"`
-	MaxLLMCalls                                   *int  `yaml:"max_llm_calls,omitempty"`
-	FinalizeBeforeMaxLLMCalls                     *bool `yaml:"finalize_before_max_llm_calls,omitempty"`
-	MaxToolIterations                             *int  `yaml:"max_tool_iterations,omitempty"`
-	PreloadMemory                                 *int  `yaml:"preload_memory,omitempty"`
-	ToolCallArgumentsJSONRepair                   *bool `yaml:"tool_call_arguments_json_repair,omitempty"`
-	DisablePostToolPrompt                         *bool `yaml:"disable_post_tool_prompt,omitempty"`
-	DisablePostToolPromptCamel                    *bool `yaml:"disablePostToolPrompt,omitempty"`
+	// MaxLLMCalls limits agent-facing model calls per invocation. Auxiliary
+	// session summary and auto-memory extraction calls are excluded.
+	MaxLLMCalls                 *int  `yaml:"max_llm_calls,omitempty"`
+	FinalizeBeforeMaxLLMCalls   *bool `yaml:"finalize_before_max_llm_calls,omitempty"`
+	MaxToolIterations           *int  `yaml:"max_tool_iterations,omitempty"`
+	PreloadMemory               *int  `yaml:"preload_memory,omitempty"`
+	ToolCallArgumentsJSONRepair *bool `yaml:"tool_call_arguments_json_repair,omitempty"`
+	DisablePostToolPrompt       *bool `yaml:"disable_post_tool_prompt,omitempty"`
+	DisablePostToolPromptCamel  *bool `yaml:"disablePostToolPrompt,omitempty"`
 
 	Instruction      *string  `yaml:"instruction,omitempty"`
 	InstructionFiles []string `yaml:"instruction_files,omitempty"`

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -92,6 +92,7 @@ const (
 	flagContextCompactionOversizedToolResultMaxTokens = "context-compaction-oversized-tool-result-max-tokens"
 	flagMaxHistoryRuns                                = "max-history-runs"
 	flagMaxLLMCalls                                   = "max-llm-calls"
+	flagFinalizeBeforeMaxLLMCalls                     = "finalize-before-max-llm-calls"
 	flagMaxToolIterations                             = "max-tool-iterations"
 	flagPreloadMemory                                 = "preload-memory"
 	flagToolCallArgumentsJSONRepair                   = "tool-call-arguments-json-repair"
@@ -189,6 +190,7 @@ type runOptions struct {
 	ContextCompactionOversizedToolResultMaxTokens int
 	MaxHistoryRuns                                int
 	MaxLLMCalls                                   int
+	FinalizeBeforeMaxLLMCalls                     bool
 	MaxToolIterations                             int
 	PreloadMemory                                 int
 	ToolCallArgumentsJSONRepair                   bool
@@ -471,6 +473,12 @@ func parseRunOptions(args []string) (runOptions, error) {
 		flagMaxLLMCalls,
 		0,
 		"Max LLM calls per invocation (0=unlimited)",
+	)
+	fs.BoolVar(
+		&opts.FinalizeBeforeMaxLLMCalls,
+		flagFinalizeBeforeMaxLLMCalls,
+		false,
+		"On the last allowed LLM call, disable tools and ask the model to finalize",
 	)
 	fs.IntVar(
 		&opts.MaxToolIterations,
@@ -1205,6 +1213,7 @@ type agentRunConfig struct {
 	ContextCompactionOversizedToolResultMaxTokens *int  `yaml:"context_compaction_oversized_tool_result_max_tokens,omitempty"`
 	MaxHistoryRuns                                *int  `yaml:"max_history_runs,omitempty"`
 	MaxLLMCalls                                   *int  `yaml:"max_llm_calls,omitempty"`
+	FinalizeBeforeMaxLLMCalls                     *bool `yaml:"finalize_before_max_llm_calls,omitempty"`
 	MaxToolIterations                             *int  `yaml:"max_tool_iterations,omitempty"`
 	PreloadMemory                                 *int  `yaml:"preload_memory,omitempty"`
 	ToolCallArgumentsJSONRepair                   *bool `yaml:"tool_call_arguments_json_repair,omitempty"`
@@ -1725,6 +1734,10 @@ func (cfg *fileConfig) apply(
 		if cfg.Agent.MaxLLMCalls != nil &&
 			!flagWasSet(set, flagMaxLLMCalls) {
 			opts.MaxLLMCalls = *cfg.Agent.MaxLLMCalls
+		}
+		if cfg.Agent.FinalizeBeforeMaxLLMCalls != nil &&
+			!flagWasSet(set, flagFinalizeBeforeMaxLLMCalls) {
+			opts.FinalizeBeforeMaxLLMCalls = *cfg.Agent.FinalizeBeforeMaxLLMCalls
 		}
 		if cfg.Agent.MaxToolIterations != nil &&
 			!flagWasSet(set, flagMaxToolIterations) {

--- a/openclaw/app/run_options_test.go
+++ b/openclaw/app/run_options_test.go
@@ -498,6 +498,7 @@ agent:
 		"-context-compaction-oversized-tool-result-max-tokens", "256",
 		"-max-history-runs", "9",
 		"-max-llm-calls", "4",
+		"-finalize-before-max-llm-calls",
 		"-max-tool-iterations", "6",
 		"-preload-memory", "-1",
 		"-tool-call-arguments-json-repair=true",
@@ -522,6 +523,7 @@ agent:
 	require.Equal(t, 256, opts.ContextCompactionOversizedToolResultMaxTokens)
 	require.Equal(t, 9, opts.MaxHistoryRuns)
 	require.Equal(t, 4, opts.MaxLLMCalls)
+	require.True(t, opts.FinalizeBeforeMaxLLMCalls)
 	require.Equal(t, 6, opts.MaxToolIterations)
 	require.Equal(t, -1, opts.PreloadMemory)
 	require.True(t, opts.ToolCallArgumentsJSONRepair)
@@ -803,6 +805,7 @@ agent:
   context_compaction_oversized_tool_result_max_tokens: 4096
   max_history_runs: 50
   max_llm_calls: 13
+  finalize_before_max_llm_calls: true
   max_tool_iterations: 11
   preload_memory: 10
   tool_call_arguments_json_repair: false
@@ -975,6 +978,7 @@ memory:
 	require.Equal(t, 4096, opts.ContextCompactionOversizedToolResultMaxTokens)
 	require.Equal(t, 50, opts.MaxHistoryRuns)
 	require.Equal(t, 13, opts.MaxLLMCalls)
+	require.True(t, opts.FinalizeBeforeMaxLLMCalls)
 	require.Equal(t, 11, opts.MaxToolIterations)
 	require.Equal(t, 10, opts.PreloadMemory)
 	require.False(t, opts.ToolCallArgumentsJSONRepair)


### PR DESCRIPTION
## Summary

- add an opt-in `-finalize-before-max-llm-calls` / `agent.finalize_before_max_llm_calls` setting
- when enabled, the last allowed model call disables tools and asks the model to produce the final answer from existing evidence
- keep existing max-LLM-call behavior unchanged by default

## Validation

```bash
cd openclaw
go test ./app -run 'TestModelCallBudget|TestAppendModelCallBudget|TestBuildModelCallBudget|TestParseRunOptions|TestLoadConfig|TestRunOptions|TestApplyConfig' -count=1
go test ./cmd/openclaw -run 'TestRunBenchmarkCommandWithIO|TestRunEvalCommandWithIOSendsFileContentParts' -count=1
```
