### PR TITLE
tool/arxivsearch: limit PDF content results

### DIFF
--- a/examples/arxivsearch/README.md
+++ b/examples/arxivsearch/README.md
@@ -32,14 +32,23 @@ The tool provides access to scholarly articles from arXiv repository:
 **Input:**
 ```json
 {
-  "query": "string",
-  "id_list": ["string"],
-  "max_results": 5,
-  "sort_by": "relevance",
-  "sort_order": "descending",
-  "read_arxiv_papers": false
+  "search": {
+    "query": "string",
+    "id_list": ["string"],
+    "max_results": 5,
+    "sort_by": "relevance",
+    "sort_order": "descending",
+    "submitted_date_from": "2025-01-01",
+    "submitted_date_to": "2025-12-31"
+  },
+  "read_arxiv_papers": true,
+  "max_content_runes": 20000
 }
 ```
+
+When PDF reading is enabled, `max_content_runes` limits the returned text for
+each article. Non-positive values use the default of 20,000 runes, and values
+above 200,000 are capped at 200,000.
 
 **Output:**
 ```json
@@ -59,12 +68,21 @@ The tool provides access to scholarly articles from arXiv repository:
       "content": [
         {
           "page": 1,
-          "text": "string"
+          "text": "partial page text",
+          "truncated": true
         }
-      ]
+      ],
+      "content_runes": 58321,
+      "returned_content_runes": 20000,
+      "content_truncated": true
     }
 ]
 ```
+
+`content_truncated` means the article's `content` is partial rather than the
+complete extracted PDF text. `content_runes` is the full extracted size and
+`returned_content_runes` is the size returned within the configured budget. A
+page-level `truncated` flag identifies the page where the budget was exhausted.
 
 **What Works (Scholarly Article Search):**
 - **Keyword Search**: Search by research topics, concepts, techniques
@@ -72,7 +90,7 @@ The tool provides access to scholarly articles from arXiv repository:
 - **Category Search**: Browse by arXiv categories (cs.AI, cs.CV, math.NA, etc.)
 - **ID Search**: Look up specific arXiv IDs (e.g., "2401.12345")
 - **Date Filtering**: Search by publication date ranges
-- **PDF Content**: Optionally read and extract text from PDF articles
+- **PDF Content**: Optionally return budgeted PDF text with explicit truncation metadata
 - **Multi-field Search**: Combine title, abstract, author searches
 
 **What Doesn't Work (Limitations):**

--- a/tool/arxivsearch/arxiv_search.go
+++ b/tool/arxivsearch/arxiv_search.go
@@ -12,10 +12,13 @@ package arxivsearch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
+	"unicode/utf8"
 
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -34,32 +37,45 @@ var (
 	maxResults = 5
 )
 
+const (
+	defaultArticleContentRunes = 20000
+	maxArticleContentRunes     = 200000
+	errEmptySearch             = "query, id list, or submitted date is required"
+)
+
 // content define an article content download from pdf
 type content struct {
-	Page int    `json:"page"`
-	Text string `json:"text"`
+	Page      int    `json:"page"`
+	Text      string `json:"text"`
+	Truncated bool   `json:"truncated,omitempty"`
 }
 
 // article define an article
 type article struct {
-	Title           string    `json:"title"`
-	ID              string    `json:"id"`
-	EntryID         string    `json:"entry_id"`
-	Authors         []string  `json:"authors"`
-	PrimaryCategory string    `json:"primary_category"`
-	Categories      []string  `json:"categories"`
-	Published       string    `json:"published"`
-	PdfURL          string    `json:"pdf_url"`
-	Links           []string  `json:"links"`
-	Summary         string    `json:"summary"`
-	Comment         string    `json:"comment"`
-	Content         []content `json:"content"`
+	Title                string    `json:"title"`
+	ID                   string    `json:"id"`
+	EntryID              string    `json:"entry_id"`
+	Authors              []string  `json:"authors"`
+	PrimaryCategory      string    `json:"primary_category"`
+	Categories           []string  `json:"categories"`
+	Published            string    `json:"published"`
+	PdfURL               string    `json:"pdf_url"`
+	Links                []string  `json:"links"`
+	Summary              string    `json:"summary"`
+	Comment              string    `json:"comment"`
+	Content              []content `json:"content"`
+	ContentRunes         int       `json:"content_runes,omitempty"`
+	ReturnedContentRunes int       `json:"returned_content_runes,omitempty"`
+	ContentTruncated     bool      `json:"content_truncated,omitempty"`
 }
 
 // searchRequest define an arxiv search request
 type searchRequest struct {
 	Search          arxiv.Search `json:"search" jsonschema:"description=Search query"`
 	ReadArxivPapers bool         `json:"read_arxiv_papers" jsonschema:"description=Whether to read the content from PDF"`
+	// MaxContentRunes limits PDF text returned per article.
+	// It defaults to 20000 and is capped at 200000.
+	MaxContentRunes int `json:"max_content_runes,omitempty"`
 }
 
 // Option define an option for arxiv tool
