### PR TITLE
session: centralize ingest option resolution

### DIFF
--- a/memory/mem0/service.go
+++ b/memory/mem0/service.go
@@ -102,13 +102,7 @@ func (s *Service) IngestSession(
 		return nil
 	}
 	writeLastExtractAt(sess, latestTs)
-	var reqOpts session.IngestOptions
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		opt(&reqOpts)
-	}
+	reqOpts := session.ResolveIngestOptions(opts...)
 	job := &ingestJob{
 		Ctx:      context.WithoutCancel(ctx),
 		UserKey:  userKey,

--- a/session/ingestor.go
+++ b/session/ingestor.go
@@ -11,38 +11,36 @@ package session
 
 import "context"
 
-// IngestOptions captures the per-request settings for Ingestor.IngestSession.
+// IngestOptions contains backend-neutral hints for one call to
+// Ingestor.IngestSession. Provider-specific ingestion policy and request
+// fields belong to the provider package rather than this shared contract.
 //
-// New fields can be added here over time without changing the Ingestor
-// interface signature, so implementations stay forward compatible as
-// ingestion semantics evolve. Callers configure it via the With* helpers
-// (e.g. WithIngestMetadata) and implementations resolve the effective values
-// by applying each option to a local IngestOptions value in a for-loop,
-// mirroring the SummaryOption pattern in this package:
-//
-//	var req session.IngestOptions
-//	for _, opt := range opts {
-//	    if opt != nil {
-//	        opt(&req)
-//	    }
-//	}
+// Implementations may ignore hints they do not support and should document
+// which hints they honor.
 type IngestOptions struct {
-	// Metadata is extra metadata to attach to the resulting memories.
-	// Backends typically merge it into the per-record metadata payload.
+	// Metadata contains caller-supplied attributes associated with the
+	// ingested session.
 	Metadata map[string]any
-	// AgentID identifies the agent that produced the session content.
-	// Backends that support multi-agent partitioning use it to scope memories.
+	// AgentID identifies the agent associated with the ingested session.
 	AgentID string
-	// RunID identifies the conversation/run associated with the ingestion.
-	// Backends that support per-run grouping use it to link related memories.
+	// RunID identifies the run associated with the ingested session.
 	RunID string
 }
 
-// IngestOption configures a single ingestion request. Use the With* helpers
-// (e.g. WithIngestMetadata, WithIngestAgentID, WithIngestRunID) to set the
-// well-known per-request fields, or construct a custom IngestOption that
-// mutates IngestOptions directly.
+// IngestOption configures the backend-neutral hints for one ingestion request.
 type IngestOption func(*IngestOptions)
+
+// ResolveIngestOptions applies opts in order and returns the resolved hints for
+// one ingestion request. Nil options are ignored.
+func ResolveIngestOptions(opts ...IngestOption) IngestOptions {
+	var resolved IngestOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&resolved)
+		}
+	}
+	return resolved
+}
 
 // WithIngestMetadata attaches the supplied metadata to a single ingestion
 // request. Repeated calls merge the maps; later values overwrite earlier
@@ -85,16 +83,14 @@ func WithIngestRunID(runID string) IngestOption {
 	}
 }
 
-// Ingestor ingests a completed session transcript into an external long-term
-// memory platform (e.g. mem0). Implementations enqueue the session for
-// asynchronous ingestion; the runner calls IngestSession after each turn
-// completes.
+// Ingestor ingests completed session content into long-term memory. The runner
+// calls IngestSession after each turn completes. Implementations may process
+// the session synchronously or enqueue it for later processing.
 //
-// The variadic IngestOption slice lets callers configure per-request
-// behaviour (metadata, agent_id, run_id, ...) without breaking the interface
-// as ingestion semantics evolve. Implementations resolve the effective values
-// by applying each option to a local IngestOptions value (see the IngestOptions
-// doc comment for the canonical snippet).
+// A nil return means that no synchronous submission error occurred; it does not
+// guarantee durable persistence unless the implementation documents stronger
+// delivery semantics. Options carry common caller hints. Provider-specific
+// behavior is configured by the implementation that owns it.
 type Ingestor interface {
 	IngestSession(ctx context.Context, sess *Session, opts ...IngestOption) error
 }

