### PR TITLE
openclaw: preserve structured shared history

### DIFF
--- a/openclaw/conversation/history.go
+++ b/openclaw/conversation/history.go
@@ -73,7 +73,10 @@ func BuildInjectedContextMessages(
 		boundary,
 		normalizeActorLabels(opts.LabelOverrides),
 	)
-	if opts.MaxHistoryRuns > 0 {
+	// Match the native history path: when summaries are enabled, the
+	// summary boundary already decides which events remain verbatim.
+	// MaxHistoryRuns is only enabled when summary mode is disabled.
+	if !opts.AddSessionSummary && opts.MaxHistoryRuns > 0 {
 		history = trimVisibleHistory(history, opts.MaxHistoryRuns)
 	}
 	out = append(out, history...)

--- a/openclaw/conversation/history.go
+++ b/openclaw/conversation/history.go
@@ -16,6 +16,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	utilmessage "trpc.group/trpc-go/trpc-agent-go/internal/util/message"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
@@ -72,8 +73,8 @@ func BuildInjectedContextMessages(
 		boundary,
 		normalizeActorLabels(opts.LabelOverrides),
 	)
-	if opts.MaxHistoryRuns > 0 && len(history) > opts.MaxHistoryRuns {
-		history = history[len(history)-opts.MaxHistoryRuns:]
+	if opts.MaxHistoryRuns > 0 {
+		history = trimVisibleHistory(history, opts.MaxHistoryRuns)
 	}
 	out = append(out, history...)
 	if len(out) == 0 {
@@ -193,6 +194,37 @@ func buildVisibleHistoryAfterEvent(
 		out = append(out, msgs...)
 	}
 	return out, foundBoundary
+}
+
+func trimVisibleHistory(
+	messages []model.Message,
+	limit int,
+) []model.Message {
+	if limit <= 0 || len(messages) <= limit {
+		return messages
+	}
+	start := len(messages) - limit
+	if messages[start].Role != model.RoleTool ||
+		messages[start].ToolID == "" {
+		return messages[start:]
+	}
+
+	truncatedToolIDs := make(map[string]struct{})
+	for i := 0; i < start; i++ {
+		for _, toolCall := range messages[i].ToolCalls {
+			if toolCall.ID != "" {
+				truncatedToolIDs[toolCall.ID] = struct{}{}
+			}
+		}
+	}
+	for start < len(messages) &&
+		messages[start].Role == model.RoleTool {
+		if _, ok := truncatedToolIDs[messages[start].ToolID]; !ok {
+			break
+		}
+		start++
+	}
+	return messages[start:]
 }
 
 func buildTurns(
@@ -407,14 +439,15 @@ func ProjectEventMessage(
 func visibleAssistantMessages(evt event.Event) []model.Message {
 	out := make([]model.Message, 0, len(evt.Response.Choices))
 	for _, choice := range evt.Response.Choices {
-		text := renderAssistantMessage(choice.Message)
-		if text == "" {
+		// Keep tool rounds and reasoning intact across shared-history runs.
+		msg := choice.Message
+		if !msg.Role.IsValid() {
+			msg.Role = model.RoleAssistant
+		}
+		if utilmessage.IsEmptyAssistantMessage(msg) {
 			continue
 		}
-		out = append(
-			out,
-			model.NewAssistantMessage(text),
-		)
+		out = append(out, msg)
 	}
 	return out
 }

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -12,6 +12,7 @@ package conversation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -162,7 +163,7 @@ func TestBuildInjectedContextMessages(t *testing.T) {
 
 	got := BuildInjectedContextMessages(sess, HistoryOptions{
 		AddSessionSummary: true,
-		MaxHistoryRuns:    10,
+		MaxHistoryRuns:    1,
 		LabelOverrides: map[string]string{
 			"u2": "Robert",
 		},
@@ -175,6 +176,50 @@ func TestBuildInjectedContextMessages(t *testing.T) {
 	require.Contains(t, got[1].Content, "Message: latest question")
 	require.Equal(t, model.RoleAssistant, got[2].Role)
 	require.Equal(t, "latest answer", got[2].Content)
+}
+
+func TestBuildInjectedContextMessagesSummaryModeKeepsToolHeavyRun(
+	t *testing.T,
+) {
+	base := time.Now().Add(-10 * time.Minute)
+	events := []event.Event{
+		userEvent("u1", "Alice", "inspect everything", base),
+	}
+	for i := 0; i < 26; i++ {
+		callID := fmt.Sprintf("call-%d", i)
+		toolCall := model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID:   callID,
+				Type: "function",
+				Function: model.FunctionDefinitionParam{
+					Name: "inspect",
+				},
+			}},
+		}
+		events = append(
+			events,
+			messageEvent(
+				authorAssistant,
+				toolCall,
+				base.Add(time.Duration(2*i+1)*time.Second),
+			),
+			messageEvent(
+				authorAssistant,
+				model.NewToolMessage(callID, "inspect", "ok"),
+				base.Add(time.Duration(2*i+2)*time.Second),
+			),
+		)
+	}
+
+	got := BuildInjectedContextMessages(&session.Session{Events: events}, HistoryOptions{
+		AddSessionSummary: true,
+		MaxHistoryRuns:    50,
+	})
+	require.Len(t, got, 53)
+	require.Equal(t, model.RoleUser, got[0].Role)
+	require.Equal(t, model.RoleAssistant, got[1].Role)
+	require.Equal(t, model.RoleTool, got[2].Role)
 }
 
 func TestBuildInjectedContextMessagesPreservesStructuredToolHistory(

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -177,6 +177,107 @@ func TestBuildInjectedContextMessages(t *testing.T) {
 	require.Equal(t, "latest answer", got[2].Content)
 }
 
+func TestBuildInjectedContextMessagesPreservesStructuredToolHistory(
+	t *testing.T,
+) {
+	base := time.Now().Add(-10 * time.Minute)
+	toolCall := model.Message{
+		Role:               model.RoleAssistant,
+		ReasoningContent:   "inspect the current configuration",
+		ReasoningSignature: "signature-1",
+		ToolCalls: []model.ToolCall{{
+			ID:   "call-1",
+			Type: "function",
+			Function: model.FunctionDefinitionParam{
+				Name:      "read_config",
+				Arguments: []byte(`{"path":"config.yaml"}`),
+			},
+		}},
+	}
+	toolResult := model.NewToolMessage(
+		"call-1",
+		"read_config",
+		`{"enabled":true}`,
+	)
+	finalAnswer := model.NewAssistantMessage("configuration is enabled")
+	finalAnswer.ReasoningContent = "summarize the tool result"
+
+	sess := &session.Session{
+		Events: []event.Event{
+			userEvent("u1", "Alice", "check config", base),
+			messageEvent(
+				authorAssistant,
+				toolCall,
+				base.Add(time.Minute),
+			),
+			messageEvent(
+				authorAssistant,
+				toolResult,
+				base.Add(2*time.Minute),
+			),
+			messageEvent(
+				authorAssistant,
+				finalAnswer,
+				base.Add(3*time.Minute),
+			),
+		},
+	}
+
+	got := BuildInjectedContextMessages(sess, HistoryOptions{})
+	require.Len(t, got, 4)
+	require.Equal(t, model.RoleUser, got[0].Role)
+	require.Equal(t, toolCall, got[1])
+	require.Equal(t, toolResult, got[2])
+	require.Equal(t, finalAnswer, got[3])
+}
+
+func TestBuildInjectedContextMessagesSkipsOrphanedToolResults(
+	t *testing.T,
+) {
+	base := time.Now().Add(-10 * time.Minute)
+	toolCall := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{{
+			ID:   "call-1",
+			Type: "function",
+			Function: model.FunctionDefinitionParam{
+				Name: "read_config",
+			},
+		}},
+	}
+	toolResult := model.NewToolMessage(
+		"call-1",
+		"read_config",
+		`{"enabled":true}`,
+	)
+	finalAnswer := model.NewAssistantMessage("configuration is enabled")
+	sess := &session.Session{
+		Events: []event.Event{
+			userEvent("u1", "Alice", "check config", base),
+			messageEvent(
+				authorAssistant,
+				toolCall,
+				base.Add(time.Minute),
+			),
+			messageEvent(
+				authorAssistant,
+				toolResult,
+				base.Add(2*time.Minute),
+			),
+			messageEvent(
+				authorAssistant,
+				finalAnswer,
+				base.Add(3*time.Minute),
+			),
+		},
+	}
+
+	got := BuildInjectedContextMessages(sess, HistoryOptions{
+		MaxHistoryRuns: 2,
+	})
+	require.Equal(t, []model.Message{finalAnswer}, got)
+}
+
 func TestBuildInjectedContextMessagesKeepsSameTimestampAfterBoundary(
 	t *testing.T,
 ) {
@@ -650,7 +751,26 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 			}},
 		},
 	}
-	require.Empty(t, visibleAssistantMessages(assistantToolOnly))
+	visible := visibleAssistantMessages(assistantToolOnly)
+	require.Len(t, visible, 1)
+	require.Equal(t, model.RoleAssistant, visible[0].Role)
+	require.Equal(
+		t,
+		assistantToolOnly.Response.Choices[0].Message.ToolCalls,
+		visible[0].ToolCalls,
+	)
+	reasoningOnly := event.Event{
+		Author: authorAssistant,
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:             model.RoleAssistant,
+					ReasoningContent: "thinking",
+				},
+			}},
+		},
+	}
+	require.Empty(t, visibleAssistantMessages(reasoningOnly))
 
 	require.Empty(
 		t,
@@ -1030,6 +1150,22 @@ func assistantEvent(content string, ts time.Time) event.Event {
 			Choices: []model.Choice{{
 				Message: model.NewAssistantMessage(content),
 			}},
+		},
+	)
+	evt.Timestamp = ts
+	return *evt
+}
+
+func messageEvent(
+	author string,
+	message model.Message,
+	ts time.Time,
+) event.Event {
+	evt := event.NewResponseEvent(
+		"inv",
+		author,
+		&model.Response{
+			Choices: []model.Choice{{Message: message}},
 		},
 	)
 	evt.Timestamp = ts

--- a/openclaw/conversation/history_test.go
+++ b/openclaw/conversation/history_test.go
@@ -278,6 +278,37 @@ func TestBuildInjectedContextMessagesSkipsOrphanedToolResults(
 	require.Equal(t, []model.Message{finalAnswer}, got)
 }
 
+func TestTrimVisibleHistory(t *testing.T) {
+	recentUser := model.NewUserMessage("recent question")
+	recentAnswer := model.NewAssistantMessage("recent answer")
+	messages := []model.Message{
+		model.NewAssistantMessage("old answer"),
+		recentUser,
+		recentAnswer,
+	}
+	require.Equal(
+		t,
+		[]model.Message{recentUser, recentAnswer},
+		trimVisibleHistory(messages, 2),
+	)
+
+	unmatchedToolResult := model.NewToolMessage(
+		"unmatched-call",
+		"read_config",
+		`{"enabled":true}`,
+	)
+	messages = []model.Message{
+		model.NewAssistantMessage("old answer"),
+		unmatchedToolResult,
+		recentAnswer,
+	}
+	require.Equal(
+		t,
+		[]model.Message{unmatchedToolResult, recentAnswer},
+		trimVisibleHistory(messages, 2),
+	)
+}
+
 func TestBuildInjectedContextMessagesKeepsSameTimestampAfterBoundary(
 	t *testing.T,
 ) {
@@ -771,6 +802,18 @@ func TestHistoryHelpers_RenderAndFilter(t *testing.T) {
 		},
 	}
 	require.Empty(t, visibleAssistantMessages(reasoningOnly))
+
+	missingRole := event.Event{
+		Author: authorAssistant,
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{Content: "answer"},
+			}},
+		},
+	}
+	visible = visibleAssistantMessages(missingRole)
+	require.Len(t, visible, 1)
+	require.Equal(t, model.RoleAssistant, visible[0].Role)
 
 	require.Empty(
 		t,


### PR DESCRIPTION
## Summary

- preserve structured assistant and tool messages when injecting shared conversation history
- retain tool calls, tool results, reasoning content, and reasoning signatures across runs
- keep speaker-aware user projection and normalize legacy messages with missing roles
- align shared-history limits with the native summary-enabled history path

## Root cause and impact

Shared conversation history rebuilt every non-user event as a plain assistant text message. This flattened tool results and discarded tool calls and reasoning metadata on the next run, while non-shared sessions continued to use the native structured history path.

The shared path also applied `max_history_runs` while session summaries were enabled, unlike the native history path. A tool-heavy turn could therefore be sliced after its last user message; downstream message validation would then discard the userless assistant/tool tail. Summary-enabled shared sessions now leave history selection to the summary boundary, matching native sessions.

## Validation

- `go test ./conversation -count=1` (from `openclaw`)
- `go test -race ./conversation -count=1`
- `go vet ./conversation ./app`
- GitHub Actions `Pull Request Check` run 10491 passed
- Codecov reports all modified and coverable lines covered
