### PR TITLE
model: add ToolChoice to GenerationConfig (constrain tool selection without mutating the tool list)

### DIFF
--- a/graph/call_options.go
+++ b/graph/call_options.go
@@ -305,7 +305,8 @@ func isEmptyGenPatch(p model.GenerationConfigPatch) bool {
 		p.ReasoningEffort == nil &&
 		p.ThinkingEnabled == nil &&
 		p.ThinkingTokens == nil &&
-		p.ThinkingLevel == nil
+		p.ThinkingLevel == nil &&
+		p.ToolChoice == nil
 }
 
 func cloneGenPatch(
@@ -355,6 +356,9 @@ func mergeGenPatch(
 	}
 	if override.ThinkingLevel != nil {
 		out.ThinkingLevel = override.ThinkingLevel
+	}
+	if override.ToolChoice != nil {
+		out.ToolChoice = override.ToolChoice
 	}
 	return out
 }

--- a/graph/call_options_test.go
+++ b/graph/call_options_test.go
@@ -82,6 +82,21 @@ func TestWithCallOptions_MergesCustomAgentConfigs(t *testing.T) {
 	require.Equal(t, callOptsTestMaxTokens, *patch.MaxTokens)
 }
 
+func TestWithCallOptions_ToolChoiceOnlyPatchIsPreserved(t *testing.T) {
+	runOpts := agent.RunOptions{}
+	WithCallOptions(
+		WithCallGenerationConfigPatch(model.GenerationConfigPatch{
+			ToolChoice: &model.ToolChoice{Mode: model.ToolChoiceFunction, FunctionName: "get_weather"},
+		}),
+	)(&runOpts)
+
+	opts := graphCallOptionsFromConfigs(runOpts.CustomAgentConfigs)
+	require.NotNil(t, opts)
+	patch := generationPatchForNode(opts, "")
+	require.NotNil(t, patch.ToolChoice)
+	require.Equal(t, "get_weather", patch.ToolChoice.FunctionName)
+}
+
 func TestWithCallOptions_ThinkingLevelOnlyPatchIsPreserved(t *testing.T) {
 	runOpts := agent.RunOptions{}
 	WithCallOptions(

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -283,6 +283,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 
 // buildChatRequest builds the chat request for the Anthropic API.
 func (m *Model) buildChatRequest(request *model.Request) (*anthropic.MessageNewParams, error) {
+	if err := request.ToolChoice.Validate(); err != nil {
+		return nil, err
+	}
 	// Convert messages to Anthropic format.
 	messages, systemPrompts, err := convertMessages(request.Messages)
 	if err != nil {

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -328,6 +328,7 @@ func (m *Model) buildChatRequest(request *model.Request) (*anthropic.MessageNewP
 	if len(request.Stop) > 0 {
 		chatRequest.StopSequences = append(chatRequest.StopSequences, request.Stop...)
 	}
+	applyToolChoice(chatRequest, request.ToolChoice)
 	if err := m.applyThinkingConfig(chatRequest, request); err != nil {
 		return nil, err
 	}
@@ -1434,4 +1435,26 @@ func convertSystemMessageContent(message model.Message) ([]anthropic.TextBlockPa
 		}
 	}
 	return blocks, nil
+}
+
+// applyToolChoice maps the provider-agnostic tool-choice constraint onto
+// Anthropic's tool_choice union. Unknown modes are ignored with a debug log.
+func applyToolChoice(chatRequest *anthropic.MessageNewParams, tc *model.ToolChoice) {
+	if tc == nil {
+		return
+	}
+	switch tc.Mode {
+	case "", model.ToolChoiceAuto:
+		chatRequest.ToolChoice = anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{}}
+	case model.ToolChoiceNone:
+		chatRequest.ToolChoice = anthropic.ToolChoiceUnionParam{OfNone: &anthropic.ToolChoiceNoneParam{}}
+	case model.ToolChoiceRequired:
+		chatRequest.ToolChoice = anthropic.ToolChoiceUnionParam{OfAny: &anthropic.ToolChoiceAnyParam{}}
+	case model.ToolChoiceFunction:
+		chatRequest.ToolChoice = anthropic.ToolChoiceUnionParam{
+			OfTool: &anthropic.ToolChoiceToolParam{Name: tc.FunctionName},
+		}
+	default:
+		log.Debugf("anthropic: unsupported tool choice mode %q, ignoring", tc.Mode)
+	}
 }

--- a/model/anthropic/toolchoice_test.go
+++ b/model/anthropic/toolchoice_test.go
@@ -10,6 +10,8 @@
 package anthropic
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
@@ -51,5 +53,17 @@ func TestApplyToolChoice(t *testing.T) {
 	if req.ToolChoice.OfAuto != nil || req.ToolChoice.OfAny != nil ||
 		req.ToolChoice.OfTool != nil || req.ToolChoice.OfNone != nil {
 		t.Fatalf("unknown mode must be ignored: %+v", req.ToolChoice)
+	}
+}
+
+func TestGenerateContentRejectsEmptyFunctionName(t *testing.T) {
+	m := New("claude-test-model")
+	_, err := m.GenerateContent(context.Background(), &model.Request{
+		GenerationConfig: model.GenerationConfig{
+			ToolChoice: &model.ToolChoice{Mode: model.ToolChoiceFunction},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "function name") {
+		t.Fatalf("empty function name must fail fast with a framework error, got %v", err)
 	}
 }

--- a/model/anthropic/toolchoice_test.go
+++ b/model/anthropic/toolchoice_test.go
@@ -1,0 +1,55 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package anthropic
+
+import (
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestApplyToolChoice(t *testing.T) {
+	req := &anthropic.MessageNewParams{}
+	applyToolChoice(req, nil)
+	if req.ToolChoice.OfAuto != nil || req.ToolChoice.OfAny != nil ||
+		req.ToolChoice.OfTool != nil || req.ToolChoice.OfNone != nil {
+		t.Fatalf("nil tool choice must not set the field: %+v", req.ToolChoice)
+	}
+
+	req = &anthropic.MessageNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: model.ToolChoiceAuto})
+	if req.ToolChoice.OfAuto == nil {
+		t.Fatalf("auto must map to the auto variant: %+v", req.ToolChoice)
+	}
+	req = &anthropic.MessageNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: model.ToolChoiceNone})
+	if req.ToolChoice.OfNone == nil {
+		t.Fatalf("none must map to the none variant: %+v", req.ToolChoice)
+	}
+	req = &anthropic.MessageNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: model.ToolChoiceRequired})
+	if req.ToolChoice.OfAny == nil {
+		t.Fatalf("required must map to the any variant: %+v", req.ToolChoice)
+	}
+	req = &anthropic.MessageNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: model.ToolChoiceFunction, FunctionName: "get_weather"})
+	if req.ToolChoice.OfTool == nil || req.ToolChoice.OfTool.Name != "get_weather" {
+		t.Fatalf("function must map to the named tool variant: %+v", req.ToolChoice)
+	}
+
+	req = &anthropic.MessageNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: "bogus"})
+	if req.ToolChoice.OfAuto != nil || req.ToolChoice.OfAny != nil ||
+		req.ToolChoice.OfTool != nil || req.ToolChoice.OfNone != nil {
+		t.Fatalf("unknown mode must be ignored: %+v", req.ToolChoice)
+	}
+}

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -175,6 +175,9 @@ func (m *Model) GenerateContent(
 	if request == nil {
 		return nil, errors.New("request cannot be nil")
 	}
+	if err := request.ToolChoice.Validate(); err != nil {
+		return nil, err
+	}
 	// Apply token tailoring if configured.
 	m.applyTokenTailoring(ctx, request)
 	chatRequest := m.convertMessages(request.Messages)

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -676,6 +676,7 @@ func (m *Model) buildChatConfig(request *model.Request) *genai.GenerateContentCo
 			},
 		}
 	}
