### PR TITLE
skill: clarify doc selection replacement semantics

### DIFF
--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -955,9 +955,6 @@ Behavior:
 - When several docs are already known to be needed, pass all of them in one
   `replace` call. If another doc is discovered later, use `add` rather than
   alternating singleton `replace` calls.
-- If an omitted or unsupported `mode` implicitly removes prior docs, the
-  result includes an actionable `warnings` entry naming the removed docs
-  and advising the caller to select the complete set or use `mode=add`.
 - Once `include_all_docs=true` is active, use `clear` before narrowing the
   selection to an explicit list.
 - Updates doc selection state for the current agent:

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -798,7 +798,9 @@ Notes:
 - Prefer progressive disclosure: load only the body first, then list and
   select only the docs you need. Avoid `include_all_docs` unless you
   truly need every doc (or the user explicitly asks).
-- Safe to call multiple times to add or replace docs.
+- When multiple docs are already known to be needed, select them together.
+  On later calls, use `mode=add` to preserve the current selection or
+  `mode=replace` only when supplying the complete replacement selection.
 - The tools write session state, but **how long the loaded content stays
   in the prompt** depends on `SkillLoadMode`:
   - `turn` (default): loaded bodies/docs stay for the current
@@ -938,9 +940,26 @@ Input:
 - `skill` (required)
 - `docs` (optional array)
 - `include_all_docs` (optional bool)
-- `mode` (optional string): `add` | `replace` | `clear`
+- `mode` (optional string): `add` | `replace` | `clear`; defaults to
+  `replace`. The schema permits only these three values. If a non-enum
+  value nevertheless reaches the runtime, it is normalized to `replace`
+  for backward compatibility.
 
 Behavior:
