### PR TITLE
{runner/trpcagent, server/trpcagent}: propagate runtime state

### DIFF
--- a/runner/trpcagent/runner.go
+++ b/runner/trpcagent/runner.go
@@ -135,6 +135,7 @@ func (r *runner) newRunRequest(
 		RunOptions: runOptions{
 			RequestID:             options.RequestID,
 			ExecutionTraceEnabled: options.ExecutionTraceEnabled,
+			RuntimeState:          options.RuntimeState,
 		},
 	}
 	if profile := profilecompiler.ProfileFromRunOptions(options); profile != nil {

--- a/runner/trpcagent/runner_test.go
+++ b/runner/trpcagent/runner_test.go
@@ -91,6 +91,10 @@ func TestRunPostsRequestAndConvertsResponseEvents(t *testing.T) {
 	runOpts := []agent.RunOption{
 		agent.WithRequestID("req-1"),
 		agent.WithExecutionTraceEnabled(true),
+		agent.MergeRuntimeState(map[string]any{
+			"ignore": true,
+			"source": "promptiter",
+		}),
 	}
 	events, err := runner.Run(
 		context.Background(),
@@ -107,6 +111,8 @@ func TestRunPostsRequestAndConvertsResponseEvents(t *testing.T) {
 	assert.Equal(t, model.NewUserMessage("match_001"), got.Input)
 	assert.Equal(t, "req-1", got.RunOptions.RequestID)
 	assert.True(t, got.RunOptions.ExecutionTraceEnabled)
+	assert.Equal(t, true, got.RunOptions.RuntimeState["ignore"])
+	assert.Equal(t, "promptiter", got.RunOptions.RuntimeState["source"])
 	assert.True(t, gotEvents[0].IsToolCallResponse())
 	assert.True(t, gotEvents[1].IsToolResultResponse())
 	assert.Equal(t, model.ObjectTypeChatCompletion, gotEvents[2].Object)

--- a/runner/trpcagent/types.go
+++ b/runner/trpcagent/types.go
@@ -22,8 +22,9 @@ type session struct {
 }
 
 type runOptions struct {
-	RequestID             string `json:"requestID,omitempty"`
-	ExecutionTraceEnabled bool   `json:"executionTraceEnabled,omitempty"`
+	RequestID             string         `json:"requestID,omitempty"`
+	ExecutionTraceEnabled bool           `json:"executionTraceEnabled,omitempty"`
+	RuntimeState          map[string]any `json:"runtimeState,omitempty"`
 }
 
 type runRequest struct {

--- a/server/trpcagent/server.go
+++ b/server/trpcagent/server.go
@@ -158,6 +158,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	runOptions = append(runOptions, agent.WithRequestID(req.RunOptions.RequestID))
+	runOptions = append(runOptions, agent.MergeRuntimeState(req.RunOptions.RuntimeState))
 	runOptions = append(runOptions, agent.WithAppName(s.appName))
 	eventCh, err := s.runner.Run(ctx, req.Session.UserID, req.Session.SessionID, req.Input, runOptions...)
 	if err != nil {

--- a/server/trpcagent/server_test.go
+++ b/server/trpcagent/server_test.go
@@ -188,6 +188,10 @@ func TestServerRunCompilesProfileAndReturnsTrace(t *testing.T) {
 		RunOptions: runOptions{
 			RequestID:             "req-1",
 			ExecutionTraceEnabled: true,
+			RuntimeState: map[string]any{
+				"ignore": true,
+				"source": "promptiter",
+			},
 		},
 	})
 	req := httptest.NewRequest(http.MethodPost, path, body)
@@ -209,6 +213,8 @@ func TestServerRunCompilesProfileAndReturnsTrace(t *testing.T) {
 	assert.Equal(t, "sports-agent", ag.runOptions.AppName)
 	assert.Equal(t, "req-1", ag.runOptions.RequestID)
 	assert.True(t, ag.runOptions.ExecutionTraceEnabled)
+	assert.Equal(t, true, ag.runOptions.RuntimeState["ignore"])
+	assert.Equal(t, "promptiter", ag.runOptions.RuntimeState["source"])
 	assert.True(t, surfacepatch.ToolSurfaceTracingEnabled(ag.runOptions.CustomAgentConfigs))
 	patch, ok := surfacepatch.PatchForNode(ag.runOptions.CustomAgentConfigs, "writer")
 	require.True(t, ok)

--- a/server/trpcagent/types.go
+++ b/server/trpcagent/types.go
@@ -25,8 +25,9 @@ type session struct {
 
 // runOptions stores tRPC-Agent API options for one run.
 type runOptions struct {
-	RequestID             string `json:"requestID,omitempty"`
-	ExecutionTraceEnabled bool   `json:"executionTraceEnabled,omitempty"`
+	RequestID             string         `json:"requestID,omitempty"`
+	ExecutionTraceEnabled bool           `json:"executionTraceEnabled,omitempty"`
+	RuntimeState          map[string]any `json:"runtimeState,omitempty"`
 }
 
 // runRequest is the request payload for POST /runs.


### PR DESCRIPTION
Propagates RunOptions.RuntimeState through the trpcagent HTTP runner and server wire format so callers can carry run-scoped state such as business-defined sampling controls across remote agent execution.