### PR TITLE
tool/mcp: document ToolSet tool name prefixing

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -846,6 +846,33 @@ agent := llmagent.New("mcp-assistant",
     llmagent.WithToolSets([]tool.ToolSet{mcpToolSet}))
 ```
 
+### Tool Name Prefixing
+
+When an MCP ToolSet is wired into an `LLMAgent` via `WithToolSets`, the
+framework wraps it with `NamedToolSet`. The model sees each remote tool under
+`{toolSetName}_{remoteToolName}` while the underlying MCP `tools/call` still
+uses the original remote name.
+
+- Default ToolSet name is `"mcp"`, so a remote tool `search` becomes
+  `mcp_search`.
+- Set a distinct name per MCP server with `mcp.WithName(...)` when you attach
+  multiple ToolSets. Reusing the default for every server can produce duplicate
+  prefixed names (for example, two servers both exposing `search` would both
+  appear as `mcp_search`).
+- If `ToolSet.Name()` is empty, no prefix is applied (not the default for
+  `NewMCPToolSet`).
+
+```go
+githubToolSet := mcp.NewMCPToolSet(githubCfg, mcp.WithName("github"))
+slackToolSet := mcp.NewMCPToolSet(slackCfg, mcp.WithName("slack"))
+
+agent := llmagent.New("multi-mcp",
+    llmagent.WithModel(model),
+    llmagent.WithToolSets([]tool.ToolSet{githubToolSet, slackToolSet}),
+)
+// Model-visible names: github_search, slack_search, ...
+```
+
 ### MCP Annotations and Permission Metadata
 
 When a remote MCP server returns tool annotations from `tools/list`, direct

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -824,6 +824,29 @@ agent := llmagent.New("mcp-assistant",
     llmagent.WithToolSets([]tool.ToolSet{mcpToolSet}))
 ```
 
+### 工具名前缀
+
+通过 `WithToolSets` 把 MCP ToolSet 挂到 `LLMAgent` 上时，框架会用
+`NamedToolSet` 包装它。模型侧看到的工具名为
+`{toolSetName}_{远端工具名}`，实际 MCP `tools/call` 仍使用远端原始名称。
+
+- 默认 ToolSet 名为 `"mcp"`，远端工具 `search` 会暴露为 `mcp_search`。
+- 挂载多个 MCP ToolSet 时，请用 `mcp.WithName(...)` 为每个 ToolSet 设置
+  不同名称。若都使用默认名，可能出现前缀冲突（例如两个 server 都有
+  `search`，模型侧都会显示为 `mcp_search`）。
+- 当 `ToolSet.Name()` 为空时不加前缀（`NewMCPToolSet` 默认不会为空）。
+
+```go
+githubToolSet := mcp.NewMCPToolSet(githubCfg, mcp.WithName("github"))
+slackToolSet := mcp.NewMCPToolSet(slackCfg, mcp.WithName("slack"))
+
+agent := llmagent.New("multi-mcp",
+    llmagent.WithModel(model),
+    llmagent.WithToolSets([]tool.ToolSet{githubToolSet, slackToolSet}),
+)
+// 模型可见名称：github_search、slack_search、...
+```
+
 ### MCP Annotations 与权限 Metadata
 
 当远端 MCP server 在 `tools/list` 中返回 tool annotations 时，直接通过

--- a/tool/mcp/config.go
+++ b/tool/mcp/config.go
@@ -164,9 +164,11 @@ func WithSessionReconnectConfig(config SessionReconnectConfig) ToolSetOption {
 	}
 }
 
-// WithName sets the name of the MCP toolset for identification and conflict resolution.
-// This name will be used when implementing tool name prefixing to avoid conflicts
-// between tools from different toolsets.
+// WithName sets the ToolSet name used for model-visible tool name prefixing.
+// When an MCP ToolSet is attached to an LLMAgent, the framework wraps it with
+// NamedToolSet and exposes each tool as {name}_{remoteToolName} (for example,
+// WithName("github") + remote tool "search" becomes "github_search"). Use a
+// distinct name for each MCP ToolSet to avoid collisions; the default is "mcp".
 func WithName(name string) ToolSetOption {
 	return func(c *toolSetConfig) {
 		c.name = name

--- a/tool/mcp/toolset.go
+++ b/tool/mcp/toolset.go
@@ -62,9 +62,9 @@ type ToolSet struct {
 }
 
 // NewMCPToolSet creates a new MCP tool set with the given configuration.
-// Use WithName option to set a custom name for the toolset to avoid name conflicts
-// for tools with the same name under different tool sets when using multiple MCP toolsets.
-// Example: NewMCPToolSet(config, WithName("your-mcp-toolset"))
+// The default ToolSet name is "mcp". When attached to an LLMAgent, tools are
+// exposed to the model as {name}_{remoteToolName}; pass WithName with a unique
+// value per MCP server to avoid prefix collisions across multiple ToolSets.
 func NewMCPToolSet(config ConnectionConfig, opts ...ToolSetOption) *ToolSet {
 	// Apply default configuration.
 	cfg := toolSetConfig{


### PR DESCRIPTION
## Summary
- Update `WithName` and `NewMCPToolSet` comments to reflect existing `NamedToolSet` prefixing (`{name}_{remoteToolName}`).
- Add MCP tool name prefixing guidance to English and Chinese `tool.md`, including the default `"mcp"` name and multi-ToolSet collision pitfall.

## Test plan
- [x] Docs-only change; no runtime behavior modified
- [x] Review rendered MkDocs section for MCP tool name prefixing


Made with [Cursor](https://cursor.com)