### PR TITLE
trpc-agent-go: strengthen contribution and API review guidance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,9 @@
 language: "en-US"
 tone_instructions: >-
   Concise professional reviews. Bilingual output: EN first, ZH collapsed.
-  Framework repo: prioritize semantic/behavioral compat, stable
-  defaults/contracts, extensibility, generality, usability, and CI-hard
-  design/behavior issues; avoid style debates.
+  This is a framework repository. Prioritize public API design, semantic and
+  behavioral compatibility, stable defaults and contracts, extensibility,
+  generality, usability, and correctness. Avoid subjective local style debates.
 early_access: false
 
 reviews:
@@ -22,6 +22,7 @@ reviews:
   sequence_diagrams: false
   estimate_code_review_effort: true
   in_progress_fortune: false
+
   path_filters:
     - "!**/*.png"
     - "!**/*.jpg"
@@ -44,101 +45,243 @@ reviews:
     - "!**/*.wasm"
 
   high_level_summary_instructions: |-
-    Please output a bilingual high-level summary.
+    Output a bilingual high-level summary.
     Show the English summary first.
-    Wrap the Chinese translation in a Markdown-compatible HTML details block collapsed by default.
-    Both versions must cover: change overview, compatibility and behavioral risks, and recommended validation steps.
-    Be specific and actionable. Avoid generic praise and irrelevant style commentary.
-    The Chinese section must use this exact wrapper:
+    Wrap the Chinese translation in a Markdown-compatible HTML details block
+    collapsed by default.
+
+    Both versions must cover:
+    - the change overview;
+    - public API and compatibility implications;
+    - behavioral and operational risks; and
+    - recommended validation.
+
+    When the pull request adds or changes exported Go APIs, include a public API
+    surface summary that lists the affected symbols and calls out questions
+    about export necessity, package ownership, API overlap, naming semantics,
+    extensibility, documentation, and compatibility.
+
+    Be specific and actionable. Avoid generic praise and subjective style
+    commentary.
+
+    Use this exact wrapper for the Chinese section:
     <details>
     <summary>中文</summary>
-    
+
     Chinese summary here.
-    
+
     </details>
 
   path_instructions:
     - path: "**/*.go"
       instructions: |
-        Write all review output bilingually: English first, then Chinese in collapsed <details><summary>中文</summary>...</details>.
-        This is framework code. Review priorities:
-        1. Semantic and behavioral compatibility
-        2. Extensibility
-        3. Generality
+        Write review output bilingually: English first, followed by Chinese in
+        a collapsed <details><summary>中文</summary>...</details> block.
+
+        This is framework code. Review priorities are:
+        1. Public API and framework design
+        2. Semantic and behavioral compatibility
+        3. Extensibility and generality
         4. Ease of use
         5. Concurrency safety, resource boundaries, and error handling
         6. Code style
 
-        Focus on:
-        - Whether default behavior remains stable and new capability is introduced through optional config, options, interfaces, callbacks, or plugins rather than by changing existing paths.
-        - Whether exported types, exported functions, exported methods, interfaces, options, error semantics, nil or zero-value semantics, JSON or serialization fields, event ordering, or streaming semantics introduce breaking changes.
-        - Adding struct fields is usually compatible. Do not raise blocking comments for that alone, but do check serialization compatibility, zero-value semantics, and default behavior.
-        - When agent, runner, graph, tool, or similar execution paths change, whether event flow, stateDelta, tool invocation order, cancellation propagation, retry semantics, or long-running tool markers change in externally observable ways.
-        - Whether abstractions remain capability-oriented rather than vendor-oriented, and avoid leaking provider-specific, model-specific, or business-specific assumptions into public layers.
-        - Whether the change introduces global mutable state, implicit singletons, unbounded queues, infinite retries, goroutine leaks, incorrect channel-closing order, or background tasks that cannot stop promptly.
-        - Whether persistence- or protocol-related structures such as session, memory, artifact, knowledge, and vectorstore remain backward compatible and have migration and rollback paths.
-        - Whether errors preserve root causes and remain distinguishable to callers. Control-flow errors should not be retried as ordinary failures.
-        - Whether security boundaries stay clear: treat external input, URLs, paths, command arguments, and model-driven tool invocations as untrusted.
-        - Whether new APIs or configuration keep the minimum required setup, sensible defaults, and consistent naming and parameter ordering.
+        Public API review:
+
+        Whenever the diff adds or changes exported types, functions, methods,
+        interfaces, fields, constants, variables, options, callbacks, or
+        sentinel errors, perform a separate review of the complete public API
+        surface.
+
+        Inventory the affected exported symbols before reviewing individual
+        implementation details. Review the surface as one coherent design,
+        including relationships and overlap between the new and existing APIs.
+
+        For each added or changed export, verify:
+        - whether external consumers need the symbol or it can remain
+          unexported;
+        - whether an existing API, option, interface, callback, or extension
+          point already supports the use case;
+        - whether the concept belongs to the declaring package and abstraction
+          layer;
+        - whether it duplicates or partially overlaps an existing public entry
+          point;
+        - whether its name represents a stable user-facing concept rather than
+          an incidental implementation, provider, vendor, or deployment detail;
+        - whether the design can evolve without parallel APIs, duplicate types,
+          or incompatible renames;
+        - whether defaults, zero values, nil inputs, errors, ownership,
+          mutation, concurrency, cancellation, cleanup, and lifecycle behavior
+          are defined where relevant;
+        - whether source, behavioral, serialization, persistence, protocol, and
+          extension compatibility are preserved;
+        - whether meaningful Godoc explains the contract, defaults,
+          constraints, and errors; and
+        - whether tests protect the public contract and externally observable
+          behavior.
+
+        Do not assume an additive export is appropriate merely because it is
+        source compatible. An unnecessary or overlapping export is still a
+        long-term framework commitment.
+
+        Provider and abstraction boundaries:
+
+        - Keep provider-, vendor-, model-, protocol-, business-, and
+          deployment-specific concepts in their owning packages.
+        - Do not move provider-specific fields or options into shared framework
+          types unless multiple implementations share the same semantics.
+        - Prefer capability-oriented shared abstractions over
+          provider-oriented abstractions.
+        - Check whether changes to shared interfaces affect all existing
+          implementations, including implementations outside the pull request.
+        - Check whether a concrete provider package can expose a necessary
+          specialized capability without expanding a shared package.
+
+        Public API naming versus local naming:
+
+        - Treat exported naming as a framework design concern when it affects
+          semantic accuracy, discoverability, package fit, abstraction
+          boundaries, provider leakage, or future evolution.
+        - Do not dismiss a public naming concern as style merely because the
+          code compiles or the name is internally consistent.
+        - Treat unexported helpers, local variables, and test names as
+          implementation details.
+        - Do not raise an unexported naming or refactoring suggestion based only
+          on personal preference.
+        - Raise a local naming issue only when the name is misleading,
+          conflicts with an established convention, or is likely to cause
+          incorrect behavior.
+
+        Compatibility and behavior:
+
+        - Verify that existing default behavior remains stable and that new
+          behavior is explicit and opt-in when practical.
+        - Check exported APIs, interfaces, options, errors, nil behavior,
+          zero-value behavior, JSON fields, event ordering, streaming,
+          cancellation, retry semantics, and lifecycle behavior.
+        - Adding a struct field is usually source compatible, but still review
+          serialization, zero-value, default, equality, comparability, and
+          external implementation implications.
+        - When agent, runner, graph, tool, or related execution paths change,
+          review event flow, stateDelta, tool invocation order, cancellation,
+          retries, long-running tool markers, and termination behavior.
+        - For persistence and protocol changes, review migration, rollback, and
+          mixed-version behavior.
+        - Verify that errors preserve root causes and remain distinguishable to
+          callers. Do not retry control-flow errors as ordinary failures.
+
+        Concurrency, resources, and security:
+
+        - Check for global mutable state, implicit singletons, unbounded queues,
+          infinite retries, goroutine leaks, incorrect channel-closing order,
+          and background work that cannot stop promptly.
+        - Verify cancellation propagation, cleanup, backpressure, ownership,
+          and resource limits.
+        - Treat external input, URLs, paths, command arguments, serialized data,
+          and model-driven tool invocations as untrusted.
+
+        Comments and documentation:
+
+        - Require newly added source comments and Godoc to be written in
+          English, except for intentionally localized test data.
+        - Check that comments explain contracts, constraints, invariants, or
+          non-obvious reasoning rather than merely restating the code.
+        - Check that every added exported symbol has meaningful Godoc.
 
         Avoid:
