### PR TITLE
server/acp: expose runners over ACP stdio

### DIFF
--- a/examples/acp/README.md
+++ b/examples/acp/README.md
@@ -1,0 +1,49 @@
+# ACP stdio Agent Example
+
+This example exposes a tRPC Agent runner as an Agent Client Protocol (ACP) v1
+agent over line-delimited JSON-RPC on standard input and output.
+
+## Run
+
+```bash
+export OPENAI_API_KEY="..."
+cd examples/acp
+go run . -model gpt-4o-mini
+```
+
+Normally an ACP client starts this command and owns its standard streams. For
+example, configure the client command as:
+
+```text
+go run /absolute/path/to/trpc-agent-go/examples/acp
+```
+
+Do not print application logs to standard output because it carries the ACP
+protocol. Send diagnostics to standard error.
+
+## Initial capability scope
+
+The adapter supports:
+
+- ACP v1 initialization
+- session creation and close
+- text and resource-link prompts
+- streaming assistant text updates, with opt-in thought updates
+- tool-call start/completion updates
+- prompt usage and stop reasons
+- session cancellation
+
+Dynamic MCP servers, session load/list/resume, client filesystem and terminal
+callbacks, image/audio prompts, and permission requests are not advertised.
+
+ACP supplies an absolute working directory for each session. Use
+`acp.WithRunOptionsFunc` when constructing the server to pass that directory to
+a request-scoped coding agent or agent factory:
+
+```go
+acp.WithRunOptionsFunc(func(session acp.Session) []agent.RunOption {
+	return []agent.RunOption{
+		agent.WithRuntimeState(map[string]any{"workspace": session.CWD}),
+	}
+})
+```

--- a/examples/acp/main.go
+++ b/examples/acp/main.go
@@ -25,6 +25,13 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	modelName := flag.String("model", "gpt-4o-mini", "OpenAI model name")
 	flag.Parse()
 
@@ -42,14 +49,13 @@ func main() {
 		acpserver.WithImplementation("trpc-agent-go-example", "1.0.0"),
 	)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	if err := server.Serve(ctx, os.Stdin, os.Stdout); err != nil &&
 		!errors.Is(err, context.Canceled) {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/examples/acp/main.go
+++ b/examples/acp/main.go
@@ -1,0 +1,55 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main exposes a basic LLM agent over ACP stdio.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	acpserver "trpc.group/trpc-go/trpc-agent-go/server/acp"
+)
+
+func main() {
+	modelName := flag.String("model", "gpt-4o-mini", "OpenAI model name")
+	flag.Parse()
+
+	agent := llmagent.New(
+		"acp-assistant",
+		llmagent.WithModel(openai.New(*modelName)),
+		llmagent.WithDescription("A helpful assistant exposed through ACP"),
+		llmagent.WithInstruction("Answer the user's request clearly and concisely."),
+	)
+	r := runner.NewRunner("acp-example", agent)
+	defer r.Close()
+
+	server, err := acpserver.New(
+		r,
+		acpserver.WithImplementation("trpc-agent-go-example", "1.0.0"),
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	if err := server.Serve(ctx, os.Stdin, os.Stdout); err != nil &&
+		!errors.Is(err, context.Canceled) {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coder/acp-go-sdk v0.13.5 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -22,6 +22,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/acp-go-sdk v0.13.5 h1:LI9jq5xon7xslaYlnoktvTVyDlE37yIk2daT7N9ASYk=
+github.com/coder/acp-go-sdk v0.13.5/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/bufbuild/protocompile v0.14.1
+	github.com/coder/acp-go-sdk v0.13.5
 	github.com/creack/pty v1.1.24
 	github.com/go-ego/gse v1.0.0
 	github.com/gomutex/godocx v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
+github.com/coder/acp-go-sdk v0.13.5 h1:LI9jq5xon7xslaYlnoktvTVyDlE37yIk2daT7N9ASYk=
+github.com/coder/acp-go-sdk v0.13.5/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/acp/converter.go
+++ b/server/acp/converter.go
@@ -1,0 +1,242 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package acp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func promptToMessage(blocks []acpsdk.ContentBlock) (model.Message, error) {
+	message := model.Message{Role: model.RoleUser}
+	var text strings.Builder
+	for _, block := range blocks {
+		switch {
+		case block.Text != nil:
+			text.WriteString(block.Text.Text)
+		case block.ResourceLink != nil:
+			mimeType := ""
+			if block.ResourceLink.MimeType != nil {
+				mimeType = *block.ResourceLink.MimeType
+			}
+			message.AddFileURL(
+				block.ResourceLink.Name,
+				block.ResourceLink.Uri,
+				mimeType,
+			)
+		case block.Image != nil:
+			return model.Message{}, errors.New("image content is not supported")
+		case block.Audio != nil:
+			return model.Message{}, errors.New("audio content is not supported")
+		case block.Resource != nil:
+			return model.Message{}, errors.New("embedded resource content is not supported")
+		default:
+			return model.Message{}, errors.New("empty content block")
+		}
+	}
+	message.Content = text.String()
+	return message, nil
+}
+
+type turnState struct {
+	textByResponse      map[string]string
+	reasoningByResponse map[string]string
+	toolCalls           map[string]toolCallState
+	stopReason          acpsdk.StopReason
+	usage               *acpsdk.Usage
+	reasoningEnabled    bool
+}
+
+type toolCallState struct {
+	title     string
+	arguments string
+}
+
+func newTurnState(reasoningEnabled bool) *turnState {
+	return &turnState{
+		textByResponse:      make(map[string]string),
+		reasoningByResponse: make(map[string]string),
+		toolCalls:           make(map[string]toolCallState),
+		stopReason:          acpsdk.StopReasonEndTurn,
+		reasoningEnabled:    reasoningEnabled,
+	}
+}
+
+func (s *turnState) translate(evt *event.Event) ([]acpsdk.SessionUpdate, error) {
+	if evt == nil || evt.Response == nil {
+		return nil, nil
+	}
+	if evt.IsTerminalError() {
+		return nil, evt.Response.Error
+	}
+	if evt.Response.Usage != nil {
+		s.usage = &acpsdk.Usage{
+			InputTokens:  evt.Response.Usage.PromptTokens,
+			OutputTokens: evt.Response.Usage.CompletionTokens,
+			TotalTokens:  evt.Response.Usage.TotalTokens,
+		}
+	}
+
+	var updates []acpsdk.SessionUpdate
+	for _, choice := range evt.Response.Choices {
+		key := responseKey(evt, choice.Index)
+		if s.reasoningEnabled {
+			if reasoning := s.contentDelta(
+				s.reasoningByResponse,
+				key,
+				choice.Delta.ReasoningContent,
+				choice.Message.ReasoningContent,
+			); reasoning != "" {
+				updates = append(updates, acpsdk.UpdateAgentThoughtText(reasoning))
+			}
+		}
+		if text := s.contentDelta(
+			s.textByResponse,
+			key,
+			choice.Delta.Content,
+			choice.Message.Content,
+		); text != "" && choice.Delta.ToolID == "" && choice.Message.ToolID == "" {
+			updates = append(updates, acpsdk.UpdateAgentMessageText(text))
+		}
+		updates = append(updates, s.translateToolCalls(choice.Delta.ToolCalls)...)
+		updates = append(updates, s.translateToolCalls(choice.Message.ToolCalls)...)
+		if update, ok := translateToolResult(choice.Delta); ok {
+			updates = append(updates, update)
+		}
+		if update, ok := translateToolResult(choice.Message); ok {
+			updates = append(updates, update)
+		}
+		s.applyFinishReason(choice.FinishReason)
+	}
+	return updates, nil
+}
+
+func responseKey(evt *event.Event, choiceIndex int) string {
+	if evt.Response.ID != "" {
+		return fmt.Sprintf("%s/%d", evt.Response.ID, choiceIndex)
+	}
+	return fmt.Sprintf("%s/%d", evt.InvocationID, choiceIndex)
+}
+
+func (*turnState) contentDelta(
+	emitted map[string]string,
+	key string,
+	delta string,
+	message string,
+) string {
+	if delta != "" {
+		emitted[key] += delta
+		return delta
+	}
+	if message == "" {
+		return ""
+	}
+	previous := emitted[key]
+	emitted[key] = message
+	if strings.HasPrefix(message, previous) {
+		return strings.TrimPrefix(message, previous)
+	}
+	return message
+}
+
+func (s *turnState) translateToolCalls(
+	toolCalls []model.ToolCall,
+) []acpsdk.SessionUpdate {
+	var updates []acpsdk.SessionUpdate
+	for _, toolCall := range toolCalls {
+		if toolCall.ID == "" {
+			continue
+		}
+		title := toolCall.Function.Name
+		if title == "" {
+			title = "Tool call"
+		}
+		arguments := string(toolCall.Function.Arguments)
+		current := toolCallState{title: title, arguments: arguments}
+		previous, exists := s.toolCalls[toolCall.ID]
+		if !exists {
+			s.toolCalls[toolCall.ID] = current
+			updates = append(updates, acpsdk.StartToolCall(
+				acpsdk.ToolCallId(toolCall.ID),
+				title,
+				acpsdk.WithStartKind(acpsdk.ToolKindOther),
+				acpsdk.WithStartStatus(acpsdk.ToolCallStatusInProgress),
+				acpsdk.WithStartRawInput(decodeJSONArgument(arguments)),
+			))
+			continue
+		}
+		if previous == current {
+			continue
+		}
+		s.toolCalls[toolCall.ID] = current
+		updates = append(updates, acpsdk.UpdateToolCall(
+			acpsdk.ToolCallId(toolCall.ID),
+			acpsdk.WithUpdateTitle(title),
+			acpsdk.WithUpdateRawInput(decodeJSONArgument(arguments)),
+		))
+	}
+	return updates
+}
+
+func decodeJSONArgument(argument string) any {
+	if argument == "" {
+		return nil
+	}
+	var decoded any
+	if json.Unmarshal([]byte(argument), &decoded) == nil {
+		return decoded
+	}
+	return argument
+}
+
+func translateToolResult(message model.Message) (acpsdk.SessionUpdate, bool) {
+	if message.ToolID == "" {
+		return acpsdk.SessionUpdate{}, false
+	}
+	options := []acpsdk.ToolCallUpdateOpt{
+		acpsdk.WithUpdateStatus(acpsdk.ToolCallStatusCompleted),
+		acpsdk.WithUpdateRawOutput(message.Content),
+	}
+	if message.Content != "" {
+		options = append(options, acpsdk.WithUpdateContent([]acpsdk.ToolCallContent{
+			acpsdk.ToolContent(acpsdk.TextBlock(message.Content)),
+		}))
+	}
+	return acpsdk.UpdateToolCall(acpsdk.ToolCallId(message.ToolID), options...), true
+}
+
+func (s *turnState) applyFinishReason(finishReason *string) {
+	if finishReason == nil {
+		return
+	}
+	switch *finishReason {
+	case "length":
+		s.stopReason = acpsdk.StopReasonMaxTokens
+	case "content_filter", "refusal":
+		s.stopReason = acpsdk.StopReasonRefusal
+	case "cancelled", "canceled":
+		s.stopReason = acpsdk.StopReasonCancelled
+	}
+}
+
+func (s *turnState) response(messageID *string) acpsdk.PromptResponse {
+	return acpsdk.PromptResponse{
+		StopReason:    s.stopReason,
+		Usage:         s.usage,
+		UserMessageId: messageID,
+	}
+}

--- a/server/acp/converter.go
+++ b/server/acp/converter.go
@@ -84,11 +84,12 @@ func (s *turnState) translate(evt *event.Event) ([]acpsdk.SessionUpdate, error) 
 		return nil, evt.Response.Error
 	}
 	if evt.Response.Usage != nil {
-		s.usage = &acpsdk.Usage{
-			InputTokens:  evt.Response.Usage.PromptTokens,
-			OutputTokens: evt.Response.Usage.CompletionTokens,
-			TotalTokens:  evt.Response.Usage.TotalTokens,
+		if s.usage == nil {
+			s.usage = &acpsdk.Usage{}
 		}
+		s.usage.InputTokens += evt.Response.Usage.PromptTokens
+		s.usage.OutputTokens += evt.Response.Usage.CompletionTokens
+		s.usage.TotalTokens += evt.Response.Usage.TotalTokens
 	}
 
 	var updates []acpsdk.SessionUpdate
@@ -121,6 +122,10 @@ func (s *turnState) translate(evt *event.Event) ([]acpsdk.SessionUpdate, error) 
 			updates = append(updates, update)
 		}
 		s.applyFinishReason(choice.FinishReason)
+		if evt.Response.ID == "" && !evt.Response.IsPartial {
+			delete(s.textByResponse, key)
+			delete(s.reasoningByResponse, key)
+		}
 	}
 	return updates, nil
 }

