### PR TITLE
model/openai: reduce logprob byte allocations

### DIFF
--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -2644,32 +2644,53 @@ func convertChatCompletionChoiceLogprobs(
 		Content: make([]model.TokenLogprob, len(logprobs.Content)),
 	}
 	for i, token := range logprobs.Content {
-		converted.Content[i] = model.TokenLogprob{
-			Token:       token.Token,
-			Logprob:     token.Logprob,
-			Bytes:       int64SliceToIntSlice(token.Bytes),
-			TopLogprobs: make([]model.TopLogprob, len(token.TopLogprobs)),
-		}
-		for j, top := range token.TopLogprobs {
-			converted.Content[i].TopLogprobs[j] = model.TopLogprob{
-				Token:   top.Token,
-				Logprob: top.Logprob,
-				Bytes:   int64SliceToIntSlice(top.Bytes),
-			}
-		}
+		converted.Content[i] = convertChatCompletionTokenLogprob(token)
 	}
 	return converted
 }
 
-func int64SliceToIntSlice(values []int64) []int {
-	if values == nil {
-		return nil
+func convertChatCompletionTokenLogprob(
+	token openai.ChatCompletionTokenLogprob,
+) model.TokenLogprob {
+	totalBytes := len(token.Bytes)
+	for _, top := range token.TopLogprobs {
+		totalBytes += len(top.Bytes)
 	}
-	converted := make([]int, len(values))
-	for i, value := range values {
-		converted[i] = int(value)
+	bytesArena := make([]int, totalBytes)
+	bytesOffset := 0
+
+	converted := model.TokenLogprob{
+		Token:       token.Token,
+		Logprob:     token.Logprob,
+		TopLogprobs: make([]model.TopLogprob, len(token.TopLogprobs)),
+	}
+	converted.Bytes, bytesOffset = copyLogprobBytes(bytesArena, bytesOffset, token.Bytes)
+	for i, top := range token.TopLogprobs {
+		converted.TopLogprobs[i] = model.TopLogprob{
+			Token:   top.Token,
+			Logprob: top.Logprob,
+		}
+		converted.TopLogprobs[i].Bytes, bytesOffset = copyLogprobBytes(
+			bytesArena,
+			bytesOffset,
+			top.Bytes,
+		)
 	}
 	return converted
+}
+
+func copyLogprobBytes(arena []int, offset int, values []int64) ([]int, int) {
+	if values == nil {
+		return nil, offset
+	}
+	start := offset
+	for i, value := range values {
+		arena[start+i] = int(value)
+	}
+	offset += len(values)
+	// Limit capacity so appending to one token's bytes cannot overwrite the
+	// adjacent bytes stored in the same arena.
+	return arena[start:offset:offset], offset
 }
 
 // FileOptions is the options for file operations.

--- a/model/openai/openai_logprobs_benchmark_test.go
+++ b/model/openai/openai_logprobs_benchmark_test.go
@@ -1,0 +1,107 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package openai
+
+import (
+	"testing"
+
+	openaigo "github.com/openai/openai-go"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	benchmarkLogprobTokens = 1024
+	benchmarkTopLogprobs   = 20
+)
+
+var benchmarkLogprobsResult *model.Logprobs
+
+func BenchmarkConvertChatCompletionChoiceLogprobs(b *testing.B) {
+	logprobs := benchmarkChoiceLogprobs(benchmarkLogprobTokens, benchmarkTopLogprobs)
+
+	b.Run("per_slice_allocations", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkLogprobsResult = convertChatCompletionChoiceLogprobsPerSlice(logprobs)
+		}
+	})
+
+	b.Run("per_token_bytes_arena", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkLogprobsResult = convertChatCompletionChoiceLogprobs(logprobs)
+		}
+	})
+}
+
+func benchmarkChoiceLogprobs(
+	tokenCount int,
+	topLogprobs int,
+) openaigo.ChatCompletionChoiceLogprobs {
+	content := make([]openaigo.ChatCompletionTokenLogprob, tokenCount)
+	for i := range content {
+		top := make([]openaigo.ChatCompletionTokenLogprobTopLogprob, topLogprobs)
+		for j := range top {
+			top[j] = openaigo.ChatCompletionTokenLogprobTopLogprob{
+				Token:   "alternative",
+				Logprob: -float64(j + 1),
+				Bytes:   []int64{97, 108, 116, 10},
+			}
+		}
+		content[i] = openaigo.ChatCompletionTokenLogprob{
+			Token:       "token",
+			Logprob:     -0.1,
+			Bytes:       []int64{116, 111, 107, 101, 110},
+			TopLogprobs: top,
+		}
+	}
+	return openaigo.ChatCompletionChoiceLogprobs{Content: content}
+}
+
+// convertChatCompletionChoiceLogprobsPerSlice preserves the previous
+// implementation as a benchmark baseline. It allocates a separate []int for
+// every generated token and top-logprob candidate.
+func convertChatCompletionChoiceLogprobsPerSlice(
+	logprobs openaigo.ChatCompletionChoiceLogprobs,
+) *model.Logprobs {
+	if len(logprobs.Content) == 0 {
+		return nil
+	}
+	converted := &model.Logprobs{
+		Content: make([]model.TokenLogprob, len(logprobs.Content)),
+	}
+	for i, token := range logprobs.Content {
+		converted.Content[i] = model.TokenLogprob{
+			Token:       token.Token,
+			Logprob:     token.Logprob,
+			Bytes:       convertLogprobBytesPerSlice(token.Bytes),
+			TopLogprobs: make([]model.TopLogprob, len(token.TopLogprobs)),
+		}
+		for j, top := range token.TopLogprobs {
+			converted.Content[i].TopLogprobs[j] = model.TopLogprob{
+				Token:   top.Token,
+				Logprob: top.Logprob,
+				Bytes:   convertLogprobBytesPerSlice(top.Bytes),
+			}
+		}
+	}
+	return converted
+}
+
+func convertLogprobBytesPerSlice(values []int64) []int {
+	if values == nil {
+		return nil
+	}
+	converted := make([]int, len(values))
+	for i, value := range values {
+		converted[i] = int(value)
+	}
+	return converted
+}

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -4904,6 +4904,7 @@ func TestConvertChatCompletionChoiceLogprobs(t *testing.T) {
 				Bytes:   []int64{65},
 				TopLogprobs: []openaigo.ChatCompletionTokenLogprobTopLogprob{
 					{Token: "B", Logprob: -0.2, Bytes: []int64{66}},
+					{Token: "C", Logprob: -0.3, Bytes: []int64{67, 68}},
 				},
 			},
 		},
