### PR TITLE
feat(langfuse): opt-in identity options and attribute rewrite hook

### DIFF
--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -14,6 +14,7 @@ package telemetry
 import (
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -30,6 +31,33 @@ import (
 	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+// genAISystem holds the gen_ai.system value stamped on agent/tool/chat spans.
+// Defaults to semconvtrace.SystemTRPCGoAgent; integrators may override via
+// SetGenAISystem (e.g. langfuse.WithGenAISystem).
+var genAISystem atomic.Value
+
+func init() {
+	genAISystem.Store(semconvtrace.SystemTRPCGoAgent)
+}
+
+// GenAISystem returns the gen_ai.system value used when stamping span attributes.
+func GenAISystem() string {
+	if v, ok := genAISystem.Load().(string); ok && v != "" {
+		return v
+	}
+	return semconvtrace.SystemTRPCGoAgent
+}
+
+// SetGenAISystem overrides the gen_ai.system value stamped by Trace* helpers.
+// An empty system restores the library default (trpc.go.agent).
+func SetGenAISystem(system string) {
+	if system == "" {
+		genAISystem.Store(semconvtrace.SystemTRPCGoAgent)
+		return
+	}
+	genAISystem.Store(system)
+}
 
 // grpcDial is a package-level variable to allow test injection of a custom dialer.
 // In production, this points to grpc.Dial.
@@ -233,7 +261,7 @@ func (s *ChatTraceState) TraceChat(span trace.Span, attributes *TraceChatAttribu
 
 func baseChatAttributes() []attribute.KeyValue {
 	return []attribute.KeyValue{
-		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAISystem, GenAISystem()),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationChat),
 	}
 }
@@ -288,7 +316,7 @@ const (
 // TraceToolCall traces the invocation of a tool call.
 func TraceToolCall(span trace.Span, sess *session.Session, declaration *tool.Declaration, args []byte, rspEvent *event.Event, err error) {
 	span.SetAttributes(
-		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAISystem, GenAISystem()),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
 		attribute.String(semconvtrace.KeyGenAIToolName, declaration.Name),
 		attribute.String(semconvtrace.KeyGenAIToolDescription, declaration.Description),
@@ -338,7 +366,7 @@ const ToolNameMergedTools = "(merged tools)"
 // for preventing trace-query requests typically sent by web UIs.
 func TraceMergedToolCalls(span trace.Span, rspEvent *event.Event) {
 	span.SetAttributes(
-		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAISystem, GenAISystem()),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
 		attribute.String(semconvtrace.KeyGenAIToolName, ToolNameMergedTools),
 		attribute.String(semconvtrace.KeyGenAIToolDescription, "(merged tools)"),
@@ -382,7 +410,7 @@ func TraceBeforeInvokeAgent(span trace.Span, invoke *agent.Invocation, agentDesc
 		return
 	}
 	attrs := []attribute.KeyValue{
-		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
+		attribute.String(semconvtrace.KeyGenAISystem, GenAISystem()),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationInvokeAgent),
 		attribute.String(semconvtrace.KeyGenAIAgentDescription, agentDescription),
 		attribute.String(semconvtrace.KeyGenAISystemInstructions, instructions),

--- a/telemetry/langfuse/attribute_rewriter.go
+++ b/telemetry/langfuse/attribute_rewriter.go
@@ -1,0 +1,61 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package langfuse
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// attributeRewritingExporter wraps a SpanExporter and rewrites span attributes
+// immediately before export. In-process span processors still observe original
+// attributes; only the export path sees the rewritten set.
+type attributeRewritingExporter struct {
+	next    sdktrace.SpanExporter
+	rewrite AttributeRewriter
+}
+
+var _ sdktrace.SpanExporter = (*attributeRewritingExporter)(nil)
+
+func (e *attributeRewritingExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	if e == nil || e.next == nil {
+		return nil
+	}
+	if e.rewrite == nil {
+		return e.next.ExportSpans(ctx, spans)
+	}
+	out := make([]sdktrace.ReadOnlySpan, len(spans))
+	for i, span := range spans {
+		out[i] = &attrRewrittenSpan{
+			ReadOnlySpan: span,
+			attrs:        e.rewrite(span.Attributes()),
+		}
+	}
+	return e.next.ExportSpans(ctx, out)
+}
+
+func (e *attributeRewritingExporter) Shutdown(ctx context.Context) error {
+	if e == nil || e.next == nil {
+		return nil
+	}
+	return e.next.Shutdown(ctx)
+}
+
+// attrRewrittenSpan overrides Attributes() while delegating all other methods.
+type attrRewrittenSpan struct {
+	sdktrace.ReadOnlySpan
+	attrs []attribute.KeyValue
+}
+
+func (s *attrRewrittenSpan) Attributes() []attribute.KeyValue {
+	return s.attrs
+}

--- a/telemetry/langfuse/config.go
+++ b/telemetry/langfuse/config.go
@@ -13,10 +13,23 @@ package langfuse
 import (
 	"os"
 	"strconv"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
 )
 
 // Option is a function that configures Start options.
 type Option func(*config)
+
+// BaggageAttributeFilter decides whether a baggage member is copied onto
+// span attributes at span start. Integrators can replace the default Langfuse
+// allowlist or compose with WithExtraBaggageAttributeKeys.
+type BaggageAttributeFilter func(baggage.Member) bool
+
+// AttributeRewriter transforms span attributes immediately before export.
+// Returning a new slice leaves the in-memory span unchanged for local processors.
+// A nil rewriter preserves attributes as stamped by the library (default).
+type AttributeRewriter func(attrs []attribute.KeyValue) []attribute.KeyValue
 
 // WithSecretKey sets the Langfuse secret key.
 func WithSecretKey(secretKey string) Option {
@@ -69,6 +82,73 @@ func WithObservationLeafValueMaxBytes(maxBytes int) Option {
 	}
 }
 
+// WithServiceName overrides the service.name resource attribute when Start
+// creates a new TracerProvider. Defaults to the library telemetry service name.
+// Ignored when an existing SDK TracerProvider is already installed.
+func WithServiceName(serviceName string) Option {
+	return func(cfg *config) {
+		cfg.serviceName = serviceName
+	}
+}
+
+// WithServiceNamespace overrides the service.namespace resource attribute when
+// Start creates a new TracerProvider. Defaults to the library namespace.
+// Ignored when an existing SDK TracerProvider is already installed.
+func WithServiceNamespace(serviceNamespace string) Option {
+	return func(cfg *config) {
+		cfg.serviceNamespace = serviceNamespace
+	}
+}
+
+// WithServiceVersion overrides the service.version resource attribute when
+// Start creates a new TracerProvider. Defaults to the library telemetry version.
+// Ignored when an existing SDK TracerProvider is already installed.
+func WithServiceVersion(serviceVersion string) Option {
+	return func(cfg *config) {
+		cfg.serviceVersion = serviceVersion
+	}
+}
+
+// WithInstrumentName overrides the OpenTelemetry instrumentation scope name
+// used for the global tracer. Defaults to the library instrument name.
+func WithInstrumentName(instrumentName string) Option {
+	return func(cfg *config) {
+		cfg.instrumentName = instrumentName
+	}
+}
+
+// WithGenAISystem overrides the gen_ai.system attribute value stamped by the
+// library on agent/tool/chat spans. Defaults to "trpc.go.agent".
+func WithGenAISystem(system string) Option {
+	return func(cfg *config) {
+		cfg.genAISystem = system
+	}
+}
+
+// WithBaggageAttributeFilter replaces the default Langfuse baggage→attribute
+// filter. When set, WithExtraBaggageAttributeKeys is ignored.
+func WithBaggageAttributeFilter(filter BaggageAttributeFilter) Option {
+	return func(cfg *config) {
+		cfg.baggageFilter = filter
+	}
+}
+
+// WithExtraBaggageAttributeKeys adds baggage keys that should be copied onto
+// span attributes in addition to the default Langfuse allowlist.
+func WithExtraBaggageAttributeKeys(keys ...string) Option {
+	return func(cfg *config) {
+		cfg.extraBaggageKeys = append(cfg.extraBaggageKeys, keys...)
+	}
+}
+
+// WithAttributeRewriter registers a transform applied to span attributes
+// immediately before they are exported to Langfuse. Defaults to nil (no rewrite).
+func WithAttributeRewriter(rewriter AttributeRewriter) Option {
+	return func(cfg *config) {
+		cfg.attributeRewriter = rewriter
+	}
+}
+
 // config holds Langfuse configuration options.
 type config struct {
 	secretKey                    string
@@ -76,6 +156,14 @@ type config struct {
 	host                         string
 	insecure                     bool
 	maxObservationLeafValueBytes *int
+	serviceName                  string
+	serviceNamespace             string
+	serviceVersion               string
+	instrumentName               string
+	genAISystem                  string
+	baggageFilter                BaggageAttributeFilter
+	extraBaggageKeys             []string
+	attributeRewriter            AttributeRewriter
 }
 
 // newConfigFromEnv creates a Langfuse config from environment variables.

--- a/telemetry/langfuse/identity_options_test.go
+++ b/telemetry/langfuse/identity_options_test.go
@@ -1,0 +1,173 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package langfuse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
+	semconvtrace "trpc.group/trpc-go/trpc-agent-go/telemetry/semconv/trace"
+	atrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
+)
+
+func TestResolveBaggageFilter_ExtraKeys(t *testing.T) {
+	filter := resolveBaggageFilter(&config{extraBaggageKeys: []string{"guild.agent_name"}})
+
+	m, err := baggage.NewMemberRaw("guild.agent_name", "persona-a")
+	require.NoError(t, err)
+	assert.True(t, filter(m))
+
+	ignored, err := baggage.NewMemberRaw("baggage.test", "x")
+	require.NoError(t, err)
+	assert.False(t, filter(ignored))
+
+	traceNameMember, err := baggage.NewMemberRaw(traceName, "persona-a")
+	require.NoError(t, err)
+	assert.True(t, filter(traceNameMember))
+}
+
+func TestResolveBaggageFilter_CustomFilterOverridesExtras(t *testing.T) {
+	filter := resolveBaggageFilter(&config{
+		extraBaggageKeys: []string{"guild.agent_name"},
+		baggageFilter: func(m baggage.Member) bool {
+			return m.Key() == "custom.only"
+		},
+	})
+	custom, err := baggage.NewMemberRaw("custom.only", "1")
+	require.NoError(t, err)
+	assert.True(t, filter(custom))
+
+	extra, err := baggage.NewMemberRaw("guild.agent_name", "persona-a")
+	require.NoError(t, err)
+	assert.False(t, filter(extra))
+}
+
+func TestAttributeRewritingExporter_RewritesBeforeNext(t *testing.T) {
+	rec := &recordingExporter{}
+	exp := &attributeRewritingExporter{
+		next: rec,
+		rewrite: func(attrs []attribute.KeyValue) []attribute.KeyValue {
+			out := make([]attribute.KeyValue, 0, len(attrs))
+			for _, a := range attrs {
+				if a.Key == semconvtrace.KeyGenAISystem {
+					out = append(out, attribute.String(semconvtrace.KeyGenAISystem, "custom.system"))
+					continue
+				}
+				out = append(out, a)
+			}
+			return out
+		},
+	}
+
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	_, span := tp.Tracer("test").Start(context.Background(), "span")
+	span.SetAttributes(attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent))
+	span.End()
+
+	spans := rec.snapshot()
+	require.Len(t, spans, 1)
+	assert.Contains(t, spans[0].Attributes(), attribute.String(semconvtrace.KeyGenAISystem, "custom.system"))
+	assert.NotContains(t, spans[0].Attributes(), attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent))
+}
+
+func TestNewSpanProcessor_ExtraBaggageKeysCopied(t *testing.T) {
+	ctx := context.Background()
+	m, err := baggage.NewMemberRaw("guild.agent_name", "persona-a")
+	require.NoError(t, err)
+	b, err := baggage.New(m)
+	require.NoError(t, err)
+	ctx = baggage.ContextWithBaggage(ctx, b)
+
+	exp := &recordingExporter{}
+	filter := resolveBaggageFilter(&config{extraBaggageKeys: []string{"guild.agent_name"}})
+	sp := newSpanProcessor(exp, filter)
+
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sp))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	_, span := tp.Tracer("test").Start(ctx, "span")
+	span.End()
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans := exp.snapshot()
+	require.Len(t, spans, 1)
+	assert.Contains(t, spans[0].Attributes(), attribute.String("guild.agent_name", "persona-a"))
+}
+
+func TestStart_AppliesIdentityOptions(t *testing.T) {
+	ctx := context.Background()
+	oldProvider := atrace.TracerProvider
+	oldTracer := atrace.Tracer
+	defer func() {
+		atrace.TracerProvider = oldProvider
+		atrace.Tracer = oldTracer
+		itelemetry.SetGenAISystem("")
+	}()
+	atrace.TracerProvider = noop.NewTracerProvider()
+
+	cfg := &config{
+		serviceName:      "brand-service",
+		serviceNamespace: "brand-ns",
+		serviceVersion:   "9.9.9",
+		instrumentName:   "brand.scope",
+		genAISystem:      "brand.system",
+	}
+	clean, err := start(ctx, cfg,
+		otlptracehttp.WithEndpoint("localhost:4318"),
+		otlptracehttp.WithInsecure(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clean(ctx) })
+
+	assert.Equal(t, "brand.system", itelemetry.GenAISystem())
+
+	sdkTP, ok := atrace.TracerProvider.(*sdktrace.TracerProvider)
+	require.True(t, ok)
+
+	_, span := sdkTP.Tracer("probe").Start(ctx, "probe")
+	readWrite, ok := span.(sdktrace.ReadWriteSpan)
+	require.True(t, ok)
+	attrs := readWrite.Resource().Attributes()
+	assert.Contains(t, attrs, semconv.ServiceName("brand-service"))
+	assert.Contains(t, attrs, semconv.ServiceNamespace("brand-ns"))
+	assert.Contains(t, attrs, semconv.ServiceVersion("9.9.9"))
+	span.End()
+}
+
+func TestOptionHelpers_ApplyToConfig(t *testing.T) {
+	cfg := &config{}
+	WithServiceName("svc")(cfg)
+	WithServiceNamespace("ns")(cfg)
+	WithServiceVersion("1.2.3")(cfg)
+	WithInstrumentName("scope")(cfg)
+	WithGenAISystem("sys")(cfg)
+	WithExtraBaggageAttributeKeys("k1", "k2")(cfg)
+	WithAttributeRewriter(func(attrs []attribute.KeyValue) []attribute.KeyValue { return attrs })(cfg)
+
+	assert.Equal(t, "svc", cfg.serviceName)
+	assert.Equal(t, "ns", cfg.serviceNamespace)
+	assert.Equal(t, "1.2.3", cfg.serviceVersion)
+	assert.Equal(t, "scope", cfg.instrumentName)
+	assert.Equal(t, "sys", cfg.genAISystem)
+	assert.Equal(t, []string{"k1", "k2"}, cfg.extraBaggageKeys)
+	assert.NotNil(t, cfg.attributeRewriter)
+}

