### PR TITLE
telemetry: add span-level filters

### DIFF
--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -287,6 +287,10 @@ const (
 
 // TraceToolCall traces the invocation of a tool call.
 func TraceToolCall(span trace.Span, sess *session.Session, declaration *tool.Declaration, args []byte, rspEvent *event.Event, err error) {
+	if !span.IsRecording() {
+		return
+	}
+
 	span.SetAttributes(
 		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),
@@ -337,6 +341,10 @@ const ToolNameMergedTools = "(merged tools)"
 // Calling this function is not needed for telemetry purposes. This is provided
 // for preventing trace-query requests typically sent by web UIs.
 func TraceMergedToolCalls(span trace.Span, rspEvent *event.Event) {
+	if !span.IsRecording() {
+		return
+	}
+
 	span.SetAttributes(
 		attribute.String(semconvtrace.KeyGenAISystem, semconvtrace.SystemTRPCGoAgent),
 		attribute.String(semconvtrace.KeyGenAIOperationName, OperationExecuteTool),

--- a/internal/telemetry/trace_test.go
+++ b/internal/telemetry/trace_test.go
@@ -275,6 +275,8 @@ func TestTraceFunctions_NonRecordingSpan_ReturnsEarly(t *testing.T) {
 	TraceBeforeInvokeAgent(span, nil, "", "", nil)
 	TraceAfterInvokeAgent(span, nil, nil, 0, model.ErrorTypeRunError)
 	TraceChat(span, nil)
+	TraceToolCall(span, nil, nil, nil, nil, nil)
+	TraceMergedToolCalls(span, nil)
 }
 
 func TestTraceBeforeAfter_Tool_Merged_Chat_Embedding(t *testing.T) {

--- a/telemetry/trace/span_filter.go
+++ b/telemetry/trace/span_filter.go
@@ -12,6 +12,7 @@ import (
 	"context"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // SpanStartFilter decides whether a span should be recorded when it is
@@ -25,14 +26,18 @@ type SpanStartFilter func(sdktrace.SamplingParameters) bool
 // events, and duration.
 type SpanExportFilter func(sdktrace.ReadOnlySpan) bool
 
-// WithSpanStartFilter filters spans when they are created.
+// WithSpanStartFilter filters spans when they are created. A nil filter
+// disables start filtering. When specified more than once, the last option
+// wins.
 func WithSpanStartFilter(filter SpanStartFilter) Option {
 	return func(opts *options) {
 		opts.spanStartFilter = filter
 	}
 }
 
-// WithSpanExportFilter filters completed spans immediately before export.
+// WithSpanExportFilter filters completed spans immediately before export. A
+// nil filter disables export filtering. When specified more than once, the
+// last option wins.
 func WithSpanExportFilter(filter SpanExportFilter) Option {
 	return func(opts *options) {
 		opts.spanExportFilter = filter
@@ -46,7 +51,11 @@ type filteringSampler struct {
 
 func (s filteringSampler) ShouldSample(params sdktrace.SamplingParameters) sdktrace.SamplingResult {
 	if s.filter != nil && !s.filter(params) {
-		return sdktrace.SamplingResult{Decision: sdktrace.Drop}
+		parent := oteltrace.SpanContextFromContext(params.ParentContext)
+		return sdktrace.SamplingResult{
+			Decision:   sdktrace.Drop,
+			Tracestate: parent.TraceState(),
+		}
 	}
 	return s.next.ShouldSample(params)
 }

--- a/telemetry/trace/span_filter.go
+++ b/telemetry/trace/span_filter.go
@@ -1,0 +1,94 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trace
+
+import (
+	"context"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SpanStartFilter decides whether a span should be recorded when it is
+// created. The parameters contain only information available at span start.
+// Returning false drops the span before any attributes or events are recorded.
+type SpanStartFilter func(sdktrace.SamplingParameters) bool
+
+// SpanExportFilter decides whether a completed span should be exported.
+// Returning false prevents the span from being sent to the configured
+// exporter. Unlike SpanStartFilter, it can inspect final attributes, status,
+// events, and duration.
+type SpanExportFilter func(sdktrace.ReadOnlySpan) bool
+
+// WithSpanStartFilter filters spans when they are created.
+func WithSpanStartFilter(filter SpanStartFilter) Option {
+	return func(opts *options) {
+		opts.spanStartFilter = filter
+	}
+}
+
+// WithSpanExportFilter filters completed spans immediately before export.
+func WithSpanExportFilter(filter SpanExportFilter) Option {
+	return func(opts *options) {
+		opts.spanExportFilter = filter
+	}
+}
+
+type filteringSampler struct {
+	filter SpanStartFilter
+	next   sdktrace.Sampler
+}
+
+func (s filteringSampler) ShouldSample(params sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	if s.filter != nil && !s.filter(params) {
+		return sdktrace.SamplingResult{Decision: sdktrace.Drop}
+	}
+	return s.next.ShouldSample(params)
+}
+
+func (s filteringSampler) Description() string {
+	return "trpc-agent-go span start filter"
+}
+
+type filteringSpanExporter struct {
+	filter SpanExportFilter
+	next   sdktrace.SpanExporter
+}
+
+func newFilteringSpanExporter(
+	next sdktrace.SpanExporter,
+	filter SpanExportFilter,
+) sdktrace.SpanExporter {
+	if filter == nil {
+		return next
+	}
+	return &filteringSpanExporter{
+		filter: filter,
+		next:   next,
+	}
+}
+
+func (e *filteringSpanExporter) ExportSpans(
+	ctx context.Context,
+	spans []sdktrace.ReadOnlySpan,
+) error {
+	filtered := make([]sdktrace.ReadOnlySpan, 0, len(spans))
+	for _, span := range spans {
+		if e.filter(span) {
+			filtered = append(filtered, span)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return e.next.ExportSpans(ctx, filtered)
+}
+
+func (e *filteringSpanExporter) Shutdown(ctx context.Context) error {
+	return e.next.Shutdown(ctx)
+}

--- a/telemetry/trace/span_filter.go
+++ b/telemetry/trace/span_filter.go
@@ -18,6 +18,9 @@ import (
 // SpanStartFilter decides whether a span should be recorded when it is
 // created. The parameters contain only information available at span start.
 // Returning false drops the span before any attributes or events are recorded.
+// Implementations may be called concurrently and must be safe for concurrent
+// use. They must treat the SamplingParameters and its referenced slices as
+// read-only.
 type SpanStartFilter func(sdktrace.SamplingParameters) bool
 
 // SpanExportFilter decides whether a completed span should be exported.

--- a/telemetry/trace/span_filter_test.go
+++ b/telemetry/trace/span_filter_test.go
@@ -1,0 +1,112 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestWithSpanFilters(t *testing.T) {
+	startFilter := func(params sdktrace.SamplingParameters) bool {
+		return params.Name != "health"
+	}
+	exportFilter := func(span sdktrace.ReadOnlySpan) bool {
+		return span.Name() != "internal"
+	}
+	opts := &options{}
+	WithSpanStartFilter(startFilter)(opts)
+	WithSpanExportFilter(exportFilter)(opts)
+
+	if opts.spanStartFilter == nil || opts.spanExportFilter == nil {
+		t.Fatal("expected both span filters to be configured")
+	}
+}
+
+func TestFilteringSampler(t *testing.T) {
+	sampler := filteringSampler{
+		filter: func(params sdktrace.SamplingParameters) bool {
+			return params.Name != "health"
+		},
+		next: sdktrace.AlwaysSample(),
+	}
+
+	if got := sampler.ShouldSample(sdktrace.SamplingParameters{
+		Name: "health",
+	}).Decision; got != sdktrace.Drop {
+		t.Fatalf("health decision = %v, want Drop", got)
+	}
+	if got := sampler.ShouldSample(sdktrace.SamplingParameters{
+		Name: "chat",
+	}).Decision; got != sdktrace.RecordAndSample {
+		t.Fatalf("chat decision = %v, want RecordAndSample", got)
+	}
+}
+
+func TestFilteringSpanExporter(t *testing.T) {
+	next := tracetest.NewInMemoryExporter()
+	exporter := newFilteringSpanExporter(
+		next,
+		func(span sdktrace.ReadOnlySpan) bool {
+			return span.Name() != "internal"
+		},
+	)
+	spans := []sdktrace.ReadOnlySpan{
+		spanSnapshot("chat"),
+		spanSnapshot("internal"),
+		spanSnapshot("tool"),
+	}
+
+	if err := exporter.ExportSpans(context.Background(), spans); err != nil {
+		t.Fatalf("ExportSpans() error = %v", err)
+	}
+	got := next.GetSpans()
+	if len(got) != 2 {
+		t.Fatalf("exported span count = %d, want 2", len(got))
+	}
+	if got[0].Name != "chat" || got[1].Name != "tool" {
+		t.Fatalf("exported spans = [%s, %s], want [chat, tool]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestFilteringSpanExporter_AllFiltered(t *testing.T) {
+	next := tracetest.NewInMemoryExporter()
+	exporter := newFilteringSpanExporter(
+		next,
+		func(sdktrace.ReadOnlySpan) bool { return false },
+	)
+
+	if err := exporter.ExportSpans(
+		context.Background(),
+		[]sdktrace.ReadOnlySpan{spanSnapshot("internal")},
+	); err != nil {
+		t.Fatalf("ExportSpans() error = %v", err)
+	}
+	if got := next.GetSpans(); len(got) != 0 {
+		t.Fatalf("exported span count = %d, want 0", len(got))
+	}
+}
+
+func TestNewFilteringSpanExporter_NilFilter(t *testing.T) {
+	next := tracetest.NewInMemoryExporter()
+	if got := newFilteringSpanExporter(next, nil); got != next {
+		t.Fatal("nil filter should return the original exporter")
+	}
+}
+
+func spanSnapshot(name string) sdktrace.ReadOnlySpan {
+	return tracetest.SpanStub{
+		Name:                 name,
+		InstrumentationScope: instrumentation.Scope{Name: "test"},
+	}.Snapshot()
+}

--- a/telemetry/trace/span_filter_test.go
+++ b/telemetry/trace/span_filter_test.go
@@ -12,9 +12,12 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func TestWithSpanFilters(t *testing.T) {
@@ -50,6 +53,32 @@ func TestFilteringSampler(t *testing.T) {
 		Name: "chat",
 	}).Decision; got != sdktrace.RecordAndSample {
 		t.Fatalf("chat decision = %v, want RecordAndSample", got)
+	}
+}
+
+func TestFilteringSampler_PreservesParentTraceState(t *testing.T) {
+	traceState, err := oteltrace.ParseTraceState("vendor=value")
+	if err != nil {
+		t.Fatalf("ParseTraceState() error = %v", err)
+	}
+	parent := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{1},
+		SpanID:     oteltrace.SpanID{1},
+		TraceState: traceState,
+	})
+	sampler := filteringSampler{
+		filter: func(sdktrace.SamplingParameters) bool { return false },
+		next:   sdktrace.AlwaysSample(),
+	}
+
+	result := sampler.ShouldSample(sdktrace.SamplingParameters{
+		ParentContext: oteltrace.ContextWithSpanContext(
+			context.Background(),
+			parent,
+		),
+	})
+	if got := result.Tracestate.String(); got != "vendor=value" {
+		t.Fatalf("Tracestate = %q, want vendor=value", got)
 	}
 }
 
@@ -102,6 +131,71 @@ func TestNewFilteringSpanExporter_NilFilter(t *testing.T) {
 	if got := newFilteringSpanExporter(next, nil); got != next {
 		t.Fatal("nil filter should return the original exporter")
 	}
+}
+
+func TestSetupTracerProvider_WiresFilters(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	restoreProvider := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(restoreProvider) })
+	shutdown := setupTracerProvider(resource.Empty(), exporter, &options{
+		spanStartFilter: func(params sdktrace.SamplingParameters) bool {
+			return params.Name != "start-drop"
+		},
+		spanExportFilter: func(span sdktrace.ReadOnlySpan) bool {
+			return span.Name() != "export-drop"
+		},
+	})
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	tracer := otel.Tracer("test")
+	for _, name := range []string{"keep", "start-drop", "export-drop"} {
+		_, span := tracer.Start(context.Background(), name)
+		span.End()
+	}
+	provider, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	if !ok {
+		t.Fatalf("TracerProvider type = %T, want *sdktrace.TracerProvider", otel.GetTracerProvider())
+	}
+	if err := provider.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush() error = %v", err)
+	}
+
+	got := exporter.GetSpans()
+	if len(got) != 1 || got[0].Name != "keep" {
+		t.Fatalf("exported spans = %v, want only keep", spanNames(got))
+	}
+}
+
+func TestSetupTracerProvider_DefaultExportsAll(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	restoreProvider := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(restoreProvider) })
+	shutdown := setupTracerProvider(resource.Empty(), exporter, &options{})
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	tracer := otel.Tracer("test")
+	for _, name := range []string{"first", "second"} {
+		_, span := tracer.Start(context.Background(), name)
+		span.End()
+	}
+	provider, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	if !ok {
+		t.Fatalf("TracerProvider type = %T, want *sdktrace.TracerProvider", otel.GetTracerProvider())
+	}
+	if err := provider.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush() error = %v", err)
+	}
+
+	got := exporter.GetSpans()
+	if len(got) != 2 {
+		t.Fatalf("exported spans = %v, want first and second", spanNames(got))
+	}
+}
+
+func spanNames(spans tracetest.SpanStubs) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name)
+	}
+	return names
 }
 
 func spanSnapshot(name string) sdktrace.ReadOnlySpan {

--- a/telemetry/trace/trace.go
+++ b/telemetry/trace/trace.go
@@ -109,6 +109,8 @@ type options struct {
 	headers             map[string]string // Headers to send with the request
 	resourceAttributes  *[]attribute.KeyValue
 	spanAttributePolicy *SpanAttributePolicy
+	spanStartFilter     SpanStartFilter
+	spanExportFilter    SpanExportFilter
 }
 
 // WithEndpoint sets the traces endpoint(host and port) the Exporter will connect to.
@@ -289,7 +291,7 @@ func initGRPCTracerProvider(ctx context.Context, res *resource.Resource, opts *o
 		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
 	}
 
-	return setupTracerProvider(res, traceExporter), nil
+	return setupTracerProvider(res, traceExporter, opts), nil
 }
 
 // Initializes an OTLP HTTP exporter, and configures the corresponding trace provider.
@@ -317,17 +319,29 @@ func initHTTPTracerProvider(ctx context.Context, res *resource.Resource, opts *o
 		return nil, fmt.Errorf("failed to create HTTP trace exporter: %w", err)
 	}
 
-	return setupTracerProvider(res, traceExporter), nil
+	return setupTracerProvider(res, traceExporter, opts), nil
 }
 
 // setupTracerProvider sets up the tracer provider with the given resource and exporter.
-func setupTracerProvider(res *resource.Resource, traceExporter sdktrace.SpanExporter) func(context.Context) error {
+func setupTracerProvider(
+	res *resource.Resource,
+	traceExporter sdktrace.SpanExporter,
+	opts *options,
+) func(context.Context) error {
 	// Register the trace exporter with a TracerProvider, using a batch
 	// span processor to aggregate spans before export.
 
+	traceExporter = newFilteringSpanExporter(traceExporter, opts.spanExportFilter)
 	bsp := sdktrace.NewBatchSpanProcessor(traceExporter)
+	var sampler sdktrace.Sampler = sdktrace.AlwaysSample()
+	if opts.spanStartFilter != nil {
+		sampler = filteringSampler{
+			filter: opts.spanStartFilter,
+			next:   sampler,
+		}
+	}
 	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSampler(sampler),
 		sdktrace.WithResource(res),
 		sdktrace.WithSpanProcessor(bsp),
 	)


### PR DESCRIPTION
## Summary

Add span-level filtering at both points requested by the issue:

- `WithSpanStartFilter` drops spans before recording, avoiding attribute/event collection work.
- `WithSpanExportFilter` evaluates completed spans immediately before export, allowing decisions based on final attributes, status, events, and duration.
- Preserve the existing always-sample and export-all behavior when filters are not configured.

## Problem and root cause

Telemetry currently supports attribute-level capture policies, but every span is still recorded and exported. Applications cannot suppress health checks, internal spans, sensitive operations, or other unwanted telemetry without replacing the tracer provider.

## User impact

Users can now selectively record or export spans while continuing to use the built-in OTLP setup. The two stages are separate because information such as final status and duration is unavailable when a span is created.

## Testing

- `go test -race -count=10 ./telemetry/trace`
- `go vet ./telemetry/trace`
- `golangci-lint run ./telemetry/trace`
- `go test ./...` (all packages passed except two unrelated macOS temporary-path/process flakes)
- `TMPDIR=/tmp go test -count=1 ./codeexecutor/local ./tool/duckduckgo` (isolated reruns passed)
- `git diff --check`

## Compatibility and risk

The new options are opt-in. Existing sampling and export behavior is unchanged. Export filtering allocates only when configured, and empty filtered batches are not forwarded to the underlying exporter.

Fixes #1040
