### PR TITLE
{docs, memory/extractor}: add opt-in assistant episode extraction

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -373,16 +373,16 @@ configuration when present, and extracts ordinary user facts and events from
 user messages. When collecting a session delta, the enabled option uses only
 the primary choice from each model response event; alternative choices are not
 treated as consecutive assistant replies. The extractor then considers
-eligible user/assistant pairs in the
-extraction delta in chronological order. The deterministic eligibility check
-accepts a structured request only when the assistant response contains at
-least two Markdown or numbered list items. It also accepts a quantitative
-question when the response introduces a numeric answer that is not already in
-the question. A single prose result, including a classification, translation,
-conversion, or summary, does not currently trigger the second stage unless it
-has the required list shape. Eligible pairs are considered in chronological
-order within a private per-request pair and source-size budget. Candidates past
-that budget are omitted because assistant-result extraction is best effort.
+eligible user/assistant pairs in the extraction delta in chronological order.
+The deterministic prefilter is language-neutral and examines response shape,
+not request keywords: it selects an assistant response containing at least two
+Markdown or numbered list items, or one that introduces a numeric token not
+already present in the user request. The second-stage prompt makes the final
+semantic decision about whether the result is durable and reusable. A prose
+result without a list or a newly introduced number does not currently trigger
+the second stage. Eligible pairs are considered in chronological order within
+a private per-request pair and source-size budget. Candidates past that budget
+are omitted because assistant-result extraction is best effort.
 The selected pairs are combined into one second request that exposes only the
 private `memory_assistant_episode` tool. This tool is never visible to the
 application Agent. An application policy configured through `WithPrompt` or

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -351,6 +351,99 @@ continue, and the extraction watermark advances after the batch is processed.
 To roll back, remove the option or set it to `UpdatePolicyMergeSimilar`. No data
 migration is required.
 
+### Opt-in Assistant Episode Extraction
+
+Auto extraction normally uses the standard fact and episode tools. Applications
+that also need to recall reusable information from earlier assistant responses
+can enable assistant episode extraction when constructing the extractor:
+
+```go
+memExtractor := extractor.NewExtractor(
+    extractorModel,
+    extractor.WithAssistantEpisodeExtraction(),
+)
+memoryService := memoryinmemory.NewMemoryService(
+    memoryinmemory.WithExtractor(memExtractor),
+)
+```
+
+The option uses two isolated extraction stages. The first stage keeps the
+standard memory tools, restricted by `WithUpdatePolicy` and enabled-tool
+configuration when present, and extracts ordinary user facts and events from
+user messages. When collecting a session delta, the enabled option uses only
+the primary choice from each model response event; alternative choices are not
+treated as consecutive assistant replies. The extractor then considers
+eligible user/assistant pairs in the
+extraction delta in chronological order. The deterministic eligibility check
+accepts a structured request only when the assistant response contains at
+least two Markdown or numbered list items. It also accepts a quantitative
+question when the response introduces a numeric answer that is not already in
+the question. A single prose result, including a classification, translation,
+conversion, or summary, does not currently trigger the second stage unless it
+has the required list shape. Eligible pairs are considered in chronological
+order within a private per-request pair and source-size budget. Candidates past
+that budget are omitted because assistant-result extraction is best effort.
+The selected pairs are combined into one second request that exposes only the
+private `memory_assistant_episode` tool. This tool is never visible to the
+application Agent. An application policy configured through `WithPrompt` or
+`SetPrompt` also constrains the second-stage request. When the ordinary stage
+produces a Delete or Clear operation, assistant pairs at or before the user
+message that caused that operation are excluded. A later, independent pair can
+still enter the optional stage. If the destructive operation cannot be bound
+to a source message, the extractor conservatively skips the optional stage for
+that call. This decision uses request-local operation provenance rather than a
+language-specific interpretation of the conversation.
+
+Assistant output is stored as attributed conversation history rather than as a
+verified fact or user preference. The framework converts every accepted call
+to an ordinary `KindEpisode` add operation, fixes the participants to `User`
+and `Assistant`, and uses the extraction reference date as the event time when
+one is present. The textual prefix shown below is descriptive only; it does not
+grant special reconciliation behavior or carry trusted provenance. For example:
+
+```json
+{
+  "memory": "Assistant-provided conversation episode: When the user asked for compact-kitchen products, the assistant recommended Alpha and Beta.",
+  "kind": "episode",
+  "participants": ["User", "Assistant"]
+}
+```
+
+The second-stage model supplies only the episode text and optional retrieval
+topics. It cannot override the memory kind, participants, event time, or
+location. The framework rejects empty text, text over 4,096 bytes, and
+quantities that are not grounded in the selected conversation pair. Quantity
+validation preserves signs, currencies, percentages, and recognized units
+while accepting equivalent forms such as `$5` and `USD 5`. To bound each
+source's contribution to the optional request, every source message is
+represented by a deterministic 8,192-byte excerpt that preserves its beginning
+and end.
+
+The assistant request uses a child deadline that ends before the parent
+extraction deadline, reserving time to persist ordinary first-stage operations.
+If that child deadline expires, or if the optional request or its callbacks
+fail, the failure is logged and the ordinary operations are preserved. A true
+parent-context cancellation still aborts the complete extraction. Deterministic
+model-output rejections, such as invalid tool arguments, oversized text, or an
+ungrounded quantity, skip only the affected assistant episode. A rejected call
+for one pair does not discard valid calls for other pairs in the same response.
+
+This feature is backend-neutral. It does not add a memory kind, field, database
+column, table, or migration. Selected pairs in the same delta share one
+second-stage model request, so extraction uses at most two model calls per
+delta: one ordinary request and one assistant request. The option is fixed for
+the lifetime of the extractor and is captured by the Auto memory worker when it
+is constructed; it does not alter the extractor's descriptive `Metadata()`.
+To disable it, construct a new extractor and memory service without the option.
+A transparent decorator can preserve this setting by implementing
+`UnwrapMemoryExtractor() extractor.MemoryExtractor`. A custom extractor or
+non-cooperating decorator keeps ordinary single-stage extraction. Nil unwrap
+results and unwrap cycles also fall back to the disabled setting.
+Previously stored assistant episodes remain ordinary episodic memories and
+continue to participate in normal retrieval, extraction context, and
+reconciliation. Operations produced by the optional stage pass through the
+same selected update policy and reconciliation path as other memory operations.
+
 ### Configuration Comparison
 
 | Step                | Agentic Mode                        | Auto Mode                              |

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -387,12 +387,13 @@ The selected pairs are combined into one second request that exposes only the
 private `memory_assistant_episode` tool. This tool is never visible to the
 application Agent. An application policy configured through `WithPrompt` or
 `SetPrompt` also constrains the second-stage request. When the ordinary stage
