### PR TITLE
server/openai/realtime: add WebSocket proxy support

### DIFF
--- a/examples/openai_realtime_proxy/README.md
+++ b/examples/openai_realtime_proxy/README.md
@@ -40,4 +40,6 @@ Then send these events one line at a time:
 The proxy preserves complete JSON events, including event types that were added
 after the installed framework version. For remote deployment, import the proxy
 package and wrap `Proxy.Handler()` with client authentication, authorization,
-origin validation, TLS, and request limits before serving it.
+origin validation, TLS, and request limits before serving it. Call
+`Proxy.Close()` before shutting down the HTTP server so hijacked WebSocket
+sessions and their upstream connections are closed and awaited.

--- a/examples/openai_realtime_proxy/README.md
+++ b/examples/openai_realtime_proxy/README.md
@@ -1,0 +1,40 @@
+# OpenAI Realtime Proxy Example
+
+This example exposes a local WebSocket endpoint and forwards OpenAI Realtime
+events bidirectionally. The API key stays on the server; clients do not receive
+it.
+
+This first milestone is transport-only. It does not invoke a tRPC Agent runner,
+execute local tools, or persist transcripts.
+
+## Run
+
+From the repository root:
+
+```bash
+export OPENAI_API_KEY="..."
+cd examples/openai_realtime_proxy
+go run . -model gpt-realtime -addr :8080
+```
+
+The local endpoint is `ws://localhost:8080/v1/realtime`.
+
+## Send a text-only session
+
+Connect with a WebSocket client such as `websocat`:
+
+```bash
+websocat ws://localhost:8080/v1/realtime
+```
+
+Then send these events one line at a time:
+
+```json
+{"type":"session.update","session":{"modalities":["text"]}}
+{"type":"conversation.item.create","item":{"type":"message","role":"user","content":[{"type":"input_text","text":"Say hello in one sentence."}]}}
+{"type":"response.create","response":{"modalities":["text"]}}
+```
+
+The proxy preserves complete JSON events, including event types that were added
+after the installed framework version. Production deployments should add client
+authentication, origin validation, TLS, and request limits around the handler.

--- a/examples/openai_realtime_proxy/README.md
+++ b/examples/openai_realtime_proxy/README.md
@@ -14,17 +14,19 @@ From the repository root:
 ```bash
 export OPENAI_API_KEY="..."
 cd examples/openai_realtime_proxy
-go run . -model gpt-realtime -addr :8080
+go run . -model gpt-realtime -addr 127.0.0.1:8080
 ```
 
-The local endpoint is `ws://localhost:8080/v1/realtime`.
+The loopback-only endpoint is `ws://127.0.0.1:8080/v1/realtime`. The example
+rejects non-loopback listen addresses because it does not authenticate
+downstream clients.
 
 ## Send a text-only session
 
 Connect with a WebSocket client such as `websocat`:
 
 ```bash
-websocat ws://localhost:8080/v1/realtime
+websocat ws://127.0.0.1:8080/v1/realtime
 ```
 
 Then send these events one line at a time:
