### PR TITLE
{server/agui, docs, examples}: add AG-UI runner factory

### DIFF
--- a/docs/mkdocs/en/agui/index.md
+++ b/docs/mkdocs/en/agui/index.md
@@ -184,3 +184,23 @@ server, err := agui.New(
 ```
 
 In this case, the real-time conversation route is `/agui/chat`, the message snapshot route is `/agui/history`, and the cancel route is `/agui/cancel`.
+
+## Custom AG-UI Runner Factory
+
+By default, `agui.New` uses the built-in AG-UI Runner to adapt the provided `runner.Runner`. To rewrite requests, events, or capability forwarding at the AG-UI layer, provide custom construction logic with `agui.WithRunnerFactory`:
+
+```go
+server, err := agui.New(
+    baseRunner,
+    agui.WithRunnerFactory(func(base runner.Runner, opts ...aguirunner.Option) (aguirunner.Runner, error) {
+        inner := aguirunner.New(base, opts...)
+        return &customAGUIRunner{inner: inner}, nil
+    }),
+)
+```
+
+`opts...` contains the AG-UI Runner configuration collected by `agui.New`. When wrapping the built-in Runner, pass it through to `aguirunner.New`; otherwise, those settings will not be applied to the built-in Runner.
+
+To support message snapshots or cancel in a custom Runner, implement `aguirunner.MessagesSnapshotter` or `aguirunner.Canceler`. `WithRunnerFactory(nil)`, a nil Runner returned by the factory, or a factory error makes `agui.New` fail.
+
+For a complete example, see [examples/agui/server/runner_factory](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/runner_factory).

--- a/docs/mkdocs/zh/agui/index.md
+++ b/docs/mkdocs/zh/agui/index.md
@@ -184,3 +184,23 @@ server, err := agui.New(
 ```
 
 此时实时对话路由为 `/agui/chat`，消息快照路由为 `/agui/history`，取消路由为 `/agui/cancel`。
+
+## 自定义 AG-UI Runner Factory
+
+默认情况下，`agui.New` 使用内置 AG-UI Runner 适配传入的 `runner.Runner`。如果需要在 AG-UI 层改写请求、事件或能力转发，可以通过 `agui.WithRunnerFactory` 提供自定义构造逻辑：
+
+```go
+server, err := agui.New(
+    baseRunner,
+    agui.WithRunnerFactory(func(base runner.Runner, opts ...aguirunner.Option) (aguirunner.Runner, error) {
+        inner := aguirunner.New(base, opts...)
+        return &customAGUIRunner{inner: inner}, nil
+    }),
+)
+```
+
+`opts...` 包含 `agui.New` 聚合出的 AG-UI Runner 配置。包装内置 Runner 时需要原样传给 `aguirunner.New`，否则这些配置不会应用到内置 Runner。
+
+自定义 Runner 如需支持消息快照或取消，需要实现 `aguirunner.MessagesSnapshotter` 或 `aguirunner.Canceler`。`WithRunnerFactory(nil)`、factory 返回 nil Runner 或 error 都会使 `agui.New` 返回错误。
+
+完整示例参见 [examples/agui/server/runner_factory](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/runner_factory)。

--- a/examples/agui/server/README.md
+++ b/examples/agui/server/README.md
@@ -8,6 +8,7 @@ This directory shows AG-UI servers that can talk to the AG-UI client examples.
 - [`skill_artifacts/`](skill_artifacts/) – Demonstrates `skill_run` output artifacts surfaced as `CustomEvent("tool.artifacts")`.
 - [`event_emitter/`](event_emitter/) – Demonstrates Node EventEmitter for emitting custom events, progress updates, and streaming text from NodeFunc.
 - [`finishresult/`](finishresult/) – Demonstrates populating `RUN_FINISHED.result` by wrapping the default translator.
+- [`runner_factory/`](runner_factory/) – Demonstrates wrapping the built-in AG-UI runner with `agui.WithRunnerFactory`.
 - [`externaltool/llmagent/`](externaltool/llmagent/) – Demonstrates `llmagent + agui + WithExternalTools` with two internal tools and two dynamically declared external tools in the same conversation.
 - [`externaltool/graphagent/`](externaltool/graphagent/) – Demonstrates a `GraphAgent` interrupt workflow with two internal tools and two external tools in the same turn.
 - [`externaltool/agentnode_llmagent/`](externaltool/agentnode_llmagent/) – Demonstrates AgentNode child `LLMAgent` external tools with AG-UI interrupt and resume.

--- a/examples/agui/server/runner_factory/README.md
+++ b/examples/agui/server/runner_factory/README.md
@@ -1,0 +1,122 @@
+# AG-UI Runner Factory Server
+
+This example demonstrates `agui.WithRunnerFactory`.
+
+It replaces the AG-UI layer runner construction with a custom factory while still reusing the framework's built-in AG-UI runner internally. The example is intentionally small: it only rewrites plain text file IDs to file links before a run, then rewrites those links back to file IDs when serving message history.
+
+## What This Example Shows
+
+- How to provide an AG-UI runner factory with `agui.WithRunnerFactory`.
+- How to wrap the built-in AG-UI runner by calling `aguirunner.New(base, opts...)`.
+- How to customize `Run` and `MessagesSnapshot` behavior without changing the framework agent runner.
+- How to keep `Cancel` support by forwarding cancellation to the inner runner.
+
+The example uses plain text markers only. It does not use AG-UI multimodal input.
+
+## Rewrite Behavior
+
+When the client sends:
+
+```text
+Summarize file:report-1
+```
+
+the custom runner passes this text to the built-in AG-UI runner as:
+
+```text
+Summarize https://files.example.local/report-1
+```
+
+When `/history` returns a `MessagesSnapshotEvent`, the custom runner rewrites the stored link back to:
+
+```text
+Summarize file:report-1
+```
+
+This mirrors a common integration pattern where clients use stable file IDs while the runtime needs temporary file URLs.
+
+## Run
+
+From the `examples/agui` module:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-openai-compatible-base-url" # Optional.
+
+go run ./server/runner_factory \
+  -model deepseek-v4-flash \
+  -address 127.0.0.1:8080 \
+  -path /agui \
+  -messages-snapshot-path /history \
+  -cancel-path /cancel
+```
+
+The server exposes:
+
+- chat endpoint: `http://127.0.0.1:8080/agui`
+- messages snapshot endpoint: `http://127.0.0.1:8080/history`
+- cancel endpoint: `http://127.0.0.1:8080/cancel`
+
+## Try with curl
+
+Send a run request with a plain text file ID:
+
+```bash
+curl -N --location http://127.0.0.1:8080/agui \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "runner-factory-demo-thread",
+    "runId": "runner-factory-demo-run-1",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Summarize file:report-1"
+      }
+    ]
+  }'
+```
+
+Inspect the message snapshot for the same thread:
+
+```bash
+curl -N --location http://127.0.0.1:8080/history \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "runner-factory-demo-thread",
+    "runId": "runner-factory-demo-history-1"
+  }'
+```
+
+Look for `file:report-1` in the snapshot output. The built-in runner saw the generated link during `Run`, but the custom runner rewrote the snapshot back to the client-facing file ID.
+
+Cancel a running request by using the same `threadId` and `runId` as the active run:
+
+```bash
+curl --location http://127.0.0.1:8080/cancel \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "threadId": "runner-factory-demo-thread",
+    "runId": "runner-factory-demo-run-1"
+  }'
+```
+
+The cancel command is only useful while the run is still active.
+
+## Implementation Notes
+
+The custom factory receives the framework agent runner and the AG-UI runner options collected by `agui.New`:
+
+```go
+func newFileLinkRunner(base runner.Runner, opts ...aguirunner.Option) (aguirunner.Runner, error) {
+	inner := aguirunner.New(base, opts...)
+	return &fileLinkRunner{inner: inner}, nil
+}
+```
+
+Passing `opts...` through is important. These options include runner-level values derived from server options such as app name, session service, timeout, messages snapshot follow behavior, distributed cancel settings, event translation controls, and values passed with `agui.WithAGUIRunnerOptions`.
+
+File layout:
+
+- `main.go`: flags, startup logs, and HTTP serving.
+- `agent.go`: model and generation configuration.
+- `agui.go`: AG-UI server construction and custom runner wrapper.

--- a/examples/agui/server/runner_factory/agent.go
+++ b/examples/agui/server/runner_factory/agent.go
@@ -1,0 +1,39 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+const agentName = "agui-runner-factory-agent"
+
+func newAgent(modelName string, stream bool) *llmagent.LLMAgent {
+	generationConfig := model.GenerationConfig{
+		MaxTokens:   intPtr(512),
+		Temperature: floatPtr(0.7),
+		Stream:      stream,
+	}
+	return llmagent.New(
+		agentName,
+		llmagent.WithModel(openai.New(modelName)),
+		llmagent.WithGenerationConfig(generationConfig),
+		llmagent.WithInstruction("You are a helpful assistant. Treat file links as already signed file URLs."),
+	)
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/examples/agui/server/runner_factory/agui.go
+++ b/examples/agui/server/runner_factory/agui.go
@@ -1,0 +1,124 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
+	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+const (
+	appName        = "runner-factory-demo"
+	fileIDPrefix   = "file:"
+	fileLinkPrefix = "https://files.example.local/"
+)
+
+func newAGUIServer(cfg serverConfig) (*agui.Server, string, func() error, error) {
+	agent := newAgent(cfg.ModelName, cfg.Stream)
+	sessionService := inmemory.NewSessionService()
+	agentRunner := runner.NewRunner(appName, agent, runner.WithSessionService(sessionService))
+	server, err := agui.New(
+		agentRunner,
+		agui.WithPath(cfg.Path),
+		agui.WithCancelEnabled(true),
+		agui.WithCancelPath(cfg.CancelPath),
+		agui.WithMessagesSnapshotEnabled(true),
+		agui.WithMessagesSnapshotPath(cfg.MessagesSnapshotPath),
+		agui.WithAppName(appName),
+		agui.WithSessionService(sessionService),
+		agui.WithTimeout(cfg.Timeout),
+		agui.WithRunnerFactory(newFileLinkRunner),
+	)
+	if err != nil {
+		agentRunner.Close()
+		return nil, "", nil, err
+	}
+	return server, agent.Info().Name, agentRunner.Close, nil
+}
+
+func newFileLinkRunner(base runner.Runner, opts ...aguirunner.Option) (aguirunner.Runner, error) {
+	inner := aguirunner.New(base, opts...)
+	return &fileLinkRunner{inner: inner}, nil
+}
+
+type fileLinkRunner struct {
+	inner aguirunner.Runner
+}
+
+func (r *fileLinkRunner) Run(
+	ctx context.Context,
+	input *adapter.RunAgentInput,
+) (<-chan aguievents.Event, error) {
+	if input != nil {
+		next := *input
+		next.Messages = rewriteMessages(input.Messages, fileIDPrefix, fileLinkPrefix)
+		input = &next
+	}
+	return r.inner.Run(ctx, input)
+}
+
+func (r *fileLinkRunner) MessagesSnapshot(
+	ctx context.Context,
+	input *adapter.RunAgentInput,
+) (<-chan aguievents.Event, error) {
+	snapshotter, ok := r.inner.(aguirunner.MessagesSnapshotter)
+	if !ok {
+		return nil, errors.New("inner runner does not support messages snapshot")
+	}
+	events, err := snapshotter.MessagesSnapshot(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan aguievents.Event)
+	go func() {
+		defer close(out)
+		for event := range events {
+			if snapshot, ok := event.(*aguievents.MessagesSnapshotEvent); ok {
+				snapshot.Messages = rewriteMessages(snapshot.Messages, fileLinkPrefix, fileIDPrefix)
+			}
+			select {
+			case out <- event:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (r *fileLinkRunner) Cancel(ctx context.Context, input *adapter.RunAgentInput) error {
+	canceler, ok := r.inner.(aguirunner.Canceler)
+	if !ok {
+		return errors.New("inner runner does not support cancel")
+	}
+	return canceler.Cancel(ctx, input)
+}
+
+func rewriteMessages(messages []types.Message, old, new string) []types.Message {
+	if len(messages) == 0 {
+		return messages
+	}
+	next := make([]types.Message, len(messages))
+	for i, message := range messages {
+		next[i] = message
+		if content, ok := message.ContentString(); ok {
+			next[i].Content = strings.ReplaceAll(content, old, new)
+		}
+	}
+	return next
+}

--- a/examples/agui/server/runner_factory/main.go
+++ b/examples/agui/server/runner_factory/main.go
@@ -1,0 +1,61 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"flag"
+	"net/http"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+)
+
+var (
+	modelName            = flag.String("model", "deepseek-v4-flash", "Model to use")
+	isStream             = flag.Bool("stream", true, "Whether to stream the response")
+	address              = flag.String("address", "127.0.0.1:8080", "Listen address")
+	path                 = flag.String("path", "/agui", "HTTP path")
+	cancelPath           = flag.String("cancel-path", "/cancel", "Cancel HTTP path")
+	messagesSnapshotPath = flag.String("messages-snapshot-path", "/history", "Messages snapshot HTTP path")
+	timeout              = flag.Duration("timeout", time.Minute, "Maximum AG-UI run duration")
+)
+
+type serverConfig struct {
+	ModelName            string
+	Stream               bool
+	Address              string
+	Path                 string
+	CancelPath           string
+	MessagesSnapshotPath string
+	Timeout              time.Duration
+}
+
+func main() {
+	flag.Parse()
+	cfg := serverConfig{
+		ModelName:            *modelName,
+		Stream:               *isStream,
+		Address:              *address,
+		Path:                 *path,
+		CancelPath:           *cancelPath,
+		MessagesSnapshotPath: *messagesSnapshotPath,
+		Timeout:              *timeout,
+	}
+	server, agentName, cleanup, err := newAGUIServer(cfg)
+	if err != nil {
+		log.Fatalf("failed to create AG-UI server: %v", err)
+	}
+	defer cleanup()
+	log.Infof("AG-UI: serving agent %q on http://%s%s", agentName, cfg.Address, cfg.Path)
+	log.Infof("AG-UI: messages snapshot available at http://%s%s", cfg.Address, cfg.MessagesSnapshotPath)
+	log.Infof("AG-UI: cancel available at http://%s%s", cfg.Address, cfg.CancelPath)
+	if err := http.ListenAndServe(cfg.Address, server.Handler()); err != nil {
+		log.Fatalf("server stopped with error: %v", err)
+	}
+}

--- a/server/agui/agui.go
+++ b/server/agui/agui.go
@@ -59,10 +59,16 @@ func newService(runner runner.Runner, opts *options) (service.Service, error) {
 	if opts.serviceFactory == nil {
 		return nil, errors.New("agui: serviceFactory must not be nil")
 	}
+	if opts.runnerFactory == nil {
+		return nil, errors.New("agui: runner factory must not be nil")
+	}
 	if opts.distributedCancelEnabled && opts.sessionService == nil {
 		return nil, errors.New("agui: session service is required when distributed cancel is enabled")
 	}
-	aguiRunner := aguirunner.New(runner, opts.aguiRunnerOptions...)
+	aguiRunner, err := createAGUIRunner(runner, opts)
+	if err != nil {
+		return nil, err
+	}
 	chatPath, err := joinURLPath(opts.basePath, opts.path)
 	if err != nil {
 		return nil, fmt.Errorf("agui: url join chat path: %w", err)
@@ -103,6 +109,18 @@ func newService(runner runner.Runner, opts *options) (service.Service, error) {
 		)
 	}
 	return opts.serviceFactory(aguiRunner, serviceOpts...), nil
+}
+
+// createAGUIRunner creates the AG-UI runner used by the service.
+func createAGUIRunner(runner runner.Runner, opts *options) (aguirunner.Runner, error) {
+	aguiRunner, err := opts.runnerFactory(runner, opts.aguiRunnerOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("agui: create runner: %w", err)
+	}
+	if aguiRunner == nil {
+		return nil, errors.New("agui: runner factory returned nil runner")
+	}
+	return aguiRunner, nil
 }
 
 // joinURLPath joins the base path and the path into a URL path.

--- a/server/agui/agui_test.go
+++ b/server/agui/agui_test.go
@@ -11,6 +11,7 @@ package agui
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -175,6 +176,176 @@ func TestNewDistributedCancelRequiresSessionService(t *testing.T) {
 	assert.EqualError(t, err, "new service: agui: session service is required when distributed cancel is enabled")
 }
 
+func TestNewRunnerFactoryNilRejected(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	r := runner.NewRunner(agent.Info().Name, agent)
+	srv, err := New(r, WithRunnerFactory(nil))
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: runner factory must not be nil")
+}
+
+func TestNewDefaultRunnerFactoryUsed(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	r := runner.NewRunner(agent.Info().Name, agent)
+	var captured aguirunner.Runner
+	serviceFactory := func(r aguirunner.Runner, _ ...service.Option) service.Service {
+		captured = r
+		return dummyAGUIService{}
+	}
+	srv, err := New(r, WithServiceFactory(serviceFactory))
+	assert.NoError(t, err)
+	assert.NotNil(t, srv)
+	assert.NotNil(t, captured)
+}
+
+func TestNewRunnerFactoryCalledWithBaseRunnerAndOptions(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	sessionSvc := inmemory.NewSessionService()
+	customRunner := &testAGUIRunner{}
+	var capturedBase runner.Runner
+	var capturedOpts []aguirunner.Option
+	factory := func(r runner.Runner, opts ...aguirunner.Option) (aguirunner.Runner, error) {
+		capturedBase = r
+		capturedOpts = append([]aguirunner.Option(nil), opts...)
+		return customRunner, nil
+	}
+	srv, err := New(baseRunner,
+		WithRunnerFactory(factory),
+		WithTimeout(2*time.Second),
+		WithAppName("demo"),
+		WithSessionService(sessionSvc),
+	)
+	ro := aguirunner.NewOptions(capturedOpts...)
+	assert.NoError(t, err)
+	assert.NotNil(t, srv)
+	assert.Same(t, baseRunner, capturedBase)
+	assert.Equal(t, 2*time.Second, ro.Timeout)
+	assert.Equal(t, "demo", ro.AppName)
+	assert.Same(t, sessionSvc, ro.SessionService)
+}
+
+func TestNewRunnerFactoryPreservesOptionOrder(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	var capturedOpts []aguirunner.Option
+	factory := func(_ runner.Runner, opts ...aguirunner.Option) (aguirunner.Runner, error) {
+		capturedOpts = append([]aguirunner.Option(nil), opts...)
+		return &testAGUIRunner{}, nil
+	}
+	srv, err := New(baseRunner,
+		WithAGUIRunnerOptions(aguirunner.WithAppName("first")),
+		WithAppName("second"),
+		WithAGUIRunnerOptions(aguirunner.WithAppName("third")),
+		WithRunnerFactory(factory),
+	)
+	ro := aguirunner.NewOptions(capturedOpts...)
+	assert.NoError(t, err)
+	assert.NotNil(t, srv)
+	assert.Equal(t, "third", ro.AppName)
+}
+
+func TestNewRunnerFactoryRunnerUsedByServiceFactory(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	customRunner := &testAGUIRunner{}
+	var captured aguirunner.Runner
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		return customRunner, nil
+	}
+	serviceFactory := func(r aguirunner.Runner, _ ...service.Option) service.Service {
+		captured = r
+		return dummyAGUIService{}
+	}
+	srv, err := New(baseRunner, WithRunnerFactory(factory), WithServiceFactory(serviceFactory))
+	assert.NoError(t, err)
+	assert.NotNil(t, srv)
+	assert.Same(t, customRunner, captured)
+}
+
+func TestNewRunnerFactoryError(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	factoryErr := errors.New("boom")
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		return nil, factoryErr
+	}
+	srv, err := New(baseRunner, WithRunnerFactory(factory))
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: create runner: boom")
+}
+
+func TestNewRunnerFactoryNilRunner(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		return nil, nil
+	}
+	srv, err := New(baseRunner, WithRunnerFactory(factory))
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: runner factory returned nil runner")
+}
+
+func TestNewMessagesSnapshotStillRequiresAppNameWithRunnerFactory(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		return &testAGUIRunner{}, nil
+	}
+	srv, err := New(baseRunner,
+		WithRunnerFactory(factory),
+		WithMessagesSnapshotEnabled(true),
+		WithSessionService(inmemory.NewSessionService()),
+	)
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: app name is required when messages snapshot is enabled")
+}
+
+func TestNewMessagesSnapshotStillRequiresSessionServiceWithRunnerFactory(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		return &testAGUIRunner{}, nil
+	}
+	srv, err := New(baseRunner,
+		WithRunnerFactory(factory),
+		WithMessagesSnapshotEnabled(true),
+		WithAppName("demo"),
+	)
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: session service is required when messages snapshot is enabled")
+}
+
+func TestNewMessagesSnapshotStillRequiresTrackServiceWithRunnerFactory(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		return &testAGUIRunner{}, nil
+	}
+	srv, err := New(baseRunner,
+		WithRunnerFactory(factory),
+		WithMessagesSnapshotEnabled(true),
+		WithAppName("demo"),
+		WithSessionService(&fakeSessionService{}),
+	)
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: session service must implement TrackService")
+}
+
+func TestNewDistributedCancelStillRequiresSessionServiceWithRunnerFactory(t *testing.T) {
+	agent := &mockAgent{info: agent.Info{Name: "demo"}}
+	baseRunner := runner.NewRunner(agent.Info().Name, agent)
+	var called bool
+	factory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		called = true
+		return &testAGUIRunner{}, nil
+	}
+	srv, err := New(baseRunner, WithRunnerFactory(factory), WithDistributedCancelEnabled(true))
+	assert.Nil(t, srv)
+	assert.EqualError(t, err, "new service: agui: session service is required when distributed cancel is enabled")
+	assert.False(t, called)
+}
+
 func TestNewServiceRequiresServiceFactory(t *testing.T) {
 	opts := &options{serviceFactory: nil}
 	svc, err := newService(runner.NewRunner("demo", &mockAgent{info: agent.Info{Name: "demo"}}), opts)
@@ -196,15 +367,14 @@ func TestNewWrapsServiceFactoryError(t *testing.T) {
 func TestNewServiceRequiresTrackService(t *testing.T) {
 	agent := &mockAgent{info: agent.Info{Name: "demo"}}
 	r := runner.NewRunner(agent.Info().Name, agent)
-	opts := &options{
-		basePath:                "/",
-		path:                    "/chat",
-		serviceFactory:          func(aguirunner.Runner, ...service.Option) service.Service { return dummyAGUIService{} },
-		messagesSnapshotEnabled: true,
-		messagesSnapshotPath:    "/history",
-		appName:                 "demo",
-		sessionService:          &fakeSessionService{},
-	}
+	opts := newOptions(
+		WithPath("/chat"),
+		WithServiceFactory(func(aguirunner.Runner, ...service.Option) service.Service { return dummyAGUIService{} }),
+		WithMessagesSnapshotEnabled(true),
+		WithMessagesSnapshotPath("/history"),
+		WithAppName("demo"),
+		WithSessionService(&fakeSessionService{}),
+	)
 	svc, err := newService(r, opts)
 	assert.Nil(t, svc)
 	assert.EqualError(t, err, "agui: session service must implement TrackService")
@@ -406,6 +576,14 @@ func (a *mockAgent) FindSubAgent(string) agent.Agent {
 type dummyAGUIService struct{}
 
 func (dummyAGUIService) Handler() http.Handler { return http.NewServeMux() }
+
+type testAGUIRunner struct{}
+
+func (*testAGUIRunner) Run(context.Context, *adapter.RunAgentInput) (<-chan aguievents.Event, error) {
+	events := make(chan aguievents.Event)
+	close(events)
+	return events, nil
+}
 
 type fakeSessionService struct{}
 

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -12,6 +12,7 @@ package agui
 import (
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/runner"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service/sse"
@@ -33,6 +34,7 @@ type options struct {
 	basePath                 string
 	path                     string
 	serviceFactory           ServiceFactory
+	runnerFactory            RunnerFactory
 	aguiRunnerOptions        []aguirunner.Option
 	messagesSnapshotPath     string
 	messagesSnapshotEnabled  bool
@@ -50,6 +52,7 @@ func newOptions(opt ...Option) *options {
 		basePath:                defaultBasePath,
 		path:                    defaultPath,
 		serviceFactory:          defaultServiceFactory,
+		runnerFactory:           defaultRunnerFactory,
 		messagesSnapshotPath:    defaultMessagesSnapshotPath,
 		messagesSnapshotEnabled: defaultMessagesSnapshotState,
 		cancelPath:              defaultCancelPath,
@@ -122,6 +125,23 @@ func WithServiceFactory(f ServiceFactory) Option {
 	return func(o *options) {
 		o.serviceFactory = f
 	}
+}
+
+// RunnerFactory creates the AG-UI runner used by the service.
+// The options are aggregated from the AG-UI server options in user-provided order.
+type RunnerFactory func(baseRunner runner.Runner, opt ...aguirunner.Option) (aguirunner.Runner, error)
+
+// WithRunnerFactory sets the AG-UI runner factory.
+// Passing nil makes New return an error.
+func WithRunnerFactory(factory RunnerFactory) Option {
+	return func(o *options) {
+		o.runnerFactory = factory
+	}
+}
+
+// defaultRunnerFactory creates the default AG-UI runner.
+func defaultRunnerFactory(r runner.Runner, opt ...aguirunner.Option) (aguirunner.Runner, error) {
+	return aguirunner.New(r, opt...), nil
 }
 
 // WithAGUIRunnerOptions sets the AG-UI runner options.

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -15,8 +15,10 @@ import (
 	"testing"
 	"time"
 
+	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service"
@@ -28,6 +30,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Equal(t, "/cancel", opts.cancelPath)
 	assert.False(t, opts.cancelEnabled)
 	assert.NotNil(t, opts.serviceFactory)
+	assert.NotNil(t, opts.runnerFactory)
 	assert.Empty(t, opts.aguiRunnerOptions)
 }
 
@@ -75,6 +78,19 @@ func TestWithServiceFactory(t *testing.T) {
 	assert.NotNil(t, svc)
 	assert.True(t, invoked)
 	assert.IsType(t, fakeService{}, svc)
+}
+
+func TestWithRunnerFactory(t *testing.T) {
+	var invoked bool
+	customFactory := func(_ runner.Runner, _ ...aguirunner.Option) (aguirunner.Runner, error) {
+		invoked = true
+		return optionTestRunner{}, nil
+	}
+	opts := newOptions(WithRunnerFactory(customFactory))
+	r, err := opts.runnerFactory(nil)
+	assert.NoError(t, err)
+	assert.True(t, invoked)
+	assert.IsType(t, optionTestRunner{}, r)
 }
 
 func TestWithTimeout(t *testing.T) {
@@ -227,4 +243,12 @@ func TestWithAppNameResolver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "custom-app", appName)
 	assert.True(t, called)
+}
+
+type optionTestRunner struct{}
+
+func (optionTestRunner) Run(context.Context, *adapter.RunAgentInput) (<-chan aguievents.Event, error) {
+	events := make(chan aguievents.Event)
+	close(events)
+	return events, nil
 }


### PR DESCRIPTION
Adds an AG-UI runner factory extension point so callers can wrap or replace the AG-UI-layer runner while preserving aggregated runner options, documents the API in the AG-UI guide, and adds a runnable example that rewrites text file IDs to links for runs and back to file IDs for message snapshots.