-        - Suggestions about naming, formatting, comment style, or "more elegant refactors" based only on personal preference.
-        - Suggestions that break public contracts or default behavior merely for implementation convenience.
+        - suggestions about unexported naming, formatting, comment style, or
+          more elegant refactors based only on personal preference;
+        - treating a shallow private helper or local implementation choice as a
+          public API design problem;
+        - recommending a new abstraction without a demonstrated responsibility
+          or external use case; and
+        - suggestions that break existing contracts or defaults merely for
+          implementation convenience.
 
-        If you believe a change is an intentional behavioral change, explicitly state:
-        - what the old behavior was;
-        - what the new behavior is;
-        - which users or extension points are affected;
-        - which tests, examples, or documentation should be updated accordingly.
+        For an intentional behavioral change, explicitly state:
+        - the old behavior;
+        - the new behavior;
+        - the affected users and extension points; and
+        - the tests, examples, documentation, migration notes, and release
+          notes that should be updated.
 
     - path: "**/*_test.go"
       instructions: |
-        Write all review output bilingually: English first, then Chinese in collapsed <details><summary>中文</summary>...</details>.
-        Prioritize whether tests validate external behavior rather than implementation details.
+        Write review output bilingually: English first, followed by Chinese in
+        a collapsed <details><summary>中文</summary>...</details> block.
 
-        Focus on:
-        - Whether the main path, boundary conditions, error paths, and regression scenarios are covered.
-        - Whether concurrency-related changes cover cancellation, shutdown, error propagation, goroutine cleanup, channel ordering, and backpressure.
-        - Whether streaming output, event flow, stateDelta, and tool invocation chains verify order, consistency, and termination semantics.
-        - Whether tests are stable and avoid time.Sleep, randomness, real external services, or machine-specific environment differences.
-        - Whether mocks, fakes, httptest, temporary directories, or other controllable substitutes are preferred.
-        - Whether assertions are strong enough to ensure the intended behavior is actually verified.
+        Prioritize whether tests protect externally observable behavior rather
+        than implementation details.
 
-        Do not suggest weakening assertions, deleting tests, or widening mocks merely to hide real problems.
+        Check:
+        - main paths, boundary conditions, error paths, and regressions;
+        - cancellation, shutdown, error propagation, goroutine cleanup, channel
+          ordering, and backpressure for concurrent behavior;
+        - ordering, consistency, and termination for streaming, events,
+          stateDelta, and tool invocation chains;
+        - deterministic behavior without unnecessary sleeps, randomness, real
+          external services, or machine-specific assumptions;
+        - appropriate use of mocks, fakes, httptest, and temporary directories;
+          and
+        - assertions strong enough to fail when the intended contract breaks.
+
+        Flag tests that only execute code, assert language properties, or
+        duplicate implementation details without protecting a project
+        contract.
+
+        Do not suggest weakening assertions, deleting meaningful tests, or
+        widening mocks to hide a real failure.
 
     - path: "test/**"
       instructions: |
-        Write all review output bilingually: English first, then Chinese in collapsed <details><summary>中文</summary>...</details>.
-        Treat code under test/ as test infrastructure rather than ordinary business code.
+        Write review output bilingually: English first, followed by Chinese in
+        a collapsed <details><summary>中文</summary>...</details> block.
 
-        Focus on:
-        - Whether test helper code is small, clear, single-purpose, and reusable.
-        - Whether it avoids relying on real external services and unstable environments.
-        - Whether it avoids hiding real behavior by pushing too much logic into fixtures.
-        - Whether logs, test data, and example configuration leak sensitive information.
+        Treat code under test/ as test infrastructure rather than ordinary
+        framework code.
+
+        Check whether test helpers:
+        - are focused, clear, and reusable;
+        - avoid unstable external dependencies and machine-specific behavior;
+        - preserve the real behavior being tested rather than hiding it behind
+          fixtures; and
+        - prevent credentials or sensitive information from leaking through
+          logs, fixtures, artifacts, or configuration.
 
     - path: "examples/**"
       instructions: |
-        Write all review output bilingually: English first, then Chinese in collapsed <details><summary>中文</summary>...</details>.
-        Examples represent the recommended usage and the user's first impression. Review them for reproducibility, clarity, and safe execution.
+        Write review output bilingually: English first, followed by Chinese in
+        a collapsed <details><summary>中文</summary>...</details> block.
 
-        Focus on:
-        - Whether they use public APIs and reflect the current recommended usage.
-        - Whether runtime steps, dependencies, environment variables, and side effects are clear.
-        - Whether sensitive information is passed through environment variables and whether example output avoids leaking tokens, secrets, or private data.
-        - Whether each example is small enough and focused on one capability instead of becoming a hidden "mini production system."
-        - Whether examples are updated when public APIs, defaults, or recommended usage change.
+        Examples represent recommended usage and a user's first impression.
+
+        Check whether examples:
+        - use current public APIs and recommended patterns;
+        - document runtime steps, dependencies, environment variables, and side
+          effects;
+        - keep credentials in environment variables and avoid exposing secrets;
+        - remain focused on one capability rather than becoming hidden
+          production systems; and
+        - are updated alongside public APIs, defaults, and recommended usage.
 
     - path: "**/*.md"
       instructions: |
-        Write all review output bilingually: English first, then Chinese in collapsed <details><summary>中文</summary>...</details>.
-        The goal of documentation is to accurately communicate the current public contract, not to optimize for writing style.
+        Write review output bilingually: English first, followed by Chinese in
+        a collapsed <details><summary>中文</summary>...</details> block.
 
