### PR TITLE
model: use precise GPT-5 context windows

### DIFF
--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -35,6 +35,9 @@ var ModelContextWindows = map[string]int{
 	"o3":         200000, // https://developers.openai.com/api/docs/models/o3
 	"o4-mini":    200000, // https://developers.openai.com/api/docs/models/o4-mini
 
+	// 1,047,576 follows OpenAI Agents SDK compaction metadata:
+	// https://github.com/openai/openai-agents-python/blob/main/src/agents/sandbox/capabilities/compaction.py
+
 	// OpenAI GPT-5.6
 	"gpt-5.6":       1047576, // Alias for GPT-5.6 Sol — https://developers.openai.com/api/docs/models/gpt-5.6-sol
 	"gpt-5.6-sol":   1047576, // https://developers.openai.com/api/docs/models/gpt-5.6-sol

--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -36,18 +36,18 @@ var ModelContextWindows = map[string]int{
 	"o4-mini":    200000, // https://developers.openai.com/api/docs/models/o4-mini
 
 	// OpenAI GPT-5.6
-	"gpt-5.6":       1050000, // Alias for GPT-5.6 Sol — https://developers.openai.com/api/docs/models/gpt-5.6-sol
-	"gpt-5.6-sol":   1050000, // https://developers.openai.com/api/docs/models/gpt-5.6-sol
-	"gpt-5.6-terra": 1050000, // https://developers.openai.com/api/docs/models/gpt-5.6-terra
-	"gpt-5.6-luna":  1050000, // https://developers.openai.com/api/docs/models/gpt-5.6-luna
+	"gpt-5.6":       1047576, // Alias for GPT-5.6 Sol — https://developers.openai.com/api/docs/models/gpt-5.6-sol
+	"gpt-5.6-sol":   1047576, // https://developers.openai.com/api/docs/models/gpt-5.6-sol
+	"gpt-5.6-terra": 1047576, // https://developers.openai.com/api/docs/models/gpt-5.6-terra
+	"gpt-5.6-luna":  1047576, // https://developers.openai.com/api/docs/models/gpt-5.6-luna
 
 	// OpenAI GPT-5.5
-	"gpt-5.5":     1050000, // https://developers.openai.com/api/docs/models/gpt-5.5
-	"gpt-5.5-pro": 1050000, // https://developers.openai.com/api/docs/models/gpt-5.5-pro
+	"gpt-5.5":     1047576, // https://developers.openai.com/api/docs/models/gpt-5.5
+	"gpt-5.5-pro": 1047576, // https://developers.openai.com/api/docs/models/gpt-5.5-pro
 
 	// OpenAI GPT-5.4
-	"gpt-5.4":      1050000, // https://developers.openai.com/api/docs/models/gpt-5.4
-	"gpt-5.4-pro":  1050000, // https://developers.openai.com/api/docs/models/gpt-5.4-pro
+	"gpt-5.4":      1047576, // https://developers.openai.com/api/docs/models/gpt-5.4
+	"gpt-5.4-pro":  1047576, // https://developers.openai.com/api/docs/models/gpt-5.4-pro
 	"gpt-5.4-mini": 400000,  // https://developers.openai.com/api/docs/models/gpt-5.4-mini
 	"gpt-5.4-nano": 400000,  // https://developers.openai.com/api/docs/models/gpt-5.4-nano
 

--- a/model/internal/model/model_info_test.go
+++ b/model/internal/model/model_info_test.go
@@ -49,22 +49,32 @@ func TestResolveContextWindow(t *testing.T) {
 		{
 			name:      "exact match - GPT-5.6 alias",
 			modelName: "gpt-5.6",
-			expected:  1050000,
+			expected:  1047576,
 		},
 		{
 			name:      "exact match - GPT-5.6 Terra",
 			modelName: "gpt-5.6-terra",
-			expected:  1050000,
+			expected:  1047576,
 		},
 		{
 			name:      "exact match - GPT-5.4",
 			modelName: "gpt-5.4",
-			expected:  1050000,
+			expected:  1047576,
 		},
 		{
 			name:      "exact match - GPT-5.4-pro",
 			modelName: "gpt-5.4-pro",
-			expected:  1050000,
+			expected:  1047576,
+		},
+		{
+			name:      "exact match - GPT-5.5",
+			modelName: "gpt-5.5",
+			expected:  1047576,
+		},
+		{
+			name:      "exact match - GPT-5.5-pro",
+			modelName: "gpt-5.5-pro",
+			expected:  1047576,
 		},
 		{
 			name:      "exact match - GPT-5.3-Codex",
@@ -319,7 +329,17 @@ func TestResolveContextWindow(t *testing.T) {
 		{
 			name:      "longest prefix match - GPT-5.4 snapshot",
 			modelName: "gpt-5.4-2026-03-05",
-			expected:  1050000,
+			expected:  1047576,
+		},
+		{
+			name:      "longest prefix match - GPT-5.5 snapshot",
+			modelName: "gpt-5.5-2026-04-23",
+			expected:  1047576,
+		},
+		{
+			name:      "longest prefix match - GPT-5.6 snapshot",
+			modelName: "gpt-5.6-sol-2026-07-09",
+			expected:  1047576,
 		},
 		{
 			name:      "longest prefix match - GPT-5.4 mini snapshot",


### PR DESCRIPTION
## Summary
- Normalize GPT-5.4, GPT-5.5, and GPT-5.6 1M-class context windows to the precise `1047576` token value.
- Update context-window resolution tests for exact and dated snapshot model IDs.

## Background
PR #2194 added the latest OpenAI model metadata and used `1050000` for these 1M-class GPT-5 families. OpenAI Agents Python and JS both use `1047576` for the same 1M-class context-window bucket, matching the exact `1M - 1024` value already documented in this registry for GPT-4.1. This follow-up keeps the GPT-5.4/5.5/5.6 entries consistent with that precise value.

## Test plan
- `go test ./model/internal/model`
- `go test ./model/...`


Made with [Cursor](https://cursor.com)