@@ -36,5 +38,6 @@ Then send these events one line at a time:
 ```
 
 The proxy preserves complete JSON events, including event types that were added
-after the installed framework version. Production deployments should add client
-authentication, origin validation, TLS, and request limits around the handler.
+after the installed framework version. For remote deployment, import the proxy
+package and wrap `Proxy.Handler()` with client authentication, authorization,
+origin validation, TLS, and request limits before serving it.

--- a/examples/openai_realtime_proxy/main.go
+++ b/examples/openai_realtime_proxy/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,7 +23,7 @@ import (
 )
 
 func main() {
-	addr := flag.String("addr", ":8080", "listen address")
+	addr := flag.String("addr", "127.0.0.1:8080", "loopback listen address")
 	modelName := flag.String("model", "gpt-realtime", "OpenAI Realtime model")
 	flag.Parse()
 
@@ -44,14 +45,34 @@ func main() {
 		log.Fatalf("create OpenAI Realtime proxy: %v", err)
 	}
 
-	log.Infof(
-		"OpenAI Realtime proxy listening on ws://localhost%s%s",
-		*addr,
-		proxy.Path(),
-	)
+	if !isLoopbackListenAddress(*addr) {
+		log.Fatal(
+			"this example only accepts a loopback -addr; wrap proxy.Handler() " +
+				"with authentication and serve it with TLS for remote access",
+		)
+	}
+	listener, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("listen on %s: %v", *addr, err)
+	}
+	defer listener.Close()
+
+	log.Infof("OpenAI Realtime proxy listening on ws://%s%s", listener.Addr(), proxy.Path())
 	// This example server intentionally uses the standard HTTP server.
 	//nolint:gosec
-	if err := http.ListenAndServe(*addr, proxy.Handler()); err != nil {
+	if err := http.Serve(listener, proxy.Handler()); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+func isLoopbackListenAddress(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/examples/openai_realtime_proxy/main.go
+++ b/examples/openai_realtime_proxy/main.go
@@ -1,0 +1,57 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main runs a text-capable OpenAI Realtime WebSocket proxy.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	modelrealtime "trpc.group/trpc-go/trpc-agent-go/model/openai/realtime"
+	serverrealtime "trpc.group/trpc-go/trpc-agent-go/server/openai/realtime"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	modelName := flag.String("model", "gpt-realtime", "OpenAI Realtime model")
+	flag.Parse()
+
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENAI_API_KEY is required")
+	}
+	upstreamURL := fmt.Sprintf(
+		"wss://api.openai.com/v1/realtime?model=%s",
+		url.QueryEscape(*modelName),
+	)
+	proxy, err := serverrealtime.New(
+		serverrealtime.WithUpstream(modelrealtime.Config{
+			URL:    upstreamURL,
+			APIKey: apiKey,
+		}),
+	)
+	if err != nil {
+		log.Fatalf("create OpenAI Realtime proxy: %v", err)
+	}
+
+	log.Infof(
+		"OpenAI Realtime proxy listening on ws://localhost%s%s",
+		*addr,
+		proxy.Path(),
+	)
+	// This example server intentionally uses the standard HTTP server.
+	//nolint:gosec
+	if err := http.ListenAndServe(*addr, proxy.Handler()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/examples/openai_realtime_proxy/main.go
+++ b/examples/openai_realtime_proxy/main.go
@@ -44,6 +44,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("create OpenAI Realtime proxy: %v", err)
 	}
+	defer proxy.Close()
 
 	if !isLoopbackListenAddress(*addr) {
 		log.Fatal(

--- a/examples/openai_realtime_proxy/main_test.go
+++ b/examples/openai_realtime_proxy/main_test.go
@@ -1,0 +1,38 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import "testing"
+
+func TestIsLoopbackListenAddress(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{addr: "127.0.0.1:8080", want: true},
+		{addr: "localhost:8080", want: true},
+		{addr: "[::1]:8080", want: true},
+		{addr: ":8080", want: false},
+		{addr: "0.0.0.0:8080", want: false},
+		{addr: "192.0.2.1:8080", want: false},
+		{addr: "invalid", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.addr, func(t *testing.T) {
+			if got := isLoopbackListenAddress(test.addr); got != test.want {
+				t.Fatalf(
+					"isLoopbackListenAddress(%q) = %v, want %v",
+					test.addr,
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/model/openai/realtime/connector.go
+++ b/model/openai/realtime/connector.go
@@ -28,10 +28,19 @@ const (
 
 // Config configures an OpenAI Realtime WebSocket connection.
 type Config struct {
-	URL             string
-	Origin          string
-	APIKey          string
-	Header          http.Header
+	// URL is the upstream Realtime WebSocket endpoint. It must use ws or wss.
+	URL string
+	// Origin is sent in the WebSocket handshake. It defaults to
+	// http://localhost when empty.
+	Origin string
+	// APIKey is sent as a Bearer token unless Header already contains an
+	// Authorization value.
+	APIKey string
+	// Header contains additional handshake headers. Connect clones it before
+	// adding defaults and never mutates the caller's map.
+	Header http.Header
+	// MaxPayloadBytes limits received frame payloads. Values less than one use
+	// the 16 MiB default.
 	MaxPayloadBytes int
 }
 
@@ -47,7 +56,9 @@ type Conn interface {
 	Close() error
 }
 
-// WebSocketConnector is the default Connector implementation.
+// WebSocketConnector is the default Connector implementation. The underlying
+// x/net WebSocket transport automatically replies to incoming ping frames with
+// pong frames.
 type WebSocketConnector struct{}
 
 // NewConnector creates the default OpenAI Realtime connector.

--- a/model/openai/realtime/connector.go
+++ b/model/openai/realtime/connector.go
@@ -1,0 +1,179 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package realtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+const (
+	defaultOrigin          = "http://localhost"
+	defaultMaxPayloadBytes = 16 << 20
+)
+
+// Config configures an OpenAI Realtime WebSocket connection.
+type Config struct {
+	URL             string
+	Origin          string
+	APIKey          string
+	Header          http.Header
+	MaxPayloadBytes int
+}
+
+// Connector opens Realtime WebSocket connections.
+type Connector interface {
+	Connect(ctx context.Context, config Config) (Conn, error)
+}
+
+// Conn sends and receives Realtime events.
+type Conn interface {
+	Send(ctx context.Context, event Event) error
+	Receive(ctx context.Context) (Event, error)
+	Close() error
+}
+
+// WebSocketConnector is the default Connector implementation.
+type WebSocketConnector struct{}
+
+// NewConnector creates the default OpenAI Realtime connector.
+func NewConnector() *WebSocketConnector {
+	return &WebSocketConnector{}
+}
+
+// Connect opens an upstream WebSocket connection.
+func (*WebSocketConnector) Connect(ctx context.Context, config Config) (Conn, error) {
+	if err := validateConfig(config); err != nil {
+		return nil, err
+	}
+	origin := config.Origin
+	if origin == "" {
+		origin = defaultOrigin
+	}
+	wsConfig, err := websocket.NewConfig(config.URL, origin)
+	if err != nil {
+		return nil, fmt.Errorf("realtime: create websocket config: %w", err)
+	}
+	wsConfig.Header = config.Header.Clone()
+	if wsConfig.Header == nil {
+		wsConfig.Header = make(http.Header)
+	}
+	if config.APIKey != "" && wsConfig.Header.Get("Authorization") == "" {
+		wsConfig.Header.Set("Authorization", "Bearer "+config.APIKey)
+	}
+	if wsConfig.Header.Get("OpenAI-Beta") == "" {
+		wsConfig.Header.Set("OpenAI-Beta", "realtime=v1")
+	}
+	ws, err := wsConfig.DialContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("realtime: connect websocket: %w", err)
+	}
+	return NewWebSocketConn(ws, config.MaxPayloadBytes), nil
+}
+
+func validateConfig(config Config) error {
+	if config.URL == "" {
+		return errors.New("realtime: websocket URL is required")
+	}
+	parsed, err := url.Parse(config.URL)
+	if err != nil {
+		return fmt.Errorf("realtime: parse websocket URL: %w", err)
+	}
+	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
+		return fmt.Errorf("realtime: unsupported websocket URL scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("realtime: websocket URL host is required")
+	}
+	return nil
+}
+
+type webSocketConn struct {
+	conn      *websocket.Conn
+	sendMu    sync.Mutex
+	receiveMu sync.Mutex
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// NewWebSocketConn adapts an x/net WebSocket connection to Conn.
+func NewWebSocketConn(conn *websocket.Conn, maxPayloadBytes int) Conn {
+	if maxPayloadBytes <= 0 {
+		maxPayloadBytes = defaultMaxPayloadBytes
+	}
+	conn.MaxPayloadBytes = maxPayloadBytes
+	return &webSocketConn{conn: conn}
+}
+
+func (c *webSocketConn) Send(ctx context.Context, event Event) error {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+
+	raw, err := event.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	stop := interruptOnCancel(ctx, c.conn.SetWriteDeadline)
+	defer stop()
+	if err := websocket.Message.Send(c.conn, string(raw)); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("realtime: send event: %w", err)
+	}
+	return nil
+}
+
+func (c *webSocketConn) Receive(ctx context.Context) (Event, error) {
+	c.receiveMu.Lock()
+	defer c.receiveMu.Unlock()
+
+	stop := interruptOnCancel(ctx, c.conn.SetReadDeadline)
+	defer stop()
+	var payload string
+	if err := websocket.Message.Receive(c.conn, &payload); err != nil {
+		if ctx.Err() != nil {
+			return Event{}, ctx.Err()
+		}
+		return Event{}, fmt.Errorf("realtime: receive event: %w", err)
+	}
+	return ParseEvent([]byte(payload))
+}
+
+func interruptOnCancel(
+	ctx context.Context,
+	setDeadline func(time.Time) error,
+) func() {
+	finished := make(chan struct{})
+	stopAfterFunc := context.AfterFunc(ctx, func() {
+		_ = setDeadline(time.Now())
+		close(finished)
+	})
+	return func() {
+		if !stopAfterFunc() {
+			<-finished
+		}
+		_ = setDeadline(time.Time{})
+	}
+}
+
+func (c *webSocketConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closeErr = c.conn.Close()
+	})
+	return c.closeErr
+}

--- a/model/openai/realtime/connector.go
+++ b/model/openai/realtime/connector.go
@@ -10,9 +10,11 @@
 package realtime
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -39,17 +41,22 @@ type Config struct {
 	// Header contains additional handshake headers. Connect clones it before
 	// adding defaults and never mutates the caller's map.
 	Header http.Header
-	// MaxPayloadBytes limits received frame payloads. Values less than one use
-	// the 16 MiB default.
+	// MaxPayloadBytes limits complete received event payloads. Values less than
+	// one use the 16 MiB default.
 	MaxPayloadBytes int
 }
 
-// Connector opens Realtime WebSocket connections.
+// Connector opens Realtime WebSocket connections. Connect may be called
+// concurrently and must honor ctx promptly. A successful call must return a
+// non-nil Conn.
 type Connector interface {
 	Connect(ctx context.Context, config Config) (Conn, error)
 }
 
-// Conn sends and receives Realtime events.
+// Conn sends and receives Realtime events. One Send and one Receive may run
+// concurrently, and Close may run concurrently with both. Implementations must
+// honor operation contexts promptly. Close must be idempotent and unblock
+// in-flight Send and Receive calls.
 type Conn interface {
 	Send(ctx context.Context, event Event) error
 	Receive(ctx context.Context) (Event, error)
@@ -91,6 +98,9 @@ func (*WebSocketConnector) Connect(ctx context.Context, config Config) (Conn, er
 	}
 	ws, err := wsConfig.DialContext(ctx)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, fmt.Errorf("realtime: connect websocket: %w", err)
 	}
 	return NewWebSocketConn(ws, config.MaxPayloadBytes), nil
@@ -114,11 +124,13 @@ func validateConfig(config Config) error {
 }
 
 type webSocketConn struct {
-	conn      *websocket.Conn
-	sendMu    sync.Mutex
-	receiveMu sync.Mutex
-	closeOnce sync.Once
-	closeErr  error
+	conn            *websocket.Conn
+	reader          *bufio.Reader
+	maxPayloadBytes int
+	sendGate        chan struct{}
+	receiveGate     chan struct{}
+	closeOnce       sync.Once
+	closeErr        error
 }
 
 // NewWebSocketConn adapts an x/net WebSocket connection to Conn.
@@ -127,12 +139,20 @@ func NewWebSocketConn(conn *websocket.Conn, maxPayloadBytes int) Conn {
 		maxPayloadBytes = defaultMaxPayloadBytes
 	}
 	conn.MaxPayloadBytes = maxPayloadBytes
-	return &webSocketConn{conn: conn}
+	return &webSocketConn{
+		conn:            conn,
+		reader:          bufio.NewReader(conn),
+		maxPayloadBytes: maxPayloadBytes,
+		sendGate:        make(chan struct{}, 1),
+		receiveGate:     make(chan struct{}, 1),
+	}
 }
 
 func (c *webSocketConn) Send(ctx context.Context, event Event) error {
-	c.sendMu.Lock()
-	defer c.sendMu.Unlock()
+	if err := acquire(ctx, c.sendGate); err != nil {
+		return err
+	}
+	defer release(c.sendGate)
 
 	raw, err := event.MarshalJSON()
 	if err != nil {
@@ -150,19 +170,91 @@ func (c *webSocketConn) Send(ctx context.Context, event Event) error {
 }
 
 func (c *webSocketConn) Receive(ctx context.Context) (Event, error) {
-	c.receiveMu.Lock()
-	defer c.receiveMu.Unlock()
+	if err := acquire(ctx, c.receiveGate); err != nil {
+		return Event{}, err
+	}
+	defer release(c.receiveGate)
 
 	stop := interruptOnCancel(ctx, c.conn.SetReadDeadline)
 	defer stop()
-	var payload string
-	if err := websocket.Message.Receive(c.conn, &payload); err != nil {
+	payload, err := readEventPayload(c.reader, c.maxPayloadBytes)
+	if err != nil {
 		if ctx.Err() != nil {
 			return Event{}, ctx.Err()
 		}
 		return Event{}, fmt.Errorf("realtime: receive event: %w", err)
 	}
-	return ParseEvent([]byte(payload))
+	return ParseEvent(payload)
+}
+
+func acquire(ctx context.Context, gate chan struct{}) error {
+	select {
+	case gate <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func release(gate chan struct{}) {
+	<-gate
+}
+
+func readEventPayload(reader *bufio.Reader, maxPayloadBytes int) ([]byte, error) {
+	payload := make([]byte, 0, 512)
+	depth := 0
+	inString := false
+	escaped := false
+	started := false
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			if errors.Is(err, io.EOF) && len(payload) != 0 {
+				return nil, io.ErrUnexpectedEOF
+			}
+			return nil, err
+		}
+		payload = append(payload, b)
+		if len(payload) > maxPayloadBytes {
+			return nil, websocket.ErrFrameTooLarge
+		}
+		if !started {
+			switch b {
+			case ' ', '\t', '\r', '\n':
+				continue
+			case '{':
+				started = true
+				depth = 1
+				continue
+			default:
+				return nil, errors.New("event payload must be a JSON object")
+			}
+		}
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch b {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch b {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				return payload, nil
+			}
+		}
+	}
 }
 
 func interruptOnCancel(

--- a/model/openai/realtime/connector_test.go
+++ b/model/openai/realtime/connector_test.go
@@ -11,6 +11,10 @@ package realtime
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,10 +78,171 @@ func TestWebSocketConnReceiveCancellation(t *testing.T) {
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+func TestWebSocketConnectorDialCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(
+		http.ResponseWriter,
+		*http.Request,
+	) {
+		close(started)
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := NewConnector().Connect(ctx, Config{
+			URL: "ws" + strings.TrimPrefix(server.URL, "http"),
+		})
+		result <- err
+	}()
+	<-started
+	assert.ErrorIs(t, <-result, context.DeadlineExceeded)
+}
+
+func TestWebSocketConnCanceledReceiveDoesNotWaitForEarlierReceive(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(websocket.Handler(func(*websocket.Conn) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	conn, err := NewConnector().Connect(context.Background(), Config{
+		URL: "ws" + strings.TrimPrefix(server.URL, "http"),
+	})
+	require.NoError(t, err)
+	wrapped := conn.(*webSocketConn)
+	firstResult := make(chan error, 1)
+	go func() {
+		_, receiveErr := conn.Receive(context.Background())
+		firstResult <- receiveErr
+	}()
+	require.Eventually(t, func() bool {
+		return len(wrapped.receiveGate) == 1
+	}, time.Second, time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = conn.Receive(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	select {
+	case err := <-firstResult:
+		t.Fatalf("first receive unexpectedly returned: %v", err)
+	default:
+	}
+	require.NoError(t, conn.Close())
+	<-firstResult
+}
+
+func TestWebSocketConnCanceledSendDoesNotWaitForAdmission(t *testing.T) {
+	conn := &webSocketConn{sendGate: make(chan struct{}, 1)}
+	conn.sendGate <- struct{}{}
+	event, err := NewEvent("session.update", nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err = conn.Send(ctx, event)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWebSocketConnReassemblesFragmentedEvent(t *testing.T) {
+	server := newFragmentedEventServer(t, []frame{
+		{opcode: websocket.TextFrame, payload: `{"type":"response.`},
+		{opcode: websocket.ContinuationFrame, payload: `audio.delta","delta":`},
+		{fin: true, opcode: websocket.ContinuationFrame, payload: `"AQID"}`},
+	})
+	defer server.Close()
+
+	conn, err := NewConnector().Connect(context.Background(), Config{
+		URL: "ws" + strings.TrimPrefix(server.URL, "http"),
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+	event, err := conn.Receive(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "response.audio.delta", event.Type())
+	assert.JSONEq(t, `{"type":"response.audio.delta","delta":"AQID"}`, string(event.Bytes()))
+}
+
+func TestWebSocketConnLimitsReassembledEvent(t *testing.T) {
+	server := newFragmentedEventServer(t, []frame{
+		{opcode: websocket.TextFrame, payload: `{"type":"`},
+		{fin: true, opcode: websocket.ContinuationFrame, payload: `response.done"}`},
+	})
+	defer server.Close()
+
+	conn, err := NewConnector().Connect(context.Background(), Config{
+		URL:             "ws" + strings.TrimPrefix(server.URL, "http"),
+		MaxPayloadBytes: 16,
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Receive(context.Background())
+	assert.ErrorIs(t, err, websocket.ErrFrameTooLarge)
+}
+
 func TestConnectorConfigValidation(t *testing.T) {
 	_, err := NewConnector().Connect(context.Background(), Config{})
 	assert.ErrorContains(t, err, "URL is required")
 
 	_, err = NewConnector().Connect(context.Background(), Config{URL: "https://example.com"})
 	assert.ErrorContains(t, err, "unsupported websocket URL scheme")
+}
+
+type frame struct {
+	fin     bool
+	opcode  byte
+	payload string
+}
+
+func newFragmentedEventServer(t *testing.T, frames []frame) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hijacker, ok := w.(http.Hijacker)
+		require.True(t, ok)
+		conn, buf, err := hijacker.Hijack()
+		require.NoError(t, err)
+		defer conn.Close()
+
+		sum := sha1.Sum([]byte(
+			r.Header.Get("Sec-WebSocket-Key") +
+				"258EAFA5-E914-47DA-95CA-C5AB0DC85B11",
+		))
+		_, err = fmt.Fprintf(
+			buf,
+			"HTTP/1.1 101 Switching Protocols\r\n"+
+				"Upgrade: websocket\r\n"+
+				"Connection: Upgrade\r\n"+
+				"Sec-WebSocket-Accept: %s\r\n\r\n",
+			base64.StdEncoding.EncodeToString(sum[:]),
+		)
+		require.NoError(t, err)
+		require.NoError(t, buf.Flush())
+		for _, frame := range frames {
+			require.NoError(t, writeFrame(buf, frame))
+		}
+		require.NoError(t, buf.Flush())
+	}))
+}
+
+func writeFrame(w io.Writer, frame frame) error {
+	header := frame.opcode
+	if frame.fin {
+		header |= 0x80
+	}
+	payload := []byte(frame.payload)
+	if len(payload) > 125 {
+		return fmt.Errorf("test frame payload is too large: %d", len(payload))
+	}
+	if _, err := w.Write([]byte{header, byte(len(payload))}); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
 }

