### PR TITLE
agent/llmagent: classify LLMAgent nodes as agents

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1536,7 +1536,7 @@ func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-c
 			},
 		)
 		if traceLease.Owns {
-			tracecapture.SetStepNodeType(traceCtx, traceLease.StepID, "llm")
+			tracecapture.SetStepNodeType(traceCtx, traceLease.StepID, "agent")
 		}
 	}
 	ctx = a.withWorkspace(ctx, invocation)

--- a/agent/llmagent/run_test.go
+++ b/agent/llmagent/run_test.go
@@ -139,7 +139,7 @@ func TestLLMAgent_Run_BeforeCallbackCust(t *testing.T) {
 	require.NotNil(t, executionTrace)
 	require.Len(t, executionTrace.Steps, 1)
 	require.False(t, executionTrace.Steps[0].EndedAt.IsZero())
-	require.Equal(t, "llm", executionTrace.Steps[0].NodeType)
+	require.Equal(t, "agent", executionTrace.Steps[0].NodeType)
 	require.Contains(t, executionTrace.Steps[0].Input.Text, "hello")
 	require.Contains(t, executionTrace.Steps[0].Output.Text, "before")
 }
@@ -227,8 +227,8 @@ func TestLLMAgent_Run_SameInvocationTwiceCreatesTwoSteps(t *testing.T) {
 	require.Len(t, executionTrace.Steps, 2)
 	require.NotEqual(t, executionTrace.Steps[0].StepID, executionTrace.Steps[1].StepID)
 	require.Equal(t, executionTrace.Steps[0].NodeID, executionTrace.Steps[1].NodeID)
-	require.Equal(t, "llm", executionTrace.Steps[0].NodeType)
-	require.Equal(t, "llm", executionTrace.Steps[1].NodeType)
+	require.Equal(t, "agent", executionTrace.Steps[0].NodeType)
+	require.Equal(t, "agent", executionTrace.Steps[1].NodeType)
 	require.False(t, executionTrace.Steps[0].EndedAt.IsZero())
 	require.False(t, executionTrace.Steps[1].EndedAt.IsZero())
 }

