### PR TITLE
examples/evaluation: add promptiter regression loop

### DIFF
--- a/examples/evaluation/promptiter/README.md
+++ b/examples/evaluation/promptiter/README.md
@@ -1,6 +1,6 @@
 # PromptIter Examples
 
-This directory contains six PromptIter examples:
+This directory contains seven PromptIter examples:
 
 - [syncrun](./syncrun): runs the full PromptIter optimization loop directly through `engine.Run` against a single-agent sports recap candidate. Its initial instruction intentionally stays simple so that PromptIter, rather than a strong hand-written seed, drives the gain.
 - [tooldesc](./tooldesc): runs the same synchronous engine flow against a single-agent travel candidate while optimizing only the candidate tool-description surface.
@@ -8,6 +8,7 @@ This directory contains six PromptIter examples:
 - [server](./server): exposes the single-agent sports recap workflow through the HTTP control-plane service in `server/promptiter`.
 - [multinode](./multinode): runs PromptIter against a multinode sports recap agent with regular function nodes, AgentNode fan-out/fan-in, and multiple optimized instruction surfaces.
 - [remote](./remote): runs PromptIter locally while executing the candidate through a remote `server/trpcagent` service, including Go, ADK Python, and LangGraph candidate server examples.
+- [regression](./regression): runs a deterministic Evaluation Service loop that attributes failures, validates PromptIter-style prompt candidates, rejects regressions through configurable gates, and writes auditable JSON and Markdown reports without an API key.
 
 All examples evaluate against fixed static gold answers stored directly in the eval sets, so repeated runs stay comparable instead of regenerating expected answers online.
 
@@ -19,4 +20,4 @@ The optimization examples keep their own command entrypoint and data layout:
 - `data/`
 - `output/`
 
-Choose `syncrun` when you want the simplest synchronous single-agent instruction example. Choose `tooldesc` when you want the simplest synchronous tool-description example. Choose `asyncrun` when you want asynchronous run lifecycle management without HTTP. Choose `server` when you want to serve PromptIter over HTTP and trigger runs remotely. Choose `multinode` when you want to see PromptIter optimize several AgentNode instruction surfaces inside a richer candidate graph. Choose `remote` when you want PromptIter to optimize an agent served by another process or framework through `server/trpcagent`.
+Choose `syncrun` when you want the simplest synchronous single-agent instruction example. Choose `tooldesc` when you want the simplest synchronous tool-description example. Choose `asyncrun` when you want asynchronous run lifecycle management without HTTP. Choose `server` when you want to serve PromptIter over HTTP and trigger runs remotely. Choose `multinode` when you want to see PromptIter optimize several AgentNode instruction surfaces inside a richer candidate graph. Choose `remote` when you want PromptIter to optimize an agent served by another process or framework through `server/trpcagent`. Choose `regression` when you need deterministic failure attribution, held-out validation gates, overfitting protection, and audit artifacts.

--- a/examples/evaluation/promptiter/regression/DESIGN.md
+++ b/examples/evaluation/promptiter/regression/DESIGN.md
@@ -1,0 +1,46 @@
+# Design
+
+The regression loop keeps optimization and acceptance as separate
+responsibilities. Evaluation Service is the source of truth for quality: every
+baseline and candidate run emits a final response, tool trajectory, and
+execution trace, then the configured built-in metrics produce per-case scores
+and pass/fail states. The loop does not infer success from optimizer output.
+This makes fake runs and model-backed runs comparable and prevents a candidate
+from bypassing evaluation.
+
+Failure attribution is deterministic and evidence based. It first inspects
+expected and actual knowledge-search calls, structured JSON validity, tool
+names and arguments, trace routing errors, and metric reasons. A generic final
+response mismatch is used only after more specific signals have been checked.
+Every failed case receives at least one category and human-readable evidence;
+the first category is the primary attribution used in summary counts. The full
+list remains in the JSON report so ambiguous failures can be audited instead
+of being forced into one label.
+
+Candidates use PromptIter's `SurfacePatch` and `Profile` contracts for the
+target instruction surface. In deterministic mode, configured patch text
+replaces the LLM-backed backward, aggregation, and optimizer stages. This keeps
+the example reproducible without credentials while preserving the integration
+boundary: production code can take candidate profiles from the normal
+PromptIter engine and reuse the same evaluation, delta, gate, and reporting
+layer.
+
+Acceptance is conjunctive. Validation gain must meet the configured threshold,
+new hard failures are rejected unless explicitly allowed, critical cases may
+not drop beyond their limit, and estimated cost and tool-call counts must stay
+within budget. Each candidate is compared with the currently accepted prompt,
+not merely the original baseline. The report also includes an original-to-final
+delta for release review.
+
+Overfitting is controlled by never using validation failures to generate the
+next candidate. Candidate targeting reads only training attributions. Every
+candidate still runs on the held-out validation set, where case-level deltas
+expose newly passed, newly failed, improved, regressed, and unchanged cases.
+The included second round intentionally improves training while damaging
+validation, proving that the gate rejects this pattern.
+
+Audit artifacts record all candidate prompts, metric results, traces, deltas,
+gate checks, rejection reasons, token estimates, tool calls, latency, seed, and
+fake model pricing. JSON supports automation; Markdown supports reviewer
+approval. Source prompt write-back is opt-in and occurs only after acceptance,
+so a generated candidate cannot silently enter production.

--- a/examples/evaluation/promptiter/regression/README.md
+++ b/examples/evaluation/promptiter/regression/README.md
@@ -1,0 +1,111 @@
+# PromptIter Regression Loop
+
+This example adds an auditable acceptance layer around Evaluation Service and
+PromptIter-style prompt patches. It evaluates a baseline on separate train and
+validation sets, attributes failures, evaluates deterministic prompt
+candidates, rejects regressions, and writes JSON and Markdown reports. No API
+key is required.
+
+## Pipeline
+
+1. Load `train.evalset.json`, `validation.evalset.json`, `metrics.json`,
+   `baseline_prompt.txt`, and `promptiter.json`.
+2. Run the baseline prompt on both sets through the Go Evaluation Service.
+3. Classify failed cases from final responses, tool trajectories, metric
+   reasons, structured output, and execution traces.
+4. Represent each configured candidate as a
+   `promptiter.SurfacePatch`/`promptiter.Profile` for
+   `candidate#instruction`.
+5. Re-evaluate each candidate on train and validation, then calculate
+   case-level deltas.
+6. Accept only candidates that satisfy every configured gate.
+7. Save every prompt, result, decision, cost, latency, seed, and fake model
+   setting in the audit reports.
+
+The deterministic runner emits normal response events, tool-call events, and
+execution traces. The built-in `final_response_avg_score` and
+`tool_trajectory_avg_score` evaluators perform scoring, so fake mode exercises
+the same Evaluation Service path as a model-backed integration.
+
+## Run
+
+```bash
+cd examples/evaluation
+go run ./promptiter/regression \
+  -config ./promptiter/regression/data/promptiter.json \
+  -output-dir ./promptiter/regression/output
+```
+
+The run completes locally in seconds and writes:
+
+```text
+output/optimization_report.json
+output/optimization_report.md
+```
+
+Use `-write-prompt=true` to replace the configured prompt source only when the
+selected candidate passes the gate. The default is audit-only and never
+modifies the source prompt.
+
+## Included Scenarios
+
+The train and validation files each contain three cases:
+
+| Scenario | Expected behavior |
+| --- | --- |
+| Lookup routing | Optimization adds the required `lookup_record` call. |
+| Structured output | Optimization changes plain text into exact JSON. |
+| Knowledge recall | The first candidate cannot fix it; the broader second candidate does. |
+| Critical direct answer | A broad search rule introduces an unnecessary tool call and must be rejected. |
+
+With the checked-in config, round 1 raises validation score from `0.5000` to
+`1.0000` and is accepted. Round 2 raises train score from `0.6667` to `0.8333`
+but lowers validation to `0.6667`. It is rejected for insufficient validation
+gain, two new hard failures, a critical-case regression, and excess tool calls.
+This is the example's explicit overfitting regression.
+
+## Gate Configuration
+
+`promptiter.json` configures:
+
+- minimum validation score gain;
+- whether newly failing cases are permitted;
+- critical case IDs and their maximum allowed score drop;
+- maximum estimated candidate cost; and
+- maximum validation tool calls.
+
+A candidate must pass all checks. Gate decisions compare against the currently
+accepted validation result, while the top-level report compares the final
+selected prompt with the original baseline.
+
+## Deterministic Task Format
+
+Each user message is a JSON object consumed by the fake runner:
+
+```json
+{
+  "intent": "lookup",
+  "query": "weather:shenzhen",
+  "answer": "Shenzhen weather is sunny.",
+  "tool": {
+    "name": "lookup_record",
+    "arguments": {"query": "weather:shenzhen"},
+    "result": {"condition": "sunny", "location": "Shenzhen"}
+  }
+}
+```
+
+Supported intents are `lookup`, `structured`, `knowledge`, and `direct`.
+Hidden or custom cases can use the same schema without changing Go code.
+
+## Production Adapter
+
+The deterministic candidate generator preserves PromptIter's patch/profile
+contract but replaces its LLM-backed backward, aggregation, and optimizer
+stages. A production integration can obtain candidates from
+`evaluation/workflow/promptiter/engine`, then pass each candidate prompt and
+its Evaluation Service result into the same delta, gate, and report functions.
+The validation set remains isolated from gradient generation in both modes.
+
+See [DESIGN.md](./DESIGN.md) for the detailed design and
+[`sample_output`](./sample_output) for checked-in reports.

