### PR TITLE
examples: add prompt optimization regression loop

### DIFF
--- a/examples/evaluation/promptiter_regression_loop/DESIGN.md
+++ b/examples/evaluation/promptiter_regression_loop/DESIGN.md
@@ -1,0 +1,7 @@
+# Design
+
+该示例把 PromptIter 的候选生成与生产回写之间补成可审计闭环。Pipeline 首先用同一 metrics 配置分别评估训练集和独立验证集，保留每条 case 的最终回复、工具轨迹、参数、route、格式、召回、成本和延迟。失败归因采用确定性优先级：运行异常、route、工具选择、工具参数、结构化格式、知识召回、最终回复，确保每个失败 case 至少有一个可解释原因，也便于替换成 Evaluation Service trace 或 LLM rubric 信号。
+
+每个候选 prompt 对训练集和验证集重新评估。验证结果按 case ID 与不可变 baseline 对齐，计算分数变化、新增通过和新增失败。Gate 同时检查验证总分最小增益、hard fail、关键 case 退化、成本增量和工具调用预算；任何条件失败都拒绝候选。这样即使候选在训练集满分，只要验证集下降或关键 case 退化，仍会被识别为过拟合并拒绝。
+
+示例的 fake trace engine 固定随机种子且无需 API Key，可在三分钟内稳定回放“有效优化、无效优化、训练提升但验证退化”三类轮次。接口可对接真实 `evaluation/workflow/promptiter`：将每轮 surface patch、EvaluationResult 和 trace 映射到相同审计结构，再复用 delta 与 gate。JSON 报告保存 baseline、每轮完整 prompt、评测、归因、delta、决策理由、模型或 fake engine 配置、成本、耗时和种子；Markdown 报告供人工审批。源 prompt 不自动回写，只有通过验证门禁的最佳候选才被标记为可考虑回写。

--- a/examples/evaluation/promptiter_regression_loop/DESIGN.md
+++ b/examples/evaluation/promptiter_regression_loop/DESIGN.md
@@ -2,6 +2,6 @@
 
 该示例把 PromptIter 的候选生成与生产回写之间补成可审计闭环。Pipeline 首先用同一 metrics 配置分别评估训练集和独立验证集，保留每条 case 的最终回复、工具轨迹、参数、route、格式、召回、成本和延迟。失败归因采用确定性优先级：运行异常、route、工具选择、工具参数、结构化格式、知识召回、最终回复，确保每个失败 case 至少有一个可解释原因，也便于替换成 Evaluation Service trace 或 LLM rubric 信号。
 
-每个候选 prompt 对训练集和验证集重新评估。验证结果按 case ID 与不可变 baseline 对齐，计算分数变化、新增通过和新增失败。Gate 同时检查验证总分最小增益、hard fail、关键 case 退化、成本增量和工具调用预算；任何条件失败都拒绝候选。这样即使候选在训练集满分，只要验证集下降或关键 case 退化，仍会被识别为过拟合并拒绝。
+每个候选 prompt 对训练集和验证集重新评估。验证结果按 case ID 与不可变 baseline 对齐，计算分数变化、新增通过和新增失败；缺失 case 同样计入失败和退化计数。Gate 在决策前从 case 与 trace 重算总分、通过/失败数、成本、延迟和工具调用数，拒绝不一致的外部映射结果，再检查验证总分达到最小增益、hard fail、关键 case 退化、成本增量和工具调用预算；任何条件失败都拒绝候选。声明 retrieval contract 时，缺失的 retrieval telemetry 不等同于 false。这样即使候选在训练集满分，只要验证集下降或关键 case 退化，仍会被识别为过拟合并拒绝。
 
 示例的 fake trace engine 固定随机种子且无需 API Key，可在三分钟内稳定回放“有效优化、无效优化、训练提升但验证退化”三类轮次。接口可对接真实 `evaluation/workflow/promptiter`：将每轮 surface patch、EvaluationResult 和 trace 映射到相同审计结构，再复用 delta 与 gate。JSON 报告保存 baseline、每轮完整 prompt、评测、归因、delta、决策理由、模型或 fake engine 配置、成本、耗时和种子；Markdown 报告供人工审批。源 prompt 不自动回写，只有通过验证门禁的最佳候选才被标记为可考虑回写。

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -1,0 +1,79 @@
+# PromptIter Regression Loop
+
+This example implements the auditable evaluation and prompt-optimization loop
+requested by issue #2003. It evaluates a baseline on separate training and
+validation sets, attributes every failure, evaluates PromptIter-style prompt
+candidates, compares validation results case by case, applies an acceptance
+gate, and writes JSON and Markdown audit reports.
+
+The default `fake_trace` engine is deterministic and requires no API key. Its
+trace fixtures model final responses, tool trajectories, routing, structured
+format validity, retrieval signals, cost, latency, and tool-call count. The
+pipeline interfaces and report model can also wrap a real PromptIter run: map
+each engine round and Evaluation Service result into the same candidate and
+case result structures before applying the shared regression gate.
+
+## Run
+
+From `examples/evaluation`:
+
+```bash
+go run ./promptiter_regression_loop \
+  --data-dir promptiter_regression_loop/data \
+  --output-dir promptiter_regression_loop/out
+```
+
+The command writes:
+
+- `optimization_report.json`: machine-readable baseline, rounds, case deltas,
+  attribution counts, costs, latency, seed, engine configuration, and decision.
+- `optimization_report.md`: reviewer-friendly summary and write-back advice.
+
+Run the tests with:
+
+```bash
+go test ./promptiter_regression_loop
+```
+
+## Inputs
+
+| File | Purpose |
+|---|---|
+| `train.evalset.json` | Three optimization cases |
+| `validation.evalset.json` | Three held-out regression cases |
+| `metrics.json` | Metric weights and pass threshold |
+| `promptiter.json` | Seed, fake engine, candidate rounds, and gate budgets |
+| `baseline_prompt.txt` | Source prompt under optimization |
+| `candidate_*.txt` | PromptIter-style candidate patches |
+
+Each case owns its fixed `expected_route`, optional tri-state
+`retrieval_required`, and ordered `expected_tool_calls`. Observed runs contain
+only runtime signals. Tool-call arguments are JSON values, so numbers, arrays,
+and nested objects round-trip without being coerced to strings. All four JSON
+input files reject unknown fields to prevent misspelled safeguards from being
+silently disabled.
+
+The sample deliberately covers three outcomes. `focused` improves both sets and
+is accepted. `ineffective` changes wording without improving validation and is
+rejected. `overfit` memorizes the training set, reaches a perfect training
+score, regresses held-out critical cases, and is rejected.
+
+## Acceptance gate
+
+A candidate must satisfy every configured condition:
+
+- validation score gain is positive and reaches `min_validation_gain`;
+- no newly failing hard case;
+- explicitly protected cases do not regress;
+- validation cost increase stays within budget;
+- total tool calls stay within budget.
+
+Runtime success, route, retrieval, structured-format, and the complete ordered
+tool trajectory are hard case contracts when the case declares them. A high
+weighted response score cannot hide a contract regression. JSON and Markdown
+reports snapshot both metrics and gate configuration so an acceptance decision
+can be reproduced from the audit artifact alone.
+
+Candidates are always compared with the immutable baseline. Only the
+highest-scoring candidate that passes every gate becomes the selected prompt;
+the example never rewrites the source prompt automatically.

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -14,6 +14,7 @@ each engine round and Evaluation Service result into the same candidate and
 case result structures before applying the shared regression gate.
 Mapped aggregate score, pass/fail counts, cost, latency, and tool-call totals
 are recomputed from case results before any gate decision.
+Mapped baseline and candidate results must also use the same evaluation-set ID.
 
 ## Run
 

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -12,6 +12,8 @@ format validity, retrieval signals, cost, latency, and tool-call count. The
 pipeline interfaces and report model can also wrap a real PromptIter run: map
 each engine round and Evaluation Service result into the same candidate and
 case result structures before applying the shared regression gate.
+Mapped aggregate score, pass/fail counts, cost, latency, and tool-call totals
+are recomputed from case results before any gate decision.
 
 ## Run
 
@@ -48,10 +50,12 @@ go test ./promptiter_regression_loop
 
 Each case owns its fixed `expected_route`, optional tri-state
 `retrieval_required`, and ordered `expected_tool_calls`. Observed runs contain
-only runtime signals. Tool-call arguments are JSON values, so numbers, arrays,
-and nested objects round-trip without being coerced to strings. All four JSON
-input files reject unknown fields to prevent misspelled safeguards from being
-silently disabled.
+only runtime signals. When a case declares either value of
+`retrieval_required`, its observed `retrieval_hit` telemetry must be present;
+an omitted value is not treated as `false`. Tool-call arguments are JSON
+values, so numbers, arrays, and nested objects round-trip without being coerced
+to strings. All four JSON input files reject unknown fields to prevent
+misspelled safeguards from being silently disabled.
 
 The sample deliberately covers three outcomes. `focused` improves both sets and
 is accepted. `ineffective` changes wording without improving validation and is

--- a/examples/evaluation/promptiter_regression_loop/data/baseline_prompt.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/baseline_prompt.txt
@@ -1,0 +1,1 @@
+Answer customer questions. You may use tools.

--- a/examples/evaluation/promptiter_regression_loop/data/candidate_focused.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/candidate_focused.txt
@@ -1,0 +1,1 @@
+Route order and refund requests to the matching tool. Preserve the user's order ID exactly, ground the answer in the tool result, and return concise JSON with status and next_action fields. Answer policy questions directly without a tool.

--- a/examples/evaluation/promptiter_regression_loop/data/candidate_ineffective.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/candidate_ineffective.txt
@@ -1,0 +1,1 @@
+Be friendly, accurate, and concise when helping customers.

--- a/examples/evaluation/promptiter_regression_loop/data/candidate_overfit.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/candidate_overfit.txt
@@ -1,0 +1,1 @@
+For the three training examples, always call order_lookup with the memorized training order IDs and emit their expected wording verbatim.

