### PR TITLE
openclaw/imageinspect: tolerate duplicated attachment paths

### DIFF
--- a/openclaw/internal/imageinspect/imageinspect.go
+++ b/openclaw/internal/imageinspect/imageinspect.go
@@ -258,8 +258,8 @@ func (i *inspector) resolvePath(raw string) (string, error) {
 	real, err := filepath.EvalSymlinks(abs)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if path, ok, resolveErr := i.resolveDuplicatedAllowedPath(
-				abs,
+			if path, ok, resolveErr := i.resolveDuplicatedAllowedPaths(
+				[]string{abs},
 				raw,
 			); ok || resolveErr != nil {
 				return path, resolveErr
@@ -302,14 +302,17 @@ func (i *inspector) resolveAllowedRelativePath(
 		}
 		return real, true, nil
 	}
+	absCandidates := make([]string, 0, len(i.allowedDirs))
 	for _, dir := range i.allowedDirs {
-		candidate := filepath.Clean(filepath.Join(dir, cleaned))
-		if path, ok, err := i.resolveDuplicatedAllowedPath(
-			candidate,
-			raw,
-		); ok || err != nil {
-			return path, true, err
-		}
+		absCandidates = append(absCandidates, filepath.Clean(
+			filepath.Join(dir, cleaned),
+		))
+	}
+	if path, ok, err := i.resolveDuplicatedAllowedPaths(
+		absCandidates,
+		raw,
+	); ok || err != nil {
+		return path, true, err
 	}
 
 	if strings.Contains(cleaned, string(os.PathSeparator)) {
@@ -399,34 +402,36 @@ func (i *inspector) resolvePreferredBasename(
 	return match, true, nil
 }
 
-func (i *inspector) resolveDuplicatedAllowedPath(
-	abs string,
+func (i *inspector) resolveDuplicatedAllowedPaths(
+	absCandidates []string,
 	raw string,
 ) (string, bool, error) {
 	var match string
-	for _, dir := range i.allowedDirs {
-		for _, candidate := range duplicatedAllowedPathCandidates(abs, dir) {
-			if !fileExists(candidate) {
-				continue
+	for _, abs := range absCandidates {
+		for _, dir := range i.allowedDirs {
+			for _, candidate := range duplicatedAllowedPathCandidates(abs, dir) {
+				if !fileExists(candidate) {
+					continue
+				}
+				real, err := filepath.EvalSymlinks(candidate)
+				if err != nil {
+					return "", true, fmt.Errorf("resolve image path: %w", err)
+				}
+				real = filepath.Clean(real)
+				if !pathInAllowedDir(real, dir) {
+					return "", true, fmt.Errorf(
+						"path %q is outside allowed_dirs",
+						raw,
+					)
+				}
+				if match != "" && match != real {
+					return "", true, fmt.Errorf(
+						"multiple corrected paths match %q in allowed_dirs",
+						raw,
+					)
+				}
+				match = real
 			}
-			real, err := filepath.EvalSymlinks(candidate)
-			if err != nil {
-				return "", true, fmt.Errorf("resolve image path: %w", err)
-			}
-			real = filepath.Clean(real)
-			if !pathInAllowedDir(real, dir) {
-				return "", true, fmt.Errorf(
-					"path %q is outside allowed_dirs",
-					raw,
-				)
-			}
-			if match != "" && match != real {
-				return "", true, fmt.Errorf(
-					"multiple corrected paths match %q in allowed_dirs",
-					raw,
-				)
-			}
-			match = real
 		}
 	}
 	if match == "" {

--- a/openclaw/internal/imageinspect/imageinspect.go
+++ b/openclaw/internal/imageinspect/imageinspect.go
@@ -40,6 +40,8 @@ const (
 	maxASCIIWidth            = 160
 	maxASCIIHeight           = 80
 	maxBasenameSearchEntries = 10000
+	maxDuplicatePathParts    = 128
+	maxDuplicateCandidates   = 64
 )
 
 var preferredBasenameSubdirs = []string{
@@ -81,11 +83,12 @@ func NewTool(cfg Config) (tool.CallableTool, error) {
 }
 
 type inspector struct {
-	allowedDirs      []string
-	allowAllFiles    bool
-	tesseractCommand string
-	timeout          time.Duration
-	maxOCRChars      int
+	allowedDirs       []string
+	allowedDirAliases []string
+	allowAllFiles     bool
+	tesseractCommand  string
+	timeout           time.Duration
+	maxOCRChars       int
 }
 
 func newInspector(cfg Config) (*inspector, error) {
@@ -96,6 +99,7 @@ func newInspector(cfg Config) (*inspector, error) {
 	}
 
 	allowedDirs := make([]string, 0, len(cfg.AllowedDirs))
+	allowedDirAliases := make([]string, 0, len(cfg.AllowedDirs))
 	for _, dir := range cfg.AllowedDirs {
 		abs, err := filepath.Abs(strings.TrimSpace(dir))
 		if err != nil {
@@ -106,6 +110,7 @@ func newInspector(cfg Config) (*inspector, error) {
 			return nil, fmt.Errorf("resolve allowed dir %q: %w", dir, err)
 		}
 		allowedDirs = append(allowedDirs, filepath.Clean(real))
+		allowedDirAliases = append(allowedDirAliases, filepath.Clean(abs))
 	}
 
 	timeout := cfg.Timeout
@@ -122,11 +127,12 @@ func newInspector(cfg Config) (*inspector, error) {
 	}
 
 	return &inspector{
-		allowedDirs:      allowedDirs,
-		allowAllFiles:    cfg.AllowAllFiles,
-		tesseractCommand: cmd,
-		timeout:          timeout,
-		maxOCRChars:      maxOCRChars,
+		allowedDirs:       allowedDirs,
+		allowedDirAliases: allowedDirAliases,
+		allowAllFiles:     cfg.AllowAllFiles,
+		tesseractCommand:  cmd,
+		timeout:           timeout,
+		maxOCRChars:       maxOCRChars,
 	}, nil
 }
 
@@ -408,29 +414,36 @@ func (i *inspector) resolveDuplicatedAllowedPaths(
 ) (string, bool, error) {
 	var match string
 	for _, abs := range absCandidates {
-		for _, dir := range i.allowedDirs {
-			for _, candidate := range duplicatedAllowedPathCandidates(abs, dir) {
-				if !fileExists(candidate) {
-					continue
+		for idx, dir := range i.allowedDirs {
+			candidateRoots := []string{dir}
+			if idx < len(i.allowedDirAliases) &&
+				i.allowedDirAliases[idx] != dir {
+				candidateRoots = append(candidateRoots, i.allowedDirAliases[idx])
+			}
+			for _, root := range candidateRoots {
+				for _, candidate := range duplicatedAllowedPathCandidates(abs, root) {
+					if !fileExists(candidate) {
+						continue
+					}
+					real, err := filepath.EvalSymlinks(candidate)
+					if err != nil {
+						return "", true, fmt.Errorf("resolve image path: %w", err)
+					}
+					real = filepath.Clean(real)
+					if !pathInAllowedDir(real, dir) {
+						return "", true, fmt.Errorf(
+							"path %q is outside allowed_dirs",
+							raw,
+						)
+					}
+					if match != "" && match != real {
+						return "", true, fmt.Errorf(
+							"multiple corrected paths match %q in allowed_dirs",
+							raw,
+						)
+					}
+					match = real
 				}
-				real, err := filepath.EvalSymlinks(candidate)
-				if err != nil {
-					return "", true, fmt.Errorf("resolve image path: %w", err)
-				}
-				real = filepath.Clean(real)
-				if !pathInAllowedDir(real, dir) {
-					return "", true, fmt.Errorf(
-						"path %q is outside allowed_dirs",
-						raw,
-					)
-				}
-				if match != "" && match != real {
-					return "", true, fmt.Errorf(
-						"multiple corrected paths match %q in allowed_dirs",
-						raw,
-					)
-				}
-				match = real
 			}
 		}
 	}
@@ -450,7 +463,7 @@ func duplicatedAllowedPathCandidates(abs string, dir string) []string {
 		return nil
 	}
 	parts := splitPath(rel)
-	if len(parts) < 2 {
+	if len(parts) < 2 || len(parts) > maxDuplicatePathParts {
 		return nil
 	}
 
@@ -477,6 +490,9 @@ func duplicatedAllowedPathCandidates(abs string, dir string) []string {
 		add(parts[1:])
 	}
 	for idx := 0; idx < len(parts)-1; idx++ {
+		if len(candidates) >= maxDuplicateCandidates {
+			break
+		}
 		if parts[idx] != parts[idx+1] {
 			continue
 		}

--- a/openclaw/internal/imageinspect/imageinspect.go
+++ b/openclaw/internal/imageinspect/imageinspect.go
@@ -257,6 +257,14 @@ func (i *inspector) resolvePath(raw string) (string, error) {
 	}
 	real, err := filepath.EvalSymlinks(abs)
 	if err != nil {
+		if os.IsNotExist(err) {
+			if path, ok, resolveErr := i.resolveDuplicatedAllowedPath(
+				abs,
+				raw,
+			); ok || resolveErr != nil {
+				return path, resolveErr
+			}
+		}
 		return "", fmt.Errorf("resolve image path: %w", err)
 	}
 	real = filepath.Clean(real)
@@ -293,6 +301,15 @@ func (i *inspector) resolveAllowedRelativePath(
 			return "", true, fmt.Errorf("path %q is outside allowed_dirs", raw)
 		}
 		return real, true, nil
+	}
+	for _, dir := range i.allowedDirs {
+		candidate := filepath.Clean(filepath.Join(dir, cleaned))
+		if path, ok, err := i.resolveDuplicatedAllowedPath(
+			candidate,
+			raw,
+		); ok || err != nil {
+			return path, true, err
+		}
 	}
 
 	if strings.Contains(cleaned, string(os.PathSeparator)) {
@@ -380,6 +397,101 @@ func (i *inspector) resolvePreferredBasename(
 		return "", false, nil
 	}
 	return match, true, nil
+}
+
+func (i *inspector) resolveDuplicatedAllowedPath(
+	abs string,
+	raw string,
+) (string, bool, error) {
+	var match string
+	for _, dir := range i.allowedDirs {
+		for _, candidate := range duplicatedAllowedPathCandidates(abs, dir) {
+			if !fileExists(candidate) {
+				continue
+			}
+			real, err := filepath.EvalSymlinks(candidate)
+			if err != nil {
+				return "", true, fmt.Errorf("resolve image path: %w", err)
+			}
+			real = filepath.Clean(real)
+			if !pathInAllowedDir(real, dir) {
+				return "", true, fmt.Errorf(
+					"path %q is outside allowed_dirs",
+					raw,
+				)
+			}
+			if match != "" && match != real {
+				return "", true, fmt.Errorf(
+					"multiple corrected paths match %q in allowed_dirs",
+					raw,
+				)
+			}
+			match = real
+		}
+	}
+	if match == "" {
+		return "", false, nil
+	}
+	return match, true, nil
+}
+
+func duplicatedAllowedPathCandidates(abs string, dir string) []string {
+	rel, err := filepath.Rel(dir, abs)
+	if err != nil || rel == "." {
+		return nil
+	}
+	if rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return nil
+	}
+	parts := splitPath(rel)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	var candidates []string
+	add := func(candidateParts []string) {
+		if len(candidateParts) == 0 {
+			return
+		}
+		candidate := filepath.Clean(filepath.Join(
+			append([]string{dir}, candidateParts...)...,
+		))
+		if !pathInAllowedDir(candidate, dir) {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		candidates = append(candidates, candidate)
+	}
+
+	if parts[0] == filepath.Base(dir) {
+		add(parts[1:])
+	}
+	for idx := 0; idx < len(parts)-1; idx++ {
+		if parts[idx] != parts[idx+1] {
+			continue
+		}
+		candidateParts := make([]string, 0, len(parts)-1)
+		candidateParts = append(candidateParts, parts[:idx]...)
+		candidateParts = append(candidateParts, parts[idx+1:]...)
+		add(candidateParts)
+	}
+	return candidates
+}
+
+func splitPath(path string) []string {
+	parts := strings.Split(path, string(os.PathSeparator))
+	out := parts[:0]
+	for _, part := range parts {
+		if part != "" && part != "." {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func pathInAllowedDir(path string, dir string) bool {

--- a/openclaw/internal/imageinspect/imageinspect_test.go
+++ b/openclaw/internal/imageinspect/imageinspect_test.go
@@ -352,6 +352,110 @@ func TestResolvePathRequiresPath(t *testing.T) {
 	require.Contains(t, err.Error(), "path is required")
 }
 
+func TestResolvePathCorrectsDuplicatedAttachmentRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	attachmentID := "attachment-12345"
+	actual := filepath.Join(root, attachmentID, attachmentID+".png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(actual), 0o755))
+	writeTestPNG(t, actual, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{root}})
+	require.NoError(t, err)
+	raw := filepath.Join(root, attachmentID, attachmentID, attachmentID+".png")
+	got, err := tool.resolvePath(raw)
+	require.NoError(t, err)
+	require.Equal(t, actual, got)
+}
+
+func TestResolvePathCorrectsDuplicatedAllowedDirBase(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	attachmentID := "attachment-12345"
+	allowed := filepath.Join(root, attachmentID)
+	actual := filepath.Join(allowed, attachmentID+".png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(actual), 0o755))
+	writeTestPNG(t, actual, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{allowed}})
+	require.NoError(t, err)
+	raw := filepath.Join(allowed, attachmentID, attachmentID+".png")
+	got, err := tool.resolvePath(raw)
+	require.NoError(t, err)
+	require.Equal(t, actual, got)
+}
+
+func TestResolvePathCorrectsDuplicatedRelativeAttachment(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	attachmentID := "attachment-12345"
+	actual := filepath.Join(root, attachmentID, attachmentID+".png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(actual), 0o755))
+	writeTestPNG(t, actual, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{root}})
+	require.NoError(t, err)
+	raw := filepath.Join(attachmentID, attachmentID, attachmentID+".png")
+	got, err := tool.resolvePath(raw)
+	require.NoError(t, err)
+	require.Equal(t, actual, got)
+}
+
+func TestResolvePathRejectsDuplicatedSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	attachmentID := "attachment-12345"
+	inside := filepath.Join(root, attachmentID, attachmentID+".png")
+	outsidePath := filepath.Join(outside, attachmentID+".png")
+	writeTestPNG(t, outsidePath, image.Rect(0, 0, 1, 1))
+	require.NoError(t, os.MkdirAll(filepath.Dir(inside), 0o755))
+	require.NoError(t, os.Symlink(outsidePath, inside))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{root}})
+	require.NoError(t, err)
+	raw := filepath.Join(root, attachmentID, attachmentID, attachmentID+".png")
+	_, err = tool.resolvePath(raw)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outside allowed_dirs")
+}
+
+func TestResolvePathRejectsAmbiguousDuplicatedCandidates(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	allowed := filepath.Join(root, "attachment")
+	first := filepath.Join(allowed, "b", "b", "image.png")
+	second := filepath.Join(allowed, "attachment", "b", "image.png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(first), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(second), 0o755))
+	writeTestPNG(t, first, image.Rect(0, 0, 1, 1))
+	writeTestPNG(t, second, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{allowed}})
+	require.NoError(t, err)
+	raw := filepath.Join(allowed, "attachment", "b", "b", "image.png")
+	_, err = tool.resolvePath(raw)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple corrected paths")
+}
+
+func TestDuplicatedAllowedPathCandidatesRejectsNonDuplicatedPaths(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.Empty(t, duplicatedAllowedPathCandidates(root, root))
+	require.Empty(t, duplicatedAllowedPathCandidates(filepath.Dir(root), root))
+	require.Empty(t, duplicatedAllowedPathCandidates(
+		filepath.Join(root, "single"),
+		root,
+	))
+}
+
 func TestInspectRejectsSymlinkEscapeFromAllowedDirs(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/imageinspect/imageinspect_test.go
+++ b/openclaw/internal/imageinspect/imageinspect_test.go
@@ -444,6 +444,34 @@ func TestResolvePathRejectsAmbiguousDuplicatedCandidates(t *testing.T) {
 	require.Contains(t, err.Error(), "multiple corrected paths")
 }
 
+func TestResolvePathRejectsDuplicatedCandidatesAcrossAllowedDirs(t *testing.T) {
+	t.Parallel()
+
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	attachmentID := "attachment-12345"
+	first := filepath.Join(firstRoot, attachmentID, attachmentID+".png")
+	second := filepath.Join(secondRoot, attachmentID, attachmentID+".png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(first), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(second), 0o755))
+	writeTestPNG(t, first, image.Rect(0, 0, 1, 1))
+	writeTestPNG(t, second, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{
+		firstRoot,
+		secondRoot,
+	}})
+	require.NoError(t, err)
+	raw := filepath.Join(
+		attachmentID,
+		attachmentID,
+		attachmentID+".png",
+	)
+	_, err = tool.resolvePath(raw)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple corrected paths")
+}
+
 func TestDuplicatedAllowedPathCandidatesRejectsNonDuplicatedPaths(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/internal/imageinspect/imageinspect_test.go
+++ b/openclaw/internal/imageinspect/imageinspect_test.go
@@ -387,6 +387,31 @@ func TestResolvePathCorrectsDuplicatedAllowedDirBase(t *testing.T) {
 	require.Equal(t, actual, got)
 }
 
+func TestResolvePathCorrectsDuplicatedPathThroughAllowedDirSymlink(t *testing.T) {
+	t.Parallel()
+
+	realRoot := t.TempDir()
+	aliasParent := t.TempDir()
+	aliasRoot := filepath.Join(aliasParent, "allowed-link")
+	require.NoError(t, os.Symlink(realRoot, aliasRoot))
+	attachmentID := "attachment-12345"
+	actual := filepath.Join(realRoot, attachmentID, attachmentID+".png")
+	require.NoError(t, os.MkdirAll(filepath.Dir(actual), 0o755))
+	writeTestPNG(t, actual, image.Rect(0, 0, 1, 1))
+
+	tool, err := newInspector(Config{AllowedDirs: []string{aliasRoot}})
+	require.NoError(t, err)
+	raw := filepath.Join(
+		aliasRoot,
+		attachmentID,
+		attachmentID,
+		attachmentID+".png",
+	)
+	got, err := tool.resolvePath(raw)
+	require.NoError(t, err)
+	require.Equal(t, actual, got)
+}
+
 func TestResolvePathCorrectsDuplicatedRelativeAttachment(t *testing.T) {
 	t.Parallel()
 
@@ -480,6 +505,20 @@ func TestDuplicatedAllowedPathCandidatesRejectsNonDuplicatedPaths(t *testing.T) 
 	require.Empty(t, duplicatedAllowedPathCandidates(filepath.Dir(root), root))
 	require.Empty(t, duplicatedAllowedPathCandidates(
 		filepath.Join(root, "single"),
+		root,
+	))
+}
+
+func TestDuplicatedAllowedPathCandidatesBoundsLongInput(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	parts := make([]string, maxDuplicatePathParts+1)
+	for idx := range parts {
+		parts[idx] = "duplicate"
+	}
+	require.Empty(t, duplicatedAllowedPathCandidates(
+		filepath.Join(append([]string{root}, parts...)...),
 		root,
 	))
 }


### PR DESCRIPTION
## Summary
- tolerate duplicated attachment path components in `image_inspect` path resolution
- keep correction scoped to configured `allowed_dirs` and existing files only
- reject ambiguous corrected matches instead of guessing

## Validation
- `go test ./internal/imageinspect`
- `git diff --check`
