### PR TITLE
server/agui: move track flush lifecycle to runner

### DIFF
--- a/server/agui/internal/track/options.go
+++ b/server/agui/internal/track/options.go
@@ -9,27 +9,18 @@
 
 package track
 
-import (
-	"time"
-
-	"trpc.group/trpc-go/trpc-agent-go/server/agui/aggregator"
-)
-
-// DefaultFlushInterval is the default flush interval for the tracker.
-const DefaultFlushInterval = time.Second
+import "trpc.group/trpc-go/trpc-agent-go/server/agui/aggregator"
 
 // options configures the tracker.
 type options struct {
 	aggregatorFactory aggregator.Factory  // aggregatorFactory builds aggregators for tracking.
 	aggregationOption []aggregator.Option // aggregationOption forwards options to the factory.
-	flushInterval     time.Duration       // flushInterval is the interval for flushing the session state.
 }
 
 // newOptions creates a new options instance.
 func newOptions(opt ...Option) *options {
 	opts := &options{
 		aggregatorFactory: aggregator.New,
-		flushInterval:     DefaultFlushInterval,
 	}
 	for _, o := range opt {
 		o(opts)
@@ -51,12 +42,5 @@ func WithAggregatorFactory(factory aggregator.Factory) Option {
 func WithAggregationOption(option ...aggregator.Option) Option {
 	return func(o *options) {
 		o.aggregationOption = append(o.aggregationOption, option...)
-	}
-}
-
-// WithFlushInterval sets the flush interval for the tracker.
-func WithFlushInterval(d time.Duration) Option {
-	return func(o *options) {
-		o.flushInterval = d
 	}
 }

--- a/server/agui/internal/track/options_test.go
+++ b/server/agui/internal/track/options_test.go
@@ -10,17 +10,15 @@
 package track
 
 import (
-	"testing"
-	"time"
-
 	"context"
+	"testing"
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/aggregator"
 )
 
-func TestOptionsWithAggregatorFactoryAndFlushInterval(t *testing.T) {
+func TestOptionsWithAggregatorFactory(t *testing.T) {
 	factoryCalled := false
 	customFactory := func(ctx context.Context, opt ...aggregator.Option) aggregator.Aggregator {
 		factoryCalled = true
@@ -30,14 +28,9 @@ func TestOptionsWithAggregatorFactoryAndFlushInterval(t *testing.T) {
 	opts := newOptions(
 		WithAggregatorFactory(customFactory),
 		WithAggregationOption(aggregator.WithEnabled(false)),
-		WithFlushInterval(250*time.Millisecond),
 	)
-
-	require.Equal(t, 250*time.Millisecond, opts.flushInterval)
-
 	agg := opts.aggregatorFactory(context.Background(), opts.aggregationOption...)
 	require.True(t, factoryCalled)
-
 	events, err := agg.Append(context.Background(), aguievents.NewTextMessageContentEvent("msg", "hi"))
 	require.NoError(t, err)
 	require.Len(t, events, 1) // disabled aggregation should pass through.

--- a/server/agui/internal/track/tracker.go
+++ b/server/agui/internal/track/tracker.go
@@ -19,8 +19,6 @@ import (
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"go.uber.org/multierr"
-	"trpc.group/trpc-go/trpc-agent-go/agent"
-	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/aggregator"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
@@ -34,8 +32,10 @@ type Tracker interface {
 	AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error
 	// GetEvents retrieves the AG-UI track events from the session.
 	GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error)
-	// Flush flushes any pending aggregated events for the given session key.
+	// Flush flushes buffered events for the given session key without closing the session state.
 	Flush(ctx context.Context, key session.Key) error
+	// Close flushes buffered events and releases the session state for the given session key.
+	Close(ctx context.Context, key session.Key) error
 }
 
 // tracker is the implementation of the Tracker interface.
@@ -46,14 +46,12 @@ type tracker struct {
 	aggregatorFactory aggregator.Factory            // aggregatorFactory builds aggregators for new sessions.
 	aggregationOption []aggregator.Option           // aggregationOption applies to newly built aggregators.
 	sessionStates     map[session.Key]*sessionState // sessionStates stores the state of each session.
-	flushInterval     time.Duration                 // flushInterval is the interval for flushing the session state.
 }
 
 // sessionState stores the state of a session.
 type sessionState struct {
-	mu         sync.Mutex            // mu guards the aggregator and the done channel.
+	mu         sync.Mutex            // mu guards the aggregator and cached session.
 	aggregator aggregator.Aggregator // aggregator aggregates events.
-	done       chan struct{}         // done is closed when the session state is removed.
 	session    *session.Session      // session caches the ensured session to avoid repeated lookups.
 }
 
@@ -70,7 +68,6 @@ func New(service session.Service, opt ...Option) (Tracker, error) {
 		aggregatorFactory: opts.aggregatorFactory,
 		aggregationOption: opts.aggregationOption,
 		sessionStates:     make(map[session.Key]*sessionState),
-		flushInterval:     opts.flushInterval,
 	}, nil
 }
 
@@ -111,13 +108,31 @@ func (t *tracker) GetEvents(ctx context.Context, key session.Key, opts ...sessio
 	return trackEvents, nil
 }
 
-// Flush flushes any pending aggregated events for the given session key.
+// Flush flushes buffered events for the given session key without closing the session state.
 func (t *tracker) Flush(ctx context.Context, key session.Key) error {
 	if err := key.CheckSessionKey(); err != nil {
 		return fmt.Errorf("session key: %w", err)
 	}
+	state := t.getExistingSessionState(key)
+	if state == nil {
+		return fmt.Errorf("session state not found: %v", key)
+	}
+	if err := t.flush(ctx, key, state); err != nil {
+		return fmt.Errorf("flush: %w", err)
+	}
+	return nil
+}
+
+// Close flushes buffered events and releases the session state for the given session key.
+func (t *tracker) Close(ctx context.Context, key session.Key) error {
+	if err := key.CheckSessionKey(); err != nil {
+		return fmt.Errorf("session key: %w", err)
+	}
+	state := t.getExistingSessionState(key)
+	if state == nil {
+		return nil
+	}
 	defer t.deleteSessionState(key)
-	state := t.getSessionState(ctx, key)
 	if err := t.flush(ctx, key, state); err != nil {
 		return fmt.Errorf("flush: %w", err)
 	}
@@ -191,47 +206,23 @@ func (t *tracker) getSessionState(ctx context.Context, key session.Key) *session
 	}
 	state := &sessionState{
 		aggregator: t.aggregatorFactory(ctx, t.aggregationOption...),
-		done:       make(chan struct{}),
 	}
 	t.sessionStates[key] = state
-	if t.flushInterval > 0 {
-		state.done = make(chan struct{})
-		flushCtx := agent.CloneContext(ctx)
-		go t.flushPeriodically(flushCtx, key, state)
-	}
 	return state
+}
+
+// getExistingSessionState returns the cached session state for the key when it exists.
+func (t *tracker) getExistingSessionState(key session.Key) *sessionState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.sessionStates[key]
 }
 
 // deleteSessionState removes the cached session state for the session key.
 func (t *tracker) deleteSessionState(key session.Key) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.flushInterval > 0 {
-		close(t.sessionStates[key].done)
-	}
 	delete(t.sessionStates, key)
-}
-
-// flushPeriodically flushes the session state periodically.
-func (t *tracker) flushPeriodically(ctx context.Context, key session.Key, state *sessionState) {
-	ticker := time.NewTicker(t.flushInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			if err := t.flush(ctx, key, state); err != nil {
-				log.WarnfContext(
-					ctx,
-					"flush: %v",
-					err,
-				)
-			}
-		case <-state.done:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
 }
 
 // flush flushes the session state.

--- a/server/agui/internal/track/tracker_test.go
+++ b/server/agui/internal/track/tracker_test.go
@@ -187,7 +187,7 @@ func TestTrackerGetEventsForwardsOptions(t *testing.T) {
 		return sess, nil
 	}
 
-	tracker, err := New(svc, WithFlushInterval(0))
+	tracker, err := New(svc)
 	require.NoError(t, err)
 
 	_, err = tracker.GetEvents(ctx, key, session.WithEventTime(afterTime))
@@ -419,26 +419,36 @@ func TestTrackerFlushPersistsPendingAggregation(t *testing.T) {
 	svc := inmemory.NewSessionService()
 	tracker, err := New(svc)
 	require.NoError(t, err)
-
 	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
 	require.NoError(t, tracker.AppendEvent(ctx, key, aguievents.NewTextMessageStartEvent("msg",
 		aguievents.WithRole("assistant"))))
 	require.NoError(t, tracker.AppendEvent(ctx, key, aguievents.NewTextMessageContentEvent("msg", "hi ")))
 	require.NoError(t, tracker.AppendEvent(ctx, key, aguievents.NewTextMessageContentEvent("msg", "there")))
-
 	require.NoError(t, tracker.Flush(ctx, key))
-
 	sess, err := svc.GetSession(ctx, key)
 	require.NoError(t, err)
 	trackEvents, err := sess.GetTrackEvents(TrackAGUI)
 	require.NoError(t, err)
 	require.Len(t, trackEvents.Events, 2)
-
 	parsed, err := aguievents.EventFromJSON(trackEvents.Events[1].Payload)
 	require.NoError(t, err)
 	content, ok := parsed.(*aguievents.TextMessageContentEvent)
 	require.True(t, ok)
 	require.Equal(t, "hi there", content.Delta)
+	require.NoError(t, tracker.AppendEvent(ctx, key, aguievents.NewTextMessageContentEvent("msg", " again")))
+	require.NoError(t, tracker.Close(ctx, key))
+	sess, err = svc.GetSession(ctx, key)
+	require.NoError(t, err)
+	trackEvents, err = sess.GetTrackEvents(TrackAGUI)
+	require.NoError(t, err)
+	require.Len(t, trackEvents.Events, 3)
+	parsed, err = aguievents.EventFromJSON(trackEvents.Events[2].Payload)
+	require.NoError(t, err)
+	content, ok = parsed.(*aguievents.TextMessageContentEvent)
+	require.True(t, ok)
+	require.Equal(t, " again", content.Delta)
+	err = tracker.Flush(ctx, key)
+	require.ErrorContains(t, err, "session state not found")
 }
 
 func TestTrackerFlushReturnsAggregatorError(t *testing.T) {
@@ -461,28 +471,14 @@ func TestTrackerFlushReturnsAggregatorError(t *testing.T) {
 	require.ErrorContains(t, err, "aggregator flush: flush fail")
 }
 
-func TestTrackerFlushPeriodically(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	svc := inmemory.NewSessionService()
-	agg := &stubAggregator{flushCh: make(chan struct{}, 2)}
-	tracker, err := New(svc,
-		WithAggregatorFactory(func(ctx context.Context, opt ...aggregator.Option) aggregator.Aggregator {
-			return agg
-		}),
-		WithFlushInterval(10*time.Millisecond),
-	)
+func TestTrackerFlushAndCloseMissingState(t *testing.T) {
+	ctx := context.Background()
+	tracker, err := New(inmemory.NewSessionService())
 	require.NoError(t, err)
-
 	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
-	require.NoError(t, tracker.AppendEvent(ctx, key, aguievents.NewTextMessageContentEvent("msg", "hi")))
-
-	select {
-	case <-agg.flushCh:
-	case <-time.After(200 * time.Millisecond):
-		require.FailNow(t, "expected periodic flush")
-	}
+	err = tracker.Flush(ctx, key)
+	require.ErrorContains(t, err, "session state not found")
+	require.NoError(t, tracker.Close(ctx, key))
 }
 
 type serviceWithoutTrack struct{}

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -710,6 +710,90 @@ func TestMessagesSnapshotFollowReceivesPeriodicFlushedContent(t *testing.T) {
 	require.Equal(t, "hello", content.Delta)
 }
 
+func TestMessagesSnapshotFollowReceivesPeriodicFlushedContentForToolRun(t *testing.T) {
+	ctx := context.Background()
+	sessionService := inmemory.NewSessionService()
+	key := session.Key{AppName: "demo", UserID: "user", SessionID: "thread"}
+	sess, err := sessionService.CreateSession(ctx, key, session.StateMap{})
+	require.NoError(t, err)
+	seedEvents := []session.TrackEvent{
+		newUserMessageTrackEvent(t, "user-1", "use the tool"),
+		newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-0", aguievents.WithRole("assistant"))),
+		newTrackEvent(t, aguievents.NewToolCallStartEvent("call-1", "calc", aguievents.WithParentMessageID("assistant-0"))),
+		newTrackEvent(t, aguievents.NewToolCallArgsEvent("call-1", "{}")),
+		newTrackEvent(t, aguievents.NewToolCallEndEvent("call-1")),
+		newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-0")),
+	}
+	for _, evt := range seedEvents {
+		trackEvent := evt
+		require.NoError(t, sessionService.AppendTrackEvent(ctx, sess, &trackEvent))
+	}
+	underlying := &streamingWaitRunner{
+		started: make(chan struct{}),
+		events:  make(chan *event.Event, 1),
+	}
+	r := New(
+		underlying,
+		WithAppName("demo"),
+		WithSessionService(sessionService),
+		WithFlushInterval(10*time.Millisecond),
+		WithMessagesSnapshotFollowEnabled(true),
+		WithMessagesSnapshotFollowMaxDuration(time.Second),
+		WithTrackPersistenceTimeout(200*time.Millisecond),
+	).(*runner)
+	runStream, err := r.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{
+			ID:         "tool-msg-1",
+			Role:       types.RoleTool,
+			Content:    "result",
+			Name:       "calc",
+			ToolCallID: "call-1",
+		}},
+	})
+	require.NoError(t, err)
+	waitForAGUIEventType(t, runStream, (*aguievents.RunStartedEvent)(nil))
+	waitForAGUIEventType(t, runStream, (*aguievents.ToolCallResultEvent)(nil))
+	select {
+	case <-underlying.started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timeout waiting for runner start")
+	}
+	runDone := make(chan struct{})
+	go func() {
+		for range runStream {
+		}
+		close(runDone)
+	}()
+	defer func() {
+		close(underlying.events)
+		<-runDone
+	}()
+	snapshotCtx, cancelSnapshot := context.WithCancel(ctx)
+	defer cancelSnapshot()
+	snapshotStream, err := r.MessagesSnapshot(snapshotCtx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "snapshot",
+	})
+	require.NoError(t, err)
+	waitForAGUIEventType(t, snapshotStream, (*aguievents.MessagesSnapshotEvent)(nil))
+	underlying.events <- &event.Event{Response: &model.Response{
+		ID:        "assistant-1",
+		Object:    model.ObjectTypeChatCompletionChunk,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Delta: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "hello",
+			},
+		}},
+	}}
+	content := waitForTextMessageContent(t, snapshotStream)
+	require.Equal(t, "assistant-1", content.MessageID)
+	require.Equal(t, "hello", content.Delta)
+}
+
 func TestMessagesSnapshotEmptyTrack(t *testing.T) {
 	svc := &testSessionService{}
 	tracker, err := track.New(svc)

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -31,6 +31,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
 func TestMessagesSnapshotRequiresAppName(t *testing.T) {
@@ -647,6 +648,66 @@ func TestMessagesSnapshotFollowAfterCancelStopsAtTerminalEvent(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, snapshot.Validate())
 	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), snapshotEvents[2])
