### PR TITLE
 {evaluation, docs}: add metric criterion json schema validation

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1005,6 +1005,7 @@ type JSONCriterion struct {
 	MatchStrategy   JSONMatchStrategy                        // MatchStrategy is the matching strategy.
 	NumberTolerance *float64                                 // NumberTolerance is the numeric tolerance.
 	Valid           bool                                     // Valid validates whether actual content is legal JSON.
+	Schema          string                                   // Schema validates actual content with JSON Schema.
 	Compare         func(actual, expected any) (bool, error) // Compare is custom comparison logic.
 }
 
@@ -1012,7 +1013,7 @@ type JSONCriterion struct {
 type JSONMatchStrategy string
 ```
 
-During comparison, `actual` is the actual value and `expected` is the expected value. When `Compare` is provided from code, JSONCriterion uses that custom logic directly. Otherwise, `valid` first validates whether actual is a complete and strict legal JSON document, and `matchStrategy` then decides whether to run built-in JSON value matching. Currently, `matchStrategy` supports `exact` and `skip`, with a default of `exact`; `exact` compares JSON values structurally, and `skip` skips built-in JSON value matching. If you only want JSON validity validation without comparing against expected, configure both `valid: true` and `matchStrategy: "skip"`. Object comparison requires identical key sets. Array comparison requires identical length and order. Numeric comparison supports a tolerance, default `1e-6`. `ignoreTree` ignores unstable fields; a leaf node set to true ignores that field and its subtree. `onlyTree` compares only selected fields; keys not present in the tree are ignored. A leaf node set to true compares that field and its subtree. `onlyTree` and `ignoreTree` cannot be set at the same time when both are non-empty.
+During comparison, `actual` is the actual value and `expected` is the expected value. When `Compare` is provided from code, JSONCriterion uses that custom logic directly. Otherwise, `valid` first validates whether actual is a complete and strict legal JSON document, `schema` validates actual against JSON Schema structure and field constraints, and `matchStrategy` then decides whether to run built-in JSON value matching. Currently, `matchStrategy` supports `exact` and `skip`, with a default of `exact`; `exact` compares JSON values structurally, and `skip` skips built-in JSON value matching. If you only want JSON validity validation or Schema validation without comparing against expected, configure `valid: true` or `schema`, and set `matchStrategy: "skip"`. Object comparison requires identical key sets. Array comparison requires identical length and order. Numeric comparison supports a tolerance, default `1e-6`. `ignoreTree` ignores unstable fields; a leaf node set to true ignores that field and its subtree. `onlyTree` compares only selected fields; keys not present in the tree are ignored. A leaf node set to true compares that field and its subtree. `onlyTree` and `ignoreTree` cannot be set at the same time when both are non-empty.
 
 Example configuration ignores `id` and `metadata.timestamp`, and relaxes numeric tolerance.
 
@@ -1038,6 +1039,15 @@ Example configuration compares only `name` and `metadata.id`, and ignores all ot
       "id": true
     }
   }
+}
+```
+
+Example configuration validates only whether actual matches the JSON Schema, without comparing against expected.
+
+```json
+{
+  "schema": "{\"type\":\"object\",\"required\":[\"name\"],\"properties\":{\"name\":{\"type\":\"string\"}},\"additionalProperties\":false}",
+  "matchStrategy": "skip"
 }
 ```
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1013,7 +1013,17 @@ type JSONCriterion struct {
 type JSONMatchStrategy string
 ```
 
-During comparison, `actual` is the actual value and `expected` is the expected value. When `Compare` is provided from code, JSONCriterion uses that custom logic directly. Otherwise, `valid` first validates whether actual is a complete and strict legal JSON document, `schema` validates actual against JSON Schema structure and field constraints, and `matchStrategy` then decides whether to run built-in JSON value matching. Currently, `matchStrategy` supports `exact` and `skip`, with a default of `exact`; `exact` compares JSON values structurally, and `skip` skips built-in JSON value matching. If you only want JSON validity validation or Schema validation without comparing against expected, configure `valid: true` or `schema`, and set `matchStrategy: "skip"`. Object comparison requires identical key sets. Array comparison requires identical length and order. Numeric comparison supports a tolerance, default `1e-6`. `ignoreTree` ignores unstable fields; a leaf node set to true ignores that field and its subtree. `onlyTree` compares only selected fields; keys not present in the tree are ignored. A leaf node set to true compares that field and its subtree. `onlyTree` and `ignoreTree` cannot be set at the same time when both are non-empty.
+During comparison, `actual` is the actual value and `expected` is the expected value. JSONCriterion runs in this order:
+
+1. If `Compare` is provided from code, JSONCriterion uses that custom logic directly and does not run the built-in `valid`, `schema`, or `matchStrategy` logic.
+2. If `Compare` is not provided, JSONCriterion runs `valid` validation first, then `schema` validation, and finally uses `matchStrategy` to decide whether to run built-in JSON value matching.
+3. If you only want JSON validity validation or Schema validation without comparing against `expected`, configure `valid: true` or `schema`, and set `matchStrategy: "skip"`.
+
+The `schema` field itself is a serialized JSON Schema string. The `actual` value is validated as its runtime value: `json.RawMessage` and `[]byte` are parsed as raw JSON first, while a Go `string` is validated as an already decoded string value. Empty `schema` disables Schema validation; invalid schema text or actual validation failure returns `(false, error)`.
+
+Currently, `matchStrategy` supports `exact` and `skip`, with a default of `exact`. `exact` compares JSON values structurally, and `skip` skips built-in JSON value matching. Object comparison requires identical key sets. Array comparison requires identical length and order. Numeric comparison supports a tolerance, default `1e-6`.
+
+`ignoreTree` ignores unstable fields; a leaf node set to true ignores that field and its subtree. `onlyTree` compares only selected fields; keys not present in the tree are ignored. A leaf node set to true compares that field and its subtree. `onlyTree` and `ignoreTree` cannot be set at the same time when both are non-empty.
 
 Example configuration ignores `id` and `metadata.timestamp`, and relaxes numeric tolerance.
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1005,7 +1005,7 @@ type JSONCriterion struct {
 	MatchStrategy   JSONMatchStrategy                        // MatchStrategy is the matching strategy.
 	NumberTolerance *float64                                 // NumberTolerance is the numeric tolerance.
 	Valid           bool                                     // Valid validates whether actual content is legal JSON.
-	Schema          string                                   // Schema validates actual content with JSON Schema.
+	Schema          json.RawMessage                          // Schema validates actual content with JSON Schema.
 	Compare         func(actual, expected any) (bool, error) // Compare is custom comparison logic.
 }
 
@@ -1019,7 +1019,9 @@ During comparison, `actual` is the actual value and `expected` is the expected v
 2. If `Compare` is not provided, JSONCriterion runs `valid` validation first, then `schema` validation, and finally uses `matchStrategy` to decide whether to run built-in JSON value matching.
 3. If you only want JSON validity validation or Schema validation without comparing against `expected`, configure `valid: true` or `schema`, and set `matchStrategy: "skip"`.
 
-The `schema` field itself is a serialized JSON Schema string. The `actual` value is validated as its runtime value: `json.RawMessage` and `[]byte` are parsed as raw JSON first, while a Go `string` is validated as an already decoded string value. Empty `schema` disables Schema validation; invalid schema text or actual validation failure returns `(false, error)`.
+The `schema` field itself is a raw JSON Schema JSON value, usually an object, and boolean schemas are also supported. In metric JSON, write the schema directly as JSON instead of an escaped string. Code can use `WithSchema` with serialized JSON Schema text.
+
+The `actual` value is validated as its runtime value: `json.RawMessage` and `[]byte` are parsed as raw JSON first, while a Go `string` is validated as an already decoded string value by default. When both `valid: true` and `schema` are configured, schema validation reuses the JSON value parsed by `valid`. Empty `schema` disables Schema validation; schemas without `$schema` are compiled as Draft 2020-12; invalid schema text or actual validation failure returns `(false, error)`.
 
 Currently, `matchStrategy` supports `exact` and `skip`, with a default of `exact`. `exact` compares JSON values structurally, and `skip` skips built-in JSON value matching. Object comparison requires identical key sets. Array comparison requires identical length and order. Numeric comparison supports a tolerance, default `1e-6`.
 
@@ -1056,7 +1058,16 @@ Example configuration validates only whether actual matches the JSON Schema, wit
 
 ```json
 {
-  "schema": "{\"type\":\"object\",\"required\":[\"name\"],\"properties\":{\"name\":{\"type\":\"string\"}},\"additionalProperties\":false}",
+  "schema": {
+    "type": "object",
+    "required": ["name"],
+    "properties": {
+      "name": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
   "matchStrategy": "skip"
 }
 ```

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1008,6 +1008,7 @@ type JSONCriterion struct {
 	MatchStrategy   JSONMatchStrategy                        // MatchStrategy 表示匹配策略
 	NumberTolerance *float64                                 // NumberTolerance 表示数字容差
 	Valid           bool                                     // Valid 表示校验实际内容是否为合法 JSON。
+	Schema          string                                   // Schema 表示用于校验实际内容的 JSON Schema。
 	Compare         func(actual, expected any) (bool, error) // Compare 自定义比较逻辑
 }
 
@@ -1015,7 +1016,7 @@ type JSONCriterion struct {
 type JSONMatchStrategy string
 ```
 
-对比时 actual 是实际值，expected 是预期值。如果在代码中提供了 `Compare`，JSONCriterion 会直接使用自定义逻辑。未提供 `Compare` 时，`valid` 用于先校验 actual 是否是一段完整且严格合法的 JSON，随后再按照 `matchStrategy` 决定是否执行内置 JSON 值匹配。当前 `matchStrategy` 支持 `exact` 与 `skip`，默认值为 `exact`；`exact` 表示按 JSON 结构精确匹配，`skip` 表示跳过内置 JSON 值匹配。因此，如果只希望做合法性校验、不希望继续比较 expected，应同时配置 `valid: true` 与 `matchStrategy: "skip"`。对象对比要求键集合一致，数组对比要求长度一致且顺序一致。数字对比支持数值容差，默认值为 `1e-6`。`ignoreTree` 用于忽略不稳定字段，叶子节点为 true 表示忽略该字段及其子树。`onlyTree` 用于只对比指定字段，未出现在字段树中的字段将被忽略；叶子节点为 true 表示对比该字段及其子树。`onlyTree` 与 `ignoreTree` 不能同时配置。两者同时非空时将报错。
+对比时 actual 是实际值，expected 是预期值。如果在代码中提供了 `Compare`，JSONCriterion 会直接使用自定义逻辑。未提供 `Compare` 时，`valid` 用于先校验 actual 是否是一段完整且严格合法的 JSON，`schema` 用于按 JSON Schema 校验 actual 的结构与字段约束，随后再按照 `matchStrategy` 决定是否执行内置 JSON 值匹配。当前 `matchStrategy` 支持 `exact` 与 `skip`，默认值为 `exact`；`exact` 表示按 JSON 结构精确匹配，`skip` 表示跳过内置 JSON 值匹配。因此，如果只希望做合法性校验或 Schema 校验、不希望继续比较 expected，应同时配置 `valid: true` 或 `schema`，并配置 `matchStrategy: "skip"`。对象对比要求键集合一致，数组对比要求长度一致且顺序一致。数字对比支持数值容差，默认值为 `1e-6`。`ignoreTree` 用于忽略不稳定字段，叶子节点为 true 表示忽略该字段及其子树。`onlyTree` 用于只对比指定字段，未出现在字段树中的字段将被忽略；叶子节点为 true 表示对比该字段及其子树。`onlyTree` 与 `ignoreTree` 不能同时配置。两者同时非空时将报错。
 
 配置示例片段如下，忽略 `id` 和 `metadata.timestamp` 字段，并放宽数字容差。
 
@@ -1041,6 +1042,15 @@ type JSONMatchStrategy string
       "id": true
     }
   }
+}
+```
+
+配置示例片段如下，只校验 actual 是否符合 JSON Schema，不继续对比 expected。
+
+```json
+{
+  "schema": "{\"type\":\"object\",\"required\":[\"name\"],\"properties\":{\"name\":{\"type\":\"string\"}},\"additionalProperties\":false}",
+  "matchStrategy": "skip"
 }
 ```
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1016,7 +1016,17 @@ type JSONCriterion struct {
 type JSONMatchStrategy string
 ```
 
-对比时 actual 是实际值，expected 是预期值。如果在代码中提供了 `Compare`，JSONCriterion 会直接使用自定义逻辑。未提供 `Compare` 时，`valid` 用于先校验 actual 是否是一段完整且严格合法的 JSON，`schema` 用于按 JSON Schema 校验 actual 的结构与字段约束，随后再按照 `matchStrategy` 决定是否执行内置 JSON 值匹配。当前 `matchStrategy` 支持 `exact` 与 `skip`，默认值为 `exact`；`exact` 表示按 JSON 结构精确匹配，`skip` 表示跳过内置 JSON 值匹配。因此，如果只希望做合法性校验或 Schema 校验、不希望继续比较 expected，应同时配置 `valid: true` 或 `schema`，并配置 `matchStrategy: "skip"`。对象对比要求键集合一致，数组对比要求长度一致且顺序一致。数字对比支持数值容差，默认值为 `1e-6`。`ignoreTree` 用于忽略不稳定字段，叶子节点为 true 表示忽略该字段及其子树。`onlyTree` 用于只对比指定字段，未出现在字段树中的字段将被忽略；叶子节点为 true 表示对比该字段及其子树。`onlyTree` 与 `ignoreTree` 不能同时配置。两者同时非空时将报错。
+对比时，`actual` 是实际值，`expected` 是预期值。JSONCriterion 的执行顺序如下：
+
+1. 如果在代码中提供了 `Compare`，直接使用自定义逻辑，不再执行内置的 `valid`、`schema` 与 `matchStrategy`。
+2. 未提供 `Compare` 时，先执行 `valid` 校验，再执行 `schema` 校验，最后根据 `matchStrategy` 决定是否执行内置 JSON 值匹配。
+3. 如果只希望做合法性校验或 Schema 校验、不希望继续比较 `expected`，应配置 `valid: true` 或 `schema`，并设置 `matchStrategy: "skip"`。
+
+`schema` 字段本身是序列化后的 JSON Schema 字符串。用于校验的 `actual` 按运行时值处理：`json.RawMessage` 与 `[]byte` 会先按原始 JSON 解析，普通 `string` 会作为已解码的字符串值校验。`schema` 为空时不执行 Schema 校验；schema 解析失败或 actual 校验失败都会返回 `(false, error)`。
+
+当前 `matchStrategy` 支持 `exact` 与 `skip`，默认值为 `exact`。`exact` 表示按 JSON 结构精确匹配，`skip` 表示跳过内置 JSON 值匹配。对象对比要求键集合一致，数组对比要求长度一致且顺序一致。数字对比支持数值容差，默认值为 `1e-6`。
+
+`ignoreTree` 用于忽略不稳定字段，叶子节点为 true 表示忽略该字段及其子树。`onlyTree` 用于只对比指定字段，未出现在字段树中的字段将被忽略；叶子节点为 true 表示对比该字段及其子树。`onlyTree` 与 `ignoreTree` 不能同时配置，两者同时非空时将报错。
 
 配置示例片段如下，忽略 `id` 和 `metadata.timestamp` 字段，并放宽数字容差。
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1008,7 +1008,7 @@ type JSONCriterion struct {
 	MatchStrategy   JSONMatchStrategy                        // MatchStrategy 表示匹配策略
 	NumberTolerance *float64                                 // NumberTolerance 表示数字容差
 	Valid           bool                                     // Valid 表示校验实际内容是否为合法 JSON。
-	Schema          string                                   // Schema 表示用于校验实际内容的 JSON Schema。
+	Schema          json.RawMessage                          // Schema 表示用于校验实际内容的 JSON Schema。
 	Compare         func(actual, expected any) (bool, error) // Compare 自定义比较逻辑
 }
 
@@ -1022,7 +1022,9 @@ type JSONMatchStrategy string
 2. 未提供 `Compare` 时，先执行 `valid` 校验，再执行 `schema` 校验，最后根据 `matchStrategy` 决定是否执行内置 JSON 值匹配。
 3. 如果只希望做合法性校验或 Schema 校验、不希望继续比较 `expected`，应配置 `valid: true` 或 `schema`，并设置 `matchStrategy: "skip"`。
 
-`schema` 字段本身是序列化后的 JSON Schema 字符串。用于校验的 `actual` 按运行时值处理：`json.RawMessage` 与 `[]byte` 会先按原始 JSON 解析，普通 `string` 会作为已解码的字符串值校验。`schema` 为空时不执行 Schema 校验；schema 解析失败或 actual 校验失败都会返回 `(false, error)`。
+`schema` 字段本身是 JSON Schema 的原始 JSON 值，通常为对象，也支持布尔 schema；在 metrics JSON 中直接写 JSON Schema，不需要再编码成字符串。代码中可通过 `WithSchema` 传入序列化后的 JSON Schema 文本。
+
+用于校验的 `actual` 按运行时值处理：`json.RawMessage` 与 `[]byte` 会先按原始 JSON 解析，普通 `string` 默认作为已解码的字符串值校验。当同时配置 `valid: true` 与 `schema` 时，schema 校验会复用 `valid` 已解析出的 JSON 值。`schema` 为空时不执行 Schema 校验；未声明 `$schema` 时按 Draft 2020-12 编译；schema 解析失败或 actual 校验失败都会返回 `(false, error)`。
 
 当前 `matchStrategy` 支持 `exact` 与 `skip`，默认值为 `exact`。`exact` 表示按 JSON 结构精确匹配，`skip` 表示跳过内置 JSON 值匹配。对象对比要求键集合一致，数组对比要求长度一致且顺序一致。数字对比支持数值容差，默认值为 `1e-6`。
 
@@ -1059,7 +1061,16 @@ type JSONMatchStrategy string
 
 ```json
 {
-  "schema": "{\"type\":\"object\",\"required\":[\"name\"],\"properties\":{\"name\":{\"type\":\"string\"}},\"additionalProperties\":false}",
+  "schema": {
+    "type": "object",
+    "required": ["name"],
+    "properties": {
+      "name": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
   "matchStrategy": "skip"
 }
 ```

--- a/evaluation/go.mod
+++ b/evaluation/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/neurosnap/sentences v1.1.2
 	github.com/panjf2000/ants/v2 v2.10.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.19.0
 	trpc.group/trpc-go/trpc-agent-go v0.8.0

--- a/evaluation/go.sum
+++ b/evaluation/go.sum
@@ -27,6 +27,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -82,6 +84,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -11,6 +11,7 @@ package clone
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -549,6 +550,7 @@ func TestCloneEvalMetric_DeepCopyKeepsAPIKeyAndDropsJudgeRunnerOptions(t *testin
 						"x": []any{"y"},
 					},
 					NumberTolerance: float64Ptr(0.1),
+					Schema:          json.RawMessage(`{"type":"object"}`),
 				},
 				Rouge: &criterionrouge.RougeCriterion{
 					RougeType: "rouge1",
@@ -607,6 +609,9 @@ func TestCloneEvalMetric_DeepCopyKeepsAPIKeyAndDropsJudgeRunnerOptions(t *testin
 
 	dst.Criterion.FinalResponse.JSON.IgnoreTree["a"].(map[string]any)["b"] = false
 	assert.Equal(t, true, src.Criterion.FinalResponse.JSON.IgnoreTree["a"].(map[string]any)["b"])
+
+	dst.Criterion.FinalResponse.JSON.Schema[2] = 'x'
+	assert.JSONEq(t, `{"type":"object"}`, string(src.Criterion.FinalResponse.JSON.Schema))
 
 	dst.Criterion.LLMJudge.Rubrics[0].Content.Text = "changed"
 	assert.Equal(t, "rubric", src.Criterion.LLMJudge.Rubrics[0].Content.Text)

--- a/evaluation/internal/clone/metric.go
+++ b/evaluation/internal/clone/metric.go
@@ -10,6 +10,8 @@
 package clone
 
 import (
+	"encoding/json"
+
 	criterionjson "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/json"
 	criterionlength "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/length"
 	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -147,6 +149,7 @@ func cloneJSONCriterion(src *criterionjson.JSONCriterion) (*criterionjson.JSONCr
 		copied.OnlyTree = onlyTree.(map[string]any)
 	}
 	copied.NumberTolerance = cloneFloat64Ptr(src.NumberTolerance)
+	copied.Schema = append(json.RawMessage(nil), src.Schema...)
 	return &copied, nil
 }
 

--- a/evaluation/metric/criterion/json/json.go
+++ b/evaluation/metric/criterion/json/json.go
@@ -11,6 +11,7 @@
 package json
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -145,11 +146,9 @@ func validateJSONSchema(actual any, schemaText string) error {
 func schemaValue(value any) (any, error) {
 	switch v := value.(type) {
 	case json.RawMessage:
-		return jsonschema.UnmarshalJSON(strings.NewReader(string(v)))
-	case string:
-		return jsonschema.UnmarshalJSON(strings.NewReader(v))
+		return jsonschema.UnmarshalJSON(bytes.NewReader(v))
 	case []byte:
-		return jsonschema.UnmarshalJSON(strings.NewReader(string(v)))
+		return jsonschema.UnmarshalJSON(bytes.NewReader(v))
 	default:
 		return value, nil
 	}

--- a/evaluation/metric/criterion/json/json.go
+++ b/evaluation/metric/criterion/json/json.go
@@ -17,6 +17,8 @@ import (
 	"math"
 	"reflect"
 	"strings"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // CompareFunc defines custom JSON comparison logic.
@@ -36,6 +38,8 @@ type JSONCriterion struct {
 	NumberTolerance *float64 `json:"numberTolerance,omitempty"`
 	// Valid validates raw JSON content when used by callers that receive unparsed content.
 	Valid bool `json:"valid,omitempty"`
+	// Schema validates actual JSON content against the provided JSON schema.
+	Schema string `json:"schema,omitempty"`
 	// CompareName selects a registered comparison implementation by name.
 	CompareName string `json:"compareName,omitempty"`
 	// Compare overrides default comparison when provided.
@@ -52,6 +56,8 @@ const (
 	JSONMatchStrategySkip JSONMatchStrategy = "skip"
 )
 
+const inlineSchemaResource = "schema.json"
+
 // New creates a new JSONCriterion with the provided options.
 func New(opt ...Option) *JSONCriterion {
 	opts := newOptions(opt...)
@@ -62,6 +68,7 @@ func New(opt ...Option) *JSONCriterion {
 		MatchStrategy:   opts.matchStrategy,
 		NumberTolerance: opts.numberTolerance,
 		Valid:           opts.valid,
+		Schema:          opts.schema,
 		CompareName:     opts.compareName,
 		Compare:         opts.compare,
 	}
@@ -81,6 +88,11 @@ func (j *JSONCriterion) Match(actual, expected any) (bool, error) {
 	if j.Valid {
 		if err := validateRawJSON(actual); err != nil {
 			return false, fmt.Errorf("parse actual raw json: %w", err)
+		}
+	}
+	if j.Schema != "" {
+		if err := validateJSONSchema(actual, j.Schema); err != nil {
+			return false, err
 		}
 	}
 	if j.MatchStrategy == JSONMatchStrategySkip {
@@ -103,6 +115,43 @@ func (j *JSONCriterion) Match(actual, expected any) (bool, error) {
 		return matchValueIgnoreTree(actual, expected, j.IgnoreTree, tolerance)
 	default:
 		return false, fmt.Errorf("invalid match strategy %s", j.MatchStrategy)
+	}
+}
+
+func validateJSONSchema(actual any, schemaText string) error {
+	schemaDoc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaText))
+	if err != nil {
+		return fmt.Errorf("parse json schema: %w", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft7)
+	if err := compiler.AddResource(inlineSchemaResource, schemaDoc); err != nil {
+		return fmt.Errorf("add json schema resource: %w", err)
+	}
+	schema, err := compiler.Compile(inlineSchemaResource)
+	if err != nil {
+		return fmt.Errorf("compile json schema: %w", err)
+	}
+	value, err := schemaValue(actual)
+	if err != nil {
+		return fmt.Errorf("parse actual raw json: %w", err)
+	}
+	if err := schema.Validate(value); err != nil {
+		return fmt.Errorf("json schema validation failed: %w", err)
+	}
+	return nil
+}
+
+func schemaValue(value any) (any, error) {
+	switch v := value.(type) {
+	case json.RawMessage:
+		return jsonschema.UnmarshalJSON(strings.NewReader(string(v)))
+	case string:
+		return jsonschema.UnmarshalJSON(strings.NewReader(v))
+	case []byte:
+		return jsonschema.UnmarshalJSON(strings.NewReader(string(v)))
+	default:
+		return value, nil
 	}
 }
 

--- a/evaluation/metric/criterion/json/json.go
+++ b/evaluation/metric/criterion/json/json.go
@@ -57,7 +57,7 @@ const (
 	JSONMatchStrategySkip JSONMatchStrategy = "skip"
 )
 
-const inlineSchemaResource = "schema.json"
+const inlineSchemaResource = "https://trpc.group/trpc-agent-go/evaluation/metric/criterion/json/schema.json"
 
 // New creates a new JSONCriterion with the provided options.
 func New(opt ...Option) *JSONCriterion {
@@ -172,14 +172,17 @@ func (j *JSONCriterion) normalizeInputs(actual, expected any) (any, any, error) 
 func rawJSONValue(value any) (any, error) {
 	switch v := value.(type) {
 	case json.RawMessage:
-		return parseRawJSON(v)
+		return jsonschema.UnmarshalJSON(bytes.NewReader(v))
 	case string:
-		return parseRawJSON(json.RawMessage(v))
+		return jsonschema.UnmarshalJSON(strings.NewReader(v))
 	case []byte:
-		return parseRawJSON(json.RawMessage(v))
+		return jsonschema.UnmarshalJSON(bytes.NewReader(v))
 	default:
-		_, err := json.Marshal(value)
-		return value, err
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		return jsonschema.UnmarshalJSON(bytes.NewReader(raw))
 	}
 }
 

--- a/evaluation/metric/criterion/json/json.go
+++ b/evaluation/metric/criterion/json/json.go
@@ -39,8 +39,8 @@ type JSONCriterion struct {
 	NumberTolerance *float64 `json:"numberTolerance,omitempty"`
 	// Valid validates raw JSON content when used by callers that receive unparsed content.
 	Valid bool `json:"valid,omitempty"`
-	// Schema validates actual JSON content against the provided JSON schema.
-	Schema string `json:"schema,omitempty"`
+	// Schema validates actual JSON content against the provided JSON Schema.
+	Schema json.RawMessage `json:"schema,omitempty"`
 	// CompareName selects a registered comparison implementation by name.
 	CompareName string `json:"compareName,omitempty"`
 	// Compare overrides default comparison when provided.
@@ -86,13 +86,16 @@ func (j *JSONCriterion) Match(actual, expected any) (bool, error) {
 	if j.Compare != nil {
 		return j.Compare(actual, expected)
 	}
+	actualForSchema := actual
 	if j.Valid {
-		if err := validateRawJSON(actual); err != nil {
+		var err error
+		actualForSchema, err = rawJSONValue(actual)
+		if err != nil {
 			return false, fmt.Errorf("parse actual raw json: %w", err)
 		}
 	}
-	if j.Schema != "" {
-		if err := validateJSONSchema(actual, j.Schema); err != nil {
+	if len(j.Schema) > 0 {
+		if err := validateJSONSchema(actualForSchema, j.Schema); err != nil {
 			return false, err
 		}
 	}
@@ -119,13 +122,13 @@ func (j *JSONCriterion) Match(actual, expected any) (bool, error) {
 	}
 }
 
-func validateJSONSchema(actual any, schemaText string) error {
-	schemaDoc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaText))
+func validateJSONSchema(actual any, schemaRaw json.RawMessage) error {
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaRaw))
 	if err != nil {
 		return fmt.Errorf("parse json schema: %w", err)
 	}
 	compiler := jsonschema.NewCompiler()
-	compiler.DefaultDraft(jsonschema.Draft7)
+	compiler.DefaultDraft(jsonschema.Draft2020)
 	if err := compiler.AddResource(inlineSchemaResource, schemaDoc); err != nil {
 		return fmt.Errorf("add json schema resource: %w", err)
 	}
@@ -166,20 +169,17 @@ func (j *JSONCriterion) normalizeInputs(actual, expected any) (any, any, error) 
 	return actualValue, expectedValue, nil
 }
 
-func validateRawJSON(value any) error {
+func rawJSONValue(value any) (any, error) {
 	switch v := value.(type) {
 	case json.RawMessage:
-		_, err := parseRawJSON(v)
-		return err
+		return parseRawJSON(v)
 	case string:
-		_, err := parseRawJSON(json.RawMessage(v))
-		return err
+		return parseRawJSON(json.RawMessage(v))
 	case []byte:
-		_, err := parseRawJSON(json.RawMessage(v))
-		return err
+		return parseRawJSON(json.RawMessage(v))
 	default:
 		_, err := json.Marshal(value)
-		return err
+		return value, err
 	}
 }
 

--- a/evaluation/metric/criterion/json/json_test.go
+++ b/evaluation/metric/criterion/json/json_test.go
@@ -124,6 +124,20 @@ func TestJSONCriterionSchemaValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "json schema validation failed")
 }
 
+func TestJSONCriterionSchemaValidationWithDecodedString(t *testing.T) {
+	criterion := &JSONCriterion{
+		Schema:        `{"type":"string"}`,
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match("Paris", nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match(float64(1), nil)
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "json schema validation failed")
+}
+
 func TestJSONCriterionSchemaRejectsInvalidSchema(t *testing.T) {
 	criterion := &JSONCriterion{Schema: `{`}
 	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))

--- a/evaluation/metric/criterion/json/json_test.go
+++ b/evaluation/metric/criterion/json/json_test.go
@@ -76,6 +76,7 @@ func TestJSONCriterionJSONRoundTrip(t *testing.T) {
 		WithMatchStrategy(JSONMatchStrategyExact),
 		WithNumberTolerance(tolerance),
 		WithValid(true),
+		WithSchema(`{"type":"object"}`),
 		WithCompareName("allow_delta"),
 	)
 	data, err := json.Marshal(criterion)
@@ -86,6 +87,7 @@ func TestJSONCriterionJSONRoundTrip(t *testing.T) {
 		"matchStrategy": "exact",
 		"numberTolerance": 0.001,
 		"valid": true,
+		"schema": "{\"type\":\"object\"}",
 		"compareName": "allow_delta"
 	}`, string(data))
 
@@ -95,10 +97,39 @@ func TestJSONCriterionJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, criterion.Ignore, decoded.Ignore)
 	assert.Equal(t, criterion.MatchStrategy, decoded.MatchStrategy)
 	assert.Equal(t, criterion.Valid, decoded.Valid)
+	assert.Equal(t, criterion.Schema, decoded.Schema)
 	assert.Equal(t, criterion.CompareName, decoded.CompareName)
 	if assert.NotNil(t, decoded.NumberTolerance) {
 		assert.Equal(t, tolerance, *decoded.NumberTolerance)
 	}
+}
+
+func TestJSONCriterionSchemaValidation(t *testing.T) {
+	criterion := &JSONCriterion{
+		Schema: `{
+			"type": "object",
+			"required": ["answer"],
+			"properties": {
+				"answer": { "type": "string" }
+			}
+		}`,
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match(json.RawMessage(`{"answer":123}`), json.RawMessage(`{}`))
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "json schema validation failed")
+}
+
+func TestJSONCriterionSchemaRejectsInvalidSchema(t *testing.T) {
+	criterion := &JSONCriterion{Schema: `{`}
+	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parse json schema")
 }
 
 func TestJSONCriterionMatchRawMessage(t *testing.T) {

--- a/evaluation/metric/criterion/json/json_test.go
+++ b/evaluation/metric/criterion/json/json_test.go
@@ -120,8 +120,7 @@ func TestJSONCriterionSchemaValidation(t *testing.T) {
 	assert.NoError(t, err)
 	ok, err = criterion.Match(json.RawMessage(`{"answer":123}`), json.RawMessage(`{}`))
 	assert.False(t, ok)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "json schema validation failed")
+	assert.ErrorContains(t, err, "json schema validation failed")
 }
 
 func TestJSONCriterionSchemaValidationWithDecodedString(t *testing.T) {
@@ -134,8 +133,7 @@ func TestJSONCriterionSchemaValidationWithDecodedString(t *testing.T) {
 	assert.NoError(t, err)
 	ok, err = criterion.Match(float64(1), nil)
 	assert.False(t, ok)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "json schema validation failed")
+	assert.ErrorContains(t, err, "json schema validation failed")
 }
 
 func TestJSONCriterionSchemaValidationWithRawBytes(t *testing.T) {
@@ -152,26 +150,26 @@ func TestJSONCriterionSchemaValidationWithRawBytes(t *testing.T) {
 	ok, err := criterion.Match([]byte(`{"answer":"Paris"}`), nil)
 	assert.True(t, ok)
 	assert.NoError(t, err)
+	ok, err = criterion.Match([]byte(`{"answer":123}`), nil)
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "json schema validation failed")
 	ok, err = criterion.Match([]byte(`not json`), nil)
 	assert.False(t, ok)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parse actual raw json")
+	assert.ErrorContains(t, err, "parse actual raw json")
 }
 
 func TestJSONCriterionSchemaRejectsInvalidSchema(t *testing.T) {
 	criterion := &JSONCriterion{Schema: `{`}
 	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))
 	assert.False(t, ok)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "parse json schema")
+	assert.ErrorContains(t, err, "parse json schema")
 }
 
 func TestJSONCriterionSchemaRejectsInvalidSchemaKeyword(t *testing.T) {
 	criterion := &JSONCriterion{Schema: `{"type":123}`}
 	ok, err := criterion.Match(map[string]any{}, nil)
 	assert.False(t, ok)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "compile json schema")
+	assert.ErrorContains(t, err, "compile json schema")
 }
 
 func TestJSONCriterionMatchRawMessage(t *testing.T) {

--- a/evaluation/metric/criterion/json/json_test.go
+++ b/evaluation/metric/criterion/json/json_test.go
@@ -12,6 +12,7 @@ package json
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,6 +173,44 @@ func TestJSONCriterionValidAndSchemaUseSameParsedValue(t *testing.T) {
 	assert.ErrorContains(t, err, "parse actual raw json")
 }
 
+func TestJSONCriterionValidAndSchemaPreservesLargeNumbers(t *testing.T) {
+	criterion := &JSONCriterion{
+		Valid:         true,
+		Schema:        json.RawMessage(`{"const":9007199254740993}`),
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match(`9007199254740993`, nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match(`9007199254740992`, nil)
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "json schema validation failed")
+}
+
+func TestJSONCriterionValidAndSchemaCanonicalizesGoValues(t *testing.T) {
+	type namedMap map[string]string
+	type answerStruct struct {
+		Answer string `json:"answer"`
+	}
+	criterion := &JSONCriterion{
+		Valid: true,
+		Schema: json.RawMessage(`{
+			"type": "object",
+			"required": ["answer"],
+			"properties": {
+				"answer": { "const": "Paris" }
+			}
+		}`),
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match(namedMap{"answer": "Paris"}, nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match(answerStruct{Answer: "Paris"}, nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}
+
 func TestJSONCriterionSchemaUsesDraft2020ByDefault(t *testing.T) {
 	criterion := &JSONCriterion{
 		Schema:        json.RawMessage(`{"type":"array","prefixItems":[{"type":"string"}]}`),
@@ -197,6 +236,8 @@ func TestJSONCriterionSchemaRejectsInvalidSchemaKeyword(t *testing.T) {
 	ok, err := criterion.Match(map[string]any{}, nil)
 	assert.False(t, ok)
 	assert.ErrorContains(t, err, "compile json schema")
+	assert.Contains(t, fmt.Sprint(err), inlineSchemaResource)
+	assert.NotContains(t, fmt.Sprint(err), "file://")
 }
 
 func TestJSONCriterionMatchRawMessage(t *testing.T) {

--- a/evaluation/metric/criterion/json/json_test.go
+++ b/evaluation/metric/criterion/json/json_test.go
@@ -87,7 +87,7 @@ func TestJSONCriterionJSONRoundTrip(t *testing.T) {
 		"matchStrategy": "exact",
 		"numberTolerance": 0.001,
 		"valid": true,
-		"schema": "{\"type\":\"object\"}",
+		"schema": {"type":"object"},
 		"compareName": "allow_delta"
 	}`, string(data))
 
@@ -97,7 +97,7 @@ func TestJSONCriterionJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, criterion.Ignore, decoded.Ignore)
 	assert.Equal(t, criterion.MatchStrategy, decoded.MatchStrategy)
 	assert.Equal(t, criterion.Valid, decoded.Valid)
-	assert.Equal(t, criterion.Schema, decoded.Schema)
+	assert.JSONEq(t, string(criterion.Schema), string(decoded.Schema))
 	assert.Equal(t, criterion.CompareName, decoded.CompareName)
 	if assert.NotNil(t, decoded.NumberTolerance) {
 		assert.Equal(t, tolerance, *decoded.NumberTolerance)
@@ -106,13 +106,13 @@ func TestJSONCriterionJSONRoundTrip(t *testing.T) {
 
 func TestJSONCriterionSchemaValidation(t *testing.T) {
 	criterion := &JSONCriterion{
-		Schema: `{
+		Schema: json.RawMessage(`{
 			"type": "object",
 			"required": ["answer"],
 			"properties": {
 				"answer": { "type": "string" }
 			}
-		}`,
+		}`),
 		MatchStrategy: JSONMatchStrategySkip,
 	}
 	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))
@@ -125,7 +125,7 @@ func TestJSONCriterionSchemaValidation(t *testing.T) {
 
 func TestJSONCriterionSchemaValidationWithDecodedString(t *testing.T) {
 	criterion := &JSONCriterion{
-		Schema:        `{"type":"string"}`,
+		Schema:        json.RawMessage(`{"type":"string"}`),
 		MatchStrategy: JSONMatchStrategySkip,
 	}
 	ok, err := criterion.Match("Paris", nil)
@@ -138,13 +138,13 @@ func TestJSONCriterionSchemaValidationWithDecodedString(t *testing.T) {
 
 func TestJSONCriterionSchemaValidationWithRawBytes(t *testing.T) {
 	criterion := &JSONCriterion{
-		Schema: `{
+		Schema: json.RawMessage(`{
 			"type": "object",
 			"required": ["answer"],
 			"properties": {
 				"answer": { "type": "string" }
 			}
-		}`,
+		}`),
 		MatchStrategy: JSONMatchStrategySkip,
 	}
 	ok, err := criterion.Match([]byte(`{"answer":"Paris"}`), nil)
@@ -158,15 +158,42 @@ func TestJSONCriterionSchemaValidationWithRawBytes(t *testing.T) {
 	assert.ErrorContains(t, err, "parse actual raw json")
 }
 
+func TestJSONCriterionValidAndSchemaUseSameParsedValue(t *testing.T) {
+	criterion := &JSONCriterion{
+		Valid:         true,
+		Schema:        json.RawMessage(`{"const":"Paris"}`),
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match(`"Paris"`, nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match(`Paris`, nil)
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "parse actual raw json")
+}
+
+func TestJSONCriterionSchemaUsesDraft2020ByDefault(t *testing.T) {
+	criterion := &JSONCriterion{
+		Schema:        json.RawMessage(`{"type":"array","prefixItems":[{"type":"string"}]}`),
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match(json.RawMessage(`["Paris"]`), nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match(json.RawMessage(`[1]`), nil)
+	assert.False(t, ok)
+	assert.ErrorContains(t, err, "json schema validation failed")
+}
+
 func TestJSONCriterionSchemaRejectsInvalidSchema(t *testing.T) {
-	criterion := &JSONCriterion{Schema: `{`}
+	criterion := &JSONCriterion{Schema: json.RawMessage(`{`)}
 	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))
 	assert.False(t, ok)
 	assert.ErrorContains(t, err, "parse json schema")
 }
 
 func TestJSONCriterionSchemaRejectsInvalidSchemaKeyword(t *testing.T) {
-	criterion := &JSONCriterion{Schema: `{"type":123}`}
+	criterion := &JSONCriterion{Schema: json.RawMessage(`{"type":123}`)}
 	ok, err := criterion.Match(map[string]any{}, nil)
 	assert.False(t, ok)
 	assert.ErrorContains(t, err, "compile json schema")

--- a/evaluation/metric/criterion/json/json_test.go
+++ b/evaluation/metric/criterion/json/json_test.go
@@ -138,12 +138,40 @@ func TestJSONCriterionSchemaValidationWithDecodedString(t *testing.T) {
 	assert.Contains(t, err.Error(), "json schema validation failed")
 }
 
+func TestJSONCriterionSchemaValidationWithRawBytes(t *testing.T) {
+	criterion := &JSONCriterion{
+		Schema: `{
+			"type": "object",
+			"required": ["answer"],
+			"properties": {
+				"answer": { "type": "string" }
+			}
+		}`,
+		MatchStrategy: JSONMatchStrategySkip,
+	}
+	ok, err := criterion.Match([]byte(`{"answer":"Paris"}`), nil)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	ok, err = criterion.Match([]byte(`not json`), nil)
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parse actual raw json")
+}
+
 func TestJSONCriterionSchemaRejectsInvalidSchema(t *testing.T) {
 	criterion := &JSONCriterion{Schema: `{`}
 	ok, err := criterion.Match(json.RawMessage(`{"answer":"Paris"}`), json.RawMessage(`{}`))
 	assert.False(t, ok)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "parse json schema")
+}
+
+func TestJSONCriterionSchemaRejectsInvalidSchemaKeyword(t *testing.T) {
+	criterion := &JSONCriterion{Schema: `{"type":123}`}
+	ok, err := criterion.Match(map[string]any{}, nil)
+	assert.False(t, ok)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "compile json schema")
 }
 
 func TestJSONCriterionMatchRawMessage(t *testing.T) {

--- a/evaluation/metric/criterion/json/options.go
+++ b/evaluation/metric/criterion/json/options.go
@@ -20,6 +20,7 @@ type options struct {
 	matchStrategy   JSONMatchStrategy
 	numberTolerance *float64
 	valid           bool
+	schema          string
 	compareName     string
 	compare         CompareFunc
 }
@@ -75,6 +76,13 @@ func WithNumberTolerance(tolerance float64) Option {
 func WithValid(valid bool) Option {
 	return func(o *options) {
 		o.valid = valid
+	}
+}
+
+// WithSchema sets the JSON schema.
+func WithSchema(schema string) Option {
+	return func(o *options) {
+		o.schema = schema
 	}
 }
 

--- a/evaluation/metric/criterion/json/options.go
+++ b/evaluation/metric/criterion/json/options.go
@@ -9,6 +9,8 @@
 
 package json
 
+import "encoding/json"
+
 // defaultNumberTolerance is the default number tolerance.
 const defaultNumberTolerance = 1e-6
 
@@ -20,7 +22,7 @@ type options struct {
 	matchStrategy   JSONMatchStrategy
 	numberTolerance *float64
 	valid           bool
-	schema          string
+	schema          json.RawMessage
 	compareName     string
 	compare         CompareFunc
 }
@@ -79,10 +81,10 @@ func WithValid(valid bool) Option {
 	}
 }
 
-// WithSchema sets the JSON schema.
+// WithSchema sets the JSON Schema from serialized JSON text.
 func WithSchema(schema string) Option {
 	return func(o *options) {
-		o.schema = schema
+		o.schema = json.RawMessage(schema)
 	}
 }
 

--- a/evaluation/metric/criterion/json/options_test.go
+++ b/evaluation/metric/criterion/json/options_test.go
@@ -27,10 +27,11 @@ func TestWithNumberTolerance(t *testing.T) {
 }
 
 func TestWithIgnoreAndMatchStrategy(t *testing.T) {
-	opts := newOptions(WithIgnore(true), WithMatchStrategy(JSONMatchStrategyExact), WithValid(true))
+	opts := newOptions(WithIgnore(true), WithMatchStrategy(JSONMatchStrategyExact), WithValid(true), WithSchema(`{"type":"object"}`))
 	assert.True(t, opts.ignore)
 	assert.Equal(t, JSONMatchStrategyExact, opts.matchStrategy)
 	assert.True(t, opts.valid)
+	assert.Equal(t, `{"type":"object"}`, opts.schema)
 }
 
 func TestWithIgnoreTreeAndCompare(t *testing.T) {

--- a/evaluation/metric/criterion/json/options_test.go
+++ b/evaluation/metric/criterion/json/options_test.go
@@ -31,7 +31,7 @@ func TestWithIgnoreAndMatchStrategy(t *testing.T) {
 	assert.True(t, opts.ignore)
 	assert.Equal(t, JSONMatchStrategyExact, opts.matchStrategy)
 	assert.True(t, opts.valid)
-	assert.Equal(t, `{"type":"object"}`, opts.schema)
+	assert.JSONEq(t, `{"type":"object"}`, string(opts.schema))
 }
 
 func TestWithIgnoreTreeAndCompare(t *testing.T) {

--- a/examples/evaluation/go.mod
+++ b/examples/evaluation/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/panjf2000/ants/v2 v2.10.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/examples/evaluation/go.sum
+++ b/examples/evaluation/go.sum
@@ -27,6 +27,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -103,6 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/runner/bestofn/go.mod
+++ b/runner/bestofn/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/openai/openai-go v1.12.0 // indirect
 	github.com/panjf2000/ants/v2 v2.10.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/runner/bestofn/go.sum
+++ b/runner/bestofn/go.sum
@@ -23,6 +23,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -75,6 +77,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/server/evaluation/go.mod
+++ b/server/evaluation/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/panjf2000/ants/v2 v2.10.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/server/evaluation/go.sum
+++ b/server/evaluation/go.sum
@@ -23,6 +23,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -93,6 +95,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/server/promptiter/go.mod
+++ b/server/promptiter/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/openai/openai-go v1.12.0 // indirect
 	github.com/panjf2000/ants/v2 v2.10.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/server/promptiter/go.sum
+++ b/server/promptiter/go.sum
@@ -23,6 +23,8 @@ github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfv
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -75,6 +77,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
Adds JSON schema validation to JSONCriterion so evaluation metrics can validate raw actual JSON before applying existing match strategies.