### PR TITLE
构建 Evaluation + Optimization 自动回归闭环

### DIFF
--- a/evaluation/workflow/promptiter/regressionloop/attribution.go
+++ b/evaluation/workflow/promptiter/regressionloop/attribution.go
@@ -8,7 +8,11 @@
 
 package regressionloop
 
-import "strings"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // AttributeCase returns deterministic failure attributions for a case.
 func AttributeCase(c CaseResult) []Attribution {
@@ -21,8 +25,8 @@ func AttributeCase(c CaseResult) []Attribution {
 	if len(c.Attributions) > 0 {
 		return c.Attributions
 	}
-	text := strings.ToLower(strings.Join(evidenceParts(c), " "))
 	for _, rule := range attributionRules() {
+		text := strings.ToLower(sourceTextForRule(c, rule.source))
 		if containsAny(text, rule.needles...) {
 			return []Attribution{{
 				Category:   rule.category,
@@ -90,8 +94,32 @@ func evidenceParts(c CaseResult) []string {
 	for _, metric := range c.MetricResults {
 		parts = append(parts, metric.Name, metric.Reason)
 	}
-	parts = append(parts, c.FinalResponse, c.ExpectedResponse, c.TraceSummary, c.RubricReason, c.StructuredOutputStatus)
 	return parts
+}
+
+func sourceTextForRule(c CaseResult, source string) string {
+	parts := evidenceParts(c)
+	switch source {
+	case "tool_trajectory":
+		parts = append(parts, toolCallsText(c.ToolTrajectory), toolCallsText(c.ExpectedToolTrajectory))
+	case "trace":
+		parts = append(parts, c.TraceSummary)
+	case "structured_output":
+		parts = append(parts, c.StructuredOutputStatus)
+	case "rubric":
+		parts = append(parts, c.RubricReason)
+	case "final_response":
+		parts = append(parts, c.FinalResponse, c.ExpectedResponse)
+	}
+	return strings.Join(parts, " ")
+}
+
+func toolCallsText(calls []ToolCall) string {
+	parts := make([]string, 0, len(calls)*3)
+	for _, call := range calls {
+		parts = append(parts, call.Name, fmt.Sprint(call.Arguments), fmt.Sprint(call.Result))
+	}
+	return strings.Join(parts, " ")
 }
 
 func bestEvidence(c CaseResult, source string) string {
@@ -147,5 +175,5 @@ func quote(value string) string {
 	if value == "" {
 		return `""`
 	}
-	return `"` + value + `"`
+	return strconv.Quote(value)
 }

--- a/evaluation/workflow/promptiter/regressionloop/attribution.go
+++ b/evaluation/workflow/promptiter/regressionloop/attribution.go
@@ -1,0 +1,151 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import "strings"
+
+// AttributeCase returns deterministic failure attributions for a case.
+func AttributeCase(c CaseResult) []Attribution {
+	if c.Passed && !c.HardFail {
+		if c.Attributions == nil {
+			return []Attribution{}
+		}
+		return c.Attributions
+	}
+	if len(c.Attributions) > 0 {
+		return c.Attributions
+	}
+	text := strings.ToLower(strings.Join(evidenceParts(c), " "))
+	for _, rule := range attributionRules() {
+		if containsAny(text, rule.needles...) {
+			return []Attribution{{
+				Category:   rule.category,
+				Confidence: rule.confidence,
+				Evidence:   bestEvidence(c, rule.source),
+				MetricName: firstMetricName(c),
+				Source:     rule.source,
+			}}
+		}
+	}
+	if len(c.MetricResults) > 0 {
+		return []Attribution{{
+			Category:   AttributionMetricThresholdMiss,
+			Confidence: 0.6,
+			Evidence:   bestEvidence(c, "metric"),
+			MetricName: firstMetricName(c),
+			Source:     "metric",
+		}}
+	}
+	return []Attribution{{
+		Category:   AttributionUnknown,
+		Confidence: 0.2,
+		Evidence:   bestEvidence(c, "unknown"),
+		Source:     "unknown",
+	}}
+}
+
+// AttributeEvaluation attaches attributions to every failed case.
+func AttributeEvaluation(summary EvaluationSummary) EvaluationSummary {
+	for i := range summary.Cases {
+		summary.Cases[i].Attributions = AttributeCase(summary.Cases[i])
+	}
+	return summary
+}
+
+type attributionRule struct {
+	category   AttributionCategory
+	source     string
+	confidence float64
+	needles    []string
+}
+
+func attributionRules() []attributionRule {
+	return []attributionRule{
+		{AttributionToolArgumentError, "tool_trajectory", 0.9, []string{"tool argument", "argument", "parameter", "param", "wrong query", "arguments mismatch"}},
+		{AttributionToolSelectionError, "tool_trajectory", 0.9, []string{"wrong tool", "missing tool", "unexpected tool", "tool selection", "tool trajectory"}},
+		{AttributionRoutingError, "trace", 0.85, []string{"route", "routing", "wrong agent", "wrong skill", "wrong node"}},
+		{AttributionFormatError, "structured_output", 0.85, []string{"format", "json", "xml", "schema", "structured output", "markdown"}},
+		{AttributionKnowledgeRecallInsufficient, "rubric", 0.8, []string{"knowledge", "recall", "missing context", "stale", "unsupported", "retrieval"}},
+		{AttributionFinalResponseMismatch, "final_response", 0.8, []string{"final response", "mismatch", "incorrect answer", "wrong answer", "reference", "expected response"}},
+	}
+}
+
+func containsAny(text string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func evidenceParts(c CaseResult) []string {
+	parts := append([]string{}, c.FailureReasons...)
+	for _, metric := range c.MetricResults {
+		parts = append(parts, metric.Name, metric.Reason)
+	}
+	parts = append(parts, c.FinalResponse, c.ExpectedResponse, c.TraceSummary, c.RubricReason, c.StructuredOutputStatus)
+	return parts
+}
+
+func bestEvidence(c CaseResult, source string) string {
+	switch source {
+	case "final_response":
+		if c.FinalResponse != "" || c.ExpectedResponse != "" {
+			return "actual final response " + quote(c.FinalResponse) + " vs expected " + quote(c.ExpectedResponse)
+		}
+	case "tool_trajectory":
+		if len(c.ToolTrajectory) > 0 || len(c.ExpectedToolTrajectory) > 0 {
+			return "tool trajectory differs from expected trajectory"
+		}
+	case "trace":
+		if c.TraceSummary != "" {
+			return c.TraceSummary
+		}
+	case "structured_output":
+		if c.StructuredOutputStatus != "" {
+			return c.StructuredOutputStatus
+		}
+	case "rubric":
+		if c.RubricReason != "" {
+			return c.RubricReason
+		}
+	}
+	for _, reason := range c.FailureReasons {
+		if strings.TrimSpace(reason) != "" {
+			return reason
+		}
+	}
+	for _, metric := range c.MetricResults {
+		if strings.TrimSpace(metric.Reason) != "" {
+			return metric.Reason
+		}
+	}
+	if c.FinalResponse != "" {
+		return "actual final response " + quote(c.FinalResponse)
+	}
+	return "failure evidence unavailable; classified as unknown"
+}
+
+func firstMetricName(c CaseResult) string {
+	for _, metric := range c.MetricResults {
+		if metric.Name != "" {
+			return metric.Name
+		}
+	}
+	return ""
+}
+
+func quote(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return `""`
+	}
+	return `"` + value + `"`
+}

--- a/evaluation/workflow/promptiter/regressionloop/attribution_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/attribution_test.go
@@ -1,0 +1,62 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributeCaseCategories(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   string
+		category AttributionCategory
+	}{
+		{"final", "final response mismatch with reference", AttributionFinalResponseMismatch},
+		{"tool selection", "wrong tool selected", AttributionToolSelectionError},
+		{"tool argument", "tool argument query is wrong", AttributionToolArgumentError},
+		{"routing", "route selected wrong agent", AttributionRoutingError},
+		{"format", "structured output json schema violation", AttributionFormatError},
+		{"knowledge", "knowledge recall missing context", AttributionKnowledgeRecallInsufficient},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := caseResult("case", 0, false)
+			c.FailureReasons = []string{tt.reason}
+			got := AttributeCase(c)
+			assert.Equal(t, tt.category, got[0].Category)
+			assert.NotEmpty(t, got[0].Evidence)
+		})
+	}
+}
+
+func TestAttributeCaseFallsBackToMetricThreshold(t *testing.T) {
+	c := CaseResult{
+		EvalID: "case",
+		Score:  0.4,
+		Passed: false,
+		MetricResults: []MetricResult{{
+			Name:   "quality",
+			Score:  0.4,
+			Passed: false,
+			Reason: "score below threshold",
+		}},
+	}
+	got := AttributeCase(c)
+	assert.Equal(t, AttributionMetricThresholdMiss, got[0].Category)
+	assert.NotEmpty(t, got[0].Evidence)
+}
+
+func TestAttributeCaseFallsBackToUnknown(t *testing.T) {
+	got := AttributeCase(CaseResult{EvalID: "case", Passed: false})
+	assert.Equal(t, AttributionUnknown, got[0].Category)
+	assert.NotEmpty(t, got[0].Evidence)
+}

--- a/evaluation/workflow/promptiter/regressionloop/attribution_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/attribution_test.go
@@ -38,6 +38,25 @@ func TestAttributeCaseCategories(t *testing.T) {
 	}
 }
 
+func TestAttributeCaseIgnoresIncidentalResponseKeywords(t *testing.T) {
+	c := caseResult("case", 0, false)
+	c.FailureReasons = []string{"wrong tool selected"}
+	c.ExpectedResponse = `{"argument":"value"}`
+
+	got := AttributeCase(c)
+	assert.Equal(t, AttributionToolSelectionError, got[0].Category)
+}
+
+func TestAttributeCaseEscapesQuotedEvidence(t *testing.T) {
+	c := caseResult("case", 0, false)
+	c.FailureReasons = []string{"final response mismatch"}
+	c.FinalResponse = `actual "quoted" value`
+
+	got := AttributeCase(c)
+	assert.Equal(t, AttributionFinalResponseMismatch, got[0].Category)
+	assert.Contains(t, got[0].Evidence, `"actual \"quoted\" value"`)
+}
+
 func TestAttributeCaseFallsBackToMetricThreshold(t *testing.T) {
 	c := CaseResult{
 		EvalID: "case",

--- a/evaluation/workflow/promptiter/regressionloop/config.go
+++ b/evaluation/workflow/promptiter/regressionloop/config.go
@@ -1,0 +1,148 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadConfig reads and validates a loop configuration from path.
+func LoadConfig(path string) (*Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("config path is empty")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("decode config: %w", err)
+	}
+	resolveConfigPaths(&cfg, filepath.Dir(path))
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Validate checks that required configuration is present and coherent.
+func (c *Config) Validate() error {
+	if c == nil {
+		return errors.New("config is nil")
+	}
+	var missing []string
+	if strings.TrimSpace(c.AppName) == "" {
+		missing = append(missing, "appName")
+	}
+	if strings.TrimSpace(c.PromptSource.ID) == "" {
+		missing = append(missing, "promptSource.id")
+	}
+	if strings.TrimSpace(c.PromptSource.Path) == "" {
+		missing = append(missing, "promptSource.path")
+	}
+	if c.PromptSource.TargetType == "" {
+		missing = append(missing, "promptSource.targetType")
+	}
+	if strings.TrimSpace(c.TrainEvalSet.ID) == "" {
+		missing = append(missing, "trainEvalSet.id")
+	}
+	if strings.TrimSpace(c.TrainEvalSet.Path) == "" {
+		missing = append(missing, "trainEvalSet.path")
+	}
+	if strings.TrimSpace(c.ValidationEvalSet.ID) == "" {
+		missing = append(missing, "validationEvalSet.id")
+	}
+	if strings.TrimSpace(c.ValidationEvalSet.Path) == "" {
+		missing = append(missing, "validationEvalSet.path")
+	}
+	if strings.TrimSpace(c.Metrics.Path) == "" {
+		missing = append(missing, "metrics.path")
+	}
+	if c.PromptIter.MaxRounds <= 0 {
+		missing = append(missing, "promptiter.maxRounds")
+	}
+	if len(c.PromptIter.TargetSurfaceIDs) == 0 {
+		missing = append(missing, "promptiter.targetSurfaceIds")
+	}
+	if c.Runner.Mode == "" {
+		missing = append(missing, "runner.mode")
+	}
+	if strings.TrimSpace(c.Output.Dir) == "" {
+		missing = append(missing, "output.dir")
+	}
+	if strings.TrimSpace(c.Output.JSONReport) == "" {
+		missing = append(missing, "output.jsonReport")
+	}
+	if strings.TrimSpace(c.Output.MarkdownReport) == "" {
+		missing = append(missing, "output.markdownReport")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required config fields: %s", strings.Join(missing, ", "))
+	}
+	if c.TrainEvalSet.ID == c.ValidationEvalSet.ID {
+		return errors.New("train and validation eval sets must be distinct")
+	}
+	if c.Gate.MinValidationScoreGain < 0 {
+		return errors.New("gate.minValidationScoreGain must be non-negative")
+	}
+	if c.Gate.MaxCost < 0 {
+		return errors.New("gate.maxCost must be non-negative")
+	}
+	if c.Gate.MaxCalls < 0 {
+		return errors.New("gate.maxCalls must be non-negative")
+	}
+	if c.Gate.MaxLatencyMS < 0 {
+		return errors.New("gate.maxLatencyMs must be non-negative")
+	}
+	switch c.PromptSource.TargetType {
+	case PromptTargetSystemPrompt, PromptTargetAgentInstruction, PromptTargetSkillDescription, PromptTargetRouterPrompt:
+	default:
+		return fmt.Errorf("unsupported prompt target type %q", c.PromptSource.TargetType)
+	}
+	switch c.Runner.Mode {
+	case RunnerModeFake, RunnerModeTrace, RunnerModeModel:
+	default:
+		return fmt.Errorf("unsupported runner mode %q", c.Runner.Mode)
+	}
+	if (c.Runner.Mode == RunnerModeFake || c.Runner.Mode == RunnerModeTrace) && c.Seed == 0 {
+		return errors.New("deterministic fake/trace mode requires a non-zero seed")
+	}
+	return nil
+}
+
+func resolveConfigPaths(cfg *Config, baseDir string) {
+	cfg.PromptSource.Path = resolvePath(baseDir, cfg.PromptSource.Path)
+	cfg.TrainEvalSet.Path = resolvePath(baseDir, cfg.TrainEvalSet.Path)
+	cfg.ValidationEvalSet.Path = resolvePath(baseDir, cfg.ValidationEvalSet.Path)
+	cfg.Metrics.Path = resolvePath(baseDir, cfg.Metrics.Path)
+	cfg.Runner.FixturePath = resolvePath(baseDir, cfg.Runner.FixturePath)
+	cfg.Output.Dir = resolvePath(baseDir, cfg.Output.Dir)
+	cfg.Output.JSONReport = resolveOutputPath(cfg.Output.Dir, cfg.Output.JSONReport)
+	cfg.Output.MarkdownReport = resolveOutputPath(cfg.Output.Dir, cfg.Output.MarkdownReport)
+}
+
+func resolvePath(baseDir, path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Clean(filepath.Join(baseDir, path))
+}
+
+func resolveOutputPath(outputDir, path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Clean(filepath.Join(outputDir, path))
+}

--- a/evaluation/workflow/promptiter/regressionloop/config.go
+++ b/evaluation/workflow/promptiter/regressionloop/config.go
@@ -9,9 +9,11 @@
 package regressionloop
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,8 +29,17 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("decode config: %w", err)
+	}
+	extraErr := decoder.Decode(&struct{}{})
+	if extraErr != io.EOF {
+		if extraErr == nil {
+			extraErr = errors.New("config must contain a single JSON object")
+		}
+		return nil, fmt.Errorf("decode config: %w", extraErr)
 	}
 	resolveConfigPaths(&cfg, filepath.Dir(path))
 	if err := cfg.Validate(); err != nil {
@@ -91,6 +102,9 @@ func (c *Config) Validate() error {
 	if len(missing) > 0 {
 		return fmt.Errorf("missing required config fields: %s", strings.Join(missing, ", "))
 	}
+	if err := validateReportPaths(c.Output.JSONReport, c.Output.MarkdownReport); err != nil {
+		return err
+	}
 	if c.TrainEvalSet.ID == c.ValidationEvalSet.ID {
 		return errors.New("train and validation eval sets must be distinct")
 	}
@@ -118,6 +132,13 @@ func (c *Config) Validate() error {
 	}
 	if (c.Runner.Mode == RunnerModeFake || c.Runner.Mode == RunnerModeTrace) && c.Seed == 0 {
 		return errors.New("deterministic fake/trace mode requires a non-zero seed")
+	}
+	return nil
+}
+
+func validateReportPaths(jsonPath, markdownPath string) error {
+	if filepath.Clean(jsonPath) == filepath.Clean(markdownPath) {
+		return errors.New("output.jsonReport and output.markdownReport must be distinct")
 	}
 	return nil
 }

--- a/evaluation/workflow/promptiter/regressionloop/config_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/config_test.go
@@ -26,6 +26,98 @@ func TestConfigValidate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "must be distinct")
 }
 
+func TestConfigValidateRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:    "nil config",
+			mutate:  nil,
+			wantErr: "config is nil",
+		},
+		{
+			name: "missing required fields",
+			mutate: func(cfg *Config) {
+				cfg.AppName = ""
+				cfg.PromptSource.ID = ""
+			},
+			wantErr: "missing required config fields",
+		},
+		{
+			name: "negative score gain",
+			mutate: func(cfg *Config) {
+				cfg.Gate.MinValidationScoreGain = -0.1
+			},
+			wantErr: "gate.minValidationScoreGain must be non-negative",
+		},
+		{
+			name: "negative max cost",
+			mutate: func(cfg *Config) {
+				cfg.Gate.MaxCost = -1
+			},
+			wantErr: "gate.maxCost must be non-negative",
+		},
+		{
+			name: "negative max calls",
+			mutate: func(cfg *Config) {
+				cfg.Gate.MaxCalls = -1
+			},
+			wantErr: "gate.maxCalls must be non-negative",
+		},
+		{
+			name: "negative max latency",
+			mutate: func(cfg *Config) {
+				cfg.Gate.MaxLatencyMS = -1
+			},
+			wantErr: "gate.maxLatencyMs must be non-negative",
+		},
+		{
+			name: "unsupported prompt target type",
+			mutate: func(cfg *Config) {
+				cfg.PromptSource.TargetType = "unknown"
+			},
+			wantErr: "unsupported prompt target type",
+		},
+		{
+			name: "unsupported runner mode",
+			mutate: func(cfg *Config) {
+				cfg.Runner.Mode = "unknown"
+			},
+			wantErr: "unsupported runner mode",
+		},
+		{
+			name: "deterministic fake mode requires seed",
+			mutate: func(cfg *Config) {
+				cfg.Seed = 0
+				cfg.Runner.Mode = RunnerModeFake
+			},
+			wantErr: "deterministic fake/trace mode requires a non-zero seed",
+		},
+		{
+			name: "deterministic trace mode requires seed",
+			mutate: func(cfg *Config) {
+				cfg.Seed = 0
+				cfg.Runner.Mode = RunnerModeTrace
+			},
+			wantErr: "deterministic fake/trace mode requires a non-zero seed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mutate == nil {
+				var cfg *Config
+				require.ErrorContains(t, cfg.Validate(), tt.wantErr)
+				return
+			}
+			cfg := testConfig(t)
+			tt.mutate(&cfg)
+			require.ErrorContains(t, cfg.Validate(), tt.wantErr)
+		})
+	}
+}
+
 func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(t)
@@ -46,4 +138,15 @@ func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "baseline_prompt.txt"), loaded.PromptSource.Path)
 	assert.Equal(t, filepath.Join(dir, "output", "optimization_report.json"), loaded.Output.JSONReport)
+}
+
+func TestLoadConfigRejectsBadInput(t *testing.T) {
+	_, err := LoadConfig("")
+	require.ErrorContains(t, err, "config path is empty")
+
+	dir := t.TempDir()
+	badJSON := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(badJSON, []byte("{"), 0o644))
+	_, err = LoadConfig(badJSON)
+	require.ErrorContains(t, err, "decode config")
 }

--- a/evaluation/workflow/promptiter/regressionloop/config_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/config_test.go
@@ -118,6 +118,31 @@ func TestConfigValidateRejectsInvalidValues(t *testing.T) {
 	}
 }
 
+func TestConfigValidateReportsRequiredFields(t *testing.T) {
+	var cfg Config
+	err := cfg.Validate()
+	require.Error(t, err)
+	for _, field := range []string{
+		"appName",
+		"promptSource.id",
+		"promptSource.path",
+		"promptSource.targetType",
+		"trainEvalSet.id",
+		"trainEvalSet.path",
+		"validationEvalSet.id",
+		"validationEvalSet.path",
+		"metrics.path",
+		"promptiter.maxRounds",
+		"promptiter.targetSurfaceIds",
+		"runner.mode",
+		"output.dir",
+		"output.jsonReport",
+		"output.markdownReport",
+	} {
+		assert.ErrorContains(t, err, field)
+	}
+}
+
 func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(t)
