### PR TITLE
tool/file: simplify static error construction

### DIFF
--- a/tool/file/file.go
+++ b/tool/file/file.go
@@ -16,6 +16,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -507,7 +508,7 @@ func (f *fileToolSet) matchFiles(
 	caseSensitive bool,
 ) ([]string, error) {
 	if pattern == "" {
-		return nil, fmt.Errorf("pattern cannot be empty")
+		return nil, errors.New("pattern cannot be empty")
 	}
 	opts := []doublestar.GlobOption{}
 	if !caseSensitive {

--- a/tool/file/listfile.go
+++ b/tool/file/listfile.go
@@ -12,6 +12,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,8 +58,8 @@ func (f *fileToolSet) listFile(
 		BaseDirectory: f.baseDir,
 	}
 	if req == nil {
-		err := fmt.Errorf("request cannot be nil")
-		rsp.Message = fmt.Sprintf("Error: %v", err)
+		err := errors.New("request cannot be nil")
+		rsp.Message = "Error: " + err.Error()
 		return rsp, err
 	}
 	rsp.Path = req.Path
@@ -70,7 +71,7 @@ func (f *fileToolSet) listFile(
 	}
 	if ref.Scheme == fileref.SchemeArtifact {
 		rsp.Message = "Error: listing artifact:// is not supported"
-		return rsp, fmt.Errorf("listing artifact:// is not supported")
+		return rsp, errors.New("listing artifact:// is not supported")
 	}
 	if ref.Scheme == fileref.SchemeWorkspace {
 		rsp.Path = fileref.WorkspaceRef(ref.Path)

--- a/tool/file/listfile_test.go
+++ b/tool/file/listfile_test.go
@@ -54,9 +54,9 @@ func TestFileTool_listFile_NilRequest(t *testing.T) {
 
 	rsp, err := fileToolSet.listFile(context.Background(), nil)
 
-	assert.Error(t, err)
+	assert.EqualError(t, err, "request cannot be nil")
 	assert.NotNil(t, rsp)
-	assert.Contains(t, rsp.Message, "request cannot be nil")
+	assert.Equal(t, "Error: request cannot be nil", rsp.Message)
 }
 
 func TestFileTool_listFile_Subdirectory(t *testing.T) {

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -13,6 +13,7 @@ package file
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -51,8 +52,8 @@ func (f *fileToolSet) readFile(
 		FileName:      "",
 	}
 	if req == nil {
-		err := fmt.Errorf("request cannot be nil")
-		rsp.Message = fmt.Sprintf("Error: %v", err)
+		err := errors.New("request cannot be nil")
+		rsp.Message = "Error: " + err.Error()
 		return rsp, err
 	}
 	rsp.FileName = req.FileName
@@ -75,10 +76,10 @@ func (f *fileToolSet) readFile(
 
 func validateReadFileRequest(req *readFileRequest) error {
 	if req == nil {
-		return fmt.Errorf("request cannot be nil")
+		return errors.New("request cannot be nil")
 	}
 	if strings.TrimSpace(req.FileName) == "" {
-		return fmt.Errorf("file name cannot be empty")
+		return errors.New("file name cannot be empty")
 	}
 	if req.StartLine != nil && *req.StartLine <= 0 {
 		return fmt.Errorf("start line must be > 0: %v", *req.StartLine)
@@ -126,7 +127,7 @@ func validateTextBytes(data []byte, mimeType string) error {
 func notTextFileErr(mimeType string) error {
 	mt := strings.TrimSpace(mimeType)
 	if mt == "" {
-		return fmt.Errorf(errNotTextFile)
+		return errors.New(errNotTextFile)
 	}
 	return fmt.Errorf(errNotTextFileTmpl, mt)
 }

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -154,8 +154,9 @@ func TestFileTool_ReadFile_NilRequest(t *testing.T) {
 	fileToolSet := toolSet.(*fileToolSet)
 
 	rsp, err := fileToolSet.readFile(context.Background(), nil)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "request cannot be nil")
 	assert.NotNil(t, rsp)
+	assert.Equal(t, "Error: request cannot be nil", rsp.Message)
 }
 
 func TestValidateReadFileRequest_Nil(t *testing.T) {

--- a/tool/file/readmultiplefiles.go
+++ b/tool/file/readmultiplefiles.go
@@ -12,6 +12,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -56,7 +57,7 @@ func (f *fileToolSet) readMultipleFiles(
 	rsp := &readMultipleFilesResponse{BaseDirectory: f.baseDir}
 	if len(req.Patterns) == 0 {
 		rsp.Message = "Error: patterns cannot be empty"
-		return rsp, fmt.Errorf("patterns cannot be empty")
+		return rsp, errors.New("patterns cannot be empty")
 	}
 	var (
 		files []string

--- a/tool/file/replacecontent.go
+++ b/tool/file/replacecontent.go
@@ -12,6 +12,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -68,7 +69,7 @@ func (f *fileToolSet) replaceContent(
 	// Validate old string.
 	if req.OldString == "" {
 		rsp.Message = "Error: old_string cannot be empty"
-		return rsp, fmt.Errorf("old_string cannot be empty")
+		return rsp, errors.New("old_string cannot be empty")
 	}
 	if req.OldString == req.NewString {
 		rsp.Message = "old_string equals new_string; no changes made"

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -12,6 +12,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,8 +79,8 @@ func (f *fileToolSet) searchContent(
 		FileMatches:    []*fileMatch{},
 	}
 	if req == nil {
-		err := fmt.Errorf("request cannot be nil")
-		rsp.Message = fmt.Sprintf("Error: %v", err)
+		err := errors.New("request cannot be nil")
+		rsp.Message = "Error: " + err.Error()
 		return rsp, err
 	}
 	rsp.Path = req.Path
@@ -167,7 +168,7 @@ func (f *fileToolSet) searchContentByPath(
 	re *regexp.Regexp,
 ) (string, []*fileMatch, error) {
 	if req == nil || re == nil {
-		return "", nil, fmt.Errorf("request cannot be nil")
+		return "", nil, errors.New("request cannot be nil")
 	}
 	pathRef, err := fileref.Parse(req.Path)
 	if err != nil {
@@ -491,10 +492,10 @@ func (f *fileToolSet) searchContentTool() tool.CallableTool {
 // validatePattern validates the file and content patterns.
 func validatePattern(filePattern string, contentPattern string) error {
 	if filePattern == "" {
-		return fmt.Errorf("file pattern cannot be empty")
+		return errors.New("file pattern cannot be empty")
 	}
 	if contentPattern == "" {
-		return fmt.Errorf("content pattern cannot be empty")
+		return errors.New("content pattern cannot be empty")
 	}
 	return nil
 }

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -386,9 +386,9 @@ func TestSearchContent_NilRequest(t *testing.T) {
 	fts := set.(*fileToolSet)
 
 	rsp, err := fts.searchContent(context.Background(), nil)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "request cannot be nil")
 	assert.NotNil(t, rsp)
-	assert.Contains(t, rsp.Message, "request cannot be nil")
+	assert.Equal(t, "Error: request cannot be nil", rsp.Message)
 }
 
 func TestSearchContent_FilePatternRef_NotExported(t *testing.T) {

--- a/tool/file/searchfile.go
+++ b/tool/file/searchfile.go
@@ -12,6 +12,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,8 +52,8 @@ func (f *fileToolSet) searchFile(
 		BaseDirectory: f.baseDir,
 	}
 	if req == nil {
-		err := fmt.Errorf("request cannot be nil")
-		rsp.Message = fmt.Sprintf("Error: %v", err)
+		err := errors.New("request cannot be nil")
+		rsp.Message = "Error: " + err.Error()
 		return rsp, err
 	}
 	rsp.Path = req.Path
@@ -60,7 +61,7 @@ func (f *fileToolSet) searchFile(
 	// Validate pattern
 	if req.Pattern == "" {
 		rsp.Message = "Error: pattern cannot be empty"
-		return rsp, fmt.Errorf("pattern cannot be empty")
+		return rsp, errors.New("pattern cannot be empty")
 	}
 
 	ref, err := fileref.Parse(req.Path)
@@ -70,7 +71,7 @@ func (f *fileToolSet) searchFile(
 	}
 	if ref.Scheme == fileref.SchemeArtifact {
 		rsp.Message = "Error: searching artifact:// is not supported"
-		return rsp, fmt.Errorf("searching artifact:// is not supported")
+		return rsp, errors.New("searching artifact:// is not supported")
 	}
 	if ref.Scheme == fileref.SchemeWorkspace {
 		rsp.Path = fileref.WorkspaceRef(ref.Path)

--- a/tool/file/searchfile_test.go
+++ b/tool/file/searchfile_test.go
@@ -286,9 +286,9 @@ func TestFileTool_SearchFile_NilRequest(t *testing.T) {
 
 	rsp, err := fileToolSet.searchFile(context.Background(), nil)
 
-	assert.Error(t, err)
+	assert.EqualError(t, err, "request cannot be nil")
 	assert.NotNil(t, rsp)
-	assert.Contains(t, rsp.Message, "request cannot be nil")
+	assert.Equal(t, "Error: request cannot be nil", rsp.Message)
 }
 
 func TestFileTool_SearchFile_WorkspaceRef(t *testing.T) {


### PR DESCRIPTION
## What changed

Use `errors.New` for static errors in `tool/file` and simplify nil-request response message construction. Strengthen nil-request tests to assert the exact returned error and response message.

## Why

Static errors do not require formatting, and formatting them back into response strings adds unnecessary indirection. Dynamic and wrapped errors continue to use `fmt.Errorf` where formatting or cause preservation is required.

## Testing

- `go test ./tool/file -count=1`
- `go build ./...`
- `golangci-lint run --timeout=10m ./tool/file`
- `gofmt -r 'interface{} -> any' -l tool/file`
- `goimports -l tool/file`

## Notes for reviewers

This change does not modify public APIs, error text, response fields, or return semantics.