-        Focus on:
-        - Whether commands, import paths, configuration keys, defaults, and return behavior match the current code.
-        - Whether README.md and README.zh_CN.md describe external usage consistently, or clearly explain any intentional differences.
-        - Whether documentation is updated when public APIs, default behavior, migration paths, or compatibility strategy change.
-        - Whether example code, configuration snippets, and directory paths are actually usable in the current repository layout.
+        Documentation must accurately describe the current public contract.
+
+        Check:
+        - commands, import paths, configuration keys, defaults, errors, and
+          return behavior against the implementation;
+        - consistency between English and translated documentation;
+        - documentation of public APIs, default behavior, migration paths, and
+          compatibility decisions; and
+        - whether examples, snippets, configuration, and repository paths are
+          usable.
+
+        Do not optimize for prose style at the expense of technical accuracy.
+
   tools:
     github-checks:
       enabled: true
@@ -152,6 +295,7 @@ reviews:
       enabled: true
     gitleaks:
       enabled: true
+
   auto_review:
     enabled: true
     drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,10 +2,9 @@
 
 language: "en-US"
 tone_instructions: >-
-  Concise professional reviews. Bilingual output: EN first, ZH collapsed.
-  This is a framework repository. Prioritize public API design, semantic and
-  behavioral compatibility, stable defaults and contracts, extensibility,
-  generality, usability, and correctness. Avoid subjective local style debates.
+  Concise professional reviews; English first, Chinese collapsed. Prioritize
+  public API design, compatibility, stable defaults, extensibility, correctness,
+  and usability. Avoid subjective local style debates.
 early_access: false
 
 reviews:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,7 +106,7 @@ reviews:
         - whether it duplicates or partially overlaps an existing public entry
           point;
         - whether its name represents a stable user-facing concept rather than
-          an incidental implementation, provider, vendor, or deployment detail;
+          an incidental implementation detail;
         - whether the design can evolve without parallel APIs, duplicate types,
           or incompatible renames;
         - whether defaults, zero values, nil inputs, errors, ownership,
@@ -123,24 +123,23 @@ reviews:
         source compatible. An unnecessary or overlapping export is still a
         long-term framework commitment.
 
-        Provider and abstraction boundaries:
+        Package and abstraction boundaries:
 
-        - Keep provider-, vendor-, model-, protocol-, business-, and
-          deployment-specific concepts in their owning packages.
-        - Do not move provider-specific fields or options into shared framework
-          types unless multiple implementations share the same semantics.
-        - Prefer capability-oriented shared abstractions over
-          provider-oriented abstractions.
+        - Keep implementation-specific concepts in their owning packages.
+        - Move a concept into a shared package only when its semantics are
+          genuinely shared across implementations.
+        - Prefer capability-oriented abstractions over abstractions organized
+          around a particular implementation.
         - Check whether changes to shared interfaces affect all existing
           implementations, including implementations outside the pull request.
-        - Check whether a concrete provider package can expose a necessary
-          specialized capability without expanding a shared package.
+        - Check whether an owning package can expose a necessary specialized
+          capability without expanding a shared package.
 
         Public API naming versus local naming:
 
         - Treat exported naming as a framework design concern when it affects
           semantic accuracy, discoverability, package fit, abstraction
-          boundaries, provider leakage, or future evolution.
+          boundaries, implementation leakage, or future evolution.
         - Do not dismiss a public naming concern as style merely because the
           code compiles or the name is internally consistent.
         - Treat unexported helpers, local variables, and test names as
@@ -150,6 +149,27 @@ reviews:
         - Raise a local naming issue only when the name is misleading,
           conflicts with an established convention, or is likely to cause
           incorrect behavior.
+
+        Idiomatic Go design:
+
+        - Check that package names are short, lowercase, and single words, and
+          that exported names read naturally when package-qualified without
+          stutter.
+        - Check MixedCaps and established initialism spelling.
+        - Prefer small, consumer-oriented interfaces. Question interfaces that
+          have no demonstrated abstraction or exist only for mocking.
+        - Prefer concrete constructor return types, useful zero values where
+          practical, and constructors that establish clear invariants.
+        - Require context.Context to be the first parameter when needed. Check
+          cancellation propagation and avoid stored contexts unless the type
+          explicitly owns that lifetime.
+        - Keep error strings lowercase and without trailing punctuation. Check
+          `%w` wrapping and expose sentinel or typed errors only when callers
+          need a stable inspection contract.
+        - Check that goroutine, channel, resource, cancellation, and shutdown
+          ownership is explicit and bounded.
+        - Require exported declaration comments to begin with the declared name
+          and describe the caller-visible contract.
 
         Compatibility and behavior:
 
@@ -201,8 +221,8 @@ reviews:
         - the old behavior;
         - the new behavior;
         - the affected users and extension points; and
-        - the tests, examples, documentation, migration notes, and release
-          notes that should be updated.
+        - the tests, examples, documentation, and migration guidance that
+          should be updated.
 
     - path: "**/*_test.go"
       instructions: |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,49 @@
+<!-- markdownlint-disable MD041 -->
+
+<!--
+Write the pull request title and description in English.
+
+The title must identify the primary affected package or repository area.
+
+Preferred form:
+  package: lowercase summary
+
+For multiple equally affected packages:
+  {package/a, package/b}: lowercase summary
+-->
+
 ## What changed
 
-Describe the user-visible behavior, API, documentation, or example changes in
-this pull request.
+Describe the externally observable behavior, API, documentation, or example
+changes. Do not only list changed files.
 
 ## Why
 
-Explain the problem this solves and any compatibility considerations.
+Explain the problem, design motivation, and why this approach was selected.
+
+## Public API and compatibility
+
+List every added, removed, renamed, or changed public API or externally
+observable contract.
+
+For each change, explain its necessity, package ownership, relationship to
+existing APIs, default behavior, and compatibility implications.
+
+Write `None` if this pull request does not change public APIs or externally
+observable contracts.
 
 ## Testing
 
-List the commands or manual checks you ran. If a check is not applicable, say
-why.
+List the automated and manual validation that was actually performed. If a
+check is not applicable, explain why.
+
+## Release notes
+
+Describe the user-visible effect of this change. Write `NONE` if there is no
+user-visible effect.
 
 ## Notes for reviewers
 
-Call out areas that deserve extra attention, such as concurrency, persistence,
-protocol compatibility, or public API changes.
+Call out areas that deserve focused review, such as public API design,
+concurrency, persistence, event ordering, streaming, cancellation, protocol
+compatibility, security boundaries, or provider-specific behavior.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,36 +14,20 @@ For multiple equally affected packages:
 
 ## What changed
 
-Describe the externally observable behavior, API, documentation, or example
-changes. Do not only list changed files.
+Summarize the outcome and its user or developer impact. Do not restate the
+implementation or enumerate changed files.
 
 ## Why
 
-Explain the problem, design motivation, and why this approach was selected.
-
-## Public API and compatibility
-
-List every added, removed, renamed, or changed public API or externally
-observable contract.
-
-For each change, explain its necessity, package ownership, relationship to
-existing APIs, default behavior, and compatibility implications.
-
-Write `None` if this pull request does not change public APIs or externally
-observable contracts.
+Explain the problem and any non-obvious design rationale.
 
 ## Testing
 
 List the automated and manual validation that was actually performed. If a
 check is not applicable, explain why.
 
