### PR TITLE
memory/tencentdb: align context offload with v2 API

### DIFF
--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -1942,10 +1942,10 @@ memSvc, err := memorytencentdb.NewService(
     // Opt-in cross-session/user reads; enable only for a trusted/isolated gateway.
     memorytencentdb.WithRecallEnabled(true),
     memorytencentdb.WithMemorySearchTool(true),
-    // Optional short-term tool result offload; requires a gateway that supports
-    // /offload/v1/hooks/* and /offload/v1/tools/*.
+    // Optional short-term context offload through the gateway v2 API.
     // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
-    //     Enabled: true,
+    //     Enabled:   true,
+    //     ServiceID: os.Getenv("TDAI_SERVICE_ID"),
     // }),
     // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
@@ -1982,27 +1982,28 @@ defer r.Close()
 - Use `runner.WithPlugins(memSvc.Plugin())` to enable automatic `/recall`
   before model calls
 - Use `runner.WithPlugins(memSvc.ContextOffloadPlugin())` only when
-  `WithContextOffload(memorytencentdb.ContextOffloadConfig{Enabled: true})` is
-  set and you want short-term tool result offload. Companion tools
-  `tdai_read_offload_ref`,
-  `tdai_read_offload_node`, and `tdai_search_offload_index` are exposed
-  through `memSvc.Tools()` when enabled.
+  `WithContextOffload(...)` is enabled and you want short-term context
+  offload. The companion `tdai_read_offload_ref` tool is exposed through
+  `memSvc.Tools()` when enabled.
 - Do **not** use `runner.WithMemoryService(...)` with this integration
 
 ### Enable Context Offload
 
-Context offload is a separate, opt-in path for large tool results. Use it only
-with a TencentDB Agent Memory gateway build that exposes the offload routes
-listed in the notes below. The Go adapter does not provide local storage,
-summarization models, or local/backend/collect modes.
+Context offload is a separate, opt-in integration with TencentDB Agent Memory's
+v2 offload API. It sends tool results to the gateway for asynchronous
+processing, asks the gateway to compact model context when the configured
+utilization threshold is reached, and exposes one tool for bounded recovery of
+archived results.
 
 Minimal setup:
 
 ```go
 memSvc, err := memorytencentdb.NewService(
     memorytencentdb.WithGatewayURL(gatewayURL),
+    memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
     memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
-        Enabled: true,
+        Enabled:   true,
+        ServiceID: os.Getenv("TDAI_SERVICE_ID"),
     }),
 )
 if err != nil {
@@ -2024,29 +2025,38 @@ r := runner.NewRunner(
 )
 ```
 
-If offload traffic should use a different gateway or key from normal
-capture/search/recall traffic, set `GatewayURL` and `APIKey` on
-`ContextOffloadConfig`:
+The v2 API requires both `Authorization: Bearer <key>` and
+`X-TDAI-Service-Id`. For the standalone upstream gateway, use the conventional
+values `local` and `default`; for a managed service, use the credentials
+assigned to the memory instance.
+
+If offload traffic should use a different gateway or API key from normal
+capture/search/recall traffic, override them on `ContextOffloadConfig`:
 
 ```go
 memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
     Enabled:    true,
-    GatewayURL: "http://127.0.0.1:8420",
-    APIKey:     os.Getenv("TDAI_OFFLOAD_GATEWAY_API_KEY"),
+    GatewayURL: offloadGatewayURL,
+    APIKey:     os.Getenv("TDAI_OFFLOAD_API_KEY"),
+    ServiceID:  os.Getenv("TDAI_SERVICE_ID"),
 })
 ```
 
 At runtime:
 
-- `ContextOffloadPlugin()` calls the gateway after tool execution. The gateway
-  may replace large tool result messages with compact references or summaries.
-- Before the next model call, the plugin asks the gateway whether the current
-  request should be rewritten with offloaded context.
-- `memSvc.Tools()` exposes `tdai_read_offload_ref`,
-  `tdai_read_offload_node`, and `tdai_search_offload_index` when context
-  offload is enabled, so the model can drill into gateway-owned offload data.
-- Do not configure local directories, local models, or L0-L3 policies in the Go
-  adapter; those concerns belong to TencentDB Agent Memory.
+- After tool execution, `ContextOffloadPlugin()` sends real tool call/result
+  pairs to `POST /v2/offload/ingest`. This does not rewrite the current tool
+  result message.
+- Before each model call, the plugin sends a prompt-only ingest for L1.5 task
+  judgment, estimates message tokens, and calls
+  `POST /v2/offload/compact` after `CompactionRatio` is reached. Failures are
+  best effort: the original model context is retained.
+- `memSvc.Tools()` exposes only `tdai_read_offload_ref`, backed by
+  `POST /v2/offload/read-ref`. It supports full, query-centered, or line-range
+  recovery, bounded by `max_tokens`.
+- The adapter deliberately limits its integration to the three routes needed
+  by this lifecycle. Storage, summaries, task maps, and offload policy remain
+  gateway responsibilities.
 
 ### Interactive Example
 
@@ -2097,9 +2107,12 @@ modes and does not write local offload state.
 
 | Field | Purpose | Default |
 | ----- | ------- | ------- |
-| `Enabled` | Enable context offload plugin and companion tools. | `false` |
-| `GatewayURL` | Optional gateway URL override for context offload hook/tool calls. Empty reuses `WithGatewayURL`. | none |
-| `APIKey` | Optional API key override for context offload hook/tool calls. Empty reuses `WithAPIKey`. | none |
+| `Enabled` | Enable the context offload plugin and result-reference tool. | `false` |
+| `GatewayURL` | Optional gateway URL override for v2 offload calls. Empty reuses `WithGatewayURL`. | none |
+| `APIKey` | Optional Bearer key override for v2 offload calls. Empty reuses `WithAPIKey`. | none |
+| `ServiceID` | Memory service ID sent as `X-TDAI-Service-Id`; required when enabled. | none |
+| `CompactionRatio` | Context-window utilization that triggers `/v2/offload/compact`; must be in `(0, 2]`. | `0.5` |
+| `TokenCounter` | Optional `model.TokenCounter` for compact request metadata. | simple estimator |
 
 ### Notes
 
@@ -2115,17 +2128,16 @@ modes and does not write local offload state.
   searchable.
 - `tdai_conversation_search` searches conversation history and defaults to the
   current gateway `session_key`.
-- Context offload is opt-in and gateway-owned. It does not call `/capture` or
-  `/recall`, and enabling recall alone will not rewrite tool result messages or
-  create Mermaid task maps.
-- The Go adapter calls gateway hook endpoints
-  `/offload/v1/hooks/after-tool-messages` and
-  `/offload/v1/hooks/before-model`. It does not create `.tdai-offload`, local
-  refs, JSONL indexes, Mermaid files, or local state.
-- The offload tools call gateway drill-down endpoints
-  `/offload/v1/tools/read-ref`, `/offload/v1/tools/read-node`, and
-  `/offload/v1/tools/search-index`. Scope validation, storage ACLs, byte
-  limits, and persistence are gateway responsibilities.
+- Context offload is opt-in and gateway-owned. It uses only
+  `/v2/offload/ingest`, `/v2/offload/compact`, and `/v2/offload/read-ref`; it
+  does not call `/capture` or `/recall`.
+- The gateway may replace archived tool results with messages such as
+  "原始工具结果已存档，如需查看完整内容请调用 Offload V2 result_ref 恢复接口".
+  Register `memSvc.Tools()` so the model can satisfy that instruction through
+  `tdai_read_offload_ref`.
+- The adapter does not create local refs, JSONL indexes, Mermaid files, or
+  local offload state. Scope validation, storage ACLs, token limits, and
+  persistence are gateway responsibilities.
 - Call `Close()` on the service so background capture workers shut down cleanly.
 
 ## References
@@ -2135,6 +2147,6 @@ modes and does not write local offload state.
 - [Auto Mode Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/auto)
 - [mem0 Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/mem0)
 - [TencentDB Agent Memory Example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/tencentdb)
-- [TencentDB Agent Memory SDK](https://github.com/Tencent/TencentDB-Agent-Memory)
+- [TencentDB Agent Memory SDK](https://github.com/TencentCloud/TencentDB-Agent-Memory)
 - [Ecosystem Guide](https://github.com/trpc-group/trpc-agent-go/blob/main/docs/mkdocs/en/ecosystem.md)
 - [API Documentation](https://pkg.go.dev/trpc.group/trpc-go/trpc-agent-go/memory)

--- a/docs/mkdocs/en/memory.md
+++ b/docs/mkdocs/en/memory.md
@@ -2045,10 +2045,13 @@ memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
 At runtime:
 
 - After tool execution, `ContextOffloadPlugin()` sends real tool call/result
-  pairs to `POST /v2/offload/ingest`. This does not rewrite the current tool
+  pairs to `POST /v2/offload/ingest`, together with the latest user prompt and
+  bounded recent conversation context. This does not rewrite the current tool
   result message.
-- Before each model call, the plugin sends a prompt-only ingest for L1.5 task
-  judgment, estimates message tokens, and calls
+- Before each model call, the plugin sends an ingest with no tool pairs for
+  L1.5 task judgment. That request still includes the latest user prompt and
+  bounded recent conversation context. The plugin then estimates message
+  tokens and calls
   `POST /v2/offload/compact` after `CompactionRatio` is reached. Failures are
   best effort: the original model context is retained.
 - `memSvc.Tools()` exposes only `tdai_read_offload_ref`, backed by
@@ -2057,6 +2060,22 @@ At runtime:
 - The adapter deliberately limits its integration to the three routes needed
   by this lifecycle. Storage, summaries, task maps, and offload policy remain
   gateway responsibilities.
+
+Both ingest paths can send up to 10 recent user or assistant messages after
+filtering, truncated to 400 Unicode code points each. The latest user prompt is
+sent separately and truncated to 500 code points. Tool messages, assistant
+tool-call messages, the duplicated current prompt, and recognized internal
+control messages are omitted from `recent_messages`.
+
+The compaction trigger is evaluated locally. The context window is resolved in
+this order: `agent.WithModelContextWindow(...)` for the current run, the
+model's `Info().ContextWindow` (which providers can expose through options such
+as `WithContextWindow(...)`), a value registered for the model name through
+`model.RegisterModelContextWindow(...)`, and finally 128,000 tokens.
+`TokenCounter` supplies the per-message counts used for both the local
+`CompactionRatio` decision and compact request metadata. If it is nil, or if a
+custom counter fails or returns a negative value, the plugin uses the simple
+token estimator for that model call.
 
 ### Interactive Example
 
@@ -2112,7 +2131,7 @@ modes and does not write local offload state.
 | `APIKey` | Optional Bearer key override for v2 offload calls. Empty reuses `WithAPIKey`. | none |
 | `ServiceID` | Memory service ID sent as `X-TDAI-Service-Id`; required when enabled. | none |
 | `CompactionRatio` | Context-window utilization that triggers `/v2/offload/compact`; must be in `(0, 2]`. | `0.5` |
-| `TokenCounter` | Optional `model.TokenCounter` for compact request metadata. | simple estimator |
+| `TokenCounter` | Optional `model.TokenCounter` used for the local `CompactionRatio` trigger and compact request metadata; failures fall back to the simple estimator. | simple estimator |
 
 ### Notes
 

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -1953,10 +1953,10 @@ memSvc, err := memorytencentdb.NewService(
     // 跨 session/user 的读取属于 opt-in，仅在 gateway 可信/隔离时开启。
     memorytencentdb.WithRecallEnabled(true),
     memorytencentdb.WithMemorySearchTool(true),
-    // 可选短期工具结果卸载；需要 gateway 支持 /offload/v1/hooks/*
-    // 和 /offload/v1/tools/*。
+    // 可选短期上下文卸载，通过 gateway v2 API 完成。
     // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
-    //     Enabled: true,
+    //     Enabled:   true,
+    //     ServiceID: os.Getenv("TDAI_SERVICE_ID"),
     // }),
     // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
 )
@@ -1990,27 +1990,27 @@ defer r.Close()
 - 通过 `llmagent.WithTools(memSvc.Tools())` 注册 TencentDB 原生检索工具。
 - 通过 `runner.WithSessionIngestor(memSvc)` 把带时间戳的 session transcript 发送给 `/capture`。
 - 通过 `runner.WithPlugins(memSvc.Plugin())` 在模型调用前启用自动 `/recall`。
-- 只有在设置 `WithContextOffload(memorytencentdb.ContextOffloadConfig{Enabled: true})`
-  且需要短期工具结果卸载时，才额外注册
-  `runner.WithPlugins(memSvc.ContextOffloadPlugin())`。启用后，配套
-  `tdai_read_offload_ref`、`tdai_read_offload_node` 和
-  `tdai_search_offload_index` 工具会通过 `memSvc.Tools()` 暴露。
+- 只有在配置 `WithContextOffload(...)`（包括 `Enabled: true` 和
+  `ServiceID`）且需要短期工具结果卸载时，才额外注册
+  `runner.WithPlugins(memSvc.ContextOffloadPlugin())`。启用后，配套的
+  `tdai_read_offload_ref` 工具会通过 `memSvc.Tools()` 暴露。
 - 不要对该集成使用 `runner.WithMemoryService(...)`。
 
 ### 启用 Context Offload
 
-context offload 是独立、显式开启的短期大工具结果卸载路径。只有在
-TencentDB Agent Memory gateway 已经提供下方 notes 中列出的 offload routes
-时才应启用它。Go adapter 不提供本地存储、摘要模型，也不再暴露
-local/backend/collect 模式。
+context offload 是独立、显式开启的 TencentDB Agent Memory v2 能力。它会将
+工具结果交给 gateway 异步处理，在上下文占用达到阈值时请求 gateway 压缩
+model context，并提供一个工具用于有界恢复已归档的原始结果。
 
 最小接入方式：
 
 ```go
 memSvc, err := memorytencentdb.NewService(
     memorytencentdb.WithGatewayURL(gatewayURL),
+    memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
     memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
-        Enabled: true,
+        Enabled:   true,
+        ServiceID: os.Getenv("TDAI_SERVICE_ID"),
     }),
 )
 if err != nil {
@@ -2032,28 +2032,34 @@ r := runner.NewRunner(
 )
 ```
 
-如果 offload 流量需要使用与普通 capture/search/recall 不同的 gateway 或 key，
-可以在 `ContextOffloadConfig` 中单独设置 `GatewayURL` 和 `APIKey`：
+v2 API 要求同时提供 `Authorization: Bearer <key>` 和
+`X-TDAI-Service-Id`。上游 standalone gateway 约定使用 `local` 和 `default`；
+托管服务应使用对应 memory 实例分配的凭据。
+
+如果 offload 流量需要使用与普通 capture/search/recall 不同的 gateway 或
+API key，可以在 `ContextOffloadConfig` 中覆盖：
 
 ```go
 memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
     Enabled:    true,
-    GatewayURL: "http://127.0.0.1:8420",
-    APIKey:     os.Getenv("TDAI_OFFLOAD_GATEWAY_API_KEY"),
+    GatewayURL: offloadGatewayURL,
+    APIKey:     os.Getenv("TDAI_OFFLOAD_API_KEY"),
+    ServiceID:  os.Getenv("TDAI_SERVICE_ID"),
 })
 ```
 
 运行时行为：
 
-- `ContextOffloadPlugin()` 会在工具执行后调用 gateway。gateway 可以把较大的
-  tool result message 替换成紧凑引用或摘要。
-- 下一次模型调用前，plugin 会询问 gateway 是否需要用已卸载上下文改写当前请求。
-- 启用 context offload 后，`memSvc.Tools()` 会暴露
-  `tdai_read_offload_ref`、`tdai_read_offload_node` 和
-  `tdai_search_offload_index`，模型可以通过这些工具继续下钻 gateway 托管的
-  offload 数据。
-- 不要在 Go adapter 中配置本地目录、本地模型或 L0-L3 策略；这些职责属于
-  TencentDB Agent Memory。
+- 工具执行后，`ContextOffloadPlugin()` 将真实的 tool call/result pair 发送到
+  `POST /v2/offload/ingest`，不会立即改写本轮 tool result message。
+- 每次模型调用前，plugin 会发送 prompt-only ingest 触发 L1.5 任务判断、估算
+  message tokens，并在达到 `CompactionRatio` 后调用
+  `POST /v2/offload/compact`。失败时保留原始 model context。
+- `memSvc.Tools()` 只额外暴露 `tdai_read_offload_ref`，底层调用
+  `POST /v2/offload/read-ref`，支持全文、关键词附近或行范围读取，并受
+  `max_tokens` 限制。
+- adapter 将集成面严格限制在完成该生命周期所需的三个路由。存储、摘要、
+  任务图和 offload 策略仍由 gateway 负责。
 
 ### 交互式示例
 
@@ -2100,9 +2106,12 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 
 | 字段 | 作用 | 默认值 |
 | ---- | ---- | ------ |
-| `Enabled` | 是否启用 context offload plugin 和配套工具。 | `false` |
-| `GatewayURL` | context offload hook/tool 调用的可选 gateway URL 覆盖。为空时复用 `WithGatewayURL`。 | 无 |
-| `APIKey` | context offload hook/tool 调用的可选 API key 覆盖。为空时复用 `WithAPIKey`。 | 无 |
+| `Enabled` | 是否启用 context offload plugin 和 result-reference 工具。 | `false` |
+| `GatewayURL` | v2 offload 调用的可选 gateway URL 覆盖。为空时复用 `WithGatewayURL`。 | 无 |
+| `APIKey` | v2 offload 调用的可选 Bearer key 覆盖。为空时复用 `WithAPIKey`。 | 无 |
+| `ServiceID` | 通过 `X-TDAI-Service-Id` 发送的 memory service ID；启用时必填。 | 无 |
+| `CompactionRatio` | 触发 `/v2/offload/compact` 的上下文窗口占用率，取值 `(0, 2]`。 | `0.5` |
+| `TokenCounter` | 用于生成 compact token 元数据的可选 `model.TokenCounter`。 | 简单估算器 |
 
 ### 注意事项
 
@@ -2110,16 +2119,14 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 - 当 gateway 设置了 `TDAI_GATEWAY_API_KEY` 时，请用 `WithAPIKey(...)` 让请求携带 `Authorization: Bearer <key>`，否则除 `/health` 外的路由都会返回 401（health 仍可通过）。
 - `tdai_memory_search` 检索已提取的长期记忆；提取是异步的，新捕获的信息可能需要短暂等待后才可检索。
 - `tdai_conversation_search` 检索对话历史，默认使用当前 gateway `session_key`。
-- context offload 是显式开启、由 gateway 承载的能力。它不调用 `/capture` 或
-  `/recall`；单独开启 recall 不会改写工具结果消息，也不会生成 Mermaid 任务图。
-- Go adapter 调用 gateway hook endpoints：
-  `/offload/v1/hooks/after-tool-messages` 和
-  `/offload/v1/hooks/before-model`。它不会创建 `.tdai-offload`、本地 refs、
-  JSONL 索引、Mermaid 文件或本地 state。
-- offload 工具调用 gateway drill-down endpoints：
-  `/offload/v1/tools/read-ref`、`/offload/v1/tools/read-node` 和
-  `/offload/v1/tools/search-index`。scope 校验、存储 ACL、返回字节限制和持久化
-  都由 gateway 负责。
+- context offload 是显式开启、由 gateway 承载的能力，只调用
+  `/v2/offload/ingest`、`/v2/offload/compact` 和
+  `/v2/offload/read-ref`，不调用 `/capture` 或 `/recall`。
+- gateway 可能将归档后的工具结果替换为“原始工具结果已存档，如需查看完整内容
+  请调用 Offload V2 result_ref 恢复接口”这类提示。请注册
+  `memSvc.Tools()`，让模型能够通过 `tdai_read_offload_ref` 完成恢复。
+- adapter 不会创建本地 refs、JSONL 索引、Mermaid 文件或本地 offload state。
+  scope 校验、存储 ACL、token 限制和持久化都由 gateway 负责。
 - 使用完成后请调用 `Close()`，确保后台 capture worker 干净退出。
 
 ## 参考链接
@@ -2129,6 +2136,6 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 - [自动提取模式示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/auto)
 - [mem0 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/mem0)
 - [TencentDB Agent Memory 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/memory/tencentdb)
-- [TencentDB Agent Memory SDK](https://github.com/Tencent/TencentDB-Agent-Memory)
+- [TencentDB Agent Memory SDK](https://github.com/TencentCloud/TencentDB-Agent-Memory)
 - [生态建设文档](https://github.com/trpc-group/trpc-agent-go/blob/main/docs/mkdocs/zh/ecosystem.md)
 - [API 文档](https://pkg.go.dev/trpc.group/trpc-go/trpc-agent-go/memory)

--- a/docs/mkdocs/zh/memory.md
+++ b/docs/mkdocs/zh/memory.md
@@ -2051,15 +2051,32 @@ memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
 运行时行为：
 
 - 工具执行后，`ContextOffloadPlugin()` 将真实的 tool call/result pair 发送到
-  `POST /v2/offload/ingest`，不会立即改写本轮 tool result message。
-- 每次模型调用前，plugin 会发送 prompt-only ingest 触发 L1.5 任务判断、估算
-  message tokens，并在达到 `CompactionRatio` 后调用
+  `POST /v2/offload/ingest`，同时携带最新 user prompt 和有界的近期对话上下文；
+  不会立即改写本轮 tool result message。
+- 每次模型调用前，plugin 会发送一个不含 tool pair 的 ingest 触发 L1.5
+  任务判断；该请求仍会携带最新 user prompt 和有界的近期对话上下文。之后
+  plugin 会估算 message tokens，并在达到 `CompactionRatio` 后调用
   `POST /v2/offload/compact`。失败时保留原始 model context。
 - `memSvc.Tools()` 只额外暴露 `tdai_read_offload_ref`，底层调用
   `POST /v2/offload/read-ref`，支持全文、关键词附近或行范围读取，并受
   `max_tokens` 限制。
 - adapter 将集成面严格限制在完成该生命周期所需的三个路由。存储、摘要、
   任务图和 offload 策略仍由 gateway 负责。
+
+两种 ingest 最多都会发送过滤后的 10 条近期 user 或 assistant message，每条
+截断为 400 个 Unicode code point。最新 user prompt 会单独发送并截断为
+500 个 code point。tool message、带 tool call 的 assistant message、与当前
+prompt 重复的 message，以及可识别的内部控制消息不会进入
+`recent_messages`。
+
+compact 是否触发由 adapter 在本地判断。context window 按以下顺序解析：
+当前 run 的 `agent.WithModelContextWindow(...)`、model 的
+`Info().ContextWindow`（provider 通常可通过 `WithContextWindow(...)` 等
+option 设置）、通过 `model.RegisterModelContextWindow(...)` 为 model name
+注册的值，最后兜底为 128,000 tokens。`TokenCounter` 的逐 message 计数既用于
+本地 `CompactionRatio` 判断，也作为 compact request metadata；未配置时使用
+简单 token 估算器，自定义 counter 报错或返回负数时，本轮 model call 也会回退
+到简单估算器。
 
 ### 交互式示例
 
@@ -2111,7 +2128,7 @@ You: 我的项目代号、部署窗口和回答偏好是什么？
 | `APIKey` | v2 offload 调用的可选 Bearer key 覆盖。为空时复用 `WithAPIKey`。 | 无 |
 | `ServiceID` | 通过 `X-TDAI-Service-Id` 发送的 memory service ID；启用时必填。 | 无 |
 | `CompactionRatio` | 触发 `/v2/offload/compact` 的上下文窗口占用率，取值 `(0, 2]`。 | `0.5` |
-| `TokenCounter` | 用于生成 compact token 元数据的可选 `model.TokenCounter`。 | 简单估算器 |
+| `TokenCounter` | 同时用于本地 `CompactionRatio` 触发判断和 compact request metadata 的可选 `model.TokenCounter`；失败时回退到简单估算器。 | 简单估算器 |
 
 ### 注意事项
 

--- a/examples/memory/tencentdb/README.md
+++ b/examples/memory/tencentdb/README.md
@@ -18,6 +18,10 @@ The integration works in three parts:
 3. **Read-only tools** — The agent can explicitly search memory through
    `tdai_memory_search` (opt-in via `WithMemorySearchTool(true)`) and
    conversation history through `tdai_conversation_search`.
+4. **Context offload v2 (optional)** — Tool results are sent to
+   `/v2/offload/ingest`; model context is compacted through
+   `/v2/offload/compact`; and the agent can recover archived details with
+   `tdai_read_offload_ref`, backed by `/v2/offload/read-ref`.
 
 > **Multi-tenant note:** automatic recall and `tdai_memory_search` read from the
 > gateway's shared long-term store, which does not currently enforce
@@ -97,6 +101,7 @@ example at another gateway URL with `-gateway`.
 | `OPENAI_BASE_URL`                | No       | Base URL for the model API endpoint | `https://api.openai.com/v1` |
 | `TENCENTDB_AGENT_MEMORY_GATEWAY` | No       | TencentDB Agent Memory gateway URL  | `http://127.0.0.1:8420`  |
 | `TDAI_GATEWAY_API_KEY`           | No       | Gateway API key (sent as `Authorization: Bearer`) when the gateway requires auth | |
+| `TDAI_SERVICE_ID`                | No       | Service ID sent as `X-TDAI-Service-Id`; setting it enables context offload v2 | |
 
 ## Command Line Arguments
 
@@ -109,6 +114,7 @@ example at another gateway URL with `-gateway`.
 | `-gateway`           | TencentDB Agent Memory gateway URL               | env or `http://127.0.0.1:8420` |
 | `-gateway-timeout`   | Timeout for gateway calls, including session flush | `60s`                   |
 | `-gateway-api-key`   | Gateway API key sent as `Authorization: Bearer`  | env `TDAI_GATEWAY_API_KEY`  |
+| `-offload-service-id` | Service ID for context offload v2; non-empty enables the feature | env `TDAI_SERVICE_ID` |
 | `-turn-wait`         | Delay after each turn for gateway capture/extraction | `0s`                   |
 | `-end-session`       | Call `/session/end` before exit                  | `false`                    |
 
@@ -145,6 +151,20 @@ go run . -model gpt-4o-mini
 go run . -gateway http://127.0.0.1:8420
 ```
 
+### Context Offload V2
+
+The v2 routes require both a non-empty Bearer key and service ID. For a
+standalone gateway, the upstream convention is `local` and `default`:
+
+```bash
+go run . \
+  -gateway-api-key local \
+  -offload-service-id default
+```
+
+For a managed service, use the API key and service ID assigned to that memory
+instance. The example never needs direct COS credentials.
+
 ### Expected Output
 
 ```text
@@ -178,6 +198,8 @@ The core wiring in Go looks like this:
 
 ```go
 import (
+    "os"
+
     memorytencentdb "trpc.group/trpc-go/trpc-agent-go/memory/tencentdb"
     "trpc.group/trpc-go/trpc-agent-go/runner"
 )
@@ -191,6 +213,10 @@ memSvc, err := memorytencentdb.NewService(
     memorytencentdb.WithRecallEnabled(true),
     memorytencentdb.WithMemorySearchTool(true),
     // memorytencentdb.WithAPIKey(os.Getenv("TDAI_GATEWAY_API_KEY")),
+    // memorytencentdb.WithContextOffload(memorytencentdb.ContextOffloadConfig{
+    //     Enabled:   true,
+    //     ServiceID: os.Getenv("TDAI_SERVICE_ID"),
+    // }),
 )
 if err != nil {
     log.Fatalf("create memory service: %v", err)
@@ -210,7 +236,10 @@ r := runner.NewRunner(
     agent,
     runner.WithSessionService(sessionSvc),
     runner.WithSessionIngestor(memSvc),
-    runner.WithPlugins(memSvc.Plugin()),
+    runner.WithPlugins(
+        memSvc.Plugin(),
+        memSvc.ContextOffloadPlugin(),
+    ),
 )
 defer r.Close()
 ```
@@ -224,6 +253,9 @@ Key points:
 - `runner.WithPlugins(memSvc.Plugin())` performs automatic recall before model
   calls and injects returned context into the request, but only when
   `WithRecallEnabled(true)` is set.
+- `runner.WithPlugins(memSvc.ContextOffloadPlugin())` activates only when
+  `ContextOffloadConfig.Enabled` is true. The companion
+  `tdai_read_offload_ref` tool is then included in `memSvc.Tools()`.
 - The adapter forwards app/user/session identifiers, but hard multi-tenant
   isolation depends on the gateway and SDK honoring those fields end-to-end, so
   cross-session/user reads (recall and memory search) are opt-in.
@@ -244,6 +276,7 @@ Key points:
 | `WithConversationSearchTool(bool)` | Expose `tdai_conversation_search`               | `true`                  |
 | `WithStandardAliases(bool)`    | Also expose standard `memory_search` alias (needs memory search enabled) | `false` |
 | `WithToolPrefix(prefix)`       | Change native tool prefix                           | `tdai`                  |
+| `WithContextOffload(config)`   | Configure the opt-in context offload v2 integration | disabled                |
 
 ## See Also
 

--- a/examples/memory/tencentdb/README.md
+++ b/examples/memory/tencentdb/README.md
@@ -100,8 +100,8 @@ example at another gateway URL with `-gateway`.
 | `OPENAI_API_KEY`                 | Yes      | API key for the chat model          |                          |
 | `OPENAI_BASE_URL`                | No       | Base URL for the model API endpoint | `https://api.openai.com/v1` |
 | `TENCENTDB_AGENT_MEMORY_GATEWAY` | No       | TencentDB Agent Memory gateway URL  | `http://127.0.0.1:8420`  |
-| `TDAI_GATEWAY_API_KEY`           | No       | Gateway API key (sent as `Authorization: Bearer`) when the gateway requires auth | |
-| `TDAI_SERVICE_ID`                | No       | Service ID sent as `X-TDAI-Service-Id`; setting it enables context offload v2 | |
+| `TDAI_GATEWAY_API_KEY`           | For offload | Gateway API key sent as `Authorization: Bearer`; required by context offload v2 | |
+| `TDAI_SERVICE_ID`                | For offload | Service ID sent as `X-TDAI-Service-Id`; setting it together with the gateway API key enables context offload v2 | |
 
 ## Command Line Arguments
 
@@ -114,7 +114,7 @@ example at another gateway URL with `-gateway`.
 | `-gateway`           | TencentDB Agent Memory gateway URL               | env or `http://127.0.0.1:8420` |
 | `-gateway-timeout`   | Timeout for gateway calls, including session flush | `60s`                   |
 | `-gateway-api-key`   | Gateway API key sent as `Authorization: Bearer`  | env `TDAI_GATEWAY_API_KEY`  |
-| `-offload-service-id` | Service ID for context offload v2; non-empty enables the feature | env `TDAI_SERVICE_ID` |
+| `-offload-service-id` | Service ID for context offload v2; requires `-gateway-api-key` | env `TDAI_SERVICE_ID` |
 | `-turn-wait`         | Delay after each turn for gateway capture/extraction | `0s`                   |
 | `-end-session`       | Call `/session/end` before exit                  | `false`                    |
 

--- a/examples/memory/tencentdb/main.go
+++ b/examples/memory/tencentdb/main.go
@@ -69,7 +69,7 @@ var (
 	offloadServiceID = flag.String(
 		"offload-service-id",
 		os.Getenv("TDAI_SERVICE_ID"),
-		"TencentDB Agent Memory service ID; non-empty enables context offload v2",
+		"TencentDB Agent Memory service ID; enables context offload v2 when a gateway API key is also configured",
 	)
 	waitBeforeRecall = flag.Duration(
 		"turn-wait",
@@ -93,6 +93,10 @@ func main() {
 	if sid == "" {
 		sid = fmt.Sprintf("tencentdb-%d", time.Now().Unix())
 	}
+	offloadEnabled := strings.TrimSpace(*offloadServiceID) != ""
+	if offloadEnabled && strings.TrimSpace(*gatewayAPIKey) == "" {
+		log.Fatal("-gateway-api-key is required when -offload-service-id enables context offload v2")
+	}
 
 	// Recall and the long-term memory_search tool are opt-in because the gateway
 	// does not enforce per-user/session scoping on those paths; enable them here
@@ -106,7 +110,7 @@ func main() {
 		memorytencentdb.WithRecallEnabled(true),
 		memorytencentdb.WithMemorySearchTool(true),
 	}
-	if strings.TrimSpace(*offloadServiceID) != "" {
+	if offloadEnabled {
 		memoryOptions = append(
 			memoryOptions,
 			memorytencentdb.WithContextOffload(
@@ -151,7 +155,7 @@ func main() {
 
 	fmt.Printf("Model: %s\n", *modelName)
 	fmt.Printf("Gateway: %s (status=%s version=%s)\n", *gatewayURL, health.Status, health.Version)
-	if strings.TrimSpace(*offloadServiceID) != "" {
+	if offloadEnabled {
 		fmt.Printf("Context offload: enabled (service=%s)\n", *offloadServiceID)
 	}
 	fmt.Printf("App: %s\nUser: %s\nSession: %s\n", *appName, *userID, sid)

--- a/examples/memory/tencentdb/main.go
+++ b/examples/memory/tencentdb/main.go
@@ -64,7 +64,12 @@ var (
 	gatewayAPIKey = flag.String(
 		"gateway-api-key",
 		os.Getenv("TDAI_GATEWAY_API_KEY"),
-		"Gateway API key sent as Authorization: Bearer when the gateway sets TDAI_GATEWAY_API_KEY",
+		"Gateway API key sent as Authorization: Bearer; context offload v2 requires a non-empty value",
+	)
+	offloadServiceID = flag.String(
+		"offload-service-id",
+		os.Getenv("TDAI_SERVICE_ID"),
+		"TencentDB Agent Memory service ID; non-empty enables context offload v2",
 	)
 	waitBeforeRecall = flag.Duration(
 		"turn-wait",
@@ -92,15 +97,27 @@ func main() {
 	// Recall and the long-term memory_search tool are opt-in because the gateway
 	// does not enforce per-user/session scoping on those paths; enable them here
 	// for the demo, which runs a single trusted local sidecar.
-	memSvc, err := memorytencentdb.NewService(
+	memoryOptions := []memorytencentdb.Option{
 		memorytencentdb.WithGatewayURL(*gatewayURL),
 		memorytencentdb.WithTimeout(*gatewayTimeout),
 		memorytencentdb.WithIngestQueueSize(8),
-		memorytencentdb.WithIngestJobTimeout(30*time.Second),
+		memorytencentdb.WithIngestJobTimeout(30 * time.Second),
 		memorytencentdb.WithAPIKey(*gatewayAPIKey),
 		memorytencentdb.WithRecallEnabled(true),
 		memorytencentdb.WithMemorySearchTool(true),
-	)
+	}
+	if strings.TrimSpace(*offloadServiceID) != "" {
+		memoryOptions = append(
+			memoryOptions,
+			memorytencentdb.WithContextOffload(
+				memorytencentdb.ContextOffloadConfig{
+					Enabled:   true,
+					ServiceID: *offloadServiceID,
+				},
+			),
+		)
+	}
+	memSvc, err := memorytencentdb.NewService(memoryOptions...)
 	if err != nil {
 		log.Fatalf("create TencentDB Agent Memory service: %v", err)
 	}
@@ -125,12 +142,18 @@ func main() {
 		chatAgent,
 		runner.WithSessionService(sessionSvc),
 		runner.WithSessionIngestor(memSvc),
-		runner.WithPlugins(memSvc.Plugin()),
+		runner.WithPlugins(
+			memSvc.Plugin(),
+			memSvc.ContextOffloadPlugin(),
+		),
 	)
 	defer r.Close()
 
 	fmt.Printf("Model: %s\n", *modelName)
 	fmt.Printf("Gateway: %s (status=%s version=%s)\n", *gatewayURL, health.Status, health.Version)
+	if strings.TrimSpace(*offloadServiceID) != "" {
+		fmt.Printf("Context offload: enabled (service=%s)\n", *offloadServiceID)
+	}
 	fmt.Printf("App: %s\nUser: %s\nSession: %s\n", *appName, *userID, sid)
 	fmt.Println(strings.Repeat("=", 60))
 

--- a/memory/tencentdb/client.go
+++ b/memory/tencentdb/client.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -26,11 +27,7 @@ const (
 	httpHeaderAccept        = "Accept"
 	httpHeaderContentType   = "Content-Type"
 	httpHeaderAuthorization = "Authorization"
-	httpHeaderAppName       = "X-App-Name"
-	httpHeaderUserID        = "X-User-Id"
-	httpHeaderSessionID     = "X-Session-Id"
-	httpHeaderSessionKey    = "X-Session-Key"
-	httpHeaderAgentName     = "X-Agent-Name"
+	httpHeaderServiceID     = "X-TDAI-Service-Id"
 	httpContentTypeJSON     = "application/json"
 	httpAuthBearerPrefix    = "Bearer "
 
@@ -43,11 +40,9 @@ const (
 	pathSearchConversations = "/search/conversations"
 	pathEndSession          = "/session/end"
 	pathHealth              = "/health"
-	pathOffloadAfterTool    = "/offload/v1/hooks/after-tool-messages"
-	pathOffloadBeforeModel  = "/offload/v1/hooks/before-model"
-	pathOffloadReadRef      = "/offload/v1/tools/read-ref"
-	pathOffloadReadNode     = "/offload/v1/tools/read-node"
-	pathOffloadSearchIndex  = "/offload/v1/tools/search-index"
+	pathOffloadIngest       = "/v2/offload/ingest"
+	pathOffloadCompact      = "/v2/offload/compact"
+	pathOffloadReadRef      = "/v2/offload/read-ref"
 
 	maxErrorBodyPreview = 512
 )
@@ -68,6 +63,11 @@ type gatewayClient struct {
 	timeout      time.Duration
 	maxBodyBytes int64
 	apiKey       string
+}
+
+type offloadGatewayClient struct {
+	gateway   *gatewayClient
+	serviceID string
 }
 
 func newGatewayClient(opts Options) (*gatewayClient, error) {
@@ -97,6 +97,40 @@ func newGatewayClient(opts Options) (*gatewayClient, error) {
 		maxBodyBytes: maxBodyBytes,
 		apiKey:       strings.TrimSpace(opts.APIKey),
 	}, nil
+}
+
+func newOffloadGatewayClient(opts Options) (*offloadGatewayClient, error) {
+	if !validCompactionRatio(opts.ContextOffload.CompactionRatio) {
+		return nil, errors.New(
+			"tencentdb memory: context offload compaction ratio must be in (0, 2]",
+		)
+	}
+	offloadOpts := opts
+	if opts.ContextOffload.GatewayURL != "" {
+		offloadOpts.GatewayURL = opts.ContextOffload.GatewayURL
+	}
+	if opts.ContextOffload.APIKey != "" {
+		offloadOpts.APIKey = opts.ContextOffload.APIKey
+	}
+	if strings.TrimSpace(offloadOpts.APIKey) == "" {
+		return nil, errors.New("tencentdb memory: context offload API key is required")
+	}
+	serviceID := strings.TrimSpace(opts.ContextOffload.ServiceID)
+	if serviceID == "" {
+		return nil, errors.New("tencentdb memory: context offload service ID is required")
+	}
+	client, err := newGatewayClient(offloadOpts)
+	if err != nil {
+		return nil, err
+	}
+	return &offloadGatewayClient{
+		gateway:   client,
+		serviceID: serviceID,
+	}, nil
+}
+
+func validCompactionRatio(ratio float64) bool {
+	return ratio > 0 && ratio <= 2 && !math.IsNaN(ratio) && !math.IsInf(ratio, 0)
 }
 
 func (c *gatewayClient) capture(ctx context.Context, req captureRequest) (*captureResponse, error) {
@@ -147,94 +181,59 @@ func (c *gatewayClient) health(ctx context.Context) (*HealthResponse, error) {
 	return &rsp, nil
 }
 
-func (c *gatewayClient) offloadAfterToolMessages(
+func (c *offloadGatewayClient) ingest(
 	ctx context.Context,
-	req offloadAfterToolMessagesRequest,
-) (*offloadAfterToolMessagesResponse, error) {
-	var rsp offloadAfterToolMessagesResponse
-	if err := c.doJSONWithHeaders(
-		ctx,
-		httpMethodPost,
-		pathOffloadAfterTool,
-		req,
-		&rsp,
-		offloadScopeHeaders(req.Scope),
-	); err != nil {
-		return nil, err
-	}
-	return &rsp, nil
+	req offloadIngestRequest,
+) (*offloadIngestData, error) {
+	return doOffloadJSON[offloadIngestData](ctx, c, pathOffloadIngest, req)
 }
 
-func (c *gatewayClient) offloadBeforeModel(
+func (c *offloadGatewayClient) compact(
 	ctx context.Context,
-	req offloadBeforeModelRequest,
-) (*offloadBeforeModelResponse, error) {
-	var rsp offloadBeforeModelResponse
-	if err := c.doJSONWithHeaders(
-		ctx,
-		httpMethodPost,
-		pathOffloadBeforeModel,
-		req,
-		&rsp,
-		offloadScopeHeaders(req.Scope),
-	); err != nil {
-		return nil, err
-	}
-	return &rsp, nil
+	req offloadCompactRequest,
+) (*offloadCompactData, error) {
+	return doOffloadJSON[offloadCompactData](ctx, c, pathOffloadCompact, req)
 }
 
-func (c *gatewayClient) offloadReadRef(
+func (c *offloadGatewayClient) readRef(
 	ctx context.Context,
 	req offloadReadRefRequest,
-) (*offloadReadRefResponse, error) {
-	var rsp offloadReadRefResponse
-	if err := c.doJSONWithHeaders(
-		ctx,
-		httpMethodPost,
-		pathOffloadReadRef,
-		req,
-		&rsp,
-		offloadScopeHeaders(req.Scope),
-	); err != nil {
-		return nil, err
-	}
-	return &rsp, nil
+) (*offloadReadRefData, error) {
+	return doOffloadJSON[offloadReadRefData](ctx, c, pathOffloadReadRef, req)
 }
 
-func (c *gatewayClient) offloadReadNode(
+func doOffloadJSON[T any](
 	ctx context.Context,
-	req offloadReadNodeRequest,
-) (*offloadReadNodeResponse, error) {
-	var rsp offloadReadNodeResponse
-	if err := c.doJSONWithHeaders(
+	client *offloadGatewayClient,
+	path string,
+	req any,
+) (*T, error) {
+	if client == nil || client.gateway == nil {
+		return nil, errors.New("tencentdb memory: context offload gateway is unavailable")
+	}
+	var envelope offloadResponseEnvelope[T]
+	if err := client.gateway.doJSONWithHeaders(
 		ctx,
 		httpMethodPost,
-		pathOffloadReadNode,
+		path,
 		req,
-		&rsp,
-		offloadScopeHeaders(req.Scope),
+		&envelope,
+		map[string]string{httpHeaderServiceID: client.serviceID},
 	); err != nil {
 		return nil, err
 	}
-	return &rsp, nil
-}
-
-func (c *gatewayClient) offloadSearchIndex(
-	ctx context.Context,
-	req offloadSearchIndexRequest,
-) (*offloadSearchIndexResponse, error) {
-	var rsp offloadSearchIndexResponse
-	if err := c.doJSONWithHeaders(
-		ctx,
-		httpMethodPost,
-		pathOffloadSearchIndex,
-		req,
-		&rsp,
-		offloadScopeHeaders(req.Scope),
-	); err != nil {
-		return nil, err
+	if envelope.Code != 0 {
+		return nil, fmt.Errorf(
+			"tencentdb memory: context offload request failed: code=%d message=%s request_id=%s",
+			envelope.Code,
+			envelope.Message,
+			envelope.RequestID,
+		)
 	}
-	return &rsp, nil
+	if envelope.Data == nil {
+		return nil, errors.New("tencentdb memory: context offload response data is missing")
+	}
+	return envelope.Data, nil
 }
 
 func (c *gatewayClient) doJSON(
@@ -332,14 +331,4 @@ func (c *gatewayClient) doJSONOnce(
 		return fmt.Errorf("tencentdb memory: unmarshal response failed: %w", err)
 	}
 	return nil
-}
-
-func offloadScopeHeaders(scope offloadScope) map[string]string {
-	return map[string]string{
-		httpHeaderAppName:    scope.AppName,
-		httpHeaderUserID:     scope.UserID,
-		httpHeaderSessionID:  scope.SessionID,
-		httpHeaderSessionKey: scope.SessionKey,
-		httpHeaderAgentName:  scope.AgentName,
-	}
 }

--- a/memory/tencentdb/context_offload.go
+++ b/memory/tencentdb/context_offload.go
@@ -11,19 +11,34 @@ package tencentdb
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 var _ plugin.Plugin = (*contextOffloadPlugin)(nil)
 
-const contextOffloadPluginName = "tencentdb_context_offload"
+const (
+	contextOffloadPluginName  = "tencentdb_context_offload"
+	defaultModelContextWindow = 128000
+	maxOffloadPromptRunes     = 500
+	maxOffloadRecentRunes     = 400
+	maxOffloadRecentMessages  = 10
+	maxOffloadPromptSessions  = 1024
+)
 
 // ContextOffloadPlugin returns a runner plugin that delegates short-term
-// context offload to TencentDB Agent Memory gateway. It is separate from
+// context offload to the TencentDB Agent Memory v2 API. It is separate from
 // Plugin so long-term recall does not unexpectedly rewrite tool history.
 func (s *Service) ContextOffloadPlugin() plugin.Plugin {
 	if s == nil {
@@ -36,6 +51,10 @@ func (s *Service) ContextOffloadPlugin() plugin.Plugin {
 }
 
 // NewContextOffloadPlugin creates a standalone context offload plugin.
+//
+// Configuration errors are reported through logs when a hook first runs.
+// NewService is preferred when callers need eager configuration validation and
+// the companion result-reference reader tool.
 func NewContextOffloadPlugin(opts ...Option) plugin.Plugin {
 	options := defaultOptions()
 	for _, opt := range opts {
@@ -48,7 +67,11 @@ func NewContextOffloadPlugin(opts ...Option) plugin.Plugin {
 
 type contextOffloadPlugin struct {
 	opts   Options
-	client *gatewayClient
+	client *offloadGatewayClient
+
+	promptMu    sync.Mutex
+	lastPrompt  map[string]string
+	promptOrder []string
 }
 
 func (p *contextOffloadPlugin) Name() string {
@@ -74,27 +97,30 @@ func (p *contextOffloadPlugin) afterToolMessages(
 	if err := validateSessionScope(args.Invocation.Session); err != nil {
 		return nil, nil
 	}
+	sessionID := p.sessionID(args.Invocation.Session)
+	if sessionID == "" {
+		log.WarnfContext(ctx, "tencentdb context offload: session ID is empty")
+		return nil, nil
+	}
+	pairs := newOffloadToolPairs(args.ToolCalls, args.ToolResultMessages)
+	if len(pairs) == 0 {
+		return nil, nil
+	}
 	client, err := p.contextOffloadClient()
 	if err != nil {
 		log.WarnfContext(ctx, "tencentdb context offload: gateway client unavailable: %v", err)
 		return nil, nil
 	}
-	rsp, err := client.offloadAfterToolMessages(ctx, offloadAfterToolMessagesRequest{
-		Scope:              newOffloadScope(p.opts, args.Invocation.Session, args.Invocation.AgentName),
-		Messages:           args.Messages,
-		ToolCalls:          args.ToolCalls,
-		ToolResultMessages: args.ToolResultMessages,
-	})
-	if err != nil {
-		log.WarnfContext(ctx, "tencentdb context offload: after-tool gateway failed: %v", err)
-		return nil, nil
+	prompt, recent := offloadPromptContext(args.Messages)
+	if _, err := client.ingest(ctx, offloadIngestRequest{
+		SessionID:      sessionID,
+		ToolPairs:      pairs,
+		Prompt:         prompt,
+		RecentMessages: recent,
+	}); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: ingest failed: %v", err)
 	}
-	if rsp == nil || len(rsp.ToolResultMessages) == 0 {
-		return nil, nil
-	}
-	return &plugin.AfterToolMessagesResult{
-		ToolResultMessages: rsp.ToolResultMessages,
-	}, nil
+	return nil, nil
 }
 
 func (p *contextOffloadPlugin) beforeModel(
@@ -111,61 +137,313 @@ func (p *contextOffloadPlugin) beforeModel(
 	if err := validateSessionScope(inv.Session); err != nil {
 		return nil, nil
 	}
+	sessionID := p.sessionID(inv.Session)
+	if sessionID == "" {
+		log.WarnfContext(ctx, "tencentdb context offload: session ID is empty")
+		return nil, nil
+	}
 	client, err := p.contextOffloadClient()
 	if err != nil {
 		log.WarnfContext(ctx, "tencentdb context offload: gateway client unavailable: %v", err)
 		return nil, nil
 	}
-	rsp, err := client.offloadBeforeModel(ctx, offloadBeforeModelRequest{
-		Scope:   newOffloadScope(p.opts, inv.Session, inv.AgentName),
-		Request: cloneModelRequest(args.Request),
+
+	prompt, recent := offloadPromptContext(args.Request.Messages)
+	p.ingestPrompt(ctx, client, sessionID, prompt, recent)
+
+	if len(args.Request.Messages) == 0 {
+		return nil, nil
+	}
+	totalTokens, messageTokens := p.countTokens(ctx, args.Request.Messages)
+	contextWindow := offloadContextWindow(inv)
+	ratio := float64(totalTokens) / float64(contextWindow)
+	if ratio < p.opts.ContextOffload.CompactionRatio {
+		return nil, nil
+	}
+
+	messages := make([]offloadMessage, 0, len(args.Request.Messages))
+	for _, message := range args.Request.Messages {
+		messages = append(messages, newOffloadMessage(message))
+	}
+	rsp, err := client.compact(ctx, offloadCompactRequest{
+		SessionID:     sessionID,
+		Messages:      messages,
+		Ratio:         math.Min(ratio, 2),
+		ContextWindow: contextWindow,
+		TotalTokens:   totalTokens,
+		MessageTokens: messageTokens,
 	})
 	if err != nil {
-		log.WarnfContext(ctx, "tencentdb context offload: before-model gateway failed: %v", err)
+		log.WarnfContext(ctx, "tencentdb context offload: compact failed: %v", err)
 		return nil, nil
 	}
-	if rsp == nil {
+	if rsp == nil || len(rsp.Messages) == 0 {
 		return nil, nil
 	}
-	messages := rsp.Messages
-	if rsp.Request != nil {
-		messages = rsp.Request.Messages
+	compacted := make([]model.Message, 0, len(rsp.Messages))
+	for _, message := range rsp.Messages {
+		if !message.Role.IsValid() {
+			log.WarnfContext(
+				ctx,
+				"tencentdb context offload: compact returned invalid role %q",
+				message.Role,
+			)
+			return nil, nil
+		}
+		compacted = append(compacted, message.modelMessage())
 	}
-	if len(messages) == 0 {
+	if hasOrphanToolResults(compacted) {
+		log.WarnfContext(ctx, "tencentdb context offload: compact returned orphan tool results")
 		return nil, nil
 	}
-	if hasOrphanToolResults(messages) {
-		log.WarnfContext(ctx, "tencentdb context offload: before-model gateway returned orphan tool results")
-		return nil, nil
-	}
-	args.Request.Messages = messages
+	args.Request.Messages = compacted
 	return nil, nil
 }
 
-func (p *contextOffloadPlugin) contextOffloadClient() (*gatewayClient, error) {
+func (p *contextOffloadPlugin) ingestPrompt(
+	ctx context.Context,
+	client *offloadGatewayClient,
+	sessionID string,
+	prompt string,
+	recent []offloadRecentMessage,
+) {
+	if prompt == "" || isInternalOffloadPrompt(prompt) ||
+		!p.markPrompt(sessionID, prompt) {
+		return
+	}
+	if _, err := client.ingest(ctx, offloadIngestRequest{
+		SessionID:      sessionID,
+		ToolPairs:      []offloadToolPair{},
+		Prompt:         prompt,
+		RecentMessages: recent,
+	}); err != nil {
+		log.WarnfContext(ctx, "tencentdb context offload: prompt ingest failed: %v", err)
+	}
+}
+
+func (p *contextOffloadPlugin) markPrompt(sessionID, prompt string) bool {
+	p.promptMu.Lock()
+	defer p.promptMu.Unlock()
+	if p.lastPrompt == nil {
+		p.lastPrompt = make(map[string]string)
+	}
+	if p.lastPrompt[sessionID] == prompt {
+		return false
+	}
+	if _, ok := p.lastPrompt[sessionID]; !ok {
+		if len(p.promptOrder) >= maxOffloadPromptSessions {
+			delete(p.lastPrompt, p.promptOrder[0])
+			p.promptOrder = p.promptOrder[1:]
+		}
+		p.promptOrder = append(p.promptOrder, sessionID)
+	}
+	p.lastPrompt[sessionID] = prompt
+	return true
+}
+
+func (p *contextOffloadPlugin) countTokens(
+	ctx context.Context,
+	messages []model.Message,
+) (int, []int) {
+	counter := p.opts.ContextOffload.TokenCounter
+	if counter == nil {
+		counter = model.NewSimpleTokenCounter()
+	}
+	total, perMessage, err := countOffloadTokens(ctx, counter, messages)
+	if err == nil {
+		return total, perMessage
+	}
+	log.WarnfContext(ctx, "tencentdb context offload: token counter failed, using simple estimate: %v", err)
+	total, perMessage, _ = countOffloadTokens(
+		ctx,
+		model.NewSimpleTokenCounter(),
+		messages,
+	)
+	return total, perMessage
+}
+
+func countOffloadTokens(
+	ctx context.Context,
+	counter model.TokenCounter,
+	messages []model.Message,
+) (int, []int, error) {
+	perMessage := make([]int, 0, len(messages))
+	total := 0
+	for _, message := range messages {
+		tokens, err := counter.CountTokens(ctx, message)
+		if err != nil {
+			return 0, nil, err
+		}
+		if tokens < 0 {
+			return 0, nil, fmt.Errorf("token counter returned negative count %d", tokens)
+		}
+		perMessage = append(perMessage, tokens)
+		total += tokens
+	}
+	return total, perMessage, nil
+}
+
+func (p *contextOffloadPlugin) contextOffloadClient() (*offloadGatewayClient, error) {
 	if p == nil {
 		return nil, nil
 	}
 	if p.client != nil {
 		return p.client, nil
 	}
-	options := p.opts
-	if options.ContextOffload.GatewayURL != "" {
-		options.GatewayURL = options.ContextOffload.GatewayURL
-	}
-	if options.ContextOffload.APIKey != "" {
-		options.APIKey = options.ContextOffload.APIKey
-	}
-	return newGatewayClient(options)
+	return newOffloadGatewayClient(p.opts)
 }
 
-func cloneModelRequest(req *model.Request) *model.Request {
-	if req == nil {
-		return nil
+func (p *contextOffloadPlugin) sessionID(sess *session.Session) string {
+	if p == nil {
+		return ""
 	}
-	cloned := *req
-	cloned.Messages = append([]model.Message(nil), req.Messages...)
-	return &cloned
+	if p.opts.SessionKeyFunc != nil {
+		return strings.TrimSpace(p.opts.SessionKeyFunc(sess))
+	}
+	return strings.TrimSpace(defaultSessionKey(sess))
+}
+
+func newOffloadToolPairs(
+	calls []model.ToolCall,
+	results []model.Message,
+) []offloadToolPair {
+	callsByID := make(map[string]model.ToolCall, len(calls))
+	for _, call := range calls {
+		if call.ID != "" {
+			callsByID[call.ID] = call
+		}
+	}
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	pairs := make([]offloadToolPair, 0, len(results))
+	for _, result := range results {
+		callID := strings.TrimSpace(result.ToolID)
+		if callID == "" {
+			continue
+		}
+		call := callsByID[callID]
+		toolName := strings.TrimSpace(call.Function.Name)
+		if toolName == "" {
+			toolName = strings.TrimSpace(result.ToolName)
+		}
+		pairs = append(pairs, offloadToolPair{
+			ToolName:   toolName,
+			ToolCallID: callID,
+			Params:     offloadToolParams(call.Function.Arguments),
+			Result:     offloadToolResult(result),
+			Timestamp:  timestamp,
+		})
+	}
+	return pairs
+}
+
+func offloadToolParams(arguments []byte) any {
+	if len(arguments) == 0 {
+		return map[string]any{}
+	}
+	var params any
+	if err := json.Unmarshal(arguments, &params); err == nil {
+		return params
+	}
+	return string(arguments)
+}
+
+func offloadToolResult(message model.Message) any {
+	if message.Content != "" {
+		return message.Content
+	}
+	if len(message.ContentParts) > 0 {
+		return message.ContentParts
+	}
+	return ""
+}
+
+func offloadPromptContext(
+	messages []model.Message,
+) (string, []offloadRecentMessage) {
+	var prompt string
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == model.RoleUser {
+			prompt = strings.TrimSpace(messageText(messages[i]))
+			if prompt != "" {
+				break
+			}
+		}
+	}
+	if prompt == "" {
+		return "", nil
+	}
+	prompt = truncateRunes(prompt, maxOffloadPromptRunes)
+	normalizedPrompt := strings.ToLower(
+		truncateRunes(strings.TrimSpace(prompt), 200),
+	)
+	recent := make([]offloadRecentMessage, 0, maxOffloadRecentMessages)
+	for _, message := range messages {
+		if message.Role != model.RoleUser && message.Role != model.RoleAssistant {
+			continue
+		}
+		if message.Role == model.RoleAssistant && len(message.ToolCalls) > 0 {
+			continue
+		}
+		content := strings.TrimSpace(messageText(message))
+		if content == "" || strings.Contains(strings.ToLower(content), "heartbeat") {
+			continue
+		}
+		if message.Role == model.RoleUser && utf8.RuneCountInString(content) <= 5 {
+			continue
+		}
+		if message.Role == model.RoleAssistant && utf8.RuneCountInString(content) <= 10 {
+			continue
+		}
+		normalized := strings.ToLower(truncateRunes(content, 200))
+		if normalizedPrompt != "" &&
+			(normalized == normalizedPrompt ||
+				strings.HasPrefix(normalized, normalizedPrompt) ||
+				strings.HasPrefix(normalizedPrompt, normalized)) {
+			continue
+		}
+		recent = append(recent, offloadRecentMessage{
+			Role:    message.Role,
+			Content: truncateRunes(content, maxOffloadRecentRunes),
+		})
+	}
+	if len(recent) > maxOffloadRecentMessages {
+		recent = recent[len(recent)-maxOffloadRecentMessages:]
+	}
+	return prompt, recent
+}
+
+func isInternalOffloadPrompt(prompt string) bool {
+	return strings.HasPrefix(prompt, "Pre-compaction") ||
+		strings.HasPrefix(prompt, "[Inter-session message]") ||
+		strings.Contains(strings.ToLower(prompt), "heartbeat")
+}
+
+func truncateRunes(value string, limit int) string {
+	if limit <= 0 || utf8.RuneCountInString(value) <= limit {
+		return value
+	}
+	runes := []rune(value)
+	return string(runes[:limit])
+}
+
+func offloadContextWindow(inv *agent.Invocation) int {
+	if inv == nil {
+		return defaultModelContextWindow
+	}
+	if window, ok := agent.ModelContextWindowFromRunOptions(&inv.RunOptions); ok {
+		return window
+	}
+	if inv.Model == nil {
+		return defaultModelContextWindow
+	}
+	info := inv.Model.Info()
+	if info.ContextWindow > 0 {
+		return info.ContextWindow
+	}
+	if window, ok := model.LookupModelContextWindow(info.Name); ok {
+		return window
+	}
+	return defaultModelContextWindow
 }
 
 func hasOrphanToolResults(messages []model.Message) bool {

--- a/memory/tencentdb/context_offload.go
+++ b/memory/tencentdb/context_offload.go
@@ -35,6 +35,8 @@ const (
 	maxOffloadRecentRunes     = 400
 	maxOffloadRecentMessages  = 10
 	maxOffloadPromptSessions  = 1024
+	heartbeatPromptPrefix     = "Read HEARTBEAT.md if it exists"
+	heartbeatReply            = "HEARTBEAT_OK"
 )
 
 // ContextOffloadPlugin returns a runner plugin that delegates short-term
@@ -403,7 +405,7 @@ func newOffloadRecentMessage(
 		return offloadRecentMessage{}, false
 	}
 	content := strings.TrimSpace(messageText(message))
-	if content == "" || strings.Contains(strings.ToLower(content), "heartbeat") {
+	if content == "" || isInternalHeartbeatMessage(content) {
 		return offloadRecentMessage{}, false
 	}
 	if message.Role == model.RoleUser && utf8.RuneCountInString(content) <= 5 {
@@ -427,9 +429,16 @@ func newOffloadRecentMessage(
 }
 
 func isInternalOffloadPrompt(prompt string) bool {
+	prompt = strings.TrimSpace(prompt)
 	return strings.HasPrefix(prompt, "Pre-compaction") ||
 		strings.HasPrefix(prompt, "[Inter-session message]") ||
-		strings.Contains(strings.ToLower(prompt), "heartbeat")
+		isInternalHeartbeatMessage(prompt)
+}
+
+func isInternalHeartbeatMessage(message string) bool {
+	message = strings.TrimSpace(message)
+	return strings.HasPrefix(message, heartbeatPromptPrefix) ||
+		message == heartbeatReply
 }
 
 func truncateRunes(value string, limit int) string {

--- a/memory/tencentdb/context_offload.go
+++ b/memory/tencentdb/context_offload.go
@@ -378,38 +378,52 @@ func offloadPromptContext(
 	)
 	recent := make([]offloadRecentMessage, 0, maxOffloadRecentMessages)
 	for _, message := range messages {
-		if message.Role != model.RoleUser && message.Role != model.RoleAssistant {
-			continue
+		recentMessage, ok := newOffloadRecentMessage(
+			message,
+			normalizedPrompt,
+		)
+		if ok {
+			recent = append(recent, recentMessage)
 		}
-		if message.Role == model.RoleAssistant && len(message.ToolCalls) > 0 {
-			continue
-		}
-		content := strings.TrimSpace(messageText(message))
-		if content == "" || strings.Contains(strings.ToLower(content), "heartbeat") {
-			continue
-		}
-		if message.Role == model.RoleUser && utf8.RuneCountInString(content) <= 5 {
-			continue
-		}
-		if message.Role == model.RoleAssistant && utf8.RuneCountInString(content) <= 10 {
-			continue
-		}
-		normalized := strings.ToLower(truncateRunes(content, 200))
-		if normalizedPrompt != "" &&
-			(normalized == normalizedPrompt ||
-				strings.HasPrefix(normalized, normalizedPrompt) ||
-				strings.HasPrefix(normalizedPrompt, normalized)) {
-			continue
-		}
-		recent = append(recent, offloadRecentMessage{
-			Role:    message.Role,
-			Content: truncateRunes(content, maxOffloadRecentRunes),
-		})
 	}
 	if len(recent) > maxOffloadRecentMessages {
 		recent = recent[len(recent)-maxOffloadRecentMessages:]
 	}
 	return prompt, recent
+}
+
+func newOffloadRecentMessage(
+	message model.Message,
+	normalizedPrompt string,
+) (offloadRecentMessage, bool) {
+	if message.Role != model.RoleUser && message.Role != model.RoleAssistant {
+		return offloadRecentMessage{}, false
+	}
+	if message.Role == model.RoleAssistant && len(message.ToolCalls) > 0 {
+		return offloadRecentMessage{}, false
+	}
+	content := strings.TrimSpace(messageText(message))
+	if content == "" || strings.Contains(strings.ToLower(content), "heartbeat") {
+		return offloadRecentMessage{}, false
+	}
+	if message.Role == model.RoleUser && utf8.RuneCountInString(content) <= 5 {
+		return offloadRecentMessage{}, false
+	}
+	if message.Role == model.RoleAssistant &&
+		utf8.RuneCountInString(content) <= 10 {
+		return offloadRecentMessage{}, false
+	}
+	normalized := strings.ToLower(truncateRunes(content, 200))
+	if normalizedPrompt != "" &&
+		(normalized == normalizedPrompt ||
+			strings.HasPrefix(normalized, normalizedPrompt) ||
+			strings.HasPrefix(normalizedPrompt, normalized)) {
+		return offloadRecentMessage{}, false
+	}
+	return offloadRecentMessage{
+		Role:    message.Role,
+		Content: truncateRunes(content, maxOffloadRecentRunes),
+	}, true
 }
 
 func isInternalOffloadPrompt(prompt string) bool {

--- a/memory/tencentdb/context_offload.go
+++ b/memory/tencentdb/context_offload.go
@@ -64,16 +64,25 @@ func NewContextOffloadPlugin(opts ...Option) plugin.Plugin {
 			opt(&options)
 		}
 	}
+	options.ContextOffload = normalizeContextOffloadConfig(
+		options.ContextOffload,
+	)
 	return &contextOffloadPlugin{opts: options}
+}
+
+type offloadPromptKey struct {
+	sessionID string
+	prompt    string
 }
 
 type contextOffloadPlugin struct {
 	opts   Options
 	client *offloadGatewayClient
 
-	promptMu    sync.Mutex
-	lastPrompt  map[string]string
-	promptOrder []string
+	promptMu        sync.Mutex
+	lastPrompt      map[string]string
+	promptOrder     []string
+	promptsInFlight map[offloadPromptKey]struct{}
 }
 
 func (p *contextOffloadPlugin) Name() string {
@@ -210,7 +219,7 @@ func (p *contextOffloadPlugin) ingestPrompt(
 	recent []offloadRecentMessage,
 ) {
 	if prompt == "" || isInternalOffloadPrompt(prompt) ||
-		!p.markPrompt(sessionID, prompt) {
+		!p.reservePrompt(sessionID, prompt) {
 		return
 	}
 	if _, err := client.ingest(ctx, offloadIngestRequest{
@@ -219,11 +228,14 @@ func (p *contextOffloadPlugin) ingestPrompt(
 		Prompt:         prompt,
 		RecentMessages: recent,
 	}); err != nil {
+		p.finishPrompt(sessionID, prompt, false)
 		log.WarnfContext(ctx, "tencentdb context offload: prompt ingest failed: %v", err)
+		return
 	}
+	p.finishPrompt(sessionID, prompt, true)
 }
 
-func (p *contextOffloadPlugin) markPrompt(sessionID, prompt string) bool {
+func (p *contextOffloadPlugin) reservePrompt(sessionID, prompt string) bool {
 	p.promptMu.Lock()
 	defer p.promptMu.Unlock()
 	if p.lastPrompt == nil {
@@ -231,6 +243,31 @@ func (p *contextOffloadPlugin) markPrompt(sessionID, prompt string) bool {
 	}
 	if p.lastPrompt[sessionID] == prompt {
 		return false
+	}
+	if p.promptsInFlight == nil {
+		p.promptsInFlight = make(map[offloadPromptKey]struct{})
+	}
+	key := offloadPromptKey{sessionID: sessionID, prompt: prompt}
+	if _, ok := p.promptsInFlight[key]; ok {
+		return false
+	}
+	p.promptsInFlight[key] = struct{}{}
+	return true
+}
+
+func (p *contextOffloadPlugin) finishPrompt(
+	sessionID string,
+	prompt string,
+	succeeded bool,
+) {
+	p.promptMu.Lock()
+	defer p.promptMu.Unlock()
+	delete(p.promptsInFlight, offloadPromptKey{
+		sessionID: sessionID,
+		prompt:    prompt,
+	})
+	if !succeeded {
+		return
 	}
 	if _, ok := p.lastPrompt[sessionID]; !ok {
 		if len(p.promptOrder) >= maxOffloadPromptSessions {
@@ -240,7 +277,6 @@ func (p *contextOffloadPlugin) markPrompt(sessionID, prompt string) bool {
 		p.promptOrder = append(p.promptOrder, sessionID)
 	}
 	p.lastPrompt[sessionID] = prompt
-	return true
 }
 
 func (p *contextOffloadPlugin) countTokens(

--- a/memory/tencentdb/context_offload_test.go
+++ b/memory/tencentdb/context_offload_test.go
@@ -12,10 +12,11 @@ package tencentdb
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,29 +29,68 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
-func TestContextOffloadPlugin_DelegatesHooksToGateway(t *testing.T) {
-	var afterReq offloadAfterToolMessagesRequest
-	var beforeReq offloadBeforeModelRequest
-	var afterHeaders http.Header
+const (
+	testOffloadAPIKey    = "offload-key"
+	testOffloadServiceID = "mem-test"
+)
+
+type fixedOffloadTokenCounter struct {
+	tokens int
+	err    error
+}
+
+func (c fixedOffloadTokenCounter) CountTokens(
+	context.Context,
+	model.Message,
+) (int, error) {
+	return c.tokens, c.err
+}
+
+func (c fixedOffloadTokenCounter) CountTokensRange(
+	_ context.Context,
+	messages []model.Message,
+	start int,
+	end int,
+) (int, error) {
+	if c.err != nil {
+		return 0, c.err
+	}
+	return (end - start) * c.tokens, nil
+}
+
+func TestContextOffloadPlugin_UsesV2IngestAndCompact(t *testing.T) {
+	var ingests []offloadIngestRequest
+	var compact offloadCompactRequest
+	var headers []http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers = append(headers, r.Header.Clone())
 		switch r.URL.Path {
-		case pathOffloadAfterTool:
-			afterHeaders = r.Header.Clone()
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&afterReq))
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"tool_result_messages": []model.Message{{
-					Role:    model.RoleTool,
-					ToolID:  "call-1",
-					Content: "summary from gateway",
-				}},
-			})
-		case pathOffloadBeforeModel:
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&beforeReq))
-			_ = json.NewEncoder(w).Encode(offloadBeforeModelResponse{
-				Messages: []model.Message{
-					model.NewSystemMessage("gateway mmd"),
-					model.NewUserMessage("compressed"),
+		case pathOffloadIngest:
+			var req offloadIngestRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			ingests = append(ingests, req)
+			writeOffloadResponse(t, w, map[string]any{"accepted": true})
+		case pathOffloadCompact:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&compact))
+			writeOffloadResponse(t, w, map[string]any{
+				"messages": []map[string]any{
+					{"role": "system", "content": "gateway task context"},
+					{"role": "user", "content": "compressed context"},
+					{
+						"role": "assistant",
+						"tool_calls": []map[string]any{{
+							"id": "call-1", "type": "function",
+							"function": map[string]any{
+								"name": "grep", "arguments": `{"pattern":"needle"}`,
+							},
+						}},
+					},
+					{
+						"role": "tool", "tool_call_id": "call-1",
+						"tool_name": "grep", "content": "archived summary",
+					},
 				},
+				"report": map[string]any{"resolvedLevel": "mild"},
 			})
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -60,8 +100,13 @@ func TestContextOffloadPlugin_DelegatesHooksToGateway(t *testing.T) {
 
 	svc, err := NewService(
 		WithGatewayURL(server.URL),
-		WithAPIKey("svc-key"),
-		WithContextOffload(ContextOffloadConfig{Enabled: true}),
+		WithAPIKey(testOffloadAPIKey),
+		WithContextOffload(ContextOffloadConfig{
+			Enabled:         true,
+			ServiceID:       testOffloadServiceID,
+			CompactionRatio: 0.5,
+			TokenCounter:    fixedOffloadTokenCounter{tokens: 60},
+		}),
 	)
 	require.NoError(t, err)
 	defer svc.Close()
@@ -70,117 +115,314 @@ func TestContextOffloadPlugin_DelegatesHooksToGateway(t *testing.T) {
 	require.NoError(t, err)
 
 	sess := &session.Session{ID: "sess-1", AppName: "app", UserID: "user"}
-	inv := &agent.Invocation{Session: sess, AgentName: "agent-name"}
+	inv := &agent.Invocation{
+		Session: sess,
+		RunOptions: agent.RunOptions{
+			ModelContextWindow: 100,
+		},
+	}
 	ctx := agent.NewInvocationContext(context.Background(), inv).Context
-	toolCalls := []model.ToolCall{{
+	call := model.ToolCall{
 		ID:   "call-1",
 		Type: "function",
 		Function: model.FunctionDefinitionParam{
 			Name:      "grep",
-			Arguments: []byte(`{"pattern":"x"}`),
+			Arguments: []byte(`{"pattern":"needle"}`),
 		},
-	}}
-	toolResults := []model.Message{{
-		Role:     model.RoleTool,
-		ToolID:   "call-1",
-		ToolName: "grep",
-		Content:  "large result",
-	}}
-	afterRsp, err := mgr.AfterToolMessages(ctx, &pluginpkg.AfterToolMessagesArgs{
-		Invocation:         inv,
-		Messages:           []model.Message{model.NewUserMessage("find x")},
-		ToolCalls:          toolCalls,
-		ToolResultMessages: toolResults,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, afterRsp)
-	require.Len(t, afterRsp.ToolResultMessages, 1)
-	assert.Equal(t, "summary from gateway", afterRsp.ToolResultMessages[0].Content)
-	assert.Equal(t, "Bearer svc-key", afterHeaders.Get(httpHeaderAuthorization))
-	assert.Equal(t, "app", afterHeaders.Get(httpHeaderAppName))
-	assert.Equal(t, "user", afterHeaders.Get(httpHeaderUserID))
-	assert.Equal(t, "sess-1", afterHeaders.Get(httpHeaderSessionID))
-	assert.Equal(t, "agent-name", afterHeaders.Get(httpHeaderAgentName))
-	assert.Equal(t, defaultSessionKey(sess), afterHeaders.Get(httpHeaderSessionKey))
-	assert.Equal(t, "app", afterReq.Scope.AppName)
-	assert.Equal(t, "user", afterReq.Scope.UserID)
-	assert.Equal(t, "sess-1", afterReq.Scope.SessionID)
-	assert.Equal(t, defaultSessionKey(sess), afterReq.Scope.SessionKey)
-	require.Len(t, afterReq.ToolResultMessages, 1)
-	assert.Equal(t, "large result", afterReq.ToolResultMessages[0].Content)
-	require.Len(t, afterReq.ToolCalls, 1)
-	assert.Equal(t, "call-1", afterReq.ToolCalls[0].ID)
+	}
+	assistant := model.NewAssistantMessage("")
+	assistant.ToolCalls = []model.ToolCall{call}
+	result := model.NewToolMessage("call-1", "grep", "large tool result")
+	messages := []model.Message{
+		model.NewUserMessage("find the deployment failure"),
+		assistant,
+		result,
+	}
 
-	req := &model.Request{Messages: []model.Message{model.NewUserMessage("next")}}
-	callbacks := mgr.ModelCallbacks()
-	require.NotNil(t, callbacks)
-	_, err = callbacks.RunBeforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	afterResult, err := mgr.AfterToolMessages(
+		ctx,
+		&pluginpkg.AfterToolMessagesArgs{
+			Invocation:         inv,
+			Messages:           messages,
+			ToolCalls:          []model.ToolCall{call},
+			ToolResultMessages: []model.Message{result},
+		},
+	)
 	require.NoError(t, err)
-	require.Len(t, req.Messages, 2)
-	assert.Equal(t, "gateway mmd", req.Messages[0].Content)
-	assert.Equal(t, "compressed", req.Messages[1].Content)
-	require.NotNil(t, beforeReq.Request)
-	require.Len(t, beforeReq.Request.Messages, 1)
-	assert.Equal(t, "next", beforeReq.Request.Messages[0].Content)
-	assert.Equal(t, "agent-name", beforeReq.Scope.AgentName)
+	assert.Nil(t, afterResult, "ingest must not rewrite tool results")
+
+	req := &model.Request{Messages: messages}
+	_, err = mgr.ModelCallbacks().RunBeforeModel(
+		ctx,
+		&model.BeforeModelArgs{Request: req},
+	)
+	require.NoError(t, err)
+	require.Len(t, req.Messages, 4)
+	assert.Equal(t, "gateway task context", req.Messages[0].Content)
+	assert.Equal(t, "compressed context", req.Messages[1].Content)
+	assert.Equal(t, "call-1", req.Messages[3].ToolID)
+	assert.Equal(t, "archived summary", req.Messages[3].Content)
+
+	require.Len(t, ingests, 2)
+	assert.Equal(t, defaultSessionKey(sess), ingests[0].SessionID)
+	require.Len(t, ingests[0].ToolPairs, 1)
+	assert.Equal(t, "grep", ingests[0].ToolPairs[0].ToolName)
+	assert.Equal(t, "call-1", ingests[0].ToolPairs[0].ToolCallID)
+	assert.Equal(t, map[string]any{"pattern": "needle"}, ingests[0].ToolPairs[0].Params)
+	assert.Equal(t, "large tool result", ingests[0].ToolPairs[0].Result)
+	assert.NotEmpty(t, ingests[0].ToolPairs[0].Timestamp)
+	assert.Equal(t, "find the deployment failure", ingests[0].Prompt)
+	assert.Empty(t, ingests[1].ToolPairs)
+	assert.Equal(t, "find the deployment failure", ingests[1].Prompt)
+
+	assert.Equal(t, defaultSessionKey(sess), compact.SessionID)
+	assert.Equal(t, 100, compact.ContextWindow)
+	assert.Equal(t, 180, compact.TotalTokens)
+	assert.Equal(t, []int{60, 60, 60}, compact.MessageTokens)
+	assert.InDelta(t, 1.8, compact.Ratio, 0.001)
+	require.Len(t, compact.Messages, 3)
+	assert.Equal(t, "call-1", compact.Messages[2].ToolCallID)
+	for _, header := range headers {
+		assert.Equal(t, "Bearer "+testOffloadAPIKey, header.Get(httpHeaderAuthorization))
+		assert.Equal(t, testOffloadServiceID, header.Get(httpHeaderServiceID))
+	}
 }
 
-func TestContextOffloadPlugin_DoesNotCreateLocalOffloadDirectory(t *testing.T) {
-	var gotAfter bool
+func TestContextOffloadPlugin_SkipsBelowThresholdAndDeduplicatesPrompt(t *testing.T) {
+	var ingestCount int
+	var compactCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == pathOffloadAfterTool {
-			gotAfter = true
-			_ = json.NewEncoder(w).Encode(offloadAfterToolMessagesResponse{})
-			return
+		switch r.URL.Path {
+		case pathOffloadIngest:
+			ingestCount++
+			writeOffloadResponse(t, w, map[string]any{"accepted": true})
+		case pathOffloadCompact:
+			compactCount++
+			writeOffloadResponse(t, w, map[string]any{"messages": []any{}})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		t.Fatalf("unexpected path: %s", r.URL.Path)
 	}))
 	defer server.Close()
 
-	workDir := t.TempDir()
-	prev, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(workDir))
-	defer func() { require.NoError(t, os.Chdir(prev)) }()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithContextOffload(ContextOffloadConfig{Enabled: true}),
-	)
-	require.NoError(t, err)
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:         true,
+		ServiceID:       testOffloadServiceID,
+		CompactionRatio: 0.5,
+		TokenCounter:    fixedOffloadTokenCounter{tokens: 1},
+	})
 	defer svc.Close()
-
 	mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
 	require.NoError(t, err)
-	sess := &session.Session{ID: "sess", AppName: "app", UserID: "user"}
-	inv := &agent.Invocation{Session: sess, AgentName: "agent"}
+	inv := &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+		RunOptions: agent.RunOptions{
+			ModelContextWindow: 100,
+		},
+	}
 	ctx := agent.NewInvocationContext(context.Background(), inv).Context
-	_, err = mgr.AfterToolMessages(ctx, &pluginpkg.AfterToolMessagesArgs{
-		Invocation: inv,
-		ToolResultMessages: []model.Message{{
-			Role:    model.RoleTool,
-			ToolID:  "call",
-			Content: "payload",
-		}},
-	})
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("same user prompt")},
+	}
+
+	for i := 0; i < 2; i++ {
+		_, err = mgr.ModelCallbacks().RunBeforeModel(
+			ctx,
+			&model.BeforeModelArgs{Request: req},
+		)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, ingestCount)
+	assert.Zero(t, compactCount)
+
+	req.Messages = []model.Message{model.NewUserMessage("HEARTBEAT check")}
+	_, err = mgr.ModelCallbacks().RunBeforeModel(
+		ctx,
+		&model.BeforeModelArgs{Request: req},
+	)
 	require.NoError(t, err)
-	assert.True(t, gotAfter)
-	assert.NoFileExists(t, filepath.Join(workDir, ".tdai-offload"))
-	assert.NoDirExists(t, filepath.Join(workDir, ".tdai-offload"))
+	assert.Equal(t, 1, ingestCount, "internal prompts must not trigger L1.5")
 }
 
-func TestContextOffloadPlugin_UsesOffloadGatewayOverride(t *testing.T) {
-	var gotAuth string
-	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("primary gateway should not receive offload request: %s", r.URL.Path)
+func TestContextOffloadPlugin_CompactionFailuresLeaveContextUnchanged(t *testing.T) {
+	tests := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "orphan tool result",
+			data: map[string]any{
+				"messages": []map[string]any{{
+					"role":         "tool",
+					"tool_call_id": "missing",
+					"content":      "orphan",
+				}},
+			},
+		},
+		{
+			name: "invalid role",
+			data: map[string]any{
+				"messages": []map[string]any{{
+					"role": "unknown", "content": "invalid",
+				}},
+			},
+		},
+		{
+			name: "empty messages",
+			data: map[string]any{"messages": []any{}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case pathOffloadIngest:
+					writeOffloadResponse(t, w, map[string]any{"accepted": true})
+				case pathOffloadCompact:
+					writeOffloadResponse(t, w, tt.data)
+				default:
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+				Enabled:         true,
+				ServiceID:       testOffloadServiceID,
+				CompactionRatio: 0.1,
+				TokenCounter:    fixedOffloadTokenCounter{tokens: 100},
+			})
+			defer svc.Close()
+			mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
+			require.NoError(t, err)
+			inv := &agent.Invocation{
+				Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+				RunOptions: agent.RunOptions{
+					ModelContextWindow: 100,
+				},
+			}
+			ctx := agent.NewInvocationContext(context.Background(), inv).Context
+			req := &model.Request{
+				Messages: []model.Message{model.NewUserMessage("original prompt")},
+			}
+
+			_, err = mgr.ModelCallbacks().RunBeforeModel(
+				ctx,
+				&model.BeforeModelArgs{Request: req},
+			)
+			require.NoError(t, err)
+			require.Len(t, req.Messages, 1)
+			assert.Equal(t, "original prompt", req.Messages[0].Content)
+		})
+	}
+}
+
+func TestContextOffloadPlugin_HTTPAndEnvelopeFailuresAreBestEffort(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "http error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "application error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"code": 42, "message": "rejected", "request_id": "req-42",
+				})
+			},
+		},
+		{
+			name: "missing data",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"code": 0, "message": "ok", "request_id": "req-empty",
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+			plugin := NewContextOffloadPlugin(
+				WithGatewayURL(server.URL),
+				WithAPIKey(testOffloadAPIKey),
+				WithContextOffload(ContextOffloadConfig{
+					Enabled:         true,
+					ServiceID:       testOffloadServiceID,
+					CompactionRatio: 0.1,
+					TokenCounter:    fixedOffloadTokenCounter{tokens: 100},
+				}),
+			)
+			assert.Equal(t, contextOffloadPluginName, plugin.Name())
+			mgr, err := pluginpkg.NewManager(plugin)
+			require.NoError(t, err)
+			inv := &agent.Invocation{
+				Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+				RunOptions: agent.RunOptions{
+					ModelContextWindow: 100,
+				},
+			}
+			ctx := agent.NewInvocationContext(context.Background(), inv).Context
+			req := &model.Request{
+				Messages: []model.Message{model.NewUserMessage("original prompt")},
+			}
+
+			_, err = mgr.ModelCallbacks().RunBeforeModel(
+				ctx,
+				&model.BeforeModelArgs{Request: req},
+			)
+			require.NoError(t, err)
+			require.Len(t, req.Messages, 1)
+			assert.Equal(t, "original prompt", req.Messages[0].Content)
+		})
+	}
+}
+
+func TestContextOffloadConfigurationValidationAndOverride(t *testing.T) {
+	_, err := NewService(
+		WithContextOffload(ContextOffloadConfig{
+			Enabled:   true,
+			ServiceID: testOffloadServiceID,
+		}),
+	)
+	require.ErrorContains(t, err, "API key is required")
+
+	_, err = NewService(
+		WithAPIKey(testOffloadAPIKey),
+		WithContextOffload(ContextOffloadConfig{Enabled: true}),
+	)
+	require.ErrorContains(t, err, "service ID is required")
+
+	for _, ratio := range []float64{2.1, math.NaN(), math.Inf(1)} {
+		_, err = NewService(
+			WithAPIKey(testOffloadAPIKey),
+			WithContextOffload(ContextOffloadConfig{
+				Enabled:         true,
+				ServiceID:       testOffloadServiceID,
+				CompactionRatio: ratio,
+			}),
+		)
+		require.ErrorContains(t, err, "compaction ratio")
+	}
+
+	primary := httptest.NewServer(http.HandlerFunc(func(
+		http.ResponseWriter,
+		*http.Request,
+	) {
+		t.Fatal("primary gateway must not receive offload traffic")
 	}))
 	defer primary.Close()
+	var gotAuth string
 	offload := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, pathOffloadAfterTool, r.URL.Path)
+		require.Equal(t, pathOffloadIngest, r.URL.Path)
 		gotAuth = r.Header.Get(httpHeaderAuthorization)
-		_ = json.NewEncoder(w).Encode(offloadAfterToolMessagesResponse{
-			ToolResultMessages: []model.Message{model.NewToolMessage("call", "tool", "offloaded")},
-		})
+		writeOffloadResponse(t, w, map[string]any{"accepted": true})
 	}))
 	defer offload.Close()
 
@@ -190,332 +432,319 @@ func TestContextOffloadPlugin_UsesOffloadGatewayOverride(t *testing.T) {
 		WithContextOffload(ContextOffloadConfig{
 			Enabled:    true,
 			GatewayURL: offload.URL,
-			APIKey:     "offload-key",
+			APIKey:     testOffloadAPIKey,
+			ServiceID:  testOffloadServiceID,
 		}),
 	)
 	require.NoError(t, err)
 	defer svc.Close()
-
 	mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
 	require.NoError(t, err)
-	sess := &session.Session{ID: "sess", AppName: "app", UserID: "user"}
-	inv := &agent.Invocation{Session: sess}
-	rsp, err := mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+	inv := &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+	}
+	_, err = mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
 		Invocation: inv,
 		ToolResultMessages: []model.Message{
 			model.NewToolMessage("call", "tool", "payload"),
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, rsp)
-	require.Len(t, rsp.ToolResultMessages, 1)
-	assert.Equal(t, "offloaded", rsp.ToolResultMessages[0].Content)
-	assert.Equal(t, "Bearer offload-key", gotAuth)
+	assert.Equal(t, "Bearer "+testOffloadAPIKey, gotAuth)
 }
 
-func TestContextOffloadPlugin_GatewayFailuresLeaveContextUnchanged(t *testing.T) {
+func TestContextOffloadReadRefToolUsesV2Contract(t *testing.T) {
+	var got offloadReadRefRequest
+	var gotHeaders http.Header
+	matchFound := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "boom", http.StatusInternalServerError)
+		require.Equal(t, pathOffloadReadRef, r.URL.Path)
+		gotHeaders = r.Header.Clone()
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		writeOffloadResponse(t, w, map[string]any{
+			"result_ref":  "offload/session/refs/call-1.md",
+			"content":     "matching evidence",
+			"truncated":   true,
+			"match_found": matchFound,
+		})
 	}))
 	defer server.Close()
 
-	plugin := NewContextOffloadPlugin(
-		WithGatewayURL(server.URL),
-		WithContextOffload(ContextOffloadConfig{Enabled: true}),
-	)
-	assert.Equal(t, contextOffloadPluginName, plugin.Name())
-	mgr, err := pluginpkg.NewManager(plugin)
-	require.NoError(t, err)
-
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:   true,
+		ServiceID: testOffloadServiceID,
+	})
+	defer svc.Close()
+	assert.Len(t, svc.Tools(), 2)
+	readRef := findCallableTool(t, svc.Tools(), "tdai_read_offload_ref")
 	sess := &session.Session{ID: "sess", AppName: "app", UserID: "user"}
-	inv := &agent.Invocation{Session: sess}
-	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: sess,
+	}).Context
 
-	afterRsp, err := mgr.AfterToolMessages(ctx, &pluginpkg.AfterToolMessagesArgs{
-		Invocation: inv,
-		ToolResultMessages: []model.Message{
-			model.NewToolMessage("call", "tool", "payload"),
-		},
+	raw, err := callToolJSON(t, readRef, ctx, &readOffloadRefToolRequest{
+		ResultRef: " offload/session/refs/call-1.md ",
+		Query:     " failure ",
+		MaxTokens: 800,
 	})
 	require.NoError(t, err)
-	assert.Nil(t, afterRsp)
-
-	req := &model.Request{Messages: []model.Message{model.NewUserMessage("original")}}
-	_, err = mgr.ModelCallbacks().RunBeforeModel(ctx, &model.BeforeModelArgs{Request: req})
-	require.NoError(t, err)
-	require.Len(t, req.Messages, 1)
-	assert.Equal(t, "original", req.Messages[0].Content)
+	rsp := raw.(*readOffloadRefToolResponse)
+	assert.Equal(t, "matching evidence", rsp.Content)
+	assert.True(t, rsp.Truncated)
+	require.NotNil(t, rsp.MatchFound)
+	assert.True(t, *rsp.MatchFound)
+	assert.Equal(t, defaultSessionKey(sess), got.SessionID)
+	assert.Equal(t, "offload/session/refs/call-1.md", got.ResultRef)
+	assert.Equal(t, "failure", got.Query)
+	assert.Nil(t, got.StartLine)
+	assert.Nil(t, got.EndLine)
+	require.NotNil(t, got.MaxTokens)
+	assert.Equal(t, 800, *got.MaxTokens)
+	assert.Equal(t, "Bearer "+testOffloadAPIKey, gotHeaders.Get(httpHeaderAuthorization))
+	assert.Equal(t, testOffloadServiceID, gotHeaders.Get(httpHeaderServiceID))
 }
 
-func TestContextOffloadPlugin_BeforeModelResponseShapes(t *testing.T) {
+func TestContextOffloadReadRefToolValidation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:   true,
+		ServiceID: testOffloadServiceID,
+	})
+	defer svc.Close()
+	readRef := findCallableTool(t, svc.Tools(), "tdai_read_offload_ref")
+	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+	}).Context
+
 	tests := []struct {
-		name        string
-		response    offloadBeforeModelResponse
-		wantContent string
+		name string
+		req  *readOffloadRefToolRequest
+		want string
 	}{
+		{name: "missing ref", req: &readOffloadRefToolRequest{}, want: "result_ref is required"},
 		{
-			name: "messages",
-			response: offloadBeforeModelResponse{
-				Messages: []model.Message{model.NewSystemMessage("from messages")},
+			name: "query and lines",
+			req: &readOffloadRefToolRequest{
+				ResultRef: "offload/s/refs/a.md", Query: "x", StartLine: 1,
 			},
-			wantContent: "from messages",
+			want: "query cannot be combined",
 		},
 		{
-			name: "request messages override",
-			response: offloadBeforeModelResponse{
-				Messages: []model.Message{model.NewSystemMessage("ignored")},
-				Request: &model.Request{
-					Messages: []model.Message{model.NewSystemMessage("from request")},
-				},
+			name: "negative",
+			req: &readOffloadRefToolRequest{
+				ResultRef: "offload/s/refs/a.md", StartLine: -1,
 			},
-			wantContent: "from request",
+			want: "supported ranges",
 		},
 		{
-			name: "orphan tool result ignored",
-			response: offloadBeforeModelResponse{
-				Messages: []model.Message{
-					model.NewToolMessage("missing-call", "tool", "orphan"),
-				},
+			name: "token limit",
+			req: &readOffloadRefToolRequest{
+				ResultRef: "offload/s/refs/a.md", MaxTokens: 4097,
 			},
-			wantContent: "original",
+			want: "supported ranges",
 		},
 		{
-			name:        "empty response ignored",
-			response:    offloadBeforeModelResponse{},
-			wantContent: "original",
+			name: "reversed lines",
+			req: &readOffloadRefToolRequest{
+				ResultRef: "offload/s/refs/a.md", StartLine: 3, EndLine: 2,
+			},
+			want: "must not exceed",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, pathOffloadBeforeModel, r.URL.Path)
-				_ = json.NewEncoder(w).Encode(tt.response)
-			}))
-			defer server.Close()
-
-			svc, err := NewService(
-				WithGatewayURL(server.URL),
-				WithContextOffload(ContextOffloadConfig{Enabled: true}),
-			)
-			require.NoError(t, err)
-			defer svc.Close()
-
-			mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
-			require.NoError(t, err)
-			ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
-				Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
-			}).Context
-			req := &model.Request{Messages: []model.Message{model.NewUserMessage("original")}}
-
-			_, err = mgr.ModelCallbacks().RunBeforeModel(ctx, &model.BeforeModelArgs{Request: req})
-			require.NoError(t, err)
-			require.Len(t, req.Messages, 1)
-			assert.Equal(t, tt.wantContent, req.Messages[0].Content)
+			_, err := callToolJSON(t, readRef, ctx, tt.req)
+			require.ErrorContains(t, err, tt.want)
 		})
 	}
+
+	_, err := callToolJSON(
+		t,
+		readRef,
+		context.Background(),
+		&readOffloadRefToolRequest{ResultRef: "offload/s/refs/a.md"},
+	)
+	require.ErrorContains(t, err, "invocation session is required")
+	_, err = callToolJSON(
+		t,
+		readRef,
+		ctx,
+		&readOffloadRefToolRequest{ResultRef: "offload/s/refs/a.md"},
+	)
+	require.Error(t, err)
 }
 
-func TestContextOffloadPlugin_SkipsInvalidInputs(t *testing.T) {
-	mgr, err := pluginpkg.NewManager(NewContextOffloadPlugin(
-		WithContextOffload(ContextOffloadConfig{Enabled: true}),
-	))
-	require.NoError(t, err)
+func TestContextOffloadHelpers(t *testing.T) {
+	assert.Equal(t, map[string]any{}, offloadToolParams(nil))
+	assert.Equal(t, "not-json", offloadToolParams([]byte("not-json")))
 
-	afterRsp, err := mgr.AfterToolMessages(context.Background(), nil)
-	require.NoError(t, err)
-	assert.Nil(t, afterRsp)
+	part := "part result"
+	assert.Equal(t, []model.ContentPart{{
+		Type: model.ContentTypeText,
+		Text: &part,
+	}}, offloadToolResult(model.Message{
+		ContentParts: []model.ContentPart{{
+			Type: model.ContentTypeText,
+			Text: &part,
+		}},
+	}))
 
-	afterRsp, err = mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
-		Invocation: &agent.Invocation{
-			Session: &session.Session{ID: "sess", AppName: "app"},
-		},
+	results := newOffloadToolPairs(nil, []model.Message{
+		model.NewToolMessage("call", "fallback-tool", "result"),
+		{Role: model.RoleTool},
 	})
-	require.NoError(t, err)
-	assert.Nil(t, afterRsp)
+	require.Len(t, results, 1)
+	assert.Equal(t, "fallback-tool", results[0].ToolName)
 
-	callbacks := mgr.ModelCallbacks()
-	_, err = callbacks.RunBeforeModel(context.Background(), &model.BeforeModelArgs{Request: nil})
-	require.NoError(t, err)
+	longPrompt := strings.Repeat("界", maxOffloadPromptRunes+10)
+	messages := []model.Message{
+		model.NewUserMessage("earlier user context"),
+		model.NewAssistantMessage("an assistant response long enough"),
+		model.NewUserMessage(longPrompt),
+	}
+	prompt, recent := offloadPromptContext(messages)
+	assert.Equal(t, maxOffloadPromptRunes, len([]rune(prompt)))
+	require.Len(t, recent, 2)
+	assert.Equal(t, model.RoleUser, recent[0].Role)
+	assert.Equal(t, model.RoleAssistant, recent[1].Role)
 
-	req := &model.Request{Messages: []model.Message{model.NewUserMessage("original")}}
-	_, err = callbacks.RunBeforeModel(context.Background(), &model.BeforeModelArgs{Request: req})
+	total, perMessage, err := countOffloadTokens(
+		context.Background(),
+		fixedOffloadTokenCounter{err: errors.New("count failed")},
+		messages,
+	)
+	require.Error(t, err)
+	assert.Zero(t, total)
+	assert.Nil(t, perMessage)
+
+	message := model.NewToolMessage("call", "tool", "content")
+	wire := newOffloadMessage(message)
+	encoded, err := json.Marshal(wire)
 	require.NoError(t, err)
-	require.Len(t, req.Messages, 1)
-	assert.Equal(t, "original", req.Messages[0].Content)
+	assert.Contains(t, string(encoded), `"tool_call_id":"call"`)
+	assert.NotContains(t, string(encoded), `"tool_id"`)
+	assert.Equal(t, message, wire.modelMessage())
+
+	assert.Equal(t, defaultModelContextWindow, offloadContextWindow(nil))
+	assert.Equal(t, "abc", truncateRunes("abcdef", 3))
+	assert.Equal(t, "abcdef", truncateRunes("abcdef", 0))
+	assert.True(t, isInternalOffloadPrompt("[Inter-session message] ping"))
+	assert.False(t, isInternalOffloadPrompt("normal prompt"))
 }
 
-func TestContextOffloadTools_DelegateToGateway(t *testing.T) {
-	var gotRef offloadReadRefRequest
-	var gotNode offloadReadNodeRequest
-	var gotSearch offloadSearchIndexRequest
-	nodeID := "001-N1"
+func TestContextOffloadPlugin_SkipsInvalidInputsAndFallsBackTokenCounter(t *testing.T) {
+	var compact offloadCompactRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case pathOffloadReadRef:
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&gotRef))
-			_ = json.NewEncoder(w).Encode(offloadReadRefResponse{
-				ResultRef: "refs/a.md",
-				Content:   "raw evidence",
-				Truncated: true,
-			})
-		case pathOffloadReadNode:
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&gotNode))
-			_ = json.NewEncoder(w).Encode(offloadReadNodeResponse{
-				NodeID: nodeID,
-				Entries: []offloadIndexEntry{{
-					NodeID:     &nodeID,
-					Summary:    "node summary",
-					ResultRef:  "refs/a.md",
-					ToolCallID: "call-1",
+		case pathOffloadIngest:
+			writeOffloadResponse(t, w, map[string]any{"accepted": true})
+		case pathOffloadCompact:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&compact))
+			writeOffloadResponse(t, w, map[string]any{
+				"messages": []map[string]any{{
+					"role": "user", "content": "compacted",
 				}},
-			})
-		case pathOffloadSearchIndex:
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&gotSearch))
-			_ = json.NewEncoder(w).Encode(offloadSearchIndexResponse{
-				Query: "needle",
-				Entries: []offloadIndexEntry{{
-					Summary:   "matched",
-					ResultRef: "refs/b.md",
-				}},
-				Total: 1,
 			})
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 	}))
 	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithContextOffload(ContextOffloadConfig{Enabled: true}),
-	)
-	require.NoError(t, err)
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:         true,
+		ServiceID:       testOffloadServiceID,
+		CompactionRatio: 0.000001,
+		TokenCounter: fixedOffloadTokenCounter{
+			err: errors.New("counter unavailable"),
+		},
+	})
 	defer svc.Close()
-
-	sess := &session.Session{ID: "sess", AppName: "app", UserID: "user"}
-	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
-		Session:   sess,
-		AgentName: "agent",
-	}).Context
-
-	readRef := findCallableTool(t, svc.Tools(), "tdai_read_offload_ref")
-	refRsp, err := callToolJSON(t, readRef, ctx, &readOffloadRefToolRequest{ResultRef: "refs/a.md"})
-	require.NoError(t, err)
-	require.IsType(t, &readOffloadRefToolResponse{}, refRsp)
-	assert.Equal(t, "raw evidence", refRsp.(*readOffloadRefToolResponse).Content)
-	assert.True(t, refRsp.(*readOffloadRefToolResponse).Truncated)
-	assert.Equal(t, "refs/a.md", gotRef.ResultRef)
-	assert.Equal(t, "app", gotRef.Scope.AppName)
-	assert.Equal(t, "agent", gotRef.Scope.AgentName)
-
-	readNode := findCallableTool(t, svc.Tools(), "tdai_read_offload_node")
-	nodeRsp, err := callToolJSON(t, readNode, ctx, &readOffloadNodeToolRequest{NodeID: nodeID})
-	require.NoError(t, err)
-	require.IsType(t, &readOffloadNodeToolResponse{}, nodeRsp)
-	assert.Equal(t, "node summary", nodeRsp.(*readOffloadNodeToolResponse).Entries[0].Summary)
-	assert.Equal(t, nodeID, gotNode.NodeID)
-
-	search := findCallableTool(t, svc.Tools(), "tdai_search_offload_index")
-	searchRsp, err := callToolJSON(t, search, ctx, &searchOffloadIndexToolRequest{Query: "needle", Limit: 100})
-	require.NoError(t, err)
-	require.IsType(t, &searchOffloadIndexToolResponse{}, searchRsp)
-	assert.Equal(t, 1, searchRsp.(*searchOffloadIndexToolResponse).Total)
-	assert.Equal(t, "needle", gotSearch.Query)
-	assert.Equal(t, maxSearchLimit, gotSearch.Limit)
-}
-
-func TestContextOffloadTools_ErrorPaths(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "boom", http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	svc, err := NewService(
-		WithGatewayURL(server.URL),
-		WithContextOffload(ContextOffloadConfig{Enabled: true}),
-	)
-	require.NoError(t, err)
-	defer svc.Close()
-
-	ctx := agent.NewInvocationContext(context.Background(), &agent.Invocation{
-		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
-	}).Context
-
-	readRef := findCallableTool(t, svc.Tools(), "tdai_read_offload_ref")
-	_, err = callToolJSON(t, readRef, ctx, &readOffloadRefToolRequest{})
-	require.ErrorContains(t, err, "result_ref is required")
-	_, err = callToolJSON(t, readRef, context.Background(), &readOffloadRefToolRequest{ResultRef: "refs/a.md"})
-	require.ErrorContains(t, err, "invocation session is required")
-	_, err = callToolJSON(t, readRef, ctx, &readOffloadRefToolRequest{ResultRef: "refs/a.md"})
-	require.Error(t, err)
-
-	readNode := findCallableTool(t, svc.Tools(), "tdai_read_offload_node")
-	_, err = callToolJSON(t, readNode, ctx, &readOffloadNodeToolRequest{})
-	require.ErrorContains(t, err, "node_id is required")
-	_, err = callToolJSON(t, readNode, ctx, &readOffloadNodeToolRequest{NodeID: "node"})
-	require.Error(t, err)
-
-	search := findCallableTool(t, svc.Tools(), "tdai_search_offload_index")
-	_, err = callToolJSON(t, search, ctx, &searchOffloadIndexToolRequest{})
-	require.ErrorContains(t, err, "query is required")
-	_, err = callToolJSON(t, search, ctx, &searchOffloadIndexToolRequest{Query: "needle"})
-	require.Error(t, err)
-}
-
-func TestContextOffloadPlugin_DisabledByDefault(t *testing.T) {
-	svc, err := NewService()
-	require.NoError(t, err)
-	defer svc.Close()
-
 	mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
 	require.NoError(t, err)
-	after, err := mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{})
+
+	after, err := mgr.AfterToolMessages(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Nil(t, after)
-	assert.Nil(t, findTool(svc.Tools(), "tdai_read_offload_ref"))
+	after, err = mgr.AfterToolMessages(context.Background(), &pluginpkg.AfterToolMessagesArgs{
+		Invocation: &agent.Invocation{
+			Session: &session.Session{ID: "sess", AppName: "app"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, after)
+
+	callbacks := mgr.ModelCallbacks()
+	_, err = callbacks.RunBeforeModel(
+		context.Background(),
+		&model.BeforeModelArgs{Request: nil},
+	)
+	require.NoError(t, err)
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("original prompt")},
+	}
+	_, err = callbacks.RunBeforeModel(
+		context.Background(),
+		&model.BeforeModelArgs{Request: req},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "original prompt", req.Messages[0].Content)
+
+	inv := &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+		RunOptions: agent.RunOptions{
+			ModelContextWindow: 1,
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	_, err = callbacks.RunBeforeModel(ctx, &model.BeforeModelArgs{Request: req})
+	require.NoError(t, err)
+	assert.Positive(t, compact.TotalTokens)
+	assert.Equal(t, "compacted", req.Messages[0].Content)
 }
 
-func TestContextOffloadHelpers(t *testing.T) {
-	assert.NotNil(t, (*Service)(nil).ContextOffloadPlugin())
-
-	standalone := &contextOffloadPlugin{opts: Options{}}
-	client, err := standalone.contextOffloadClient()
-	require.Error(t, err)
-	assert.Nil(t, client)
-
-	client, err = (*contextOffloadPlugin)(nil).contextOffloadClient()
+func newOffloadTestService(
+	t *testing.T,
+	gatewayURL string,
+	config ContextOffloadConfig,
+) *Service {
+	t.Helper()
+	svc, err := NewService(
+		WithGatewayURL(gatewayURL),
+		WithAPIKey(testOffloadAPIKey),
+		WithContextOffload(config),
+	)
 	require.NoError(t, err)
-	assert.Nil(t, client)
+	return svc
+}
 
-	assert.Nil(t, cloneModelRequest(nil))
-	assistant := model.NewAssistantMessage("")
-	assistant.ToolCalls = []model.ToolCall{{ID: "call-1"}}
-	assert.False(t, hasOrphanToolResults([]model.Message{
-		assistant,
-		{Role: model.RoleTool, ToolID: "call-1"},
+func writeOffloadResponse(t *testing.T, w http.ResponseWriter, data any) {
+	t.Helper()
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		"code":       0,
+		"message":    "ok",
+		"request_id": "req-test",
+		"data":       data,
 	}))
-	assert.False(t, hasOrphanToolResults([]model.Message{
-		{Role: model.RoleTool},
-	}))
-
-	var rsp offloadAfterToolMessagesResponse
-	require.NoError(t, json.Unmarshal([]byte(`{"toolResultMessages":[{"role":"tool","tool_id":"call","content":"camel"}]}`), &rsp))
-	require.Len(t, rsp.ToolResultMessages, 1)
-	assert.Equal(t, "camel", rsp.ToolResultMessages[0].Content)
-	require.Error(t, json.Unmarshal([]byte(`{`), &rsp))
 }
 
 func findTool(tools []tool.Tool, name string) tool.Tool {
-	for _, t := range tools {
-		if t != nil && t.Declaration() != nil && t.Declaration().Name == name {
-			return t
+	for _, candidate := range tools {
+		if candidate != nil && candidate.Declaration() != nil &&
+			candidate.Declaration().Name == name {
+			return candidate
 		}
 	}
 	return nil
 }
 
-func findCallableTool(t *testing.T, tools []tool.Tool, name string) tool.CallableTool {
+func findCallableTool(
+	t *testing.T,
+	tools []tool.Tool,
+	name string,
+) tool.CallableTool {
 	t.Helper()
 	found := findTool(tools, name)
 	require.NotNil(t, found, "tool %s", name)
@@ -524,9 +753,14 @@ func findCallableTool(t *testing.T, tools []tool.Tool, name string) tool.Callabl
 	return callable
 }
 
-func callToolJSON(t *testing.T, callable tool.CallableTool, ctx context.Context, req any) (any, error) {
+func callToolJSON(
+	t *testing.T,
+	callable tool.CallableTool,
+	ctx context.Context,
+	req any,
+) (any, error) {
 	t.Helper()
-	b, err := json.Marshal(req)
+	body, err := json.Marshal(req)
 	require.NoError(t, err)
-	return callable.Call(ctx, b)
+	return callable.Call(ctx, body)
 }

--- a/memory/tencentdb/context_offload_test.go
+++ b/memory/tencentdb/context_offload_test.go
@@ -235,13 +235,73 @@ func TestContextOffloadPlugin_SkipsBelowThresholdAndDeduplicatesPrompt(t *testin
 	assert.Equal(t, 1, ingestCount)
 	assert.Zero(t, compactCount)
 
-	req.Messages = []model.Message{model.NewUserMessage("HEARTBEAT check")}
+	req.Messages = []model.Message{model.NewUserMessage(
+		"debug the heartbeat timeout",
+	)}
 	_, err = mgr.ModelCallbacks().RunBeforeModel(
 		ctx,
 		&model.BeforeModelArgs{Request: req},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, 1, ingestCount, "internal prompts must not trigger L1.5")
+	assert.Equal(t, 2, ingestCount, "user heartbeat requests must trigger L1.5")
+
+	req.Messages = []model.Message{model.NewUserMessage(
+		"Read HEARTBEAT.md if it exists (workspace context).",
+	)}
+	_, err = mgr.ModelCallbacks().RunBeforeModel(
+		ctx,
+		&model.BeforeModelArgs{Request: req},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, ingestCount, "internal prompts must not trigger L1.5")
+}
+
+func TestContextOffloadPlugin_PreservesUserHeartbeatRequests(t *testing.T) {
+	var ingests []offloadIngestRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, pathOffloadIngest, r.URL.Path)
+		var req offloadIngestRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		ingests = append(ingests, req)
+		writeOffloadResponse(t, w, map[string]any{"accepted": true})
+	}))
+	defer server.Close()
+
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:         true,
+		ServiceID:       testOffloadServiceID,
+		CompactionRatio: 2,
+		TokenCounter:    fixedOffloadTokenCounter{tokens: 1},
+	})
+	defer svc.Close()
+	mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
+	require.NoError(t, err)
+	inv := &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+		RunOptions: agent.RunOptions{
+			ModelContextWindow: 1000,
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("debug the heartbeat timeout"),
+		model.NewAssistantMessage("the heartbeat logs show repeated timeouts"),
+		model.NewUserMessage("what should I check next?"),
+	}}
+
+	_, err = mgr.ModelCallbacks().RunBeforeModel(
+		ctx,
+		&model.BeforeModelArgs{Request: req},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, ingests, 1)
+	assert.Equal(t, "what should I check next?", ingests[0].Prompt)
+	require.Len(t, ingests[0].RecentMessages, 2)
+	assert.Equal(t, "debug the heartbeat timeout",
+		ingests[0].RecentMessages[0].Content)
+	assert.Equal(t, "the heartbeat logs show repeated timeouts",
+		ingests[0].RecentMessages[1].Content)
 }
 
 func TestContextOffloadPlugin_CompactionFailuresLeaveContextUnchanged(t *testing.T) {
@@ -632,6 +692,11 @@ func TestContextOffloadHelpers(t *testing.T) {
 	assert.Equal(t, "abc", truncateRunes("abcdef", 3))
 	assert.Equal(t, "abcdef", truncateRunes("abcdef", 0))
 	assert.True(t, isInternalOffloadPrompt("[Inter-session message] ping"))
+	assert.True(t, isInternalOffloadPrompt(
+		"Read HEARTBEAT.md if it exists (workspace context).",
+	))
+	assert.True(t, isInternalOffloadPrompt("HEARTBEAT_OK"))
+	assert.False(t, isInternalOffloadPrompt("debug the heartbeat timeout"))
 	assert.False(t, isInternalOffloadPrompt("normal prompt"))
 }
 

--- a/memory/tencentdb/context_offload_test.go
+++ b/memory/tencentdb/context_offload_test.go
@@ -17,7 +17,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -256,6 +258,113 @@ func TestContextOffloadPlugin_SkipsBelowThresholdAndDeduplicatesPrompt(t *testin
 	assert.Equal(t, 2, ingestCount, "internal prompts must not trigger L1.5")
 }
 
+func TestContextOffloadPlugin_RetriesPromptAfterIngestFailure(t *testing.T) {
+	var ingestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, pathOffloadIngest, r.URL.Path)
+		ingestCount++
+		if ingestCount == 1 {
+			http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+			return
+		}
+		writeOffloadResponse(t, w, map[string]any{"accepted": true})
+	}))
+	defer server.Close()
+
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:         true,
+		ServiceID:       testOffloadServiceID,
+		CompactionRatio: 0.5,
+		TokenCounter:    fixedOffloadTokenCounter{tokens: 1},
+	})
+	defer svc.Close()
+	mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
+	require.NoError(t, err)
+	inv := &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+		RunOptions: agent.RunOptions{
+			ModelContextWindow: 100,
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("retry this prompt")},
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err = mgr.ModelCallbacks().RunBeforeModel(
+			ctx,
+			&model.BeforeModelArgs{Request: req},
+		)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 2, ingestCount,
+		"failed ingest must retry and successful ingest must deduplicate")
+}
+
+func TestContextOffloadPlugin_DeduplicatesPromptWhileInFlight(t *testing.T) {
+	var ingestCount atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, pathOffloadIngest, r.URL.Path)
+		if ingestCount.Add(1) == 1 {
+			close(started)
+			<-release
+		}
+		writeOffloadResponse(t, w, map[string]any{"accepted": true})
+	}))
+	defer server.Close()
+
+	svc := newOffloadTestService(t, server.URL, ContextOffloadConfig{
+		Enabled:         true,
+		ServiceID:       testOffloadServiceID,
+		CompactionRatio: 0.5,
+		TokenCounter:    fixedOffloadTokenCounter{tokens: 1},
+	})
+	defer svc.Close()
+	mgr, err := pluginpkg.NewManager(svc.ContextOffloadPlugin())
+	require.NoError(t, err)
+	inv := &agent.Invocation{
+		Session: &session.Session{ID: "sess", AppName: "app", UserID: "user"},
+		RunOptions: agent.RunOptions{
+			ModelContextWindow: 100,
+		},
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv).Context
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("same in-flight prompt")},
+	}
+	callbacks := mgr.ModelCallbacks()
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := callbacks.RunBeforeModel(
+			ctx,
+			&model.BeforeModelArgs{Request: req},
+		)
+		firstDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first ingest")
+	}
+
+	_, err = callbacks.RunBeforeModel(
+		ctx,
+		&model.BeforeModelArgs{Request: req},
+	)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, ingestCount.Load())
+	close(release)
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first ingest to finish")
+	}
+}
+
 func TestContextOffloadPlugin_PreservesUserHeartbeatRequests(t *testing.T) {
 	var ingests []offloadIngestRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -445,7 +554,28 @@ func TestContextOffloadPlugin_HTTPAndEnvelopeFailuresAreBestEffort(t *testing.T)
 }
 
 func TestContextOffloadConfigurationValidationAndOverride(t *testing.T) {
-	_, err := NewService(
+	directContextOffloadOption := func(options *Options) {
+		options.ContextOffload = ContextOffloadConfig{
+			Enabled:   true,
+			ServiceID: testOffloadServiceID,
+		}
+	}
+	svcWithDirectOption, err := NewService(
+		WithAPIKey(testOffloadAPIKey),
+		directContextOffloadOption,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, defaultCompactionRatio,
+		svcWithDirectOption.opts.ContextOffload.CompactionRatio)
+	require.NoError(t, svcWithDirectOption.Close())
+
+	standalone := NewContextOffloadPlugin(directContextOffloadOption)
+	standalonePlugin, ok := standalone.(*contextOffloadPlugin)
+	require.True(t, ok)
+	assert.Equal(t, defaultCompactionRatio,
+		standalonePlugin.opts.ContextOffload.CompactionRatio)
+
+	_, err = NewService(
 		WithContextOffload(ContextOffloadConfig{
 			Enabled:   true,
 			ServiceID: testOffloadServiceID,

--- a/memory/tencentdb/context_offload_types.go
+++ b/memory/tencentdb/context_offload_types.go
@@ -9,120 +9,104 @@
 
 package tencentdb
 
-import (
-	"encoding/json"
-	"strings"
+import "trpc.group/trpc-go/trpc-agent-go/model"
 
-	"trpc.group/trpc-go/trpc-agent-go/model"
-	"trpc.group/trpc-go/trpc-agent-go/session"
-)
-
-type offloadScope struct {
-	AppName    string `json:"app_name"`
-	UserID     string `json:"user_id"`
-	SessionID  string `json:"session_id"`
-	SessionKey string `json:"session_key"`
-	AgentName  string `json:"agent_name"`
+type offloadResponseEnvelope[T any] struct {
+	Code      int    `json:"code"`
+	Message   string `json:"message"`
+	RequestID string `json:"request_id"`
+	Data      *T     `json:"data,omitempty"`
 }
 
-type offloadAfterToolMessagesRequest struct {
-	Scope              offloadScope     `json:"scope"`
-	Messages           []model.Message  `json:"messages,omitempty"`
-	ToolCalls          []model.ToolCall `json:"tool_calls,omitempty"`
-	ToolResultMessages []model.Message  `json:"tool_result_messages"`
+type offloadToolPair struct {
+	ToolName   string `json:"tool_name"`
+	ToolCallID string `json:"tool_call_id"`
+	Params     any    `json:"params"`
+	Result     any    `json:"result"`
+	Error      string `json:"error,omitempty"`
+	Timestamp  string `json:"timestamp"`
+	DurationMS int64  `json:"duration_ms,omitempty"`
 }
 
-type offloadAfterToolMessagesResponse struct {
-	ToolResultMessages []model.Message `json:"tool_result_messages"`
+type offloadRecentMessage struct {
+	Role    model.Role `json:"role"`
+	Content string     `json:"content"`
 }
 
-func (r *offloadAfterToolMessagesResponse) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		ToolResultMessages      []model.Message `json:"tool_result_messages"`
-		ToolResultMessagesCamel []model.Message `json:"toolResultMessages"`
+type offloadIngestRequest struct {
+	SessionID      string                 `json:"session_id"`
+	ToolPairs      []offloadToolPair      `json:"tool_pairs"`
+	Prompt         string                 `json:"prompt,omitempty"`
+	RecentMessages []offloadRecentMessage `json:"recent_messages,omitempty"`
+}
+
+type offloadIngestData struct{}
+
+type offloadCompactRequest struct {
+	SessionID     string           `json:"session_id"`
+	Messages      []offloadMessage `json:"messages"`
+	Ratio         float64          `json:"ratio"`
+	ContextWindow int              `json:"context_window"`
+	TotalTokens   int              `json:"total_tokens"`
+	MessageTokens []int            `json:"message_tokens,omitempty"`
+}
+
+type offloadCompactData struct {
+	Messages []offloadMessage `json:"messages"`
+}
+
+// offloadMessage follows the OpenAI-compatible message shape accepted by the
+// offload v2 compaction endpoint. TencentDB uses tool_call_id for tool result
+// messages, while model.Message calls the same field ToolID.
+type offloadMessage struct {
+	Role               model.Role          `json:"role"`
+	Content            string              `json:"content,omitempty"`
+	ContentParts       []model.ContentPart `json:"content_parts,omitempty"`
+	ToolCallID         string              `json:"tool_call_id,omitempty"`
+	ToolName           string              `json:"tool_name,omitempty"`
+	ToolCalls          []model.ToolCall    `json:"tool_calls,omitempty"`
+	ReasoningContent   string              `json:"reasoning_content,omitempty"`
+	ReasoningSignature string              `json:"reasoning_signature,omitempty"`
+}
+
+func newOffloadMessage(message model.Message) offloadMessage {
+	return offloadMessage{
+		Role:               message.Role,
+		Content:            message.Content,
+		ContentParts:       message.ContentParts,
+		ToolCallID:         message.ToolID,
+		ToolName:           message.ToolName,
+		ToolCalls:          message.ToolCalls,
+		ReasoningContent:   message.ReasoningContent,
+		ReasoningSignature: message.ReasoningSignature,
 	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	r.ToolResultMessages = raw.ToolResultMessages
-	if len(r.ToolResultMessages) == 0 {
-		r.ToolResultMessages = raw.ToolResultMessagesCamel
-	}
-	return nil
 }
 
-type offloadBeforeModelRequest struct {
-	Scope   offloadScope   `json:"scope"`
-	Request *model.Request `json:"request"`
-}
-
-type offloadBeforeModelResponse struct {
-	Request  *model.Request  `json:"request,omitempty"`
-	Messages []model.Message `json:"messages,omitempty"`
+func (m offloadMessage) modelMessage() model.Message {
+	return model.Message{
+		Role:               m.Role,
+		Content:            m.Content,
+		ContentParts:       m.ContentParts,
+		ToolID:             m.ToolCallID,
+		ToolName:           m.ToolName,
+		ToolCalls:          m.ToolCalls,
+		ReasoningContent:   m.ReasoningContent,
+		ReasoningSignature: m.ReasoningSignature,
+	}
 }
 
 type offloadReadRefRequest struct {
-	Scope     offloadScope `json:"scope"`
-	ResultRef string       `json:"result_ref"`
-}
-
-type offloadReadRefResponse struct {
+	SessionID string `json:"session_id"`
 	ResultRef string `json:"result_ref"`
-	Content   string `json:"content"`
-	Truncated bool   `json:"truncated,omitempty"`
+	Query     string `json:"query,omitempty"`
+	StartLine *int   `json:"start_line,omitempty"`
+	EndLine   *int   `json:"end_line,omitempty"`
+	MaxTokens *int   `json:"max_tokens,omitempty"`
 }
 
-type offloadReadNodeRequest struct {
-	Scope  offloadScope `json:"scope"`
-	NodeID string       `json:"node_id"`
-}
-
-type offloadReadNodeResponse struct {
-	NodeID  string              `json:"node_id"`
-	Entries []offloadIndexEntry `json:"entries,omitempty"`
-}
-
-type offloadSearchIndexRequest struct {
-	Scope offloadScope `json:"scope"`
-	Query string       `json:"query"`
-	Limit int          `json:"limit,omitempty"`
-}
-
-type offloadSearchIndexResponse struct {
-	Query   string              `json:"query"`
-	Entries []offloadIndexEntry `json:"entries,omitempty"`
-	Total   int                 `json:"total"`
-}
-
-type offloadIndexEntry struct {
-	Timestamp  string   `json:"timestamp,omitempty"`
-	NodeID     *string  `json:"node_id,omitempty"`
-	ToolCall   string   `json:"tool_call,omitempty"`
-	Summary    string   `json:"summary,omitempty"`
-	ResultRef  string   `json:"result_ref,omitempty"`
-	ToolCallID string   `json:"tool_call_id,omitempty"`
-	SessionKey string   `json:"session_key,omitempty"`
-	Score      float64  `json:"score,omitempty"`
-	Offloaded  any      `json:"offloaded,omitempty"`
-	Keywords   []string `json:"keywords,omitempty"`
-}
-
-func newOffloadScope(opts Options, sess *session.Session, agentName string) offloadScope {
-	scope := offloadScope{
-		SessionKey: defaultSessionKeyWithFunc(opts, sess),
-		AgentName:  strings.TrimSpace(agentName),
-	}
-	if sess != nil {
-		scope.AppName = strings.TrimSpace(sess.AppName)
-		scope.UserID = strings.TrimSpace(sess.UserID)
-		scope.SessionID = strings.TrimSpace(sess.ID)
-	}
-	return scope
-}
-
-func defaultSessionKeyWithFunc(opts Options, sess *session.Session) string {
-	if opts.SessionKeyFunc != nil {
-		return opts.SessionKeyFunc(sess)
-	}
-	return defaultSessionKey(sess)
+type offloadReadRefData struct {
+	ResultRef  string `json:"result_ref"`
+	Content    string `json:"content"`
+	Truncated  bool   `json:"truncated"`
+	MatchFound *bool  `json:"match_found,omitempty"`
 }

--- a/memory/tencentdb/options.go
+++ b/memory/tencentdb/options.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -26,6 +27,7 @@ const (
 	defaultIngestWorkers    = 1
 	defaultIngestQueueSize  = 10
 	defaultIngestJobTimeout = 30 * time.Second
+	defaultCompactionRatio  = 0.5
 )
 
 // SessionKeyFunc maps a framework session to the TencentDB Agent Memory
@@ -34,19 +36,33 @@ const (
 type SessionKeyFunc func(*session.Session) string
 
 // ContextOffloadConfig configures the optional TencentDB Agent Memory context
-// offload gateway integration. Zero values reuse the Service gateway settings.
+// offload v2 integration. GatewayURL and APIKey reuse the Service settings when
+// empty; ServiceID is required when Enabled is true.
 type ContextOffloadConfig struct {
-	// Enabled controls whether ContextOffloadPlugin and companion tools are
+	// Enabled controls whether ContextOffloadPlugin and its companion tool are
 	// active.
 	Enabled bool
 
 	// GatewayURL optionally overrides Service.GatewayURL for context offload
-	// hook and drill-down tool calls. Empty reuses Service.GatewayURL.
+	// API calls. Empty reuses Service.GatewayURL.
 	GatewayURL string
 
 	// APIKey optionally overrides Service.APIKey for context offload calls.
 	// Empty reuses Service.APIKey.
 	APIKey string
+
+	// ServiceID identifies the TencentDB Agent Memory service instance used by
+	// the v2 offload API. It is required when Enabled is true.
+	ServiceID string
+
+	// CompactionRatio is the context-window utilization at which the plugin
+	// asks the gateway to compact model messages. Zero selects the default 0.5;
+	// non-zero values must be in (0, 2].
+	CompactionRatio float64
+
+	// TokenCounter estimates the token metadata required by the gateway
+	// compaction API. Nil uses model.NewSimpleTokenCounter.
+	TokenCounter model.TokenCounter
 }
 
 // Options configures Service.
@@ -101,12 +117,18 @@ func defaultOptions() Options {
 }
 
 func defaultContextOffloadConfig() ContextOffloadConfig {
-	return ContextOffloadConfig{}
+	return ContextOffloadConfig{
+		CompactionRatio: defaultCompactionRatio,
+	}
 }
 
 func normalizeContextOffloadConfig(cfg ContextOffloadConfig) ContextOffloadConfig {
 	cfg.GatewayURL = strings.TrimRight(strings.TrimSpace(cfg.GatewayURL), "/")
 	cfg.APIKey = strings.TrimSpace(cfg.APIKey)
+	cfg.ServiceID = strings.TrimSpace(cfg.ServiceID)
+	if cfg.CompactionRatio == 0 {
+		cfg.CompactionRatio = defaultCompactionRatio
+	}
 	return cfg
 }
 
@@ -248,9 +270,9 @@ func WithToolPrefix(prefix string) Option {
 }
 
 // WithContextOffload configures the explicit TencentDB Agent Memory context
-// offload gateway integration and companion drill-down tools. It is disabled
-// by default; set ContextOffloadConfig.Enabled to true before registering
-// ContextOffloadPlugin.
+// offload v2 integration and its result-reference reader tool. It is disabled
+// by default. When enabling it, configure ContextOffloadConfig.ServiceID and
+// an API key before registering ContextOffloadPlugin.
 func WithContextOffload(cfg ContextOffloadConfig) Option {
 	return func(o *Options) {
 		o.ContextOffload = normalizeContextOffloadConfig(cfg)

--- a/memory/tencentdb/options.go
+++ b/memory/tencentdb/options.go
@@ -60,8 +60,11 @@ type ContextOffloadConfig struct {
 	// non-zero values must be in (0, 2].
 	CompactionRatio float64
 
-	// TokenCounter estimates the token metadata required by the gateway
-	// compaction API. Nil uses model.NewSimpleTokenCounter.
+	// TokenCounter estimates per-message tokens for the local CompactionRatio
+	// trigger and for gateway request metadata. Nil uses
+	// model.NewSimpleTokenCounter. If counting fails or returns a negative
+	// value, the plugin retries token counting with the simple counter for that
+	// model call.
 	TokenCounter model.TokenCounter
 }
 

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -32,7 +32,7 @@ var _ session.Ingestor = (*Service)(nil)
 type Service struct {
 	opts          Options
 	client        *gatewayClient
-	offloadClient *gatewayClient
+	offloadClient *offloadGatewayClient
 
 	queue  chan ingestJob
 	mu     sync.RWMutex
@@ -60,17 +60,9 @@ func NewService(opts ...Option) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	offloadClient := client
-	if options.ContextOffload.Enabled &&
-		(options.ContextOffload.GatewayURL != "" || options.ContextOffload.APIKey != "") {
-		offloadOptions := options
-		if options.ContextOffload.GatewayURL != "" {
-			offloadOptions.GatewayURL = options.ContextOffload.GatewayURL
-		}
-		if options.ContextOffload.APIKey != "" {
-			offloadOptions.APIKey = options.ContextOffload.APIKey
-		}
-		offloadClient, err = newGatewayClient(offloadOptions)
+	var offloadClient *offloadGatewayClient
+	if options.ContextOffload.Enabled {
+		offloadClient, err = newOffloadGatewayClient(options)
 		if err != nil {
 			return nil, err
 		}
@@ -89,14 +81,11 @@ func NewService(opts ...Option) (*Service, error) {
 	return s, nil
 }
 
-func (s *Service) contextOffloadClient() *gatewayClient {
+func (s *Service) contextOffloadClient() *offloadGatewayClient {
 	if s == nil {
 		return nil
 	}
-	if s.offloadClient != nil {
-		return s.offloadClient
-	}
-	return s.client
+	return s.offloadClient
 }
 
 // IngestSession captures the latest user/assistant exchange and transcript

--- a/memory/tencentdb/service.go
+++ b/memory/tencentdb/service.go
@@ -56,6 +56,9 @@ func NewService(opts ...Option) (*Service, error) {
 			opt(&options)
 		}
 	}
+	options.ContextOffload = normalizeContextOffloadConfig(
+		options.ContextOffload,
+	)
 	client, err := newGatewayClient(options)
 	if err != nil {
 		return nil, err

--- a/memory/tencentdb/tools.go
+++ b/memory/tencentdb/tools.go
@@ -52,38 +52,23 @@ type searchConversationsToolResponse struct {
 }
 
 type readOffloadRefToolRequest struct {
-	ResultRef string `json:"result_ref" description:"Relative result reference produced by TencentDB context offload, for example refs/node_20260612_000001.md."`
+	ResultRef string `json:"result_ref" description:"Result reference produced by TencentDB context offload, for example offload/session/refs/call_1.md."`
+	Query     string `json:"query,omitempty" description:"Optional case-insensitive text to locate within the archived result. Cannot be combined with line ranges."`
+	StartLine int    `json:"start_line,omitempty" description:"Optional one-based first line to read. Cannot be combined with query."`
+	EndLine   int    `json:"end_line,omitempty" description:"Optional one-based last line to read. Cannot be combined with query."`
+	MaxTokens int    `json:"max_tokens,omitempty" description:"Maximum response size in tokens. Defaults to 1600, maximum 4096."`
 }
 
 type readOffloadRefToolResponse struct {
-	ResultRef string `json:"result_ref"`
-	Content   string `json:"content"`
-	Truncated bool   `json:"truncated,omitempty"`
-}
-
-type readOffloadNodeToolRequest struct {
-	NodeID string `json:"node_id" description:"Mermaid node_id produced by TencentDB context offload."`
-}
-
-type readOffloadNodeToolResponse struct {
-	NodeID  string              `json:"node_id"`
-	Entries []offloadIndexEntry `json:"entries"`
-}
-
-type searchOffloadIndexToolRequest struct {
-	Query string `json:"query" description:"Keyword query over TencentDB context offload summaries, tool calls, node IDs, and result_refs."`
-	Limit int    `json:"limit,omitempty" description:"Maximum results. Defaults to 5, maximum 20."`
-}
-
-type searchOffloadIndexToolResponse struct {
-	Query   string              `json:"query"`
-	Entries []offloadIndexEntry `json:"entries"`
-	Total   int                 `json:"total"`
+	ResultRef  string `json:"result_ref"`
+	Content    string `json:"content"`
+	Truncated  bool   `json:"truncated"`
+	MatchFound *bool  `json:"match_found,omitempty"`
 }
 
 func (s *Service) buildTools() []tool.Tool {
-	out := make([]tool.Tool, 0, 5)
-	seen := make(map[string]struct{}, 5)
+	out := make([]tool.Tool, 0, 3)
+	seen := make(map[string]struct{}, 3)
 	add := func(t tool.Tool) {
 		if t == nil || t.Declaration() == nil {
 			return
@@ -107,8 +92,6 @@ func (s *Service) buildTools() []tool.Tool {
 	}
 	if s.opts.ContextOffload.Enabled {
 		add(s.newReadOffloadRefTool(s.nativeToolName("read_offload_ref")))
-		add(s.newReadOffloadNodeTool(s.nativeToolName("read_offload_node")))
-		add(s.newSearchOffloadIndexTool(s.nativeToolName("search_offload_index")))
 	}
 	return out
 }
@@ -199,6 +182,21 @@ func (s *Service) newReadOffloadRefTool(name string) tool.CallableTool {
 		if req == nil || strings.TrimSpace(req.ResultRef) == "" {
 			return nil, fmt.Errorf("%s: result_ref is required", name)
 		}
+		query := strings.TrimSpace(req.Query)
+		if query != "" && (req.StartLine != 0 || req.EndLine != 0) {
+			return nil, fmt.Errorf("%s: query cannot be combined with line ranges", name)
+		}
+		if req.StartLine < 0 || req.EndLine < 0 ||
+			req.MaxTokens < 0 || req.MaxTokens > 4096 {
+			return nil, fmt.Errorf(
+				"%s: start_line, end_line, and max_tokens must be within the supported ranges",
+				name,
+			)
+		}
+		if req.StartLine > 0 && req.EndLine > 0 &&
+			req.StartLine > req.EndLine {
+			return nil, fmt.Errorf("%s: start_line must not exceed end_line", name)
+		}
 		inv, err := currentInvocation(ctx)
 		if err != nil {
 			return nil, err
@@ -207,9 +205,13 @@ func (s *Service) newReadOffloadRefTool(name string) tool.CallableTool {
 		if client == nil {
 			return nil, fmt.Errorf("%s: context offload gateway is unavailable", name)
 		}
-		rsp, err := client.offloadReadRef(ctx, offloadReadRefRequest{
-			Scope:     newOffloadScope(s.opts, inv.Session, inv.AgentName),
+		rsp, err := client.readRef(ctx, offloadReadRefRequest{
+			SessionID: s.sessionKey(inv.Session),
 			ResultRef: strings.TrimSpace(req.ResultRef),
+			Query:     query,
+			StartLine: optionalPositiveInt(req.StartLine),
+			EndLine:   optionalPositiveInt(req.EndLine),
+			MaxTokens: optionalPositiveInt(req.MaxTokens),
 		})
 		if err != nil {
 			return nil, err
@@ -220,9 +222,10 @@ func (s *Service) newReadOffloadRefTool(name string) tool.CallableTool {
 			}, nil
 		}
 		return &readOffloadRefToolResponse{
-			ResultRef: rsp.ResultRef,
-			Content:   rsp.Content,
-			Truncated: rsp.Truncated,
+			ResultRef:  rsp.ResultRef,
+			Content:    rsp.Content,
+			Truncated:  rsp.Truncated,
+			MatchFound: rsp.MatchFound,
 		}, nil
 	}
 	return function.NewFunctionTool(
@@ -233,81 +236,11 @@ func (s *Service) newReadOffloadRefTool(name string) tool.CallableTool {
 	)
 }
 
-func (s *Service) newReadOffloadNodeTool(name string) tool.CallableTool {
-	fn := func(ctx context.Context, req *readOffloadNodeToolRequest) (*readOffloadNodeToolResponse, error) {
-		if req == nil || strings.TrimSpace(req.NodeID) == "" {
-			return nil, fmt.Errorf("%s: node_id is required", name)
-		}
-		inv, err := currentInvocation(ctx)
-		if err != nil {
-			return nil, err
-		}
-		client := s.contextOffloadClient()
-		if client == nil {
-			return nil, fmt.Errorf("%s: context offload gateway is unavailable", name)
-		}
-		nodeID := strings.TrimSpace(req.NodeID)
-		rsp, err := client.offloadReadNode(ctx, offloadReadNodeRequest{
-			Scope:  newOffloadScope(s.opts, inv.Session, inv.AgentName),
-			NodeID: nodeID,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if rsp == nil {
-			return &readOffloadNodeToolResponse{NodeID: nodeID}, nil
-		}
-		return &readOffloadNodeToolResponse{
-			NodeID:  rsp.NodeID,
-			Entries: rsp.Entries,
-		}, nil
+func optionalPositiveInt(value int) *int {
+	if value <= 0 {
+		return nil
 	}
-	return function.NewFunctionTool(
-		fn,
-		function.WithName(name),
-		function.WithDescription("Read TencentDB context offload entries mapped to a Mermaid node_id. "+
-			"Use this to drill down from the active task Mermaid graph."),
-	)
-}
-
-func (s *Service) newSearchOffloadIndexTool(name string) tool.CallableTool {
-	fn := func(ctx context.Context, req *searchOffloadIndexToolRequest) (*searchOffloadIndexToolResponse, error) {
-		if req == nil || strings.TrimSpace(req.Query) == "" {
-			return nil, fmt.Errorf("%s: query is required", name)
-		}
-		inv, err := currentInvocation(ctx)
-		if err != nil {
-			return nil, err
-		}
-		client := s.contextOffloadClient()
-		if client == nil {
-			return nil, fmt.Errorf("%s: context offload gateway is unavailable", name)
-		}
-		query := strings.TrimSpace(req.Query)
-		limit := normalizeLimit(req.Limit)
-		rsp, err := client.offloadSearchIndex(ctx, offloadSearchIndexRequest{
-			Scope: newOffloadScope(s.opts, inv.Session, inv.AgentName),
-			Query: query,
-			Limit: limit,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if rsp == nil {
-			return &searchOffloadIndexToolResponse{Query: query}, nil
-		}
-		return &searchOffloadIndexToolResponse{
-			Query:   rsp.Query,
-			Entries: rsp.Entries,
-			Total:   rsp.Total,
-		}, nil
-	}
-	return function.NewFunctionTool(
-		fn,
-		function.WithName(name),
-		function.WithDescription("Search TencentDB context offload L1 summaries and refs for the current session. "+
-			"Use this when the active Mermaid graph does not show the exact result_ref needed."),
-	)
+	return &value
 }
 
 func currentSession(ctx context.Context) (*session.Session, error) {


### PR DESCRIPTION
## What changed

- align optional TencentDB context offload with the upstream V2 ingest, compact, and read-ref contracts
- require V2 service identity, preserve framework messages on gateway failures, and remove unsupported legacy route/tool assumptions
- update tests, the TencentDB example, and English/Chinese documentation

## Why

The previous adapter expected gateway routes that TencentDB Agent Memory never provided. TencentCloud/TencentDB-Agent-Memory#560 added the missing bounded result-ref recovery route, so the framework can now integrate only with the real V2 surface.

## Testing

- `go build ./...`
- `go test ./memory/tencentdb -race`
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m`
- live smoke test against TencentDB Agent Memory `feat/server` covering ingest, compact, and read-ref

## Notes for reviewers

`ContextOffloadConfig` adds `ServiceID`, `CompactionRatio`, and an optional `TokenCounter`. Context offload remains disabled by default. Enabling it now validates the V2-required bearer key and service ID. The two previously exposed tools without upstream routes are intentionally removed.

Related: TencentCloud/TencentDB-Agent-Memory#560