### PR TITLE
{server/agui, docs}: sync AG-UI app names with runner sessions

### DIFF
--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -242,6 +242,8 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithUserIDRe
 
 When `AppNameResolver` returns a non-empty string, that value is used as the `AppName` for the request. When it returns an empty string, the framework falls back to `agui.WithAppName(name)`. The real-time conversation, message snapshot, and cancel routes reuse the same resolution logic, so related requests for the same session must resolve to the same `AppName`.
 
+The resolved `AppName` is the canonical session boundary for an AG-UI request. During a real-time run, AG-UI passes it to the underlying Runner as `agent.WithAppName`, keeping the Runner session key consistent with AG-UI track events, message snapshots, and cancel routing.
+
 When message snapshots are enabled, configure `agui.WithAppName(name)` as the default value.
 
 ```go
@@ -274,6 +276,8 @@ server, _ := agui.New(
 ## Custom `RunOptionResolver`
 
 `RunOptionResolver` adds [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go) for the current agent run. It runs for every request, and the returned options only affect that run. The AG-UI runner still maps request `input.Tools` to caller-executed tools after the custom resolver returns.
+
+Do not return `agent.WithAppName` from `RunOptionResolver` to configure AG-UI session ownership. AG-UI `AppName` should come from `agui.WithAppName` or `agui.WithAppNameResolver`; when the resolved `AppName` is non-empty, it overrides any `agent.WithAppName` set by `RunOptionResolver`.
 
 ```go
 import (

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -242,6 +242,8 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithUserIDRe
 
 `AppNameResolver` 返回非空字符串时，会使用该值作为本次请求的 `AppName`；返回空字符串时，会回退到 `agui.WithAppName(name)`。实时对话、消息快照和取消路由会复用同一套解析逻辑，因此同一会话的相关请求需要解析出一致的 `AppName`。
 
+解析得到的 `AppName` 是 AG-UI 请求的规范会话边界。实时对话运行时，AG-UI 会把该值作为 `agent.WithAppName` 传给底层 Runner，使底层 Runner 的 session key 与 AG-UI track、消息快照和取消路由保持一致。
+
 开启消息快照功能时，需要配置 `agui.WithAppName(name)` 作为默认值。
 
 ```go
@@ -274,6 +276,8 @@ server, _ := agui.New(
 ## 自定义 `RunOptionResolver`
 
 `RunOptionResolver` 用于为本次 Agent 运行补充 [`agent.RunOption`](https://github.com/trpc-group/trpc-agent-go/blob/main/agent/invocation.go)。它会在每次请求处理时执行，返回的选项只作用于当前这次运行。AG-UI runner 会在自定义 resolver 返回后，继续把请求里的 `input.Tools` 映射为调用方执行的工具。
+
+不要通过 `RunOptionResolver` 返回 `agent.WithAppName` 配置 AG-UI 会话归属。AG-UI 的 `AppName` 应由 `agui.WithAppName` 或 `agui.WithAppNameResolver` 提供；当解析出的 `AppName` 非空时，它会覆盖 `RunOptionResolver` 中设置的 `agent.WithAppName`。
 
 ```go
 import (

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -375,6 +375,9 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 	if len(messages.toolMessages) > 0 {
 		runOption = append(runOption, withToolResultMessageRewriter(messages.toolMessages))
 	}
+	if appName != "" {
+		runOption = append(runOption, agent.WithAppName(appName))
+	}
 	ctx, span, err := r.startSpan(ctx, runAgentInput)
 	if err != nil {
 		return nil, fmt.Errorf("start span: %w", err)

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1520,6 +1520,88 @@ func TestRunUsesResolvedAppNameForTrackKey(t *testing.T) {
 	}
 }
 
+func TestRunUsesResolvedAppNameForUnderlyingRunner(t *testing.T) {
+	var gotOptions agent.RunOptions
+	underlying := &fakeRunner{
+		run: func(ctx context.Context, userID, sessionID string, message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			gotOptions = agent.NewRunOptions(opts...)
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(
+		underlying,
+		WithAppName("static-app"),
+		WithAppNameResolver(forwardedPropsAppNameResolver),
+	)
+	input := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"appName": "dynamic-app"},
+		Messages:       []types.Message{{ID: "user-msg-1", Role: types.RoleUser, Content: "hi"}},
+	}
+	ch, err := r.Run(context.Background(), input)
+	require.NoError(t, err)
+	collectEvents(t, ch)
+	assert.Equal(t, "dynamic-app", gotOptions.AppName)
+}
+
+func TestRunUsesStaticAppNameForUnderlyingRunner(t *testing.T) {
+	var gotOptions agent.RunOptions
+	underlying := &fakeRunner{
+		run: func(ctx context.Context, userID, sessionID string, message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			gotOptions = agent.NewRunOptions(opts...)
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(underlying, WithAppName("static-app"))
+	input := &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{ID: "user-msg-1", Role: types.RoleUser, Content: "hi"}},
+	}
+	ch, err := r.Run(context.Background(), input)
+	require.NoError(t, err)
+	collectEvents(t, ch)
+	assert.Equal(t, "static-app", gotOptions.AppName)
+}
+
+func TestRunResolvedAppNameOverridesRunOptionResolverAppName(t *testing.T) {
+	var gotOptions agent.RunOptions
+	underlying := &fakeRunner{
+		run: func(ctx context.Context, userID, sessionID string, message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			gotOptions = agent.NewRunOptions(opts...)
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(
+		underlying,
+		WithAppName("static-app"),
+		WithAppNameResolver(forwardedPropsAppNameResolver),
+		WithRunOptionResolver(func(context.Context, *adapter.RunAgentInput) ([]agent.RunOption, error) {
+			return []agent.RunOption{agent.WithAppName("custom-app")}, nil
+		}),
+	)
+	input := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"appName": "dynamic-app"},
+		Messages:       []types.Message{{ID: "user-msg-1", Role: types.RoleUser, Content: "hi"}},
+	}
+	ch, err := r.Run(context.Background(), input)
+	require.NoError(t, err)
+	collectEvents(t, ch)
+	assert.Equal(t, "dynamic-app", gotOptions.AppName)
+}
+
 func TestRunAppNameResolverError(t *testing.T) {
 	underlying := &fakeRunner{}
 	r := &runner{


### PR DESCRIPTION
This updates the AG-UI runner to treat the resolved AG-UI app name as the canonical session boundary by forwarding it to the underlying runner as the final run app name, keeping AG-UI track, snapshot, cancel routing, and runner session persistence aligned. It also documents that AG-UI app names should be configured through WithAppName or WithAppNameResolver instead of RunOptionResolver. Fixes #2273.