### PR TITLE
{agent, graph, internal, docs}: align node types with static structure

### DIFF
--- a/agent/graphagent/graph_agent_test.go
+++ b/agent/graphagent/graph_agent_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/graph"
@@ -4077,10 +4078,10 @@ func TestGraphAgent_Run_ExecutionTraceCapturesComplexGraph(t *testing.T) {
 			"route_count": count + 1,
 			"visited":     []string{"route"},
 		}, nil
-	})
+	}, graph.WithNodeType(graph.NodeTypeRouter))
 	builder.AddNode("tools", func(context.Context, graph.State) (any, error) {
 		return graph.State{"visited": []string{"tools"}}, nil
-	})
+	}, graph.WithNodeType(graph.NodeType("custom")))
 	builder.AddNode("branch_a", func(context.Context, graph.State) (any, error) {
 		return graph.State{"visited": []string{"branch_a"}}, nil
 	})
@@ -4092,7 +4093,7 @@ func TestGraphAgent_Run_ExecutionTraceCapturesComplexGraph(t *testing.T) {
 	})
 	builder.AddNode("join", func(context.Context, graph.State) (any, error) {
 		return graph.State{"visited": []string{"join"}}, nil
-	})
+	}, graph.WithNodeType(graph.NodeTypeJoin))
 	builder.AddNode("done", func(context.Context, graph.State) (any, error) {
 		return graph.State{"visited": []string{"done"}}, nil
 	})