-## Release notes
-
-Describe the user-visible effect of this change. Write `NONE` if there is no
-user-visible effect.
-
 ## Notes for reviewers
 
-Call out areas that deserve focused review, such as public API design,
-concurrency, persistence, event ordering, streaming, cancellation, protocol
-compatibility, security boundaries, or provider-specific behavior.
+Optionally call out risks or design decisions that are not obvious from the
+diff, such as public API, compatibility, concurrency, persistence, protocol, or
+security concerns.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@ Preferred form:
 
 For multiple equally affected packages:
   {package/a, package/b}: lowercase summary
+
+For a coherent cross-cutting change spanning many packages with no primary
+package:
+  lsc: lowercase summary
 -->
 
 ## What changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,38 @@ new abstractions before their responsibility and ownership are clear.
 New behavior should preserve existing defaults and should be opt-in when
 practical.
 
-Framework abstractions should be capability-oriented. Keep provider-, vendor-,
-model-, protocol-, business-, and deployment-specific concepts in their owning
-packages unless there is a demonstrated provider-independent abstraction.
+Framework abstractions should be capability-oriented. Keep
+implementation-specific concepts in their owning packages unless their
+semantics are genuinely shared across implementations.
 
 Update documentation and examples whenever public behavior, defaults,
 configuration, or recommended usage changes.
+
+## Go design conventions
+
+Follow Effective Go and the Go Code Review Comments, while preserving
+established APIs when compatibility requires it.
+
+- Use `gofmt` and `goimports`.
+- Use short, lowercase, single-word package names, and make exported names read
+  naturally with their package qualifier without stutter.
+- Use MixedCaps and spell common initialisms consistently.
+- Prefer small, consumer-oriented interfaces and concrete constructor return
+  types. Do not add an interface for a hypothetical abstraction.
+- Make zero values useful when practical; use constructors to establish
+  invariants when necessary.
+- Pass `context.Context` first when needed, propagate cancellation, and avoid
+  storing contexts in structs unless the type owns that lifetime.
+- Keep error strings lowercase and without trailing punctuation. Preserve
+  causes with `%w` when callers need them; expose inspectable errors only for a
+  stable caller contract.
+- Make goroutine, channel, resource, cancellation, and shutdown ownership
+  explicit.
+- Write Godoc for exported declarations as complete sentences beginning with
+  the declared name and describing the caller-visible contract.
+
+Do not refactor established public APIs or raise local style comments merely to
+apply an idiom when the existing code is clear and compatible.
 
 ## Implementation workflow
 
@@ -124,10 +150,6 @@ For every added or changed public symbol, verify:
    Tests exercise the public contract and externally observable behavior rather
    than only implementation details.
 
-10. **Disclosure**
-    The pull request description lists the public API changes, their necessity,
-    and their compatibility implications.
-
 If an export cannot be justified, keep it private.
 
 If two public entry points perform substantially the same operation, consolidate
@@ -137,7 +159,7 @@ them or establish and document clearly distinct contracts.
 
 Public API naming is a framework design concern. Review exported names for
 semantic accuracy, discoverability, package fit, abstraction boundaries,
-provider leakage, and future evolution.
+implementation leakage, and future evolution.
 
 Unexported helpers, local variables, and test names are implementation details.
 Do not block a change based only on a personal naming or refactoring preference.
@@ -154,8 +176,8 @@ behavior are exempt from the English requirement.
 Comments should explain contracts, constraints, invariants, non-obvious
 behavior, or design reasoning. Avoid comments that merely restate the code.
 
-When preparing a pull request, follow the title, description, language, public
-API, label, and release-note requirements in `CONTRIBUTING.md`.
+When preparing a pull request, follow the title, description, language, and
+label requirements in `CONTRIBUTING.md`.
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,189 @@
 # AGENTS.md
 
-## Cursor Cloud specific instructions
+## Project overview
 
-### Project overview
+tRPC-Agent-Go is a Go multi-module framework for building AI agent systems. It
+is not a standalone application and does not have a single root `main.go`.
 
-tRPC-Agent-Go is a Go multi-module monorepo (library/framework) for building AI agent systems. It is **not** a standalone application — there is no single `main.go` to run. The root module path is `trpc.group/trpc-go/trpc-agent-go`.
+The root module path is:
 
-### Go version
+```text
+trpc.group/trpc-go/trpc-agent-go
+```
 
-The root `go.mod` requires Go 1.21. The environment has Go 1.22+ pre-installed, which is compatible. Some sub-modules (e.g. under `test/`) require Go 1.24+; `go mod download` handles this automatically via toolchain directives.
+The root module requires Go 1.21. Some independent modules, including modules
+under `test/`, require newer Go toolchains.
 
-### Common commands
+## Engineering principles
 
-| Task | Command | Notes |
-|------|---------|-------|
-| Build | `go build ./...` | Root module only |
-| Unit tests | `go test ./...` | Root module; all tests use mocks, no API keys needed |
-| E2E tests | `cd test && go test ./...` | Separate module in `test/` |
-| Lint | `golangci-lint run --timeout=10m` | Config in `.golangci.yml` |
-| gofmt check | `gofmt -r 'interface{} -> any' -l .` | CI enforces `any` over `interface{}` |
-| goimports check | `goimports -l .` | |
-| All sub-module tests (CI-style) | `bash .github/scripts/run-go-tests.sh` | Runs tests across ~80 modules excluding examples/docs/test |
-| Check example builds | `bash .github/scripts/check-examples.sh` | |
+Preserve syntax, semantic, behavioral, serialization, persistence, and protocol
+compatibility unless the task explicitly requires a documented change.
 
-### Non-obvious caveats
+Prefer minimal, focused changes. Avoid unrelated refactoring and avoid creating
+new abstractions before their responsibility and ownership are clear.
 
