### PR TITLE
coderuntime: add sandboxed Python runners

### DIFF
--- a/codeexecutor/codeact/doc.go
+++ b/codeexecutor/codeact/doc.go
@@ -11,8 +11,9 @@
 // CodeAct does not make Python safe by itself. LocalRunner applies
 // defense-in-depth process hardening for development and already isolated
 // environments, but preserves general Python syntax and builtins; it does not
-// apply Dynamic Workflow's language restrictions. Production guest code must
-// run in an isolated container, microVM, or an equivalent sandbox. This package
-// owns the host-side security boundary: only explicitly registered tools can be
+// apply Dynamic Workflow's language restrictions. SandboxRunner adds local OS
+// sandboxing through codeexecutor/sandbox. Stronger container, microVM, or
+// remote isolation can be supplied by implementing Runtime. This package owns
+// the host-side capability boundary: only explicitly registered tools can be
 // called, and their input and output schemas are validated on the Go side.
 package codeact

--- a/codeexecutor/codeact/sandbox.go
+++ b/codeexecutor/codeact/sandbox.go
@@ -1,0 +1,169 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package codeact
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox"
+	"trpc.group/trpc-go/trpc-agent-go/internal/coderuntime/sandboxpython"
+)
+
+const sandboxGuestStderrLimit = 1 << 20
+
+// SandboxRunner executes tool-orchestration Python through
+// codeexecutor/sandbox. Its default options use a fresh OS-sandboxed workspace.
+// Use NewSandboxRunner to construct it. Configure exported fields before first
+// use; mutating them concurrently with ExecuteCodeAct is not safe.
+type SandboxRunner struct {
+	// Python selects an interpreter through the host PATH and may require
+	// sandbox read grants. When empty, the sandbox resolves python3 from its
+	// clean PATH.
+	Python string
+	// Timeout sets an optional deadline for the full execution and propagates
+	// cancellation to host tool calls. Tool handlers must honor their context
+	// for timely cancellation. The zero value relies on the caller's context.
+	Timeout time.Duration
+	// MaxCodeBytes bounds generated code before the process starts. The default
+	// is 64 KiB. Use a negative value to disable the limit.
+	MaxCodeBytes int
+
+	runner *sandboxpython.Runner
+}
+
+// NewSandboxRunner creates a runner backed by codeexecutor/sandbox. The default
+// options require managed OS sandboxing. Guest workspaces are always one-shot
+// even if opts contain another session policy.
+func NewSandboxRunner(opts ...sandbox.Option) *SandboxRunner {
+	return &SandboxRunner{runner: sandboxpython.New(opts...)}
+}
+
+// ExecuteCodeAct implements Runtime using a fresh sandboxed Python guest.
+func (r *SandboxRunner) ExecuteCodeAct(
+	ctx context.Context,
+	req Request,
+	handler ToolCallHandler,
+) (Result, error) {
+	if r == nil || r.runner == nil {
+		return Result{}, errRequired("sandbox runner")
+	}
+	runCtx, cancel := localExecutionContext(ctx, r.Timeout)
+	defer cancel()
+	return executeStdio(runCtx, r, req, handler)
+}
+
+func (r *SandboxRunner) start(
+	ctx context.Context,
+	req Request,
+	script string,
+) (stdioProcess, error) {
+	process, err := r.runner.StartScript(
+		ctx,
+		sandboxpython.Config{
+			Python:       r.Python,
+			MaxCodeBytes: r.MaxCodeBytes,
+		},
+		req.Code,
+		"guest.py",
+		[]byte(script),
+		[]string{"-u"},
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox guest: %w", err)
+	}
+	stderr := newSandboxStderrCapture(sandboxGuestStderrLimit)
+	stderrDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(stderr, process.Stderr())
+		close(stderrDone)
+	}()
+	return &sandboxStdioProcess{
+		process:    process,
+		stderr:     stderr,
+		stderrDone: stderrDone,
+	}, nil
+}
+
+type sandboxStdioProcess struct {
+	process    *sandboxpython.Process
+	stderr     *sandboxStderrCapture
+	stderrDone <-chan struct{}
+}
+
+func (p *sandboxStdioProcess) Stdin() io.WriteCloser { return p.process.Stdin() }
+
+func (p *sandboxStdioProcess) Stdout() io.ReadCloser { return p.process.Stdout() }
+
+func (p *sandboxStdioProcess) Kill() error { return p.process.Kill() }
+
+func (p *sandboxStdioProcess) diagnosticOutput() string {
+	if p == nil || p.stderr == nil {
+		return ""
+	}
+	output := p.stderr.String()
+	if p.stderr.Exceeded() {
+		output += "\n[stderr truncated]"
+	}
+	return output
+}
+
+func (p *sandboxStdioProcess) Wait() error {
+	err := p.process.Wait()
+	if p.stderrDone != nil {
+		<-p.stderrDone
+	}
+	return err
+}
+
+type sandboxStderrCapture struct {
+	mu       sync.Mutex
+	limit    int
+	buf      bytes.Buffer
+	exceeded bool
+}
+
+func newSandboxStderrCapture(limit int) *sandboxStderrCapture {
+	return &sandboxStderrCapture{limit: limit}
+}
+
+func (b *sandboxStderrCapture) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = b.buf.Write(p[:remaining])
+	}
+	if remaining < len(p) {
+		b.exceeded = true
+	}
+	return len(p), nil
+}
+
+func (b *sandboxStderrCapture) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func (b *sandboxStderrCapture) Exceeded() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.exceeded
+}
+
+var _ Runtime = (*SandboxRunner)(nil)

--- a/codeexecutor/codeact/sandbox.go
+++ b/codeexecutor/codeact/sandbox.go
@@ -120,11 +120,10 @@ func (p *sandboxStdioProcess) diagnosticOutput() string {
 }
 
 func (p *sandboxStdioProcess) Wait() error {
-	err := p.process.Wait()
 	if p.stderrDone != nil {
 		<-p.stderrDone
 	}
-	return err
+	return p.process.Wait()
 }
 
 type sandboxStderrCapture struct {

--- a/codeexecutor/codeact/sandbox_test.go
+++ b/codeexecutor/codeact/sandbox_test.go
@@ -175,6 +175,68 @@ func TestSandboxRunnerIncludesGuestStderrInFailure(t *testing.T) {
 	require.ErrorContains(t, err, "guest bootstrap failed")
 }
 
+func TestSandboxRunnerDrainsGuestStderrBeforeWait(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell wrapper is Unix-specific")
+	}
+	wrapper := filepath.Join(t.TempDir(), "python-with-stderr-burst")
+	require.NoError(t, os.WriteFile(
+		wrapper,
+		[]byte(`#!/bin/sh
+IFS= read -r _
+i=0
+while [ "$i" -lt 8192 ]; do
+  printf '0123456789abcdef0123456789abcdef'
+  i=$((i + 1))
+done >&2
+printf '\nfinal stderr marker\n' >&2
+exit 97
+`),
+		0o700,
+	))
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Python = wrapper
+
+	_, err := Execute(
+		context.Background(),
+		runner,
+		fakeToolCallHandler{},
+		"return None",
+	)
+	require.ErrorContains(t, err, "final stderr marker")
+}
+
+func TestSandboxRunnerKillsDescendantHoldingStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group cleanup is Unix-specific")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	originalTimeout := completedGuestWaitTimeout
+	completedGuestWaitTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { completedGuestWaitTimeout = originalTimeout })
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+
+	started := time.Now()
+	result, err := Execute(
+		context.Background(),
+		runner,
+		fakeToolCallHandler{},
+		"import subprocess, sys\n"+
+			"subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'], "+
+			"stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL)\n"+
+			"return 'done'",
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, `"done"`, string(result.Value))
+	require.Less(t, time.Since(started), 2*time.Second)
+}
+
 func TestSandboxStderrCaptureBoundsOutput(t *testing.T) {
 	capture := newSandboxStderrCapture(4)
 	n, err := capture.Write([]byte("abcdef"))

--- a/codeexecutor/codeact/sandbox_test.go
+++ b/codeexecutor/codeact/sandbox_test.go
@@ -1,0 +1,264 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package codeact
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox"
+)
+
+func TestSandboxRunnerRoutesToolCalls(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	root := t.TempDir()
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	handler := toolCallHandlerFunc(func(_ context.Context, call ToolCall) (json.RawMessage, error) {
+		require.Equal(t, "add", call.Name)
+		require.JSONEq(t, `{"a":20,"b":22}`, string(call.Args))
+		return json.RawMessage(`42`), nil
+	})
+
+	result, err := Execute(
+		context.Background(),
+		runner,
+		handler,
+		"value = await call_tool('add', a=20, b=22)\nreturn {'answer': value}",
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"answer":42}`, string(result.Value))
+	requireNoSandboxGuestScripts(t, root)
+}
+
+func TestSandboxRunnerUsesCleanEnvironment(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	t.Setenv("TRPC_SANDBOX_ENV_PROBE", "must-not-leak")
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	result, err := Execute(
+		context.Background(),
+		runner,
+		fakeToolCallHandler{},
+		"import os\nreturn os.getenv('TRPC_SANDBOX_ENV_PROBE')",
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, "null", string(result.Value))
+}
+
+func TestSandboxRunnerManagedBackendBlocksNetworkAndHostWrites(t *testing.T) {
+	requireManagedSandbox(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	address := listener.Addr().(*net.TCPAddr)
+	probe, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
+	require.NoError(t, err)
+	require.NoError(t, probe.Close())
+	escapePath := filepath.Join(t.TempDir(), "sandbox-escape")
+	code := fmt.Sprintf(`
+import socket
+network_blocked = False
+s = socket.socket()
+s.settimeout(0.2)
+try:
+    s.connect((%q, %d))
+except Exception:
+    network_blocked = True
+finally:
+    s.close()
+write_blocked = False
+try:
+    with open(%q, "w") as f:
+        f.write("escaped")
+except Exception:
+    write_blocked = True
+return {"network_blocked": network_blocked, "write_blocked": write_blocked}
+`, address.IP.String(), address.Port, escapePath)
+
+	result, err := Execute(
+		context.Background(),
+		NewSandboxRunner(),
+		fakeToolCallHandler{},
+		code,
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"network_blocked":true,"write_blocked":true}`, string(result.Value))
+	require.NoFileExists(t, escapePath)
+}
+
+func TestSandboxRunnerEnforcesCodeLimit(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.MaxCodeBytes = 8
+	_, err := Execute(
+		context.Background(),
+		runner,
+		fakeToolCallHandler{},
+		"return None",
+	)
+	require.ErrorContains(t, err, "code exceeds 8 bytes")
+}
+
+func TestSandboxRunnerOptionalTimeoutStopsBusyCode(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Timeout = 100 * time.Millisecond
+	started := time.Now()
+	_, err := Execute(
+		context.Background(),
+		runner,
+		fakeToolCallHandler{},
+		"while True:\n    pass",
+	)
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 5*time.Second)
+}
+
+func TestSandboxRunnerIncludesGuestStderrInFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell wrapper is Unix-specific")
+	}
+	wrapper := filepath.Join(t.TempDir(), "python-with-stderr")
+	require.NoError(t, os.WriteFile(
+		wrapper,
+		[]byte(
+			"#!/bin/sh\n"+
+				"IFS= read -r _\n"+
+				"echo 'guest bootstrap failed' >&2\n"+
+				"exit 97\n",
+		),
+		0o700,
+	))
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Python = wrapper
+
+	_, err := Execute(
+		context.Background(),
+		runner,
+		fakeToolCallHandler{},
+		"return None",
+	)
+	require.ErrorContains(t, err, "guest bootstrap failed")
+}
+
+func TestSandboxStderrCaptureBoundsOutput(t *testing.T) {
+	capture := newSandboxStderrCapture(4)
+	n, err := capture.Write([]byte("abcdef"))
+	require.NoError(t, err)
+	require.Equal(t, 6, n)
+	require.Equal(t, "abcd", capture.String())
+	require.True(t, capture.Exceeded())
+
+	process := &sandboxStdioProcess{stderr: capture}
+	require.Equal(t, "abcd\n[stderr truncated]", process.diagnosticOutput())
+	var nilProcess *sandboxStdioProcess
+	require.Empty(t, nilProcess.diagnosticOutput())
+}
+
+func TestSandboxRunnerTimeoutCancelsToolCallAndCleansWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	root := t.TempDir()
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	runner.Timeout = 500 * time.Millisecond
+	handlerErr := make(chan error, 1)
+	handler := toolCallHandlerFunc(func(ctx context.Context, _ ToolCall) (json.RawMessage, error) {
+		<-ctx.Done()
+		handlerErr <- ctx.Err()
+		return nil, ctx.Err()
+	})
+
+	_, err := Execute(
+		context.Background(),
+		runner,
+		handler,
+		"value = await call_tool('wait')\nreturn value",
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	select {
+	case err := <-handlerErr:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(2 * time.Second):
+		t.Fatal("tool call handler did not observe the runner timeout")
+	}
+	requireNoSandboxGuestScripts(t, root)
+}
+
+func TestSandboxRunnerRequiresConstructor(t *testing.T) {
+	_, err := (&SandboxRunner{}).ExecuteCodeAct(
+		context.Background(),
+		Request{Code: "return None", Language: "python"},
+		fakeToolCallHandler{},
+	)
+	require.ErrorContains(t, err, "sandbox runner is required")
+}
+
+func requireNoSandboxGuestScripts(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == "guest.py" {
+			t.Fatalf("guest script was not cleaned up: %s", path)
+		}
+		return nil
+	}))
+}
+
+func requireManagedSandbox(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("bwrap"); err != nil {
+			t.Skip("bubblewrap is not installed")
+		}
+	case "darwin":
+		if _, err := os.Stat("/usr/bin/sandbox-exec"); err != nil {
+			t.Skip("sandbox-exec is not installed")
+		}
+	default:
+		t.Skip("managed sandbox backend is unavailable")
+	}
+}

--- a/codeexecutor/codeact/stdio.go
+++ b/codeexecutor/codeact/stdio.go
@@ -28,9 +28,9 @@ var guestPython string
 var completedGuestWaitTimeout = 2 * time.Second
 var completedGuestKillWaitTimeout = 100 * time.Millisecond
 
-// stdioRunner starts a guest process that speaks the local stdio protocol.
-// It is an implementation detail of LocalRunner; non-stdio backends implement
-// Runtime directly.
+// stdioRunner starts a guest process that speaks the built-in stdio protocol.
+// It is an implementation detail of the local and OS-sandbox runners;
+// non-stdio backends implement Runtime directly.
 type stdioRunner interface {
 	start(context.Context, Request, string) (stdioProcess, error)
 }
