### PR TITLE
internal/telemetry:Reduce streaming TraceChat request attribute allocations

### DIFF
--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -5020,6 +5020,7 @@ func emitFastModelResponseEvent(
 
 func traceProcessedModelResponse(
 	span oteltrace.Span,
+	traceState *itelemetry.ChatTraceState,
 	tracker *itelemetry.ChatMetricsTracker,
 	invocation *agent.Invocation,
 	request *model.Request,
@@ -5039,9 +5040,9 @@ func traceProcessedModelResponse(
 	if tracker != nil {
 		ttfb = tracker.FirstTokenTimeDuration()
 	}
-	itelemetry.TraceChat(span, &itelemetry.TraceChatAttributes{
+	traceState.CommitRequest(span, request, "")
+	traceState.TraceChunk(span, &itelemetry.TraceChunkAttributes{
 		Invocation:       invocation,
-		Request:          request,
 		Response:         response,
 		EventID:          lastEvent.ID,
 		TimeToFirstToken: ttfb,
@@ -5054,6 +5055,7 @@ type modelResponseProcessor struct {
 	stableInvocation               *agent.Invocation
 	observabilityInvocation        *agent.Invocation
 	invocation                     *agent.Invocation
+	chatTraceState                 itelemetry.ChatTraceState
 	tracker                        *itelemetry.ChatMetricsTracker
 	timingInfo                     *model.TimingInfo
 	partialUsageState              responseusage.PartialState
@@ -5373,6 +5375,7 @@ func (p *modelResponseProcessor) handleResponse(response *model.Response) (bool,
 	)
 	traceProcessedModelResponse(
 		p.config.Span,
+		&p.chatTraceState,
 		p.tracker,
 		p.observabilityInvocation,
 		p.config.Request,

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -5040,9 +5040,9 @@ func traceProcessedModelResponse(
 	if tracker != nil {
 		ttfb = tracker.FirstTokenTimeDuration()
 	}
-	traceState.CommitRequest(span, request, "")
-	traceState.TraceChunk(span, &itelemetry.TraceChunkAttributes{
+	traceState.TraceChat(span, &itelemetry.TraceChatAttributes{
 		Invocation:       invocation,
+		Request:          request,
 		Response:         response,
 		EventID:          lastEvent.ID,
 		TimeToFirstToken: ttfb,

--- a/graph/state_graph_additional_test.go
+++ b/graph/state_graph_additional_test.go
@@ -276,6 +276,16 @@ func graphHasNonEmptyStringAttr(attrs []attribute.KeyValue, key string) bool {
 	return false
 }
 
+func graphCountAttr(attrs []attribute.KeyValue, key string) int {
+	count := 0
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			count++
+		}
+	}
+	return count
+}
+
 func TestWorkflowTypeFromNodeType(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -2032,6 +2042,80 @@ func TestExecuteModelAndProcessResponses_UsesConfigFallbackForSparseStableTraceM
 	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyGenAIRequestModel, modelImpl.Info().Name))
 }
 
+func TestExecuteModelAndProcessResponses_ProgressivelyCompletesInvocationTraceMetadataOnRecordingSpan(t *testing.T) {
+	modelImpl := &multiResponseModel{
+		responses: []*model.Response{
+			{
+				IsPartial: true,
+				Choices: []model.Choice{
+					{Message: model.NewAssistantMessage("partial-1")},
+				},
+			},
+			{
+				IsPartial: true,
+				Choices: []model.Choice{
+					{Message: model.NewAssistantMessage("partial-2")},
+				},
+			},
+			{
+				Done: true,
+				Choices: []model.Choice{
+					{Message: model.NewAssistantMessage("done")},
+				},
+			},
+		},
+	}
+	invocation := agent.NewInvocation(
+		agent.WithInvocationID("inv-trace-progressive"),
+	)
+	var callbackCount int
+	callbacks := model.NewCallbacks().RegisterAfterModel(
+		func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+			callbackCount++
+			if callbackCount == 2 {
+				invocation.Session = &session.Session{
+					ID:     "sess-trace-progressive",
+					UserID: "user-trace-progressive",
+				}
+			}
+			return nil, nil
+		},
+	)
+	span := newGraphRecordingSpan()
+	resp, err := executeModelAndProcessResponses(
+		agent.NewInvocationContext(context.Background(), invocation),
+		modelExecutionConfig{
+			Invocation:     invocation,
+			ModelCallbacks: callbacks,
+			LLMModel:       modelImpl,
+			Request: &model.Request{
+				Messages: []model.Message{model.NewUserMessage("hi")},
+			},
+			InvocationID: invocation.InvocationID,
+			Span:         span,
+			NodeID:       "llm",
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, 3, callbackCount)
+
+	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyInvocationID, invocation.InvocationID))
+	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyGenAIConversationID, "sess-trace-progressive"))
+	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyRunnerUserID, "user-trace-progressive"))
+	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyGenAIRequestModel, modelImpl.Info().Name))
+
+	// Session metadata is补全 on the second chunk; only the last two TraceChunk calls emit it.
+	require.Equal(t, 2, graphCountAttr(span.attrs, semconvtrace.KeyGenAIConversationID))
+	require.Equal(t, 2, graphCountAttr(span.attrs, semconvtrace.KeyRunnerUserID))
+	require.Equal(t, 3, graphCountAttr(span.attrs, semconvtrace.KeyInvocationID))
+	require.Equal(t, 3, graphCountAttr(span.attrs, semconvtrace.KeyGenAIRequestModel))
+
+	// Request payload is committed once for the whole streaming span.
+	require.Equal(t, 1, graphCountAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
+	require.Equal(t, 1, graphCountAttr(span.attrs, semconvtrace.KeyLLMRequest))
+}
+
 func TestExecuteModelAndProcessResponses_RefreshesStableTraceMetadataAfterInPlaceInvocationUpdate(t *testing.T) {
 	modelImpl := &captureModel{}
 	invocation := agent.NewInvocation(
@@ -3201,6 +3285,7 @@ func TestTraceProcessedModelResponse_DisableTracing(t *testing.T) {
 
 	traceProcessedModelResponse(
 		noop.Span{},
+		&itelemetry.ChatTraceState{},
 		tracker,
 		invocation,
 		&model.Request{},

--- a/graph/state_graph_additional_test.go
+++ b/graph/state_graph_additional_test.go
@@ -2105,7 +2105,7 @@ func TestExecuteModelAndProcessResponses_ProgressivelyCompletesInvocationTraceMe
 	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyRunnerUserID, "user-trace-progressive"))
 	require.True(t, graphHasAttr(span.attrs, semconvtrace.KeyGenAIRequestModel, modelImpl.Info().Name))
 
-	// Session metadata is补全 on the second chunk; only the last two TraceChunk calls emit it.
+	// Session metadata is补全 on the second chunk; only the last two TraceChat chunk writes emit it.
 	require.Equal(t, 2, graphCountAttr(span.attrs, semconvtrace.KeyGenAIConversationID))
 	require.Equal(t, 2, graphCountAttr(span.attrs, semconvtrace.KeyRunnerUserID))
 	require.Equal(t, 3, graphCountAttr(span.attrs, semconvtrace.KeyInvocationID))

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -813,6 +813,7 @@ type streamingResponseProcessor struct {
 	eventChan               chan<- *event.Event
 	span                    oteltrace.Span
 	startedSpan             bool
+	chatTraceState          itelemetry.ChatTraceState
 	tracker                 *itelemetry.ChatMetricsTracker
 	timingInfo              *model.TimingInfo
 	partialUsageState       responseusage.PartialState
@@ -1066,7 +1067,7 @@ func (p *streamingResponseProcessor) traceChat(
 	if p.tracker != nil {
 		ttfb = p.tracker.FirstTokenTimeDuration()
 	}
-	itelemetry.TraceChat(p.span, &itelemetry.TraceChatAttributes{
+	p.chatTraceState.TraceChat(p.span, &itelemetry.TraceChatAttributes{
 		Invocation: observabilityInvocationForCurrent(
 			eventInvocation,
 			p.observabilityInvocation,

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1067,12 +1067,12 @@ func (p *streamingResponseProcessor) traceChat(
 	if p.tracker != nil {
 		ttfb = p.tracker.FirstTokenTimeDuration()
 	}
-	p.chatTraceState.TraceChat(p.span, &itelemetry.TraceChatAttributes{
+	p.chatTraceState.CommitRequest(p.span, p.llmRequest, "")
+	p.chatTraceState.TraceChunk(p.span, &itelemetry.TraceChunkAttributes{
 		Invocation: observabilityInvocationForCurrent(
 			eventInvocation,
 			p.observabilityInvocation,
 		),
-		Request:          p.llmRequest,
 		Response:         response,
 		EventID:          llmResponseEvent.ID,
 		TimeToFirstToken: ttfb,

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1067,12 +1067,12 @@ func (p *streamingResponseProcessor) traceChat(
 	if p.tracker != nil {
 		ttfb = p.tracker.FirstTokenTimeDuration()
 	}
-	p.chatTraceState.CommitRequest(p.span, p.llmRequest, "")
-	p.chatTraceState.TraceChunk(p.span, &itelemetry.TraceChunkAttributes{
+	p.chatTraceState.TraceChat(p.span, &itelemetry.TraceChatAttributes{
 		Invocation: observabilityInvocationForCurrent(
 			eventInvocation,
 			p.observabilityInvocation,
 		),
+		Request:          p.llmRequest,
 		Response:         response,
 		EventID:          llmResponseEvent.ID,
 		TimeToFirstToken: ttfb,

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -11,6 +11,7 @@ package llmflow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -152,6 +153,15 @@ func flowHasAttr(attrs []attribute.KeyValue, key string, want any) bool {
 		}
 	}
 	return false
+}
+
+func lastFlowAttrStringValue(attrs []attribute.KeyValue, key string) (string, bool) {
+	for i := len(attrs) - 1; i >= 0; i-- {
+		if string(attrs[i].Key) == key {
+			return attrs[i].Value.AsString(), true
+		}
+	}
+	return "", false
 }
 
 func TestLatencyDiagnosticHelpers(t *testing.T) {
@@ -1195,6 +1205,63 @@ func TestProcessStreamingResponses_UsesUpdatedInvocationForResponseUsageTiming(t
 	require.NotNil(t, lastEvent)
 	require.NotNil(t, response1.Usage)
 	require.Nil(t, response2.Usage)
+}
+
+func TestProcessStreamingResponses_RequestAttributeStateInvalidatesAfterModelMutation(t *testing.T) {
+	var callbackCount int
+	f := New(nil, nil, Options{
+		ModelCallbacks: model.NewCallbacks().RegisterAfterModel(
+			func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+				callbackCount++
+				if callbackCount == 2 {
+					args.Request.Messages[0].Content = "bbbb" // Same length, different bytes.
+				}
+				return &model.AfterModelResult{}, nil
+			},
+		),
+	})
+	invocation := agent.NewInvocation(agent.WithInvocationID("inv-request-attribute-state"))
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("aaaa")},
+	}
+	responseSeq := func(yield func(*model.Response) bool) {
+		yield(&model.Response{
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Delta: model.Message{Role: model.RoleAssistant, Content: "partial"},
+			}},
+		})
+		yield(&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("done"),
+			}},
+		})
+	}
+	eventChan := make(chan *event.Event, 10)
+	span := newFlowRecordingSpan()
+
+	lastEvent, err := f.processStreamingResponses(
+		context.Background(),
+		invocation,
+		nil,
+		req,
+		responseSeq,
+		eventChan,
+		span,
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lastEvent)
+
+	inputJSON, ok := lastFlowAttrStringValue(span.attrs, semconvtrace.KeyGenAIInputMessages)
+	require.True(t, ok, "missing input message trace attribute")
+	var messages []struct {
+		Content string `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(inputJSON), &messages))
+	require.Len(t, messages, 1)
+	require.Equal(t, "bbbb", messages[0].Content)
 }
 
 func TestProcessStreamingResponses_AttachesTimingInfoBeforeAfterModelCallbacks(t *testing.T) {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -164,6 +164,16 @@ func lastFlowAttrStringValue(attrs []attribute.KeyValue, key string) (string, bo
 	return "", false
 }
 
+func flowCountAttr(attrs []attribute.KeyValue, key string) int {
+	count := 0
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			count++
+		}
+	}
+	return count
+}
+
 func TestLatencyDiagnosticHelpers(t *testing.T) {
 	ctx := context.Background()
 	_, disabledSpan, disabledStarted := startLatencySpan(ctx, nil, "disabled")
@@ -1207,7 +1217,7 @@ func TestProcessStreamingResponses_UsesUpdatedInvocationForResponseUsageTiming(t
 	require.Nil(t, response2.Usage)
 }
 
-func TestProcessStreamingResponses_RequestAttributeStateInvalidatesAfterModelMutation(t *testing.T) {
+func TestProcessStreamingResponses_RequestAttributeStateIgnoresLaterModelMutation(t *testing.T) {
 	var callbackCount int
 	f := New(nil, nil, Options{
 		ModelCallbacks: model.NewCallbacks().RegisterAfterModel(
@@ -1261,7 +1271,66 @@ func TestProcessStreamingResponses_RequestAttributeStateInvalidatesAfterModelMut
 	}
 	require.NoError(t, json.Unmarshal([]byte(inputJSON), &messages))
 	require.Len(t, messages, 1)
+	require.Equal(t, "aaaa", messages[0].Content)
+}
+
+func TestProcessStreamingResponses_RequestAttributeStateCapturesFirstAfterModelMutation(t *testing.T) {
+	var callbackCount int
+	f := New(nil, nil, Options{
+		ModelCallbacks: model.NewCallbacks().RegisterAfterModel(
+			func(ctx context.Context, args *model.AfterModelArgs) (*model.AfterModelResult, error) {
+				callbackCount++
+				if callbackCount == 1 {
+					args.Request.Messages[0].Content = "bbbb" // Same length, different bytes.
+				}
+				return &model.AfterModelResult{}, nil
+			},
+		),
+	})
+	invocation := agent.NewInvocation(agent.WithInvocationID("inv-request-first-chunk-mutation"))
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("aaaa")},
+	}
+	responseSeq := func(yield func(*model.Response) bool) {
+		yield(&model.Response{
+			IsPartial: true,
+			Choices: []model.Choice{{
+				Delta: model.Message{Role: model.RoleAssistant, Content: "partial"},
+			}},
+		})
+		yield(&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("done"),
+			}},
+		})
+	}
+	eventChan := make(chan *event.Event, 10)
+	span := newFlowRecordingSpan()
+
+	lastEvent, err := f.processStreamingResponses(
+		context.Background(),
+		invocation,
+		nil,
+		req,
+		responseSeq,
+		eventChan,
+		span,
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lastEvent)
+	require.Equal(t, 2, callbackCount)
+
+	inputJSON, ok := lastFlowAttrStringValue(span.attrs, semconvtrace.KeyGenAIInputMessages)
+	require.True(t, ok, "missing input message trace attribute")
+	var messages []struct {
+		Content string `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(inputJSON), &messages))
+	require.Len(t, messages, 1)
 	require.Equal(t, "bbbb", messages[0].Content)
+	require.Equal(t, 1, flowCountAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
 }
 
 func TestProcessStreamingResponses_AttachesTimingInfoBeforeAfterModelCallbacks(t *testing.T) {

--- a/internal/modeltelemetry/reporter.go
+++ b/internal/modeltelemetry/reporter.go
@@ -107,9 +107,9 @@ func (r *Reporter) TrackResponse(response *model.Response) {
 		if r.tracker != nil {
 			ttfb = r.tracker.FirstTokenTimeDuration()
 		}
-		r.traceState.CommitRequest(r.span, r.request, "")
-		r.traceState.TraceChunk(r.span, &itelemetry.TraceChunkAttributes{
+		r.traceState.TraceChat(r.span, &itelemetry.TraceChatAttributes{
 			Invocation:       r.invocation,
+			Request:          r.request,
 			Response:         response,
 			TimeToFirstToken: ttfb,
 		})

--- a/internal/modeltelemetry/reporter.go
+++ b/internal/modeltelemetry/reporter.go
@@ -30,6 +30,7 @@ type Reporter struct {
 	request      *model.Request
 	span         oteltrace.Span
 	startedSpan  bool
+	traceState   itelemetry.ChatTraceState
 	tracker      *itelemetry.ChatMetricsTracker
 	recordMetric func()
 	ended        bool
@@ -106,9 +107,9 @@ func (r *Reporter) TrackResponse(response *model.Response) {
 		if r.tracker != nil {
 			ttfb = r.tracker.FirstTokenTimeDuration()
 		}
-		itelemetry.TraceChat(r.span, &itelemetry.TraceChatAttributes{
+		r.traceState.CommitRequest(r.span, r.request, "")
+		r.traceState.TraceChunk(r.span, &itelemetry.TraceChunkAttributes{
 			Invocation:       r.invocation,
-			Request:          r.request,
 			Response:         response,
 			TimeToFirstToken: ttfb,
 		})

--- a/internal/modeltelemetry/reporter_test.go
+++ b/internal/modeltelemetry/reporter_test.go
@@ -109,6 +109,28 @@ func TestReporterTrackResponseTracesWithTracker(t *testing.T) {
 	require.Equal(t, int64(5), attrs[semconvtrace.KeyGenAIUsageOutputTokens].AsInt64())
 }
 
+func TestReporterWithoutResponseDoesNotTraceRequestPayload(t *testing.T) {
+	recorder := useChatTelemetrySpanRecorder(t)
+	reporter := StartChat(
+		context.Background(),
+		&testModel{name: "request-model"},
+		&model.Request{Messages: []model.Message{model.NewUserMessage("secret")}},
+		true,
+	)
+
+	reporter.End()
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	attrs := attributesMap(spans[0].Attributes())
+	_, ok := attrs[semconvtrace.KeyLLMRequest]
+	require.False(t, ok)
+	_, ok = attrs[semconvtrace.KeyGenAIInputMessages]
+	require.False(t, ok)
+	_, ok = attrs[semconvtrace.KeyGenAIInputMessagesOTel]
+	require.False(t, ok)
+}
+
 func TestReporterTrackResponseHandlesNilInputsAndNilTracker(t *testing.T) {
 	recorder := useChatTelemetrySpanRecorder(t)
 	_, span := telemetrytrace.Tracer.Start(context.Background(), "manual-chat")

--- a/internal/telemetry/span_attribute.go
+++ b/internal/telemetry/span_attribute.go
@@ -37,6 +37,15 @@ func appendStringAttribute(
 	marshal func() ([]byte, error),
 ) []attribute.KeyValue {
 	rule := Resolve(operation, key)
+	return appendStringAttributeWithRule(attrs, operation, key, notSerializable, marshal, rule)
+}
+
+func appendStringAttributeWithRule(
+	attrs []attribute.KeyValue,
+	operation, key, notSerializable string,
+	marshal func() ([]byte, error),
+	rule AttributeRule,
+) []attribute.KeyValue {
 	if rule.Action == AttributeDrop {
 		return attrs
 	}

--- a/internal/telemetry/span_attribute_test.go
+++ b/internal/telemetry/span_attribute_test.go
@@ -91,6 +91,51 @@ func TestAppendStringAttribute_OmitSkipsMarshal(t *testing.T) {
 	}
 }
 
+func TestAppendStringAttributeWithRule_UsesProvidedRule(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+
+	key := semconvtrace.KeyGenAIInputMessages
+	marshal := func() ([]byte, error) {
+		return []byte(`[{"role":"user","content":"hello"}]`), nil
+	}
+	dropRule := AttributeRule{
+		Operation: OperationChat,
+		Key:       key,
+		Action:    AttributeDrop,
+	}
+
+	var marshalCalls int
+	SetSpanAttributePolicy(AppendAttributeRule(SpanAttributePolicy{}, AttributeRule{
+		Operation: OperationChat,
+		Key:       key,
+		Action:    AttributeCapture,
+	}))
+	attrs := appendStringAttributeWithRule(nil, OperationChat, key, "", func() ([]byte, error) {
+		marshalCalls++
+		return marshal()
+	}, dropRule)
+	if len(attrs) != 0 {
+		t.Fatal("expected provided drop rule to skip attribute")
+	}
+	if marshalCalls != 0 {
+		t.Fatal("expected provided drop rule to skip marshal")
+	}
+
+	marshalCalls = 0
+	SetSpanAttributePolicy(AppendAttributeRule(SpanAttributePolicy{}, dropRule))
+	captureRule := AttributeRule{Action: AttributeCapture}
+	attrs = appendStringAttributeWithRule(nil, OperationChat, key, "", func() ([]byte, error) {
+		marshalCalls++
+		return marshal()
+	}, captureRule)
+	if len(attrs) != 1 {
+		t.Fatalf("expected provided capture rule to write attribute, got %d", len(attrs))
+	}
+	if marshalCalls != 1 {
+		t.Fatal("expected provided capture rule to marshal")
+	}
+}
+
 func TestSetBytesAttribute_MaxBytesOmitOverLimitSkipsMarshal(t *testing.T) {
 	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
 

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -12,7 +12,6 @@
 package telemetry
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -150,307 +149,84 @@ func marshalTelemetryChoices(choices []model.Choice) ([]byte, error) {
 
 // ChatTraceState keeps per-chat-span trace state for repeated streaming chunks.
 //
-// The state is internal to framework call paths. It reuses message-derived
-// request attributes because they dominate streaming allocations and can be
-// fingerprinted without re-marshaling the whole request.
+// Request attributes are committed once per chat span. Invocation and response
+// attributes remain chunk-scoped because they are cheap and may be completed as
+// streaming processing advances.
 //
 // ChatTraceState is not goroutine-safe and must not be shared across chat spans.
 type ChatTraceState struct {
-	requestAttrs chatRequestAttributes
+	requestCommitted bool
+	cachedPolicy     *SpanAttributePolicy
+}
+
+// TraceChunkAttributes contains per-response chunk trace inputs.
+type TraceChunkAttributes struct {
+	Invocation       *agent.Invocation
+	Response         *model.Response
+	EventID          string
+	TimeToFirstToken time.Duration
+}
+
+// CommitRequest writes base chat and request attributes once per chat span.
+func (s *ChatTraceState) CommitRequest(span trace.Span, req *model.Request, taskType string) {
+	if !span.IsRecording() {
+		return
+	}
+
+	policy := spanAttributePolicy.Load()
+	if s != nil && s.requestCommitted && s.cachedPolicy == policy {
+		return
+	}
+
+	attrs := baseChatAttributes()
+	if taskType != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAITaskType, taskType))
+	}
+	attrs = append(attrs, buildRequestAttributes(req)...)
+
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+
+	if s != nil {
+		s.requestCommitted = true
+		s.cachedPolicy = policy
+	}
+}
+
+// TraceChunk writes invocation, chunk metadata, and response attributes.
+func (s *ChatTraceState) TraceChunk(span trace.Span, attributes *TraceChunkAttributes) {
+	if !span.IsRecording() || attributes == nil {
+		return
+	}
+
+	attrs := buildInvocationAttributes(attributes.Invocation)
+	if attributes.EventID != "" {
+		attrs = append(attrs, attribute.String(semconvtrace.KeyEventID, attributes.EventID))
+	}
+	if attributes.TimeToFirstToken > 0 {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyTRPCAgentGoClientTimeToFirstToken, attributes.TimeToFirstToken.Seconds()))
+	}
+	attrs = append(attrs, buildResponseAttributes(attributes.Response, semconvtrace.ValueDefaultErrorType)...)
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+
+	if attributes.Response != nil && attributes.Response.Error != nil {
+		span.SetStatus(codes.Error, attributes.Response.Error.Message)
+	}
 }
 
 // TraceChat traces the invocation of an LLM call using reusable per-span state.
 func (s *ChatTraceState) TraceChat(span trace.Span, attributes *TraceChatAttributes) {
-	if s == nil {
-		traceChat(span, attributes, nil)
-		return
-	}
-	traceChat(span, attributes, &s.requestAttrs)
+	traceChatWithState(span, attributes, s)
 }
 
-type chatRequestAttributes struct {
-	inputMessages     reusableAttribute
-	inputMessagesOTel reusableAttribute
-}
-
-type reusableAttribute struct {
-	valid       bool
-	fingerprint uint64
-	rule        AttributeRule
-	attrs       []attribute.KeyValue
-}
-
-func (r *chatRequestAttributes) appendTo(attrs []attribute.KeyValue, req *model.Request) []attribute.KeyValue {
-	if r == nil {
-		var requestAttrs chatRequestAttributes
-		return requestAttrs.appendTo(attrs, req)
+func baseChatAttributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
 	}
-
-	if req == nil {
-		return attrs
-	}
-
-	attrs = append(attrs,
-		attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, req.GenerationConfig.Stop),
-		attribute.Int(semconvtrace.KeyGenAIRequestChoiceCount, 1),
-	)
-
-	// Add generation config attributes
-	genConfig := req.GenerationConfig
-	// Add stream attribute only when it's true
-	if genConfig.Stream {
-		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestIsStream, true))
-	}
-	if fp := genConfig.FrequencyPenalty; fp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
-	}
-	if mt := genConfig.MaxTokens; mt != nil {
-		attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
-	}
-	if pp := genConfig.PresencePenalty; pp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
-	}
-	if tp := genConfig.Temperature; tp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
-	}
-	if tp := genConfig.TopP; tp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
-	}
-	if te := genConfig.ThinkingEnabled; te != nil {
-		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
-	}
-
-	// Add request body
-	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyLLMRequest, "<not json serializable>", func() ([]byte, error) {
-		return json.Marshal(req)
-	})
-
-	// Add tool definitions as best-effort structured array (JSON string fallback)
-	if len(req.Tools) > 0 {
-		definitions := make([]*tool.Declaration, 0, len(req.Tools))
-		for _, t := range toolorder.SortedTools(req.Tools) {
-			definitions = append(definitions, t.Declaration())
-		}
-		if len(definitions) > 0 {
-			attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIRequestToolDefinitions, "", func() ([]byte, error) {
-				return json.Marshal(definitions)
-			})
-		}
-	}
-
-	// Add messages
-	messageFingerprint := requestMessagesFingerprint(req.Messages)
-	attrs = r.appendStringAttribute(
-		attrs,
-		&r.inputMessages,
-		messageFingerprint,
-		OperationChat,
-		semconvtrace.KeyGenAIInputMessages,
-		"<not json serializable>",
-		func() ([]byte, error) {
-			return marshalTelemetryMessages(req.Messages)
-		},
-	)
-	attrs = r.appendStringAttribute(
-		attrs,
-		&r.inputMessagesOTel,
-		messageFingerprint,
-		OperationChat,
-		semconvtrace.KeyGenAIInputMessagesOTel,
-		"<not json serializable>",
-		func() ([]byte, error) {
-			return marshalOTelTelemetryMessages(req.Messages)
-		},
-	)
-
-	return attrs
-}
-
-func (r *chatRequestAttributes) appendStringAttribute(
-	attrs []attribute.KeyValue,
-	slot *reusableAttribute,
-	fingerprint uint64,
-	operation, key, notSerializable string,
-	marshal func() ([]byte, error),
-) []attribute.KeyValue {
-	rule := Resolve(operation, key)
-	if slot.valid && slot.fingerprint == fingerprint && slot.rule == rule {
-		return append(attrs, slot.attrs...)
-	}
-	before := len(attrs)
-	attrs = appendStringAttributeWithRule(attrs, operation, key, notSerializable, marshal, rule)
-	slot.valid = true
-	slot.fingerprint = fingerprint
-	slot.rule = rule
-	slot.attrs = append([]attribute.KeyValue(nil), attrs[before:]...)
-	return attrs
-}
-
-const (
-	fnvOffset64 = 14695981039346656037
-	fnvPrime64  = 1099511628211
-)
-
-// requestMessagesFingerprint is a performance fingerprint for detecting whether
-// cached message attributes can be reused. It is not a security checksum and is
-// only valid within a single ChatTraceState lifetime.
-func requestMessagesFingerprint(messages []model.Message) uint64 {
-	h := uint64(fnvOffset64)
-	h = hashInt(h, len(messages))
-	for _, msg := range messages {
-		h = hashString(h, string(msg.Role))
-		h = hashString(h, msg.Content)
-		h = hashContentParts(h, msg.ContentParts)
-		h = hashString(h, msg.ToolID)
-		h = hashString(h, msg.ToolName)
-		h = hashToolCalls(h, msg.ToolCalls)
-		h = hashString(h, msg.ReasoningContent)
-	}
-	return h
-}
-
-func hashString(h uint64, s string) uint64 {
-	h = hashInt(h, len(s))
-	return hashRawString(h, s)
-}
-
-func hashRawString(h uint64, s string) uint64 {
-	for i := 0; i < len(s); i++ {
-		h ^= uint64(s[i])
-		h *= fnvPrime64
-	}
-	return h
-}
-
-func hashBytes(h uint64, b []byte) uint64 {
-	h = hashBool(h, b != nil)
-	h = hashInt(h, len(b))
-	return hashRawBytes(h, b)
-}
-
-func hashRawBytes(h uint64, b []byte) uint64 {
-	for _, c := range b {
-		h ^= uint64(c)
-		h *= fnvPrime64
-	}
-	return h
-}
-
-func hashBool(h uint64, b bool) uint64 {
-	if b {
-		return hashInt(h, 1)
-	}
-	return hashInt(h, 0)
-}
-
-func hashInt(h uint64, n int) uint64 {
-	return hashInt64(h, int64(n))
-}
-
-func hashInt64(h uint64, n int64) uint64 {
-	var buf [binary.MaxVarintLen64]byte
-	size := binary.PutVarint(buf[:], n)
-	return hashRawBytes(h, buf[:size])
-}
-
-func hashContentParts(h uint64, parts []model.ContentPart) uint64 {
-	h = hashInt(h, len(parts))
-	for _, part := range parts {
-		h = hashString(h, string(part.Type))
-		if part.Text != nil {
-			h = hashBool(h, true)
-			h = hashString(h, *part.Text)
-		} else {
-			h = hashBool(h, false)
-		}
-		h = hashImage(h, part.Image)
-		h = hashAudio(h, part.Audio)
-		h = hashFile(h, part.File)
-		h = hashContentRef(h, part.ContentRef)
-	}
-	return h
-}
-
-func hashImage(h uint64, image *model.Image) uint64 {
-	if image == nil {
-		return hashBool(h, false)
-	}
-	h = hashBool(h, true)
-	h = hashString(h, image.URL)
-	h = hashBytes(h, image.Data)
-	h = hashString(h, image.Detail)
-	h = hashString(h, image.Format)
-	return h
-}
-
-func hashAudio(h uint64, audio *model.Audio) uint64 {
-	if audio == nil {
-		return hashBool(h, false)
-	}
-	h = hashBool(h, true)
-	h = hashBytes(h, audio.Data)
-	h = hashString(h, audio.Format)
-	return h
-}
-
-func hashFile(h uint64, file *model.File) uint64 {
-	if file == nil {
-		return hashBool(h, false)
-	}
-	h = hashBool(h, true)
-	h = hashString(h, file.Name)
-	h = hashString(h, file.URL)
-	h = hashBytes(h, file.Data)
-	h = hashString(h, file.FileID)
-	h = hashString(h, file.MimeType)
-	return h
-}
-
-func hashContentRef(h uint64, ref *model.ContentRef) uint64 {
-	if ref == nil {
-		return hashBool(h, false)
-	}
-	h = hashBool(h, true)
-	h = hashString(h, ref.ArtifactRef)
-	h = hashString(h, ref.ArtifactName)
-	h = hashInt(h, ref.ArtifactVersion)
-	h = hashString(h, ref.MimeType)
-	h = hashInt64(h, ref.SizeBytes)
-	h = hashString(h, ref.SHA256)
-	h = hashString(h, ref.OriginalName)
-	h = hashString(h, ref.EventID)
-	h = hashString(h, ref.RequestID)
-	return h
-}
-
-func hashToolCalls(h uint64, calls []model.ToolCall) uint64 {
-	h = hashInt(h, len(calls))
-	for _, call := range calls {
-		h = hashString(h, call.Type)
-		h = hashString(h, call.Function.Name)
-		h = hashBool(h, call.Function.Strict)
-		h = hashString(h, call.Function.Description)
-		h = hashBytes(h, call.Function.Arguments)
-		h = hashString(h, call.ID)
-		if call.Index != nil {
-			h = hashBool(h, true)
-			h = hashInt(h, *call.Index)
-		} else {
-			h = hashBool(h, false)
-		}
-		if len(call.ExtraFields) > 0 {
-			b, err := json.Marshal(call.ExtraFields)
-			h = hashBool(h, err == nil)
-			if err != nil {
-				h = hashString(h, err.Error())
-			} else {
-				h = hashBytes(h, b)
-			}
-		} else {
-			h = hashInt(h, 0)
-		}
-	}
-	return h
 }
 
 // TraceWorkflow traces the workflow.
@@ -763,52 +539,25 @@ func NewSummarizeTaskType(name string) string {
 
 // TraceChat traces the invocation of an LLM call.
 func TraceChat(span trace.Span, attributes *TraceChatAttributes) {
-	traceChat(span, attributes, nil)
+	traceChatWithState(span, attributes, nil)
 }
 
-func traceChat(
-	span trace.Span,
-	attributes *TraceChatAttributes,
-	requestAttrs *chatRequestAttributes,
-) {
+func traceChatWithState(span trace.Span, attributes *TraceChatAttributes, state *ChatTraceState) {
 	if !span.IsRecording() {
 		return
 	}
-	attrs := []attribute.KeyValue{
-		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
-		attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
-	}
 	if attributes == nil {
-		span.SetAttributes(attrs...)
+		span.SetAttributes(baseChatAttributes()...)
 		return
 	}
 
-	if attributes.EventID != "" {
-		attrs = append(attrs, attribute.String(semconvtrace.KeyEventID, attributes.EventID))
-	}
-	if attributes.TimeToFirstToken > 0 {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyTRPCAgentGoClientTimeToFirstToken, attributes.TimeToFirstToken.Seconds()))
-	}
-	if attributes.TaskType != "" {
-		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAITaskType, attributes.TaskType))
-	}
-
-	// Add invocation attributes
-	attrs = append(attrs, buildInvocationAttributes(attributes.Invocation)...)
-
-	// Add request attributes
-	attrs = requestAttrs.appendTo(attrs, attributes.Request)
-
-	// Add response attributes
-	attrs = append(attrs, buildResponseAttributes(attributes.Response, semconvtrace.ValueDefaultErrorType)...)
-
-	// Set all attributes at once
-	span.SetAttributes(attrs...)
-
-	// Handle response error status
-	if attributes.Response != nil && attributes.Response.Error != nil {
-		span.SetStatus(codes.Error, attributes.Response.Error.Message)
-	}
+	state.CommitRequest(span, attributes.Request, attributes.TaskType)
+	state.TraceChunk(span, &TraceChunkAttributes{
+		Invocation:       attributes.Invocation,
+		Response:         attributes.Response,
+		EventID:          attributes.EventID,
+		TimeToFirstToken: attributes.TimeToFirstToken,
+	})
 }
 
 // buildInvocationAttributes extracts attributes from the invocation.
@@ -837,8 +586,67 @@ func buildInvocationAttributes(invoke *agent.Invocation) []attribute.KeyValue {
 
 // buildRequestAttributes builds request-related attributes.
 func buildRequestAttributes(req *model.Request) []attribute.KeyValue {
-	var requestAttrs chatRequestAttributes
-	return requestAttrs.appendTo(nil, req)
+	if req == nil {
+		return nil
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, req.GenerationConfig.Stop),
+		attribute.Int(semconvtrace.KeyGenAIRequestChoiceCount, 1),
+	}
+
+	// Add generation config attributes
+	genConfig := req.GenerationConfig
+	// Add stream attribute only when it's true
+	if genConfig.Stream {
+		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestIsStream, true))
+	}
+	if fp := genConfig.FrequencyPenalty; fp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
+	}
+	if mt := genConfig.MaxTokens; mt != nil {
+		attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
+	}
+	if pp := genConfig.PresencePenalty; pp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
+	}
+	if tp := genConfig.Temperature; tp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
+	}
+	if tp := genConfig.TopP; tp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
+	}
+	if te := genConfig.ThinkingEnabled; te != nil {
+		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
+	}
+
+	// Add request body
+	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyLLMRequest, "<not json serializable>", func() ([]byte, error) {
+		return json.Marshal(req)
+	})
+
+	// Add tool definitions as best-effort structured array (JSON string fallback)
+	if len(req.Tools) > 0 {
+		definitions := make([]*tool.Declaration, 0, len(req.Tools))
+		for _, t := range toolorder.SortedTools(req.Tools) {
+			definitions = append(definitions, t.Declaration())
+		}
+		if len(definitions) > 0 {
+			attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIRequestToolDefinitions, "", func() ([]byte, error) {
+				return json.Marshal(definitions)
+			})
+		}
+	}
+
+	// Add messages
+	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIInputMessages, "<not json serializable>", func() ([]byte, error) {
+		return marshalTelemetryMessages(req.Messages)
+	})
+	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIInputMessagesOTel, "<not json serializable>", func() ([]byte, error) {
+		return marshalOTelTelemetryMessages(req.Messages)
+	})
+
+	return attrs
 }
 
 // buildResponseAttributes builds response-related attributes.

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -278,7 +278,7 @@ func (r *chatRequestAttributes) appendStringAttribute(
 		return append(attrs, slot.attrs...)
 	}
 	before := len(attrs)
