### PR TITLE
{evaluation, docs, examples}: add extension metadata

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -865,7 +865,7 @@ type Criterion struct {
 }
 ```
 
-`metricName` selects the evaluator implementation from Registry. The following evaluators are built in by default:
+`metricName` selects the evaluator implementation from Registry and identifies the metric in results. The following evaluators are built in by default:
 
 - `tool_trajectory_avg_score`: tool trajectory consistency evaluator, requires expected output.
 - `final_response_avg_score`: final response evaluator, does not require LLM, requires expected output.
@@ -2871,14 +2871,13 @@ agentEvaluator, err := evaluation.New(
 
 #### Custom Evaluators
 
-When built-in evaluators do not cover a business rule, implement `evaluator.Evaluator` and register it in Registry. A metric file uses `evaluatorName` to select the evaluator implementation, while `metricName` remains the metric instance name shown in results. If the evaluator needs extra configuration, put it in `extension` and read it from the custom evaluator.
+When built-in evaluators do not cover a business rule, implement `evaluator.Evaluator` and register it in Registry. A metric file uses `metricName` to select the evaluator implementation and to identify the metric in results. If the evaluator needs extra configuration, put it in `extension` and read it from the custom evaluator.
 
 Example metric configuration:
 
 ```json
 {
   "metricName": "support_response_policy",
-  "evaluatorName": "response_policy",
   "threshold": 1,
   "extension": {
     "requiredPhrase": "support"
@@ -2890,7 +2889,7 @@ Example wiring:
 
 ```go
 reg := registry.New()
-if err := reg.Register("response_policy", responsePolicyEvaluator{}); err != nil {
+if err := reg.Register("support_response_policy", responsePolicyEvaluator{}); err != nil {
 	log.Fatalf("register evaluator: %v", err)
 }
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -854,6 +854,7 @@ type EvalMetric struct {
 	EvaluatorName string               // EvaluatorName is an optional evaluator implementation name.
 	Threshold     float64              // Threshold is the threshold value.
 	Criterion     *criterion.Criterion // Criterion is the evaluation criteria.
+	Extension     any                  // Extension is caller-defined metadata.
 }
 
 // Criterion represents a collection of evaluation criteria.
@@ -878,6 +879,8 @@ type Criterion struct {
 - `llm_rubric_knowledge_recall`: LLM rubric knowledge recall evaluator, requires EvalSet to provide session input and LLMJudge plus rubrics.
 
 `threshold` defines the threshold. Evaluators output a `score` and determine pass or fail based on it. The definition of `score` varies slightly across evaluators, but a common approach is to compute scores per Invocation and aggregate them into an overall score. Under the same EvalSet, `metricName` must be unique. The order of metrics in the file also affects the evaluation execution order and result display order.
+
+`extension` carries caller-defined metadata for an evaluation metric, such as platform-side weights, grouping, or display configuration. The framework only reads, stores, and passes this field with `EvalMetric`; it does not interpret its business meaning or guarantee deep-copy semantics for its contents. Custom evaluators, platform logic, or custom aggregation logic can read it when needed.
 
 Below is an example metric file for tool trajectory.
 
@@ -2865,6 +2868,40 @@ agentEvaluator, err := evaluation.New(
 	evaluation.WithRegistry(reg),
 )
 ```
+
+#### Custom Evaluators
+
+When built-in evaluators do not cover a business rule, implement `evaluator.Evaluator` and register it in Registry. A metric file uses `evaluatorName` to select the evaluator implementation, while `metricName` remains the metric instance name shown in results. If the evaluator needs extra configuration, put it in `extension` and read it from the custom evaluator.
+
+Example metric configuration:
+
+```json
+{
+  "metricName": "support_response_policy",
+  "evaluatorName": "response_policy",
+  "threshold": 1,
+  "extension": {
+    "requiredPhrase": "support"
+  }
+}
+```
+
+Example wiring:
+
+```go
+reg := registry.New()
+if err := reg.Register("response_policy", responsePolicyEvaluator{}); err != nil {
+	log.Fatalf("register evaluator: %v", err)
+}
+
+agentEvaluator, err := evaluation.New(
+	appName,
+	runner,
+	evaluation.WithRegistry(reg),
+)
+```
+
+For a complete runnable example, see [examples/evaluation/metricextension](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/metricextension).
 
 ### EvalResult
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -866,7 +866,7 @@ type Criterion struct {
 }
 ```
 
-`metricName` 默认用于从 Registry 选择评估器实现，常见内置评估器如下：
+`metricName` 用于从 Registry 选择评估器实现，并作为结果中的指标标识。常见内置评估器如下：
 
 - `tool_trajectory_avg_score`：工具轨迹一致性评估器，需要配置预期输出。
 - `final_response_avg_score`：最终响应评估器，不需要 LLM，需要配置预期输出。
@@ -2869,14 +2869,13 @@ agentEvaluator, err := evaluation.New(
 
 #### 自定义评估器
 
-当内置评估器不能覆盖业务规则时，可以实现 `evaluator.Evaluator` 并注册到 Registry。指标文件通过 `evaluatorName` 选择评估器实现，`metricName` 仍作为结果中的指标实例名；如果评估器需要额外配置，可以放在 `extension` 中，由自定义评估器自行读取。
+当内置评估器不能覆盖业务规则时，可以实现 `evaluator.Evaluator` 并注册到 Registry。指标文件通过 `metricName` 选择评估器实现，并把它作为结果中的指标标识。如果评估器需要额外配置，可以放在 `extension` 中，由自定义评估器自行读取。
 
 指标配置示例：
 
 ```json
 {
   "metricName": "support_response_policy",
-  "evaluatorName": "response_policy",
   "threshold": 1,
   "extension": {
     "requiredPhrase": "support"
@@ -2888,7 +2887,7 @@ agentEvaluator, err := evaluation.New(
 
 ```go
 reg := registry.New()
-if err := reg.Register("response_policy", responsePolicyEvaluator{}); err != nil {
+if err := reg.Register("support_response_policy", responsePolicyEvaluator{}); err != nil {
 	log.Fatalf("register evaluator: %v", err)
 }
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -855,6 +855,7 @@ type EvalMetric struct {
 	EvaluatorName string               // EvaluatorName 是评估器实现名，可选
 	Threshold     float64              // Threshold 是阈值
 	Criterion     *criterion.Criterion // Criterion 是评估准则
+	Extension     any                  // Extension 是调用方自定义元数据
 }
 
 // Criterion 表示评估准则集合
@@ -879,6 +880,8 @@ type Criterion struct {
 - `llm_rubric_knowledge_recall`：LLM rubric 知识召回评估器，需要评估集提供会话输入并配置 LLMJudge 和评估细则 rubrics。
 
 `metricName` 需要在同一份指标文件中保持唯一，因为它同时作为结果中的指标标识。`threshold` 用于定义阈值，评估器会输出 `score` 并据此判断通过或失败。不同评估器对 `score` 的定义略有差异，但常见做法是对每轮 Invocation 计算分数，再对多轮结果做聚合得到整体分数。指标文件的数组顺序也会影响评估执行顺序与结果展示顺序。
+
+`extension` 用于携带调用方自定义的评估指标元数据，例如平台侧的权重、分组或展示配置。框架只负责随 `EvalMetric` 读取、存储和传递该字段，不解释其中的业务语义，也不承诺对其内容做深拷贝；自定义评估器、平台逻辑或自定义聚合逻辑可以按需读取。
 
 下面给出一个工具轨迹指标文件示例。
 
@@ -2863,6 +2866,40 @@ agentEvaluator, err := evaluation.New(
 	evaluation.WithRegistry(reg),
 )
 ```
+
+#### 自定义评估器
+
+当内置评估器不能覆盖业务规则时，可以实现 `evaluator.Evaluator` 并注册到 Registry。指标文件通过 `evaluatorName` 选择评估器实现，`metricName` 仍作为结果中的指标实例名；如果评估器需要额外配置，可以放在 `extension` 中，由自定义评估器自行读取。
+
+指标配置示例：
+
+```json
+{
+  "metricName": "support_response_policy",
+  "evaluatorName": "response_policy",
+  "threshold": 1,
+  "extension": {
+    "requiredPhrase": "support"
+  }
+}
+```
+
+代码接入示例：
+
+```go
+reg := registry.New()
+if err := reg.Register("response_policy", responsePolicyEvaluator{}); err != nil {
+	log.Fatalf("register evaluator: %v", err)
+}
+
+agentEvaluator, err := evaluation.New(
+	appName,
+	runner,
+	evaluation.WithRegistry(reg),
+)
+```
+
+完整可运行示例参见 [examples/evaluation/metricextension](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/metricextension)。
 
 ### 评估结果 EvalResult
 

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -80,6 +80,19 @@ func TestCloneEvalMetric_NilInput(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+func TestCloneEvalMetric_AssignsExtensionAsIs(t *testing.T) {
+	extension := map[string]any{"weight": 0.7}
+	src := &metric.EvalMetric{
+		MetricName: "metric-1",
+		Extension:  extension,
+	}
+	dst, err := CloneEvalMetric(src)
+	require.NoError(t, err)
+	require.NotNil(t, dst)
+	dst.Extension.(map[string]any)["weight"] = 0.3
+	assert.Equal(t, 0.3, src.Extension.(map[string]any)["weight"])
+}
+
 func TestCloneEvalMetric_DeepCopiesJudgeTemplate(t *testing.T) {
 	src := &metric.EvalMetric{
 		MetricName:    "metric-1",

--- a/evaluation/internal/clone/metric.go
+++ b/evaluation/internal/clone/metric.go
@@ -31,6 +31,7 @@ func CloneEvalMetric(src *metric.EvalMetric) (*metric.EvalMetric, error) {
 		return nil, errNilInput("eval metric")
 	}
 	copied := *src
+	// Extension is intentionally assigned as-is because callers own its clone semantics.
 	clonedCriterion, err := cloneCriterion(src.Criterion)
 	if err != nil {
 		return nil, err

--- a/evaluation/metric/metric.go
+++ b/evaluation/metric/metric.go
@@ -22,6 +22,7 @@ type EvalMetric struct {
 	EvaluatorName string               `json:"evaluatorName,omitempty"` // EvaluatorName routes to the evaluator implementation.
 	Threshold     float64              `json:"threshold,omitempty"`     // Threshold value for this metric.
 	Criterion     *criterion.Criterion `json:"criterion,omitempty"`     // Evaluation criterion used by the metric.
+	Extension     any                  `json:"extension,omitempty"`     // Extension stores caller-defined metadata for this metric.
 }
 
 // Manager defines the interface for managing evaluation metrics.

--- a/evaluation/metric/metric_test.go
+++ b/evaluation/metric/metric_test.go
@@ -20,17 +20,22 @@ func TestEvalMetricJSONMarshalling(t *testing.T) {
 	metric := &EvalMetric{
 		MetricName: "accuracy",
 		Threshold:  0.8,
+		Extension: map[string]any{
+			"caseThreshold": 0.7,
+			"weight":        0.3,
+		},
 	}
 
 	data, err := json.Marshal(metric)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"metricName":"accuracy","threshold":0.8}`, string(data))
+	assert.JSONEq(t, `{"metricName":"accuracy","threshold":0.8,"extension":{"caseThreshold":0.7,"weight":0.3}}`, string(data))
 
 	var decoded EvalMetric
 	err = json.Unmarshal(data, &decoded)
 	assert.NoError(t, err)
 	assert.Equal(t, metric.MetricName, decoded.MetricName)
 	assert.Equal(t, metric.Threshold, decoded.Threshold)
+	assert.Equal(t, map[string]any{"caseThreshold": 0.7, "weight": 0.3}, decoded.Extension)
 }
 
 func TestEvalMetricJSONOmitEmpty(t *testing.T) {

--- a/examples/evaluation/metricextension/README.md
+++ b/examples/evaluation/metricextension/README.md
@@ -1,0 +1,70 @@
+# Metric Extension Evaluation Example
+
+This example shows how a custom evaluator can read caller-defined settings from `metric.EvalMetric.Extension`.
+
+It uses local file managers and a real LLM support agent.
+
+## What It Demonstrates
+
+- Registering a custom evaluator in `evaluation/evaluator/registry`.
+- Routing a metric instance to that evaluator with `EvaluatorName`.
+- Storing evaluator-specific policy settings in `EvalMetric.Extension`.
+- Returning normal metric `Score` and `Status` from the evaluator.
+
+## Run
+
+Configure the OpenAI-compatible model service first.
+
+```bash
+export OPENAI_API_KEY="sk-..."
+# Optional. Defaults to https://api.openai.com/v1 when not set.
+export OPENAI_BASE_URL="https://api.openai.com/v1"
+```
+
+```bash
+cd examples/evaluation/metricextension
+go run . \
+  -model "deepseek-v4-flash" \
+  -data-dir "./data" \
+  -output-dir "./output" \
+  -eval-set "support-policy-basic" \
+  -runs 1
+```
+
+## Key Metric Configuration
+
+```json
+{
+  "metricName": "support_response_policy",
+  "evaluatorName": "response_policy",
+  "threshold": 1,
+  "extension": {
+    "requiredPhrase": "support"
+  }
+}
+```
+
+`MetricName` is the metric instance name shown in results. `EvaluatorName` selects the evaluator implementation. The custom evaluator reads `requiredPhrase` from `EvalMetric.Extension` and checks whether the final response contains it.
+
+## Data Layout
+
+```shell
+data/
+└── metric-extension-app/
+    ├── support-policy-basic.evalset.json
+    └── support-policy-basic.metrics.json
+```
+
+## Output
+
+```log
+Evaluation completed with metric extension
+App: metric-extension-app
+Eval Set: support-policy-basic
+Overall Status: passed
+Runs: 1
+Case sign_in_help -> passed
+  Metric support_response_policy: score 1.00 (threshold 1.00) => passed
+
+Results saved under: ./output
+```

--- a/examples/evaluation/metricextension/README.md
+++ b/examples/evaluation/metricextension/README.md
@@ -7,7 +7,7 @@ It uses local file managers and a real LLM support agent.
 ## What It Demonstrates
 
 - Registering a custom evaluator in `evaluation/evaluator/registry`.
-- Routing a metric instance to that evaluator with `EvaluatorName`.
+- Routing a metric instance to that evaluator with `MetricName`.
 - Storing evaluator-specific policy settings in `EvalMetric.Extension`.
 - Returning normal metric `Score` and `Status` from the evaluator.
 
@@ -17,8 +17,7 @@ Configure the OpenAI-compatible model service first.
 
 ```bash
 export OPENAI_API_KEY="sk-..."
-# Optional. Defaults to https://api.openai.com/v1 when not set.
-export OPENAI_BASE_URL="https://api.openai.com/v1"
+export OPENAI_BASE_URL="https://api.deepseek.com/v1"
 ```
 
 ```bash
@@ -36,7 +35,6 @@ go run . \
 ```json
 {
   "metricName": "support_response_policy",
-  "evaluatorName": "response_policy",
   "threshold": 1,
   "extension": {
     "requiredPhrase": "support"
@@ -44,7 +42,7 @@ go run . \
 }
 ```
 
-`MetricName` is the metric instance name shown in results. `EvaluatorName` selects the evaluator implementation. The custom evaluator reads `requiredPhrase` from `EvalMetric.Extension` and checks whether the final response contains it.
+`MetricName` selects the evaluator implementation from Registry and is also the metric name shown in results. The custom evaluator reads `requiredPhrase` from `EvalMetric.Extension` and checks whether the final response contains it.
 
 ## Data Layout
 

--- a/examples/evaluation/metricextension/agent.go
+++ b/examples/evaluation/metricextension/agent.go
@@ -1,0 +1,44 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+func newSupportAgent(modelName string, stream bool) agent.Agent {
+	genCfg := model.GenerationConfig{
+		MaxTokens:   intPtr(256),
+		Temperature: floatPtr(0.0),
+		Stream:      stream,
+	}
+	return llmagent.New(
+		supportAgentName,
+		llmagent.WithModel(openai.New(modelName)),
+		llmagent.WithInstruction(""+
+			"You are a support assistant.\n"+
+			"Answer the user in one concise sentence.\n"+
+			"Every answer must include these exact lowercase words: please, support, help.\n"+
+			"Do not say 'cannot help' or \"can't help\"."),
+		llmagent.WithDescription("Support agent demonstrating metric extension evaluation."),
+		llmagent.WithGenerationConfig(genCfg),
+	)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/examples/evaluation/metricextension/data/metric-extension-app/support-policy-basic.evalset.json
+++ b/examples/evaluation/metricextension/data/metric-extension-app/support-policy-basic.evalset.json
@@ -1,0 +1,26 @@
+{
+  "evalSetId": "support-policy-basic",
+  "name": "support-policy-basic",
+  "evalCases": [
+    {
+      "evalId": "sign_in_help",
+      "conversation": [
+        {
+          "invocationId": "sign_in_help-1",
+          "userContent": {
+            "role": "user",
+            "content": "I cannot sign in to my workspace."
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Please open a support ticket with your workspace ID so support can help check the account status."
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "metric-extension-app",
+        "userId": "user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/metricextension/data/metric-extension-app/support-policy-basic.metrics.json
+++ b/examples/evaluation/metricextension/data/metric-extension-app/support-policy-basic.metrics.json
@@ -1,0 +1,10 @@
+[
+  {
+    "metricName": "support_response_policy",
+    "evaluatorName": "response_policy",
+    "threshold": 1,
+    "extension": {
+      "requiredPhrase": "support"
+    }
+  }
+]

--- a/examples/evaluation/metricextension/data/metric-extension-app/support-policy-basic.metrics.json
+++ b/examples/evaluation/metricextension/data/metric-extension-app/support-policy-basic.metrics.json
@@ -1,7 +1,6 @@
 [
   {
     "metricName": "support_response_policy",
-    "evaluatorName": "response_policy",
     "threshold": 1,
     "extension": {
       "requiredPhrase": "support"

--- a/examples/evaluation/metricextension/evaluate.go
+++ b/examples/evaluation/metricextension/evaluate.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -31,8 +32,14 @@ func (responsePolicyEvaluator) Description() string {
 
 func (responsePolicyEvaluator) Evaluate(_ context.Context, actuals, _ []*evalset.Invocation,
 	evalMetric *metric.EvalMetric) (*evaluator.EvaluateResult, error) {
-	extension, _ := evalMetric.Extension.(map[string]any)
-	requiredPhrase, _ := extension["requiredPhrase"].(string)
+	extension, ok := evalMetric.Extension.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("extension must be an object")
+	}
+	requiredPhrase, ok := extension["requiredPhrase"].(string)
+	if !ok || requiredPhrase == "" {
+		return nil, fmt.Errorf("extension.requiredPhrase must be a non-empty string")
+	}
 	requiredPhrase = strings.ToLower(requiredPhrase)
 	results := make([]*evaluator.PerInvocationResult, 0, len(actuals))
 	overallScore := 0.0

--- a/examples/evaluation/metricextension/evaluate.go
+++ b/examples/evaluation/metricextension/evaluate.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type responsePolicyEvaluator struct{}
+
+func (responsePolicyEvaluator) Name() string {
+	return responsePolicyEvaluatorName
+}
+
+func (responsePolicyEvaluator) Description() string {
+	return "Evaluates final responses using response policy settings from metric extension."
+}
+
+func (responsePolicyEvaluator) Evaluate(_ context.Context, actuals, _ []*evalset.Invocation,
+	evalMetric *metric.EvalMetric) (*evaluator.EvaluateResult, error) {
+	extension, _ := evalMetric.Extension.(map[string]any)
+	requiredPhrase, _ := extension["requiredPhrase"].(string)
+	requiredPhrase = strings.ToLower(requiredPhrase)
+	results := make([]*evaluator.PerInvocationResult, 0, len(actuals))
+	overallScore := 0.0
+	for _, actual := range actuals {
+		content := ""
+		if actual != nil && actual.FinalResponse != nil {
+			content = actual.FinalResponse.Content
+		}
+		score := 0.0
+		if strings.Contains(strings.ToLower(content), requiredPhrase) {
+			score = 1
+		}
+		invocationStatus := status.EvalStatusFailed
+		if score >= evalMetric.Threshold {
+			invocationStatus = status.EvalStatusPassed
+		}
+		results = append(results, &evaluator.PerInvocationResult{
+			Score:  score,
+			Status: invocationStatus,
+		})
+		overallScore += score
+	}
+	if len(results) > 0 {
+		overallScore = overallScore / float64(len(results))
+	}
+	overallStatus := status.EvalStatusFailed
+	if overallScore >= evalMetric.Threshold {
+		overallStatus = status.EvalStatusPassed
+	}
+	return &evaluator.EvaluateResult{
+		OverallScore:         overallScore,
+		OverallStatus:        overallStatus,
+		PerInvocationResults: results,
+	}, nil
+}

--- a/examples/evaluation/metricextension/main.go
+++ b/examples/evaluation/metricextension/main.go
@@ -38,7 +38,7 @@ const (
 	appName                     = "metric-extension-app"
 	defaultEvalSetID            = "support-policy-basic"
 	supportAgentName            = "support-agent"
-	responsePolicyEvaluatorName = "response_policy"
+	responsePolicyEvaluatorName = "support_response_policy"
 )
 
 func main() {

--- a/examples/evaluation/metricextension/main.go
+++ b/examples/evaluation/metricextension/main.go
@@ -1,0 +1,74 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+var (
+	dataDir   = flag.String("data-dir", "./data", "Directory containing evaluation set and metric files")
+	outputDir = flag.String("output-dir", "./output", "Directory where evaluation results will be stored")
+	evalSet   = flag.String("eval-set", defaultEvalSetID, "Evaluation set identifier to execute")
+	modelName = flag.String("model", "deepseek-v4-flash", "Model to use for evaluation runs")
+	streaming = flag.Bool("streaming", false, "Enable streaming responses from the agent")
+	numRuns   = flag.Int("runs", 1, "Number of times to repeat the evaluation loop per case")
+)
+
+const (
+	appName                     = "metric-extension-app"
+	defaultEvalSetID            = "support-policy-basic"
+	supportAgentName            = "support-agent"
+	responsePolicyEvaluatorName = "response_policy"
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	run := runner.NewRunner(appName, newSupportAgent(*modelName, *streaming))
+	defer run.Close()
+	evalSetManager := evalsetlocal.New(evalset.WithBaseDir(*dataDir))
+	metricManager := metriclocal.New(metric.WithBaseDir(*dataDir))
+	evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(*outputDir))
+	reg := registry.New()
+	if err := reg.Register(responsePolicyEvaluatorName, responsePolicyEvaluator{}); err != nil {
+		log.Fatalf("register response policy evaluator: %v", err)
+	}
+	agentEvaluator, err := evaluation.New(
+		appName,
+		run,
+		evaluation.WithEvalSetManager(evalSetManager),
+		evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager),
+		evaluation.WithRegistry(reg),
+		evaluation.WithNumRuns(*numRuns),
+	)
+	if err != nil {
+		log.Fatalf("create evaluator: %v", err)
+	}
+	defer agentEvaluator.Close()
+	result, err := agentEvaluator.Evaluate(ctx, *evalSet)
+	if err != nil {
+		log.Fatalf("evaluate: %v", err)
+	}
+	printSummary(result, *outputDir)
+}

--- a/examples/evaluation/metricextension/print.go
+++ b/examples/evaluation/metricextension/print.go
@@ -1,0 +1,41 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+)
+
+func printSummary(result *evaluation.EvaluationResult, outDir string) {
+	fmt.Println("Evaluation completed with metric extension")
+	fmt.Printf("App: %s\n", result.AppName)
+	fmt.Printf("Eval Set: %s\n", result.EvalSetID)
+	fmt.Printf("Overall Status: %s\n", result.OverallStatus)
+	runs := 0
+	if len(result.EvalCases) > 0 {
+		runs = len(result.EvalCases[0].EvalCaseResults)
+	}
+	fmt.Printf("Runs: %d\n", runs)
+	for _, caseResult := range result.EvalCases {
+		fmt.Printf("Case %s -> %s\n", caseResult.EvalCaseID, caseResult.OverallStatus)
+		for _, metricResult := range caseResult.MetricResults {
+			fmt.Printf("  Metric %s: score %.2f (threshold %.2f) => %s\n",
+				metricResult.MetricName,
+				metricResult.Score,
+				metricResult.Threshold,
+				metricResult.EvalStatus,
+			)
+		}
+		fmt.Println()
+	}
+	fmt.Printf("Results saved under: %s\n", outDir)
+}


### PR DESCRIPTION
Adds caller-defined metadata to EvalMetric so platforms can attach metric-specific configuration such as weights without changing core metric fields.