--- a/server/acp/converter.go
+++ b/server/acp/converter.go
@@ -55,10 +55,12 @@ func promptToMessage(blocks []acpsdk.ContentBlock) (model.Message, error) {
 type turnState struct {
 	textByResponse      map[string]string
 	reasoningByResponse map[string]string
+	activeResponses     map[string]string
 	toolCalls           map[string]toolCallState
 	stopReason          acpsdk.StopReason
 	usage               *acpsdk.Usage
 	reasoningEnabled    bool
+	nextResponse        uint64
 }
 
 type toolCallState struct {
@@ -70,6 +72,7 @@ func newTurnState(reasoningEnabled bool) *turnState {
 	return &turnState{
 		textByResponse:      make(map[string]string),
 		reasoningByResponse: make(map[string]string),
+		activeResponses:     make(map[string]string),
 		toolCalls:           make(map[string]toolCallState),
 		stopReason:          acpsdk.StopReasonEndTurn,
 		reasoningEnabled:    reasoningEnabled,
@@ -83,7 +86,7 @@ func (s *turnState) translate(evt *event.Event) ([]acpsdk.SessionUpdate, error) 
 	if evt.IsTerminalError() {
 		return nil, evt.Response.Error
 	}
-	if evt.Response.Usage != nil {
+	if evt.Response.Usage != nil && !evt.Response.IsPartial {
 		if s.usage == nil {
 			s.usage = &acpsdk.Usage{}
 		}
@@ -94,7 +97,8 @@ func (s *turnState) translate(evt *event.Event) ([]acpsdk.SessionUpdate, error) 
 
 	var updates []acpsdk.SessionUpdate
 	for _, choice := range evt.Response.Choices {
-		key := responseKey(evt, choice.Index)
+		streamKey := responseStreamKey(evt, choice.Index)
+		key := s.responseKey(evt, streamKey)
 		if s.reasoningEnabled {
 			if reasoning := s.contentDelta(
 				s.reasoningByResponse,
@@ -122,19 +126,34 @@ func (s *turnState) translate(evt *event.Event) ([]acpsdk.SessionUpdate, error) 
 			updates = append(updates, update)
 		}
 		s.applyFinishReason(choice.FinishReason)
-		if evt.Response.ID == "" && !evt.Response.IsPartial {
+		if !evt.Response.IsPartial {
 			delete(s.textByResponse, key)
 			delete(s.reasoningByResponse, key)
+			if s.activeResponses[streamKey] == key {
+				delete(s.activeResponses, streamKey)
+			}
 		}
 	}
 	return updates, nil
 }
 
-func responseKey(evt *event.Event, choiceIndex int) string {
-	if evt.Response.ID != "" {
-		return fmt.Sprintf("%s/%d", evt.Response.ID, choiceIndex)
-	}
+func responseStreamKey(evt *event.Event, choiceIndex int) string {
 	return fmt.Sprintf("%s/%d", evt.InvocationID, choiceIndex)
+}
+
+func (s *turnState) responseKey(evt *event.Event, streamKey string) string {
+	if evt.Response.ID != "" {
+		key := fmt.Sprintf("%s/%s", evt.Response.ID, streamKey)
+		s.activeResponses[streamKey] = key
+		return key
+	}
+	if key := s.activeResponses[streamKey]; key != "" {
+		return key
+	}
+	s.nextResponse++
+	key := fmt.Sprintf("response-%d/%s", s.nextResponse, streamKey)
+	s.activeResponses[streamKey] = key
+	return key
 }
 
 func (*turnState) contentDelta(
@@ -228,10 +247,19 @@ func (s *turnState) applyFinishReason(finishReason *string) {
 	if finishReason == nil {
 		return
 	}
-	switch *finishReason {
-	case "length":
+	switch strings.ToLower(strings.TrimSpace(*finishReason)) {
+	case "length", "max_tokens":
 		s.stopReason = acpsdk.StopReasonMaxTokens
-	case "content_filter", "refusal":
+	case "blocked",
+		"blocklist",
+		"content_filter",
+		"content_filtered",
+		"guardrail_intervened",
+		"prohibited_content",
+		"recitation",
+		"refusal",
+		"safety",
+		"spii":
 		s.stopReason = acpsdk.StopReasonRefusal
 	case "cancelled", "canceled":
 		s.stopReason = acpsdk.StopReasonCancelled

--- a/server/acp/converter_test.go
+++ b/server/acp/converter_test.go
@@ -1,0 +1,130 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package acp
+
+import (
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestPromptToMessage(t *testing.T) {
+	mimeType := "text/plain"
+	message, err := promptToMessage([]acpsdk.ContentBlock{
+		acpsdk.TextBlock("explain "),
+		{
+			ResourceLink: &acpsdk.ContentBlockResourceLink{
+				Name:     "README.md",
+				Uri:      "file:///workspace/README.md",
+				MimeType: &mimeType,
+				Type:     "resource_link",
+			},
+		},
+		acpsdk.TextBlock("briefly"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, model.RoleUser, message.Role)
+	assert.Equal(t, "explain briefly", message.Content)
+	require.Len(t, message.ContentParts, 1)
+	require.NotNil(t, message.ContentParts[0].File)
+	assert.Equal(t, "README.md", message.ContentParts[0].File.Name)
+	assert.Equal(t, "file:///workspace/README.md", message.ContentParts[0].File.URL)
+	assert.Equal(t, mimeType, message.ContentParts[0].File.MimeType)
+}
+
+func TestPromptToMessageRejectsUnadvertisedContent(t *testing.T) {
+	_, err := promptToMessage([]acpsdk.ContentBlock{
+		acpsdk.ImageBlock("aGVsbG8=", "image/png"),
+	})
+	assert.ErrorContains(t, err, "image content is not supported")
+}
+
+func TestTurnStateTranslatesRunnerEvents(t *testing.T) {
+	state := newTurnState(true)
+	finishReason := "length"
+	events := []*event.Event{
+		{
+			InvocationID: "invocation",
+			Response: &model.Response{
+				ID:        "response",
+				IsPartial: true,
+				Choices: []model.Choice{{
+					Delta: model.Message{
+						Content:          "hel",
+						ReasoningContent: "think",
+					},
+				}},
+			},
+		},
+		{
+			InvocationID: "invocation",
+			Response: &model.Response{
+				ID: "response",
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Content:          "hello",
+						ReasoningContent: "thinking",
+						ToolCalls: []model.ToolCall{{
+							ID: "call-1",
+							Function: model.FunctionDefinitionParam{
+								Name:      "search",
+								Arguments: []byte(`{"query":"ACP"}`),
+							},
+						}},
+					},
+					FinishReason: &finishReason,
+				}},
+				Usage: &model.Usage{
+					PromptTokens:     3,
+					CompletionTokens: 5,
+					TotalTokens:      8,
+				},
+			},
+		},
+		{
+			InvocationID: "invocation",
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Role:    model.RoleTool,
+						ToolID:  "call-1",
+						Content: "result",
+					},
+				}},
+			},
+		},
+	}
+
+	var updates []acpsdk.SessionUpdate
+	for _, evt := range events {
+		translated, err := state.translate(evt)
+		require.NoError(t, err)
+		updates = append(updates, translated...)
+	}
+	require.Len(t, updates, 6)
+	assert.Equal(t, "think", updates[0].AgentThoughtChunk.Content.Text.Text)
+	assert.Equal(t, "hel", updates[1].AgentMessageChunk.Content.Text.Text)
+	assert.Equal(t, "ing", updates[2].AgentThoughtChunk.Content.Text.Text)
+	assert.Equal(t, "lo", updates[3].AgentMessageChunk.Content.Text.Text)
+	require.NotNil(t, updates[4].ToolCall)
+	assert.Equal(t, acpsdk.ToolCallId("call-1"), updates[4].ToolCall.ToolCallId)
+	require.NotNil(t, updates[5].ToolCallUpdate)
+	assert.Equal(t, acpsdk.ToolCallStatusCompleted, *updates[5].ToolCallUpdate.Status)
+
+	response := state.response(nil)
+	assert.Equal(t, acpsdk.StopReasonMaxTokens, response.StopReason)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, 8, response.Usage.TotalTokens)
+}

--- a/server/acp/converter_test.go
+++ b/server/acp/converter_test.go
@@ -128,3 +128,39 @@ func TestTurnStateTranslatesRunnerEvents(t *testing.T) {
 	require.NotNil(t, response.Usage)
 	assert.Equal(t, 8, response.Usage.TotalTokens)
 }
+
+func TestTurnStateAccumulatesUsageAcrossModelCalls(t *testing.T) {
+	state := newTurnState(false)
+	for _, usage := range []*model.Usage{
+		{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5},
+		{PromptTokens: 4, CompletionTokens: 1, TotalTokens: 5},
+	} {
+		_, err := state.translate(&event.Event{
+			Response: &model.Response{Usage: usage},
+		})
+		require.NoError(t, err)
+	}
+
+	response := state.response(nil)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, 6, response.Usage.InputTokens)
+	assert.Equal(t, 4, response.Usage.OutputTokens)
+	assert.Equal(t, 10, response.Usage.TotalTokens)
+}
+
+func TestTurnStateSeparatesCompletedResponsesWithoutIDs(t *testing.T) {
+	state := newTurnState(false)
+	for _, text := range []string{"first", "second"} {
+		updates, err := state.translate(&event.Event{
+			InvocationID: "invocation",
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{Content: text},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, updates, 1)
+		assert.Equal(t, text, updates[0].AgentMessageChunk.Content.Text.Text)
+	}
+}

--- a/server/acp/converter_test.go
+++ b/server/acp/converter_test.go
@@ -62,7 +62,7 @@ func TestTurnStateTranslatesRunnerEvents(t *testing.T) {
 				IsPartial: true,
 				Choices: []model.Choice{{
 					Delta: model.Message{
-						Content:          "hel",
+						Content:          "hell",
 						ReasoningContent: "think",
 					},
 				}},
@@ -115,9 +115,9 @@ func TestTurnStateTranslatesRunnerEvents(t *testing.T) {
 	}
 	require.Len(t, updates, 6)
 	assert.Equal(t, "think", updates[0].AgentThoughtChunk.Content.Text.Text)
-	assert.Equal(t, "hel", updates[1].AgentMessageChunk.Content.Text.Text)
+	assert.Equal(t, "hell", updates[1].AgentMessageChunk.Content.Text.Text)
 	assert.Equal(t, "ing", updates[2].AgentThoughtChunk.Content.Text.Text)
-	assert.Equal(t, "lo", updates[3].AgentMessageChunk.Content.Text.Text)
+	assert.Equal(t, "o", updates[3].AgentMessageChunk.Content.Text.Text)
 	require.NotNil(t, updates[4].ToolCall)
 	assert.Equal(t, acpsdk.ToolCallId("call-1"), updates[4].ToolCall.ToolCallId)
 	require.NotNil(t, updates[5].ToolCallUpdate)

--- a/server/acp/converter_test.go
+++ b/server/acp/converter_test.go
@@ -45,10 +45,42 @@ func TestPromptToMessage(t *testing.T) {
 }
 
 func TestPromptToMessageRejectsUnadvertisedContent(t *testing.T) {
-	_, err := promptToMessage([]acpsdk.ContentBlock{
-		acpsdk.ImageBlock("aGVsbG8=", "image/png"),
-	})
-	assert.ErrorContains(t, err, "image content is not supported")
+	tests := []struct {
+		name  string
+		block acpsdk.ContentBlock
+		err   string
+	}{
+		{
+			name:  "image",
+			block: acpsdk.ImageBlock("aGVsbG8=", "image/png"),
+			err:   "image content is not supported",
+		},
+		{
+			name:  "audio",
+			block: acpsdk.AudioBlock("aGVsbG8=", "audio/wav"),
+			err:   "audio content is not supported",
+		},
+		{
+			name: "embedded resource",
+			block: acpsdk.ResourceBlock(acpsdk.EmbeddedResourceResource{
+				TextResourceContents: &acpsdk.TextResourceContents{
+					Uri:  "file:///workspace/README.md",
+					Text: "contents",
+				},
+			}),
+			err: "embedded resource content is not supported",
+		},
+		{
+			name: "empty",
+			err:  "empty content block",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := promptToMessage([]acpsdk.ContentBlock{test.block})
+			assert.ErrorContains(t, err, test.err)
+		})
+	}
 }
 
 func TestTurnStateTranslatesRunnerEvents(t *testing.T) {
@@ -162,5 +194,66 @@ func TestTurnStateSeparatesCompletedResponsesWithoutIDs(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, updates, 1)
 		assert.Equal(t, text, updates[0].AgentMessageChunk.Content.Text.Text)
+	}
+}
+
+func TestTurnStateHandlesErrorsAndEmptyEvents(t *testing.T) {
+	state := newTurnState(false)
+	for _, evt := range []*event.Event{nil, {}} {
+		updates, err := state.translate(evt)
+		require.NoError(t, err)
+		assert.Empty(t, updates)
+	}
+
+	wantErr := &model.ResponseError{Message: "model failed"}
+	_, err := state.translate(&event.Event{
+		Response: &model.Response{
+			Done:  true,
+			Error: wantErr,
+		},
+	})
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestTurnStateUpdatesToolCalls(t *testing.T) {
+	state := newTurnState(false)
+	toolCall := model.ToolCall{
+		ID: "call-1",
+		Function: model.FunctionDefinitionParam{
+			Arguments: []byte(`{"query":"ACP"}`),
+		},
+	}
+
+	updates := state.translateToolCalls([]model.ToolCall{{}, toolCall})
+	require.Len(t, updates, 1)
+	assert.Equal(t, "Tool call", updates[0].ToolCall.Title)
+
+	assert.Empty(t, state.translateToolCalls([]model.ToolCall{toolCall}))
+	toolCall.Function.Name = "search"
+	toolCall.Function.Arguments = []byte("incomplete JSON")
+	updates = state.translateToolCalls([]model.ToolCall{toolCall})
+	require.Len(t, updates, 1)
+	require.NotNil(t, updates[0].ToolCallUpdate)
+	assert.Equal(t, "search", *updates[0].ToolCallUpdate.Title)
+}
+
+func TestTurnStateMapsFinishReasons(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   acpsdk.StopReason
+	}{
+		{reason: "content_filter", want: acpsdk.StopReasonRefusal},
+		{reason: "refusal", want: acpsdk.StopReasonRefusal},
+		{reason: "cancelled", want: acpsdk.StopReasonCancelled},
+		{reason: "canceled", want: acpsdk.StopReasonCancelled},
+		{reason: "stop", want: acpsdk.StopReasonEndTurn},
+	}
+	for _, test := range tests {
+		t.Run(test.reason, func(t *testing.T) {
+			state := newTurnState(false)
+			state.applyFinishReason(nil)
+			state.applyFinishReason(&test.reason)
+			assert.Equal(t, test.want, state.response(nil).StopReason)
+		})
 	}
 }

--- a/server/acp/converter_test.go
+++ b/server/acp/converter_test.go
@@ -163,12 +163,40 @@ func TestTurnStateTranslatesRunnerEvents(t *testing.T) {
 
 func TestTurnStateAccumulatesUsageAcrossModelCalls(t *testing.T) {
 	state := newTurnState(false)
-	for _, usage := range []*model.Usage{
-		{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5},
-		{PromptTokens: 4, CompletionTokens: 1, TotalTokens: 5},
+	for _, response := range []*model.Response{
+		{
+			IsPartial: true,
+			Usage: &model.Usage{
+				PromptTokens:     1,
+				CompletionTokens: 1,
+				TotalTokens:      2,
+			},
+		},
+		{
+			Usage: &model.Usage{
+				PromptTokens:     2,
+				CompletionTokens: 3,
+				TotalTokens:      5,
+			},
+		},
+		{
+			IsPartial: true,
+			Usage: &model.Usage{
+				PromptTokens:     3,
+				CompletionTokens: 1,
+				TotalTokens:      4,
+			},
+		},
+		{
+			Usage: &model.Usage{
+				PromptTokens:     4,
+				CompletionTokens: 1,
+				TotalTokens:      5,
+			},
+		},
 	} {
 		_, err := state.translate(&event.Event{
-			Response: &model.Response{Usage: usage},
+			Response: response,
 		})
 		require.NoError(t, err)
 	}
@@ -184,7 +212,6 @@ func TestTurnStateSeparatesCompletedResponsesWithoutIDs(t *testing.T) {
 	state := newTurnState(false)
 	for _, text := range []string{"first", "second"} {
 		updates, err := state.translate(&event.Event{
-			InvocationID: "invocation",
 			Response: &model.Response{
 				Choices: []model.Choice{{
 					Message: model.Message{Content: text},
@@ -195,6 +222,46 @@ func TestTurnStateSeparatesCompletedResponsesWithoutIDs(t *testing.T) {
 		require.Len(t, updates, 1)
 		assert.Equal(t, text, updates[0].AgentMessageChunk.Content.Text.Text)
 	}
+}
+
+func TestTurnStateAssociatesIDLessFinalResponseWithStream(t *testing.T) {
+	state := newTurnState(true)
+	events := []*event.Event{
+		{
+			InvocationID: "invocation",
+			Response: &model.Response{
+				ID:        "response",
+				IsPartial: true,
+				Choices: []model.Choice{{
+					Delta: model.Message{
+						Content:          "answer",
+						ReasoningContent: "thought",
+					},
+				}},
+			},
+		},
+		{
+			InvocationID: "invocation",
+			Response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{
+						Content:          "answer",
+						ReasoningContent: "thought",
+					},
+				}},
+			},
+		},
+	}
+
+	var updates []acpsdk.SessionUpdate
+	for _, evt := range events {
+		translated, err := state.translate(evt)
+		require.NoError(t, err)
+		updates = append(updates, translated...)
+	}
+	require.Len(t, updates, 2)
+	assert.Equal(t, "thought", updates[0].AgentThoughtChunk.Content.Text.Text)
+	assert.Equal(t, "answer", updates[1].AgentMessageChunk.Content.Text.Text)
 }
 
 func TestTurnStateHandlesErrorsAndEmptyEvents(t *testing.T) {
@@ -242,7 +309,12 @@ func TestTurnStateMapsFinishReasons(t *testing.T) {
 		reason string
 		want   acpsdk.StopReason
 	}{
+		{reason: "length", want: acpsdk.StopReasonMaxTokens},
+		{reason: "max_tokens", want: acpsdk.StopReasonMaxTokens},
+		{reason: "MAX_TOKENS", want: acpsdk.StopReasonMaxTokens},
 		{reason: "content_filter", want: acpsdk.StopReasonRefusal},
+		{reason: "SAFETY", want: acpsdk.StopReasonRefusal},
+		{reason: "guardrail_intervened", want: acpsdk.StopReasonRefusal},
 		{reason: "refusal", want: acpsdk.StopReasonRefusal},
 		{reason: "cancelled", want: acpsdk.StopReasonCancelled},
 		{reason: "canceled", want: acpsdk.StopReasonCancelled},

--- a/server/acp/server.go
+++ b/server/acp/server.go
@@ -1,0 +1,532 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package acp exposes a runner through Agent Client Protocol (ACP) v1.
+package acp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+	"github.com/google/uuid"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+)
+
+const (
+	defaultImplementationName    = "trpc-agent-go"
+	defaultImplementationVersion = "dev"
+	defaultUserID                = "acp"
+)
+
+// Session describes an ACP session when run options are resolved.
+type Session struct {
+	ID  string
+	CWD string
+}
+
+// RunOptionsFunc returns request-scoped runner options for an ACP session.
+type RunOptionsFunc func(Session) []agent.RunOption
+
+// Option configures a Server.
+type Option func(*options)
+
+type options struct {
+	userID             string
+	implementationName string
+	implementationVer  string
+	sessionIDGenerator func() string
+	runOptions         []agent.RunOption
+	runOptionsFunc     RunOptionsFunc
+	reasoningEnabled   bool
+}
+
+// WithUserID sets the runner user ID shared by sessions on this server.
+func WithUserID(userID string) Option {
+	return func(options *options) {
+		options.userID = userID
+	}
+}
+
+// WithImplementation sets the implementation metadata returned by initialize.
+func WithImplementation(name, version string) Option {
+	return func(options *options) {
+		options.implementationName = name
+		options.implementationVer = version
+	}
+}
+
+// WithSessionIDGenerator replaces the default UUID session ID generator.
+func WithSessionIDGenerator(generator func() string) Option {
+	return func(options *options) {
+		options.sessionIDGenerator = generator
+	}
+}
+
+// WithRunOptions adds static options to every runner invocation.
+func WithRunOptions(runOptions ...agent.RunOption) Option {
+	return func(options *options) {
+		options.runOptions = append(options.runOptions, runOptions...)
+	}
+}
+
+// WithRunOptionsFunc sets a function that derives runner options from an ACP
+// session. It can use Session.CWD to configure a request-scoped coding agent.
+func WithRunOptionsFunc(runOptionsFunc RunOptionsFunc) Option {
+	return func(options *options) {
+		options.runOptionsFunc = runOptionsFunc
+	}
+}
+
+// WithReasoningContentEnabled controls whether model reasoning is exposed as
+// ACP agent_thought_chunk updates. It is disabled by default.
+func WithReasoningContentEnabled(enabled bool) Option {
+	return func(options *options) {
+		options.reasoningEnabled = enabled
+	}
+}
+
+// Server adapts a runner to ACP connections.
+type Server struct {
+	runner             runner.Runner
+	managedRunner      runner.ManagedRunner
+	userID             string
+	implementation     acpsdk.Implementation
+	sessionIDGenerator func() string
+	runOptions         []agent.RunOption
+	runOptionsFunc     RunOptionsFunc
+	reasoningEnabled   bool
+}
+
+// New creates an ACP server backed by a runner.
+func New(r runner.Runner, opts ...Option) (*Server, error) {
+	if r == nil {
+		return nil, errors.New("acp: runner is required")
+	}
+	options := options{
+		userID:             defaultUserID,
+		implementationName: defaultImplementationName,
+		implementationVer:  defaultImplementationVersion,
+		sessionIDGenerator: uuid.NewString,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.userID == "" {
+		return nil, errors.New("acp: user ID is required")
+	}
+	if options.implementationName == "" {
+		return nil, errors.New("acp: implementation name is required")
+	}
+	if options.implementationVer == "" {
+		return nil, errors.New("acp: implementation version is required")
+	}
+	if options.sessionIDGenerator == nil {
+		return nil, errors.New("acp: session ID generator is required")
+	}
+	server := &Server{
+		runner:             r,
+		userID:             options.userID,
+		implementation:     acpsdk.Implementation{Name: options.implementationName, Version: options.implementationVer},
+		sessionIDGenerator: options.sessionIDGenerator,
+		runOptions:         append([]agent.RunOption(nil), options.runOptions...),
+		runOptionsFunc:     options.runOptionsFunc,
+		reasoningEnabled:   options.reasoningEnabled,
+	}
+	server.managedRunner, _ = r.(runner.ManagedRunner)
+	return server, nil
+}
+
+// Connection is an active ACP connection.
+type Connection struct {
+	connection *acpsdk.AgentSideConnection
+	agent      *protocolAgent
+}
+
+// Done is closed when the ACP peer disconnects.
+func (c *Connection) Done() <-chan struct{} {
+	return c.connection.Done()
+}
+
+// Connect starts serving one ACP connection over line-delimited JSON-RPC.
+// Input is read from the ACP client and output is written back to it.
+func (s *Server) Connect(input io.Reader, output io.Writer) (*Connection, error) {
+	if input == nil {
+		return nil, errors.New("acp: input is required")
+	}
+	if output == nil {
+		return nil, errors.New("acp: output is required")
+	}
+	protocolAgent := newProtocolAgent(s)
+	connection := acpsdk.NewAgentSideConnection(protocolAgent, output, input)
+	protocolAgent.connection = connection
+	go func() {
+		<-connection.Done()
+		protocolAgent.cancelAll()
+	}()
+	return &Connection{connection: connection, agent: protocolAgent}, nil
+}
+
+// Serve connects an ACP client and blocks until the peer disconnects or ctx is
+// canceled. Callers remain responsible for closing their transport.
+func (s *Server) Serve(ctx context.Context, input io.Reader, output io.Writer) error {
+	connection, err := s.Connect(input, output)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-connection.Done():
+		return nil
+	case <-ctx.Done():
+		connection.agent.cancelAll()
+		return ctx.Err()
+	}
+}
+
+type protocolAgent struct {
+	server     *Server
+	connection *acpsdk.AgentSideConnection
+	sessions   map[string]*sessionState
+	mu         sync.Mutex
+}
+
+type sessionState struct {
+	id        string
+	cwd       string
+	cancel    context.CancelFunc
+	requestID string
+	closed    bool
+	mu        sync.Mutex
+}
+
+func newProtocolAgent(server *Server) *protocolAgent {
+	return &protocolAgent{
+		server:   server,
+		sessions: make(map[string]*sessionState),
+	}
+}
+
+func (a *protocolAgent) Initialize(
+	_ context.Context,
+	request acpsdk.InitializeRequest,
+) (acpsdk.InitializeResponse, error) {
+	protocolVersion := request.ProtocolVersion
+	if protocolVersion != acpsdk.ProtocolVersionNumber {
+		protocolVersion = acpsdk.ProtocolVersionNumber
+	}
+	implementation := a.server.implementation
+	return acpsdk.InitializeResponse{
+		ProtocolVersion: protocolVersion,
+		AgentCapabilities: acpsdk.AgentCapabilities{
+			SessionCapabilities: acpsdk.SessionCapabilities{
+				Close: &acpsdk.SessionCloseCapabilities{},
+			},
+		},
+		AgentInfo:   &implementation,
+		AuthMethods: []acpsdk.AuthMethod{},
+	}, nil
+}
+
+func (a *protocolAgent) NewSession(
+	_ context.Context,
+	request acpsdk.NewSessionRequest,
+) (acpsdk.NewSessionResponse, error) {
+	if !filepath.IsAbs(request.Cwd) {
+		return acpsdk.NewSessionResponse{}, acpsdk.NewInvalidParams(
+			map[string]any{"cwd": "must be an absolute path"},
+		)
+	}
+	if len(request.McpServers) != 0 {
+		return acpsdk.NewSessionResponse{}, acpsdk.NewInvalidParams(
+			map[string]any{"mcpServers": "dynamic MCP servers are not supported"},
+		)
+	}
+	if len(request.AdditionalDirectories) != 0 {
+		return acpsdk.NewSessionResponse{}, acpsdk.NewInvalidParams(
+			map[string]any{"additionalDirectories": "additional directories are not supported"},
+		)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	sessionID := a.server.sessionIDGenerator()
+	if sessionID == "" {
+		return acpsdk.NewSessionResponse{}, errors.New("acp: generated empty session ID")
+	}
+	if _, exists := a.sessions[sessionID]; exists {
+		return acpsdk.NewSessionResponse{}, fmt.Errorf(
+			"acp: generated duplicate session ID %q",
+			sessionID,
+		)
+	}
+	a.sessions[sessionID] = &sessionState{id: sessionID, cwd: request.Cwd}
+	return acpsdk.NewSessionResponse{SessionId: acpsdk.SessionId(sessionID)}, nil
+}
+
+func (a *protocolAgent) Prompt(
+	ctx context.Context,
+	request acpsdk.PromptRequest,
+) (acpsdk.PromptResponse, error) {
+	session, err := a.getSession(string(request.SessionId))
+	if err != nil {
+		return acpsdk.PromptResponse{}, err
+	}
+	message, err := promptToMessage(request.Prompt)
+	if err != nil {
+		return acpsdk.PromptResponse{}, acpsdk.NewInvalidParams(
+			map[string]any{"prompt": err.Error()},
+		)
+	}
+	requestID := uuid.NewString()
+	runCtx, cancel := context.WithCancel(ctx)
+	if err := a.beginPrompt(session, requestID, cancel); err != nil {
+		cancel()
+		return acpsdk.PromptResponse{}, err
+	}
+	defer cancel()
+	defer a.finishPrompt(session, requestID)
+
+	runOptions := append([]agent.RunOption(nil), a.server.runOptions...)
+	if a.server.runOptionsFunc != nil {
+		runOptions = append(runOptions, a.server.runOptionsFunc(Session{
+			ID:  session.id,
+			CWD: session.cwd,
+		})...)
+	}
+	runOptions = append(runOptions, agent.WithRequestID(requestID))
+	events, err := a.server.runner.Run(
+		runCtx,
+		a.server.userID,
+		session.id,
+		message,
+		runOptions...,
+	)
+	if err != nil {
+		if runCtx.Err() != nil {
+			return canceledPromptResponse(request.MessageId), nil
+		}
+		return acpsdk.PromptResponse{}, err
+	}
+
+	turn := newTurnState(a.server.reasoningEnabled)
+	for {
+		select {
+		case <-runCtx.Done():
+			return canceledPromptResponse(request.MessageId), nil
+		case event, ok := <-events:
+			if !ok {
+				if runCtx.Err() != nil {
+					return canceledPromptResponse(request.MessageId), nil
+				}
+				return turn.response(request.MessageId), nil
+			}
+			updates, err := turn.translate(event)
+			if err != nil {
+				return acpsdk.PromptResponse{}, err
+			}
+			for _, update := range updates {
+				if err := a.connection.SessionUpdate(runCtx, acpsdk.SessionNotification{
+					SessionId: request.SessionId,
+					Update:    update,
+				}); err != nil {
+					if runCtx.Err() != nil {
+						return canceledPromptResponse(request.MessageId), nil
+					}
+					return acpsdk.PromptResponse{}, err
+				}
+			}
+		}
+	}
+}
+
+func canceledPromptResponse(messageID *string) acpsdk.PromptResponse {
+	return acpsdk.PromptResponse{
+		StopReason:    acpsdk.StopReasonCancelled,
+		UserMessageId: messageID,
+	}
+}
+
+func (a *protocolAgent) Cancel(
+	_ context.Context,
+	request acpsdk.CancelNotification,
+) error {
+	session, err := a.getSession(string(request.SessionId))
+	if err != nil {
+		return nil
+	}
+	a.cancelPrompt(session)
+	return nil
+}
+
+func (a *protocolAgent) CloseSession(
+	_ context.Context,
+	request acpsdk.CloseSessionRequest,
+) (acpsdk.CloseSessionResponse, error) {
+	sessionID := string(request.SessionId)
+	a.mu.Lock()
+	session, ok := a.sessions[sessionID]
+	if ok {
+		delete(a.sessions, sessionID)
+	}
+	a.mu.Unlock()
+	if !ok {
+		return acpsdk.CloseSessionResponse{}, acpsdk.NewInvalidParams(
+			map[string]any{"sessionId": "unknown session"},
+		)
+	}
+	a.closeSession(session)
+	return acpsdk.CloseSessionResponse{}, nil
+}
+
+func (a *protocolAgent) getSession(sessionID string) (*sessionState, error) {
+	a.mu.Lock()
+	session := a.sessions[sessionID]
+	a.mu.Unlock()
+	if session == nil {
+		return nil, acpsdk.NewInvalidParams(
+			map[string]any{"sessionId": "unknown session"},
+		)
+	}
+	return session, nil
+}
+
+func (a *protocolAgent) beginPrompt(
+	session *sessionState,
+	requestID string,
+	cancel context.CancelFunc,
+) error {
+	session.mu.Lock()
+	if session.closed {
+		session.mu.Unlock()
+		return acpsdk.NewInvalidParams(
+			map[string]any{"sessionId": "session is closed"},
+		)
+	}
+	previousCancel := session.cancel
+	previousRequestID := session.requestID
+	session.cancel = cancel
+	session.requestID = requestID
+	session.mu.Unlock()
+	if previousCancel != nil {
+		previousCancel()
+	}
+	if previousRequestID != "" && a.server.managedRunner != nil {
+		a.server.managedRunner.Cancel(previousRequestID)
+	}
+	return nil
+}
+
+func (a *protocolAgent) finishPrompt(session *sessionState, requestID string) {
+	session.mu.Lock()
+	if session.requestID == requestID {
+		session.cancel = nil
+		session.requestID = ""
+	}
+	session.mu.Unlock()
+}
+
+func (a *protocolAgent) cancelPrompt(session *sessionState) {
+	session.mu.Lock()
+	cancel := session.cancel
+	requestID := session.requestID
+	session.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if requestID != "" && a.server.managedRunner != nil {
+		a.server.managedRunner.Cancel(requestID)
+	}
+}
+
+func (a *protocolAgent) closeSession(session *sessionState) {
+	session.mu.Lock()
+	session.closed = true
+	cancel := session.cancel
+	requestID := session.requestID
+	session.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if requestID != "" && a.server.managedRunner != nil {
+		a.server.managedRunner.Cancel(requestID)
+	}
+}
+
+func (a *protocolAgent) cancelAll() {
+	a.mu.Lock()
+	sessions := make([]*sessionState, 0, len(a.sessions))
+	for _, session := range a.sessions {
+		sessions = append(sessions, session)
+	}
+	a.mu.Unlock()
+	for _, session := range sessions {
+		a.cancelPrompt(session)
+	}
+}
+
+func (*protocolAgent) Authenticate(
+	context.Context,
+	acpsdk.AuthenticateRequest,
+) (acpsdk.AuthenticateResponse, error) {
+	return acpsdk.AuthenticateResponse{}, acpsdk.NewMethodNotFound(
+		acpsdk.AgentMethodAuthenticate,
+	)
+}
+
+func (*protocolAgent) Logout(
+	context.Context,
+	acpsdk.LogoutRequest,
+) (acpsdk.LogoutResponse, error) {
+	return acpsdk.LogoutResponse{}, acpsdk.NewMethodNotFound(
+		acpsdk.AgentMethodLogout,
+	)
+}
+
+func (*protocolAgent) ListSessions(
+	context.Context,
+	acpsdk.ListSessionsRequest,
+) (acpsdk.ListSessionsResponse, error) {
+	return acpsdk.ListSessionsResponse{}, acpsdk.NewMethodNotFound(
+		acpsdk.AgentMethodSessionList,
+	)
+}
+
+func (*protocolAgent) ResumeSession(
+	context.Context,
+	acpsdk.ResumeSessionRequest,
+) (acpsdk.ResumeSessionResponse, error) {
+	return acpsdk.ResumeSessionResponse{}, acpsdk.NewMethodNotFound(
+		acpsdk.AgentMethodSessionResume,
+	)
+}
+
+func (*protocolAgent) SetSessionConfigOption(
+	context.Context,
+	acpsdk.SetSessionConfigOptionRequest,
+) (acpsdk.SetSessionConfigOptionResponse, error) {
+	return acpsdk.SetSessionConfigOptionResponse{}, acpsdk.NewMethodNotFound(
+		acpsdk.AgentMethodSessionSetConfigOption,
+	)
+}
+
+func (*protocolAgent) SetSessionMode(
+	context.Context,
+	acpsdk.SetSessionModeRequest,
+) (acpsdk.SetSessionModeResponse, error) {
+	return acpsdk.SetSessionModeResponse{}, acpsdk.NewMethodNotFound(
+		acpsdk.AgentMethodSessionSetMode,
+	)
+}
+
+var _ acpsdk.Agent = (*protocolAgent)(nil)

--- a/server/acp/server.go
+++ b/server/acp/server.go
@@ -70,6 +70,8 @@ func WithImplementation(name, version string) Option {
 }
 
 // WithSessionIDGenerator replaces the default UUID session ID generator.
+// The Server serializes calls to generator and rejects IDs that it has used
+// previously, including IDs from closed sessions and other connections.
 func WithSessionIDGenerator(generator func() string) Option {
 	return func(options *options) {
 		options.sessionIDGenerator = generator
@@ -109,6 +111,8 @@ type Server struct {
 	runOptions         []agent.RunOption
 	runOptionsFunc     RunOptionsFunc
 	reasoningEnabled   bool
+	sessionMu          sync.Mutex
+	usedSessionIDs     map[string]struct{}
 }
 
 // New creates an ACP server backed by a runner.
@@ -145,6 +149,7 @@ func New(r runner.Runner, opts ...Option) (*Server, error) {
 		runOptions:         append([]agent.RunOption(nil), options.runOptions...),
 		runOptionsFunc:     options.runOptionsFunc,
 		reasoningEnabled:   options.reasoningEnabled,
+		usedSessionIDs:     make(map[string]struct{}),
 	}
 	server.managedRunner, _ = r.(runner.ManagedRunner)
 	return server, nil
@@ -259,20 +264,28 @@ func (a *protocolAgent) NewSession(
 			map[string]any{"additionalDirectories": "additional directories are not supported"},
 		)
 	}
+	sessionID, err := a.server.newSessionID()
+	if err != nil {
+		return acpsdk.NewSessionResponse{}, err
+	}
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	sessionID := a.server.sessionIDGenerator()
-	if sessionID == "" {
-		return acpsdk.NewSessionResponse{}, errors.New("acp: generated empty session ID")
-	}
-	if _, exists := a.sessions[sessionID]; exists {
-		return acpsdk.NewSessionResponse{}, fmt.Errorf(
-			"acp: generated duplicate session ID %q",
-			sessionID,
-		)
-	}
 	a.sessions[sessionID] = &sessionState{id: sessionID, cwd: request.Cwd}
+	a.mu.Unlock()
 	return acpsdk.NewSessionResponse{SessionId: acpsdk.SessionId(sessionID)}, nil
+}
+
+func (s *Server) newSessionID() (string, error) {
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+	sessionID := s.sessionIDGenerator()
+	if sessionID == "" {
+		return "", errors.New("acp: generated empty session ID")
+	}
+	if _, exists := s.usedSessionIDs[sessionID]; exists {
+		return "", fmt.Errorf("acp: generated duplicate session ID %q", sessionID)
+	}
+	s.usedSessionIDs[sessionID] = struct{}{}
+	return sessionID, nil
 }
 
 func (a *protocolAgent) Prompt(
@@ -315,6 +328,7 @@ func (a *protocolAgent) Prompt(
 	)
 	if err != nil {
 		if runCtx.Err() != nil {
+			a.stopPrompt(requestID, cancel)
 			return canceledPromptResponse(request.MessageId), nil
 		}
 		return acpsdk.PromptResponse{}, err
@@ -324,7 +338,8 @@ func (a *protocolAgent) Prompt(
 	for {
 		select {
 		case <-runCtx.Done():
-			go drainEvents(events)
+			a.stopPrompt(requestID, cancel)
+			drainEvents(events)
 			return canceledPromptResponse(request.MessageId), nil
 		case event, ok := <-events:
 			if !ok {
@@ -335,7 +350,8 @@ func (a *protocolAgent) Prompt(
 			}
 			updates, err := turn.translate(event)
 			if err != nil {
-				go drainEvents(events)
+				a.stopPrompt(requestID, cancel)
+				drainEvents(events)
 				return acpsdk.PromptResponse{}, err
 			}
 			for _, update := range updates {
@@ -344,10 +360,12 @@ func (a *protocolAgent) Prompt(
 					Update:    update,
 				}); err != nil {
 					if runCtx.Err() != nil {
-						go drainEvents(events)
+						a.stopPrompt(requestID, cancel)
+						drainEvents(events)
 						return canceledPromptResponse(request.MessageId), nil
 					}
-					go drainEvents(events)
+					a.stopPrompt(requestID, cancel)
+					drainEvents(events)
 					return acpsdk.PromptResponse{}, err
 				}
 			}
@@ -426,17 +444,15 @@ func (a *protocolAgent) beginPrompt(
 			map[string]any{"sessionId": "session is closed"},
 		)
 	}
-	previousCancel := session.cancel
-	previousRequestID := session.requestID
+	if session.requestID != "" {
+		session.mu.Unlock()
+		return acpsdk.NewInvalidParams(
+			map[string]any{"sessionId": "prompt already in progress"},
+		)
+	}
 	session.cancel = cancel
 	session.requestID = requestID
 	session.mu.Unlock()
-	if previousCancel != nil {
-		previousCancel()
-	}
-	if previousRequestID != "" && a.server.managedRunner != nil {
-		a.server.managedRunner.Cancel(previousRequestID)
-	}
 	return nil
 }
 
@@ -458,6 +474,16 @@ func (a *protocolAgent) cancelPrompt(session *sessionState) {
 		cancel()
 	}
 	if requestID != "" && a.server.managedRunner != nil {
+		a.server.managedRunner.Cancel(requestID)
+	}
+}
+
+func (a *protocolAgent) stopPrompt(
+	requestID string,
+	cancel context.CancelFunc,
+) {
+	cancel()
+	if a.server.managedRunner != nil {
 		a.server.managedRunner.Cancel(requestID)
 	}
 }

--- a/server/acp/server.go
+++ b/server/acp/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
@@ -323,6 +324,7 @@ func (a *protocolAgent) Prompt(
 	for {
 		select {
 		case <-runCtx.Done():
+			go drainEvents(events)
 			return canceledPromptResponse(request.MessageId), nil
 		case event, ok := <-events:
 			if !ok {
@@ -333,6 +335,7 @@ func (a *protocolAgent) Prompt(
 			}
 			updates, err := turn.translate(event)
 			if err != nil {
+				go drainEvents(events)
 				return acpsdk.PromptResponse{}, err
 			}
 			for _, update := range updates {
@@ -341,12 +344,22 @@ func (a *protocolAgent) Prompt(
 					Update:    update,
 				}); err != nil {
 					if runCtx.Err() != nil {
+						go drainEvents(events)
 						return canceledPromptResponse(request.MessageId), nil
 					}
+					go drainEvents(events)
 					return acpsdk.PromptResponse{}, err
 				}
 			}
 		}
+	}
+}
+
+func drainEvents(events <-chan *event.Event) {
+	if events == nil {
+		return
+	}
+	for range events {
 	}
 }
 

--- a/server/acp/server_test.go
+++ b/server/acp/server_test.go
@@ -1,0 +1,356 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package acp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestServerPromptOverACP(t *testing.T) {
+	fakeRunner := &testRunner{
+		run: func(_ context.Context) <-chan *event.Event {
+			finishReason := "stop"
+			events := make(chan *event.Event, 4)
+			events <- &event.Event{
+				InvocationID: "invocation",
+				Response: &model.Response{
+					ID:        "response",
+					IsPartial: true,
+					Choices: []model.Choice{{
+						Delta: model.Message{Content: "hello"},
+					}},
+				},
+			}
+			events <- &event.Event{
+				InvocationID: "invocation",
+				Response: &model.Response{
+					ID: "response",
+					Choices: []model.Choice{{
+						Message:      model.Message{Content: "hello"},
+						FinishReason: &finishReason,
+					}},
+					Usage: &model.Usage{
+						PromptTokens:     2,
+						CompletionTokens: 1,
+						TotalTokens:      3,
+					},
+				},
+			}
+			close(events)
+			return events
+		},
+	}
+	server, err := New(
+		fakeRunner,
+		WithUserID("editor-user"),
+		WithImplementation("test-agent", "1.0.0"),
+		WithSessionIDGenerator(func() string { return "session-1" }),
+		WithRunOptionsFunc(func(session Session) []agent.RunOption {
+			return []agent.RunOption{agent.WithRuntimeState(map[string]any{
+				"cwd": session.CWD,
+			})}
+		}),
+	)
+	require.NoError(t, err)
+
+	client := &testClient{}
+	clientConnection, cleanup := connectTestClient(t, server, client)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	initializeResponse, err := clientConnection.Initialize(ctx, acpsdk.InitializeRequest{
+		ProtocolVersion: acpsdk.ProtocolVersionNumber,
+	})
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		acpsdk.ProtocolVersion(acpsdk.ProtocolVersionNumber),
+		initializeResponse.ProtocolVersion,
+	)
+	require.NotNil(t, initializeResponse.AgentInfo)
+	assert.Equal(t, "test-agent", initializeResponse.AgentInfo.Name)
+	require.NotNil(t, initializeResponse.AgentCapabilities.SessionCapabilities.Close)
+
+	session, err := clientConnection.NewSession(ctx, acpsdk.NewSessionRequest{
+		Cwd:        "/workspace",
+		McpServers: []acpsdk.McpServer{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, acpsdk.SessionId("session-1"), session.SessionId)
+
+	messageID := "9a27ea91-a754-40cc-a557-105011523714"
+	promptResponse, err := clientConnection.Prompt(ctx, acpsdk.PromptRequest{
+		SessionId: session.SessionId,
+		MessageId: &messageID,
+		Prompt:    []acpsdk.ContentBlock{acpsdk.TextBlock("hi")},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, acpsdk.StopReasonEndTurn, promptResponse.StopReason)
+	assert.Equal(t, &messageID, promptResponse.UserMessageId)
+	require.NotNil(t, promptResponse.Usage)
+	assert.Equal(t, 3, promptResponse.Usage.TotalTokens)
+
+	call := fakeRunner.lastCall()
+	assert.Equal(t, "editor-user", call.userID)
+	assert.Equal(t, "session-1", call.sessionID)
+	assert.Equal(t, "hi", call.message.Content)
+	assert.NotEmpty(t, call.options.RequestID)
+	assert.Equal(t, "/workspace", call.options.RuntimeState["cwd"])
+
+	updates := client.allUpdates()
+	require.Len(t, updates, 1)
+	assert.Equal(t, "hello", updates[0].Update.AgentMessageChunk.Content.Text.Text)
+
+	_, err = clientConnection.CloseSession(ctx, acpsdk.CloseSessionRequest{
+		SessionId: session.SessionId,
+	})
+	require.NoError(t, err)
+}
+
+func TestServerCancellation(t *testing.T) {
+	started := make(chan struct{})
+	cancelObserved := make(chan struct{})
+	fakeRunner := &testRunner{
+		run: func(ctx context.Context) <-chan *event.Event {
+			events := make(chan *event.Event)
+			close(started)
+			go func() {
+				<-ctx.Done()
+				close(cancelObserved)
+				close(events)
+			}()
+			return events
+		},
+	}
+	server, err := New(
+		fakeRunner,
+		WithSessionIDGenerator(func() string { return "session-cancel" }),
+	)
+	require.NoError(t, err)
+	clientConnection, cleanup := connectTestClient(t, server, &testClient{})
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	session, err := clientConnection.NewSession(ctx, acpsdk.NewSessionRequest{
+		Cwd:        "/workspace",
+		McpServers: []acpsdk.McpServer{},
+	})
+	require.NoError(t, err)
+
+	type promptResult struct {
+		response acpsdk.PromptResponse
+		err      error
+	}
+	result := make(chan promptResult, 1)
+	go func() {
+		response, promptErr := clientConnection.Prompt(ctx, acpsdk.PromptRequest{
+			SessionId: session.SessionId,
+			Prompt:    []acpsdk.ContentBlock{acpsdk.TextBlock("wait")},
+		})
+		result <- promptResult{response: response, err: promptErr}
+	}()
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("runner did not start")
+	}
+	require.NoError(t, clientConnection.Cancel(ctx, acpsdk.CancelNotification{
+		SessionId: session.SessionId,
+	}))
+
+	select {
+	case <-cancelObserved:
+	case <-ctx.Done():
+		t.Fatal("runner context was not canceled")
+	}
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		assert.Equal(t, acpsdk.StopReasonCancelled, got.response.StopReason)
+	case <-ctx.Done():
+		t.Fatal("prompt did not return")
+	}
+}
+
+func TestServerValidation(t *testing.T) {
+	_, err := New(nil)
+	assert.ErrorContains(t, err, "runner is required")
+
+	server, err := New(&testRunner{})
+	require.NoError(t, err)
+	_, err = server.Connect(nil, nil)
+	assert.ErrorContains(t, err, "input is required")
+}
+
+type runnerCall struct {
+	userID    string
+	sessionID string
+	message   model.Message
+	options   agent.RunOptions
+}
+
+type testRunner struct {
+	run   func(context.Context) <-chan *event.Event
+	mu    sync.Mutex
+	calls []runnerCall
+}
+
+func (r *testRunner) Run(
+	ctx context.Context,
+	userID string,
+	sessionID string,
+	message model.Message,
+	runOptions ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	var options agent.RunOptions
+	for _, runOption := range runOptions {
+		runOption(&options)
+	}
+	r.mu.Lock()
+	r.calls = append(r.calls, runnerCall{
+		userID:    userID,
+		sessionID: sessionID,
+		message:   message,
+		options:   options,
+	})
+	r.mu.Unlock()
+	if r.run == nil {
+		events := make(chan *event.Event)
+		close(events)
+		return events, nil
+	}
+	return r.run(ctx), nil
+}
+
+func (*testRunner) Close() error {
+	return nil
+}
+
+func (r *testRunner) lastCall() runnerCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[len(r.calls)-1]
+}
+
+type testClient struct {
+	mu      sync.Mutex
+	updates []acpsdk.SessionNotification
+}
+
+func (c *testClient) SessionUpdate(
+	_ context.Context,
+	update acpsdk.SessionNotification,
+) error {
+	c.mu.Lock()
+	c.updates = append(c.updates, update)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *testClient) allUpdates() []acpsdk.SessionNotification {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]acpsdk.SessionNotification(nil), c.updates...)
+}
+
+func (*testClient) ReadTextFile(
+	context.Context,
+	acpsdk.ReadTextFileRequest,
+) (acpsdk.ReadTextFileResponse, error) {
+	return acpsdk.ReadTextFileResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) WriteTextFile(
+	context.Context,
+	acpsdk.WriteTextFileRequest,
+) (acpsdk.WriteTextFileResponse, error) {
+	return acpsdk.WriteTextFileResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) RequestPermission(
+	context.Context,
+	acpsdk.RequestPermissionRequest,
+) (acpsdk.RequestPermissionResponse, error) {
+	return acpsdk.RequestPermissionResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) CreateTerminal(
+	context.Context,
+	acpsdk.CreateTerminalRequest,
+) (acpsdk.CreateTerminalResponse, error) {
+	return acpsdk.CreateTerminalResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) KillTerminal(
+	context.Context,
+	acpsdk.KillTerminalRequest,
+) (acpsdk.KillTerminalResponse, error) {
+	return acpsdk.KillTerminalResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) TerminalOutput(
+	context.Context,
+	acpsdk.TerminalOutputRequest,
+) (acpsdk.TerminalOutputResponse, error) {
+	return acpsdk.TerminalOutputResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) ReleaseTerminal(
+	context.Context,
+	acpsdk.ReleaseTerminalRequest,
+) (acpsdk.ReleaseTerminalResponse, error) {
+	return acpsdk.ReleaseTerminalResponse{}, errors.New("not implemented")
+}
+
+func (*testClient) WaitForTerminalExit(
+	context.Context,
+	acpsdk.WaitForTerminalExitRequest,
+) (acpsdk.WaitForTerminalExitResponse, error) {
+	return acpsdk.WaitForTerminalExitResponse{}, errors.New("not implemented")
+}
+
+func connectTestClient(
+	t *testing.T,
+	server *Server,
+	client acpsdk.Client,
+) (*acpsdk.ClientSideConnection, func()) {
+	t.Helper()
+	serverTransport, clientTransport := net.Pipe()
+	serverConnection, err := server.Connect(serverTransport, serverTransport)
+	require.NoError(t, err)
+	clientConnection := acpsdk.NewClientSideConnection(
+		client,
+		clientTransport,
+		clientTransport,
+	)
+	return clientConnection, func() {
+		require.NoError(t, clientTransport.Close())
+		select {
+		case <-serverConnection.Done():
+		case <-time.After(time.Second):
+			t.Error("server connection did not close")
+		}
+	}
+}

--- a/server/acp/server_test.go
+++ b/server/acp/server_test.go
@@ -210,6 +210,109 @@ func TestServerValidation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = server.Connect(nil, nil)
 	assert.ErrorContains(t, err, "input is required")
+	_, err = server.Connect(&net.TCPConn{}, nil)
+	assert.ErrorContains(t, err, "output is required")
+
+	tests := []struct {
+		name   string
+		option Option
+		err    string
+	}{
+		{name: "user ID", option: WithUserID(""), err: "user ID is required"},
+		{
+			name:   "implementation name",
+			option: WithImplementation("", "1.0.0"),
+			err:    "implementation name is required",
+		},
+		{
+			name:   "implementation version",
+			option: WithImplementation("agent", ""),
+			err:    "implementation version is required",
+		},
+		{
+			name:   "session ID generator",
+			option: WithSessionIDGenerator(nil),
+			err:    "session ID generator is required",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(&testRunner{}, test.option)
+			assert.ErrorContains(t, err, test.err)
+		})
+	}
+}
+
+func TestProtocolAgentSessionValidation(t *testing.T) {
+	sessionIDs := []string{"", "session-1", "session-1"}
+	server, err := New(
+		&testRunner{},
+		WithRunOptions(agent.WithRuntimeState(map[string]any{"static": true})),
+		WithReasoningContentEnabled(true),
+		WithSessionIDGenerator(func() string {
+			sessionID := sessionIDs[0]
+			sessionIDs = sessionIDs[1:]
+			return sessionID
+		}),
+	)
+	require.NoError(t, err)
+	protocolAgent := newProtocolAgent(server)
+	ctx := context.Background()
+
+	_, err = protocolAgent.NewSession(ctx, acpsdk.NewSessionRequest{Cwd: "relative"})
+	assert.ErrorContains(t, err, "absolute path")
+	_, err = protocolAgent.NewSession(ctx, acpsdk.NewSessionRequest{
+		Cwd:        "/workspace",
+		McpServers: []acpsdk.McpServer{{}},
+	})
+	assert.ErrorContains(t, err, "dynamic MCP servers")
+	_, err = protocolAgent.NewSession(ctx, acpsdk.NewSessionRequest{
+		Cwd:                   "/workspace",
+		AdditionalDirectories: []string{"/other"},
+	})
+	assert.ErrorContains(t, err, "additional directories")
+	_, err = protocolAgent.NewSession(ctx, acpsdk.NewSessionRequest{Cwd: "/workspace"})
+	assert.ErrorContains(t, err, "empty session ID")
+
+	response, err := protocolAgent.NewSession(
+		ctx,
+		acpsdk.NewSessionRequest{Cwd: "/workspace"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, acpsdk.SessionId("session-1"), response.SessionId)
+	_, err = protocolAgent.NewSession(ctx, acpsdk.NewSessionRequest{Cwd: "/workspace"})
+	assert.ErrorContains(t, err, "duplicate session ID")
+
+	_, err = protocolAgent.CloseSession(ctx, acpsdk.CloseSessionRequest{
+		SessionId: "unknown",
+	})
+	assert.ErrorContains(t, err, "unknown session")
+	require.NoError(t, protocolAgent.Cancel(ctx, acpsdk.CancelNotification{
+		SessionId: "unknown",
+	}))
+}
+
+func TestProtocolAgentUnsupportedMethods(t *testing.T) {
+	server, err := New(&testRunner{})
+	require.NoError(t, err)
+	protocolAgent := newProtocolAgent(server)
+	ctx := context.Background()
+
+	_, err = protocolAgent.Authenticate(ctx, acpsdk.AuthenticateRequest{})
+	assert.ErrorContains(t, err, "Method not found")
+	_, err = protocolAgent.Logout(ctx, acpsdk.LogoutRequest{})
+	assert.ErrorContains(t, err, "Method not found")
+	_, err = protocolAgent.ListSessions(ctx, acpsdk.ListSessionsRequest{})
+	assert.ErrorContains(t, err, "Method not found")
+	_, err = protocolAgent.ResumeSession(ctx, acpsdk.ResumeSessionRequest{})
+	assert.ErrorContains(t, err, "Method not found")
+	_, err = protocolAgent.SetSessionConfigOption(
+		ctx,
+		acpsdk.SetSessionConfigOptionRequest{},
+	)
+	assert.ErrorContains(t, err, "Method not found")
+	_, err = protocolAgent.SetSessionMode(ctx, acpsdk.SetSessionModeRequest{})
+	assert.ErrorContains(t, err, "Method not found")
 }
 
 type runnerCall struct {

--- a/server/acp/server_test.go
+++ b/server/acp/server_test.go
@@ -131,13 +131,16 @@ func TestServerPromptOverACP(t *testing.T) {
 func TestServerCancellation(t *testing.T) {
 	started := make(chan struct{})
 	cancelObserved := make(chan struct{})
+	producerFinished := make(chan struct{})
 	fakeRunner := &testRunner{
 		run: func(ctx context.Context) <-chan *event.Event {
 			events := make(chan *event.Event)
 			close(started)
 			go func() {
+				defer close(producerFinished)
 				<-ctx.Done()
 				close(cancelObserved)
+				events <- &event.Event{}
 				close(events)
 			}()
 			return events
@@ -191,6 +194,11 @@ func TestServerCancellation(t *testing.T) {
 		assert.Equal(t, acpsdk.StopReasonCancelled, got.response.StopReason)
 	case <-ctx.Done():
 		t.Fatal("prompt did not return")
+	}
+	select {
+	case <-producerFinished:
+	case <-ctx.Done():
+		t.Fatal("runner event producer was not drained")
 	}
 }
 

--- a/server/acp/server_test.go
+++ b/server/acp/server_test.go
@@ -202,6 +202,127 @@ func TestServerCancellation(t *testing.T) {
 	}
 }
 
+func TestProtocolAgentRejectsConcurrentPromptUntilRunFinishes(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &testRunner{
+		run: func(ctx context.Context) <-chan *event.Event {
+			events := make(chan *event.Event)
+			close(started)
+			go func() {
+				<-ctx.Done()
+				<-release
+				close(events)
+			}()
+			return events
+		},
+	}
+	server, err := New(
+		runner,
+		WithSessionIDGenerator(func() string { return "session-serialized" }),
+	)
+	require.NoError(t, err)
+	protocolAgent := newProtocolAgent(server)
+	session, err := protocolAgent.NewSession(
+		context.Background(),
+		acpsdk.NewSessionRequest{Cwd: "/workspace"},
+	)
+	require.NoError(t, err)
+
+	firstResult := make(chan error, 1)
+	go func() {
+		_, promptErr := protocolAgent.Prompt(
+			context.Background(),
+			acpsdk.PromptRequest{
+				SessionId: session.SessionId,
+				Prompt:    []acpsdk.ContentBlock{acpsdk.TextBlock("first")},
+			},
+		)
+		firstResult <- promptErr
+	}()
+	<-started
+
+	_, err = protocolAgent.Prompt(
+		context.Background(),
+		acpsdk.PromptRequest{
+			SessionId: session.SessionId,
+			Prompt:    []acpsdk.ContentBlock{acpsdk.TextBlock("second")},
+		},
+	)
+	assert.ErrorContains(t, err, "prompt already in progress")
+	assert.Equal(t, 1, runner.callCount())
+
+	require.NoError(t, protocolAgent.Cancel(
+		context.Background(),
+		acpsdk.CancelNotification{SessionId: session.SessionId},
+	))
+	select {
+	case err := <-firstResult:
+		t.Fatalf("prompt returned before the runner finished: %v", err)
+	default:
+	}
+	close(release)
+	require.NoError(t, <-firstResult)
+}
+
+func TestServerSessionIDsAreUniqueAcrossConnectionsAndLifetime(t *testing.T) {
+	server, err := New(
+		&testRunner{},
+		WithSessionIDGenerator(func() string { return "shared-session" }),
+	)
+	require.NoError(t, err)
+	agents := []*protocolAgent{newProtocolAgent(server), newProtocolAgent(server)}
+	type result struct {
+		agent    *protocolAgent
+		response acpsdk.NewSessionResponse
+		err      error
+	}
+	results := make(chan result, len(agents))
+	var ready sync.WaitGroup
+	ready.Add(len(agents))
+	start := make(chan struct{})
+	for _, agentInstance := range agents {
+		go func(a *protocolAgent) {
+			ready.Done()
+			<-start
+			response, newSessionErr := a.NewSession(
+				context.Background(),
+				acpsdk.NewSessionRequest{Cwd: "/workspace"},
+			)
+			results <- result{agent: a, response: response, err: newSessionErr}
+		}(agentInstance)
+	}
+	ready.Wait()
+	close(start)
+
+	var succeeded result
+	var successCount int
+	var duplicateCount int
+	for range agents {
+		got := <-results
+		if got.err == nil {
+			succeeded = got
+			successCount++
+			continue
+		}
+		assert.ErrorContains(t, got.err, "duplicate session ID")
+		duplicateCount++
+	}
+	assert.Equal(t, 1, successCount)
+	assert.Equal(t, 1, duplicateCount)
+
+	_, err = succeeded.agent.CloseSession(
+		context.Background(),
+		acpsdk.CloseSessionRequest{SessionId: succeeded.response.SessionId},
+	)
+	require.NoError(t, err)
+	_, err = newProtocolAgent(server).NewSession(
+		context.Background(),
+		acpsdk.NewSessionRequest{Cwd: "/workspace"},
+	)
+	assert.ErrorContains(t, err, "duplicate session ID")
+}
+
 func TestServerValidation(t *testing.T) {
 	_, err := New(nil)
 	assert.ErrorContains(t, err, "runner is required")
@@ -363,6 +484,12 @@ func (r *testRunner) lastCall() runnerCall {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.calls[len(r.calls)-1]
+}
+
+func (r *testRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
 }
 
 type testClient struct {


### PR DESCRIPTION
## Summary

Fixes #2296.

Adds an ACP v1 stdio adapter that exposes an existing `runner.Runner` without adding ACP concepts to the runner, agent, model, or event packages.

## Changes

- add `server/acp` with line-delimited JSON-RPC stdio connection handling
- support initialize, session/new, session/prompt, session/update, session/cancel, and session/close
- translate ACP text/resource-link prompts into `model.Message`
- translate runner text, opt-in reasoning, tool-call lifecycle, usage, and stop reasons into ACP updates
- propagate cancellation through both context cancellation and `runner.ManagedRunner.Cancel` when available
- isolate sessions per ACP connection and guard prompt/close races
- return standard method-not-found responses for unadvertised capabilities
- add a runnable OpenAI-backed ACP stdio example and capability documentation
- use `github.com/coder/acp-go-sdk v0.13.5` for current ACP v1 schema and JSON-RPC transport support

## User impact

IDE/editor ACP clients can start a trpc-agent-go process over stdio, create sessions, submit prompts, receive streaming assistant/tool updates, cancel work, and close sessions. Existing server and Runner behavior is unchanged.

## Validation

Passed:

- `go test -race -count=20 ./server/acp`
- `go test ./acp` (from `examples`)
- `go test ./...` (from `test`)
- `go vet ./server/acp`
- `go build ./...`
- `golangci-lint run --timeout=10m ./server/acp/...`
- root and examples `go mod tidy`
- `gofmt` / `goimports` checks

The root `go test ./...` run passed `server/acp` and all other packages except the existing macOS Unix-socket path-sensitive `tool/duckduckgo` test. That package passed when rerun with a short temporary directory: `TMPDIR=/tmp go test -count=1 ./tool/duckduckgo`.

## Compatibility and risk

- additive server package and example; no existing public API changes
- ACP SDK and this module both support Go 1.21
- reasoning updates are disabled by default to avoid exposing model reasoning unintentionally
- image/audio/embedded-resource prompts, dynamic MCP configuration, permission requests, client filesystem/terminal callbacks, and session load/list/resume are intentionally not advertised in this first milestone
- callers choose how ACP session `cwd` configures request-scoped agents through `WithRunOptionsFunc`

## Release note

Added ACP v1 stdio support for exposing trpc-agent-go runners to IDEs and editor clients.