### PR TITLE
docs: clarify structured output provider compatibility

### DIFF
--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -912,6 +912,9 @@ tool ran. When correctness depends on tool execution, verify the tool-call and
 tool-result events. If an endpoint does not reliably support the combination,
 split the operation into a tool-enabled call without native structured output,
 followed by a tool-disabled call that produces the structured final response.
+The second call must receive the first call's evidence by continuing the same
+session or message history, or by explicitly including its tool-call and
+tool-result messages.
 
 Related backend discussions include
 [vLLM #39929](https://github.com/vllm-project/vllm/issues/39929), which tracks

--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -897,6 +897,28 @@ Structured output ensures that agent responses conform to a predefined format, m
 | **Data Location** | Event.StructuredOutput | Event.StructuredOutput | Model response content | Session State |
 | **Primary Use Case** | Flexible schema with tools | Type-safe structured output | Simple structured responses | State storage & flow control |
 
+### Provider Compatibility
+
+The framework allows tools to be configured with
+`WithStructuredOutputJSONSchema` or `WithStructuredOutputJSON`, but the model
+service must also support combining tool calling with native structured output.
+Some OpenAI-compatible endpoints accept both `tools` and
+`response_format: json_schema` while applying the JSON constraint to the entire
+generation. In that case, constrained decoding can suppress the model-specific
+tool-call syntax and return schema-valid JSON without any tool call.
+
+An HTTP success response and valid JSON therefore do not prove that a required
+tool ran. When correctness depends on tool execution, verify the tool-call and
+tool-result events. If an endpoint does not reliably support the combination,
+split the operation into a tool-enabled call without native structured output,
+followed by a tool-disabled call that produces the structured final response.
+
+Related backend discussions include
+[vLLM #39929](https://github.com/vllm-project/vllm/issues/39929), which tracks
+`response_format` suppressing automatic tool calls, and
+[SGLang #21593](https://github.com/sgl-project/sglang/pull/21593), which fixes
+conflicts between constrained decoding and model-specific tool-call formats.
+
 ### WithStructuredOutputJSONSchema
 
 Provides a user-defined JSON schema for structured output while **allowing tool usage**. This is the most flexible option for agents that need both structured output and tool capabilities.

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -849,6 +849,25 @@ llmagent := llmagent.New("llmagent", llmagent.WithAgentCallbacks(callbacks))
 | **数据位置** | Event.StructuredOutput | Event.StructuredOutput | 模型响应内容 | Session State |
 | **主要用途** | 灵活 schema + 工具 | 类型安全的结构化输出 | 简单的结构化响应 | 状态存储和流程控制 |
 
+### Provider 兼容性
+
+框架允许同时配置工具与 `WithStructuredOutputJSONSchema` 或
+`WithStructuredOutputJSON`，但模型服务也必须支持组合使用工具调用与原生结构化输出。
+部分 OpenAI 兼容端点会接受 `tools` 和 `response_format: json_schema`，
+却把 JSON 约束应用于整个生成过程。在这种情况下，约束解码可能会抑制模型专用的
+工具调用语法，最终返回符合 schema 的 JSON，却没有实际发起任何工具调用。
+
+因此，HTTP 请求成功且 JSON 校验通过，并不能证明所需工具已执行。当结果正确性依赖
+工具执行时，应同时检查工具调用与工具结果事件。如果端点不能可靠支持该组合，
+可将操作拆成两次调用：先在不启用原生结构化输出的情况下调用工具，再禁用工具并
+生成结构化的最终答复。
+
+相关后端讨论包括
+[vLLM #39929](https://github.com/vllm-project/vllm/issues/39929)，该 issue
+跟踪 `response_format` 抑制自动工具调用的问题；以及
+[SGLang #21593](https://github.com/sgl-project/sglang/pull/21593)，该 PR
+修复了约束解码与模型专用工具调用格式之间的冲突。
+
 ### WithStructuredOutputJSONSchema
 
 提供用户自定义的 JSON schema 用于结构化输出，同时**允许使用工具**。这是需要结构化输出和工具能力的 Agent 的最灵活选项。

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -860,7 +860,8 @@ llmagent := llmagent.New("llmagent", llmagent.WithAgentCallbacks(callbacks))
 因此，HTTP 请求成功且 JSON 校验通过，并不能证明所需工具已执行。当结果正确性依赖
 工具执行时，应同时检查工具调用与工具结果事件。如果端点不能可靠支持该组合，
 可将操作拆成两次调用：先在不启用原生结构化输出的情况下调用工具，再禁用工具并
-生成结构化的最终答复。
+生成结构化的最终答复。第二次调用必须通过延续相同的 session 或消息历史来获取
+第一次调用的证据，或者显式包含第一次调用的工具调用与工具结果消息。
 
 相关后端讨论包括
 [vLLM #39929](https://github.com/vllm-project/vllm/issues/39929)，该 issue

--- a/examples/structuredoutputskills/README.md
+++ b/examples/structuredoutputskills/README.md
@@ -29,7 +29,10 @@ events shown by this example.
 
 If your endpoint does not reliably support the combination, use separate model
 calls: collect evidence with tools and without native structured output, then
-disable tools and request the structured final response. See
+disable tools and request the structured final response. Continue the same
+session or message history for the second call, or explicitly include the first
+call's tool-call and tool-result messages, so the final response receives the
+collected evidence. See
 [vLLM #39929](https://github.com/vllm-project/vllm/issues/39929) and
 [SGLang #21593](https://github.com/sgl-project/sglang/pull/21593) for related
 backend behavior.
@@ -44,11 +47,14 @@ go run . -model deepseek-v4-flash
 
 Then ask anything (for example: "run the hello skill").
 
-You should see:
+With a compatible provider, you should see:
 
 - tool calls (`skill_load`, then `skill_run`)
 - a final JSON response
 - a typed `event.StructuredOutput` payload printed by the example
+
+If a required tool call does not appear, do not treat a schema-valid final
+response as evidence that the tool ran. Use the separate-call fallback above.
 
 ## What the skill does
 

--- a/examples/structuredoutputskills/README.md
+++ b/examples/structuredoutputskills/README.md
@@ -19,6 +19,21 @@ The key idea is:
 - Only the **final** answer must be a single JSON object that matches the
   schema.
 
+## Provider compatibility
+
+This pattern requires the model service to support tools together with native
+structured output. Some OpenAI-compatible endpoints accept both request fields
+but let the JSON constraint suppress tool calls. A schema-valid final response
+does not by itself prove that a tool ran; check the tool-call and tool-result
+events shown by this example.
+
+If your endpoint does not reliably support the combination, use separate model
+calls: collect evidence with tools and without native structured output, then
+disable tools and request the structured final response. See
+[vLLM #39929](https://github.com/vllm-project/vllm/issues/39929) and
+[SGLang #21593](https://github.com/sgl-project/sglang/pull/21593) for related
+backend behavior.
+
 ## Run
 
 From this directory:


### PR DESCRIPTION
## What changed

- Add provider compatibility guidance to the English and Chinese structured output documentation.
- Clarify that allowing tools at the framework level does not guarantee that every OpenAI-compatible endpoint supports combining `tools` with native `response_format: json_schema`.
- Document how to verify required tool execution and the two-call fallback for incompatible endpoints.
- Add the same compatibility note to the structured output + Skills example.

## Why

Some OpenAI-compatible backends accept both request fields but apply the final JSON constraint to the entire generation. This can suppress model-specific tool-call syntax and return schema-valid JSON without executing a required tool.

The current documentation says tools are allowed with structured output, but does not distinguish framework support from provider capability. Related backend behavior is documented in:

- https://github.com/vllm-project/vllm/issues/39929
- https://github.com/sgl-project/sglang/pull/21593

## Testing

- `git diff --check`
- `mkdocs build --strict -f docs/mkdocs.yml`

## Notes for reviewers

This is a documentation-only change. It does not alter request construction or runtime behavior. The vLLM link demonstrates the same `response_format` and automatic tool-calling conflict; the SGLang link is a related fix for constrained decoding with model-specific tool-call formats.

RELEASE NOTES: Clarified provider compatibility requirements when combining tools with structured output.

Made with [Cursor](https://cursor.com)