--- a/session/ingestor_test.go
+++ b/session/ingestor_test.go
@@ -17,27 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// applyIngestOpts mirrors the canonical apply-in-place loop documented on
-// IngestOptions so the test suite exercises helpers through the same path as
-// real Ingestor implementations.
-func applyIngestOpts(opts ...IngestOption) IngestOptions {
-	var got IngestOptions
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		opt(&got)
-	}
-	return got
-}
-
 func TestWithIngestMetadata_Sets(t *testing.T) {
-	got := applyIngestOpts(WithIngestMetadata(map[string]any{"k": "v"}))
+	got := ResolveIngestOptions(WithIngestMetadata(map[string]any{"k": "v"}))
 	require.Equal(t, map[string]any{"k": "v"}, got.Metadata)
 }
 
 func TestWithIngestMetadata_EmptyAndNilIgnored(t *testing.T) {
-	got := applyIngestOpts(
+	got := ResolveIngestOptions(
 		WithIngestMetadata(nil),
 		WithIngestMetadata(map[string]any{}),
 	)
@@ -45,7 +31,7 @@ func TestWithIngestMetadata_EmptyAndNilIgnored(t *testing.T) {
 }
 
 func TestWithIngestMetadata_MergesAndOverwrites(t *testing.T) {
-	got := applyIngestOpts(
+	got := ResolveIngestOptions(
 		WithIngestMetadata(map[string]any{"shared": "first", "only_in_first": 1}),
 		WithIngestMetadata(map[string]any{"shared": "second", "only_in_second": true}),
 	)
@@ -57,7 +43,7 @@ func TestWithIngestMetadata_MergesAndOverwrites(t *testing.T) {
 
 func TestWithIngestMetadata_ResolvedMapIsIndependent(t *testing.T) {
 	caller := map[string]any{"k": "v"}
-	got := applyIngestOpts(WithIngestMetadata(caller))
+	got := ResolveIngestOptions(WithIngestMetadata(caller))
 
 	caller["k"] = "mutated"
 	caller["new"] = "injected"
@@ -69,18 +55,18 @@ func TestWithIngestMetadata_ResolvedMapIsIndependent(t *testing.T) {
 
 func TestWithIngestAgentID(t *testing.T) {
 	t.Run("sets agent id", func(t *testing.T) {
-		got := applyIngestOpts(WithIngestAgentID("agent-a"))
+		got := ResolveIngestOptions(WithIngestAgentID("agent-a"))
 		assert.Equal(t, "agent-a", got.AgentID)
 	})
 	t.Run("empty value is ignored", func(t *testing.T) {
-		got := applyIngestOpts(
+		got := ResolveIngestOptions(
 			WithIngestAgentID("agent-a"),
 			WithIngestAgentID(""),
 		)
 		assert.Equal(t, "agent-a", got.AgentID, "empty string must not clear an earlier value")
 	})
 	t.Run("later non-empty overrides", func(t *testing.T) {
-		got := applyIngestOpts(
+		got := ResolveIngestOptions(
 			WithIngestAgentID("agent-a"),
 			WithIngestAgentID("agent-b"),
 		)
@@ -90,18 +76,18 @@ func TestWithIngestAgentID(t *testing.T) {
 
 func TestWithIngestRunID(t *testing.T) {
 	t.Run("sets run id", func(t *testing.T) {
-		got := applyIngestOpts(WithIngestRunID("run-a"))
+		got := ResolveIngestOptions(WithIngestRunID("run-a"))
 		assert.Equal(t, "run-a", got.RunID)
 	})
 	t.Run("empty value is ignored", func(t *testing.T) {
-		got := applyIngestOpts(
+		got := ResolveIngestOptions(
 			WithIngestRunID("run-a"),
 			WithIngestRunID(""),
 		)
 		assert.Equal(t, "run-a", got.RunID, "empty string must not clear an earlier value")
 	})
 	t.Run("later non-empty overrides", func(t *testing.T) {
-		got := applyIngestOpts(
+		got := ResolveIngestOptions(
 			WithIngestRunID("run-a"),
 			WithIngestRunID("run-b"),
 		)
@@ -109,13 +95,15 @@ func TestWithIngestRunID(t *testing.T) {
 	})
 }
 
-func TestIngestOptions_CombinedApply(t *testing.T) {
-	got := applyIngestOpts(
+func TestResolveIngestOptions(t *testing.T) {
+	got := ResolveIngestOptions(
 		WithIngestMetadata(map[string]any{"tag": "x"}),
+		nil,
 		WithIngestAgentID("agent-1"),
+		WithIngestAgentID("agent-2"),
 		WithIngestRunID("run-1"),
 	)
-	assert.Equal(t, "agent-1", got.AgentID)
+	assert.Equal(t, "agent-2", got.AgentID)
 	assert.Equal(t, "run-1", got.RunID)
 	assert.Equal(t, "x", got.Metadata["tag"])
 }
@@ -127,7 +115,7 @@ type stubIngestor struct {
 }
 
 func (s *stubIngestor) IngestSession(_ context.Context, _ *Session, opts ...IngestOption) error {
-	s.last = applyIngestOpts(opts...)
+	s.last = ResolveIngestOptions(opts...)
 	return nil
 }
 


### PR DESCRIPTION
## What changed

Defines ingestion options as shared per-call hints and provides canonical option resolution for Ingestor implementations. Mem0 now uses the shared resolver without changing when options are evaluated.

## Why

Provider-specific request fields should remain in their owning packages. The shared session contract should grow only when semantics are common across implementations.

## Testing

- `go build ./...`
- `go test ./...`
- `go test -race ./session ./memory/mem0`
- `go vet ./session ./memory/mem0`
- `go test ./runner`
- `cd test && go test ./...`
- Repository multi-module tests: affected packages passed; an unrelated Unix socket test failed under the long macOS temporary path and passed when rerun with a shorter temporary path
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`

## Notes for reviewers

The only new exported symbol is `session.ResolveIngestOptions`. The existing interface, option fields, defaults, and backend behavior remain compatible.