+}
+
+func TestMessagesSnapshotFollowReceivesPeriodicFlushedContent(t *testing.T) {
+	underlying := &streamingWaitRunner{
+		started: make(chan struct{}),
+		events:  make(chan *event.Event, 1),
+	}
+	r := New(
+		underlying,
+		WithAppName("demo"),
+		WithSessionService(inmemory.NewSessionService()),
+		WithFlushInterval(10*time.Millisecond),
+		WithMessagesSnapshotFollowEnabled(true),
+		WithMessagesSnapshotFollowMaxDuration(time.Second),
+		WithTrackPersistenceTimeout(200*time.Millisecond),
+	).(*runner)
+	runStream, err := r.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleUser, Content: "hi"}},
+	})
+	require.NoError(t, err)
+	waitForAGUIEventType(t, runStream, (*aguievents.RunStartedEvent)(nil))
+	select {
+	case <-underlying.started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timeout waiting for runner start")
+	}
+	runDone := make(chan struct{})
+	go func() {
+		for range runStream {
+		}
+		close(runDone)
+	}()
+	defer func() {
+		close(underlying.events)
+		<-runDone
+	}()
+	snapshotCtx, cancelSnapshot := context.WithCancel(context.Background())
+	defer cancelSnapshot()
+	snapshotStream, err := r.MessagesSnapshot(snapshotCtx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "snapshot",
+	})
+	require.NoError(t, err)
+	waitForAGUIEventType(t, snapshotStream, (*aguievents.MessagesSnapshotEvent)(nil))
+	underlying.events <- &event.Event{Response: &model.Response{
+		ID:        "assistant-1",
+		Object:    model.ObjectTypeChatCompletionChunk,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Delta: model.Message{
+				Role:    model.RoleAssistant,
+				Content: "hello",
+			},
+		}},
+	}}
+	content := waitForTextMessageContent(t, snapshotStream)
+	require.Equal(t, "assistant-1", content.MessageID)
+	require.Equal(t, "hello", content.Delta)
 }
 
 func TestMessagesSnapshotEmptyTrack(t *testing.T) {
@@ -1491,6 +1552,19 @@ func (reasoningWaitRunner) Run(ctx context.Context, userID, sessionID string, me
 
 func (reasoningWaitRunner) Close() error { return nil }
 
+type streamingWaitRunner struct {
+	started chan struct{}
+	events  chan *event.Event
+}
+
+func (r *streamingWaitRunner) Run(ctx context.Context, userID, sessionID string, message model.Message,
+	runOpts ...agent.RunOption) (<-chan *event.Event, error) {
+	close(r.started)
+	return r.events, nil
+}
+
+func (r *streamingWaitRunner) Close() error { return nil }
+
 func waitForAGUIEventType(t *testing.T, ch <-chan aguievents.Event, want any) {
 	t.Helper()
 	wantType := reflect.TypeOf(want)
@@ -1504,6 +1578,22 @@ func waitForAGUIEventType(t *testing.T, ch <-chan aguievents.Event, want any) {
 			}
 		case <-timeout:
 			require.FailNow(t, "timeout waiting for AG-UI event")
+		}
+	}
+}
+
+func waitForTextMessageContent(t *testing.T, ch <-chan aguievents.Event) *aguievents.TextMessageContentEvent {
+	t.Helper()
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			require.True(t, ok)
+			if content, ok := evt.(*aguievents.TextMessageContentEvent); ok {
+				return content
+			}
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for text message content")
 		}
 	}
 }
