### PR TITLE
tool/hostexec: split linux sysproc tests

### DIFF
--- a/tool/hostexec/hostexec_linux_test.go
+++ b/tool/hostexec/hostexec_linux_test.go
@@ -1,0 +1,40 @@
+//go:build linux
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hostexec
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyParentDeathSignal(t *testing.T) {
+	applyParentDeathSignal(nil)
+
+	attr := &syscall.SysProcAttr{}
+	applyParentDeathSignal(attr)
+	require.Equal(t, syscall.SIGTERM, attr.Pdeathsig)
+}
+
+func TestPrepareCommandsParentDeathSignal(t *testing.T) {
+	pipeCmd := &exec.Cmd{}
+	preparePipeCommand(pipeCmd)
+	require.NotNil(t, pipeCmd.SysProcAttr)
+	require.Equal(t, syscall.SIGTERM, pipeCmd.SysProcAttr.Pdeathsig)
+
+	ptyCmd := &exec.Cmd{}
+	preparePTYCommand(ptyCmd)
+	require.NotNil(t, ptyCmd.SysProcAttr)
+	require.Equal(t, syscall.SIGTERM, ptyCmd.SysProcAttr.Pdeathsig)
+}

--- a/tool/hostexec/hostexec_unix_test.go
+++ b/tool/hostexec/hostexec_unix_test.go
@@ -56,14 +56,6 @@ func waitForProcessExit(
 	t.Fatalf("background child pid %d is still alive", pid)
 }
 
-func TestApplyParentDeathSignal(t *testing.T) {
-	applyParentDeathSignal(nil)
-
-	attr := &syscall.SysProcAttr{}
-	applyParentDeathSignal(attr)
-	require.Equal(t, syscall.SIGTERM, attr.Pdeathsig)
-}
-
 func TestPrepareCommands(t *testing.T) {
 	preparePipeCommand(nil)
 	preparePTYCommand(nil)
@@ -72,13 +64,11 @@ func TestPrepareCommands(t *testing.T) {
 	preparePipeCommand(pipeCmd)
 	require.NotNil(t, pipeCmd.SysProcAttr)
 	require.True(t, pipeCmd.SysProcAttr.Setpgid)
-	require.Equal(t, syscall.SIGTERM, pipeCmd.SysProcAttr.Pdeathsig)
 
 	ptyCmd := &exec.Cmd{}
 	preparePTYCommand(ptyCmd)
 	require.NotNil(t, ptyCmd.SysProcAttr)
 	require.False(t, ptyCmd.SysProcAttr.Setpgid)
-	require.Equal(t, syscall.SIGTERM, ptyCmd.SysProcAttr.Pdeathsig)
 }
 
 func TestCommandProcessGroupID(t *testing.T) {


### PR DESCRIPTION
## Summary
- Move `SysProcAttr.Pdeathsig` assertions into Linux-only hostexec tests.
- Keep the shared Unix hostexec tests limited to portable `SysProcAttr` fields.

## Validation
- `go test ./tool/hostexec`
- `GOOS=linux GOARCH=amd64 go test -c ./tool/hostexec`
- PR checks pass, including `Pull Request Check`, `GITHUB_OPENSOURCE_SCAN_PIPELINE@PULL_REQUEST`, `test@PULL_REQUEST`, and Codecov patch coverage.