### PR TITLE
trpc-agent-go: restore Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,7 @@ Inspired by amazing frameworks like **ADK**, **Agno**, **CrewAI**, **AutoGen**, 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=trpc-group/trpc-agent-go&type=Date)](https://star-history.com/#trpc-group/trpc-agent-go&Date)
+[![Star History Chart](https://api.star-history.com/chart?repos=trpc-group/trpc-agent-go&type=date&legend=top-left&sealed_token=cOvxWW_HIOl_iqhx7EX4sM_lhJS9pKkMhBbgGeVmfRtpJI3blqrmWSBobm1va_F_A-FPah1pI_zv5E8uVf9sIDzA2WKntW21ZPiJQ9k_Tw_hECs-FuyetP6G6K3Ub0JKSBUB7uQNQNU7hpbcX5Rhoev4ujQ4SXDseYXGP_Bu_P-ptJeVcFVRscMmKhZC)](https://www.star-history.com/?repos=trpc-group%2Ftrpc-agent-go&type=date&legend=top-left)
 
 ---
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -758,7 +758,7 @@ go vet ./...
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=trpc-group/trpc-agent-go&type=Date)](https://star-history.com/#trpc-group/trpc-agent-go&Date)
+[![Star History Chart](https://api.star-history.com/chart?repos=trpc-group/trpc-agent-go&type=date&legend=top-left&sealed_token=cOvxWW_HIOl_iqhx7EX4sM_lhJS9pKkMhBbgGeVmfRtpJI3blqrmWSBobm1va_F_A-FPah1pI_zv5E8uVf9sIDzA2WKntW21ZPiJQ9k_Tw_hECs-FuyetP6G6K3Ub0JKSBUB7uQNQNU7hpbcX5Rhoev4ujQ4SXDseYXGP_Bu_P-ptJeVcFVRscMmKhZC)](https://www.star-history.com/?repos=trpc-group%2Ftrpc-agent-go&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
## Summary

- replace the deprecated Star History SVG embed in the English and Chinese READMEs
- use the current chart endpoint with a sealed repository-scoped token
- update the chart link to the current Star History URL format

## Why

GitHub now restricts the stargazers endpoint to repository administrators and collaborators. The previous anonymous Star History embed can no longer retrieve this repository's star history.

The replacement embed was generated with a dedicated fine-grained token limited to `trpc-group/trpc-agent-go`, with only read-only metadata access and an expiration configured. Only the encrypted `sealed_token` is included in the README.

## Impact

The Star History section can use the authenticated chart path required by the current GitHub API restrictions, while keeping the token's permissions and repository scope minimal.

## Validation

- `git diff --check`
- confirmed both READMEs use the same generated chart URL
- confirmed the Star History destination page returns HTTP 200
- the chart service currently returns HTTP 500 because its container is overloaded; the official Star History repository's own sealed-token chart fails the same way, so live rendering could not be verified at PR creation time
