### PR TITLE
model/openai: add Kimi variant

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1958,12 +1958,16 @@ For Kimi models that require thinking to remain enabled, leave
 turns, pass the complete provider extension explicitly:
 
 ```go
-openai.WithExtraFields(map[string]any{
-    "thinking": map[string]string{
-        "type": "enabled",
-        "keep": "all",
-    },
-})
+llm := openai.New(
+    "kimi-k2.6",
+    openai.WithVariant(openai.VariantKimi),
+    openai.WithExtraFields(map[string]any{
+        "thinking": map[string]string{
+            "type": "enabled",
+            "keep": "all",
+        },
+    }),
+)
 ```
 
 #### 8. Streaming Tool Call Deltas: ShowToolCallDelta

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1830,6 +1830,15 @@ The framework currently supports the following Variants:
 - Serializes the thinking toggle using GLM's `thinking` object format
 - Falls back to exposing `reasoning_content` as visible content when some GLM gateways return an empty `content` field without tool calls
 
+**6. VariantKimi**
+
+- Kimi Open Platform adaptation
+- Default BaseURL: `https://api.moonshot.ai/v1`
+- API Key environment variable name: `MOONSHOT_API_KEY`
+- Automatically inferred for the official `api.moonshot.ai` and `api.moonshot.cn` hosts
+- Serializes the thinking toggle as `{"thinking": {"type": "enabled"}}`
+- Uses `file-extract` as the default file upload purpose
+
 ##### 7.2. Usage
 
 **Usage Example**：
@@ -1849,6 +1858,11 @@ model := openai.New("deepseek-v4-flash",
     openai.WithBaseURL("https://api.deepseek.com/v1"),
     openai.WithAPIKey("your-api-key"),
     openai.WithVariant(openai.VariantDeepSeek), // Specify the DeepSeek variant
+)
+
+// Use the Kimi Open Platform
+model = openai.New("kimi-k2.6",
+    openai.WithVariant(openai.VariantKimi), // Reads MOONSHOT_API_KEY automatically
 )
 ```
 
@@ -1881,6 +1895,9 @@ For certain Variants, the framework supports reading configuration from environm
 # DeepSeek
 export DEEPSEEK_API_KEY="your-api-key"
 # No need to call WithAPIKey explicitly; the framework reads it automatically
+
+# Kimi
+export MOONSHOT_API_KEY="your-api-key"
 ```
 
 ```go
@@ -1910,6 +1927,7 @@ The OpenAI-compatible variants serialize `ThinkingEnabled=true` as follows:
 | `VariantHunyuan` | `"thinking": {"type": "enabled"}` |
 | `VariantGLM` | `"thinking": {"type": "enabled"}` |
 | `VariantQwen` | `"enable_thinking": true` |
+| `VariantKimi` | `"thinking": {"type": "enabled"}` |
 
 For example, to deterministically enable thinking through the official DeepSeek API:
 
@@ -1934,6 +1952,19 @@ request := &model.Request{
 ```
 
 `ThinkingEnabled` applies only to models that expose an explicit thinking toggle; use `ReasoningEffort` instead when a model exposes only a reasoning budget. For external services that implement one of the thinking-toggle formats above, explicitly setting the matching `Variant` and `ThinkingEnabled` is usually sufficient. If a gateway uses a different field or requires additional parameters, use `openai.WithExtraFields(...)` to add or override provider-specific fields.