@@ -40,6 +40,10 @@ type stdioProcess interface {
 	Stdout() io.ReadCloser
 	Wait() error
 	Kill() error
+}
+
+type stdioProcessDiagnostics interface {
+	diagnosticOutput() string
 }
 
 // LocalRunner runs the guest with a caller-supplied Python executable. Use it
@@ -185,47 +189,68 @@ func executeStdio(ctx context.Context, runner stdioRunner, req Request, handler 
 			_ = p.Wait()
 		}
 	}()
+	fail := func(err error) (Result, error) {
+		closeStdin()
+		if !waited {
+			_ = p.Kill()
+			_ = p.Wait()
+			waited = true
+		}
+		return Result{}, stdioErrorWithDiagnostics(p, err)
+	}
 
 	enc := json.NewEncoder(p.Stdin())
 	dec := bufio.NewScanner(p.Stdout())
 	dec.Buffer(make([]byte, 1024), 4<<20)
 	if err := enc.Encode(protocolMessage{Type: "run", Code: req.Code}); err != nil {
-		return Result{}, err
+		return fail(err)
 	}
 	for dec.Scan() {
 		var msg protocolMessage
 		if err := json.Unmarshal(dec.Bytes(), &msg); err != nil {
-			return Result{}, fmt.Errorf("codeact: malformed guest message: %w", err)
+			return fail(fmt.Errorf("codeact: malformed guest message: %w", err))
 		}
 		switch msg.Type {
 		case "tool_call":
 			if err := handleStdioToolCall(ctx, handler, enc, msg); err != nil {
-				return Result{}, err
+				return fail(err)
 			}
 		case "complete":
 			closeStdin()
 			waited = true
 			waitErr := waitForCompletedGuest(ctx, p, completedGuestWaitTimeout)
 			if waitErr != nil {
-				return Result{}, fmt.Errorf("codeact: wait for guest: %w", waitErr)
+				return fail(fmt.Errorf("codeact: wait for guest: %w", waitErr))
 			}
 			if msg.Name != "" {
-				return Result{}, errors.New(msg.Name)
+				return fail(errors.New(msg.Name))
 			}
 			return Result{Value: msg.Args, Stdout: msg.Code}, nil
 		default:
-			return Result{}, fmt.Errorf("codeact: unknown guest message %q", msg.Type)
+			return fail(fmt.Errorf("codeact: unknown guest message %q", msg.Type))
 		}
 	}
 	if err := dec.Err(); err != nil {
-		return Result{}, err
+		return fail(err)
 	}
 	select {
 	case <-ctx.Done():
-		return Result{}, ctx.Err()
+		return fail(ctx.Err())
 	case <-time.After(10 * time.Millisecond):
 	}
