### PR TITLE
{evaluation, docs}: extend template bindings

### DIFF
--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1738,7 +1738,7 @@ The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in r
 
 `actual.userContent`, `actual.finalResponse`, and `expected.finalResponse` render the current scoring turn's user input, actual final response, and expected final response respectively. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID` to specify the trace step `NodeID`; the resolver selects the last matching step from the current invocation's `executionTrace.steps` and reads `Input.Text` or `Output.Text`. When using a trace source, the evaluation call must pass `agent.WithExecutionTraceEnabled(true)`. If the current actual invocation has no `ExecutionTrace`, evaluation fails. `expected.finalResponse` requires the current expected turn to contain `finalResponse`. If the template binds that field but the expected turn has only placeholder `userContent` and no `finalResponse`, evaluation fails directly. `metric.rubrics` renders the effective `criterion.llmJudge.rubrics` for the current metric as a JSON string, including case-level rubrics after merging.
 
-`source.path` is optional. It extracts a JSON subfield after the source value is resolved. It supports a restricted JSONPath subset: root selector `$`, object fields such as `.field`, and array indexes such as `[index]`, for example `$[0].content.text`. Wildcards and filters are not supported. Extracted strings are rendered as-is; extracted objects or arrays are encoded back to JSON strings.
+`source.path` is optional. It extracts a JSON subfield after the source value is resolved. It supports a restricted JSONPath subset: root selector `$`, object fields such as `.field`, and array indexes such as `[index]`, for example `$[0].content.text`. Quoted bracket keys, wildcards, filters, field names containing dots, and missing delimiters after array indexes are not supported. If the resolved source is not valid JSON, or if the path is invalid, missing, out of range, or reaches the wrong type, evaluation fails. Extracted strings are rendered as-is; extracted objects or arrays are encoded back to JSON strings.
 
 For example, a template can bind the first rubric text from the current metric:
 
