### PR TITLE
{agent/codex, docs}: stream Codex JSONL events

### DIFF
--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -118,12 +118,15 @@ func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invoca
 		return
 	}
 	if cmdResult.runErr != nil {
-		if result.Error == nil {
-			a.emitRunError(ctx, invocation, out, combined, cmdResult.runErr)
+		if result.Error != nil {
+			a.emitCodexError(ctx, invocation, out, result.Error)
+			return
 		}
+		a.emitRunError(ctx, invocation, out, combined, cmdResult.runErr)
 		return
 	}
 	if result.Error != nil {
+		a.emitCodexError(ctx, invocation, out, result.Error)
 		return
 	}
 	a.emitFinalResponse(ctx, invocation, out, combined, result, observedThreadID, resumeThreadID)
@@ -278,6 +281,11 @@ func (a *codexAgent) emitRunError(ctx context.Context, invocation *agent.Invocat
 		},
 	}
 	a.emitEvent(ctx, invocation, out, event.NewResponseEvent(invocation.InvocationID, a.name, rsp))
+}
+
+// emitCodexError emits the terminal error response observed in the Codex transcript.
+func (a *codexAgent) emitCodexError(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event, responseErr *model.ResponseError) {
+	a.emitEvent(ctx, invocation, out, errorEventFromResponseError(invocation.InvocationID, a.name, responseErr, true))
 }
 
 // emitFlowError emits an error response event and stops further invocation processing.