-- **GOPATH/bin must be on PATH** for `golangci-lint` and `goimports` to work. The update script handles installation, and `~/.bashrc` exports the path. If a tool is missing, run: `export PATH="$PATH:$(go env GOPATH)/bin"`.
-- **No external API keys needed for tests.** The entire test suite uses mocks. API keys (e.g. `OPENAI_API_KEY`) are only needed to run the examples under `examples/`.
-- **Multi-module monorepo:** There are ~80 `go.mod` files. Running `go test ./...` from the repo root only tests the root module. To test all modules, use the CI script `.github/scripts/run-go-tests.sh`.
-- **SQLite CGO dependency:** The root module depends on `github.com/mattn/go-sqlite3`, which requires CGO. Ensure `CGO_ENABLED=1` (the default) and a C compiler is available.
-- **License headers required on all `.go` files.** CI checks that every Go file has the Tencent Apache 2.0 header. See `CONTRIBUTING.md` for the template.
+New behavior should preserve existing defaults and should be opt-in when
+practical.
+
+Framework abstractions should be capability-oriented. Keep provider-, vendor-,
+model-, protocol-, business-, and deployment-specific concepts in their owning
+packages unless there is a demonstrated provider-independent abstraction.
+
+Update documentation and examples whenever public behavior, defaults,
+configuration, or recommended usage changes.
+
+## Implementation workflow
+
+### Understand the existing design
+
+Before implementation:
+
+- inspect the owning package and adjacent abstraction layers;
+- search for existing types, methods, interfaces, options, callbacks, and
+  extension points related to the requested capability;
+- inspect relevant tests, documentation, examples, and recent design decisions;
+- identify compatibility constraints and external implementations; and
+- determine the smallest surface required by external consumers.
+
+Do not add a parallel API until the distinction from existing APIs is clear.
+
+### Implement conservatively
+
+Keep implementation details unexported unless external consumers require them.
+
+Prefer extending a coherent existing contract over adding overlapping types or
+entry points.
+
+Do not change default, zero-value, nil, error, ordering, cancellation, retry,
+persistence, or lifecycle behavior accidentally.
+
+Tests must cover the intended public behavior, meaningful boundary conditions,
+and regression cases. Avoid tests that only execute code or assert language
+properties without protecting a project contract.
+
+## Public API and framework design
+
+Treat exported APIs and externally observable behavior as long-lived
+compatibility commitments.
+
+Public surface includes:
+
+- exported types, functions, methods, interfaces, fields, constants, and
+  variables;
+- options, callbacks, plugin contracts, and sentinel errors;
+- default, zero-value, nil, error, ownership, concurrency, and lifecycle
+  behavior;
+- JSON and other serialization fields;
+- persistence schemas and migration behavior;
+- protocol and wire contracts; and
+- event ordering, streaming, cancellation, retry, and tool invocation behavior.
+
+### Mandatory second-pass design review
+
+After implementation and before final validation, perform a separate review of
+the complete diff for public API and framework design.
+
+This second pass is mandatory whenever the change adds or modifies public
+surface or externally observable behavior.
+
+For every added or changed public symbol, verify:
+
+1. **Export necessity**
+   The symbol is required by external consumers and cannot reasonably remain
+   unexported.
+
+2. **Package ownership**
+   The concept belongs to the declaring package and abstraction layer.
+
+3. **API overlap**
+   The symbol does not duplicate or partially overlap an existing type, method,
+   option, or extension point without a distinct user-facing contract.
+
+4. **Naming semantics**
+   The name represents a stable user-facing concept rather than an incidental
+   implementation or deployment detail.
+
+5. **Extensibility**
+   The design can support foreseeable variants without parallel APIs,
+   duplicated types, or incompatible renames.
+
+6. **Compatibility**
+   Existing source, behavior, defaults, serialization, persistence, protocols,
+   and external implementations remain compatible unless an intentional change
+   is explicitly documented.
+
+7. **Contract completeness**
+   Zero values, nil inputs, errors, ownership, mutation, concurrency,
+   cancellation, cleanup, and lifecycle behavior are defined where relevant.
+
+8. **Documentation**
+   Every exported symbol has meaningful Godoc describing its contract,
+   constraints, defaults, and errors where relevant.
+
+9. **Validation**
+   Tests exercise the public contract and externally observable behavior rather
+   than only implementation details.
+
+10. **Disclosure**
+    The pull request description lists the public API changes, their necessity,
+    and their compatibility implications.
+
+If an export cannot be justified, keep it private.
+
+If two public entry points perform substantially the same operation, consolidate
+them or establish and document clearly distinct contracts.
+
+### Public API naming and local naming
+
+Public API naming is a framework design concern. Review exported names for
+semantic accuracy, discoverability, package fit, abstraction boundaries,
+provider leakage, and future evolution.
+
+Unexported helpers, local variables, and test names are implementation details.
+Do not block a change based only on a personal naming or refactoring preference.
+Raise a local naming issue only when the name is misleading, conflicts with an
+established convention, or is likely to cause incorrect behavior.
+
+## Language and documentation
+
+Write source-code comments and Godoc in English.
+
+Translated documentation and test data that intentionally verifies localized
+behavior are exempt from the English requirement.
+
+Comments should explain contracts, constraints, invariants, non-obvious
+behavior, or design reasoning. Avoid comments that merely restate the code.
+
+When preparing a pull request, follow the title, description, language, public
+API, label, and release-note requirements in `CONTRIBUTING.md`.
+
+## Validation
+
+Use validation proportional to the affected modules and risk.
+
+- Build the root module with `go build ./...`.
+- Test the root module with `go test ./...`.
+- Test the separate E2E module with `cd test && go test ./...`.
+- Test all library modules with `.github/scripts/run-go-tests.sh`.
+- Check example modules with `.github/scripts/check-examples.sh`.
+- Run lint with `golangci-lint run --timeout=10m`.
+- Check formatting and `any` usage with
+  `gofmt -r 'interface{} -> any' -l .`.
+- Check imports with `goimports -l .`.
+
+Run targeted tests while iterating and broader validation before delivery.
+
+## Repository-specific caveats
+
+- The repository contains many independent Go modules. Running `go test ./...`
+  from the repository root does not test every module.
+- Tests use mocks and should not require external API credentials. Credentials
+  are only needed for examples that call external services.
+- The root module depends on `github.com/mattn/go-sqlite3`, which requires CGO
+  and a C compiler.
+- `golangci-lint` and `goimports` may require the Go binary directory to be on
+  `PATH`.
+- Some modules use toolchain directives and may download a newer compatible Go
+  toolchain automatically.
+- Every new Go file must include the Tencent Apache 2.0 license header from
+  `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,154 +1,286 @@
 # How to Contribute
 
-Thank you for your interest and support in tRPC-Agent-Go!
+Thank you for your interest in contributing to tRPC-Agent-Go.
 
-We welcome and appreciate any form of contribution, including but not limited to submitting issues, providing improvement suggestions, improving documentation, fixing bugs, and adding features.
-This document aims to provide you with a detailed contribution guide to help you better participate in the project.
-Please read this guide carefully before contributing and make sure to follow the rules here.
-We look forward to working with you to make this project better together!
+We welcome bug fixes, features, tests, documentation, examples, design
+improvements, and other contributions. Please read this guide before submitting
+a change so that proposals, implementations, and reviews can proceed
+consistently.
 
 ## Before contributing code
 
-The project welcomes code patches, but to make sure things are well coordinated you should discuss any significant change before starting the work.
-It's recommended that you signal your intention to contribute in the issue tracker, either by claiming an [existing one](https://github.com/trpc-group/trpc-agent-go/issues) or by [opening a new issue](https://github.com/trpc-group/trpc-agent-go/issues/new).
+### Start with the issue tracker
 
-### Checking the issue tracker
+Except for trivial changes, contributions should be associated with an existing
+issue or a newly opened issue.
 
-Whether you already know what contribution to make, or you are searching for an idea, the [issue tracker](https://github.com/trpc-group/trpc-agent-go/issues) is always the first place to go.
-Issues are triaged to categorize them and manage the workflow.
+Starting with an issue allows maintainers and contributors to agree on the
+problem, scope, and high-level design before implementation begins. It also
+helps prevent duplicate work and avoids moving architectural discussions into
+code review.
 
-Most issues will be marked with one of the following workflow labels:
-- **NeedsInvestigation**: The issue is not fully understood and requires analysis to understand the root cause.
-- **NeedsDecision**: The issue is relatively well understood, but the tRPC-Agent-Go team hasn't yet decided the best way to address it.
-  It would be better to wait for a decision before writing code.
-  If you are interested in working on an issue in this state, feel free to "ping" maintainers in the issue's comments if some time has passed without a decision.
-- **NeedsFix**: The issue is fully understood and code can be written to fix it.
+The issue tracker uses the following workflow labels:
 
-### Opening an issue for any new problem
+- **NeedsInvestigation**: The problem is not yet sufficiently understood.
+- **NeedsDecision**: The problem is understood, but the project has not selected
+  an approach. Wait for a decision before starting implementation.
+- **NeedsFix**: The problem and expected direction are sufficiently clear for
+  implementation.
 
-Excluding very trivial changes, all contributions should be connected to an existing issue.
-Feel free to open one and discuss your plans.
-This process gives everyone a chance to validate the design, helps prevent duplication of effort, and ensures that the idea fits inside the goals for the language and tools.
-It also checks that the design is sound before code is written; the code review tool is not the place for high-level discussions.
+If an issue remains in `NeedsDecision` for some time, contributors may ask
+maintainers for an update in the issue discussion.
 
-When opening an issue, make sure to answer these five questions:
-1. What version of tRPC-Agent-Go are you using ?
-2. What operating system and processor architecture are you using(`go env`)?
+### Report bugs with enough context
+
+A bug report should answer the following questions:
+
+1. Which version of tRPC-Agent-Go are you using?
+2. Which operating system and processor architecture are you using?
 3. What did you do?
-4. What did you expect to see?
-5. What did you see instead?
+4. What did you expect to happen?
+5. What happened instead?
 
-For change proposals, see Proposing Changes To [tRPC-Proposals](https://github.com/trpc-group/trpc/tree/main/proposal).
+Include the relevant output of `go env` when environment details may affect the
+problem.
+
+### Discuss significant changes first
+
+Significant features, framework abstractions, public API changes, persistence
+changes, and protocol changes should be discussed before implementation.
+
+High-level design should be settled in an issue or proposal. Code review should
+verify and refine an agreed design, not become the first place where the design
+is considered.
+
+For larger change proposals, see
+[Proposing Changes to tRPC](https://github.com/trpc-group/trpc/tree/main/proposal).
 
 ## Contributing code
 
-Follow the [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow) to [create a GitHub pull request](https://docs.github.com/en/get-started/quickstart/github-flow#create-a-pull-request).
-If this is your first time submitting a PR to the tRPC-Agent-Go project, you will be reminded in the "Conversation" tab of the PR to sign and submit the [Contributor License Agreement](https://github.com/trpc-group/cla-database/blob/main/Tencent-Contributor-License-Agreement.md).
-Only when you have signed the Contributor License Agreement, your submitted PR has the possibility of being accepted.
+Follow the
+[GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+and submit changes through a pull request.
 
-Some things to keep in mind:
-- Ensure that your code conforms to the project's code specifications.
-  This includes but is not limited to code style, comment specifications, etc. This helps us to maintain the cleanliness and consistency of the project.
-- Before submitting a PR, please make sure that you have tested your code locally(`go test ./...`).
-  Ensure that the code has no obvious errors and can run normally.
-- To update the pull request with new code, just push it to the branch;
-  you can either add more commits, or rebase and force-push (both styles are accepted).
-- If the request is accepted, all commits will be squashed, and the final commit description will be composed by concatenating the pull request's title and description.
-  The individual commits' descriptions will be discarded.
-  See following "Write good commit messages" for some suggestions.
+First-time contributors must sign the
+[Tencent Contributor License Agreement](https://github.com/trpc-group/cla-database/blob/main/Tencent-Contributor-License-Agreement.md).
+The pull request Conversation tab will provide signing instructions when
+required.
 
-### Writing good commit messages
+### Language
 
-Commit messages in tRPC-Agent-Go follow a specific set of conventions, which we discuss in this section.
+Pull request titles and descriptions must be written in English.
 
-Here is an example of a good one:
+Source-code comments and Go documentation comments must also be written in
+English. Exceptions include translated documentation and test data that
+intentionally verifies localized behavior.
 
+Review discussions may use another language when that makes communication more
+effective.
 
-> math: improve Sin, Cos and Tan precision for very large arguments
->
-> The existing implementation has poor numerical properties for
-> large arguments, so use the McGillicutty algorithm to improve
-> accuracy above 1e10.
->
-> The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
->
-> Fixes #159
->
-> RELEASE NOTES: Improved precision of Sin, Cos, and Tan for very large arguments (>1e10) 
+### Pull request title
 
-#### First line
+Every pull request title must identify the primary affected package or
+repository area and summarize the result of the change.
 
-The first line of the change description is conventionally a short one-line summary of the change, prefixed by the primary affected package.
+Prefer the following form for a change with one primary package:
 
-A rule of thumb is that it should be written so to complete the sentence "This change modifies tRPC-Agent-Go to _____."
-That means it does not start with a capital letter, is not a complete sentence, and actually summarizes the result of the change.
+```text
+package: lowercase summary
+```
 
-Follow the first line by a blank line.
+When multiple packages are equally affected, enclose the package list in braces
+and separate package names with a comma and a space:
 
-#### Main content
+```text
+{package/a, package/b}: lowercase summary
+```
 
-The rest of the description elaborates and should provide context for the change and explain what it does.
-Write in complete sentences with correct punctuation, just like for your comments in tRPC-Agent-Go.
-Don't use HTML, Markdown, or any other markup language.
-Add any relevant information, such as benchmark data if the change affects performance.
-The [benchstat](https://godoc.org/golang.org/x/perf/cmd/benchstat) tool is conventionally used to format benchmark data for change descriptions.
+Use one primary package whenever possible. Do not add documentation, tests, or
+examples to the package list when they only support the primary implementation
+change.
 
-#### Referencing issues
+For a change that does not belong to a Go package, use the narrowest repository
+area or subsystem that owns the change.
 
-The special notation "Fixes #12345" associates the change with issue 12345 in the tRPC-Agent-Go issue tracker.
-When this change is eventually applied, the issue tracker will automatically mark the issue as fixed.
+The summary should:
 
-- If there is a corresponding issue, add either `Fixes #12345` or `Updates #12345` (the latter if this is not a complete fix) to this comment
-- If referring to a repo other than `trpc-agent-go` you can use the `owner/repo#issue_number` syntax: `Fixes trpc-group/tnet#12345`
+- begin with a lowercase letter;
+- describe the result rather than the implementation process;
+- be concise but meaningful without reading the diff; and
+- complete the sentence “This change modifies tRPC-Agent-Go to _____.”
 