@@ -171,9 +187,12 @@ func NewToolSet(opts ...Option) (*ToolSet, error) {
 	return t, nil
 }
 
-func (t *ToolSet) search(ctx context.Context, req searchRequest) ([]article, error) {
-	if len(req.Search.Query) == 0 && len(req.Search.IDList) == 0 {
-		return nil, fmt.Errorf("query or id list is empty")
+func (t *ToolSet) search(
+	ctx context.Context,
+	req searchRequest,
+) ([]article, error) {
+	if isEmptySearch(req.Search) {
+		return nil, errors.New(errEmptySearch)
 	}
 	if req.Search.MaxResults == nil {
 		req.Search.MaxResults = &maxResults
@@ -184,6 +203,7 @@ func (t *ToolSet) search(ctx context.Context, req searchRequest) ([]article, err
 	}
 	articles := make([]article, 0, len(results))
 	var pdfReader reader.Reader
+	maxContentRunes := normalizedMaxContentRunes(req.MaxContentRunes)
 	if req.ReadArxivPapers {
 		pdfReader = pdf.New()
 	}
@@ -213,14 +233,80 @@ func (t *ToolSet) search(ctx context.Context, req searchRequest) ([]article, err
 			if err != nil {
 				return nil, fmt.Errorf("failed to read PDF from URL: %w", err)
 			}
-			for pageNum, doc := range documents {
-				arti.Content = append(arti.Content, content{
-					Page: pageNum + 1,
-					Text: doc.Content,
-				})
-			}
+			appendArticleContent(&arti, documents, maxContentRunes)
 		}
 		articles = append(articles, arti)
 	}
 	return articles, nil
+}
+
+func isEmptySearch(search arxiv.Search) bool {
+	return len(search.Query) == 0 &&
+		len(search.IDList) == 0 &&
+		len(search.SubmittedDateFrom) == 0 &&
+		len(search.SubmittedDateTo) == 0
+}
+
+func normalizedMaxContentRunes(maxRunes int) int {
+	if maxRunes <= 0 {
+		return defaultArticleContentRunes
+	}
+	if maxRunes > maxArticleContentRunes {
+		return maxArticleContentRunes
+	}
+	return maxRunes
+}
+
+func appendArticleContent(
+	arti *article,
+	documents []*document.Document,
+	maxRunes int,
+) {
+	if arti == nil {
+		return
+	}
+	remaining := maxRunes
+	for pageNum, doc := range documents {
+		if doc == nil {
+			continue
+		}
+		text := doc.Content
+		contentRunes := utf8.RuneCountInString(text)
+		arti.ContentRunes += contentRunes
+		page := content{
+			Page: pageNum + 1,
+			Text: text,
+		}
+		if remaining <= 0 {
+			if contentRunes > 0 {
+				arti.ContentTruncated = true
+			}
+			continue
+		}
+		if contentRunes > remaining {
+			page.Text = truncateRunes(text, remaining)
+			page.Truncated = true
+			arti.ContentTruncated = true
+		}
+		returnedRunes := utf8.RuneCountInString(page.Text)
+		arti.ReturnedContentRunes += returnedRunes
+		remaining -= returnedRunes
+		arti.Content = append(arti.Content, page)
+	}
+}
+
+func truncateRunes(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(text) <= maxRunes {
+		return text
+	}
+	for idx := range text {
+		if maxRunes == 0 {
+			return text[:idx]
+		}
+		maxRunes--
+	}
+	return text
 }

--- a/tool/arxivsearch/arxiv_search.go
+++ b/tool/arxivsearch/arxiv_search.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -75,7 +76,7 @@ type searchRequest struct {
 	ReadArxivPapers bool         `json:"read_arxiv_papers" jsonschema:"description=Whether to read the content from PDF"`
 	// MaxContentRunes limits PDF text returned per article.
 	// It defaults to 20000 and is capped at 200000.
-	MaxContentRunes int `json:"max_content_runes,omitempty"`
+	MaxContentRunes int `json:"max_content_runes,omitempty" jsonschema:"description=Maximum PDF text runes returned per article when read_arxiv_papers is true. Non-positive values use the 20000 default; values above 200000 are capped. Set read_arxiv_papers to false to omit PDF content."`
 }
 
 // Option define an option for arxiv tool
@@ -241,10 +242,19 @@ func (t *ToolSet) search(
 }
 
 func isEmptySearch(search arxiv.Search) bool {
-	return len(search.Query) == 0 &&
-		len(search.IDList) == 0 &&
-		len(search.SubmittedDateFrom) == 0 &&
-		len(search.SubmittedDateTo) == 0
+	return strings.TrimSpace(search.Query) == "" &&
+		!hasNonEmptyString(search.IDList) &&
+		strings.TrimSpace(search.SubmittedDateFrom) == "" &&
+		strings.TrimSpace(search.SubmittedDateTo) == ""
+}
+
+func hasNonEmptyString(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizedMaxContentRunes(maxRunes int) int {

--- a/tool/arxivsearch/arxiv_search.go
+++ b/tool/arxivsearch/arxiv_search.go
@@ -41,7 +41,7 @@ var (
 const (
 	defaultArticleContentRunes = 20000
 	maxArticleContentRunes     = 200000
-	errEmptySearch             = "query, id list, or submitted date is required"
+	errEmptySearch             = "query, id list, submitted_date_from, or submitted_date_to is required"
 )
 
 // content define an article content download from pdf
@@ -182,7 +182,8 @@ func NewToolSet(opts ...Option) (*ToolSet, error) {
 			"the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, "+
 			"electrical engineering and systems science, and economics. "+
 			"Returns a list of articles, containing title, authors, primary category, categories, published date, PDF URL, "+
-			"links, summary, comment, and content (if read_arxiv_papers is true)."),
+			"links, summary, comment, and capped PDF content with truncation metadata (if read_arxiv_papers is true). "+
+			"Use max_content_runes to adjust the per-article PDF content cap."),
 	))
 	t.tools = tools
 	return t, nil

--- a/tool/arxivsearch/arxiv_search_test.go
+++ b/tool/arxivsearch/arxiv_search_test.go
@@ -171,13 +171,16 @@ func Test_arxivTool_search(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		req          searchRequest
-		setupServer  func() *httptest.Server
-		wantErr      bool
-		wantErrText  string
-		wantArticles int
-		wantContent  []content
+		name          string
+		req           searchRequest
+		setupServer   func() *httptest.Server
+		wantErr       bool
+		wantErrText   string
+		wantArticles  int
+		wantContent   []content
+		wantRunes     int
+		wantReturned  int
+		wantTruncated bool
 	}{
 		{
 			name: "normal case with query",
@@ -217,6 +220,36 @@ func Test_arxivTool_search(t *testing.T) {
 					Text: "Hello World",
 				},
 			},
+		},
+		{
+			name: "read pdf content applies max content runes",
+			req: searchRequest{
+				Search: arxiv.Search{
+					Query: "pdf cap test",
+				},
+				ReadArxivPapers: true,
+				MaxContentRunes: 5,
+			},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					entryXML := createEntryXML("PDF Cap Test Paper", "6789.0123v1", "cs.AI", pdfServer.URL+"/capped.pdf")
+					feedXML := createFeedXML([]string{entryXML})
+					w.Header().Set("Content-Type", "application/xml")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(feedXML))
+				}))
+			},
+			wantArticles: 1,
+			wantContent: []content{
+				{
+					Page:      1,
+					Text:      "Hello",
+					Truncated: true,
+				},
+			},
+			wantRunes:     11,
+			wantReturned:  5,
+			wantTruncated: true,
 		},
 		{
 			name: "empty query and id list",
@@ -395,6 +428,15 @@ func Test_arxivTool_search(t *testing.T) {
 			if tt.req.ReadArxivPapers {
 				for _, article := range got {
 					assert.Equal(t, article.Content, tt.wantContent)
+					if tt.wantRunes > 0 || tt.wantReturned > 0 ||
+						tt.wantTruncated {
+						assert.Equal(t, tt.wantRunes,
+							article.ContentRunes)
+						assert.Equal(t, tt.wantReturned,
+							article.ReturnedContentRunes)
+						assert.Equal(t, tt.wantTruncated,
+							article.ContentTruncated)
+					}
 				}
 			}
 		})