+	applyToolChoice(chatRequest, request.ToolChoice)
 
 	// Set response_format for native structured outputs when requested.
 	if request.StructuredOutput != nil &&
@@ -1019,4 +1020,33 @@ func (m *Model) convertContentPart(part model.ContentPart) *genai.Part {
 		return genai.NewPartFromBytes(part.File.Data, part.File.MimeType)
 	}
 	return nil
+}
+
+// applyToolChoice maps the provider-agnostic tool-choice constraint onto
+// Gemini's function calling config. The "function" mode uses ANY plus
+// AllowedFunctionNames, which is Gemini's way to force one named tool.
+// Unknown modes are ignored with a debug log.
+func applyToolChoice(chatRequest *genai.GenerateContentConfig, tc *model.ToolChoice) {
+	if tc == nil {
+		return
+	}
+	fc := &genai.FunctionCallingConfig{}
+	switch tc.Mode {
+	case "", model.ToolChoiceAuto:
+		fc.Mode = genai.FunctionCallingConfigModeAuto
+	case model.ToolChoiceNone:
+		fc.Mode = genai.FunctionCallingConfigModeNone
+	case model.ToolChoiceRequired:
+		fc.Mode = genai.FunctionCallingConfigModeAny
+	case model.ToolChoiceFunction:
+		fc.Mode = genai.FunctionCallingConfigModeAny
+		fc.AllowedFunctionNames = []string{tc.FunctionName}
+	default:
+		log.Debugf("gemini: unsupported tool choice mode %q, ignoring", tc.Mode)
+		return
+	}
+	if chatRequest.ToolConfig == nil {
+		chatRequest.ToolConfig = &genai.ToolConfig{}
+	}
+	chatRequest.ToolConfig.FunctionCallingConfig = fc
 }

