### PR TITLE
tool/agent: isolate AgentTool run-scoped tools

### DIFF
--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -625,6 +625,11 @@ func (at *Tool) childInvocationOptions(
 	if parentInv == nil {
 		return invocationOpts
 	}
+	invocationOpts = append(invocationOpts, func(inv *agent.Invocation) {
+		runOptions := inv.RunOptions
+		clearInheritedToolRunOptions(&runOptions)
+		inv.RunOptions = runOptions
+	})
 	if at.hasPinnedRunOptions() {
 		invocationOpts = append(invocationOpts, func(inv *agent.Invocation) {
 			runOptions := inv.RunOptions
@@ -641,6 +646,16 @@ func (at *Tool) childInvocationOptions(
 		)
 	}
 	return invocationOpts
+}
+
+func clearInheritedToolRunOptions(runOptions *agent.RunOptions) {
+	if runOptions == nil {
+		return
+	}
+	runOptions.ToolFilter = nil
+	runOptions.AdditionalTools = nil
+	runOptions.ExternalTools = nil
+	runOptions.ExternalToolNames = nil
 }
 
 func (at *Tool) hasPinnedRunOptions() bool {

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -5803,6 +5803,12 @@ func TestTool_ChildInvocationOptions_ClearsInheritedToolRunOptions(t *testing.T)
 	require.NotNil(t, parentInv.RunOptions.ToolFilter)
 }
 
+func TestClearInheritedToolRunOptions_Nil(t *testing.T) {
+	require.NotPanics(t, func() {
+		clearInheritedToolRunOptions(nil)
+	})
+}
+
 func TestTool_WithPinModel_Disabled_PreservesModelName(t *testing.T) {
 	mockAgent := &mockAgent{
 		name:        "test-agent",

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -569,6 +569,16 @@ func (m *toolSurfaceRecordingModel) sawTool(name string) bool {
 	return false
 }
 
+func newAgentToolTestTool(name string) tool.Tool {
+	return function.NewFunctionTool(
+		func(_ context.Context, _ map[string]string) (string, error) {
+			return name, nil
+		},
+		function.WithName(name),
+		function.WithDescription("Returns a test response."),
+	)
+}
+
 type handoffArgs struct {
 	AgentID string `json:"agent_id"`
 	Task    string `json:"task"`
@@ -5242,6 +5252,47 @@ func TestTool_callWithParentInvocation_NoSessionFallback(t *testing.T) {
 	require.Equal(t, "Hello from mock agent!", res)
 }
 
+func TestTool_callWithParentInvocation_DoesNotInheritParentToolSurface(t *testing.T) {
+	const (
+		childToolName      = "child_tool"
+		additionalToolName = "parent_additional"
+		externalToolName   = "parent_external"
+	)
+	childTool := newAgentToolTestTool(childToolName)
+	additionalTool := newAgentToolTestTool(additionalToolName)
+	externalTool := newAgentToolTestTool(externalToolName)
+	childModel := &toolSurfaceRecordingModel{
+		name:    "child-model",
+		message: model.NewAssistantMessage("child done"),
+	}
+	child := llmagent.New(
+		"child-agent",
+		llmagent.WithModel(childModel),
+		llmagent.WithTools([]tool.Tool{childTool}),
+	)
+	at := NewTool(child)
+	parentRunOptions := agent.NewRunOptions(
+		agent.WithAdditionalTools([]tool.Tool{additionalTool}),
+		agent.WithExternalTools([]tool.Tool{externalTool}),
+		agent.WithToolFilter(func(_ context.Context, tl tool.Tool) bool {
+			decl := tl.Declaration()
+			return decl == nil || decl.Name != childToolName
+		}),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(session.NewSession("app", "user", "session")),
+		agent.WithInvocationRunOptions(parentRunOptions),
+		agent.WithInvocationEventFilterKey("parent-agent"),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+	result, err := at.Call(ctx, []byte(`{"request":"hi"}`))
+	require.NoError(t, err)
+	require.Equal(t, "child done", result)
+	require.True(t, childModel.sawTool(childToolName))
+	require.False(t, childModel.sawTool(additionalToolName))
+	require.False(t, childModel.sawTool(externalToolName))
+}
+
 func TestTool_callWithParentInvocation_PreservesRunStructuredOutput(t *testing.T) {
 	modelImpl := &structuredOutputCaptureModel{name: "capture-model"}
 	child := llmagent.New("structured-output-child", llmagent.WithModel(modelImpl))
@@ -5697,6 +5748,59 @@ func TestTool_WithPinRunOptions_PreservesRuntimeState(t *testing.T) {
 	childInv := parentInv.Clone(opts...)
 	require.Empty(t, childInv.RunOptions.ModelName)
 	require.Equal(t, runtimeState, childInv.RunOptions.RuntimeState)
+}
+
+func TestTool_ChildInvocationOptions_ClearsInheritedToolRunOptions(t *testing.T) {
+	mockAgent := &mockAgent{
+		name:        "test-agent",
+		description: "A test agent",
+	}
+	agentTool := NewTool(mockAgent)
+	additionalTool := newAgentToolTestTool("parent_additional")
+	externalTool := newAgentToolTestTool("parent_external")
+	toolFilter := func(context.Context, tool.Tool) bool {
+		return false
+	}
+	executionFilter := func(context.Context, tool.Tool) bool {
+		return true
+	}
+	permissionPolicy := tool.PermissionPolicyFunc(
+		func(context.Context, *tool.PermissionRequest) (tool.PermissionDecision, error) {
+			return tool.AllowPermission(), nil
+		},
+	)
+	parentInv := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			ModelName:            "parent-model",
+			RuntimeState:         map[string]any{"room_id": "r1"},
+			ToolFilter:           toolFilter,
+			AdditionalTools:      []tool.Tool{additionalTool},
+			ExternalTools:        []tool.Tool{externalTool},
+			ExternalToolNames:    map[string]bool{"parent_external": true},
+			ToolExecutionFilter:  executionFilter,
+			ToolPermissionPolicy: permissionPolicy,
+		}),
+	)
+	opts := agentTool.childInvocationOptions(
+		context.Background(),
+		parentInv,
+		model.NewUserMessage("test"),
+		"child-key",
+		nil,
+	)
+	childInv := parentInv.Clone(opts...)
+	require.Nil(t, childInv.RunOptions.ToolFilter)
+	require.Nil(t, childInv.RunOptions.AdditionalTools)
+	require.Nil(t, childInv.RunOptions.ExternalTools)
+	require.Nil(t, childInv.RunOptions.ExternalToolNames)
+	require.Equal(t, "parent-model", childInv.RunOptions.ModelName)
+	require.Equal(t, map[string]any{"room_id": "r1"}, childInv.RunOptions.RuntimeState)
+	require.NotNil(t, childInv.RunOptions.ToolExecutionFilter)
+	require.NotNil(t, childInv.RunOptions.ToolPermissionPolicy)
+	require.Equal(t, additionalTool, parentInv.RunOptions.AdditionalTools[0])
+	require.Equal(t, externalTool, parentInv.RunOptions.ExternalTools[0])
+	require.Equal(t, map[string]bool{"parent_external": true}, parentInv.RunOptions.ExternalToolNames)
+	require.NotNil(t, parentInv.RunOptions.ToolFilter)
 }
 
 func TestTool_WithPinModel_Disabled_PreservesModelName(t *testing.T) {


### PR DESCRIPTION
Refs #2219. This isolates ordinary AgentTool child invocations from parent run-scoped tool surface fields by clearing inherited additional tools, external tools, external tool names, and tool filters at the AgentTool boundary, while leaving other clone-based orchestration paths unchanged.