### PR TITLE
tool/file: allow absolute reads under base dir

### DIFF
--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -496,7 +496,11 @@ func TestNewFileToolSet_RuntimeReadDirsCanDisable(t *testing.T) {
 		[]byte(`{"file_name":`+strconv.Quote(tmpFile)+`}`),
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "outside configured read-only roots")
+	require.Contains(
+		t,
+		err.Error(),
+		"outside base_directory and configured read-only roots",
+	)
 }
 
 func TestDefaultFileReadOnlyDirsIncludesPlatformTmp(t *testing.T) {

--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -300,7 +300,7 @@ func (f *fileToolSet) resolveReadPath(requestPath string) (string, error) {
 		return f.resolvePath(requestPath)
 	}
 	clean := filepath.Clean(raw)
-	if _, ok := f.matchExtraReadRoot(clean); ok {
+	if _, ok := f.matchReadRoot(clean); ok {
 		return clean, nil
 	}
 	return "", fmt.Errorf(
@@ -310,6 +310,42 @@ func (f *fileToolSet) resolveReadPath(requestPath string) (string, error) {
 		extraReadRootGuidance,
 		relativePathGuidance,
 	)
+}
+
+func (f *fileToolSet) matchReadRoot(absPath string) (string, bool) {
+	if root, ok := f.matchBaseReadRoot(absPath); ok {
+		return root, true
+	}
+	return f.matchExtraReadRoot(absPath)
+}
+
+func (f *fileToolSet) matchBaseReadRoot(absPath string) (string, bool) {
+	if f == nil || strings.TrimSpace(f.baseDir) == "" {
+		return "", false
+	}
+	root := filepath.Clean(f.baseDir)
+	if !filepath.IsAbs(root) {
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			return "", false
+		}
+		root = absRoot
+	}
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = filepath.Clean(resolved)
+	}
+	candidate := filepath.Clean(absPath)
+	evaluatedCandidate, resolvedPath := evalPathWithExistingParent(candidate)
+	candidateInRoot := isPathWithinRoot(candidate, root)
+	evaluatedInRoot := resolvedPath &&
+		isPathWithinRoot(evaluatedCandidate, root)
+	if candidateInRoot && (!resolvedPath || evaluatedInRoot) {
+		return root, true
+	}
+	if !candidateInRoot && evaluatedInRoot {
+		return root, true
+	}
+	return "", false
 }
 
 func (f *fileToolSet) matchExtraReadRoot(absPath string) (string, bool) {

--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -336,13 +336,7 @@ func (f *fileToolSet) matchBaseReadRoot(absPath string) (string, bool) {
 	}
 	candidate := filepath.Clean(absPath)
 	evaluatedCandidate, resolvedPath := evalPathWithExistingParent(candidate)
-	candidateInRoot := isPathWithinRoot(candidate, root)
-	evaluatedInRoot := resolvedPath &&
-		isPathWithinRoot(evaluatedCandidate, root)
-	if candidateInRoot && (!resolvedPath || evaluatedInRoot) {
-		return root, true
-	}
-	if !candidateInRoot && evaluatedInRoot {
+	if readRootContains(candidate, evaluatedCandidate, root, resolvedPath) {
 		return root, true
 	}
 	return "", false
@@ -355,17 +349,31 @@ func (f *fileToolSet) matchExtraReadRoot(absPath string) (string, bool) {
 	candidate := filepath.Clean(absPath)
 	evaluatedCandidate, resolvedPath := evalPathWithExistingParent(candidate)
 	for _, root := range f.extraReadRoots {
-		candidateInRoot := isPathWithinRoot(candidate, root)
-		evaluatedInRoot := resolvedPath &&
-			isPathWithinRoot(evaluatedCandidate, root)
-		if candidateInRoot && (!resolvedPath || evaluatedInRoot) {
-			return root, true
-		}
-		if !candidateInRoot && evaluatedInRoot {
+		if readRootContains(
+			candidate,
+			evaluatedCandidate,
+			root,
+			resolvedPath,
+		) {
 			return root, true
 		}
 	}
 	return "", false
+}
+
+func readRootContains(
+	candidate string,
+	evaluatedCandidate string,
+	root string,
+	resolvedPath bool,
+) bool {
+	candidateInRoot := isPathWithinRoot(candidate, root)
+	evaluatedInRoot := resolvedPath &&
+		isPathWithinRoot(evaluatedCandidate, root)
+	if candidateInRoot && (!resolvedPath || evaluatedInRoot) {
+		return true
+	}
+	return !candidateInRoot && evaluatedInRoot
 }
 
 func evalPathWithExistingParent(path string) (string, bool) {

--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -53,10 +53,10 @@ const (
 	relativePathGuidance        = "Use a relative path under " +
 		"base_directory. If exec_command wrote an absolute temp " +
 		"path, fs_read_file can read it only when that path is " +
-		"under a configured read-only root; otherwise have " +
-		"exec_command print the needed data directly."
+		"under base_directory or a configured read-only root; " +
+		"otherwise have exec_command print the needed data directly."
 	extraReadRootGuidance = "Absolute paths are readable only when " +
-		"they are under a configured read-only root."
+		"they are under base_directory or a configured read-only root."
 	missingFileRecoveryGuidance = "Use " +
 		missingFileListToolName + " or " +
 		missingFileSearchToolName +
@@ -304,8 +304,8 @@ func (f *fileToolSet) resolveReadPath(requestPath string) (string, error) {
 		return clean, nil
 	}
 	return "", fmt.Errorf(
-		"invalid path - absolute path is outside configured "+
-			"read-only roots: %s. %s %s",
+		"invalid path - absolute path is outside base_directory "+
+			"and configured read-only roots: %s. %s %s",
 		requestPath,
 		extraReadRootGuidance,
 		relativePathGuidance,

--- a/tool/file/file_test.go
+++ b/tool/file/file_test.go
@@ -230,6 +230,24 @@ func TestResolveReadPath_ExtraReadRoot(t *testing.T) {
 	assert.Contains(t, err.Error(), relativePathGuidance)
 }
 
+func TestResolveReadPath_AbsolutePathUnderRelativeBaseDir(t *testing.T) {
+	dir, err := os.MkdirTemp(".", "file-base-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+	absDir, err := filepath.Abs(dir)
+	assert.NoError(t, err)
+	allowed := filepath.Join(absDir, "a.txt")
+	assert.NoError(t, os.WriteFile(allowed, []byte("ok"), 0o644))
+
+	set, err := NewToolSet(WithBaseDir(dir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	p, err := fts.resolveReadPath(allowed)
+	assert.NoError(t, err)
+	assert.Equal(t, allowed, p)
+}
+
 func TestResolvePath_Empty(t *testing.T) {
 	dir := t.TempDir()
 	set, err := NewToolSet(WithBaseDir(dir))

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -28,7 +28,7 @@ import (
 
 // readFileRequest represents the input for the read file operation.
 type readFileRequest struct {
-	FileName  string `json:"file_name" jsonschema:"description=Relative file path under base_directory or workspace:// or artifact:// file ref or an absolute path under a configured read-only root"`
+	FileName  string `json:"file_name" description:"Relative file path under base_directory, workspace:// or artifact:// file ref, or an absolute path under base_directory or a configured read-only root"`
 	StartLine *int   `json:"start_line,omitempty" jsonschema:"description=Optional 1-based start line to begin reading from"`
 	NumLines  *int   `json:"num_lines,omitempty" jsonschema:"description=Optional maximum number of lines to return"`
 }
@@ -388,7 +388,8 @@ func (f *fileToolSet) readFileTool() tool.CallableTool {
 		function.WithDescription(
 			"Read a text file under base_directory. Supports "+
 				"workspace:// refs, artifact:// refs, and "+
-				"absolute paths under configured read-only roots. "+
+				"absolute paths under base_directory or configured "+
+				"read-only roots. "+
 				"Optional start_line and num_lines select line "+
 				"ranges.",
 		),

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -78,6 +78,23 @@ func TestFileTool_ReadFile_AbsolutePathUnderExtraReadRoot(t *testing.T) {
 	assert.Contains(t, err.Error(), "outside configured read-only roots")
 }
 
+func TestFileTool_ReadFile_AbsolutePathUnderBaseDir(t *testing.T) {
+	base := t.TempDir()
+	fileName := filepath.Join(base, "derived.json")
+	assert.NoError(t, os.WriteFile(fileName, []byte(`{"ok":true}`), 0o644))
+
+	toolSet, err := NewToolSet(WithBaseDir(base))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: fileName},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"ok":true}`, rsp.Contents)
+}
+
 func TestFileTool_ReadFile_BlocksSymlinkEscapeFromExtraReadRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink permissions vary on windows")
@@ -94,6 +111,30 @@ func TestFileTool_ReadFile_BlocksSymlinkEscapeFromExtraReadRoot(t *testing.T) {
 		WithBaseDir(base),
 		WithReadOnlyDirs(extra),
 	)
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: link},
+	)
+	assert.Error(t, err)
+	assert.Empty(t, rsp.Contents)
+	assert.Contains(t, err.Error(), "outside configured read-only roots")
+}
+
+func TestFileTool_ReadFile_BlocksSymlinkEscapeFromBaseDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions vary on windows")
+	}
+	base := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	assert.NoError(t, os.WriteFile(secret, []byte("secret"), 0o644))
+	link := filepath.Join(base, "link.txt")
+	assert.NoError(t, os.Symlink(secret, link))
+
+	toolSet, err := NewToolSet(WithBaseDir(base))
 	assert.NoError(t, err)
 	fileToolSet := toolSet.(*fileToolSet)
 

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -75,7 +75,7 @@ func TestFileTool_ReadFile_AbsolutePathUnderExtraReadRoot(t *testing.T) {
 		&readFileRequest{FileName: filepath.Join(t.TempDir(), "x.txt")},
 	)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "outside configured read-only roots")
+	assert.Contains(t, err.Error(), "outside base_directory and configured read-only roots")
 }
 
 func TestFileTool_ReadFile_AbsolutePathUnderBaseDir(t *testing.T) {
@@ -120,7 +120,7 @@ func TestFileTool_ReadFile_BlocksSymlinkEscapeFromExtraReadRoot(t *testing.T) {
 	)
 	assert.Error(t, err)
 	assert.Empty(t, rsp.Contents)
-	assert.Contains(t, err.Error(), "outside configured read-only roots")
+	assert.Contains(t, err.Error(), "outside base_directory and configured read-only roots")
 }
 
 func TestFileTool_ReadFile_BlocksSymlinkEscapeFromBaseDir(t *testing.T) {
@@ -144,7 +144,7 @@ func TestFileTool_ReadFile_BlocksSymlinkEscapeFromBaseDir(t *testing.T) {
 	)
 	assert.Error(t, err)
 	assert.Empty(t, rsp.Contents)
-	assert.Contains(t, err.Error(), "outside configured read-only roots")
+	assert.Contains(t, err.Error(), "outside base_directory and configured read-only roots")
 }
 
 func TestFileTool_ReadFile_NilRequest(t *testing.T) {

--- a/tool/file/readmultiplefiles.go
+++ b/tool/file/readmultiplefiles.go
@@ -256,7 +256,8 @@ func (f *fileToolSet) readMultipleFilesTool() tool.CallableTool {
 		function.WithDescription(
 			"Read multiple text files under base_directory. "+
 				"Supports glob patterns, workspace:// refs, and "+
-				"explicit absolute paths under configured read-only roots.",
+				"explicit absolute paths under base_directory or "+
+				"configured read-only roots.",
 		),
 	)
 }

--- a/tool/file/readmultiplefiles_test.go
+++ b/tool/file/readmultiplefiles_test.go
@@ -245,7 +245,7 @@ func TestReadMultipleFiles_BlocksSymlinkEscapeFromExtraReadRoot(t *testing.T) {
 	assert.Contains(
 		t,
 		rsp.Files[0].Message,
-		"outside configured read-only roots",
+		"outside base_directory and configured read-only roots",
 	)
 }
 

--- a/tool/file/readmultiplefiles_test.go
+++ b/tool/file/readmultiplefiles_test.go
@@ -219,6 +219,25 @@ func TestReadMultipleFiles_AbsolutePathUnderExtraReadRoot(t *testing.T) {
 	assert.Equal(t, "derived", rsp.Files[0].Contents)
 }
 
+func TestReadMultipleFiles_AbsolutePathUnderBaseDir(t *testing.T) {
+	base := t.TempDir()
+	fileName := filepath.Join(base, "derived.txt")
+	assert.NoError(t, os.WriteFile(fileName, []byte("derived"), 0o644))
+
+	set, err := NewToolSet(WithBaseDir(base))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	rsp, err := fts.readMultipleFiles(
+		context.Background(),
+		&readMultipleFilesRequest{Patterns: []string{fileName}},
+	)
+	assert.NoError(t, err)
+	assert.Len(t, rsp.Files, 1)
+	assert.Equal(t, fileName, rsp.Files[0].FileName)
+	assert.Equal(t, "derived", rsp.Files[0].Contents)
+}
+
 func TestReadMultipleFiles_BlocksSymlinkEscapeFromExtraReadRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink permissions vary on windows")

--- a/tool/file/schema_test.go
+++ b/tool/file/schema_test.go
@@ -33,7 +33,13 @@ func TestFileTool_InputSchemaDescriptions(t *testing.T) {
 	assert.Contains(
 		t,
 		declarations["read_file"].Description,
-		"absolute paths under configured read-only roots",
+		"absolute paths under base_directory or configured read-only roots",
+	)
+	require.Contains(t, declarations, "read_multiple_files")
+	assert.Contains(
+		t,
+		declarations["read_multiple_files"].Description,
+		"absolute paths under base_directory or configured read-only roots",
 	)
 
 	expected := map[string]map[string]string{
@@ -43,7 +49,7 @@ func TestFileTool_InputSchemaDescriptions(t *testing.T) {
 			"overwrite": "Whether to replace the file if it already exists",
 		},
 		"read_file": {
-			"file_name":  "Relative file path under base_directory or workspace:// or artifact:// file ref or an absolute path under a configured read-only root",
+			"file_name":  "Relative file path under base_directory, workspace:// or artifact:// file ref, or an absolute path under base_directory or a configured read-only root",
 			"start_line": "Optional 1-based start line to begin reading from",
 			"num_lines":  "Optional maximum number of lines to return",
 		},


### PR DESCRIPTION
Summary:
- allow read_file/read_multiple_files absolute paths when they resolve under the configured base directory
- keep write/list/search relative-only and preserve symlink escape checks

Validation:
- go test ./tool/file -run 'TestFileTool_ReadFile_(AbsolutePathUnderBaseDir|BlocksSymlinkEscapeFromBaseDir|AbsolutePathUnderExtraReadRoot|BlocksSymlinkEscapeFromExtraReadRoot)|TestResolveReadPath_(ExtraReadRoot|AbsolutePathUnderRelativeBaseDir)|TestReadMultipleFiles_AbsolutePathUnderExtraReadRoot|TestReadMultipleFiles_BlocksSymlinkEscapeFromExtraReadRoot' -count=1