### PR TITLE
session: expose persistent backend schema versions

### DIFF
--- a/session/clickhouse/init.go
+++ b/session/clickhouse/init.go
@@ -18,6 +18,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 )
 
+// SchemaVersion is the canonical persistence schema version expected by this backend.
+const SchemaVersion = "v1"
+
 // SQL templates for table creation (ClickHouse syntax)
 // Most tables use updated_at as the ReplacingMergeTree version column. Session
 // summaries keep updated_at as the semantic summary cutoff and use version_at

--- a/session/clickhouse/service.go
+++ b/session/clickhouse/service.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/clickhouse"
 )
@@ -143,6 +144,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		s.startCleanupRoutine()
 	}
 
+	schemaversion.Register("trpc.group/trpc-go/trpc-agent-go/session/clickhouse", SchemaVersion)
 	return s, nil
 }
 

--- a/session/internal/schemaversion/schema.go
+++ b/session/internal/schemaversion/schema.go
@@ -1,0 +1,59 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package schemaversion tracks the canonical schema versions of created session backends.
+package schemaversion
+
+import "sync"
+
+var registry = struct {
+	sync.Mutex
+	versions  map[string]string
+	reporters []func(modulePath, version string)
+}{
+	versions: make(map[string]string),
+}
+
+// Register records the canonical schema version of a successfully created session backend.
+func Register(modulePath, version string) {
+	if modulePath == "" || version == "" {
+		return
+	}
+
+	registry.Lock()
+	if _, ok := registry.versions[modulePath]; ok {
+		registry.Unlock()
+		return
+	}
+	registry.versions[modulePath] = version
+	reporters := append([]func(string, string){}, registry.reporters...)
+	registry.Unlock()
+
+	for _, reporter := range reporters {
+		reporter(modulePath, version)
+	}
+}
+
+// Observe adds a reporter and replays all versions registered before it.
+func Observe(reporter func(modulePath, version string)) {
+	if reporter == nil {
+		return
+	}
+
+	registry.Lock()
+	registry.reporters = append(registry.reporters, reporter)
+	versions := make(map[string]string, len(registry.versions))
+	for modulePath, version := range registry.versions {
+		versions[modulePath] = version
+	}
+	registry.Unlock()
+
+	for modulePath, version := range versions {
+		reporter(modulePath, version)
+	}
+}

--- a/session/internal/schemaversion/schema_test.go
+++ b/session/internal/schemaversion/schema_test.go
@@ -1,0 +1,94 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package schemaversion
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReporterReceivesRegisteredVersions(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	Register("example/session/mysql", "v1")
+	Register("", "v1")
+	Register("example/session/redis", "")
+
+	got := make(map[string]string)
+	Observe(func(modulePath, version string) {
+		got[modulePath] = version
+	})
+	require.Equal(t, map[string]string{
+		"example/session/mysql": "v1",
+	}, got)
+
+	Register("example/session/redis", "v1")
+	require.Equal(t, "v1", got["example/session/redis"])
+
+	replayed := make(map[string]string)
+	Observe(func(modulePath, version string) {
+		replayed[modulePath] = version
+	})
+	require.Equal(t, got, replayed)
+}
+
+func TestRegisterKeepsFirstVersion(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	var calls int
+	Observe(func(_, _ string) {
+		calls++
+	})
+	Register("example/session/mysql", "v1")
+	Register("example/session/mysql", "v1")
+	Register("example/session/mysql", "v2")
+	require.Equal(t, 1, calls)
+}
+
+func TestRegisterConcurrent(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	var mu sync.Mutex
+	got := make(map[string]string)
+	Observe(func(modulePath, version string) {
+		mu.Lock()
+		got[modulePath] = version
+		mu.Unlock()
+	})
+
+	var wg sync.WaitGroup
+	for _, modulePath := range []string{
+		"example/session/mysql",
+		"example/session/redis",
+		"example/session/postgres",
+	} {
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			Register(path, "v1")
+		}(modulePath)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, got, 3)
+}
+
+func resetRegistry() {
+	registry.Lock()
+	defer registry.Unlock()
+	registry.versions = make(map[string]string)
+	registry.reporters = nil
+}

--- a/session/mongodb/init.go
+++ b/session/mongodb/init.go
@@ -20,6 +20,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 )
 
+// SchemaVersion is the canonical persistence schema version expected by this backend.
+const SchemaVersion = "v1"
+
 // ensureIndexes creates the indexes required by the session backend.
 //
 // All unique indexes filter on active documents so soft-deleted documents do

--- a/session/mongodb/service.go
+++ b/session/mongodb/service.go
@@ -29,6 +29,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mongodb"
 )
@@ -174,6 +175,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		s.startCleanupRoutine()
 	}
 
+	schemaversion.Register("trpc.group/trpc-go/trpc-agent-go/session/mongodb", SchemaVersion)
 	return s, nil
 }
 

--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -21,6 +21,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 )
 
