### PR TITLE
agent: avoid copying opaque invocation state

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -1751,10 +1751,8 @@ func cloneStateReflectValue(
 	value reflect.Value,
 	visited map[reflectVisit]reflect.Value,
 ) (reflect.Value, bool) {
-	if value.IsValid() && value.CanInterface() {
-		if cloned, ok := cloneKnownStateValue(value.Interface()); ok {
-			return reflect.ValueOf(cloned), true
-		}
+	if cloned, ok := cloneKnownStateReflectValue(value); ok {
+		return cloned, true
 	}
 	switch value.Kind() {
 	case reflect.Interface:
@@ -1777,31 +1775,49 @@ func cloneStateReflectValue(
 	}
 }
 
-func cloneKnownStateValue(value any) (any, bool) {
-	switch v := value.(type) {
-	case *bytes.Buffer:
-		if v == nil {
-			return v, true
+var (
+	bytesBufferStateType    = reflect.TypeOf(bytes.Buffer{})
+	bytesBufferPtrStateType = reflect.TypeOf((*bytes.Buffer)(nil))
+	stringBuilderStateType  = reflect.TypeOf((*strings.Builder)(nil))
+	bigIntStateType         = reflect.TypeOf(big.Int{})
+	bigIntPtrStateType      = reflect.TypeOf((*big.Int)(nil))
+)
+
+func cloneKnownStateReflectValue(value reflect.Value) (reflect.Value, bool) {
+	if !value.IsValid() || !value.CanInterface() {
+		return reflect.Value{}, false
+	}
+	// Match by type before calling Interface. Interface on an arbitrary struct
+	// copies its fields, which is unsafe for opaque state carrying locks.
+	switch value.Type() {
+	case bytesBufferPtrStateType:
+		if value.IsNil() {
+			return value, true
 		}
-		return bytes.NewBuffer(cloneBytes(v.Bytes())), true
-	case bytes.Buffer:
-		return *bytes.NewBuffer(cloneBytes(v.Bytes())), true
-	case *strings.Builder:
-		if v == nil {
-			return v, true
+		v := value.Interface().(*bytes.Buffer)
+		return reflect.ValueOf(bytes.NewBuffer(cloneBytes(v.Bytes()))), true
+	case bytesBufferStateType:
+		v := value.Interface().(bytes.Buffer)
+		return reflect.ValueOf(*bytes.NewBuffer(cloneBytes(v.Bytes()))), true
+	case stringBuilderStateType:
+		if value.IsNil() {
+			return value, true
 		}
+		v := value.Interface().(*strings.Builder)
 		var cloned strings.Builder
 		_, _ = cloned.WriteString(v.String())
-		return &cloned, true
-	case *big.Int:
-		if v == nil {
-			return v, true
+		return reflect.ValueOf(&cloned), true
+	case bigIntPtrStateType:
+		if value.IsNil() {
+			return value, true
 		}
-		return new(big.Int).Set(v), true
-	case big.Int:
-		return *new(big.Int).Set(&v), true
+		v := value.Interface().(*big.Int)
+		return reflect.ValueOf(new(big.Int).Set(v)), true
+	case bigIntStateType:
+		v := value.Interface().(big.Int)
+		return reflect.ValueOf(*new(big.Int).Set(&v)), true
 	default:
-		return nil, false
+		return reflect.Value{}, false
 	}
 }
 

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -751,6 +752,141 @@ func TestInvocation_ViewCopiesNestedMutableCustomState(t *testing.T) {
 	sourceNode, ok := sourceValue.(*customNode)
 	require.True(t, ok)
 	require.Equal(t, []byte("ghi"), sourceNode.Data)
+}
+
+func TestInvocation_ViewClonesKnownMutableState(t *testing.T) {
+	const (
+		bufferPtrStateKey   = "custom:buffer_ptr"
+		bufferValueStateKey = "custom:buffer_value"
+		builderStateKey     = "custom:builder"
+		bigPtrStateKey      = "custom:big_ptr"
+		bigValueStateKey    = "custom:big_value"
+	)
+	bufferPtr := bytes.NewBufferString("abc")
+	bufferValue := *bytes.NewBufferString("def")
+	var builder strings.Builder
+	builder.WriteString("ghi")
+	bigPtr := big.NewInt(10)
+	bigValue := *big.NewInt(20)
+
+	inv := NewInvocation()
+	inv.SetState(bufferPtrStateKey, bufferPtr)
+	inv.SetState(bufferValueStateKey, bufferValue)
+	inv.SetState(builderStateKey, &builder)
+	inv.SetState(bigPtrStateKey, bigPtr)
+	inv.SetState(bigValueStateKey, bigValue)
+
+	view := inv.View()
+	viewBufferPtr, ok := GetStateValue[*bytes.Buffer](view, bufferPtrStateKey)
+	require.True(t, ok)
+	require.NotSame(t, bufferPtr, viewBufferPtr)
+	viewBufferPtr.WriteString("-view")
+	require.Equal(t, "abc", bufferPtr.String())
+
+	viewBufferValue, ok := GetStateValue[bytes.Buffer](view, bufferValueStateKey)
+	require.True(t, ok)
+	viewBufferValue.WriteString("-view")
+	sourceBufferValue, ok := GetStateValue[bytes.Buffer](inv, bufferValueStateKey)
+	require.True(t, ok)
+	require.Equal(t, "def", sourceBufferValue.String())
+
+	viewBuilder, ok := GetStateValue[*strings.Builder](view, builderStateKey)
+	require.True(t, ok)
+	require.NotSame(t, &builder, viewBuilder)
+	viewBuilder.WriteString("-view")
+	require.Equal(t, "ghi", builder.String())
+
+	viewBigPtr, ok := GetStateValue[*big.Int](view, bigPtrStateKey)
+	require.True(t, ok)
+	require.NotSame(t, bigPtr, viewBigPtr)
+	viewBigPtr.Add(viewBigPtr, big.NewInt(1))
+	require.Equal(t, int64(10), bigPtr.Int64())
+
+	viewBigValue, ok := GetStateValue[big.Int](view, bigValueStateKey)
+	require.True(t, ok)
+	viewBigValue.Add(&viewBigValue, big.NewInt(1))
+	sourceBigValue, ok := GetStateValue[big.Int](inv, bigValueStateKey)
+	require.True(t, ok)
+	require.Equal(t, int64(20), sourceBigValue.Int64())
+}
+
+func TestInvocation_ViewKeepsNilKnownMutablePointers(t *testing.T) {
+	const (
+		nilBufferStateKey  = "custom:nil_buffer"
+		nilBuilderStateKey = "custom:nil_builder"
+		nilBigStateKey     = "custom:nil_big"
+	)
+	var (
+		nilBuffer  *bytes.Buffer
+		nilBuilder *strings.Builder
+		nilBig     *big.Int
+	)
+	inv := NewInvocation()
+	inv.SetState(nilBufferStateKey, nilBuffer)
+	inv.SetState(nilBuilderStateKey, nilBuilder)
+	inv.SetState(nilBigStateKey, nilBig)
+
+	view := inv.View()
+	viewBuffer, ok := GetStateValue[*bytes.Buffer](view, nilBufferStateKey)
+	require.True(t, ok)
+	require.Nil(t, viewBuffer)
+	viewBuilder, ok := GetStateValue[*strings.Builder](view, nilBuilderStateKey)
+	require.True(t, ok)
+	require.Nil(t, viewBuilder)
+	viewBig, ok := GetStateValue[*big.Int](view, nilBigStateKey)
+	require.True(t, ok)
+	require.Nil(t, viewBig)
+}
+
+func TestInvocation_ViewKeepsOpaqueStateByReference(t *testing.T) {
+	const opaqueStateKey = "custom:opaque"
+	type opaqueState struct {
+		mu    sync.Mutex
+		value int
+	}
+	source := &opaqueState{value: 1}
+	inv := NewInvocation()
+	inv.SetState(opaqueStateKey, source)
+
+	view := inv.View()
+	viewState, ok := GetStateValue[*opaqueState](view, opaqueStateKey)
+	require.True(t, ok)
+	require.Same(t, source, viewState)
+}
+
+func TestInvocationViewDoesNotRaceWithOpaqueStateMutation(t *testing.T) {
+	const opaqueStateKey = "custom:opaque"
+	type opaqueState struct {
+		mu    sync.Mutex
+		value int
+	}
+	source := &opaqueState{}
+	inv := NewInvocation()
+	inv.SetState(opaqueStateKey, source)
+
+	const iterations = 10000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			_ = inv.View()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			source.mu.Lock()
+			source.value++
+			source.mu.Unlock()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }
 
 func TestCloneStateValueHandlesEdgeCases(t *testing.T) {

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -889,6 +889,20 @@ func TestInvocationViewDoesNotRaceWithOpaqueStateMutation(t *testing.T) {
 	wg.Wait()
 }
 
+func TestCloneKnownStateReflectValueRejectsUnsafeReflectValues(t *testing.T) {
+	cloned, ok := cloneKnownStateReflectValue(reflect.Value{})
+	require.False(t, ok)
+	require.False(t, cloned.IsValid())
+
+	type opaqueState struct {
+		hidden int
+	}
+	hiddenField := reflect.ValueOf(opaqueState{hidden: 1}).Field(0)
+	cloned, ok = cloneKnownStateReflectValue(hiddenField)
+	require.False(t, ok)
+	require.False(t, cloned.IsValid())
+}
+
 func TestCloneStateValueHandlesEdgeCases(t *testing.T) {
 	type namedString string
 	type customPayload struct {

--- a/internal/state/steer/steer_test.go
+++ b/internal/state/steer/steer_test.go
@@ -11,6 +11,7 @@ package steer
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -179,6 +180,37 @@ func TestAttach_AfterBorrowedReestablishesOwnership(t *testing.T) {
 	Close(inv)
 	require.False(t, queue.Enqueue(model.NewUserMessage("rejected")),
 		"Attach must clear a stale borrowed marker so Close closes the queue")
+}
+
+func TestInvocationViewDoesNotRaceWithClose(t *testing.T) {
+	inv := agent.NewInvocation()
+	queue := NewQueue()
+	for i := 0; i < 16; i++ {
+		require.True(t, queue.Enqueue(model.NewUserMessage("hello")))
+	}
+	Attach(inv, queue)
+
+	const iterations = 10000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			_ = inv.View()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			Close(inv)
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }
 
 func TestNilSafety(t *testing.T) {


### PR DESCRIPTION
## Summary

- avoid calling `reflect.Value.Interface()` on unknown opaque invocation-state structs before deciding whether they are safe to clone
- keep existing explicit clones for `bytes.Buffer`, `strings.Builder`, and `big.Int`
- add a race regression test covering concurrent `Invocation.View()` and steer queue `Close()`

## Root Cause

`Invocation.View()` attempted to detect known mutable values by calling `Interface()` before dispatching on the reflected kind. For an unknown struct value, that can copy the struct fields before the later opaque-struct guard returns the original value. A steer `Queue` carries a lock and can be closed concurrently, so this pre-check could race with `Queue.Close()`.

## Validation

- `go test -race ./internal/state/steer -run TestInvocationViewDoesNotRaceWithClose -count=1`
- `go test ./agent ./internal/state/steer -count=1`
- `go test -race ./agent ./internal/state/steer -count=1`
- `go test ./internal/state/steer -run TestInvocationViewDoesNotRaceWithClose -count=1`

Also attempted `go test ./... -count=1`; it failed in unrelated `codeexecutor/local` and `codeexecutor/sandbox` tests due local file mode and bwrap option behavior, while the affected packages passed.

Close #2154
