### PR TITLE
evaluation: add PromptIter regression and optimization workflow

### DIFF
--- a/agent/structure/export.go
+++ b/agent/structure/export.go
@@ -179,13 +179,14 @@ func cloneSnapshot(raw *Snapshot) *Snapshot {
 			SurfaceID: surface.SurfaceID,
 			NodeID:    surface.NodeID,
 			Type:      surface.Type,
-			Value:     cloneSurfaceValue(surface.Value),
+			Value:     CloneSurfaceValue(surface.Value),
 		})
 	}
 	return snapshot
 }
 
-func cloneSurfaceValue(value SurfaceValue) SurfaceValue {
+// CloneSurfaceValue returns a deep copy that callers may mutate independently.
+func CloneSurfaceValue(value SurfaceValue) SurfaceValue {
 	cloned := SurfaceValue{
 		FewShot: cloneFewShot(value.FewShot),
 		Tools:   cloneToolRefs(value.Tools),
@@ -297,7 +298,7 @@ func cloneFewShot(value []FewShotExample) []FewShotExample {
 }
 
 func normalizeSurfaceValue(value SurfaceValue) SurfaceValue {
-	value = cloneSurfaceValue(value)
+	value = CloneSurfaceValue(value)
 	if len(value.Tools) > 0 {
 		sort.Slice(value.Tools, func(i, j int) bool {
 			return value.Tools[i].ID < value.Tools[j].ID

--- a/agent/structure/export.go
+++ b/agent/structure/export.go
@@ -186,7 +186,8 @@ func cloneSnapshot(raw *Snapshot) *Snapshot {
 }
 
 // CloneSurfaceValue returns a deep copy that callers may mutate independently.
-// It preserves the distinction between nil and non-nil empty collections.
+// It preserves the distinction between nil and non-nil empty collections,
+// including JSON-shaped values stored in tool schemas.
 func CloneSurfaceValue(value SurfaceValue) SurfaceValue {
 	cloned := SurfaceValue{
 		FewShot: cloneFewShot(value.FewShot),
@@ -267,26 +268,61 @@ func cloneSchemaValues(in []any) []any {
 }
 
 func cloneSchemaValue(value any) any {
-	switch current := value.(type) {
-	case nil:
+	if value == nil {
 		return nil
-	case *tool.Schema:
-		return cloneToolSchema(current)
-	case map[string]any:
-		if current == nil {
-			return map[string]any(nil)
+	}
+	return cloneJSONValue(reflect.ValueOf(value)).Interface()
+}
+
+func cloneJSONValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
 		}
-		out := make(map[string]any, len(current))
-		for key, item := range current {
-			out[key] = cloneSchemaValue(item)
+		out := reflect.New(value.Type()).Elem()
+		out.Set(cloneJSONValue(value.Elem()))
+		return out
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		if value.Type() == reflect.TypeOf((*tool.Schema)(nil)) {
+			return reflect.ValueOf(cloneToolSchema(value.Interface().(*tool.Schema)))
+		}
+		out := reflect.New(value.Type().Elem())
+		out.Elem().Set(cloneJSONValue(value.Elem()))
+		return out
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		out := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iterator := value.MapRange()
+		for iterator.Next() {
+			out.SetMapIndex(cloneJSONValue(iterator.Key()), cloneJSONValue(iterator.Value()))
 		}
 		return out
-	case []any:
-		return cloneSchemaValues(current)
-	case []byte:
-		return cloneSlice(current)
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		out := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for index := 0; index < value.Len(); index++ {
+			out.Index(index).Set(cloneJSONValue(value.Index(index)))
+		}
+		return out
+	case reflect.Array:
+		out := reflect.New(value.Type()).Elem()
+		for index := 0; index < value.Len(); index++ {
+			out.Index(index).Set(cloneJSONValue(value.Index(index)))
+		}
+		return out
 	default:
-		return current
+		return value
 	}
 }
 
@@ -311,7 +347,7 @@ func cloneSlice[T any](value []T) []T {
 }
 
 func normalizeSurfaceValue(value SurfaceValue) SurfaceValue {
-	value = CloneSurfaceValue(value)
+	value = canonicalizeSurfaceValue(CloneSurfaceValue(value))
 	if len(value.Tools) > 0 {
 		sort.Slice(value.Tools, func(i, j int) bool {
 			return value.Tools[i].ID < value.Tools[j].ID
@@ -325,6 +361,96 @@ func normalizeSurfaceValue(value SurfaceValue) SurfaceValue {
 		value.Skills = uniqueSkillRefs(value.Skills)
 	}
 	return value
+}
+
+// canonicalizeSurfaceValue preserves the historical representation used to
+// calculate structure IDs while CloneSurfaceValue retains copy fidelity.
+func canonicalizeSurfaceValue(value SurfaceValue) SurfaceValue {
+	if len(value.FewShot) == 0 {
+		value.FewShot = nil
+	} else {
+		for index := range value.FewShot {
+			if len(value.FewShot[index].Messages) == 0 {
+				value.FewShot[index].Messages = nil
+			}
+		}
+	}
+	if len(value.Tools) == 0 {
+		value.Tools = nil
+	} else {
+		for index := range value.Tools {
+			canonicalizeToolSchema(value.Tools[index].InputSchema)
+			canonicalizeToolSchema(value.Tools[index].OutputSchema)
+		}
+	}
+	if len(value.Skills) == 0 {
+		value.Skills = nil
+	}
+	return value
+}
+
+func canonicalizeToolSchema(schema *tool.Schema) {
+	if schema == nil {
+		return
+	}
+	if len(schema.Required) == 0 {
+		schema.Required = nil
+	}
+	if len(schema.Properties) == 0 {
+		schema.Properties = nil
+	} else {
+		for _, property := range schema.Properties {
+			canonicalizeToolSchema(property)
+		}
+	}
+	canonicalizeToolSchema(schema.Items)
+	schema.AdditionalProperties = canonicalizeSchemaValue(schema.AdditionalProperties)
+	schema.Default = canonicalizeSchemaValue(schema.Default)
+	if len(schema.Enum) == 0 {
+		schema.Enum = nil
+	} else {
+		for index := range schema.Enum {
+			schema.Enum[index] = canonicalizeSchemaValue(schema.Enum[index])
+		}
+	}
+	if len(schema.Defs) == 0 {
+		schema.Defs = nil
+	} else {
+		for _, definition := range schema.Defs {
+			canonicalizeToolSchema(definition)
+		}
+	}
+}
+
+func canonicalizeSchemaValue(value any) any {
+	switch current := value.(type) {
+	case *tool.Schema:
+		canonicalizeToolSchema(current)
+		return current
+	case map[string]any:
+		if current == nil {
+			return map[string]any{}
+		}
+		for key, item := range current {
+			current[key] = canonicalizeSchemaValue(item)
+		}
+		return current
+	case []any:
+		if len(current) == 0 {
+			return []any(nil)
+		}
+		for index := range current {
+			current[index] = canonicalizeSchemaValue(current[index])
+		}
+		return current
+	case []byte:
+		if len(current) == 0 {
+			return []byte(nil)
+		}
+		return current
+	default:
+		return current
+	}
 }
 
 func uniqueToolRefs(refs []ToolRef) []ToolRef {

--- a/agent/structure/export.go
+++ b/agent/structure/export.go
@@ -186,11 +186,12 @@ func cloneSnapshot(raw *Snapshot) *Snapshot {
 }
 
 // CloneSurfaceValue returns a deep copy that callers may mutate independently.
+// It preserves the distinction between nil and non-nil empty collections.
 func CloneSurfaceValue(value SurfaceValue) SurfaceValue {
 	cloned := SurfaceValue{
 		FewShot: cloneFewShot(value.FewShot),
 		Tools:   cloneToolRefs(value.Tools),
-		Skills:  append([]SkillRef(nil), value.Skills...),
+		Skills:  cloneSlice(value.Skills),
 	}
 	if value.Text != nil {
 		text := *value.Text
@@ -209,7 +210,7 @@ func CloneSurfaceValue(value SurfaceValue) SurfaceValue {
 }
 
 func cloneToolRefs(refs []ToolRef) []ToolRef {
-	if len(refs) == 0 {
+	if refs == nil {
 		return nil
 	}
 	out := make([]ToolRef, len(refs))
@@ -232,7 +233,7 @@ func cloneToolSchema(schema *tool.Schema) *tool.Schema {
 		Type:                 schema.Type,
 		Description:          schema.Description,
 		Pattern:              schema.Pattern,
-		Required:             append([]string(nil), schema.Required...),
+		Required:             cloneSlice(schema.Required),
 		Properties:           cloneSchemaMap(schema.Properties),
 		Items:                cloneToolSchema(schema.Items),
 		AdditionalProperties: cloneSchemaValue(schema.AdditionalProperties),
@@ -244,7 +245,7 @@ func cloneToolSchema(schema *tool.Schema) *tool.Schema {
 }
 
 func cloneSchemaMap(in map[string]*tool.Schema) map[string]*tool.Schema {
-	if len(in) == 0 {
+	if in == nil {
 		return nil
 	}
 	out := make(map[string]*tool.Schema, len(in))
@@ -255,7 +256,7 @@ func cloneSchemaMap(in map[string]*tool.Schema) map[string]*tool.Schema {
 }
 
 func cloneSchemaValues(in []any) []any {
-	if len(in) == 0 {
+	if in == nil {
 		return nil
 	}
 	out := make([]any, len(in))
@@ -272,6 +273,9 @@ func cloneSchemaValue(value any) any {
 	case *tool.Schema:
 		return cloneToolSchema(current)
 	case map[string]any:
+		if current == nil {
+			return map[string]any(nil)
+		}
 		out := make(map[string]any, len(current))
 		for key, item := range current {
 			out[key] = cloneSchemaValue(item)
@@ -280,20 +284,29 @@ func cloneSchemaValue(value any) any {
 	case []any:
 		return cloneSchemaValues(current)
 	case []byte:
-		return append([]byte(nil), current...)
+		return cloneSlice(current)
 	default:
 		return current
 	}
 }
 
 func cloneFewShot(value []FewShotExample) []FewShotExample {
-	if len(value) == 0 {
+	if value == nil {
 		return nil
 	}
 	out := make([]FewShotExample, len(value))
 	for i, example := range value {
-		out[i].Messages = append([]FewShotMessage(nil), example.Messages...)
+		out[i].Messages = cloneSlice(example.Messages)
 	}
+	return out
+}
+
+func cloneSlice[T any](value []T) []T {
+	if value == nil {
+		return nil
+	}
+	out := make([]T, len(value))
+	copy(out, value)
 	return out
 }
 

--- a/agent/structure/export_test.go
+++ b/agent/structure/export_test.go
@@ -241,7 +241,7 @@ func TestCloneSurfaceValue_ClonesModelHeaders(t *testing.T) {
 			Headers:  map[string]string{"X-Test": "1"},
 		},
 	}
-	cloned := cloneSurfaceValue(value)
+	cloned := CloneSurfaceValue(value)
 	require.NotNil(t, cloned.Model)
 	require.NotSame(t, value.Model, cloned.Model)
 	require.Equal(t, map[string]string{"X-Test": "1"}, cloned.Model.Headers)
@@ -256,7 +256,7 @@ func TestCloneSurfaceValue_ClonesEmptyModelHeaders(t *testing.T) {
 			Headers: map[string]string{},
 		},
 	}
-	cloned := cloneSurfaceValue(value)
+	cloned := CloneSurfaceValue(value)
 	require.NotNil(t, cloned.Model)
 	require.NotNil(t, cloned.Model.Headers)
 	cloned.Model.Headers["X-Test"] = "1"

--- a/agent/structure/export_test.go
+++ b/agent/structure/export_test.go
@@ -292,6 +292,30 @@ func TestCloneSurfaceValue_PreservesEmptyCollections(t *testing.T) {
 	require.NotNil(t, input.Default)
 }
 
+func TestCloneSurfaceValue_ClonesTypedSchemaValues(t *testing.T) {
+	typedMap := map[string]string{"state": "source"}
+	typedSlice := []string{"source"}
+	pointerValue := map[string]any{"state": "source"}
+	typedMapSlice := []map[string]string{{"state": "source"}}
+	value := SurfaceValue{Tools: []ToolRef{{InputSchema: &tool.Schema{
+		AdditionalProperties: &pointerValue,
+		Default:              typedMapSlice,
+		Enum:                 []any{typedMap, typedSlice},
+	}}}}
+
+	cloned := CloneSurfaceValue(value)
+	clonedSchema := cloned.Tools[0].InputSchema
+	clonedSchema.Enum[0].(map[string]string)["state"] = "clone"
+	clonedSchema.Enum[1].([]string)[0] = "clone"
+	(*clonedSchema.AdditionalProperties.(*map[string]any))["state"] = "clone"
+	clonedSchema.Default.([]map[string]string)[0]["state"] = "clone"
+
+	assert.Equal(t, "source", typedMap["state"])
+	assert.Equal(t, "source", typedSlice[0])
+	assert.Equal(t, "source", pointerValue["state"])
+	assert.Equal(t, "source", typedMapSlice[0]["state"])
+}
+
 func TestModelRef_JSONOmitsEmptyFields(t *testing.T) {
 	data, err := json.Marshal(ModelRef{Name: "gpt-5.2"})
 	require.NoError(t, err)

--- a/agent/structure/export_test.go
+++ b/agent/structure/export_test.go
@@ -263,6 +263,35 @@ func TestCloneSurfaceValue_ClonesEmptyModelHeaders(t *testing.T) {
 	assert.Empty(t, value.Model.Headers)
 }
 
+func TestCloneSurfaceValue_PreservesEmptyCollections(t *testing.T) {
+	value := SurfaceValue{
+		FewShot: []FewShotExample{{Messages: []FewShotMessage{}}, {}},
+		Tools:   []ToolRef{},
+		Skills:  []SkillRef{},
+	}
+	cloned := CloneSurfaceValue(value)
+	require.NotNil(t, cloned.FewShot)
+	require.NotNil(t, cloned.FewShot[0].Messages)
+	assert.Nil(t, cloned.FewShot[1].Messages)
+	require.NotNil(t, cloned.Tools)
+	require.NotNil(t, cloned.Skills)
+
+	schema := &tool.Schema{
+		Required:   []string{},
+		Properties: map[string]*tool.Schema{},
+		Enum:       []any{},
+		Defs:       map[string]*tool.Schema{},
+		Default:    []byte{},
+	}
+	cloned = CloneSurfaceValue(SurfaceValue{Tools: []ToolRef{{InputSchema: schema}}})
+	input := cloned.Tools[0].InputSchema
+	require.NotNil(t, input.Required)
+	require.NotNil(t, input.Properties)
+	require.NotNil(t, input.Enum)
+	require.NotNil(t, input.Defs)
+	require.NotNil(t, input.Default)
+}
+
 func TestModelRef_JSONOmitsEmptyFields(t *testing.T) {
 	data, err := json.Marshal(ModelRef{Name: "gpt-5.2"})
 	require.NoError(t, err)

--- a/agent/structure/id_test.go
+++ b/agent/structure/id_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 func TestExport_NodeID_IsStableAcrossRepeatedExports(t *testing.T) {
@@ -59,6 +61,55 @@ func TestExport_StructureID_IsStableAcrossRepeatedExports(t *testing.T) {
 	second, err := Export(context.Background(), ag)
 	require.NoError(t, err)
 	assert.Equal(t, first.StructureID, second.StructureID)
+}
+
+func TestExport_StructureID_CanonicalizesEmptyCollections(t *testing.T) {
+	nilCollections := structureIDAgent(t, SurfaceValue{
+		Tools: []ToolRef{{ID: "lookup", InputSchema: &tool.Schema{
+			Default: map[string]any{
+				"nested_map":  map[string]any(nil),
+				"nested_list": []any(nil),
+			},
+			AdditionalProperties: []byte(nil),
+		}}},
+	})
+	emptyCollections := structureIDAgent(t, SurfaceValue{
+		FewShot: []FewShotExample{}, Skills: []SkillRef{},
+		Tools: []ToolRef{{ID: "lookup", InputSchema: &tool.Schema{
+			Required: []string{}, Properties: map[string]*tool.Schema{},
+			Default: map[string]any{
+				"nested_map":  map[string]any{},
+				"nested_list": []any{},
+			},
+			Enum: []any{}, Defs: map[string]*tool.Schema{},
+			AdditionalProperties: []byte{},
+		}}},
+	})
+
+	assert.Equal(t, nilCollections.StructureID, emptyCollections.StructureID)
+	assert.Equal(t,
+		"struct_a4862209a83ac6204e1b59c32cf17a4a390f9823fe7b40210e8cc3ee5daf6e5b",
+		emptyCollections.StructureID,
+	)
+}
+
+func structureIDAgent(t *testing.T, toolValue SurfaceValue) *Snapshot {
+	t.Helper()
+	text := "instruction"
+	snapshot, err := Export(context.Background(), &customExporterAgent{
+		testAgent: &testAgent{name: "root"},
+		snapshot: &Snapshot{
+			EntryNodeID: "root",
+			Nodes:       []Node{{NodeID: "root", Kind: NodeKindAgent, Name: "root"}},
+			Surfaces: []Surface{
+				{NodeID: "root", Type: SurfaceTypeInstruction, Value: SurfaceValue{Text: &text}},
+				{NodeID: "root", Type: SurfaceTypeFewShot, Value: SurfaceValue{FewShot: []FewShotExample{}}},
+				{NodeID: "root", Type: SurfaceTypeTool, Value: toolValue},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return snapshot
 }
 
 func TestExport_StructureID_ChangesWhenNodeChanges(t *testing.T) {

--- a/evaluation/workflow/promptiter/regression/attribution.go
+++ b/evaluation/workflow/promptiter/regression/attribution.go
@@ -1,0 +1,357 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FailureCategory is the primary, deterministic cause assigned to a failed case.
+type FailureCategory string
+
+const (
+	FailureExecutionError       FailureCategory = "execution_error"
+	FailureRouteError           FailureCategory = "route_error"
+	FailureToolCallError        FailureCategory = "tool_call_error"
+	FailureToolArgumentError    FailureCategory = "tool_argument_error"
+	FailureFormatError          FailureCategory = "format_error"
+	FailureKnowledgeRecall      FailureCategory = "knowledge_recall_insufficient"
+	FailureFinalResponse        FailureCategory = "final_response_mismatch"
+	FailureOtherEvaluationError FailureCategory = "other_evaluation_failure"
+)
+
+// Failure explains why one case failed.
+type Failure struct {
+	CaseID      string          `json:"case_id"`
+	Category    FailureCategory `json:"category"`
+	MetricNames []string        `json:"metric_names"`
+	Reason      string          `json:"reason"`
+}
+
+// FailureHint is the bounded feedback supplied to PromptIter.
+type FailureHint struct {
+	CaseID   string          `json:"case_id"`
+	Category FailureCategory `json:"category"`
+	Reason   string          `json:"reason"`
+}
+
+// Attribution contains failures and stable category totals.
+type Attribution struct {
+	Failures []Failure               `json:"failures"`
+	Counts   map[FailureCategory]int `json:"counts"`
+}
+
+// Attribute assigns one primary cause to every failed case.
+func Attribute(summary *EvalSummary) (*Attribution, error) {
+	if summary == nil {
+		return nil, errors.New("evaluation summary is nil")
+	}
+	result := &Attribution{Counts: make(map[FailureCategory]int)}
+	for _, evalCase := range summary.Cases {
+		if evalCase.Passed {
+			continue
+		}
+		failure := attributeCase(evalCase)
+		result.Failures = append(result.Failures, failure)
+		result.Counts[failure.Category]++
+	}
+	sort.Slice(result.Failures, func(i, j int) bool { return result.Failures[i].CaseID < result.Failures[j].CaseID })
+	return result, nil
+}
+
+// Hints converts attribution into concise PromptIter feedback.
+func Hints(attribution *Attribution) ([]FailureHint, error) {
+	if attribution == nil {
+		return nil, errors.New("attribution is nil")
+	}
+	hints := make([]FailureHint, 0, len(attribution.Failures))
+	for _, failure := range attribution.Failures {
+		hints = append(hints, FailureHint{
+			CaseID: failure.CaseID, Category: failure.Category,
+			Reason: truncate(failure.Reason, 512),
+		})
+	}
+	return hints, nil
+}
+
+func attributeCase(evalCase CaseSummary) Failure {
+	failedMetrics := make([]MetricSummary, 0, len(evalCase.Metrics))
+	metricNames := make([]string, 0, len(evalCase.Metrics))
+	for _, metric := range evalCase.Metrics {
+		if metric.Evaluated && !metric.Passed {
+			failedMetrics = append(failedMetrics, metric)
+			metricNames = append(metricNames, metric.Name)
+		}
+	}
+	sort.Strings(metricNames)
+	failure := Failure{CaseID: evalCase.ID, MetricNames: metricNames}
+	switch {
+	case evalCase.Error != "" || routeHasError(evalCase.ActualInvocations):
+		failure.Category = FailureExecutionError
+		failure.Reason = firstNonEmpty(evalCase.Error, firstRouteError(evalCase.ActualInvocations), "execution failed")
+	case routesDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations):
+		failure.Category = FailureRouteError
+		failure.Reason = "actual route does not match expected route"
+	case toolCallsDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations, toolOrderSensitive(failedMetrics)):
+		failure.Category = FailureToolCallError
+		failure.Reason = "actual tool names or order do not match expected trajectory"
+	case toolArgumentsDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations, toolOrderSensitive(failedMetrics)):
+		failure.Category = FailureToolArgumentError
+		failure.Reason = "tool arguments do not match expected arguments"
+	case toolResultsDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations, toolOrderSensitive(failedMetrics)):
+		failure.Category = FailureToolCallError
+		failure.Reason = "tool results do not match expected results"
+	case formatFailure(failedMetrics):
+		failure.Category = FailureFormatError
+		failure.Reason = metricReasonText(failedMetrics, "response format did not satisfy the evaluator")
+	case knowledgeFailure(failedMetrics):
+		failure.Category = FailureKnowledgeRecall
+		failure.Reason = metricReasonText(failedMetrics, "retrieved knowledge was insufficient")
+	case hasCriterion(failedMetrics, "final_response"):
+		failure.Category = FailureFinalResponse
+		failure.Reason = metricReasonText(failedMetrics, "final response did not match the expected result")
+	default:
+		failure.Category = FailureOtherEvaluationError
+		failure.Reason = metricReasonText(failedMetrics, "evaluation failed without a more specific cause")
+	}
+	failure.Reason = truncate(failure.Reason, 1024)
+	return failure
+}
+
+func routeHasError(invocations []InvocationSummary) bool {
+	return firstRouteError(invocations) != ""
+}
+
+func firstRouteError(invocations []InvocationSummary) string {
+	for _, invocation := range invocations {
+		for _, step := range invocation.Route {
+			if strings.TrimSpace(step.Error) != "" {
+				return step.Error
+			}
+		}
+	}
+	return ""
+}
+
+func routesDiffer(actual, expected []InvocationSummary) bool {
+	if len(expected) == 0 {
+		return false
+	}
+	hasExpectedRoute := false
+	for _, invocation := range expected {
+		hasExpectedRoute = hasExpectedRoute || len(invocation.Route) > 0
+	}
+	if !hasExpectedRoute {
+		return false
+	}
+	if len(actual) != len(expected) {
+		return true
+	}
+	for i := range actual {
+		if len(actual[i].Route) != len(expected[i].Route) {
+			return true
+		}
+		for j := range actual[i].Route {
+			left, right := actual[i].Route[j], expected[i].Route[j]
+			if left.Agent != right.Agent || left.Branch != right.Branch || left.NodeID != right.NodeID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func toolCallsDiffer(actual, expected []InvocationSummary, orderSensitive bool) bool {
+	if len(expected) == 0 {
+		return false
+	}
+	if len(actual) != len(expected) {
+		return true
+	}
+	for i := range actual {
+		if len(actual[i].Tools) != len(expected[i].Tools) {
+			return true
+		}
+		actualNames, expectedNames := toolNames(actual[i].Tools), toolNames(expected[i].Tools)
+		if !orderSensitive {
+			sort.Strings(actualNames)
+			sort.Strings(expectedNames)
+		}
+		if strings.Join(actualNames, "\x00") != strings.Join(expectedNames, "\x00") {
+			return true
+		}
+	}
+	return false
+}
+
+func toolArgumentsDiffer(actual, expected []InvocationSummary, orderSensitive bool) bool {
+	if len(expected) == 0 || len(actual) != len(expected) {
+		return false
+	}
+	for i := range actual {
+		if len(actual[i].Tools) != len(expected[i].Tools) {
+			return false
+		}
+		left, right := toolSignatures(actual[i].Tools), toolSignatures(expected[i].Tools)
+		if !orderSensitive {
+			sort.Strings(left)
+			sort.Strings(right)
+		}
+		if strings.Join(left, "\x00") != strings.Join(right, "\x00") {
+			return true
+		}
+	}
+	return false
+}
+
+func toolResultsDiffer(actual, expected []InvocationSummary, orderSensitive bool) bool {
+	if len(expected) == 0 || len(actual) != len(expected) {
+		return false
+	}
+	for i := range actual {
+		if len(actual[i].Tools) != len(expected[i].Tools) {
+			return false
+		}
+		left, right := toolResultSignatures(actual[i].Tools), toolResultSignatures(expected[i].Tools)
+		if !orderSensitive {
+			sort.Strings(left)
+			sort.Strings(right)
+		}
+		if strings.Join(left, "\x00") != strings.Join(right, "\x00") {
+			return true
+		}
+	}
+	return false
+}
+
+func toolOrderSensitive(metrics []MetricSummary) bool {
+	for _, metric := range metrics {
+		if metric.Criterion == "tool_trajectory" && metric.ToolOrderSensitive {
+			return true
+		}
+	}
+	return false
+}
+
+func toolNames(tools []ToolSummary) []string {
+	result := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		result = append(result, tool.Name)
+	}
+	return result
+}
+
+func toolSignatures(tools []ToolSummary) []string {
+	result := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		var value any
+		if json.Unmarshal(tool.Arguments, &value) == nil {
+			canonical, _ := json.Marshal(value)
+			result = append(result, tool.Name+"\x00"+string(canonical))
+		} else {
+			result = append(result, tool.Name+"\x00"+string(tool.Arguments))
+		}
+	}
+	return result
+}
+
+func toolResultSignatures(tools []ToolSummary) []string {
+	result := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		result = append(result, tool.Name+"\x00"+canonicalJSON(tool.Arguments)+"\x00"+canonicalJSON(tool.Result))
+	}
+	return result
+}
+
+func canonicalJSON(raw json.RawMessage) string {
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return string(raw)
+	}
+	canonical, _ := json.Marshal(value)
+	return string(canonical)
+}
+
+func formatFailure(metrics []MetricSummary) bool {
+	for _, metric := range metrics {
+		if structuredFieldMatches(metric, []string{"format", "json", "xml", "schema", "structured"}) {
+			return true
+		}
+		reason := strings.ToLower(metric.Reason)
+		for _, phrase := range []string{"invalid json", "json schema", "invalid xml", "output format", "structured output", "format mismatch"} {
+			if strings.Contains(reason, phrase) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func knowledgeFailure(metrics []MetricSummary) bool {
+	for _, metric := range metrics {
+		if structuredFieldMatches(metric, []string{"knowledge", "recall", "grounding", "context", "citation"}) {
+			return true
+		}
+		reason := strings.ToLower(metric.Reason)
+		for _, phrase := range []string{"retrieved context", "missing citation", "insufficient context", "knowledge recall", "not grounded"} {
+			if strings.Contains(reason, phrase) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func structuredFieldMatches(metric MetricSummary, wanted []string) bool {
+	fields := append([]string{metric.Name, metric.Criterion}, metric.RubricTypes...)
+	for _, field := range fields {
+		tokens := strings.FieldsFunc(strings.ToLower(field), func(r rune) bool {
+			return r == '_' || r == '-' || r == ' ' || r == '/' || r == '.'
+		})
+		for _, token := range tokens {
+			for _, word := range wanted {
+				if token == word {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hasCriterion(metrics []MetricSummary, criterion string) bool {
+	for _, metric := range metrics {
+		if metric.Criterion == criterion {
+			return true
+		}
+	}
+	return false
+}
+
+func metricReasonText(metrics []MetricSummary, fallback string) string {
+	for _, metric := range metrics {
+		if metric.Reason != "" {
+			return fmt.Sprintf("%s: %s", metric.Name, metric.Reason)
+		}
+	}
+	return fallback
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/evaluation/workflow/promptiter/regression/attribution.go
+++ b/evaluation/workflow/promptiter/regression/attribution.go
@@ -40,9 +40,10 @@ type Failure struct {
 
 // FailureHint is the bounded feedback supplied to PromptIter.
 type FailureHint struct {
-	CaseID   string          `json:"case_id"`
-	Category FailureCategory `json:"category"`
-	Reason   string          `json:"reason"`
+	CaseID     string          `json:"case_id"`
+	MetricName string          `json:"metric_name"`
+	Category   FailureCategory `json:"category"`
+	Reason     string          `json:"reason"`
 }
 
 // Attribution contains failures and stable category totals.
@@ -76,10 +77,12 @@ func Hints(attribution *Attribution) ([]FailureHint, error) {
 	}
 	hints := make([]FailureHint, 0, len(attribution.Failures))
 	for _, failure := range attribution.Failures {
-		hints = append(hints, FailureHint{
-			CaseID: failure.CaseID, Category: failure.Category,
-			Reason: truncate(failure.Reason, 512),
-		})
+		for _, metricName := range failure.MetricNames {
+			hints = append(hints, FailureHint{
+				CaseID: failure.CaseID, MetricName: metricName, Category: failure.Category,
+				Reason: truncate(failure.Reason, 512),
+			})
+		}
 	}
 	return hints, nil
 }

--- a/evaluation/workflow/promptiter/regression/attribution.go
+++ b/evaluation/workflow/promptiter/regression/attribution.go
@@ -32,10 +32,11 @@ const (
 
 // Failure explains why one case failed.
 type Failure struct {
-	CaseID      string          `json:"case_id"`
-	Category    FailureCategory `json:"category"`
-	MetricNames []string        `json:"metric_names"`
-	Reason      string          `json:"reason"`
+	CaseID        string            `json:"case_id"`
+	Category      FailureCategory   `json:"category"`
+	MetricNames   []string          `json:"metric_names"`
+	MetricReasons map[string]string `json:"metric_reasons,omitempty"`
+	Reason        string            `json:"reason"`
 }
 
 // FailureHint is the bounded feedback supplied to PromptIter.
@@ -78,9 +79,13 @@ func Hints(attribution *Attribution) ([]FailureHint, error) {
 	hints := make([]FailureHint, 0, len(attribution.Failures))
 	for _, failure := range attribution.Failures {
 		for _, metricName := range failure.MetricNames {
+			reason := failure.MetricReasons[metricName]
+			if strings.TrimSpace(reason) == "" {
+				reason = failure.Reason
+			}
 			hints = append(hints, FailureHint{
 				CaseID: failure.CaseID, MetricName: metricName, Category: failure.Category,
-				Reason: truncate(failure.Reason, 512),
+				Reason: truncate(reason, 512),
 			})
 		}
 	}
@@ -128,7 +133,24 @@ func attributeCase(evalCase CaseSummary) Failure {
 		failure.Reason = metricReasonText(failedMetrics, "evaluation failed without a more specific cause")
 	}
 	failure.Reason = truncate(failure.Reason, 1024)
+	failure.MetricReasons = make(map[string]string, len(failedMetrics))
+	for _, metric := range failedMetrics {
+		reason := failure.Reason
+		if !sharedFailureReason(failure.Category) {
+			reason = firstNonEmpty(metric.Reason, failure.Reason)
+		}
+		failure.MetricReasons[metric.Name] = truncate(reason, 512)
+	}
 	return failure
+}
+
+func sharedFailureReason(category FailureCategory) bool {
+	switch category {
+	case FailureExecutionError, FailureRouteError, FailureToolCallError, FailureToolArgumentError:
+		return true
+	default:
+		return false
+	}
 }
 
 func routeHasError(invocations []InvocationSummary) bool {

--- a/evaluation/workflow/promptiter/regression/attribution.go
+++ b/evaluation/workflow/promptiter/regression/attribution.go
@@ -9,7 +9,6 @@
 package regression
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -102,7 +101,9 @@ func attributeCase(evalCase CaseSummary) Failure {
 		}
 	}
 	sort.Strings(metricNames)
+	sort.Slice(failedMetrics, func(i, j int) bool { return failedMetrics[i].Name < failedMetrics[j].Name })
 	failure := Failure{CaseID: evalCase.ID, MetricNames: metricNames}
+	toolCategory, toolReason, hasToolFailure := attributeToolFailure(failedMetrics)
 	switch {
 	case evalCase.Error != "" || routeHasError(evalCase.ActualInvocations):
 		failure.Category = FailureExecutionError
@@ -110,15 +111,9 @@ func attributeCase(evalCase CaseSummary) Failure {
 	case routesDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations):
 		failure.Category = FailureRouteError
 		failure.Reason = "actual route does not match expected route"
-	case toolCallsDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations, toolOrderSensitive(failedMetrics)):
-		failure.Category = FailureToolCallError
-		failure.Reason = "actual tool names or order do not match expected trajectory"
-	case toolArgumentsDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations, toolOrderSensitive(failedMetrics)):
-		failure.Category = FailureToolArgumentError
-		failure.Reason = "tool arguments do not match expected arguments"
-	case toolResultsDiffer(evalCase.ActualInvocations, evalCase.ExpectedInvocations, toolOrderSensitive(failedMetrics)):
-		failure.Category = FailureToolCallError
-		failure.Reason = "tool results do not match expected results"
+	case hasToolFailure:
+		failure.Category = toolCategory
+		failure.Reason = toolReason
 	case formatFailure(failedMetrics):
 		failure.Category = FailureFormatError
 		failure.Reason = metricReasonText(failedMetrics, "response format did not satisfy the evaluator")
@@ -196,115 +191,26 @@ func routesDiffer(actual, expected []InvocationSummary) bool {
 	return false
 }
 
-func toolCallsDiffer(actual, expected []InvocationSummary, orderSensitive bool) bool {
-	if len(expected) == 0 {
-		return false
-	}
-	if len(actual) != len(expected) {
-		return true
-	}
-	for i := range actual {
-		if len(actual[i].Tools) != len(expected[i].Tools) {
-			return true
-		}
-		actualNames, expectedNames := toolNames(actual[i].Tools), toolNames(expected[i].Tools)
-		if !orderSensitive {
-			sort.Strings(actualNames)
-			sort.Strings(expectedNames)
-		}
-		if strings.Join(actualNames, "\x00") != strings.Join(expectedNames, "\x00") {
-			return true
-		}
-	}
-	return false
-}
-
-func toolArgumentsDiffer(actual, expected []InvocationSummary, orderSensitive bool) bool {
-	if len(expected) == 0 || len(actual) != len(expected) {
-		return false
-	}
-	for i := range actual {
-		if len(actual[i].Tools) != len(expected[i].Tools) {
-			return false
-		}
-		left, right := toolSignatures(actual[i].Tools), toolSignatures(expected[i].Tools)
-		if !orderSensitive {
-			sort.Strings(left)
-			sort.Strings(right)
-		}
-		if strings.Join(left, "\x00") != strings.Join(right, "\x00") {
-			return true
-		}
-	}
-	return false
-}
-
-func toolResultsDiffer(actual, expected []InvocationSummary, orderSensitive bool) bool {
-	if len(expected) == 0 || len(actual) != len(expected) {
-		return false
-	}
-	for i := range actual {
-		if len(actual[i].Tools) != len(expected[i].Tools) {
-			return false
-		}
-		left, right := toolResultSignatures(actual[i].Tools), toolResultSignatures(expected[i].Tools)
-		if !orderSensitive {
-			sort.Strings(left)
-			sort.Strings(right)
-		}
-		if strings.Join(left, "\x00") != strings.Join(right, "\x00") {
-			return true
-		}
-	}
-	return false
-}
-
-func toolOrderSensitive(metrics []MetricSummary) bool {
+func attributeToolFailure(metrics []MetricSummary) (FailureCategory, string, bool) {
+	var toolMetrics []MetricSummary
 	for _, metric := range metrics {
-		if metric.Criterion == "tool_trajectory" && metric.ToolOrderSensitive {
-			return true
+		if metric.Criterion == "tool_trajectory" {
+			toolMetrics = append(toolMetrics, metric)
 		}
 	}
-	return false
-}
-
-func toolNames(tools []ToolSummary) []string {
-	result := make([]string, 0, len(tools))
-	for _, tool := range tools {
-		result = append(result, tool.Name)
+	if len(toolMetrics) == 0 {
+		return "", "", false
 	}
-	return result
-}
-
-func toolSignatures(tools []ToolSummary) []string {
-	result := make([]string, 0, len(tools))
-	for _, tool := range tools {
-		var value any
-		if json.Unmarshal(tool.Arguments, &value) == nil {
-			canonical, _ := json.Marshal(value)
-			result = append(result, tool.Name+"\x00"+string(canonical))
-		} else {
-			result = append(result, tool.Name+"\x00"+string(tool.Arguments))
+	for _, metric := range toolMetrics {
+		if strings.Contains(strings.ToLower(metric.Reason), "arguments mismatch") {
+			return FailureToolArgumentError, firstNonEmpty(
+				metric.Reason, "tool trajectory arguments did not satisfy the evaluator",
+			), true
 		}
 	}
-	return result
-}
-
-func toolResultSignatures(tools []ToolSummary) []string {
-	result := make([]string, 0, len(tools))
-	for _, tool := range tools {
-		result = append(result, tool.Name+"\x00"+canonicalJSON(tool.Arguments)+"\x00"+canonicalJSON(tool.Result))
-	}
-	return result
-}
-
-func canonicalJSON(raw json.RawMessage) string {
-	var value any
-	if json.Unmarshal(raw, &value) != nil {
-		return string(raw)
-	}
-	canonical, _ := json.Marshal(value)
-	return string(canonical)
+	return FailureToolCallError, firstNonEmpty(
+		toolMetrics[0].Reason, "tool trajectory did not satisfy the evaluator",
+	), true
 }
 
 func formatFailure(metrics []MetricSummary) bool {

--- a/evaluation/workflow/promptiter/regression/attribution_gate_test.go
+++ b/evaluation/workflow/promptiter/regression/attribution_gate_test.go
@@ -1,0 +1,279 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestAttributeCategories(t *testing.T) {
+	tool := func(name, arguments string) ToolSummary {
+		return ToolSummary{Name: name, Arguments: json.RawMessage(arguments)}
+	}
+	invocation := func(tools []ToolSummary, route []RouteStep) []InvocationSummary {
+		return []InvocationSummary{{Tools: tools, Route: route}}
+	}
+	tests := []struct {
+		name     string
+		evalCase CaseSummary
+		want     FailureCategory
+	}{
+		{name: "execution", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+			c.Error = "runner stopped"
+		}), want: FailureExecutionError},
+		{name: "step error", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+			c.ActualInvocations = invocation(nil, []RouteStep{{Error: "tool failed"}})
+		}), want: FailureExecutionError},
+		{name: "route", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+			c.ActualInvocations = invocation(nil, []RouteStep{{Agent: "wrong"}})
+			c.ExpectedInvocations = invocation(nil, []RouteStep{{Agent: "right"}})
+		}), want: FailureRouteError},
+		{name: "tool call", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+			c.ActualInvocations = invocation([]ToolSummary{tool("search", `{}`)}, nil)
+			c.ExpectedInvocations = invocation([]ToolSummary{tool("lookup", `{}`)}, nil)
+		}), want: FailureToolCallError},
+		{name: "tool arguments", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+			c.ActualInvocations = invocation([]ToolSummary{tool("search", `{"q":"go"}`)}, nil)
+			c.ExpectedInvocations = invocation([]ToolSummary{tool("search", `{"q":"rust"}`)}, nil)
+		}), want: FailureToolArgumentError},
+		{name: "tool result", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+			c.ActualInvocations = invocation([]ToolSummary{{Name: "search", Arguments: json.RawMessage(`{"q":"go"}`), Result: json.RawMessage(`{"answer":"wrong"}`)}}, nil)
+			c.ExpectedInvocations = invocation([]ToolSummary{{Name: "search", Arguments: json.RawMessage(`{"q":"go"}`), Result: json.RawMessage(`{"answer":"right"}`)}}, nil)
+		}), want: FailureToolCallError},
+		{name: "format", evalCase: failedCase("case", MetricSummary{
+			Name: "judge", Evaluated: true, RubricTypes: []string{"JSON format"}, Reason: "invalid schema",
+		}, nil), want: FailureFormatError},
+		{name: "knowledge", evalCase: failedCase("case", MetricSummary{
+			Name: "grounding", Evaluated: true, Reason: "missing citation",
+		}, nil), want: FailureKnowledgeRecall},
+		{name: "information is not format", evalCase: failedCase("case", MetricSummary{
+			Name: "answer", Evaluated: true, Reason: "missing information from retrieved context",
+		}, nil), want: FailureKnowledgeRecall},
+		{name: "final response", evalCase: failedCase("case", MetricSummary{
+			Name: "answer", Evaluated: true, Criterion: "final_response", Reason: "wrong answer",
+		}, nil), want: FailureFinalResponse},
+		{name: "fallback", evalCase: failedCase("case", MetricSummary{Name: "custom", Evaluated: true}, nil), want: FailureOtherEvaluationError},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attribution, err := Attribute(&EvalSummary{Cases: []CaseSummary{test.evalCase}})
+			if err != nil {
+				t.Fatalf("Attribute() error = %v", err)
+			}
+			if got := attribution.Failures[0].Category; got != test.want {
+				t.Fatalf("category = %q, want %q", got, test.want)
+			}
+			if attribution.Failures[0].Reason == "" || attribution.Counts[test.want] != 1 {
+				t.Fatalf("attribution = %+v", attribution)
+			}
+		})
+	}
+}
+
+func TestAttributeSkipsPassedCasesAndBuildsHints(t *testing.T) {
+	summary := &EvalSummary{Cases: []CaseSummary{
+		{ID: "passed", Passed: true},
+		failedCase("failed", MetricSummary{Name: "answer", Evaluated: true, Criterion: "final_response", Reason: strings.Repeat("x", 800)}, nil),
+	}}
+	attribution, err := Attribute(summary)
+	if err != nil {
+		t.Fatalf("Attribute() error = %v", err)
+	}
+	hints, err := Hints(attribution)
+	if err != nil {
+		t.Fatalf("Hints() error = %v", err)
+	}
+	if len(hints) != 1 || hints[0].CaseID != "failed" || len([]rune(hints[0].Reason)) > 530 {
+		t.Fatalf("hints = %+v", hints)
+	}
+}
+
+func TestAttributeSortsCasesAndBuildsOneHintPerFailedMetric(t *testing.T) {
+	if _, err := Attribute(nil); err == nil {
+		t.Fatal("Attribute(nil) error = nil")
+	}
+	if _, err := Hints(nil); err == nil {
+		t.Fatal("Hints(nil) error = nil")
+	}
+	summary := &EvalSummary{Cases: []CaseSummary{
+		failedCase("z", MetricSummary{Name: "b", Evaluated: true, Reason: strings.Repeat("x", 800)}, nil),
+		failedCase("a", MetricSummary{Name: "a", Evaluated: true, Reason: "bad"}, nil),
+	}}
+	summary.Cases[0].Metrics = append(summary.Cases[0].Metrics, MetricSummary{Name: "a", Evaluated: true, Reason: "also bad"})
+	attribution, err := Attribute(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hints, err := Hints(attribution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attribution.Failures[0].CaseID != "a" || len(hints) != 3 || len([]rune(hints[1].Reason)) > 530 {
+		t.Fatalf("attribution=%+v hints=%+v", attribution, hints)
+	}
+}
+
+func TestToolComparisonKeepsArgumentsAndResultsAssociated(t *testing.T) {
+	tool := func(argument, result string) ToolSummary {
+		return ToolSummary{Name: "search", Arguments: json.RawMessage(argument), Result: json.RawMessage(result)}
+	}
+	paired := []ToolSummary{tool(`{"q":"a"}`, `1`), tool(`{"q":"b"}`, `2`)}
+	tests := []struct {
+		name           string
+		actual         []ToolSummary
+		orderSensitive bool
+		wantDifferent  bool
+	}{
+		{name: "result mismatch", actual: []ToolSummary{tool(`{"q":"a"}`, `9`), tool(`{"q":"b"}`, `2`)}, wantDifferent: true},
+		{name: "cross paired", actual: []ToolSummary{tool(`{"q":"a"}`, `2`), tool(`{"q":"b"}`, `1`)}, wantDifferent: true},
+		{name: "order insensitive", actual: []ToolSummary{paired[1], paired[0]}},
+		{name: "order sensitive", actual: []ToolSummary{paired[1], paired[0]}, orderSensitive: true, wantDifferent: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := []InvocationSummary{{Tools: test.actual}}
+			expected := []InvocationSummary{{Tools: paired}}
+			got := toolCallsDiffer(actual, expected, test.orderSensitive) ||
+				toolArgumentsDiffer(actual, expected, test.orderSensitive) ||
+				toolResultsDiffer(actual, expected, test.orderSensitive)
+			if got != test.wantDifferent {
+				t.Fatalf("trajectory differs = %t, want %t", got, test.wantDifferent)
+			}
+		})
+	}
+}
+
+func TestGateAcceptsCandidateAtBoundaries(t *testing.T) {
+	delta := validationDelta(0.1, CaseDelta{
+		ID: "critical", Kind: DeltaImproved, ScoreDelta: 0.1,
+		Metrics: []MetricDelta{{Name: "hard", Kind: DeltaImproved, ScoreDelta: -0.05}},
+	})
+	decision, err := Gate(GatePolicy{
+		MinValidationGain: 0.1, RejectNewHardFail: true, HardMetrics: []string{"hard"},
+		CriticalCases: []string{"critical"}, MaxMetricDrop: 0.05, MaxModelCalls: 2, MaxTokens: 100,
+	}, delta, Cost{ModelCalls: 2, Tokens: 100})
+	if err != nil {
+		t.Fatalf("Gate() error = %v", err)
+	}
+	if !decision.Accepted || len(decision.Reasons) != 0 {
+		t.Fatalf("decision = %+v", decision)
+	}
+}
+
+func TestGateRejectsRegressionsAndBudgets(t *testing.T) {
+	delta := validationDelta(-0.1, CaseDelta{
+		ID: "critical", Kind: DeltaNewlyFailed, ScoreDelta: -0.2,
+		Metrics: []MetricDelta{{Name: "hard", Kind: DeltaNewlyFailed, ScoreDelta: -0.3}},
+	})
+	decision, err := Gate(GatePolicy{
+		RejectNewHardFail: true, HardMetrics: []string{"hard"}, CriticalCases: []string{"critical"},
+		MaxMetricDrop: 0.1, MaxModelCalls: 1, MaxTokens: 10,
+	}, delta, Cost{ModelCalls: 2, Tokens: 11})
+	if err != nil {
+		t.Fatalf("Gate() error = %v", err)
+	}
+	if decision.Accepted || len(decision.Reasons) != 6 {
+		t.Fatalf("decision = %+v", decision)
+	}
+	for _, fragment := range []string{"validation score", "critical case", "hard metric", "dropped", "model calls", "tokens"} {
+		if !containsReason(decision.Reasons, fragment) {
+			t.Fatalf("reasons %v do not contain %q", decision.Reasons, fragment)
+		}
+	}
+}
+
+func TestGateRejectsInvalidPolicyAndMissingConfiguredNames(t *testing.T) {
+	delta := validationDelta(0.1, CaseDelta{ID: "case", Metrics: []MetricDelta{{Name: "metric"}}})
+	tests := []GatePolicy{
+		{MaxMetricDrop: -1},
+		{MaxTokens: -1},
+		{MinValidationGain: math.NaN()},
+		{MaxMetricDrop: math.Inf(1)},
+		{HardMetrics: []string{""}},
+		{HardMetrics: []string{"missing"}},
+		{CriticalCases: []string{"missing"}},
+		{HardMetrics: []string{"metric", "metric"}},
+	}
+	for _, policy := range tests {
+		if _, err := Gate(policy, delta, Cost{}); err == nil {
+			t.Fatalf("Gate(%+v) error = nil", policy)
+		}
+	}
+}
+
+func TestGateRejectsNilDeltaAndNegativeCost(t *testing.T) {
+	if _, err := Gate(GatePolicy{}, nil, Cost{}); err == nil {
+		t.Fatal("Gate(nil) error = nil")
+	}
+	if _, err := Gate(GatePolicy{}, validationDelta(0), Cost{LatencyMS: -1}); err == nil {
+		t.Fatal("Gate(negative cost) error = nil")
+	}
+}
+
+func TestGateRejectsMetricEvaluationStateChanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		metric MetricDelta
+		policy GatePolicy
+		want   string
+	}{
+		{
+			name: "hard metric becomes evaluated failure",
+			metric: MetricDelta{
+				Name: "hard", Kind: DeltaUnchanged, CandidateEvaluated: true, CandidatePassed: false,
+			},
+			policy: GatePolicy{RejectNewHardFail: true, HardMetrics: []string{"hard"}},
+			want:   "hard metric",
+		},
+		{
+			name: "evaluation disappears",
+			metric: MetricDelta{
+				Name: "quality", Kind: DeltaUnchanged, BaselineEvaluated: true, BaselinePassed: true,
+			},
+			policy: GatePolicy{},
+			want:   "no longer evaluated",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			delta := validationDelta(0, CaseDelta{ID: "case", Metrics: []MetricDelta{test.metric}})
+			decision, err := Gate(test.policy, delta, Cost{})
+			if err != nil {
+				t.Fatalf("Gate() error = %v", err)
+			}
+			if decision.Accepted || !containsReason(decision.Reasons, test.want) {
+				t.Fatalf("decision = %+v", decision)
+			}
+		})
+	}
+}
+
+func failedCase(id string, metric MetricSummary, modify func(*CaseSummary)) CaseSummary {
+	result := CaseSummary{ID: id, Metrics: []MetricSummary{metric}}
+	if modify != nil {
+		modify(&result)
+	}
+	return result
+}
+
+func validationDelta(scoreDelta float64, cases ...CaseDelta) *DatasetDelta {
+	return &DatasetDelta{EvalSetID: "validation", ScoreDelta: scoreDelta, Cases: cases}
+}
+
+func containsReason(reasons []string, fragment string) bool {
+	for _, reason := range reasons {
+		if strings.Contains(reason, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/evaluation/workflow/promptiter/regression/attribution_gate_test.go
+++ b/evaluation/workflow/promptiter/regression/attribution_gate_test.go
@@ -122,6 +122,27 @@ func TestAttributeSortsCasesAndBuildsOneHintPerFailedMetric(t *testing.T) {
 	}
 }
 
+func TestHintsPreserveMetricSpecificReasons(t *testing.T) {
+	summary := &EvalSummary{Cases: []CaseSummary{failedCase("case", MetricSummary{
+		Name: "format", Evaluated: true, Reason: "invalid JSON",
+	}, nil)}}
+	summary.Cases[0].Metrics = append(summary.Cases[0].Metrics, MetricSummary{
+		Name: "quality", Evaluated: true, Reason: "missing citation",
+	})
+	attribution, err := Attribute(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hints, err := Hints(attribution)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hints) != 2 || hints[0].MetricName != "format" || hints[0].Reason != "invalid JSON" ||
+		hints[1].MetricName != "quality" || hints[1].Reason != "missing citation" {
+		t.Fatalf("hints = %+v", hints)
+	}
+}
+
 func TestToolComparisonKeepsArgumentsAndResultsAssociated(t *testing.T) {
 	tool := func(argument, result string) ToolSummary {
 		return ToolSummary{Name: "search", Arguments: json.RawMessage(argument), Result: json.RawMessage(result)}

--- a/evaluation/workflow/promptiter/regression/attribution_gate_test.go
+++ b/evaluation/workflow/promptiter/regression/attribution_gate_test.go
@@ -37,18 +37,33 @@ func TestAttributeCategories(t *testing.T) {
 			c.ActualInvocations = invocation(nil, []RouteStep{{Agent: "wrong"}})
 			c.ExpectedInvocations = invocation(nil, []RouteStep{{Agent: "right"}})
 		}), want: FailureRouteError},
-		{name: "tool call", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
+		{name: "tool call", evalCase: failedCase("case", MetricSummary{
+			Name: "tools", Evaluated: true, Criterion: "tool_trajectory",
+			Reason: "number of tool calls mismatch",
+		}, nil), want: FailureToolCallError},
+		{name: "tool arguments", evalCase: failedCase("case", MetricSummary{
+			Name: "tools", Evaluated: true, Criterion: "tool_trajectory",
+			Reason: "match tools: arguments mismatch: values differ",
+		}, nil), want: FailureToolArgumentError},
+		{name: "tool result", evalCase: failedCase("case", MetricSummary{
+			Name: "tools", Evaluated: true, Criterion: "tool_trajectory",
+			Reason: "match tools: result mismatch",
+		}, nil), want: FailureToolCallError},
+		{name: "final response ignores unrelated tool evidence", evalCase: failedCase("case", MetricSummary{
+			Name: "answer", Evaluated: true, Criterion: "final_response", Reason: "wrong answer",
+		}, func(c *CaseSummary) {
 			c.ActualInvocations = invocation([]ToolSummary{tool("search", `{}`)}, nil)
 			c.ExpectedInvocations = invocation([]ToolSummary{tool("lookup", `{}`)}, nil)
-		}), want: FailureToolCallError},
-		{name: "tool arguments", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
-			c.ActualInvocations = invocation([]ToolSummary{tool("search", `{"q":"go"}`)}, nil)
-			c.ExpectedInvocations = invocation([]ToolSummary{tool("search", `{"q":"rust"}`)}, nil)
-		}), want: FailureToolArgumentError},
-		{name: "tool result", evalCase: failedCase("case", MetricSummary{Name: "m", Evaluated: true}, func(c *CaseSummary) {
-			c.ActualInvocations = invocation([]ToolSummary{{Name: "search", Arguments: json.RawMessage(`{"q":"go"}`), Result: json.RawMessage(`{"answer":"wrong"}`)}}, nil)
-			c.ExpectedInvocations = invocation([]ToolSummary{{Name: "search", Arguments: json.RawMessage(`{"q":"go"}`), Result: json.RawMessage(`{"answer":"right"}`)}}, nil)
-		}), want: FailureToolCallError},
+		}), want: FailureFinalResponse},
+		{name: "passed subset or custom tool metric does not override failure", evalCase: failedCase("case", MetricSummary{
+			Name: "answer", Evaluated: true, Criterion: "final_response", Reason: "wrong answer",
+		}, func(c *CaseSummary) {
+			c.Metrics = append(c.Metrics, MetricSummary{
+				Name: "tools", Evaluated: true, Passed: true, Criterion: "tool_trajectory",
+			})
+			c.ActualInvocations = invocation([]ToolSummary{tool("extra", `{}`)}, nil)
+			c.ExpectedInvocations = invocation([]ToolSummary{tool("expected", `{}`)}, nil)
+		}), want: FailureFinalResponse},
 		{name: "format", evalCase: failedCase("case", MetricSummary{
 			Name: "judge", Evaluated: true, RubricTypes: []string{"JSON format"}, Reason: "invalid schema",
 		}, nil), want: FailureFormatError},
@@ -74,6 +89,11 @@ func TestAttributeCategories(t *testing.T) {
 			}
 			if attribution.Failures[0].Reason == "" || attribution.Counts[test.want] != 1 {
 				t.Fatalf("attribution = %+v", attribution)
+			}
+			if strings.HasPrefix(test.name, "tool ") &&
+				attribution.Failures[0].Reason != test.evalCase.Metrics[0].Reason {
+				t.Fatalf("reason = %q, want evaluator reason %q",
+					attribution.Failures[0].Reason, test.evalCase.Metrics[0].Reason)
 			}
 		})
 	}
@@ -140,36 +160,6 @@ func TestHintsPreserveMetricSpecificReasons(t *testing.T) {
 	if len(hints) != 2 || hints[0].MetricName != "format" || hints[0].Reason != "invalid JSON" ||
 		hints[1].MetricName != "quality" || hints[1].Reason != "missing citation" {
 		t.Fatalf("hints = %+v", hints)
-	}
-}
-
-func TestToolComparisonKeepsArgumentsAndResultsAssociated(t *testing.T) {
-	tool := func(argument, result string) ToolSummary {
-		return ToolSummary{Name: "search", Arguments: json.RawMessage(argument), Result: json.RawMessage(result)}
-	}
-	paired := []ToolSummary{tool(`{"q":"a"}`, `1`), tool(`{"q":"b"}`, `2`)}
-	tests := []struct {
-		name           string
-		actual         []ToolSummary
-		orderSensitive bool
-		wantDifferent  bool
-	}{
-		{name: "result mismatch", actual: []ToolSummary{tool(`{"q":"a"}`, `9`), tool(`{"q":"b"}`, `2`)}, wantDifferent: true},
-		{name: "cross paired", actual: []ToolSummary{tool(`{"q":"a"}`, `2`), tool(`{"q":"b"}`, `1`)}, wantDifferent: true},
-		{name: "order insensitive", actual: []ToolSummary{paired[1], paired[0]}},
-		{name: "order sensitive", actual: []ToolSummary{paired[1], paired[0]}, orderSensitive: true, wantDifferent: true},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := []InvocationSummary{{Tools: test.actual}}
-			expected := []InvocationSummary{{Tools: paired}}
-			got := toolCallsDiffer(actual, expected, test.orderSensitive) ||
-				toolArgumentsDiffer(actual, expected, test.orderSensitive) ||
-				toolResultsDiffer(actual, expected, test.orderSensitive)
-			if got != test.wantDifferent {
-				t.Fatalf("trajectory differs = %t, want %t", got, test.wantDifferent)
-			}
-		})
 	}
 }
 

--- a/evaluation/workflow/promptiter/regression/compare.go
+++ b/evaluation/workflow/promptiter/regression/compare.go
@@ -36,6 +36,8 @@ type MetricDelta struct {
 	ScoreDelta         float64   `json:"score_delta"`
 	BaselineEvaluated  bool      `json:"baseline_evaluated"`
 	CandidateEvaluated bool      `json:"candidate_evaluated"`
+	BaselinePassed     bool      `json:"baseline_passed"`
+	CandidatePassed    bool      `json:"candidate_passed"`
 }
 
 // CaseDelta compares one evaluation case.
@@ -128,6 +130,7 @@ func compareCase(baseline, candidate CaseSummary) (CaseDelta, error) {
 		result.Metrics = append(result.Metrics, MetricDelta{
 			Name: name, Kind: kind, BaselineScore: before.Score, CandidateScore: after.Score,
 			ScoreDelta: scoreDelta, BaselineEvaluated: before.Evaluated, CandidateEvaluated: after.Evaluated,
+			BaselinePassed: before.Passed, CandidatePassed: after.Passed,
 		})
 	}
 	return result, nil

--- a/evaluation/workflow/promptiter/regression/compare.go
+++ b/evaluation/workflow/promptiter/regression/compare.go
@@ -1,0 +1,198 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+const scoreDeltaEpsilon = 1e-9
+
+// DeltaKind describes how a candidate changed a result.
+type DeltaKind string
+
+const (
+	DeltaNewlyPassed DeltaKind = "newly_passed"
+	DeltaNewlyFailed DeltaKind = "newly_failed"
+	DeltaImproved    DeltaKind = "improved"
+	DeltaRegressed   DeltaKind = "regressed"
+	DeltaUnchanged   DeltaKind = "unchanged"
+)
+
+// MetricDelta compares one metric.
+type MetricDelta struct {
+	Name               string    `json:"name"`
+	Kind               DeltaKind `json:"kind"`
+	BaselineScore      float64   `json:"baseline_score"`
+	CandidateScore     float64   `json:"candidate_score"`
+	ScoreDelta         float64   `json:"score_delta"`
+	BaselineEvaluated  bool      `json:"baseline_evaluated"`
+	CandidateEvaluated bool      `json:"candidate_evaluated"`
+}
+
+// CaseDelta compares one evaluation case.
+type CaseDelta struct {
+	ID             string        `json:"id"`
+	Kind           DeltaKind     `json:"kind"`
+	BaselineScore  float64       `json:"baseline_score"`
+	CandidateScore float64       `json:"candidate_score"`
+	ScoreDelta     float64       `json:"score_delta"`
+	Metrics        []MetricDelta `json:"metrics"`
+}
+
+// DatasetDelta compares baseline and candidate results for one eval set.
+type DatasetDelta struct {
+	EvalSetID      string      `json:"eval_set_id"`
+	Kind           DeltaKind   `json:"kind"`
+	BaselineScore  float64     `json:"baseline_score"`
+	CandidateScore float64     `json:"candidate_score"`
+	ScoreDelta     float64     `json:"score_delta"`
+	Cases          []CaseDelta `json:"cases"`
+}
+
+// Compare returns deterministic per-dataset, per-case, and per-metric deltas.
+func Compare(baseline, candidate *EvalSummary) (*DatasetDelta, error) {
+	if baseline == nil || candidate == nil {
+		return nil, errors.New("baseline and candidate summaries must not be nil")
+	}
+	if baseline.EvalSetID != candidate.EvalSetID {
+		return nil, fmt.Errorf("eval set mismatch: %q and %q", baseline.EvalSetID, candidate.EvalSetID)
+	}
+	kind, delta, err := classifyDelta(baseline.Score, candidate.Score, baseline.Passed, candidate.Passed)
+	if err != nil {
+		return nil, err
+	}
+	result := &DatasetDelta{
+		EvalSetID: baseline.EvalSetID, Kind: kind, BaselineScore: baseline.Score,
+		CandidateScore: candidate.Score, ScoreDelta: delta,
+	}
+	baselineCases, err := caseIndex(baseline.Cases)
+	if err != nil {
+		return nil, fmt.Errorf("baseline: %w", err)
+	}
+	candidateCases, err := caseIndex(candidate.Cases)
+	if err != nil {
+		return nil, fmt.Errorf("candidate: %w", err)
+	}
+	if err := sameKeys("case", baselineCases, candidateCases); err != nil {
+		return nil, err
+	}
+	ids := sortedKeys(baselineCases)
+	for _, id := range ids {
+		item, err := compareCase(baselineCases[id], candidateCases[id])
+		if err != nil {
+			return nil, fmt.Errorf("compare case %q: %w", id, err)
+		}
+		result.Cases = append(result.Cases, item)
+	}
+	return result, nil
+}
+
+func compareCase(baseline, candidate CaseSummary) (CaseDelta, error) {
+	kind, delta, err := classifyDelta(baseline.Score, candidate.Score, baseline.Passed, candidate.Passed)
+	if err != nil {
+		return CaseDelta{}, err
+	}
+	result := CaseDelta{
+		ID: baseline.ID, Kind: kind, BaselineScore: baseline.Score,
+		CandidateScore: candidate.Score, ScoreDelta: delta,
+	}
+	baselineMetrics, err := metricIndex(baseline.Metrics)
+	if err != nil {
+		return CaseDelta{}, fmt.Errorf("baseline: %w", err)
+	}
+	candidateMetrics, err := metricIndex(candidate.Metrics)
+	if err != nil {
+		return CaseDelta{}, fmt.Errorf("candidate: %w", err)
+	}
+	if err := sameKeys("metric", baselineMetrics, candidateMetrics); err != nil {
+		return CaseDelta{}, err
+	}
+	for _, name := range sortedKeys(baselineMetrics) {
+		before, after := baselineMetrics[name], candidateMetrics[name]
+		kind, scoreDelta, err := classifyDelta(before.Score, after.Score, before.Passed, after.Passed)
+		if err != nil {
+			return CaseDelta{}, fmt.Errorf("metric %q: %w", name, err)
+		}
+		if !before.Evaluated && !after.Evaluated {
+			kind = DeltaUnchanged
+		}
+		result.Metrics = append(result.Metrics, MetricDelta{
+			Name: name, Kind: kind, BaselineScore: before.Score, CandidateScore: after.Score,
+			ScoreDelta: scoreDelta, BaselineEvaluated: before.Evaluated, CandidateEvaluated: after.Evaluated,
+		})
+	}
+	return result, nil
+}
+
+func classifyDelta(baseline, candidate float64, baselinePassed, candidatePassed bool) (DeltaKind, float64, error) {
+	if !finite(baseline) || !finite(candidate) || !finite(candidate-baseline) {
+		return "", 0, errors.New("scores must be finite")
+	}
+	delta := candidate - baseline
+	switch {
+	case !baselinePassed && candidatePassed:
+		return DeltaNewlyPassed, delta, nil
+	case baselinePassed && !candidatePassed:
+		return DeltaNewlyFailed, delta, nil
+	case delta > scoreDeltaEpsilon:
+		return DeltaImproved, delta, nil
+	case delta < -scoreDeltaEpsilon:
+		return DeltaRegressed, delta, nil
+	default:
+		return DeltaUnchanged, delta, nil
+	}
+}
+
+func caseIndex(items []CaseSummary) (map[string]CaseSummary, error) {
+	result := make(map[string]CaseSummary, len(items))
+	for _, item := range items {
+		if item.ID == "" {
+			return nil, errors.New("case has no id")
+		}
+		if _, ok := result[item.ID]; ok {
+			return nil, fmt.Errorf("duplicate case %q", item.ID)
+		}
+		result[item.ID] = item
+	}
+	return result, nil
+}
+
+func metricIndex(items []MetricSummary) (map[string]MetricSummary, error) {
+	result := make(map[string]MetricSummary, len(items))
+	for _, item := range items {
+		if item.Name == "" {
+			return nil, errors.New("metric has no name")
+		}
+		if _, ok := result[item.Name]; ok {
+			return nil, fmt.Errorf("duplicate metric %q", item.Name)
+		}
+		result[item.Name] = item
+	}
+	return result, nil
+}
+
+func sameKeys[T any](kind string, left, right map[string]T) error {
+	leftKeys, rightKeys := sortedKeys(left), sortedKeys(right)
+	if fmt.Sprint(leftKeys) != fmt.Sprint(rightKeys) {
+		return fmt.Errorf("%s sets differ: %v and %v", kind, leftKeys, rightKeys)
+	}
+	return nil
+}
+
+func sortedKeys[T any](items map[string]T) []string {
+	keys := make([]string, 0, len(items))
+	for key := range items {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/evaluation/workflow/promptiter/regression/gate.go
+++ b/evaluation/workflow/promptiter/regression/gate.go
@@ -22,8 +22,11 @@ type GatePolicy struct {
 	HardMetrics       []string `json:"hard_metrics,omitempty"`
 	CriticalCases     []string `json:"critical_cases,omitempty"`
 	MaxMetricDrop     float64  `json:"max_metric_drop"`
-	MaxModelCalls     int      `json:"max_model_calls,omitempty"`
-	MaxTokens         int64    `json:"max_tokens,omitempty"`
+	// MaxModelCalls limits candidate acceptance by cumulative run calls. It
+	// includes baseline and all attempted rounds; zero disables the check.
+	MaxModelCalls int `json:"max_model_calls,omitempty"`
+	// MaxTokens applies the same cumulative acceptance limit to tokens.
+	MaxTokens int64 `json:"max_tokens,omitempty"`
 }
 
 // GateDecision records whether a candidate may replace the current prompt.
@@ -32,15 +35,15 @@ type GateDecision struct {
 	Reasons  []string `json:"reasons"`
 }
 
-// Gate evaluates validation quality and candidate serving cost.
-func Gate(policy GatePolicy, validation *DatasetDelta, cost Cost) (*GateDecision, error) {
+// Gate evaluates validation quality and projected cumulative run cost.
+func Gate(policy GatePolicy, validation *DatasetDelta, runCost Cost) (*GateDecision, error) {
 	if validation == nil {
 		return nil, errors.New("validation delta is nil")
 	}
 	if err := validatePolicy(policy); err != nil {
 		return nil, err
 	}
-	if cost.ModelCalls < 0 || cost.Tokens < 0 || cost.LatencyMS < 0 {
+	if runCost.ModelCalls < 0 || runCost.Tokens < 0 || runCost.LatencyMS < 0 {
 		return nil, errors.New("candidate cost must not be negative")
 	}
 	decision := &GateDecision{}
@@ -87,11 +90,11 @@ func Gate(policy GatePolicy, validation *DatasetDelta, cost Cost) (*GateDecision
 	if missing := missingNames(policy.CriticalCases, foundCases); len(missing) > 0 {
 		return nil, fmt.Errorf("critical cases not present in validation delta: %v", missing)
 	}
-	if policy.MaxModelCalls > 0 && cost.ModelCalls > policy.MaxModelCalls {
-		decision.Reasons = append(decision.Reasons, fmt.Sprintf("model calls %d exceed budget %d", cost.ModelCalls, policy.MaxModelCalls))
+	if policy.MaxModelCalls > 0 && runCost.ModelCalls > policy.MaxModelCalls {
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf("model calls %d exceed budget %d", runCost.ModelCalls, policy.MaxModelCalls))
 	}
-	if policy.MaxTokens > 0 && cost.Tokens > policy.MaxTokens {
-		decision.Reasons = append(decision.Reasons, fmt.Sprintf("tokens %d exceed budget %d", cost.Tokens, policy.MaxTokens))
+	if policy.MaxTokens > 0 && runCost.Tokens > policy.MaxTokens {
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf("tokens %d exceed budget %d", runCost.Tokens, policy.MaxTokens))
 	}
 	decision.Accepted = len(decision.Reasons) == 0
 	return decision, nil

--- a/evaluation/workflow/promptiter/regression/gate.go
+++ b/evaluation/workflow/promptiter/regression/gate.go
@@ -1,0 +1,139 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// GatePolicy configures the acceptance requirements for a prompt candidate.
+type GatePolicy struct {
+	MinValidationGain float64  `json:"min_validation_gain"`
+	RejectNewHardFail bool     `json:"reject_new_hard_fail"`
+	HardMetrics       []string `json:"hard_metrics,omitempty"`
+	CriticalCases     []string `json:"critical_cases,omitempty"`
+	MaxMetricDrop     float64  `json:"max_metric_drop"`
+	MaxModelCalls     int      `json:"max_model_calls,omitempty"`
+	MaxTokens         int64    `json:"max_tokens,omitempty"`
+}
+
+// GateDecision records whether a candidate may replace the current prompt.
+type GateDecision struct {
+	Accepted bool     `json:"accepted"`
+	Reasons  []string `json:"reasons"`
+}
+
+// Gate evaluates validation quality and candidate serving cost.
+func Gate(policy GatePolicy, validation *DatasetDelta, cost Cost) (*GateDecision, error) {
+	if validation == nil {
+		return nil, errors.New("validation delta is nil")
+	}
+	if err := validatePolicy(policy); err != nil {
+		return nil, err
+	}
+	if cost.ModelCalls < 0 || cost.Tokens < 0 || cost.LatencyMS < 0 {
+		return nil, errors.New("candidate cost must not be negative")
+	}
+	decision := &GateDecision{}
+	if validation.ScoreDelta+scoreDeltaEpsilon < policy.MinValidationGain {
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf(
+			"validation score gain %.6f is below required %.6f", validation.ScoreDelta, policy.MinValidationGain,
+		))
+	}
+	hardMetrics := stringSet(policy.HardMetrics)
+	criticalCases := stringSet(policy.CriticalCases)
+	foundMetrics := make(map[string]bool)
+	foundCases := make(map[string]bool)
+	for _, evalCase := range validation.Cases {
+		if _, ok := criticalCases[evalCase.ID]; ok {
+			foundCases[evalCase.ID] = true
+			if evalCase.Kind == DeltaNewlyFailed || evalCase.ScoreDelta < -scoreDeltaEpsilon {
+				decision.Reasons = append(decision.Reasons, fmt.Sprintf("critical case %q regressed", evalCase.ID))
+			}
+		}
+		for _, metric := range evalCase.Metrics {
+			if metric.BaselineEvaluated && !metric.CandidateEvaluated {
+				decision.Reasons = append(decision.Reasons, fmt.Sprintf(
+					"metric %q in case %q is no longer evaluated", metric.Name, evalCase.ID,
+				))
+			}
+			if _, ok := hardMetrics[metric.Name]; ok {
+				foundMetrics[metric.Name] = true
+				newHardFail := metric.Kind == DeltaNewlyFailed ||
+					(!metric.BaselineEvaluated && metric.CandidateEvaluated && !metric.CandidatePassed)
+				if policy.RejectNewHardFail && newHardFail {
+					decision.Reasons = append(decision.Reasons, fmt.Sprintf("hard metric %q newly failed in case %q", metric.Name, evalCase.ID))
+				}
+			}
+			if metric.ScoreDelta < -policy.MaxMetricDrop-scoreDeltaEpsilon {
+				decision.Reasons = append(decision.Reasons, fmt.Sprintf(
+					"metric %q in case %q dropped %.6f", metric.Name, evalCase.ID, -metric.ScoreDelta,
+				))
+			}
+		}
+	}
+	if missing := missingNames(policy.HardMetrics, foundMetrics); len(missing) > 0 {
+		return nil, fmt.Errorf("hard metrics not present in validation delta: %v", missing)
+	}
+	if missing := missingNames(policy.CriticalCases, foundCases); len(missing) > 0 {
+		return nil, fmt.Errorf("critical cases not present in validation delta: %v", missing)
+	}
+	if policy.MaxModelCalls > 0 && cost.ModelCalls > policy.MaxModelCalls {
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf("model calls %d exceed budget %d", cost.ModelCalls, policy.MaxModelCalls))
+	}
+	if policy.MaxTokens > 0 && cost.Tokens > policy.MaxTokens {
+		decision.Reasons = append(decision.Reasons, fmt.Sprintf("tokens %d exceed budget %d", cost.Tokens, policy.MaxTokens))
+	}
+	decision.Accepted = len(decision.Reasons) == 0
+	return decision, nil
+}
+
+func validatePolicy(policy GatePolicy) error {
+	if !finite(policy.MinValidationGain) || !finite(policy.MaxMetricDrop) {
+		return errors.New("gate score thresholds must be finite")
+	}
+	if policy.MaxMetricDrop < 0 || policy.MaxModelCalls < 0 || policy.MaxTokens < 0 {
+		return errors.New("gate budgets must not be negative")
+	}
+	for kind, names := range map[string][]string{"hard metric": policy.HardMetrics, "critical case": policy.CriticalCases} {
+		seen := make(map[string]struct{})
+		for _, name := range names {
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("%s name is empty", kind)
+			}
+			if _, ok := seen[name]; ok {
+				return fmt.Errorf("duplicate %s %q", kind, name)
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func stringSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func missingNames(configured []string, found map[string]bool) []string {
+	var missing []string
+	for _, name := range configured {
+		if !found[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/evaluation/workflow/promptiter/regression/pipeline.go
+++ b/evaluation/workflow/promptiter/regression/pipeline.go
@@ -55,18 +55,18 @@ type RunRequest struct {
 
 // Round records one candidate and its acceptance evidence.
 type Round struct {
-	Number           int
-	InputPrompt      string
-	CandidatePrompt  string
-	Hints            []FailureHint
-	Train            *EvalSummary
-	Validation       *EvalSummary
-	TrainDelta       *DatasetDelta
-	ValidationDelta  *DatasetDelta
-	Attribution      *Attribution
-	Gate             *GateDecision
-	ServingCost      Cost
-	OptimizationCost Cost
+	Number           int           `json:"number"`
+	InputPrompt      string        `json:"input_prompt"`
+	CandidatePrompt  string        `json:"candidate_prompt"`
+	Hints            []FailureHint `json:"hints"`
+	Train            *EvalSummary  `json:"train"`
+	Validation       *EvalSummary  `json:"validation"`
+	TrainDelta       *DatasetDelta `json:"train_delta"`
+	ValidationDelta  *DatasetDelta `json:"validation_delta"`
+	Attribution      *Attribution  `json:"validation_attribution"`
+	Gate             *GateDecision `json:"gate"`
+	ServingCost      Cost          `json:"serving_cost"`
+	OptimizationCost Cost          `json:"optimization_cost"`
 }
 
 // OptimizationRun is the complete in-memory result consumed by audit reports.

--- a/evaluation/workflow/promptiter/regression/pipeline.go
+++ b/evaluation/workflow/promptiter/regression/pipeline.go
@@ -175,11 +175,11 @@ func Run(ctx context.Context, request RunRequest, evaluate EvaluateFunc, generat
 		if err != nil {
 			return nil, fmt.Errorf("serving cost round %d: %w", roundNumber, err)
 		}
-		gateCost, err := addCosts(servingCost, candidate.Cost)
+		projectedTotalCost, err := addCosts(run.TotalCost, servingCost, candidate.Cost)
 		if err != nil {
-			return nil, fmt.Errorf("gate cost round %d: %w", roundNumber, err)
+			return nil, fmt.Errorf("projected total cost round %d: %w", roundNumber, err)
 		}
-		decision, err := Gate(request.GatePolicy, validationDelta, gateCost)
+		decision, err := Gate(request.GatePolicy, validationDelta, projectedTotalCost)
 		if err != nil {
 			return nil, fmt.Errorf("gate round %d: %w", roundNumber, err)
 		}
@@ -205,10 +205,7 @@ func Run(ctx context.Context, request RunRequest, evaluate EvaluateFunc, generat
 			TrainAttribution: trainAttribution, Attribution: validationAttribution,
 			Gate: decision, ServingCost: servingCost, OptimizationCost: candidate.Cost,
 		})
-		run.TotalCost, err = addCosts(run.TotalCost, servingCost, candidate.Cost)
-		if err != nil {
-			return nil, fmt.Errorf("total cost round %d: %w", roundNumber, err)
-		}
+		run.TotalCost = projectedTotalCost
 		if decision.Accepted {
 			run.AcceptedPrompt = candidate.Prompt
 			run.AcceptedTrain = candidateTrain

--- a/evaluation/workflow/promptiter/regression/pipeline.go
+++ b/evaluation/workflow/promptiter/regression/pipeline.go
@@ -1,0 +1,286 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+)
+
+// EvaluationOutput is one Evaluation Service result and its runtime-observed cost.
+type EvaluationOutput struct {
+	Result *evaluation.EvaluationResult
+	Cost   Cost
+}
+
+// EvaluateFunc evaluates one prompt against one configured eval set.
+type EvaluateFunc func(context.Context, string, string, int64) (*EvaluationOutput, error)
+
+// CandidateRequest contains the accepted prompt and its current training failures.
+type CandidateRequest struct {
+	Prompt string
+	Hints  []FailureHint
+	Round  int
+	Seed   int64
+}
+
+// Candidate is a generated prompt and its runtime-observed optimization cost.
+type Candidate struct {
+	Prompt string
+	Cost   Cost
+}
+
+// GenerateFunc generates one prompt candidate.
+type GenerateFunc func(context.Context, CandidateRequest) (*Candidate, error)
+
+// RunRequest configures one complete regression loop.
+type RunRequest struct {
+	InitialPrompt       string
+	TrainEvalSetID      string
+	ValidationEvalSetID string
+	GatePolicy          GatePolicy
+	MaxRounds           int
+	Seed                int64
+}
+
+// Round records one candidate and its acceptance evidence.
+type Round struct {
+	Number           int
+	InputPrompt      string
+	CandidatePrompt  string
+	Hints            []FailureHint
+	Train            *EvalSummary
+	Validation       *EvalSummary
+	TrainDelta       *DatasetDelta
+	ValidationDelta  *DatasetDelta
+	Attribution      *Attribution
+	Gate             *GateDecision
+	ServingCost      Cost
+	OptimizationCost Cost
+}
+
+// OptimizationRun is the complete in-memory result consumed by audit reports.
+type OptimizationRun struct {
+	InitialPrompt        string
+	AcceptedPrompt       string
+	BaselineTrain        *EvalSummary
+	BaselineValidation   *EvalSummary
+	AcceptedTrain        *EvalSummary
+	AcceptedValidation   *EvalSummary
+	Rounds               []Round
+	TotalCost            Cost
+	WriteBackRecommended bool
+	StopReason           string
+	Seed                 int64
+}
+
+// Run executes baseline evaluation, candidate generation, regression, and gating.
+func Run(ctx context.Context, request RunRequest, evaluate EvaluateFunc, generate GenerateFunc) (*OptimizationRun, error) {
+	if err := validateRunRequest(request, evaluate, generate); err != nil {
+		return nil, err
+	}
+	baselineTrain, baselineTrainCost, err := evaluateSummary(ctx, evaluate, request.InitialPrompt, request.TrainEvalSetID, request.Seed)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate baseline train: %w", err)
+	}
+	baselineValidation, baselineValidationCost, err := evaluateSummary(
+		ctx, evaluate, request.InitialPrompt, request.ValidationEvalSetID, request.Seed,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("evaluate baseline validation: %w", err)
+	}
+	totalCost, err := addCosts(baselineTrainCost, baselineValidationCost)
+	if err != nil {
+		return nil, fmt.Errorf("baseline cost: %w", err)
+	}
+	run := &OptimizationRun{
+		InitialPrompt: request.InitialPrompt, AcceptedPrompt: request.InitialPrompt,
+		BaselineTrain: baselineTrain, BaselineValidation: baselineValidation,
+		AcceptedTrain: baselineTrain, AcceptedValidation: baselineValidation,
+		Rounds: make([]Round, 0, request.MaxRounds), TotalCost: totalCost, Seed: request.Seed,
+	}
+
+	for roundNumber := 1; roundNumber <= request.MaxRounds; roundNumber++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		attribution, err := Attribute(run.AcceptedTrain)
+		if err != nil {
+			return nil, fmt.Errorf("attribute train round %d: %w", roundNumber, err)
+		}
+		hints, err := Hints(attribution)
+		if err != nil {
+			return nil, fmt.Errorf("build hints round %d: %w", roundNumber, err)
+		}
+		if len(hints) == 0 {
+			run.StopReason = "no optimizable training failures"
+			break
+		}
+		candidate, err := generate(ctx, CandidateRequest{
+			Prompt: run.AcceptedPrompt, Hints: append([]FailureHint(nil), hints...),
+			Round: roundNumber, Seed: request.Seed,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("generate candidate round %d: %w", roundNumber, err)
+		}
+		if candidate == nil || strings.TrimSpace(candidate.Prompt) == "" {
+			return nil, fmt.Errorf("generate candidate round %d returned no prompt", roundNumber)
+		}
+		if err := validateCost(candidate.Cost); err != nil {
+			return nil, fmt.Errorf("candidate round %d cost: %w", roundNumber, err)
+		}
+		candidateTrain, trainCost, err := evaluateSummary(
+			ctx, evaluate, candidate.Prompt, request.TrainEvalSetID, request.Seed,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate candidate train round %d: %w", roundNumber, err)
+		}
+		candidateValidation, validationCost, err := evaluateSummary(
+			ctx, evaluate, candidate.Prompt, request.ValidationEvalSetID, request.Seed,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate candidate validation round %d: %w", roundNumber, err)
+		}
+		trainDelta, err := Compare(run.AcceptedTrain, candidateTrain)
+		if err != nil {
+			return nil, fmt.Errorf("compare train round %d: %w", roundNumber, err)
+		}
+		validationDelta, err := Compare(run.AcceptedValidation, candidateValidation)
+		if err != nil {
+			return nil, fmt.Errorf("compare validation round %d: %w", roundNumber, err)
+		}
+		if validationDelta.EvalSetID != request.ValidationEvalSetID {
+			return nil, fmt.Errorf("gate round %d received eval set %q, want validation %q",
+				roundNumber, validationDelta.EvalSetID, request.ValidationEvalSetID)
+		}
+		servingCost, err := addCosts(trainCost, validationCost)
+		if err != nil {
+			return nil, fmt.Errorf("serving cost round %d: %w", roundNumber, err)
+		}
+		gateCost, err := addCosts(servingCost, candidate.Cost)
+		if err != nil {
+			return nil, fmt.Errorf("gate cost round %d: %w", roundNumber, err)
+		}
+		decision, err := Gate(request.GatePolicy, validationDelta, gateCost)
+		if err != nil {
+			return nil, fmt.Errorf("gate round %d: %w", roundNumber, err)
+		}
+		validationAttribution, err := Attribute(candidateValidation)
+		if err != nil {
+			return nil, fmt.Errorf("attribute validation round %d: %w", roundNumber, err)
+		}
+		run.Rounds = append(run.Rounds, Round{
+			Number: roundNumber, InputPrompt: run.AcceptedPrompt, CandidatePrompt: candidate.Prompt,
+			Hints: hints, Train: candidateTrain, Validation: candidateValidation,
+			TrainDelta: trainDelta, ValidationDelta: validationDelta, Attribution: validationAttribution,
+			Gate: decision, ServingCost: servingCost, OptimizationCost: candidate.Cost,
+		})
+		run.TotalCost, err = addCosts(run.TotalCost, servingCost, candidate.Cost)
+		if err != nil {
+			return nil, fmt.Errorf("total cost round %d: %w", roundNumber, err)
+		}
+		if decision.Accepted {
+			run.AcceptedPrompt = candidate.Prompt
+			run.AcceptedTrain = candidateTrain
+			run.AcceptedValidation = candidateValidation
+			run.WriteBackRecommended = true
+			run.StopReason = "candidate accepted by regression gate"
+			break
+		}
+	}
+	if run.StopReason == "" {
+		run.StopReason = "maximum rounds reached without an accepted candidate"
+	}
+	return run, nil
+}
+
+func evaluateSummary(
+	ctx context.Context, evaluate EvaluateFunc, prompt, evalSetID string, seed int64,
+) (*EvalSummary, Cost, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, Cost{}, err
+	}
+	output, err := evaluate(ctx, prompt, evalSetID, seed)
+	if err != nil {
+		return nil, Cost{}, err
+	}
+	if output == nil || output.Result == nil {
+		return nil, Cost{}, errors.New("evaluator returned no result")
+	}
+	if err := validateCost(output.Cost); err != nil {
+		return nil, Cost{}, err
+	}
+	summary, err := Summarize(output.Result)
+	if err != nil {
+		return nil, Cost{}, err
+	}
+	if summary.EvalSetID != evalSetID {
+		return nil, Cost{}, fmt.Errorf("evaluator returned eval set %q, want %q", summary.EvalSetID, evalSetID)
+	}
+	// Runtime-observed model calls are authoritative; trace-derived tokens and
+	// latency fill fields that an evaluator wrapper did not observe.
+	if output.Cost.Tokens == 0 {
+		output.Cost.Tokens = summary.Cost.Tokens
+	}
+	if output.Cost.LatencyMS == 0 {
+		output.Cost.LatencyMS = summary.Cost.LatencyMS
+	}
+	summary.Cost = output.Cost
+	return summary, output.Cost, nil
+}
+
+func validateRunRequest(request RunRequest, evaluate EvaluateFunc, generate GenerateFunc) error {
+	switch {
+	case evaluate == nil:
+		return errors.New("evaluator is nil")
+	case generate == nil:
+		return errors.New("candidate generator is nil")
+	case strings.TrimSpace(request.InitialPrompt) == "":
+		return errors.New("initial prompt is empty")
+	case strings.TrimSpace(request.TrainEvalSetID) == "":
+		return errors.New("train eval set id is empty")
+	case strings.TrimSpace(request.ValidationEvalSetID) == "":
+		return errors.New("validation eval set id is empty")
+	case request.TrainEvalSetID == request.ValidationEvalSetID:
+		return errors.New("train and validation eval set ids must differ")
+	case request.MaxRounds <= 0:
+		return errors.New("max rounds must be greater than zero")
+	default:
+		return validatePolicy(request.GatePolicy)
+	}
+}
+
+func validateCost(cost Cost) error {
+	if cost.ModelCalls < 0 || cost.Tokens < 0 || cost.LatencyMS < 0 {
+		return errors.New("cost must not be negative")
+	}
+	return nil
+}
+
+func addCosts(costs ...Cost) (Cost, error) {
+	var result Cost
+	for _, cost := range costs {
+		if err := validateCost(cost); err != nil {
+			return Cost{}, err
+		}
+		if result.ModelCalls > int(^uint(0)>>1)-cost.ModelCalls ||
+			result.Tokens > int64(^uint64(0)>>1)-cost.Tokens ||
+			result.LatencyMS > int64(^uint64(0)>>1)-cost.LatencyMS {
+			return Cost{}, errors.New("cost overflow")
+		}
+		result.ModelCalls += cost.ModelCalls
+		result.Tokens += cost.Tokens
+		result.LatencyMS += cost.LatencyMS
+	}
+	return result, nil
+}

--- a/evaluation/workflow/promptiter/regression/pipeline.go
+++ b/evaluation/workflow/promptiter/regression/pipeline.go
@@ -21,6 +21,9 @@ import (
 type EvaluationOutput struct {
 	Result *evaluation.EvaluationResult
 	Cost   Cost
+	// MetricNames identifies configured metrics when inference fails before
+	// the Evaluation Service can emit per-metric results.
+	MetricNames []string
 }
 
 // EvaluateFunc evaluates one prompt against one configured eval set.
@@ -63,6 +66,7 @@ type Round struct {
 	Validation       *EvalSummary  `json:"validation"`
 	TrainDelta       *DatasetDelta `json:"train_delta"`
 	ValidationDelta  *DatasetDelta `json:"validation_delta"`
+	TrainAttribution *Attribution  `json:"train_attribution"`
 	Attribution      *Attribution  `json:"validation_attribution"`
 	Gate             *GateDecision `json:"gate"`
 	ServingCost      Cost          `json:"serving_cost"`
@@ -108,6 +112,10 @@ func Run(ctx context.Context, request RunRequest, evaluate EvaluateFunc, generat
 		BaselineTrain: baselineTrain, BaselineValidation: baselineValidation,
 		AcceptedTrain: baselineTrain, AcceptedValidation: baselineValidation,
 		Rounds: make([]Round, 0, request.MaxRounds), TotalCost: totalCost, Seed: request.Seed,
+	}
+	if hasExecutionFailure(baselineTrain) || hasExecutionFailure(baselineValidation) {
+		run.StopReason = "baseline evaluation has execution failures"
+		return run, nil
 	}
 
 	for roundNumber := 1; roundNumber <= request.MaxRounds; roundNumber++ {
@@ -175,14 +183,26 @@ func Run(ctx context.Context, request RunRequest, evaluate EvaluateFunc, generat
 		if err != nil {
 			return nil, fmt.Errorf("gate round %d: %w", roundNumber, err)
 		}
+		trainAttribution, err := Attribute(candidateTrain)
+		if err != nil {
+			return nil, fmt.Errorf("attribute train candidate round %d: %w", roundNumber, err)
+		}
 		validationAttribution, err := Attribute(candidateValidation)
 		if err != nil {
 			return nil, fmt.Errorf("attribute validation round %d: %w", roundNumber, err)
 		}
+		if hasExecutionFailure(candidateTrain) {
+			decision.Reasons = append(decision.Reasons, "candidate train evaluation has execution failures")
+		}
+		if hasExecutionFailure(candidateValidation) {
+			decision.Reasons = append(decision.Reasons, "candidate validation evaluation has execution failures")
+		}
+		decision.Accepted = len(decision.Reasons) == 0
 		run.Rounds = append(run.Rounds, Round{
 			Number: roundNumber, InputPrompt: run.AcceptedPrompt, CandidatePrompt: candidate.Prompt,
 			Hints: hints, Train: candidateTrain, Validation: candidateValidation,
-			TrainDelta: trainDelta, ValidationDelta: validationDelta, Attribution: validationAttribution,
+			TrainDelta: trainDelta, ValidationDelta: validationDelta,
+			TrainAttribution: trainAttribution, Attribution: validationAttribution,
 			Gate: decision, ServingCost: servingCost, OptimizationCost: candidate.Cost,
 		})
 		run.TotalCost, err = addCosts(run.TotalCost, servingCost, candidate.Cost)
@@ -204,6 +224,18 @@ func Run(ctx context.Context, request RunRequest, evaluate EvaluateFunc, generat
 	return run, nil
 }
 
+func hasExecutionFailure(summary *EvalSummary) bool {
+	if summary == nil {
+		return false
+	}
+	for _, evalCase := range summary.Cases {
+		if strings.TrimSpace(evalCase.Error) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func evaluateSummary(
 	ctx context.Context, evaluate EvaluateFunc, prompt, evalSetID string, seed int64,
 ) (*EvalSummary, Cost, error) {
@@ -220,7 +252,7 @@ func evaluateSummary(
 	if err := validateCost(output.Cost); err != nil {
 		return nil, Cost{}, err
 	}
-	summary, err := Summarize(output.Result)
+	summary, err := summarize(output.Result, output.MetricNames)
 	if err != nil {
 		return nil, Cost{}, err
 	}

--- a/evaluation/workflow/promptiter/regression/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regression/pipeline_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation"
@@ -96,18 +97,11 @@ func TestRunRejectsWrongEvaluationSetBeforeGate(t *testing.T) {
 }
 
 func TestRunStopsWithoutOptimizableTrainingFailures(t *testing.T) {
-	executionFailure := pipelineResult("train", 1, true)
-	executionFailure.EvalCases[0].RunDetails = []*evaluation.EvaluationCaseRunDetails{{
-		Inference: &evaluation.EvaluationInferenceDetails{
-			Status: status.EvalStatusFailed, ErrorMessage: "runner stopped",
-		},
-	}}
 	tests := []struct {
 		name  string
 		train *evaluation.EvaluationResult
 	}{
 		{name: "all training metrics pass", train: pipelineResult("train", 1, true)},
-		{name: "execution failure without failed metric", train: executionFailure},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -132,6 +126,78 @@ func TestRunStopsWithoutOptimizableTrainingFailures(t *testing.T) {
 			}
 			if run.StopReason != "no optimizable training failures" || run.AcceptedPrompt != "base" {
 				t.Fatalf("run = %+v", run)
+			}
+		})
+	}
+}
+
+func TestRunAuditsBaselineExecutionFailureWithoutGenerating(t *testing.T) {
+	for _, failureSet := range []string{"train", "validation"} {
+		t.Run(failureSet, func(t *testing.T) {
+			generated := 0
+			evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+				result := pipelineResult(evalSetID, 1, true)
+				if evalSetID == failureSet {
+					result = executionFailureResult(evalSetID)
+				}
+				return &EvaluationOutput{Result: result, MetricNames: []string{"quality"}}, nil
+			}
+			run, err := Run(context.Background(), RunRequest{
+				InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1,
+			}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+				generated++
+				return &Candidate{Prompt: "unexpected"}, nil
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			report, err := BuildReport(run, testAuditMetadata("baseline-failure"))
+			if err != nil {
+				t.Fatalf("BuildReport() error = %v", err)
+			}
+			trainFailures := report.BaselineTrainAttribution.Counts[FailureExecutionError]
+			validationFailures := report.BaselineValidationAttribution.Counts[FailureExecutionError]
+			if generated != 0 || len(run.Rounds) != 0 ||
+				run.StopReason != "baseline evaluation has execution failures" ||
+				trainFailures+validationFailures != 1 {
+				t.Fatalf("run = %+v, report = %+v, generated = %d", run, report, generated)
+			}
+		})
+	}
+}
+
+func TestRunRejectsAndAuditsCandidateExecutionFailure(t *testing.T) {
+	for _, failureSet := range []string{"train", "validation"} {
+		t.Run(failureSet, func(t *testing.T) {
+			evaluate := func(_ context.Context, prompt, evalSetID string, _ int64) (*EvaluationOutput, error) {
+				result := pipelineResult(evalSetID, 0, false)
+				if prompt == "candidate" {
+					result = pipelineResult(evalSetID, 1, true)
+					if evalSetID == failureSet {
+						result = executionFailureResult(evalSetID)
+					}
+				}
+				return &EvaluationOutput{Result: result, MetricNames: []string{"quality"}}, nil
+			}
+			run, err := Run(context.Background(), RunRequest{
+				InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1,
+			}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+				return &Candidate{Prompt: "candidate"}, nil
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			report, err := BuildReport(run, testAuditMetadata("candidate-failure"))
+			if err != nil {
+				t.Fatalf("BuildReport() error = %v", err)
+			}
+			trainFailures := report.Rounds[0].TrainAttribution.Counts[FailureExecutionError]
+			validationFailures := report.Rounds[0].Attribution.Counts[FailureExecutionError]
+			if len(run.Rounds) != 1 || run.Rounds[0].Gate.Accepted || run.AcceptedPrompt != "base" ||
+				run.WriteBackRecommended || trainFailures+validationFailures != 1 ||
+				!strings.Contains(strings.Join(run.Rounds[0].Gate.Reasons, " "),
+					"candidate "+failureSet+" evaluation has execution failures") {
+				t.Fatalf("run = %+v, report = %+v", run, report)
 			}
 		})
 	}
@@ -212,9 +278,12 @@ func TestRunPropagatesEvaluationErrorsByStage(t *testing.T) {
 }
 
 func TestGeneratePromptIterUsesTargetAndHints(t *testing.T) {
+	otherPrompt := "keep me"
 	engine := &promptIterStub{
 		structure: &astructure.Snapshot{
-			StructureID: "structure", Surfaces: []astructure.Surface{{SurfaceID: "system"}},
+			StructureID: "structure", Surfaces: []astructure.Surface{
+				{SurfaceID: "system"}, {SurfaceID: "reviewer"},
+			},
 		},
 		candidate: "improved prompt",
 	}
@@ -222,6 +291,13 @@ func TestGeneratePromptIterUsesTargetAndHints(t *testing.T) {
 		Train:      []promptiterengine.EvalSetInput{{EvalSetID: "train"}},
 		Validation: []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
 		MaxRounds:  9,
+		InitialProfile: &promptiter.Profile{
+			StructureID: "structure",
+			Overrides: []promptiter.SurfaceOverride{
+				{SurfaceID: "system", Value: astructure.SurfaceValue{Text: stringPointer("old target")}},
+				{SurfaceID: "reviewer", Value: astructure.SurfaceValue{Text: &otherPrompt}},
+			},
+		},
 	}
 	prompt, err := GeneratePromptIter(context.Background(), engine, base, "system", CandidateRequest{
 		Prompt: "baseline", Hints: []FailureHint{{CaseID: "case", MetricName: "quality", Reason: "wrong answer"}},
@@ -239,7 +315,21 @@ func TestGeneratePromptIterUsesTargetAndHints(t *testing.T) {
 		*engine.request.InitialProfile.Overrides[0].Value.Text != "baseline" {
 		t.Fatalf("initial profile = %+v", engine.request.InitialProfile)
 	}
+	if len(engine.request.InitialProfile.Overrides) != 2 ||
+		engine.request.InitialProfile.Overrides[1].Value.Text == nil ||
+		*engine.request.InitialProfile.Overrides[1].Value.Text != "keep me" {
+		t.Fatalf("non-target override was not preserved: %+v", engine.request.InitialProfile)
+	}
+	if got := *base.InitialProfile.Overrides[0].Value.Text; got != "old target" {
+		t.Fatalf("base target override was modified: %q", got)
+	}
+	*engine.request.InitialProfile.Overrides[1].Value.Text = "engine mutation"
+	if got := *base.InitialProfile.Overrides[1].Value.Text; got != "keep me" {
+		t.Fatalf("base non-target override shares mutable state: %q", got)
+	}
 }
+
+func stringPointer(value string) *string { return &value }
 
 func TestGeneratePromptIterRejectsMissingCandidate(t *testing.T) {
 	engine := &promptIterStub{structure: &astructure.Snapshot{
@@ -425,5 +515,26 @@ func pipelineResult(evalSetID string, score float64, passed bool) *evaluation.Ev
 				Details: &evalresult.EvalMetricResultDetails{Reason: "wrong answer"},
 			}},
 		}},
+	}
+}
+
+func executionFailureResult(evalSetID string) *evaluation.EvaluationResult {
+	return &evaluation.EvaluationResult{
+		EvalSetID: evalSetID,
+		EvalCases: []*evaluation.EvaluationCaseResult{{
+			EvalCaseID:    "case",
+			OverallStatus: status.EvalStatusFailed,
+			EvalCaseResults: []*evalresult.EvalCaseResult{{
+				RunID: 1, ErrorMessage: "inference unavailable",
+			}},
+		}},
+	}
+}
+
+func testAuditMetadata(runID string) AuditMetadata {
+	started := time.Unix(100, 0).UTC()
+	return AuditMetadata{
+		RunID: runID, StartedAt: started, FinishedAt: started.Add(time.Second),
+		Runtime: RuntimeAudit{Mode: "test"},
 	}
 }

--- a/evaluation/workflow/promptiter/regression/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regression/pipeline_test.go
@@ -78,6 +78,42 @@ func TestRunPromotesAcceptedPromptAndKeepsRejectedRound(t *testing.T) {
 	}
 }
 
+func TestRunAppliesBudgetToCumulativeCostAcrossRounds(t *testing.T) {
+	evaluations := map[string]*evaluation.EvaluationResult{
+		"base/train":             pipelineResult("train", 0, false),
+		"base/validation":        pipelineResult("validation", 0, false),
+		"candidate-1/train":      pipelineResult("train", 0.5, true),
+		"candidate-1/validation": pipelineResult("validation", 0, false),
+		"candidate-2/train":      pipelineResult("train", 1, true),
+		"candidate-2/validation": pipelineResult("validation", 1, true),
+	}
+	evaluate := func(_ context.Context, prompt, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		return &EvaluationOutput{
+			Result: evaluations[prompt+"/"+evalSetID], Cost: Cost{ModelCalls: 1, Tokens: 10},
+		}, nil
+	}
+	run, err := Run(context.Background(), RunRequest{
+		InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation",
+		MaxRounds: 2, GatePolicy: GatePolicy{MinValidationGain: 0.5, MaxModelCalls: 5, MaxTokens: 50},
+	}, evaluate, func(_ context.Context, request CandidateRequest) (*Candidate, error) {
+		return &Candidate{
+			Prompt: fmt.Sprintf("candidate-%d", request.Round), Cost: Cost{ModelCalls: 1, Tokens: 5},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(run.Rounds) != 2 || run.Rounds[0].Gate.Accepted || run.Rounds[1].Gate.Accepted ||
+		run.TotalCost.ModelCalls != 8 || run.TotalCost.Tokens != 70 || run.WriteBackRecommended {
+		t.Fatalf("run = %+v", run)
+	}
+	reasons := strings.Join(run.Rounds[1].Gate.Reasons, " ")
+	if !strings.Contains(reasons, "model calls 8 exceed budget 5") ||
+		!strings.Contains(reasons, "tokens 70 exceed budget 50") {
+		t.Fatalf("round two gate reasons = %v", run.Rounds[1].Gate.Reasons)
+	}
+}
+
 func TestRunRejectsWrongEvaluationSetBeforeGate(t *testing.T) {
 	evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
 		returnedID := evalSetID

--- a/evaluation/workflow/promptiter/regression/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regression/pipeline_test.go
@@ -1,0 +1,429 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+func TestRunPromotesAcceptedPromptAndKeepsRejectedRound(t *testing.T) {
+	evaluations := map[string]*evaluation.EvaluationResult{
+		"base/train":             pipelineResult("train", 0.4, false),
+		"base/validation":        pipelineResult("validation", 0.4, false),
+		"candidate-1/train":      pipelineResult("train", 0.8, true),
+		"candidate-1/validation": pipelineResult("validation", 0.3, false),
+		"candidate-2/train":      pipelineResult("train", 0.7, true),
+		"candidate-2/validation": pipelineResult("validation", 0.7, true),
+	}
+	var evaluationRequests []string
+	evaluate := func(_ context.Context, prompt, evalSetID string, seed int64) (*EvaluationOutput, error) {
+		if seed != 2003 {
+			t.Fatalf("seed = %d", seed)
+		}
+		key := prompt + "/" + evalSetID
+		evaluationRequests = append(evaluationRequests, key)
+		return &EvaluationOutput{Result: evaluations[key], Cost: Cost{ModelCalls: 1, Tokens: 10}}, nil
+	}
+	var generated []CandidateRequest
+	generate := func(_ context.Context, request CandidateRequest) (*Candidate, error) {
+		generated = append(generated, request)
+		return &Candidate{Prompt: fmt.Sprintf("candidate-%d", request.Round), Cost: Cost{ModelCalls: 1, Tokens: 5}}, nil
+	}
+	run, err := Run(context.Background(), RunRequest{
+		InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation",
+		GatePolicy: GatePolicy{MinValidationGain: 0.1, MaxMetricDrop: 1}, MaxRounds: 2, Seed: 2003,
+	}, evaluate, generate)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if run.AcceptedPrompt != "candidate-2" || !run.WriteBackRecommended || len(run.Rounds) != 2 {
+		t.Fatalf("run = %+v", run)
+	}
+	if run.Rounds[0].Gate.Accepted || !run.Rounds[1].Gate.Accepted {
+		t.Fatalf("round gates = %+v, %+v", run.Rounds[0].Gate, run.Rounds[1].Gate)
+	}
+	if generated[0].Prompt != "base" || generated[1].Prompt != "base" {
+		t.Fatalf("generated requests = %+v", generated)
+	}
+	if len(generated[0].Hints) != 1 || generated[0].Hints[0].MetricName != "quality" {
+		t.Fatalf("round one hints = %+v", generated[0].Hints)
+	}
+	if run.TotalCost.ModelCalls != 8 || run.TotalCost.Tokens != 70 {
+		t.Fatalf("total cost = %+v", run.TotalCost)
+	}
+	wantRequests := []string{
+		"base/train", "base/validation", "candidate-1/train", "candidate-1/validation",
+		"candidate-2/train", "candidate-2/validation",
+	}
+	if strings.Join(evaluationRequests, ",") != strings.Join(wantRequests, ",") {
+		t.Fatalf("evaluation requests = %v", evaluationRequests)
+	}
+}
+
+func TestRunRejectsWrongEvaluationSetBeforeGate(t *testing.T) {
+	evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		returnedID := evalSetID
+		if evalSetID == "validation" {
+			returnedID = "train"
+		}
+		return &EvaluationOutput{Result: pipelineResult(returnedID, 0.5, false)}, nil
+	}
+	_, err := Run(context.Background(), RunRequest{
+		InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1,
+	}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return &Candidate{Prompt: "candidate"}, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), `want "validation"`) {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
+func TestRunStopsWithoutOptimizableTrainingFailures(t *testing.T) {
+	executionFailure := pipelineResult("train", 1, true)
+	executionFailure.EvalCases[0].RunDetails = []*evaluation.EvaluationCaseRunDetails{{
+		Inference: &evaluation.EvaluationInferenceDetails{
+			Status: status.EvalStatusFailed, ErrorMessage: "runner stopped",
+		},
+	}}
+	tests := []struct {
+		name  string
+		train *evaluation.EvaluationResult
+	}{
+		{name: "all training metrics pass", train: pipelineResult("train", 1, true)},
+		{name: "execution failure without failed metric", train: executionFailure},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generatorCalls := 0
+			evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+				if evalSetID == "train" {
+					return &EvaluationOutput{Result: test.train}, nil
+				}
+				return &EvaluationOutput{Result: pipelineResult("validation", 1, true)}, nil
+			}
+			run, err := Run(context.Background(), RunRequest{
+				InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 2,
+			}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+				generatorCalls++
+				return &Candidate{Prompt: "unexpected"}, nil
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if generatorCalls != 0 || len(run.Rounds) != 0 || run.WriteBackRecommended {
+				t.Fatalf("run = %+v, generator calls = %d", run, generatorCalls)
+			}
+			if run.StopReason != "no optimizable training failures" || run.AcceptedPrompt != "base" {
+				t.Fatalf("run = %+v", run)
+			}
+		})
+	}
+}
+
+func TestRunValidatesInputsAndCollaboratorErrors(t *testing.T) {
+	valid := RunRequest{InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1}
+	evaluate := func(context.Context, string, string, int64) (*EvaluationOutput, error) {
+		return nil, errors.New("evaluation unavailable")
+	}
+	generate := func(context.Context, CandidateRequest) (*Candidate, error) { return &Candidate{Prompt: "next"}, nil }
+	tests := []struct {
+		request  RunRequest
+		evaluate EvaluateFunc
+		generate GenerateFunc
+	}{
+		{request: valid, generate: generate},
+		{request: valid, evaluate: evaluate},
+		{request: RunRequest{}, evaluate: evaluate, generate: generate},
+		{request: RunRequest{InitialPrompt: "x", ValidationEvalSetID: "validation", MaxRounds: 1}, evaluate: evaluate, generate: generate},
+		{request: RunRequest{InitialPrompt: "x", TrainEvalSetID: "train", MaxRounds: 1}, evaluate: evaluate, generate: generate},
+		{request: RunRequest{InitialPrompt: "x", TrainEvalSetID: "train", ValidationEvalSetID: "validation"}, evaluate: evaluate, generate: generate},
+		{request: RunRequest{InitialPrompt: "x", TrainEvalSetID: "same", ValidationEvalSetID: "same", MaxRounds: 1}, evaluate: evaluate, generate: generate},
+	}
+	for _, test := range tests {
+		if _, err := Run(context.Background(), test.request, test.evaluate, test.generate); err == nil {
+			t.Fatalf("Run(%+v) error = nil", test.request)
+		}
+	}
+}
+
+func TestRunRejectsGeneratorAndRuntimeCosts(t *testing.T) {
+	valid := RunRequest{InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1}
+	evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		return &EvaluationOutput{Result: pipelineResult(evalSetID, 0, false)}, nil
+	}
+	if _, err := Run(context.Background(), valid, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return nil, errors.New("optimizer unavailable")
+	}); err == nil || !strings.Contains(err.Error(), "optimizer unavailable") {
+		t.Fatalf("generator error = %v", err)
+	}
+	if _, err := Run(context.Background(), valid, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return &Candidate{Prompt: "candidate", Cost: Cost{Tokens: -1}}, nil
+	}); err == nil || !strings.Contains(err.Error(), "cost") {
+		t.Fatalf("candidate cost error = %v", err)
+	}
+	badCost := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		return &EvaluationOutput{Result: pipelineResult(evalSetID, 0, false), Cost: Cost{ModelCalls: -1}}, nil
+	}
+	if _, err := Run(context.Background(), valid, badCost, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return &Candidate{Prompt: "candidate"}, nil
+	}); err == nil || !strings.Contains(err.Error(), "cost") {
+		t.Fatalf("evaluation cost error = %v", err)
+	}
+}
+
+func TestRunPropagatesEvaluationErrorsByStage(t *testing.T) {
+	for _, failAt := range []int{2, 3, 4} {
+		t.Run(fmt.Sprintf("evaluation %d", failAt), func(t *testing.T) {
+			calls := 0
+			evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+				calls++
+				if calls == failAt {
+					return nil, errors.New("evaluation unavailable")
+				}
+				return &EvaluationOutput{Result: pipelineResult(evalSetID, 0, false)}, nil
+			}
+			_, err := Run(context.Background(), RunRequest{
+				InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1,
+			}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+				return &Candidate{Prompt: "candidate"}, nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "evaluation unavailable") {
+				t.Fatalf("Run() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestGeneratePromptIterUsesTargetAndHints(t *testing.T) {
+	engine := &promptIterStub{
+		structure: &astructure.Snapshot{
+			StructureID: "structure", Surfaces: []astructure.Surface{{SurfaceID: "system"}},
+		},
+		candidate: "improved prompt",
+	}
+	base := promptiterengine.RunRequest{
+		Train:      []promptiterengine.EvalSetInput{{EvalSetID: "train"}},
+		Validation: []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
+		MaxRounds:  9,
+	}
+	prompt, err := GeneratePromptIter(context.Background(), engine, base, "system", CandidateRequest{
+		Prompt: "baseline", Hints: []FailureHint{{CaseID: "case", MetricName: "quality", Reason: "wrong answer"}},
+	})
+	if err != nil {
+		t.Fatalf("GeneratePromptIter() error = %v", err)
+	}
+	if prompt != "improved prompt" || engine.request.MaxRounds != 1 || len(engine.request.Train[0].LossHints) != 1 {
+		t.Fatalf("prompt = %q, request = %+v", prompt, engine.request)
+	}
+	if base.MaxRounds != 9 || len(base.Train[0].LossHints) != 0 {
+		t.Fatalf("base request was modified: %+v", base)
+	}
+	if engine.request.InitialProfile.Overrides[0].Value.Text == nil ||
+		*engine.request.InitialProfile.Overrides[0].Value.Text != "baseline" {
+		t.Fatalf("initial profile = %+v", engine.request.InitialProfile)
+	}
+}
+
+func TestGeneratePromptIterRejectsMissingCandidate(t *testing.T) {
+	engine := &promptIterStub{structure: &astructure.Snapshot{
+		StructureID: "structure", Surfaces: []astructure.Surface{{SurfaceID: "system"}},
+	}}
+	_, err := GeneratePromptIter(context.Background(), engine, promptiterengine.RunRequest{
+		Train:      []promptiterengine.EvalSetInput{{EvalSetID: "train"}},
+		Validation: []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
+	}, "system", CandidateRequest{Prompt: "baseline"})
+	if err == nil {
+		t.Fatal("GeneratePromptIter() error = nil")
+	}
+}
+
+func TestGeneratePromptIterRejectsInvalidContracts(t *testing.T) {
+	validBase := promptiterengine.RunRequest{
+		Train: []promptiterengine.EvalSetInput{{EvalSetID: "train"}}, Validation: []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
+	}
+	validRequest := CandidateRequest{Prompt: "baseline"}
+	validStructure := &astructure.Snapshot{StructureID: "structure", Surfaces: []astructure.Surface{{SurfaceID: "system"}}}
+	tests := []struct {
+		name    string
+		engine  promptiterengine.Engine
+		base    promptiterengine.RunRequest
+		target  string
+		request CandidateRequest
+	}{
+		{name: "nil engine", base: validBase, target: "system", request: validRequest},
+		{name: "missing target", engine: &promptIterStub{structure: validStructure}, base: validBase, request: validRequest},
+		{name: "wrong dataset count", engine: &promptIterStub{structure: validStructure}, target: "system", request: validRequest},
+		{name: "describe error", engine: &promptIterStub{describeErr: errors.New("describe")}, base: validBase, target: "system", request: validRequest},
+		{name: "missing surface", engine: &promptIterStub{structure: &astructure.Snapshot{StructureID: "structure"}}, base: validBase, target: "system", request: validRequest},
+		{name: "incomplete hint", engine: &promptIterStub{structure: validStructure}, base: validBase, target: "system",
+			request: CandidateRequest{Prompt: "baseline", Hints: []FailureHint{{CaseID: "case"}}}},
+		{name: "run error", engine: &promptIterStub{structure: validStructure, runErr: errors.New("run")}, base: validBase, target: "system", request: validRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := GeneratePromptIter(context.Background(), test.engine, test.base, test.target, test.request); err == nil {
+				t.Fatal("GeneratePromptIter() error = nil")
+			}
+		})
+	}
+}
+
+func TestPromptFromProfileRejectsDuplicateAndEmptyTarget(t *testing.T) {
+	empty := " "
+	value := "candidate"
+	for _, profile := range []*promptiter.Profile{
+		{},
+		{Overrides: []promptiter.SurfaceOverride{{SurfaceID: "system", Value: astructure.SurfaceValue{Text: &empty}}}},
+		{Overrides: []promptiter.SurfaceOverride{
+			{SurfaceID: "system", Value: astructure.SurfaceValue{Text: &value}},
+			{SurfaceID: "system", Value: astructure.SurfaceValue{Text: &value}},
+		}},
+	} {
+		if _, err := promptFromProfile(profile, "system"); err == nil {
+			t.Fatalf("promptFromProfile(%+v) error = nil", profile)
+		}
+	}
+}
+
+func TestAddCostsRejectsOverflow(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	maxInt64 := int64(^uint64(0) >> 1)
+	for _, costs := range [][]Cost{
+		{{ModelCalls: maxInt}, {ModelCalls: 1}},
+		{{Tokens: maxInt64}, {Tokens: 1}},
+		{{LatencyMS: maxInt64}, {LatencyMS: 1}},
+	} {
+		if _, err := addCosts(costs...); err == nil {
+			t.Fatalf("addCosts(%+v) error = nil", costs)
+		}
+	}
+}
+
+func TestRunCancellationNilOutputsAndEmptyCandidate(t *testing.T) {
+	valid := RunRequest{InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	evaluate := func(ctx context.Context, _ string, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return &EvaluationOutput{Result: pipelineResult(evalSetID, 0, false)}, nil
+	}
+	if _, err := Run(cancelled, valid, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return &Candidate{Prompt: "candidate"}, nil
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Run() error = %v", err)
+	}
+	if _, err := Run(context.Background(), valid, func(context.Context, string, string, int64) (*EvaluationOutput, error) {
+		return nil, nil
+	}, func(context.Context, CandidateRequest) (*Candidate, error) { return nil, nil }); err == nil {
+		t.Fatal("Run() accepted nil evaluation output")
+	}
+	if _, err := Run(context.Background(), valid, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return &Candidate{}, nil
+	}); err == nil || !strings.Contains(err.Error(), "no prompt") {
+		t.Fatalf("empty candidate error = %v", err)
+	}
+}
+
+func TestRunChecksCancellationBeforeCandidateGeneration(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	evaluations := 0
+	evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		evaluations++
+		if evaluations == 2 {
+			cancel()
+		}
+		return &EvaluationOutput{Result: pipelineResult(evalSetID, 0, false)}, nil
+	}
+	generated := false
+	_, err := Run(ctx, RunRequest{
+		InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation", MaxRounds: 1,
+	}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		generated = true
+		return &Candidate{Prompt: "candidate"}, nil
+	})
+	if !errors.Is(err, context.Canceled) || generated {
+		t.Fatalf("Run() error = %v, generated = %t", err, generated)
+	}
+}
+
+func TestRunStopsAtMaximumRounds(t *testing.T) {
+	evaluate := func(_ context.Context, _, evalSetID string, _ int64) (*EvaluationOutput, error) {
+		return &EvaluationOutput{Result: pipelineResult(evalSetID, 0, false)}, nil
+	}
+	run, err := Run(context.Background(), RunRequest{
+		InitialPrompt: "base", TrainEvalSetID: "train", ValidationEvalSetID: "validation",
+		MaxRounds: 1, GatePolicy: GatePolicy{MinValidationGain: 1},
+	}, evaluate, func(context.Context, CandidateRequest) (*Candidate, error) {
+		return &Candidate{Prompt: "candidate"}, nil
+	})
+	if err != nil || run.StopReason != "maximum rounds reached without an accepted candidate" || len(run.Rounds) != 1 {
+		t.Fatalf("Run() = %+v, %v", run, err)
+	}
+}
+
+type promptIterStub struct {
+	structure   *astructure.Snapshot
+	candidate   string
+	request     promptiterengine.RunRequest
+	describeErr error
+	runErr      error
+}
+
+func (s *promptIterStub) Describe(context.Context) (*astructure.Snapshot, error) {
+	return s.structure, s.describeErr
+}
+
+func (s *promptIterStub) Run(
+	_ context.Context, request *promptiterengine.RunRequest, _ ...promptiterengine.Option,
+) (*promptiterengine.RunResult, error) {
+	s.request = *request
+	if s.runErr != nil {
+		return nil, s.runErr
+	}
+	if s.candidate == "" {
+		return &promptiterengine.RunResult{}, nil
+	}
+	text := s.candidate
+	return &promptiterengine.RunResult{Rounds: []promptiterengine.RoundResult{{
+		OutputProfile: &promptiter.Profile{
+			StructureID: "structure",
+			Overrides:   []promptiter.SurfaceOverride{{SurfaceID: "system", Value: astructure.SurfaceValue{Text: &text}}},
+		},
+	}}}, nil
+}
+
+func pipelineResult(evalSetID string, score float64, passed bool) *evaluation.EvaluationResult {
+	evalStatus := status.EvalStatusFailed
+	if passed {
+		evalStatus = status.EvalStatusPassed
+	}
+	return &evaluation.EvaluationResult{
+		EvalSetID: evalSetID,
+		EvalCases: []*evaluation.EvaluationCaseResult{{
+			EvalCaseID: "case",
+			MetricResults: []*evalresult.EvalMetricResult{{
+				MetricName: "quality", Score: score, Threshold: 0.5, EvalStatus: evalStatus,
+				Details: &evalresult.EvalMetricResultDetails{Reason: "wrong answer"},
+			}},
+		}},
+	}
+}

--- a/evaluation/workflow/promptiter/regression/pipeline_test.go
+++ b/evaluation/workflow/promptiter/regression/pipeline_test.go
@@ -367,6 +367,74 @@ func TestGeneratePromptIterUsesTargetAndHints(t *testing.T) {
 
 func stringPointer(value string) *string { return &value }
 
+func TestGeneratePromptIterRejectsStaleInitialProfile(t *testing.T) {
+	engine := &promptIterStub{
+		structure: &astructure.Snapshot{
+			StructureID: "current", Surfaces: []astructure.Surface{
+				{SurfaceID: "system"}, {SurfaceID: "reviewer"},
+			},
+		},
+		candidate: "candidate",
+	}
+	_, err := GeneratePromptIter(context.Background(), engine, promptiterengine.RunRequest{
+		Train:      []promptiterengine.EvalSetInput{{EvalSetID: "train"}},
+		Validation: []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
+		InitialProfile: &promptiter.Profile{
+			StructureID: "stale",
+			Overrides: []promptiter.SurfaceOverride{{
+				SurfaceID: "reviewer", Value: astructure.SurfaceValue{Text: stringPointer("review")},
+			}},
+		},
+	}, "system", CandidateRequest{Prompt: "baseline"})
+	if err == nil || !strings.Contains(err.Error(), `structure id "stale" does not match current structure id "current"`) {
+		t.Fatalf("GeneratePromptIter() error = %v", err)
+	}
+	if engine.runCalls != 0 {
+		t.Fatalf("engine Run() calls = %d", engine.runCalls)
+	}
+}
+
+func TestGeneratePromptIterBindsUnboundProfileAndPreservesEmptyFewShot(t *testing.T) {
+	engine := &promptIterStub{
+		structure: &astructure.Snapshot{
+			StructureID: "current", Surfaces: []astructure.Surface{
+				{SurfaceID: "system"},
+				{
+					SurfaceID: "examples",
+					NodeID:    "answer",
+					Type:      astructure.SurfaceTypeFewShot,
+					Value: astructure.SurfaceValue{FewShot: []astructure.FewShotExample{{
+						Messages: []astructure.FewShotMessage{{Role: "user", Content: "baseline"}},
+					}}},
+				},
+			},
+		},
+		candidate: "candidate",
+	}
+	base := promptiterengine.RunRequest{
+		Train:      []promptiterengine.EvalSetInput{{EvalSetID: "train"}},
+		Validation: []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
+		InitialProfile: &promptiter.Profile{
+			Overrides: []promptiter.SurfaceOverride{{
+				SurfaceID: "examples", Value: astructure.SurfaceValue{FewShot: []astructure.FewShotExample{}},
+			}},
+		},
+	}
+	if _, err := GeneratePromptIter(
+		context.Background(), engine, base, "system", CandidateRequest{Prompt: "baseline"},
+	); err != nil {
+		t.Fatalf("GeneratePromptIter() error = %v", err)
+	}
+	if engine.request.InitialProfile.StructureID != "current" ||
+		len(engine.request.InitialProfile.Overrides) != 2 ||
+		engine.request.InitialProfile.Overrides[0].Value.FewShot == nil {
+		t.Fatalf("initial profile = %+v", engine.request.InitialProfile)
+	}
+	if base.InitialProfile.StructureID != "" || base.InitialProfile.Overrides[0].Value.FewShot == nil {
+		t.Fatalf("base profile was modified: %+v", base.InitialProfile)
+	}
+}
+
 func TestGeneratePromptIterRejectsMissingCandidate(t *testing.T) {
 	engine := &promptIterStub{structure: &astructure.Snapshot{
 		StructureID: "structure", Surfaces: []astructure.Surface{{SurfaceID: "system"}},
@@ -510,6 +578,7 @@ type promptIterStub struct {
 	structure   *astructure.Snapshot
 	candidate   string
 	request     promptiterengine.RunRequest
+	runCalls    int
 	describeErr error
 	runErr      error
 }
@@ -521,6 +590,7 @@ func (s *promptIterStub) Describe(context.Context) (*astructure.Snapshot, error)
 func (s *promptIterStub) Run(
 	_ context.Context, request *promptiterengine.RunRequest, _ ...promptiterengine.Option,
 ) (*promptiterengine.RunResult, error) {
+	s.runCalls++
 	s.request = *request
 	if s.runErr != nil {
 		return nil, s.runErr

--- a/evaluation/workflow/promptiter/regression/promptiter.go
+++ b/evaluation/workflow/promptiter/regression/promptiter.go
@@ -1,0 +1,107 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// GeneratePromptIter runs one existing PromptIter engine round for one prompt surface.
+func GeneratePromptIter(
+	ctx context.Context,
+	engine promptiterengine.Engine,
+	base promptiterengine.RunRequest,
+	targetSurfaceID string,
+	request CandidateRequest,
+) (string, error) {
+	if engine == nil {
+		return "", errors.New("PromptIter engine is nil")
+	}
+	if strings.TrimSpace(targetSurfaceID) == "" || strings.TrimSpace(request.Prompt) == "" {
+		return "", errors.New("PromptIter target surface and input prompt are required")
+	}
+	if len(base.Train) != 1 || len(base.Validation) != 1 {
+		return "", errors.New("PromptIter regression requires one train and one validation eval set")
+	}
+	structure, err := engine.Describe(ctx)
+	if err != nil {
+		return "", fmt.Errorf("describe PromptIter structure: %w", err)
+	}
+	if structure == nil || structure.StructureID == "" || !containsSurface(structure.Surfaces, targetSurfaceID) {
+		return "", fmt.Errorf("PromptIter structure does not contain target surface %q", targetSurfaceID)
+	}
+	runRequest := base
+	runRequest.Train = cloneEvalSetInputs(base.Train)
+	runRequest.Validation = cloneEvalSetInputs(base.Validation)
+	runRequest.MaxRounds = 1
+	runRequest.TargetSurfaceIDs = []string{targetSurfaceID}
+	text := request.Prompt
+	runRequest.InitialProfile = &promptiter.Profile{
+		StructureID: structure.StructureID,
+		Overrides:   []promptiter.SurfaceOverride{{SurfaceID: targetSurfaceID, Value: astructure.SurfaceValue{Text: &text}}},
+	}
+	for _, hint := range request.Hints {
+		if hint.CaseID == "" || hint.MetricName == "" || strings.TrimSpace(hint.Reason) == "" {
+			return "", errors.New("PromptIter failure hint is incomplete")
+		}
+		runRequest.Train[0].LossHints = append(runRequest.Train[0].LossHints, promptiterengine.LossHint{
+			EvalCaseID: hint.CaseID, MetricName: hint.MetricName, Reason: hint.Reason,
+		})
+	}
+	run, err := engine.Run(ctx, &runRequest)
+	if err != nil {
+		return "", fmt.Errorf("run PromptIter: %w", err)
+	}
+	if run == nil || len(run.Rounds) != 1 || run.Rounds[0].OutputProfile == nil {
+		return "", errors.New("PromptIter returned no candidate profile")
+	}
+	return promptFromProfile(run.Rounds[0].OutputProfile, targetSurfaceID)
+}
+
+func promptFromProfile(profile *promptiter.Profile, targetSurfaceID string) (string, error) {
+	var result *string
+	for _, override := range profile.Overrides {
+		if override.SurfaceID != targetSurfaceID {
+			continue
+		}
+		if result != nil {
+			return "", fmt.Errorf("PromptIter returned duplicate target surface %q", targetSurfaceID)
+		}
+		result = override.Value.Text
+	}
+	if result == nil || strings.TrimSpace(*result) == "" {
+		return "", fmt.Errorf("PromptIter returned no text for target surface %q", targetSurfaceID)
+	}
+	return *result, nil
+}
+
+func cloneEvalSetInputs(inputs []promptiterengine.EvalSetInput) []promptiterengine.EvalSetInput {
+	result := append([]promptiterengine.EvalSetInput(nil), inputs...)
+	for index := range result {
+		result[index].EvalCaseIDs = append([]string(nil), result[index].EvalCaseIDs...)
+		result[index].LossHints = append([]promptiterengine.LossHint(nil), result[index].LossHints...)
+	}
+	return result
+}
+
+func containsSurface(surfaces []astructure.Surface, id string) bool {
+	for _, surface := range surfaces {
+		if surface.SurfaceID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/evaluation/workflow/promptiter/regression/promptiter.go
+++ b/evaluation/workflow/promptiter/regression/promptiter.go
@@ -49,10 +49,9 @@ func GeneratePromptIter(
 	runRequest.MaxRounds = 1
 	runRequest.TargetSurfaceIDs = []string{targetSurfaceID}
 	text := request.Prompt
-	runRequest.InitialProfile = &promptiter.Profile{
-		StructureID: structure.StructureID,
-		Overrides:   []promptiter.SurfaceOverride{{SurfaceID: targetSurfaceID, Value: astructure.SurfaceValue{Text: &text}}},
-	}
+	runRequest.InitialProfile = profileWithPrompt(
+		base.InitialProfile, structure.StructureID, targetSurfaceID, text,
+	)
 	for _, hint := range request.Hints {
 		if hint.CaseID == "" || hint.MetricName == "" || strings.TrimSpace(hint.Reason) == "" {
 			return "", errors.New("PromptIter failure hint is incomplete")
@@ -69,6 +68,28 @@ func GeneratePromptIter(
 		return "", errors.New("PromptIter returned no candidate profile")
 	}
 	return promptFromProfile(run.Rounds[0].OutputProfile, targetSurfaceID)
+}
+
+func profileWithPrompt(base *promptiter.Profile, structureID, targetSurfaceID, text string) *promptiter.Profile {
+	profile := &promptiter.Profile{StructureID: structureID}
+	if base != nil {
+		profile.Overrides = append([]promptiter.SurfaceOverride(nil), base.Overrides...)
+		for index := range profile.Overrides {
+			profile.Overrides[index].Value = astructure.CloneSurfaceValue(profile.Overrides[index].Value)
+		}
+	}
+	target := promptiter.SurfaceOverride{
+		SurfaceID: targetSurfaceID,
+		Value:     astructure.SurfaceValue{Text: &text},
+	}
+	for index := range profile.Overrides {
+		if profile.Overrides[index].SurfaceID == targetSurfaceID {
+			profile.Overrides[index] = target
+			return profile
+		}
+	}
+	profile.Overrides = append(profile.Overrides, target)
+	return profile
 }
 
 func promptFromProfile(profile *promptiter.Profile, targetSurfaceID string) (string, error) {

--- a/evaluation/workflow/promptiter/regression/promptiter.go
+++ b/evaluation/workflow/promptiter/regression/promptiter.go
@@ -49,9 +49,12 @@ func GeneratePromptIter(
 	runRequest.MaxRounds = 1
 	runRequest.TargetSurfaceIDs = []string{targetSurfaceID}
 	text := request.Prompt
-	runRequest.InitialProfile = profileWithPrompt(
+	runRequest.InitialProfile, err = profileWithPrompt(
 		base.InitialProfile, structure.StructureID, targetSurfaceID, text,
 	)
+	if err != nil {
+		return "", err
+	}
 	for _, hint := range request.Hints {
 		if hint.CaseID == "" || hint.MetricName == "" || strings.TrimSpace(hint.Reason) == "" {
 			return "", errors.New("PromptIter failure hint is incomplete")
@@ -70,9 +73,17 @@ func GeneratePromptIter(
 	return promptFromProfile(run.Rounds[0].OutputProfile, targetSurfaceID)
 }
 
-func profileWithPrompt(base *promptiter.Profile, structureID, targetSurfaceID, text string) *promptiter.Profile {
+func profileWithPrompt(
+	base *promptiter.Profile, structureID, targetSurfaceID, text string,
+) (*promptiter.Profile, error) {
 	profile := &promptiter.Profile{StructureID: structureID}
 	if base != nil {
+		if base.StructureID != "" && base.StructureID != structureID {
+			return nil, fmt.Errorf(
+				"promptiter initial profile structure id %q does not match current structure id %q",
+				base.StructureID, structureID,
+			)
+		}
 		profile.Overrides = append([]promptiter.SurfaceOverride(nil), base.Overrides...)
 		for index := range profile.Overrides {
 			profile.Overrides[index].Value = astructure.CloneSurfaceValue(profile.Overrides[index].Value)
@@ -85,11 +96,11 @@ func profileWithPrompt(base *promptiter.Profile, structureID, targetSurfaceID, t
 	for index := range profile.Overrides {
 		if profile.Overrides[index].SurfaceID == targetSurfaceID {
 			profile.Overrides[index] = target
-			return profile
+			return profile, nil
 		}
 	}
 	profile.Overrides = append(profile.Overrides, target)
-	return profile
+	return profile, nil
 }
 
 func promptFromProfile(profile *promptiter.Profile, targetSurfaceID string) (string, error) {

--- a/evaluation/workflow/promptiter/regression/regression_test.go
+++ b/evaluation/workflow/promptiter/regression/regression_test.go
@@ -171,6 +171,33 @@ func TestSummarizeKeepsFailedRunTraceAndStructuredContent(t *testing.T) {
 	}
 }
 
+func TestSummarizePreservesExecutionFailureWithoutMetrics(t *testing.T) {
+	failedCase := &evaluation.EvaluationCaseResult{
+		EvalCaseID:    "failed",
+		OverallStatus: status.EvalStatusFailed,
+		EvalCaseResults: []*evalresult.EvalCaseResult{{
+			RunID: 1, ErrorMessage: "inference unavailable",
+		}},
+	}
+	summary, err := summarize(&evaluation.EvaluationResult{
+		EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{failedCase},
+	}, []string{"quality"})
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary.Score != 0 || summary.Passed || len(summary.Cases[0].Metrics) != 1 ||
+		summary.Cases[0].Error != "inference unavailable" {
+		t.Fatalf("summary = %+v", summary)
+	}
+	attribution, err := Attribute(summary)
+	if err != nil {
+		t.Fatalf("Attribute() error = %v", err)
+	}
+	if len(attribution.Failures) != 1 || attribution.Failures[0].Category != FailureExecutionError {
+		t.Fatalf("attribution = %+v", attribution)
+	}
+}
+
 func TestSafeJSONHashesLongToolResult(t *testing.T) {
 	result := safeJSON(map[string]any{"result": strings.Repeat("x", 20<<10), "bearerToken": "leak"})
 	if strings.Contains(string(result), "leak") || !strings.Contains(string(result), `"truncated":true`) ||

--- a/evaluation/workflow/promptiter/regression/regression_test.go
+++ b/evaluation/workflow/promptiter/regression/regression_test.go
@@ -322,6 +322,9 @@ func TestCompareSortsAndComparesMetrics(t *testing.T) {
 	if delta.Kind != DeltaNewlyPassed || delta.Cases[0].Metrics[0].Name != "a" || delta.Cases[0].Metrics[1].Kind != DeltaUnchanged {
 		t.Fatalf("delta = %+v", delta)
 	}
+	if !delta.Cases[0].Metrics[0].CandidatePassed || delta.Cases[0].Metrics[0].BaselinePassed {
+		t.Fatalf("metric pass states = %+v", delta.Cases[0].Metrics[0])
+	}
 }
 
 func TestCompareRejectsDifferentShapes(t *testing.T) {

--- a/evaluation/workflow/promptiter/regression/regression_test.go
+++ b/evaluation/workflow/promptiter/regression/regression_test.go
@@ -1,0 +1,369 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/finalresponse"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/tooltrajectory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestSummarize(t *testing.T) {
+	result := &evaluation.EvaluationResult{
+		AppName: "app", EvalSetID: "set", ExecutionTime: 1500 * time.Millisecond,
+		EvalCases: []*evaluation.EvaluationCaseResult{
+			evalCase("b", metric("quality", 0.5, status.EvalStatusFailed, finalCriterion())),
+			evalCase("a",
+				metric("quality", 1, status.EvalStatusPassed, finalCriterion()),
+				metric("unused", 0, status.EvalStatusNotEvaluated, nil),
+			),
+		},
+	}
+	result.EvalCases[0].EvalCaseResults = []*evalresult.EvalCaseResult{{
+		RunID: 1,
+		EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+			ActualInvocation: &evalset.Invocation{
+				FinalResponse:  &model.Message{Content: "actual"},
+				Tools:          []*evalset.Tool{{Name: "search", Arguments: map[string]any{"q": "go"}}},
+				ExecutionTrace: &trace.Trace{Steps: []trace.Step{{AgentName: "router", Branch: "answer", NodeID: "n1"}}},
+			},
+			ExpectedInvocation: &evalset.Invocation{FinalResponse: &model.Message{Content: "expected"}},
+		}},
+	}}
+
+	summary, err := Summarize(result)
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary.Score != 0.75 || summary.Passed || summary.LatencyMS != 1500 {
+		t.Fatalf("summary = %+v", summary)
+	}
+	if got := []string{summary.Cases[0].ID, summary.Cases[1].ID}; got[0] != "a" || got[1] != "b" {
+		t.Fatalf("case order = %v", got)
+	}
+	evidence := summary.Cases[1].ActualInvocations[0]
+	if evidence.FinalResponse != "actual" || evidence.Tools[0].Name != "search" || evidence.Route[0].Agent != "router" {
+		t.Fatalf("evidence = %+v", evidence)
+	}
+}
+
+func TestSummarizeMetricEvidence(t *testing.T) {
+	judge := metric("judge", 0, status.EvalStatusFailed, &criterion.Criterion{LLMJudge: &llm.LLMCriterion{
+		Rubrics: []*llm.Rubric{{Type: "knowledge"}, {Type: "format"}},
+	}})
+	toolMetric := metric("tools", 1, status.EvalStatusPassed, &criterion.Criterion{
+		ToolTrajectory: &tooltrajectory.ToolTrajectoryCriterion{OrderSensitive: true},
+	})
+	caseResult := evalCase("case", judge, toolMetric)
+	caseResult.EvalCaseResults = []*evalresult.EvalCaseResult{{
+		EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+			EvalMetricResults: []*evalresult.EvalMetricResult{{
+				MetricName: "judge", Details: &evalresult.EvalMetricResultDetails{Reason: "missing citation"},
+			}},
+		}},
+	}}
+	summary, err := Summarize(&evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{caseResult}})
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	metrics := summary.Cases[0].Metrics
+	if metrics[0].Reason != "missing citation" || strings.Join(metrics[0].RubricTypes, ",") != "format,knowledge" {
+		t.Fatalf("judge metric = %+v", metrics[0])
+	}
+	if metrics[1].Criterion != "tool_trajectory" || !metrics[1].ToolOrderSensitive {
+		t.Fatalf("tool metric = %+v", metrics[1])
+	}
+}
+
+func TestSummarizeUsesRubricReasons(t *testing.T) {
+	detailed := metric("details", 0, status.EvalStatusFailed, nil)
+	detailed.Details = &evalresult.EvalMetricResultDetails{RubricScores: []*evalresult.RubricScore{{Reason: "details rubric"}}}
+	perInvocation := metric("invocation", 0, status.EvalStatusFailed, nil)
+	caseResult := evalCase("case", detailed, perInvocation)
+	caseResult.EvalCaseResults = []*evalresult.EvalCaseResult{{
+		EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+			EvalMetricResults: []*evalresult.EvalMetricResult{{
+				MetricName: "invocation", Details: &evalresult.EvalMetricResultDetails{
+					RubricScores: []*evalresult.RubricScore{{Reason: "invocation rubric"}},
+				},
+			}},
+		}},
+	}}
+	summary, err := Summarize(&evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{caseResult}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Cases[0].Metrics[0].Reason != "details rubric" || summary.Cases[0].Metrics[1].Reason != "invocation rubric" {
+		t.Fatalf("metric reasons = %+v", summary.Cases[0].Metrics)
+	}
+}
+
+func TestSummarizeKeepsFailedRunTraceAndStructuredContent(t *testing.T) {
+	textPart := "structured answer"
+	started := time.Unix(100, 0)
+	runTrace := &trace.Trace{
+		RootInvocationID: "invocation", Status: trace.TraceStatusIncomplete,
+		StartedAt: started, EndedAt: started.Add(250 * time.Millisecond),
+		Usage: &model.Usage{TotalTokens: 17},
+		Steps: []trace.Step{{AgentName: "worker", NodeID: "tool", Error: "tool failed"}},
+	}
+	failedCase := evalCase("failed", metric("quality", 0, status.EvalStatusFailed, finalCriterion()))
+	failedCase.EvalCaseResults = []*evalresult.EvalCaseResult{{
+		RunID: 3, ErrorMessage: "runner stopped",
+		EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+			ActualInvocation: &evalset.Invocation{
+				InvocationID: "invocation",
+				FinalResponse: &model.Message{ContentParts: []model.ContentPart{
+					{Type: model.ContentTypeText, Text: &textPart},
+					{Type: model.ContentTypeImage},
+				}},
+				Tools: []*evalset.Tool{{Name: "lookup", Arguments: map[string]any{
+					"openai_api_key": "leak", "token": "leak", "database-password": "leak",
+					"nested": map[string]any{"accessToken": "leak", "clientSecret": "leak"},
+				}, Result: map[string]any{"secret": "leak", "clientSecret": "leak"}}},
+			},
+		}},
+	}}
+	failedCase.RunDetails = []*evaluation.EvaluationCaseRunDetails{{
+		RunID: 3,
+		Inference: &evaluation.EvaluationInferenceDetails{
+			Status: status.EvalStatusFailed, ErrorMessage: "runner stopped",
+			ExecutionTraces: []*trace.Trace{runTrace},
+		},
+	}}
+
+	summary, err := Summarize(&evaluation.EvaluationResult{
+		EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{failedCase},
+	})
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	actual := summary.Cases[0].ActualInvocations[0]
+	if actual.FinalResponse != "structured answer\n[image]" || actual.Route[0].Error != "tool failed" {
+		t.Fatalf("failed evidence = %+v", actual)
+	}
+	if strings.Contains(string(actual.Tools[0].Arguments), "leak") || strings.Contains(string(actual.Tools[0].Result), "leak") {
+		t.Fatalf("tool evidence leaked: arguments=%s result=%s", actual.Tools[0].Arguments, actual.Tools[0].Result)
+	}
+	if summary.Cost.ModelCalls != 0 || summary.Cost.Tokens != 17 || summary.Cost.LatencyMS != 250 {
+		t.Fatalf("cost = %+v", summary.Cost)
+	}
+	if summary.Cases[0].Passed {
+		t.Fatal("failed run was marked passed")
+	}
+}
+
+func TestSafeJSONHashesLongToolResult(t *testing.T) {
+	result := safeJSON(map[string]any{"result": strings.Repeat("x", 20<<10), "bearerToken": "leak"})
+	if strings.Contains(string(result), "leak") || !strings.Contains(string(result), `"truncated":true`) ||
+		!strings.Contains(string(result), `"sha256"`) {
+		t.Fatalf("safeJSON() = %s", result)
+	}
+}
+
+func TestSafeJSONRejectsUnencodableValuesAndRedactsArrays(t *testing.T) {
+	if got := string(safeJSON(make(chan int))); got != "null" {
+		t.Fatalf("safeJSON(channel) = %s", got)
+	}
+	got := string(safeJSON([]any{map[string]any{"authorization": "leak"}, "safe"}))
+	if strings.Contains(got, "leak") || !strings.Contains(got, "redacted") {
+		t.Fatalf("safeJSON(array) = %s", got)
+	}
+}
+
+func TestSummarizeRejectsInvalidResults(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *evaluation.EvaluationResult
+	}{
+		{name: "nil"},
+		{name: "empty eval set", result: &evaluation.EvaluationResult{}},
+		{name: "no metrics", result: &evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{{EvalCaseID: "case"}}}},
+		{name: "duplicate cases", result: &evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{
+			evalCase("case", metric("m", 1, status.EvalStatusPassed, nil)),
+			evalCase("case", metric("m", 1, status.EvalStatusPassed, nil)),
+		}}},
+		{name: "non finite", result: &evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{
+			evalCase("case", metric("m", math.NaN(), status.EvalStatusPassed, nil)),
+		}}},
+		{name: "duplicate metrics", result: &evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{
+			evalCase("case", metric("m", 1, status.EvalStatusPassed, nil), metric("m", 1, status.EvalStatusPassed, nil)),
+		}}},
+		{name: "no evaluated metrics", result: &evaluation.EvaluationResult{EvalSetID: "set", EvalCases: []*evaluation.EvaluationCaseResult{
+			evalCase("case", metric("m", 0, status.EvalStatusNotEvaluated, nil)),
+		}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := Summarize(test.result); err == nil {
+				t.Fatal("Summarize() error = nil")
+			}
+		})
+	}
+}
+
+func TestSummarizeFallsBackToInvocationTrace(t *testing.T) {
+	started := time.Unix(10, 0)
+	result := pipelineResult("set", 0, false)
+	result.EvalCases[0].EvalCaseResults = []*evalresult.EvalCaseResult{{
+		RunID: 1, EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+			ActualInvocation: &evalset.Invocation{InvocationID: "inv", ExecutionTrace: &trace.Trace{
+				StartedAt: started, EndedAt: started.Add(20 * time.Millisecond), Usage: &model.Usage{TotalTokens: 7},
+				Status: trace.TraceStatusIncomplete,
+			}},
+		}},
+	}}
+	summary, err := Summarize(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Cost.Tokens != 7 || summary.Cost.LatencyMS != 20 || summary.Cases[0].Passed {
+		t.Fatalf("summary = %+v", summary)
+	}
+}
+
+func TestSummarizeAlignsRunDetailsTraceByInvocationID(t *testing.T) {
+	result := pipelineResult("set", 0, false)
+	result.EvalCases[0].EvalCaseResults = []*evalresult.EvalCaseResult{{
+		RunID: 7, EvalMetricResultPerInvocation: []*evalresult.EvalMetricResultPerInvocation{{
+			ActualInvocation: &evalset.Invocation{InvocationID: "wanted"},
+		}},
+	}}
+	result.EvalCases[0].RunDetails = []*evaluation.EvaluationCaseRunDetails{{
+		RunID: 7, Inference: &evaluation.EvaluationInferenceDetails{ExecutionTraces: []*trace.Trace{
+			{RootInvocationID: "other", Steps: []trace.Step{{AgentName: "wrong"}}},
+			{RootInvocationID: "wanted", Steps: []trace.Step{{AgentName: "matched"}}},
+		}},
+	}}
+	summary, err := Summarize(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	route := summary.Cases[0].ActualInvocations[0].Route
+	if len(route) != 1 || route[0].Agent != "matched" {
+		t.Fatalf("aligned route = %+v", route)
+	}
+}
+
+func TestTraceExecutionFailed(t *testing.T) {
+	tests := []*trace.Trace{
+		{Status: trace.TraceStatusFailed},
+		{Status: trace.TraceStatusIncomplete},
+		{Status: trace.TraceStatusCompleted, Steps: []trace.Step{{Error: "tool failed"}}},
+	}
+	for _, executionTrace := range tests {
+		if !traceExecutionFailed(executionTrace) {
+			t.Fatalf("traceExecutionFailed(%+v) = false", executionTrace)
+		}
+	}
+	if traceExecutionFailed(&trace.Trace{Status: trace.TraceStatusCompleted}) {
+		t.Fatal("completed trace was marked failed")
+	}
+}
+
+func TestCompareClassifications(t *testing.T) {
+	tests := []struct {
+		name                      string
+		before, after             float64
+		beforePassed, afterPassed bool
+		want                      DeltaKind
+	}{
+		{name: "newly passed", before: 0, after: 1, afterPassed: true, want: DeltaNewlyPassed},
+		{name: "newly failed", before: 1, after: 0, beforePassed: true, want: DeltaNewlyFailed},
+		{name: "improved", before: 0.4, after: 0.6, want: DeltaImproved},
+		{name: "regressed", before: 0.6, after: 0.4, want: DeltaRegressed},
+		{name: "unchanged", before: 0.5, after: 0.5 + scoreDeltaEpsilon/2, want: DeltaUnchanged},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kind, _, err := classifyDelta(test.before, test.after, test.beforePassed, test.afterPassed)
+			if err != nil || kind != test.want {
+				t.Fatalf("classifyDelta() = %q, %v; want %q", kind, err, test.want)
+			}
+		})
+	}
+}
+
+func TestCompareSortsAndComparesMetrics(t *testing.T) {
+	baseline := summary("set", 0.5, false, CaseSummary{
+		ID: "case", Score: 0.5, Metrics: []MetricSummary{
+			{Name: "z", Score: 0, Evaluated: false},
+			{Name: "a", Score: 0.5, Evaluated: true},
+		},
+	})
+	candidate := summary("set", 1, true, CaseSummary{
+		ID: "case", Score: 1, Passed: true, Metrics: []MetricSummary{
+			{Name: "a", Score: 1, Passed: true, Evaluated: true},
+			{Name: "z", Score: 0, Evaluated: false},
+		},
+	})
+	delta, err := Compare(baseline, candidate)
+	if err != nil {
+		t.Fatalf("Compare() error = %v", err)
+	}
+	if delta.Kind != DeltaNewlyPassed || delta.Cases[0].Metrics[0].Name != "a" || delta.Cases[0].Metrics[1].Kind != DeltaUnchanged {
+		t.Fatalf("delta = %+v", delta)
+	}
+}
+
+func TestCompareRejectsDifferentShapes(t *testing.T) {
+	baseline := summary("set", 1, true, CaseSummary{ID: "a"})
+	tests := []*EvalSummary{
+		summary("other", 1, true, CaseSummary{ID: "a"}),
+		summary("set", 1, true, CaseSummary{ID: "b"}),
+		summary("set", 1, true, CaseSummary{ID: "a", Metrics: []MetricSummary{{Name: "new"}}}),
+	}
+	for _, candidate := range tests {
+		if _, err := Compare(baseline, candidate); err == nil {
+			t.Fatalf("Compare(%+v) error = nil", candidate)
+		}
+	}
+}
+
+func TestCompareRejectsInvalidCaseAndMetricIdentities(t *testing.T) {
+	tests := [][2]*EvalSummary{
+		{summary("set", 1, true, CaseSummary{}), summary("set", 1, true, CaseSummary{ID: "case"})},
+		{summary("set", 1, true, CaseSummary{ID: "case"}, CaseSummary{ID: "case"}), summary("set", 1, true, CaseSummary{ID: "case"})},
+		{summary("set", 1, true, CaseSummary{ID: "case", Metrics: []MetricSummary{{}}}), summary("set", 1, true, CaseSummary{ID: "case", Metrics: []MetricSummary{{Name: "m"}}})},
+		{summary("set", 1, true, CaseSummary{ID: "case", Metrics: []MetricSummary{{Name: "m"}, {Name: "m"}}}), summary("set", 1, true, CaseSummary{ID: "case", Metrics: []MetricSummary{{Name: "m"}}})},
+	}
+	for _, pair := range tests {
+		if _, err := Compare(pair[0], pair[1]); err == nil {
+			t.Fatalf("Compare(%+v, %+v) error = nil", pair[0], pair[1])
+		}
+	}
+}
+
+func evalCase(id string, metrics ...*evalresult.EvalMetricResult) *evaluation.EvaluationCaseResult {
+	return &evaluation.EvaluationCaseResult{EvalCaseID: id, MetricResults: metrics}
+}
+
+func metric(name string, score float64, evalStatus status.EvalStatus, c *criterion.Criterion) *evalresult.EvalMetricResult {
+	return &evalresult.EvalMetricResult{MetricName: name, Score: score, Threshold: 0.5, EvalStatus: evalStatus, Criterion: c}
+}
+
+func finalCriterion() *criterion.Criterion {
+	return &criterion.Criterion{FinalResponse: &finalresponse.FinalResponseCriterion{}}
+}
+
+func summary(id string, score float64, passed bool, cases ...CaseSummary) *EvalSummary {
+	return &EvalSummary{EvalSetID: id, Score: score, Passed: passed, Cases: cases}
+}

--- a/evaluation/workflow/promptiter/regression/regression_test.go
+++ b/evaluation/workflow/promptiter/regression/regression_test.go
@@ -88,7 +88,7 @@ func TestSummarizeMetricEvidence(t *testing.T) {
 	if metrics[0].Reason != "missing citation" || strings.Join(metrics[0].RubricTypes, ",") != "format,knowledge" {
 		t.Fatalf("judge metric = %+v", metrics[0])
 	}
-	if metrics[1].Criterion != "tool_trajectory" || !metrics[1].ToolOrderSensitive {
+	if metrics[1].Criterion != "tool_trajectory" {
 		t.Fatalf("tool metric = %+v", metrics[1])
 	}
 }

--- a/evaluation/workflow/promptiter/regression/report.go
+++ b/evaluation/workflow/promptiter/regression/report.go
@@ -1,0 +1,467 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ReportSchemaVersion identifies the audit report contract.
+const ReportSchemaVersion = "v1"
+
+// AuditInput identifies one reproducibility input without exposing absolute paths.
+type AuditInput struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+// RuntimeAudit identifies the deterministic or model-backed runtime.
+type RuntimeAudit struct {
+	Mode         string            `json:"mode"`
+	Provider     string            `json:"provider,omitempty"`
+	Model        string            `json:"model,omitempty"`
+	ConfigSHA256 string            `json:"config_sha256,omitempty"`
+	Config       map[string]string `json:"config,omitempty"`
+}
+
+// AuditMetadata records caller-supplied reproducibility facts.
+type AuditMetadata struct {
+	RunID      string       `json:"run_id"`
+	StartedAt  time.Time    `json:"started_at"`
+	FinishedAt time.Time    `json:"finished_at"`
+	DurationMS int64        `json:"duration_ms"`
+	Seed       int64        `json:"seed"`
+	Inputs     []AuditInput `json:"inputs"`
+	Runtime    RuntimeAudit `json:"runtime"`
+}
+
+// PromptAudit stores prompt text and a stable content hash.
+type PromptAudit struct {
+	Text   string `json:"text"`
+	SHA256 string `json:"sha256"`
+}
+
+// FinalDecision summarizes whether the candidate should be written back.
+type FinalDecision struct {
+	Accepted             bool   `json:"accepted"`
+	WriteBackRecommended bool   `json:"write_back_recommended"`
+	StopReason           string `json:"reason"`
+}
+
+// ReportEvaluation keeps score details while including execution evidence only
+// when it is needed to explain a baseline failure.
+type ReportEvaluation struct {
+	EvalSetID string       `json:"eval_set_id"`
+	Score     float64      `json:"score"`
+	Passed    bool         `json:"passed"`
+	Cases     []ReportCase `json:"cases"`
+}
+
+// ReportCase is the compact audit view of one evaluated case.
+type ReportCase struct {
+	ID                  string              `json:"id"`
+	Score               float64             `json:"score"`
+	Passed              bool                `json:"passed"`
+	Error               string              `json:"error,omitempty"`
+	Metrics             []ReportMetric      `json:"metrics"`
+	ActualInvocations   []InvocationSummary `json:"actual_invocations,omitempty"`
+	ExpectedInvocations []InvocationSummary `json:"expected_invocations,omitempty"`
+}
+
+// ReportMetric omits normalization-only details from the audit summary.
+type ReportMetric struct {
+	Name      string  `json:"name"`
+	Score     float64 `json:"score"`
+	Threshold float64 `json:"threshold"`
+	Passed    bool    `json:"passed"`
+	Evaluated bool    `json:"evaluated"`
+	Reason    string  `json:"reason,omitempty"`
+}
+
+// ReportDatasetDelta contains only changed cases and metrics. Dataset-level
+// scores remain available on the adjacent evaluation summary.
+type ReportDatasetDelta struct {
+	EvalSetID  string            `json:"eval_set_id"`
+	Kind       DeltaKind         `json:"kind"`
+	ScoreDelta float64           `json:"score_delta"`
+	Cases      []ReportCaseDelta `json:"changed_cases,omitempty"`
+}
+
+// ReportCaseDelta is a changed case in a compact dataset delta.
+type ReportCaseDelta struct {
+	ID             string              `json:"id"`
+	Kind           DeltaKind           `json:"kind"`
+	BaselineScore  float64             `json:"baseline_score"`
+	CandidateScore float64             `json:"candidate_score"`
+	ScoreDelta     float64             `json:"score_delta"`
+	Metrics        []ReportMetricDelta `json:"changed_metrics,omitempty"`
+}
+
+// ReportMetricDelta is a changed metric or evaluation-state transition.
+type ReportMetricDelta struct {
+	Name               string    `json:"name"`
+	Kind               DeltaKind `json:"kind"`
+	BaselineScore      float64   `json:"baseline_score"`
+	CandidateScore     float64   `json:"candidate_score"`
+	ScoreDelta         float64   `json:"score_delta"`
+	BaselineEvaluated  bool      `json:"baseline_evaluated"`
+	CandidateEvaluated bool      `json:"candidate_evaluated"`
+}
+
+// ReportRound removes repeated candidate execution evidence already explained
+// by deltas and attribution.
+type ReportRound struct {
+	Number           int                 `json:"number"`
+	InputPrompt      string              `json:"input_prompt"`
+	CandidatePrompt  string              `json:"candidate_prompt"`
+	Hints            []FailureHint       `json:"hints"`
+	Train            *ReportEvaluation   `json:"train"`
+	Validation       *ReportEvaluation   `json:"validation"`
+	TrainDelta       *ReportDatasetDelta `json:"train_delta"`
+	ValidationDelta  *ReportDatasetDelta `json:"validation_delta"`
+	Attribution      *Attribution        `json:"validation_attribution"`
+	Gate             *GateDecision       `json:"gate"`
+	ServingCost      Cost                `json:"serving_cost"`
+	OptimizationCost Cost                `json:"optimization_cost"`
+}
+
+// OptimizationReport is the single source used by JSON and Markdown writers.
+type OptimizationReport struct {
+	SchemaVersion                 string            `json:"schema_version"`
+	Status                        string            `json:"status"`
+	Audit                         AuditMetadata     `json:"audit"`
+	InitialPrompt                 PromptAudit       `json:"initial_prompt"`
+	AcceptedPrompt                PromptAudit       `json:"accepted_prompt"`
+	BaselineTrain                 *ReportEvaluation `json:"baseline_train"`
+	BaselineValidation            *ReportEvaluation `json:"baseline_validation"`
+	BaselineTrainAttribution      *Attribution      `json:"baseline_train_attribution"`
+	BaselineValidationAttribution *Attribution      `json:"baseline_validation_attribution"`
+	Rounds                        []ReportRound     `json:"rounds"`
+	Decision                      FinalDecision     `json:"decision"`
+	Cost                          Cost              `json:"cost"`
+}
+
+// BuildReport validates a completed run and builds its auditable representation.
+func BuildReport(run *OptimizationRun, metadata AuditMetadata) (*OptimizationReport, error) {
+	if run == nil || run.BaselineTrain == nil || run.BaselineValidation == nil {
+		return nil, errors.New("optimization run or baseline results are missing")
+	}
+	if strings.TrimSpace(run.InitialPrompt) == "" || strings.TrimSpace(run.AcceptedPrompt) == "" {
+		return nil, errors.New("optimization run prompts are missing")
+	}
+	if strings.TrimSpace(run.StopReason) == "" {
+		return nil, errors.New("optimization run stop reason is missing")
+	}
+	for index, round := range run.Rounds {
+		if round.Number <= 0 || round.Train == nil || round.Validation == nil ||
+			round.TrainDelta == nil || round.ValidationDelta == nil || round.Gate == nil {
+			return nil, fmt.Errorf("round at index %d is incomplete", index)
+		}
+		if _, err := addCosts(round.ServingCost, round.OptimizationCost); err != nil {
+			return nil, fmt.Errorf("round %d cost: %w", round.Number, err)
+		}
+	}
+	normalized, err := normalizeAudit(metadata, run.Seed)
+	if err != nil {
+		return nil, err
+	}
+	status := "rejected"
+	if run.WriteBackRecommended {
+		status = "accepted"
+	} else if len(run.Rounds) == 0 {
+		status = "not_optimized"
+	}
+	baselineTrainAttribution, err := Attribute(run.BaselineTrain)
+	if err != nil {
+		return nil, fmt.Errorf("attribute baseline train: %w", err)
+	}
+	baselineValidationAttribution, err := Attribute(run.BaselineValidation)
+	if err != nil {
+		return nil, fmt.Errorf("attribute baseline validation: %w", err)
+	}
+	return &OptimizationReport{
+		SchemaVersion: ReportSchemaVersion, Status: status, Audit: normalized,
+		InitialPrompt: promptAudit(run.InitialPrompt), AcceptedPrompt: promptAudit(run.AcceptedPrompt),
+		BaselineTrain:                 reportEvaluation(run.BaselineTrain, true),
+		BaselineValidation:            reportEvaluation(run.BaselineValidation, true),
+		BaselineTrainAttribution:      baselineTrainAttribution,
+		BaselineValidationAttribution: baselineValidationAttribution,
+		Rounds:                        reportRounds(run.Rounds),
+		Decision: FinalDecision{
+			Accepted: run.WriteBackRecommended, WriteBackRecommended: run.WriteBackRecommended,
+			StopReason: run.StopReason,
+		},
+		Cost: run.TotalCost,
+	}, nil
+}
+
+func reportEvaluation(summary *EvalSummary, includeFailureEvidence bool) *ReportEvaluation {
+	result := &ReportEvaluation{EvalSetID: summary.EvalSetID, Score: summary.Score, Passed: summary.Passed,
+		Cases: make([]ReportCase, 0, len(summary.Cases))}
+	for _, evalCase := range summary.Cases {
+		item := ReportCase{ID: evalCase.ID, Score: evalCase.Score, Passed: evalCase.Passed, Error: evalCase.Error}
+		for _, metric := range evalCase.Metrics {
+			item.Metrics = append(item.Metrics, ReportMetric{
+				Name: metric.Name, Score: metric.Score, Threshold: metric.Threshold,
+				Passed: metric.Passed, Evaluated: metric.Evaluated, Reason: metric.Reason,
+			})
+		}
+		if includeFailureEvidence && !evalCase.Passed {
+			item.ActualInvocations = evalCase.ActualInvocations
+			item.ExpectedInvocations = evalCase.ExpectedInvocations
+		}
+		result.Cases = append(result.Cases, item)
+	}
+	return result
+}
+
+func reportRounds(rounds []Round) []ReportRound {
+	result := make([]ReportRound, 0, len(rounds))
+	for _, round := range rounds {
+		result = append(result, ReportRound{
+			Number: round.Number, InputPrompt: round.InputPrompt, CandidatePrompt: round.CandidatePrompt,
+			Hints: round.Hints, Train: reportEvaluation(round.Train, false),
+			Validation: reportEvaluation(round.Validation, false), TrainDelta: reportDelta(round.TrainDelta),
+			ValidationDelta: reportDelta(round.ValidationDelta), Attribution: round.Attribution, Gate: round.Gate,
+			ServingCost: round.ServingCost, OptimizationCost: round.OptimizationCost,
+		})
+	}
+	return result
+}
+
+func reportDelta(delta *DatasetDelta) *ReportDatasetDelta {
+	result := &ReportDatasetDelta{EvalSetID: delta.EvalSetID, Kind: delta.Kind, ScoreDelta: delta.ScoreDelta}
+	for _, evalCase := range delta.Cases {
+		item := ReportCaseDelta{ID: evalCase.ID, Kind: evalCase.Kind, BaselineScore: evalCase.BaselineScore,
+			CandidateScore: evalCase.CandidateScore, ScoreDelta: evalCase.ScoreDelta}
+		for _, metric := range evalCase.Metrics {
+			if metric.Kind == DeltaUnchanged && metric.BaselineEvaluated == metric.CandidateEvaluated {
+				continue
+			}
+			item.Metrics = append(item.Metrics, ReportMetricDelta{Name: metric.Name, Kind: metric.Kind,
+				BaselineScore: metric.BaselineScore, CandidateScore: metric.CandidateScore, ScoreDelta: metric.ScoreDelta,
+				BaselineEvaluated: metric.BaselineEvaluated, CandidateEvaluated: metric.CandidateEvaluated})
+		}
+		if evalCase.Kind != DeltaUnchanged || len(item.Metrics) > 0 {
+			result.Cases = append(result.Cases, item)
+		}
+	}
+	return result
+}
+
+// WriteJSON writes deterministic, indented JSON.
+func WriteJSON(writer io.Writer, report *OptimizationReport) error {
+	if writer == nil || report == nil {
+		return errors.New("JSON writer and report are required")
+	}
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(report)
+}
+
+// WriteMarkdown writes a concise human-readable audit report.
+func WriteMarkdown(writer io.Writer, report *OptimizationReport) error {
+	if writer == nil || report == nil {
+		return errors.New("Markdown writer and report are required")
+	}
+	var output strings.Builder
+	fmt.Fprintf(&output, "# Prompt Optimization Report\n\n")
+	fmt.Fprintf(&output, "- Status: **%s**\n", report.Status)
+	fmt.Fprintf(&output, "- Decision: %s\n", report.Decision.StopReason)
+	fmt.Fprintf(&output, "- Seed: %d\n", report.Audit.Seed)
+	fmt.Fprintf(&output, "- Runtime: %s", report.Audit.Runtime.Mode)
+	if report.Audit.Runtime.Model != "" {
+		fmt.Fprintf(&output, " (%s)", report.Audit.Runtime.Model)
+	}
+	fmt.Fprintln(&output)
+	fmt.Fprintln(&output)
+
+	fmt.Fprintln(&output, "## Baseline")
+	fmt.Fprintln(&output)
+	fmt.Fprintln(&output, "| Dataset | Score | Passed |")
+	fmt.Fprintln(&output, "| --- | ---: | :---: |")
+	markdownScoreRow(&output, "Train", report.BaselineTrain)
+	markdownScoreRow(&output, "Validation", report.BaselineValidation)
+	fmt.Fprintln(&output, "\n### Train failures")
+	writeAttribution(&output, report.BaselineTrainAttribution)
+	fmt.Fprintln(&output, "\n### Validation failures")
+	writeAttribution(&output, report.BaselineValidationAttribution)
+
+	fmt.Fprintln(&output, "\n## Optimization Rounds")
+	if len(report.Rounds) == 0 {
+		fmt.Fprintln(&output, "\nNo candidate was generated.")
+	}
+	for _, round := range report.Rounds {
+		fmt.Fprintf(&output, "\n### Round %d\n\n", round.Number)
+		fmt.Fprintf(&output, "- Gate: **%s**\n", acceptedText(round.Gate != nil && round.Gate.Accepted))
+		fmt.Fprintln(&output, "- Candidate prompt:")
+		fmt.Fprintf(&output, "\n```text\n%s\n```\n", markdownCodeBlock(round.CandidatePrompt))
+		if round.Gate != nil {
+			for _, reason := range round.Gate.Reasons {
+				fmt.Fprintf(&output, "  - %s\n", reason)
+			}
+		}
+		fmt.Fprintf(&output, "- Train score: %.6f (%+.6f)\n", round.Train.Score, round.TrainDelta.ScoreDelta)
+		fmt.Fprintf(&output, "- Validation score: %.6f (%+.6f)\n", round.Validation.Score, round.ValidationDelta.ScoreDelta)
+		fmt.Fprintf(&output, "- Evaluation cost: %s\n", costText(round.ServingCost))
+		fmt.Fprintf(&output, "- Optimization cost: %s\n", costText(round.OptimizationCost))
+		roundCost, _ := addCosts(round.ServingCost, round.OptimizationCost)
+		fmt.Fprintf(&output, "- Round total: %s\n", costText(roundCost))
+		writeCaseDeltas(&output, round.ValidationDelta)
+		writeMetricDeltas(&output, round.ValidationDelta)
+		writeAttribution(&output, round.Attribution)
+	}
+
+	fmt.Fprintln(&output, "\n## Cost")
+	fmt.Fprintln(&output)
+	fmt.Fprintf(&output, "- Model calls: %d\n- Tokens: %d\n- Latency: %d ms\n",
+		report.Cost.ModelCalls, report.Cost.Tokens, report.Cost.LatencyMS)
+	_, err := io.WriteString(writer, output.String())
+	return err
+}
+
+func normalizeAudit(metadata AuditMetadata, seed int64) (AuditMetadata, error) {
+	if metadata.RunID == "" || metadata.StartedAt.IsZero() || metadata.FinishedAt.IsZero() {
+		return AuditMetadata{}, errors.New("audit run id and timestamps are required")
+	}
+	if metadata.FinishedAt.Before(metadata.StartedAt) {
+		return AuditMetadata{}, errors.New("audit finish time precedes start time")
+	}
+	metadata.Seed = seed
+	metadata.DurationMS = metadata.FinishedAt.Sub(metadata.StartedAt).Milliseconds()
+	metadata.Inputs = append([]AuditInput(nil), metadata.Inputs...)
+	sort.Slice(metadata.Inputs, func(i, j int) bool { return metadata.Inputs[i].Name < metadata.Inputs[j].Name })
+	for index := range metadata.Inputs {
+		input := &metadata.Inputs[index]
+		if input.Name == "" || input.SHA256 == "" {
+			return AuditMetadata{}, errors.New("audit input name and sha256 are required")
+		}
+		input.Path = filepath.Base(input.Path)
+	}
+	metadata.Runtime.Config = cloneAndRedactConfig(metadata.Runtime.Config)
+	if metadata.Runtime.Mode == "" {
+		return AuditMetadata{}, errors.New("audit runtime mode is required")
+	}
+	return metadata, nil
+}
+
+func cloneAndRedactConfig(config map[string]string) map[string]string {
+	if len(config) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(config))
+	for key, value := range config {
+		if sensitiveKey(key) {
+			value = "<redacted>"
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func promptAudit(text string) PromptAudit {
+	hash := sha256.Sum256([]byte(text))
+	return PromptAudit{Text: text, SHA256: fmt.Sprintf("%x", hash)}
+}
+
+func markdownScoreRow(output *strings.Builder, name string, summary *ReportEvaluation) {
+	fmt.Fprintf(output, "| %s | %.6f | %t |\n", name, summary.Score, summary.Passed)
+}
+
+func acceptedText(accepted bool) string {
+	if accepted {
+		return "accepted"
+	}
+	return "rejected"
+}
+
+func writeCaseDeltas(output *strings.Builder, delta *ReportDatasetDelta) {
+	if delta == nil {
+		return
+	}
+	fmt.Fprintln(output, "\n| Case | Change | Baseline | Candidate | Delta |")
+	fmt.Fprintln(output, "| --- | --- | ---: | ---: | ---: |")
+	for _, evalCase := range delta.Cases {
+		fmt.Fprintf(output, "| %s | %s | %.6f | %.6f | %+.6f |\n",
+			markdownCell(evalCase.ID), evalCase.Kind, evalCase.BaselineScore, evalCase.CandidateScore, evalCase.ScoreDelta)
+	}
+}
+
+func writeMetricDeltas(output *strings.Builder, delta *ReportDatasetDelta) {
+	if delta == nil {
+		return
+	}
+	wroteHeader := false
+	for _, evalCase := range delta.Cases {
+		for _, metric := range evalCase.Metrics {
+			if metric.Kind == DeltaUnchanged && metric.BaselineEvaluated == metric.CandidateEvaluated {
+				continue
+			}
+			if !wroteHeader {
+				fmt.Fprintln(output, "\nChanged metrics:")
+				fmt.Fprintln(output, "\n| Case | Metric | Change | Baseline | Candidate | Delta |")
+				fmt.Fprintln(output, "| --- | --- | --- | ---: | ---: | ---: |")
+				wroteHeader = true
+			}
+			fmt.Fprintf(output, "| %s | %s | %s | %.6f | %.6f | %+.6f |\n",
+				markdownCell(evalCase.ID), markdownCell(metric.Name), metricChange(metric),
+				metric.BaselineScore, metric.CandidateScore, metric.ScoreDelta)
+		}
+	}
+}
+
+func metricChange(metric ReportMetricDelta) string {
+	if metric.BaselineEvaluated != metric.CandidateEvaluated {
+		if metric.CandidateEvaluated {
+			return "newly_evaluated"
+		}
+		return "no_longer_evaluated"
+	}
+	return string(metric.Kind)
+}
+
+func costText(cost Cost) string {
+	return fmt.Sprintf("%d calls, %d tokens, %d ms", cost.ModelCalls, cost.Tokens, cost.LatencyMS)
+}
+
+func writeAttribution(output *strings.Builder, attribution *Attribution) {
+	if attribution == nil || len(attribution.Counts) == 0 {
+		return
+	}
+	categories := make([]string, 0, len(attribution.Counts))
+	for category := range attribution.Counts {
+		categories = append(categories, string(category))
+	}
+	sort.Strings(categories)
+	fmt.Fprintln(output, "\nFailure attribution:")
+	for _, category := range categories {
+		fmt.Fprintf(output, "- %s: %d\n", category, attribution.Counts[FailureCategory(category)])
+	}
+	for _, failure := range attribution.Failures {
+		fmt.Fprintf(output, "  - %s: %s — %s\n", markdownCell(failure.CaseID), failure.Category, markdownCell(failure.Reason))
+	}
+}
+
+func markdownCell(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "|", "\\|"), "\n", " ")
+}
+
+func markdownCodeBlock(value string) string {
+	return strings.ReplaceAll(value, "```", "` ` `")
+}

--- a/evaluation/workflow/promptiter/regression/report.go
+++ b/evaluation/workflow/promptiter/regression/report.go
@@ -134,6 +134,7 @@ type ReportRound struct {
 	Validation       *ReportEvaluation   `json:"validation"`
 	TrainDelta       *ReportDatasetDelta `json:"train_delta"`
 	ValidationDelta  *ReportDatasetDelta `json:"validation_delta"`
+	TrainAttribution *Attribution        `json:"train_attribution"`
 	Attribution      *Attribution        `json:"validation_attribution"`
 	Gate             *GateDecision       `json:"gate"`
 	ServingCost      Cost                `json:"serving_cost"`
@@ -237,7 +238,8 @@ func reportRounds(rounds []Round) []ReportRound {
 			Number: round.Number, InputPrompt: round.InputPrompt, CandidatePrompt: round.CandidatePrompt,
 			Hints: round.Hints, Train: reportEvaluation(round.Train, false),
 			Validation: reportEvaluation(round.Validation, false), TrainDelta: reportDelta(round.TrainDelta),
-			ValidationDelta: reportDelta(round.ValidationDelta), Attribution: round.Attribution, Gate: round.Gate,
+			ValidationDelta:  reportDelta(round.ValidationDelta),
+			TrainAttribution: round.TrainAttribution, Attribution: round.Attribution, Gate: round.Gate,
 			ServingCost: round.ServingCost, OptimizationCost: round.OptimizationCost,
 		})
 	}

--- a/evaluation/workflow/promptiter/regression/report_test.go
+++ b/evaluation/workflow/promptiter/regression/report_test.go
@@ -1,0 +1,196 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildReportAndWriters(t *testing.T) {
+	baselineTrain, err := Summarize(pipelineResult("train", 0.4, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	baselineValidation, err := Summarize(pipelineResult("validation", 0.4, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateTrain, err := Summarize(pipelineResult("train", 0.8, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateValidation, err := Summarize(pipelineResult("validation", 0.8, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	trainDelta, _ := Compare(baselineTrain, candidateTrain)
+	validationDelta, _ := Compare(baselineValidation, candidateValidation)
+	attribution, _ := Attribute(candidateValidation)
+	run := &OptimizationRun{
+		InitialPrompt: "baseline prompt", AcceptedPrompt: "candidate prompt",
+		BaselineTrain: baselineTrain, BaselineValidation: baselineValidation,
+		AcceptedTrain: candidateTrain, AcceptedValidation: candidateValidation,
+		Rounds: []Round{{
+			Number: 1, InputPrompt: "baseline prompt", CandidatePrompt: "candidate prompt",
+			Train: candidateTrain, Validation: candidateValidation,
+			TrainDelta: trainDelta, ValidationDelta: validationDelta, Attribution: attribution,
+			Gate: &GateDecision{Accepted: true}, ServingCost: Cost{ModelCalls: 2, Tokens: 20},
+		}},
+		TotalCost:            Cost{ModelCalls: 4, Tokens: 40, LatencyMS: 10},
+		WriteBackRecommended: true, StopReason: "candidate accepted by regression gate", Seed: 2003,
+	}
+	started := time.Date(2026, 7, 18, 8, 0, 0, 0, time.UTC)
+	report, err := BuildReport(run, AuditMetadata{
+		RunID: "run-2003", StartedAt: started, FinishedAt: started.Add(2 * time.Second),
+		Inputs: []AuditInput{
+			{Name: "validation", Path: "/private/data/validation.evalset.json", SHA256: "def"},
+			{Name: "train", Path: "/private/data/train.evalset.json", SHA256: "abc"},
+		},
+		Runtime: RuntimeAudit{
+			Mode: "fake", Model: "deterministic", Config: map[string]string{
+				"openai_api_key": "must-not-leak", "scenario": "regression",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildReport() error = %v", err)
+	}
+	if report.Status != "accepted" || report.Audit.DurationMS != 2000 || report.Audit.Seed != 2003 {
+		t.Fatalf("report = %+v", report)
+	}
+	if report.Audit.Inputs[0].Name != "train" || report.Audit.Inputs[0].Path != "train.evalset.json" {
+		t.Fatalf("inputs = %+v", report.Audit.Inputs)
+	}
+	if report.Audit.Runtime.Config["openai_api_key"] != "<redacted>" || report.InitialPrompt.SHA256 == "" {
+		t.Fatalf("audit = %+v, prompt = %+v", report.Audit, report.InitialPrompt)
+	}
+
+	var jsonOutput bytes.Buffer
+	if err := WriteJSON(&jsonOutput, report); err != nil {
+		t.Fatalf("WriteJSON() error = %v", err)
+	}
+	var decoded OptimizationReport
+	if err := json.Unmarshal(jsonOutput.Bytes(), &decoded); err != nil {
+		t.Fatalf("JSON is invalid: %v", err)
+	}
+	if decoded.Decision.StopReason != run.StopReason || strings.Contains(jsonOutput.String(), "must-not-leak") || strings.Contains(jsonOutput.String(), "/private/") {
+		t.Fatalf("JSON output leaked or lost data: %s", jsonOutput.String())
+	}
+	metric := decoded.BaselineTrain.Cases[0].Metrics[0]
+	if metric.Passed || !metric.Evaluated || metric.Threshold != 0.5 || metric.Reason == "" {
+		t.Fatalf("report metric lost evaluation facts: %+v", metric)
+	}
+
+	var markdown bytes.Buffer
+	if err := WriteMarkdown(&markdown, report); err != nil {
+		t.Fatalf("WriteMarkdown() error = %v", err)
+	}
+	for _, text := range []string{
+		"Status: **accepted**", "Train failures", "Validation failures", "Round 1",
+		"Validation score", "Evaluation cost: 2 calls, 20 tokens", "Changed metrics", "newly_passed", "Model calls: 4",
+	} {
+		if !strings.Contains(markdown.String(), text) {
+			t.Fatalf("Markdown does not contain %q:\n%s", text, markdown.String())
+		}
+	}
+}
+
+func TestBuildReportWithoutCandidate(t *testing.T) {
+	baseline, err := Summarize(pipelineResult("train", 1, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := BuildReport(&OptimizationRun{
+		InitialPrompt: "baseline", AcceptedPrompt: "baseline",
+		BaselineTrain: baseline, BaselineValidation: baseline,
+		StopReason: "no optimizable training failures",
+	}, validAudit())
+	if err != nil {
+		t.Fatalf("BuildReport() error = %v", err)
+	}
+	if report.Status != "not_optimized" || report.Decision.Accepted {
+		t.Fatalf("report = %+v", report)
+	}
+	var markdown bytes.Buffer
+	if err := WriteMarkdown(&markdown, report); err != nil || !strings.Contains(markdown.String(), "No candidate was generated") {
+		t.Fatalf("WriteMarkdown() = %v\n%s", err, markdown.String())
+	}
+}
+
+func TestBuildReportRejectsIncompleteInputs(t *testing.T) {
+	if _, err := BuildReport(nil, validAudit()); err == nil {
+		t.Fatal("BuildReport(nil) error = nil")
+	}
+	baseline, _ := Summarize(pipelineResult("train", 1, true))
+	if _, err := BuildReport(&OptimizationRun{
+		InitialPrompt: "prompt", AcceptedPrompt: "prompt", BaselineTrain: baseline,
+		BaselineValidation: baseline, StopReason: "done",
+	}, AuditMetadata{}); err == nil {
+		t.Fatal("BuildReport() accepted incomplete audit")
+	}
+	if _, err := BuildReport(&OptimizationRun{
+		InitialPrompt: "prompt", AcceptedPrompt: "prompt", BaselineTrain: baseline,
+		BaselineValidation: baseline, StopReason: "done", Rounds: []Round{{Number: 1}},
+	}, validAudit()); err == nil || !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("BuildReport() incomplete round error = %v", err)
+	}
+	for _, run := range []*OptimizationRun{
+		{BaselineTrain: baseline, BaselineValidation: baseline, StopReason: "done"},
+		{InitialPrompt: "prompt", AcceptedPrompt: "prompt", BaselineTrain: baseline, BaselineValidation: baseline},
+		{InitialPrompt: "prompt", AcceptedPrompt: "prompt", BaselineTrain: baseline, BaselineValidation: baseline,
+			StopReason: "done", Rounds: []Round{{Number: 1, Train: baseline, Validation: baseline,
+				TrainDelta: &DatasetDelta{}, ValidationDelta: &DatasetDelta{}, Gate: &GateDecision{}, ServingCost: Cost{Tokens: -1}}}},
+	} {
+		if _, err := BuildReport(run, validAudit()); err == nil {
+			t.Fatalf("BuildReport(%+v) error = nil", run)
+		}
+	}
+}
+
+func TestReportRejectsInvalidWritersAndAudit(t *testing.T) {
+	baseline, _ := Summarize(pipelineResult("train", 1, true))
+	run := &OptimizationRun{InitialPrompt: "prompt", AcceptedPrompt: "prompt", BaselineTrain: baseline,
+		BaselineValidation: baseline, StopReason: "done"}
+	if err := WriteJSON(nil, &OptimizationReport{}); err == nil {
+		t.Fatal("WriteJSON(nil) error = nil")
+	}
+	if err := WriteJSON(&bytes.Buffer{}, nil); err == nil {
+		t.Fatal("WriteJSON(nil report) error = nil")
+	}
+	if err := WriteMarkdown(nil, &OptimizationReport{}); err == nil {
+		t.Fatal("WriteMarkdown(nil) error = nil")
+	}
+	if err := WriteMarkdown(&bytes.Buffer{}, nil); err == nil {
+		t.Fatal("WriteMarkdown(nil report) error = nil")
+	}
+	started := time.Now().UTC()
+	audits := []AuditMetadata{
+		{RunID: "run", StartedAt: started, FinishedAt: started.Add(-time.Second), Runtime: RuntimeAudit{Mode: "fake"}},
+		{RunID: "run", StartedAt: started, FinishedAt: started, Runtime: RuntimeAudit{}},
+		{RunID: "run", StartedAt: started, FinishedAt: started, Runtime: RuntimeAudit{Mode: "fake"}, Inputs: []AuditInput{{SHA256: "hash"}}},
+		{RunID: "run", StartedAt: started, FinishedAt: started, Runtime: RuntimeAudit{Mode: "fake"}, Inputs: []AuditInput{{Name: "input"}}},
+	}
+	for _, audit := range audits {
+		if _, err := BuildReport(run, audit); err == nil {
+			t.Fatalf("BuildReport(%+v) error = nil", audit)
+		}
+	}
+}
+
+func validAudit() AuditMetadata {
+	started := time.Date(2026, 7, 18, 8, 0, 0, 0, time.UTC)
+	return AuditMetadata{
+		RunID: "run", StartedAt: started, FinishedAt: started.Add(time.Second),
+		Runtime: RuntimeAudit{Mode: "fake"},
+	}
+}

--- a/evaluation/workflow/promptiter/regression/result.go
+++ b/evaluation/workflow/promptiter/regression/result.go
@@ -93,6 +93,10 @@ type RouteStep struct {
 
 // Summarize converts a normal Evaluation Service result into deterministic facts.
 func Summarize(result *evaluation.EvaluationResult) (*EvalSummary, error) {
+	return summarize(result, nil)
+}
+
+func summarize(result *evaluation.EvaluationResult, configuredMetricNames []string) (*EvalSummary, error) {
 	if result == nil {
 		return nil, errors.New("evaluation result is nil")
 	}
@@ -122,7 +126,7 @@ func Summarize(result *evaluation.EvaluationResult) (*EvalSummary, error) {
 		if i > 0 && cases[i-1].EvalCaseID == evalCase.EvalCaseID {
 			return nil, fmt.Errorf("duplicate evaluation case %q", evalCase.EvalCaseID)
 		}
-		caseSummary, score, count, err := summarizeCase(evalCase)
+		caseSummary, score, count, err := summarizeCase(evalCase, configuredMetricNames)
 		if err != nil {
 			return nil, fmt.Errorf("summarize case %q: %w", evalCase.EvalCaseID, err)
 		}
@@ -142,7 +146,9 @@ func Summarize(result *evaluation.EvaluationResult) (*EvalSummary, error) {
 	return summary, nil
 }
 
-func summarizeCase(evalCase *evaluation.EvaluationCaseResult) (CaseSummary, float64, int, error) {
+func summarizeCase(
+	evalCase *evaluation.EvaluationCaseResult, configuredMetricNames []string,
+) (CaseSummary, float64, int, error) {
 	summary := CaseSummary{ID: evalCase.EvalCaseID}
 	for _, run := range evalCase.EvalCaseResults {
 		if run != nil && strings.TrimSpace(run.ErrorMessage) != "" {
@@ -169,6 +175,13 @@ func summarizeCase(evalCase *evaluation.EvaluationCaseResult) (CaseSummary, floa
 	}
 
 	metrics := append([]*evalresult.EvalMetricResult(nil), evalCase.MetricResults...)
+	if len(metrics) == 0 && summary.Error != "" {
+		var err error
+		metrics, err = failedMetricResults(configuredMetricNames, summary.Error)
+		if err != nil {
+			return CaseSummary{}, 0, 0, err
+		}
+	}
 	sort.Slice(metrics, func(i, j int) bool {
 		if metrics[i] == nil {
 			return true
@@ -207,6 +220,30 @@ func summarizeCase(evalCase *evaluation.EvaluationCaseResult) (CaseSummary, floa
 	summary.Passed = allPassed
 	summary.ActualInvocations, summary.ExpectedInvocations = invocationEvidence(evalCase)
 	return summary, total, count, nil
+}
+
+func failedMetricResults(metricNames []string, reason string) ([]*evalresult.EvalMetricResult, error) {
+	if len(metricNames) == 0 {
+		return nil, errors.New("execution failure has no configured metric identities")
+	}
+	seen := make(map[string]struct{}, len(metricNames))
+	results := make([]*evalresult.EvalMetricResult, 0, len(metricNames))
+	for index, name := range metricNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, fmt.Errorf("configured metric at index %d has no name", index)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate configured metric %q", name)
+		}
+		seen[name] = struct{}{}
+		results = append(results, &evalresult.EvalMetricResult{
+			MetricName: name,
+			EvalStatus: status.EvalStatusFailed,
+			Details:    &evalresult.EvalMetricResultDetails{Reason: reason},
+		})
+	}
+	return results, nil
 }
 
 func summarizeMetric(metric *evalresult.EvalMetricResult, runs []*evalresult.EvalCaseResult) MetricSummary {

--- a/evaluation/workflow/promptiter/regression/result.go
+++ b/evaluation/workflow/promptiter/regression/result.go
@@ -1,0 +1,524 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package regression compares Evaluation Service results for PromptIter workflows.
+package regression
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// EvalSummary is the compact result shared by comparison, gating, and reports.
+type EvalSummary struct {
+	EvalSetID string        `json:"eval_set_id"`
+	Score     float64       `json:"score"`
+	Passed    bool          `json:"passed"`
+	LatencyMS int64         `json:"latency_ms"`
+	Cost      Cost          `json:"cost"`
+	Cases     []CaseSummary `json:"cases"`
+}
+
+// Cost is the model usage observed in execution traces, including failed runs.
+type Cost struct {
+	// ModelCalls is populated by a runtime model wrapper; traces cannot provide
+	// an exact count because their usage may aggregate several model calls.
+	ModelCalls int   `json:"model_calls"`
+	Tokens     int64 `json:"tokens"`
+	LatencyMS  int64 `json:"latency_ms"`
+}
+
+// CaseSummary contains one case's aggregate metrics and attribution evidence.
+type CaseSummary struct {
+	ID                  string              `json:"id"`
+	Score               float64             `json:"score"`
+	Passed              bool                `json:"passed"`
+	Error               string              `json:"error,omitempty"`
+	Metrics             []MetricSummary     `json:"metrics"`
+	ActualInvocations   []InvocationSummary `json:"actual_invocations,omitempty"`
+	ExpectedInvocations []InvocationSummary `json:"expected_invocations,omitempty"`
+}
+
+// MetricSummary contains the aggregate facts needed to compare and explain a metric.
+type MetricSummary struct {
+	Name               string   `json:"name"`
+	Score              float64  `json:"score"`
+	Threshold          float64  `json:"threshold"`
+	Passed             bool     `json:"passed"`
+	Evaluated          bool     `json:"evaluated"`
+	Reason             string   `json:"reason,omitempty"`
+	Criterion          string   `json:"criterion,omitempty"`
+	RubricTypes        []string `json:"rubric_types,omitempty"`
+	ToolOrderSensitive bool     `json:"tool_order_sensitive,omitempty"`
+}
+
+// InvocationSummary is the bounded execution evidence used by failure attribution.
+type InvocationSummary struct {
+	FinalResponse string        `json:"final_response,omitempty"`
+	Tools         []ToolSummary `json:"tools,omitempty"`
+	Route         []RouteStep   `json:"route,omitempty"`
+}
+
+// ToolSummary is one tool call in invocation order.
+type ToolSummary struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	Result    json.RawMessage `json:"result,omitempty"`
+}
+
+// RouteStep is the stable routing identity of one execution trace step.
+type RouteStep struct {
+	Agent  string `json:"agent,omitempty"`
+	Branch string `json:"branch,omitempty"`
+	NodeID string `json:"node_id,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Summarize converts a normal Evaluation Service result into deterministic facts.
+func Summarize(result *evaluation.EvaluationResult) (*EvalSummary, error) {
+	if result == nil {
+		return nil, errors.New("evaluation result is nil")
+	}
+	if strings.TrimSpace(result.EvalSetID) == "" {
+		return nil, errors.New("evaluation result has no eval set id")
+	}
+	if result.ExecutionTime < 0 {
+		return nil, errors.New("evaluation result has negative execution time")
+	}
+	cases := append([]*evaluation.EvaluationCaseResult(nil), result.EvalCases...)
+	sort.Slice(cases, func(i, j int) bool {
+		if cases[i] == nil {
+			return true
+		}
+		if cases[j] == nil {
+			return false
+		}
+		return cases[i].EvalCaseID < cases[j].EvalCaseID
+	})
+	summary := &EvalSummary{EvalSetID: result.EvalSetID, LatencyMS: result.ExecutionTime.Milliseconds()}
+	var total float64
+	var metricCount int
+	for i, evalCase := range cases {
+		if evalCase == nil || strings.TrimSpace(evalCase.EvalCaseID) == "" {
+			return nil, fmt.Errorf("evaluation case at index %d is nil or has no id", i)
+		}
+		if i > 0 && cases[i-1].EvalCaseID == evalCase.EvalCaseID {
+			return nil, fmt.Errorf("duplicate evaluation case %q", evalCase.EvalCaseID)
+		}
+		caseSummary, score, count, err := summarizeCase(evalCase)
+		if err != nil {
+			return nil, fmt.Errorf("summarize case %q: %w", evalCase.EvalCaseID, err)
+		}
+		summary.Cases = append(summary.Cases, caseSummary)
+		addCaseCost(&summary.Cost, evalCase)
+		total += score
+		metricCount += count
+	}
+	if metricCount == 0 {
+		return nil, errors.New("evaluation result has no evaluated metrics")
+	}
+	summary.Score = total / float64(metricCount)
+	summary.Passed = len(summary.Cases) > 0
+	for _, evalCase := range summary.Cases {
+		summary.Passed = summary.Passed && evalCase.Passed
+	}
+	return summary, nil
+}
+
+func summarizeCase(evalCase *evaluation.EvaluationCaseResult) (CaseSummary, float64, int, error) {
+	summary := CaseSummary{ID: evalCase.EvalCaseID}
+	for _, run := range evalCase.EvalCaseResults {
+		if run != nil && strings.TrimSpace(run.ErrorMessage) != "" {
+			summary.Error = run.ErrorMessage
+			break
+		}
+	}
+	if summary.Error == "" {
+		for _, detail := range evalCase.RunDetails {
+			if detail == nil || detail.Inference == nil {
+				continue
+			}
+			if detail.Inference.ErrorMessage != "" {
+				summary.Error = detail.Inference.ErrorMessage
+			} else if detail.Inference.Status == status.EvalStatusFailed {
+				summary.Error = "inference failed"
+			}
+			for _, executionTrace := range detail.Inference.ExecutionTraces {
+				if summary.Error == "" && traceExecutionFailed(executionTrace) {
+					summary.Error = "execution trace failed"
+				}
+			}
+		}
+	}
+
+	metrics := append([]*evalresult.EvalMetricResult(nil), evalCase.MetricResults...)
+	sort.Slice(metrics, func(i, j int) bool {
+		if metrics[i] == nil {
+			return true
+		}
+		if metrics[j] == nil {
+			return false
+		}
+		return metrics[i].MetricName < metrics[j].MetricName
+	})
+	var total float64
+	var count int
+	allPassed := summary.Error == ""
+	for i, metric := range metrics {
+		if metric == nil || strings.TrimSpace(metric.MetricName) == "" {
+			return CaseSummary{}, 0, 0, fmt.Errorf("metric at index %d is nil or has no name", i)
+		}
+		if i > 0 && metrics[i-1].MetricName == metric.MetricName {
+			return CaseSummary{}, 0, 0, fmt.Errorf("duplicate metric %q", metric.MetricName)
+		}
+		if !finite(metric.Score) || !finite(metric.Threshold) {
+			return CaseSummary{}, 0, 0, fmt.Errorf("metric %q has a non-finite score or threshold", metric.MetricName)
+		}
+		item := summarizeMetric(metric, evalCase.EvalCaseResults)
+		summary.Metrics = append(summary.Metrics, item)
+		if !item.Evaluated {
+			continue
+		}
+		total += item.Score
+		count++
+		allPassed = allPassed && item.Passed
+	}
+	if count == 0 {
+		return CaseSummary{}, 0, 0, errors.New("case has no evaluated metrics")
+	}
+	summary.Score = total / float64(count)
+	summary.Passed = allPassed
+	summary.ActualInvocations, summary.ExpectedInvocations = invocationEvidence(evalCase)
+	return summary, total, count, nil
+}
+
+func summarizeMetric(metric *evalresult.EvalMetricResult, runs []*evalresult.EvalCaseResult) MetricSummary {
+	result := MetricSummary{
+		Name:      metric.MetricName,
+		Score:     metric.Score,
+		Threshold: metric.Threshold,
+		Passed:    metric.EvalStatus == status.EvalStatusPassed,
+		Evaluated: metric.EvalStatus != status.EvalStatusNotEvaluated,
+	}
+	if metric.Details != nil {
+		result.Reason = metric.Details.Reason
+		if result.Reason == "" {
+			for _, rubric := range metric.Details.RubricScores {
+				if rubric != nil && rubric.Reason != "" {
+					result.Reason = rubric.Reason
+					break
+				}
+			}
+		}
+	}
+	if result.Reason == "" && !result.Passed && result.Evaluated {
+		result.Reason = metricReason(runs, metric.MetricName)
+	}
+	if metric.Criterion == nil {
+		return result
+	}
+	switch {
+	case metric.Criterion.ToolTrajectory != nil:
+		result.Criterion = "tool_trajectory"
+		result.ToolOrderSensitive = metric.Criterion.ToolTrajectory.OrderSensitive
+	case metric.Criterion.FinalResponse != nil:
+		result.Criterion = "final_response"
+	case metric.Criterion.LLMJudge != nil:
+		result.Criterion = "llm_judge"
+		for _, rubric := range metric.Criterion.LLMJudge.Rubrics {
+			if rubric != nil && rubric.Type != "" {
+				result.RubricTypes = append(result.RubricTypes, rubric.Type)
+			}
+		}
+		sort.Strings(result.RubricTypes)
+	}
+	return result
+}
+
+func metricReason(runs []*evalresult.EvalCaseResult, name string) string {
+	for _, run := range runs {
+		if run == nil {
+			continue
+		}
+		for _, invocation := range run.EvalMetricResultPerInvocation {
+			if invocation == nil {
+				continue
+			}
+			for _, metric := range invocation.EvalMetricResults {
+				if metric == nil || metric.MetricName != name || metric.Details == nil {
+					continue
+				}
+				if metric.Details.Reason != "" {
+					return metric.Details.Reason
+				}
+				for _, rubric := range metric.Details.RubricScores {
+					if rubric != nil && rubric.Reason != "" {
+						return rubric.Reason
+					}
+				}
+			}
+		}
+	}
+	return "metric failed without evaluator reason"
+}
+
+func invocationEvidence(evalCase *evaluation.EvaluationCaseResult) ([]InvocationSummary, []InvocationSummary) {
+	runs := evalCase.EvalCaseResults
+	runs = append([]*evalresult.EvalCaseResult(nil), runs...)
+	sort.Slice(runs, func(i, j int) bool {
+		if runs[i] == nil {
+			return true
+		}
+		if runs[j] == nil {
+			return false
+		}
+		return runs[i].RunID < runs[j].RunID
+	})
+	var actual, expected []InvocationSummary
+	for _, run := range runs {
+		if run == nil {
+			continue
+		}
+		for _, pair := range run.EvalMetricResultPerInvocation {
+			if pair == nil {
+				continue
+			}
+			actual = appendInvocation(actual, pair.ActualInvocation, traceForInvocation(evalCase.RunDetails, run.RunID, pair.ActualInvocation))
+			expected = appendInvocation(expected, pair.ExpectedInvocation)
+		}
+	}
+	return actual, expected
+}
+
+func appendInvocation(dst []InvocationSummary, invocation *evalset.Invocation, executionTrace ...*trace.Trace) []InvocationSummary {
+	if invocation == nil {
+		return dst
+	}
+	item := InvocationSummary{}
+	if invocation.FinalResponse != nil {
+		item.FinalResponse = messageText(invocation.FinalResponse)
+	}
+	for _, call := range invocation.Tools {
+		if call == nil {
+			continue
+		}
+		arguments := safeJSON(call.Arguments)
+		tool := ToolSummary{Name: call.Name, Arguments: arguments}
+		if call.Result != nil {
+			tool.Result = safeJSON(call.Result)
+		}
+		item.Tools = append(item.Tools, tool)
+	}
+	if invocation.FinalResponse != nil {
+		for _, call := range invocation.FinalResponse.ToolCalls {
+			item.Tools = append(item.Tools, ToolSummary{Name: call.Function.Name, Arguments: safeJSON(call.Function.Arguments)})
+		}
+	}
+	selectedTrace := invocation.ExecutionTrace
+	if len(executionTrace) > 0 && executionTrace[0] != nil {
+		selectedTrace = executionTrace[0]
+	}
+	item.Route = summarizeTrace(selectedTrace)
+	return append(dst, item)
+}
+
+func traceForInvocation(details []*evaluation.EvaluationCaseRunDetails, runID int, invocation *evalset.Invocation) *trace.Trace {
+	for _, detail := range details {
+		if detail == nil || detail.RunID != runID || detail.Inference == nil {
+			continue
+		}
+		for _, candidate := range detail.Inference.ExecutionTraces {
+			if candidate == nil {
+				continue
+			}
+			if invocation != nil && invocation.InvocationID != "" && candidate.RootInvocationID == invocation.InvocationID {
+				return candidate
+			}
+		}
+		if len(detail.Inference.ExecutionTraces) == 1 {
+			return detail.Inference.ExecutionTraces[0]
+		}
+	}
+	return nil
+}
+
+func messageText(message *model.Message) string {
+	parts := make([]string, 0, 1+len(message.ContentParts))
+	if message.Content != "" {
+		parts = append(parts, message.Content)
+	}
+	for _, part := range message.ContentParts {
+		if part.Type == model.ContentTypeText && part.Text != nil {
+			parts = append(parts, *part.Text)
+		} else {
+			parts = append(parts, "["+string(part.Type)+"]")
+		}
+	}
+	return truncate(strings.Join(parts, "\n"), 4096)
+}
+
+func safeJSON(value any) json.RawMessage {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage(`null`)
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return json.RawMessage(`null`)
+	}
+	encoded, err := json.Marshal(redactValue(decoded))
+	if err != nil {
+		return json.RawMessage(`null`)
+	}
+	if len(encoded) > 16<<10 {
+		hash := sha256.Sum256(encoded)
+		encoded, _ = json.Marshal(map[string]any{"truncated": true, "sha256": fmt.Sprintf("%x", hash), "bytes": len(encoded)})
+	}
+	return encoded
+}
+
+func truncate(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit]) + "... [truncated]"
+}
+
+func redactValue(value any) any {
+	switch item := value.(type) {
+	case map[string]any:
+		redacted := make(map[string]any, len(item))
+		for key, child := range item {
+			if sensitiveKey(key) {
+				redacted[key] = "<redacted>"
+			} else {
+				redacted[key] = redactValue(child)
+			}
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(item))
+		for index, child := range item {
+			redacted[index] = redactValue(child)
+		}
+		return redacted
+	default:
+		return value
+	}
+}
+
+func sensitiveKey(key string) bool {
+	normalized := strings.Map(func(character rune) rune {
+		if character >= 'a' && character <= 'z' || character >= '0' && character <= '9' {
+			return character
+		}
+		if character >= 'A' && character <= 'Z' {
+			return character + ('a' - 'A')
+		}
+		return -1
+	}, key)
+	for _, fragment := range []string{"authorization", "apikey", "token", "password", "secret", "cookie", "privatekey", "credential"} {
+		if strings.Contains(normalized, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func addCaseCost(cost *Cost, evalCase *evaluation.EvaluationCaseResult) {
+	traceFound := false
+	for _, detail := range evalCase.RunDetails {
+		if detail == nil || detail.Inference == nil {
+			continue
+		}
+		for _, executionTrace := range detail.Inference.ExecutionTraces {
+			if executionTrace == nil {
+				continue
+			}
+			traceFound = true
+			addTraceCost(cost, executionTrace)
+		}
+	}
+	if traceFound {
+		return
+	}
+	for _, run := range evalCase.EvalCaseResults {
+		if run == nil {
+			continue
+		}
+		for _, invocation := range run.EvalMetricResultPerInvocation {
+			if invocation != nil && invocation.ActualInvocation != nil && invocation.ActualInvocation.ExecutionTrace != nil {
+				addTraceCost(cost, invocation.ActualInvocation.ExecutionTrace)
+			}
+		}
+	}
+}
+
+func addTraceCost(cost *Cost, executionTrace *trace.Trace) {
+	if executionTrace.Usage != nil {
+		cost.Tokens += int64(executionTrace.Usage.TotalTokens)
+	}
+	if !executionTrace.StartedAt.IsZero() && !executionTrace.EndedAt.IsZero() {
+		duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt)
+		if duration > 0 {
+			cost.LatencyMS += duration.Milliseconds()
+		}
+	}
+	if executionTrace.Usage == nil {
+		for _, step := range executionTrace.Steps {
+			if step.Usage != nil {
+				cost.Tokens += int64(step.Usage.TotalTokens)
+			}
+		}
+	}
+}
+
+func summarizeTrace(executionTrace *trace.Trace) []RouteStep {
+	if executionTrace == nil {
+		return nil
+	}
+	result := make([]RouteStep, 0, len(executionTrace.Steps))
+	for _, step := range executionTrace.Steps {
+		result = append(result, RouteStep{
+			Agent: step.AgentName, Branch: step.Branch, NodeID: step.NodeID, Error: step.Error,
+		})
+	}
+	return result
+}
+
+func traceExecutionFailed(executionTrace *trace.Trace) bool {
+	if executionTrace == nil {
+		return false
+	}
+	if executionTrace.Status == trace.TraceStatusFailed || executionTrace.Status == trace.TraceStatusIncomplete {
+		return true
+	}
+	for _, step := range executionTrace.Steps {
+		if step.Error != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func finite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}

--- a/evaluation/workflow/promptiter/regression/result.go
+++ b/evaluation/workflow/promptiter/regression/result.go
@@ -58,15 +58,14 @@ type CaseSummary struct {
 
 // MetricSummary contains the aggregate facts needed to compare and explain a metric.
 type MetricSummary struct {
-	Name               string   `json:"name"`
-	Score              float64  `json:"score"`
-	Threshold          float64  `json:"threshold"`
-	Passed             bool     `json:"passed"`
-	Evaluated          bool     `json:"evaluated"`
-	Reason             string   `json:"reason,omitempty"`
-	Criterion          string   `json:"criterion,omitempty"`
-	RubricTypes        []string `json:"rubric_types,omitempty"`
-	ToolOrderSensitive bool     `json:"tool_order_sensitive,omitempty"`
+	Name        string   `json:"name"`
+	Score       float64  `json:"score"`
+	Threshold   float64  `json:"threshold"`
+	Passed      bool     `json:"passed"`
+	Evaluated   bool     `json:"evaluated"`
+	Reason      string   `json:"reason,omitempty"`
+	Criterion   string   `json:"criterion,omitempty"`
+	RubricTypes []string `json:"rubric_types,omitempty"`
 }
 
 // InvocationSummary is the bounded execution evidence used by failure attribution.
@@ -274,7 +273,6 @@ func summarizeMetric(metric *evalresult.EvalMetricResult, runs []*evalresult.Eva
 	switch {
 	case metric.Criterion.ToolTrajectory != nil:
 		result.Criterion = "tool_trajectory"
-		result.ToolOrderSensitive = metric.Criterion.ToolTrajectory.OrderSensitive
 	case metric.Criterion.FinalResponse != nil:
 		result.Criterion = "final_response"
 	case metric.Criterion.LLMJudge != nil:

--- a/examples/evaluation/promptiter_regression_loop/DESIGN.md
+++ b/examples/evaluation/promptiter_regression_loop/DESIGN.md
@@ -4,4 +4,6 @@
 
 外层循环每次只让 PromptIter 产生一个候选，再重新运行训练集和验证集。候选必须满足验证集最小提升、hard metric 不新增失败、critical case 不退化、单 metric 降幅和调用/token 预算。被拒绝候选不会晋升，后续轮次仍以最近接受的 prompt 为基线；第一个通过外部门禁的候选结束循环。这样可以明确拒绝“训练提升但验证退化”的过拟合结果。
 
+`maxModelCalls` 和 `maxTokens` 按 baseline 和所有已尝试轮次的累计成本限制候选验收，不是单轮上限或执行前硬熔断；0 表示关闭检查。
+
 fake runtime 运行真实 PromptIter engine 的 evaluate、backward、aggregate、optimizer、profile patch 和 validation stage，只把各 stage runner 换成确定性实现，无 API key 也能复现无效、过拟合和成功三轮。runner 精确统计调用数，trace 补充 token 与延迟证据。最终同一报告对象生成 JSON 和 Markdown，记录 prompt、输入哈希、seed、runtime、变化的 case/metric delta、归因、门禁理由和每轮成本；失败 baseline 保存必要 evidence，候选不重复展开相同轨迹。系统只建议是否回写，不修改源 prompt。

--- a/examples/evaluation/promptiter_regression_loop/DESIGN.md
+++ b/examples/evaluation/promptiter_regression_loop/DESIGN.md
@@ -1,0 +1,7 @@
+# 方案设计说明
+
+闭环以 Evaluation Service 结果为事实来源，分别评测训练集和验证集。结果摘要保留 case、metric、final response、工具轨迹和 trace route；失败归因按执行、路由、工具、参数、格式、知识召回、最终回复和兜底类别的固定优先级，为 PromptIter 生成 case + metric hint。
+
+外层循环每次只让 PromptIter 产生一个候选，再重新运行训练集和验证集。候选必须满足验证集最小提升、hard metric 不新增失败、critical case 不退化、单 metric 降幅和调用/token 预算。被拒绝候选不会晋升，后续轮次仍以最近接受的 prompt 为基线；第一个通过外部门禁的候选结束循环。这样可以明确拒绝“训练提升但验证退化”的过拟合结果。
+
+fake runtime 运行真实 PromptIter engine 的 evaluate、backward、aggregate、optimizer、profile patch 和 validation stage，只把各 stage runner 换成确定性实现，无 API key 也能复现无效、过拟合和成功三轮。runner 精确统计调用数，trace 补充 token 与延迟证据。最终同一报告对象生成 JSON 和 Markdown，记录 prompt、输入哈希、seed、runtime、变化的 case/metric delta、归因、门禁理由和每轮成本；失败 baseline 保存必要 evidence，候选不重复展开相同轨迹。系统只建议是否回写，不修改源 prompt。

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -1,0 +1,51 @@
+# PromptIter Regression Loop
+
+This example runs a reproducible prompt optimization loop using the Evaluation Service and the real PromptIter engine:
+
+```text
+baseline evaluation → failure attribution → candidate generation
+→ train/validation regression → acceptance gate → JSON/Markdown audit
+```
+
+The default runtime is deterministic and needs no API key. Run it from `examples/evaluation`:
+
+```bash
+go run ./promptiter_regression_loop \
+  -seed=2003 \
+  -output=./promptiter_regression_loop/output
+```
+
+The command never modifies `data/baseline_prompt.txt`. An accepted result only recommends write-back.
+Do not include production credentials or secrets in prompts, eval fixtures, or model responses written to audit reports.
+
+## Fixture behavior
+
+The fixtures contain three training cases and three held-out validation cases. Every case checks the final response and `echo_ping` tool trajectory through the real Evaluation Service. PromptIter runs its evaluate, backward, aggregate, optimizer, profile-patch, and validation stages; deterministic stage runners make the result reproducible without an API key.
+
+| Round | Candidate behavior | Expected result |
+| --- | --- | --- |
+| 1 | Same behavior as baseline | Rejected: optimization is ineffective |
+| 2 | All training cases pass, validation regresses | Rejected: overfitting |
+| 3 | Training and validation improve | Accepted |
+
+Rejected candidates are never promoted. The next round still starts from the last accepted prompt. The loop stops after the first candidate that passes the external regression gate.
+
+## Inputs and outputs
+
+- `data/train.evalset.json`: three training cases.
+- `data/validation.evalset.json`: three held-out cases.
+- `data/metrics.json`: final-response and tool-trajectory metrics.
+- `data/promptiter.json`: candidates, round limit, and gate policy.
+- `data/fake_engine.json`: deterministic model usage and latency.
+- `output/optimization_report.json`: structured audit artifact.
+- `output/optimization_report.md`: reviewer-oriented explanation.
+
+The reports include baseline scores and failure evidence, every candidate prompt, changed case/metric deltas, gate reasons, serving/optimization cost, seed, input hashes, and runtime identity. Candidate summaries omit repeated trajectories and unchanged deltas to keep the JSON reviewable.
+
+Run the end-to-end test with:
+
+```bash
+go test -race ./promptiter_regression_loop -count=1
+```
+
+To use a model-backed runtime, replace the deterministic PromptIter stage runners in `runtime.go` with audited model runners. The outer regression gate remains the final acceptance authority.

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -30,6 +30,8 @@ The fixtures contain three training cases and three held-out validation cases. E
 
 Rejected candidates are never promoted. The next round still starts from the last accepted prompt. The loop stops after the first candidate that passes the external regression gate.
 
+`gate.maxModelCalls` and `gate.maxTokens` limit candidate acceptance by cumulative cost across the baseline and all attempted rounds. They are not per-round limits or pre-execution hard stops; zero disables the check.
+
 ## Inputs and outputs
 
 - `data/train.evalset.json`: three training cases.

--- a/examples/evaluation/promptiter_regression_loop/config.go
+++ b/examples/evaluation/promptiter_regression_loop/config.go
@@ -1,0 +1,190 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regression"
+)
+
+const (
+	appName          = "promptiter-regression-loop"
+	agentName        = "candidate"
+	toolName         = "echo_ping"
+	targetSurfaceID  = "answer#instruction"
+	defaultDataDir   = "./promptiter_regression_loop/data"
+	defaultOutputDir = "./promptiter_regression_loop/output"
+)
+
+type fixturePaths struct {
+	baseline   string
+	train      string
+	validation string
+	metrics    string
+	promptiter string
+	fakeEngine string
+}
+
+type loopConfig struct {
+	baseline   string
+	train      *evalset.EvalSet
+	validation *evalset.EvalSet
+	metrics    []*metric.EvalMetric
+	candidates []string
+	maxRounds  int
+	gate       regression.GatePolicy
+	engine     fakeEngineConfig
+	seed       int64
+	inputs     []regression.AuditInput
+	configHash string
+}
+
+type promptIterConfig struct {
+	Candidates []string   `json:"candidates"`
+	MaxRounds  int        `json:"maxRounds"`
+	Gate       gateConfig `json:"gate"`
+}
+
+type gateConfig struct {
+	MinValidationGain float64  `json:"minValidationGain"`
+	RejectNewHardFail bool     `json:"rejectNewHardFail"`
+	HardMetrics       []string `json:"hardMetrics"`
+	CriticalCases     []string `json:"criticalCases"`
+	MaxMetricDrop     float64  `json:"maxMetricDrop"`
+	MaxModelCalls     int      `json:"maxModelCalls"`
+	MaxTokens         int64    `json:"maxTokens"`
+}
+
+type fakeEngineConfig struct {
+	EngineID           string `json:"engineId"`
+	PromptTokens       int    `json:"promptTokens"`
+	CompletionTokens   int    `json:"completionTokens"`
+	LatencyMS          int64  `json:"latencyMillis"`
+	OptimizerTokens    int64  `json:"optimizerTokens"`
+	OptimizerLatencyMS int64  `json:"optimizerLatencyMillis"`
+}
+
+func defaultPaths() fixturePaths {
+	baseDir := defaultDataDir
+	if _, err := os.Stat(baseDir); err != nil {
+		if _, localErr := os.Stat("./data"); localErr == nil {
+			baseDir = "./data"
+		}
+	}
+	return fixturePaths{
+		baseline:   filepath.Join(baseDir, "baseline_prompt.txt"),
+		train:      filepath.Join(baseDir, "train.evalset.json"),
+		validation: filepath.Join(baseDir, "validation.evalset.json"),
+		metrics:    filepath.Join(baseDir, "metrics.json"),
+		promptiter: filepath.Join(baseDir, "promptiter.json"),
+		fakeEngine: filepath.Join(baseDir, "fake_engine.json"),
+	}
+}
+
+func loadConfig(paths fixturePaths, seed int64) (loopConfig, error) {
+	var config loopConfig
+	config.seed = seed
+	baseline, audit, err := readInput("baseline_prompt", paths.baseline)
+	if err != nil {
+		return config, err
+	}
+	config.baseline = strings.TrimSpace(string(baseline))
+	config.inputs = append(config.inputs, audit)
+	var promptConfig promptIterConfig
+	files := []struct {
+		name string
+		path string
+		out  any
+	}{
+		{name: "train_evalset", path: paths.train, out: &config.train},
+		{name: "validation_evalset", path: paths.validation, out: &config.validation},
+		{name: "metrics", path: paths.metrics, out: &config.metrics},
+		{name: "promptiter", path: paths.promptiter, out: &promptConfig},
+		{name: "fake_engine", path: paths.fakeEngine, out: &config.engine},
+	}
+	hasher := sha256.New()
+	hasher.Write(baseline)
+	for _, file := range files {
+		data, input, err := readInput(file.name, file.path)
+		if err != nil {
+			return loopConfig{}, err
+		}
+		if err := json.Unmarshal(data, file.out); err != nil {
+			return loopConfig{}, fmt.Errorf("decode %s: %w", file.name, err)
+		}
+		config.inputs = append(config.inputs, input)
+		hasher.Write(data)
+	}
+	config.candidates = promptConfig.Candidates
+	config.maxRounds = promptConfig.MaxRounds
+	config.gate = regression.GatePolicy{
+		MinValidationGain: promptConfig.Gate.MinValidationGain,
+		RejectNewHardFail: promptConfig.Gate.RejectNewHardFail,
+		HardMetrics:       promptConfig.Gate.HardMetrics,
+		CriticalCases:     promptConfig.Gate.CriticalCases,
+		MaxMetricDrop:     promptConfig.Gate.MaxMetricDrop,
+		MaxModelCalls:     promptConfig.Gate.MaxModelCalls,
+		MaxTokens:         promptConfig.Gate.MaxTokens,
+	}
+	hasher.Write([]byte(fmt.Sprint(seed)))
+	config.configHash = hex.EncodeToString(hasher.Sum(nil))
+	if err := validateConfig(config); err != nil {
+		return loopConfig{}, err
+	}
+	return config, nil
+}
+
+func readInput(name, path string) ([]byte, regression.AuditInput, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, regression.AuditInput{}, fmt.Errorf("read %s %q: %w", name, path, err)
+	}
+	hash := sha256.Sum256(data)
+	return data, regression.AuditInput{Name: name, Path: path, SHA256: hex.EncodeToString(hash[:])}, nil
+}
+
+func validateConfig(config loopConfig) error {
+	switch {
+	case config.baseline == "":
+		return errors.New("baseline prompt is empty")
+	case config.train == nil || config.validation == nil:
+		return errors.New("train and validation evalsets are required")
+	case config.train.EvalSetID == "" || config.validation.EvalSetID == "":
+		return errors.New("evalset IDs are required")
+	case config.train.EvalSetID == config.validation.EvalSetID:
+		return errors.New("train and validation evalset IDs must differ")
+	case len(config.train.EvalCases) != 3 || len(config.validation.EvalCases) != 3:
+		return errors.New("fixtures require three train and three validation cases")
+	case len(config.metrics) == 0:
+		return errors.New("metrics are empty")
+	case config.maxRounds <= 0 || len(config.candidates) < config.maxRounds:
+		return errors.New("candidate count must cover maxRounds")
+	case config.engine.EngineID == "":
+		return errors.New("fake engine ID is empty")
+	case config.engine.PromptTokens < 0 || config.engine.CompletionTokens < 0 ||
+		config.engine.LatencyMS < 0 || config.engine.OptimizerTokens < 0 || config.engine.OptimizerLatencyMS < 0:
+		return errors.New("fake engine cost must not be negative")
+	}
+	for index, candidate := range config.candidates {
+		if strings.TrimSpace(candidate) == "" {
+			return fmt.Errorf("candidate %d is empty", index+1)
+		}
+	}
+	return nil
+}

--- a/examples/evaluation/promptiter_regression_loop/config.go
+++ b/examples/evaluation/promptiter_regression_loop/config.go
@@ -9,11 +9,13 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,15 +110,16 @@ func loadConfig(paths fixturePaths, seed int64) (loopConfig, error) {
 	config.inputs = append(config.inputs, audit)
 	var promptConfig promptIterConfig
 	files := []struct {
-		name string
-		path string
-		out  any
+		name   string
+		path   string
+		out    any
+		strict bool
 	}{
 		{name: "train_evalset", path: paths.train, out: &config.train},
 		{name: "validation_evalset", path: paths.validation, out: &config.validation},
 		{name: "metrics", path: paths.metrics, out: &config.metrics},
-		{name: "promptiter", path: paths.promptiter, out: &promptConfig},
-		{name: "fake_engine", path: paths.fakeEngine, out: &config.engine},
+		{name: "promptiter", path: paths.promptiter, out: &promptConfig, strict: true},
+		{name: "fake_engine", path: paths.fakeEngine, out: &config.engine, strict: true},
 	}
 	hasher := sha256.New()
 	hasher.Write(baseline)
@@ -125,7 +128,7 @@ func loadConfig(paths fixturePaths, seed int64) (loopConfig, error) {
 		if err != nil {
 			return loopConfig{}, err
 		}
-		if err := json.Unmarshal(data, file.out); err != nil {
+		if err := decodeConfigJSON(data, file.out, file.strict); err != nil {
 			return loopConfig{}, fmt.Errorf("decode %s: %w", file.name, err)
 		}
 		config.inputs = append(config.inputs, input)
@@ -148,6 +151,25 @@ func loadConfig(paths fixturePaths, seed int64) (loopConfig, error) {
 		return loopConfig{}, err
 	}
 	return config, nil
+}
+
+func decodeConfigJSON(data []byte, destination any, strict bool) error {
+	if !strict {
+		return json.Unmarshal(data, destination)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
 }
 
 func readInput(name, path string) ([]byte, regression.AuditInput, error) {

--- a/examples/evaluation/promptiter_regression_loop/config_test.go
+++ b/examples/evaluation/promptiter_regression_loop/config_test.go
@@ -1,0 +1,110 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+)
+
+func TestLoadConfigIsStable(t *testing.T) {
+	first, err := loadConfig(defaultPaths(), 2003)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := loadConfig(defaultPaths(), 2003)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.configHash == "" || first.configHash != second.configHash || len(first.inputs) != 6 {
+		t.Fatalf("config hashes or inputs are unstable: %q %q %+v", first.configHash, second.configHash, first.inputs)
+	}
+	for _, input := range first.inputs {
+		if len(input.SHA256) != 64 {
+			t.Fatalf("input hash = %+v", input)
+		}
+	}
+}
+
+func TestLoadConfigRejectsUnreadableAndInvalidJSON(t *testing.T) {
+	paths := defaultPaths()
+	paths.metrics = filepath.Join(t.TempDir(), "missing.json")
+	if _, err := loadConfig(paths, 1); err == nil || !strings.Contains(err.Error(), "read metrics") {
+		t.Fatalf("missing metrics error = %v", err)
+	}
+	invalid := filepath.Join(t.TempDir(), "invalid.json")
+	if err := os.WriteFile(invalid, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	paths = defaultPaths()
+	paths.promptiter = invalid
+	if _, err := loadConfig(paths, 1); err == nil || !strings.Contains(err.Error(), "decode promptiter") {
+		t.Fatalf("invalid JSON error = %v", err)
+	}
+}
+
+func TestValidateConfigRejectsInvalidFixtures(t *testing.T) {
+	valid, err := loadConfig(defaultPaths(), 2003)
+	if err != nil {
+		t.Fatal(err)
+	}
+	threeCases := func(id string) *evalset.EvalSet {
+		return &evalset.EvalSet{EvalSetID: id, EvalCases: []*evalset.EvalCase{{}, {}, {}}}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*loopConfig)
+	}{
+		{name: "empty baseline", mutate: func(c *loopConfig) { c.baseline = "" }},
+		{name: "missing evalset", mutate: func(c *loopConfig) { c.train = nil }},
+		{name: "missing ID", mutate: func(c *loopConfig) { c.train = threeCases("") }},
+		{name: "same ID", mutate: func(c *loopConfig) { c.validation.EvalSetID = c.train.EvalSetID }},
+		{name: "wrong case count", mutate: func(c *loopConfig) { c.train.EvalCases = nil }},
+		{name: "no metrics", mutate: func(c *loopConfig) { c.metrics = nil }},
+		{name: "rounds uncovered", mutate: func(c *loopConfig) { c.maxRounds = len(c.candidates) + 1 }},
+		{name: "empty engine ID", mutate: func(c *loopConfig) { c.engine.EngineID = "" }},
+		{name: "negative engine cost", mutate: func(c *loopConfig) { c.engine.PromptTokens = -1 }},
+		{name: "empty candidate", mutate: func(c *loopConfig) { c.candidates[0] = " " }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := valid
+			config.train = threeCases(valid.train.EvalSetID)
+			config.validation = threeCases(valid.validation.EvalSetID)
+			config.metrics = append([]*metric.EvalMetric(nil), valid.metrics...)
+			config.candidates = append([]string(nil), valid.candidates...)
+			test.mutate(&config)
+			if err := validateConfig(config); err == nil {
+				t.Fatal("validateConfig() error = nil")
+			}
+		})
+	}
+}
+
+func TestParseOptions(t *testing.T) {
+	options, err := parseOptions([]string{"-seed=9", "-output=custom", "-baseline-prompt=prompt.txt"}, &bytes.Buffer{})
+	if err != nil || options.seed != 9 || options.outputDir != "custom" || options.paths.baseline != "prompt.txt" {
+		t.Fatalf("parseOptions() = %+v, %v", options, err)
+	}
+	defaults, err := parseOptions(nil, &bytes.Buffer{})
+	if err != nil || defaults.seed != 2003 || defaults.outputDir != defaultOutputDir {
+		t.Fatalf("default parseOptions() = %+v, %v", defaults, err)
+	}
+	for _, arguments := range [][]string{{"unexpected"}, {"-seed=bad"}} {
+		if _, err := parseOptions(arguments, &bytes.Buffer{}); err == nil {
+			t.Fatalf("parseOptions(%v) error = nil", arguments)
+		}
+	}
+}

--- a/examples/evaluation/promptiter_regression_loop/config_test.go
+++ b/examples/evaluation/promptiter_regression_loop/config_test.go
@@ -55,6 +55,71 @@ func TestLoadConfigRejectsUnreadableAndInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestLoadConfigRejectsInvalidControlConfigContracts(t *testing.T) {
+	tests := []struct {
+		name        string
+		configName  string
+		content     string
+		setPath     func(*fixturePaths, string)
+		wantMessage string
+	}{
+		{
+			name:       "unknown promptiter gate field",
+			configName: "promptiter",
+			content: `{
+				"candidates": ["candidate"],
+				"maxRounds": 1,
+				"gate": {"maxToken": 700, "rejectNewHardFails": true}
+			}`,
+			setPath: func(paths *fixturePaths, path string) {
+				paths.promptiter = path
+			},
+			wantMessage: `unknown field "maxToken"`,
+		},
+		{
+			name:        "unknown fake engine field",
+			configName:  "fake_engine",
+			content:     `{"engineId": "fake", "promptToken": 1}`,
+			setPath:     func(paths *fixturePaths, path string) { paths.fakeEngine = path },
+			wantMessage: `unknown field "promptToken"`,
+		},
+		{
+			name:        "trailing promptiter value",
+			configName:  "promptiter",
+			content:     `{"candidates":["candidate"],"maxRounds":1,"gate":{}} {}`,
+			setPath:     func(paths *fixturePaths, path string) { paths.promptiter = path },
+			wantMessage: "multiple JSON values",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), test.configName+".json")
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			paths := defaultPaths()
+			test.setPath(&paths, path)
+			_, err := loadConfig(paths, 1)
+			if err == nil || !strings.Contains(err.Error(), "decode "+test.configName) ||
+				!strings.Contains(err.Error(), test.wantMessage) {
+				t.Fatalf("loadConfig() error = %v, want %q", err, test.wantMessage)
+			}
+		})
+	}
+}
+
+func TestDecodeConfigJSONKeepsFrameworkInputsForwardCompatible(t *testing.T) {
+	var value struct {
+		Known int `json:"known"`
+	}
+	if err := decodeConfigJSON([]byte(`{"known":1,"future":2}`), &value, false); err != nil {
+		t.Fatalf("decodeConfigJSON() error = %v", err)
+	}
+	if value.Known != 1 {
+		t.Fatalf("decoded known field = %d, want 1", value.Known)
+	}
+}
+
 func TestValidateConfigRejectsInvalidFixtures(t *testing.T) {
 	valid, err := loadConfig(defaultPaths(), 2003)
 	if err != nil {

--- a/examples/evaluation/promptiter_regression_loop/data/baseline_prompt.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/baseline_prompt.txt
@@ -1,0 +1,1 @@
+Reply with pong only for basic and short ping requests. fixture:baseline

--- a/examples/evaluation/promptiter_regression_loop/data/fake_engine.json
+++ b/examples/evaluation/promptiter_regression_loop/data/fake_engine.json
@@ -1,0 +1,8 @@
+{
+  "engineId": "deterministic-ping-v1",
+  "promptTokens": 4,
+  "completionTokens": 1,
+  "latencyMillis": 2,
+  "optimizerTokens": 5,
+  "optimizerLatencyMillis": 2
+}

--- a/examples/evaluation/promptiter_regression_loop/data/fake_engine.json
+++ b/examples/evaluation/promptiter_regression_loop/data/fake_engine.json
@@ -3,6 +3,6 @@
   "promptTokens": 4,
   "completionTokens": 1,
   "latencyMillis": 2,
-  "optimizerTokens": 5,
-  "optimizerLatencyMillis": 2
+  "optimizerTokens": 13,
+  "optimizerLatencyMillis": 7
 }

--- a/examples/evaluation/promptiter_regression_loop/data/metrics.json
+++ b/examples/evaluation/promptiter_regression_loop/data/metrics.json
@@ -1,0 +1,23 @@
+[
+  {
+    "metricName": "quality",
+    "evaluatorName": "final_response_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "finalResponse": {"text": {"matchStrategy": "exact"}}
+    }
+  },
+  {
+    "metricName": "tool_trajectory_avg_score",
+    "evaluatorName": "tool_trajectory_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "toolTrajectory": {
+        "orderSensitive": true,
+        "defaultStrategy": {
+          "name": {"matchStrategy": "exact"}, "arguments": {"matchStrategy": "exact"}, "result": {"matchStrategy": "exact"}
+        }
+      }
+    }
+  }
+]

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter.json
@@ -7,7 +7,7 @@
     "hardMetrics": ["quality"],
     "criticalCases": ["validation-case-3"],
     "maxMetricDrop": 0.5,
-    "maxModelCalls": 40,
-    "maxTokens": 200
+    "maxModelCalls": 120,
+    "maxTokens": 600
   }
 }

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter.json
@@ -1,0 +1,13 @@
+{
+  "candidates": ["Rephrase without changing behavior. fixture:ineffective", "Optimize only the training cases. fixture:train-only", "Reply with pong for every valid ping request. fixture:balanced"],
+  "maxRounds": 3,
+  "gate": {
+    "minValidationGain": 0.3,
+    "rejectNewHardFail": true,
+    "hardMetrics": ["quality"],
+    "criticalCases": ["validation-case-3"],
+    "maxMetricDrop": 0.5,
+    "maxModelCalls": 40,
+    "maxTokens": 200
+  }
+}

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter.json
@@ -8,6 +8,6 @@
     "criticalCases": ["validation-case-3"],
     "maxMetricDrop": 0.5,
     "maxModelCalls": 120,
-    "maxTokens": 600
+    "maxTokens": 700
   }
 }

--- a/examples/evaluation/promptiter_regression_loop/data/train.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/train.evalset.json
@@ -1,0 +1,36 @@
+{
+  "evalSetId": "regression-train",
+  "name": "Prompt regression training fixtures",
+  "evalCases": [
+    {
+      "evalId": "train-case-1",
+      "conversation": [{
+        "invocationId": "train-case-1-invocation",
+        "userContent": {"role": "user", "content": "basic ping request"},
+        "finalResponse": {"role": "assistant", "content": "pong"},
+        "tools": [{"id": "echo-call", "name": "echo_ping", "arguments": {"value": "ping"}, "result": {"value": "pong"}}]
+      }],
+      "sessionInput": {"appName": "promptiter-regression-loop", "userId": "fixture-user"}
+    },
+    {
+      "evalId": "train-case-2",
+      "conversation": [{
+        "invocationId": "train-case-2-invocation",
+        "userContent": {"role": "user", "content": "polite ping request"},
+        "finalResponse": {"role": "assistant", "content": "pong"},
+        "tools": [{"id": "echo-call", "name": "echo_ping", "arguments": {"value": "ping"}, "result": {"value": "pong"}}]
+      }],
+      "sessionInput": {"appName": "promptiter-regression-loop", "userId": "fixture-user"}
+    },
+    {
+      "evalId": "train-case-3",
+      "conversation": [{
+        "invocationId": "train-case-3-invocation",
+        "userContent": {"role": "user", "content": "noisy ping request"},
+        "finalResponse": {"role": "assistant", "content": "pong"},
+        "tools": [{"id": "echo-call", "name": "echo_ping", "arguments": {"value": "ping"}, "result": {"value": "pong"}}]
+      }],
+      "sessionInput": {"appName": "promptiter-regression-loop", "userId": "fixture-user"}
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/data/validation.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/validation.evalset.json
@@ -1,0 +1,36 @@
+{
+  "evalSetId": "regression-validation",
+  "name": "Prompt regression validation fixtures",
+  "evalCases": [
+    {
+      "evalId": "validation-case-1",
+      "conversation": [{
+        "invocationId": "validation-case-1-invocation",
+        "userContent": {"role": "user", "content": "short ping request"},
+        "finalResponse": {"role": "assistant", "content": "pong"},
+        "tools": [{"id": "echo-call", "name": "echo_ping", "arguments": {"value": "ping"}, "result": {"value": "pong"}}]
+      }],
+      "sessionInput": {"appName": "promptiter-regression-loop", "userId": "fixture-user"}
+    },
+    {
+      "evalId": "validation-case-2",
+      "conversation": [{
+        "invocationId": "validation-case-2-invocation",
+        "userContent": {"role": "user", "content": "formal ping request"},
+        "finalResponse": {"role": "assistant", "content": "pong"},
+        "tools": [{"id": "echo-call", "name": "echo_ping", "arguments": {"value": "ping"}, "result": {"value": "pong"}}]
+      }],
+      "sessionInput": {"appName": "promptiter-regression-loop", "userId": "fixture-user"}
+    },
+    {
+      "evalId": "validation-case-3",
+      "conversation": [{
+        "invocationId": "validation-case-3-invocation",
+        "userContent": {"role": "user", "content": "edge ping request"},
+        "finalResponse": {"role": "assistant", "content": "pong"},
+        "tools": [{"id": "echo-call", "name": "echo_ping", "arguments": {"value": "ping"}, "result": {"value": "pong"}}]
+      }],
+      "sessionInput": {"appName": "promptiter-regression-loop", "userId": "fixture-user"}
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/main.go
+++ b/examples/evaluation/promptiter_regression_loop/main.go
@@ -1,0 +1,122 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regression"
+)
+
+type commandOptions struct {
+	paths     fixturePaths
+	outputDir string
+	seed      int64
+}
+
+func main() {
+	options, err := parseOptions(os.Args[1:], os.Stderr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	report, err := runCommand(context.Background(), options)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("status: %s\nwrite-back recommended: %t\noutput: %s\n",
+		report.Status, report.Decision.WriteBackRecommended, options.outputDir)
+}
+
+func parseOptions(arguments []string, errorOutput io.Writer) (commandOptions, error) {
+	options := commandOptions{paths: defaultPaths()}
+	flags := flag.NewFlagSet("promptiter_regression_loop", flag.ContinueOnError)
+	flags.SetOutput(errorOutput)
+	flags.StringVar(&options.paths.baseline, "baseline-prompt", options.paths.baseline, "baseline prompt file")
+	flags.StringVar(&options.paths.train, "train-evalset", options.paths.train, "training evalset JSON")
+	flags.StringVar(&options.paths.validation, "validation-evalset", options.paths.validation, "validation evalset JSON")
+	flags.StringVar(&options.paths.metrics, "metrics", options.paths.metrics, "metrics JSON")
+	flags.StringVar(&options.paths.promptiter, "promptiter-config", options.paths.promptiter, "PromptIter config JSON")
+	flags.StringVar(&options.paths.fakeEngine, "fake-engine-config", options.paths.fakeEngine, "fake engine config JSON")
+	flags.StringVar(&options.outputDir, "output", defaultOutputDir, "report output directory")
+	flags.Int64Var(&options.seed, "seed", 2003, "deterministic seed")
+	if err := flags.Parse(arguments); err != nil {
+		return commandOptions{}, err
+	}
+	if flags.NArg() > 0 {
+		return commandOptions{}, fmt.Errorf("unexpected arguments: %v", flags.Args())
+	}
+	return options, nil
+}
+
+func runCommand(ctx context.Context, options commandOptions) (*regression.OptimizationReport, error) {
+	config, err := loadConfig(options.paths, options.seed)
+	if err != nil {
+		return nil, err
+	}
+	started := time.Now().UTC()
+	run, err := runFakeLoop(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+	metadata := regression.AuditMetadata{
+		RunID:     fmt.Sprintf("promptiter-regression-%d-%s", config.seed, started.Format("20060102T150405.000000000Z")),
+		StartedAt: started, FinishedAt: time.Now().UTC(),
+		Seed: config.seed, Inputs: config.inputs,
+		Runtime: regression.RuntimeAudit{
+			Mode: "fake", Model: config.engine.EngineID, ConfigSHA256: config.configHash,
+			Config: map[string]string{"optimizer": "deterministic-promptiter", "max_rounds": fmt.Sprint(config.maxRounds)},
+		},
+	}
+	report, err := regression.BuildReport(run, metadata)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(options.outputDir, 0o700); err != nil {
+		return nil, err
+	}
+	jsonFile, err := openReport(filepath.Join(options.outputDir, "optimization_report.json"))
+	if err != nil {
+		return nil, err
+	}
+	jsonErr := regression.WriteJSON(jsonFile, report)
+	closeErr := jsonFile.Close()
+	if jsonErr != nil || closeErr != nil {
+		return nil, errors.Join(jsonErr, closeErr)
+	}
+	markdownFile, err := openReport(filepath.Join(options.outputDir, "optimization_report.md"))
+	if err != nil {
+		return nil, err
+	}
+	markdownErr := regression.WriteMarkdown(markdownFile, report)
+	closeErr = markdownFile.Close()
+	if markdownErr != nil || closeErr != nil {
+		return nil, errors.Join(markdownErr, closeErr)
+	}
+	return report, nil
+}
+
+func openReport(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	return file, nil
+}

--- a/examples/evaluation/promptiter_regression_loop/main.go
+++ b/examples/evaluation/promptiter_regression_loop/main.go
@@ -89,34 +89,33 @@ func runCommand(ctx context.Context, options commandOptions) (*regression.Optimi
 	if err := os.MkdirAll(options.outputDir, 0o700); err != nil {
 		return nil, err
 	}
-	jsonFile, err := openReport(filepath.Join(options.outputDir, "optimization_report.json"))
-	if err != nil {
+	if err := writeReport(filepath.Join(options.outputDir, "optimization_report.json"), func(writer io.Writer) error {
+		return regression.WriteJSON(writer, report)
+	}); err != nil {
 		return nil, err
 	}
-	jsonErr := regression.WriteJSON(jsonFile, report)
-	closeErr := jsonFile.Close()
-	if jsonErr != nil || closeErr != nil {
-		return nil, errors.Join(jsonErr, closeErr)
-	}
-	markdownFile, err := openReport(filepath.Join(options.outputDir, "optimization_report.md"))
-	if err != nil {
+	if err := writeReport(filepath.Join(options.outputDir, "optimization_report.md"), func(writer io.Writer) error {
+		return regression.WriteMarkdown(writer, report)
+	}); err != nil {
 		return nil, err
-	}
-	markdownErr := regression.WriteMarkdown(markdownFile, report)
-	closeErr = markdownFile.Close()
-	if markdownErr != nil || closeErr != nil {
-		return nil, errors.Join(markdownErr, closeErr)
 	}
 	return report, nil
 }
 
-func openReport(path string) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+func writeReport(path string, write func(io.Writer) error) error {
+	file, err := os.CreateTemp(filepath.Dir(path), ".report-*")
 	if err != nil {
-		return nil, err
+		return err
 	}
+	temporaryPath := file.Name()
+	defer os.Remove(temporaryPath)
 	if err := file.Chmod(0o600); err != nil {
-		return nil, errors.Join(err, file.Close())
+		return errors.Join(err, file.Close())
 	}
-	return file, nil
+	writeErr := write(file)
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		return errors.Join(writeErr, closeErr)
+	}
+	return os.Rename(temporaryPath, path)
 }

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
@@ -1,0 +1,1168 @@
+{
+  "schema_version": "v1",
+  "status": "accepted",
+  "audit": {
+    "run_id": "promptiter-regression-2003-20260718T141000.129395098Z",
+    "started_at": "2026-07-18T14:10:00.129395098Z",
+    "finished_at": "2026-07-18T14:10:00.133637289Z",
+    "duration_ms": 4,
+    "seed": 2003,
+    "inputs": [
+      {
+        "name": "baseline_prompt",
+        "path": "baseline_prompt.txt",
+        "sha256": "179a9d34f467b7d96785ba6271fa9aa96d9ef084cdcff33a2a5b61d36d3303c4"
+      },
+      {
+        "name": "fake_engine",
+        "path": "fake_engine.json",
+        "sha256": "0f885a4898143e764a398dcc995f4a8f0647987190f495b1e330016b7e8e71c0"
+      },
+      {
+        "name": "metrics",
+        "path": "metrics.json",
+        "sha256": "029056c87319d2c7b8fbe87393bca4f9c39dd11c01d64944e4ef4530936d9dd1"
+      },
+      {
+        "name": "promptiter",
+        "path": "promptiter.json",
+        "sha256": "604961453a14cf5e3a17c268eaca277840c627f21ba5f5f955bccfe0da1bc255"
+      },
+      {
+        "name": "train_evalset",
+        "path": "train.evalset.json",
+        "sha256": "b9f7ee5c55c88a49ea7531aee15041cbd6ff75f1a6fda2ab2cff3b50917bfcb8"
+      },
+      {
+        "name": "validation_evalset",
+        "path": "validation.evalset.json",
+        "sha256": "bd093d6103b66ec95baa56484453cfed50c25b6ec22dfb3d75397d6fcc6ae06e"
+      }
+    ],
+    "runtime": {
+      "mode": "fake",
+      "model": "deterministic-ping-v1",
+      "config_sha256": "1deca002f96c1ba70eaac288a9822f1a21d82542664c45f4e24d4614db5b09fd",
+      "config": {
+        "max_rounds": "3",
+        "optimizer": "deterministic-promptiter"
+      }
+    }
+  },
+  "initial_prompt": {
+    "text": "Reply with pong only for basic and short ping requests. fixture:baseline",
+    "sha256": "b085697c911b238a4947292ca2f4dd4a35e87824c5d175be8f87eea3b5f67ae0"
+  },
+  "accepted_prompt": {
+    "text": "Reply with pong for every valid ping request. fixture:balanced",
+    "sha256": "dce53b10df6d6b6daa50a41e4ae9ec979fee83875b5cac87a71e0db60d1aa278"
+  },
+  "baseline_train": {
+    "eval_set_id": "regression-train",
+    "score": 0.6666666666666666,
+    "passed": false,
+    "cases": [
+      {
+        "id": "train-case-1",
+        "score": 1,
+        "passed": true,
+        "metrics": [
+          {
+            "name": "quality",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          },
+          {
+            "name": "tool_trajectory_avg_score",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          }
+        ]
+      },
+      {
+        "id": "train-case-2",
+        "score": 0.5,
+        "passed": false,
+        "metrics": [
+          {
+            "name": "quality",
+            "score": 0,
+            "threshold": 1,
+            "passed": false,
+            "evaluated": true,
+            "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "name": "tool_trajectory_avg_score",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          }
+        ],
+        "actual_invocations": [
+          {
+            "final_response": "not-pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ],
+            "route": [
+              {
+                "agent": "candidate",
+                "node_id": "answer"
+              }
+            ]
+          }
+        ],
+        "expected_invocations": [
+          {
+            "final_response": "pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "train-case-3",
+        "score": 0.5,
+        "passed": false,
+        "metrics": [
+          {
+            "name": "quality",
+            "score": 0,
+            "threshold": 1,
+            "passed": false,
+            "evaluated": true,
+            "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "name": "tool_trajectory_avg_score",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          }
+        ],
+        "actual_invocations": [
+          {
+            "final_response": "not-pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ],
+            "route": [
+              {
+                "agent": "candidate",
+                "node_id": "answer"
+              }
+            ]
+          }
+        ],
+        "expected_invocations": [
+          {
+            "final_response": "pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "baseline_validation": {
+    "eval_set_id": "regression-validation",
+    "score": 0.6666666666666666,
+    "passed": false,
+    "cases": [
+      {
+        "id": "validation-case-1",
+        "score": 1,
+        "passed": true,
+        "metrics": [
+          {
+            "name": "quality",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          },
+          {
+            "name": "tool_trajectory_avg_score",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          }
+        ]
+      },
+      {
+        "id": "validation-case-2",
+        "score": 0.5,
+        "passed": false,
+        "metrics": [
+          {
+            "name": "quality",
+            "score": 0,
+            "threshold": 1,
+            "passed": false,
+            "evaluated": true,
+            "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "name": "tool_trajectory_avg_score",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          }
+        ],
+        "actual_invocations": [
+          {
+            "final_response": "not-pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ],
+            "route": [
+              {
+                "agent": "candidate",
+                "node_id": "answer"
+              }
+            ]
+          }
+        ],
+        "expected_invocations": [
+          {
+            "final_response": "pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "validation-case-3",
+        "score": 0.5,
+        "passed": false,
+        "metrics": [
+          {
+            "name": "quality",
+            "score": 0,
+            "threshold": 1,
+            "passed": false,
+            "evaluated": true,
+            "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "name": "tool_trajectory_avg_score",
+            "score": 1,
+            "threshold": 1,
+            "passed": true,
+            "evaluated": true
+          }
+        ],
+        "actual_invocations": [
+          {
+            "final_response": "not-pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ],
+            "route": [
+              {
+                "agent": "candidate",
+                "node_id": "answer"
+              }
+            ]
+          }
+        ],
+        "expected_invocations": [
+          {
+            "final_response": "pong",
+            "tools": [
+              {
+                "name": "echo_ping",
+                "arguments": {
+                  "value": "ping"
+                },
+                "result": {
+                  "value": "pong"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "baseline_train_attribution": {
+    "failures": [
+      {
+        "case_id": "train-case-2",
+        "category": "final_response_mismatch",
+        "metric_names": [
+          "quality"
+        ],
+        "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+      },
+      {
+        "case_id": "train-case-3",
+        "category": "final_response_mismatch",
+        "metric_names": [
+          "quality"
+        ],
+        "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+      }
+    ],
+    "counts": {
+      "final_response_mismatch": 2
+    }
+  },
+  "baseline_validation_attribution": {
+    "failures": [
+      {
+        "case_id": "validation-case-2",
+        "category": "final_response_mismatch",
+        "metric_names": [
+          "quality"
+        ],
+        "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+      },
+      {
+        "case_id": "validation-case-3",
+        "category": "final_response_mismatch",
+        "metric_names": [
+          "quality"
+        ],
+        "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+      }
+    ],
+    "counts": {
+      "final_response_mismatch": 2
+    }
+  },
+  "rounds": [
+    {
+      "number": 1,
+      "input_prompt": "Reply with pong only for basic and short ping requests. fixture:baseline",
+      "candidate_prompt": "Rephrase without changing behavior. fixture:ineffective",
+      "hints": [
+        {
+          "case_id": "train-case-2",
+          "metric_name": "quality",
+          "category": "final_response_mismatch",
+          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
+        {
+          "case_id": "train-case-3",
+          "metric_name": "quality",
+          "category": "final_response_mismatch",
+          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+        }
+      ],
+      "train": {
+        "eval_set_id": "regression-train",
+        "score": 0.6666666666666666,
+        "passed": false,
+        "cases": [
+          {
+            "id": "train-case-1",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-2",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-3",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation": {
+        "eval_set_id": "regression-validation",
+        "score": 0.6666666666666666,
+        "passed": false,
+        "cases": [
+          {
+            "id": "validation-case-1",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-2",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-3",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "train_delta": {
+        "eval_set_id": "regression-train",
+        "kind": "unchanged",
+        "score_delta": 0
+      },
+      "validation_delta": {
+        "eval_set_id": "regression-validation",
+        "kind": "unchanged",
+        "score_delta": 0
+      },
+      "validation_attribution": {
+        "failures": [
+          {
+            "case_id": "validation-case-2",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "case_id": "validation-case-3",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          }
+        ],
+        "counts": {
+          "final_response_mismatch": 2
+        }
+      },
+      "gate": {
+        "accepted": false,
+        "reasons": [
+          "validation score gain 0.000000 is below required 0.300000"
+        ]
+      },
+      "serving_cost": {
+        "model_calls": 12,
+        "tokens": 60,
+        "latency_ms": 24
+      },
+      "optimization_cost": {
+        "model_calls": 22,
+        "tokens": 110,
+        "latency_ms": 44
+      }
+    },
+    {
+      "number": 2,
+      "input_prompt": "Reply with pong only for basic and short ping requests. fixture:baseline",
+      "candidate_prompt": "Optimize only the training cases. fixture:train-only",
+      "hints": [
+        {
+          "case_id": "train-case-2",
+          "metric_name": "quality",
+          "category": "final_response_mismatch",
+          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
+        {
+          "case_id": "train-case-3",
+          "metric_name": "quality",
+          "category": "final_response_mismatch",
+          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+        }
+      ],
+      "train": {
+        "eval_set_id": "regression-train",
+        "score": 1,
+        "passed": true,
+        "cases": [
+          {
+            "id": "train-case-1",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-2",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-3",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation": {
+        "eval_set_id": "regression-validation",
+        "score": 0.5,
+        "passed": false,
+        "cases": [
+          {
+            "id": "validation-case-1",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-2",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-3",
+            "score": 0.5,
+            "passed": false,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "evaluated": true,
+                "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "train_delta": {
+        "eval_set_id": "regression-train",
+        "kind": "newly_passed",
+        "score_delta": 0.33333333333333337,
+        "changed_cases": [
+          {
+            "id": "train-case-2",
+            "kind": "newly_passed",
+            "baseline_score": 0.5,
+            "candidate_score": 1,
+            "score_delta": 0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_passed",
+                "baseline_score": 0,
+                "candidate_score": 1,
+                "score_delta": 1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-3",
+            "kind": "newly_passed",
+            "baseline_score": 0.5,
+            "candidate_score": 1,
+            "score_delta": 0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_passed",
+                "baseline_score": 0,
+                "candidate_score": 1,
+                "score_delta": 1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation_delta": {
+        "eval_set_id": "regression-validation",
+        "kind": "regressed",
+        "score_delta": -0.16666666666666663,
+        "changed_cases": [
+          {
+            "id": "validation-case-1",
+            "kind": "newly_failed",
+            "baseline_score": 1,
+            "candidate_score": 0.5,
+            "score_delta": -0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_failed",
+                "baseline_score": 1,
+                "candidate_score": 0,
+                "score_delta": -1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation_attribution": {
+        "failures": [
+          {
+            "case_id": "validation-case-1",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "case_id": "validation-case-2",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "case_id": "validation-case-3",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          }
+        ],
+        "counts": {
+          "final_response_mismatch": 3
+        }
+      },
+      "gate": {
+        "accepted": false,
+        "reasons": [
+          "validation score gain -0.166667 is below required 0.300000",
+          "hard metric \"quality\" newly failed in case \"validation-case-1\"",
+          "metric \"quality\" in case \"validation-case-1\" dropped 1.000000"
+        ]
+      },
+      "serving_cost": {
+        "model_calls": 12,
+        "tokens": 60,
+        "latency_ms": 24
+      },
+      "optimization_cost": {
+        "model_calls": 22,
+        "tokens": 110,
+        "latency_ms": 44
+      }
+    },
+    {
+      "number": 3,
+      "input_prompt": "Reply with pong only for basic and short ping requests. fixture:baseline",
+      "candidate_prompt": "Reply with pong for every valid ping request. fixture:balanced",
+      "hints": [
+        {
+          "case_id": "train-case-2",
+          "metric_name": "quality",
+          "category": "final_response_mismatch",
+          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
+        {
+          "case_id": "train-case-3",
+          "metric_name": "quality",
+          "category": "final_response_mismatch",
+          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+        }
+      ],
+      "train": {
+        "eval_set_id": "regression-train",
+        "score": 1,
+        "passed": true,
+        "cases": [
+          {
+            "id": "train-case-1",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-2",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-3",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation": {
+        "eval_set_id": "regression-validation",
+        "score": 1,
+        "passed": true,
+        "cases": [
+          {
+            "id": "validation-case-1",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-2",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-3",
+            "score": 1,
+            "passed": true,
+            "metrics": [
+              {
+                "name": "quality",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true,
+                "evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "train_delta": {
+        "eval_set_id": "regression-train",
+        "kind": "newly_passed",
+        "score_delta": 0.33333333333333337,
+        "changed_cases": [
+          {
+            "id": "train-case-2",
+            "kind": "newly_passed",
+            "baseline_score": 0.5,
+            "candidate_score": 1,
+            "score_delta": 0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_passed",
+                "baseline_score": 0,
+                "candidate_score": 1,
+                "score_delta": 1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "train-case-3",
+            "kind": "newly_passed",
+            "baseline_score": 0.5,
+            "candidate_score": 1,
+            "score_delta": 0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_passed",
+                "baseline_score": 0,
+                "candidate_score": 1,
+                "score_delta": 1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation_delta": {
+        "eval_set_id": "regression-validation",
+        "kind": "newly_passed",
+        "score_delta": 0.33333333333333337,
+        "changed_cases": [
+          {
+            "id": "validation-case-2",
+            "kind": "newly_passed",
+            "baseline_score": 0.5,
+            "candidate_score": 1,
+            "score_delta": 0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_passed",
+                "baseline_score": 0,
+                "candidate_score": 1,
+                "score_delta": 1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          },
+          {
+            "id": "validation-case-3",
+            "kind": "newly_passed",
+            "baseline_score": 0.5,
+            "candidate_score": 1,
+            "score_delta": 0.5,
+            "changed_metrics": [
+              {
+                "name": "quality",
+                "kind": "newly_passed",
+                "baseline_score": 0,
+                "candidate_score": 1,
+                "score_delta": 1,
+                "baseline_evaluated": true,
+                "candidate_evaluated": true
+              }
+            ]
+          }
+        ]
+      },
+      "validation_attribution": {
+        "failures": null,
+        "counts": {}
+      },
+      "gate": {
+        "accepted": true,
+        "reasons": null
+      },
+      "serving_cost": {
+        "model_calls": 12,
+        "tokens": 60,
+        "latency_ms": 24
+      },
+      "optimization_cost": {
+        "model_calls": 22,
+        "tokens": 110,
+        "latency_ms": 44
+      }
+    }
+  ],
+  "decision": {
+    "accepted": true,
+    "write_back_recommended": true,
+    "reason": "candidate accepted by regression gate"
+  },
+  "cost": {
+    "model_calls": 114,
+    "tokens": 570,
+    "latency_ms": 228
+  }
+}

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
@@ -2,9 +2,9 @@
   "schema_version": "v1",
   "status": "accepted",
   "audit": {
-    "run_id": "promptiter-regression-2003-20260718T141000.129395098Z",
-    "started_at": "2026-07-18T14:10:00.129395098Z",
-    "finished_at": "2026-07-18T14:10:00.133637289Z",
+    "run_id": "promptiter-regression-2003-20260720T141210.362223302Z",
+    "started_at": "2026-07-20T14:12:10.362223302Z",
+    "finished_at": "2026-07-20T14:12:10.366531466Z",
     "duration_ms": 4,
     "seed": 2003,
     "inputs": [
@@ -26,7 +26,7 @@
       {
         "name": "promptiter",
         "path": "promptiter.json",
-        "sha256": "604961453a14cf5e3a17c268eaca277840c627f21ba5f5f955bccfe0da1bc255"
+        "sha256": "3c25e8457e88f54953d32cde5ffcf8d6e22d471668e992fbe26a5cd6fe8b4f61"
       },
       {
         "name": "train_evalset",
@@ -42,7 +42,7 @@
     "runtime": {
       "mode": "fake",
       "model": "deterministic-ping-v1",
-      "config_sha256": "1deca002f96c1ba70eaac288a9822f1a21d82542664c45f4e24d4614db5b09fd",
+      "config_sha256": "09a2a08427679ddcd35788bcdd7bae3a9275c2cff0590a6f86ccdc97fef6a5ef",
       "config": {
         "max_rounds": "3",
         "optimizer": "deterministic-promptiter"
@@ -361,6 +361,9 @@
         "metric_names": [
           "quality"
         ],
+        "metric_reasons": {
+          "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
         "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
       },
       {
@@ -369,6 +372,9 @@
         "metric_names": [
           "quality"
         ],
+        "metric_reasons": {
+          "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
         "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
       }
     ],
@@ -384,6 +390,9 @@
         "metric_names": [
           "quality"
         ],
+        "metric_reasons": {
+          "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
         "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
       },
       {
@@ -392,6 +401,9 @@
         "metric_names": [
           "quality"
         ],
+        "metric_reasons": {
+          "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+        },
         "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
       }
     ],
@@ -409,13 +421,13 @@
           "case_id": "train-case-2",
           "metric_name": "quality",
           "category": "final_response_mismatch",
-          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
         },
         {
           "case_id": "train-case-3",
           "metric_name": "quality",
           "category": "final_response_mismatch",
-          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
         }
       ],
       "train": {
@@ -572,6 +584,35 @@
         "kind": "unchanged",
         "score_delta": 0
       },
+      "train_attribution": {
+        "failures": [
+          {
+            "case_id": "train-case-2",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          },
+          {
+            "case_id": "train-case-3",
+            "category": "final_response_mismatch",
+            "metric_names": [
+              "quality"
+            ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
+            "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          }
+        ],
+        "counts": {
+          "final_response_mismatch": 2
+        }
+      },
       "validation_attribution": {
         "failures": [
           {
@@ -580,6 +621,9 @@
             "metric_names": [
               "quality"
             ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
             "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
           },
           {
@@ -588,6 +632,9 @@
             "metric_names": [
               "quality"
             ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
             "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
           }
         ],
@@ -621,13 +668,13 @@
           "case_id": "train-case-2",
           "metric_name": "quality",
           "category": "final_response_mismatch",
-          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
         },
         {
           "case_id": "train-case-3",
           "metric_name": "quality",
           "category": "final_response_mismatch",
-          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
         }
       ],
       "train": {
@@ -841,6 +888,10 @@
           }
         ]
       },
+      "train_attribution": {
+        "failures": null,
+        "counts": {}
+      },
       "validation_attribution": {
         "failures": [
           {
@@ -849,6 +900,9 @@
             "metric_names": [
               "quality"
             ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
             "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
           },
           {
@@ -857,6 +911,9 @@
             "metric_names": [
               "quality"
             ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
             "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
           },
           {
@@ -865,6 +922,9 @@
             "metric_names": [
               "quality"
             ],
+            "metric_reasons": {
+              "quality": "final response mismatch: text mismatch: source not-pong and target pong do not match"
+            },
             "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
           }
         ],
@@ -900,13 +960,13 @@
           "case_id": "train-case-2",
           "metric_name": "quality",
           "category": "final_response_mismatch",
-          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
         },
         {
           "case_id": "train-case-3",
           "metric_name": "quality",
           "category": "final_response_mismatch",
-          "reason": "quality: final response mismatch: text mismatch: source not-pong and target pong do not match"
+          "reason": "final response mismatch: text mismatch: source not-pong and target pong do not match"
         }
       ],
       "train": {
@@ -1134,6 +1194,10 @@
             ]
           }
         ]
+      },
+      "train_attribution": {
+        "failures": null,
+        "counts": {}
       },
       "validation_attribution": {
         "failures": null,

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.json
@@ -2,10 +2,10 @@
   "schema_version": "v1",
   "status": "accepted",
   "audit": {
-    "run_id": "promptiter-regression-2003-20260720T141210.362223302Z",
-    "started_at": "2026-07-20T14:12:10.362223302Z",
-    "finished_at": "2026-07-20T14:12:10.366531466Z",
-    "duration_ms": 4,
+    "run_id": "promptiter-regression-2003-20260720T154642.545456616Z",
+    "started_at": "2026-07-20T15:46:42.545456616Z",
+    "finished_at": "2026-07-20T15:46:42.549239517Z",
+    "duration_ms": 3,
     "seed": 2003,
     "inputs": [
       {
@@ -16,7 +16,7 @@
       {
         "name": "fake_engine",
         "path": "fake_engine.json",
-        "sha256": "0f885a4898143e764a398dcc995f4a8f0647987190f495b1e330016b7e8e71c0"
+        "sha256": "eb13913cdc96fe2d1f0c3cc6bc696ad615d7cd4a003a1870c40888753e4aea6e"
       },
       {
         "name": "metrics",
@@ -26,7 +26,7 @@
       {
         "name": "promptiter",
         "path": "promptiter.json",
-        "sha256": "3c25e8457e88f54953d32cde5ffcf8d6e22d471668e992fbe26a5cd6fe8b4f61"
+        "sha256": "7efb98c83e598aeef343b14030e980bd657f9656c126862de074d27d8c0fdd2d"
       },
       {
         "name": "train_evalset",
@@ -42,7 +42,7 @@
     "runtime": {
       "mode": "fake",
       "model": "deterministic-ping-v1",
-      "config_sha256": "09a2a08427679ddcd35788bcdd7bae3a9275c2cff0590a6f86ccdc97fef6a5ef",
+      "config_sha256": "04eada0069151439910135d63cdc706e57a147afd364a12322375bb36d461ca2",
       "config": {
         "max_rounds": "3",
         "optimizer": "deterministic-promptiter"
@@ -655,8 +655,8 @@
       },
       "optimization_cost": {
         "model_calls": 22,
-        "tokens": 110,
-        "latency_ms": 44
+        "tokens": 142,
+        "latency_ms": 64
       }
     },
     {
@@ -947,8 +947,8 @@
       },
       "optimization_cost": {
         "model_calls": 22,
-        "tokens": 110,
-        "latency_ms": 44
+        "tokens": 142,
+        "latency_ms": 64
       }
     },
     {
@@ -1214,8 +1214,8 @@
       },
       "optimization_cost": {
         "model_calls": 22,
-        "tokens": 110,
-        "latency_ms": 44
+        "tokens": 142,
+        "latency_ms": 64
       }
     }
   ],
@@ -1226,7 +1226,7 @@
   },
   "cost": {
     "model_calls": 114,
-    "tokens": 570,
-    "latency_ms": 228
+    "tokens": 666,
+    "latency_ms": 288
   }
 }

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
@@ -1,0 +1,117 @@
+# Prompt Optimization Report
+
+- Status: **accepted**
+- Decision: candidate accepted by regression gate
+- Seed: 2003
+- Runtime: fake (deterministic-ping-v1)
+
+## Baseline
+
+| Dataset | Score | Passed |
+| --- | ---: | :---: |
+| Train | 0.666667 | false |
+| Validation | 0.666667 | false |
+
+### Train failures
+
+Failure attribution:
+- final_response_mismatch: 2
+  - train-case-2: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+  - train-case-3: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+
+### Validation failures
+
+Failure attribution:
+- final_response_mismatch: 2
+  - validation-case-2: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+  - validation-case-3: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+
+## Optimization Rounds
+
+### Round 1
+
+- Gate: **rejected**
+- Candidate prompt:
+
+```text
+Rephrase without changing behavior. fixture:ineffective
+```
+  - validation score gain 0.000000 is below required 0.300000
+- Train score: 0.666667 (+0.000000)
+- Validation score: 0.666667 (+0.000000)
+- Evaluation cost: 12 calls, 60 tokens, 24 ms
+- Optimization cost: 22 calls, 110 tokens, 44 ms
+- Round total: 34 calls, 170 tokens, 68 ms
+
+| Case | Change | Baseline | Candidate | Delta |
+| --- | --- | ---: | ---: | ---: |
+
+Failure attribution:
+- final_response_mismatch: 2
+  - validation-case-2: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+  - validation-case-3: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+
+### Round 2
+
+- Gate: **rejected**
+- Candidate prompt:
+
+```text
+Optimize only the training cases. fixture:train-only
+```
+  - validation score gain -0.166667 is below required 0.300000
+  - hard metric "quality" newly failed in case "validation-case-1"
+  - metric "quality" in case "validation-case-1" dropped 1.000000
+- Train score: 1.000000 (+0.333333)
+- Validation score: 0.500000 (-0.166667)
+- Evaluation cost: 12 calls, 60 tokens, 24 ms
+- Optimization cost: 22 calls, 110 tokens, 44 ms
+- Round total: 34 calls, 170 tokens, 68 ms
+
+| Case | Change | Baseline | Candidate | Delta |
+| --- | --- | ---: | ---: | ---: |
+| validation-case-1 | newly_failed | 1.000000 | 0.500000 | -0.500000 |
+
+Changed metrics:
+
+| Case | Metric | Change | Baseline | Candidate | Delta |
+| --- | --- | --- | ---: | ---: | ---: |
+| validation-case-1 | quality | newly_failed | 1.000000 | 0.000000 | -1.000000 |
+
+Failure attribution:
+- final_response_mismatch: 3
+  - validation-case-1: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+  - validation-case-2: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+  - validation-case-3: final_response_mismatch — quality: final response mismatch: text mismatch: source not-pong and target pong do not match
+
+### Round 3
+
+- Gate: **accepted**
+- Candidate prompt:
+
+```text
+Reply with pong for every valid ping request. fixture:balanced
+```
+- Train score: 1.000000 (+0.333333)
+- Validation score: 1.000000 (+0.333333)
+- Evaluation cost: 12 calls, 60 tokens, 24 ms
+- Optimization cost: 22 calls, 110 tokens, 44 ms
+- Round total: 34 calls, 170 tokens, 68 ms
+
+| Case | Change | Baseline | Candidate | Delta |
+| --- | --- | ---: | ---: | ---: |
+| validation-case-2 | newly_passed | 0.500000 | 1.000000 | +0.500000 |
+| validation-case-3 | newly_passed | 0.500000 | 1.000000 | +0.500000 |
+
+Changed metrics:
+
+| Case | Metric | Change | Baseline | Candidate | Delta |
+| --- | --- | --- | ---: | ---: | ---: |
+| validation-case-2 | quality | newly_passed | 0.000000 | 1.000000 | +1.000000 |
+| validation-case-3 | quality | newly_passed | 0.000000 | 1.000000 | +1.000000 |
+
+## Cost
+
+- Model calls: 114
+- Tokens: 570
+- Latency: 228 ms

--- a/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/optimization_report.md
@@ -40,8 +40,8 @@ Rephrase without changing behavior. fixture:ineffective
 - Train score: 0.666667 (+0.000000)
 - Validation score: 0.666667 (+0.000000)
 - Evaluation cost: 12 calls, 60 tokens, 24 ms
-- Optimization cost: 22 calls, 110 tokens, 44 ms
-- Round total: 34 calls, 170 tokens, 68 ms
+- Optimization cost: 22 calls, 142 tokens, 64 ms
+- Round total: 34 calls, 202 tokens, 88 ms
 
 | Case | Change | Baseline | Candidate | Delta |
 | --- | --- | ---: | ---: | ---: |
@@ -65,8 +65,8 @@ Optimize only the training cases. fixture:train-only
 - Train score: 1.000000 (+0.333333)
 - Validation score: 0.500000 (-0.166667)
 - Evaluation cost: 12 calls, 60 tokens, 24 ms
-- Optimization cost: 22 calls, 110 tokens, 44 ms
-- Round total: 34 calls, 170 tokens, 68 ms
+- Optimization cost: 22 calls, 142 tokens, 64 ms
+- Round total: 34 calls, 202 tokens, 88 ms
 
 | Case | Change | Baseline | Candidate | Delta |
 | --- | --- | ---: | ---: | ---: |
@@ -95,8 +95,8 @@ Reply with pong for every valid ping request. fixture:balanced
 - Train score: 1.000000 (+0.333333)
 - Validation score: 1.000000 (+0.333333)
 - Evaluation cost: 12 calls, 60 tokens, 24 ms
-- Optimization cost: 22 calls, 110 tokens, 44 ms
-- Round total: 34 calls, 170 tokens, 68 ms
+- Optimization cost: 22 calls, 142 tokens, 64 ms
+- Round total: 34 calls, 202 tokens, 88 ms
 
 | Case | Change | Baseline | Candidate | Delta |
 | --- | --- | ---: | ---: | ---: |
@@ -113,5 +113,5 @@ Changed metrics:
 ## Cost
 
 - Model calls: 114
-- Tokens: 570
-- Latency: 228 ms
+- Tokens: 666
+- Latency: 288 ms

--- a/examples/evaluation/promptiter_regression_loop/runtime.go
+++ b/examples/evaluation/promptiter_regression_loop/runtime.go
@@ -1,0 +1,271 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	evalresultinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metricinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regression"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+const (
+	baselineMarker  = "fixture:baseline"
+	ineffectiveMark = "fixture:ineffective"
+	overfitMarker   = "fixture:train-only"
+	balancedMarker  = "fixture:balanced"
+)
+
+func runFakeLoop(ctx context.Context, config loopConfig) (*regression.OptimizationRun, error) {
+	evaluate := func(ctx context.Context, prompt, evalSetID string, _ int64) (*regression.EvaluationOutput, error) {
+		return evaluatePrompt(ctx, config, prompt, evalSetID)
+	}
+	generate := func(ctx context.Context, request regression.CandidateRequest) (*regression.Candidate, error) {
+		if request.Round <= 0 || request.Round > len(config.candidates) {
+			return nil, fmt.Errorf("candidate round %d is not configured", request.Round)
+		}
+		engine, counter, closeRuntime, err := newPromptIterRuntime(ctx, config, config.candidates[request.Round-1])
+		if err != nil {
+			return nil, err
+		}
+		defer closeRuntime()
+		prompt, err := regression.GeneratePromptIter(ctx, engine, promptiterengine.RunRequest{
+			Train:      []promptiterengine.EvalSetInput{{EvalSetID: config.train.EvalSetID}},
+			Validation: []promptiterengine.EvalSetInput{{EvalSetID: config.validation.EvalSetID}},
+		}, targetSurfaceID, request)
+		if err != nil {
+			return nil, err
+		}
+		return &regression.Candidate{Prompt: prompt, Cost: counter.snapshot()}, nil
+	}
+	return regression.Run(ctx, regression.RunRequest{
+		InitialPrompt: config.baseline, TrainEvalSetID: config.train.EvalSetID,
+		ValidationEvalSetID: config.validation.EvalSetID, GatePolicy: config.gate,
+		MaxRounds: config.maxRounds, Seed: config.seed,
+	}, evaluate, generate)
+}
+
+func evaluatePrompt(ctx context.Context, config loopConfig, prompt, evalSetID string) (_ *regression.EvaluationOutput, resultErr error) {
+	evalSetManager := evalsetinmemory.New()
+	metricManager := metricinmemory.New()
+	evalResultManager := evalresultinmemory.New()
+	defer func() {
+		resultErr = errors.Join(resultErr, evalSetManager.Close(), metricManager.Close(), evalResultManager.Close())
+	}()
+	fixture, err := fixtureByID(config, evalSetID)
+	if err != nil {
+		return nil, err
+	}
+	if err := addFixture(ctx, evalSetManager, metricManager, fixture, config); err != nil {
+		return nil, err
+	}
+	counter := &costCounter{engine: config.engine}
+	evaluator, err := evaluation.New(appName, &deterministicRunner{prompt: prompt, counter: counter},
+		evaluation.WithEvalSetManager(evalSetManager), evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager), evaluation.WithRegistry(registry.New()), evaluation.WithNumRuns(1))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { resultErr = errors.Join(resultErr, evaluator.Close()) }()
+	result, err := evaluator.Evaluate(ctx, evalSetID, evaluation.WithRunDetailsEnabled(true))
+	if err != nil {
+		return nil, err
+	}
+	return &regression.EvaluationOutput{Result: result, Cost: counter.snapshot()}, nil
+}
+
+func newPromptIterRuntime(
+	ctx context.Context, config loopConfig, candidate string,
+) (promptiterengine.Engine, *costCounter, func() error, error) {
+	evalSetManager := evalsetinmemory.New()
+	metricManager := metricinmemory.New()
+	evalResultManager := evalresultinmemory.New()
+	closeManagers := func() error {
+		return errors.Join(evalSetManager.Close(), metricManager.Close(), evalResultManager.Close())
+	}
+	for _, fixture := range []*evalset.EvalSet{config.train, config.validation} {
+		if err := addFixture(ctx, evalSetManager, metricManager, fixture, config); err != nil {
+			return nil, nil, closeManagers, err
+		}
+	}
+	counter := &costCounter{engine: config.engine}
+	evaluator, err := evaluation.New(appName, &deterministicRunner{prompt: config.baseline, counter: counter},
+		evaluation.WithEvalSetManager(evalSetManager), evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager), evaluation.WithRegistry(registry.New()), evaluation.WithNumRuns(1))
+	if err != nil {
+		return nil, nil, closeManagers, err
+	}
+	closeRuntime := func() error { return errors.Join(evaluator.Close(), closeManagers()) }
+	backwardRunner := &jsonRunner{counter: counter, output: fmt.Sprintf(
+		`{"Gradients":[{"SurfaceID":%q,"Severity":"P1","Gradient":"fix failed response"}],"Upstream":[]}`, targetSurfaceID)}
+	aggregatorRunner := &jsonRunner{counter: counter, output: `{"Gradients":[{"Severity":"P1","Gradient":"fix failed response"}]}`}
+	candidateJSON, _ := json.Marshal(candidate)
+	optimizerRunner := &jsonRunner{counter: counter, output: fmt.Sprintf(
+		`{"Value":{"Text":%s},"Reason":"apply failure hints"}`, candidateJSON)}
+	backwarderInstance, err := backwarder.New(ctx, backwardRunner)
+	if err != nil {
+		return nil, nil, closeRuntime, err
+	}
+	aggregatorInstance, err := aggregator.New(ctx, aggregatorRunner)
+	if err != nil {
+		return nil, nil, closeRuntime, err
+	}
+	optimizerInstance, err := optimizer.New(ctx, optimizerRunner)
+	if err != nil {
+		return nil, nil, closeRuntime, err
+	}
+	baseline := config.baseline
+	structure := &astructure.Snapshot{
+		StructureID: "fixture-agent", EntryNodeID: "answer",
+		Nodes: []astructure.Node{{NodeID: "answer", Kind: astructure.NodeKindLLM, Name: agentName}},
+		Surfaces: []astructure.Surface{{SurfaceID: targetSurfaceID, NodeID: "answer", Type: astructure.SurfaceTypeInstruction,
+			Value: astructure.SurfaceValue{Text: &baseline}}},
+	}
+	engine, err := promptiterengine.New(ctx, promptiterengine.WithStructure(structure),
+		promptiterengine.WithAgentEvaluator(evaluator), promptiterengine.WithBackwarder(backwarderInstance),
+		promptiterengine.WithAggregator(aggregatorInstance), promptiterengine.WithOptimizer(optimizerInstance))
+	return engine, counter, closeRuntime, err
+}
+
+func addFixture(ctx context.Context, sets evalset.Manager, metrics metric.Manager, fixture *evalset.EvalSet, config loopConfig) error {
+	if _, err := sets.Create(ctx, appName, fixture.EvalSetID); err != nil {
+		return err
+	}
+	for _, evalCase := range fixture.EvalCases {
+		if err := sets.AddCase(ctx, appName, fixture.EvalSetID, evalCase); err != nil {
+			return err
+		}
+	}
+	for _, evalMetric := range config.metrics {
+		if err := metrics.Add(ctx, appName, fixture.EvalSetID, evalMetric); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fixtureByID(config loopConfig, evalSetID string) (*evalset.EvalSet, error) {
+	if config.train.EvalSetID == evalSetID {
+		return config.train, nil
+	}
+	if config.validation.EvalSetID == evalSetID {
+		return config.validation, nil
+	}
+	return nil, fmt.Errorf("evalset %q is not configured", evalSetID)
+}
+
+type deterministicRunner struct {
+	prompt  string
+	counter *costCounter
+}
+
+func (r *deterministicRunner) Run(_ context.Context, _, _ string, message model.Message, opts ...agent.RunOption) (<-chan *event.Event, error) {
+	var runOptions agent.RunOptions
+	for _, option := range opts {
+		option(&runOptions)
+	}
+	prompt := r.prompt
+	if runOptions.Instruction != "" {
+		prompt = runOptions.Instruction
+	}
+	r.counter.record(2)
+	content := "not-pong"
+	if shouldReplyPong(prompt, message.Content) {
+		content = "pong"
+	}
+	invocationID := "fixture-invocation"
+	started := time.Unix(0, 0)
+	events := []*event.Event{
+		{InvocationID: invocationID, Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+			Role: model.RoleAssistant, ToolCalls: []model.ToolCall{{ID: "echo-call", Function: model.FunctionDefinitionParam{Name: toolName, Arguments: []byte(`{"value":"ping"}`)}}},
+		}}}}},
+		{InvocationID: invocationID, Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Role: model.RoleTool, ToolID: "echo-call", ToolName: toolName, Content: `{"value":"pong"}`}}}}},
+		{InvocationID: invocationID, Response: &model.Response{Done: true, Choices: []model.Choice{{Message: model.NewAssistantMessage(content)}}}},
+		{InvocationID: invocationID, ExecutionTrace: &trace.Trace{
+			RootAgentName: agentName, RootInvocationID: invocationID, Status: trace.TraceStatusCompleted,
+			StartedAt: started, EndedAt: started.Add(time.Duration(2*r.counter.engine.LatencyMS) * time.Millisecond),
+			Usage: &model.Usage{TotalTokens: 2 * (r.counter.engine.PromptTokens + r.counter.engine.CompletionTokens)},
+			Steps: []trace.Step{{StepID: "answer", AgentName: agentName, NodeID: "answer", NodeType: "llm",
+				Input: &trace.Snapshot{Text: message.Content}, Output: &trace.Snapshot{Text: content}, AppliedSurfaceIDs: []string{targetSurfaceID}}},
+		}, Response: &model.Response{Object: model.ObjectTypeRunnerCompletion, Done: true}},
+	}
+	channel := make(chan *event.Event, len(events))
+	for _, item := range events {
+		channel <- item
+	}
+	close(channel)
+	return channel, nil
+}
+
+func (*deterministicRunner) Close() error { return nil }
+
+type costCounter struct {
+	mu     sync.Mutex
+	engine fakeEngineConfig
+	calls  int
+}
+
+func (c *costCounter) record(calls int) { c.mu.Lock(); c.calls += calls; c.mu.Unlock() }
+func (c *costCounter) snapshot() regression.Cost {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return regression.Cost{ModelCalls: c.calls, Tokens: int64(c.calls * (c.engine.PromptTokens + c.engine.CompletionTokens)), LatencyMS: int64(c.calls) * c.engine.LatencyMS}
+}
+
+type jsonRunner struct {
+	counter *costCounter
+	output  string
+}
+
+func (r *jsonRunner) Run(context.Context, string, string, model.Message, ...agent.RunOption) (<-chan *event.Event, error) {
+	r.counter.record(1)
+	channel := make(chan *event.Event, 1)
+	channel <- &event.Event{Response: &model.Response{Done: true, Choices: []model.Choice{{Message: model.NewAssistantMessage(r.output)}}}}
+	close(channel)
+	return channel, nil
+}
+func (*jsonRunner) Close() error { return nil }
+
+func shouldReplyPong(prompt, user string) bool {
+	prompt, user = strings.ToLower(prompt), strings.ToLower(user)
+	switch {
+	case strings.Contains(prompt, balancedMarker):
+		return true
+	case strings.Contains(prompt, overfitMarker):
+		return strings.Contains(user, "basic") || strings.Contains(user, "polite") || strings.Contains(user, "noisy")
+	case strings.Contains(prompt, ineffectiveMark), strings.Contains(prompt, baselineMarker):
+		return strings.Contains(user, "basic") || strings.Contains(user, "short")
+	default:
+		return false
+	}
+}
+
+var _ runner.Runner = (*deterministicRunner)(nil)

--- a/examples/evaluation/promptiter_regression_loop/runtime.go
+++ b/examples/evaluation/promptiter_regression_loop/runtime.go
@@ -202,7 +202,7 @@ func (r *deterministicRunner) Run(_ context.Context, _, _ string, message model.
 	if runOptions.Instruction != "" {
 		prompt = runOptions.Instruction
 	}
-	r.counter.record(2)
+	r.counter.recordServing(2)
 	content := "not-pong"
 	if shouldReplyPong(prompt, message.Content) {
 		content = "pong"
@@ -236,14 +236,29 @@ func (*deterministicRunner) Close() error { return nil }
 type costCounter struct {
 	mu     sync.Mutex
 	engine fakeEngineConfig
-	calls  int
+	cost   regression.Cost
 }
 
-func (c *costCounter) record(calls int) { c.mu.Lock(); c.calls += calls; c.mu.Unlock() }
+func (c *costCounter) recordServing(calls int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cost.ModelCalls += calls
+	c.cost.Tokens += int64(calls) * int64(c.engine.PromptTokens+c.engine.CompletionTokens)
+	c.cost.LatencyMS += int64(calls) * c.engine.LatencyMS
+}
+
+func (c *costCounter) recordOptimizer(calls int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cost.ModelCalls += calls
+	c.cost.Tokens += int64(calls) * c.engine.OptimizerTokens
+	c.cost.LatencyMS += int64(calls) * c.engine.OptimizerLatencyMS
+}
+
 func (c *costCounter) snapshot() regression.Cost {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return regression.Cost{ModelCalls: c.calls, Tokens: int64(c.calls * (c.engine.PromptTokens + c.engine.CompletionTokens)), LatencyMS: int64(c.calls) * c.engine.LatencyMS}
+	return c.cost
 }
 
 type jsonRunner struct {
@@ -252,7 +267,7 @@ type jsonRunner struct {
 }
 
 func (r *jsonRunner) Run(context.Context, string, string, model.Message, ...agent.RunOption) (<-chan *event.Event, error) {
-	r.counter.record(1)
+	r.counter.recordOptimizer(1)
 	channel := make(chan *event.Event, 1)
 	channel <- &event.Event{Response: &model.Response{Done: true, Choices: []model.Choice{{Message: model.NewAssistantMessage(r.output)}}}}
 	close(channel)

--- a/examples/evaluation/promptiter_regression_loop/runtime.go
+++ b/examples/evaluation/promptiter_regression_loop/runtime.go
@@ -99,7 +99,13 @@ func evaluatePrompt(ctx context.Context, config loopConfig, prompt, evalSetID st
 	if err != nil {
 		return nil, err
 	}
-	return &regression.EvaluationOutput{Result: result, Cost: counter.snapshot()}, nil
+	metricNames := make([]string, 0, len(config.metrics))
+	for _, configuredMetric := range config.metrics {
+		metricNames = append(metricNames, configuredMetric.MetricName)
+	}
+	return &regression.EvaluationOutput{
+		Result: result, Cost: counter.snapshot(), MetricNames: metricNames,
+	}, nil
 }
 
 func newPromptIterRuntime(

--- a/examples/evaluation/promptiter_regression_loop/runtime_test.go
+++ b/examples/evaluation/promptiter_regression_loop/runtime_test.go
@@ -1,0 +1,131 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/regression"
+)
+
+func TestFakeRegressionLoopEndToEnd(t *testing.T) {
+	started := time.Now()
+	outputDir := filepath.Join(t.TempDir(), "new-output")
+	report, err := runCommand(context.Background(), commandOptions{
+		paths: defaultPaths(), outputDir: outputDir, seed: 2003,
+	})
+	if err != nil {
+		t.Fatalf("runCommand() error = %v", err)
+	}
+	if time.Since(started) > 3*time.Minute {
+		t.Fatalf("fake loop exceeded three minutes")
+	}
+	if report.Status != "accepted" || !report.Decision.WriteBackRecommended || len(report.Rounds) != 3 {
+		t.Fatalf("report = %+v", report)
+	}
+	if report.Rounds[0].Gate.Accepted || report.Rounds[1].Gate.Accepted || !report.Rounds[2].Gate.Accepted {
+		t.Fatalf("round gates = %+v, %+v, %+v", report.Rounds[0].Gate, report.Rounds[1].Gate, report.Rounds[2].Gate)
+	}
+	if report.Rounds[0].ValidationDelta.ScoreDelta != 0 {
+		t.Fatalf("ineffective round delta = %+v", report.Rounds[0].ValidationDelta)
+	}
+	if report.Rounds[1].TrainDelta.ScoreDelta <= 0 || report.Rounds[1].ValidationDelta.ScoreDelta >= 0 {
+		t.Fatalf("overfit round deltas = train %+v, validation %+v",
+			report.Rounds[1].TrainDelta, report.Rounds[1].ValidationDelta)
+	}
+	if report.Rounds[2].ValidationDelta.ScoreDelta <= 0 || report.Cost.ModelCalls == 0 || report.Cost.Tokens == 0 {
+		t.Fatalf("accepted round or cost = %+v, %+v", report.Rounds[2], report.Cost)
+	}
+	for _, name := range []string{"optimization_report.json", "optimization_report.md"} {
+		path := filepath.Join(outputDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !strings.Contains(string(data), "candidate accepted by regression gate") {
+			t.Fatalf("%s does not contain decision", name)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("%s permissions = %v", name, info.Mode().Perm())
+		}
+	}
+}
+
+func TestRunCommandPreservesExistingOutputDirectoryPermissions(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "existing-output")
+	if err := os.Mkdir(outputDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCommand(context.Background(), commandOptions{paths: defaultPaths(), outputDir: outputDir, seed: 2003}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o750 {
+		t.Fatalf("output directory permissions = %o, want 750", info.Mode().Perm())
+	}
+}
+
+func TestPromptIterConsumesFailureHints(t *testing.T) {
+	config, err := loadConfig(defaultPaths(), 2003)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, _, closeRuntime, err := newPromptIterRuntime(context.Background(), config, config.candidates[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeRuntime()
+	base := promptiterengine.RunRequest{
+		Train:      []promptiterengine.EvalSetInput{{EvalSetID: config.train.EvalSetID}},
+		Validation: []promptiterengine.EvalSetInput{{EvalSetID: config.validation.EvalSetID}},
+	}
+	request := regression.CandidateRequest{Prompt: config.baseline, Round: 1, Seed: config.seed,
+		Hints: []regression.FailureHint{{CaseID: "train-case-2", MetricName: "quality",
+			Category: regression.FailureFinalResponse, Reason: "final response mismatch"}}}
+	prompt, err := regression.GeneratePromptIter(context.Background(), engine, base, targetSurfaceID, request)
+	if err != nil || prompt != config.candidates[0] {
+		t.Fatalf("GeneratePromptIter() = %q, %v", prompt, err)
+	}
+	request.Hints[0].MetricName = "missing-metric"
+	if _, err := regression.GeneratePromptIter(context.Background(), engine, base, targetSurfaceID, request); err == nil {
+		t.Fatal("GeneratePromptIter() accepted a hint unrelated to evaluation failures")
+	}
+}
+
+func TestDeterministicGeneratorUsesRound(t *testing.T) {
+	config, err := loadConfig(defaultPaths(), 2003)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runFakeLoop(context.Background(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, round := range run.Rounds {
+		if round.CandidatePrompt != config.candidates[index] {
+			t.Fatalf("round %d prompt = %q", index+1, round.CandidatePrompt)
+		}
+		if round.InputPrompt != config.baseline {
+			t.Fatalf("rejected prompt was promoted in round %d", index+1)
+		}
+	}
+}

--- a/examples/evaluation/promptiter_regression_loop/runtime_test.go
+++ b/examples/evaluation/promptiter_regression_loop/runtime_test.go
@@ -48,6 +48,12 @@ func TestFakeRegressionLoopEndToEnd(t *testing.T) {
 	if report.Rounds[2].ValidationDelta.ScoreDelta <= 0 || report.Cost.ModelCalls == 0 || report.Cost.Tokens == 0 {
 		t.Fatalf("accepted round or cost = %+v, %+v", report.Rounds[2], report.Cost)
 	}
+	if got := report.Rounds[0].ServingCost; got.ModelCalls != 12 || got.Tokens != 60 || got.LatencyMS != 24 {
+		t.Fatalf("serving cost = %+v", got)
+	}
+	if got := report.Rounds[0].OptimizationCost; got.ModelCalls != 22 || got.Tokens != 142 || got.LatencyMS != 64 {
+		t.Fatalf("optimization cost = %+v", got)
+	}
 	for _, name := range []string{"optimization_report.json", "optimization_report.md"} {
 		path := filepath.Join(outputDir, name)
 		data, err := os.ReadFile(path)

--- a/examples/evaluation/promptiter_regression_loop/runtime_test.go
+++ b/examples/evaluation/promptiter_regression_loop/runtime_test.go
@@ -90,6 +90,56 @@ func TestRunCommandPreservesExistingOutputDirectoryPermissions(t *testing.T) {
 	}
 }
 
+func TestRunCommandReplacesReportSymlinkWithoutModifyingTarget(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "output")
+	if err := os.Mkdir(outputDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(root, "target.json")
+	targetContent := []byte("do not replace")
+	if err := os.WriteFile(targetPath, targetContent, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(targetPath, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	reportPath := filepath.Join(outputDir, "optimization_report.json")
+	if err := os.Symlink(targetPath, reportPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCommand(context.Background(), commandOptions{
+		paths: defaultPaths(), outputDir: outputDir, seed: 2003,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	gotTarget, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotTarget) != string(targetContent) {
+		t.Fatalf("symlink target content = %q, want %q", gotTarget, targetContent)
+	}
+	targetInfo, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetInfo.Mode().Perm() != 0o640 {
+		t.Fatalf("symlink target permissions = %o, want 640", targetInfo.Mode().Perm())
+	}
+	reportInfo, err := os.Lstat(reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reportInfo.Mode().IsRegular() {
+		t.Fatalf("report mode = %v, want regular file", reportInfo.Mode())
+	}
+	if reportInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("report permissions = %o, want 600", reportInfo.Mode().Perm())
+	}
+}
+
 func TestPromptIterConsumesFailureHints(t *testing.T) {
 	config, err := loadConfig(defaultPaths(), 2003)
 	if err != nil {


### PR DESCRIPTION
## What changed

Adds a reproducible Evaluation + PromptIter regression loop:

```text
baseline train/validation evaluation
→ failure attribution
→ PromptIter candidate generation
→ candidate regression
→ acceptance gate
→ JSON/Markdown audit report
```

The pipeline summarizes Evaluation Service results, attributes each failed case,
and converts failed case/metric reasons into PromptIter loss hints. Every
candidate is rerun against separate training and validation evalsets and compared
with the last accepted prompt at dataset, case, and metric levels.

A candidate is accepted only when validation gain reaches the configured
minimum, no new hard failure is introduced, critical cases and metrics stay
within regression limits, and model-call/token budgets are respected. Rejected
candidates are not promoted, so training gains accompanied by validation
regression are rejected as overfitting. The pipeline only recommends write-back;
it never modifies the source prompt.

## Deterministic example

`examples/evaluation/promptiter_regression_loop` contains three training and
three validation cases using real Evaluation Service final-response and
tool-trajectory metrics.

The example instantiates the existing PromptIter engine and runs its evaluation,
loss, backward, aggregation, optimizer, profile-patch, and validation stages.
Deterministic stage runners require no API key and reproduce three rounds:

| Round | Scenario | Decision |
| --- | --- | --- |
| 1 | Candidate is equivalent to baseline | Rejected as ineffective |
| 2 | Training improves, validation regresses | Rejected as overfitting |
| 3 | Training and validation improve | Accepted |

Run from `examples/evaluation`:

```bash
go run ./promptiter_regression_loop \
  -seed=2003 \
  -output=./promptiter_regression_loop/output
```

The generated JSON and Markdown reports include prompts, baseline scores and
failure evidence, changed case/metric deltas, gate reasons, per-round cost,
seed, runtime/input hashes, and the final write-back recommendation.

## Testing

```bash
cd evaluation
go test -race ./workflow/promptiter/regression -count=1

cd ../examples/evaluation
go test -race ./promptiter_regression_loop -count=1
```

Closes #2003
