### PR TITLE
tool/mcp: canonicalize empty content results

### DIFF
--- a/tool/mcp/tool.go
+++ b/tool/mcp/tool.go
@@ -30,6 +30,9 @@ type mcpToolResult struct {
 // MarshalJSON implements json.Marshaler.
 // It marshals only the Content slice for backward compatibility.
 func (r *mcpToolResult) MarshalJSON() ([]byte, error) {
+	if r == nil || len(r.Content) == 0 {
+		return []byte("[]"), nil
+	}
 	return json.Marshal(r.Content)
 }
 

--- a/tool/mcp/tool_test.go
+++ b/tool/mcp/tool_test.go
@@ -294,6 +294,28 @@ func TestMCPToolResult_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestMCPToolResult_MarshalJSON_EmptyContentAsArray(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *mcpToolResult
+	}{
+		{name: "nil result", result: nil},
+		{name: "nil content", result: &mcpToolResult{}},
+		{name: "empty content", result: &mcpToolResult{Content: []mcp.Content{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.result.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON failed: %v", err)
+			}
+			if string(data) != "[]" {
+				t.Fatalf("expected empty JSON array, got %q", string(data))
+			}
+		})
+	}
+}
+
 func TestMCPToolResult_GetCallbackResult(t *testing.T) {
 	expected := []mcp.Content{mcp.NewTextContent("hello")}
 	result := &mcpToolResult{


### PR DESCRIPTION
## Summary
- Canonicalize MCP tool results with nil or empty `Content` as `[]` when marshaled into the default tool message payload.
- Keep non-empty MCP content serialization unchanged and leave callback-facing `GetCallbackResult()` behavior intact.

## Background
MCP tool results model `Content` as a list of content items. When an MCP server returns no content and no structured content, the Go wrapper currently marshals a nil slice as JSON `null`. That leaks a Go representation detail into the model-facing tool result and makes the payload shape differ from normal MCP content arrays.

This change treats the empty/no-content case as an empty content list (`[]`). It is a small MCP canonicalization fix rather than a general empty function-tool-output change: regular function tools already marshal empty slices as `[]`, and structured MCP content is already converted into text content in `callTool`.

## Test plan
- `go test ./tool/mcp/... -run 'MarshalJSON|NoContent|StructuredContent' -count=1`


Made with [Cursor](https://cursor.com)