--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -154,6 +154,7 @@ func (a *codexAgent) emitFinalResponse(
 		finalContent = strings.TrimSpace(result.FinalMessage)
 	}
 	rsp := &model.Response{
+		ID:     strings.TrimSpace(result.FinalMessageID),
 		Object: model.ObjectTypeChatCompletion,
 		Done:   true,
 		Usage:  result.Usage,

--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -97,39 +97,58 @@ func (a *codexAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-c
 func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event) {
 	defer close(out)
 	resumeThreadID := sessionThreadID(invocation.Session)
-	stdout, stderr, runErr := a.runWithSession(ctx, resumeThreadID, invocation.Message.Content)
-	combinedRaw := append([]byte(nil), stdout...)
-	if len(stdout) > 0 && len(stderr) > 0 {
-		combinedRaw = append(combinedRaw, '\n')
+	streamer := newCodexStreamEmitter(ctx, a, invocation, out)
+	cmdResult := a.runWithSession(ctx, resumeThreadID, invocation.Message.Content, streamer)
+	combined := bytes.TrimSpace(combineOutput(cmdResult.stdout, cmdResult.stderr))
+	result := streamer.Result()
+	observedThreadID := result.ThreadID
+	if observedThreadID == "" {
+		observedThreadID = extractThreadID(cmdResult.stdout)
 	}
-	combinedRaw = append(combinedRaw, stderr...)
-	combined := bytes.TrimSpace(combinedRaw)
-	observedThreadID := extractThreadID(stdout)
-	if hookErr := a.handleRawOutputHook(ctx, invocation, resumeThreadID, observedThreadID, stdout, stderr, runErr); hookErr != nil {
+	if hookErr := a.handleRawOutputHook(ctx, invocation, resumeThreadID, observedThreadID, cmdResult.stdout, cmdResult.stderr, cmdResult.err()); hookErr != nil {
 		err := fmt.Errorf("raw output hook: %w", hookErr)
-		if runErr != nil {
-			err = errors.Join(err, fmt.Errorf("command error: %w", runErr))
+		if cmdErr := cmdResult.err(); cmdErr != nil {
+			err = errors.Join(err, fmt.Errorf("command error: %w", cmdErr))
 		}
 		a.emitFlowError(ctx, invocation, out, combined, err)
 		return
 	}
-	if runErr != nil {
-		a.emitRunError(ctx, invocation, out, combined, runErr)
+	if cmdResult.outputErr != nil {
+		a.emitFlowError(ctx, invocation, out, combined, fmt.Errorf("stream codex transcript: %w", cmdResult.outputErr))
 		return
 	}
-	result := &transcriptResult{}
-	if len(stdout) > 0 {
-		parsed, err := parseTranscriptEvents(stdout, invocation.InvocationID, a.name)
-		if err != nil {
-			decodeErr := fmt.Errorf("parse codex transcript: %w", err)
-			a.emitFlowError(ctx, invocation, out, combined, decodeErr)
-			return
+	if cmdResult.runErr != nil {
+		if result.Error == nil {
+			a.emitRunError(ctx, invocation, out, combined, cmdResult.runErr)
 		}
-		result = parsed
-		for _, e := range parsed.Events {
-			a.emitEvent(ctx, invocation, out, e)
-		}
+		return
 	}
+	if result.Error != nil {
+		return
+	}
+	a.emitFinalResponse(ctx, invocation, out, combined, result, observedThreadID, resumeThreadID)
+}
+
+// combineOutput joins stdout and stderr with the same display rules as the previous buffered path.
+func combineOutput(stdout []byte, stderr []byte) []byte {
+	combined := append([]byte(nil), stdout...)
+	if len(stdout) > 0 && len(stderr) > 0 {
+		combined = append(combined, '\n')
+	}
+	combined = append(combined, stderr...)
+	return combined
+}
+
+// emitFinalResponse emits the final assistant response after the Codex turn completes.
+func (a *codexAgent) emitFinalResponse(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	out chan<- *event.Event,
+	combined []byte,
+	result *transcriptResult,
+	threadID string,
+	resumeThreadID string,
+) {
 	finalContent := string(combined)
 	if strings.TrimSpace(result.FinalMessage) != "" {
 		finalContent = strings.TrimSpace(result.FinalMessage)
@@ -149,13 +168,64 @@ func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invoca
 		},
 	}
 	evt := event.NewResponseEvent(invocation.InvocationID, a.name, rsp)
-	if result.ThreadID == "" {
-		result.ThreadID = observedThreadID
-	}
-	if result.ThreadID != "" && result.ThreadID != resumeThreadID {
-		evt.StateDelta = map[string][]byte{StateKeyThreadID: []byte(result.ThreadID)}
+	if threadID != "" && threadID != resumeThreadID {
+		evt.StateDelta = map[string][]byte{StateKeyThreadID: []byte(threadID)}
 	}
 	a.emitEvent(ctx, invocation, out, evt)
+}
+
+// codexStreamEmitter owns one incremental transcript parser for a CLI attempt.
+type codexStreamEmitter struct {
+	ctx     context.Context
+	agent   *codexAgent
+	inv     *agent.Invocation
+	out     chan<- *event.Event
+	stream  *transcriptStream
+	emitted bool
+}
+
+// newCodexStreamEmitter creates an emitter for a Codex invocation.
+func newCodexStreamEmitter(ctx context.Context, a *codexAgent, inv *agent.Invocation, out chan<- *event.Event) *codexStreamEmitter {
+	e := &codexStreamEmitter{
+		ctx:   ctx,
+		agent: a,
+		inv:   inv,
+		out:   out,
+	}
+	e.Reset()
+	return e
+}
+
+// Reset discards buffered transcript state for a fresh CLI attempt.
+func (e *codexStreamEmitter) Reset() {
+	e.stream = newTranscriptStream(e.inv.InvocationID, e.agent.name)
+	e.emitted = false
+}
+
+// HandleLine parses and emits events from one Codex JSONL stdout line.
+func (e *codexStreamEmitter) HandleLine(line []byte) error {
+	events, err := e.stream.HandleLine(line)
+	if err != nil {
+		return err
+	}
+	for _, evt := range events {
+		if evt == nil {
+			continue
+		}
+		e.emitted = true
+		if err := agent.EmitEvent(e.ctx, e.inv, e.out, evt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Result returns the accumulated transcript state.
+func (e *codexStreamEmitter) Result() *transcriptResult {
+	if e == nil || e.stream == nil {
+		return &transcriptResult{}
+	}
+	return e.stream.Result()
 }
 
 // handleRawOutputHook invokes the configured raw output hook.
@@ -231,26 +301,34 @@ func (a *codexAgent) emitFlowError(ctx context.Context, invocation *agent.Invoca
 	a.emitEvent(ctx, invocation, out, event.NewResponseEvent(invocation.InvocationID, a.name, rsp))
 }
 
-// runWithSession executes the CLI with resume-first semantics and returns stdout/stderr.
-func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string) ([]byte, []byte, error) {
+// runWithSession executes the CLI with resume-first semantics and streams stdout events.
+func (a *codexAgent) runWithSession(ctx context.Context, threadID, prompt string, streamer *codexStreamEmitter) commandResult {
 	if strings.TrimSpace(threadID) != "" {
-		stdout, stderr, runErr := a.runResume(ctx, threadID, prompt)
-		if runErr == nil {
-			return stdout, stderr, nil
+		streamer.Reset()
+		resumeResult := a.runResume(ctx, threadID, prompt, streamer.HandleLine)
+		if resumeResult.err() == nil {
+			return resumeResult
 		}
-		createStdout, createStderr, createErr := a.runCreate(ctx, prompt)
-		if createErr == nil {
-			return createStdout, createStderr, nil
+		if resumeResult.outputErr != nil || streamer.emitted {
+			return resumeResult
 		}
-		overallErr := fmt.Errorf("run resume %v: %w", threadID, runErr)
-		overallErr = errors.Join(overallErr, fmt.Errorf("run exec: %w", createErr))
-		return createStdout, createStderr, overallErr
+		streamer.Reset()
+		createResult := a.runCreate(ctx, prompt, streamer.HandleLine)
+		if createResult.err() == nil {
+			return createResult
+		}
+		if createResult.runErr != nil {
+			overallErr := fmt.Errorf("run resume %v: %w", threadID, resumeResult.runErr)
+			createResult.runErr = errors.Join(overallErr, fmt.Errorf("run exec: %w", createResult.runErr))
+		}
+		return createResult
 	}
-	return a.runCreate(ctx, prompt)
+	streamer.Reset()
+	return a.runCreate(ctx, prompt, streamer.HandleLine)
 }
 
 // runCreate starts a new Codex exec session.
-func (a *codexAgent) runCreate(ctx context.Context, prompt string) ([]byte, []byte, error) {
+func (a *codexAgent) runCreate(ctx context.Context, prompt string, onStdoutLine commandOutputHandler) commandResult {
 	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+1)
 	cmdArgs = append(cmdArgs, a.globalArgs...)
 	cmdArgs = append(cmdArgs, "exec")
@@ -261,11 +339,11 @@ func (a *codexAgent) runCreate(ctx context.Context, prompt string) ([]byte, []by
 		stdin: []byte(prompt),
 		env:   a.env,
 		dir:   a.workDir,
-	})
+	}, onStdoutLine)
 }
 
 // runResume resumes an existing Codex thread.
-func (a *codexAgent) runResume(ctx context.Context, threadID, prompt string) ([]byte, []byte, error) {
+func (a *codexAgent) runResume(ctx context.Context, threadID, prompt string, onStdoutLine commandOutputHandler) commandResult {
 	cmdArgs := make([]string, 0, len(a.globalArgs)+len(a.args)+3)
 	cmdArgs = append(cmdArgs, a.globalArgs...)
 	cmdArgs = append(cmdArgs, "exec", "resume")
@@ -277,7 +355,7 @@ func (a *codexAgent) runResume(ctx context.Context, threadID, prompt string) ([]
 		stdin: []byte(prompt),
 		env:   a.env,
 		dir:   a.workDir,
-	})
+	}, onStdoutLine)
 }
 
 // emitEvent forwards an event to the caller and logs emission failures.

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -381,6 +381,37 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	require.Equal(t, "Hi.", string(calls[1].stdin))
 }
 
+func TestCodexAgent_Run_ResumeFailureAfterStreamedEventDoesNotFallback(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-resume-stream-error")
+	sess.SetState(StateKeyThreadID, []byte("thread-1"))
+	inv := newTestInvocation("inv-resume-stream-error", sess, "Hi.")
+	transcript := `{"type":"thread.started","thread_id":"thread-1"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"sleep 1","status":"in_progress"}}`
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			if len(cmd.args) > 1 && cmd.args[1] == "resume" {
+				return []byte(transcript), []byte("resume crashed"), errors.New("resume exit 1")
+			}
+			return []byte(`{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"fresh"}}`), nil, nil
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 2)
+	require.True(t, events[0].IsToolCallResponse())
+	require.True(t, events[1].IsTerminalError())
+	require.Equal(t, model.ErrorTypeRunError, events[1].Error.Type)
+	require.Contains(t, events[1].Error.Message, "resume crashed")
+	require.Empty(t, events[1].StateDelta)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
+}
+
 func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
 	ctx := context.Background()
 	sess := session.NewSession("app", "user", "sess-4")
@@ -701,16 +732,35 @@ func TestParseTranscriptEvents_ErrorEventMapping(t *testing.T) {
 	require.Equal(t, model.ObjectTypeChatCompletionChunk, result.Events[0].Object)
 	require.False(t, result.Events[0].Done)
 	require.True(t, result.Events[0].IsPartial)
+	require.Nil(t, result.Events[0].Error)
 	require.False(t, result.Events[0].IsTerminalError())
-	require.Equal(t, model.ErrorTypeRunError, result.Events[0].Error.Type)
-	require.Equal(t, "turn failed", result.Events[0].Error.Message)
-	require.NotNil(t, result.Events[0].Error.Code)
-	require.Equal(t, "bad_turn", *result.Events[0].Error.Code)
+	require.Equal(t, "turn failed", result.Events[0].Choices[0].Delta.Content)
 	require.False(t, result.Events[1].Done)
 	require.True(t, result.Events[1].IsPartial)
+	require.Nil(t, result.Events[1].Error)
 	require.False(t, result.Events[1].IsTerminalError())
-	require.Equal(t, "top-level error", result.Events[1].Error.Message)
+	require.Equal(t, "top-level error", result.Events[1].Choices[0].Delta.Content)
 	require.Equal(t, "top-level error", result.Error.Message)
+}
+
+func TestErrorEventFromResponseErrorClonesTerminalError(t *testing.T) {
+	param := "prompt"
+	code := "bad_turn"
+	responseErr := &model.ResponseError{
+		Type:    model.ErrorTypeRunError,
+		Message: "original",
+		Param:   &param,
+		Code:    &code,
+	}
+	evt := errorEventFromResponseError("inv-clone", "codex", responseErr, true)
+	responseErr.Message = "mutated"
+	*responseErr.Param = "mutated-param"
+	*responseErr.Code = "mutated-code"
+	require.Equal(t, "original", evt.Error.Message)
+	require.NotNil(t, evt.Error.Param)
+	require.Equal(t, "prompt", *evt.Error.Param)
+	require.NotNil(t, evt.Error.Code)
+	require.Equal(t, "bad_turn", *evt.Error.Code)
 }
 
 func TestTranscriptHelpers_Fallbacks(t *testing.T) {

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -132,20 +132,24 @@ func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 3)
+	require.Len(t, events, 4)
 	require.True(t, events[0].IsToolCallResponse())
 	require.True(t, events[1].IsToolResultResponse())
-	require.True(t, events[2].IsFinalResponse())
+	require.False(t, events[2].IsFinalResponse())
+	require.True(t, events[3].IsFinalResponse())
 	require.Equal(t, "command_execution", events[0].Choices[0].Message.ToolCalls[0].Function.Name)
 	require.Equal(t, `{"command":"/usr/bin/bash -lc 'printf hi'"}`, string(events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
 	require.Equal(t, "hi", events[1].Choices[0].Message.Content)
 	require.Equal(t, "done", events[2].Choices[0].Message.Content)
-	require.Equal(t, 10, events[2].Usage.PromptTokens)
-	require.Equal(t, 3, events[2].Usage.CompletionTokens)
-	require.Equal(t, 13, events[2].Usage.TotalTokens)
-	require.Equal(t, 2, events[2].Usage.PromptTokensDetails.CachedTokens)
-	require.Equal(t, 1, events[2].Usage.CompletionTokensDetails.ReasoningTokens)
-	require.Equal(t, []byte("thread-1"), events[2].StateDelta[StateKeyThreadID])
+	require.Equal(t, "item_1", events[2].Response.ID)
+	require.Equal(t, "done", events[3].Choices[0].Message.Content)
+	require.Equal(t, "item_1", events[3].Response.ID)
+	require.Equal(t, 10, events[3].Usage.PromptTokens)
+	require.Equal(t, 3, events[3].Usage.CompletionTokens)
+	require.Equal(t, 13, events[3].Usage.TotalTokens)
+	require.Equal(t, 2, events[3].Usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, 1, events[3].Usage.CompletionTokensDetails.ReasoningTokens)
+	require.Equal(t, []byte("thread-1"), events[3].StateDelta[StateKeyThreadID])
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, "codex", calls[0].bin)
@@ -196,12 +200,72 @@ func TestCodexAgent_Run_StreamsToolEventBeforeCommandReturns(t *testing.T) {
 	}
 	close(release)
 	events := append([]*event.Event{first}, drainEvents(ch)...)
-	require.Len(t, events, 3)
+	require.Len(t, events, 4)
 	require.True(t, events[1].IsToolResultResponse())
 	require.Equal(t, "done", events[1].Choices[0].Message.Content)
-	require.True(t, events[2].IsFinalResponse())
+	require.False(t, events[2].IsFinalResponse())
 	require.Equal(t, "finished", events[2].Choices[0].Message.Content)
-	require.Equal(t, 3, events[2].Usage.TotalTokens)
+	require.True(t, events[3].IsFinalResponse())
+	require.Equal(t, "finished", events[3].Choices[0].Message.Content)
+	require.Equal(t, 3, events[3].Usage.TotalTokens)
+}
+
+func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-stream-2")
+	inv := newTestInvocation("inv-stream-2", sess, "Say, run, say.")
+	release := make(chan struct{})
+	returned := make(chan struct{})
+	firstLine := []byte(`{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"good luck"}}` + "\n")
+	rest := []byte(`{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"sleep 1","status":"in_progress"}}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"sleep 1","aggregated_output":"done","exit_code":0,"status":"completed"}}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"practice makes perfect"}}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":3,"output_tokens":4}}` + "\n")
+	runner := &scriptedRunner{
+		stream: func(cmd command, onStdoutLine commandOutputHandler) commandResult {
+			stdout := append([]byte(nil), firstLine...)
+			if err := onStdoutLine(firstLine); err != nil {
+				close(returned)
+				return commandResult{stdout: stdout, outputErr: err}
+			}
+			<-release
+			stdout = append(stdout, rest...)
+			outputErr := emitScriptedStdout(rest, onStdoutLine)
+			close(returned)
+			return commandResult{stdout: stdout, outputErr: outputErr}
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	var first *event.Event
+	select {
+	case first = <-ch:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for streamed assistant event")
+	}
+	require.False(t, first.IsFinalResponse())
+	require.Equal(t, model.ObjectTypeChatCompletion, first.Object)
+	require.Equal(t, "item_0", first.Response.ID)
+	require.Equal(t, "good luck", first.Choices[0].Message.Content)
+	select {
+	case <-returned:
+		require.FailNow(t, "command returned before the test released it")
+	default:
+	}
+	close(release)
+	events := append([]*event.Event{first}, drainEvents(ch)...)
+	require.Len(t, events, 5)
+	require.True(t, events[1].IsToolCallResponse())
+	require.True(t, events[2].IsToolResultResponse())
+	require.False(t, events[3].IsFinalResponse())
+	require.Equal(t, "practice makes perfect", events[3].Choices[0].Message.Content)
+	require.Equal(t, "item_2", events[3].Response.ID)
+	require.True(t, events[4].IsFinalResponse())
+	require.Equal(t, "practice makes perfect", events[4].Choices[0].Message.Content)
+	require.Equal(t, "item_2", events[4].Response.ID)
+	require.Equal(t, 7, events[4].Usage.TotalTokens)
 }
 
 func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
@@ -220,9 +284,12 @@ func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 1)
+	require.Len(t, events, 2)
 	require.Equal(t, "hello", events[0].Choices[0].Message.Content)
-	require.Empty(t, events[0].StateDelta)
+	require.False(t, events[0].IsFinalResponse())
+	require.True(t, events[1].IsFinalResponse())
+	require.Equal(t, "hello", events[1].Choices[0].Message.Content)
+	require.Empty(t, events[1].StateDelta)
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
@@ -248,9 +315,12 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 1)
+	require.Len(t, events, 2)
 	require.Equal(t, "fresh", events[0].Choices[0].Message.Content)
-	require.Equal(t, []byte("thread-2"), events[0].StateDelta[StateKeyThreadID])
+	require.False(t, events[0].IsFinalResponse())
+	require.True(t, events[1].IsFinalResponse())
+	require.Equal(t, "fresh", events[1].Choices[0].Message.Content)
+	require.Equal(t, []byte("thread-2"), events[1].StateDelta[StateKeyThreadID])
 	calls := runner.Calls()
 	require.Len(t, calls, 2)
 	require.Equal(t, []string{"exec", "resume", "--json", "stale-thread"}, calls[0].args)
@@ -384,17 +454,18 @@ func TestCodexAgent_Run_RawOutputHookError(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 3)
+	require.Len(t, events, 4)
 	require.True(t, events[0].IsToolCallResponse())
 	require.True(t, events[1].IsToolResultResponse())
-	require.True(t, events[2].IsFinalResponse())
-	require.Equal(t, model.ObjectTypeError, events[2].Object)
-	require.NotNil(t, events[2].Error)
-	require.Equal(t, model.ErrorTypeFlowError, events[2].Error.Type)
-	require.Contains(t, events[2].Error.Message, "raw output hook")
-	require.Contains(t, events[2].Error.Message, "hook failed")
-	require.Contains(t, events[2].Choices[0].Message.Content, "thread-hook-2")
-	require.Contains(t, events[2].Choices[0].Message.Content, "warn")
+	require.Equal(t, "hello", events[2].Choices[0].Message.Content)
+	require.True(t, events[3].IsFinalResponse())
+	require.Equal(t, model.ObjectTypeError, events[3].Object)
+	require.NotNil(t, events[3].Error)
+	require.Equal(t, model.ErrorTypeFlowError, events[3].Error.Type)
+	require.Contains(t, events[3].Error.Message, "raw output hook")
+	require.Contains(t, events[3].Error.Message, "hook failed")
+	require.Contains(t, events[3].Choices[0].Message.Content, "thread-hook-2")
+	require.Contains(t, events[3].Choices[0].Message.Content, "warn")
 }
 
 func TestCodexAgent_InfoAndRunnerArgs(t *testing.T) {
@@ -500,11 +571,14 @@ func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "thread-parse", result.ThreadID)
 	require.Equal(t, "done", result.FinalMessage)
-	require.Len(t, result.Events, 2)
+	require.Equal(t, "item_1", result.FinalMessageID)
+	require.Len(t, result.Events, 3)
 	require.True(t, result.Events[0].IsToolCallResponse())
 	require.True(t, result.Events[1].IsToolResultResponse())
+	require.False(t, result.Events[2].IsFinalResponse())
 	require.Equal(t, "pwd", commandArg(t, result.Events[0]))
 	require.Equal(t, "/tmp\n", result.Events[1].Choices[0].Message.Content)
+	require.Equal(t, "done", result.Events[2].Choices[0].Message.Content)
 }
 
 func TestParseTranscriptEvents_MCPToolCallMapping(t *testing.T) {

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -136,11 +136,13 @@ func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
 	require.True(t, events[0].IsToolCallResponse())
 	require.True(t, events[1].IsToolResultResponse())
 	require.False(t, events[2].IsFinalResponse())
+	require.True(t, events[2].IsPartial)
+	require.Equal(t, model.ObjectTypeChatCompletionChunk, events[2].Object)
 	require.True(t, events[3].IsFinalResponse())
 	require.Equal(t, "command_execution", events[0].Choices[0].Message.ToolCalls[0].Function.Name)
 	require.Equal(t, `{"command":"/usr/bin/bash -lc 'printf hi'"}`, string(events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
 	require.Equal(t, "hi", events[1].Choices[0].Message.Content)
-	require.Equal(t, "done", events[2].Choices[0].Message.Content)
+	require.Equal(t, "done", events[2].Choices[0].Delta.Content)
 	require.Equal(t, "item_1", events[2].Response.ID)
 	require.Equal(t, "done", events[3].Choices[0].Message.Content)
 	require.Equal(t, "item_1", events[3].Response.ID)
@@ -204,7 +206,8 @@ func TestCodexAgent_Run_StreamsToolEventBeforeCommandReturns(t *testing.T) {
 	require.True(t, events[1].IsToolResultResponse())
 	require.Equal(t, "done", events[1].Choices[0].Message.Content)
 	require.False(t, events[2].IsFinalResponse())
-	require.Equal(t, "finished", events[2].Choices[0].Message.Content)
+	require.True(t, events[2].IsPartial)
+	require.Equal(t, "finished", events[2].Choices[0].Delta.Content)
 	require.True(t, events[3].IsFinalResponse())
 	require.Equal(t, "finished", events[3].Choices[0].Message.Content)
 	require.Equal(t, 3, events[3].Usage.TotalTokens)
@@ -246,9 +249,10 @@ func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
 		require.FailNow(t, "timed out waiting for streamed assistant event")
 	}
 	require.False(t, first.IsFinalResponse())
-	require.Equal(t, model.ObjectTypeChatCompletion, first.Object)
+	require.True(t, first.IsPartial)
+	require.Equal(t, model.ObjectTypeChatCompletionChunk, first.Object)
 	require.Equal(t, "item_0", first.Response.ID)
-	require.Equal(t, "good luck", first.Choices[0].Message.Content)
+	require.Equal(t, "good luck", first.Choices[0].Delta.Content)
 	select {
 	case <-returned:
 		require.FailNow(t, "command returned before the test released it")
@@ -260,12 +264,58 @@ func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
 	require.True(t, events[1].IsToolCallResponse())
 	require.True(t, events[2].IsToolResultResponse())
 	require.False(t, events[3].IsFinalResponse())
-	require.Equal(t, "practice makes perfect", events[3].Choices[0].Message.Content)
+	require.True(t, events[3].IsPartial)
+	require.Equal(t, "practice makes perfect", events[3].Choices[0].Delta.Content)
 	require.Equal(t, "item_2", events[3].Response.ID)
 	require.True(t, events[4].IsFinalResponse())
 	require.Equal(t, "practice makes perfect", events[4].Choices[0].Message.Content)
 	require.Equal(t, "item_2", events[4].Response.ID)
 	require.Equal(t, 7, events[4].Usage.TotalTokens)
+}
+
+func TestCodexAgent_Run_StreamsErrorsAsNonTerminalUntilCommandFinishes(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-stream-error-1")
+	inv := newTestInvocation("inv-stream-error-1", sess, "Fail twice.")
+	returned := make(chan struct{})
+	transcript := []byte(`{"type":"turn.failed","error":{"message":"first failure","code":"first"}}
+{"type":"error","message":"second failure"}` + "\n")
+	runner := &scriptedRunner{
+		stream: func(cmd command, onStdoutLine commandOutputHandler) commandResult {
+			outputErr := emitScriptedStdout(transcript, onStdoutLine)
+			close(returned)
+			return commandResult{stdout: transcript, outputErr: outputErr}
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	doneEvent := make(chan *event.Event, 1)
+	go func() {
+		for evt := range ch {
+			if evt != nil && evt.Done {
+				doneEvent <- evt
+				return
+			}
+		}
+		doneEvent <- nil
+	}()
+	var terminal *event.Event
+	select {
+	case terminal = <-doneEvent:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for terminal error")
+	}
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		require.FailNow(t, "command blocked after streamed error observations")
+	}
+	require.NotNil(t, terminal)
+	require.True(t, terminal.IsTerminalError())
+	require.Equal(t, model.ObjectTypeError, terminal.Object)
+	require.Equal(t, "second failure", terminal.Error.Message)
 }
 
 func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
@@ -285,8 +335,9 @@ func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
 	require.NoError(t, err)
 	events := drainEvents(ch)
 	require.Len(t, events, 2)
-	require.Equal(t, "hello", events[0].Choices[0].Message.Content)
 	require.False(t, events[0].IsFinalResponse())
+	require.True(t, events[0].IsPartial)
+	require.Equal(t, "hello", events[0].Choices[0].Delta.Content)
 	require.True(t, events[1].IsFinalResponse())
 	require.Equal(t, "hello", events[1].Choices[0].Message.Content)
 	require.Empty(t, events[1].StateDelta)
@@ -316,8 +367,9 @@ func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	require.NoError(t, err)
 	events := drainEvents(ch)
 	require.Len(t, events, 2)
-	require.Equal(t, "fresh", events[0].Choices[0].Message.Content)
 	require.False(t, events[0].IsFinalResponse())
+	require.True(t, events[0].IsPartial)
+	require.Equal(t, "fresh", events[0].Choices[0].Delta.Content)
 	require.True(t, events[1].IsFinalResponse())
 	require.Equal(t, "fresh", events[1].Choices[0].Message.Content)
 	require.Equal(t, []byte("thread-2"), events[1].StateDelta[StateKeyThreadID])
@@ -457,7 +509,8 @@ func TestCodexAgent_Run_RawOutputHookError(t *testing.T) {
 	require.Len(t, events, 4)
 	require.True(t, events[0].IsToolCallResponse())
 	require.True(t, events[1].IsToolResultResponse())
-	require.Equal(t, "hello", events[2].Choices[0].Message.Content)
+	require.True(t, events[2].IsPartial)
+	require.Equal(t, "hello", events[2].Choices[0].Delta.Content)
 	require.True(t, events[3].IsFinalResponse())
 	require.Equal(t, model.ObjectTypeError, events[3].Object)
 	require.NotNil(t, events[3].Error)
@@ -578,7 +631,8 @@ func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
 	require.False(t, result.Events[2].IsFinalResponse())
 	require.Equal(t, "pwd", commandArg(t, result.Events[0]))
 	require.Equal(t, "/tmp\n", result.Events[1].Choices[0].Message.Content)
-	require.Equal(t, "done", result.Events[2].Choices[0].Message.Content)
+	require.True(t, result.Events[2].IsPartial)
+	require.Equal(t, "done", result.Events[2].Choices[0].Delta.Content)
 }
 
 func TestParseTranscriptEvents_MCPToolCallMapping(t *testing.T) {
@@ -644,11 +698,17 @@ func TestParseTranscriptEvents_ErrorEventMapping(t *testing.T) {
 	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-error-1", "codex")
 	require.NoError(t, err)
 	require.Len(t, result.Events, 2)
-	require.Equal(t, model.ObjectTypeError, result.Events[0].Object)
+	require.Equal(t, model.ObjectTypeChatCompletionChunk, result.Events[0].Object)
+	require.False(t, result.Events[0].Done)
+	require.True(t, result.Events[0].IsPartial)
+	require.False(t, result.Events[0].IsTerminalError())
 	require.Equal(t, model.ErrorTypeRunError, result.Events[0].Error.Type)
 	require.Equal(t, "turn failed", result.Events[0].Error.Message)
 	require.NotNil(t, result.Events[0].Error.Code)
 	require.Equal(t, "bad_turn", *result.Events[0].Error.Code)
+	require.False(t, result.Events[1].Done)
+	require.True(t, result.Events[1].IsPartial)
+	require.False(t, result.Events[1].IsTerminalError())
 	require.Equal(t, "top-level error", result.Events[1].Error.Message)
 	require.Equal(t, "top-level error", result.Error.Message)
 }

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -10,6 +10,7 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -27,21 +29,33 @@ import (
 
 // scriptedRunner is a deterministic commandRunner used for unit tests.
 type scriptedRunner struct {
-	mu    sync.Mutex
-	calls []command
-	run   func(command) ([]byte, []byte, error)
+	mu     sync.Mutex
+	calls  []command
+	run    func(command) ([]byte, []byte, error)
+	stream func(command, commandOutputHandler) commandResult
 }
 
 // Run implements commandRunner.
-func (r *scriptedRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, error) {
+func (r *scriptedRunner) Run(ctx context.Context, cmd command, onStdoutLine commandOutputHandler) commandResult {
 	r.mu.Lock()
 	r.calls = append(r.calls, cmd)
 	run := r.run
+	stream := r.stream
 	r.mu.Unlock()
-	if run == nil {
-		return nil, nil, nil
+	if stream != nil {
+		return stream(cmd, onStdoutLine)
 	}
-	return run(cmd)
+	if run == nil {
+		return commandResult{}
+	}
+	stdout, stderr, runErr := run(cmd)
+	outputErr := emitScriptedStdout(stdout, onStdoutLine)
+	return commandResult{
+		stdout:    stdout,
+		stderr:    stderr,
+		runErr:    runErr,
+		outputErr: outputErr,
+	}
 }
 
 // Calls returns a snapshot of captured command invocations.
@@ -60,6 +74,25 @@ func drainEvents(ch <-chan *event.Event) []*event.Event {
 		events = append(events, e)
 	}
 	return events
+}
+
+// emitScriptedStdout forwards captured stdout to the command output handler.
+func emitScriptedStdout(stdout []byte, onStdoutLine commandOutputHandler) error {
+	if onStdoutLine == nil {
+		return nil
+	}
+	for len(stdout) > 0 {
+		idx := bytes.IndexByte(stdout, '\n')
+		if idx < 0 {
+			return onStdoutLine(stdout)
+		}
+		line := stdout[:idx+1]
+		stdout = stdout[idx+1:]
+		if err := onStdoutLine(line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // newTestInvocation creates a test invocation with a user prompt.
@@ -118,6 +151,57 @@ func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
 	require.Equal(t, "codex", calls[0].bin)
 	require.Equal(t, []string{"exec", "--json"}, calls[0].args)
 	require.Equal(t, "Run printf.", string(calls[0].stdin))
+}
+
+func TestCodexAgent_Run_StreamsToolEventBeforeCommandReturns(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-stream-1")
+	inv := newTestInvocation("inv-stream-1", sess, "Run slow command.")
+	release := make(chan struct{})
+	returned := make(chan struct{})
+	firstLine := []byte(`{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"sleep 1","status":"in_progress"}}` + "\n")
+	rest := []byte(`{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"sleep 1","aggregated_output":"done","exit_code":0,"status":"completed"}}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"finished"}}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}` + "\n")
+	runner := &scriptedRunner{
+		stream: func(cmd command, onStdoutLine commandOutputHandler) commandResult {
+			stdout := append([]byte(nil), firstLine...)
+			if err := onStdoutLine(firstLine); err != nil {
+				close(returned)
+				return commandResult{stdout: stdout, outputErr: err}
+			}
+			<-release
+			stdout = append(stdout, rest...)
+			outputErr := emitScriptedStdout(rest, onStdoutLine)
+			close(returned)
+			return commandResult{stdout: stdout, outputErr: outputErr}
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	var first *event.Event
+	select {
+	case first = <-ch:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for streamed tool event")
+	}
+	require.True(t, first.IsToolCallResponse())
+	require.Equal(t, "sleep 1", commandArg(t, first))
+	select {
+	case <-returned:
+		require.FailNow(t, "command returned before the test released it")
+	default:
+	}
+	close(release)
+	events := append([]*event.Event{first}, drainEvents(ch)...)
+	require.Len(t, events, 3)
+	require.True(t, events[1].IsToolResultResponse())
+	require.Equal(t, "done", events[1].Choices[0].Message.Content)
+	require.True(t, events[2].IsFinalResponse())
+	require.Equal(t, "finished", events[2].Choices[0].Message.Content)
+	require.Equal(t, 3, events[2].Usage.TotalTokens)
 }
 
 func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
@@ -250,7 +334,7 @@ func TestCodexAgent_Run_RawOutputHookReceivesCommandError(t *testing.T) {
 	runErr := errors.New("exit 1")
 	runner := &scriptedRunner{
 		run: func(cmd command) ([]byte, []byte, error) {
-			return []byte("stdout text"), []byte("stderr text"), runErr
+			return nil, []byte("stderr text"), runErr
 		},
 	}
 	var got RawOutputHookArgs
@@ -268,12 +352,12 @@ func TestCodexAgent_Run_RawOutputHookReceivesCommandError(t *testing.T) {
 	require.Len(t, events, 1)
 	require.ErrorIs(t, got.Error, runErr)
 	require.Equal(t, "--help", got.Prompt)
-	require.Equal(t, "stdout text", string(got.Stdout))
+	require.Empty(t, string(got.Stdout))
 	require.Equal(t, "stderr text", string(got.Stderr))
 	require.NotNil(t, events[0].Error)
 	require.Equal(t, model.ErrorTypeRunError, events[0].Error.Type)
-	require.Equal(t, "stdout text\nstderr text", events[0].Error.Message)
-	require.Equal(t, "stdout text\nstderr text", events[0].Choices[0].Message.Content)
+	require.Equal(t, "stderr text", events[0].Error.Message)
+	require.Equal(t, "stderr text", events[0].Choices[0].Message.Content)
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, []string{"exec", "--json"}, calls[0].args)
@@ -300,15 +384,17 @@ func TestCodexAgent_Run_RawOutputHookError(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 1)
-	require.True(t, events[0].IsFinalResponse())
-	require.Equal(t, model.ObjectTypeError, events[0].Object)
-	require.NotNil(t, events[0].Error)
-	require.Equal(t, model.ErrorTypeFlowError, events[0].Error.Type)
-	require.Contains(t, events[0].Error.Message, "raw output hook")
-	require.Contains(t, events[0].Error.Message, "hook failed")
-	require.Contains(t, events[0].Choices[0].Message.Content, "thread-hook-2")
-	require.Contains(t, events[0].Choices[0].Message.Content, "warn")
+	require.Len(t, events, 3)
+	require.True(t, events[0].IsToolCallResponse())
+	require.True(t, events[1].IsToolResultResponse())
+	require.True(t, events[2].IsFinalResponse())
+	require.Equal(t, model.ObjectTypeError, events[2].Object)
+	require.NotNil(t, events[2].Error)
+	require.Equal(t, model.ErrorTypeFlowError, events[2].Error.Type)
+	require.Contains(t, events[2].Error.Message, "raw output hook")
+	require.Contains(t, events[2].Error.Message, "hook failed")
+	require.Contains(t, events[2].Choices[0].Message.Content, "thread-hook-2")
+	require.Contains(t, events[2].Choices[0].Message.Content, "warn")
 }
 
 func TestCodexAgent_InfoAndRunnerArgs(t *testing.T) {
@@ -375,35 +461,35 @@ func TestCodexAgent_Run_ValidationErrors(t *testing.T) {
 func TestExecCommandRunner_Run(t *testing.T) {
 	tmp := t.TempDir()
 	runner := execCommandRunner{}
-	stdout, stderr, err := runner.Run(context.Background(), command{
+	result := runner.Run(context.Background(), command{
 		bin:  "sh",
 		args: []string{"-c", "printf \"$FOO\""},
 		env:  []string{"FOO=bar"},
-	})
-	require.NoError(t, err)
-	require.Equal(t, "bar", string(stdout))
-	require.Empty(t, string(stderr))
-	stdout, stderr, err = runner.Run(context.Background(), command{
+	}, nil)
+	require.NoError(t, result.err())
+	require.Equal(t, "bar", string(result.stdout))
+	require.Empty(t, string(result.stderr))
+	result = runner.Run(context.Background(), command{
 		bin:   "sh",
 		args:  []string{"-c", "cat"},
 		stdin: []byte("--help"),
-	})
-	require.NoError(t, err)
-	require.Equal(t, "--help", string(stdout))
-	require.Empty(t, string(stderr))
-	stdout, stderr, err = runner.Run(context.Background(), command{
+	}, nil)
+	require.NoError(t, result.err())
+	require.Equal(t, "--help", string(result.stdout))
+	require.Empty(t, string(result.stderr))
+	result = runner.Run(context.Background(), command{
 		bin:  "sh",
 		args: []string{"-c", "pwd"},
 		dir:  tmp,
-	})
-	require.NoError(t, err)
-	got := strings.TrimSpace(string(stdout))
+	}, nil)
+	require.NoError(t, result.err())
+	got := strings.TrimSpace(string(result.stdout))
 	gotResolved, err := filepath.EvalSymlinks(got)
 	require.NoError(t, err)
 	wantResolved, err := filepath.EvalSymlinks(tmp)
 	require.NoError(t, err)
 	require.Equal(t, wantResolved, gotResolved)
-	require.Empty(t, string(stderr))
+	require.Empty(t, string(result.stderr))
 }
 
 func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
@@ -476,6 +562,21 @@ func TestParseTranscriptEvents_SkillToolMapping(t *testing.T) {
 	require.Equal(t, "debug", directArgs.Skill)
 	require.Equal(t, "", directArgs.Command)
 	require.Equal(t, "ok", result.Events[1].Choices[0].Message.Content)
+}
+
+func TestParseTranscriptEvents_ErrorEventMapping(t *testing.T) {
+	transcript := `{"type":"turn.failed","error":{"message":"turn failed","code":"bad_turn"}}
+{"type":"error","message":"top-level error"}`
+	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-error-1", "codex")
+	require.NoError(t, err)
+	require.Len(t, result.Events, 2)
+	require.Equal(t, model.ObjectTypeError, result.Events[0].Object)
+	require.Equal(t, model.ErrorTypeRunError, result.Events[0].Error.Type)
+	require.Equal(t, "turn failed", result.Events[0].Error.Message)
+	require.NotNil(t, result.Events[0].Error.Code)
+	require.Equal(t, "bad_turn", *result.Events[0].Error.Code)
+	require.Equal(t, "top-level error", result.Events[1].Error.Message)
+	require.Equal(t, "top-level error", result.Error.Message)
 }
 
 func TestTranscriptHelpers_Fallbacks(t *testing.T) {

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -316,6 +317,54 @@ func TestCodexAgent_Run_StreamsErrorsAsNonTerminalUntilCommandFinishes(t *testin
 	require.True(t, terminal.IsTerminalError())
 	require.Equal(t, model.ObjectTypeError, terminal.Object)
 	require.Equal(t, "second failure", terminal.Error.Message)
+}
+
+func TestCodexAgent_Run_StreamParseErrorEmitsFlowError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-stream-parse-error")
+	inv := newTestInvocation("inv-stream-parse-error", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte("{not-json}\n"), nil, nil
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.Equal(t, model.ObjectTypeError, events[0].Object)
+	require.NotNil(t, events[0].Error)
+	require.Equal(t, model.ErrorTypeFlowError, events[0].Error.Type)
+	require.Contains(t, events[0].Error.Message, "stream codex transcript")
+	require.Equal(t, "{not-json}", events[0].Choices[0].Message.Content)
+}
+
+func TestCodexAgent_Run_CommandErrorAfterCodexFailureEmitsTerminalCodexError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-codex-error-run-error")
+	inv := newTestInvocation("inv-codex-error-run-error", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			transcript := []byte(`{"type":"turn.failed","error":{"message":"codex failed","code":"bad_turn"}}` + "\n")
+			return transcript, []byte("process failed"), errors.New("exit 1")
+		},
+	}
+	ag, err := New(withCommandRunner(runner))
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 2)
+	require.False(t, events[0].Done)
+	require.True(t, events[0].IsPartial)
+	require.Nil(t, events[0].Error)
+	require.True(t, events[1].IsTerminalError())
+	require.Equal(t, "codex failed", events[1].Error.Message)
+	require.NotNil(t, events[1].Error.Code)
+	require.Equal(t, "bad_turn", *events[1].Error.Code)
+	require.Equal(t, "codex failed", events[1].Choices[0].Message.Content)
 }
 
 func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
@@ -647,6 +696,70 @@ func TestExecCommandRunner_Run(t *testing.T) {
 	require.Empty(t, string(result.stderr))
 }
 
+func TestExecCommandRunner_Run_StreamsStdoutLines(t *testing.T) {
+	runner := execCommandRunner{}
+	var lines []string
+	result := runner.Run(context.Background(), command{
+		bin:  "sh",
+		args: []string{"-c", "printf 'one\\n'; printf 'two'"},
+	}, func(line []byte) error {
+		lines = append(lines, string(line))
+		return nil
+	})
+	require.NoError(t, result.err())
+	require.Equal(t, "one\ntwo", string(result.stdout))
+	require.Empty(t, string(result.stderr))
+	require.Equal(t, []string{"one\n", "two"}, lines)
+}
+
+func TestExecCommandRunner_Run_StopsProcessOnStreamHandlerError(t *testing.T) {
+	runner := execCommandRunner{}
+	handlerErr := errors.New("stop streaming")
+	result := runner.Run(context.Background(), command{
+		bin:  "sh",
+		args: []string{"-c", "printf 'one\\n'; sleep 5; printf 'two\\n'"},
+	}, func(line []byte) error {
+		require.Equal(t, "one\n", string(line))
+		return handlerErr
+	})
+	require.ErrorIs(t, result.outputErr, handlerErr)
+	require.ErrorIs(t, result.err(), handlerErr)
+	require.Error(t, result.runErr)
+	require.Equal(t, "one\n", string(result.stdout))
+}
+
+func TestExecCommandRunner_Run_ReportsStartErrorWithStreaming(t *testing.T) {
+	runner := execCommandRunner{}
+	result := runner.Run(context.Background(), command{
+		bin: filepath.Join(t.TempDir(), "missing-codex"),
+	}, func(line []byte) error {
+		require.Empty(t, line)
+		return nil
+	})
+	require.Error(t, result.runErr)
+	require.NoError(t, result.outputErr)
+	require.Empty(t, result.stdout)
+	require.Empty(t, result.stderr)
+}
+
+func TestReadStdoutLines_ReportsReaderErrorAfterCapturedLine(t *testing.T) {
+	reader, writer := io.Pipe()
+	readErr := errors.New("read failed")
+	go func() {
+		_, _ = writer.Write([]byte("one\n"))
+		_ = writer.CloseWithError(readErr)
+	}()
+	var capture bytes.Buffer
+	var lines []string
+	err := readStdoutLines(reader, &capture, func(line []byte) error {
+		lines = append(lines, string(line))
+		return nil
+	})
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, "one\n", capture.String())
+	require.Equal(t, []string{"one\n"}, lines)
+}
+
 func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
 	transcript := `{"type":"thread.started","thread_id":"thread-parse"}
 {"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"pwd","aggregated_output":"/tmp\n","exit_code":0,"status":"completed"}}
@@ -743,6 +856,33 @@ func TestParseTranscriptEvents_ErrorEventMapping(t *testing.T) {
 	require.Equal(t, "top-level error", result.Error.Message)
 }
 
+func TestParseTranscriptEvents_ErrorPayloadShapes(t *testing.T) {
+	transcript := `{"type":"turn.failed","error":"quoted failure"}
+{"type":"turn.failed","error":{"type":"api_error","message":"api failed","code":"api_code"}}`
+	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-error-2", "codex")
+	require.NoError(t, err)
+	require.Len(t, result.Events, 2)
+	require.Equal(t, "quoted failure", result.Events[0].Choices[0].Delta.Content)
+	require.Equal(t, "api failed", result.Events[1].Choices[0].Delta.Content)
+	require.NotNil(t, result.Error)
+	require.Equal(t, "api_error", result.Error.Type)
+	require.NotNil(t, result.Error.Code)
+	require.Equal(t, "api_code", *result.Error.Code)
+}
+
+func TestErrorEventFromRecord(t *testing.T) {
+	evt := errorEventFromRecord("inv-error-record", "codex", codexEvent{
+		Type:  codexEventTurnFailed,
+		Error: json.RawMessage(`"quoted failure"`),
+	}, false)
+	require.NotNil(t, evt)
+	require.False(t, evt.Done)
+	require.True(t, evt.IsPartial)
+	require.Nil(t, evt.Error)
+	require.Equal(t, "quoted failure", evt.Choices[0].Delta.Content)
+	require.Nil(t, errorEventFromResponseError("inv-error-nil", "codex", nil, false))
+}
+
 func TestErrorEventFromResponseErrorClonesTerminalError(t *testing.T) {
 	param := "prompt"
 	code := "bad_turn"
@@ -783,6 +923,32 @@ func TestTranscriptHelpers_Fallbacks(t *testing.T) {
 	require.JSONEq(t, `{}`, string(marshalArgs(func() {})))
 	require.Nil(t, (*codexUsage)(nil).toModelUsage())
 	require.Nil(t, (&codexUsage{}).toModelUsage())
+}
+
+func TestTranscriptStream_HandlesEmptyLinesAndNilState(t *testing.T) {
+	require.Empty(t, (*transcriptStream)(nil).Result().Events)
+	require.Nil(t, (*transcriptStream)(nil).HandleRecord(codexEvent{Type: codexEventThreadStarted}))
+	stream := newTranscriptStream("inv-stream-helper", "codex")
+	events, err := stream.HandleLine([]byte(" \n"))
+	require.NoError(t, err)
+	require.Nil(t, events)
+	stream.result = nil
+	require.Empty(t, stream.Result().Events)
+}
+
+func TestCodexStreamEmitter_HandlesEmptyLinesAndNilState(t *testing.T) {
+	ctx := context.Background()
+	inv := newTestInvocation("inv-emitter-helper", session.NewSession("app", "user", "sess-emitter-helper"), "Hi.")
+	out := make(chan *event.Event, 1)
+	rawAgent, err := New()
+	require.NoError(t, err)
+	ag, ok := rawAgent.(*codexAgent)
+	require.True(t, ok)
+	emitter := newCodexStreamEmitter(ctx, ag, inv, out)
+	require.NoError(t, emitter.HandleLine([]byte("\n")))
+	require.False(t, emitter.emitted)
+	require.Empty(t, emitter.Result().Events)
+	require.Empty(t, (*codexStreamEmitter)(nil).Result().Events)
 }
 
 func TestParseTranscriptEvents_EmptyAndInvalidOutput(t *testing.T) {

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -144,9 +144,9 @@ func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
 	require.Equal(t, `{"command":"/usr/bin/bash -lc 'printf hi'"}`, string(events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
 	require.Equal(t, "hi", events[1].Choices[0].Message.Content)
 	require.Equal(t, "done", events[2].Choices[0].Delta.Content)
-	require.Equal(t, "item_1", events[2].Response.ID)
+	require.Equal(t, "inv-1:item_1", events[2].Response.ID)
 	require.Equal(t, "done", events[3].Choices[0].Message.Content)
-	require.Equal(t, "item_1", events[3].Response.ID)
+	require.Equal(t, "inv-1:item_1", events[3].Response.ID)
 	require.Equal(t, 10, events[3].Usage.PromptTokens)
 	require.Equal(t, 3, events[3].Usage.CompletionTokens)
 	require.Equal(t, 13, events[3].Usage.TotalTokens)
@@ -252,7 +252,7 @@ func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
 	require.False(t, first.IsFinalResponse())
 	require.True(t, first.IsPartial)
 	require.Equal(t, model.ObjectTypeChatCompletionChunk, first.Object)
-	require.Equal(t, "item_0", first.Response.ID)
+	require.Equal(t, "inv-stream-2:item_0", first.Response.ID)
 	require.Equal(t, "good luck", first.Choices[0].Delta.Content)
 	select {
 	case <-returned:
@@ -267,10 +267,10 @@ func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
 	require.False(t, events[3].IsFinalResponse())
 	require.True(t, events[3].IsPartial)
 	require.Equal(t, "practice makes perfect", events[3].Choices[0].Delta.Content)
-	require.Equal(t, "item_2", events[3].Response.ID)
+	require.Equal(t, "inv-stream-2:item_2", events[3].Response.ID)
 	require.True(t, events[4].IsFinalResponse())
 	require.Equal(t, "practice makes perfect", events[4].Choices[0].Message.Content)
-	require.Equal(t, "item_2", events[4].Response.ID)
+	require.Equal(t, "inv-stream-2:item_2", events[4].Response.ID)
 	require.Equal(t, 7, events[4].Usage.TotalTokens)
 }
 
@@ -768,7 +768,7 @@ func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "thread-parse", result.ThreadID)
 	require.Equal(t, "done", result.FinalMessage)
-	require.Equal(t, "item_1", result.FinalMessageID)
+	require.Equal(t, "inv-parse-1:item_1", result.FinalMessageID)
 	require.Len(t, result.Events, 3)
 	require.True(t, result.Events[0].IsToolCallResponse())
 	require.True(t, result.Events[1].IsToolResultResponse())
@@ -777,6 +777,21 @@ func TestParseTranscriptEvents_CompletedToolWithoutStarted(t *testing.T) {
 	require.Equal(t, "/tmp\n", result.Events[1].Choices[0].Message.Content)
 	require.True(t, result.Events[2].IsPartial)
 	require.Equal(t, "done", result.Events[2].Choices[0].Delta.Content)
+}
+
+func TestParseTranscriptEvents_ScopesAssistantResponseIDsByInvocation(t *testing.T) {
+	transcript := `{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}`
+	first, err := parseTranscriptEvents([]byte(transcript), "inv-scope-1", "codex")
+	require.NoError(t, err)
+	second, err := parseTranscriptEvents([]byte(transcript), "inv-scope-2", "codex")
+	require.NoError(t, err)
+	require.Len(t, first.Events, 1)
+	require.Len(t, second.Events, 1)
+	require.Equal(t, "inv-scope-1:item_1", first.FinalMessageID)
+	require.Equal(t, "inv-scope-1:item_1", first.Events[0].Response.ID)
+	require.Equal(t, "inv-scope-2:item_1", second.FinalMessageID)
+	require.Equal(t, "inv-scope-2:item_1", second.Events[0].Response.ID)
+	require.NotEqual(t, first.FinalMessageID, second.FinalMessageID)
 }
 
 func TestParseTranscriptEvents_MCPToolCallMapping(t *testing.T) {
@@ -847,11 +862,13 @@ func TestParseTranscriptEvents_ErrorEventMapping(t *testing.T) {
 	require.True(t, result.Events[0].IsPartial)
 	require.Nil(t, result.Events[0].Error)
 	require.False(t, result.Events[0].IsTerminalError())
+	require.Equal(t, "inv-parse-error-1:codex-error-observation", result.Events[0].Response.ID)
 	require.Equal(t, "turn failed", result.Events[0].Choices[0].Delta.Content)
 	require.False(t, result.Events[1].Done)
 	require.True(t, result.Events[1].IsPartial)
 	require.Nil(t, result.Events[1].Error)
 	require.False(t, result.Events[1].IsTerminalError())
+	require.Equal(t, "inv-parse-error-1:codex-error-observation", result.Events[1].Response.ID)
 	require.Equal(t, "top-level error", result.Events[1].Choices[0].Delta.Content)
 	require.Equal(t, "top-level error", result.Error.Message)
 }
@@ -879,6 +896,7 @@ func TestErrorEventFromRecord(t *testing.T) {
 	require.False(t, evt.Done)
 	require.True(t, evt.IsPartial)
 	require.Nil(t, evt.Error)
+	require.Equal(t, "inv-error-record:codex-error-observation", evt.Response.ID)
 	require.Equal(t, "quoted failure", evt.Choices[0].Delta.Content)
 	require.Nil(t, errorEventFromResponseError("inv-error-nil", "codex", nil, false))
 }

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -25,7 +25,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	sessioninmemory "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
 // scriptedRunner is a deterministic commandRunner used for unit tests.
@@ -133,26 +135,30 @@ func TestCodexAgent_Run_CreateParsesEventsAndStoresThread(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 4)
+	require.Len(t, events, 5)
 	require.True(t, events[0].IsToolCallResponse())
-	require.True(t, events[1].IsToolResultResponse())
-	require.False(t, events[2].IsFinalResponse())
-	require.True(t, events[2].IsPartial)
-	require.Equal(t, model.ObjectTypeChatCompletionChunk, events[2].Object)
-	require.True(t, events[3].IsFinalResponse())
+	require.True(t, events[0].IsPartial)
+	require.True(t, events[1].IsToolCallResponse())
+	require.False(t, events[1].IsPartial)
+	require.True(t, events[2].IsToolResultResponse())
+	require.False(t, events[3].IsFinalResponse())
+	require.True(t, events[3].IsPartial)
+	require.Equal(t, model.ObjectTypeChatCompletionChunk, events[3].Object)
+	require.True(t, events[4].IsFinalResponse())
 	require.Equal(t, "command_execution", events[0].Choices[0].Message.ToolCalls[0].Function.Name)
 	require.Equal(t, `{"command":"/usr/bin/bash -lc 'printf hi'"}`, string(events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.Equal(t, "hi", events[1].Choices[0].Message.Content)
-	require.Equal(t, "done", events[2].Choices[0].Delta.Content)
-	require.Equal(t, "inv-1:item_1", events[2].Response.ID)
-	require.Equal(t, "done", events[3].Choices[0].Message.Content)
+	require.Equal(t, `{"command":"/usr/bin/bash -lc 'printf hi'"}`, string(events[1].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.Equal(t, "hi", events[2].Choices[0].Message.Content)
+	require.Equal(t, "done", events[3].Choices[0].Delta.Content)
 	require.Equal(t, "inv-1:item_1", events[3].Response.ID)
-	require.Equal(t, 10, events[3].Usage.PromptTokens)
-	require.Equal(t, 3, events[3].Usage.CompletionTokens)
-	require.Equal(t, 13, events[3].Usage.TotalTokens)
-	require.Equal(t, 2, events[3].Usage.PromptTokensDetails.CachedTokens)
-	require.Equal(t, 1, events[3].Usage.CompletionTokensDetails.ReasoningTokens)
-	require.Equal(t, []byte("thread-1"), events[3].StateDelta[StateKeyThreadID])
+	require.Equal(t, "done", events[4].Choices[0].Message.Content)
+	require.Equal(t, "inv-1:item_1", events[4].Response.ID)
+	require.Equal(t, 10, events[4].Usage.PromptTokens)
+	require.Equal(t, 3, events[4].Usage.CompletionTokens)
+	require.Equal(t, 13, events[4].Usage.TotalTokens)
+	require.Equal(t, 2, events[4].Usage.PromptTokensDetails.CachedTokens)
+	require.Equal(t, 1, events[4].Usage.CompletionTokensDetails.ReasoningTokens)
+	require.Equal(t, []byte("thread-1"), events[4].StateDelta[StateKeyThreadID])
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, "codex", calls[0].bin)
@@ -195,6 +201,7 @@ func TestCodexAgent_Run_StreamsToolEventBeforeCommandReturns(t *testing.T) {
 		require.FailNow(t, "timed out waiting for streamed tool event")
 	}
 	require.True(t, first.IsToolCallResponse())
+	require.True(t, first.IsPartial)
 	require.Equal(t, "sleep 1", commandArg(t, first))
 	select {
 	case <-returned:
@@ -203,15 +210,17 @@ func TestCodexAgent_Run_StreamsToolEventBeforeCommandReturns(t *testing.T) {
 	}
 	close(release)
 	events := append([]*event.Event{first}, drainEvents(ch)...)
-	require.Len(t, events, 4)
-	require.True(t, events[1].IsToolResultResponse())
-	require.Equal(t, "done", events[1].Choices[0].Message.Content)
-	require.False(t, events[2].IsFinalResponse())
-	require.True(t, events[2].IsPartial)
-	require.Equal(t, "finished", events[2].Choices[0].Delta.Content)
-	require.True(t, events[3].IsFinalResponse())
-	require.Equal(t, "finished", events[3].Choices[0].Message.Content)
-	require.Equal(t, 3, events[3].Usage.TotalTokens)
+	require.Len(t, events, 5)
+	require.True(t, events[1].IsToolCallResponse())
+	require.False(t, events[1].IsPartial)
+	require.True(t, events[2].IsToolResultResponse())
+	require.Equal(t, "done", events[2].Choices[0].Message.Content)
+	require.False(t, events[3].IsFinalResponse())
+	require.True(t, events[3].IsPartial)
+	require.Equal(t, "finished", events[3].Choices[0].Delta.Content)
+	require.True(t, events[4].IsFinalResponse())
+	require.Equal(t, "finished", events[4].Choices[0].Message.Content)
+	require.Equal(t, 3, events[4].Usage.TotalTokens)
 }
 
 func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
@@ -261,17 +270,20 @@ func TestCodexAgent_Run_StreamsAssistantMessagesAroundToolEvents(t *testing.T) {
 	}
 	close(release)
 	events := append([]*event.Event{first}, drainEvents(ch)...)
-	require.Len(t, events, 5)
+	require.Len(t, events, 6)
 	require.True(t, events[1].IsToolCallResponse())
-	require.True(t, events[2].IsToolResultResponse())
-	require.False(t, events[3].IsFinalResponse())
-	require.True(t, events[3].IsPartial)
-	require.Equal(t, "practice makes perfect", events[3].Choices[0].Delta.Content)
-	require.Equal(t, "inv-stream-2:item_2", events[3].Response.ID)
-	require.True(t, events[4].IsFinalResponse())
-	require.Equal(t, "practice makes perfect", events[4].Choices[0].Message.Content)
+	require.True(t, events[1].IsPartial)
+	require.True(t, events[2].IsToolCallResponse())
+	require.False(t, events[2].IsPartial)
+	require.True(t, events[3].IsToolResultResponse())
+	require.False(t, events[4].IsFinalResponse())
+	require.True(t, events[4].IsPartial)
+	require.Equal(t, "practice makes perfect", events[4].Choices[0].Delta.Content)
 	require.Equal(t, "inv-stream-2:item_2", events[4].Response.ID)
-	require.Equal(t, 7, events[4].Usage.TotalTokens)
+	require.True(t, events[5].IsFinalResponse())
+	require.Equal(t, "practice makes perfect", events[5].Choices[0].Message.Content)
+	require.Equal(t, "inv-stream-2:item_2", events[5].Response.ID)
+	require.Equal(t, 7, events[5].Usage.TotalTokens)
 }
 
 func TestCodexAgent_Run_StreamsErrorsAsNonTerminalUntilCommandFinishes(t *testing.T) {
@@ -452,6 +464,7 @@ func TestCodexAgent_Run_ResumeFailureAfterStreamedEventDoesNotFallback(t *testin
 	events := drainEvents(ch)
 	require.Len(t, events, 2)
 	require.True(t, events[0].IsToolCallResponse())
+	require.True(t, events[0].IsPartial)
 	require.True(t, events[1].IsTerminalError())
 	require.Equal(t, model.ErrorTypeRunError, events[1].Error.Type)
 	require.Contains(t, events[1].Error.Message, "resume crashed")
@@ -459,6 +472,43 @@ func TestCodexAgent_Run_ResumeFailureAfterStreamedEventDoesNotFallback(t *testin
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Equal(t, []string{"exec", "resume", "--json", "thread-1"}, calls[0].args)
+}
+
+func TestCodexAgent_Run_ToolStartedFailureDoesNotPersistOrphanToolCall(t *testing.T) {
+	ctx := context.Background()
+	transcript := `{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"sleep 1","status":"in_progress"}}`
+	cmdErr := errors.New("codex failed")
+	cmdRunner := &scriptedRunner{
+		run: func(command) ([]byte, []byte, error) {
+			return []byte(transcript), []byte("failed"), cmdErr
+		},
+	}
+	ag, err := New(withCommandRunner(cmdRunner))
+	require.NoError(t, err)
+	sessionService := sessioninmemory.NewSessionService()
+	r := trunner.NewRunner("app", ag, trunner.WithSessionService(sessionService))
+	t.Cleanup(func() {
+		require.NoError(t, r.Close())
+	})
+	eventCh, err := r.Run(ctx, "user", "sess-orphan-tool", model.NewUserMessage("Run slow command."))
+	require.NoError(t, err)
+	var sawPartialToolCall bool
+	for evt := range eventCh {
+		if evt != nil && evt.IsToolCallResponse() {
+			sawPartialToolCall = true
+			require.True(t, evt.IsPartial)
+		}
+	}
+	require.True(t, sawPartialToolCall)
+	sess, err := sessionService.GetSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "sess-orphan-tool",
+	})
+	require.NoError(t, err)
+	for _, evt := range sess.Events {
+		require.False(t, evt.IsToolCallResponse())
+	}
 }
 
 func TestCodexAgent_Run_ResumeAndCreateErrorsReturnRunError(t *testing.T) {
@@ -586,19 +636,22 @@ func TestCodexAgent_Run_RawOutputHookError(t *testing.T) {
 	ch, err := ag.Run(ctx, inv)
 	require.NoError(t, err)
 	events := drainEvents(ch)
-	require.Len(t, events, 4)
+	require.Len(t, events, 5)
 	require.True(t, events[0].IsToolCallResponse())
-	require.True(t, events[1].IsToolResultResponse())
-	require.True(t, events[2].IsPartial)
-	require.Equal(t, "hello", events[2].Choices[0].Delta.Content)
-	require.True(t, events[3].IsFinalResponse())
-	require.Equal(t, model.ObjectTypeError, events[3].Object)
-	require.NotNil(t, events[3].Error)
-	require.Equal(t, model.ErrorTypeFlowError, events[3].Error.Type)
-	require.Contains(t, events[3].Error.Message, "raw output hook")
-	require.Contains(t, events[3].Error.Message, "hook failed")
-	require.Contains(t, events[3].Choices[0].Message.Content, "thread-hook-2")
-	require.Contains(t, events[3].Choices[0].Message.Content, "warn")
+	require.True(t, events[0].IsPartial)
+	require.True(t, events[1].IsToolCallResponse())
+	require.False(t, events[1].IsPartial)
+	require.True(t, events[2].IsToolResultResponse())
+	require.True(t, events[3].IsPartial)
+	require.Equal(t, "hello", events[3].Choices[0].Delta.Content)
+	require.True(t, events[4].IsFinalResponse())
+	require.Equal(t, model.ObjectTypeError, events[4].Object)
+	require.NotNil(t, events[4].Error)
+	require.Equal(t, model.ErrorTypeFlowError, events[4].Error.Type)
+	require.Contains(t, events[4].Error.Message, "raw output hook")
+	require.Contains(t, events[4].Error.Message, "hook failed")
+	require.Contains(t, events[4].Choices[0].Message.Content, "thread-hook-2")
+	require.Contains(t, events[4].Choices[0].Message.Content, "warn")
 }
 
 func TestCodexAgent_InfoAndRunnerArgs(t *testing.T) {
@@ -800,11 +853,15 @@ func TestParseTranscriptEvents_MCPToolCallMapping(t *testing.T) {
 {"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}`
 	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-2", "codex")
 	require.NoError(t, err)
-	require.Len(t, result.Events, 2)
+	require.Len(t, result.Events, 3)
 	require.Equal(t, "mcp__calc__add", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
-	require.Equal(t, "mcp__calc__add", result.Events[1].Choices[0].Message.ToolName)
+	require.True(t, result.Events[0].IsPartial)
+	require.Equal(t, "mcp__calc__add", result.Events[1].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.False(t, result.Events[1].IsPartial)
+	require.Equal(t, "mcp__calc__add", result.Events[2].Choices[0].Message.ToolName)
 	require.JSONEq(t, `{"a":1,"b":2}`, string(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.Equal(t, "3", result.Events[1].Choices[0].Message.Content)
+	require.JSONEq(t, `{"a":1,"b":2}`, string(result.Events[1].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.Equal(t, "3", result.Events[2].Choices[0].Message.Content)
 	require.Equal(t, 9, result.Usage.TotalTokens)
 }
 
@@ -819,19 +876,23 @@ func TestParseTranscriptEvents_BuiltInToolMapping(t *testing.T) {
 {"type":"item.completed","item":{"id":"item_image","type":"image_generation","saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}}`
 	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-builtins-1", "codex")
 	require.NoError(t, err)
-	require.Len(t, result.Events, 8)
+	require.Len(t, result.Events, 12)
 	require.Equal(t, "web_search", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
 	require.JSONEq(t, `{"query":"trpc agent"}`, string(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.JSONEq(t, `[{"title":"doc"}]`, result.Events[1].Choices[0].Message.Content)
-	require.Equal(t, "file_change", result.Events[2].Choices[0].Message.ToolCalls[0].Function.Name)
-	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, string(result.Events[2].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, result.Events[3].Choices[0].Message.Content)
-	require.Equal(t, "image_view", result.Events[4].Choices[0].Message.ToolCalls[0].Function.Name)
-	require.JSONEq(t, `{"path":"/tmp/input.png"}`, string(result.Events[4].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.JSONEq(t, `{"width":64,"height":32}`, result.Events[5].Choices[0].Message.Content)
-	require.Equal(t, "image_generation", result.Events[6].Choices[0].Message.ToolCalls[0].Function.Name)
-	require.JSONEq(t, `{"prompt":"draw icon"}`, string(result.Events[6].Choices[0].Message.ToolCalls[0].Function.Arguments))
-	require.JSONEq(t, `{"saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}`, result.Events[7].Choices[0].Message.Content)
+	require.True(t, result.Events[0].IsPartial)
+	require.Equal(t, "web_search", result.Events[1].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.False(t, result.Events[1].IsPartial)
+	require.JSONEq(t, `[{"title":"doc"}]`, result.Events[2].Choices[0].Message.Content)
+	require.Equal(t, "file_change", result.Events[3].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, string(result.Events[3].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.Equal(t, "file_change", result.Events[4].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"path":"main.go","kind":"update"}`, result.Events[5].Choices[0].Message.Content)
+	require.Equal(t, "image_view", result.Events[6].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"path":"/tmp/input.png"}`, string(result.Events[6].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `{"width":64,"height":32}`, result.Events[8].Choices[0].Message.Content)
+	require.Equal(t, "image_generation", result.Events[9].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"prompt":"draw icon"}`, string(result.Events[9].Choices[0].Message.ToolCalls[0].Function.Arguments))
+	require.JSONEq(t, `{"saved_path":"/tmp/icon.png","revised_prompt":"draw a clean icon","status":"completed"}`, result.Events[11].Choices[0].Message.Content)
 }
 
 func TestParseTranscriptEvents_SkillToolMapping(t *testing.T) {
@@ -839,16 +900,20 @@ func TestParseTranscriptEvents_SkillToolMapping(t *testing.T) {
 {"type":"item.completed","item":{"id":"item_skill","type":"skill","skill":"debug","result":"ok","status":"completed"}}`
 	result, err := parseTranscriptEvents([]byte(transcript), "inv-parse-skill-1", "codex")
 	require.NoError(t, err)
-	require.Len(t, result.Events, 2)
+	require.Len(t, result.Events, 3)
 	require.True(t, result.Events[0].IsToolCallResponse())
-	require.True(t, result.Events[1].IsToolResultResponse())
+	require.True(t, result.Events[0].IsPartial)
+	require.True(t, result.Events[1].IsToolCallResponse())
+	require.False(t, result.Events[1].IsPartial)
+	require.True(t, result.Events[2].IsToolResultResponse())
 	require.Equal(t, "skill_run", result.Events[0].Choices[0].Message.ToolCalls[0].Function.Name)
-	require.Equal(t, "skill_run", result.Events[1].Choices[0].Message.ToolName)
+	require.Equal(t, "skill_run", result.Events[1].Choices[0].Message.ToolCalls[0].Function.Name)
+	require.Equal(t, "skill_run", result.Events[2].Choices[0].Message.ToolName)
 	var directArgs skillRunArgs
 	require.NoError(t, json.Unmarshal(result.Events[0].Choices[0].Message.ToolCalls[0].Function.Arguments, &directArgs))
 	require.Equal(t, "debug", directArgs.Skill)
 	require.Equal(t, "", directArgs.Command)
-	require.Equal(t, "ok", result.Events[1].Choices[0].Message.Content)
+	require.Equal(t, "ok", result.Events[2].Choices[0].Message.Content)
 }
 
 func TestParseTranscriptEvents_ErrorEventMapping(t *testing.T) {

--- a/agent/codex/command.go
+++ b/agent/codex/command.go
@@ -11,8 +11,11 @@
 package codex
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -31,17 +34,37 @@ type command struct {
 	dir string
 }
 
+// commandOutputHandler observes one stdout JSONL line as soon as it is available.
+type commandOutputHandler func(line []byte) error
+
+// commandResult contains captured process output and execution errors.
+type commandResult struct {
+	// Stdout is the complete stdout captured from the process.
+	stdout []byte
+	// Stderr is the complete stderr captured from the process.
+	stderr []byte
+	// RunErr is the process execution error.
+	runErr error
+	// OutputErr is the stdout observer error.
+	outputErr error
+}
+
+// err returns all errors associated with the command execution.
+func (r commandResult) err() error {
+	return errors.Join(r.outputErr, r.runErr)
+}
+
 // commandRunner executes external commands and captures stdout/stderr output.
 type commandRunner interface {
-	// Run executes cmd and returns captured stdout, stderr, and the process error.
-	Run(ctx context.Context, cmd command) ([]byte, []byte, error)
+	// Run executes cmd and optionally streams stdout JSONL lines to onStdoutLine.
+	Run(ctx context.Context, cmd command, onStdoutLine commandOutputHandler) commandResult
 }
 
 // execCommandRunner executes commands via os/exec.
 type execCommandRunner struct{}
 
 // Run executes cmd with exec.CommandContext and captures stdout/stderr.
-func (execCommandRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, error) {
+func (execCommandRunner) Run(ctx context.Context, cmd command, onStdoutLine commandOutputHandler) commandResult {
 	// nosemgrep: go.lang.security.audit.dangerous-exec-command
 	// This agent intentionally executes a locally installed Codex CLI binary.
 	c := exec.CommandContext(ctx, cmd.bin, cmd.args...) //nolint:gosec // The executable path is provided via agent options.
@@ -56,8 +79,56 @@ func (execCommandRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, 
 	if len(cmd.stdin) > 0 {
 		c.Stdin = bytes.NewReader(cmd.stdin)
 	}
-	c.Stdout = &stdout
 	c.Stderr = &stderr
-	runErr := c.Run()
-	return stdout.Bytes(), stderr.Bytes(), runErr
+	if onStdoutLine == nil {
+		c.Stdout = &stdout
+		runErr := c.Run()
+		return commandResult{
+			stdout: stdout.Bytes(),
+			stderr: stderr.Bytes(),
+			runErr: runErr,
+		}
+	}
+	stdoutPipe, err := c.StdoutPipe()
+	if err != nil {
+		return commandResult{runErr: err}
+	}
+	if err := c.Start(); err != nil {
+		return commandResult{runErr: err}
+	}
+	outputErr := readStdoutLines(stdoutPipe, &stdout, onStdoutLine)
+	if outputErr != nil && c.Process != nil {
+		_ = c.Process.Kill()
+	}
+	runErr := c.Wait()
+	return commandResult{
+		stdout:    stdout.Bytes(),
+		stderr:    stderr.Bytes(),
+		runErr:    runErr,
+		outputErr: outputErr,
+	}
+}
+
+// readStdoutLines captures stdout and forwards each complete JSONL record.
+func readStdoutLines(r io.Reader, capture *bytes.Buffer, onLine commandOutputHandler) error {
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, writeErr := capture.Write(line); writeErr != nil {
+				return writeErr
+			}
+			if onLine != nil {
+				if handleErr := onLine(line); handleErr != nil {
+					return handleErr
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
 }

--- a/agent/codex/options.go
+++ b/agent/codex/options.go
@@ -54,9 +54,9 @@ type RawOutputHookArgs struct {
 	Error error
 }
 
-// RawOutputHook is invoked after the CLI command completes and before transcript parsing.
+// RawOutputHook is invoked after the CLI command completes and after streamed transcript events are emitted.
 //
-// If the hook returns an error, the agent emits a final error event and stops processing the invocation.
+// If the hook returns an error, the agent emits a trailing error event and skips the final assistant response.
 type RawOutputHook func(ctx context.Context, args *RawOutputHookArgs) error
 
 // WithName sets the agent name.

--- a/agent/codex/options.go
+++ b/agent/codex/options.go
@@ -120,7 +120,7 @@ func withCommandRunner(runner commandRunner) Option {
 func newOptions(opt ...Option) (*options, error) {
 	opts := &options{
 		name:          "codex-cli",
-		description:   "Invokes a locally installed Codex CLI and emits tool events from its JSONL output.",
+		description:   "Invokes a locally installed Codex CLI and emits assistant and tool events from its JSONL output.",
 		bin:           "codex",
 		commandRunner: execCommandRunner{},
 	}

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -168,7 +168,7 @@ func (s *transcriptStream) HandleRecord(rec codexEvent) []*event.Event {
 		s.result.Events = append(s.result.Events, events...)
 		return events
 	case codexEventTurnFailed, codexEventError:
-		evt := errorEventFromRecord(s.invocationID, s.author, rec)
+		evt := errorEventFromRecord(s.invocationID, s.author, rec, false)
 		s.result.Error = evt.Response.Error
 		s.result.Events = append(s.result.Events, evt)
 		return []*event.Event{evt}
@@ -271,36 +271,67 @@ func completedEventsFromItem(invocationID, author string, item *codexItem, toolN
 }
 
 // errorEventFromRecord creates a framework error event from a Codex failure record.
-func errorEventFromRecord(invocationID, author string, rec codexEvent) *event.Event {
-	responseErr := responseErrorFromRecord(rec)
-	rsp := &model.Response{
-		Object: model.ObjectTypeError,
-		Done:   true,
-		Choices: []model.Choice{
-			{
-				Index: 0,
-				Message: model.Message{
-					Role:    model.RoleAssistant,
-					Content: responseErr.Message,
-				},
-			},
+func errorEventFromRecord(invocationID, author string, rec codexEvent, terminal bool) *event.Event {
+	return errorEventFromResponseError(invocationID, author, responseErrorFromRecord(rec), terminal)
+}
+
+// errorEventFromResponseError creates a framework error event from parsed error details.
+func errorEventFromResponseError(invocationID, author string, responseErr *model.ResponseError, terminal bool) *event.Event {
+	if responseErr == nil {
+		return nil
+	}
+	object := model.ObjectTypeChatCompletionChunk
+	done := false
+	partial := true
+	choice := model.Choice{
+		Index: 0,
+		Delta: model.Message{
+			Role:    model.RoleAssistant,
+			Content: responseErr.Message,
 		},
-		Error: responseErr,
+	}
+	if terminal {
+		object = model.ObjectTypeError
+		done = true
+		partial = false
+		choice = model.Choice{
+			Index: 0,
+			Message: model.Message{
+				Role:    model.RoleAssistant,
+				Content: responseErr.Message,
+			},
+		}
+	}
+	rsp := &model.Response{
+		Object:    object,
+		Done:      done,
+		IsPartial: partial,
+		Choices:   []model.Choice{choice},
+		Error:     responseErr,
 	}
 	return event.NewResponseEvent(invocationID, author, rsp)
 }
 
-// newAssistantMessageEvent creates a non-terminal response for one complete Codex assistant item.
+// newAssistantMessageEvent creates a partial response segment for one complete Codex assistant item.
 func newAssistantMessageEvent(invocationID, author, responseID, text string) *event.Event {
 	content := strings.TrimSpace(text)
 	if content == "" {
 		return nil
 	}
 	rsp := &model.Response{
-		ID:      strings.TrimSpace(responseID),
-		Object:  model.ObjectTypeChatCompletion,
-		Done:    false,
-		Choices: []model.Choice{{Index: 0, Message: model.Message{Role: model.RoleAssistant, Content: content}}},
+		ID:        strings.TrimSpace(responseID),
+		Object:    model.ObjectTypeChatCompletionChunk,
+		Done:      false,
+		IsPartial: true,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: content,
+				},
+			},
+		},
 	}
 	return event.NewResponseEvent(invocationID, author, rsp)
 }

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -168,8 +168,9 @@ func (s *transcriptStream) HandleRecord(rec codexEvent) []*event.Event {
 		s.result.Events = append(s.result.Events, events...)
 		return events
 	case codexEventTurnFailed, codexEventError:
-		evt := errorEventFromRecord(s.invocationID, s.author, rec, false)
-		s.result.Error = evt.Response.Error
+		responseErr := responseErrorFromRecord(rec)
+		evt := errorEventFromResponseError(s.invocationID, s.author, responseErr, false)
+		s.result.Error = cloneCodexResponseError(responseErr)
 		s.result.Events = append(s.result.Events, evt)
 		return []*event.Event{evt}
 	}
@@ -290,10 +291,12 @@ func errorEventFromResponseError(invocationID, author string, responseErr *model
 			Content: responseErr.Message,
 		},
 	}
+	var eventErr *model.ResponseError
 	if terminal {
 		object = model.ObjectTypeError
 		done = true
 		partial = false
+		eventErr = cloneCodexResponseError(responseErr)
 		choice = model.Choice{
 			Index: 0,
 			Message: model.Message{
@@ -307,7 +310,7 @@ func errorEventFromResponseError(invocationID, author string, responseErr *model
 		Done:      done,
 		IsPartial: partial,
 		Choices:   []model.Choice{choice},
-		Error:     responseErr,
+		Error:     eventErr,
 	}
 	return event.NewResponseEvent(invocationID, author, rsp)
 }
@@ -367,6 +370,23 @@ func responseErrorFromRecord(rec codexEvent) *model.ResponseError {
 		rspErr.Code = &code
 	}
 	return rspErr
+}
+
+// cloneCodexResponseError returns an owned copy of a Codex response error.
+func cloneCodexResponseError(responseErr *model.ResponseError) *model.ResponseError {
+	if responseErr == nil {
+		return nil
+	}
+	cloned := *responseErr
+	if responseErr.Param != nil {
+		param := *responseErr.Param
+		cloned.Param = &param
+	}
+	if responseErr.Code != nil {
+		code := *responseErr.Code
+		cloned.Code = &code
+	}
+	return &cloned
 }
 
 // decodeErrorPayload decodes a Codex error payload into message, type, and code.

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -100,11 +100,12 @@ type codexError struct {
 
 // transcriptResult is the framework event projection of one Codex JSONL transcript.
 type transcriptResult struct {
-	Events       []*event.Event
-	FinalMessage string
-	ThreadID     string
-	Usage        *model.Usage
-	Error        *model.ResponseError
+	Events         []*event.Event
+	FinalMessage   string
+	FinalMessageID string
+	ThreadID       string
+	Usage          *model.Usage
+	Error          *model.ResponseError
 }
 
 // transcriptStream incrementally maps Codex JSONL records to framework events.
@@ -244,7 +245,12 @@ func completedEventsFromItem(invocationID, author string, item *codexItem, toolN
 	}
 	if item.Type == codexItemAgentMessage {
 		result.FinalMessage = item.Text
-		return nil
+		result.FinalMessageID = strings.TrimSpace(item.ID)
+		evt := newAssistantMessageEvent(invocationID, author, result.FinalMessageID, item.Text)
+		if evt == nil {
+			return nil
+		}
+		return []*event.Event{evt}
 	}
 	if !isToolItem(item.Type) || strings.TrimSpace(item.ID) == "" {
 		return nil
@@ -280,6 +286,21 @@ func errorEventFromRecord(invocationID, author string, rec codexEvent) *event.Ev
 			},
 		},
 		Error: responseErr,
+	}
+	return event.NewResponseEvent(invocationID, author, rsp)
+}
+
+// newAssistantMessageEvent creates a non-terminal response for one complete Codex assistant item.
+func newAssistantMessageEvent(invocationID, author, responseID, text string) *event.Event {
+	content := strings.TrimSpace(text)
+	if content == "" {
+		return nil
+	}
+	rsp := &model.Response{
+		ID:      strings.TrimSpace(responseID),
+		Object:  model.ObjectTypeChatCompletion,
+		Done:    false,
+		Choices: []model.Choice{{Index: 0, Message: model.Message{Role: model.RoleAssistant, Content: content}}},
 	}
 	return event.NewResponseEvent(invocationID, author, rsp)
 }

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -25,6 +25,8 @@ const (
 	codexEventItemStarted    = "item.started"
 	codexEventItemCompleted  = "item.completed"
 	codexEventTurnCompleted  = "turn.completed"
+	codexEventTurnFailed     = "turn.failed"
+	codexEventError          = "error"
 	codexItemAgentMessage    = "agent_message"
 	codexItemCommand         = "command_execution"
 	codexItemMCPToolCall     = "mcp_tool_call"
@@ -38,10 +40,13 @@ const (
 
 // codexEvent represents one top-level JSONL event produced by Codex CLI.
 type codexEvent struct {
-	Type     string      `json:"type,omitempty"`
-	ThreadID string      `json:"thread_id,omitempty"`
-	Item     *codexItem  `json:"item,omitempty"`
-	Usage    *codexUsage `json:"usage,omitempty"`
+	Type     string          `json:"type,omitempty"`
+	ThreadID string          `json:"thread_id,omitempty"`
+	Item     *codexItem      `json:"item,omitempty"`
+	Usage    *codexUsage     `json:"usage,omitempty"`
+	Message  string          `json:"message,omitempty"`
+	Code     string          `json:"code,omitempty"`
+	Error    json.RawMessage `json:"error,omitempty"`
 }
 
 // codexItem carries one Codex turn item.
@@ -86,12 +91,88 @@ type codexUsage struct {
 	ReasoningOutputTokens int `json:"reasoning_output_tokens,omitempty"`
 }
 
+// codexError carries error details from Codex JSONL events.
+type codexError struct {
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
 // transcriptResult is the framework event projection of one Codex JSONL transcript.
 type transcriptResult struct {
 	Events       []*event.Event
 	FinalMessage string
 	ThreadID     string
 	Usage        *model.Usage
+	Error        *model.ResponseError
+}
+
+// transcriptStream incrementally maps Codex JSONL records to framework events.
+type transcriptStream struct {
+	invocationID string
+	author       string
+	result       *transcriptResult
+	toolNames    map[string]string
+}
+
+// newTranscriptStream creates an incremental transcript mapper.
+func newTranscriptStream(invocationID, author string) *transcriptStream {
+	return &transcriptStream{
+		invocationID: invocationID,
+		author:       author,
+		result:       &transcriptResult{},
+		toolNames:    make(map[string]string),
+	}
+}
+
+// Result returns the accumulated transcript state.
+func (s *transcriptStream) Result() *transcriptResult {
+	if s == nil || s.result == nil {
+		return &transcriptResult{}
+	}
+	return s.result
+}
+
+// HandleLine processes one Codex JSONL stdout line.
+func (s *transcriptStream) HandleLine(line []byte) ([]*event.Event, error) {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var rec codexEvent
+	if err := json.Unmarshal(trimmed, &rec); err != nil {
+		return nil, err
+	}
+	return s.HandleRecord(rec), nil
+}
+
+// HandleRecord processes one decoded Codex event record.
+func (s *transcriptStream) HandleRecord(rec codexEvent) []*event.Event {
+	if s == nil {
+		return nil
+	}
+	switch rec.Type {
+	case codexEventThreadStarted:
+		s.result.ThreadID = strings.TrimSpace(rec.ThreadID)
+	case codexEventTurnCompleted:
+		s.result.Usage = rec.Usage.toModelUsage()
+	case codexEventItemStarted:
+		evt := toolCallEventFromItem(s.invocationID, s.author, rec.Item, s.toolNames)
+		if evt != nil {
+			s.result.Events = append(s.result.Events, evt)
+			return []*event.Event{evt}
+		}
+	case codexEventItemCompleted:
+		events := completedEventsFromItem(s.invocationID, s.author, rec.Item, s.toolNames, s.result)
+		s.result.Events = append(s.result.Events, events...)
+		return events
+	case codexEventTurnFailed, codexEventError:
+		evt := errorEventFromRecord(s.invocationID, s.author, rec)
+		s.result.Error = evt.Response.Error
+		s.result.Events = append(s.result.Events, evt)
+		return []*event.Event{evt}
+	}
+	return nil
 }
 
 // parseTranscriptEvents parses Codex CLI JSONL events into framework events.
@@ -100,25 +181,11 @@ func parseTranscriptEvents(stdout []byte, invocationID, author string) (*transcr
 	if err != nil {
 		return nil, err
 	}
-	result := &transcriptResult{}
-	toolNames := make(map[string]string)
+	stream := newTranscriptStream(invocationID, author)
 	for _, rec := range records {
-		switch rec.Type {
-		case codexEventThreadStarted:
-			result.ThreadID = strings.TrimSpace(rec.ThreadID)
-		case codexEventTurnCompleted:
-			result.Usage = rec.Usage.toModelUsage()
-		case codexEventItemStarted:
-			evt := toolCallEventFromItem(invocationID, author, rec.Item, toolNames)
-			if evt != nil {
-				result.Events = append(result.Events, evt)
-			}
-		case codexEventItemCompleted:
-			events := completedEventsFromItem(invocationID, author, rec.Item, toolNames, result)
-			result.Events = append(result.Events, events...)
-		}
+		stream.HandleRecord(rec)
 	}
-	return result, nil
+	return stream.Result(), nil
 }
 
 // parseTranscriptRecords decodes Codex JSONL output.
@@ -195,6 +262,78 @@ func completedEventsFromItem(invocationID, author string, item *codexItem, toolN
 	}
 	events = append(events, newToolResultEvent(invocationID, author, toolID, toolName, toolResult(item)))
 	return events
+}
+
+// errorEventFromRecord creates a framework error event from a Codex failure record.
+func errorEventFromRecord(invocationID, author string, rec codexEvent) *event.Event {
+	responseErr := responseErrorFromRecord(rec)
+	rsp := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Choices: []model.Choice{
+			{
+				Index: 0,
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: responseErr.Message,
+				},
+			},
+		},
+		Error: responseErr,
+	}
+	return event.NewResponseEvent(invocationID, author, rsp)
+}
+
+// responseErrorFromRecord extracts error details from a Codex failure record.
+func responseErrorFromRecord(rec codexEvent) *model.ResponseError {
+	msg := strings.TrimSpace(rec.Message)
+	errType := strings.TrimSpace(rec.Type)
+	code := strings.TrimSpace(rec.Code)
+	if len(normalizeJSON(rec.Error)) > 0 {
+		payloadMsg, payloadType, payloadCode := decodeErrorPayload(rec.Error)
+		if strings.TrimSpace(payloadMsg) != "" {
+			msg = payloadMsg
+		}
+		if strings.TrimSpace(payloadType) != "" {
+			errType = payloadType
+		}
+		if strings.TrimSpace(payloadCode) != "" {
+			code = payloadCode
+		}
+	}
+	if msg == "" {
+		msg = strings.TrimSpace(rec.Type)
+	}
+	rspErr := &model.ResponseError{
+		Type:    model.ErrorTypeRunError,
+		Message: msg,
+	}
+	if errType != "" && errType != codexEventTurnFailed && errType != codexEventError {
+		rspErr.Type = errType
+	}
+	if code != "" {
+		rspErr.Code = &code
+	}
+	return rspErr
+}
+
+// decodeErrorPayload decodes a Codex error payload into message, type, and code.
+func decodeErrorPayload(raw json.RawMessage) (string, string, string) {
+	trimmed := normalizeJSON(raw)
+	if len(trimmed) == 0 {
+		return "", "", ""
+	}
+	if trimmed[0] == '"' {
+		var text string
+		if err := json.Unmarshal(trimmed, &text); err == nil {
+			return text, "", ""
+		}
+	}
+	var payload codexError
+	if err := json.Unmarshal(trimmed, &payload); err == nil {
+		return payload.Message, payload.Type, payload.Code
+	}
+	return string(trimmed), "", ""
 }
 
 // isToolItem reports whether a Codex item should be mapped as a framework tool event.

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -36,6 +36,7 @@ const (
 	codexItemImageGeneration = "image_generation"
 	codexItemSkill           = "skill"
 	frameworkToolSkillRun    = "skill_run"
+	codexErrorObservationID  = "codex-error-observation"
 )
 
 // codexEvent represents one top-level JSONL event produced by Codex CLI.
@@ -246,7 +247,7 @@ func completedEventsFromItem(invocationID, author string, item *codexItem, toolN
 	}
 	if item.Type == codexItemAgentMessage {
 		result.FinalMessage = item.Text
-		result.FinalMessageID = strings.TrimSpace(item.ID)
+		result.FinalMessageID = scopedCodexResponseID(invocationID, item.ID)
 		evt := newAssistantMessageEvent(invocationID, author, result.FinalMessageID, item.Text)
 		if evt == nil {
 			return nil
@@ -305,7 +306,12 @@ func errorEventFromResponseError(invocationID, author string, responseErr *model
 			},
 		}
 	}
+	responseID := ""
+	if !terminal {
+		responseID = scopedCodexResponseID(invocationID, codexErrorObservationID)
+	}
 	rsp := &model.Response{
+		ID:        responseID,
 		Object:    object,
 		Done:      done,
 		IsPartial: partial,
@@ -313,6 +319,19 @@ func errorEventFromResponseError(invocationID, author string, responseErr *model
 		Error:     eventErr,
 	}
 	return event.NewResponseEvent(invocationID, author, rsp)
+}
+
+// scopedCodexResponseID qualifies Codex-local item IDs with the framework invocation ID.
+func scopedCodexResponseID(invocationID, itemID string) string {
+	itemID = strings.TrimSpace(itemID)
+	invocationID = strings.TrimSpace(invocationID)
+	if itemID == "" {
+		return ""
+	}
+	if invocationID == "" {
+		return itemID
+	}
+	return invocationID + ":" + itemID
 }
 
 // newAssistantMessageEvent creates a partial response segment for one complete Codex assistant item.

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -237,7 +237,7 @@ func toolCallEventFromItem(invocationID, author string, item *codexItem, toolNam
 		return nil
 	}
 	toolNames[toolID] = toolName
-	return newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item))
+	return newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item), true)
 }
 
 // completedEventsFromItem creates framework events for an item.completed record.
@@ -266,8 +266,8 @@ func completedEventsFromItem(invocationID, author string, item *codexItem, toolN
 			return nil
 		}
 		toolNames[toolID] = toolName
-		events = append(events, newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item)))
 	}
+	events = append(events, newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item), false))
 	events = append(events, newToolResultEvent(invocationID, author, toolID, toolName, toolResult(item)))
 	return events
 }
@@ -692,7 +692,7 @@ func decodeRawJSON(raw json.RawMessage) string {
 }
 
 // newToolCallEvent creates a tool-call event for one Codex item.
-func newToolCallEvent(invocationID, author, toolID, toolName string, args []byte) *event.Event {
+func newToolCallEvent(invocationID, author, toolID, toolName string, args []byte, partial bool) *event.Event {
 	toolCall := model.ToolCall{
 		Type: "function",
 		ID:   toolID,
@@ -702,8 +702,9 @@ func newToolCallEvent(invocationID, author, toolID, toolName string, args []byte
 		},
 	}
 	rsp := &model.Response{
-		Object: model.ObjectTypeChatCompletion,
-		Done:   false,
+		Object:    model.ObjectTypeChatCompletion,
+		Done:      false,
+		IsPartial: partial,
 		Choices: []model.Choice{
 			{
 				Index: 0,

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -77,7 +77,7 @@ If multiple external skill repositories are configured for that Codex CLI enviro
 
 ## Event mapping
 
-The agent emits tool and error events as Codex JSONL records arrive, then emits the final response after the Codex turn completes. It does not emit intermediate reasoning events.
+The agent emits assistant, tool, and error events as Codex JSONL records arrive, then emits a final completion response after the Codex turn completes. Codex `agent_message` items are complete message items rather than token deltas, so they are emitted as non-terminal assistant responses. The final completion response uses the last assistant message content and carries final usage and thread state. It does not emit intermediate reasoning events.
 
 | Codex JSONL output | Framework event |
 | --- | --- |
@@ -86,7 +86,7 @@ The agent emits tool and error events as Codex JSONL records arrive, then emits 
 | `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
 | Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
 | `type == "turn.failed"` or `type == "error"` | error response event |
-| `item.type == "agent_message"` | final response event content |
+| `item.type == "agent_message"` | non-terminal assistant response event; the last item also becomes the final response content |
 | `type == "turn.completed"` | final response usage |
 
 MCP tool calls are normalized to Claude Code-compatible names when possible: `mcp__<server>__<tool>`.

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -85,7 +85,7 @@ The agent emits assistant, tool, and error events as Codex JSONL records arrive,
 | `item.type == "command_execution"` | tool-call and tool-result response events |
 | `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
 | Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
-| `type == "turn.failed"` or `type == "error"` | non-terminal error observation, followed by one terminal error after the command finishes |
+| `type == "turn.failed"` or `type == "error"` | non-terminal error observation chunk without `Response.Error`, followed by one terminal error after the command finishes |
 | `item.type == "agent_message"` | partial assistant chunk event; the last item also becomes the final response content |
 | `type == "turn.completed"` | final response usage |
 
@@ -100,7 +100,7 @@ Codex creates its own thread id. The agent persists that id in session state und
 1. First turn: write the prompt to stdin of `codex exec --json`
 2. Later turns: write the prompt to stdin of `codex exec resume --json <thread-id>`
 
-If resume fails, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If both resume and create fail, the invocation returns a run error.
+If resume fails before any transcript event is emitted, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If resume has already emitted framework events, or if stdout parsing fails, the agent surfaces that failure instead of starting a fresh run to avoid duplicating visible progress or tool side effects. If both resume and create fail, the invocation returns a run error.
 
 To keep context, use the same app name, user ID, and session ID in `runner`.
 

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -77,7 +77,7 @@ If multiple external skill repositories are configured for that Codex CLI enviro
 
 ## Event mapping
 
-The agent emits assistant, tool, and error events as Codex JSONL records arrive, then emits a final completion response after the Codex turn completes. Codex `agent_message` items are complete message items rather than token deltas, so they are emitted as non-terminal assistant responses. The final completion response uses the last assistant message content and carries final usage and thread state. It does not emit intermediate reasoning events.
+The agent emits assistant, tool, and error events as Codex JSONL records arrive, then emits a final completion response after the Codex turn completes. Codex `agent_message` items are complete message items rather than token deltas, but the agent exposes them as partial `chat.completion.chunk` segments so session persistence stores only the final assistant response. The final completion response uses the last assistant message content and carries final usage and thread state. It does not emit intermediate reasoning events.
 
 | Codex JSONL output | Framework event |
 | --- | --- |
@@ -85,8 +85,8 @@ The agent emits assistant, tool, and error events as Codex JSONL records arrive,
 | `item.type == "command_execution"` | tool-call and tool-result response events |
 | `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
 | Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
-| `type == "turn.failed"` or `type == "error"` | error response event |
-| `item.type == "agent_message"` | non-terminal assistant response event; the last item also becomes the final response content |
+| `type == "turn.failed"` or `type == "error"` | non-terminal error observation, followed by one terminal error after the command finishes |
+| `item.type == "agent_message"` | partial assistant chunk event; the last item also becomes the final response content |
 | `type == "turn.completed"` | final response usage |
 
 MCP tool calls are normalized to Claude Code-compatible names when possible: `mcp__<server>__<tool>`.

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-tRPC-Agent-Go provides a `Codex` `Agent` implementation. It executes a local Codex CLI with `codex exec --json`, parses the JSONL event stream, and maps Codex activity into framework events.
+tRPC-Agent-Go provides a `Codex` `Agent` implementation. It executes a local Codex CLI with `codex exec --json`, parses the JSONL event stream, and maps Codex activity into framework events as the stream arrives.
 
 The primary use cases include:
 
@@ -77,7 +77,7 @@ If multiple external skill repositories are configured for that Codex CLI enviro
 
 ## Event mapping
 
-The agent emits tool events and one final response event. It does not emit intermediate reasoning events.
+The agent emits tool and error events as Codex JSONL records arrive, then emits the final response after the Codex turn completes. It does not emit intermediate reasoning events.
 
 | Codex JSONL output | Framework event |
 | --- | --- |
@@ -85,6 +85,7 @@ The agent emits tool events and one final response event. It does not emit inter
 | `item.type == "command_execution"` | tool-call and tool-result response events |
 | `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
 | Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
+| `type == "turn.failed"` or `type == "error"` | error response event |
 | `item.type == "agent_message"` | final response event content |
 | `type == "turn.completed"` | final response usage |
 
@@ -128,4 +129,4 @@ ag, err := codex.New(
 | `WithExtraArgs(args...)` | Appends `codex exec` flags before the optional resume session id. |
 | `WithEnv(env...)` | Adds CLI environment variables. Use `KEY=VALUE`. |
 | `WithWorkDir(dir)` | Sets the CLI process working directory. |
-| `WithRawOutputHook(hook)` | Observes raw stdout and stderr. The hook runs after the CLI finishes and before parsing. |
+| `WithRawOutputHook(hook)` | Observes raw stdout and stderr. The hook runs after the CLI finishes and after streamed transcript events are emitted; returning an error appends an error event and skips the final assistant response. |

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -86,7 +86,7 @@ The agent emits assistant, tool, and error events as Codex JSONL records arrive,
 | `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
 | Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
 | `type == "turn.failed"` or `type == "error"` | non-terminal error observation chunk without `Response.Error`, followed by one terminal error after the command finishes |
-| `item.type == "agent_message"` | partial assistant chunk event; the last item also becomes the final response content |
+| `item.type == "agent_message"` | partial assistant chunk event; the last `agent_message` item also becomes the final response content |
 | `type == "turn.completed"` | final response usage |
 
 MCP tool calls are normalized to Claude Code-compatible names when possible: `mcp__<server>__<tool>`.

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -85,7 +85,7 @@ ag, err := codex.New(
 | `item.type == "command_execution"` | tool-call 与 tool-result response 事件 |
 | `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
 | `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
-| `type == "turn.failed"` 或 `type == "error"` | 非终止 error observation；命令结束后再发出一个终止 error |
+| `type == "turn.failed"` 或 `type == "error"` | 不携带 `Response.Error` 的非终止 error observation chunk；命令结束后再发出一个终止 error |
 | `item.type == "agent_message"` | partial assistant chunk 事件；最后一个 item 同时作为 final response 内容 |
 | `type == "turn.completed"` | final response usage |
 
@@ -100,7 +100,7 @@ Codex 会自行创建 thread id。该 Agent 会把这个 id 存入 session state
 1. 首轮：把 prompt 写入 `codex exec --json` 的 stdin
 2. 后续轮次：把 prompt 写入 `codex exec resume --json <thread-id>` 的 stdin
 
-如果 resume 失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 与新建执行都失败，本次调用会返回 run error。
+如果 resume 在发出任何 transcript 事件前失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 已经发出过框架事件，或 stdout 解析失败，则不会再启动新的执行，以避免重复暴露进度或重复执行工具副作用，而是直接返回本次失败。如果 resume 与新建执行都失败，本次调用会返回 run error。
 
 如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
 

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-tRPC-Agent-Go 提供了 `Codex` 的 `Agent` 实现，通过执行本地 Codex CLI 的 `codex exec --json` 获取 JSONL 事件流，并映射为框架事件。
+tRPC-Agent-Go 提供了 `Codex` 的 `Agent` 实现，通过执行本地 Codex CLI 的 `codex exec --json` 获取 JSONL 事件流，并实时映射为框架事件。
 
 该实现的主要用途包括：
 
@@ -77,7 +77,7 @@ ag, err := codex.New(
 
 ## 事件映射
 
-该 Agent 只发出工具事件与最终响应事件，不发出中间 reasoning 事件。
+该 Agent 会实时发出工具事件与错误事件，并在 Codex turn 完成后发出最终响应事件；不发出中间 reasoning 事件。
 
 | Codex JSONL 输出 | 框架事件 |
 | --- | --- |
@@ -85,6 +85,7 @@ ag, err := codex.New(
 | `item.type == "command_execution"` | tool-call 与 tool-result response 事件 |
 | `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
 | `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
+| `type == "turn.failed"` 或 `type == "error"` | error response 事件 |
 | `item.type == "agent_message"` | final response 内容 |
 | `type == "turn.completed"` | final response usage |
 
@@ -128,4 +129,4 @@ ag, err := codex.New(
 | `WithExtraArgs(args...)` | 在可选 resume session id 前追加 `codex exec` flags。 |
 | `WithEnv(env...)` | 追加 CLI 环境变量。格式为 `KEY=VALUE`。 |
 | `WithWorkDir(dir)` | 设置 CLI 进程工作目录。 |
-| `WithRawOutputHook(hook)` | 观测 raw stdout/stderr。回调会在 CLI 结束后、解析前调用。 |
+| `WithRawOutputHook(hook)` | 观测 raw stdout/stderr。回调会在 CLI 结束后、流式事件发出后调用；如果返回错误，会追加错误事件并跳过最终 assistant response。 |

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -77,7 +77,7 @@ ag, err := codex.New(
 
 ## 事件映射
 
-该 Agent 会实时发出工具事件与错误事件，并在 Codex turn 完成后发出最终响应事件；不发出中间 reasoning 事件。
+该 Agent 会随着 Codex JSONL 到达实时发出 assistant、工具与错误事件，并在 Codex turn 完成后发出最终完成响应。Codex 的 `agent_message` 是完整消息 item，不是 token delta，因此会映射为非终止 assistant response。最终完成响应使用最后一个 assistant message 的内容，并携带最终 usage 与 thread state；不发出中间 reasoning 事件。
 
 | Codex JSONL 输出 | 框架事件 |
 | --- | --- |
@@ -86,7 +86,7 @@ ag, err := codex.New(
 | `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
 | `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
 | `type == "turn.failed"` 或 `type == "error"` | error response 事件 |
-| `item.type == "agent_message"` | final response 内容 |
+| `item.type == "agent_message"` | 非终止 assistant response；最后一个 item 同时作为 final response 内容 |
 | `type == "turn.completed"` | final response usage |
 
 MCP 工具调用会尽量归一化为与 Claude Code 兼容的工具名：`mcp__<server>__<tool>`。

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -77,7 +77,7 @@ ag, err := codex.New(
 
 ## 事件映射
 
-该 Agent 会随着 Codex JSONL 到达实时发出 assistant、工具与错误事件，并在 Codex turn 完成后发出最终完成响应。Codex 的 `agent_message` 是完整消息 item，不是 token delta，因此会映射为非终止 assistant response。最终完成响应使用最后一个 assistant message 的内容，并携带最终 usage 与 thread state；不发出中间 reasoning 事件。
+该 Agent 会随着 Codex JSONL 到达实时发出 assistant、工具与错误事件，并在 Codex turn 完成后发出最终完成响应。Codex 的 `agent_message` 是完整消息 item，不是 token delta，但该 Agent 会把它暴露为 partial `chat.completion.chunk` segment，确保 session 持久化只保存最终 assistant response。最终完成响应使用最后一个 assistant message 的内容，并携带最终 usage 与 thread state；不发出中间 reasoning 事件。
 
 | Codex JSONL 输出 | 框架事件 |
 | --- | --- |
@@ -85,8 +85,8 @@ ag, err := codex.New(
 | `item.type == "command_execution"` | tool-call 与 tool-result response 事件 |
 | `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
 | `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
-| `type == "turn.failed"` 或 `type == "error"` | error response 事件 |
-| `item.type == "agent_message"` | 非终止 assistant response；最后一个 item 同时作为 final response 内容 |
+| `type == "turn.failed"` 或 `type == "error"` | 非终止 error observation；命令结束后再发出一个终止 error |
+| `item.type == "agent_message"` | partial assistant chunk 事件；最后一个 item 同时作为 final response 内容 |
 | `type == "turn.completed"` | final response usage |
 
 MCP 工具调用会尽量归一化为与 Claude Code 兼容的工具名：`mcp__<server>__<tool>`。

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -86,7 +86,7 @@ ag, err := codex.New(
 | `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
 | `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
 | `type == "turn.failed"` 或 `type == "error"` | 不携带 `Response.Error` 的非终止 error observation chunk；命令结束后再发出一个终止 error |
-| `item.type == "agent_message"` | partial assistant chunk 事件；最后一个 item 同时作为 final response 内容 |
+| `item.type == "agent_message"` | partial assistant chunk 事件；最后一个 `agent_message` item 同时作为 final response 内容 |
 | `type == "turn.completed"` | final response usage |
 
 MCP 工具调用会尽量归一化为与 Claude Code 兼容的工具名：`mcp__<server>__<tool>`。

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -6,6 +6,7 @@ The agent executes `codex exec --json` and parses JSONL output to emit:
 
 - tool-call events for Codex command, MCP, built-in tool, and skill items
 - tool-result events for completed tool items
+- partial assistant chunk events for completed Codex assistant message items
 - a final response event from the Codex agent message
 - a session state update containing `codex.StateKeyThreadID` when Codex reports a new thread id
 

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -10,7 +10,7 @@ The agent executes `codex exec --json` and parses JSONL output to emit:
 - a final response event from the Codex agent message
 - a session state update containing `codex.StateKeyThreadID` when Codex reports a new thread id
 
-It also uses `codex exec resume --json <thread-id>` on later turns in the same framework session. If resume fails, it starts a fresh `codex exec` run and stores the new thread id when one is reported.
+It also uses `codex exec resume --json <thread-id>` on later turns in the same framework session. If resume fails before emitting any transcript events, it starts a fresh `codex exec` run and stores the new thread id when one is reported. If resume has already emitted events, the agent surfaces the failure instead of starting a fresh run to avoid duplicating visible progress or tool side effects.
 
 The example can configure two integrations:
 

--- a/examples/codex/main.go
+++ b/examples/codex/main.go
@@ -84,6 +84,7 @@ func runOnce(ctx context.Context, r runner.Runner, userID, sessionID, prompt str
 	if err != nil {
 		return err
 	}
+	var lastAssistantResponseID string
 	for evt := range ch {
 		if evt == nil {
 			continue
@@ -94,11 +95,33 @@ func runOnce(ctx context.Context, r runner.Runner, userID, sessionID, prompt str
 		}
 		printToolEvents(evt)
 		printThreadState(evt)
-		if evt.IsFinalResponse() && len(evt.Choices) > 0 {
-			fmt.Printf("Assistant: %s\n", strings.TrimSpace(evt.Choices[0].Message.Content))
-		}
+		printAssistantEvent(evt, &lastAssistantResponseID)
 	}
 	return nil
+}
+
+func printAssistantEvent(evt *event.Event, lastAssistantResponseID *string) {
+	if evt.Response == nil || len(evt.Choices) == 0 || evt.IsToolCallResponse() || evt.IsToolResultResponse() {
+		return
+	}
+	content := strings.TrimSpace(evt.Choices[0].Message.Content)
+	if content == "" {
+		return
+	}
+	if evt.IsFinalResponse() {
+		if evt.Response.ID != "" && lastAssistantResponseID != nil && evt.Response.ID == *lastAssistantResponseID {
+			return
+		}
+		fmt.Printf("Assistant: %s\n", content)
+		return
+	}
+	if evt.Object != model.ObjectTypeChatCompletion || evt.Done || evt.IsPartial {
+		return
+	}
+	if lastAssistantResponseID != nil {
+		*lastAssistantResponseID = evt.Response.ID
+	}
+	fmt.Printf("Assistant: %s\n", content)
 }
 
 func printToolEvents(evt *event.Event) {

--- a/examples/codex/main.go
+++ b/examples/codex/main.go
@@ -104,7 +104,7 @@ func printAssistantEvent(evt *event.Event, lastAssistantResponseID *string) {
 	if evt.Response == nil || len(evt.Choices) == 0 || evt.IsToolCallResponse() || evt.IsToolResultResponse() {
 		return
 	}
-	content := strings.TrimSpace(evt.Choices[0].Message.Content)
+	content := assistantText(evt)
 	if content == "" {
 		return
 	}
@@ -115,13 +115,21 @@ func printAssistantEvent(evt *event.Event, lastAssistantResponseID *string) {
 		fmt.Printf("Assistant: %s\n", content)
 		return
 	}
-	if evt.Object != model.ObjectTypeChatCompletion || evt.Done || evt.IsPartial {
+	if evt.Object != model.ObjectTypeChatCompletionChunk || evt.Done || !evt.IsPartial {
 		return
 	}
 	if lastAssistantResponseID != nil {
 		*lastAssistantResponseID = evt.Response.ID
 	}
 	fmt.Printf("Assistant: %s\n", content)
+}
+
+func assistantText(evt *event.Event) string {
+	content := strings.TrimSpace(evt.Choices[0].Message.Content)
+	if content != "" {
+		return content
+	}
+	return strings.TrimSpace(evt.Choices[0].Delta.Content)
 }
 
 func printToolEvents(evt *event.Event) {

--- a/server/agui/translator/message_lifecycle.go
+++ b/server/agui/translator/message_lifecycle.go
@@ -51,6 +51,15 @@ func (t *translator) closeTextStreamsBeforeQueuedUserMessage() []aguievents.Even
 	return t.closeCurrentTextStream()
 }
 
+func (t *translator) closeTextStreamsBeforeToolEvent() []aguievents.Event {
+	if t.concurrentMessageStreamsEnabled {
+		events := t.closeOpenTextStreams()
+		t.clearGraphTextAppendTarget()
+		return events
+	}
+	return t.closeCurrentTextStream()
+}
+
 func (t *translator) translateReasoningMessageEvents(rsp *model.Response) ([]aguievents.Event, error) {
 	if t.concurrentMessageStreamsEnabled {
 		return t.concurrentReasoningEvents(rsp)

--- a/server/agui/translator/toolcall_delta.go
+++ b/server/agui/translator/toolcall_delta.go
@@ -54,6 +54,9 @@ func (t *translator) messageToolCallEvents(parentMessageID string, choice model.
 				t.discardDeltaToolCall(state)
 			}
 		}
+		if toolCall.ID != "" && t.hasSeenToolCallID(toolCall.ID) {
+			continue
+		}
 		t.recordToolCallID(toolCall.ID)
 		// Tool Call Start Event.
 		startOpt := []aguievents.ToolCallStartOption{aguievents.WithParentMessageID(parentMessageID)}

--- a/server/agui/translator/translator.go
+++ b/server/agui/translator/translator.go
@@ -186,6 +186,7 @@ func (t *translator) Translate(ctx context.Context, event *agentevent.Event) ([]
 		events = append(events, textMessageEvents...)
 	}
 	if rsp.IsToolCallResponse() {
+		events = append(events, t.closeTextStreamsBeforeToolEvent()...)
 		toolCallEvents, err := t.toolCallEvent(rsp)
 		if err != nil {
 			return nil, err
@@ -200,6 +201,7 @@ func (t *translator) Translate(ctx context.Context, event *agentevent.Event) ([]
 			}
 			events = append(events, toolResultActivityEvents...)
 		} else {
+			events = append(events, t.closeTextStreamsBeforeToolEvent()...)
 			toolResultEvents, err := t.toolResultEvent(rsp, event.ID)
 			if err != nil {
 				return nil, err

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -666,6 +666,45 @@ func TestTranslateErrorResponse(t *testing.T) {
 	assert.Equal(t, "run", runErr.RunID())
 }
 
+func TestTranslateErrorObservationClosesOnTerminalError(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+	observation := &model.Response{
+		ID:        "inv-1:codex-error-observation",
+		Object:    model.ObjectTypeChatCompletionChunk,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, Content: "first failure"},
+		}},
+	}
+	events, err := translator.Translate(context.Background(), &agentevent.Event{Response: observation})
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+	start, ok := events[0].(*aguievents.TextMessageStartEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "inv-1:codex-error-observation", start.MessageID)
+	content, ok := events[1].(*aguievents.TextMessageContentEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "inv-1:codex-error-observation", content.MessageID)
+	assert.Equal(t, "first failure", content.Delta)
+	terminal := &model.Response{
+		Object: model.ObjectTypeError,
+		Done:   true,
+		Error:  &model.ResponseError{Message: "final failure"},
+	}
+	events, err = translator.Translate(context.Background(), &agentevent.Event{Response: terminal})
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+	end, ok := events[0].(*aguievents.TextMessageEndEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "inv-1:codex-error-observation", end.MessageID)
+	runErr, ok := events[1].(*aguievents.RunErrorEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "final failure", runErr.Message)
+}
+
 func TestTranslateErrorResponseClosesOpenToolCallDelta(t *testing.T) {
 	translator := newTranslatorImplForTest(t, WithToolCallDeltaStreamingEnabled(true))
 	if translator == nil {

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -705,6 +705,86 @@ func TestTranslateErrorObservationClosesOnTerminalError(t *testing.T) {
 	assert.Equal(t, "final failure", runErr.Message)
 }
 
+func TestTranslateAssistantToolAssistantClosesTextBoundary(t *testing.T) {
+	translator := newTranslatorForTest(t)
+	if translator == nil {
+		return
+	}
+	firstAssistant := &model.Response{
+		ID:        "assistant-1",
+		Object:    model.ObjectTypeChatCompletionChunk,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, Content: "good luck"},
+		}},
+	}
+	events, err := translator.Translate(context.Background(), &agentevent.Event{Response: firstAssistant})
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+	toolCall := model.ToolCall{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Name:      "shell",
+			Arguments: []byte(`{"command":"printf done"}`),
+		},
+	}
+	startedTool := &model.Response{
+		Object:    model.ObjectTypeChatCompletion,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleAssistant, ToolCalls: []model.ToolCall{toolCall}},
+		}},
+	}
+	events, err = translator.Translate(context.Background(), &agentevent.Event{ID: "tool-start", Response: startedTool})
+	assert.NoError(t, err)
+	assert.Len(t, events, 4)
+	endText, ok := events[0].(*aguievents.TextMessageEndEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "assistant-1", endText.MessageID)
+	startTool, ok := events[1].(*aguievents.ToolCallStartEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "call-1", startTool.ToolCallID)
+	completedTool := &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleAssistant, ToolCalls: []model.ToolCall{toolCall}},
+		}},
+	}
+	events, err = translator.Translate(context.Background(), &agentevent.Event{ID: "tool-complete", Response: completedTool})
+	assert.NoError(t, err)
+	assert.Empty(t, events)
+	toolResult := &model.Response{
+		Object: model.ObjectTypeToolResponse,
+		Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleTool, ToolID: "call-1", Content: "done"},
+		}},
+	}
+	events, err = translator.Translate(context.Background(), &agentevent.Event{ID: "tool-result", Response: toolResult})
+	assert.NoError(t, err)
+	assert.Len(t, events, 1)
+	result, ok := events[0].(*aguievents.ToolCallResultEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "tool-result", result.MessageID)
+	secondAssistant := &model.Response{
+		ID:        "assistant-2",
+		Object:    model.ObjectTypeChatCompletionChunk,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, Content: "practice makes perfect"},
+		}},
+	}
+	events, err = translator.Translate(context.Background(), &agentevent.Event{Response: secondAssistant})
+	assert.NoError(t, err)
+	assert.Len(t, events, 2)
+	startText, ok := events[0].(*aguievents.TextMessageStartEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "assistant-2", startText.MessageID)
+	content, ok := events[1].(*aguievents.TextMessageContentEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "assistant-2", content.MessageID)
+	assert.Equal(t, "practice makes perfect", content.Delta)
+}
+
 func TestTranslateErrorResponseClosesOpenToolCallDelta(t *testing.T) {
 	translator := newTranslatorImplForTest(t, WithToolCallDeltaStreamingEnabled(true))
 	if translator == nil {
@@ -2642,8 +2722,11 @@ func TestTranslateToolResultResponse(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Len(t, events, 1)
-	result, ok := events[0].(*aguievents.ToolCallResultEvent)
+	assert.Len(t, events, 2)
+	endText, ok := events[0].(*aguievents.TextMessageEndEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "msg-1", endText.MessageID)
+	result, ok := events[1].(*aguievents.ToolCallResultEvent)
 	assert.True(t, ok)
 	assert.Equal(t, "evt-tool-1", result.MessageID)
 	assert.Equal(t, "tool-1", result.ToolCallID)

--- a/server/openai/converter.go
+++ b/server/openai/converter.go
@@ -440,6 +440,12 @@ func (c *converter) aggregateStreamingEvents(events []*event.Event) (*openAIResp
 		// Use the last event if no event with usage found.
 		finalEvent = events[len(events)-1]
 	}
+	if finalEvent.Response != nil && len(finalEvent.Response.Choices) > 0 {
+		if finalContent := finalEvent.Response.Choices[0].Message.Content; finalContent != "" {
+			allContent.Reset()
+			allContent.WriteString(finalContent)
+		}
+	}
 	// Build the aggregated message.
 	msg := model.Message{
 		Role:      model.RoleAssistant,

--- a/server/openai/converter.go
+++ b/server/openai/converter.go
@@ -408,45 +408,22 @@ func (c *converter) aggregateStreamingEvents(events []*event.Event) (*openAIResp
 	if len(events) == 0 {
 		return nil, fmt.Errorf("no events to aggregate")
 	}
-	// Find the final event with usage.
-	var finalEvent *event.Event
-	var allContent strings.Builder
-	var toolCalls []model.ToolCall
-	for _, evt := range events {
-		if evt.Response != nil && evt.Usage != nil {
-			finalEvent = evt
-		}
-		if choice, ok := firstResponseChoice(evt); ok {
-			// Handle streaming delta content.
-			if choice.Delta.Content != "" {
-				allContent.WriteString(choice.Delta.Content)
-			}
-			// Handle non-streaming message content (for compatibility).
-			if choice.Message.Content != "" && allContent.Len() == 0 {
-				allContent.WriteString(choice.Message.Content)
-			}
-			// Handle streaming delta tool calls.
-			if len(choice.Delta.ToolCalls) > 0 {
-				toolCalls = append(toolCalls, choice.Delta.ToolCalls...)
-			}
-			// Handle non-streaming message tool calls (for compatibility).
-			if len(choice.Message.ToolCalls) > 0 && len(toolCalls) == 0 {
-				toolCalls = append(toolCalls, choice.Message.ToolCalls...)
-			}
-		}
+	finalEvent, usageEvent, content, toolCalls := scanStreamingEvents(events)
+	if finalEvent == nil {
+		finalEvent = usageEvent
 	}
 	if finalEvent == nil {
-		// Use the last event if no event with usage found.
+		// Use the last event if no completion or usage event was found.
 		finalEvent = events[len(events)-1]
 	}
-	if finalContent := finalResponseMessageContent(finalEvent); finalContent != "" {
-		allContent.Reset()
-		allContent.WriteString(finalContent)
+	if finalEvent == nil {
+		return nil, fmt.Errorf("no response events to aggregate")
 	}
+	content, toolCalls = applyFinalMessageChoice(content, toolCalls, finalEvent)
 	// Build the aggregated message.
 	msg := model.Message{
 		Role:      model.RoleAssistant,
-		Content:   allContent.String(),
+		Content:   content,
 		ToolCalls: toolCalls,
 	}
 	openAIMsg, err := c.convertModelMessageToOpenAI(msg)
@@ -476,14 +453,80 @@ func (c *converter) aggregateStreamingEvents(events []*event.Event) (*openAIResp
 			},
 		},
 	}
-	if finalEvent.Usage != nil {
+	if usageEvent == nil {
+		usageEvent = finalEvent
+	}
+	if usageEvent.Usage != nil {
 		response.Usage = &openAIUsage{
-			PromptTokens:     finalEvent.Usage.PromptTokens,
-			CompletionTokens: finalEvent.Usage.CompletionTokens,
-			TotalTokens:      finalEvent.Usage.TotalTokens,
+			PromptTokens:     usageEvent.Usage.PromptTokens,
+			CompletionTokens: usageEvent.Usage.CompletionTokens,
+			TotalTokens:      usageEvent.Usage.TotalTokens,
 		}
 	}
 	return response, nil
+}
+
+func scanStreamingEvents(events []*event.Event) (*event.Event, *event.Event, string, []model.ToolCall) {
+	var finalEvent *event.Event
+	var usageEvent *event.Event
+	var allContent strings.Builder
+	var toolCalls []model.ToolCall
+	for _, evt := range events {
+		if evt == nil {
+			continue
+		}
+		if evt.Response != nil && evt.Usage != nil {
+			usageEvent = evt
+		}
+		if isAssistantCompletionEvent(evt) {
+			finalEvent = evt
+		}
+		if choice, ok := firstResponseChoice(evt); ok {
+			appendStreamingChoice(&allContent, &toolCalls, choice)
+		}
+	}
+	return finalEvent, usageEvent, allContent.String(), toolCalls
+}
+
+func appendStreamingChoice(allContent *strings.Builder, toolCalls *[]model.ToolCall, choice model.Choice) {
+	if choice.Delta.Content != "" {
+		allContent.WriteString(choice.Delta.Content)
+	}
+	if choice.Message.Content != "" && allContent.Len() == 0 {
+		allContent.WriteString(choice.Message.Content)
+	}
+	if len(choice.Delta.ToolCalls) > 0 {
+		*toolCalls = append(*toolCalls, choice.Delta.ToolCalls...)
+	}
+	if len(choice.Message.ToolCalls) > 0 && len(*toolCalls) == 0 {
+		*toolCalls = append(*toolCalls, choice.Message.ToolCalls...)
+	}
+}
+
+func isAssistantCompletionEvent(evt *event.Event) bool {
+	if evt == nil || evt.Response == nil || evt.Response.IsPartial {
+		return false
+	}
+	rsp := evt.Response
+	if rsp.Object != model.ObjectTypeChatCompletion || len(rsp.Choices) == 0 {
+		return false
+	}
+	return !rsp.IsToolCallResponse() && !rsp.IsToolResultResponse()
+}
+
+func applyFinalMessageChoice(content string, toolCalls []model.ToolCall, evt *event.Event) (string, []model.ToolCall) {
+	choice, ok := firstResponseChoice(evt)
+	if !ok {
+		return content, toolCalls
+	}
+	if choice.Message.Content == "" && len(choice.Message.ToolCalls) == 0 {
+		return content, toolCalls
+	}
+	if choice.Message.Content != "" {
+		content = choice.Message.Content
+	}
+	toolCalls = append([]model.ToolCall(nil), choice.Message.ToolCalls...)
+	return content, toolCalls
 }
 
 func firstResponseChoice(evt *event.Event) (model.Choice, bool) {
@@ -491,14 +534,6 @@ func firstResponseChoice(evt *event.Event) (model.Choice, bool) {
 		return model.Choice{}, false
 	}
 	return evt.Response.Choices[0], true
-}
-
-func finalResponseMessageContent(evt *event.Event) string {
-	choice, ok := firstResponseChoice(evt)
-	if !ok {
-		return ""
-	}
-	return choice.Message.Content
 }
 
 // generateResponseID generates a unique response ID.

--- a/server/openai/converter.go
+++ b/server/openai/converter.go
@@ -416,8 +416,7 @@ func (c *converter) aggregateStreamingEvents(events []*event.Event) (*openAIResp
 		if evt.Response != nil && evt.Usage != nil {
 			finalEvent = evt
 		}
-		if evt.Response != nil && len(evt.Response.Choices) > 0 {
-			choice := evt.Response.Choices[0]
+		if choice, ok := firstResponseChoice(evt); ok {
 			// Handle streaming delta content.
 			if choice.Delta.Content != "" {
 				allContent.WriteString(choice.Delta.Content)
@@ -440,11 +439,9 @@ func (c *converter) aggregateStreamingEvents(events []*event.Event) (*openAIResp
 		// Use the last event if no event with usage found.
 		finalEvent = events[len(events)-1]
 	}
-	if finalEvent.Response != nil && len(finalEvent.Response.Choices) > 0 {
-		if finalContent := finalEvent.Response.Choices[0].Message.Content; finalContent != "" {
-			allContent.Reset()
-			allContent.WriteString(finalContent)
-		}
+	if finalContent := finalResponseMessageContent(finalEvent); finalContent != "" {
+		allContent.Reset()
+		allContent.WriteString(finalContent)
 	}
 	// Build the aggregated message.
 	msg := model.Message{
@@ -487,6 +484,21 @@ func (c *converter) aggregateStreamingEvents(events []*event.Event) (*openAIResp
 		}
 	}
 	return response, nil
+}
+
+func firstResponseChoice(evt *event.Event) (model.Choice, bool) {
+	if evt == nil || evt.Response == nil || len(evt.Response.Choices) == 0 {
+		return model.Choice{}, false
+	}
+	return evt.Response.Choices[0], true
+}
+
+func finalResponseMessageContent(evt *event.Event) string {
+	choice, ok := firstResponseChoice(evt)
+	if !ok {
+		return ""
+	}
+	return choice.Message.Content
 }
 
 // generateResponseID generates a unique response ID.

--- a/server/openai/converter_test.go
+++ b/server/openai/converter_test.go
@@ -655,6 +655,50 @@ func TestConverter_aggregateStreamingEvents(t *testing.T) {
 				assert.Equal(t, "tool_calls", *resp.Choices[0].FinishReason)
 			},
 		},
+		{
+			name: "final message content overrides prior assistant observations",
+			events: []*event.Event{
+				{
+					ID: "event-observation",
+					Response: &model.Response{
+						Object: model.ObjectTypeChatCompletionChunk,
+						Choices: []model.Choice{
+							{
+								Delta: model.Message{
+									Content: "good luck",
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "event-final",
+					Response: &model.Response{
+						Object: model.ObjectTypeChatCompletion,
+						Choices: []model.Choice{
+							{
+								Message: model.Message{
+									Content: "practice makes perfect",
+								},
+							},
+						},
+						Usage: &model.Usage{
+							PromptTokens:     3,
+							CompletionTokens: 4,
+							TotalTokens:      7,
+						},
+					},
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, resp *openAIResponse) {
+				assert.NotNil(t, resp)
+				assert.Equal(t, "event-final", resp.ID)
+				assert.Equal(t, "practice makes perfect", resp.Choices[0].Message.Content)
+				assert.NotNil(t, resp.Usage)
+				assert.Equal(t, 7, resp.Usage.TotalTokens)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/openai/converter_test.go
+++ b/server/openai/converter_test.go
@@ -699,6 +699,91 @@ func TestConverter_aggregateStreamingEvents(t *testing.T) {
 				assert.Equal(t, 7, resp.Usage.TotalTokens)
 			},
 		},
+		{
+			name: "final message without usage overrides observations before runner completion",
+			events: []*event.Event{
+				{
+					ID: "event-observation-1",
+					Response: &model.Response{
+						Object:    model.ObjectTypeChatCompletionChunk,
+						IsPartial: true,
+						Choices: []model.Choice{
+							{
+								Delta: model.Message{
+									Content: "good luck",
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "event-observation-2",
+					Response: &model.Response{
+						Object:    model.ObjectTypeChatCompletionChunk,
+						IsPartial: true,
+						Choices: []model.Choice{
+							{
+								Delta: model.Message{
+									Content: "practice makes perfect",
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "event-tool-call",
+					Response: &model.Response{
+						Object: model.ObjectTypeChatCompletion,
+						Choices: []model.Choice{
+							{
+								Message: model.Message{
+									ToolCalls: []model.ToolCall{
+										{
+											ID:   "call-1",
+											Type: "function",
+											Function: model.FunctionDefinitionParam{
+												Name: "shell",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "event-final",
+					Response: &model.Response{
+						Object: model.ObjectTypeChatCompletion,
+						Done:   true,
+						Choices: []model.Choice{
+							{
+								Message: model.Message{
+									Content: "practice makes perfect",
+								},
+							},
+						},
+					},
+				},
+				{
+					ID: "event-runner-completion",
+					Response: &model.Response{
+						Object: model.ObjectTypeRunnerCompletion,
+						Done:   true,
+					},
+				},
+			},
+			wantErr: false,
+			check: func(t *testing.T, resp *openAIResponse) {
+				assert.NotNil(t, resp)
+				assert.Equal(t, "event-final", resp.ID)
+				assert.Equal(t, "practice makes perfect", resp.Choices[0].Message.Content)
+				assert.Empty(t, resp.Choices[0].Message.ToolCalls)
+				assert.NotNil(t, resp.Choices[0].FinishReason)
+				assert.Equal(t, "stop", *resp.Choices[0].FinishReason)
+				assert.Nil(t, resp.Usage)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This updates the Codex CLI agent to consume codex exec --json stdout incrementally, emitting tool and error events as JSONL records arrive while keeping the final assistant response after turn completion for usage and state updates. It also adjusts raw output hook semantics for streamed events and documents the behavior.