### PR TITLE
.github: sync Rhino Bird labels from referenced issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,10 @@ this pull request.
 
 Explain the problem this solves and any compatibility considerations.
 
+## Related issue
+
+<!-- Reference related issues, for example `Fixes #123` or `Related to #123`. -->
+
 ## Testing
 
 List the commands or manual checks you ran. If a check is not applicable, say

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,10 +7,6 @@ this pull request.
 
 Explain the problem this solves and any compatibility considerations.
 
-## Related issue
-
-<!-- Reference related issues, for example `Fixes #123` or `Related to #123`. -->
-
 ## Testing
 
 List the commands or manual checks you ran. If a check is not applicable, say

--- a/.github/scripts/sync-rhino-labels.js
+++ b/.github/scripts/sync-rhino-labels.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const MAX_ISSUE_REFERENCES = 20;
+const MANAGED_LABELS = Object.freeze([
+  '腾讯犀牛鸟开源专属',
+  '犀牛鸟-低难度',
+  '犀牛鸟-中高难度',
+]);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripIgnoredMarkdown(value) {
+  return value
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/~~~[\s\S]*?~~~/g, '')
+    .replace(/`[^`\r\n]*`/g, '');
+}
+
+function extractIssueNumbers(body, owner, repo) {
+  const text = stripIgnoredMarkdown(body || '');
+  const matches = [];
+  const issueURLPattern = new RegExp(
+    `https?://github\\.com/${escapeRegExp(owner)}/${escapeRegExp(repo)}/issues/([1-9]\\d*)\\b`,
+    'gi',
+  );
+  const qualifiedReferencePattern = new RegExp(
+    `\\b${escapeRegExp(owner)}/${escapeRegExp(repo)}#([1-9]\\d*)\\b`,
+    'gi',
+  );
+  const localReferencePattern = /(^|[^\w./#-])#([1-9]\d*)\b/gm;
+
+  for (const match of text.matchAll(issueURLPattern)) {
+    matches.push({ index: match.index, issueNumber: Number(match[1]) });
+  }
+  for (const match of text.matchAll(qualifiedReferencePattern)) {
+    matches.push({ index: match.index, issueNumber: Number(match[1]) });
+  }
+  for (const match of text.matchAll(localReferencePattern)) {
+    matches.push({ index: match.index, issueNumber: Number(match[2]) });
+  }
+
+  matches.sort((left, right) => left.index - right.index);
+  return [...new Set(matches.map((match) => match.issueNumber))];
+}
+
+function labelName(label) {
+  return typeof label === 'string' ? label : label.name;
+}
+
+async function syncRhinoLabels({ github, context, core }) {
+  const pullRequest = context.payload.pull_request;
+  if (!pullRequest) {
+    throw new Error('pull_request payload is required');
+  }
+
+  const { owner, repo } = context.repo;
+  const referencedIssues = extractIssueNumbers(pullRequest.body, owner, repo);
+  if (referencedIssues.length === 0) {
+    core.info('No same-repository issue references found in the pull request body.');
+    return;
+  }
+
+  if (referencedIssues.length > MAX_ISSUE_REFERENCES) {
+    core.warning(
+      `Found ${referencedIssues.length} issue references; only the first ${MAX_ISSUE_REFERENCES} will be checked.`,
+    );
+  }
+
+  const managedLabels = new Set(MANAGED_LABELS);
+  const desiredLabels = new Set();
+  for (const issueNumber of referencedIssues.slice(0, MAX_ISSUE_REFERENCES)) {
+    let response;
+    try {
+      response = await github.rest.issues.get({
+        owner,
+        repo,
+        issue_number: issueNumber,
+      });
+    } catch (error) {
+      if (error.status === 404) {
+        core.warning(`Referenced issue #${issueNumber} was not found; skipping it.`);
+        continue;
+      }
+      throw error;
+    }
+
+    if (response.data.pull_request) {
+      core.info(`#${issueNumber} is a pull request, not an issue; skipping it.`);
+      continue;
+    }
+
+    for (const label of response.data.labels || []) {
+      const name = labelName(label);
+      if (managedLabels.has(name)) {
+        desiredLabels.add(name);
+      }
+    }
+  }
+
+  const currentLabels = new Set((pullRequest.labels || []).map(labelName));
+  const missingLabels = [...desiredLabels].filter((label) => !currentLabels.has(label));
+  if (missingLabels.length === 0) {
+    core.info('No Rhino Bird labels need to be added.');
+    return;
+  }
+
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: pullRequest.number,
+    labels: missingLabels,
+  });
+  core.info(`Added labels to pull request #${pullRequest.number}: ${missingLabels.join(', ')}`);
+}
+
+module.exports = syncRhinoLabels;
+module.exports.extractIssueNumbers = extractIssueNumbers;
+module.exports.MANAGED_LABELS = MANAGED_LABELS;
+module.exports.MAX_ISSUE_REFERENCES = MAX_ISSUE_REFERENCES;