@@ -4913,10 +4914,25 @@ func TestConvertChatCompletionChoiceLogprobs(t *testing.T) {
 	assert.Equal(t, "A", got.Content[0].Token)
 	assert.Equal(t, -0.1, got.Content[0].Logprob)
 	assert.Equal(t, []int{65}, got.Content[0].Bytes)
-	require.Len(t, got.Content[0].TopLogprobs, 1)
+	require.Len(t, got.Content[0].TopLogprobs, 2)
 	assert.Equal(t, "B", got.Content[0].TopLogprobs[0].Token)
 	assert.Equal(t, []int{66}, got.Content[0].TopLogprobs[0].Bytes)
-	assert.Nil(t, int64SliceToIntSlice(nil))
+	assert.Equal(t, []int{67, 68}, got.Content[0].TopLogprobs[1].Bytes)
+
+	// Each view has capped capacity, so appending cannot overwrite the
+	// neighboring bytes stored in the shared per-token arena.
+	got.Content[0].Bytes = append(got.Content[0].Bytes, 99)
+	assert.Equal(t, []int{66}, got.Content[0].TopLogprobs[0].Bytes)
+	assert.Equal(t, []int{67, 68}, got.Content[0].TopLogprobs[1].Bytes)
+	got.Content[0].TopLogprobs[0].Bytes = append(
+		got.Content[0].TopLogprobs[0].Bytes,
+		100,
+	)
+	assert.Equal(t, []int{67, 68}, got.Content[0].TopLogprobs[1].Bytes)
+
+	assert.Nil(t, convertChatCompletionChoiceLogprobs(
+		openaigo.ChatCompletionChoiceLogprobs{},
+	))
 }
 
 // TestConvertUserMessageContent_WithImage tests image content conversion.


### PR DESCRIPTION
## Summary
- allocate one bytes arena per generated token for its token and top-logprob byte views
- cap each view's capacity so appends cannot overwrite adjacent arena data
- add a benchmark against the previous per-slice conversion; allocations drop from 22,530 to 2,050 per operation and runtime improves by about 23% for 1,024 tokens with 20 alternatives

## Test plan
- [x] `go test ./model/openai -count=1`
- [x] `go test ./model/openai -run '^$' -bench '^BenchmarkConvertChatCompletionChoiceLogprobs$' -benchmem -count=3`
- [x] GLM smoke test with `top_logprobs=20` (32 generated tokens, 640 alternatives, 672 byte views validated)

Made with [Cursor](https://cursor.com)