### PR TITLE
session/redis: add WithDisableScriptCache to run Lua scripts via EVAL

### DIFF
--- a/docs/mkdocs/en/session/redis.md
+++ b/docs/mkdocs/en/session/redis.md
@@ -33,6 +33,7 @@ Redis storage is suitable for production environments and distributed applicatio
 | `WithKeyPrefix(prefix string)` | `string` | `""` | Redis key prefix; all keys will start with `prefix:`. Useful when multiple apps share one Redis instance |
 | `WithCompatMode(mode CompatMode)` | `CompatMode` | `CompatModeLegacy` | Storage compatibility mode. Options: `CompatModeNone`, `CompatModeLegacy`, `CompatModeTransition`. See [Storage Compatibility Mode (CompatMode)](#storage-compatibility-mode-compatmode) |
 | `WithEnableUserSessionIndex(enable bool)` | `bool` | `false` | Enable the per-user session index for HashIdx. See [User Session Index](#user-session-index) |
+| `WithDisableScriptCache(disable bool)` | `bool` | `false` | Keep `EVALSHA`-first execution by default. When enabled, run Lua scripts via `EVAL` only for backends with unreliable script caches, at the cost of sending the full script body on every call |
 
 **Async Persistence:**
 

--- a/docs/mkdocs/zh/session/redis.md
+++ b/docs/mkdocs/zh/session/redis.md
@@ -33,6 +33,7 @@ Redis 存储适用于生产环境和分布式应用，提供高性能和自动�
 | `WithKeyPrefix(prefix string)` | `string` | `""` | Redis key 前缀，所有 key 将以 `prefix:` 开头。适用于多应用共享同一 Redis 实例的场景 |
 | `WithCompatMode(mode CompatMode)` | `CompatMode` | `CompatModeLegacy` | 存储兼容模式。可选值：`CompatModeNone`、`CompatModeLegacy`、`CompatModeTransition`。详见[存储兼容模式](#存储兼容模式compatmode) |
 | `WithEnableUserSessionIndex(enable bool)` | `bool` | `false` | 启用 HashIdx 的用户级 Session 索引。详见[用户级 Session 索引](#用户级-session-索引) |
+| `WithDisableScriptCache(disable bool)` | `bool` | `false` | 默认保持 `EVALSHA`-first；启用后仅通过 `EVAL` 执行 Lua 脚本，适用于脚本缓存不可靠的后端，但每次调用都会发送完整脚本，增加带宽开销 |
 
 **异步持久化配置：**
 

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -34,6 +34,11 @@ type Config struct {
 	// on the user session index.
 	// When false (default), no index is maintained and ListSessions falls back to SCAN.
 	EnableUserSessionIndex bool
+	// DisableScriptCache runs all Lua scripts via EVAL instead of the default
+	// EVALSHA-first Script.Run. Enable for proxy/cluster backends whose script
+	// cache is not reliably maintained (e.g. a Tendis cluster fronted by twemproxy),
+	// avoiding repeated NOSCRIPT round-trips and the resulting monitoring noise.
+	DisableScriptCache bool
 }
 
 // Client implements HashIdx session storage logic.
@@ -50,6 +55,21 @@ func NewClient(client redis.UniversalClient, cfg Config) *Client {
 		keys:   newKeyBuilder(cfg.KeyPrefix),
 		cfg:    cfg,
 	}
+}
+
+// runScript executes a Lua script against the redis client. By default it uses
+// Script.Run (EVALSHA first, with automatic EVAL fallback on NOSCRIPT). When
+// cfg.DisableScriptCache is set it uses Script.Eval directly, sending the full
+// script body every time and skipping EVALSHA — suited to proxy/cluster backends
+// whose script cache is not reliably kept (e.g. a Tendis cluster fronted by
+// twemproxy, which recommends EVAL over EVALSHA).
+func (c *Client) runScript(
+	ctx context.Context, script *redis.Script, keys []string, args ...interface{},
+) *redis.Cmd {
+	if c.cfg.DisableScriptCache {
+		return script.Eval(ctx, c.client, keys, args...)
+	}
+	return script.Run(ctx, c.client, keys, args...)
 }
 
 // sessionMeta is the session metadata structure for HashIdx.
@@ -247,7 +267,7 @@ func (c *Client) loadSessionDataViaLua(
 		c.keys.UserStateKey(key.AppName, key.UserID),
 	}
 
-	raw, err := luaLoadSessionData.Run(ctx, c.client, keys).Text()
+	raw, err := c.runScript(ctx, luaLoadSessionData, keys).Text()
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +370,7 @@ func (c *Client) AppendEvent(ctx context.Context, key session.Key, evt *event.Ev
 		boolToInt(shouldStoreEvent),
 	}
 
-	result, err := luaAppendEvent.Run(ctx, c.client, keys, args...).Int()
+	result, err := c.runScript(ctx, luaAppendEvent, keys, args...).Int()
 	if err != nil {
 		return fmt.Errorf("append event: %w", err)
 	}
@@ -393,7 +413,7 @@ func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
 			return err
 		}
 	} else {
-		if _, err := luaDeleteSessionLegacy.Run(ctx, c.client, keys).Result(); err != nil {
+		if _, err := c.runScript(ctx, luaDeleteSessionLegacy, keys).Result(); err != nil {
 			return fmt.Errorf("delete session: %w", err)
 		}
 	}
@@ -411,7 +431,7 @@ func (c *Client) TrimConversations(ctx context.Context, key session.Key, count i
 		c.keys.EventTimeIndexKey(key),
 	}
 
-	result, err := luaTrimConversations.Run(ctx, c.client, keys, count).StringSlice()
+	result, err := c.runScript(ctx, luaTrimConversations, keys, count).StringSlice()
 	if err != nil {
 		return nil, fmt.Errorf("trim conversations: %w", err)
 	}
@@ -434,7 +454,7 @@ func (c *Client) DeleteEvent(ctx context.Context, key session.Key, eventID strin
 		c.keys.EventTimeIndexKey(key),
 	}
 
-	if _, err := luaDeleteEvent.Run(ctx, c.client, keys, eventID).Result(); err != nil {
+	if _, err := c.runScript(ctx, luaDeleteEvent, keys, eventID).Result(); err != nil {
 		return fmt.Errorf("delete event: %w", err)
 	}
 	return nil
@@ -615,7 +635,7 @@ func (c *Client) loadSessionBasic(
 	sess.UpdatedAt = meta.UpdatedAt
 
 	if !listOnlyMeta {
-		result, err := luaLoadEvents.Run(ctx, c.client,
+		result, err := c.runScript(ctx, luaLoadEvents,
 			[]string{
 				c.keys.EventDataKey(key),
 				c.keys.EventTimeIndexKey(key),

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -64,7 +64,7 @@ func NewClient(client redis.UniversalClient, cfg Config) *Client {
 // whose script cache is not reliably kept (e.g. a Tendis cluster fronted by
 // twemproxy, which recommends EVAL over EVALSHA).
 func (c *Client) runScript(
-	ctx context.Context, script *redis.Script, keys []string, args ...interface{},
+	ctx context.Context, script *redis.Script, keys []string, args ...any,
 ) *redis.Cmd {
 	if c.cfg.DisableScriptCache {
 		return script.Eval(ctx, c.client, keys, args...)

--- a/session/redis/internal/hashidx/state.go
+++ b/session/redis/internal/hashidx/state.go
@@ -47,9 +47,9 @@ func (c *Client) UpdateSessionState(ctx context.Context, key session.Key, state 
 		return fmt.Errorf("marshal session state nil keys: %w", err)
 	}
 
-	result, err := luaUpdateSessionState.Run(
+	result, err := c.runScript(
 		ctx,
-		c.client,
+		luaUpdateSessionState,
 		[]string{c.keys.SessionMetaKey(key)},
 		string(statePatchJSON),
 		string(nilKeysJSON),

--- a/session/redis/internal/hashidx/summary.go
+++ b/session/redis/internal/hashidx/summary.go
@@ -62,8 +62,8 @@ func (c *Client) CreateSummary(
 
 	sumKey := c.keys.SummaryKey(key)
 
-	if _, err := luaSummarySetIfNewer.Run(
-		ctx, c.client, []string{sumKey}, filterKey, string(payload), ttlSeconds,
+	if _, err := c.runScript(
+		ctx, luaSummarySetIfNewer, []string{sumKey}, filterKey, string(payload), ttlSeconds,
 	).Result(); err != nil {
 		return fmt.Errorf("store summary failed: %w", err)
 	}

--- a/session/redis/internal/hashidx/track.go
+++ b/session/redis/internal/hashidx/track.go
@@ -57,7 +57,7 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 		tracksVal,
 	}
 
-	result, err := luaAppendTrackEvent.Run(ctx, c.client, keys, args...).Int64()
+	result, err := c.runScript(ctx, luaAppendTrackEvent, keys, args...).Int64()
 	if err != nil {
 		return fmt.Errorf("append track event: %w", err)
 	}
@@ -107,7 +107,7 @@ func (c *Client) loadTrackEventsViaLua(
 	minScore, maxScore string,
 	limit int,
 ) ([]session.TrackEvent, error) {
-	rawEvents, err := luaLoadTrackEvents.Run(ctx, c.client,
+	rawEvents, err := c.runScript(ctx, luaLoadTrackEvents,
 		[]string{
 			c.keys.TrackDataKey(key, track),
 			c.keys.TrackTimeIndexKey(key, track),

--- a/session/redis/internal/hashidx/user_session_index.go
+++ b/session/redis/internal/hashidx/user_session_index.go
@@ -42,7 +42,7 @@ func (c *Client) addSessionToUserIndex(ctx context.Context, key session.Key, met
 		ttlSeconds = int64(c.cfg.SessionTTL.Seconds())
 	}
 
-	result, err := luaCreateSession.Run(ctx, c.client,
+	result, err := c.runScript(ctx, luaCreateSession,
 		[]string{metaKey, indexKey},
 		string(metaJSON), key.SessionID, ttlSeconds, string(indexEntry),
 	).Int()
@@ -63,7 +63,7 @@ func (c *Client) removeSessionFromUserIndex(ctx context.Context, dataKeys []stri
 	keys := make([]string, 0, len(dataKeys)+1)
 	keys = append(keys, dataKeys...)
 	keys = append(keys, indexKey)
-	if _, err := luaDeleteSession.Run(ctx, c.client, keys, key.SessionID).Result(); err != nil {
+	if _, err := c.runScript(ctx, luaDeleteSession, keys, key.SessionID).Result(); err != nil {
 		return fmt.Errorf("delete session: %w", err)
 	}
 	return nil

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -60,7 +60,7 @@ func NewClient(client redis.UniversalClient, cfg Config) *Client {
 // is set it uses Script.Eval directly, suited to proxy/cluster backends whose script
 // cache is not reliably kept (e.g. a Tendis cluster fronted by twemproxy).
 func (c *Client) runScript(
-	ctx context.Context, script *redis.Script, keys []string, args ...interface{},
+	ctx context.Context, script *redis.Script, keys []string, args ...any,
 ) *redis.Cmd {
 	if c.cfg.DisableScriptCache {
 		return script.Eval(ctx, c.client, keys, args...)

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -33,6 +33,10 @@ type Config struct {
 	UserStateTTL      time.Duration
 	SessionEventLimit int
 	KeyPrefix         string // Prefix for legacy keys
+	// DisableScriptCache runs Lua scripts via EVAL instead of the EVALSHA-first
+	// Script.Run. Enable for proxy/cluster backends whose script cache is not
+	// reliably maintained (e.g. a Tendis cluster fronted by twemproxy).
+	DisableScriptCache bool
 }
 
 // Client implements ZSet session storage logic.
@@ -49,6 +53,19 @@ func NewClient(client redis.UniversalClient, cfg Config) *Client {
 		client: client,
 		cfg:    cfg,
 	}
+}
+
+// runScript executes a Lua script against the redis client. By default it uses
+// Script.Run (EVALSHA first, EVAL fallback on NOSCRIPT). When cfg.DisableScriptCache
+// is set it uses Script.Eval directly, suited to proxy/cluster backends whose script
+// cache is not reliably kept (e.g. a Tendis cluster fronted by twemproxy).
+func (c *Client) runScript(
+	ctx context.Context, script *redis.Script, keys []string, args ...interface{},
+) *redis.Cmd {
+	if c.cfg.DisableScriptCache {
+		return script.Eval(ctx, c.client, keys, args...)
+	}
+	return script.Run(ctx, c.client, keys, args...)
 }
 
 // SessionState is the state of a session (ZSet structure).
@@ -971,8 +988,8 @@ func (c *Client) CreateSummary(
 	sumKey := c.sessionSummaryKey(key)
 	hashField := key.SessionID
 
-	if _, err := luaSummariesSetIfNewer.Run(
-		ctx, c.client, []string{sumKey}, hashField, filterKey, string(payload),
+	if _, err := c.runScript(
+		ctx, luaSummariesSetIfNewer, []string{sumKey}, hashField, filterKey, string(payload),
 	).Result(); err != nil {
 		return fmt.Errorf("store summary (lua) failed: %w", err)
 	}

--- a/session/redis/options.go
+++ b/session/redis/options.go
@@ -94,6 +94,8 @@ type ServiceOpts struct {
 	compatMode             CompatMode
 	enableTracing          bool
 	enableUserSessionIndex bool
+	// disableScriptCache runs Lua scripts via EVAL instead of EVALSHA-first.
+	disableScriptCache bool
 }
 
 // ServiceOpt is the option for the redis session service.
@@ -315,5 +317,19 @@ func WithEnableTracing(enable bool) ServiceOpt {
 func WithEnableUserSessionIndex(enable bool) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.enableUserSessionIndex = enable
+	}
+}
+
+// WithDisableScriptCache runs all Lua scripts via EVAL instead of the default
+// EVALSHA-first execution. Enable it for proxy/cluster Redis backends whose
+// server-side script cache is not reliably maintained — e.g. a Tendis cluster
+// fronted by twemproxy, whose own guidance is to use EVAL rather than EVALSHA.
+// It removes the repeated NOSCRIPT round-trips (and the resulting error-code
+// noise in tracing/monitoring) at the cost of sending the full script body on
+// every call. Leave it off (default) for standalone Redis or master-slave
+// Tendis where EVALSHA script caching works normally.
+func WithDisableScriptCache(disable bool) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.disableScriptCache = disable
 	}
 }

--- a/session/redis/service.go
+++ b/session/redis/service.go
@@ -134,11 +134,12 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 
 	// Initialize ZSet config
 	zsetCfg := zset.Config{
-		SessionTTL:        sessionTTL,
-		AppStateTTL:       appStateTTL,
-		UserStateTTL:      userStateTTL,
-		SessionEventLimit: opts.sessionEventLimit,
-		KeyPrefix:         opts.keyPrefix,
+		SessionTTL:         sessionTTL,
+		AppStateTTL:        appStateTTL,
+		UserStateTTL:       userStateTTL,
+		SessionEventLimit:  opts.sessionEventLimit,
+		KeyPrefix:          opts.keyPrefix,
+		DisableScriptCache: opts.disableScriptCache,
 	}
 
 	// Initialize HashIdx config
@@ -149,6 +150,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		SessionEventLimit:      opts.sessionEventLimit,
 		KeyPrefix:              opts.keyPrefix,
 		EnableUserSessionIndex: opts.enableUserSessionIndex,
+		DisableScriptCache:     opts.disableScriptCache,
 	}
 
 	s := &Service{

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -1073,6 +1073,9 @@ func TestService_WithDisableScriptCache(t *testing.T) {
 	require.NoError(t, err)
 	defer service.Close()
 
+	recorder := &scriptCommandRecorder{}
+	service.redisClient.AddHook(recorder)
+
 	ctx := context.Background()
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
 
@@ -1082,6 +1085,7 @@ func TestService_WithDisableScriptCache(t *testing.T) {
 
 	evt := createTestEvent("e1", "agent", "hello", time.Now(), true)
 	require.NoError(t, service.AppendEvent(ctx, sess, evt))
+	assert.Equal(t, []string{"eval"}, recorder.snapshot())
 
 	got, err := service.GetSession(ctx, key)
 	require.NoError(t, err)
@@ -1093,6 +1097,67 @@ func TestService_WithDisableScriptCache(t *testing.T) {
 	sessions, err := service.ListSessions(ctx, session.UserKey{AppName: "app", UserID: "u1"})
 	require.NoError(t, err)
 	assert.Len(t, sessions, 1)
+}
+
+func TestService_UsesScriptCacheByDefault(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	service, err := NewService(WithRedisClientURL(redisURL))
+	require.NoError(t, err)
+	defer service.Close()
+
+	recorder := &scriptCommandRecorder{}
+	service.redisClient.AddHook(recorder)
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := service.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	evt := createTestEvent("e1", "agent", "hello", time.Now(), true)
+	require.NoError(t, service.AppendEvent(ctx, sess, evt))
+	assert.Equal(t, []string{"evalsha", "eval"}, recorder.snapshot())
+}
+
+type scriptCommandRecorder struct {
+	mu       sync.Mutex
+	commands []string
+}
+
+func (h *scriptCommandRecorder) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h *scriptCommandRecorder) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		h.record(cmd.Name())
+		return next(ctx, cmd)
+	}
+}
+
+func (h *scriptCommandRecorder) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		for _, cmd := range cmds {
+			h.record(cmd.Name())
+		}
+		return next(ctx, cmds)
+	}
+}
+
+func (h *scriptCommandRecorder) record(command string) {
+	if command != "eval" && command != "evalsha" {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.commands = append(h.commands, command)
+}
+
+func (h *scriptCommandRecorder) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.commands...)
 }
 
 // setupTestRedis creates a miniredis instance and returns its URL and cleanup function.

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -1058,6 +1058,43 @@ func TestService_DeleteSession_WithEvents(t *testing.T) {
 	assert.Nil(t, deletedSess)
 }
 
+func TestService_WithDisableScriptCache(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	// WithDisableScriptCache forces every Lua script to run via EVAL instead of
+	// the default EVALSHA-first Script.Run. Exercise a full session round-trip to
+	// make sure the EVAL path is functionally identical: AppendEvent runs
+	// luaAppendEvent and GetSession runs luaLoadSessionData, both via EVAL here.
+	service, err := NewService(
+		WithRedisClientURL(redisURL),
+		WithDisableScriptCache(true),
+	)
+	require.NoError(t, err)
+	defer service.Close()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+
+	sess, err := service.CreateSession(ctx, key, session.StateMap{"k": []byte("v")})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	evt := createTestEvent("e1", "agent", "hello", time.Now(), true)
+	require.NoError(t, service.AppendEvent(ctx, sess, evt))
+
+	got, err := service.GetSession(ctx, key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []byte("v"), got.State["k"])
+	require.Len(t, got.Events, 1)
+	assert.Equal(t, "e1", got.Events[0].ID)
+
+	sessions, err := service.ListSessions(ctx, session.UserKey{AppName: "app", UserID: "u1"})
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+}
+
 // setupTestRedis creates a miniredis instance and returns its URL and cleanup function.
 func setupTestRedis(t *testing.T) (string, func()) {
 	t.Helper()

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -1097,6 +1097,28 @@ func TestService_WithDisableScriptCache(t *testing.T) {
 	sessions, err := service.ListSessions(ctx, session.UserKey{AppName: "app", UserID: "u1"})
 	require.NoError(t, err)
 	assert.Len(t, sessions, 1)
+	assert.Equal(t, []string{"eval", "eval", "eval"}, recorder.snapshot())
+}
+
+func TestService_WithDisableScriptCache_ZSetSummary(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	service, err := NewService(
+		WithRedisClientURL(redisURL),
+		WithDisableScriptCache(true),
+	)
+	require.NoError(t, err)
+	defer service.Close()
+
+	recorder := &scriptCommandRecorder{}
+	service.redisClient.AddHook(recorder)
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sum := &session.Summary{Summary: "summary", UpdatedAt: time.Now().UTC()}
+	require.NoError(t, service.zsetClient.CreateSummary(ctx, key, "all", sum, 0))
+	assert.Equal(t, []string{"eval"}, recorder.snapshot())
 }
 
 func TestService_UsesScriptCacheByDefault(t *testing.T) {


### PR DESCRIPTION
## What changed

Adds `redis.WithDisableScriptCache(disable bool)` to the redis session service. When enabled, the hashidx and zset clients run every Lua script via `EVAL` instead of the default `Script.Run` (which is EVALSHA-first with an EVAL fallback). The option defaults to off, so existing behavior is unchanged.

## Why

The redis session backend runs all Lua scripts with `Script.Run`, which issues `EVALSHA` first and only falls back to `EVAL` when the server replies `NOSCRIPT`. On proxy/cluster backends whose server-side script cache is not reliably maintained — for example a Tendis cluster fronted by twemproxy — `EVALSHA` misses frequently. Every miss still self-heals via the `EVAL` fallback, so requests keep succeeding, but each miss costs an extra round trip and reports a business error code (`NOSCRIPT`) into tracing/monitoring, which inflates the observed redis error rate.

`WithDisableScriptCache(true)` skips `EVALSHA` entirely and sends `EVAL` directly. This matches the guidance for such cluster backends and removes both the extra round trip and the monitoring noise, at the cost of sending the full script body on every call. It is backward compatible: default off keeps standalone redis and master-slave Tendis on the EVALSHA-first path.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` under `session/redis` all pass.
- Added `TestService_WithDisableScriptCache` (miniredis) covering CreateSession / AppendEvent / GetSession / ListSessions with the option enabled.
- Verified against a local redis with `MONITOR`: with the option on, only `EVAL` commands are issued (0 `EVALSHA`); with it off, `EVALSHA` is issued as before.

## Notes for reviewers

- Public API addition (`WithDisableScriptCache`). Suggested type label: `type/feature`.
- All 13 script call sites (12 hashidx + 1 zset) now go through a small `runScript` helper that branches `Script.Eval` vs `Script.Run` on the config flag; when the flag is off, every call site keeps its original behavior.

RELEASE NOTES: Added redis.WithDisableScriptCache to the redis session service, which runs Lua scripts via EVAL instead of EVALSHA for proxy/cluster backends (such as a Tendis cluster) whose script cache is not reliably maintained.
