### PR TITLE
processor: preserve deadline event identity

### DIFF
--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -463,12 +463,17 @@ func persistFunctionResponseAfterDeadline(
 	)
 	defer cancel()
 	routeEvent := sessionroute.SnapshotEventIdentity(functionResponseEvent)
-	functionResponseEvent = applyEventPluginsAfterDeadline(
+	parentMetadata := functionResponseEvent.ParentMetadata
+	functionResponseEvent, err := applyEventPluginsAfterDeadline(
 		persistCtx,
 		invocation,
 		functionResponseEvent,
 	)
+	if err != nil {
+		return err
+	}
 	restoreEventRoutingFields(functionResponseEvent, routeEvent)
+	functionResponseEvent.ParentMetadata = parentMetadata
 
 	attached, err := appender.Invoke(
 		persistCtx,
@@ -505,19 +510,18 @@ func applyEventPluginsAfterDeadline(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	evt *event.Event,
-) *event.Event {
+) (*event.Event, error) {
 	if evt == nil || invocation == nil || invocation.Plugins == nil {
-		return evt
+		return evt, nil
 	}
 	updated, err := invocation.Plugins.OnEvent(ctx, invocation, evt)
 	if err != nil {
-		log.ErrorfContext(ctx, "plugin OnEvent failed: %v", err)
-		return evt
+		return nil, err
 	}
 	if updated == nil {
-		return evt
+		return evt, nil
 	}
-	return updated
+	return updated, nil
 }
 
 func restoreEventRoutingFields(dst *event.Event, src *event.Event) {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -457,6 +457,9 @@ func persistFunctionResponseAfterDeadline(
 	invocation *agent.Invocation,
 	functionResponseEvent *event.Event,
 ) error {
+	if functionResponseEvent == nil {
+		return nil
+	}
 	persistCtx, cancel := context.WithTimeout(
 		context.WithoutCancel(ctx),
 		funcRespDeadlinePersistenceTimeout,

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -466,15 +466,16 @@ func persistFunctionResponseAfterDeadline(
 	)
 	defer cancel()
 	routeEvent := sessionroute.SnapshotEventIdentity(functionResponseEvent)
-	parentMetadata := functionResponseEvent.ParentMetadata
-	functionResponseEvent, err := applyEventPluginsAfterDeadline(
+	var parentMetadata *event.ParentInvocationMetadata
+	if functionResponseEvent.ParentMetadata != nil {
+		metadata := *functionResponseEvent.ParentMetadata
+		parentMetadata = &metadata
+	}
+	functionResponseEvent = applyEventPluginsAfterDeadline(
 		persistCtx,
 		invocation,
 		functionResponseEvent,
 	)
-	if err != nil {
-		return err
-	}
 	restoreEventRoutingFields(functionResponseEvent, routeEvent)
 	functionResponseEvent.ParentMetadata = parentMetadata
 
@@ -513,18 +514,19 @@ func applyEventPluginsAfterDeadline(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	evt *event.Event,
-) (*event.Event, error) {
+) *event.Event {
 	if evt == nil || invocation == nil || invocation.Plugins == nil {
-		return evt, nil
+		return evt
 	}
 	updated, err := invocation.Plugins.OnEvent(ctx, invocation, evt)
 	if err != nil {
-		return nil, err
+		log.ErrorfContext(ctx, "plugin OnEvent failed: %v", err)
+		return evt
 	}
 	if updated == nil {
-		return evt, nil
+		return evt
 	}
-	return updated, nil
+	return updated
 }
 
 func restoreEventRoutingFields(dst *event.Event, src *event.Event) {

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -4043,6 +4043,12 @@ func TestPersistFunctionResponseAfterDeadline_AppliesEventPlugins(
 				replacement.ParentInvocationID = "other-parent"
 				replacement.Branch = "other-branch"
 				replacement.FilterKey = "other-filter"
+				replacement.ParentMetadata =
+					&event.ParentInvocationMetadata{
+						TriggerType: event.TriggerTypeTransfer,
+						TriggerID:   "other-trigger",
+						TriggerName: "other-trigger-name",
+					}
 				return replacement, nil
 			})
 		},
@@ -4068,6 +4074,11 @@ func TestPersistFunctionResponseAfterDeadline_AppliesEventPlugins(
 	original.ParentInvocationID = "parent-1"
 	original.Branch = "branch-1"
 	original.FilterKey = "filter-1"
+	original.ParentMetadata = &event.ParentInvocationMetadata{
+		TriggerType: event.TriggerTypeToolCall,
+		TriggerID:   "call-1",
+		TriggerName: "echo",
+	}
 
 	err := persistFunctionResponseAfterDeadline(ctx, inv, original)
 
@@ -4078,10 +4089,85 @@ func TestPersistFunctionResponseAfterDeadline_AppliesEventPlugins(
 	require.Equal(t, original.RequestID, persisted.RequestID)
 	require.Equal(t, original.InvocationID, persisted.InvocationID)
 	require.Equal(t, original.ParentInvocationID, persisted.ParentInvocationID)
+	require.Same(t, original.ParentMetadata, persisted.ParentMetadata)
+	require.Equal(t, event.TriggerTypeToolCall,
+		persisted.ParentMetadata.TriggerType)
+	require.Equal(t, "call-1", persisted.ParentMetadata.TriggerID)
+	require.Equal(t, "echo", persisted.ParentMetadata.TriggerName)
 	require.Equal(t, original.Branch, persisted.Branch)
 	require.Equal(t, original.FilterKey, persisted.FilterKey)
 }
 
+func TestPersistFunctionResponseAfterDeadline_PluginErrorStopsPersistence(
+	t *testing.T,
+) {
+	ctx, cancel := context.WithDeadline(
+		context.Background(),
+		time.Now().Add(-time.Second),
+	)
+	defer cancel()
+
+	wantErr := errors.New("redaction failed")
+	mgr := plugin.MustNewManager(&hookPlugin{
+		name: "failing-redaction",
+		reg: func(r *plugin.Registry) {
+			r.OnEvent(func(
+				context.Context,
+				*agent.Invocation,
+				*event.Event,
+			) (*event.Event, error) {
+				return nil, wantErr
+			})
+		},
+	})
+	service := sessioninmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, service.Close())
+	})
+	recordingService := &recordingSessionService{Service: service}
+
+	for _, tc := range []struct {
+		name           string
+		attachAppender bool
+	}{
+		{name: "attached appender", attachAppender: true},
+		{name: "session service fallback"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := agent.NewInvocation(
+				agent.WithInvocationSessionService(recordingService),
+				agent.WithInvocationPlugins(mgr),
+			)
+			var appenderCalls atomic.Int32
+			if tc.attachAppender {
+				appender.Attach(inv, func(
+					context.Context,
+					*event.Event,
+				) error {
+					appenderCalls.Add(1)
+					return nil
+				})
+			}
+			evt := event.NewResponseEvent(
+				"test-invocation",
+				"test-agent",
+				&model.Response{Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						"call-1",
+						"echo",
+						"secret tool output",
+					),
+				}}},
+			)
+
+			err := persistFunctionResponseAfterDeadline(ctx, inv, evt)
+
+			require.ErrorIs(t, err, wantErr)
+			require.Zero(t, appenderCalls.Load())
+			require.Zero(t, recordingService.appendCalls.Load())
+		})
+	}
+}
 func TestFunctionCallResponseProcessor_HandleFunctionCallsAndSendEvent_Warns(
 	t *testing.T,
 ) {

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -3934,6 +3934,13 @@ func TestPersistFunctionResponseAfterDeadline_FallbacksAndErrors(
 		time.Now().Add(-time.Second),
 	)
 	defer cancel()
+	t.Run("nil event", func(t *testing.T) {
+		require.NoError(t, persistFunctionResponseAfterDeadline(
+			ctx,
+			nil,
+			nil,
+		))
+	})
 	evt := event.NewResponseEvent(
 		"test-invocation",
 		"test-agent",

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -4029,11 +4029,15 @@ func TestPersistFunctionResponseAfterDeadline_AppliesEventPlugins(
 		name: "redact-event",
 		reg: func(r *plugin.Registry) {
 			r.OnEvent(func(
-				context.Context,
-				*agent.Invocation,
-				*event.Event,
+				_ context.Context,
+				_ *agent.Invocation,
+				evt *event.Event,
 			) (*event.Event, error) {
 				pluginCalls++
+				evt.ParentMetadata.TriggerType =
+					event.TriggerTypeTransfer
+				evt.ParentMetadata.TriggerID = "mutated-trigger"
+				evt.ParentMetadata.TriggerName = "mutated-name"
 				replacement := event.NewResponseEvent(
 					"",
 					"test-agent",
@@ -4096,16 +4100,17 @@ func TestPersistFunctionResponseAfterDeadline_AppliesEventPlugins(
 	require.Equal(t, original.RequestID, persisted.RequestID)
 	require.Equal(t, original.InvocationID, persisted.InvocationID)
 	require.Equal(t, original.ParentInvocationID, persisted.ParentInvocationID)
-	require.Same(t, original.ParentMetadata, persisted.ParentMetadata)
+	require.NotSame(t, original.ParentMetadata, persisted.ParentMetadata)
 	require.Equal(t, event.TriggerTypeToolCall,
 		persisted.ParentMetadata.TriggerType)
 	require.Equal(t, "call-1", persisted.ParentMetadata.TriggerID)
 	require.Equal(t, "echo", persisted.ParentMetadata.TriggerName)
+	require.Equal(t, "mutated-trigger", original.ParentMetadata.TriggerID)
 	require.Equal(t, original.Branch, persisted.Branch)
 	require.Equal(t, original.FilterKey, persisted.FilterKey)
 }
 
-func TestPersistFunctionResponseAfterDeadline_PluginErrorStopsPersistence(
+func TestPersistFunctionResponseAfterDeadline_PluginErrorPersistsOriginal(
 	t *testing.T,
 ) {
 	ctx, cancel := context.WithDeadline(
@@ -4132,6 +4137,16 @@ func TestPersistFunctionResponseAfterDeadline_PluginErrorStopsPersistence(
 		require.NoError(t, service.Close())
 	})
 	recordingService := &recordingSessionService{Service: service}
+	sess, err := service.CreateSession(
+		context.Background(),
+		session.Key{
+			AppName:   "test-app",
+			UserID:    "test-user",
+			SessionID: "test-session",
+		},
+		nil,
+	)
+	require.NoError(t, err)
 
 	for _, tc := range []struct {
 		name           string
@@ -4141,17 +4156,21 @@ func TestPersistFunctionResponseAfterDeadline_PluginErrorStopsPersistence(
 		{name: "session service fallback"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			recordingService.appendCalls.Store(0)
 			inv := agent.NewInvocation(
+				agent.WithInvocationSession(sess),
 				agent.WithInvocationSessionService(recordingService),
 				agent.WithInvocationPlugins(mgr),
 			)
 			var appenderCalls atomic.Int32
+			var appended *event.Event
 			if tc.attachAppender {
 				appender.Attach(inv, func(
-					context.Context,
-					*event.Event,
+					_ context.Context,
+					evt *event.Event,
 				) error {
 					appenderCalls.Add(1)
+					appended = evt
 					return nil
 				})
 			}
@@ -4169,9 +4188,19 @@ func TestPersistFunctionResponseAfterDeadline_PluginErrorStopsPersistence(
 
 			err := persistFunctionResponseAfterDeadline(ctx, inv, evt)
 
-			require.ErrorIs(t, err, wantErr)
+			require.NoError(t, err)
+			if tc.attachAppender {
+				require.Equal(t, int32(1), appenderCalls.Load())
+				require.Zero(t, recordingService.appendCalls.Load())
+				require.Same(t, evt, appended)
+				return
+			}
 			require.Zero(t, appenderCalls.Load())
-			require.Zero(t, recordingService.appendCalls.Load())
+			require.Equal(
+				t,
+				int32(1),
+				recordingService.appendCalls.Load(),
+			)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- preserve `ParentMetadata` by value when deadline fallback event plugins mutate or replace an event
- keep `OnEvent` error handling aligned with the normal runner path by logging the error and persisting the original event
- guard nil deadline events and cover both appender and session-service fallback paths

## Root Cause

The deadline fallback introduced by #2211 restored scalar routing fields after event plugins, but retained parent trigger metadata only by pointer. An in-place hook mutation could therefore change the join key used to correlate parallel child-agent events.

## Validation

- `go test ./internal/flow/processor -count=1`
- focused deadline plugin tests with `-count=10`
- focused deadline plugin tests with `-race`
- `go vet ./internal/flow/processor`
- `goimports`, `gofmt`, changed-line width, and `git diff --check`
- processor coverage: 93.2%; `persistFunctionResponseAfterDeadline`: 100%
- `go test ./...` completed except for two unrelated local environment failures: an older bubblewrap binary without `--clearenv`, and preconfigured Langfuse environment variables

Follow-up to #2211.