@@ -2545,7 +2545,7 @@ Variable bindings support the following sources:
 
 Every placeholder in the template must be explicitly bound in `variableBindings`. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID`; the resolver selects the last step whose `NodeID` matches in the current invocation execution trace. When using a trace source, the evaluation caller must enable `agent.WithExecutionTraceEnabled(true)`. Binding `expected.finalResponse` requires the current expected turn to contain `finalResponse`; if the template uses that field but the expected turn does not contain a final response, evaluation fails directly. `metric.rubrics` renders the effective `criterion.llmJudge.rubrics` for the current metric as a JSON string, including case-level rubrics after merging.
 
-`source.path` can extract a JSON subfield from the resolved source value. It supports restricted JSONPath forms such as `$`, `.field`, and `[index]`. For example:
+`source.path` can extract a JSON subfield from the resolved source value. It supports restricted JSONPath forms such as `$`, `.field`, and `[index]`; quoted bracket keys, wildcards, filters, field names containing dots, and missing delimiters after array indexes are not supported. If the source is not valid JSON or path traversal fails, evaluation fails. For example:
 
 ```json
 {

--- a/docs/mkdocs/en/evaluation.md
+++ b/docs/mkdocs/en/evaluation.md
@@ -1617,6 +1617,7 @@ type TemplateVariableSource struct {
 	Scope    TemplateVariableScope     // Scope is the source scope.
 	Field    TemplateVariableField     // Field is the source field.
 	Selector *TemplateVariableSelector // Selector is the trace step selector.
+	Path     string                    // Path is an optional JSONPath for extracting a subfield from the source value.
 }
 
 // TemplateVariableSelector represents a template variable selector.
@@ -1630,6 +1631,7 @@ type TemplateVariableScope string
 const (
 	TemplateVariableScopeActual   TemplateVariableScope = "actual"
 	TemplateVariableScopeExpected TemplateVariableScope = "expected"
+	TemplateVariableScopeMetric   TemplateVariableScope = "metric"
 )
 
 // TemplateVariableField represents the template variable source field.
@@ -1640,6 +1642,7 @@ const (
 	TemplateVariableFieldFinalResponse   TemplateVariableField = "finalResponse"
 	TemplateVariableFieldTraceStepInput  TemplateVariableField = "traceStepInput"
 	TemplateVariableFieldTraceStepOutput TemplateVariableField = "traceStepOutput"
+	TemplateVariableFieldRubrics         TemplateVariableField = "rubrics"
 )
 
 // Rubric represents one evaluation rubric.
@@ -1720,19 +1723,50 @@ When `sampleParallelismEnabled=true` and `sampleParallelism=2`, the parallelism 
 
 The target metric uses `criterion.llmJudge` to carry the rubric list. Built-in rubric evaluators read the merged criteria and use structured output by default to make the judge return per-rubric scores through `rubricScores`. During `Evaluate`, after metric-level rubrics and `EvalCase.rubrics` are merged and before the judge model is called, each merged rubric used by structured output must have a non-empty and unique `id`. If validation fails, evaluation returns an error such as `llm judge rubric id is required for structured output` or `duplicate llm judge rubric id "accuracy"`. To debug ID conflicts, inspect the merged `criterion.llmJudge.rubrics` from the metric configuration and case-level rubrics. Custom rubric evaluators can read the same field.
 
-`template` is used only by `llm_judge_template`. It keeps template-based evaluation focused on cases where the prompt changes while the evaluation orchestration stays the same. Template evaluators do not read `rubrics`; evaluation criteria should be written directly into `template.prompt`.
+`template` is used only by `llm_judge_template`. It keeps template-based evaluation focused on cases where the prompt changes while the evaluation orchestration stays the same. Template evaluators do not evaluate structured `rubrics` like the `llm_rubric_*` family by default; write the evaluation criteria directly into `template.prompt`, or explicitly bind `metric.rubrics` when the prompt needs the current metric rubrics.
 
 `template.prompt` uses double-brace template syntax such as `{{question}}` and `{{answer}}`. Every placeholder must be explicitly bound in `variableBindings`. Unbound variables, unknown variables, or binding resolution failures all result in errors.
 
-`template.variableBindings` supports values from `actual` and `expected` in the current scoring turn:
+`template.variableBindings` supports values from `actual`, `expected`, and the current metric configuration:
 
 - `actual.userContent`
 - `actual.finalResponse`
 - `actual.traceStepInput`
 - `actual.traceStepOutput`
 - `expected.finalResponse`
+- `metric.rubrics`
 
-`actual.userContent`, `actual.finalResponse`, and `expected.finalResponse` render the current scoring turn's user input, actual final response, and expected final response respectively. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID` to specify the trace step `NodeID`; the resolver selects the last matching step from the current invocation's `executionTrace.steps` and reads `Input.Text` or `Output.Text`. When using a trace source, the evaluation call must pass `agent.WithExecutionTraceEnabled(true)`. If the current actual invocation has no `ExecutionTrace`, evaluation fails. `expected.finalResponse` requires the current expected turn to contain `finalResponse`. If the template binds that field but the expected turn has only placeholder `userContent` and no `finalResponse`, evaluation fails directly.
+`actual.userContent`, `actual.finalResponse`, and `expected.finalResponse` render the current scoring turn's user input, actual final response, and expected final response respectively. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID` to specify the trace step `NodeID`; the resolver selects the last matching step from the current invocation's `executionTrace.steps` and reads `Input.Text` or `Output.Text`. When using a trace source, the evaluation call must pass `agent.WithExecutionTraceEnabled(true)`. If the current actual invocation has no `ExecutionTrace`, evaluation fails. `expected.finalResponse` requires the current expected turn to contain `finalResponse`. If the template binds that field but the expected turn has only placeholder `userContent` and no `finalResponse`, evaluation fails directly. `metric.rubrics` renders the effective `criterion.llmJudge.rubrics` for the current metric as a JSON string, including case-level rubrics after merging.
+
+`source.path` is optional. It extracts a JSON subfield after the source value is resolved. It supports a restricted JSONPath subset: root selector `$`, object fields such as `.field`, and array indexes such as `[index]`, for example `$[0].content.text`. Wildcards and filters are not supported. Extracted strings are rendered as-is; extracted objects or arrays are encoded back to JSON strings.
+
+For example, a template can bind the first rubric text from the current metric:
+
+```json
+{
+  "templateVariable": "first_rubric",
+  "source": {
+    "scope": "metric",
+    "field": "rubrics",
+    "path": "$[0].content.text"
+  }
+}
+```
+
+If the agent final response is itself a valid JSON string, `path` can extract fields from it. For example, when `actual.finalResponse.content` is `{"answer":"Paris","confidence":0.98}`:
+
+```json
+{
+  "templateVariable": "answer",
+  "source": {
+    "scope": "actual",
+    "field": "finalResponse",
+    "path": "$.answer"
+  }
+}
+```
+
+Plain natural-language text, Markdown fenced JSON, or content with extra prefixes or suffixes is not trimmed or repaired automatically.
 
 `template.responseScorerName` specifies how judge output is parsed. The current supported values are:
 
@@ -2489,7 +2523,7 @@ Example metric configuration for LLM pairwise comparison:
 
 ##### LLM Template Evaluator
 
-The LLM template evaluator uses the evaluator name `llm_judge_template` and belongs to the LLM Judge evaluator family. It is suitable for scenarios where the evaluation orchestration stays the same, but you want to reduce the number of evaluator definitions by customizing the judge prompt, variable bindings, and response parsing strategy. Unlike the `llm_rubric_*` family, template evaluators do not consume structured `rubrics`; evaluation criteria should be written directly into `criterion.llmJudge.template.prompt`.
+The LLM template evaluator uses the evaluator name `llm_judge_template` and belongs to the LLM Judge evaluator family. It is suitable for scenarios where the evaluation orchestration stays the same, but you want to reduce the number of evaluator definitions by customizing the judge prompt, variable bindings, and response parsing strategy. Unlike the `llm_rubric_*` family, template evaluators do not evaluate structured `rubrics` by default; evaluation criteria usually belong in `criterion.llmJudge.template.prompt`, and prompts can explicitly bind `metric.rubrics` when they need the current metric rubrics.
 
 Template evaluators are typically configured with `evaluatorName: "llm_judge_template"`, while `metricName` remains the metric instance name. This allows one metric file to define multiple template metrics, such as one using `single_score`, another using `rubric_scores`, and another using a platform-registered scorer, while reusing the same evaluator implementation and keeping distinct `metricName` values in results.
 
@@ -2507,8 +2541,35 @@ Variable bindings support the following sources:
 - `actual.traceStepInput`
 - `actual.traceStepOutput`
 - `expected.finalResponse`
+- `metric.rubrics`
 
-Every placeholder in the template must be explicitly bound in `variableBindings`. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID`; the resolver selects the last step whose `NodeID` matches in the current invocation execution trace. When using a trace source, the evaluation caller must enable `agent.WithExecutionTraceEnabled(true)`. Binding `expected.finalResponse` requires the current expected turn to contain `finalResponse`; if the template uses that field but the expected turn does not contain a final response, evaluation fails directly.
+Every placeholder in the template must be explicitly bound in `variableBindings`. `actual.traceStepInput` and `actual.traceStepOutput` require `source.selector.nodeID`; the resolver selects the last step whose `NodeID` matches in the current invocation execution trace. When using a trace source, the evaluation caller must enable `agent.WithExecutionTraceEnabled(true)`. Binding `expected.finalResponse` requires the current expected turn to contain `finalResponse`; if the template uses that field but the expected turn does not contain a final response, evaluation fails directly. `metric.rubrics` renders the effective `criterion.llmJudge.rubrics` for the current metric as a JSON string, including case-level rubrics after merging.
+
+`source.path` can extract a JSON subfield from the resolved source value. It supports restricted JSONPath forms such as `$`, `.field`, and `[index]`. For example:
+
+```json
+{
+  "templateVariable": "first_rubric",
+  "source": {
+    "scope": "metric",
+    "field": "rubrics",
+    "path": "$[0].content.text"
+  }
+}
+```
+
+If the agent final response is itself a valid JSON string, `path` can extract fields from it. For example, when `actual.finalResponse.content` is `{"answer":"Paris","confidence":0.98}`:
+
+```json
+{
+  "templateVariable": "answer",
+  "source": {
+    "scope": "actual",
+    "field": "finalResponse",
+    "path": "$.answer"
+  }
+}
+```
 
 The template evaluator currently provides four built-in response parsing modes:
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1620,6 +1620,7 @@ type TemplateVariableSource struct {
 	Scope    TemplateVariableScope     // Scope 是来源作用域
 	Field    TemplateVariableField     // Field 是来源字段
 	Selector *TemplateVariableSelector // Selector 是 trace step 选择器，可选
+	Path     string                    // Path 是可选 JSONPath，用于从来源值中继续提取子字段
 }
 
 // TemplateVariableSelector 表示模板变量选择器
@@ -1633,6 +1634,7 @@ type TemplateVariableScope string
 const (
 	TemplateVariableScopeActual   TemplateVariableScope = "actual"
 	TemplateVariableScopeExpected TemplateVariableScope = "expected"
+	TemplateVariableScopeMetric   TemplateVariableScope = "metric"
 )
 
 // TemplateVariableField 表示模板变量来源字段
@@ -1643,6 +1645,7 @@ const (
 	TemplateVariableFieldFinalResponse   TemplateVariableField = "finalResponse"
 	TemplateVariableFieldTraceStepInput  TemplateVariableField = "traceStepInput"
 	TemplateVariableFieldTraceStepOutput TemplateVariableField = "traceStepOutput"
+	TemplateVariableFieldRubrics         TemplateVariableField = "rubrics"
 )
 
 // Rubric 表示一条评估细则
@@ -1718,19 +1721,50 @@ type RubricContent struct {
 
 目标 metric 使用 `criterion.llmJudge` 承载 rubric 列表。内置 rubric evaluator 会读取合并后的细则，并默认使用结构化输出让裁判按 `rubricScores` 返回逐条评分。每次 `Evaluate` 执行时，框架会先合并 metric 级 rubrics 与 `EvalCase.rubrics`，再在调用裁判模型前校验参与结构化输出的 merged rubric：每条 rubric 都必须具备非空且唯一的 `id`。如果校验失败，评估会返回类似 `llm judge rubric id is required for structured output` 或 `duplicate llm judge rubric id "accuracy"` 的错误。排查时请检查 metric 配置与 case 级 rubrics 合并后的 `criterion.llmJudge.rubrics` 及其 `id`。自定义 rubric evaluator 按同一字段读取即可。
 
-`template` 仅用于 `llm_judge_template`。它将模板化评估限制在“prompt 不同，但评估编排逻辑相同”的场景，不要求框架把所有评估器都表达成模板。模板评估器不读取 `rubrics`，评估标准应直接写入 `template.prompt`。
+`template` 仅用于 `llm_judge_template`。它将模板化评估限制在“prompt 不同，但评估编排逻辑相同”的场景，不要求框架把所有评估器都表达成模板。模板评估器默认不会像 `llm_rubric_*` 系列那样按结构化 `rubrics` 执行评估；如果模板需要引用当前指标的 rubric 内容，可以通过 `metric.rubrics` 显式绑定到 prompt。
 
 `template.prompt` 使用双大括号模板语法，例如 `{{question}}`、`{{answer}}`。每个占位符都必须在 `variableBindings` 中显式绑定；未绑定变量、未知变量或绑定解析失败都会直接报错，不存在“可选变量”或空字符串兜底。
 
-`template.variableBindings` 支持从当前评分轮的 `actual` 和 `expected` 中取值：
+`template.variableBindings` 支持从当前评分轮的 `actual`、`expected` 以及当前指标配置 `metric` 中取值：
 
 - `actual.userContent`
 - `actual.finalResponse`
 - `actual.traceStepInput`
 - `actual.traceStepOutput`
 - `expected.finalResponse`
+- `metric.rubrics`
 
-其中 `actual.userContent`、`actual.finalResponse`、`expected.finalResponse` 分别渲染当前评分轮的用户输入、实际最终回答和预期最终回答；`actual.traceStepInput` 与 `actual.traceStepOutput` 需要在 `source.selector.nodeID` 中指定 trace step 的 `NodeID`，解析器会在当前 invocation 的 `executionTrace.steps` 中选择最后一个匹配 step，并分别读取 `Input.Text` 或 `Output.Text`。使用 trace source 时，发起评估需要传入 `agent.WithExecutionTraceEnabled(true)`；如果当前 actual invocation 没有 `ExecutionTrace`，评估会报错。`expected.finalResponse` 要求当前预期轮必须存在 `finalResponse`；如果模板绑定了该字段，但预期轮只有占位 `userContent`、没有 `finalResponse`，评估会直接报错。
+其中 `actual.userContent`、`actual.finalResponse`、`expected.finalResponse` 分别渲染当前评分轮的用户输入、实际最终回答和预期最终回答；`actual.traceStepInput` 与 `actual.traceStepOutput` 需要在 `source.selector.nodeID` 中指定 trace step 的 `NodeID`，解析器会在当前 invocation 的 `executionTrace.steps` 中选择最后一个匹配 step，并分别读取 `Input.Text` 或 `Output.Text`。使用 trace source 时，发起评估需要传入 `agent.WithExecutionTraceEnabled(true)`；如果当前 actual invocation 没有 `ExecutionTrace`，评估会报错。`expected.finalResponse` 要求当前预期轮必须存在 `finalResponse`；如果模板绑定了该字段，但预期轮只有占位 `userContent`、没有 `finalResponse`，评估会直接报错。`metric.rubrics` 会把当前指标生效的 `criterion.llmJudge.rubrics` 渲染为 JSON 字符串，包含 case 级 rubric 合并后的结果。
+
+`source.path` 是可选字段，用于在来源值解析完成后继续提取 JSON 子字段。它支持受限 JSONPath：根选择器 `$`、对象字段 `.field`、数组下标 `[index]`，例如 `$[0].content.text`；不支持通配符或过滤表达式。提取到字符串时会原样渲染，提取到对象或数组时会重新编码为 JSON 字符串。
+
+例如，模板可以把当前指标的第一条 rubric 文本绑定为一个变量：
+
+```json
+{
+  "templateVariable": "first_rubric",
+  "source": {
+    "scope": "metric",
+    "field": "rubrics",
+    "path": "$[0].content.text"
+  }
+}
+```
+
+如果 agent 的最终回答本身是合法 JSON 字符串，也可以用 `path` 提取其中字段。例如 `actual.finalResponse.content` 为 `{"answer":"Paris","confidence":0.98}` 时：
+
+```json
+{
+  "templateVariable": "answer",
+  "source": {
+    "scope": "actual",
+    "field": "finalResponse",
+    "path": "$.answer"
+  }
+}
+```
+
+普通自然语言文本、Markdown code fence 包裹的 JSON 或带额外前后缀的内容不会被自动裁剪或修正。
 
 `template.responseScorerName` 用于指定如何解析裁判输出，当前支持：
 
@@ -2486,7 +2520,7 @@ LLM 成对比较评估指标配置示例如下：
 
 ##### LLM 模板评估器
 
-LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM Judge 类评估器。它适用于这样一类场景：评估执行链路本身没有变化，但希望通过自定义 prompt、变量绑定和响应解析策略来减少新评估器定义数量。与 `llm_rubric_*` 系列不同，模板评估器不消费结构化 `rubrics`，评估标准应直接写入 `criterion.llmJudge.template.prompt`。
+LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM Judge 类评估器。它适用于这样一类场景：评估执行链路本身没有变化，但希望通过自定义 prompt、变量绑定和响应解析策略来减少新评估器定义数量。与 `llm_rubric_*` 系列不同，模板评估器默认不会按结构化 `rubrics` 执行评估；评估标准通常直接写入 `criterion.llmJudge.template.prompt`，需要复用当前指标 rubric 时再通过 `metric.rubrics` 显式绑定。
 
 模板评估器通常配合 `evaluatorName: "llm_judge_template"` 使用，并让 `metricName` 仅承担指标实例名的职责。这样一份指标文件里可以同时配置多条模板评估指标，例如一条走 `single_score`，另一条走 `rubric_scores`，另一条走平台注册的 scorer，它们都复用同一个评估器实现，但结果中的 `metricName` 彼此独立。
 
@@ -2504,8 +2538,35 @@ LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM
 - `actual.traceStepInput`
 - `actual.traceStepOutput`
 - `expected.finalResponse`
+- `metric.rubrics`
 
-模板中的每个占位符都必须在 `variableBindings` 中显式绑定。`actual.traceStepInput` 与 `actual.traceStepOutput` 需要配置 `source.selector.nodeID`，解析器会选择当前 invocation execution trace 中最后一个 `NodeID` 匹配的 step。使用 trace source 时，评估调用方需要开启 `agent.WithExecutionTraceEnabled(true)`；`expected.finalResponse` 绑定要求当前预期轮存在 `finalResponse`，如果模板使用了该字段但预期轮没有最终回答，评估会直接报错。
+模板中的每个占位符都必须在 `variableBindings` 中显式绑定。`actual.traceStepInput` 与 `actual.traceStepOutput` 需要配置 `source.selector.nodeID`，解析器会选择当前 invocation execution trace 中最后一个 `NodeID` 匹配的 step。使用 trace source 时，评估调用方需要开启 `agent.WithExecutionTraceEnabled(true)`；`expected.finalResponse` 绑定要求当前预期轮存在 `finalResponse`，如果模板使用了该字段但预期轮没有最终回答，评估会直接报错。`metric.rubrics` 会把当前指标生效的 `criterion.llmJudge.rubrics` 渲染为 JSON 字符串，包含 case 级 rubric 合并后的结果。
+
+`source.path` 可以从来源值中继续提取 JSON 子字段，支持 `$`、`.field`、`[index]` 这类受限 JSONPath。例如：
+
+```json
+{
+  "templateVariable": "first_rubric",
+  "source": {
+    "scope": "metric",
+    "field": "rubrics",
+    "path": "$[0].content.text"
+  }
+}
+```
+
+如果 agent 的最终回答本身是合法 JSON 字符串，也可以用 `path` 提取其中字段。例如 `actual.finalResponse.content` 为 `{"answer":"Paris","confidence":0.98}` 时：
+
+```json
+{
+  "templateVariable": "answer",
+  "source": {
+    "scope": "actual",
+    "field": "finalResponse",
+    "path": "$.answer"
+  }
+}
+```
 
 模板评估器当前内置四种响应解析模式：
 

--- a/docs/mkdocs/zh/evaluation.md
+++ b/docs/mkdocs/zh/evaluation.md
@@ -1736,7 +1736,7 @@ type RubricContent struct {
 
 其中 `actual.userContent`、`actual.finalResponse`、`expected.finalResponse` 分别渲染当前评分轮的用户输入、实际最终回答和预期最终回答；`actual.traceStepInput` 与 `actual.traceStepOutput` 需要在 `source.selector.nodeID` 中指定 trace step 的 `NodeID`，解析器会在当前 invocation 的 `executionTrace.steps` 中选择最后一个匹配 step，并分别读取 `Input.Text` 或 `Output.Text`。使用 trace source 时，发起评估需要传入 `agent.WithExecutionTraceEnabled(true)`；如果当前 actual invocation 没有 `ExecutionTrace`，评估会报错。`expected.finalResponse` 要求当前预期轮必须存在 `finalResponse`；如果模板绑定了该字段，但预期轮只有占位 `userContent`、没有 `finalResponse`，评估会直接报错。`metric.rubrics` 会把当前指标生效的 `criterion.llmJudge.rubrics` 渲染为 JSON 字符串，包含 case 级 rubric 合并后的结果。
 
-`source.path` 是可选字段，用于在来源值解析完成后继续提取 JSON 子字段。它支持受限 JSONPath：根选择器 `$`、对象字段 `.field`、数组下标 `[index]`，例如 `$[0].content.text`；不支持通配符或过滤表达式。提取到字符串时会原样渲染，提取到对象或数组时会重新编码为 JSON 字符串。
+`source.path` 是可选字段，用于在来源值解析完成后继续提取 JSON 子字段。它支持受限 JSONPath：根选择器 `$`、对象字段 `.field`、数组下标 `[index]`，例如 `$[0].content.text`；不支持带引号的方括号 key、通配符、过滤表达式、字段名中包含点号的 key，也不支持数组下标后省略分隔符。来源值不是合法 JSON、路径语法非法、字段或下标不存在、越界或类型不匹配时，评估会失败。提取到字符串时会原样渲染，提取到对象或数组时会重新编码为 JSON 字符串。
 
 例如，模板可以把当前指标的第一条 rubric 文本绑定为一个变量：
 
@@ -2542,7 +2542,7 @@ LLM 模板评估器对应的评估器名称为 `llm_judge_template`，属于 LLM
 
 模板中的每个占位符都必须在 `variableBindings` 中显式绑定。`actual.traceStepInput` 与 `actual.traceStepOutput` 需要配置 `source.selector.nodeID`，解析器会选择当前 invocation execution trace 中最后一个 `NodeID` 匹配的 step。使用 trace source 时，评估调用方需要开启 `agent.WithExecutionTraceEnabled(true)`；`expected.finalResponse` 绑定要求当前预期轮存在 `finalResponse`，如果模板使用了该字段但预期轮没有最终回答，评估会直接报错。`metric.rubrics` 会把当前指标生效的 `criterion.llmJudge.rubrics` 渲染为 JSON 字符串，包含 case 级 rubric 合并后的结果。
 
-`source.path` 可以从来源值中继续提取 JSON 子字段，支持 `$`、`.field`、`[index]` 这类受限 JSONPath。例如：
+`source.path` 可以从来源值中继续提取 JSON 子字段，支持 `$`、`.field`、`[index]` 这类受限 JSONPath；不支持带引号的方括号 key、通配符、过滤表达式、字段名中包含点号的 key，也不支持数组下标后省略分隔符。来源值不是合法 JSON 或路径解析失败时，评估会失败。例如：
 
 ```json
 {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
@@ -11,12 +11,14 @@ package template
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor/internal/content"
 	operatorregistry "trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/jsonpath"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	metricllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -62,7 +64,7 @@ func (c *templateMessagesConstructor) ConstructMessages(ctx context.Context, act
 	if templateOptions.ResponseScorerName == "" {
 		return nil, fmt.Errorf("template responseScorerName is empty")
 	}
-	values, err := resolveTemplateValues(actuals, expecteds, templateOptions.VariableBindings)
+	values, err := resolveTemplateValues(actuals, expecteds, evalMetric, templateOptions.VariableBindings)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +103,7 @@ func judgeTemplateOptions(evalMetric *metric.EvalMetric) (*metricllm.JudgeTempla
 	return evalMetric.Criterion.LLMJudge.Template, nil
 }
 
-func resolveTemplateValues(actuals, expecteds []*evalset.Invocation,
+func resolveTemplateValues(actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric,
 	bindings []*metricllm.TemplateVariableBinding) (prompt.Vars, error) {
 	values := make(prompt.Vars, len(bindings))
 	seen := make(map[string]struct{}, len(bindings))
@@ -117,7 +119,7 @@ func resolveTemplateValues(actuals, expecteds []*evalset.Invocation,
 			return nil, fmt.Errorf("templateVariable %q is duplicated", name)
 		}
 		seen[name] = struct{}{}
-		value, err := resolveBindingValue(actuals, expecteds, binding.Source)
+		value, err := resolveBindingValue(actuals, expecteds, evalMetric, binding.Source)
 		if err != nil {
 			return nil, fmt.Errorf("resolve template variable %q: %w", name, err)
 		}
@@ -126,19 +128,30 @@ func resolveTemplateValues(actuals, expecteds []*evalset.Invocation,
 	return values, nil
 }
 
-func resolveBindingValue(actuals, expecteds []*evalset.Invocation,
+func resolveBindingValue(actuals, expecteds []*evalset.Invocation, evalMetric *metric.EvalMetric,
 	source *metricllm.TemplateVariableSource) (string, error) {
 	if source == nil {
 		return "", fmt.Errorf("source is nil")
 	}
+	var value string
+	var err error
 	switch source.Scope {
 	case metricllm.TemplateVariableScopeActual:
-		return resolveActualValue(actuals, source)
+		value, err = resolveActualValue(actuals, source)
 	case metricllm.TemplateVariableScopeExpected:
-		return resolveExpectedValue(expecteds, source)
+		value, err = resolveExpectedValue(expecteds, source)
+	case metricllm.TemplateVariableScopeMetric:
+		value, err = resolveMetricValue(evalMetric, source)
 	default:
 		return "", fmt.Errorf("unsupported source %s.%s", source.Scope, source.Field)
 	}
+	if err != nil {
+		return "", err
+	}
+	if source.Path == "" {
+		return value, nil
+	}
+	return jsonpath.Extract(value, source.Path)
 }
 
 func resolveActualValue(actuals []*evalset.Invocation, source *metricllm.TemplateVariableSource) (string, error) {
@@ -182,6 +195,38 @@ func resolveExpectedValue(expecteds []*evalset.Invocation, source *metricllm.Tem
 		return "", fmt.Errorf("unsupported source %s.%s",
 			metricllm.TemplateVariableScopeExpected, source.Field)
 	}
+}
+
+func resolveMetricValue(evalMetric *metric.EvalMetric, source *metricllm.TemplateVariableSource) (string, error) {
+	if evalMetric == nil || evalMetric.Criterion == nil || evalMetric.Criterion.LLMJudge == nil {
+		return "", fmt.Errorf("llm judge criterion is required")
+	}
+	switch source.Field {
+	case metricllm.TemplateVariableFieldRubrics:
+		rubrics := visibleRubrics(evalMetric.Criterion.LLMJudge.Rubrics)
+		if len(rubrics) == 0 {
+			return "", fmt.Errorf("metric rubrics are empty")
+		}
+		raw, err := json.Marshal(rubrics)
+		if err != nil {
+			return "", fmt.Errorf("marshal metric rubrics: %w", err)
+		}
+		return string(raw), nil
+	default:
+		return "", fmt.Errorf("unsupported source %s.%s",
+			metricllm.TemplateVariableScopeMetric, source.Field)
+	}
+}
+
+func visibleRubrics(rubrics []*metricllm.Rubric) []*metricllm.Rubric {
+	visible := make([]*metricllm.Rubric, 0, len(rubrics))
+	for _, rubric := range rubrics {
+		if rubric == nil || rubric.Content == nil {
+			continue
+		}
+		visible = append(visible, rubric)
+	}
+	return visible
 }
 
 func resolveTraceStepSnapshot(actuals []*evalset.Invocation, source *metricllm.TemplateVariableSource, input bool) (string, error) {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template.go
@@ -10,9 +10,11 @@
 package template
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/llm/operator/messagesconstructor"
@@ -207,15 +209,25 @@ func resolveMetricValue(evalMetric *metric.EvalMetric, source *metricllm.Templat
 		if len(rubrics) == 0 {
 			return "", fmt.Errorf("metric rubrics are empty")
 		}
-		raw, err := json.Marshal(rubrics)
+		raw, err := encodeJSONForPrompt(rubrics)
 		if err != nil {
 			return "", fmt.Errorf("marshal metric rubrics: %w", err)
 		}
-		return string(raw), nil
+		return raw, nil
 	default:
 		return "", fmt.Errorf("unsupported source %s.%s",
 			metricllm.TemplateVariableScopeMetric, source.Field)
 	}
+}
+
+func encodeJSONForPrompt(value any) (string, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(buf.String(), "\n"), nil
 }
 
 func visibleRubrics(rubrics []*metricllm.Rubric) []*metricllm.Rubric {

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
@@ -139,6 +139,73 @@ func TestConstructMessagesRendersTraceStepInput(t *testing.T) {
 	assert.Contains(t, messages[0].Content, "Tool input: match query")
 }
 
+func TestConstructMessagesRendersMetricRubrics(t *testing.T) {
+	constructor := New()
+	evalMetric := buildTemplateEvalMetric(
+		"Rubrics: {{rubrics}}",
+		&criterionllm.TemplateVariableBinding{
+			TemplateVariable: "rubrics",
+			Source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeMetric,
+				Field: criterionllm.TemplateVariableFieldRubrics,
+			},
+		},
+	)
+	evalMetric.Criterion.LLMJudge.Rubrics = []*criterionllm.Rubric{
+		{ID: "r1", Content: &criterionllm.RubricContent{Text: "Must be correct."}},
+	}
+	messages, err := constructor.ConstructMessages(context.Background(), nil, nil, evalMetric)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, `"id":"r1"`)
+	assert.Contains(t, messages[0].Content, `"text":"Must be correct."`)
+}
+
+func TestConstructMessagesAppliesJSONPath(t *testing.T) {
+	constructor := New()
+	actual := &evalset.Invocation{
+		ExecutionTrace: &agenttrace.Trace{
+			Steps: []agenttrace.Step{
+				{NodeID: "fetch", Output: &agenttrace.Snapshot{Text: `{"payload":{"answer":"Paris","evidence":{"city":"Paris"}}}`}},
+			},
+		},
+	}
+	messages, err := constructor.ConstructMessages(
+		context.Background(),
+		[]*evalset.Invocation{actual},
+		nil,
+		buildTemplateEvalMetric(
+			"Answer: {{answer}}\nEvidence: {{evidence}}",
+			&criterionllm.TemplateVariableBinding{
+				TemplateVariable: "answer",
+				Source: &criterionllm.TemplateVariableSource{
+					Scope: criterionllm.TemplateVariableScopeActual,
+					Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+					Selector: &criterionllm.TemplateVariableSelector{
+						NodeID: "fetch",
+					},
+					Path: "$.payload.answer",
+				},
+			},
+			&criterionllm.TemplateVariableBinding{
+				TemplateVariable: "evidence",
+				Source: &criterionllm.TemplateVariableSource{
+					Scope: criterionllm.TemplateVariableScopeActual,
+					Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+					Selector: &criterionllm.TemplateVariableSelector{
+						NodeID: "fetch",
+					},
+					Path: "payload.evidence",
+				},
+			},
+		),
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, "Answer: Paris")
+	assert.Contains(t, messages[0].Content, `Evidence: {"city":"Paris"}`)
+}
+
 func TestConstructMessagesRejectsDuplicateBindings(t *testing.T) {
 	constructor := New()
 
@@ -190,7 +257,7 @@ func TestConstructMessagesRequiresExpectedFinalResponse(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected finalResponse is empty")
 }
 
-func TestStructuredOutputResolvesResponseScorerSchema(t *testing.T) {
+func TestStructuredOutputDefaultsToResponseScorerName(t *testing.T) {
 	constructor, ok := New().(messagesconstructor.StructuredOutputMessagesConstructor)
 	require.True(t, ok)
 	output, err := constructor.StructuredOutput(context.Background(), nil, nil,
@@ -202,6 +269,30 @@ func TestStructuredOutputResolvesResponseScorerSchema(t *testing.T) {
 	evalMetric := buildTemplateEvalMetric("Answer: {{answer}}", nil)
 	evalMetric.Criterion.LLMJudge.Template.ResponseScorerName = operatorregistry.ResponseScorerRubricScoresName
 	output, err = constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "rubric_scores_result", output.JSONSchema.Name)
+	evalMetric.Criterion.LLMJudge.Template.ResponseScorerName = operatorregistry.ResponseScorerCategoricalName
+	evalMetric.Criterion.LLMJudge.Template.ResponseScorerOptions = &criterionllm.ResponseScorerOptions{
+		Categories: []*criterionllm.CategoryScore{
+			{Label: "correct", Score: 1},
+			{Label: "incorrect", Score: 0},
+		},
+	}
+	output, err = constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotNil(t, output.JSONSchema)
+	assert.Equal(t, "categorical_result", output.JSONSchema.Name)
+}
+
+func TestStructuredOutputUsesStructuredOutputName(t *testing.T) {
+	constructor := New().(messagesconstructor.StructuredOutputMessagesConstructor)
+	evalMetric := buildTemplateEvalMetric("Answer: {{answer}}", nil)
+	evalMetric.Criterion.LLMJudge.Template.ResponseScorerName = operatorregistry.ResponseScorerSingleScoreName
+	evalMetric.Criterion.LLMJudge.Template.StructuredOutputName = operatorregistry.StructuredOutputRubricScoresName
+	output, err := constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
 	require.NoError(t, err)
 	require.NotNil(t, output)
 	require.NotNil(t, output.JSONSchema)
@@ -222,13 +313,13 @@ func TestStructuredOutputRejectsInvalidTemplateOptions(t *testing.T) {
 	assert.Contains(t, err.Error(), "template is nil")
 }
 
-func TestStructuredOutputRejectsUnsupportedScorer(t *testing.T) {
+func TestStructuredOutputRejectsUnsupportedStructuredOutput(t *testing.T) {
 	constructor := New().(messagesconstructor.StructuredOutputMessagesConstructor)
 	evalMetric := buildTemplateEvalMetric("Answer: {{answer}}", nil)
-	evalMetric.Criterion.LLMJudge.Template.ResponseScorerName = "missing"
+	evalMetric.Criterion.LLMJudge.Template.StructuredOutputName = "missing"
 	_, err := constructor.StructuredOutput(context.Background(), nil, nil, evalMetric)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `unsupported response scorer "missing"`)
+	assert.Contains(t, err.Error(), `unsupported structured output "missing"`)
 }
 
 func TestConstructMessagesRejectsUnknownPlaceholder(t *testing.T) {
@@ -307,11 +398,11 @@ func TestConstructMessagesRejectsInvalidTemplateOptions(t *testing.T) {
 }
 
 func TestResolveTemplateValuesRejectsInvalidBindings(t *testing.T) {
-	values, err := resolveTemplateValues(nil, nil, []*criterionllm.TemplateVariableBinding{nil})
+	values, err := resolveTemplateValues(nil, nil, nil, []*criterionllm.TemplateVariableBinding{nil})
 	require.Error(t, err)
 	assert.Nil(t, values)
 	assert.Contains(t, err.Error(), "template binding is nil")
-	values, err = resolveTemplateValues(nil, nil, []*criterionllm.TemplateVariableBinding{{
+	values, err = resolveTemplateValues(nil, nil, nil, []*criterionllm.TemplateVariableBinding{{
 		Source: &criterionllm.TemplateVariableSource{
 			Scope: criterionllm.TemplateVariableScopeActual,
 			Field: criterionllm.TemplateVariableFieldFinalResponse,
@@ -323,17 +414,27 @@ func TestResolveTemplateValuesRejectsInvalidBindings(t *testing.T) {
 }
 
 func TestResolveBindingValueRejectsNilAndUnsupportedSource(t *testing.T) {
-	value, err := resolveBindingValue(nil, nil, nil)
+	value, err := resolveBindingValue(nil, nil, nil, nil)
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "source is nil")
-	value, err = resolveBindingValue(nil, nil, &criterionllm.TemplateVariableSource{
-		Scope: "metric",
+	value, err = resolveBindingValue(nil, nil, buildTemplateEvalMetric("{{x}}"), &criterionllm.TemplateVariableSource{
+		Scope: criterionllm.TemplateVariableScopeMetric,
 		Field: criterionllm.TemplateVariableFieldFinalResponse,
 	})
 	require.Error(t, err)
 	assert.Empty(t, value)
 	assert.Contains(t, err.Error(), "unsupported source metric.finalResponse")
+}
+
+func TestResolveBindingValueRejectsEmptyRubrics(t *testing.T) {
+	value, err := resolveBindingValue(nil, nil, buildTemplateEvalMetric("{{rubrics}}"), &criterionllm.TemplateVariableSource{
+		Scope: criterionllm.TemplateVariableScopeMetric,
+		Field: criterionllm.TemplateVariableFieldRubrics,
+	})
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "metric rubrics are empty")
 }
 
 func TestResolveActualValueRejectsInvalidActualInput(t *testing.T) {
@@ -404,6 +505,20 @@ func TestResolveTraceStepErrors(t *testing.T) {
 		{
 			name:    "empty node id",
 			actuals: []*evalset.Invocation{{ExecutionTrace: &agenttrace.Trace{}}},
+			source: &criterionllm.TemplateVariableSource{
+				Scope: criterionllm.TemplateVariableScopeActual,
+				Field: criterionllm.TemplateVariableFieldTraceStepOutput,
+				Selector: &criterionllm.TemplateVariableSelector{
+					NodeID: "",
+				},
+			},
+			wantErr: "trace selector nodeID is required",
+		},
+		{
+			name: "space node id is not trimmed",
+			actuals: []*evalset.Invocation{{
+				ExecutionTrace: &agenttrace.Trace{Steps: []agenttrace.Step{{NodeID: "fetch"}}},
+			}},
 			source: &criterionllm.TemplateVariableSource{
 				Scope: criterionllm.TemplateVariableScopeActual,
 				Field: criterionllm.TemplateVariableFieldTraceStepOutput,

--- a/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
+++ b/evaluation/evaluator/llm/operator/messagesconstructor/template/template_test.go
@@ -152,13 +152,16 @@ func TestConstructMessagesRendersMetricRubrics(t *testing.T) {
 		},
 	)
 	evalMetric.Criterion.LLMJudge.Rubrics = []*criterionllm.Rubric{
-		{ID: "r1", Content: &criterionllm.RubricContent{Text: "Must be correct."}},
+		{ID: "r1", Content: &criterionllm.RubricContent{Text: "Must preserve x < y > z & value."}},
 	}
 	messages, err := constructor.ConstructMessages(context.Background(), nil, nil, evalMetric)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	assert.Contains(t, messages[0].Content, `"id":"r1"`)
-	assert.Contains(t, messages[0].Content, `"text":"Must be correct."`)
+	assert.Contains(t, messages[0].Content, `"text":"Must preserve x < y > z & value."`)
+	assert.NotContains(t, messages[0].Content, `\u003c`)
+	assert.NotContains(t, messages[0].Content, `\u003e`)
+	assert.NotContains(t, messages[0].Content, `\u0026`)
 }
 
 func TestConstructMessagesAppliesJSONPath(t *testing.T) {
@@ -166,7 +169,7 @@ func TestConstructMessagesAppliesJSONPath(t *testing.T) {
 	actual := &evalset.Invocation{
 		ExecutionTrace: &agenttrace.Trace{
 			Steps: []agenttrace.Step{
-				{NodeID: "fetch", Output: &agenttrace.Snapshot{Text: `{"payload":{"answer":"Paris","evidence":{"city":"Paris"}}}`}},
+				{NodeID: "fetch", Output: &agenttrace.Snapshot{Text: `{"payload":{"answer":"Paris","evidence":{"city":"Paris","comparison":"x < y > z & a"}}}`}},
 			},
 		},
 	}
@@ -203,7 +206,10 @@ func TestConstructMessagesAppliesJSONPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	assert.Contains(t, messages[0].Content, "Answer: Paris")
-	assert.Contains(t, messages[0].Content, `Evidence: {"city":"Paris"}`)
+	assert.Contains(t, messages[0].Content, `Evidence: {"city":"Paris","comparison":"x < y > z & a"}`)
+	assert.NotContains(t, messages[0].Content, `\u003c`)
+	assert.NotContains(t, messages[0].Content, `\u003e`)
+	assert.NotContains(t, messages[0].Content, `\u0026`)
 }
 
 func TestConstructMessagesRejectsDuplicateBindings(t *testing.T) {

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -118,6 +118,7 @@ func TestCloneEvalMetric_DeepCopiesJudgeTemplate(t *testing.T) {
 								Selector: &criterionllm.TemplateVariableSelector{
 									NodeID: "ignored",
 								},
+								Path: "$.question",
 							},
 						},
 					},
@@ -147,6 +148,8 @@ func TestCloneEvalMetric_DeepCopiesJudgeTemplate(t *testing.T) {
 	assert.Equal(t, criterionllm.TemplateVariableScopeActual, src.Criterion.LLMJudge.Template.VariableBindings[0].Source.Scope)
 	dst.Criterion.LLMJudge.Template.VariableBindings[0].Source.Selector.NodeID = "changed"
 	assert.Equal(t, "ignored", src.Criterion.LLMJudge.Template.VariableBindings[0].Source.Selector.NodeID)
+	dst.Criterion.LLMJudge.Template.VariableBindings[0].Source.Path = "$.changed"
+	assert.Equal(t, "$.question", src.Criterion.LLMJudge.Template.VariableBindings[0].Source.Path)
 	dst.Criterion.LLMJudge.Template.ResponseScorerOptions.Categories[0].Label = "changed"
 	assert.Equal(t, "correct", src.Criterion.LLMJudge.Template.ResponseScorerOptions.Categories[0].Label)
 	dst.Criterion.LLMJudge.Template.ResponseScorerOptions.Categories[0].Score = 0

--- a/evaluation/internal/jsonpath/extract.go
+++ b/evaluation/internal/jsonpath/extract.go
@@ -1,0 +1,156 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package jsonpath extracts values with a restricted JSON path subset.
+package jsonpath
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type segment struct {
+	key   *string
+	index *int
+}
+
+// Extract extracts a rendered value from raw JSON using a restricted path subset.
+func Extract(rawValue, path string) (string, error) {
+	var value any
+	if err := json.Unmarshal([]byte(rawValue), &value); err != nil {
+		return "", fmt.Errorf("parse source json for path %q: %w", path, err)
+	}
+	segments, err := parse(path)
+	if err != nil {
+		return "", err
+	}
+	current := value
+	for _, segment := range segments {
+		if segment.key != nil {
+			object, ok := current.(map[string]any)
+			if !ok {
+				return "", fmt.Errorf("json path %q expects object before key %q", path, *segment.key)
+			}
+			next, ok := object[*segment.key]
+			if !ok {
+				return "", fmt.Errorf("json path %q key %q not found", path, *segment.key)
+			}
+			current = next
+			continue
+		}
+		array, ok := current.([]any)
+		if !ok {
+			return "", fmt.Errorf("json path %q expects array before index %d", path, *segment.index)
+		}
+		if *segment.index < 0 || *segment.index >= len(array) {
+			return "", fmt.Errorf("json path %q index %d out of range", path, *segment.index)
+		}
+		current = array[*segment.index]
+	}
+	return renderValue(current)
+}
+
+func parse(path string) ([]segment, error) {
+	if path == "" {
+		return nil, nil
+	}
+	i := 0
+	if path[0] == '$' {
+		i = 1
+		if len(path) > 1 && path[1] != '.' && path[1] != '[' {
+			return nil, fmt.Errorf("json path %q has invalid root selector", path)
+		}
+	}
+	segments := make([]segment, 0)
+	for i < len(path) {
+		switch path[i] {
+		case '.':
+			i++
+			key, next, err := parseKey(path, i)
+			if err != nil {
+				return nil, err
+			}
+			segments = append(segments, segment{key: &key})
+			i = next
+		case '[':
+			index, next, err := parseIndex(path, i)
+			if err != nil {
+				return nil, err
+			}
+			segments = append(segments, segment{index: &index})
+			i = next
+		default:
+			key, next, err := parseKey(path, i)
+			if err != nil {
+				return nil, err
+			}
+			segments = append(segments, segment{key: &key})
+			i = next
+		}
+	}
+	return segments, nil
+}
+
+func parseKey(path string, start int) (string, int, error) {
+	if start >= len(path) {
+		return "", start, fmt.Errorf("json path %q missing key", path)
+	}
+	i := start
+	for i < len(path) && path[i] != '.' && path[i] != '[' {
+		if path[i] == ']' {
+			return "", i, fmt.Errorf("json path %q has unexpected ]", path)
+		}
+		i++
+	}
+	if i == start {
+		return "", i, fmt.Errorf("json path %q missing key", path)
+	}
+	key := path[start:i]
+	if strings.Contains(key, "*") {
+		return "", i, fmt.Errorf("json path %q contains unsupported wildcard", path)
+	}
+	return key, i, nil
+}
+
+func parseIndex(path string, start int) (int, int, error) {
+	end := strings.IndexByte(path[start:], ']')
+	if end < 0 {
+		return 0, start, fmt.Errorf("json path %q missing ]", path)
+	}
+	rawIndex := path[start+1 : start+end]
+	if rawIndex == "" {
+		return 0, start, fmt.Errorf("json path %q missing index", path)
+	}
+	index, err := strconv.Atoi(rawIndex)
+	if err != nil {
+		return 0, start, fmt.Errorf("json path %q has invalid index %q", path, rawIndex)
+	}
+	return index, start + end + 1, nil
+}
+
+func renderValue(value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case nil:
+		return "null", nil
+	case bool:
+		if v {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshal json path value: %w", err)
+		}
+		return string(raw), nil
+	}
+}

--- a/evaluation/internal/jsonpath/extract.go
+++ b/evaluation/internal/jsonpath/extract.go
@@ -10,8 +10,10 @@
 package jsonpath
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 )
@@ -24,7 +26,16 @@ type segment struct {
 // Extract extracts a rendered value from raw JSON using a restricted path subset.
 func Extract(rawValue, path string) (string, error) {
 	var value any
-	if err := json.Unmarshal([]byte(rawValue), &value); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(rawValue))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return "", fmt.Errorf("parse source json for path %q: %w", path, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return "", fmt.Errorf("parse source json for path %q: multiple JSON values", path)
+		}
 		return "", fmt.Errorf("parse source json for path %q: %w", path, err)
 	}
 	segments, err := parse(path)
@@ -87,6 +98,9 @@ func parse(path string) ([]segment, error) {
 			segments = append(segments, segment{index: &index})
 			i = next
 		default:
+			if len(segments) != 0 || i != 0 {
+				return nil, fmt.Errorf("json path %q missing delimiter before key", path)
+			}
 			key, next, err := parseKey(path, i)
 			if err != nil {
 				return nil, err
@@ -147,10 +161,20 @@ func renderValue(value any) (string, error) {
 		}
 		return "false", nil
 	default:
-		raw, err := json.Marshal(v)
+		raw, err := encodeJSON(v)
 		if err != nil {
 			return "", fmt.Errorf("marshal json path value: %w", err)
 		}
-		return string(raw), nil
+		return raw, nil
 	}
+}
+
+func encodeJSON(value any) (string, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(buf.String(), "\n"), nil
 }

--- a/evaluation/internal/jsonpath/extract_test.go
+++ b/evaluation/internal/jsonpath/extract_test.go
@@ -1,0 +1,129 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package jsonpath
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractReturnsRenderedValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   string
+		path  string
+		value string
+	}{
+		{
+			name:  "dotted key",
+			raw:   `{"payload":{"answer":"Paris"}}`,
+			path:  "$.payload.answer",
+			value: "Paris",
+		},
+		{
+			name:  "implicit root",
+			raw:   `{"payload":{"evidence":{"city":"Paris"}}}`,
+			path:  "payload.evidence",
+			value: `{"city":"Paris"}`,
+		},
+		{
+			name:  "array index",
+			raw:   `{"items":[{"name":"first"},{"name":"second"}]}`,
+			path:  "$.items[1].name",
+			value: "second",
+		},
+		{
+			name:  "root object",
+			raw:   `{"answer":"Paris"}`,
+			path:  "$",
+			value: `{"answer":"Paris"}`,
+		},
+		{
+			name:  "empty path root object",
+			raw:   `{"answer":"Paris"}`,
+			path:  "",
+			value: `{"answer":"Paris"}`,
+		},
+		{
+			name:  "boolean",
+			raw:   `{"ok":true}`,
+			path:  "$.ok",
+			value: "true",
+		},
+		{
+			name:  "null",
+			raw:   `{"value":null}`,
+			path:  "$.value",
+			value: "null",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := Extract(tt.raw, tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.value, value)
+		})
+	}
+}
+
+func TestExtractRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		path    string
+		wantErr string
+	}{
+		{
+			name:    "invalid json",
+			raw:     "plain text",
+			path:    "$.answer",
+			wantErr: "parse source json",
+		},
+		{
+			name:    "invalid root selector",
+			raw:     `{"payload":{"answer":"Paris"}}`,
+			path:    "$payload.answer",
+			wantErr: "invalid root selector",
+		},
+		{
+			name:    "wildcard",
+			raw:     `{"payload":{"answer":"Paris"}}`,
+			path:    "$.payload.*",
+			wantErr: "unsupported wildcard",
+		},
+		{
+			name:    "missing key",
+			raw:     `{"payload":{}}`,
+			path:    "$.payload.answer",
+			wantErr: `key "answer" not found`,
+		},
+		{
+			name:    "index out of range",
+			raw:     `{"items":[]}`,
+			path:    "$.items[0]",
+			wantErr: "index 0 out of range",
+		},
+		{
+			name:    "array expected",
+			raw:     `{"items":{}}`,
+			path:    "$.items[0]",
+			wantErr: "expects array before index 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := Extract(tt.raw, tt.path)
+			require.Error(t, err)
+			assert.Empty(t, value)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/evaluation/internal/jsonpath/extract_test.go
+++ b/evaluation/internal/jsonpath/extract_test.go
@@ -59,6 +59,12 @@ func TestExtractReturnsRenderedValue(t *testing.T) {
 			value: "true",
 		},
 		{
+			name:  "false boolean",
+			raw:   `{"ok":false}`,
+			path:  "$.ok",
+			value: "false",
+		},
+		{
 			name:  "null",
 			raw:   `{"value":null}`,
 			path:  "$.value",
@@ -100,10 +106,34 @@ func TestExtractRejectsInvalidInputs(t *testing.T) {
 			wantErr: "parse source json",
 		},
 		{
+			name:    "multiple json values",
+			raw:     `{} {}`,
+			path:    "$",
+			wantErr: "multiple JSON values",
+		},
+		{
+			name:    "invalid trailing json",
+			raw:     `{} [`,
+			path:    "$",
+			wantErr: "parse source json",
+		},
+		{
 			name:    "invalid root selector",
 			raw:     `{"payload":{"answer":"Paris"}}`,
 			path:    "$payload.answer",
 			wantErr: "invalid root selector",
+		},
+		{
+			name:    "missing key after dot",
+			raw:     `{"payload":{"answer":"Paris"}}`,
+			path:    "$.payload.",
+			wantErr: "missing key",
+		},
+		{
+			name:    "unexpected closing bracket",
+			raw:     `{"payload":{"answer":"Paris"}}`,
+			path:    "$.payload]",
+			wantErr: "unexpected ]",
 		},
 		{
 			name:    "wildcard",
@@ -118,6 +148,12 @@ func TestExtractRejectsInvalidInputs(t *testing.T) {
 			wantErr: `key "answer" not found`,
 		},
 		{
+			name:    "object expected",
+			raw:     `{"payload":[]}`,
+			path:    "$.payload.answer",
+			wantErr: "expects object before key",
+		},
+		{
 			name:    "index out of range",
 			raw:     `{"items":[]}`,
 			path:    "$.items[0]",
@@ -128,6 +164,24 @@ func TestExtractRejectsInvalidInputs(t *testing.T) {
 			raw:     `{"items":{}}`,
 			path:    "$.items[0]",
 			wantErr: "expects array before index 0",
+		},
+		{
+			name:    "missing closing bracket",
+			raw:     `{"items":[]}`,
+			path:    "$.items[0",
+			wantErr: "missing ]",
+		},
+		{
+			name:    "missing index",
+			raw:     `{"items":[]}`,
+			path:    "$.items[]",
+			wantErr: "missing index",
+		},
+		{
+			name:    "invalid index",
+			raw:     `{"items":[]}`,
+			path:    "$.items[one]",
+			wantErr: "invalid index",
 		},
 		{
 			name:    "missing delimiter after index",

--- a/evaluation/internal/jsonpath/extract_test.go
+++ b/evaluation/internal/jsonpath/extract_test.go
@@ -64,6 +64,18 @@ func TestExtractReturnsRenderedValue(t *testing.T) {
 			path:  "$.value",
 			value: "null",
 		},
+		{
+			name:  "large number",
+			raw:   `{"id":9007199254740993}`,
+			path:  "$.id",
+			value: "9007199254740993",
+		},
+		{
+			name:  "object keeps comparison characters",
+			raw:   `{"rule":{"text":"x < y > z & a"}}`,
+			path:  "$.rule",
+			value: `{"text":"x < y > z & a"}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -116,6 +128,12 @@ func TestExtractRejectsInvalidInputs(t *testing.T) {
 			raw:     `{"items":{}}`,
 			path:    "$.items[0]",
 			wantErr: "expects array before index 0",
+		},
+		{
+			name:    "missing delimiter after index",
+			raw:     `{"items":[{"name":"first"}]}`,
+			path:    "$.items[0]name",
+			wantErr: "missing delimiter",
 		},
 	}
 	for _, tt := range tests {

--- a/evaluation/metric/criterion/llm/llm.go
+++ b/evaluation/metric/criterion/llm/llm.go
@@ -110,6 +110,7 @@ type TemplateVariableSource struct {
 	Scope    TemplateVariableScope     `json:"scope,omitempty"`
 	Field    TemplateVariableField     `json:"field,omitempty"`
 	Selector *TemplateVariableSelector `json:"selector,omitempty"`
+	Path     string                    `json:"path,omitempty"`
 }
 
 // TemplateVariableSelector selects one execution trace step.
@@ -125,6 +126,8 @@ const (
 	TemplateVariableScopeActual TemplateVariableScope = "actual"
 	// TemplateVariableScopeExpected binds against the current expected invocation.
 	TemplateVariableScopeExpected TemplateVariableScope = "expected"
+	// TemplateVariableScopeMetric binds against the current metric configuration.
+	TemplateVariableScopeMetric TemplateVariableScope = "metric"
 )
 
 // TemplateVariableField identifies which field is extracted from the source object.
@@ -139,6 +142,8 @@ const (
 	TemplateVariableFieldTraceStepInput TemplateVariableField = "traceStepInput"
 	// TemplateVariableFieldTraceStepOutput extracts the selected trace step output text.
 	TemplateVariableFieldTraceStepOutput TemplateVariableField = "traceStepOutput"
+	// TemplateVariableFieldRubrics extracts the metric rubrics.
+	TemplateVariableFieldRubrics TemplateVariableField = "rubrics"
 )
 
 // MarshalJSON omits APIKey from JSON output while still allowing JSON input to populate it.

--- a/evaluation/metric/criterion/llm/llm_test.go
+++ b/evaluation/metric/criterion/llm/llm_test.go
@@ -109,7 +109,8 @@ func TestTemplateVariableSourceJSONSupportsExpandedFields(t *testing.T) {
   "field": "traceStepOutput",
   "selector": {
     "nodeID": "fetch_match"
-  }
+  },
+  "path": "$.payload.answer"
 }`
 	var source TemplateVariableSource
 	err := json.Unmarshal([]byte(payload), &source)
@@ -118,6 +119,7 @@ func TestTemplateVariableSourceJSONSupportsExpandedFields(t *testing.T) {
 	assert.Equal(t, TemplateVariableFieldTraceStepOutput, source.Field)
 	require.NotNil(t, source.Selector)
 	assert.Equal(t, "fetch_match", source.Selector.NodeID)
+	assert.Equal(t, "$.payload.answer", source.Path)
 	data, err := json.Marshal(source)
 	require.NoError(t, err)
 	assert.JSONEq(t, payload, string(data))
@@ -126,6 +128,32 @@ func TestTemplateVariableSourceJSONSupportsExpandedFields(t *testing.T) {
 func TestTemplateVariableSourceConstantsCoverTemplateEvaluatorSources(t *testing.T) {
 	assert.Equal(t, TemplateVariableField("traceStepInput"), TemplateVariableFieldTraceStepInput)
 	assert.Equal(t, TemplateVariableField("traceStepOutput"), TemplateVariableFieldTraceStepOutput)
+	assert.Equal(t, TemplateVariableScope("metric"), TemplateVariableScopeMetric)
+	assert.Equal(t, TemplateVariableField("rubrics"), TemplateVariableFieldRubrics)
+}
+
+func TestJudgeTemplateOptionsJSONSupportsResponseScorerOptions(t *testing.T) {
+	const payload = `{
+  "responseScorerName": "categorical",
+  "structuredOutputName": "categorical_schema",
+  "responseScorerOptions": {
+    "categories": [
+      { "label": "correct", "score": 1 },
+      { "label": "incorrect", "score": 0 }
+    ]
+  }
+}`
+	var options JudgeTemplateOptions
+	err := json.Unmarshal([]byte(payload), &options)
+	require.NoError(t, err)
+	assert.Equal(t, "categorical_schema", options.StructuredOutputName)
+	require.NotNil(t, options.ResponseScorerOptions)
+	require.Len(t, options.ResponseScorerOptions.Categories, 2)
+	assert.Equal(t, "correct", options.ResponseScorerOptions.Categories[0].Label)
+	assert.Equal(t, 1.0, options.ResponseScorerOptions.Categories[0].Score)
+	data, err := json.Marshal(options)
+	require.NoError(t, err)
+	assert.JSONEq(t, payload, string(data))
 }
 
 func TestTemplateVariableSourceOldJSONShapeRemainsStable(t *testing.T) {

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -4271,6 +4271,7 @@ func TestLocalEvaluateUsesEvalCaseResultAggregator(t *testing.T) {
 	assert.Same(t, inferenceResult, aggregator.input.InferenceResult)
 	require.Len(t, aggregator.input.EvalMetrics, 1)
 	assert.Equal(t, fakeEval.name, aggregator.input.EvalMetrics[0].MetricName)
+	assert.Equal(t, 0.8, aggregator.input.EvalMetrics[0].Threshold)
 	assert.Equal(t, map[string]any{"weight": 0.7}, aggregator.input.EvalMetrics[0].Extension)
 	require.Len(t, aggregator.input.MetricResults, 1)
 	assert.Equal(t, status.EvalStatusFailed, aggregator.input.MetricResults[0].EvalStatus)

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -42,6 +42,7 @@ import (
 	criteriontext "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/text"
 	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
 	metricregistry "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/score"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/toolmock"
@@ -362,10 +363,9 @@ func TestExecutionTracesFromInvocationsHandlesEmptyAndNilInvocations(t *testing.
 }
 
 type fakeEvaluator struct {
-	name   string
-	result *evaluator.EvaluateResult
-	err    error
-
+	name              string
+	result            *evaluator.EvaluateResult
+	err               error
 	receivedActuals   []*evalset.Invocation
 	receivedExpecteds []*evalset.Invocation
 	receivedMetric    *metric.EvalMetric
@@ -1679,7 +1679,18 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 			OverallScore:  0.8,
 			OverallStatus: status.EvalStatusPassed,
 			PerInvocationResults: []*evaluator.PerInvocationResult{
-				{Score: 0.8, Status: status.EvalStatusPassed},
+				{
+					Score:  0.8,
+					Status: status.EvalStatusPassed,
+					Details: &evaluator.PerInvocationDetails{
+						Reason: "category matched",
+						Score:  0.8,
+						Value: &score.Value{
+							Kind:        score.KindCategorical,
+							Categorical: "correct",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1710,8 +1721,14 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Len(t, caseResult.OverallEvalMetricResults, 1)
 	assert.Equal(t, metricName, caseResult.OverallEvalMetricResults[0].MetricName)
 	assert.Equal(t, 0.8, caseResult.OverallEvalMetricResults[0].Score)
+	assert.Nil(t, caseResult.OverallEvalMetricResults[0].Details.Value)
 	assert.Len(t, caseResult.EvalMetricResultPerInvocation, 1)
 	assert.Len(t, caseResult.EvalMetricResultPerInvocation[0].EvalMetricResults, 1)
+	perMetric := caseResult.EvalMetricResultPerInvocation[0].EvalMetricResults[0]
+	require.NotNil(t, perMetric.Details)
+	require.NotNil(t, perMetric.Details.Value)
+	assert.Equal(t, score.KindCategorical, perMetric.Details.Value.Kind)
+	assert.Equal(t, "correct", perMetric.Details.Value.Categorical)
 	assert.Equal(t, "demo-user", caseResult.UserID)
 }
 
@@ -2260,11 +2277,7 @@ func TestLocalEvaluatePerCaseErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, mgr, reg, inference, config := tc.setup(t)
-			opts := &service.Options{
-				EvalSetManager:           mgr,
-				Registry:                 reg,
-				EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
-			}
+			opts := service.NewOptions(service.WithEvalSetManager(mgr), service.WithRegistry(reg))
 			_, err := svc.evaluatePerCase(ctx, inference, config, opts)
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -4213,7 +4226,7 @@ func TestLocalEvaluateUsesEvalCaseResultAggregator(t *testing.T) {
 	assert.NoError(t, mgr.AddCase(ctx, appName, evalSetID, makeEvalCase(appName, caseID, "prompt")))
 	reg := registry.New()
 	fakeEval := &fakeEvaluator{
-		name: "metric_with_custom_aggregation",
+		name: "metric-aggregate",
 		result: &evaluator.EvaluateResult{
 			OverallScore:         0.2,
 			OverallStatus:        status.EvalStatusFailed,
@@ -4235,26 +4248,30 @@ func TestLocalEvaluateUsesEvalCaseResultAggregator(t *testing.T) {
 		makeActualInvocation("actual-1", "prompt", "answer"),
 	})
 	runResult, err := svc.Evaluate(ctx, &service.EvaluateRequest{
-		AppName:   appName,
-		EvalSetID: evalSetID,
-		InferenceResults: []*service.InferenceResult{
-			inferenceResult,
-		},
+		AppName:          appName,
+		EvalSetID:        evalSetID,
+		InferenceResults: []*service.InferenceResult{inferenceResult},
 		EvaluateConfig: &service.EvaluateConfig{
-			EvalMetrics: []*metric.EvalMetric{{MetricName: fakeEval.name}},
+			EvalMetrics: []*metric.EvalMetric{{
+				MetricName: fakeEval.name,
+				Threshold:  0.8,
+				Extension:  map[string]any{"weight": 0.7},
+			}},
 		},
 	})
 	require.NoError(t, err)
 	require.Len(t, runResult.EvalCaseResults, 1)
-	assert.Equal(t, 0.75, runResult.EvalCaseResults[0].Score)
-	assert.Equal(t, status.EvalStatusPassed, runResult.EvalCaseResults[0].FinalEvalStatus)
+	caseResult := runResult.EvalCaseResults[0]
+	assert.Equal(t, 0.75, caseResult.Score)
+	assert.Equal(t, status.EvalStatusPassed, caseResult.FinalEvalStatus)
 	require.NotNil(t, aggregator.input)
 	assert.Equal(t, appName, aggregator.input.AppName)
 	assert.Equal(t, evalSetID, aggregator.input.EvalSetID)
-	require.NotNil(t, aggregator.input.EvalCase)
 	assert.Equal(t, caseID, aggregator.input.EvalCase.EvalID)
+	assert.Same(t, inferenceResult, aggregator.input.InferenceResult)
 	require.Len(t, aggregator.input.EvalMetrics, 1)
 	assert.Equal(t, fakeEval.name, aggregator.input.EvalMetrics[0].MetricName)
+	assert.Equal(t, map[string]any{"weight": 0.7}, aggregator.input.EvalMetrics[0].Extension)
 	require.Len(t, aggregator.input.MetricResults, 1)
 	assert.Equal(t, status.EvalStatusFailed, aggregator.input.MetricResults[0].EvalStatus)
 }
@@ -4283,7 +4300,7 @@ func TestLocalEvaluateMarksCaseFailedWhenEvalCaseResultAggregatorFails(t *testin
 				makeActualInvocation("actual-1", "prompt", "answer"),
 			}),
 		},
-		EvaluateConfig: &service.EvaluateConfig{},
+		EvaluateConfig: &service.EvaluateConfig{EvalMetrics: []*metric.EvalMetric{}},
 	})
 	require.NoError(t, err)
 	require.Len(t, runResult.EvalCaseResults, 1)
@@ -4464,11 +4481,7 @@ func TestEvaluatePerCaseUsesCaseEffectiveMetric(t *testing.T) {
 	})
 	result, err := svc.evaluatePerCase(ctx, inferenceResult, &service.EvaluateConfig{
 		EvalMetrics: []*metric.EvalMetric{configuredMetric},
-	}, &service.Options{
-		EvalSetManager:           mgr,
-		Registry:                 reg,
-		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
-	})
+	}, service.NewOptions(service.WithEvalSetManager(mgr), service.WithRegistry(reg)))
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	assert.Len(t, configuredMetric.Criterion.LLMJudge.Rubrics, 1)
@@ -4525,11 +4538,7 @@ func TestEvaluatePerCaseBindsCaseRubricByMetricNameWhenEvaluatorNameDiffers(t *t
 				Criterion:     &criterion.Criterion{LLMJudge: &criterionllm.LLMCriterion{}},
 			},
 		},
-	}, &service.Options{
-		EvalSetManager:           mgr,
-		Registry:                 reg,
-		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
-	})
+	}, service.NewOptions(service.WithEvalSetManager(mgr), service.WithRegistry(reg)))
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	require.NotNil(t, fakeEval.receivedMetric)
@@ -4573,11 +4582,7 @@ func TestEvaluatePerCaseTemplateEvaluatorKeepsCaseRubricInEffectiveCriterion(t *
 				Criterion:     &criterion.Criterion{LLMJudge: &criterionllm.LLMCriterion{}},
 			},
 		},
-	}, &service.Options{
-		EvalSetManager:           mgr,
-		Registry:                 reg,
-		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
-	})
+	}, service.NewOptions(service.WithEvalSetManager(mgr), service.WithRegistry(reg)))
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	if assert.Len(t, result.OverallEvalMetricResults, 1) {
@@ -4650,11 +4655,7 @@ func TestEvaluatePerCaseTemplateTraceBindingMaterializesPromptAndPersistsActualT
 				},
 			},
 		},
-	}, &service.Options{
-		EvalSetManager:           mgr,
-		Registry:                 reg,
-		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
-	})
+	}, service.NewOptions(service.WithEvalSetManager(mgr), service.WithRegistry(reg)))
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusPassed, result.FinalEvalStatus)
 	require.NotNil(t, fakeEval.receivedActuals[0].ExecutionTrace)
@@ -4937,11 +4938,7 @@ func TestEvaluatePerCaseSkipsMissingEvaluatorWithCaseRubric(t *testing.T) {
 		EvalMetrics: []*metric.EvalMetric{
 			{MetricName: "missing_metric"},
 		},
-	}, &service.Options{
-		EvalSetManager:           mgr,
-		Registry:                 reg,
-		EvalCaseResultAggregator: service.NewOptions().EvalCaseResultAggregator,
-	})
+	}, service.NewOptions(service.WithEvalSetManager(mgr), service.WithRegistry(reg)))
 	assert.NoError(t, err)
 	assert.Equal(t, status.EvalStatusNotEvaluated, result.FinalEvalStatus)
 	assert.Empty(t, result.OverallEvalMetricResults)


### PR DESCRIPTION
Adds metric rubric bindings and JSONPath extraction for template LLM judges so platform templates can reference structured actual, expected, trace, and metric data.