### PR TITLE
{server/agui, docs}: add forwardedProps run metadata

### DIFF
--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -798,7 +798,7 @@ The top-level `timestamp` on a real-time AG-UI event is the protocol event times
 
 `parentMetadata` is necessary because `parentInvocationId` only identifies the parent execution, not the specific tool call inside it. When a model issues parallel AgentTool calls to the same sub-agent in one turn, all spawned invocations share the same `parentInvocationId`; only `parentMetadata.triggerId` can disambiguate which `TOOL_CALL_START` each child invocation belongs to. When the parent did not invoke this child via a tool call (e.g., a top-level run), `parentMetadata` is absent.
 
-The `MESSAGES_SNAPSHOT` event returned by the message snapshot route can also carry source information. In this case, `rawEvent` is not source information for one event, but a source index built by message and tool call:
+The `MESSAGES_SNAPSHOT` event returned by the message snapshot route can also carry source information. In this case, `rawEvent` is not source information for one event, but a source index built by message, tool call, and run:
 
 ```json
 {
@@ -826,12 +826,21 @@ The `MESSAGES_SNAPSHOT` event returned by the message snapshot route can also ca
         "branch": "root.member-a",
         "timestamp": 1781258401000
       }
+    },
+    "runs": {
+      "run-1": {
+        "author": "demo-user",
+        "forwardedProps": {
+          "file_url": "https://example.com/demo.png"
+        },
+        "timestamp": 1781258400000
+      }
     }
   }
 }
 ```
 
-When restoring historical messages, use `rawEvent.messages[messageId]` to get the message source and timestamp, or `rawEvent.toolCalls[toolCallId]` to get the tool call source and timestamp. The indexed `timestamp` first reuses the top-level `timestamp` from the historical real-time event; only old data without an event `timestamp` falls back to the persisted track event time. Source information in the index uses the same fields as `rawEvent` in real-time events, so the frontend can reuse those field semantics to restore grouping state.
+When restoring historical messages, use `rawEvent.messages[messageId]` to get the message source and timestamp, or `rawEvent.toolCalls[toolCallId]` to get the tool call source and timestamp. To restore request-level `forwardedProps`, read `rawEvent.runs[runId].forwardedProps`. The indexed `timestamp` first reuses the top-level `timestamp` from the historical real-time event; only old data without an event `timestamp` falls back to the persisted track event time. Source information in the index uses the same fields as `rawEvent` in real-time events, so the frontend can reuse those field semantics to restore grouping state.
 
 ## External Tools
 

