### PR TITLE
evolution: protect managed skill deletion

### DIFF
--- a/evolution/worker.go
+++ b/evolution/worker.go
@@ -12,6 +12,7 @@ package evolution
 import (
 	"context"
 	"hash/fnv"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -1050,7 +1051,7 @@ func (w *worker) isEvolutionManagedSkill(name string, repo skill.Repository, sco
 	if err != nil {
 		return false
 	}
-	return !strings.HasPrefix(rel, "..")
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel)
 }
 
 func (w *worker) applyUpdates(ctx context.Context, updates []*SkillUpdate, scope skill.SkillScope, scoped bool, repo skill.Repository) bool {
@@ -1100,8 +1101,15 @@ func (w *worker) applyDeletions(ctx context.Context, names []string, scope skill
 	}
 	mutated := false
 	for _, name := range names {
-		if name == "" || !skillExists(repo, name) {
+		if strings.TrimSpace(name) == "" || !skillExists(repo, name) {
 			// Idempotent: nothing to delete (or never existed).
+			continue
+		}
+		// Write isolation: only delete skills that live within the
+		// evolution-managed directory. Bundled and user-authored skills
+		// are protected from accidental deletion.
+		if !w.isEvolutionManagedSkill(name, repo, scope, scoped) {
+			log.WarnfContext(ctx, "evolution: delete skill %q skipped: not evolution-managed (protected)", name)
 			continue
 		}
 		if err := publisher.DeleteSkill(ctx, name); err != nil {

--- a/evolution/worker_test.go
+++ b/evolution/worker_test.go
@@ -2370,6 +2370,88 @@ func TestWorker_ApplyUpdates_AllowsEvolutionSkill(t *testing.T) {
 	pub.mu.Unlock()
 }
 
+func TestWorker_ApplyDeletions_SkipsNonEvolutionSkill(t *testing.T) {
+	root := t.TempDir()
+	managedDir := filepath.Join(root, "skills", "evolution")
+	pub := &mockPublisher{}
+	repo := &mockSkillRepo{
+		summaries: []skill.Summary{
+			{Name: "User Skill", Description: "user-authored skill"},
+		},
+		bodies: map[string]string{"User Skill": "body"},
+		paths: map[string]string{
+			"User Skill": filepath.Join(root, "skills", "local", "user-skill"),
+		},
+	}
+	rev := &mockReviewer{
+		decision: &ReviewDecision{
+			Deletions: []string{"User Skill"},
+		},
+	}
+	w := newWorker(workerConfig{
+		Reviewer:         rev,
+		Publisher:        pub,
+		ReviewPolicy:     alwaysReviewPolicy{},
+		SkillRepo:        repo,
+		ManagedSkillsDir: managedDir,
+	})
+
+	sess := newTestSession()
+	addEvents(sess,
+		model.Message{Role: model.RoleUser, Content: "delete user skill"},
+		model.Message{Role: model.RoleAssistant, Content: "ok"},
+	)
+	w.processJob(&pendingJob{ctx: context.Background(), job: LearningJob{Session: sess}})
+
+	pub.mu.Lock()
+	assert.Empty(t, pub.deletions, "delete to user-authored skill should be skipped")
+	pub.mu.Unlock()
+	repo.mu.Lock()
+	assert.Equal(t, 0, repo.refreshed, "repo should not refresh when deletion was skipped")
+	repo.mu.Unlock()
+}
+
+func TestWorker_ApplyDeletions_AllowsEvolutionSkill(t *testing.T) {
+	root := t.TempDir()
+	managedDir := filepath.Join(root, "skills", "evolution")
+	pub := &mockPublisher{}
+	repo := &mockSkillRepo{
+		summaries: []skill.Summary{
+			{Name: "Learned Analysis", Description: "evolution skill"},
+		},
+		bodies: map[string]string{"Learned Analysis": "body"},
+		paths: map[string]string{
+			"Learned Analysis": filepath.Join(managedDir, "learned-analysis"),
+		},
+	}
+	rev := &mockReviewer{
+		decision: &ReviewDecision{
+			Deletions: []string{"Learned Analysis"},
+		},
+	}
+	w := newWorker(workerConfig{
+		Reviewer:         rev,
+		Publisher:        pub,
+		ReviewPolicy:     alwaysReviewPolicy{},
+		SkillRepo:        repo,
+		ManagedSkillsDir: managedDir,
+	})
+
+	sess := newTestSession()
+	addEvents(sess,
+		model.Message{Role: model.RoleUser, Content: "delete learned skill"},
+		model.Message{Role: model.RoleAssistant, Content: "ok"},
+	)
+	w.processJob(&pendingJob{ctx: context.Background(), job: LearningJob{Session: sess}})
+
+	pub.mu.Lock()
+	require.Equal(t, []string{"Learned Analysis"}, pub.deletions, "delete to evolution skill should be allowed")
+	pub.mu.Unlock()
+	repo.mu.Lock()
+	assert.Equal(t, 1, repo.refreshed)
+	repo.mu.Unlock()
+}
+
 func TestWorker_ApplyUpdates_NoIsolationWhenManagedDirEmpty(t *testing.T) {
 	pub := &mockPublisher{}
 	repo := &mockSkillRepo{


### PR DESCRIPTION
## Summary

- Add the same evolution-managed ownership guard to the non-approval deletion path that updates and approval-gated deletions already use.
- Tighten managed path containment checks to avoid false positives from sibling paths.
- Cover deletion behavior for protected user-authored skills and evolution-managed skills.

## Validation

- `go test ./evolution`
- `go test ./evolution -cover` passes with 90.7% statement coverage
- `go test ./...` was run locally; unrelated existing failures were observed on macOS:
  - `tool/hostexec` references Linux-only `syscall.SysProcAttr.Pdeathsig` in tests
  - `tool/duckduckgo` failed to bind its Unix socket in a temp path
