### PR TITLE
session/mysql: log timestamp precision mismatches as errors

### DIFF
--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -569,7 +569,9 @@ func (s *Service) initDB(ctx context.Context) error {
 		}
 	}
 
-	// Verify schema (column drift is fatal; index drift is logged as warnings).
+	// Verify schema. Column type/nullability drift is fatal, timestamp
+	// precision drift is logged as a warning, and index drift follows the
+	// policy documented by verifyIndexes.
 	if err := s.verifySchema(ctx); err != nil {
 		return fmt.Errorf("schema verification failed: %w", err)
 	}
@@ -674,13 +676,16 @@ func (s *Service) tableExists(ctx context.Context, tableName string) (bool, erro
 	return count > 0, nil
 }
 
-// verifyColumns verifies that table columns match expectations.
+// verifyColumns verifies column types and nullability, and warns when timestamp
+// precision differs from TIMESTAMP(6).
 func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedColumns []tableColumn) error {
 	// Get actual columns from database
 	actualColumns := make(map[string]tableColumn)
+	actualDatetimePrecisions := make(map[string]sql.NullInt64)
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
 		var name, dataType, isNullable string
-		if err := rows.Scan(&name, &dataType, &isNullable); err != nil {
+		var datetimePrecision sql.NullInt64
+		if err := rows.Scan(&name, &dataType, &isNullable, &datetimePrecision); err != nil {
 			return err
 		}
 		actualColumns[name] = tableColumn{
@@ -688,8 +693,9 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 			dataType: dataType,
 			nullable: isNullable == "YES",
 		}
+		actualDatetimePrecisions[name] = datetimePrecision
 		return nil
-	}, `SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
+	}, `SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, DATETIME_PRECISION
 		FROM information_schema.columns
 		WHERE table_schema = DATABASE()
 		AND table_name = ?
@@ -710,6 +716,22 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 		if actual.dataType != expected.dataType {
 			return fmt.Errorf("column %s.%s has type %s, expected %s",
 				tableName, expected.name, actual.dataType, expected.dataType)
+		}
+		if expected.dataType == "timestamp" {
+			precision := actualDatetimePrecisions[expected.name]
+			if !precision.Valid || precision.Int64 != 6 {
+				actualType := "TIMESTAMP"
+				if precision.Valid {
+					actualType = fmt.Sprintf("TIMESTAMP(%d)", precision.Int64)
+				}
+				log.WarnfContext(
+					ctx,
+					"column %s.%s uses %s, expected TIMESTAMP(6); timestamp precision mismatch may cause incorrect time comparisons",
+					tableName,
+					expected.name,
+					actualType,
+				)
+			}
 		}
 
 		// Check nullable

--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -758,7 +758,11 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 	if len(timestampMismatches) > 0 {
 		log.ErrorfContext(
 			ctx,
-			"table %s has timestamp precision mismatches: %s; expected TIMESTAMP(6); mismatches may cause incorrect time comparisons or ordering; review and run: ALTER TABLE `%s` %s;",
+			"table %s has timestamp precision mismatches: %s; expected TIMESTAMP(6); "+
+				"mismatches may cause incorrect time comparisons or ordering; canonical schema migration template "+
+				"(review SHOW CREATE TABLE first; preserve any custom defaults, ON UPDATE clauses, comments, "+
+				"and other column attributes; changing timestamp precision may rebuild the table and block writes): "+
+				"ALTER TABLE `%s` %s;",
 			tableName,
 			strings.Join(timestampMismatches, ", "),
 			tableName,

--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -676,6 +676,23 @@ func (s *Service) tableExists(ctx context.Context, tableName string) (bool, erro
 	return count > 0, nil
 }
 
+func alterTimestampPrecisionClause(column tableColumn) string {
+	definition := "TIMESTAMP(6)"
+	switch column.name {
+	case "created_at":
+		definition += " NOT NULL DEFAULT CURRENT_TIMESTAMP(6)"
+	case "updated_at":
+		definition += " NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)"
+	default:
+		if column.nullable {
+			definition += " NULL DEFAULT NULL"
+		} else {
+			definition += " NOT NULL"
+		}
+	}
+	return fmt.Sprintf("MODIFY COLUMN `%s` %s", column.name, definition)
+}
+
 // verifyColumns verifies column types and nullability, and logs an error when
 // timestamp precision differs from TIMESTAMP(6).
 func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedColumns []tableColumn) error {
@@ -705,6 +722,9 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 		return fmt.Errorf("query columns failed: %w", err)
 	}
 
+	var timestampMismatches []string
+	var timestampAlterClauses []string
+
 	// Check each expected column
 	for _, expected := range expectedColumns {
 		actual, exists := actualColumns[expected.name]
@@ -724,13 +744,8 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 				if precision.Valid {
 					actualType = fmt.Sprintf("TIMESTAMP(%d)", precision.Int64)
 				}
-				log.ErrorfContext(
-					ctx,
-					"column %s.%s uses %s, expected TIMESTAMP(6); timestamp precision mismatch may cause incorrect time comparisons",
-					tableName,
-					expected.name,
-					actualType,
-				)
+				timestampMismatches = append(timestampMismatches, fmt.Sprintf("%s uses %s", expected.name, actualType))
+				timestampAlterClauses = append(timestampAlterClauses, alterTimestampPrecisionClause(expected))
 			}
 		}
 
@@ -739,6 +754,16 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 			return fmt.Errorf("column %s.%s nullable mismatch: got %v, expected %v",
 				tableName, expected.name, actual.nullable, expected.nullable)
 		}
