### PR TITLE
model: add latest OpenAI, Claude, and Kimi metadata

### DIFF
--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -35,6 +35,12 @@ var ModelContextWindows = map[string]int{
 	"o3":         200000, // https://developers.openai.com/api/docs/models/o3
 	"o4-mini":    200000, // https://developers.openai.com/api/docs/models/o4-mini
 
+	// OpenAI GPT-5.6
+	"gpt-5.6":       1050000, // Alias for GPT-5.6 Sol — https://developers.openai.com/api/docs/models/gpt-5.6-sol
+	"gpt-5.6-sol":   1050000, // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+	"gpt-5.6-terra": 1050000, // https://developers.openai.com/api/docs/models/gpt-5.6-terra
+	"gpt-5.6-luna":  1050000, // https://developers.openai.com/api/docs/models/gpt-5.6-luna
+
 	// OpenAI GPT-5.5
 	"gpt-5.5":     1050000, // https://developers.openai.com/api/docs/models/gpt-5.5
 	"gpt-5.5-pro": 1050000, // https://developers.openai.com/api/docs/models/gpt-5.5-pro
@@ -44,6 +50,9 @@ var ModelContextWindows = map[string]int{
 	"gpt-5.4-pro":  1050000, // https://developers.openai.com/api/docs/models/gpt-5.4-pro
 	"gpt-5.4-mini": 400000,  // https://developers.openai.com/api/docs/models/gpt-5.4-mini
 	"gpt-5.4-nano": 400000,  // https://developers.openai.com/api/docs/models/gpt-5.4-nano
+
+	// OpenAI GPT-5.3
+	"gpt-5.3-codex": 400000, // https://developers.openai.com/api/docs/models/gpt-5.3-codex
 
 	// OpenAI GPT-5.2
 	"gpt-5.2":             400000, // https://developers.openai.com/api/docs/models/gpt-5.2
@@ -103,11 +112,17 @@ var ModelContextWindows = map[string]int{
 	"davinci":          2049,
 
 	// Anthropic Claude.
-	// Provider page: https://docs.anthropic.com/en/docs/about-claude/models/overview
-	// Beta context-window header (1M tier on Sonnet 4 / 4.5):
-	//   https://docs.anthropic.com/en/docs/build-with-claude/context-windows
-	// Default windows shown below; 1M on Sonnet 4 / 4.5 requires the
-	// `context-1m-2025-08-07` beta header.
+	// Provider page: https://platform.claude.com/docs/en/about-claude/models/overview
+	// Context windows: https://platform.claude.com/docs/en/build-with-claude/context-windows
+
+	// Anthropic Claude 5
+	"claude-fable-5":  1000000,
+	"claude-mythos-5": 1000000,
+	"claude-sonnet-5": 1000000,
+
+	// Anthropic Claude 4.8
+	"claude-4.8-opus": 1000000,
+	"claude-opus-4-8": 1000000,
 
 	// Anthropic Claude 4.7
 	"claude-4.7-opus": 1000000,
@@ -495,21 +510,25 @@ var ModelContextWindows = map[string]int{
 	// Moonshot Kimi.
 	// Provider page: https://platform.kimi.com/docs/models
 	// Per-family pricing pages:
+	//   - https://platform.kimi.com/docs/pricing/chat-k27-code  (Kimi K2.7 Code)
 	//   - https://platform.kimi.com/docs/pricing/chat-k26  (Kimi K2.6)
 	//   - https://platform.kimi.com/docs/pricing/chat-k25  (Kimi K2.5)
-	//   - https://platform.kimi.com/docs/pricing/chat-k2   (Kimi K2 family; deprecating 2026-05-25)
 	//   - https://platform.kimi.com/docs/pricing/chat-v1   (Moonshot V1)
 	// "256K" on these pages is documented as 256,000 tokens on the pricing
 	// pages and as 262,144 tokens on a few quickstart pages — we use 256,000
 	// for consistency with the pricing/billing page across the family.
 
-	// Kimi K2.6 (current flagship)
+	// Kimi K2.7 Code (current coding flagship)
+	"kimi-k2.7-code":           256000,
+	"kimi-k2.7-code-highspeed": 256000,
+
+	// Kimi K2.6 (current general-purpose flagship)
 	"kimi-k2.6": 256000,
 
 	// Kimi K2.5
 	"kimi-k2.5": 256000,
 
-	// Kimi K2 (scheduled for deprecation 2026-05-25; migrate to k2.6)
+	// Kimi K2 (discontinued 2026-05-25; retained for historical resolution)
 	"kimi-k2-0905-preview":   256000,
 	"kimi-k2-turbo-preview":  256000,
 	"kimi-k2-thinking":       256000,
@@ -627,6 +646,12 @@ var ModelMaxOutputTokens = map[string]int{
 	"o3":         100000, // https://developers.openai.com/api/docs/models/o3
 	"o4-mini":    100000, // https://developers.openai.com/api/docs/models/o4-mini
 
+	// OpenAI GPT-5.6
+	"gpt-5.6":       128000, // Alias for GPT-5.6 Sol — https://developers.openai.com/api/docs/models/gpt-5.6-sol
+	"gpt-5.6-sol":   128000, // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+	"gpt-5.6-terra": 128000, // https://developers.openai.com/api/docs/models/gpt-5.6-terra
+	"gpt-5.6-luna":  128000, // https://developers.openai.com/api/docs/models/gpt-5.6-luna
+
 	// OpenAI GPT-5.5
 	"gpt-5.5":     128000, // https://developers.openai.com/api/docs/models/gpt-5.5
 	"gpt-5.5-pro": 128000, // https://developers.openai.com/api/docs/models/gpt-5.5-pro
@@ -636,6 +661,9 @@ var ModelMaxOutputTokens = map[string]int{
 	"gpt-5.4-pro":  128000, // https://developers.openai.com/api/docs/models/gpt-5.4-pro
 	"gpt-5.4-mini": 128000, // https://developers.openai.com/api/docs/models/gpt-5.4-mini
 	"gpt-5.4-nano": 128000, // https://developers.openai.com/api/docs/models/gpt-5.4-nano
+
+	// OpenAI GPT-5.3
+	"gpt-5.3-codex": 128000, // https://developers.openai.com/api/docs/models/gpt-5.3-codex
 
 	// OpenAI GPT-5.2
 	"gpt-5.2":             128000, // https://developers.openai.com/api/docs/models/gpt-5.2
@@ -673,8 +701,8 @@ var ModelMaxOutputTokens = map[string]int{
 	"gpt-4-turbo": 4096, // https://developers.openai.com/api/docs/models/gpt-4-turbo
 
 	// Anthropic Claude.
-	// Provider page: https://docs.anthropic.com/en/docs/about-claude/models/overview
-	// Migration guide: https://docs.anthropic.com/en/docs/about-claude/models/migration-guide
+	// Provider page: https://platform.claude.com/docs/en/about-claude/models/overview
+	// Migration guide: https://platform.claude.com/docs/en/about-claude/models/migration-guide
 	// The values below are synchronous Messages API limits. Some Batch API
 	// requests can opt into larger beta output caps.
 

--- a/model/internal/model/model_info_test.go
+++ b/model/internal/model/model_info_test.go
@@ -47,6 +47,16 @@ func TestResolveContextWindow(t *testing.T) {
 			expected:  400000,
 		},
 		{
+			name:      "exact match - GPT-5.6 alias",
+			modelName: "gpt-5.6",
+			expected:  1050000,
+		},
+		{
+			name:      "exact match - GPT-5.6 Terra",
+			modelName: "gpt-5.6-terra",
+			expected:  1050000,
+		},
+		{
 			name:      "exact match - GPT-5.4",
 			modelName: "gpt-5.4",
 			expected:  1050000,
@@ -55,6 +65,11 @@ func TestResolveContextWindow(t *testing.T) {
 			name:      "exact match - GPT-5.4-pro",
 			modelName: "gpt-5.4-pro",
 			expected:  1050000,
+		},
+		{
+			name:      "exact match - GPT-5.3-Codex",
+			modelName: "gpt-5.3-codex",
+			expected:  400000,
 		},
 		{
 			name:      "exact match - GPT-5.2-codex",
@@ -89,6 +104,26 @@ func TestResolveContextWindow(t *testing.T) {
 		{
 			name:      "exact match - Claude Sonnet 4.6",
 			modelName: "claude-sonnet-4-6",
+			expected:  1000000,
+		},
+		{
+			name:      "exact match - Claude Fable 5",
+			modelName: "claude-fable-5",
+			expected:  1000000,
+		},
+		{
+			name:      "exact match - Claude Mythos 5",
+			modelName: "claude-mythos-5",
+			expected:  1000000,
+		},
+		{
+			name:      "exact match - Claude Sonnet 5",
+			modelName: "claude-sonnet-5",
+			expected:  1000000,
+		},
+		{
+			name:      "exact match - Claude Opus 4.8 alias",
+			modelName: "claude-opus-4-8",
 			expected:  1000000,
 		},
 		{
@@ -194,6 +229,16 @@ func TestResolveContextWindow(t *testing.T) {
 		{
 			name:      "exact match - Kimi K2.6",
 			modelName: "kimi-k2.6",
+			expected:  256000,
+		},
+		{
+			name:      "exact match - Kimi K2.7 Code",
+			modelName: "kimi-k2.7-code",
+			expected:  256000,
+		},
+		{
+			name:      "exact match - Kimi K2.7 Code HighSpeed",
+			modelName: "kimi-k2.7-code-highspeed",
 			expected:  256000,
 		},
 		{
@@ -539,7 +584,13 @@ func TestResolveMaxOutputTokens(t *testing.T) {
 		{name: "prefix o1-mini snapshot", modelName: "o1-mini-2024-09-12", expected: 65536},
 		{name: "exact gpt-5.2", modelName: "gpt-5.2", expected: 128000},
 		{name: "exact gpt-5.2 chat latest", modelName: "gpt-5.2-chat-latest", expected: 16384},
+		{name: "exact gpt-5.6 alias", modelName: "gpt-5.6", expected: 128000},
+		{name: "exact gpt-5.6 Luna", modelName: "gpt-5.6-luna", expected: 128000},
+		{name: "exact gpt-5.3 Codex", modelName: "gpt-5.3-codex", expected: 128000},
 		{name: "gpt-5.4 mini", modelName: "gpt-5.4-mini", expected: 128000},
+		{name: "claude fable 5", modelName: "claude-fable-5", expected: 128000},
+		{name: "claude mythos 5", modelName: "claude-mythos-5", expected: 128000},
+		{name: "claude sonnet 5", modelName: "claude-sonnet-5", expected: 128000},
 		{name: "claude opus 4.8", modelName: "claude-opus-4-8", expected: 128000},
 		{name: "claude sonnet 4.6", modelName: "claude-sonnet-4-6", expected: 128000},
 		{name: "claude 3.7 sonnet", modelName: "claude-3-7-sonnet-20250219", expected: 64000},


### PR DESCRIPTION
## Summary

- add context and maximum-output metadata for GPT-5.6 Sol, Terra, Luna, the `gpt-5.6` alias, and GPT-5.3-Codex
- add context metadata for Claude Fable 5, Mythos 5, Sonnet 5, and Opus 4.8
- add context metadata for Kimi K2.7 Code and Kimi K2.7 Code HighSpeed
- update Kimi K2 lifecycle comments and extend exact-match coverage for the new entries

## Why

Without explicit entries, context-window resolution falls back to 128K and under-reports the capacity of these recently released models. OpenAI maximum-output resolution also needs explicit coverage for the new GPT model IDs.

The values and model identifiers are based on the providers' current official model documentation.

## Validation

- formatting and import checks
- model package and provider tests
- model metadata package coverage: 92.2%
- targeted reruns for unrelated environment-sensitive root test cases