--- a/model/gemini/toolchoice_test.go
+++ b/model/gemini/toolchoice_test.go
@@ -1,0 +1,57 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package gemini
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestApplyToolChoice(t *testing.T) {
+	cfg := &genai.GenerateContentConfig{}
+	applyToolChoice(cfg, nil)
+	if cfg.ToolConfig != nil {
+		t.Fatalf("nil tool choice must not touch ToolConfig: %+v", cfg.ToolConfig)
+	}
+
+	for mode, want := range map[string]genai.FunctionCallingConfigMode{
+		"":                       genai.FunctionCallingConfigModeAuto,
+		model.ToolChoiceAuto:     genai.FunctionCallingConfigModeAuto,
+		model.ToolChoiceNone:     genai.FunctionCallingConfigModeNone,
+		model.ToolChoiceRequired: genai.FunctionCallingConfigModeAny,
+	} {
+		cfg := &genai.GenerateContentConfig{}
+		applyToolChoice(cfg, &model.ToolChoice{Mode: mode})
+		if cfg.ToolConfig == nil || cfg.ToolConfig.FunctionCallingConfig.Mode != want {
+			t.Fatalf("mode %q: got %+v want %v", mode, cfg.ToolConfig, want)
+		}
+	}
+
+	// function mode: ANY + allowed names; existing ToolConfig preserved.
+	cfg = &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{
+		FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeAuto},
+	}}
+	applyToolChoice(cfg, &model.ToolChoice{Mode: model.ToolChoiceFunction, FunctionName: "get_weather"})
+	fc := cfg.ToolConfig.FunctionCallingConfig
+	if fc.Mode != genai.FunctionCallingConfigModeAny || len(fc.AllowedFunctionNames) != 1 ||
+		fc.AllowedFunctionNames[0] != "get_weather" {
+		t.Fatalf("function mode mapping wrong: %+v", fc)
+	}
+
+	// Unknown mode: ignored, existing config untouched.
+	cfg = &genai.GenerateContentConfig{}
+	applyToolChoice(cfg, &model.ToolChoice{Mode: "bogus"})
+	if cfg.ToolConfig != nil {
+		t.Fatalf("unknown mode must be ignored: %+v", cfg.ToolConfig)
+	}
+}

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -798,6 +798,7 @@ func (m *Model) buildChatRequest(request *model.Request) (*openai.ChatCompletion
 	if request.ReasoningEffort != nil {
 		chatRequest.ReasoningEffort = shared.ReasoningEffort(*request.ReasoningEffort)
 	}
+	applyToolChoice(chatRequest, request.ToolChoice)
 	opts := m.buildThinkingOption(request)
 	// Add model-level extra fields to the request.
 	for key, value := range m.extraFields {
@@ -3086,4 +3087,35 @@ func normalizeEmbeddedErrorCode(raw json.RawMessage) string {
 		return n.String()
 	}
 	return ""
+}
+
+// applyToolChoice maps the provider-agnostic tool-choice constraint onto the
+// OpenAI-compatible tool_choice field. Unknown modes are ignored with a debug
+// log so requests keep working against adapters/providers that predate a mode.
+func applyToolChoice(chatRequest *openai.ChatCompletionNewParams, tc *model.ToolChoice) {
+	if tc == nil {
+		return
+	}
+	switch tc.Mode {
+	case "", model.ToolChoiceAuto:
+		chatRequest.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("auto"),
+		}
+	case model.ToolChoiceNone:
+		chatRequest.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("none"),
+		}
+	case model.ToolChoiceRequired:
+		chatRequest.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("required"),
+		}
+	case model.ToolChoiceFunction:
+		chatRequest.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfChatCompletionNamedToolChoice: &openai.ChatCompletionNamedToolChoiceParam{
+				Function: openai.ChatCompletionNamedToolChoiceFunctionParam{Name: tc.FunctionName},
+			},
+		}
+	default:
+		log.Debugf("openai: unsupported tool choice mode %q, ignoring", tc.Mode)
+	}
 }

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -469,6 +469,9 @@ func (m *Model) prepareChatRequest(
 	if err := validateLogprobsConfig(request); err != nil {
 		return nil, nil, err
 	}
+	if err := request.ToolChoice.Validate(); err != nil {
+		return nil, nil, err
+	}
 	// Optimize message structure for cache if enabled.
 	if m.optimizeForCache {
 		request.Messages = m.optimizeMessagesForCache(request.Messages)

--- a/model/openai/toolchoice_test.go
+++ b/model/openai/toolchoice_test.go
@@ -1,0 +1,52 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package openai
+
+import (
+	"testing"
+
+	openai "github.com/openai/openai-go"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestApplyToolChoice(t *testing.T) {
+	// nil leaves the field untouched (provider default).
+	req := &openai.ChatCompletionNewParams{}
+	applyToolChoice(req, nil)
+	if req.ToolChoice.OfAuto.Valid() || req.ToolChoice.OfChatCompletionNamedToolChoice != nil {
+		t.Fatalf("nil tool choice must not set the field: %+v", req.ToolChoice)
+	}
+
+	for mode, want := range map[string]string{
+		"": "auto", model.ToolChoiceAuto: "auto",
+		model.ToolChoiceNone: "none", model.ToolChoiceRequired: "required",
+	} {
+		req := &openai.ChatCompletionNewParams{}
+		applyToolChoice(req, &model.ToolChoice{Mode: mode})
+		if got := req.ToolChoice.OfAuto.Value; got != want {
+			t.Fatalf("mode %q: got %q want %q", mode, got, want)
+		}
+	}
+
+	req = &openai.ChatCompletionNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: model.ToolChoiceFunction, FunctionName: "get_weather"})
+	named := req.ToolChoice.OfChatCompletionNamedToolChoice
+	if named == nil || named.Function.Name != "get_weather" {
+		t.Fatalf("function mode must set the named tool: %+v", req.ToolChoice)
+	}
+
+	// Unknown mode: ignored, no panic, field untouched.
+	req = &openai.ChatCompletionNewParams{}
+	applyToolChoice(req, &model.ToolChoice{Mode: "bogus"})
+	if req.ToolChoice.OfAuto.Valid() || req.ToolChoice.OfChatCompletionNamedToolChoice != nil {
+		t.Fatalf("unknown mode must be ignored: %+v", req.ToolChoice)
+	}
+}

--- a/model/openai/toolchoice_test.go
+++ b/model/openai/toolchoice_test.go
@@ -10,6 +10,8 @@
 package openai
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	openai "github.com/openai/openai-go"
@@ -48,5 +50,17 @@ func TestApplyToolChoice(t *testing.T) {
 	applyToolChoice(req, &model.ToolChoice{Mode: "bogus"})
 	if req.ToolChoice.OfAuto.Valid() || req.ToolChoice.OfChatCompletionNamedToolChoice != nil {
 		t.Fatalf("unknown mode must be ignored: %+v", req.ToolChoice)
+	}
+}
+
+func TestGenerateContentRejectsEmptyFunctionName(t *testing.T) {
+	m := New("default-model")
+	_, err := m.GenerateContent(context.Background(), &model.Request{
+		GenerationConfig: model.GenerationConfig{
+			ToolChoice: &model.ToolChoice{Mode: model.ToolChoiceFunction},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "function name") {
+		t.Fatalf("empty function name must fail fast with a framework error, got %v", err)
 	}
 }

--- a/model/request.go
+++ b/model/request.go
@@ -456,6 +456,50 @@ type GenerationConfig struct {
 	// ThinkingLevel controls the qualitative thinking level for providers that support it.
 	// Gemini 3 uses this field for thinkingConfig.thinkingLevel.
 	ThinkingLevel *string `json:"thinking_level,omitempty"`
+
+	// ToolChoice constrains which tool the model may call for this request
+	// without changing Tools. Keeping the Tools slice stable preserves the
+	// provider's prompt-cache prefix (the tools block renders first in the
+	// request) and avoids confusing the model when history references a tool
+	// that is no longer listed.
+	//
+	// nil means provider default (equivalent to "auto"). Adapters that cannot
+	// express a requested mode ignore the field and log at debug level.
+	//
+	// Note: ToolChoiceRequired and ToolChoiceFunction stay in effect for every
+	// subsequent request until cleared — a forced choice left set after the
+	// tool result loops the model forever. Callers that force a tool for one
+	// step (e.g. from a BeforeModel callback) must reset the field afterwards.
+	ToolChoice *ToolChoice `json:"tool_choice,omitempty"`
+}
+
+// Tool choice modes understood by ToolChoice.Mode.
+const (
+	// ToolChoiceAuto lets the model decide freely (provider default).
+	ToolChoiceAuto = "auto"
+	// ToolChoiceNone forbids tool calls for this request.
+	ToolChoiceNone = "none"
+	// ToolChoiceRequired forces the model to call some tool.
+	ToolChoiceRequired = "required"
+	// ToolChoiceFunction forces the model to call one named tool.
+	ToolChoiceFunction = "function"
+)
+
+// ToolChoice constrains tool selection for one request without mutating the
+// tool list. Provider mapping:
+//
+//	Mode       OpenAI-compatible   Anthropic          Gemini
+//	auto       "auto"              {"type":"auto"}    mode AUTO
+//	none       "none"              {"type":"none"}    mode NONE
+//	required   "required"          {"type":"any"}     mode ANY
+//	function   named function      {"type":"tool"}    mode ANY + allowed_function_names
+type ToolChoice struct {
+	// Mode is one of ToolChoiceAuto, ToolChoiceNone, ToolChoiceRequired or
+	// ToolChoiceFunction. The zero value behaves like ToolChoiceAuto.
+	Mode string `json:"mode"`
+	// FunctionName names the forced tool. Required when Mode is
+	// ToolChoiceFunction, ignored otherwise.
+	FunctionName string `json:"function_name,omitempty"`
 }
 
 // GenerationConfigPatch selectively overrides fields in GenerationConfig.
@@ -482,6 +526,9 @@ type GenerationConfigPatch struct {
 	ThinkingEnabled  *bool    `json:"thinking_enabled,omitempty"`
 	ThinkingTokens   *int     `json:"thinking_tokens,omitempty"`
 	ThinkingLevel    *string  `json:"thinking_level,omitempty"`
+	// ToolChoice overrides the tool-choice constraint. nil means "do not
+	// override"; a pointer to the zero value resets the constraint to auto.
+	ToolChoice *ToolChoice `json:"tool_choice,omitempty"`
 }
 
 // ApplyGenerationConfigPatch applies patch to base and returns the merged
@@ -528,6 +575,9 @@ func ApplyGenerationConfigPatch(
 	}
 	if patch.ThinkingLevel != nil {
 		base.ThinkingLevel = patch.ThinkingLevel
+	}
+	if patch.ToolChoice != nil {
+		base.ToolChoice = patch.ToolChoice
 	}
 	return base
 }

--- a/model/request.go
+++ b/model/request.go
@@ -11,6 +11,7 @@ package model
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -500,6 +501,22 @@ type ToolChoice struct {
 	// FunctionName names the forced tool. Required when Mode is
 	// ToolChoiceFunction, ignored otherwise.
 	FunctionName string `json:"function_name,omitempty"`
+}
+
+// Validate rejects tool-choice values that no provider can accept. It is
+// nil-safe so adapters can call it unconditionally. Unknown modes are NOT
+// rejected here — adapters ignore them with a debug log so newer modes can
+// degrade gracefully on older adapters; an empty function name in function
+// mode is invalid everywhere and fails fast with a deterministic error
+// instead of a provider-side one.
+func (tc *ToolChoice) Validate() error {
+	if tc == nil {
+		return nil
+	}
+	if tc.Mode == ToolChoiceFunction && strings.TrimSpace(tc.FunctionName) == "" {
+		return errors.New("tool_choice: function mode requires a non-empty function name")
+	}
+	return nil
 }
 
 // GenerationConfigPatch selectively overrides fields in GenerationConfig.

--- a/model/request_test.go
+++ b/model/request_test.go
@@ -1194,3 +1194,32 @@ func TestApplyGenerationConfigPatchToolChoice(t *testing.T) {
 		t.Fatalf("zero-value patch must reset the constraint, got %+v", got.ToolChoice)
 	}
 }
+
+func TestToolChoiceValidate(t *testing.T) {
+	var nilTC *ToolChoice
+	if err := nilTC.Validate(); err != nil {
+		t.Fatalf("nil tool choice must validate: %v", err)
+	}
+	ok := []*ToolChoice{
+		{},
+		{Mode: ToolChoiceAuto},
+		{Mode: ToolChoiceNone},
+		{Mode: ToolChoiceRequired},
+		{Mode: ToolChoiceFunction, FunctionName: "get_weather"},
+		{Mode: "future-mode"}, // unknown modes degrade at the adapter, not here
+	}
+	for _, tc := range ok {
+		if err := tc.Validate(); err != nil {
+			t.Fatalf("%+v must validate: %v", tc, err)
+		}
+	}
+	bad := []*ToolChoice{
+		{Mode: ToolChoiceFunction},
+		{Mode: ToolChoiceFunction, FunctionName: "   "},
+	}
+	for _, tc := range bad {
+		if err := tc.Validate(); err == nil {
+			t.Fatalf("%+v must be rejected", tc)
+		}
+	}
+}

--- a/model/request_test.go
+++ b/model/request_test.go
@@ -1173,3 +1173,24 @@ func TestRole_ToolRole(t *testing.T) {
 	assert.Equal(t, "tool", role.String())
 	assert.True(t, role.IsValid())
 }
+
+func TestApplyGenerationConfigPatchToolChoice(t *testing.T) {
+	base := GenerationConfig{}
+	// nil patch field: do not override.
+	got := ApplyGenerationConfigPatch(base, GenerationConfigPatch{})
+	if got.ToolChoice != nil {
+		t.Fatalf("nil patch must not set ToolChoice, got %+v", got.ToolChoice)
+	}
+	// pointer patch overrides.
+	forced := &ToolChoice{Mode: ToolChoiceFunction, FunctionName: "get_weather"}
+	got = ApplyGenerationConfigPatch(base, GenerationConfigPatch{ToolChoice: forced})
+	if got.ToolChoice == nil || got.ToolChoice.FunctionName != "get_weather" {
+		t.Fatalf("patch must override ToolChoice, got %+v", got.ToolChoice)
+	}
+	// zero-value pointer resets to auto semantics.
+	base.ToolChoice = forced
+	got = ApplyGenerationConfigPatch(base, GenerationConfigPatch{ToolChoice: &ToolChoice{}})
+	if got.ToolChoice == nil || got.ToolChoice.Mode != "" {
+		t.Fatalf("zero-value patch must reset the constraint, got %+v", got.ToolChoice)
+	}
+}


### PR DESCRIPTION
## What changed

Adds a provider-agnostic way to constrain which tool the model may call for a request, without mutating the `Tools` slice:

- `model.ToolChoice{Mode, FunctionName}` with four modes — `auto`, `none`, `required`, `function` — plus mode constants.
- `GenerationConfig.ToolChoice *ToolChoice` and a matching `GenerationConfigPatch.ToolChoice` entry (nil = do not override).
- Provider mappings:

| Mode | OpenAI-compatible | Anthropic | Gemini |
|---|---|---|---|
| auto | `"auto"` | `{"type":"auto"}` | mode `AUTO` |
| none | `"none"` | `{"type":"none"}` | mode `NONE` |
| required | `"required"` | `{"type":"any"}` | mode `ANY` |
| function | named function | `{"type":"tool","name":N}` | mode `ANY` + `allowed_function_names:[N]` |

Adapters that cannot express a requested mode ignore the field with a debug log. Static use goes through `llmagent.WithGenerationConfig`; per-step forcing needs no new hooks — a `BeforeModel` callback already mutates the request:

```go
req.GenerationConfig.ToolChoice = &model.ToolChoice{
    Mode: model.ToolChoiceFunction, FunctionName: approvedTool,
}
```

## Why

Today the only way to constrain tool selection is to add/remove entries in `Tools` per turn, which:

- invalidates the whole prompt-cache prefix (the tools block renders first in the request);
- confuses the model when history references a tool that is no longer listed.

All three major wire protocols already express this as a request field (OpenAI-compatible `tool_choice`, Anthropic `tool_choice`, Gemini `function_calling_config`); `server/openai`'s converter even parses it on the serving side — there was just no way to set it on an outgoing request.

Compatibility: additive only. The field defaults to nil (provider default), no existing behavior changes. Prior art: adk-python has the same gap open (google/adk-python#773); its interim answer — passing Gemini's native `tool_config` through — doesn't translate across providers.

## Testing

- `go test ./model/...` (root module) — includes new `TestApplyToolChoice` (openai) and `TestApplyGenerationConfigPatchToolChoice`.
- `cd model/anthropic && go test ./...` and `cd model/gemini && go test ./...` — new `TestApplyToolChoice` in each, all four modes + nil safety + unknown-mode no-op.
- `go build ./... && go vet ./model/...`, `gofmt -l` clean on touched files.

## Notes for reviewers

- Public API addition (`model.ToolChoice`, one field on `GenerationConfig` and on `GenerationConfigPatch`) — names follow the wire-protocol vocabulary.
- `required`/`function` left set after a tool result loops the model forever; the godoc warns that per-step forcing belongs in a callback that resets the field. Auto-clearing was deliberately not implemented (it would surprise callers who set it statically on purpose).
- Gemini's `function` mode maps to `ANY` + a single `AllowedFunctionNames` entry; multi-name allowlists are a possible follow-up but providers diverge there, so the first cut keeps the four portable modes only.
- Adapters not mapped in this PR (ollama/huggingface/hunyuan/bedrock) ignore the field; happy to follow up per adapter if the direction is agreed.
