### PR TITLE
openclaw/browser: describe configured targets in schema

### DIFF
--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -385,8 +385,26 @@ func (t *Tool) Declaration() *tool.Declaration {
 		InputSchema: browserSchema(
 			t.evaluateEnabled,
 			t.driverTypeForProfile(t.defaultProfile),
+			t.browserTargetDescription(),
 		),
 	}
+}
+
+func (t *Tool) browserTargetDescription() string {
+	description := "Browser target. Omit for the default host browser."
+	targets := make([]string, 0, 2)
+	if hasServerTarget(t.sandboxServer) {
+		targets = append(targets, targetSandbox)
+	}
+	if hasNodeServerTarget(t.nodeTargets) {
+		targets = append(targets, targetNode)
+	}
+	if len(targets) == 0 {
+		return description + " No non-default browser targets are configured."
+	}
+	sort.Strings(targets)
+	return description + " Available non-default targets: " +
+		strings.Join(targets, ", ") + "."
 }
 
 // Close releases browser profile drivers owned by this tool.
@@ -711,7 +729,11 @@ func (r *cancelCleanupRegistry) register(profile string) bool {
 	return true
 }
 
-func browserSchema(evaluateEnabled bool, driverType string) *tool.Schema {
+func browserSchema(
+	evaluateEnabled bool,
+	driverType string,
+	targetDescription string,
+) *tool.Schema {
 	actionDescription := "Browser action. Supported actions include: " +
 		strings.Join(visibleActionsForDriver(
 			driverType,
@@ -775,11 +797,8 @@ func browserSchema(evaluateEnabled bool, driverType string) *tool.Schema {
 	}
 
 	properties := map[string]*tool.Schema{
-		"action": stringSchema(actionDescription),
-		"target": stringSchema(
-			"Browser target. Omit for default host; only use " +
-				"sandbox or node when configured.",
-		),
+		"action":         stringSchema(actionDescription),
+		"target":         stringSchema(targetDescription),
 		"node":           stringSchema("Node browser target."),
 		"profile":        stringSchema("Browser profile name."),
 		"targetUrl":      stringSchema("Alias for browser URL."),

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -1300,7 +1300,40 @@ func TestNewTool_DeclarationExposesSchema(t *testing.T) {
 	require.Contains(
 		t,
 		decl.InputSchema.Properties["target"].Description,
-		"only use sandbox or node when configured",
+		"No non-default browser targets are configured",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["target"].Description,
+		"sandbox",
+	)
+	require.NotContains(
+		t,
+		decl.InputSchema.Properties["target"].Description,
+		"node",
+	)
+}
+
+func TestNewTool_DeclarationDescribesConfiguredBrowserTargets(t *testing.T) {
+	t.Parallel()
+
+	tool, err := NewTool(Config{
+		SandboxServerURL: "http://127.0.0.1:20790",
+		Nodes: []NodeConfig{{
+			ID:        "edge",
+			ServerURL: "http://127.0.0.1:21790",
+		}},
+		Profiles: []ProfileConfig{{
+			Name: defaultProfileName,
+		}},
+	})
+	require.NoError(t, err)
+
+	decl := tool.Declaration()
+	require.Contains(
+		t,
+		decl.InputSchema.Properties["target"].Description,
+		"Available non-default targets: node, sandbox",
 	)
 }
 
@@ -4270,6 +4303,32 @@ func TestToolResolveDriver_TargetFallbackPaths(t *testing.T) {
 		serverDrv, ok := drv.(*serverProfileDriver)
 		require.True(t, ok)
 		require.Equal(t, "http://127.0.0.1:20790", serverDrv.baseURL)
+	})
+
+	t.Run("sandbox without sandbox server stays strict", func(t *testing.T) {
+		tool := newToolWithDrivers(
+			defaultProfileName,
+			false,
+			navigationPolicy{},
+			&serverTargetConfig{
+				ID:        targetHost,
+				ServerURL: "http://127.0.0.1:19790",
+			},
+			nil,
+			nil,
+			map[string]ProfileConfig{
+				defaultProfileName: {Name: defaultProfileName},
+			},
+			map[string]driver{
+				defaultProfileName: &fakeDriver{},
+			},
+		)
+
+		_, _, err := tool.resolveDriver(input{
+			Target: targetSandbox,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "sandbox target is not configured")
 	})
 
 	t.Run("single node auto select", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- describe browser target values from the active runtime configuration instead of always hinting sandbox/node
- keep explicit target=sandbox strict when sandbox_server_url is not configured, even if a host browser server exists
- add tests for dynamic target schema text and strict sandbox resolution

## Validation
- go test ./internal/browser -count=1