### PR TITLE
session: synchronize UpdateUserSession with Clone

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -471,15 +471,14 @@ func (sess *Session) UpdateUserSession(event *event.Event, opts ...Option) {
 		log.Info("session or event is nil")
 		return
 	}
+	sess.EventMu.Lock()
 	if event.Response != nil && !event.IsPartial && event.IsValidContent() {
-		sess.EventMu.Lock()
 		sess.Events = append(sess.Events, *event)
 		// Apply filtering options.
 		sess.ApplyEventFiltering(opts...)
-		sess.EventMu.Unlock()
 	}
-
 	sess.UpdatedAt = time.Now()
+	sess.EventMu.Unlock()
 	sess.ApplyEventStateDelta(event)
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2143,6 +2143,34 @@ func TestSession_Clone_Concurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSession_Clone_ConcurrentUpdateUserSession(t *testing.T) {
+	sess := NewSession("app", "user", "session")
+	updatedAt := sess.UpdatedAt
+	ev := &event.Event{}
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			sess.Clone()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			sess.UpdateUserSession(ev)
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+	assert.True(t, sess.UpdatedAt.After(updatedAt))
+}
+
 func TestNewSession(t *testing.T) {
 	fixedTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION
## What changed

`Session.Clone` can now run concurrently with `UpdateUserSession` without racing on `UpdatedAt`. Event appends and the corresponding timestamp update share the existing `EventMu` critical section.

## Why

`Clone` reads `Events` and `UpdatedAt` while holding `EventMu`, but `UpdateUserSession` previously wrote `UpdatedAt` after releasing that mutex. Concurrent persistence and snapshotting therefore produced a data race and could expose mismatched event and timestamp state.

## Testing

- `go test ./session -count=1`
- `go test -race ./session -run TestSession_Clone_ConcurrentUpdateUserSession -count=10`
- `go vet ./session`

## Notes for reviewers

There are no exported symbol or persistence-format changes. This only synchronizes the existing `UpdateUserSession` mutation with the lock already used by `Clone`.