### PR TITLE
docs(model): clarify thinking toggle variants

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1789,7 +1789,7 @@ model := anthropic.New("claude-sonnet-4-0",
 
 #### 7. Variant Optimization: Adapting to Platform-Specific Behaviors
 
-The Variant mechanism is an important optimization in the Model module, used to handle platform-specific behavioral differences across OpenAI-compatible providers. By specifying different Variants, the framework can automatically adapt to API differences between platforms, especially for file upload, deletion, and processing logic.
+The Variant mechanism is an important optimization in the Model module, used to handle platform-specific behavioral differences across OpenAI-compatible providers. By specifying different Variants, the framework can automatically adapt to API differences between platforms, including file handling and thinking-toggle serialization.
 
 ##### 7.1. Supported Variant Types
 
@@ -1823,6 +1823,12 @@ The framework currently supports the following Variants:
 - Default BaseURL：`https://dashscope.aliyuncs.com/compatible-mode/v1`
 - API Key environment variable name：`DASHSCOPE_API_KEY`
 - Other behaviors are consistent with standard OpenAI
+
+**5. VariantGLM**
+
+- GLM OpenAI-compatible API adaptation
+- Serializes the thinking toggle using GLM's `thinking` object format
+- Falls back to exposing `reasoning_content` as visible content when some GLM gateways return an empty `content` field without tool calls
 
 ##### 7.2. Usage
 
@@ -1885,6 +1891,49 @@ model := openai.New("deepseek-v4-flash",
     openai.WithVariant(openai.VariantDeepSeek), // Automatically reads DEEPSEEK_API_KEY
 )
 ```
+
+##### 7.4. Thinking Toggles and Variants
+
+`Variant` and `GenerationConfig.ThinkingEnabled` have different responsibilities:
+
+- `WithVariant(...)` selects the provider protocol and determines which field and JSON shape represent the thinking toggle.
+- `ThinkingEnabled` explicitly enables or disables thinking.
+
+Setting only a `Variant` **does not emit a thinking toggle**. When `ThinkingEnabled == nil`, the framework omits the toggle and lets the provider apply its default. Even if a provider currently enables thinking by default, callers that require deterministic behavior should set `ThinkingEnabled` explicitly.
+
+The OpenAI-compatible variants serialize `ThinkingEnabled=true` as follows:
+
+| Variant | Request field for `ThinkingEnabled=true` |
+| --- | --- |
+| `VariantOpenAI` | `"thinking_enabled": true` |
+| `VariantDeepSeek` | `"thinking": {"type": "enabled"}` |
+| `VariantHunyuan` | `"thinking": {"type": "enabled"}` |
+| `VariantGLM` | `"thinking": {"type": "enabled"}` |
+| `VariantQwen` | `"enable_thinking": true` |
+
+For example, to deterministically enable thinking through the official DeepSeek API:
+
+```go
+thinking := true
+
+llm := openai.New("deepseek-v4-flash",
+    openai.WithBaseURL("https://api.deepseek.com"),
+    openai.WithAPIKey("your-api-key"),
+    openai.WithVariant(openai.VariantDeepSeek),
+)
+
+request := &model.Request{
+    Messages: []model.Message{
+        model.NewUserMessage("Analyze this problem."),
+    },
+    GenerationConfig: model.GenerationConfig{
+        Stream:          true,
+        ThinkingEnabled: &thinking,
+    },
+}
+```
+
+`ThinkingEnabled` applies only to models that expose an explicit thinking toggle; use `ReasoningEffort` instead when a model exposes only a reasoning budget. For external services that implement one of the thinking-toggle formats above, explicitly setting the matching `Variant` and `ThinkingEnabled` is usually sufficient. If a gateway uses a different field or requires additional parameters, use `openai.WithExtraFields(...)` to add or override provider-specific fields.
 
 #### 8. Streaming Tool Call Deltas: ShowToolCallDelta
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1772,7 +1772,7 @@ model := anthropic.New("claude-sonnet-4-0",
 
 #### 7. Variant 优化：平台特有行为适配
 
-Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容平台的特有行为差异。通过指定不同的 Variant，框架能够自动适配各平台的 API 差异，特别是文件上传、删除和处理逻辑。
+Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容平台的特有行为差异。通过指定不同的 Variant，框架能够自动适配各平台的 API 差异，包括文件处理和思考开关字段的序列化格式。
 
 ##### 7.1. 支持的 Variant 类型
 
@@ -1806,6 +1806,12 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 - 默认 BaseURL：`https://dashscope.aliyuncs.com/compatible-mode/v1`
 - API Key 环境变量名：`DASHSCOPE_API_KEY`
 - 其他行为与标准 OpenAI 一致
+
+**5. VariantGLM（智谱 GLM）**
+
+- GLM OpenAI-compatible 接口适配
+- 使用 GLM 的 `thinking` 对象格式序列化思考开关
+- 当部分 GLM 网关把最终答案放在 `reasoning_content` 且 `content` 为空时，框架会将其回退为可见内容
 
 ##### 7.2. 使用方式
 
@@ -1868,6 +1874,49 @@ model := openai.New("deepseek-v4-flash",
     openai.WithVariant(openai.VariantDeepSeek), // 自动读取 DEEPSEEK_API_KEY
 )
 ```
+
+##### 7.4. 思考开关与 Variant
+
+`Variant` 和 `GenerationConfig.ThinkingEnabled` 负责不同的事情：
+
+- `WithVariant(...)` 选择服务方协议，决定思考开关应使用哪个字段和 JSON 格式；
+- `ThinkingEnabled` 决定是否显式开启或关闭思考。
+
+仅设置 `Variant` **不会自动发送思考开关**。当 `ThinkingEnabled == nil` 时，框架不发送任何开关字段，由服务方使用默认值。即使某个服务方当前默认开启思考，如果调用方需要确定性行为，也应显式设置 `ThinkingEnabled`。
+
+各 OpenAI-compatible Variant 的序列化结果如下：
+
+| Variant | `ThinkingEnabled=true` 的请求字段 |
+| --- | --- |
+| `VariantOpenAI` | `"thinking_enabled": true` |
+| `VariantDeepSeek` | `"thinking": {"type": "enabled"}` |
+| `VariantHunyuan` | `"thinking": {"type": "enabled"}` |
+| `VariantGLM` | `"thinking": {"type": "enabled"}` |
+| `VariantQwen` | `"enable_thinking": true` |
+
+例如，通过官方 DeepSeek API 确定性地开启思考：
+
+```go
+thinking := true
+
+llm := openai.New("deepseek-v4-flash",
+    openai.WithBaseURL("https://api.deepseek.com"),
+    openai.WithAPIKey("your-api-key"),
+    openai.WithVariant(openai.VariantDeepSeek),
+)
+
+request := &model.Request{
+    Messages: []model.Message{
+        model.NewUserMessage("分析这个问题。"),
+    },
+    GenerationConfig: model.GenerationConfig{
+        Stream:          true,
+        ThinkingEnabled: &thinking,
+    },
+}
+```
+
+`ThinkingEnabled` 只适用于提供显式思考开关的模型；如果模型只支持推理预算，请改用 `ReasoningEffort`。对实现上述思考开关格式的外部服务，通常显式设置对应 `Variant` 和 `ThinkingEnabled` 即可。如果代理网关使用了不同字段或需要额外参数，可以通过 `openai.WithExtraFields(...)` 添加或覆盖服务方特有字段。
 
 #### 8. 流式工具调用增量：ShowToolCallDelta
 

--- a/examples/thinking/README.md
+++ b/examples/thinking/README.md
@@ -52,7 +52,11 @@ The two flags have separate roles:
 - `-variant` selects the provider protocol and controls how the request field is serialized.
 - `-thinking` explicitly enables or disables thinking.
 
-For deterministic behavior, pass both values. A variant by itself does not enable thinking; if `ThinkingEnabled` is left unset in application code, the provider applies its own default. The built-in variants serialize the switch as follows:
+For deterministic behavior in application code, configure both `Variant` and
+`ThinkingEnabled`. A variant by itself does not enable thinking; if
+`ThinkingEnabled` is left unset, the provider applies its own default. This
+demo defaults `-thinking` to `true`, so omitting that CLI flag still sends the
+enabled toggle. The built-in variants serialize the switch as follows:
 
 | Variant | Enabled request field |
 | ------- | --------------------- |

--- a/examples/thinking/README.md
+++ b/examples/thinking/README.md
@@ -30,7 +30,7 @@ This example demonstrates a clean chat interface that surfaces the model's inter
 | Argument            | Description                                  | Default Value        |
 | ------------------- | -------------------------------------------- | -------------------- |
 | `-model`            | Name of the model to use                     | `deepseek-v4-pro`  |
-| `-variant`          | Model variant: `openai`, `deepseek`, `qwen`, `hunyuan` | `openai`     |
+| `-variant`          | Model variant: `openai`, `deepseek`, `qwen`, `hunyuan`, `glm` | `openai`     |
 | `-streaming`        | Enable streaming mode for responses          | `true`               |
 | `-thinking`         | Enable reasoning/thinking (if provider supports) | `true`            |
 | `-thinking-tokens`  | Max reasoning tokens (if provider supports)  | `2048`               |
@@ -44,6 +44,21 @@ This example demonstrates a clean chat interface that surfaces the model's inter
 | `discard_previous` | Discard `reasoning_content` from previous turns, keep current (default, recommended). |
 | `keep_all`         | Keep all `reasoning_content` in history.                     |
 | `discard_all`      | Discard all `reasoning_content` from history.                |
+
+### Thinking Toggle and Variant
+
+The two flags have separate roles:
+
+- `-variant` selects the provider protocol and controls how the request field is serialized.
+- `-thinking` explicitly enables or disables thinking.
+
+For deterministic behavior, pass both values. A variant by itself does not enable thinking; if `ThinkingEnabled` is left unset in application code, the provider applies its own default. The built-in variants serialize the switch as follows:
+
+| Variant | Enabled request field |
+| ------- | --------------------- |
+| `openai` | `"thinking_enabled": true` |
+| `deepseek`, `hunyuan`, `glm` | `"thinking": {"type": "enabled"}` |
+| `qwen` | `"enable_thinking": true` |
 
 ## Usage
 
@@ -121,7 +136,7 @@ Usage of ./thinking:
   -thinking-tokens int
         Max reasoning tokens if provider supports it (default 2048)
   -variant string
-        Name of Variant to use when use openai provider, openai / hunyuan / deepseek / qwen (default "openai")
+        Name of Variant to use with the OpenAI provider: openai / hunyuan / deepseek / qwen / glm (default "openai")
 ```
 
 ## Chat Interface
@@ -184,6 +199,7 @@ Debug: true
 
 - This demo uses the in-memory session service for simplicity.
 - Reasoning visibility depends on the provider/model. Enabling flags signals intent but does not guarantee reasoning will be returned.
+- Passing `-thinking=false` emits the variant-specific disabled value instead of falling back to the provider default.
 - Debug mode is enabled by default to help verify `reasoning_content` handling in multi-turn conversations.
 - The default `-reasoning-mode=discard_previous` follows DeepSeek API best practices: discard `reasoning_content` from previous turns while keeping the current turn's reasoning for tool call scenarios.
 - The `calculator` and `current_time` tools are always available to test thinking + tool call scenarios.

--- a/examples/thinking/main.go
+++ b/examples/thinking/main.go
@@ -34,7 +34,7 @@ var (
 	streaming       = flag.Bool("streaming", true, "Enable streaming mode for responses")
 	thinkingEnabled = flag.Bool("thinking", true, "Enable reasoning/thinking mode if provider supports it")
 	thinkingTokens  = flag.Int("thinking-tokens", 2048, "Max reasoning tokens if provider supports it")
-	variant         = flag.String("variant", "openai", "Name of Variant to use when use openai provider, openai / hunyuan / deepseek / qwen")
+	variant         = flag.String("variant", "openai", "Name of Variant to use with the OpenAI provider: openai / hunyuan / deepseek / qwen / glm")
 	debug           = flag.Bool("debug", true, "Print messages sent to model API for debugging")
 	reasoningMode   = flag.String("reasoning-mode", "discard_previous",
 		"How to handle reasoning_content in history: keep_all, discard_previous, discard_all")
@@ -93,12 +93,12 @@ func (c *thinkingChat) setup(_ context.Context) error {
 	var sessionService session.Service = sessioninmemory.NewSessionService()
 
 	genConfig := model.GenerationConfig{
-		MaxTokens:   intPtr(2000),
-		Temperature: floatPtr(0.7),
-		Stream:      c.streaming,
+		MaxTokens:       intPtr(2000),
+		Temperature:     floatPtr(0.7),
+		Stream:          c.streaming,
+		ThinkingEnabled: thinkingEnabled,
 	}
 	if thinkingEnabled != nil && *thinkingEnabled {
-		genConfig.ThinkingEnabled = thinkingEnabled
 		genConfig.ThinkingTokens = thinkingTokens
 	}
 


### PR DESCRIPTION
## Summary

- document how `Variant` and `GenerationConfig.ThinkingEnabled` work together
- list the thinking-toggle JSON emitted by every OpenAI-compatible variant, including GLM
- clarify provider defaults, `ReasoningEffort`, and the `WithExtraFields` escape hatch
- make the thinking example emit an explicit disabled value for `-thinking=false`

## Why

The existing documentation mentioned both APIs but did not explain their separate responsibilities. A variant selects the provider-specific wire format; it does not enable thinking by itself. This ambiguity can cause callers to rely on provider defaults or send the wrong field through OpenAI-compatible gateways.

## Validation

- `mkdocs build --strict -f docs/mkdocs.yml`
- `go test ./model/openai -count=1` (513 tests passed)
- `go test ./... -count=1` in `examples/thinking`
- `go vet ./...` and `golangci-lint run ./...` in `examples/thinking`
- root `go test ./... -count=1`: 10,936 passed; one existing 100 ms hedge timing test failed once and then passed 5 consecutive targeted reruns
