### PR TITLE
lsc: remove unused production helpers

### DIFF
--- a/agent/claudecode/claude_agent_test.go
+++ b/agent/claudecode/claude_agent_test.go
@@ -32,6 +32,12 @@ type scriptedRunner struct {
 	run   func(command) ([]byte, []byte, error)
 }
 
+func withCommandRunner(runner commandRunner) Option {
+	return func(o *options) {
+		o.commandRunner = runner
+	}
+}
+
 // Run implements commandRunner.
 func (r *scriptedRunner) Run(ctx context.Context, cmd command) ([]byte, []byte, error) {
 	r.mu.Lock()

--- a/agent/claudecode/options.go
+++ b/agent/claudecode/options.go
@@ -114,13 +114,6 @@ func WithRawOutputHook(hook RawOutputHook) Option {
 	}
 }
 
-// withCommandRunner overrides how the agent executes external commands, only for test.
-func withCommandRunner(runner commandRunner) Option {
-	return func(o *options) {
-		o.commandRunner = runner
-	}
-}
-
 // newOptions applies options and validates the resulting configuration.
 func newOptions(opt ...Option) (*options, error) {
 	opts := &options{

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -38,6 +38,28 @@ type scriptedRunner struct {
 	stream func(command, commandOutputHandler) commandResult
 }
 
+func withCommandRunner(runner commandRunner) Option {
+	return func(o *options) {
+		o.commandRunner = runner
+	}
+}
+
+func parseTranscriptEvents(stdout []byte, invocationID, author string) (*transcriptResult, error) {
+	records, err := parseTranscriptRecords(stdout)
+	if err != nil {
+		return nil, err
+	}
+	stream := newTranscriptStream(invocationID, author)
+	for _, rec := range records {
+		stream.HandleRecord(rec)
+	}
+	return stream.Result(), nil
+}
+
+func errorEventFromRecord(invocationID, author string, rec codexEvent, terminal bool) *event.Event {
+	return errorEventFromResponseError(invocationID, author, responseErrorFromRecord(rec), terminal)
+}
+
 // Run implements commandRunner.
 func (r *scriptedRunner) Run(ctx context.Context, cmd command, onStdoutLine commandOutputHandler) commandResult {
 	r.mu.Lock()

--- a/agent/codex/options.go
+++ b/agent/codex/options.go
@@ -109,13 +109,6 @@ func WithRawOutputHook(hook RawOutputHook) Option {
 	}
 }
 
-// withCommandRunner overrides how the agent executes external commands, only for test.
-func withCommandRunner(runner commandRunner) Option {
-	return func(o *options) {
-		o.commandRunner = runner
-	}
-}
-
 // newOptions applies options and validates the resulting configuration.
 func newOptions(opt ...Option) (*options, error) {
 	opts := &options{

--- a/agent/codex/transcript.go
+++ b/agent/codex/transcript.go
@@ -178,19 +178,6 @@ func (s *transcriptStream) HandleRecord(rec codexEvent) []*event.Event {
 	return nil
 }
 
-// parseTranscriptEvents parses Codex CLI JSONL events into framework events.
-func parseTranscriptEvents(stdout []byte, invocationID, author string) (*transcriptResult, error) {
-	records, err := parseTranscriptRecords(stdout)
-	if err != nil {
-		return nil, err
-	}
-	stream := newTranscriptStream(invocationID, author)
-	for _, rec := range records {
-		stream.HandleRecord(rec)
-	}
-	return stream.Result(), nil
-}
-
 // parseTranscriptRecords decodes Codex JSONL output.
 func parseTranscriptRecords(stdout []byte) ([]codexEvent, error) {
 	trimmed := bytes.TrimSpace(stdout)
@@ -270,11 +257,6 @@ func completedEventsFromItem(invocationID, author string, item *codexItem, toolN
 	events = append(events, newToolCallEvent(invocationID, author, toolID, toolName, toolArguments(item), false))
 	events = append(events, newToolResultEvent(invocationID, author, toolID, toolName, toolResult(item)))
 	return events
-}
-
-// errorEventFromRecord creates a framework error event from a Codex failure record.
-func errorEventFromRecord(invocationID, author string, rec codexEvent, terminal bool) *event.Event {
-	return errorEventFromResponseError(invocationID, author, responseErrorFromRecord(rec), terminal)
 }
 
 // errorEventFromResponseError creates a framework error event from parsed error details.

--- a/agent/graphagent/graph_agent.go
+++ b/agent/graphagent/graph_agent.go
@@ -173,16 +173,6 @@ func (ga *GraphAgent) runWithoutBarrier(ctx context.Context, invocation *agent.I
 	)
 }
 
-func (ga *GraphAgent) forwardEventStream(ctx context.Context, innerChan <-chan *event.Event, out chan<- *event.Event) {
-	defer close(out)
-	for evt := range innerChan {
-		if err := event.EmitEvent(ctx, out, evt); err != nil {
-			log.Errorf("graphagent: emit event failed: %v.", err)
-			return
-		}
-	}
-}
-
 // runWithBarrier emits a start barrier, waits for completion, then runs the graph with callbacks
 // pipeline and forwards all events to the provided output channel.
 func (ga *GraphAgent) runWithBarrier(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event) {

--- a/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
+++ b/codeexecutor/e2b/internal/codeinterpreter/sandbox.go
@@ -106,17 +106,6 @@ func (s *Sandbox) setCachedSandboxDomain(d string) {
 	s.Unlock()
 }
 
-// sandboxHostDomain returns the domain to use when constructing direct URLs
-// to this sandbox's exposed ports. It prefers the domain returned by the E2B
-// API (which is where the sandbox actually runs — important for self-hosted
-// deployments), falling back to the client-configured domain.
-func (s *Sandbox) sandboxHostDomain() string {
-	if d := s.cachedSandboxDomain(); d != "" {
-		return d
-	}
-	return s.connection.Domain
-}
-
 func (s *Sandbox) hostID(sandboxDomain string) string {
 	if sandboxDomain == "" && s.clientID != "" {
 		return s.id + "-" + s.clientID

--- a/codeexecutor/local/local.go
+++ b/codeexecutor/local/local.go
@@ -299,10 +299,6 @@ func (e *CodeExecutor) executeCommand(
 	return string(output), nil
 }
 
-func removeHelperFile(path string) {
-	_ = os.Remove(path)
-}
-
 // CodeBlockDelimiter returns the code block delimiter used by the local
 // executor.
 func (e *CodeExecutor) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {

--- a/graph/checkpoint/sqlite/sqlite.go
+++ b/graph/checkpoint/sqlite/sqlite.go
@@ -23,10 +23,6 @@ import (
 )
 
 const (
-	// SQLite table names and SQL statements.
-	sqliteTableCheckpoints = "checkpoints"
-	sqliteTableWrites      = "checkpoint_writes"
-
 	sqliteCreateCheckpoints = "CREATE TABLE IF NOT EXISTS checkpoints (" +
 		"lineage_id TEXT NOT NULL, " +
 		"checkpoint_ns TEXT NOT NULL, " +
@@ -61,9 +57,6 @@ const (
 
 	sqliteSelectByID = "SELECT checkpoint_json, metadata_json, parent_checkpoint_id, checkpoint_ns, checkpoint_id " +
 		"FROM checkpoints WHERE lineage_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? LIMIT 1"
-
-	sqliteSelectIDsAsc = "SELECT checkpoint_id, ts FROM checkpoints " +
-		"WHERE lineage_id = ? AND checkpoint_ns = ? ORDER BY ts ASC"
 
 	sqliteInsertWrite = "INSERT OR REPLACE INTO checkpoint_writes (" +
 		"lineage_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, value_json, task_path, seq) " +

--- a/internal/shellsafe/parser.go
+++ b/internal/shellsafe/parser.go
@@ -76,7 +76,6 @@ type Pipeline struct {
 type commandParser func(src string) ([][]string, error)
 
 // parseCommand is wired at package init by the implementation file.
-// Tests may temporarily replace it through withParser.
 var parseCommand commandParser = parseCommandSimple
 
 // Parse validates command against the structural rules described in
@@ -96,16 +95,6 @@ func Parse(command string) (*Pipeline, error) {
 		return nil, errors.New("command is empty")
 	}
 	return &Pipeline{Commands: cmds}, nil
-}
-
-// withParser swaps the active parser for the duration of the
-// returned cleanup function and returns the previous parser. It is
-// intended for tests that exercise the Pipeline / Policy layer
-// without exercising the underlying parser implementation.
-func withParser(p commandParser) (restore func()) {
-	prev := parseCommand
-	parseCommand = p
-	return func() { parseCommand = prev }
 }
 
 // implicitDeny is the set of executable names that are always
@@ -401,10 +390,6 @@ func matchAllow(set []string, name, base, goos string) bool {
 		}
 	}
 	return false
-}
-
-func basename(s string) string {
-	return basenameForGOOS(s, runtime.GOOS)
 }
 
 // basenameForGOOS returns just the path basename of s without any

--- a/internal/shellsafe/parser_test.go
+++ b/internal/shellsafe/parser_test.go
@@ -991,6 +991,12 @@ func TestPreviewList(t *testing.T) {
 	}
 }
 
+func withParser(p commandParser) (restore func()) {
+	prev := parseCommand
+	parseCommand = p
+	return func() { parseCommand = prev }
+}
+
 // TestParser_SeamAllowsReplacement is a contract test for the
 // commandParser seam: it temporarily installs a stub backend,
 // verifies that Parse / Policy.Check route through it, and that

--- a/memory/extractor/memory.go
+++ b/memory/extractor/memory.go
@@ -277,10 +277,6 @@ func (e *memoryExtractor) buildMessages(
 	return result
 }
 
-// currentDatePlaceholder is replaced in the prompt template with
-// the actual reference date.
-const currentDatePlaceholder = "{current_date}"
-
 // buildSystemPrompt builds the system prompt with existing memories
 // and available actions based on enabled tools.
 // refDate is substituted into the prompt's {current_date} placeholder

--- a/memory/extractor/memory_test.go
+++ b/memory/extractor/memory_test.go
@@ -22,6 +22,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
+const currentDatePlaceholder = "{current_date}"
+
 // mockModel is a mock implementation of model.Model for testing.
 type mockModel struct {
 	name      string

--- a/memory/mem0/helpers.go
+++ b/memory/mem0/helpers.go
@@ -41,8 +41,6 @@ const (
 	queryKeyPageSize = "page_size"
 	queryKeyTopK     = "top_k"
 
-	memoryUserRole = "user"
-
 	defaultListPageSize = 100
 	defaultSearchTopK   = 20
 	maxOSSListTopK      = 1000

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolorder"
@@ -48,9 +47,7 @@ type Model struct {
 	chatStreamCompleteCallback ChatStreamCompleteCallbackFunc
 	enableTokenTailoring       bool                    // Enable automatic token tailoring.
 	maxInputTokens             int                     // Max input tokens for token tailoring.
-	tokenCounterOnce           sync.Once               // sync.Once for lazy initialization of tokenCounter.
 	tokenCounter               model.TokenCounter      // Token counter for token tailoring.
-	tailoringStrategyOnce      sync.Once               // sync.Once for lazy initialization of tailoringStrategy.
 	tailoringStrategy          model.TailoringStrategy // Tailoring strategy for token tailoring.
 	// Token tailoring budget parameters (instance-level overrides).
 	protocolOverheadTokens int

--- a/planner/react/react_planner.go
+++ b/planner/react/react_planner.go
@@ -159,27 +159,6 @@ func (p *Planner) ProcessPlanningResponse(
 	return &processedResponse
 }
 
-// hasValidToolCalls checks if the response contains any valid tool calls.
-func (p *Planner) hasValidToolCalls(response *model.Response) bool {
-	if response == nil || len(response.Choices) == 0 {
-		return false
-	}
-	for _, choice := range response.Choices {
-		if len(choice.Message.ToolCalls) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// getResponseContent extracts the text content from the response.
-func (p *Planner) getResponseContent(response *model.Response) string {
-	if response == nil || len(response.Choices) == 0 {
-		return ""
-	}
-	return response.Choices[0].Message.Content
-}
-
 // isIntentDescription checks if the content appears to be an intent
 // description rather than a final answer. Intent descriptions typically
 // indicate the agent wants to take an action but hasn't properly formed
@@ -267,20 +246,6 @@ func (p *Planner) hasFinalAnswerTag(content string) bool {
 		}
 	}
 	return true
-}
-
-// splitByLastPattern splits text by the last occurrence of a separator.
-// Returns the text before the last separator and the text after it.
-// The separator itself is not included in either returned part.
-func (p *Planner) splitByLastPattern(
-	text string,
-	separator string,
-) (string, string) {
-	index := strings.LastIndex(text, separator)
-	if index == -1 {
-		return text, ""
-	}
-	return text[:index], text[index+len(separator):]
 }
 
 // buildPlannerInstruction builds the comprehensive planning instruction

--- a/planner/react/react_planner_test.go
+++ b/planner/react/react_planner_test.go
@@ -216,66 +216,6 @@ func TestPlanner_ProcessPlanResp_Delta(t *testing.T) {
 	}
 }
 
-func TestPlanner_SplitByLastPattern(t *testing.T) {
-	p := New()
-
-	tests := []struct {
-		name      string
-		text      string
-		separator string
-		before    string
-		after     string
-	}{
-		{
-			name:      "normal split",
-			text:      "Hello SPLIT World",
-			separator: "SPLIT",
-			before:    "Hello ",
-			after:     " World",
-		},
-		{
-			name:      "no separator",
-			text:      "Hello World",
-			separator: "SPLIT",
-			before:    "Hello World",
-			after:     "",
-		},
-		{
-			name:      "multiple separators",
-			text:      "A SPLIT B SPLIT C",
-			separator: "SPLIT",
-			before:    "A SPLIT B ",
-			after:     " C",
-		},
-		{
-			name:      "empty text",
-			text:      "",
-			separator: "SPLIT",
-			before:    "",
-			after:     "",
-		},
-		{
-			name:      "separator at end",
-			text:      "Hello SPLIT",
-			separator: "SPLIT",
-			before:    "Hello ",
-			after:     "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			before, after := p.splitByLastPattern(tt.text, tt.separator)
-			if before != tt.before {
-				t.Errorf("splitByLastPattern() before = %q, want %q", before, tt.before)
-			}
-			if after != tt.after {
-				t.Errorf("splitByLastPattern() after = %q, want %q", after, tt.after)
-			}
-		})
-	}
-}
-
 func TestPlanner_BuildPlannerInstruction(t *testing.T) {
 	p := New()
 
@@ -698,61 +638,5 @@ func TestPlanner_HasFinalAnswerTag(t *testing.T) {
 		if result != tt.expected {
 			t.Errorf("hasFinalAnswerTag(%q) = %v, want %v", tt.content, result, tt.expected)
 		}
-	}
-}
-
-func TestPlanner_HasValidToolCalls(t *testing.T) {
-	p := New()
-
-	tests := []struct {
-		name     string
-		response *model.Response
-		expected bool
-	}{
-		{
-			name:     "nil response",
-			response: nil,
-			expected: false,
-		},
-		{
-			name: "empty choices",
-			response: &model.Response{
-				Choices: []model.Choice{},
-			},
-			expected: false,
-		},
-		{
-			name: "no tool calls",
-			response: &model.Response{
-				Choices: []model.Choice{
-					{Message: model.Message{Content: "hello"}},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "with tool calls",
-			response: &model.Response{
-				Choices: []model.Choice{
-					{
-						Message: model.Message{
-							ToolCalls: []model.ToolCall{
-								{Function: model.FunctionDefinitionParam{Name: "test"}},
-							},
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := p.hasValidToolCalls(tt.response)
-			if result != tt.expected {
-				t.Errorf("hasValidToolCalls() = %v, want %v", result, tt.expected)
-			}
-		})
 	}
 }

--- a/prompt/text.go
+++ b/prompt/text.go
@@ -205,23 +205,6 @@ func uniqueSortedNames(names []string) []string {
 	return out
 }
 
-func uniqueSortedStrings(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{}, len(values))
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	sort.Strings(out)
-	return out
-}
-
 func formatPlaceholderNames(names []string) []string {
 	if len(names) == 0 {
 		return nil

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -489,12 +489,6 @@ func writeSummary(
 	}
 }
 
-func selectUpdatedAt(tmp *session.Session, prevAt, latestTs time.Time, hasDelta bool) time.Time {
-	prev := session.NewSummaryBoundary("", prevAt)
-	latest := session.NewSummaryBoundary("", latestTs)
-	return selectSummaryBoundary(tmp, "", prev, latest, hasDelta).CutoffTime()
-}
-
 func selectSummaryBoundary(
 	tmp *session.Session,
 	filterKey string,
@@ -635,14 +629,6 @@ func skipBranchForkFullSessionCascadeFromContext(ctx context.Context) bool {
 	}
 	skip, _ := ctx.Value(skipBranchForkFullSessionCascadeContextKey{}).(bool)
 	return skip
-}
-
-func readLastIncludedTimestamp(tmp *session.Session) time.Time {
-	boundary := readLastIncludedBoundary(tmp, "")
-	if boundary == nil {
-		return time.Time{}
-	}
-	return boundary.CutoffTime()
 }
 
 func readLastIncludedBoundary(

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -401,9 +401,14 @@ func TestSummarizeSession_UsesPreviousBoundaryCutoff(t *testing.T) {
 func TestSelectUpdatedAt_Fallbacks(t *testing.T) {
 	prev := time.Date(2023, 1, 2, 9, 0, 0, 0, time.UTC)
 	latest := time.Date(2023, 1, 2, 10, 0, 0, 0, time.UTC)
+	selectUpdatedAt := func(tmp *session.Session, latestTs time.Time, hasDelta bool) time.Time {
+		prevBoundary := session.NewSummaryBoundary("", prev)
+		latestBoundary := session.NewSummaryBoundary("", latestTs)
+		return selectSummaryBoundary(tmp, "", prevBoundary, latestBoundary, hasDelta).CutoffTime()
+	}
 
 	t.Run("no delta keeps prev", func(t *testing.T) {
-		got := selectUpdatedAt(nil, prev, latest, false)
+		got := selectUpdatedAt(nil, latest, false)
 		assert.True(t, got.Equal(prev.UTC()))
 	})
 
@@ -411,17 +416,17 @@ func TestSelectUpdatedAt_Fallbacks(t *testing.T) {
 		tmp := &session.Session{State: session.StateMap{
 			session.SummaryLastIncludedTimestampStateKey: []byte("bad-ts"),
 		}}
-		got := selectUpdatedAt(tmp, prev, latest, true)
+		got := selectUpdatedAt(tmp, latest, true)
 		assert.True(t, got.Equal(latest.UTC()))
 	})
 
 	t.Run("nil session with delta falls back to latest", func(t *testing.T) {
-		got := selectUpdatedAt(nil, prev, latest, true)
+		got := selectUpdatedAt(nil, latest, true)
 		assert.True(t, got.Equal(latest.UTC()))
 	})
 
 	t.Run("zero latestTs with delta keeps prev", func(t *testing.T) {
-		got := selectUpdatedAt(nil, prev, time.Time{}, true)
+		got := selectUpdatedAt(nil, time.Time{}, true)
 		assert.True(t, got.Equal(prev.UTC()))
 	})
 }

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -257,16 +257,6 @@ func evaluateTimeThreshold(interval time.Duration) checkEvaluator {
 	}
 }
 
-// checkTokenThresholdFromMessage checks if the token count of the given message exceeds the threshold.
-func checkTokenThresholdFromMessage(
-	ctx context.Context,
-	tokenCount int,
-	message model.Message,
-) bool {
-	tokens, ok := countTokenThresholdMessage(ctx, message)
-	return ok && tokens > tokenCount
-}
-
 func countTokenThresholdMessage(
 	ctx context.Context,
 	message model.Message,

--- a/telemetry/langfuse/attribute.go
+++ b/telemetry/langfuse/attribute.go
@@ -55,9 +55,6 @@ const (
 	environment = "langfuse.environment"
 	release     = "langfuse.release"
 	version     = "langfuse.version"
-
-	// Internal
-	asRoot = "langfuse.internal.as_root"
 )
 
 // usageDetails collects token usage metrics for Langfuse's usage_details JSON field.

--- a/telemetry/langfuse/attribute_test.go
+++ b/telemetry/langfuse/attribute_test.go
@@ -48,8 +48,6 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "langfuse.release", release)
 	assert.Equal(t, "langfuse.version", version)
 
-	// Test internal attribute constants
-	assert.Equal(t, "langfuse.internal.as_root", asRoot)
 }
 
 func TestConstantTypes(t *testing.T) {
@@ -61,7 +59,7 @@ func TestConstantTypes(t *testing.T) {
 		observationInput, observationOutput,
 		observationCompletionStartTime, observationModel, observationModelParameters,
 		observationUsageDetails, observationCostDetails, observationPromptName, observationPromptVersion,
-		environment, release, version, asRoot,
+		environment, release, version,
 	}
 
 	for _, constant := range constants {
@@ -78,7 +76,7 @@ func TestConstantUniqueness(t *testing.T) {
 		observationInput, observationOutput,
 		observationCompletionStartTime, observationModel, observationModelParameters,
 		observationUsageDetails, observationCostDetails, observationPromptName, observationPromptVersion,
-		environment, release, version, asRoot,
+		environment, release, version,
 	}
 
 	// Check for duplicates
@@ -98,7 +96,7 @@ func TestConstantNamingConvention(t *testing.T) {
 		observationInput, observationOutput, observationCompletionStartTime,
 		observationModel, observationModelParameters, observationUsageDetails,
 		observationCostDetails, observationPromptName, observationPromptVersion,
-		environment, release, version, asRoot,
+		environment, release, version,
 	}
 
 	for _, constant := range langfuseConstants {

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -331,14 +331,6 @@ func getStringPtr(v *commonpb.AnyValue) *string {
 	return &s
 }
 
-// stringValueOrNA returns the string value of v, or "N/A" if v is nil.
-func stringValueOrNA(v *commonpb.AnyValue) string {
-	if v == nil {
-		return "N/A"
-	}
-	return v.GetStringValue()
-}
-
 func stringPtrValueOrNA(v *string) string {
 	if v == nil {
 		return "N/A"
@@ -368,36 +360,6 @@ func truncateObservationInputMessages(raw string) string {
 		sanitizeTelemetryMessagesForObservation(msgs, plan)
 	}
 	if b, err := json.Marshal(msgs); err == nil {
-		return string(b)
-	}
-	return truncateObservationValue(raw)
-}
-
-func truncateObservationOutputChoices(raw string) string {
-	maxLeafBytes := getObservationMaxBytes()
-	if maxLeafBytes == 0 {
-		return ""
-	}
-	if maxLeafBytes < 0 || len([]byte(raw)) <= maxLeafBytes {
-		return raw
-	}
-	if isOTelMessagesPayload(raw) {
-		return truncateObservationJSONLeafValues(raw)
-	}
-
-	var choices []observationTelemetryChoice
-	if err := json.Unmarshal([]byte(raw), &choices); err != nil {
-		return truncateObservationValue(raw)
-	}
-
-	if maxLeafBytes > 0 {
-		plan := truncateMessagesPlan{textLimit: maxLeafBytes, binaryLimit: maxLeafBytes}
-		for i := range choices {
-			sanitizeSingleTelemetryMessageForObservation(&choices[i].Message, plan)
-			sanitizeSingleTelemetryMessageForObservation(&choices[i].Delta, plan)
-		}
-	}
-	if b, err := json.Marshal(choices); err == nil {
 		return string(b)
 	}
 	return truncateObservationValue(raw)
@@ -517,19 +479,6 @@ type observationTelemetryMessage struct {
 	Name             string              `json:"name,omitempty"`
 	ToolCalls        []model.ToolCall    `json:"tool_calls,omitempty"`
 	ReasoningContent string              `json:"reasoning_content,omitempty"`
-}
-
-type observationTelemetryChoice struct {
-	Index        int                         `json:"index"`
-	Message      observationTelemetryMessage `json:"message,omitempty"`
-	Delta        observationTelemetryMessage `json:"delta,omitempty"`
-	FinishReason *string                     `json:"finish_reason,omitempty"`
-}
-
-func sanitizeMessagesForObservation(messages []model.Message, plan truncateMessagesPlan) {
-	for i := range messages {
-		sanitizeSingleMessageForObservation(&messages[i], plan)
-	}
 }
 
 func sanitizeTelemetryMessagesForObservation(messages []observationTelemetryMessage, plan truncateMessagesPlan) {

--- a/tool/mcp/config.go
+++ b/tool/mcp/config.go
@@ -39,8 +39,6 @@ const (
 
 // Default configurations.
 const (
-	// defaultMaxReconnectAttempts is the default maximum number of session reconnection attempts.
-	defaultMaxReconnectAttempts = 3
 	// minReconnectAttempts is the minimum allowed reconnection attempts.
 	minReconnectAttempts = 1
 	// maxReconnectAttemptsLimit is the maximum allowed reconnection attempts.


### PR DESCRIPTION
## What changed

Removed private helpers, constants, and fields that are unreachable from production code. Test-only command-runner and parser seams now live in test files, and tests that only exercised obsolete React planner helpers were removed.

## Why

The repository had accumulated implementation leftovers, including `checkTokenThresholdFromMessage`, that no production path called. Keeping these symbols in production packages made maintenance and static analysis noisier without preserving a runtime contract.

This cleanup only removes unexported code and does not change public APIs or runtime behavior.

## Testing

- `go build ./...`
- `go test ./... -count=1`
- `cd test && go test ./... -count=1`
- `bash .github/scripts/run-go-tests.sh`
- `bash .github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m`
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`

## Notes for reviewers

The removed symbols were verified with `staticcheck -checks=U1000 -tests=false` and repository-wide reference searches. Platform-specific helpers that remain reachable only on another operating system were intentionally retained.

On macOS, the all-module test script encountered mutually exclusive temporary-path constraints in the DuckDuckGo Unix-socket test and the sandbox-exec Unix-socket test. Each package passed in the complementary run, and the root suite passed in a single run.
