### PR TITLE
.github: reduce pull request check queue pressure

### DIFF
--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -3,7 +3,12 @@ on:
   pull_request:
   merge_group:
   push:
+    branches:
+      - main
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: read # Use with `only-new-issues` option.


### PR DESCRIPTION
## What changed

Pull request checks now avoid duplicate branch-push runs and cancel superseded runs for the same pull request, reducing queue pressure without changing the validation jobs themselves.

## Why

The workflow currently runs on both `push` and `pull_request` for branches in the canonical repository. A single update can therefore schedule two copies of a workflow that expands to roughly 159 jobs. Additional commits also leave older pull request runs consuming runner capacity.

This change limits automatic push checks to `main` and groups pull request runs by pull request number. Push, merge queue, and manually dispatched runs use a unique run ID, so they are not canceled by pull request activity.

## Testing

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'the runner of ".*" action is too old' .github/workflows/prc.yml`
- Independent review of event and concurrency behavior for pull requests, main pushes, merge groups, and manual dispatches

## Notes for reviewers

- Non-`main` branches without an open pull request no longer run this workflow automatically; `workflow_dispatch` remains available.
- Main pushes, merge queue runs, and manual runs are not canceled by the new pull request concurrency group.
- Existing action-version warnings for `actions/checkout@v3` and `golangci/golangci-lint-action@v3` are unchanged and outside this focused change.
