### PR TITLE
telemetry/langfuse: avoid double-counting cached input tokens

### DIFF
--- a/telemetry/langfuse/attribute.go
+++ b/telemetry/langfuse/attribute.go
@@ -75,6 +75,25 @@ func (u *usageDetails) empty() bool {
 	return *u == (usageDetails{})
 }
 
+// normalized returns mutually exclusive usage buckets as required by Langfuse.
+//
+// OpenAI-compatible and Gemini providers report cached tokens as a subset of
+// input tokens. Anthropic and Bedrock report cache reads and cache creation as
+// separate buckets, and their adapters also populate InputCached as a cache-read
+// compatibility alias.
+func (u usageDetails) normalized() usageDetails {
+	if u.InputCacheRead != 0 || u.InputCacheCreation != 0 {
+		// Prefer provider-specific buckets and drop the duplicate compatibility alias.
+		u.InputCached = 0
+		return u
+	}
+
+	// Langfuse flat usage details must not overlap. Keep cached input in its own
+	// bucket and convert the inclusive provider input count to the uncached remainder.
+	u.Input = max(u.Input-u.InputCached, 0)
+	return u
+}
+
 // observationInputPrompt is the Langfuse observation.input shape.
 //
 // tools is passed through as raw JSON from gen_ai.request.tool.definitions.

--- a/telemetry/langfuse/attribute_test.go
+++ b/telemetry/langfuse/attribute_test.go
@@ -109,3 +109,81 @@ func TestConstantNamingConvention(t *testing.T) {
 	assert.Equal(t, "langfuse.user.id", traceUserID)
 	assert.Equal(t, "langfuse.session.id", traceSessionID)
 }
+
+func TestUsageDetailsNormalized(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage usageDetails
+		want  usageDetails
+	}{
+		{
+			name:  "without cache",
+			usage: usageDetails{Input: 100, Output: 50},
+			want:  usageDetails{Input: 100, Output: 50},
+		},
+		{
+			name:  "inclusive cached input",
+			usage: usageDetails{Input: 100, Output: 50, InputCached: 30},
+			want:  usageDetails{Input: 70, Output: 50, InputCached: 30},
+		},
+		{
+			name:  "all input cached",
+			usage: usageDetails{Input: 30, Output: 10, InputCached: 30},
+			want:  usageDetails{Output: 10, InputCached: 30},
+		},
+		{
+			name:  "cached input exceeds input",
+			usage: usageDetails{Input: 20, Output: 10, InputCached: 30},
+			want:  usageDetails{Output: 10, InputCached: 30},
+		},
+		{
+			name: "provider cache read replaces compatibility alias",
+			usage: usageDetails{
+				Input:          20,
+				Output:         10,
+				InputCached:    80,
+				InputCacheRead: 80,
+			},
+			want: usageDetails{
+				Input:          20,
+				Output:         10,
+				InputCacheRead: 80,
+			},
+		},
+		{
+			name: "provider cache creation preserves exclusive input",
+			usage: usageDetails{
+				Input:              20,
+				Output:             10,
+				InputCacheCreation: 80,
+			},
+			want: usageDetails{
+				Input:              20,
+				Output:             10,
+				InputCacheCreation: 80,
+			},
+		},
+		{
+			name: "provider cache details take precedence",
+			usage: usageDetails{
+				Input:              20,
+				Output:             10,
+				InputCached:        70,
+				InputCacheRead:     70,
+				InputCacheCreation: 10,
+			},
+			want: usageDetails{
+				Input:              20,
+				Output:             10,
+				InputCacheRead:     70,
+				InputCacheCreation: 10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.usage.normalized())
+		})
+	}
+}

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -195,8 +195,9 @@ func transformCallLLM(span *tracepb.Span) {
 	}
 
 	// observation.usage_details
-	if !collected.usage.empty() {
-		if usageJSON, err := json.Marshal(collected.usage); err == nil {
+	usage := collected.usage.normalized()
+	if !usage.empty() {
+		if usageJSON, err := json.Marshal(usage); err == nil {
 			newAttributes = append(newAttributes, stringKV(observationUsageDetails, string(usageJSON)))
 		}
 	}

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -627,7 +627,7 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 			inputTokens:   100,
 			outputTokens:  50,
 			cachedTokens:  30,
-			expectedUsage: map[string]int64{"input": 100, "output": 50, "input_cached": 30},
+			expectedUsage: map[string]int64{"input": 70, "output": 50, "input_cached": 30},
 		},
 		{
 			name:            "with Anthropic cache_read tokens",
@@ -650,7 +650,21 @@ func TestTransformCallLLM_UsageDetails(t *testing.T) {
 			cachedTokens:        50,
 			cacheReadTokens:     70,
 			cacheCreationTokens: 20,
-			expectedUsage:       map[string]int64{"input": 300, "output": 100, "input_cached": 50, "input_cache_read": 70, "input_cache_creation": 20},
+			expectedUsage:       map[string]int64{"input": 300, "output": 100, "input_cache_read": 70, "input_cache_creation": 20},
+		},
+		{
+			name:          "cached tokens equal input",
+			inputTokens:   30,
+			outputTokens:  10,
+			cachedTokens:  30,
+			expectedUsage: map[string]int64{"output": 10, "input_cached": 30},
+		},
+		{
+			name:          "cached tokens exceed input",
+			inputTokens:   20,
+			outputTokens:  10,
+			cachedTokens:  30,
+			expectedUsage: map[string]int64{"output": 10, "input_cached": 30},
 		},
 		{
 			name:          "zero tokens omitted",


### PR DESCRIPTION
## What changed

Langfuse generation observations now report mutually exclusive input usage buckets. Cached input is no longer counted twice in displayed usage, totals, or inferred cost, while no-cache behavior and existing usage key names remain unchanged.

## Why

Langfuse treats each flat `usage_details` key as a non-overlapping bucket and sums keys containing `input`. OpenAI-compatible and Gemini responses report cached tokens as a subset of their inclusive input count, so forwarding both values unchanged inflated input usage. Anthropic and Bedrock expose cache reads and cache creation separately; their compatibility cache alias must not be emitted as an additional bucket.

Fixes #2281

## Testing

- `go test ./telemetry/langfuse -count=1`
- `go test ./...`
- `go build ./...`
- Verified a synthetic Go exporter observation with input 100, cached input 30, and output 50 is stored as input 70 + cached 30 and aggregates to input 100, total 150.
- Compared the result with Langfuse Python SDK flat-exclusive and OpenAI-schema observations.
- Ran the Agent + Runner prompt-cache example against an OpenAI-compatible provider: all 6 turns completed, calculator and time tool calls succeeded, and 5 turns reported cache hits. A real sample with prompt 2495, cached 2304, and output 291 was stored as input 191 + cached 2304 and aggregated to input 2495, total 2786. Agent observations contributed no duplicate token usage.

## Notes for reviewers

This intentionally changes externally observable Langfuse usage totals but adds no public Go API. Provider-specific cache-read/cache-creation buckets take precedence over the duplicate generic cached-input compatibility alias.