-#### PR type label
+Use an ASCII colon followed by one space. A generic change type, issue number,
+tool name, or bracketed tag does not replace the affected package name.
 
-The PR type label is used to help identify the types of changes going into the release over time. This may allow the Release Team to develop a better understanding of what sorts of issues we would miss with a faster release cadence.
+### Pull request description
 
-For all pull requests, one of the following PR type labels must be set:
+Keep the pull request template and complete every applicable section.
 
-- type/bug: Fixes a newly discovered bug.
-- type/enhancement: Adding tests, refactoring.
-- type/feature: New functionality.
-- type/documentation: Adds documentation.
-- type/api-change: Adds, removes, or changes an API.
-- type/failing-test: CI test case is showing intermittent failures.
-- type/performance: Changes that improves performance.
-- type/ci: Changes the CI configuration files and scripts.
+The description must explain:
 
-#### Release notes
+- **What changed**: the externally observable behavior, API, documentation, or
+  example changes.
+- **Why**: the problem, design motivation, and reason for selecting the proposed
+  approach.
+- **Public API and compatibility**: the affected public contracts and their
+  compatibility implications.
+- **Testing**: the automated and manual validation that was actually performed.
+- **Release notes**: the user-visible effect of the change, or `NONE`.
+- **Notes for reviewers**: areas that deserve focused review.
 