--- a/tool/arxivsearch/arxiv_search_test.go
+++ b/tool/arxivsearch/arxiv_search_test.go
@@ -531,6 +531,21 @@ func TestNormalizedMaxContentRunes(t *testing.T) {
 		normalizedMaxContentRunes(maxArticleContentRunes+1))
 }
 
+func TestIsEmptySearchTrimsWhitespace(t *testing.T) {
+	assert.True(t, isEmptySearch(arxiv.Search{
+		Query:             "  \t\n",
+		IDList:            []string{" ", "\t"},
+		SubmittedDateFrom: " ",
+		SubmittedDateTo:   "\n",
+	}))
+	assert.False(t, isEmptySearch(arxiv.Search{
+		IDList: []string{" ", "2301.00001"},
+	}))
+	assert.False(t, isEmptySearch(arxiv.Search{
+		SubmittedDateFrom: "2022-01-01",
+	}))
+}
+
 func TestAppendArticleContentAppliesRuneBudget(t *testing.T) {
 	var got article
 	appendArticleContent(&got, []*document.Document{
@@ -547,6 +562,23 @@ func TestAppendArticleContentAppliesRuneBudget(t *testing.T) {
 	assert.True(t, got.ContentTruncated)
 	assert.Equal(t, 13, got.ContentRunes)
 	assert.Equal(t, 7, got.ReturnedContentRunes)
+}
+
+func TestAppendArticleContentHandlesNilAndZeroBudget(t *testing.T) {
+	require.NotPanics(t, func() {
+		appendArticleContent(nil, []*document.Document{{Content: "ignored"}}, 1)
+	})
+
+	var got article
+	appendArticleContent(&got, []*document.Document{
+		nil,
+		{Content: "alpha"},
+	}, 0)
+
+	assert.Empty(t, got.Content)
+	assert.True(t, got.ContentTruncated)
+	assert.Equal(t, 5, got.ContentRunes)
+	assert.Equal(t, 0, got.ReturnedContentRunes)
 }
 
 func TestAppendArticleContentKeepsShortDocuments(t *testing.T) {

--- a/tool/arxivsearch/arxiv_search_test.go
+++ b/tool/arxivsearch/arxiv_search_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/tool/arxivsearch/internal/arxiv"
 )
 
@@ -174,6 +175,7 @@ func Test_arxivTool_search(t *testing.T) {
 		req          searchRequest
 		setupServer  func() *httptest.Server
 		wantErr      bool
+		wantErrText  string
 		wantArticles int
 		wantContent  []content
 	}{
@@ -227,7 +229,31 @@ func Test_arxivTool_search(t *testing.T) {
 					w.Write([]byte(feedXML))
 				}))
 			},
-			wantErr: true,
+			wantErr:     true,
+			wantErrText: errEmptySearch,
+		},
+		{
+			name: "date only query",
+			req: searchRequest{
+				Search: arxiv.Search{
+					SubmittedDateFrom: "2022-06-01",
+					SubmittedDateTo:   "2022-06-30",
+				},
+			},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					query := r.URL.Query().Get("search_query")
+					assert.Equal(t,
+						"submittedDate:[202206010000 TO 202206302359]",
+						query)
+
+					feedXML := createFeedXML([]string{})
+					w.Header().Set("Content-Type", "application/xml")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(feedXML))
+				}))
+			},
+			wantArticles: 0,
 		},
 		{
 			name: "search returns error",
@@ -352,6 +378,9 @@ func Test_arxivTool_search(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Error(t, err, "Expected error")
+				if tt.wantErrText != "" {
+					assert.ErrorContains(t, err, tt.wantErrText)
+				}
 				return
 			}
 
@@ -492,6 +521,46 @@ func TestWithTimeout_EnforcedAtCallPath(t *testing.T) {
 	assert.Equal(t, 30*time.Second, original.Timeout, "original client must remain unmutated")
 	assert.Equal(t, http.RoundTripper(blockingRoundTripper{}), original.Transport,
 		"original transport must remain unmutated")
+}
+
+func TestNormalizedMaxContentRunes(t *testing.T) {
+	assert.Equal(t, defaultArticleContentRunes, normalizedMaxContentRunes(0))
+	assert.Equal(t, defaultArticleContentRunes, normalizedMaxContentRunes(-1))
+	assert.Equal(t, 123, normalizedMaxContentRunes(123))
+	assert.Equal(t, maxArticleContentRunes,
+		normalizedMaxContentRunes(maxArticleContentRunes+1))
+}
+
+func TestAppendArticleContentAppliesRuneBudget(t *testing.T) {
+	var got article
+	appendArticleContent(&got, []*document.Document{
+		{Content: "alpha"},
+		{Content: "βγδε"},
+		{Content: "tail"},
+	}, 7)
+
+	require.Len(t, got.Content, 2)
+	assert.Equal(t, "alpha", got.Content[0].Text)
+	assert.False(t, got.Content[0].Truncated)
+	assert.Equal(t, "βγ", got.Content[1].Text)
+	assert.True(t, got.Content[1].Truncated)
+	assert.True(t, got.ContentTruncated)
+	assert.Equal(t, 13, got.ContentRunes)
+	assert.Equal(t, 7, got.ReturnedContentRunes)
+}
+
+func TestAppendArticleContentKeepsShortDocuments(t *testing.T) {
+	var got article
+	appendArticleContent(&got, []*document.Document{
+		{Content: "Hello World"},
+	}, defaultArticleContentRunes)
+
+	require.Len(t, got.Content, 1)
+	assert.Equal(t, "Hello World", got.Content[0].Text)
+	assert.False(t, got.Content[0].Truncated)
+	assert.False(t, got.ContentTruncated)
+	assert.Equal(t, 11, got.ContentRunes)
+	assert.Equal(t, 11, got.ReturnedContentRunes)
 }
 
 // TestNewTool tests the NewToolSet function

--- a/tool/arxivsearch/internal/arxiv/client.go
+++ b/tool/arxivsearch/internal/arxiv/client.go
@@ -234,34 +234,29 @@ func normalizeArxivDateBound(raw string, upper bool) (string, error) {
 	if raw == "" {
 		return "", fmt.Errorf("empty date")
 	}
-	digits := dateDigits(raw)
-	switch len(digits) {
-	case 8:
-		if upper {
-			digits += "2359"
-		} else {
-			digits += "0000"
+	formats := []struct {
+		layout   string
+		dateOnly bool
+	}{
+		{layout: "2006-01-02", dateOnly: true},
+		{layout: "20060102", dateOnly: true},
+		{layout: "200601021504"},
+		{layout: "2006-01-02 15:04"},
+	}
+	for _, format := range formats {
+		parsed, err := time.Parse(format.layout, raw)
+		if err != nil {
+			continue
 		}
-	case 12:
-	default:
-		return "", fmt.Errorf(
-			"expected YYYY-MM-DD, YYYYMMDD, or YYYYMMDDHHMM",
-		)
-	}
-	if _, err := time.Parse("200601021504", digits); err != nil {
-		return "", err
-	}
-	return digits, nil
-}
-
-func dateDigits(raw string) string {
-	var b strings.Builder
-	for _, r := range raw {
-		if r >= '0' && r <= '9' {
-			b.WriteRune(r)
+		if format.dateOnly && upper {
+			parsed = parsed.Add(23*time.Hour + 59*time.Minute)
 		}
+		return parsed.Format("200601021504"), nil
 	}
-	return b.String()
+	return "", fmt.Errorf(
+		"expected YYYY-MM-DD, YYYYMMDD, YYYYMMDDHHMM, or " +
+			"YYYY-MM-DD HH:MM",
+	)
 }
 
 // fetchPage fetches a page of results

--- a/tool/arxivsearch/internal/arxiv/client.go
+++ b/tool/arxivsearch/internal/arxiv/client.go
@@ -177,10 +177,23 @@ func buildSearchQuery(search Search) (string, error) {
 	if dateClause == "" {
 		return query, nil
 	}
+	if containsSubmittedDateClause(query) {
+		return "", fmt.Errorf(
+			"query already contains submittedDate; use either the " +
+				"query clause or submitted_date_from/to",
+		)
+	}
 	if query == "" {
 		return dateClause, nil
 	}
 	return query + " AND " + dateClause, nil
+}
+
+func containsSubmittedDateClause(query string) bool {
+	return strings.Contains(
+		strings.ToLower(query),
+		"submitteddate:",
+	)
 }
 
 func submittedDateClause(from string, to string) (string, error) {
@@ -202,6 +215,12 @@ func submittedDateClause(from string, to string) (string, error) {
 	toDate, err := normalizeArxivDateBound(to, true)
 	if err != nil {
 		return "", fmt.Errorf("invalid submitted_date_to: %w", err)
+	}
+	if fromDate > toDate {
+		return "", fmt.Errorf(
+			"submitted_date_from must be before or equal to " +
+				"submitted_date_to",
+		)
 	}
 	return fmt.Sprintf(
 		"submittedDate:[%s TO %s]",

--- a/tool/arxivsearch/internal/arxiv/client.go
+++ b/tool/arxivsearch/internal/arxiv/client.go
@@ -139,8 +139,12 @@ func (c *Client) Search(search Search) ([]Result, error) {
 // buildQueryURL builds the query URL for the search
 func (c *Client) buildQueryURL(search Search, start, maxResults int) (string, error) {
 	params := url.Values{}
-	if search.Query != "" {
-		params.Add("search_query", search.Query)
+	query, err := buildSearchQuery(search)
+	if err != nil {
+		return "", err
+	}
+	if query != "" {
+		params.Add("search_query", query)
 	}
 	if len(search.IDList) > 0 {
 		params.Add("id_list", strings.Join(search.IDList, ","))
@@ -159,6 +163,86 @@ func (c *Client) buildQueryURL(search Search, start, maxResults int) (string, er
 	}
 
 	return c.BaseURL + "?" + params.Encode(), nil
+}
+
+func buildSearchQuery(search Search) (string, error) {
+	query := strings.TrimSpace(search.Query)
+	dateClause, err := submittedDateClause(
+		search.SubmittedDateFrom,
+		search.SubmittedDateTo,
+	)
+	if err != nil {
+		return "", err
+	}
+	if dateClause == "" {
+		return query, nil
+	}
+	if query == "" {
+		return dateClause, nil
+	}
+	return query + " AND " + dateClause, nil
+}
+
+func submittedDateClause(from string, to string) (string, error) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if from == "" && to == "" {
+		return "", nil
+	}
+	if from == "" {
+		from = "199001010000"
+	}
+	if to == "" {
+		to = "999912312359"
+	}
+	fromDate, err := normalizeArxivDateBound(from, false)
+	if err != nil {
+		return "", fmt.Errorf("invalid submitted_date_from: %w", err)
+	}
+	toDate, err := normalizeArxivDateBound(to, true)
+	if err != nil {
+		return "", fmt.Errorf("invalid submitted_date_to: %w", err)
+	}
+	return fmt.Sprintf(
+		"submittedDate:[%s TO %s]",
+		fromDate,
+		toDate,
+	), nil
+}
+
+func normalizeArxivDateBound(raw string, upper bool) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty date")
+	}
+	digits := dateDigits(raw)
+	switch len(digits) {
+	case 8:
+		if upper {
+			digits += "2359"
+		} else {
+			digits += "0000"
+		}
+	case 12:
+	default:
+		return "", fmt.Errorf(
+			"expected YYYY-MM-DD, YYYYMMDD, or YYYYMMDDHHMM",
+		)
+	}
+	if _, err := time.Parse("200601021504", digits); err != nil {
+		return "", err
+	}
+	return digits, nil
+}
+
+func dateDigits(raw string) string {
+	var b strings.Builder
+	for _, r := range raw {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // fetchPage fetches a page of results

--- a/tool/arxivsearch/internal/arxiv/client.go
+++ b/tool/arxivsearch/internal/arxiv/client.go
@@ -186,7 +186,7 @@ func buildSearchQuery(search Search) (string, error) {
 	if query == "" {
 		return dateClause, nil
 	}
-	return query + " AND " + dateClause, nil
+	return "(" + query + ") AND " + dateClause, nil
 }
 
 func containsSubmittedDateClause(query string) bool {

--- a/tool/arxivsearch/internal/arxiv/client_test.go
+++ b/tool/arxivsearch/internal/arxiv/client_test.go
@@ -172,6 +172,37 @@ func TestClient_buildQueryURL(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "duplicate submitted date clause",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					Query:             "cat:cs.AI AND submittedDate:[202201010000 TO 202201312359]",
+					SubmittedDateFrom: "2022-06-01",
+				},
+				start:      0,
+				maxResults: 5,
+			},
+			wantErr: true,
+		},
+		{
+			name: "inverted submitted date range",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					Query:             "cat:cs.AI",
+					SubmittedDateFrom: "2022-12-31",
+					SubmittedDateTo:   "2022-01-01",
+				},
+				start:      0,
+				maxResults: 5,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tool/arxivsearch/internal/arxiv/client_test.go
+++ b/tool/arxivsearch/internal/arxiv/client_test.go
@@ -140,7 +140,23 @@ func TestClient_buildQueryURL(t *testing.T) {
 				start:      0,
 				maxResults: 10,
 			},
-			want: "http://arxiv.org?max_results=10&search_query=cat%3Acs.AI+AND+submittedDate%3A%5B202206010000+TO+202206302359%5D&start=0",
+			want: "http://arxiv.org?max_results=10&search_query=%28cat%3Acs.AI%29+AND+submittedDate%3A%5B202206010000+TO+202206302359%5D&start=0",
+		},
+		{
+			name: "submitted date range groups compound query",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					Query:             "cat:cs.AI OR cat:cs.LG",
+					SubmittedDateFrom: "2022-06-01",
+					SubmittedDateTo:   "2022-06-30",
+				},
+				start:      0,
+				maxResults: 10,
+			},
+			want: "http://arxiv.org?max_results=10&search_query=%28cat%3Acs.AI+OR+cat%3Acs.LG%29+AND+submittedDate%3A%5B202206010000+TO+202206302359%5D&start=0",
 		},
 		{
 			name: "submitted date range only",
@@ -170,7 +186,7 @@ func TestClient_buildQueryURL(t *testing.T) {
 				start:      0,
 				maxResults: 5,
 			},
-			want: "http://arxiv.org?max_results=5&search_query=cat%3Acs.AI+AND+submittedDate%3A%5B202206010000+TO+999912312359%5D&start=0",
+			want: "http://arxiv.org?max_results=5&search_query=%28cat%3Acs.AI%29+AND+submittedDate%3A%5B202206010000+TO+999912312359%5D&start=0",
 		},
 		{
 			name: "submitted date to only",

--- a/tool/arxivsearch/internal/arxiv/client_test.go
+++ b/tool/arxivsearch/internal/arxiv/client_test.go
@@ -126,6 +126,52 @@ func TestClient_buildQueryURL(t *testing.T) {
 			},
 			want: "http://example.com?max_results=1&search_query=hello+world%21&start=0",
 		},
+		{
+			name: "submitted date range with query",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					Query:             "cat:cs.AI",
+					SubmittedDateFrom: "2022-06-01",
+					SubmittedDateTo:   "2022-06-30",
+				},
+				start:      0,
+				maxResults: 10,
+			},
+			want: "http://arxiv.org?max_results=10&search_query=cat%3Acs.AI+AND+submittedDate%3A%5B202206010000+TO+202206302359%5D&start=0",
+		},
+		{
+			name: "submitted date range only",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					SubmittedDateFrom: "2016-08-11",
+					SubmittedDateTo:   "2016-08-11",
+				},
+				start:      0,
+				maxResults: 5,
+			},
+			want: "http://arxiv.org?max_results=5&search_query=submittedDate%3A%5B201608110000+TO+201608112359%5D&start=0",
+		},
+		{
+			name: "invalid submitted date",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					Query:             "cat:cs.AI",
+					SubmittedDateFrom: "2022-13-01",
+				},
+				start:      0,
+				maxResults: 5,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -144,6 +190,34 @@ func TestClient_buildQueryURL(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("Client.buildQueryURL() = \n%v, \nwant \n%v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestNormalizeArxivDateBound(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		upper   bool
+		want    string
+		wantErr bool
+	}{
+		{name: "lower date", raw: "2022-06-01", want: "202206010000"},
+		{name: "upper date", raw: "20220630", upper: true, want: "202206302359"},
+		{name: "minute", raw: "202206011234", want: "202206011234"},
+		{name: "date time text", raw: "2022-06-01 12:34", want: "202206011234"},
+		{name: "bad date", raw: "2022-02-31", wantErr: true},
+		{name: "bad shape", raw: "2022", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeArxivDateBound(tt.raw, tt.upper)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/tool/arxivsearch/internal/arxiv/client_test.go
+++ b/tool/arxivsearch/internal/arxiv/client_test.go
@@ -283,6 +283,7 @@ func TestNormalizeArxivDateBound(t *testing.T) {
 		{name: "minute", raw: "202206011234", want: "202206011234"},
 		{name: "date time text", raw: "2022-06-01 12:34", want: "202206011234"},
 		{name: "bad date", raw: "2022-02-31", wantErr: true},
+		{name: "unexpected date character", raw: "2022-0x6-01", wantErr: true},
 		{name: "bad shape", raw: "2022", wantErr: true},
 	}
 	for _, tt := range tests {

--- a/tool/arxivsearch/internal/arxiv/client_test.go
+++ b/tool/arxivsearch/internal/arxiv/client_test.go
@@ -158,6 +158,35 @@ func TestClient_buildQueryURL(t *testing.T) {
 			want: "http://arxiv.org?max_results=5&search_query=submittedDate%3A%5B201608110000+TO+201608112359%5D&start=0",
 		},
 		{
+			name: "submitted date from only",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					Query:             "cat:cs.AI",
+					SubmittedDateFrom: "2022-06-01",
+				},
+				start:      0,
+				maxResults: 5,
+			},
+			want: "http://arxiv.org?max_results=5&search_query=cat%3Acs.AI+AND+submittedDate%3A%5B202206010000+TO+999912312359%5D&start=0",
+		},
+		{
+			name: "submitted date to only",
+			fields: fields{
+				baseURL: "http://arxiv.org",
+			},
+			args: args{
+				search: Search{
+					SubmittedDateTo: "2022-06-30",
+				},
+				start:      0,
+				maxResults: 5,
+			},
+			want: "http://arxiv.org?max_results=5&search_query=submittedDate%3A%5B199001010000+TO+202206302359%5D&start=0",
+		},
+		{
 			name: "invalid submitted date",
 			fields: fields{
 				baseURL: "http://arxiv.org",

--- a/tool/arxivsearch/internal/arxiv/types.go
+++ b/tool/arxivsearch/internal/arxiv/types.go
@@ -73,8 +73,8 @@ type Search struct {
 	MaxResults        *int          `json:"max_results,omitempty" jsonschema:"description=Maximum number of results to return"`
 	SortBy            SortCriterion `json:"sort_by,omitempty" jsonschema:"description=Sort criterion: relevance or lastUpdatedDate or submittedDate,enum=relevance,enum=lastUpdatedDate,enum=submittedDate"`
 	SortOrder         SortOrder     `json:"sort_order,omitempty" jsonschema:"description=Sort order: ascending or descending,enum=ascending,enum=descending"`
-	SubmittedDateFrom string        `json:"submitted_date_from,omitempty" jsonschema:"description=Submitted date lower bound in YYYY-MM-DD or YYYYMMDDHHMM GMT"`
-	SubmittedDateTo   string        `json:"submitted_date_to,omitempty" jsonschema:"description=Submitted date upper bound in YYYY-MM-DD or YYYYMMDDHHMM GMT"`
+	SubmittedDateFrom string        `json:"submitted_date_from,omitempty" jsonschema:"description=Submitted date lower bound in YYYY-MM-DD or YYYYMMDDHHMM GMT. Can be used without submitted_date_to for an open-ended range."`
+	SubmittedDateTo   string        `json:"submitted_date_to,omitempty" jsonschema:"description=Submitted date upper bound in YYYY-MM-DD or YYYYMMDDHHMM GMT. Can be used without submitted_date_from for an open-ended range."`
 }
 
 // ClientConfig contains the configuration for the arXiv client

--- a/tool/arxivsearch/internal/arxiv/types.go
+++ b/tool/arxivsearch/internal/arxiv/types.go
@@ -68,11 +68,13 @@ type Result struct {
 
 // Search defines the search parameters
 type Search struct {
-	Query      string        `json:"query" jsonschema:"description=The search query string for arXiv articles"`
-	IDList     []string      `json:"id_list,omitempty" jsonschema:"description=List of arXiv IDs to search for"`
-	MaxResults *int          `json:"max_results,omitempty" jsonschema:"description=Maximum number of results to return"`
-	SortBy     SortCriterion `json:"sort_by,omitempty" jsonschema:"description=Sort criterion: relevance or lastUpdatedDate or submittedDate,enum=relevance,enum=lastUpdatedDate,enum=submittedDate"`
-	SortOrder  SortOrder     `json:"sort_order,omitempty" jsonschema:"description=Sort order: ascending or descending,enum=ascending,enum=descending"`
+	Query             string        `json:"query,omitempty" jsonschema:"description=The search query string for arXiv articles"`
+	IDList            []string      `json:"id_list,omitempty" jsonschema:"description=List of arXiv IDs to search for"`
+	MaxResults        *int          `json:"max_results,omitempty" jsonschema:"description=Maximum number of results to return"`
+	SortBy            SortCriterion `json:"sort_by,omitempty" jsonschema:"description=Sort criterion: relevance or lastUpdatedDate or submittedDate,enum=relevance,enum=lastUpdatedDate,enum=submittedDate"`
+	SortOrder         SortOrder     `json:"sort_order,omitempty" jsonschema:"description=Sort order: ascending or descending,enum=ascending,enum=descending"`
+	SubmittedDateFrom string        `json:"submitted_date_from,omitempty" jsonschema:"description=Submitted date lower bound in YYYY-MM-DD or YYYYMMDDHHMM GMT"`
+	SubmittedDateTo   string        `json:"submitted_date_to,omitempty" jsonschema:"description=Submitted date upper bound in YYYY-MM-DD or YYYYMMDDHHMM GMT"`
 }
 
 // ClientConfig contains the configuration for the arXiv client


### PR DESCRIPTION
Summary
- cap PDF text returned by arxiv_search when read_arxiv_papers is enabled
- add truncation metadata and an optional max_content_runes override
- keep normal metadata-only arXiv search behavior unchanged
- validate submitted-date helper fields and document open-ended date ranges

Behavior notes
- read_arxiv_papers=true now returns PDF text up to 20,000 runes per article by default, with truncation metadata when content is capped.
- max_content_runes can raise the per-article cap up to 200,000 runes; non-positive values use the default. Use read_arxiv_papers=false for metadata-only search results.
- submitted_date_from/submitted_date_to may be used for open-ended ranges, but inverted ranges and duplicate query-level submittedDate clauses are rejected.

Validation
- cd tool/arxivsearch && go test ./...