--- a/examples/evaluation/promptiter/regression/attribution.go
+++ b/examples/evaluation/promptiter/regression/attribution.go
@@ -1,0 +1,184 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func attributeFailures(input attributionInput) []failureAttribution {
+	attributions := make([]failureAttribution, 0, 4)
+	seen := make(map[failureCategory]struct{})
+	add := func(category failureCategory, evidence string) {
+		if _, ok := seen[category]; ok {
+			return
+		}
+		evidence = strings.TrimSpace(evidence)
+		if evidence == "" {
+			evidence = "failed evaluation signal matched this category"
+		}
+		seen[category] = struct{}{}
+		attributions = append(attributions, failureAttribution{
+			Category: category,
+			Evidence: evidence,
+		})
+	}
+
+	if knowledgeFailure(input) {
+		add(failureKnowledgeRecall, "knowledge_search was missing or did not provide the expected grounded answer")
+	}
+	if expectsStructuredOutput(input.expectedResponse) && input.actualResponse != input.expectedResponse {
+		if json.Valid([]byte(strings.TrimSpace(input.actualResponse))) {
+			add(failureFormat, "structured response JSON does not match the expected output")
+		} else {
+			add(failureFormat, "expected valid JSON but the final response was not valid JSON")
+		}
+	}
+
+	attributeToolFailures(input, add)
+	if traceShowsRouteFailure(input.trace) || reasonsContain(input.metrics, "route", "router", "transfer", "handoff") {
+		add(failureRoute, "execution trace or metric reason indicates an incorrect route")
+	}
+	if reasonsContain(input.metrics, "format", "json", "schema", "xml", "structured") {
+		add(failureFormat, "metric reason indicates a structured output or format violation")
+	}
+	if finalResponseFailed(input.metrics) && input.actualResponse != input.expectedResponse {
+		add(failureFinalResponse, "actual final response does not match the expected response")
+	}
+
+	if len(attributions) == 0 {
+		add(failureUnknown, firstFailureReason(input.metrics))
+	}
+	return attributions
+}
+
+func knowledgeFailure(input attributionInput) bool {
+	for _, tool := range input.expectedTools {
+		if strings.Contains(strings.ToLower(tool.Name), "knowledge") {
+			if len(input.actualTools) == 0 {
+				return true
+			}
+			for _, actual := range input.actualTools {
+				if actual.Name == tool.Name &&
+					jsonValuesEqual(actual.Arguments, tool.Arguments) &&
+					jsonValuesEqual(actual.Result, tool.Result) {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return reasonsContain(input.metrics, "knowledge", "recall", "grounding", "grounded")
+}
+
+func attributeToolFailures(input attributionInput, add func(failureCategory, string)) {
+	switch {
+	case len(input.expectedTools) == 0 && len(input.actualTools) > 0:
+		add(failureRoute, fmt.Sprintf("unexpected tool %q was called", input.actualTools[0].Name))
+		return
+	case len(input.expectedTools) > 0 && len(input.actualTools) == 0:
+		add(failureRoute, fmt.Sprintf("expected tool %q was not called", input.expectedTools[0].Name))
+		add(failureToolCall, "tool trajectory is missing an expected call")
+		return
+	case len(input.expectedTools) != len(input.actualTools):
+		add(failureToolCall, fmt.Sprintf(
+			"actual tool count %d does not match expected count %d",
+			len(input.actualTools),
+			len(input.expectedTools),
+		))
+	}
+
+	for i := 0; i < len(input.actualTools) && i < len(input.expectedTools); i++ {
+		actual := input.actualTools[i]
+		expected := input.expectedTools[i]
+		if actual.Name != expected.Name {
+			add(failureToolCall, fmt.Sprintf(
+				"actual tool %q does not match expected tool %q",
+				actual.Name,
+				expected.Name,
+			))
+			continue
+		}
+		if !jsonValuesEqual(actual.Arguments, expected.Arguments) {
+			add(failureToolArgument, fmt.Sprintf("arguments for tool %q do not match", actual.Name))
+		}
+		if !jsonValuesEqual(actual.Result, expected.Result) {
+			add(failureToolCall, fmt.Sprintf("result for tool %q does not match", actual.Name))
+		}
+	}
+}
+
+func jsonValuesEqual(left, right any) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	if leftErr != nil || rightErr != nil {
+		return reflect.DeepEqual(left, right)
+	}
+	var leftValue any
+	var rightValue any
+	if json.Unmarshal(leftJSON, &leftValue) != nil || json.Unmarshal(rightJSON, &rightValue) != nil {
+		return string(leftJSON) == string(rightJSON)
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
+}
+
+func expectsStructuredOutput(response string) bool {
+	trimmed := strings.TrimSpace(response)
+	return strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")
+}
+
+func traceShowsRouteFailure(trace traceAudit) bool {
+	for _, step := range trace.Steps {
+		text := strings.ToLower(strings.Join([]string{step.NodeID, step.NodeType, step.Error}, " "))
+		if strings.Contains(text, "route") && step.Error != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func reasonsContain(metrics []metricEvaluation, words ...string) bool {
+	for _, metric := range metrics {
+		if metric.Passed {
+			continue
+		}
+		reason := strings.ToLower(metric.Reason)
+		for _, word := range words {
+			if strings.Contains(reason, strings.ToLower(word)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func finalResponseFailed(metrics []metricEvaluation) bool {
+	for _, metric := range metrics {
+		if metric.Name == metricFinalResponse && !metric.Passed {
+			return true
+		}
+	}
+	return false
+}
+
+func firstFailureReason(metrics []metricEvaluation) string {
+	for _, metric := range metrics {
+		if metric.Passed {
+			continue
+		}
+		if reason := strings.TrimSpace(metric.Reason); reason != "" {
+			return reason
+		}
+		return fmt.Sprintf("metric %q failed without a detailed reason", metric.Name)
+	}
+	return "case failed without a recognized evaluation signal"
+}

--- a/examples/evaluation/promptiter/regression/attribution_test.go
+++ b/examples/evaluation/promptiter/regression/attribution_test.go
@@ -1,0 +1,116 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import "testing"
+
+func TestAttributeFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    attributionInput
+		expected failureCategory
+	}{
+		{
+			name: "structured output",
+			input: attributionInput{
+				metrics:          []metricEvaluation{{Name: metricFinalResponse, Passed: false, Reason: "final response mismatch"}},
+				actualResponse:   "value=42",
+				expectedResponse: `{"value":42}`,
+			},
+			expected: failureFormat,
+		},
+		{
+			name: "wrong tool",
+			input: attributionInput{
+				metrics: []metricEvaluation{{Name: metricToolTrajectory, Passed: false, Reason: "tool mismatch"}},
+				actualTools: []toolAudit{
+					{Name: "search_web", Arguments: map[string]any{"q": "weather"}},
+				},
+				expectedTools: []toolAudit{
+					{Name: "lookup_record", Arguments: map[string]any{"q": "weather"}},
+				},
+			},
+			expected: failureToolCall,
+		},
+		{
+			name: "wrong arguments",
+			input: attributionInput{
+				metrics: []metricEvaluation{{Name: metricToolTrajectory, Passed: false, Reason: "arguments mismatch"}},
+				actualTools: []toolAudit{
+					{Name: "lookup_record", Arguments: map[string]any{"q": "shanghai"}},
+				},
+				expectedTools: []toolAudit{
+					{Name: "lookup_record", Arguments: map[string]any{"q": "shenzhen"}},
+				},
+			},
+			expected: failureToolArgument,
+		},
+		{
+			name: "knowledge recall",
+			input: attributionInput{
+				metrics: []metricEvaluation{
+					{Name: metricFinalResponse, Passed: false, Reason: "missing grounded answer"},
+					{Name: metricToolTrajectory, Passed: false, Reason: "tool count mismatch"},
+				},
+				actualResponse:   "I do not have enough context.",
+				expectedResponse: "Retention is 30 days.",
+				expectedTools: []toolAudit{
+					{Name: "knowledge_search", Arguments: map[string]any{"query": "retention"}},
+				},
+			},
+			expected: failureKnowledgeRecall,
+		},
+		{
+			name: "route trace",
+			input: attributionInput{
+				metrics: []metricEvaluation{{Name: metricFinalResponse, Passed: false, Reason: "wrong answer"}},
+				trace: traceAudit{
+					Steps: []traceStepAudit{{NodeID: "router", Error: "route selected billing instead of support"}},
+				},
+			},
+			expected: failureRoute,
+		},
+		{
+			name: "generic final response",
+			input: attributionInput{
+				metrics:          []metricEvaluation{{Name: metricFinalResponse, Passed: false, Reason: "text mismatch"}},
+				actualResponse:   "blue",
+				expectedResponse: "green",
+			},
+			expected: failureFinalResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attributions := attributeFailures(test.input)
+			if len(attributions) == 0 {
+				t.Fatal("attributeFailures returned no attribution")
+			}
+			if attributions[0].Category != test.expected {
+				t.Fatalf("primary category = %q, want %q", attributions[0].Category, test.expected)
+			}
+			if attributions[0].Evidence == "" {
+				t.Fatal("primary attribution evidence is empty")
+			}
+		})
+	}
+}
+
+func TestAttributeFailuresAlwaysExplainsFailedCase(t *testing.T) {
+	attributions := attributeFailures(attributionInput{
+		metrics: []metricEvaluation{{Name: "custom_rubric", Passed: false}},
+	})
+	if len(attributions) != 1 {
+		t.Fatalf("attribution count = %d, want 1", len(attributions))
+	}
+	if attributions[0].Category != failureUnknown {
+		t.Fatalf("category = %q, want %q", attributions[0].Category, failureUnknown)
+	}
+}

--- a/examples/evaluation/promptiter/regression/config.go
+++ b/examples/evaluation/promptiter/regression/config.go
@@ -1,0 +1,167 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type pipelineConfig struct {
+	AppName         string            `json:"appName"`
+	TargetSurfaceID string            `json:"targetSurfaceId"`
+	MaxRounds       int               `json:"maxRounds"`
+	Seed            int64             `json:"seed"`
+	Inputs          inputConfig       `json:"inputs"`
+	FakeModel       fakeModelConfig   `json:"fakeModel"`
+	Gate            gateConfig        `json:"gate"`
+	Candidates      []candidateConfig `json:"candidates"`
+}
+
+type inputConfig struct {
+	TrainEvalSet      string `json:"trainEvalSet"`
+	ValidationEvalSet string `json:"validationEvalSet"`
+	Metrics           string `json:"metrics"`
+	PromptSource      string `json:"promptSource"`
+}
+
+type fakeModelConfig struct {
+	Name                       string  `json:"name"`
+	PromptCostPerMillionTokens float64 `json:"promptCostPerMillionTokens"`
+	OutputCostPerMillionTokens float64 `json:"outputCostPerMillionTokens"`
+	LatencyMillis              int64   `json:"latencyMillis"`
+}
+
+type candidateConfig struct {
+	ID             string            `json:"id"`
+	Append         string            `json:"append"`
+	Reason         string            `json:"reason"`
+	TargetFailures []failureCategory `json:"targetFailures"`
+}
+
+func loadConfig(path string) (pipelineConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pipelineConfig{}, fmt.Errorf("read config: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var config pipelineConfig
+	if err := decoder.Decode(&config); err != nil {
+		return pipelineConfig{}, fmt.Errorf("decode config: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return pipelineConfig{}, errors.New("decode config: multiple JSON values")
+		}
+		return pipelineConfig{}, fmt.Errorf("decode config trailing value: %w", err)
+	}
+	if err := validateConfig(config); err != nil {
+		return pipelineConfig{}, err
+	}
+	baseDir := filepath.Dir(path)
+	config.Inputs.TrainEvalSet = resolvePath(baseDir, config.Inputs.TrainEvalSet)
+	config.Inputs.ValidationEvalSet = resolvePath(baseDir, config.Inputs.ValidationEvalSet)
+	config.Inputs.Metrics = resolvePath(baseDir, config.Inputs.Metrics)
+	config.Inputs.PromptSource = resolvePath(baseDir, config.Inputs.PromptSource)
+	return config, nil
+}
+
+func validateConfig(config pipelineConfig) error {
+	switch {
+	case strings.TrimSpace(config.AppName) == "":
+		return errors.New("app name is empty")
+	case strings.TrimSpace(config.TargetSurfaceID) == "":
+		return errors.New("target surface id is empty")
+	case config.MaxRounds <= 0:
+		return errors.New("max rounds must be greater than zero")
+	case strings.TrimSpace(config.Inputs.TrainEvalSet) == "":
+		return errors.New("train eval set path is empty")
+	case strings.TrimSpace(config.Inputs.ValidationEvalSet) == "":
+		return errors.New("validation eval set path is empty")
+	case strings.TrimSpace(config.Inputs.Metrics) == "":
+		return errors.New("metrics path is empty")
+	case strings.TrimSpace(config.Inputs.PromptSource) == "":
+		return errors.New("prompt source path is empty")
+	case strings.TrimSpace(config.FakeModel.Name) == "":
+		return errors.New("fake model name is empty")
+	case config.FakeModel.LatencyMillis < 0:
+		return errors.New("fake model latency must not be negative")
+	case config.FakeModel.PromptCostPerMillionTokens < 0:
+		return errors.New("fake model prompt token cost must not be negative")
+	case config.FakeModel.OutputCostPerMillionTokens < 0:
+		return errors.New("fake model output token cost must not be negative")
+	case config.Gate.MaxCriticalScoreDrop < 0:
+		return errors.New("maximum critical score drop must not be negative")
+	case config.Gate.MaxEstimatedCostUSD < 0:
+		return errors.New("maximum estimated cost must not be negative")
+	case config.Gate.MaxToolCalls < 0:
+		return errors.New("maximum tool calls must not be negative")
+	case len(config.Candidates) == 0:
+		return errors.New("candidate list is empty")
+	}
+	seen := make(map[string]struct{}, len(config.Candidates))
+	for index, candidate := range config.Candidates {
+		if strings.TrimSpace(candidate.ID) == "" {
+			return fmt.Errorf("candidate %d id is empty", index)
+		}
+		if _, ok := seen[candidate.ID]; ok {
+			return fmt.Errorf("candidate id %q is duplicated", candidate.ID)
+		}
+		seen[candidate.ID] = struct{}{}
+		if strings.TrimSpace(candidate.Append) == "" {
+			return fmt.Errorf("candidate %q append text is empty", candidate.ID)
+		}
+		if strings.TrimSpace(candidate.Reason) == "" {
+			return fmt.Errorf("candidate %q reason is empty", candidate.ID)
+		}
+		if len(candidate.TargetFailures) == 0 {
+			return fmt.Errorf("candidate %q target failures are empty", candidate.ID)
+		}
+		for _, category := range candidate.TargetFailures {
+			if !isKnownFailureCategory(category) {
+				return fmt.Errorf(
+					"candidate %q has unknown target failure %q",
+					candidate.ID,
+					category,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func isKnownFailureCategory(category failureCategory) bool {
+	switch category {
+	case failureFinalResponse,
+		failureToolCall,
+		failureToolArgument,
+		failureRoute,
+		failureFormat,
+		failureKnowledgeRecall,
+		failureUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolvePath(baseDir, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(baseDir, path))
+}

--- a/examples/evaluation/promptiter/regression/config_test.go
+++ b/examples/evaluation/promptiter/regression/config_test.go
@@ -1,0 +1,80 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateConfigRejectsInvalidCostAndFailureTargets(t *testing.T) {
+	valid := pipelineConfig{
+		AppName:         "app",
+		TargetSurfaceID: "candidate#instruction",
+		MaxRounds:       1,
+		Inputs: inputConfig{
+			TrainEvalSet:      "train.json",
+			ValidationEvalSet: "validation.json",
+			Metrics:           "metrics.json",
+			PromptSource:      "prompt.txt",
+		},
+		FakeModel: fakeModelConfig{Name: "fake"},
+		Candidates: []candidateConfig{{
+			ID:             "candidate",
+			Append:         "instruction",
+			Reason:         "reason",
+			TargetFailures: []failureCategory{failureFormat},
+		}},
+	}
+	tests := []struct {
+		name          string
+		mutate        func(*pipelineConfig)
+		errorContains string
+	}{
+		{
+			name: "negative prompt cost",
+			mutate: func(config *pipelineConfig) {
+				config.FakeModel.PromptCostPerMillionTokens = -0.1
+			},
+			errorContains: "prompt token cost",
+		},
+		{
+			name: "negative output cost",
+			mutate: func(config *pipelineConfig) {
+				config.FakeModel.OutputCostPerMillionTokens = -0.1
+			},
+			errorContains: "output token cost",
+		},
+		{
+			name: "empty targets",
+			mutate: func(config *pipelineConfig) {
+				config.Candidates[0].TargetFailures = nil
+			},
+			errorContains: "target failures are empty",
+		},
+		{
+			name: "unknown target",
+			mutate: func(config *pipelineConfig) {
+				config.Candidates[0].TargetFailures = []failureCategory{"typo"}
+			},
+			errorContains: "unknown target failure",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := valid
+			config.Candidates = append([]candidateConfig(nil), valid.Candidates...)
+			test.mutate(&config)
+			err := validateConfig(config)
+			if err == nil || !strings.Contains(err.Error(), test.errorContains) {
+				t.Fatalf("validateConfig error = %v, want containing %q", err, test.errorContains)
+			}
+		})
+	}
+}

--- a/examples/evaluation/promptiter/regression/data/baseline_prompt.txt
+++ b/examples/evaluation/promptiter/regression/data/baseline_prompt.txt
@@ -1,0 +1,1 @@
+Answer each request concisely using only the provided task payload.

--- a/examples/evaluation/promptiter/regression/data/metrics.json
+++ b/examples/evaluation/promptiter/regression/data/metrics.json
@@ -1,0 +1,34 @@
+[
+  {
+    "metricName": "final_response_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "matchStrategy": "exact"
+        }
+      }
+    }
+  },
+  {
+    "metricName": "tool_trajectory_avg_score",
+    "threshold": 1,
+    "criterion": {
+      "toolTrajectory": {
+        "orderSensitive": true,
+        "subsetMatching": false,
+        "defaultStrategy": {
+          "name": {
+            "matchStrategy": "exact"
+          },
+          "arguments": {
+            "matchStrategy": "exact"
+          },
+          "result": {
+            "matchStrategy": "exact"
+          }
+        }
+      }
+    }
+  }
+]

--- a/examples/evaluation/promptiter/regression/data/promptiter.json
+++ b/examples/evaluation/promptiter/regression/data/promptiter.json
@@ -1,0 +1,47 @@
+{
+  "appName": "promptiter-regression-loop",
+  "targetSurfaceId": "candidate#instruction",
+  "maxRounds": 2,
+  "seed": 20260724,
+  "inputs": {
+    "trainEvalSet": "train.evalset.json",
+    "validationEvalSet": "validation.evalset.json",
+    "metrics": "metrics.json",
+    "promptSource": "baseline_prompt.txt"
+  },
+  "fakeModel": {
+    "name": "deterministic-promptiter-v1",
+    "promptCostPerMillionTokens": 0.2,
+    "outputCostPerMillionTokens": 0.8,
+    "latencyMillis": 4
+  },
+  "gate": {
+    "minValidationScoreGain": 0.05,
+    "allowNewHardFails": false,
+    "criticalCaseIds": [
+      "validation_direct_critical"
+    ],
+    "maxCriticalScoreDrop": 0,
+    "maxEstimatedCostUsd": 0.01,
+    "maxToolCalls": 2
+  },
+  "candidates": [
+    {
+      "id": "balanced-routing-and-format",
+      "append": "Use lookup tools only for lookup tasks. Emit strict JSON for structured tasks. Preserve direct answers without tools.\n[use_lookup_for_lookup_tasks]\n[emit_json_for_structured_tasks]",
+      "reason": "Training failures show missing lookup calls and invalid structured output.",
+      "targetFailures": [
+        "route_error",
+        "format_error"
+      ]
+    },
+    {
+      "id": "knowledge-overfit",
+      "append": "Search knowledge before every non-lookup task.\n[search_knowledge_for_all_non_lookup_tasks]",
+      "reason": "The remaining training failure lacks retrieved knowledge, but this broad rule may overfit.",
+      "targetFailures": [
+        "knowledge_recall_insufficient"
+      ]
+    }
+  ]
+}

--- a/examples/evaluation/promptiter/regression/data/train.evalset.json
+++ b/examples/evaluation/promptiter/regression/data/train.evalset.json
@@ -1,0 +1,93 @@
+{
+  "evalSetId": "regression-train",
+  "name": "regression-train",
+  "description": "Training cases for deterministic prompt optimization.",
+  "evalCases": [
+    {
+      "evalId": "train_lookup_weather",
+      "conversation": [
+        {
+          "invocationId": "train_lookup_weather-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"intent\":\"lookup\",\"query\":\"weather:shenzhen\",\"answer\":\"Shenzhen weather is sunny.\",\"tool\":{\"name\":\"lookup_record\",\"arguments\":{\"query\":\"weather:shenzhen\"},\"result\":{\"condition\":\"sunny\",\"location\":\"Shenzhen\"}}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Shenzhen weather is sunny."
+          },
+          "tools": [
+            {
+              "id": "expected-train-lookup",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "weather:shenzhen"
+              },
+              "result": {
+                "condition": "sunny",
+                "location": "Shenzhen"
+              }
+            }
+          ]
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-regression-loop",
+        "userId": "evaluation-user"
+      }
+    },
+    {
+      "evalId": "train_structured_order",
+      "conversation": [
+        {
+          "invocationId": "train_structured_order-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"intent\":\"structured\",\"query\":\"order summary\",\"answer\":\"{\\\"status\\\":\\\"ok\\\",\\\"total\\\":42}\",\"output\":{\"status\":\"ok\",\"total\":42}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "{\"status\":\"ok\",\"total\":42}"
+          },
+          "tools": []
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-regression-loop",
+        "userId": "evaluation-user"
+      }
+    },
+    {
+      "evalId": "train_knowledge_retention",
+      "conversation": [
+        {
+          "invocationId": "train_knowledge_retention-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"intent\":\"knowledge\",\"query\":\"document retention\",\"answer\":\"Document retention is 30 days.\",\"tool\":{\"name\":\"knowledge_search\",\"arguments\":{\"query\":\"document retention\"},\"result\":{\"answer\":\"Document retention is 30 days.\"}}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Document retention is 30 days."
+          },
+          "tools": [
+            {
+              "id": "expected-train-knowledge",
+              "name": "knowledge_search",
+              "arguments": {
+                "query": "document retention"
+              },
+              "result": {
+                "answer": "Document retention is 30 days."
+              }
+            }
+          ]
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-regression-loop",
+        "userId": "evaluation-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter/regression/data/validation.evalset.json
+++ b/examples/evaluation/promptiter/regression/data/validation.evalset.json
@@ -1,0 +1,82 @@
+{
+  "evalSetId": "regression-validation",
+  "name": "regression-validation",
+  "description": "Held-out cases for prompt regression gating.",
+  "evalCases": [
+    {
+      "evalId": "validation_lookup_exchange_rate",
+      "conversation": [
+        {
+          "invocationId": "validation_lookup_exchange_rate-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"intent\":\"lookup\",\"query\":\"rate:USD:CNY\",\"answer\":\"The USD/CNY rate is 7.20.\",\"tool\":{\"name\":\"lookup_record\",\"arguments\":{\"query\":\"rate:USD:CNY\"},\"result\":{\"pair\":\"USD/CNY\",\"rate\":7.2}}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "The USD/CNY rate is 7.20."
+          },
+          "tools": [
+            {
+              "id": "expected-validation-lookup",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "rate:USD:CNY"
+              },
+              "result": {
+                "pair": "USD/CNY",
+                "rate": 7.2
+              }
+            }
+          ]
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-regression-loop",
+        "userId": "evaluation-user"
+      }
+    },
+    {
+      "evalId": "validation_structured_profile",
+      "conversation": [
+        {
+          "invocationId": "validation_structured_profile-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"intent\":\"structured\",\"query\":\"profile summary\",\"answer\":\"{\\\"active\\\":true,\\\"tier\\\":\\\"gold\\\"}\",\"output\":{\"active\":true,\"tier\":\"gold\"}}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "{\"active\":true,\"tier\":\"gold\"}"
+          },
+          "tools": []
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-regression-loop",
+        "userId": "evaluation-user"
+      }
+    },
+    {
+      "evalId": "validation_direct_critical",
+      "conversation": [
+        {
+          "invocationId": "validation_direct_critical-1",
+          "userContent": {
+            "role": "user",
+            "content": "{\"intent\":\"direct\",\"query\":\"two plus two\",\"answer\":\"2 + 2 = 4.\"}"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "2 + 2 = 4."
+          },
+          "tools": []
+        }
+      ],
+      "sessionInput": {
+        "appName": "promptiter-regression-loop",
+        "userId": "evaluation-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/promptiter/regression/delta.go
+++ b/examples/evaluation/promptiter/regression/delta.go
@@ -1,0 +1,102 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+)
+
+const scoreEpsilon = 1e-9
+
+func compareEvaluations(
+	baseline evaluationSummary,
+	candidate evaluationSummary,
+) (evaluationDelta, error) {
+	baselineCases, err := indexCases(baseline.Cases)
+	if err != nil {
+		return evaluationDelta{}, fmt.Errorf("index baseline cases: %w", err)
+	}
+	candidateCases, err := indexCases(candidate.Cases)
+	if err != nil {
+		return evaluationDelta{}, fmt.Errorf("index candidate cases: %w", err)
+	}
+	if len(baselineCases) != len(candidateCases) {
+		return evaluationDelta{}, fmt.Errorf(
+			"case count mismatch: baseline=%d candidate=%d",
+			len(baselineCases),
+			len(candidateCases),
+		)
+	}
+
+	caseIDs := make([]string, 0, len(baselineCases))
+	for caseID := range baselineCases {
+		if _, ok := candidateCases[caseID]; !ok {
+			return evaluationDelta{}, fmt.Errorf("candidate result is missing case %q", caseID)
+		}
+		caseIDs = append(caseIDs, caseID)
+	}
+	sort.Strings(caseIDs)
+
+	delta := evaluationDelta{
+		ScoreDelta: roundScore(candidate.Score - baseline.Score),
+		Cases:      make([]caseDelta, 0, len(caseIDs)),
+	}
+	for _, caseID := range caseIDs {
+		baselineCase := baselineCases[caseID]
+		candidateCase := candidateCases[caseID]
+		item := caseDelta{
+			CaseID:          caseID,
+			BaselineScore:   baselineCase.Score,
+			CandidateScore:  candidateCase.Score,
+			ScoreDelta:      roundScore(candidateCase.Score - baselineCase.Score),
+			BaselinePassed:  baselineCase.Passed,
+			CandidatePassed: candidateCase.Passed,
+		}
+		switch {
+		case !baselineCase.Passed && candidateCase.Passed:
+			item.Class = caseNewlyPassed
+			delta.NewlyPassed++
+		case baselineCase.Passed && !candidateCase.Passed:
+			item.Class = caseNewlyFailed
+			delta.NewlyFailed++
+		case item.ScoreDelta > scoreEpsilon:
+			item.Class = caseImproved
+			delta.Improved++
+		case item.ScoreDelta < -scoreEpsilon:
+			item.Class = caseRegressed
+			delta.Regressed++
+		default:
+			item.Class = caseUnchanged
+			delta.Unchanged++
+		}
+		delta.Cases = append(delta.Cases, item)
+	}
+	return delta, nil
+}
+
+func indexCases(cases []caseEvaluation) (map[string]caseEvaluation, error) {
+	index := make(map[string]caseEvaluation, len(cases))
+	for _, evalCase := range cases {
+		if evalCase.CaseID == "" {
+			return nil, errors.New("case id is empty")
+		}
+		if _, exists := index[evalCase.CaseID]; exists {
+			return nil, fmt.Errorf("duplicate case id %q", evalCase.CaseID)
+		}
+		index[evalCase.CaseID] = evalCase
+	}
+	return index, nil
+}
+
+func roundScore(value float64) float64 {
+	return math.Round(value*1e9) / 1e9
+}

--- a/examples/evaluation/promptiter/regression/delta_test.go
+++ b/examples/evaluation/promptiter/regression/delta_test.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import "testing"
+
+func TestCompareEvaluationsClassifiesCaseDeltas(t *testing.T) {
+	baseline := evaluationSummary{
+		Score: 0.48,
+		Cases: []caseEvaluation{
+			{CaseID: "new-pass", Score: 0.25, Passed: false},
+			{CaseID: "new-fail", Score: 1.00, Passed: true},
+			{CaseID: "improved", Score: 0.40, Passed: false},
+			{CaseID: "regressed", Score: 0.80, Passed: false},
+			{CaseID: "unchanged", Score: 0.50, Passed: false},
+		},
+	}
+	candidate := evaluationSummary{
+		Score: 0.63,
+		Cases: []caseEvaluation{
+			{CaseID: "new-pass", Score: 1.00, Passed: true},
+			{CaseID: "new-fail", Score: 0.50, Passed: false},
+			{CaseID: "improved", Score: 0.75, Passed: false},
+			{CaseID: "regressed", Score: 0.60, Passed: false},
+			{CaseID: "unchanged", Score: 0.50, Passed: false},
+		},
+	}
+
+	delta, err := compareEvaluations(baseline, candidate)
+	if err != nil {
+		t.Fatalf("compareEvaluations returned error: %v", err)
+	}
+	if delta.ScoreDelta != 0.15 {
+		t.Fatalf("score delta = %.2f, want 0.15", delta.ScoreDelta)
+	}
+	assertDeltaClass(t, delta, "new-pass", caseNewlyPassed)
+	assertDeltaClass(t, delta, "new-fail", caseNewlyFailed)
+	assertDeltaClass(t, delta, "improved", caseImproved)
+	assertDeltaClass(t, delta, "regressed", caseRegressed)
+	assertDeltaClass(t, delta, "unchanged", caseUnchanged)
+	if delta.NewlyPassed != 1 || delta.NewlyFailed != 1 || delta.Improved != 1 || delta.Regressed != 1 {
+		t.Fatalf("unexpected delta counts: %+v", delta)
+	}
+}
+
+func TestCompareEvaluationsRejectsMismatchedCases(t *testing.T) {
+	_, err := compareEvaluations(
+		evaluationSummary{Cases: []caseEvaluation{{CaseID: "only-baseline"}}},
+		evaluationSummary{Cases: []caseEvaluation{{CaseID: "only-candidate"}}},
+	)
+	if err == nil {
+		t.Fatal("compareEvaluations returned nil error")
+	}
+}
+
+func assertDeltaClass(t *testing.T, delta evaluationDelta, caseID string, want caseDeltaClass) {
+	t.Helper()
+	for _, item := range delta.Cases {
+		if item.CaseID == caseID {
+			if item.Class != want {
+				t.Fatalf("case %q class = %q, want %q", caseID, item.Class, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("case %q not found", caseID)
+}

--- a/examples/evaluation/promptiter/regression/evaluate.go
+++ b/examples/evaluation/promptiter/regression/evaluate.go
@@ -1,0 +1,436 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metricinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+)
+
+type evaluationRuntime struct {
+	evaluator evaluation.AgentEvaluator
+	model     fakeModelConfig
+	evalSets  map[string]*evalset.EvalSet
+}
+
+func loadEvaluationInputs(
+	config pipelineConfig,
+) (*evalset.EvalSet, *evalset.EvalSet, []*metric.EvalMetric, string, error) {
+	train, err := loadJSONFile[evalset.EvalSet](config.Inputs.TrainEvalSet)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("load train eval set: %w", err)
+	}
+	validation, err := loadJSONFile[evalset.EvalSet](config.Inputs.ValidationEvalSet)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("load validation eval set: %w", err)
+	}
+	metrics, err := loadJSONFile[[]*metric.EvalMetric](config.Inputs.Metrics)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("load metrics: %w", err)
+	}
+	promptData, err := os.ReadFile(config.Inputs.PromptSource)
+	if err != nil {
+		return nil, nil, nil, "", fmt.Errorf("read prompt source: %w", err)
+	}
+	prompt := strings.TrimSpace(string(promptData))
+	if prompt == "" {
+		return nil, nil, nil, "", errors.New("baseline prompt is empty")
+	}
+	if err := validateEvaluationInputs(train, validation, *metrics); err != nil {
+		return nil, nil, nil, "", err
+	}
+	return train, validation, *metrics, prompt, nil
+}
+
+func loadJSONFile[T any](path string) (*T, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var value T
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("multiple JSON values")
+		}
+		return nil, err
+	}
+	return &value, nil
+}
+
+func validateEvaluationInputs(
+	train *evalset.EvalSet,
+	validation *evalset.EvalSet,
+	metrics []*metric.EvalMetric,
+) error {
+	switch {
+	case train == nil || strings.TrimSpace(train.EvalSetID) == "":
+		return errors.New("train eval set id is empty")
+	case validation == nil || strings.TrimSpace(validation.EvalSetID) == "":
+		return errors.New("validation eval set id is empty")
+	case train.EvalSetID == validation.EvalSetID:
+		return errors.New("train and validation eval set ids must differ")
+	case len(train.EvalCases) == 0:
+		return errors.New("train eval set has no cases")
+	case len(validation.EvalCases) == 0:
+		return errors.New("validation eval set has no cases")
+	case len(metrics) == 0:
+		return errors.New("metrics list is empty")
+	}
+	return nil
+}
+
+func newEvaluationRuntime(
+	ctx context.Context,
+	config pipelineConfig,
+	train *evalset.EvalSet,
+	validation *evalset.EvalSet,
+	metrics []*metric.EvalMetric,
+) (*evaluationRuntime, error) {
+	evalSetManager := evalsetinmemory.New()
+	metricManager := metricinmemory.New()
+	resultManager := evalresultinmemory.New()
+	for _, evalSet := range []*evalset.EvalSet{train, validation} {
+		if err := addEvalSet(ctx, evalSetManager, config.AppName, evalSet); err != nil {
+			return nil, err
+		}
+		for _, evalMetric := range metrics {
+			if err := metricManager.Add(ctx, config.AppName, evalSet.EvalSetID, evalMetric); err != nil {
+				return nil, fmt.Errorf(
+					"add metric %q to eval set %q: %w",
+					evalMetric.MetricName,
+					evalSet.EvalSetID,
+					err,
+				)
+			}
+		}
+	}
+	runner := &deterministicRunner{
+		targetSurfaceID: config.TargetSurfaceID,
+		model:           config.FakeModel,
+		seed:            config.Seed,
+	}
+	agentEvaluator, err := evaluation.New(
+		config.AppName,
+		runner,
+		evaluation.WithEvalSetManager(evalSetManager),
+		evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(resultManager),
+		evaluation.WithNumRuns(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create agent evaluator: %w", err)
+	}
+	return &evaluationRuntime{
+		evaluator: agentEvaluator,
+		model:     config.FakeModel,
+		evalSets: map[string]*evalset.EvalSet{
+			train.EvalSetID:      train,
+			validation.EvalSetID: validation,
+		},
+	}, nil
+}
+
+func addEvalSet(
+	ctx context.Context,
+	manager evalset.Manager,
+	appName string,
+	input *evalset.EvalSet,
+) error {
+	if _, err := manager.Create(ctx, appName, input.EvalSetID); err != nil {
+		return fmt.Errorf("create eval set %q: %w", input.EvalSetID, err)
+	}
+	for _, evalCase := range input.EvalCases {
+		if err := manager.AddCase(ctx, appName, input.EvalSetID, evalCase); err != nil {
+			return fmt.Errorf("add case to eval set %q: %w", input.EvalSetID, err)
+		}
+	}
+	return nil
+}
+
+func (r *evaluationRuntime) close() error {
+	if r == nil || r.evaluator == nil {
+		return nil
+	}
+	return r.evaluator.Close()
+}
+
+func (r *evaluationRuntime) evaluate(
+	ctx context.Context,
+	evalSetID string,
+	prompt string,
+) (evaluationSummary, error) {
+	expectedSet, ok := r.evalSets[evalSetID]
+	if !ok {
+		return evaluationSummary{}, fmt.Errorf("eval set %q is not loaded", evalSetID)
+	}
+	result, err := r.evaluator.Evaluate(
+		ctx,
+		evalSetID,
+		evaluation.WithRunDetailsEnabled(true),
+		evaluation.WithRunOptions(agent.WithInstruction(prompt)),
+	)
+	if err != nil {
+		return evaluationSummary{}, fmt.Errorf("evaluate %q: %w", evalSetID, err)
+	}
+	return r.adaptEvaluation(result, expectedSet)
+}
+
+func (r *evaluationRuntime) adaptEvaluation(
+	result *evaluation.EvaluationResult,
+	expectedSet *evalset.EvalSet,
+) (evaluationSummary, error) {
+	if result == nil {
+		return evaluationSummary{}, errors.New("evaluation result is nil")
+	}
+	expectedCases := make(map[string]*evalset.EvalCase, len(expectedSet.EvalCases))
+	for _, evalCase := range expectedSet.EvalCases {
+		if evalCase != nil {
+			expectedCases[evalCase.EvalID] = evalCase
+		}
+	}
+	summary := evaluationSummary{
+		EvalSetID: result.EvalSetID,
+		Cases:     make([]caseEvaluation, 0, len(result.EvalCases)),
+	}
+	totalMetricScore := 0.0
+	metricCount := 0
+	for _, evalCase := range result.EvalCases {
+		if evalCase == nil {
+			continue
+		}
+		expected, ok := expectedCases[evalCase.EvalCaseID]
+		if !ok {
+			return evaluationSummary{}, fmt.Errorf(
+				"expected eval case %q is missing",
+				evalCase.EvalCaseID,
+			)
+		}
+		adapted, err := r.adaptCase(evalCase, expected)
+		if err != nil {
+			return evaluationSummary{}, fmt.Errorf("adapt case %q: %w", evalCase.EvalCaseID, err)
+		}
+		for _, metricResult := range adapted.Metrics {
+			totalMetricScore += metricResult.Score
+			metricCount++
+		}
+		if adapted.Passed {
+			summary.PassedCases++
+		} else {
+			summary.FailedCases++
+		}
+		addCost(&summary.Cost, adapted.Cost)
+		summary.LatencyMillis += adapted.LatencyMillis
+		summary.Cases = append(summary.Cases, adapted)
+	}
+	if metricCount == 0 {
+		return evaluationSummary{}, errors.New("evaluation result contains no metric scores")
+	}
+	summary.Score = roundScore(totalMetricScore / float64(metricCount))
+	sort.Slice(summary.Cases, func(i, j int) bool {
+		return summary.Cases[i].CaseID < summary.Cases[j].CaseID
+	})
+	return summary, nil
+}
+
+func (r *evaluationRuntime) adaptCase(
+	result *evaluation.EvaluationCaseResult,
+	expected *evalset.EvalCase,
+) (caseEvaluation, error) {
+	if len(result.RunDetails) != 1 || result.RunDetails[0] == nil ||
+		result.RunDetails[0].Inference == nil {
+		return caseEvaluation{}, errors.New("case must contain exactly one inference run detail")
+	}
+	inference := result.RunDetails[0].Inference
+	actualInvocations := inference.Inferences
+	expectedInvocations := expected.Conversation
+	actualResponse := lastResponse(actualInvocations)
+	expectedResponse := lastResponse(expectedInvocations)
+	actualTools := flattenTools(actualInvocations)
+	expectedTools := flattenTools(expectedInvocations)
+	metricResults := result.MetricResults
+	if len(result.EvalCaseResults) == 1 && result.EvalCaseResults[0] != nil {
+		metricResults = result.EvalCaseResults[0].OverallEvalMetricResults
+	}
+	metrics := adaptMetrics(metricResults)
+	adapted := caseEvaluation{
+		CaseID:                 result.EvalCaseID,
+		Score:                  averageMetricScore(metrics),
+		Passed:                 allMetricsPassed(metrics),
+		FinalResponse:          actualResponse,
+		ExpectedResponse:       expectedResponse,
+		ToolTrajectory:         actualTools,
+		ExpectedToolTrajectory: expectedTools,
+		Metrics:                metrics,
+	}
+	adapted.Trace, adapted.Cost, adapted.LatencyMillis = r.adaptTraces(inference.ExecutionTraces)
+	adapted.Cost.ToolCalls = len(actualTools)
+	if !adapted.Passed {
+		adapted.FailureAttributions = attributeFailures(attributionInput{
+			metrics:          metrics,
+			actualResponse:   actualResponse,
+			expectedResponse: expectedResponse,
+			actualTools:      actualTools,
+			expectedTools:    expectedTools,
+			trace:            adapted.Trace,
+		})
+	}
+	return adapted, nil
+}
+
+func adaptMetrics(results []*evalresult.EvalMetricResult) []metricEvaluation {
+	metrics := make([]metricEvaluation, 0, len(results))
+	for _, result := range results {
+		if result == nil || result.EvalStatus == status.EvalStatusNotEvaluated {
+			continue
+		}
+		adapted := metricEvaluation{
+			Name:      result.MetricName,
+			Score:     result.Score,
+			Threshold: result.Threshold,
+			Passed:    result.EvalStatus == status.EvalStatusPassed,
+		}
+		if result.Details != nil {
+			adapted.Reason = strings.TrimSpace(result.Details.Reason)
+		}
+		metrics = append(metrics, adapted)
+	}
+	sort.Slice(metrics, func(i, j int) bool {
+		return metrics[i].Name < metrics[j].Name
+	})
+	return metrics
+}
+
+func lastResponse(invocations []*evalset.Invocation) string {
+	for index := len(invocations) - 1; index >= 0; index-- {
+		if invocations[index] != nil && invocations[index].FinalResponse != nil {
+			return invocations[index].FinalResponse.Content
+		}
+	}
+	return ""
+}
+
+func flattenTools(invocations []*evalset.Invocation) []toolAudit {
+	tools := make([]toolAudit, 0)
+	for _, invocation := range invocations {
+		if invocation == nil {
+			continue
+		}
+		for _, toolCall := range invocation.Tools {
+			if toolCall == nil {
+				continue
+			}
+			tools = append(tools, toolAudit{
+				ID:        toolCall.ID,
+				Name:      toolCall.Name,
+				Arguments: toolCall.Arguments,
+				Result:    toolCall.Result,
+			})
+		}
+	}
+	return tools
+}
+
+func (r *evaluationRuntime) adaptTraces(
+	traces []*agenttrace.Trace,
+) (traceAudit, costSummary, int64) {
+	audit := traceAudit{Steps: make([]traceStepAudit, 0)}
+	var cost costSummary
+	var latency int64
+	for _, trace := range traces {
+		if trace == nil {
+			continue
+		}
+		audit.Status = string(trace.Status)
+		if trace.Usage != nil {
+			cost.ModelCalls++
+			cost.PromptTokens += trace.Usage.PromptTokens
+			cost.CompletionTokens += trace.Usage.CompletionTokens
+			cost.TotalTokens += trace.Usage.TotalTokens
+		}
+		latency += trace.EndedAt.Sub(trace.StartedAt).Milliseconds()
+		for _, step := range trace.Steps {
+			audit.Steps = append(audit.Steps, traceStepAudit{
+				StepID:            step.StepID,
+				NodeID:            step.NodeID,
+				NodeType:          step.NodeType,
+				AppliedSurfaceIDs: append([]string(nil), step.AppliedSurfaceIDs...),
+				Error:             step.Error,
+			})
+		}
+	}
+	cost.EstimatedCostUSD = estimateCost(cost, r.model)
+	return audit, cost, latency
+}
+
+func averageMetricScore(metrics []metricEvaluation) float64 {
+	if len(metrics) == 0 {
+		return 0
+	}
+	total := 0.0
+	for _, metric := range metrics {
+		total += metric.Score
+	}
+	return roundScore(total / float64(len(metrics)))
+}
+
+func allMetricsPassed(metrics []metricEvaluation) bool {
+	if len(metrics) == 0 {
+		return false
+	}
+	for _, metric := range metrics {
+		if !metric.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+func estimateCost(cost costSummary, model fakeModelConfig) float64 {
+	value := float64(cost.PromptTokens)*model.PromptCostPerMillionTokens/1_000_000 +
+		float64(cost.CompletionTokens)*model.OutputCostPerMillionTokens/1_000_000
+	return roundCost(value)
+}
+
+func roundCost(value float64) float64 {
+	const precision = 1_000_000_000
+	return float64(int64(value*precision+0.5)) / precision
+}
+
+func addCost(target *costSummary, addition costSummary) {
+	target.ModelCalls += addition.ModelCalls
+	target.ToolCalls += addition.ToolCalls
+	target.PromptTokens += addition.PromptTokens
+	target.CompletionTokens += addition.CompletionTokens
+	target.TotalTokens += addition.TotalTokens
+	target.EstimatedCostUSD = roundCost(target.EstimatedCostUSD + addition.EstimatedCostUSD)
+}

--- a/examples/evaluation/promptiter/regression/gate.go
+++ b/examples/evaluation/promptiter/regression/gate.go
@@ -1,0 +1,125 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import "fmt"
+
+func decideGate(
+	config gateConfig,
+	baseline evaluationSummary,
+	candidate evaluationSummary,
+	delta evaluationDelta,
+) gateDecision {
+	decision := gateDecision{
+		Reasons: make([]string, 0),
+		Checks:  make([]gateCheck, 0, 5),
+	}
+	addCheck := func(name string, passed bool, detail string) {
+		decision.Checks = append(decision.Checks, gateCheck{
+			Name:   name,
+			Passed: passed,
+			Detail: detail,
+		})
+		if !passed {
+			decision.Reasons = append(decision.Reasons, detail)
+		}
+	}
+
+	addCheck(
+		"minimum_validation_gain",
+		delta.ScoreDelta+scoreEpsilon >= config.MinValidationScoreGain,
+		fmt.Sprintf(
+			"validation score gain %.4f must be at least %.4f",
+			delta.ScoreDelta,
+			config.MinValidationScoreGain,
+		),
+	)
+
+	hardFailPassed := config.AllowNewHardFails || delta.NewlyFailed == 0
+	addCheck(
+		"no_new_hard_fails",
+		hardFailPassed,
+		fmt.Sprintf(
+			"candidate introduced %d new hard fail(s); allowNewHardFails=%t",
+			delta.NewlyFailed,
+			config.AllowNewHardFails,
+		),
+	)
+
+	criticalPassed, criticalDetail := checkCriticalCases(config, baseline, candidate)
+	addCheck("critical_cases", criticalPassed, criticalDetail)
+
+	costPassed := config.MaxEstimatedCostUSD <= 0 ||
+		candidate.Cost.EstimatedCostUSD <= config.MaxEstimatedCostUSD+scoreEpsilon
+	addCheck(
+		"cost_budget",
+		costPassed,
+		fmt.Sprintf(
+			"candidate cost budget: estimated $%.6f, limit $%.6f",
+			candidate.Cost.EstimatedCostUSD,
+			config.MaxEstimatedCostUSD,
+		),
+	)
+
+	toolCallsPassed := config.MaxToolCalls <= 0 || candidate.Cost.ToolCalls <= config.MaxToolCalls
+	addCheck(
+		"tool_call_budget",
+		toolCallsPassed,
+		fmt.Sprintf(
+			"candidate tool-call budget: used %d, limit %d",
+			candidate.Cost.ToolCalls,
+			config.MaxToolCalls,
+		),
+	)
+
+	decision.Accepted = len(decision.Reasons) == 0
+	if decision.Accepted {
+		decision.Reasons = []string{"all acceptance checks passed"}
+	}
+	return decision
+}
+
+func checkCriticalCases(
+	config gateConfig,
+	baseline evaluationSummary,
+	candidate evaluationSummary,
+) (bool, string) {
+	if len(config.CriticalCaseIDs) == 0 {
+		return true, "no critical cases configured"
+	}
+	baselineCases, err := indexCases(baseline.Cases)
+	if err != nil {
+		return false, fmt.Sprintf("critical case baseline index failed: %v", err)
+	}
+	candidateCases, err := indexCases(candidate.Cases)
+	if err != nil {
+		return false, fmt.Sprintf("critical case candidate index failed: %v", err)
+	}
+	for _, caseID := range config.CriticalCaseIDs {
+		baselineCase, baselineOK := baselineCases[caseID]
+		candidateCase, candidateOK := candidateCases[caseID]
+		if !baselineOK || !candidateOK {
+			return false, fmt.Sprintf("critical case %q is missing from an evaluation result", caseID)
+		}
+		drop := baselineCase.Score - candidateCase.Score
+		if drop > config.MaxCriticalScoreDrop+scoreEpsilon {
+			return false, fmt.Sprintf(
+				"critical case %q score dropped by %.4f, limit %.4f",
+				caseID,
+				drop,
+				config.MaxCriticalScoreDrop,
+			)
+		}
+	}
+	return true, fmt.Sprintf(
+		"%d critical case(s) stayed within the %.4f score-drop limit",
+		len(config.CriticalCaseIDs),
+		config.MaxCriticalScoreDrop,
+	)
+}

--- a/examples/evaluation/promptiter/regression/gate_test.go
+++ b/examples/evaluation/promptiter/regression/gate_test.go
@@ -1,0 +1,128 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecideGate(t *testing.T) {
+	baseConfig := gateConfig{
+		MinValidationScoreGain: 0.05,
+		AllowNewHardFails:      false,
+		CriticalCaseIDs:        []string{"critical"},
+		MaxCriticalScoreDrop:   0,
+		MaxEstimatedCostUSD:    0.02,
+		MaxToolCalls:           2,
+	}
+	baseline := evaluationSummary{
+		Score: 0.60,
+		Cases: []caseEvaluation{
+			{CaseID: "regular", Score: 0.50, Passed: false},
+			{CaseID: "critical", Score: 1.00, Passed: true},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		candidate     evaluationSummary
+		wantAccepted  bool
+		reasonContain string
+	}{
+		{
+			name: "accept",
+			candidate: evaluationSummary{
+				Score: 0.75,
+				Cases: []caseEvaluation{
+					{CaseID: "regular", Score: 0.75, Passed: false},
+					{CaseID: "critical", Score: 1.00, Passed: true},
+				},
+				Cost: costSummary{EstimatedCostUSD: 0.01, ToolCalls: 1},
+			},
+			wantAccepted: true,
+		},
+		{
+			name: "insufficient gain",
+			candidate: evaluationSummary{
+				Score: 0.64,
+				Cases: baseline.Cases,
+				Cost:  costSummary{EstimatedCostUSD: 0.01, ToolCalls: 1},
+			},
+			reasonContain: "score gain",
+		},
+		{
+			name: "new hard fail",
+			candidate: evaluationSummary{
+				Score: 0.80,
+				Cases: []caseEvaluation{
+					{CaseID: "regular", Score: 1.00, Passed: true},
+					{CaseID: "critical", Score: 0.50, Passed: false},
+				},
+				Cost: costSummary{EstimatedCostUSD: 0.01, ToolCalls: 1},
+			},
+			reasonContain: "hard fail",
+		},
+		{
+			name: "critical regression",
+			candidate: evaluationSummary{
+				Score: 0.80,
+				Cases: []caseEvaluation{
+					{CaseID: "regular", Score: 1.00, Passed: true},
+					{CaseID: "critical", Score: 0.90, Passed: true},
+				},
+				Cost: costSummary{EstimatedCostUSD: 0.01, ToolCalls: 1},
+			},
+			reasonContain: "critical case",
+		},
+		{
+			name: "cost budget",
+			candidate: evaluationSummary{
+				Score: 0.80,
+				Cases: baseline.Cases,
+				Cost:  costSummary{EstimatedCostUSD: 0.03, ToolCalls: 1},
+			},
+			reasonContain: "cost budget",
+		},
+		{
+			name: "tool budget",
+			candidate: evaluationSummary{
+				Score: 0.80,
+				Cases: baseline.Cases,
+				Cost:  costSummary{EstimatedCostUSD: 0.01, ToolCalls: 3},
+			},
+			reasonContain: "tool-call budget",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			delta, err := compareEvaluations(baseline, test.candidate)
+			if err != nil {
+				t.Fatalf("compareEvaluations returned error: %v", err)
+			}
+			decision := decideGate(baseConfig, baseline, test.candidate, delta)
+			if decision.Accepted != test.wantAccepted {
+				t.Fatalf("accepted = %t, want %t; reasons: %v", decision.Accepted, test.wantAccepted, decision.Reasons)
+			}
+			if test.reasonContain != "" && !containsReason(decision.Reasons, test.reasonContain) {
+				t.Fatalf("reasons %v do not contain %q", decision.Reasons, test.reasonContain)
+			}
+		})
+	}
+}
+
+func containsReason(reasons []string, part string) bool {
+	for _, reason := range reasons {
+		if strings.Contains(reason, part) {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/evaluation/promptiter/regression/main.go
+++ b/examples/evaluation/promptiter/regression/main.go
@@ -1,0 +1,56 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"path/filepath"
+	"time"
+)
+
+var (
+	configPath  = flag.String("config", "./data/promptiter.json", "Path to the regression-loop configuration")
+	outputDir   = flag.String("output-dir", "./output", "Directory for optimization_report.json and optimization_report.md")
+	writePrompt = flag.Bool("write-prompt", false, "Write an accepted candidate back to the configured prompt source")
+	timeout     = flag.Duration("timeout", 3*time.Minute, "Maximum pipeline runtime")
+)
+
+func main() {
+	flag.Parse()
+	if *timeout <= 0 {
+		log.Fatal("timeout must be greater than zero")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	report, err := runPipeline(ctx, pipelineOptions{
+		ConfigPath:  *configPath,
+		OutputDir:   *outputDir,
+		WritePrompt: *writePrompt,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	decision := "REJECT"
+	if report.GateDecision.Accepted {
+		decision = "ACCEPT"
+	}
+	fmt.Printf("PromptIter regression loop completed: %s\n", decision)
+	fmt.Printf("Validation score: %.4f -> %.4f (%+.4f)\n",
+		report.Baseline.Validation.Score,
+		report.Candidate.Validation.Score,
+		report.Delta.ScoreDelta,
+	)
+	fmt.Printf("Reports: %s, %s\n",
+		filepath.Join(*outputDir, reportJSONFile),
+		filepath.Join(*outputDir, reportMDFile),
+	)
+}

--- a/examples/evaluation/promptiter/regression/main.go
+++ b/examples/evaluation/promptiter/regression/main.go
@@ -26,6 +26,9 @@ var (
 
 func main() {
 	flag.Parse()
+	if err := validatePositionalArgs(flag.Args()); err != nil {
+		log.Fatal(err)
+	}
 	if *timeout <= 0 {
 		log.Fatal("timeout must be greater than zero")
 	}
@@ -52,5 +55,15 @@ func main() {
 	fmt.Printf("Reports: %s, %s\n",
 		filepath.Join(*outputDir, reportJSONFile),
 		filepath.Join(*outputDir, reportMDFile),
+	)
+}
+
+func validatePositionalArgs(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"unexpected positional argument %q; -write-prompt is a boolean flag",
+		args[0],
 	)
 }

--- a/examples/evaluation/promptiter/regression/main_test.go
+++ b/examples/evaluation/promptiter/regression/main_test.go
@@ -1,0 +1,32 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidatePositionalArgs(t *testing.T) {
+	t.Run("accepts no positional arguments", func(t *testing.T) {
+		if err := validatePositionalArgs(nil); err != nil {
+			t.Fatalf("validate positional arguments: %v", err)
+		}
+	})
+
+	t.Run("rejects unexpected positional arguments", func(t *testing.T) {
+		err := validatePositionalArgs([]string{"/tmp/accepted_prompt.txt"})
+		if err == nil {
+			t.Fatal("expected positional argument validation error")
+		}
+		if !strings.Contains(err.Error(), "unexpected positional argument") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/examples/evaluation/promptiter/regression/optimize.go
+++ b/examples/evaluation/promptiter/regression/optimize.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+)
+
+type promptCandidate struct {
+	ID      string
+	Reason  string
+	Patch   promptiter.SurfacePatch
+	Profile promptiter.Profile
+}
+
+func buildPromptCandidate(
+	basePrompt string,
+	config candidateConfig,
+	targetSurfaceID string,
+) (promptCandidate, error) {
+	basePrompt = strings.TrimSpace(basePrompt)
+	appendText := strings.TrimSpace(config.Append)
+	if basePrompt == "" {
+		return promptCandidate{}, fmt.Errorf("base prompt is empty")
+	}
+	if appendText == "" {
+		return promptCandidate{}, fmt.Errorf("candidate %q append text is empty", config.ID)
+	}
+	candidateText := basePrompt + "\n\n" + appendText
+	patch := promptiter.SurfacePatch{
+		SurfaceID: targetSurfaceID,
+		Value:     astructure.SurfaceValue{Text: &candidateText},
+		Reason:    config.Reason,
+	}
+	return promptCandidate{
+		ID:     config.ID,
+		Reason: config.Reason,
+		Patch:  patch,
+		Profile: promptiter.Profile{
+			StructureID: "deterministic-regression-loop",
+			Overrides: []promptiter.SurfaceOverride{{
+				SurfaceID: targetSurfaceID,
+				Value:     patch.Value,
+			}},
+		},
+	}, nil
+}
+
+func candidateTargetsCurrentFailures(
+	config candidateConfig,
+	currentTrain evaluationSummary,
+) bool {
+	if len(config.TargetFailures) == 0 {
+		return true
+	}
+	current := summarizeFailures(currentTrain)
+	for _, category := range config.TargetFailures {
+		if current[category] > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/examples/evaluation/promptiter/regression/pipeline.go
+++ b/examples/evaluation/promptiter/regression/pipeline.go
@@ -1,0 +1,244 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const reportSchemaVersion = "1.0"
+
+type pipelineOptions struct {
+	ConfigPath  string
+	OutputDir   string
+	WritePrompt bool
+}
+
+func runPipeline(
+	ctx context.Context,
+	options pipelineOptions,
+) (optimizationReport, error) {
+	startedAt := time.Now().UTC()
+	config, err := loadConfig(options.ConfigPath)
+	if err != nil {
+		return optimizationReport{}, err
+	}
+	trainSet, validationSet, metrics, baselinePrompt, err := loadEvaluationInputs(config)
+	if err != nil {
+		return optimizationReport{}, err
+	}
+	runtime, err := newEvaluationRuntime(ctx, config, trainSet, validationSet, metrics)
+	if err != nil {
+		return optimizationReport{}, err
+	}
+	defer runtime.close()
+
+	baselineTrain, err := runtime.evaluate(ctx, trainSet.EvalSetID, baselinePrompt)
+	if err != nil {
+		return optimizationReport{}, fmt.Errorf("evaluate baseline train set: %w", err)
+	}
+	baselineValidation, err := runtime.evaluate(ctx, validationSet.EvalSetID, baselinePrompt)
+	if err != nil {
+		return optimizationReport{}, fmt.Errorf("evaluate baseline validation set: %w", err)
+	}
+	baseline := promptEvaluation{
+		Prompt:     baselinePrompt,
+		Train:      baselineTrain,
+		Validation: baselineValidation,
+	}
+
+	current := baseline
+	selected := baseline
+	selectedDecision := gateDecision{
+		Accepted: false,
+		Reasons:  []string{"no candidate passed the acceptance gate"},
+	}
+	selected.CandidateID = "baseline"
+	rounds := make([]roundAudit, 0, config.MaxRounds)
+	var candidateCosts costSummary
+	evaluatedRounds := 0
+	for _, candidateConfig := range config.Candidates {
+		if evaluatedRounds >= config.MaxRounds {
+			break
+		}
+		if !candidateTargetsCurrentFailures(candidateConfig, current.Train) {
+			continue
+		}
+		roundStartedAt := time.Now()
+		proposal, err := buildPromptCandidate(
+			current.Prompt,
+			candidateConfig,
+			config.TargetSurfaceID,
+		)
+		if err != nil {
+			return optimizationReport{}, err
+		}
+		if len(proposal.Profile.Overrides) != 1 ||
+			proposal.Profile.Overrides[0].Value.Text == nil {
+			return optimizationReport{}, fmt.Errorf("candidate %q prompt patch is empty", proposal.ID)
+		}
+		evaluatedRounds++
+		candidatePrompt := *proposal.Profile.Overrides[0].Value.Text
+		train, err := runtime.evaluate(ctx, trainSet.EvalSetID, candidatePrompt)
+		if err != nil {
+			return optimizationReport{}, fmt.Errorf(
+				"evaluate candidate %q train set: %w",
+				proposal.ID,
+				err,
+			)
+		}
+		validation, err := runtime.evaluate(ctx, validationSet.EvalSetID, candidatePrompt)
+		if err != nil {
+			return optimizationReport{}, fmt.Errorf(
+				"evaluate candidate %q validation set: %w",
+				proposal.ID,
+				err,
+			)
+		}
+		delta, err := compareEvaluations(current.Validation, validation)
+		if err != nil {
+			return optimizationReport{}, fmt.Errorf(
+				"compare candidate %q validation: %w",
+				proposal.ID,
+				err,
+			)
+		}
+		decision := decideGate(config.Gate, current.Validation, validation, delta)
+		candidate := promptEvaluation{
+			Round:       evaluatedRounds,
+			CandidateID: proposal.ID,
+			Prompt:      candidatePrompt,
+			Train:       train,
+			Validation:  validation,
+		}
+		rounds = append(rounds, roundAudit{
+			Round:          evaluatedRounds,
+			CandidateID:    proposal.ID,
+			Prompt:         candidatePrompt,
+			PatchReason:    proposal.Reason,
+			Train:          train,
+			Validation:     validation,
+			Delta:          delta,
+			Decision:       decision,
+			DurationMillis: time.Since(roundStartedAt).Milliseconds(),
+		})
+		addCost(&candidateCosts, train.Cost)
+		addCost(&candidateCosts, validation.Cost)
+		if decision.Accepted {
+			current = candidate
+			selected = candidate
+			selectedDecision = decision
+		}
+	}
+	if evaluatedRounds == 0 {
+		return optimizationReport{}, errors.New("no candidate targeted the current training failures")
+	}
+
+	finalDelta, err := compareEvaluations(baseline.Validation, selected.Validation)
+	if err != nil {
+		return optimizationReport{}, fmt.Errorf("compare selected candidate to baseline: %w", err)
+	}
+	baselineCosts := costSummary{}
+	addCost(&baselineCosts, baseline.Train.Cost)
+	addCost(&baselineCosts, baseline.Validation.Cost)
+	totalCosts := baselineCosts
+	addCost(&totalCosts, candidateCosts)
+	report := optimizationReport{
+		SchemaVersion: reportSchemaVersion,
+		RunID: deterministicID(
+			config.Seed,
+			trainSet.EvalSetID,
+			validationSet.EvalSetID,
+			config.TargetSurfaceID,
+			baselinePrompt,
+		),
+		Inputs: inputAudit{
+			TrainEvalSet:      portableInputPath(config.Inputs.TrainEvalSet),
+			ValidationEvalSet: portableInputPath(config.Inputs.ValidationEvalSet),
+			Metrics:           portableInputPath(config.Inputs.Metrics),
+			PromptSource:      portableInputPath(config.Inputs.PromptSource),
+			Config:            portableInputPath(options.ConfigPath),
+		},
+		Configuration: configurationAudit{
+			TargetSurfaceID: config.TargetSurfaceID,
+			MaxRounds:       config.MaxRounds,
+			Gate:            config.Gate,
+		},
+		Runtime: runtimeAudit{
+			Seed:           config.Seed,
+			Engine:         "evaluation-service+promptiter-deterministic",
+			Model:          config.FakeModel,
+			StartedAt:      startedAt,
+			DurationMillis: time.Since(startedAt).Milliseconds(),
+		},
+		Baseline:     baseline,
+		Candidate:    selected,
+		Delta:        finalDelta,
+		GateDecision: selectedDecision,
+		FailureAttribution: attributionSummary{
+			Baseline:  summarizeFailures(baseline.Train, baseline.Validation),
+			Candidate: summarizeFailures(selected.Train, selected.Validation),
+		},
+		CostLatency: costLatencySummary{
+			Baseline:           baselineCosts,
+			Candidates:         candidateCosts,
+			Total:              totalCosts,
+			TotalLatencyMillis: evaluationLatency(baseline.Train, baseline.Validation) + roundsLatency(rounds),
+		},
+		Rounds: rounds,
+	}
+	if err := writeReports(options.OutputDir, report); err != nil {
+		return optimizationReport{}, err
+	}
+	if options.WritePrompt && report.GateDecision.Accepted {
+		if err := os.WriteFile(config.Inputs.PromptSource, []byte(strings.TrimSpace(selected.Prompt)+"\n"), 0o644); err != nil {
+			return optimizationReport{}, fmt.Errorf("write accepted prompt: %w", err)
+		}
+	}
+	return report, nil
+}
+
+func summarizeFailures(summaries ...evaluationSummary) map[failureCategory]int {
+	counts := make(map[failureCategory]int)
+	for _, summary := range summaries {
+		for _, evalCase := range summary.Cases {
+			if len(evalCase.FailureAttributions) == 0 {
+				continue
+			}
+			counts[evalCase.FailureAttributions[0].Category]++
+		}
+	}
+	return counts
+}
+
+func portableInputPath(path string) string {
+	return filepath.ToSlash(filepath.Join(filepath.Base(filepath.Dir(path)), filepath.Base(path)))
+}
+
+func evaluationLatency(summaries ...evaluationSummary) int64 {
+	var total int64
+	for _, summary := range summaries {
+		total += summary.LatencyMillis
+	}
+	return total
+}
+
+func roundsLatency(rounds []roundAudit) int64 {
+	var total int64
+	for _, round := range rounds {
+		total += round.Train.LatencyMillis + round.Validation.LatencyMillis
+	}
+	return total
+}

--- a/examples/evaluation/promptiter/regression/pipeline_test.go
+++ b/examples/evaluation/promptiter/regression/pipeline_test.go
@@ -1,0 +1,140 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunPipelineDeterministicExample(t *testing.T) {
+	outputDir := t.TempDir()
+	start := time.Now()
+	report, err := runPipeline(context.Background(), pipelineOptions{
+		ConfigPath: "data/promptiter.json",
+		OutputDir:  outputDir,
+	})
+	if err != nil {
+		t.Fatalf("runPipeline returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 3*time.Minute {
+		t.Fatalf("pipeline took %s, want less than 3 minutes", elapsed)
+	}
+	if len(report.Baseline.Train.Cases) != 3 || len(report.Baseline.Validation.Cases) != 3 {
+		t.Fatalf(
+			"baseline case counts = train %d validation %d, want 3 and 3",
+			len(report.Baseline.Train.Cases),
+			len(report.Baseline.Validation.Cases),
+		)
+	}
+	if report.Baseline.Validation.Score != 0.5 {
+		t.Fatalf("baseline validation score = %.4f, want 0.5000", report.Baseline.Validation.Score)
+	}
+	assertFailedMetricsHaveReasons(t, report.Baseline.Train)
+	assertFailedMetricsHaveReasons(t, report.Baseline.Validation)
+	if report.Candidate.Validation.Score != 1 {
+		t.Fatalf("candidate validation score = %.4f, want 1.0000", report.Candidate.Validation.Score)
+	}
+	if !report.GateDecision.Accepted {
+		t.Fatalf("selected candidate was rejected: %v", report.GateDecision.Reasons)
+	}
+	if len(report.Rounds) != 2 {
+		t.Fatalf("round count = %d, want 2", len(report.Rounds))
+	}
+	if !report.Rounds[0].Decision.Accepted {
+		t.Fatalf("round 1 was rejected: %v", report.Rounds[0].Decision.Reasons)
+	}
+	if report.Rounds[1].Decision.Accepted {
+		t.Fatal("overfit round was accepted")
+	}
+	if report.Rounds[1].Train.Score <= report.Rounds[0].Train.Score {
+		t.Fatalf(
+			"overfit train score %.4f did not improve over %.4f",
+			report.Rounds[1].Train.Score,
+			report.Rounds[0].Train.Score,
+		)
+	}
+	if report.Rounds[1].Validation.Score >= report.Rounds[0].Validation.Score {
+		t.Fatalf(
+			"overfit validation score %.4f did not regress from %.4f",
+			report.Rounds[1].Validation.Score,
+			report.Rounds[0].Validation.Score,
+		)
+	}
+	for _, name := range []string{reportJSONFile, reportMDFile} {
+		if _, err := os.Stat(filepath.Join(outputDir, name)); err != nil {
+			t.Fatalf("stat generated report %q: %v", name, err)
+		}
+	}
+}
+
+func TestRunPipelineKeepsBaselineWhenAllCandidatesAreRejected(t *testing.T) {
+	sourceConfigPath, err := filepath.Abs("data/promptiter.json")
+	if err != nil {
+		t.Fatalf("resolve config path: %v", err)
+	}
+	config, err := loadConfig(sourceConfigPath)
+	if err != nil {
+		t.Fatalf("loadConfig returned error: %v", err)
+	}
+	config.MaxRounds = 1
+	config.Candidates = []candidateConfig{{
+		ID:             "rejected-overfit",
+		Append:         directiveKnowledgeAll,
+		Reason:         "Intentionally over-broad candidate.",
+		TargetFailures: []failureCategory{failureRoute},
+	}}
+	configData, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "promptiter.json")
+	if err := os.WriteFile(configPath, configData, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	report, err := runPipeline(context.Background(), pipelineOptions{
+		ConfigPath: configPath,
+		OutputDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("runPipeline returned error: %v", err)
+	}
+	if report.GateDecision.Accepted {
+		t.Fatal("all-rejected pipeline returned an accepted decision")
+	}
+	if report.Candidate.CandidateID != "baseline" {
+		t.Fatalf("selected candidate = %q, want baseline", report.Candidate.CandidateID)
+	}
+	if report.Candidate.Prompt != report.Baseline.Prompt {
+		t.Fatal("all-rejected pipeline did not preserve the baseline prompt")
+	}
+	if report.Delta.ScoreDelta != 0 {
+		t.Fatalf("all-rejected score delta = %.4f, want 0", report.Delta.ScoreDelta)
+	}
+}
+
+func assertFailedMetricsHaveReasons(t *testing.T, summary evaluationSummary) {
+	t.Helper()
+	for _, evalCase := range summary.Cases {
+		for _, metric := range evalCase.Metrics {
+			if !metric.Passed && metric.Reason == "" {
+				t.Fatalf(
+					"failed metric %q for case %q has no reason",
+					metric.Name,
+					evalCase.CaseID,
+				)
+			}
+		}
+	}
+}

--- a/examples/evaluation/promptiter/regression/report.go
+++ b/examples/evaluation/promptiter/regression/report.go
@@ -1,0 +1,196 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	reportJSONFile = "optimization_report.json"
+	reportMDFile   = "optimization_report.md"
+)
+
+func writeReports(outputDir string, report optimizationReport) error {
+	if outputDir == "" {
+		return fmt.Errorf("output directory is empty")
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	jsonData, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON report: %w", err)
+	}
+	jsonData = append(jsonData, '\n')
+	if err := os.WriteFile(filepath.Join(outputDir, reportJSONFile), jsonData, 0o644); err != nil {
+		return fmt.Errorf("write JSON report: %w", err)
+	}
+	markdown, err := renderMarkdown(report)
+	if err != nil {
+		return fmt.Errorf("render Markdown report: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, reportMDFile), []byte(markdown), 0o644); err != nil {
+		return fmt.Errorf("write Markdown report: %w", err)
+	}
+	return nil
+}
+
+func renderMarkdown(report optimizationReport) (string, error) {
+	if report.SchemaVersion == "" {
+		return "", fmt.Errorf("report schema version is empty")
+	}
+	var builder strings.Builder
+	decision := "REJECT"
+	if report.GateDecision.Accepted {
+		decision = "ACCEPT"
+	}
+	fmt.Fprintln(&builder, "# Prompt Optimization Report")
+	fmt.Fprintln(&builder)
+	fmt.Fprintf(&builder, "- Run: `%s`\n", markdownCell(report.RunID))
+	fmt.Fprintf(&builder, "- Decision: **%s**\n", decision)
+	fmt.Fprintf(&builder, "- Candidate: `%s` (round %d)\n",
+		markdownCell(report.Candidate.CandidateID), report.Candidate.Round)
+	fmt.Fprintf(&builder, "- Engine: `%s`; model: `%s`; seed: `%d`\n",
+		markdownCell(report.Runtime.Engine),
+		markdownCell(report.Runtime.Model.Name),
+		report.Runtime.Seed,
+	)
+	fmt.Fprintf(&builder, "- Train score: `%.4f` -> `%.4f`\n",
+		report.Baseline.Train.Score,
+		report.Candidate.Train.Score,
+	)
+	fmt.Fprintf(&builder, "- Validation score: `%.4f` -> `%.4f` (`%+.4f`)\n",
+		report.Baseline.Validation.Score,
+		report.Candidate.Validation.Score,
+		report.Delta.ScoreDelta,
+	)
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "## Gate Decision")
+	fmt.Fprintln(&builder)
+	for _, reason := range report.GateDecision.Reasons {
+		fmt.Fprintf(&builder, "- %s\n", reason)
+	}
+	fmt.Fprintln(&builder)
+	fmt.Fprintln(&builder, "| Check | Passed | Detail |")
+	fmt.Fprintln(&builder, "| --- | --- | --- |")
+	for _, check := range report.GateDecision.Checks {
+		fmt.Fprintf(&builder, "| %s | %t | %s |\n",
+			markdownCell(check.Name), check.Passed, markdownCell(check.Detail))
+	}
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "## Validation Delta")
+	fmt.Fprintln(&builder)
+	fmt.Fprintln(&builder, "| Case | Baseline | Candidate | Delta | Classification |")
+	fmt.Fprintln(&builder, "| --- | ---: | ---: | ---: | --- |")
+	for _, item := range report.Delta.Cases {
+		fmt.Fprintf(&builder, "| %s | %.4f | %.4f | %+.4f | %s |\n",
+			markdownCell(item.CaseID),
+			item.BaselineScore,
+			item.CandidateScore,
+			item.ScoreDelta,
+			item.Class,
+		)
+	}
+	fmt.Fprintln(&builder)
+	fmt.Fprintf(&builder,
+		"Newly passed: **%d**. Newly failed: **%d**. Improved: **%d**. Regressed: **%d**.\n",
+		report.Delta.NewlyPassed,
+		report.Delta.NewlyFailed,
+		report.Delta.Improved,
+		report.Delta.Regressed,
+	)
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "## Optimization Rounds")
+	fmt.Fprintln(&builder)
+	fmt.Fprintln(&builder, "| Round | Candidate | Train | Validation | Delta | Decision | Reasons |")
+	fmt.Fprintln(&builder, "| ---: | --- | ---: | ---: | ---: | --- | --- |")
+	for _, round := range report.Rounds {
+		roundDecision := "rejected"
+		if round.Decision.Accepted {
+			roundDecision = "accepted"
+		}
+		fmt.Fprintf(&builder, "| %d | %s | %.4f | %.4f | %+.4f | %s | %s |\n",
+			round.Round,
+			markdownCell(round.CandidateID),
+			round.Train.Score,
+			round.Validation.Score,
+			round.Delta.ScoreDelta,
+			roundDecision,
+			markdownCell(strings.Join(round.Decision.Reasons, "; ")),
+		)
+	}
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "## Failure Attribution")
+	fmt.Fprintln(&builder)
+	writeAttributionTable(&builder, report.FailureAttribution)
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "## Cost and Latency")
+	fmt.Fprintln(&builder)
+	fmt.Fprintf(&builder,
+		"Total: %d model calls, %d tool calls, %d tokens, estimated cost `$%.6f`, latency `%d ms`.\n",
+		report.CostLatency.Total.ModelCalls,
+		report.CostLatency.Total.ToolCalls,
+		report.CostLatency.Total.TotalTokens,
+		report.CostLatency.Total.EstimatedCostUSD,
+		report.CostLatency.TotalLatencyMillis,
+	)
+	fmt.Fprintln(&builder)
+
+	fmt.Fprintln(&builder, "## Recommended Prompt")
+	fmt.Fprintln(&builder)
+	fmt.Fprintln(&builder, "```text")
+	recommendedPrompt := report.Baseline.Prompt
+	if report.GateDecision.Accepted {
+		recommendedPrompt = report.Candidate.Prompt
+	}
+	fmt.Fprintln(&builder, recommendedPrompt)
+	fmt.Fprintln(&builder, "```")
+	return builder.String(), nil
+}
+
+func writeAttributionTable(builder *strings.Builder, summary attributionSummary) {
+	categories := make(map[failureCategory]struct{})
+	for category := range summary.Baseline {
+		categories[category] = struct{}{}
+	}
+	for category := range summary.Candidate {
+		categories[category] = struct{}{}
+	}
+	ordered := make([]string, 0, len(categories))
+	for category := range categories {
+		ordered = append(ordered, string(category))
+	}
+	sort.Strings(ordered)
+	fmt.Fprintln(builder, "| Category | Baseline | Candidate |")
+	fmt.Fprintln(builder, "| --- | ---: | ---: |")
+	for _, category := range ordered {
+		key := failureCategory(category)
+		fmt.Fprintf(builder, "| %s | %d | %d |\n",
+			markdownCell(category),
+			summary.Baseline[key],
+			summary.Candidate[key],
+		)
+	}
+}
+
+func markdownCell(value string) string {
+	value = strings.ReplaceAll(value, "|", "\\|")
+	return strings.ReplaceAll(value, "\n", " ")
+}

--- a/examples/evaluation/promptiter/regression/report_test.go
+++ b/examples/evaluation/promptiter/regression/report_test.go
@@ -1,0 +1,106 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRenderReport(t *testing.T) {
+	report := optimizationReport{
+		SchemaVersion: "1.0",
+		RunID:         "seed-42",
+		Baseline: promptEvaluation{
+			Prompt:     "baseline",
+			Validation: evaluationSummary{Score: 0.50},
+		},
+		Candidate: promptEvaluation{
+			CandidateID: "balanced",
+			Prompt:      "candidate",
+			Validation:  evaluationSummary{Score: 0.90},
+		},
+		Delta: evaluationDelta{
+			ScoreDelta:  0.40,
+			NewlyPassed: 1,
+			Cases: []caseDelta{{
+				CaseID:         "case-1",
+				BaselineScore:  0,
+				CandidateScore: 1,
+				ScoreDelta:     1,
+				Class:          caseNewlyPassed,
+			}},
+		},
+		GateDecision: gateDecision{
+			Accepted: true,
+			Reasons:  []string{"all acceptance checks passed"},
+		},
+		FailureAttribution: attributionSummary{
+			Baseline: map[failureCategory]int{failureRoute: 1},
+		},
+		Rounds: []roundAudit{{
+			Round:       1,
+			CandidateID: "balanced",
+			Decision:    gateDecision{Accepted: true},
+		}},
+	}
+
+	jsonData, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	for _, field := range []string{`"baseline"`, `"candidate"`, `"delta"`, `"gateDecision"`, `"failureAttribution"`, `"costLatency"`} {
+		if !strings.Contains(string(jsonData), field) {
+			t.Fatalf("JSON report does not contain %s", field)
+		}
+	}
+
+	markdown, err := renderMarkdown(report)
+	if err != nil {
+		t.Fatalf("renderMarkdown returned error: %v", err)
+	}
+	for _, text := range []string{
+		"# Prompt Optimization Report",
+		"ACCEPT",
+		"0.5000",
+		"0.9000",
+		"case-1",
+		"newly_passed",
+		"all acceptance checks passed",
+	} {
+		if !strings.Contains(markdown, text) {
+			t.Fatalf("Markdown report does not contain %q:\n%s", text, markdown)
+		}
+	}
+}
+
+func TestRenderReportRecommendsBaselineWhenRejected(t *testing.T) {
+	report := optimizationReport{
+		SchemaVersion: "1.0",
+		Baseline: promptEvaluation{
+			Prompt: "safe baseline",
+		},
+		Candidate: promptEvaluation{
+			Prompt: "rejected candidate",
+		},
+		GateDecision: gateDecision{Accepted: false},
+	}
+	markdown, err := renderMarkdown(report)
+	if err != nil {
+		t.Fatalf("renderMarkdown returned error: %v", err)
+	}
+	recommended := markdown[strings.LastIndex(markdown, "## Recommended Prompt"):]
+	if !strings.Contains(recommended, "safe baseline") {
+		t.Fatalf("recommended prompt does not contain baseline:\n%s", recommended)
+	}
+	if strings.Contains(recommended, "rejected candidate") {
+		t.Fatalf("recommended prompt contains rejected candidate:\n%s", recommended)
+	}
+}

--- a/examples/evaluation/promptiter/regression/runner.go
+++ b/examples/evaluation/promptiter/regression/runner.go
@@ -1,0 +1,298 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	agenttrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	directiveLookup       = "[use_lookup_for_lookup_tasks]"
+	directiveJSON         = "[emit_json_for_structured_tasks]"
+	directiveKnowledgeAll = "[search_knowledge_for_all_non_lookup_tasks]"
+)
+
+type deterministicRunner struct {
+	targetSurfaceID string
+	model           fakeModelConfig
+	seed            int64
+}
+
+type fakeTask struct {
+	Intent string    `json:"intent"`
+	Query  string    `json:"query,omitempty"`
+	Answer string    `json:"answer"`
+	Output any       `json:"output,omitempty"`
+	Tool   *fakeTool `json:"tool,omitempty"`
+}
+
+type fakeTool struct {
+	Name      string `json:"name"`
+	Arguments any    `json:"arguments"`
+	Result    any    `json:"result"`
+}
+
+type fakeRunResult struct {
+	response string
+	tools    []fakeTool
+	route    string
+}
+
+func (r *deterministicRunner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	runOptions ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var task fakeTask
+	if err := json.Unmarshal([]byte(message.Content), &task); err != nil {
+		return nil, fmt.Errorf("decode deterministic task: %w", err)
+	}
+	if err := validateFakeTask(task); err != nil {
+		return nil, err
+	}
+	options := agent.NewRunOptions(runOptions...)
+	result, err := executeFakeTask(task, options.Instruction)
+	if err != nil {
+		return nil, err
+	}
+	invocationID := deterministicID(r.seed, userID, message.Content, options.Instruction)
+	events := make(chan *event.Event, len(result.tools)*2+1)
+	for index, toolCall := range result.tools {
+		toolID := fmt.Sprintf("%s-tool-%d", invocationID, index+1)
+		arguments, err := json.Marshal(toolCall.Arguments)
+		if err != nil {
+			return nil, fmt.Errorf("marshal fake tool arguments: %w", err)
+		}
+		toolResult, err := json.Marshal(toolCall.Result)
+		if err != nil {
+			return nil, fmt.Errorf("marshal fake tool result: %w", err)
+		}
+		events <- newToolCallEvent(invocationID, toolID, toolCall.Name, arguments)
+		events <- newToolResultEvent(invocationID, toolID, toolCall.Name, string(toolResult))
+	}
+	events <- r.newCompletionEvent(invocationID, sessionID, message, options.Instruction, result)
+	close(events)
+	return events, nil
+}
+
+func (r *deterministicRunner) Close() error {
+	return nil
+}
+
+func executeFakeTask(task fakeTask, prompt string) (fakeRunResult, error) {
+	hasLookupRule := strings.Contains(prompt, directiveLookup)
+	hasJSONRule := strings.Contains(prompt, directiveJSON)
+	hasOverfitRule := strings.Contains(prompt, directiveKnowledgeAll)
+	result := fakeRunResult{route: "direct"}
+
+	switch task.Intent {
+	case "lookup":
+		if !hasLookupRule {
+			result.response = "I cannot perform lookups."
+			result.route = "direct_fallback"
+			return result, nil
+		}
+		if task.Tool == nil {
+			return fakeRunResult{}, errors.New("lookup task has no tool specification")
+		}
+		result.tools = append(result.tools, *task.Tool)
+		result.response = task.Answer
+		result.route = "lookup"
+	case "structured":
+		if hasJSONRule {
+			output, err := json.Marshal(task.Output)
+			if err != nil {
+				return fakeRunResult{}, fmt.Errorf("marshal structured output: %w", err)
+			}
+			result.response = string(output)
+		} else {
+			result.response = fmt.Sprintf("value=%v", task.Output)
+		}
+	case "knowledge":
+		if !hasOverfitRule {
+			result.response = "I do not have enough context."
+			result.route = "direct_fallback"
+			return result, nil
+		}
+		if task.Tool == nil {
+			return fakeRunResult{}, errors.New("knowledge task has no tool specification")
+		}
+		result.tools = append(result.tools, *task.Tool)
+		result.response = task.Answer
+		result.route = "knowledge"
+	case "direct":
+		result.response = task.Answer
+	default:
+		return fakeRunResult{}, fmt.Errorf("unsupported deterministic task intent %q", task.Intent)
+	}
+
+	if hasOverfitRule && task.Intent != "lookup" && task.Intent != "knowledge" {
+		result.tools = append(result.tools, fakeTool{
+			Name:      "knowledge_search",
+			Arguments: map[string]any{"query": task.Query},
+			Result:    map[string]any{"answer": task.Answer},
+		})
+		result.route = "knowledge_overfit"
+	}
+	return result, nil
+}
+
+func validateFakeTask(task fakeTask) error {
+	switch {
+	case strings.TrimSpace(task.Intent) == "":
+		return errors.New("deterministic task intent is empty")
+	case strings.TrimSpace(task.Answer) == "":
+		return errors.New("deterministic task answer is empty")
+	default:
+		return nil
+	}
+}
+
+func newToolCallEvent(
+	invocationID string,
+	toolID string,
+	toolName string,
+	arguments []byte,
+) *event.Event {
+	return &event.Event{
+		InvocationID: invocationID,
+		Response: &model.Response{
+			Object: model.ObjectTypeChatCompletion,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						ID:   toolID,
+						Type: "function",
+						Function: model.FunctionDefinitionParam{
+							Name:      toolName,
+							Arguments: arguments,
+						},
+					}},
+				},
+			}},
+		},
+	}
+}
+
+func newToolResultEvent(
+	invocationID string,
+	toolID string,
+	toolName string,
+	content string,
+) *event.Event {
+	return &event.Event{
+		InvocationID: invocationID,
+		Response: &model.Response{
+			Object: model.ObjectTypeToolResponse,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:     model.RoleTool,
+					ToolID:   toolID,
+					ToolName: toolName,
+					Content:  content,
+				},
+			}},
+		},
+	}
+}
+
+func (r *deterministicRunner) newCompletionEvent(
+	invocationID string,
+	sessionID string,
+	input model.Message,
+	prompt string,
+	result fakeRunResult,
+) *event.Event {
+	promptTokens := approximateTokens(prompt) + approximateTokens(input.Content)
+	completionTokens := approximateTokens(result.response)
+	usage := &model.Usage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+	startedAt := time.Unix(r.seed, 0).UTC()
+	endedAt := startedAt.Add(time.Duration(r.model.LatencyMillis) * time.Millisecond)
+	step := agenttrace.Step{
+		StepID:            invocationID + "-step",
+		InvocationID:      invocationID,
+		AgentName:         "candidate",
+		NodeID:            result.route,
+		NodeType:          "llm",
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		AppliedSurfaceIDs: []string{r.targetSurfaceID},
+		Input:             &agenttrace.Snapshot{Text: input.Content},
+		Output:            &agenttrace.Snapshot{Text: result.response},
+		Usage:             usage,
+	}
+	return &event.Event{
+		InvocationID: invocationID,
+		ExecutionTrace: &agenttrace.Trace{
+			RootAgentName:    "candidate",
+			RootInvocationID: invocationID,
+			SessionID:        sessionID,
+			StartedAt:        startedAt,
+			EndedAt:          endedAt,
+			Status:           agenttrace.TraceStatusCompleted,
+			Input:            &agenttrace.Snapshot{Text: input.Content},
+			Output:           &agenttrace.Snapshot{Text: result.response},
+			Usage:            usage,
+			Steps:            []agenttrace.Step{step},
+		},
+		Response: &model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Model:  r.model.Name,
+			Done:   true,
+			Usage:  usage,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: result.response,
+				},
+			}},
+		},
+	}
+}
+
+func deterministicID(seed int64, values ...string) string {
+	hash := sha256.New()
+	fmt.Fprintf(hash, "%d", seed)
+	for _, value := range values {
+		hash.Write([]byte{0})
+		hash.Write([]byte(value))
+	}
+	return "fake-" + hex.EncodeToString(hash.Sum(nil))[:16]
+}
+
+func approximateTokens(value string) int {
+	runes := utf8.RuneCountInString(value)
+	if runes == 0 {
+		return 0
+	}
+	return (runes + 3) / 4
+}

--- a/examples/evaluation/promptiter/regression/sample_output/optimization_report.json
+++ b/examples/evaluation/promptiter/regression/sample_output/optimization_report.json
@@ -1,0 +1,1892 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "fake-2aeef6b62d700ac4",
+  "inputs": {
+    "trainEvalSet": "data/train.evalset.json",
+    "validationEvalSet": "data/validation.evalset.json",
+    "metrics": "data/metrics.json",
+    "promptSource": "data/baseline_prompt.txt",
+    "config": "data/promptiter.json"
+  },
+  "configuration": {
+    "targetSurfaceId": "candidate#instruction",
+    "maxRounds": 2,
+    "gate": {
+      "minValidationScoreGain": 0.05,
+      "allowNewHardFails": false,
+      "criticalCaseIds": [
+        "validation_direct_critical"
+      ],
+      "maxCriticalScoreDrop": 0,
+      "maxEstimatedCostUsd": 0.01,
+      "maxToolCalls": 2
+    }
+  },
+  "runtime": {
+    "seed": 20260724,
+    "engine": "evaluation-service+promptiter-deterministic",
+    "model": {
+      "name": "deterministic-promptiter-v1",
+      "promptCostPerMillionTokens": 0.2,
+      "outputCostPerMillionTokens": 0.8,
+      "latencyMillis": 4
+    },
+    "startedAt": "2026-07-24T03:12:56.522584067Z",
+    "durationMillis": 1
+  },
+  "baseline": {
+    "prompt": "Answer each request concisely using only the provided task payload.",
+    "train": {
+      "evalSetId": "regression-train",
+      "score": 0.166666667,
+      "passedCases": 0,
+      "failedCases": 3,
+      "cases": [
+        {
+          "caseId": "train_knowledge_retention",
+          "score": 0,
+          "passed": false,
+          "finalResponse": "I do not have enough context.",
+          "expectedResponse": "Document retention is 30 days.",
+          "expectedToolTrajectory": [
+            {
+              "id": "expected-train-knowledge",
+              "name": "knowledge_search",
+              "arguments": {
+                "query": "document retention"
+              },
+              "result": {
+                "answer": "Document retention is 30 days."
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "final response mismatch: text mismatch: source I do not have enough context. and target Document retention is 30 days. do not match"
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(0) != expected(1)"
+            }
+          ],
+          "failureAttributions": [
+            {
+              "category": "knowledge_recall_insufficient",
+              "evidence": "knowledge_search was missing or did not provide the expected grounded answer"
+            },
+            {
+              "category": "route_error",
+              "evidence": "expected tool \"knowledge_search\" was not called"
+            },
+            {
+              "category": "tool_call_error",
+              "evidence": "tool trajectory is missing an expected call"
+            },
+            {
+              "category": "final_response_mismatch",
+              "evidence": "actual final response does not match the expected response"
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-313ac9a2ef7b1585-step",
+                "nodeId": "direct_fallback",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 73,
+            "completionTokens": 8,
+            "totalTokens": 81,
+            "estimatedCostUsd": 0.000021
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "train_lookup_weather",
+          "score": 0,
+          "passed": false,
+          "finalResponse": "I cannot perform lookups.",
+          "expectedResponse": "Shenzhen weather is sunny.",
+          "expectedToolTrajectory": [
+            {
+              "id": "expected-train-lookup",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "weather:shenzhen"
+              },
+              "result": {
+                "condition": "sunny",
+                "location": "Shenzhen"
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "final response mismatch: text mismatch: source I cannot perform lookups. and target Shenzhen weather is sunny. do not match"
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(0) != expected(1)"
+            }
+          ],
+          "failureAttributions": [
+            {
+              "category": "route_error",
+              "evidence": "expected tool \"lookup_record\" was not called"
+            },
+            {
+              "category": "tool_call_error",
+              "evidence": "tool trajectory is missing an expected call"
+            },
+            {
+              "category": "final_response_mismatch",
+              "evidence": "actual final response does not match the expected response"
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-badd8ad5fe2721a1-step",
+                "nodeId": "direct_fallback",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 70,
+            "completionTokens": 7,
+            "totalTokens": 77,
+            "estimatedCostUsd": 0.0000196
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "train_structured_order",
+          "score": 0.5,
+          "passed": false,
+          "finalResponse": "value=map[status:ok total:42]",
+          "expectedResponse": "{\"status\":\"ok\",\"total\":42}",
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "final response mismatch: text mismatch: source value=map[status:ok total:42] and target {\"status\":\"ok\",\"total\":42} do not match"
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "failureAttributions": [
+            {
+              "category": "format_error",
+              "evidence": "expected valid JSON but the final response was not valid JSON"
+            },
+            {
+              "category": "final_response_mismatch",
+              "evidence": "actual final response does not match the expected response"
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-0a775e53e0088b55-step",
+                "nodeId": "direct",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 49,
+            "completionTokens": 8,
+            "totalTokens": 57,
+            "estimatedCostUsd": 0.0000162
+          },
+          "latencyMillis": 4
+        }
+      ],
+      "cost": {
+        "modelCalls": 3,
+        "toolCalls": 0,
+        "promptTokens": 192,
+        "completionTokens": 23,
+        "totalTokens": 215,
+        "estimatedCostUsd": 0.0000568
+      },
+      "latencyMillis": 12
+    },
+    "validation": {
+      "evalSetId": "regression-validation",
+      "score": 0.5,
+      "passedCases": 1,
+      "failedCases": 2,
+      "cases": [
+        {
+          "caseId": "validation_direct_critical",
+          "score": 1,
+          "passed": true,
+          "finalResponse": "2 + 2 = 4.",
+          "expectedResponse": "2 + 2 = 4.",
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-523c80166187f1d3-step",
+                "nodeId": "direct",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 33,
+            "completionTokens": 3,
+            "totalTokens": 36,
+            "estimatedCostUsd": 0.000009
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "validation_lookup_exchange_rate",
+          "score": 0,
+          "passed": false,
+          "finalResponse": "I cannot perform lookups.",
+          "expectedResponse": "The USD/CNY rate is 7.20.",
+          "expectedToolTrajectory": [
+            {
+              "id": "expected-validation-lookup",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "rate:USD:CNY"
+              },
+              "result": {
+                "pair": "USD/CNY",
+                "rate": 7.2
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "final response mismatch: text mismatch: source I cannot perform lookups. and target The USD/CNY rate is 7.20. do not match"
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(0) != expected(1)"
+            }
+          ],
+          "failureAttributions": [
+            {
+              "category": "route_error",
+              "evidence": "expected tool \"lookup_record\" was not called"
+            },
+            {
+              "category": "tool_call_error",
+              "evidence": "tool trajectory is missing an expected call"
+            },
+            {
+              "category": "final_response_mismatch",
+              "evidence": "actual final response does not match the expected response"
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-724cba9cb600ba05-step",
+                "nodeId": "direct_fallback",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 64,
+            "completionTokens": 7,
+            "totalTokens": 71,
+            "estimatedCostUsd": 0.0000184
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "validation_structured_profile",
+          "score": 0.5,
+          "passed": false,
+          "finalResponse": "value=map[active:true tier:gold]",
+          "expectedResponse": "{\"active\":true,\"tier\":\"gold\"}",
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "final response mismatch: text mismatch: source value=map[active:true tier:gold] and target {\"active\":true,\"tier\":\"gold\"} do not match"
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "failureAttributions": [
+            {
+              "category": "format_error",
+              "evidence": "expected valid JSON but the final response was not valid JSON"
+            },
+            {
+              "category": "final_response_mismatch",
+              "evidence": "actual final response does not match the expected response"
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-92e88c3ff4f82fd4-step",
+                "nodeId": "direct",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 51,
+            "completionTokens": 8,
+            "totalTokens": 59,
+            "estimatedCostUsd": 0.0000166
+          },
+          "latencyMillis": 4
+        }
+      ],
+      "cost": {
+        "modelCalls": 3,
+        "toolCalls": 0,
+        "promptTokens": 148,
+        "completionTokens": 18,
+        "totalTokens": 166,
+        "estimatedCostUsd": 0.000044
+      },
+      "latencyMillis": 12
+    }
+  },
+  "candidate": {
+    "round": 1,
+    "candidateId": "balanced-routing-and-format",
+    "prompt": "Answer each request concisely using only the provided task payload.\n\nUse lookup tools only for lookup tasks. Emit strict JSON for structured tasks. Preserve direct answers without tools.\n[use_lookup_for_lookup_tasks]\n[emit_json_for_structured_tasks]",
+    "train": {
+      "evalSetId": "regression-train",
+      "score": 0.666666667,
+      "passedCases": 2,
+      "failedCases": 1,
+      "cases": [
+        {
+          "caseId": "train_knowledge_retention",
+          "score": 0,
+          "passed": false,
+          "finalResponse": "I do not have enough context.",
+          "expectedResponse": "Document retention is 30 days.",
+          "expectedToolTrajectory": [
+            {
+              "id": "expected-train-knowledge",
+              "name": "knowledge_search",
+              "arguments": {
+                "query": "document retention"
+              },
+              "result": {
+                "answer": "Document retention is 30 days."
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "final response mismatch: text mismatch: source I do not have enough context. and target Document retention is 30 days. do not match"
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 0,
+              "threshold": 1,
+              "passed": false,
+              "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(0) != expected(1)"
+            }
+          ],
+          "failureAttributions": [
+            {
+              "category": "knowledge_recall_insufficient",
+              "evidence": "knowledge_search was missing or did not provide the expected grounded answer"
+            },
+            {
+              "category": "route_error",
+              "evidence": "expected tool \"knowledge_search\" was not called"
+            },
+            {
+              "category": "tool_call_error",
+              "evidence": "tool trajectory is missing an expected call"
+            },
+            {
+              "category": "final_response_mismatch",
+              "evidence": "actual final response does not match the expected response"
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-6f1790be95b460c2-step",
+                "nodeId": "direct_fallback",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 119,
+            "completionTokens": 8,
+            "totalTokens": 127,
+            "estimatedCostUsd": 0.0000302
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "train_lookup_weather",
+          "score": 1,
+          "passed": true,
+          "finalResponse": "Shenzhen weather is sunny.",
+          "expectedResponse": "Shenzhen weather is sunny.",
+          "toolTrajectory": [
+            {
+              "id": "fake-243b349c538f82ef-tool-1",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "weather:shenzhen"
+              },
+              "result": {
+                "condition": "sunny",
+                "location": "Shenzhen"
+              }
+            }
+          ],
+          "expectedToolTrajectory": [
+            {
+              "id": "expected-train-lookup",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "weather:shenzhen"
+              },
+              "result": {
+                "condition": "sunny",
+                "location": "Shenzhen"
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-243b349c538f82ef-step",
+                "nodeId": "lookup",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 1,
+            "promptTokens": 116,
+            "completionTokens": 7,
+            "totalTokens": 123,
+            "estimatedCostUsd": 0.0000288
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "train_structured_order",
+          "score": 1,
+          "passed": true,
+          "finalResponse": "{\"status\":\"ok\",\"total\":42}",
+          "expectedResponse": "{\"status\":\"ok\",\"total\":42}",
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-5da42605c23694d1-step",
+                "nodeId": "direct",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 95,
+            "completionTokens": 7,
+            "totalTokens": 102,
+            "estimatedCostUsd": 0.0000246
+          },
+          "latencyMillis": 4
+        }
+      ],
+      "cost": {
+        "modelCalls": 3,
+        "toolCalls": 1,
+        "promptTokens": 330,
+        "completionTokens": 22,
+        "totalTokens": 352,
+        "estimatedCostUsd": 0.0000836
+      },
+      "latencyMillis": 12
+    },
+    "validation": {
+      "evalSetId": "regression-validation",
+      "score": 1,
+      "passedCases": 3,
+      "failedCases": 0,
+      "cases": [
+        {
+          "caseId": "validation_direct_critical",
+          "score": 1,
+          "passed": true,
+          "finalResponse": "2 + 2 = 4.",
+          "expectedResponse": "2 + 2 = 4.",
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-35a51e7369c4ca30-step",
+                "nodeId": "direct",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 79,
+            "completionTokens": 3,
+            "totalTokens": 82,
+            "estimatedCostUsd": 0.0000182
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "validation_lookup_exchange_rate",
+          "score": 1,
+          "passed": true,
+          "finalResponse": "The USD/CNY rate is 7.20.",
+          "expectedResponse": "The USD/CNY rate is 7.20.",
+          "toolTrajectory": [
+            {
+              "id": "fake-12aa3333f2c96f78-tool-1",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "rate:USD:CNY"
+              },
+              "result": {
+                "pair": "USD/CNY",
+                "rate": 7.2
+              }
+            }
+          ],
+          "expectedToolTrajectory": [
+            {
+              "id": "expected-validation-lookup",
+              "name": "lookup_record",
+              "arguments": {
+                "query": "rate:USD:CNY"
+              },
+              "result": {
+                "pair": "USD/CNY",
+                "rate": 7.2
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-12aa3333f2c96f78-step",
+                "nodeId": "lookup",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 1,
+            "promptTokens": 110,
+            "completionTokens": 7,
+            "totalTokens": 117,
+            "estimatedCostUsd": 0.0000276
+          },
+          "latencyMillis": 4
+        },
+        {
+          "caseId": "validation_structured_profile",
+          "score": 1,
+          "passed": true,
+          "finalResponse": "{\"active\":true,\"tier\":\"gold\"}",
+          "expectedResponse": "{\"active\":true,\"tier\":\"gold\"}",
+          "metrics": [
+            {
+              "name": "final_response_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            },
+            {
+              "name": "tool_trajectory_avg_score",
+              "score": 1,
+              "threshold": 1,
+              "passed": true
+            }
+          ],
+          "trace": {
+            "status": "completed",
+            "steps": [
+              {
+                "stepId": "fake-df98521b8f02afdb-step",
+                "nodeId": "direct",
+                "nodeType": "llm",
+                "appliedSurfaceIds": [
+                  "candidate#instruction"
+                ]
+              }
+            ]
+          },
+          "cost": {
+            "modelCalls": 1,
+            "toolCalls": 0,
+            "promptTokens": 97,
+            "completionTokens": 8,
+            "totalTokens": 105,
+            "estimatedCostUsd": 0.0000258
+          },
+          "latencyMillis": 4
+        }
+      ],
+      "cost": {
+        "modelCalls": 3,
+        "toolCalls": 1,
+        "promptTokens": 286,
+        "completionTokens": 18,
+        "totalTokens": 304,
+        "estimatedCostUsd": 0.0000716
+      },
+      "latencyMillis": 12
+    }
+  },
+  "delta": {
+    "scoreDelta": 0.5,
+    "newlyPassed": 2,
+    "newlyFailed": 0,
+    "improved": 0,
+    "regressed": 0,
+    "unchanged": 1,
+    "cases": [
+      {
+        "caseId": "validation_direct_critical",
+        "baselineScore": 1,
+        "candidateScore": 1,
+        "scoreDelta": 0,
+        "baselinePassed": true,
+        "candidatePassed": true,
+        "class": "unchanged"
+      },
+      {
+        "caseId": "validation_lookup_exchange_rate",
+        "baselineScore": 0,
+        "candidateScore": 1,
+        "scoreDelta": 1,
+        "baselinePassed": false,
+        "candidatePassed": true,
+        "class": "newly_passed"
+      },
+      {
+        "caseId": "validation_structured_profile",
+        "baselineScore": 0.5,
+        "candidateScore": 1,
+        "scoreDelta": 0.5,
+        "baselinePassed": false,
+        "candidatePassed": true,
+        "class": "newly_passed"
+      }
+    ]
+  },
+  "gateDecision": {
+    "accepted": true,
+    "reasons": [
+      "all acceptance checks passed"
+    ],
+    "checks": [
+      {
+        "name": "minimum_validation_gain",
+        "passed": true,
+        "detail": "validation score gain 0.5000 must be at least 0.0500"
+      },
+      {
+        "name": "no_new_hard_fails",
+        "passed": true,
+        "detail": "candidate introduced 0 new hard fail(s); allowNewHardFails=false"
+      },
+      {
+        "name": "critical_cases",
+        "passed": true,
+        "detail": "1 critical case(s) stayed within the 0.0000 score-drop limit"
+      },
+      {
+        "name": "cost_budget",
+        "passed": true,
+        "detail": "candidate cost budget: estimated $0.000072, limit $0.010000"
+      },
+      {
+        "name": "tool_call_budget",
+        "passed": true,
+        "detail": "candidate tool-call budget: used 1, limit 2"
+      }
+    ]
+  },
+  "failureAttribution": {
+    "baseline": {
+      "format_error": 2,
+      "knowledge_recall_insufficient": 1,
+      "route_error": 2
+    },
+    "candidate": {
+      "knowledge_recall_insufficient": 1
+    }
+  },
+  "costLatency": {
+    "baseline": {
+      "modelCalls": 6,
+      "toolCalls": 0,
+      "promptTokens": 340,
+      "completionTokens": 41,
+      "totalTokens": 381,
+      "estimatedCostUsd": 0.0001008
+    },
+    "candidates": {
+      "modelCalls": 12,
+      "toolCalls": 8,
+      "promptTokens": 1370,
+      "completionTokens": 80,
+      "totalTokens": 1450,
+      "estimatedCostUsd": 0.000338
+    },
+    "total": {
+      "modelCalls": 18,
+      "toolCalls": 8,
+      "promptTokens": 1710,
+      "completionTokens": 121,
+      "totalTokens": 1831,
+      "estimatedCostUsd": 0.0004388
+    },
+    "totalLatencyMillis": 72
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "candidateId": "balanced-routing-and-format",
+      "prompt": "Answer each request concisely using only the provided task payload.\n\nUse lookup tools only for lookup tasks. Emit strict JSON for structured tasks. Preserve direct answers without tools.\n[use_lookup_for_lookup_tasks]\n[emit_json_for_structured_tasks]",
+      "patchReason": "Training failures show missing lookup calls and invalid structured output.",
+      "train": {
+        "evalSetId": "regression-train",
+        "score": 0.666666667,
+        "passedCases": 2,
+        "failedCases": 1,
+        "cases": [
+          {
+            "caseId": "train_knowledge_retention",
+            "score": 0,
+            "passed": false,
+            "finalResponse": "I do not have enough context.",
+            "expectedResponse": "Document retention is 30 days.",
+            "expectedToolTrajectory": [
+              {
+                "id": "expected-train-knowledge",
+                "name": "knowledge_search",
+                "arguments": {
+                  "query": "document retention"
+                },
+                "result": {
+                  "answer": "Document retention is 30 days."
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "reason": "final response mismatch: text mismatch: source I do not have enough context. and target Document retention is 30 days. do not match"
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(0) != expected(1)"
+              }
+            ],
+            "failureAttributions": [
+              {
+                "category": "knowledge_recall_insufficient",
+                "evidence": "knowledge_search was missing or did not provide the expected grounded answer"
+              },
+              {
+                "category": "route_error",
+                "evidence": "expected tool \"knowledge_search\" was not called"
+              },
+              {
+                "category": "tool_call_error",
+                "evidence": "tool trajectory is missing an expected call"
+              },
+              {
+                "category": "final_response_mismatch",
+                "evidence": "actual final response does not match the expected response"
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-6f1790be95b460c2-step",
+                  "nodeId": "direct_fallback",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 0,
+              "promptTokens": 119,
+              "completionTokens": 8,
+              "totalTokens": 127,
+              "estimatedCostUsd": 0.0000302
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "train_lookup_weather",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "Shenzhen weather is sunny.",
+            "expectedResponse": "Shenzhen weather is sunny.",
+            "toolTrajectory": [
+              {
+                "id": "fake-243b349c538f82ef-tool-1",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "weather:shenzhen"
+                },
+                "result": {
+                  "condition": "sunny",
+                  "location": "Shenzhen"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "id": "expected-train-lookup",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "weather:shenzhen"
+                },
+                "result": {
+                  "condition": "sunny",
+                  "location": "Shenzhen"
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-243b349c538f82ef-step",
+                  "nodeId": "lookup",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 116,
+              "completionTokens": 7,
+              "totalTokens": 123,
+              "estimatedCostUsd": 0.0000288
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "train_structured_order",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "{\"status\":\"ok\",\"total\":42}",
+            "expectedResponse": "{\"status\":\"ok\",\"total\":42}",
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-5da42605c23694d1-step",
+                  "nodeId": "direct",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 0,
+              "promptTokens": 95,
+              "completionTokens": 7,
+              "totalTokens": 102,
+              "estimatedCostUsd": 0.0000246
+            },
+            "latencyMillis": 4
+          }
+        ],
+        "cost": {
+          "modelCalls": 3,
+          "toolCalls": 1,
+          "promptTokens": 330,
+          "completionTokens": 22,
+          "totalTokens": 352,
+          "estimatedCostUsd": 0.0000836
+        },
+        "latencyMillis": 12
+      },
+      "validation": {
+        "evalSetId": "regression-validation",
+        "score": 1,
+        "passedCases": 3,
+        "failedCases": 0,
+        "cases": [
+          {
+            "caseId": "validation_direct_critical",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "2 + 2 = 4.",
+            "expectedResponse": "2 + 2 = 4.",
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-35a51e7369c4ca30-step",
+                  "nodeId": "direct",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 0,
+              "promptTokens": 79,
+              "completionTokens": 3,
+              "totalTokens": 82,
+              "estimatedCostUsd": 0.0000182
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "validation_lookup_exchange_rate",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "The USD/CNY rate is 7.20.",
+            "expectedResponse": "The USD/CNY rate is 7.20.",
+            "toolTrajectory": [
+              {
+                "id": "fake-12aa3333f2c96f78-tool-1",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "rate:USD:CNY"
+                },
+                "result": {
+                  "pair": "USD/CNY",
+                  "rate": 7.2
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "id": "expected-validation-lookup",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "rate:USD:CNY"
+                },
+                "result": {
+                  "pair": "USD/CNY",
+                  "rate": 7.2
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-12aa3333f2c96f78-step",
+                  "nodeId": "lookup",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 110,
+              "completionTokens": 7,
+              "totalTokens": 117,
+              "estimatedCostUsd": 0.0000276
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "validation_structured_profile",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "{\"active\":true,\"tier\":\"gold\"}",
+            "expectedResponse": "{\"active\":true,\"tier\":\"gold\"}",
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-df98521b8f02afdb-step",
+                  "nodeId": "direct",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 0,
+              "promptTokens": 97,
+              "completionTokens": 8,
+              "totalTokens": 105,
+              "estimatedCostUsd": 0.0000258
+            },
+            "latencyMillis": 4
+          }
+        ],
+        "cost": {
+          "modelCalls": 3,
+          "toolCalls": 1,
+          "promptTokens": 286,
+          "completionTokens": 18,
+          "totalTokens": 304,
+          "estimatedCostUsd": 0.0000716
+        },
+        "latencyMillis": 12
+      },
+      "delta": {
+        "scoreDelta": 0.5,
+        "newlyPassed": 2,
+        "newlyFailed": 0,
+        "improved": 0,
+        "regressed": 0,
+        "unchanged": 1,
+        "cases": [
+          {
+            "caseId": "validation_direct_critical",
+            "baselineScore": 1,
+            "candidateScore": 1,
+            "scoreDelta": 0,
+            "baselinePassed": true,
+            "candidatePassed": true,
+            "class": "unchanged"
+          },
+          {
+            "caseId": "validation_lookup_exchange_rate",
+            "baselineScore": 0,
+            "candidateScore": 1,
+            "scoreDelta": 1,
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "class": "newly_passed"
+          },
+          {
+            "caseId": "validation_structured_profile",
+            "baselineScore": 0.5,
+            "candidateScore": 1,
+            "scoreDelta": 0.5,
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "class": "newly_passed"
+          }
+        ]
+      },
+      "decision": {
+        "accepted": true,
+        "reasons": [
+          "all acceptance checks passed"
+        ],
+        "checks": [
+          {
+            "name": "minimum_validation_gain",
+            "passed": true,
+            "detail": "validation score gain 0.5000 must be at least 0.0500"
+          },
+          {
+            "name": "no_new_hard_fails",
+            "passed": true,
+            "detail": "candidate introduced 0 new hard fail(s); allowNewHardFails=false"
+          },
+          {
+            "name": "critical_cases",
+            "passed": true,
+            "detail": "1 critical case(s) stayed within the 0.0000 score-drop limit"
+          },
+          {
+            "name": "cost_budget",
+            "passed": true,
+            "detail": "candidate cost budget: estimated $0.000072, limit $0.010000"
+          },
+          {
+            "name": "tool_call_budget",
+            "passed": true,
+            "detail": "candidate tool-call budget: used 1, limit 2"
+          }
+        ]
+      },
+      "durationMillis": 0
+    },
+    {
+      "round": 2,
+      "candidateId": "knowledge-overfit",
+      "prompt": "Answer each request concisely using only the provided task payload.\n\nUse lookup tools only for lookup tasks. Emit strict JSON for structured tasks. Preserve direct answers without tools.\n[use_lookup_for_lookup_tasks]\n[emit_json_for_structured_tasks]\n\nSearch knowledge before every non-lookup task.\n[search_knowledge_for_all_non_lookup_tasks]",
+      "patchReason": "The remaining training failure lacks retrieved knowledge, but this broad rule may overfit.",
+      "train": {
+        "evalSetId": "regression-train",
+        "score": 0.833333333,
+        "passedCases": 2,
+        "failedCases": 1,
+        "cases": [
+          {
+            "caseId": "train_knowledge_retention",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "Document retention is 30 days.",
+            "expectedResponse": "Document retention is 30 days.",
+            "toolTrajectory": [
+              {
+                "id": "fake-d6b69a8732817edf-tool-1",
+                "name": "knowledge_search",
+                "arguments": {
+                  "query": "document retention"
+                },
+                "result": {
+                  "answer": "Document retention is 30 days."
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "id": "expected-train-knowledge",
+                "name": "knowledge_search",
+                "arguments": {
+                  "query": "document retention"
+                },
+                "result": {
+                  "answer": "Document retention is 30 days."
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-d6b69a8732817edf-step",
+                  "nodeId": "knowledge",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 142,
+              "completionTokens": 8,
+              "totalTokens": 150,
+              "estimatedCostUsd": 0.0000348
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "train_lookup_weather",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "Shenzhen weather is sunny.",
+            "expectedResponse": "Shenzhen weather is sunny.",
+            "toolTrajectory": [
+              {
+                "id": "fake-20d96b170ff41c39-tool-1",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "weather:shenzhen"
+                },
+                "result": {
+                  "condition": "sunny",
+                  "location": "Shenzhen"
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "id": "expected-train-lookup",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "weather:shenzhen"
+                },
+                "result": {
+                  "condition": "sunny",
+                  "location": "Shenzhen"
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-20d96b170ff41c39-step",
+                  "nodeId": "lookup",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 139,
+              "completionTokens": 7,
+              "totalTokens": 146,
+              "estimatedCostUsd": 0.0000334
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "train_structured_order",
+            "score": 0.5,
+            "passed": false,
+            "finalResponse": "{\"status\":\"ok\",\"total\":42}",
+            "expectedResponse": "{\"status\":\"ok\",\"total\":42}",
+            "toolTrajectory": [
+              {
+                "id": "fake-f14c1774f1629223-tool-1",
+                "name": "knowledge_search",
+                "arguments": {
+                  "query": "order summary"
+                },
+                "result": {
+                  "answer": "{\"status\":\"ok\",\"total\":42}"
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(1) != expected(0)"
+              }
+            ],
+            "failureAttributions": [
+              {
+                "category": "route_error",
+                "evidence": "unexpected tool \"knowledge_search\" was called"
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-f14c1774f1629223-step",
+                  "nodeId": "knowledge_overfit",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 118,
+              "completionTokens": 7,
+              "totalTokens": 125,
+              "estimatedCostUsd": 0.0000292
+            },
+            "latencyMillis": 4
+          }
+        ],
+        "cost": {
+          "modelCalls": 3,
+          "toolCalls": 3,
+          "promptTokens": 399,
+          "completionTokens": 22,
+          "totalTokens": 421,
+          "estimatedCostUsd": 0.0000974
+        },
+        "latencyMillis": 12
+      },
+      "validation": {
+        "evalSetId": "regression-validation",
+        "score": 0.666666667,
+        "passedCases": 1,
+        "failedCases": 2,
+        "cases": [
+          {
+            "caseId": "validation_direct_critical",
+            "score": 0.5,
+            "passed": false,
+            "finalResponse": "2 + 2 = 4.",
+            "expectedResponse": "2 + 2 = 4.",
+            "toolTrajectory": [
+              {
+                "id": "fake-1431391683582bef-tool-1",
+                "name": "knowledge_search",
+                "arguments": {
+                  "query": "two plus two"
+                },
+                "result": {
+                  "answer": "2 + 2 = 4."
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(1) != expected(0)"
+              }
+            ],
+            "failureAttributions": [
+              {
+                "category": "route_error",
+                "evidence": "unexpected tool \"knowledge_search\" was called"
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-1431391683582bef-step",
+                  "nodeId": "knowledge_overfit",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 102,
+              "completionTokens": 3,
+              "totalTokens": 105,
+              "estimatedCostUsd": 0.0000228
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "validation_lookup_exchange_rate",
+            "score": 1,
+            "passed": true,
+            "finalResponse": "The USD/CNY rate is 7.20.",
+            "expectedResponse": "The USD/CNY rate is 7.20.",
+            "toolTrajectory": [
+              {
+                "id": "fake-d9b7abbf80b5e447-tool-1",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "rate:USD:CNY"
+                },
+                "result": {
+                  "pair": "USD/CNY",
+                  "rate": 7.2
+                }
+              }
+            ],
+            "expectedToolTrajectory": [
+              {
+                "id": "expected-validation-lookup",
+                "name": "lookup_record",
+                "arguments": {
+                  "query": "rate:USD:CNY"
+                },
+                "result": {
+                  "pair": "USD/CNY",
+                  "rate": 7.2
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-d9b7abbf80b5e447-step",
+                  "nodeId": "lookup",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 133,
+              "completionTokens": 7,
+              "totalTokens": 140,
+              "estimatedCostUsd": 0.0000322
+            },
+            "latencyMillis": 4
+          },
+          {
+            "caseId": "validation_structured_profile",
+            "score": 0.5,
+            "passed": false,
+            "finalResponse": "{\"active\":true,\"tier\":\"gold\"}",
+            "expectedResponse": "{\"active\":true,\"tier\":\"gold\"}",
+            "toolTrajectory": [
+              {
+                "id": "fake-3d7cbba64d93cbf4-tool-1",
+                "name": "knowledge_search",
+                "arguments": {
+                  "query": "profile summary"
+                },
+                "result": {
+                  "answer": "{\"active\":true,\"tier\":\"gold\"}"
+                }
+              }
+            ],
+            "metrics": [
+              {
+                "name": "final_response_avg_score",
+                "score": 1,
+                "threshold": 1,
+                "passed": true
+              },
+              {
+                "name": "tool_trajectory_avg_score",
+                "score": 0,
+                "threshold": 1,
+                "passed": false,
+                "reason": "tool trajectory mismatch: validate tool counts: number of tool calls mismatch: actual(1) != expected(0)"
+              }
+            ],
+            "failureAttributions": [
+              {
+                "category": "route_error",
+                "evidence": "unexpected tool \"knowledge_search\" was called"
+              }
+            ],
+            "trace": {
+              "status": "completed",
+              "steps": [
+                {
+                  "stepId": "fake-3d7cbba64d93cbf4-step",
+                  "nodeId": "knowledge_overfit",
+                  "nodeType": "llm",
+                  "appliedSurfaceIds": [
+                    "candidate#instruction"
+                  ]
+                }
+              ]
+            },
+            "cost": {
+              "modelCalls": 1,
+              "toolCalls": 1,
+              "promptTokens": 120,
+              "completionTokens": 8,
+              "totalTokens": 128,
+              "estimatedCostUsd": 0.0000304
+            },
+            "latencyMillis": 4
+          }
+        ],
+        "cost": {
+          "modelCalls": 3,
+          "toolCalls": 3,
+          "promptTokens": 355,
+          "completionTokens": 18,
+          "totalTokens": 373,
+          "estimatedCostUsd": 0.0000854
+        },
+        "latencyMillis": 12
+      },
+      "delta": {
+        "scoreDelta": -0.333333333,
+        "newlyPassed": 0,
+        "newlyFailed": 2,
+        "improved": 0,
+        "regressed": 0,
+        "unchanged": 1,
+        "cases": [
+          {
+            "caseId": "validation_direct_critical",
+            "baselineScore": 1,
+            "candidateScore": 0.5,
+            "scoreDelta": -0.5,
+            "baselinePassed": true,
+            "candidatePassed": false,
+            "class": "newly_failed"
+          },
+          {
+            "caseId": "validation_lookup_exchange_rate",
+            "baselineScore": 1,
+            "candidateScore": 1,
+            "scoreDelta": 0,
+            "baselinePassed": true,
+            "candidatePassed": true,
+            "class": "unchanged"
+          },
+          {
+            "caseId": "validation_structured_profile",
+            "baselineScore": 1,
+            "candidateScore": 0.5,
+            "scoreDelta": -0.5,
+            "baselinePassed": true,
+            "candidatePassed": false,
+            "class": "newly_failed"
+          }
+        ]
+      },
+      "decision": {
+        "accepted": false,
+        "reasons": [
+          "validation score gain -0.3333 must be at least 0.0500",
+          "candidate introduced 2 new hard fail(s); allowNewHardFails=false",
+          "critical case \"validation_direct_critical\" score dropped by 0.5000, limit 0.0000",
+          "candidate tool-call budget: used 3, limit 2"
+        ],
+        "checks": [
+          {
+            "name": "minimum_validation_gain",
+            "passed": false,
+            "detail": "validation score gain -0.3333 must be at least 0.0500"
+          },
+          {
+            "name": "no_new_hard_fails",
+            "passed": false,
+            "detail": "candidate introduced 2 new hard fail(s); allowNewHardFails=false"
+          },
+          {
+            "name": "critical_cases",
+            "passed": false,
+            "detail": "critical case \"validation_direct_critical\" score dropped by 0.5000, limit 0.0000"
+          },
+          {
+            "name": "cost_budget",
+            "passed": true,
+            "detail": "candidate cost budget: estimated $0.000085, limit $0.010000"
+          },
+          {
+            "name": "tool_call_budget",
+            "passed": false,
+            "detail": "candidate tool-call budget: used 3, limit 2"
+          }
+        ]
+      },
+      "durationMillis": 0
+    }
+  ]
+}

--- a/examples/evaluation/promptiter/regression/sample_output/optimization_report.md
+++ b/examples/evaluation/promptiter/regression/sample_output/optimization_report.md
@@ -1,0 +1,59 @@
+# Prompt Optimization Report
+
+- Run: `fake-2aeef6b62d700ac4`
+- Decision: **ACCEPT**
+- Candidate: `balanced-routing-and-format` (round 1)
+- Engine: `evaluation-service+promptiter-deterministic`; model: `deterministic-promptiter-v1`; seed: `20260724`
+- Train score: `0.1667` -> `0.6667`
+- Validation score: `0.5000` -> `1.0000` (`+0.5000`)
+
+## Gate Decision
+
+- all acceptance checks passed
+
+| Check | Passed | Detail |
+| --- | --- | --- |
+| minimum_validation_gain | true | validation score gain 0.5000 must be at least 0.0500 |
+| no_new_hard_fails | true | candidate introduced 0 new hard fail(s); allowNewHardFails=false |
+| critical_cases | true | 1 critical case(s) stayed within the 0.0000 score-drop limit |
+| cost_budget | true | candidate cost budget: estimated $0.000072, limit $0.010000 |
+| tool_call_budget | true | candidate tool-call budget: used 1, limit 2 |
+
+## Validation Delta
+
+| Case | Baseline | Candidate | Delta | Classification |
+| --- | ---: | ---: | ---: | --- |
+| validation_direct_critical | 1.0000 | 1.0000 | +0.0000 | unchanged |
+| validation_lookup_exchange_rate | 0.0000 | 1.0000 | +1.0000 | newly_passed |
+| validation_structured_profile | 0.5000 | 1.0000 | +0.5000 | newly_passed |
+
+Newly passed: **2**. Newly failed: **0**. Improved: **0**. Regressed: **0**.
+
+## Optimization Rounds
+
+| Round | Candidate | Train | Validation | Delta | Decision | Reasons |
+| ---: | --- | ---: | ---: | ---: | --- | --- |
+| 1 | balanced-routing-and-format | 0.6667 | 1.0000 | +0.5000 | accepted | all acceptance checks passed |
+| 2 | knowledge-overfit | 0.8333 | 0.6667 | -0.3333 | rejected | validation score gain -0.3333 must be at least 0.0500; candidate introduced 2 new hard fail(s); allowNewHardFails=false; critical case "validation_direct_critical" score dropped by 0.5000, limit 0.0000; candidate tool-call budget: used 3, limit 2 |
+
+## Failure Attribution
+
+| Category | Baseline | Candidate |
+| --- | ---: | ---: |
+| format_error | 2 | 0 |
+| knowledge_recall_insufficient | 1 | 1 |
+| route_error | 2 | 0 |
+
+## Cost and Latency
+
+Total: 18 model calls, 8 tool calls, 1831 tokens, estimated cost `$0.000439`, latency `72 ms`.
+
+## Recommended Prompt
+
+```text
+Answer each request concisely using only the provided task payload.
+
+Use lookup tools only for lookup tasks. Emit strict JSON for structured tasks. Preserve direct answers without tools.
+[use_lookup_for_lookup_tasks]
+[emit_json_for_structured_tasks]
+```

--- a/examples/evaluation/promptiter/regression/types.go
+++ b/examples/evaluation/promptiter/regression/types.go
@@ -1,0 +1,224 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import "time"
+
+const (
+	metricFinalResponse  = "final_response_avg_score"
+	metricToolTrajectory = "tool_trajectory_avg_score"
+)
+
+type failureCategory string
+
+const (
+	failureFinalResponse   failureCategory = "final_response_mismatch"
+	failureToolCall        failureCategory = "tool_call_error"
+	failureToolArgument    failureCategory = "tool_argument_error"
+	failureRoute           failureCategory = "route_error"
+	failureFormat          failureCategory = "format_error"
+	failureKnowledgeRecall failureCategory = "knowledge_recall_insufficient"
+	failureUnknown         failureCategory = "unknown_failure"
+)
+
+type failureAttribution struct {
+	Category failureCategory `json:"category"`
+	Evidence string          `json:"evidence"`
+}
+
+type metricEvaluation struct {
+	Name      string  `json:"name"`
+	Score     float64 `json:"score"`
+	Threshold float64 `json:"threshold"`
+	Passed    bool    `json:"passed"`
+	Reason    string  `json:"reason,omitempty"`
+}
+
+type toolAudit struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name"`
+	Arguments any    `json:"arguments,omitempty"`
+	Result    any    `json:"result,omitempty"`
+}
+
+type traceStepAudit struct {
+	StepID            string   `json:"stepId,omitempty"`
+	NodeID            string   `json:"nodeId,omitempty"`
+	NodeType          string   `json:"nodeType,omitempty"`
+	AppliedSurfaceIDs []string `json:"appliedSurfaceIds,omitempty"`
+	Error             string   `json:"error,omitempty"`
+}
+
+type traceAudit struct {
+	Status string           `json:"status,omitempty"`
+	Steps  []traceStepAudit `json:"steps,omitempty"`
+}
+
+type costSummary struct {
+	ModelCalls       int     `json:"modelCalls"`
+	ToolCalls        int     `json:"toolCalls"`
+	PromptTokens     int     `json:"promptTokens"`
+	CompletionTokens int     `json:"completionTokens"`
+	TotalTokens      int     `json:"totalTokens"`
+	EstimatedCostUSD float64 `json:"estimatedCostUsd"`
+}
+
+type caseEvaluation struct {
+	CaseID                 string               `json:"caseId"`
+	Score                  float64              `json:"score"`
+	Passed                 bool                 `json:"passed"`
+	FinalResponse          string               `json:"finalResponse,omitempty"`
+	ExpectedResponse       string               `json:"expectedResponse,omitempty"`
+	ToolTrajectory         []toolAudit          `json:"toolTrajectory,omitempty"`
+	ExpectedToolTrajectory []toolAudit          `json:"expectedToolTrajectory,omitempty"`
+	Metrics                []metricEvaluation   `json:"metrics"`
+	FailureAttributions    []failureAttribution `json:"failureAttributions,omitempty"`
+	Trace                  traceAudit           `json:"trace"`
+	Cost                   costSummary          `json:"cost"`
+	LatencyMillis          int64                `json:"latencyMillis"`
+}
+
+type evaluationSummary struct {
+	EvalSetID     string           `json:"evalSetId"`
+	Score         float64          `json:"score"`
+	PassedCases   int              `json:"passedCases"`
+	FailedCases   int              `json:"failedCases"`
+	Cases         []caseEvaluation `json:"cases"`
+	Cost          costSummary      `json:"cost"`
+	LatencyMillis int64            `json:"latencyMillis"`
+}
+
+type caseDeltaClass string
+
+const (
+	caseNewlyPassed caseDeltaClass = "newly_passed"
+	caseNewlyFailed caseDeltaClass = "newly_failed"
+	caseImproved    caseDeltaClass = "improved"
+	caseRegressed   caseDeltaClass = "regressed"
+	caseUnchanged   caseDeltaClass = "unchanged"
+)
+
+type caseDelta struct {
+	CaseID          string         `json:"caseId"`
+	BaselineScore   float64        `json:"baselineScore"`
+	CandidateScore  float64        `json:"candidateScore"`
+	ScoreDelta      float64        `json:"scoreDelta"`
+	BaselinePassed  bool           `json:"baselinePassed"`
+	CandidatePassed bool           `json:"candidatePassed"`
+	Class           caseDeltaClass `json:"class"`
+}
+
+type evaluationDelta struct {
+	ScoreDelta  float64     `json:"scoreDelta"`
+	NewlyPassed int         `json:"newlyPassed"`
+	NewlyFailed int         `json:"newlyFailed"`
+	Improved    int         `json:"improved"`
+	Regressed   int         `json:"regressed"`
+	Unchanged   int         `json:"unchanged"`
+	Cases       []caseDelta `json:"cases"`
+}
+
+type gateConfig struct {
+	MinValidationScoreGain float64  `json:"minValidationScoreGain"`
+	AllowNewHardFails      bool     `json:"allowNewHardFails"`
+	CriticalCaseIDs        []string `json:"criticalCaseIds"`
+	MaxCriticalScoreDrop   float64  `json:"maxCriticalScoreDrop"`
+	MaxEstimatedCostUSD    float64  `json:"maxEstimatedCostUsd"`
+	MaxToolCalls           int      `json:"maxToolCalls"`
+}
+
+type gateCheck struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail"`
+}
+
+type gateDecision struct {
+	Accepted bool        `json:"accepted"`
+	Reasons  []string    `json:"reasons"`
+	Checks   []gateCheck `json:"checks"`
+}
+
+type promptEvaluation struct {
+	Round       int               `json:"round,omitempty"`
+	CandidateID string            `json:"candidateId,omitempty"`
+	Prompt      string            `json:"prompt"`
+	Train       evaluationSummary `json:"train"`
+	Validation  evaluationSummary `json:"validation"`
+}
+
+type roundAudit struct {
+	Round          int               `json:"round"`
+	CandidateID    string            `json:"candidateId"`
+	Prompt         string            `json:"prompt"`
+	PatchReason    string            `json:"patchReason"`
+	Train          evaluationSummary `json:"train"`
+	Validation     evaluationSummary `json:"validation"`
+	Delta          evaluationDelta   `json:"delta"`
+	Decision       gateDecision      `json:"decision"`
+	DurationMillis int64             `json:"durationMillis"`
+}
+
+type attributionSummary struct {
+	Baseline  map[failureCategory]int `json:"baseline"`
+	Candidate map[failureCategory]int `json:"candidate"`
+}
+
+type costLatencySummary struct {
+	Baseline           costSummary `json:"baseline"`
+	Candidates         costSummary `json:"candidates"`
+	Total              costSummary `json:"total"`
+	TotalLatencyMillis int64       `json:"totalLatencyMillis"`
+}
+
+type inputAudit struct {
+	TrainEvalSet      string `json:"trainEvalSet"`
+	ValidationEvalSet string `json:"validationEvalSet"`
+	Metrics           string `json:"metrics"`
+	PromptSource      string `json:"promptSource"`
+	Config            string `json:"config"`
+}
+
+type runtimeAudit struct {
+	Seed           int64           `json:"seed"`
+	Engine         string          `json:"engine"`
+	Model          fakeModelConfig `json:"model"`
+	StartedAt      time.Time       `json:"startedAt"`
+	DurationMillis int64           `json:"durationMillis"`
+}
+
+type configurationAudit struct {
+	TargetSurfaceID string     `json:"targetSurfaceId"`
+	MaxRounds       int        `json:"maxRounds"`
+	Gate            gateConfig `json:"gate"`
+}
+
+type optimizationReport struct {
+	SchemaVersion      string             `json:"schemaVersion"`
+	RunID              string             `json:"runId"`
+	Inputs             inputAudit         `json:"inputs"`
+	Configuration      configurationAudit `json:"configuration"`
+	Runtime            runtimeAudit       `json:"runtime"`
+	Baseline           promptEvaluation   `json:"baseline"`
+	Candidate          promptEvaluation   `json:"candidate"`
+	Delta              evaluationDelta    `json:"delta"`
+	GateDecision       gateDecision       `json:"gateDecision"`
+	FailureAttribution attributionSummary `json:"failureAttribution"`
+	CostLatency        costLatencySummary `json:"costLatency"`
+	Rounds             []roundAudit       `json:"rounds"`
+}
+
+type attributionInput struct {
+	metrics          []metricEvaluation
+	actualResponse   string
+	expectedResponse string
+	actualTools      []toolAudit
+	expectedTools    []toolAudit
+	trace            traceAudit
+}


### PR DESCRIPTION
## What changed

- Added a deterministic Evaluation Service pipeline that evaluates baseline and candidate prompts on separate train and validation sets.
- Added evidence-based failure attribution, per-case deltas, configurable acceptance gates, and JSON/Markdown audit reports.
- Added six runnable cases and an explicit overfitting round where train improves while validation regresses and is rejected.

## Why

PromptIter candidates need held-out regression checks and auditable acceptance criteria before a prompt can be written back. The deterministic runner exercises final responses, tool trajectories, and execution traces without requiring an API key.

## Testing

- `go test -race -cover ./promptiter/regression` from `examples/evaluation` (79.9% statement coverage)
- `go vet ./promptiter/regression`
- `go test ./...` from `examples/evaluation` (36 packages)
- `.github/scripts/check-examples.sh` (all 28 example modules)
- End-to-end deterministic run: validation `0.5000 -> 1.0000`; overfit round rejected after train improved while validation regressed
- Two-run deterministic report comparison using relative and absolute config paths

## Testing evidence

### 1. Targeted tests, coverage, and repository checks

Local upload file: `/home/liudebao/opensource/trpc-agent-go/docs/pr-2323-screenshots/01-targeted-tests.png`

**UPLOAD IMAGE HERE: `01-targeted-tests.png`**

### 2. Held-out validation improvement and acceptance gate

Local upload file: `/home/liudebao/opensource/trpc-agent-go/docs/pr-2323-screenshots/02-regression-loop-result.png`

**UPLOAD IMAGE HERE: `02-regression-loop-result.png`**

### 3. Overfitting rejection and audit artifacts

Local upload file: `/home/liudebao/opensource/trpc-agent-go/docs/pr-2323-screenshots/03-overfit-rejection-audit.png`

**UPLOAD IMAGE HERE: `03-overfit-rejection-audit.png`**

## Notes for reviewers

The change adds no public framework API. Deterministic candidates use PromptIter `SurfacePatch` and `Profile` as the adapter boundary; production PromptIter engine output can feed the same delta, gate, and report layer. Prompt source write-back remains opt-in and requires an accepted candidate. Rejected decisions always retain and recommend the baseline prompt.

Fixes #2003