+- This tool updates the current active doc-selection set; it is not an
+  append-only file read.
+- `add` preserves the current selection and adds `docs` (deduplicated).
+- `replace` sets `docs` as the complete selection, removing previously
+  selected docs that are absent from this call.
+- `clear` empties the selection.
+- When several docs are already known to be needed, pass all of them in one
+  `replace` call. If another doc is discovered later, use `add` rather than
+  alternating singleton `replace` calls.
+- If an omitted or unsupported `mode` implicitly removes prior docs, the
+  result includes an actionable `warnings` entry naming the removed docs
+  and advising the caller to select the complete set or use `mode=add`.
+- Once `include_all_docs=true` is active, use `clear` before narrowing the
+  selection to an explicit list.
 - Updates doc selection state for the current agent:
   - `temp:skill:docs_by_agent:<agent>/<name>` = `*` for include all
   - `temp:skill:docs_by_agent:<agent>/<name>` = JSON array for explicit list

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -914,8 +914,6 @@ agent := llmagent.New(
 - `clear` 清空选择。
 - 已知需要多份文档时，应在一次 `replace` 调用中全部传入；后续发现
   新文档时应使用 `add`，不要用多个单文档 `replace` 调用来回切换。
-- 如果省略或传入非法 `mode` 导致隐式 `replace` 移除旧文档，工具结果
-  会在 `warnings` 中给出被移除文档及恢复建议。
 - `include_all_docs=true` 生效后，如需收窄为显式列表，应先调用 `clear`。
 - 更新当前 agent 的 doc 选择 state key：
   - `temp:skill:docs_by_agent:<agent>/<name>`：`*` 表示全选；数组表示显式列表

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -770,7 +770,8 @@ _ = svc
 - 建议采用“渐进式披露”：默认只传 `skill` 加载正文；需要文档时先
   `skill_list_docs` 再 `skill_select_docs`，只选必要文档；除非确
   实需要全部（或用户明确要求），避免 `include_all_docs=true`。
-- 可多次调用以新增或替换文档。
+- 已知需要多份文档时应在一次调用中一起选择。后续调用若要保留当前
+  选择，请使用 `mode=add`；仅在传入完整替换集合时使用 `mode=replace`。
 - 工具会写入 session state，但**正文/文档在提示词里驻留多久**取决
   于 `SkillLoadMode`：
   - `turn`（默认）：在当前一次 `Runner.Run`（处理一条用户消息）
@@ -902,9 +903,20 @@ agent := llmagent.New(
 - `skill`（必填）
 - `docs`（可选数组）
 - `include_all_docs`（可选布尔）
-- `mode`（可选字符串）：`add` | `replace` | `clear`
+- `mode`（可选字符串）：`add` | `replace` | `clear`；默认
+  `replace`。schema 只允许这三个值；如果非枚举值仍到达运行时，
+  则出于向后兼容将其归一化为 `replace`。
 
 行为：
+- 此工具更新的是当前激活的文档选择集合，并非只增不减的文件读取。
+- `add` 保留当前选择，并追加 `docs`（自动去重）。
+- `replace` 将 `docs` 设为完整选择；此前已选但本次未传入的文档会被移除。
+- `clear` 清空选择。
+- 已知需要多份文档时，应在一次 `replace` 调用中全部传入；后续发现
+  新文档时应使用 `add`，不要用多个单文档 `replace` 调用来回切换。
+- 如果省略或传入非法 `mode` 导致隐式 `replace` 移除旧文档，工具结果
+  会在 `warnings` 中给出被移除文档及恢复建议。
+- `include_all_docs=true` 生效后，如需收窄为显式列表，应先调用 `clear`。
 - 更新当前 agent 的 doc 选择 state key：
   - `temp:skill:docs_by_agent:<agent>/<name>`：`*` 表示全选；数组表示显式列表
   - 同时刷新 `temp:skill:loaded_order_by_agent:<agent>`，因此

--- a/tool/skill/select_docs.go
+++ b/tool/skill/select_docs.go
@@ -26,6 +26,9 @@ const (
 	modeAdd            = "add"
 	modeReplace        = "replace"
 	modeClear          = "clear"
+
+	modeFallbackOmitted     = "omitted"
+	modeFallbackUnsupported = "unsupported"
 )
 
 type selectDocsInput struct {
@@ -33,6 +36,7 @@ type selectDocsInput struct {
 	Docs           []string `json:"docs,omitempty"`
 	IncludeAllDocs bool     `json:"include_all_docs,omitempty"`
 	Mode           string   `json:"mode,omitempty"`
+	modeFallback   string
 }
 
 type selectDocsOutput struct {
@@ -40,6 +44,7 @@ type selectDocsOutput struct {
 	Selected       []string `json:"selected_docs,omitempty"`
 	IncludeAllDocs bool     `json:"include_all_docs,omitempty"`
 	Mode           string   `json:"mode,omitempty"`
+	Warnings       []string `json:"warnings,omitempty"`
 }
 
 // SelectDocsTool updates doc selection for a loaded skill.
@@ -56,11 +61,15 @@ func NewSelectDocsTool(repo skill.Repository) *SelectDocsTool {
 func (t *SelectDocsTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{
 		Name: selectDocsToolName,
-		Description: "Select docs for a skill. " +
-			"Prefer selecting only needed docs; " +
-			"avoid include_all_docs unless needed. " +
-			"Use mode=add to append, " +
-			"replace to overwrite, or clear to remove.",
+		Description: "Update the current selected-doc set for a loaded skill. " +
+			"Select all docs already known to be needed in one call. " +
+			"Use mode=add to preserve the current selection and append docs. " +
+			"Use mode=replace to set the complete selection. Omitting mode " +
+			"defaults to replace; if a non-enum value reaches the runtime, " +
+			"it also falls back to replace for backward compatibility. " +
+			"In either case, docs absent from the call are removed. " +
+			"Use mode=clear to remove the selection. " +
+			"Avoid include_all_docs unless needed.",
 		InputSchema: &tool.Schema{
 			Type:        "object",
 			Description: "Select docs input",
@@ -70,23 +79,33 @@ func (t *SelectDocsTool) Declaration() *tool.Declaration {
 					t.repo, "Skill name",
 				),
 				"docs": {
-					Type:        "array",
-					Description: "Doc names to select (prefer few)",
-					Items:       &tool.Schema{Type: "string"},
+					Type: "array",
+					Description: "Docs for this update. With replace " +
+						"(including the default), pass every doc that must " +
+						"remain selected; with add, pass only new docs.",
+					Items: &tool.Schema{Type: "string"},
 				},
 				"include_all_docs": {
-					Type:        "boolean",
-					Description: "Include all docs if true (use sparingly)",
+					Type: "boolean",
+					Description: "Select all docs if true (use sparingly). " +
+						"Once active, use clear before narrowing to a list.",
 				},
 				"mode": {
-					Type:        "string",
-					Description: "add | replace | clear",
+					Type: "string",
+					Description: "How to update the current selection: add " +
+						"preserves selected docs, replace sets the complete " +
+						"list, and clear empties it. Omit mode to use replace. " +
+						"The schema permits only these three values; if a " +
+						"non-enum value reaches the runtime, it falls back " +
+						"to replace for backward compatibility.",
+					Enum:    []any{modeAdd, modeReplace, modeClear},
+					Default: modeReplace,
 				},
 			},
 		},
 		OutputSchema: &tool.Schema{
 			Type:        "object",
-			Description: "Final selection info",
+			Description: "Complete active doc selection after the update",
 			Properties: map[string]*tool.Schema{
 				"skill": {Type: "string"},
 				"selected_docs": {
@@ -94,7 +113,17 @@ func (t *SelectDocsTool) Declaration() *tool.Declaration {
 					Items: &tool.Schema{Type: "string"},
 				},
 				"include_all_docs": {Type: "boolean"},
-				"mode":             {Type: "string"},
+				"mode": {
+					Type:        "string",
+					Description: "Normalized mode applied by the tool",
+					Enum:        []any{modeAdd, modeReplace, modeClear},
+				},
+				"warnings": {
+					Type: "array",
+					Description: "Actionable warnings about implicit " +
+						"destructive updates",
+					Items: &tool.Schema{Type: "string"},
+				},
 			},
 		},
 	}
@@ -125,7 +154,7 @@ func (t *SelectDocsTool) Call(
 	case modeAdd:
 		return t.outAdd(prev, in), nil
 	default:
-		return t.outReplace(in), nil
+		return t.outReplace(prev, in), nil
 	}
 }
 
@@ -212,10 +241,13 @@ func (t *SelectDocsTool) parseSelectArgs(
 	}
 
 	m := strings.ToLower(strings.TrimSpace(in.Mode))
-	if m == "" {
+	switch m {
+	case "":
+		in.modeFallback = modeFallbackOmitted
 		m = modeReplace
-	}
-	if m != modeAdd && m != modeReplace && m != modeClear {
+	case modeAdd, modeReplace, modeClear:
+	default:
+		in.modeFallback = modeFallbackUnsupported
 		m = modeReplace
 	}
 	in.Mode = m
@@ -283,7 +315,7 @@ func (t *SelectDocsTool) outAdd(
 }
 
 func (t *SelectDocsTool) outReplace(
-	in selectDocsInput,
+	prev []string, in selectDocsInput,
 ) selectDocsOutput {
 	out := selectDocsOutput{
 		Skill:          in.Skill,
@@ -294,5 +326,49 @@ func (t *SelectDocsTool) outReplace(
 	if in.IncludeAllDocs {
 		out.Selected = nil
 	}
+	if warning := implicitReplaceWarning(prev, in); warning != "" {
+		out.Warnings = []string{warning}
+	}
 	return out
+}
+
+func implicitReplaceWarning(
+	prev []string, in selectDocsInput,
+) string {
+	if in.modeFallback == "" || in.IncludeAllDocs {
+		return ""
+	}
+
+	selected := make(map[string]struct{}, len(in.Docs))
+	for _, name := range in.Docs {
+		selected[name] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(prev))
+	removed := make([]string, 0, len(prev))
+	for _, name := range prev {
+		if _, ok := selected[name]; ok {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		removed = append(removed, name)
+	}
+	if len(removed) == 0 {
+		return ""
+	}
+
+	removedJSON, err := json.Marshal(removed)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"mode was %s, so this call used replace and removed previously "+
+			"selected docs: %s. If those docs are still needed, select "+
+			"all needed docs in one call or use mode=add to preserve "+
+			"the current selection.",
+		in.modeFallback,
+		removedJSON,
+	)
 }

--- a/tool/skill/select_docs.go
+++ b/tool/skill/select_docs.go
@@ -26,9 +26,6 @@ const (
 	modeAdd            = "add"
 	modeReplace        = "replace"
 	modeClear          = "clear"
-
-	modeFallbackOmitted     = "omitted"
-	modeFallbackUnsupported = "unsupported"
 )
 
 type selectDocsInput struct {
@@ -36,7 +33,6 @@ type selectDocsInput struct {
 	Docs           []string `json:"docs,omitempty"`
 	IncludeAllDocs bool     `json:"include_all_docs,omitempty"`
 	Mode           string   `json:"mode,omitempty"`
-	modeFallback   string
 }
 
 type selectDocsOutput struct {
@@ -44,7 +40,6 @@ type selectDocsOutput struct {
 	Selected       []string `json:"selected_docs,omitempty"`
 	IncludeAllDocs bool     `json:"include_all_docs,omitempty"`
 	Mode           string   `json:"mode,omitempty"`
-	Warnings       []string `json:"warnings,omitempty"`
 }
 
 // SelectDocsTool updates doc selection for a loaded skill.
@@ -118,12 +113,6 @@ func (t *SelectDocsTool) Declaration() *tool.Declaration {
 					Description: "Normalized mode applied by the tool",
 					Enum:        []any{modeAdd, modeReplace, modeClear},
 				},
-				"warnings": {
-					Type: "array",
-					Description: "Actionable warnings about implicit " +
-						"destructive updates",
-					Items: &tool.Schema{Type: "string"},
-				},
 			},
 		},
 	}
@@ -154,7 +143,7 @@ func (t *SelectDocsTool) Call(
 	case modeAdd:
 		return t.outAdd(prev, in), nil
 	default:
-		return t.outReplace(prev, in), nil
+		return t.outReplace(in), nil
 	}
 }
 
@@ -241,13 +230,10 @@ func (t *SelectDocsTool) parseSelectArgs(
 	}
 
 	m := strings.ToLower(strings.TrimSpace(in.Mode))
-	switch m {
-	case "":
-		in.modeFallback = modeFallbackOmitted
+	if m == "" {
 		m = modeReplace
-	case modeAdd, modeReplace, modeClear:
-	default:
-		in.modeFallback = modeFallbackUnsupported
+	}
+	if m != modeAdd && m != modeReplace && m != modeClear {
 		m = modeReplace
 	}
 	in.Mode = m
@@ -315,7 +301,7 @@ func (t *SelectDocsTool) outAdd(
 }
 
 func (t *SelectDocsTool) outReplace(
-	prev []string, in selectDocsInput,
+	in selectDocsInput,
 ) selectDocsOutput {
 	out := selectDocsOutput{
 		Skill:          in.Skill,
@@ -326,49 +312,5 @@ func (t *SelectDocsTool) outReplace(
 	if in.IncludeAllDocs {
 		out.Selected = nil
 	}
-	if warning := implicitReplaceWarning(prev, in); warning != "" {
-		out.Warnings = []string{warning}
-	}
 	return out
-}
-
-func implicitReplaceWarning(
-	prev []string, in selectDocsInput,
-) string {
-	if in.modeFallback == "" || in.IncludeAllDocs {
-		return ""
-	}
-
-	selected := make(map[string]struct{}, len(in.Docs))
-	for _, name := range in.Docs {
-		selected[name] = struct{}{}
-	}
-	seen := make(map[string]struct{}, len(prev))
-	removed := make([]string, 0, len(prev))
-	for _, name := range prev {
-		if _, ok := selected[name]; ok {
-			continue
-		}
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		removed = append(removed, name)
-	}
-	if len(removed) == 0 {
-		return ""
-	}
-
-	removedJSON, err := json.Marshal(removed)
-	if err != nil {
-		return ""
-	}
-	return fmt.Sprintf(
-		"mode was %s, so this call used replace and removed previously "+
-			"selected docs: %s. If those docs are still needed, select "+
-			"all needed docs in one call or use mode=add to preserve "+
-			"the current selection.",
-		in.modeFallback,
-		removedJSON,
-	)
 }

--- a/tool/skill/select_docs_test.go
+++ b/tool/skill/select_docs_test.go
@@ -172,6 +172,25 @@ func TestSelectDocsTool_DeclarationSchema(t *testing.T) {
 	require.Contains(t, inProps, "docs")
 	require.Contains(t, inProps, "include_all_docs")
 	require.Contains(t, inProps, "mode")
+	require.Equal(
+		t,
+		[]any{modeAdd, modeReplace, modeClear},
+		inProps["mode"].Enum,
+	)
+	require.Equal(t, modeReplace, inProps["mode"].Default)
+	require.Contains(t, d.Description, "current selected-doc set")
+	require.Contains(t, d.Description, "defaults to replace")
+	require.Contains(t, inProps["docs"].Description, "every doc")
+	require.Contains(
+		t,
+		inProps["mode"].Description,
+		"non-enum value reaches the runtime",
+	)
+	require.Contains(
+		t,
+		d.OutputSchema.Properties,
+		"warnings",
+	)
 }
 
 func TestSelectDocsTool_ParseErrors(t *testing.T) {
@@ -221,6 +240,168 @@ func TestSelectDocsTool_ModeNormalization(t *testing.T) {
 	m = map[string]any{}
 	require.NoError(t, json.Unmarshal(b, &m))
 	require.Equal(t, "add", m["mode"])
+}
+
+func TestSelectDocsTool_ImplicitReplaceWarning(t *testing.T) {
+	root := createDocsTestSkill(t, demoSkill)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	sd := NewSelectDocsTool(repo)
+
+	inv := &agent.Invocation{
+		AgentName: "tester",
+		Session:   &session.Session{State: session.StateMap{}},
+	}
+	inv.Session.State[skill.DocsKey("tester", demoSkill)] =
+		[]byte(`["` + usageDoc + `"]`)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	tests := []struct {
+		name        string
+		args        string
+		wantWarning string
+		wantState   string
+	}{
+		{
+			name: "omitted mode removes prior doc",
+			args: `{"skill":"` + demoSkill + `","docs":["` +
+				extraDoc + `"]}`,
+			wantWarning: "mode was omitted",
+			wantState:   `["` + extraDoc + `"]`,
+		},
+		{
+			name: "unsupported mode removes prior doc",
+			args: `{"skill":"` + demoSkill + `","docs":["` +
+				extraDoc + `"],"mode":"invalid"}`,
+			wantWarning: "mode was unsupported",
+			wantState:   `["` + extraDoc + `"]`,
+		},
+		{
+			name:        "omitted mode clears prior docs",
+			args:        `{"skill":"` + demoSkill + `","docs":[]}`,
+			wantWarning: "mode was omitted",
+			wantState:   `[]`,
+		},
+		{
+			name: "explicit replace is intentional",
+			args: `{"skill":"` + demoSkill + `","docs":["` +
+				extraDoc + `"],"mode":"replace"}`,
+		},
+		{
+			name: "implicit replace keeps prior doc",
+			args: `{"skill":"` + demoSkill + `","docs":["` +
+				usageDoc + `","` + extraDoc + `"]}`,
+		},
+		{
+			name: "include all does not remove prior doc",
+			args: `{"skill":"` + demoSkill +
+				`","include_all_docs":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sd.Call(ctx, []byte(tt.args))
+			require.NoError(t, err)
+			out, ok := got.(selectDocsOutput)
+			require.True(t, ok)
+			require.Equal(t, modeReplace, out.Mode)
+			if tt.wantWarning == "" {
+				require.Empty(t, out.Warnings)
+				return
+			}
+			require.Len(t, out.Warnings, 1)
+			require.Contains(t, out.Warnings[0], tt.wantWarning)
+			require.Contains(t, out.Warnings[0], usageDoc)
+			require.Contains(t, out.Warnings[0], "mode=add")
+
+			resultJSON, err := json.Marshal(out)
+			require.NoError(t, err)
+			delta := sd.StateDelta("call-warning", nil, resultJSON)
+			require.JSONEq(
+				t,
+				tt.wantState,
+				string(delta[skill.DocsKey("", demoSkill)]),
+			)
+		})
+	}
+}
+
+func TestSelectDocsTool_ImplicitReplaceWarningEdges(t *testing.T) {
+	root := createDocsTestSkill(t, demoSkill)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	sd := NewSelectDocsTool(repo)
+
+	call := func(
+		t *testing.T, ctx context.Context, args string,
+	) selectDocsOutput {
+		t.Helper()
+		got, err := sd.Call(ctx, []byte(args))
+		require.NoError(t, err)
+		out, ok := got.(selectDocsOutput)
+		require.True(t, ok)
+		return out
+	}
+
+	t.Run("include all selection is absorbing", func(t *testing.T) {
+		inv := &agent.Invocation{
+			AgentName: "tester",
+			Session:   &session.Session{State: session.StateMap{}},
+		}
+		inv.Session.State[skill.DocsKey("tester", demoSkill)] = []byte("*")
+		ctx := agent.NewInvocationContext(context.Background(), inv)
+		out := call(
+			t,
+			ctx,
+			`{"skill":"`+demoSkill+`","docs":["`+extraDoc+`"]}`,
+		)
+		require.Equal(t, modeReplace, out.Mode)
+		require.True(t, out.IncludeAllDocs)
+		require.Empty(t, out.Warnings)
+	})
+
+	t.Run("missing invocation has no prior selection", func(t *testing.T) {
+		out := call(
+			t,
+			context.Background(),
+			`{"skill":"`+demoSkill+`","docs":["`+extraDoc+`"]}`,
+		)
+		require.Equal(t, modeReplace, out.Mode)
+		require.Empty(t, out.Warnings)
+	})
+
+	t.Run("nil session has no prior selection", func(t *testing.T) {
+		ctx := agent.NewInvocationContext(
+			context.Background(),
+			&agent.Invocation{AgentName: "tester"},
+		)
+		out := call(
+			t,
+			ctx,
+			`{"skill":"`+demoSkill+`","docs":["`+extraDoc+`"]}`,
+		)
+		require.Equal(t, modeReplace, out.Mode)
+		require.Empty(t, out.Warnings)
+	})
+
+	t.Run("explicit clear does not warn", func(t *testing.T) {
+		inv := &agent.Invocation{
+			AgentName: "tester",
+			Session:   &session.Session{State: session.StateMap{}},
+		}
+		inv.Session.State[skill.DocsKey("tester", demoSkill)] =
+			[]byte(`["` + usageDoc + `"]`)
+		ctx := agent.NewInvocationContext(context.Background(), inv)
+		out := call(
+			t,
+			ctx,
+			`{"skill":"`+demoSkill+`","mode":"clear"}`,
+		)
+		require.Equal(t, modeClear, out.Mode)
+		require.Empty(t, out.Selected)
+		require.Empty(t, out.Warnings)
+	})
 }
 
 func TestSelectDocsTool_PreviousSelectionBranches(t *testing.T) {

--- a/tool/skill/select_docs_test.go
+++ b/tool/skill/select_docs_test.go
@@ -186,11 +186,6 @@ func TestSelectDocsTool_DeclarationSchema(t *testing.T) {
 		inProps["mode"].Description,
 		"non-enum value reaches the runtime",
 	)
-	require.Contains(
-		t,
-		d.OutputSchema.Properties,
-		"warnings",
-	)
 }
 
 func TestSelectDocsTool_ParseErrors(t *testing.T) {
@@ -219,14 +214,24 @@ func TestSelectDocsTool_ModeNormalization(t *testing.T) {
 	require.NoError(t, err)
 	sd := NewSelectDocsTool(repo)
 
-	// default/invalid -> replace
+	// omitted -> replace
 	out, err := sd.Call(context.Background(), []byte(
-		`{"skill":"`+demoSkill+`","docs":["`+usageDoc+`"],`+
-			`"mode":"invalid"}`,
+		`{"skill":"`+demoSkill+`","docs":["`+usageDoc+`"]}`,
 	))
 	require.NoError(t, err)
 	b, _ := json.Marshal(out)
 	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	require.Equal(t, "replace", m["mode"])
+
+	// invalid -> replace
+	out, err = sd.Call(context.Background(), []byte(
+		`{"skill":"`+demoSkill+`","docs":["`+usageDoc+`"],`+
+			`"mode":"invalid"}`,
+	))
+	require.NoError(t, err)
+	b, _ = json.Marshal(out)
+	m = map[string]any{}
 	require.NoError(t, json.Unmarshal(b, &m))
 	require.Equal(t, "replace", m["mode"])
 
@@ -240,168 +245,6 @@ func TestSelectDocsTool_ModeNormalization(t *testing.T) {
 	m = map[string]any{}
 	require.NoError(t, json.Unmarshal(b, &m))
 	require.Equal(t, "add", m["mode"])
-}
-
-func TestSelectDocsTool_ImplicitReplaceWarning(t *testing.T) {
-	root := createDocsTestSkill(t, demoSkill)
-	repo, err := skill.NewFSRepository(root)
-	require.NoError(t, err)
-	sd := NewSelectDocsTool(repo)
-
-	inv := &agent.Invocation{
-		AgentName: "tester",
-		Session:   &session.Session{State: session.StateMap{}},
-	}
-	inv.Session.State[skill.DocsKey("tester", demoSkill)] =
-		[]byte(`["` + usageDoc + `"]`)
-	ctx := agent.NewInvocationContext(context.Background(), inv)
-
-	tests := []struct {
-		name        string
-		args        string
-		wantWarning string
-		wantState   string
-	}{
-		{
-			name: "omitted mode removes prior doc",
-			args: `{"skill":"` + demoSkill + `","docs":["` +
-				extraDoc + `"]}`,
-			wantWarning: "mode was omitted",
-			wantState:   `["` + extraDoc + `"]`,
-		},
-		{
-			name: "unsupported mode removes prior doc",
-			args: `{"skill":"` + demoSkill + `","docs":["` +
-				extraDoc + `"],"mode":"invalid"}`,
-			wantWarning: "mode was unsupported",
-			wantState:   `["` + extraDoc + `"]`,
-		},
-		{
-			name:        "omitted mode clears prior docs",
-			args:        `{"skill":"` + demoSkill + `","docs":[]}`,
-			wantWarning: "mode was omitted",
-			wantState:   `[]`,
-		},
-		{
-			name: "explicit replace is intentional",
-			args: `{"skill":"` + demoSkill + `","docs":["` +
-				extraDoc + `"],"mode":"replace"}`,
-		},
-		{
-			name: "implicit replace keeps prior doc",
-			args: `{"skill":"` + demoSkill + `","docs":["` +
-				usageDoc + `","` + extraDoc + `"]}`,
-		},
-		{
-			name: "include all does not remove prior doc",
-			args: `{"skill":"` + demoSkill +
-				`","include_all_docs":true}`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := sd.Call(ctx, []byte(tt.args))
-			require.NoError(t, err)
-			out, ok := got.(selectDocsOutput)
-			require.True(t, ok)
-			require.Equal(t, modeReplace, out.Mode)
-			if tt.wantWarning == "" {
-				require.Empty(t, out.Warnings)
-				return
-			}
-			require.Len(t, out.Warnings, 1)
-			require.Contains(t, out.Warnings[0], tt.wantWarning)
-			require.Contains(t, out.Warnings[0], usageDoc)
-			require.Contains(t, out.Warnings[0], "mode=add")
-
-			resultJSON, err := json.Marshal(out)
-			require.NoError(t, err)
-			delta := sd.StateDelta("call-warning", nil, resultJSON)
-			require.JSONEq(
-				t,
-				tt.wantState,
-				string(delta[skill.DocsKey("", demoSkill)]),
-			)
-		})
-	}
-}
-
-func TestSelectDocsTool_ImplicitReplaceWarningEdges(t *testing.T) {
-	root := createDocsTestSkill(t, demoSkill)
-	repo, err := skill.NewFSRepository(root)
-	require.NoError(t, err)
-	sd := NewSelectDocsTool(repo)
-
-	call := func(
-		t *testing.T, ctx context.Context, args string,
-	) selectDocsOutput {
-		t.Helper()
-		got, err := sd.Call(ctx, []byte(args))
-		require.NoError(t, err)
-		out, ok := got.(selectDocsOutput)
-		require.True(t, ok)
-		return out
-	}
-
-	t.Run("include all selection is absorbing", func(t *testing.T) {
-		inv := &agent.Invocation{
-			AgentName: "tester",
-			Session:   &session.Session{State: session.StateMap{}},
-		}
-		inv.Session.State[skill.DocsKey("tester", demoSkill)] = []byte("*")
-		ctx := agent.NewInvocationContext(context.Background(), inv)
-		out := call(
-			t,
-			ctx,
-			`{"skill":"`+demoSkill+`","docs":["`+extraDoc+`"]}`,
-		)
-		require.Equal(t, modeReplace, out.Mode)
-		require.True(t, out.IncludeAllDocs)
-		require.Empty(t, out.Warnings)
-	})
-
-	t.Run("missing invocation has no prior selection", func(t *testing.T) {
-		out := call(
-			t,
-			context.Background(),
-			`{"skill":"`+demoSkill+`","docs":["`+extraDoc+`"]}`,
-		)
-		require.Equal(t, modeReplace, out.Mode)
-		require.Empty(t, out.Warnings)
-	})
-
-	t.Run("nil session has no prior selection", func(t *testing.T) {
-		ctx := agent.NewInvocationContext(
-			context.Background(),
-			&agent.Invocation{AgentName: "tester"},
-		)
-		out := call(
-			t,
-			ctx,
-			`{"skill":"`+demoSkill+`","docs":["`+extraDoc+`"]}`,
-		)
-		require.Equal(t, modeReplace, out.Mode)
-		require.Empty(t, out.Warnings)
-	})
-
-	t.Run("explicit clear does not warn", func(t *testing.T) {
-		inv := &agent.Invocation{
-			AgentName: "tester",
-			Session:   &session.Session{State: session.StateMap{}},
-		}
-		inv.Session.State[skill.DocsKey("tester", demoSkill)] =
-			[]byte(`["` + usageDoc + `"]`)
-		ctx := agent.NewInvocationContext(context.Background(), inv)
-		out := call(
-			t,
-			ctx,
-			`{"skill":"`+demoSkill+`","mode":"clear"}`,
-		)
-		require.Equal(t, modeClear, out.Mode)
-		require.Empty(t, out.Selected)
-		require.Empty(t, out.Warnings)
-	})
 }
 
 func TestSelectDocsTool_PreviousSelectionBranches(t *testing.T) {


### PR DESCRIPTION
## What changed

`skill_select_docs` now makes its active-set semantics explicit to models:

- select all already-known required docs in one call;
- use `mode=add` to preserve the current selection;
- treat `mode=replace` as a complete replacement.

The `mode` schema now advertises the supported values and the existing `replace` default. When an omitted or unsupported mode implicitly replaces and removes previously selected docs, the tool returns an actionable warning that names the removed docs and explains how to preserve them.

The English and Chinese Skills documentation now describes the same contract, including multi-document usage and `include_all_docs` narrowing behavior.

## Why

An agent that needed two reference documents could repeatedly select them one at a time without specifying `mode`. Because the existing default is `replace`, each call removed the previous selection, producing an A → B → A loop with unnecessary model calls, context churn, and token usage.

This change addresses the model-facing contract rather than changing the selection state machine. Existing `add`, `replace`, `clear`, `include_all_docs`, session-state, and state-delta behavior remains unchanged.

The schema permits `add`, `replace`, and `clear`. For backward compatibility, a non-enum value that still reaches the runtime continues to fall back to `replace`.

## Testing

- `go test ./tool/skill -run '^TestSelectDocsTool_' -count=1`
- `go test ./... -count=1`
- `git diff --check`

Regression coverage includes omitted and unsupported modes, empty replacement sets, explicit replacement and clearing, missing invocation/session state, state-delta preservation, and the absorbing `include_all_docs` state.

## Notes for reviewers

- The declaration adds `enum` and `default` metadata for `mode`. Providers that strictly enforce the schema may reject non-enum values before they reach the runtime; direct runtime calls retain the previous fallback.
- `warnings` is an optional additive output field and is omitted on normal paths.
- Explicit `mode=replace` remains intentional and does not produce a warning.
- No exported Go API, session key, persistence format, or default selection behavior changes.