-Release notes are required for any pull request with user-visible changes, this could mean:
+Do not leave template instructions unchanged. Do not submit a description that
+only repeats the title or lists changed files without explaining their behavior
+and motivation.
 
-- User facing, critical bug-fixes
-- Notable feature additions
-- Deprecations or removals
-- API changes
-- Documents additions
+Markdown is allowed in pull request descriptions.
 
-If the current PR doesn't have user-visible changes, such as internal code refactoring or adding test cases, the release notes should be filled with 'NONE' and the changes in this PR will not be recorded in the next version's CHANGELOG. If the current PR has user-visible changes, the release notes should be filled out according to the actual situation, avoiding technical details and describing the impact of the current changes from a user's perspective as much as possible.
+Pull requests are squash-merged. The final commit description is composed from
+the pull request title and description, while individual commit descriptions
+are discarded. Write the title and description as durable project history.
 
-Release notes are one of the most important reference points for users about to import or upgrade to a particular release of tRPC-Agent-Go.
+### Public API and framework design
 
-## Miscellaneous topics
+Treat every public API and externally observable framework behavior as a
+long-lived compatibility commitment.
 
-### Copyright headers
+A public API change includes adding, removing, renaming, or changing:
 
-Files in the tRPC-Agent-Go repository don't list author names, both to avoid clutter and to avoid having to keep the lists up to date.
-Instead, your name will appear in the change log.
+- an exported type, function, method, interface, field, constant, or variable;
+- an option, callback, plugin contract, or sentinel error;
+- default, zero-value, nil, ownership, concurrency, or lifecycle behavior;
+- serialized fields, persistence formats, or protocol contracts; or
+- event ordering, streaming, cancellation, retry, or other observable behavior.
 
-New files that you contribute should use the standard copyright header:
+Before adding a public API:
+
+- search for an existing API or extension point that can support the use case;
+- verify that the concept belongs to the selected package and abstraction layer;
+- keep provider-, vendor-, model-, protocol-, business-, and
+  deployment-specific concepts out of shared packages unless they form a
+  demonstrated general abstraction;
+- avoid parallel entry points with substantially overlapping responsibilities;
+- prefer the smallest surface that supports external consumers; and
+- consider how the API can evolve without duplicate types, methods, or
+  incompatible renames.
+
+The pull request description must list every added or changed public symbol and
+explain:
+
+- why the public surface is necessary;
+- why an existing API or extension point is insufficient;
+- why the symbol belongs in its package;
+- its default, zero-value, nil, error, ownership, and lifecycle behavior where
+  relevant;
+- its source, behavioral, serialization, persistence, and protocol
+  compatibility where relevant; and
+- any migration, deprecation, or future-extension considerations.
+
+Every exported symbol must have meaningful Godoc that explains its contract.
+Documentation that only restates the declaration is insufficient.
+
+Public API naming is a framework design concern. Review exported names for
+semantic accuracy, discoverability, package fit, abstraction boundaries, and
+future evolution. Unexported naming and local refactoring preferences are not
+public API concerns unless they are misleading or likely to cause incorrect
+behavior.
+
+### Code quality and validation
+
+Keep changes focused and avoid unrelated refactoring.
+
+Before submitting or updating a pull request:
+
+- format Go code with `gofmt`;
+- organize imports with `goimports`;
+- run tests for every affected module;
+- run the root test suite when the root module is affected;
+- add targeted tests for new behavior, boundary conditions, and regressions;
+- update documentation and examples when public behavior changes; and
+- verify that tests do not depend on credentials, external services,
+  machine-specific paths, or unstable timing unless explicitly required.
+
+Tests should validate externally observable behavior rather than merely execute
+new code. Assertions should be strong enough to fail when the intended contract
+is broken.
+
+Report validation commands in a portable form. Do not include local absolute
+paths, machine-specific cache directories, credentials, or developer-specific
+environment configuration in pull request descriptions.
+
+### Referencing issues
+
+Use `Fixes #12345` when the pull request completely resolves an issue.
+
+Use `Updates #12345` when the pull request contributes to an issue but does not
+fully resolve it.
+
+For an issue in another repository, use the full repository reference:
+
+```text
+Fixes owner/repository#12345
+```
+
+### Pull request type
+
+Every pull request must have an appropriate type label:
+
+- `type/bug`: fixes a newly discovered bug;
+- `type/enhancement`: improves or refactors existing behavior;
+- `type/feature`: adds new functionality;
+- `type/documentation`: changes documentation;
+- `type/api-change`: adds, removes, or changes a public API or contract;
+- `type/failing-test`: addresses an intermittent or failing CI test;
+- `type/performance`: improves performance; or
+- `type/ci`: changes CI configuration or scripts.
+
+Use `type/api-change` whenever the change affects a public API or externally
+observable contract, even if another type label also applies.
+
+### Release notes
+
+Release notes are required for user-visible changes, including:
+
+- critical bug fixes;
+- notable features;
+- deprecations or removals;
+- public API or behavioral changes; and
+- significant documentation additions.
+
+Describe the impact from the user’s perspective and avoid unnecessary
+implementation detail.
+
+Use `NONE` for changes without user-visible impact, such as internal
+refactoring or test-only changes.
+
+### Updating a pull request
+
+Push additional commits to the pull request branch when addressing feedback.
+
+Both incremental commits and rebasing with a force-push are accepted. Keep the
+pull request description synchronized with the final design and behavior,
+especially after public APIs or compatibility decisions change.
+
+## Copyright headers
+
+Source files do not list individual author names. Contributor information is
+preserved in project history instead.
+
+New Go files must use the following header:
+
+<!-- markdownlint-disable MD013 -->
 
 ```go
 //
-// Tencent is pleased to support the open source community by making trpc-agent-go available. 
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
 //
-// Copyright (C) 2025 Tencent.  All rights reserved. 
-
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
 // trpc-agent-go is licensed under the Apache License Version 2.0.
 //
 //
 ```
 
-Files in the repository are copyrighted the year they are added.
-Do not update the copyright year on files that you change.
+<!-- markdownlint-enable MD013 -->
+
+Use the year in which the file is added. Do not update the copyright year when
+modifying an existing file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,7 +273,7 @@ New Go files must use the following header:
 //
 // Tencent is pleased to support the open source community by making trpc-agent-go available.
 //
