### PR TITLE
docs: fix invocation constructor typo

### DIFF
--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -122,7 +122,7 @@ llm := llmagent.New(
   ),
 )
 
-inv := agent.NewInvoction()
+inv := agent.NewInvocation()
 inv.SetState("case", "case-1")
 
 // Initialize session state (Runner + SessionService)

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -107,7 +107,7 @@ llm := llmagent.New(
   ),
 )
 
-inv := agent.NewInvoction()
+inv := agent.NewInvocation()
 inv.SetState("case", "case-1")
 
 // 通过 SessionService 初始化状态（用户态/应用态 + 会话本地键）


### PR DESCRIPTION
## What changed

Corrects the invocation constructor name in the English and Chinese agent guides so the code samples use the valid public API.

## Why

The samples currently call the misspelled `agent.NewInvoction()`, which does not compile. The exported constructor is `agent.NewInvocation()`.

Thanks to @GongNanyue for spotting the typo and proposing the original fix in #1801.

## Testing

- `mkdocs build --strict`
- `git diff --check`
- Verified there are no remaining `NewInvoction` occurrences under `docs/mkdocs`.

## Notes for reviewers

No public API or runtime behavior changes.

Closes #1801