--- a/examples/evaluation/promptiter_regression_loop/data/metrics.json
+++ b/examples/evaluation/promptiter_regression_loop/data/metrics.json
@@ -1,0 +1,6 @@
+{
+  "pass_threshold": 0.75,
+  "response_weight": 0.5,
+  "tool_weight": 0.3,
+  "format_weight": 0.2
+}

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter.json
@@ -1,0 +1,16 @@
+{
+  "seed": 2003,
+  "engine": {"type": "fake_trace", "model": "deterministic-v1"},
+  "gate": {
+    "min_validation_gain": 0.08,
+    "no_new_hard_fails": true,
+    "critical_case_ids": ["validation-refund"],
+    "max_cost_increase": 0.20,
+    "max_tool_calls": 3
+  },
+  "candidates": [
+    {"id": "focused", "prompt_file": "candidate_focused.txt"},
+    {"id": "ineffective", "prompt_file": "candidate_ineffective.txt"},
+    {"id": "overfit", "prompt_file": "candidate_overfit.txt"}
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/data/train.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/train.evalset.json
@@ -1,0 +1,32 @@
+{
+  "eval_set_id": "support-train",
+  "cases": [
+    {
+      "id": "train-order-status", "input": "Where is order A100?", "expected_response": "A100 shipped tomorrow", "expected_tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "A100"}}], "expected_route": "orders", "retrieval_required": true,
+      "runs": {
+        "baseline": {"final_response": "I cannot find it", "tool_calls": [{"name": "search", "arguments": {"q": "A100"}}], "route": "general", "format_valid": false, "retrieval_hit": false, "cost": 0.10, "latency_ms": 20},
+        "focused": {"final_response": "A100 shipped tomorrow", "tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "A100"}}], "route": "orders", "format_valid": true, "retrieval_hit": true, "cost": 0.11, "latency_ms": 18},
+        "ineffective": {"final_response": "I cannot find it", "tool_calls": [{"name": "search", "arguments": {"q": "A100"}}], "route": "general", "format_valid": false, "retrieval_hit": false, "cost": 0.10, "latency_ms": 20},
+        "overfit": {"final_response": "A100 shipped tomorrow", "tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "A100"}}], "route": "orders", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 16}
+      }
+    },
+    {
+      "id": "train-refund", "input": "Refund order B200", "expected_response": "B200 refund eligible", "expected_tool_calls": [{"name": "refund_check", "arguments": {"order_id": "B200"}}], "expected_route": "refunds", "retrieval_required": true, "critical": true,
+      "runs": {
+        "baseline": {"final_response": "B200 refund unknown", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "B-200"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 22},
+        "focused": {"final_response": "B200 refund eligible", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "B200"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.11, "latency_ms": 17},
+        "ineffective": {"final_response": "B200 refund unknown", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "B-200"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 22},
+        "overfit": {"final_response": "B200 refund eligible", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "B200"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 15}
+      }
+    },
+    {
+      "id": "train-policy", "input": "What is the return window?", "expected_response": "returns allowed 30 days", "retrieval_required": true,
+      "runs": {
+        "baseline": {"final_response": "returns allowed 30 days", "format_valid": false, "retrieval_hit": true, "cost": 0.05, "latency_ms": 10},
+        "focused": {"final_response": "returns allowed 30 days", "format_valid": true, "retrieval_hit": true, "cost": 0.05, "latency_ms": 9},
+        "ineffective": {"final_response": "returns allowed 30 days", "format_valid": false, "retrieval_hit": true, "cost": 0.05, "latency_ms": 10},
+        "overfit": {"final_response": "returns allowed 30 days", "format_valid": true, "retrieval_hit": true, "cost": 0.05, "latency_ms": 9}
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/data/validation.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/validation.evalset.json
@@ -1,0 +1,32 @@
+{
+  "eval_set_id": "support-validation",
+  "cases": [
+    {
+      "id": "validation-order", "input": "Track order C300", "expected_response": "C300 arriving Friday", "expected_tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "C300"}}], "expected_route": "orders", "retrieval_required": true,
+      "runs": {
+        "baseline": {"final_response": "C300 unknown", "tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "C-300"}}], "route": "orders", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 21},
+        "focused": {"final_response": "C300 arriving Friday", "tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "C300"}}], "route": "orders", "format_valid": true, "retrieval_hit": true, "cost": 0.11, "latency_ms": 18},
+        "ineffective": {"final_response": "C300 unknown", "tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "C-300"}}], "route": "orders", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 21},
+        "overfit": {"final_response": "A100 shipped tomorrow", "tool_calls": [{"name": "order_lookup", "arguments": {"order_id": "A100"}}], "route": "orders", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 16}
+      }
+    },
+    {
+      "id": "validation-refund", "input": "Can D400 be refunded?", "expected_response": "D400 refund denied final sale", "expected_tool_calls": [{"name": "refund_check", "arguments": {"order_id": "D400"}}], "expected_route": "refunds", "retrieval_required": true, "critical": true,
+      "runs": {
+        "baseline": {"final_response": "D400 refund denied final sale", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "D400"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 20},
+        "focused": {"final_response": "D400 refund denied final sale", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "D400"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.11, "latency_ms": 17},
+        "ineffective": {"final_response": "D400 refund denied final sale", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "D400"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 20},
+        "overfit": {"final_response": "B200 refund eligible", "tool_calls": [{"name": "refund_check", "arguments": {"order_id": "B200"}}], "route": "refunds", "format_valid": true, "retrieval_hit": true, "cost": 0.10, "latency_ms": 15}
+      }
+    },
+    {
+      "id": "validation-policy", "input": "Do sale items follow the return window?", "expected_response": "final sale items not returnable", "retrieval_required": true,
+      "runs": {
+        "baseline": {"final_response": "I do not know", "format_valid": true, "retrieval_hit": false, "cost": 0.05, "latency_ms": 10},
+        "focused": {"final_response": "final sale items not returnable", "format_valid": true, "retrieval_hit": true, "cost": 0.05, "latency_ms": 9},
+        "ineffective": {"final_response": "I do not know", "format_valid": true, "retrieval_hit": false, "cost": 0.05, "latency_ms": 10},
+        "overfit": {"final_response": "returns allowed 30 days", "format_valid": true, "retrieval_hit": false, "cost": 0.05, "latency_ms": 9}
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/main.go
+++ b/examples/evaluation/promptiter_regression_loop/main.go
@@ -1,0 +1,46 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	dataDir := flag.String("data-dir", "data", "directory containing evalsets, metrics, prompts, and promptiter config")
+	outputDir := flag.String("output-dir", ".", "report output directory")
+	timeout := flag.Duration("timeout", 3*time.Minute, "pipeline timeout")
+	flag.Parse()
+	pipeline, err := LoadPipeline(*dataDir)
+	if err != nil {
+		fail(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	report, err := pipeline.Run(ctx)
+	if err != nil {
+		fail(err)
+	}
+	if err := WriteReports(report, *outputDir); err != nil {
+		fail(err)
+	}
+	selectedScore := report.BaselineValidation.OverallScore
+	for _, round := range report.Rounds {
+		if round.CandidateID == report.SelectedCandidate {
+			selectedScore = round.Validation.OverallScore
+		}
+	}
+	fmt.Printf("optimization complete: accepted=%t candidate=%s validation=%.3f duration=%dms\n", report.Accepted, report.SelectedCandidate, selectedScore, report.DurationMS)
+}
+
+func fail(err error) { fmt.Fprintln(os.Stderr, "error:", err); os.Exit(1) }

--- a/examples/evaluation/promptiter_regression_loop/optimization_report.json.example
+++ b/examples/evaluation/promptiter_regression_loop/optimization_report.json.example
@@ -1,0 +1,917 @@
+{
+  "started_at": "2026-07-22T00:06:13.4291642+08:00",
+  "duration_ms": 0,
+  "seed": 2003,
+  "engine": {
+    "type": "fake_trace",
+    "model": "deterministic-v1"
+  },
+  "metrics": {
+    "pass_threshold": 0.75,
+    "response_weight": 0.5,
+    "tool_weight": 0.3,
+    "format_weight": 0.2
+  },
+  "gate": {
+    "min_validation_gain": 0.08,
+    "no_new_hard_fails": true,
+    "critical_case_ids": [
+      "validation-refund"
+    ],
+    "max_cost_increase": 0.2,
+    "max_tool_calls": 3
+  },
+  "baseline_prompt": "Answer customer questions. You may use tools.",
+  "baseline_train": {
+    "eval_set_id": "support-train",
+    "prompt_id": "baseline",
+    "overall_score": 0.494,
+    "passed": 0,
+    "failed": 3,
+    "total_cost": 0.25,
+    "tool_calls": 2,
+    "latency_ms": 52,
+    "cases": [
+      {
+        "case_id": "train-order-status",
+        "critical": false,
+        "score": 0,
+        "passed": false,
+        "attribution": "route_error",
+        "reason": "route \"general\", expected \"orders\"",
+        "final_response": "I cannot find it",
+        "tool_calls": [
+          {
+            "name": "search",
+            "arguments": {
+              "q": "A100"
+            }
+          }
+        ],
+        "trace": {
+          "final_response": "I cannot find it",
+          "tool_calls": [
+            {
+              "name": "search",
+              "arguments": {
+                "q": "A100"
+              }
+            }
+          ],
+          "route": "general",
+          "format_valid": false,
+          "retrieval_hit": false,
+          "cost": 0.1,
+          "latency_ms": 20
+        }
+      },
+      {
+        "case_id": "train-refund",
+        "critical": true,
+        "score": 0.683,
+        "passed": false,
+        "attribution": "tool_argument_error",
+        "reason": "tool arguments do not match the expected trajectory",
+        "final_response": "B200 refund unknown",
+        "tool_calls": [
+          {
+            "name": "refund_check",
+            "arguments": {
+              "order_id": "B-200"
+            }
+          }
+        ],
+        "trace": {
+          "final_response": "B200 refund unknown",
+          "tool_calls": [
+            {
+              "name": "refund_check",
+              "arguments": {
+                "order_id": "B-200"
+              }
+            }
+          ],
+          "route": "refunds",
+          "format_valid": true,
+          "retrieval_hit": true,
+          "cost": 0.1,
+          "latency_ms": 22
+        }
+      },
+      {
+        "case_id": "train-policy",
+        "critical": false,
+        "score": 0.8,
+        "passed": false,
+        "attribution": "format_error",
+        "reason": "final response violates the required structured format",
+        "final_response": "returns allowed 30 days",
+        "trace": {
+          "final_response": "returns allowed 30 days",
+          "format_valid": false,
+          "retrieval_hit": true,
+          "cost": 0.05,
+          "latency_ms": 10
+        }
+      }
+    ]
+  },
+  "baseline_validation": {
+    "eval_set_id": "support-validation",
+    "prompt_id": "baseline",
+    "overall_score": 0.706,
+    "passed": 1,
+    "failed": 2,
+    "total_cost": 0.25,
+    "tool_calls": 2,
+    "latency_ms": 51,
+    "cases": [
+      {
+        "case_id": "validation-order",
+        "critical": false,
+        "score": 0.517,
+        "passed": false,
+        "attribution": "tool_argument_error",
+        "reason": "tool arguments do not match the expected trajectory",
+        "final_response": "C300 unknown",
+        "tool_calls": [
+          {
+            "name": "order_lookup",
+            "arguments": {
+              "order_id": "C-300"
+            }
+          }
+        ],
+        "trace": {
+          "final_response": "C300 unknown",
+          "tool_calls": [
+            {
+              "name": "order_lookup",
+              "arguments": {
+                "order_id": "C-300"
+              }
+            }
+          ],
+          "route": "orders",
+          "format_valid": true,
+          "retrieval_hit": true,
+          "cost": 0.1,
+          "latency_ms": 21
+        }
+      },
+      {
+        "case_id": "validation-refund",
+        "critical": true,
+        "score": 1,
+        "passed": true,
+        "final_response": "D400 refund denied final sale",
+        "tool_calls": [
+          {
+            "name": "refund_check",
+            "arguments": {
+              "order_id": "D400"
+            }
+          }
+        ],
+        "trace": {
+          "final_response": "D400 refund denied final sale",
+          "tool_calls": [
+            {
+              "name": "refund_check",
+              "arguments": {
+                "order_id": "D400"
+              }
+            }
+          ],
+          "route": "refunds",
+          "format_valid": true,
+          "retrieval_hit": true,
+          "cost": 0.1,
+          "latency_ms": 20
+        }
+      },
+      {
+        "case_id": "validation-policy",
+        "critical": false,
+        "score": 0.6,
+        "passed": false,
+        "attribution": "knowledge_retrieval_insufficient",
+        "reason": "retrieval hit false, expected true",
+        "final_response": "I do not know",
+        "trace": {
+          "final_response": "I do not know",
+          "format_valid": true,
+          "retrieval_hit": false,
+          "cost": 0.05,
+          "latency_ms": 10
+        }
+      }
+    ]
+  },
+  "attribution_counts": {
+    "format_error": 1,
+    "knowledge_retrieval_insufficient": 1,
+    "route_error": 1,
+    "tool_argument_error": 2
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "candidate_id": "focused",
+      "prompt": "Route order and refund requests to the matching tool. Preserve the user's order ID exactly, ground the answer in the tool result, and return concise JSON with status and next_action fields. Answer policy questions directly without a tool.",
+      "train": {
+        "eval_set_id": "support-train",
+        "prompt_id": "focused",
+        "overall_score": 1,
+        "passed": 3,
+        "failed": 0,
+        "total_cost": 0.27,
+        "tool_calls": 2,
+        "latency_ms": 44,
+        "cases": [
+          {
+            "case_id": "train-order-status",
+            "critical": false,
+            "score": 1,
+            "passed": true,
+            "final_response": "A100 shipped tomorrow",
+            "tool_calls": [
+              {
+                "name": "order_lookup",
+                "arguments": {
+                  "order_id": "A100"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "A100 shipped tomorrow",
+              "tool_calls": [
+                {
+                  "name": "order_lookup",
+                  "arguments": {
+                    "order_id": "A100"
+                  }
+                }
+              ],
+              "route": "orders",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.11,
+              "latency_ms": 18
+            }
+          },
+          {
+            "case_id": "train-refund",
+            "critical": true,
+            "score": 1,
+            "passed": true,
+            "final_response": "B200 refund eligible",
+            "tool_calls": [
+              {
+                "name": "refund_check",
+                "arguments": {
+                  "order_id": "B200"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "B200 refund eligible",
+              "tool_calls": [
+                {
+                  "name": "refund_check",
+                  "arguments": {
+                    "order_id": "B200"
+                  }
+                }
+              ],
+              "route": "refunds",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.11,
+              "latency_ms": 17
+            }
+          },
+          {
+            "case_id": "train-policy",
+            "critical": false,
+            "score": 1,
+            "passed": true,
+            "final_response": "returns allowed 30 days",
+            "trace": {
+              "final_response": "returns allowed 30 days",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.05,
+              "latency_ms": 9
+            }
+          }
+        ]
+      },
+      "validation": {
+        "eval_set_id": "support-validation",
+        "prompt_id": "focused",
+        "overall_score": 1,
+        "passed": 3,
+        "failed": 0,
+        "total_cost": 0.27,
+        "tool_calls": 2,
+        "latency_ms": 44,
+        "cases": [
+          {
+            "case_id": "validation-order",
+            "critical": false,
+            "score": 1,
+            "passed": true,
+            "final_response": "C300 arriving Friday",
+            "tool_calls": [
+              {
+                "name": "order_lookup",
+                "arguments": {
+                  "order_id": "C300"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "C300 arriving Friday",
+              "tool_calls": [
+                {
+                  "name": "order_lookup",
+                  "arguments": {
+                    "order_id": "C300"
+                  }
+                }
+              ],
+              "route": "orders",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.11,
+              "latency_ms": 18
+            }
+          },
+          {
+            "case_id": "validation-refund",
+            "critical": true,
+            "score": 1,
+            "passed": true,
+            "final_response": "D400 refund denied final sale",
+            "tool_calls": [
+              {
+                "name": "refund_check",
+                "arguments": {
+                  "order_id": "D400"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "D400 refund denied final sale",
+              "tool_calls": [
+                {
+                  "name": "refund_check",
+                  "arguments": {
+                    "order_id": "D400"
+                  }
+                }
+              ],
+              "route": "refunds",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.11,
+              "latency_ms": 17
+            }
+          },
+          {
+            "case_id": "validation-policy",
+            "critical": false,
+            "score": 1,
+            "passed": true,
+            "final_response": "final sale items not returnable",
+            "trace": {
+              "final_response": "final sale items not returnable",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.05,
+              "latency_ms": 9
+            }
+          }
+        ]
+      },
+      "delta": {
+        "score_delta": 0.294,
+        "newly_passed": 2,
+        "newly_failed": 0,
+        "improved": 2,
+        "regressed": 0,
+        "cases": [
+          {
+            "case_id": "validation-order",
+            "baseline_score": 0.517,
+            "candidate_score": 1,
+            "score_delta": 0.483,
+            "newly_passed": true,
+            "newly_failed": false,
+            "critical": false
+          },
+          {
+            "case_id": "validation-policy",
+            "baseline_score": 0.6,
+            "candidate_score": 1,
+            "score_delta": 0.4,
+            "newly_passed": true,
+            "newly_failed": false,
+            "critical": false
+          },
+          {
+            "case_id": "validation-refund",
+            "baseline_score": 1,
+            "candidate_score": 1,
+            "score_delta": 0,
+            "newly_passed": false,
+            "newly_failed": false,
+            "critical": true
+          }
+        ]
+      },
+      "gate": {
+        "accepted": true,
+        "reasons": [
+          "accepted: validation score improved by 0.294 with no protected regression"
+        ]
+      },
+      "duration_ms": 0
+    },
+    {
+      "round": 2,
+      "candidate_id": "ineffective",
+      "prompt": "Be friendly, accurate, and concise when helping customers.",
+      "train": {
+        "eval_set_id": "support-train",
+        "prompt_id": "ineffective",
+        "overall_score": 0.494,
+        "passed": 0,
+        "failed": 3,
+        "total_cost": 0.25,
+        "tool_calls": 2,
+        "latency_ms": 52,
+        "cases": [
+          {
+            "case_id": "train-order-status",
+            "critical": false,
+            "score": 0,
+            "passed": false,
+            "attribution": "route_error",
+            "reason": "route \"general\", expected \"orders\"",
+            "final_response": "I cannot find it",
+            "tool_calls": [
+              {
+                "name": "search",
+                "arguments": {
+                  "q": "A100"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "I cannot find it",
+              "tool_calls": [
+                {
+                  "name": "search",
+                  "arguments": {
+                    "q": "A100"
+                  }
+                }
+              ],
+              "route": "general",
+              "format_valid": false,
+              "retrieval_hit": false,
+              "cost": 0.1,
+              "latency_ms": 20
+            }
+          },
+          {
+            "case_id": "train-refund",
+            "critical": true,
+            "score": 0.683,
+            "passed": false,
+            "attribution": "tool_argument_error",
+            "reason": "tool arguments do not match the expected trajectory",
+            "final_response": "B200 refund unknown",
+            "tool_calls": [
+              {
+                "name": "refund_check",
+                "arguments": {
+                  "order_id": "B-200"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "B200 refund unknown",
+              "tool_calls": [
+                {
+                  "name": "refund_check",
+                  "arguments": {
+                    "order_id": "B-200"
+                  }
+                }
+              ],
+              "route": "refunds",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 22
+            }
+          },
+          {
+            "case_id": "train-policy",
+            "critical": false,
+            "score": 0.8,
+            "passed": false,
+            "attribution": "format_error",
+            "reason": "final response violates the required structured format",
+            "final_response": "returns allowed 30 days",
+            "trace": {
+              "final_response": "returns allowed 30 days",
+              "format_valid": false,
+              "retrieval_hit": true,
+              "cost": 0.05,
+              "latency_ms": 10
+            }
+          }
+        ]
+      },
+      "validation": {
+        "eval_set_id": "support-validation",
+        "prompt_id": "ineffective",
+        "overall_score": 0.706,
+        "passed": 1,
+        "failed": 2,
+        "total_cost": 0.25,
+        "tool_calls": 2,
+        "latency_ms": 51,
+        "cases": [
+          {
+            "case_id": "validation-order",
+            "critical": false,
+            "score": 0.517,
+            "passed": false,
+            "attribution": "tool_argument_error",
+            "reason": "tool arguments do not match the expected trajectory",
+            "final_response": "C300 unknown",
+            "tool_calls": [
+              {
+                "name": "order_lookup",
+                "arguments": {
+                  "order_id": "C-300"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "C300 unknown",
+              "tool_calls": [
+                {
+                  "name": "order_lookup",
+                  "arguments": {
+                    "order_id": "C-300"
+                  }
+                }
+              ],
+              "route": "orders",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 21
+            }
+          },
+          {
+            "case_id": "validation-refund",
+            "critical": true,
+            "score": 1,
+            "passed": true,
+            "final_response": "D400 refund denied final sale",
+            "tool_calls": [
+              {
+                "name": "refund_check",
+                "arguments": {
+                  "order_id": "D400"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "D400 refund denied final sale",
+              "tool_calls": [
+                {
+                  "name": "refund_check",
+                  "arguments": {
+                    "order_id": "D400"
+                  }
+                }
+              ],
+              "route": "refunds",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 20
+            }
+          },
+          {
+            "case_id": "validation-policy",
+            "critical": false,
+            "score": 0.6,
+            "passed": false,
+            "attribution": "knowledge_retrieval_insufficient",
+            "reason": "retrieval hit false, expected true",
+            "final_response": "I do not know",
+            "trace": {
+              "final_response": "I do not know",
+              "format_valid": true,
+              "retrieval_hit": false,
+              "cost": 0.05,
+              "latency_ms": 10
+            }
+          }
+        ]
+      },
+      "delta": {
+        "score_delta": 0,
+        "newly_passed": 0,
+        "newly_failed": 0,
+        "improved": 0,
+        "regressed": 0,
+        "cases": [
+          {
+            "case_id": "validation-order",
+            "baseline_score": 0.517,
+            "candidate_score": 0.517,
+            "score_delta": 0,
+            "newly_passed": false,
+            "newly_failed": false,
+            "critical": false
+          },
+          {
+            "case_id": "validation-policy",
+            "baseline_score": 0.6,
+            "candidate_score": 0.6,
+            "score_delta": 0,
+            "newly_passed": false,
+            "newly_failed": false,
+            "critical": false
+          },
+          {
+            "case_id": "validation-refund",
+            "baseline_score": 1,
+            "candidate_score": 1,
+            "score_delta": 0,
+            "newly_passed": false,
+            "newly_failed": false,
+            "critical": true
+          }
+        ]
+      },
+      "gate": {
+        "accepted": false,
+        "reasons": [
+          "validation gain 0.000 must be greater than 0.080"
+        ]
+      },
+      "duration_ms": 0
+    },
+    {
+      "round": 3,
+      "candidate_id": "overfit",
+      "prompt": "For the three training examples, always call order_lookup with the memorized training order IDs and emit their expected wording verbatim.",
+      "train": {
+        "eval_set_id": "support-train",
+        "prompt_id": "overfit",
+        "overall_score": 1,
+        "passed": 3,
+        "failed": 0,
+        "total_cost": 0.25,
+        "tool_calls": 2,
+        "latency_ms": 40,
+        "cases": [
+          {
+            "case_id": "train-order-status",
+            "critical": false,
+            "score": 1,
+            "passed": true,
+            "final_response": "A100 shipped tomorrow",
+            "tool_calls": [
+              {
+                "name": "order_lookup",
+                "arguments": {
+                  "order_id": "A100"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "A100 shipped tomorrow",
+              "tool_calls": [
+                {
+                  "name": "order_lookup",
+                  "arguments": {
+                    "order_id": "A100"
+                  }
+                }
+              ],
+              "route": "orders",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 16
+            }
+          },
+          {
+            "case_id": "train-refund",
+            "critical": true,
+            "score": 1,
+            "passed": true,
+            "final_response": "B200 refund eligible",
+            "tool_calls": [
+              {
+                "name": "refund_check",
+                "arguments": {
+                  "order_id": "B200"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "B200 refund eligible",
+              "tool_calls": [
+                {
+                  "name": "refund_check",
+                  "arguments": {
+                    "order_id": "B200"
+                  }
+                }
+              ],
+              "route": "refunds",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 15
+            }
+          },
+          {
+            "case_id": "train-policy",
+            "critical": false,
+            "score": 1,
+            "passed": true,
+            "final_response": "returns allowed 30 days",
+            "trace": {
+              "final_response": "returns allowed 30 days",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.05,
+              "latency_ms": 9
+            }
+          }
+        ]
+      },
+      "validation": {
+        "eval_set_id": "support-validation",
+        "prompt_id": "overfit",
+        "overall_score": 0.433,
+        "passed": 0,
+        "failed": 3,
+        "total_cost": 0.25,
+        "tool_calls": 2,
+        "latency_ms": 40,
+        "cases": [
+          {
+            "case_id": "validation-order",
+            "critical": false,
+            "score": 0.35,
+            "passed": false,
+            "attribution": "tool_argument_error",
+            "reason": "tool arguments do not match the expected trajectory",
+            "final_response": "A100 shipped tomorrow",
+            "tool_calls": [
+              {
+                "name": "order_lookup",
+                "arguments": {
+                  "order_id": "A100"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "A100 shipped tomorrow",
+              "tool_calls": [
+                {
+                  "name": "order_lookup",
+                  "arguments": {
+                    "order_id": "A100"
+                  }
+                }
+              ],
+              "route": "orders",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 16
+            }
+          },
+          {
+            "case_id": "validation-refund",
+            "critical": true,
+            "score": 0.45,
+            "passed": false,
+            "attribution": "tool_argument_error",
+            "reason": "tool arguments do not match the expected trajectory",
+            "final_response": "B200 refund eligible",
+            "tool_calls": [
+              {
+                "name": "refund_check",
+                "arguments": {
+                  "order_id": "B200"
+                }
+              }
+            ],
+            "trace": {
+              "final_response": "B200 refund eligible",
+              "tool_calls": [
+                {
+                  "name": "refund_check",
+                  "arguments": {
+                    "order_id": "B200"
+                  }
+                }
+              ],
+              "route": "refunds",
+              "format_valid": true,
+              "retrieval_hit": true,
+              "cost": 0.1,
+              "latency_ms": 15
+            }
+          },
+          {
+            "case_id": "validation-policy",
+            "critical": false,
+            "score": 0.5,
+            "passed": false,
+            "attribution": "knowledge_retrieval_insufficient",
+            "reason": "retrieval hit false, expected true",
+            "final_response": "returns allowed 30 days",
+            "trace": {
+              "final_response": "returns allowed 30 days",
+              "format_valid": true,
+              "retrieval_hit": false,
+              "cost": 0.05,
+              "latency_ms": 9
+            }
+          }
+        ]
+      },
+      "delta": {
+        "score_delta": -0.273,
+        "newly_passed": 0,
+        "newly_failed": 1,
+        "improved": 0,
+        "regressed": 3,
+        "cases": [
+          {
+            "case_id": "validation-order",
+            "baseline_score": 0.517,
+            "candidate_score": 0.35,
+            "score_delta": -0.167,
+            "newly_passed": false,
+            "newly_failed": false,
+            "critical": false
+          },
+          {
+            "case_id": "validation-policy",
+            "baseline_score": 0.6,
+            "candidate_score": 0.5,
+            "score_delta": -0.1,
+            "newly_passed": false,
+            "newly_failed": false,
+            "critical": false
+          },
+          {
+            "case_id": "validation-refund",
+            "baseline_score": 1,
+            "candidate_score": 0.45,
+            "score_delta": -0.55,
+            "newly_passed": false,
+            "newly_failed": true,
+            "critical": true
+          }
+        ]
+      },
+      "gate": {
+        "accepted": false,
+        "reasons": [
+          "validation gain -0.273 must be greater than 0.080",
+          "new hard fail: validation-refund",
+          "critical case newly failed: validation-refund",
+          "critical case regressed: validation-refund",
+          "critical case did not pass: validation-refund"
+        ]
+      },
+      "duration_ms": 0
+    }
+  ],
+  "selected_candidate": "focused",
+  "selected_prompt": "Route order and refund requests to the matching tool. Preserve the user's order ID exactly, ground the answer in the tool result, and return concise JSON with status and next_action fields. Answer policy questions directly without a tool.",
+  "accepted": true,
+  "decision_reasons": [
+    "accepted: validation score improved by 0.294 with no protected regression"
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/optimization_report.json.example
+++ b/examples/evaluation/promptiter_regression_loop/optimization_report.json.example
@@ -668,7 +668,7 @@
       "gate": {
         "accepted": false,
         "reasons": [
-          "validation gain 0.000 must be greater than 0.080"
+          "validation gain 0.000 must be positive and reach 0.080"
         ]
       },
       "duration_ms": 0
@@ -898,7 +898,7 @@
       "gate": {
         "accepted": false,
         "reasons": [
-          "validation gain -0.273 must be greater than 0.080",
+          "validation gain -0.273 must be positive and reach 0.080",
           "new hard fail: validation-refund",
           "critical case newly failed: validation-refund",
           "critical case regressed: validation-refund",

--- a/examples/evaluation/promptiter_regression_loop/optimization_report.md.example
+++ b/examples/evaluation/promptiter_regression_loop/optimization_report.md.example
@@ -1,0 +1,81 @@
+# Prompt Optimization Regression Report
+
+- **Decision:** ACCEPT
+- **Selected candidate:** focused
+- **Baseline train score:** 0.494
+- **Baseline validation score:** 0.706
+- **Runtime:** 0 ms
+- **Seed:** 2003
+- **Engine:** fake_trace (deterministic-v1)
+
+## Reproducibility configuration
+
+- Pass threshold: 0.750
+- Metric weights (response / tool / format): 0.500 / 0.300 / 0.200
+- Minimum validation gain: 0.080
+- No new hard fails: true
+- Critical cases: validation-refund
+- Maximum cost increase: 0.200
+- Maximum tool calls: 3
+
+## Failure attribution
+
+| Category | Count |
+|---|---:|
+| format_error | 1 |
+| knowledge_retrieval_insufficient | 1 |
+| route_error | 1 |
+| tool_argument_error | 2 |
+
+## Candidate rounds
+
+### Round 1: focused
+
+- Train score: 1.000
+- Validation score: 1.000
+- Validation delta: +0.294
+- Newly passed / failed: 2 / 0
+- Gate: ACCEPT — accepted: validation score improved by 0.294 with no protected regression
+- Cost: 0.270; tool calls: 2; latency: 44 ms
+
+| Case | Baseline | Candidate | Delta | Change |
+|---|---:|---:|---:|---|
+| validation-order | 0.517 | 1.000 | +0.483 | new pass |
+| validation-policy | 0.600 | 1.000 | +0.400 | new pass |
+| validation-refund | 1.000 | 1.000 | +0.000 | unchanged |
+
+### Round 2: ineffective
+
+- Train score: 0.494
+- Validation score: 0.706
+- Validation delta: +0.000
+- Newly passed / failed: 0 / 0
+- Gate: REJECT — validation gain 0.000 must be greater than 0.080
+- Cost: 0.250; tool calls: 2; latency: 51 ms
+
+| Case | Baseline | Candidate | Delta | Change |
+|---|---:|---:|---:|---|
+| validation-order | 0.517 | 0.517 | +0.000 | unchanged |
+| validation-policy | 0.600 | 0.600 | +0.000 | unchanged |
+| validation-refund | 1.000 | 1.000 | +0.000 | unchanged |
+
+### Round 3: overfit
+
+- Train score: 1.000
+- Validation score: 0.433
+- Validation delta: -0.273
+- Newly passed / failed: 0 / 1
+- Gate: REJECT — validation gain -0.273 must be greater than 0.080; new hard fail: validation-refund; critical case newly failed: validation-refund; critical case regressed: validation-refund; critical case did not pass: validation-refund
+- Cost: 0.250; tool calls: 2; latency: 40 ms
+
+| Case | Baseline | Candidate | Delta | Change |
+|---|---:|---:|---:|---|
+| validation-order | 0.517 | 0.350 | -0.167 | unchanged |
+| validation-policy | 0.600 | 0.500 | -0.100 | unchanged |
+| validation-refund | 1.000 | 0.450 | -0.550 | new fail |
+
+## Final decision
+
+- accepted: validation score improved by 0.294 with no protected regression
+
+The candidate generalizes on the held-out validation set and is safe to consider for source-prompt write-back after human review.

--- a/examples/evaluation/promptiter_regression_loop/optimization_report.md.example
+++ b/examples/evaluation/promptiter_regression_loop/optimization_report.md.example
@@ -50,7 +50,7 @@
 - Validation score: 0.706
 - Validation delta: +0.000
 - Newly passed / failed: 0 / 0
-- Gate: REJECT — validation gain 0.000 must be greater than 0.080
+- Gate: REJECT — validation gain 0.000 must be positive and reach 0.080
 - Cost: 0.250; tool calls: 2; latency: 51 ms
 
 | Case | Baseline | Candidate | Delta | Change |
@@ -65,7 +65,7 @@
 - Validation score: 0.433
 - Validation delta: -0.273
 - Newly passed / failed: 0 / 1
-- Gate: REJECT — validation gain -0.273 must be greater than 0.080; new hard fail: validation-refund; critical case newly failed: validation-refund; critical case regressed: validation-refund; critical case did not pass: validation-refund
+- Gate: REJECT — validation gain -0.273 must be positive and reach 0.080; new hard fail: validation-refund; critical case newly failed: validation-refund; critical case regressed: validation-refund; critical case did not pass: validation-refund
 - Cost: 0.250; tool calls: 2; latency: 40 ms
 
 | Case | Baseline | Candidate | Delta | Change |

--- a/examples/evaluation/promptiter_regression_loop/pipeline.go
+++ b/examples/evaluation/promptiter_regression_loop/pipeline.go
@@ -1,0 +1,626 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Pipeline struct {
+	Dir     string
+	Metrics MetricsConfig
+	Config  LoopConfig
+	Train   EvalSet
+	Valid   EvalSet
+}
+
+func LoadPipeline(dir string) (*Pipeline, error) {
+	p := &Pipeline{Dir: dir}
+	for _, item := range []struct {
+		name   string
+		target any
+	}{
+		{"train.evalset.json", &p.Train}, {"validation.evalset.json", &p.Valid},
+		{"metrics.json", &p.Metrics}, {"promptiter.json", &p.Config},
+	} {
+		if err := decodeJSONFile(filepath.Join(dir, item.name), item.target); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", item.name, err)
+		}
+	}
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *Pipeline) validate() error {
+	if p.Config.Engine.Type != "fake_trace" {
+		return fmt.Errorf("unsupported deterministic engine %q", p.Config.Engine.Type)
+	}
+	if len(p.Train.Cases) < 3 || len(p.Valid.Cases) < 3 {
+		return errors.New("train and validation sets need at least three cases each")
+	}
+	if err := validateMetrics(p.Metrics); err != nil {
+		return err
+	}
+	if err := validateGate(p.Config.Gate); err != nil {
+		return err
+	}
+
+	promptIDs := []string{"baseline"}
+	candidateIDs := map[string]bool{"baseline": true}
+	for i, candidate := range p.Config.Candidates {
+		if strings.TrimSpace(candidate.ID) == "" {
+			return fmt.Errorf("candidate %d has an empty ID", i+1)
+		}
+		if candidateIDs[candidate.ID] {
+			return fmt.Errorf("duplicate or reserved candidate ID %q", candidate.ID)
+		}
+		candidateIDs[candidate.ID] = true
+		promptIDs = append(promptIDs, candidate.ID)
+		if _, err := resolveDataFile(p.Dir, candidate.PromptFile); err != nil {
+			return fmt.Errorf("candidate %q prompt file: %w", candidate.ID, err)
+		}
+	}
+	if _, err := resolveDataFile(p.Dir, "baseline_prompt.txt"); err != nil {
+		return fmt.Errorf("baseline prompt file: %w", err)
+	}
+	if _, err := validateEvalSet("train", p.Train, promptIDs); err != nil {
+		return err
+	}
+	validIDs, err := validateEvalSet("validation", p.Valid, promptIDs)
+	if err != nil {
+		return err
+	}
+	protected := make(map[string]bool, len(p.Config.Gate.CriticalCaseIDs))
+	for _, id := range p.Config.Gate.CriticalCaseIDs {
+		if strings.TrimSpace(id) == "" {
+			return errors.New("critical case ID cannot be empty")
+		}
+		if protected[id] {
+			return fmt.Errorf("duplicate critical case ID %q", id)
+		}
+		protected[id] = true
+		if !validIDs[id] {
+			return fmt.Errorf("critical case ID %q is not in the validation set", id)
+		}
+	}
+	return nil
+}
+
+func validateMetrics(cfg MetricsConfig) error {
+	for _, field := range []struct {
+		name  string
+		value float64
+	}{
+		{"pass_threshold", cfg.PassThreshold},
+		{"response_weight", cfg.ResponseWeight},
+		{"tool_weight", cfg.ToolWeight},
+		{"format_weight", cfg.FormatWeight},
+	} {
+		if !finite(field.value) {
+			return fmt.Errorf("metrics %s must be finite", field.name)
+		}
+	}
+	if cfg.PassThreshold < 0 || cfg.PassThreshold > 1 {
+		return errors.New("metrics pass_threshold must be between 0 and 1")
+	}
+	if cfg.ResponseWeight < 0 || cfg.ToolWeight < 0 || cfg.FormatWeight < 0 {
+		return errors.New("metric weights cannot be negative")
+	}
+	totalWeight := cfg.ResponseWeight + cfg.ToolWeight + cfg.FormatWeight
+	if !finite(totalWeight) {
+		return errors.New("total metric weight must be finite")
+	}
+	if totalWeight <= 0 {
+		return errors.New("at least one metric weight must be positive")
+	}
+	return nil
+}
+
+func validateGate(cfg GateConfig) error {
+	if !finite(cfg.MinValidationGain) || cfg.MinValidationGain < 0 || cfg.MinValidationGain > 1 {
+		return errors.New("gate min_validation_gain must be finite and between 0 and 1")
+	}
+	if cfg.MaxCostIncrease != nil && (!finite(*cfg.MaxCostIncrease) || *cfg.MaxCostIncrease < 0) {
+		return errors.New("gate max_cost_increase must be finite and non-negative")
+	}
+	if cfg.MaxToolCalls != nil && *cfg.MaxToolCalls < 0 {
+		return errors.New("gate max_tool_calls must be non-negative")
+	}
+	return nil
+}
+
+func validateEvalSet(name string, set EvalSet, promptIDs []string) (map[string]bool, error) {
+	if strings.TrimSpace(set.ID) == "" {
+		return nil, fmt.Errorf("%s eval set has an empty ID", name)
+	}
+	caseIDs := make(map[string]bool, len(set.Cases))
+	for i, evalCase := range set.Cases {
+		if strings.TrimSpace(evalCase.ID) == "" {
+			return nil, fmt.Errorf("%s case %d has an empty ID", name, i+1)
+		}
+		if caseIDs[evalCase.ID] {
+			return nil, fmt.Errorf("%s eval set has duplicate case ID %q", name, evalCase.ID)
+		}
+		caseIDs[evalCase.ID] = true
+		for _, promptID := range promptIDs {
+			trace, ok := evalCase.Runs[promptID]
+			if !ok {
+				return nil, fmt.Errorf("%s case %q has no trace for prompt %q", name, evalCase.ID, promptID)
+			}
+			if !finite(trace.Cost) || trace.Cost < 0 {
+				return nil, fmt.Errorf("%s case %q prompt %q has invalid cost", name, evalCase.ID, promptID)
+			}
+			if trace.LatencyMS < 0 {
+				return nil, fmt.Errorf("%s case %q prompt %q has negative latency", name, evalCase.ID, promptID)
+			}
+		}
+	}
+	return caseIDs, nil
+}
+
+func finite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func resolveDataFile(root, name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", errors.New("path is empty")
+	}
+	if len(name) >= 2 && ((name[0] >= 'a' && name[0] <= 'z') ||
+		(name[0] >= 'A' && name[0] <= 'Z')) && name[1] == ':' {
+		return "", fmt.Errorf("path %q must be relative to the data directory", name)
+	}
+	name = filepath.FromSlash(strings.ReplaceAll(name, `\`, "/"))
+	if filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
+		return "", fmt.Errorf("path %q must be relative to the data directory", name)
+	}
+	resolvedRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve data directory: %w", err)
+	}
+	resolvedRoot, err = filepath.EvalSymlinks(resolvedRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve data directory links: %w", err)
+	}
+	candidate, err := filepath.Abs(filepath.Join(resolvedRoot, name))
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", name, err)
+	}
+	candidate, err = filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q links: %w", name, err)
+	}
+	relative, err := filepath.Rel(resolvedRoot, candidate)
+	if err != nil {
+		return "", fmt.Errorf("validate path %q: %w", name, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", fmt.Errorf("path %q escapes the data directory", name)
+	}
+	info, err := os.Stat(candidate)
+	if err != nil {
+		return "", fmt.Errorf("stat path %q: %w", name, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("path %q is not a regular file", name)
+	}
+	return candidate, nil
+}
+
+func (p *Pipeline) Run(ctx context.Context) (*OptimizationReport, error) {
+	if err := p.validate(); err != nil {
+		return nil, fmt.Errorf("validate pipeline: %w", err)
+	}
+	started := time.Now()
+	baselinePath, err := resolveDataFile(p.Dir, "baseline_prompt.txt")
+	if err != nil {
+		return nil, fmt.Errorf("resolve baseline prompt: %w", err)
+	}
+	baselinePrompt, err := readPrompt(baselinePath)
+	if err != nil {
+		return nil, err
+	}
+	report := &OptimizationReport{
+		StartedAt:      started,
+		Seed:           p.Config.Seed,
+		Engine:         p.Config.Engine,
+		Metrics:        p.Metrics,
+		Gate:           cloneGateConfig(p.Config.Gate),
+		BaselinePrompt: baselinePrompt,
+	}
+	report.BaselineTrain, err = p.Evaluate(ctx, p.Train, "baseline")
+	if err != nil {
+		return nil, err
+	}
+	report.BaselineValidation, err = p.Evaluate(ctx, p.Valid, "baseline")
+	if err != nil {
+		return nil, err
+	}
+	report.AttributionCounts = CountAttributions(report.BaselineTrain, report.BaselineValidation)
+
+	bestScore := report.BaselineValidation.OverallScore
+	for i, candidate := range p.Config.Candidates {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		roundStart := time.Now()
+		promptPath, err := resolveDataFile(p.Dir, candidate.PromptFile)
+		if err != nil {
+			return nil, fmt.Errorf("resolve candidate %q prompt: %w", candidate.ID, err)
+		}
+		prompt, err := readPrompt(promptPath)
+		if err != nil {
+			return nil, err
+		}
+		train, err := p.Evaluate(ctx, p.Train, candidate.ID)
+		if err != nil {
+			return nil, err
+		}
+		validation, err := p.Evaluate(ctx, p.Valid, candidate.ID)
+		if err != nil {
+			return nil, err
+		}
+		delta := CompareEvaluations(report.BaselineValidation, validation)
+		gate := ApplyGate(p.Config.Gate, report.BaselineValidation, validation, delta)
+		round := RoundAudit{Round: i + 1, CandidateID: candidate.ID, Prompt: prompt, Train: train, Validation: validation, Delta: delta, Gate: gate, DurationMS: time.Since(roundStart).Milliseconds()}
+		report.Rounds = append(report.Rounds, round)
+		if gate.Accepted && validation.OverallScore > bestScore {
+			bestScore, report.Accepted = validation.OverallScore, true
+			report.SelectedCandidate, report.SelectedPrompt = candidate.ID, prompt
+			report.DecisionReasons = append([]string(nil), gate.Reasons...)
+		}
+	}
+	if !report.Accepted {
+		report.DecisionReasons = []string{"no candidate passed the validation acceptance gate with a score improvement"}
+	}
+	report.DurationMS = time.Since(started).Milliseconds()
+	return report, nil
+}
+
+func (p *Pipeline) Evaluate(ctx context.Context, set EvalSet, promptID string) (EvaluationResult, error) {
+	result := EvaluationResult{EvalSetID: set.ID, PromptID: promptID}
+	if err := validateMetrics(p.Metrics); err != nil {
+		return result, err
+	}
+	for _, evalCase := range set.Cases {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+		trace, ok := evalCase.Runs[promptID]
+		if !ok {
+			return result, fmt.Errorf("case %s has no trace for prompt %s", evalCase.ID, promptID)
+		}
+		if !finite(trace.Cost) || trace.Cost < 0 {
+			return result, fmt.Errorf("case %s prompt %s has invalid cost", evalCase.ID, promptID)
+		}
+		if trace.LatencyMS < 0 {
+			return result, fmt.Errorf("case %s prompt %s has negative latency", evalCase.ID, promptID)
+		}
+		caseResult := ScoreCase(evalCase, trace, p.Metrics)
+		result.Cases = append(result.Cases, caseResult)
+		result.OverallScore += caseResult.Score
+		result.TotalCost += trace.Cost
+		if !finite(result.TotalCost) {
+			return result, fmt.Errorf("case %s prompt %s overflows total cost", evalCase.ID, promptID)
+		}
+		result.ToolCalls += len(trace.ToolCalls)
+		if trace.LatencyMS > math.MaxInt64-result.LatencyMS {
+			return result, fmt.Errorf("case %s prompt %s overflows total latency", evalCase.ID, promptID)
+		}
+		result.LatencyMS += trace.LatencyMS
+		if caseResult.Passed {
+			result.Passed++
+		} else {
+			result.Failed++
+		}
+	}
+	result.OverallScore = round(result.OverallScore / float64(len(result.Cases)))
+	result.TotalCost = round(result.TotalCost)
+	return result, nil
+}
+
+func ScoreCase(c EvalCase, trace RunTrace, metrics MetricsConfig) CaseResult {
+	response := similarity(c.ExpectedResponse, trace.FinalResponse)
+	toolScore := 0.0
+	if sameToolCalls(c.ExpectedToolCalls, trace.ToolCalls) {
+		toolScore = 1
+	} else if sameToolNames(c.ExpectedToolCalls, trace.ToolCalls) {
+		toolScore = 0.5
+	}
+	formatScore := 0.0
+	if trace.FormatValid {
+		formatScore = 1
+	}
+	weight := metrics.ResponseWeight + metrics.ToolWeight + metrics.FormatWeight
+	score := 0.0
+	if weight > 0 {
+		score = (response*metrics.ResponseWeight + toolScore*metrics.ToolWeight + formatScore*metrics.FormatWeight) / weight
+	}
+	contractsPassed := trace.Error == "" &&
+		trace.FormatValid &&
+		sameToolCalls(c.ExpectedToolCalls, trace.ToolCalls) &&
+		(c.ExpectedRoute == "" || trace.Route == c.ExpectedRoute) &&
+		(c.RetrievalRequired == nil || trace.RetrievalHit == *c.RetrievalRequired)
+	result := CaseResult{
+		CaseID:        c.ID,
+		Critical:      c.Critical,
+		Score:         round(score),
+		Passed:        contractsPassed && score >= metrics.PassThreshold,
+		FinalResponse: trace.FinalResponse,
+		ToolCalls:     trace.ToolCalls,
+		Trace:         trace,
+	}
+	if !result.Passed {
+		result.Attribution, result.Reason = AttributeFailure(c, trace, response)
+	}
+	return result
+}
+
+func AttributeFailure(c EvalCase, trace RunTrace, responseSimilarity float64) (Attribution, string) {
+	switch {
+	case trace.Error != "":
+		return AttributionRuntime, "runner returned: " + trace.Error
+	case c.ExpectedRoute != "" && trace.Route != c.ExpectedRoute:
+		return AttributionRoute, fmt.Sprintf("route %q, expected %q", trace.Route, c.ExpectedRoute)
+	case !sameToolNames(c.ExpectedToolCalls, trace.ToolCalls):
+		return AttributionToolCall, "tool call sequence does not match the expected trajectory"
+	case !sameToolCalls(c.ExpectedToolCalls, trace.ToolCalls):
+		return AttributionToolArgs, "tool arguments do not match the expected trajectory"
+	case !trace.FormatValid:
+		return AttributionFormat, "final response violates the required structured format"
+	case c.RetrievalRequired != nil && trace.RetrievalHit != *c.RetrievalRequired:
+		return AttributionKnowledge, fmt.Sprintf("retrieval hit %t, expected %t", trace.RetrievalHit, *c.RetrievalRequired)
+	case responseSimilarity < 1:
+		return AttributionFinalResponse, "final response does not contain the expected facts"
+	default:
+		return AttributionUnknown, "metric score is below threshold; inspect trace"
+	}
+}
+
+func CompareEvaluations(baseline, candidate EvaluationResult) DeltaSummary {
+	d := DeltaSummary{ScoreDelta: round(candidate.OverallScore - baseline.OverallScore)}
+	base := make(map[string]CaseResult, len(baseline.Cases))
+	candidateIDs := make(map[string]bool, len(candidate.Cases))
+	for _, c := range baseline.Cases {
+		if _, exists := base[c.CaseID]; exists {
+			d.CaseSetErrors = append(d.CaseSetErrors, "duplicate baseline case: "+c.CaseID)
+			continue
+		}
+		base[c.CaseID] = c
+	}
+	if len(base) != len(baseline.Cases) {
+		d.CaseSetErrors = append(d.CaseSetErrors, "non-bijective baseline case set")
+	}
+	for _, c := range candidate.Cases {
+		if candidateIDs[c.CaseID] {
+			d.CaseSetErrors = append(d.CaseSetErrors, "duplicate candidate case: "+c.CaseID)
+			continue
+		}
+		candidateIDs[c.CaseID] = true
+		b, ok := base[c.CaseID]
+		if !ok {
+			d.CaseSetErrors = append(d.CaseSetErrors, "extra candidate case: "+c.CaseID)
+			continue
+		}
+		cd := CaseDelta{CaseID: c.CaseID, BaselineScore: b.Score, CandidateScore: c.Score, ScoreDelta: round(c.Score - b.Score), NewlyPassed: !b.Passed && c.Passed, NewlyFailed: b.Passed && !c.Passed, Critical: b.Critical || c.Critical}
+		if cd.NewlyPassed {
+			d.NewlyPassed++
+		}
+		if cd.NewlyFailed {
+			d.NewlyFailed++
+		}
+		if cd.ScoreDelta > 0 {
+			d.Improved++
+		}
+		if cd.ScoreDelta < 0 {
+			d.Regressed++
+		}
+		d.Cases = append(d.Cases, cd)
+	}
+	if len(candidate.Cases) != len(candidateIDs) {
+		d.CaseSetErrors = append(d.CaseSetErrors, "non-bijective candidate case set")
+	}
+	for id := range base {
+		if !candidateIDs[id] {
+			d.CaseSetErrors = append(d.CaseSetErrors, "missing candidate case: "+id)
+			baselineCase := base[id]
+			d.Cases = append(d.Cases, CaseDelta{CaseID: id, BaselineScore: baselineCase.Score, CandidateScore: 0, ScoreDelta: round(-baselineCase.Score), NewlyFailed: baselineCase.Passed, Critical: baselineCase.Critical})
+		}
+	}
+	sort.Slice(d.Cases, func(i, j int) bool { return d.Cases[i].CaseID < d.Cases[j].CaseID })
+	sort.Strings(d.CaseSetErrors)
+	return d
+}
+
+func ApplyGate(cfg GateConfig, baseline, candidate EvaluationResult, delta DeltaSummary) GateDecision {
+	d := GateDecision{Accepted: true}
+	for _, caseError := range delta.CaseSetErrors {
+		d.Accepted = false
+		d.Reasons = append(d.Reasons, "invalid evaluation case set: "+caseError)
+	}
+	if delta.ScoreDelta <= cfg.MinValidationGain {
+		d.Accepted = false
+		d.Reasons = append(d.Reasons, fmt.Sprintf("validation gain %.3f must be greater than %.3f", delta.ScoreDelta, cfg.MinValidationGain))
+	}
+	if cfg.NoNewHardFails {
+		for _, c := range delta.Cases {
+			if c.Critical && c.NewlyFailed {
+				d.Accepted = false
+				d.Reasons = append(d.Reasons, "new hard fail: "+c.CaseID)
+			}
+		}
+	}
+	critical := make(map[string]bool, len(cfg.CriticalCaseIDs))
+	for _, id := range cfg.CriticalCaseIDs {
+		critical[id] = true
+	}
+	candidatePassed := make(map[string]bool, len(candidate.Cases))
+	for _, c := range candidate.Cases {
+		candidatePassed[c.CaseID] = c.Passed
+	}
+	for _, c := range delta.Cases {
+		if !critical[c.CaseID] {
+			continue
+		}
+		if c.NewlyFailed {
+			d.Accepted = false
+			d.Reasons = append(d.Reasons, "critical case newly failed: "+c.CaseID)
+		}
+		if c.ScoreDelta < 0 {
+			d.Accepted = false
+			d.Reasons = append(d.Reasons, "critical case regressed: "+c.CaseID)
+		}
+		if passed, exists := candidatePassed[c.CaseID]; exists && !passed {
+			d.Accepted = false
+			d.Reasons = append(d.Reasons, "critical case did not pass: "+c.CaseID)
+		}
+	}
+	if cfg.MaxCostIncrease != nil && candidate.TotalCost-baseline.TotalCost > *cfg.MaxCostIncrease {
+		d.Accepted = false
+		d.Reasons = append(d.Reasons, "cost increase exceeds budget")
+	}
+	if cfg.MaxToolCalls != nil && candidate.ToolCalls > *cfg.MaxToolCalls {
+		d.Accepted = false
+		d.Reasons = append(d.Reasons, "tool call budget exceeded")
+	}
+	if d.Accepted {
+		d.Reasons = []string{fmt.Sprintf("accepted: validation score improved by %.3f with no protected regression", delta.ScoreDelta)}
+	}
+	return d
+}
+
+func CountAttributions(results ...EvaluationResult) map[Attribution]int {
+	out := map[Attribution]int{}
+	for _, result := range results {
+		for _, c := range result.Cases {
+			if !c.Passed {
+				out[c.Attribution]++
+			}
+		}
+	}
+	return out
+}
+func readPrompt(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read prompt %s: %w", path, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func decodeJSONFile(path string, target any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func sameToolNames(expected, actual []ToolCall) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for i := range expected {
+		if expected[i].Name != actual[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+func sameToolCalls(expected, actual []ToolCall) bool {
+	if !sameToolNames(expected, actual) {
+		return false
+	}
+	for i := range expected {
+		if len(expected[i].Arguments) == 0 && len(actual[i].Arguments) == 0 {
+			continue
+		}
+		if !reflect.DeepEqual(expected[i].Arguments, actual[i].Arguments) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneGateConfig(cfg GateConfig) GateConfig {
+	cloned := cfg
+	cloned.CriticalCaseIDs = append([]string(nil), cfg.CriticalCaseIDs...)
+	if cfg.MaxCostIncrease != nil {
+		value := *cfg.MaxCostIncrease
+		cloned.MaxCostIncrease = &value
+	}
+	if cfg.MaxToolCalls != nil {
+		value := *cfg.MaxToolCalls
+		cloned.MaxToolCalls = &value
+	}
+	return cloned
+}
+func similarity(expected, actual string) float64 {
+	e := words(expected)
+	if len(e) == 0 {
+		return 1
+	}
+	a := words(actual)
+	hit := 0
+	for w := range e {
+		if a[w] {
+			hit++
+		}
+	}
+	return float64(hit) / float64(len(e))
+}
+func words(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, w := range strings.Fields(strings.ToLower(s)) {
+		w = strings.Trim(w, ".,!?;:\"'()[]{}")
+		if w != "" {
+			out[w] = true
+		}
+	}
+	return out
+}
+func round(v float64) float64 {
+	const scale = 1000.0
+	// At this magnitude float64 has no fractional thousandths to discard, and
+	// multiplying by scale would turn an otherwise finite audit value into Inf.
+	if finite(v) && math.Abs(v) > math.MaxFloat64/scale {
+		return v
+	}
+	return math.Round(v*scale) / scale
+}

--- a/examples/evaluation/promptiter_regression_loop/pipeline.go
+++ b/examples/evaluation/promptiter_regression_loop/pipeline.go
@@ -414,6 +414,13 @@ func CompareEvaluations(baseline, candidate EvaluationResult) DeltaSummary {
 	baselineAggregate, baselineErrors := summarizeEvaluation(baseline)
 	candidateAggregate, candidateErrors := summarizeEvaluation(candidate)
 	d := DeltaSummary{ScoreDelta: round(candidateAggregate.OverallScore - baselineAggregate.OverallScore)}
+	if baseline.EvalSetID != candidate.EvalSetID {
+		d.CaseSetErrors = append(d.CaseSetErrors, fmt.Sprintf(
+			"evaluation set ID mismatch: baseline %q, candidate %q",
+			baseline.EvalSetID,
+			candidate.EvalSetID,
+		))
+	}
 	for _, err := range baselineErrors {
 		d.CaseSetErrors = append(d.CaseSetErrors, "invalid baseline aggregate: "+err)
 	}
@@ -553,6 +560,13 @@ func validateGateEvaluationInputs(
 	baselineAggregate, baselineErrors := summarizeEvaluation(baseline)
 	candidateAggregate, candidateErrors := summarizeEvaluation(candidate)
 	validationErrors := append([]string(nil), delta.CaseSetErrors...)
+	if baseline.EvalSetID != candidate.EvalSetID {
+		validationErrors = append(validationErrors, fmt.Sprintf(
+			"evaluation set ID mismatch: baseline %q, candidate %q",
+			baseline.EvalSetID,
+			candidate.EvalSetID,
+		))
+	}
 	for _, err := range baselineErrors {
 		validationErrors = append(validationErrors, "invalid baseline aggregate: "+err)
 	}

--- a/examples/evaluation/promptiter_regression_loop/pipeline.go
+++ b/examples/evaluation/promptiter_regression_loop/pipeline.go
@@ -173,6 +173,9 @@ func validateEvalSet(name string, set EvalSet, promptIDs []string) (map[string]b
 			if trace.LatencyMS < 0 {
 				return nil, fmt.Errorf("%s case %q prompt %q has negative latency", name, evalCase.ID, promptID)
 			}
+			if evalCase.RetrievalRequired != nil && trace.RetrievalHit == nil {
+				return nil, fmt.Errorf("%s case %q prompt %q is missing retrieval telemetry", name, evalCase.ID, promptID)
+			}
 		}
 	}
 	return caseIDs, nil
@@ -364,7 +367,7 @@ func ScoreCase(c EvalCase, trace RunTrace, metrics MetricsConfig) CaseResult {
 		trace.FormatValid &&
 		sameToolCalls(c.ExpectedToolCalls, trace.ToolCalls) &&
 		(c.ExpectedRoute == "" || trace.Route == c.ExpectedRoute) &&
-		(c.RetrievalRequired == nil || trace.RetrievalHit == *c.RetrievalRequired)
+		retrievalContractPassed(c.RetrievalRequired, trace.RetrievalHit)
 	result := CaseResult{
 		CaseID:        c.ID,
 		Critical:      c.Critical,
@@ -392,8 +395,10 @@ func AttributeFailure(c EvalCase, trace RunTrace, responseSimilarity float64) (A
 		return AttributionToolArgs, "tool arguments do not match the expected trajectory"
 	case !trace.FormatValid:
 		return AttributionFormat, "final response violates the required structured format"
-	case c.RetrievalRequired != nil && trace.RetrievalHit != *c.RetrievalRequired:
-		return AttributionKnowledge, fmt.Sprintf("retrieval hit %t, expected %t", trace.RetrievalHit, *c.RetrievalRequired)
+	case c.RetrievalRequired != nil && trace.RetrievalHit == nil:
+		return AttributionKnowledge, "retrieval telemetry is missing"
+	case c.RetrievalRequired != nil && *trace.RetrievalHit != *c.RetrievalRequired:
+		return AttributionKnowledge, fmt.Sprintf("retrieval hit %t, expected %t", *trace.RetrievalHit, *c.RetrievalRequired)
 	case responseSimilarity < 1:
 		return AttributionFinalResponse, "final response does not contain the expected facts"
 	default:
@@ -401,8 +406,20 @@ func AttributeFailure(c EvalCase, trace RunTrace, responseSimilarity float64) (A
 	}
 }
 
+func retrievalContractPassed(required, observed *bool) bool {
+	return required == nil || (observed != nil && *observed == *required)
+}
+
 func CompareEvaluations(baseline, candidate EvaluationResult) DeltaSummary {
-	d := DeltaSummary{ScoreDelta: round(candidate.OverallScore - baseline.OverallScore)}
+	baselineAggregate, baselineErrors := summarizeEvaluation(baseline)
+	candidateAggregate, candidateErrors := summarizeEvaluation(candidate)
+	d := DeltaSummary{ScoreDelta: round(candidateAggregate.OverallScore - baselineAggregate.OverallScore)}
+	for _, err := range baselineErrors {
+		d.CaseSetErrors = append(d.CaseSetErrors, "invalid baseline aggregate: "+err)
+	}
+	for _, err := range candidateErrors {
+		d.CaseSetErrors = append(d.CaseSetErrors, "invalid candidate aggregate: "+err)
+	}
 	base := make(map[string]CaseResult, len(baseline.Cases))
 	candidateIDs := make(map[string]bool, len(candidate.Cases))
 	for _, c := range baseline.Cases {
@@ -427,19 +444,7 @@ func CompareEvaluations(baseline, candidate EvaluationResult) DeltaSummary {
 			continue
 		}
 		cd := CaseDelta{CaseID: c.CaseID, BaselineScore: b.Score, CandidateScore: c.Score, ScoreDelta: round(c.Score - b.Score), NewlyPassed: !b.Passed && c.Passed, NewlyFailed: b.Passed && !c.Passed, Critical: b.Critical || c.Critical}
-		if cd.NewlyPassed {
-			d.NewlyPassed++
-		}
-		if cd.NewlyFailed {
-			d.NewlyFailed++
-		}
-		if cd.ScoreDelta > 0 {
-			d.Improved++
-		}
-		if cd.ScoreDelta < 0 {
-			d.Regressed++
-		}
-		d.Cases = append(d.Cases, cd)
+		recordCaseDelta(&d, cd)
 	}
 	if len(candidate.Cases) != len(candidateIDs) {
 		d.CaseSetErrors = append(d.CaseSetErrors, "non-bijective candidate case set")
@@ -448,7 +453,8 @@ func CompareEvaluations(baseline, candidate EvaluationResult) DeltaSummary {
 		if !candidateIDs[id] {
 			d.CaseSetErrors = append(d.CaseSetErrors, "missing candidate case: "+id)
 			baselineCase := base[id]
-			d.Cases = append(d.Cases, CaseDelta{CaseID: id, BaselineScore: baselineCase.Score, CandidateScore: 0, ScoreDelta: round(-baselineCase.Score), NewlyFailed: baselineCase.Passed, Critical: baselineCase.Critical})
+			caseDelta := CaseDelta{CaseID: id, BaselineScore: baselineCase.Score, CandidateScore: 0, ScoreDelta: round(-baselineCase.Score), NewlyFailed: baselineCase.Passed, Critical: baselineCase.Critical}
+			recordCaseDelta(&d, caseDelta)
 		}
 	}
 	sort.Slice(d.Cases, func(i, j int) bool { return d.Cases[i].CaseID < d.Cases[j].CaseID })
@@ -456,21 +462,60 @@ func CompareEvaluations(baseline, candidate EvaluationResult) DeltaSummary {
 	return d
 }
 
+func recordCaseDelta(summary *DeltaSummary, delta CaseDelta) {
+	if delta.NewlyPassed {
+		summary.NewlyPassed++
+	}
+	if delta.NewlyFailed {
+		summary.NewlyFailed++
+	}
+	if delta.ScoreDelta > 0 {
+		summary.Improved++
+	}
+	if delta.ScoreDelta < 0 {
+		summary.Regressed++
+	}
+	summary.Cases = append(summary.Cases, delta)
+}
+
 func ApplyGate(cfg GateConfig, baseline, candidate EvaluationResult, delta DeltaSummary) GateDecision {
 	d := GateDecision{Accepted: true}
-	for _, caseError := range delta.CaseSetErrors {
+	baselineAggregate, candidateAggregate, expectedScoreDelta, validationErrors :=
+		validateGateEvaluationInputs(baseline, candidate, delta)
+	for _, caseError := range validationErrors {
 		d.Accepted = false
 		d.Reasons = append(d.Reasons, "invalid evaluation case set: "+caseError)
 	}
-	if delta.ScoreDelta <= cfg.MinValidationGain {
+	if expectedScoreDelta <= 0 || expectedScoreDelta < cfg.MinValidationGain {
 		d.Accepted = false
-		d.Reasons = append(d.Reasons, fmt.Sprintf("validation gain %.3f must be greater than %.3f", delta.ScoreDelta, cfg.MinValidationGain))
+		d.Reasons = append(d.Reasons, fmt.Sprintf("validation gain %.3f must be positive and reach %.3f", expectedScoreDelta, cfg.MinValidationGain))
 	}
+	applyProtectedCaseRules(&d, cfg, candidate, delta)
+	if cfg.MaxCostIncrease != nil && candidateAggregate.TotalCost-baselineAggregate.TotalCost > *cfg.MaxCostIncrease {
+		d.Accepted = false
+		d.Reasons = append(d.Reasons, "cost increase exceeds budget")
+	}
+	if cfg.MaxToolCalls != nil && candidateAggregate.ToolCalls > *cfg.MaxToolCalls {
+		d.Accepted = false
+		d.Reasons = append(d.Reasons, "tool call budget exceeded")
+	}
+	if d.Accepted {
+		d.Reasons = []string{fmt.Sprintf("accepted: validation score improved by %.3f with no protected regression", expectedScoreDelta)}
+	}
+	return d
+}
+
+func applyProtectedCaseRules(
+	decision *GateDecision,
+	cfg GateConfig,
+	candidate EvaluationResult,
+	delta DeltaSummary,
+) {
 	if cfg.NoNewHardFails {
 		for _, c := range delta.Cases {
 			if c.Critical && c.NewlyFailed {
-				d.Accepted = false
-				d.Reasons = append(d.Reasons, "new hard fail: "+c.CaseID)
+				decision.Accepted = false
+				decision.Reasons = append(decision.Reasons, "new hard fail: "+c.CaseID)
 			}
 		}
 	}
@@ -487,30 +532,123 @@ func ApplyGate(cfg GateConfig, baseline, candidate EvaluationResult, delta Delta
 			continue
 		}
 		if c.NewlyFailed {
-			d.Accepted = false
-			d.Reasons = append(d.Reasons, "critical case newly failed: "+c.CaseID)
+			decision.Accepted = false
+			decision.Reasons = append(decision.Reasons, "critical case newly failed: "+c.CaseID)
 		}
 		if c.ScoreDelta < 0 {
-			d.Accepted = false
-			d.Reasons = append(d.Reasons, "critical case regressed: "+c.CaseID)
+			decision.Accepted = false
+			decision.Reasons = append(decision.Reasons, "critical case regressed: "+c.CaseID)
 		}
 		if passed, exists := candidatePassed[c.CaseID]; exists && !passed {
-			d.Accepted = false
-			d.Reasons = append(d.Reasons, "critical case did not pass: "+c.CaseID)
+			decision.Accepted = false
+			decision.Reasons = append(decision.Reasons, "critical case did not pass: "+c.CaseID)
 		}
 	}
-	if cfg.MaxCostIncrease != nil && candidate.TotalCost-baseline.TotalCost > *cfg.MaxCostIncrease {
-		d.Accepted = false
-		d.Reasons = append(d.Reasons, "cost increase exceeds budget")
+}
+
+func validateGateEvaluationInputs(
+	baseline, candidate EvaluationResult,
+	delta DeltaSummary,
+) (evaluationAggregate, evaluationAggregate, float64, []string) {
+	baselineAggregate, baselineErrors := summarizeEvaluation(baseline)
+	candidateAggregate, candidateErrors := summarizeEvaluation(candidate)
+	validationErrors := append([]string(nil), delta.CaseSetErrors...)
+	for _, err := range baselineErrors {
+		validationErrors = append(validationErrors, "invalid baseline aggregate: "+err)
 	}
-	if cfg.MaxToolCalls != nil && candidate.ToolCalls > *cfg.MaxToolCalls {
-		d.Accepted = false
-		d.Reasons = append(d.Reasons, "tool call budget exceeded")
+	for _, err := range candidateErrors {
+		validationErrors = append(validationErrors, "invalid candidate aggregate: "+err)
 	}
-	if d.Accepted {
-		d.Reasons = []string{fmt.Sprintf("accepted: validation score improved by %.3f with no protected regression", delta.ScoreDelta)}
+	expectedScoreDelta := round(candidateAggregate.OverallScore - baselineAggregate.OverallScore)
+	if delta.ScoreDelta != expectedScoreDelta {
+		validationErrors = append(validationErrors, fmt.Sprintf(
+			"score delta %.3f does not match case aggregates %.3f",
+			delta.ScoreDelta,
+			expectedScoreDelta,
+		))
 	}
-	return d
+	seen := map[string]bool{}
+	unique := validationErrors[:0]
+	for _, validationError := range validationErrors {
+		if seen[validationError] {
+			continue
+		}
+		seen[validationError] = true
+		unique = append(unique, validationError)
+	}
+	return baselineAggregate, candidateAggregate, expectedScoreDelta, unique
+}
+
+type evaluationAggregate struct {
+	OverallScore float64
+	TotalCost    float64
+	ToolCalls    int
+	LatencyMS    int64
+	Passed       int
+	Failed       int
+}
+
+func summarizeEvaluation(result EvaluationResult) (evaluationAggregate, []string) {
+	var aggregate evaluationAggregate
+	var validationErrors []string
+	if len(result.Cases) == 0 {
+		return aggregate, []string{"cases must not be empty"}
+	}
+	for _, item := range result.Cases {
+		if !finite(item.Score) || item.Score < 0 || item.Score > 1 {
+			validationErrors = append(validationErrors, fmt.Sprintf("case %q has invalid score", item.CaseID))
+		} else {
+			aggregate.OverallScore += item.Score
+		}
+		if !finite(item.Trace.Cost) || item.Trace.Cost < 0 {
+			validationErrors = append(validationErrors, fmt.Sprintf("case %q has invalid cost", item.CaseID))
+		} else {
+			aggregate.TotalCost += item.Trace.Cost
+		}
+		if item.Trace.LatencyMS < 0 || item.Trace.LatencyMS > math.MaxInt64-aggregate.LatencyMS {
+			validationErrors = append(validationErrors, fmt.Sprintf("case %q has invalid latency", item.CaseID))
+		} else {
+			aggregate.LatencyMS += item.Trace.LatencyMS
+		}
+		if len(item.Trace.ToolCalls) > math.MaxInt-aggregate.ToolCalls {
+			validationErrors = append(validationErrors, fmt.Sprintf("case %q overflows tool calls", item.CaseID))
+		} else {
+			aggregate.ToolCalls += len(item.Trace.ToolCalls)
+		}
+		if !sameToolCalls(item.ToolCalls, item.Trace.ToolCalls) {
+			validationErrors = append(validationErrors, fmt.Sprintf("case %q tool calls disagree with its trace", item.CaseID))
+		}
+		if item.Passed {
+			aggregate.Passed++
+		} else {
+			aggregate.Failed++
+		}
+	}
+	aggregate.OverallScore = round(aggregate.OverallScore / float64(len(result.Cases)))
+	aggregate.TotalCost = round(aggregate.TotalCost)
+	for _, check := range []struct {
+		name       string
+		supplied   any
+		recomputed any
+	}{
+		{"overall score", result.OverallScore, aggregate.OverallScore},
+		{"total cost", result.TotalCost, aggregate.TotalCost},
+		{"tool calls", result.ToolCalls, aggregate.ToolCalls},
+		{"latency", result.LatencyMS, aggregate.LatencyMS},
+		{"passed count", result.Passed, aggregate.Passed},
+		{"failed count", result.Failed, aggregate.Failed},
+	} {
+		if !reflect.DeepEqual(check.supplied, check.recomputed) {
+			validationErrors = append(validationErrors, fmt.Sprintf(
+				"%s %v does not match recomputed %v",
+				check.name,
+				check.supplied,
+				check.recomputed,
+			))
+		}
+	}
+	sort.Strings(validationErrors)
+	return aggregate, validationErrors
 }
 
 func CountAttributions(results ...EvaluationResult) map[Attribution]int {

--- a/examples/evaluation/promptiter_regression_loop/pipeline_test.go
+++ b/examples/evaluation/promptiter_regression_loop/pipeline_test.go
@@ -1,0 +1,532 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAttributeFailure(t *testing.T) {
+	retrievalRequired := true
+	expectedCalls := []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Shenzhen"}}}
+	c := EvalCase{
+		ExpectedResponse:  "sunny",
+		ExpectedToolCalls: expectedCalls,
+		ExpectedRoute:     "weather",
+		RetrievalRequired: &retrievalRequired,
+	}
+	tests := []struct {
+		name  string
+		trace RunTrace
+		want  Attribution
+	}{
+		{"runtime", RunTrace{Error: "boom"}, AttributionRuntime},
+		{"route", RunTrace{Route: "chat"}, AttributionRoute},
+		{"tool", RunTrace{Route: "weather", ToolCalls: []ToolCall{{Name: "search"}}}, AttributionToolCall},
+		{"args", RunTrace{Route: "weather", ToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Beijing"}}}}, AttributionToolArgs},
+		{"format", RunTrace{Route: "weather", ToolCalls: expectedCalls, RetrievalHit: true}, AttributionFormat},
+		{"knowledge", RunTrace{Route: "weather", ToolCalls: expectedCalls, FormatValid: true}, AttributionKnowledge},
+		{"response", RunTrace{Route: "weather", ToolCalls: expectedCalls, FormatValid: true, RetrievalHit: true}, AttributionFinalResponse},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := AttributeFailure(c, tt.trace, 0)
+			if got != tt.want {
+				t.Fatalf("got %s want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreCaseRuntimeErrorCannotPass(t *testing.T) {
+	c := EvalCase{ID: "runtime", ExpectedResponse: "ok"}
+	trace := RunTrace{FinalResponse: "ok", FormatValid: true, Error: "runner failed"}
+	metrics := MetricsConfig{ResponseWeight: 1, FormatWeight: 1, PassThreshold: 0.5}
+
+	got := ScoreCase(c, trace, metrics)
+	if got.Passed || got.Attribution != AttributionRuntime {
+		t.Fatalf("runtime failure must not pass: %+v", got)
+	}
+}
+
+func TestScoreCaseRejectsUnexpectedToolArgs(t *testing.T) {
+	c := EvalCase{ID: "args", ExpectedToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Shenzhen"}}}}
+	trace := RunTrace{ToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Shenzhen", "units": "metric"}}}, FormatValid: true}
+	metrics := MetricsConfig{ToolWeight: 1, PassThreshold: 0.75}
+
+	got := ScoreCase(c, trace, metrics)
+	if got.Passed || got.Attribution != AttributionToolArgs {
+		t.Fatalf("unexpected tool arguments must be rejected: %+v", got)
+	}
+}
+
+func TestScoreCasePreservesOrderedNestedToolTrajectory(t *testing.T) {
+	expected := []ToolCall{
+		{Name: "search", Arguments: map[string]any{"limit": float64(2), "filters": map[string]any{"region": "cn"}}},
+		{Name: "summarize", Arguments: map[string]any{"ids": []any{"a", "b"}}},
+	}
+	c := EvalCase{ID: "trajectory", ExpectedResponse: "done", ExpectedToolCalls: expected}
+	metrics := MetricsConfig{ResponseWeight: 1, ToolWeight: 1, FormatWeight: 1, PassThreshold: 0.8}
+
+	got := ScoreCase(c, RunTrace{FinalResponse: "done", ToolCalls: expected, FormatValid: true}, metrics)
+	if !got.Passed {
+		t.Fatalf("complete ordered trajectory should pass: %+v", got)
+	}
+	reversed := []ToolCall{expected[1], expected[0]}
+	got = ScoreCase(c, RunTrace{FinalResponse: "done", ToolCalls: reversed, FormatValid: true}, metrics)
+	if got.Passed || got.Attribution != AttributionToolCall {
+		t.Fatalf("reordered trajectory must fail: %+v", got)
+	}
+}
+
+func TestScoreCaseTreatsOmittedAndEmptyToolArgumentsEqually(t *testing.T) {
+	c := EvalCase{ID: "no-args", ExpectedToolCalls: []ToolCall{{Name: "ping"}}}
+	trace := RunTrace{ToolCalls: []ToolCall{{Name: "ping", Arguments: map[string]any{}}}, FormatValid: true}
+	got := ScoreCase(c, trace, MetricsConfig{ToolWeight: 1, PassThreshold: 1})
+	if !got.Passed {
+		t.Fatalf("semantically empty tool arguments should match: %+v", got)
+	}
+}
+
+func TestExecutionContractsAreHardRequirements(t *testing.T) {
+	retrievalRequired := true
+	expectedCalls := []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Shenzhen"}}}
+	c := EvalCase{
+		ID:                "critical",
+		ExpectedResponse:  "sunny",
+		ExpectedToolCalls: expectedCalls,
+		ExpectedRoute:     "weather",
+		RetrievalRequired: &retrievalRequired,
+		Critical:          true,
+	}
+	metrics := MetricsConfig{ResponseWeight: 0.7, ToolWeight: 0.2, FormatWeight: 0.1, PassThreshold: 0.75}
+	baseline := ScoreCase(c, RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", FormatValid: true, RetrievalHit: true}, metrics)
+	if !baseline.Passed {
+		t.Fatalf("baseline should pass: %+v", baseline)
+	}
+
+	tests := []struct {
+		name  string
+		trace RunTrace
+	}{
+		{"route", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "chat", FormatValid: true, RetrievalHit: true}},
+		{"retrieval", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", FormatValid: true}},
+		{"format", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", RetrievalHit: true}},
+		{"arguments", RunTrace{FinalResponse: "sunny", ToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Beijing"}}}, Route: "weather", FormatValid: true, RetrievalHit: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := ScoreCase(c, tt.trace, metrics)
+			if candidate.Passed {
+				t.Fatalf("execution regression passed weighted scoring: %+v", candidate)
+			}
+			delta := CompareEvaluations(
+				EvaluationResult{OverallScore: baseline.Score, Cases: []CaseResult{baseline}},
+				EvaluationResult{OverallScore: candidate.Score, Cases: []CaseResult{candidate}},
+			)
+			gate := ApplyGate(GateConfig{NoNewHardFails: true}, EvaluationResult{}, EvaluationResult{}, delta)
+			if gate.Accepted {
+				t.Fatalf("gate accepted execution regression: %+v", gate)
+			}
+			if !strings.Contains(strings.Join(gate.Reasons, " "), "new hard fail: critical") {
+				t.Fatalf("gate did not record the execution contract as a hard fail: %+v", gate)
+			}
+		})
+	}
+}
+
+func TestCompareEvaluations(t *testing.T) {
+	base := EvaluationResult{OverallScore: .5, Cases: []CaseResult{{CaseID: "a", Score: .4, Passed: false}, {CaseID: "b", Score: .8, Passed: true}}}
+	candidate := EvaluationResult{OverallScore: .6, Cases: []CaseResult{{CaseID: "a", Score: .8, Passed: true}, {CaseID: "b", Score: .4, Passed: false}}}
+	d := CompareEvaluations(base, candidate)
+	if d.NewlyPassed != 1 || d.NewlyFailed != 1 || d.ScoreDelta != .1 {
+		t.Fatalf("unexpected delta: %+v", d)
+	}
+}
+
+func TestGateRejectsOverfitHardRegression(t *testing.T) {
+	base := EvaluationResult{OverallScore: .7, TotalCost: 1, ToolCalls: 1, Cases: []CaseResult{{CaseID: "critical", Critical: true, Score: 1, Passed: true}}}
+	candidate := EvaluationResult{OverallScore: .8, TotalCost: 1, ToolCalls: 1, Cases: []CaseResult{{CaseID: "critical", Critical: true, Score: .2, Passed: false}}}
+	delta := CompareEvaluations(base, candidate)
+	maxCostIncrease := 1.0
+	maxToolCalls := 2
+	gate := ApplyGate(GateConfig{MinValidationGain: .01, NoNewHardFails: true, CriticalCaseIDs: []string{"critical"}, MaxCostIncrease: &maxCostIncrease, MaxToolCalls: &maxToolCalls}, base, candidate, delta)
+	if gate.Accepted || !strings.Contains(strings.Join(gate.Reasons, " "), "hard fail") {
+		t.Fatalf("expected hard-fail rejection: %+v", gate)
+	}
+}
+
+func TestConfiguredCriticalCaseRejectsNewFailureWithHigherScore(t *testing.T) {
+	base := EvaluationResult{OverallScore: .5, Cases: []CaseResult{{CaseID: "critical", Score: .6, Passed: true}}}
+	candidate := EvaluationResult{OverallScore: .7, Cases: []CaseResult{{CaseID: "critical", Score: .8, Passed: false}}}
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(GateConfig{MinValidationGain: .1, CriticalCaseIDs: []string{"critical"}}, base, candidate, delta)
+	if gate.Accepted || !strings.Contains(strings.Join(gate.Reasons, " "), "critical case newly failed") {
+		t.Fatalf("configured critical hard failure was accepted: %+v", gate)
+	}
+}
+
+func TestGateRejectsNonBijectiveEvaluationCases(t *testing.T) {
+	validBase := []CaseResult{{CaseID: "a", Passed: true}, {CaseID: "b", Passed: true}}
+	tests := []struct {
+		name      string
+		baseline  []CaseResult
+		candidate []CaseResult
+		want      string
+	}{
+		{"missing", validBase, []CaseResult{{CaseID: "a", Passed: true}}, "missing candidate case: b"},
+		{"extra", validBase, append(append([]CaseResult{}, validBase...), CaseResult{CaseID: "c"}), "extra candidate case: c"},
+		{"duplicate-candidate", validBase, []CaseResult{{CaseID: "a"}, {CaseID: "a"}, {CaseID: "b"}}, "duplicate candidate case: a"},
+		{"duplicate-baseline", []CaseResult{{CaseID: "a"}, {CaseID: "a"}}, []CaseResult{{CaseID: "a"}}, "duplicate baseline case: a"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := EvaluationResult{OverallScore: .5, Cases: tt.baseline}
+			candidate := EvaluationResult{OverallScore: .8, Cases: tt.candidate}
+			delta := CompareEvaluations(base, candidate)
+			gate := ApplyGate(GateConfig{MinValidationGain: .1}, base, candidate, delta)
+			if gate.Accepted || !strings.Contains(strings.Join(gate.Reasons, " "), tt.want) {
+				t.Fatalf("invalid case set was not rejected: delta=%+v gate=%+v", delta, gate)
+			}
+		})
+	}
+}
+
+func TestGateRejectsMissingProtectedCaseEvenWithHigherScore(t *testing.T) {
+	base := EvaluationResult{
+		OverallScore: .7,
+		Cases: []CaseResult{
+			{CaseID: "critical", Critical: true, Score: .7, Passed: true},
+			{CaseID: "normal", Score: .7, Passed: true},
+		},
+	}
+	candidate := EvaluationResult{
+		OverallScore: .95,
+		Cases:        []CaseResult{{CaseID: "normal", Score: .95, Passed: true}},
+	}
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(
+		GateConfig{
+			MinValidationGain: 0.05,
+			CriticalCaseIDs:   []string{"critical"},
+		},
+		base,
+		candidate,
+		delta,
+	)
+	if gate.Accepted {
+		t.Fatalf("candidate missing critical case should be rejected: %+v", gate)
+	}
+	if !strings.Contains(strings.Join(gate.Reasons, " "), "invalid evaluation case set: missing candidate case: critical") {
+		t.Fatalf("missing critical case was not surfaced as a case-set violation: %+v", gate)
+	}
+}
+
+func TestGateRejectsCriticalCaseThatFailsEvenWithHigherScore(t *testing.T) {
+	base := EvaluationResult{
+		OverallScore: .5,
+		Cases: []CaseResult{
+			{CaseID: "critical", Critical: true, Score: .9, Passed: true},
+			{CaseID: "normal", Score: .4, Passed: true},
+		},
+	}
+	candidate := EvaluationResult{
+		OverallScore: .8,
+		Cases: []CaseResult{
+			{CaseID: "critical", Critical: true, Score: .9, Passed: false},
+			{CaseID: "normal", Score: .95, Passed: true},
+		},
+	}
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(
+		GateConfig{
+			MinValidationGain: 0.05,
+			CriticalCaseIDs:   []string{"critical"},
+		},
+		base,
+		candidate,
+		delta,
+	)
+	if gate.Accepted {
+		t.Fatalf("critical failed case should be rejected: %+v", gate)
+	}
+	if !strings.Contains(strings.Join(gate.Reasons, " "), "critical case did not pass: critical") {
+		t.Fatalf("critical fail reason missing: %+v", gate)
+	}
+}
+
+func TestGateOmittedBudgetsAreDisabled(t *testing.T) {
+	base := EvaluationResult{OverallScore: .5, TotalCost: 1, ToolCalls: 0}
+	candidate := EvaluationResult{OverallScore: .7, TotalCost: 3, ToolCalls: 4}
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(GateConfig{MinValidationGain: .1}, base, candidate, delta)
+	if !gate.Accepted {
+		t.Fatalf("omitted budgets must not reject a candidate: %+v", gate)
+	}
+}
+
+func TestGateRejectsZeroGainConsistently(t *testing.T) {
+	base := EvaluationResult{OverallScore: .8}
+	candidate := EvaluationResult{OverallScore: .8}
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(GateConfig{MinValidationGain: 0}, base, candidate, delta)
+	if gate.Accepted {
+		t.Fatalf("zero-gain candidate must not be accepted: %+v", gate)
+	}
+}
+
+func TestDecodeJSONRejectsUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "promptiter.json")
+	if err := os.WriteFile(path, []byte(`{"seed":1,"engine":{"type":"fake_trace","model":"fixture"},"gate":{"min_validation_gain":0,"misspelled_guard":true},"candidates":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var cfg LoopConfig
+	if err := decodeJSONFile(path, &cfg); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown safeguard field was not rejected: %v", err)
+	}
+}
+
+func TestPipelineAndReport(t *testing.T) {
+	p, err := LoadPipeline("data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := p.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Accepted || r.SelectedCandidate != "focused" || len(r.Rounds) != 3 {
+		t.Fatalf("unexpected result: %+v", r)
+	}
+	if r.Rounds[2].Gate.Accepted {
+		t.Fatal("overfit candidate must be rejected")
+	}
+	encoded, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored OptimizationReport
+	if err := json.Unmarshal(encoded, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(r.Metrics, restored.Metrics) || !reflect.DeepEqual(r.Gate, restored.Gate) {
+		t.Fatalf("report did not preserve reproducibility config: before=%+v/%+v after=%+v/%+v", r.Metrics, r.Gate, restored.Metrics, restored.Gate)
+	}
+	md := MarkdownReport(r)
+	if !strings.Contains(md, "new fail") || !strings.Contains(md, "Failure attribution") || !strings.Contains(md, "Reproducibility configuration") {
+		t.Fatal("report is incomplete")
+	}
+}
+
+func TestCheckedInReportExamplesMatchCurrentSchema(t *testing.T) {
+	data, err := os.ReadFile("optimization_report.json.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	var report OptimizationReport
+	if err := decoder.Decode(&report); err != nil {
+		t.Fatalf("JSON report example does not match the current schema: %v", err)
+	}
+	pipeline, err := LoadPipeline("data")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := pipeline.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual.StartedAt = report.StartedAt
+	actual.DurationMS = report.DurationMS
+	for i := range actual.Rounds {
+		actual.Rounds[i].DurationMS = report.Rounds[i].DurationMS
+	}
+	if !reflect.DeepEqual(*actual, report) {
+		t.Fatal("JSON report example does not match current deterministic pipeline output")
+	}
+	markdown, err := os.ReadFile("optimization_report.md.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := MarkdownReport(&report); got != string(markdown) {
+		t.Fatal("Markdown report example was not generated from the JSON example")
+	}
+}
+
+func TestPipelineValidationRejectsAmbiguousIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Pipeline)
+		want   string
+	}{
+		{"reserved candidate", func(p *Pipeline) { p.Config.Candidates[0].ID = "baseline" }, "reserved candidate ID"},
+		{"duplicate candidate", func(p *Pipeline) { p.Config.Candidates = append(p.Config.Candidates, p.Config.Candidates[0]) }, "duplicate or reserved candidate ID"},
+		{"duplicate validation case", func(p *Pipeline) { p.Valid.Cases[1].ID = p.Valid.Cases[0].ID }, "duplicate case ID"},
+		{"unknown critical case", func(p *Pipeline) { p.Config.Gate.CriticalCaseIDs = []string{"typo"} }, "is not in the validation set"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline, _ := validPipelineForValidation(t)
+			tt.mutate(pipeline)
+			if err := pipeline.validate(); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPipelineValidationRejectsInvalidNumericConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Pipeline)
+		want   string
+	}{
+		{"negative weight", func(p *Pipeline) { p.Metrics.ToolWeight = -1 }, "weights cannot be negative"},
+		{"nonfinite threshold", func(p *Pipeline) { p.Metrics.PassThreshold = math.Inf(1) }, "must be finite"},
+		{"overflowing total weight", func(p *Pipeline) {
+			p.Metrics.ResponseWeight = 1e308
+			p.Metrics.ToolWeight = 1e308
+		}, "total metric weight must be finite"},
+		{"zero weights", func(p *Pipeline) { p.Metrics.ResponseWeight = 0 }, "at least one metric weight"},
+		{"negative gain", func(p *Pipeline) { p.Config.Gate.MinValidationGain = -0.1 }, "min_validation_gain"},
+		{"negative cost budget", func(p *Pipeline) { value := -1.0; p.Config.Gate.MaxCostIncrease = &value }, "max_cost_increase"},
+		{"negative tool budget", func(p *Pipeline) { value := -1; p.Config.Gate.MaxToolCalls = &value }, "max_tool_calls"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline, _ := validPipelineForValidation(t)
+			tt.mutate(pipeline)
+			if err := pipeline.validate(); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateRejectsAggregateOverflow(t *testing.T) {
+	pipeline := &Pipeline{Metrics: MetricsConfig{ResponseWeight: 1}}
+	t.Run("large finite cost", func(t *testing.T) {
+		set := EvalSet{ID: "large", Cases: []EvalCase{
+			{ID: "one", Runs: map[string]RunTrace{"baseline": {Cost: 1e308}}},
+		}}
+		result, err := pipeline.Evaluate(context.Background(), set, "baseline")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !finite(result.TotalCost) || result.TotalCost != 1e308 {
+			t.Fatalf("large finite cost became %v", result.TotalCost)
+		}
+	})
+	t.Run("cost", func(t *testing.T) {
+		set := EvalSet{ID: "cost", Cases: []EvalCase{
+			{ID: "one", Runs: map[string]RunTrace{"baseline": {Cost: 1e308}}},
+			{ID: "two", Runs: map[string]RunTrace{"baseline": {Cost: 1e308}}},
+		}}
+		if _, err := pipeline.Evaluate(context.Background(), set, "baseline"); err == nil || !strings.Contains(err.Error(), "overflows total cost") {
+			t.Fatalf("Evaluate() cost overflow error = %v", err)
+		}
+	})
+	t.Run("latency", func(t *testing.T) {
+		set := EvalSet{ID: "latency", Cases: []EvalCase{
+			{ID: "one", Runs: map[string]RunTrace{"baseline": {LatencyMS: math.MaxInt64}}},
+			{ID: "two", Runs: map[string]RunTrace{"baseline": {LatencyMS: 1}}},
+		}}
+		if _, err := pipeline.Evaluate(context.Background(), set, "baseline"); err == nil || !strings.Contains(err.Error(), "overflows total latency") {
+			t.Fatalf("Evaluate() latency overflow error = %v", err)
+		}
+	})
+}
+
+func TestPipelineValidationRejectsPromptPathEscape(t *testing.T) {
+	pipeline, root := validPipelineForValidation(t)
+	outside := filepath.Join(root, "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, escaped := range []string{
+		"../outside.txt", `..\outside.txt`, `C:\outside.txt`,
+		"/outside.txt", `\\server\share\outside.txt`,
+	} {
+		t.Run(escaped, func(t *testing.T) {
+			copy := *pipeline
+			copy.Config = pipeline.Config
+			copy.Config.Candidates = append([]CandidateConfig(nil), pipeline.Config.Candidates...)
+			copy.Config.Candidates[0].PromptFile = escaped
+			if err := copy.validate(); err == nil || !strings.Contains(err.Error(), "prompt file") {
+				t.Fatalf("validate() accepted escaped prompt %q: %v", escaped, err)
+			}
+		})
+	}
+}
+
+func TestPipelineValidationRejectsPromptSymlinkEscape(t *testing.T) {
+	pipeline, root := validPipelineForValidation(t)
+	outside := filepath.Join(root, "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(pipeline.Dir, "linked.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	pipeline.Config.Candidates[0].PromptFile = "linked.txt"
+	if err := pipeline.validate(); err == nil || !strings.Contains(err.Error(), "escapes the data directory") {
+		t.Fatalf("validate() accepted escaped symlink: %v", err)
+	}
+}
+
+func validPipelineForValidation(t *testing.T) (*Pipeline, string) {
+	t.Helper()
+	root := t.TempDir()
+	data := filepath.Join(root, "data")
+	if err := os.MkdirAll(data, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"baseline_prompt.txt": "baseline", "candidate.txt": "candidate",
+	} {
+		if err := os.WriteFile(filepath.Join(data, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	makeSet := func(id, prefix string) EvalSet {
+		set := EvalSet{ID: id}
+		for i := 1; i <= 3; i++ {
+			set.Cases = append(set.Cases, EvalCase{
+				ID: fmt.Sprintf("%s-%d", prefix, i),
+				Runs: map[string]RunTrace{
+					"baseline": {FormatValid: true},
+					"focused":  {FormatValid: true},
+				},
+			})
+		}
+		return set
+	}
+	pipeline := &Pipeline{
+		Dir:     data,
+		Metrics: MetricsConfig{PassThreshold: 0.5, ResponseWeight: 1},
+		Config: LoopConfig{
+			Engine:     EngineConfig{Type: "fake_trace", Model: "fixture"},
+			Gate:       GateConfig{CriticalCaseIDs: []string{"validation-1"}},
+			Candidates: []CandidateConfig{{ID: "focused", PromptFile: "candidate.txt"}},
+		},
+		Train: makeSet("train", "train"),
+		Valid: makeSet("validation", "validation"),
+	}
+	return pipeline, root
+}

--- a/examples/evaluation/promptiter_regression_loop/pipeline_test.go
+++ b/examples/evaluation/promptiter_regression_loop/pipeline_test.go
@@ -268,6 +268,35 @@ func TestMissingCandidateCaseUpdatesSummaryCounters(t *testing.T) {
 	if delta.NewlyFailed != 1 || delta.Regressed != 1 {
 		t.Fatalf("missing case was absent from delta counters: %+v", delta)
 	}
+	report := &OptimizationReport{
+		BaselineValidation: base,
+		Rounds: []RoundAudit{{
+			Round:       1,
+			CandidateID: "candidate",
+			Validation:  candidate,
+			Delta:       delta,
+			Gate:        GateDecision{Reasons: []string{"missing candidate case"}},
+		}},
+	}
+	markdown := MarkdownReport(report)
+	if !strings.Contains(markdown, "- Newly passed / failed: 0 / 1") ||
+		!strings.Contains(markdown, "| missing | 0.600 | 0.000 | -0.600 | new fail |") {
+		t.Fatalf("missing case was inconsistent in Markdown report:\n%s", markdown)
+	}
+}
+
+func TestGateRejectsMismatchedEvaluationSetIDs(t *testing.T) {
+	base := evaluationFromCases(CaseResult{CaseID: "case", Score: .5, Passed: true})
+	candidate := evaluationFromCases(CaseResult{CaseID: "case", Score: .8, Passed: true})
+	base.EvalSetID = "validation"
+	candidate.EvalSetID = "training"
+
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(GateConfig{MinValidationGain: .1}, base, candidate, delta)
+	reasons := strings.Join(gate.Reasons, " ")
+	if gate.Accepted || !strings.Contains(reasons, `evaluation set ID mismatch: baseline "validation", candidate "training"`) {
+		t.Fatalf("mismatched evaluation sets were accepted: delta=%+v gate=%+v", delta, gate)
+	}
 }
 
 func TestGateRejectsMissingProtectedCaseEvenWithHigherScore(t *testing.T) {

--- a/examples/evaluation/promptiter_regression_loop/pipeline_test.go
+++ b/examples/evaluation/promptiter_regression_loop/pipeline_test.go
@@ -20,6 +20,32 @@ import (
 	"testing"
 )
 
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func evaluationFromCases(cases ...CaseResult) EvaluationResult {
+	result := EvaluationResult{Cases: cases}
+	for index := range result.Cases {
+		item := &result.Cases[index]
+		if item.Trace.ToolCalls == nil && item.ToolCalls != nil {
+			item.Trace.ToolCalls = item.ToolCalls
+		}
+		result.OverallScore += item.Score
+		result.TotalCost += item.Trace.Cost
+		result.ToolCalls += len(item.Trace.ToolCalls)
+		result.LatencyMS += item.Trace.LatencyMS
+		if item.Passed {
+			result.Passed++
+		} else {
+			result.Failed++
+		}
+	}
+	result.OverallScore = round(result.OverallScore / float64(len(result.Cases)))
+	result.TotalCost = round(result.TotalCost)
+	return result
+}
+
 func TestAttributeFailure(t *testing.T) {
 	retrievalRequired := true
 	expectedCalls := []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Shenzhen"}}}
@@ -38,9 +64,9 @@ func TestAttributeFailure(t *testing.T) {
 		{"route", RunTrace{Route: "chat"}, AttributionRoute},
 		{"tool", RunTrace{Route: "weather", ToolCalls: []ToolCall{{Name: "search"}}}, AttributionToolCall},
 		{"args", RunTrace{Route: "weather", ToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Beijing"}}}}, AttributionToolArgs},
-		{"format", RunTrace{Route: "weather", ToolCalls: expectedCalls, RetrievalHit: true}, AttributionFormat},
+		{"format", RunTrace{Route: "weather", ToolCalls: expectedCalls, RetrievalHit: boolPointer(true)}, AttributionFormat},
 		{"knowledge", RunTrace{Route: "weather", ToolCalls: expectedCalls, FormatValid: true}, AttributionKnowledge},
-		{"response", RunTrace{Route: "weather", ToolCalls: expectedCalls, FormatValid: true, RetrievalHit: true}, AttributionFinalResponse},
+		{"response", RunTrace{Route: "weather", ToolCalls: expectedCalls, FormatValid: true, RetrievalHit: boolPointer(true)}, AttributionFinalResponse},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +86,24 @@ func TestScoreCaseRuntimeErrorCannotPass(t *testing.T) {
 	got := ScoreCase(c, trace, metrics)
 	if got.Passed || got.Attribution != AttributionRuntime {
 		t.Fatalf("runtime failure must not pass: %+v", got)
+	}
+}
+
+func TestScoreCaseRequiresRetrievalTelemetryForFalseContract(t *testing.T) {
+	retrievalRequired := false
+	evalCase := EvalCase{
+		ID:                "no-retrieval",
+		ExpectedResponse:  "ok",
+		RetrievalRequired: &retrievalRequired,
+	}
+	result := ScoreCase(
+		evalCase,
+		RunTrace{FinalResponse: "ok", FormatValid: true},
+		MetricsConfig{ResponseWeight: 1, FormatWeight: 1, PassThreshold: 1},
+	)
+	if result.Passed || result.Attribution != AttributionKnowledge ||
+		!strings.Contains(result.Reason, "missing") {
+		t.Fatalf("missing retrieval telemetry satisfied a false contract: %+v", result)
 	}
 }
 
@@ -114,7 +158,7 @@ func TestExecutionContractsAreHardRequirements(t *testing.T) {
 		Critical:          true,
 	}
 	metrics := MetricsConfig{ResponseWeight: 0.7, ToolWeight: 0.2, FormatWeight: 0.1, PassThreshold: 0.75}
-	baseline := ScoreCase(c, RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", FormatValid: true, RetrievalHit: true}, metrics)
+	baseline := ScoreCase(c, RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", FormatValid: true, RetrievalHit: boolPointer(true)}, metrics)
 	if !baseline.Passed {
 		t.Fatalf("baseline should pass: %+v", baseline)
 	}
@@ -123,10 +167,10 @@ func TestExecutionContractsAreHardRequirements(t *testing.T) {
 		name  string
 		trace RunTrace
 	}{
-		{"route", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "chat", FormatValid: true, RetrievalHit: true}},
+		{"route", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "chat", FormatValid: true, RetrievalHit: boolPointer(true)}},
 		{"retrieval", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", FormatValid: true}},
-		{"format", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", RetrievalHit: true}},
-		{"arguments", RunTrace{FinalResponse: "sunny", ToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Beijing"}}}, Route: "weather", FormatValid: true, RetrievalHit: true}},
+		{"format", RunTrace{FinalResponse: "sunny", ToolCalls: expectedCalls, Route: "weather", RetrievalHit: boolPointer(true)}},
+		{"arguments", RunTrace{FinalResponse: "sunny", ToolCalls: []ToolCall{{Name: "weather", Arguments: map[string]any{"city": "Beijing"}}}, Route: "weather", FormatValid: true, RetrievalHit: boolPointer(true)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -134,11 +178,10 @@ func TestExecutionContractsAreHardRequirements(t *testing.T) {
 			if candidate.Passed {
 				t.Fatalf("execution regression passed weighted scoring: %+v", candidate)
 			}
-			delta := CompareEvaluations(
-				EvaluationResult{OverallScore: baseline.Score, Cases: []CaseResult{baseline}},
-				EvaluationResult{OverallScore: candidate.Score, Cases: []CaseResult{candidate}},
-			)
-			gate := ApplyGate(GateConfig{NoNewHardFails: true}, EvaluationResult{}, EvaluationResult{}, delta)
+			baselineResult := evaluationFromCases(baseline)
+			candidateResult := evaluationFromCases(candidate)
+			delta := CompareEvaluations(baselineResult, candidateResult)
+			gate := ApplyGate(GateConfig{NoNewHardFails: true}, baselineResult, candidateResult, delta)
 			if gate.Accepted {
 				t.Fatalf("gate accepted execution regression: %+v", gate)
 			}
@@ -150,8 +193,8 @@ func TestExecutionContractsAreHardRequirements(t *testing.T) {
 }
 
 func TestCompareEvaluations(t *testing.T) {
-	base := EvaluationResult{OverallScore: .5, Cases: []CaseResult{{CaseID: "a", Score: .4, Passed: false}, {CaseID: "b", Score: .8, Passed: true}}}
-	candidate := EvaluationResult{OverallScore: .6, Cases: []CaseResult{{CaseID: "a", Score: .8, Passed: true}, {CaseID: "b", Score: .4, Passed: false}}}
+	base := evaluationFromCases(CaseResult{CaseID: "a", Score: .4, Passed: false}, CaseResult{CaseID: "b", Score: .8, Passed: true})
+	candidate := evaluationFromCases(CaseResult{CaseID: "a", Score: .8, Passed: true}, CaseResult{CaseID: "b", Score: .6, Passed: false})
 	d := CompareEvaluations(base, candidate)
 	if d.NewlyPassed != 1 || d.NewlyFailed != 1 || d.ScoreDelta != .1 {
 		t.Fatalf("unexpected delta: %+v", d)
@@ -159,8 +202,15 @@ func TestCompareEvaluations(t *testing.T) {
 }
 
 func TestGateRejectsOverfitHardRegression(t *testing.T) {
-	base := EvaluationResult{OverallScore: .7, TotalCost: 1, ToolCalls: 1, Cases: []CaseResult{{CaseID: "critical", Critical: true, Score: 1, Passed: true}}}
-	candidate := EvaluationResult{OverallScore: .8, TotalCost: 1, ToolCalls: 1, Cases: []CaseResult{{CaseID: "critical", Critical: true, Score: .2, Passed: false}}}
+	call := []ToolCall{{Name: "lookup"}}
+	base := evaluationFromCases(
+		CaseResult{CaseID: "critical", Critical: true, Score: 1, Passed: true, ToolCalls: call, Trace: RunTrace{Cost: .5}},
+		CaseResult{CaseID: "normal", Score: .4, Passed: true, Trace: RunTrace{Cost: .5}},
+	)
+	candidate := evaluationFromCases(
+		CaseResult{CaseID: "critical", Critical: true, Score: .6, Passed: false, ToolCalls: call, Trace: RunTrace{Cost: .5}},
+		CaseResult{CaseID: "normal", Score: 1, Passed: true, Trace: RunTrace{Cost: .5}},
+	)
 	delta := CompareEvaluations(base, candidate)
 	maxCostIncrease := 1.0
 	maxToolCalls := 2
@@ -171,8 +221,8 @@ func TestGateRejectsOverfitHardRegression(t *testing.T) {
 }
 
 func TestConfiguredCriticalCaseRejectsNewFailureWithHigherScore(t *testing.T) {
-	base := EvaluationResult{OverallScore: .5, Cases: []CaseResult{{CaseID: "critical", Score: .6, Passed: true}}}
-	candidate := EvaluationResult{OverallScore: .7, Cases: []CaseResult{{CaseID: "critical", Score: .8, Passed: false}}}
+	base := evaluationFromCases(CaseResult{CaseID: "critical", Score: .6, Passed: true})
+	candidate := evaluationFromCases(CaseResult{CaseID: "critical", Score: .8, Passed: false})
 	delta := CompareEvaluations(base, candidate)
 	gate := ApplyGate(GateConfig{MinValidationGain: .1, CriticalCaseIDs: []string{"critical"}}, base, candidate, delta)
 	if gate.Accepted || !strings.Contains(strings.Join(gate.Reasons, " "), "critical case newly failed") {
@@ -195,8 +245,8 @@ func TestGateRejectsNonBijectiveEvaluationCases(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			base := EvaluationResult{OverallScore: .5, Cases: tt.baseline}
-			candidate := EvaluationResult{OverallScore: .8, Cases: tt.candidate}
+			base := evaluationFromCases(tt.baseline...)
+			candidate := evaluationFromCases(tt.candidate...)
 			delta := CompareEvaluations(base, candidate)
 			gate := ApplyGate(GateConfig{MinValidationGain: .1}, base, candidate, delta)
 			if gate.Accepted || !strings.Contains(strings.Join(gate.Reasons, " "), tt.want) {
@@ -206,18 +256,26 @@ func TestGateRejectsNonBijectiveEvaluationCases(t *testing.T) {
 	}
 }
 
+func TestMissingCandidateCaseUpdatesSummaryCounters(t *testing.T) {
+	base := evaluationFromCases(
+		CaseResult{CaseID: "present", Score: .8, Passed: true},
+		CaseResult{CaseID: "missing", Score: .6, Passed: true},
+	)
+	candidate := evaluationFromCases(
+		CaseResult{CaseID: "present", Score: .9, Passed: true},
+	)
+	delta := CompareEvaluations(base, candidate)
+	if delta.NewlyFailed != 1 || delta.Regressed != 1 {
+		t.Fatalf("missing case was absent from delta counters: %+v", delta)
+	}
+}
+
 func TestGateRejectsMissingProtectedCaseEvenWithHigherScore(t *testing.T) {
-	base := EvaluationResult{
-		OverallScore: .7,
-		Cases: []CaseResult{
-			{CaseID: "critical", Critical: true, Score: .7, Passed: true},
-			{CaseID: "normal", Score: .7, Passed: true},
-		},
-	}
-	candidate := EvaluationResult{
-		OverallScore: .95,
-		Cases:        []CaseResult{{CaseID: "normal", Score: .95, Passed: true}},
-	}
+	base := evaluationFromCases(
+		CaseResult{CaseID: "critical", Critical: true, Score: .7, Passed: true},
+		CaseResult{CaseID: "normal", Score: .7, Passed: true},
+	)
+	candidate := evaluationFromCases(CaseResult{CaseID: "normal", Score: .95, Passed: true})
 	delta := CompareEvaluations(base, candidate)
 	gate := ApplyGate(
 		GateConfig{
@@ -237,20 +295,14 @@ func TestGateRejectsMissingProtectedCaseEvenWithHigherScore(t *testing.T) {
 }
 
 func TestGateRejectsCriticalCaseThatFailsEvenWithHigherScore(t *testing.T) {
-	base := EvaluationResult{
-		OverallScore: .5,
-		Cases: []CaseResult{
-			{CaseID: "critical", Critical: true, Score: .9, Passed: true},
-			{CaseID: "normal", Score: .4, Passed: true},
-		},
-	}
-	candidate := EvaluationResult{
-		OverallScore: .8,
-		Cases: []CaseResult{
-			{CaseID: "critical", Critical: true, Score: .9, Passed: false},
-			{CaseID: "normal", Score: .95, Passed: true},
-		},
-	}
+	base := evaluationFromCases(
+		CaseResult{CaseID: "critical", Critical: true, Score: .9, Passed: true},
+		CaseResult{CaseID: "normal", Score: .4, Passed: true},
+	)
+	candidate := evaluationFromCases(
+		CaseResult{CaseID: "critical", Critical: true, Score: .9, Passed: false},
+		CaseResult{CaseID: "normal", Score: .95, Passed: true},
+	)
 	delta := CompareEvaluations(base, candidate)
 	gate := ApplyGate(
 		GateConfig{
@@ -270,8 +322,12 @@ func TestGateRejectsCriticalCaseThatFailsEvenWithHigherScore(t *testing.T) {
 }
 
 func TestGateOmittedBudgetsAreDisabled(t *testing.T) {
-	base := EvaluationResult{OverallScore: .5, TotalCost: 1, ToolCalls: 0}
-	candidate := EvaluationResult{OverallScore: .7, TotalCost: 3, ToolCalls: 4}
+	base := evaluationFromCases(CaseResult{CaseID: "case", Score: .5, Passed: true, Trace: RunTrace{Cost: 1}})
+	calls := []ToolCall{{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}}
+	candidate := evaluationFromCases(CaseResult{
+		CaseID: "case", Score: .7, Passed: true, ToolCalls: calls,
+		Trace: RunTrace{Cost: 3},
+	})
 	delta := CompareEvaluations(base, candidate)
 	gate := ApplyGate(GateConfig{MinValidationGain: .1}, base, candidate, delta)
 	if !gate.Accepted {
@@ -280,12 +336,52 @@ func TestGateOmittedBudgetsAreDisabled(t *testing.T) {
 }
 
 func TestGateRejectsZeroGainConsistently(t *testing.T) {
-	base := EvaluationResult{OverallScore: .8}
-	candidate := EvaluationResult{OverallScore: .8}
+	base := evaluationFromCases(CaseResult{CaseID: "case", Score: .8, Passed: true})
+	candidate := evaluationFromCases(CaseResult{CaseID: "case", Score: .8, Passed: true})
 	delta := CompareEvaluations(base, candidate)
 	gate := ApplyGate(GateConfig{MinValidationGain: 0}, base, candidate, delta)
 	if gate.Accepted {
 		t.Fatalf("zero-gain candidate must not be accepted: %+v", gate)
+	}
+}
+
+func TestGateAcceptsGainAtConfiguredMinimum(t *testing.T) {
+	base := evaluationFromCases(CaseResult{CaseID: "case", Score: .5, Passed: true})
+	candidate := evaluationFromCases(CaseResult{CaseID: "case", Score: .6, Passed: true})
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(GateConfig{MinValidationGain: .1}, base, candidate, delta)
+	if !gate.Accepted {
+		t.Fatalf("gain at configured minimum was rejected: delta=%+v gate=%+v", delta, gate)
+	}
+}
+
+func TestGateRecomputesMappedAggregates(t *testing.T) {
+	base := evaluationFromCases(CaseResult{
+		CaseID: "case", Score: .5, Passed: true,
+		Trace: RunTrace{Cost: 1, LatencyMS: 10},
+	})
+	calls := []ToolCall{{Name: "lookup"}, {Name: "fetch"}}
+	candidate := evaluationFromCases(CaseResult{
+		CaseID: "case", Score: .4, Passed: true, ToolCalls: calls,
+		Trace: RunTrace{Cost: 3, LatencyMS: 20},
+	})
+	candidate.OverallScore = .9
+	candidate.TotalCost = 0
+	candidate.ToolCalls = 0
+	maxCostIncrease := .5
+	maxToolCalls := 1
+	delta := CompareEvaluations(base, candidate)
+	gate := ApplyGate(GateConfig{
+		MinValidationGain: .1,
+		MaxCostIncrease:   &maxCostIncrease,
+		MaxToolCalls:      &maxToolCalls,
+	}, base, candidate, delta)
+	reasons := strings.Join(gate.Reasons, " ")
+	if gate.Accepted || delta.ScoreDelta != -.1 ||
+		!strings.Contains(reasons, "invalid candidate aggregate") ||
+		!strings.Contains(reasons, "cost increase exceeds budget") ||
+		!strings.Contains(reasons, "tool call budget exceeded") {
+		t.Fatalf("mapped aggregate tampering was trusted: delta=%+v gate=%+v", delta, gate)
 	}
 }
 

--- a/examples/evaluation/promptiter_regression_loop/report.go
+++ b/examples/evaluation/promptiter_regression_loop/report.go
@@ -1,0 +1,112 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func WriteReports(report *OptimizationReport, outputDir string) error {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "optimization_report.json"), append(data, '\n'), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outputDir, "optimization_report.md"), []byte(MarkdownReport(report)), 0o644)
+}
+
+func MarkdownReport(r *OptimizationReport) string {
+	var b strings.Builder
+	b.WriteString("# Prompt Optimization Regression Report\n\n")
+	fmt.Fprintf(&b, "- **Decision:** %s\n", decision(r.Accepted))
+	fmt.Fprintf(&b, "- **Selected candidate:** %s\n", valueOr(r.SelectedCandidate, "none"))
+	fmt.Fprintf(&b, "- **Baseline train score:** %.3f\n", r.BaselineTrain.OverallScore)
+	fmt.Fprintf(&b, "- **Baseline validation score:** %.3f\n", r.BaselineValidation.OverallScore)
+	fmt.Fprintf(&b, "- **Runtime:** %d ms\n- **Seed:** %d\n- **Engine:** %s (%s)\n\n", r.DurationMS, r.Seed, r.Engine.Type, r.Engine.Model)
+	b.WriteString("## Reproducibility configuration\n\n")
+	fmt.Fprintf(&b, "- Pass threshold: %.3f\n", r.Metrics.PassThreshold)
+	fmt.Fprintf(&b, "- Metric weights (response / tool / format): %.3f / %.3f / %.3f\n", r.Metrics.ResponseWeight, r.Metrics.ToolWeight, r.Metrics.FormatWeight)
+	fmt.Fprintf(&b, "- Minimum validation gain: %.3f\n", r.Gate.MinValidationGain)
+	fmt.Fprintf(&b, "- No new hard fails: %t\n", r.Gate.NoNewHardFails)
+	fmt.Fprintf(&b, "- Critical cases: %s\n", valueOr(strings.Join(r.Gate.CriticalCaseIDs, ", "), "none"))
+	fmt.Fprintf(&b, "- Maximum cost increase: %s\n", optionalFloat(r.Gate.MaxCostIncrease))
+	fmt.Fprintf(&b, "- Maximum tool calls: %s\n\n", optionalInt(r.Gate.MaxToolCalls))
+	b.WriteString("## Failure attribution\n\n| Category | Count |\n|---|---:|\n")
+	keys := make([]string, 0, len(r.AttributionCounts))
+	for key := range r.AttributionCounts {
+		keys = append(keys, string(key))
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Fprintf(&b, "| %s | %d |\n", key, r.AttributionCounts[Attribution(key)])
+	}
+	b.WriteString("\n## Candidate rounds\n")
+	for _, round := range r.Rounds {
+		fmt.Fprintf(&b, "\n### Round %d: %s\n\n", round.Round, round.CandidateID)
+		fmt.Fprintf(&b, "- Train score: %.3f\n- Validation score: %.3f\n- Validation delta: %+.3f\n- Newly passed / failed: %d / %d\n- Gate: %s — %s\n- Cost: %.3f; tool calls: %d; latency: %d ms\n\n", round.Train.OverallScore, round.Validation.OverallScore, round.Delta.ScoreDelta, round.Delta.NewlyPassed, round.Delta.NewlyFailed, decision(round.Gate.Accepted), strings.Join(round.Gate.Reasons, "; "), round.Validation.TotalCost, round.Validation.ToolCalls, round.Validation.LatencyMS)
+		b.WriteString("| Case | Baseline | Candidate | Delta | Change |\n|---|---:|---:|---:|---|\n")
+		for _, c := range round.Delta.Cases {
+			change := "unchanged"
+			if c.NewlyPassed {
+				change = "new pass"
+			}
+			if c.NewlyFailed {
+				change = "new fail"
+			}
+			fmt.Fprintf(&b, "| %s | %.3f | %.3f | %+.3f | %s |\n", c.CaseID, c.BaselineScore, c.CandidateScore, c.ScoreDelta, change)
+		}
+	}
+	b.WriteString("\n## Final decision\n\n")
+	for _, reason := range r.DecisionReasons {
+		fmt.Fprintf(&b, "- %s\n", reason)
+	}
+	if r.Accepted {
+		b.WriteString("\nThe candidate generalizes on the held-out validation set and is safe to consider for source-prompt write-back after human review.\n")
+	} else {
+		b.WriteString("\nNo prompt should be written back. Keep the baseline and inspect the rejected-round audit records.\n")
+	}
+	return b.String()
+}
+
+func decision(accepted bool) string {
+	if accepted {
+		return "ACCEPT"
+	}
+	return "REJECT"
+}
+func valueOr(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func optionalFloat(value *float64) string {
+	if value == nil {
+		return "disabled"
+	}
+	return fmt.Sprintf("%.3f", *value)
+}
+
+func optionalInt(value *int) string {
+	if value == nil {
+		return "disabled"
+	}
+	return fmt.Sprint(*value)
+}

--- a/examples/evaluation/promptiter_regression_loop/types.go
+++ b/examples/evaluation/promptiter_regression_loop/types.go
@@ -1,0 +1,166 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import "time"
+
+type EvalSet struct {
+	ID    string     `json:"eval_set_id"`
+	Cases []EvalCase `json:"cases"`
+}
+
+type EvalCase struct {
+	ID                string              `json:"id"`
+	Input             string              `json:"input"`
+	ExpectedResponse  string              `json:"expected_response"`
+	ExpectedToolCalls []ToolCall          `json:"expected_tool_calls,omitempty"`
+	ExpectedRoute     string              `json:"expected_route,omitempty"`
+	RetrievalRequired *bool               `json:"retrieval_required,omitempty"`
+	Critical          bool                `json:"critical,omitempty"`
+	Runs              map[string]RunTrace `json:"runs"`
+}
+
+type ToolCall struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+type RunTrace struct {
+	FinalResponse string     `json:"final_response"`
+	ToolCalls     []ToolCall `json:"tool_calls,omitempty"`
+	Route         string     `json:"route,omitempty"`
+	FormatValid   bool       `json:"format_valid"`
+	RetrievalHit  bool       `json:"retrieval_hit"`
+	Cost          float64    `json:"cost"`
+	LatencyMS     int64      `json:"latency_ms"`
+	Error         string     `json:"error,omitempty"`
+}
+
+type MetricsConfig struct {
+	PassThreshold  float64 `json:"pass_threshold"`
+	ResponseWeight float64 `json:"response_weight"`
+	ToolWeight     float64 `json:"tool_weight"`
+	FormatWeight   float64 `json:"format_weight"`
+}
+
+type LoopConfig struct {
+	Seed       int64             `json:"seed"`
+	Engine     EngineConfig      `json:"engine"`
+	Gate       GateConfig        `json:"gate"`
+	Candidates []CandidateConfig `json:"candidates"`
+}
+
+type EngineConfig struct {
+	Type  string `json:"type"`
+	Model string `json:"model"`
+}
+
+type CandidateConfig struct {
+	ID         string `json:"id"`
+	PromptFile string `json:"prompt_file"`
+}
+
+type GateConfig struct {
+	MinValidationGain float64  `json:"min_validation_gain"`
+	NoNewHardFails    bool     `json:"no_new_hard_fails"`
+	CriticalCaseIDs   []string `json:"critical_case_ids"`
+	MaxCostIncrease   *float64 `json:"max_cost_increase,omitempty"`
+	MaxToolCalls      *int     `json:"max_tool_calls,omitempty"`
+}
+
+type Attribution string
+
+const (
+	AttributionFinalResponse Attribution = "final_response_mismatch"
+	AttributionToolCall      Attribution = "tool_call_error"
+	AttributionToolArgs      Attribution = "tool_argument_error"
+	AttributionRoute         Attribution = "route_error"
+	AttributionFormat        Attribution = "format_error"
+	AttributionKnowledge     Attribution = "knowledge_retrieval_insufficient"
+	AttributionRuntime       Attribution = "runtime_error"
+	AttributionUnknown       Attribution = "unknown"
+)
+
+type CaseResult struct {
+	CaseID        string      `json:"case_id"`
+	Critical      bool        `json:"critical"`
+	Score         float64     `json:"score"`
+	Passed        bool        `json:"passed"`
+	Attribution   Attribution `json:"attribution,omitempty"`
+	Reason        string      `json:"reason,omitempty"`
+	FinalResponse string      `json:"final_response"`
+	ToolCalls     []ToolCall  `json:"tool_calls,omitempty"`
+	Trace         RunTrace    `json:"trace"`
+}
+
+type EvaluationResult struct {
+	EvalSetID    string       `json:"eval_set_id"`
+	PromptID     string       `json:"prompt_id"`
+	OverallScore float64      `json:"overall_score"`
+	Passed       int          `json:"passed"`
+	Failed       int          `json:"failed"`
+	TotalCost    float64      `json:"total_cost"`
+	ToolCalls    int          `json:"tool_calls"`
+	LatencyMS    int64        `json:"latency_ms"`
+	Cases        []CaseResult `json:"cases"`
+}
+
+type CaseDelta struct {
+	CaseID         string  `json:"case_id"`
+	BaselineScore  float64 `json:"baseline_score"`
+	CandidateScore float64 `json:"candidate_score"`
+	ScoreDelta     float64 `json:"score_delta"`
+	NewlyPassed    bool    `json:"newly_passed"`
+	NewlyFailed    bool    `json:"newly_failed"`
+	Critical       bool    `json:"critical"`
+}
+
+type DeltaSummary struct {
+	ScoreDelta    float64     `json:"score_delta"`
+	NewlyPassed   int         `json:"newly_passed"`
+	NewlyFailed   int         `json:"newly_failed"`
+	Improved      int         `json:"improved"`
+	Regressed     int         `json:"regressed"`
+	CaseSetErrors []string    `json:"case_set_errors,omitempty"`
+	Cases         []CaseDelta `json:"cases"`
+}
+
+type GateDecision struct {
+	Accepted bool     `json:"accepted"`
+	Reasons  []string `json:"reasons"`
+}
+
+type RoundAudit struct {
+	Round       int              `json:"round"`
+	CandidateID string           `json:"candidate_id"`
+	Prompt      string           `json:"prompt"`
+	Train       EvaluationResult `json:"train"`
+	Validation  EvaluationResult `json:"validation"`
+	Delta       DeltaSummary     `json:"delta"`
+	Gate        GateDecision     `json:"gate"`
+	DurationMS  int64            `json:"duration_ms"`
+}
+
+type OptimizationReport struct {
+	StartedAt          time.Time           `json:"started_at"`
+	DurationMS         int64               `json:"duration_ms"`
+	Seed               int64               `json:"seed"`
+	Engine             EngineConfig        `json:"engine"`
+	Metrics            MetricsConfig       `json:"metrics"`
+	Gate               GateConfig          `json:"gate"`
+	BaselinePrompt     string              `json:"baseline_prompt"`
+	BaselineTrain      EvaluationResult    `json:"baseline_train"`
+	BaselineValidation EvaluationResult    `json:"baseline_validation"`
+	AttributionCounts  map[Attribution]int `json:"attribution_counts"`
+	Rounds             []RoundAudit        `json:"rounds"`
+	SelectedCandidate  string              `json:"selected_candidate,omitempty"`
+	SelectedPrompt     string              `json:"selected_prompt,omitempty"`
+	Accepted           bool                `json:"accepted"`
+	DecisionReasons    []string            `json:"decision_reasons"`
+}

--- a/examples/evaluation/promptiter_regression_loop/types.go
+++ b/examples/evaluation/promptiter_regression_loop/types.go
@@ -36,7 +36,7 @@ type RunTrace struct {
 	ToolCalls     []ToolCall `json:"tool_calls,omitempty"`
 	Route         string     `json:"route,omitempty"`
 	FormatValid   bool       `json:"format_valid"`
-	RetrievalHit  bool       `json:"retrieval_hit"`
+	RetrievalHit  *bool      `json:"retrieval_hit,omitempty"`
 	Cost          float64    `json:"cost"`
 	LatencyMS     int64      `json:"latency_ms"`
 	Error         string     `json:"error,omitempty"`


### PR DESCRIPTION
## Summary

Implements #2003 with a deterministic Evaluation + PromptIter-style optimization regression loop under `examples/evaluation/promptiter_regression_loop`.

- evaluates the baseline prompt independently on training and validation sets
- attributes failures from runtime, route, tool selection, tool arguments, structured format, knowledge retrieval, and final-response signals
- evaluates multiple prompt candidates and records every prompt and round
- compares validation results case by case, including score delta, newly passing cases, and newly failing cases
- gates candidates on minimum validation gain, new hard failures, protected-case regressions, cost increase, and tool-call budget
- records engine configuration, random seed, latency, cost, tool calls, traces, decisions, and rejection reasons
- generates machine-readable JSON and reviewer-friendly Markdown audit reports
- provides a deterministic fake trace engine so the complete pipeline runs without an API key

The report structures and gate can also consume rounds produced by the existing `evaluation/workflow/promptiter` engine and Evaluation Service. The deterministic example isolates the regression and acceptance behavior from model variance.

## Sample outcomes

The six supplied cases cover three required optimization outcomes:

| Candidate | Train | Validation | Decision |
|---|---:|---:|---|
| baseline | 0.494 | 0.706 | reference |
| focused | 1.000 | 1.000 | accepted |
| ineffective | 0.494 | 0.706 | rejected: no validation gain |
| overfit | 1.000 | 0.433 | rejected: held-out and protected-case regression |

The overfit candidate improves the training set to a perfect score but is rejected because validation quality drops and a critical refund case regresses.

## Validation

- `go test ./promptiter_regression_loop`
- `go vet ./promptiter_regression_loop`
- `go test ./promptiter/...`
- `go test ./...` from `examples/evaluation`
- deterministic CLI run generated both `optimization_report.json` and `optimization_report.md`
- complete fake pipeline runtime was below one second, well within the three-minute requirement

## Usage

```bash
cd examples/evaluation

go run ./promptiter_regression_loop \
  --data-dir promptiter_regression_loop/data \
  --output-dir promptiter_regression_loop/out
```

The pipeline never rewrites the source prompt automatically. A passing candidate is marked as eligible for human-reviewed write-back, while every rejected candidate remains in the audit report.