+
+For Kimi models that require thinking to remain enabled, leave
+`ThinkingEnabled` unset. To preserve reasoning across Kimi K2.6 conversation
+turns, pass the complete provider extension explicitly:
+
+```go
+openai.WithExtraFields(map[string]any{
+    "thinking": map[string]string{
+        "type": "enabled",
+        "keep": "all",
+    },
+})
+```
 
 #### 8. Streaming Tool Call Deltas: ShowToolCallDelta
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1940,12 +1940,16 @@ request := &model.Request{
 Kimi K2.6 在多轮对话间保留推理内容，可显式传入完整的服务方扩展：
 
 ```go
-openai.WithExtraFields(map[string]any{
-    "thinking": map[string]string{
-        "type": "enabled",
-        "keep": "all",
-    },
-})
+llm := openai.New(
+    "kimi-k2.6",
+    openai.WithVariant(openai.VariantKimi),
+    openai.WithExtraFields(map[string]any{
+        "thinking": map[string]string{
+            "type": "enabled",
+            "keep": "all",
+        },
+    }),
+)
 ```
 
 #### 8. 流式工具调用增量：ShowToolCallDelta

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1813,6 +1813,15 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 - 使用 GLM 的 `thinking` 对象格式序列化思考开关
 - 当部分 GLM 网关把最终答案放在 `reasoning_content` 且 `content` 为空时，框架会将其回退为可见内容
 
+**6. VariantKimi**
+
+- Kimi 开放平台适配
+- 默认 BaseURL：`https://api.moonshot.ai/v1`
+- API Key 环境变量名：`MOONSHOT_API_KEY`
+- 对官方 `api.moonshot.ai` 和 `api.moonshot.cn` host 自动推断
+- 将思考开关序列化为 `{"thinking": {"type": "enabled"}}`
+- 文件上传默认使用 `file-extract` purpose
+
 ##### 7.2. 使用方式
 
 **使用示例**：
@@ -1832,6 +1841,11 @@ model := openai.New("deepseek-v4-flash",
     openai.WithBaseURL("https://api.deepseek.com/v1"),
     openai.WithAPIKey("your-api-key"),
     openai.WithVariant(openai.VariantDeepSeek), // 指定 DeepSeek
+)
+
+// 使用 Kimi 开放平台
+model = openai.New("kimi-k2.6",
+    openai.WithVariant(openai.VariantKimi), // 自动读取 MOONSHOT_API_KEY
 )
 ```
 
@@ -1864,6 +1878,9 @@ message := model.Message{
 # DeepSeek 自动配置
 export DEEPSEEK_API_KEY="your-api-key"
 # 无需显式调用 WithAPIKey，框架会自动读取
+
+# Kimi 自动配置
+export MOONSHOT_API_KEY="your-api-key"
 ```
 
 ```go
@@ -1893,6 +1910,7 @@ model := openai.New("deepseek-v4-flash",
 | `VariantHunyuan` | `"thinking": {"type": "enabled"}` |
 | `VariantGLM` | `"thinking": {"type": "enabled"}` |
 | `VariantQwen` | `"enable_thinking": true` |
+| `VariantKimi` | `"thinking": {"type": "enabled"}` |
 
 例如，通过官方 DeepSeek API 确定性地开启思考：
 
@@ -1917,6 +1935,18 @@ request := &model.Request{
 ```
 
 `ThinkingEnabled` 只适用于提供显式思考开关的模型；如果模型只支持推理预算，请改用 `ReasoningEffort`。对实现上述思考开关格式的外部服务，通常显式设置对应 `Variant` 和 `ThinkingEnabled` 即可。如果代理网关使用了不同字段或需要额外参数，可以通过 `openai.WithExtraFields(...)` 添加或覆盖服务方特有字段。
+
+对于要求始终开启思考的 Kimi 模型，应省略 `ThinkingEnabled`。如需让
+Kimi K2.6 在多轮对话间保留推理内容，可显式传入完整的服务方扩展：
+
+```go
+openai.WithExtraFields(map[string]any{
+    "thinking": map[string]string{
+        "type": "enabled",
+        "keep": "all",
+    },
+})
+```
 
 #### 8. 流式工具调用增量：ShowToolCallDelta
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -54,6 +54,12 @@ const (
 	//nolint:gosec
 	qwenAPIKeyName     string = "DASHSCOPE_API_KEY"
 	defaultQwenBaseURL string = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+	//nolint:gosec
+	kimiAPIKeyName     string = "MOONSHOT_API_KEY"
+	defaultKimiBaseURL string = "https://api.moonshot.ai/v1"
+	kimiAPIHost        string = "api.moonshot.ai"
+	kimiCNAPIHost      string = "api.moonshot.cn"
 )
 
 // Variant represents different model variants with specific behaviors.
@@ -74,6 +80,8 @@ const (
 	// VariantGLM is the GLM OpenAI-compatible variant. Some GLM gateways
 	// return the visible final answer in reasoning_content with empty content.
 	VariantGLM Variant = "glm"
+	// VariantKimi is the Kimi OpenAI-compatible variant.
+	VariantKimi Variant = "kimi"
 )
 
 // thinkingValueConvertor converts ThinkingEnabled bool to the variant-specific value.
@@ -244,6 +252,16 @@ var variantConfigs = map[Variant]variantConfig{
 		thinkingValueConvertor:            thinkingTypeValueConvertor,
 		reasoningContentAsContentFallback: true,
 	},
+	VariantKimi: {
+		filePurpose:               openai.FilePurpose("file-extract"),
+		fileDeletionMethod:        http.MethodDelete,
+		skipFileTypeInContent:     false,
+		fileDeletionBodyConvertor: defaultFileDeletionBodyConvertor,
+		apiKeyName:                kimiAPIKeyName,
+		defaultBaseURL:            defaultKimiBaseURL,
+		thinkingEnabledKey:        thinkingKey,
+		thinkingValueConvertor:    thinkingTypeValueConvertor,
+	},
 }
 
 // Model implements the model.Model interface for OpenAI API.