+// SchemaVersion is the canonical persistence schema version expected by this backend.
+const SchemaVersion = "v1"
+
 // SQL templates for table creation (MySQL syntax)
 const (
 	sqlCreateSessionStatesTable = `

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mysql"
 )
@@ -158,6 +159,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		s.startCleanupRoutine()
 	}
 
+	schemaversion.Register("trpc.group/trpc-go/trpc-agent-go/session/mysql", SchemaVersion)
 	return s, nil
 }
 

--- a/session/pgvector/init.go
+++ b/session/pgvector/init.go
@@ -21,6 +21,9 @@ import (
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
 )
 
+// SchemaVersion is the canonical persistence schema version expected by this backend.
+const SchemaVersion = "v1"
+
 // initDB initializes the database schema including pgvector
 // extension, tables, indexes, and HNSW vector index.
 func (s *Service) initDB(ctx context.Context) error {

--- a/session/pgvector/service.go
+++ b/session/pgvector/service.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
 )
@@ -243,6 +244,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		s.startCleanupRoutine()
 	}
 
+	schemaversion.Register("trpc.group/trpc-go/trpc-agent-go/session/pgvector", SchemaVersion)
 	return s, nil
 }
 

--- a/session/postgres/init.go
+++ b/session/postgres/init.go
@@ -20,6 +20,9 @@ import (
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
 )
 
+// SchemaVersion is the canonical persistence schema version expected by this backend.
+const SchemaVersion = "v1"
+
 // SQL templates for table creation
 const (
 	sqlCreateSessionStatesTable = `

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/postgres"
 )
@@ -195,6 +196,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		s.startCleanupRoutine()
 	}
 
+	schemaversion.Register("trpc.group/trpc-go/trpc-agent-go/session/postgres", SchemaVersion)
 	return s, nil
 }
 

--- a/session/redis/options_test.go
+++ b/session/redis/options_test.go
@@ -26,9 +26,16 @@ func (f *fakeRedisOptionsSummarizer) ShouldSummarize(sess *session.Session) bool
 func (f *fakeRedisOptionsSummarizer) Summarize(ctx context.Context, sess *session.Session) (string, error) {
 	return "test summary", nil
 }
+
 func (f *fakeRedisOptionsSummarizer) SetPrompt(prompt string)  {}
 func (f *fakeRedisOptionsSummarizer) SetModel(m model.Model)   {}
 func (f *fakeRedisOptionsSummarizer) Metadata() map[string]any { return map[string]any{"test": "data"} }
+
+func TestSchemaVersionForCompatMode(t *testing.T) {
+	require.Equal(t, SchemaVersion, schemaVersionForCompatMode(CompatModeNone))
+	require.Equal(t, SchemaVersion, schemaVersionForCompatMode(CompatModeLegacy))
+	require.Equal(t, legacySchemaVersion, schemaVersionForCompatMode(CompatModeTransition))
+}
 
 func TestWithAsyncSummaryNum(t *testing.T) {
 	tests := []struct {

--- a/session/redis/service.go
+++ b/session/redis/service.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/hook"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	"trpc.group/trpc-go/trpc-agent-go/session/internal/sessionopt"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/hashidx"
@@ -30,6 +31,13 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/zset"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/redis"
 	atrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
+)
+
+const (
+	// SchemaVersion is the current hashidx persistence schema version.
+	SchemaVersion = "v2"
+	// legacySchemaVersion is the zset persistence schema version used in transition mode.
+	legacySchemaVersion = "v1"
 )
 
 var (
@@ -179,7 +187,18 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		s.asyncWorker.Start()
 	}
 
+	schemaversion.Register(
+		"trpc.group/trpc-go/trpc-agent-go/session/redis",
+		schemaVersionForCompatMode(opts.compatMode),
+	)
 	return s, nil
+}
+
+func schemaVersionForCompatMode(mode CompatMode) string {
+	if mode == CompatModeTransition {
+		return legacySchemaVersion
+	}
+	return SchemaVersion
 }
 
 // checkSessionExists checks if session exists in zset and hashidx using pipeline.

--- a/session/schema_version.go
+++ b/session/schema_version.go
@@ -1,0 +1,18 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package session
+
+import "trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
+
+// ObserveSchemaVersions registers a callback for observing the canonical schema
+// versions of persistent session backends created in this process. Versions
+// registered before the callback is installed are reported immediately.
+func ObserveSchemaVersions(reporter func(modulePath, version string)) {
+	schemaversion.Observe(reporter)
+}

--- a/session/sqlite/init.go
+++ b/session/sqlite/init.go
@@ -18,6 +18,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 )
 
+// SchemaVersion is the canonical persistence schema version expected by this backend.
+const SchemaVersion = "v1"
+
 const (
 	sqlCreateSessionStatesTable = `
 CREATE TABLE IF NOT EXISTS {{TABLE_NAME}} (

--- a/session/sqlite/service.go
+++ b/session/sqlite/service.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/hook"
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/schemaversion"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 )
 
@@ -164,6 +165,7 @@ func NewService(db *sql.DB, options ...ServiceOpt) (*Service, error) {
 		s.startCleanupRoutine()
 	}
 
+	schemaversion.Register("trpc.group/trpc-go/trpc-agent-go/session/sqlite", SchemaVersion)
 	return s, nil
 }
 


### PR DESCRIPTION
## Summary

- Add exported schema version constants for ClickHouse, MongoDB, MySQL, pgvector, PostgreSQL, Redis, and SQLite session backends.
- Register a backend's selected schema version only after its service is created successfully.
- Add a session-level observer that replays versions registered before the observer is installed.
- Report Redis zset transition mode as schema v1 and hashidx modes as schema v2.

## Scope

The reported value identifies the persistence schema selected and expected by the backend. It does not inspect the physical database DDL or validate manual schema changes.

## Tests

- `go test -count=1 ./session/...`
- `go test -race -count=1 ./session/internal/schemaversion`
- `go vet ./session/...`
- `go test ./...` and `go vet ./...` in each changed session backend module
