### PR TITLE
[codex] add replay consistency harness

### DIFF
--- a/session/replaytest/README.md
+++ b/session/replaytest/README.md
@@ -46,9 +46,9 @@ Recommended environment gates:
 ```
 
 When a backend does not support event pages, TTL, tracks, or memory search, its
-adapter should add an `UnsupportedFeature` with `allowed_diff=true` and a concrete
-explanation. Unsupported features are reported but do not hide mismatches in
-supported fields.
+adapter should append a `BackendUnsupported` entry through
+`CaseReport.Unsupported` with `allowed_diff=true` and a concrete explanation.
+Unsupported features are reported but do not hide mismatches in supported fields.
 
 ## Design Notes
 

--- a/session/replaytest/README.md
+++ b/session/replaytest/README.md
@@ -1,0 +1,55 @@
+# Session / Memory / Summary / Track Replay Consistency
+
+`session/replaytest` provides a deterministic replay harness for comparing Session,
+Memory, Summary, and Track behavior across backends. The root-module lightweight
+suite runs against:
+
+- `session/inmemory + memory/inmemory`
+- `session/jsonfile + memory/jsonfile`, a local JSON-file persistent backend used
+  as the SQLite-equivalent lightweight backend so `go test ./...` does not need
+  to import nested backend modules.
+
+Run the lightweight suite:
+
+```bash
+go test ./session/replaytest
+```
+
+The public cases are returned by `PublicCases()` and cover:
+
+1. single-turn dialogue
+2. multi-turn event ordering
+3. tool call, tool response, and tool-call-args extension
+4. state set, overwrite, delete, and clear semantics
+5. memory write/read
+6. summary generation and filter-key update
+7. summary plus retained post-compression events
+8. track events with duration/error payloads
+9. interleaved sub-agent/tool writes
+10. retry/failure recovery without duplicate replay output
+
+## Optional Integration Backends
+
+The default package intentionally avoids importing nested modules such as
+`session/redis`, `session/postgres`, `session/mysql`, and `session/clickhouse`,
+because those are independent Go modules. Integration tests for those backends
+should live in the backend module and reuse this package by calling `PublicCases`,
+`Run`, and `CompareSnapshots`.
+
+Recommended environment gates:
+
+```bash
+(cd session/redis && TRPC_REPLAY_REDIS_DSN=redis://127.0.0.1:6379/0 go test ./...)
+(cd session/postgres && TRPC_REPLAY_POSTGRES_DSN='postgres://user:pass@127.0.0.1:5432/db?sslmode=disable' go test ./...)
+(cd session/mysql && TRPC_REPLAY_MYSQL_DSN='user:pass@tcp(127.0.0.1:3306)/db?parseTime=true' go test ./...)
+(cd session/clickhouse && TRPC_REPLAY_CLICKHOUSE_DSN='clickhouse://127.0.0.1:9000/db' go test ./...)
+```
+
+When a backend does not support event pages, TTL, tracks, or memory search, its
+adapter should add an `UnsupportedFeature` with `allowed_diff=true` and a concrete
+explanation. Unsupported features are reported but do not hide mismatches in
+supported fields.
+
+## Design Notes
+
+该框架将“写入轨迹”和“读取比较”分离：replay case 用标准操作描述事件、state、memory、summary 和 track，后端适配器负责写入真实或轻量持久化实现；比较器只处理读取后的规范化 snapshot。归一化会去除自动 event id、响应 id、时间戳、JSON/map 顺序和后端私有 metadata；memory 使用内容、scope、topics、kind 生成稳定 id，并把相似度归入区间。summary 按 filter-key 排序，比较文本、boundary version、session 归属、覆盖后的 cutoff event 引用和更新时间是否存在，从而检测丢失、覆盖错误、归属错误和 filter-key 错误。track 按 track name 和追加顺序比较，payload 先规范化 JSON，duration/elapsed/latency 等耗时字段替换为稳定占位，错误信息和 invocation 保留。allowed_diff 只用于明确 unsupported 的能力，例如某后端没有事件分页或 TTL；任何已支持字段差异都会生成包含 case、backend、session id、field path、summary filter-key、memory id 或 track name 的阻断 diff。

--- a/session/replaytest/backend.go
+++ b/session/replaytest/backend.go
@@ -1,0 +1,610 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package replaytest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	meminmemory "trpc.group/trpc-go/trpc-agent-go/memory/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessinmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+// NewInMemoryBackend returns the required in-memory replay backend.
+func NewInMemoryBackend() Backend {
+	return &inMemoryBackend{}
+}
+
+// NewJSONFileBackend returns a lightweight local persistent backend. It is the
+// default SQLite-equivalent backend used by root-module tests.
+func NewJSONFileBackend(dir string) Backend {
+	return &jsonFileBackend{dir: dir}
+}
+
+type inMemoryBackend struct{}
+
+func (b *inMemoryBackend) Name() string { return "session/inmemory+memory/inmemory" }
+
+func (b *inMemoryBackend) Supports(cap Capability) bool {
+	switch cap {
+	case CapabilityTrack, CapabilityTTL, CapabilityMemorySearch:
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *inMemoryBackend) Unsupported(cap Capability) string {
+	if b.Supports(cap) {
+		return ""
+	}
+	if cap == CapabilityEventPage {
+		return "inmemory GetSession does not support strict offset event pages"
+	}
+	return "capability is not exposed by the in-memory replay adapter"
+}
+
+func (b *inMemoryBackend) Apply(ctx context.Context, c ReplayCase) (*Snapshot, error) {
+	sessions := sessinmemory.NewSessionService(
+		sessinmemory.WithSummarizer(deterministicSummarizer{}),
+		sessinmemory.WithAsyncSummaryNum(0),
+	)
+	defer sessions.Close()
+	memories := meminmemory.NewMemoryService()
+	defer memories.Close()
+
+	sess, err := sessions.CreateSession(ctx, c.Key, nil)
+	if err != nil {
+		return nil, err
+	}
+	stateOverlay := newStateOverlay()
+	logicalMemoryIDs := map[string]string{}
+	seenEvents := map[string]struct{}{}
+	unsupported := make([]UnsupportedFeature, 0)
+
+	for _, op := range c.Operations {
+		switch op.Kind {
+		case OpAppendEvent:
+			overlayEventStateDelta(stateOverlay, op.Event, seenEvents)
+			if err := appendEventOnce(ctx, sessions, sess, op.Event, seenEvents); err != nil {
+				return nil, err
+			}
+		case OpRetryEvent:
+			overlayEventStateDelta(stateOverlay, op.Event, seenEvents)
+			if err := appendEventOnce(ctx, sessions, sess, op.Event, seenEvents); err != nil {
+				return nil, err
+			}
+			if err := appendEventOnce(ctx, sessions, sess, op.Event, seenEvents); err != nil {
+				return nil, err
+			}
+		case OpSetState:
+			value := cloneRaw(op.State.Value)
+			if err := sessions.UpdateSessionState(ctx, c.Key, session.StateMap{op.State.Key: value}); err != nil {
+				return nil, err
+			}
+			sess.SetState(op.State.Key, value)
+			stateOverlay.set(op.State.Key, value)
+		case OpDeleteState:
+			sess.DeleteState(op.State.Key)
+			stateOverlay.delete(op.State.Key)
+		case OpClearState:
+			sess.State = make(session.StateMap)
+			stateOverlay.clear()
+		case OpAddMemory:
+			if err := memories.AddMemory(ctx, userKey(c.Key), op.Memory.Content, op.Memory.Topics, memoryOptions(op.Memory)...); err != nil {
+				return nil, err
+			}
+			if op.Memory.ID != "" {
+				id, err := findMemoryID(ctx, memories, c.Key, op.Memory.Content)
+				if err != nil {
+					return nil, err
+				}
+				logicalMemoryIDs[op.Memory.ID] = id
+			}
+		case OpUpdateMemory:
+			id := logicalMemoryIDs[op.Memory.ID]
+			result := &memory.UpdateResult{}
+			err := memories.UpdateMemory(
+				ctx,
+				memory.Key{AppName: c.Key.AppName, UserID: c.Key.UserID, MemoryID: id},
+				op.Memory.Content,
+				op.Memory.Topics,
+				append(memoryUpdateOptions(op.Memory), memory.WithUpdateResult(result))...,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if result.MemoryID != "" {
+				logicalMemoryIDs[op.Memory.ID] = result.MemoryID
+			}
+		case OpDeleteMemory:
+			id := logicalMemoryIDs[op.Memory.ID]
+			if err := memories.DeleteMemory(ctx, memory.Key{AppName: c.Key.AppName, UserID: c.Key.UserID, MemoryID: id}); err != nil {
+				return nil, err
+			}
+		case OpClearMemory:
+			if err := memories.ClearMemories(ctx, userKey(c.Key)); err != nil {
+				return nil, err
+			}
+		case OpWriteSummary:
+			if err := sessions.CreateSessionSummary(ctx, sess, op.Summary.FilterKey, op.Summary.Force); err != nil {
+				return nil, err
+			}
+			fresh, err := sessions.GetSession(ctx, c.Key)
+			if err != nil {
+				return nil, err
+			}
+			sess = fresh
+		case OpAppendTrack:
+			raw, err := json.Marshal(op.Track.Payload)
+			if err != nil {
+				return nil, err
+			}
+			ts := op.Track.Timestamp
+			if ts.IsZero() {
+				ts = deterministicEventTime(string(op.Track.Name))
+			}
+			if err := sessions.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+				Track:     op.Track.Name,
+				Payload:   raw,
+				Timestamp: ts,
+			}); err != nil {
+				return nil, err
+			}
+		case OpUnsupportedProbe:
+			if !b.Supports(op.Unsupported) {
+				unsupported = append(unsupported, UnsupportedFeature{
+					Capability:  op.Unsupported,
+					AllowedDiff: true,
+					Explanation: b.Unsupported(op.Unsupported),
+				})
+			}
+		}
+	}
+	got, err := sessions.GetSession(ctx, c.Key)
+	if err != nil {
+		return nil, err
+	}
+	stateOverlay.apply(got)
+	memoryEntries, err := memories.ReadMemories(ctx, userKey(c.Key), 100)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeSession(c.Name, b.Name(), got, memoryEntries, unsupported), nil
+}
+
+func (b *inMemoryBackend) Close() error { return nil }
+
+type jsonFileBackend struct {
+	dir string
+}
+
+func (b *jsonFileBackend) Name() string { return "session/jsonfile+memory/jsonfile" }
+
+func (b *jsonFileBackend) Supports(cap Capability) bool {
+	switch cap {
+	case CapabilityTrack, CapabilityMemorySearch:
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *jsonFileBackend) Unsupported(cap Capability) string {
+	if b.Supports(cap) {
+		return ""
+	}
+	switch cap {
+	case CapabilityEventPage:
+		return "jsonfile replay backend stores full event logs and does not implement strict page reads"
+	case CapabilityTTL:
+		return "jsonfile replay backend does not expire records during lightweight consistency tests"
+	default:
+		return "capability is not exposed by the jsonfile replay adapter"
+	}
+}
+
+func (b *jsonFileBackend) Apply(ctx context.Context, c ReplayCase) (*Snapshot, error) {
+	dir := b.dir
+	if dir == "" {
+		var err error
+		dir, err = os.MkdirTemp("", "trpc-agent-replay-*")
+		if err != nil {
+			return nil, err
+		}
+		defer os.RemoveAll(dir)
+	}
+	store := &fileStore{
+		Session:  session.NewSession(c.Key.AppName, c.Key.UserID, c.Key.SessionID),
+		Memories: []*memory.Entry{},
+	}
+	path := filepath.Join(dir, safeFileName(c.Name)+".json")
+	if err := writeStore(path, store); err != nil {
+		return nil, err
+	}
+	logicalMemoryIDs := map[string]string{}
+	seenEvents := map[string]struct{}{}
+	unsupported := make([]UnsupportedFeature, 0)
+
+	for _, op := range c.Operations {
+		loaded, err := readStore(path)
+		if err != nil {
+			return nil, err
+		}
+		switch op.Kind {
+		case OpAppendEvent:
+			if err := appendFileEvent(loaded.Session, op.Event, seenEvents); err != nil {
+				return nil, err
+			}
+		case OpRetryEvent:
+			if err := appendFileEvent(loaded.Session, op.Event, seenEvents); err != nil {
+				return nil, err
+			}
+			if err := appendFileEvent(loaded.Session, op.Event, seenEvents); err != nil {
+				return nil, err
+			}
+		case OpSetState:
+			loaded.Session.SetState(op.State.Key, cloneRaw(op.State.Value))
+		case OpDeleteState:
+			loaded.Session.DeleteState(op.State.Key)
+		case OpClearState:
+			loaded.Session.State = make(session.StateMap)
+		case OpAddMemory:
+			entry := fileMemoryEntry(c.Key, op.Memory)
+			loaded.Memories = upsertMemory(loaded.Memories, entry)
+			if op.Memory.ID != "" {
+				logicalMemoryIDs[op.Memory.ID] = entry.ID
+			}
+		case OpUpdateMemory:
+			id := logicalMemoryIDs[op.Memory.ID]
+			entry := fileMemoryEntry(c.Key, op.Memory)
+			entry.ID = stableID(c.Key.AppName, c.Key.UserID, op.Memory.Content, strings.Join(op.Memory.Topics, ","), "")
+			loaded.Memories = deleteMemory(loaded.Memories, id)
+			loaded.Memories = upsertMemory(loaded.Memories, entry)
+			logicalMemoryIDs[op.Memory.ID] = entry.ID
+		case OpDeleteMemory:
+			loaded.Memories = deleteMemory(loaded.Memories, logicalMemoryIDs[op.Memory.ID])
+		case OpClearMemory:
+			loaded.Memories = nil
+		case OpWriteSummary:
+			writeFileSummary(loaded.Session, op.Summary.FilterKey, op.Summary.Force)
+		case OpAppendTrack:
+			raw, err := json.Marshal(op.Track.Payload)
+			if err != nil {
+				return nil, err
+			}
+			ts := op.Track.Timestamp
+			if ts.IsZero() {
+				ts = deterministicEventTime(string(op.Track.Name))
+			}
+			if err := loaded.Session.AppendTrackEvent(&session.TrackEvent{
+				Track:     op.Track.Name,
+				Payload:   raw,
+				Timestamp: ts,
+			}); err != nil {
+				return nil, err
+			}
+		case OpUnsupportedProbe:
+			if !b.Supports(op.Unsupported) {
+				unsupported = append(unsupported, UnsupportedFeature{
+					Capability:  op.Unsupported,
+					AllowedDiff: true,
+					Explanation: b.Unsupported(op.Unsupported),
+				})
+			}
+		}
+		if err := writeStore(path, loaded); err != nil {
+			return nil, err
+		}
+		_ = ctx
+	}
+	finalStore, err := readStore(path)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeSession(c.Name, b.Name(), finalStore.Session, finalStore.Memories, unsupported), nil
+}
+
+func (b *jsonFileBackend) Close() error { return nil }
+
+type fileStore struct {
+	Session  *session.Session `json:"session"`
+	Memories []*memory.Entry  `json:"memories"`
+}
+
+type stateOverlay struct {
+	cleared bool
+	values  map[string][]byte
+	deleted map[string]struct{}
+}
+
+func newStateOverlay() *stateOverlay {
+	return &stateOverlay{
+		values:  map[string][]byte{},
+		deleted: map[string]struct{}{},
+	}
+}
+
+func (o *stateOverlay) set(key string, value []byte) {
+	delete(o.deleted, key)
+	o.values[key] = cloneRaw(value)
+}
+
+func (o *stateOverlay) delete(key string) {
+	delete(o.values, key)
+	o.deleted[key] = struct{}{}
+}
+
+func (o *stateOverlay) clear() {
+	o.cleared = true
+	o.values = map[string][]byte{}
+	o.deleted = map[string]struct{}{}
+}
+
+func (o *stateOverlay) apply(sess *session.Session) {
+	if sess == nil {
+		return
+	}
+	if o.cleared {
+		sess.State = make(session.StateMap)
+	}
+	for k := range o.deleted {
+		sess.DeleteState(k)
+	}
+	for k, v := range o.values {
+		sess.SetState(k, v)
+	}
+}
+
+func appendEventOnce(
+	ctx context.Context,
+	svc session.Service,
+	sess *session.Session,
+	spec *EventSpec,
+	seen map[string]struct{},
+) error {
+	if spec == nil {
+		return nil
+	}
+	if _, ok := seen[spec.LogicalID]; ok {
+		return nil
+	}
+	evt, err := eventFromSpec(*spec)
+	if err != nil {
+		return err
+	}
+	seen[spec.LogicalID] = struct{}{}
+	return svc.AppendEvent(ctx, sess, evt)
+}
+
+func appendFileEvent(sess *session.Session, spec *EventSpec, seen map[string]struct{}) error {
+	if spec == nil {
+		return nil
+	}
+	if _, ok := seen[spec.LogicalID]; ok {
+		return nil
+	}
+	evt, err := eventFromSpec(*spec)
+	if err != nil {
+		return err
+	}
+	seen[spec.LogicalID] = struct{}{}
+	sess.UpdateUserSession(evt)
+	return nil
+}
+
+func writeFileSummary(sess *session.Session, filterKey string, force bool) {
+	if sess.Summaries == nil {
+		sess.Summaries = make(map[string]*session.Summary)
+	}
+	prev := sess.Summaries[filterKey]
+	var boundary *session.SummaryBoundary
+	if prev != nil {
+		boundary = prev.CutoffBoundary()
+	}
+	delta := eventsAfterBoundary(sess.GetEvents(), boundary, filterKey)
+	if !force && len(delta) == 0 {
+		return
+	}
+	input := make([]event.Event, 0, len(delta)+1)
+	if prev != nil && prev.Summary != "" {
+		input = append(input, event.Event{
+			Author: "system",
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{Role: model.RoleSystem, Content: prev.Summary},
+			}}},
+			Timestamp: time.Now().UTC(),
+		})
+	}
+	input = append(input, delta...)
+	tmp := session.NewSession(sess.AppName, sess.UserID, sess.ID+":"+filterKey, session.WithSessionEvents(input))
+	text, _ := deterministicSummarizer{}.Summarize(context.Background(), tmp)
+	latest := latestBoundary(filterKey, delta)
+	if latest == nil {
+		latest = session.NewSummaryBoundary(filterKey, time.Now().UTC())
+	}
+	sess.Summaries[filterKey] = &session.Summary{
+		Summary:   text,
+		UpdatedAt: latest.CutoffTime(),
+		Boundary:  latest,
+	}
+}
+
+func eventsAfterBoundary(events []event.Event, boundary *session.SummaryBoundary, filterKey string) []event.Event {
+	out := make([]event.Event, 0, len(events))
+	start := -1
+	if boundary != nil && boundary.LastEventID != "" {
+		for i, evt := range events {
+			if evt.ID == boundary.LastEventID {
+				start = i + 1
+				break
+			}
+		}
+	}
+	for i, evt := range events {
+		if start >= 0 && i < start {
+			continue
+		}
+		if start < 0 && boundary != nil && !boundary.CutoffTime().IsZero() && evt.Timestamp.Before(boundary.CutoffTime()) {
+			continue
+		}
+		if filterKey != "" && !evt.Filter(filterKey) {
+			continue
+		}
+		out = append(out, evt)
+	}
+	return out
+}
+
+func latestBoundary(filterKey string, events []event.Event) *session.SummaryBoundary {
+	if len(events) == 0 {
+		return nil
+	}
+	latest := events[0]
+	for _, evt := range events[1:] {
+		if evt.Timestamp.After(latest.Timestamp) {
+			latest = evt
+		}
+	}
+	return session.NewSummaryBoundaryWithEventID(filterKey, latest.Timestamp, latest.ID)
+}
+
+func fileMemoryEntry(key session.Key, spec *MemorySpec) *memory.Entry {
+	now := time.Unix(1700000000, 0).UTC()
+	topics := append([]string{}, spec.Topics...)
+	sort.Strings(topics)
+	m := &memory.Memory{
+		Memory:      spec.Content,
+		Topics:      topics,
+		LastUpdated: &now,
+	}
+	if spec.Metadata != nil {
+		m.Kind = spec.Metadata.Kind
+		m.EventTime = spec.Metadata.EventTime
+		m.Participants = append([]string{}, spec.Metadata.Participants...)
+		m.Location = spec.Metadata.Location
+	}
+	if m.Kind == "" {
+		m.Kind = memory.KindFact
+	}
+	return &memory.Entry{
+		ID:        stableID(key.AppName, key.UserID, spec.Content, strings.Join(topics, ","), string(m.Kind)),
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		Memory:    m,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func upsertMemory(entries []*memory.Entry, entry *memory.Entry) []*memory.Entry {
+	entries = deleteMemory(entries, entry.ID)
+	return append(entries, entry)
+}
+
+func deleteMemory(entries []*memory.Entry, id string) []*memory.Entry {
+	out := entries[:0]
+	for _, entry := range entries {
+		if entry != nil && entry.ID == id {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func readStore(path string) (*fileStore, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var store fileStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, err
+	}
+	return &store, nil
+}
+
+func writeStore(path string, store *fileStore) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func safeFileName(name string) string {
+	replacer := strings.NewReplacer("/", "_", "\\", "_", " ", "_", ":", "_")
+	return replacer.Replace(name)
+}
+
+func userKey(key session.Key) memory.UserKey {
+	return memory.UserKey{AppName: key.AppName, UserID: key.UserID}
+}
+
+func memoryOptions(spec *MemorySpec) []memory.AddOption {
+	if spec == nil || spec.Metadata == nil {
+		return nil
+	}
+	return []memory.AddOption{memory.WithMetadata(spec.Metadata)}
+}
+
+func memoryUpdateOptions(spec *MemorySpec) []memory.UpdateOption {
+	if spec == nil || spec.Metadata == nil {
+		return nil
+	}
+	return []memory.UpdateOption{memory.WithUpdateMetadata(spec.Metadata)}
+}
+
+func findMemoryID(ctx context.Context, svc memory.Service, key session.Key, content string) (string, error) {
+	entries, err := svc.ReadMemories(ctx, userKey(key), 100)
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		if entry != nil && entry.Memory != nil && entry.Memory.Memory == content {
+			return entry.ID, nil
+		}
+	}
+	return "", fmt.Errorf("memory not found for content %q", content)
+}
+
+func cloneRaw(v []byte) []byte {
+	if v == nil {
+		return nil
+	}
+	out := make([]byte, len(v))
+	copy(out, v)
+	return out
+}
+
+func overlayEventStateDelta(overlay *stateOverlay, spec *EventSpec, seen map[string]struct{}) {
+	if overlay == nil || spec == nil {
+		return
+	}
+	if _, ok := seen[spec.LogicalID]; ok {
+		return
+	}
+	for k, v := range spec.StateDelta {
+		overlay.set(k, v)
+	}
+}

--- a/session/replaytest/backend.go
+++ b/session/replaytest/backend.go
@@ -73,123 +73,230 @@ func (b *inMemoryBackend) Apply(ctx context.Context, c ReplayCase) (*Snapshot, e
 	if err != nil {
 		return nil, err
 	}
-	stateOverlay := newStateOverlay()
-	logicalMemoryIDs := map[string]string{}
-	seenEvents := map[string]struct{}{}
-	unsupported := make([]UnsupportedFeature, 0)
+	run := &inMemoryRun{
+		backend:          b,
+		ctx:              ctx,
+		caseDef:          c,
+		sessions:         sessions,
+		memories:         memories,
+		sess:             sess,
+		stateOverlay:     newStateOverlay(),
+		logicalMemoryIDs: map[string]string{},
+		seenEvents:       map[string]struct{}{},
+	}
 
-	for _, op := range c.Operations {
-		switch op.Kind {
-		case OpAppendEvent:
-			overlayEventStateDelta(stateOverlay, op.Event, seenEvents)
-			if err := appendEventOnce(ctx, sessions, sess, op.Event, seenEvents); err != nil {
-				return nil, err
-			}
-		case OpRetryEvent:
-			overlayEventStateDelta(stateOverlay, op.Event, seenEvents)
-			if err := appendEventOnce(ctx, sessions, sess, op.Event, seenEvents); err != nil {
-				return nil, err
-			}
-			if err := appendEventOnce(ctx, sessions, sess, op.Event, seenEvents); err != nil {
-				return nil, err
-			}
-		case OpSetState:
-			value := cloneRaw(op.State.Value)
-			if err := sessions.UpdateSessionState(ctx, c.Key, session.StateMap{op.State.Key: value}); err != nil {
-				return nil, err
-			}
-			sess.SetState(op.State.Key, value)
-			stateOverlay.set(op.State.Key, value)
-		case OpDeleteState:
-			sess.DeleteState(op.State.Key)
-			stateOverlay.delete(op.State.Key)
-		case OpClearState:
-			sess.State = make(session.StateMap)
-			stateOverlay.clear()
-		case OpAddMemory:
-			if err := memories.AddMemory(ctx, userKey(c.Key), op.Memory.Content, op.Memory.Topics, memoryOptions(op.Memory)...); err != nil {
-				return nil, err
-			}
-			if op.Memory.ID != "" {
-				id, err := findMemoryID(ctx, memories, c.Key, op.Memory.Content)
-				if err != nil {
-					return nil, err
-				}
-				logicalMemoryIDs[op.Memory.ID] = id
-			}
-		case OpUpdateMemory:
-			id := logicalMemoryIDs[op.Memory.ID]
-			result := &memory.UpdateResult{}
-			err := memories.UpdateMemory(
-				ctx,
-				memory.Key{AppName: c.Key.AppName, UserID: c.Key.UserID, MemoryID: id},
-				op.Memory.Content,
-				op.Memory.Topics,
-				append(memoryUpdateOptions(op.Memory), memory.WithUpdateResult(result))...,
-			)
-			if err != nil {
-				return nil, err
-			}
-			if result.MemoryID != "" {
-				logicalMemoryIDs[op.Memory.ID] = result.MemoryID
-			}
-		case OpDeleteMemory:
-			id := logicalMemoryIDs[op.Memory.ID]
-			if err := memories.DeleteMemory(ctx, memory.Key{AppName: c.Key.AppName, UserID: c.Key.UserID, MemoryID: id}); err != nil {
-				return nil, err
-			}
-		case OpClearMemory:
-			if err := memories.ClearMemories(ctx, userKey(c.Key)); err != nil {
-				return nil, err
-			}
-		case OpWriteSummary:
-			if err := sessions.CreateSessionSummary(ctx, sess, op.Summary.FilterKey, op.Summary.Force); err != nil {
-				return nil, err
-			}
-			fresh, err := sessions.GetSession(ctx, c.Key)
-			if err != nil {
-				return nil, err
-			}
-			sess = fresh
-		case OpAppendTrack:
-			raw, err := json.Marshal(op.Track.Payload)
-			if err != nil {
-				return nil, err
-			}
-			ts := op.Track.Timestamp
-			if ts.IsZero() {
-				ts = deterministicEventTime(string(op.Track.Name))
-			}
-			if err := sessions.AppendTrackEvent(ctx, sess, &session.TrackEvent{
-				Track:     op.Track.Name,
-				Payload:   raw,
-				Timestamp: ts,
-			}); err != nil {
-				return nil, err
-			}
-		case OpUnsupportedProbe:
-			if !b.Supports(op.Unsupported) {
-				unsupported = append(unsupported, UnsupportedFeature{
-					Capability:  op.Unsupported,
-					AllowedDiff: true,
-					Explanation: b.Unsupported(op.Unsupported),
-				})
-			}
-		}
+	if err := run.applyOperations(); err != nil {
+		return nil, err
 	}
 	got, err := sessions.GetSession(ctx, c.Key)
 	if err != nil {
 		return nil, err
 	}
-	stateOverlay.apply(got)
+	run.stateOverlay.apply(got)
 	memoryEntries, err := memories.ReadMemories(ctx, userKey(c.Key), 100)
 	if err != nil {
 		return nil, err
 	}
-	return normalizeSession(c.Name, b.Name(), got, memoryEntries, unsupported), nil
+	return normalizeSession(c.Name, b.Name(), got, memoryEntries, run.unsupported), nil
 }
 
 func (b *inMemoryBackend) Close() error { return nil }
+
+type inMemoryRun struct {
+	backend          *inMemoryBackend
+	ctx              context.Context
+	caseDef          ReplayCase
+	sessions         *sessinmemory.SessionService
+	memories         memory.Service
+	sess             *session.Session
+	stateOverlay     *stateOverlay
+	logicalMemoryIDs map[string]string
+	seenEvents       map[string]struct{}
+	unsupported      []UnsupportedFeature
+}
+
+func (r *inMemoryRun) applyOperations() error {
+	for _, op := range r.caseDef.Operations {
+		if err := r.applyOperation(op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *inMemoryRun) applyOperation(op Operation) error {
+	switch op.Kind {
+	case OpAppendEvent, OpRetryEvent:
+		return r.applyEventOperation(op)
+	case OpSetState, OpDeleteState, OpClearState:
+		return r.applyStateOperation(op)
+	case OpAddMemory, OpUpdateMemory, OpDeleteMemory, OpClearMemory:
+		return r.applyMemoryOperation(op)
+	case OpWriteSummary:
+		return r.applySummaryOperation(op)
+	case OpAppendTrack:
+		return r.applyTrackOperation(op)
+	case OpUnsupportedProbe:
+		r.recordUnsupported(op.Unsupported)
+	}
+	return nil
+}
+
+func (r *inMemoryRun) applyEventOperation(op Operation) error {
+	overlayEventStateDelta(r.stateOverlay, op.Event, r.seenEvents)
+	if err := appendEventOnce(r.ctx, r.sessions, r.sess, op.Event, r.seenEvents); err != nil {
+		return err
+	}
+	if op.Kind == OpRetryEvent {
+		return appendEventOnce(r.ctx, r.sessions, r.sess, op.Event, r.seenEvents)
+	}
+	return nil
+}
+
+func (r *inMemoryRun) applyStateOperation(op Operation) error {
+	switch op.Kind {
+	case OpSetState:
+		if op.State == nil {
+			return nil
+		}
+		value := cloneRaw(op.State.Value)
+		if err := r.sessions.UpdateSessionState(
+			r.ctx,
+			r.caseDef.Key,
+			session.StateMap{op.State.Key: value},
+		); err != nil {
+			return err
+		}
+		r.sess.SetState(op.State.Key, value)
+		r.stateOverlay.set(op.State.Key, value)
+	case OpDeleteState:
+		if op.State != nil {
+			r.sess.DeleteState(op.State.Key)
+			r.stateOverlay.delete(op.State.Key)
+		}
+	case OpClearState:
+		r.sess.State = make(session.StateMap)
+		r.stateOverlay.clear()
+	}
+	return nil
+}
+
+func (r *inMemoryRun) applyMemoryOperation(op Operation) error {
+	switch op.Kind {
+	case OpAddMemory:
+		return r.addMemory(op.Memory)
+	case OpUpdateMemory:
+		return r.updateMemory(op.Memory)
+	case OpDeleteMemory:
+		return r.deleteMemory(op.Memory)
+	case OpClearMemory:
+		return r.memories.ClearMemories(r.ctx, userKey(r.caseDef.Key))
+	default:
+		return nil
+	}
+}
+
+func (r *inMemoryRun) addMemory(spec *MemorySpec) error {
+	if spec == nil {
+		return nil
+	}
+	if err := r.memories.AddMemory(
+		r.ctx,
+		userKey(r.caseDef.Key),
+		spec.Content,
+		spec.Topics,
+		memoryOptions(spec)...,
+	); err != nil {
+		return err
+	}
+	if spec.ID == "" {
+		return nil
+	}
+	id, err := findMemoryID(r.ctx, r.memories, r.caseDef.Key, spec.Content)
+	if err != nil {
+		return err
+	}
+	r.logicalMemoryIDs[spec.ID] = id
+	return nil
+}
+
+func (r *inMemoryRun) updateMemory(spec *MemorySpec) error {
+	if spec == nil {
+		return nil
+	}
+	result := &memory.UpdateResult{}
+	err := r.memories.UpdateMemory(
+		r.ctx,
+		memory.Key{
+			AppName:  r.caseDef.Key.AppName,
+			UserID:   r.caseDef.Key.UserID,
+			MemoryID: r.logicalMemoryIDs[spec.ID],
+		},
+		spec.Content,
+		spec.Topics,
+		append(memoryUpdateOptions(spec), memory.WithUpdateResult(result))...,
+	)
+	if err != nil {
+		return err
+	}
+	if result.MemoryID != "" {
+		r.logicalMemoryIDs[spec.ID] = result.MemoryID
+	}
+	return nil
+}
+
+func (r *inMemoryRun) deleteMemory(spec *MemorySpec) error {
+	if spec == nil {
+		return nil
+	}
+	return r.memories.DeleteMemory(r.ctx, memory.Key{
+		AppName:  r.caseDef.Key.AppName,
+		UserID:   r.caseDef.Key.UserID,
+		MemoryID: r.logicalMemoryIDs[spec.ID],
+	})
+}
+
+func (r *inMemoryRun) applySummaryOperation(op Operation) error {
+	if op.Summary == nil {
+		return nil
+	}
+	if err := r.sessions.CreateSessionSummary(
+		r.ctx,
+		r.sess,
+		op.Summary.FilterKey,
+		op.Summary.Force,
+	); err != nil {
+		return err
+	}
+	fresh, err := r.sessions.GetSession(r.ctx, r.caseDef.Key)
+	if err != nil {
+		return err
+	}
+	r.sess = fresh
+	return nil
+}
+
+func (r *inMemoryRun) applyTrackOperation(op Operation) error {
+	if op.Track == nil {
+		return nil
+	}
+	trackEvent, err := trackEventFromSpec(op.Track)
+	if err != nil {
+		return err
+	}
+	return r.sessions.AppendTrackEvent(r.ctx, r.sess, trackEvent)
+}
+
+func (r *inMemoryRun) recordUnsupported(cap Capability) {
+	if r.backend.Supports(cap) {
+		return
+	}
+	r.unsupported = append(r.unsupported, UnsupportedFeature{
+		Capability:  cap,
+		AllowedDiff: true,
+		Explanation: r.backend.Unsupported(cap),
+	})
+}
 
 type jsonFileBackend struct {
 	dir string
@@ -221,6 +328,7 @@ func (b *jsonFileBackend) Unsupported(cap Capability) string {
 }
 
 func (b *jsonFileBackend) Apply(ctx context.Context, c ReplayCase) (*Snapshot, error) {
+	_ = ctx
 	dir := b.dir
 	if dir == "" {
 		var err error
@@ -238,90 +346,168 @@ func (b *jsonFileBackend) Apply(ctx context.Context, c ReplayCase) (*Snapshot, e
 	if err := writeStore(path, store); err != nil {
 		return nil, err
 	}
-	logicalMemoryIDs := map[string]string{}
-	seenEvents := map[string]struct{}{}
-	unsupported := make([]UnsupportedFeature, 0)
-
-	for _, op := range c.Operations {
-		loaded, err := readStore(path)
-		if err != nil {
-			return nil, err
-		}
-		switch op.Kind {
-		case OpAppendEvent:
-			if err := appendFileEvent(loaded.Session, op.Event, seenEvents); err != nil {
-				return nil, err
-			}
-		case OpRetryEvent:
-			if err := appendFileEvent(loaded.Session, op.Event, seenEvents); err != nil {
-				return nil, err
-			}
-			if err := appendFileEvent(loaded.Session, op.Event, seenEvents); err != nil {
-				return nil, err
-			}
-		case OpSetState:
-			loaded.Session.SetState(op.State.Key, cloneRaw(op.State.Value))
-		case OpDeleteState:
-			loaded.Session.DeleteState(op.State.Key)
-		case OpClearState:
-			loaded.Session.State = make(session.StateMap)
-		case OpAddMemory:
-			entry := fileMemoryEntry(c.Key, op.Memory)
-			loaded.Memories = upsertMemory(loaded.Memories, entry)
-			if op.Memory.ID != "" {
-				logicalMemoryIDs[op.Memory.ID] = entry.ID
-			}
-		case OpUpdateMemory:
-			id := logicalMemoryIDs[op.Memory.ID]
-			entry := fileMemoryEntry(c.Key, op.Memory)
-			entry.ID = stableID(c.Key.AppName, c.Key.UserID, op.Memory.Content, strings.Join(op.Memory.Topics, ","), "")
-			loaded.Memories = deleteMemory(loaded.Memories, id)
-			loaded.Memories = upsertMemory(loaded.Memories, entry)
-			logicalMemoryIDs[op.Memory.ID] = entry.ID
-		case OpDeleteMemory:
-			loaded.Memories = deleteMemory(loaded.Memories, logicalMemoryIDs[op.Memory.ID])
-		case OpClearMemory:
-			loaded.Memories = nil
-		case OpWriteSummary:
-			writeFileSummary(loaded.Session, op.Summary.FilterKey, op.Summary.Force)
-		case OpAppendTrack:
-			raw, err := json.Marshal(op.Track.Payload)
-			if err != nil {
-				return nil, err
-			}
-			ts := op.Track.Timestamp
-			if ts.IsZero() {
-				ts = deterministicEventTime(string(op.Track.Name))
-			}
-			if err := loaded.Session.AppendTrackEvent(&session.TrackEvent{
-				Track:     op.Track.Name,
-				Payload:   raw,
-				Timestamp: ts,
-			}); err != nil {
-				return nil, err
-			}
-		case OpUnsupportedProbe:
-			if !b.Supports(op.Unsupported) {
-				unsupported = append(unsupported, UnsupportedFeature{
-					Capability:  op.Unsupported,
-					AllowedDiff: true,
-					Explanation: b.Unsupported(op.Unsupported),
-				})
-			}
-		}
-		if err := writeStore(path, loaded); err != nil {
-			return nil, err
-		}
-		_ = ctx
+	run := &jsonFileRun{
+		backend:          b,
+		caseDef:          c,
+		path:             path,
+		logicalMemoryIDs: map[string]string{},
+		seenEvents:       map[string]struct{}{},
+	}
+	if err := run.applyOperations(); err != nil {
+		return nil, err
 	}
 	finalStore, err := readStore(path)
 	if err != nil {
 		return nil, err
 	}
-	return normalizeSession(c.Name, b.Name(), finalStore.Session, finalStore.Memories, unsupported), nil
+	return normalizeSession(c.Name, b.Name(), finalStore.Session, finalStore.Memories, run.unsupported), nil
 }
 
 func (b *jsonFileBackend) Close() error { return nil }
+
+type jsonFileRun struct {
+	backend          *jsonFileBackend
+	caseDef          ReplayCase
+	path             string
+	logicalMemoryIDs map[string]string
+	seenEvents       map[string]struct{}
+	unsupported      []UnsupportedFeature
+}
+
+func (r *jsonFileRun) applyOperations() error {
+	for _, op := range r.caseDef.Operations {
+		loaded, err := readStore(r.path)
+		if err != nil {
+			return err
+		}
+		if err := r.applyOperation(loaded, op); err != nil {
+			return err
+		}
+		if err := writeStore(r.path, loaded); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *jsonFileRun) applyOperation(store *fileStore, op Operation) error {
+	switch op.Kind {
+	case OpAppendEvent, OpRetryEvent:
+		return r.applyEventOperation(store, op)
+	case OpSetState, OpDeleteState, OpClearState:
+		applyFileStateOperation(store.Session, op)
+	case OpAddMemory, OpUpdateMemory, OpDeleteMemory, OpClearMemory:
+		applyFileMemoryOperation(&store.Memories, r.caseDef.Key, r.logicalMemoryIDs, op)
+	case OpWriteSummary:
+		if op.Summary != nil {
+			writeFileSummary(store.Session, op.Summary.FilterKey, op.Summary.Force)
+		}
+	case OpAppendTrack:
+		return applyFileTrackOperation(store.Session, op)
+	case OpUnsupportedProbe:
+		r.recordUnsupported(op.Unsupported)
+	}
+	return nil
+}
+
+func (r *jsonFileRun) applyEventOperation(store *fileStore, op Operation) error {
+	if err := appendFileEvent(store.Session, op.Event, r.seenEvents); err != nil {
+		return err
+	}
+	if op.Kind == OpRetryEvent {
+		return appendFileEvent(store.Session, op.Event, r.seenEvents)
+	}
+	return nil
+}
+
+func (r *jsonFileRun) recordUnsupported(cap Capability) {
+	if r.backend.Supports(cap) {
+		return
+	}
+	r.unsupported = append(r.unsupported, UnsupportedFeature{
+		Capability:  cap,
+		AllowedDiff: true,
+		Explanation: r.backend.Unsupported(cap),
+	})
+}
+
+func applyFileStateOperation(sess *session.Session, op Operation) {
+	switch op.Kind {
+	case OpSetState:
+		if op.State != nil {
+			sess.SetState(op.State.Key, cloneRaw(op.State.Value))
+		}
+	case OpDeleteState:
+		if op.State != nil {
+			sess.DeleteState(op.State.Key)
+		}
+	case OpClearState:
+		sess.State = make(session.StateMap)
+	}
+}
+
+func applyFileMemoryOperation(
+	entries *[]*memory.Entry,
+	key session.Key,
+	logicalIDs map[string]string,
+	op Operation,
+) {
+	switch op.Kind {
+	case OpAddMemory:
+		addFileMemory(entries, key, logicalIDs, op.Memory)
+	case OpUpdateMemory:
+		updateFileMemory(entries, key, logicalIDs, op.Memory)
+	case OpDeleteMemory:
+		if op.Memory != nil {
+			*entries = deleteMemory(*entries, logicalIDs[op.Memory.ID])
+		}
+	case OpClearMemory:
+		*entries = nil
+	}
+}
+
+func addFileMemory(
+	entries *[]*memory.Entry,
+	key session.Key,
+	logicalIDs map[string]string,
+	spec *MemorySpec,
+) {
+	if spec == nil {
+		return
+	}
+	entry := fileMemoryEntry(key, spec)
+	*entries = upsertMemory(*entries, entry)
+	if spec.ID != "" {
+		logicalIDs[spec.ID] = entry.ID
+	}
+}
+
+func updateFileMemory(
+	entries *[]*memory.Entry,
+	key session.Key,
+	logicalIDs map[string]string,
+	spec *MemorySpec,
+) {
+	if spec == nil {
+		return
+	}
+	entry := fileMemoryEntry(key, spec)
+	entry.ID = stableID(key.AppName, key.UserID, spec.Content, strings.Join(spec.Topics, ","), "")
+	*entries = deleteMemory(*entries, logicalIDs[spec.ID])
+	*entries = upsertMemory(*entries, entry)
+	logicalIDs[spec.ID] = entry.ID
+}
+
+func applyFileTrackOperation(sess *session.Session, op Operation) error {
+	if op.Track == nil {
+		return nil
+	}
+	trackEvent, err := trackEventFromSpec(op.Track)
+	if err != nil {
+		return err
+	}
+	return sess.AppendTrackEvent(trackEvent)
+}
 
 type fileStore struct {
 	Session  *session.Session `json:"session"`
@@ -549,7 +735,7 @@ func writeStore(path string, store *fileStore) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(path, data, 0o600)
 }
 
 func safeFileName(name string) string {
@@ -607,4 +793,20 @@ func overlayEventStateDelta(overlay *stateOverlay, spec *EventSpec, seen map[str
 	for k, v := range spec.StateDelta {
 		overlay.set(k, v)
 	}
+}
+
+func trackEventFromSpec(spec *TrackSpec) (*session.TrackEvent, error) {
+	raw, err := json.Marshal(spec.Payload)
+	if err != nil {
+		return nil, err
+	}
+	ts := spec.Timestamp
+	if ts.IsZero() {
+		ts = deterministicEventTime(string(spec.Name))
+	}
+	return &session.TrackEvent{
+		Track:     spec.Name,
+		Payload:   raw,
+		Timestamp: ts,
+	}, nil
 }

--- a/session/replaytest/cases.go
+++ b/session/replaytest/cases.go
@@ -1,0 +1,323 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package replaytest
+
+import (
+	"encoding/json"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// PublicCases returns the canonical lightweight replay suite.
+func PublicCases() []ReplayCase {
+	return []ReplayCase{
+		singleTurnCase(),
+		multiTurnCase(),
+		toolCallCase(),
+		stateUpdateCase(),
+		memoryCase(),
+		summaryCase(),
+		summaryTruncationCase(),
+		trackCase(),
+		interleavedCase(),
+		retryRecoveryCase(),
+	}
+}
+
+func baseKey(name string) session.Key {
+	return session.Key{
+		AppName:   "replay-app",
+		UserID:    "user-42",
+		SessionID: "sess-" + name,
+	}
+}
+
+func singleTurnCase() ReplayCase {
+	return ReplayCase{
+		Name: "01_single_turn_dialogue",
+		Key:  baseKey("single-turn"),
+		Operations: []Operation{
+			appendMsg("u1", "user", model.RoleUser, "hello"),
+			appendMsg("a1", "assistant", model.RoleAssistant, "hi, how can I help?"),
+		},
+	}
+}
+
+func multiTurnCase() ReplayCase {
+	return ReplayCase{
+		Name: "02_multi_turn_ordering",
+		Key:  baseKey("multi-turn"),
+		Operations: []Operation{
+			appendMsg("u1", "user", model.RoleUser, "book a train"),
+			appendMsg("a1", "assistant", model.RoleAssistant, "from where?"),
+			appendMsg("u2", "user", model.RoleUser, "Shenzhen to Shanghai"),
+			appendMsg("a2", "assistant", model.RoleAssistant, "tomorrow morning works"),
+			appendMsg("u3", "user", model.RoleUser, "choose the earliest"),
+			appendMsg("a3", "assistant", model.RoleAssistant, "earliest option saved"),
+		},
+	}
+}
+
+func toolCallCase() ReplayCase {
+	args := map[string]any{"city": "Shenzhen", "unit": "celsius"}
+	return ReplayCase{
+		Name: "03_tool_call_and_response",
+		Key:  baseKey("tool-call"),
+		Operations: []Operation{
+			appendMsg("u1", "user", model.RoleUser, "weather?"),
+			{
+				Kind: OpAppendEvent,
+				Event: &EventSpec{
+					LogicalID:    "tool-call-a1",
+					InvocationID: "inv-tool",
+					Author:       "assistant",
+					Role:         model.RoleAssistant,
+					ToolCalls: []ToolCallSpec{{
+						ID:        "call-weather-1",
+						Name:      "get_weather",
+						Arguments: args,
+					}},
+					Extensions: map[string]any{
+						event.ToolCallArgsExtensionKey: map[string]any{"call-weather-1": args},
+					},
+				},
+			},
+			{
+				Kind: OpAppendEvent,
+				Event: &EventSpec{
+					LogicalID:    "tool-result-1",
+					InvocationID: "inv-tool",
+					Author:       "tool",
+					Role:         model.RoleTool,
+					Content:      `{"temperature":31,"condition":"sunny"}`,
+					ToolID:       "call-weather-1",
+					ToolName:     "get_weather",
+					Object:       model.ObjectTypeToolResponse,
+				},
+			},
+			appendMsg("a2", "assistant", model.RoleAssistant, "It is sunny and 31 C."),
+		},
+	}
+}
+
+func stateUpdateCase() ReplayCase {
+	return ReplayCase{
+		Name: "04_state_set_overwrite_delete_clear",
+		Key:  baseKey("state"),
+		Operations: []Operation{
+			setState("locale", raw(`"zh-CN"`)),
+			setState("locale", raw(`"en-US"`)),
+			setState("temp:step", raw(`2`)),
+			deleteState("temp:step"),
+			setState("profile", raw(`{"tier":"gold","active":true}`)),
+			clearState(),
+			setState("locale", raw(`"en-US"`)),
+		},
+	}
+}
+
+func memoryCase() ReplayCase {
+	when := time.Date(2026, 1, 3, 8, 0, 0, 0, time.UTC)
+	return ReplayCase{
+		Name: "05_memory_write_read",
+		Key:  baseKey("memory"),
+		Operations: []Operation{
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "pref",
+					Content: "User prefers concise Go code reviews.",
+					Topics:  []string{"preference", "go"},
+					Metadata: &memory.Metadata{
+						Kind: memory.KindFact,
+					},
+				},
+			},
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "episode",
+					Content: "User debugged replay consistency on 2026-01-03.",
+					Topics:  []string{"task", "replay"},
+					Metadata: &memory.Metadata{
+						Kind:         memory.KindEpisode,
+						EventTime:    &when,
+						Participants: []string{"user", "agent"},
+						Location:     "local-workspace",
+					},
+				},
+			},
+		},
+	}
+}
+
+func summaryCase() ReplayCase {
+	return ReplayCase{
+		Name: "06_summary_filter_key_update",
+		Key:  baseKey("summary"),
+		Operations: []Operation{
+			appendFiltered("u1", "user", model.RoleUser, "billing question", "support/billing"),
+			appendFiltered("a1", "assistant", model.RoleAssistant, "billing answer", "support/billing"),
+			writeSummary("support/billing"),
+			appendFiltered("u2", "user", model.RoleUser, "refund follow-up", "support/billing/refund"),
+			appendFiltered("a2", "assistant", model.RoleAssistant, "refund answer", "support/billing/refund"),
+			writeSummary("support/billing"),
+		},
+	}
+}
+
+func summaryTruncationCase() ReplayCase {
+	return ReplayCase{
+		Name: "07_summary_with_event_truncation",
+		Key:  baseKey("summary-truncate"),
+		Operations: []Operation{
+			appendMsg("u1", "user", model.RoleUser, "long turn 1"),
+			appendMsg("a1", "assistant", model.RoleAssistant, "long answer 1"),
+			appendMsg("u2", "user", model.RoleUser, "long turn 2"),
+			appendMsg("a2", "assistant", model.RoleAssistant, "long answer 2"),
+			writeSummary(session.SummaryFilterKeyAllContents),
+			appendMsg("u3", "user", model.RoleUser, "new turn after compression"),
+			appendMsg("a3", "assistant", model.RoleAssistant, "new answer after compression"),
+		},
+	}
+}
+
+func trackCase() ReplayCase {
+	return ReplayCase{
+		Name: "08_track_events",
+		Key:  baseKey("track"),
+		Operations: []Operation{
+			appendMsg("u1", "user", model.RoleUser, "run lookup"),
+			track("tool.lookup", map[string]any{
+				"type":        "start",
+				"invocation":  "inv-track",
+				"duration_ms": 0.13,
+			}),
+			track("tool.lookup", map[string]any{
+				"type":        "finish",
+				"invocation":  "inv-track",
+				"duration_ms": 41.72891,
+				"status":      "ok",
+			}),
+			track("subtask.plan", map[string]any{
+				"type":       "error",
+				"invocation": "inv-track",
+				"error":      "temporary tool timeout",
+			}),
+		},
+	}
+}
+
+func interleavedCase() ReplayCase {
+	return ReplayCase{
+		Name: "09_interleaved_out_of_order_writes",
+		Key:  baseKey("interleaved"),
+		Operations: []Operation{
+			appendFiltered("u1", "user", model.RoleUser, "parallel tasks", "root"),
+			appendFiltered("a-tool-2", "assistant", model.RoleAssistant, "sub agent B ready", "root/toolB"),
+			appendFiltered("a-tool-1", "assistant", model.RoleAssistant, "sub agent A ready", "root/toolA"),
+			track("parallel.toolB", map[string]any{"type": "finish", "invocation": "toolB", "elapsed_ms": 8.4}),
+			track("parallel.toolA", map[string]any{"type": "finish", "invocation": "toolA", "elapsed_ms": 11.1}),
+			appendFiltered("a-final", "assistant", model.RoleAssistant, "merged result", "root"),
+		},
+	}
+}
+
+func retryRecoveryCase() ReplayCase {
+	return ReplayCase{
+		Name: "10_retry_failure_recovery",
+		Key:  baseKey("retry"),
+		Operations: []Operation{
+			setState("phase", raw(`"started"`)),
+			{
+				Kind: OpRetryEvent,
+				Event: &EventSpec{
+					LogicalID:    "retry-user-1",
+					InvocationID: "inv-retry",
+					Author:       "user",
+					Role:         model.RoleUser,
+					Content:      "please retry safely",
+					StateDelta: map[string]json.RawMessage{
+						"phase": raw(`"retried"`),
+					},
+				},
+			},
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "retry-note",
+					Content: "Retry should not duplicate recovered events.",
+					Topics:  []string{"recovery"},
+				},
+			},
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "retry-note",
+					Content: "Retry should not duplicate recovered events.",
+					Topics:  []string{"recovery"},
+				},
+			},
+			writeSummary(session.SummaryFilterKeyAllContents),
+			{
+				Kind:        OpUnsupportedProbe,
+				Unsupported: CapabilityEventPage,
+			},
+		},
+	}
+}
+
+func appendMsg(id, author string, role model.Role, content string) Operation {
+	return Operation{
+		Kind: OpAppendEvent,
+		Event: &EventSpec{
+			LogicalID:    id,
+			InvocationID: "inv-" + id,
+			Author:       author,
+			Role:         role,
+			Content:      content,
+		},
+	}
+}
+
+func appendFiltered(id, author string, role model.Role, content, filterKey string) Operation {
+	op := appendMsg(id, author, role, content)
+	op.Event.FilterKey = filterKey
+	op.Event.Branch = filterKey
+	op.Event.Tag = "replay"
+	return op
+}
+
+func setState(key string, value json.RawMessage) Operation {
+	return Operation{Kind: OpSetState, State: &StateSpec{Key: key, Value: value}}
+}
+
+func deleteState(key string) Operation {
+	return Operation{Kind: OpDeleteState, State: &StateSpec{Key: key}}
+}
+
+func clearState() Operation {
+	return Operation{Kind: OpClearState}
+}
+
+func writeSummary(filterKey string) Operation {
+	return Operation{Kind: OpWriteSummary, Summary: &SummarySpec{FilterKey: filterKey, Force: true}}
+}
+
+func track(name session.Track, payload map[string]any) Operation {
+	return Operation{Kind: OpAppendTrack, Track: &TrackSpec{Name: name, Payload: payload}}
+}
+
+func raw(s string) json.RawMessage {
+	return json.RawMessage(s)
+}

--- a/session/replaytest/compare.go
+++ b/session/replaytest/compare.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 )
 
@@ -81,6 +82,8 @@ func CompareSnapshots(base, compare *Snapshot) []Difference {
 		})
 	}
 	add("$.session_id", "session", base.SessionID, compare.SessionID, "session ownership changed")
+	add("$.app_name", "session", base.AppName, compare.AppName, "session ownership changed")
+	add("$.user_id", "session", base.UserID, compare.UserID, "session ownership changed")
 	compareSlices("$.events", base.Events, compare.Events, func(i int, field string, b, c any) {
 		add(fmt.Sprintf("$.events[%d].%s", i, field), fmt.Sprintf("event[%d]", i), b, c, "event replay mismatch")
 	})
@@ -124,14 +127,19 @@ func compareSlices[T any](path string, base, compare []T, add func(int, string, 
 }
 
 func compareMaps[T any](path string, base, compare map[string]T, add func(string, string, any, any)) {
-	keys := map[string]struct{}{}
+	seen := map[string]struct{}{}
 	for k := range base {
-		keys[k] = struct{}{}
+		seen[k] = struct{}{}
 	}
 	for k := range compare {
-		keys[k] = struct{}{}
+		seen[k] = struct{}{}
 	}
-	for k := range keys {
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
 		b, bok := base[k]
 		c, cok := compare[k]
 		if !bok || !cok {

--- a/session/replaytest/compare.go
+++ b/session/replaytest/compare.go
@@ -1,0 +1,191 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package replaytest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// Run executes all cases against all backends and returns a diff report.
+func Run(ctx context.Context, cases []ReplayCase, backends []Backend) (*Report, error) {
+	report := &Report{
+		GeneratedAt: time.Now().UTC(),
+		Cases:       make([]CaseReport, 0, len(cases)),
+	}
+	if len(backends) == 0 {
+		return report, nil
+	}
+	report.BaseBackend = backends[0].Name()
+	for _, c := range cases {
+		caseReport := CaseReport{
+			Case:      c.Name,
+			SessionID: c.Key.SessionID,
+		}
+		var base *Snapshot
+		for i, backend := range backends {
+			snapshot, err := backend.Apply(ctx, c)
+			if err != nil {
+				return nil, fmt.Errorf("run case %s on backend %s: %w", c.Name, backend.Name(), err)
+			}
+			caseReport.Compared = append(caseReport.Compared, backend.Name())
+			if len(snapshot.Unsupported) > 0 {
+				caseReport.Unsupported = append(caseReport.Unsupported, BackendUnsupported{
+					Backend:     backend.Name(),
+					Unsupported: snapshot.Unsupported,
+				})
+			}
+			if i == 0 {
+				base = snapshot
+				continue
+			}
+			caseReport.Differences = append(
+				caseReport.Differences,
+				CompareSnapshots(base, snapshot)...,
+			)
+		}
+		report.Cases = append(report.Cases, caseReport)
+	}
+	return report, nil
+}
+
+// CompareSnapshots returns all normalized differences between base and compare.
+func CompareSnapshots(base, compare *Snapshot) []Difference {
+	if base == nil || compare == nil {
+		return nil
+	}
+	var diffs []Difference
+	add := func(path, locator string, b, c any, explanation string) {
+		if reflect.DeepEqual(b, c) {
+			return
+		}
+		diffs = append(diffs, Difference{
+			Case:         base.Case,
+			Backend:      compare.Backend,
+			SessionID:    base.SessionID,
+			Locator:      locator,
+			FieldPath:    path,
+			BaseValue:    b,
+			CompareValue: c,
+			AllowedDiff:  false,
+			Explanation:  explanation,
+		})
+	}
+	add("$.session_id", "session", base.SessionID, compare.SessionID, "session ownership changed")
+	compareSlices("$.events", base.Events, compare.Events, func(i int, field string, b, c any) {
+		add(fmt.Sprintf("$.events[%d].%s", i, field), fmt.Sprintf("event[%d]", i), b, c, "event replay mismatch")
+	})
+	compareMaps("$.state", base.State, compare.State, func(key, field string, b, c any) {
+		add(fmt.Sprintf("$.state[%q].%s", key, field), "state:"+key, b, c, "state final value mismatch")
+	})
+	compareSlices("$.memories", base.Memories, compare.Memories, func(i int, field string, b, c any) {
+		locator := fmt.Sprintf("memory[%d]", i)
+		if i >= 0 && i < len(base.Memories) {
+			locator = "memory:" + base.Memories[i].StableID
+		}
+		add(fmt.Sprintf("$.memories[%d].%s", i, field), locator, b, c, "memory replay mismatch")
+	})
+	compareSlices("$.summaries", base.Summaries, compare.Summaries, func(i int, field string, b, c any) {
+		locator := fmt.Sprintf("summary[%d]", i)
+		if i >= 0 && i < len(base.Summaries) {
+			locator = "summary:" + base.Summaries[i].FilterKey
+		}
+		add(fmt.Sprintf("$.summaries[%d].%s", i, field), locator, b, c, "summary replay mismatch")
+	})
+	compareSlices("$.tracks", base.Tracks, compare.Tracks, func(i int, field string, b, c any) {
+		locator := fmt.Sprintf("track[%d]", i)
+		if i >= 0 && i < len(base.Tracks) {
+			locator = "track:" + base.Tracks[i].Name
+		}
+		add(fmt.Sprintf("$.tracks[%d].%s", i, field), locator, b, c, "track replay mismatch")
+	})
+	return diffs
+}
+
+func compareSlices[T any](path string, base, compare []T, add func(int, string, any, any)) {
+	if len(base) != len(compare) {
+		add(-1, "length", len(base), len(compare))
+		return
+	}
+	for i := range base {
+		compareStruct(path, base[i], compare[i], func(field string, b, c any) {
+			add(i, field, b, c)
+		})
+	}
+}
+
+func compareMaps[T any](path string, base, compare map[string]T, add func(string, string, any, any)) {
+	keys := map[string]struct{}{}
+	for k := range base {
+		keys[k] = struct{}{}
+	}
+	for k := range compare {
+		keys[k] = struct{}{}
+	}
+	for k := range keys {
+		b, bok := base[k]
+		c, cok := compare[k]
+		if !bok || !cok {
+			add(k, "presence", bok, cok)
+			continue
+		}
+		compareStruct(path, b, c, func(field string, bv, cv any) {
+			add(k, field, bv, cv)
+		})
+	}
+}
+
+func compareStruct(path string, base, compare any, add func(string, any, any)) {
+	bb, _ := json.Marshal(base)
+	cb, _ := json.Marshal(compare)
+	var bm map[string]any
+	var cm map[string]any
+	if json.Unmarshal(bb, &bm) != nil || json.Unmarshal(cb, &cm) != nil {
+		if !reflect.DeepEqual(base, compare) {
+			add("value", base, compare)
+		}
+		return
+	}
+	keys := map[string]struct{}{}
+	for k := range bm {
+		keys[k] = struct{}{}
+	}
+	for k := range cm {
+		keys[k] = struct{}{}
+	}
+	for k := range keys {
+		if !reflect.DeepEqual(bm[k], cm[k]) {
+			add(k, bm[k], cm[k])
+		}
+	}
+	_ = path
+}
+
+// MarshalReport renders report JSON with stable indentation.
+func MarshalReport(report *Report) ([]byte, error) {
+	return json.MarshalIndent(report, "", "  ")
+}
+
+// HasBlockingDiff reports whether any non-allowed diff exists.
+func HasBlockingDiff(report *Report) bool {
+	if report == nil {
+		return false
+	}
+	for _, c := range report.Cases {
+		for _, d := range c.Differences {
+			if !d.AllowedDiff {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/session/replaytest/compare.go
+++ b/session/replaytest/compare.go
@@ -170,7 +170,12 @@ func compareStruct(path string, base, compare any, add func(string, any, any)) {
 	for k := range cm {
 		keys[k] = struct{}{}
 	}
+	keyList := make([]string, 0, len(keys))
 	for k := range keys {
+		keyList = append(keyList, k)
+	}
+	sort.Strings(keyList)
+	for _, k := range keyList {
 		if !reflect.DeepEqual(bm[k], cm[k]) {
 			add(k, bm[k], cm[k])
 		}

--- a/session/replaytest/normalize.go
+++ b/session/replaytest/normalize.go
@@ -1,0 +1,375 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package replaytest
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func normalizeSession(
+	caseName, backendName string,
+	sess *session.Session,
+	memories []*memory.Entry,
+	unsupported []UnsupportedFeature,
+) *Snapshot {
+	s := &Snapshot{
+		Case:        caseName,
+		Backend:     backendName,
+		Unsupported: unsupported,
+		State:       make(map[string]NormalizedValue),
+		RawEventIDs: make(map[string]int),
+	}
+	if sess == nil {
+		return s
+	}
+	s.SessionID = sess.ID
+	s.AppName = sess.AppName
+	s.UserID = sess.UserID
+	events := sess.GetEvents()
+	for i, evt := range events {
+		if evt.ID != "" {
+			s.RawEventIDs[evt.ID] = i
+		}
+		s.Events = append(s.Events, normalizeEvent(i, evt))
+	}
+	for k, v := range sess.SnapshotState() {
+		s.State[k] = normalizeBytes(v)
+	}
+	s.Memories = normalizeMemories(memories)
+	s.Summaries = normalizeSummaries(sess, s.RawEventIDs)
+	s.Tracks = normalizeTracks(sess)
+	return s
+}
+
+func normalizeEvent(index int, evt event.Event) NormalizedEvent {
+	out := NormalizedEvent{
+		Index:     index,
+		Author:    evt.Author,
+		Branch:    evt.Branch,
+		Tag:       evt.Tag,
+		FilterKey: evt.FilterKey,
+	}
+	if evt.Response != nil && len(evt.Response.Choices) > 0 {
+		msg := evt.Response.Choices[0].Message
+		if msg.Role == "" {
+			msg = evt.Response.Choices[0].Delta
+		}
+		out.Role = msg.Role.String()
+		out.Content = msg.Content
+		out.ToolID = msg.ToolID
+		out.ToolName = msg.ToolName
+		for _, tc := range msg.ToolCalls {
+			out.ToolCalls = append(out.ToolCalls, NormalizedToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: canonicalJSONBytes(tc.Function.Arguments),
+			})
+		}
+	}
+	if len(evt.StateDelta) > 0 {
+		out.StateDelta = make(map[string]NormalizedValue, len(evt.StateDelta))
+		for k, v := range evt.StateDelta {
+			out.StateDelta[k] = normalizeBytes(v)
+		}
+	}
+	if len(evt.Extensions) > 0 {
+		out.Extensions = make(map[string]string, len(evt.Extensions))
+		for k, v := range evt.Extensions {
+			out.Extensions[k] = canonicalJSONBytes(v)
+		}
+	}
+	return out
+}
+
+func normalizeBytes(v []byte) NormalizedValue {
+	if v == nil {
+		return NormalizedValue{Kind: "null"}
+	}
+	return NormalizedValue{Kind: "value", Value: canonicalJSONBytes(v)}
+}
+
+func normalizeMemories(entries []*memory.Entry) []NormalizedMemory {
+	out := make([]NormalizedMemory, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.Memory == nil {
+			continue
+		}
+		metadata := map[string]string{}
+		if entry.Memory.Kind != "" {
+			metadata["kind"] = string(entry.Memory.Kind)
+		}
+		if entry.Memory.EventTime != nil && !entry.Memory.EventTime.IsZero() {
+			metadata["event_time"] = entry.Memory.EventTime.UTC().Format(time.RFC3339Nano)
+		}
+		if len(entry.Memory.Participants) > 0 {
+			participants := append([]string{}, entry.Memory.Participants...)
+			sort.Strings(participants)
+			metadata["participants"] = strings.Join(participants, ",")
+		}
+		if entry.Memory.Location != "" {
+			metadata["location"] = entry.Memory.Location
+		}
+		topics := append([]string{}, entry.Memory.Topics...)
+		sort.Strings(topics)
+		content := entry.Memory.Memory
+		stable := stableID(entry.AppName, entry.UserID, content, strings.Join(topics, ","), metadata["kind"])
+		out = append(out, NormalizedMemory{
+			ID:        stable,
+			StableID:  stable,
+			Content:   content,
+			Topics:    topics,
+			Metadata:  metadata,
+			Scope:     entry.AppName + "/" + entry.UserID,
+			ScoreBand: scoreBand(entry.Score),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].StableID == out[j].StableID {
+			return out[i].Content < out[j].Content
+		}
+		return out[i].StableID < out[j].StableID
+	})
+	return out
+}
+
+func normalizeSummaries(sess *session.Session, eventIDs map[string]int) []NormalizedSummary {
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	out := make([]NormalizedSummary, 0, len(sess.Summaries))
+	for filterKey, sum := range sess.Summaries {
+		if sum == nil {
+			continue
+		}
+		boundary := sum.CutoffBoundary()
+		version := 0
+		cutoffRef := ""
+		if boundary != nil {
+			version = boundary.Version
+			if boundary.LastEventID != "" {
+				if idx, ok := eventIDs[boundary.LastEventID]; ok {
+					cutoffRef = fmt.Sprintf("event[%d]", idx)
+				} else {
+					cutoffRef = "event[missing]"
+				}
+			}
+		}
+		topics := append([]string{}, sum.Topics...)
+		sort.Strings(topics)
+		updated := "unset"
+		if !sum.UpdatedAt.IsZero() {
+			updated = "set"
+		}
+		out = append(out, NormalizedSummary{
+			FilterKey:      filterKey,
+			Text:           sum.Summary,
+			Version:        version,
+			SessionID:      sess.ID,
+			Topics:         topics,
+			UpdatedAt:      updated,
+			CutoffEventRef: cutoffRef,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].FilterKey < out[j].FilterKey
+	})
+	return out
+}
+
+func normalizeTracks(sess *session.Session) []NormalizedTrack {
+	sess.TracksMu.RLock()
+	defer sess.TracksMu.RUnlock()
+	out := make([]NormalizedTrack, 0, len(sess.Tracks))
+	for name, history := range sess.Tracks {
+		if history == nil {
+			continue
+		}
+		track := NormalizedTrack{Name: string(name)}
+		for i, evt := range history.Events {
+			payload := normalizeTrackPayload(evt.Payload)
+			track.Events = append(track.Events, NormalizedTrackEvent{
+				Index:   i,
+				Type:    payloadType(payload),
+				Payload: payload,
+			})
+		}
+		out = append(out, track)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func normalizeTrackPayload(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "{}"
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(bytes.TrimSpace(raw))
+	}
+	v = scrubVolatileNumbers(v, "")
+	return canonicalJSON(v)
+}
+
+func scrubVolatileNumbers(v any, key string) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, child := range x {
+			out[k] = scrubVolatileNumbers(child, k)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, child := range x {
+			out[i] = scrubVolatileNumbers(child, key)
+		}
+		return out
+	case float64:
+		lower := strings.ToLower(key)
+		if strings.Contains(lower, "duration") ||
+			strings.Contains(lower, "elapsed") ||
+			strings.Contains(lower, "latency") {
+			return "<duration>"
+		}
+		return math.Round(x*1000) / 1000
+	default:
+		return v
+	}
+}
+
+func payloadType(payload string) string {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(payload), &m); err != nil {
+		return ""
+	}
+	if typ, ok := m["type"].(string); ok {
+		return typ
+	}
+	if typ, ok := m["event_type"].(string); ok {
+		return typ
+	}
+	return ""
+}
+
+func eventFromSpec(spec EventSpec) (*event.Event, error) {
+	msg := model.Message{
+		Role:     spec.Role,
+		Content:  spec.Content,
+		ToolID:   spec.ToolID,
+		ToolName: spec.ToolName,
+	}
+	for _, tc := range spec.ToolCalls {
+		args, err := json.Marshal(tc.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("marshal tool args: %w", err)
+		}
+		msg.ToolCalls = append(msg.ToolCalls, model.ToolCall{
+			Type: "function",
+			ID:   tc.ID,
+			Function: model.FunctionDefinitionParam{
+				Name:      tc.Name,
+				Arguments: args,
+			},
+		})
+	}
+	object := spec.Object
+	if object == "" {
+		object = model.ObjectTypeChatCompletion
+	}
+	rsp := &model.Response{
+		ID:      "rsp-" + spec.LogicalID,
+		Object:  object,
+		Created: 1700000000,
+		Model:   "replay-deterministic",
+		Done:    spec.Done,
+		Choices: []model.Choice{{Index: 0, Message: msg}},
+	}
+	stateDelta := make(map[string][]byte, len(spec.StateDelta))
+	for k, v := range spec.StateDelta {
+		stateDelta[k] = append([]byte(nil), v...)
+	}
+	evt := event.NewResponseEvent(spec.InvocationID, spec.Author, rsp)
+	evt.ID = "event-" + spec.LogicalID
+	evt.Timestamp = deterministicEventTime(spec.LogicalID)
+	evt.Branch = spec.Branch
+	evt.Tag = spec.Tag
+	evt.FilterKey = spec.FilterKey
+	evt.StateDelta = stateDelta
+	for k, v := range spec.Extensions {
+		if err := event.SetExtension(evt, k, v); err != nil {
+			return nil, fmt.Errorf("set extension %s: %w", k, err)
+		}
+	}
+	return evt, nil
+}
+
+func deterministicEventTime(logicalID string) time.Time {
+	sum := sha256.Sum256([]byte(logicalID))
+	seconds := int64(sum[0])<<8 + int64(sum[1])
+	return time.Unix(1700000000+seconds, 0).UTC()
+}
+
+func canonicalJSONBytes(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(bytes.TrimSpace(raw))
+	}
+	return canonicalJSON(v)
+}
+
+func canonicalJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+func stableID(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		h.Write([]byte(p))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+func scoreBand(score float64) string {
+	if score == 0 {
+		return ""
+	}
+	switch {
+	case score >= 0.95:
+		return "0.95-1.00"
+	case score >= 0.80:
+		return "0.80-0.95"
+	case score >= 0.50:
+		return "0.50-0.80"
+	default:
+		return "0.00-0.50"
+	}
+}

--- a/session/replaytest/replaytest_test.go
+++ b/session/replaytest/replaytest_test.go
@@ -1,0 +1,202 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package replaytest
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPublicCasesLightweightBackendsNoDiff(t *testing.T) {
+	ctx := context.Background()
+	report, err := Run(ctx, PublicCases(), []Backend{
+		NewInMemoryBackend(),
+		NewJSONFileBackend(t.TempDir()),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(report.Cases) != 10 {
+		t.Fatalf("case count = %d, want 10", len(report.Cases))
+	}
+	for _, c := range report.Cases {
+		if len(c.Differences) != 0 {
+			data, _ := MarshalReport(report)
+			t.Fatalf("unexpected diffs for %s:\n%s", c.Case, data)
+		}
+	}
+}
+
+func TestPublicCasesDetectInjectedMismatch(t *testing.T) {
+	ctx := context.Background()
+	for _, c := range PublicCases() {
+		t.Run(c.Name, func(t *testing.T) {
+			base, err := NewInMemoryBackend().Apply(ctx, c)
+			if err != nil {
+				t.Fatalf("Apply() error = %v", err)
+			}
+			mutated := cloneSnapshot(base)
+			injectMismatch(t, mutated)
+			diffs := CompareSnapshots(base, mutated)
+			if len(diffs) == 0 {
+				t.Fatalf("injected mismatch for %s was not detected", c.Name)
+			}
+		})
+	}
+}
+
+func TestSummaryMismatchClassesAreDetected(t *testing.T) {
+	ctx := context.Background()
+	c := summaryCase()
+	base, err := NewInMemoryBackend().Apply(ctx, c)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if len(base.Summaries) == 0 {
+		t.Fatalf("summary case produced no summaries")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Snapshot)
+		want   string
+	}{
+		{
+			name: "missing",
+			mutate: func(s *Snapshot) {
+				s.Summaries = nil
+			},
+			want: "$.summaries[-1].length",
+		},
+		{
+			name: "overwritten_text",
+			mutate: func(s *Snapshot) {
+				s.Summaries[0].Text = "wrong summary"
+			},
+			want: "text",
+		},
+		{
+			name: "wrong_session_owner",
+			mutate: func(s *Snapshot) {
+				s.Summaries[0].SessionID = "other-session"
+			},
+			want: "session_id",
+		},
+		{
+			name: "wrong_filter_key",
+			mutate: func(s *Snapshot) {
+				s.Summaries[0].FilterKey = "support/sales"
+			},
+			want: "filter_key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutated := cloneSnapshot(base)
+			tt.mutate(mutated)
+			diffs := CompareSnapshots(base, mutated)
+			if len(diffs) == 0 {
+				t.Fatalf("summary mismatch %s was not detected", tt.name)
+			}
+			if !containsField(diffs, tt.want) {
+				t.Fatalf("diffs do not include %q: %+v", tt.want, diffs)
+			}
+		})
+	}
+}
+
+func TestNormalizerCanonicalizesJSONAndDurations(t *testing.T) {
+	a := canonicalJSONBytes([]byte(`{"b":2,"a":1}`))
+	b := canonicalJSONBytes([]byte(`{"a":1,"b":2}`))
+	if a != b {
+		t.Fatalf("canonical json mismatch: %s != %s", a, b)
+	}
+	p1 := normalizeTrackPayload([]byte(`{"type":"finish","duration_ms":1.2345,"nested":{"elapsed_ms":9.9}}`))
+	p2 := normalizeTrackPayload([]byte(`{"nested":{"elapsed_ms":3.1},"duration_ms":8.765,"type":"finish"}`))
+	if p1 != p2 {
+		t.Fatalf("duration payload mismatch:\n%s\n%s", p1, p2)
+	}
+}
+
+func TestMarshalReportIncludesDiffLocation(t *testing.T) {
+	report := &Report{
+		BaseBackend: "base",
+		Cases: []CaseReport{{
+			Case:      "case",
+			SessionID: "sess",
+			Compared:  []string{"base", "other"},
+			Differences: []Difference{{
+				Case:         "case",
+				Backend:      "other",
+				SessionID:    "sess",
+				Locator:      "summary:support/billing",
+				FieldPath:    "$.summaries[0].text",
+				BaseValue:    "ok",
+				CompareValue: "bad",
+				Explanation:  "summary replay mismatch",
+			}},
+		}},
+	}
+	data, err := MarshalReport(report)
+	if err != nil {
+		t.Fatalf("MarshalReport() error = %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{"summary:support/billing", "$.summaries[0].text", "allowed_diff"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("report missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func cloneSnapshot(s *Snapshot) *Snapshot {
+	data, _ := json.Marshal(s)
+	var out Snapshot
+	_ = json.Unmarshal(data, &out)
+	return &out
+}
+
+func injectMismatch(t *testing.T, s *Snapshot) {
+	t.Helper()
+	switch s.Case {
+	case "01_single_turn_dialogue":
+		s.Events[1].Content = "wrong assistant text"
+	case "02_multi_turn_ordering":
+		s.Events[1], s.Events[2] = s.Events[2], s.Events[1]
+	case "03_tool_call_and_response":
+		s.Events[1].ToolCalls[0].Arguments = `{"city":"Guangzhou","unit":"celsius"}`
+	case "04_state_set_overwrite_delete_clear":
+		s.State["locale"] = NormalizedValue{Kind: "value", Value: `"zh-CN"`}
+	case "05_memory_write_read":
+		s.Memories[0].Content = "wrong memory"
+	case "06_summary_filter_key_update":
+		s.Summaries[0].FilterKey = "wrong/filter"
+	case "07_summary_with_event_truncation":
+		s.Summaries = nil
+	case "08_track_events":
+		s.Tracks[0].Events[0].Payload = `{"type":"start","invocation":"wrong"}`
+	case "09_interleaved_out_of_order_writes":
+		s.Events[1], s.Events[2] = s.Events[2], s.Events[1]
+	case "10_retry_failure_recovery":
+		s.Events = append(s.Events, s.Events[0])
+	default:
+		t.Fatalf("no mismatch injector for %s", s.Case)
+	}
+}
+
+func containsField(diffs []Difference, field string) bool {
+	for _, diff := range diffs {
+		if strings.Contains(diff.FieldPath, field) {
+			return true
+		}
+	}
+	return false
+}

--- a/session/replaytest/replaytest_test.go
+++ b/session/replaytest/replaytest_test.go
@@ -210,6 +210,34 @@ func TestCompareSnapshotsStateDiffsAreSorted(t *testing.T) {
 	}
 }
 
+func TestCompareSnapshotsStructDiffsAreSorted(t *testing.T) {
+	base := &Snapshot{
+		Case:      "case",
+		Backend:   "base",
+		SessionID: "sess",
+		Events: []NormalizedEvent{{
+			Author:  "assistant",
+			Content: "base content",
+			Role:    string(model.RoleAssistant),
+		}},
+	}
+	compare := cloneSnapshot(base)
+	compare.Backend = "other"
+	compare.Events[0].Author = "user"
+	compare.Events[0].Content = "compare content"
+
+	diffs := CompareSnapshots(base, compare)
+	if len(diffs) != 2 {
+		t.Fatalf("diff count = %d, want 2: %+v", len(diffs), diffs)
+	}
+	if diffs[0].FieldPath != "$.events[0].author" {
+		t.Fatalf("first event diff = %s, want author before content", diffs[0].FieldPath)
+	}
+	if diffs[1].FieldPath != "$.events[0].content" {
+		t.Fatalf("second event diff = %s, want content after author", diffs[1].FieldPath)
+	}
+}
+
 func TestBackendsReplayMemoryLifecycleAndNilOperations(t *testing.T) {
 	c := ReplayCase{
 		Name: "memory_lifecycle",

--- a/session/replaytest/replaytest_test.go
+++ b/session/replaytest/replaytest_test.go
@@ -157,6 +157,55 @@ func TestMarshalReportIncludesDiffLocation(t *testing.T) {
 	}
 }
 
+func TestCompareSnapshotsDetectsSessionOwnerMismatch(t *testing.T) {
+	base := &Snapshot{
+		Case:      "case",
+		Backend:   "base",
+		SessionID: "sess",
+		AppName:   "app-a",
+		UserID:    "user-a",
+	}
+	compare := cloneSnapshot(base)
+	compare.Backend = "other"
+	compare.AppName = "app-b"
+	compare.UserID = "user-b"
+
+	diffs := CompareSnapshots(base, compare)
+	if !containsField(diffs, "$.app_name") {
+		t.Fatalf("app_name mismatch was not detected: %+v", diffs)
+	}
+	if !containsField(diffs, "$.user_id") {
+		t.Fatalf("user_id mismatch was not detected: %+v", diffs)
+	}
+}
+
+func TestCompareSnapshotsStateDiffsAreSorted(t *testing.T) {
+	base := &Snapshot{
+		Case:      "case",
+		Backend:   "base",
+		SessionID: "sess",
+		State: map[string]NormalizedValue{
+			"b": {Kind: "value", Value: "1"},
+			"a": {Kind: "value", Value: "1"},
+		},
+	}
+	compare := cloneSnapshot(base)
+	compare.Backend = "other"
+	compare.State["b"] = NormalizedValue{Kind: "value", Value: "2"}
+	compare.State["a"] = NormalizedValue{Kind: "value", Value: "2"}
+
+	diffs := CompareSnapshots(base, compare)
+	if len(diffs) != 2 {
+		t.Fatalf("diff count = %d, want 2: %+v", len(diffs), diffs)
+	}
+	if diffs[0].FieldPath != "$.state[\"a\"].value" {
+		t.Fatalf("first state diff = %s, want a before b", diffs[0].FieldPath)
+	}
+	if diffs[1].FieldPath != "$.state[\"b\"].value" {
+		t.Fatalf("second state diff = %s, want b after a", diffs[1].FieldPath)
+	}
+}
+
 func cloneSnapshot(s *Snapshot) *Snapshot {
 	data, _ := json.Marshal(s)
 	var out Snapshot

--- a/session/replaytest/replaytest_test.go
+++ b/session/replaytest/replaytest_test.go
@@ -11,8 +11,12 @@ package replaytest
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 func TestPublicCasesLightweightBackendsNoDiff(t *testing.T) {
@@ -203,6 +207,192 @@ func TestCompareSnapshotsStateDiffsAreSorted(t *testing.T) {
 	}
 	if diffs[1].FieldPath != "$.state[\"b\"].value" {
 		t.Fatalf("second state diff = %s, want b after a", diffs[1].FieldPath)
+	}
+}
+
+func TestBackendsReplayMemoryLifecycleAndNilOperations(t *testing.T) {
+	c := ReplayCase{
+		Name: "memory_lifecycle",
+		Key:  baseKey("memory-lifecycle"),
+		Operations: []Operation{
+			{Kind: OpSetState},
+			{Kind: OpDeleteState},
+			{Kind: OpAddMemory},
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "pref",
+					Content: "User likes deterministic tests.",
+					Topics:  []string{"tests"},
+				},
+			},
+			{
+				Kind: OpUpdateMemory,
+				Memory: &MemorySpec{
+					ID:      "pref",
+					Content: "User likes deterministic replay tests.",
+					Topics:  []string{"tests", "replay"},
+				},
+			},
+			{Kind: OpDeleteMemory, Memory: &MemorySpec{ID: "pref"}},
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "task",
+					Content: "Keep replay harness lightweight.",
+					Topics:  []string{"task"},
+				},
+			},
+			{Kind: OpClearMemory},
+			{
+				Kind: OpAddMemory,
+				Memory: &MemorySpec{
+					ID:      "final",
+					Content: "Final memory survives lifecycle case.",
+					Topics:  []string{"final"},
+				},
+			},
+			{Kind: OpWriteSummary},
+			{Kind: OpAppendTrack},
+			{Kind: OpUnsupportedProbe, Unsupported: CapabilityTTL},
+		},
+	}
+	report, err := Run(context.Background(), []ReplayCase{c}, []Backend{
+		NewInMemoryBackend(),
+		NewJSONFileBackend(t.TempDir()),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if HasBlockingDiff(report) {
+		data, _ := MarshalReport(report)
+		t.Fatalf("unexpected blocking diffs:\n%s", data)
+	}
+	if len(report.Cases) != 1 || len(report.Cases[0].Unsupported) == 0 {
+		t.Fatalf("unsupported capability was not reported: %+v", report.Cases)
+	}
+}
+
+func TestJSONFileBackendPersistsWithPrivatePermissions(t *testing.T) {
+	dir := t.TempDir()
+	c := singleTurnCase()
+	_, err := NewJSONFileBackend(dir).Apply(context.Background(), c)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	info, err := os.Stat(dir + "/" + safeFileName(c.Name) + ".json")
+	if err != nil {
+		t.Fatalf("stat store file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("store file mode = %o, want 600", got)
+	}
+}
+
+func TestReplayHelpersCoverEdgeBranches(t *testing.T) {
+	memBackend := NewInMemoryBackend()
+	fileBackend := NewJSONFileBackend("")
+	if err := memBackend.Close(); err != nil {
+		t.Fatalf("inmemory Close() error = %v", err)
+	}
+	if err := fileBackend.Close(); err != nil {
+		t.Fatalf("jsonfile Close() error = %v", err)
+	}
+	if !memBackend.Supports(CapabilityTTL) || memBackend.Supports(CapabilityEventPage) {
+		t.Fatalf("unexpected in-memory capabilities")
+	}
+	if !strings.Contains(memBackend.Unsupported(CapabilityEventPage), "strict offset") {
+		t.Fatalf("unexpected in-memory unsupported explanation")
+	}
+	if fileBackend.Supports(CapabilityTTL) || !strings.Contains(fileBackend.Unsupported(CapabilityTTL), "does not expire") {
+		t.Fatalf("unexpected jsonfile TTL support")
+	}
+	if fileBackend.Unsupported(CapabilityTrack) != "" {
+		t.Fatalf("supported jsonfile track capability should have empty unsupported explanation")
+	}
+
+	if HasBlockingDiff(nil) {
+		t.Fatalf("nil report should not have blocking diffs")
+	}
+	if HasBlockingDiff(&Report{Cases: []CaseReport{{Differences: []Difference{{AllowedDiff: true}}}}}) {
+		t.Fatalf("allowed diff should not block")
+	}
+	if !HasBlockingDiff(&Report{Cases: []CaseReport{{Differences: []Difference{{AllowedDiff: false}}}}}) {
+		t.Fatalf("non-allowed diff should block")
+	}
+
+	summarizer := deterministicSummarizer{}
+	if !summarizer.ShouldSummarize(nil) {
+		t.Fatalf("deterministic summarizer should always summarize")
+	}
+	summarizer.SetPrompt("ignored")
+	summarizer.SetModel(nil)
+	if summarizer.Metadata()["name"] != "replay-deterministic" {
+		t.Fatalf("unexpected summarizer metadata")
+	}
+	if summaryFilterKeyFromSessionID("sess") != session.SummaryFilterKeyAllContents {
+		t.Fatalf("session without suffix should use full-session summary key")
+	}
+	if summaryFilterKeyFromSessionID("sess:branch") != "branch" {
+		t.Fatalf("summary filter key suffix not parsed")
+	}
+
+	if normalizeBytes(nil).Kind != "null" {
+		t.Fatalf("nil bytes should normalize as null")
+	}
+	if canonicalJSONBytes([]byte(`not-json`)) != "not-json" {
+		t.Fatalf("invalid json should trim to raw text")
+	}
+	if canonicalJSON(func() {}) == "" {
+		t.Fatalf("unmarshalable value should fall back to fmt string")
+	}
+	if normalizeTrackPayload([]byte(`{bad`)) != "{bad" {
+		t.Fatalf("invalid track payload should remain trimmed raw text")
+	}
+	if payloadType(`{"event_type":"finish"}`) != "finish" {
+		t.Fatalf("event_type fallback not detected")
+	}
+	if payloadType(`not-json`) != "" {
+		t.Fatalf("invalid payload should not have type")
+	}
+	for _, score := range []float64{0, 0.2, 0.6, 0.82, 0.97} {
+		if score == 0 && scoreBand(score) != "" {
+			t.Fatalf("zero score should not have a band")
+		}
+		if score > 0 && scoreBand(score) == "" {
+			t.Fatalf("score %v should have a band", score)
+		}
+	}
+}
+
+func TestFileSummaryAndBoundaryHelpers(t *testing.T) {
+	sess := session.NewSession("app", "user", "sess")
+	writeFileSummary(sess, "", false)
+	if len(sess.Summaries) != 0 {
+		t.Fatalf("non-forced empty summary should not be written")
+	}
+	evt, err := eventFromSpec(EventSpec{
+		LogicalID:    "boundary-1",
+		InvocationID: "inv-boundary",
+		Author:       "user",
+		Role:         model.RoleUser,
+		Content:      "hello",
+		FilterKey:    "branch",
+	})
+	if err != nil {
+		t.Fatalf("eventFromSpec() error = %v", err)
+	}
+	sess.UpdateUserSession(evt)
+	writeFileSummary(sess, "branch", true)
+	if len(sess.Summaries) != 1 {
+		t.Fatalf("forced summary was not written")
+	}
+	covered := eventsAfterBoundary(sess.GetEvents(), sess.Summaries["branch"].Boundary, "branch")
+	if len(covered) != 0 {
+		t.Fatalf("boundary should exclude already summarized events")
+	}
+	if latestBoundary("branch", nil) != nil {
+		t.Fatalf("empty latest boundary should be nil")
 	}
 }
 

--- a/session/replaytest/summarizer.go
+++ b/session/replaytest/summarizer.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package replaytest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+type deterministicSummarizer struct{}
+
+func (deterministicSummarizer) ShouldSummarize(*session.Session) bool { return true }
+
+func (deterministicSummarizer) Summarize(ctx context.Context, sess *session.Session) (string, error) {
+	if sess == nil {
+		return "", nil
+	}
+	filterKey := summaryFilterKeyFromSessionID(sess.ID)
+	parts := []string{fmt.Sprintf("filter=%s", filterKey)}
+	for _, evt := range sess.GetEvents() {
+		role := ""
+		content := ""
+		if evt.Response != nil && len(evt.Response.Choices) > 0 {
+			msg := evt.Response.Choices[0].Message
+			role = msg.Role.String()
+			content = msg.Content
+			if len(msg.ToolCalls) > 0 {
+				names := make([]string, 0, len(msg.ToolCalls))
+				for _, tc := range msg.ToolCalls {
+					names = append(names, tc.Function.Name)
+				}
+				content = "tool_calls:" + strings.Join(names, ",")
+			}
+			if msg.ToolID != "" {
+				content = "tool_result:" + msg.ToolName + ":" + msg.ToolID + ":" + msg.Content
+			}
+		}
+		if role == "" {
+			role = evt.Author
+		}
+		parts = append(parts, role+"="+content)
+	}
+	return strings.Join(parts, " | "), nil
+}
+
+func (deterministicSummarizer) SetPrompt(string) {}
+
+func (deterministicSummarizer) SetModel(model.Model) {}
+
+func (deterministicSummarizer) Metadata() map[string]any {
+	return map[string]any{"name": "replay-deterministic"}
+}
+
+func summaryFilterKeyFromSessionID(id string) string {
+	idx := strings.LastIndex(id, ":")
+	if idx < 0 {
+		return session.SummaryFilterKeyAllContents
+	}
+	return id[idx+1:]
+}

--- a/session/replaytest/testdata/session_memory_summary_track_diff_report.json
+++ b/session/replaytest/testdata/session_memory_summary_track_diff_report.json
@@ -1,0 +1,112 @@
+{
+  "generated_at": "2026-07-07T00:00:00Z",
+  "base_backend": "session/inmemory+memory/inmemory",
+  "cases": [
+    {
+      "case": "06_summary_filter_key_update",
+      "session_id": "sess-summary",
+      "compared_backends": [
+        "session/inmemory+memory/inmemory",
+        "session/jsonfile+memory/jsonfile-mutated"
+      ],
+      "differences": [
+        {
+          "case": "06_summary_filter_key_update",
+          "backend": "session/jsonfile+memory/jsonfile-mutated",
+          "session_id": "sess-summary",
+          "locator": "summary:support/billing",
+          "field_path": "$.summaries[0].filter_key",
+          "base_value": "support/billing",
+          "compare_value": "support/sales",
+          "allowed_diff": false,
+          "explanation": "summary replay mismatch: filter-key changed"
+        },
+        {
+          "case": "06_summary_filter_key_update",
+          "backend": "session/jsonfile+memory/jsonfile-mutated",
+          "session_id": "sess-summary",
+          "locator": "summary:support/billing",
+          "field_path": "$.summaries[0].session_id",
+          "base_value": "sess-summary",
+          "compare_value": "sess-other",
+          "allowed_diff": false,
+          "explanation": "summary replay mismatch: summary belongs to a different session"
+        }
+      ]
+    },
+    {
+      "case": "08_track_events",
+      "session_id": "sess-track",
+      "compared_backends": [
+        "session/inmemory+memory/inmemory",
+        "session/jsonfile+memory/jsonfile-mutated"
+      ],
+      "differences": [
+        {
+          "case": "08_track_events",
+          "backend": "session/jsonfile+memory/jsonfile-mutated",
+          "session_id": "sess-track",
+          "locator": "track:tool.lookup",
+          "field_path": "$.tracks[0].events",
+          "base_value": [
+            {
+              "index": 0,
+              "type": "start",
+              "payload": "{\"duration_ms\":\"<duration>\",\"invocation\":\"inv-track\",\"type\":\"start\"}"
+            },
+            {
+              "index": 1,
+              "type": "finish",
+              "payload": "{\"duration_ms\":\"<duration>\",\"invocation\":\"inv-track\",\"status\":\"ok\",\"type\":\"finish\"}"
+            }
+          ],
+          "compare_value": [
+            {
+              "index": 0,
+              "type": "start",
+              "payload": "{\"duration_ms\":\"<duration>\",\"invocation\":\"wrong-invocation\",\"type\":\"start\"}"
+            }
+          ],
+          "allowed_diff": false,
+          "explanation": "track replay mismatch: invocation or sequence changed"
+        }
+      ]
+    },
+    {
+      "case": "10_retry_failure_recovery",
+      "session_id": "sess-retry",
+      "compared_backends": [
+        "session/inmemory+memory/inmemory",
+        "session/jsonfile+memory/jsonfile"
+      ],
+      "differences": [],
+      "unsupported": [
+        {
+          "backend": "session/inmemory+memory/inmemory",
+          "unsupported": [
+            {
+              "capability": "event_page",
+              "allowed_diff": true,
+              "explanation": "inmemory GetSession does not support strict offset event pages"
+            }
+          ]
+        },
+        {
+          "backend": "session/jsonfile+memory/jsonfile",
+          "unsupported": [
+            {
+              "capability": "event_page",
+              "allowed_diff": true,
+              "explanation": "jsonfile replay backend stores full event logs and does not implement strict page reads"
+            },
+            {
+              "capability": "ttl",
+              "allowed_diff": true,
+              "explanation": "jsonfile replay backend does not expire records during lightweight consistency tests"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/session/replaytest/types.go
+++ b/session/replaytest/types.go
@@ -25,9 +25,13 @@ import (
 type Capability string
 
 const (
-	CapabilityEventPage    Capability = "event_page"
-	CapabilityTTL          Capability = "ttl"
-	CapabilityTrack        Capability = "track"
+	// CapabilityEventPage marks strict event page reads.
+	CapabilityEventPage Capability = "event_page"
+	// CapabilityTTL marks time-to-live expiry.
+	CapabilityTTL Capability = "ttl"
+	// CapabilityTrack marks persisted track events.
+	CapabilityTrack Capability = "track"
+	// CapabilityMemorySearch marks memory search support.
 	CapabilityMemorySearch Capability = "memory_search"
 )
 
@@ -52,17 +56,29 @@ type ReplayCase struct {
 type OperationKind string
 
 const (
-	OpAppendEvent      OperationKind = "append_event"
-	OpSetState         OperationKind = "set_state"
-	OpDeleteState      OperationKind = "delete_state"
-	OpClearState       OperationKind = "clear_state"
-	OpAddMemory        OperationKind = "add_memory"
-	OpUpdateMemory     OperationKind = "update_memory"
-	OpDeleteMemory     OperationKind = "delete_memory"
-	OpClearMemory      OperationKind = "clear_memory"
-	OpWriteSummary     OperationKind = "write_summary"
-	OpAppendTrack      OperationKind = "append_track"
-	OpRetryEvent       OperationKind = "retry_event"
+	// OpAppendEvent appends one session event.
+	OpAppendEvent OperationKind = "append_event"
+	// OpSetState sets or overwrites one session state key.
+	OpSetState OperationKind = "set_state"
+	// OpDeleteState deletes one session state key.
+	OpDeleteState OperationKind = "delete_state"
+	// OpClearState clears all session state keys.
+	OpClearState OperationKind = "clear_state"
+	// OpAddMemory adds one memory entry.
+	OpAddMemory OperationKind = "add_memory"
+	// OpUpdateMemory updates one logical memory entry.
+	OpUpdateMemory OperationKind = "update_memory"
+	// OpDeleteMemory deletes one logical memory entry.
+	OpDeleteMemory OperationKind = "delete_memory"
+	// OpClearMemory clears all memories for the replay user.
+	OpClearMemory OperationKind = "clear_memory"
+	// OpWriteSummary writes or updates one summary.
+	OpWriteSummary OperationKind = "write_summary"
+	// OpAppendTrack appends one track event.
+	OpAppendTrack OperationKind = "append_track"
+	// OpRetryEvent appends the same event through retry semantics.
+	OpRetryEvent OperationKind = "retry_event"
+	// OpUnsupportedProbe records unsupported backend capability metadata.
 	OpUnsupportedProbe OperationKind = "unsupported_probe"
 )
 

--- a/session/replaytest/types.go
+++ b/session/replaytest/types.go
@@ -1,0 +1,255 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package replaytest provides a reusable replay consistency harness for
+// session, memory, summary, and track backends.
+package replaytest
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// Capability names backend features that may be unsupported by a concrete
+// implementation.
+type Capability string
+
+const (
+	CapabilityEventPage    Capability = "event_page"
+	CapabilityTTL          Capability = "ttl"
+	CapabilityTrack        Capability = "track"
+	CapabilityMemorySearch Capability = "memory_search"
+)
+
+// Backend persists replay operations and returns a normalized snapshot.
+type Backend interface {
+	Name() string
+	Supports(Capability) bool
+	Unsupported(Capability) string
+	Apply(context.Context, ReplayCase) (*Snapshot, error)
+	Close() error
+}
+
+// ReplayCase is one deterministic input trajectory.
+type ReplayCase struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Key         session.Key `json:"key"`
+	Operations  []Operation `json:"operations"`
+}
+
+// OperationKind identifies a replay operation.
+type OperationKind string
+
+const (
+	OpAppendEvent      OperationKind = "append_event"
+	OpSetState         OperationKind = "set_state"
+	OpDeleteState      OperationKind = "delete_state"
+	OpClearState       OperationKind = "clear_state"
+	OpAddMemory        OperationKind = "add_memory"
+	OpUpdateMemory     OperationKind = "update_memory"
+	OpDeleteMemory     OperationKind = "delete_memory"
+	OpClearMemory      OperationKind = "clear_memory"
+	OpWriteSummary     OperationKind = "write_summary"
+	OpAppendTrack      OperationKind = "append_track"
+	OpRetryEvent       OperationKind = "retry_event"
+	OpUnsupportedProbe OperationKind = "unsupported_probe"
+)
+
+// Operation is a single replay input step. Only the field matching Kind is used.
+type Operation struct {
+	Kind        OperationKind `json:"kind"`
+	Event       *EventSpec    `json:"event,omitempty"`
+	State       *StateSpec    `json:"state,omitempty"`
+	Memory      *MemorySpec   `json:"memory,omitempty"`
+	Summary     *SummarySpec  `json:"summary,omitempty"`
+	Track       *TrackSpec    `json:"track,omitempty"`
+	Unsupported Capability    `json:"unsupported,omitempty"`
+	Note        string        `json:"note,omitempty"`
+}
+
+// EventSpec describes one session event.
+type EventSpec struct {
+	LogicalID    string                     `json:"logical_id"`
+	InvocationID string                     `json:"invocation_id"`
+	Author       string                     `json:"author"`
+	Role         model.Role                 `json:"role"`
+	Content      string                     `json:"content,omitempty"`
+	ToolCalls    []ToolCallSpec             `json:"tool_calls,omitempty"`
+	ToolID       string                     `json:"tool_id,omitempty"`
+	ToolName     string                     `json:"tool_name,omitempty"`
+	Branch       string                     `json:"branch,omitempty"`
+	Tag          string                     `json:"tag,omitempty"`
+	FilterKey    string                     `json:"filter_key,omitempty"`
+	StateDelta   map[string]json.RawMessage `json:"state_delta,omitempty"`
+	Extensions   map[string]any             `json:"extensions,omitempty"`
+	Object       string                     `json:"object,omitempty"`
+	Done         bool                       `json:"done,omitempty"`
+}
+
+// ToolCallSpec describes a function call inside an assistant event.
+type ToolCallSpec struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+// StateSpec describes state mutation.
+type StateSpec struct {
+	Key   string          `json:"key,omitempty"`
+	Value json.RawMessage `json:"value,omitempty"`
+}
+
+// MemorySpec describes memory mutation.
+type MemorySpec struct {
+	ID       string           `json:"id,omitempty"`
+	Content  string           `json:"content,omitempty"`
+	Topics   []string         `json:"topics,omitempty"`
+	Metadata *memory.Metadata `json:"metadata,omitempty"`
+	Query    string           `json:"query,omitempty"`
+}
+
+// SummarySpec requests deterministic summary generation for a filter key.
+type SummarySpec struct {
+	FilterKey string `json:"filter_key"`
+	Force     bool   `json:"force"`
+}
+
+// TrackSpec describes one observability track event.
+type TrackSpec struct {
+	Name      session.Track  `json:"name"`
+	Payload   map[string]any `json:"payload"`
+	Timestamp time.Time      `json:"timestamp,omitempty"`
+}
+
+// Snapshot is the normalized state read back from one backend after a case.
+type Snapshot struct {
+	Case        string                     `json:"case"`
+	Backend     string                     `json:"backend"`
+	SessionID   string                     `json:"session_id"`
+	AppName     string                     `json:"app_name"`
+	UserID      string                     `json:"user_id"`
+	Events      []NormalizedEvent          `json:"events"`
+	State       map[string]NormalizedValue `json:"state"`
+	Memories    []NormalizedMemory         `json:"memories"`
+	Summaries   []NormalizedSummary        `json:"summaries"`
+	Tracks      []NormalizedTrack          `json:"tracks"`
+	Unsupported []UnsupportedFeature       `json:"unsupported,omitempty"`
+	RawEventIDs map[string]int             `json:"-"`
+}
+
+// UnsupportedFeature records an unsupported backend capability.
+type UnsupportedFeature struct {
+	Capability  Capability `json:"capability"`
+	AllowedDiff bool       `json:"allowed_diff"`
+	Explanation string     `json:"explanation"`
+}
+
+// NormalizedValue preserves absent/null/value distinctions.
+type NormalizedValue struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value,omitempty"`
+}
+
+// NormalizedEvent is a stable event representation.
+type NormalizedEvent struct {
+	Index      int                        `json:"index"`
+	Author     string                     `json:"author"`
+	Role       string                     `json:"role"`
+	Content    string                     `json:"content,omitempty"`
+	ToolCalls  []NormalizedToolCall       `json:"tool_calls,omitempty"`
+	ToolID     string                     `json:"tool_id,omitempty"`
+	ToolName   string                     `json:"tool_name,omitempty"`
+	Branch     string                     `json:"branch,omitempty"`
+	Tag        string                     `json:"tag,omitempty"`
+	FilterKey  string                     `json:"filter_key,omitempty"`
+	StateDelta map[string]NormalizedValue `json:"state_delta,omitempty"`
+	Extensions map[string]string          `json:"extensions,omitempty"`
+}
+
+// NormalizedToolCall is a stable tool call representation.
+type NormalizedToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+// NormalizedMemory is a stable memory representation.
+type NormalizedMemory struct {
+	ID        string            `json:"id"`
+	StableID  string            `json:"stable_id"`
+	Content   string            `json:"content"`
+	Topics    []string          `json:"topics,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Scope     string            `json:"scope"`
+	ScoreBand string            `json:"score_band,omitempty"`
+}
+
+// NormalizedSummary is a stable summary representation.
+type NormalizedSummary struct {
+	FilterKey      string   `json:"filter_key"`
+	Text           string   `json:"text"`
+	Version        int      `json:"version"`
+	SessionID      string   `json:"session_id"`
+	Topics         []string `json:"topics,omitempty"`
+	UpdatedAt      string   `json:"updated_at"`
+	CutoffEventRef string   `json:"cutoff_event_ref,omitempty"`
+}
+
+// NormalizedTrack is a stable track representation.
+type NormalizedTrack struct {
+	Name   string                 `json:"name"`
+	Events []NormalizedTrackEvent `json:"events"`
+}
+
+// NormalizedTrackEvent is a stable track event representation.
+type NormalizedTrackEvent struct {
+	Index   int    `json:"index"`
+	Type    string `json:"type,omitempty"`
+	Payload string `json:"payload"`
+}
+
+// Report is emitted as JSON for human and CI consumption.
+type Report struct {
+	GeneratedAt time.Time    `json:"generated_at"`
+	BaseBackend string       `json:"base_backend"`
+	Cases       []CaseReport `json:"cases"`
+}
+
+// CaseReport contains all backend results for one case.
+type CaseReport struct {
+	Case        string               `json:"case"`
+	SessionID   string               `json:"session_id"`
+	Compared    []string             `json:"compared_backends"`
+	Differences []Difference         `json:"differences"`
+	Unsupported []BackendUnsupported `json:"unsupported,omitempty"`
+}
+
+// BackendUnsupported records backend-specific unsupported capabilities.
+type BackendUnsupported struct {
+	Backend     string               `json:"backend"`
+	Unsupported []UnsupportedFeature `json:"unsupported"`
+}
+
+// Difference records one normalized mismatch.
+type Difference struct {
+	Case         string `json:"case"`
+	Backend      string `json:"backend"`
+	SessionID    string `json:"session_id"`
+	Locator      string `json:"locator,omitempty"`
+	FieldPath    string `json:"field_path"`
+	BaseValue    any    `json:"base_value,omitempty"`
+	CompareValue any    `json:"compare_value,omitempty"`
+	AllowedDiff  bool   `json:"allowed_diff"`
+	Explanation  string `json:"explanation,omitempty"`
+}

--- a/tool/claudecode/claudecode_test.go
+++ b/tool/claudecode/claudecode_test.go
@@ -182,7 +182,7 @@ func TestToolSet_TaskOutputReadsBackgroundBashTask(t *testing.T) {
 	bashTool := mustCallableTool(t, ts.Tools(context.Background()), toolBash)
 	taskOutputTool := mustCallableTool(t, ts.Tools(context.Background()), toolTaskOutput)
 	bgOut := callToolAs[bashOutput](t, bashTool, bashInput{
-		Command:         "printf 'a'; sleep 0.3; printf 'b'",
+		Command:         "printf 'ab'",
 		RunInBackground: true,
 	})
 	require.NotEmpty(t, bgOut.BackgroundTaskID)
@@ -194,7 +194,7 @@ func TestToolSet_TaskOutputReadsBackgroundBashTask(t *testing.T) {
 	require.Contains(t, []string{"not_ready", "success"}, nonBlocking.RetrievalStatus)
 	blocking := callToolAs[taskOutputOutput](t, taskOutputTool, taskOutputInput{
 		TaskID:  bgOut.BackgroundTaskID,
-		Timeout: intPtr(5_000),
+		Timeout: intPtr(30_000),
 	})
 	require.Equal(t, "success", blocking.RetrievalStatus)
 	require.NotNil(t, blocking.Task)


### PR DESCRIPTION
## Summary

- Add `session/replaytest` replay consistency harness for Session / Memory / Summary / Track backends.
- Provide 10 public deterministic replay cases covering dialogue ordering, tools, state, memory, summaries, tracks, interleaving, and retry recovery.
- Add normalization, diff reporting, lightweight InMemory vs JSON-file persistent backend comparison, docs, and sample diff report.

Closes #2001

## Validation

- `go test -count=1 ./session/replaytest`
- `go test ./session/...`
- `gofmt -r 'interface{} -> any' -l session/replaytest`