--- a/telemetry/langfuse/spanprocessor.go
+++ b/telemetry/langfuse/spanprocessor.go
@@ -18,9 +18,13 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-func newSpanProcessor(e sdktrace.SpanExporter) sdktrace.SpanProcessor {
+func newSpanProcessor(e sdktrace.SpanExporter, filter BaggageAttributeFilter) sdktrace.SpanProcessor {
+	if filter == nil {
+		filter = defaultLangfuseTraceAttributeFilter
+	}
 	return &baggageBatchSpanProcessor{
-		next: sdktrace.NewBatchSpanProcessor(e),
+		next:   sdktrace.NewBatchSpanProcessor(e),
+		filter: filter,
 	}
 }
 
@@ -29,14 +33,19 @@ func newSpanProcessor(e sdktrace.SpanExporter) sdktrace.SpanProcessor {
 //
 // This mirrors the behavior of go.opentelemetry.io/contrib/processors/baggagecopy.
 type baggageBatchSpanProcessor struct {
-	next sdktrace.SpanProcessor
+	next   sdktrace.SpanProcessor
+	filter BaggageAttributeFilter
 }
 
 var _ sdktrace.SpanProcessor = (*baggageBatchSpanProcessor)(nil)
 
 func (p *baggageBatchSpanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpan) {
+	filter := p.filter
+	if filter == nil {
+		filter = defaultLangfuseTraceAttributeFilter
+	}
 	for _, member := range baggage.FromContext(ctx).Members() {
-		if defaultLangfuseTraceAttributeFilter(member) {
+		if filter(member) {
 			span.SetAttributes(attribute.String(member.Key(), member.Value()))
 		}
 	}
@@ -52,6 +61,7 @@ func (p *baggageBatchSpanProcessor) OnStart(ctx context.Context, span sdktrace.R
 // Propagated attributes:
 // - userId: langfuse.user.id or user.id
 // - sessionId: langfuse.session.id or session.id
+// - trace name: langfuse.trace.name
 // - metadata: langfuse.trace.metadata.* (top-level metadata keys)
 // - version: langfuse.version
 // - release: langfuse.release
@@ -61,6 +71,7 @@ func defaultLangfuseTraceAttributeFilter(member baggage.Member) bool {
 	switch k {
 	case traceUserID, "user.id",
 		traceSessionID, "session.id",
+		traceName,
 		version, release,
 		traceTags:
 		return true

--- a/telemetry/langfuse/spanprocessor_test.go
+++ b/telemetry/langfuse/spanprocessor_test.go
@@ -51,7 +51,7 @@ func (e *recordingExporter) snapshot() []sdktrace.ReadOnlySpan {
 
 func TestNewSpanProcessor(t *testing.T) {
 	exp := &dummyExporter{}
-	sp := newSpanProcessor(exp)
+	sp := newSpanProcessor(exp, nil)
 	if sp == nil {
 		t.Fatalf("newSpanProcessor returned nil")
 	}
@@ -68,7 +68,7 @@ func TestNewSpanProcessor_CopiesBaggageToSpanAttributes(t *testing.T) {
 	ctx = baggage.ContextWithBaggage(ctx, b)
 
 	exp := &recordingExporter{}
-	sp := newSpanProcessor(exp)
+	sp := newSpanProcessor(exp, nil)
 
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()
@@ -96,7 +96,7 @@ func TestNewSpanProcessor_DefaultFilter_IgnoresNonLangfuseKeys(t *testing.T) {
 	ctx = baggage.ContextWithBaggage(ctx, b)
 
 	exp := &recordingExporter{}
-	sp := newSpanProcessor(exp)
+	sp := newSpanProcessor(exp, nil)
 
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sp))
 	defer func() { _ = tp.Shutdown(context.Background()) }()

--- a/telemetry/langfuse/start_internal_test.go
+++ b/telemetry/langfuse/start_internal_test.go
@@ -27,7 +27,7 @@ func TestStart_Internal_WithNoopProvider(t *testing.T) {
 
 	atrace.TracerProvider = noop.NewTracerProvider()
 
-	clean, err := start(ctx, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
+	clean, err := start(ctx, &config{}, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
 	if err != nil {
 		t.Fatalf("start() error = %v", err)
 	}
@@ -42,7 +42,7 @@ func TestStart_Internal_WithExistingSDKProvider(t *testing.T) {
 	// Use a real sdk tracer provider to hit the branch that registers processor
 	atrace.TracerProvider = sdktrace.NewTracerProvider()
 
-	clean, err := start(ctx, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
+	clean, err := start(ctx, &config{}, otlptracehttp.WithEndpoint("localhost:4318"), otlptracehttp.WithInsecure())
 	if err != nil {
 		t.Fatalf("start() error = %v", err)
 	}

--- a/telemetry/langfuse/tracer.go
+++ b/telemetry/langfuse/tracer.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
@@ -57,10 +58,14 @@ func Start(ctx context.Context, opts ...Option) (clean func(context.Context) err
 		otelOpts = append(otelOpts, otlptracehttp.WithInsecure())
 	}
 
-	return start(ctx, otelOpts...)
+	return start(ctx, config, otelOpts...)
 }
 
-func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(context.Context) error, err error) {
+func start(ctx context.Context, cfg *config, opts ...otlptracehttp.Option) (clean func(context.Context) error, err error) {
+	if cfg == nil {
+		cfg = &config{}
+	}
+
 	p := atrace.TracerProvider
 	_, ok := p.(noop.TracerProvider)
 	var provider *sdktrace.TracerProvider
@@ -76,13 +81,29 @@ func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(contex
 	if err != nil {
 		return nil, err
 	}
-	processor := newSpanProcessor(exp)
+	var spanExp sdktrace.SpanExporter = exp
+	if cfg.attributeRewriter != nil {
+		spanExp = &attributeRewritingExporter{next: exp, rewrite: cfg.attributeRewriter}
+	}
+	processor := newSpanProcessor(spanExp, resolveBaggageFilter(cfg))
 	if provider == nil {
+		serviceNamespace := semconvtrace.ResourceServiceNamespace
+		if cfg.serviceNamespace != "" {
+			serviceNamespace = cfg.serviceNamespace
+		}
+		serviceName := semconvtrace.ResourceServiceName
+		if cfg.serviceName != "" {
+			serviceName = cfg.serviceName
+		}
+		serviceVersion := semconvtrace.ResourceServiceVersion
+		if cfg.serviceVersion != "" {
+			serviceVersion = cfg.serviceVersion
+		}
 		res, err := resource.New(ctx,
 			resource.WithAttributes(
-				semconv.ServiceNamespace(semconvtrace.ResourceServiceNamespace),
-				semconv.ServiceName(semconvtrace.ResourceServiceName),
-				semconv.ServiceVersion(semconvtrace.ResourceServiceVersion),
+				semconv.ServiceNamespace(serviceNamespace),
+				semconv.ServiceName(serviceName),
+				semconv.ServiceVersion(serviceVersion),
 			),
 		)
 		if err != nil {
@@ -98,7 +119,14 @@ func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(contex
 		provider.RegisterSpanProcessor(processor)
 	}
 
-	atrace.Tracer = provider.Tracer(itelemetry.InstrumentName)
+	instrumentName := itelemetry.InstrumentName
+	if cfg.instrumentName != "" {
+		instrumentName = cfg.instrumentName
+	}
+	if cfg.genAISystem != "" {
+		itelemetry.SetGenAISystem(cfg.genAISystem)
+	}
+	atrace.Tracer = provider.Tracer(instrumentName)
 	return provider.Shutdown, nil
 }
 
@@ -106,4 +134,27 @@ func start(ctx context.Context, opts ...otlptracehttp.Option) (clean func(contex
 func encodeAuth(pk, sk string) string {
 	auth := pk + ":" + sk
 	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func resolveBaggageFilter(cfg *config) BaggageAttributeFilter {
+	if cfg != nil && cfg.baggageFilter != nil {
+		return cfg.baggageFilter
+	}
+	if cfg == nil || len(cfg.extraBaggageKeys) == 0 {
+		return defaultLangfuseTraceAttributeFilter
+	}
+	extras := make(map[string]struct{}, len(cfg.extraBaggageKeys))
+	for _, k := range cfg.extraBaggageKeys {
+		if k == "" {
+			continue
+		}
+		extras[k] = struct{}{}
+	}
+	return func(member baggage.Member) bool {
+		if defaultLangfuseTraceAttributeFilter(member) {
+			return true
+		}
+		_, ok := extras[member.Key()]
+		return ok
+	}
 }


### PR DESCRIPTION
## Summary
Adds opt-in options on `langfuse.Start` so integrators can brand or scrub exported identity without changing library defaults:

- `WithServiceName` / `WithServiceNamespace` / `WithServiceVersion`
- `WithInstrumentName` (tracer scope)
- `WithGenAISystem` (overrides `gen_ai.system` stamped by Trace* helpers; default remains `trpc.go.agent`)
- `WithBaggageAttributeFilter` / `WithExtraBaggageAttributeKeys`
- `WithAttributeRewriter` (export-time attribute rewrite; default is no-op)

Also allows `langfuse.trace.name` in the default baggage attribute filter (aligned with Langfuse OTEL docs).

## Compatibility
Zero options ⇒ behavior identical to today (`trpc-go-agent` / `telemetry` / `trpc.agent.go` / `trpc.go.agent`).

## Test plan
- [x] Existing langfuse + internal/telemetry tests pass
- [x] New option / baggage / rewriter tests in `telemetry/langfuse/identity_options_test.go`