@@ -1548,6 +1638,10 @@ func (s *sequenceTracker) Flush(ctx context.Context, key session.Key) error {
 	return nil
 }
 
+func (s *sequenceTracker) Close(ctx context.Context, key session.Key) error {
+	return nil
+}
+
 type blockingTracker struct {
 	unblock <-chan struct{}
 	events  *session.TrackEvents
@@ -1563,6 +1657,10 @@ func (b *blockingTracker) GetEvents(ctx context.Context, key session.Key, opts .
 }
 
 func (b *blockingTracker) Flush(ctx context.Context, key session.Key) error {
+	return nil
+}
+
+func (b *blockingTracker) Close(ctx context.Context, key session.Key) error {
 	return nil
 }
 
@@ -1591,6 +1689,10 @@ func (t *errorAfterFirstTracker) Flush(ctx context.Context, key session.Key) err
 	return nil
 }
 
+func (t *errorAfterFirstTracker) Close(ctx context.Context, key session.Key) error {
+	return nil
+}
+
 type emptyTrackThenTerminalTracker struct {
 	mu       sync.Mutex
 	calls    int
@@ -1616,6 +1718,10 @@ func (t *emptyTrackThenTerminalTracker) GetEvents(ctx context.Context, key sessi
 }
 
 func (t *emptyTrackThenTerminalTracker) Flush(ctx context.Context, key session.Key) error {
+	return nil
+}
+
+func (t *emptyTrackThenTerminalTracker) Close(ctx context.Context, key session.Key) error {
 	return nil
 }
 

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -17,12 +17,12 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/aggregator"
-	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 const (
+	defaultFlushInterval                          = time.Second
 	defaultPostRunFinalizationTimeout             = 5 * time.Second
 	defaultTrackPersistenceTimeout                = 5 * time.Second
 	defaultTimeout                                = time.Hour
@@ -84,7 +84,7 @@ func NewOptions(opt ...Option) *Options {
 		StateResolver:                          defaultStateResolver,
 		RunOptionResolver:                      defaultRunOptionResolver,
 		AggregatorFactory:                      aggregator.New,
-		FlushInterval:                          track.DefaultFlushInterval,
+		FlushInterval:                          defaultFlushInterval,
 		StartSpan:                              defaultStartSpan,
 		PostRunFinalizationTimeout:             defaultPostRunFinalizationTimeout,
 		TrackPersistenceTimeout:                defaultTrackPersistenceTimeout,

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -65,7 +65,6 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		tracker, err = track.New(opts.SessionService,
 			track.WithAggregatorFactory(opts.AggregatorFactory),
 			track.WithAggregationOption(opts.AggregationOption...),
-			track.WithFlushInterval(opts.FlushInterval),
 		)
 		if err != nil {
 			log.Warnf("agui: tracker disabled: %v", err)
@@ -441,12 +440,16 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 	threadID := input.threadID
 	runID := input.runID
 	if input.enableTrack {
+		var stopTrackFlush func()
 		defer func() {
-			if err := r.flushTrack(ctx, input.key); err != nil {
+			if stopTrackFlush != nil {
+				stopTrackFlush()
+			}
+			if err := r.closeTrack(ctx, input.key); err != nil {
 				log.WarnfContext(
 					ctx,
 					"agui run: threadID: %s, runID: %s, "+
-						"flush track events: %v",
+						"close track events: %v",
 					threadID,
 					runID,
 					err,
@@ -463,6 +466,8 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 					runID,
 					err,
 				)
+			} else {
+				stopTrackFlush = r.startTrackFlushLoop(ctx, input.key, threadID, runID)
 			}
 		}
 	}
@@ -516,6 +521,42 @@ func (r *runner) flushTrack(ctx context.Context, key session.Key) error {
 	flushCtx, cancel := r.newTrackPersistenceContext(ctx)
 	defer cancel()
 	return r.tracker.Flush(flushCtx, key)
+}
+
+func (r *runner) closeTrack(ctx context.Context, key session.Key) error {
+	closeCtx, cancel := r.newTrackPersistenceContext(ctx)
+	defer cancel()
+	return r.tracker.Close(closeCtx, key)
+}
+
+func (r *runner) startTrackFlushLoop(ctx context.Context, key session.Key, threadID, runID string) func() {
+	if r.flushInterval <= 0 {
+		return nil
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(r.flushInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := r.flushTrack(ctx, key); err != nil {
+					log.WarnfContext(ctx, "agui run: threadID: %s, runID: %s, flush track events: %v",
+						threadID, runID, err)
+				}
+			case <-stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return func() {
+		close(stop)
+		<-done
+	}
 }
 
 func (r *runner) emitPostRunTerminalEvent(ctx context.Context, events chan<- aguievents.Event, input *runInput) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -160,6 +160,7 @@ type runInput struct {
 	runOption       []agent.RunOption
 	translator      translator.Translator
 	enableTrack     bool
+	startTrackFlush func()
 	span            trace.Span
 	resume          *resumeInfo
 	terminalEmitted bool
@@ -441,6 +442,12 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 	runID := input.runID
 	if input.enableTrack {
 		var stopTrackFlush func()
+		var startTrackFlushOnce sync.Once
+		input.startTrackFlush = func() {
+			startTrackFlushOnce.Do(func() {
+				stopTrackFlush = r.startTrackFlushLoop(ctx, input.key, threadID, runID)
+			})
+		}
 		defer func() {
 			if stopTrackFlush != nil {
 				stopTrackFlush()
@@ -467,7 +474,7 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 					err,
 				)
 			} else {
-				stopTrackFlush = r.startTrackFlushLoop(ctx, input.key, threadID, runID)
+				input.startTrackFlush()
 			}
 		}
 	}
@@ -930,6 +937,8 @@ func (r *runner) emitEvent(ctx context.Context, events chan<- aguievents.Event, 
 				input.runID,
 				err,
 			)
+		} else if input.startTrackFlush != nil {
+			input.startTrackFlush()
 		}
 	}
 	select {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -2196,7 +2196,7 @@ func TestRunFlushesTracker(t *testing.T) {
 	assert.NoError(t, err)
 	collectEvents(t, ch)
 	assert.GreaterOrEqual(t, recorder.appendCount, 1)
-	assert.Equal(t, 1, recorder.flushCount)
+	assert.Equal(t, 1, recorder.closeCount)
 }
 
 func TestRecordTrackEventUsesDetachedPersistenceContext(t *testing.T) {
@@ -2984,6 +2984,7 @@ func (f *fakeTranslator) Translate(ctx context.Context, evt *agentevent.Event) (
 type flushRecorder struct {
 	appendCount int
 	flushCount  int
+	closeCount  int
 }
 
 func (f *flushRecorder) AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
@@ -2997,6 +2998,11 @@ func (f *flushRecorder) GetEvents(ctx context.Context, key session.Key, opts ...
 
 func (f *flushRecorder) Flush(ctx context.Context, key session.Key) error {
 	f.flushCount++
+	return nil
+}
+
+func (f *flushRecorder) Close(ctx context.Context, key session.Key) error {
+	f.closeCount++
 	return nil
 }
 
@@ -3021,6 +3027,10 @@ func (c *contextRecorderTracker) Flush(context.Context, session.Key) error {
 	return nil
 }
 
+func (c *contextRecorderTracker) Close(context.Context, session.Key) error {
+	return nil
+}
+
 type deadlineWaitingTracker struct{}
 
 func (deadlineWaitingTracker) AppendEvent(ctx context.Context, _ session.Key, _ aguievents.Event) error {
@@ -3037,11 +3047,16 @@ func (deadlineWaitingTracker) Flush(context.Context, session.Key) error {
 	return nil
 }
 
+func (deadlineWaitingTracker) Close(context.Context, session.Key) error {
+	return nil
+}
+
 type recordingTracker struct {
 	mu         sync.Mutex
 	events     []aguievents.Event
 	keys       []session.Key
 	flushCount int
+	closeCount int
 }
 
 func (r *recordingTracker) AppendEvent(ctx context.Context, key session.Key, event aguievents.Event) error {
@@ -3060,6 +3075,13 @@ func (r *recordingTracker) Flush(ctx context.Context, key session.Key) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.flushCount++
+	return nil
+}
+
+func (r *recordingTracker) Close(ctx context.Context, key session.Key) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closeCount++
 	return nil
 }
 
@@ -3112,6 +3134,11 @@ func (e *errorTracker) GetEvents(ctx context.Context,
 }
 
 func (e *errorTracker) Flush(ctx context.Context,
+	_ session.Key) error {
+	return e.flushErr
+}
+
+func (e *errorTracker) Close(ctx context.Context,
 	_ session.Key) error {
 	return e.flushErr
 }

--- a/server/agui/runner/source_metadata_test.go
+++ b/server/agui/runner/source_metadata_test.go
@@ -548,6 +548,13 @@ func (s *staticTrackEventsTracker) Flush(
 	return nil
 }
 
+func (s *staticTrackEventsTracker) Close(
+	context.Context,
+	session.Key,
+) error {
+	return nil
+}
+
 type getEventsErrorTracker struct {
 	err error
 }
@@ -569,6 +576,13 @@ func (g *getEventsErrorTracker) GetEvents(
 }
 
 func (g *getEventsErrorTracker) Flush(
+	context.Context,
+	session.Key,
+) error {
+	return nil
+}
+
+func (g *getEventsErrorTracker) Close(
 	context.Context,
 	session.Key,
 ) error {


### PR DESCRIPTION
This moves AG-UI track periodic flushing out of the tracker AppendEvent path and into the runner run lifecycle, separates in-run buffer flushing from final tracker cleanup, and keeps message snapshot follow able to tail buffered streaming content while a run is still active.