@@ -4140,6 +4141,17 @@ func TestGraphAgent_Run_ExecutionTraceCapturesComplexGraph(t *testing.T) {
 	require.NotNil(t, completion)
 	require.NotNil(t, completion.ExecutionTrace)
 	executionTrace := completion.ExecutionTrace
+	staticStructure, err := astructure.Export(context.Background(), ag)
+	require.NoError(t, err)
+	staticNodeKinds := make(map[string]astructure.NodeKind, len(staticStructure.Nodes))
+	for _, node := range staticStructure.Nodes {
+		staticNodeKinds[node.NodeID] = node.Kind
+	}
+	for _, step := range executionTrace.Steps {
+		staticNodeKind, ok := staticNodeKinds[step.NodeID]
+		require.True(t, ok, "trace node %q is missing from static structure", step.NodeID)
+		require.Equal(t, string(staticNodeKind), step.NodeType, step.NodeID)
+	}
 	require.Equal(t, atrace.Trace{
 		RootAgentName:    "assistant",
 		RootInvocationID: "root-invocation",

--- a/agent/graphagent/structure_export.go
+++ b/agent/graphagent/structure_export.go
@@ -42,7 +42,7 @@ func (ga *GraphAgent) Export(
 		nodePaths[node.ID] = nodePath
 		snapshot.Nodes = append(snapshot.Nodes, structure.Node{
 			NodeID: nodePath,
-			Kind:   nodeKindFromGraphNodeType(node.Type),
+			Kind:   istructure.NormalizeNodeKind(node.Type.String()),
 			Name:   node.Name,
 		})
 	}
@@ -112,19 +112,6 @@ func appendAgentNodeChildSnapshot(
 	}
 	snapshot.Edges = append(snapshot.Edges, rebased.Edges...)
 	snapshot.Surfaces = append(snapshot.Surfaces, rebased.Surfaces...)
-}
-
-func nodeKindFromGraphNodeType(nodeType graph.NodeType) structure.NodeKind {
-	switch nodeType {
-	case graph.NodeTypeLLM:
-		return structure.NodeKindLLM
-	case graph.NodeTypeTool:
-		return structure.NodeKindTool
-	case graph.NodeTypeAgent:
-		return structure.NodeKindAgent
-	default:
-		return structure.NodeKindFunction
-	}
 }
 
 func exportGraphNodeSurfaces(

--- a/agent/trace/trace.go
+++ b/agent/trace/trace.go
@@ -52,8 +52,8 @@ type Step struct {
 	AgentName          string
 	Branch             string
 	NodeID             string
-	// NodeType is the semantic type of the executed node. Common framework
-	// values include function, llm, tool, agent, join, and router.
+	// NodeType is the semantic type of the executed node and matches the node
+	// kind in the static structure: function, llm, tool, or agent.
 	NodeType           string
 	StartedAt          time.Time
 	EndedAt            time.Time

--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -1536,7 +1536,7 @@ Execution traces are attached to the runner completion event as an in-memory art
 Each recorded step carries stable fields such as:
 
 - `NodeID`: the static node path for the executed node
-- `NodeType`: the node's semantic type, such as `function`, `llm`, `tool`, `agent`, `join`, or `router`
+- `NodeType`: the node's semantic type (`function`, `llm`, `tool`, or `agent`), matching the node kind in the static structure
 - `PredecessorStepIDs`: the direct step dependencies in this run
 - `Input` and `Output`: stable text snapshots captured for the step
 - `Error`: the terminal step error, when the step fails

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -1481,7 +1481,7 @@ for evt := range events {
 每个步骤都会带上这些稳定字段：
 
 - `NodeID`：本次执行对应的静态节点路径
-- `NodeType`：节点的语义类型，例如 `function`、`llm`、`tool`、`agent`、`join` 或 `router`
+- `NodeType`：节点的语义类型（`function`、`llm`、`tool` 或 `agent`），与静态结构中的节点类型一致
 - `PredecessorStepIDs`：这次运行里该步骤的直接前驱步骤
 - `Input` 和 `Output`：步骤输入输出的稳定文本快照
 - `Error`：步骤失败时记录的终态错误

--- a/graph/executor.go
+++ b/graph/executor.go
@@ -2882,7 +2882,7 @@ func (e *Executor) initializeNodeContext(
 		tracecapture.SetStepNodeType(
 			agent.NewInvocationContext(ctx, invocation),
 			traceStepID,
-			nodeType.String(),
+			string(istructure.NormalizeNodeKind(nodeType.String())),
 		)
 		stateCopy[currentTraceStepIDStateKey] = traceStepID
 	}

--- a/internal/structure/structure.go
+++ b/internal/structure/structure.go
@@ -17,6 +17,20 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/structure"
 )
 
+// NormalizeNodeKind maps a node type to the public static structure taxonomy.
+func NormalizeNodeKind(kind string) structure.NodeKind {
+	switch structure.NodeKind(kind) {
+	case structure.NodeKindLLM:
+		return structure.NodeKindLLM
+	case structure.NodeKindTool:
+		return structure.NodeKindTool
+	case structure.NodeKindAgent:
+		return structure.NodeKindAgent
+	default:
+		return structure.NodeKindFunction
+	}
+}
+
 // PathAllocator allocates stable child paths under one parent node.
 type PathAllocator struct {
 	parentNodeID string

--- a/internal/structure/structure_test.go
+++ b/internal/structure/structure_test.go
@@ -16,6 +16,28 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/structure"
 )
 
+func TestNormalizeNodeKind(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want structure.NodeKind
+	}{
+		{name: "function", kind: "function", want: structure.NodeKindFunction},
+		{name: "llm", kind: "llm", want: structure.NodeKindLLM},
+		{name: "tool", kind: "tool", want: structure.NodeKindTool},
+		{name: "agent", kind: "agent", want: structure.NodeKindAgent},
+		{name: "join", kind: "join", want: structure.NodeKindFunction},
+		{name: "router", kind: "router", want: structure.NodeKindFunction},
+		{name: "custom", kind: "custom", want: structure.NodeKindFunction},
+		{name: "empty", kind: "", want: structure.NodeKindFunction},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeNodeKind(tt.kind))
+		})
+	}
+}
+
 func TestPathAllocator_AllocatesEscapedStablePaths(t *testing.T) {
 	allocator := NewPathAllocator("root")
 	assert.Equal(t, "root/_", allocator.Next(""))


### PR DESCRIPTION
Aligns execution trace node type values with the static structure export by centralizing graph node type normalization in internal/structure and reusing it from graphagent and graph execution paths. This keeps trace steps and exported structure nodes on the same semantic labels.