--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -181,6 +181,62 @@ Historical `RUN_*` messages in `MESSAGES_SNAPSHOT` have the following shape:
 }
 ```
 
+## User Input forwardedProps Metadata
+
+If your business stores attachments, form context, or other request-side information in AG-UI request `forwardedProps` and needs to restore that information from the history route after a page refresh, enable event source metadata:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+)
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithEventSourceMetadataEnabled(true),
+)
+```
+
+After this is enabled, when the real-time conversation request persists the user input event, it writes the `forwardedProps` field from the AG-UI request body to the user input event's `rawEvent.forwardedProps`; in the Go API, that field corresponds to `RunAgentInput.ForwardedProps`. When reading history, the message snapshot route aggregates it into `MESSAGES_SNAPSHOT.rawEvent.runs[runId].forwardedProps`:
+
+```json
+{
+  "type": "MESSAGES_SNAPSHOT",
+  "messages": [
+    {
+      "id": "user-1",
+      "role": "user",
+      "content": "Please check the attachment"
+    }
+  ],
+  "rawEvent": {
+    "runs": {
+      "run-1": {
+        "author": "demo-user",
+        "forwardedProps": {
+          "file_url": "https://example.com/demo.png",
+          "attachments": [
+            {
+              "id": "file-1",
+              "mimeType": "image/png"
+            }
+          ]
+        },
+        "timestamp": 1781258400000
+      }
+    },
+    "messages": {
+      "user-1": {
+        "author": "demo-user",
+        "timestamp": 1781258400000
+      }
+    }
+  }
+}
+```
+
 ## Messages Snapshot Continuation
 
 By default, the messages snapshot route returns a one-shot snapshot and immediately closes the connection. When a user refreshes or reconnects while a real-time conversation is running, new AG-UI events may continue to be produced after the snapshot is generated. In this case, enable messages snapshot continuation so the same SSE connection continues receiving subsequent events after returning the snapshot.

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -798,7 +798,7 @@ server, err := agui.New(
 
 之所以需要 `parentMetadata`，是因为 `parentInvocationId` 只标识父级执行，并不能区分父级内部的具体哪一次 tool call。当模型在一轮里对同一个子 Agent 发起多个并行 AgentTool 调用时，所有派生出的 invocation 共享相同的 `parentInvocationId`；只有 `parentMetadata.triggerId` 才能区分每个子 invocation 对应的是哪一次 `TOOL_CALL_START`。当父级不是通过工具调用触发本次执行时（例如顶层 run），`parentMetadata` 字段缺省。
 
-消息快照路由返回的 `MESSAGES_SNAPSHOT` 事件也可以携带来源信息。此时 `rawEvent` 不是单条事件的来源信息，而是按消息和工具调用建立的来源索引：
+消息快照路由返回的 `MESSAGES_SNAPSHOT` 事件也可以携带来源信息。此时 `rawEvent` 不是单条事件的来源信息，而是按消息、工具调用和运行建立的来源索引：
 
 ```json
 {
@@ -826,12 +826,21 @@ server, err := agui.New(
         "branch": "root.member-a",
         "timestamp": 1781258401000
       }
+    },
+    "runs": {
+      "run-1": {
+        "author": "demo-user",
+        "forwardedProps": {
+          "file_url": "https://example.com/demo.png"
+        },
+        "timestamp": 1781258400000
+      }
     }
   }
 }
 ```
 
-恢复历史消息时，可以通过 `rawEvent.messages[messageId]` 获取消息来源，也可以通过 `rawEvent.toolCalls[toolCallId]` 获取工具调用来源。索引中的来源信息与实时事件里的 `rawEvent` 使用同一组字段，前端可以沿用这些字段含义恢复分组状态。
+恢复历史消息时，可以通过 `rawEvent.messages[messageId]` 获取消息来源，也可以通过 `rawEvent.toolCalls[toolCallId]` 获取工具调用来源；如果需要恢复请求级 `forwardedProps`，可以读取 `rawEvent.runs[runId].forwardedProps`。索引中的来源信息与实时事件里的 `rawEvent` 使用同一组字段，前端可以沿用这些字段含义恢复分组状态。
 
 ## 外部工具
 

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -840,7 +840,7 @@ server, err := agui.New(
 }
 ```
 
-恢复历史消息时，可以通过 `rawEvent.messages[messageId]` 获取消息来源，也可以通过 `rawEvent.toolCalls[toolCallId]` 获取工具调用来源；如果需要恢复请求级 `forwardedProps`，可以读取 `rawEvent.runs[runId].forwardedProps`。索引中的来源信息与实时事件里的 `rawEvent` 使用同一组字段，前端可以沿用这些字段含义恢复分组状态。
+恢复历史消息时，可以通过 `rawEvent.messages[messageId]` 获取消息来源和时间戳，也可以通过 `rawEvent.toolCalls[toolCallId]` 获取工具调用来源和时间戳；如果需要恢复请求级 `forwardedProps`，可以读取 `rawEvent.runs[runId].forwardedProps`。索引中的 `timestamp` 优先复用历史实时事件顶层的 `timestamp`；只有旧数据缺少事件 `timestamp` 时，才回退使用持久化 track event 的时间。索引中的来源信息与实时事件里的 `rawEvent` 使用同一组字段，前端可以沿用这些字段含义恢复分组状态。
 
 ## 外部工具
 

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -181,6 +181,62 @@ server, err := agui.New(
 }
 ```
 
+## 用户输入 forwardedProps 元数据
+
+如果业务在 AG-UI 请求的 `forwardedProps` 中携带附件、表单上下文或其他请求侧信息，并希望刷新页面后仍能通过历史接口恢复这些信息，可以开启事件来源元数据：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+)
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithEventSourceMetadataEnabled(true),
+)
+```
+
+开启后，实时对话请求在持久化用户输入事件时，会把 AG-UI 请求体中的 `forwardedProps` 字段写入该用户输入事件的 `rawEvent.forwardedProps`；在 Go API 中，该字段对应 `RunAgentInput.ForwardedProps`。读取历史时，消息快照路由会把它聚合到 `MESSAGES_SNAPSHOT.rawEvent.runs[runId].forwardedProps`：
+
+```json
+{
+  "type": "MESSAGES_SNAPSHOT",
+  "messages": [
+    {
+      "id": "user-1",
+      "role": "user",
+      "content": "请看附件"
+    }
+  ],
+  "rawEvent": {
+    "runs": {
+      "run-1": {
+        "author": "demo-user",
+        "forwardedProps": {
+          "file_url": "https://example.com/demo.png",
+          "attachments": [
+            {
+              "id": "file-1",
+              "mimeType": "image/png"
+            }
+          ]
+        },
+        "timestamp": 1781258400000
+      }
+    },
+    "messages": {
+      "user-1": {
+        "author": "demo-user",
+        "timestamp": 1781258400000
+      }
+    }
+  }
+}
+```
+
 ## 消息快照续传
 
 默认情况下，消息快照路由只返回一次性快照并立即结束连接。当用户在实时对话运行期间刷新或重连时，快照生成之后可能还有新的 AG-UI 事件继续产生。此时可以开启消息快照续传，让同一条 SSE 连接在返回快照后继续接收后续事件。

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -37,12 +37,15 @@ type Metadata struct {
 	ParentMetadata *agentevent.ParentInvocationMetadata `json:"parentMetadata,omitempty"`
 	Branch         string                               `json:"branch,omitempty"`
 	Timestamp      *int64                               `json:"timestamp,omitempty"`
+	// ForwardedProps stores run-scoped AG-UI forwardedProps captured for a user input event.
+	ForwardedProps any `json:"forwardedProps,omitempty"`
 }
 
-// SnapshotMetadata indexes source metadata for messages snapshot payloads.
+// SnapshotMetadata indexes source metadata for message snapshot payloads.
 type SnapshotMetadata struct {
 	Messages  map[string]Metadata `json:"messages,omitempty"`
 	ToolCalls map[string]Metadata `json:"toolCalls,omitempty"`
+	Runs      map[string]Metadata `json:"runs,omitempty"`
 }
 
 // SnapshotMetadataOption configures how snapshot metadata is built.
@@ -62,12 +65,19 @@ func WithRunLifecycleEvents(include bool) SnapshotMetadataOption {
 
 // IsZero reports whether the metadata is empty.
 func (m Metadata) IsZero() bool {
-	return m == (Metadata{})
+	return m.EventID == "" &&
+		m.Author == "" &&
+		m.InvocationID == "" &&
+		m.ParentInvocationID == "" &&
+		m.ParentMetadata == nil &&
+		m.Branch == "" &&
+		m.Timestamp == nil &&
+		m.ForwardedProps == nil
 }
 
 // IsZero reports whether the snapshot metadata is empty.
 func (m SnapshotMetadata) IsZero() bool {
-	return len(m.Messages) == 0 && len(m.ToolCalls) == 0
+	return len(m.Messages) == 0 && len(m.ToolCalls) == 0 && len(m.Runs) == 0
 }
 
 // FromEvent resolves source metadata from an agent event.
@@ -132,6 +142,9 @@ func FromRawEvent(raw any) (Metadata, bool) {
 			Branch:             stringFromMap(v, "branch"),
 			Timestamp:          int64FromMap(v, "timestamp"),
 		}
+		if forwardedProps, ok := v["forwardedProps"]; ok {
+			metadata.ForwardedProps = forwardedProps
+		}
 		if pm, ok := v["parentMetadata"].(map[string]any); ok {
 			metadata.ParentMetadata = &agentevent.ParentInvocationMetadata{
 				TriggerType: stringFromMap(pm, "triggerType"),
@@ -166,6 +179,7 @@ func BuildSnapshotMetadata(
 	metadata := SnapshotMetadata{
 		Messages:  make(map[string]Metadata),
 		ToolCalls: make(map[string]Metadata),
+		Runs:      make(map[string]Metadata),
 	}
 	for _, trackEvent := range events {
 		if len(trackEvent.Payload) == 0 {
@@ -193,6 +207,12 @@ func BuildSnapshotMetadata(
 		if !ok && sourceMetadata.Timestamp == nil {
 			continue
 		}
+		runID := runIDFromRawEvent(base.RawEvent)
+		recordRunMetadata(metadata.Runs, runID, sourceMetadata)
+		sourceMetadata.ForwardedProps = nil
+		if sourceMetadata.IsZero() {
+			continue
+		}
 		recordSnapshotMetadata(metadata.Messages, metadata.ToolCalls,
 			evt, sourceMetadata)
 	}
@@ -201,6 +221,9 @@ func BuildSnapshotMetadata(
 	}
 	if len(metadata.ToolCalls) == 0 {
 		metadata.ToolCalls = nil
+	}
+	if len(metadata.Runs) == 0 {
+		metadata.Runs = nil
 	}
 	return metadata
 }
@@ -268,6 +291,27 @@ func int64FromMap(values map[string]any, key string) *int64 {
 		return &ts
 	default:
 		return nil
+	}
+}
+
+func runIDFromRawEvent(raw any) string {
+	switch v := raw.(type) {
+	case nil:
+		return ""
+	case map[string]any:
+		return stringFromMap(v, "runId")
+	default:
+		rawJSON, err := json.Marshal(raw)
+		if err != nil {
+			return ""
+		}
+		var metadata struct {
+			RunID string `json:"runId,omitempty"`
+		}
+		if err := json.Unmarshal(rawJSON, &metadata); err != nil {
+			return ""
+		}
+		return metadata.RunID
 	}
 }
 
@@ -368,6 +412,17 @@ func recordToolCallMetadata(
 	toolCalls[toolCallID] = mergeMetadata(toolCalls[toolCallID], metadata)
 }
 
+func recordRunMetadata(
+	runs map[string]Metadata,
+	runID string,
+	metadata Metadata,
+) {
+	if runID == "" || metadata.ForwardedProps == nil {
+		return
+	}
+	runs[runID] = mergeMetadata(runs[runID], metadata)
+}
+
 func mergeMetadata(existing Metadata, incoming Metadata) Metadata {
 	merged := existing
 	if incoming.EventID != "" {
@@ -389,6 +444,9 @@ func mergeMetadata(existing Metadata, incoming Metadata) Metadata {
 		(merged.Timestamp == nil || *incoming.Timestamp < *merged.Timestamp) {
 		ts := *incoming.Timestamp
 		merged.Timestamp = &ts
+	}
+	if incoming.ForwardedProps != nil {
+		merged.ForwardedProps = incoming.ForwardedProps
 	}
 	return merged
 }

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -45,7 +45,10 @@ type Metadata struct {
 type SnapshotMetadata struct {
 	Messages  map[string]Metadata `json:"messages,omitempty"`
 	ToolCalls map[string]Metadata `json:"toolCalls,omitempty"`
-	Runs      map[string]Metadata `json:"runs,omitempty"`
+	// Runs stores run-scoped metadata keyed by run ID. It is populated from
+	// persisted user-input forwardedProps metadata and is not a general run
+	// event source index.
+	Runs map[string]Metadata `json:"runs,omitempty"`
 }
 
 // SnapshotMetadataOption configures how snapshot metadata is built.

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -570,9 +570,23 @@ func TestRecordMetadataSkipsEmptyIDs(t *testing.T) {
 	recordMessageMetadata(messages, "", testMetadata("evt-1"))
 	recordToolCallMetadata(toolCalls, "", testMetadata("evt-1"))
 	recordRunMetadata(runs, "", Metadata{ForwardedProps: map[string]any{}})
+	recordRunMetadata(runs, "run-1", Metadata{})
 	assert.Empty(t, messages)
 	assert.Empty(t, toolCalls)
 	assert.Empty(t, runs)
+}
+
+func TestRunIDFromRawEvent(t *testing.T) {
+	assert.Empty(t, runIDFromRawEvent(nil))
+	assert.Equal(t, "run-1", runIDFromRawEvent(map[string]any{"runId": "run-1"}))
+	assert.Empty(t, runIDFromRawEvent(map[string]any{"runId": 123}))
+	assert.Equal(t, "run-2", runIDFromRawEvent(struct {
+		RunID string `json:"runId,omitempty"`
+	}{RunID: "run-2"}))
+	assert.Empty(t, runIDFromRawEvent(struct {
+		RunID int `json:"runId,omitempty"`
+	}{RunID: 123}))
+	assert.Empty(t, runIDFromRawEvent(func() {}))
 }
 
 func TestBuildSnapshotMetadataIndexesMessagesAndToolCalls(t *testing.T) {
@@ -802,6 +816,31 @@ func TestBuildSnapshotMetadataIndexesForwardedPropsByRunID(t *testing.T) {
 	require.Contains(t, metadata.Messages, "user-1")
 	gotMessage := metadata.Messages["user-1"]
 	assert.Nil(t, gotMessage.ForwardedProps)
+}
+
+func TestBuildSnapshotMetadataIndexesRunOnlyForwardedProps(t *testing.T) {
+	forwardedProps := map[string]any{"file_url": "https://example.com/demo.png"}
+	userMessage := aguitypes.Message{
+		ID:      "user-1",
+		Role:    aguitypes.RoleUser,
+		Content: "hello",
+	}
+	userEvent := aguievents.NewCustomEvent(
+		multimodal.CustomEventNameUserMessage,
+		aguievents.WithValue(userMessage),
+	)
+	userEvent.GetBaseEvent().TimestampMs = nil
+	metadata := BuildSnapshotMetadata([]session.TrackEvent{
+		newTrackEvent(t, withRawEvent(userEvent, map[string]any{
+			"runId":          "run-1",
+			"forwardedProps": forwardedProps,
+		})),
+	})
+	assert.Equal(t, SnapshotMetadata{
+		Runs: map[string]Metadata{
+			"run-1": {ForwardedProps: forwardedProps},
+		},
+	}, metadata)
 }
 
 func TestCustomUserMessageIDRejectsInvalidPayloads(t *testing.T) {

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -37,6 +37,7 @@ const (
 func TestMetadataIsZero(t *testing.T) {
 	assert.True(t, Metadata{}.IsZero())
 	assert.False(t, testMetadata("evt-1").IsZero())
+	assert.False(t, Metadata{ForwardedProps: map[string]any{}}.IsZero())
 }
 
 func TestSnapshotMetadataIsZero(t *testing.T) {
@@ -44,6 +45,11 @@ func TestSnapshotMetadataIsZero(t *testing.T) {
 	assert.False(t, SnapshotMetadata{
 		Messages: map[string]Metadata{
 			testMessageID: testMetadata("evt-1"),
+		},
+	}.IsZero())
+	assert.False(t, SnapshotMetadata{
+		Runs: map[string]Metadata{
+			"run-1": {ForwardedProps: map[string]any{}},
 		},
 	}.IsZero())
 }
@@ -157,6 +163,7 @@ func TestFromRawEventRejectsUnsupportedValues(t *testing.T) {
 
 func TestFromRawEventSupportsMapPayload(t *testing.T) {
 	timestamp := int64(1781258400000)
+	forwardedProps := map[string]any{"file_url": "https://example.com/demo.png"}
 	metadata, ok := FromRawEvent(map[string]any{
 		"eventId":            "evt-1",
 		"author":             "member-a",
@@ -164,6 +171,7 @@ func TestFromRawEventSupportsMapPayload(t *testing.T) {
 		"parentInvocationId": "parent-1",
 		"branch":             "root.member-a",
 		"timestamp":          float64(timestamp),
+		"forwardedProps":     forwardedProps,
 	})
 	require.True(t, ok)
 	assert.Equal(t, Metadata{
@@ -173,6 +181,7 @@ func TestFromRawEventSupportsMapPayload(t *testing.T) {
 		ParentInvocationID: "parent-1",
 		Branch:             "root.member-a",
 		Timestamp:          &timestamp,
+		ForwardedProps:     forwardedProps,
 	}, metadata)
 }
 
@@ -557,10 +566,13 @@ func TestRecordSnapshotMetadataSkipsChunkEventsWithoutMessageID(
 func TestRecordMetadataSkipsEmptyIDs(t *testing.T) {
 	messages := map[string]Metadata{}
 	toolCalls := map[string]Metadata{}
+	runs := map[string]Metadata{}
 	recordMessageMetadata(messages, "", testMetadata("evt-1"))
 	recordToolCallMetadata(toolCalls, "", testMetadata("evt-1"))
+	recordRunMetadata(runs, "", Metadata{ForwardedProps: map[string]any{}})
 	assert.Empty(t, messages)
 	assert.Empty(t, toolCalls)
+	assert.Empty(t, runs)
 }
 
 func TestBuildSnapshotMetadataIndexesMessagesAndToolCalls(t *testing.T) {
@@ -761,6 +773,37 @@ func TestBuildSnapshotMetadataIndexesCustomUserMessageID(t *testing.T) {
 	assert.Equal(t, timestampTime.UnixMilli(), *got.Timestamp)
 }
 
+func TestBuildSnapshotMetadataIndexesForwardedPropsByRunID(t *testing.T) {
+	timestampTime := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	forwardedProps := map[string]any{"file_url": "https://example.com/demo.png"}
+	userMessage := aguitypes.Message{
+		ID:      "user-1",
+		Role:    aguitypes.RoleUser,
+		Content: "hello",
+	}
+	userEvent := aguievents.NewCustomEvent(
+		multimodal.CustomEventNameUserMessage,
+		aguievents.WithValue(userMessage),
+	)
+	withTimestamp(userEvent, timestampTime)
+	metadata := BuildSnapshotMetadata([]session.TrackEvent{
+		newTrackEventAt(t, withRawEvent(userEvent, map[string]any{
+			"runId":          "run-1",
+			"author":         "demo-user",
+			"forwardedProps": forwardedProps,
+		}), timestampTime.Add(time.Hour)),
+	})
+	require.Contains(t, metadata.Runs, "run-1")
+	gotRun := metadata.Runs["run-1"]
+	require.NotNil(t, gotRun.Timestamp)
+	assert.Equal(t, timestampTime.UnixMilli(), *gotRun.Timestamp)
+	assert.Equal(t, "demo-user", gotRun.Author)
+	assert.Equal(t, forwardedProps, gotRun.ForwardedProps)
+	require.Contains(t, metadata.Messages, "user-1")
+	gotMessage := metadata.Messages["user-1"]
+	assert.Nil(t, gotMessage.ForwardedProps)
+}
+
 func TestCustomUserMessageIDRejectsInvalidPayloads(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -831,8 +874,8 @@ func withTimestamp(event aguievents.Event, timestamp time.Time) aguievents.Event
 
 func withRawEvent(
 	event aguievents.Event,
-	metadata Metadata,
+	raw any,
 ) aguievents.Event {
-	event.GetBaseEvent().RawEvent = metadata
+	event.GetBaseEvent().RawEvent = raw
 	return event
 }

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -221,8 +221,10 @@ func WithReasoningContentEnabled(enabled bool) Option {
 	}
 }
 
-// WithEventSourceMetadataEnabled controls whether translated AG-UI events
-// include source metadata from the original trpc-agent-go event in rawEvent.
+// WithEventSourceMetadataEnabled controls whether AG-UI events include source
+// metadata in rawEvent. Translated events include metadata from the original
+// trpc-agent-go event, and message snapshots include request forwardedProps
+// under rawEvent.runs when the request provides it.
 func WithEventSourceMetadataEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.aguiRunnerOptions = append(

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -382,6 +382,65 @@ func TestMessagesSnapshotAttachesSourceMetadataIndex(t *testing.T) {
 	assertSnapshotMetadataTimestamp(t, got.ToolCalls["tool-call-1"], baseTime.Add(time.Second))
 }
 
+func TestMessagesSnapshotAttachesForwardedPropsRunMetadata(t *testing.T) {
+	baseTime := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	forwardedProps := map[string]any{
+		"file_url": "https://example.com/demo.png",
+		"attachments": []any{
+			map[string]any{"id": "file-1", "mimeType": "image/png"},
+		},
+	}
+	userEvent := withSnapshotRawEvent(
+		withSnapshotTimestamp(aguievents.NewCustomEvent(
+			multimodal.CustomEventNameUserMessage,
+			aguievents.WithValue(types.Message{
+				ID:      "user-1",
+				Role:    types.RoleUser,
+				Content: "hi",
+			}),
+		), baseTime),
+		map[string]any{
+			"runId":          "real-run",
+			"author":         "demo-user",
+			"forwardedProps": forwardedProps,
+		},
+	)
+	svc := &testSessionService{
+		trackEvents: []session.TrackEvent{
+			newTrackEventAt(t, userEvent, baseTime.Add(time.Hour)),
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:                     noopBaseRunner{},
+		userIDResolver:             NewOptions().UserIDResolver,
+		runAgentInputHook:          NewOptions().RunAgentInputHook,
+		appName:                    "demo",
+		tracker:                    tracker,
+		eventSourceMetadataEnabled: true,
+	}
+	stream, err := r.MessagesSnapshot(
+		context.Background(),
+		&adapter.RunAgentInput{ThreadID: "thread", RunID: "run"},
+	)
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 1)
+	gotRawEvent, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
+	require.True(t, ok)
+	require.Contains(t, gotRawEvent.Runs, "real-run")
+	gotRun := gotRawEvent.Runs["real-run"]
+	assert.Equal(t, "demo-user", gotRun.Author)
+	assert.Equal(t, forwardedProps, gotRun.ForwardedProps)
+	assertSnapshotMetadataTimestamp(t, gotRun, baseTime)
+	require.Contains(t, gotRawEvent.Messages, "user-1")
+	assert.Nil(t, gotRawEvent.Messages["user-1"].ForwardedProps)
+}
+
 func TestMessagesSnapshotUsesResolvedAppName(t *testing.T) {
 	svc := &testSessionService{
 		trackEvents: []session.TrackEvent{
@@ -1524,9 +1583,9 @@ func collectAGUIEvents(t *testing.T, ch <-chan aguievents.Event) []aguievents.Ev
 
 func withSnapshotRawEvent(
 	event aguievents.Event,
-	metadata source.Metadata,
+	raw any,
 ) aguievents.Event {
-	event.GetBaseEvent().RawEvent = metadata
+	event.GetBaseEvent().RawEvent = raw
 	return event
 }
 

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -66,7 +66,7 @@ type Options struct {
 	GraphNodeInterruptActivityEnabled         bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
 	GraphNodeInterruptActivityTopLevelOnly    bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
 	ReasoningContentEnabled                   bool                  // ReasoningContentEnabled controls whether reasoning content events are emitted.
-	EventSourceMetadataEnabled                bool                  // EventSourceMetadataEnabled attaches original trpc-agent-go source metadata to translated AG-UI events.
+	EventSourceMetadataEnabled                bool                  // EventSourceMetadataEnabled attaches source metadata to AG-UI rawEvent fields.
 	ToolResultInputTranslationEnabled         bool                  // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
 	ToolCallDeltaStreamingEnabled             bool                  // ToolCallDeltaStreamingEnabled streams partial tool-call arguments.
 	StreamingToolResultActivityEnabled        bool                  // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
@@ -309,8 +309,10 @@ func WithReasoningContentEnabled(enabled bool) Option {
 	}
 }
 
-// WithEventSourceMetadataEnabled controls whether translated AG-UI events
-// carry source metadata from the original trpc-agent-go event in rawEvent.
+// WithEventSourceMetadataEnabled controls whether AG-UI events carry source
+// metadata in rawEvent. Translated events use the original trpc-agent-go event,
+// and message snapshots include request forwardedProps under rawEvent.runs when
+// present.
 func WithEventSourceMetadataEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.EventSourceMetadataEnabled = enabled

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -1255,18 +1255,10 @@ func normalizeForwardedPropsSourceMetadata(ctx context.Context, input *runInput)
 		)
 		return nil, false
 	}
-	var forwardedProps any
-	if err := json.Unmarshal(data, &forwardedProps); err != nil {
-		log.ErrorfContext(
-			ctx,
-			"agui run: threadID: %s, runID: %s, unmarshal forwardedProps source metadata: %v",
-			input.threadID,
-			input.runID,
-			err,
-		)
-		return nil, false
+	if string(data) == "null" {
+		return nil, true
 	}
-	return forwardedProps, true
+	return input.runAgentInput.ForwardedProps, true
 }
 
 func (r *runner) newExecutionContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelCauseFunc) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -30,6 +30,7 @@ import (
 	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
@@ -181,6 +182,11 @@ type runAgentMessages struct {
 	inputID      string
 	userMessage  *types.Message
 	toolMessages []toolResultInputMessage
+}
+
+type runForwardedPropsSourceMetadata struct {
+	source.Metadata
+	RunID string `json:"runId,omitempty"`
 }
 
 type toolResultInputMessage struct {
@@ -489,7 +495,7 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 			}
 		}()
 		if input.messages.inputMessage.Role == model.RoleUser {
-			if err := r.recordUserMessage(ctx, input.key, input.messages.userMessage); err != nil {
+			if err := r.recordUserMessage(ctx, input); err != nil {
 				log.WarnfContext(
 					ctx,
 					"agui run: threadID: %s, runID: %s, record input "+
@@ -1193,10 +1199,11 @@ func (r *runner) shouldTrackEvent(event aguievents.Event) bool {
 	return !aguitool.IsStreamingToolResultActivityEvent(event)
 }
 
-func (r *runner) recordUserMessage(ctx context.Context, key session.Key, message *types.Message) error {
-	if message == nil {
+func (r *runner) recordUserMessage(ctx context.Context, input *runInput) error {
+	if input == nil || input.messages == nil || input.messages.userMessage == nil {
 		return errors.New("user message is nil")
 	}
+	message := input.messages.userMessage
 	if message.Role != types.RoleUser {
 		return fmt.Errorf("user message role must be user: %s", message.Role)
 	}
@@ -1205,13 +1212,61 @@ func (r *runner) recordUserMessage(ctx context.Context, key session.Key, message
 		userMessage.ID = uuid.NewString()
 	}
 	if userMessage.Name == "" {
-		userMessage.Name = key.UserID
+		userMessage.Name = input.key.UserID
 	}
 	evt := aguievents.NewCustomEvent(multimodal.CustomEventNameUserMessage, aguievents.WithValue(userMessage))
-	if err := r.recordTrackEvent(ctx, key, evt); err != nil {
+	if metadata, ok := r.forwardedPropsSourceMetadata(ctx, input); ok {
+		evt.GetBaseEvent().RawEvent = metadata
+	}
+	if err := r.recordTrackEvent(ctx, input.key, evt); err != nil {
 		return fmt.Errorf("record track event: %w", err)
 	}
 	return nil
+}
+
+func (r *runner) forwardedPropsSourceMetadata(ctx context.Context, input *runInput) (any, bool) {
+	if !r.eventSourceMetadataEnabled ||
+		input.runAgentInput == nil ||
+		input.runAgentInput.ForwardedProps == nil {
+		return nil, false
+	}
+	forwardedProps, ok := normalizeForwardedPropsSourceMetadata(ctx, input)
+	if !ok || forwardedProps == nil {
+		return nil, false
+	}
+	return runForwardedPropsSourceMetadata{
+		Metadata: source.Metadata{
+			Author:         input.key.UserID,
+			ForwardedProps: forwardedProps,
+		},
+		RunID: input.runID,
+	}, true
+}
+
+func normalizeForwardedPropsSourceMetadata(ctx context.Context, input *runInput) (any, bool) {
+	data, err := json.Marshal(input.runAgentInput.ForwardedProps)
+	if err != nil {
+		log.ErrorfContext(
+			ctx,
+			"agui run: threadID: %s, runID: %s, marshal forwardedProps source metadata: %v",
+			input.threadID,
+			input.runID,
+			err,
+		)
+		return nil, false
+	}
+	var forwardedProps any
+	if err := json.Unmarshal(data, &forwardedProps); err != nil {
+		log.ErrorfContext(
+			ctx,
+			"agui run: threadID: %s, runID: %s, unmarshal forwardedProps source metadata: %v",
+			input.threadID,
+			input.runID,
+			err,
+		)
+		return nil, false
+	}
+	return forwardedProps, true
 }
 
 func (r *runner) newExecutionContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelCauseFunc) {

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -2391,6 +2391,26 @@ func TestRecordUserMessageTracksForwardedPropsSourceMetadata(t *testing.T) {
 	assert.Equal(t, "run", rawEvent["runId"])
 }
 
+func TestRecordUserMessageSkipsForwardedPropsMetadataByDefault(t *testing.T) {
+	tracker := &recordingTracker{}
+	r := &runner{tracker: tracker}
+	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
+	msg := &types.Message{Role: types.RoleUser, Content: "hi"}
+	runAgentInput := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"file_url": "https://example.com/demo.png"},
+	}
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, runAgentInput))
+	require.NoError(t, err)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.Len(t, tracker.events, 1)
+	custom, ok := tracker.events[0].(*aguievents.CustomEvent)
+	require.True(t, ok)
+	assert.Nil(t, custom.GetBaseEvent().RawEvent)
+}
+
 func TestRecordUserMessageSkipsInvalidForwardedPropsMetadata(t *testing.T) {
 	originalErrorfContext := log.ErrorfContext
 	errorCalls := 0
@@ -2433,6 +2453,25 @@ func TestRecordUserMessageSkipsNilForwardedPropsMetadata(t *testing.T) {
 		ThreadID:       "thread",
 		RunID:          "run",
 		ForwardedProps: forwardedProps,
+	}
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, runAgentInput))
+	require.NoError(t, err)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.Len(t, tracker.events, 1)
+	custom, ok := tracker.events[0].(*aguievents.CustomEvent)
+	require.True(t, ok)
+	assert.Nil(t, custom.GetBaseEvent().RawEvent)
+}
+
+func TestRecordUserMessageSkipsMissingForwardedPropsMetadata(t *testing.T) {
+	tracker := &recordingTracker{}
+	r := &runner{tracker: tracker, eventSourceMetadataEnabled: true}
+	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
+	msg := &types.Message{Role: types.RoleUser, Content: "hi"}
+	runAgentInput := &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
 	}
 	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, runAgentInput))
 	require.NoError(t, err)

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -32,6 +32,7 @@ import (
 	baserunner "trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
 	aguitrack "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
@@ -2331,12 +2332,10 @@ func TestRecordUserMessageTracksCustomEvent(t *testing.T) {
 	r := &runner{tracker: tracker}
 	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
 	msg := &types.Message{Role: types.RoleUser, Content: "hi"}
-
-	err := r.recordUserMessage(context.Background(), key, msg)
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, nil))
 	require.NoError(t, err)
 	assert.Empty(t, msg.ID)
 	assert.Empty(t, msg.Name)
-
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
 	require.Len(t, tracker.events, 1)
@@ -2351,6 +2350,98 @@ func TestRecordUserMessageTracksCustomEvent(t *testing.T) {
 	content, ok := userMessage.ContentString()
 	require.True(t, ok)
 	assert.Equal(t, "hi", content)
+}
+
+func TestRecordUserMessageTracksForwardedPropsSourceMetadata(t *testing.T) {
+	tracker := &recordingTracker{}
+	r := &runner{tracker: tracker, eventSourceMetadataEnabled: true}
+	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
+	msg := &types.Message{Role: types.RoleUser, Content: "hi"}
+	forwardedProps := map[string]any{
+		"file_url": "https://example.com/demo.png",
+		"attachments": []any{
+			map[string]any{"id": "file-1", "mimeType": "image/png"},
+		},
+	}
+	runAgentInput := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: forwardedProps,
+	}
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, runAgentInput))
+	require.NoError(t, err)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.Len(t, tracker.events, 1)
+	custom, ok := tracker.events[0].(*aguievents.CustomEvent)
+	require.True(t, ok)
+	got, ok := custom.GetBaseEvent().RawEvent.(runForwardedPropsSourceMetadata)
+	require.True(t, ok)
+	assert.Equal(t, "run", got.RunID)
+	metadata, ok := source.FromRawEvent(got)
+	require.True(t, ok)
+	assert.Equal(t, "demo-user", metadata.Author)
+	assert.Equal(t, forwardedProps, metadata.ForwardedProps)
+	payload, err := custom.ToJSON()
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	rawEvent, ok := decoded["rawEvent"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "run", rawEvent["runId"])
+}
+
+func TestRecordUserMessageSkipsInvalidForwardedPropsMetadata(t *testing.T) {
+	originalErrorfContext := log.ErrorfContext
+	errorCalls := 0
+	var gotFormat string
+	log.ErrorfContext = func(_ context.Context, format string, _ ...any) {
+		errorCalls++
+		gotFormat = format
+	}
+	t.Cleanup(func() {
+		log.ErrorfContext = originalErrorfContext
+	})
+	tracker := &recordingTracker{}
+	r := &runner{tracker: tracker, eventSourceMetadataEnabled: true}
+	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
+	msg := &types.Message{Role: types.RoleUser, Content: "hi"}
+	runAgentInput := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: map[string]any{"bad": func() {}},
+	}
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, runAgentInput))
+	require.NoError(t, err)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.Len(t, tracker.events, 1)
+	custom, ok := tracker.events[0].(*aguievents.CustomEvent)
+	require.True(t, ok)
+	assert.Nil(t, custom.GetBaseEvent().RawEvent)
+	assert.Equal(t, 1, errorCalls)
+	assert.Contains(t, gotFormat, "marshal forwardedProps source metadata")
+}
+
+func TestRecordUserMessageSkipsNilForwardedPropsMetadata(t *testing.T) {
+	var forwardedProps map[string]any
+	tracker := &recordingTracker{}
+	r := &runner{tracker: tracker, eventSourceMetadataEnabled: true}
+	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
+	msg := &types.Message{Role: types.RoleUser, Content: "hi"}
+	runAgentInput := &adapter.RunAgentInput{
+		ThreadID:       "thread",
+		RunID:          "run",
+		ForwardedProps: forwardedProps,
+	}
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, msg, runAgentInput))
+	require.NoError(t, err)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.Len(t, tracker.events, 1)
+	custom, ok := tracker.events[0].(*aguievents.CustomEvent)
+	require.True(t, ok)
+	assert.Nil(t, custom.GetBaseEvent().RawEvent)
 }
 
 func TestRunUsesResolvedAppNameForTrackKey(t *testing.T) {
@@ -2526,12 +2617,31 @@ func TestResolveAppNameReturnsResolverError(t *testing.T) {
 func TestRecordUserMessageRejectsNilAndNonUserRole(t *testing.T) {
 	r := &runner{}
 	key := session.Key{AppName: "app", UserID: "demo-user", SessionID: "thread"}
-
-	err := r.recordUserMessage(context.Background(), key, nil)
+	err := r.recordUserMessage(context.Background(), recordUserMessageInput(key, nil, nil))
 	assert.ErrorContains(t, err, "user message is nil")
-
-	err = r.recordUserMessage(context.Background(), key, &types.Message{Role: types.RoleTool, Content: "hi"})
+	err = r.recordUserMessage(context.Background(), recordUserMessageInput(
+		key,
+		&types.Message{Role: types.RoleTool, Content: "hi"},
+		nil,
+	))
 	assert.ErrorContains(t, err, "user message role must be user")
+}
+
+func recordUserMessageInput(
+	key session.Key,
+	message *types.Message,
+	runAgentInput *adapter.RunAgentInput,
+) *runInput {
+	if runAgentInput == nil {
+		runAgentInput = &adapter.RunAgentInput{}
+	}
+	return &runInput{
+		key:           key,
+		threadID:      runAgentInput.ThreadID,
+		runID:         runAgentInput.RunID,
+		runAgentInput: runAgentInput,
+		messages:      &runAgentMessages{userMessage: message},
+	}
 }
 
 func TestRunUserMessageRecordedInTrackAsCustomEventWithStringContent(t *testing.T) {


### PR DESCRIPTION
Persist AG-UI user input forwardedProps in source metadata when event source metadata is enabled, expose the data through MESSAGES_SNAPSHOT rawEvent.runs keyed by run ID, and update AG-UI documentation in English and Chinese to describe the run-level history metadata path.