### PR TITLE
evaluation/workflow/promptiter/aggregator: fall back on empty aggregation

### DIFF
--- a/evaluation/workflow/promptiter/aggregator/aggregator.go
+++ b/evaluation/workflow/promptiter/aggregator/aggregator.go
@@ -264,6 +264,35 @@ func sanitizeAggregatedGradientProposal(
 		})
 	}
 	if len(resolved.Gradients) == 0 {
+		return fallbackAggregatedGradient(request)
+	}
+	sort.SliceStable(resolved.Gradients, func(i, j int) bool {
+		return compareGradients(resolved.Gradients[i], resolved.Gradients[j]) < 0
+	})
+	return resolved, nil
+}
+
+func fallbackAggregatedGradient(request *Request) (*promptiter.AggregatedSurfaceGradient, error) {
+	resolved := &promptiter.AggregatedSurfaceGradient{
+		SurfaceID: request.SurfaceID,
+		NodeID:    request.NodeID,
+		Type:      request.Type,
+		Gradients: make([]promptiter.SurfaceGradient, 0, len(request.Gradients)),
+	}
+	for _, gradient := range request.Gradients {
+		if gradient.Gradient == "" {
+			continue
+		}
+		resolved.Gradients = append(resolved.Gradients, promptiter.SurfaceGradient{
+			EvalSetID:  gradient.EvalSetID,
+			EvalCaseID: gradient.EvalCaseID,
+			StepID:     gradient.StepID,
+			SurfaceID:  request.SurfaceID,
+			Severity:   gradient.Severity,
+			Gradient:   gradient.Gradient,
+		})
+	}
+	if len(resolved.Gradients) == 0 {
 		return nil, errors.New("aggregated gradient is empty")
 	}
 	sort.SliceStable(resolved.Gradients, func(i, j int) bool {

--- a/evaluation/workflow/promptiter/aggregator/aggregator_test.go
+++ b/evaluation/workflow/promptiter/aggregator/aggregator_test.go
@@ -258,11 +258,50 @@ func TestAggregateUsesDefaultUUIDSessionID(t *testing.T) {
 	assert.NoError(t, parseErr)
 	assert.NotNil(t, r.lastRunOpts.StructuredOutput)
 	assert.Equal(t, model.StructuredOutputJSONSchema, r.lastRunOpts.StructuredOutput.Type)
+	requireStructuredOutputSchema(t, r.lastRunOpts.StructuredOutput.JSONSchema.Schema)
 	assert.Equal(
 		t,
 		reflect.TypeOf((*aggregatedGradientProposal)(nil)),
 		r.lastRunOpts.StructuredOutputType,
 	)
+}
+
+func requireStructuredOutputSchema(t *testing.T, schema map[string]any) {
+	t.Helper()
+	properties, ok := schema["properties"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	gradientsSchema, ok := properties["Gradients"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	itemSchema, ok := gradientsSchema["items"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	itemProperties, ok := itemSchema["properties"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	gradientSchema, ok := itemProperties["Gradient"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, "string", gradientSchema["type"])
+	severitySchema, ok := itemProperties["Severity"].(map[string]any)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, []string{"P0", "P1", "P2", "P3"}, severitySchema["enum"])
+	assert.Equal(t, false, itemSchema["additionalProperties"])
+	assert.Equal(t, false, schema["additionalProperties"])
 }
 
 func TestAggregateFallsBackToFinalContent(t *testing.T) {
@@ -566,7 +605,7 @@ func TestAggregateRejectsMissingRuntimeDependencies(t *testing.T) {
 	assert.EqualError(t, err, "session id supplier is nil")
 }
 
-func TestAggregateRejectsMessageBuildAndEmptyDecodedGradient(t *testing.T) {
+func TestAggregateHandlesMessageBuildAndEmptyDecodedGradient(t *testing.T) {
 	t.Run("message builder error", func(t *testing.T) {
 		ag, err := New(
 			context.Background(),
@@ -587,7 +626,7 @@ func TestAggregateRejectsMessageBuildAndEmptyDecodedGradient(t *testing.T) {
 		assert.Nil(t, result)
 		assert.EqualError(t, runErr, "build aggregation message: boom")
 	})
-	t.Run("empty decoded gradient", func(t *testing.T) {
+	t.Run("empty decoded gradient falls back to request gradients", func(t *testing.T) {
 		ag, err := New(context.Background(), &fakeRunner{
 			events: []*event.Event{
 				event.NewResponseEvent(
@@ -607,10 +646,59 @@ func TestAggregateRejectsMessageBuildAndEmptyDecodedGradient(t *testing.T) {
 			SurfaceID: "surf_1",
 			NodeID:    "node_1",
 			Type:      astructure.SurfaceTypeInstruction,
-			Gradients: []promptiter.SurfaceGradient{{SurfaceID: "surf_1", Gradient: "citation issue"}},
+			Gradients: []promptiter.SurfaceGradient{{
+				EvalSetID:  "set_a",
+				EvalCaseID: "case_1",
+				StepID:     "s1",
+				SurfaceID:  "surf_1",
+				Severity:   promptiter.LossSeverityP1,
+				Gradient:   "citation issue",
+			}},
 		})
-		assert.Nil(t, result)
-		assert.EqualError(t, runErr, "sanitize aggregated gradient proposal: aggregated gradient is empty")
+		assert.NoError(t, runErr)
+		assert.NotNil(t, result)
+		if result == nil || result.Gradient == nil {
+			return
+		}
+		assert.Equal(t, []promptiter.SurfaceGradient{{
+			EvalSetID:  "set_a",
+			EvalCaseID: "case_1",
+			StepID:     "s1",
+			SurfaceID:  "surf_1",
+			Severity:   promptiter.LossSeverityP1,
+			Gradient:   "citation issue",
+		}}, result.Gradient.Gradients)
+	})
+	t.Run("empty structured gradients fall back to request gradients", func(t *testing.T) {
+		ag, err := New(context.Background(), &fakeRunner{
+			events: []*event.Event{
+				event.NewResponseEvent(
+					"invocation-id",
+					"aggregator",
+					&model.Response{Done: true},
+					event.WithStructuredOutputPayload(map[string]any{
+						"Gradients": []any{},
+					}),
+				),
+			},
+		})
+		assert.NoError(t, err)
+		result, runErr := ag.Aggregate(context.Background(), &Request{
+			SurfaceID: "surf_1",
+			NodeID:    "node_1",
+			Type:      astructure.SurfaceTypeInstruction,
+			Gradients: []promptiter.SurfaceGradient{{
+				SurfaceID: "surf_1",
+				Severity:  promptiter.LossSeverityP1,
+				Gradient:  "citation issue",
+			}},
+		})
+		assert.NoError(t, runErr)
+		assert.NotNil(t, result)
+		if result == nil || result.Gradient == nil {
+			return
+		}
+		assert.Equal(t, "citation issue", result.Gradient.Gradients[0].Gradient)
 	})
 }
 
@@ -795,8 +883,10 @@ func TestNormalizeRequestAndSanitizeAggregatedGradient(t *testing.T) {
 			{Gradient: ""},
 		},
 	})
-	assert.Nil(t, gradient)
-	assert.EqualError(t, err, "aggregated gradient is empty")
+	assert.NoError(t, err)
+	assert.NotNil(t, gradient)
+	assert.Equal(t, "grounding", gradient.Gradients[0].Gradient)
+	assert.Equal(t, "detail", gradient.Gradients[1].Gradient)
 	gradient, err = sanitizeAggregatedGradientProposal(validRequest, &aggregatedGradientProposal{
 		Gradients: []gradientProposal{
 			{Gradient: "detail", Severity: promptiter.LossSeverityP2},

--- a/evaluation/workflow/promptiter/aggregator/message.go
+++ b/evaluation/workflow/promptiter/aggregator/message.go
@@ -32,6 +32,7 @@ Requirements:
 - Keep the response as raw JSON only.
 - Do not wrap the response in markdown code fences.
 - Return only merged gradient items. The caller will attach the target surface identity and type.
+- Never return an empty Gradients array.
 - Merge duplicated or overlapping gradients when appropriate.
 - Drop clearly empty or redundant gradient items.
 

--- a/evaluation/workflow/promptiter/aggregator/options.go
+++ b/evaluation/workflow/promptiter/aggregator/options.go
@@ -11,9 +11,11 @@ package aggregator
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/google/uuid"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
 )
 
 // options stores optional aggregation behavior.
@@ -31,11 +33,7 @@ type Option func(*options)
 func newOptions(opt ...Option) *options {
 	opts := &options{
 		runOptions: []agent.RunOption{
-			agent.WithStructuredOutputJSON(
-				new(aggregatedGradientProposal),
-				true,
-				"One aggregated PromptIter gradient proposal.",
-			),
+			aggregatedGradientStructuredOutput(),
 		},
 		messageBuilder:    defaultMessageBuilder(),
 		userIDSupplier:    defaultUserIDSupplier(),
@@ -51,6 +49,50 @@ func newOptions(opt ...Option) *options {
 func WithRunOptions(runOptions ...agent.RunOption) Option {
 	return func(opts *options) {
 		opts.runOptions = append(opts.runOptions, runOptions...)
+	}
+}
+
+func aggregatedGradientStructuredOutput() agent.RunOption {
+	return func(opts *agent.RunOptions) {
+		agent.WithStructuredOutputJSONSchema(
+			"AggregatedGradientProposal",
+			aggregatedGradientProposalSchema(),
+			true,
+			"One aggregated PromptIter gradient proposal.",
+		)(opts)
+		opts.StructuredOutputType = reflect.TypeOf((*aggregatedGradientProposal)(nil))
+	}
+}
+
+func aggregatedGradientProposalSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"Gradients": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"Severity": map[string]any{
+							"type": "string",
+							"enum": []string{
+								string(promptiter.LossSeverityP0),
+								string(promptiter.LossSeverityP1),
+								string(promptiter.LossSeverityP2),
+								string(promptiter.LossSeverityP3),
+							},
+						},
+						"Gradient": map[string]any{
+							"type": "string",
+						},
+					},
+					"required":             []string{"Severity", "Gradient"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"Gradients"},
+		"additionalProperties": false,
 	}
 }
 


### PR DESCRIPTION
This change keeps PromptIter aggregation resilient when the aggregator model returns an empty gradient proposal by falling back to the already validated input gradients for that surface. It also tightens the aggregator prompt and structured output schema so worker models are steered toward non-empty, schema-shaped gradient proposals without relying on provider-specific unsupported schema constraints.