### PR TITLE
test(openclaw): avoid OCR timeout executable race

### DIFF
--- a/openclaw/internal/imageinspect/imageinspect_test.go
+++ b/openclaw/internal/imageinspect/imageinspect_test.go
@@ -16,6 +16,7 @@ import (
 	"image/color"
 	"image/png"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -234,17 +235,21 @@ func TestRunOCRTimeout(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cmd := writeShellScript(t, dir, "tesseract-slow", `
+	script := writeShellScript(t, dir, "tesseract-slow", `
 sleep 1
 `)
+	// Invoke the fresh script through sh to avoid Linux ETXTBSY races when a
+	// newly written file is executed directly.
+	shell, err := exec.LookPath("sh")
+	require.NoError(t, err)
 
 	tool, err := newInspector(Config{
 		AllowedDirs:      []string{dir},
-		TesseractCommand: cmd,
+		TesseractCommand: shell,
 		Timeout:          time.Millisecond,
 	})
 	require.NoError(t, err)
-	_, err = tool.runOCR(context.Background(), "sample.png", inspectRequest{})
+	_, err = tool.runOCR(context.Background(), script, inspectRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timed out")
 }


### PR DESCRIPTION
## Summary

- Stabilize `TestRunOCRTimeout` by invoking the generated slow script through the system shell.
- Keep the test focused on the OCR command timeout instead of executable-file creation timing.

## Root cause

GitHub Actions intermittently returned `ETXTBSY` while directly executing the newly written temporary script. That startup error occurred before the expected timeout path and caused the assertion to fail even though the OCR timeout behavior was unchanged.

## Validation

- `go test ./internal/imageinspect -run '^TestRunOCRTimeout$' -count=500`
- `go test -race ./internal/imageinspect -run '^TestRunOCRTimeout$' -count=50`
- `go test ./internal/imageinspect -count=1`

Related CI failure: https://github.com/trpc-group/trpc-agent-go/actions/runs/29221124951/job/86726283768