--- a/model/openai/realtime/connector_test.go
+++ b/model/openai/realtime/connector_test.go
@@ -1,0 +1,83 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package realtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+)
+
+func TestWebSocketConnector(t *testing.T) {
+	requests := make(chan *http.Request, 1)
+	server := httptest.NewServer(websocket.Handler(func(conn *websocket.Conn) {
+		requests <- conn.Request()
+		var payload string
+		require.NoError(t, websocket.Message.Receive(conn, &payload))
+		require.NoError(t, websocket.Message.Send(conn, payload))
+	}))
+	defer server.Close()
+
+	conn, err := NewConnector().Connect(context.Background(), Config{
+		URL:    "ws" + strings.TrimPrefix(server.URL, "http"),
+		APIKey: "test-key",
+		Header: http.Header{"X-Test": []string{"value"}},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	event, err := NewEvent("session.update", map[string]any{"session": map[string]any{"model": "test"}})
+	require.NoError(t, err)
+	require.NoError(t, conn.Send(context.Background(), event))
+	got, err := conn.Receive(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "session.update", got.Type())
+	assert.JSONEq(t, string(event.Bytes()), string(got.Bytes()))
+
+	req := <-requests
+	assert.Equal(t, "Bearer test-key", req.Header.Get("Authorization"))
+	assert.Equal(t, "realtime=v1", req.Header.Get("OpenAI-Beta"))
+	assert.Equal(t, "value", req.Header.Get("X-Test"))
+}
+
+func TestWebSocketConnReceiveCancellation(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(websocket.Handler(func(conn *websocket.Conn) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	conn, err := NewConnector().Connect(context.Background(), Config{
+		URL: "ws" + strings.TrimPrefix(server.URL, "http"),
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = conn.Receive(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestConnectorConfigValidation(t *testing.T) {
+	_, err := NewConnector().Connect(context.Background(), Config{})
+	assert.ErrorContains(t, err, "URL is required")
+
+	_, err = NewConnector().Connect(context.Background(), Config{URL: "https://example.com"})
+	assert.ErrorContains(t, err, "unsupported websocket URL scheme")
+}

--- a/model/openai/realtime/event.go
+++ b/model/openai/realtime/event.go
@@ -1,0 +1,90 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package realtime provides OpenAI Realtime WebSocket event and connection
+// primitives.
+package realtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Event is an OpenAI Realtime client or server event. It preserves the full
+// wire representation so new event fields can pass through without requiring
+// a framework release.
+type Event struct {
+	eventType string
+	raw       json.RawMessage
+}
+
+// ParseEvent validates and parses a Realtime JSON event.
+func ParseEvent(data []byte) (Event, error) {
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return Event{}, fmt.Errorf("realtime: decode event: %w", err)
+	}
+	if envelope.Type == "" {
+		return Event{}, errors.New("realtime: event type is required")
+	}
+	raw := bytes.Clone(data)
+	return Event{eventType: envelope.Type, raw: raw}, nil
+}
+
+// NewEvent creates an event with the supplied type and fields.
+func NewEvent(eventType string, fields map[string]any) (Event, error) {
+	if eventType == "" {
+		return Event{}, errors.New("realtime: event type is required")
+	}
+	payload := make(map[string]any, len(fields)+1)
+	for key, value := range fields {
+		if key == "type" {
+			continue
+		}
+		payload[key] = value
+	}
+	payload["type"] = eventType
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return Event{}, fmt.Errorf("realtime: encode event: %w", err)
+	}
+	return Event{eventType: eventType, raw: raw}, nil
+}
+
+// Type returns the event's protocol type.
+func (e Event) Type() string {
+	return e.eventType
+}
+
+// Bytes returns an independent copy of the event's JSON wire representation.
+func (e Event) Bytes() []byte {
+	return bytes.Clone(e.raw)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e Event) MarshalJSON() ([]byte, error) {
+	if e.eventType == "" || len(e.raw) == 0 {
+		return nil, errors.New("realtime: invalid empty event")
+	}
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *Event) UnmarshalJSON(data []byte) error {
+	parsed, err := ParseEvent(data)
+	if err != nil {
+		return err
+	}
+	*e = parsed
+	return nil
+}

--- a/model/openai/realtime/event.go
+++ b/model/openai/realtime/event.go
@@ -41,7 +41,8 @@ func ParseEvent(data []byte) (Event, error) {
 	return Event{eventType: envelope.Type, raw: raw}, nil
 }
 
-// NewEvent creates an event with the supplied type and fields.
+// NewEvent creates an event with the supplied type and fields. A "type" entry
+// in fields is ignored; eventType always determines the event type.
 func NewEvent(eventType string, fields map[string]any) (Event, error) {
 	if eventType == "" {
 		return Event{}, errors.New("realtime: event type is required")

--- a/model/openai/realtime/event_test.go
+++ b/model/openai/realtime/event_test.go
@@ -1,0 +1,68 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package realtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventRoundTrip(t *testing.T) {
+	tests := []string{
+		`{"type":"session.update","session":{"modalities":["text","audio"]}}`,
+		`{"type":"input_audio_buffer.append","audio":"AAEC"}`,
+		`{"type":"conversation.item.input_audio_transcription.completed","transcript":"hello"}`,
+		`{"type":"response.done","response":{"id":"resp_1"}}`,
+		`{"type":"response.function_call_arguments.done","call_id":"call_1","arguments":"{\"city\":\"Paris\"}"}`,
+		`{"type":"conversation.item.create","item":{"type":"function_call_output","call_id":"call_1","output":"sunny"}}`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			event, err := ParseEvent([]byte(input))
+			require.NoError(t, err)
+			assert.NotEmpty(t, event.Type())
+			assert.JSONEq(t, input, string(event.Bytes()))
+
+			encoded, err := json.Marshal(event)
+			require.NoError(t, err)
+			assert.JSONEq(t, input, string(encoded))
+
+			var decoded Event
+			require.NoError(t, json.Unmarshal(encoded, &decoded))
+			assert.Equal(t, event.Type(), decoded.Type())
+		})
+	}
+}
+
+func TestEventValidation(t *testing.T) {
+	_, err := ParseEvent([]byte(`{`))
+	assert.ErrorContains(t, err, "decode event")
+
+	_, err = ParseEvent([]byte(`{"event_id":"evt_1"}`))
+	assert.ErrorContains(t, err, "event type is required")
+
+	_, err = NewEvent("", nil)
+	assert.ErrorContains(t, err, "event type is required")
+
+	event, err := NewEvent("response.cancel", map[string]any{
+		"type":        "ignored",
+		"response_id": "resp_1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "response.cancel", event.Type())
+	assert.JSONEq(t, `{"type":"response.cancel","response_id":"resp_1"}`, string(event.Bytes()))
+
+	_, err = json.Marshal(Event{})
+	assert.ErrorContains(t, err, "invalid empty event")
+}

--- a/server/openai/realtime/proxy.go
+++ b/server/openai/realtime/proxy.go
@@ -31,6 +31,13 @@ type Proxy struct {
 	config    modelrealtime.Config
 	connector modelrealtime.Connector
 	handler   http.Handler
+	ctx       context.Context
+	cancel    context.CancelFunc
+	sessionMu sync.Mutex
+	sessionWG sync.WaitGroup
+	closed    bool
+	closeOnce sync.Once
+	done      chan struct{}
 }
 
 // Option configures a Proxy.
@@ -61,10 +68,14 @@ func New(opts ...Option) (*Proxy, error) {
 		return nil, errors.New("openai realtime proxy: upstream URL is required")
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	proxy := &Proxy{
 		path:      options.path,
 		config:    cloneConfig(options.config),
 		connector: options.connector,
+		ctx:       ctx,
+		cancel:    cancel,
+		done:      make(chan struct{}),
 	}
 	proxy.setupHandler()
 	return proxy, nil
@@ -84,8 +95,9 @@ func WithUpstream(config modelrealtime.Config) Option {
 	}
 }
 
-// WithConnector replaces the upstream connector. It is useful for custom
-// transports and deterministic tests.
+// WithConnector replaces the upstream connector. Custom implementations must
+// satisfy the concurrency and cancellation contracts on modelrealtime.Connector
+// and modelrealtime.Conn.
 func WithConnector(connector modelrealtime.Connector) Option {
 	return func(options *proxyOptions) {
 		options.connector = connector
@@ -111,13 +123,37 @@ func (p *Proxy) Path() string {
 	return p.path
 }
 
+// Close stops accepting proxy sessions, closes both peers of every active
+// session, and waits for their relay goroutines to exit. Close is idempotent.
+func (p *Proxy) Close() error {
+	p.closeOnce.Do(func() {
+		p.sessionMu.Lock()
+		p.closed = true
+		p.cancel()
+		p.sessionMu.Unlock()
+		p.sessionWG.Wait()
+		close(p.done)
+	})
+	<-p.done
+	return nil
+}
+
 func (p *Proxy) setupHandler() {
-	websocketHandler := websocket.Handler(p.handleWebSocket)
+	websocketHandler := websocket.Server{
+		Handler: websocket.Handler(p.handleWebSocket),
+		Handshake: func(*websocket.Config, *http.Request) error {
+			return nil
+		},
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc(p.path, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.Header().Set("Allow", http.MethodGet)
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if p.isClosed() {
+			http.Error(w, "proxy is closed", http.StatusServiceUnavailable)
 			return
 		}
 		websocketHandler.ServeHTTP(w, r)
@@ -126,11 +162,15 @@ func (p *Proxy) setupHandler() {
 }
 
 func (p *Proxy) handleWebSocket(downstreamWS *websocket.Conn) {
-	ctx, cancel := context.WithCancel(downstreamWS.Request().Context())
-	defer cancel()
+	ctx, cancel, finish, ok := p.beginSession(downstreamWS.Request().Context())
+	if !ok {
+		_ = downstreamWS.Close()
+		return
+	}
+	defer finish()
 
 	upstream, err := p.connector.Connect(ctx, cloneConfig(p.config))
-	if err != nil {
+	if err != nil || upstream == nil {
 		p.sendConnectionError(ctx, downstreamWS)
 		return
 	}
@@ -152,6 +192,32 @@ func (p *Proxy) handleWebSocket(downstreamWS *websocket.Conn) {
 	_ = downstream.Close()
 	_ = upstream.Close()
 	relayWG.Wait()
+}
+
+func (p *Proxy) isClosed() bool {
+	p.sessionMu.Lock()
+	defer p.sessionMu.Unlock()
+	return p.closed
+}
+
+func (p *Proxy) beginSession(
+	parent context.Context,
+) (context.Context, context.CancelFunc, func(), bool) {
+	p.sessionMu.Lock()
+	if p.closed {
+		p.sessionMu.Unlock()
+		return nil, nil, nil, false
+	}
+	p.sessionWG.Add(1)
+	p.sessionMu.Unlock()
+
+	ctx, cancel := context.WithCancel(parent)
+	stopOwnerCancellation := context.AfterFunc(p.ctx, cancel)
+	return ctx, cancel, func() {
+		stopOwnerCancellation()
+		cancel()
+		p.sessionWG.Done()
+	}, true
 }
 
 func (*Proxy) relay(

--- a/server/openai/realtime/proxy.go
+++ b/server/openai/realtime/proxy.go
@@ -24,7 +24,8 @@ import (
 const defaultPath = "/v1/realtime"
 
 // Proxy forwards OpenAI Realtime events between clients and an upstream
-// Realtime WebSocket endpoint.
+// Realtime WebSocket endpoint. It does not authenticate downstream clients;
+// applications are responsible for access control around Handler.
 type Proxy struct {
 	path      string
 	config    modelrealtime.Config
@@ -97,6 +98,10 @@ func cloneConfig(config modelrealtime.Config) modelrealtime.Config {
 }
 
 // Handler returns the proxy's HTTP handler.
+//
+// The handler performs no downstream authentication or authorization and
+// relays accepted connections with the configured upstream credentials.
+// Callers must add access-control middleware before exposing it publicly.
 func (p *Proxy) Handler() http.Handler {
 	return p.handler
 }

--- a/server/openai/realtime/proxy.go
+++ b/server/openai/realtime/proxy.go
@@ -1,0 +1,189 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package realtime provides an OpenAI Realtime-compatible WebSocket proxy.
+package realtime
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+
+	modelrealtime "trpc.group/trpc-go/trpc-agent-go/model/openai/realtime"
+
+	"golang.org/x/net/websocket"
+)
+
+const defaultPath = "/v1/realtime"
+
+// Proxy forwards OpenAI Realtime events between clients and an upstream
+// Realtime WebSocket endpoint.
+type Proxy struct {
+	path      string
+	config    modelrealtime.Config
+	connector modelrealtime.Connector
+	handler   http.Handler
+}
+
+// Option configures a Proxy.
+type Option func(*proxyOptions)
+
+type proxyOptions struct {
+	path      string
+	config    modelrealtime.Config
+	connector modelrealtime.Connector
+}
+
+// New creates a Realtime WebSocket proxy.
+func New(opts ...Option) (*Proxy, error) {
+	options := proxyOptions{
+		path:      defaultPath,
+		connector: modelrealtime.NewConnector(),
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.path == "" || options.path[0] != '/' {
+		return nil, errors.New("openai realtime proxy: path must start with /")
+	}
+	if options.connector == nil {
+		return nil, errors.New("openai realtime proxy: connector is required")
+	}
+	if options.config.URL == "" {
+		return nil, errors.New("openai realtime proxy: upstream URL is required")
+	}
+
+	proxy := &Proxy{
+		path:      options.path,
+		config:    cloneConfig(options.config),
+		connector: options.connector,
+	}
+	proxy.setupHandler()
+	return proxy, nil
+}
+
+// WithPath sets the downstream WebSocket endpoint path.
+func WithPath(path string) Option {
+	return func(options *proxyOptions) {
+		options.path = path
+	}
+}
+
+// WithUpstream configures the upstream Realtime connection.
+func WithUpstream(config modelrealtime.Config) Option {
+	return func(options *proxyOptions) {
+		options.config = cloneConfig(config)
+	}
+}
+
+// WithConnector replaces the upstream connector. It is useful for custom
+// transports and deterministic tests.
+func WithConnector(connector modelrealtime.Connector) Option {
+	return func(options *proxyOptions) {
+		options.connector = connector
+	}
+}
+
+func cloneConfig(config modelrealtime.Config) modelrealtime.Config {
+	config.Header = config.Header.Clone()
+	return config
+}
+
+// Handler returns the proxy's HTTP handler.
+func (p *Proxy) Handler() http.Handler {
+	return p.handler
+}
+
+// Path returns the downstream WebSocket endpoint path.
+func (p *Proxy) Path() string {
+	return p.path
+}
+
+func (p *Proxy) setupHandler() {
+	websocketHandler := websocket.Handler(p.handleWebSocket)
+	mux := http.NewServeMux()
+	mux.HandleFunc(p.path, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		websocketHandler.ServeHTTP(w, r)
+	})
+	p.handler = mux
+}
+
+func (p *Proxy) handleWebSocket(downstreamWS *websocket.Conn) {
+	ctx, cancel := context.WithCancel(downstreamWS.Request().Context())
+	defer cancel()
+
+	upstream, err := p.connector.Connect(ctx, cloneConfig(p.config))
+	if err != nil {
+		p.sendConnectionError(ctx, downstreamWS)
+		return
+	}
+	downstream := modelrealtime.NewWebSocketConn(
+		downstreamWS,
+		p.config.MaxPayloadBytes,
+	)
+	defer downstream.Close()
+	defer upstream.Close()
+
+	errCh := make(chan error, 2)
+	var relayWG sync.WaitGroup
+	relayWG.Add(2)
+	go p.relay(ctx, &relayWG, errCh, downstream, upstream)
+	go p.relay(ctx, &relayWG, errCh, upstream, downstream)
+
+	<-errCh
+	cancel()
+	_ = downstream.Close()
+	_ = upstream.Close()
+	relayWG.Wait()
+}
+
+func (*Proxy) relay(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	errCh chan<- error,
+	source modelrealtime.Conn,
+	target modelrealtime.Conn,
+) {
+	defer wg.Done()
+	for {
+		event, err := source.Receive(ctx)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if err := target.Send(ctx, event); err != nil {
+			errCh <- err
+			return
+		}
+	}
+}
+
+func (*Proxy) sendConnectionError(
+	ctx context.Context,
+	conn *websocket.Conn,
+) {
+	event, err := modelrealtime.NewEvent("error", map[string]any{
+		"error": map[string]any{
+			"type":    "connection_error",
+			"message": "upstream connection failed",
+		},
+	})
+	if err != nil {
+		return
+	}
+	downstream := modelrealtime.NewWebSocketConn(conn, 0)
+	_ = downstream.Send(ctx, event)
+	_ = downstream.Close()
+}

--- a/server/openai/realtime/proxy_test.go
+++ b/server/openai/realtime/proxy_test.go
@@ -1,0 +1,207 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package realtime
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	modelrealtime "trpc.group/trpc-go/trpc-agent-go/model/openai/realtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+)
+
+func TestProxyForwardsEventsBidirectionally(t *testing.T) {
+	upstream := newFakeConn()
+	connector := &fakeConnector{conn: upstream}
+	proxy, err := New(
+		WithUpstream(modelrealtime.Config{
+			URL:    "wss://api.openai.example/v1/realtime?model=test",
+			APIKey: "secret",
+			Header: http.Header{"X-Upstream": []string{"value"}},
+		}),
+		WithConnector(connector),
+	)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(proxy.Handler())
+	defer server.Close()
+	downstream, err := websocket.Dial(
+		"ws"+strings.TrimPrefix(server.URL, "http")+proxy.Path(),
+		"",
+		"http://localhost",
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, websocket.Message.Send(
+		downstream,
+		`{"type":"input_audio_buffer.append","audio":"AAEC"}`,
+	))
+	select {
+	case event := <-upstream.sent:
+		assert.Equal(t, "input_audio_buffer.append", event.Type())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream event")
+	}
+
+	serverEvent, err := modelrealtime.ParseEvent(
+		[]byte(`{"type":"response.audio.delta","delta":"BAUG"}`),
+	)
+	require.NoError(t, err)
+	upstream.received <- serverEvent
+
+	var payload string
+	require.NoError(t, websocket.Message.Receive(downstream, &payload))
+	assert.JSONEq(t, `{"type":"response.audio.delta","delta":"BAUG"}`, payload)
+
+	connector.mu.Lock()
+	gotConfig := connector.config
+	connector.mu.Unlock()
+	assert.Equal(t, "secret", gotConfig.APIKey)
+	assert.Equal(t, "value", gotConfig.Header.Get("X-Upstream"))
+
+	require.NoError(t, downstream.Close())
+	select {
+	case <-upstream.closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream cleanup")
+	}
+}
+
+func TestProxyReportsUpstreamConnectionError(t *testing.T) {
+	proxy, err := New(
+		WithUpstream(modelrealtime.Config{URL: "wss://api.openai.example/v1/realtime"}),
+		WithConnector(&fakeConnector{err: errors.New("dial failed")}),
+	)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(proxy.Handler())
+	defer server.Close()
+	conn, err := websocket.Dial(
+		"ws"+strings.TrimPrefix(server.URL, "http")+proxy.Path(),
+		"",
+		"http://localhost",
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	var payload string
+	require.NoError(t, websocket.Message.Receive(conn, &payload))
+	assert.JSONEq(t, `{
+		"type":"error",
+		"error":{
+			"type":"connection_error",
+			"message":"upstream connection failed"
+		}
+	}`, payload)
+}
+
+func TestProxyRejectsNonWebSocketMethod(t *testing.T) {
+	proxy, err := New(
+		WithUpstream(modelrealtime.Config{URL: "wss://api.openai.example/v1/realtime"}),
+		WithConnector(&fakeConnector{conn: newFakeConn()}),
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, proxy.Path(), nil)
+	recorder := httptest.NewRecorder()
+	proxy.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+	assert.Equal(t, http.MethodGet, recorder.Header().Get("Allow"))
+}
+
+func TestProxyValidation(t *testing.T) {
+	_, err := New()
+	assert.ErrorContains(t, err, "upstream URL is required")
+
+	_, err = New(
+		WithPath("relative"),
+		WithUpstream(modelrealtime.Config{URL: "wss://example.com"}),
+	)
+	assert.ErrorContains(t, err, "path must start with")
+
+	_, err = New(
+		WithUpstream(modelrealtime.Config{URL: "wss://example.com"}),
+		WithConnector(nil),
+	)
+	assert.ErrorContains(t, err, "connector is required")
+}
+
+type fakeConnector struct {
+	mu     sync.Mutex
+	config modelrealtime.Config
+	conn   modelrealtime.Conn
+	err    error
+}
+
+func (c *fakeConnector) Connect(
+	_ context.Context,
+	config modelrealtime.Config,
+) (modelrealtime.Conn, error) {
+	c.mu.Lock()
+	c.config = config
+	c.mu.Unlock()
+	return c.conn, c.err
+}
+
+type fakeConn struct {
+	received chan modelrealtime.Event
+	sent     chan modelrealtime.Event
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{
+		received: make(chan modelrealtime.Event, 1),
+		sent:     make(chan modelrealtime.Event, 1),
+		closed:   make(chan struct{}),
+	}
+}
+
+func (c *fakeConn) Send(
+	ctx context.Context,
+	event modelrealtime.Event,
+) error {
+	select {
+	case c.sent <- event:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.closed:
+		return errors.New("closed")
+	}
+}
+
+func (c *fakeConn) Receive(ctx context.Context) (modelrealtime.Event, error) {
+	select {
+	case event := <-c.received:
+		return event, nil
+	case <-ctx.Done():
+		return modelrealtime.Event{}, ctx.Err()
+	case <-c.closed:
+		return modelrealtime.Event{}, errors.New("closed")
+	}
+}
+
+func (c *fakeConn) Close() error {
+	c.once.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}

--- a/server/openai/realtime/proxy_test.go
+++ b/server/openai/realtime/proxy_test.go
@@ -10,8 +10,11 @@
 package realtime
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -83,12 +86,114 @@ func TestProxyForwardsEventsBidirectionally(t *testing.T) {
 	}
 }
 
+func TestProxyAcceptsHandshakeWithoutOrigin(t *testing.T) {
+	upstream := newFakeConn()
+	proxy, err := New(
+		WithUpstream(modelrealtime.Config{URL: "wss://api.openai.example/v1/realtime"}),
+		WithConnector(&fakeConnector{conn: upstream}),
+	)
+	require.NoError(t, err)
+	defer proxy.Close()
+	server := httptest.NewServer(proxy.Handler())
+	defer server.Close()
+
+	conn, response := dialWithoutOrigin(t, server.URL, proxy.Path())
+	assert.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+	require.NoError(t, conn.Close())
+	select {
+	case <-upstream.closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream cleanup")
+	}
+}
+
+func TestProxyCloseStopsHijackedSessions(t *testing.T) {
+	upstream := newFakeConn()
+	proxy, err := New(
+		WithUpstream(modelrealtime.Config{URL: "wss://api.openai.example/v1/realtime"}),
+		WithConnector(&fakeConnector{conn: upstream}),
+	)
+	require.NoError(t, err)
+	server := httptest.NewServer(proxy.Handler())
+	defer server.Close()
+	downstream, err := websocket.Dial(
+		"ws"+strings.TrimPrefix(server.URL, "http")+proxy.Path(),
+		"",
+		"http://localhost",
+	)
+	require.NoError(t, err)
+	defer downstream.Close()
+
+	require.NoError(t, websocket.Message.Send(
+		downstream,
+		`{"type":"session.update"}`,
+	))
+	select {
+	case <-upstream.sent:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for active relay")
+	}
+
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- proxy.Close()
+	}()
+	select {
+	case err := <-closeResult:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("proxy close did not wait for and stop active relays")
+	}
+	select {
+	case <-upstream.closed:
+	default:
+		t.Fatal("upstream connection was not closed")
+	}
+	var payload string
+	assert.Error(t, websocket.Message.Receive(downstream, &payload))
+	require.NoError(t, proxy.Close())
+
+	request := httptest.NewRequest(http.MethodGet, proxy.Path(), nil)
+	recorder := httptest.NewRecorder()
+	proxy.Handler().ServeHTTP(recorder, request)
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+}
+
 func TestProxyReportsUpstreamConnectionError(t *testing.T) {
 	proxy, err := New(
 		WithUpstream(modelrealtime.Config{URL: "wss://api.openai.example/v1/realtime"}),
 		WithConnector(&fakeConnector{err: errors.New("dial failed")}),
 	)
 	require.NoError(t, err)
+
+	server := httptest.NewServer(proxy.Handler())
+	defer server.Close()
+	conn, err := websocket.Dial(
+		"ws"+strings.TrimPrefix(server.URL, "http")+proxy.Path(),
+		"",
+		"http://localhost",
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	var payload string
+	require.NoError(t, websocket.Message.Receive(conn, &payload))
+	assert.JSONEq(t, `{
+		"type":"error",
+		"error":{
+			"type":"connection_error",
+			"message":"upstream connection failed"
+		}
+	}`, payload)
+}
+
+func TestProxyRejectsNilSuccessfulConnectorConnection(t *testing.T) {
+	proxy, err := New(
+		WithUpstream(modelrealtime.Config{URL: "wss://api.openai.example/v1/realtime"}),
+		WithConnector(&fakeConnector{}),
+	)
+	require.NoError(t, err)
+	defer proxy.Close()
 
 	server := httptest.NewServer(proxy.Handler())
 	defer server.Close()
@@ -204,4 +309,33 @@ func (c *fakeConn) Close() error {
 		close(c.closed)
 	})
 	return nil
+}
+
+func dialWithoutOrigin(
+	t *testing.T,
+	serverURL string,
+	path string,
+) (net.Conn, *http.Response) {
+	t.Helper()
+	address := strings.TrimPrefix(serverURL, "http://")
+	conn, err := net.Dial("tcp", address)
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(
+		conn,
+		"GET %s HTTP/1.1\r\n"+
+			"Host: %s\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"+
+			"Sec-WebSocket-Version: 13\r\n\r\n",
+		path,
+		address,
+	)
+	require.NoError(t, err)
+	response, err := http.ReadResponse(
+		bufio.NewReader(conn),
+		&http.Request{Method: http.MethodGet},
+	)
+	require.NoError(t, err)
+	return conn, response
 }


### PR DESCRIPTION
## Summary

Fixes #2224.

Adds the first transport-only milestone proposed in the issue: an OpenAI Realtime event codec, cancellable WebSocket connector, and bidirectional proxy server. This deliberately leaves Runner/tool/session bridging for follow-up work after the wire lifecycle is proven.

## Changes

- add a forward-compatible Realtime JSON event codec that preserves unknown fields
- add an authenticated upstream WebSocket connector with payload limits, serialized reads/writes, context cancellation, and deterministic close handling
- add a configurable `/v1/realtime` bidirectional proxy with upstream failure events and peer-close cleanup
- add codec, header/auth, cancellation, forwarding, error, validation, and cleanup tests
- add a runnable text-only proxy example and deployment safety notes

## User impact

Applications can expose a local OpenAI Realtime-compatible WebSocket endpoint without changing the existing chat-completions, Runner, tool, or session paths. OpenAI credentials remain on the proxy server.

## Validation

Passed:

- `go test -race -count=10 ./model/openai/realtime ./server/openai/realtime`
- `go test ./openai_realtime_proxy` (from `examples`)
- `go test ./...` (from `test`)
- `go build ./...`
- `golangci-lint run --timeout=10m ./model/openai/realtime/... ./server/openai/realtime/...`
- `gofmt` / `goimports` checks

The root `go test ./...` run passed the new packages and failed only in existing macOS environment-sensitive tests (`codeexecutor/local`, `tool/duckduckgo`, and a second run under `/tmp` in `codeexecutor/sandbox`). Each failing package passed when rerun in a compatible/default temp-path environment.

## Compatibility and risk

- additive packages and example only; existing APIs and behavior are unchanged
- no new dependency is introduced (`golang.org/x/net/websocket` is already a root dependency)
- the generic event envelope avoids coupling public APIs to an evolving Realtime schema
- proxy mode intentionally does not execute framework tools or persist audio/transcripts

## Release note

Added transport-level OpenAI Realtime WebSocket proxy support.