### PR TITLE
openclaw: read text-like uploads as documents

### DIFF
--- a/openclaw/internal/octool/file_tools.go
+++ b/openclaw/internal/octool/file_tools.go
@@ -493,7 +493,7 @@ func documentKindFromPath(path string) string {
 		return docKindPDF
 	case ".docx", ".doc":
 		return docKindDOCX
-	case ".txt", ".md", ".markdown", ".json", ".csv",
+	case ".txt", ".md", ".markdown", ".json", ".jsonld", ".csv",
 		".yaml", ".yml", ".log":
 		return docKindText
 	case ".png", ".jpg", ".jpeg", ".webp", ".gif":

--- a/openclaw/internal/octool/file_tools.go
+++ b/openclaw/internal/octool/file_tools.go
@@ -494,7 +494,12 @@ func documentKindFromPath(path string) string {
 	case ".docx", ".doc":
 		return docKindDOCX
 	case ".txt", ".md", ".markdown", ".json", ".jsonld", ".csv",
-		".yaml", ".yml", ".log":
+		".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf",
+		".log", ".py", ".go", ".js", ".jsx", ".ts", ".tsx",
+		".java", ".c", ".cc", ".cpp", ".h", ".hpp", ".rs",
+		".rb", ".php", ".sh", ".bash", ".zsh", ".fish", ".sql",
+		".xml", ".html", ".htm", ".css", ".scss", ".less",
+		".rst", ".tex":
 		return docKindText
 	case ".png", ".jpg", ".jpeg", ".webp", ".gif":
 		return docKindImage

--- a/openclaw/internal/octool/file_tools_test.go
+++ b/openclaw/internal/octool/file_tools_test.go
@@ -213,6 +213,12 @@ func TestReadDocumentTool_TextDocxAndErrors(t *testing.T) {
 		[]byte(`{"@context":"https://schema.org","name":"example"}`),
 		0o600,
 	))
+	pythonPath := filepath.Join(t.TempDir(), "script.py")
+	require.NoError(t, os.WriteFile(
+		pythonPath,
+		[]byte("print('hello')\n"),
+		0o600,
+	))
 
 	docxPath := createSampleDOCX(t, "hello docx")
 	tool := newReadDocumentTool()
@@ -237,6 +243,15 @@ func TestReadDocumentTool_TextDocxAndErrors(t *testing.T) {
 	require.Equal(t, docKindText, jsonldRes.Kind)
 	require.Contains(t, jsonldRes.Text, `"@context"`)
 	require.Contains(t, jsonldRes.Text, `"name":"example"`)
+
+	pythonOut, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
+		"path": pythonPath,
+	}))
+	require.NoError(t, err)
+
+	pythonRes := pythonOut.(readDocumentResult)
+	require.Equal(t, docKindText, pythonRes.Kind)
+	require.Contains(t, pythonRes.Text, "print('hello')")
 
 	docxOut, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
 		"path": docxPath,
@@ -317,6 +332,9 @@ func TestReadDocumentHelpers(t *testing.T) {
 	require.Equal(t, docKindDOCX, documentKindFromPath(docxPath))
 	require.Equal(t, docKindText, documentKindFromPath(logPath))
 	require.Equal(t, docKindText, documentKindFromPath("metadata.jsonld"))
+	require.Equal(t, docKindText, documentKindFromPath("script.py"))
+	require.Equal(t, docKindText, documentKindFromPath("query.sql"))
+	require.Equal(t, docKindText, documentKindFromPath("config.toml"))
 	require.Equal(t, docKindImage, documentKindFromPath("chart.png"))
 	require.Equal(t, docKindImage, documentKindFromPath("photo.jpeg"))
 	require.Equal(t, "", documentKindFromPath("bad.bin"))

--- a/openclaw/internal/octool/file_tools_test.go
+++ b/openclaw/internal/octool/file_tools_test.go
@@ -207,6 +207,12 @@ func TestReadDocumentTool_TextDocxAndErrors(t *testing.T) {
 		[]byte("alpha\nbeta\ngamma"),
 		0o600,
 	))
+	jsonldPath := filepath.Join(t.TempDir(), "metadata.jsonld")
+	require.NoError(t, os.WriteFile(
+		jsonldPath,
+		[]byte(`{"@context":"https://schema.org","name":"example"}`),
+		0o600,
+	))
 
 	docxPath := createSampleDOCX(t, "hello docx")
 	tool := newReadDocumentTool()
@@ -221,6 +227,16 @@ func TestReadDocumentTool_TextDocxAndErrors(t *testing.T) {
 	require.Equal(t, docKindText, textRes.Kind)
 	require.True(t, textRes.Truncated)
 	require.Equal(t, "alpha", textRes.Text)
+
+	jsonldOut, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
+		"path": jsonldPath,
+	}))
+	require.NoError(t, err)
+
+	jsonldRes := jsonldOut.(readDocumentResult)
+	require.Equal(t, docKindText, jsonldRes.Kind)
+	require.Contains(t, jsonldRes.Text, `"@context"`)
+	require.Contains(t, jsonldRes.Text, `"name":"example"`)
 
 	docxOut, err := tool.Call(context.Background(), mustJSON(t, map[string]any{
 		"path": docxPath,
@@ -300,6 +316,7 @@ func TestReadDocumentHelpers(t *testing.T) {
 
 	require.Equal(t, docKindDOCX, documentKindFromPath(docxPath))
 	require.Equal(t, docKindText, documentKindFromPath(logPath))
+	require.Equal(t, docKindText, documentKindFromPath("metadata.jsonld"))
 	require.Equal(t, docKindImage, documentKindFromPath("chart.png"))
 	require.Equal(t, docKindImage, documentKindFromPath("photo.jpeg"))
 	require.Equal(t, "", documentKindFromPath("bad.bin"))


### PR DESCRIPTION
## Summary
- treat `.jsonld` files as text documents in `read_document`
- cover JSON-LD reads and document kind detection

## Tests
- `go test ./internal/octool -run 'TestReadDocumentTool_TextDocxAndErrors|TestReadDocumentHelpers' -count=1`