### PR TITLE
agent/taskrun/inprocess: wait for task completion before cancel assertion

### DIFF
--- a/agent/taskrun/inprocess/service_test.go
+++ b/agent/taskrun/inprocess/service_test.go
@@ -1031,7 +1031,9 @@ func TestServiceScopesAndErrors(t *testing.T) {
 	_, _, err = svc.Cancel(context.Background(), "missing")
 	require.ErrorIs(t, err, ErrRunNotFound)
 
-	completed, err := svc.Wait(context.Background(), first.ID)
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), time.Second)
+	defer cancelWait()
+	completed, err := svc.Wait(waitCtx, first.ID)
 	require.NoError(t, err)
 	require.Equal(t, StatusCompleted, completed.Status)
 

--- a/agent/taskrun/inprocess/service_test.go
+++ b/agent/taskrun/inprocess/service_test.go
@@ -1031,6 +1031,10 @@ func TestServiceScopesAndErrors(t *testing.T) {
 	_, _, err = svc.Cancel(context.Background(), "missing")
 	require.ErrorIs(t, err, ErrRunNotFound)
 
+	completed, err := svc.Wait(context.Background(), first.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, completed.Status)
+
 	canceled, changed, err := svc.Cancel(context.Background(), first.ID)
 	require.NoError(t, err)
 	require.False(t, changed)


### PR DESCRIPTION
<img width="1154" height="267" alt="image" src="https://github.com/user-attachments/assets/7da3d70b-e958-4ac6-9bf1-7e8608cd3e0d" />

fix #2163 ci fail

#2058 的 ci 流程 (test/go.mod) 里也有一样的问题 因为它也把 testify 从 v1.10.0 升到了 v1.11.1。

背景: #1698 #2161 #2163 #2259

A2A 从 v0.2.5 升级到当前版本时，同时把 testify 从 v1.10.0 升到了 v1.11.1。
require.Eventually 的行为在两个版本间变了：
- v1.10.0：第一次检查要等 tick，这里是 10ms；
- v1.11.1：第一次检查立即异步执行。
原测试：
`require.Eventually(... len(runs) == 2 ..., 1*time.Second, 10*time.Millisecond)`
以前这 10ms 恰好给后台任务留出了完成时间，所以测试一直通过。升级后第一次检查立即满足 len(runs)==2，测试马上调用 Cancel，此时任务仍可能处于 queued/running，于是 changed=true，断言失败。
所以不是 A2A 业务逻辑导致 taskrun 出错，而是 A2A 的依赖升级暴露了原测试对 Eventually 延迟行为的隐式依赖。正确修复是显式 Wait 到 StatusCompleted，不能依赖 Eventually 的内部调度。

https://github.com/trpc-group/trpc-agent-go/commit/f4dcee2e311256245ebcd73c69035fa5c77a87ba#diff-adff2cb253b0ddcf974e54b3b42cfe5c99afa79df4e40629adf05962549f6dc4

这个diff内引入的测试意图如下

`TestServiceScopesAndErrors` 的整体意图是验证三类行为：

1. 生命周期和参数校验

```text
未 Start 就 Spawn       -> ErrNotStarted
owner/session/task 为空 -> 返回对应校验错误
```

2. 任务作用域和重复 ID

```text
user-a 创建两个任务
user-b 创建一个任务
重复使用任务 ID        -> ErrRunAlreadyExists
按 user-a 查询         -> 只能得到 2 个
按 user-a + parent-a   -> 只能得到 first
```

3. 不存在任务和终态取消

```text
Get/Cancel 不存在任务 -> ErrRunNotFound
已完成任务再次 Cancel -> changed=false，状态保持 terminal
```

其中 `Eventually` 原本大概是想等待异步任务状态稳定，但它实际只检查 `List` 数量，不能证明任务已完成。它与后面的终态 `Cancel` 验证混在一起，旧版 Testify 的 10ms 延迟又刚好掩盖了这个问题。

改动内容：
- 仅修改 agent/taskrun/inprocess/service_test.go
- 在调用 Cancel(first.ID) 前，先通过 Wait 等待任务进入 StatusCompleted
- 确保后续断言 changed == false 稳定可靠

<img width="1920" height="842" alt="{B57C3BCF-0B22-4409-A098-1E2CC0337F6F}" src="https://github.com/user-attachments/assets/7feca8ca-7b84-4341-b695-4c476f8841b9" />