-	return Result{}, errors.New("codeact: guest exited without a completion message")
+	return fail(errors.New("codeact: guest exited without a completion message"))
+}
+
+func stdioErrorWithDiagnostics(p stdioProcess, err error) error {
+	diagnostics, ok := p.(stdioProcessDiagnostics)
+	if !ok {
+		return err
+	}
+	output := strings.TrimSpace(diagnostics.diagnosticOutput())
+	if output == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, output)
 }
 
 func handleStdioToolCall(

--- a/codeexecutor/codeact/types.go
+++ b/codeexecutor/codeact/types.go
@@ -35,7 +35,8 @@ type ToolCall struct {
 }
 
 // ToolCallHandler handles sandbox-originated tool calls. Implementations are
-// the host capability boundary; runtimes should not bypass them.
+// the host capability boundary; runtimes should not bypass them. Handlers must
+// honor context cancellation and return promptly after the context is done.
 type ToolCallHandler interface {
 	HandleToolCall(context.Context, ToolCall) (json.RawMessage, error)
 }

--- a/codeexecutor/sandbox/docs/README.md
+++ b/codeexecutor/sandbox/docs/README.md
@@ -66,3 +66,25 @@ variable injection model is described in
 can inherit all, core, or no host variables, apply excludes or allow-lists, and
 the runtime always injects stable workspace variables such as `HOME`, `TMPDIR`,
 `WORKSPACE_DIR`, and `OUTPUT_DIR`.
+
+For backward compatibility, `RunProgram` keeps its existing environment
+behavior and does not advertise generic `CleanEnv` support. The new
+`StartProcess` API honors `ProcessSpec.CleanEnv`: when it is true, the
+process starts without host environment variables; explicit policy settings,
+per-run variables, and sandbox-owned workspace variables are still applied.
+
+## Full-duplex Processes
+
+`Runtime.StartProcess` starts a program through the same permission checks and
+native sandbox backend as `RunProgram`, but returns separate stdin, stdout, and
+stderr pipes. It is intended for machine protocols that need multiple request
+and response exchanges while the process stays alive.
+
+Callers must drain stdout and stderr and must call `Wait` after normal exit or
+`Kill`. `Wait` releases native backend resources and the workspace run lock. A
+process abandoned without `Wait` can retain backend resources and, with serial
+workspace concurrency, block later runs on that workspace. Context cancellation
+terminates the process but does not replace the caller's responsibility to call
+`Wait`. A zero `ProcessSpec.Timeout` adds no runtime timeout; the
+caller's context remains authoritative. `RunProgram` keeps its existing default
+timeout behavior. Interactive input is written through `Process.Stdin()`.

--- a/codeexecutor/sandbox/env.go
+++ b/codeexecutor/sandbox/env.go
@@ -59,21 +59,24 @@ func (r *Runtime) buildEnvironment(
 	ws codeexecutor.Workspace,
 	spec codeexecutor.RunProgramSpec,
 ) []string {
-	env := map[string]string{}
-	host := hostEnvMap()
-	switch r.envPolicy.Inherit {
-	case ShellEnvironmentPolicyInheritNone:
-	case ShellEnvironmentPolicyInheritCore:
-		for k, v := range host {
-			if isCoreEnvironmentKey(k) {
-				env[k] = v
-			}
-		}
-	default:
-		for k, v := range host {
-			env[k] = v
-		}
-	}
+	// RunProgram preserves its historical environment behavior, including
+	// host inheritance when spec.CleanEnv is set.
+	return r.buildEnvironmentFrom(ws, spec.Env, true)
+}
+
+func (r *Runtime) buildProcessEnvironment(
+	ws codeexecutor.Workspace,
+	spec ProcessSpec,
+) []string {
+	return r.buildEnvironmentFrom(ws, spec.Env, !spec.CleanEnv)
+}
+
+func (r *Runtime) buildEnvironmentFrom(
+	ws codeexecutor.Workspace,
+	explicit map[string]string,
+	inheritHost bool,
+) []string {
+	env := r.inheritedEnvironment(inheritHost)
 	if r.envPolicy.ApplyDefaultExcludes {
 		for k := range env {
 			if isSecretName(k) {
@@ -93,7 +96,7 @@ func (r *Runtime) buildEnvironment(
 			env[k] = v
 		}
 	}
-	for k, v := range spec.Env {
+	for k, v := range explicit {
 		if k != "" {
 			env[k] = v
 		}
@@ -123,6 +126,28 @@ func (r *Runtime) buildEnvironment(
 		env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	}
 	return envSlice(env)
+}
+
+func (r *Runtime) inheritedEnvironment(enabled bool) map[string]string {
+	env := map[string]string{}
+	if !enabled {
+		return env
+	}
+	host := hostEnvMap()
+	switch r.envPolicy.Inherit {
+	case ShellEnvironmentPolicyInheritNone:
+	case ShellEnvironmentPolicyInheritCore:
+		for k, v := range host {
+			if isCoreEnvironmentKey(k) {
+				env[k] = v
+			}
+		}
+	default:
+		for k, v := range host {
+			env[k] = v
+		}
+	}
+	return env
 }
 
 func isCoreEnvironmentKey(name string) bool {

--- a/codeexecutor/sandbox/process.go
+++ b/codeexecutor/sandbox/process.go
@@ -1,0 +1,256 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+// ProcessSpec describes a full-duplex sandbox process. Input is written through
+// Process.Stdin after startup rather than supplied in the spec.
+type ProcessSpec struct {
+	// Cmd is the program to execute.
+	Cmd string
+	// Args are passed to Cmd.
+	Args []string
+	// Env adds or overrides process environment variables.
+	Env map[string]string
+	// CleanEnv prevents host environment inheritance. Sandbox policy variables,
+	// Env, and sandbox-owned workspace variables are still applied.
+	CleanEnv bool
+	// Cwd is the working directory relative to the workspace root. The default
+	// is codeexecutor.DirWork.
+	Cwd string
+	// Timeout optionally bounds the process lifetime. The zero value relies on
+	// the caller's context without adding a runtime deadline.
+	Timeout time.Duration
+	// Limits requests resource limits supported by the active backend.
+	Limits codeexecutor.ResourceLimits
+}
+
+func (s ProcessSpec) runProgramSpec() codeexecutor.RunProgramSpec {
+	return codeexecutor.RunProgramSpec{
+		Cmd:     s.Cmd,
+		Args:    s.Args,
+		Env:     s.Env,
+		Cwd:     s.Cwd,
+		Timeout: s.Timeout,
+		Limits:  s.Limits,
+	}
+}
+
+// Process is a running sandboxed program with separate standard streams.
+// Callers must call Wait after the process exits or is killed. Abandoning a
+// Process without Wait can retain backend resources and, under serial workspace
+// concurrency, permanently block later runs on the same workspace.
+type Process struct {
+	prepared *preparedProcess
+	stdin    io.WriteCloser
+	stdout   io.ReadCloser
+	stderr   io.ReadCloser
+
+	waitOnce sync.Once
+	waitDone chan struct{}
+	waitErr  error
+}
+
+type preparedProcess struct {
+	cmd     *exec.Cmd
+	backend string
+	runCtx  context.Context
+	release func()
+	once    sync.Once
+}
+
+func (p *preparedProcess) cleanup() {
+	if p == nil {
+		return
+	}
+	p.once.Do(func() {
+		if p.release != nil {
+			p.release()
+		}
+	})
+}
+
+// StartProcess starts a sandboxed program and returns its standard streams.
+// A zero spec.Timeout adds no runtime deadline and relies on ctx. The caller
+// owns the protocol, output limits, and stream draining. Every successfully
+// returned Process must eventually be reaped with Wait, including after Kill or
+// context cancellation.
+func (r *Runtime) StartProcess(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec ProcessSpec,
+) (*Process, error) {
+	prepared, err := r.prepareProcess(ctx, ws, spec)
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := prepared.cmd.StdinPipe()
+	if err != nil {
+		prepared.cleanup()
+		return nil, fmt.Errorf("sandbox: create process stdin: %w", err)
+	}
+	stdout, err := prepared.cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		prepared.cleanup()
+		return nil, fmt.Errorf("sandbox: create process stdout: %w", err)
+	}
+	stderr, err := prepared.cmd.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		prepared.cleanup()
+		return nil, fmt.Errorf("sandbox: create process stderr: %w", err)
+	}
+	if err := prepared.cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		_ = stderr.Close()
+		prepared.cleanup()
+		return nil, backendError(ErrSetupFailed, prepared.backend, err)
+	}
+	return &Process{
+		prepared: prepared,
+		stdin:    stdin,
+		stdout:   stdout,
+		stderr:   stderr,
+		waitDone: make(chan struct{}),
+	}, nil
+}
+
+func (r *Runtime) prepareProcess(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec ProcessSpec,
+) (*preparedProcess, error) {
+	runSpec := spec.runProgramSpec()
+	prep, err := r.prepareRun(ctx, ws, runSpec)
+	if err != nil {
+		return nil, err
+	}
+	unlock := func() {}
+	if r.sessionPolicy.RunConcurrency == SessionRunConcurrencySerial {
+		unlock, err = r.lockWorkspaceRunContext(ctx, ws)
+		if err != nil {
+			return nil, err
+		}
+	}
+	runCtx := ctx
+	cancel := func() {}
+	if spec.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, spec.Timeout)
+	}
+	env := r.buildProcessEnvironment(ws, spec)
+	cmd, backendName, backendCleanup, err := r.commandForProfile(
+		runCtx, prep.profile, ws, prep.cwd, env, runSpec,
+	)
+	if err != nil {
+		cancel()
+		unlock()
+		return nil, err
+	}
+	setupProcess(cmd)
+	cmd.Cancel = func() error { return killProcessGroup(cmd) }
+	cmd.WaitDelay = 2 * time.Second
+	return &preparedProcess{
+		cmd:     cmd,
+		backend: backendName,
+		runCtx:  runCtx,
+		release: func() {
+			if backendCleanup != nil {
+				backendCleanup()
+			}
+			cancel()
+			unlock()
+		},
+	}, nil
+}
+
+// Stdin returns the process standard-input pipe.
+func (p *Process) Stdin() io.WriteCloser {
+	if p == nil {
+		return nil
+	}
+	return p.stdin
+}
+
+// Stdout returns the process standard-output pipe.
+func (p *Process) Stdout() io.ReadCloser {
+	if p == nil {
+		return nil
+	}
+	return p.stdout
+}
+
+// Stderr returns the process standard-error pipe.
+func (p *Process) Stderr() io.ReadCloser {
+	if p == nil {
+		return nil
+	}
+	return p.stderr
+}
+
+// Wait waits for process exit and releases backend resources exactly once.
+// Concurrent and repeated calls return the same result.
+func (p *Process) Wait() error {
+	if p == nil || p.prepared == nil || p.prepared.cmd == nil {
+		return nil
+	}
+	p.waitOnce.Do(func() {
+		p.waitErr = p.prepared.cmd.Wait()
+		if p.waitErr != nil {
+			processErr := p.waitErr
+			switch p.prepared.runCtx.Err() {
+			case context.DeadlineExceeded:
+				p.waitErr = &sandboxError{
+					Kind:    ErrTimeout,
+					Op:      "process",
+					Backend: p.prepared.backend,
+					Err: errors.Join(
+						context.DeadlineExceeded,
+						processErr,
+					),
+				}
+			case context.Canceled:
+				p.waitErr = errors.Join(context.Canceled, processErr)
+			}
+		}
+		p.prepared.cleanup()
+		close(p.waitDone)
+	})
+	<-p.waitDone
+	return p.waitErr
+}
+
+// Kill requests termination of the sandboxed process. On Unix-like systems it
+// targets the process group; other platforms use their available process
+// termination mechanism. Call Wait afterward to release all backend resources.
+// Killing an already-exited process succeeds.
+func (p *Process) Kill() error {
+	if p == nil || p.prepared == nil {
+		return nil
+	}
+	err := killProcessGroup(p.prepared.cmd)
+	if errors.Is(err, os.ErrProcessDone) || isProcessDoneError(err) {
+		return nil
+	}
+	return err
+}

--- a/codeexecutor/sandbox/process.go
+++ b/codeexecutor/sandbox/process.go
@@ -208,14 +208,17 @@ func (p *Process) Stderr() io.ReadCloser {
 	return p.stderr
 }
 
-// Wait waits for process exit and releases backend resources exactly once.
-// Concurrent and repeated calls return the same result.
+// Wait waits for process exit and releases backend resources exactly once. On
+// Unix-like systems it also makes a best-effort attempt to terminate remaining
+// members of the process group after the leader exits. Concurrent and repeated
+// calls return the same result.
 func (p *Process) Wait() error {
 	if p == nil || p.prepared == nil || p.prepared.cmd == nil {
 		return nil
 	}
 	p.waitOnce.Do(func() {
 		p.waitErr = p.prepared.cmd.Wait()
+		cleanupProcessTree(p.prepared.cmd)
 		if p.waitErr != nil {
 			processErr := p.waitErr
 			switch p.prepared.runCtx.Err() {

--- a/codeexecutor/sandbox/process_done_unix.go
+++ b/codeexecutor/sandbox/process_done_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 //
 // Tencent is pleased to support the open source community by making
 // trpc-agent-go available.
@@ -7,7 +9,13 @@
 // trpc-agent-go is licensed under the Apache License Version 2.0.
 //
 
-// Package sandbox provides an OS-level sandbox code executor. Runtime supports
-// both buffered RunProgram calls and full-duplex StartProcess calls; both use
-// the same workspace, permission, environment, and native-backend enforcement.
 package sandbox
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isProcessDoneError(err error) bool {
+	return errors.Is(err, syscall.ESRCH)
+}

--- a/codeexecutor/sandbox/process_done_windows.go
+++ b/codeexecutor/sandbox/process_done_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 //
 // Tencent is pleased to support the open source community by making
 // trpc-agent-go available.
@@ -7,7 +9,6 @@
 // trpc-agent-go is licensed under the Apache License Version 2.0.
 //
 
-// Package sandbox provides an OS-level sandbox code executor. Runtime supports
-// both buffered RunProgram calls and full-duplex StartProcess calls; both use
-// the same workspace, permission, environment, and native-backend enforcement.
 package sandbox
+
+func isProcessDoneError(error) bool { return false }

--- a/codeexecutor/sandbox/process_test.go
+++ b/codeexecutor/sandbox/process_test.go
@@ -1,0 +1,408 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package sandbox
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+)
+
+const processHelperEnv = "TRPC_SANDBOX_PROCESS_HELPER"
+
+func TestProcessHelper(t *testing.T) {
+	mode := os.Getenv(processHelperEnv)
+	if mode == "" {
+		return
+	}
+	switch mode {
+	case "echo":
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			line := scanner.Text()
+			_, _ = fmt.Fprintln(os.Stdout, "out:"+line)
+			_, _ = fmt.Fprintln(os.Stderr, "err:"+line)
+			if line == "quit" {
+				return
+			}
+		}
+	case "env":
+		_, _ = fmt.Fprintln(os.Stdout, os.Getenv("TRPC_SANDBOX_ENV_PROBE"))
+	case "sleep":
+		time.Sleep(150 * time.Millisecond)
+		_, _ = fmt.Fprintln(os.Stdout, "done")
+	default:
+		os.Exit(2)
+	}
+}
+
+func TestStartProcessSupportsBidirectionalSeparatedStreams(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	process := startProcessHelper(t, rt, ws, "echo", 0)
+	stdout := bufio.NewReader(process.Stdout())
+	stderr := bufio.NewReader(process.Stderr())
+
+	_, err := io.WriteString(process.Stdin(), "first\n")
+	require.NoError(t, err)
+	require.Equal(t, "out:first\n", readLine(t, stdout))
+	require.Equal(t, "err:first\n", readLine(t, stderr))
+
+	_, err = io.WriteString(process.Stdin(), "quit\n")
+	require.NoError(t, err)
+	require.Equal(t, "out:quit\n", readLine(t, stdout))
+	require.Equal(t, "err:quit\n", readLine(t, stderr))
+	require.NoError(t, process.Stdin().Close())
+	require.NoError(t, process.Wait())
+}
+
+func TestProcessSpecConvertsExecutionFields(t *testing.T) {
+	spec := ProcessSpec{
+		Cmd:      "python3",
+		Args:     []string{"guest.py"},
+		Env:      map[string]string{"MODE": "test"},
+		CleanEnv: true,
+		Cwd:      codeexecutor.DirRuns,
+		Timeout:  time.Minute,
+		Limits:   codeexecutor.ResourceLimits{MemoryMB: 128},
+	}
+	got := spec.runProgramSpec()
+	require.Equal(t, spec.Cmd, got.Cmd)
+	require.Equal(t, spec.Args, got.Args)
+	require.Equal(t, spec.Env, got.Env)
+	require.Equal(t, spec.Cwd, got.Cwd)
+	require.Equal(t, spec.Timeout, got.Timeout)
+	require.Equal(t, spec.Limits, got.Limits)
+	require.Empty(t, got.Stdin)
+	require.False(t, got.CleanEnv)
+}
+
+func TestNilProcessOperations(t *testing.T) {
+	var process *Process
+	require.Nil(t, process.Stdin())
+	require.Nil(t, process.Stdout())
+	require.Nil(t, process.Stderr())
+	require.NoError(t, process.Kill())
+	require.NoError(t, process.Wait())
+
+	var prepared *preparedProcess
+	require.NotPanics(t, prepared.cleanup)
+}
+
+func TestProcessWaitIsConcurrentAndIdempotent(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	process := startProcessHelper(t, rt, ws, "sleep", 5*time.Second)
+	_, err := io.Copy(io.Discard, process.Stdout())
+	require.NoError(t, err)
+
+	const waiters = 8
+	errs := make(chan error, waiters)
+	var wg sync.WaitGroup
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- process.Wait()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.NoError(t, process.Wait())
+	require.NoError(t, process.Kill())
+}
+
+func TestStartProcessZeroTimeoutDoesNotUseRunDefault(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t, WithDefaultTimeout(time.Millisecond))
+	process := startProcessHelper(t, rt, ws, "sleep", 0)
+	out, err := io.ReadAll(process.Stdout())
+	require.NoError(t, err)
+	require.NoError(t, process.Wait())
+	require.Contains(t, string(out), "done\n")
+}
+
+func TestStartProcessExplicitTimeoutStopsProgram(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	started := time.Now()
+	process := startProcessHelper(t, rt, ws, "sleep", 20*time.Millisecond)
+	_, _ = io.Copy(io.Discard, process.Stdout())
+	require.ErrorIs(t, process.Wait(), context.DeadlineExceeded)
+	require.Less(t, time.Since(started), 2*time.Second)
+}
+
+func TestStartProcessContextCancellationStopsProgram(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	process, err := rt.StartProcess(ctx, ws, processHelperSpec("sleep", 0))
+	require.NoError(t, err)
+	cancel()
+	_, _ = io.Copy(io.Discard, process.Stdout())
+	waitErr := process.Wait()
+	require.ErrorIs(t, waitErr, context.Canceled)
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, waitErr, &exitErr)
+}
+
+func TestStartProcessFailureReleasesSerialRunLock(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	_, err := rt.StartProcess(context.Background(), ws, ProcessSpec{
+		Cmd: "program-that-does-not-exist",
+	})
+	require.Error(t, err)
+
+	process := startProcessHelper(t, rt, ws, "sleep", 5*time.Second)
+	_, err = io.Copy(io.Discard, process.Stdout())
+	require.NoError(t, err)
+	require.NoError(t, process.Wait())
+}
+
+func TestStartProcessCleanEnvDoesNotInheritHost(t *testing.T) {
+	t.Setenv("TRPC_SANDBOX_ENV_PROBE", "must-not-leak")
+	rt, ws := newProcessTestRuntime(t)
+	process := startProcessHelper(t, rt, ws, "env", 5*time.Second)
+	out, err := io.ReadAll(process.Stdout())
+	require.NoError(t, err)
+	require.NoError(t, process.Wait())
+	require.NotContains(t, string(out), "must-not-leak")
+	require.True(t, strings.HasPrefix(string(out), "\n"))
+	capabilities := rt.Describe()
+	require.False(t, capabilities.Streaming)
+	require.False(t, capabilities.SupportsCleanEnv)
+}
+
+func TestRunProgramKeepsLegacyCleanEnvBehavior(t *testing.T) {
+	t.Setenv("TRPC_SANDBOX_ENV_PROBE", "still-inherited")
+	rt, ws := newProcessTestRuntime(t)
+	result, err := rt.RunProgram(context.Background(), ws, codeexecutor.RunProgramSpec{
+		Cmd:      os.Args[0],
+		Args:     []string{"-test.run=TestProcessHelper"},
+		Env:      map[string]string{processHelperEnv: "env"},
+		CleanEnv: true,
+	})
+	require.NoError(t, err)
+	require.Contains(t, result.Stdout, "still-inherited\n")
+	require.False(t, rt.Describe().SupportsCleanEnv)
+	require.Empty(t, rt.runLocks)
+}
+
+func TestRunProgramContextCancellationUnblocksSerialLockWait(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	first := startProcessHelper(t, rt, ws, "echo", 0)
+	t.Cleanup(func() {
+		_ = first.Kill()
+		_ = first.Wait()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := rt.RunProgram(
+			ctx,
+			ws,
+			codeexecutor.RunProgramSpec{
+				Cmd:  os.Args[0],
+				Args: []string{"-test.run=^TestProcessHelper$"},
+				Env:  map[string]string{processHelperEnv: "sleep"},
+			},
+		)
+		result <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		lock := rt.runLocks[workspaceRunLockKey(ws)]
+		return lock != nil && lock.refs == 2
+	}, time.Second, 5*time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled RunProgram remained blocked on the serial run lock")
+	}
+	require.Len(t, rt.runLocks, 1)
+	require.NoError(t, first.Kill())
+	require.Error(t, first.Wait())
+	require.Empty(t, rt.runLocks)
+}
+
+func TestStartProcessHoldsSerialRunLockUntilWait(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	first := startProcessHelper(t, rt, ws, "echo", 0)
+
+	started := make(chan *Process, 1)
+	errs := make(chan error, 1)
+	go func() {
+		process, err := rt.StartProcess(
+			context.Background(),
+			ws,
+			processHelperSpec("sleep", 5*time.Second),
+		)
+		if err != nil {
+			errs <- err
+			return
+		}
+		started <- process
+	}()
+
+	select {
+	case process := <-started:
+		_ = process.Kill()
+		_ = process.Wait()
+		t.Fatal("second process started while the first held the serial lock")
+	case err := <-errs:
+		t.Fatalf("second process failed before lock release: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	_, err := io.WriteString(first.Stdin(), "quit\n")
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, first.Stdout())
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, first.Stderr())
+	require.NoError(t, err)
+	require.NoError(t, first.Wait())
+
+	select {
+	case second := <-started:
+		require.Len(t, rt.runLocks, 1)
+		_ = second.Kill()
+		_ = second.Wait()
+	case err := <-errs:
+		t.Fatalf("second process failed after lock release: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second process did not start after lock release")
+	}
+	require.Empty(t, rt.runLocks)
+}
+
+func TestStartProcessContextCancellationUnblocksSerialLockWait(t *testing.T) {
+	rt, ws := newProcessTestRuntime(t)
+	first := startProcessHelper(t, rt, ws, "echo", 0)
+	t.Cleanup(func() {
+		_ = first.Kill()
+		_ = first.Wait()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type startResult struct {
+		process *Process
+		err     error
+	}
+	started := make(chan struct{})
+	result := make(chan startResult, 1)
+	go func() {
+		close(started)
+		process, err := rt.StartProcess(
+			ctx,
+			ws,
+			processHelperSpec("sleep", 5*time.Second),
+		)
+		result <- startResult{process: process, err: err}
+	}()
+	<-started
+
+	select {
+	case got := <-result:
+		if got.process != nil {
+			_ = got.process.Kill()
+			_ = got.process.Wait()
+		}
+		t.Fatalf("second process returned before cancellation: %v", got.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancel()
+
+	select {
+	case got := <-result:
+		if got.process != nil {
+			_ = got.process.Kill()
+			_ = got.process.Wait()
+		}
+		require.ErrorIs(t, got.err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled StartProcess remained blocked on the serial run lock")
+	}
+	require.Len(t, rt.runLocks, 1)
+	require.NoError(t, first.Kill())
+	require.Error(t, first.Wait())
+	require.Empty(t, rt.runLocks)
+}
+
+func newProcessTestRuntime(t *testing.T, extra ...Option) (*Runtime, codeexecutor.Workspace) {
+	t.Helper()
+	options := []Option{
+		WithPermissionProfile(DangerFullAccessProfile()),
+		WithSessionPolicy(SessionPolicy{
+			Persistence:    SessionPersistencePerTurn,
+			RunConcurrency: SessionRunConcurrencySerial,
+		}),
+		WithShellEnvironmentPolicy(ShellEnvironmentPolicy{
+			Inherit: ShellEnvironmentPolicyInheritAll,
+		}),
+	}
+	options = append(options, extra...)
+	rt := NewRuntime(options...)
+	ws, err := rt.CreateWorkspace(context.Background(), t.Name(), codeexecutor.WorkspacePolicy{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Cleanup(context.Background(), ws))
+	})
+	return rt, ws
+}
+
+func startProcessHelper(
+	t *testing.T,
+	rt *Runtime,
+	ws codeexecutor.Workspace,
+	mode string,
+	timeout time.Duration,
+) *Process {
+	t.Helper()
+	process, err := rt.StartProcess(
+		context.Background(),
+		ws,
+		processHelperSpec(mode, timeout),
+	)
+	require.NoError(t, err)
+	return process
+}
+
+func processHelperSpec(mode string, timeout time.Duration) ProcessSpec {
+	return ProcessSpec{
+		Cmd:      os.Args[0],
+		Args:     []string{"-test.run=^TestProcessHelper$"},
+		Env:      map[string]string{processHelperEnv: mode},
+		CleanEnv: true,
+		Timeout:  timeout,
+	}
+}
+
+func readLine(t *testing.T, reader *bufio.Reader) string {
+	t.Helper()
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	return line
+}

--- a/codeexecutor/sandbox/process_unix.go
+++ b/codeexecutor/sandbox/process_unix.go
@@ -26,3 +26,7 @@ func killProcessGroup(cmd *exec.Cmd) error {
 	}
 	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }
+
+func cleanupProcessTree(cmd *exec.Cmd) {
+	_ = killProcessGroup(cmd)
+}

--- a/codeexecutor/sandbox/process_unix_test.go
+++ b/codeexecutor/sandbox/process_unix_test.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessWaitCleansDescendantsAfterRootExits(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	dir := t.TempDir()
+	gate := filepath.Join(dir, "release-descendant")
+	marker := filepath.Join(dir, "descendant-survived")
+	childCode := fmt.Sprintf(
+		"import pathlib,time; gate=pathlib.Path(%q); marker=pathlib.Path(%q); "+
+			"\nwhile not gate.exists(): time.sleep(0.01)"+
+			"\nmarker.write_text('alive')",
+		gate,
+		marker,
+	)
+	parentCode := fmt.Sprintf(
+		"import subprocess,sys\nsubprocess.Popen([sys.executable, '-c', %q], "+
+			"stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, "+
+			"stderr=subprocess.DEVNULL)\n",
+		childCode,
+	)
+	rt, ws := newProcessTestRuntime(t)
+	process, err := rt.StartProcess(context.Background(), ws, ProcessSpec{
+		Cmd:      python,
+		Args:     []string{"-c", parentCode},
+		CleanEnv: true,
+	})
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, process.Stdout())
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, process.Stderr())
+	require.NoError(t, err)
+	require.NoError(t, process.Wait())
+
+	require.NoError(t, os.WriteFile(gate, []byte("go"), 0o600))
+	require.Never(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	_, err = os.Stat(marker)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/codeexecutor/sandbox/process_windows.go
+++ b/codeexecutor/sandbox/process_windows.go
@@ -21,3 +21,5 @@ func killProcessGroup(cmd *exec.Cmd) error {
 	}
 	return cmd.Process.Kill()
 }
+
+func cleanupProcessTree(*exec.Cmd) {}

--- a/codeexecutor/sandbox/runner.go
+++ b/codeexecutor/sandbox/runner.go
@@ -33,9 +33,11 @@ func (r *Runtime) RunProgram(
 		return codeexecutor.RunResult{}, err
 	}
 	if r.sessionPolicy.RunConcurrency == SessionRunConcurrencySerial {
-		lock := r.runLock(ws)
-		lock.Lock()
-		defer lock.Unlock()
+		unlock, err := r.lockWorkspaceRunContext(ctx, ws)
+		if err != nil {
+			return codeexecutor.RunResult{}, err
+		}
+		defer unlock()
 	}
 	runCtx, cancel := context.WithTimeout(ctx, prep.timeout)
 	defer cancel()

--- a/codeexecutor/sandbox/runtime.go
+++ b/codeexecutor/sandbox/runtime.go
@@ -41,7 +41,7 @@ type Runtime struct {
 	defaultTimeout   time.Duration
 
 	mu       sync.Mutex
-	runLocks map[string]*sync.Mutex
+	runLocks map[string]*workspaceRunLock
 
 	preflightOnce  sync.Once
 	preflightErr   error
@@ -60,7 +60,7 @@ func NewRuntime(opts ...Option) *Runtime {
 		envPolicy:      normalizeShellEnvironmentPolicy(ShellEnvironmentPolicy{}),
 		outputMaxBytes: defaultOutputMaxBytes,
 		defaultTimeout: defaultRunTimeout,
-		runLocks:       map[string]*sync.Mutex{},
+		runLocks:       map[string]*workspaceRunLock{},
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -213,19 +213,89 @@ func workspacePathForID(root string, id string) (string, string) {
 	return filepath.Join(pathParts...), strings.Join(parts, "_")
 }
 
-func (r *Runtime) runLock(ws codeexecutor.Workspace) *sync.Mutex {
+type workspaceRunLock struct {
+	token chan struct{}
+	// refs is guarded by Runtime.mu and counts holders plus waiters.
+	refs int
+}
+
+func newWorkspaceRunLock() *workspaceRunLock {
+	lock := &workspaceRunLock{token: make(chan struct{}, 1)}
+	lock.token <- struct{}{}
+	return lock
+}
+
+func (l *workspaceRunLock) LockContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-l.token:
+	}
+	if err := ctx.Err(); err != nil {
+		l.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (l *workspaceRunLock) Unlock() {
+	select {
+	case l.token <- struct{}{}:
+	default:
+		panic("sandbox: unlock of unlocked workspace run lock")
+	}
+}
+
+func workspaceRunLockKey(ws codeexecutor.Workspace) string {
+	if ws.Path != "" {
+		return ws.Path
+	}
+	return ws.ID
+}
+
+func (r *Runtime) lockWorkspaceRunContext(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+) (func(), error) {
+	key, lock := r.retainWorkspaceRunLock(ws)
+	if err := lock.LockContext(ctx); err != nil {
+		r.releaseWorkspaceRunLock(key, lock)
+		return nil, err
+	}
+	return func() {
+		lock.Unlock()
+		r.releaseWorkspaceRunLock(key, lock)
+	}, nil
+}
+
+func (r *Runtime) retainWorkspaceRunLock(
+	ws codeexecutor.Workspace,
+) (string, *workspaceRunLock) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	key := ws.Path
-	if key == "" {
-		key = ws.ID
+	key := workspaceRunLockKey(ws)
+	lock := r.runLocks[key]
+	if lock == nil {
+		lock = newWorkspaceRunLock()
+		r.runLocks[key] = lock
 	}
-	if l := r.runLocks[key]; l != nil {
-		return l
+	lock.refs++
+	return key, lock
+}
+
+func (r *Runtime) releaseWorkspaceRunLock(
+	key string,
+	lock *workspaceRunLock,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if lock.refs <= 0 {
+		panic("sandbox: release of unretained workspace run lock")
 	}
-	l := &sync.Mutex{}
-	r.runLocks[key] = l
-	return l
+	lock.refs--
+	if lock.refs == 0 && r.runLocks[key] == lock {
+		delete(r.runLocks, key)
+	}
 }
 
 func (r *Runtime) applyManifestPolicy() {

--- a/codeexecutor/sandbox/runtime_test.go
+++ b/codeexecutor/sandbox/runtime_test.go
@@ -456,10 +456,24 @@ func TestRuntimeDefaultsDescribeAndHelpers(t *testing.T) {
 	if sameOrChild(filepath.Join(string(os.PathSeparator), "tmp", "a"), filepath.Join(string(os.PathSeparator), "tmp", "ab")) {
 		t.Fatalf("sibling path matched as child")
 	}
-	firstLock := rt.runLock(codeexecutor.Workspace{ID: "lock"})
-	secondLock := rt.runLock(codeexecutor.Workspace{ID: "lock"})
+	lockWorkspace := codeexecutor.Workspace{ID: "lock"}
+	firstKey, firstLock := rt.retainWorkspaceRunLock(lockWorkspace)
+	secondKey, secondLock := rt.retainWorkspaceRunLock(lockWorkspace)
 	if firstLock != secondLock {
 		t.Fatalf("runLock did not reuse lock")
+	}
+	if firstKey != secondKey || firstLock.refs != 2 {
+		t.Fatalf(
+			"retained run lock = (%q, %d refs), want (%q, 2 refs)",
+			secondKey,
+			firstLock.refs,
+			firstKey,
+		)
+	}
+	rt.releaseWorkspaceRunLock(secondKey, secondLock)
+	rt.releaseWorkspaceRunLock(firstKey, firstLock)
+	if len(rt.runLocks) != 0 {
+		t.Fatalf("released run lock remained registered: %#v", rt.runLocks)
 	}
 	missingRoot := filepath.Join(t.TempDir(), "missing-root")
 	if err := ensureNoSymlinkEscape(missingRoot, filepath.Join(missingRoot, "child")); err != nil {

--- a/codeexecutor/workspace.go
+++ b/codeexecutor/workspace.go
@@ -154,14 +154,13 @@ type Capabilities struct {
 	ReadOnlyMount  bool
 	Streaming      bool
 	MaxDiskBytes   int64
-	// SupportsCleanEnv reports whether this runtime actually
-	// honors RunProgramSpec.CleanEnv - i.e. it can start the
-	// spawned program with the spec.Env only, instead of the
-	// inherited process environment. Tool layers that depend on
-	// CleanEnv for security (e.g. tool/workspaceexec policy mode)
-	// must gate on this capability and fail closed when it is
-	// false, because the alternative is silently degrading the
-	// policy contract on backends that ignore CleanEnv.
+	// SupportsCleanEnv reports whether ProgramRunner.RunProgram honors
+	// RunProgramSpec.CleanEnv - i.e. it can start the spawned program with
+	// spec.Env only, instead of the inherited process environment. Tool layers
+	// that depend on CleanEnv for security (e.g. tool/workspaceexec policy
+	// mode) must gate on this capability and fail closed when it is false,
+	// because the alternative is silently degrading the policy contract on
+	// backends that ignore CleanEnv.
 	//
 	// Defaults to false so any backend that has not been audited
 	// for CleanEnv support is treated as "does not support" until

--- a/docs/mkdocs/en/codeact.md
+++ b/docs/mkdocs/en/codeact.md
@@ -9,7 +9,11 @@ LLM -> execute_tool_code -> Runtime -> guest call_tool(name, JSON args)
 
 The Go gateway is the trust boundary: it rejects unknown tools, validates input JSON against the tool declaration, calls the tool, then validates/serializes its result before returning it to guest code. Guest code never gets Go references or host credentials.
 
-`Runtime` is the transport boundary. The built-in `LocalRunner` implements it with a Python stdio guest. Remote or sandbox-native backends should implement `Runtime` directly and route sandbox-originated `ToolCall` values to the provided `ToolCallHandler`.
+`Runtime` is the transport boundary. `LocalRunner` executes a Python stdio
+guest directly. `SandboxRunner` uses the same callback protocol inside a fresh
+OS-sandboxed workspace. Remote services and microVM platforms should implement
+`Runtime` directly and route guest `ToolCall` values to the provided
+`ToolCallHandler`.
 
 ## Security
 
@@ -33,9 +37,42 @@ default, and rejects generated source larger than 64 KiB unless configured
 otherwise. These are intentional behavior changes rather than a security
 sandbox boundary.
 
-Applications should implement `codeact.Runtime` for their existing remote
-sandbox, microVM, or container service, with the isolation, resource, and
-dependency policies appropriate to their environment.
+For local OS isolation, construct a sandbox-backed runtime and pass it where a
+`LocalRunner` would otherwise be used:
+
+```go
+runtime := codeact.NewSandboxRunner()
+orchestrator, err := toolcode.NewTool(runtime, managedTools)
+```
+
+With the no-option constructor shown above, each execution gets a one-shot
+workspace and a clean environment. It uses the managed
+`codeexecutor/sandbox` backend, restricts networking by default, and never
+falls back to `LocalRunner` if sandbox setup fails. Linux requires `bubblewrap`;
+macOS uses `/usr/bin/sandbox-exec`; managed sandboxing is not implemented on
+Windows.
+
+`SandboxRunner.Timeout` sets a deadline for the complete execution and
+propagates cancellation to the guest and host tool calls. Go context
+cancellation is cooperative: tool handlers must return promptly when their
+context is done. The zero value adds no deadline and relies on the caller's
+context. A production caller must provide a context deadline or configure this
+timeout; if both are present, the earlier deadline wins. CPU, memory, and
+process-count quotas remain the responsibility of the surrounding container,
+microVM, or remote runtime.
+
+When `SandboxRunner.Python` is empty, the sandbox resolves `python3` from its
+clean PATH. Any non-empty value, including an explicit `"python3"`, is resolved
+through the host PATH and converted to an absolute path. An interpreter outside
+the backend's default runtime paths may also need a managed permission profile
+extended with `sandbox.WorkspaceWriteProfile().WithReadPaths(...)` and passed
+through `sandbox.WithPermissionProfile(...)`.
+
+The OS sandbox remains host-local and grants the platform/runtime paths needed
+to launch the interpreter; exact read visibility differs by backend. It is not
+a tenant boundary equivalent to a microVM. Use a container, microVM, or remote
+`Runtime` when the guest must have no host filesystem visibility or needs
+stronger resource and tenant isolation.
 
 ## Why not call raw HTTP APIs from generated code?
 

--- a/docs/mkdocs/en/dynamic-workflow.md
+++ b/docs/mkdocs/en/dynamic-workflow.md
@@ -174,6 +174,10 @@ the same `instance_id` explicitly means the calls share one child history; if
 those calls happen concurrently, they are serialized to avoid concurrent reads
 and writes to the same conversation branch.
 
+The shared history contains child inputs and emitted events. A dynamic
+`instruction` is configuration for that call only and is not persisted as a
+conversation message. Put facts that a later call must remember in `input`.
+
 These options affect only the current child Agent call. A workflow cannot use
 them to change the model, permission policy, or add host capabilities that the
 base Agent did not already have.
@@ -317,6 +321,12 @@ facts = await call_tool("search_catalog", query="trail backpack")
 `call_tool` can only call tools explicitly passed through
 `WithCodeCallableTools`. It does not automatically see the root Agent's tools.
 
+Selecting a tool through `agent(..., tools=[...])` authorizes the child Agent
+to use it; it does not guarantee that the model will call it. Structured output
+constrains the child's final response shape, not the provenance of its fields.
+When Python control flow must consume an exact host-tool result, use
+`call_tool` first and pass those facts to an Agent for interpretation.
+
 Do not put execution tools, `run_workflow` itself, `execute_tool_code`,
 `transfer_to_agent`, `await_user_reply`, workspace tools, or AgentTools into
 `WithCodeCallableTools`. They create recursive or mixed control-flow
@@ -362,9 +372,47 @@ default, rejects generated source larger than 64 KiB unless configured
 otherwise, and enforces the documented restricted Python subset. These are
 intentional behavior changes rather than a security sandbox boundary.
 
-In production, provide your own `dynamicworkflow.Runtime`, such as a container,
-microVM, or remote sandbox, and enforce filesystem, network, process,
-dependency, and resource limits there.
+For local OS isolation, use the built-in sandbox runner:
+
+```go
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.NewSandboxRunner(),
+    childAgents,
+)
+```
+
+With the no-option constructor shown above, every workflow gets a one-shot
+workspace and clean process environment. The runner uses
+`codeexecutor/sandbox`, restricts networking by default, and fails closed
+instead of falling back to local execution. Linux requires `bubblewrap`; macOS
+uses `/usr/bin/sandbox-exec`; Windows has no managed backend.
+
+`SandboxRunner.Timeout` sets a deadline for the complete workflow and
+propagates cancellation to the guest and host Tool or child-Agent callbacks. Go
+context cancellation is cooperative: call handlers must return promptly when
+their context is done. The zero value adds no deadline and relies on the
+caller's context. A production caller must provide a context deadline or
+configure this timeout; if both are present, the earlier deadline wins. CPU,
+memory, and process-count quotas remain the responsibility of the surrounding
+container, microVM, or remote runtime.
+
+When `SandboxRunner.Python` is empty, the sandbox resolves `python3` from its
+clean PATH. Any non-empty value, including an explicit `"python3"`, is resolved
+through the host PATH and converted to an absolute path. An interpreter outside
+the backend's default runtime paths may also need a managed permission profile
+extended with `sandbox.WorkspaceWriteProfile().WithReadPaths(...)` and passed
+through `sandbox.WithPermissionProfile(...)`.
+
+The OS sandbox remains host-local and grants the platform/runtime paths needed
+to launch Python; exact read visibility differs by backend. It is not a tenant
+boundary equivalent to a microVM. Use a container, microVM, or remote `Runtime`
+when the guest must have no host filesystem visibility or needs stronger
+resource and tenant isolation.
+
+See the runnable
+[Sandbox Dynamic Workflow example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/dynamicworkflow/sandbox)
+for an Agent whose generated workflow runs in the managed sandbox while child
+Agent tools and events remain in Go.
 
 Generated workflow code should call host tools rather than direct HTTP APIs.
 Authentication, authorization, retries, idempotency, audit, rate limiting, and

--- a/docs/mkdocs/zh/codeact.md
+++ b/docs/mkdocs/zh/codeact.md
@@ -7,7 +7,11 @@ LLM -> execute_tool_code -> Runtime -> guest call_tool(name, JSON args)
                                   -> Go Gateway -> trpc Tool
 ```
 
-`Gateway` 是能力边界，负责 allowlist、schema 校验和真实 Go tool 调用。`Runtime` 是传输/执行边界：内置 `LocalRunner` 用 Python stdio guest 实现；远端 sandbox、microVM、容器服务或平台原生 callback 后端应直接实现 `codeact.Runtime`，并把 sandbox 产生的 `ToolCall` 路由给传入的 `ToolCallHandler`。
+`Gateway` 是能力边界，负责 allowlist、schema 校验和真实 Go tool 调用。`Runtime`
+是传输/执行边界：`LocalRunner` 直接运行 Python stdio guest；`SandboxRunner` 在每次
+调用新建的 OS sandbox workspace 中运行同一套 callback 协议。远端服务或 microVM
+平台应直接实现 `codeact.Runtime`，并把 guest 产生的 `ToolCall` 路由给传入的
+`ToolCallHandler`。
 
 ## 安全边界
 
@@ -25,7 +29,35 @@ Workflow 不同，不应用 AST 或 builtin allowlist。二者共享的是进程
 目录，并会拒绝超过 64 KiB 的生成源码，除非调用方显式调整限制。这些是有意的行为
 变化，但不会构成安全 sandbox 边界。
 
-生产应用应基于已有远端 sandbox、microVM 或容器服务实现 `codeact.Runtime`，并由应用侧配置隔离、资源和依赖策略。
+需要本地 OS 隔离时，可以在原来传入 `LocalRunner` 的位置改用：
+
+```go
+runtime := codeact.NewSandboxRunner()
+orchestrator, err := toolcode.NewTool(runtime, managedTools)
+```
+
+使用上面不带 option 的构造方式时，每次执行都会使用一次性 workspace 和 clean
+environment。它使用 `codeexecutor/sandbox` 的 managed backend，默认限制网络；
+如果 sandbox 初始化失败，会直接报错，不会 fallback 到 `LocalRunner`。Linux 需要
+`bubblewrap`，macOS 使用 `/usr/bin/sandbox-exec`，Windows 尚未实现 managed
+sandbox。
+
+`SandboxRunner.Timeout` 会为完整执行设置 deadline，并把取消信号传导给 guest 和宿主
+Tool 调用。Go context 采用协作式取消，Tool handler 必须在 context 结束后及时返回。
+零值不会额外添加 deadline，而是依赖调用方 context；生产环境必须为调用方 context
+设置 deadline，或者显式配置该 timeout。两者同时存在时，以更早到期者为准。CPU、
+内存和进程数配额仍应由外层容器、microVM 或远端 runtime 提供。
+
+`SandboxRunner.Python` 为空时，sandbox 会从自己的 clean PATH 解析 `python3`。任何
+非空值（包括显式的 `"python3"`）都会先通过宿主 PATH 解析并转换成绝对路径。如果
+解释器不在 backend 默认开放的 runtime 路径中，还需要通过
+`sandbox.WorkspaceWriteProfile().WithReadPaths(...)` 扩展 managed permission
+profile，并将其传给 `sandbox.WithPermissionProfile(...)`。
+
+OS sandbox 仍然运行在宿主机上，并会开放启动解释器所需的平台与 runtime 路径；具体
+只读可见范围因 backend 而异。它不等价于 microVM 级租户边界。如果 guest 不能看到
+任何宿主文件，或者需要更强的 CPU、内存和租户隔离，应使用容器、microVM 或远端
+`Runtime`。
 
 ## 为什么不让生成代码直接调用 HTTP API？
 

--- a/docs/mkdocs/zh/dynamic-workflow.md
+++ b/docs/mkdocs/zh/dynamic-workflow.md
@@ -157,6 +157,9 @@ review = await agent(
 历史，适合并发分支。显式传相同 `instance_id` 表示复用同一条子历史；
 并发调用同一个 `instance_id` 会被串行执行，避免同时读写同一段会话历史。
 
+复用的历史包含子 Agent 的输入和产生的事件。动态 `instruction` 只配置当前这次
+调用，不会作为对话消息持久化；后续调用必须记住的事实应放在 `input` 中。
+
 这些选项只影响当前这次子 Agent 调用。workflow 不能借它改变模型、权限策略，
 也不能新增基础 Agent 本来没有的宿主能力。
 
@@ -289,6 +292,11 @@ facts = await call_tool("search_catalog", query="trail backpack")
 
 `call_tool` 只能调用 `WithCodeCallableTools` 显式传入的工具。它不会自动看到根 Agent 的工具。
 
+`agent(..., tools=[...])` 只是授权子 Agent 使用这些工具，并不保证模型一定调用；
+结构化输出约束的是子 Agent 最终回答的形状，而不是字段的数据来源。如果 Python
+控制流必须使用宿主工具的精确结果，应先通过 `call_tool` 取得原始数据，再交给
+Agent 解读。
+
 不要把执行类工具、`run_workflow` 自身、`execute_tool_code`、`transfer_to_agent`、
 `await_user_reply`、workspace 工具或 AgentTool 放进 `WithCodeCallableTools`。这些工具容易形成
 递归或混合控制流边界；workflow 调用子 Agent 应使用 `agent(...)`。
@@ -324,8 +332,42 @@ Go 框架掌控。
 目录，会拒绝超过 64 KiB 的生成源码（除非显式调整限制），并执行文档声明的受限
 Python 子集。这些是有意的行为变化，但不会构成安全 sandbox 边界。
 
-生产环境应提供自己的 `dynamicworkflow.Runtime`，例如容器、microVM 或远端 sandbox，
-并在里面落实文件系统、网络、进程、依赖和资源限制。
+需要本地 OS 隔离时，可以直接使用内置 sandbox runner：
+
+```go
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.NewSandboxRunner(),
+    childAgents,
+)
+```
+
+使用上面不带 option 的构造方式时，每次 workflow 都会使用一次性 workspace 和
+clean process environment。该 runner 复用 `codeexecutor/sandbox`，默认限制网络；
+sandbox 初始化失败时会直接报错，不会 fallback 到本地执行。Linux 需要
+`bubblewrap`，macOS 使用 `/usr/bin/sandbox-exec`，Windows 尚未实现 managed
+backend。
+
+`SandboxRunner.Timeout` 会为完整 workflow 设置 deadline，并把取消信号传导给 guest、
+宿主 Tool 和子 Agent callback。Go context 采用协作式取消，call handler 必须在
+context 结束后及时返回。零值不会额外添加 deadline，而是依赖调用方 context；生产
+环境必须为调用方 context 设置 deadline，或者显式配置该 timeout。两者同时存在时，
+以更早到期者为准。CPU、内存和进程数配额仍应由外层容器、microVM 或远端 runtime
+提供。
+
+`SandboxRunner.Python` 为空时，sandbox 会从自己的 clean PATH 解析 `python3`。任何
+非空值（包括显式的 `"python3"`）都会先通过宿主 PATH 解析并转换成绝对路径。如果
+解释器不在 backend 默认开放的 runtime 路径中，还需要通过
+`sandbox.WorkspaceWriteProfile().WithReadPaths(...)` 扩展 managed permission
+profile，并将其传给 `sandbox.WithPermissionProfile(...)`。
+
+OS sandbox 仍然运行在宿主机上，并会开放启动 Python 所需的平台与 runtime 路径；
+具体只读可见范围因 backend 而异。它不等价于 microVM 级租户边界。如果 guest 不能
+看到任何宿主文件，或者需要更强的资源与租户隔离，应使用容器、microVM 或远端
+`Runtime`。
+
+可运行代码见
+[Sandbox Dynamic Workflow 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/dynamicworkflow/sandbox)：
+生成的 workflow 在 managed sandbox 中运行，子 Agent 工具与事件仍留在 Go 框架内。
 
 生成的 workflow 代码应该调用宿主工具，而不是直接调用 HTTP API。认证、授权、
 重试、幂等、审计、限流和 API 版本适配仍应由业务工具在 Go 侧掌控。

--- a/examples/dynamicworkflow/sandbox/README.md
+++ b/examples/dynamicworkflow/sandbox/README.md
@@ -1,0 +1,196 @@
+# Sandbox Dynamic Workflow Example
+
+This example runs model-generated Dynamic Workflow Python in the built-in OS
+sandbox:
+
+```text
+sandbox_workflow_assistant
+└── run_workflow
+    ├── Python workflow: one-shot sandbox workspace
+    └── Go callback bridge
+        └── operations_agent
+            └── tool: get_service_health
+```
+
+Only the temporary Python glue code runs inside the sandbox. Child Agents,
+their tools, Session persistence, and event streaming remain in the Go
+framework. A child Agent can therefore call `get_service_health`, and the
+frontend still receives its output and tool-call events through the root
+Runner's event stream.
+
+This example focuses on the execution boundary. The `basic` and `research`
+examples cover broader Dynamic Workflow patterns.
+
+## What it demonstrates
+
+- `dynamicworkflow.NewSandboxRunner()` as the `run_workflow` Runtime.
+- A one-shot workspace and clean process environment for every workflow.
+- Network-restricted managed sandbox execution.
+- A configured workflow timeout that also propagates cancellation to Go
+  callbacks.
+- Shared Session persistence with workflow-local model context isolated from
+  ancestor tool transcripts through
+  `llmagent.WithMessageFilterMode(llmagent.IsolatedRequest)`.
+- A deterministic demo health tool whose invocation remains in Go rather than
+  moving into Python.
+- Generated workflow source and nested tool events in the terminal.
+- Fail-closed behavior: sandbox setup errors never fall back to `LocalRunner`.
+
+## Prerequisites
+
+- Go 1.24.4 or later.
+- Python 3 available to the managed sandbox.
+- An OpenAI-compatible model endpoint.
+- A supported managed sandbox backend:
+  - Linux: install `bubblewrap` (`bwrap`).
+  - macOS: `/usr/bin/sandbox-exec` must be available.
+  - Windows: the managed backend is not implemented.
+
+```bash
+export OPENAI_API_KEY="<your-api-key>"
+# Optional for an OpenAI-compatible endpoint:
+export OPENAI_BASE_URL="https://your-endpoint/v1"
+```
+
+## Run
+
+From the repository's `examples` directory:
+
+```bash
+go run ./dynamicworkflow/sandbox -model gpt-5
+```
+
+With no `-prompt`, the example starts an interactive session:
+
+- `/new` starts a new conversation session.
+- `/exit` exits.
+
+For a single turn:
+
+```bash
+go run ./dynamicworkflow/sandbox \
+  -model gpt-5 \
+  -show-workflow-code \
+  -prompt 'Build a temporary team to assess rolling out an in-memory cache for the catalog service. Have a planner propose the rollout, a verifier call get_service_health, and a reviewer allow at most two revisions before making a final decision.'
+```
+
+Useful flags:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `-model` | `gpt-5` | Model on the configured OpenAI-compatible endpoint. |
+| `-prompt` | empty | Single-turn request; empty starts interactive mode. |
+| `-show-workflow-code` | `false` | Print generated Python before execution. |
+| `-workflow-timeout` | `10m` | Full workflow deadline; `0` relies on caller context. |
+| `-python` | empty | Explicit interpreter; empty uses sandbox-resolved `python3`; custom paths may need read grants. |
+
+## Expected workflow
+
+For the rollout prompt above, the model should generate a workflow with this
+general shape:
+
+```python
+plan = await agent(
+    {"change": "Add an in-memory cache", "service": "catalog"},
+    instruction="Act as a rollout planner and propose a staged plan.",
+    tools=[],
+)
+
+health = await agent(
+    {"service": "catalog", "plan": plan["text"]},
+    instruction=(
+        "Act as an operational verifier. Call get_service_health for catalog "
+        "and assess whether the current state permits this rollout."
+    ),
+    tools=["get_service_health"],
+)
+
+for revision in range(3):
+    review = await agent(
+        {"plan": plan["text"], "health": health["text"]},
+        instruction=(
+            "Act as a strict reviewer. Approve the plan or return concrete "
+            "changes required before rollout."
+        ),
+        tools=[],
+        structured_output={
+            "type": "object",
+            "properties": {
+                "approved": {"type": "boolean"},
+                "feedback": {"type": "string"},
+            },
+            "required": ["approved", "feedback"],
+            "additionalProperties": False,
+        },
+    )
+    if review["structured"]["approved"] or revision == 2:
+        break
+    plan = await agent(
+        {
+            "plan": plan["text"],
+            "feedback": review["structured"]["feedback"],
+        },
+        instruction="Revise the rollout plan against every item of review feedback.",
+        tools=[],
+    )
+
+return {
+    "plan": plan["text"],
+    "health": health["text"],
+    "review": review["structured"],
+}
+```
+
+The precise code and prose are model-generated. The stable boundary is:
+
+- Python may use the Dynamic Workflow DSL.
+- `agent(...)` requests cross the stdio bridge back into Go.
+- When selected by the verifier, `get_service_health` is called by the Go child
+  Agent.
+- Child Agent output and tool events remain visible on the original event
+  stream.
+
+The verifier Agent decides when to call `get_service_health`, so its nested tool
+events are visible. Tool selection is authorization, not a guarantee that a
+model will invoke the tool. If Python must branch on the exact health payload,
+also register the business tool with
+`dynamicworkflow.WithCodeCallableTools` and obtain the raw value through
+`call_tool` before asking an Agent to interpret it.
+
+When `-show-workflow-code` is enabled, the terminal prints the generated source
+before the sandbox starts. A successful run should also include nested events
+similar to:
+
+```text
+[operations_agent via dynamic_workflow] tool call: get_service_health ...
+[operations_agent via dynamic_workflow] tool result: get_service_health ...
+```
+
+## Python selection
+
+Leaving `-python` empty lets the sandbox resolve `python3` from its clean PATH.
+Any non-empty value, including `-python python3`, is first resolved through the
+host PATH and converted to an absolute path.
+
+An explicitly selected interpreter outside the backend's default readable
+runtime paths needs a corresponding sandbox read grant in application code.
+The example uses the default managed permission profile and does not broaden
+host filesystem visibility.
+
+## Security boundary
+
+`SandboxRunner` provides stronger local isolation than `LocalRunner`, but it is
+not a microVM tenant boundary:
+
+- The managed profile restricts networking by default.
+- The guest receives a clean environment and a one-shot workspace.
+- Sandbox setup fails closed.
+- `-workflow-timeout` sets a deadline for the guest and Go callbacks.
+- Go context cancellation is cooperative; Tool and Agent handlers must return
+  promptly when their context is done.
+- CPU, memory, and process-count quotas remain the responsibility of an outer
+  container, microVM, or remote Runtime.
+
+Only give child Agents the tools required for their role. The OS sandbox
+controls the Python process; Go-side Tool authorization remains an application
+capability boundary.

--- a/examples/dynamicworkflow/sandbox/main.go
+++ b/examples/dynamicworkflow/sandbox/main.go
@@ -1,0 +1,462 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates Dynamic Workflow with its generated Python glue
+// running in the managed OS sandbox while child Agents and tools remain in Go.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/dynamicworkflow"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+var (
+	modelName = flag.String(
+		"model",
+		"gpt-5",
+		"Model name for the OpenAI-compatible endpoint",
+	)
+	prompt = flag.String(
+		"prompt",
+		"",
+		"Optional single-turn prompt. If empty, start interactive chat.",
+	)
+	showWorkflowCode = flag.Bool(
+		"show-workflow-code",
+		false,
+		"Print the generated Python workflow code before executing it",
+	)
+	workflowTimeout = flag.Duration(
+		"workflow-timeout",
+		10*time.Minute,
+		"Maximum workflow duration; zero relies only on the caller context",
+	)
+	python = flag.String(
+		"python",
+		"",
+		"Explicit Python interpreter; empty resolves python3 inside the sandbox; custom paths may need sandbox read grants",
+	)
+)
+
+func main() {
+	flag.Parse()
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Fprintln(
+			os.Stderr,
+			"OPENAI_API_KEY is required (OPENAI_BASE_URL is optional).",
+		)
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	modelInstance := openai.New(*modelName)
+	workflowTool, err := buildWorkflowTool(
+		modelInstance,
+		*workflowTimeout,
+		*python,
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build workflow tool: %v\n", err)
+		os.Exit(1)
+	}
+	if *showWorkflowCode {
+		workflowTool = workflowCodePrintingTool{inner: workflowTool}
+	}
+
+	root := llmagent.New(
+		"sandbox_workflow_assistant",
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription(
+			"Builds temporary, sandboxed workflows for operational planning and review.",
+		),
+		llmagent.WithInstruction(`Answer simple requests directly. For a task that benefits from temporary roles, independent analysis, tool-backed verification, or review-and-revision, call run_workflow exactly once and do not return Python source. Call agent() for every requested business role; never simulate a role or hard-code its output in Python.
+
+Important: run_workflow automatically wraps its code in an async function. Supply only that function body. A valid body starts directly with statements such as "result = await agent(...)" and ends with a top-level "return result". Code beginning with "async def run():" is invalid. Never define a wrapper, call asyncio.run(), or import anything.
+
+This example has one operations_agent template, so template is usually omitted. Use tools=[] for planning, analysis, review, and revision roles. Use tools=["get_service_health"] only for a verifier explicitly instructed to inspect current service health before deciding, and preserve the exact catalog, checkout, or search service name from the request. Allow at most two revision attempts, followed by a final review if needed, and return a concise final result.`),
+		llmagent.WithTools([]tool.Tool{workflowTool}),
+	)
+	r := runner.NewRunner("sandbox-dynamic-workflow-example", root)
+	defer r.Close()
+
+	chat := &sandboxWorkflowChat{
+		runner:    r,
+		userID:    "demo-user",
+		sessionID: newSessionID(),
+		modelName: *modelName,
+	}
+	if strings.TrimSpace(*prompt) != "" {
+		if err := chat.processMessage(ctx, *prompt); err != nil {
+			fmt.Fprintf(os.Stderr, "run agent: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	chat.printBanner()
+	if err := chat.start(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "interactive chat failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func buildWorkflowTool(
+	m model.Model,
+	timeout time.Duration,
+	pythonPath string,
+) (tool.CallableTool, error) {
+	healthTool := function.NewFunctionTool(
+		getServiceHealth,
+		function.WithName("get_service_health"),
+		function.WithDescription(
+			"Return a deterministic demo health snapshot for catalog, checkout, "+
+				"or search. Use it only when a workflow role must verify "+
+				"operational readiness.",
+		),
+	)
+	operationsAgent := llmagent.New(
+		"operations_agent",
+		llmagent.WithModel(m),
+		// Persist child events in the shared Session while keeping ancestor
+		// tool transcripts out of each workflow-local model request.
+		llmagent.WithMessageFilterMode(llmagent.IsolatedRequest),
+		llmagent.WithDescription(
+			"A neutral template for a workflow-local planner, verifier, reviewer, or reviser.",
+		),
+		llmagent.WithInstruction(`Follow the dynamic instance instruction as the complete definition of your current role. Treat input as JSON context. When explicitly asked for a current health check, call get_service_health exactly once with the requested catalog, checkout, or search service name before answering, and reproduce its status, error_rate, p95_latency_ms, and observations exactly. Otherwise do not call tools. Never call a tool not offered to your current role. Distinguish observed health data from recommendations. When a structured output contract is requested, return data conforming to it.`),
+		llmagent.WithTools([]tool.Tool{healthTool}),
+	)
+
+	sandboxRunner := dynamicworkflow.NewSandboxRunner()
+	sandboxRunner.Timeout = timeout
+	sandboxRunner.Python = strings.TrimSpace(pythonPath)
+	return dynamicworkflow.NewTool(
+		sandboxRunner,
+		[]agent.Agent{operationsAgent},
+	)
+}
+
+type serviceHealthRequest struct {
+	Service string `json:"service" jsonschema:"description=Service name: catalog, checkout, or search."`
+}
+
+type serviceHealthResult struct {
+	Service      string   `json:"service"`
+	Status       string   `json:"status"`
+	ErrorRate    float64  `json:"error_rate"`
+	P95LatencyMS int      `json:"p95_latency_ms"`
+	Observations []string `json:"observations"`
+}
+
+func getServiceHealth(
+	_ context.Context,
+	req serviceHealthRequest,
+) (serviceHealthResult, error) {
+	switch strings.ToLower(strings.TrimSpace(req.Service)) {
+	case "catalog":
+		return serviceHealthResult{
+			Service:      "catalog",
+			Status:       "healthy",
+			ErrorRate:    0.002,
+			P95LatencyMS: 84,
+			Observations: []string{
+				"Read traffic is stable.",
+				"Database utilization is below the alert threshold.",
+				"No active incidents are associated with the service.",
+			},
+		}, nil
+	case "checkout":
+		return serviceHealthResult{
+			Service:      "checkout",
+			Status:       "degraded",
+			ErrorRate:    0.018,
+			P95LatencyMS: 420,
+			Observations: []string{
+				"Latency increased during the latest traffic peak.",
+				"One downstream payment dependency is recovering.",
+			},
+		}, nil
+	case "search":
+		return serviceHealthResult{
+			Service:      "search",
+			Status:       "healthy",
+			ErrorRate:    0.004,
+			P95LatencyMS: 132,
+			Observations: []string{
+				"Index freshness is within the target window.",
+				"Capacity has headroom for the expected rollout traffic.",
+			},
+		}, nil
+	default:
+		return serviceHealthResult{}, fmt.Errorf(
+			"unknown service %q; expected catalog, checkout, or search",
+			req.Service,
+		)
+	}
+}
+
+type sandboxWorkflowChat struct {
+	runner    runner.Runner
+	userID    string
+	sessionID string
+	modelName string
+}
+
+func newSessionID() string {
+	return fmt.Sprintf("sandbox-dynamic-workflow-%d", time.Now().UnixNano())
+}
+
+func (c *sandboxWorkflowChat) printBanner() {
+	fmt.Println("Sandbox Dynamic Workflow Example")
+	fmt.Printf("Model: %s\n", c.modelName)
+	fmt.Printf("Session: %s\n", c.sessionID)
+	fmt.Printf("Workflow timeout: %s\n", *workflowTimeout)
+	if strings.TrimSpace(*python) == "" {
+		fmt.Println("Python: sandbox-resolved python3")
+	} else {
+		fmt.Printf("Python: %s\n", *python)
+	}
+	fmt.Println("Type '/new' to start a new session or '/exit' to quit.")
+	fmt.Println("Sample prompts:")
+	fmt.Println("  Build a temporary team to assess rolling out an in-memory cache for the catalog service. Have a planner propose the rollout, a verifier call get_service_health, and a reviewer allow at most two revisions before making a final decision.")
+	fmt.Println("  Compare two rollout plans in parallel for the search service, verify current health, and recommend the safer plan.")
+	fmt.Println(strings.Repeat("=", 72))
+}
+
+func (c *sandboxWorkflowChat) start(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		input := strings.TrimSpace(scanner.Text())
+		if input == "" {
+			continue
+		}
+		switch strings.ToLower(input) {
+		case "/exit":
+			fmt.Println("Goodbye.")
+			return nil
+		case "/new":
+			c.sessionID = newSessionID()
+			fmt.Printf("Started new session: %s\n\n", c.sessionID)
+			continue
+		}
+		if err := c.processMessage(ctx, input); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *sandboxWorkflowChat) processMessage(
+	ctx context.Context,
+	userMessage string,
+) error {
+	events, err := c.runner.Run(
+		ctx,
+		c.userID,
+		c.sessionID,
+		model.NewUserMessage(userMessage),
+	)
+	if err != nil {
+		return fmt.Errorf("run agent: %w", err)
+	}
+	printEvents(events)
+	return nil
+}
+
+type workflowCodePrintingTool struct {
+	inner tool.CallableTool
+}
+
+func (t workflowCodePrintingTool) Declaration() *tool.Declaration {
+	return t.inner.Declaration()
+}
+
+func (t workflowCodePrintingTool) Call(
+	ctx context.Context,
+	raw []byte,
+) (any, error) {
+	t.printWorkflowCode(raw)
+	return t.inner.Call(ctx, raw)
+}
+
+func (t workflowCodePrintingTool) StreamableCall(
+	ctx context.Context,
+	raw []byte,
+) (*tool.StreamReader, error) {
+	t.printWorkflowCode(raw)
+	streamable, ok := t.inner.(tool.StreamableTool)
+	if !ok {
+		return nil, fmt.Errorf(
+			"workflow code printer: inner tool is not streamable",
+		)
+	}
+	return streamable.StreamableCall(ctx, raw)
+}
+
+func (t workflowCodePrintingTool) TRPCAgentGoStructuredStreamErrorsOptIn() bool {
+	structured, ok := t.inner.(interface {
+		TRPCAgentGoStructuredStreamErrorsOptIn() bool
+	})
+	return ok && structured.TRPCAgentGoStructuredStreamErrorsOptIn()
+}
+
+func (t workflowCodePrintingTool) printWorkflowCode(raw []byte) {
+	var input struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &input); err == nil &&
+		strings.TrimSpace(input.Code) != "" {
+		fmt.Fprintln(
+			os.Stderr,
+			"\n===== generated sandbox workflow code =====",
+		)
+		fmt.Fprintln(os.Stderr, input.Code)
+		fmt.Fprintln(
+			os.Stderr,
+			"===== end generated sandbox workflow code =====",
+		)
+		fmt.Fprintln(os.Stderr)
+	}
+}
+
+func printEvents(events <-chan *event.Event) {
+	eventCount := 0
+	for evt := range events {
+		if evt == nil {
+			continue
+		}
+		eventCount++
+		if evt.Response != nil && evt.Response.Error != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"[%s] error: %s\n",
+				eventLabel(evt),
+				evt.Response.Error.Message,
+			)
+			continue
+		}
+		if printToolEvent(evt) {
+			continue
+		}
+		if evt.StructuredOutput != nil {
+			if raw, err := json.Marshal(evt.StructuredOutput); err == nil {
+				fmt.Printf("[%s] structured: %s\n", eventLabel(evt), raw)
+			}
+		}
+		if evt.Response == nil || len(evt.Response.Choices) == 0 {
+			continue
+		}
+		choice := evt.Response.Choices[0]
+		content := choice.Delta.Content
+		if content == "" {
+			content = choice.Message.Content
+		}
+		if strings.TrimSpace(content) != "" {
+			fmt.Printf("[%s] %s\n", eventLabel(evt), content)
+		}
+	}
+	if eventCount == 0 {
+		fmt.Fprintln(os.Stderr, "no events were emitted")
+	}
+}
+
+func printToolEvent(evt *event.Event) bool {
+	if evt == nil || evt.Response == nil {
+		return false
+	}
+	if evt.Response.IsToolCallResponse() {
+		for _, choice := range evt.Response.Choices {
+			for _, call := range append(
+				choice.Message.ToolCalls,
+				choice.Delta.ToolCalls...,
+			) {
+				fmt.Printf(
+					"[%s] tool call: %s",
+					eventLabel(evt),
+					call.Function.Name,
+				)
+				if call.ID != "" {
+					fmt.Printf(" (id: %s)", call.ID)
+				}
+				if len(call.Function.Arguments) > 0 {
+					fmt.Printf(" args: %s", string(call.Function.Arguments))
+				}
+				fmt.Println()
+			}
+		}
+		return true
+	}
+	if evt.Response.IsToolResultResponse() {
+		for _, choice := range evt.Response.Choices {
+			msg := choice.Message
+			if msg.ToolID == "" && choice.Delta.ToolID != "" {
+				msg = choice.Delta
+			}
+			if msg.ToolID == "" {
+				continue
+			}
+			name := msg.ToolName
+			if name == "" {
+				name = "tool"
+			}
+			content := strings.TrimSpace(msg.Content)
+			runes := []rune(content)
+			if len(runes) > 240 {
+				content = string(runes[:240]) + "..."
+			}
+			fmt.Printf(
+				"[%s] tool result: %s (id: %s) %s\n",
+				eventLabel(evt),
+				name,
+				msg.ToolID,
+				content,
+			)
+		}
+		return true
+	}
+	return false
+}
+
+func eventLabel(evt *event.Event) string {
+	if evt == nil {
+		return "unknown"
+	}
+	label := evt.Author
+	if label == "" {
+		label = "unknown"
+	}
+	if evt.ParentMetadata != nil && evt.ParentMetadata.TriggerType != "" {
+		label += " via " + evt.ParentMetadata.TriggerType
+	}
+	return label
+}

--- a/internal/coderuntime/sandboxpython/sandboxpython.go
+++ b/internal/coderuntime/sandboxpython/sandboxpython.go
@@ -1,0 +1,219 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+// Package sandboxpython starts one-shot Python guests through the OS sandbox
+// runtime. Feature-specific protocols remain in their owning packages.
+package sandboxpython
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox"
+)
+
+const defaultMaxCodeBytes = 64 << 10
+
+// Config controls one sandboxed Python guest.
+type Config struct {
+	// Python selects the guest interpreter. When empty, the sandbox resolves
+	// python3 from its clean PATH.
+	Python string
+	// Timeout optionally bounds the guest lifetime. The zero value relies on
+	// the caller's context without adding a runtime deadline.
+	Timeout time.Duration
+	// MaxCodeBytes bounds generated code before the process starts. The zero
+	// value uses the 64 KiB default; a negative value disables the limit.
+	MaxCodeBytes int
+}
+
+// Runner owns a sandbox runtime configured for one-shot guest workspaces.
+type Runner struct {
+	runtime *sandbox.Runtime
+}
+
+// New constructs a sandboxed Python runner. Guest workspaces are always
+// per-turn and are removed after the process is reaped.
+func New(opts ...sandbox.Option) *Runner {
+	forced := sandbox.WithSessionPolicy(sandbox.SessionPolicy{
+		Persistence:    sandbox.SessionPersistencePerTurn,
+		RunConcurrency: sandbox.SessionRunConcurrencyParallel,
+	})
+	runtimeOpts := append([]sandbox.Option(nil), opts...)
+	runtimeOpts = append(runtimeOpts, forced)
+	return &Runner{runtime: sandbox.NewRuntime(runtimeOpts...)}
+}
+
+// Process is a sandbox process plus its one-shot workspace lifecycle.
+type Process struct {
+	process *sandbox.Process
+	runtime *sandbox.Runtime
+	ws      codeexecutor.Workspace
+
+	cleanupOnce sync.Once
+	cleanupErr  error
+}
+
+// StartScript writes a private bootstrap script and starts it in an empty work
+// directory. interpreterArgs precede the script path; scriptArgs follow it.
+func (r *Runner) StartScript(
+	ctx context.Context,
+	cfg Config,
+	code string,
+	scriptName string,
+	script []byte,
+	interpreterArgs []string,
+	scriptArgs []string,
+) (*Process, error) {
+	if r == nil || r.runtime == nil {
+		return nil, errors.New("sandboxpython: runner is required")
+	}
+	if err := validateCodeSize(code, cfg.MaxCodeBytes); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(scriptName) == "" {
+		return nil, errors.New("sandboxpython: script name is required")
+	}
+	pythonPath, err := resolvePythonPath(cfg.Python)
+	if err != nil {
+		return nil, err
+	}
+	ws, err := r.runtime.CreateWorkspace(
+		ctx,
+		"generated-code/"+uuid.NewString(),
+		codeexecutor.WorkspacePolicy{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sandboxpython: create workspace: %w", err)
+	}
+	cleanup := func() {
+		_ = r.runtime.Cleanup(context.WithoutCancel(ctx), ws)
+	}
+	scriptRel := filepath.Join(
+		codeexecutor.DirRuns,
+		filepath.Base(scriptName),
+	)
+	if err := r.runtime.PutFiles(ctx, ws, []codeexecutor.PutFile{{
+		Path:    scriptRel,
+		Content: script,
+		Mode:    0o600,
+	}}); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("sandboxpython: write guest script: %w", err)
+	}
+	args := make([]string, 0, len(interpreterArgs)+1+len(scriptArgs))
+	args = append(args, interpreterArgs...)
+	args = append(args, filepath.Join(ws.Path, scriptRel))
+	args = append(args, scriptArgs...)
+	process, err := r.runtime.StartProcess(ctx, ws, sandbox.ProcessSpec{
+		Cmd:  pythonPath,
+		Args: args,
+		Env: map[string]string{
+			"PYTHONIOENCODING": "utf-8",
+			"PYTHONNOUSERSITE": "1",
+		},
+		CleanEnv: true,
+		Cwd:      codeexecutor.DirWork,
+		Timeout:  cfg.Timeout,
+	})
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("sandboxpython: start guest: %w", err)
+	}
+	return &Process{process: process, runtime: r.runtime, ws: ws}, nil
+}
+
+func resolvePythonPath(python string) (string, error) {
+	python = strings.TrimSpace(python)
+	if python == "" {
+		// Let the sandbox resolve its default interpreter from the clean,
+		// sandbox-controlled PATH. Resolving the host's preferred Python here
+		// could select a path outside the managed profile's read grants.
+		return "python3", nil
+	}
+	pythonPath, err := exec.LookPath(python)
+	if err != nil {
+		return "", fmt.Errorf("sandboxpython: resolve Python: %w", err)
+	}
+	if filepath.IsAbs(pythonPath) {
+		return pythonPath, nil
+	}
+	pythonPath, err = filepath.Abs(pythonPath)
+	if err != nil {
+		return "", fmt.Errorf("sandboxpython: resolve absolute Python path: %w", err)
+	}
+	return pythonPath, nil
+}
+
+func validateCodeSize(code string, maxBytes int) error {
+	if maxBytes < 0 {
+		return nil
+	}
+	limit := maxBytes
+	if limit == 0 {
+		limit = defaultMaxCodeBytes
+	}
+	if len(code) > limit {
+		return fmt.Errorf("sandboxpython: code exceeds %d bytes", limit)
+	}
+	return nil
+}
+
+// Stdin returns the guest standard-input pipe.
+func (p *Process) Stdin() io.WriteCloser {
+	if p == nil || p.process == nil {
+		return nil
+	}
+	return p.process.Stdin()
+}
+
+// Stdout returns the guest standard-output pipe.
+func (p *Process) Stdout() io.ReadCloser {
+	if p == nil || p.process == nil {
+		return nil
+	}
+	return p.process.Stdout()
+}
+
+// Stderr returns the guest standard-error pipe.
+func (p *Process) Stderr() io.ReadCloser {
+	if p == nil || p.process == nil {
+		return nil
+	}
+	return p.process.Stderr()
+}
+
+// Kill terminates the guest process group.
+func (p *Process) Kill() error {
+	if p == nil || p.process == nil {
+		return nil
+	}
+	return p.process.Kill()
+}
+
+// Wait reaps the process and removes its one-shot workspace.
+func (p *Process) Wait() error {
+	if p == nil || p.process == nil {
+		return nil
+	}
+	waitErr := p.process.Wait()
+	p.cleanupOnce.Do(func() {
+		p.cleanupErr = p.runtime.Cleanup(context.Background(), p.ws)
+	})
+	return errors.Join(waitErr, p.cleanupErr)
+}

--- a/internal/coderuntime/sandboxpython/sandboxpython_test.go
+++ b/internal/coderuntime/sandboxpython/sandboxpython_test.go
@@ -1,0 +1,356 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package sandboxpython
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox"
+)
+
+func TestRunnerStartsGuestWithCleanEnvAndRemovesWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	t.Setenv("TRPC_SANDBOX_ENV_PROBE", "must-not-leak")
+	root := t.TempDir()
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+		sandbox.WithSessionPolicy(sandbox.SessionPolicy{
+			Persistence: sandbox.SessionPersistencePerSession,
+		}),
+	)
+	process, err := runner.StartScript(
+		context.Background(),
+		Config{},
+		"print('ok')",
+		"guest.py",
+		[]byte("import os\nprint(os.getenv('TRPC_SANDBOX_ENV_PROBE'))\nprint(os.getcwd())\n"),
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	workspacePath := process.ws.Path
+	require.DirExists(t, workspacePath)
+	require.NoError(t, process.Stdin().Close())
+	out, err := io.ReadAll(process.Stdout())
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, process.Stderr())
+	require.NoError(t, err)
+	require.NoError(t, process.Wait())
+	require.NotContains(t, string(out), "must-not-leak")
+	require.Contains(t, string(out), filepath.Join(workspacePath, "work"))
+	require.NoDirExists(t, workspacePath)
+}
+
+func TestRunnerKillReapsProcessAndRemovesWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(t.TempDir()),
+	)
+	process, err := runner.StartScript(
+		context.Background(),
+		Config{},
+		"while True: pass",
+		"guest.py",
+		[]byte("while True:\n    pass\n"),
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	workspacePath := process.ws.Path
+	var drains sync.WaitGroup
+	drains.Add(2)
+	go func() {
+		defer drains.Done()
+		_, _ = io.Copy(io.Discard, process.Stdout())
+	}()
+	go func() {
+		defer drains.Done()
+		_, _ = io.Copy(io.Discard, process.Stderr())
+	}()
+
+	require.NoError(t, process.Kill())
+	require.Error(t, process.Wait())
+	drains.Wait()
+	require.NoDirExists(t, workspacePath)
+}
+
+func TestRunnerRejectsCodeBeforeCreatingWorkspace(t *testing.T) {
+	root := t.TempDir()
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	_, err := runner.StartScript(
+		context.Background(),
+		Config{MaxCodeBytes: 4},
+		"return None",
+		"guest.py",
+		[]byte("print('x')"),
+		nil,
+		nil,
+	)
+	require.ErrorContains(t, err, "code exceeds 4 bytes")
+	entries, readErr := os.ReadDir(root)
+	require.NoError(t, readErr)
+	require.Empty(t, entries)
+}
+
+func TestRunnerRejectsEmptyScriptName(t *testing.T) {
+	root := t.TempDir()
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	_, err := runner.StartScript(
+		context.Background(),
+		Config{},
+		"return None",
+		" ",
+		[]byte("print('x')"),
+		nil,
+		nil,
+	)
+	require.ErrorContains(t, err, "script name is required")
+	entries, readErr := os.ReadDir(root)
+	require.NoError(t, readErr)
+	require.Empty(t, entries)
+}
+
+func TestRunnerCleansWorkspaceWhenGuestStartFails(t *testing.T) {
+	root := t.TempDir()
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	_, err := runner.StartScript(
+		context.Background(),
+		Config{Python: "python-that-does-not-exist"},
+		"return None",
+		"guest.py",
+		[]byte("print('x')"),
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".py") {
+			t.Fatalf("guest file remained after start failure: %s", path)
+		}
+		return nil
+	}))
+}
+
+func TestRunnerSupportsRelativePythonPath(t *testing.T) {
+	pythonPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	pythonPath, err = filepath.Abs(pythonPath)
+	require.NoError(t, err)
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+	relativePython, err := filepath.Rel(currentDir, pythonPath)
+	require.NoError(t, err)
+
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(t.TempDir()),
+	)
+	process, err := runner.StartScript(
+		context.Background(),
+		Config{Python: relativePython},
+		"print('ok')",
+		"guest.py",
+		[]byte("print('ok')\n"),
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	out, err := io.ReadAll(process.Stdout())
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, process.Stderr())
+	require.NoError(t, err)
+	require.NoError(t, process.Wait())
+	require.Equal(t, "ok", strings.TrimSpace(string(out)))
+}
+
+func TestRunnerTimeoutReapsProcessAndRemovesWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(t.TempDir()),
+	)
+	process, err := runner.StartScript(
+		context.Background(),
+		Config{Timeout: 20 * time.Millisecond},
+		"while True: pass",
+		"guest.py",
+		[]byte("while True:\n    pass\n"),
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	workspacePath := process.ws.Path
+	var drains sync.WaitGroup
+	drains.Add(2)
+	go func() {
+		defer drains.Done()
+		_, _ = io.Copy(io.Discard, process.Stdout())
+	}()
+	go func() {
+		defer drains.Done()
+		_, _ = io.Copy(io.Discard, process.Stderr())
+	}()
+	require.ErrorIs(t, process.Wait(), context.DeadlineExceeded)
+	drains.Wait()
+	require.NoDirExists(t, workspacePath)
+}
+
+func TestRunnerContextCancellationReapsProcessAndRemovesWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runner := New(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(t.TempDir()),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	process, err := runner.StartScript(
+		ctx,
+		Config{},
+		"while True: pass",
+		"guest.py",
+		[]byte("while True:\n    pass\n"),
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	workspacePath := process.ws.Path
+	var drains sync.WaitGroup
+	drains.Add(2)
+	go func() {
+		defer drains.Done()
+		_, _ = io.Copy(io.Discard, process.Stdout())
+	}()
+	go func() {
+		defer drains.Done()
+		_, _ = io.Copy(io.Discard, process.Stderr())
+	}()
+
+	cancel()
+	require.ErrorIs(t, process.Wait(), context.Canceled)
+	drains.Wait()
+	require.NoDirExists(t, workspacePath)
+}
+
+func TestResolvePythonPathUsesHostPathAndReturnsAbsolutePath(t *testing.T) {
+	binDir := t.TempDir()
+	name := "custom-python"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	python := filepath.Join(binDir, name)
+	require.NoError(t, os.WriteFile(python, []byte("#!/bin/sh\n"), 0o700))
+	t.Setenv("PATH", binDir)
+
+	resolved, err := resolvePythonPath(name)
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(resolved))
+	require.Equal(t, python, resolved)
+}
+
+func TestResolvePythonPathKeepsDefaultSandboxResolved(t *testing.T) {
+	resolved, err := resolvePythonPath("")
+	require.NoError(t, err)
+	require.Equal(t, "python3", resolved)
+}
+
+func TestNilRunnerIsRejected(t *testing.T) {
+	var runner *Runner
+	_, err := runner.StartScript(
+		context.Background(),
+		Config{},
+		"return None",
+		"guest.py",
+		[]byte("print('x')"),
+		nil,
+		nil,
+	)
+	require.ErrorContains(t, err, "runner is required")
+}
+
+func TestNilProcessOperations(t *testing.T) {
+	var process *Process
+	require.Nil(t, process.Stdin())
+	require.Nil(t, process.Stdout())
+	require.Nil(t, process.Stderr())
+	require.NoError(t, process.Kill())
+	require.NoError(t, process.Wait())
+}
+
+func TestNegativeCodeLimitDisablesValidation(t *testing.T) {
+	require.NoError(t, validateCodeSize(strings.Repeat("x", defaultMaxCodeBytes+1), -1))
+	require.Error(t, validateCodeSize(strings.Repeat("x", defaultMaxCodeBytes+1), 0))
+}
+
+func TestRunnerDoesNotFallbackFromUnsupportedBackend(t *testing.T) {
+	backend := sandbox.BackendAuto
+	switch runtime.GOOS {
+	case "linux":
+		backend = sandbox.BackendMacOSSandboxExec
+	case "darwin":
+		backend = sandbox.BackendLinuxBubblewrap
+	}
+	root := t.TempDir()
+	runner := New(
+		sandbox.WithBackend(backend),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	_, err := runner.StartScript(
+		context.Background(),
+		Config{},
+		"return None",
+		"guest.py",
+		[]byte("print('x')"),
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !info.IsDir() && info.Name() == "guest.py" {
+			t.Fatalf("unsupported backend fell back and retained guest script: %s", path)
+		}
+		return nil
+	}))
+}

--- a/tool/dynamicworkflow/sandbox.go
+++ b/tool/dynamicworkflow/sandbox.go
@@ -1,0 +1,104 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package dynamicworkflow
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox"
+	"trpc.group/trpc-go/trpc-agent-go/internal/coderuntime/sandboxpython"
+)
+
+// SandboxRunner executes workflow Python through codeexecutor/sandbox. Its
+// default options use a fresh OS-sandboxed workspace. Use NewSandboxRunner to
+// construct it. Configure exported fields before first use; mutating them
+// concurrently with ExecuteWorkflow is not safe.
+type SandboxRunner struct {
+	// Python selects an interpreter through the host PATH and may require
+	// sandbox read grants. When empty, the sandbox resolves python3 from its
+	// clean PATH.
+	Python string
+	// Timeout sets an optional deadline for the full execution and propagates
+	// cancellation to host callbacks. Call handlers must honor their context
+	// for timely cancellation. The zero value relies on the caller's context.
+	Timeout time.Duration
+	// MaxCodeBytes bounds workflow source before the process starts. The
+	// default is 64 KiB. Use a negative value to disable the limit.
+	MaxCodeBytes int
+
+	runner *sandboxpython.Runner
+}
+
+// NewSandboxRunner creates a runner backed by codeexecutor/sandbox. The default
+// options require managed OS sandboxing. Guest workspaces are always one-shot
+// even if opts contain another session policy.
+func NewSandboxRunner(opts ...sandbox.Option) *SandboxRunner {
+	return &SandboxRunner{runner: sandboxpython.New(opts...)}
+}
+
+// ExecuteWorkflow implements Runtime with a fresh sandboxed Python guest.
+func (r *SandboxRunner) ExecuteWorkflow(
+	ctx context.Context,
+	req Request,
+	handler CallHandler,
+) (Result, error) {
+	if r == nil || r.runner == nil {
+		return Result{}, required("sandbox runner")
+	}
+	if handler == nil {
+		return Result{}, required("call handler")
+	}
+	runCtx, cancel := localExecutionContext(ctx, r.Timeout)
+	defer cancel()
+	guest, err := r.startSandboxGuest(runCtx, req.Code)
+	if err != nil {
+		return Result{}, err
+	}
+	return runWorkflowGuest(runCtx, guest, handler)
+}
+
+func (r *SandboxRunner) startSandboxGuest(
+	ctx context.Context,
+	code string,
+) (*workflowGuestProcess, error) {
+	process, err := r.runner.StartScript(
+		ctx,
+		sandboxpython.Config{
+			Python:       r.Python,
+			MaxCodeBytes: r.MaxCodeBytes,
+		},
+		code,
+		"guest.py",
+		[]byte(pythonGuest),
+		nil,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("dynamicworkflow: start sandbox guest: %w", err)
+	}
+	stderr := newLimitedBuffer(workflowGuestCapturedOutputLimit)
+	stderrDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(stderr, process.Stderr())
+		close(stderrDone)
+	}()
+	return &workflowGuestProcess{
+		process:    process,
+		stdin:      process.Stdin(),
+		stdout:     process.Stdout(),
+		stderr:     stderr,
+		stderrDone: stderrDone,
+		code:       code,
+	}, nil
+}
+
+var _ Runtime = (*SandboxRunner)(nil)

--- a/tool/dynamicworkflow/sandbox_test.go
+++ b/tool/dynamicworkflow/sandbox_test.go
@@ -179,6 +179,73 @@ func TestSandboxRunnerOptionalTimeoutStopsBusyWorkflow(t *testing.T) {
 	require.Less(t, time.Since(started), 5*time.Second)
 }
 
+func TestSandboxRunnerDrainsGuestStderrBeforeWait(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell wrapper is Unix-specific")
+	}
+	wrapper := filepath.Join(t.TempDir(), "python-with-stderr-burst")
+	require.NoError(t, os.WriteFile(
+		wrapper,
+		[]byte(`#!/bin/sh
+i=0
+while [ "$i" -lt 8192 ]; do
+  printf '0123456789abcdef0123456789abcdef'
+  i=$((i + 1))
+done >&2
+printf '\nfinal stderr marker\n' >&2
+exit 97
+`),
+		0o700,
+	))
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Python = wrapper
+
+	_, err := Execute(
+		context.Background(),
+		runner,
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"return None",
+	)
+	require.ErrorContains(t, err, "final stderr marker")
+}
+
+func TestSandboxRunnerKillsDescendantHoldingStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group cleanup is Unix-specific")
+	}
+	wrapper := filepath.Join(t.TempDir(), "python-with-stderr-descendant")
+	require.NoError(t, os.WriteFile(
+		wrapper,
+		[]byte(`#!/bin/sh
+/bin/sleep 30 &
+printf '{"type":"done","result":"done"}\n'
+exit 0
+`),
+		0o700,
+	))
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Python = wrapper
+
+	started := time.Now()
+	result, err := Execute(
+		context.Background(),
+		runner,
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"return None",
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, `"done"`, string(result.Value))
+	require.Less(t, time.Since(started), 2*time.Second)
+}
+
 func TestSandboxRunnerTimeoutCancelsCallbackAndCleansWorkspace(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 is not installed")

--- a/tool/dynamicworkflow/sandbox_test.go
+++ b/tool/dynamicworkflow/sandbox_test.go
@@ -1,0 +1,252 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox"
+)
+
+func TestSandboxRunnerRoutesWorkflowCalls(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	root := t.TempDir()
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindTool, call.Kind)
+		require.Equal(t, "add", call.Name)
+		require.JSONEq(t, `{"a":20,"b":22}`, string(call.Args))
+		return json.RawMessage(`42`), nil
+	})
+
+	result, err := Execute(context.Background(), runner, handler, `
+answer = await call_tool("add", a=20, b=22)
+return {"answer": answer}
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"answer":42}`, string(result.Value))
+	requireNoGuestScripts(t, root)
+}
+
+func TestSandboxRunnerRoutesAgentCalls(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		require.Empty(t, call.Name)
+		require.JSONEq(t, `{
+			"input":{"draft":"hello"},
+			"options":{"template":"reviewer"}
+		}`, string(call.Args))
+		return json.RawMessage(`{"text":"approved"}`), nil
+	})
+
+	result, err := Execute(context.Background(), runner, handler, `
+review = await agent({"draft": "hello"}, "reviewer")
+return {"review": review["text"]}
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"review":"approved"}`, string(result.Value))
+}
+
+func TestSandboxRunnerUsesCleanEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell wrapper is Unix-specific")
+	}
+	python, err := exec.LookPath("python3")
+	require.NoError(t, err)
+	python, err = filepath.Abs(python)
+	require.NoError(t, err)
+	t.Setenv("TRPC_SANDBOX_ENV_PROBE", "must-not-leak")
+	wrapper := filepath.Join(t.TempDir(), "python-clean-env-check")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ -n "$TRPC_SANDBOX_ENV_PROBE" ]; then
+  echo "host environment leaked" >&2
+  exit 97
+fi
+exec %s "$@"
+`, shellQuote(python))
+	require.NoError(t, os.WriteFile(wrapper, []byte(script), 0o700))
+
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Python = wrapper
+	result, err := Execute(
+		context.Background(),
+		runner,
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"return {'clean': True}",
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"clean":true}`, string(result.Value))
+}
+
+func TestSandboxRunnerManagedBackend(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("bwrap"); err != nil {
+			t.Skip("bubblewrap is not installed")
+		}
+	case "darwin":
+		if _, err := os.Stat("/usr/bin/sandbox-exec"); err != nil {
+			t.Skip("sandbox-exec is not installed")
+		}
+	default:
+		t.Skip("managed sandbox backend is unavailable")
+	}
+	runner := NewSandboxRunner()
+	result, err := Execute(
+		context.Background(),
+		runner,
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"return {'sandboxed': True}",
+	)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"sandboxed":true}`, string(result.Value))
+}
+
+func TestSandboxRunnerEnforcesCodeLimit(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.MaxCodeBytes = 8
+	_, err := Execute(
+		context.Background(),
+		runner,
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"return None",
+	)
+	require.ErrorContains(t, err, "code exceeds 8 bytes")
+}
+
+func TestSandboxRunnerOptionalTimeoutStopsBusyWorkflow(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	runner.Timeout = 100 * time.Millisecond
+	started := time.Now()
+	_, err := Execute(
+		context.Background(),
+		runner,
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+		"while True:\n    pass\nreturn None",
+	)
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 5*time.Second)
+}
+
+func TestSandboxRunnerTimeoutCancelsCallbackAndCleansWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	root := t.TempDir()
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+		sandbox.WithWorkspaceRoot(root),
+	)
+	runner.Timeout = 500 * time.Millisecond
+	handlerErr := make(chan error, 1)
+	handler := callHandlerFunc(func(ctx context.Context, _ Call) (json.RawMessage, error) {
+		<-ctx.Done()
+		handlerErr <- ctx.Err()
+		return nil, ctx.Err()
+	})
+
+	_, err := Execute(
+		context.Background(),
+		runner,
+		handler,
+		`return await call_tool("wait")`,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	select {
+	case err := <-handlerErr:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(2 * time.Second):
+		t.Fatal("workflow callback did not observe the runner timeout")
+	}
+	requireNoGuestScripts(t, root)
+}
+
+func TestSandboxRunnerRequiresConstructor(t *testing.T) {
+	_, err := (&SandboxRunner{}).ExecuteWorkflow(
+		context.Background(),
+		Request{Code: "return None"},
+		callHandlerFunc(func(context.Context, Call) (json.RawMessage, error) {
+			return nil, nil
+		}),
+	)
+	require.ErrorContains(t, err, "sandbox runner is required")
+}
+
+func TestSandboxRunnerRequiresCallHandler(t *testing.T) {
+	_, err := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	).ExecuteWorkflow(
+		context.Background(),
+		Request{Code: "return None"},
+		nil,
+	)
+	require.ErrorContains(t, err, "call handler is required")
+}
+
+func requireNoGuestScripts(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == "guest.py" {
+			t.Fatalf("guest script was not cleaned up: %s", path)
+		}
+		return nil
+	}))
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -88,11 +88,12 @@ type protocolMessage struct {
 }
 
 type workflowGuestProcess struct {
-	process workflowProcess
-	stdin   io.WriteCloser
-	stdout  io.Reader
-	stderr  *limitedBuffer
-	code    string
+	process    workflowProcess
+	stdin      io.WriteCloser
+	stdout     io.Reader
+	stderr     *limitedBuffer
+	stderrDone <-chan struct{}
+	code       string
 }
 
 type workflowProcess interface {
@@ -364,6 +365,9 @@ func finishWorkflowGuest(
 	}
 	_ = guest.stdin.Close()
 	waitErr := waitWorkflowGuest(ctx, guest)
+	if guest.stderrDone != nil {
+		<-guest.stderrDone
+	}
 	if guest.stderr.Exceeded() && state.guestErr == nil {
 		state.guestErr = fmt.Errorf(
 			"dynamicworkflow: guest stderr exceeds %d bytes",

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -365,9 +365,6 @@ func finishWorkflowGuest(
 	}
 	_ = guest.stdin.Close()
 	waitErr := waitWorkflowGuest(ctx, guest)
-	if guest.stderrDone != nil {
-		<-guest.stderrDone
-	}
 	if guest.stderr.Exceeded() && state.guestErr == nil {
 		state.guestErr = fmt.Errorf(
 			"dynamicworkflow: guest stderr exceeds %d bytes",
@@ -432,6 +429,9 @@ func workflowGuestScannerError(err error) error {
 func waitWorkflowGuest(ctx context.Context, guest *workflowGuestProcess) error {
 	waitCh := make(chan error, 1)
 	go func() {
+		if guest.stderrDone != nil {
+			<-guest.stderrDone
+		}
 		waitCh <- guest.process.Wait()
 	}()
 	timer := time.NewTimer(workflowGuestExitGrace)

--- a/tool/dynamicworkflow/types.go
+++ b/tool/dynamicworkflow/types.go
@@ -85,7 +85,8 @@ type Call struct {
 
 // CallHandler is the host capability boundary. Runtimes must route every
 // sandbox-originated call through this handler rather than accessing host
-// services directly.
+// services directly. Handlers must honor context cancellation and return
+// promptly after the context is done.
 type CallHandler interface {
 	HandleWorkflowCall(context.Context, Call) (json.RawMessage, error)
 }


### PR DESCRIPTION
Add sandbox-backed Python runners for CodeAct and Dynamic Workflow by extending the existing sandbox runtime with full-duplex process support.

Includes lifecycle and isolation tests, security-boundary documentation, and a runnable Dynamic Workflow example.