@@ -144,9 +169,21 @@ func TestLoadConfigRejectsBadInput(t *testing.T) {
 	_, err := LoadConfig("")
 	require.ErrorContains(t, err, "config path is empty")
 
+	_, err = LoadConfig(filepath.Join(t.TempDir(), "missing.json"))
+	require.ErrorContains(t, err, "read config")
+
 	dir := t.TempDir()
 	badJSON := filepath.Join(dir, "bad.json")
 	require.NoError(t, os.WriteFile(badJSON, []byte("{"), 0o644))
 	_, err = LoadConfig(badJSON)
 	require.ErrorContains(t, err, "decode config")
+
+	invalid := testConfig(t)
+	invalid.AppName = ""
+	data, err := json.Marshal(invalid)
+	require.NoError(t, err)
+	invalidPath := filepath.Join(dir, "invalid.json")
+	require.NoError(t, os.WriteFile(invalidPath, data, 0o644))
+	_, err = LoadConfig(invalidPath)
+	require.ErrorContains(t, err, "missing required config fields")
 }

--- a/evaluation/workflow/promptiter/regressionloop/config_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/config_test.go
@@ -1,0 +1,49 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	cfg := testConfig(t)
+	require.NoError(t, cfg.Validate())
+
+	cfg.TrainEvalSet.ID = "validation"
+	require.ErrorContains(t, cfg.Validate(), "must be distinct")
+}
+
+func TestLoadConfigResolvesRelativePaths(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(t)
+	cfg.PromptSource.Path = "baseline_prompt.txt"
+	cfg.TrainEvalSet.Path = "train.evalset.json"
+	cfg.ValidationEvalSet.Path = "validation.evalset.json"
+	cfg.Metrics.Path = "metrics.json"
+	cfg.Output.Dir = "output"
+	cfg.Output.JSONReport = "optimization_report.json"
+	cfg.Output.MarkdownReport = "optimization_report.md"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "baseline_prompt.txt"), []byte("prompt"), 0o644))
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	configPath := filepath.Join(dir, "promptiter.json")
+	require.NoError(t, os.WriteFile(configPath, data, 0o644))
+
+	loaded, err := LoadConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "baseline_prompt.txt"), loaded.PromptSource.Path)
+	assert.Equal(t, filepath.Join(dir, "output", "optimization_report.json"), loaded.Output.JSONReport)
+}

--- a/evaluation/workflow/promptiter/regressionloop/config_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/config_test.go
@@ -74,6 +74,15 @@ func TestConfigValidateRejectsInvalidValues(t *testing.T) {
 			wantErr: "gate.maxLatencyMs must be non-negative",
 		},
 		{
+			name: "colliding report paths",
+			mutate: func(cfg *Config) {
+				cfg.Output.JSONReport = filepath.Join(cfg.Output.Dir, "same")
+				cfg.Output.MarkdownReport = cfg.Output.Dir + string(filepath.Separator) +
+					"nested" + string(filepath.Separator) + ".." + string(filepath.Separator) + "same"
+			},
+			wantErr: "output.jsonReport and output.markdownReport must be distinct",
+		},
+		{
 			name: "unsupported prompt target type",
 			mutate: func(cfg *Config) {
 				cfg.PromptSource.TargetType = "unknown"
@@ -178,9 +187,27 @@ func TestLoadConfigRejectsBadInput(t *testing.T) {
 	_, err = LoadConfig(badJSON)
 	require.ErrorContains(t, err, "decode config")
 
+	valid := testConfig(t)
+	data, err := json.Marshal(valid)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	raw["gate"].(map[string]any)["blockCriticalRegressions"] = true
+	unknownData, err := json.Marshal(raw)
+	require.NoError(t, err)
+	unknownPath := filepath.Join(dir, "unknown.json")
+	require.NoError(t, os.WriteFile(unknownPath, unknownData, 0o644))
+	_, err = LoadConfig(unknownPath)
+	require.ErrorContains(t, err, `unknown field "blockCriticalRegressions"`)
+
+	trailingPath := filepath.Join(dir, "trailing.json")
+	require.NoError(t, os.WriteFile(trailingPath, append(data, []byte("\n{}")...), 0o644))
+	_, err = LoadConfig(trailingPath)
+	require.ErrorContains(t, err, "config must contain a single JSON object")
+
 	invalid := testConfig(t)
 	invalid.AppName = ""
-	data, err := json.Marshal(invalid)
+	data, err = json.Marshal(invalid)
 	require.NoError(t, err)
 	invalidPath := filepath.Join(dir, "invalid.json")
 	require.NoError(t, os.WriteFile(invalidPath, data, 0o644))

--- a/evaluation/workflow/promptiter/regressionloop/delta.go
+++ b/evaluation/workflow/promptiter/regressionloop/delta.go
@@ -1,0 +1,135 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import "sort"
+
+// ComputeDeltas compares baseline and candidate validation case results.
+func ComputeDeltas(baseline, candidate EvaluationSummary, criticalCaseIDs []string) ([]CaseDelta, DeltaSummary) {
+	baselineByID := caseIndex(baseline.Cases)
+	candidateByID := caseIndex(candidate.Cases)
+	ids := make(map[string]struct{}, len(baselineByID)+len(candidateByID))
+	for id := range baselineByID {
+		ids[id] = struct{}{}
+	}
+	for id := range candidateByID {
+		ids[id] = struct{}{}
+	}
+	critical := criticalIndex(criticalCaseIDs)
+	ordered := make([]string, 0, len(ids))
+	for id := range ids {
+		ordered = append(ordered, id)
+	}
+	sort.Strings(ordered)
+	deltas := make([]CaseDelta, 0, len(ordered))
+	var summary DeltaSummary
+	for _, id := range ordered {
+		base, hasBase := baselineByID[id]
+		cand, hasCand := candidateByID[id]
+		delta := CaseDelta{EvalID: id, Transition: TransitionMissing}
+		if hasBase {
+			delta.EvalSetID = base.EvalSetID
+			delta.BaselineScore = base.Score
+			delta.BaselinePassed = base.Passed
+		}
+		if hasCand {
+			if delta.EvalSetID == "" {
+				delta.EvalSetID = cand.EvalSetID
+			}
+			delta.CandidateScore = cand.Score
+			delta.CandidatePassed = cand.Passed
+			delta.NewHardFail = cand.HardFail && (!hasBase || !base.HardFail)
+		}
+		if hasBase && hasCand {
+			delta.ScoreDelta = cand.Score - base.Score
+			delta.Transition = classifyTransition(base, cand)
+			delta.CriticalRegression = isCritical(base, cand, critical) && (delta.ScoreDelta < 0 || (base.Passed && !cand.Passed))
+			delta.AttributionChange = attributionChange(base.Attributions, cand.Attributions)
+		}
+		addDeltaSummary(&summary, delta)
+		deltas = append(deltas, delta)
+	}
+	return deltas, summary
+}
+
+func caseIndex(cases []CaseResult) map[string]CaseResult {
+	index := make(map[string]CaseResult, len(cases))
+	for _, c := range cases {
+		index[c.EvalID] = c
+	}
+	return index
+}
+
+func criticalIndex(ids []string) map[string]struct{} {
+	index := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		index[id] = struct{}{}
+	}
+	return index
+}
+
+func classifyTransition(base, cand CaseResult) Transition {
+	switch {
+	case !base.Passed && cand.Passed:
+		return TransitionNewlyPassed
+	case base.Passed && !cand.Passed:
+		return TransitionNewlyFailed
+	case cand.Score > base.Score:
+		return TransitionImproved
+	case cand.Score < base.Score:
+		return TransitionRegressed
+	default:
+		return TransitionUnchanged
+	}
+}
+
+func isCritical(base, cand CaseResult, configured map[string]struct{}) bool {
+	if base.Critical || cand.Critical {
+		return true
+	}
+	_, ok := configured[base.EvalID]
+	return ok
+}
+
+func addDeltaSummary(summary *DeltaSummary, delta CaseDelta) {
+	switch delta.Transition {
+	case TransitionNewlyPassed:
+		summary.NewlyPassed++
+	case TransitionNewlyFailed:
+		summary.NewlyFailed++
+	case TransitionImproved:
+		summary.Improved++
+	case TransitionRegressed:
+		summary.Regressed++
+	case TransitionUnchanged:
+		summary.Unchanged++
+	}
+	if delta.NewHardFail {
+		summary.NewHardFails++
+	}
+	if delta.CriticalRegression {
+		summary.CriticalRegressions++
+	}
+}
+
+func attributionChange(base, cand []Attribution) string {
+	if len(base) == 0 && len(cand) == 0 {
+		return ""
+	}
+	if len(base) == 0 {
+		return "candidate attribution added"
+	}
+	if len(cand) == 0 {
+		return "candidate attribution cleared"
+	}
+	if base[0].Category != cand[0].Category {
+		return string(base[0].Category) + " -> " + string(cand[0].Category)
+	}
+	return ""
+}

--- a/evaluation/workflow/promptiter/regressionloop/delta_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/delta_test.go
@@ -50,3 +50,24 @@ func TestComputeDeltasClassifiesTransitions(t *testing.T) {
 	assert.Equal(t, 1, summary.NewHardFails)
 	assert.Equal(t, 1, summary.CriticalRegressions)
 }
+
+func TestComputeDeltasMarksCasesMissingFromEitherSide(t *testing.T) {
+	baseline := evalSummary(0.5,
+		caseResult("shared", 0.5, true),
+		caseResult("baseline-only", 0.4, false),
+	)
+	candidate := evalSummary(0.6,
+		caseResult("shared", 0.6, true),
+		caseResult("candidate-only", 0.7, true),
+	)
+
+	deltas, _ := ComputeDeltas(baseline, candidate, nil)
+	byID := map[string]CaseDelta{}
+	for _, delta := range deltas {
+		byID[delta.EvalID] = delta
+	}
+
+	assert.Equal(t, TransitionMissing, byID["baseline-only"].Transition)
+	assert.Equal(t, TransitionMissing, byID["candidate-only"].Transition)
+	assert.Equal(t, TransitionImproved, byID["shared"].Transition)
+}

--- a/evaluation/workflow/promptiter/regressionloop/delta_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/delta_test.go
@@ -1,0 +1,52 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeDeltasClassifiesTransitions(t *testing.T) {
+	baseline := evalSummary(0.5,
+		caseResult("new-pass", 0.2, false),
+		caseResult("new-fail", 0.9, true),
+		caseResult("improved", 0.4, false),
+		caseResult("regressed", 0.8, true),
+		caseResult("unchanged", 0.7, true),
+	)
+	candidate := evalSummary(0.6,
+		caseResult("new-pass", 0.9, true),
+		caseResult("new-fail", 0, false),
+		caseResult("improved", 0.6, false),
+		caseResult("regressed", 0.6, true),
+		caseResult("unchanged", 0.7, true),
+	)
+	deltas, summary := ComputeDeltas(baseline, candidate, []string{"new-fail"})
+
+	byID := map[string]CaseDelta{}
+	for _, delta := range deltas {
+		byID[delta.EvalID] = delta
+	}
+	assert.Equal(t, TransitionNewlyPassed, byID["new-pass"].Transition)
+	assert.Equal(t, TransitionNewlyFailed, byID["new-fail"].Transition)
+	assert.Equal(t, TransitionImproved, byID["improved"].Transition)
+	assert.Equal(t, TransitionRegressed, byID["regressed"].Transition)
+	assert.Equal(t, TransitionUnchanged, byID["unchanged"].Transition)
+	assert.True(t, byID["new-fail"].NewHardFail)
+	assert.True(t, byID["new-fail"].CriticalRegression)
+	assert.Equal(t, 1, summary.NewlyPassed)
+	assert.Equal(t, 1, summary.NewlyFailed)
+	assert.Equal(t, 1, summary.Improved)
+	assert.Equal(t, 1, summary.Regressed)
+	assert.Equal(t, 1, summary.Unchanged)
+	assert.Equal(t, 1, summary.NewHardFails)
+	assert.Equal(t, 1, summary.CriticalRegressions)
+}

--- a/evaluation/workflow/promptiter/regressionloop/gate.go
+++ b/evaluation/workflow/promptiter/regressionloop/gate.go
@@ -24,6 +24,16 @@ func EvaluateGate(policy GatePolicy, baseline, candidate EvaluationSummary, delt
 			policy.MinValidationScoreGain,
 		))
 	}
+	missingCases := countMissingValidationCases(deltas)
+	if missingCases == 0 {
+		decision.PassedRules = append(decision.PassedRules, "validation_case_coverage")
+	} else {
+		decision.FailedRules = append(decision.FailedRules, "validation_case_coverage")
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf(
+			"baseline and candidate validation sets differ by %d case(s)",
+			missingCases,
+		))
+	}
 	if !policy.AllowNewHardFails {
 		newHardFails := countNewHardFails(deltas)
 		if newHardFails == 0 {
@@ -87,6 +97,16 @@ func countCriticalRegressions(deltas []CaseDelta) int {
 	count := 0
 	for _, delta := range deltas {
 		if delta.CriticalRegression {
+			count++
+		}
+	}
+	return count
+}
+
+func countMissingValidationCases(deltas []CaseDelta) int {
+	count := 0
+	for _, delta := range deltas {
+		if delta.Transition == TransitionMissing {
 			count++
 		}
 	}

--- a/evaluation/workflow/promptiter/regressionloop/gate.go
+++ b/evaluation/workflow/promptiter/regressionloop/gate.go
@@ -1,0 +1,94 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import "fmt"
+
+// EvaluateGate applies acceptance policy to validation scores, deltas, and budgets.
+func EvaluateGate(policy GatePolicy, baseline, candidate EvaluationSummary, deltas []CaseDelta, cost CostSummary, latency LatencySummary) GateDecision {
+	scoreDelta := candidate.Score - baseline.Score
+	decision := GateDecision{ScoreDelta: scoreDelta}
+	if scoreDelta >= policy.MinValidationScoreGain {
+		decision.PassedRules = append(decision.PassedRules, "validation_score_gain")
+	} else {
+		decision.FailedRules = append(decision.FailedRules, "validation_score_gain")
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf(
+			"validation score gain %.4f is below threshold %.4f",
+			scoreDelta,
+			policy.MinValidationScoreGain,
+		))
+	}
+	if !policy.AllowNewHardFails {
+		newHardFails := countNewHardFails(deltas)
+		if newHardFails == 0 {
+			decision.PassedRules = append(decision.PassedRules, "no_new_hard_fails")
+		} else {
+			decision.FailedRules = append(decision.FailedRules, "no_new_hard_fails")
+			decision.Reasons = append(decision.Reasons, fmt.Sprintf("candidate introduced %d new hard fail(s)", newHardFails))
+		}
+	}
+	if policy.BlockCriticalRegression {
+		regressions := countCriticalRegressions(deltas)
+		if regressions == 0 {
+			decision.PassedRules = append(decision.PassedRules, "critical_case_non_regression")
+		} else {
+			decision.FailedRules = append(decision.FailedRules, "critical_case_non_regression")
+			decision.Reasons = append(decision.Reasons, fmt.Sprintf("candidate regressed %d critical case(s)", regressions))
+		}
+	}
+	if policy.MaxCost > 0 {
+		if cost.EstimatedCost <= policy.MaxCost {
+			decision.PassedRules = append(decision.PassedRules, "max_cost")
+		} else {
+			decision.FailedRules = append(decision.FailedRules, "max_cost")
+			decision.Reasons = append(decision.Reasons, fmt.Sprintf("estimated cost %.4f exceeds budget %.4f", cost.EstimatedCost, policy.MaxCost))
+		}
+	}
+	if policy.MaxCalls > 0 {
+		if cost.Calls <= policy.MaxCalls {
+			decision.PassedRules = append(decision.PassedRules, "max_calls")
+		} else {
+			decision.FailedRules = append(decision.FailedRules, "max_calls")
+			decision.Reasons = append(decision.Reasons, fmt.Sprintf("call count %d exceeds budget %d", cost.Calls, policy.MaxCalls))
+		}
+	}
+	if policy.MaxLatencyMS > 0 {
+		if latency.TotalMS <= policy.MaxLatencyMS {
+			decision.PassedRules = append(decision.PassedRules, "max_latency")
+		} else {
+			decision.FailedRules = append(decision.FailedRules, "max_latency")
+			decision.Reasons = append(decision.Reasons, fmt.Sprintf("latency %dms exceeds budget %dms", latency.TotalMS, policy.MaxLatencyMS))
+		}
+	}
+	decision.Accepted = len(decision.FailedRules) == 0
+	if decision.Accepted {
+		decision.Reasons = append(decision.Reasons, "candidate satisfies all acceptance gates")
+	}
+	return decision
+}
+
+func countNewHardFails(deltas []CaseDelta) int {
+	count := 0
+	for _, delta := range deltas {
+		if delta.NewHardFail {
+			count++
+		}
+	}
+	return count
+}
+
+func countCriticalRegressions(deltas []CaseDelta) int {
+	count := 0
+	for _, delta := range deltas {
+		if delta.CriticalRegression {
+			count++
+		}
+	}
+	return count
+}

--- a/evaluation/workflow/promptiter/regressionloop/gate_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/gate_test.go
@@ -42,3 +42,23 @@ func TestEvaluateGateRejectsRegressionAndBudgets(t *testing.T) {
 		decision.FailedRules,
 	)
 }
+
+func TestEvaluateGateRejectsMismatchedValidationCases(t *testing.T) {
+	decision := EvaluateGate(
+		GatePolicy{MinValidationScoreGain: 0.05, AllowNewHardFails: true},
+		evalSummary(0.7),
+		evalSummary(0.8),
+		[]CaseDelta{
+			{EvalID: "baseline-only", Transition: TransitionMissing},
+			{EvalID: "candidate-only", Transition: TransitionMissing},
+		},
+		CostSummary{},
+		LatencySummary{},
+	)
+
+	assert.False(t, decision.Accepted)
+	assert.Contains(t, decision.FailedRules, "validation_case_coverage")
+	assert.Contains(t, decision.Reasons, "baseline and candidate validation sets differ by 2 case(s)")
+	assert.NotContains(t, decision.FailedRules, "no_new_hard_fails")
+	assert.NotContains(t, decision.FailedRules, "critical_case_non_regression")
+}

--- a/evaluation/workflow/promptiter/regressionloop/gate_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/gate_test.go
@@ -1,0 +1,44 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateGateAcceptsCleanImprovement(t *testing.T) {
+	decision := EvaluateGate(
+		GatePolicy{MinValidationScoreGain: 0.05, AllowNewHardFails: false, BlockCriticalRegression: true, MaxCalls: 10, MaxLatencyMS: 100},
+		evalSummary(0.7),
+		evalSummary(0.8),
+		nil,
+		CostSummary{Calls: 2, EstimatedCost: 0.01},
+		LatencySummary{TotalMS: 20},
+	)
+	assert.True(t, decision.Accepted)
+	assert.Empty(t, decision.FailedRules)
+}
+
+func TestEvaluateGateRejectsRegressionAndBudgets(t *testing.T) {
+	decision := EvaluateGate(
+		GatePolicy{MinValidationScoreGain: 0.2, AllowNewHardFails: false, BlockCriticalRegression: true, MaxCost: 0.01, MaxCalls: 1, MaxLatencyMS: 10},
+		evalSummary(0.7),
+		evalSummary(0.75),
+		[]CaseDelta{{EvalID: "critical", NewHardFail: true, CriticalRegression: true}},
+		CostSummary{Calls: 2, EstimatedCost: 0.02},
+		LatencySummary{TotalMS: 20},
+	)
+	assert.False(t, decision.Accepted)
+	assert.ElementsMatch(t,
+		[]string{"validation_score_gain", "no_new_hard_fails", "critical_case_non_regression", "max_cost", "max_calls", "max_latency"},
+		decision.FailedRules,
+	)
+}

--- a/evaluation/workflow/promptiter/regressionloop/pipeline.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline.go
@@ -138,12 +138,13 @@ func (p *Pipeline) Run(ctx context.Context, cfg Config) (*RunResult, error) {
 			selected = &copy
 		}
 	}
-	finalRound := bestRound(rounds)
 	finalDelta := DeltaReport{}
 	finalGate := GateDecision{Accepted: false, Reasons: []string{"no candidate generated"}}
