### PR TITLE
openclaw/app: sanitize MCP image tool messages

### DIFF
--- a/openclaw/app/mcp_images.go
+++ b/openclaw/app/mcp_images.go
@@ -33,7 +33,7 @@ const (
 	mcpImageDetailAuto = "auto"
 
 	mcpImagesUserContent = "MCP tool returned image(s)."
-	mcpImageDataOmitted  = "[omitted: image data attached separately]"
+	mcpImageDataOmitted  = "[omitted: image data]"
 )
 
 type mcpContentItem struct {
@@ -61,15 +61,17 @@ func mcpImageResultMessages(
 	}
 
 	items := extractMCPContentItems(in.Result)
-	candidates := countMCPImageCandidates(items)
-	if candidates == 0 {
+	if countMCPImageItems(items) == 0 {
 		return nil, nil
 	}
+	candidates := countMCPImageCandidates(items)
 	defaultMsg = sanitizedMCPImageToolMessage(
 		defaultMsg,
 		in.Result,
-		items,
 	)
+	if candidates == 0 {
+		return []model.Message{defaultMsg}, nil
+	}
 	allowed := tool.ReserveToolResultAttachments(ctx, candidates)
 	if allowed <= 0 {
 		return []model.Message{defaultMsg}, nil
@@ -81,7 +83,7 @@ func mcpImageResultMessages(
 
 	userMsg := model.Message{
 		Role:    model.RoleUser,
-		Content: mcpImageUserContent(in.Result),
+		Content: mcpImagesUserContent,
 	}
 	for _, img := range images {
 		userMsg.AddImageData(img.Data, mcpImageDetailAuto, img.Format)
@@ -90,43 +92,14 @@ func mcpImageResultMessages(
 	return []model.Message{defaultMsg, userMsg}, nil
 }
 
-func mcpImageUserContent(result any) string {
-	path := mcpImageSavedPath(result)
-	if path == "" {
-		return mcpImagesUserContent
-	}
-	return mcpImagesUserContent + " Saved file: " + path +
-		". Use image_inspect with the saved file path when detailed " +
-		"visual reading or OCR is needed."
-}
-
-func mcpImageSavedPath(result any) string {
-	body, err := json.Marshal(result)
-	if err != nil {
-		return ""
-	}
-	var envelope struct {
-		ScreenshotPath string `json:"screenshotPath"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(envelope.ScreenshotPath)
-}
-
 func sanitizedMCPImageToolMessage(
 	msg model.Message,
 	result any,
-	items []mcpContentItem,
 ) model.Message {
-	sanitizedItems := sanitizeMCPContentItems(items)
-	if len(sanitizedItems) == 0 {
-		return msg
-	}
-
-	content, ok := sanitizedMCPResultJSON(result, sanitizedItems)
+	content, ok := sanitizedMCPResultJSON(result)
 	if !ok {
-		content = mustMarshalMCPContentItems(sanitizedItems)
+		msg.Content = mcpImageDataOmitted
+		return msg
 	}
 	if content != "" {
 		msg.Content = content
@@ -134,34 +107,15 @@ func sanitizedMCPImageToolMessage(
 	return msg
 }
 
-func sanitizeMCPContentItems(items []mcpContentItem) []mcpContentItem {
-	if len(items) == 0 {
-		return nil
-	}
-	out := make([]mcpContentItem, 0, len(items))
-	for _, item := range items {
-		if strings.ToLower(strings.TrimSpace(item.Type)) !=
-			mcpContentTypeImage {
-			out = append(out, item)
-			continue
-		}
-		if _, ok := mcpImageFormatFromMime(item.MimeType); !ok {
-			out = append(out, item)
-			continue
-		}
-		item.Data = mcpImageDataOmitted
-		out = append(out, item)
-	}
-	return out
-}
-
 func sanitizedMCPResultJSON(
 	result any,
-	items []mcpContentItem,
 ) (string, bool) {
-	body, err := json.Marshal(result)
+	body, err := marshalModelVisibleJSON(result)
 	if err != nil {
 		return "", false
+	}
+	if content, ok := sanitizeMCPContentJSON(body); ok {
+		return string(content), true
 	}
 
 	var envelope map[string]json.RawMessage
@@ -172,8 +126,8 @@ func sanitizedMCPResultJSON(
 		return "", false
 	}
 
-	itemBytes, err := marshalModelVisibleJSON(items)
-	if err != nil {
+	itemBytes, ok := sanitizeMCPContentJSON(envelope["content"])
+	if !ok {
 		return "", false
 	}
 	envelope["content"] = itemBytes
@@ -185,9 +139,36 @@ func sanitizedMCPResultJSON(
 	return string(sanitized), true
 }
 
-func mustMarshalMCPContentItems(items []mcpContentItem) string {
-	body, _ := marshalModelVisibleJSON(items)
-	return string(body)
+func sanitizeMCPContentJSON(body []byte) ([]byte, bool) {
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, false
+	}
+	found := false
+	for _, item := range items {
+		var contentType string
+		if err := json.Unmarshal(item["type"], &contentType); err != nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(contentType)) !=
+			mcpContentTypeImage {
+			continue
+		}
+		omitted, err := json.Marshal(mcpImageDataOmitted)
+		if err != nil {
+			return nil, false
+		}
+		item["data"] = omitted
+		found = true
+	}
+	if !found {
+		return nil, false
+	}
+	sanitized, err := marshalModelVisibleJSON(items)
+	if err != nil {
+		return nil, false
+	}
+	return sanitized, true
 }
 
 func marshalModelVisibleJSON(v any) ([]byte, error) {
@@ -236,6 +217,17 @@ func countMCPImageCandidates(items []mcpContentItem) int {
 			continue
 		}
 		if _, ok := mcpImageFormatFromMime(item.MimeType); ok {
+			count++
+		}
+	}
+	return count
+}
+
+func countMCPImageItems(items []mcpContentItem) int {
+	var count int
+	for _, item := range items {
+		if strings.ToLower(strings.TrimSpace(item.Type)) ==
+			mcpContentTypeImage {
 			count++
 		}
 	}

--- a/openclaw/app/mcp_images.go
+++ b/openclaw/app/mcp_images.go
@@ -10,6 +10,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -32,6 +33,7 @@ const (
 	mcpImageDetailAuto = "auto"
 
 	mcpImagesUserContent = "MCP tool returned image(s)."
+	mcpImageDataOmitted  = "[omitted: image data attached separately]"
 )
 
 type mcpContentItem struct {
@@ -63,24 +65,139 @@ func mcpImageResultMessages(
 	if candidates == 0 {
 		return nil, nil
 	}
+	defaultMsg = sanitizedMCPImageToolMessage(
+		defaultMsg,
+		in.Result,
+		items,
+	)
 	allowed := tool.ReserveToolResultAttachments(ctx, candidates)
 	if allowed <= 0 {
-		return nil, nil
+		return []model.Message{defaultMsg}, nil
 	}
 	images := extractMCPImagesUpTo(ctx, items, allowed)
 	if len(images) == 0 {
-		return nil, nil
+		return []model.Message{defaultMsg}, nil
 	}
 
 	userMsg := model.Message{
 		Role:    model.RoleUser,
-		Content: mcpImagesUserContent,
+		Content: mcpImageUserContent(in.Result),
 	}
 	for _, img := range images {
 		userMsg.AddImageData(img.Data, mcpImageDetailAuto, img.Format)
 	}
 
 	return []model.Message{defaultMsg, userMsg}, nil
+}
+
+func mcpImageUserContent(result any) string {
+	path := mcpImageSavedPath(result)
+	if path == "" {
+		return mcpImagesUserContent
+	}
+	return mcpImagesUserContent + " Saved file: " + path +
+		". Use image_inspect with the saved file path when detailed " +
+		"visual reading or OCR is needed."
+}
+
+func mcpImageSavedPath(result any) string {
+	body, err := json.Marshal(result)
+	if err != nil {
+		return ""
+	}
+	var envelope struct {
+		ScreenshotPath string `json:"screenshotPath"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(envelope.ScreenshotPath)
+}
+
+func sanitizedMCPImageToolMessage(
+	msg model.Message,
+	result any,
+	items []mcpContentItem,
+) model.Message {
+	sanitizedItems := sanitizeMCPContentItems(items)
+	if len(sanitizedItems) == 0 {
+		return msg
+	}
+
+	content, ok := sanitizedMCPResultJSON(result, sanitizedItems)
+	if !ok {
+		content = mustMarshalMCPContentItems(sanitizedItems)
+	}
+	if content != "" {
+		msg.Content = content
+	}
+	return msg
+}
+
+func sanitizeMCPContentItems(items []mcpContentItem) []mcpContentItem {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]mcpContentItem, 0, len(items))
+	for _, item := range items {
+		if strings.ToLower(strings.TrimSpace(item.Type)) !=
+			mcpContentTypeImage {
+			out = append(out, item)
+			continue
+		}
+		if _, ok := mcpImageFormatFromMime(item.MimeType); !ok {
+			out = append(out, item)
+			continue
+		}
+		item.Data = mcpImageDataOmitted
+		out = append(out, item)
+	}
+	return out
+}
+
+func sanitizedMCPResultJSON(
+	result any,
+	items []mcpContentItem,
+) (string, bool) {
+	body, err := json.Marshal(result)
+	if err != nil {
+		return "", false
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", false
+	}
+	if _, ok := envelope["content"]; !ok {
+		return "", false
+	}
+
+	itemBytes, err := marshalModelVisibleJSON(items)
+	if err != nil {
+		return "", false
+	}
+	envelope["content"] = itemBytes
+
+	sanitized, err := marshalModelVisibleJSON(envelope)
+	if err != nil {
+		return "", false
+	}
+	return string(sanitized), true
+}
+
+func mustMarshalMCPContentItems(items []mcpContentItem) string {
+	body, _ := marshalModelVisibleJSON(items)
+	return string(body)
+}
+
+func marshalModelVisibleJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
 }
 
 func extractMCPImages(ctx context.Context, result any) []mcpImage {

--- a/openclaw/app/mcp_images_test.go
+++ b/openclaw/app/mcp_images_test.go
@@ -305,6 +305,22 @@ func TestSanitizedMCPResultJSONFallbacks(t *testing.T) {
 	content, ok = sanitizedMCPResultJSON([]mcpContentItem{})
 	require.False(t, ok)
 	require.Empty(t, content)
+
+	content, ok = sanitizedMCPResultJSON(map[string]any{
+		"other": "value",
+	})
+	require.False(t, ok)
+	require.Empty(t, content)
+
+	content, ok = sanitizedMCPResultJSON(map[string]any{
+		"content": "not-an-item-list",
+	})
+	require.False(t, ok)
+	require.Empty(t, content)
+
+	body, ok := sanitizeMCPContentJSON([]byte(`[{"type":{}}]`))
+	require.False(t, ok)
+	require.Nil(t, body)
 }
 
 func TestMarshalModelVisibleJSONError(t *testing.T) {

--- a/openclaw/app/mcp_images_test.go
+++ b/openclaw/app/mcp_images_test.go
@@ -30,22 +30,29 @@ func TestMCPImageResultMessages_ReturnsImages(t *testing.T) {
 		Role:     model.RoleTool,
 		ToolID:   "tool-call-1",
 		ToolName: "browser_page_screenshot",
-		Content:  "[]",
+		Content:  "contains raw screenshot",
 	}
 
+	result := map[string]any{
+		"action":         "screenshot",
+		"screenshotPath": "/tmp/screenshot.png",
+		"content": []mcpContentItem{
+			{Type: "text", Data: "visible text"},
+			{
+				Type:     "image",
+				Data:     encoded,
+				MimeType: "image/png",
+			},
+		},
+	}
 	in := &tool.ToolResultMessagesInput{
 		ToolName:           "browser_page_screenshot",
 		ToolCallID:         "tool-call-1",
 		DefaultToolMessage: defaultMsg,
 		Arguments:          []byte(`{}`),
-		Result:             []mcpContentItem{{Type: "text"}},
+		Result:             result,
 		Declaration:        nil,
 	}
-	in.Result = append(in.Result.([]mcpContentItem), mcpContentItem{
-		Type:     "image",
-		Data:     encoded,
-		MimeType: "image/png",
-	})
 
 	got, err := mcpImageResultMessages(context.Background(), in)
 	require.NoError(t, err)
@@ -54,14 +61,54 @@ func TestMCPImageResultMessages_ReturnsImages(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, msgs, 2)
 
-	require.Equal(t, defaultMsg, msgs[0])
+	require.Equal(t, defaultMsg.Role, msgs[0].Role)
+	require.Equal(t, defaultMsg.ToolID, msgs[0].ToolID)
+	require.Equal(t, defaultMsg.ToolName, msgs[0].ToolName)
+	require.NotContains(t, msgs[0].Content, encoded)
+	require.Contains(t, msgs[0].Content, mcpImageDataOmitted)
+	require.Contains(t, msgs[0].Content, "visible text")
 	require.Equal(t, model.RoleUser, msgs[1].Role)
-	require.Equal(t, mcpImagesUserContent, msgs[1].Content)
+	require.Contains(t, msgs[1].Content, mcpImagesUserContent)
+	require.Contains(t, msgs[1].Content, "/tmp/screenshot.png")
+	require.Contains(t, msgs[1].Content, "image_inspect")
 	require.Len(t, msgs[1].ContentParts, 1)
 	require.NotNil(t, msgs[1].ContentParts[0].Image)
 	require.Equal(t, raw, msgs[1].ContentParts[0].Image.Data)
 	require.Equal(t, "png", msgs[1].ContentParts[0].Image.Format)
 	require.Equal(t, mcpImageDetailAuto, msgs[1].ContentParts[0].Image.Detail)
+}
+
+func TestMCPImageResultMessages_DoesNotEscapeVisibleJSONText(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	raw := []byte("fake image bytes")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	in := &tool.ToolResultMessagesInput{
+		DefaultToolMessage: model.Message{Role: model.RoleTool},
+		Result: map[string]any{
+			"content": []mcpContentItem{
+				{Type: "text", Data: "a < b & c > d"},
+				{
+					Type:     "image",
+					Data:     encoded,
+					MimeType: "image/png",
+				},
+			},
+		},
+	}
+
+	got, err := mcpImageResultMessages(context.Background(), in)
+	require.NoError(t, err)
+
+	msgs, ok := got.([]model.Message)
+	require.True(t, ok)
+	require.NotEmpty(t, msgs)
+	require.Contains(t, msgs[0].Content, "a < b & c > d")
+	require.NotContains(t, msgs[0].Content, `\u003c`)
+	require.NotContains(t, msgs[0].Content, `\u003e`)
+	require.NotContains(t, msgs[0].Content, `\u0026`)
 }
 
 func TestMCPImageResultMessages_ConsumesAttachmentBudget(t *testing.T) {
@@ -103,7 +150,11 @@ func TestMCPImageResultMessages_ConsumesAttachmentBudget(t *testing.T) {
 
 	got, err = mcpImageResultMessages(ctx, in)
 	require.NoError(t, err)
-	require.Nil(t, got)
+	msgs, ok = got.([]model.Message)
+	require.True(t, ok)
+	require.Len(t, msgs, 1)
+	require.NotContains(t, msgs[0].Content, encoded)
+	require.Contains(t, msgs[0].Content, mcpImageDataOmitted)
 }
 
 func TestMCPImageResultMessages_NoImagesFallsBack(t *testing.T) {
@@ -120,10 +171,14 @@ func TestMCPImageResultMessages_NoImagesFallsBack(t *testing.T) {
 	require.Nil(t, got)
 }
 
-func TestMCPImageResultMessages_BadBase64FallsBack(t *testing.T) {
+func TestMCPImageResultMessages_BadBase64SanitizesToolMessage(t *testing.T) {
 	t.Parallel()
 
-	defaultMsg := model.Message{Role: model.RoleTool}
+	defaultMsg := model.Message{
+		Role:    model.RoleTool,
+		ToolID:  "tool-call-1",
+		Content: "contains raw image",
+	}
 	in := &tool.ToolResultMessagesInput{
 		DefaultToolMessage: defaultMsg,
 		Result: []mcpContentItem{{
@@ -135,7 +190,11 @@ func TestMCPImageResultMessages_BadBase64FallsBack(t *testing.T) {
 
 	got, err := mcpImageResultMessages(context.Background(), in)
 	require.NoError(t, err)
-	require.Nil(t, got)
+	msgs, ok := got.([]model.Message)
+	require.True(t, ok)
+	require.Len(t, msgs, 1)
+	require.NotContains(t, msgs[0].Content, "not base64")
+	require.Contains(t, msgs[0].Content, mcpImageDataOmitted)
 }
 
 func TestMCPImageResultMessages_NilInputFallsBack(t *testing.T) {
@@ -164,6 +223,70 @@ func TestMCPImageResultMessages_BadDefaultMessageFallsBack(t *testing.T) {
 	got, err := mcpImageResultMessages(context.Background(), in)
 	require.NoError(t, err)
 	require.Nil(t, got)
+}
+
+func TestSanitizedMCPImageToolMessageFallbacks(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("fake image bytes")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	msg := model.Message{
+		Role:    model.RoleTool,
+		Content: "original content",
+	}
+	items := []mcpContentItem{
+		{Type: "text", Data: "visible <text>"},
+		{Type: "image", Data: encoded, MimeType: "image/png"},
+		{Type: "image", Data: "keep-me", MimeType: "image/tiff"},
+	}
+
+	got := sanitizedMCPImageToolMessage(msg, items, items)
+	require.NotContains(t, got.Content, encoded)
+	require.Contains(t, got.Content, mcpImageDataOmitted)
+	require.Contains(t, got.Content, "visible <text>")
+	require.Contains(t, got.Content, "keep-me")
+	require.NotContains(t, got.Content, `\u003c`)
+
+	got = sanitizedMCPImageToolMessage(msg, func() {}, items)
+	require.NotContains(t, got.Content, encoded)
+	require.Contains(t, got.Content, mcpImageDataOmitted)
+
+	got = sanitizedMCPImageToolMessage(msg, nil, nil)
+	require.Equal(t, msg, got)
+}
+
+func TestMCPImageSavedPathFallbacks(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcpImageSavedPath(func() {}))
+	require.Empty(t, mcpImageSavedPath(map[string]any{
+		"screenshotPath": " \t ",
+	}))
+	require.Empty(t, mcpImageSavedPath(map[string]any{
+		"content": make(chan int),
+	}))
+}
+
+func TestSanitizedMCPResultJSONFallbacks(t *testing.T) {
+	t.Parallel()
+
+	items := []mcpContentItem{{Type: "text", Data: "visible"}}
+
+	content, ok := sanitizedMCPResultJSON(func() {}, items)
+	require.False(t, ok)
+	require.Empty(t, content)
+
+	content, ok = sanitizedMCPResultJSON([]mcpContentItem{}, items)
+	require.False(t, ok)
+	require.Empty(t, content)
+}
+
+func TestMarshalModelVisibleJSONError(t *testing.T) {
+	t.Parallel()
+
+	body, err := marshalModelVisibleJSON(func() {})
+	require.Error(t, err)
+	require.Nil(t, body)
 }
 
 func TestExtractMCPImages_NilResultReturnsNil(t *testing.T) {

--- a/openclaw/app/mcp_images_test.go
+++ b/openclaw/app/mcp_images_test.go
@@ -68,9 +68,9 @@ func TestMCPImageResultMessages_ReturnsImages(t *testing.T) {
 	require.Contains(t, msgs[0].Content, mcpImageDataOmitted)
 	require.Contains(t, msgs[0].Content, "visible text")
 	require.Equal(t, model.RoleUser, msgs[1].Role)
-	require.Contains(t, msgs[1].Content, mcpImagesUserContent)
-	require.Contains(t, msgs[1].Content, "/tmp/screenshot.png")
-	require.Contains(t, msgs[1].Content, "image_inspect")
+	require.Equal(t, mcpImagesUserContent, msgs[1].Content)
+	require.NotContains(t, msgs[1].Content, "/tmp/screenshot.png")
+	require.NotContains(t, msgs[1].Content, "image_inspect")
 	require.Len(t, msgs[1].ContentParts, 1)
 	require.NotNil(t, msgs[1].ContentParts[0].Image)
 	require.Equal(t, raw, msgs[1].ContentParts[0].Image.Data)
@@ -88,12 +88,25 @@ func TestMCPImageResultMessages_DoesNotEscapeVisibleJSONText(
 	in := &tool.ToolResultMessagesInput{
 		DefaultToolMessage: model.Message{Role: model.RoleTool},
 		Result: map[string]any{
-			"content": []mcpContentItem{
-				{Type: "text", Data: "a < b & c > d"},
+			"content": []map[string]any{
 				{
-					Type:     "image",
-					Data:     encoded,
-					MimeType: "image/png",
+					"type": "text",
+					"text": "a < b & c > d",
+					"annotations": map[string]any{
+						"audience": []string{"assistant"},
+					},
+				},
+				{
+					"type": "resource",
+					"resource": map[string]any{
+						"uri":  "file:///report.txt",
+						"text": "resource text",
+					},
+				},
+				{
+					"type":     "image",
+					"data":     encoded,
+					"mimeType": "image/png",
 				},
 			},
 		},
@@ -106,6 +119,9 @@ func TestMCPImageResultMessages_DoesNotEscapeVisibleJSONText(
 	require.True(t, ok)
 	require.NotEmpty(t, msgs)
 	require.Contains(t, msgs[0].Content, "a < b & c > d")
+	require.Contains(t, msgs[0].Content, "annotations")
+	require.Contains(t, msgs[0].Content, "file:///report.txt")
+	require.Contains(t, msgs[0].Content, "resource text")
 	require.NotContains(t, msgs[0].Content, `\u003c`)
 	require.NotContains(t, msgs[0].Content, `\u003e`)
 	require.NotContains(t, msgs[0].Content, `\u0026`)
@@ -240,43 +256,53 @@ func TestSanitizedMCPImageToolMessageFallbacks(t *testing.T) {
 		{Type: "image", Data: "keep-me", MimeType: "image/tiff"},
 	}
 
-	got := sanitizedMCPImageToolMessage(msg, items, items)
+	got := sanitizedMCPImageToolMessage(msg, items)
 	require.NotContains(t, got.Content, encoded)
 	require.Contains(t, got.Content, mcpImageDataOmitted)
 	require.Contains(t, got.Content, "visible <text>")
-	require.Contains(t, got.Content, "keep-me")
+	require.NotContains(t, got.Content, "keep-me")
 	require.NotContains(t, got.Content, `\u003c`)
 
-	got = sanitizedMCPImageToolMessage(msg, func() {}, items)
-	require.NotContains(t, got.Content, encoded)
-	require.Contains(t, got.Content, mcpImageDataOmitted)
-
-	got = sanitizedMCPImageToolMessage(msg, nil, nil)
-	require.Equal(t, msg, got)
+	got = sanitizedMCPImageToolMessage(msg, func() {})
+	require.Equal(t, mcpImageDataOmitted, got.Content)
 }
 
-func TestMCPImageSavedPathFallbacks(t *testing.T) {
+func TestMCPImageResultMessages_DoesNotTrustSavedPath(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, mcpImageSavedPath(func() {}))
-	require.Empty(t, mcpImageSavedPath(map[string]any{
-		"screenshotPath": " \t ",
-	}))
-	require.Empty(t, mcpImageSavedPath(map[string]any{
-		"content": make(chan int),
-	}))
+	encoded := base64.StdEncoding.EncodeToString([]byte("image"))
+	got, err := mcpImageResultMessages(
+		context.Background(),
+		&tool.ToolResultMessagesInput{
+			ToolName: "untrusted_mcp_tool",
+			DefaultToolMessage: model.Message{
+				Role: model.RoleTool,
+			},
+			Result: map[string]any{
+				"screenshotPath": "/allowed/secret.png",
+				"content": []mcpContentItem{{
+					Type:     "image",
+					Data:     encoded,
+					MimeType: "image/png",
+				}},
+			},
+		},
+	)
+	require.NoError(t, err)
+	msgs := got.([]model.Message)
+	require.Len(t, msgs, 2)
+	require.Equal(t, mcpImagesUserContent, msgs[1].Content)
+	require.NotContains(t, msgs[1].Content, "/allowed/secret.png")
 }
 
 func TestSanitizedMCPResultJSONFallbacks(t *testing.T) {
 	t.Parallel()
 
-	items := []mcpContentItem{{Type: "text", Data: "visible"}}
-
-	content, ok := sanitizedMCPResultJSON(func() {}, items)
+	content, ok := sanitizedMCPResultJSON(func() {})
 	require.False(t, ok)
 	require.Empty(t, content)
 
-	content, ok = sanitizedMCPResultJSON([]mcpContentItem{}, items)
+	content, ok = sanitizedMCPResultJSON([]mcpContentItem{})
 	require.False(t, ok)
 	require.Empty(t, content)
 }
@@ -341,6 +367,40 @@ func TestExtractMCPImages_UnsupportedMimeIsSkipped(t *testing.T) {
 		MimeType: "image/tiff",
 	}})
 	require.Nil(t, images)
+}
+
+func TestMCPImageResultMessages_UnsupportedMimeIsSanitized(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("tiff image"))
+	got, err := mcpImageResultMessages(
+		context.Background(),
+		&tool.ToolResultMessagesInput{
+			DefaultToolMessage: model.Message{
+				Role:    model.RoleTool,
+				Content: encoded,
+			},
+			Result: []map[string]any{
+				{
+					"type":     "image",
+					"data":     encoded,
+					"mimeType": "image/tiff",
+				},
+				{
+					"type": "text",
+					"text": "preserved context",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	msgs := got.([]model.Message)
+	require.Len(t, msgs, 1)
+	require.NotContains(t, msgs[0].Content, encoded)
+	require.Contains(t, msgs[0].Content, mcpImageDataOmitted)
+	require.Contains(t, msgs[0].Content, "preserved context")
 }
 
 func TestUnwrapMCPResultContent_FallsBackToOriginalResult(

--- a/openclaw/internal/browser/result.go
+++ b/openclaw/internal/browser/result.go
@@ -60,6 +60,7 @@ type Result struct {
 	Supported        []string              `json:"supportedActions,omitempty"`
 	NavigationPolicy *NavigationPolicyInfo `json:"navigationPolicy,omitempty"`
 	TargetID         string                `json:"targetId,omitempty"`
+	ScreenshotPath   string                `json:"screenshotPath,omitempty"`
 	Profiles         []ProfileInfo         `json:"profiles,omitempty"`
 	Tabs             []TabInfo             `json:"tabs,omitempty"`
 	Untrusted        bool                  `json:"untrusted,omitempty"`

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -1561,6 +1561,7 @@ func (t *Tool) handleScreenshot(
 	if err != nil {
 		return Result{}, err
 	}
+	_, captureFailed := compactBrowserErrorText(extractText(raw))
 	raw = compactBrowserErrorResult(raw)
 
 	result := newBaseResult(
@@ -1570,7 +1571,9 @@ func (t *Tool) handleScreenshot(
 		t.evaluateEnabled,
 	)
 	result.TargetID = strings.TrimSpace(in.TargetID)
-	result.ScreenshotPath = filename
+	if !captureFailed {
+		result.ScreenshotPath = filename
+	}
 	result.Content = raw
 	return result, nil
 }

--- a/openclaw/internal/browser/tool.go
+++ b/openclaw/internal/browser/tool.go
@@ -1570,6 +1570,7 @@ func (t *Tool) handleScreenshot(
 		t.evaluateEnabled,
 	)
 	result.TargetID = strings.TrimSpace(in.TargetID)
+	result.ScreenshotPath = filename
 	result.Content = raw
 	return result, nil
 }

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -2837,7 +2837,7 @@ func TestToolCall_ScreenshotDirProvidesDefaultFilename(t *testing.T) {
 	tool := newTestTool(drv)
 	tool.screenshotDir = dir
 
-	_, err := tool.Call(
+	raw, err := tool.Call(
 		context.Background(),
 		mustJSON(t, map[string]any{
 			"action": actionScreenshot,
@@ -2852,6 +2852,9 @@ func TestToolCall_ScreenshotDirProvidesDefaultFilename(t *testing.T) {
 	require.Equal(t, dir, filepath.Dir(filename))
 	require.Contains(t, filepath.Base(filename), "screenshot-")
 	require.Equal(t, ".jpg", filepath.Ext(filename))
+
+	got := raw.(Result)
+	require.Equal(t, filename, got.ScreenshotPath)
 }
 
 func TestResolveScreenshotFilenameCompatibilityBranches(t *testing.T) {

--- a/openclaw/internal/browser/tool_test.go
+++ b/openclaw/internal/browser/tool_test.go
@@ -2898,6 +2898,7 @@ func TestToolCall_ScreenshotCompactsBrowserCrashContent(t *testing.T) {
 		},
 	}
 	tool := newTestTool(drv)
+	tool.screenshotDir = t.TempDir()
 
 	raw, err := tool.Call(
 		context.Background(),
@@ -2908,6 +2909,7 @@ func TestToolCall_ScreenshotCompactsBrowserCrashContent(t *testing.T) {
 	require.NoError(t, err)
 
 	got := raw.(Result)
+	require.Empty(t, got.ScreenshotPath)
 	text := extractText(got.Content)
 	require.Contains(t, text, browserCrashSummary)
 	require.NotContains(t, text, "--disable-field-trial-config")


### PR DESCRIPTION
## Summary
- strip inline image data from MCP image tool messages before replaying them to the model
- keep text metadata in the tool message and attach supported images through content parts when budget allows
- return a sanitized tool message even when the attachment budget is exhausted or image decoding fails

## Validation
- go test ./app -run 'TestMCPImageResultMessages|TestExtractMCPImages|TestUnwrapMCPResultContent|TestMCPImageFormatFromMime'\n- go test ./app