### PR TITLE
{evaluation, docs, examples}: add eval case result aggregation

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -3375,7 +3375,7 @@ agentEvaluator, err := evaluation.New(
 
 If a custom aggregator returns an error, the local implementation marks the current case as `failed` and writes the error message to `errorMessage`.
 
-When reading results, distinguish case-level results from metric-level results. A custom aggregator only decides the case-level `score` and `finalEvalStatus`. Each metric's own `score`, `threshold`, and `evalStatus` are still computed by the corresponding Evaluator and kept in `overallEvalMetricResults`. The overall status in the result summary follows the case-level `finalEvalStatus`, while `metricSummaries` still keep each metric's own status for display and diagnosis. Therefore, a custom aggregation strategy can allow a case to pass even when one metric fails.
+When reading results, distinguish case-level results from metric-level results. A custom aggregator only decides the case-level `score` and `finalEvalStatus`. Each metric's own `score`, `threshold`, and `evalStatus` are still computed by the corresponding Evaluator and kept in `overallEvalMetricResults`. Therefore, a custom aggregation strategy can allow a case to pass even when one metric fails.
 
 ### AgentEvaluator
 
@@ -3415,11 +3415,11 @@ type EvaluationCaseResult struct {
 
 By default, `evaluation.New` creates AgentEvaluator and uses in-memory EvalSetManager, MetricManager, EvalResultManager, and the default Registry, and also creates a local Service. If you want to read EvalSet and metric configuration from local files and write results to files, you need to inject Local Managers explicitly.
 
-AgentEvaluator supports running the same evaluation set multiple times via `WithNumRuns`. During aggregation, it summarizes multiple runs by case. `OverallStatus` is summarized from each run's `EvalCaseResult.finalEvalStatus`; metrics with the same name are averaged and compared with thresholds to produce metric-level aggregated status, which is written to `MetricResults` for display and diagnosis. Each run's raw results are preserved in `EvalCaseResults`.
+AgentEvaluator supports running the same evaluation set multiple times via `WithNumRuns`. With the default single run, `OverallStatus` comes from that run's `EvalCaseResult.finalEvalStatus`. When `WithNumRuns` is greater than 1, aggregation is performed by case: metrics with the same name are averaged and compared with thresholds, and the aggregated metric statuses are then used to compute the case `OverallStatus`. Each run's raw results are preserved in `EvalCaseResults`, and aggregated metric results are written to `MetricResults` for display and diagnosis.
 
 ### NumRuns: Repeated Runs
 
-Because Agent execution may be nondeterministic, `evaluation.WithNumRuns` provides repeated runs to reduce randomness from a single run. The default is 1. When `evaluation.WithNumRuns(n)` is specified, the same evaluation set will perform n rounds of inference and evaluation within a single Evaluate, summarize multiple `finalEvalStatus` values at case granularity, and generate metric-level aggregated results by averaging metrics with the same name.
+Because Agent execution may be nondeterministic, `evaluation.WithNumRuns` provides repeated runs to reduce randomness from a single run. The default is 1. When `evaluation.WithNumRuns(n)` is specified with n greater than 1, the same evaluation set performs n rounds of inference and evaluation within a single Evaluate, averages metrics with the same name at case granularity, and computes the case status from the aggregated metric statuses.
 
 The number of result files does not increase linearly with repeated runs. One Evaluate writes a single result file corresponding to one EvalSetResult. When `NumRuns` is greater than 1, the file contains detailed results for multiple runs. Results for the same case across different runs appear in `EvalCaseResults` and are distinguished by `runId`.
 

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -513,7 +513,7 @@ As shown below, the framework standardizes the Agent runtime through a unified e
 - **Metric** defines metric configuration and includes `metricName`, `criterion`, and `threshold`. `metricName` selects the evaluator implementation, `criterion` describes evaluation criteria, and `threshold` defines the threshold.
 - **Evaluator** reads actual and expected traces, computes `score` based on `criterion`, then compares with `threshold` to determine pass or fail.
 - **Registry** maintains mappings between `metricName` and Evaluator. Built-in and custom evaluators integrate through it.
-- **Service** runs cases, collects traces, calls evaluators for scoring, and returns evaluation results.
+- **Service** runs cases, collects traces, calls evaluators for scoring, and uses the case result aggregator to generate evaluation case-level scores and statuses.
 - **AgentEvaluator** is created via `evaluation.New` with Runner, Managers, Registry, and other dependencies, and exposes `Evaluate` to users.
 
 A typical evaluation run includes the following steps.
@@ -2931,6 +2931,8 @@ type EvalSetResult struct {
 type EvalCaseResult struct {
 	EvalSetID                     string                           // EvalSetID is the evaluation set identifier.
 	EvalID                        string                           // EvalID is the case identifier.
+	RunID                         int                              // RunID is the run sequence number.
+	Score                         float64                          // Score is the case-level aggregated score.
 	FinalEvalStatus               status.EvalStatus                // FinalEvalStatus is the final status.
 	ErrorMessage                  string                           // ErrorMessage is the error message.
 	OverallEvalMetricResults      []*EvalMetricResult              // OverallEvalMetricResults is the list of overall metric results.
@@ -2971,7 +2973,7 @@ type RubricScore struct {
 }
 ```
 
-Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting.
+Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, and `finalEvalStatus` is the evaluation case-level final status. Both are computed by the Service case result aggregator.
 
 For `llm_judge_template`, `criterion.llmJudge.template.prompt` in results has two different meanings:
 
@@ -2987,6 +2989,7 @@ Below is an example result file snippet.
   "evalCaseResults": [
     {
       "evalId": "calc_add",
+      "score": 1,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [
         {
@@ -3188,6 +3191,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 )
 
 // Service is the evaluation service interface.
@@ -3237,6 +3241,27 @@ type EvalSetRunResult struct {
 	EvalSetID       string                       // EvalSetID is the evaluation set identifier.
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults are the evaluation case results.
 }
+
+// EvalCaseResultAggregator aggregates metric results for a single evaluation case.
+type EvalCaseResultAggregator interface {
+	Aggregate(ctx context.Context, input *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error)
+}
+
+// EvalCaseResultAggregationInput is the context required to aggregate a single evaluation case result.
+type EvalCaseResultAggregationInput struct {
+	AppName         string                         // AppName is the application name.
+	EvalSetID       string                         // EvalSetID is the evaluation set identifier.
+	EvalCase        *evalset.EvalCase              // EvalCase is the current evaluation case configuration.
+	InferenceResult *InferenceResult               // InferenceResult is the inference result for the current evaluation case.
+	EvalMetrics     []*metric.EvalMetric           // EvalMetrics are the actually executed evaluation metrics.
+	MetricResults   []*evalresult.EvalMetricResult // MetricResults are the corresponding overall metric results.
+}
+
+// EvalCaseResultAggregationResult is the aggregated evaluation case result.
+type EvalCaseResultAggregationResult struct {
+	Score  float64           // Score is the case-level score.
+	Status status.EvalStatus // Status is the case-level status.
+}
 ```
 
 The framework provides a local Service implementation that depends on Runner for inference, EvalSetManager for EvalSet loading, and Registry for evaluator lookup.
@@ -3259,7 +3284,98 @@ The local implementation looks up Evaluators from Registry and calls `Evaluator.
 
 When `evalMode` is `trace`, inference is skipped. If `actualConversation` is configured, actual traces come from `actualConversation` and `conversation` continues to represent expected traces. If `actualConversation` is omitted, `conversation` is treated as the actual trace and the evaluation phase builds placeholder expecteds that preserve only `userContent`. When `expectedRunnerEnabled` is enabled, the evaluation phase instead reuses the `ExpectedInferences` that were already generated during inference.
 
-After evaluation, it returns `EvalSetRunResult` to AgentEvaluator.
+After all metrics are evaluated, the local implementation passes the current case, actual inference result, actually executed metric list, and corresponding metric results to `EvalCaseResultAggregator`. The aggregator computes `EvalCaseResult.score` and `EvalCaseResult.finalEvalStatus`. Evaluation then generates `EvalSetRunResult` and returns it to AgentEvaluator.
+
+#### Evaluation Case Result Aggregation
+
+An evaluation case can contain multiple metrics. Each Evaluator first produces metric-level `score`, `threshold`, and `evalStatus`, and `EvalCaseResultAggregator` then aggregates them into case-level `score` and `finalEvalStatus`. The default aggregator preserves the framework's existing all-metrics-pass semantics. If any metric fails, the case fails; if no metric fails and at least one metric passes, the case passes; if no metric result is available, the case is not evaluated. The default score is binary: passed cases score 1, while failed or not-evaluated cases score 0.
+
+The `EvalCaseResultAggregator` interface is defined as follows.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type EvalCaseResultAggregator interface {
+	// Aggregate aggregates metric results for a single evaluation case.
+	Aggregate(ctx context.Context, input *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error)
+}
+
+type EvalCaseResultAggregationInput struct {
+	AppName         string                         // AppName is the application name.
+	EvalSetID       string                         // EvalSetID is the evaluation set identifier.
+	EvalCase        *evalset.EvalCase              // EvalCase is the current evaluation case configuration.
+	InferenceResult *InferenceResult               // InferenceResult is the inference result for the current evaluation case.
+	EvalMetrics     []*metric.EvalMetric           // EvalMetrics are the actually executed evaluation metrics.
+	MetricResults   []*evalresult.EvalMetricResult // MetricResults are the corresponding overall metric results.
+}
+
+type EvalCaseResultAggregationResult struct {
+	Score  float64           // Score is the case-level score.
+	Status status.EvalStatus // Status is the case-level status.
+}
+```
+
+The following example computes a weighted score from `EvalMetric.Extension.weight`. See [examples/evaluation/caseaggregation](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/caseaggregation) for the complete example.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type weightedAggregator struct {
+	Threshold float64
+}
+
+func (a weightedAggregator) Aggregate(ctx context.Context, input *service.EvalCaseResultAggregationInput) (*service.EvalCaseResultAggregationResult, error) {
+	var totalScore float64
+	var totalWeight float64
+	for i, evalMetric := range input.EvalMetrics {
+		weight := weightFromExtension(evalMetric.Extension)
+		totalScore += input.MetricResults[i].Score * weight
+		totalWeight += weight
+	}
+	if totalWeight == 0 {
+		return &service.EvalCaseResultAggregationResult{Status: status.EvalStatusNotEvaluated}, nil
+	}
+	score := totalScore / totalWeight
+	resultStatus := status.EvalStatusFailed
+	if score >= a.Threshold {
+		resultStatus = status.EvalStatusPassed
+	}
+	return &service.EvalCaseResultAggregationResult{Score: score, Status: resultStatus}, nil
+}
+
+func weightFromExtension(extension any) float64 {
+	values, ok := extension.(map[string]any)
+	if !ok {
+		return 1
+	}
+	weight, ok := values["weight"].(float64)
+	if !ok || weight <= 0 {
+		return 1
+	}
+	return weight
+}
+
+agentEvaluator, err := evaluation.New(
+	appName,
+	runner,
+	evaluation.WithEvalCaseResultAggregator(weightedAggregator{
+		Threshold: 0.8,
+	}),
+)
+```
+
+If a custom aggregator returns an error, the local implementation marks the current case as `failed` and writes the error message to `errorMessage`.
+
+When reading results, distinguish case-level results from metric-level results. A custom aggregator only decides the case-level `score` and `finalEvalStatus`. Each metric's own `score`, `threshold`, and `evalStatus` are still computed by the corresponding Evaluator and kept in `overallEvalMetricResults`. The overall status in the result summary follows the case-level `finalEvalStatus`, while `metricSummaries` still keep each metric's own status for display and diagnosis. Therefore, a custom aggregation strategy can allow a case to pass even when one metric fails.
 
 ### AgentEvaluator
 
@@ -3299,11 +3415,11 @@ type EvaluationCaseResult struct {
 
 By default, `evaluation.New` creates AgentEvaluator and uses in-memory EvalSetManager, MetricManager, EvalResultManager, and the default Registry, and also creates a local Service. If you want to read EvalSet and metric configuration from local files and write results to files, you need to inject Local Managers explicitly.
 
-AgentEvaluator supports running the same evaluation set multiple times via `WithNumRuns`. During aggregation, it summarizes multiple runs by case, averages scores for metrics with the same name, compares with thresholds to determine aggregated status, and writes aggregated results into `MetricResults`. Each run's raw results are preserved in `EvalCaseResults`.
+AgentEvaluator supports running the same evaluation set multiple times via `WithNumRuns`. During aggregation, it summarizes multiple runs by case. `OverallStatus` is summarized from each run's `EvalCaseResult.finalEvalStatus`; metrics with the same name are averaged and compared with thresholds to produce metric-level aggregated status, which is written to `MetricResults` for display and diagnosis. Each run's raw results are preserved in `EvalCaseResults`.
 
 ### NumRuns: Repeated Runs
 
-Because Agent execution may be nondeterministic, `evaluation.WithNumRuns` provides repeated runs to reduce randomness from a single run. The default is 1. When `evaluation.WithNumRuns(n)` is specified, the same evaluation set will perform n rounds of inference and evaluation within a single Evaluate, and aggregation will average scores by metric name at case granularity.
+Because Agent execution may be nondeterministic, `evaluation.WithNumRuns` provides repeated runs to reduce randomness from a single run. The default is 1. When `evaluation.WithNumRuns(n)` is specified, the same evaluation set will perform n rounds of inference and evaluation within a single Evaluate, summarize multiple `finalEvalStatus` values at case granularity, and generate metric-level aggregated results by averaging metrics with the same name.
 
 The number of result files does not increase linearly with repeated runs. One Evaluate writes a single result file corresponding to one EvalSetResult. When `NumRuns` is greater than 1, the file contains detailed results for multiple runs. Results for the same case across different runs appear in `EvalCaseResults` and are distinguished by `runId`.
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -512,7 +512,7 @@ metricManager.Add(ctx, appName, evalSetID, evalMetric)
 - **评估指标 Metric** 用于定义评估指标配置，包含 `metricName`、`criterion`、`threshold`。`metricName` 用来选择评估器实现，`criterion` 用来描述评估准则，`threshold` 用来定义阈值。
 - **评估器 Evaluator** 读取实际轨迹与预期轨迹，按 `criterion` 计算 `score`，再与 `threshold` 对比得到通过或失败。
 - **评估器注册中心 Registry** 维护 `metricName` 与 Evaluator 的映射关系，内置评估器和自定义评估器都通过它接入。
-- **评估服务 Service** 负责执行用例、采集轨迹、调用评估器打分，返回评估结果。
+- **评估服务 Service** 负责执行用例、采集轨迹、调用评估器打分，并通过用例结果聚合器生成评估用例级别的分数与状态。
 - **AgentEvaluator** 通过 `evaluation.New` 创建并注入 Runner、Managers、Registry 等依赖，对用户接入层提供 `Evaluate` 方法。
 
 一次评估运行通常包含以下步骤。
@@ -2929,6 +2929,8 @@ type EvalSetResult struct {
 type EvalCaseResult struct {
 	EvalSetID                     string                           // EvalSetID 是评估集标识
 	EvalID                        string                           // EvalID 是用例标识
+	RunID                         int                              // RunID 是运行序号
+	Score                         float64                          // Score 是用例级聚合分数
 	FinalEvalStatus               status.EvalStatus                // FinalEvalStatus 是最终状态
 	ErrorMessage                  string                           // ErrorMessage 是错误信息
 	OverallEvalMetricResults      []*EvalMetricResult              // OverallEvalMetricResults 是整体指标结果列表
@@ -2969,7 +2971,7 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态；它们由 Service 的用例结果聚合器计算。
 
 对于 `llm_judge_template`，结果中的 `criterion.llmJudge.template.prompt` 需要区分两层语义：
 
@@ -2985,6 +2987,7 @@ type RubricScore struct {
   "evalCaseResults": [
     {
       "evalId": "calc_add",
+      "score": 1,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [
         {
@@ -3186,6 +3189,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 )
 
 // Service 是评估服务接口
@@ -3235,6 +3239,27 @@ type EvalSetRunResult struct {
 	EvalSetID       string                       // EvalSetID 是评估集标识
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults 是评估用例结果
 }
+
+// EvalCaseResultAggregator 聚合单个评估用例下的多条指标结果
+type EvalCaseResultAggregator interface {
+	Aggregate(ctx context.Context, input *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error)
+}
+
+// EvalCaseResultAggregationInput 是聚合单个评估用例结果所需的上下文
+type EvalCaseResultAggregationInput struct {
+	AppName         string                         // AppName 是应用名
+	EvalSetID       string                         // EvalSetID 是评估集标识
+	EvalCase        *evalset.EvalCase              // EvalCase 是当前评估用例配置
+	InferenceResult *InferenceResult               // InferenceResult 是当前评估用例的推理结果
+	EvalMetrics     []*metric.EvalMetric           // EvalMetrics 是实际执行的评估指标列表
+	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是对应指标的整体结果
+}
+
+// EvalCaseResultAggregationResult 是聚合后的评估用例结果
+type EvalCaseResultAggregationResult struct {
+	Score  float64           // Score 是用例级分数
+	Status status.EvalStatus // Status 是用例级状态
+}
 ```
 
 框架提供了 Service 的本地实现，依赖 Runner 执行推理，EvalSetManager 读取 EvalSet，Registry 定位评估器实现。
@@ -3257,7 +3282,98 @@ Local 实现会通过 Registry 按 `MetricName` 获取 Evaluator，并调用 `Ev
 
 当 `evalMode` 为 `trace` 时，推理阶段跳过 Runner；若配置了 `actualConversation`，则实际轨迹 actuals 来自 `actualConversation`，而 `conversation` 继续表示预期轨迹。若未配置 `actualConversation`，则 `conversation` 会被视为实际轨迹，评估阶段再基于该轨迹构造仅保留 `userContent` 的占位 expecteds；开启 `expectedRunnerEnabled` 时，评估阶段则直接复用推理阶段已经生成好的 `ExpectedInferences`。
 
-评估完成后会生成 `EvalSetRunResult` 并返回给 AgentEvaluator。
+所有指标评估完成后，Local 实现会把当前用例、实际推理结果、实际执行的指标列表和对应指标结果交给 `EvalCaseResultAggregator`，由它计算 `EvalCaseResult.score` 与 `EvalCaseResult.finalEvalStatus`。评估完成后会生成 `EvalSetRunResult` 并返回给 AgentEvaluator。
+
+#### 评估用例结果聚合
+
+一个评估用例可以包含多个指标。各 Evaluator 先产出指标级 `score`、`threshold` 与 `evalStatus`，再由 `EvalCaseResultAggregator` 汇总为用例级 `score` 和 `finalEvalStatus`。默认聚合器沿用框架原有的全指标通过语义，任一指标失败则用例失败，没有失败且至少一个指标通过则用例通过，没有可用指标结果则用例未评估。默认分数是二值的，用例通过时为 1，失败或未评估时为 0。
+
+`EvalCaseResultAggregator` 接口定义如下。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type EvalCaseResultAggregator interface {
+	// Aggregate 聚合单个评估用例的指标结果
+	Aggregate(ctx context.Context, input *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error)
+}
+
+type EvalCaseResultAggregationInput struct {
+	AppName         string                         // AppName 是应用名
+	EvalSetID       string                         // EvalSetID 是评估集标识
+	EvalCase        *evalset.EvalCase              // EvalCase 是当前评估用例配置
+	InferenceResult *InferenceResult               // InferenceResult 是当前评估用例的推理结果
+	EvalMetrics     []*metric.EvalMetric           // EvalMetrics 是实际执行的评估指标列表
+	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是对应指标的整体结果
+}
+
+type EvalCaseResultAggregationResult struct {
+	Score  float64           // Score 是用例级分数
+	Status status.EvalStatus // Status 是用例级状态
+}
+```
+
+下面示例按 `EvalMetric.Extension.weight` 计算加权分。完整示例参见 [examples/evaluation/caseaggregation](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/caseaggregation)。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type weightedAggregator struct {
+	Threshold float64
+}
+
+func (a weightedAggregator) Aggregate(ctx context.Context, input *service.EvalCaseResultAggregationInput) (*service.EvalCaseResultAggregationResult, error) {
+	var totalScore float64
+	var totalWeight float64
+	for i, evalMetric := range input.EvalMetrics {
+		weight := weightFromExtension(evalMetric.Extension)
+		totalScore += input.MetricResults[i].Score * weight
+		totalWeight += weight
+	}
+	if totalWeight == 0 {
+		return &service.EvalCaseResultAggregationResult{Status: status.EvalStatusNotEvaluated}, nil
+	}
+	score := totalScore / totalWeight
+	resultStatus := status.EvalStatusFailed
+	if score >= a.Threshold {
+		resultStatus = status.EvalStatusPassed
+	}
+	return &service.EvalCaseResultAggregationResult{Score: score, Status: resultStatus}, nil
+}
+
+func weightFromExtension(extension any) float64 {
+	values, ok := extension.(map[string]any)
+	if !ok {
+		return 1
+	}
+	weight, ok := values["weight"].(float64)
+	if !ok || weight <= 0 {
+		return 1
+	}
+	return weight
+}
+
+agentEvaluator, err := evaluation.New(
+	appName,
+	runner,
+	evaluation.WithEvalCaseResultAggregator(weightedAggregator{
+		Threshold: 0.8,
+	}),
+)
+```
+
+如果自定义聚合器返回错误，Local 实现会将当前用例标记为 `failed`，并把错误信息写入 `errorMessage`。
+
+读取结果时需要区分用例级结果和指标级结果。自定义聚合器只决定用例级 `score` 与 `finalEvalStatus`。单条指标自己的 `score`、`threshold` 与 `evalStatus` 仍由对应 Evaluator 计算，并保留在 `overallEvalMetricResults` 中。结果汇总的整体状态会跟随用例级 `finalEvalStatus`，`metricSummaries` 继续保留每个指标自己的状态用于展示和诊断。因此，自定义聚合策略可以让某个指标失败但用例整体通过。
 
 ### AgentEvaluator
 
@@ -3297,11 +3413,11 @@ type EvaluationCaseResult struct {
 
 默认情况下，`evaluation.New` 会创建 AgentEvaluator 并使用 InMemory 的 EvalSetManager、MetricManager、EvalResultManager 与默认 Registry，同时创建本地 Service。若希望从本地文件读取 EvalSet 与指标配置，并将结果写入文件，需要显式注入 Local Manager。
 
-AgentEvaluator 支持通过 `WithNumRuns` 对同一评估集运行多次。聚合时会按用例维度汇总多次运行的结果，对同名指标取平均分并与阈值对比得到聚合状态，聚合结果写入 `MetricResults`，每次运行的原始结果保留在 `EvalCaseResults`。
+AgentEvaluator 支持通过 `WithNumRuns` 对同一评估集运行多次。聚合时会按用例维度汇总多次运行的结果，`OverallStatus` 按每次运行的 `EvalCaseResult.finalEvalStatus` 汇总；对同名指标取平均分并与阈值对比得到指标级聚合状态，写入 `MetricResults` 用于展示和诊断。每次运行的原始结果保留在 `EvalCaseResults`。
 
 ### NumRuns 重复运行次数
 
-由于 Agent 的运行过程可能存在不确定性，`evaluation.WithNumRuns` 提供了重复运行机制，用于降低单次运行带来的偶然性。默认运行次数为 1 次，指定 `evaluation.WithNumRuns(n)` 后，同一个评估集会在同一次 Evaluate 中完成 n 次推理与评估，并在汇总时以用例为粒度聚合多次运行的分数，默认按同名指标的平均分得到聚合结果。
+由于 Agent 的运行过程可能存在不确定性，`evaluation.WithNumRuns` 提供了重复运行机制，用于降低单次运行带来的偶然性。默认运行次数为 1 次，指定 `evaluation.WithNumRuns(n)` 后，同一个评估集会在同一次 Evaluate 中完成 n 次推理与评估，并在汇总时以用例为粒度汇总多次运行的 `finalEvalStatus`，同时按同名指标的平均分生成指标级聚合结果。
 
 重复运行次数不会线性增加评估结果文件的数量。一次 Evaluate 只会写入一份评估结果文件，对应一个 EvalSetResult；当 `NumRuns` 大于 1 时，文件内部会包含多次运行的明细结果，同一用例在不同运行中的结果会分别出现在 `EvalCaseResults` 中，并通过 `runId` 区分。
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -3373,7 +3373,7 @@ agentEvaluator, err := evaluation.New(
 
 如果自定义聚合器返回错误，Local 实现会将当前用例标记为 `failed`，并把错误信息写入 `errorMessage`。
 
-读取结果时需要区分用例级结果和指标级结果。自定义聚合器只决定用例级 `score` 与 `finalEvalStatus`。单条指标自己的 `score`、`threshold` 与 `evalStatus` 仍由对应 Evaluator 计算，并保留在 `overallEvalMetricResults` 中。结果汇总的整体状态会跟随用例级 `finalEvalStatus`，`metricSummaries` 继续保留每个指标自己的状态用于展示和诊断。因此，自定义聚合策略可以让某个指标失败但用例整体通过。
+读取结果时需要区分用例级结果和指标级结果。自定义聚合器只决定用例级 `score` 与 `finalEvalStatus`。单条指标自己的 `score`、`threshold` 与 `evalStatus` 仍由对应 Evaluator 计算，并保留在 `overallEvalMetricResults` 中。因此，自定义聚合策略可能让某个指标失败但用例整体通过。
 
 ### AgentEvaluator
 
@@ -3413,11 +3413,11 @@ type EvaluationCaseResult struct {
 
 默认情况下，`evaluation.New` 会创建 AgentEvaluator 并使用 InMemory 的 EvalSetManager、MetricManager、EvalResultManager 与默认 Registry，同时创建本地 Service。若希望从本地文件读取 EvalSet 与指标配置，并将结果写入文件，需要显式注入 Local Manager。
 
-AgentEvaluator 支持通过 `WithNumRuns` 对同一评估集运行多次。聚合时会按用例维度汇总多次运行的结果，`OverallStatus` 按每次运行的 `EvalCaseResult.finalEvalStatus` 汇总；对同名指标取平均分并与阈值对比得到指标级聚合状态，写入 `MetricResults` 用于展示和诊断。每次运行的原始结果保留在 `EvalCaseResults`。
+AgentEvaluator 支持通过 `WithNumRuns` 对同一评估集运行多次。默认运行 1 次时，`OverallStatus` 来自该次运行的 `EvalCaseResult.finalEvalStatus`；当 `WithNumRuns` 大于 1 时，聚合会按用例维度对同名指标取平均分并与阈值对比，再由聚合后的指标状态得到用例 `OverallStatus`。每次运行的原始结果保留在 `EvalCaseResults`，聚合后的指标结果写入 `MetricResults` 用于展示和诊断。
 
 ### NumRuns 重复运行次数
 
-由于 Agent 的运行过程可能存在不确定性，`evaluation.WithNumRuns` 提供了重复运行机制，用于降低单次运行带来的偶然性。默认运行次数为 1 次，指定 `evaluation.WithNumRuns(n)` 后，同一个评估集会在同一次 Evaluate 中完成 n 次推理与评估，并在汇总时以用例为粒度汇总多次运行的 `finalEvalStatus`，同时按同名指标的平均分生成指标级聚合结果。
+由于 Agent 的运行过程可能存在不确定性，`evaluation.WithNumRuns` 提供了重复运行机制，用于降低单次运行带来的偶然性。默认运行次数为 1 次，指定 `evaluation.WithNumRuns(n)` 且 n 大于 1 后，同一个评估集会在同一次 Evaluate 中完成 n 次推理与评估，并在汇总时以用例为粒度对同名指标取平均分，再根据聚合后的指标状态计算用例状态。
 
 重复运行次数不会线性增加评估结果文件的数量。一次 Evaluate 只会写入一份评估结果文件，对应一个 EvalSetResult；当 `NumRuns` 大于 1 时，文件内部会包含多次运行的明细结果，同一用例在不同运行中的结果会分别出现在 `EvalCaseResults` 中，并通过 `runId` 区分。
 

--- a/evaluation/evalresult/evalresult.go
+++ b/evaluation/evalresult/evalresult.go
@@ -43,6 +43,8 @@ type EvalCaseResult struct {
 	EvalID string `json:"evalId,omitempty"`
 	// RunID identifies the run that produced this case result.
 	RunID int `json:"runId,omitempty"`
+	// Score is the aggregated case-level score.
+	Score float64 `json:"score,omitempty"`
 	// FinalEvalStatus is the final eval status for this eval case.
 	FinalEvalStatus status.EvalStatus `json:"finalEvalStatus,omitempty"`
 	// ErrorMessage contains the error message when evaluation execution failed.

--- a/evaluation/evalresult/evalresult_test.go
+++ b/evaluation/evalresult/evalresult_test.go
@@ -27,6 +27,7 @@ func TestEvalSetResultJSONRoundTrip(t *testing.T) {
     {
       "evalSetId": "greeting-set",
       "evalId": "case-1",
+      "score": 0.95,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [
         {
@@ -144,6 +145,7 @@ func TestEvalSetResultJSONRoundTrip(t *testing.T) {
 
 	caseResult := result.EvalCaseResults[0]
 	assert.Equal(t, "case-1", caseResult.EvalID)
+	assert.Equal(t, 0.95, caseResult.Score)
 	assert.Equal(t, status.EvalStatusPassed, caseResult.FinalEvalStatus)
 	assert.Equal(t, "greeting-set", caseResult.EvalSetID)
 	assert.Len(t, caseResult.OverallEvalMetricResults, 1)

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -65,6 +65,7 @@ func New(appName string, runner runner.Runner, opt ...Option) (AgentEvaluator, e
 		metricManager:                     opts.metricManager,
 		registry:                          opts.registry,
 		metricRegistry:                    opts.metricRegistry,
+		evalCaseResultAggregator:          opts.evalCaseResultAggregator,
 		evalService:                       opts.evalService,
 		callbacks:                         opts.callbacks,
 		expectedRunner:                    opts.expectedRunner,
@@ -107,6 +108,9 @@ func New(appName string, runner runner.Runner, opt ...Option) (AgentEvaluator, e
 		if opts.userSimulator != nil {
 			serviceOpts = append(serviceOpts, service.WithUserSimulator(opts.userSimulator))
 		}
+		if opts.evalCaseResultAggregator != nil {
+			serviceOpts = append(serviceOpts, service.WithEvalCaseResultAggregator(opts.evalCaseResultAggregator))
+		}
 		evalService, err := local.New(a.runner, serviceOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("create eval service: %w", err)
@@ -127,6 +131,7 @@ type agentEvaluator struct {
 	metricManager                     metric.Manager
 	registry                          registry.Registry
 	metricRegistry                    metricregistry.Registry
+	evalCaseResultAggregator          service.EvalCaseResultAggregator
 	evalService                       service.Service
 	callbacks                         *service.Callbacks
 	expectedRunner                    runner.Runner
@@ -220,6 +225,7 @@ func (a *agentEvaluator) mergeCallOptions(opt ...Option) (*options, error) {
 		metricManager:                     a.metricManager,
 		registry:                          a.registry,
 		metricRegistry:                    a.metricRegistry,
+		evalCaseResultAggregator:          a.evalCaseResultAggregator,
 		evalService:                       a.evalService,
 		callbacks:                         a.callbacks,
 		expectedRunner:                    a.expectedRunner,
@@ -506,6 +512,9 @@ func (a *agentEvaluator) runEvaluationOnce(
 	}
 	if opts.evalCaseParallelEvaluationEnabled != nil {
 		evaluateOpts = append(evaluateOpts, service.WithEvalCaseParallelEvaluationEnabled(*opts.evalCaseParallelEvaluationEnabled))
+	}
+	if opts.evalCaseResultAggregator != nil {
+		evaluateOpts = append(evaluateOpts, service.WithEvalCaseResultAggregator(opts.evalCaseResultAggregator))
 	}
 	runResult, err := opts.evalService.Evaluate(ctx, evaluateRequest, evaluateOpts...)
 	if err != nil {

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -542,16 +542,14 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 		threshold float64
 		criterion *criterion.Criterion
 	}
-	hasRunError := false
 	// Group metrics results by metric name.
 	aggregatedMetrics := make(map[string]*aggregatedMetric)
+	runStatuses := make([]status.EvalStatus, 0, len(runs))
 	for _, run := range runs {
 		if run == nil {
 			continue
 		}
-		if run.ErrorMessage != "" {
-			hasRunError = true
-		}
+		runStatuses = append(runStatuses, run.FinalEvalStatus)
 		for _, metric := range run.OverallEvalMetricResults {
 			// Skip metrics that did not run to avoid diluting averaged scores.
 			if metric.EvalStatus == status.EvalStatusNotEvaluated {
@@ -581,12 +579,9 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 			Criterion:  aggregatedMetric.criterion,
 		})
 	}
-	overallStatus, err := istatus.SummarizeMetricsStatus(metricResults)
+	overallStatus, err := istatus.Summarize(runStatuses)
 	if err != nil {
-		return nil, fmt.Errorf("summarize metrics status: %w", err)
-	}
-	if overallStatus == status.EvalStatusNotEvaluated && hasRunError {
-		overallStatus = status.EvalStatusFailed
+		return nil, fmt.Errorf("summarize case run status: %w", err)
 	}
 	return &EvaluationCaseResult{
 		EvalCaseID:      caseID,

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -597,7 +597,14 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 
 func summarizeAggregateCaseRunsStatus(runStatuses []status.EvalStatus, metricResults []*evalresult.EvalMetricResult, hasRunError bool) (status.EvalStatus, error) {
 	if len(runStatuses) <= 1 {
-		return istatus.Summarize(runStatuses)
+		overallStatus, err := istatus.Summarize(runStatuses)
+		if err != nil {
+			return status.EvalStatusFailed, err
+		}
+		if overallStatus == status.EvalStatusNotEvaluated && hasRunError {
+			return status.EvalStatusFailed, nil
+		}
+		return overallStatus, nil
 	}
 	overallStatus, err := istatus.SummarizeMetricsStatus(metricResults)
 	if err != nil {

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -545,11 +545,15 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 	// Group metrics results by metric name.
 	aggregatedMetrics := make(map[string]*aggregatedMetric)
 	runStatuses := make([]status.EvalStatus, 0, len(runs))
+	hasRunError := false
 	for _, run := range runs {
 		if run == nil {
 			continue
 		}
 		runStatuses = append(runStatuses, run.FinalEvalStatus)
+		if run.ErrorMessage != "" {
+			hasRunError = true
+		}
 		for _, metric := range run.OverallEvalMetricResults {
 			// Skip metrics that did not run to avoid diluting averaged scores.
 			if metric.EvalStatus == status.EvalStatusNotEvaluated {
@@ -579,7 +583,7 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 			Criterion:  aggregatedMetric.criterion,
 		})
 	}
-	overallStatus, err := istatus.Summarize(runStatuses)
+	overallStatus, err := summarizeAggregateCaseRunsStatus(runStatuses, metricResults, hasRunError)
 	if err != nil {
 		return nil, fmt.Errorf("summarize case run status: %w", err)
 	}
@@ -589,6 +593,20 @@ func aggregateCaseRuns(caseID string, runs []*evalresult.EvalCaseResult) (*Evalu
 		EvalCaseResults: runs,
 		MetricResults:   metricResults,
 	}, nil
+}
+
+func summarizeAggregateCaseRunsStatus(runStatuses []status.EvalStatus, metricResults []*evalresult.EvalMetricResult, hasRunError bool) (status.EvalStatus, error) {
+	if len(runStatuses) <= 1 {
+		return istatus.Summarize(runStatuses)
+	}
+	overallStatus, err := istatus.SummarizeMetricsStatus(metricResults)
+	if err != nil {
+		return status.EvalStatusFailed, err
+	}
+	if overallStatus == status.EvalStatusNotEvaluated && hasRunError {
+		return status.EvalStatusFailed, nil
+	}
+	return overallStatus, nil
 }
 
 func collectRunDetails(runs []*evalresult.EvalCaseResult, runDetailsByID map[int]*EvaluationCaseRunDetails) []*EvaluationCaseRunDetails {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -851,6 +851,9 @@ func TestAgentEvaluatorEvaluatePassesServiceCallOptions(t *testing.T) {
 	svc := &fakeService{}
 	callbacks := service.NewCallbacks()
 	reg := registry.New()
+	aggregator := passEvalCaseResultAggregator{}
+	toolMockRunner := stubRunner{}
+	simulator := stubSimulator{}
 
 	ae, err := New(
 		appName,
@@ -865,6 +868,9 @@ func TestAgentEvaluatorEvaluatePassesServiceCallOptions(t *testing.T) {
 		WithEvalCaseParallelInferenceEnabled(true),
 		WithEvalCaseParallelEvaluationEnabled(true),
 		WithRunOptions(agent.WithInstruction("prompt")),
+		WithEvalCaseResultAggregator(aggregator),
+		WithToolMockRunner(toolMockRunner),
+		WithUserSimulator(simulator),
 	)
 	assert.NoError(t, err)
 	if err != nil {
@@ -883,6 +889,8 @@ func TestAgentEvaluatorEvaluatePassesServiceCallOptions(t *testing.T) {
 	inferenceOpts := svc.inferenceOptions[0]
 	assert.Same(t, evalSetMgr, inferenceOpts.EvalSetManager)
 	assert.Same(t, callbacks, inferenceOpts.Callbacks)
+	assert.Equal(t, toolMockRunner, inferenceOpts.ToolMockRunner)
+	assert.Equal(t, simulator, inferenceOpts.UserSimulator)
 	assert.Len(t, inferenceOpts.RunOptions, 1)
 	assert.Equal(t, 2, inferenceOpts.EvalCaseParallelism)
 	assert.True(t, inferenceOpts.EvalCaseParallelInferenceEnabled)
@@ -891,8 +899,10 @@ func TestAgentEvaluatorEvaluatePassesServiceCallOptions(t *testing.T) {
 	assert.Same(t, evalSetMgr, evaluateOpts.EvalSetManager)
 	assert.Same(t, reg, evaluateOpts.Registry)
 	assert.Same(t, callbacks, evaluateOpts.Callbacks)
+	assert.Equal(t, toolMockRunner, evaluateOpts.ToolMockRunner)
 	assert.Equal(t, 2, evaluateOpts.EvalCaseParallelism)
 	assert.True(t, evaluateOpts.EvalCaseParallelEvaluationEnabled)
+	assert.Equal(t, aggregator, evaluateOpts.EvalCaseResultAggregator)
 }
 
 func TestAgentEvaluatorEvaluateAppliesPerCallNumRuns(t *testing.T) {
@@ -2126,6 +2136,19 @@ func TestAggregateCaseRunsNotEvaluated(t *testing.T) {
 	assert.Equal(t, status.EvalStatusNotEvaluated, result.OverallStatus)
 	assert.Empty(t, result.MetricResults)
 	assert.Len(t, result.EvalCaseResults, 1)
+}
+
+func TestAggregateCaseRunsSkipsNilRuns(t *testing.T) {
+	runs := []*evalresult.EvalCaseResult{
+		nil,
+		makeEvalCaseResult("set", "case", "metric", 1, 1, status.EvalStatusPassed),
+	}
+	result, err := aggregateCaseRuns("case", runs)
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+	assert.Len(t, result.MetricResults, 1)
+	assert.Len(t, result.EvalCaseResults, 2)
 }
 
 func TestAggregateCaseRunsHardFailureWithoutMetrics(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -50,6 +50,12 @@ func (stubRunner) Close() error {
 	return nil
 }
 
+type passEvalCaseResultAggregator struct{}
+
+func (passEvalCaseResultAggregator) Aggregate(context.Context, *service.EvalCaseResultAggregationInput) (*service.EvalCaseResultAggregationResult, error) {
+	return &service.EvalCaseResultAggregationResult{Score: 1, Status: status.EvalStatusPassed}, nil
+}
+
 type fakeService struct {
 	inferenceResults [][]*service.InferenceResult
 	evaluateResults  []*service.EvalSetRunResult
@@ -429,6 +435,20 @@ func TestNewAgentEvaluatorWithParallelOptionsBuildsLocalService(t *testing.T) {
 		WithEvalCaseParallelism(2),
 		WithEvalCaseParallelInferenceEnabled(true),
 		WithEvalCaseParallelEvaluationEnabled(true),
+	)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.NoError(t, ae.Close())
+}
+
+func TestNewAgentEvaluatorWithEvalCaseResultAggregatorBuildsLocalService(t *testing.T) {
+	ae, err := New(
+		"app",
+		stubRunner{},
+		WithEvalCaseResultAggregator(passEvalCaseResultAggregator{}),
 	)
 	assert.NoError(t, err)
 	if err != nil {
@@ -2122,6 +2142,37 @@ func TestAggregateCaseRunsHardFailureWithoutMetrics(t *testing.T) {
 	assert.Equal(t, status.EvalStatusFailed, result.OverallStatus)
 	assert.Empty(t, result.MetricResults)
 	assert.Len(t, result.EvalCaseResults, 1)
+}
+
+func TestAggregateCaseRunsMultipleRunsFailedWhenRunErrorHasNoMetrics(t *testing.T) {
+	runs := []*evalresult.EvalCaseResult{
+		{
+			EvalSetID:       "set",
+			EvalID:          "case",
+			FinalEvalStatus: status.EvalStatusNotEvaluated,
+			ErrorMessage:    "inference failed",
+		},
+		{
+			EvalSetID:       "set",
+			EvalID:          "case",
+			FinalEvalStatus: status.EvalStatusNotEvaluated,
+		},
+	}
+	result, err := aggregateCaseRuns("case", runs)
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusFailed, result.OverallStatus)
+	assert.Empty(t, result.MetricResults)
+	assert.Len(t, result.EvalCaseResults, 2)
+}
+
+func TestSummarizeAggregateCaseRunsStatusRejectsInvalidMetricStatus(t *testing.T) {
+	overallStatus, err := summarizeAggregateCaseRunsStatus(
+		[]status.EvalStatus{status.EvalStatusPassed, status.EvalStatusPassed},
+		[]*evalresult.EvalMetricResult{{EvalStatus: status.EvalStatusUnknown}},
+		false,
+	)
+	assert.Error(t, err)
+	assert.Equal(t, status.EvalStatusFailed, overallStatus)
 }
 
 func TestSummarizeOverallStatus(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1362,11 +1362,11 @@ func TestAgentEvaluatorEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, evalSetID, evaluationResult.EvalSetID)
 	assert.Equal(t, appName, evaluationResult.AppName)
 	assert.Len(t, evaluationResult.EvalCases, 1)
-	assert.Equal(t, status.EvalStatusPassed, evaluationResult.OverallStatus)
+	assert.Equal(t, status.EvalStatusFailed, evaluationResult.OverallStatus)
 
 	caseResult := evaluationResult.EvalCases[0]
 	assert.Equal(t, caseID, caseResult.EvalCaseID)
-	assert.Equal(t, status.EvalStatusPassed, caseResult.OverallStatus)
+	assert.Equal(t, status.EvalStatusFailed, caseResult.OverallStatus)
 	assert.Len(t, caseResult.MetricResults, 1)
 	assert.InDelta(t, 1.0, caseResult.MetricResults[0].Score, 0.001)
 	assert.Len(t, caseResult.EvalCaseResults, 2)
@@ -2061,10 +2061,31 @@ func TestAggregateCaseRunsSuccess(t *testing.T) {
 	result, err := aggregateCaseRuns(caseID, runs)
 	assert.NoError(t, err)
 	assert.Equal(t, caseID, result.EvalCaseID)
-	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+	assert.Equal(t, status.EvalStatusFailed, result.OverallStatus)
 	assert.Len(t, result.MetricResults, 1)
 	assert.InDelta(t, 1.0, result.MetricResults[0].Score, 0.001)
 	assert.Len(t, result.EvalCaseResults, 2)
+}
+
+func TestAggregateCaseRunsUsesCaseFinalStatusWhenMetricsFail(t *testing.T) {
+	runs := []*evalresult.EvalCaseResult{
+		{
+			EvalSetID:       "set",
+			EvalID:          "case",
+			RunID:           1,
+			Score:           0.8,
+			FinalEvalStatus: status.EvalStatusPassed,
+			OverallEvalMetricResults: []*evalresult.EvalMetricResult{
+				makeEvalMetricResult("important", 1, status.EvalStatusPassed, 1),
+				makeEvalMetricResult("minor", 0, status.EvalStatusFailed, 1),
+			},
+		},
+	}
+
+	result, err := aggregateCaseRuns("case", runs)
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
+	assert.Len(t, result.MetricResults, 2)
 }
 
 func TestAggregateCaseRunsUnknownStatus(t *testing.T) {
@@ -2072,9 +2093,8 @@ func TestAggregateCaseRunsUnknownStatus(t *testing.T) {
 		makeEvalCaseResult("set", "case", "metric", 0.5, 1, status.EvalStatusUnknown),
 	}
 	result, err := aggregateCaseRuns("case", runs)
-	assert.NoError(t, err)
-	assert.Equal(t, status.EvalStatusFailed, result.OverallStatus)
-	assert.Len(t, result.MetricResults, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }
 
 func TestAggregateCaseRunsNotEvaluated(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -2138,6 +2138,22 @@ func TestAggregateCaseRunsNotEvaluated(t *testing.T) {
 	assert.Len(t, result.EvalCaseResults, 1)
 }
 
+func TestAggregateCaseRunsSingleRunFailedWhenRunErrorHasNoMetrics(t *testing.T) {
+	runs := []*evalresult.EvalCaseResult{
+		{
+			EvalSetID:       "set",
+			EvalID:          "case",
+			FinalEvalStatus: status.EvalStatusNotEvaluated,
+			ErrorMessage:    "inference failed",
+		},
+	}
+	result, err := aggregateCaseRuns("case", runs)
+	assert.NoError(t, err)
+	assert.Equal(t, status.EvalStatusFailed, result.OverallStatus)
+	assert.Empty(t, result.MetricResults)
+	assert.Len(t, result.EvalCaseResults, 1)
+}
+
 func TestAggregateCaseRunsSkipsNilRuns(t *testing.T) {
 	runs := []*evalresult.EvalCaseResult{
 		nil,

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1362,11 +1362,11 @@ func TestAgentEvaluatorEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, evalSetID, evaluationResult.EvalSetID)
 	assert.Equal(t, appName, evaluationResult.AppName)
 	assert.Len(t, evaluationResult.EvalCases, 1)
-	assert.Equal(t, status.EvalStatusFailed, evaluationResult.OverallStatus)
+	assert.Equal(t, status.EvalStatusPassed, evaluationResult.OverallStatus)
 
 	caseResult := evaluationResult.EvalCases[0]
 	assert.Equal(t, caseID, caseResult.EvalCaseID)
-	assert.Equal(t, status.EvalStatusFailed, caseResult.OverallStatus)
+	assert.Equal(t, status.EvalStatusPassed, caseResult.OverallStatus)
 	assert.Len(t, caseResult.MetricResults, 1)
 	assert.InDelta(t, 1.0, caseResult.MetricResults[0].Score, 0.001)
 	assert.Len(t, caseResult.EvalCaseResults, 2)
@@ -2061,7 +2061,7 @@ func TestAggregateCaseRunsSuccess(t *testing.T) {
 	result, err := aggregateCaseRuns(caseID, runs)
 	assert.NoError(t, err)
 	assert.Equal(t, caseID, result.EvalCaseID)
-	assert.Equal(t, status.EvalStatusFailed, result.OverallStatus)
+	assert.Equal(t, status.EvalStatusPassed, result.OverallStatus)
 	assert.Len(t, result.MetricResults, 1)
 	assert.InDelta(t, 1.0, result.MetricResults[0].Score, 0.001)
 	assert.Len(t, result.EvalCaseResults, 2)

--- a/evaluation/internal/multirun/multirun.go
+++ b/evaluation/internal/multirun/multirun.go
@@ -202,7 +202,14 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 
 func summarizeCaseSummaryStatus(metricSummaries []*evalresult.EvalMetricSummary, runStatuses []status.EvalStatus, hasRunError bool, numRuns int) (status.EvalStatus, error) {
 	if numRuns <= 1 {
-		return istatus.Summarize(runStatuses)
+		overallStatus, err := istatus.Summarize(runStatuses)
+		if err != nil {
+			return status.EvalStatusFailed, err
+		}
+		if overallStatus == status.EvalStatusNotEvaluated && hasRunError {
+			return status.EvalStatusFailed, nil
+		}
+		return overallStatus, nil
 	}
 	statuses := make([]status.EvalStatus, 0, len(metricSummaries))
 	for _, summary := range metricSummaries {

--- a/evaluation/internal/multirun/multirun.go
+++ b/evaluation/internal/multirun/multirun.go
@@ -133,6 +133,7 @@ func buildEvalSetRunSummaries(runCaseResults map[int][]*evalresult.EvalCaseResul
 type caseAgg struct {
 	runStatusCounts evalresult.EvalStatusCounts
 	runStatuses     []status.EvalStatus
+	hasRunError     bool
 	runSummaries    []*evalresult.EvalCaseRunSummary
 	metricAgg       map[string]*metricAgg
 }
@@ -154,6 +155,9 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 				aggs[caseID] = agg
 			}
 			agg.runStatuses = append(agg.runStatuses, caseResult.FinalEvalStatus)
+			if caseResult.ErrorMessage != "" {
+				agg.hasRunError = true
+			}
 			if err := addEvalStatus(&agg.runStatusCounts, caseResult.FinalEvalStatus); err != nil {
 				return nil, status.EvalStatusFailed, err
 			}
@@ -173,7 +177,7 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 	caseStatuses := make([]status.EvalStatus, 0, len(aggs))
 	for caseID, agg := range aggs {
 		metricSummaries := buildMetricSummaries(agg.metricAgg)
-		overallStatus, err := istatus.Summarize(agg.runStatuses)
+		overallStatus, err := summarizeCaseSummaryStatus(metricSummaries, agg.runStatuses, agg.hasRunError, len(runIDs))
 		if err != nil {
 			return nil, status.EvalStatusFailed, fmt.Errorf("summarize case %s status: %w", caseID, err)
 		}
@@ -194,6 +198,27 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 		return nil, status.EvalStatusFailed, fmt.Errorf("summarize eval set status: %w", err)
 	}
 	return caseSummaries, overallStatus, nil
+}
+
+func summarizeCaseSummaryStatus(metricSummaries []*evalresult.EvalMetricSummary, runStatuses []status.EvalStatus, hasRunError bool, numRuns int) (status.EvalStatus, error) {
+	if numRuns <= 1 {
+		return istatus.Summarize(runStatuses)
+	}
+	statuses := make([]status.EvalStatus, 0, len(metricSummaries))
+	for _, summary := range metricSummaries {
+		if summary == nil {
+			continue
+		}
+		statuses = append(statuses, summary.EvalStatus)
+	}
+	overallStatus, err := istatus.Summarize(statuses)
+	if err != nil {
+		return status.EvalStatusFailed, err
+	}
+	if overallStatus == status.EvalStatusNotEvaluated && hasRunError {
+		return status.EvalStatusFailed, nil
+	}
+	return overallStatus, nil
 }
 
 func addEvalStatus(counts *evalresult.EvalStatusCounts, s status.EvalStatus) error {

--- a/evaluation/internal/multirun/multirun.go
+++ b/evaluation/internal/multirun/multirun.go
@@ -132,7 +132,7 @@ func buildEvalSetRunSummaries(runCaseResults map[int][]*evalresult.EvalCaseResul
 
 type caseAgg struct {
 	runStatusCounts evalresult.EvalStatusCounts
-	hasRunError     bool
+	runStatuses     []status.EvalStatus
 	runSummaries    []*evalresult.EvalCaseRunSummary
 	metricAgg       map[string]*metricAgg
 }
@@ -153,9 +153,7 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 				agg = &caseAgg{metricAgg: make(map[string]*metricAgg)}
 				aggs[caseID] = agg
 			}
-			if caseResult.ErrorMessage != "" {
-				agg.hasRunError = true
-			}
+			agg.runStatuses = append(agg.runStatuses, caseResult.FinalEvalStatus)
 			if err := addEvalStatus(&agg.runStatusCounts, caseResult.FinalEvalStatus); err != nil {
 				return nil, status.EvalStatusFailed, err
 			}
@@ -175,7 +173,7 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 	caseStatuses := make([]status.EvalStatus, 0, len(aggs))
 	for caseID, agg := range aggs {
 		metricSummaries := buildMetricSummaries(agg.metricAgg)
-		overallStatus, err := summarizeOverallFromMetricSummaries(metricSummaries, agg.hasRunError)
+		overallStatus, err := istatus.Summarize(agg.runStatuses)
 		if err != nil {
 			return nil, status.EvalStatusFailed, fmt.Errorf("summarize case %s status: %w", caseID, err)
 		}
@@ -196,24 +194,6 @@ func buildEvalCaseSummaries(runCaseResults map[int][]*evalresult.EvalCaseResult,
 		return nil, status.EvalStatusFailed, fmt.Errorf("summarize eval set status: %w", err)
 	}
 	return caseSummaries, overallStatus, nil
-}
-
-func summarizeOverallFromMetricSummaries(metricSummaries []*evalresult.EvalMetricSummary, hasRunError bool) (status.EvalStatus, error) {
-	statuses := make([]status.EvalStatus, 0, len(metricSummaries))
-	for _, summary := range metricSummaries {
-		if summary == nil {
-			continue
-		}
-		statuses = append(statuses, summary.EvalStatus)
-	}
-	overallStatus, err := istatus.Summarize(statuses)
-	if err != nil {
-		return status.EvalStatusFailed, err
-	}
-	if overallStatus == status.EvalStatusNotEvaluated && hasRunError {
-		return status.EvalStatusFailed, nil
-	}
-	return overallStatus, nil
 }
 
 func addEvalStatus(counts *evalresult.EvalStatusCounts, s status.EvalStatus) error {

--- a/evaluation/internal/multirun/multirun_test.go
+++ b/evaluation/internal/multirun/multirun_test.go
@@ -231,6 +231,39 @@ func TestSummarizeMultiRunCaseRunErrorTurnsNotEvaluatedIntoFailed(t *testing.T) 
 	assert.Nil(t, caseSummary.MetricSummaries)
 }
 
+func TestSummarizeMultiRunMultipleRunsFailedWhenRunErrorHasNoMetrics(t *testing.T) {
+	result := &evalresult.EvalSetResult{
+		EvalSetID: "set",
+		EvalCaseResults: []*evalresult.EvalCaseResult{
+			{
+				EvalSetID:       "set",
+				EvalID:          "A",
+				RunID:           1,
+				FinalEvalStatus: status.EvalStatusNotEvaluated,
+				ErrorMessage:    "boom",
+			},
+		},
+	}
+
+	err := SummarizeMultiRun(result, 2)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, result.Summary)
+	if result.Summary == nil {
+		return
+	}
+
+	assert.Equal(t, status.EvalStatusFailed, result.Summary.OverallStatus)
+	assert.Len(t, result.Summary.EvalCaseSummaries, 1)
+	if len(result.Summary.EvalCaseSummaries) == 0 {
+		return
+	}
+
+	caseSummary := result.Summary.EvalCaseSummaries[0]
+	assert.Equal(t, status.EvalStatusFailed, caseSummary.OverallStatus)
+	assert.Nil(t, caseSummary.MetricSummaries)
+}
+
 func TestSummarizeMultiRunUsesCaseFinalStatusWhenMetricsFail(t *testing.T) {
 	result := &evalresult.EvalSetResult{
 		EvalSetID: "set",
@@ -274,6 +307,17 @@ func TestSummarizeMultiRunUsesCaseFinalStatusWhenMetricsFail(t *testing.T) {
 		assert.Equal(t, 1, caseSummary.RunStatusCounts.Passed)
 	}
 	assert.Len(t, caseSummary.MetricSummaries, 2)
+}
+
+func TestSummarizeCaseSummaryStatusRejectsInvalidMetricSummaryStatus(t *testing.T) {
+	overallStatus, err := summarizeCaseSummaryStatus(
+		[]*evalresult.EvalMetricSummary{{EvalStatus: status.EvalStatusUnknown}},
+		[]status.EvalStatus{status.EvalStatusPassed, status.EvalStatusPassed},
+		false,
+		2,
+	)
+	assert.Error(t, err)
+	assert.Equal(t, status.EvalStatusFailed, overallStatus)
 }
 
 func TestSummarizeMultiRunUsesMetricSummaryStatusAcrossMultipleRuns(t *testing.T) {

--- a/evaluation/internal/multirun/multirun_test.go
+++ b/evaluation/internal/multirun/multirun_test.go
@@ -201,7 +201,7 @@ func TestSummarizeMultiRunCaseRunErrorTurnsNotEvaluatedIntoFailed(t *testing.T) 
 				EvalSetID:       "set",
 				EvalID:          "A",
 				RunID:           1,
-				FinalEvalStatus: status.EvalStatusFailed,
+				FinalEvalStatus: status.EvalStatusNotEvaluated,
 				ErrorMessage:    "boom",
 			},
 		},
@@ -215,6 +215,7 @@ func TestSummarizeMultiRunCaseRunErrorTurnsNotEvaluatedIntoFailed(t *testing.T) 
 		return
 	}
 
+	assert.Equal(t, status.EvalStatusFailed, result.Summary.OverallStatus)
 	assert.Len(t, result.Summary.EvalCaseSummaries, 1)
 	if len(result.Summary.EvalCaseSummaries) == 0 {
 		return

--- a/evaluation/internal/multirun/multirun_test.go
+++ b/evaluation/internal/multirun/multirun_test.go
@@ -231,6 +231,51 @@ func TestSummarizeMultiRunCaseRunErrorTurnsNotEvaluatedIntoFailed(t *testing.T) 
 	assert.Nil(t, caseSummary.MetricSummaries)
 }
 
+func TestSummarizeMultiRunUsesCaseFinalStatusWhenMetricsFail(t *testing.T) {
+	result := &evalresult.EvalSetResult{
+		EvalSetID: "set",
+		EvalCaseResults: []*evalresult.EvalCaseResult{
+			{
+				EvalSetID:       "set",
+				EvalID:          "A",
+				RunID:           1,
+				Score:           0.8,
+				FinalEvalStatus: status.EvalStatusPassed,
+				OverallEvalMetricResults: []*evalresult.EvalMetricResult{
+					{MetricName: "important", Score: 1, EvalStatus: status.EvalStatusPassed, Threshold: 1},
+					{MetricName: "minor", Score: 0, EvalStatus: status.EvalStatusFailed, Threshold: 1},
+				},
+			},
+		},
+	}
+
+	err := SummarizeMultiRun(result, 1)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, result.Summary)
+	if result.Summary == nil {
+		return
+	}
+
+	assert.Equal(t, status.EvalStatusPassed, result.Summary.OverallStatus)
+	assert.NotNil(t, result.Summary.RunStatusCounts)
+	if result.Summary.RunStatusCounts != nil {
+		assert.Equal(t, 1, result.Summary.RunStatusCounts.Passed)
+	}
+	assert.Len(t, result.Summary.EvalCaseSummaries, 1)
+	if len(result.Summary.EvalCaseSummaries) == 0 {
+		return
+	}
+
+	caseSummary := result.Summary.EvalCaseSummaries[0]
+	assert.Equal(t, status.EvalStatusPassed, caseSummary.OverallStatus)
+	assert.NotNil(t, caseSummary.RunStatusCounts)
+	if caseSummary.RunStatusCounts != nil {
+		assert.Equal(t, 1, caseSummary.RunStatusCounts.Passed)
+	}
+	assert.Len(t, caseSummary.MetricSummaries, 2)
+}
+
 func TestSummarizeMultiRunMetricRunSummariesAreSortedByName(t *testing.T) {
 	result := &evalresult.EvalSetResult{
 		EvalSetID: "set",
@@ -457,11 +502,11 @@ func TestBuildEvalCaseSummariesSkipsNilCaseResults(t *testing.T) {
 
 	summaries, overall, err := buildEvalCaseSummaries(runCaseResults, []int{1})
 	assert.NoError(t, err)
-	assert.Equal(t, status.EvalStatusNotEvaluated, overall)
+	assert.Equal(t, status.EvalStatusPassed, overall)
 	assert.Len(t, summaries, 1)
 	if len(summaries) == 1 && summaries[0] != nil {
 		assert.Equal(t, "A", summaries[0].EvalID)
-		assert.Equal(t, status.EvalStatusNotEvaluated, summaries[0].OverallStatus)
+		assert.Equal(t, status.EvalStatusPassed, summaries[0].OverallStatus)
 		assert.Len(t, summaries[0].RunSummaries, 1)
 	}
 }
@@ -484,14 +529,6 @@ func TestBuildEvalCaseSummariesReturnsErrorOnUnexpectedMetricStatus(t *testing.T
 	_, _, err := buildEvalCaseSummaries(runCaseResults, []int{1})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected eval status")
-}
-
-func TestSummarizeOverallFromMetricSummariesErrorsOnUnknownStatusAndSkipsNil(t *testing.T) {
-	_, err := summarizeOverallFromMetricSummaries([]*evalresult.EvalMetricSummary{
-		nil,
-		{MetricName: "m", EvalStatus: status.EvalStatusUnknown},
-	}, false)
-	assert.Error(t, err)
 }
 
 func TestAddEvalStatusNilCountsReturnsError(t *testing.T) {

--- a/evaluation/internal/multirun/multirun_test.go
+++ b/evaluation/internal/multirun/multirun_test.go
@@ -276,6 +276,68 @@ func TestSummarizeMultiRunUsesCaseFinalStatusWhenMetricsFail(t *testing.T) {
 	assert.Len(t, caseSummary.MetricSummaries, 2)
 }
 
+func TestSummarizeMultiRunUsesMetricSummaryStatusAcrossMultipleRuns(t *testing.T) {
+	result := &evalresult.EvalSetResult{
+		EvalSetID: "set",
+		EvalCaseResults: []*evalresult.EvalCaseResult{
+			{
+				EvalSetID:       "set",
+				EvalID:          "A",
+				RunID:           1,
+				FinalEvalStatus: status.EvalStatusFailed,
+				OverallEvalMetricResults: []*evalresult.EvalMetricResult{
+					{MetricName: "m", Score: 0.5, EvalStatus: status.EvalStatusFailed, Threshold: 1},
+				},
+			},
+			{
+				EvalSetID:       "set",
+				EvalID:          "A",
+				RunID:           2,
+				FinalEvalStatus: status.EvalStatusPassed,
+				OverallEvalMetricResults: []*evalresult.EvalMetricResult{
+					{MetricName: "m", Score: 1.5, EvalStatus: status.EvalStatusPassed, Threshold: 1},
+				},
+			},
+		},
+	}
+
+	err := SummarizeMultiRun(result, 2)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, result.Summary)
+	if result.Summary == nil {
+		return
+	}
+
+	assert.Equal(t, status.EvalStatusPassed, result.Summary.OverallStatus)
+	assert.NotNil(t, result.Summary.RunStatusCounts)
+	if result.Summary.RunStatusCounts != nil {
+		assert.Equal(t, 1, result.Summary.RunStatusCounts.Passed)
+		assert.Equal(t, 1, result.Summary.RunStatusCounts.Failed)
+	}
+	assert.Len(t, result.Summary.EvalCaseSummaries, 1)
+	if len(result.Summary.EvalCaseSummaries) == 0 {
+		return
+	}
+
+	caseSummary := result.Summary.EvalCaseSummaries[0]
+	assert.Equal(t, status.EvalStatusPassed, caseSummary.OverallStatus)
+	assert.NotNil(t, caseSummary.RunStatusCounts)
+	if caseSummary.RunStatusCounts != nil {
+		assert.Equal(t, 1, caseSummary.RunStatusCounts.Passed)
+		assert.Equal(t, 1, caseSummary.RunStatusCounts.Failed)
+	}
+	assert.Len(t, caseSummary.MetricSummaries, 1)
+	if len(caseSummary.MetricSummaries) == 0 {
+		return
+	}
+
+	metricSummary := caseSummary.MetricSummaries[0]
+	assert.Equal(t, "m", metricSummary.MetricName)
+	assert.Equal(t, 1.0, metricSummary.AverageScore)
+	assert.Equal(t, status.EvalStatusPassed, metricSummary.EvalStatus)
+}
+
 func TestSummarizeMultiRunMetricRunSummariesAreSortedByName(t *testing.T) {
 	result := &evalresult.EvalSetResult{
 		EvalSetID: "set",

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -36,6 +36,7 @@ type options struct {
 	metricManager                     metric.Manager
 	registry                          registry.Registry
 	metricRegistry                    metricregistry.Registry
+	evalCaseResultAggregator          service.EvalCaseResultAggregator
 	evalService                       service.Service
 	expectedRunner                    runner.Runner
 	userSimulator                     usersimulation.Simulator
@@ -107,6 +108,13 @@ func WithRegistry(r registry.Registry) Option {
 func WithMetricRegistry(r metricregistry.Registry) Option {
 	return func(o *options) {
 		o.metricRegistry = r
+	}
+}
+
+// WithEvalCaseResultAggregator sets the eval case result aggregator for service evaluation.
+func WithEvalCaseResultAggregator(aggregator service.EvalCaseResultAggregator) Option {
+	return func(o *options) {
+		o.evalCaseResultAggregator = aggregator
 	}
 }
 

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -54,6 +54,12 @@ func (stubConversation) Close() error {
 	return nil
 }
 
+type stubEvalCaseResultAggregator struct{}
+
+func (stubEvalCaseResultAggregator) Aggregate(context.Context, *service.EvalCaseResultAggregationInput) (*service.EvalCaseResultAggregationResult, error) {
+	return &service.EvalCaseResultAggregationResult{}, nil
+}
+
 func TestNewOptionsDefaults(t *testing.T) {
 	opts := newOptions()
 
@@ -104,6 +110,12 @@ func TestWithMetricRegistry(t *testing.T) {
 	opts := newOptions(WithMetricRegistry(custom))
 
 	assert.Equal(t, custom, opts.metricRegistry)
+}
+
+func TestWithEvalCaseResultAggregator(t *testing.T) {
+	custom := stubEvalCaseResultAggregator{}
+	opts := newOptions(WithEvalCaseResultAggregator(custom))
+	assert.Equal(t, custom, opts.evalCaseResultAggregator)
 }
 
 func TestWithEvaluationService(t *testing.T) {

--- a/evaluation/service/aggregation.go
+++ b/evaluation/service/aggregation.go
@@ -1,0 +1,64 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	istatus "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/status"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+// EvalCaseResultAggregator aggregates metric results into one eval case result.
+type EvalCaseResultAggregator interface {
+	// Aggregate computes the case-level score and status from metric results.
+	Aggregate(ctx context.Context, input *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error)
+}
+
+// EvalCaseResultAggregationInput contains the context needed to aggregate one eval case result.
+type EvalCaseResultAggregationInput struct {
+	AppName         string                         // AppName identifies the app being evaluated.
+	EvalSetID       string                         // EvalSetID identifies the eval set.
+	EvalCase        *evalset.EvalCase              // EvalCase is the source eval case configuration.
+	InferenceResult *InferenceResult               // InferenceResult is the inference output being evaluated.
+	EvalMetrics     []*metric.EvalMetric           // EvalMetrics contains metrics that produced MetricResults in the same order.
+	MetricResults   []*evalresult.EvalMetricResult // MetricResults contains the overall metric results for the eval case.
+}
+
+// EvalCaseResultAggregationResult contains the aggregated eval case result.
+type EvalCaseResultAggregationResult struct {
+	Score  float64           // Score is the case-level score.
+	Status status.EvalStatus // Status is the case-level evaluation status.
+}
+
+type defaultEvalCaseResultAggregator struct{}
+
+func (defaultEvalCaseResultAggregator) Aggregate(_ context.Context, input *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error) {
+	if input == nil {
+		return nil, errors.New("eval case result aggregation input is nil")
+	}
+	finalStatus, err := istatus.SummarizeMetricsStatus(input.MetricResults)
+	if err != nil {
+		return nil, fmt.Errorf("summarize metric results: %w", err)
+	}
+	switch finalStatus {
+	case status.EvalStatusPassed:
+		return &EvalCaseResultAggregationResult{Score: 1, Status: finalStatus}, nil
+	case status.EvalStatusFailed, status.EvalStatusNotEvaluated:
+		return &EvalCaseResultAggregationResult{Score: 0, Status: finalStatus}, nil
+	default:
+		return nil, fmt.Errorf("unexpected eval status %v", finalStatus)
+	}
+}

--- a/evaluation/service/aggregation.go
+++ b/evaluation/service/aggregation.go
@@ -39,7 +39,7 @@ type EvalCaseResultAggregationInput struct {
 
 // EvalCaseResultAggregationResult contains the aggregated eval case result.
 type EvalCaseResultAggregationResult struct {
-	Score  float64           // Score is the case-level score.
+	Score  float64           // Score is the finite case-level score.
 	Status status.EvalStatus // Status is the case-level evaluation status.
 }
 

--- a/evaluation/service/aggregation_test.go
+++ b/evaluation/service/aggregation_test.go
@@ -1,0 +1,57 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+func TestDefaultEvalCaseResultAggregator(t *testing.T) {
+	tests := []struct {
+		name       string
+		metrics    []*evalresult.EvalMetricResult
+		wantScore  float64
+		wantStatus status.EvalStatus
+	}{
+		{name: "all passed", metrics: []*evalresult.EvalMetricResult{{EvalStatus: status.EvalStatusPassed}}, wantScore: 1, wantStatus: status.EvalStatusPassed},
+		{name: "one failed", metrics: []*evalresult.EvalMetricResult{{EvalStatus: status.EvalStatusPassed}, {EvalStatus: status.EvalStatusFailed}}, wantScore: 0, wantStatus: status.EvalStatusFailed},
+		{name: "not evaluated", metrics: []*evalresult.EvalMetricResult{{EvalStatus: status.EvalStatusNotEvaluated}}, wantScore: 0, wantStatus: status.EvalStatusNotEvaluated},
+		{name: "empty metrics", metrics: []*evalresult.EvalMetricResult{}, wantScore: 0, wantStatus: status.EvalStatusNotEvaluated},
+	}
+	aggregator := defaultEvalCaseResultAggregator{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := aggregator.Aggregate(context.Background(), &EvalCaseResultAggregationInput{MetricResults: tc.metrics})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantScore, got.Score)
+			assert.Equal(t, tc.wantStatus, got.Status)
+		})
+	}
+}
+
+func TestDefaultEvalCaseResultAggregatorRejectsInvalidInput(t *testing.T) {
+	aggregator := defaultEvalCaseResultAggregator{}
+	got, err := aggregator.Aggregate(context.Background(), nil)
+	assert.ErrorContains(t, err, "eval case result aggregation input is nil")
+	assert.Nil(t, got)
+	got, err = aggregator.Aggregate(context.Background(), &EvalCaseResultAggregationInput{
+		MetricResults: []*evalresult.EvalMetricResult{{EvalStatus: status.EvalStatusUnknown}},
+	})
+	assert.ErrorContains(t, err, "summarize metric results")
+	assert.Nil(t, got)
+}

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -29,7 +29,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/callback"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/clone"
-	istatus "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/status"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -53,6 +52,7 @@ type local struct {
 	evalResultManager                 evalresult.Manager
 	registry                          registry.Registry
 	metricRegistry                    metricregistry.Registry
+	evalCaseResultAggregator          service.EvalCaseResultAggregator
 	sessionIDSupplier                 func(ctx context.Context) string
 	userSimulator                     usersimulation.Simulator
 	callbacks                         *service.Callbacks
@@ -88,6 +88,9 @@ func New(runner runner.Runner, opt ...service.Option) (service.Service, error) {
 	if opts.MetricRegistry == nil {
 		return nil, errors.New("metric registry is nil")
 	}
+	if opts.EvalCaseResultAggregator == nil {
+		return nil, errors.New("eval case result aggregator is nil")
+	}
 	if opts.SessionIDSupplier == nil {
 		return nil, errors.New("session id supplier is nil")
 	}
@@ -99,6 +102,7 @@ func New(runner runner.Runner, opt ...service.Option) (service.Service, error) {
 		evalResultManager:                 opts.EvalResultManager,
 		registry:                          opts.Registry,
 		metricRegistry:                    opts.MetricRegistry,
+		evalCaseResultAggregator:          opts.EvalCaseResultAggregator,
 		sessionIDSupplier:                 opts.SessionIDSupplier,
 		userSimulator:                     opts.UserSimulator,
 		callbacks:                         opts.Callbacks,
@@ -393,6 +397,9 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 	if opts.Registry == nil {
 		return nil, errors.New("registry is nil")
 	}
+	if opts.EvalCaseResultAggregator == nil {
+		return nil, errors.New("eval case result aggregator is nil")
+	}
 	evalCase, err := opts.EvalSetManager.GetCase(ctx,
 		inferenceResult.AppName,
 		inferenceResult.EvalSetID,
@@ -417,6 +424,7 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 	}
 	// overallMetricResults collects the metric results for the entire eval case.
 	overallMetricResults := make([]*evalresult.EvalMetricResult, 0, len(evaluateConfig.EvalMetrics))
+	effectiveMetrics := make([]*metric.EvalMetric, 0, len(evaluateConfig.EvalMetrics))
 	perInvocation := make([]*evalresult.EvalMetricResultPerInvocation, len(inputs.actuals))
 	for i, actual := range inputs.actuals {
 		perInvocation[i] = &evalresult.EvalMetricResultPerInvocation{
@@ -447,6 +455,7 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 		if err != nil {
 			return nil, fmt.Errorf("run evaluation for metric %s: %w", evalMetric.MetricName, err)
 		}
+		effectiveMetrics = append(effectiveMetrics, evalMetric)
 		if len(result.PerInvocationResults) != len(perInvocation) {
 			return nil, fmt.Errorf("metric %s returned %d per-invocation results, expected %d", evalMetric.MetricName,
 				len(result.PerInvocationResults), len(perInvocation))
@@ -498,15 +507,30 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 			},
 		})
 	}
-	// Summarize the overall metric results and return the final eval status.
-	finalStatus, err := istatus.SummarizeMetricsStatus(overallMetricResults)
+	aggregation, err := opts.EvalCaseResultAggregator.Aggregate(ctx, &service.EvalCaseResultAggregationInput{
+		AppName:         inferenceResult.AppName,
+		EvalSetID:       inferenceResult.EvalSetID,
+		EvalCase:        evalCase,
+		InferenceResult: inferenceResult,
+		EvalMetrics:     effectiveMetrics,
+		MetricResults:   overallMetricResults,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("summarize overall metric results: %w", err)
+		return nil, fmt.Errorf("aggregate eval case result: %w", err)
+	}
+	if aggregation == nil {
+		return nil, errors.New("eval case result aggregation result is nil")
+	}
+	switch aggregation.Status {
+	case evalstatus.EvalStatusPassed, evalstatus.EvalStatusFailed, evalstatus.EvalStatusNotEvaluated:
+	default:
+		return nil, fmt.Errorf("unexpected eval case result aggregation status %v", aggregation.Status)
 	}
 	return &evalresult.EvalCaseResult{
 		EvalSetID:                     inferenceResult.EvalSetID,
 		EvalID:                        inferenceResult.EvalCaseID,
-		FinalEvalStatus:               finalStatus,
+		Score:                         aggregation.Score,
+		FinalEvalStatus:               aggregation.Status,
 		OverallEvalMetricResults:      overallMetricResults,
 		EvalMetricResultPerInvocation: perInvocation,
 		SessionID:                     inferenceResult.SessionID,

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -525,6 +526,9 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 	case evalstatus.EvalStatusPassed, evalstatus.EvalStatusFailed, evalstatus.EvalStatusNotEvaluated:
 	default:
 		return nil, fmt.Errorf("unexpected eval case result aggregation status %v", aggregation.Status)
+	}
+	if math.IsNaN(aggregation.Score) || math.IsInf(aggregation.Score, 0) {
+		return nil, fmt.Errorf("eval case result aggregation score must be finite: %v", aggregation.Score)
 	}
 	return &evalresult.EvalCaseResult{
 		EvalSetID:                     inferenceResult.EvalSetID,

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -388,6 +388,20 @@ func (f *fakeEvaluator) Evaluate(ctx context.Context, actuals, expecteds []*eval
 	return f.result, nil
 }
 
+type fakeEvalCaseResultAggregator struct {
+	result *service.EvalCaseResultAggregationResult
+	err    error
+	input  *service.EvalCaseResultAggregationInput
+}
+
+func (f *fakeEvalCaseResultAggregator) Aggregate(_ context.Context, input *service.EvalCaseResultAggregationInput) (*service.EvalCaseResultAggregationResult, error) {
+	f.input = input
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
 type blockingEvaluator struct {
 	name          string
 	result        *evaluator.EvaluateResult
@@ -678,6 +692,14 @@ func TestLocalNewValidationErrors(t *testing.T) {
 				service.WithRegistry(nil),
 			},
 			wantErr: "registry is nil",
+		},
+		{
+			name: "nil_eval_case_result_aggregator",
+			r:    &fakeRunner{},
+			options: []service.Option{
+				service.WithEvalCaseResultAggregator(nil),
+			},
+			wantErr: "eval case result aggregator is nil",
 		},
 		{
 			name: "nil_session_id_supplier",
@@ -2148,7 +2170,11 @@ func TestLocalEvaluatePerCaseErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, mgr, reg, inference, config := tc.setup(t)
-			opts := &service.Options{EvalSetManager: mgr, Registry: reg}
+			opts := &service.Options{
+				EvalSetManager:           mgr,
+				Registry:                 reg,
+				EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+			}
 			_, err := svc.evaluatePerCase(ctx, inference, config, opts)
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -2167,8 +2193,9 @@ func TestLocalEvaluatePerCaseRejectsNilManagers(t *testing.T) {
 	config := &service.EvaluateConfig{EvalMetrics: []*metric.EvalMetric{}}
 
 	_, err := svc.evaluatePerCase(ctx, inference, config, &service.Options{
-		EvalSetManager: nil,
-		Registry:       registry.New(),
+		EvalSetManager:           nil,
+		Registry:                 registry.New(),
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	})
 	assert.Error(t, err)
 	if err != nil {
@@ -2176,8 +2203,9 @@ func TestLocalEvaluatePerCaseRejectsNilManagers(t *testing.T) {
 	}
 
 	_, err = svc.evaluatePerCase(ctx, inference, config, &service.Options{
-		EvalSetManager: evalsetinmemory.New(),
-		Registry:       nil,
+		EvalSetManager:           evalsetinmemory.New(),
+		Registry:                 nil,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	})
 	assert.Error(t, err)
 	if err != nil {
@@ -3746,10 +3774,11 @@ func TestLocalEvaluateAfterEvaluateSetReceivesNilResultWhenEvaluateFails(t *test
 	})
 
 	svc := &local{
-		callbacks:      callbacks,
-		evalSetManager: evalsetinmemory.New(),
-		registry:       registry.New(),
-		metricRegistry: metricregistry.New(),
+		callbacks:                callbacks,
+		evalSetManager:           evalsetinmemory.New(),
+		registry:                 registry.New(),
+		metricRegistry:           metricregistry.New(),
+		evalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	}
 	_, err := svc.Evaluate(ctx, req)
 	assert.Error(t, err)
@@ -3789,10 +3818,11 @@ func TestLocalEvaluateAfterEvaluateSetReceivesRunResultOnSuccess(t *testing.T) {
 	})
 
 	svc := &local{
-		callbacks:      callbacks,
-		evalSetManager: evalsetinmemory.New(),
-		registry:       registry.New(),
-		metricRegistry: metricregistry.New(),
+		callbacks:                callbacks,
+		evalSetManager:           evalsetinmemory.New(),
+		registry:                 registry.New(),
+		metricRegistry:           metricregistry.New(),
+		evalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	}
 	res, err := svc.Evaluate(ctx, req)
 	assert.NoError(t, err)
@@ -4010,10 +4040,12 @@ func TestEvaluatePerCaseScenarioRunsConfiguredMetric(t *testing.T) {
 			{MetricName: "llm_rubric_response"},
 		},
 	}, &service.Options{
-		EvalSetManager: mgr,
-		Registry:       reg,
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, 1.0, result.Score)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	assert.Len(t, result.OverallEvalMetricResults, 1)
 	if assert.Len(t, result.EvalMetricResultPerInvocation, 1) {
@@ -4023,6 +4055,96 @@ func TestEvaluatePerCaseScenarioRunsConfiguredMetric(t *testing.T) {
 	assert.Equal(t, status.EvalStatusPassed, result.OverallEvalMetricResults[0].EvalStatus)
 	assert.Equal(t, inferenceResult.Inferences, fakeEval.receivedActuals)
 	assert.Len(t, fakeEval.receivedExpecteds, 1)
+}
+
+func TestLocalEvaluateUsesEvalCaseResultAggregator(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-aggregate"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, makeEvalCase(appName, caseID, "prompt")))
+	reg := registry.New()
+	fakeEval := &fakeEvaluator{
+		name: "metric_with_custom_aggregation",
+		result: &evaluator.EvaluateResult{
+			OverallScore:         0.2,
+			OverallStatus:        status.EvalStatusFailed,
+			PerInvocationResults: []*evaluator.PerInvocationResult{{Score: 0.2, Status: status.EvalStatusFailed}},
+		},
+	}
+	assert.NoError(t, reg.Register(fakeEval.name, fakeEval))
+	aggregator := &fakeEvalCaseResultAggregator{
+		result: &service.EvalCaseResultAggregationResult{Score: 0.75, Status: status.EvalStatusPassed},
+	}
+	svc, err := New(
+		&fakeRunner{},
+		service.WithEvalSetManager(mgr),
+		service.WithRegistry(reg),
+		service.WithEvalCaseResultAggregator(aggregator),
+	)
+	require.NoError(t, err)
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	runResult, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:   appName,
+		EvalSetID: evalSetID,
+		InferenceResults: []*service.InferenceResult{
+			inferenceResult,
+		},
+		EvaluateConfig: &service.EvaluateConfig{
+			EvalMetrics: []*metric.EvalMetric{{MetricName: fakeEval.name}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, runResult.EvalCaseResults, 1)
+	assert.Equal(t, 0.75, runResult.EvalCaseResults[0].Score)
+	assert.Equal(t, status.EvalStatusPassed, runResult.EvalCaseResults[0].FinalEvalStatus)
+	require.NotNil(t, aggregator.input)
+	assert.Equal(t, appName, aggregator.input.AppName)
+	assert.Equal(t, evalSetID, aggregator.input.EvalSetID)
+	require.NotNil(t, aggregator.input.EvalCase)
+	assert.Equal(t, caseID, aggregator.input.EvalCase.EvalID)
+	require.Len(t, aggregator.input.EvalMetrics, 1)
+	assert.Equal(t, fakeEval.name, aggregator.input.EvalMetrics[0].MetricName)
+	require.Len(t, aggregator.input.MetricResults, 1)
+	assert.Equal(t, status.EvalStatusFailed, aggregator.input.MetricResults[0].EvalStatus)
+}
+
+func TestLocalEvaluateMarksCaseFailedWhenEvalCaseResultAggregatorFails(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-aggregate-error"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, makeEvalCase(appName, caseID, "prompt")))
+	aggregator := &fakeEvalCaseResultAggregator{err: errors.New("aggregate failed")}
+	svc, err := New(
+		&fakeRunner{},
+		service.WithEvalSetManager(mgr),
+		service.WithEvalCaseResultAggregator(aggregator),
+	)
+	require.NoError(t, err)
+	runResult, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:   appName,
+		EvalSetID: evalSetID,
+		InferenceResults: []*service.InferenceResult{
+			makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+				makeActualInvocation("actual-1", "prompt", "answer"),
+			}),
+		},
+		EvaluateConfig: &service.EvaluateConfig{},
+	})
+	require.NoError(t, err)
+	require.Len(t, runResult.EvalCaseResults, 1)
+	assert.Equal(t, status.EvalStatusFailed, runResult.EvalCaseResults[0].FinalEvalStatus)
+	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "aggregate eval case result")
+	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "aggregate failed")
 }
 
 func TestBuildCaseEffectiveMetricAppendsCaseRubrics(t *testing.T) {
@@ -4114,8 +4236,9 @@ func TestEvaluatePerCaseUsesCaseEffectiveMetric(t *testing.T) {
 	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
 		EvalMetrics: []*metric.EvalMetric{configuredMetric},
 	}, &service.Options{
-		EvalSetManager: mgr,
-		Registry:       reg,
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
@@ -4173,7 +4296,11 @@ func TestEvaluatePerCaseBindsCaseRubricByMetricNameWhenEvaluatorNameDiffers(t *t
 				Criterion:     &criterion.Criterion{LLMJudge: &criterionllm.LLMCriterion{}},
 			},
 		},
-	}, &service.Options{EvalSetManager: mgr, Registry: reg})
+	}, &service.Options{
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	require.NotNil(t, fakeEval.receivedMetric)
@@ -4217,7 +4344,11 @@ func TestEvaluatePerCaseTemplateEvaluatorKeepsCaseRubricInEffectiveCriterion(t *
 				Criterion:     &criterion.Criterion{LLMJudge: &criterionllm.LLMCriterion{}},
 			},
 		},
-	}, &service.Options{EvalSetManager: mgr, Registry: reg})
+	}, &service.Options{
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	if assert.Len(t, result.OverallEvalMetricResults, 1) {
@@ -4290,7 +4421,11 @@ func TestEvaluatePerCaseTemplateTraceBindingMaterializesPromptAndPersistsActualT
 				},
 			},
 		},
-	}, &service.Options{EvalSetManager: mgr, Registry: reg})
+	}, &service.Options{
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	require.NotNil(t, fakeEval.receivedActuals[0].ExecutionTrace)
@@ -4574,8 +4709,9 @@ func TestEvaluatePerCaseSkipsMissingEvaluatorWithCaseRubric(t *testing.T) {
 			{MetricName: "missing_metric"},
 		},
 	}, &service.Options{
-		EvalSetManager: mgr,
-		Registry:       reg,
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusNotEvaluated, result.FinalEvalStatus)

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -388,6 +388,22 @@ func (f *fakeEvaluator) Evaluate(ctx context.Context, actuals, expecteds []*eval
 	return f.result, nil
 }
 
+type failingRegistry struct {
+	err error
+}
+
+func (f failingRegistry) Register(string, evaluator.Evaluator) error {
+	return nil
+}
+
+func (f failingRegistry) Get(string) (evaluator.Evaluator, error) {
+	return nil, f.err
+}
+
+func (f failingRegistry) List() []string {
+	return nil
+}
+
 type fakeEvalCaseResultAggregator struct {
 	result *service.EvalCaseResultAggregationResult
 	err    error
@@ -692,6 +708,14 @@ func TestLocalNewValidationErrors(t *testing.T) {
 				service.WithRegistry(nil),
 			},
 			wantErr: "registry is nil",
+		},
+		{
+			name: "nil_metric_registry",
+			r:    &fakeRunner{},
+			options: []service.Option{
+				service.WithMetricRegistry(nil),
+			},
+			wantErr: "metric registry is nil",
 		},
 		{
 			name: "nil_eval_case_result_aggregator",
@@ -1516,6 +1540,42 @@ func TestLocalEvaluateRequestValidation(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestLocalResolveEvaluateOptionsUsesStoredEvalCaseResultAggregator(t *testing.T) {
+	aggregator := &fakeEvalCaseResultAggregator{}
+	svc := &local{
+		evalSetManager:           evalsetinmemory.New(),
+		registry:                 registry.New(),
+		metricRegistry:           metricregistry.New(),
+		evalCaseResultAggregator: aggregator,
+	}
+	opts, err := svc.resolveEvaluateOptions()
+	assert.NoError(t, err)
+	require.NotNil(t, opts)
+	assert.Same(t, aggregator, opts.EvalCaseResultAggregator)
+}
+
+func TestLocalResolveEvaluateOptionsRejectsNilEvalCaseResultAggregator(t *testing.T) {
+	svc := &local{
+		evalSetManager: evalsetinmemory.New(),
+		registry:       registry.New(),
+		metricRegistry: metricregistry.New(),
+	}
+	opts, err := svc.resolveEvaluateOptions()
+	assert.ErrorContains(t, err, "eval case result aggregator is nil")
+	assert.Nil(t, opts)
+}
+
+func TestLocalResolveEvaluateOptionsRejectsNilMetricRegistry(t *testing.T) {
+	svc := &local{
+		evalSetManager:           evalsetinmemory.New(),
+		registry:                 registry.New(),
+		evalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	}
+	opts, err := svc.resolveEvaluateOptions()
+	assert.ErrorContains(t, err, "metric registry is nil")
+	assert.Nil(t, opts)
+}
+
 func TestLocalEvaluateParallelInvokeFailureAddsContext(t *testing.T) {
 	ctx := context.Background()
 	appName := "app"
@@ -1569,6 +1629,35 @@ func TestLocalEvaluateParallelInvokeFailureAddsContext(t *testing.T) {
 	if err != nil {
 		assert.Contains(t, err.Error(), "submit evaluation task for eval case case")
 	}
+}
+
+func TestLocalEvaluateWrapsMetricExtensionResolveError(t *testing.T) {
+	ctx := context.Background()
+	svc := &local{
+		evalSetManager:           evalsetinmemory.New(),
+		registry:                 registry.New(),
+		metricRegistry:           metricregistry.New(),
+		evalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	}
+	result, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:          "app",
+		EvalSetID:        "set",
+		InferenceResults: []*service.InferenceResult{},
+		EvaluateConfig: &service.EvaluateConfig{
+			EvalMetrics: []*metric.EvalMetric{
+				{
+					Criterion: &criterion.Criterion{
+						FinalResponse: &finalresponse.FinalResponseCriterion{
+							Text: &criteriontext.TextCriterion{CompareName: "missing"},
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.ErrorContains(t, err, "resolve metric extensions")
+	assert.ErrorContains(t, err, "resolve metric at index 0")
+	assert.Nil(t, result)
 }
 
 func TestLocalEvaluateSuccess(t *testing.T) {
@@ -2211,6 +2300,61 @@ func TestLocalEvaluatePerCaseRejectsNilManagers(t *testing.T) {
 	if err != nil {
 		assert.Contains(t, err.Error(), "registry is nil")
 	}
+}
+
+func TestLocalEvaluatePerCaseReturnsRegistryLookupError(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-registry-error"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	require.NoError(t, err)
+	require.NoError(t, mgr.AddCase(ctx, appName, evalSetID, makeEvalCase(appName, caseID, "prompt")))
+	svc := &local{}
+	inference := makeInferenceResult(appName, evalSetID, caseID, "session", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.evaluatePerCase(ctx, inference, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{{MetricName: "metric-registry-error"}},
+	}, &service.Options{
+		EvalSetManager:           mgr,
+		Registry:                 failingRegistry{err: errors.New("registry failed")},
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	})
+	assert.ErrorContains(t, err, "registry failed")
+	assert.Nil(t, result)
+}
+
+func TestLocalEvaluatePerCaseReturnsEffectiveMetricError(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-effective-metric-error"
+	metricName := "metric-case-rubric"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	require.NoError(t, err)
+	evalCase := makeEvalCase(appName, caseID, "prompt")
+	evalCase.Rubrics = []*evalset.EvalCaseRubric{
+		{MetricName: metricName, ID: "case-rubric", Content: &evalset.EvalCaseRubricContent{Text: "Case-specific rule."}},
+	}
+	require.NoError(t, mgr.AddCase(ctx, appName, evalSetID, evalCase))
+	reg := registry.New()
+	require.NoError(t, reg.Register(metricName, &fakeEvaluator{name: metricName}))
+	svc := &local{}
+	inference := makeInferenceResult(appName, evalSetID, caseID, "session", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	result, err := svc.evaluatePerCase(ctx, inference, &service.EvaluateConfig{
+		EvalMetrics: []*metric.EvalMetric{{MetricName: metricName}},
+	}, &service.Options{
+		EvalSetManager:           mgr,
+		Registry:                 reg,
+		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
+	})
+	assert.ErrorContains(t, err, "llmJudge criterion is required")
+	assert.Nil(t, result)
 }
 
 func TestLocalInferenceTraceModeSkipsRunner(t *testing.T) {
@@ -4145,6 +4289,56 @@ func TestLocalEvaluateMarksCaseFailedWhenEvalCaseResultAggregatorFails(t *testin
 	assert.Equal(t, status.EvalStatusFailed, runResult.EvalCaseResults[0].FinalEvalStatus)
 	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "aggregate eval case result")
 	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "aggregate failed")
+}
+
+func TestLocalEvaluatePerCaseRejectsInvalidEvalCaseResultAggregation(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-invalid-aggregation"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	require.NoError(t, err)
+	require.NoError(t, mgr.AddCase(ctx, appName, evalSetID, makeEvalCase(appName, caseID, "prompt")))
+	reg := registry.New()
+	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-1")
+	inferenceResult := makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+		makeActualInvocation("actual-1", "prompt", "answer"),
+	})
+	tests := []struct {
+		name       string
+		aggregator service.EvalCaseResultAggregator
+		wantErr    string
+	}{
+		{
+			name:       "nil aggregator",
+			aggregator: nil,
+			wantErr:    "eval case result aggregator is nil",
+		},
+		{
+			name:       "nil aggregation result",
+			aggregator: &fakeEvalCaseResultAggregator{},
+			wantErr:    "eval case result aggregation result is nil",
+		},
+		{
+			name: "unknown aggregation status",
+			aggregator: &fakeEvalCaseResultAggregator{
+				result: &service.EvalCaseResultAggregationResult{Status: status.EvalStatusUnknown},
+			},
+			wantErr: "unexpected eval case result aggregation status",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{}, &service.Options{
+				EvalSetManager:           mgr,
+				Registry:                 reg,
+				EvalCaseResultAggregator: tc.aggregator,
+			})
+			assert.ErrorContains(t, err, tc.wantErr)
+			assert.Nil(t, result)
+		})
+	}
 }
 
 func TestBuildCaseEffectiveMetricAppendsCaseRubrics(t *testing.T) {

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -4289,6 +4290,40 @@ func TestLocalEvaluateMarksCaseFailedWhenEvalCaseResultAggregatorFails(t *testin
 	assert.Equal(t, status.EvalStatusFailed, runResult.EvalCaseResults[0].FinalEvalStatus)
 	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "aggregate eval case result")
 	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "aggregate failed")
+}
+
+func TestLocalEvaluateMarksCaseFailedWhenEvalCaseResultAggregatorReturnsNonFiniteScore(t *testing.T) {
+	ctx := context.Background()
+	appName := "app"
+	evalSetID := "set"
+	caseID := "case-aggregate-nan"
+	mgr := evalsetinmemory.New()
+	_, err := mgr.Create(ctx, appName, evalSetID)
+	assert.NoError(t, err)
+	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, makeEvalCase(appName, caseID, "prompt")))
+	aggregator := &fakeEvalCaseResultAggregator{
+		result: &service.EvalCaseResultAggregationResult{Score: math.NaN(), Status: status.EvalStatusPassed},
+	}
+	svc, err := New(
+		&fakeRunner{},
+		service.WithEvalSetManager(mgr),
+		service.WithEvalCaseResultAggregator(aggregator),
+	)
+	require.NoError(t, err)
+	runResult, err := svc.Evaluate(ctx, &service.EvaluateRequest{
+		AppName:   appName,
+		EvalSetID: evalSetID,
+		InferenceResults: []*service.InferenceResult{
+			makeInferenceResult(appName, evalSetID, caseID, "session-1", []*evalset.Invocation{
+				makeActualInvocation("actual-1", "prompt", "answer"),
+			}),
+		},
+		EvaluateConfig: &service.EvaluateConfig{},
+	})
+	require.NoError(t, err)
+	require.Len(t, runResult.EvalCaseResults, 1)
+	assert.Equal(t, status.EvalStatusFailed, runResult.EvalCaseResults[0].FinalEvalStatus)
+	assert.Contains(t, runResult.EvalCaseResults[0].ErrorMessage, "eval case result aggregation score must be finite")
 }
 
 func TestLocalEvaluatePerCaseRejectsInvalidEvalCaseResultAggregation(t *testing.T) {

--- a/evaluation/service/local/options.go
+++ b/evaluation/service/local/options.go
@@ -54,6 +54,7 @@ func (s *local) resolveEvaluateOptions(opt ...service.Option) (*service.Options,
 		EvalSetManager:                    s.evalSetManager,
 		Registry:                          s.registry,
 		MetricRegistry:                    s.metricRegistry,
+		EvalCaseResultAggregator:          s.evalCaseResultAggregator,
 		ExpectedRunner:                    s.expectedRunner,
 		ToolMockRunner:                    s.toolMockRunner,
 		Callbacks:                         s.callbacks,
@@ -73,6 +74,9 @@ func (s *local) resolveEvaluateOptions(opt ...service.Option) (*service.Options,
 	}
 	if callOpts.MetricRegistry == nil {
 		return nil, errors.New("metric registry is nil")
+	}
+	if callOpts.EvalCaseResultAggregator == nil {
+		return nil, errors.New("eval case result aggregator is nil")
 	}
 	if callOpts.EvalCaseParallelEvaluationEnabled {
 		if callOpts.EvalCaseParallelism <= 0 {

--- a/evaluation/service/options.go
+++ b/evaluation/service/options.go
@@ -31,6 +31,7 @@ type Options struct {
 	EvalResultManager                 evalresult.Manager               // EvalResultManager is used to store and retrieve eval results.
 	Registry                          registry.Registry                // Registry is used to store and retrieve evaluator.
 	MetricRegistry                    metricregistry.Registry          // MetricRegistry resolves runtime metric extensions.
+	EvalCaseResultAggregator          EvalCaseResultAggregator         // EvalCaseResultAggregator computes eval case score and status.
 	SessionIDSupplier                 func(ctx context.Context) string // SessionIDSupplier is used to generate session IDs.
 	ExpectedRunner                    runner.Runner                    // ExpectedRunner is used to generate dynamic expected outputs.
 	ToolMockRunner                    runner.Runner                    // ToolMockRunner generates dynamic tool mock results.
@@ -48,10 +49,11 @@ type Option func(*Options)
 // NewOptions creates a new Options with the default values.
 func NewOptions(opt ...Option) *Options {
 	opts := &Options{
-		EvalSetManager:    evalsetinmemory.New(),
-		EvalResultManager: evalresultinmemory.New(),
-		Registry:          registry.New(),
-		MetricRegistry:    metricregistry.New(),
+		EvalSetManager:           evalsetinmemory.New(),
+		EvalResultManager:        evalresultinmemory.New(),
+		Registry:                 registry.New(),
+		MetricRegistry:           metricregistry.New(),
+		EvalCaseResultAggregator: defaultEvalCaseResultAggregator{},
 		SessionIDSupplier: func(ctx context.Context) string {
 			return uuid.New().String()
 		},
@@ -93,6 +95,13 @@ func WithRegistry(r registry.Registry) Option {
 func WithMetricRegistry(r metricregistry.Registry) Option {
 	return func(o *Options) {
 		o.MetricRegistry = r
+	}
+}
+
+// WithEvalCaseResultAggregator sets the eval case result aggregator.
+func WithEvalCaseResultAggregator(aggregator EvalCaseResultAggregator) Option {
+	return func(o *Options) {
+		o.EvalCaseResultAggregator = aggregator
 	}
 }
 

--- a/evaluation/service/options_test.go
+++ b/evaluation/service/options_test.go
@@ -52,12 +52,19 @@ func (stubConversation) Close() error {
 	return nil
 }
 
+type stubEvalCaseResultAggregator struct{}
+
+func (stubEvalCaseResultAggregator) Aggregate(context.Context, *EvalCaseResultAggregationInput) (*EvalCaseResultAggregationResult, error) {
+	return &EvalCaseResultAggregationResult{}, nil
+}
+
 func TestNewOptionsDefaults(t *testing.T) {
 	opts := NewOptions()
 	assert.NotNil(t, opts.EvalSetManager)
 	assert.NotNil(t, opts.EvalResultManager)
 	assert.NotNil(t, opts.Registry)
 	assert.NotNil(t, opts.MetricRegistry)
+	assert.NotNil(t, opts.EvalCaseResultAggregator)
 	assert.NotNil(t, opts.SessionIDSupplier)
 	assert.Nil(t, opts.ExpectedRunner)
 	assert.Nil(t, opts.UserSimulator)
@@ -91,6 +98,12 @@ func TestWithMetricRegistry(t *testing.T) {
 	custom := metricregistry.New()
 	opts := NewOptions(WithMetricRegistry(custom))
 	assert.Equal(t, custom, opts.MetricRegistry)
+}
+
+func TestWithEvalCaseResultAggregator(t *testing.T) {
+	custom := stubEvalCaseResultAggregator{}
+	opts := NewOptions(WithEvalCaseResultAggregator(custom))
+	assert.Equal(t, custom, opts.EvalCaseResultAggregator)
 }
 
 func TestWithSessionIDSupplier(t *testing.T) {

--- a/examples/evaluation/caseaggregation/README.md
+++ b/examples/evaluation/caseaggregation/README.md
@@ -1,0 +1,113 @@
+# Case Aggregation Evaluation Example
+
+This example shows how to compute a case-level score and status with a custom `service.EvalCaseResultAggregator`.
+
+It uses local file managers, a real LLM support agent, built-in final-response metrics, and a custom aggregator.
+
+## What It Demonstrates
+
+- Injecting a custom case result aggregator through `evaluation.WithEvalCaseResultAggregator`.
+- Routing multiple metric instances to the built-in `final_response_avg_score` evaluator with `evaluatorName`.
+- Reading metric weights from `EvalMetric.Extension`.
+- Computing each metric's normal `score`, `threshold`, and `evalStatus`.
+- Computing the eval-case `score` and `finalEvalStatus` with a weighted aggregation policy.
+
+## Environment Variables
+
+The example supports the following environment variables:
+
+| Variable | Description | Default Value |
+|----------|-------------|---------------|
+| `OPENAI_API_KEY` | API key for the model service (required) | `` |
+| `OPENAI_BASE_URL` | Base URL for the model API endpoint | `https://api.openai.com/v1` |
+
+**Note**: The `OPENAI_API_KEY` is required for the example to work.
+
+## Run
+
+Configure the OpenAI-compatible model service first.
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export OPENAI_BASE_URL="https://api.deepseek.com/v1"
+```
+
+```bash
+cd examples/evaluation/caseaggregation
+go run . \
+  -model "deepseek-v4-flash" \
+  -data-dir "./data" \
+  -output-dir "./output" \
+  -eval-set "support-quality-basic"
+```
+
+## Key Metric Configuration
+
+```json
+[
+  {
+    "metricName": "answer_is_substantive",
+    "evaluatorName": "final_response_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "matchStrategy": "skip",
+          "length": {
+            "min": 40
+          }
+        }
+      }
+    },
+    "extension": {
+      "weight": 0.8
+    }
+  },
+  {
+    "metricName": "max_six_chars",
+    "evaluatorName": "final_response_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "matchStrategy": "skip",
+          "length": {
+            "max": 6
+          }
+        }
+      }
+    },
+    "extension": {
+      "weight": 0.2
+    }
+  }
+]
+```
+
+`metricName` is the business metric name shown in results. `evaluatorName` selects the built-in evaluator implementation from Registry. The custom aggregator reads `weight` from `EvalMetric.Extension` and uses its own threshold configuration to decide the case status.
+
+## Data Layout
+
+```shell
+data/
+└── case-aggregation-app/
+    ├── support-quality-basic.evalset.json
+    └── support-quality-basic.metrics.json
+```
+
+## Output
+
+```log
+Evaluation completed with case aggregation
+App: case-aggregation-app
+Eval Set: support-quality-basic
+Saved Result: output/case-aggregation-app/case-aggregation-app_support-quality-basic_xxx.evalset_result.json
+Case support_weighted_tradeoff run 1 -> passed (case score 0.80)
+  Actual Response: Please contact your workspace administrator or support team to review the account lock and restore access.
+  Metric answer_is_substantive: score 1.00 (threshold 1.00) => passed
+  Metric max_six_chars: score 0.00 (threshold 1.00) => failed
+```
+
+The case demonstrates the custom policy: one metric fails, but the case passes because the weighted case score reaches the case threshold.
+
+The top-level summary follows the case-level `finalEvalStatus`. Metric summaries still keep each metric's own pass/fail status for diagnostics, so a failed metric can appear in the summary while the case and overall result are passed.

--- a/examples/evaluation/caseaggregation/README.md
+++ b/examples/evaluation/caseaggregation/README.md
@@ -110,4 +110,4 @@ Case support_weighted_tradeoff run 1 -> passed (case score 0.80)
 
 The case demonstrates the custom policy: one metric fails, but the case passes because the weighted case score reaches the case threshold.
 
-The top-level summary follows the case-level `finalEvalStatus`. Metric summaries still keep each metric's own pass/fail status for diagnostics, so a failed metric can appear in the summary while the case and overall result are passed.
+Because this example runs once, the top-level summary follows the case-level `finalEvalStatus`. Metric summaries still keep each metric's own pass/fail status for diagnostics, so a failed metric can appear in the summary while the case and overall result are passed.

--- a/examples/evaluation/caseaggregation/agent.go
+++ b/examples/evaluation/caseaggregation/agent.go
@@ -1,0 +1,42 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+func newSupportAgent(modelName string, stream bool) agent.Agent {
+	genCfg := model.GenerationConfig{
+		MaxTokens:   intPtr(128),
+		Temperature: floatPtr(0.0),
+		Stream:      stream,
+	}
+	return llmagent.New(
+		caseAggregationAgentName,
+		llmagent.WithModel(openai.New(modelName)),
+		llmagent.WithInstruction(""+
+			"You are a support assistant.\n"+
+			"Answer the user in one clear, concise, and helpful sentence."),
+		llmagent.WithDescription("Support assistant for account access questions."),
+		llmagent.WithGenerationConfig(genCfg),
+	)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}

--- a/examples/evaluation/caseaggregation/aggregator.go
+++ b/examples/evaluation/caseaggregation/aggregator.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type weightedCaseAggregator struct {
+	Threshold float64
+}
+
+type metricSettings struct {
+	Weight float64
+}
+
+func (a weightedCaseAggregator) Aggregate(_ context.Context,
+	input *service.EvalCaseResultAggregationInput) (*service.EvalCaseResultAggregationResult, error) {
+	if input == nil {
+		return nil, errors.New("aggregation input is nil")
+	}
+	weightedScore := 0.0
+	totalWeight := 0.0
+	for i, evalMetric := range input.EvalMetrics {
+		if evalMetric == nil || i >= len(input.MetricResults) || input.MetricResults[i] == nil {
+			continue
+		}
+		settings := readMetricSettings(evalMetric.Extension)
+		weightedScore += input.MetricResults[i].Score * settings.Weight
+		totalWeight += settings.Weight
+	}
+	if totalWeight == 0 {
+		return &service.EvalCaseResultAggregationResult{
+			Score:  0,
+			Status: status.EvalStatusNotEvaluated,
+		}, nil
+	}
+	score := weightedScore / totalWeight
+	resultStatus := status.EvalStatusFailed
+	if score >= a.Threshold {
+		resultStatus = status.EvalStatusPassed
+	}
+	return &service.EvalCaseResultAggregationResult{
+		Score:  score,
+		Status: resultStatus,
+	}, nil
+}
+
+func readMetricSettings(extension any) metricSettings {
+	values, ok := extension.(map[string]any)
+	if !ok {
+		return metricSettings{Weight: 1}
+	}
+	settings := metricSettings{Weight: 1}
+	if weight, ok := values["weight"].(float64); ok && weight > 0 {
+		settings.Weight = weight
+	}
+	return settings
+}

--- a/examples/evaluation/caseaggregation/data/case-aggregation-app/support-quality-basic.evalset.json
+++ b/examples/evaluation/caseaggregation/data/case-aggregation-app/support-quality-basic.evalset.json
@@ -1,0 +1,22 @@
+{
+  "evalSetId": "support-quality-basic",
+  "name": "support-quality-basic",
+  "evalCases": [
+    {
+      "evalId": "support_weighted_tradeoff",
+      "conversation": [
+        {
+          "invocationId": "support_weighted_tradeoff-1",
+          "userContent": {
+            "role": "user",
+            "content": "My workspace account is locked."
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "case-aggregation-app",
+        "userId": "demo-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/caseaggregation/data/case-aggregation-app/support-quality-basic.metrics.json
+++ b/examples/evaluation/caseaggregation/data/case-aggregation-app/support-quality-basic.metrics.json
@@ -1,0 +1,38 @@
+[
+  {
+    "metricName": "answer_is_substantive",
+    "evaluatorName": "final_response_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "matchStrategy": "skip",
+          "length": {
+            "min": 40
+          }
+        }
+      }
+    },
+    "extension": {
+      "weight": 0.8
+    }
+  },
+  {
+    "metricName": "max_six_chars",
+    "evaluatorName": "final_response_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "matchStrategy": "skip",
+          "length": {
+            "max": 6
+          }
+        }
+      }
+    },
+    "extension": {
+      "weight": 0.2
+    }
+  }
+]

--- a/examples/evaluation/caseaggregation/main.go
+++ b/examples/evaluation/caseaggregation/main.go
@@ -1,0 +1,72 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+var (
+	dataDir   = flag.String("data-dir", "./data", "Directory containing evaluation set and metric files")
+	outputDir = flag.String("output-dir", "./output", "Directory where evaluation results will be stored")
+	evalSetID = flag.String("eval-set", defaultEvalSetID, "Evaluation set identifier to execute")
+	modelName = flag.String("model", "deepseek-v4-flash", "Model to use for evaluation runs")
+	streaming = flag.Bool("streaming", false, "Enable streaming responses from the agent")
+)
+
+const (
+	appName                  = "case-aggregation-app"
+	defaultEvalSetID         = "support-quality-basic"
+	caseAggregationAgentName = "case-aggregation-agent"
+	defaultCaseThreshold     = 0.8
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	run := runner.NewRunner(appName, newSupportAgent(*modelName, *streaming))
+	defer run.Close()
+	evalSetManager := evalsetlocal.New(evalset.WithBaseDir(*dataDir))
+	metricManager := metriclocal.New(metric.WithBaseDir(*dataDir))
+	evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(*outputDir))
+	reg := registry.New()
+	agentEvaluator, err := evaluation.New(
+		appName,
+		run,
+		evaluation.WithEvalSetManager(evalSetManager),
+		evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager),
+		evaluation.WithRegistry(reg),
+		evaluation.WithEvalCaseResultAggregator(weightedCaseAggregator{
+			Threshold: defaultCaseThreshold,
+		}),
+	)
+	if err != nil {
+		log.Fatalf("create evaluator: %v", err)
+	}
+	defer agentEvaluator.Close()
+	result, err := agentEvaluator.Evaluate(ctx, *evalSetID)
+	if err != nil {
+		log.Fatalf("evaluate: %v", err)
+	}
+	printSummary(result, *outputDir)
+}

--- a/examples/evaluation/caseaggregation/output/case-aggregation-app/case-aggregation-app_support-quality-basic_381aabbc-352f-4b9c-bb8d-27accddc9abb.evalset_result.json
+++ b/examples/evaluation/caseaggregation/output/case-aggregation-app/case-aggregation-app_support-quality-basic_381aabbc-352f-4b9c-bb8d-27accddc9abb.evalset_result.json
@@ -1,0 +1,199 @@
+{
+  "evalSetResultId": "case-aggregation-app_support-quality-basic_381aabbc-352f-4b9c-bb8d-27accddc9abb",
+  "evalSetResultName": "case-aggregation-app_support-quality-basic_381aabbc-352f-4b9c-bb8d-27accddc9abb",
+  "evalSetId": "support-quality-basic",
+  "evalCaseResults": [
+    {
+      "evalSetId": "support-quality-basic",
+      "evalId": "support_weighted_tradeoff",
+      "runId": 1,
+      "score": 0.8,
+      "finalEvalStatus": "passed",
+      "overallEvalMetricResults": [
+        {
+          "metricName": "answer_is_substantive",
+          "score": 1,
+          "evalStatus": "passed",
+          "threshold": 1,
+          "criterion": {
+            "finalResponse": {
+              "text": {
+                "matchStrategy": "skip",
+                "length": {
+                  "min": 40
+                }
+              }
+            }
+          },
+          "details": {
+            "score": 1
+          }
+        },
+        {
+          "metricName": "max_six_chars",
+          "evalStatus": "failed",
+          "threshold": 1,
+          "criterion": {
+            "finalResponse": {
+              "text": {
+                "matchStrategy": "skip",
+                "length": {
+                  "max": 6
+                }
+              }
+            }
+          },
+          "details": {
+            "reason": "final response mismatch: text mismatch: length mismatch: actual length 137 is greater than max 6, expected range [0, 6]"
+          }
+        }
+      ],
+      "evalMetricResultPerInvocation": [
+        {
+          "actualInvocation": {
+            "invocationId": "07b2c059-bc47-4678-b293-a93623c919f1",
+            "userContent": {
+              "role": "user",
+              "content": "My workspace account is locked."
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "Your workspace account is locked; please contact your IT administrator or use the \"Forgot Password\" option to reset it and regain access."
+            }
+          },
+          "expectedInvocation": {
+            "invocationId": "support_weighted_tradeoff-1",
+            "userContent": {
+              "role": "user",
+              "content": "My workspace account is locked."
+            }
+          },
+          "evalMetricResults": [
+            {
+              "metricName": "answer_is_substantive",
+              "score": 1,
+              "evalStatus": "passed",
+              "threshold": 1,
+              "criterion": {
+                "finalResponse": {
+                  "text": {
+                    "matchStrategy": "skip",
+                    "length": {
+                      "min": 40
+                    }
+                  }
+                }
+              },
+              "details": {
+                "score": 1
+              }
+            },
+            {
+              "metricName": "max_six_chars",
+              "evalStatus": "failed",
+              "threshold": 1,
+              "criterion": {
+                "finalResponse": {
+                  "text": {
+                    "matchStrategy": "skip",
+                    "length": {
+                      "max": 6
+                    }
+                  }
+                }
+              },
+              "details": {
+                "reason": "final response mismatch: text mismatch: length mismatch: actual length 137 is greater than max 6, expected range [0, 6]"
+              }
+            }
+          ]
+        }
+      ],
+      "sessionId": "fbbc32b5-a0b5-4c03-b5ba-43a0f5131314",
+      "userId": "demo-user"
+    }
+  ],
+  "summary": {
+    "overallStatus": "passed",
+    "numRuns": 1,
+    "runStatusCounts": {
+      "passed": 1
+    },
+    "runSummaries": [
+      {
+        "runId": 1,
+        "overallStatus": "passed",
+        "caseStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "answer_is_substantive",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          },
+          {
+            "metricName": "max_six_chars",
+            "evalStatus": "failed",
+            "threshold": 1,
+            "statusCounts": {
+              "failed": 1
+            }
+          }
+        ]
+      }
+    ],
+    "evalCaseSummaries": [
+      {
+        "evalId": "support_weighted_tradeoff",
+        "overallStatus": "passed",
+        "runStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "answer_is_substantive",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          },
+          {
+            "metricName": "max_six_chars",
+            "evalStatus": "failed",
+            "threshold": 1,
+            "statusCounts": {
+              "failed": 1
+            }
+          }
+        ],
+        "runSummaries": [
+          {
+            "runId": 1,
+            "finalEvalStatus": "passed",
+            "metricResults": [
+              {
+                "metricName": "answer_is_substantive",
+                "score": 1,
+                "evalStatus": "passed",
+                "threshold": 1
+              },
+              {
+                "metricName": "max_six_chars",
+                "evalStatus": "failed",
+                "threshold": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "creationTimestamp": 1784776035.293141
+}

--- a/examples/evaluation/caseaggregation/print.go
+++ b/examples/evaluation/caseaggregation/print.go
@@ -1,0 +1,61 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+)
+
+func printSummary(result *evaluation.EvaluationResult, outDir string) {
+	fmt.Println("Evaluation completed with case aggregation")
+	fmt.Printf("App: %s\n", result.AppName)
+	fmt.Printf("Eval Set: %s\n", result.EvalSetID)
+	if result.EvalResult != nil && result.EvalResult.EvalSetResultID != "" {
+		fmt.Printf("Saved Result: %s\n", filepath.Join(outDir, appName, result.EvalResult.EvalSetResultID+".evalset_result.json"))
+	}
+	for _, caseSummary := range result.EvalCases {
+		for _, caseResult := range caseSummary.EvalCaseResults {
+			fmt.Printf("Case %s run %d -> %s (case score %.2f)\n",
+				caseResult.EvalID,
+				caseResult.RunID,
+				caseResult.FinalEvalStatus,
+				caseResult.Score,
+			)
+			if response := actualFinalResponse(caseResult); response != "" {
+				fmt.Printf("  Actual Response: %s\n", response)
+			}
+			for _, metricResult := range caseResult.OverallEvalMetricResults {
+				fmt.Printf("  Metric %s: score %.2f (threshold %.2f) => %s\n",
+					metricResult.MetricName,
+					metricResult.Score,
+					metricResult.Threshold,
+					metricResult.EvalStatus,
+				)
+			}
+			fmt.Println()
+		}
+	}
+}
+
+func actualFinalResponse(caseResult *evalresult.EvalCaseResult) string {
+	if caseResult == nil || len(caseResult.EvalMetricResultPerInvocation) == 0 {
+		return ""
+	}
+	invocationResult := caseResult.EvalMetricResultPerInvocation[0]
+	if invocationResult == nil || invocationResult.ActualInvocation == nil ||
+		invocationResult.ActualInvocation.FinalResponse == nil {
+		return ""
+	}
+	return invocationResult.ActualInvocation.FinalResponse.Content
+}


### PR DESCRIPTION
Adds a service-level eval case result aggregator that computes case score and status from metric results while preserving the default all-metrics-pass behavior.