### PR TITLE
openclaw/subagentrun: allow sync spawn without delivery

### DIFF
--- a/openclaw/internal/outbound/resolve.go
+++ b/openclaw/internal/outbound/resolve.go
@@ -11,12 +11,15 @@ package outbound
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/channel/telegram"
 )
+
+var ErrTargetUnavailable = errors.New("outbound: unable to resolve target")
 
 const (
 	runtimeStateDeliveryChannel = "openclaw.delivery.channel"
@@ -47,9 +50,7 @@ func ResolveTarget(
 
 	if strings.TrimSpace(target.Channel) == "" ||
 		strings.TrimSpace(target.Target) == "" {
-		return DeliveryTarget{}, fmt.Errorf(
-			"outbound: unable to resolve target",
-		)
+		return DeliveryTarget{}, ErrTargetUnavailable
 	}
 	if err := validateTarget(target); err != nil {
 		return DeliveryTarget{}, err

--- a/openclaw/internal/subagentrun/tool.go
+++ b/openclaw/internal/subagentrun/tool.go
@@ -268,15 +268,9 @@ func (t *spawnTool) Call(
 	if err != nil {
 		return nil, err
 	}
-	delivery, err := outbound.ResolveTarget(
-		ctx,
-		outbound.DeliveryTarget{},
-	)
+	delivery, err := resolveSpawnDeliveryTarget(ctx, mode)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"subagent: resolve delivery target: %w",
-			err,
-		)
+		return nil, err
 	}
 
 	run, err := t.svc.Spawn(ctx, SpawnRequest{
@@ -443,6 +437,27 @@ func (t *waitTool) Call(
 		defer cancel()
 	}
 	return t.svc.WaitForUser(waitCtx, userID, in.ID)
+}
+
+func resolveSpawnDeliveryTarget(
+	ctx context.Context,
+	mode string,
+) (outbound.DeliveryTarget, error) {
+	delivery, err := outbound.ResolveTarget(
+		ctx,
+		outbound.DeliveryTarget{},
+	)
+	if err == nil {
+		return delivery, nil
+	}
+	if mode != spawnModeAsync &&
+		errors.Is(err, outbound.ErrTargetUnavailable) {
+		return outbound.DeliveryTarget{}, nil
+	}
+	return outbound.DeliveryTarget{}, fmt.Errorf(
+		"subagent: resolve delivery target: %w",
+		err,
+	)
 }
 
 func normalizeSpawnMode(mode string) (string, error) {

--- a/openclaw/internal/subagentrun/tool_test.go
+++ b/openclaw/internal/subagentrun/tool_test.go
@@ -147,6 +147,45 @@ func TestSpawnToolSyncAndReviewModesWait(t *testing.T) {
 	require.Equal(t, testParentAgentName, route.AgentName)
 }
 
+func TestSpawnToolSyncModeAllowsMissingDeliveryTarget(t *testing.T) {
+	t.Parallel()
+
+	runner := &captureRunner{reply: "sync result"}
+	svc, err := NewService(t.TempDir(), runner, nil)
+	require.NoError(t, err)
+	svc.Start(context.Background())
+	t.Cleanup(func() {
+		require.NoError(t, svc.Close())
+	})
+
+	tools := NewTools(svc)
+	ctx := newInvocationContext("admin", "admin-session", nil)
+
+	syncedAny, err := tools.spawn.Call(
+		ctx,
+		[]byte(`{"task":"review","mode":"sync"}`),
+	)
+	require.NoError(t, err)
+	synced := syncedAny.(*openclawsubagent.Run)
+	require.Equal(t, openclawsubagent.StatusCompleted, synced.Status)
+	require.Equal(t, "sync result", synced.Result)
+
+	reviewedAny, err := tools.spawn.Call(
+		ctx,
+		[]byte(`{"task":"review","mode":"review"}`),
+	)
+	require.NoError(t, err)
+	reviewed := reviewedAny.(*openclawsubagent.Run)
+	require.Equal(t, openclawsubagent.StatusCompleted, reviewed.Status)
+	require.Equal(t, "sync result", reviewed.Result)
+
+	_, err = tools.spawn.Call(
+		ctx,
+		[]byte(`{"task":"review","mode":"async"}`),
+	)
+	require.ErrorIs(t, err, outbound.ErrTargetUnavailable)
+}
+
 func TestSpawnToolSyncWaitTimeoutReturnsLatestRun(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- allow `subagents_spawn` in `sync`/`review` mode when no outbound delivery target is available
- keep `async` mode requiring a delivery target so background completion notifications remain routable
- expose the missing-target case as a typed outbound error for callers that can treat delivery as optional

## Validation
- `go test ./internal/outbound ./internal/subagentrun`
