### PR TITLE
internal/flow: surface structured output parse failures

### DIFF
--- a/internal/flow/processor/output.go
+++ b/internal/flow/processor/output.go
@@ -20,6 +20,18 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
+const (
+	structuredOutputParseErrorCode         = "structured_output_parse_error"
+	structuredOutputParseErrorExtensionKey = "trpc_agent.structured_output_parse_error"
+	structuredOutputParseErrorSnippetBytes = 512
+)
+
+type structuredOutputParseErrorExtension struct {
+	Error     string `json:"error"`
+	Snippet   string `json:"snippet,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
 // OutputResponseProcessor processes final responses and handles output_key and output_schema functionality.
 type OutputResponseProcessor struct {
 	outputKey    string
@@ -100,6 +112,7 @@ func (p *OutputResponseProcessor) emitStructuredOutput(
 				"Structured output unmarshal failed: %v",
 				err,
 			)
+			p.emitStructuredOutputParseError(ctx, invocation, jsonObject, err, ch)
 			return
 		}
 		typedEvt := event.New(
@@ -124,6 +137,7 @@ func (p *OutputResponseProcessor) emitStructuredOutput(
 			"Structured output unmarshal failed: %v",
 			err,
 		)
+		p.emitStructuredOutputParseError(ctx, invocation, jsonObject, err, ch)
 		return
 	}
 	untypedEvt := event.New(
@@ -134,6 +148,43 @@ func (p *OutputResponseProcessor) emitStructuredOutput(
 	)
 	log.DebugContext(ctx, "Emitted untyped structured output payload event.")
 	agent.EmitEvent(ctx, invocation, ch, untypedEvt)
+}
+
+func (p *OutputResponseProcessor) emitStructuredOutputParseError(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	jsonObject string,
+	parseErr error,
+	ch chan<- *event.Event,
+) {
+	if invocation == nil || parseErr == nil {
+		return
+	}
+	snippet, truncated := truncateStructuredOutputSnippet(jsonObject)
+	errEvt := event.New(
+		invocation.InvocationID,
+		invocation.AgentName,
+		event.WithObject(model.ObjectTypeStateUpdate),
+		event.WithTag(structuredOutputParseErrorCode),
+		event.WithExtension(
+			structuredOutputParseErrorExtensionKey,
+			structuredOutputParseErrorExtension{
+				Error:     parseErr.Error(),
+				Snippet:   snippet,
+				Truncated: truncated,
+			},
+		),
+	)
+	if err := agent.EmitEvent(ctx, invocation, ch, errEvt); err != nil {
+		log.WarnfContext(ctx, "Failed to emit structured output parse error event: %v", err)
+	}
+}
+
+func truncateStructuredOutputSnippet(s string) (string, bool) {
+	if len(s) <= structuredOutputParseErrorSnippetBytes {
+		return s, false
+	}
+	return s[:structuredOutputParseErrorSnippetBytes], true
 }
 
 // handleOutputKey validates and emits state delta for output_key/output_schema cases.

--- a/internal/flow/processor/output_structured_test.go
+++ b/internal/flow/processor/output_structured_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -89,5 +90,75 @@ func TestOutputResponseProcessor_StructuredOutputUntypedEvent(t *testing.T) {
 		}
 	default:
 		t.Fatalf("expected an event to be emitted")
+	}
+}
+
+func TestOutputResponseProcessor_StructuredOutputParseErrorTruncatesSnippet(t *testing.T) {
+	ctx := context.Background()
+	proc := NewOutputResponseProcessor("", nil)
+
+	inv := &agent.Invocation{InvocationID: "inv", AgentName: "agent"}
+	inv.StructuredOutputType = reflect.TypeOf(typedStruct{})
+
+	content := "{" + strings.Repeat("x", structuredOutputParseErrorSnippetBytes+1) + "}"
+	rsp := &model.Response{
+		Done:    true,
+		Choices: []model.Choice{{Message: model.Message{Content: content}}},
+	}
+
+	ch := make(chan *event.Event, 1)
+	proc.ProcessResponse(ctx, inv, &model.Request{}, rsp, ch)
+	close(ch)
+	if len(ch) != 1 {
+		t.Fatalf("expected one parse error event, got %d", len(ch))
+	}
+	evt := <-ch
+	assertStructuredOutputParseError(t, evt)
+	raw := evt.Extensions[structuredOutputParseErrorExtensionKey]
+	var ext structuredOutputParseErrorExtension
+	if err := json.Unmarshal(raw, &ext); err != nil {
+		t.Fatalf("unmarshal parse error extension: %v", err)
+	}
+	if len(ext.Snippet) != structuredOutputParseErrorSnippetBytes {
+		t.Fatalf("expected snippet length %d, got %d", structuredOutputParseErrorSnippetBytes, len(ext.Snippet))
+	}
+	if !ext.Truncated {
+		t.Fatalf("expected truncated=true")
+	}
+}
+
+func assertStructuredOutputParseError(
+	t *testing.T,
+	evt *event.Event,
+) {
+	t.Helper()
+	if evt == nil {
+		t.Fatalf("expected parse error event")
+	}
+	if evt.Object != model.ObjectTypeStateUpdate {
+		t.Fatalf("expected state update parse error event, got %q", evt.Object)
+	}
+	if evt.Done {
+		t.Fatalf("parse error event should be non-terminal")
+	}
+	if evt.Error != nil {
+		t.Fatalf("parse error observability event should not set Response.Error: %v", evt.Error)
+	}
+	if !evt.ContainsTag(structuredOutputParseErrorCode) {
+		t.Fatalf("expected parse error tag %q", structuredOutputParseErrorCode)
+	}
+	raw, ok := evt.Extensions[structuredOutputParseErrorExtensionKey]
+	if !ok {
+		t.Fatalf("expected parse error extension %q", structuredOutputParseErrorExtensionKey)
+	}
+	var ext structuredOutputParseErrorExtension
+	if err := json.Unmarshal(raw, &ext); err != nil {
+		t.Fatalf("unmarshal parse error extension: %v", err)
+	}
+	if ext.Error == "" {
+		t.Fatalf("expected extension error")
+	}
+	if ext.Snippet == "" {
+		t.Fatalf("expected extension snippet")
 	}
 }

--- a/internal/flow/processor/output_test.go
+++ b/internal/flow/processor/output_test.go
@@ -344,9 +344,10 @@ func TestOutputResponseProcessor_TypedInvalidJSON(t *testing.T) {
 	proc.ProcessResponse(ctx, inv, nil, rsp, ch)
 
 	close(ch)
-	if len(ch) != 0 {
-		t.Fatalf("expected no events for invalid structured output")
+	if len(ch) != 1 {
+		t.Fatalf("expected one parse error event for invalid structured output, got %d", len(ch))
 	}
+	assertStructuredOutputParseError(t, <-ch)
 }
 
 func TestOutputResponseProcessor_HandleOutputKey_AddNoticeError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Emit a non-terminal observability event when structured output parsing fails.
- Attach a namespaced extension with the parse error and a 512-byte truncated snippet for diagnostics.
- Keep runner completion and trace status unchanged by avoiding `Response.Error` on the observability event.

## Test plan
- `go test ./internal/flow/processor`
- IDE lints for touched files


Made with [Cursor](https://cursor.com)