-	if finalRound != nil {
-		finalDelta.Cases, finalDelta.Summary = ComputeDeltas(baseValidation, finalRound.Validation, cfg.Gate.CriticalCaseIDs)
-		finalGate = finalRound.GateDecision
+	if selected != nil {
+		finalDelta.Cases, finalDelta.Summary = ComputeDeltas(baseValidation, selected.Validation, cfg.Gate.CriticalCaseIDs)
+		finalGate = selected.GateDecision
+	} else if len(rounds) > 0 {
+		finalGate = GateDecision{Accepted: false, Reasons: []string{"no candidate accepted by gate"}}
 	}
 	report := &Report{
 		Run: RunMetadata{
@@ -188,17 +189,4 @@ func (p *Pipeline) evaluate(ctx context.Context, cfg Config, phase Phase, round 
 		return EvaluationSummary{}, fmt.Errorf("evaluate %s %s: %w", phase, evalSet.ID, err)
 	}
 	return AttributeEvaluation(result), nil
-}
-
-func bestRound(rounds []CandidateRound) *CandidateRound {
-	if len(rounds) == 0 {
-		return nil
-	}
-	best := rounds[0]
-	for _, round := range rounds[1:] {
-		if round.Validation.Score > best.Validation.Score {
-			best = round
-		}
-	}
-	return &best
 }

--- a/evaluation/workflow/promptiter/regressionloop/pipeline.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline.go
@@ -1,0 +1,204 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Evaluator evaluates one prompt on one eval set.
+type Evaluator interface {
+	Evaluate(ctx context.Context, req EvaluationRequest) (EvaluationSummary, error)
+}
+
+// Optimizer generates candidate prompts from baseline and train evidence.
+type Optimizer interface {
+	Candidates(ctx context.Context, req OptimizationRequest) ([]Candidate, error)
+}
+
+// Clock supplies time for reproducible tests.
+type Clock interface {
+	Now() time.Time
+}
+
+// SystemClock reads time from the host.
+type SystemClock struct{}
+
+// Now returns the current host time.
+func (SystemClock) Now() time.Time { return time.Now() }
+
+// EvaluationRequest describes one evaluator call.
+type EvaluationRequest struct {
+	Phase        Phase
+	Round        int
+	Prompt       string
+	PromptSource PromptSource
+	EvalSet      EvalSetRef
+	Metrics      MetricsRef
+	Config       Config
+}
+
+// OptimizationRequest describes candidate generation inputs.
+type OptimizationRequest struct {
+	Config             Config
+	BaselinePrompt     string
+	BaselineTrain      EvaluationSummary
+	BaselineValidation EvaluationSummary
+}
+
+// Pipeline orchestrates the full regression loop.
+type Pipeline struct {
+	Evaluator Evaluator
+	Optimizer Optimizer
+	Clock     Clock
+}
+
+// Run executes baseline evaluation, optimization, validation gates, and reporting.
+func (p *Pipeline) Run(ctx context.Context, cfg Config) (*RunResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if p == nil || p.Evaluator == nil {
+		return nil, fmt.Errorf("evaluator is nil")
+	}
+	if p.Optimizer == nil {
+		return nil, fmt.Errorf("optimizer is nil")
+	}
+	clock := p.Clock
+	if clock == nil {
+		clock = SystemClock{}
+	}
+	start := clock.Now()
+	baselinePrompt, err := os.ReadFile(cfg.PromptSource.Path)
+	if err != nil {
+		return nil, fmt.Errorf("read baseline prompt: %w", err)
+	}
+	cfg.PromptSource.BaselineText = string(baselinePrompt)
+	baseTrain, err := p.evaluate(ctx, cfg, PhaseBaselineTrain, 0, string(baselinePrompt), cfg.TrainEvalSet)
+	if err != nil {
+		return nil, err
+	}
+	baseValidation, err := p.evaluate(ctx, cfg, PhaseBaselineValidation, 0, string(baselinePrompt), cfg.ValidationEvalSet)
+	if err != nil {
+		return nil, err
+	}
+	baseline := EvaluationPair{Train: baseTrain, Validation: baseValidation}
+	candidates, err := p.Optimizer.Candidates(ctx, OptimizationRequest{
+		Config:             cfg,
+		BaselinePrompt:     string(baselinePrompt),
+		BaselineTrain:      baseTrain,
+		BaselineValidation: baseValidation,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("generate candidates: %w", err)
+	}
+	if cfg.PromptIter.MaxRounds > 0 && len(candidates) > cfg.PromptIter.MaxRounds {
+		candidates = candidates[:cfg.PromptIter.MaxRounds]
+	}
+	rounds := make([]CandidateRound, 0, len(candidates))
+	var selected *CandidateRound
+	for _, candidate := range candidates {
+		train, err := p.evaluate(ctx, cfg, PhaseCandidateTrain, candidate.Round, candidate.Prompt, cfg.TrainEvalSet)
+		if err != nil {
+			return nil, err
+		}
+		validation, err := p.evaluate(ctx, cfg, PhaseCandidateValidation, candidate.Round, candidate.Prompt, cfg.ValidationEvalSet)
+		if err != nil {
+			return nil, err
+		}
+		deltas, _ := ComputeDeltas(baseValidation, validation, cfg.Gate.CriticalCaseIDs)
+		roundCost := CostSummary{}
+		addCost(&roundCost, train.Cost)
+		addCost(&roundCost, validation.Cost)
+		roundLatency := LatencySummary{TotalMS: train.Latency.TotalMS + validation.Latency.TotalMS}
+		gate := EvaluateGate(cfg.Gate, baseValidation, validation, deltas, roundCost, roundLatency)
+		round := CandidateRound{
+			Round:        candidate.Round,
+			Prompt:       candidate.Prompt,
+			Reason:       candidate.Reason,
+			Train:        train,
+			Validation:   validation,
+			Delta:        deltas,
+			GateDecision: gate,
+			Cost:         roundCost,
+			Latency:      roundLatency,
+		}
+		rounds = append(rounds, round)
+		if gate.Accepted && (selected == nil || round.Validation.Score > selected.Validation.Score) {
+			copy := round
+			selected = &copy
+		}
+	}
+	finalRound := bestRound(rounds)
+	finalDelta := DeltaReport{}
+	finalGate := GateDecision{Accepted: false, Reasons: []string{"no candidate generated"}}
+	if finalRound != nil {
+		finalDelta.Cases, finalDelta.Summary = ComputeDeltas(baseValidation, finalRound.Validation, cfg.Gate.CriticalCaseIDs)
+		finalGate = finalRound.GateDecision
+	}
+	report := &Report{
+		Run: RunMetadata{
+			AppName:    cfg.AppName,
+			StartedAt:  start.Format(time.RFC3339),
+			DurationMS: int64(clock.Now().Sub(start) / time.Millisecond),
+			Seed:       cfg.Seed,
+			Runner:     cfg.Runner,
+		},
+		Baseline:          baseline,
+		Candidates:        rounds,
+		SelectedCandidate: selected,
+		Delta:             finalDelta,
+		GateDecision:      finalGate,
+		Artifacts:         []string{cfg.Output.JSONReport, cfg.Output.MarkdownReport},
+	}
+	report.FailureAttributionStats = BuildAttributionStats(report.Baseline, report.Candidates)
+	report.CostSummary = SumCost(report.Baseline, report.Candidates)
+	report.LatencySummary = SumLatency(report.Baseline, report.Candidates)
+	if err := WriteReports(report, cfg.Output.JSONReport, cfg.Output.MarkdownReport); err != nil {
+		return nil, err
+	}
+	return &RunResult{
+		Report:       report,
+		JSONPath:     cfg.Output.JSONReport,
+		MarkdownPath: cfg.Output.MarkdownReport,
+		StartedAt:    start,
+	}, nil
+}
+
+func (p *Pipeline) evaluate(ctx context.Context, cfg Config, phase Phase, round int, prompt string, evalSet EvalSetRef) (EvaluationSummary, error) {
+	result, err := p.Evaluator.Evaluate(ctx, EvaluationRequest{
+		Phase:        phase,
+		Round:        round,
+		Prompt:       prompt,
+		PromptSource: cfg.PromptSource,
+		EvalSet:      evalSet,
+		Metrics:      cfg.Metrics,
+		Config:       cfg,
+	})
+	if err != nil {
+		return EvaluationSummary{}, fmt.Errorf("evaluate %s %s: %w", phase, evalSet.ID, err)
+	}
+	return AttributeEvaluation(result), nil
+}
+
+func bestRound(rounds []CandidateRound) *CandidateRound {
+	if len(rounds) == 0 {
+		return nil
+	}
+	best := rounds[0]
+	for _, round := range rounds[1:] {
+		if round.Validation.Score > best.Validation.Score {
+			best = round
+		}
+	}
+	return &best
+}

--- a/evaluation/workflow/promptiter/regressionloop/pipeline.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline.go
@@ -134,8 +134,8 @@ func (p *Pipeline) Run(ctx context.Context, cfg Config) (*RunResult, error) {
 		}
 		rounds = append(rounds, round)
 		if gate.Accepted && (selected == nil || round.Validation.Score > selected.Validation.Score) {
-			copy := round
-			selected = &copy
+			snapshot := round
+			selected = &snapshot
 		}
 	}
 	finalDelta := DeltaReport{}

--- a/evaluation/workflow/promptiter/regressionloop/pipeline.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -188,5 +189,25 @@ func (p *Pipeline) evaluate(ctx context.Context, cfg Config, phase Phase, round 
 	if err != nil {
 		return EvaluationSummary{}, fmt.Errorf("evaluate %s %s: %w", phase, evalSet.ID, err)
 	}
+	if err := validateEvaluationSummary(result); err != nil {
+		return EvaluationSummary{}, fmt.Errorf("evaluate %s %s: invalid summary: %w", phase, evalSet.ID, err)
+	}
 	return AttributeEvaluation(result), nil
+}
+
+func validateEvaluationSummary(summary EvaluationSummary) error {
+	if len(summary.Cases) == 0 {
+		return fmt.Errorf("cases are empty")
+	}
+	seen := make(map[string]struct{}, len(summary.Cases))
+	for i, c := range summary.Cases {
+		if strings.TrimSpace(c.EvalID) == "" {
+			return fmt.Errorf("case %d has an empty eval ID", i)
+		}
+		if _, ok := seen[c.EvalID]; ok {
+			return fmt.Errorf("duplicate eval ID %q", c.EvalID)
+		}
+		seen[c.EvalID] = struct{}{}
+	}
+	return nil
 }

--- a/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
@@ -1,0 +1,90 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineRunsBaselineBeforeCandidatesAndIsReproducible(t *testing.T) {
+	cfg := testConfig(t)
+	evaluator := &fakeEvaluator{results: map[string]EvaluationSummary{
+		phaseKey(PhaseBaselineTrain, 0):       evalSummary(0.5, caseResult("train", 0.5, false)),
+		phaseKey(PhaseBaselineValidation, 0):  evalSummary(0.6, caseResult("valid", 0.6, true)),
+		phaseKey(PhaseCandidateTrain, 1):      evalSummary(0.8, caseResult("train", 0.8, true)),
+		phaseKey(PhaseCandidateValidation, 1): evalSummary(0.8, caseResult("valid", 0.8, true)),
+	}}
+	pipeline := &Pipeline{
+		Evaluator: evaluator,
+		Optimizer: fakeOptimizer{candidates: []Candidate{{Round: 1, Prompt: "better"}}},
+		Clock: &fixedClock{ticks: []time.Time{
+			time.Unix(100, 0).UTC(),
+			time.Unix(101, 0).UTC(),
+		}},
+	}
+
+	first, err := pipeline.Run(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, PhaseBaselineTrain, evaluator.calls[0].Phase)
+	assert.Equal(t, PhaseBaselineValidation, evaluator.calls[1].Phase)
+	assert.Equal(t, PhaseCandidateTrain, evaluator.calls[2].Phase)
+	assert.Equal(t, PhaseCandidateValidation, evaluator.calls[3].Phase)
+	assert.True(t, first.Report.GateDecision.Accepted)
+
+	evaluator.calls = nil
+	pipeline.Clock = &fixedClock{ticks: []time.Time{time.Unix(100, 0).UTC(), time.Unix(101, 0).UTC()}}
+	second, err := pipeline.Run(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, first.Report.Run.StartedAt, second.Report.Run.StartedAt)
+	assert.Equal(t, first.Report.GateDecision, second.Report.GateDecision)
+}
+
+func TestPipelineRejectsOverfitCandidate(t *testing.T) {
+	cfg := testConfig(t)
+	evaluator := &fakeEvaluator{results: map[string]EvaluationSummary{
+		phaseKey(PhaseBaselineTrain, 0):      evalSummary(0.4, caseResult("train", 0.4, false)),
+		phaseKey(PhaseBaselineValidation, 0): evalSummary(0.8, caseResult("critical", 0.8, true)),
+		phaseKey(PhaseCandidateTrain, 1):     evalSummary(0.9, caseResult("train", 0.9, true)),
+		phaseKey(PhaseCandidateValidation, 1): evalSummary(0.5, CaseResult{
+			EvalID:   "critical",
+			Critical: true,
+			Score:    0,
+			Passed:   false,
+			HardFail: true,
+			MetricResults: []MetricResult{{
+				Name:     "quality",
+				Score:    0,
+				Passed:   false,
+				HardFail: true,
+				Reason:   "format error",
+			}},
+			FailureReasons: []string{"format error"},
+		}),
+	}}
+	pipeline := &Pipeline{
+		Evaluator: evaluator,
+		Optimizer: fakeOptimizer{candidates: []Candidate{{Round: 1, Prompt: "overfit"}}},
+		Clock: &fixedClock{ticks: []time.Time{
+			time.Unix(100, 0).UTC(),
+			time.Unix(101, 0).UTC(),
+		}},
+	}
+
+	result, err := pipeline.Run(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.False(t, result.Report.GateDecision.Accepted)
+	assert.Contains(t, result.Report.GateDecision.FailedRules, "no_new_hard_fails")
+	assert.Contains(t, result.Report.GateDecision.FailedRules, "critical_case_non_regression")
+	assert.Nil(t, result.Report.SelectedCandidate)
+}

--- a/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
@@ -133,3 +133,92 @@ func TestPipelineFinalReportUsesSelectedAcceptedCandidate(t *testing.T) {
 	assert.False(t, result.Report.Candidates[1].GateDecision.Accepted)
 	assert.Contains(t, result.Report.Candidates[1].GateDecision.FailedRules, "max_calls")
 }
+
+func TestPipelineRequiresValidConfigAndDependencies(t *testing.T) {
+	cfg := testConfig(t)
+
+	_, err := (&Pipeline{}).Run(context.Background(), cfg)
+	require.ErrorContains(t, err, "evaluator is nil")
+
+	_, err = (&Pipeline{Evaluator: &fakeEvaluator{}}).Run(context.Background(), cfg)
+	require.ErrorContains(t, err, "optimizer is nil")
+
+	cfg.AppName = ""
+	_, err = (&Pipeline{Evaluator: &fakeEvaluator{}, Optimizer: fakeOptimizer{}}).Run(context.Background(), cfg)
+	require.ErrorContains(t, err, "missing required config fields")
+}
+
+func TestPipelineReportsNoCandidateGenerated(t *testing.T) {
+	cfg := testConfig(t)
+	evaluator := &fakeEvaluator{results: map[string]EvaluationSummary{
+		phaseKey(PhaseBaselineTrain, 0):      evalSummary(0.5, caseResult("train", 0.5, true)),
+		phaseKey(PhaseBaselineValidation, 0): evalSummary(0.6, caseResult("valid", 0.6, true)),
+	}}
+	pipeline := &Pipeline{
+		Evaluator: evaluator,
+		Optimizer: fakeOptimizer{},
+	}
+
+	result, err := pipeline.Run(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Nil(t, result.Report.SelectedCandidate)
+	assert.False(t, result.Report.GateDecision.Accepted)
+	assert.Contains(t, result.Report.GateDecision.Reasons, "no candidate generated")
+	assert.Empty(t, result.Report.Delta.Cases)
+}
+
+func TestPipelineLimitsCandidatesToMaxRounds(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.PromptIter.MaxRounds = 1
+	evaluator := &fakeEvaluator{results: map[string]EvaluationSummary{
+		phaseKey(PhaseBaselineTrain, 0):       evalSummary(0.5, caseResult("train", 0.5, false)),
+		phaseKey(PhaseBaselineValidation, 0):  evalSummary(0.6, caseResult("valid", 0.6, true)),
+		phaseKey(PhaseCandidateTrain, 1):      evalSummary(0.8, caseResult("train", 0.8, true)),
+		phaseKey(PhaseCandidateValidation, 1): evalSummary(0.8, caseResult("valid", 0.8, true)),
+	}}
+	pipeline := &Pipeline{
+		Evaluator: evaluator,
+		Optimizer: fakeOptimizer{candidates: []Candidate{
+			{Round: 1, Prompt: "used"},
+			{Round: 2, Prompt: "truncated"},
+		}},
+		Clock: &fixedClock{ticks: []time.Time{
+			time.Unix(100, 0).UTC(),
+			time.Unix(101, 0).UTC(),
+		}},
+	}
+
+	result, err := pipeline.Run(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Len(t, result.Report.Candidates, 1)
+	assert.Equal(t, "used", result.Report.Candidates[0].Prompt)
+	require.Len(t, evaluator.calls, 4)
+	assert.Equal(t, 1, evaluator.calls[3].Round)
+}
+
+func TestPipelinePropagatesOptimizerAndEvaluatorErrors(t *testing.T) {
+	cfg := testConfig(t)
+	baseResults := map[string]EvaluationSummary{
+		phaseKey(PhaseBaselineTrain, 0):      evalSummary(0.5, caseResult("train", 0.5, true)),
+		phaseKey(PhaseBaselineValidation, 0): evalSummary(0.6, caseResult("valid", 0.6, true)),
+	}
+
+	_, err := (&Pipeline{
+		Evaluator: &fakeEvaluator{results: baseResults},
+		Optimizer: fakeOptimizer{err: errFake},
+	}).Run(context.Background(), cfg)
+	require.ErrorContains(t, err, "generate candidates")
+
+	_, err = (&Pipeline{
+		Evaluator: &fakeEvaluator{
+			results: baseResults,
+			errors:  map[string]error{phaseKey(PhaseCandidateValidation, 1): errFake},
+		},
+		Optimizer: fakeOptimizer{candidates: []Candidate{{Round: 1, Prompt: "candidate"}}},
+		Clock: &fixedClock{ticks: []time.Time{
+			time.Unix(100, 0).UTC(),
+			time.Unix(101, 0).UTC(),
+		}},
+	}).Run(context.Background(), cfg)
+	require.ErrorContains(t, err, "evaluate candidate_validation validation")
+}

--- a/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
@@ -84,7 +84,52 @@ func TestPipelineRejectsOverfitCandidate(t *testing.T) {
 	result, err := pipeline.Run(context.Background(), cfg)
 	require.NoError(t, err)
 	assert.False(t, result.Report.GateDecision.Accepted)
-	assert.Contains(t, result.Report.GateDecision.FailedRules, "no_new_hard_fails")
-	assert.Contains(t, result.Report.GateDecision.FailedRules, "critical_case_non_regression")
+	assert.Contains(t, result.Report.GateDecision.Reasons, "no candidate accepted by gate")
+	require.Len(t, result.Report.Candidates, 1)
+	assert.Contains(t, result.Report.Candidates[0].GateDecision.FailedRules, "no_new_hard_fails")
+	assert.Contains(t, result.Report.Candidates[0].GateDecision.FailedRules, "critical_case_non_regression")
 	assert.Nil(t, result.Report.SelectedCandidate)
+}
+
+func TestPipelineFinalReportUsesSelectedAcceptedCandidate(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Gate.MaxCalls = 2
+	evaluator := &fakeEvaluator{results: map[string]EvaluationSummary{
+		phaseKey(PhaseBaselineTrain, 0):      evalSummary(0.5, caseResult("train", 0.5, false)),
+		phaseKey(PhaseBaselineValidation, 0): evalSummary(0.6, caseResult("valid", 0.6, true)),
+		phaseKey(PhaseCandidateTrain, 1):     evalSummary(0.7, caseResult("train", 0.7, true)),
+		phaseKey(PhaseCandidateValidation, 1): evalSummary(0.75,
+			caseResult("valid", 0.75, true),
+		),
+		phaseKey(PhaseCandidateTrain, 2): evalSummary(0.95,
+			caseResult("train-a", 0.95, true),
+			caseResult("train-b", 0.95, true),
+		),
+		phaseKey(PhaseCandidateValidation, 2): evalSummary(0.9,
+			caseResult("valid", 0.9, true),
+			caseResult("extra", 0.9, true),
+		),
+	}}
+	pipeline := &Pipeline{
+		Evaluator: evaluator,
+		Optimizer: fakeOptimizer{candidates: []Candidate{
+			{Round: 1, Prompt: "accepted"},
+			{Round: 2, Prompt: "higher-score-but-too-expensive"},
+		}},
+		Clock: &fixedClock{ticks: []time.Time{
+			time.Unix(100, 0).UTC(),
+			time.Unix(101, 0).UTC(),
+		}},
+	}
+
+	result, err := pipeline.Run(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result.Report.SelectedCandidate)
+	assert.Equal(t, 1, result.Report.SelectedCandidate.Round)
+	assert.True(t, result.Report.GateDecision.Accepted)
+	assert.Equal(t, result.Report.SelectedCandidate.GateDecision, result.Report.GateDecision)
+	require.Len(t, result.Report.Delta.Cases, 1)
+	assert.Equal(t, 0.75, result.Report.Delta.Cases[0].CandidateScore)
+	assert.False(t, result.Report.Candidates[1].GateDecision.Accepted)
+	assert.Contains(t, result.Report.Candidates[1].GateDecision.FailedRules, "max_calls")
 }

--- a/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/pipeline_test.go
@@ -211,8 +211,12 @@ func TestPipelinePropagatesOptimizerAndEvaluatorErrors(t *testing.T) {
 
 	_, err = (&Pipeline{
 		Evaluator: &fakeEvaluator{
-			results: baseResults,
-			errors:  map[string]error{phaseKey(PhaseCandidateValidation, 1): errFake},
+			results: map[string]EvaluationSummary{
+				phaseKey(PhaseBaselineTrain, 0):      baseResults[phaseKey(PhaseBaselineTrain, 0)],
+				phaseKey(PhaseBaselineValidation, 0): baseResults[phaseKey(PhaseBaselineValidation, 0)],
+				phaseKey(PhaseCandidateTrain, 1):     evalSummary(0.7, caseResult("train", 0.7, true)),
+			},
+			errors: map[string]error{phaseKey(PhaseCandidateValidation, 1): errFake},
 		},
 		Optimizer: fakeOptimizer{candidates: []Candidate{{Round: 1, Prompt: "candidate"}}},
 		Clock: &fixedClock{ticks: []time.Time{
@@ -221,4 +225,44 @@ func TestPipelinePropagatesOptimizerAndEvaluatorErrors(t *testing.T) {
 		}},
 	}).Run(context.Background(), cfg)
 	require.ErrorContains(t, err, "evaluate candidate_validation validation")
+}
+
+func TestPipelineRejectsInvalidEvaluatorSummaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary EvaluationSummary
+		wantErr string
+	}{
+		{
+			name:    "empty cases",
+			summary: evalSummary(0.5),
+			wantErr: "cases are empty",
+		},
+		{
+			name:    "empty eval ID",
+			summary: evalSummary(0.5, caseResult(" ", 0.5, true)),
+			wantErr: "case 0 has an empty eval ID",
+		},
+		{
+			name: "duplicate eval ID",
+			summary: evalSummary(0.5,
+				caseResult("duplicate", 0.4, false),
+				caseResult("duplicate", 0.6, true),
+			),
+			wantErr: `duplicate eval ID "duplicate"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig(t)
+			_, err := (&Pipeline{
+				Evaluator: &fakeEvaluator{results: map[string]EvaluationSummary{
+					phaseKey(PhaseBaselineTrain, 0): tt.summary,
+				}},
+				Optimizer: fakeOptimizer{},
+			}).Run(context.Background(), cfg)
+			require.ErrorContains(t, err, "evaluate baseline_train train: invalid summary")
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
 }

--- a/evaluation/workflow/promptiter/regressionloop/promptiter.go
+++ b/evaluation/workflow/promptiter/regressionloop/promptiter.go
@@ -1,0 +1,32 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+
+// CandidatesFromPromptIterResult adapts existing PromptIter engine rounds into regression loop candidates.
+func CandidatesFromPromptIterResult(result *promptiterengine.RunResult) []Candidate {
+	if result == nil {
+		return nil
+	}
+	candidates := make([]Candidate, 0, len(result.Rounds))
+	for _, round := range result.Rounds {
+		candidate := Candidate{Round: round.Round}
+		if round.OutputProfile != nil && len(round.OutputProfile.Overrides) > 0 {
+			if round.OutputProfile.Overrides[0].Value.Text != nil {
+				candidate.Prompt = *round.OutputProfile.Overrides[0].Value.Text
+			}
+		}
+		if round.Acceptance != nil {
+			candidate.Reason = round.Acceptance.Reason
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates
+}

--- a/evaluation/workflow/promptiter/regressionloop/promptiter.go
+++ b/evaluation/workflow/promptiter/regressionloop/promptiter.go
@@ -8,20 +8,21 @@
 
 package regressionloop
 
-import promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
 
 // CandidatesFromPromptIterResult adapts existing PromptIter engine rounds into regression loop candidates.
-func CandidatesFromPromptIterResult(result *promptiterengine.RunResult) []Candidate {
+func CandidatesFromPromptIterResult(result *promptiterengine.RunResult, promptSurfaceID string) []Candidate {
 	if result == nil {
 		return nil
 	}
 	candidates := make([]Candidate, 0, len(result.Rounds))
 	for _, round := range result.Rounds {
 		candidate := Candidate{Round: round.Round}
-		if round.OutputProfile != nil && len(round.OutputProfile.Overrides) > 0 {
-			if round.OutputProfile.Overrides[0].Value.Text != nil {
-				candidate.Prompt = *round.OutputProfile.Overrides[0].Value.Text
-			}
+		if round.OutputProfile != nil {
+			candidate.Prompt = promptTextForSurface(round.OutputProfile.Overrides, promptSurfaceID)
 		}
 		if round.Acceptance != nil {
 			candidate.Reason = round.Acceptance.Reason
@@ -29,4 +30,14 @@ func CandidatesFromPromptIterResult(result *promptiterengine.RunResult) []Candid
 		candidates = append(candidates, candidate)
 	}
 	return candidates
+}
+
+func promptTextForSurface(overrides []promptiter.SurfaceOverride, surfaceID string) string {
+	for _, override := range overrides {
+		if override.SurfaceID != surfaceID || override.Value.Text == nil {
+			continue
+		}
+		return *override.Value.Text
+	}
+	return ""
 }

--- a/evaluation/workflow/promptiter/regressionloop/promptiter.go
+++ b/evaluation/workflow/promptiter/regressionloop/promptiter.go
@@ -20,10 +20,14 @@ func CandidatesFromPromptIterResult(result *promptiterengine.RunResult, promptSu
 	}
 	candidates := make([]Candidate, 0, len(result.Rounds))
 	for _, round := range result.Rounds {
-		candidate := Candidate{Round: round.Round}
-		if round.OutputProfile != nil {
-			candidate.Prompt = promptTextForSurface(round.OutputProfile.Overrides, promptSurfaceID)
+		if round.OutputProfile == nil {
+			continue
 		}
+		prompt, found := promptTextForSurface(round.OutputProfile.Overrides, promptSurfaceID)
+		if !found {
+			continue
+		}
+		candidate := Candidate{Round: round.Round, Prompt: prompt}
 		if round.Acceptance != nil {
 			candidate.Reason = round.Acceptance.Reason
 		}
@@ -32,12 +36,12 @@ func CandidatesFromPromptIterResult(result *promptiterengine.RunResult, promptSu
 	return candidates
 }
 
-func promptTextForSurface(overrides []promptiter.SurfaceOverride, surfaceID string) string {
+func promptTextForSurface(overrides []promptiter.SurfaceOverride, surfaceID string) (string, bool) {
 	for _, override := range overrides {
 		if override.SurfaceID != surfaceID || override.Value.Text == nil {
 			continue
 		}
-		return *override.Value.Text
+		return *override.Value.Text, true
 	}
-	return ""
+	return "", false
 }

--- a/evaluation/workflow/promptiter/regressionloop/promptiter_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/promptiter_test.go
@@ -19,17 +19,24 @@ import (
 )
 
 func TestCandidatesFromPromptIterResult(t *testing.T) {
-	assert.Nil(t, CandidatesFromPromptIterResult(nil))
+	assert.Nil(t, CandidatesFromPromptIterResult(nil, "agent#instruction"))
 
 	prompt := "candidate prompt"
+	wrongPrompt := "wrong prompt"
 	result := &promptiterengine.RunResult{
 		Rounds: []promptiterengine.RoundResult{
 			{
 				Round: 1,
-				OutputProfile: &promptiter.Profile{Overrides: []promptiter.SurfaceOverride{{
-					SurfaceID: "agent#instruction",
-					Value:     structure.SurfaceValue{Text: &prompt},
-				}}},
+				OutputProfile: &promptiter.Profile{Overrides: []promptiter.SurfaceOverride{
+					{
+						SurfaceID: "agent#model",
+						Value:     structure.SurfaceValue{Text: &wrongPrompt},
+					},
+					{
+						SurfaceID: "agent#instruction",
+						Value:     structure.SurfaceValue{Text: &prompt},
+					},
+				}},
 				Acceptance: &promptiterengine.AcceptanceDecision{Reason: "accepted by promptiter"},
 			},
 			{
@@ -42,7 +49,7 @@ func TestCandidatesFromPromptIterResult(t *testing.T) {
 		},
 	}
 
-	candidates := CandidatesFromPromptIterResult(result)
+	candidates := CandidatesFromPromptIterResult(result, "agent#instruction")
 	require.Len(t, candidates, 3)
 	assert.Equal(t, Candidate{Round: 1, Prompt: prompt, Reason: "accepted by promptiter"}, candidates[0])
 	assert.Equal(t, Candidate{Round: 2}, candidates[1])

--- a/evaluation/workflow/promptiter/regressionloop/promptiter_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/promptiter_test.go
@@ -1,0 +1,50 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+func TestCandidatesFromPromptIterResult(t *testing.T) {
+	assert.Nil(t, CandidatesFromPromptIterResult(nil))
+
+	prompt := "candidate prompt"
+	result := &promptiterengine.RunResult{
+		Rounds: []promptiterengine.RoundResult{
+			{
+				Round: 1,
+				OutputProfile: &promptiter.Profile{Overrides: []promptiter.SurfaceOverride{{
+					SurfaceID: "agent#instruction",
+					Value:     structure.SurfaceValue{Text: &prompt},
+				}}},
+				Acceptance: &promptiterengine.AcceptanceDecision{Reason: "accepted by promptiter"},
+			},
+			{
+				Round:         2,
+				OutputProfile: &promptiter.Profile{Overrides: []promptiter.SurfaceOverride{{SurfaceID: "agent#model"}}},
+			},
+			{
+				Round: 3,
+			},
+		},
+	}
+
+	candidates := CandidatesFromPromptIterResult(result)
+	require.Len(t, candidates, 3)
+	assert.Equal(t, Candidate{Round: 1, Prompt: prompt, Reason: "accepted by promptiter"}, candidates[0])
+	assert.Equal(t, Candidate{Round: 2}, candidates[1])
+	assert.Equal(t, Candidate{Round: 3}, candidates[2])
+}

--- a/evaluation/workflow/promptiter/regressionloop/promptiter_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/promptiter_test.go
@@ -23,6 +23,7 @@ func TestCandidatesFromPromptIterResult(t *testing.T) {
 
 	prompt := "candidate prompt"
 	wrongPrompt := "wrong prompt"
+	emptyPrompt := ""
 	result := &promptiterengine.RunResult{
 		Rounds: []promptiterengine.RoundResult{
 			{
@@ -46,12 +47,25 @@ func TestCandidatesFromPromptIterResult(t *testing.T) {
 			{
 				Round: 3,
 			},
+			{
+				Round: 4,
+				OutputProfile: &promptiter.Profile{Overrides: []promptiter.SurfaceOverride{{
+					SurfaceID: "agent#instruction",
+				}}},
+			},
+			{
+				Round: 5,
+				OutputProfile: &promptiter.Profile{Overrides: []promptiter.SurfaceOverride{{
+					SurfaceID: "agent#instruction",
+					Value:     structure.SurfaceValue{Text: &emptyPrompt},
+				}}},
+				Acceptance: &promptiterengine.AcceptanceDecision{Reason: "intentionally empty"},
+			},
 		},
 	}
 
 	candidates := CandidatesFromPromptIterResult(result, "agent#instruction")
-	require.Len(t, candidates, 3)
+	require.Len(t, candidates, 2)
 	assert.Equal(t, Candidate{Round: 1, Prompt: prompt, Reason: "accepted by promptiter"}, candidates[0])
-	assert.Equal(t, Candidate{Round: 2}, candidates[1])
-	assert.Equal(t, Candidate{Round: 3}, candidates[2])
+	assert.Equal(t, Candidate{Round: 5, Prompt: "", Reason: "intentionally empty"}, candidates[1])
 }

--- a/evaluation/workflow/promptiter/regressionloop/report.go
+++ b/evaluation/workflow/promptiter/regressionloop/report.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // WriteReports writes JSON and Markdown reports to disk.
@@ -51,7 +52,7 @@ func MarkdownReport(report *Report) string {
 	}
 	fmt.Fprintf(&buf, "# Optimization Report\n\n")
 	fmt.Fprintf(&buf, "Decision: **%s**\n\n", decision)
-	fmt.Fprintf(&buf, "App: `%s`\n\n", report.Run.AppName)
+	fmt.Fprintf(&buf, "App: %s\n\n", markdownInlineCode(report.Run.AppName))
 	fmt.Fprintf(&buf, "Seed: `%d`\n\n", report.Run.Seed)
 	fmt.Fprintf(&buf, "Runner: `%s`\n\n", report.Run.Runner.Mode)
 	fmt.Fprintf(&buf, "Duration: `%dms`\n\n", report.Run.DurationMS)
@@ -66,14 +67,14 @@ func MarkdownReport(report *Report) string {
 	fmt.Fprintf(&buf, "- Accepted: `%t`\n", report.GateDecision.Accepted)
 	fmt.Fprintf(&buf, "- Validation score delta: `%.2f`\n", report.GateDecision.ScoreDelta)
 	for _, reason := range report.GateDecision.Reasons {
-		fmt.Fprintf(&buf, "- Reason: %s\n", reason)
+		fmt.Fprintf(&buf, "- Reason: %s\n", markdownText(reason))
 	}
 	fmt.Fprintf(&buf, "\n## Validation Delta\n\n")
 	fmt.Fprintf(&buf, "| Case | Baseline | Candidate | Delta | Transition | New hard fail | Critical regression |\n")
 	fmt.Fprintf(&buf, "| --- | ---: | ---: | ---: | --- | --- | --- |\n")
 	for _, delta := range report.Delta.Cases {
-		fmt.Fprintf(&buf, "| `%s` | %.2f | %.2f | %.2f | `%s` | `%t` | `%t` |\n",
-			delta.EvalID,
+		fmt.Fprintf(&buf, "| %s | %.2f | %.2f | %.2f | `%s` | `%t` | `%t` |\n",
+			markdownTableCell(delta.EvalID),
 			delta.BaselineScore,
 			delta.CandidateScore,
 			delta.ScoreDelta,
@@ -90,9 +91,9 @@ func MarkdownReport(report *Report) string {
 	for _, candidate := range report.Candidates {
 		fmt.Fprintf(&buf, "### Round %d\n\n", candidate.Round)
 		fmt.Fprintf(&buf, "- Accepted: `%t`\n", candidate.GateDecision.Accepted)
-		fmt.Fprintf(&buf, "- Prompt: `%s`\n", candidate.Prompt)
+		fmt.Fprintf(&buf, "- Prompt:\n\n%s\n", markdownCodeBlock(candidate.Prompt))
 		for _, reason := range candidate.GateDecision.Reasons {
-			fmt.Fprintf(&buf, "- Gate reason: %s\n", reason)
+			fmt.Fprintf(&buf, "- Gate reason: %s\n", markdownText(reason))
 		}
 		fmt.Fprintf(&buf, "\n")
 	}
@@ -102,9 +103,56 @@ func MarkdownReport(report *Report) string {
 	fmt.Fprintf(&buf, "- Total latency: `%dms`\n", report.LatencySummary.TotalMS)
 	fmt.Fprintf(&buf, "\n## Artifacts\n\n")
 	for _, artifact := range report.Artifacts {
-		fmt.Fprintf(&buf, "- `%s`\n", artifact)
+		fmt.Fprintf(&buf, "- %s\n", markdownInlineCode(artifact))
 	}
 	return buf.String()
+}
+
+func markdownText(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "`", "\\`")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\r\n", "<br>")
+	return strings.ReplaceAll(value, "\n", "<br>")
+}
+
+func markdownTableCell(value string) string {
+	return markdownText(value)
+}
+
+func markdownInlineCode(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	fence := strings.Repeat("`", longestBacktickRun(value)+1)
+	if len(fence) < 1 {
+		fence = "`"
+	}
+	return fence + value + fence
+}
+
+func markdownCodeBlock(value string) string {
+	fenceLength := longestBacktickRun(value) + 1
+	if fenceLength < 3 {
+		fenceLength = 3
+	}
+	fence := strings.Repeat("`", fenceLength)
+	return fence + "text\n" + value + "\n" + fence
+}
+
+func longestBacktickRun(value string) int {
+	longest := 0
+	current := 0
+	for _, r := range value {
+		if r == '`' {
+			current++
+			if current > longest {
+				longest = current
+			}
+			continue
+		}
+		current = 0
+	}
+	return longest
 }
 
 // BuildAttributionStats counts categories across all report evaluations.

--- a/evaluation/workflow/promptiter/regressionloop/report.go
+++ b/evaluation/workflow/promptiter/regressionloop/report.go
@@ -1,0 +1,163 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// WriteReports writes JSON and Markdown reports to disk.
+func WriteReports(report *Report, jsonPath, markdownPath string) error {
+	if report == nil {
+		return fmt.Errorf("report is nil")
+	}
+	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
+		return fmt.Errorf("create json report dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(markdownPath), 0o755); err != nil {
+		return fmt.Errorf("create markdown report dir: %w", err)
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode json report: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return fmt.Errorf("write json report: %w", err)
+	}
+	if err := os.WriteFile(markdownPath, []byte(MarkdownReport(report)), 0o644); err != nil {
+		return fmt.Errorf("write markdown report: %w", err)
+	}
+	return nil
+}
+
+// MarkdownReport renders a human-readable audit report.
+func MarkdownReport(report *Report) string {
+	var buf bytes.Buffer
+	decision := "REJECT"
+	if report.GateDecision.Accepted {
+		decision = "ACCEPT"
+	}
+	fmt.Fprintf(&buf, "# Optimization Report\n\n")
+	fmt.Fprintf(&buf, "Decision: **%s**\n\n", decision)
+	fmt.Fprintf(&buf, "App: `%s`\n\n", report.Run.AppName)
+	fmt.Fprintf(&buf, "Seed: `%d`\n\n", report.Run.Seed)
+	fmt.Fprintf(&buf, "Runner: `%s`\n\n", report.Run.Runner.Mode)
+	fmt.Fprintf(&buf, "Duration: `%dms`\n\n", report.Run.DurationMS)
+	fmt.Fprintf(&buf, "## Score Summary\n\n")
+	fmt.Fprintf(&buf, "| Phase | Train | Validation |\n")
+	fmt.Fprintf(&buf, "| --- | ---: | ---: |\n")
+	fmt.Fprintf(&buf, "| Baseline | %.2f | %.2f |\n", report.Baseline.Train.Score, report.Baseline.Validation.Score)
+	for _, candidate := range report.Candidates {
+		fmt.Fprintf(&buf, "| Candidate %d | %.2f | %.2f |\n", candidate.Round, candidate.Train.Score, candidate.Validation.Score)
+	}
+	fmt.Fprintf(&buf, "\n## Gate Decision\n\n")
+	fmt.Fprintf(&buf, "- Accepted: `%t`\n", report.GateDecision.Accepted)
+	fmt.Fprintf(&buf, "- Validation score delta: `%.2f`\n", report.GateDecision.ScoreDelta)
+	for _, reason := range report.GateDecision.Reasons {
+		fmt.Fprintf(&buf, "- Reason: %s\n", reason)
+	}
+	fmt.Fprintf(&buf, "\n## Validation Delta\n\n")
+	fmt.Fprintf(&buf, "| Case | Baseline | Candidate | Delta | Transition | New hard fail | Critical regression |\n")
+	fmt.Fprintf(&buf, "| --- | ---: | ---: | ---: | --- | --- | --- |\n")
+	for _, delta := range report.Delta.Cases {
+		fmt.Fprintf(&buf, "| `%s` | %.2f | %.2f | %.2f | `%s` | `%t` | `%t` |\n",
+			delta.EvalID,
+			delta.BaselineScore,
+			delta.CandidateScore,
+			delta.ScoreDelta,
+			delta.Transition,
+			delta.NewHardFail,
+			delta.CriticalRegression,
+		)
+	}
+	fmt.Fprintf(&buf, "\n## Failure Attribution\n\n")
+	for _, key := range sortedStatKeys(report.FailureAttributionStats) {
+		fmt.Fprintf(&buf, "- `%s`: %d\n", key, report.FailureAttributionStats[key])
+	}
+	fmt.Fprintf(&buf, "\n## Candidate Rounds\n\n")
+	for _, candidate := range report.Candidates {
+		fmt.Fprintf(&buf, "### Round %d\n\n", candidate.Round)
+		fmt.Fprintf(&buf, "- Accepted: `%t`\n", candidate.GateDecision.Accepted)
+		fmt.Fprintf(&buf, "- Prompt: `%s`\n", candidate.Prompt)
+		for _, reason := range candidate.GateDecision.Reasons {
+			fmt.Fprintf(&buf, "- Gate reason: %s\n", reason)
+		}
+		fmt.Fprintf(&buf, "\n")
+	}
+	fmt.Fprintf(&buf, "## Cost and Latency\n\n")
+	fmt.Fprintf(&buf, "- Calls: `%d`\n", report.CostSummary.Calls)
+	fmt.Fprintf(&buf, "- Estimated cost: `%.4f`\n", report.CostSummary.EstimatedCost)
+	fmt.Fprintf(&buf, "- Total latency: `%dms`\n", report.LatencySummary.TotalMS)
+	fmt.Fprintf(&buf, "\n## Artifacts\n\n")
+	for _, artifact := range report.Artifacts {
+		fmt.Fprintf(&buf, "- `%s`\n", artifact)
+	}
+	return buf.String()
+}
+
+// BuildAttributionStats counts categories across all report evaluations.
+func BuildAttributionStats(baseline EvaluationPair, candidates []CandidateRound) map[string]int {
+	stats := map[string]int{}
+	addEvaluationStats(stats, baseline.Train)
+	addEvaluationStats(stats, baseline.Validation)
+	for _, candidate := range candidates {
+		addEvaluationStats(stats, candidate.Train)
+		addEvaluationStats(stats, candidate.Validation)
+	}
+	return stats
+}
+
+// SumCost returns total cost across baseline and candidates.
+func SumCost(baseline EvaluationPair, candidates []CandidateRound) CostSummary {
+	total := CostSummary{}
+	addCost(&total, baseline.Train.Cost)
+	addCost(&total, baseline.Validation.Cost)
+	for _, candidate := range candidates {
+		addCost(&total, candidate.Cost)
+	}
+	return total
+}
+
+// SumLatency returns total latency across baseline and candidates.
+func SumLatency(baseline EvaluationPair, candidates []CandidateRound) LatencySummary {
+	total := LatencySummary{}
+	total.TotalMS += baseline.Train.Latency.TotalMS + baseline.Validation.Latency.TotalMS
+	for _, candidate := range candidates {
+		total.TotalMS += candidate.Latency.TotalMS
+	}
+	return total
+}
+
+func addEvaluationStats(stats map[string]int, summary EvaluationSummary) {
+	for _, c := range summary.Cases {
+		for _, attribution := range c.Attributions {
+			stats[string(attribution.Category)]++
+		}
+	}
+}
+
+func addCost(total *CostSummary, cost CostSummary) {
+	total.Calls += cost.Calls
+	total.EstimatedCost += cost.EstimatedCost
+}
+
+func sortedStatKeys(stats map[string]int) []string {
+	keys := make([]string, 0, len(stats))
+	for key := range stats {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/evaluation/workflow/promptiter/regressionloop/report.go
+++ b/evaluation/workflow/promptiter/regressionloop/report.go
@@ -23,6 +23,9 @@ func WriteReports(report *Report, jsonPath, markdownPath string) error {
 	if report == nil {
 		return fmt.Errorf("report is nil")
 	}
+	if err := validateReportPaths(jsonPath, markdownPath); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
 		return fmt.Errorf("create json report dir: %w", err)
 	}

--- a/evaluation/workflow/promptiter/regressionloop/report_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/report_test.go
@@ -37,6 +37,11 @@ func TestWriteReports(t *testing.T) {
 	assert.Contains(t, string(md), "candidate satisfies")
 }
 
+func TestWriteReportsRejectsNilReport(t *testing.T) {
+	err := WriteReports(nil, "optimization_report.json", "optimization_report.md")
+	require.ErrorContains(t, err, "report is nil")
+}
+
 func sampleReport() *Report {
 	base := evalSummary(0.6, caseResult("case", 0.6, true))
 	candidate := evalSummary(0.8, caseResult("case", 0.8, true))

--- a/evaluation/workflow/promptiter/regressionloop/report_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/report_test.go
@@ -1,0 +1,61 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReports(t *testing.T) {
+	dir := t.TempDir()
+	report := sampleReport()
+	jsonPath := filepath.Join(dir, "optimization_report.json")
+	mdPath := filepath.Join(dir, "optimization_report.md")
+
+	require.NoError(t, WriteReports(report, jsonPath, mdPath))
+	data, err := os.ReadFile(jsonPath)
+	require.NoError(t, err)
+	var decoded Report
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "test-app", decoded.Run.AppName)
+	md, err := os.ReadFile(mdPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(md), "Decision: **ACCEPT**")
+	assert.Contains(t, string(md), "Validation Delta")
+	assert.Contains(t, string(md), "candidate satisfies")
+}
+
+func sampleReport() *Report {
+	base := evalSummary(0.6, caseResult("case", 0.6, true))
+	candidate := evalSummary(0.8, caseResult("case", 0.8, true))
+	deltas, summary := ComputeDeltas(base, candidate, nil)
+	gate := EvaluateGate(GatePolicy{MinValidationScoreGain: 0.1, AllowNewHardFails: false, BlockCriticalRegression: true}, base, candidate, deltas, CostSummary{}, LatencySummary{})
+	round := CandidateRound{Round: 1, Prompt: "better", Train: candidate, Validation: candidate, Delta: deltas, GateDecision: gate}
+	return &Report{
+		Run: RunMetadata{
+			AppName: "test-app",
+			Seed:    42,
+			Runner:  RunnerConfig{Mode: RunnerModeFake},
+		},
+		Baseline:                EvaluationPair{Train: base, Validation: base},
+		Candidates:              []CandidateRound{round},
+		SelectedCandidate:       &round,
+		Delta:                   DeltaReport{Summary: summary, Cases: deltas},
+		GateDecision:            gate,
+		FailureAttributionStats: map[string]int{"final_response_mismatch": 1},
+		CostSummary:             CostSummary{Calls: 1},
+		LatencySummary:          LatencySummary{TotalMS: 1},
+	}
+}

--- a/evaluation/workflow/promptiter/regressionloop/report_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/report_test.go
@@ -42,6 +42,24 @@ func TestWriteReportsRejectsNilReport(t *testing.T) {
 	require.ErrorContains(t, err, "report is nil")
 }
 
+func TestMarkdownReportEscapesDynamicText(t *testing.T) {
+	report := sampleReport()
+	report.Run.AppName = "app`name\nnext"
+	report.GateDecision.Reasons = []string{"reason | with `code`\nnext"}
+	report.Delta.Cases[0].EvalID = "case|`id`\nnext"
+	report.Candidates[0].Prompt = "first `line` | value\n```\nlast"
+	report.Candidates[0].GateDecision.Reasons = []string{"gate | reason\nnext"}
+	report.Artifacts = []string{"path`name\nnext"}
+
+	markdown := MarkdownReport(report)
+	assert.Contains(t, markdown, "App: ``app`name next``")
+	assert.Contains(t, markdown, "- Reason: reason \\| with \\`code\\`<br>next")
+	assert.Contains(t, markdown, "| case\\|\\`id\\`<br>next |")
+	assert.Contains(t, markdown, "````text\nfirst `line` | value\n```\nlast\n````")
+	assert.Contains(t, markdown, "- Gate reason: gate \\| reason<br>next")
+	assert.Contains(t, markdown, "- ``path`name next``")
+}
+
 func sampleReport() *Report {
 	base := evalSummary(0.6, caseResult("case", 0.6, true))
 	candidate := evalSummary(0.8, caseResult("case", 0.8, true))

--- a/evaluation/workflow/promptiter/regressionloop/report_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/report_test.go
@@ -42,6 +42,21 @@ func TestWriteReportsRejectsNilReport(t *testing.T) {
 	require.ErrorContains(t, err, "report is nil")
 }
 
+func TestWriteReportsRejectsCollidingPaths(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "optimization_report")
+	markdownPath := dir + string(filepath.Separator) + "nested" + string(filepath.Separator) +
+		".." + string(filepath.Separator) + "optimization_report"
+	require.NoError(t, os.WriteFile(jsonPath, []byte("existing"), 0o644))
+
+	err := WriteReports(sampleReport(), jsonPath, markdownPath)
+	require.ErrorContains(t, err, "output.jsonReport and output.markdownReport must be distinct")
+	data, readErr := os.ReadFile(jsonPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing", string(data))
+	assert.NoDirExists(t, filepath.Join(dir, "nested"))
+}
+
 func TestMarkdownReportEscapesDynamicText(t *testing.T) {
 	report := sampleReport()
 	report.Run.AppName = "app`name\nnext"

--- a/evaluation/workflow/promptiter/regressionloop/testhelpers_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/testhelpers_test.go
@@ -1,0 +1,127 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regressionloop
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fixedClock struct {
+	ticks []time.Time
+	i     int
+}
+
+func (c *fixedClock) Now() time.Time {
+	if c.i >= len(c.ticks) {
+		return c.ticks[len(c.ticks)-1]
+	}
+	tick := c.ticks[c.i]
+	c.i++
+	return tick
+}
+
+type fakeEvaluator struct {
+	calls   []EvaluationRequest
+	results map[string]EvaluationSummary
+}
+
+func (e *fakeEvaluator) Evaluate(ctx context.Context, req EvaluationRequest) (EvaluationSummary, error) {
+	e.calls = append(e.calls, req)
+	key := phaseKey(req.Phase, req.Round)
+	result := e.results[key]
+	result.EvalSetID = req.EvalSet.ID
+	return result, nil
+}
+
+type fakeOptimizer struct {
+	candidates []Candidate
+}
+
+func (o fakeOptimizer) Candidates(ctx context.Context, req OptimizationRequest) ([]Candidate, error) {
+	return o.candidates, nil
+}
+
+func phaseKey(phase Phase, round int) string {
+	return string(phase) + ":" + string(rune('0'+round))
+}
+
+func testConfig(t *testing.T) Config {
+	t.Helper()
+	dir := t.TempDir()
+	prompt := filepath.Join(dir, "baseline_prompt.txt")
+	require.NoError(t, os.WriteFile(prompt, []byte("baseline"), 0o644))
+	return Config{
+		AppName: "test-app",
+		Seed:    42,
+		PromptSource: PromptSource{
+			ID:         "prompt",
+			Path:       prompt,
+			TargetType: PromptTargetAgentInstruction,
+			SurfaceID:  "agent#instruction",
+		},
+		TrainEvalSet:      EvalSetRef{ID: "train", Path: filepath.Join(dir, "train.evalset.json")},
+		ValidationEvalSet: EvalSetRef{ID: "validation", Path: filepath.Join(dir, "validation.evalset.json")},
+		Metrics:           MetricsRef{Path: filepath.Join(dir, "metrics.json")},
+		PromptIter:        PromptIterConfig{MaxRounds: 3, TargetSurfaceIDs: []string{"agent#instruction"}},
+		Gate: GatePolicy{
+			MinValidationScoreGain:  0.05,
+			AllowNewHardFails:       false,
+			BlockCriticalRegression: true,
+			MaxCalls:                20,
+			MaxLatencyMS:            1000,
+		},
+		Runner: RunnerConfig{Mode: RunnerModeFake, Deterministic: true},
+		Output: OutputConfig{
+			Dir:            dir,
+			JSONReport:     filepath.Join(dir, "optimization_report.json"),
+			MarkdownReport: filepath.Join(dir, "optimization_report.md"),
+		},
+	}
+}
+
+func evalSummary(score float64, cases ...CaseResult) EvaluationSummary {
+	status := "passed"
+	for _, c := range cases {
+		if !c.Passed {
+			status = "failed"
+			break
+		}
+	}
+	return EvaluationSummary{
+		Score:   score,
+		Status:  status,
+		Cases:   cases,
+		Cost:    CostSummary{Calls: len(cases), EstimatedCost: float64(len(cases)) * 0.001},
+		Latency: LatencySummary{TotalMS: int64(len(cases) * 10)},
+	}
+}
+
+func caseResult(id string, score float64, passed bool) CaseResult {
+	return CaseResult{
+		EvalID:   id,
+		Score:    score,
+		Passed:   passed,
+		HardFail: !passed && score == 0,
+		MetricResults: []MetricResult{{
+			Name:     "quality",
+			Score:    score,
+			Passed:   passed,
+			HardFail: !passed && score == 0,
+			Reason:   "final response mismatch",
+		}},
+		FinalResponse:    "actual",
+		ExpectedResponse: "expected",
+	}
+}

--- a/evaluation/workflow/promptiter/regressionloop/testhelpers_test.go
+++ b/evaluation/workflow/promptiter/regressionloop/testhelpers_test.go
@@ -10,6 +10,7 @@ package regressionloop
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,11 +36,15 @@ func (c *fixedClock) Now() time.Time {
 type fakeEvaluator struct {
 	calls   []EvaluationRequest
 	results map[string]EvaluationSummary
+	errors  map[string]error
 }
 
 func (e *fakeEvaluator) Evaluate(ctx context.Context, req EvaluationRequest) (EvaluationSummary, error) {
 	e.calls = append(e.calls, req)
 	key := phaseKey(req.Phase, req.Round)
+	if err := e.errors[key]; err != nil {
+		return EvaluationSummary{}, err
+	}
 	result := e.results[key]
 	result.EvalSetID = req.EvalSet.ID
 	return result, nil
@@ -47,11 +52,17 @@ func (e *fakeEvaluator) Evaluate(ctx context.Context, req EvaluationRequest) (Ev
 
 type fakeOptimizer struct {
 	candidates []Candidate
+	err        error
 }
 
 func (o fakeOptimizer) Candidates(ctx context.Context, req OptimizationRequest) ([]Candidate, error) {
+	if o.err != nil {
+		return nil, o.err
+	}
 	return o.candidates, nil
 }
+
+var errFake = errors.New("fake failure")
 
 func phaseKey(phase Phase, round int) string {
 	return string(phase) + ":" + string(rune('0'+round))

--- a/evaluation/workflow/promptiter/regressionloop/types.go
+++ b/evaluation/workflow/promptiter/regressionloop/types.go
@@ -1,0 +1,328 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package regressionloop provides an auditable evaluation and prompt optimization loop.
+package regressionloop
+
+import "time"
+
+// PromptTargetType identifies the prompt surface type under optimization.
+type PromptTargetType string
+
+const (
+	// PromptTargetSystemPrompt targets system-level behavior text.
+	PromptTargetSystemPrompt PromptTargetType = "system_prompt"
+	// PromptTargetAgentInstruction targets an agent instruction surface.
+	PromptTargetAgentInstruction PromptTargetType = "agent_instruction"
+	// PromptTargetSkillDescription targets a skill description surface.
+	PromptTargetSkillDescription PromptTargetType = "skill_description"
+	// PromptTargetRouterPrompt targets routing instructions.
+	PromptTargetRouterPrompt PromptTargetType = "router_prompt"
+)
+
+// RunnerMode identifies how evaluations and candidates are produced.
+type RunnerMode string
+
+const (
+	// RunnerModeFake uses deterministic fake outcomes.
+	RunnerModeFake RunnerMode = "fake"
+	// RunnerModeTrace uses recorded trace outcomes.
+	RunnerModeTrace RunnerMode = "trace"
+	// RunnerModeModel uses live model execution.
+	RunnerModeModel RunnerMode = "model"
+)
+
+// Phase identifies a pipeline evaluation phase.
+type Phase string
+
+const (
+	// PhaseBaselineTrain evaluates the baseline prompt on the train set.
+	PhaseBaselineTrain Phase = "baseline_train"
+	// PhaseBaselineValidation evaluates the baseline prompt on the validation set.
+	PhaseBaselineValidation Phase = "baseline_validation"
+	// PhaseCandidateTrain evaluates a candidate prompt on the train set.
+	PhaseCandidateTrain Phase = "candidate_train"
+	// PhaseCandidateValidation evaluates a candidate prompt on the validation set.
+	PhaseCandidateValidation Phase = "candidate_validation"
+)
+
+// AttributionCategory identifies a deterministic failure reason class.
+type AttributionCategory string
+
+const (
+	// AttributionFinalResponseMismatch indicates the final answer mismatched the reference.
+	AttributionFinalResponseMismatch AttributionCategory = "final_response_mismatch"
+	// AttributionToolSelectionError indicates the wrong tool was called or a required tool was omitted.
+	AttributionToolSelectionError AttributionCategory = "tool_selection_error"
+	// AttributionToolArgumentError indicates a tool was called with incorrect arguments.
+	AttributionToolArgumentError AttributionCategory = "tool_argument_error"
+	// AttributionRoutingError indicates the request was routed to the wrong node/agent/skill.
+	AttributionRoutingError AttributionCategory = "routing_error"
+	// AttributionFormatError indicates malformed or non-compliant output format.
+	AttributionFormatError AttributionCategory = "format_error"
+	// AttributionKnowledgeRecallInsufficient indicates missing or stale knowledge/context.
+	AttributionKnowledgeRecallInsufficient AttributionCategory = "knowledge_recall_insufficient"
+	// AttributionMetricThresholdMiss indicates no specific class was found beyond metric failure.
+	AttributionMetricThresholdMiss AttributionCategory = "metric_threshold_miss"
+	// AttributionUnknown indicates incomplete evidence.
+	AttributionUnknown AttributionCategory = "unknown"
+)
+
+// Transition identifies one validation case's baseline-to-candidate movement.
+type Transition string
+
+const (
+	// TransitionNewlyPassed indicates a failed baseline became passing.
+	TransitionNewlyPassed Transition = "newly_passed"
+	// TransitionNewlyFailed indicates a passing baseline became failing.
+	TransitionNewlyFailed Transition = "newly_failed"
+	// TransitionImproved indicates score improved without pass/fail transition.
+	TransitionImproved Transition = "improved"
+	// TransitionRegressed indicates score regressed without pass/fail transition.
+	TransitionRegressed Transition = "regressed"
+	// TransitionUnchanged indicates no score or status change.
+	TransitionUnchanged Transition = "unchanged"
+	// TransitionMissing indicates either baseline or candidate case is missing.
+	TransitionMissing Transition = "missing"
+)
+
+// PromptSource describes the prompt surface under optimization.
+type PromptSource struct {
+	ID           string           `json:"id"`
+	Path         string           `json:"path"`
+	TargetType   PromptTargetType `json:"targetType"`
+	SurfaceID    string           `json:"surfaceId,omitempty"`
+	BaselineText string           `json:"baselineText,omitempty"`
+}
+
+// EvalSetRef identifies one evaluation set input.
+type EvalSetRef struct {
+	ID      string   `json:"id"`
+	Path    string   `json:"path"`
+	CaseIDs []string `json:"caseIds,omitempty"`
+}
+
+// MetricsRef identifies the metric configuration input.
+type MetricsRef struct {
+	Path         string `json:"path"`
+	MetricFileID string `json:"metricFileId,omitempty"`
+}
+
+// PromptIterConfig configures candidate generation.
+type PromptIterConfig struct {
+	MaxRounds                  int      `json:"maxRounds"`
+	TargetSurfaceIDs           []string `json:"targetSurfaceIds"`
+	MinScoreGain               float64  `json:"minScoreGain,omitempty"`
+	MaxRoundsWithoutAcceptance int      `json:"maxRoundsWithoutAcceptance,omitempty"`
+	TargetScore                *float64 `json:"targetScore,omitempty"`
+}
+
+// RunnerConfig stores runner identity and deterministic settings.
+type RunnerConfig struct {
+	Mode           RunnerMode `json:"mode"`
+	FixturePath    string     `json:"fixturePath,omitempty"`
+	ModelName      string     `json:"modelName,omitempty"`
+	JudgeModelName string     `json:"judgeModelName,omitempty"`
+	Deterministic  bool       `json:"deterministic,omitempty"`
+}
+
+// OutputConfig configures report output paths.
+type OutputConfig struct {
+	Dir            string `json:"dir"`
+	JSONReport     string `json:"jsonReport"`
+	MarkdownReport string `json:"markdownReport"`
+}
+
+// GatePolicy configures final candidate acceptance.
+type GatePolicy struct {
+	MinValidationScoreGain  float64  `json:"minValidationScoreGain"`
+	AllowNewHardFails       bool     `json:"allowNewHardFails"`
+	BlockCriticalRegression bool     `json:"blockCriticalRegression"`
+	CriticalCaseIDs         []string `json:"criticalCaseIds,omitempty"`
+	MaxCost                 float64  `json:"maxCost,omitempty"`
+	MaxCalls                int      `json:"maxCalls,omitempty"`
+	MaxLatencyMS            int64    `json:"maxLatencyMs,omitempty"`
+}
+
+// Config is the top-level loop configuration.
+type Config struct {
+	AppName           string           `json:"appName"`
+	Seed              int64            `json:"seed"`
+	PromptSource      PromptSource     `json:"promptSource"`
+	TrainEvalSet      EvalSetRef       `json:"trainEvalSet"`
+	ValidationEvalSet EvalSetRef       `json:"validationEvalSet"`
+	Metrics           MetricsRef       `json:"metrics"`
+	PromptIter        PromptIterConfig `json:"promptiter"`
+	Gate              GatePolicy       `json:"gate"`
+	Runner            RunnerConfig     `json:"runner"`
+	Output            OutputConfig     `json:"output"`
+}
+
+// MetricResult stores one metric measurement for an evaluated case.
+type MetricResult struct {
+	Name     string  `json:"name"`
+	Score    float64 `json:"score"`
+	Passed   bool    `json:"passed"`
+	HardFail bool    `json:"hardFail,omitempty"`
+	Reason   string  `json:"reason,omitempty"`
+}
+
+// ToolCall stores a compact trajectory entry.
+type ToolCall struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+	Result    map[string]any `json:"result,omitempty"`
+}
+
+// CaseResult stores output, scoring, and evidence for one evaluated case.
+type CaseResult struct {
+	EvalSetID              string         `json:"evalSetId,omitempty"`
+	EvalID                 string         `json:"evalId"`
+	Critical               bool           `json:"critical,omitempty"`
+	Score                  float64        `json:"score"`
+	Passed                 bool           `json:"passed"`
+	HardFail               bool           `json:"hardFail"`
+	MetricResults          []MetricResult `json:"metricResults,omitempty"`
+	FinalResponse          string         `json:"finalResponse,omitempty"`
+	ExpectedResponse       string         `json:"expectedResponse,omitempty"`
+	ToolTrajectory         []ToolCall     `json:"toolTrajectory,omitempty"`
+	ExpectedToolTrajectory []ToolCall     `json:"expectedToolTrajectory,omitempty"`
+	TraceSummary           string         `json:"traceSummary,omitempty"`
+	RubricReason           string         `json:"rubricReason,omitempty"`
+	StructuredOutputStatus string         `json:"structuredOutputStatus,omitempty"`
+	FailureReasons         []string       `json:"failureReasons,omitempty"`
+	Attributions           []Attribution  `json:"attributions"`
+}
+
+// Attribution stores one failure attribution.
+type Attribution struct {
+	Category   AttributionCategory `json:"category"`
+	Confidence float64             `json:"confidence,omitempty"`
+	Evidence   string              `json:"evidence"`
+	MetricName string              `json:"metricName,omitempty"`
+	Source     string              `json:"source,omitempty"`
+}
+
+// EvaluationSummary stores set-level and case-level evaluation results.
+type EvaluationSummary struct {
+	EvalSetID string         `json:"evalSetId"`
+	Score     float64        `json:"score"`
+	Status    string         `json:"status"`
+	Cases     []CaseResult   `json:"cases"`
+	Cost      CostSummary    `json:"cost,omitempty"`
+	Latency   LatencySummary `json:"latency,omitempty"`
+}
+
+// EvaluationPair stores train and validation evaluation summaries.
+type EvaluationPair struct {
+	Train      EvaluationSummary `json:"train"`
+	Validation EvaluationSummary `json:"validation"`
+}
+
+// Candidate stores a prompt candidate generated by optimization.
+type Candidate struct {
+	Round  int    `json:"round"`
+	Prompt string `json:"prompt"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// CandidateRound stores full round audit state.
+type CandidateRound struct {
+	Round        int               `json:"round"`
+	Prompt       string            `json:"prompt"`
+	Reason       string            `json:"reason,omitempty"`
+	Train        EvaluationSummary `json:"train"`
+	Validation   EvaluationSummary `json:"validation"`
+	Delta        []CaseDelta       `json:"delta"`
+	GateDecision GateDecision      `json:"gateDecision"`
+	Cost         CostSummary       `json:"cost,omitempty"`
+	Latency      LatencySummary    `json:"latency,omitempty"`
+}
+
+// CaseDelta stores one validation case comparison.
+type CaseDelta struct {
+	EvalSetID          string     `json:"evalSetId,omitempty"`
+	EvalID             string     `json:"evalId"`
+	BaselineScore      float64    `json:"baselineScore"`
+	CandidateScore     float64    `json:"candidateScore"`
+	ScoreDelta         float64    `json:"scoreDelta"`
+	BaselinePassed     bool       `json:"baselinePassed,omitempty"`
+	CandidatePassed    bool       `json:"candidatePassed,omitempty"`
+	Transition         Transition `json:"transition"`
+	NewHardFail        bool       `json:"newHardFail"`
+	CriticalRegression bool       `json:"criticalRegression"`
+	AttributionChange  string     `json:"attributionChange,omitempty"`
+}
+
+// DeltaSummary summarizes validation deltas.
+type DeltaSummary struct {
+	NewlyPassed         int `json:"newlyPassed"`
+	NewlyFailed         int `json:"newlyFailed"`
+	Improved            int `json:"improved"`
+	Regressed           int `json:"regressed"`
+	Unchanged           int `json:"unchanged"`
+	NewHardFails        int `json:"newHardFails"`
+	CriticalRegressions int `json:"criticalRegressions"`
+}
+
+// DeltaReport stores report-level validation delta.
+type DeltaReport struct {
+	Summary DeltaSummary `json:"summary"`
+	Cases   []CaseDelta  `json:"cases"`
+}
+
+// GateDecision stores final gate outcome.
+type GateDecision struct {
+	Accepted    bool     `json:"accepted"`
+	ScoreDelta  float64  `json:"scoreDelta"`
+	PassedRules []string `json:"passedRules,omitempty"`
+	FailedRules []string `json:"failedRules,omitempty"`
+	Reasons     []string `json:"reasons"`
+}
+
+// CostSummary stores deterministic or real cost counters.
+type CostSummary struct {
+	Calls         int     `json:"calls"`
+	EstimatedCost float64 `json:"estimatedCost"`
+}
+
+// LatencySummary stores latency totals.
+type LatencySummary struct {
+	TotalMS int64 `json:"totalMs"`
+}
+
+// RunMetadata stores report run metadata.
+type RunMetadata struct {
+	AppName    string       `json:"appName"`
+	StartedAt  string       `json:"startedAt"`
+	DurationMS int64        `json:"durationMs"`
+	Seed       int64        `json:"seed"`
+	Runner     RunnerConfig `json:"runner"`
+}
+
+// Report is the machine-readable audit artifact.
+type Report struct {
+	Run                     RunMetadata      `json:"run"`
+	Baseline                EvaluationPair   `json:"baseline"`
+	Candidates              []CandidateRound `json:"candidates"`
+	SelectedCandidate       *CandidateRound  `json:"selectedCandidate"`
+	Delta                   DeltaReport      `json:"delta"`
+	GateDecision            GateDecision     `json:"gateDecision"`
+	FailureAttributionStats map[string]int   `json:"failureAttributionStats"`
+	CostSummary             CostSummary      `json:"costSummary"`
+	LatencySummary          LatencySummary   `json:"latencySummary"`
+	Artifacts               []string         `json:"artifacts,omitempty"`
+}
+
+// RunResult stores in-memory outputs from one pipeline run.
+type RunResult struct {
+	Report       *Report
+	JSONPath     string
+	MarkdownPath string
+	StartedAt    time.Time
+}

--- a/examples/evaluation/promptiter_regression_loop/DESIGN.md
+++ b/examples/evaluation/promptiter_regression_loop/DESIGN.md
@@ -1,0 +1,5 @@
+# Design
+
+本示例把 baseline 评测、失败归因、PromptIter 优化、验证回归和审计落盘串成闭环。pipeline 读取 prompt、train/validation evalset、metrics 与 gate 配置后，评测训练集和验证集，并记录每条 case 的分数、pass/fail、hard fail、回复、工具轨迹、trace、rubric 与结构化输出状态。归因采用确定性规则：工具缺失、参数错误、路由错误、格式错误、知识召回不足、最终回复不匹配进入对应类别；仅分数低于阈值时归为 metric_threshold_miss，证据不足则归为 unknown。
+
+PromptIter 通过 optimizer 接口接入；示例用 fake optimizer 生成成功、无效、训练提升但验证退化三类候选。每个候选都重跑验证集并计算逐 case delta。gate 只信验证集：总分提升达标、无新增 hard fail、关键 case 不退化，且调用、成本、延迟不超预算。报告保存每轮 prompt、delta、gate 理由、归因、成本、耗时和 seed。

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -1,0 +1,73 @@
+# PromptIter Regression Loop Example
+
+This example demonstrates a deterministic Evaluation + Optimization regression loop for prompt changes. It runs without model credentials and writes both machine-readable and reviewer-readable optimization reports.
+
+## What It Covers
+
+- Baseline evaluation on train and validation sets.
+- Failure attribution from final response, tool trajectory, trace, rubric, and structured-output evidence.
+- PromptIter-style candidate generation for one agent instruction surface.
+- Validation-set regression comparison against the baseline.
+- Acceptance gates for minimum validation gain, new hard fails, critical-case regression, call budget, cost budget, and latency budget.
+- Audit reports with candidate prompts, per-case deltas, gate reasons, seed, fake runner config, cost, and latency.
+
+## Files
+
+```text
+data/promptiter-regression-loop-app/
+├── baseline_prompt.txt
+├── train.evalset.json
+├── validation.evalset.json
+├── metrics.json
+└── promptiter.json
+
+output/
+├── optimization_report.json
+└── optimization_report.md
+```
+
+The train set contains three cases and the validation set contains three cases. The fake optimizer emits three candidate rounds:
+
+- Round 1 improves validation and is accepted.
+- Round 2 is ineffective and is rejected for insufficient gain.
+- Round 3 improves train score but regresses validation, introduces a hard fail, and is rejected.
+
+## Run
+
+```bash
+cd examples/evaluation/promptiter_regression_loop
+go run . \
+  -config ./data/promptiter-regression-loop-app/promptiter.json \
+  -output-dir ./output
+```
+
+Expected output:
+
+```text
+Baseline validation score: 0.65
+Best candidate validation score: 0.86
+Gate accepted: true
+JSON report: ./output/optimization_report.json
+Markdown report: ./output/optimization_report.md
+```
+
+No `OPENAI_API_KEY` is required. The sample uses `runner.mode=fake` and a fixed seed from `promptiter.json`.
+
+## Test
+
+From this directory:
+
+```bash
+go test .
+```
+
+From the evaluation module:
+
+```bash
+cd ../../../evaluation
+go test ./workflow/promptiter/regressionloop
+```
+
+## Report Review
+
+Open `output/optimization_report.md` for a reviewer summary. The JSON report is the source of truth for automation and includes the full baseline, candidates, per-case validation delta, gate decision, attribution stats, cost summary, and latency summary.

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/baseline_prompt.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/baseline_prompt.txt
@@ -1,0 +1,1 @@
+BASELINE_PROMPT: answer support questions briefly.

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/metrics.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/metrics.json
@@ -1,0 +1,11 @@
+[
+  {
+    "metricName": "deterministic_quality",
+    "threshold": 0.75,
+    "criterion": {
+      "fake": {
+        "description": "Deterministic score supplied by fake runner for regression-loop auditing."
+      }
+    }
+  }
+]

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/promptiter.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/promptiter.json
@@ -1,0 +1,47 @@
+{
+  "appName": "promptiter-regression-loop-app",
+  "seed": 20260708,
+  "promptSource": {
+    "id": "support-agent-instruction",
+    "path": "baseline_prompt.txt",
+    "targetType": "agent_instruction",
+    "surfaceId": "support-agent#instruction"
+  },
+  "trainEvalSet": {
+    "id": "train",
+    "path": "train.evalset.json"
+  },
+  "validationEvalSet": {
+    "id": "validation",
+    "path": "validation.evalset.json"
+  },
+  "metrics": {
+    "path": "metrics.json",
+    "metricFileId": "metrics"
+  },
+  "promptiter": {
+    "maxRounds": 3,
+    "targetSurfaceIds": ["support-agent#instruction"],
+    "minScoreGain": 0.05,
+    "maxRoundsWithoutAcceptance": 2,
+    "targetScore": 0.95
+  },
+  "gate": {
+    "minValidationScoreGain": 0.05,
+    "allowNewHardFails": false,
+    "blockCriticalRegression": true,
+    "criticalCaseIds": ["val_json_receipt"],
+    "maxCost": 1,
+    "maxCalls": 30,
+    "maxLatencyMs": 1000
+  },
+  "runner": {
+    "mode": "fake",
+    "deterministic": true
+  },
+  "output": {
+    "dir": "../../output",
+    "jsonReport": "optimization_report.json",
+    "markdownReport": "optimization_report.md"
+  }
+}

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/train.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/train.evalset.json
@@ -1,0 +1,135 @@
+{
+  "evalSetId": "train",
+  "name": "train",
+  "evalCases": [
+    {
+      "evalId": "train_tool_argument",
+      "userInput": "Check order A100 status.",
+      "expectedResponse": "Order A100 is shipped.",
+      "expectedTools": [
+        {
+          "name": "lookup_order",
+          "arguments": { "order_id": "A100" },
+          "result": { "status": "shipped" }
+        }
+      ],
+      "expectedFailureCategory": "tool_argument_error",
+      "fakeOutcomes": {
+        "baseline": {
+          "score": 0.25,
+          "passed": false,
+          "finalResponse": "I cannot find the order.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": { "order_id": "100" },
+              "result": { "status": "not_found" }
+            }
+          ],
+          "failureReasons": ["tool argument query is wrong for order id"]
+        },
+        "candidate_success": {
+          "score": 0.95,
+          "passed": true,
+          "finalResponse": "Order A100 is shipped.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": { "order_id": "A100" },
+              "result": { "status": "shipped" }
+            }
+          ]
+        },
+        "candidate_ineffective": {
+          "score": 0.3,
+          "passed": false,
+          "finalResponse": "I cannot find the order.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": { "order_id": "100" },
+              "result": { "status": "not_found" }
+            }
+          ],
+          "failureReasons": ["tool argument query is wrong for order id"]
+        },
+        "candidate_overfit": {
+          "score": 1,
+          "passed": true,
+          "finalResponse": "Order A100 is shipped.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": { "order_id": "A100" },
+              "result": { "status": "shipped" }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "evalId": "train_format",
+      "userInput": "Return a JSON receipt for refund R55.",
+      "expectedResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+      "expectedFailureCategory": "format_error",
+      "fakeOutcomes": {
+        "baseline": {
+          "score": 0.4,
+          "passed": false,
+          "finalResponse": "Refund R55 is approved.",
+          "structuredOutputStatus": "format error: expected JSON object",
+          "failureReasons": ["structured output json schema violation"]
+        },
+        "candidate_success": {
+          "score": 0.9,
+          "passed": true,
+          "finalResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}"
+        },
+        "candidate_ineffective": {
+          "score": 0.45,
+          "passed": false,
+          "finalResponse": "Refund R55 is approved.",
+          "structuredOutputStatus": "format error: expected JSON object",
+          "failureReasons": ["structured output json schema violation"]
+        },
+        "candidate_overfit": {
+          "score": 0.95,
+          "passed": true,
+          "finalResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}"
+        }
+      }
+    },
+    {
+      "evalId": "train_knowledge_recall",
+      "userInput": "What is the SLA for premium support?",
+      "expectedResponse": "Premium support SLA is 2 hours.",
+      "expectedFailureCategory": "knowledge_recall_insufficient",
+      "fakeOutcomes": {
+        "baseline": {
+          "score": 0.55,
+          "passed": false,
+          "finalResponse": "Premium support is usually same day.",
+          "rubricReason": "knowledge recall missing context for premium SLA",
+          "failureReasons": ["knowledge recall missing context"]
+        },
+        "candidate_success": {
+          "score": 0.85,
+          "passed": true,
+          "finalResponse": "Premium support SLA is 2 hours."
+        },
+        "candidate_ineffective": {
+          "score": 0.55,
+          "passed": false,
+          "finalResponse": "Premium support is usually same day.",
+          "rubricReason": "knowledge recall missing context for premium SLA",
+          "failureReasons": ["knowledge recall missing context"]
+        },
+        "candidate_overfit": {
+          "score": 0.98,
+          "passed": true,
+          "finalResponse": "Premium support SLA is 2 hours."
+        }
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/validation.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter-regression-loop-app/validation.evalset.json
@@ -1,0 +1,126 @@
+{
+  "evalSetId": "validation",
+  "name": "validation",
+  "evalCases": [
+    {
+      "evalId": "val_tool_selection",
+      "userInput": "Tell me the shipment ETA for tracking T900.",
+      "expectedResponse": "Tracking T900 arrives tomorrow.",
+      "expectedTools": [
+        {
+          "name": "lookup_tracking",
+          "arguments": { "tracking_id": "T900" },
+          "result": { "eta": "tomorrow" }
+        }
+      ],
+      "expectedFailureCategory": "tool_selection_error",
+      "fakeOutcomes": {
+        "baseline": {
+          "score": 0.5,
+          "passed": false,
+          "finalResponse": "I do not have live tracking access.",
+          "toolTrajectory": [],
+          "failureReasons": ["missing tool call caused tool selection failure"]
+        },
+        "candidate_success": {
+          "score": 0.92,
+          "passed": true,
+          "finalResponse": "Tracking T900 arrives tomorrow.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_tracking",
+              "arguments": { "tracking_id": "T900" },
+              "result": { "eta": "tomorrow" }
+            }
+          ]
+        },
+        "candidate_ineffective": {
+          "score": 0.52,
+          "passed": false,
+          "finalResponse": "I do not have live tracking access.",
+          "toolTrajectory": [],
+          "failureReasons": ["missing tool call caused tool selection failure"]
+        },
+        "candidate_overfit": {
+          "score": 0.9,
+          "passed": true,
+          "finalResponse": "Tracking T900 arrives tomorrow.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_tracking",
+              "arguments": { "tracking_id": "T900" },
+              "result": { "eta": "tomorrow" }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "evalId": "val_route_skill",
+      "userInput": "Route this password reset request to account support.",
+      "expectedResponse": "Routed to account support.",
+      "expectedFailureCategory": "routing_error",
+      "fakeOutcomes": {
+        "baseline": {
+          "score": 0.65,
+          "passed": false,
+          "finalResponse": "Routed to billing support.",
+          "traceSummary": "route selected wrong agent: billing_support",
+          "failureReasons": ["route selected wrong agent"]
+        },
+        "candidate_success": {
+          "score": 0.82,
+          "passed": true,
+          "finalResponse": "Routed to account support.",
+          "traceSummary": "route selected account_support"
+        },
+        "candidate_ineffective": {
+          "score": 0.65,
+          "passed": false,
+          "finalResponse": "Routed to billing support.",
+          "traceSummary": "route selected wrong agent: billing_support",
+          "failureReasons": ["route selected wrong agent"]
+        },
+        "candidate_overfit": {
+          "score": 0.7,
+          "passed": false,
+          "finalResponse": "Routed to account support after manual review.",
+          "traceSummary": "route selected wrong node for review flow",
+          "failureReasons": ["route selected wrong node"]
+        }
+      }
+    },
+    {
+      "evalId": "val_json_receipt",
+      "critical": true,
+      "userInput": "Return JSON receipt for payment P77.",
+      "expectedResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+      "expectedFailureCategory": "format_error",
+      "fakeOutcomes": {
+        "baseline": {
+          "score": 0.8,
+          "passed": true,
+          "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}"
+        },
+        "candidate_success": {
+          "score": 0.85,
+          "passed": true,
+          "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}"
+        },
+        "candidate_ineffective": {
+          "score": 0.8,
+          "passed": true,
+          "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}"
+        },
+        "candidate_overfit": {
+          "score": 0,
+          "passed": false,
+          "hardFail": true,
+          "finalResponse": "Payment P77 captured.",
+          "structuredOutputStatus": "format error: expected JSON object",
+          "failureReasons": ["structured output json schema violation"]
+        }
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/main.go
+++ b/examples/evaluation/promptiter_regression_loop/main.go
@@ -1,0 +1,77 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regressionloop"
+)
+
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("promptiter_regression_loop", flag.ContinueOnError)
+	configPath := flags.String("config", "", "Path to promptiter regression loop config")
+	outputDir := flags.String("output-dir", "", "Directory for optimization reports")
+	seed := flags.Int64("seed", 0, "Deterministic seed override")
+	deterministic := flags.Bool("deterministic", true, "Enable deterministic fake/trace mode")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := regressionloop.LoadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	if *outputDir != "" {
+		cfg.Output.Dir = *outputDir
+		cfg.Output.JSONReport = joinOutput(*outputDir, "optimization_report.json")
+		cfg.Output.MarkdownReport = joinOutput(*outputDir, "optimization_report.md")
+	}
+	if *seed != 0 {
+		cfg.Seed = *seed
+	}
+	cfg.Runner.Deterministic = *deterministic
+	pipeline := &regressionloop.Pipeline{
+		Evaluator: newFakeEvaluator(),
+		Optimizer: fakeOptimizer{},
+	}
+	result, err := pipeline.Run(ctx, *cfg)
+	if err != nil {
+		return err
+	}
+	report := result.Report
+	bestScore := 0.0
+	if report.SelectedCandidate != nil {
+		bestScore = report.SelectedCandidate.Validation.Score
+	} else if len(report.Candidates) > 0 {
+		bestScore = report.Candidates[0].Validation.Score
+	}
+	fmt.Printf("Baseline validation score: %.2f\n", report.Baseline.Validation.Score)
+	fmt.Printf("Best candidate validation score: %.2f\n", bestScore)
+	fmt.Printf("Gate accepted: %t\n", report.GateDecision.Accepted)
+	fmt.Printf("JSON report: %s\n", result.JSONPath)
+	fmt.Printf("Markdown report: %s\n", result.MarkdownPath)
+	return nil
+}
+
+func joinOutput(dir, name string) string {
+	if dir == "" {
+		return name
+	}
+	return dir + string(os.PathSeparator) + name
+}

--- a/examples/evaluation/promptiter_regression_loop/main_test.go
+++ b/examples/evaluation/promptiter_regression_loop/main_test.go
@@ -1,0 +1,44 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regressionloop"
+)
+
+func TestRunDeterministicExample(t *testing.T) {
+	outputDir := t.TempDir()
+	err := run(context.Background(), []string{
+		"-config", "./data/promptiter-regression-loop-app/promptiter.json",
+		"-output-dir", outputDir,
+	})
+	require.NoError(t, err)
+	jsonPath := filepath.Join(outputDir, "optimization_report.json")
+	mdPath := filepath.Join(outputDir, "optimization_report.md")
+	data, err := os.ReadFile(jsonPath)
+	require.NoError(t, err)
+	var report regressionloop.Report
+	require.NoError(t, json.Unmarshal(data, &report))
+	assert.True(t, report.GateDecision.Accepted)
+	require.Len(t, report.Candidates, 3)
+	assert.False(t, report.Candidates[2].GateDecision.Accepted)
+	assert.Contains(t, report.Candidates[2].GateDecision.FailedRules, "no_new_hard_fails")
+	md, err := os.ReadFile(mdPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(md), "Validation Delta")
+	assert.Contains(t, string(md), "Candidate 3")
+}

--- a/examples/evaluation/promptiter_regression_loop/main_test.go
+++ b/examples/evaluation/promptiter_regression_loop/main_test.go
@@ -42,3 +42,15 @@ func TestRunDeterministicExample(t *testing.T) {
 	assert.Contains(t, string(md), "Validation Delta")
 	assert.Contains(t, string(md), "Candidate 3")
 }
+
+func TestFakeEvaluatorRejectsEmptyEvalSet(t *testing.T) {
+	dir := t.TempDir()
+	evalsetPath := filepath.Join(dir, "empty.evalset.json")
+	require.NoError(t, os.WriteFile(evalsetPath, []byte(`{"evalSetId":"empty","evalCases":[]}`), 0o644))
+
+	_, err := newFakeEvaluator().Evaluate(context.Background(), regressionloop.EvaluationRequest{
+		Prompt:  "baseline",
+		EvalSet: regressionloop.EvalSetRef{ID: "empty", Path: evalsetPath},
+	})
+	require.ErrorContains(t, err, "has no eval cases")
+}

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
@@ -1,0 +1,1366 @@
+{
+  "run": {
+    "appName": "promptiter-regression-loop-app",
+    "startedAt": "2026-07-08T20:22:00+08:00",
+    "durationMs": 0,
+    "seed": 20260708,
+    "runner": {
+      "mode": "fake",
+      "deterministic": true
+    }
+  },
+  "baseline": {
+    "train": {
+      "evalSetId": "train",
+      "score": 0.4000000000000001,
+      "status": "failed",
+      "cases": [
+        {
+          "evalSetId": "train",
+          "evalId": "train_tool_argument",
+          "score": 0.25,
+          "passed": false,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.25,
+              "passed": false,
+              "reason": "tool argument query is wrong for order id"
+            }
+          ],
+          "finalResponse": "I cannot find the order.",
+          "expectedResponse": "Order A100 is shipped.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": {
+                "order_id": "100"
+              },
+              "result": {
+                "status": "not_found"
+              }
+            }
+          ],
+          "expectedToolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": {
+                "order_id": "A100"
+              },
+              "result": {
+                "status": "shipped"
+              }
+            }
+          ],
+          "failureReasons": [
+            "tool argument query is wrong for order id"
+          ],
+          "attributions": [
+            {
+              "category": "tool_argument_error",
+              "confidence": 0.9,
+              "evidence": "tool trajectory differs from expected trajectory",
+              "metricName": "deterministic_quality",
+              "source": "tool_trajectory"
+            }
+          ]
+        },
+        {
+          "evalSetId": "train",
+          "evalId": "train_format",
+          "score": 0.4,
+          "passed": false,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.4,
+              "passed": false,
+              "reason": "structured output json schema violation"
+            }
+          ],
+          "finalResponse": "Refund R55 is approved.",
+          "expectedResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+          "structuredOutputStatus": "format error: expected JSON object",
+          "failureReasons": [
+            "structured output json schema violation"
+          ],
+          "attributions": [
+            {
+              "category": "format_error",
+              "confidence": 0.85,
+              "evidence": "format error: expected JSON object",
+              "metricName": "deterministic_quality",
+              "source": "structured_output"
+            }
+          ]
+        },
+        {
+          "evalSetId": "train",
+          "evalId": "train_knowledge_recall",
+          "score": 0.55,
+          "passed": false,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.55,
+              "passed": false,
+              "reason": "knowledge recall missing context"
+            }
+          ],
+          "finalResponse": "Premium support is usually same day.",
+          "expectedResponse": "Premium support SLA is 2 hours.",
+          "rubricReason": "knowledge recall missing context for premium SLA",
+          "failureReasons": [
+            "knowledge recall missing context"
+          ],
+          "attributions": [
+            {
+              "category": "knowledge_recall_insufficient",
+              "confidence": 0.8,
+              "evidence": "knowledge recall missing context for premium SLA",
+              "metricName": "deterministic_quality",
+              "source": "rubric"
+            }
+          ]
+        }
+      ],
+      "cost": {
+        "calls": 3,
+        "estimatedCost": 0.003
+      },
+      "latency": {
+        "totalMs": 15
+      }
+    },
+    "validation": {
+      "evalSetId": "validation",
+      "score": 0.65,
+      "status": "failed",
+      "cases": [
+        {
+          "evalSetId": "validation",
+          "evalId": "val_tool_selection",
+          "score": 0.5,
+          "passed": false,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.5,
+              "passed": false,
+              "reason": "missing tool call caused tool selection failure"
+            }
+          ],
+          "finalResponse": "I do not have live tracking access.",
+          "expectedResponse": "Tracking T900 arrives tomorrow.",
+          "expectedToolTrajectory": [
+            {
+              "name": "lookup_tracking",
+              "arguments": {
+                "tracking_id": "T900"
+              },
+              "result": {
+                "eta": "tomorrow"
+              }
+            }
+          ],
+          "failureReasons": [
+            "missing tool call caused tool selection failure"
+          ],
+          "attributions": [
+            {
+              "category": "tool_selection_error",
+              "confidence": 0.9,
+              "evidence": "tool trajectory differs from expected trajectory",
+              "metricName": "deterministic_quality",
+              "source": "tool_trajectory"
+            }
+          ]
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_route_skill",
+          "score": 0.65,
+          "passed": false,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.65,
+              "passed": false,
+              "reason": "route selected wrong agent"
+            }
+          ],
+          "finalResponse": "Routed to billing support.",
+          "expectedResponse": "Routed to account support.",
+          "traceSummary": "route selected wrong agent: billing_support",
+          "failureReasons": [
+            "route selected wrong agent"
+          ],
+          "attributions": [
+            {
+              "category": "routing_error",
+              "confidence": 0.85,
+              "evidence": "route selected wrong agent: billing_support",
+              "metricName": "deterministic_quality",
+              "source": "trace"
+            }
+          ]
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_json_receipt",
+          "critical": true,
+          "score": 0.8,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.8,
+              "passed": true
+            }
+          ],
+          "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+          "expectedResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+          "attributions": []
+        }
+      ],
+      "cost": {
+        "calls": 3,
+        "estimatedCost": 0.003
+      },
+      "latency": {
+        "totalMs": 15
+      }
+    }
+  },
+  "candidates": [
+    {
+      "round": 1,
+      "prompt": "SUCCESS_PROMPT: call tools only when needed, preserve final answer format, and verify numeric facts.",
+      "reason": "fix tool and format failures without changing validation-critical behavior",
+      "train": {
+        "evalSetId": "train",
+        "score": 0.9,
+        "status": "passed",
+        "cases": [
+          {
+            "evalSetId": "train",
+            "evalId": "train_tool_argument",
+            "score": 0.95,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.95,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Order A100 is shipped.",
+            "expectedResponse": "Order A100 is shipped.",
+            "toolTrajectory": [
+              {
+                "name": "lookup_order",
+                "arguments": {
+                  "order_id": "A100"
+                },
+                "result": {
+                  "status": "shipped"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "name": "lookup_order",
+                "arguments": {
+                  "order_id": "A100"
+                },
+                "result": {
+                  "status": "shipped"
+                }
+              }
+            ],
+            "attributions": []
+          },
+          {
+            "evalSetId": "train",
+            "evalId": "train_format",
+            "score": 0.9,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.9,
+                "passed": true
+              }
+            ],
+            "finalResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+            "expectedResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+            "attributions": []
+          },
+          {
+            "evalSetId": "train",
+            "evalId": "train_knowledge_recall",
+            "score": 0.85,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.85,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Premium support SLA is 2 hours.",
+            "expectedResponse": "Premium support SLA is 2 hours.",
+            "attributions": []
+          }
+        ],
+        "cost": {
+          "calls": 3,
+          "estimatedCost": 0.003
+        },
+        "latency": {
+          "totalMs": 15
+        }
+      },
+      "validation": {
+        "evalSetId": "validation",
+        "score": 0.8633333333333333,
+        "status": "passed",
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "evalId": "val_tool_selection",
+            "score": 0.92,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.92,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Tracking T900 arrives tomorrow.",
+            "expectedResponse": "Tracking T900 arrives tomorrow.",
+            "toolTrajectory": [
+              {
+                "name": "lookup_tracking",
+                "arguments": {
+                  "tracking_id": "T900"
+                },
+                "result": {
+                  "eta": "tomorrow"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "name": "lookup_tracking",
+                "arguments": {
+                  "tracking_id": "T900"
+                },
+                "result": {
+                  "eta": "tomorrow"
+                }
+              }
+            ],
+            "attributions": []
+          },
+          {
+            "evalSetId": "validation",
+            "evalId": "val_route_skill",
+            "score": 0.82,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.82,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Routed to account support.",
+            "expectedResponse": "Routed to account support.",
+            "traceSummary": "route selected account_support",
+            "attributions": []
+          },
+          {
+            "evalSetId": "validation",
+            "evalId": "val_json_receipt",
+            "critical": true,
+            "score": 0.85,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.85,
+                "passed": true
+              }
+            ],
+            "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+            "expectedResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+            "attributions": []
+          }
+        ],
+        "cost": {
+          "calls": 3,
+          "estimatedCost": 0.003
+        },
+        "latency": {
+          "totalMs": 15
+        }
+      },
+      "delta": [
+        {
+          "evalSetId": "validation",
+          "evalId": "val_json_receipt",
+          "baselineScore": 0.8,
+          "candidateScore": 0.85,
+          "scoreDelta": 0.04999999999999993,
+          "baselinePassed": true,
+          "candidatePassed": true,
+          "transition": "improved",
+          "newHardFail": false,
+          "criticalRegression": false
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_route_skill",
+          "baselineScore": 0.65,
+          "candidateScore": 0.82,
+          "scoreDelta": 0.16999999999999993,
+          "candidatePassed": true,
+          "transition": "newly_passed",
+          "newHardFail": false,
+          "criticalRegression": false,
+          "attributionChange": "candidate attribution cleared"
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_tool_selection",
+          "baselineScore": 0.5,
+          "candidateScore": 0.92,
+          "scoreDelta": 0.42000000000000004,
+          "candidatePassed": true,
+          "transition": "newly_passed",
+          "newHardFail": false,
+          "criticalRegression": false,
+          "attributionChange": "candidate attribution cleared"
+        }
+      ],
+      "gateDecision": {
+        "accepted": true,
+        "scoreDelta": 0.21333333333333326,
+        "passedRules": [
+          "validation_score_gain",
+          "no_new_hard_fails",
+          "critical_case_non_regression",
+          "max_cost",
+          "max_calls",
+          "max_latency"
+        ],
+        "reasons": [
+          "candidate satisfies all acceptance gates"
+        ]
+      },
+      "cost": {
+        "calls": 6,
+        "estimatedCost": 0.006
+      },
+      "latency": {
+        "totalMs": 30
+      }
+    },
+    {
+      "round": 2,
+      "prompt": "INEFFECTIVE_PROMPT: be helpful and concise.",
+      "reason": "generic rewrite with no material validation gain",
+      "train": {
+        "evalSetId": "train",
+        "score": 0.43333333333333335,
+        "status": "failed",
+        "cases": [
+          {
+            "evalSetId": "train",
+            "evalId": "train_tool_argument",
+            "score": 0.3,
+            "passed": false,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.3,
+                "passed": false,
+                "reason": "tool argument query is wrong for order id"
+              }
+            ],
+            "finalResponse": "I cannot find the order.",
+            "expectedResponse": "Order A100 is shipped.",
+            "toolTrajectory": [
+              {
+                "name": "lookup_order",
+                "arguments": {
+                  "order_id": "100"
+                },
+                "result": {
+                  "status": "not_found"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "name": "lookup_order",
+                "arguments": {
+                  "order_id": "A100"
+                },
+                "result": {
+                  "status": "shipped"
+                }
+              }
+            ],
+            "failureReasons": [
+              "tool argument query is wrong for order id"
+            ],
+            "attributions": [
+              {
+                "category": "tool_argument_error",
+                "confidence": 0.9,
+                "evidence": "tool trajectory differs from expected trajectory",
+                "metricName": "deterministic_quality",
+                "source": "tool_trajectory"
+              }
+            ]
+          },
+          {
+            "evalSetId": "train",
+            "evalId": "train_format",
+            "score": 0.45,
+            "passed": false,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.45,
+                "passed": false,
+                "reason": "structured output json schema violation"
+              }
+            ],
+            "finalResponse": "Refund R55 is approved.",
+            "expectedResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+            "structuredOutputStatus": "format error: expected JSON object",
+            "failureReasons": [
+              "structured output json schema violation"
+            ],
+            "attributions": [
+              {
+                "category": "format_error",
+                "confidence": 0.85,
+                "evidence": "format error: expected JSON object",
+                "metricName": "deterministic_quality",
+                "source": "structured_output"
+              }
+            ]
+          },
+          {
+            "evalSetId": "train",
+            "evalId": "train_knowledge_recall",
+            "score": 0.55,
+            "passed": false,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.55,
+                "passed": false,
+                "reason": "knowledge recall missing context"
+              }
+            ],
+            "finalResponse": "Premium support is usually same day.",
+            "expectedResponse": "Premium support SLA is 2 hours.",
+            "rubricReason": "knowledge recall missing context for premium SLA",
+            "failureReasons": [
+              "knowledge recall missing context"
+            ],
+            "attributions": [
+              {
+                "category": "knowledge_recall_insufficient",
+                "confidence": 0.8,
+                "evidence": "knowledge recall missing context for premium SLA",
+                "metricName": "deterministic_quality",
+                "source": "rubric"
+              }
+            ]
+          }
+        ],
+        "cost": {
+          "calls": 3,
+          "estimatedCost": 0.003
+        },
+        "latency": {
+          "totalMs": 15
+        }
+      },
+      "validation": {
+        "evalSetId": "validation",
+        "score": 0.6566666666666666,
+        "status": "failed",
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "evalId": "val_tool_selection",
+            "score": 0.52,
+            "passed": false,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.52,
+                "passed": false,
+                "reason": "missing tool call caused tool selection failure"
+              }
+            ],
+            "finalResponse": "I do not have live tracking access.",
+            "expectedResponse": "Tracking T900 arrives tomorrow.",
+            "expectedToolTrajectory": [
+              {
+                "name": "lookup_tracking",
+                "arguments": {
+                  "tracking_id": "T900"
+                },
+                "result": {
+                  "eta": "tomorrow"
+                }
+              }
+            ],
+            "failureReasons": [
+              "missing tool call caused tool selection failure"
+            ],
+            "attributions": [
+              {
+                "category": "tool_selection_error",
+                "confidence": 0.9,
+                "evidence": "tool trajectory differs from expected trajectory",
+                "metricName": "deterministic_quality",
+                "source": "tool_trajectory"
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "evalId": "val_route_skill",
+            "score": 0.65,
+            "passed": false,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.65,
+                "passed": false,
+                "reason": "route selected wrong agent"
+              }
+            ],
+            "finalResponse": "Routed to billing support.",
+            "expectedResponse": "Routed to account support.",
+            "traceSummary": "route selected wrong agent: billing_support",
+            "failureReasons": [
+              "route selected wrong agent"
+            ],
+            "attributions": [
+              {
+                "category": "routing_error",
+                "confidence": 0.85,
+                "evidence": "route selected wrong agent: billing_support",
+                "metricName": "deterministic_quality",
+                "source": "trace"
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "evalId": "val_json_receipt",
+            "critical": true,
+            "score": 0.8,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.8,
+                "passed": true
+              }
+            ],
+            "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+            "expectedResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+            "attributions": []
+          }
+        ],
+        "cost": {
+          "calls": 3,
+          "estimatedCost": 0.003
+        },
+        "latency": {
+          "totalMs": 15
+        }
+      },
+      "delta": [
+        {
+          "evalSetId": "validation",
+          "evalId": "val_json_receipt",
+          "baselineScore": 0.8,
+          "candidateScore": 0.8,
+          "scoreDelta": 0,
+          "baselinePassed": true,
+          "candidatePassed": true,
+          "transition": "unchanged",
+          "newHardFail": false,
+          "criticalRegression": false
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_route_skill",
+          "baselineScore": 0.65,
+          "candidateScore": 0.65,
+          "scoreDelta": 0,
+          "transition": "unchanged",
+          "newHardFail": false,
+          "criticalRegression": false
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_tool_selection",
+          "baselineScore": 0.5,
+          "candidateScore": 0.52,
+          "scoreDelta": 0.020000000000000018,
+          "transition": "improved",
+          "newHardFail": false,
+          "criticalRegression": false
+        }
+      ],
+      "gateDecision": {
+        "accepted": false,
+        "scoreDelta": 0.006666666666666599,
+        "passedRules": [
+          "no_new_hard_fails",
+          "critical_case_non_regression",
+          "max_cost",
+          "max_calls",
+          "max_latency"
+        ],
+        "failedRules": [
+          "validation_score_gain"
+        ],
+        "reasons": [
+          "validation score gain 0.0067 is below threshold 0.0500"
+        ]
+      },
+      "cost": {
+        "calls": 6,
+        "estimatedCost": 0.006
+      },
+      "latency": {
+        "totalMs": 30
+      }
+    },
+    {
+      "round": 3,
+      "prompt": "OVERFIT_PROMPT: optimize train cases aggressively even if validation formatting changes.",
+      "reason": "train-focused prompt that causes validation regression",
+      "train": {
+        "evalSetId": "train",
+        "score": 0.9766666666666666,
+        "status": "passed",
+        "cases": [
+          {
+            "evalSetId": "train",
+            "evalId": "train_tool_argument",
+            "score": 1,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 1,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Order A100 is shipped.",
+            "expectedResponse": "Order A100 is shipped.",
+            "toolTrajectory": [
+              {
+                "name": "lookup_order",
+                "arguments": {
+                  "order_id": "A100"
+                },
+                "result": {
+                  "status": "shipped"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "name": "lookup_order",
+                "arguments": {
+                  "order_id": "A100"
+                },
+                "result": {
+                  "status": "shipped"
+                }
+              }
+            ],
+            "attributions": []
+          },
+          {
+            "evalSetId": "train",
+            "evalId": "train_format",
+            "score": 0.95,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.95,
+                "passed": true
+              }
+            ],
+            "finalResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+            "expectedResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+            "attributions": []
+          },
+          {
+            "evalSetId": "train",
+            "evalId": "train_knowledge_recall",
+            "score": 0.98,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.98,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Premium support SLA is 2 hours.",
+            "expectedResponse": "Premium support SLA is 2 hours.",
+            "attributions": []
+          }
+        ],
+        "cost": {
+          "calls": 3,
+          "estimatedCost": 0.003
+        },
+        "latency": {
+          "totalMs": 15
+        }
+      },
+      "validation": {
+        "evalSetId": "validation",
+        "score": 0.5333333333333333,
+        "status": "failed",
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "evalId": "val_tool_selection",
+            "score": 0.9,
+            "passed": true,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.9,
+                "passed": true
+              }
+            ],
+            "finalResponse": "Tracking T900 arrives tomorrow.",
+            "expectedResponse": "Tracking T900 arrives tomorrow.",
+            "toolTrajectory": [
+              {
+                "name": "lookup_tracking",
+                "arguments": {
+                  "tracking_id": "T900"
+                },
+                "result": {
+                  "eta": "tomorrow"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "name": "lookup_tracking",
+                "arguments": {
+                  "tracking_id": "T900"
+                },
+                "result": {
+                  "eta": "tomorrow"
+                }
+              }
+            ],
+            "attributions": []
+          },
+          {
+            "evalSetId": "validation",
+            "evalId": "val_route_skill",
+            "score": 0.7,
+            "passed": false,
+            "hardFail": false,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0.7,
+                "passed": false,
+                "reason": "route selected wrong node"
+              }
+            ],
+            "finalResponse": "Routed to account support after manual review.",
+            "expectedResponse": "Routed to account support.",
+            "traceSummary": "route selected wrong node for review flow",
+            "failureReasons": [
+              "route selected wrong node"
+            ],
+            "attributions": [
+              {
+                "category": "routing_error",
+                "confidence": 0.85,
+                "evidence": "route selected wrong node for review flow",
+                "metricName": "deterministic_quality",
+                "source": "trace"
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "evalId": "val_json_receipt",
+            "critical": true,
+            "score": 0,
+            "passed": false,
+            "hardFail": true,
+            "metricResults": [
+              {
+                "name": "deterministic_quality",
+                "score": 0,
+                "passed": false,
+                "hardFail": true,
+                "reason": "structured output json schema violation"
+              }
+            ],
+            "finalResponse": "Payment P77 captured.",
+            "expectedResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+            "structuredOutputStatus": "format error: expected JSON object",
+            "failureReasons": [
+              "structured output json schema violation"
+            ],
+            "attributions": [
+              {
+                "category": "format_error",
+                "confidence": 0.85,
+                "evidence": "format error: expected JSON object",
+                "metricName": "deterministic_quality",
+                "source": "structured_output"
+              }
+            ]
+          }
+        ],
+        "cost": {
+          "calls": 3,
+          "estimatedCost": 0.003
+        },
+        "latency": {
+          "totalMs": 15
+        }
+      },
+      "delta": [
+        {
+          "evalSetId": "validation",
+          "evalId": "val_json_receipt",
+          "baselineScore": 0.8,
+          "candidateScore": 0,
+          "scoreDelta": -0.8,
+          "baselinePassed": true,
+          "transition": "newly_failed",
+          "newHardFail": true,
+          "criticalRegression": true,
+          "attributionChange": "candidate attribution added"
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_route_skill",
+          "baselineScore": 0.65,
+          "candidateScore": 0.7,
+          "scoreDelta": 0.04999999999999993,
+          "transition": "improved",
+          "newHardFail": false,
+          "criticalRegression": false
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_tool_selection",
+          "baselineScore": 0.5,
+          "candidateScore": 0.9,
+          "scoreDelta": 0.4,
+          "candidatePassed": true,
+          "transition": "newly_passed",
+          "newHardFail": false,
+          "criticalRegression": false,
+          "attributionChange": "candidate attribution cleared"
+        }
+      ],
+      "gateDecision": {
+        "accepted": false,
+        "scoreDelta": -0.1166666666666667,
+        "passedRules": [
+          "max_cost",
+          "max_calls",
+          "max_latency"
+        ],
+        "failedRules": [
+          "validation_score_gain",
+          "no_new_hard_fails",
+          "critical_case_non_regression"
+        ],
+        "reasons": [
+          "validation score gain -0.1167 is below threshold 0.0500",
+          "candidate introduced 1 new hard fail(s)",
+          "candidate regressed 1 critical case(s)"
+        ]
+      },
+      "cost": {
+        "calls": 6,
+        "estimatedCost": 0.006
+      },
+      "latency": {
+        "totalMs": 30
+      }
+    }
+  ],
+  "selectedCandidate": {
+    "round": 1,
+    "prompt": "SUCCESS_PROMPT: call tools only when needed, preserve final answer format, and verify numeric facts.",
+    "reason": "fix tool and format failures without changing validation-critical behavior",
+    "train": {
+      "evalSetId": "train",
+      "score": 0.9,
+      "status": "passed",
+      "cases": [
+        {
+          "evalSetId": "train",
+          "evalId": "train_tool_argument",
+          "score": 0.95,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.95,
+              "passed": true
+            }
+          ],
+          "finalResponse": "Order A100 is shipped.",
+          "expectedResponse": "Order A100 is shipped.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": {
+                "order_id": "A100"
+              },
+              "result": {
+                "status": "shipped"
+              }
+            }
+          ],
+          "expectedToolTrajectory": [
+            {
+              "name": "lookup_order",
+              "arguments": {
+                "order_id": "A100"
+              },
+              "result": {
+                "status": "shipped"
+              }
+            }
+          ],
+          "attributions": []
+        },
+        {
+          "evalSetId": "train",
+          "evalId": "train_format",
+          "score": 0.9,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.9,
+              "passed": true
+            }
+          ],
+          "finalResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+          "expectedResponse": "{\"refund_id\":\"R55\",\"status\":\"approved\"}",
+          "attributions": []
+        },
+        {
+          "evalSetId": "train",
+          "evalId": "train_knowledge_recall",
+          "score": 0.85,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.85,
+              "passed": true
+            }
+          ],
+          "finalResponse": "Premium support SLA is 2 hours.",
+          "expectedResponse": "Premium support SLA is 2 hours.",
+          "attributions": []
+        }
+      ],
+      "cost": {
+        "calls": 3,
+        "estimatedCost": 0.003
+      },
+      "latency": {
+        "totalMs": 15
+      }
+    },
+    "validation": {
+      "evalSetId": "validation",
+      "score": 0.8633333333333333,
+      "status": "passed",
+      "cases": [
+        {
+          "evalSetId": "validation",
+          "evalId": "val_tool_selection",
+          "score": 0.92,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.92,
+              "passed": true
+            }
+          ],
+          "finalResponse": "Tracking T900 arrives tomorrow.",
+          "expectedResponse": "Tracking T900 arrives tomorrow.",
+          "toolTrajectory": [
+            {
+              "name": "lookup_tracking",
+              "arguments": {
+                "tracking_id": "T900"
+              },
+              "result": {
+                "eta": "tomorrow"
+              }
+            }
+          ],
+          "expectedToolTrajectory": [
+            {
+              "name": "lookup_tracking",
+              "arguments": {
+                "tracking_id": "T900"
+              },
+              "result": {
+                "eta": "tomorrow"
+              }
+            }
+          ],
+          "attributions": []
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_route_skill",
+          "score": 0.82,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.82,
+              "passed": true
+            }
+          ],
+          "finalResponse": "Routed to account support.",
+          "expectedResponse": "Routed to account support.",
+          "traceSummary": "route selected account_support",
+          "attributions": []
+        },
+        {
+          "evalSetId": "validation",
+          "evalId": "val_json_receipt",
+          "critical": true,
+          "score": 0.85,
+          "passed": true,
+          "hardFail": false,
+          "metricResults": [
+            {
+              "name": "deterministic_quality",
+              "score": 0.85,
+              "passed": true
+            }
+          ],
+          "finalResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+          "expectedResponse": "{\"payment_id\":\"P77\",\"status\":\"captured\"}",
+          "attributions": []
+        }
+      ],
+      "cost": {
+        "calls": 3,
+        "estimatedCost": 0.003
+      },
+      "latency": {
+        "totalMs": 15
+      }
+    },
+    "delta": [
+      {
+        "evalSetId": "validation",
+        "evalId": "val_json_receipt",
+        "baselineScore": 0.8,
+        "candidateScore": 0.85,
+        "scoreDelta": 0.04999999999999993,
+        "baselinePassed": true,
+        "candidatePassed": true,
+        "transition": "improved",
+        "newHardFail": false,
+        "criticalRegression": false
+      },
+      {
+        "evalSetId": "validation",
+        "evalId": "val_route_skill",
+        "baselineScore": 0.65,
+        "candidateScore": 0.82,
+        "scoreDelta": 0.16999999999999993,
+        "candidatePassed": true,
+        "transition": "newly_passed",
+        "newHardFail": false,
+        "criticalRegression": false,
+        "attributionChange": "candidate attribution cleared"
+      },
+      {
+        "evalSetId": "validation",
+        "evalId": "val_tool_selection",
+        "baselineScore": 0.5,
+        "candidateScore": 0.92,
+        "scoreDelta": 0.42000000000000004,
+        "candidatePassed": true,
+        "transition": "newly_passed",
+        "newHardFail": false,
+        "criticalRegression": false,
+        "attributionChange": "candidate attribution cleared"
+      }
+    ],
+    "gateDecision": {
+      "accepted": true,
+      "scoreDelta": 0.21333333333333326,
+      "passedRules": [
+        "validation_score_gain",
+        "no_new_hard_fails",
+        "critical_case_non_regression",
+        "max_cost",
+        "max_calls",
+        "max_latency"
+      ],
+      "reasons": [
+        "candidate satisfies all acceptance gates"
+      ]
+    },
+    "cost": {
+      "calls": 6,
+      "estimatedCost": 0.006
+    },
+    "latency": {
+      "totalMs": 30
+    }
+  },
+  "delta": {
+    "summary": {
+      "newlyPassed": 2,
+      "newlyFailed": 0,
+      "improved": 1,
+      "regressed": 0,
+      "unchanged": 0,
+      "newHardFails": 0,
+      "criticalRegressions": 0
+    },
+    "cases": [
+      {
+        "evalSetId": "validation",
+        "evalId": "val_json_receipt",
+        "baselineScore": 0.8,
+        "candidateScore": 0.85,
+        "scoreDelta": 0.04999999999999993,
+        "baselinePassed": true,
+        "candidatePassed": true,
+        "transition": "improved",
+        "newHardFail": false,
+        "criticalRegression": false
+      },
+      {
+        "evalSetId": "validation",
+        "evalId": "val_route_skill",
+        "baselineScore": 0.65,
+        "candidateScore": 0.82,
+        "scoreDelta": 0.16999999999999993,
+        "candidatePassed": true,
+        "transition": "newly_passed",
+        "newHardFail": false,
+        "criticalRegression": false,
+        "attributionChange": "candidate attribution cleared"
+      },
+      {
+        "evalSetId": "validation",
+        "evalId": "val_tool_selection",
+        "baselineScore": 0.5,
+        "candidateScore": 0.92,
+        "scoreDelta": 0.42000000000000004,
+        "candidatePassed": true,
+        "transition": "newly_passed",
+        "newHardFail": false,
+        "criticalRegression": false,
+        "attributionChange": "candidate attribution cleared"
+      }
+    ]
+  },
+  "gateDecision": {
+    "accepted": true,
+    "scoreDelta": 0.21333333333333326,
+    "passedRules": [
+      "validation_score_gain",
+      "no_new_hard_fails",
+      "critical_case_non_regression",
+      "max_cost",
+      "max_calls",
+      "max_latency"
+    ],
+    "reasons": [
+      "candidate satisfies all acceptance gates"
+    ]
+  },
+  "failureAttributionStats": {
+    "format_error": 3,
+    "knowledge_recall_insufficient": 2,
+    "routing_error": 3,
+    "tool_argument_error": 2,
+    "tool_selection_error": 2
+  },
+  "costSummary": {
+    "calls": 24,
+    "estimatedCost": 0.024
+  },
+  "latencySummary": {
+    "totalMs": 120
+  },
+  "artifacts": [
+    "./output/optimization_report.json",
+    "./output/optimization_report.md"
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
@@ -1,7 +1,7 @@
 {
   "run": {
     "appName": "promptiter-regression-loop-app",
-    "startedAt": "2026-07-08T20:22:00+08:00",
+    "startedAt": "2026-07-13T11:34:52+08:00",
     "durationMs": 0,
     "seed": 20260708,
     "runner": {
@@ -462,6 +462,7 @@
         "scoreDelta": 0.21333333333333326,
         "passedRules": [
           "validation_score_gain",
+          "validation_case_coverage",
           "no_new_hard_fails",
           "critical_case_non_regression",
           "max_cost",
@@ -749,6 +750,7 @@
         "accepted": false,
         "scoreDelta": 0.006666666666666599,
         "passedRules": [
+          "validation_case_coverage",
           "no_new_hard_fails",
           "critical_case_non_regression",
           "max_cost",
@@ -1016,6 +1018,7 @@
         "accepted": false,
         "scoreDelta": -0.1166666666666667,
         "passedRules": [
+          "validation_case_coverage",
           "max_cost",
           "max_calls",
           "max_latency"
@@ -1263,6 +1266,7 @@
       "scoreDelta": 0.21333333333333326,
       "passedRules": [
         "validation_score_gain",
+        "validation_case_coverage",
         "no_new_hard_fails",
         "critical_case_non_regression",
         "max_cost",
@@ -1335,6 +1339,7 @@
     "scoreDelta": 0.21333333333333326,
     "passedRules": [
       "validation_score_gain",
+      "validation_case_coverage",
       "no_new_hard_fails",
       "critical_case_non_regression",
       "max_cost",
@@ -1360,7 +1365,7 @@
     "totalMs": 120
   },
   "artifacts": [
-    "./output/optimization_report.json",
-    "./output/optimization_report.md"
+    "promptiter_regression_loop/output/optimization_report.json",
+    "promptiter_regression_loop/output/optimization_report.md"
   ]
 }

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
@@ -29,9 +29,9 @@ Duration: `0ms`
 
 | Case | Baseline | Candidate | Delta | Transition | New hard fail | Critical regression |
 | --- | ---: | ---: | ---: | --- | --- | --- |
-| `val_json_receipt` | 0.80 | 0.85 | 0.05 | `improved` | `false` | `false` |
-| `val_route_skill` | 0.65 | 0.82 | 0.17 | `newly_passed` | `false` | `false` |
-| `val_tool_selection` | 0.50 | 0.92 | 0.42 | `newly_passed` | `false` | `false` |
+| val_json_receipt | 0.80 | 0.85 | 0.05 | `improved` | `false` | `false` |
+| val_route_skill | 0.65 | 0.82 | 0.17 | `newly_passed` | `false` | `false` |
+| val_tool_selection | 0.50 | 0.92 | 0.42 | `newly_passed` | `false` | `false` |
 
 ## Failure Attribution
 
@@ -46,19 +46,31 @@ Duration: `0ms`
 ### Round 1
 
 - Accepted: `true`
-- Prompt: `SUCCESS_PROMPT: call tools only when needed, preserve final answer format, and verify numeric facts.`
+- Prompt:
+
+```text
+SUCCESS_PROMPT: call tools only when needed, preserve final answer format, and verify numeric facts.
+```
 - Gate reason: candidate satisfies all acceptance gates
 
 ### Round 2
 
 - Accepted: `false`
-- Prompt: `INEFFECTIVE_PROMPT: be helpful and concise.`
+- Prompt:
+
+```text
+INEFFECTIVE_PROMPT: be helpful and concise.
+```
 - Gate reason: validation score gain 0.0067 is below threshold 0.0500
 
 ### Round 3
 
 - Accepted: `false`
-- Prompt: `OVERFIT_PROMPT: optimize train cases aggressively even if validation formatting changes.`
+- Prompt:
+
+```text
+OVERFIT_PROMPT: optimize train cases aggressively even if validation formatting changes.
+```
 - Gate reason: validation score gain -0.1167 is below threshold 0.0500
 - Gate reason: candidate introduced 1 new hard fail(s)
 - Gate reason: candidate regressed 1 critical case(s)
@@ -71,5 +83,5 @@ Duration: `0ms`
 
 ## Artifacts
 
-- `./output/optimization_report.json`
-- `./output/optimization_report.md`
+- `promptiter_regression_loop/output/optimization_report.json`
+- `promptiter_regression_loop/output/optimization_report.md`

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
@@ -1,0 +1,75 @@
+# Optimization Report
+
+Decision: **ACCEPT**
+
+App: `promptiter-regression-loop-app`
+
+Seed: `20260708`
+
+Runner: `fake`
+
+Duration: `0ms`
+
+## Score Summary
+
+| Phase | Train | Validation |
+| --- | ---: | ---: |
+| Baseline | 0.40 | 0.65 |
+| Candidate 1 | 0.90 | 0.86 |
+| Candidate 2 | 0.43 | 0.66 |
+| Candidate 3 | 0.98 | 0.53 |
+
+## Gate Decision
+
+- Accepted: `true`
+- Validation score delta: `0.21`
+- Reason: candidate satisfies all acceptance gates
+
+## Validation Delta
+
+| Case | Baseline | Candidate | Delta | Transition | New hard fail | Critical regression |
+| --- | ---: | ---: | ---: | --- | --- | --- |
+| `val_json_receipt` | 0.80 | 0.85 | 0.05 | `improved` | `false` | `false` |
+| `val_route_skill` | 0.65 | 0.82 | 0.17 | `newly_passed` | `false` | `false` |
+| `val_tool_selection` | 0.50 | 0.92 | 0.42 | `newly_passed` | `false` | `false` |
+
+## Failure Attribution
+
+- `format_error`: 3
+- `knowledge_recall_insufficient`: 2
+- `routing_error`: 3
+- `tool_argument_error`: 2
+- `tool_selection_error`: 2
+
+## Candidate Rounds
+
+### Round 1
+
+- Accepted: `true`
+- Prompt: `SUCCESS_PROMPT: call tools only when needed, preserve final answer format, and verify numeric facts.`
+- Gate reason: candidate satisfies all acceptance gates
+
+### Round 2
+
+- Accepted: `false`
+- Prompt: `INEFFECTIVE_PROMPT: be helpful and concise.`
+- Gate reason: validation score gain 0.0067 is below threshold 0.0500
+
+### Round 3
+
+- Accepted: `false`
+- Prompt: `OVERFIT_PROMPT: optimize train cases aggressively even if validation formatting changes.`
+- Gate reason: validation score gain -0.1167 is below threshold 0.0500
+- Gate reason: candidate introduced 1 new hard fail(s)
+- Gate reason: candidate regressed 1 critical case(s)
+
+## Cost and Latency
+
+- Calls: `24`
+- Estimated cost: `0.0240`
+- Total latency: `120ms`
+
+## Artifacts
+
+- `./output/optimization_report.json`
+- `./output/optimization_report.md`

--- a/examples/evaluation/promptiter_regression_loop/promptiter_fake.go
+++ b/examples/evaluation/promptiter_regression_loop/promptiter_fake.go
@@ -1,0 +1,31 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regressionloop"
+)
+
+const (
+	candidateSuccess     = "SUCCESS_PROMPT: call tools only when needed, preserve final answer format, and verify numeric facts."
+	candidateIneffective = "INEFFECTIVE_PROMPT: be helpful and concise."
+	candidateOverfit     = "OVERFIT_PROMPT: optimize train cases aggressively even if validation formatting changes."
+)
+
+type fakeOptimizer struct{}
+
+func (fakeOptimizer) Candidates(ctx context.Context, req regressionloop.OptimizationRequest) ([]regressionloop.Candidate, error) {
+	return []regressionloop.Candidate{
+		{Round: 1, Prompt: candidateSuccess, Reason: "fix tool and format failures without changing validation-critical behavior"},
+		{Round: 2, Prompt: candidateIneffective, Reason: "generic rewrite with no material validation gain"},
+		{Round: 3, Prompt: candidateOverfit, Reason: "train-focused prompt that causes validation regression"},
+	}, nil
+}

--- a/examples/evaluation/promptiter_regression_loop/runner_fake.go
+++ b/examples/evaluation/promptiter_regression_loop/runner_fake.go
@@ -1,0 +1,126 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regressionloop"
+)
+
+type fakeEvaluator struct{}
+
+type fakeEvalSet struct {
+	EvalSetID string     `json:"evalSetId"`
+	Name      string     `json:"name"`
+	EvalCases []fakeCase `json:"evalCases"`
+}
+
+type fakeCase struct {
+	EvalID                  string                     `json:"evalId"`
+	Critical                bool                       `json:"critical,omitempty"`
+	ExpectedFailureCategory string                     `json:"expectedFailureCategory,omitempty"`
+	UserInput               string                     `json:"userInput"`
+	ExpectedResponse        string                     `json:"expectedResponse"`
+	ExpectedTools           []regressionloop.ToolCall  `json:"expectedTools,omitempty"`
+	FakeOutcomes            map[string]fakeCaseOutcome `json:"fakeOutcomes"`
+}
+
+type fakeCaseOutcome struct {
+	Score                  float64                   `json:"score"`
+	Passed                 bool                      `json:"passed"`
+	HardFail               bool                      `json:"hardFail,omitempty"`
+	FinalResponse          string                    `json:"finalResponse"`
+	ToolTrajectory         []regressionloop.ToolCall `json:"toolTrajectory,omitempty"`
+	TraceSummary           string                    `json:"traceSummary,omitempty"`
+	RubricReason           string                    `json:"rubricReason,omitempty"`
+	StructuredOutputStatus string                    `json:"structuredOutputStatus,omitempty"`
+	FailureReasons         []string                  `json:"failureReasons,omitempty"`
+}
+
+func newFakeEvaluator() fakeEvaluator {
+	return fakeEvaluator{}
+}
+
+func (fakeEvaluator) Evaluate(ctx context.Context, req regressionloop.EvaluationRequest) (regressionloop.EvaluationSummary, error) {
+	data, err := os.ReadFile(req.EvalSet.Path)
+	if err != nil {
+		return regressionloop.EvaluationSummary{}, fmt.Errorf("read evalset %s: %w", req.EvalSet.Path, err)
+	}
+	var set fakeEvalSet
+	if err := json.Unmarshal(data, &set); err != nil {
+		return regressionloop.EvaluationSummary{}, fmt.Errorf("decode evalset %s: %w", req.EvalSet.Path, err)
+	}
+	key := promptKey(req.Prompt)
+	cases := make([]regressionloop.CaseResult, 0, len(set.EvalCases))
+	total := 0.0
+	for _, evalCase := range set.EvalCases {
+		outcome, ok := evalCase.FakeOutcomes[key]
+		if !ok {
+			return regressionloop.EvaluationSummary{}, fmt.Errorf("missing fake outcome for case %s prompt %s", evalCase.EvalID, key)
+		}
+		result := regressionloop.CaseResult{
+			EvalSetID:              set.EvalSetID,
+			EvalID:                 evalCase.EvalID,
+			Critical:               evalCase.Critical,
+			Score:                  outcome.Score,
+			Passed:                 outcome.Passed,
+			HardFail:               outcome.HardFail,
+			FinalResponse:          outcome.FinalResponse,
+			ExpectedResponse:       evalCase.ExpectedResponse,
+			ToolTrajectory:         outcome.ToolTrajectory,
+			ExpectedToolTrajectory: evalCase.ExpectedTools,
+			TraceSummary:           outcome.TraceSummary,
+			RubricReason:           outcome.RubricReason,
+			StructuredOutputStatus: outcome.StructuredOutputStatus,
+			FailureReasons:         outcome.FailureReasons,
+			MetricResults: []regressionloop.MetricResult{{
+				Name:     "deterministic_quality",
+				Score:    outcome.Score,
+				Passed:   outcome.Passed,
+				HardFail: outcome.HardFail,
+				Reason:   strings.Join(outcome.FailureReasons, "; "),
+			}},
+		}
+		cases = append(cases, result)
+		total += outcome.Score
+	}
+	status := "passed"
+	for _, c := range cases {
+		if !c.Passed {
+			status = "failed"
+			break
+		}
+	}
+	return regressionloop.EvaluationSummary{
+		EvalSetID: set.EvalSetID,
+		Score:     total / float64(len(cases)),
+		Status:    status,
+		Cases:     cases,
+		Cost:      regressionloop.CostSummary{Calls: len(cases), EstimatedCost: float64(len(cases)) * 0.001},
+		Latency:   regressionloop.LatencySummary{TotalMS: int64(len(cases) * 5)},
+	}, nil
+}
+
+func promptKey(prompt string) string {
+	switch {
+	case strings.Contains(prompt, "SUCCESS_PROMPT"):
+		return "candidate_success"
+	case strings.Contains(prompt, "INEFFECTIVE_PROMPT"):
+		return "candidate_ineffective"
+	case strings.Contains(prompt, "OVERFIT_PROMPT"):
+		return "candidate_overfit"
+	default:
+		return "baseline"
+	}
+}

--- a/examples/evaluation/promptiter_regression_loop/runner_fake.go
+++ b/examples/evaluation/promptiter_regression_loop/runner_fake.go
@@ -61,6 +61,9 @@ func (fakeEvaluator) Evaluate(ctx context.Context, req regressionloop.Evaluation
 	if err := json.Unmarshal(data, &set); err != nil {
 		return regressionloop.EvaluationSummary{}, fmt.Errorf("decode evalset %s: %w", req.EvalSet.Path, err)
 	}
+	if len(set.EvalCases) == 0 {
+		return regressionloop.EvaluationSummary{}, fmt.Errorf("evalset %s has no eval cases", req.EvalSet.ID)
+	}
 	key := promptKey(req.Prompt)
 	cases := make([]regressionloop.CaseResult, 0, len(set.EvalCases))
 	total := 0.0


### PR DESCRIPTION
## Summary

- add an auditable PromptIter regression loop package under evaluation/workflow/promptiter/regressionloop
- support deterministic baseline evaluation, failure attribution, candidate validation deltas, gate decisions, and JSON/Markdown report generation
- add a runnable deterministic example with train/validation evalsets, metrics, config, sample reports, README, and design notes

Fixes #2003

## Validation

- git diff --cached --check
- cd evaluation && go test ./workflow/promptiter/regressionloop
- cd examples/evaluation && go test ./promptiter_regression_loop
- cd examples/evaluation && go run ./promptiter_regression_loop -config promptiter_regression_loop/data/promptiter-regression-loop-app/promptiter.json -output-dir /tmp/promptiter-regression-loop-check