-// Copyright (C) 2025 Tencent.  All rights reserved.
+// Copyright (C) <YEAR> Tencent.  All rights reserved.
 //
 // trpc-agent-go is licensed under the Apache License Version 2.0.
 //

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,16 @@ and separate package names with a comma and a space:
 {package/a, package/b}: lowercase summary
 ```
 
+When a coherent cross-cutting change spans too many packages for a useful
+package list and no single package is primary, `lsc` may be used as the
+repository-level scope:
+
+```text
+lsc: lowercase summary
+```
+
+Do not use `lsc` merely to avoid identifying a clear primary package.
+
 Use one primary package whenever possible. Do not add documentation, tests, or
 examples to the package list when they only support the primary implementation
 change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,23 +114,21 @@ tool name, or bracketed tag does not replace the affected package name.
 
 ### Pull request description
 
-Keep the pull request template and complete every applicable section.
+Keep the description concise. The diff is the source of truth; the description
+should provide the context that code alone cannot.
 
-The description must explain:
+Use the pull request template to explain:
 
-- **What changed**: the externally observable behavior, API, documentation, or
-  example changes.
-- **Why**: the problem, design motivation, and reason for selecting the proposed
-  approach.
-- **Public API and compatibility**: the affected public contracts and their
-  compatibility implications.
-- **Testing**: the automated and manual validation that was actually performed.
-- **Release notes**: the user-visible effect of the change, or `NONE`.
-- **Notes for reviewers**: areas that deserve focused review.
+- **What changed**: the outcome and its user or developer impact.
+- **Why**: the problem and any non-obvious design rationale.
+- **Testing**: the validation that was actually performed.
+- **Notes for reviewers**: optional risks or design decisions that deserve
+  focused review.
 
-Do not leave template instructions unchanged. Do not submit a description that
-only repeats the title or lists changed files without explaining their behavior
-and motivation.
+Do not restate the implementation, enumerate every changed file or symbol, or
+leave template instructions unchanged. When a public API, compatibility, or
+migration concern is not clear from the diff, call it out under **Notes for
+reviewers**.
 
 Markdown is allowed in pull request descriptions.
 
@@ -155,25 +153,12 @@ Before adding a public API:
 
 - search for an existing API or extension point that can support the use case;
 - verify that the concept belongs to the selected package and abstraction layer;
-- keep provider-, vendor-, model-, protocol-, business-, and
-  deployment-specific concepts out of shared packages unless they form a
-  demonstrated general abstraction;
+- keep implementation-specific concepts in their owning packages unless their
+  semantics are genuinely shared across implementations;
 - avoid parallel entry points with substantially overlapping responsibilities;
 - prefer the smallest surface that supports external consumers; and
 - consider how the API can evolve without duplicate types, methods, or
   incompatible renames.
-
-The pull request description must list every added or changed public symbol and
-explain:
-
-- why the public surface is necessary;
-- why an existing API or extension point is insufficient;
-- why the symbol belongs in its package;
-- its default, zero-value, nil, error, ownership, and lifecycle behavior where
-  relevant;
-- its source, behavioral, serialization, persistence, and protocol
-  compatibility where relevant; and
-- any migration, deprecation, or future-extension considerations.
 
 Every exported symbol must have meaningful Godoc that explains its contract.
 Documentation that only restates the declaration is insufficient.
@@ -183,6 +168,40 @@ semantic accuracy, discoverability, package fit, abstraction boundaries, and
 future evolution. Unexported naming and local refactoring preferences are not
 public API concerns unless they are misleading or likely to cause incorrect
 behavior.
+
+### Go conventions
+
+Follow [Effective Go](https://go.dev/doc/effective_go) and the
+[Go Code Review Comments](https://go.dev/wiki/CodeReviewComments), while
+preserving established project APIs when compatibility requires it.
+
+- Format code with `gofmt` and organize imports with `goimports`.
+- Use short, lowercase, single-word package names. Avoid underscores, mixed
+  capitals, and names that repeat their package when qualified.
+- Use MixedCaps for Go names and spell common initialisms consistently, such as
+  `ID`, `URL`, and `HTTP`.
+- Make exported names read naturally with their package qualifier. Avoid
+  stutter and redundant prefixes such as `pkg.PkgType`.
+- Prefer small interfaces that describe behavior required by consumers. Do not
+  introduce an interface only to anticipate hypothetical implementations or to
+  make a concrete type easier to mock.
+- Prefer returning concrete types from constructors. Add a constructor when it
+  establishes invariants or improves usability; otherwise, make the zero value
+  useful when practical.
+- Pass `context.Context` as the first parameter when an operation needs it. Do
+  not store a context in a struct unless the type explicitly represents that
+  context's lifetime.
+- Keep error strings lowercase and without trailing punctuation. Wrap errors
+  with `%w` when callers need the cause, and expose sentinel or typed errors
+  only when callers have a stable reason to inspect them.
+- Make goroutine, channel, resource, cancellation, and shutdown ownership
+  explicit. Background work must have a bounded way to stop.
+- Write doc comments for exported declarations as complete sentences beginning
+  with the declared name, and document behavior that callers must understand.
+
+Do not turn idiomatic guidance into subjective churn. Match surrounding code
+when several forms are valid, and do not refactor established public APIs only
+to satisfy a style preference.
 
 ### Code quality and validation
 
@@ -236,29 +255,13 @@ Every pull request must have an appropriate type label:
 Use `type/api-change` whenever the change affects a public API or externally
 observable contract, even if another type label also applies.
 
-### Release notes
-
-Release notes are required for user-visible changes, including:
-
-- critical bug fixes;
-- notable features;
-- deprecations or removals;
-- public API or behavioral changes; and
-- significant documentation additions.
-
-Describe the impact from the user’s perspective and avoid unnecessary
-implementation detail.
-
-Use `NONE` for changes without user-visible impact, such as internal
-refactoring or test-only changes.
-
 ### Updating a pull request
 
 Push additional commits to the pull request branch when addressing feedback.
 
 Both incremental commits and rebasing with a force-push are accepted. Keep the
-pull request description synchronized with the final design and behavior,
-especially after public APIs or compatibility decisions change.
+pull request description synchronized with the final outcome and any important
+review context.
 
 ## Copyright headers
 


### PR DESCRIPTION
## What changed

- define concise English, package-scoped pull request conventions, including `lsc` for coherent cross-cutting changes with no primary package;
- add public API and idiomatic Go design guidance for contributors and coding agents;
- configure CodeRabbit to review exported API design, package boundaries, compatibility, concurrency, errors, documentation, and tests; and
- correct the Go license-header template.

No runtime code or public API is changed.

## Why

Recent reviews exposed recurring problems around unnecessary exports, overlapping APIs, package ownership, naming semantics, and inconsistent pull request metadata. This change turns those lessons into general guidance for future contributions.

## Testing

- `npx --yes markdownlint-cli2@0.22.0 CONTRIBUTING.md AGENTS.md .github/PULL_REQUEST_TEMPLATE.md`
- parsed `.coderabbit.yaml` with Ruby YAML
- verified `tone_instructions` is within CodeRabbit's 250-character limit
- `git diff --check`

## Notes for reviewers

The CodeRabbit configuration in this pull request takes effect after it is merged because reviews of external pull requests use the configuration from the base branch.