### PR TITLE
codeexecutor: refresh stale workspace instances

### DIFF
--- a/codeexecutor/manifest.go
+++ b/codeexecutor/manifest.go
@@ -17,6 +17,9 @@ import (
 
 // ErrPartialOutputCommit marks a CollectOutputs error after output files may
 // already have been added to the returned manifest or persisted as artifacts.
+// When an error matches both ErrPartialOutputCommit and [ErrWorkspaceStale],
+// callers should invalidate the workspace handle but must not replay output
+// collection; [IsWorkspaceRetrySafe] returns false for that combination.
 var ErrPartialOutputCommit = errors.New("partial output commit")
 
 // InputSpec declares a single input mapping into the workspace.

--- a/codeexecutor/registry.go
+++ b/codeexecutor/registry.go
@@ -11,27 +11,37 @@ package codeexecutor
 
 import (
 	"context"
+	"errors"
 	"sync"
+)
+
+var errWorkspaceInstanceIDEmpty = errors.New(
+	"codeexecutor: WorkspaceInstanceProvider returned an empty instance ID",
 )
 
 // WorkspaceRegistry keeps a process-level mapping of logical IDs to
 // created workspaces for reuse within a session.
 type WorkspaceRegistry struct {
 	mu       sync.Mutex
-	byID     map[string]Workspace
+	byID     map[string]workspaceRegistryEntry
 	inflight map[string]*workspaceCreateCall
 }
 
+type workspaceRegistryEntry struct {
+	ws         Workspace
+	instanceID WorkspaceInstanceID
+}
+
 type workspaceCreateCall struct {
-	done chan struct{}
-	ws   Workspace
-	err  error
+	done  chan struct{}
+	entry workspaceRegistryEntry
+	err   error
 }
 
 // NewWorkspaceRegistry creates a new in-memory registry.
 func NewWorkspaceRegistry() *WorkspaceRegistry {
 	return &WorkspaceRegistry{
-		byID:     map[string]Workspace{},
+		byID:     map[string]workspaceRegistryEntry{},
 		inflight: map[string]*workspaceCreateCall{},
 	}
 }
@@ -39,64 +49,173 @@ func NewWorkspaceRegistry() *WorkspaceRegistry {
 // Acquire creates or returns an existing workspace with the given id.
 // Concurrent first-time acquires for the same id coalesce to a single
 // CreateWorkspace so init hooks and workspace creation run at most once per id.
+//
+// Managers that do not implement [WorkspaceInstanceProvider] retain the legacy
+// cache behavior. For an instance-aware manager, a cache hit checks the current
+// instance ID outside the registry lock. When the ID changes, concurrent
+// callers coalesce to one CreateWorkspace call and the successful result
+// atomically replaces the old entry. Validation and recreation failures leave
+// the old entry cached so a later call can retry.
 func (r *WorkspaceRegistry) Acquire(
 	ctx context.Context, m WorkspaceManager, id string,
 ) (Workspace, error) {
-	r.mu.Lock()
-	if ws, ok := r.byID[id]; ok {
-		r.mu.Unlock()
-		return ws, nil
+	ws, _, err := r.AcquireWithInstanceID(ctx, m, id)
+	return ws, err
+}
+
+// AcquireWithInstanceID is the instance-aware form of Acquire. It returns the
+// instance ID stored atomically with the workspace entry. Legacy managers
+// return an empty instance ID.
+func (r *WorkspaceRegistry) AcquireWithInstanceID(
+	ctx context.Context,
+	m WorkspaceManager,
+	id string,
+) (Workspace, WorkspaceInstanceID, error) {
+	provider, _ := m.(WorkspaceInstanceProvider)
+	entry, err := r.acquire(ctx, m, provider, id)
+	if err != nil {
+		return Workspace{}, "", err
 	}
-	if err := ctx.Err(); err != nil {
+	return entry.ws, entry.instanceID, nil
+}
+
+func (r *WorkspaceRegistry) acquire(
+	ctx context.Context,
+	m WorkspaceManager,
+	provider WorkspaceInstanceProvider,
+	id string,
+) (workspaceRegistryEntry, error) {
+	for {
+		r.mu.Lock()
+		entry, cached := r.byID[id]
+		if cached && provider == nil {
+			r.mu.Unlock()
+			return entry, nil
+		}
+		if err := ctx.Err(); err != nil {
+			r.mu.Unlock()
+			return workspaceRegistryEntry{}, err
+		}
+		if call, ok := r.inflight[id]; ok {
+			r.mu.Unlock()
+			return waitWorkspaceCreate(ctx, call)
+		}
+		if !cached {
+			call := r.newCreateCallLocked(id)
+			createCtx := context.WithoutCancel(ctx)
+			r.mu.Unlock()
+
+			go r.createWorkspace(createCtx, m, provider, id, call)
+			return waitWorkspaceCreate(ctx, call)
+		}
 		r.mu.Unlock()
-		return Workspace{}, err
-	}
-	if call, ok := r.inflight[id]; ok {
+
+		currentID, err := provider.WorkspaceInstanceID(ctx, entry.ws)
+		if err != nil {
+			return workspaceRegistryEntry{}, err
+		}
+		if currentID == "" {
+			return workspaceRegistryEntry{}, errWorkspaceInstanceIDEmpty
+		}
+
+		r.mu.Lock()
+		if call, ok := r.inflight[id]; ok {
+			r.mu.Unlock()
+			return waitWorkspaceCreate(ctx, call)
+		}
+		latest, ok := r.byID[id]
+		if !ok || latest != entry {
+			r.mu.Unlock()
+			continue
+		}
+		if currentID == entry.instanceID {
+			r.mu.Unlock()
+			return entry, nil
+		}
+		call := r.newCreateCallLocked(id)
+		createCtx := context.WithoutCancel(ctx)
 		r.mu.Unlock()
+
+		go r.createWorkspace(createCtx, m, provider, id, call)
 		return waitWorkspaceCreate(ctx, call)
 	}
+}
+
+func (r *WorkspaceRegistry) newCreateCallLocked(id string) *workspaceCreateCall {
 	if r.inflight == nil {
 		r.inflight = map[string]*workspaceCreateCall{}
 	}
 	call := &workspaceCreateCall{done: make(chan struct{})}
 	r.inflight[id] = call
-	createCtx := context.WithoutCancel(ctx)
-	r.mu.Unlock()
-
-	go r.createWorkspace(createCtx, m, id, call)
-	return waitWorkspaceCreate(ctx, call)
+	return call
 }
 
 func (r *WorkspaceRegistry) createWorkspace(
 	ctx context.Context,
 	m WorkspaceManager,
+	provider WorkspaceInstanceProvider,
 	id string,
 	call *workspaceCreateCall,
 ) {
 	ws, err := m.CreateWorkspace(ctx, id, WorkspacePolicy{})
+	entry := workspaceRegistryEntry{ws: ws}
+	if err == nil && provider != nil {
+		entry.instanceID, err = provider.WorkspaceInstanceID(ctx, ws)
+		if err == nil && entry.instanceID == "" {
+			err = errWorkspaceInstanceIDEmpty
+		}
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if err == nil {
 		if r.byID == nil {
-			r.byID = map[string]Workspace{}
+			r.byID = map[string]workspaceRegistryEntry{}
 		}
-		r.byID[id] = ws
+		r.byID[id] = entry
 	}
-	call.ws = ws
+	call.entry = entry
 	call.err = err
 	delete(r.inflight, id)
 	close(call.done)
 }
 
-func waitWorkspaceCreate(ctx context.Context, call *workspaceCreateCall) (Workspace, error) {
+func waitWorkspaceCreate(
+	ctx context.Context,
+	call *workspaceCreateCall,
+) (workspaceRegistryEntry, error) {
 	select {
 	case <-ctx.Done():
-		return Workspace{}, ctx.Err()
+		return workspaceRegistryEntry{}, ctx.Err()
 	case <-call.done:
 		if call.err != nil {
-			return Workspace{}, call.err
+			return workspaceRegistryEntry{}, call.err
 		}
-		return call.ws, nil
+		return call.entry, nil
 	}
+}
+
+// InvalidateIf removes id only when both its cached workspace handle and
+// instance ID still match. It never calls [WorkspaceManager.Cleanup], because a
+// deterministic workspace path may already belong to a newer physical
+// instance by the time stale work is reported.
+//
+// The conditional comparison prevents a late stale report from evicting a
+// workspace that another caller has already refreshed.
+func (r *WorkspaceRegistry) InvalidateIf(
+	id string,
+	ws Workspace,
+	instanceID WorkspaceInstanceID,
+) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.byID[id]
+	if !ok || entry.ws != ws || entry.instanceID != instanceID {
+		return false
+	}
+	delete(r.byID, id)
+	return true
 }

--- a/codeexecutor/registry.go
+++ b/codeexecutor/registry.go
@@ -19,17 +19,23 @@ var errWorkspaceInstanceIDEmpty = errors.New(
 	"codeexecutor: WorkspaceInstanceProvider returned an empty instance ID",
 )
 
+var errWorkspaceRegistryTokenExhausted = errors.New(
+	"codeexecutor: workspace registry entry token exhausted",
+)
+
 // WorkspaceRegistry keeps a process-level mapping of logical IDs to
 // created workspaces for reuse within a session.
 type WorkspaceRegistry struct {
-	mu       sync.Mutex
-	byID     map[string]workspaceRegistryEntry
-	inflight map[string]*workspaceCreateCall
+	mu        sync.Mutex
+	byID      map[string]workspaceRegistryEntry
+	inflight  map[string]*workspaceCreateCall
+	nextToken uint64
 }
 
 type workspaceRegistryEntry struct {
-	ws         Workspace
-	instanceID WorkspaceInstanceID
+	ws                Workspace
+	backendInstanceID WorkspaceInstanceID
+	entryToken        uint64
 }
 
 type workspaceCreateCall struct {
@@ -59,24 +65,24 @@ func NewWorkspaceRegistry() *WorkspaceRegistry {
 func (r *WorkspaceRegistry) Acquire(
 	ctx context.Context, m WorkspaceManager, id string,
 ) (Workspace, error) {
-	ws, _, err := r.AcquireWithInstanceID(ctx, m, id)
-	return ws, err
+	handle, err := r.AcquireHandle(ctx, m, id)
+	return handle.Workspace, err
 }
 
-// AcquireWithInstanceID is the instance-aware form of Acquire. It returns the
-// instance ID stored atomically with the workspace entry. Legacy managers
-// return an empty instance ID.
-func (r *WorkspaceRegistry) AcquireWithInstanceID(
+// AcquireHandle is the cache-entry-aware form of Acquire. The returned handle
+// carries a registry-owned token that remains non-zero even for legacy
+// managers, allowing stale work to invalidate only the exact entry it used.
+func (r *WorkspaceRegistry) AcquireHandle(
 	ctx context.Context,
 	m WorkspaceManager,
 	id string,
-) (Workspace, WorkspaceInstanceID, error) {
+) (WorkspaceHandle, error) {
 	provider, _ := m.(WorkspaceInstanceProvider)
 	entry, err := r.acquire(ctx, m, provider, id)
 	if err != nil {
-		return Workspace{}, "", err
+		return WorkspaceHandle{}, err
 	}
-	return entry.ws, entry.instanceID, nil
+	return r.handle(id, entry), nil
 }
 
 func (r *WorkspaceRegistry) acquire(
@@ -110,7 +116,7 @@ func (r *WorkspaceRegistry) acquire(
 		}
 		r.mu.Unlock()
 
-		currentID, err := provider.WorkspaceInstanceID(ctx, entry.ws)
+		currentID, err := provider.InstanceID(ctx)
 		if err != nil {
 			return workspaceRegistryEntry{}, err
 		}
@@ -128,7 +134,7 @@ func (r *WorkspaceRegistry) acquire(
 			r.mu.Unlock()
 			continue
 		}
-		if currentID == entry.instanceID {
+		if currentID == entry.backendInstanceID {
 			r.mu.Unlock()
 			return entry, nil
 		}
@@ -157,22 +163,52 @@ func (r *WorkspaceRegistry) createWorkspace(
 	id string,
 	call *workspaceCreateCall,
 ) {
-	ws, err := m.CreateWorkspace(ctx, id, WorkspacePolicy{})
-	entry := workspaceRegistryEntry{ws: ws}
-	if err == nil && provider != nil {
-		entry.instanceID, err = provider.WorkspaceInstanceID(ctx, ws)
-		if err == nil && entry.instanceID == "" {
+	var before WorkspaceInstanceID
+	var err error
+	if provider != nil {
+		before, err = provider.InstanceID(ctx)
+		if err == nil && before == "" {
 			err = errWorkspaceInstanceIDEmpty
+		}
+	}
+	var ws Workspace
+	if err == nil {
+		ws, err = m.CreateWorkspace(ctx, id, WorkspacePolicy{})
+	}
+	entry := workspaceRegistryEntry{
+		ws:                ws,
+		backendInstanceID: before,
+	}
+	if err == nil && provider != nil {
+		after, probeErr := provider.InstanceID(ctx)
+		switch {
+		case probeErr != nil:
+			err = probeErr
+		case after == "":
+			err = errWorkspaceInstanceIDEmpty
+		case after != before:
+			err = errors.Join(
+				ErrWorkspaceStale,
+				errors.New(
+					"codeexecutor: workspace instance changed during creation",
+				),
+			)
 		}
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if err == nil {
-		if r.byID == nil {
-			r.byID = map[string]workspaceRegistryEntry{}
+		if r.nextToken == ^uint64(0) {
+			err = errWorkspaceRegistryTokenExhausted
+		} else {
+			if r.byID == nil {
+				r.byID = map[string]workspaceRegistryEntry{}
+			}
+			r.nextToken++
+			entry.entryToken = r.nextToken
+			r.byID[id] = entry
 		}
-		r.byID[id] = entry
 	}
 	call.entry = entry
 	call.err = err
@@ -195,27 +231,37 @@ func waitWorkspaceCreate(
 	}
 }
 
-// InvalidateIf removes id only when both its cached workspace handle and
-// instance ID still match. It never calls [WorkspaceManager.Cleanup], because a
-// deterministic workspace path may already belong to a newer physical
-// instance by the time stale work is reported.
+// Invalidate removes only the exact cache entry represented by handle. It never
+// calls [WorkspaceManager.Cleanup], because a deterministic workspace path may
+// already belong to a newer physical instance by the time stale work is
+// reported.
 //
-// The conditional comparison prevents a late stale report from evicting a
-// workspace that another caller has already refreshed.
-func (r *WorkspaceRegistry) InvalidateIf(
-	id string,
-	ws Workspace,
-	instanceID WorkspaceInstanceID,
-) bool {
-	if r == nil {
+// The registry-owned token prevents a late stale report from evicting a
+// workspace that another caller has already refreshed, including for legacy
+// managers whose backend instance ID is empty.
+func (r *WorkspaceRegistry) Invalidate(handle WorkspaceHandle) bool {
+	if r == nil || handle.registry != r || handle.entryToken == 0 {
 		return false
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	entry, ok := r.byID[id]
-	if !ok || entry.ws != ws || entry.instanceID != instanceID {
+	entry, ok := r.byID[handle.registryID]
+	if !ok || entry.entryToken != handle.entryToken {
 		return false
 	}
-	delete(r.byID, id)
+	delete(r.byID, handle.registryID)
 	return true
+}
+
+func (r *WorkspaceRegistry) handle(
+	id string,
+	entry workspaceRegistryEntry,
+) WorkspaceHandle {
+	return WorkspaceHandle{
+		Workspace:  entry.ws,
+		InstanceID: entry.backendInstanceID,
+		registry:   r,
+		registryID: id,
+		entryToken: entry.entryToken,
+	}
 }

--- a/codeexecutor/registry_test.go
+++ b/codeexecutor/registry_test.go
@@ -193,8 +193,8 @@ func (m *rotatingWM) CreateWorkspace(
 	if err != nil {
 		return Workspace{}, err
 	}
-	// Keep the handle deterministic across instances. The instance ID is what
-	// prevents a late stale report from evicting a refreshed entry.
+	// Keep the workspace deterministic across instances. The registry token,
+	// not Workspace equality, prevents late invalidation of a refreshed entry.
 	return Workspace{ID: id, Path: "/tmp/" + id}, nil
 }
 
@@ -202,9 +202,8 @@ func (*rotatingWM) Cleanup(context.Context, Workspace) error {
 	return nil
 }
 
-func (m *rotatingWM) WorkspaceInstanceID(
+func (m *rotatingWM) InstanceID(
 	context.Context,
-	Workspace,
 ) (WorkspaceInstanceID, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -356,29 +355,164 @@ func TestWorkspaceRegistry_Acquire_ConcurrentRefreshCreatesOnce(t *testing.T) {
 	require.Equal(t, 2, wm.callCount())
 }
 
-func TestWorkspaceRegistry_InvalidateIf_IsConditional(t *testing.T) {
+func TestWorkspaceRegistry_Invalidate_IsConditional(t *testing.T) {
 	r := NewWorkspaceRegistry()
 	wm := &rotatingWM{instanceID: "instance-1"}
 	ctx := context.Background()
 
-	ws, err := r.Acquire(ctx, wm, "invalidate")
+	handle, err := r.AcquireHandle(ctx, wm, "invalidate")
 	require.NoError(t, err)
-	require.False(t, r.InvalidateIf(
-		"invalidate",
-		Workspace{ID: ws.ID, Path: "/other"},
-		"instance-1",
-	))
-	require.False(t, r.InvalidateIf("invalidate", ws, "instance-2"))
-	require.True(t, r.InvalidateIf("invalidate", ws, "instance-1"))
+	require.False(t, r.Invalidate(WorkspaceHandle{}))
+	require.False(t, NewWorkspaceRegistry().Invalidate(handle))
+	require.True(t, r.Invalidate(handle))
 
 	_, err = r.Acquire(ctx, wm, "invalidate")
 	require.NoError(t, err)
 	require.Equal(t, 2, wm.callCount())
 
 	wm.setInstanceID("instance-2")
-	_, err = r.Acquire(ctx, wm, "invalidate")
+	refreshed, err := r.AcquireHandle(ctx, wm, "invalidate")
 	require.NoError(t, err)
 	require.Equal(t, 3, wm.callCount())
-	require.False(t, r.InvalidateIf("invalidate", ws, "instance-1"),
+	require.False(t, r.Invalidate(handle),
 		"a stale instance must not evict the refreshed deterministic handle")
+	require.True(t, r.Invalidate(refreshed))
+}
+
+type instanceProbeResult struct {
+	id  WorkspaceInstanceID
+	err error
+}
+
+type fencedWM struct {
+	mu       sync.Mutex
+	probes   []instanceProbeResult
+	creates  int
+	cleanups int
+}
+
+func (m *fencedWM) CreateWorkspace(
+	_ context.Context,
+	id string,
+	_ WorkspacePolicy,
+) (Workspace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.creates++
+	return Workspace{ID: id, Path: "/tmp/" + id}, nil
+}
+
+func (m *fencedWM) Cleanup(context.Context, Workspace) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanups++
+	return nil
+}
+
+func (m *fencedWM) InstanceID(
+	context.Context,
+) (WorkspaceInstanceID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.probes) == 0 {
+		return "", errors.New("unexpected instance probe")
+	}
+	result := m.probes[0]
+	m.probes = m.probes[1:]
+	return result.id, result.err
+}
+
+func (m *fencedWM) addProbes(results ...instanceProbeResult) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.probes = append(m.probes, results...)
+}
+
+func TestWorkspaceRegistry_AcquireHandle_GenerationFence(t *testing.T) {
+	t.Run("stable generation installs handle", func(t *testing.T) {
+		r := NewWorkspaceRegistry()
+		wm := &fencedWM{probes: []instanceProbeResult{
+			{id: "instance-a"},
+			{id: "instance-a"},
+		}}
+
+		handle, err := r.AcquireHandle(context.Background(), wm, "stable")
+		require.NoError(t, err)
+		require.Equal(t, WorkspaceInstanceID("instance-a"),
+			handle.InstanceID)
+		require.NotZero(t, handle.entryToken)
+		require.Equal(t, 1, wm.creates)
+	})
+
+	t.Run("rotation during creation is not cached or cleaned", func(t *testing.T) {
+		r := NewWorkspaceRegistry()
+		wm := &fencedWM{probes: []instanceProbeResult{
+			{id: "instance-a"},
+			{id: "instance-b"},
+		}}
+
+		_, err := r.AcquireHandle(context.Background(), wm, "rotated")
+		require.ErrorIs(t, err, ErrWorkspaceStale)
+		require.NotContains(t, r.byID, "rotated")
+		require.Equal(t, 1, wm.creates)
+		require.Zero(t, wm.cleanups)
+
+		wm.addProbes(
+			instanceProbeResult{id: "instance-b"},
+			instanceProbeResult{id: "instance-b"},
+		)
+		handle, err := r.AcquireHandle(
+			context.Background(), wm, "rotated",
+		)
+		require.NoError(t, err)
+		require.Equal(t, WorkspaceInstanceID("instance-b"),
+			handle.InstanceID)
+		require.Equal(t, 2, wm.creates)
+	})
+}
+
+func TestWorkspaceRegistry_AcquireHandle_PostflightErrorKeepsOldEntry(
+	t *testing.T,
+) {
+	r := NewWorkspaceRegistry()
+	wm := &fencedWM{probes: []instanceProbeResult{
+		{id: "instance-a"},
+		{id: "instance-a"},
+	}}
+	old, err := r.AcquireHandle(context.Background(), wm, "postflight")
+	require.NoError(t, err)
+
+	postErr := errors.New("postflight failed")
+	wm.addProbes(
+		instanceProbeResult{id: "instance-b"}, // cache validation
+		instanceProbeResult{id: "instance-b"}, // creation preflight
+		instanceProbeResult{err: postErr},     // creation postflight
+	)
+	_, err = r.AcquireHandle(context.Background(), wm, "postflight")
+	require.ErrorIs(t, err, postErr)
+	require.Equal(t, old.entryToken, r.byID["postflight"].entryToken)
+	require.Equal(t, 2, wm.creates)
+}
+
+func TestWorkspaceRegistry_Invalidate_LegacyLateStaleCannotEvictNewToken(
+	t *testing.T,
+) {
+	r := NewWorkspaceRegistry()
+	wm := &fakeWM{}
+	ctx := context.Background()
+
+	old, err := r.AcquireHandle(ctx, wm, "legacy")
+	require.NoError(t, err)
+	require.True(t, r.Invalidate(old))
+	current, err := r.AcquireHandle(ctx, wm, "legacy")
+	require.NoError(t, err)
+	require.Equal(t, old.Workspace, current.Workspace)
+	require.NotEqual(t, old.entryToken, current.entryToken)
+
+	require.False(t, r.Invalidate(old))
+	require.False(t, r.Invalidate(old))
+	got, err := r.AcquireHandle(ctx, wm, "legacy")
+	require.NoError(t, err)
+	require.Equal(t, current.entryToken, got.entryToken)
+	require.Equal(t, 2, wm.callCount())
 }

--- a/codeexecutor/registry_test.go
+++ b/codeexecutor/registry_test.go
@@ -155,3 +155,230 @@ func TestWorkspaceRegistry_Acquire_CanceledMissDoesNotCreate(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Equal(t, 0, wm.callCount())
 }
+
+type rotatingWM struct {
+	mu sync.Mutex
+
+	instanceID  WorkspaceInstanceID
+	createErr   error
+	providerErr error
+	calls       int
+
+	rebuildEntered chan struct{}
+	rebuildRelease chan struct{}
+	rebuildOnce    sync.Once
+}
+
+func (m *rotatingWM) CreateWorkspace(
+	ctx context.Context,
+	id string,
+	_ WorkspacePolicy,
+) (Workspace, error) {
+	m.mu.Lock()
+	m.calls++
+	call := m.calls
+	err := m.createErr
+	entered := m.rebuildEntered
+	release := m.rebuildRelease
+	m.mu.Unlock()
+
+	if call > 1 && entered != nil {
+		m.rebuildOnce.Do(func() { close(entered) })
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return Workspace{}, ctx.Err()
+		}
+	}
+	if err != nil {
+		return Workspace{}, err
+	}
+	// Keep the handle deterministic across instances. The instance ID is what
+	// prevents a late stale report from evicting a refreshed entry.
+	return Workspace{ID: id, Path: "/tmp/" + id}, nil
+}
+
+func (*rotatingWM) Cleanup(context.Context, Workspace) error {
+	return nil
+}
+
+func (m *rotatingWM) WorkspaceInstanceID(
+	context.Context,
+	Workspace,
+) (WorkspaceInstanceID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.instanceID, m.providerErr
+}
+
+func (m *rotatingWM) setInstanceID(id WorkspaceInstanceID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.instanceID = id
+}
+
+func (m *rotatingWM) setCreateError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createErr = err
+}
+
+func (m *rotatingWM) setProviderError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.providerErr = err
+}
+
+func (m *rotatingWM) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func TestWorkspaceRegistry_Acquire_InstanceAwareStable(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{instanceID: "instance-1"}
+
+	ws1, err := r.Acquire(context.Background(), wm, "stable")
+	require.NoError(t, err)
+	ws2, err := r.Acquire(context.Background(), wm, "stable")
+	require.NoError(t, err)
+
+	require.Equal(t, ws1, ws2)
+	require.Equal(t, 1, wm.callCount())
+}
+
+func TestWorkspaceRegistry_Acquire_InstanceChangeRecreates(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{instanceID: "instance-1"}
+
+	ws1, err := r.Acquire(context.Background(), wm, "rotating")
+	require.NoError(t, err)
+	wm.setInstanceID("instance-2")
+	ws2, err := r.Acquire(context.Background(), wm, "rotating")
+	require.NoError(t, err)
+
+	require.Equal(t, ws1, ws2, "deterministic handles may be reused across instances")
+	require.Equal(t, 2, wm.callCount())
+	_, err = r.Acquire(context.Background(), wm, "rotating")
+	require.NoError(t, err)
+	require.Equal(t, 2, wm.callCount())
+}
+
+func TestWorkspaceRegistry_Acquire_RejectsEmptyInstanceID(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{}
+
+	_, err := r.Acquire(context.Background(), wm, "empty-instance")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty instance ID")
+}
+
+func TestWorkspaceRegistry_Acquire_ValidationFailureKeepsEntry(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{instanceID: "instance-1"}
+	ctx := context.Background()
+
+	want, err := r.Acquire(ctx, wm, "validation")
+	require.NoError(t, err)
+	probeErr := errors.New("probe failed")
+	wm.setProviderError(probeErr)
+	_, err = r.Acquire(ctx, wm, "validation")
+	require.ErrorIs(t, err, probeErr)
+	require.Equal(t, 1, wm.callCount())
+
+	wm.setProviderError(nil)
+	got, err := r.Acquire(ctx, wm, "validation")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Equal(t, 1, wm.callCount())
+}
+
+func TestWorkspaceRegistry_Acquire_RebuildFailureKeepsEntry(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{instanceID: "instance-1"}
+	ctx := context.Background()
+
+	_, err := r.Acquire(ctx, wm, "rebuild")
+	require.NoError(t, err)
+	wm.setInstanceID("instance-2")
+	rebuildErr := errors.New("rebuild failed")
+	wm.setCreateError(rebuildErr)
+	_, err = r.Acquire(ctx, wm, "rebuild")
+	require.ErrorIs(t, err, rebuildErr)
+	require.Equal(t, 2, wm.callCount())
+
+	wm.setCreateError(nil)
+	_, err = r.Acquire(ctx, wm, "rebuild")
+	require.NoError(t, err)
+	require.Equal(t, 3, wm.callCount())
+}
+
+func TestWorkspaceRegistry_Acquire_ConcurrentRefreshCreatesOnce(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{instanceID: "instance-1"}
+	_, err := r.Acquire(context.Background(), wm, "concurrent-refresh")
+	require.NoError(t, err)
+
+	wm.setInstanceID("instance-2")
+	wm.rebuildEntered = make(chan struct{})
+	wm.rebuildRelease = make(chan struct{})
+
+	const n = 32
+	start := make(chan struct{})
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := r.Acquire(
+				context.Background(),
+				wm,
+				"concurrent-refresh",
+			)
+			errs <- err
+		}()
+	}
+	close(start)
+	select {
+	case <-wm.rebuildEntered:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+	close(wm.rebuildRelease)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 2, wm.callCount())
+}
+
+func TestWorkspaceRegistry_InvalidateIf_IsConditional(t *testing.T) {
+	r := NewWorkspaceRegistry()
+	wm := &rotatingWM{instanceID: "instance-1"}
+	ctx := context.Background()
+
+	ws, err := r.Acquire(ctx, wm, "invalidate")
+	require.NoError(t, err)
+	require.False(t, r.InvalidateIf(
+		"invalidate",
+		Workspace{ID: ws.ID, Path: "/other"},
+		"instance-1",
+	))
+	require.False(t, r.InvalidateIf("invalidate", ws, "instance-2"))
+	require.True(t, r.InvalidateIf("invalidate", ws, "instance-1"))
+
+	_, err = r.Acquire(ctx, wm, "invalidate")
+	require.NoError(t, err)
+	require.Equal(t, 2, wm.callCount())
+
+	wm.setInstanceID("instance-2")
+	_, err = r.Acquire(ctx, wm, "invalidate")
+	require.NoError(t, err)
+	require.Equal(t, 3, wm.callCount())
+	require.False(t, r.InvalidateIf("invalidate", ws, "instance-1"),
+		"a stale instance must not evict the refreshed deterministic handle")
+}

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -12,6 +12,7 @@ package codeexecutor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -46,12 +47,59 @@ const (
 	AttrMountUsed = "mount_used"
 )
 
-// Workspace represents an isolated execution workspace.
-// Path is host path for local runtime or a logical mount path for
-// containers.
+// Workspace represents an isolated logical execution workspace.
 type Workspace struct {
-	ID   string
+	// ID identifies the logical workspace, typically for an execution,
+	// session, or invocation. It may remain unchanged when the backend
+	// replaces the physical execution environment, so it must not be used to
+	// detect whether a cached handle is stale. Instance-aware backends expose
+	// that separate identity through [WorkspaceInstanceProvider].
+	ID string
+	// Path is a host path for a local runtime or a logical mount path for
+	// containers. Like ID, a deterministic Path may be reused across physical
+	// execution-environment instances.
 	Path string
+}
+
+// ErrWorkspaceStale reports that a workspace handle belongs to a physical
+// execution-environment instance that is no longer current.
+//
+// Backends must return this error only when they know that the requested
+// operation did not start, or when the failed operation is safe for a higher
+// layer to reconcile again. In particular, transport timeouts, lost responses,
+// ordinary file-system errors, and non-zero program exit codes must not be
+// converted to ErrWorkspaceStale: their side effects may be unknown, and
+// retrying them could execute a user command twice.
+var ErrWorkspaceStale = errors.New("codeexecutor: workspace is stale")
+
+// WorkspaceInstanceID identifies the physical execution-environment instance
+// to which a cached [Workspace] handle belongs.
+//
+// The value is opaque to the framework and must be non-empty. It must remain
+// stable while cached workspaces can be reused, and must change whenever the
+// backend recreates the environment such that cached handles need to be
+// recreated. Unlike [Workspace.ID], it identifies that physical instance
+// rather than the logical workspace. It is not a workspace-content, file, or
+// metadata version.
+type WorkspaceInstanceID string
+
+// WorkspaceInstanceProvider is an optional [WorkspaceManager] capability for
+// backends whose physical execution environment can be replaced while logical
+// workspace IDs remain stable.
+//
+// WorkspaceInstanceID must return the current opaque, non-empty instance ID.
+// The lookup may make the backend ready (for example, by lazily reconnecting),
+// but must not modify workspace contents. Implementations must follow the
+// stability and change rules documented on [WorkspaceInstanceID].
+//
+// A wrapper around a WorkspaceManager must forward this capability when the
+// wrapped manager implements it. A wrapper whose manager does not implement it
+// must not synthesize an empty ID or otherwise advertise the capability.
+type WorkspaceInstanceProvider interface {
+	WorkspaceInstanceID(
+		ctx context.Context,
+		ws Workspace,
+	) (WorkspaceInstanceID, error)
 }
 
 // WorkspacePolicy configures workspace behavior.

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -83,11 +83,30 @@ var ErrWorkspaceStale = errors.New("codeexecutor: workspace is stale")
 // metadata version.
 type WorkspaceInstanceID string
 
+// WorkspaceHandle binds a logical [Workspace] to the backend instance that
+// created it and to one exact [WorkspaceRegistry] cache entry.
+//
+// InstanceID is empty for legacy managers that do not implement
+// [WorkspaceInstanceProvider]. The registry-owned identity is intentionally
+// private: callers can copy a handle and pass it back to
+// [WorkspaceRegistry.Invalidate], but cannot forge or reuse its cache token.
+type WorkspaceHandle struct {
+	Workspace  Workspace
+	InstanceID WorkspaceInstanceID
+
+	registry   *WorkspaceRegistry
+	registryID string
+	entryToken uint64
+}
+
 // WorkspaceInstanceProvider is an optional [WorkspaceManager] capability for
 // backends whose physical execution environment can be replaced while logical
 // workspace IDs remain stable.
 //
-// WorkspaceInstanceID must return the current opaque, non-empty instance ID.
+// InstanceID must return the current opaque, non-empty instance ID. The ID must
+// change on every physical environment replacement; an ID must never be reused
+// within a process, even if a platform-level identifier is reused.
+//
 // The lookup may make the backend ready (for example, by lazily reconnecting),
 // but must not modify workspace contents. Implementations must follow the
 // stability and change rules documented on [WorkspaceInstanceID].
@@ -96,10 +115,7 @@ type WorkspaceInstanceID string
 // wrapped manager implements it. A wrapper whose manager does not implement it
 // must not synthesize an empty ID or otherwise advertise the capability.
 type WorkspaceInstanceProvider interface {
-	WorkspaceInstanceID(
-		ctx context.Context,
-		ws Workspace,
-	) (WorkspaceInstanceID, error)
+	InstanceID(ctx context.Context) (WorkspaceInstanceID, error)
 }
 
 // WorkspacePolicy configures workspace behavior.

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -62,15 +62,36 @@ type Workspace struct {
 }
 
 // ErrWorkspaceStale reports that a workspace handle belongs to a physical
-// execution-environment instance that is no longer current.
+// execution-environment instance that is no longer current. Callers should
+// invalidate the exact [WorkspaceHandle] whenever an error matches this value.
 //
-// Backends must return this error only when they know that the requested
-// operation did not start, or when the failed operation is safe for a higher
-// layer to reconcile again. In particular, transport timeouts, lost responses,
-// ordinary file-system errors, and non-zero program exit codes must not be
-// converted to ErrWorkspaceStale: their side effects may be unknown, and
-// retrying them could execute a user command twice.
+// A standalone ErrWorkspaceStale remains safe to retry for compatibility.
+// Errors that also match [ErrWorkspaceRetryUnsafe] or
+// [ErrPartialOutputCommit] are invalidation-only signals and must not be
+// replayed. Callers performing automatic replay must use
+// [IsWorkspaceRetrySafe] rather than testing ErrWorkspaceStale alone.
+//
+// Backends must not return a standalone ErrWorkspaceStale for transport
+// timeouts, lost responses, ordinary file-system errors, or non-zero program
+// exit codes when side effects may be unknown. Such failures must remain
+// ordinary errors or join ErrWorkspaceRetryUnsafe.
 var ErrWorkspaceStale = errors.New("codeexecutor: workspace is stale")
+
+// ErrWorkspaceRetryUnsafe marks a stale operation that may have produced side
+// effects and therefore must not be replayed automatically. The enclosing error
+// should also match [ErrWorkspaceStale] so callers can invalidate its handle.
+var ErrWorkspaceRetryUnsafe = errors.New(
+	"codeexecutor: workspace operation is unsafe to retry",
+)
+
+// IsWorkspaceRetrySafe reports whether err authorizes automatic workspace
+// replay. A stale partial output commit is always unsafe because outputs or
+// artifacts may already have been persisted.
+func IsWorkspaceRetrySafe(err error) bool {
+	return errors.Is(err, ErrWorkspaceStale) &&
+		!errors.Is(err, ErrWorkspaceRetryUnsafe) &&
+		!errors.Is(err, ErrPartialOutputCommit)
+}
 
 // WorkspaceInstanceID identifies the physical execution-environment instance
 // to which a cached [Workspace] handle belongs.

--- a/codeexecutor/workspace_bootstrap.go
+++ b/codeexecutor/workspace_bootstrap.go
@@ -25,9 +25,10 @@ import "time"
 // wire it into their workspace_exec tool.
 //
 // Files are staged first (in declaration order); Commands then run
-// (also in declaration order). Both are idempotent: the reconciler
-// fingerprints each entry and skips work whose fingerprint plus
-// on-disk sentinel are still satisfied.
+// (also in declaration order). The reconciler fingerprints each entry and
+// skips work whose fingerprint plus on-disk sentinel are still satisfied. This
+// provides eventual convergence, not exactly-once execution: callers remain
+// responsible for making initialization commands replay-safe.
 type WorkspaceBootstrapSpec struct {
 	// Files are static inputs that must exist before commands run.
 	// Each entry maps a workspace-relative Target to either inline
@@ -65,6 +66,11 @@ type WorkspaceFile struct {
 // execute during workspace preparation. The command runs through the
 // engine's runner, with the same isolation guarantees as user
 // commands.
+//
+// A fingerprint or marker records a known successful result; it cannot make an
+// arbitrary command exactly-once. If a backend cannot prove that a failed
+// command never started, it must not report [ErrWorkspaceStale], because the
+// framework will not automatically replay an uncertain command result.
 //
 // Self-healing notes:
 //

--- a/codeexecutor/workspace_init.go
+++ b/codeexecutor/workspace_init.go
@@ -231,11 +231,18 @@ func (e *workspaceInitEngine) Manager() WorkspaceManager {
 	if mgr == nil {
 		return nil
 	}
-	return &workspaceInitManager{
+	wrapped := &workspaceInitManager{
 		inner: mgr,
 		eng:   e.inner,
 		hooks: e.hooks,
 	}
+	if provider, ok := mgr.(WorkspaceInstanceProvider); ok {
+		return &workspaceInstanceInitManager{
+			workspaceInitManager: wrapped,
+			provider:             provider,
+		}
+	}
+	return wrapped
 }
 
 func (e *workspaceInitEngine) FS() WorkspaceFS { return e.inner.FS() }
@@ -248,6 +255,21 @@ type workspaceInitManager struct {
 	inner WorkspaceManager
 	eng   Engine
 	hooks []WorkspaceInitHook
+}
+
+// workspaceInstanceInitManager is deliberately a separate wrapper type.
+// Keeping WorkspaceInstanceID off workspaceInitManager means legacy managers
+// do not accidentally advertise the optional capability with a fabricated ID.
+type workspaceInstanceInitManager struct {
+	*workspaceInitManager
+	provider WorkspaceInstanceProvider
+}
+
+func (m *workspaceInstanceInitManager) WorkspaceInstanceID(
+	ctx context.Context,
+	ws Workspace,
+) (WorkspaceInstanceID, error) {
+	return m.provider.WorkspaceInstanceID(ctx, ws)
 }
 
 func (m *workspaceInitManager) CreateWorkspace(

--- a/codeexecutor/workspace_init.go
+++ b/codeexecutor/workspace_init.go
@@ -37,7 +37,9 @@ const (
 // succeeds and before that workspace is returned to callers. Use it for
 // deterministic setup (stage inputs, install dependencies). Hooks are scoped to
 // workspace creation: they do not watch files on disk or re-run later solely
-// because workspace contents changed.
+// because workspace contents changed. Hooks must be replay-safe: an
+// instance-aware backend can replace its physical environment during creation,
+// causing the complete provisioning sequence to run again on the new instance.
 //
 // Multiple hooks run in declaration order; failure labels use hook index
 // (0, 1, ...). Use [NewWorkspaceInitHook] for declarative staging and commands with
@@ -265,11 +267,10 @@ type workspaceInstanceInitManager struct {
 	provider WorkspaceInstanceProvider
 }
 
-func (m *workspaceInstanceInitManager) WorkspaceInstanceID(
+func (m *workspaceInstanceInitManager) InstanceID(
 	ctx context.Context,
-	ws Workspace,
 ) (WorkspaceInstanceID, error) {
-	return m.provider.WorkspaceInstanceID(ctx, ws)
+	return m.provider.InstanceID(ctx)
 }
 
 func (m *workspaceInitManager) CreateWorkspace(
@@ -292,6 +293,12 @@ func (m *workspaceInitManager) CreateWorkspace(
 	for i, h := range m.hooks {
 		if err := h(ctx, env); err != nil {
 			hookErr := fmt.Errorf("workspace init hook %d: %w", i, err)
+			if errors.Is(err, ErrWorkspaceStale) {
+				// A deterministic path may already belong to the replacement
+				// instance. Cleaning up through a stale handle could delete
+				// newly provisioned data.
+				return Workspace{}, hookErr
+			}
 			// Best-effort cleanup without inheriting deadline/cancel from ctx,
 			// which may already be expired when the hook failed for timeout.
 			cleanCtx, cancel := context.WithTimeout(

--- a/codeexecutor/workspace_init.go
+++ b/codeexecutor/workspace_init.go
@@ -145,6 +145,14 @@ func NewWorkspaceInitHook(spec WorkspaceInitSpec) WorkspaceInitHook {
 // information—the same requirements as [WorkspaceFS.StageInputs]. Standard agent
 // workspace-session tooling injects that context before [WorkspaceRegistry.Acquire],
 // so init hooks can load artifacts without extra setup.
+//
+// When a hook fails, a legacy manager receives best-effort cleanup unless the
+// error is [ErrWorkspaceStale]. An instance-aware manager is never cleaned up
+// automatically after hook failure: checking [WorkspaceInstanceProvider.InstanceID]
+// and calling [WorkspaceManager.Cleanup] cannot be atomic, so cleanup could affect
+// a replacement instance that reused the logical workspace path. Such backends
+// should reclaim failed workspaces through their instance lifecycle or TTL. The
+// original hook error is preserved and is not converted to [ErrWorkspaceStale].
 func NewWorkspaceInitExecutor(
 	exec CodeExecutor,
 	hooks ...WorkspaceInitHook,
@@ -278,19 +286,11 @@ func (m *workspaceInstanceInitManager) CreateWorkspace(
 	execID string,
 	pol WorkspacePolicy,
 ) (Workspace, error) {
-	instanceID, err := m.provider.InstanceID(ctx)
-	if err != nil {
-		return Workspace{}, err
-	}
-	if instanceID == "" {
-		return Workspace{}, errWorkspaceInstanceIDEmpty
-	}
 	return m.workspaceInitManager.createWorkspace(
 		ctx,
 		execID,
 		pol,
-		m.provider,
-		instanceID,
+		false,
 	)
 }
 
@@ -299,15 +299,14 @@ func (m *workspaceInitManager) CreateWorkspace(
 	execID string,
 	pol WorkspacePolicy,
 ) (Workspace, error) {
-	return m.createWorkspace(ctx, execID, pol, nil, "")
+	return m.createWorkspace(ctx, execID, pol, true)
 }
 
 func (m *workspaceInitManager) createWorkspace(
 	ctx context.Context,
 	execID string,
 	pol WorkspacePolicy,
-	provider WorkspaceInstanceProvider,
-	instanceID WorkspaceInstanceID,
+	cleanupHookFailure bool,
 ) (Workspace, error) {
 	ws, err := m.inner.CreateWorkspace(ctx, execID, pol)
 	if err != nil {
@@ -330,22 +329,20 @@ func (m *workspaceInitManager) createWorkspace(
 				// newly provisioned data.
 				return Workspace{}, hookErr
 			}
+			if !cleanupHookFailure {
+				// InstanceID and Cleanup are separate backend calls, so a
+				// check-before-cleanup cannot prevent rotation between them.
+				// Never clean up through an instance-aware wrapper: its
+				// deterministic workspace path may already belong to a
+				// replacement instance.
+				return Workspace{}, hookErr
+			}
 			// Best-effort cleanup without inheriting deadline/cancel from ctx,
 			// which may already be expired when the hook failed for timeout.
 			cleanCtx, cancel := context.WithTimeout(
 				context.WithoutCancel(ctx),
 				workspaceInitCleanupTimeout,
 			)
-			if provider != nil {
-				currentID, probeErr := provider.InstanceID(cleanCtx)
-				if probeErr != nil || currentID != instanceID {
-					cancel()
-					// The deterministic workspace path may now refer to a
-					// replacement instance. Preserve the original hook error,
-					// but do not risk deleting the replacement.
-					return Workspace{}, hookErr
-				}
-			}
 			cerr := m.inner.Cleanup(cleanCtx, ws)
 			cancel()
 			if cerr != nil {

--- a/codeexecutor/workspace_init.go
+++ b/codeexecutor/workspace_init.go
@@ -273,10 +273,41 @@ func (m *workspaceInstanceInitManager) InstanceID(
 	return m.provider.InstanceID(ctx)
 }
 
+func (m *workspaceInstanceInitManager) CreateWorkspace(
+	ctx context.Context,
+	execID string,
+	pol WorkspacePolicy,
+) (Workspace, error) {
+	instanceID, err := m.provider.InstanceID(ctx)
+	if err != nil {
+		return Workspace{}, err
+	}
+	if instanceID == "" {
+		return Workspace{}, errWorkspaceInstanceIDEmpty
+	}
+	return m.workspaceInitManager.createWorkspace(
+		ctx,
+		execID,
+		pol,
+		m.provider,
+		instanceID,
+	)
+}
+
 func (m *workspaceInitManager) CreateWorkspace(
 	ctx context.Context,
 	execID string,
 	pol WorkspacePolicy,
+) (Workspace, error) {
+	return m.createWorkspace(ctx, execID, pol, nil, "")
+}
+
+func (m *workspaceInitManager) createWorkspace(
+	ctx context.Context,
+	execID string,
+	pol WorkspacePolicy,
+	provider WorkspaceInstanceProvider,
+	instanceID WorkspaceInstanceID,
 ) (Workspace, error) {
 	ws, err := m.inner.CreateWorkspace(ctx, execID, pol)
 	if err != nil {
@@ -305,6 +336,16 @@ func (m *workspaceInitManager) CreateWorkspace(
 				context.WithoutCancel(ctx),
 				workspaceInitCleanupTimeout,
 			)
+			if provider != nil {
+				currentID, probeErr := provider.InstanceID(cleanCtx)
+				if probeErr != nil || currentID != instanceID {
+					cancel()
+					// The deterministic workspace path may now refer to a
+					// replacement instance. Preserve the original hook error,
+					// but do not risk deleting the replacement.
+					return Workspace{}, hookErr
+				}
+			}
 			cerr := m.inner.Cleanup(cleanCtx, ws)
 			cancel()
 			if cerr != nil {

--- a/codeexecutor/workspace_init_test.go
+++ b/codeexecutor/workspace_init_test.go
@@ -238,6 +238,58 @@ func TestWorkspaceInitEngine_DelegatesCapabilities(t *testing.T) {
 	require.Same(t, runner, wrapped.Runner())
 	require.Equal(t, Capabilities{}, wrapped.Describe())
 	require.NotNil(t, wrapped.Manager())
+	_, ok := wrapped.Manager().(WorkspaceInstanceProvider)
+	require.False(t, ok, "legacy managers must not advertise an empty instance ID")
+}
+
+func TestWorkspaceInitEngine_ForwardsWorkspaceInstanceProvider(t *testing.T) {
+	fs := &recordingFS{}
+	runner := &recordingRunner{}
+	innerManager := &rotatingWM{instanceID: "instance-1"}
+	inner := NewEngine(innerManager, fs, runner)
+	wrapped := newWorkspaceInitEngine(inner, nil)
+
+	manager := wrapped.Manager()
+	provider, ok := manager.(WorkspaceInstanceProvider)
+	require.True(t, ok)
+	got, err := provider.WorkspaceInstanceID(
+		context.Background(),
+		Workspace{ID: "ws", Path: "/tmp/ws"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, WorkspaceInstanceID("instance-1"), got)
+}
+
+func TestWorkspaceInitEngine_InstanceChangeRerunsHooks(t *testing.T) {
+	innerManager := &rotatingWM{instanceID: "instance-1"}
+	inner := NewEngine(innerManager, &recordingFS{}, &recordingRunner{})
+	var mu sync.Mutex
+	hookCalls := 0
+	wrapped := newWorkspaceInitEngine(
+		inner,
+		[]WorkspaceInitHook{func(context.Context, WorkspaceInitEnv) error {
+			mu.Lock()
+			defer mu.Unlock()
+			hookCalls++
+			return nil
+		}},
+	)
+	reg := NewWorkspaceRegistry()
+
+	_, err := reg.Acquire(context.Background(), wrapped.Manager(), "init-refresh")
+	require.NoError(t, err)
+	_, err = reg.Acquire(context.Background(), wrapped.Manager(), "init-refresh")
+	require.NoError(t, err)
+	mu.Lock()
+	require.Equal(t, 1, hookCalls)
+	mu.Unlock()
+
+	innerManager.setInstanceID("instance-2")
+	_, err = reg.Acquire(context.Background(), wrapped.Manager(), "init-refresh")
+	require.NoError(t, err)
+	mu.Lock()
+	require.Equal(t, 2, hookCalls)
+	mu.Unlock()
 }
 
 func TestWorkspaceInitManager_CreateWorkspaceInnerError(t *testing.T) {

--- a/codeexecutor/workspace_init_test.go
+++ b/codeexecutor/workspace_init_test.go
@@ -252,10 +252,7 @@ func TestWorkspaceInitEngine_ForwardsWorkspaceInstanceProvider(t *testing.T) {
 	manager := wrapped.Manager()
 	provider, ok := manager.(WorkspaceInstanceProvider)
 	require.True(t, ok)
-	got, err := provider.WorkspaceInstanceID(
-		context.Background(),
-		Workspace{ID: "ws", Path: "/tmp/ws"},
-	)
+	got, err := provider.InstanceID(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, WorkspaceInstanceID("instance-1"), got)
 }
@@ -292,6 +289,39 @@ func TestWorkspaceInitEngine_InstanceChangeRerunsHooks(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestWorkspaceInitEngine_RotationDuringHooksRequiresStableReplay(
+	t *testing.T,
+) {
+	innerManager := &rotatingWM{instanceID: "instance-1"}
+	inner := NewEngine(innerManager, &recordingFS{}, &recordingRunner{})
+	hookCalls := 0
+	wrapped := newWorkspaceInitEngine(
+		inner,
+		[]WorkspaceInitHook{func(context.Context, WorkspaceInitEnv) error {
+			hookCalls++
+			if hookCalls == 1 {
+				innerManager.setInstanceID("instance-2")
+			}
+			return nil
+		}},
+	)
+	reg := NewWorkspaceRegistry()
+
+	_, err := reg.Acquire(
+		context.Background(), wrapped.Manager(), "init-fence",
+	)
+	require.ErrorIs(t, err, ErrWorkspaceStale)
+	require.NotContains(t, reg.byID, "init-fence")
+
+	handle, err := reg.AcquireHandle(
+		context.Background(), wrapped.Manager(), "init-fence",
+	)
+	require.NoError(t, err)
+	require.Equal(t, WorkspaceInstanceID("instance-2"),
+		handle.InstanceID)
+	require.Equal(t, 2, hookCalls)
+}
+
 func TestWorkspaceInitManager_CreateWorkspaceInnerError(t *testing.T) {
 	boom := errors.New("boom")
 	inner := NewEngine(&fakeWM{err: boom}, &recordingFS{}, &recordingRunner{})
@@ -316,6 +346,38 @@ func TestWorkspaceInitManager_CleanupFailureIsReported(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "workspace init hook 0")
 	require.Contains(t, err.Error(), "cleanup failed")
+}
+
+func TestWorkspaceInitManager_StaleHookSkipsCleanup(t *testing.T) {
+	inner := &cleanupRecordingWM{}
+	mgr := &workspaceInitManager{
+		inner: inner,
+		eng:   NewEngine(inner, &recordingFS{}, &recordingRunner{}),
+		hooks: []WorkspaceInitHook{
+			func(context.Context, WorkspaceInitEnv) error {
+				return fmt.Errorf("backend rotated: %w", ErrWorkspaceStale)
+			},
+		},
+	}
+
+	_, err := mgr.CreateWorkspace(context.Background(), "x", WorkspacePolicy{})
+	require.ErrorIs(t, err, ErrWorkspaceStale)
+	require.Zero(t, inner.cleanupCalls)
+}
+
+type cleanupRecordingWM struct {
+	cleanupCalls int
+}
+
+func (m *cleanupRecordingWM) CreateWorkspace(
+	_ context.Context, id string, _ WorkspacePolicy,
+) (Workspace, error) {
+	return Workspace{ID: id, Path: "/tmp/" + id}, nil
+}
+
+func (m *cleanupRecordingWM) Cleanup(context.Context, Workspace) error {
+	m.cleanupCalls++
+	return nil
 }
 
 type cleanupFailWM struct {

--- a/codeexecutor/workspace_init_test.go
+++ b/codeexecutor/workspace_init_test.go
@@ -349,23 +349,66 @@ func TestWorkspaceInitManager_CleanupFailureIsReported(t *testing.T) {
 }
 
 func TestWorkspaceInitManager_StaleHookSkipsCleanup(t *testing.T) {
+	staleHook := func(context.Context, WorkspaceInitEnv) error {
+		return fmt.Errorf("backend rotated: %w", ErrWorkspaceStale)
+	}
+
+	t.Run("legacy manager", func(t *testing.T) {
+		inner := &cleanupRecordingWM{}
+		mgr := &workspaceInitManager{
+			inner: inner,
+			eng:   NewEngine(inner, &recordingFS{}, &recordingRunner{}),
+			hooks: []WorkspaceInitHook{staleHook},
+		}
+
+		_, err := mgr.CreateWorkspace(
+			context.Background(), "x", WorkspacePolicy{},
+		)
+		require.ErrorIs(t, err, ErrWorkspaceStale)
+		require.Zero(t, inner.cleanupCalls)
+	})
+
+	t.Run("instance-aware manager", func(t *testing.T) {
+		inner := &cleanupInstanceWM{instanceID: "instance-1"}
+		eng := NewEngine(inner, &recordingFS{}, &recordingRunner{})
+		mgr := newWorkspaceInitEngine(
+			eng,
+			[]WorkspaceInitHook{staleHook},
+		).Manager()
+
+		_, err := mgr.CreateWorkspace(
+			context.Background(), "x", WorkspacePolicy{},
+		)
+		require.ErrorIs(t, err, ErrWorkspaceStale)
+		require.Zero(t, inner.cleanupCalls)
+		require.Zero(t, inner.instanceCalls)
+	})
+}
+
+func TestWorkspaceInitManager_LegacyOrdinaryHookErrorCleansUp(
+	t *testing.T,
+) {
+	timeoutErr := errors.New("timeout after command submission")
 	inner := &cleanupRecordingWM{}
 	mgr := &workspaceInitManager{
 		inner: inner,
 		eng:   NewEngine(inner, &recordingFS{}, &recordingRunner{}),
 		hooks: []WorkspaceInitHook{
 			func(context.Context, WorkspaceInitEnv) error {
-				return fmt.Errorf("backend rotated: %w", ErrWorkspaceStale)
+				return timeoutErr
 			},
 		},
 	}
 
-	_, err := mgr.CreateWorkspace(context.Background(), "x", WorkspacePolicy{})
-	require.ErrorIs(t, err, ErrWorkspaceStale)
-	require.Zero(t, inner.cleanupCalls)
+	_, err := mgr.CreateWorkspace(
+		context.Background(), "x", WorkspacePolicy{},
+	)
+	require.ErrorIs(t, err, timeoutErr)
+	require.NotErrorIs(t, err, ErrWorkspaceStale)
+	require.Equal(t, 1, inner.cleanupCalls)
 }
 
-func TestWorkspaceInitManager_OrdinaryHookErrorFencesCleanupByInstance(
+func TestWorkspaceInitManager_InstanceAwareOrdinaryHookErrorSkipsCleanup(
 	t *testing.T,
 ) {
 	timeoutErr := errors.New("timeout after command submission")
@@ -387,10 +430,12 @@ func TestWorkspaceInitManager_OrdinaryHookErrorFencesCleanupByInstance(
 			context.Background(), "x", WorkspacePolicy{},
 		)
 		require.ErrorIs(t, err, timeoutErr)
+		require.NotErrorIs(t, err, ErrWorkspaceStale)
 		require.Zero(t, inner.cleanupCalls)
+		require.Zero(t, inner.instanceCalls)
 	})
 
-	t.Run("stable instance still cleans up", func(t *testing.T) {
+	t.Run("stable instance also skips cleanup", func(t *testing.T) {
 		inner := &cleanupInstanceWM{instanceID: "instance-1"}
 		eng := NewEngine(inner, &recordingFS{}, &recordingRunner{})
 		mgr := newWorkspaceInitEngine(
@@ -406,7 +451,9 @@ func TestWorkspaceInitManager_OrdinaryHookErrorFencesCleanupByInstance(
 			context.Background(), "x", WorkspacePolicy{},
 		)
 		require.ErrorIs(t, err, timeoutErr)
-		require.Equal(t, 1, inner.cleanupCalls)
+		require.NotErrorIs(t, err, ErrWorkspaceStale)
+		require.Zero(t, inner.cleanupCalls)
+		require.Zero(t, inner.instanceCalls)
 	})
 }
 
@@ -426,8 +473,9 @@ func (m *cleanupRecordingWM) Cleanup(context.Context, Workspace) error {
 }
 
 type cleanupInstanceWM struct {
-	instanceID   WorkspaceInstanceID
-	cleanupCalls int
+	instanceID    WorkspaceInstanceID
+	instanceCalls int
+	cleanupCalls  int
 }
 
 func (m *cleanupInstanceWM) CreateWorkspace(
@@ -444,6 +492,7 @@ func (m *cleanupInstanceWM) Cleanup(context.Context, Workspace) error {
 func (m *cleanupInstanceWM) InstanceID(
 	context.Context,
 ) (WorkspaceInstanceID, error) {
+	m.instanceCalls++
 	return m.instanceID, nil
 }
 

--- a/codeexecutor/workspace_init_test.go
+++ b/codeexecutor/workspace_init_test.go
@@ -365,6 +365,51 @@ func TestWorkspaceInitManager_StaleHookSkipsCleanup(t *testing.T) {
 	require.Zero(t, inner.cleanupCalls)
 }
 
+func TestWorkspaceInitManager_OrdinaryHookErrorFencesCleanupByInstance(
+	t *testing.T,
+) {
+	timeoutErr := errors.New("timeout after command submission")
+
+	t.Run("rotation skips cleanup", func(t *testing.T) {
+		inner := &cleanupInstanceWM{instanceID: "instance-1"}
+		eng := NewEngine(inner, &recordingFS{}, &recordingRunner{})
+		mgr := newWorkspaceInitEngine(
+			eng,
+			[]WorkspaceInitHook{
+				func(context.Context, WorkspaceInitEnv) error {
+					inner.instanceID = "instance-2"
+					return timeoutErr
+				},
+			},
+		).Manager()
+
+		_, err := mgr.CreateWorkspace(
+			context.Background(), "x", WorkspacePolicy{},
+		)
+		require.ErrorIs(t, err, timeoutErr)
+		require.Zero(t, inner.cleanupCalls)
+	})
+
+	t.Run("stable instance still cleans up", func(t *testing.T) {
+		inner := &cleanupInstanceWM{instanceID: "instance-1"}
+		eng := NewEngine(inner, &recordingFS{}, &recordingRunner{})
+		mgr := newWorkspaceInitEngine(
+			eng,
+			[]WorkspaceInitHook{
+				func(context.Context, WorkspaceInitEnv) error {
+					return timeoutErr
+				},
+			},
+		).Manager()
+
+		_, err := mgr.CreateWorkspace(
+			context.Background(), "x", WorkspacePolicy{},
+		)
+		require.ErrorIs(t, err, timeoutErr)
+		require.Equal(t, 1, inner.cleanupCalls)
+	})
+}
+
 type cleanupRecordingWM struct {
 	cleanupCalls int
 }
@@ -378,6 +423,28 @@ func (m *cleanupRecordingWM) CreateWorkspace(
 func (m *cleanupRecordingWM) Cleanup(context.Context, Workspace) error {
 	m.cleanupCalls++
 	return nil
+}
+
+type cleanupInstanceWM struct {
+	instanceID   WorkspaceInstanceID
+	cleanupCalls int
+}
+
+func (m *cleanupInstanceWM) CreateWorkspace(
+	_ context.Context, id string, _ WorkspacePolicy,
+) (Workspace, error) {
+	return Workspace{ID: id, Path: "/tmp/" + id}, nil
+}
+
+func (m *cleanupInstanceWM) Cleanup(context.Context, Workspace) error {
+	m.cleanupCalls++
+	return nil
+}
+
+func (m *cleanupInstanceWM) InstanceID(
+	context.Context,
+) (WorkspaceInstanceID, error) {
+	return m.instanceID, nil
 }
 
 type cleanupFailWM struct {

--- a/codeexecutor/workspace_test.go
+++ b/codeexecutor/workspace_test.go
@@ -10,10 +10,51 @@
 package codeexecutor
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsWorkspaceRetrySafe(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "standalone stale",
+			err:  ErrWorkspaceStale,
+			want: true,
+		},
+		{
+			name: "stale partial commit",
+			err: errors.Join(
+				ErrWorkspaceStale,
+				ErrPartialOutputCommit,
+			),
+		},
+		{
+			name: "stale explicitly unsafe",
+			err: errors.Join(
+				ErrWorkspaceStale,
+				ErrWorkspaceRetryUnsafe,
+			),
+		},
+		{
+			name: "ordinary error",
+			err:  errors.New("ordinary"),
+		},
+		{
+			name: "nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsWorkspaceRetrySafe(tt.err))
+		})
+	}
+}
 
 func TestBuildBlockSpec_PythonAndBash(t *testing.T) {
 	f, m, c, a, err := BuildBlockSpec(

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -179,11 +179,12 @@ func (w *Workspace) Collect(
 	if len(patterns) == 0 {
 		return []*File{}, nil
 	}
-	eng, ws, err := w.bindWorkspace(ctx)
+	eng, handle, err := w.bindWorkspaceHandle(ctx)
 	if err != nil {
 		return nil, err
 	}
-	raw, err := eng.FS().Collect(ctx, ws, patterns)
+	raw, err := eng.FS().Collect(ctx, handle.Workspace, patterns)
+	w.invalidateWorkspaceHandleIfStale(handle, err)
 	if err != nil {
 		return nil, err
 	}
@@ -213,11 +214,13 @@ func (w *Workspace) PutFiles(
 	if len(files) == 0 {
 		return nil
 	}
-	eng, ws, err := w.bindWorkspace(ctx)
+	eng, handle, err := w.bindWorkspaceHandle(ctx)
 	if err != nil {
 		return err
 	}
-	return eng.FS().PutFiles(ctx, ws, files)
+	err = eng.FS().PutFiles(ctx, handle.Workspace, files)
+	w.invalidateWorkspaceHandleIfStale(handle, err)
+	return err
 }
 
 // SaveArtifact persists an existing workspace file as an artifact via
@@ -265,9 +268,7 @@ func (w *Workspace) SaveArtifact(
 		Save:          true,
 		Inline:        false,
 	})
-	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-		w.resolver.InvalidateWorkspaceHandle(handle)
-	}
+	w.invalidateWorkspaceHandleIfStale(handle, err)
 	// ErrPartialOutputCommit means the artifact already landed in the
 	// service but some non-fatal post-commit work failed (e.g. cleanup
 	// or secondary inline read). Mirror tool/workspaceexec.SaveArtifact
@@ -321,11 +322,13 @@ func (w *Workspace) StageInputs(
 		return nil
 	}
 	ctxIO := workspacefacade.WithArtifactContext(ctx)
-	eng, ws, err := w.bindWorkspace(ctxIO)
+	eng, handle, err := w.bindWorkspaceHandle(ctxIO)
 	if err != nil {
 		return err
 	}
-	return eng.FS().StageInputs(ctxIO, ws, specs)
+	err = eng.FS().StageInputs(ctxIO, handle.Workspace, specs)
+	w.invalidateWorkspaceHandleIfStale(handle, err)
+	return err
 }
 
 // RunProgram executes a program inside the current invocation's
@@ -360,7 +363,7 @@ func (w *Workspace) RunProgram(
 		return codeexecutor.RunResult{}, err
 	}
 	spec.Cwd = cwd
-	eng, ws, err := w.bindWorkspace(ctx)
+	eng, handle, err := w.bindWorkspaceHandle(ctx)
 	if err != nil {
 		return codeexecutor.RunResult{}, err
 	}
@@ -370,15 +373,9 @@ func (w *Workspace) RunProgram(
 			"workspaceio: executor does not expose a program runner",
 		)
 	}
-	return runner.RunProgram(ctx, ws, spec)
-}
-
-// bindWorkspace resolves the engine and acquires the invocation workspace.
-func (w *Workspace) bindWorkspace(
-	ctx context.Context,
-) (codeexecutor.Engine, codeexecutor.Workspace, error) {
-	eng, handle, err := w.bindWorkspaceHandle(ctx)
-	return eng, handle.Workspace, err
+	result, err := runner.RunProgram(ctx, handle.Workspace, spec)
+	w.invalidateWorkspaceHandleIfStale(handle, err)
+	return result, err
 }
 
 func (w *Workspace) bindWorkspaceHandle(
@@ -400,6 +397,16 @@ func (w *Workspace) bindWorkspaceHandle(
 		return nil, codeexecutor.WorkspaceHandle{}, err
 	}
 	return eng, handle, nil
+}
+
+func (w *Workspace) invalidateWorkspaceHandleIfStale(
+	handle codeexecutor.WorkspaceHandle,
+	err error,
+) {
+	if w != nil && w.resolver != nil &&
+		errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		w.resolver.InvalidateWorkspaceHandle(handle)
+	}
 }
 
 // toFile converts a codeexecutor.File into the public File type.

--- a/codeexecutor/workspaceio/workspace_io.go
+++ b/codeexecutor/workspaceio/workspace_io.go
@@ -252,10 +252,11 @@ func (w *Workspace) SaveArtifact(
 		cfg.MaxBytes = workspacefacade.DefaultArtifactMaxBytes
 	}
 	ctxIO := workspacefacade.WithArtifactContext(ctx)
-	eng, ws, err := w.bindWorkspace(ctxIO)
+	eng, handle, err := w.bindWorkspaceHandle(ctxIO)
 	if err != nil {
 		return nil, err
 	}
+	ws := handle.Workspace
 	manifest, err := eng.FS().CollectOutputs(ctxIO, ws, codeexecutor.OutputSpec{
 		Globs:         []string{rel},
 		MaxFiles:      1,
@@ -264,6 +265,9 @@ func (w *Workspace) SaveArtifact(
 		Save:          true,
 		Inline:        false,
 	})
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		w.resolver.InvalidateWorkspaceHandle(handle)
+	}
 	// ErrPartialOutputCommit means the artifact already landed in the
 	// service but some non-fatal post-commit work failed (e.g. cleanup
 	// or secondary inline read). Mirror tool/workspaceexec.SaveArtifact
@@ -373,22 +377,29 @@ func (w *Workspace) RunProgram(
 func (w *Workspace) bindWorkspace(
 	ctx context.Context,
 ) (codeexecutor.Engine, codeexecutor.Workspace, error) {
+	eng, handle, err := w.bindWorkspaceHandle(ctx)
+	return eng, handle.Workspace, err
+}
+
+func (w *Workspace) bindWorkspaceHandle(
+	ctx context.Context,
+) (codeexecutor.Engine, codeexecutor.WorkspaceHandle, error) {
 	if w == nil || w.resolver == nil {
-		return nil, codeexecutor.Workspace{}, errors.New(
+		return nil, codeexecutor.WorkspaceHandle{}, errors.New(
 			"workspaceio: workspace is not initialized",
 		)
 	}
 	eng := w.resolver.EnsureEngine()
 	if eng == nil || eng.FS() == nil || eng.Manager() == nil {
-		return nil, codeexecutor.Workspace{}, errors.New(
+		return nil, codeexecutor.WorkspaceHandle{}, errors.New(
 			"workspaceio: executor does not expose a live workspace engine",
 		)
 	}
-	ws, err := w.resolver.CreateWorkspace(ctx, eng, "workspace")
+	handle, err := w.resolver.CreateWorkspaceHandle(ctx, eng, "workspace")
 	if err != nil {
-		return nil, codeexecutor.Workspace{}, err
+		return nil, codeexecutor.WorkspaceHandle{}, err
 	}
-	return eng, ws, nil
+	return eng, handle, nil
 }
 
 // toFile converts a codeexecutor.File into the public File type.

--- a/codeexecutor/workspaceio/workspace_io_test.go
+++ b/codeexecutor/workspaceio/workspace_io_test.go
@@ -12,6 +12,7 @@ package workspaceio
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -425,6 +426,7 @@ func (s *stubFSExec) Engine() codeexecutor.Engine { return s.eng }
 // backend that emits the error organically.
 type partialCommitFS struct {
 	codeexecutor.WorkspaceFS
+	err error
 }
 
 func (p *partialCommitFS) CollectOutputs(
@@ -436,7 +438,31 @@ func (p *partialCommitFS) CollectOutputs(
 	if err != nil {
 		return m, err
 	}
+	if p.err != nil {
+		return m, p.err
+	}
 	return m, codeexecutor.ErrPartialOutputCommit
+}
+
+type countingWorkspaceManager struct {
+	inner   codeexecutor.WorkspaceManager
+	creates int
+}
+
+func (m *countingWorkspaceManager) CreateWorkspace(
+	ctx context.Context,
+	execID string,
+	policy codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.creates++
+	return m.inner.CreateWorkspace(ctx, execID, policy)
+}
+
+func (m *countingWorkspaceManager) Cleanup(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+) error {
+	return m.inner.Cleanup(ctx, ws)
 }
 
 // TestSaveArtifact_PartialCommitStillReturnsRef pins the contract that
@@ -470,6 +496,46 @@ func TestSaveArtifact_PartialCommitStillReturnsRef(t *testing.T) {
 	require.NotNil(t, ref)
 	require.Equal(t, "out/done.txt", ref.Path)
 	require.NotEmpty(t, ref.SavedAs)
+}
+
+func TestSaveArtifact_PartialStaleInvalidatesWorkspace(t *testing.T) {
+	rt := localexec.NewRuntime("")
+	manager := &countingWorkspaceManager{inner: rt}
+	fs := &partialCommitFS{
+		WorkspaceFS: rt,
+		err: errors.Join(
+			codeexecutor.ErrPartialOutputCommit,
+			codeexecutor.ErrWorkspaceStale,
+		),
+	}
+	eng := codeexecutor.NewEngine(manager, fs, rt)
+	exec := &stubFSExec{eng: eng}
+	ws := New(exec, codeexecutor.NewWorkspaceRegistry())
+	svc := inmemory.NewService()
+	inv := agent.NewInvocation(
+		agent.WithInvocationMessage(model.NewUserMessage("hi")),
+		agent.WithInvocationSession(&session.Session{
+			ID: "sess-partial-stale", AppName: "app", UserID: "user",
+		}),
+		agent.WithInvocationArtifactService(svc),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	require.NoError(t, ws.PutFiles(ctx, codeexecutor.PutFile{
+		Path: "out/done.txt", Content: []byte("ok"),
+	}))
+	require.Equal(t, 1, manager.creates)
+
+	ref, err := ws.SaveArtifact(ctx, "out/done.txt")
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	require.Equal(t, "out/done.txt", ref.Path)
+	require.NotEmpty(t, ref.SavedAs)
+
+	_, err = ws.Collect(ctx, "out/done.txt")
+	require.NoError(t, err)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace once")
 }
 
 // captureCtxStageFS snapshots the ctx that StageInputs receives without

--- a/codeexecutor/workspaceio/workspace_io_test.go
+++ b/codeexecutor/workspaceio/workspace_io_test.go
@@ -465,6 +465,150 @@ func (m *countingWorkspaceManager) Cleanup(
 	return m.inner.Cleanup(ctx, ws)
 }
 
+type staleOperationBackend struct {
+	operation string
+	calls     int
+}
+
+func (b *staleOperationBackend) operationError(operation string) error {
+	if b.operation != operation {
+		return nil
+	}
+	b.calls++
+	if b.calls == 1 {
+		return codeexecutor.ErrWorkspaceStale
+	}
+	return nil
+}
+
+func (b *staleOperationBackend) PutFiles(
+	context.Context,
+	codeexecutor.Workspace,
+	[]codeexecutor.PutFile,
+) error {
+	return b.operationError("put_files")
+}
+
+func (*staleOperationBackend) StageDirectory(
+	context.Context,
+	codeexecutor.Workspace,
+	string,
+	string,
+	codeexecutor.StageOptions,
+) error {
+	return nil
+}
+
+func (b *staleOperationBackend) Collect(
+	context.Context,
+	codeexecutor.Workspace,
+	[]string,
+) ([]codeexecutor.File, error) {
+	return nil, b.operationError("collect")
+}
+
+func (b *staleOperationBackend) StageInputs(
+	context.Context,
+	codeexecutor.Workspace,
+	[]codeexecutor.InputSpec,
+) error {
+	return b.operationError("stage_inputs")
+}
+
+func (*staleOperationBackend) CollectOutputs(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.OutputSpec,
+) (codeexecutor.OutputManifest, error) {
+	return codeexecutor.OutputManifest{}, nil
+}
+
+func (b *staleOperationBackend) RunProgram(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	return codeexecutor.RunResult{}, b.operationError("run_program")
+}
+
+func TestBackendOperationStaleInvalidatesLegacyHandleWithoutReplay(
+	t *testing.T,
+) {
+	tests := []struct {
+		name      string
+		operation string
+		call      func(*Workspace) error
+	}{
+		{
+			name:      "collect",
+			operation: "collect",
+			call: func(ws *Workspace) error {
+				_, err := ws.Collect(context.Background(), "work/a.txt")
+				return err
+			},
+		},
+		{
+			name:      "put files",
+			operation: "put_files",
+			call: func(ws *Workspace) error {
+				return ws.PutFiles(
+					context.Background(),
+					codeexecutor.PutFile{Path: "work/a.txt"},
+				)
+			},
+		},
+		{
+			name:      "stage inputs",
+			operation: "stage_inputs",
+			call: func(ws *Workspace) error {
+				return ws.StageInputs(
+					context.Background(),
+					[]codeexecutor.InputSpec{{
+						From: "data:text/plain,hello",
+						To:   "in/a.txt",
+					}},
+				)
+			},
+		},
+		{
+			name:      "run program",
+			operation: "run_program",
+			call: func(ws *Workspace) error {
+				_, err := ws.RunProgram(
+					context.Background(),
+					codeexecutor.RunProgramSpec{Cmd: "true"},
+				)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := localexec.NewRuntime("")
+			manager := &countingWorkspaceManager{inner: rt}
+			backend := &staleOperationBackend{
+				operation: tt.operation,
+			}
+			eng := codeexecutor.NewEngine(manager, backend, backend)
+			ws := New(
+				&stubFSExec{eng: eng},
+				codeexecutor.NewWorkspaceRegistry(),
+			)
+
+			err := tt.call(ws)
+			require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+			require.Equal(t, 1, backend.calls,
+				"the stale operation must not replay in the current call")
+			require.Equal(t, 1, manager.creates)
+
+			require.NoError(t, tt.call(ws))
+			require.Equal(t, 2, backend.calls)
+			require.Equal(t, 2, manager.creates,
+				"the next call must rebuild the invalidated workspace once")
+		})
+	}
+}
+
 // TestSaveArtifact_PartialCommitStillReturnsRef pins the contract that
 // ErrPartialOutputCommit is non-fatal: the artifact has already been
 // persisted and callers must still receive the ref. Mirrors the same

--- a/internal/workspaceinput/stager.go
+++ b/internal/workspaceinput/stager.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -68,15 +69,17 @@ type StagedInput struct {
 }
 
 // StageConversationFiles materializes conversation file inputs into
-// work/inputs/ for the current invocation workspace.
+// work/inputs/ for the current invocation workspace. Ordinary best-effort
+// failures are returned as warnings; ErrWorkspaceStale remains a typed error so
+// callers can invalidate the exact workspace handle before deciding to retry.
 func StageConversationFiles(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
-) ([]StagedInput, []string) {
+) ([]StagedInput, []string, error) {
 	inv, ok := agent.InvocationFromContext(ctx)
 	if !ok || inv == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	files := filesFromSession(inv.Session)
@@ -84,26 +87,30 @@ func StageConversationFiles(
 		files = append(files, msgFiles...)
 	}
 	if len(files) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var staged []StagedInput
 	var warnings []string
+	var stageErr error
 	if err := codeexecutor.WithWorkspaceMetadataLock(
 		ctx,
 		ws.Path,
 		func(ctx context.Context) error {
-			staged, warnings = stageConversationFilesLocked(
+			staged, warnings, stageErr = stageConversationFilesLocked(
 				ctx, eng, ws, files,
 			)
-			return nil
+			return stageErr
 		},
 	); err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			return staged, warnings, err
+		}
 		return nil, []string{
 			fmt.Sprintf("%s lock metadata: %v", warnPrefix, err),
-		}
+		}, nil
 	}
-	return staged, warnings
+	return staged, warnings, nil
 }
 
 func stageConversationFilesLocked(
@@ -111,17 +118,20 @@ func stageConversationFilesLocked(
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
 	files []model.File,
-) ([]StagedInput, []string) {
+) ([]StagedInput, []string, error) {
 	inv, ok := agent.InvocationFromContext(ctx)
 	if !ok || inv == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	stager := skillstage.New()
 	md, err := stager.LoadWorkspaceMetadata(ctx, eng, ws)
 	if err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			return nil, nil, err
+		}
 		return nil, []string{
 			fmt.Sprintf("%s load metadata: %v", warnPrefix, err),
-		}
+		}, nil
 	}
 
 	existingTo := make(map[string]struct{})
@@ -167,21 +177,27 @@ func stageConversationFilesLocked(
 	}
 
 	if len(puts) == 0 {
-		return staged, warnings
+		return staged, warnings, nil
 	}
 	if err := eng.FS().PutFiles(ctx, ws, puts); err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			return nil, nil, err
+		}
 		return nil, []string{
 			fmt.Sprintf("%s stage files: %v", warnPrefix, err),
-		}
+		}, nil
 	}
 	if err := stager.SaveWorkspaceMetadata(ctx, eng, ws, md); err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			return staged, warnings, err
+		}
 		warnings = append(warnings, fmt.Sprintf(
 			"%s save metadata: %v",
 			warnPrefix,
 			err,
 		))
 	}
-	return staged, warnings
+	return staged, warnings, nil
 }
 
 // ArtifactBaseName extracts a stable basename from an artifact:// ref.

--- a/internal/workspaceinput/stager_test.go
+++ b/internal/workspaceinput/stager_test.go
@@ -176,7 +176,8 @@ func TestStageConversationFiles_Warnings(t *testing.T) {
 			collectErr: fmt.Errorf("collect failed"),
 		}, nil)
 
-		staged, warnings := StageConversationFiles(ctx, eng, ws)
+		staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+		require.NoError(t, err)
 		require.Nil(t, staged)
 		require.Len(t, warnings, 1)
 		require.Contains(t, warnings[0], "load metadata")
@@ -187,7 +188,8 @@ func TestStageConversationFiles_Warnings(t *testing.T) {
 		fs := &stubFS{putErr: fmt.Errorf("put failed")}
 		eng := codeexecutor.NewEngine(nil, fs, nil)
 
-		staged, warnings := StageConversationFiles(ctx, eng, ws)
+		staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+		require.NoError(t, err)
 		require.Nil(t, staged)
 		require.Len(t, warnings, 1)
 		require.Contains(t, warnings[0], "stage files")
@@ -206,7 +208,8 @@ func TestStageConversationFiles_Warnings(t *testing.T) {
 		runner := &stubRunner{err: fmt.Errorf("move failed")}
 		eng := codeexecutor.NewEngine(nil, fs, runner)
 
-		staged, warnings := StageConversationFiles(ctx, eng, ws)
+		staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+		require.NoError(t, err)
 		require.Len(t, staged, 1)
 		require.Len(t, warnings, 1)
 		require.Contains(t, warnings[0], "save metadata")
@@ -219,6 +222,45 @@ func TestStageConversationFiles_Warnings(t *testing.T) {
 		require.Equal(t, "report.txt", staged[0].OriginalName)
 		require.Equal(t, "text/plain", staged[0].MIMEType)
 		require.Equal(t, int64(5), staged[0].SizeBytes)
+	})
+
+	t.Run("load metadata stale", func(t *testing.T) {
+		ctx := newInvocationCtx(msg, nil, nil, nil)
+		eng := codeexecutor.NewEngine(nil, &stubFS{
+			collectErr: fmt.Errorf("collect: %w", codeexecutor.ErrWorkspaceStale),
+		}, nil)
+
+		staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.Nil(t, staged)
+		require.Empty(t, warnings)
+	})
+
+	t.Run("put files stale", func(t *testing.T) {
+		ctx := newInvocationCtx(msg, nil, nil, nil)
+		fs := &stubFS{
+			putErr: fmt.Errorf("put: %w", codeexecutor.ErrWorkspaceStale),
+		}
+		eng := codeexecutor.NewEngine(nil, fs, nil)
+
+		staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.Nil(t, staged)
+		require.Empty(t, warnings)
+	})
+
+	t.Run("save metadata stale", func(t *testing.T) {
+		ctx := newInvocationCtx(msg, nil, nil, nil)
+		fs := &stubFS{}
+		runner := &stubRunner{
+			err: fmt.Errorf("move: %w", codeexecutor.ErrWorkspaceStale),
+		}
+		eng := codeexecutor.NewEngine(nil, fs, runner)
+
+		staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.Len(t, staged, 1)
+		require.Empty(t, warnings)
 	})
 }
 
@@ -523,7 +565,8 @@ func TestStageConversationFiles_MergesSessionAndMessageFiles(t *testing.T) {
 	)
 
 	ctx := newInvocationCtx(message, sess, nil, nil)
-	staged, warnings := StageConversationFiles(ctx, eng, ws)
+	staged, warnings, err := StageConversationFiles(ctx, eng, ws)
+	require.NoError(t, err)
 
 	require.Len(t, staged, 2)
 	require.Empty(t, warnings)
@@ -570,22 +613,24 @@ func TestStageConversationFiles_CoversEmptyAndReusePaths(t *testing.T) {
 	ws := codeexecutor.Workspace{ID: "ws"}
 
 	t.Run("no invocation", func(t *testing.T) {
-		staged, warnings := StageConversationFiles(
+		staged, warnings, err := StageConversationFiles(
 			context.Background(),
 			codeexecutor.NewEngine(nil, &stubFS{}, nil),
 			ws,
 		)
+		require.NoError(t, err)
 		require.Nil(t, staged)
 		require.Nil(t, warnings)
 	})
 
 	t.Run("locked helper without invocation", func(t *testing.T) {
-		staged, warnings := stageConversationFilesLocked(
+		staged, warnings, err := stageConversationFilesLocked(
 			context.Background(),
 			codeexecutor.NewEngine(nil, &stubFS{}, nil),
 			ws,
 			[]model.File{{Name: "report.txt", Data: []byte("data")}},
 		)
+		require.NoError(t, err)
 		require.Nil(t, staged)
 		require.Nil(t, warnings)
 	})
@@ -597,11 +642,12 @@ func TestStageConversationFiles_CoversEmptyAndReusePaths(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		staged, warnings := StageConversationFiles(
+		staged, warnings, err := StageConversationFiles(
 			ctx,
 			codeexecutor.NewEngine(nil, &stubFS{}, nil),
 			ws,
 		)
+		require.NoError(t, err)
 		require.Nil(t, staged)
 		require.Len(t, warnings, 1)
 		require.Contains(t, warnings[0], "lock metadata")
@@ -609,11 +655,12 @@ func TestStageConversationFiles_CoversEmptyAndReusePaths(t *testing.T) {
 
 	t.Run("no files", func(t *testing.T) {
 		ctx := newInvocationCtx(model.NewUserMessage("no files"), nil, nil, nil)
-		staged, warnings := StageConversationFiles(
+		staged, warnings, err := StageConversationFiles(
 			ctx,
 			codeexecutor.NewEngine(nil, &stubFS{}, nil),
 			ws,
 		)
+		require.NoError(t, err)
 		require.Nil(t, staged)
 		require.Nil(t, warnings)
 	})
@@ -644,11 +691,12 @@ func TestStageConversationFiles_CoversEmptyAndReusePaths(t *testing.T) {
 		})
 		ctx := newInvocationCtx(msg, nil, nil, nil)
 
-		staged, warnings := StageConversationFiles(
+		staged, warnings, err := StageConversationFiles(
 			ctx,
 			codeexecutor.NewEngine(nil, fs, &stubRunner{}),
 			ws,
 		)
+		require.NoError(t, err)
 		require.Len(t, staged, 1)
 		require.Empty(t, warnings)
 		require.Equal(

--- a/internal/workspaceprep/command.go
+++ b/internal/workspaceprep/command.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -232,7 +233,11 @@ func (r *commandRequirement) Apply(
 				Mode:    codeexecutor.DefaultScriptFileMode,
 			}},
 		); err != nil {
-			return fmt.Errorf("write marker: %w", err)
+			markerErr := fmt.Errorf("write marker: %w", err)
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+				return errors.Join(markerErr, ErrReconcileRetryUnsafe)
+			}
+			return markerErr
 		}
 	}
 	return nil

--- a/internal/workspaceprep/providers.go
+++ b/internal/workspaceprep/providers.go
@@ -267,16 +267,18 @@ func (r *conversationFilesRequirement) SentinelExists(
 	return true, nil
 }
 
-// Apply delegates to StageConversationFiles. Because this requirement
-// is Optional, the reconciler converts a non-nil error into a
-// warning rather than aborting; that matches the legacy auto-staging
-// behavior which never blocked execution on a partial stage.
+// Apply delegates to StageConversationFiles. Ordinary staging warnings retain
+// the legacy best-effort behavior. Stale errors remain typed so the reconciler
+// can abort before executing against a replaced workspace.
 func (r *conversationFilesRequirement) Apply(
 	ctx context.Context, rctx ApplyContext,
 ) error {
-	_, warnings := workspaceinput.StageConversationFiles(
+	_, warnings, err := workspaceinput.StageConversationFiles(
 		ctx, rctx.Engine, rctx.Workspace,
 	)
+	if err != nil {
+		return err
+	}
 	if len(warnings) > 0 {
 		return fmt.Errorf(
 			"conversation files warnings: %s",

--- a/internal/workspaceprep/providers_test.go
+++ b/internal/workspaceprep/providers_test.go
@@ -11,6 +11,7 @@ package workspaceprep
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -269,8 +270,7 @@ func TestConversationFilesRequirement_Metadata(t *testing.T) {
 	require.Equal(t, KindConversationFile, r.Kind())
 	require.Equal(t, PhaseFile, r.Phase())
 	require.False(t, r.Required(),
-		"conversation files must stay optional so a partial stage "+
-			"degrades to a warning instead of aborting the turn")
+		"ordinary partial staging failures remain optional warnings")
 	require.Equal(t,
 		codeexecutor.DirWork+"/inputs",
 		r.Target(),
@@ -364,6 +364,36 @@ func TestConversationFilesRequirement_ApplyStagesInlineBytes(t *testing.T) {
 	))
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(got))
+}
+
+func TestConversationFilesRequirement_ApplyPropagatesStale(t *testing.T) {
+	inv := &agent.Invocation{
+		Message: model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeFile,
+				File: &model.File{
+					Name: "note.txt",
+					Data: []byte("hello"),
+				},
+			}},
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	stale := fmt.Errorf(
+		"metadata belongs to old instance: %w",
+		codeexecutor.ErrWorkspaceStale,
+	)
+	r := &conversationFilesRequirement{}
+
+	err := r.Apply(ctx, ApplyContext{
+		Engine: &fakeEngine{
+			fs: &fakeFS{collectErr: stale},
+		},
+		Workspace:  codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
+		Invocation: inv,
+	})
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
 }
 
 // TestFileDigest_ReturnsStableKeys pins the digest format the

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -11,6 +11,7 @@ package workspaceprep
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -21,6 +22,14 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillstage"
+)
+
+// ErrReconcileRetryUnsafe marks a stale reconciliation result that happened
+// after at least one command completed successfully. The error still wraps
+// [codeexecutor.ErrWorkspaceStale], but callers must not replay reconciliation
+// automatically because an arbitrary command could execute twice.
+var ErrReconcileRetryUnsafe = errors.New(
+	"workspaceprep: reconciliation is unsafe to retry",
 )
 
 // defaultReconciler is the process-local, single-node implementation
@@ -82,6 +91,7 @@ func (r *defaultReconciler) Reconcile(
 
 	var warnings []string
 	changed := false
+	commandApplied := false
 	var changedKeys []string
 	for _, req := range reqs {
 		applied, warn, err := r.runOne(ctx, rctx, req)
@@ -89,6 +99,9 @@ func (r *defaultReconciler) Reconcile(
 			warnings = append(warnings, warn)
 		}
 		if err != nil {
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+				return warnings, markRetryUnsafe(err, commandApplied)
+			}
 			if !req.Required() {
 				warnings = append(warnings, fmt.Sprintf(
 					"optional requirement %q failed: %v",
@@ -100,6 +113,12 @@ func (r *defaultReconciler) Reconcile(
 				if saveErr := r.saveReconcileMetadata(
 					ctx, eng, ws, baseMD, md, changedKeys,
 				); saveErr != nil {
+					if errors.Is(saveErr, codeexecutor.ErrWorkspaceStale) {
+						return warnings, markRetryUnsafe(
+							saveErr,
+							commandApplied,
+						)
+					}
 					return warnings, fmt.Errorf(
 						"workspaceprep: save metadata after "+
 							"partial apply: %w",
@@ -115,18 +134,31 @@ func (r *defaultReconciler) Reconcile(
 		if applied {
 			changed = true
 			changedKeys = append(changedKeys, req.Key())
+			if req.Kind() == KindCommand {
+				commandApplied = true
+			}
 		}
 	}
 	if changed {
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, changedKeys,
 		); err != nil {
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+				return warnings, markRetryUnsafe(err, commandApplied)
+			}
 			warnings = append(warnings, fmt.Sprintf(
 				"save metadata: %v", err,
 			))
 		}
 	}
 	return warnings, nil
+}
+
+func markRetryUnsafe(err error, unsafe bool) error {
+	if !unsafe {
+		return err
+	}
+	return errors.Join(err, ErrReconcileRetryUnsafe)
 }
 
 func (r *defaultReconciler) saveReconcileMetadata(

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -24,13 +24,14 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillstage"
 )
 
-// ErrReconcileRetryUnsafe marks a stale reconciliation result that happened
-// after at least one command completed successfully. The error still wraps
-// [codeexecutor.ErrWorkspaceStale], but callers must not replay reconciliation
-// automatically because an arbitrary command could execute twice.
-var ErrReconcileRetryUnsafe = errors.New(
-	"workspaceprep: reconciliation is unsafe to retry",
-)
+// ErrReconcileRetryUnsafe marks a stale reconciliation result after a command
+// may have started. The error still wraps [codeexecutor.ErrWorkspaceStale], but
+// callers must not replay reconciliation automatically because an arbitrary
+// command could execute twice.
+//
+// Deprecated: use [codeexecutor.ErrWorkspaceRetryUnsafe]. This alias remains
+// for compatibility with existing internal callers.
+var ErrReconcileRetryUnsafe = codeexecutor.ErrWorkspaceRetryUnsafe
 
 // defaultReconciler is the process-local, single-node implementation
 // of Reconciler. It uses a keyed mutex on ws.Path to serialize

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -98,13 +98,11 @@ func (r *defaultReconciler) Reconcile(
 		if warn != "" {
 			warnings = append(warnings, warn)
 		}
-		if err != nil {
-			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-				return warnings, markRetryUnsafe(
-					err,
-					commandMayHaveStarted,
-				)
-			}
+		if staleErr := staleRetryError(
+			err,
+			commandMayHaveStarted,
+		); staleErr != nil {
+			return warnings, staleErr
 		}
 		if applyAttempted && req.Kind() == KindCommand {
 			// A non-stale command result does not prove that the command
@@ -124,11 +122,11 @@ func (r *defaultReconciler) Reconcile(
 				if saveErr := r.saveReconcileMetadata(
 					ctx, eng, ws, baseMD, md, changedKeys,
 				); saveErr != nil {
-					if errors.Is(saveErr, codeexecutor.ErrWorkspaceStale) {
-						return warnings, markRetryUnsafe(
-							saveErr,
-							commandMayHaveStarted,
-						)
+					if staleErr := staleRetryError(
+						saveErr,
+						commandMayHaveStarted,
+					); staleErr != nil {
+						return warnings, staleErr
 					}
 					return warnings, fmt.Errorf(
 						"workspaceprep: save metadata after "+
@@ -151,11 +149,11 @@ func (r *defaultReconciler) Reconcile(
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, changedKeys,
 		); err != nil {
-			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-				return warnings, markRetryUnsafe(
-					err,
-					commandMayHaveStarted,
-				)
+			if staleErr := staleRetryError(
+				err,
+				commandMayHaveStarted,
+			); staleErr != nil {
+				return warnings, staleErr
 			}
 			warnings = append(warnings, fmt.Sprintf(
 				"save metadata: %v", err,
@@ -163,6 +161,13 @@ func (r *defaultReconciler) Reconcile(
 		}
 	}
 	return warnings, nil
+}
+
+func staleRetryError(err error, unsafe bool) error {
+	if !errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		return nil
+	}
+	return markRetryUnsafe(err, unsafe)
 }
 
 func markRetryUnsafe(err error, unsafe bool) error {

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -91,17 +91,28 @@ func (r *defaultReconciler) Reconcile(
 
 	var warnings []string
 	changed := false
-	commandApplied := false
+	commandMayHaveStarted := false
 	var changedKeys []string
 	for _, req := range reqs {
-		applied, warn, err := r.runOne(ctx, rctx, req)
+		applied, applyAttempted, warn, err := r.runOne(ctx, rctx, req)
 		if warn != "" {
 			warnings = append(warnings, warn)
 		}
 		if err != nil {
 			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-				return warnings, markRetryUnsafe(err, commandApplied)
+				return warnings, markRetryUnsafe(
+					err,
+					commandMayHaveStarted,
+				)
 			}
+		}
+		if applyAttempted && req.Kind() == KindCommand {
+			// A non-stale command result does not prove that the command
+			// avoided side effects. This includes optional timeouts,
+			// non-zero exits, and failures after successful execution.
+			commandMayHaveStarted = true
+		}
+		if err != nil {
 			if !req.Required() {
 				warnings = append(warnings, fmt.Sprintf(
 					"optional requirement %q failed: %v",
@@ -116,7 +127,7 @@ func (r *defaultReconciler) Reconcile(
 					if errors.Is(saveErr, codeexecutor.ErrWorkspaceStale) {
 						return warnings, markRetryUnsafe(
 							saveErr,
-							commandApplied,
+							commandMayHaveStarted,
 						)
 					}
 					return warnings, fmt.Errorf(
@@ -134,9 +145,6 @@ func (r *defaultReconciler) Reconcile(
 		if applied {
 			changed = true
 			changedKeys = append(changedKeys, req.Key())
-			if req.Kind() == KindCommand {
-				commandApplied = true
-			}
 		}
 	}
 	if changed {
@@ -144,7 +152,10 @@ func (r *defaultReconciler) Reconcile(
 			ctx, eng, ws, baseMD, md, changedKeys,
 		); err != nil {
 			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-				return warnings, markRetryUnsafe(err, commandApplied)
+				return warnings, markRetryUnsafe(
+					err,
+					commandMayHaveStarted,
+				)
 			}
 			warnings = append(warnings, fmt.Sprintf(
 				"save metadata: %v", err,
@@ -269,31 +280,31 @@ func cloneReconcileMetadata(
 	return out
 }
 
-// runOne applies a single requirement. It returns whether work was
-// done (so the caller knows to persist metadata), a non-empty warning
-// string that callers should surface, and an error on hard failure.
+// runOne applies a single requirement. It returns whether work was done (so the
+// caller knows to persist metadata), whether Apply was attempted, a non-empty
+// warning string that callers should surface, and an error on hard failure.
 func (r *defaultReconciler) runOne(
 	ctx context.Context,
 	rctx ApplyContext,
 	req Requirement,
-) (bool, string, error) {
+) (bool, bool, string, error) {
 	key := req.Key()
 	expected, err := req.Fingerprint(ctx, rctx)
 	if err != nil {
-		return false, "", fmt.Errorf("fingerprint: %w", err)
+		return false, false, "", fmt.Errorf("fingerprint: %w", err)
 	}
 	prev, hasPrev := rctx.Metadata.Prepared[key]
 	if hasPrev && prev.Fingerprint == expected {
 		ok, err := req.SentinelExists(ctx, rctx)
 		if err != nil {
-			return false, "", fmt.Errorf("sentinel: %w", err)
+			return false, false, "", fmt.Errorf("sentinel: %w", err)
 		}
 		if ok {
-			return false, "", nil
+			return false, false, "", nil
 		}
 	}
 	if err := req.Apply(ctx, rctx); err != nil {
-		return false, "", err
+		return false, true, "", err
 	}
 	rctx.Metadata.Prepared[key] = codeexecutor.PreparedRecord{
 		Key:         key,
@@ -302,7 +313,7 @@ func (r *defaultReconciler) runOne(
 		Target:      req.Target(),
 		PreparedAt:  time.Now(),
 	}
-	return true, "", nil
+	return true, true, "", nil
 }
 
 // sortRequirements orders requirements by Phase and, within a phase,

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -11,6 +11,7 @@ package workspaceprep
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -558,6 +559,153 @@ func TestReconciler_OptionalRequirementFailureIsWarning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, warnings)
 	require.Contains(t, warnings[0], "optional requirement")
+}
+
+func TestReconciler_StaleRetryDisposition(t *testing.T) {
+	stale := fmt.Errorf("rotated: %w", codeexecutor.ErrWorkspaceStale)
+
+	t.Run("metadata load stale is retry safe", func(t *testing.T) {
+		eng := &fakeEngine{fs: &fakeFS{collectErr: stale}}
+		req := &orderReq{
+			key:   "never-applied",
+			kind:  KindFile,
+			phase: PhaseFile,
+		}
+
+		_, err := NewReconciler().Reconcile(
+			context.Background(),
+			eng,
+			codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
+			[]Requirement{req},
+		)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.False(t, errors.Is(err, ErrReconcileRetryUnsafe))
+	})
+
+	t.Run("command not started is retry safe", func(t *testing.T) {
+		eng, ws := newTestEngine(t)
+		req := &orderReq{
+			key:      "stale-command",
+			kind:     KindCommand,
+			phase:    PhaseCommand,
+			applyErr: stale,
+		}
+
+		warnings, err := NewReconciler().Reconcile(
+			context.Background(), eng, ws, []Requirement{req},
+		)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.False(t, errors.Is(err, ErrReconcileRetryUnsafe))
+		require.Empty(t, warnings)
+	})
+
+	t.Run("stale after successful command is retry unsafe", func(t *testing.T) {
+		eng, ws := newTestEngine(t)
+		var laterCalls int
+		success := &orderReq{
+			key:   "successful-command",
+			kind:  KindCommand,
+			phase: PhaseCommand,
+			apply: func() {},
+		}
+		later := &orderReq{
+			key:      "later-stale",
+			kind:     KindCommand,
+			phase:    PhaseCommand,
+			apply:    func() { laterCalls++ },
+			applyErr: stale,
+		}
+
+		_, err := NewReconciler().Reconcile(
+			context.Background(), eng, ws,
+			[]Requirement{success, later},
+		)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.ErrorIs(t, err, ErrReconcileRetryUnsafe)
+		require.Equal(t, 1, laterCalls)
+	})
+
+	t.Run("optional stale remains a control-flow error", func(t *testing.T) {
+		eng, ws := newTestEngine(t)
+		var nextCalls int
+		optional := &orderReq{
+			key:      "optional-stale",
+			kind:     KindFile,
+			phase:    PhaseFile,
+			optional: true,
+			applyErr: stale,
+		}
+		next := &orderReq{
+			key:   "must-not-run",
+			kind:  KindCommand,
+			phase: PhaseCommand,
+			apply: func() { nextCalls++ },
+		}
+
+		warnings, err := NewReconciler().Reconcile(
+			context.Background(), eng, ws,
+			[]Requirement{optional, next},
+		)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.False(t, errors.Is(err, ErrReconcileRetryUnsafe))
+		require.Empty(t, warnings)
+		require.Zero(t, nextCalls)
+	})
+
+	t.Run("metadata commit stale after command is retry unsafe",
+		func(t *testing.T) {
+			fs := &fakeFS{}
+			eng := &fakeEngine{
+				fs: fs,
+				runner: &fakeRunner{
+					err: stale,
+				},
+			}
+			req := &orderReq{
+				key:   "successful-command",
+				kind:  KindCommand,
+				phase: PhaseCommand,
+				apply: func() {},
+			}
+
+			_, err := NewReconciler().Reconcile(
+				context.Background(),
+				eng,
+				codeexecutor.Workspace{
+					ID:   "ws",
+					Path: t.TempDir(),
+				},
+				[]Requirement{req},
+			)
+			require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+			require.ErrorIs(t, err, ErrReconcileRetryUnsafe)
+		},
+	)
+
+	t.Run("marker stale after command is retry unsafe", func(t *testing.T) {
+		req, err := NewCommandRequirement(CommandSpec{
+			Cmd:        "setup",
+			MarkerPath: "work/.setup-complete",
+		})
+		require.NoError(t, err)
+		eng := &fakeEngine{
+			fs: &fakeFS{
+				putErr: stale,
+			},
+			runner: &fakeRunner{
+				res: codeexecutor.RunResult{ExitCode: 0},
+			},
+		}
+
+		_, err = NewReconciler().Reconcile(
+			context.Background(),
+			eng,
+			codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
+			[]Requirement{req},
+		)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+		require.ErrorIs(t, err, ErrReconcileRetryUnsafe)
+	})
 }
 
 // orderReq is a minimal Requirement implementation used by tests to

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -625,6 +625,34 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 		require.Equal(t, 1, laterCalls)
 	})
 
+	t.Run("stale after failed optional command is retry unsafe",
+		func(t *testing.T) {
+			eng, ws := newTestEngine(t)
+			optionalFailure := &orderReq{
+				key:      "optional-command",
+				kind:     KindCommand,
+				phase:    PhaseCommand,
+				optional: true,
+				applyErr: errors.New("timeout after submission"),
+			}
+			laterStale := &orderReq{
+				key:      "later-stale",
+				kind:     KindCommand,
+				phase:    PhaseCommand,
+				applyErr: stale,
+			}
+
+			warnings, err := NewReconciler().Reconcile(
+				context.Background(), eng, ws,
+				[]Requirement{optionalFailure, laterStale},
+			)
+			require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+			require.ErrorIs(t, err, ErrReconcileRetryUnsafe)
+			require.Len(t, warnings, 1)
+			require.Contains(t, warnings[0], "optional requirement")
+		},
+	)
+
 	t.Run("optional stale remains a control-flow error", func(t *testing.T) {
 		eng, ws := newTestEngine(t)
 		var nextCalls int

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -622,6 +622,8 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
 		require.ErrorIs(t, err, ErrReconcileRetryUnsafe)
+		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceRetryUnsafe)
+		require.False(t, codeexecutor.IsWorkspaceRetrySafe(err))
 		require.Equal(t, 1, laterCalls)
 	})
 

--- a/internal/workspacesession/resolver.go
+++ b/internal/workspacesession/resolver.go
@@ -65,19 +65,60 @@ func (r *Resolver) CreateWorkspace(
 	eng codeexecutor.Engine,
 	name string,
 ) (codeexecutor.Workspace, error) {
+	ws, _, err := r.CreateWorkspaceWithInstanceID(ctx, eng, name)
+	return ws, err
+}
+
+// CreateWorkspaceWithInstanceID acquires the invocation-scoped workspace and
+// returns the instance ID cached atomically with it. Legacy managers return an
+// empty instance ID.
+func (r *Resolver) CreateWorkspaceWithInstanceID(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	name string,
+) (
+	codeexecutor.Workspace,
+	codeexecutor.WorkspaceInstanceID,
+	error,
+) {
 	reg := r.reg
 	if reg == nil {
 		reg = codeexecutor.NewWorkspaceRegistry()
 		r.reg = reg
 	}
-	sid := name
+	sid := workspaceKey(ctx, name)
 	if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
-		if key := KeyFromInvocation(inv); key != "" {
-			sid = key
-		}
 		ctx = withWorkspaceArtifactContext(ctx, inv)
 	}
-	return reg.Acquire(ctx, eng.Manager(), sid)
+	return reg.AcquireWithInstanceID(ctx, eng.Manager(), sid)
+}
+
+// InvalidateWorkspaceIf conditionally removes the workspace selected by the
+// same invocation-key rules as CreateWorkspace. A late stale report cannot
+// evict a refreshed entry because the registry compares both ws and instanceID.
+func (r *Resolver) InvalidateWorkspaceIf(
+	ctx context.Context,
+	name string,
+	ws codeexecutor.Workspace,
+	instanceID codeexecutor.WorkspaceInstanceID,
+) bool {
+	if r == nil || r.reg == nil {
+		return false
+	}
+	return r.reg.InvalidateIf(
+		workspaceKey(ctx, name),
+		ws,
+		instanceID,
+	)
+}
+
+func workspaceKey(ctx context.Context, fallback string) string {
+	if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
+		if key := KeyFromInvocation(inv); key != "" {
+			return key
+		}
+	}
+	return fallback
 }
 
 // KeyFromInvocation derives the shared workspace key for an invocation.

--- a/internal/workspacesession/resolver.go
+++ b/internal/workspacesession/resolver.go
@@ -65,22 +65,17 @@ func (r *Resolver) CreateWorkspace(
 	eng codeexecutor.Engine,
 	name string,
 ) (codeexecutor.Workspace, error) {
-	ws, _, err := r.CreateWorkspaceWithInstanceID(ctx, eng, name)
-	return ws, err
+	handle, err := r.CreateWorkspaceHandle(ctx, eng, name)
+	return handle.Workspace, err
 }
 
-// CreateWorkspaceWithInstanceID acquires the invocation-scoped workspace and
-// returns the instance ID cached atomically with it. Legacy managers return an
-// empty instance ID.
-func (r *Resolver) CreateWorkspaceWithInstanceID(
+// CreateWorkspaceHandle acquires the invocation-scoped workspace together with
+// the registry token required for ABA-safe conditional invalidation.
+func (r *Resolver) CreateWorkspaceHandle(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	name string,
-) (
-	codeexecutor.Workspace,
-	codeexecutor.WorkspaceInstanceID,
-	error,
-) {
+) (codeexecutor.WorkspaceHandle, error) {
 	reg := r.reg
 	if reg == nil {
 		reg = codeexecutor.NewWorkspaceRegistry()
@@ -90,26 +85,18 @@ func (r *Resolver) CreateWorkspaceWithInstanceID(
 	if inv, ok := agent.InvocationFromContext(ctx); ok && inv != nil {
 		ctx = withWorkspaceArtifactContext(ctx, inv)
 	}
-	return reg.AcquireWithInstanceID(ctx, eng.Manager(), sid)
+	return reg.AcquireHandle(ctx, eng.Manager(), sid)
 }
 
-// InvalidateWorkspaceIf conditionally removes the workspace selected by the
-// same invocation-key rules as CreateWorkspace. A late stale report cannot
-// evict a refreshed entry because the registry compares both ws and instanceID.
-func (r *Resolver) InvalidateWorkspaceIf(
-	ctx context.Context,
-	name string,
-	ws codeexecutor.Workspace,
-	instanceID codeexecutor.WorkspaceInstanceID,
+// InvalidateWorkspaceHandle conditionally removes the exact registry entry
+// represented by handle.
+func (r *Resolver) InvalidateWorkspaceHandle(
+	handle codeexecutor.WorkspaceHandle,
 ) bool {
 	if r == nil || r.reg == nil {
 		return false
 	}
-	return r.reg.InvalidateIf(
-		workspaceKey(ctx, name),
-		ws,
-		instanceID,
-	)
+	return r.reg.Invalidate(handle)
 }
 
 func workspaceKey(ctx context.Context, fallback string) string {

--- a/internal/workspacesession/resolver_test.go
+++ b/internal/workspacesession/resolver_test.go
@@ -257,14 +257,13 @@ func (*resolverInstanceManager) Cleanup(
 	return nil
 }
 
-func (m *resolverInstanceManager) WorkspaceInstanceID(
+func (m *resolverInstanceManager) InstanceID(
 	context.Context,
-	codeexecutor.Workspace,
 ) (codeexecutor.WorkspaceInstanceID, error) {
 	return m.instanceID, nil
 }
 
-func TestResolver_InvalidateWorkspaceIf_UsesInvocationKey(t *testing.T) {
+func TestResolver_InvalidateWorkspaceHandle_UsesInvocationKey(t *testing.T) {
 	mgr := &resolverInstanceManager{instanceID: "instance-1"}
 	eng := codeexecutor.NewEngine(
 		mgr,
@@ -280,21 +279,11 @@ func TestResolver_InvalidateWorkspaceIf_UsesInvocationKey(t *testing.T) {
 	}
 	ctx := agent.NewInvocationContext(context.Background(), inv)
 
-	ws, err := r.CreateWorkspace(ctx, eng, "fallback")
+	handle, err := r.CreateWorkspaceHandle(ctx, eng, "fallback")
 	require.NoError(t, err)
 	require.Equal(t, 1, mgr.creates)
-	require.False(t, r.InvalidateWorkspaceIf(
-		ctx,
-		"fallback",
-		ws,
-		"wrong-instance",
-	))
-	require.True(t, r.InvalidateWorkspaceIf(
-		ctx,
-		"fallback",
-		ws,
-		"instance-1",
-	))
+	require.False(t, NewResolver(nil, nil).InvalidateWorkspaceHandle(handle))
+	require.True(t, r.InvalidateWorkspaceHandle(handle))
 
 	_, err = r.CreateWorkspace(ctx, eng, "fallback")
 	require.NoError(t, err)

--- a/internal/workspacesession/resolver_test.go
+++ b/internal/workspacesession/resolver_test.go
@@ -235,3 +235,68 @@ func TestResolver_CreateWorkspace_InjectsArtifactContext(t *testing.T) {
 	require.Equal(t, "myapp/u1/sess-art", ws.ID)
 	require.True(t, probe.sawOK)
 }
+
+type resolverInstanceManager struct {
+	instanceID codeexecutor.WorkspaceInstanceID
+	creates    int
+}
+
+func (m *resolverInstanceManager) CreateWorkspace(
+	_ context.Context,
+	id string,
+	_ codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.creates++
+	return codeexecutor.Workspace{ID: id, Path: "/tmp/" + id}, nil
+}
+
+func (*resolverInstanceManager) Cleanup(
+	context.Context,
+	codeexecutor.Workspace,
+) error {
+	return nil
+}
+
+func (m *resolverInstanceManager) WorkspaceInstanceID(
+	context.Context,
+	codeexecutor.Workspace,
+) (codeexecutor.WorkspaceInstanceID, error) {
+	return m.instanceID, nil
+}
+
+func TestResolver_InvalidateWorkspaceIf_UsesInvocationKey(t *testing.T) {
+	mgr := &resolverInstanceManager{instanceID: "instance-1"}
+	eng := codeexecutor.NewEngine(
+		mgr,
+		&resolverStubFS{},
+		&resolverStubRunner{},
+	)
+	r := NewResolver(nil, nil)
+	inv := agent.NewInvocation()
+	inv.Session = &session.Session{
+		AppName: "app",
+		UserID:  "user",
+		ID:      "session",
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	ws, err := r.CreateWorkspace(ctx, eng, "fallback")
+	require.NoError(t, err)
+	require.Equal(t, 1, mgr.creates)
+	require.False(t, r.InvalidateWorkspaceIf(
+		ctx,
+		"fallback",
+		ws,
+		"wrong-instance",
+	))
+	require.True(t, r.InvalidateWorkspaceIf(
+		ctx,
+		"fallback",
+		ws,
+		"instance-1",
+	))
+
+	_, err = r.CreateWorkspace(ctx, eng, "fallback")
+	require.NoError(t, err)
+	require.Equal(t, 2, mgr.creates)
+}

--- a/tool/skill/exec.go
+++ b/tool/skill/exec.go
@@ -642,12 +642,15 @@ func (t *ExecTool) captureFinalResult(
 	if err != nil {
 		return nil, err
 	}
-	files, manifest, outputWarn, err := t.run.prepareOutputs(
+	files, manifest, outputWarn, partialStale, err := t.run.prepareOutputs(
 		ctxIO,
 		sess.eng,
 		sess.ws,
 		sess.in,
 	)
+	if partialStale {
+		t.run.invalidateWorkspaceHandle(sess.handle)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/tool/skill/exec.go
+++ b/tool/skill/exec.go
@@ -12,6 +12,7 @@ package skill
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -87,9 +88,10 @@ type sessionKillOutput struct {
 type execSession struct {
 	mu sync.Mutex
 
-	proc codeexecutor.ProgramSession
-	eng  codeexecutor.Engine
-	ws   codeexecutor.Workspace
+	proc   codeexecutor.ProgramSession
+	eng    codeexecutor.Engine
+	ws     codeexecutor.Workspace
+	handle codeexecutor.WorkspaceHandle
 
 	in                    runInput
 	staged                []stagedInput
@@ -354,48 +356,26 @@ func (t *ExecTool) StreamableCall(
 	runIn, saveRequested, outputsSaveSkipReason := t.run.
 		applyArtifactSaveOverrides(ctx, in.runInput)
 	in.runInput = runIn
-	eng, ws, skillRoot, ctxIO, staged, stageWarn, err := t.run.
-		prepareWorkspaceForRun(ctx, in.runInput)
-	if err != nil {
-		return nil, err
+	prepared, proc, err := t.startProgramAttempt(ctx, in)
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		t.run.invalidateWorkspaceHandle(prepared.handle)
+		prepared, proc, err = t.startProgramAttempt(ctx, in)
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			t.run.invalidateWorkspaceHandle(prepared.handle)
+		}
 	}
-	runner, ok := eng.Runner().(codeexecutor.InteractiveProgramRunner)
-	if !ok {
-		return nil, fmt.Errorf(
-			"skill_exec is not supported by the current executor",
-		)
-	}
-	cwd := resolveCWD(in.Cwd, skillRoot)
-	spec, err := t.run.buildRunProgramSpec(
-		ctxIO,
-		eng,
-		ws,
-		skillRoot,
-		cwd,
-		in.runInput,
-	)
-	if err != nil {
-		return nil, err
-	}
-	proc, err := runner.StartProgram(
-		ctxIO,
-		ws,
-		codeexecutor.InteractiveProgramSpec{
-			RunProgramSpec: spec,
-			TTY:            in.TTY,
-		},
-	)
 	if err != nil {
 		return nil, err
 	}
 
 	sess := &execSession{
 		proc:                  proc,
-		eng:                   eng,
-		ws:                    ws,
+		eng:                   prepared.eng,
+		ws:                    prepared.handle.Workspace,
+		handle:                prepared.handle,
 		in:                    in.runInput,
-		staged:                staged,
-		stageWarnings:         stageWarn,
+		staged:                prepared.staged,
+		stageWarnings:         prepared.warnings,
 		saveRequested:         saveRequested,
 		outputsSaveSkipReason: outputsSaveSkipReason,
 	}
@@ -411,6 +391,47 @@ func (t *ExecTool) StreamableCall(
 		return nil, err
 	}
 	return buildExecStream(poll.Output, result), nil
+}
+
+func (t *ExecTool) startProgramAttempt(
+	ctx context.Context,
+	in execInput,
+) (
+	workspaceRunPreparation,
+	codeexecutor.ProgramSession,
+	error,
+) {
+	prepared, err := t.run.prepareWorkspaceForRun(ctx, in.runInput)
+	if err != nil {
+		return prepared, nil, err
+	}
+	runner, ok := prepared.eng.Runner().(codeexecutor.InteractiveProgramRunner)
+	if !ok {
+		return prepared, nil, fmt.Errorf(
+			"skill_exec is not supported by the current executor",
+		)
+	}
+	cwd := resolveCWD(in.Cwd, prepared.skillRoot)
+	spec, err := t.run.buildRunProgramSpec(
+		prepared.ctxIO,
+		prepared.eng,
+		prepared.handle.Workspace,
+		prepared.skillRoot,
+		cwd,
+		in.runInput,
+	)
+	if err != nil {
+		return prepared, nil, err
+	}
+	proc, err := runner.StartProgram(
+		prepared.ctxIO,
+		prepared.handle.Workspace,
+		codeexecutor.InteractiveProgramSpec{
+			RunProgramSpec: spec,
+			TTY:            in.TTY,
+		},
+	)
+	return prepared, proc, err
 }
 
 // StreamableCall writes stdin to a running skill session.
@@ -431,6 +452,7 @@ func (t *WriteStdinTool) StreamableCall(
 	}
 	if in.Chars != "" || in.Submit {
 		if err := sess.proc.Write(in.Chars, in.Submit); err != nil {
+			t.exec.invalidateSessionWorkspaceIfStale(sess, err)
 			return nil, err
 		}
 	}
@@ -498,11 +520,14 @@ func (t *KillSessionTool) Call(
 	poll := sess.proc.Poll(nil)
 	if poll.Status == codeexecutor.ProgramStatusRunning {
 		if err := sess.proc.Kill(defaultSessionKill); err != nil {
+			t.exec.invalidateSessionWorkspaceIfStale(sess, err)
 			return nil, err
 		}
 		status = "killed"
 	}
-	_ = sess.proc.Close()
+	if err := sess.proc.Close(); err != nil {
+		t.exec.invalidateSessionWorkspaceIfStale(sess, err)
+	}
 	if _, err := t.exec.removeSession(in.SessionID); err != nil {
 		return nil, err
 	}
@@ -560,7 +585,9 @@ func (t *ExecTool) cleanupExpiredLocked() {
 			now.Sub(sess.exitedAt) >= t.ttl
 		sess.mu.Unlock()
 		if expired {
-			_ = sess.proc.Close()
+			if err := sess.proc.Close(); err != nil {
+				t.invalidateSessionWorkspaceIfStale(sess, err)
+			}
 			delete(t.sessions, id)
 		}
 	}
@@ -574,6 +601,7 @@ func (t *ExecTool) buildExecOutput(
 ) (execOutput, error) {
 	result, err := t.captureFinalResult(ctx, sess, poll)
 	if err != nil {
+		t.invalidateSessionWorkspaceIfStale(sess, err)
 		return execOutput{}, err
 	}
 	out := execOutput{
@@ -605,12 +633,15 @@ func (t *ExecTool) captureFinalResult(
 	}
 
 	ctxIO := withArtifactContext(ctx)
-	autoFiles := t.run.autoExportWorkspaceOut(
+	autoFiles, err := t.run.autoExportWorkspaceOut(
 		ctxIO,
 		sess.eng,
 		sess.ws,
 		sess.in,
 	)
+	if err != nil {
+		return nil, err
+	}
 	files, manifest, outputWarn, err := t.run.prepareOutputs(
 		ctxIO,
 		sess.eng,
@@ -660,8 +691,20 @@ func (t *ExecTool) captureFinalResult(
 	sess.finalized = true
 	sess.finalizedAt = t.clock()
 	sess.exitedAt = sess.finalizedAt
-	_ = sess.proc.Close()
+	if err := sess.proc.Close(); err != nil {
+		t.invalidateSessionWorkspaceIfStale(sess, err)
+	}
 	return sess.final, nil
+}
+
+func (t *ExecTool) invalidateSessionWorkspaceIfStale(
+	sess *execSession,
+	err error,
+) {
+	if t != nil && t.run != nil &&
+		errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		t.run.invalidateWorkspaceHandle(sess.handle)
+	}
 }
 
 func sessionRunResult(

--- a/tool/skill/exec.go
+++ b/tool/skill/exec.go
@@ -359,9 +359,11 @@ func (t *ExecTool) StreamableCall(
 	prepared, proc, err := t.startProgramAttempt(ctx, in)
 	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
 		t.run.invalidateWorkspaceHandle(prepared.handle)
-		prepared, proc, err = t.startProgramAttempt(ctx, in)
-		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-			t.run.invalidateWorkspaceHandle(prepared.handle)
+		if codeexecutor.IsWorkspaceRetrySafe(err) {
+			prepared, proc, err = t.startProgramAttempt(ctx, in)
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+				t.run.invalidateWorkspaceHandle(prepared.handle)
+			}
 		}
 	}
 	if err != nil {

--- a/tool/skill/exec_test.go
+++ b/tool/skill/exec_test.go
@@ -328,6 +328,72 @@ func TestExecArtifactsStateDelta(t *testing.T) {
 	require.Equal(t, "artifact://a.txt@3", got.Artifacts[0].Ref)
 }
 
+func TestExecTool_StaleWriteInvalidatesLegacyWorkspace(t *testing.T) {
+	manager := &legacySkillRetryManager{}
+	session := &stubProgramSession{
+		id: "stale-write",
+		polls: []codeexecutor.ProgramPoll{{
+			Status: codeexecutor.ProgramStatusRunning,
+			Output: "ready",
+		}},
+		writeErr: codeexecutor.ErrWorkspaceStale,
+	}
+	runner := &staleWriteSkillRunner{session: session}
+	eng := &managedEngine{
+		m: manager,
+		f: &stubFS{},
+		r: runner,
+	}
+	runTool := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: eng},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{WorkspaceSkillDir: "."}, nil
+		})),
+	)
+	execTool := NewExecTool(runTool)
+	startArgs, err := jsonMarshal(execInput{
+		runInput: runInput{
+			Skill:   testSkillName,
+			Command: echoOK,
+		},
+	})
+	require.NoError(t, err)
+	reader, err := execTool.StreamableCall(
+		context.Background(),
+		startArgs,
+	)
+	require.NoError(t, err)
+	_, started := drainExecStream(t, reader)
+	require.Equal(t, "stale-write", started.SessionID)
+	require.Equal(t, 1, manager.creates)
+
+	writeArgs, err := jsonMarshal(sessionWriteInput{
+		SessionID: "stale-write",
+		Chars:     "must-not-replay",
+	})
+	require.NoError(t, err)
+	_, err = NewWriteStdinTool(execTool).StreamableCall(
+		context.Background(),
+		writeArgs,
+	)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+
+	runArgs, err := jsonMarshal(runInput{
+		Skill:   testSkillName,
+		Command: echoOK,
+	})
+	require.NoError(t, err)
+	_, err = runTool.Call(context.Background(), runArgs)
+	require.NoError(t, err)
+	require.Equal(t, 2, manager.creates)
+	require.Equal(t, []string{"must-not-replay"}, session.writes,
+		"stdin must not be replayed after an uncertain session write")
+}
+
 type stubProgramSession struct {
 	mu         sync.Mutex
 	id         string
@@ -335,6 +401,7 @@ type stubProgramSession struct {
 	logOutput  string
 	runResult  codeexecutor.RunResult
 	writes     []string
+	writeErr   error
 	killErr    error
 	killCalled bool
 	closeCount int
@@ -412,7 +479,7 @@ func (s *stubProgramSession) Write(
 		data += "\n"
 	}
 	s.writes = append(s.writes, data)
-	return nil
+	return s.writeErr
 }
 
 func (s *stubProgramSession) Kill(grace time.Duration) error {
@@ -432,6 +499,26 @@ func (s *stubProgramSession) Close() error {
 
 func (s *stubProgramSession) RunResult() codeexecutor.RunResult {
 	return s.runResult
+}
+
+type staleWriteSkillRunner struct {
+	session *stubProgramSession
+}
+
+func (*staleWriteSkillRunner) RunProgram(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	return codeexecutor.RunResult{ExitCode: 0}, nil
+}
+
+func (r *staleWriteSkillRunner) StartProgram(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.InteractiveProgramSpec,
+) (codeexecutor.ProgramSession, error) {
+	return r.session, nil
 }
 
 type logOnlyProgramSession struct {

--- a/tool/skill/exec_test.go
+++ b/tool/skill/exec_test.go
@@ -258,6 +258,73 @@ func TestExecTool_PartialMetadataCommitReturnsFiles(t *testing.T) {
 	require.Contains(t, out.Result.Warnings, warnPartialOutputCommit)
 }
 
+func TestExecTool_PartialStaleInvalidatesWithoutReplay(t *testing.T) {
+	manager := &legacySkillRetryManager{}
+	fs := &partialStaleSkillFS{
+		stubFS: &stubFS{},
+		manifest: codeexecutor.OutputManifest{
+			Files: []codeexecutor.FileRef{{
+				Name:    outATxt,
+				Content: contentHi,
+			}},
+		},
+	}
+	exitCode := 0
+	session := &stubProgramSession{
+		id: "partial-stale",
+		polls: []codeexecutor.ProgramPoll{{
+			Status:   codeexecutor.ProgramStatusExited,
+			ExitCode: &exitCode,
+		}},
+		runResult: codeexecutor.RunResult{ExitCode: 0},
+	}
+	runner := &staleWriteSkillRunner{session: session}
+	runTool := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: &managedEngine{
+			m: manager,
+			f: fs,
+			r: runner,
+		}},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{WorkspaceSkillDir: "."}, nil
+		})),
+	)
+	execTool := NewExecTool(runTool)
+	args, err := jsonMarshal(execInput{
+		runInput: runInput{
+			Skill:   testSkillName,
+			Command: echoOK,
+			Outputs: &codeexecutor.OutputSpec{
+				Globs:  []string{outGlobTxt},
+				Inline: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	reader, err := execTool.StreamableCall(context.Background(), args)
+	require.NoError(t, err)
+	_, out := drainExecStream(t, reader)
+	require.NotNil(t, out.Result)
+	require.Contains(t, out.Result.Warnings, warnPartialOutputCommit)
+	require.Len(t, out.Result.OutputFiles, 1)
+	require.Equal(t, 1, runner.starts,
+		"partial output must not replay the completed session")
+	require.Equal(t, 1, manager.creates)
+
+	reader, err = execTool.StreamableCall(context.Background(), args)
+	require.NoError(t, err)
+	_, out = drainExecStream(t, reader)
+	require.NotNil(t, out.Result)
+	require.Equal(t, 2, runner.starts)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace once")
+}
+
 func TestKillSessionTool_RemovesSession(t *testing.T) {
 	root := t.TempDir()
 	writeSkill(t, root, testSkillName)
@@ -503,6 +570,7 @@ func (s *stubProgramSession) RunResult() codeexecutor.RunResult {
 
 type staleWriteSkillRunner struct {
 	session *stubProgramSession
+	starts  int
 }
 
 func (*staleWriteSkillRunner) RunProgram(
@@ -518,6 +586,7 @@ func (r *staleWriteSkillRunner) StartProgram(
 	codeexecutor.Workspace,
 	codeexecutor.InteractiveProgramSpec,
 ) (codeexecutor.ProgramSession, error) {
+	r.starts++
 	return r.session, nil
 }
 

--- a/tool/skill/exec_test.go
+++ b/tool/skill/exec_test.go
@@ -12,6 +12,7 @@ package skill
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"sync"
@@ -325,6 +326,59 @@ func TestExecTool_PartialStaleInvalidatesWithoutReplay(t *testing.T) {
 		"the next call must rebuild the invalidated workspace once")
 }
 
+func TestExecTool_UnsafeStartStaleInvalidatesWithoutReplay(t *testing.T) {
+	manager := &legacySkillRetryManager{}
+	exitCode := 0
+	runner := &staleWriteSkillRunner{
+		session: &stubProgramSession{
+			id: "started-after-unsafe",
+			polls: []codeexecutor.ProgramPoll{{
+				Status:   codeexecutor.ProgramStatusExited,
+				ExitCode: &exitCode,
+			}},
+			runResult: codeexecutor.RunResult{ExitCode: 0},
+		},
+		startErrors: []error{errors.Join(
+			codeexecutor.ErrWorkspaceStale,
+			codeexecutor.ErrWorkspaceRetryUnsafe,
+		)},
+	}
+	runTool := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: &managedEngine{
+			m: manager,
+			f: &stubFS{},
+			r: runner,
+		}},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{WorkspaceSkillDir: "."}, nil
+		})),
+	)
+	execTool := NewExecTool(runTool)
+	args, err := jsonMarshal(execInput{runInput: runInput{
+		Skill:   testSkillName,
+		Command: echoOK,
+	}})
+	require.NoError(t, err)
+
+	_, err = execTool.StreamableCall(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceRetryUnsafe)
+	require.Equal(t, 1, runner.starts, "unsafe stale must not replay")
+	require.Equal(t, 1, manager.creates)
+
+	reader, err := execTool.StreamableCall(context.Background(), args)
+	require.NoError(t, err)
+	_, out := drainExecStream(t, reader)
+	require.Equal(t, codeexecutor.ProgramStatusExited, out.Status)
+	require.Equal(t, 2, runner.starts)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace once")
+}
+
 func TestKillSessionTool_RemovesSession(t *testing.T) {
 	root := t.TempDir()
 	writeSkill(t, root, testSkillName)
@@ -569,8 +623,9 @@ func (s *stubProgramSession) RunResult() codeexecutor.RunResult {
 }
 
 type staleWriteSkillRunner struct {
-	session *stubProgramSession
-	starts  int
+	session     *stubProgramSession
+	startErrors []error
+	starts      int
 }
 
 func (*staleWriteSkillRunner) RunProgram(
@@ -587,6 +642,11 @@ func (r *staleWriteSkillRunner) StartProgram(
 	codeexecutor.InteractiveProgramSpec,
 ) (codeexecutor.ProgramSession, error) {
 	r.starts++
+	if len(r.startErrors) > 0 {
+		err := r.startErrors[0]
+		r.startErrors = r.startErrors[1:]
+		return nil, err
+	}
 	return r.session, nil
 }
 

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -654,7 +654,10 @@ func (t *RunTool) prepareWorkspaceForRun(
 	if err != nil {
 		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
 	}
-	staged, stageWarn := t.stageUserFileInputs(ctx, eng, ws)
+	staged, stageWarn, err := t.stageUserFileInputs(ctx, eng, ws)
+	if err != nil {
+		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
+	}
 	ctxIO := withArtifactContext(ctx)
 	if len(in.Inputs) > 0 {
 		if err := eng.FS().StageInputs(ctxIO, ws, in.Inputs); err != nil {
@@ -750,7 +753,7 @@ func (t *RunTool) stageUserFileInputs(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
-) ([]stagedInput, []string) {
+) ([]stagedInput, []string, error) {
 	return workspaceinput.StageConversationFiles(ctx, eng, ws)
 }
 

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -512,12 +512,15 @@ func (t *RunTool) Call(
 		}
 		return nil, err
 	}
-	files, manifest, outputWarn, err := t.prepareOutputs(
+	files, manifest, outputWarn, partialStale, err := t.prepareOutputs(
 		prepared.ctxIO,
 		prepared.eng,
 		ws,
 		in,
 	)
+	if partialStale {
+		t.invalidateWorkspaceHandle(prepared.handle)
+	}
 	if err != nil {
 		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
 			t.invalidateWorkspaceHandle(prepared.handle)
@@ -1869,21 +1872,29 @@ func withArtifactContext(ctx context.Context) context.Context {
 }
 
 // prepareOutputs collects files either through OutputSpec or legacy
-// output_files patterns. It returns collected files and optional
-// manifest.
+// output_files patterns. The bool result reports a non-fatal partial commit
+// that also carried ErrWorkspaceStale, allowing callers to invalidate the
+// exact handle while preserving the partial output result.
 func (t *RunTool) prepareOutputs(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
 	in runInput,
-) ([]codeexecutor.File, *codeexecutor.OutputManifest, []string, error) {
+) (
+	[]codeexecutor.File,
+	*codeexecutor.OutputManifest,
+	[]string,
+	bool,
+	error,
+) {
 	var files []codeexecutor.File
 	var manifest *codeexecutor.OutputManifest
 	if in.Outputs != nil && len(in.OutputFiles) == 0 {
 		m, err := eng.FS().CollectOutputs(ctx, ws, *in.Outputs)
+		stale := errors.Is(err, codeexecutor.ErrWorkspaceStale)
 		if err != nil &&
 			!errors.Is(err, codeexecutor.ErrPartialOutputCommit) {
-			return nil, nil, nil, err
+			return nil, nil, nil, false, err
 		}
 		manifest = &m
 		if in.Outputs.Inline {
@@ -1892,15 +1903,15 @@ func (t *RunTool) prepareOutputs(
 		if err != nil {
 			return files, manifest, []string{
 				warnPartialOutputCommit,
-			}, nil
+			}, stale, nil
 		}
-		return files, manifest, nil, nil
+		return files, manifest, nil, false, nil
 	}
 	fs, err := t.collectFiles(ctx, eng, ws, in.OutputFiles)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
-	return fs, nil, nil, nil
+	return fs, nil, nil, false, nil
 }
 
 func outputFilesFromManifest(

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -646,27 +646,67 @@ func (t *RunTool) prepareWorkspaceForRun(
 	error,
 ) {
 	eng := t.ensureEngine()
-	ws, err := t.createWorkspace(ctx, eng, in.Skill)
-	if err != nil {
-		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
-	}
-	stageRes, err := t.stageSkillForRun(ctx, eng, ws, in.Skill)
-	if err != nil {
-		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
-	}
-	staged, stageWarn, err := t.stageUserFileInputs(ctx, eng, ws)
-	if err != nil {
-		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
-	}
-	ctxIO := withArtifactContext(ctx)
-	if len(in.Inputs) > 0 {
-		if err := eng.FS().StageInputs(ctxIO, ws, in.Inputs); err != nil {
-			return nil, codeexecutor.Workspace{}, "", nil, nil,
-				nil, err
+	prepared, acquired, err := t.prepareWorkspaceAttempt(ctx, eng, in)
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		if acquired {
+			t.wsr.InvalidateWorkspaceHandle(prepared.handle)
+		}
+		prepared, acquired, err = t.prepareWorkspaceAttempt(ctx, eng, in)
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) && acquired {
+			t.wsr.InvalidateWorkspaceHandle(prepared.handle)
 		}
 	}
-	return eng, ws, stageRes.WorkspaceSkillDir, ctxIO, staged, stageWarn,
+	if err != nil {
+		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
+	}
+	return eng,
+		prepared.handle.Workspace,
+		prepared.skillRoot,
+		prepared.ctxIO,
+		prepared.staged,
+		prepared.warnings,
 		nil
+}
+
+type workspaceRunPreparation struct {
+	handle    codeexecutor.WorkspaceHandle
+	skillRoot string
+	ctxIO     context.Context
+	staged    []stagedInput
+	warnings  []string
+}
+
+func (t *RunTool) prepareWorkspaceAttempt(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	in runInput,
+) (workspaceRunPreparation, bool, error) {
+	handle, err := t.createWorkspaceHandle(ctx, eng, in.Skill)
+	if err != nil {
+		return workspaceRunPreparation{}, false, err
+	}
+	prepared := workspaceRunPreparation{handle: handle}
+	ws := handle.Workspace
+	stageRes, err := t.stageSkillForRun(ctx, eng, ws, in.Skill)
+	if err != nil {
+		return prepared, true, err
+	}
+	prepared.skillRoot = stageRes.WorkspaceSkillDir
+	prepared.staged, prepared.warnings, err = t.stageUserFileInputs(
+		ctx, eng, ws,
+	)
+	if err != nil {
+		return prepared, true, err
+	}
+	prepared.ctxIO = withArtifactContext(ctx)
+	if len(in.Inputs) > 0 {
+		if err := eng.FS().StageInputs(
+			prepared.ctxIO, ws, in.Inputs,
+		); err != nil {
+			return prepared, true, err
+		}
+	}
+	return prepared, true, nil
 }
 
 func (t *RunTool) stageSkillForRun(
@@ -907,13 +947,20 @@ func (t *RunTool) ensureEngine() codeexecutor.Engine {
 func (t *RunTool) createWorkspace(
 	ctx context.Context, eng codeexecutor.Engine, name string,
 ) (codeexecutor.Workspace, error) {
+	handle, err := t.createWorkspaceHandle(ctx, eng, name)
+	return handle.Workspace, err
+}
+
+func (t *RunTool) createWorkspaceHandle(
+	ctx context.Context, eng codeexecutor.Engine, name string,
+) (codeexecutor.WorkspaceHandle, error) {
 	if t.reg == nil || t.wsr == nil {
 		if t.reg == nil {
 			t.reg = codeexecutor.NewWorkspaceRegistry()
 		}
 		t.wsr = workspacesession.NewResolver(t.exec, t.reg)
 	}
-	return t.wsr.CreateWorkspace(ctx, eng, name)
+	return t.wsr.CreateWorkspaceHandle(ctx, eng, name)
 }
 
 // stageSkill materializes the skill source under skills/<name>.

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -483,28 +483,45 @@ func (t *RunTool) Call(
 		ctx,
 		in,
 	)
-	eng, ws, skillRoot, ctxIO, staged, stageWarn, err := t.
-		prepareWorkspaceForRun(
-			ctx,
-			in,
-		)
+	prepared, err := t.prepareWorkspaceForRun(ctx, in)
 	if err != nil {
 		return nil, err
 	}
-	cwd := resolveCWD(in.Cwd, skillRoot)
-	rr, err := t.runProgram(ctxIO, eng, ws, skillRoot, cwd, in)
+	rr, err := t.runPrepared(prepared, in)
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		t.invalidateWorkspaceHandle(prepared.handle)
+		prepared, err = t.prepareWorkspaceForRun(ctx, in)
+		if err == nil {
+			rr, err = t.runPrepared(prepared, in)
+		}
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			t.invalidateWorkspaceHandle(prepared.handle)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	autoFiles := t.autoExportWorkspaceOut(ctxIO, eng, ws, in)
+	ws := prepared.handle.Workspace
+	autoFiles, err := t.autoExportWorkspaceOut(
+		prepared.ctxIO, prepared.eng, ws, in,
+	)
+	if err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			t.invalidateWorkspaceHandle(prepared.handle)
+		}
+		return nil, err
+	}
 	files, manifest, outputWarn, err := t.prepareOutputs(
-		ctxIO,
-		eng,
+		prepared.ctxIO,
+		prepared.eng,
 		ws,
 		in,
 	)
 	if err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			t.invalidateWorkspaceHandle(prepared.handle)
+		}
 		return nil, err
 	}
 	filteredOutputs := filterFailedEmptyOutputs(rr, files, manifest)
@@ -529,9 +546,9 @@ func (t *RunTool) Call(
 	if len(outputWarn) > 0 {
 		out.Warnings = append(out.Warnings, outputWarn...)
 	}
-	out.StagedInputs = staged
-	if len(stageWarn) > 0 {
-		out.Warnings = append(out.Warnings, stageWarn...)
+	out.StagedInputs = prepared.staged
+	if len(prepared.warnings) > 0 {
+		out.Warnings = append(out.Warnings, prepared.warnings...)
 	}
 	if len(filteredOutputs.omittedNames) > 0 {
 		toolcache.DeleteSkillRunOutputFilesFromContext(
@@ -636,15 +653,7 @@ func (t *RunTool) applyArtifactSaveOverrides(
 func (t *RunTool) prepareWorkspaceForRun(
 	ctx context.Context,
 	in runInput,
-) (
-	codeexecutor.Engine,
-	codeexecutor.Workspace,
-	string,
-	context.Context,
-	[]stagedInput,
-	[]string,
-	error,
-) {
+) (workspaceRunPreparation, error) {
 	eng := t.ensureEngine()
 	prepared, acquired, err := t.prepareWorkspaceAttempt(ctx, eng, in)
 	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
@@ -657,18 +666,13 @@ func (t *RunTool) prepareWorkspaceForRun(
 		}
 	}
 	if err != nil {
-		return nil, codeexecutor.Workspace{}, "", nil, nil, nil, err
+		return workspaceRunPreparation{}, err
 	}
-	return eng,
-		prepared.handle.Workspace,
-		prepared.skillRoot,
-		prepared.ctxIO,
-		prepared.staged,
-		prepared.warnings,
-		nil
+	return prepared, nil
 }
 
 type workspaceRunPreparation struct {
+	eng       codeexecutor.Engine
 	handle    codeexecutor.WorkspaceHandle
 	skillRoot string
 	ctxIO     context.Context
@@ -685,7 +689,7 @@ func (t *RunTool) prepareWorkspaceAttempt(
 	if err != nil {
 		return workspaceRunPreparation{}, false, err
 	}
-	prepared := workspaceRunPreparation{handle: handle}
+	prepared := workspaceRunPreparation{eng: eng, handle: handle}
 	ws := handle.Workspace
 	stageRes, err := t.stageSkillForRun(ctx, eng, ws, in.Skill)
 	if err != nil {
@@ -707,6 +711,29 @@ func (t *RunTool) prepareWorkspaceAttempt(
 		}
 	}
 	return prepared, true, nil
+}
+
+func (t *RunTool) runPrepared(
+	prepared workspaceRunPreparation,
+	in runInput,
+) (codeexecutor.RunResult, error) {
+	cwd := resolveCWD(in.Cwd, prepared.skillRoot)
+	return t.runProgram(
+		prepared.ctxIO,
+		prepared.eng,
+		prepared.handle.Workspace,
+		prepared.skillRoot,
+		cwd,
+		in,
+	)
+}
+
+func (t *RunTool) invalidateWorkspaceHandle(
+	handle codeexecutor.WorkspaceHandle,
+) {
+	if t != nil && t.wsr != nil {
+		t.wsr.InvalidateWorkspaceHandle(handle)
+	}
 }
 
 func (t *RunTool) stageSkillForRun(
@@ -863,21 +890,27 @@ func (t *RunTool) autoExportWorkspaceOut(
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
 	in runInput,
-) []codeexecutor.File {
+) ([]codeexecutor.File, error) {
 	if eng == nil || in.Outputs != nil || len(in.OutputFiles) > 0 {
-		return nil
+		return nil, nil
 	}
 	files, err := eng.FS().Collect(ctx, ws,
 		[]string{defaultAutoExportPattern})
-	if err != nil || len(files) == 0 {
-		return nil
+	if err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			return nil, err
+		}
+		return nil, nil
+	}
+	if len(files) == 0 {
+		return nil, nil
 	}
 	if len(files) > defaultAutoExportMax {
 		files = files[:defaultAutoExportMax]
 	}
 	trimTruncatedUTF8TextFiles(files)
 	toolcache.StoreSkillRunOutputFilesFromContext(ctx, files)
-	return files
+	return files, nil
 }
 
 // parseRunArgs validates and decodes input args.

--- a/tool/skill/run.go
+++ b/tool/skill/run.go
@@ -490,12 +490,14 @@ func (t *RunTool) Call(
 	rr, err := t.runPrepared(prepared, in)
 	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
 		t.invalidateWorkspaceHandle(prepared.handle)
-		prepared, err = t.prepareWorkspaceForRun(ctx, in)
-		if err == nil {
-			rr, err = t.runPrepared(prepared, in)
-		}
-		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-			t.invalidateWorkspaceHandle(prepared.handle)
+		if codeexecutor.IsWorkspaceRetrySafe(err) {
+			prepared, err = t.prepareWorkspaceForRun(ctx, in)
+			if err == nil {
+				rr, err = t.runPrepared(prepared, in)
+			}
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+				t.invalidateWorkspaceHandle(prepared.handle)
+			}
 		}
 	}
 	if err != nil {
@@ -663,9 +665,11 @@ func (t *RunTool) prepareWorkspaceForRun(
 		if acquired {
 			t.wsr.InvalidateWorkspaceHandle(prepared.handle)
 		}
-		prepared, acquired, err = t.prepareWorkspaceAttempt(ctx, eng, in)
-		if errors.Is(err, codeexecutor.ErrWorkspaceStale) && acquired {
-			t.wsr.InvalidateWorkspaceHandle(prepared.handle)
+		if codeexecutor.IsWorkspaceRetrySafe(err) {
+			prepared, acquired, err = t.prepareWorkspaceAttempt(ctx, eng, in)
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) && acquired {
+				t.wsr.InvalidateWorkspaceHandle(prepared.handle)
+			}
 		}
 	}
 	if err != nil {

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -4131,11 +4131,12 @@ func (m *stubDownloadModel) DownloadFile(
 
 func TestRunTool_stageUserFileInputs_NoInvocation(t *testing.T) {
 	rt := &RunTool{}
-	staged, warnings := rt.stageUserFileInputs(
+	staged, warnings, err := rt.stageUserFileInputs(
 		context.Background(),
 		nil,
 		codeexecutor.Workspace{},
 	)
+	require.NoError(t, err)
 	require.Nil(t, staged)
 	require.Nil(t, warnings)
 }
@@ -4146,11 +4147,12 @@ func TestRunTool_stageUserFileInputs_NoFiles(t *testing.T) {
 		agent.WithInvocationMessage(model.NewUserMessage("hi")),
 	)
 	ctx := agent.NewInvocationContext(context.Background(), inv)
-	staged, warnings := rt.stageUserFileInputs(
+	staged, warnings, err := rt.stageUserFileInputs(
 		ctx,
 		nil,
 		codeexecutor.Workspace{},
 	)
+	require.NoError(t, err)
 	require.Nil(t, staged)
 	require.Nil(t, warnings)
 }
@@ -4166,13 +4168,42 @@ func TestRunTool_stageUserFileInputs_MetadataError_Warn(t *testing.T) {
 	inv := agent.NewInvocation(agent.WithInvocationMessage(user))
 	ctx := agent.NewInvocationContext(context.Background(), inv)
 
-	_, warnings := rt.stageUserFileInputs(
+	_, warnings, err := rt.stageUserFileInputs(
 		ctx,
 		nil,
 		codeexecutor.Workspace{},
 	)
+	require.NoError(t, err)
 	require.Len(t, warnings, 1)
 	require.Contains(t, warnings[0], "load metadata")
+}
+
+func TestRunTool_stageUserFileInputs_StalePropagates(t *testing.T) {
+	rt := &RunTool{}
+	user := model.NewUserMessage("upload")
+	user.AddFileData(
+		uploadNotesTxt,
+		[]byte(contentHi),
+		"text/plain",
+	)
+	inv := agent.NewInvocation(agent.WithInvocationMessage(user))
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	stale := fmt.Errorf(
+		"metadata from old workspace: %w",
+		codeexecutor.ErrWorkspaceStale,
+	)
+
+	_, warnings, err := rt.stageUserFileInputs(
+		ctx,
+		codeexecutor.NewEngine(
+			nil,
+			&stubFS{collectErr: stale},
+			nil,
+		),
+		codeexecutor.Workspace{},
+	)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.Empty(t, warnings)
 }
 
 func TestSanitizeUserFileName(t *testing.T) {

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -4242,17 +4242,93 @@ func TestRunTool_PreparationStaleInvalidatesLegacyHandleAndRetries(
 	inv := agent.NewInvocation(agent.WithInvocationMessage(user))
 	ctx := agent.NewInvocationContext(context.Background(), inv)
 
-	_, ws, _, _, staged, warnings, err := rt.prepareWorkspaceForRun(
+	prepared, err := rt.prepareWorkspaceForRun(
 		ctx,
 		runInput{Skill: testSkillName},
 	)
 	require.NoError(t, err)
-	require.Equal(t, "skill-workspace", ws.ID)
-	require.Len(t, staged, 1)
-	require.Empty(t, warnings)
+	require.Equal(t, "skill-workspace", prepared.handle.Workspace.ID)
+	require.Len(t, prepared.staged, 1)
+	require.Empty(t, prepared.warnings)
 	require.Equal(t, 2, manager.creates,
 		"stale legacy cache entry must be invalidated before retry")
 	require.Equal(t, 2, fs.collectCalls)
+}
+
+func TestRunTool_RunStaleInvalidatesLegacyHandleAndRetries(
+	t *testing.T,
+) {
+	manager := &legacySkillRetryManager{}
+	runner := &staleOnceSkillRunner{}
+	eng := &managedEngine{
+		m: manager,
+		f: &stubFS{},
+		r: runner,
+	}
+	rt := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: eng},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{
+				WorkspaceSkillDir: path.Join(
+					codeexecutor.DirSkills,
+					testSkillName,
+				),
+			}, nil
+		})),
+	)
+	args, err := jsonMarshal(runInput{
+		Skill:   testSkillName,
+		Command: echoOK,
+	})
+	require.NoError(t, err)
+
+	_, err = rt.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, 2, runner.calls)
+	require.Equal(t, 2, manager.creates,
+		"pre-start stale must rebuild the exact legacy cache entry")
+}
+
+func TestRunTool_OutputStaleInvalidatesWithoutReplayingCommand(
+	t *testing.T,
+) {
+	manager := &legacySkillRetryManager{}
+	fs := &staleOnceSkillFS{}
+	runner := &stubRunner{
+		res: codeexecutor.RunResult{ExitCode: 0},
+	}
+	eng := &managedEngine{m: manager, f: fs, r: runner}
+	rt := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: eng},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{WorkspaceSkillDir: "."}, nil
+		})),
+	)
+	args, err := jsonMarshal(runInput{
+		Skill:   testSkillName,
+		Command: echoOK,
+	})
+	require.NoError(t, err)
+
+	_, err = rt.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.Equal(t, 1, runner.calls,
+		"the completed command must not be replayed")
+	require.Equal(t, 1, manager.creates)
+
+	_, err = rt.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, 2, runner.calls)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace")
 }
 
 func TestSanitizeUserFileName(t *testing.T) {
@@ -5520,6 +5596,25 @@ func (r *stubRunner) RunProgram(
 	return r.res, r.err
 }
 
+type staleOnceSkillRunner struct {
+	calls int
+}
+
+func (r *staleOnceSkillRunner) RunProgram(
+	_ context.Context,
+	_ codeexecutor.Workspace,
+	_ codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	r.calls++
+	if r.calls == 1 {
+		return codeexecutor.RunResult{}, fmt.Errorf(
+			"program did not start: %w",
+			codeexecutor.ErrWorkspaceStale,
+		)
+	}
+	return codeexecutor.RunResult{ExitCode: 0}, nil
+}
+
 type stubEngine struct {
 	f codeexecutor.WorkspaceFS
 	r codeexecutor.ProgramRunner
@@ -5830,7 +5925,7 @@ func TestRunTool_prepareWorkspaceForRun_CreateWorkspaceError(t *testing.T) {
 		}},
 	)
 
-	_, _, _, _, _, _, err := rt.prepareWorkspaceForRun(
+	_, err := rt.prepareWorkspaceForRun(
 		context.Background(),
 		runInput{Skill: testSkillName},
 	)

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -3093,6 +3093,64 @@ func TestRunTool_OutputsSpec_PartialMetadataCommitReturnsFiles(
 	require.Contains(t, out.Warnings, warnPartialOutputCommit)
 }
 
+func TestRunTool_OutputsSpec_PartialStaleInvalidatesWithoutReplay(
+	t *testing.T,
+) {
+	manager := &legacySkillRetryManager{}
+	fs := &partialStaleSkillFS{
+		stubFS: &stubFS{},
+		manifest: codeexecutor.OutputManifest{
+			Files: []codeexecutor.FileRef{{
+				Name:     outATxt,
+				Content:  contentHi,
+				MIMEType: "text/plain",
+			}},
+		},
+	}
+	runner := &stubRunner{
+		res: codeexecutor.RunResult{ExitCode: 0},
+	}
+	rt := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: &managedEngine{
+			m: manager,
+			f: fs,
+			r: runner,
+		}},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{WorkspaceSkillDir: "."}, nil
+		})),
+	)
+	enc, err := jsonMarshal(runInput{
+		Skill:   testSkillName,
+		Command: echoOK,
+		Outputs: &codeexecutor.OutputSpec{
+			Globs:  []string{outGlobTxt},
+			Inline: true,
+		},
+	})
+	require.NoError(t, err)
+
+	res, err := rt.Call(context.Background(), enc)
+	require.NoError(t, err)
+	out := res.(runOutput)
+	require.Contains(t, out.Warnings, warnPartialOutputCommit)
+	require.Len(t, out.OutputFiles, 1)
+	require.Equal(t, contentHi, out.OutputFiles[0].Content)
+	require.Equal(t, 1, runner.calls,
+		"partial output must not replay the completed command")
+	require.Equal(t, 1, manager.creates)
+
+	_, err = rt.Call(context.Background(), enc)
+	require.NoError(t, err)
+	require.Equal(t, 2, runner.calls)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace once")
+}
+
 // Using Outputs spec with Save=true and Inline=false should attach
 // artifact refs from manifest without inlining file content.
 func TestRunTool_OutputsSpec_Save_NoInline(t *testing.T) {
@@ -5467,6 +5525,22 @@ type stubFS struct {
 type staleOnceSkillFS struct {
 	stubFS
 	collectCalls int
+}
+
+type partialStaleSkillFS struct {
+	*stubFS
+	manifest codeexecutor.OutputManifest
+}
+
+func (f *partialStaleSkillFS) CollectOutputs(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.OutputSpec,
+) (codeexecutor.OutputManifest, error) {
+	return f.manifest, errors.Join(
+		codeexecutor.ErrPartialOutputCommit,
+		codeexecutor.ErrWorkspaceStale,
+	)
 }
 
 func (f *staleOnceSkillFS) Collect(

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -4206,6 +4206,55 @@ func TestRunTool_stageUserFileInputs_StalePropagates(t *testing.T) {
 	require.Empty(t, warnings)
 }
 
+func TestRunTool_PreparationStaleInvalidatesLegacyHandleAndRetries(
+	t *testing.T,
+) {
+	manager := &legacySkillRetryManager{}
+	fs := &staleOnceSkillFS{}
+	eng := &managedEngine{
+		m: manager,
+		f: fs,
+		r: &stubRunner{
+			res: codeexecutor.RunResult{ExitCode: 0},
+		},
+	}
+	rt := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: eng},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{
+				WorkspaceSkillDir: path.Join(
+					codeexecutor.DirSkills,
+					testSkillName,
+				),
+			}, nil
+		})),
+	)
+	user := model.NewUserMessage("upload")
+	user.AddFileData(
+		uploadNotesTxt,
+		[]byte(contentHi),
+		"text/plain",
+	)
+	inv := agent.NewInvocation(agent.WithInvocationMessage(user))
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	_, ws, _, _, staged, warnings, err := rt.prepareWorkspaceForRun(
+		ctx,
+		runInput{Skill: testSkillName},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "skill-workspace", ws.ID)
+	require.Len(t, staged, 1)
+	require.Empty(t, warnings)
+	require.Equal(t, 2, manager.creates,
+		"stale legacy cache entry must be invalidated before retry")
+	require.Equal(t, 2, fs.collectCalls)
+}
+
 func TestSanitizeUserFileName(t *testing.T) {
 	tests := []struct {
 		name string
@@ -5339,6 +5388,26 @@ type stubFS struct {
 	putFiles []codeexecutor.PutFile
 }
 
+type staleOnceSkillFS struct {
+	stubFS
+	collectCalls int
+}
+
+func (f *staleOnceSkillFS) Collect(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	patterns []string,
+) ([]codeexecutor.File, error) {
+	f.collectCalls++
+	if f.collectCalls == 1 {
+		return nil, fmt.Errorf(
+			"workspace rotated before metadata read: %w",
+			codeexecutor.ErrWorkspaceStale,
+		)
+	}
+	return f.stubFS.Collect(ctx, ws, patterns)
+}
+
 func (s *stubFS) PutFiles(
 	_ context.Context,
 	_ codeexecutor.Workspace,
@@ -5389,6 +5458,29 @@ func (*stubFS) CollectOutputs(
 type stubManager struct {
 	ws  codeexecutor.Workspace
 	err error
+}
+
+type legacySkillRetryManager struct {
+	creates int
+}
+
+func (m *legacySkillRetryManager) CreateWorkspace(
+	_ context.Context,
+	_ string,
+	_ codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.creates++
+	return codeexecutor.Workspace{
+		ID:   "skill-workspace",
+		Path: "/tmp/skill-workspace",
+	}, nil
+}
+
+func (*legacySkillRetryManager) Cleanup(
+	context.Context,
+	codeexecutor.Workspace,
+) error {
+	return nil
 }
 
 func (m *stubManager) CreateWorkspace(

--- a/tool/skill/run_test.go
+++ b/tool/skill/run_test.go
@@ -4351,6 +4351,46 @@ func TestRunTool_RunStaleInvalidatesLegacyHandleAndRetries(
 		"pre-start stale must rebuild the exact legacy cache entry")
 }
 
+func TestRunTool_UnsafeStaleInvalidatesWithoutReplay(t *testing.T) {
+	manager := &legacySkillRetryManager{}
+	runner := &staleOnceSkillRunner{firstErr: errors.Join(
+		codeexecutor.ErrWorkspaceStale,
+		codeexecutor.ErrWorkspaceRetryUnsafe,
+	)}
+	eng := &managedEngine{
+		m: manager,
+		f: &stubFS{},
+		r: runner,
+	}
+	rt := NewRunTool(
+		&mockRepo{},
+		&engineExec{eng: eng},
+		WithSkillStager(skillStagerFunc(func(
+			context.Context,
+			SkillStageRequest,
+		) (SkillStageResult, error) {
+			return SkillStageResult{WorkspaceSkillDir: "."}, nil
+		})),
+	)
+	args, err := jsonMarshal(runInput{
+		Skill:   testSkillName,
+		Command: echoOK,
+	})
+	require.NoError(t, err)
+
+	_, err = rt.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceRetryUnsafe)
+	require.Equal(t, 1, runner.calls, "unsafe stale must not replay")
+	require.Equal(t, 1, manager.creates)
+
+	_, err = rt.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, 2, runner.calls)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace once")
+}
+
 func TestRunTool_OutputStaleInvalidatesWithoutReplayingCommand(
 	t *testing.T,
 ) {
@@ -5671,7 +5711,8 @@ func (r *stubRunner) RunProgram(
 }
 
 type staleOnceSkillRunner struct {
-	calls int
+	calls    int
+	firstErr error
 }
 
 func (r *staleOnceSkillRunner) RunProgram(
@@ -5681,6 +5722,9 @@ func (r *staleOnceSkillRunner) RunProgram(
 ) (codeexecutor.RunResult, error) {
 	r.calls++
 	if r.calls == 1 {
+		if r.firstErr != nil {
+			return codeexecutor.RunResult{}, r.firstErr
+		}
 		return codeexecutor.RunResult{}, fmt.Errorf(
 			"program did not start: %w",
 			codeexecutor.ErrWorkspaceStale,

--- a/tool/workspaceexec/save_artifact.go
+++ b/tool/workspaceexec/save_artifact.go
@@ -121,10 +121,15 @@ func (t *SaveArtifactTool) Call(
 	if err != nil {
 		return nil, err
 	}
-	ws, err := t.exec.resolver.CreateWorkspace(ctxIO, eng, "workspace")
+	handle, err := t.exec.resolver.CreateWorkspaceHandle(
+		ctxIO,
+		eng,
+		"workspace",
+	)
 	if err != nil {
 		return nil, err
 	}
+	ws := handle.Workspace
 	manifest, err := eng.FS().CollectOutputs(ctxIO, ws, codeexecutor.OutputSpec{
 		Globs:         []string{rel},
 		MaxFiles:      1,
@@ -133,6 +138,9 @@ func (t *SaveArtifactTool) Call(
 		Save:          true,
 		Inline:        false,
 	})
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		t.exec.resolver.InvalidateWorkspaceHandle(handle)
+	}
 	if err != nil && !errors.Is(err, codeexecutor.ErrPartialOutputCommit) {
 		return nil, err
 	}

--- a/tool/workspaceexec/save_artifact_test.go
+++ b/tool/workspaceexec/save_artifact_test.go
@@ -299,6 +299,51 @@ func TestSaveArtifactTool_ManifestFailures(t *testing.T) {
 	})
 }
 
+func TestSaveArtifactTool_PartialStaleInvalidatesWorkspace(
+	t *testing.T,
+) {
+	manager := &countingSaveManager{}
+	fs := stubOutputFS{
+		manifest: codeexecutor.OutputManifest{
+			Files: []codeexecutor.FileRef{{
+				Name:      "out/site.zip",
+				SavedAs:   "out/site.zip",
+				Version:   2,
+				SizeBytes: 10,
+			}},
+		},
+		err: errors.Join(
+			codeexecutor.ErrPartialOutputCommit,
+			codeexecutor.ErrWorkspaceStale,
+		),
+	}
+	execTool := NewExecTool(&stubEngineExec{
+		eng: codeexecutor.NewEngine(
+			manager,
+			fs,
+			&nonInteractiveRunner{},
+		),
+	})
+	tl := NewSaveArtifactTool(execTool)
+	ctx := saveArtifactContext()
+	enc, err := json.Marshal(saveArtifactInput{Path: "out/site.zip"})
+	require.NoError(t, err)
+
+	res, err := tl.Call(ctx, enc)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"artifact://out/site.zip@2",
+		res.(saveArtifactOutput).Ref,
+	)
+	require.Equal(t, 1, manager.creates)
+
+	_, err = tl.Call(ctx, enc)
+	require.NoError(t, err)
+	require.Equal(t, 2, manager.creates,
+		"the next call must rebuild the invalidated workspace once")
+}
+
 func TestSaveArtifactTool_StateDeltaFallbacks(t *testing.T) {
 	tl := NewSaveArtifactTool(NewExecTool(localexec.New()))
 
@@ -417,6 +462,29 @@ func (s *stubEngineExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
 }
 
 func (s *stubEngineExec) Engine() codeexecutor.Engine { return s.eng }
+
+type countingSaveManager struct {
+	creates int
+}
+
+func (m *countingSaveManager) CreateWorkspace(
+	_ context.Context,
+	id string,
+	_ codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.creates++
+	return codeexecutor.Workspace{
+		ID:   id,
+		Path: "/tmp/" + id,
+	}, nil
+}
+
+func (*countingSaveManager) Cleanup(
+	context.Context,
+	codeexecutor.Workspace,
+) error {
+	return nil
+}
 
 type stubOutputFS struct {
 	manifest codeexecutor.OutputManifest

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -142,13 +142,13 @@ type execOutput struct {
 }
 
 type execRequest struct {
-	background          bool
-	tty                 bool
-	yield               *int
-	eng                 codeexecutor.Engine
-	ws                  codeexecutor.Workspace
-	workspaceInstanceID codeexecutor.WorkspaceInstanceID
-	spec                codeexecutor.RunProgramSpec
+	background      bool
+	tty             bool
+	yield           *int
+	eng             codeexecutor.Engine
+	ws              codeexecutor.Workspace
+	workspaceHandle codeexecutor.WorkspaceHandle
+	spec            codeexecutor.RunProgramSpec
 }
 
 type killOutput struct {
@@ -645,27 +645,27 @@ func (t *ExecTool) callWithWorkspaceRetry(
 		return out, err
 	}
 	if acquired {
-		t.resolver.InvalidateWorkspaceIf(
-			ctx,
-			"workspace",
-			req.ws,
-			req.workspaceInstanceID,
-		)
+		t.resolver.InvalidateWorkspaceHandle(req.workspaceHandle)
+	}
+	if errors.Is(err, workspaceprep.ErrReconcileRetryUnsafe) {
+		return out, err
 	}
 	retry := base
-	out, _, err = t.executeWorkspaceAttempt(ctx, &retry)
+	out, acquired, err = t.executeWorkspaceAttempt(ctx, &retry)
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) && acquired {
+		t.resolver.InvalidateWorkspaceHandle(retry.workspaceHandle)
+	}
 	return out, err
 }
 
 // executeWorkspaceAttempt keeps Acquire, reconciliation, and process start in
-// one retry unit. ErrWorkspaceStale is contractually restricted to failures
-// before a user command starts (or to idempotent reconciliation), so the caller
-// can safely retry this unit once without replaying an uncertain command.
+// one retry unit. Stale always invalidates the exact acquired handle, while the
+// caller separately checks reconciliation's retry-safety marker before replay.
 func (t *ExecTool) executeWorkspaceAttempt(
 	ctx context.Context,
 	req *execRequest,
 ) (execOutput, bool, error) {
-	ws, workspaceInstanceID, err := t.resolver.CreateWorkspaceWithInstanceID(
+	handle, err := t.resolver.CreateWorkspaceHandle(
 		ctx,
 		req.eng,
 		"workspace",
@@ -673,8 +673,8 @@ func (t *ExecTool) executeWorkspaceAttempt(
 	if err != nil {
 		return execOutput{}, false, err
 	}
-	req.ws = ws
-	req.workspaceInstanceID = workspaceInstanceID
+	req.workspaceHandle = handle
+	req.ws = handle.Workspace
 	if err := t.reconcileWorkspace(ctx, req.eng, req.ws); err != nil {
 		return execOutput{}, true, err
 	}
@@ -975,7 +975,7 @@ func (t *ExecTool) reconcileWorkspace(
 	ws codeexecutor.Workspace,
 ) error {
 	if t == nil || len(t.providers) == 0 {
-		_, warnings := workspaceinput.StageConversationFiles(ctx, eng, ws)
+		_, warnings, err := workspaceinput.StageConversationFiles(ctx, eng, ws)
 		for _, warning := range warnings {
 			log.WarnfContext(
 				ctx,
@@ -983,7 +983,7 @@ func (t *ExecTool) reconcileWorkspace(
 				warning,
 			)
 		}
-		return nil
+		return err
 	}
 	inv, _ := agent.InvocationFromContext(ctx)
 	var all []workspaceprep.Requirement

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -142,12 +142,13 @@ type execOutput struct {
 }
 
 type execRequest struct {
-	background bool
-	tty        bool
-	yield      *int
-	eng        codeexecutor.Engine
-	ws         codeexecutor.Workspace
-	spec       codeexecutor.RunProgramSpec
+	background          bool
+	tty                 bool
+	yield               *int
+	eng                 codeexecutor.Engine
+	ws                  codeexecutor.Workspace
+	workspaceInstanceID codeexecutor.WorkspaceInstanceID
+	spec                codeexecutor.RunProgramSpec
 }
 
 type killOutput struct {
@@ -580,10 +581,7 @@ func (t *ExecTool) Call(ctx context.Context, args []byte) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if t.sessional {
-		return t.callSessional(ctx, req)
-	}
-	return t.callNonSessional(ctx, req)
+	return t.callWithWorkspaceRetry(ctx, req)
 }
 
 func parseExecInput(args []byte) (execInput, error) {
@@ -616,13 +614,6 @@ func (t *ExecTool) prepareExec(
 	if err := checkRunnerSupportsPolicy(eng, policyActive); err != nil {
 		return execRequest{}, err
 	}
-	ws, err := t.resolver.CreateWorkspace(ctx, eng, "workspace")
-	if err != nil {
-		return execRequest{}, err
-	}
-	if err := t.reconcileWorkspace(ctx, eng, ws); err != nil {
-		return execRequest{}, err
-	}
 	timeout := firstIntValue(in.TimeoutSec, in.TimeoutSecOld)
 	if timeout <= 0 {
 		timeout = in.Timeout
@@ -632,7 +623,6 @@ func (t *ExecTool) prepareExec(
 		tty:        firstBoolValue(in.TTY, in.PTY),
 		yield:      firstIntPtr(in.YieldTimeMS, in.YieldMs),
 		eng:        eng,
-		ws:         ws,
 		spec: codeexecutor.RunProgramSpec{
 			Cmd:      "sh",
 			Args:     shellArgsForPolicy(policyActive, in.Command),
@@ -643,6 +633,57 @@ func (t *ExecTool) prepareExec(
 			Timeout:  execTimeout(timeout),
 		},
 	}, nil
+}
+
+func (t *ExecTool) callWithWorkspaceRetry(
+	ctx context.Context,
+	base execRequest,
+) (execOutput, error) {
+	req := base
+	out, acquired, err := t.executeWorkspaceAttempt(ctx, &req)
+	if err == nil || !errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		return out, err
+	}
+	if acquired {
+		t.resolver.InvalidateWorkspaceIf(
+			ctx,
+			"workspace",
+			req.ws,
+			req.workspaceInstanceID,
+		)
+	}
+	retry := base
+	out, _, err = t.executeWorkspaceAttempt(ctx, &retry)
+	return out, err
+}
+
+// executeWorkspaceAttempt keeps Acquire, reconciliation, and process start in
+// one retry unit. ErrWorkspaceStale is contractually restricted to failures
+// before a user command starts (or to idempotent reconciliation), so the caller
+// can safely retry this unit once without replaying an uncertain command.
+func (t *ExecTool) executeWorkspaceAttempt(
+	ctx context.Context,
+	req *execRequest,
+) (execOutput, bool, error) {
+	ws, workspaceInstanceID, err := t.resolver.CreateWorkspaceWithInstanceID(
+		ctx,
+		req.eng,
+		"workspace",
+	)
+	if err != nil {
+		return execOutput{}, false, err
+	}
+	req.ws = ws
+	req.workspaceInstanceID = workspaceInstanceID
+	if err := t.reconcileWorkspace(ctx, req.eng, req.ws); err != nil {
+		return execOutput{}, true, err
+	}
+	if t.sessional {
+		out, err := t.callSessional(ctx, *req)
+		return out, true, err
+	}
+	out, err := t.callNonSessional(ctx, *req)
+	return out, true, err
 }
 
 // checkCommandPolicy enforces the optional allow/deny lists. When no

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -676,7 +676,7 @@ func (t *ExecTool) callWithWorkspaceRetry(
 	if acquired {
 		t.resolver.InvalidateWorkspaceHandle(req.workspaceHandle)
 	}
-	if errors.Is(err, workspaceprep.ErrReconcileRetryUnsafe) {
+	if !codeexecutor.IsWorkspaceRetrySafe(err) {
 		return out, err
 	}
 	retry := base

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -100,6 +100,7 @@ type execSession struct {
 	mu sync.Mutex
 
 	proc        codeexecutor.ProgramSession
+	handle      codeexecutor.WorkspaceHandle
 	exitedAt    time.Time
 	finalized   bool
 	finalizedAt time.Time
@@ -890,7 +891,10 @@ func (t *ExecTool) startInteractive(
 	if err != nil {
 		return execOutput{}, err
 	}
-	t.putSession(proc.ID(), &execSession{proc: proc})
+	t.putSession(proc.ID(), &execSession{
+		proc:   proc,
+		handle: req.workspaceHandle,
+	})
 	poll := initialPoll(proc, req.background, req.yield)
 	out := pollOutput(proc.ID(), poll)
 	out = t.limitOutput(out)
@@ -938,6 +942,7 @@ func (t *WriteStdinTool) Call(ctx context.Context, args []byte) (any, error) {
 	appendNewline := firstBoolValue(in.AppendNewline, in.Submit)
 	if in.Chars != "" || appendNewline {
 		if err := sess.proc.Write(in.Chars, appendNewline); err != nil {
+			t.exec.invalidateSessionWorkspaceIfStale(sess, err)
 			return nil, err
 		}
 	}
@@ -979,6 +984,7 @@ func (t *KillSessionTool) Call(_ context.Context, args []byte) (any, error) {
 	poll := sess.proc.Poll(nil)
 	if poll.Status == codeexecutor.ProgramStatusRunning {
 		if err := sess.proc.Kill(programsession.DefaultSessionKill); err != nil {
+			t.exec.invalidateSessionWorkspaceIfStale(sess, err)
 			return nil, err
 		}
 		status = "killed"
@@ -1096,6 +1102,7 @@ func (t *ExecTool) finalizeAndRemoveSession(id string) error {
 	}
 	t.markSessionFinalized(sess)
 	if err := sess.proc.Close(); err != nil {
+		t.invalidateSessionWorkspaceIfStale(sess, err)
 		return err
 	}
 	_, err = t.removeSession(id)
@@ -1121,8 +1128,20 @@ func (t *ExecTool) cleanupExpiredLocked() {
 		if expired {
 			if err := sess.proc.Close(); err == nil {
 				delete(t.sessions, id)
+			} else {
+				t.invalidateSessionWorkspaceIfStale(sess, err)
 			}
 		}
+	}
+}
+
+func (t *ExecTool) invalidateSessionWorkspaceIfStale(
+	sess *execSession,
+	err error,
+) {
+	if t != nil && t.resolver != nil &&
+		errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		t.resolver.InvalidateWorkspaceHandle(sess.handle)
 	}
 }
 

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -13,8 +13,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -908,6 +910,346 @@ func (p writeFailProgramSession) Log(_, _ *int) codeexecutor.ProgramLog {
 func (p writeFailProgramSession) Write(string, bool) error { return p.err }
 func (p writeFailProgramSession) Kill(time.Duration) error { return nil }
 func (p writeFailProgramSession) Close() error             { return nil }
+
+type staleRetryManager struct {
+	mu         sync.Mutex
+	instance   int
+	createRuns int
+}
+
+func (m *staleRetryManager) CreateWorkspace(
+	_ context.Context,
+	id string,
+	_ codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createRuns++
+	return codeexecutor.Workspace{
+		ID:   id,
+		Path: "/tmp/" + id,
+	}, nil
+}
+
+func (*staleRetryManager) Cleanup(
+	context.Context,
+	codeexecutor.Workspace,
+) error {
+	return nil
+}
+
+func (m *staleRetryManager) WorkspaceInstanceID(
+	context.Context,
+	codeexecutor.Workspace,
+) (codeexecutor.WorkspaceInstanceID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return codeexecutor.WorkspaceInstanceID(
+		fmt.Sprintf("instance-%d", m.instance),
+	), nil
+}
+
+func (m *staleRetryManager) rotate() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.instance++
+}
+
+func (m *staleRetryManager) createCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.createRuns
+}
+
+type staleRetryRunner struct {
+	mu sync.Mutex
+
+	manager      *staleRetryManager
+	userErrors   []error
+	userAttempts int
+	userStarts   int
+}
+
+func (r *staleRetryRunner) RunProgram(
+	_ context.Context,
+	_ codeexecutor.Workspace,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	// Reconciliation uses bash to commit metadata. Only sh is the user
+	// workspace_exec command in these tests.
+	if spec.Cmd != "sh" {
+		return codeexecutor.RunResult{ExitCode: 0}, nil
+	}
+	r.mu.Lock()
+	r.userAttempts++
+	var err error
+	if len(r.userErrors) > 0 {
+		err = r.userErrors[0]
+		r.userErrors = r.userErrors[1:]
+	}
+	if !errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		r.userStarts++
+	}
+	r.mu.Unlock()
+	if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+		r.manager.rotate()
+	}
+	if err != nil {
+		return codeexecutor.RunResult{}, err
+	}
+	return codeexecutor.RunResult{
+		Stdout:   "ok",
+		ExitCode: 0,
+	}, nil
+}
+
+func (r *staleRetryRunner) counts() (attempts int, starts int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.userAttempts, r.userStarts
+}
+
+type staleRetryFS struct {
+	nonInteractiveFS
+
+	mu        sync.Mutex
+	manager   *staleRetryManager
+	staleNext bool
+}
+
+func (f *staleRetryFS) PutFiles(
+	context.Context,
+	codeexecutor.Workspace,
+	[]codeexecutor.PutFile,
+) error {
+	f.mu.Lock()
+	stale := f.staleNext
+	f.staleNext = false
+	f.mu.Unlock()
+	if stale {
+		f.manager.rotate()
+		return fmt.Errorf(
+			"workspace changed before file write: %w",
+			codeexecutor.ErrWorkspaceStale,
+		)
+	}
+	return nil
+}
+
+type staleRetryExec struct {
+	eng codeexecutor.Engine
+}
+
+func (*staleRetryExec) ExecuteCode(
+	context.Context,
+	codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (*staleRetryExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
+}
+
+func (e *staleRetryExec) Engine() codeexecutor.Engine {
+	return e.eng
+}
+
+func newStaleRetryExec(
+	manager *staleRetryManager,
+	fs codeexecutor.WorkspaceFS,
+	runner *staleRetryRunner,
+) *staleRetryExec {
+	return &staleRetryExec{
+		eng: codeexecutor.NewEngine(manager, fs, runner),
+	}
+}
+
+type staleInteractiveRetryRunner struct {
+	*staleRetryRunner
+
+	mu            sync.Mutex
+	startAttempts int
+	starts        int
+}
+
+func (r *staleInteractiveRetryRunner) StartProgram(
+	_ context.Context,
+	_ codeexecutor.Workspace,
+	_ codeexecutor.InteractiveProgramSpec,
+) (codeexecutor.ProgramSession, error) {
+	r.mu.Lock()
+	r.startAttempts++
+	attempt := r.startAttempts
+	if attempt > 1 {
+		r.starts++
+	}
+	r.mu.Unlock()
+	if attempt == 1 {
+		r.manager.rotate()
+		return nil, fmt.Errorf(
+			"before process start: %w",
+			codeexecutor.ErrWorkspaceStale,
+		)
+	}
+	exitCode := 0
+	return failingProgramSession{
+		poll: codeexecutor.ProgramPoll{
+			Status:   codeexecutor.ProgramStatusExited,
+			ExitCode: &exitCode,
+		},
+	}, nil
+}
+
+func (r *staleInteractiveRetryRunner) startCounts() (
+	attempts int,
+	starts int,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.startAttempts, r.starts
+}
+
+func TestExecTool_WorkspaceStaleBeforeRunRetriesOnce(t *testing.T) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleRetryRunner{
+		manager: manager,
+		userErrors: []error{
+			fmt.Errorf("before submit: %w", codeexecutor.ErrWorkspaceStale),
+		},
+	}
+	exec := newStaleRetryExec(
+		manager,
+		&nonInteractiveFS{},
+		runner,
+	)
+	tl := NewExecTool(exec)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount())
+	attempts, starts := runner.counts()
+	require.Equal(t, 2, attempts)
+	require.Equal(t, 1, starts, "the user command must start only once")
+}
+
+func TestExecTool_WorkspaceStaleBeforeInteractiveStartRetriesOnce(
+	t *testing.T,
+) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleInteractiveRetryRunner{
+		staleRetryRunner: &staleRetryRunner{manager: manager},
+	}
+	exec := &staleRetryExec{
+		eng: codeexecutor.NewEngine(
+			manager,
+			&nonInteractiveFS{},
+			runner,
+		),
+	}
+	tl := NewExecTool(exec)
+	args, err := json.Marshal(execInput{
+		Command:    "interactive",
+		Background: true,
+	})
+	require.NoError(t, err)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		codeexecutor.ProgramStatusExited,
+		got.(execOutput).Status,
+	)
+	require.Equal(t, 2, manager.createCount())
+	attempts, starts := runner.startCounts()
+	require.Equal(t, 2, attempts)
+	require.Equal(t, 1, starts)
+}
+
+func TestExecTool_WorkspaceStaleTwiceStops(t *testing.T) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleRetryRunner{
+		manager: manager,
+		userErrors: []error{
+			codeexecutor.ErrWorkspaceStale,
+			fmt.Errorf("still stale: %w", codeexecutor.ErrWorkspaceStale),
+		},
+	}
+	exec := newStaleRetryExec(
+		manager,
+		&nonInteractiveFS{},
+		runner,
+	)
+	tl := NewExecTool(exec)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	_, err = tl.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.Equal(t, 2, manager.createCount())
+	attempts, starts := runner.counts()
+	require.Equal(t, 2, attempts)
+	require.Zero(t, starts)
+}
+
+func TestExecTool_NonStaleRunErrorDoesNotRetry(t *testing.T) {
+	manager := &staleRetryManager{instance: 1}
+	uncertain := errors.New("transport timeout after request submission")
+	runner := &staleRetryRunner{
+		manager:    manager,
+		userErrors: []error{uncertain},
+	}
+	exec := newStaleRetryExec(
+		manager,
+		&nonInteractiveFS{},
+		runner,
+	)
+	tl := NewExecTool(exec)
+	args, err := json.Marshal(execInput{Command: "side-effect"})
+	require.NoError(t, err)
+
+	_, err = tl.Call(context.Background(), args)
+	require.ErrorIs(t, err, uncertain)
+	require.Equal(t, 1, manager.createCount())
+	attempts, starts := runner.counts()
+	require.Equal(t, 1, attempts)
+	require.Equal(t, 1, starts)
+}
+
+func TestExecTool_WorkspaceStaleDuringReconcileRetriesBeforeCommand(
+	t *testing.T,
+) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleRetryRunner{manager: manager}
+	fs := &staleRetryFS{
+		manager:   manager,
+		staleNext: true,
+	}
+	exec := newStaleRetryExec(manager, fs, runner)
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Files: []codeexecutor.WorkspaceFile{{
+				Target:  "work/seed.txt",
+				Content: []byte("seed"),
+			}},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount())
+	attempts, starts := runner.counts()
+	require.Equal(t, 1, attempts)
+	require.Equal(t, 1, starts)
+}
 
 type nonInteractiveExec struct{}
 

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -28,6 +28,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/programsession"
 	"trpc.group/trpc-go/trpc-agent-go/internal/skillstage"
+	"trpc.group/trpc-go/trpc-agent-go/internal/workspaceprep"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
@@ -938,9 +939,8 @@ func (*staleRetryManager) Cleanup(
 	return nil
 }
 
-func (m *staleRetryManager) WorkspaceInstanceID(
+func (m *staleRetryManager) InstanceID(
 	context.Context,
-	codeexecutor.Workspace,
 ) (codeexecutor.WorkspaceInstanceID, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -961,13 +961,93 @@ func (m *staleRetryManager) createCount() int {
 	return m.createRuns
 }
 
+type legacyABAManager struct {
+	mu      sync.Mutex
+	creates int
+}
+
+func (m *legacyABAManager) CreateWorkspace(
+	_ context.Context,
+	id string,
+	_ codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.creates++
+	return codeexecutor.Workspace{
+		ID:   id,
+		Path: "/tmp/" + id,
+	}, nil
+}
+
+func (*legacyABAManager) Cleanup(
+	context.Context,
+	codeexecutor.Workspace,
+) error {
+	return nil
+}
+
+func (m *legacyABAManager) createCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.creates
+}
+
+type legacyABARunner struct {
+	mu sync.Mutex
+
+	calls       int
+	starts      int
+	lateEntered chan struct{}
+	releaseLate chan struct{}
+}
+
+func (r *legacyABARunner) RunProgram(
+	_ context.Context,
+	_ codeexecutor.Workspace,
+	_ codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	r.mu.Lock()
+	r.calls++
+	call := r.calls
+	r.mu.Unlock()
+
+	switch call {
+	case 1:
+		close(r.lateEntered)
+		<-r.releaseLate
+		return codeexecutor.RunResult{}, fmt.Errorf(
+			"late stale result: %w",
+			codeexecutor.ErrWorkspaceStale,
+		)
+	case 2:
+		return codeexecutor.RunResult{}, fmt.Errorf(
+			"refreshing stale result: %w",
+			codeexecutor.ErrWorkspaceStale,
+		)
+	default:
+		r.mu.Lock()
+		r.starts++
+		r.mu.Unlock()
+		return codeexecutor.RunResult{Stdout: "ok", ExitCode: 0}, nil
+	}
+}
+
+func (r *legacyABARunner) counts() (calls int, starts int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls, r.starts
+}
+
 type staleRetryRunner struct {
 	mu sync.Mutex
 
-	manager      *staleRetryManager
-	userErrors   []error
-	userAttempts int
-	userStarts   int
+	manager         *staleRetryManager
+	userErrors      []error
+	metadataErrors  []error
+	userAttempts    int
+	userStarts      int
+	bootstrapStarts int
 }
 
 func (r *staleRetryRunner) RunProgram(
@@ -975,9 +1055,21 @@ func (r *staleRetryRunner) RunProgram(
 	_ codeexecutor.Workspace,
 	spec codeexecutor.RunProgramSpec,
 ) (codeexecutor.RunResult, error) {
-	// Reconciliation uses bash to commit metadata. Only sh is the user
-	// workspace_exec command in these tests.
 	if spec.Cmd != "sh" {
+		r.mu.Lock()
+		if spec.Cmd == "bash" && len(r.metadataErrors) > 0 {
+			err := r.metadataErrors[0]
+			r.metadataErrors = r.metadataErrors[1:]
+			r.mu.Unlock()
+			if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+				r.manager.rotate()
+			}
+			return codeexecutor.RunResult{}, err
+		}
+		if spec.Cmd != "bash" {
+			r.bootstrapStarts++
+		}
+		r.mu.Unlock()
 		return codeexecutor.RunResult{ExitCode: 0}, nil
 	}
 	r.mu.Lock()
@@ -1007,6 +1099,12 @@ func (r *staleRetryRunner) counts() (attempts int, starts int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.userAttempts, r.userStarts
+}
+
+func (r *staleRetryRunner) bootstrapCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.bootstrapStarts
 }
 
 type staleRetryFS struct {
@@ -1249,6 +1347,96 @@ func TestExecTool_WorkspaceStaleDuringReconcileRetriesBeforeCommand(
 	attempts, starts := runner.counts()
 	require.Equal(t, 1, attempts)
 	require.Equal(t, 1, starts)
+}
+
+func TestExecTool_UnsafeReconcileStaleInvalidatesWithoutReplay(
+	t *testing.T,
+) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleRetryRunner{
+		manager: manager,
+		metadataErrors: []error{
+			fmt.Errorf(
+				"metadata commit after command: %w",
+				codeexecutor.ErrWorkspaceStale,
+			),
+		},
+	}
+	exec := newStaleRetryExec(manager, &nonInteractiveFS{}, runner)
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Commands: []codeexecutor.WorkspaceCommand{{
+				Cmd: "setup-with-side-effect",
+			}},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "must-not-start"})
+	require.NoError(t, err)
+
+	_, err = tl.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.ErrorIs(t, err, workspaceprep.ErrReconcileRetryUnsafe)
+	require.Equal(t, 1, manager.createCount(),
+		"unsafe reconciliation must not reacquire and replay")
+	require.Equal(t, 1, runner.bootstrapCount())
+	attempts, starts := runner.counts()
+	require.Zero(t, attempts)
+	require.Zero(t, starts)
+}
+
+func TestExecTool_LegacyLateStaleDoesNotEvictRefreshedHandle(
+	t *testing.T,
+) {
+	manager := &legacyABAManager{}
+	runner := &legacyABARunner{
+		lateEntered: make(chan struct{}),
+		releaseLate: make(chan struct{}),
+	}
+	exec := &staleRetryExec{
+		eng: codeexecutor.NewEngine(
+			manager,
+			&nonInteractiveFS{},
+			runner,
+		),
+	}
+	tl := NewExecTool(exec)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	type callResult struct {
+		value any
+		err   error
+	}
+	lateResult := make(chan callResult, 1)
+	go func() {
+		value, err := tl.Call(context.Background(), args)
+		lateResult <- callResult{value: value, err: err}
+	}()
+	select {
+	case <-runner.lateEntered:
+	case <-time.After(time.Second):
+		t.Fatal("late attempt did not reach the runner")
+	}
+
+	refreshed, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", refreshed.(execOutput).Output)
+
+	close(runner.releaseLate)
+	var late callResult
+	select {
+	case late = <-lateResult:
+	case <-time.After(time.Second):
+		t.Fatal("late attempt did not finish")
+	}
+	require.NoError(t, late.err)
+	require.Equal(t, "ok", late.value.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount(),
+		"late invalidation must not evict the replacement entry")
+	calls, starts := runner.counts()
+	require.Equal(t, 4, calls)
+	require.Equal(t, 2, starts)
 }
 
 type nonInteractiveExec struct{}

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1118,6 +1118,32 @@ func (p writeFailProgramSession) Write(string, bool) error { return p.err }
 func (p writeFailProgramSession) Kill(time.Duration) error { return nil }
 func (p writeFailProgramSession) Close() error             { return nil }
 
+type staleWriteRunner struct{}
+
+func (staleWriteRunner) RunProgram(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	return codeexecutor.RunResult{Stdout: "ok"}, nil
+}
+
+func (staleWriteRunner) StartProgram(
+	context.Context,
+	codeexecutor.Workspace,
+	codeexecutor.InteractiveProgramSpec,
+) (codeexecutor.ProgramSession, error) {
+	return writeFailProgramSession{
+		poll: codeexecutor.ProgramPoll{
+			Status: codeexecutor.ProgramStatusRunning,
+		},
+		err: fmt.Errorf(
+			"old session backend is gone: %w",
+			codeexecutor.ErrWorkspaceStale,
+		),
+	}, nil
+}
+
 type staleRetryManager struct {
 	mu         sync.Mutex
 	instance   int
@@ -1484,6 +1510,49 @@ func TestExecTool_WorkspaceStaleBeforeInteractiveStartRetriesOnce(
 	attempts, starts := runner.startCounts()
 	require.Equal(t, 2, attempts)
 	require.Equal(t, 1, starts)
+}
+
+func TestExecTool_StaleSessionWriteInvalidatesLegacyWorkspace(
+	t *testing.T,
+) {
+	manager := &legacyABAManager{}
+	exec := &staleRetryExec{
+		eng: codeexecutor.NewEngine(
+			manager,
+			&nonInteractiveFS{},
+			staleWriteRunner{},
+		),
+	}
+	execTool := NewExecTool(exec)
+	startArgs, err := json.Marshal(execInput{
+		Command:    "interactive",
+		Background: true,
+	})
+	require.NoError(t, err)
+
+	started, err := execTool.Call(context.Background(), startArgs)
+	require.NoError(t, err)
+	require.Equal(t, "write-fail", started.(execOutput).SessionID)
+	require.Equal(t, 1, manager.createCount())
+
+	writeArgs, err := json.Marshal(writeInput{
+		SessionID: "write-fail",
+		Chars:     "must-not-replay",
+	})
+	require.NoError(t, err)
+	_, err = NewWriteStdinTool(execTool).Call(
+		context.Background(),
+		writeArgs,
+	)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+
+	nextArgs, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+	got, err := execTool.Call(context.Background(), nextArgs)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount(),
+		"the next call must rebuild exactly once")
 }
 
 func TestExecTool_WorkspaceStaleTwiceStops(t *testing.T) {

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1478,6 +1478,42 @@ func TestExecTool_WorkspaceStaleBeforeRunRetriesOnce(t *testing.T) {
 	require.Equal(t, 1, starts, "the user command must start only once")
 }
 
+func TestExecTool_UnsafeStaleInvalidatesWithoutReplay(t *testing.T) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleRetryRunner{
+		manager: manager,
+		userErrors: []error{errors.Join(
+			codeexecutor.ErrWorkspaceStale,
+			codeexecutor.ErrWorkspaceRetryUnsafe,
+		)},
+	}
+	exec := newStaleRetryExec(
+		manager,
+		&nonInteractiveFS{},
+		runner,
+	)
+	tl := NewExecTool(exec)
+	args, err := json.Marshal(execInput{Command: "side-effect"})
+	require.NoError(t, err)
+
+	_, err = tl.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceRetryUnsafe)
+	require.Equal(t, 1, manager.createCount())
+	attempts, starts := runner.counts()
+	require.Equal(t, 1, attempts, "unsafe stale must not replay")
+	require.Zero(t, starts)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount(),
+		"the next call must rebuild the invalidated workspace once")
+	attempts, starts = runner.counts()
+	require.Equal(t, 2, attempts)
+	require.Equal(t, 1, starts)
+}
+
 func TestExecTool_WorkspaceStaleBeforeInteractiveStartRetriesOnce(
 	t *testing.T,
 ) {

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1250,6 +1250,7 @@ type staleRetryRunner struct {
 
 	manager         *staleRetryManager
 	userErrors      []error
+	bootstrapErrors []error
 	metadataErrors  []error
 	userAttempts    int
 	userStarts      int
@@ -1272,10 +1273,21 @@ func (r *staleRetryRunner) RunProgram(
 			}
 			return codeexecutor.RunResult{}, err
 		}
+		var err error
 		if spec.Cmd != "bash" {
 			r.bootstrapStarts++
+			if len(r.bootstrapErrors) > 0 {
+				err = r.bootstrapErrors[0]
+				r.bootstrapErrors = r.bootstrapErrors[1:]
+			}
 		}
 		r.mu.Unlock()
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			r.manager.rotate()
+		}
+		if err != nil {
+			return codeexecutor.RunResult{}, err
+		}
 		return codeexecutor.RunResult{ExitCode: 0}, nil
 	}
 	r.mu.Lock()
@@ -1586,6 +1598,47 @@ func TestExecTool_UnsafeReconcileStaleInvalidatesWithoutReplay(
 	require.Equal(t, 1, manager.createCount(),
 		"unsafe reconciliation must not reacquire and replay")
 	require.Equal(t, 1, runner.bootstrapCount())
+	attempts, starts := runner.counts()
+	require.Zero(t, attempts)
+	require.Zero(t, starts)
+}
+
+func TestExecTool_FailedOptionalCommandPreventsLaterStaleReplay(
+	t *testing.T,
+) {
+	manager := &staleRetryManager{instance: 1}
+	runner := &staleRetryRunner{
+		manager: manager,
+		bootstrapErrors: []error{
+			errors.New("timeout after optional command submission"),
+			fmt.Errorf(
+				"later command did not start: %w",
+				codeexecutor.ErrWorkspaceStale,
+			),
+		},
+	}
+	exec := newStaleRetryExec(manager, &nonInteractiveFS{}, runner)
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Commands: []codeexecutor.WorkspaceCommand{
+				{
+					Cmd:      "optional-side-effect",
+					Optional: true,
+				},
+				{Cmd: "later-stale"},
+			},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "must-not-start"})
+	require.NoError(t, err)
+
+	_, err = tl.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.ErrorIs(t, err, workspaceprep.ErrReconcileRetryUnsafe)
+	require.Equal(t, 1, manager.createCount(),
+		"an uncertain optional command must prevent reconciliation replay")
+	require.Equal(t, 2, runner.bootstrapCount())
 	attempts, starts := runner.counts()
 	require.Zero(t, attempts)
 	require.Zero(t, starts)


### PR DESCRIPTION
## What changed

Workspace-backed tools can now detect when a backend has replaced its physical execution environment, rebuild cached logical workspaces once under concurrency, and recover one time from an explicitly safe stale-handle failure. Legacy workspace managers retain their existing cache behavior.

## Why

A reconnecting backend can preserve the same logical workspace ID and deterministic path while replacing the underlying executor or filesystem instance. Reusing the old cached handle skips workspace initialization and can target an invalid environment. Recovery must also avoid replaying commands whose execution result is uncertain.

The new instance identity is opaque and separate from `Workspace.ID`: the latter remains the stable logical identity, while `WorkspaceInstanceID` identifies the physical environment generation. `ErrWorkspaceStale` is intentionally limited to operations known not to have started, or to idempotent reconciliation work.

## Testing

- `go test ./...`
- `go test -race ./codeexecutor ./internal/workspacesession ./tool/workspaceexec`
- `git diff --check`

## Notes for reviewers

- The public API is additive and optional. Managers without `WorkspaceInstanceProvider` preserve the previous behavior.
- Refreshes are singleflight per logical workspace ID; validation and recreation failures retain the previous cache entry for a later retry.
- Conditional invalidation compares both the workspace handle and instance ID and deliberately does not call `Cleanup`, preventing a late stale report from deleting a deterministic path already owned by a newer instance.
- `workspace_exec` retries exactly once and only for errors matching `ErrWorkspaceStale`; transport timeouts, lost responses, ordinary filesystem errors, non-zero exits, and post-start interactive operations are not replayed.