--- a/agent/llmagent/structure_export.go
+++ b/agent/llmagent/structure_export.go
@@ -41,7 +41,7 @@ func (a *LLMAgent) Export(
 		Nodes: []structure.Node{
 			{
 				NodeID: rootNodeID,
-				Kind:   structure.NodeKindLLM,
+				Kind:   structure.NodeKindAgent,
 				Name:   name,
 			},
 		},

--- a/agent/llmagent/structure_export_test.go
+++ b/agent/llmagent/structure_export_test.go
@@ -43,7 +43,7 @@ func TestExport_LLMAgent_BasicSnapshot(t *testing.T) {
 	assertLLMSnapshotEqual(t, snapshot, &structure.Snapshot{
 		EntryNodeID: "assistant",
 		Nodes: []structure.Node{
-			{NodeID: "assistant", Kind: structure.NodeKindLLM, Name: "assistant"},
+			{NodeID: "assistant", Kind: structure.NodeKindAgent, Name: "assistant"},
 		},
 		Edges: []structure.Edge{},
 		Surfaces: []structure.Surface{
@@ -99,8 +99,8 @@ func TestExport_LLMAgent_ConfiguredSnapshot(t *testing.T) {
 	assertLLMSnapshotEqual(t, snapshot, &structure.Snapshot{
 		EntryNodeID: "assistant",
 		Nodes: []structure.Node{
-			{NodeID: "assistant", Kind: structure.NodeKindLLM, Name: "assistant"},
-			{NodeID: "assistant/sub", Kind: structure.NodeKindLLM, Name: "sub"},
+			{NodeID: "assistant", Kind: structure.NodeKindAgent, Name: "assistant"},
+			{NodeID: "assistant/sub", Kind: structure.NodeKindAgent, Name: "sub"},
 			{NodeID: "assistant/sub~2", Kind: structure.NodeKindAgent, Name: "sub"},
 		},
 		Edges: []structure.Edge{
@@ -191,7 +191,7 @@ func TestExport_LLMAgent_DoubleBraceSyntax(t *testing.T) {
 	assertLLMSnapshotEqual(t, snapshot, &structure.Snapshot{
 		EntryNodeID: "assistant",
 		Nodes: []structure.Node{
-			{NodeID: "assistant", Kind: structure.NodeKindLLM, Name: "assistant"},
+			{NodeID: "assistant", Kind: structure.NodeKindAgent, Name: "assistant"},
 		},
 		Edges: []structure.Edge{},
 		Surfaces: []structure.Surface{

--- a/agent/structure/structure.go
+++ b/agent/structure/structure.go
@@ -30,7 +30,7 @@ type NodeKind string
 const (
 	// NodeKindAgent represents an agent node.
 	NodeKindAgent NodeKind = "agent"
-	// NodeKindLLM represents an LLM node.
+	// NodeKindLLM represents an LLM operation node.
 	NodeKindLLM NodeKind = "llm"
 	// NodeKindFunction represents a function node.
 	NodeKindFunction NodeKind = "function"

--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -1561,7 +1561,7 @@ Execution traces are attached to the runner completion event as an in-memory art
 Each recorded step carries stable fields such as:
 
 - `NodeID`: the static node path for the executed node
-- `NodeType`: the node's semantic type (`function`, `llm`, `tool`, or `agent`), matching the node kind in the static structure
+- `NodeType`: the node's semantic type (`function`, `llm`, `tool`, or `agent`), matching the node kind in the static structure; `agent` represents an agent execution unit, including `LLMAgent`, and `llm` represents an explicit LLM operation node
 - `PredecessorStepIDs`: the direct step dependencies in this run
 - `Input` and `Output`: stable text snapshots captured for the step
 - `Error`: the terminal step error, when the step fails

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -1501,7 +1501,7 @@ for evt := range events {
 每个步骤都会带上这些稳定字段：
 
 - `NodeID`：本次执行对应的静态节点路径
-- `NodeType`：节点的语义类型（`function`、`llm`、`tool` 或 `agent`），与静态结构中的节点类型一致
+- `NodeType`：节点的语义类型（`function`、`llm`、`tool` 或 `agent`），与静态结构中的节点类型一致；`agent` 表示 Agent 执行单元（包括 `LLMAgent`），`llm` 表示显式 LLM 操作节点
 - `PredecessorStepIDs`：这次运行里该步骤的直接前驱步骤
 - `Input` 和 `Output`：步骤输入输出的稳定文本快照
 - `Error`：步骤失败时记录的终态错误

--- a/graph/events.go
+++ b/graph/events.go
@@ -97,14 +97,19 @@ const (
 // NodeType represents the type of a graph node.
 type NodeType string
 
-// Node type constants.
 const (
+	// NodeTypeFunction represents a function node.
 	NodeTypeFunction NodeType = "function"
-	NodeTypeLLM      NodeType = "llm"
-	NodeTypeTool     NodeType = "tool"
-	NodeTypeAgent    NodeType = "agent"
-	NodeTypeJoin     NodeType = "join"
-	NodeTypeRouter   NodeType = "router"
+	// NodeTypeLLM represents an LLM operation node.
+	NodeTypeLLM NodeType = "llm"
+	// NodeTypeTool represents a tool node.
+	NodeTypeTool NodeType = "tool"
+	// NodeTypeAgent represents an agent node.
+	NodeTypeAgent NodeType = "agent"
+	// NodeTypeJoin represents a join node.
+	NodeTypeJoin NodeType = "join"
+	// NodeTypeRouter represents a router node.
+	NodeTypeRouter NodeType = "router"
 )
 
 // String returns the string representation of the node type.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -113,7 +113,7 @@ type Node struct {
 	Name        string
 	Description string
 	Function    NodeFunc
-	Type        NodeType // Type of the node (function, llm, tool, etc.)
+	Type        NodeType // Type of the node (function, LLM operation, tool, etc.)
 
 	// userInputKey is the state key used as one-shot input for LLM and
 	// Agent nodes. When empty, StateKeyUserInput is used.

--- a/runner/execution_trace_test.go
+++ b/runner/execution_trace_test.go
@@ -139,7 +139,7 @@ func TestRunnerCompletion_LLMRunProducesOneRealExecutionStep(t *testing.T) {
 	assert.Equal(t, completion.InvocationID, step.InvocationID)
 	assert.Equal(t, "assistant", step.AgentName)
 	assert.Equal(t, "assistant", step.NodeID)
-	assert.Equal(t, "llm", step.NodeType)
+	assert.Equal(t, "agent", step.NodeType)
 	assert.Empty(t, step.PredecessorStepIDs)
 	require.NotNil(t, step.Input)
 	require.NotNil(t, step.Output)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -9701,19 +9701,19 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesDeepNestedWorkflowPatches(
 		t,
 		snapshot,
 		"start",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	plannerNodeID := requireNodeIDByNameAndKind(
 		t,
 		snapshot,
 		"planner",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	workerNodeID := requireNodeIDByNameAndKind(
 		t,
 		snapshot,
 		"worker",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var startPatch agent.SurfacePatch
 	startPatch.SetInstruction("start patched instruction")
@@ -9828,13 +9828,13 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesDirectChainChildPatch(
 		t,
 		snapshot,
 		"planner",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	writerNodeID := requireNodeIDByNameAndKind(
 		t,
 		snapshot,
 		"writer",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var plannerPatch agent.SurfacePatch
 	plannerPatch.SetInstruction("planner patched instruction")
@@ -9983,13 +9983,13 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesDirectParallelBranchPatches(
 		t,
 		snapshot,
 		"researcher",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	reviewerNodeID := requireNodeIDByNameAndKind(
 		t,
 		snapshot,
 		"reviewer",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var researcherPatch agent.SurfacePatch
 	researcherPatch.SetInstruction("researcher patched instruction")
@@ -10146,7 +10146,7 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesDirectCycleChildPatch(
 		t,
 		snapshot,
 		"worker",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var workerPatch agent.SurfacePatch
 	workerPatch.SetInstruction("worker patched instruction")
@@ -10749,7 +10749,7 @@ func TestRunner_Run_WithSurfacePatchForNode_AppliesGraphCompositeChildPatch(
 		t,
 		snapshot,
 		"planner",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	require.Equal(t, "assistant/pipeline/planner", plannerNodeID)
 	var patch agent.SurfacePatch

--- a/team/structure_export_test.go
+++ b/team/structure_export_test.go
@@ -56,9 +56,9 @@ func TestExport_TeamCoordinator_MembersHangFromCoordinatorRoot(t *testing.T) {
 		EntryNodeID: "team",
 		Nodes: []structure.Node{
 			{NodeID: "team", Kind: structure.NodeKindAgent, Name: "team"},
-			{NodeID: "team/coordinator", Kind: structure.NodeKindLLM, Name: "team"},
-			{NodeID: "team/coordinator/delegate", Kind: structure.NodeKindLLM, Name: "delegate"},
-			{NodeID: "team/researcher", Kind: structure.NodeKindLLM, Name: "researcher"},
+			{NodeID: "team/coordinator", Kind: structure.NodeKindAgent, Name: "team"},
+			{NodeID: "team/coordinator/delegate", Kind: structure.NodeKindAgent, Name: "delegate"},
+			{NodeID: "team/researcher", Kind: structure.NodeKindAgent, Name: "researcher"},
 		},
 		Edges: []structure.Edge{
 			{FromNodeID: "team", ToNodeID: "team/coordinator"},
@@ -127,9 +127,9 @@ func TestExport_TeamCoordinator_CoordinatorNamespaceAvoidsMemberCollision(t *tes
 		EntryNodeID: "team",
 		Nodes: []structure.Node{
 			{NodeID: "team", Kind: structure.NodeKindAgent, Name: "team"},
-			{NodeID: "team/coordinator", Kind: structure.NodeKindLLM, Name: "team"},
-			{NodeID: "team/coordinator/researcher", Kind: structure.NodeKindLLM, Name: "researcher"},
-			{NodeID: "team/researcher", Kind: structure.NodeKindLLM, Name: "researcher"},
+			{NodeID: "team/coordinator", Kind: structure.NodeKindAgent, Name: "team"},
+			{NodeID: "team/coordinator/researcher", Kind: structure.NodeKindAgent, Name: "researcher"},
+			{NodeID: "team/researcher", Kind: structure.NodeKindAgent, Name: "researcher"},
 		},
 		Edges: []structure.Edge{
 			{FromNodeID: "team", ToNodeID: "team/coordinator"},
@@ -219,8 +219,8 @@ func TestExport_TeamSwarm_DoesNotRecursivelyExpandMemberRoster(t *testing.T) {
 		EntryNodeID: "swarm",
 		Nodes: []structure.Node{
 			{NodeID: "swarm", Kind: structure.NodeKindAgent, Name: "swarm"},
-			{NodeID: "swarm/alpha", Kind: structure.NodeKindLLM, Name: "alpha"},
-			{NodeID: "swarm/beta", Kind: structure.NodeKindLLM, Name: "beta"},
+			{NodeID: "swarm/alpha", Kind: structure.NodeKindAgent, Name: "alpha"},
+			{NodeID: "swarm/beta", Kind: structure.NodeKindAgent, Name: "beta"},
 		},
 		Edges: []structure.Edge{
 			{FromNodeID: "swarm", ToNodeID: "swarm/alpha"},
@@ -268,9 +268,9 @@ func TestExport_TeamSwarm_ThreeMembersFormDirectedCompleteGraph(t *testing.T) {
 		EntryNodeID: "swarm",
 		Nodes: []structure.Node{
 			{NodeID: "swarm", Kind: structure.NodeKindAgent, Name: "swarm"},
-			{NodeID: "swarm/alpha", Kind: structure.NodeKindLLM, Name: "alpha"},
-			{NodeID: "swarm/beta", Kind: structure.NodeKindLLM, Name: "beta"},
-			{NodeID: "swarm/gamma", Kind: structure.NodeKindLLM, Name: "gamma"},
+			{NodeID: "swarm/alpha", Kind: structure.NodeKindAgent, Name: "alpha"},
+			{NodeID: "swarm/beta", Kind: structure.NodeKindAgent, Name: "beta"},
+			{NodeID: "swarm/gamma", Kind: structure.NodeKindAgent, Name: "gamma"},
 		},
 		Edges: []structure.Edge{
 			{FromNodeID: "swarm", ToNodeID: "swarm/alpha"},

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -2160,17 +2160,12 @@ func TestRunnerRun_WithSurfacePatchForNode_AppliesCoordinatorAndMemberPatches(
 	tm, err := New(coordinator, []agent.Agent{member})
 	require.NoError(t, err)
 	snapshot := mustExportTeamSnapshot(t, tm)
-	coordinatorNodeID := requireTeamNodeIDByNameAndKind(
-		t,
-		snapshot,
-		"team",
-		structure.NodeKindLLM,
-	)
+	coordinatorNodeID := "team/coordinator"
 	memberNodeID := requireTeamNodeIDByNameAndKind(
 		t,
 		snapshot,
 		"researcher",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var coordinatorPatch agent.SurfacePatch
 	coordinatorPatch.SetInstruction("coordinator patched instruction")
@@ -2252,13 +2247,13 @@ func TestRunnerRun_WithSurfacePatchForNode_AppliesSwarmMemberPatches(
 		t,
 		snapshot,
 		"alpha",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	betaNodeID := requireTeamNodeIDByNameAndKind(
 		t,
 		snapshot,
 		"beta",
-		structure.NodeKindLLM,
+		structure.NodeKindAgent,
 	)
 	var alphaPatch agent.SurfacePatch
 	alphaPatch.SetInstruction("alpha patched instruction")


### PR DESCRIPTION
This changes LLMAgent static structure and execution trace output to classify LLMAgent nodes as agent, while leaving llm reserved for explicit LLM operation nodes such as graph LLM nodes. The documentation and related expectations now describe that distinction.