@@ -377,10 +395,21 @@ func inferVariant(baseURL string) Variant {
 	if isDeepSeekBaseURL(baseURL) {
 		return VariantDeepSeek
 	}
+	if isKimiBaseURL(baseURL) {
+		return VariantKimi
+	}
 	return VariantOpenAI
 }
 
 func isDeepSeekBaseURL(raw string) bool {
+	return baseURLMatchesHost(raw, deepSeekAPIHost)
+}
+
+func isKimiBaseURL(raw string) bool {
+	return baseURLMatchesHost(raw, kimiAPIHost, kimiCNAPIHost)
+}
+
+func baseURLMatchesHost(raw string, hosts ...string) bool {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return false
@@ -389,7 +418,12 @@ func isDeepSeekBaseURL(raw string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.EqualFold(parsed.Hostname(), deepSeekAPIHost)
+	for _, host := range hosts {
+		if strings.EqualFold(parsed.Hostname(), host) {
+			return true
+		}
+	}
+	return false
 }
 
 // Info implements the model.Model interface.

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -57,6 +57,7 @@ func TestMain(m *testing.M) {
 func TestNew(t *testing.T) {
 	var testKey = "test-key"
 	t.Setenv(deepSeekAPIKeyName, testKey)
+	t.Setenv(kimiAPIKeyName, testKey)
 	tests := []struct {
 		name       string
 		modelName  string
@@ -94,6 +95,49 @@ func TestNew(t *testing.T) {
 			expectOpts: []Option{
 				WithAPIKey(testKey),
 				WithBaseURL(defaultDeepSeekBaseURL),
+			},
+		},
+		{
+			name:      "variant kimi",
+			modelName: "kimi-k2.6",
+			opts: []Option{
+				WithVariant(VariantKimi),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL(defaultKimiBaseURL),
+			},
+		},
+		{
+			name:      "does not infer kimi from official model name",
+			modelName: "kimi-k2.6",
+			opts: []Option{
+				WithAPIKey(testKey),
+			},
+			expectOpts: nil,
+		},
+		{
+			name:      "infers kimi from international api base url",
+			modelName: "custom-model",
+			opts: []Option{
+				WithBaseURL("https://api.moonshot.ai/v1"),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL("https://api.moonshot.ai/v1"),
+				WithVariant(VariantKimi),
+			},
+		},
+		{
+			name:      "infers kimi from china api base url",
+			modelName: "custom-model",
+			opts: []Option{
+				WithBaseURL("https://api.moonshot.cn/v1"),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL("https://api.moonshot.cn/v1"),
+				WithVariant(VariantKimi),
 			},
 		},
 		{
@@ -228,6 +272,46 @@ func TestIsDeepSeekBaseURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isDeepSeekBaseURL(tt.rawURL))
+		})
+	}
+}
+
+func TestIsKimiBaseURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   bool
+	}{
+		{
+			name:   "matches international api host",
+			rawURL: "https://api.moonshot.ai/v1",
+			want:   true,
+		},
+		{
+			name:   "matches china api host after trim and lowercase",
+			rawURL: " HTTPS://API.MOONSHOT.CN/V1 ",
+			want:   true,
+		},
+		{
+			name:   "does not match platform host",
+			rawURL: "https://platform.moonshot.ai/v1",
+			want:   false,
+		},
+		{
+			name:   "does not match custom proxy host",
+			rawURL: "https://moonshot-proxy.internal/v1",
+			want:   false,
+		},
+		{
+			name:   "parse error does not fall back to substring match",
+			rawURL: "https://api.moonshot.ai/%zz",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isKimiBaseURL(tt.rawURL))
 		})
 	}
 }
@@ -3735,6 +3819,81 @@ func TestModel_GenerateContent_HunyuanThinkingPayload(t *testing.T) {
 	}
 }
 