-produces a Delete or Clear operation, assistant pairs at or before the user
-message that caused that operation are excluded. A later, independent pair can
-still enter the optional stage. If the destructive operation cannot be bound
-to a source message, the extractor conservatively skips the optional stage for
-that call. This decision uses request-local operation provenance rather than a
-language-specific interpretation of the conversation.
+produces a Clear operation, candidate pairs at or before its request-local
+`source_user_index` are excluded. A Delete operation excludes only the pairs
+explicitly listed in its request-local `affected_source_user_indexes`;
+unrelated pairs remain eligible. If a destructive operation has missing or
+invalid request-local scope, the extractor conservatively skips the optional
+stage for that call. This decision uses request-local operation provenance
+rather than a language-specific interpretation of the conversation.
 
 Assistant output is stored as attributed conversation history rather than as a
 verified fact or user preference. The framework converts every accepted call

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -369,8 +369,10 @@ memoryService := memoryinmemory.NewMemoryService(
 
 The option uses two isolated extraction stages. The first stage keeps the
 standard memory tools, restricted by `WithUpdatePolicy` and enabled-tool
-configuration when present, and extracts ordinary user facts and events from
-user messages. When collecting a session delta, the enabled option uses only
+configuration when present. It retains assistant turns as context for
+interpreting references, confirmations, and short user replies, but only user
+messages can supply or authorize ordinary memory operations. When collecting a
+session delta, the enabled option uses only
 the primary choice from each model response event; alternative choices are not
 treated as consecutive assistant replies. The extractor then considers
 eligible user/assistant pairs in the extraction delta in chronological order.
@@ -416,10 +418,11 @@ grant special reconciliation behavior or carry trusted provenance. For example:
 
 The second-stage model supplies only the episode text and optional retrieval
 topics. It cannot override the memory kind, participants, event time, or
-location. The framework rejects empty text, text over 4,096 bytes, and
-quantities that are not grounded in the selected conversation pair. Quantity
-validation preserves signs, currencies, percentages, and recognized units
-while accepting equivalent forms such as `$5` and `USD 5`. To bound each
+location. The framework rejects empty text, text over 4,096 bytes, and ASCII
+numeric values whose normalized value or adjacent sign, currency symbol, or
+percent sign is not grounded in the selected conversation pair. Natural-language
+units and currency labels are enforced by the second-stage prompt rather than
+the deterministic validator. To bound each
 source's contribution to the optional request, every source message is
 represented by a deterministic 8,192-byte excerpt that preserves its beginning
 and end.

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -380,7 +380,11 @@ Markdown or numbered list items, or one that introduces a numeric token not
 already present in the user request. The second-stage prompt makes the final
 semantic decision about whether the result is durable and reusable. A prose
 result without a list or a newly introduced number does not currently trigger
-the second stage. Eligible pairs are considered in chronological order within
+the second stage. Before storing a generated episode, a deterministic guard
+checks ASCII numbers and adjacent signs, currency symbols, and percent signs
+against the source response. Natural-language units and currency labels remain
+the responsibility of the second-stage prompt, which requires preserving them
+exactly. Eligible pairs are considered in chronological order within
 a private per-request pair and source-size budget. Candidates past that budget
 are omitted because assistant-result extraction is best effort.
 The selected pairs are combined into one second request that exposes only the

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -341,12 +341,12 @@ memoryService := memoryinmemory.NewMemoryService(
 配置了 `WithUpdatePolicy` 或 enabled tools，也会应用对应的工具约束，并且仅从
 user message 提取普通用户事实和事件。收集 session delta 时，功能开启后只使用每个
 模型响应事件的 primary choice，不会把同一响应的备选 choice 当作连续的 assistant
-回复。随后，提取器会按时间顺序检查当前
-extraction delta 中符合条件的 user/assistant pair。确定性的 eligibility 检查仅在
-assistant 返回至少两个 Markdown 或编号列表项时接受结构化请求；对于数量问题，
-则要求回答引入一个未出现在问题中的数值答案。单段 prose 形式的分类、翻译、转换
-或总结目前不会触发第二阶段，除非回答同时满足上述列表形态。Eligible pair 按时间
-顺序进入私有的单次请求 pair 数量和 source 体积预算；超出预算的候选会被忽略，因为
+回复。随后，提取器会按时间顺序检查当前 extraction delta 中符合条件的
+user/assistant pair。确定性预筛选与语言无关，只检查响应形态而不匹配请求关键词：
+assistant 响应包含至少两个 Markdown 或编号列表项，或者引入了 user 请求中没有的
+数值 token 时，该 pair 会进入第二阶段。第二阶段 prompt 再对结果是否持久、可复用
+作最终语义判断。没有列表或新数值的单段 prose 结果目前不会触发第二阶段。
+Eligible pair 按时间顺序进入私有的单次请求 pair 数量和 source 体积预算；超出预算的候选会被忽略，因为
 assistant 结果提取采用 best-effort 语义。入选的 pair 会合并到一次第二阶段请求中，
 并且只暴露私有的 `memory_assistant_episode` 工具。该工具不会暴露给应用的 Agent。
 通过 `WithPrompt` 或 `SetPrompt` 配置的应用提取约束同样适用于第二阶段请求。普通

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -346,6 +346,8 @@ user/assistant pair。确定性预筛选与语言无关，只检查响应形态�
 assistant 响应包含至少两个 Markdown 或编号列表项，或者引入了 user 请求中没有的
 数值 token 时，该 pair 会进入第二阶段。第二阶段 prompt 再对结果是否持久、可复用
 作最终语义判断。没有列表或新数值的单段 prose 结果目前不会触发第二阶段。
+写入生成的 episode 前，确定性护栏会将 ASCII 数字及其紧邻的正负号、货币符号和百分号
+与原始回答对照。自然语言单位和货币名称由第二阶段 prompt 负责，prompt 会要求按原文保留。
 Eligible pair 按时间顺序进入私有的单次请求 pair 数量和 source 体积预算；超出预算的候选会被忽略，因为
 assistant 结果提取采用 best-effort 语义。入选的 pair 会合并到一次第二阶段请求中，
 并且只暴露私有的 `memory_assistant_episode` 工具。该工具不会暴露给应用的 Agent。

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -338,8 +338,9 @@ memoryService := memoryinmemory.NewMemoryService(
 ```
 
 该 option 使用两个彼此隔离的提取阶段。第一阶段继续使用标准 memory tools；如果
-配置了 `WithUpdatePolicy` 或 enabled tools，也会应用对应的工具约束，并且仅从
-user message 提取普通用户事实和事件。收集 session delta 时，功能开启后只使用每个
+配置了 `WithUpdatePolicy` 或 enabled tools，也会应用对应的工具约束。Assistant
+消息会作为上下文保留，用于理解指代、确认和简短的 user 回复，但只有 user 消息
+能够提供或授权普通 memory operation。收集 session delta 时，功能开启后只使用每个
 模型响应事件的 primary choice，不会把同一响应的备选 choice 当作连续的 assistant
 回复。随后，提取器会按时间顺序检查当前 extraction delta 中符合条件的
 user/assistant pair。确定性预筛选与语言无关，只检查响应形态而不匹配请求关键词：
@@ -373,9 +374,10 @@ reconcile 行为。例如：
 ```
 
 第二阶段模型只能提供 episode 正文和可选的检索 topics，不能覆盖 memory kind、
-participants、event time 或 location。正文为空、超过 4,096 bytes，或包含无法在
-当前 conversation pair 中找到依据的数量时，调用会被拒绝。数量校验会保留正负号、
-币种、百分号和已识别单位，同时允许 `$5` 与 `USD 5` 等等价写法。为了限制每条
+participants、event time 或 location。正文为空、超过 4,096 bytes，或者 ASCII
+数值的规范化数值及紧邻的正负号、货币符号或百分号无法在当前 conversation pair 中
+找到依据时，调用会被拒绝。自然语言单位和货币名称由第二阶段 prompt 约束，不属于
+确定性校验器的检查范围。为了限制每条
 source message 对可选请求的体积贡献，每条消息都会被表示为确定性的 8,192-byte
 摘录，并保留首尾内容。
 

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -349,11 +349,12 @@ assistant 返回至少两个 Markdown 或编号列表项时接受结构化请求
 顺序进入私有的单次请求 pair 数量和 source 体积预算；超出预算的候选会被忽略，因为
 assistant 结果提取采用 best-effort 语义。入选的 pair 会合并到一次第二阶段请求中，
 并且只暴露私有的 `memory_assistant_episode` 工具。该工具不会暴露给应用的 Agent。
-通过 `WithPrompt` 或 `SetPrompt` 配置的应用提取约束同样适用于第二阶段请求。当
-普通阶段产生 Delete 或 Clear operation 时，触发该 operation 的 user message 及其
-之前的 assistant pair 会被排除；之后独立出现的新 pair 仍可进入可选阶段。如果
-破坏性 operation 无法绑定到来源消息，提取器会保守地跳过本次可选阶段。该判断使用
-请求内的 operation 来源信息，不依赖针对特定语言的对话意图解析。
+通过 `WithPrompt` 或 `SetPrompt` 配置的应用提取约束同样适用于第二阶段请求。普通
+阶段产生 Clear operation 时，其请求内 `source_user_index` 对应位置及之前的候选 pair
+会被排除。Delete operation 只排除请求内 `affected_source_user_indexes` 明确列出的
+pair，不影响无关 pair。如果破坏性 operation 的请求内作用范围缺失或非法，提取器会
+保守地跳过本次可选阶段。该判断使用请求内的 operation 来源信息，不依赖针对特定
+语言的对话意图解析。
 
 Assistant 输出会被记录为“带归属的对话历史”，而不是已经验证的事实或用户偏好。
 框架将每个通过校验的调用固定转换为普通 `KindEpisode` add 操作，将 participants

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -321,6 +321,80 @@ best-effort 持久化行为：单个写入失败会记录日志，后续 operati
 
 回退时删除该 option，或将其设置为 `UpdatePolicyMergeSimilar` 即可，不需要数据迁移。
 
+### 可选的 Assistant Episode 提取
+
+Auto extraction 默认使用标准 fact 和 episode 工具。如果应用还需要在后续对话中
+召回 assistant 曾经提供的可复用信息，可以在构造 extractor 时显式开启 assistant
+episode 提取：
+
+```go
+memExtractor := extractor.NewExtractor(
+    extractorModel,
+    extractor.WithAssistantEpisodeExtraction(),
+)
+memoryService := memoryinmemory.NewMemoryService(
+    memoryinmemory.WithExtractor(memExtractor),
+)
+```
+
+该 option 使用两个彼此隔离的提取阶段。第一阶段继续使用标准 memory tools；如果
+配置了 `WithUpdatePolicy` 或 enabled tools，也会应用对应的工具约束，并且仅从
+user message 提取普通用户事实和事件。收集 session delta 时，功能开启后只使用每个
+模型响应事件的 primary choice，不会把同一响应的备选 choice 当作连续的 assistant
+回复。随后，提取器会按时间顺序检查当前
+extraction delta 中符合条件的 user/assistant pair。确定性的 eligibility 检查仅在
+assistant 返回至少两个 Markdown 或编号列表项时接受结构化请求；对于数量问题，
+则要求回答引入一个未出现在问题中的数值答案。单段 prose 形式的分类、翻译、转换
+或总结目前不会触发第二阶段，除非回答同时满足上述列表形态。Eligible pair 按时间
+顺序进入私有的单次请求 pair 数量和 source 体积预算；超出预算的候选会被忽略，因为
+assistant 结果提取采用 best-effort 语义。入选的 pair 会合并到一次第二阶段请求中，
+并且只暴露私有的 `memory_assistant_episode` 工具。该工具不会暴露给应用的 Agent。
+通过 `WithPrompt` 或 `SetPrompt` 配置的应用提取约束同样适用于第二阶段请求。当
+普通阶段产生 Delete 或 Clear operation 时，触发该 operation 的 user message 及其
+之前的 assistant pair 会被排除；之后独立出现的新 pair 仍可进入可选阶段。如果
+破坏性 operation 无法绑定到来源消息，提取器会保守地跳过本次可选阶段。该判断使用
+请求内的 operation 来源信息，不依赖针对特定语言的对话意图解析。
+
+Assistant 输出会被记录为“带归属的对话历史”，而不是已经验证的事实或用户偏好。
+框架将每个通过校验的调用固定转换为普通 `KindEpisode` add 操作，将 participants
+设置为 `User` 和 `Assistant`；如果 extraction context 带有 reference date，则将其
+作为 event time。下面的正文前缀只用于描述，不承载可信来源，也不会赋予特殊的
+reconcile 行为。例如：
+
+```json
+{
+  "memory": "Assistant-provided conversation episode: 当用户询问适合紧凑厨房的产品时，assistant 推荐了 Alpha 和 Beta。",
+  "kind": "episode",
+  "participants": ["User", "Assistant"]
+}
+```
+
+第二阶段模型只能提供 episode 正文和可选的检索 topics，不能覆盖 memory kind、
+participants、event time 或 location。正文为空、超过 4,096 bytes，或包含无法在
+当前 conversation pair 中找到依据的数量时，调用会被拒绝。数量校验会保留正负号、
+币种、百分号和已识别单位，同时允许 `$5` 与 `USD 5` 等等价写法。为了限制每条
+source message 对可选请求的体积贡献，每条消息都会被表示为确定性的 8,192-byte
+摘录，并保留首尾内容。
+
+Assistant 请求使用早于父 extraction deadline 结束的子 deadline，为第一阶段普通
+operation 的持久化预留时间。子 deadline 到期、可选请求失败或 callback 失败都只会
+记录日志，并保留第一阶段已经生成的普通 operation；只有父 context 真正取消时才会
+中止整个提取。工具参数非法、正文过长或数量缺少依据等确定性模型输出拒绝只跳过对应
+的 assistant episode；同一响应中某一 pair 的无效调用不会丢弃其他 pair 的有效调用。
+
+该功能与存储后端无关，不会新增 memory kind、字段、数据库列、数据表或迁移。同一
+delta 中入选的 pair 共用一次第二阶段模型请求，因此每个 delta 最多调用模型两次：
+一次普通提取和一次 assistant 提取。普通对话仍只有一次
+extraction 调用。该 option 在 extractor 生命周期内不可修改，并由 Auto memory
+worker 在构造时读取和固定；它不会改变 extractor 的描述性 `Metadata()`。需要关闭
+时，应重新构造未传入该 option 的 extractor 和 memory service。透明 decorator
+可以实现 `UnwrapMemoryExtractor() extractor.MemoryExtractor` 以保留此配置；自定义
+extractor 或不合作的 decorator 使用普通单阶段提取。返回 nil 或形成循环的 unwrap
+也会安全回退为关闭状态。此前已经
+保存的 assistant episode 仍是普通 episodic memory，会继续参与正常检索、提取上下文
+和 reconcile。可选阶段产生的 operation 与其他 memory operation 一样，经过所选
+update policy 和 reconcile 路径。
+
 ### 两种模式配置对比
 
 | 步骤         | 工具驱动模式（Agentic）             | 自动提取模式（Auto）                   |

--- a/examples/memory/auto/README.md
+++ b/examples/memory/auto/README.md
@@ -247,6 +247,8 @@ memoryService := memoryinmemory.NewMemoryService(
 | `-debug`     | Enable debug mode to print messages sent to model                         | `false`          |
 | `-knowledge` | Enable a small local knowledge base with `knowledge_search`                | `false`          |
 | `-disable-auto-memory-on-external-context` | Stop future auto-memory extraction after `knowledge_search` is used | `false` |
+| `-update-policy` | Update policy: `merge_similar`, `preserve_history`, or `append_only` | `merge_similar` |
+| `-assistant-episode` | Extract reusable assistant results as episode memories | `false` |
 
 ## Usage
 
@@ -264,6 +266,35 @@ go run .
 # Use different models for chat and extraction.
 go run . -model gpt-4o -ext-model gpt-4o-mini
 ```
+
+Model names beginning with `glm` automatically use the OpenAI client's GLM
+compatibility variant.
+
+### Update Policies
+
+The default `merge_similar` policy preserves the existing auto-memory
+behavior. The other policies are opt-in:
+
+```bash
+# Preserve older facts and update only for safe, non-conflicting enrichment.
+go run . -update-policy preserve_history
+
+# Keep non-duplicate extracted memories as independent entries.
+go run . -update-policy append_only
+```
+
+Assistant episode extraction is also opt-in and can be combined with any
+update policy:
+
+```bash
+go run . \
+  -update-policy preserve_history \
+  -assistant-episode
+```
+
+When enabled, reusable assistant-produced results such as recommendations,
+plans, and structured comparisons can be stored as ordinary episode memories.
+The memory schema and storage tables do not change.
 
 ### Memory Backend Configuration
 
@@ -351,6 +382,8 @@ Output:
 
 ```
 Usage of ./auto:
+  -assistant-episode
+        Extract reusable assistant results as episode memories
   -debug
         Enable debug mode to print messages sent to model
   -disable-auto-memory-on-external-context
@@ -365,6 +398,8 @@ Usage of ./auto:
         Model for chat responses (default "deepseek-v4-flash")
   -streaming
         Enable streaming mode for responses (default true)
+  -update-policy string
+        Memory update policy: merge_similar, preserve_history, or append_only (default "merge_similar")
 ```
 
 ## Chat Interface
@@ -379,6 +414,8 @@ Memory Service: inmemory
 Streaming: true
 Knowledge: false
 Disable Auto Memory On External Context: false
+Update Policy: merge_similar
+Assistant Episode Extraction: false
 ==================================================
 
 💡 Auto memory mode extracts user information automatically.

--- a/examples/memory/auto/main.go
+++ b/examples/memory/auto/main.go
@@ -81,10 +81,24 @@ var (
 		false,
 		"Stop future auto-memory extraction after knowledge_search is used",
 	)
+	updatePolicyFlag = flag.String(
+		"update-policy",
+		string(extractor.UpdatePolicyMergeSimilar),
+		"Memory update policy: merge_similar, preserve_history, or append_only",
+	)
+	assistantEpisode = flag.Bool(
+		"assistant-episode",
+		false,
+		"Extract reusable assistant results as episode memories",
+	)
 )
 
 func main() {
 	flag.Parse()
+	policy, err := parseUpdatePolicy(*updatePolicyFlag)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Println("🧠 Auto Memory Demo")
 	fmt.Printf("Chat Model: %s\n", *modelName)
@@ -98,6 +112,8 @@ func main() {
 	fmt.Printf("Streaming: %t\n", *streaming)
 	fmt.Printf("Knowledge: %t\n", *enableKnowledge)
 	fmt.Printf("Disable Auto Memory On External Context: %t\n", *disableAutoMemoryOnExternalContext)
+	fmt.Printf("Update Policy: %s\n", policy)
+	fmt.Printf("Assistant Episode Extraction: %t\n", *assistantEpisode)
 	fmt.Println(strings.Repeat("=", 50))
 	fmt.Println()
 	fmt.Println("💡 Auto memory mode extracts user information automatically.")
@@ -114,6 +130,8 @@ func main() {
 		debug:                              *debug,
 		enableKnowledge:                    *enableKnowledge,
 		disableAutoMemoryOnExternalContext: *disableAutoMemoryOnExternalContext,
+		updatePolicy:                       policy,
+		assistantEpisode:                   *assistantEpisode,
 	}
 
 	if err := chat.run(); err != nil {
@@ -131,11 +149,33 @@ type autoMemoryChat struct {
 	debug                              bool
 	enableKnowledge                    bool
 	disableAutoMemoryOnExternalContext bool
+	updatePolicy                       extractor.UpdatePolicy
+	assistantEpisode                   bool
 	runner                             runner.Runner
 	memoryService                      memory.Service
 	sessionService                     session.Service
 	userID                             string
 	sessionID                          string
+}
+
+func parseUpdatePolicy(value string) (extractor.UpdatePolicy, error) {
+	policy := extractor.UpdatePolicy(value)
+	switch policy {
+	case extractor.UpdatePolicyMergeSimilar,
+		extractor.UpdatePolicyPreserveHistory,
+		extractor.UpdatePolicyAppendOnly:
+		return policy, nil
+	default:
+		return "", fmt.Errorf("unsupported update policy %q", value)
+	}
+}
+
+func newOpenAIModel(name string) *openai.Model {
+	options := []openai.Option{}
+	if strings.HasPrefix(strings.ToLower(name), "glm") {
+		options = append(options, openai.WithVariant(openai.VariantGLM))
+	}
+	return openai.New(name, options...)
 }
 
 // run starts the interactive chat session.
@@ -249,28 +289,21 @@ func deterministicEmbedding(text string) []float64 {
 // setup creates the runner with LLM agent and auto memory extraction.
 func (c *autoMemoryChat) setup(ctx context.Context) error {
 	// Create models.
-	chatModel := openai.New(c.modelName)
-	extractModel := openai.New(c.extractorModel)
+	chatModel := newOpenAIModel(c.modelName)
+	extractModel := newOpenAIModel(c.extractorModel)
 
-	// Create memory extractor with optional extraction checkers.
-	// The extractor uses LLM to analyze conversations and extract memories.
-	// Checkers control when extraction should be triggered.
-	memExtractor := extractor.NewExtractor(
-		extractModel,
-		// Optional: configure extraction checkers.
-		// By default, extraction happens on every turn.
-		// Use checkers to control extraction frequency:
-		//
-		// Example 1: Extract when messages > 5 OR every 3 minutes (OR logic).
-		// extractor.WithCheckersAny(
-		//     extractor.CheckMessageThreshold(5),
-		//     extractor.CheckTimeInterval(3*time.Minute),
-		// ),
-		//
-		// Example 2: Extract when messages > 10 AND every 5 minutes (AND logic).
-		// extractor.WithChecker(extractor.CheckMessageThreshold(10)),
-		// extractor.WithChecker(extractor.CheckTimeInterval(5*time.Minute)),
-	)
+	// Create the extractor with the selected opt-in behavior. Extraction
+	// checkers can be appended here to control extraction frequency.
+	extractorOptions := []extractor.Option{
+		extractor.WithUpdatePolicy(c.updatePolicy),
+	}
+	if c.assistantEpisode {
+		extractorOptions = append(
+			extractorOptions,
+			extractor.WithAssistantEpisodeExtraction(),
+		)
+	}
+	memExtractor := extractor.NewExtractor(extractModel, extractorOptions...)
 
 	// Create memory service with auto extraction enabled.
 	// When extractor is set, write tools (add/update/delete) are hidden, but

--- a/memory/extractor/assistant.go
+++ b/memory/extractor/assistant.go
@@ -27,11 +27,12 @@ import (
 )
 
 const (
-	assistantEpisodeToolName       = "memory_assistant_episode"
-	assistantEpisodePairIDKey      = "pair_id"
-	assistantEpisodeSourceIndexKey = "source_user_index"
-	assistantEpisodeMaxBytes       = 4096
-	assistantEpisodeSourceMaxBytes = 8192
+	assistantEpisodeToolName                 = "memory_assistant_episode"
+	assistantEpisodePairIDKey                = "pair_id"
+	assistantEpisodeSourceIndexKey           = "source_user_index"
+	assistantEpisodeAffectedSourceIndexesKey = "affected_source_user_indexes"
+	assistantEpisodeMaxBytes                 = 4096
+	assistantEpisodeSourceMaxBytes           = 8192
 	// These private limits bound the optional request; overflow is best effort.
 	assistantEpisodeRequestMaxPairs       = 32
 	assistantEpisodeRequestMaxSourceBytes = 64 * 1024
@@ -116,9 +117,10 @@ type assistantEpisodePair struct {
 }
 
 type assistantEpisodeOrdinaryResult struct {
-	operations               []*Operation
-	destructiveSourceIndex   int
-	destructiveSourceUnknown bool
+	operations              []*Operation
+	clearSourceIndex        int
+	deletedSourceIndexes    map[int]struct{}
+	destructiveScopeUnknown bool
 }
 
 type assistantEpisodeSource struct {
@@ -169,12 +171,13 @@ func (e *memoryExtractor) extractWithAssistantEpisodes(
 	if !e.assistantEpisodeAddEnabled() {
 		return ordinary.operations, nil
 	}
-	if ordinary.destructiveSourceUnknown {
+	if ordinary.destructiveScopeUnknown {
 		return ordinary.operations, nil
 	}
 	candidates := selectAssistantEpisodeCandidates(
 		messages,
-		ordinary.destructiveSourceIndex,
+		ordinary.clearSourceIndex,
+		ordinary.deletedSourceIndexes,
 	)
 	if len(candidates) == 0 {
 		return ordinary.operations, nil
@@ -221,10 +224,7 @@ func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
 	_, deleteEnabled := ordinaryTools[memory.DeleteToolName]
 	_, clearEnabled := ordinaryTools[memory.ClearToolName]
 	trackDestructiveSource := deleteEnabled || clearEnabled
-	ordinaryMessages := assistantEpisodeUserMessages(
-		messages,
-		trackDestructiveSource,
-	)
+	ordinaryMessages := assistantEpisodeUserMessages(messages)
 	nextCtx := ctx
 	if len(ordinaryMessages) > 0 {
 		if trackDestructiveSource {
@@ -248,14 +248,29 @@ func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
 			func(callCtx context.Context, call model.ToolCall) {
 				if op := ordinaryExtractor.parseToolCall(callCtx, call); op != nil {
 					result.operations = append(result.operations, op)
-					if op.Type == OperationDelete || op.Type == OperationClear {
+					switch op.Type {
+					case OperationClear:
 						sourceIndex, ok := assistantEpisodeOperationSourceIndex(
 							call, len(ordinaryMessages),
 						)
 						if !ok {
-							result.destructiveSourceUnknown = true
-						} else if sourceIndex > result.destructiveSourceIndex {
-							result.destructiveSourceIndex = sourceIndex
+							result.destructiveScopeUnknown = true
+						} else if sourceIndex > result.clearSourceIndex {
+							result.clearSourceIndex = sourceIndex
+						}
+					case OperationDelete:
+						indexes, ok := assistantEpisodeDeleteSourceIndexes(
+							call, len(ordinaryMessages),
+						)
+						if !ok {
+							result.destructiveScopeUnknown = true
+							break
+						}
+						if result.deletedSourceIndexes == nil {
+							result.deletedSourceIndexes = make(map[int]struct{})
+						}
+						for _, index := range indexes {
+							result.deletedSourceIndexes[index] = struct{}{}
 						}
 					}
 				}
@@ -270,12 +285,16 @@ func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
 
 func selectAssistantEpisodeCandidates(
 	messages []model.Message,
-	destructiveSourceIndex int,
+	clearSourceIndex int,
+	deletedSourceIndexes map[int]struct{},
 ) []assistantEpisodePair {
 	pairs := selectAssistantEpisodePairs(messages)
 	candidates := make([]assistantEpisodePair, 0, len(pairs))
 	for _, pair := range pairs {
-		if pair.userIndex <= destructiveSourceIndex {
+		if pair.userIndex <= clearSourceIndex {
+			continue
+		}
+		if _, deleted := deletedSourceIndexes[pair.userIndex]; deleted {
 			continue
 		}
 		if !strongAssistantEpisodeCandidate(
@@ -504,21 +523,10 @@ func eligibleAssistantEpisodeMessage(message model.Message, role model.Role) boo
 		len(message.ToolCalls) == 0 && assistantEpisodeMessageText(message) != ""
 }
 
-func assistantEpisodeUserMessages(
-	messages []model.Message,
-	includeSourceIndex bool,
-) []model.Message {
+func assistantEpisodeUserMessages(messages []model.Message) []model.Message {
 	result := make([]model.Message, 0, len(messages))
 	for _, message := range messages {
 		if eligibleAssistantEpisodeMessage(message, model.RoleUser) {
-			if includeSourceIndex {
-				message.Content = fmt.Sprintf(
-					"[%s=%d]\n%s",
-					assistantEpisodeSourceIndexKey,
-					len(result)+1,
-					message.Content,
-				)
-			}
 			result = append(result, message)
 		}
 	}

--- a/memory/extractor/assistant.go
+++ b/memory/extractor/assistant.go
@@ -50,22 +50,6 @@ const (
 )
 
 var (
-	assistantEpisodeListItemPattern = regexp.MustCompile(
-		`(?m)^\s*(?:[-*•]\s+|\d{1,2}[.)]\s+)\S`,
-	)
-	assistantEpisodeStructuredRequestPattern = regexp.MustCompile(
-		`(?i)\b(?:recommend(?:ation)?s?|suggest(?:ion)?s?|examples?|list|` +
-			`options?|choices?|give\s+me|show\s+me|what\s+(?:are|were)|` +
-			`extract|identify|predict|classif(?:y|ication)|summari[sz]e|` +
-			`translate|convert)\b|` +
-			`推荐|建议|示例|例子|列出|清单|选项|有哪些|提取|识别|分类|总结|翻译|转换`,
-	)
-	assistantEpisodeQuantityRequestPattern = regexp.MustCompile(
-		`(?i)\b(?:how\s+(?:many|much|long|often)|` +
-			`what\s+(?:number|amount|duration|percentage|percent))\b|` +
-			`多少|几次|多久|多长|百分之`,
-	)
-	assistantEpisodeNumberPattern   = regexp.MustCompile(`\b\d+(?:[.,]\d+)*(?:%|\b)`)
 	assistantEpisodeQuantityPattern = regexp.MustCompile(
 		`(?i)([+\-−]?)(?:((?:` + assistantEpisodeCurrencyPattern + `))[ \t]*)?` +
 			`([+\-−]?)([0-9]+(?:[.,][0-9]+)*)` +
@@ -599,23 +583,110 @@ func trimSplitUTF8Start(text string, start int) int {
 }
 
 func strongAssistantEpisodeCandidate(userText, assistantText string) bool {
-	if assistantEpisodeStructuredRequestPattern.MatchString(userText) &&
-		len(assistantEpisodeListItemPattern.FindAllStringIndex(assistantText, 3)) >= 2 {
+	if assistantEpisodeListItemCount(assistantText, 2) >= 2 {
 		return true
 	}
-	if !assistantEpisodeQuantityRequestPattern.MatchString(userText) {
-		return false
-	}
-	userNumbers := make(map[string]struct{})
-	for _, value := range assistantEpisodeNumberPattern.FindAllString(userText, -1) {
-		userNumbers[value] = struct{}{}
-	}
-	for _, value := range assistantEpisodeNumberPattern.FindAllString(assistantText, -1) {
+	userNumbers := assistantEpisodeNumericTokens(userText)
+	for value := range assistantEpisodeNumericTokens(assistantText) {
 		if _, ok := userNumbers[value]; !ok {
 			return true
 		}
 	}
 	return false
+}
+
+func assistantEpisodeListItemCount(text string, limit int) int {
+	count := 0
+	for _, line := range strings.Split(text, "\n") {
+		if !assistantEpisodeListItem(line) {
+			continue
+		}
+		count++
+		if count >= limit {
+			return count
+		}
+	}
+	return count
+}
+
+func assistantEpisodeListItem(line string) bool {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return false
+	}
+
+	runes := []rune(line)
+	markerEnd := 0
+	switch runes[0] {
+	case '-', '*', '+', '•':
+		markerEnd = 1
+	default:
+		for markerEnd < len(runes) && unicode.IsDigit(runes[markerEnd]) {
+			markerEnd++
+		}
+		if markerEnd == 0 || markerEnd > 2 || markerEnd >= len(runes) ||
+			(runes[markerEnd] != '.' && runes[markerEnd] != ')') {
+			return false
+		}
+		markerEnd++
+	}
+
+	if markerEnd >= len(runes) || !unicode.IsSpace(runes[markerEnd]) {
+		return false
+	}
+	return strings.TrimSpace(string(runes[markerEnd+1:])) != ""
+}
+
+func assistantEpisodeNumericTokens(text string) map[string]struct{} {
+	runes := []rune(text)
+	tokens := make(map[string]struct{})
+	for i := 0; i < len(runes); {
+		if !unicode.IsDigit(runes[i]) {
+			i++
+			continue
+		}
+		start := i
+		i++
+		for i < len(runes) {
+			if unicode.IsDigit(runes[i]) {
+				i++
+				continue
+			}
+			if assistantEpisodeNumberSeparator(runes[i]) && i+1 < len(runes) &&
+				unicode.IsDigit(runes[i+1]) {
+				i++
+				continue
+			}
+			break
+		}
+		if assistantEpisodeNumberedListMarker(runes, start, i) {
+			continue
+		}
+		if i < len(runes) && (runes[i] == '%' || runes[i] == '％') {
+			i++
+		}
+		tokens[string(runes[start:i])] = struct{}{}
+	}
+	return tokens
+}
+
+func assistantEpisodeNumberedListMarker(runes []rune, start, end int) bool {
+	for i := start - 1; i >= 0 && runes[i] != '\n'; i-- {
+		if !unicode.IsSpace(runes[i]) {
+			return false
+		}
+	}
+	return end+1 < len(runes) && (runes[end] == '.' || runes[end] == ')') &&
+		unicode.IsSpace(runes[end+1])
+}
+
+func assistantEpisodeNumberSeparator(value rune) bool {
+	switch value {
+	case '.', ',', '．', '，', '٫', '٬':
+		return true
+	default:
+		return false
+	}
 }
 
 func validateAssistantEpisodeQuantities(memoryText, source string) error {

--- a/memory/extractor/assistant.go
+++ b/memory/extractor/assistant.go
@@ -39,60 +39,12 @@ const (
 	assistantEpisodeDeadlineReserve       = 5 * time.Second
 	assistantEpisodePrefix                = assistantmemory.Prefix
 	assistantEpisodeTruncationMarker      = "\n...[truncated]...\n"
-	assistantEpisodeCurrencyPattern       = `[$€£¥]|USD|EUR|GBP|JPY|CNY|RMB`
-	assistantEpisodeUnitPattern           = `percent(?:age)?|%|°[ \t]*(?:C|F|K)|` +
-		`kilograms?|milligrams?|grams?|pounds?|` +
-		`kilometers?|kilometres?|miles?|` +
-		`centimeters?|centimetres?|millimeters?|millimetres?|` +
-		`meters?|metres?|milliliters?|millilitres?|liters?|litres?|` +
-		`hours?|minutes?|seconds?|days?|weeks?|months?|years?|` +
-		`kgs?|mg|lbs?|km|cm|mm|ml|hrs?|mins?|min|secs?|mi|g|l|h|s|m`
 )
 
-var (
-	assistantEpisodeQuantityPattern = regexp.MustCompile(
-		`(?i)([+\-−]?)(?:((?:` + assistantEpisodeCurrencyPattern + `))[ \t]*)?` +
-			`([+\-−]?)([0-9]+(?:[.,][0-9]+)*)` +
-			`(?:[ \t]*((?:` + assistantEpisodeCurrencyPattern + `)|` +
-			`(?:` + assistantEpisodeUnitPattern + `)` +
-			`(?:[ \t]*/[ \t]*(?:` + assistantEpisodeUnitPattern + `))?))?`,
-	)
-	assistantEpisodeUnitAliases = buildAssistantEpisodeUnitAliases()
+var assistantEpisodeNumberPattern = regexp.MustCompile(
+	`([+\-−]?)(?:([$€£¥])[ \t]*)?([+\-−]?)([0-9]+(?:[.,][0-9]+)*)` +
+		`(?:[ \t]*([$€£¥]))?[ \t]*([%％]?)`,
 )
-
-func buildAssistantEpisodeUnitAliases() map[string]string {
-	groups := map[string][]string{
-		"%":     {"%", "percent", "percentage"},
-		"°c":    {"°c"},
-		"°f":    {"°f"},
-		"°k":    {"°k"},
-		"kg":    {"kg", "kgs", "kilogram", "kilograms"},
-		"mg":    {"mg", "milligram", "milligrams"},
-		"g":     {"g", "gram", "grams"},
-		"lb":    {"lb", "lbs", "pound", "pounds"},
-		"km":    {"km", "kilometer", "kilometers", "kilometre", "kilometres"},
-		"mi":    {"mi", "mile", "miles"},
-		"cm":    {"cm", "centimeter", "centimeters", "centimetre", "centimetres"},
-		"mm":    {"mm", "millimeter", "millimeters", "millimetre", "millimetres"},
-		"m":     {"m", "meter", "meters", "metre", "metres"},
-		"ml":    {"ml", "milliliter", "milliliters", "millilitre", "millilitres"},
-		"l":     {"l", "liter", "liters", "litre", "litres"},
-		"h":     {"h", "hr", "hrs", "hour", "hours"},
-		"min":   {"min", "mins", "minute", "minutes"},
-		"s":     {"s", "sec", "secs", "second", "seconds"},
-		"day":   {"day", "days"},
-		"week":  {"week", "weeks"},
-		"month": {"month", "months"},
-		"year":  {"year", "years"},
-	}
-	aliases := make(map[string]string)
-	for canonical, names := range groups {
-		for _, name := range names {
-			aliases[name] = canonical
-		}
-	}
-	return aliases
-}
 
 type assistantEpisodePair struct {
 	user      model.Message
@@ -113,11 +65,11 @@ type assistantEpisodeSource struct {
 	assistantText string
 }
 
-type assistantEpisodeQuantity struct {
+type assistantEpisodeNumber struct {
 	sign     string
 	value    string
-	unit     string
 	currency string
+	percent  bool
 }
 
 // WithAssistantEpisodeExtraction enables extraction of reusable assistant
@@ -443,7 +395,7 @@ func (e *memoryExtractor) parseAssistantEpisode(
 	if len(memoryText) > assistantEpisodeMaxBytes {
 		return nil, fmt.Errorf("assistant episode exceeds %d bytes", assistantEpisodeMaxBytes)
 	}
-	if err := validateAssistantEpisodeQuantities(memoryText, source); err != nil {
+	if err := validateAssistantEpisodeNumbers(memoryText, source); err != nil {
 		return nil, err
 	}
 	op := &Operation{
@@ -689,85 +641,72 @@ func assistantEpisodeNumberSeparator(value rune) bool {
 	}
 }
 
-func validateAssistantEpisodeQuantities(memoryText, source string) error {
-	sourceQuantities := make(map[assistantEpisodeQuantity]struct{})
-	for _, quantity := range assistantEpisodeQuantities(source) {
-		sourceQuantities[quantity] = struct{}{}
+func validateAssistantEpisodeNumbers(memoryText, source string) error {
+	sourceNumbers := make(map[assistantEpisodeNumber]struct{})
+	for _, number := range assistantEpisodeNumbers(source) {
+		sourceNumbers[number] = struct{}{}
 	}
-	for _, quantity := range assistantEpisodeQuantities(memoryText) {
-		if _, ok := sourceQuantities[quantity]; !ok {
+	for _, number := range assistantEpisodeNumbers(memoryText) {
+		if _, ok := sourceNumbers[number]; !ok {
 			return fmt.Errorf(
-				"assistant episode quantity %q is not present in the source",
-				formatAssistantEpisodeQuantity(quantity),
+				"assistant episode number %q is not present in the source",
+				formatAssistantEpisodeNumber(number),
 			)
 		}
 	}
 	return nil
 }
 
-func assistantEpisodeQuantities(text string) []assistantEpisodeQuantity {
-	matches := assistantEpisodeQuantityPattern.FindAllStringSubmatchIndex(text, -1)
-	quantities := make([]assistantEpisodeQuantity, 0, len(matches))
+func assistantEpisodeNumbers(text string) []assistantEpisodeNumber {
+	matches := assistantEpisodeNumberPattern.FindAllStringSubmatchIndex(text, -1)
+	numbers := make([]assistantEpisodeNumber, 0, len(matches))
 	for _, match := range matches {
-		quantity, ok := parseAssistantEpisodeQuantity(text, match)
+		number, ok := parseAssistantEpisodeNumber(text, match)
 		if ok {
-			quantities = append(quantities, quantity)
+			numbers = append(numbers, number)
 		}
 	}
-	return quantities
+	return numbers
 }
 
-func parseAssistantEpisodeQuantity(
+func parseAssistantEpisodeNumber(
 	text string,
 	match []int,
-) (assistantEpisodeQuantity, bool) {
-	if len(match) != 12 {
-		return assistantEpisodeQuantity{}, false
+) (assistantEpisodeNumber, bool) {
+	if len(match) != 14 {
+		return assistantEpisodeNumber{}, false
+	}
+	numberStart := match[8]
+	numberEnd := match[9]
+	if assistantEpisodeASCIIListMarker(text, numberStart, numberEnd) {
+		return assistantEpisodeNumber{}, false
 	}
 	sign := assistantEpisodeMatchGroup(text, match, 1) +
 		assistantEpisodeMatchGroup(text, match, 3)
-	prefix := assistantEpisodeMatchGroup(text, match, 2)
-	value := assistantEpisodeMatchGroup(text, match, 4)
-	suffix := assistantEpisodeMatchGroup(text, match, 5)
-	start := match[0]
-	end := match[1]
-	if suffix != "" && end < len(text) {
-		next, _ := utf8.DecodeRuneInString(text[end:])
-		last, _ := utf8.DecodeLastRuneInString(suffix)
-		if unicode.IsLetter(last) && assistantEpisodeIdentifierRune(next) {
-			// A short unit alternative can match the beginning of an ordinary
-			// word (for example, "m" in "meals"). Treat that case as an
-			// unqualified number instead of discarding the number entirely.
-			suffix = ""
-		}
+	currency := assistantEpisodeMatchGroup(text, match, 2)
+	suffixCurrency := assistantEpisodeMatchGroup(text, match, 5)
+	if suffixCurrency != "" && suffixCurrency != currency {
+		currency += suffixCurrency
 	}
-	if prefix == "" && sign != "" && start > 0 {
-		previous, _ := utf8.DecodeLastRuneInString(text[:start])
-		if unicode.IsDigit(previous) {
-			sign = ""
-		}
+	if currency == "" && sign != "" && match[0] > 0 &&
+		text[match[0]-1] >= '0' && text[match[0]-1] <= '9' {
+		sign = ""
 	}
-
-	prefixCurrency := normalizeAssistantEpisodeCurrency(prefix)
-	suffixCurrency := normalizeAssistantEpisodeCurrency(suffix)
-	currency := prefixCurrency
-	if suffixCurrency != "" {
-		if currency == "" {
-			currency = suffixCurrency
-		} else if currency != suffixCurrency {
-			currency += "/" + suffixCurrency
-		}
-	}
-	unit := ""
-	if suffixCurrency == "" {
-		unit = normalizeAssistantEpisodeUnit(suffix)
-	}
-	return assistantEpisodeQuantity{
+	return assistantEpisodeNumber{
 		sign:     strings.ReplaceAll(sign, "−", "-"),
-		value:    normalizeAssistantEpisodeNumber(value),
-		unit:     unit,
+		value:    normalizeAssistantEpisodeNumber(text[numberStart:numberEnd]),
 		currency: currency,
+		percent:  assistantEpisodeMatchGroup(text, match, 6) != "",
 	}, true
+}
+
+func assistantEpisodeASCIIListMarker(text string, start, end int) bool {
+	lineStart := strings.LastIndexByte(text[:start], '\n') + 1
+	if strings.TrimSpace(text[lineStart:start]) != "" || end+1 >= len(text) {
+		return false
+	}
+	return (text[end] == '.' || text[end] == ')') &&
+		(text[end+1] == ' ' || text[end+1] == '\t')
 }
 
 func assistantEpisodeMatchGroup(text string, match []int, group int) string {
@@ -777,10 +716,6 @@ func assistantEpisodeMatchGroup(text string, match []int, group int) string {
 		return ""
 	}
 	return text[start:end]
-}
-
-func assistantEpisodeIdentifierRune(value rune) bool {
-	return value == '_' || unicode.IsLetter(value) || unicode.IsDigit(value)
 }
 
 func normalizeAssistantEpisodeNumber(value string) string {
@@ -815,53 +750,17 @@ func normalizeAssistantEpisodeNumber(value string) string {
 	return integer + "." + fraction
 }
 
-func normalizeAssistantEpisodeCurrency(value string) string {
-	switch strings.ToUpper(strings.TrimSpace(value)) {
-	case "$", "USD":
-		return "usd"
-	case "€", "EUR":
-		return "eur"
-	case "£", "GBP":
-		return "gbp"
-	case "¥":
-		return "yen-yuan"
-	case "JPY":
-		return "jpy"
-	case "CNY", "RMB":
-		return "cny"
-	default:
-		return ""
-	}
-}
-
-func normalizeAssistantEpisodeUnit(value string) string {
-	normalized := strings.ToLower(strings.Join(strings.Fields(value), ""))
-	parts := strings.Split(normalized, "/")
-	if len(parts) == 1 {
-		return assistantEpisodeUnitAliases[normalized]
-	}
-	if len(parts) != 2 {
-		return ""
-	}
-	numerator := assistantEpisodeUnitAliases[parts[0]]
-	denominator := assistantEpisodeUnitAliases[parts[1]]
-	if numerator == "" || denominator == "" {
-		return ""
-	}
-	return numerator + "/" + denominator
-}
-
-func formatAssistantEpisodeQuantity(quantity assistantEpisodeQuantity) string {
+func formatAssistantEpisodeNumber(number assistantEpisodeNumber) string {
 	var builder strings.Builder
-	if quantity.currency != "" {
-		builder.WriteString(quantity.currency)
-		builder.WriteByte(' ')
+	if number.sign != "" {
+		builder.WriteString(number.sign)
 	}
-	builder.WriteString(quantity.sign)
-	builder.WriteString(quantity.value)
-	if quantity.unit != "" {
-		builder.WriteByte(' ')
-		builder.WriteString(quantity.unit)
+	if number.currency != "" {
+		builder.WriteString(number.currency)
+	}
+	builder.WriteString(number.value)
+	if number.percent {
+		builder.WriteByte('%')
 	}
 	return builder.String()
 }
@@ -918,6 +817,8 @@ provided by the assistant as attributed conversation episodes.
   contains a durable, reusable result.
 - Preserve the paired user request and the assistant's exact material result,
   including names, quantities, dates, durations, negation, and qualifications.
+- Preserve units and currency labels exactly as written. Do not translate,
+  expand, abbreviate, infer, or convert them.
 - Preserve item-to-detail relationships in lists and procedures.
 - Record attributed conversation history, not verified truth or a user fact.
 - Skip acknowledgments, refusals, follow-up questions, generic explanations,

--- a/memory/extractor/assistant.go
+++ b/memory/extractor/assistant.go
@@ -1,0 +1,845 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package extractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/internal/assistantmemory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	assistantEpisodeToolName       = "memory_assistant_episode"
+	assistantEpisodePairIDKey      = "pair_id"
+	assistantEpisodeSourceIndexKey = "source_user_index"
+	assistantEpisodeMaxBytes       = 4096
+	assistantEpisodeSourceMaxBytes = 8192
+	// These private limits bound the optional request; overflow is best effort.
+	assistantEpisodeRequestMaxPairs       = 32
+	assistantEpisodeRequestMaxSourceBytes = 64 * 1024
+	assistantEpisodeDeadlineReserve       = 5 * time.Second
+	assistantEpisodePrefix                = assistantmemory.Prefix
+	assistantEpisodeTruncationMarker      = "\n...[truncated]...\n"
+	assistantEpisodeCurrencyPattern       = `[$€£¥]|USD|EUR|GBP|JPY|CNY|RMB`
+	assistantEpisodeUnitPattern           = `percent(?:age)?|%|°[ \t]*(?:C|F|K)|` +
+		`kilograms?|milligrams?|grams?|pounds?|` +
+		`kilometers?|kilometres?|miles?|` +
+		`centimeters?|centimetres?|millimeters?|millimetres?|` +
+		`meters?|metres?|milliliters?|millilitres?|liters?|litres?|` +
+		`hours?|minutes?|seconds?|days?|weeks?|months?|years?|` +
+		`kgs?|mg|lbs?|km|cm|mm|ml|hrs?|mins?|min|secs?|mi|g|l|h|s|m`
+)
+
+var (
+	assistantEpisodeListItemPattern = regexp.MustCompile(
+		`(?m)^\s*(?:[-*•]\s+|\d{1,2}[.)]\s+)\S`,
+	)
+	assistantEpisodeStructuredRequestPattern = regexp.MustCompile(
+		`(?i)\b(?:recommend(?:ation)?s?|suggest(?:ion)?s?|examples?|list|` +
+			`options?|choices?|give\s+me|show\s+me|what\s+(?:are|were)|` +
+			`extract|identify|predict|classif(?:y|ication)|summari[sz]e|` +
+			`translate|convert)\b|` +
+			`推荐|建议|示例|例子|列出|清单|选项|有哪些|提取|识别|分类|总结|翻译|转换`,
+	)
+	assistantEpisodeQuantityRequestPattern = regexp.MustCompile(
+		`(?i)\b(?:how\s+(?:many|much|long|often)|` +
+			`what\s+(?:number|amount|duration|percentage|percent))\b|` +
+			`多少|几次|多久|多长|百分之`,
+	)
+	assistantEpisodeNumberPattern   = regexp.MustCompile(`\b\d+(?:[.,]\d+)*(?:%|\b)`)
+	assistantEpisodeQuantityPattern = regexp.MustCompile(
+		`(?i)([+\-−]?)(?:((?:` + assistantEpisodeCurrencyPattern + `))[ \t]*)?` +
+			`([+\-−]?)([0-9]+(?:[.,][0-9]+)*)` +
+			`(?:[ \t]*((?:` + assistantEpisodeCurrencyPattern + `)|` +
+			`(?:` + assistantEpisodeUnitPattern + `)` +
+			`(?:[ \t]*/[ \t]*(?:` + assistantEpisodeUnitPattern + `))?))?`,
+	)
+	assistantEpisodeUnitAliases = buildAssistantEpisodeUnitAliases()
+)
+
+func buildAssistantEpisodeUnitAliases() map[string]string {
+	groups := map[string][]string{
+		"%":     {"%", "percent", "percentage"},
+		"°c":    {"°c"},
+		"°f":    {"°f"},
+		"°k":    {"°k"},
+		"kg":    {"kg", "kgs", "kilogram", "kilograms"},
+		"mg":    {"mg", "milligram", "milligrams"},
+		"g":     {"g", "gram", "grams"},
+		"lb":    {"lb", "lbs", "pound", "pounds"},
+		"km":    {"km", "kilometer", "kilometers", "kilometre", "kilometres"},
+		"mi":    {"mi", "mile", "miles"},
+		"cm":    {"cm", "centimeter", "centimeters", "centimetre", "centimetres"},
+		"mm":    {"mm", "millimeter", "millimeters", "millimetre", "millimetres"},
+		"m":     {"m", "meter", "meters", "metre", "metres"},
+		"ml":    {"ml", "milliliter", "milliliters", "millilitre", "millilitres"},
+		"l":     {"l", "liter", "liters", "litre", "litres"},
+		"h":     {"h", "hr", "hrs", "hour", "hours"},
+		"min":   {"min", "mins", "minute", "minutes"},
+		"s":     {"s", "sec", "secs", "second", "seconds"},
+		"day":   {"day", "days"},
+		"week":  {"week", "weeks"},
+		"month": {"month", "months"},
+		"year":  {"year", "years"},
+	}
+	aliases := make(map[string]string)
+	for canonical, names := range groups {
+		for _, name := range names {
+			aliases[name] = canonical
+		}
+	}
+	return aliases
+}
+
+type assistantEpisodePair struct {
+	user      model.Message
+	assistant model.Message
+	userIndex int
+}
+
+type assistantEpisodeOrdinaryResult struct {
+	operations               []*Operation
+	destructiveSourceIndex   int
+	destructiveSourceUnknown bool
+}
+
+type assistantEpisodeSource struct {
+	id            string
+	userText      string
+	assistantText string
+}
+
+type assistantEpisodeQuantity struct {
+	sign     string
+	value    string
+	unit     string
+	currency string
+}
+
+// WithAssistantEpisodeExtraction enables extraction of reusable assistant
+// responses as ordinary episodic memory. The setting is fixed when the
+// extractor is constructed. It does not add a memory kind or change storage
+// schemas.
+func WithAssistantEpisodeExtraction() Option {
+	return func(e *memoryExtractor) {
+		e.assistantEpisodeExtraction = true
+	}
+}
+
+// ConfiguredAssistantEpisodeExtraction carries the built-in extractor setting
+// through an internal-only capability used by the auto-memory worker.
+func (e *memoryExtractor) ConfiguredAssistantEpisodeExtraction() assistantmemory.Value {
+	return assistantmemory.Value(e.assistantEpisodeExtraction)
+}
+
+func (e *memoryExtractor) extractWithAssistantEpisodes(
+	ctx context.Context,
+	messages []model.Message,
+	existing []*memory.Entry,
+) ([]*Operation, error) {
+	if e.enabledTools != nil && len(e.enabledTools) == 0 {
+		return nil, nil
+	}
+	nextCtx, ordinary, err := e.extractAssistantEpisodeOrdinaryStage(
+		ctx,
+		messages,
+		existing,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !e.assistantEpisodeAddEnabled() {
+		return ordinary.operations, nil
+	}
+	if ordinary.destructiveSourceUnknown {
+		return ordinary.operations, nil
+	}
+	candidates := selectAssistantEpisodeCandidates(
+		messages,
+		ordinary.destructiveSourceIndex,
+	)
+	if len(candidates) == 0 {
+		return ordinary.operations, nil
+	}
+	candidates, skipped := boundAssistantEpisodeCandidates(candidates)
+	if skipped > 0 {
+		log.WarnfContext(
+			nextCtx,
+			"extractor: assistant episode request budget skipped %d of %d candidates",
+			skipped,
+			skipped+len(candidates),
+		)
+	}
+
+	assistantCallCtx, cancel := assistantEpisodeRequestContext(nextCtx)
+	defer cancel()
+	_, assistantOps, err := e.extractAssistantEpisodes(assistantCallCtx, candidates)
+	if err != nil {
+		if nextCtx.Err() != nil {
+			return nil, fmt.Errorf("extract assistant episodes: %w", err)
+		}
+		log.WarnfContext(
+			nextCtx,
+			"extractor: optional assistant episode extraction failed: %v",
+			err,
+		)
+		return ordinary.operations, nil
+	}
+	return append(ordinary.operations, assistantOps...), nil
+}
+
+func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
+	ctx context.Context,
+	messages []model.Message,
+	existing []*memory.Entry,
+) (context.Context, assistantEpisodeOrdinaryResult, error) {
+	var result assistantEpisodeOrdinaryResult
+	ordinaryExtractor := *e
+	ordinaryExtractor.assistantEpisodeExtraction = false
+	ordinaryTools := ordinaryExtractor.extractionTools()
+	if len(ordinaryTools) == 0 {
+		return ctx, result, nil
+	}
+	_, deleteEnabled := ordinaryTools[memory.DeleteToolName]
+	_, clearEnabled := ordinaryTools[memory.ClearToolName]
+	trackDestructiveSource := deleteEnabled || clearEnabled
+	ordinaryMessages := assistantEpisodeUserMessages(
+		messages,
+		trackDestructiveSource,
+	)
+	nextCtx := ctx
+	if len(ordinaryMessages) > 0 {
+		if trackDestructiveSource {
+			ordinaryTools = assistantEpisodeOrdinaryTools(
+				ordinaryTools,
+				len(ordinaryMessages),
+			)
+		}
+		req := &model.Request{
+			Messages: ordinaryExtractor.buildMessages(
+				ctx,
+				ordinaryMessages,
+				existing,
+			),
+			Tools: ordinaryTools,
+		}
+		var err error
+		nextCtx, err = ordinaryExtractor.runExtractionRequest(
+			ctx,
+			req,
+			func(callCtx context.Context, call model.ToolCall) {
+				if op := ordinaryExtractor.parseToolCall(callCtx, call); op != nil {
+					result.operations = append(result.operations, op)
+					if op.Type == OperationDelete || op.Type == OperationClear {
+						sourceIndex, ok := assistantEpisodeOperationSourceIndex(
+							call, len(ordinaryMessages),
+						)
+						if !ok {
+							result.destructiveSourceUnknown = true
+						} else if sourceIndex > result.destructiveSourceIndex {
+							result.destructiveSourceIndex = sourceIndex
+						}
+					}
+				}
+			},
+		)
+		if err != nil {
+			return nextCtx, result, err
+		}
+	}
+	return nextCtx, result, nil
+}
+
+func selectAssistantEpisodeCandidates(
+	messages []model.Message,
+	destructiveSourceIndex int,
+) []assistantEpisodePair {
+	pairs := selectAssistantEpisodePairs(messages)
+	candidates := make([]assistantEpisodePair, 0, len(pairs))
+	for _, pair := range pairs {
+		if pair.userIndex <= destructiveSourceIndex {
+			continue
+		}
+		if !strongAssistantEpisodeCandidate(
+			assistantEpisodeMessageText(pair.user),
+			assistantEpisodeMessageText(pair.assistant),
+		) {
+			continue
+		}
+		candidates = append(candidates, pair)
+	}
+	return candidates
+}
+
+func boundAssistantEpisodeCandidates(
+	pairs []assistantEpisodePair,
+) ([]assistantEpisodePair, int) {
+	limit := min(len(pairs), assistantEpisodeRequestMaxPairs)
+	bounded := make([]assistantEpisodePair, 0, limit)
+	sourceBytes := 0
+	for _, pair := range pairs[:limit] {
+		pairBytes := len(assistantEpisodeSourceExcerpt(
+			assistantEpisodeMessageText(pair.user),
+		)) + len(assistantEpisodeSourceExcerpt(
+			assistantEpisodeMessageText(pair.assistant),
+		))
+		if sourceBytes+pairBytes > assistantEpisodeRequestMaxSourceBytes {
+			break
+		}
+		bounded = append(bounded, pair)
+		sourceBytes += pairBytes
+	}
+	return bounded, len(pairs) - len(bounded)
+}
+
+func assistantEpisodeRequestContext(
+	ctx context.Context,
+) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return context.WithCancel(ctx)
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return context.WithDeadline(ctx, deadline)
+	}
+	reserve := min(assistantEpisodeDeadlineReserve, remaining/2)
+	return context.WithDeadline(ctx, deadline.Add(-reserve))
+}
+
+func (e *memoryExtractor) extractAssistantEpisodes(
+	ctx context.Context,
+	pairs []assistantEpisodePair,
+) (context.Context, []*Operation, error) {
+	sources := make([]assistantEpisodeSource, 0, len(pairs))
+	messages := make([]model.Message, 0, len(pairs)*2+2)
+	messages = append(messages, model.NewSystemMessage(e.assistantEpisodePrompt(ctx)))
+	for i, pair := range pairs {
+		source := assistantEpisodeSource{
+			id: fmt.Sprintf("pair-%d", i+1),
+			userText: assistantEpisodeSourceExcerpt(
+				assistantEpisodeMessageText(pair.user),
+			),
+			assistantText: assistantEpisodeSourceExcerpt(
+				assistantEpisodeMessageText(pair.assistant),
+			),
+		}
+		sources = append(sources, source)
+		messages = append(
+			messages,
+			model.NewUserMessage(source.id+" user request:\n"+source.userText),
+			model.NewAssistantMessage(source.id+" assistant response:\n"+source.assistantText),
+		)
+	}
+	messages = append(messages, model.NewUserMessage(
+		"Extract every eligible assistant result. Set pair_id to the pair label "+
+			"shown with its source, and call the tool at most once for each pair.",
+	))
+	sourceByID := make(map[string]assistantEpisodeSource, len(sources))
+	indexByID := make(map[string]int, len(sources))
+	for i, source := range sources {
+		sourceByID[source.id] = source
+		indexByID[source.id] = i
+	}
+	operations := make([]*Operation, len(sources))
+	seenIDs := make(map[string]struct{}, len(sources))
+	nextCtx, err := e.runExtractionRequest(ctx, &model.Request{
+		Messages: messages,
+		Tools: map[string]tool.Tool{
+			assistantEpisodeToolName: newAssistantEpisodeTool(sources),
+		},
+	}, func(callCtx context.Context, call model.ToolCall) {
+		if call.Function.Name != assistantEpisodeToolName {
+			return
+		}
+		var args map[string]any
+		if err := json.Unmarshal(call.Function.Arguments, &args); err != nil {
+			logAssistantEpisodeRejection(callCtx, "invalid tool arguments")
+			return
+		}
+		pairID, _ := args[assistantEpisodePairIDKey].(string)
+		source, ok := sourceByID[pairID]
+		if !ok {
+			logAssistantEpisodeRejection(callCtx, "unknown pair id")
+			return
+		}
+		if _, ok := seenIDs[pairID]; ok {
+			logAssistantEpisodeRejection(callCtx, "duplicate pair id")
+			return
+		}
+		operation, parseErr := e.parseAssistantEpisode(
+			callCtx,
+			args,
+			source.userText+"\n"+source.assistantText,
+		)
+		if parseErr != nil {
+			logAssistantEpisodeRejection(callCtx, "content validation failed")
+			return
+		}
+		seenIDs[pairID] = struct{}{}
+		operations[indexByID[pairID]] = operation
+	})
+	if err != nil {
+		return nextCtx, nil, err
+	}
+	result := make([]*Operation, 0, len(operations))
+	for _, operation := range operations {
+		if operation != nil {
+			result = append(result, operation)
+		}
+	}
+	return nextCtx, result, nil
+}
+
+func logAssistantEpisodeRejection(ctx context.Context, reason string) {
+	log.WarnfContext(ctx, "extractor: skipped invalid assistant episode: %s", reason)
+}
+
+func (e *memoryExtractor) assistantEpisodePrompt(ctx context.Context) string {
+	base := assistantEpisodeSystemPrompt
+	if e.prompt == defaultPrompt {
+		return base
+	}
+	return base + `
+
+The following application-defined extraction policy also applies to this
+request. If it conflicts with the assistant episode instructions, do not
+extract the conflicting information:
+
+` + e.renderPrompt(referenceDate(ctx))
+}
+
+func (e *memoryExtractor) parseAssistantEpisode(
+	ctx context.Context,
+	args map[string]any,
+	source string,
+) (*Operation, error) {
+	memoryText, _ := args[argKeyMemory].(string)
+	memoryText = strings.TrimSpace(memoryText)
+	if memoryText == "" {
+		return nil, errors.New("memory is required")
+	}
+	if len(memoryText) > assistantEpisodeMaxBytes {
+		return nil, fmt.Errorf("assistant episode exceeds %d bytes", assistantEpisodeMaxBytes)
+	}
+	if err := validateAssistantEpisodeQuantities(memoryText, source); err != nil {
+		return nil, err
+	}
+	op := &Operation{
+		Type:         OperationAdd,
+		Memory:       assistantmemory.Prefix + memoryText,
+		Topics:       toStringSlice(args[argKeyTopics]),
+		MemoryKind:   memory.KindEpisode,
+		Participants: []string{"User", "Assistant"},
+	}
+	if eventTime, ok := ReferenceDateFromContext(ctx); ok {
+		eventTime = eventTime.UTC()
+		op.EventTime = &eventTime
+	}
+	return op, nil
+}
+
+func selectAssistantEpisodePairs(messages []model.Message) []assistantEpisodePair {
+	pairs := make([]assistantEpisodePair, 0, len(messages)/2)
+	var pendingUser model.Message
+	var pendingAssistant model.Message
+	userIndex := 0
+	pendingUserIndex := 0
+	hasPendingUser := false
+	hasPendingAssistant := false
+	for _, message := range messages {
+		if message.Role == model.RoleUser {
+			if hasPendingUser && hasPendingAssistant {
+				pairs = append(pairs, assistantEpisodePair{
+					user:      pendingUser,
+					assistant: pendingAssistant,
+					userIndex: pendingUserIndex,
+				})
+			}
+			hasPendingUser = eligibleAssistantEpisodeMessage(message, model.RoleUser)
+			if hasPendingUser {
+				userIndex++
+				pendingUser = message
+				pendingUserIndex = userIndex
+			}
+			hasPendingAssistant = false
+			continue
+		}
+		if !eligibleAssistantEpisodeMessage(message, model.RoleAssistant) || !hasPendingUser {
+			continue
+		}
+		pendingAssistant = message
+		hasPendingAssistant = true
+	}
+	if hasPendingUser && hasPendingAssistant {
+		pairs = append(pairs, assistantEpisodePair{
+			user:      pendingUser,
+			assistant: pendingAssistant,
+			userIndex: pendingUserIndex,
+		})
+	}
+	return pairs
+}
+
+func eligibleAssistantEpisodeMessage(message model.Message, role model.Role) bool {
+	return message.Role == role && message.ToolID == "" &&
+		len(message.ToolCalls) == 0 && assistantEpisodeMessageText(message) != ""
+}
+
+func assistantEpisodeUserMessages(
+	messages []model.Message,
+	includeSourceIndex bool,
+) []model.Message {
+	result := make([]model.Message, 0, len(messages))
+	for _, message := range messages {
+		if eligibleAssistantEpisodeMessage(message, model.RoleUser) {
+			if includeSourceIndex {
+				message.Content = fmt.Sprintf(
+					"[%s=%d]\n%s",
+					assistantEpisodeSourceIndexKey,
+					len(result)+1,
+					message.Content,
+				)
+			}
+			result = append(result, message)
+		}
+	}
+	return result
+}
+
+func assistantEpisodeMessageText(message model.Message) string {
+	parts := make([]string, 0, len(message.ContentParts)+1)
+	if content := strings.TrimSpace(message.Content); content != "" {
+		parts = append(parts, content)
+	}
+	for _, part := range message.ContentParts {
+		if part.Type == model.ContentTypeText && part.Text != nil {
+			if text := strings.TrimSpace(*part.Text); text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func assistantEpisodeSourceExcerpt(text string) string {
+	if len(text) <= assistantEpisodeSourceMaxBytes {
+		return text
+	}
+	available := assistantEpisodeSourceMaxBytes -
+		len(assistantEpisodeTruncationMarker)
+	headBytes := available / 2
+	headEnd := trimSplitUTF8End(text, headBytes)
+	tailStart := trimSplitUTF8Start(text, len(text)-(available-headBytes))
+	return text[:headEnd] + assistantEpisodeTruncationMarker + text[tailStart:]
+}
+
+func trimSplitUTF8End(text string, end int) int {
+	if end <= 0 || end >= len(text) || utf8.RuneStart(text[end]) {
+		return end
+	}
+	start := end - 1
+	lowerBound := max(0, end-(utf8.UTFMax-1))
+	for start > lowerBound && !utf8.RuneStart(text[start]) {
+		start--
+	}
+	if !utf8.RuneStart(text[start]) {
+		return end
+	}
+	_, size := utf8.DecodeRuneInString(text[start:])
+	if size > end-start {
+		return start
+	}
+	return end
+}
+
+func trimSplitUTF8Start(text string, start int) int {
+	if start <= 0 || start >= len(text) || utf8.RuneStart(text[start]) {
+		return start
+	}
+	runeStart := start - 1
+	lowerBound := max(0, start-(utf8.UTFMax-1))
+	for runeStart > lowerBound && !utf8.RuneStart(text[runeStart]) {
+		runeStart--
+	}
+	if !utf8.RuneStart(text[runeStart]) {
+		return start
+	}
+	_, size := utf8.DecodeRuneInString(text[runeStart:])
+	if size > start-runeStart {
+		return runeStart + size
+	}
+	return start
+}
+
+func strongAssistantEpisodeCandidate(userText, assistantText string) bool {
+	if assistantEpisodeStructuredRequestPattern.MatchString(userText) &&
+		len(assistantEpisodeListItemPattern.FindAllStringIndex(assistantText, 3)) >= 2 {
+		return true
+	}
+	if !assistantEpisodeQuantityRequestPattern.MatchString(userText) {
+		return false
+	}
+	userNumbers := make(map[string]struct{})
+	for _, value := range assistantEpisodeNumberPattern.FindAllString(userText, -1) {
+		userNumbers[value] = struct{}{}
+	}
+	for _, value := range assistantEpisodeNumberPattern.FindAllString(assistantText, -1) {
+		if _, ok := userNumbers[value]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAssistantEpisodeQuantities(memoryText, source string) error {
+	sourceQuantities := make(map[assistantEpisodeQuantity]struct{})
+	for _, quantity := range assistantEpisodeQuantities(source) {
+		sourceQuantities[quantity] = struct{}{}
+	}
+	for _, quantity := range assistantEpisodeQuantities(memoryText) {
+		if _, ok := sourceQuantities[quantity]; !ok {
+			return fmt.Errorf(
+				"assistant episode quantity %q is not present in the source",
+				formatAssistantEpisodeQuantity(quantity),
+			)
+		}
+	}
+	return nil
+}
+
+func assistantEpisodeQuantities(text string) []assistantEpisodeQuantity {
+	matches := assistantEpisodeQuantityPattern.FindAllStringSubmatchIndex(text, -1)
+	quantities := make([]assistantEpisodeQuantity, 0, len(matches))
+	for _, match := range matches {
+		quantity, ok := parseAssistantEpisodeQuantity(text, match)
+		if ok {
+			quantities = append(quantities, quantity)
+		}
+	}
+	return quantities
+}
+
+func parseAssistantEpisodeQuantity(
+	text string,
+	match []int,
+) (assistantEpisodeQuantity, bool) {
+	if len(match) != 12 {
+		return assistantEpisodeQuantity{}, false
+	}
+	sign := assistantEpisodeMatchGroup(text, match, 1) +
+		assistantEpisodeMatchGroup(text, match, 3)
+	prefix := assistantEpisodeMatchGroup(text, match, 2)
+	value := assistantEpisodeMatchGroup(text, match, 4)
+	suffix := assistantEpisodeMatchGroup(text, match, 5)
+	start := match[0]
+	end := match[1]
+	if suffix != "" && end < len(text) {
+		next, _ := utf8.DecodeRuneInString(text[end:])
+		last, _ := utf8.DecodeLastRuneInString(suffix)
+		if unicode.IsLetter(last) && assistantEpisodeIdentifierRune(next) {
+			// A short unit alternative can match the beginning of an ordinary
+			// word (for example, "m" in "meals"). Treat that case as an
+			// unqualified number instead of discarding the number entirely.
+			suffix = ""
+		}
+	}
+	if prefix == "" && sign != "" && start > 0 {
+		previous, _ := utf8.DecodeLastRuneInString(text[:start])
+		if unicode.IsDigit(previous) {
+			sign = ""
+		}
+	}
+
+	prefixCurrency := normalizeAssistantEpisodeCurrency(prefix)
+	suffixCurrency := normalizeAssistantEpisodeCurrency(suffix)
+	currency := prefixCurrency
+	if suffixCurrency != "" {
+		if currency == "" {
+			currency = suffixCurrency
+		} else if currency != suffixCurrency {
+			currency += "/" + suffixCurrency
+		}
+	}
+	unit := ""
+	if suffixCurrency == "" {
+		unit = normalizeAssistantEpisodeUnit(suffix)
+	}
+	return assistantEpisodeQuantity{
+		sign:     strings.ReplaceAll(sign, "−", "-"),
+		value:    normalizeAssistantEpisodeNumber(value),
+		unit:     unit,
+		currency: currency,
+	}, true
+}
+
+func assistantEpisodeMatchGroup(text string, match []int, group int) string {
+	start := match[group*2]
+	end := match[group*2+1]
+	if start < 0 || end < 0 {
+		return ""
+	}
+	return text[start:end]
+}
+
+func assistantEpisodeIdentifierRune(value rune) bool {
+	return value == '_' || unicode.IsLetter(value) || unicode.IsDigit(value)
+}
+
+func normalizeAssistantEpisodeNumber(value string) string {
+	normalized := value
+	if strings.Contains(normalized, ",") {
+		integer, fraction, hasFraction := strings.Cut(normalized, ".")
+		parts := strings.Split(integer, ",")
+		if len(parts[0]) > 0 && len(parts[0]) <= 3 {
+			grouped := true
+			for _, part := range parts[1:] {
+				if len(part) != 3 {
+					grouped = false
+					break
+				}
+			}
+			if grouped {
+				normalized = strings.Join(parts, "")
+				if hasFraction {
+					normalized += "." + fraction
+				}
+			}
+		}
+	}
+	integer, fraction, hasFraction := strings.Cut(normalized, ".")
+	if !hasFraction {
+		return normalized
+	}
+	fraction = strings.TrimRight(fraction, "0")
+	if fraction == "" {
+		return integer
+	}
+	return integer + "." + fraction
+}
+
+func normalizeAssistantEpisodeCurrency(value string) string {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "$", "USD":
+		return "usd"
+	case "€", "EUR":
+		return "eur"
+	case "£", "GBP":
+		return "gbp"
+	case "¥":
+		return "yen-yuan"
+	case "JPY":
+		return "jpy"
+	case "CNY", "RMB":
+		return "cny"
+	default:
+		return ""
+	}
+}
+
+func normalizeAssistantEpisodeUnit(value string) string {
+	normalized := strings.ToLower(strings.Join(strings.Fields(value), ""))
+	parts := strings.Split(normalized, "/")
+	if len(parts) == 1 {
+		return assistantEpisodeUnitAliases[normalized]
+	}
+	if len(parts) != 2 {
+		return ""
+	}
+	numerator := assistantEpisodeUnitAliases[parts[0]]
+	denominator := assistantEpisodeUnitAliases[parts[1]]
+	if numerator == "" || denominator == "" {
+		return ""
+	}
+	return numerator + "/" + denominator
+}
+
+func formatAssistantEpisodeQuantity(quantity assistantEpisodeQuantity) string {
+	var builder strings.Builder
+	if quantity.currency != "" {
+		builder.WriteString(quantity.currency)
+		builder.WriteByte(' ')
+	}
+	builder.WriteString(quantity.sign)
+	builder.WriteString(quantity.value)
+	if quantity.unit != "" {
+		builder.WriteByte(' ')
+		builder.WriteString(quantity.unit)
+	}
+	return builder.String()
+}
+
+func (e *memoryExtractor) assistantEpisodeAddEnabled() bool {
+	if e.enabledTools == nil {
+		return true
+	}
+	_, ok := e.enabledTools[memory.AddToolName]
+	return ok
+}
+
+func newAssistantEpisodeTool(
+	sources []assistantEpisodeSource,
+) *declarationOnlyTool {
+	properties := map[string]*tool.Schema{
+		argKeyMemory: {
+			Type: "string",
+			Description: "A concise, self-contained account of the user's " +
+				"request and the result supplied by the assistant.",
+		},
+		argKeyTopics: {
+			Type:        "array",
+			Description: "Optional retrieval topics.",
+			Items:       &tool.Schema{Type: "string"},
+		},
+	}
+	pairIDs := make([]any, 0, len(sources))
+	for _, source := range sources {
+		pairIDs = append(pairIDs, source.id)
+	}
+	properties[assistantEpisodePairIDKey] = &tool.Schema{
+		Type:        "string",
+		Description: "The pair label associated with this result.",
+		Enum:        pairIDs,
+	}
+	return &declarationOnlyTool{decl: &tool.Declaration{
+		Name: assistantEpisodeToolName,
+		Description: "Record one durable, reusable result supplied by an " +
+			"assistant response as attributed conversation history.",
+		InputSchema: &tool.Schema{
+			Type:                 "object",
+			Properties:           properties,
+			Required:             []string{argKeyMemory, assistantEpisodePairIDKey},
+			AdditionalProperties: false,
+		},
+	}}
+}
+
+const assistantEpisodeSystemPrompt = `You extract durable results previously
+provided by the assistant as attributed conversation episodes.
+
+- Call memory_assistant_episode at most once for each labeled pair that
+  contains a durable, reusable result.
+- Preserve the paired user request and the assistant's exact material result,
+  including names, quantities, dates, durations, negation, and qualifications.
+- Preserve item-to-detail relationships in lists and procedures.
+- Record attributed conversation history, not verified truth or a user fact.
+- Skip acknowledgments, refusals, follow-up questions, generic explanations,
+  hidden reasoning, credentials, tool arguments, and raw tool results.`

--- a/memory/extractor/assistant.go
+++ b/memory/extractor/assistant.go
@@ -160,22 +160,24 @@ func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
 	_, deleteEnabled := ordinaryTools[memory.DeleteToolName]
 	_, clearEnabled := ordinaryTools[memory.ClearToolName]
 	trackDestructiveSource := deleteEnabled || clearEnabled
-	ordinaryMessages := assistantEpisodeUserMessages(messages)
+	ordinaryInput, userMessageCount := assistantEpisodeOrdinaryMessages(messages)
 	nextCtx := ctx
-	if len(ordinaryMessages) > 0 {
+	if userMessageCount > 0 {
 		if trackDestructiveSource {
 			ordinaryTools = assistantEpisodeOrdinaryTools(
 				ordinaryTools,
-				len(ordinaryMessages),
+				userMessageCount,
 			)
 		}
+		ordinaryMessages := ordinaryExtractor.buildMessages(
+			ctx,
+			ordinaryInput,
+			existing,
+		)
+		ordinaryMessages[0].Content += assistantEpisodeOrdinaryContextPolicy
 		req := &model.Request{
-			Messages: ordinaryExtractor.buildMessages(
-				ctx,
-				ordinaryMessages,
-				existing,
-			),
-			Tools: ordinaryTools,
+			Messages: ordinaryMessages,
+			Tools:    ordinaryTools,
 		}
 		var err error
 		nextCtx, err = ordinaryExtractor.runExtractionRequest(
@@ -187,7 +189,7 @@ func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
 					switch op.Type {
 					case OperationClear:
 						sourceIndex, ok := assistantEpisodeOperationSourceIndex(
-							call, len(ordinaryMessages),
+							call, userMessageCount,
 						)
 						if !ok {
 							result.destructiveScopeUnknown = true
@@ -196,7 +198,7 @@ func (e *memoryExtractor) extractAssistantEpisodeOrdinaryStage(
 						}
 					case OperationDelete:
 						indexes, ok := assistantEpisodeDeleteSourceIndexes(
-							call, len(ordinaryMessages),
+							call, userMessageCount,
 						)
 						if !ok {
 							result.destructiveScopeUnknown = true
@@ -459,14 +461,21 @@ func eligibleAssistantEpisodeMessage(message model.Message, role model.Role) boo
 		len(message.ToolCalls) == 0 && assistantEpisodeMessageText(message) != ""
 }
 
-func assistantEpisodeUserMessages(messages []model.Message) []model.Message {
+func assistantEpisodeOrdinaryMessages(
+	messages []model.Message,
+) ([]model.Message, int) {
 	result := make([]model.Message, 0, len(messages))
+	userCount := 0
 	for _, message := range messages {
-		if eligibleAssistantEpisodeMessage(message, model.RoleUser) {
+		switch {
+		case eligibleAssistantEpisodeMessage(message, model.RoleUser):
+			result = append(result, message)
+			userCount++
+		case eligibleAssistantEpisodeMessage(message, model.RoleAssistant):
 			result = append(result, message)
 		}
 	}
-	return result
+	return result, userCount
 }
 
 func assistantEpisodeMessageText(message model.Message) string {
@@ -809,6 +818,16 @@ func newAssistantEpisodeTool(
 		},
 	}}
 }
+
+const assistantEpisodeOrdinaryContextPolicy = `
+
+<assistant_context_policy>
+Only user messages can supply or authorize ordinary memory operations in this
+stage. Assistant messages are context only: use them to interpret references,
+confirmations, and short user replies. Do not create, update, delete, or clear
+memory from information supplied only by an assistant message. Reusable
+assistant results are handled by a separate extraction stage.
+</assistant_context_policy>`
 
 const assistantEpisodeSystemPrompt = `You extract durable results previously
 provided by the assistant as attributed conversation episodes.

--- a/memory/extractor/assistant_test.go
+++ b/memory/extractor/assistant_test.go
@@ -105,6 +105,11 @@ func TestAssistantEpisodeExtractionDisabledPreservesRequest(t *testing.T) {
 	if _, ok := m.requests[0].Tools[assistantEpisodeToolName]; ok {
 		t.Fatal("default request exposes the assistant episode tool")
 	}
+	if requestContainsRoleSubstring(
+		m.requests[0], model.RoleSystem, "assistant_context_policy",
+	) {
+		t.Fatal("default request contains the opt-in assistant context policy")
+	}
 	if !requestContainsRoleContent(m.requests[0], model.RoleAssistant, "- Alpha\n- Beta") {
 		t.Fatal("default request no longer contains the assistant message")
 	}
@@ -157,11 +162,45 @@ func TestAssistantEpisodeExtractionSkipsWeakCandidate(t *testing.T) {
 	if len(m.requests) != 1 {
 		t.Fatalf("model calls = %d, want 1", len(m.requests))
 	}
-	if requestContainsRole(m.requests[0], model.RoleAssistant) {
-		t.Fatal("ordinary extraction received an assistant message")
+	if !requestContainsRoleContent(m.requests[0], model.RoleAssistant, "You're welcome.") {
+		t.Fatal("ordinary extraction omitted assistant context")
+	}
+	if !requestContainsRoleSubstring(
+		m.requests[0], model.RoleSystem, "Assistant messages are context only",
+	) {
+		t.Fatal("ordinary extraction omitted the assistant context policy")
 	}
 	if _, ok := m.requests[0].Tools[assistantEpisodeToolName]; ok {
 		t.Fatal("ordinary extraction exposes the assistant episode tool")
+	}
+}
+
+func TestAssistantEpisodeOrdinaryStageKeepsContextForShortUserReply(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+
+	_, err := ext.Extract(context.Background(), []model.Message{
+		model.NewAssistantMessage("Do you prefer tea or coffee?"),
+		model.NewUserMessage("Coffee."),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	request := m.requests[0]
+	if !requestContainsRoleContent(
+		request, model.RoleAssistant, "Do you prefer tea or coffee?",
+	) || !requestContainsRoleContent(request, model.RoleUser, "Coffee.") {
+		t.Fatalf("ordinary request lost conversation context: %#v", request.Messages)
+	}
+	if !requestContainsRoleSubstring(
+		request, model.RoleSystem, "Only user messages can supply or authorize",
+	) || !requestContainsRoleSubstring(
+		request, model.RoleSystem, "Do not create, update, delete, or clear",
+	) {
+		t.Fatal("ordinary request does not mark assistant messages as context only")
 	}
 }
 
@@ -313,8 +352,8 @@ func TestAssistantEpisodeExtractionUsesConditionalSecondStage(t *testing.T) {
 	if len(m.requests) != 2 {
 		t.Fatalf("model calls = %d, want 2", len(m.requests))
 	}
-	if requestContainsRole(m.requests[0], model.RoleAssistant) {
-		t.Fatal("ordinary extraction received an assistant message")
+	if !requestContainsRoleContent(m.requests[0], model.RoleAssistant, "- Alpha\n- Beta") {
+		t.Fatal("ordinary extraction omitted assistant context")
 	}
 	if got := len(m.requests[1].Tools); got != 1 {
 		t.Fatalf("second-stage tool count = %d, want 1", got)

--- a/memory/extractor/assistant_test.go
+++ b/memory/extractor/assistant_test.go
@@ -181,6 +181,26 @@ func TestAssistantEpisodeOrdinaryStagePreservesContentWithoutDestructiveTools(t 
 	}
 }
 
+func TestAssistantEpisodeOrdinaryStagePreservesContentWithDestructiveTools(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	const content = "Remember that I like coffee."
+	if _, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage(content),
+		model.NewAssistantMessage("Understood."),
+	}, nil); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if !requestContainsRoleContent(m.requests[0], model.RoleUser, content) {
+		t.Fatalf("ordinary request changed user content: %#v", m.requests[0].Messages)
+	}
+	for _, message := range m.requests[0].Messages {
+		if strings.Contains(message.Content, "[source_user_index=") {
+			t.Fatalf("ordinary request leaked source label: %q", message.Content)
+		}
+	}
+}
+
 func TestAssistantEpisodeExtractionIncludesStoredEpisodesInOrdinaryStage(t *testing.T) {
 	m := &assistantTestModel{steps: []assistantModelStep{{}}}
 	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
@@ -847,6 +867,61 @@ func TestAssistantEpisodeExtractionSkipsAfterDeleteWithoutSource(t *testing.T) {
 	}
 }
 
+func TestAssistantEpisodeExtractionKeepsPairUnrelatedToDelete(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{calls: []model.ToolCall{makeToolCall(memory.DeleteToolName, []byte(`{
+			"memory_id":"birthday",
+			"affected_source_user_indexes":[]
+		}`))}},
+		{calls: []model.ToolCall{assistantEpisodeToolCall(`{
+			"pair_id":"pair-1",
+			"memory":"The assistant recommended Alpha and Beta."
+		}`)}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two products."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Forget my birthday."),
+		model.NewAssistantMessage("Done."),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if len(operations) != 2 || operations[0].Type != OperationDelete ||
+		operations[1].Type != OperationAdd {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsPairCoveredByDelete(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{
+		calls: []model.ToolCall{makeToolCall(memory.DeleteToolName, []byte(`{
+			"memory_id":"recommendation",
+			"affected_source_user_indexes":[1]
+		}`))},
+	}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two products."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Forget that recommendation."),
+		model.NewAssistantMessage("Done."),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if len(operations) != 1 || operations[0].Type != OperationDelete {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
 func TestAssistantEpisodeExtractionContinuesAfterEarlierClear(t *testing.T) {
 	m := &assistantTestModel{steps: []assistantModelStep{
 		{calls: []model.ToolCall{makeToolCall(
@@ -942,24 +1017,69 @@ func TestAssistantEpisodeOperationSourceIndex(t *testing.T) {
 	}
 }
 
+func TestAssistantEpisodeDeleteSourceIndexes(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments string
+		userCount int
+		want      []int
+		wantOK    bool
+	}{
+		{"empty", `{"affected_source_user_indexes":[]}`, 3, []int{}, true},
+		{"sorted unique", `{"affected_source_user_indexes":[2,1,2]}`, 3, []int{1, 2}, true},
+		{"missing", `{}`, 3, nil, false},
+		{"null", `{"affected_source_user_indexes":null}`, 3, nil, false},
+		{"out of range", `{"affected_source_user_indexes":[4]}`, 3, nil, false},
+		{"wrong type", `{"affected_source_user_indexes":1}`, 3, nil, false},
+		{"malformed", `{`, 3, nil, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			call := makeToolCall(memory.DeleteToolName, []byte(test.arguments))
+			got, ok := assistantEpisodeDeleteSourceIndexes(call, test.userCount)
+			if !reflect.DeepEqual(got, test.want) || ok != test.wantOK {
+				t.Fatalf("source indexes = (%v, %v), want (%v, %v)",
+					got, ok, test.want, test.wantOK)
+			}
+		})
+	}
+}
+
 func TestAssistantEpisodeOrdinaryDestructiveToolsRequireSource(t *testing.T) {
 	tools := assistantEpisodeOrdinaryTools(backgroundTools, 2)
-	for _, name := range []string{memory.DeleteToolName, memory.ClearToolName} {
-		declaration := tools[name].Declaration()
-		property := declaration.InputSchema.Properties[assistantEpisodeSourceIndexKey]
-		if property == nil {
-			t.Fatalf("%s omitted %s", name, assistantEpisodeSourceIndexKey)
-		}
-		if !slices.Contains(declaration.InputSchema.Required, assistantEpisodeSourceIndexKey) {
-			t.Fatalf("%s does not require %s", name, assistantEpisodeSourceIndexKey)
-		}
-		if got, want := property.Enum, []any{1, 2}; !reflect.DeepEqual(got, want) {
-			t.Fatalf("%s source enum = %#v, want %#v", name, got, want)
-		}
+	clearDeclaration := tools[memory.ClearToolName].Declaration()
+	clearProperty := clearDeclaration.InputSchema.Properties[assistantEpisodeSourceIndexKey]
+	if clearProperty == nil ||
+		!slices.Contains(clearDeclaration.InputSchema.Required, assistantEpisodeSourceIndexKey) {
+		t.Fatal("memory_clear does not require its source user index")
 	}
-	if _, ok := backgroundTools[memory.ClearToolName].Declaration().
-		InputSchema.Properties[assistantEpisodeSourceIndexKey]; ok {
-		t.Fatal("request-local source property mutated the shared tool")
+	if got, want := clearProperty.Enum, []any{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("memory_clear source enum = %#v, want %#v", got, want)
+	}
+
+	deleteDeclaration := tools[memory.DeleteToolName].Declaration()
+	deleteProperty := deleteDeclaration.InputSchema.Properties[assistantEpisodeAffectedSourceIndexesKey]
+	if deleteProperty == nil || !slices.Contains(
+		deleteDeclaration.InputSchema.Required,
+		assistantEpisodeAffectedSourceIndexesKey,
+	) {
+		t.Fatal("memory_delete does not require affected source indexes")
+	}
+	if deleteProperty.Type != "array" || deleteProperty.Items == nil {
+		t.Fatalf("memory_delete source schema = %#v", deleteProperty)
+	}
+	if got, want := deleteProperty.Items.Enum, []any{1, 2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("memory_delete source enum = %#v, want %#v", got, want)
+	}
+	for _, name := range []string{memory.DeleteToolName, memory.ClearToolName} {
+		for _, key := range []string{
+			assistantEpisodeSourceIndexKey,
+			assistantEpisodeAffectedSourceIndexesKey,
+		} {
+			if _, ok := backgroundTools[name].Declaration().InputSchema.Properties[key]; ok {
+				t.Fatalf("request-local property %s mutated shared %s", key, name)
+			}
+		}
 	}
 }
 

--- a/memory/extractor/assistant_test.go
+++ b/memory/extractor/assistant_test.go
@@ -1,0 +1,1673 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package extractor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/internal/assistantmemory"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type assistantModelStep struct {
+	calls         []model.ToolCall
+	err           error
+	before        func()
+	waitForCancel bool
+}
+
+type assistantTestModel struct {
+	steps    []assistantModelStep
+	requests []*model.Request
+}
+
+func (m *assistantTestModel) GenerateContent(
+	ctx context.Context,
+	request *model.Request,
+) (<-chan *model.Response, error) {
+	stepIndex := len(m.requests)
+	m.requests = append(m.requests, request)
+	if stepIndex >= len(m.steps) {
+		return nil, errors.New("unexpected model call")
+	}
+	step := m.steps[stepIndex]
+	if step.before != nil {
+		step.before()
+	}
+	if step.waitForCancel {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if step.err != nil {
+		return nil, step.err
+	}
+	responses := make(chan *model.Response, 1)
+	responses <- &model.Response{Choices: []model.Choice{{
+		Message: model.Message{ToolCalls: step.calls},
+	}}}
+	close(responses)
+	return responses, nil
+}
+
+func (m *assistantTestModel) Info() model.Info {
+	return model.Info{Name: "assistant-test-model"}
+}
+
+func TestAssistantEpisodeExtractionIsOptIn(t *testing.T) {
+	disabled := NewExtractor(nil).(*memoryExtractor)
+	if disabled.assistantEpisodeExtraction {
+		t.Fatal("assistant episode extraction is enabled by default")
+	}
+	if assistantmemory.Enabled(disabled) {
+		t.Fatal("default extractor reports assistant episode capability")
+	}
+
+	enabled := NewExtractor(nil, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	if !enabled.assistantEpisodeExtraction {
+		t.Fatal("assistant episode extraction was not enabled")
+	}
+	if !assistantmemory.Enabled(enabled) {
+		t.Fatal("enabled extractor does not report assistant episode capability")
+	}
+	if !reflect.DeepEqual(disabled.Metadata(), enabled.Metadata()) {
+		t.Fatal("assistant option changed descriptive extractor metadata")
+	}
+}
+
+func TestAssistantEpisodeExtractionDisabledPreservesRequest(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m)
+	messages := []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("- Alpha\n- Beta"),
+	}
+	if _, err := ext.Extract(context.Background(), messages, nil); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if _, ok := m.requests[0].Tools[assistantEpisodeToolName]; ok {
+		t.Fatal("default request exposes the assistant episode tool")
+	}
+	if !requestContainsRoleContent(m.requests[0], model.RoleAssistant, "- Alpha\n- Beta") {
+		t.Fatal("default request no longer contains the assistant message")
+	}
+}
+
+func TestAssistantEpisodeExtractionFallsBackWhenWorkerCapabilityIsHidden(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	ctx := assistantmemory.WithWorkerConfiguration(context.Background(), false)
+
+	if _, err := ext.Extract(ctx, []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("- Alpha\n- Beta"),
+	}, nil); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if !requestContainsRoleContent(m.requests[0], model.RoleAssistant, "- Alpha\n- Beta") {
+		t.Fatal("worker-disabled fallback omitted the ordinary assistant message")
+	}
+}
+
+func TestAssistantEpisodeExtractionDisabledPreservesEmptyEnabledToolsBehavior(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m).(*memoryExtractor)
+	ext.SetEnabledTools(map[string]struct{}{})
+
+	if _, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Remember nothing from this request."),
+	}, nil); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if got := len(m.requests[0].Tools); got != len(backgroundTools) {
+		t.Fatalf("tool count = %d, want %d", got, len(backgroundTools))
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsWeakCandidate(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	_, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Thanks for the help."),
+		model.NewAssistantMessage("You're welcome."),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if requestContainsRole(m.requests[0], model.RoleAssistant) {
+		t.Fatal("ordinary extraction received an assistant message")
+	}
+	if _, ok := m.requests[0].Tools[assistantEpisodeToolName]; ok {
+		t.Fatal("ordinary extraction exposes the assistant episode tool")
+	}
+}
+
+func TestAssistantEpisodeOrdinaryStagePreservesContentWithoutDestructiveTools(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	ext.SetEnabledTools(map[string]struct{}{memory.AddToolName: {}})
+	const content = "Recommend two options."
+	if _, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage(content),
+		model.NewAssistantMessage("No structured answer."),
+	}, nil); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if !requestContainsRoleContent(m.requests[0], model.RoleUser, content) {
+		t.Fatalf("ordinary request changed user content: %#v", m.requests[0].Messages)
+	}
+}
+
+func TestAssistantEpisodeExtractionIncludesStoredEpisodesInOrdinaryStage(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	existing := []*memory.Entry{
+		{
+			ID:     "ordinary",
+			Memory: &memory.Memory{Memory: "User likes compact kitchens."},
+		},
+		{
+			ID: "assistant",
+			Memory: &memory.Memory{Memory: assistantEpisodePrefix +
+				"The assistant recommended Alpha and Beta."},
+		},
+	}
+
+	_, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("I still like compact kitchens."),
+	}, existing)
+
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if !requestContainsRoleSubstring(
+		m.requests[0], model.RoleSystem, "User likes compact kitchens.",
+	) {
+		t.Fatal("ordinary stage omitted an ordinary existing memory")
+	}
+	if !requestContainsRoleSubstring(
+		m.requests[0], model.RoleSystem, "The assistant recommended Alpha and Beta.",
+	) {
+		t.Fatal("ordinary stage omitted a stored assistant episode")
+	}
+}
+
+func TestAssistantEpisodeExtractionDoesNotApplyEarlierForgetToLaterExchange(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+
+	_, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Please clear all my memories."),
+		model.NewAssistantMessage("Understood."),
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if !requestContainsRoleSubstring(
+		m.requests[1], model.RoleUser, "Recommend two options.",
+	) {
+		t.Fatal("assistant request omitted the later exchange")
+	}
+	if requestContainsRoleSubstring(
+		m.requests[1], model.RoleUser, "clear all my memories",
+	) {
+		t.Fatal("assistant request included the earlier clear request")
+	}
+}
+
+func TestAssistantEpisodeExtractionDoesNotInterpretForgetWording(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Please clear all my memories."),
+		model.NewAssistantMessage("Understood."),
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if len(operations) != 0 {
+		t.Fatalf("operations = %#v, want none", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionUsesConditionalSecondStage(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{calls: []model.ToolCall{makeToolCall(memory.AddToolName, []byte(`{
+			"memory":"User wants options for a compact kitchen."
+		}`))}},
+		{calls: []model.ToolCall{assistantEpisodeToolCall(`{
+			"pair_id":"pair-1",
+			"memory":"When the user requested compact-kitchen options, the assistant recommended Alpha and Beta.",
+			"topics":["compact kitchen","recommendations"]
+		}`)}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	reference := time.Date(2026, time.July, 21, 10, 30, 0, 0, time.UTC)
+	operations, err := ext.Extract(
+		WithReferenceDate(context.Background(), reference),
+		[]model.Message{
+			model.NewUserMessage("Recommend options for a compact kitchen."),
+			model.NewAssistantMessage("- Alpha\n- Beta"),
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if requestContainsRole(m.requests[0], model.RoleAssistant) {
+		t.Fatal("ordinary extraction received an assistant message")
+	}
+	if got := len(m.requests[1].Tools); got != 1 {
+		t.Fatalf("second-stage tool count = %d, want 1", got)
+	}
+	if _, ok := m.requests[1].Tools[assistantEpisodeToolName]; !ok {
+		t.Fatal("second stage does not expose the assistant episode tool")
+	}
+	if got := m.requests[1].Messages[0].Content; got != assistantEpisodeSystemPrompt {
+		t.Fatalf("default second-stage prompt changed:\n%s", got)
+	}
+	if len(operations) != 2 {
+		t.Fatalf("operation count = %d, want 2", len(operations))
+	}
+	assistantOperation := operations[1]
+	if assistantOperation.MemoryKind != memory.KindEpisode {
+		t.Fatalf("assistant kind = %q, want %q", assistantOperation.MemoryKind, memory.KindEpisode)
+	}
+	if !strings.HasPrefix(assistantOperation.Memory, assistantEpisodePrefix) {
+		t.Fatalf("assistant memory = %q", assistantOperation.Memory)
+	}
+	if !reflect.DeepEqual(
+		assistantOperation.Participants,
+		[]string{"User", "Assistant"},
+	) {
+		t.Fatalf("participants = %#v", assistantOperation.Participants)
+	}
+	if assistantOperation.EventTime == nil ||
+		!assistantOperation.EventTime.Equal(reference) {
+		t.Fatalf("event time = %v, want %v", assistantOperation.EventTime, reference)
+	}
+}
+
+func TestAssistantEpisodeExtractionFailureKeepsOrdinaryOperations(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{calls: []model.ToolCall{makeToolCall(memory.AddToolName, []byte(`{
+			"memory":"User wants two recommendations."
+		}`))}},
+		{err: errors.New("assistant model unavailable")},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(operations) != 1 || operations[0].Memory != "User wants two recommendations." {
+		t.Fatalf("operations = %#v, want ordinary operation", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionUsesCustomPromptInBothStages(t *testing.T) {
+	const customPolicy = "Never retain medical information from any conversation."
+	const customPrompt = customPolicy + " Current date: {current_date}."
+	reference := time.Date(2026, time.August, 5, 10, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		configure func(*memoryExtractor)
+	}{
+		{
+			name: "constructor option",
+			configure: func(e *memoryExtractor) {
+				WithPrompt(customPrompt)(e)
+			},
+		},
+		{
+			name: "setter",
+			configure: func(e *memoryExtractor) {
+				e.SetPrompt(customPrompt)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+			ext := NewExtractor(m, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+			test.configure(ext)
+			_, err := ext.Extract(WithReferenceDate(context.Background(), reference), []model.Message{
+				model.NewUserMessage("Recommend two options."),
+				model.NewAssistantMessage("1. Alpha\n2. Beta"),
+			}, nil)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if len(m.requests) != 2 {
+				t.Fatalf("model calls = %d, want 2", len(m.requests))
+			}
+			for requestIndex, request := range m.requests {
+				if !requestContainsRoleSubstring(request, model.RoleSystem, customPolicy) ||
+					!requestContainsRoleSubstring(request, model.RoleSystem, "Current date: 2026-08-05.") {
+					t.Fatalf("request %d does not contain rendered custom prompt", requestIndex)
+				}
+				if requestContainsRoleSubstring(request, model.RoleSystem, "{current_date}") {
+					t.Fatalf("request %d contains an unrendered current_date variable", requestIndex)
+				}
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeExtractionProcessesAllEligiblePairs(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{},
+		{calls: []model.ToolCall{
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-1",
+				"memory":"The assistant recommended Alpha and Beta."
+			}`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-2",
+				"memory":"The assistant recommended Gamma and Delta."
+			}`),
+		}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("Let me check."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Suggest two alternatives."),
+		model.NewAssistantMessage("1. Gamma\n2. Delta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if !requestContainsRoleSubstring(
+		m.requests[1],
+		model.RoleSystem,
+		"at most once for each labeled pair",
+	) {
+		t.Fatal("assistant stage did not use the multi-pair prompt")
+	}
+	if !requestContainsRoleSubstring(m.requests[1], model.RoleAssistant, "1. Alpha\n2. Beta") ||
+		requestContainsRoleSubstring(m.requests[1], model.RoleAssistant, "Let me check.") {
+		t.Fatal("batch assistant stage did not use the final reply for its first user turn")
+	}
+	if !requestContainsRoleSubstring(m.requests[1], model.RoleAssistant, "1. Gamma\n2. Delta") {
+		t.Fatal("batch assistant stage is not associated with the second user turn")
+	}
+	if len(operations) != 2 {
+		t.Fatalf("operations = %#v, want 2 assistant episodes", operations)
+	}
+	for _, expected := range []string{"Alpha and Beta", "Gamma and Delta"} {
+		if !slices.ContainsFunc(operations, func(operation *Operation) bool {
+			return strings.Contains(operation.Memory, expected)
+		}) {
+			t.Fatalf("operations do not contain %q: %#v", expected, operations)
+		}
+	}
+}
+
+func TestAssistantEpisodeExtractionKeepsInBudgetEligiblePairs(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	const pairCount = 17
+	messages := make([]model.Message, 0, pairCount*2)
+	for i := 0; i < pairCount; i++ {
+		messages = append(
+			messages,
+			model.NewUserMessage(fmt.Sprintf("Recommend two options for case %d.", i)),
+			model.NewAssistantMessage(fmt.Sprintf("1. Alpha-%d\n2. Beta-%d", i, i)),
+		)
+	}
+
+	operations, err := ext.Extract(context.Background(), messages, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(operations) != 0 {
+		t.Fatalf("operations = %#v, want none", operations)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if !requestContainsRoleSubstring(m.requests[1], model.RoleUser, "pair-17 user request") {
+		t.Fatal("assistant request dropped an eligible pair")
+	}
+	declaration := m.requests[1].Tools[assistantEpisodeToolName].Declaration()
+	pairIDs := declaration.InputSchema.Properties[assistantEpisodePairIDKey].Enum
+	if len(pairIDs) != pairCount || pairIDs[pairCount-1] != "pair-17" {
+		t.Fatalf("pair id enum = %#v, want all %d pairs", pairIDs, pairCount)
+	}
+}
+
+func TestAssistantEpisodeExtractionBoundsCandidateWork(t *testing.T) {
+	tests := []struct {
+		name      string
+		pairCount int
+		userText  func(int) string
+		answer    func(int) string
+		wantPairs int
+	}{
+		{
+			name:      "pair count",
+			pairCount: assistantEpisodeRequestMaxPairs + 1,
+			userText: func(i int) string {
+				return fmt.Sprintf("Recommend two options for case %d.", i)
+			},
+			answer: func(i int) string {
+				return fmt.Sprintf("1. Alpha-%d\n2. Beta-%d", i, i)
+			},
+			wantPairs: assistantEpisodeRequestMaxPairs,
+		},
+		{
+			name:      "source bytes",
+			pairCount: 5,
+			userText: func(i int) string {
+				return fmt.Sprintf("Recommend two options for case %d.\n", i) +
+					strings.Repeat("u", assistantEpisodeSourceMaxBytes)
+			},
+			answer: func(i int) string {
+				return fmt.Sprintf("1. Alpha-%d\n2. Beta-%d\n", i, i) +
+					strings.Repeat("a", assistantEpisodeSourceMaxBytes)
+			},
+			wantPairs: assistantEpisodeRequestMaxSourceBytes /
+				(2 * assistantEpisodeSourceMaxBytes),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+			ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+			messages := make([]model.Message, 0, test.pairCount*2)
+			for i := 0; i < test.pairCount; i++ {
+				messages = append(
+					messages,
+					model.NewUserMessage(test.userText(i)),
+					model.NewAssistantMessage(test.answer(i)),
+				)
+			}
+
+			operations, err := ext.Extract(context.Background(), messages, nil)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if len(operations) != 0 {
+				t.Fatalf("operations = %#v, want none", operations)
+			}
+			if len(m.requests) != 2 {
+				t.Fatalf("model calls = %d, want 2", len(m.requests))
+			}
+			declaration := m.requests[1].Tools[assistantEpisodeToolName].Declaration()
+			pairIDs := declaration.InputSchema.Properties[assistantEpisodePairIDKey].Enum
+			if len(pairIDs) != test.wantPairs {
+				t.Fatalf("pair id count = %d, want %d", len(pairIDs), test.wantPairs)
+			}
+			if requestContainsRoleSubstring(
+				m.requests[1], model.RoleUser,
+				fmt.Sprintf("case %d", test.wantPairs),
+			) {
+				t.Fatal("assistant request includes a candidate past its budget")
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeExtractionTreatsEveryUserTurnAsBoundary(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{},
+		{calls: []model.ToolCall{assistantEpisodeToolCall(`{
+			"pair_id":"pair-1",
+			"memory":"The assistant recommended Alpha and Beta."
+		}`)}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	imageOnlyUser := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeImage},
+		},
+	}
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		imageOnlyUser,
+		model.NewAssistantMessage("1. Gamma\n2. Delta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if !requestContainsRoleSubstring(m.requests[1], model.RoleAssistant, "1. Alpha\n2. Beta") ||
+		requestContainsRoleSubstring(m.requests[1], model.RoleAssistant, "1. Gamma\n2. Delta") {
+		t.Fatal("assistant reply crossed a non-text user-turn boundary")
+	}
+	if len(operations) != 1 || !strings.Contains(operations[0].Memory, "Alpha and Beta") {
+		t.Fatalf("operations = %#v, want the first user turn only", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionDeadlineKeepsOrdinaryOperations(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{calls: []model.ToolCall{makeToolCall(memory.AddToolName, []byte(`{
+			"memory":"User wants two recommendations."
+		}`))}},
+		{waitForCancel: true},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	messages := []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Suggest two alternatives."),
+		model.NewAssistantMessage("1. Gamma\n2. Delta"),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	operations, err := ext.Extract(ctx, messages, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("parent context ended before ordinary operations returned: %v", ctx.Err())
+	}
+	if len(operations) != 1 || operations[0].Memory != "User wants two recommendations." {
+		t.Fatalf("operations = %#v, want ordinary operation", operations)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+}
+
+func TestAssistantEpisodeExtractionReturnsOrdinaryStageError(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{
+		err: errors.New("ordinary extraction failed"),
+	}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "ordinary extraction failed") {
+		t.Fatalf("error = %v, want ordinary extraction failure", err)
+	}
+	if operations != nil {
+		t.Fatalf("operations = %#v, want nil", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionPropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{},
+		{before: cancel, err: context.Canceled},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(ctx, []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
+	}
+	if operations != nil {
+		t.Fatalf("operations = %#v, want nil", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionAllowsNoAssistantOperation(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if len(operations) != 0 {
+		t.Fatalf("operations = %#v, want none", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionAllowsAssistantOnlyInput(t *testing.T) {
+	m := &assistantTestModel{}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 0 {
+		t.Fatalf("model calls = %d, want 0", len(m.requests))
+	}
+	if len(operations) != 0 {
+		t.Fatalf("operations = %#v, want none", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionRespectsEnabledTools(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	ext.SetEnabledTools(map[string]struct{}{})
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(operations) != 0 {
+		t.Fatalf("operations = %#v, want none", operations)
+	}
+	if len(m.requests) != 0 {
+		t.Fatalf("model calls = %d, want 0", len(m.requests))
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsSecondStageWithoutAddTool(t *testing.T) {
+	tests := []struct {
+		name         string
+		policy       UpdatePolicy
+		wantRequests int
+	}{
+		{
+			name:         "ordinary delete remains available",
+			policy:       UpdatePolicyMergeSimilar,
+			wantRequests: 1,
+		},
+		{
+			name:         "policy intersection removes all tools",
+			policy:       UpdatePolicyAppendOnly,
+			wantRequests: 0,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &assistantTestModel{steps: []assistantModelStep{{}}}
+			ext := NewExtractor(
+				m,
+				WithAssistantEpisodeExtraction(),
+				WithUpdatePolicy(test.policy),
+			).(*memoryExtractor)
+			ext.SetEnabledTools(map[string]struct{}{
+				memory.DeleteToolName: {},
+			})
+
+			operations, err := ext.Extract(context.Background(), []model.Message{
+				model.NewUserMessage("Recommend two options."),
+				model.NewAssistantMessage("1. Alpha\n2. Beta"),
+			}, nil)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if len(operations) != 0 {
+				t.Fatalf("operations = %#v, want none", operations)
+			}
+			if len(m.requests) != test.wantRequests {
+				t.Fatalf("model calls = %d, want %d", len(m.requests), test.wantRequests)
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeOrdinaryStageUsesUpdatePolicyTools(t *testing.T) {
+	tests := []struct {
+		name        string
+		policy      UpdatePolicy
+		wantTools   int
+		wantAddOnly bool
+	}{
+		{name: "merge similar", policy: UpdatePolicyMergeSimilar, wantTools: len(backgroundTools)},
+		{name: "preserve history", policy: UpdatePolicyPreserveHistory, wantTools: len(backgroundTools)},
+		{name: "append only", policy: UpdatePolicyAppendOnly, wantTools: 1, wantAddOnly: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &assistantTestModel{steps: []assistantModelStep{{}}}
+			ext := NewExtractor(
+				m,
+				WithUpdatePolicy(test.policy),
+				WithAssistantEpisodeExtraction(),
+			)
+			_, err := ext.Extract(context.Background(), []model.Message{
+				model.NewUserMessage("Remember this preference."),
+			}, nil)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			if got := len(m.requests[0].Tools); got != test.wantTools {
+				t.Fatalf("tool count = %d, want %d", got, test.wantTools)
+			}
+			if test.wantAddOnly {
+				if _, ok := m.requests[0].Tools[memory.AddToolName]; !ok {
+					t.Fatal("append-only ordinary stage omitted memory_add")
+				}
+				for _, name := range []string{
+					memory.UpdateToolName,
+					memory.DeleteToolName,
+					memory.ClearToolName,
+				} {
+					if _, ok := m.requests[0].Tools[name]; ok {
+						t.Fatalf("append-only ordinary stage exposed %s", name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsAfterClearOperation(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{calls: []model.ToolCall{
+		makeToolCall(memory.ClearToolName, []byte(`{"source_user_index":1}`)),
+	}}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if len(operations) != 1 || operations[0].Type != OperationClear {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsAfterDeleteWithoutSource(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{
+		calls: []model.ToolCall{makeToolCall(memory.DeleteToolName, []byte(`{
+			"memory_id":"stale"
+		}`))},
+	}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if len(operations) != 1 || operations[0].Type != OperationDelete {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionContinuesAfterEarlierClear(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{calls: []model.ToolCall{makeToolCall(
+			memory.ClearToolName,
+			[]byte(`{"source_user_index":1}`),
+		)}},
+		{calls: []model.ToolCall{assistantEpisodeToolCall(`{
+			"pair_id":"pair-1",
+			"memory":"The assistant recommended Alpha and Beta."
+		}`)}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Clear all memories."),
+		model.NewAssistantMessage("Understood."),
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+	if len(operations) != 2 || operations[0].Type != OperationClear ||
+		operations[1].Type != OperationAdd {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsPairBeforeLaterClear(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{calls: []model.ToolCall{
+		makeToolCall(memory.ClearToolName, []byte(`{"source_user_index":2}`)),
+	}}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Clear all memories."),
+		model.NewAssistantMessage("Understood."),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(m.requests))
+	}
+	if len(operations) != 1 || operations[0].Type != OperationClear {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionUserWordingDoesNotControlOptionalStage(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{}, {}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	_, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Please forget my old recommendation."),
+		model.NewAssistantMessage("Understood."),
+		model.NewUserMessage("Never mind, keep it."),
+		model.NewAssistantMessage("Understood."),
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(m.requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(m.requests))
+	}
+}
+
+func TestAssistantEpisodeOperationSourceIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments string
+		userCount int
+		want      int
+		wantOK    bool
+	}{
+		{"valid", `{"source_user_index":2}`, 3, 2, true},
+		{"missing", `{}`, 3, 0, false},
+		{"out of range", `{"source_user_index":4}`, 3, 0, false},
+		{"malformed", `{`, 3, 0, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			call := makeToolCall(memory.ClearToolName, []byte(test.arguments))
+			got, ok := assistantEpisodeOperationSourceIndex(call, test.userCount)
+			if got != test.want || ok != test.wantOK {
+				t.Fatalf("source index = (%d, %v), want (%d, %v)", got, ok, test.want, test.wantOK)
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeOrdinaryDestructiveToolsRequireSource(t *testing.T) {
+	tools := assistantEpisodeOrdinaryTools(backgroundTools, 2)
+	for _, name := range []string{memory.DeleteToolName, memory.ClearToolName} {
+		declaration := tools[name].Declaration()
+		property := declaration.InputSchema.Properties[assistantEpisodeSourceIndexKey]
+		if property == nil {
+			t.Fatalf("%s omitted %s", name, assistantEpisodeSourceIndexKey)
+		}
+		if !slices.Contains(declaration.InputSchema.Required, assistantEpisodeSourceIndexKey) {
+			t.Fatalf("%s does not require %s", name, assistantEpisodeSourceIndexKey)
+		}
+		if got, want := property.Enum, []any{1, 2}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s source enum = %#v, want %#v", name, got, want)
+		}
+	}
+	if _, ok := backgroundTools[memory.ClearToolName].Declaration().
+		InputSchema.Properties[assistantEpisodeSourceIndexKey]; ok {
+		t.Fatal("request-local source property mutated the shared tool")
+	}
+}
+
+func TestAssistantEpisodeExtractionRejectsUngroundedNumber(t *testing.T) {
+	ext := NewExtractor(nil, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	_, err := ext.parseAssistantEpisode(
+		context.Background(),
+		map[string]any{argKeyMemory: "The assistant recommended 3 options."},
+		"The user requested options. The assistant recommended Alpha and Beta.",
+	)
+	if err == nil {
+		t.Fatal("ungrounded number was accepted")
+	}
+}
+
+func TestExtractAssistantEpisodeRejectsInvalidArguments(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{
+		calls: []model.ToolCall{
+			assistantEpisodeToolCall(`{"memory":`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-1",
+				"memory":"The assistant recommended Alpha and Beta."
+			}`),
+		},
+	}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	_, operations, err := ext.extractAssistantEpisodes(
+		context.Background(),
+		[]assistantEpisodePair{{
+			user:      model.NewUserMessage("Recommend two options."),
+			assistant: model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		}},
+	)
+	if err != nil {
+		t.Fatalf("error = %v, want content rejection to be non-fatal", err)
+	}
+	if len(operations) != 1 || !strings.Contains(operations[0].Memory, "Alpha and Beta") {
+		t.Fatalf("operations = %#v, want later valid call", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionSkipsInvalidContentAndKeepsOrdinaryOperations(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{calls: []model.ToolCall{makeToolCall(memory.AddToolName, []byte(`{
+			"memory":"User wants two recommendations."
+		}`))}},
+		{calls: []model.ToolCall{assistantEpisodeToolCall(`{
+				"pair_id":"pair-1",
+				"memory":"The assistant recommended 99 options."
+		}`)}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(operations) != 1 || operations[0].Memory != "User wants two recommendations." {
+		t.Fatalf("operations = %#v, want ordinary operation only", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionBatchSkipsOnlyInvalidPair(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{},
+		{calls: []model.ToolCall{
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-1",
+				"memory":"The assistant recommended 99 options."
+			}`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-2",
+				"memory":"The assistant recommended Gamma and Delta."
+			}`),
+		}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Suggest two alternatives."),
+		model.NewAssistantMessage("1. Gamma\n2. Delta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(operations) != 1 || !strings.Contains(operations[0].Memory, "Gamma and Delta") {
+		t.Fatalf("operations = %#v, want valid pair only", operations)
+	}
+}
+
+func TestAssistantEpisodeExtractionBatchRejectsInvalidCallsIndependently(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{
+		{},
+		{calls: []model.ToolCall{
+			makeToolCall(memory.AddToolName, []byte(`{"memory":"ignored"}`)),
+			assistantEpisodeToolCall(`{"pair_id":`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"unknown",
+				"memory":"The assistant recommended Alpha and Beta."
+			}`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-1",
+				"memory":"The assistant recommended Alpha and Beta."
+			}`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-1",
+				"memory":"The assistant recommended a duplicate result."
+			}`),
+			assistantEpisodeToolCall(`{
+				"pair_id":"pair-2",
+				"memory":"The assistant recommended Gamma and Delta."
+			}`),
+		}},
+	}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction())
+	operations, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		model.NewUserMessage("Suggest two alternatives."),
+		model.NewAssistantMessage("1. Gamma\n2. Delta"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(operations) != 2 {
+		t.Fatalf("operations = %#v, want one result per valid pair", operations)
+	}
+	if !strings.Contains(operations[0].Memory, "Alpha and Beta") ||
+		!strings.Contains(operations[1].Memory, "Gamma and Delta") {
+		t.Fatalf("operations are not ordered by source pair: %#v", operations)
+	}
+}
+
+func TestExtractAssistantEpisodeUsesFirstValidCall(t *testing.T) {
+	m := &assistantTestModel{steps: []assistantModelStep{{calls: []model.ToolCall{
+		makeToolCall(memory.AddToolName, []byte(`{"memory":"ignored"}`)),
+		assistantEpisodeToolCall(`{
+			"pair_id":"pair-1",
+			"memory":"The assistant recommended Alpha and Beta."
+		}`),
+		assistantEpisodeToolCall(`{
+			"pair_id":"pair-1",
+			"memory":"The assistant recommended Gamma and Delta."
+		}`),
+	}}}}
+	ext := NewExtractor(m, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	_, operations, err := ext.extractAssistantEpisodes(
+		context.Background(),
+		[]assistantEpisodePair{{
+			user:      model.NewUserMessage("Recommend two options."),
+			assistant: model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		}},
+	)
+	if err != nil {
+		t.Fatalf("extract assistant episode: %v", err)
+	}
+	want := assistantEpisodePrefix + "The assistant recommended Alpha and Beta."
+	if len(operations) != 1 || operations[0].Memory != want {
+		t.Fatalf("operations = %#v, want memory %q", operations, want)
+	}
+}
+
+func TestParseAssistantEpisodeValidation(t *testing.T) {
+	ext := NewExtractor(nil, WithAssistantEpisodeExtraction()).(*memoryExtractor)
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "missing memory",
+			args: map[string]any{},
+			want: "memory is required",
+		},
+		{
+			name: "oversized memory",
+			args: map[string]any{
+				argKeyMemory: strings.Repeat("x", assistantEpisodeMaxBytes+1),
+			},
+			want: "exceeds 4096 bytes",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ext.parseAssistantEpisode(
+				context.Background(),
+				test.args,
+				"The assistant recommended 17 options.",
+			)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	op, err := ext.parseAssistantEpisode(
+		context.Background(),
+		map[string]any{
+			argKeyMemory: "The assistant recommended 17 options.",
+			argKeyTopics: []any{"recommendations", "options"},
+		},
+		"The assistant recommended 17 options.",
+	)
+	if err != nil {
+		t.Fatalf("parse grounded episode: %v", err)
+	}
+	if op.EventTime != nil {
+		t.Fatalf("event time = %v, want nil", op.EventTime)
+	}
+	if !reflect.DeepEqual(op.Topics, []string{"recommendations", "options"}) {
+		t.Fatalf("topics = %#v", op.Topics)
+	}
+}
+
+func TestSelectAssistantEpisodePairs(t *testing.T) {
+	toolAssistant := model.NewAssistantMessage("1. Alpha\n2. Beta")
+	toolAssistant.ToolID = "tool-call"
+	callingAssistant := model.NewAssistantMessage("1. Alpha\n2. Beta")
+	callingAssistant.ToolCalls = []model.ToolCall{{}}
+	tests := []struct {
+		name     string
+		messages []model.Message
+	}{
+		{
+			name:     "no assistant",
+			messages: []model.Message{model.NewUserMessage("Recommend options.")},
+		},
+		{
+			name:     "assistant tool message",
+			messages: []model.Message{model.NewUserMessage("Recommend options."), toolAssistant},
+		},
+		{
+			name:     "assistant making tool call",
+			messages: []model.Message{model.NewUserMessage("Recommend options."), callingAssistant},
+		},
+		{
+			name:     "empty assistant",
+			messages: []model.Message{model.NewUserMessage("Recommend options."), model.NewAssistantMessage("")},
+		},
+		{
+			name:     "assistant without user",
+			messages: []model.Message{model.NewAssistantMessage("1. Alpha\n2. Beta")},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if pairs := selectAssistantEpisodePairs(test.messages); len(pairs) != 0 {
+				t.Fatalf("pairs = %#v, want none", pairs)
+			}
+		})
+	}
+}
+
+func TestValidateAssistantEpisodeQuantities(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		memoryText string
+		wantError  bool
+	}{
+		{
+			name:       "equivalent normalized quantities",
+			source:     "The result was -5°C, cost $5, weighed 1,000.25 kg, measured 5 m, lasted 5 min, held 5 ml, and reached 20%.",
+			memoryText: "The result was -5 °C, cost USD 5, weighed 1000.25 kilograms, measured 5 meters, lasted 5 minutes, held 5 milliliters, and reached 20 percent.",
+		},
+		{
+			name:       "ordinary count nouns are not units",
+			source:     "The assistant proposed 3 meals.",
+			memoryText: "The assistant provided 3 recipes.",
+		},
+		{
+			name:       "date separators are not negative signs",
+			source:     "The event happened on 2023-04-15.",
+			memoryText: "The recorded date was 2023-04-15.",
+		},
+		{
+			name:       "removed negative sign",
+			source:     "The temperature was -5°C.",
+			memoryText: "The temperature was 5°C.",
+			wantError:  true,
+		},
+		{
+			name:       "removed sign before currency",
+			source:     "The adjustment was -$5.",
+			memoryText: "The adjustment was $5.",
+			wantError:  true,
+		},
+		{
+			name:       "equivalent sign placement around currency",
+			source:     "The adjustment was -$5.",
+			memoryText: "The adjustment was $-5.",
+		},
+		{
+			name:       "equivalent decimal currency",
+			source:     "The price was $5.00.",
+			memoryText: "The price was USD 5.",
+		},
+		{
+			name:       "changed currency",
+			source:     "The price was $5.",
+			memoryText: "The price was €5.",
+			wantError:  true,
+		},
+		{
+			name:       "changed unit",
+			source:     "The package weighed 5 kg.",
+			memoryText: "The package weighed 5 lb.",
+			wantError:  true,
+		},
+		{
+			name:       "removed percentage",
+			source:     "The discount was 20%.",
+			memoryText: "The discount was 20.",
+			wantError:  true,
+		},
+		{
+			name:       "changed time unit",
+			source:     "The plan takes 5 days.",
+			memoryText: "The plan takes 5 weeks.",
+			wantError:  true,
+		},
+		{
+			name:       "changed prefix-sharing time unit",
+			source:     "The plan takes 5 minutes.",
+			memoryText: "The plan takes 5 months.",
+			wantError:  true,
+		},
+		{
+			name:       "removed time unit",
+			source:     "The plan takes 5 minutes.",
+			memoryText: "The plan takes 5.",
+			wantError:  true,
+		},
+		{
+			name:       "percentage followed by text",
+			source:     "The offer is 20%off.",
+			memoryText: "The offer is 20 off.",
+			wantError:  true,
+		},
+		{
+			name:       "equivalent compound unit",
+			source:     "The speed was 5 km/h.",
+			memoryText: "The speed was 5 kilometers/hour.",
+		},
+		{
+			name:       "changed compound unit",
+			source:     "The speed was 5 km/h.",
+			memoryText: "The speed was 5 km/s.",
+			wantError:  true,
+		},
+		{
+			name:       "attached identifier cannot hide a changed number",
+			source:     "The selected model is item5.",
+			memoryText: "The selected model is item6.",
+			wantError:  true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateAssistantEpisodeQuantities(test.memoryText, test.source)
+			if test.wantError && err == nil {
+				t.Fatal("quantity change was accepted")
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("valid quantities were rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseAssistantEpisodeQuantityBoundariesAndCurrencies(t *testing.T) {
+	if _, ok := parseAssistantEpisodeQuantity("", nil); ok {
+		t.Fatal("invalid match indexes were accepted")
+	}
+
+	parse := func(text string) (assistantEpisodeQuantity, bool) {
+		t.Helper()
+		match := assistantEpisodeQuantityPattern.FindStringSubmatchIndex(text)
+		if match == nil {
+			t.Fatalf("quantity pattern did not match %q", text)
+		}
+		return parseAssistantEpisodeQuantity(text, match)
+	}
+	for _, text := range []string{"item5", "5items"} {
+		quantity, ok := parse(text)
+		if !ok || quantity.value != "5" {
+			t.Fatalf("identifier-embedded quantity %q was not grounded: %#v", text, quantity)
+		}
+	}
+
+	tests := []struct {
+		text string
+		want assistantEpisodeQuantity
+	}{
+		{
+			text: "5 EUR",
+			want: assistantEpisodeQuantity{value: "5", currency: "eur"},
+		},
+		{
+			text: "$5 EUR",
+			want: assistantEpisodeQuantity{value: "5", currency: "usd/eur"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.text, func(t *testing.T) {
+			got, ok := parse(test.text)
+			if !ok {
+				t.Fatalf("quantity %q was rejected", test.text)
+			}
+			if got != test.want {
+				t.Fatalf("quantity = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeAssistantEpisodeNumber(t *testing.T) {
+	tests := map[string]string{
+		"1000":     "1000",
+		"1,000":    "1000",
+		"1,000.25": "1000.25",
+		"5.00":     "5",
+		"5.20":     "5.2",
+		"1234,567": "1234,567",
+		"1,23":     "1,23",
+	}
+	for input, want := range tests {
+		if got := normalizeAssistantEpisodeNumber(input); got != want {
+			t.Fatalf("normalize %q = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestNormalizeAssistantEpisodeCurrency(t *testing.T) {
+	tests := map[string]string{
+		"$":       "usd",
+		" usd ":   "usd",
+		"€":       "eur",
+		"GBP":     "gbp",
+		"¥":       "yen-yuan",
+		"JPY":     "jpy",
+		"RMB":     "cny",
+		"unknown": "",
+	}
+	for input, want := range tests {
+		if got := normalizeAssistantEpisodeCurrency(input); got != want {
+			t.Fatalf("normalize %q = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestNormalizeAssistantEpisodeUnit(t *testing.T) {
+	tests := map[string]string{
+		"percentage":  "%",
+		"° C":         "°c",
+		"°F":          "°f",
+		"°K":          "°k",
+		"kilograms":   "kg",
+		"milligrams":  "mg",
+		"grams":       "g",
+		"pounds":      "lb",
+		"kilometres":  "km",
+		"miles":       "mi",
+		"centimetres": "cm",
+		"millimetres": "mm",
+		"metres":      "m",
+		"millilitres": "ml",
+		"litres":      "l",
+		"hours":       "h",
+		"minutes":     "min",
+		"seconds":     "s",
+		"days":        "day",
+		"weeks":       "week",
+		"months":      "month",
+		"years":       "year",
+		"km / hours":  "km/h",
+		"unknown":     "",
+		"km/unknown":  "",
+		"km/h/s":      "",
+	}
+	for input, want := range tests {
+		if got := normalizeAssistantEpisodeUnit(input); got != want {
+			t.Fatalf("normalize %q = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestAssistantEpisodeMessageTextUsesTextParts(t *testing.T) {
+	text := " part text "
+	empty := "  "
+	message := model.Message{
+		Content: " body text ",
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeImage},
+			{Type: model.ContentTypeText},
+			{Type: model.ContentTypeText, Text: &empty},
+			{Type: model.ContentTypeText, Text: &text},
+		},
+	}
+	if got, want := assistantEpisodeMessageText(message), "body text\npart text"; got != want {
+		t.Fatalf("message text = %q, want %q", got, want)
+	}
+	message.Content = ""
+	if got, want := assistantEpisodeMessageText(message), "part text"; got != want {
+		t.Fatalf("content-part text = %q, want %q", got, want)
+	}
+}
+
+func TestAssistantEpisodeToolAvailability(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled map[string]struct{}
+		want    bool
+	}{
+		{name: "not configured", want: true},
+		{name: "empty", enabled: map[string]struct{}{}, want: false},
+		{
+			name:    "add enabled",
+			enabled: map[string]struct{}{memory.AddToolName: {}},
+			want:    true,
+		},
+		{
+			name:    "different tool enabled",
+			enabled: map[string]struct{}{memory.ClearToolName: {}},
+			want:    false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ext := &memoryExtractor{enabledTools: test.enabled}
+			if got := ext.assistantEpisodeAddEnabled(); got != test.want {
+				t.Fatalf("assistant add enabled = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeToolSchemaIsStorageCompatible(t *testing.T) {
+	declaration := newAssistantEpisodeTool([]assistantEpisodeSource{{id: "pair-1"}}).Declaration()
+	if got := len(declaration.InputSchema.Properties); got != 3 {
+		t.Fatalf("property count = %d, want 3", got)
+	}
+	if !slices.Contains(declaration.InputSchema.Required, argKeyMemory) ||
+		!slices.Contains(declaration.InputSchema.Required, assistantEpisodePairIDKey) {
+		t.Fatalf("required fields = %#v", declaration.InputSchema.Required)
+	}
+	if got := declaration.InputSchema.Properties[assistantEpisodePairIDKey].Enum; !reflect.DeepEqual(got, []any{"pair-1"}) {
+		t.Fatalf("pair id enum = %#v", got)
+	}
+	for _, frameworkOwned := range []string{
+		argKeyMemoryKind,
+		argKeyEventTime,
+		argKeyParticipants,
+		argKeyLocation,
+	} {
+		if _, ok := declaration.InputSchema.Properties[frameworkOwned]; ok {
+			t.Fatalf("schema exposes framework-owned field %q", frameworkOwned)
+		}
+	}
+}
+
+func TestStrongAssistantEpisodeCandidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		user      string
+		assistant string
+		want      bool
+	}{
+		{
+			name:      "structured list",
+			user:      "Recommend options.",
+			assistant: "- Alpha\n- Beta",
+			want:      true,
+		},
+		{
+			name:      "structured response without list",
+			user:      "Recommend options.",
+			assistant: "Alpha is the best option.",
+			want:      false,
+		},
+		{
+			name:      "quantity",
+			user:      "How many options are available?",
+			assistant: "There are 17 options.",
+			want:      true,
+		},
+		{
+			name:      "number repeated by user",
+			user:      "How many of the 17 options are available?",
+			assistant: "There are 17 options.",
+			want:      false,
+		},
+		{
+			name:      "acknowledgment",
+			user:      "Thanks.",
+			assistant: "You're welcome.",
+			want:      false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := strongAssistantEpisodeCandidate(test.user, test.assistant); got != test.want {
+				t.Fatalf("candidate = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAssistantEpisodeSourceExcerptIsBoundedUTF8(t *testing.T) {
+	const suffix = "-suffix!"
+	input := "prefix-" + strings.Repeat("界", assistantEpisodeSourceMaxBytes) + suffix
+	excerpt := assistantEpisodeSourceExcerpt(input)
+	if len(excerpt) > assistantEpisodeSourceMaxBytes {
+		t.Fatalf("excerpt bytes = %d, want <= %d", len(excerpt), assistantEpisodeSourceMaxBytes)
+	}
+	if !utf8.ValidString(excerpt) {
+		t.Fatal("excerpt is not valid UTF-8")
+	}
+	if !strings.HasPrefix(excerpt, "prefix-") || !strings.HasSuffix(excerpt, suffix) {
+		t.Fatalf("excerpt does not preserve source boundaries: %q", excerpt)
+	}
+	if !strings.Contains(excerpt, assistantEpisodeTruncationMarker) {
+		t.Fatal("excerpt does not report truncation")
+	}
+}
+
+func TestAssistantEpisodeSourceExcerptPreservesInteriorInvalidUTF8(t *testing.T) {
+	input := []byte(strings.Repeat("x", assistantEpisodeSourceMaxBytes*2))
+	input[17] = 0xff
+	input[len(input)-17] = 0xfe
+
+	excerpt := assistantEpisodeSourceExcerpt(string(input))
+	if len(excerpt) > assistantEpisodeSourceMaxBytes {
+		t.Fatalf("excerpt bytes = %d, want <= %d", len(excerpt), assistantEpisodeSourceMaxBytes)
+	}
+	if !strings.Contains(excerpt, string([]byte{0xff})) {
+		t.Fatal("excerpt discarded an invalid byte inside the retained head")
+	}
+	if !strings.Contains(excerpt, string([]byte{0xfe})) {
+		t.Fatal("excerpt discarded an invalid byte inside the retained tail")
+	}
+	if !strings.Contains(excerpt, assistantEpisodeTruncationMarker) {
+		t.Fatal("excerpt does not report truncation")
+	}
+}
+
+func TestAssistantEpisodeSourceExcerptRepairsOnlySplitRune(t *testing.T) {
+	const text = "a界b"
+	if got := trimSplitUTF8End(text, 2); got != 1 {
+		t.Fatalf("head boundary = %d, want 1", got)
+	}
+	if got := trimSplitUTF8Start(text, 2); got != 4 {
+		t.Fatalf("tail boundary = %d, want 4", got)
+	}
+	if got := trimSplitUTF8End(text, 1); got != 1 {
+		t.Fatalf("safe head boundary = %d, want 1", got)
+	}
+	if got := trimSplitUTF8Start(text, len(text)); got != len(text) {
+		t.Fatalf("terminal tail boundary = %d, want %d", got, len(text))
+	}
+
+	invalid := string([]byte{'a', 0x80, 0x80, 0x80, 0x80, 'b'})
+	if got := trimSplitUTF8End(invalid, 4); got != 4 {
+		t.Fatalf("invalid head boundary = %d, want 4", got)
+	}
+	if got := trimSplitUTF8Start(invalid, 4); got != 4 {
+		t.Fatalf("invalid tail boundary = %d, want 4", got)
+	}
+}
+
+func assistantEpisodeToolCall(arguments string) model.ToolCall {
+	return makeToolCall(assistantEpisodeToolName, []byte(arguments))
+}
+
+func requestContainsRole(request *model.Request, role model.Role) bool {
+	for _, message := range request.Messages {
+		if message.Role == role {
+			return true
+		}
+	}
+	return false
+}
+
+func requestContainsRoleContent(
+	request *model.Request,
+	role model.Role,
+	content string,
+) bool {
+	for _, message := range request.Messages {
+		if message.Role == role && message.Content == content {
+			return true
+		}
+	}
+	return false
+}
+
+func requestContainsRoleSubstring(
+	request *model.Request,
+	role model.Role,
+	content string,
+) bool {
+	for _, message := range request.Messages {
+		if message.Role == role && strings.Contains(message.Content, content) {
+			return true
+		}
+	}
+	return false
+}

--- a/memory/extractor/assistant_test.go
+++ b/memory/extractor/assistant_test.go
@@ -1653,13 +1653,31 @@ func TestStrongAssistantEpisodeCandidate(t *testing.T) {
 	}{
 		{
 			name:      "structured list",
-			user:      "Recommend options.",
+			user:      "Which option should I use?",
 			assistant: "- Alpha\n- Beta",
 			want:      true,
 		},
 		{
+			name:      "non english structured list",
+			user:      "どの選択肢を使うべきですか？",
+			assistant: "• Alpha\n• Beta",
+			want:      true,
+		},
+		{
+			name:      "plus marker list",
+			user:      "Which option should I use?",
+			assistant: "+ Alpha\n+ Beta",
+			want:      true,
+		},
+		{
+			name:      "unicode numbered list",
+			user:      "ما الخيارات المتاحة؟",
+			assistant: "١. Alpha\n٢. Beta",
+			want:      true,
+		},
+		{
 			name:      "structured response without list",
-			user:      "Recommend options.",
+			user:      "Which option should I use?",
 			assistant: "Alpha is the best option.",
 			want:      false,
 		},
@@ -1667,6 +1685,12 @@ func TestStrongAssistantEpisodeCandidate(t *testing.T) {
 			name:      "quantity",
 			user:      "How many options are available?",
 			assistant: "There are 17 options.",
+			want:      true,
+		},
+		{
+			name:      "non english quantity",
+			user:      "كم عدد الخيارات المتاحة؟",
+			assistant: "هناك ١٧ خيارًا.",
 			want:      true,
 		},
 		{
@@ -1679,6 +1703,12 @@ func TestStrongAssistantEpisodeCandidate(t *testing.T) {
 			name:      "acknowledgment",
 			user:      "Thanks.",
 			assistant: "You're welcome.",
+			want:      false,
+		},
+		{
+			name:      "one list item",
+			user:      "Show the result.",
+			assistant: "1. Alpha",
 			want:      false,
 		},
 	}

--- a/memory/extractor/assistant_test.go
+++ b/memory/extractor/assistant_test.go
@@ -1336,7 +1336,7 @@ func TestSelectAssistantEpisodePairs(t *testing.T) {
 	}
 }
 
-func TestValidateAssistantEpisodeQuantities(t *testing.T) {
+func TestValidateAssistantEpisodeNumbers(t *testing.T) {
 	tests := []struct {
 		name       string
 		source     string
@@ -1344,9 +1344,9 @@ func TestValidateAssistantEpisodeQuantities(t *testing.T) {
 		wantError  bool
 	}{
 		{
-			name:       "equivalent normalized quantities",
-			source:     "The result was -5°C, cost $5, weighed 1,000.25 kg, measured 5 m, lasted 5 min, held 5 ml, and reached 20%.",
-			memoryText: "The result was -5 °C, cost USD 5, weighed 1000.25 kilograms, measured 5 meters, lasted 5 minutes, held 5 milliliters, and reached 20 percent.",
+			name:       "equivalent normalized numbers",
+			source:     "The result was -5, cost $5.00, weighed 1,000.25, and reached 20%.",
+			memoryText: "The result was -5, cost $5, weighed 1000.25, and reached 20%.",
 		},
 		{
 			name:       "ordinary count nouns are not units",
@@ -1376,9 +1376,9 @@ func TestValidateAssistantEpisodeQuantities(t *testing.T) {
 			memoryText: "The adjustment was $-5.",
 		},
 		{
-			name:       "equivalent decimal currency",
+			name:       "equivalent decimal with currency symbol",
 			source:     "The price was $5.00.",
-			memoryText: "The price was USD 5.",
+			memoryText: "The price was $5.",
 		},
 		{
 			name:       "changed currency",
@@ -1387,10 +1387,14 @@ func TestValidateAssistantEpisodeQuantities(t *testing.T) {
 			wantError:  true,
 		},
 		{
-			name:       "changed unit",
+			name:       "natural language units are delegated to prompt",
 			source:     "The package weighed 5 kg.",
 			memoryText: "The package weighed 5 lb.",
-			wantError:  true,
+		},
+		{
+			name:       "currency labels are delegated to prompt",
+			source:     "The price was USD 5.",
+			memoryText: "The price was EUR 5.",
 		},
 		{
 			name:       "removed percentage",
@@ -1399,39 +1403,24 @@ func TestValidateAssistantEpisodeQuantities(t *testing.T) {
 			wantError:  true,
 		},
 		{
-			name:       "changed time unit",
+			name:       "natural language durations are delegated to prompt",
 			source:     "The plan takes 5 days.",
 			memoryText: "The plan takes 5 weeks.",
-			wantError:  true,
 		},
 		{
-			name:       "changed prefix-sharing time unit",
-			source:     "The plan takes 5 minutes.",
-			memoryText: "The plan takes 5 months.",
-			wantError:  true,
-		},
-		{
-			name:       "removed time unit",
+			name:       "omitted natural language unit is delegated to prompt",
 			source:     "The plan takes 5 minutes.",
 			memoryText: "The plan takes 5.",
-			wantError:  true,
 		},
 		{
-			name:       "percentage followed by text",
+			name:       "percentage symbol remains grounded next to text",
 			source:     "The offer is 20%off.",
-			memoryText: "The offer is 20 off.",
-			wantError:  true,
+			memoryText: "The offer is 20% off.",
 		},
 		{
-			name:       "equivalent compound unit",
-			source:     "The speed was 5 km/h.",
-			memoryText: "The speed was 5 kilometers/hour.",
-		},
-		{
-			name:       "changed compound unit",
+			name:       "compound units are delegated to prompt",
 			source:     "The speed was 5 km/h.",
 			memoryText: "The speed was 5 km/s.",
-			wantError:  true,
 		},
 		{
 			name:       "attached identifier cannot hide a changed number",
@@ -1442,58 +1431,69 @@ func TestValidateAssistantEpisodeQuantities(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateAssistantEpisodeQuantities(test.memoryText, test.source)
+			err := validateAssistantEpisodeNumbers(test.memoryText, test.source)
 			if test.wantError && err == nil {
-				t.Fatal("quantity change was accepted")
+				t.Fatal("number change was accepted")
 			}
 			if !test.wantError && err != nil {
-				t.Fatalf("valid quantities were rejected: %v", err)
+				t.Fatalf("valid numbers were rejected: %v", err)
 			}
 		})
 	}
 }
 
-func TestParseAssistantEpisodeQuantityBoundariesAndCurrencies(t *testing.T) {
-	if _, ok := parseAssistantEpisodeQuantity("", nil); ok {
-		t.Fatal("invalid match indexes were accepted")
-	}
-
-	parse := func(text string) (assistantEpisodeQuantity, bool) {
-		t.Helper()
-		match := assistantEpisodeQuantityPattern.FindStringSubmatchIndex(text)
-		if match == nil {
-			t.Fatalf("quantity pattern did not match %q", text)
-		}
-		return parseAssistantEpisodeQuantity(text, match)
-	}
-	for _, text := range []string{"item5", "5items"} {
-		quantity, ok := parse(text)
-		if !ok || quantity.value != "5" {
-			t.Fatalf("identifier-embedded quantity %q was not grounded: %#v", text, quantity)
-		}
-	}
-
+func TestAssistantEpisodeNumbers(t *testing.T) {
 	tests := []struct {
 		text string
-		want assistantEpisodeQuantity
+		want []assistantEpisodeNumber
 	}{
 		{
-			text: "5 EUR",
-			want: assistantEpisodeQuantity{value: "5", currency: "eur"},
+			text: "The values are -5, +6, $7, € 8, 9%, and 1,000.25.",
+			want: []assistantEpisodeNumber{
+				{sign: "-", value: "5"},
+				{sign: "+", value: "6"},
+				{value: "7", currency: "$"},
+				{value: "8", currency: "€"},
+				{value: "9", percent: true},
+				{value: "1000.25"},
+			},
 		},
 		{
-			text: "$5 EUR",
-			want: assistantEpisodeQuantity{value: "5", currency: "usd/eur"},
+			text: "The dates are 2023-04-15 and the models are item5 and 5items.",
+			want: []assistantEpisodeNumber{
+				{value: "2023"},
+				{value: "04"},
+				{value: "15"},
+				{value: "5"},
+				{value: "5"},
+			},
+		},
+		{
+			text: "1. Alpha\n2) Beta\nThere are 3 choices.",
+			want: []assistantEpisodeNumber{{value: "3"}},
+		},
+		{
+			text: "The adjustment was -$5, $-6, and -$ 7.",
+			want: []assistantEpisodeNumber{
+				{sign: "-", value: "5", currency: "$"},
+				{sign: "-", value: "6", currency: "$"},
+				{sign: "-", value: "7", currency: "$"},
+			},
+		},
+		{
+			text: "$5€ must not become 5, and $\n6 must not bind across lines.",
+			want: []assistantEpisodeNumber{
+				{value: "5", currency: "$€"},
+				{value: "5"},
+				{value: "6"},
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.text, func(t *testing.T) {
-			got, ok := parse(test.text)
-			if !ok {
-				t.Fatalf("quantity %q was rejected", test.text)
-			}
-			if got != test.want {
-				t.Fatalf("quantity = %#v, want %#v", got, test.want)
+			got := assistantEpisodeNumbers(test.text)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("numbers = %#v, want %#v", got, test.want)
 			}
 		})
 	}
@@ -1511,60 +1511,6 @@ func TestNormalizeAssistantEpisodeNumber(t *testing.T) {
 	}
 	for input, want := range tests {
 		if got := normalizeAssistantEpisodeNumber(input); got != want {
-			t.Fatalf("normalize %q = %q, want %q", input, got, want)
-		}
-	}
-}
-
-func TestNormalizeAssistantEpisodeCurrency(t *testing.T) {
-	tests := map[string]string{
-		"$":       "usd",
-		" usd ":   "usd",
-		"€":       "eur",
-		"GBP":     "gbp",
-		"¥":       "yen-yuan",
-		"JPY":     "jpy",
-		"RMB":     "cny",
-		"unknown": "",
-	}
-	for input, want := range tests {
-		if got := normalizeAssistantEpisodeCurrency(input); got != want {
-			t.Fatalf("normalize %q = %q, want %q", input, got, want)
-		}
-	}
-}
-
-func TestNormalizeAssistantEpisodeUnit(t *testing.T) {
-	tests := map[string]string{
-		"percentage":  "%",
-		"° C":         "°c",
-		"°F":          "°f",
-		"°K":          "°k",
-		"kilograms":   "kg",
-		"milligrams":  "mg",
-		"grams":       "g",
-		"pounds":      "lb",
-		"kilometres":  "km",
-		"miles":       "mi",
-		"centimetres": "cm",
-		"millimetres": "mm",
-		"metres":      "m",
-		"millilitres": "ml",
-		"litres":      "l",
-		"hours":       "h",
-		"minutes":     "min",
-		"seconds":     "s",
-		"days":        "day",
-		"weeks":       "week",
-		"months":      "month",
-		"years":       "year",
-		"km / hours":  "km/h",
-		"unknown":     "",
-		"km/unknown":  "",
-		"km/h/s":      "",
-	}
-	for input, want := range tests {
-		if got := normalizeAssistantEpisodeUnit(input); got != want {
 			t.Fatalf("normalize %q = %q, want %q", input, got, want)
 		}
 	}

--- a/memory/extractor/memory.go
+++ b/memory/extractor/memory.go
@@ -19,6 +19,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/internal/assistantmemory"
 	"trpc.group/trpc-go/trpc-agent-go/memory/internal/updatepolicy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/prompt"
@@ -46,7 +47,8 @@ type memoryExtractor struct {
 	prompt   string
 	checkers []Checker
 
-	updatePolicy UpdatePolicy
+	updatePolicy               UpdatePolicy
+	assistantEpisodeExtraction bool
 
 	enabledTools map[string]struct{}
 
@@ -131,60 +133,83 @@ func (e *memoryExtractor) Extract(
 			effective = &copy
 		}
 	}
-
-	// Build request with tool declarations.
-	req := &model.Request{
-		Messages: effective.buildMessages(ctx, messages, existing),
-		Tools:    effective.extractionTools(),
+	if effective.assistantEpisodeExtraction {
+		if enabled, managed := assistantmemory.WorkerConfiguration(ctx); managed && !enabled {
+			return effective.extractOperations(ctx, messages, existing)
+		}
+		return effective.extractWithAssistantEpisodes(ctx, messages, existing)
 	}
+	return effective.extractOperations(ctx, messages, existing)
+}
 
-	// Call model.
-	ctx, rspChan, err := effective.runBeforeModelCallbacks(ctx, req)
+func (e *memoryExtractor) extractOperations(
+	ctx context.Context,
+	messages []model.Message,
+	existing []*memory.Entry,
+) ([]*Operation, error) {
+	req := &model.Request{
+		Messages: e.buildMessages(ctx, messages, existing),
+		Tools:    e.extractionTools(),
+	}
+	var ops []*Operation
+	_, err := e.runExtractionRequest(ctx, req, func(
+		callCtx context.Context,
+		call model.ToolCall,
+	) {
+		if op := e.parseToolCall(callCtx, call); op != nil {
+			ops = append(ops, op)
+		}
+	})
 	if err != nil {
 		return nil, err
 	}
+	return ops, nil
+}
+
+func (e *memoryExtractor) runExtractionRequest(
+	ctx context.Context,
+	req *model.Request,
+	handleCall func(context.Context, model.ToolCall),
+) (context.Context, error) {
+	ctx, rspChan, err := e.runBeforeModelCallbacks(ctx, req)
+	if err != nil {
+		return ctx, err
+	}
 	if rspChan == nil {
-		rspChan, err = effective.model.GenerateContent(ctx, req)
+		rspChan, err = e.model.GenerateContent(ctx, req)
 		if err != nil {
 			log.WarnfContext(ctx, "extractor: model call failed: %v", err)
-			return nil, fmt.Errorf("model call failed: %w", err)
+			return ctx, fmt.Errorf("model call failed: %w", err)
 		}
 	}
 	if rspChan == nil {
-		return nil, errors.New("model returned nil response channel")
+		return ctx, errors.New("model returned nil response channel")
 	}
 
-	// Parse tool calls into operations.
-	var ops []*Operation
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("memory extraction canceled: %w", ctx.Err())
+			return ctx, fmt.Errorf("memory extraction canceled: %w", ctx.Err())
 		case rsp, ok := <-rspChan:
 			if !ok {
-				return ops, nil
+				return ctx, nil
 			}
-			ctx, rsp, err = effective.runAfterModelCallbacks(ctx, req, rsp)
+			ctx, rsp, err = e.runAfterModelCallbacks(ctx, req, rsp)
 			if err != nil {
-				return nil, err
+				return ctx, err
 			}
 			if rsp == nil {
 				continue
 			}
 			if rsp.Error != nil {
-				return nil, fmt.Errorf("model error: %s", rsp.Error.Message)
+				return ctx, fmt.Errorf("model error: %s", rsp.Error.Message)
 			}
 			if len(rsp.Choices) == 0 {
 				continue
 			}
-			// Choices are alternative candidates rather than cumulative
-			// tool-call batches, so only the selected primary choice
-			// should be converted into operations.
+			// Choices are alternatives, so only the primary choice is used.
 			for _, call := range rsp.Choices[0].Message.ToolCalls {
-				op := effective.parseToolCall(ctx, call)
-				if op != nil {
-					ops = append(ops, op)
-				}
+				handleCall(ctx, call)
 			}
 		}
 	}
@@ -295,20 +320,10 @@ func (e *memoryExtractor) buildSystemPrompt(
 ) string {
 	var sb strings.Builder
 
-	dateStr := refDate.UTC().Format(time.DateOnly)
-	renderedPrompt, err := prompt.Text{Template: e.prompt}.Render(prompt.RenderEnv{
-		Vars: prompt.Vars{
-			"current_date": dateStr,
-		},
-	})
-	if err != nil {
-		renderedPrompt = e.prompt
-	}
-	sb.WriteString(renderedPrompt)
+	sb.WriteString(e.renderPrompt(refDate))
 	if policyBlock := e.updatePolicyPromptBlock(); policyBlock != "" {
 		sb.WriteString(policyBlock)
 	}
-
 	// Append available actions.
 	sb.WriteString("\n<available_actions>\n")
 	sb.WriteString(e.availableActionsBlock())
@@ -327,6 +342,18 @@ func (e *memoryExtractor) buildSystemPrompt(
 	}
 
 	return sb.String()
+}
+
+func (e *memoryExtractor) renderPrompt(refDate time.Time) string {
+	rendered, err := prompt.Text{Template: e.prompt}.Render(prompt.RenderEnv{
+		Vars: prompt.Vars{
+			"current_date": refDate.UTC().Format(time.DateOnly),
+		},
+	})
+	if err != nil {
+		return e.prompt
+	}
+	return rendered
 }
 
 // toolActionDescriptions maps background tool names to their

--- a/memory/extractor/tools.go
+++ b/memory/extractor/tools.go
@@ -9,8 +9,11 @@
 package extractor
 
 import (
+	"encoding/json"
+
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	memorytool "trpc.group/trpc-go/trpc-agent-go/memory/tool"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -40,6 +43,65 @@ func filterTools(
 		}
 	}
 	return filtered
+}
+
+// assistantEpisodeOrdinaryTools adds request-local source provenance to
+// destructive tools. The extra argument is visible only to the opt-in
+// extraction request and is ignored by normal operation parsing.
+func assistantEpisodeOrdinaryTools(
+	tools map[string]tool.Tool,
+	userCount int,
+) map[string]tool.Tool {
+	result := make(map[string]tool.Tool, len(tools))
+	for name, current := range tools {
+		result[name] = current
+	}
+	sourceIndexes := make([]any, userCount)
+	for i := range sourceIndexes {
+		sourceIndexes[i] = i + 1
+	}
+	for _, name := range []string{memory.DeleteToolName, memory.ClearToolName} {
+		current, ok := result[name]
+		if !ok || current.Declaration() == nil ||
+			current.Declaration().InputSchema == nil {
+			continue
+		}
+		declaration := *current.Declaration()
+		schema := *declaration.InputSchema
+		schema.Properties = make(map[string]*tool.Schema, len(schema.Properties)+1)
+		for propertyName, property := range declaration.InputSchema.Properties {
+			schema.Properties[propertyName] = property
+		}
+		schema.Properties[assistantEpisodeSourceIndexKey] = &tool.Schema{
+			Type: "integer",
+			Description: "The source_user_index label of the user message " +
+				"that requests this destructive operation.",
+			Enum: sourceIndexes,
+		}
+		schema.Required = append(
+			append([]string(nil), schema.Required...),
+			assistantEpisodeSourceIndexKey,
+		)
+		declaration.InputSchema = &schema
+		result[name] = &declarationOnlyTool{decl: &declaration}
+	}
+	return result
+}
+
+func assistantEpisodeOperationSourceIndex(
+	call model.ToolCall,
+	userCount int,
+) (int, bool) {
+	var args struct {
+		SourceUserIndex int `json:"source_user_index"`
+	}
+	if err := json.Unmarshal(call.Function.Arguments, &args); err != nil {
+		return 0, false
+	}
+	if args.SourceUserIndex <= 0 || args.SourceUserIndex > userCount {
+		return 0, false
+	}
+	return args.SourceUserIndex, true
 }
 
 // backgroundTools is the pre-built map of background tools for model request.

--- a/memory/extractor/tools.go
+++ b/memory/extractor/tools.go
@@ -10,6 +10,7 @@ package extractor
 
 import (
 	"encoding/json"
+	"slices"
 
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	memorytool "trpc.group/trpc-go/trpc-agent-go/memory/tool"
@@ -46,8 +47,8 @@ func filterTools(
 }
 
 // assistantEpisodeOrdinaryTools adds request-local source provenance to
-// destructive tools. The extra argument is visible only to the opt-in
-// extraction request and is ignored by normal operation parsing.
+// destructive tools. The extra arguments are visible only to the opt-in
+// extraction request and are ignored by normal operation parsing.
 func assistantEpisodeOrdinaryTools(
 	tools map[string]tool.Tool,
 	userCount int,
@@ -72,16 +73,32 @@ func assistantEpisodeOrdinaryTools(
 		for propertyName, property := range declaration.InputSchema.Properties {
 			schema.Properties[propertyName] = property
 		}
-		schema.Properties[assistantEpisodeSourceIndexKey] = &tool.Schema{
-			Type: "integer",
-			Description: "The source_user_index label of the user message " +
-				"that requests this destructive operation.",
-			Enum: sourceIndexes,
+		schema.Required = append([]string(nil), schema.Required...)
+		if name == memory.ClearToolName {
+			schema.Properties[assistantEpisodeSourceIndexKey] = &tool.Schema{
+				Type: "integer",
+				Description: "The 1-based position among user messages of the " +
+					"message that requests this clear operation.",
+				Enum: sourceIndexes,
+			}
+			schema.Required = append(
+				schema.Required,
+				assistantEpisodeSourceIndexKey,
+			)
+		} else {
+			schema.Properties[assistantEpisodeAffectedSourceIndexesKey] = &tool.Schema{
+				Type: "array",
+				Description: "The 1-based positions among user messages whose " +
+					"paired assistant results are covered by this deletion. Use " +
+					"an empty array when no assistant result in this request is " +
+					"covered.",
+				Items: &tool.Schema{Type: "integer", Enum: sourceIndexes},
+			}
+			schema.Required = append(
+				schema.Required,
+				assistantEpisodeAffectedSourceIndexesKey,
+			)
 		}
-		schema.Required = append(
-			append([]string(nil), schema.Required...),
-			assistantEpisodeSourceIndexKey,
-		)
 		declaration.InputSchema = &schema
 		result[name] = &declarationOnlyTool{decl: &declaration}
 	}
@@ -102,6 +119,43 @@ func assistantEpisodeOperationSourceIndex(
 		return 0, false
 	}
 	return args.SourceUserIndex, true
+}
+
+func assistantEpisodeDeleteSourceIndexes(
+	call model.ToolCall,
+	userCount int,
+) ([]int, bool) {
+	var args map[string]json.RawMessage
+	if err := json.Unmarshal(call.Function.Arguments, &args); err != nil {
+		return nil, false
+	}
+	raw, ok := args[assistantEpisodeAffectedSourceIndexesKey]
+	if !ok {
+		return nil, false
+	}
+	var indexes []int
+	if err := json.Unmarshal(raw, &indexes); err != nil {
+		return nil, false
+	}
+	if indexes == nil {
+		return nil, false
+	}
+	seen := make(map[int]struct{}, len(indexes))
+	for _, index := range indexes {
+		if index <= 0 || index > userCount {
+			return nil, false
+		}
+		if _, ok := seen[index]; ok {
+			continue
+		}
+		seen[index] = struct{}{}
+	}
+	result := make([]int, 0, len(seen))
+	for index := range seen {
+		result = append(result, index)
+	}
+	slices.Sort(result)
+	return result, true
 }
 
 // backgroundTools is the pre-built map of background tools for model request.

--- a/memory/internal/assistantmemory/assistantmemory.go
+++ b/memory/internal/assistantmemory/assistantmemory.go
@@ -1,0 +1,50 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package assistantmemory carries the built-in extractor's assistant-episode
+// configuration across memory package boundaries.
+package assistantmemory
+
+import (
+	"context"
+)
+
+// Prefix labels assistant-provided conversation episodes stored as ordinary
+// episodic memories. It is descriptive content and does not carry provenance.
+const Prefix = "Assistant-provided conversation episode: "
+
+type provider interface {
+	ConfiguredAssistantEpisodeExtraction() Value
+}
+
+// Value identifies whether assistant-episode extraction was configured on a
+// built-in extractor.
+type Value bool
+
+type workerConfigurationKey struct{}
+
+// Enabled reports whether a built-in extractor has assistant-episode
+// extraction enabled. External extractors cannot accidentally implement this
+// capability because its interface is internal to this module.
+func Enabled(value any) bool {
+	provider, ok := value.(provider)
+	return ok && bool(provider.ConfiguredAssistantEpisodeExtraction())
+}
+
+// WithWorkerConfiguration records the assistant-episode setting captured by
+// an Auto memory worker for one extraction call.
+func WithWorkerConfiguration(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, workerConfigurationKey{}, enabled)
+}
+
+// WorkerConfiguration returns the setting supplied by an Auto memory worker.
+// The second result is false for direct extractor calls outside a worker.
+func WorkerConfiguration(ctx context.Context) (bool, bool) {
+	enabled, ok := ctx.Value(workerConfigurationKey{}).(bool)
+	return enabled, ok
+}

--- a/memory/internal/assistantmemory/assistantmemory_test.go
+++ b/memory/internal/assistantmemory/assistantmemory_test.go
@@ -1,0 +1,50 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package assistantmemory
+
+import (
+	"context"
+	"testing"
+)
+
+type configuredProvider struct {
+	enabled Value
+}
+
+func (p configuredProvider) ConfiguredAssistantEpisodeExtraction() Value {
+	return p.enabled
+}
+
+func TestEnabled(t *testing.T) {
+	if Enabled(nil) {
+		t.Fatal("nil value enabled assistant extraction")
+	}
+	if Enabled(struct{}{}) {
+		t.Fatal("unrelated value enabled assistant extraction")
+	}
+	if Enabled(configuredProvider{}) {
+		t.Fatal("disabled provider enabled assistant extraction")
+	}
+	if !Enabled(configuredProvider{enabled: true}) {
+		t.Fatal("enabled provider did not enable assistant extraction")
+	}
+}
+
+func TestWorkerConfiguration(t *testing.T) {
+	if _, ok := WorkerConfiguration(context.Background()); ok {
+		t.Fatal("unmanaged context reported worker configuration")
+	}
+	for _, enabled := range []bool{false, true} {
+		ctx := WithWorkerConfiguration(context.Background(), enabled)
+		got, ok := WorkerConfiguration(ctx)
+		if !ok || got != enabled {
+			t.Fatalf("worker configuration = (%v, %v), want (%v, true)", got, ok, enabled)
+		}
+	}
+}

--- a/memory/internal/memory/auto.go
+++ b/memory/internal/memory/auto.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/memory/extractor"
+	"trpc.group/trpc-go/trpc-agent-go/memory/internal/assistantmemory"
 	"trpc.group/trpc-go/trpc-agent-go/memory/internal/updatepolicy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -73,7 +74,6 @@ const (
 	// return per reconcile probe. Keeping this small bounds the extra
 	// cost while still surfacing the closest match reliably.
 	reconcileTopK = 3
-
 	// reconcileSkipScore: at or above this search Score the candidate
 	// is treated as an equivalent memory. The add is either dropped or
 	// rewritten into a topic-only update.
@@ -166,8 +166,8 @@ type memoryExtractorUnwrapper interface {
 	UnwrapMemoryExtractor() extractor.MemoryExtractor
 }
 
-// ConfigureExtractorEnabledTools passes enabled tool flags to the
-// extractor if it implements EnabledToolsConfigurer.
+// ConfigureExtractorEnabledTools passes enabled tool flags to the extractor
+// and to the built-in capability owner exposed by a cooperating decorator.
 func ConfigureExtractorEnabledTools(
 	ext extractor.MemoryExtractor,
 	enabledTools map[string]struct{},
@@ -175,6 +175,23 @@ func ConfigureExtractorEnabledTools(
 	if c, ok := ext.(EnabledToolsConfigurer); ok {
 		c.SetEnabledTools(enabledTools)
 	}
+	capabilityExtractor := unwrapMemoryExtractor(ext)
+	if isNilMemoryExtractor(capabilityExtractor) ||
+		sameMemoryExtractor(ext, capabilityExtractor) {
+		return
+	}
+	if c, ok := capabilityExtractor.(EnabledToolsConfigurer); ok {
+		c.SetEnabledTools(enabledTools)
+	}
+}
+
+func sameMemoryExtractor(first, second extractor.MemoryExtractor) bool {
+	firstType := reflect.TypeOf(first)
+	if firstType == nil || firstType != reflect.TypeOf(second) ||
+		!firstType.Comparable() {
+		return false
+	}
+	return first == second
 }
 
 // unwrapMemoryExtractor follows cooperating decorators to the extractor that
@@ -243,13 +260,14 @@ type MemoryOperator interface {
 
 // AutoMemoryWorker manages async memory extraction workers.
 type AutoMemoryWorker struct {
-	config       AutoMemoryConfig
-	operator     MemoryOperator
-	updatePolicy extractor.UpdatePolicy
-	jobChans     []chan *MemoryJob
-	wg           sync.WaitGroup
-	mu           sync.RWMutex
-	started      bool
+	config                     AutoMemoryConfig
+	operator                   MemoryOperator
+	updatePolicy               extractor.UpdatePolicy
+	assistantEpisodeExtraction bool
+	jobChans                   []chan *MemoryJob
+	wg                         sync.WaitGroup
+	mu                         sync.RWMutex
+	started                    bool
 }
 
 // NewAutoMemoryWorker creates a new auto memory worker.
@@ -260,10 +278,12 @@ func NewAutoMemoryWorker(
 	operator MemoryOperator,
 ) *AutoMemoryWorker {
 	config.EnabledTools = maps.Clone(config.EnabledTools)
+	capabilityExtractor := unwrapMemoryExtractor(config.Extractor)
 	return &AutoMemoryWorker{
-		config:       config,
-		operator:     operator,
-		updatePolicy: updatePolicyFor(unwrapMemoryExtractor(config.Extractor)),
+		config:                     config,
+		operator:                   operator,
+		updatePolicy:               updatePolicyFor(capabilityExtractor),
+		assistantEpisodeExtraction: assistantmemory.Enabled(capabilityExtractor),
 	}
 }
 
@@ -337,7 +357,11 @@ func (w *AutoMemoryWorker) EnqueueJob(ctx context.Context, sess *session.Session
 	}
 
 	since := readLastExtractAt(sess)
-	latestTs, messages := scanDeltaSince(sess, since)
+	latestTs, messages := scanDeltaSince(
+		sess,
+		since,
+		w.assistantEpisodeExtraction,
+	)
 	if len(messages) == 0 {
 		log.DebugfContext(ctx, "auto_memory: skipped due to no new messages for user %s/%s",
 			userKey.AppName, userKey.UserID)
@@ -493,10 +517,15 @@ func (w *AutoMemoryWorker) prepareAutoMemoryOperations(
 		return nil, fmt.Errorf("auto_memory: prepare existing memories failed: %w", err)
 	}
 
-	// Extract memory operations.
+	// Worker-owned context markers keep built-in extractor behavior aligned
+	// with the capabilities visible to this worker through decorators.
 	extractionCtx := updatepolicy.WithWorkerConfiguration(
 		ctx,
 		updatepolicy.Value(w.updatePolicy),
+	)
+	extractionCtx = assistantmemory.WithWorkerConfiguration(
+		extractionCtx,
+		w.assistantEpisodeExtraction,
 	)
 	ops, err := w.config.Extractor.Extract(extractionCtx, messages, existing)
 	if err != nil {
@@ -773,6 +802,7 @@ func writeLastExtractAt(sess *session.Session, ts time.Time) {
 func scanDeltaSince(
 	sess *session.Session,
 	since time.Time,
+	primaryResponseOnly bool,
 ) (time.Time, []model.Message) {
 	var latestTs time.Time
 	var messages []model.Message
@@ -795,8 +825,18 @@ func scanDeltaSince(
 			continue
 		}
 
+		choices := e.Response.Choices
+		if primaryResponseOnly {
+			choices = nil
+			for index := range e.Response.Choices {
+				if e.Response.Choices[index].Index == 0 {
+					choices = e.Response.Choices[index : index+1]
+					break
+				}
+			}
+		}
 		// Extract messages from response choices, excluding tool-related messages.
-		for _, choice := range e.Response.Choices {
+		for _, choice := range choices {
 			msg := choice.Message
 			// Skip tool messages and messages with tool calls.
 			if msg.Role == model.RoleTool || msg.ToolID != "" {
@@ -910,10 +950,12 @@ func (w *AutoMemoryWorker) decideAddOp(
 	var best *memory.Entry
 	bestJaccard := 0.0
 	bestTier := -1
+	eligibleCount := 0
 	for _, c := range candidates {
 		if c == nil || c.Memory == nil {
 			continue
 		}
+		eligibleCount++
 		j := tokenJaccard(op.Memory, c.Memory.Memory)
 		tier := reconcileDecisionTier(c.Score, j)
 		if best == nil ||
@@ -924,6 +966,9 @@ func (w *AutoMemoryWorker) decideAddOp(
 			best = c
 			bestJaccard = j
 			bestTier = tier
+		}
+		if eligibleCount == reconcileTopK {
+			break
 		}
 	}
 	if best == nil || best.Memory == nil || best.ID == "" {

--- a/memory/internal/memory/auto_test.go
+++ b/memory/internal/memory/auto_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -23,6 +24,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/memory"
 	"trpc.group/trpc-go/trpc-agent-go/memory/extractor"
+	"trpc.group/trpc-go/trpc-agent-go/memory/internal/assistantmemory"
+	"trpc.group/trpc-go/trpc-agent-go/memory/internal/updatepolicy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
@@ -43,6 +46,20 @@ type mockExtractor struct {
 	ops             []*extractor.Operation
 	err             error
 	captureExisting func([]*memory.Entry)
+	metadata        map[string]any
+}
+
+type mockAssistantExtractor struct {
+	*mockExtractor
+	policy updatepolicy.Value
+}
+
+func (m *mockAssistantExtractor) ConfiguredAssistantEpisodeExtraction() assistantmemory.Value {
+	return true
+}
+
+func (m *mockAssistantExtractor) ConfiguredUpdatePolicy() updatepolicy.Value {
+	return m.policy
 }
 
 func (m *mockExtractor) Extract(
@@ -68,6 +85,9 @@ func (m *mockExtractor) SetPrompt(prompt string) {}
 func (m *mockExtractor) SetModel(model model.Model) {}
 
 func (m *mockExtractor) Metadata() map[string]any {
+	if m.metadata != nil {
+		return m.metadata
+	}
 	return map[string]any{}
 }
 
@@ -355,7 +375,7 @@ func TestScanDeltaSince_SkipsToolMessages(t *testing.T) {
 		model.NewToolMessage("call_1", memory.SearchToolName, "{\"count\":0}"))
 	appendSessionMessage(sess, base.Add(assistOffset), model.NewAssistantMessage("answer"))
 
-	latestTs, msgs := scanDeltaSince(sess, time.Time{})
+	latestTs, msgs := scanDeltaSince(sess, time.Time{}, false)
 	require.Equal(t, base.Add(assistOffset), latestTs)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, model.RoleUser, msgs[0].Role)
@@ -1012,12 +1032,14 @@ type mockModel struct {
 	name      string
 	responses []*model.Response
 	err       error
+	calls     int
 }
 
 func (m *mockModel) GenerateContent(
 	ctx context.Context,
 	request *model.Request,
 ) (<-chan *model.Response, error) {
+	m.calls++
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -1031,6 +1053,116 @@ func (m *mockModel) GenerateContent(
 
 func (m *mockModel) Info() model.Info {
 	return model.Info{Name: m.name}
+}
+
+type assistantDeadlineModel struct {
+	calls int
+}
+
+type assistantBestEffortModel struct {
+	calls int
+}
+
+type assistantDeleteModel struct {
+	calls int
+}
+
+func (m *assistantDeleteModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	m.calls++
+	var name string
+	var arguments []byte
+	if m.calls == 1 {
+		name = memory.DeleteToolName
+		arguments, _ = json.Marshal(map[string]string{"memory_id": "existing"})
+	} else {
+		name = "memory_assistant_episode"
+		arguments, _ = json.Marshal(map[string]any{
+			"pair_id": "pair-1",
+			"memory":  "The assistant recommended Alpha and Beta.",
+		})
+	}
+	return responseChannel([]model.ToolCall{{
+		Type: "function",
+		Function: model.FunctionDefinitionParam{
+			Name:      name,
+			Arguments: arguments,
+		},
+	}}), nil
+}
+
+func (m *assistantDeleteModel) Info() model.Info {
+	return model.Info{Name: "assistant-delete-model"}
+}
+
+func (m *assistantBestEffortModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	m.calls++
+	switch m.calls {
+	case 1:
+		arguments, _ := json.Marshal(map[string]string{
+			"memory": "User wants two recommendations.",
+		})
+		return responseChannel([]model.ToolCall{{
+			Type: "function",
+			Function: model.FunctionDefinitionParam{
+				Name:      memory.AddToolName,
+				Arguments: arguments,
+			},
+		}}), nil
+	case 2:
+		return nil, errors.New("assistant stage unavailable")
+	default:
+		return nil, fmt.Errorf("unexpected model call %d", m.calls)
+	}
+}
+
+func (m *assistantBestEffortModel) Info() model.Info {
+	return model.Info{Name: "assistant-best-effort-model"}
+}
+
+func (m *assistantDeadlineModel) GenerateContent(
+	ctx context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	call := m.calls
+	m.calls++
+
+	switch call {
+	case 0:
+		arguments, _ := json.Marshal(map[string]string{
+			"memory": "User wants two recommendations.",
+		})
+		return responseChannel([]model.ToolCall{{
+			Type: "function",
+			Function: model.FunctionDefinitionParam{
+				Name:      memory.AddToolName,
+				Arguments: arguments,
+			},
+		}}), nil
+	case 1:
+		<-ctx.Done()
+		return nil, ctx.Err()
+	default:
+		return nil, fmt.Errorf("unexpected model call %d", call)
+	}
+}
+
+func (m *assistantDeadlineModel) Info() model.Info {
+	return model.Info{Name: "assistant-deadline-model"}
+}
+
+func responseChannel(calls []model.ToolCall) <-chan *model.Response {
+	responses := make(chan *model.Response, 1)
+	responses <- &model.Response{Choices: []model.Choice{{
+		Message: model.Message{ToolCalls: calls},
+	}}}
+	close(responses)
+	return responses
 }
 
 // newMockModelWithToolCalls creates a mock model that returns tool calls.
@@ -1499,11 +1631,80 @@ func TestScanDeltaSince_NilResponse(t *testing.T) {
 	appendSessionMessage(sess, now.Add(time.Second),
 		model.NewUserMessage("hello"))
 
-	latestTs, msgs := scanDeltaSince(sess, time.Time{})
+	latestTs, msgs := scanDeltaSince(sess, time.Time{}, false)
 
 	assert.Equal(t, now.Add(time.Second), latestTs)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "hello", msgs[0].Content)
+}
+
+func TestScanDeltaSince_PreservesAllResponseChoices(t *testing.T) {
+	sess := newTestSession("test-app", "user-1")
+	now := time.Now()
+	sess.Events = append(sess.Events, event.Event{
+		Timestamp: now,
+		Response: &model.Response{Choices: []model.Choice{
+			{Index: 0, Message: model.NewAssistantMessage("first choice")},
+			{Index: 1, Message: model.NewAssistantMessage("second choice")},
+		}},
+	})
+
+	_, msgs := scanDeltaSince(sess, time.Time{}, false)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "first choice", msgs[0].Content)
+	assert.Equal(t, "second choice", msgs[1].Content)
+}
+
+func TestScanDeltaSince_AssistantExtractionUsesPrimaryResponseChoice(t *testing.T) {
+	sess := newTestSession("test-app", "user-1")
+	now := time.Now()
+	sess.Events = append(sess.Events, event.Event{
+		Timestamp: now,
+		Response: &model.Response{Choices: []model.Choice{
+			{Index: 1, Message: model.NewAssistantMessage("alternative choice")},
+			{Index: 0, Message: model.NewAssistantMessage("primary choice")},
+		}},
+	})
+
+	_, msgs := scanDeltaSince(sess, time.Time{}, true)
+
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "primary choice", msgs[0].Content)
+}
+
+func TestScanDeltaSince_AssistantExtractionRequiresPrimaryResponseChoice(t *testing.T) {
+	sess := newTestSession("test-app", "user-1")
+	now := time.Now()
+	sess.Events = append(sess.Events, event.Event{
+		Timestamp: now,
+		Response: &model.Response{Choices: []model.Choice{
+			{Index: 1, Message: model.NewAssistantMessage("alternative choice")},
+		}},
+	})
+
+	_, msgs := scanDeltaSince(sess, time.Time{}, true)
+
+	assert.Empty(t, msgs)
+}
+
+func TestScanDeltaSince_AssistantExtractionKeepsPrimaryChoicePerEvent(t *testing.T) {
+	sess := newTestSession("test-app", "user-1")
+	now := time.Now()
+	for i, content := range []string{"first event", "second event"} {
+		sess.Events = append(sess.Events, event.Event{
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+			Response: &model.Response{Choices: []model.Choice{
+				{Index: 0, Message: model.NewAssistantMessage(content)},
+			}},
+		})
+	}
+
+	_, msgs := scanDeltaSince(sess, time.Time{}, true)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "first event", msgs[0].Content)
+	assert.Equal(t, "second event", msgs[1].Content)
 }
 
 func TestScanDeltaSince_SkipsMessagesWithToolCalls(t *testing.T) {
@@ -1527,7 +1728,7 @@ func TestScanDeltaSince_SkipsMessagesWithToolCalls(t *testing.T) {
 	appendSessionMessage(sess, now.Add(time.Second),
 		model.NewAssistantMessage("Here is the result."))
 
-	_, msgs := scanDeltaSince(sess, time.Time{})
+	_, msgs := scanDeltaSince(sess, time.Time{}, false)
 
 	// Only the normal message should be included.
 	require.Len(t, msgs, 1)
@@ -1545,7 +1746,7 @@ func TestScanDeltaSince_ContentParts(t *testing.T) {
 		ContentParts: []model.ContentPart{{Type: "text", Text: &textContent}},
 	})
 
-	_, msgs := scanDeltaSince(sess, time.Time{})
+	_, msgs := scanDeltaSince(sess, time.Time{}, false)
 
 	require.Len(t, msgs, 1)
 	assert.Equal(t, model.RoleUser, msgs[0].Role)
@@ -1561,7 +1762,7 @@ func TestScanDeltaSince_EmptyContentSkipped(t *testing.T) {
 		Role: model.RoleAssistant,
 	})
 
-	_, msgs := scanDeltaSince(sess, time.Time{})
+	_, msgs := scanDeltaSince(sess, time.Time{}, false)
 
 	assert.Empty(t, msgs)
 }
@@ -1589,6 +1790,71 @@ func TestAutoMemoryWorker_WritesLastExtractAt_OnSuccess(t *testing.T) {
 	ts, parseErr := time.Parse(time.RFC3339Nano, string(raw))
 	require.NoError(t, parseErr)
 	assert.True(t, ts.Equal(t2.UTC()))
+}
+
+func TestAutoMemoryWorker_AssistantDeadlineAdvancesWatermark(t *testing.T) {
+	extractionModel := &assistantDeadlineModel{}
+	ext := extractor.NewExtractor(extractionModel, extractor.WithAssistantEpisodeExtraction())
+	op := newMockOperator()
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{
+		Extractor:        ext,
+		MemoryJobTimeout: 100 * time.Millisecond,
+	}, op)
+
+	sess := newTestSession("test-app", "user-1")
+	latest := time.Now().UTC()
+	job := &MemoryJob{
+		Ctx:      context.Background(),
+		UserKey:  memory.UserKey{AppName: "test-app", UserID: "user-1"},
+		Session:  sess,
+		LatestTs: latest,
+		Messages: []model.Message{
+			model.NewUserMessage("Recommend two options."),
+			model.NewAssistantMessage("1. Alpha\n2. Beta"),
+			model.NewUserMessage("Suggest two alternatives."),
+			model.NewAssistantMessage("1. Gamma\n2. Delta"),
+		},
+	}
+
+	worker.processJob(job)
+	raw, ok := sess.GetState(memory.SessionStateKeyAutoMemoryLastExtractAt)
+	require.True(t, ok, "optional assistant deadline blocked the watermark")
+	watermark, err := time.Parse(time.RFC3339Nano, string(raw))
+	require.NoError(t, err)
+	assert.True(t, watermark.Equal(latest))
+	assert.Equal(t, 1, op.addCalls, "ordinary user memory was not preserved")
+	assert.Equal(t, 2, extractionModel.calls)
+}
+
+func TestAutoMemoryWorker_AssistantOptionalFailureAdvancesWatermark(t *testing.T) {
+	extractionModel := &assistantBestEffortModel{}
+	ext := extractor.NewExtractor(
+		extractionModel,
+		extractor.WithAssistantEpisodeExtraction(),
+	)
+	op := newMockOperator()
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, op)
+
+	sess := newTestSession("test-app", "user-1")
+	latest := time.Now().UTC()
+	worker.processJob(&MemoryJob{
+		Ctx:      context.Background(),
+		UserKey:  memory.UserKey{AppName: "test-app", UserID: "user-1"},
+		Session:  sess,
+		LatestTs: latest,
+		Messages: []model.Message{
+			model.NewUserMessage("Recommend two options."),
+			model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		},
+	})
+
+	raw, ok := sess.GetState(memory.SessionStateKeyAutoMemoryLastExtractAt)
+	require.True(t, ok, "optional assistant failure blocked the watermark")
+	watermark, err := time.Parse(time.RFC3339Nano, string(raw))
+	require.NoError(t, err)
+	assert.True(t, watermark.Equal(latest))
+	assert.Equal(t, 1, op.addCalls)
+	assert.Equal(t, 2, extractionModel.calls)
 }
 
 // configurableExtractor is a mock extractor implementing
@@ -1621,6 +1887,36 @@ func TestConfigureExtractorEnabledTools(t *testing.T) {
 			memory.AddToolName: {},
 		})
 	})
+
+	t.Run("cooperating decorator configures capability owner", func(t *testing.T) {
+		inner := &configurableExtractor{}
+		ext := &unwrappingExtractor{MemoryExtractor: inner}
+		enabled := map[string]struct{}{
+			memory.DeleteToolName: {},
+		}
+		ConfigureExtractorEnabledTools(ext, enabled)
+		assert.Equal(t, enabled, inner.enabledTools)
+	})
+}
+
+func TestConfigureExtractorEnabledToolsPreventsWrappedAssistantRequest(t *testing.T) {
+	recording := &requestRecordingModel{mockModel: &mockModel{name: "wrapped"}}
+	builtin := extractor.NewExtractor(
+		recording,
+		extractor.WithAssistantEpisodeExtraction(),
+	)
+	ext := &unwrappingExtractor{MemoryExtractor: builtin}
+	ConfigureExtractorEnabledTools(ext, map[string]struct{}{
+		memory.DeleteToolName: {},
+	})
+
+	_, err := ext.Extract(context.Background(), []model.Message{
+		model.NewUserMessage("Recommend two options."),
+		model.NewAssistantMessage("1. Alpha\n2. Beta"),
+	}, nil)
+	require.NoError(t, err)
+	require.Len(t, recording.requests, 1)
+	assert.NotContains(t, recording.requests[0].Tools, memory.AddToolName)
 }
 
 func TestAutoMemoryWorker_IsToolEnabled(t *testing.T) {
@@ -1954,6 +2250,271 @@ func TestCreateAutoMemory_SearchError_FallsBackToRead(t *testing.T) {
 // reconcileUserKey returns the userKey used by reconcile decision tests.
 func reconcileUserKey() memory.UserKey {
 	return memory.UserKey{AppName: "app", UserID: "u1"}
+}
+
+func TestCreateAutoMemory_AssistantPrefixDoesNotBypassReconcile(t *testing.T) {
+	text := assistantmemory.Prefix + "The assistant recommended Alpha and Beta."
+	ext := &mockAssistantExtractor{mockExtractor: &mockExtractor{
+		ops: []*extractor.Operation{{
+			Type:       extractor.OperationAdd,
+			Memory:     text,
+			MemoryKind: memory.KindEpisode,
+		}},
+	}}
+	op := newMockOperator()
+	op.searchResults = []*memory.Entry{{
+		ID:     "assistant-existing",
+		Memory: &memory.Memory{Memory: text, Kind: memory.KindEpisode},
+		Score:  0.99,
+	}}
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, op)
+
+	err := worker.createAutoMemory(
+		context.Background(),
+		reconcileUserKey(),
+		[]model.Message{model.NewUserMessage("Recommend two options.")},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, op.addCalls)
+	assert.Equal(t, 0, op.updateCalls)
+}
+
+func TestReconcileOps_AssistantPrefixUsesNormalCandidateOrdering(t *testing.T) {
+	ext := &mockAssistantExtractor{mockExtractor: &mockExtractor{}}
+	op := newMockOperator()
+	op.searchResults = []*memory.Entry{
+		{
+			ID: "assistant-existing",
+			Memory: &memory.Memory{Memory: assistantmemory.Prefix +
+				"User works at Acme as a backend engineer."},
+			Score: 0.99,
+		},
+		{
+			ID: "ordinary-existing",
+			Memory: &memory.Memory{
+				Memory: "User works at Acme as a backend engineer.",
+				Topics: []string{"work"},
+			},
+			Score: 0.95,
+		},
+	}
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, op)
+
+	out := worker.reconcileOps(context.Background(), reconcileUserKey(), []*extractor.Operation{{
+		Type:   extractor.OperationAdd,
+		Memory: "User works at Acme as a backend engineer.",
+		Topics: []string{"work"},
+	}})
+
+	require.Len(t, out, 1)
+	assert.Equal(t, extractor.OperationUpdate, out[0].Type)
+	assert.Equal(t, "assistant-existing", out[0].MemoryID)
+}
+
+func TestAutoMemoryWorker_DoesNotUseMetadataAsAssistantConfiguration(t *testing.T) {
+	ext := &mockExtractor{metadata: map[string]any{
+		"conversation_extraction": "assistant-episode",
+	}}
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, newMockOperator())
+
+	assert.False(t, worker.assistantEpisodeExtraction)
+}
+
+func TestAutoMemoryWorker_CapturesBuiltInAssistantConfiguration(t *testing.T) {
+	disabled := NewAutoMemoryWorker(AutoMemoryConfig{
+		Extractor: extractor.NewExtractor(nil),
+	}, newMockOperator())
+	assert.False(t, disabled.assistantEpisodeExtraction)
+
+	enabledExtractor := extractor.NewExtractor(
+		nil,
+		extractor.WithAssistantEpisodeExtraction(),
+	)
+	enabled := NewAutoMemoryWorker(AutoMemoryConfig{
+		Extractor: enabledExtractor,
+	}, newMockOperator())
+	assert.True(t, enabled.assistantEpisodeExtraction)
+
+	decorated := NewAutoMemoryWorker(AutoMemoryConfig{
+		Extractor: &decoratedExtractor{MemoryExtractor: enabledExtractor},
+	}, newMockOperator())
+	assert.False(t, decorated.assistantEpisodeExtraction)
+
+	unwrapped := NewAutoMemoryWorker(AutoMemoryConfig{
+		Extractor: &unwrappingExtractor{MemoryExtractor: &unwrappingExtractor{
+			MemoryExtractor: enabledExtractor,
+		}},
+	}, newMockOperator())
+	assert.True(t, unwrapped.assistantEpisodeExtraction)
+}
+
+func TestAutoMemoryWorker_DecoratorCannotHalfEnableAssistantExtraction(t *testing.T) {
+	m := &mockModel{name: "decorated-assistant"}
+	builtin := extractor.NewExtractor(
+		m,
+		extractor.WithAssistantEpisodeExtraction(),
+	)
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{
+		Extractor: &decoratedExtractor{MemoryExtractor: builtin},
+	}, newMockOperator())
+
+	err := worker.createAutoMemory(
+		context.Background(),
+		reconcileUserKey(),
+		[]model.Message{
+			model.NewUserMessage("Recommend two options."),
+			model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, m.calls)
+}
+
+func TestAutoMemoryWorker_CooperatingDecoratorPreservesAssistantExtraction(t *testing.T) {
+	for _, policy := range []extractor.UpdatePolicy{
+		extractor.UpdatePolicyMergeSimilar,
+		extractor.UpdatePolicyPreserveHistory,
+		extractor.UpdatePolicyAppendOnly,
+	} {
+		t.Run(string(policy), func(t *testing.T) {
+			m := &mockModel{name: "decorated-assistant"}
+			builtin := extractor.NewExtractor(
+				m,
+				extractor.WithUpdatePolicy(policy),
+				extractor.WithAssistantEpisodeExtraction(),
+			)
+			inner := &unwrappingExtractor{MemoryExtractor: builtin}
+			worker := NewAutoMemoryWorker(AutoMemoryConfig{
+				Extractor: &unwrappingExtractor{MemoryExtractor: inner},
+			}, newMockOperator())
+
+			err := worker.createAutoMemory(
+				context.Background(),
+				reconcileUserKey(),
+				[]model.Message{
+					model.NewUserMessage("Recommend two options."),
+					model.NewAssistantMessage("1. Alpha\n2. Beta"),
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, policy, worker.updatePolicy)
+			assert.True(t, worker.assistantEpisodeExtraction)
+			assert.Equal(t, 2, m.calls)
+		})
+	}
+}
+
+func TestPrepareAutoMemoryOperations_ComposesAssistantExtractionWithPolicies(t *testing.T) {
+	for _, policy := range []extractor.UpdatePolicy{
+		extractor.UpdatePolicyMergeSimilar,
+		extractor.UpdatePolicyPreserveHistory,
+		extractor.UpdatePolicyAppendOnly,
+	} {
+		t.Run(string(policy), func(t *testing.T) {
+			ordinary := &extractor.Operation{
+				Type:   extractor.OperationAdd,
+				Memory: "User likes Alpha.",
+				Topics: []string{"Alpha"},
+			}
+			if policy == extractor.UpdatePolicyAppendOnly {
+				ordinary.Type = extractor.OperationUpdate
+				ordinary.MemoryID = "ordinary"
+				ordinary.Memory = "User likes Alpha and Beta."
+			}
+			assistant := &extractor.Operation{
+				Type:       extractor.OperationAdd,
+				Memory:     assistantmemory.Prefix + "The assistant recommended Alpha.",
+				MemoryKind: memory.KindEpisode,
+			}
+			ext := &mockAssistantExtractor{
+				mockExtractor: &mockExtractor{ops: []*extractor.Operation{ordinary, assistant}},
+				policy:        updatepolicy.Value(policy),
+			}
+			op := newMockOperator()
+			op.searchResults = []*memory.Entry{
+				{
+					ID: "ordinary",
+					Memory: &memory.Memory{
+						Memory: "User likes Alpha.",
+						Topics: []string{"Alpha"},
+					},
+				},
+			}
+			worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, op)
+
+			operations, err := worker.prepareAutoMemoryOperations(
+				context.Background(),
+				reconcileUserKey(),
+				[]model.Message{model.NewUserMessage("Remember Alpha.")},
+			)
+
+			require.NoError(t, err)
+			if policy == extractor.UpdatePolicyAppendOnly {
+				require.Len(t, operations, 2)
+				assert.Equal(t, extractor.OperationAdd, operations[0].Type)
+				assert.Empty(t, operations[0].MemoryID)
+			} else {
+				require.Len(t, operations, 1)
+			}
+			assert.True(t, strings.HasPrefix(
+				operations[len(operations)-1].Memory,
+				assistantmemory.Prefix,
+			))
+		})
+	}
+}
+
+func TestAutoMemoryWorker_DeleteOperationSkipsAssistantEpisode(t *testing.T) {
+	m := &assistantDeleteModel{}
+	ext := extractor.NewExtractor(
+		m,
+		extractor.WithUpdatePolicy(extractor.UpdatePolicyPreserveHistory),
+		extractor.WithAssistantEpisodeExtraction(),
+	)
+	op := newMockOperator()
+	op.searchResults = []*memory.Entry{{
+		ID:     "existing",
+		Memory: &memory.Memory{Memory: "User likes coffee."},
+	}}
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, op)
+
+	err := worker.createAutoMemory(
+		context.Background(),
+		reconcileUserKey(),
+		[]model.Message{
+			model.NewUserMessage("Recommend two options."),
+			model.NewAssistantMessage("1. Alpha\n2. Beta"),
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, m.calls)
+	assert.Equal(t, 1, op.deleteCalls)
+	assert.Equal(t, 0, op.addCalls)
+}
+
+func TestReconcileOps_DisabledExtractorKeepsLegacyBehavior(t *testing.T) {
+	text := assistantmemory.Prefix + "The assistant recommended Alpha and Beta."
+	op := newMockOperator()
+	op.searchResults = []*memory.Entry{{
+		ID:     "assistant-existing",
+		Memory: &memory.Memory{Memory: text},
+		Score:  0.99,
+	}}
+	worker := NewAutoMemoryWorker(
+		AutoMemoryConfig{Extractor: &mockExtractor{}},
+		op,
+	)
+
+	out := worker.reconcileOps(context.Background(), reconcileUserKey(), []*extractor.Operation{{
+		Type:   extractor.OperationAdd,
+		Memory: text,
+	}})
+
+	require.Empty(t, out, "disabled extractor must retain legacy reconcile behavior")
 }
 
 // TestReconcileOps_SkipOnHighSimilarity verifies that an Add whose


### PR DESCRIPTION
## Summary

- Add construction-time opt-in Assistant episode extraction through `extractor.WithAssistantEpisodeExtraction()`.
- Keep ordinary user-memory extraction and optional Assistant-result extraction in separate model stages.
- Use a language-neutral response-shape prefilter before the semantic Assistant-stage decision.
- Batch all eligible pairs from one extraction delta into one private Assistant-only model request.
- Store accepted results as ordinary `memory.KindEpisode` Add operations without changing persistence schemas.
- Preserve ordinary operations when the optional Assistant stage fails.
- Apply request-local destructive scope without parsing deletion intent from natural language: Clear excludes pairs at or before its source index, while Delete excludes only explicitly covered pairs.
- Send Assistant episode operations through the same configured update policy and reconciliation path as other memory operations.

## Motivation

The default extractor primarily records durable user facts and events. It can miss concrete results previously supplied by the Assistant, such as recommendation lists, structured options, or calculated quantities.

These results can be useful in later conversations, but should be stored as attributed conversation history rather than rewritten as verified facts, user preferences, or user actions.

## Usage

```go
memExtractor := extractor.NewExtractor(
    model,
    extractor.WithAssistantEpisodeExtraction(),
)
```

The option is disabled by default and fixed for the lifetime of the extractor.

## Extraction Flow

### Ordinary stage

The first stage:

- retains eligible User and Assistant text turns so contextual user replies remain interpretable;
- treats Assistant turns as context only: only User messages can supply or authorize ordinary memory operations;
- uses the normal memory extraction tools;
- keeps the configured update-policy and enabled-tool constraints;
- receives the same selected existing-memory context as normal extraction;
- produces ordinary fact and episode operations.

If the ordinary stage emits Clear, candidate pairs at or before its request-local `source_user_index` are excluded. Delete excludes only pairs explicitly listed in its request-local `affected_source_user_indexes`. If either destructive operation has missing or invalid request-local scope, the extractor conservatively skips the optional Assistant stage for that extraction call. These decisions are based on extracted operations, not an English/Chinese regular-expression classifier.

### Optional Assistant stage

The extractor examines completed user/assistant pairs from the same extraction delta.

A pair passes the language-neutral prefilter when the Assistant response:

- contains at least two Markdown or numbered list items; or
- introduces a normalized numeric token not already present in the User request.

The prefilter does not inspect English, Chinese, or other language-specific request keywords. The second-stage prompt makes the semantic decision about whether a candidate is durable and reusable. A prose response without a qualifying list or newly introduced numeric token does not currently activate the second stage; acknowledgments, follow-up questions, refusals, and generic explanations are rejected by that stage.

Eligible pairs are bounded by private pair/source-size limits and combined into one model request. The request exposes only the private `memory_assistant_episode` tool. Each call must identify one allowed `pair_id`; that identifier exists only during extraction and is not persisted or returned by retrieval.

## Validation

The Assistant-stage prompt requires concise attributed history and preservation of material names, quantities, dates, negation, and qualifications. Deterministic validation additionally enforces:

- a known, unique `pair_id`;
- non-empty memory text no larger than 4,096 bytes;
- normalized ASCII numeric values and adjacent signs, currency symbols, and percent signs grounded in the selected user/assistant pair;
- at most one accepted episode per pair.

Natural-language units and textual currency labels are preserved by the second-stage prompt, not validated deterministically. These checks are lexical safeguards, not a general semantic-entailment guarantee.

## Failure Semantics

The Assistant stage is optional and best effort.

- Ordinary-stage failure remains fatal.
- Optional-stage request or callback failure is logged and valid ordinary operations are preserved.
- Invalid Assistant tool calls are skipped independently.
- A true caller-context cancellation remains fatal.
- A child deadline reserves time for ordinary operations to be returned and persisted.

The feature therefore does not make ordinary Auto memory extraction depend on a second successful model call.

## Storage and Policy Integration

Each accepted result becomes an ordinary Add operation with:

- `memory.KindEpisode`;
- fixed `User` and `Assistant` participants;
- the extraction reference date when available;
- a descriptive internal text prefix identifying attributed Assistant history.

```json
{
  "memory": "Assistant-provided conversation episode: When the user asked for compact-kitchen products, the assistant recommended Alpha and Beta.",
  "kind": "episode",
  "participants": ["User", "Assistant"]
}
```

No new memory kind, field, database table, column, migration, or public Agent tool is introduced.

Assistant episode operations use the selected policy from #2233 and the normal worker reconciliation path. Previously stored Assistant episodes are ordinary episodic memories: they remain available to normal extraction context, reconciliation, and QA retrieval.

## Compatibility

Without `WithAssistantEpisodeExtraction()`:

- the original single-stage extraction path is used;
- no Assistant tool or prompt is exposed;
- no additional model call is made;
- session delta handling and enabled tools keep their existing behavior;
- extractor metadata is unchanged;
- storage and retrieval are unchanged.

The setting is captured when the Auto memory worker is constructed. A cooperating decorator can preserve it through `UnwrapMemoryExtractor()`; custom or non-cooperating extractors retain ordinary single-stage behavior.

Reconstructing the extractor without the option stops future Assistant extraction. Existing stored episodes remain ordinary memories; no migration is required.

## Development Evaluation

For reference, a fixed 50-case LongMemEval development run produced:

| Update policy | Assistant disabled | Assistant enabled | Delta |
|---|---:|---:|---:|
| Merge Similar | 28% | 58% | +30pp |
| Preserve History | 82% | 90% | +8pp |
| Append Only | 82% | 88% | +6pp |

These development results are included for reference only and are not a reproduction of the current PR head: the language-neutral eligibility prefilter and deterministic grounding contract were refined after this run.

## Test

- `go test ./memory/...`
- `go test -cover ./memory/extractor ./memory/internal/memory ./memory/internal/updatepolicy`
- `go test -race ./memory/extractor ./memory/internal/memory`
- `go vet ./memory/extractor ./memory/internal/memory`
- `golangci-lint run --timeout=5m ./memory/extractor/... ./memory/internal/assistantmemory/... ./memory/internal/updatepolicy/... ./memory/internal/memory/...`

The integration matrix covers the disabled default and Assistant extraction with Merge Similar, Preserve History, and Append Only, including decorator capability preservation, optional-stage failures, Delete/Clear suppression, stored-entry behavior, and ordinary reconciliation.