+	}
+	if len(timestampMismatches) > 0 {
+		log.ErrorfContext(
+			ctx,
+			"table %s has timestamp precision mismatches: %s; expected TIMESTAMP(6); mismatches may cause incorrect time comparisons or ordering; review and run: ALTER TABLE `%s` %s;",
+			tableName,
+			strings.Join(timestampMismatches, ", "),
+			tableName,
+			strings.Join(timestampAlterClauses, ", "),
+		)
 	}
 
 	return nil

--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -570,7 +570,7 @@ func (s *Service) initDB(ctx context.Context) error {
 	}
 
 	// Verify schema. Column type/nullability drift is fatal, timestamp
-	// precision drift is logged as a warning, and index drift follows the
+	// precision drift is logged as an error, and index drift follows the
 	// policy documented by verifyIndexes.
 	if err := s.verifySchema(ctx); err != nil {
 		return fmt.Errorf("schema verification failed: %w", err)
@@ -676,8 +676,8 @@ func (s *Service) tableExists(ctx context.Context, tableName string) (bool, erro
 	return count > 0, nil
 }
 
-// verifyColumns verifies column types and nullability, and warns when timestamp
-// precision differs from TIMESTAMP(6).
+// verifyColumns verifies column types and nullability, and logs an error when
+// timestamp precision differs from TIMESTAMP(6).
 func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedColumns []tableColumn) error {
 	// Get actual columns from database
 	actualColumns := make(map[string]tableColumn)
@@ -724,7 +724,7 @@ func (s *Service) verifyColumns(ctx context.Context, tableName string, expectedC
 				if precision.Valid {
 					actualType = fmt.Sprintf("TIMESTAMP(%d)", precision.Int64)
 				}
-				log.WarnfContext(
+				log.ErrorfContext(
 					ctx,
 					"column %s.%s uses %s, expected TIMESTAMP(6); timestamp precision mismatch may cause incorrect time comparisons",
 					tableName,

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -671,7 +671,10 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 				"created_at": int64(0),
 			},
 			wantError: false,
-			wantErrorLogContains: "review and run: ALTER TABLE `test_table` MODIFY COLUMN `created_at` " +
+			wantErrorLogContains: "canonical schema migration template (review SHOW CREATE TABLE first; " +
+				"preserve any custom defaults, ON UPDATE clauses, comments, and other column attributes; " +
+				"changing timestamp precision may rebuild the table and block writes): " +
+				"ALTER TABLE `test_table` MODIFY COLUMN `created_at` " +
 				"TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);",
 		},
 		{

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -12,6 +12,7 @@ package mysql
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -20,7 +21,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
+	agentlog "trpc.group/trpc-go/trpc-agent-go/log"
 )
+
+func datetimePrecisionForType(dataType string) any {
+	if dataType == "timestamp" {
+		return int64(6)
+	}
+	return nil
+}
 
 // mockVerifySchemaQueries adds mock expectations for verifySchema queries
 func mockVerifySchemaQueries(mock sqlmock.Sqlmock, tablePrefix string) {
@@ -43,13 +52,13 @@ func mockVerifySchemaQueries(mock sqlmock.Sqlmock, tablePrefix string) {
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 		// 2. verifyColumns query
-		colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE"})
+		colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE", "DATETIME_PRECISION"})
 		for _, col := range schema.columns {
 			isNullable := "NO"
 			if col.nullable {
 				isNullable = "YES"
 			}
-			colRows.AddRow(col.name, col.dataType, isNullable)
+			colRows.AddRow(col.name, col.dataType, isNullable, datetimePrecisionForType(col.dataType))
 		}
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT COLUMN_NAME")).
 			WithArgs(fullTableName).
@@ -364,13 +373,13 @@ func TestVerifySchema_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 	// 2. verifyColumns
-	rows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE"})
+	rows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE", "DATETIME_PRECISION"})
 	for _, col := range expectedSchema[testTable].columns {
 		isNullable := "NO"
 		if col.nullable {
 			isNullable = "YES"
 		}
-		rows.AddRow(col.name, col.dataType, isNullable)
+		rows.AddRow(col.name, col.dataType, isNullable, datetimePrecisionForType(col.dataType))
 	}
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COLUMN_NAME")).
 		WithArgs(fullTableName).
@@ -422,13 +431,13 @@ func TestVerifySchema_MissingUniqueIndexFatal(t *testing.T) {
 		WithArgs(fullTableName).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	// Columns match.
-	colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE"})
+	colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE", "DATETIME_PRECISION"})
 	for _, col := range expectedSchema[testTable].columns {
 		isNullable := "NO"
 		if col.nullable {
 			isNullable = "YES"
 		}
-		colRows.AddRow(col.name, col.dataType, isNullable)
+		colRows.AddRow(col.name, col.dataType, isNullable, datetimePrecisionForType(col.dataType))
 	}
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COLUMN_NAME")).
 		WithArgs(fullTableName).
@@ -615,11 +624,13 @@ func TestVerifyIndexes_Scenarios(t *testing.T) {
 
 func TestVerifyColumns_Scenarios(t *testing.T) {
 	tests := []struct {
-		name            string
-		expectedColumns []tableColumn
-		actualColumns   map[string]tableColumn
-		wantError       bool
-		wantErrContains string
+		name                string
+		expectedColumns     []tableColumn
+		actualColumns       map[string]tableColumn
+		datetimePrecisions  map[string]any
+		wantError           bool
+		wantErrContains     string
+		wantWarningContains string
 	}{
 		{
 			name: "all columns correct",
@@ -634,6 +645,33 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 				"state":    {"state", "json", true},
 			},
 			wantError: false,
+		},
+		{
+			name: "timestamp precision six",
+			expectedColumns: []tableColumn{
+				{"created_at", "timestamp", false},
+			},
+			actualColumns: map[string]tableColumn{
+				"created_at": {"created_at", "timestamp", false},
+			},
+			datetimePrecisions: map[string]any{
+				"created_at": int64(6),
+			},
+			wantError: false,
+		},
+		{
+			name: "timestamp precision mismatch warns",
+			expectedColumns: []tableColumn{
+				{"created_at", "timestamp", false},
+			},
+			actualColumns: map[string]tableColumn{
+				"created_at": {"created_at", "timestamp", false},
+			},
+			datetimePrecisions: map[string]any{
+				"created_at": int64(0),
+			},
+			wantError:           false,
+			wantWarningContains: "column test_table.created_at uses TIMESTAMP(0), expected TIMESTAMP(6)",
 		},
 		{
 			name: "missing column",
@@ -681,17 +719,29 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 
 			s := createTestService(t, db)
 			ctx := context.Background()
+			originalWarnfContext := agentlog.WarnfContext
+			var warnings []string
+			agentlog.WarnfContext = func(_ context.Context, format string, args ...any) {
+				warnings = append(warnings, fmt.Sprintf(format, args...))
+			}
+			defer func() {
+				agentlog.WarnfContext = originalWarnfContext
+			}()
 
 			tableName := "test_table"
 
 			// Build mock rows from actualColumns
-			rows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE"})
+			rows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE", "DATETIME_PRECISION"})
 			for _, col := range tt.actualColumns {
 				isNullable := "NO"
 				if col.nullable {
 					isNullable = "YES"
 				}
-				rows.AddRow(col.name, col.dataType, isNullable)
+				precision := datetimePrecisionForType(col.dataType)
+				if configured, ok := tt.datetimePrecisions[col.name]; ok {
+					precision = configured
+				}
+				rows.AddRow(col.name, col.dataType, isNullable, precision)
 			}
 
 			mock.ExpectQuery(regexp.QuoteMeta("SELECT COLUMN_NAME")).
@@ -706,6 +756,12 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
+			}
+			if tt.wantWarningContains == "" {
+				assert.Empty(t, warnings)
+			} else {
+				require.Len(t, warnings, 1)
+				assert.Contains(t, warnings[0], tt.wantWarningContains)
 			}
 			assert.NoError(t, mock.ExpectationsWereMet())
 		})

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -624,13 +624,13 @@ func TestVerifyIndexes_Scenarios(t *testing.T) {
 
 func TestVerifyColumns_Scenarios(t *testing.T) {
 	tests := []struct {
-		name                string
-		expectedColumns     []tableColumn
-		actualColumns       map[string]tableColumn
-		datetimePrecisions  map[string]any
-		wantError           bool
-		wantErrContains     string
-		wantWarningContains string
+		name                 string
+		expectedColumns      []tableColumn
+		actualColumns        map[string]tableColumn
+		datetimePrecisions   map[string]any
+		wantError            bool
+		wantErrContains      string
+		wantErrorLogContains string
 	}{
 		{
 			name: "all columns correct",
@@ -660,7 +660,7 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "timestamp precision mismatch warns",
+			name: "timestamp precision mismatch logs error",
 			expectedColumns: []tableColumn{
 				{"created_at", "timestamp", false},
 			},
@@ -670,8 +670,8 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 			datetimePrecisions: map[string]any{
 				"created_at": int64(0),
 			},
-			wantError:           false,
-			wantWarningContains: "column test_table.created_at uses TIMESTAMP(0), expected TIMESTAMP(6)",
+			wantError:            false,
+			wantErrorLogContains: "column test_table.created_at uses TIMESTAMP(0), expected TIMESTAMP(6)",
 		},
 		{
 			name: "missing column",
@@ -719,13 +719,13 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 
 			s := createTestService(t, db)
 			ctx := context.Background()
-			originalWarnfContext := agentlog.WarnfContext
-			var warnings []string
-			agentlog.WarnfContext = func(_ context.Context, format string, args ...any) {
-				warnings = append(warnings, fmt.Sprintf(format, args...))
+			originalErrorfContext := agentlog.ErrorfContext
+			var errorLogs []string
+			agentlog.ErrorfContext = func(_ context.Context, format string, args ...any) {
+				errorLogs = append(errorLogs, fmt.Sprintf(format, args...))
 			}
 			defer func() {
-				agentlog.WarnfContext = originalWarnfContext
+				agentlog.ErrorfContext = originalErrorfContext
 			}()
 
 			tableName := "test_table"
@@ -757,11 +757,11 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			if tt.wantWarningContains == "" {
-				assert.Empty(t, warnings)
+			if tt.wantErrorLogContains == "" {
+				assert.Empty(t, errorLogs)
 			} else {
-				require.Len(t, warnings, 1)
-				assert.Contains(t, warnings[0], tt.wantWarningContains)
+				require.Len(t, errorLogs, 1)
+				assert.Contains(t, errorLogs[0], tt.wantErrorLogContains)
 			}
 			assert.NoError(t, mock.ExpectationsWereMet())
 		})

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -670,8 +670,34 @@ func TestVerifyColumns_Scenarios(t *testing.T) {
 			datetimePrecisions: map[string]any{
 				"created_at": int64(0),
 			},
-			wantError:            false,
-			wantErrorLogContains: "column test_table.created_at uses TIMESTAMP(0), expected TIMESTAMP(6)",
+			wantError: false,
+			wantErrorLogContains: "review and run: ALTER TABLE `test_table` MODIFY COLUMN `created_at` " +
+				"TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);",
+		},
+		{
+			name: "multiple timestamp precision mismatches use one alter statement",
+			expectedColumns: []tableColumn{
+				{"created_at", "timestamp", false},
+				{"updated_at", "timestamp", false},
+				{"expires_at", "timestamp", true},
+			},
+			actualColumns: map[string]tableColumn{
+				"created_at": {"created_at", "timestamp", false},
+				"updated_at": {"updated_at", "timestamp", false},
+				"expires_at": {"expires_at", "timestamp", true},
+			},
+			datetimePrecisions: map[string]any{
+				"created_at": int64(0),
+				"updated_at": int64(0),
+				"expires_at": int64(0),
+			},
+			wantError: false,
+			wantErrorLogContains: "ALTER TABLE `test_table` " +
+				"MODIFY COLUMN `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), " +
+				"MODIFY COLUMN `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) " +
+				"ON UPDATE CURRENT_TIMESTAMP(6), " +
+				"MODIFY COLUMN `expires_at` " +
+				"TIMESTAMP(6) NULL DEFAULT NULL;",
 		},
 		{
 			name: "missing column",

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -3533,13 +3533,13 @@ func mockDBInitWithPrefix(mock sqlmock.Sqlmock, tablePrefix string) {
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
 		// 2. verifyColumns query
-		colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE"})
+		colRows := sqlmock.NewRows([]string{"COLUMN_NAME", "DATA_TYPE", "IS_NULLABLE", "DATETIME_PRECISION"})
 		for _, col := range schema.columns {
 			isNullable := "NO"
 			if col.nullable {
 				isNullable = "YES"
 			}
-			colRows.AddRow(col.name, col.dataType, isNullable)
+			colRows.AddRow(col.name, col.dataType, isNullable, datetimePrecisionForType(col.dataType))
 		}
 		mock.ExpectQuery("SELECT COLUMN_NAME").
 			WithArgs(fullTableName).


### PR DESCRIPTION
## What changed

- Read `DATETIME_PRECISION` during MySQL session schema verification.
- Log an error when a column expected to be `TIMESTAMP(6)` uses another precision.
- Include one canonical `ALTER TABLE` migration template per affected table, preserving the schema's expected nullability, defaults, and `ON UPDATE` behavior.
- Tell operators to inspect `SHOW CREATE TABLE` and preserve any custom column attributes before executing the template.
- Keep existing fatal validation for missing columns, type mismatches, and nullability mismatches.
- Add regression coverage for matching precision, individual mismatches, and combined per-table migration statements.

## Why

MySQL session state and event tables can use different timestamp precision in existing deployments. A lower-precision event timestamp can compare earlier than a microsecond-precision session creation boundary, which may omit same-second events when session history is reconstructed.

The event `created_at` column also provides persistence ordering for history, pagination, and event-window cursors. Whole-second precision substantially increases timestamp collisions and can make those paths unstable or skip same-timestamp rows.

New schemas already use `TIMESTAMP(6)`, but existing tables are not altered automatically. An error-level diagnostic surfaces this correctness risk without blocking startup. The suggested DDL combines all mismatched timestamp columns for a table into one statement so operators can review and schedule the migration explicitly.

## Testing

- `cd session/mysql && go test ./...`
- `cd session/mysql && go test -race ./...`
- `cd session/mysql && go vet ./...`
- MySQL 8.0.44 integration test covering all six session tables and 23 timestamp columns.

## Notes for reviewers

This change only adds schema diagnostics and migration guidance. It does not alter existing tables, fail service startup, or change event read boundaries.

The logged DDL is a canonical schema migration template. Operators should inspect `SHOW CREATE TABLE`, preserve custom defaults, `ON UPDATE` clauses, comments, and other column attributes, and assess table rebuild and write-blocking risk before running it in production.