+func TestModel_GenerateContent_KimiThinkingPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    string
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+			want:    "enabled",
+		},
+		{
+			name:    "disabled",
+			enabled: false,
+			want:    "disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured map[string]any
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprint(w, `{
+						"id": "test",
+						"object": "chat.completion",
+						"created": 1699200000,
+						"model": "kimi-k2.6",
+						"choices": [{
+							"index": 0,
+							"message": {
+								"role": "assistant",
+								"content": "ok"
+							},
+							"finish_reason": "stop"
+						}]
+					}`)
+				},
+			))
+			defer server.Close()
+
+			m := New(
+				"kimi-k2.6",
+				WithVariant(VariantKimi),
+				WithBaseURL(server.URL),
+				WithAPIKey("test-key"),
+			)
+			req := &model.Request{
+				Messages: []model.Message{
+					model.NewUserMessage("hi"),
+				},
+				GenerationConfig: model.GenerationConfig{
+					ThinkingEnabled: &tt.enabled,
+				},
+			}
+			ch, err := m.GenerateContent(context.Background(), req)
+			require.NoError(t, err)
+			for resp := range ch {
+				require.Nil(t, resp.Error)
+			}
+
+			thinking, ok := captured[thinkingKey].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.want, thinking["type"])
+			require.NotContains(t, captured, model.ThinkingEnabledKey)
+		})
+	}
+}
+
 // TestModel_GenerateContent_NonStreaming_ToolCallNoID_Synthesized verifies that
 // when the provider omits tool_call.id in a non-streaming response, we synthesize
 // a stable ID (auto_call_<index>). This covers the non-streaming code path in