--- a/.github/scripts/sync-rhino-labels.test.js
+++ b/.github/scripts/sync-rhino-labels.test.js
@@ -1,0 +1,230 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const syncRhinoLabels = require('./sync-rhino-labels');
+const {
+  extractIssueNumbers,
+  MAX_ISSUE_REFERENCES,
+} = syncRhinoLabels;
+
+function createCore() {
+  return {
+    infoMessages: [],
+    warningMessages: [],
+    info(message) {
+      this.infoMessages.push(message);
+    },
+    warning(message) {
+      this.warningMessages.push(message);
+    },
+  };
+}
+
+function createContext(body, labels = []) {
+  return {
+    repo: { owner: 'trpc-group', repo: 'trpc-agent-go' },
+    payload: {
+      pull_request: {
+        number: 42,
+        body,
+        labels,
+      },
+    },
+  };
+}
+
+test('extractIssueNumbers finds supported same-repository references', () => {
+  const body = [
+    'Fixes #2001',
+    'Issue: #2002 and related to (#2003).',
+    'https://github.com/trpc-group/trpc-agent-go/issues/2004',
+    'HTTPS://GITHUB.COM/TRPC-GROUP/TRPC-AGENT-GO/ISSUES/2005',
+    'Resolves trpc-group/trpc-agent-go#2006',
+    'Duplicate #2001',
+  ].join('\n');
+
+  assert.deepEqual(
+    extractIssueNumbers(body, 'trpc-group', 'trpc-agent-go'),
+    [2001, 2002, 2003, 2004, 2005, 2006],
+  );
+});
+
+test('extractIssueNumbers ignores cross-repository and pull request URLs', () => {
+  const body = [
+    'Fixes another-owner/another-repo#2001',
+    'See https://github.com/trpc-group/trpc-agent-go/pull/2002',
+    'C#2003 is not an issue reference.',
+    '##2004 is a heading, not an issue reference.',
+  ].join('\n');
+
+  assert.deepEqual(extractIssueNumbers(body, 'trpc-group', 'trpc-agent-go'), []);
+});
+
+test('extractIssueNumbers ignores references in comments and code', () => {
+  const body = [
+    '<!-- Fixes #2001 -->',
+    '`Issue #2002`',
+    '```text\nRelated to #2003\n```',
+    '~~~markdown\nFixes #2004\n~~~',
+    'Fixes #2005',
+  ].join('\n');
+
+  assert.deepEqual(
+    extractIssueNumbers(body, 'trpc-group', 'trpc-agent-go'),
+    [2005],
+  );
+});
+
+test('syncRhinoLabels exits cleanly when the body has no issue references', async () => {
+  const core = createCore();
+
+  await syncRhinoLabels({
+    github: {},
+    context: createContext('No related issue.'),
+    core,
+  });
+
+  assert.match(core.infoMessages.at(-1), /No same-repository issue references/);
+});
+
+test('syncRhinoLabels adds only missing managed labels from referenced issues', async () => {
+  const addedLabels = [];
+  const github = {
+    rest: {
+      issues: {
+        async get({ issue_number: issueNumber }) {
+          if (issueNumber === 2001) {
+            return {
+              data: {
+                labels: [
+                  { name: '腾讯犀牛鸟开源专属' },
+                  { name: '犀牛鸟-低难度' },
+                  { name: 'type/feature' },
+                ],
+              },
+            };
+          }
+          return {
+            data: {
+              labels: ['腾讯犀牛鸟开源专属', '犀牛鸟-中高难度'],
+            },
+          };
+        },
+        async addLabels({ labels }) {
+          addedLabels.push(...labels);
+        },
+      },
+    },
+  };
+  const core = createCore();
+  const context = createContext('Fixes #2001\nRelated to #2003', [
+    { name: '腾讯犀牛鸟开源专属' },
+  ]);
+
+  await syncRhinoLabels({ github, context, core });
+
+  assert.deepEqual(addedLabels, ['犀牛鸟-低难度', '犀牛鸟-中高难度']);
+  assert.match(core.infoMessages.at(-1), /Added labels/);
+});
+
+test('syncRhinoLabels skips missing issues, pull requests, and unrelated labels', async () => {
+  let addLabelsCalled = false;
+  const github = {
+    rest: {
+      issues: {
+        async get({ issue_number: issueNumber }) {
+          if (issueNumber === 404) {
+            const error = new Error('not found');
+            error.status = 404;
+            throw error;
+          }
+          if (issueNumber === 100) {
+            return { data: { pull_request: {}, labels: ['犀牛鸟-低难度'] } };
+          }
+          return { data: { labels: [{ name: 'type/feature' }] } };
+        },
+        async addLabels() {
+          addLabelsCalled = true;
+        },
+      },
+    },
+  };
+  const core = createCore();
+
+  await syncRhinoLabels({
+    github,
+    context: createContext('Issue #404, #100, and #200'),
+    core,
+  });
+
+  assert.equal(addLabelsCalled, false);
+  assert.equal(core.warningMessages.length, 1);
+  assert.match(core.infoMessages.at(-1), /No Rhino Bird labels/);
+});
+
+test('syncRhinoLabels limits the number of issue lookups', async () => {
+  let lookupCount = 0;
+  const references = Array.from(
+    { length: MAX_ISSUE_REFERENCES + 2 },
+    (_, index) => `#${index + 1}`,
+  ).join(' ');
+  const github = {
+    rest: {
+      issues: {
+        async get() {
+          lookupCount += 1;
+          return { data: { labels: [] } };
+        },
+        async addLabels() {
+          throw new Error('unexpected label write');
+        },
+      },
+    },
+  };
+  const core = createCore();
+
+  await syncRhinoLabels({
+    github,
+    context: createContext(references),
+    core,
+  });
+
+  assert.equal(lookupCount, MAX_ISSUE_REFERENCES);
+  assert.equal(core.warningMessages.length, 1);
+});
+
+test('syncRhinoLabels fails without a pull request payload', async () => {
+  await assert.rejects(
+    syncRhinoLabels({
+      github: {},
+      context: { payload: {}, repo: {} },
+      core: createCore(),
+    }),
+    /pull_request payload is required/,
+  );
+});
+
+test('syncRhinoLabels propagates unexpected API failures', async () => {
+  const github = {
+    rest: {
+      issues: {
+        async get() {
+          const error = new Error('rate limited');
+          error.status = 429;
+          throw error;
+        },
+      },
+    },
+  };
+
+  await assert.rejects(
+    syncRhinoLabels({
+      github,
+      context: createContext('Fixes #2001'),
+      core: createCore(),
+    }),
+    /rate limited/,
+  );
+});

