### PR TITLE
server/trpcagent: add app route prefix accessor

### DIFF
--- a/server/trpcagent/server.go
+++ b/server/trpcagent/server.go
@@ -81,6 +81,12 @@ func (s *Server) BasePath() string {
 	return s.basePath
 }
 
+// AppPath returns the app-specific route prefix exposed by the server.
+func (s *Server) AppPath() string {
+	path, _ := url.JoinPath(s.basePath, s.appName)
+	return path
+}
+
 func (s *Server) setupHandler() error {
 	mux := http.NewServeMux()
 	if s.agent != nil {

--- a/server/trpcagent/server_test.go
+++ b/server/trpcagent/server_test.go
@@ -600,6 +600,7 @@ func TestServerOptionsApplyBasePathTimeoutAndCORS(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "/api/apps", srv.BasePath())
+	assert.Equal(t, "/api/apps/sports-agent", srv.AppPath())
 	req := httptest.NewRequest(http.MethodGet, "/api/apps/sports-agent/structure", nil)
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)


### PR DESCRIPTION
This exposes an AppPath accessor on the tRPC-Agent server that returns the fully joined base path and app name. It lets HTTP integrations mount a single app server at its app-specific route prefix without duplicating route construction or reaching into server internals.