-	attrs = appendStringAttribute(attrs, operation, key, notSerializable, marshal)
+	attrs = appendStringAttributeWithRule(attrs, operation, key, notSerializable, marshal, rule)
 	slot.valid = true
 	slot.fingerprint = fingerprint
 	slot.rule = rule

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -160,22 +160,22 @@ type ChatTraceState struct {
 	cachedPolicy     *SpanAttributePolicy
 }
 
-// TraceChunkAttributes contains per-response chunk trace inputs.
-type TraceChunkAttributes struct {
+// traceChunkAttributes contains per-response chunk trace inputs.
+type traceChunkAttributes struct {
 	Invocation       *agent.Invocation
 	Response         *model.Response
 	EventID          string
 	TimeToFirstToken time.Duration
 }
 
-// CommitRequest writes base chat and request attributes for a chat span.
+// commitRequest writes base chat and request attributes for a chat span.
 //
 // Request payload attributes are committed once while the global span attribute
 // policy pointer remains unchanged. If the policy pointer changes, request
 // attributes are rebuilt and written again under the new policy. Base chat
 // attributes may be rewritten on those refreshes. When req is nil, only base
 // attributes are written and request commit state is not latched.
-func (s *ChatTraceState) CommitRequest(span trace.Span, req *model.Request, taskType string) {
+func (s *ChatTraceState) commitRequest(span trace.Span, req *model.Request, taskType string) {
 	if !span.IsRecording() {
 		return
 	}
@@ -203,8 +203,8 @@ func (s *ChatTraceState) CommitRequest(span trace.Span, req *model.Request, task
 	}
 }
 
-// TraceChunk writes invocation, chunk metadata, and response attributes.
-func (s *ChatTraceState) TraceChunk(span trace.Span, attributes *TraceChunkAttributes) {
+// traceChunk writes invocation, chunk metadata, and response attributes.
+func (s *ChatTraceState) traceChunk(span trace.Span, attributes *traceChunkAttributes) {
 	if !span.IsRecording() || attributes == nil {
 		return
 	}
@@ -226,7 +226,7 @@ func (s *ChatTraceState) TraceChunk(span trace.Span, attributes *TraceChunkAttri
 	}
 }
 
-// TraceChat traces the invocation of an LLM call using reusable per-span state.
+// TraceChat is the single entry point for stateful streaming chat traces.
 func (s *ChatTraceState) TraceChat(span trace.Span, attributes *TraceChatAttributes) {
 	traceChatWithState(span, attributes, s)
 }
@@ -560,8 +560,8 @@ func traceChatWithState(span trace.Span, attributes *TraceChatAttributes, state 
 		return
 	}
 
-	state.CommitRequest(span, attributes.Request, attributes.TaskType)
-	state.TraceChunk(span, &TraceChunkAttributes{
+	state.commitRequest(span, attributes.Request, attributes.TaskType)
+	state.traceChunk(span, &traceChunkAttributes{
 		Invocation:       attributes.Invocation,
 		Response:         attributes.Response,
 		EventID:          attributes.EventID,

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -147,6 +147,305 @@ func marshalTelemetryChoices(choices []model.Choice) ([]byte, error) {
 	return json.Marshal(out)
 }
 
+// ChatTraceState keeps per-chat-span trace state for repeated streaming chunks.
+//
+// The state is internal to framework call paths. It reuses message-derived
+// request attributes because they dominate streaming allocations and can be
+// fingerprinted without re-marshaling the whole request.
+//
+// ChatTraceState is not goroutine-safe and must not be shared across chat spans.
+type ChatTraceState struct {
+	requestAttrs chatRequestAttributes
+}
+
+// TraceChat traces the invocation of an LLM call using reusable per-span state.
+func (s *ChatTraceState) TraceChat(span trace.Span, attributes *TraceChatAttributes) {
+	if s == nil {
+		traceChat(span, attributes, nil)
+		return
+	}
+	traceChat(span, attributes, &s.requestAttrs)
+}
+
+type chatRequestAttributes struct {
+	inputMessages     reusableAttribute
+	inputMessagesOTel reusableAttribute
+}
+
+type reusableAttribute struct {
+	valid       bool
+	fingerprint uint64
+	rule        AttributeRule
+	attrs       []attribute.KeyValue
+}
+
+func (r *chatRequestAttributes) appendTo(attrs []attribute.KeyValue, req *model.Request) []attribute.KeyValue {
+	if r == nil {
+		var requestAttrs chatRequestAttributes
+		return requestAttrs.appendTo(attrs, req)
+	}
+
+	if req == nil {
+		return attrs
+	}
+
+	attrs = append(attrs,
+		attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, req.GenerationConfig.Stop),
+		attribute.Int(semconvtrace.KeyGenAIRequestChoiceCount, 1),
+	)
+
+	// Add generation config attributes
+	genConfig := req.GenerationConfig
+	// Add stream attribute only when it's true
+	if genConfig.Stream {
+		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestIsStream, true))
+	}
+	if fp := genConfig.FrequencyPenalty; fp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
+	}
+	if mt := genConfig.MaxTokens; mt != nil {
+		attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
+	}
+	if pp := genConfig.PresencePenalty; pp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
+	}
+	if tp := genConfig.Temperature; tp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
+	}
+	if tp := genConfig.TopP; tp != nil {
+		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
+	}
+	if te := genConfig.ThinkingEnabled; te != nil {
+		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
+	}
+
+	// Add request body
+	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyLLMRequest, "<not json serializable>", func() ([]byte, error) {
+		return json.Marshal(req)
+	})
+
+	// Add tool definitions as best-effort structured array (JSON string fallback)
+	if len(req.Tools) > 0 {
+		definitions := make([]*tool.Declaration, 0, len(req.Tools))
+		for _, t := range toolorder.SortedTools(req.Tools) {
+			definitions = append(definitions, t.Declaration())
+		}
+		if len(definitions) > 0 {
+			attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIRequestToolDefinitions, "", func() ([]byte, error) {
+				return json.Marshal(definitions)
+			})
+		}
+	}
+
+	// Add messages
+	messageFingerprint := requestMessagesFingerprint(req.Messages)
+	attrs = r.appendStringAttribute(
+		attrs,
+		&r.inputMessages,
+		messageFingerprint,
+		OperationChat,
+		semconvtrace.KeyGenAIInputMessages,
+		"<not json serializable>",
+		func() ([]byte, error) {
+			return marshalTelemetryMessages(req.Messages)
+		},
+	)
+	attrs = r.appendStringAttribute(
+		attrs,
+		&r.inputMessagesOTel,
+		messageFingerprint,
+		OperationChat,
+		semconvtrace.KeyGenAIInputMessagesOTel,
+		"<not json serializable>",
+		func() ([]byte, error) {
+			return marshalOTelTelemetryMessages(req.Messages)
+		},
+	)
+
+	return attrs
+}
+
+func (r *chatRequestAttributes) appendStringAttribute(
+	attrs []attribute.KeyValue,
+	slot *reusableAttribute,
+	fingerprint uint64,
+	operation, key, notSerializable string,
+	marshal func() ([]byte, error),
+) []attribute.KeyValue {
+	rule := Resolve(operation, key)
+	if slot.valid && slot.fingerprint == fingerprint && slot.rule == rule {
+		return append(attrs, slot.attrs...)
+	}
+	before := len(attrs)
+	attrs = appendStringAttribute(attrs, operation, key, notSerializable, marshal)
+	slot.valid = true
+	slot.fingerprint = fingerprint
+	slot.rule = rule
+	slot.attrs = append(slot.attrs[:0], attrs[before:]...)
+	return attrs
+}
+
+const (
+	fnvOffset64 = 14695981039346656037
+	fnvPrime64  = 1099511628211
+)
+
+// requestMessagesFingerprint is a performance fingerprint for detecting whether
+// cached message attributes can be reused. It is not a security checksum and is
+// only valid within a single ChatTraceState lifetime.
+func requestMessagesFingerprint(messages []model.Message) uint64 {
+	h := uint64(fnvOffset64)
+	h = hashInt(h, len(messages))
+	for _, msg := range messages {
+		h = hashString(h, string(msg.Role))
+		h = hashString(h, msg.Content)
+		h = hashContentParts(h, msg.ContentParts)
+		h = hashString(h, msg.ToolID)
+		h = hashString(h, msg.ToolName)
+		h = hashToolCalls(h, msg.ToolCalls)
+		h = hashString(h, msg.ReasoningContent)
+	}
+	return h
+}
+
+func hashString(h uint64, s string) uint64 {
+	h = hashInt(h, len(s))
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= fnvPrime64
+	}
+	return h
+}
+
+func hashBytes(h uint64, b []byte) uint64 {
+	h = hashInt(h, len(b))
+	for _, c := range b {
+		h ^= uint64(c)
+		h *= fnvPrime64
+	}
+	return h
+}
+
+func hashBool(h uint64, b bool) uint64 {
+	if b {
+		return hashInt(h, 1)
+	}
+	return hashInt(h, 0)
+}
+
+func hashInt(h uint64, n int) uint64 {
+	u := uint64(n)
+	for i := 0; i < 8; i++ {
+		h ^= uint64(byte(u >> (i * 8)))
+		h *= fnvPrime64
+	}
+	return h
+}
+
+func hashInt64(h uint64, n int64) uint64 {
+	u := uint64(n)
+	for i := 0; i < 8; i++ {
+		h ^= uint64(byte(u >> (i * 8)))
+		h *= fnvPrime64
+	}
+	return h
+}
+
+func hashContentParts(h uint64, parts []model.ContentPart) uint64 {
+	h = hashInt(h, len(parts))
+	for _, part := range parts {
+		h = hashString(h, string(part.Type))
+		if part.Text != nil {
+			h = hashBool(h, true)
+			h = hashString(h, *part.Text)
+		} else {
+			h = hashBool(h, false)
+		}
+		h = hashImage(h, part.Image)
+		h = hashAudio(h, part.Audio)
+		h = hashFile(h, part.File)
+		h = hashContentRef(h, part.ContentRef)
+	}
+	return h
+}
+
+func hashImage(h uint64, image *model.Image) uint64 {
+	if image == nil {
+		return hashBool(h, false)
+	}
+	h = hashBool(h, true)
+	h = hashString(h, image.URL)
+	h = hashBytes(h, image.Data)
+	h = hashString(h, image.Detail)
+	h = hashString(h, image.Format)
+	return h
+}
+
+func hashAudio(h uint64, audio *model.Audio) uint64 {
+	if audio == nil {
+		return hashBool(h, false)
+	}
+	h = hashBool(h, true)
+	h = hashBytes(h, audio.Data)
+	h = hashString(h, audio.Format)
+	return h
+}
+
+func hashFile(h uint64, file *model.File) uint64 {
+	if file == nil {
+		return hashBool(h, false)
+	}
+	h = hashBool(h, true)
+	h = hashString(h, file.Name)
+	h = hashString(h, file.URL)
+	h = hashBytes(h, file.Data)
+	h = hashString(h, file.FileID)
+	h = hashString(h, file.MimeType)
+	return h
+}
+
+func hashContentRef(h uint64, ref *model.ContentRef) uint64 {
+	if ref == nil {
+		return hashBool(h, false)
+	}
+	h = hashBool(h, true)
+	h = hashString(h, ref.ArtifactRef)
+	h = hashString(h, ref.ArtifactName)
+	h = hashInt(h, ref.ArtifactVersion)
+	h = hashString(h, ref.MimeType)
+	h = hashInt64(h, ref.SizeBytes)
+	h = hashString(h, ref.SHA256)
+	h = hashString(h, ref.OriginalName)
+	h = hashString(h, ref.EventID)
+	h = hashString(h, ref.RequestID)
+	return h
+}
+
+func hashToolCalls(h uint64, calls []model.ToolCall) uint64 {
+	h = hashInt(h, len(calls))
+	for _, call := range calls {
+		h = hashString(h, call.Type)
+		h = hashString(h, call.Function.Name)
+		h = hashBool(h, call.Function.Strict)
+		h = hashString(h, call.Function.Description)
+		h = hashBytes(h, call.Function.Arguments)
+		h = hashString(h, call.ID)
+		if call.Index != nil {
+			h = hashBool(h, true)
+			h = hashInt(h, *call.Index)
+		} else {
+			h = hashBool(h, false)
+		}
+		if len(call.ExtraFields) > 0 {
+			b, _ := json.Marshal(call.ExtraFields)
+			h = hashBytes(h, b)
+		} else {
+			h = hashInt(h, 0)
+		}
+	}
+	return h
+}
+
 // TraceWorkflow traces the workflow.
 func TraceWorkflow(span trace.Span, workflow *Workflow) {
 	if !span.IsRecording() {
@@ -457,6 +756,14 @@ func NewSummarizeTaskType(name string) string {
 
 // TraceChat traces the invocation of an LLM call.
 func TraceChat(span trace.Span, attributes *TraceChatAttributes) {
+	traceChat(span, attributes, nil)
+}
+
+func traceChat(
+	span trace.Span,
+	attributes *TraceChatAttributes,
+	requestAttrs *chatRequestAttributes,
+) {
 	if !span.IsRecording() {
 		return
 	}
@@ -483,7 +790,7 @@ func TraceChat(span trace.Span, attributes *TraceChatAttributes) {
 	attrs = append(attrs, buildInvocationAttributes(attributes.Invocation)...)
 
 	// Add request attributes
-	attrs = append(attrs, buildRequestAttributes(attributes.Request)...)
+	attrs = requestAttrs.appendTo(attrs, attributes.Request)
 
 	// Add response attributes
 	attrs = append(attrs, buildResponseAttributes(attributes.Response, semconvtrace.ValueDefaultErrorType)...)
@@ -523,67 +830,8 @@ func buildInvocationAttributes(invoke *agent.Invocation) []attribute.KeyValue {
 
 // buildRequestAttributes builds request-related attributes.
 func buildRequestAttributes(req *model.Request) []attribute.KeyValue {
-	if req == nil {
-		return nil
-	}
-
-	attrs := []attribute.KeyValue{
-		attribute.StringSlice(semconvtrace.KeyGenAIRequestStopSequences, req.GenerationConfig.Stop),
-		attribute.Int(semconvtrace.KeyGenAIRequestChoiceCount, 1),
-	}
-
-	// Add generation config attributes
-	genConfig := req.GenerationConfig
-	// Add stream attribute only when it's true
-	if genConfig.Stream {
-		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestIsStream, true))
-	}
-	if fp := genConfig.FrequencyPenalty; fp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestFrequencyPenalty, *fp))
-	}
-	if mt := genConfig.MaxTokens; mt != nil {
-		attrs = append(attrs, attribute.Int(semconvtrace.KeyGenAIRequestMaxTokens, *mt))
-	}
-	if pp := genConfig.PresencePenalty; pp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestPresencePenalty, *pp))
-	}
-	if tp := genConfig.Temperature; tp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTemperature, *tp))
-	}
-	if tp := genConfig.TopP; tp != nil {
-		attrs = append(attrs, attribute.Float64(semconvtrace.KeyGenAIRequestTopP, *tp))
-	}
-	if te := genConfig.ThinkingEnabled; te != nil {
-		attrs = append(attrs, attribute.Bool(semconvtrace.KeyGenAIRequestThinkingEnabled, *te))
-	}
-
-	// Add request body
-	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyLLMRequest, "<not json serializable>", func() ([]byte, error) {
-		return json.Marshal(req)
-	})
-
-	// Add tool definitions as best-effort structured array (JSON string fallback)
-	if len(req.Tools) > 0 {
-		definitions := make([]*tool.Declaration, 0, len(req.Tools))
-		for _, t := range toolorder.SortedTools(req.Tools) {
-			definitions = append(definitions, t.Declaration())
-		}
-		if len(definitions) > 0 {
-			attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIRequestToolDefinitions, "", func() ([]byte, error) {
-				return json.Marshal(definitions)
-			})
-		}
-	}
-
-	// Add messages
-	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIInputMessages, "<not json serializable>", func() ([]byte, error) {
-		return marshalTelemetryMessages(req.Messages)
-	})
-	attrs = appendStringAttribute(attrs, OperationChat, semconvtrace.KeyGenAIInputMessagesOTel, "<not json serializable>", func() ([]byte, error) {
-		return marshalOTelTelemetryMessages(req.Messages)
-	})
-
-	return attrs
+	var requestAttrs chatRequestAttributes
+	return requestAttrs.appendTo(nil, req)
 }
 
 // buildResponseAttributes builds response-related attributes.

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -12,6 +12,7 @@
 package telemetry
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -281,7 +282,7 @@ func (r *chatRequestAttributes) appendStringAttribute(
 	slot.valid = true
 	slot.fingerprint = fingerprint
 	slot.rule = rule
-	slot.attrs = append(slot.attrs[:0], attrs[before:]...)
+	slot.attrs = append([]attribute.KeyValue(nil), attrs[before:]...)
 	return attrs
 }
 