@@ -3956,6 +4115,47 @@ func TestUploadFileData_Success(t *testing.T) {
 	id, err := m.UploadFileData(context.Background(), "batch_input.jsonl", []byte("hello jsonl"), WithPurpose(openaigo.FilePurposeBatch), WithPath(""), WithFileBaseURL(server.URL))
 	require.NoErrorf(t, err, "UploadFileData failed: %v", err)
 	assert.Equalf(t, "file_test_1", id, "expected id=file_test_1, got %s", id)
+}
+
+func TestUploadFileData_KimiDefaults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/files", r.URL.Path)
+		require.NoError(t, r.ParseMultipartForm(10<<20))
+		require.Equal(
+			t,
+			"file-extract",
+			r.MultipartForm.Value["purpose"][0],
+		)
+		files := r.MultipartForm.File["file"]
+		require.Len(t, files, 1)
+		require.Equal(t, "notes.txt", files[0].Filename)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"id":"file_kimi_1",
+			"object":"file",
+			"bytes":5,
+			"created_at":123,
+			"filename":"notes.txt",
+			"purpose":"file-extract"
+		}`)
+	}))
+	defer server.Close()
+
+	m := New(
+		"kimi-k2.6",
+		WithVariant(VariantKimi),
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL+"/v1"),
+	)
+	id, err := m.UploadFileData(
+		context.Background(),
+		"notes.txt",
+		[]byte("hello"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "file_kimi_1", id)
 }
 
 // TestUploadFile_Success tests UploadFile with a temp file and mock server.
@@ -4552,6 +4752,14 @@ func TestWithVariant(t *testing.T) {
 			opts.Variant,
 			"expected variant to be VariantGLM",
 		)
+		assert.True(t, opts.variantSet, "expected variantSet to be true")
+	})
+
+	t.Run("kimi variant", func(t *testing.T) {
+		opts := &options{}
+		WithVariant(VariantKimi)(opts)
+
+		assert.Equal(t, VariantKimi, opts.Variant, "expected variant to be VariantKimi")
 		assert.True(t, opts.variantSet, "expected variantSet to be true")
 	})
 
@@ -7500,6 +7708,13 @@ func TestBuildThinkingOption(t *testing.T) {
 		{
 			name:            "Hunyuan variant with thinking enabled",
 			variant:         VariantHunyuan,
+			thinkingEnabled: &trueVal,
+			wantKeys:        []string{thinkingKey},
+			wantValues:      []any{map[string]string{"type": "enabled"}},
+		},
+		{
+			name:            "Kimi variant with thinking enabled",
+			variant:         VariantKimi,
 			thinkingEnabled: &trueVal,
 			wantKeys:        []string{thinkingKey},
 			wantValues:      []any{map[string]string{"type": "enabled"}},

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -316,6 +316,10 @@ func WithExtraFields(extraFields map[string]any) Option {
 // The default variant is VariantOpenAI.
 // Optional variants are:
 // - VariantHunyuan: Hunyuan variant with specific file handling.
+// - VariantDeepSeek: DeepSeek-compatible request behavior.
+// - VariantQwen: Qwen-compatible request behavior.
+// - VariantGLM: GLM-compatible request and response behavior.
+// - VariantKimi: Kimi-compatible request and file behavior.
 func WithVariant(variant Variant) Option {
 	return func(opts *options) {
 		opts.Variant = variant

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -517,6 +517,8 @@ const (
 	qwenAPIHost     = "dashscope.aliyuncs.com"
 	hunyuanAPIHost  = "api.hunyuan.cloud.tencent.com"
 	glmAPIHost      = "open.bigmodel.cn"
+	kimiAPIHost     = "api.moonshot.ai"
+	kimiCNAPIHost   = "api.moonshot.cn"
 
 	openAIAPIKeyEnvName  = "OPENAI_API_KEY"
 	openAIBaseURLEnvName = "OPENAI_BASE_URL"
@@ -4031,7 +4033,8 @@ func parseOpenAIVariant(
 		openai.VariantDeepSeek,
 		openai.VariantHunyuan,
 		openai.VariantQwen,
-		openai.VariantGLM:
+		openai.VariantGLM,
+		openai.VariantKimi:
 		return variant, nil
 	default:
 		return "", fmt.Errorf("unsupported openai variant: %s", raw)
@@ -4086,6 +4089,9 @@ func inferOpenAIVariant(baseURL string) openai.Variant {
 		return openai.VariantHunyuan
 	case strings.EqualFold(host, glmAPIHost):
 		return openai.VariantGLM
+	case strings.EqualFold(host, kimiAPIHost),
+		strings.EqualFold(host, kimiCNAPIHost):
+		return openai.VariantKimi
 	default:
 		return openai.VariantOpenAI
 	}

--- a/openclaw/app/app_test.go
+++ b/openclaw/app/app_test.go
@@ -4484,6 +4484,10 @@ func TestParseOpenAIVariant_Explicit(t *testing.T) {
 	v, err = parseOpenAIVariant(string(openai.VariantGLM), "")
 	require.NoError(t, err)
 	require.Equal(t, openai.VariantGLM, v)
+
+	v, err = parseOpenAIVariant(string(openai.VariantKimi), "")
+	require.NoError(t, err)
+	require.Equal(t, openai.VariantKimi, v)
 }
 
 func TestParseOpenAIVariant_Auto(t *testing.T) {
@@ -4557,6 +4561,16 @@ func TestInferOpenAIVariant(t *testing.T) {
 		t,
 		openai.VariantGLM,
 		inferOpenAIVariant("https://open.bigmodel.cn/api/paas/v4"),
+	)
+	require.Equal(
+		t,
+		openai.VariantKimi,
+		inferOpenAIVariant("https://api.moonshot.ai/v1"),
+	)
+	require.Equal(
+		t,
+		openai.VariantKimi,
+		inferOpenAIVariant("https://api.moonshot.cn/v1"),
 	)
 	require.Equal(
 		t,

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -641,7 +641,7 @@ func parseRunOptions(args []string) (runOptions, error) {
 		"openai-variant",
 		defaultOpenAIVariant,
 		"OpenAI variant: auto, openai, deepseek, qwen, hunyuan, "+
-			"glm (auto uses configured base URL host)",
+			"glm, kimi (auto uses configured base URL host)",
 	)
 	fs.StringVar(
 		&opts.OpenAIBaseURL,


### PR DESCRIPTION
## Summary

- add a first-class Kimi OpenAI-compatible variant
- configure the official international and China endpoints, API key environment variable, thinking payload, and file upload purpose
- expose the variant through OpenClaw auto-detection and document its usage in English and Chinese

## Validation

- `go test ./model/openai -count=1`
- `go test ./... -count=1` (the Unix-socket test was re-run successfully with a shorter temporary directory)
- `go test ./app -run 'TestParseOpenAIVariant|TestInferOpenAIVariant|TestModelCompatibilityRunOptions' -count=1` in the OpenClaw module
- `go vet ./model/openai`
- `go vet ./app` in the OpenClaw module
- `goimports -l` on the changed Go files

`golangci-lint` could not load the repository configuration with the locally installed version because that version expects a different `output.formats` schema; CI will run the repository-pinned lint toolchain.
