### PR TITLE
evaluation: drop hallucinated surface/step ids instead of failin for backwarder

### DIFF
--- a/evaluation/workflow/promptiter/backwarder/backwarder.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder.go
@@ -503,6 +503,14 @@ func sanitizeSurfaceGradient(
 			request.StepID,
 		)
 	}
+	// LLM 有时会幻觉出 request AllowedGradientSurfaceIDs 集合外的 surface id。
+	// 单条 drop（keep=false），不 kill 整轮 sanitize —— sanitizeBackwardResult
+	// 最终若 gradients + upstream 都空，会在末尾 "backward result is empty" 兜底 fatal。
+	if gradient.SurfaceID != "" {
+		if _, ok := surfaceIndex[gradient.SurfaceID]; !ok {
+			return promptiter.SurfaceGradient{}, false, nil
+		}
+	}
 	surfaceID, err := sanitizeGradientSurfaceID(surfaceIndex, gradient.SurfaceID)
 	if err != nil {
 		return promptiter.SurfaceGradient{}, false, fmt.Errorf("sanitize gradient surface id: %w", err)
@@ -522,6 +530,14 @@ func sanitizePropagation(
 	predecessorIndex map[string]Predecessor,
 	propagation Propagation,
 ) (Propagation, bool, error) {
+	// LLM 有时会幻觉出 request Predecessors 集合外的 step id。
+	// 单条 drop（keep=false），不 kill 整轮 sanitize —— sanitizeBackwardResult
+	// 最终若 gradients + upstream 都空，会在末尾 "backward result is empty" 兜底 fatal。
+	if propagation.PredecessorStepID != "" {
+		if _, ok := predecessorIndex[propagation.PredecessorStepID]; !ok {
+			return Propagation{}, false, nil
+		}
+	}
 	predecessorStepID, err := sanitizePropagationPredecessorStepID(predecessorIndex, propagation.PredecessorStepID)
 	if err != nil {
 		return Propagation{}, false, fmt.Errorf("sanitize propagation predecessor step id: %w", err)

--- a/evaluation/workflow/promptiter/backwarder/backwarder.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder.go
@@ -503,9 +503,10 @@ func sanitizeSurfaceGradient(
 			request.StepID,
 		)
 	}
-	// LLM 有时会幻觉出 request AllowedGradientSurfaceIDs 集合外的 surface id。
-	// 单条 drop（keep=false），不 kill 整轮 sanitize —— sanitizeBackwardResult
-	// 最终若 gradients + upstream 都空，会在末尾 "backward result is empty" 兜底 fatal。
+	// LLM sometimes hallucinates a surface id outside request AllowedGradientSurfaceIDs.
+	// Drop this single entry (keep=false) instead of failing the entire sanitize round.
+	// sanitizeBackwardResult still guards against a fully-empty result via
+	// its final "backward result is empty" check.
 	if gradient.SurfaceID != "" {
 		if _, ok := surfaceIndex[gradient.SurfaceID]; !ok {
 			return promptiter.SurfaceGradient{}, false, nil
@@ -530,9 +531,10 @@ func sanitizePropagation(
 	predecessorIndex map[string]Predecessor,
 	propagation Propagation,
 ) (Propagation, bool, error) {
-	// LLM 有时会幻觉出 request Predecessors 集合外的 step id。
-	// 单条 drop（keep=false），不 kill 整轮 sanitize —— sanitizeBackwardResult
-	// 最终若 gradients + upstream 都空，会在末尾 "backward result is empty" 兜底 fatal。
+	// LLM sometimes hallucinates a step id outside request Predecessors.
+	// Drop this single entry (keep=false) instead of failing the entire sanitize round.
+	// sanitizeBackwardResult still guards against a fully-empty result via
+	// its final "backward result is empty" check.
 	if propagation.PredecessorStepID != "" {
 		if _, ok := predecessorIndex[propagation.PredecessorStepID]; !ok {
 			return Propagation{}, false, nil

--- a/evaluation/workflow/promptiter/backwarder/backwarder_test.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder_test.go
@@ -590,8 +590,9 @@ func TestBackwardRejectsInvalidResultOutput(t *testing.T) {
 
 		rsp, err := bw.Backward(context.Background(), newRestrictedInstructionRequest())
 
-		// LLM 幻觉出 allowed surface 集合外的 id：该 gradient 被 drop；
-		// 这是唯一一条 gradient，drop 后 result 全空 → 走 "backward result is empty" 兜底。
+		// LLM hallucinates an id outside the allowed surface set: that gradient
+		// is dropped. Since it's the only gradient, result becomes fully empty
+		// and falls through to the "backward result is empty" fatal path.
 		assert.Error(t, err)
 		assert.Nil(t, rsp)
 		assert.Contains(t, err.Error(), "backward result is empty")

--- a/evaluation/workflow/promptiter/backwarder/backwarder_test.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder_test.go
@@ -976,9 +976,9 @@ func TestNormalizeRequestAndSanitizeBackwardResult(t *testing.T) {
 	result, err = sanitizeBackwardResult(request, nil)
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "backward result is nil")
-	// LLM 幻觉出 request Predecessors 集合外的 step id：单条 drop；
-	// 若这是唯一的 propagation，sanitize 后 upstream/gradients 都空，
-	// sanitizeBackwardResult 走 "backward result is empty" 兜底 fatal。
+	// LLM hallucinates a step id outside request Predecessors: single drop;
+	// if this is the only propagation, sanitize leaves upstream/gradients empty,
+	// so sanitizeBackwardResult falls through to "backward result is empty" fatal.
 	result, err = sanitizeBackwardResult(request, &Result{
 		Upstream: []Propagation{
 			{
@@ -991,7 +991,7 @@ func TestNormalizeRequestAndSanitizeBackwardResult(t *testing.T) {
 	})
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "backward result is empty")
-	// 同上：surface id 幻觉，单条 drop → 剩下全空 → empty result。
+	// Same for surface id hallucination: single drop -> all empty -> empty result.
 	result, err = sanitizeBackwardResult(request, &Result{
 		Gradients: []promptiter.SurfaceGradient{
 			{SurfaceID: "surf_2", Gradient: "wrong target"},
@@ -999,10 +999,10 @@ func TestNormalizeRequestAndSanitizeBackwardResult(t *testing.T) {
 	})
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "backward result is empty")
-	// 幻觉与合法混合：只 drop 幻觉那条，合法的保留。
+	// Mixed hallucinated + valid entries: only the hallucinated ones are dropped.
 	result, err = sanitizeBackwardResult(request, &Result{
 		Gradients: []promptiter.SurfaceGradient{
-			{SurfaceID: "surf_2", Gradient: "wrong target"}, // 幻觉，drop
+			{SurfaceID: "surf_2", Gradient: "wrong target"}, // hallucinated, drop
 			{SurfaceID: "surf_1", Gradient: "keep me", Severity: promptiter.LossSeverityP1},
 		},
 		Upstream: []Propagation{

--- a/evaluation/workflow/promptiter/backwarder/backwarder_test.go
+++ b/evaluation/workflow/promptiter/backwarder/backwarder_test.go
@@ -590,9 +590,11 @@ func TestBackwardRejectsInvalidResultOutput(t *testing.T) {
 
 		rsp, err := bw.Backward(context.Background(), newRestrictedInstructionRequest())
 
+		// LLM 幻觉出 allowed surface 集合外的 id：该 gradient 被 drop；
+		// 这是唯一一条 gradient，drop 后 result 全空 → 走 "backward result is empty" 兜底。
 		assert.Error(t, err)
 		assert.Nil(t, rsp)
-		assert.Contains(t, err.Error(), "allowed gradient surfaces")
+		assert.Contains(t, err.Error(), "backward result is empty")
 	})
 
 	t.Run("unknown predecessor step id", func(t *testing.T) {
@@ -974,6 +976,9 @@ func TestNormalizeRequestAndSanitizeBackwardResult(t *testing.T) {
 	result, err = sanitizeBackwardResult(request, nil)
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "backward result is nil")
+	// LLM 幻觉出 request Predecessors 集合外的 step id：单条 drop；
+	// 若这是唯一的 propagation，sanitize 后 upstream/gradients 都空，
+	// sanitizeBackwardResult 走 "backward result is empty" 兜底 fatal。
 	result, err = sanitizeBackwardResult(request, &Result{
 		Upstream: []Propagation{
 			{
@@ -985,14 +990,32 @@ func TestNormalizeRequestAndSanitizeBackwardResult(t *testing.T) {
 		},
 	})
 	assert.Nil(t, result)
-	assert.EqualError(t, err, `sanitize propagation: sanitize propagation predecessor step id: propagation predecessor step id "missing" is not part of request predecessors`)
+	assert.EqualError(t, err, "backward result is empty")
+	// 同上：surface id 幻觉，单条 drop → 剩下全空 → empty result。
 	result, err = sanitizeBackwardResult(request, &Result{
 		Gradients: []promptiter.SurfaceGradient{
 			{SurfaceID: "surf_2", Gradient: "wrong target"},
 		},
 	})
 	assert.Nil(t, result)
-	assert.EqualError(t, err, `sanitize surface gradient: sanitize gradient surface id: gradient surface id "surf_2" is not part of allowed gradient surfaces`)
+	assert.EqualError(t, err, "backward result is empty")
+	// 幻觉与合法混合：只 drop 幻觉那条，合法的保留。
+	result, err = sanitizeBackwardResult(request, &Result{
+		Gradients: []promptiter.SurfaceGradient{
+			{SurfaceID: "surf_2", Gradient: "wrong target"}, // 幻觉，drop
+			{SurfaceID: "surf_1", Gradient: "keep me", Severity: promptiter.LossSeverityP1},
+		},
+		Upstream: []Propagation{
+			{PredecessorStepID: "missing", Gradients: []GradientPacket{{Gradient: "hallucinated"}}}, // drop
+			{PredecessorStepID: "pred_1", Gradients: []GradientPacket{{Gradient: "keep me"}}},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Len(t, result.Gradients, 1)
+	assert.Equal(t, "surf_1", result.Gradients[0].SurfaceID)
+	assert.Len(t, result.Upstream, 1)
+	assert.Equal(t, "pred_1", result.Upstream[0].PredecessorStepID)
 	result, err = sanitizeBackwardResult(request, &Result{
 		Gradients: []promptiter.SurfaceGradient{
 			{SurfaceID: "surf_1", Gradient: "keep this", Severity: promptiter.LossSeverityP1},


### PR DESCRIPTION
…g whole round

LLM sometimes hallucinates surface/step ids outside the allowed AllowedGradientSurfaceIDs / Predecessors sets. Previously a single illegal id would fail the entire sanitize round. Now such entries are dropped individually (keep=false); the final "backward result is empty" check still guards against a fully-empty result.

## What changed

Describe the user-visible behavior, API, documentation, or example changes in
this pull request.

## Why

Explain the problem this solves and any compatibility considerations.

## Testing

List the commands or manual checks you ran. If a check is not applicable, say
why.

## Notes for reviewers

Call out areas that deserve extra attention, such as concurrency, persistence,
protocol compatibility, or public API changes.
