### PR TITLE
session/mysql: handle second-precision event timestamps

### DIFF
--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -305,6 +305,67 @@ func TestGetEventsList(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("KeepsEventTruncatedToSessionCreationSecond", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		s := createTestService(t, db)
+		key := session.Key{AppName: "app1", UserID: "user1", SessionID: "sess1"}
+		sessionCreatedAt := time.Date(2026, time.July, 13, 19, 2, 24, 222256000, time.UTC)
+		eventCreatedAt := sessionCreatedAt.Truncate(time.Second)
+		evt := event.NewResponseEvent("inv-1", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "user message"}}},
+		})
+		evtBytes, err := json.Marshal(evt)
+		require.NoError(t, err)
+
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(key.AppName, key.UserID, key.SessionID, evtBytes, eventCreatedAt)
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+			WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
+			WillReturnRows(rows)
+
+		result, err := s.getEventsList(
+			context.Background(), []session.Key{key}, []time.Time{sessionCreatedAt}, 0, time.Time{}, nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Len(t, result[0], 1)
+		assert.Equal(t, "inv-1", result[0][0].InvocationID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("DropsEventBeforeSessionCreationSecond", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		s := createTestService(t, db)
+		key := session.Key{AppName: "app1", UserID: "user1", SessionID: "sess1"}
+		sessionCreatedAt := time.Date(2026, time.July, 13, 19, 2, 24, 222256000, time.UTC)
+		eventCreatedAt := sessionCreatedAt.Truncate(time.Second).Add(-time.Second)
+		evt := event.NewResponseEvent("inv-old", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "old user message"}}},
+		})
+		evtBytes, err := json.Marshal(evt)
+		require.NoError(t, err)
+
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
+			AddRow(key.AppName, key.UserID, key.SessionID, evtBytes, eventCreatedAt)
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+			WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
+			WillReturnRows(rows)
+
+		result, err := s.getEventsList(
+			context.Background(), []session.Key{key}, []time.Time{sessionCreatedAt}, 0, time.Time{}, nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Empty(t, result[0])
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
 	t.Run("WithLimit", func(t *testing.T) {
 		db, mock, err := sqlmock.New()
 		require.NoError(t, err)
@@ -489,7 +550,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(10), newer).
 			AddRow(int64(11), older)
 		mock.ExpectQuery("SELECT id, created_at FROM").
-			WithArgs("app1", "user1", "sess1", createdAt, 2, 1).
+			WithArgs("app1", "user1", "sess1", sessionEventBoundary(createdAt), 2, 1).
 			WillReturnRows(idRows)
 
 		// Phase 2: fetch events by IDs. Return order is deliberately not the
@@ -543,7 +604,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(2), now.Add(-time.Minute)).
 			AddRow(int64(1), now.Add(-2*time.Minute))
 		mock.ExpectQuery("SELECT id, created_at FROM").
-			WithArgs("app1", "user1", "sess1", createdAt, 3, 0).
+			WithArgs("app1", "user1", "sess1", sessionEventBoundary(createdAt), 3, 0).
 			WillReturnRows(idRows)
 
 		eventRows := sqlmock.NewRows([]string{"id", "event"}).
@@ -589,7 +650,7 @@ func TestGetEventsList(t *testing.T) {
 			AddRow(int64(10), newer).
 			AddRow(int64(11), older)
 		mock.ExpectQuery("SELECT id, created_at FROM").
-			WithArgs("app1", "user1", "sess1", createdAt, 2, 1).
+			WithArgs("app1", "user1", "sess1", sessionEventBoundary(createdAt), 2, 1).
 			WillReturnRows(idRows)
 
 		eventRows := sqlmock.NewRows([]string{"id", "event"}).
@@ -766,7 +827,7 @@ func TestGetSessionEvents_DelegatesToPagedEvents(t *testing.T) {
 	evt2Bytes, _ := json.Marshal(evt2)
 
 	mock.ExpectQuery("SELECT id, created_at FROM").
-		WithArgs(key.AppName, key.UserID, key.SessionID, createdAt, 2, 0).
+		WithArgs(key.AppName, key.UserID, key.SessionID, sessionEventBoundary(createdAt), 2, 0).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).
 			AddRow(int64(2), newer).
 			AddRow(int64(1), older))
@@ -891,7 +952,7 @@ func TestLimitedEventHelpers_ErrorsAndBoundaries(t *testing.T) {
 
 		s := createTestService(t, db)
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at FROM session_events")).
-			WithArgs(key.AppName, key.UserID, key.SessionID, createdAt, userAnchorSearchBatchSize).
+			WithArgs(key.AppName, key.UserID, key.SessionID, sessionEventBoundary(createdAt), userAnchorSearchBatchSize).
 			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
 
 		anchor, ok, err := s.getLastUserEventBeforeRefs(

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -612,6 +612,19 @@ func (s *Service) deleteSessionState(ctx context.Context, key session.Key) error
 	return nil
 }
 
+// eventPredatesSession reports whether an event belongs to an earlier
+// incarnation of a session. Some existing MySQL schemas store event times at
+// second precision while session state times retain microseconds. Normalize
+// the session boundary to the lower precision so an event created in the same
+// second is not incorrectly discarded.
+func sessionEventBoundary(sessionCreatedAt time.Time) time.Time {
+	return sessionCreatedAt.Truncate(time.Second)
+}
+
+func eventPredatesSession(eventCreatedAt, sessionCreatedAt time.Time) bool {
+	return eventCreatedAt.Before(sessionEventBoundary(sessionCreatedAt))
+}
+
 // getEventsList loads events for multiple sessions in batch.
 // sessionCreatedAts is used to filter out events created before the session was (re)created,
 // which handles the case where an expired session is overwritten but old events still exist.
@@ -685,7 +698,7 @@ func (s *Service) getEventsList(
 		keyStr := fmt.Sprintf("%s:%s:%s", appName, userID, sessionID)
 
 		if sessCreatedAt, ok := sessionCreatedAtMap[keyStr]; ok {
-			if eventCreatedAt.Before(sessCreatedAt) {
+			if eventPredatesSession(eventCreatedAt, sessCreatedAt) {
 				return nil
 			}
 		}
@@ -743,7 +756,7 @@ func (s *Service) getLimitedSessionEvents(
 	if filterAfterTime.IsZero() && s.opts.sessionTTL > 0 {
 		filterAfterTime = time.Now().Add(-s.opts.sessionTTL)
 	}
-	queryAfterTime := maxTime(filterAfterTime, sessionCreatedAt)
+	queryAfterTime := maxTime(filterAfterTime, sessionEventBoundary(sessionCreatedAt))
 
 	refs, err := s.getRecentEventRefs(ctx, key, queryAfterTime, restoreAfterTime, limit)
 	if err != nil {
@@ -1008,6 +1021,7 @@ func (s *Service) getPreviousEventRefs(
 	eventAfterTime time.Time,
 	before *eventRef,
 ) ([]eventRef, error) {
+	sessionCreatedAt = sessionEventBoundary(sessionCreatedAt)
 	if !eventAfterTime.IsZero() {
 		return s.getEventRefsWithTimestamp(
 			ctx,
@@ -1169,8 +1183,9 @@ func (s *Service) getPagedEvents(
 	if afterTime.IsZero() && s.opts.sessionTTL > 0 {
 		afterTime = time.Now().Add(-s.opts.sessionTTL)
 	}
-	if sessionCreatedAt.After(afterTime) {
-		afterTime = sessionCreatedAt
+	sessionBoundary := sessionEventBoundary(sessionCreatedAt)
+	if sessionBoundary.After(afterTime) {
+		afterTime = sessionBoundary
 	}
 
 	// Phase 1: fetch only ordering metadata with ORDER BY + LIMIT/OFFSET.

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -406,7 +406,7 @@ func TestGetSession_SummaryAwareRestoreFallsBackToCreatedAtWhenEventTimestampMis
 	legacyBytes := marshalEventWithoutTimestamp(t, legacy)
 	eventCreatedAt := cutoff.Add(time.Minute)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, created_at, JSON_UNQUOTE(JSON_EXTRACT(event, '$.timestamp')) FROM session_events")).
-		WithArgs(key.AppName, key.UserID, key.SessionID, sessState.CreatedAt, defaultSessionEventLimit).
+		WithArgs(key.AppName, key.UserID, key.SessionID, sessionEventBoundary(sessState.CreatedAt), defaultSessionEventLimit).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "event_timestamp"}).
 			AddRow(int64(1), eventCreatedAt, nil))
 	expectEventsByRefs(
@@ -567,7 +567,7 @@ func TestGetSession_SummaryAwareRestoreIgnoredForEventPage(t *testing.T) {
 	require.NoError(t, err)
 	eventCreatedAt := sessState.CreatedAt.Add(time.Minute)
 	mock.ExpectQuery("SELECT id, created_at FROM").
-		WithArgs(key.AppName, key.UserID, key.SessionID, sessState.CreatedAt, 1, 0).
+		WithArgs(key.AppName, key.UserID, key.SessionID, sessionEventBoundary(sessState.CreatedAt), 1, 0).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).
 			AddRow(int64(1), eventCreatedAt))
 	expectEventsByRefs(

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -128,6 +128,9 @@ func expectLimitedEventRefs(
 	limit int,
 	refs ...eventRef,
 ) *sqlmock.ExpectedQuery {
+	if t, ok := afterTime.(time.Time); ok {
+		afterTime = sessionEventBoundary(t)
+	}
 	rows := sqlmock.NewRows([]string{"id", "created_at"})
 	for _, ref := range refs {
 		rows.AddRow(ref.id, ref.createdAt)
@@ -144,6 +147,9 @@ func expectLimitedEventRefsWithTimestamp(
 	limit int,
 	refs ...eventRef,
 ) *sqlmock.ExpectedQuery {
+	if t, ok := afterTime.(time.Time); ok {
+		afterTime = sessionEventBoundary(t)
+	}
 	rows := sqlmock.NewRows([]string{"id", "created_at", "event_timestamp"})
 	for _, ref := range refs {
 		rows.AddRow(ref.id, ref.createdAt, ref.eventTimestamp.Format(time.RFC3339Nano))
@@ -190,6 +196,9 @@ func expectNoUserAnchor(
 	sessionCreatedAt driver.Value,
 	extraArgs ...driver.Value,
 ) *sqlmock.ExpectedQuery {
+	if t, ok := sessionCreatedAt.(time.Time); ok {
+		sessionCreatedAt = sessionEventBoundary(t)
+	}
 	args := []driver.Value{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	args = append(args, extraArgs...)
 	args = append(args, userAnchorSearchBatchSize)
@@ -204,6 +213,9 @@ func expectNoUserAnchorWithTimestamp(
 	sessionCreatedAt driver.Value,
 	extraArgs ...driver.Value,
 ) *sqlmock.ExpectedQuery {
+	if t, ok := sessionCreatedAt.(time.Time); ok {
+		sessionCreatedAt = sessionEventBoundary(t)
+	}
 	args := []driver.Value{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	args = append(args, extraArgs...)
 	args = append(args, userAnchorSearchBatchSize)
@@ -219,6 +231,9 @@ func expectPreviousEventRefs(
 	before *eventRef,
 	refs ...eventRef,
 ) *sqlmock.ExpectedQuery {
+	if t, ok := sessionCreatedAt.(time.Time); ok {
+		sessionCreatedAt = sessionEventBoundary(t)
+	}
 	args := []driver.Value{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	if before != nil {
 		args = append(args, before.createdAt)

--- a/session/mysql/window.go
+++ b/session/mysql/window.go
@@ -172,7 +172,7 @@ LIMIT 1`,
 		key.AppName,
 		key.UserID,
 		key.SessionID,
-		sessionCreatedAt,
+		sessionEventBoundary(sessionCreatedAt),
 		anchorEventID,
 	)
 	if err != nil {
@@ -272,7 +272,7 @@ LIMIT ?`,
 		key.AppName,
 		key.UserID,
 		key.SessionID,
-		sessionCreatedAt,
+		sessionEventBoundary(sessionCreatedAt),
 		cursorCreatedAt,
 		eventWindowBatchSize,
 	)


### PR DESCRIPTION
## Background

Early versions of the MySQL session schema defined event timestamps as `TIMESTAMP` without fractional-second precision. MySQL therefore stored values at second precision. The schema was later updated to `TIMESTAMP(6)`, and newly created tables now retain microseconds.

However, initialization uses `CREATE TABLE IF NOT EXISTS`, which does not alter an existing table. Deployments whose session tables were created with the earlier schema can therefore still have second-precision `session_events.created_at` columns. The event write path supplies a microsecond-precision Go `time.Time`, but MySQL truncates it according to the physical column definition.

Session state may still retain a creation time such as `20:09:14.225054`, while an event inserted during that same second is stored as `20:09:14.000000`. Loading history with `created_at >= session.CreatedAt` then excludes that event. The row remains in the database, but it is missing from the reconstructed session history.

## Considered approaches

### Migrate existing columns to microsecond precision

Changing legacy columns to `TIMESTAMP(6)` gives future writes consistent precision. It requires a coordinated DDL migration, which can be operationally expensive for large tables, and it does not recover precision already lost from historical rows. Requiring this schema at startup would also be a breaking change for existing deployments.

### Keep the exact session timestamp boundary

This preserves the strictest boundary and avoids considering any earlier timestamp, but remains incorrect for legacy second-precision tables. Events created during the session creation second can still be omitted.

### Normalize the read boundary to second precision

Truncate the session creation boundary before querying or filtering events. This is backward compatible, protects historical data, and requires no immediate migration. The trade-off is that the read window is widened to the beginning of the same second. Because event queries are also scoped by application, user, and session identifiers, events from a previous session incarnation are still excluded unless they share the same session key and creation second.

## Chosen approach

This PR normalizes session event boundaries to second precision across limited, paged, full-history, anchor, and event-window paths. It also adds regression coverage for retaining same-second events while rejecting events from an earlier second.

New tables should continue using `TIMESTAMP(6)`. Existing deployments may migrate their schema separately, while the read-side compatibility remains necessary for legacy rows and avoids making a database migration a prerequisite for upgrading the library.

## Testing

- `cd session/mysql && go test ./...`