### PR TITLE
memory: remove session tool hints from preload prompt

### DIFF
--- a/internal/flow/processor/content_memory_test.go
+++ b/internal/flow/processor/content_memory_test.go
@@ -138,6 +138,10 @@ func TestFormatMemoriesForPrompt(t *testing.T) {
 				"PRELOADED_USER_MEMORIES BEGINS",
 				"## User Memories",
 			},
+			excludes: []string{
+				"session_search",
+				"session_load",
+			},
 		},
 		{
 			name: "single memory",
@@ -570,6 +574,8 @@ func TestGetPreloadMemoryMessage(t *testing.T) {
 		assert.Contains(t, msg.Content, "Quick memory pass")
 		assert.Contains(t, msg.Content, "User likes coffee")
 		assert.Contains(t, msg.Content, "mem-1")
+		assert.NotContains(t, msg.Content, "session_search")
+		assert.NotContains(t, msg.Content, "session_load")
 	})
 
 	t.Run("uses preload memory playbook override", func(t *testing.T) {
@@ -934,6 +940,8 @@ func TestProcessRequest_WithPreloadMemory(t *testing.T) {
 		assert.Contains(t, req.Messages[0].Content, "Decision boundary")
 		assert.Contains(t, req.Messages[0].Content, "User Memories")
 		assert.Contains(t, req.Messages[0].Content, "User prefers dark mode")
+		assert.NotContains(t, req.Messages[0].Content, "session_search")
+		assert.NotContains(t, req.Messages[0].Content, "session_load")
 	})
 
 	t.Run("adaptive preload uses search result in system message", func(t *testing.T) {
@@ -1173,6 +1181,8 @@ func TestProcessRequest_PreloadMemory_UserInjectionMode(t *testing.T) {
 	require.Contains(t, req.Messages[1].Content, "Decision boundary")
 	require.Contains(t, req.Messages[1].Content, "User Memories")
 	require.Contains(t, req.Messages[1].Content, "User prefers dark mode")
+	require.NotContains(t, req.Messages[1].Content, "session_search")
+	require.NotContains(t, req.Messages[1].Content, "session_load")
 	require.Contains(t, req.Messages[1].Content, "hello")
 }
 

--- a/internal/flow/processor/preload_memory_prompt.go
+++ b/internal/flow/processor/preload_memory_prompt.go
@@ -24,8 +24,7 @@ avoid repeated questions, and help keep responses consistent across sessions.
 Decision boundary: should you use memory for this request?
 
 - Skip memory only when the request is clearly self-contained and does not need
-  user preferences, profile details, prior decisions, or prior conversation
-  context.
+  user preferences, profile details, durable user facts, or prior decisions.
 - Use memory by default when the request asks for personalization, continuity,
   preferences, recurring projects, or anything that may depend on prior sessions.
 - If unsure, do a quick memory pass instead of asking the user to repeat context.
@@ -38,9 +37,10 @@ Quick memory pass:
 3. Use memory_load only when it is available and you need to inspect stored
    memories beyond the preloaded set, or when memory_search points to entries
    that need expansion.
-4. Use session_search/session_load only when they are available and you need
-   prior conversation details, exact wording, or tool traces. Use memory_* tools
-   for durable user facts and preferences.
+4. For exact prior-conversation details, wording, or tool traces, rely only on
+   session-history context or separate session-history tool guidance when it is
+   explicitly provided. Use preloaded memories for durable user facts and
+   preferences.
 5. Keep lookup lightweight. Stop once the relevant memory is found or when
    searches do not return useful matches.
 


### PR DESCRIPTION
## Summary
- Remove direct `session_search` / `session_load` references from the default preload memory playbook.
- Keep prior-conversation guidance generic so session-history lookup is only suggested when separately provided.
- Add regression assertions that preload memory prompts do not mention session tools by default.

## Test plan
- `go test ./internal/flow/processor ./agent/llmagent`
- `git diff --check`