@@ -310,6 +311,10 @@ func requestMessagesFingerprint(messages []model.Message) uint64 {
 
 func hashString(h uint64, s string) uint64 {
 	h = hashInt(h, len(s))
+	return hashRawString(h, s)
+}
+
+func hashRawString(h uint64, s string) uint64 {
 	for i := 0; i < len(s); i++ {
 		h ^= uint64(s[i])
 		h *= fnvPrime64
@@ -318,7 +323,12 @@ func hashString(h uint64, s string) uint64 {
 }
 
 func hashBytes(h uint64, b []byte) uint64 {
+	h = hashBool(h, b != nil)
 	h = hashInt(h, len(b))
+	return hashRawBytes(h, b)
+}
+
+func hashRawBytes(h uint64, b []byte) uint64 {
 	for _, c := range b {
 		h ^= uint64(c)
 		h *= fnvPrime64
@@ -334,21 +344,13 @@ func hashBool(h uint64, b bool) uint64 {
 }
 
 func hashInt(h uint64, n int) uint64 {
-	u := uint64(n)
-	for i := 0; i < 8; i++ {
-		h ^= uint64(byte(u >> (i * 8)))
-		h *= fnvPrime64
-	}
-	return h
+	return hashInt64(h, int64(n))
 }
 
 func hashInt64(h uint64, n int64) uint64 {
-	u := uint64(n)
-	for i := 0; i < 8; i++ {
-		h ^= uint64(byte(u >> (i * 8)))
-		h *= fnvPrime64
-	}
-	return h
+	var buf [binary.MaxVarintLen64]byte
+	size := binary.PutVarint(buf[:], n)
+	return hashRawBytes(h, buf[:size])
 }
 
 func hashContentParts(h uint64, parts []model.ContentPart) uint64 {
@@ -437,8 +439,13 @@ func hashToolCalls(h uint64, calls []model.ToolCall) uint64 {
 			h = hashBool(h, false)
 		}
 		if len(call.ExtraFields) > 0 {
-			b, _ := json.Marshal(call.ExtraFields)
-			h = hashBytes(h, b)
+			b, err := json.Marshal(call.ExtraFields)
+			h = hashBool(h, err == nil)
+			if err != nil {
+				h = hashString(h, err.Error())
+			} else {
+				h = hashBytes(h, b)
+			}
 		} else {
 			h = hashInt(h, 0)
 		}

--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -149,9 +149,10 @@ func marshalTelemetryChoices(choices []model.Choice) ([]byte, error) {
 
 // ChatTraceState keeps per-chat-span trace state for repeated streaming chunks.
 //
-// Request attributes are committed once per chat span. Invocation and response
-// attributes remain chunk-scoped because they are cheap and may be completed as
-// streaming processing advances.
+// Request attributes are normally committed once per chat span while the
+// installed span attribute policy pointer remains unchanged. Invocation and
+// response attributes remain chunk-scoped because they are cheap and may be
+// completed as streaming processing advances.
 //
 // ChatTraceState is not goroutine-safe and must not be shared across chat spans.
 type ChatTraceState struct {
@@ -167,7 +168,13 @@ type TraceChunkAttributes struct {
 	TimeToFirstToken time.Duration
 }
 
-// CommitRequest writes base chat and request attributes once per chat span.
+// CommitRequest writes base chat and request attributes for a chat span.
+//
+// Request payload attributes are committed once while the global span attribute
+// policy pointer remains unchanged. If the policy pointer changes, request
+// attributes are rebuilt and written again under the new policy. Base chat
+// attributes may be rewritten on those refreshes. When req is nil, only base
+// attributes are written and request commit state is not latched.
 func (s *ChatTraceState) CommitRequest(span trace.Span, req *model.Request, taskType string) {
 	if !span.IsRecording() {
 		return
@@ -182,13 +189,15 @@ func (s *ChatTraceState) CommitRequest(span trace.Span, req *model.Request, task
 	if taskType != "" {
 		attrs = append(attrs, attribute.String(semconvtrace.KeyGenAITaskType, taskType))
 	}
-	attrs = append(attrs, buildRequestAttributes(req)...)
+	if req != nil {
+		attrs = append(attrs, buildRequestAttributes(req)...)
+	}
 
 	if len(attrs) > 0 {
 		span.SetAttributes(attrs...)
 	}
 
-	if s != nil {
+	if s != nil && req != nil {
 		s.requestCommitted = true
 		s.cachedPolicy = policy
 	}

--- a/internal/telemetry/trace_chat_state_test.go
+++ b/internal/telemetry/trace_chat_state_test.go
@@ -47,7 +47,7 @@ func TestChatTraceState_RequestAttributesCommittedOnce(t *testing.T) {
 	}
 }
 
-func TestChatTraceState_PolicyDropSkipsRecommit(t *testing.T) {
+func TestChatTraceState_PolicyDropSkipsDroppedRequestAttributesOnRefresh(t *testing.T) {
 	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
 
 	req := &model.Request{
@@ -71,6 +71,40 @@ func TestChatTraceState_PolicyDropSkipsRecommit(t *testing.T) {
 	after := countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages)
 	if after != before {
 		t.Fatalf("drop policy should not append cached input messages: before=%d after=%d", before, after)
+	}
+}
+
+func TestChatTraceState_NilRequestThenRequestCommitsPayload(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+	installChatStreamingPolicyForTest()
+
+	span := newRecordingSpan()
+	state := &ChatTraceState{}
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	}
+
+	state.TraceChat(span, &TraceChatAttributes{
+		Response: chatResponseForChatStateTest("first"),
+	})
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 0 {
+		t.Fatalf("expected no input messages before request is committed, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
+	}
+
+	state.TraceChat(span, &TraceChatAttributes{
+		Request:  req,
+		Response: chatResponseForChatStateTest("second"),
+	})
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 1 {
+		t.Fatalf("expected input messages after delayed request commit, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
+	}
+
+	state.TraceChat(span, &TraceChatAttributes{
+		Request:  req,
+		Response: chatResponseForChatStateTest("third"),
+	})
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 1 {
+		t.Fatalf("expected input messages committed once, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
 	}
 }
 

--- a/internal/telemetry/trace_chat_state_test.go
+++ b/internal/telemetry/trace_chat_state_test.go
@@ -20,7 +20,7 @@ import (
 	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 )
 
-func TestChatTraceState_UpdatesWhenMessagesMutate(t *testing.T) {
+func TestChatTraceState_RequestAttributesCommittedOnce(t *testing.T) {
 	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
 	installChatStreamingPolicyForTest()
 
@@ -31,7 +31,7 @@ func TestChatTraceState_UpdatesWhenMessagesMutate(t *testing.T) {
 	state := &ChatTraceState{}
 
 	state.TraceChat(span, &TraceChatAttributes{Request: req})
-	req.Messages[0].Content = "bbbb" // Same length, different bytes.
+	req.Messages[0].Content = "bbbb" // Request mutations after commit are not reflected.
 	state.TraceChat(span, &TraceChatAttributes{Request: req})
 
 	got := lastAttrStringValue(t, span.attrs, semconvtrace.KeyGenAIInputMessages)
@@ -39,12 +39,15 @@ func TestChatTraceState_UpdatesWhenMessagesMutate(t *testing.T) {
 	if err := json.Unmarshal([]byte(got), &messages); err != nil {
 		t.Fatalf("unmarshal input messages: %v", err)
 	}
-	if len(messages) != 1 || messages[0].Content != "bbbb" {
-		t.Fatalf("expected mutated message in cached trace, got %+v", messages)
+	if len(messages) != 1 || messages[0].Content != "aaaa" {
+		t.Fatalf("expected initially committed message in trace, got %+v", messages)
+	}
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 1 {
+		t.Fatalf("expected input messages to be committed once, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
 	}
 }
 
-func TestChatTraceState_PolicyDropInvalidatesCachedAttribute(t *testing.T) {
+func TestChatTraceState_PolicyDropSkipsRecommit(t *testing.T) {
 	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
 
 	req := &model.Request{
@@ -83,11 +86,11 @@ func TestChatTraceState_ResponseAttributesStillUpdate(t *testing.T) {
 
 	state.TraceChat(span, &TraceChatAttributes{
 		Request:  req,
-		Response: chatResponseForCacheTest("first"),
+		Response: chatResponseForChatStateTest("first"),
 	})
 	state.TraceChat(span, &TraceChatAttributes{
 		Request:  req,
-		Response: chatResponseForCacheTest("second"),
+		Response: chatResponseForChatStateTest("second"),
 	})
 
 	got := lastAttrStringValue(t, span.attrs, semconvtrace.KeyGenAIOutputMessages)
@@ -97,133 +100,6 @@ func TestChatTraceState_ResponseAttributesStillUpdate(t *testing.T) {
 	}
 	if len(choices) != 1 || choices[0].Delta.Content != "second" {
 		t.Fatalf("expected latest response output, got %+v", choices)
-	}
-}
-
-func TestRequestMessagesFingerprint_DistinguishesNilAndEmptyBytes(t *testing.T) {
-	nilArgs := []model.Message{{
-		Role: model.RoleAssistant,
-		ToolCalls: []model.ToolCall{{
-			ID: "call",
-			Function: model.FunctionDefinitionParam{
-				Name: "tool",
-			},
-		}},
-	}}
-	emptyArgs := []model.Message{{
-		Role: model.RoleAssistant,
-		ToolCalls: []model.ToolCall{{
-			ID: "call",
-			Function: model.FunctionDefinitionParam{
-				Name:      "tool",
-				Arguments: []byte{},
-			},
-		}},
-	}}
-
-	if requestMessagesFingerprint(nilArgs) == requestMessagesFingerprint(emptyArgs) {
-		t.Fatal("expected nil and empty byte slices to produce different fingerprints")
-	}
-}
-
-func TestRequestMessagesFingerprint_DistinguishesExtraFieldsMarshalError(t *testing.T) {
-	validExtraFields := []model.Message{{
-		Role: model.RoleAssistant,
-		ToolCalls: []model.ToolCall{{
-			ID:          "call",
-			ExtraFields: map[string]any{"valid": "value"},
-		}},
-	}}
-	invalidExtraFields := []model.Message{{
-		Role: model.RoleAssistant,
-		ToolCalls: []model.ToolCall{{
-			ID: "call",
-			ExtraFields: map[string]any{
-				"invalid": func() {},
-			},
-		}},
-	}}
-
-	if requestMessagesFingerprint(validExtraFields) == requestMessagesFingerprint(invalidExtraFields) {
-		t.Fatal("expected extra field marshal errors to affect the fingerprint")
-	}
-}
-
-func TestRequestMessagesFingerprint_CoversMultimodalAndToolCallFields(t *testing.T) {
-	text := "part-text"
-	index := 2
-	messages := []model.Message{{
-		Role:    model.RoleUser,
-		Content: "message content",
-		ContentParts: []model.ContentPart{
-			{Type: model.ContentTypeText, Text: &text},
-			{
-				Type: model.ContentTypeImage,
-				Image: &model.Image{
-					URL:    "https://example.com/image.png",
-					Data:   []byte{0x01, 0x02},
-					Detail: "high",
-					Format: "png",
-				},
-			},
-			{
-				Type: model.ContentTypeAudio,
-				Audio: &model.Audio{
-					Data:   []byte{0x03},
-					Format: "wav",
-				},
-			},
-			{
-				Type: model.ContentTypeFile,
-				File: &model.File{
-					Name:     "notes.txt",
-					URL:      "https://example.com/notes.txt",
-					Data:     []byte{0x04},
-					FileID:   "file-id",
-					MimeType: "text/plain",
-				},
-			},
-			{Type: model.ContentTypeText},
-			{
-				Type: model.ContentTypeText,
-				ContentRef: &model.ContentRef{
-					ArtifactRef:     "artifact://doc@3",
-					ArtifactName:    "doc",
-					ArtifactVersion: 3,
-					MimeType:        "application/pdf",
-					SizeBytes:       4096,
-					SHA256:          "deadbeef",
-					OriginalName:    "doc.pdf",
-					EventID:         "event-1",
-					RequestID:       "request-1",
-				},
-			},
-		},
-		ToolID:           "tool-id",
-		ToolName:         "tool-name",
-		ReasoningContent: "thinking",
-		ToolCalls: []model.ToolCall{{
-			Type:  "function",
-			ID:    "call-1",
-			Index: &index,
-			Function: model.FunctionDefinitionParam{
-				Name:        "lookup",
-				Strict:      true,
-				Description: "lookup data",
-				Arguments:   []byte(`{"query":"weather"}`),
-			},
-			ExtraFields: map[string]any{"provider": "gemini"},
-		}},
-	}}
-
-	stable := requestMessagesFingerprint(messages)
-	if stable != requestMessagesFingerprint(messages) {
-		t.Fatal("expected stable fingerprint for identical messages")
-	}
-
-	messages[0].ReasoningContent = "changed reasoning"
-	if stable == requestMessagesFingerprint(messages) {
-		t.Fatal("expected fingerprint to change when message fields change")
 	}
 }
 
@@ -244,7 +120,7 @@ func TestChatTraceState_NilReceiverUsesStatelessPath(t *testing.T) {
 func TestTraceChat_NilAttributesSetsBaseSpanAttributes(t *testing.T) {
 	span := newRecordingSpan()
 
-	traceChat(span, nil, nil)
+	TraceChat(span, nil)
 
 	if countAttr(span.attrs, semconvtrace.KeyGenAISystem) != 1 {
 		t.Fatalf("expected gen_ai.system attribute, got %d", countAttr(span.attrs, semconvtrace.KeyGenAISystem))
@@ -289,34 +165,34 @@ func TestChatTraceState_RequestWithOptionalGenerationConfig(t *testing.T) {
 	if countAttr(span.attrs, semconvtrace.KeyGenAIRequestThinkingEnabled) == 0 {
 		t.Fatal("expected thinking enabled attribute")
 	}
-	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 2 {
-		t.Fatalf("expected cached input messages on each chunk, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 1 {
+		t.Fatalf("expected input messages committed once, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
 	}
 }
 
-func BenchmarkTraceChatStreamingRequestAttributes_NoCache(b *testing.B) {
+func BenchmarkTraceChatStreamingRequestAttributes_Stateless(b *testing.B) {
 	benchmarkTraceChatStreamingRequestAttributes(b, false)
 }
 
-func BenchmarkTraceChatStreamingRequestAttributes_WithCache(b *testing.B) {
+func BenchmarkTraceChatStreamingRequestAttributes_WithState(b *testing.B) {
 	benchmarkTraceChatStreamingRequestAttributes(b, true)
 }
 
-func benchmarkTraceChatStreamingRequestAttributes(b *testing.B, useCache bool) {
+func benchmarkTraceChatStreamingRequestAttributes(b *testing.B, useState bool) {
 	installChatStreamingPolicyForTest()
 	defer SetSpanAttributePolicy(SpanAttributePolicy{})
 
-	req := &model.Request{Messages: multiTurnMessagesForCacheTest(4)}
+	req := &model.Request{Messages: multiTurnMessagesForChatStateTest(4)}
 	responses := make([]*model.Response, 40)
 	for i := range responses {
-		responses[i] = chatResponseForCacheTest(fmt.Sprintf("chunk-%d", i))
+		responses[i] = chatResponseForChatStateTest(fmt.Sprintf("chunk-%d", i))
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		span := newRecordingSpan()
-		if useCache {
+		if useState {
 			state := &ChatTraceState{}
 			for _, rsp := range responses {
 				state.TraceChat(span, &TraceChatAttributes{Request: req, Response: rsp})
@@ -346,7 +222,7 @@ func installChatStreamingPolicyForTest() {
 	SetSpanAttributePolicy(policy)
 }
 
-func chatResponseForCacheTest(content string) *model.Response {
+func chatResponseForChatStateTest(content string) *model.Response {
 	return &model.Response{
 		ID:    "response-id",
 		Model: "test-model",
@@ -357,7 +233,7 @@ func chatResponseForCacheTest(content string) *model.Response {
 	}
 }
 
-func multiTurnMessagesForCacheTest(turns int) []model.Message {
+func multiTurnMessagesForChatStateTest(turns int) []model.Message {
 	messages := make([]model.Message, 0, turns*2)
 	for i := 0; i < turns; i++ {
 		messages = append(messages,

--- a/internal/telemetry/trace_request_cache_test.go
+++ b/internal/telemetry/trace_request_cache_test.go
@@ -100,6 +100,55 @@ func TestChatTraceState_ResponseAttributesStillUpdate(t *testing.T) {
 	}
 }
 
+func TestRequestMessagesFingerprint_DistinguishesNilAndEmptyBytes(t *testing.T) {
+	nilArgs := []model.Message{{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{{
+			ID: "call",
+			Function: model.FunctionDefinitionParam{
+				Name: "tool",
+			},
+		}},
+	}}
+	emptyArgs := []model.Message{{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{{
+			ID: "call",
+			Function: model.FunctionDefinitionParam{
+				Name:      "tool",
+				Arguments: []byte{},
+			},
+		}},
+	}}
+
+	if requestMessagesFingerprint(nilArgs) == requestMessagesFingerprint(emptyArgs) {
+		t.Fatal("expected nil and empty byte slices to produce different fingerprints")
+	}
+}
+
+func TestRequestMessagesFingerprint_DistinguishesExtraFieldsMarshalError(t *testing.T) {
+	emptyExtraFields := []model.Message{{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{{
+			ID:          "call",
+			ExtraFields: map[string]any{},
+		}},
+	}}
+	invalidExtraFields := []model.Message{{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{{
+			ID: "call",
+			ExtraFields: map[string]any{
+				"invalid": func() {},
+			},
+		}},
+	}}
+
+	if requestMessagesFingerprint(emptyExtraFields) == requestMessagesFingerprint(invalidExtraFields) {
+		t.Fatal("expected extra field marshal errors to affect the fingerprint")
+	}
+}
+
 func BenchmarkTraceChatStreamingRequestAttributes_NoCache(b *testing.B) {
 	benchmarkTraceChatStreamingRequestAttributes(b, false)
 }

--- a/internal/telemetry/trace_request_cache_test.go
+++ b/internal/telemetry/trace_request_cache_test.go
@@ -1,0 +1,196 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
+)
+
+func TestChatTraceState_UpdatesWhenMessagesMutate(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+	installChatStreamingPolicyForTest()
+
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("aaaa")},
+	}
+	span := newRecordingSpan()
+	state := &ChatTraceState{}
+
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+	req.Messages[0].Content = "bbbb" // Same length, different bytes.
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+
+	got := lastAttrStringValue(t, span.attrs, semconvtrace.KeyGenAIInputMessages)
+	var messages []telemetryMessage
+	if err := json.Unmarshal([]byte(got), &messages); err != nil {
+		t.Fatalf("unmarshal input messages: %v", err)
+	}
+	if len(messages) != 1 || messages[0].Content != "bbbb" {
+		t.Fatalf("expected mutated message in cached trace, got %+v", messages)
+	}
+}
+
+func TestChatTraceState_PolicyDropInvalidatesCachedAttribute(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	}
+	span := newRecordingSpan()
+	state := &ChatTraceState{}
+
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+	before := countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages)
+	if before != 1 {
+		t.Fatalf("expected one input message attribute before drop, got %d", before)
+	}
+
+	SetSpanAttributePolicy(AppendAttributeRule(SpanAttributePolicy{}, AttributeRule{
+		Operation: OperationChat,
+		Key:       semconvtrace.KeyGenAIInputMessages,
+		Action:    AttributeDrop,
+	}))
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+	after := countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages)
+	if after != before {
+		t.Fatalf("drop policy should not append cached input messages: before=%d after=%d", before, after)
+	}
+}
+
+func TestChatTraceState_ResponseAttributesStillUpdate(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+	installChatStreamingPolicyForTest()
+
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	}
+	span := newRecordingSpan()
+	state := &ChatTraceState{}
+
+	state.TraceChat(span, &TraceChatAttributes{
+		Request:  req,
+		Response: chatResponseForCacheTest("first"),
+	})
+	state.TraceChat(span, &TraceChatAttributes{
+		Request:  req,
+		Response: chatResponseForCacheTest("second"),
+	})
+
+	got := lastAttrStringValue(t, span.attrs, semconvtrace.KeyGenAIOutputMessages)
+	var choices []telemetryChoice
+	if err := json.Unmarshal([]byte(got), &choices); err != nil {
+		t.Fatalf("unmarshal output messages: %v", err)
+	}
+	if len(choices) != 1 || choices[0].Delta.Content != "second" {
+		t.Fatalf("expected latest response output, got %+v", choices)
+	}
+}
+
+func BenchmarkTraceChatStreamingRequestAttributes_NoCache(b *testing.B) {
+	benchmarkTraceChatStreamingRequestAttributes(b, false)
+}
+
+func BenchmarkTraceChatStreamingRequestAttributes_WithCache(b *testing.B) {
+	benchmarkTraceChatStreamingRequestAttributes(b, true)
+}
+
+func benchmarkTraceChatStreamingRequestAttributes(b *testing.B, useCache bool) {
+	installChatStreamingPolicyForTest()
+	defer SetSpanAttributePolicy(SpanAttributePolicy{})
+
+	req := &model.Request{Messages: multiTurnMessagesForCacheTest(4)}
+	responses := make([]*model.Response, 40)
+	for i := range responses {
+		responses[i] = chatResponseForCacheTest(fmt.Sprintf("chunk-%d", i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		span := newRecordingSpan()
+		if useCache {
+			state := &ChatTraceState{}
+			for _, rsp := range responses {
+				state.TraceChat(span, &TraceChatAttributes{Request: req, Response: rsp})
+			}
+			continue
+		}
+		for _, rsp := range responses {
+			TraceChat(span, &TraceChatAttributes{Request: req, Response: rsp})
+		}
+	}
+}
+
+func installChatStreamingPolicyForTest() {
+	policy := SpanAttributePolicy{}
+	for _, key := range []string{
+		semconvtrace.KeyLLMRequest,
+		semconvtrace.KeyLLMResponse,
+		semconvtrace.KeyGenAIInputMessagesOTel,
+		semconvtrace.KeyGenAIOutputMessagesOTel,
+	} {
+		policy = AppendAttributeRule(policy, AttributeRule{
+			Operation: OperationChat,
+			Key:       key,
+			Action:    AttributeDrop,
+		})
+	}
+	SetSpanAttributePolicy(policy)
+}
+
+func chatResponseForCacheTest(content string) *model.Response {
+	return &model.Response{
+		ID:    "response-id",
+		Model: "test-model",
+		Choices: []model.Choice{{
+			Index: 0,
+			Delta: model.Message{Role: model.RoleAssistant, Content: content},
+		}},
+	}
+}
+
+func multiTurnMessagesForCacheTest(turns int) []model.Message {
+	messages := make([]model.Message, 0, turns*2)
+	for i := 0; i < turns; i++ {
+		messages = append(messages,
+			model.NewUserMessage(strings.Repeat(fmt.Sprintf("user-turn-%d ", i), 200)),
+			model.NewAssistantMessage(strings.Repeat(fmt.Sprintf("assistant-turn-%d ", i), 200)),
+		)
+	}
+	return messages
+}
+
+func lastAttrStringValue(t *testing.T, attrs []attribute.KeyValue, key string) string {
+	t.Helper()
+	for i := len(attrs) - 1; i >= 0; i-- {
+		if string(attrs[i].Key) == key {
+			return attrs[i].Value.AsString()
+		}
+	}
+	t.Fatalf("missing attribute %s", key)
+	return ""
+}
+
+func countAttr(attrs []attribute.KeyValue, key string) int {
+	count := 0
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/telemetry/trace_request_cache_test.go
+++ b/internal/telemetry/trace_request_cache_test.go
@@ -127,11 +127,11 @@ func TestRequestMessagesFingerprint_DistinguishesNilAndEmptyBytes(t *testing.T) 
 }
 
 func TestRequestMessagesFingerprint_DistinguishesExtraFieldsMarshalError(t *testing.T) {
-	emptyExtraFields := []model.Message{{
+	validExtraFields := []model.Message{{
 		Role: model.RoleAssistant,
 		ToolCalls: []model.ToolCall{{
 			ID:          "call",
-			ExtraFields: map[string]any{},
+			ExtraFields: map[string]any{"valid": "value"},
 		}},
 	}}
 	invalidExtraFields := []model.Message{{
@@ -144,8 +144,153 @@ func TestRequestMessagesFingerprint_DistinguishesExtraFieldsMarshalError(t *test
 		}},
 	}}
 
-	if requestMessagesFingerprint(emptyExtraFields) == requestMessagesFingerprint(invalidExtraFields) {
+	if requestMessagesFingerprint(validExtraFields) == requestMessagesFingerprint(invalidExtraFields) {
 		t.Fatal("expected extra field marshal errors to affect the fingerprint")
+	}
+}
+
+func TestRequestMessagesFingerprint_CoversMultimodalAndToolCallFields(t *testing.T) {
+	text := "part-text"
+	index := 2
+	messages := []model.Message{{
+		Role:    model.RoleUser,
+		Content: "message content",
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeText, Text: &text},
+			{
+				Type: model.ContentTypeImage,
+				Image: &model.Image{
+					URL:    "https://example.com/image.png",
+					Data:   []byte{0x01, 0x02},
+					Detail: "high",
+					Format: "png",
+				},
+			},
+			{
+				Type: model.ContentTypeAudio,
+				Audio: &model.Audio{
+					Data:   []byte{0x03},
+					Format: "wav",
+				},
+			},
+			{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name:     "notes.txt",
+					URL:      "https://example.com/notes.txt",
+					Data:     []byte{0x04},
+					FileID:   "file-id",
+					MimeType: "text/plain",
+				},
+			},
+			{Type: model.ContentTypeText},
+			{
+				Type: model.ContentTypeText,
+				ContentRef: &model.ContentRef{
+					ArtifactRef:     "artifact://doc@3",
+					ArtifactName:    "doc",
+					ArtifactVersion: 3,
+					MimeType:        "application/pdf",
+					SizeBytes:       4096,
+					SHA256:          "deadbeef",
+					OriginalName:    "doc.pdf",
+					EventID:         "event-1",
+					RequestID:       "request-1",
+				},
+			},
+		},
+		ToolID:           "tool-id",
+		ToolName:         "tool-name",
+		ReasoningContent: "thinking",
+		ToolCalls: []model.ToolCall{{
+			Type:  "function",
+			ID:    "call-1",
+			Index: &index,
+			Function: model.FunctionDefinitionParam{
+				Name:        "lookup",
+				Strict:      true,
+				Description: "lookup data",
+				Arguments:   []byte(`{"query":"weather"}`),
+			},
+			ExtraFields: map[string]any{"provider": "gemini"},
+		}},
+	}}
+
+	stable := requestMessagesFingerprint(messages)
+	if stable != requestMessagesFingerprint(messages) {
+		t.Fatal("expected stable fingerprint for identical messages")
+	}
+
+	messages[0].ReasoningContent = "changed reasoning"
+	if stable == requestMessagesFingerprint(messages) {
+		t.Fatal("expected fingerprint to change when message fields change")
+	}
+}
+
+func TestChatTraceState_NilReceiverUsesStatelessPath(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+	installChatStreamingPolicyForTest()
+
+	var state *ChatTraceState
+	span := newRecordingSpan()
+	req := &model.Request{Messages: []model.Message{model.NewUserMessage("hello")}}
+
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 1 {
+		t.Fatalf("expected input messages attribute from nil ChatTraceState path")
+	}
+}
+
+func TestTraceChat_NilAttributesSetsBaseSpanAttributes(t *testing.T) {
+	span := newRecordingSpan()
+
+	traceChat(span, nil, nil)
+
+	if countAttr(span.attrs, semconvtrace.KeyGenAISystem) != 1 {
+		t.Fatalf("expected gen_ai.system attribute, got %d", countAttr(span.attrs, semconvtrace.KeyGenAISystem))
+	}
+	if countAttr(span.attrs, semconvtrace.KeyGenAIOperationName) != 1 {
+		t.Fatalf("expected gen_ai.operation.name attribute, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIOperationName))
+	}
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 0 {
+		t.Fatalf("expected no input messages when attributes are nil")
+	}
+}
+
+func TestChatTraceState_RequestWithOptionalGenerationConfig(t *testing.T) {
+	t.Cleanup(func() { SetSpanAttributePolicy(SpanAttributePolicy{}) })
+	installChatStreamingPolicyForTest()
+
+	fp := 0.1
+	mt := 128
+	pp := 0.2
+	tp := 0.7
+	topP := 0.9
+	thinkingEnabled := true
+	req := &model.Request{
+		GenerationConfig: model.GenerationConfig{
+			Stop:             []string{"END"},
+			Stream:           true,
+			FrequencyPenalty: &fp,
+			MaxTokens:        &mt,
+			PresencePenalty:  &pp,
+			Temperature:      &tp,
+			TopP:             &topP,
+			ThinkingEnabled:  &thinkingEnabled,
+		},
+		Messages: []model.Message{model.NewUserMessage("hello")},
+	}
+	span := newRecordingSpan()
+	state := &ChatTraceState{}
+
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+	state.TraceChat(span, &TraceChatAttributes{Request: req})
+
+	if countAttr(span.attrs, semconvtrace.KeyGenAIRequestThinkingEnabled) == 0 {
+		t.Fatal("expected thinking enabled attribute")
+	}
+	if countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages) != 2 {
+		t.Fatalf("expected cached input messages on each chunk, got %d", countAttr(span.attrs, semconvtrace.KeyGenAIInputMessages))
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR reduces allocation pressure in streaming LLM traces by committing request-side span attributes once per chat span while continuing to update response-side attributes for every chunk.
Previously, every streaming response chunk rebuilt and serialized the full request attributes, including `llm_request`, tool definitions, and input messages. Since the request is normally stable during one model invocation, this work was redundant.
## What Changed
- Added `ChatTraceState` to maintain per-chat-span request commit state.
- Split tracing internally into two phases:
  - request attributes are committed once;
  - invocation metadata and response attributes are updated per chunk.
- Kept `TraceChat` as the single integration entry point.
- Integrated stateful tracing into:
  - `llmflow` streaming responses;
  - graph model response processing;
  - direct-model telemetry reporting.
- Preserved the existing stateless `TraceChat` behavior for other callers.
- Added tests covering:
  - request attributes being committed once;
  - response attributes updating per chunk;
  - delayed commit for nil requests;
  - span attribute policy refresh;
  - AfterModel request mutation timing;
  - llmflow, graph, and modeltelemetry integrations.
## Behavior and Safety
- No public API or configuration changes.
- `ChatTraceState` is internal, scoped to one chat span, and is not goroutine-safe.
- Request attributes reflect the request seen at the first successful commit.
  Later in-place request mutations are not reflected in the same span.
- Invocation metadata remains chunk-scoped so fields populated during streaming
  can still be captured.
- Response attributes and error status continue to update for every chunk.
## Performance
For a 40-chunk streaming benchmark with multi-turn messages:
- Stateless: approximately 1.30 ms/op, 2.17 MB/op, 738 allocs/op
- Stateful: approximately 0.08 ms/op, 125 KB/op, 416 allocs/op
## Validation
- Affected package tests pass.
- Lint and CI checks pass.
- No breaking API changes detected.