--- a/.github/workflows/rhino-labeler.yml
+++ b/.github/workflows/rhino-labeler.yml
@@ -1,0 +1,28 @@
+name: Sync Rhino Bird labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync-labels:
+    name: Copy labels from referenced issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted workflow code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Add Rhino Bird labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const syncRhinoLabels = require('./.github/scripts/sync-rhino-labels');
+            await syncRhinoLabels({ github, context, core });

--- a/.github/workflows/rhino-labeler.yml
+++ b/.github/workflows/rhino-labeler.yml
@@ -15,13 +15,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out trusted workflow code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Add Rhino Bird labels
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@v9
         with:
           script: |
             const syncRhinoLabels = require('./.github/scripts/sync-rhino-labels');


### PR DESCRIPTION
## What changed

- add a `pull_request_target` workflow that copies existing Rhino Bird labels from same-repository issues referenced in a pull request description
- recognize short references, qualified references, and full issue URLs while ignoring references in comments and code snippets
- restrict copied labels to an explicit allowlist, preserve all existing pull request labels, and cap issue lookups per event
- add focused tests for parsing, label selection, API failures, and lookup limits

## Why

Rhino Bird pull requests currently require maintainers to copy program and difficulty labels from the corresponding issue by hand. This change makes that process automatic for new and edited pull requests without hard-coding individual issue numbers.

The workflow is intentionally add-only. Editing a pull request description cannot remove labels that a maintainer applied manually. Pull requests without a related issue remain unaffected.

## Security

- run only trusted default-branch workflow code under `pull_request_target`
- never check out or execute pull request head code
- grant only `contents: read` and `issues: write`
- treat pull request descriptions as untrusted data and bound issue API lookups

## Testing

- `node --test --experimental-test-coverage .github/scripts/sync-rhino-labels.test.js`
  - 9 tests passed
  - core script coverage: 100% lines, 91.67% branches, 100% functions
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/rhino-labeler.yml`
- `git diff --check`
