### PR TITLE
{session, server/agui, docs}: add track event history controls

### DIFF
--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -690,8 +690,8 @@ Track events are a trajectory storage mechanism in Session that is independent o
 **Interface**:
 
 Track event writes are exposed through the optional `session.TrackService`
-interface. Storage backends that support persisted track history also expose a
-`GetTrackEvents` method on their concrete service types.
+interface. Storage backends that support track history persist these events with
+the session data.
 
 ```go
 type TrackService interface {
@@ -699,18 +699,18 @@ type TrackService interface {
 }
 ```
 
-Not all storage backends implement track event APIs. A type assertion is required:
+Not all storage backends implement track event writes. A type assertion is required:
 
-| Storage Backend | Implements TrackService | Has GetTrackEvents |
-| --- | --- | --- |
-| Memory (inmemory) | ✅ | ✅ |
-| SQLite | ✅ | ✅ |
-| Redis | ✅ | ✅ |
-| PostgreSQL | ✅ | ✅ |
-| PGVector | ✅ | ✅ |
-| MySQL | ✅ | ✅ |
-| MongoDB | ✅ | ✅ |
-| ClickHouse | ❌ | ❌ |
+| Storage Backend | Implements TrackService |
+| --- | --- |
+| Memory (inmemory) | ✅ |
+| SQLite | ✅ |
+| Redis | ✅ |
+| PostgreSQL | ✅ |
+| PGVector | ✅ |
+| MySQL | ✅ |
+| MongoDB | ✅ |
+| ClickHouse | ❌ |
 
 **Basic usage**:
 
@@ -729,25 +729,14 @@ err := trackService.AppendTrackEvent(ctx, sess, &session.TrackEvent{
     Timestamp: time.Now(),
 })
 
-// Retrieve persisted track events directly when supported
-type trackEventReader interface {
-    GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
-}
-reader, ok := sessionService.(trackEventReader)
-if !ok {
-    log.Fatal("current storage backend does not expose GetTrackEvents")
-}
-trackEvents, err := reader.GetTrackEvents(ctx, session.Key{
-    AppName:   sess.AppName,
-    UserID:    sess.UserID,
-    SessionID: sess.ID,
-}, "ui-events")
+// Read track events already loaded in the session snapshot
+trackEvents, err := sess.GetTrackEvents("ui-events")
 ```
 
 `Session.GetTrackEvents` reads only the track events already loaded into a
-session snapshot. Use the backend `GetTrackEvents` method for persisted history
-views such as AG-UI history, because it reads the track storage directly and
-does not depend on the session state's track index.
+session snapshot. AG-UI history uses persisted track history internally when the
+configured session service supports it, and falls back to the session snapshot
+otherwise.
 
 ## Semantic Recall (PGVector Only)
 

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -358,6 +358,8 @@ Supports setting Time To Live for session data with automatic cleanup of expired
 **Supported TTL types:**
 
 - **SessionTTL**: Expiration time for session state and events
+- **TrackEventTTL**: Expiration time for track events where supported. Defaults
+  to SessionTTL unless configured; setting it to `0` disables track event expiry
 - **AppStateTTL**: Expiration time for app-level state
 - **UserStateTTL**: Expiration time for user-level state
 
@@ -687,7 +689,9 @@ Track events are a trajectory storage mechanism in Session that is independent o
 
 **Interface**:
 
-The Track event API is defined on the `session.TrackService` interface, which is separate from `session.Service`:
+Track event writes are exposed through the optional `session.TrackService`
+interface. Storage backends that support persisted track history also expose a
+`GetTrackEvents` method on their concrete service types.
 
 ```go
 type TrackService interface {
@@ -695,18 +699,18 @@ type TrackService interface {
 }
 ```
 
-Not all storage backends implement `TrackService`. A type assertion is required:
+Not all storage backends implement track event APIs. A type assertion is required:
 
-| Storage Backend | Implements TrackService |
-| --- | --- |
-| Memory (inmemory) | ✅ |
-| SQLite | ✅ |
-| Redis | ✅ |
-| PostgreSQL | ✅ |
-| PGVector | ✅ |
-| MySQL | ✅ |
-| MongoDB | ✅ |
-| ClickHouse | ❌ |
+| Storage Backend | Implements TrackService | Has GetTrackEvents |
+| --- | --- | --- |
+| Memory (inmemory) | ✅ | ✅ |
+| SQLite | ✅ | ✅ |
+| Redis | ✅ | ✅ |
+| PostgreSQL | ✅ | ✅ |
+| PGVector | ✅ | ✅ |
+| MySQL | ✅ | ✅ |
+| MongoDB | ✅ | ✅ |
+| ClickHouse | ❌ | ❌ |
 
 **Basic usage**:
 
@@ -725,9 +729,25 @@ err := trackService.AppendTrackEvent(ctx, sess, &session.TrackEvent{
     Timestamp: time.Now(),
 })
 
-// Retrieve track events from session
-trackEvents, err := sess.GetTrackEvents("ui-events")
+// Retrieve persisted track events directly when supported
+type trackEventReader interface {
+    GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
+}
+reader, ok := sessionService.(trackEventReader)
+if !ok {
+    log.Fatal("current storage backend does not expose GetTrackEvents")
+}
+trackEvents, err := reader.GetTrackEvents(ctx, session.Key{
+    AppName:   sess.AppName,
+    UserID:    sess.UserID,
+    SessionID: sess.ID,
+}, "ui-events")
 ```
+
+`Session.GetTrackEvents` reads only the track events already loaded into a
+session snapshot. Use the backend `GetTrackEvents` method for persisted history
+views such as AG-UI history, because it reads the track storage directly and
+does not depend on the session state's track index.
 
 ## Semantic Recall (PGVector Only)
 

--- a/docs/mkdocs/en/session/index.md
+++ b/docs/mkdocs/en/session/index.md
@@ -359,7 +359,8 @@ Supports setting Time To Live for session data with automatic cleanup of expired
 
 - **SessionTTL**: Expiration time for session state and events
 - **TrackEventTTL**: Expiration time for track events where supported. Defaults
-  to SessionTTL unless configured; setting it to `0` disables track event expiry
+  to SessionTTL unless configured; setting it to a non-positive value disables
+  track event expiry
 - **AppStateTTL**: Expiration time for app-level state
 - **UserStateTTL**: Expiration time for user-level state
 
@@ -729,14 +730,14 @@ err := trackService.AppendTrackEvent(ctx, sess, &session.TrackEvent{
     Timestamp: time.Now(),
 })
 
-// Read track events already loaded in the session snapshot
+// Read track events from this in-memory session snapshot
 trackEvents, err := sess.GetTrackEvents("ui-events")
 ```
 
 `Session.GetTrackEvents` reads only the track events already loaded into a
-session snapshot. AG-UI history uses persisted track history internally when the
-configured session service supports it, and falls back to the session snapshot
-otherwise.
+session object. Reload the session before treating it as a history snapshot.
+AG-UI history uses persisted track history internally when the configured
+session service supports it, and falls back to the session snapshot otherwise.
 
 ## Semantic Recall (PGVector Only)
 

--- a/docs/mkdocs/en/session/mongodb.md
+++ b/docs/mkdocs/en/session/mongodb.md
@@ -40,7 +40,7 @@ state and append history in one transaction.
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session in context-window mode |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Non-positive values disable track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | Event and track cleanup interval; defaults to 5 minutes if session or track event TTL is configured |

--- a/docs/mkdocs/en/session/mongodb.md
+++ b/docs/mkdocs/en/session/mongodb.md
@@ -40,9 +40,10 @@ state and append history in one transaction.
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session in context-window mode |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
-| `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | Event and track cleanup interval; defaults to 5 minutes if session TTL is configured |
+| `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | Event and track cleanup interval; defaults to 5 minutes if session or track event TTL is configured |
 | `WithSoftDelete(enable bool)` | `bool` | `true` | Enable or disable soft delete |
 
 ### Async Persistence Configuration
@@ -123,10 +124,11 @@ sessionService, err := mongodb.NewService(
 Session state, app state, and user state use MongoDB TTL indexes on `expires_at`.
 Summaries do not have an independent TTL and follow the session lifecycle.
 
-Session events and track events intentionally do not use TTL indexes. They are
-cleaned by the service as whole session groups so a session's history does not
-partially disappear while the session is still active. Dedicated cleanup indexes
-on `updated_at` support these grouped cleanup scans.
+Session events and track events intentionally do not use TTL indexes. By default,
+they are cleaned by the service as whole session groups so a session's history
+does not partially disappear while the session is still active. If
+`WithTrackEventTTL` is configured, track events use that TTL independently.
+Dedicated cleanup indexes on `updated_at` support these cleanup scans.
 
 ## Storage Structure
 

--- a/docs/mkdocs/en/session/mysql.md
+++ b/docs/mkdocs/en/session/mysql.md
@@ -29,7 +29,7 @@ MySQL storage is suitable for production environments and applications requiring
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Non-positive values disable track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | TTL cleanup interval; defaults to 5 minutes if TTL is configured |

--- a/docs/mkdocs/en/session/mysql.md
+++ b/docs/mkdocs/en/session/mysql.md
@@ -29,6 +29,7 @@ MySQL storage is suitable for production environments and applications requiring
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | TTL cleanup interval; defaults to 5 minutes if TTL is configured |

--- a/docs/mkdocs/en/session/pgvector.md
+++ b/docs/mkdocs/en/session/pgvector.md
@@ -41,6 +41,7 @@ All regular PostgreSQL session capabilities still apply here: TTL cleanup, soft 
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | TTL cleanup interval; defaults to 5 minutes if any TTL is configured |

--- a/docs/mkdocs/en/session/pgvector.md
+++ b/docs/mkdocs/en/session/pgvector.md
@@ -41,7 +41,7 @@ All regular PostgreSQL session capabilities still apply here: TTL cleanup, soft 
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Non-positive values disable track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | TTL cleanup interval; defaults to 5 minutes if any TTL is configured |

--- a/docs/mkdocs/en/session/postgres.md
+++ b/docs/mkdocs/en/session/postgres.md
@@ -35,7 +35,7 @@ PostgreSQL storage is suitable for production environments and applications requ
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Non-positive values disable track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | TTL cleanup interval; defaults to 5 minutes if TTL is configured |

--- a/docs/mkdocs/en/session/postgres.md
+++ b/docs/mkdocs/en/session/postgres.md
@@ -35,6 +35,7 @@ PostgreSQL storage is suitable for production environments and applications requ
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | Session TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | Track event TTL. Passing `0` disables track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | App state TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | User state TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0` (auto) | TTL cleanup interval; defaults to 5 minutes if TTL is configured |

--- a/docs/mkdocs/en/session/redis.md
+++ b/docs/mkdocs/en/session/redis.md
@@ -28,7 +28,7 @@ Redis storage is suitable for production environments and distributed applicatio
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | TTL for session state and events; negative values are treated as 0 |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | TTL for track events. Passing `0` disables track event expiry |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | TTL for track events. Non-positive values disable track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | TTL for app-level state |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | TTL for user-level state |
 | `WithKeyPrefix(prefix string)` | `string` | `""` | Redis key prefix; all keys will start with `prefix:`. Useful when multiple apps share one Redis instance |

--- a/docs/mkdocs/en/session/redis.md
+++ b/docs/mkdocs/en/session/redis.md
@@ -6,7 +6,7 @@ Redis storage is suitable for production environments and distributed applicatio
 
 - Redis-based persistence for sessions, events, and state
 - Supports Redis Standalone / Sentinel / Cluster deployment modes
-- Independent TTL control for Session, AppState, and UserState
+- Independent TTL control for Session, TrackEvent, AppState, and UserState
 - Optional async persistence to reduce write latency
 - Optional OpenTelemetry tracing
 - Async session summary generation
@@ -28,6 +28,7 @@ Redis storage is suitable for production environments and distributed applicatio
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | Maximum events per session |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | TTL for session state and events; negative values are treated as 0 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | Inherits SessionTTL | TTL for track events. Passing `0` disables track event expiry |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | TTL for app-level state |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0` (no expiry) | TTL for user-level state |
 | `WithKeyPrefix(prefix string)` | `string` | `""` | Redis key prefix; all keys will start with `prefix:`. Useful when multiple apps share one Redis instance |

--- a/docs/mkdocs/en/session/sqlite.md
+++ b/docs/mkdocs/en/session/sqlite.md
@@ -48,7 +48,8 @@ defer sessionService.Close()
 
 ## Configuration Options
 
-- **TTL and cleanup**: `WithSessionTTL`, `WithTrackEventTTL`,
+- **TTL and cleanup**: `WithSessionTTL`, `WithTrackEventTTL` (inherits
+  `SessionTTL`; non-positive values disable track event expiry),
   `WithAppStateTTL`, `WithUserStateTTL`, `WithCleanupInterval`
 - **Retention**: `WithSessionEventLimit`
 - **Persistence**: `WithEnableAsyncPersist`, `WithAsyncPersisterNum`

--- a/docs/mkdocs/en/session/sqlite.md
+++ b/docs/mkdocs/en/session/sqlite.md
@@ -48,8 +48,8 @@ defer sessionService.Close()
 
 ## Configuration Options
 
-- **TTL and cleanup**: `WithSessionTTL`, `WithAppStateTTL`, `WithUserStateTTL`,
-  `WithCleanupInterval`
+- **TTL and cleanup**: `WithSessionTTL`, `WithTrackEventTTL`,
+  `WithAppStateTTL`, `WithUserStateTTL`, `WithCleanupInterval`
 - **Retention**: `WithSessionEventLimit`
 - **Persistence**: `WithEnableAsyncPersist`, `WithAsyncPersisterNum`
 - **Soft delete**: `WithSoftDelete` (default is enabled)

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -699,9 +699,8 @@ Track 事件是 Session 中独立于主对话事件的轨迹存储机制，目�
 
 **接口说明**：
 
-Track 事件写入定义在可选的 `session.TrackService` 接口上。支持持久化
-Track 历史读取的存储后端，会在各自的具体 service 类型上暴露
-`GetTrackEvents` 方法。
+Track 事件写入定义在可选的 `session.TrackService` 接口上。支持 Track
+历史的存储后端会随 session 数据持久化这些事件。
 
 ```go
 type TrackService interface {
@@ -709,18 +708,18 @@ type TrackService interface {
 }
 ```
 
-并非所有存储后端都实现了 Track event API。使用时需要通过类型断言获取：
+并非所有存储后端都实现了 Track event 写入。使用时需要通过类型断言获取：
 
-| 存储后端 | 是否实现 TrackService | 是否有 GetTrackEvents |
-| --- | --- | --- |
-| 内存存储（inmemory） | ✅ | ✅ |
-| SQLite | ✅ | ✅ |
-| Redis 存储 | ✅ | ✅ |
-| PostgreSQL 存储 | ✅ | ✅ |
-| PGVector | ✅ | ✅ |
-| MySQL 存储 | ✅ | ✅ |
-| MongoDB 存储 | ✅ | ✅ |
-| ClickHouse 存储 | ❌ | ❌ |
+| 存储后端 | 是否实现 TrackService |
+| --- | --- |
+| 内存存储（inmemory） | ✅ |
+| SQLite | ✅ |
+| Redis 存储 | ✅ |
+| PostgreSQL 存储 | ✅ |
+| PGVector | ✅ |
+| MySQL 存储 | ✅ |
+| MongoDB 存储 | ✅ |
+| ClickHouse 存储 | ❌ |
 
 **基本用法**：
 
@@ -739,25 +738,13 @@ err := trackService.AppendTrackEvent(ctx, sess, &session.TrackEvent{
     Timestamp: time.Now(),
 })
 
-// 支持时，直接读取持久化 Track 事件
-type trackEventReader interface {
-    GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
-}
-reader, ok := sessionService.(trackEventReader)
-if !ok {
-    log.Fatal("当前存储后端未暴露 GetTrackEvents")
-}
-trackEvents, err := reader.GetTrackEvents(ctx, session.Key{
-    AppName:   sess.AppName,
-    UserID:    sess.UserID,
-    SessionID: sess.ID,
-}, "ui-events")
+// 读取已经加载到 session 快照中的 Track 事件
+trackEvents, err := sess.GetTrackEvents("ui-events")
 ```
 
 `Session.GetTrackEvents` 只读取已经加载到 session 快照中的 Track 事件。
-AG-UI 历史记录这类持久化历史视图应优先使用
-backend 的 `GetTrackEvents` 方法，因为它直接读取 Track 存储，不依赖
-session state 中的 track 索引。
+AG-UI 历史记录会在配置的 session service 支持时内部使用持久化 Track
+历史，否则回退到 session 快照。
 
 ## 语义召回（仅 PGVector）
 

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -360,7 +360,7 @@ sessionService := inmemory.NewSessionService(
 **支持的 TTL 类型：**
 
 - **SessionTTL**：会话状态和事件的过期时间
-- **TrackEventTTL**：支持的存储后端中 Track event 的过期时间。默认继承 SessionTTL，显式设置为 `0` 表示 Track event 不过期
+- **TrackEventTTL**：支持的存储后端中 Track event 的过期时间。默认继承 SessionTTL，显式设置为非正数表示 Track event 不过期
 - **AppStateTTL**：应用级状态的过期时间
 - **UserStateTTL**：用户级状态的过期时间
 
@@ -738,13 +738,13 @@ err := trackService.AppendTrackEvent(ctx, sess, &session.TrackEvent{
     Timestamp: time.Now(),
 })
 
-// 读取已经加载到 session 快照中的 Track 事件
+// 读取当前内存中 session 快照里的 Track 事件
 trackEvents, err := sess.GetTrackEvents("ui-events")
 ```
 
 `Session.GetTrackEvents` 只读取已经加载到 session 快照中的 Track 事件。
-AG-UI 历史记录会在配置的 session service 支持时内部使用持久化 Track
-历史，否则回退到 session 快照。
+把 session 当作历史快照使用前，需要先重新加载 session。AG-UI 历史记录会在配置的
+session service 支持时内部使用持久化 Track 历史，否则回退到 session 快照。
 
 ## 语义召回（仅 PGVector）
 

--- a/docs/mkdocs/zh/session/index.md
+++ b/docs/mkdocs/zh/session/index.md
@@ -360,6 +360,7 @@ sessionService := inmemory.NewSessionService(
 **支持的 TTL 类型：**
 
 - **SessionTTL**：会话状态和事件的过期时间
+- **TrackEventTTL**：支持的存储后端中 Track event 的过期时间。默认继承 SessionTTL，显式设置为 `0` 表示 Track event 不过期
 - **AppStateTTL**：应用级状态的过期时间
 - **UserStateTTL**：用户级状态的过期时间
 
@@ -698,7 +699,9 @@ Track 事件是 Session 中独立于主对话事件的轨迹存储机制，目�
 
 **接口说明**：
 
-Track 事件的 API 定义在 `session.TrackService` 接口上，它独立于 `session.Service`：
+Track 事件写入定义在可选的 `session.TrackService` 接口上。支持持久化
+Track 历史读取的存储后端，会在各自的具体 service 类型上暴露
+`GetTrackEvents` 方法。
 
 ```go
 type TrackService interface {
@@ -706,18 +709,18 @@ type TrackService interface {
 }
 ```
 
-并非所有存储后端都实现了 `TrackService`。使用时需要通过类型断言获取：
+并非所有存储后端都实现了 Track event API。使用时需要通过类型断言获取：
 
-| 存储后端 | 是否实现 TrackService |
-| --- | --- |
-| 内存存储（inmemory） | ✅ |
-| SQLite | ✅ |
-| Redis 存储 | ✅ |
-| PostgreSQL 存储 | ✅ |
-| PGVector | ✅ |
-| MySQL 存储 | ✅ |
-| MongoDB 存储 | ✅ |
-| ClickHouse 存储 | ❌ |
+| 存储后端 | 是否实现 TrackService | 是否有 GetTrackEvents |
+| --- | --- | --- |
+| 内存存储（inmemory） | ✅ | ✅ |
+| SQLite | ✅ | ✅ |
+| Redis 存储 | ✅ | ✅ |
+| PostgreSQL 存储 | ✅ | ✅ |
+| PGVector | ✅ | ✅ |
+| MySQL 存储 | ✅ | ✅ |
+| MongoDB 存储 | ✅ | ✅ |
+| ClickHouse 存储 | ❌ | ❌ |
 
 **基本用法**：
 
@@ -736,9 +739,25 @@ err := trackService.AppendTrackEvent(ctx, sess, &session.TrackEvent{
     Timestamp: time.Now(),
 })
 
-// 从会话中获取 Track 事件
-trackEvents, err := sess.GetTrackEvents("ui-events")
+// 支持时，直接读取持久化 Track 事件
+type trackEventReader interface {
+    GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
+}
+reader, ok := sessionService.(trackEventReader)
+if !ok {
+    log.Fatal("当前存储后端未暴露 GetTrackEvents")
+}
+trackEvents, err := reader.GetTrackEvents(ctx, session.Key{
+    AppName:   sess.AppName,
+    UserID:    sess.UserID,
+    SessionID: sess.ID,
+}, "ui-events")
 ```
+
+`Session.GetTrackEvents` 只读取已经加载到 session 快照中的 Track 事件。
+AG-UI 历史记录这类持久化历史视图应优先使用
+backend 的 `GetTrackEvents` 方法，因为它直接读取 Track 存储，不依赖
+session state 中的 track 索引。
 
 ## 语义召回（仅 PGVector）
 

--- a/docs/mkdocs/zh/session/mongodb.md
+++ b/docs/mkdocs/zh/session/mongodb.md
@@ -35,7 +35,7 @@ MongoDB 会话存储要求部署支持多文档事务，例如副本集或分片
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | context-window 模式下每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。非正数表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | 事件和 Track 清理间隔，默认 5 分钟（如果配置了会话或 Track event TTL） |

--- a/docs/mkdocs/zh/session/mongodb.md
+++ b/docs/mkdocs/zh/session/mongodb.md
@@ -35,9 +35,10 @@ MongoDB 会话存储要求部署支持多文档事务，例如副本集或分片
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | context-window 模式下每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
-| `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | 事件和 Track 清理间隔，默认 5 分钟（如果配置了会话 TTL） |
+| `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | 事件和 Track 清理间隔，默认 5 分钟（如果配置了会话或 Track event TTL） |
 | `WithSoftDelete(enable bool)` | `bool` | `true` | 启用或禁用软删除 |
 
 ### 异步持久化配置
@@ -116,7 +117,7 @@ sessionService, err := mongodb.NewService(
 
 会话状态、应用状态和用户状态使用 MongoDB `expires_at` TTL 索引。摘要不设置独立 TTL，跟随会话生命周期。
 
-Session events 和 track events 不使用 TTL 索引。它们由服务按会话维度整组清理，避免仍然活跃的会话历史被局部删除，并通过 `updated_at` cleanup 索引支撑分组清理扫描。
+Session events 和 track events 不使用 TTL 索引。默认情况下，它们由服务按会话维度整组清理，避免仍然活跃的会话历史被局部删除。配置 `WithTrackEventTTL` 后，track events 使用该 TTL 独立清理，并通过 `updated_at` cleanup 索引支撑清理扫描。
 
 ## 存储结构
 

--- a/docs/mkdocs/zh/session/mysql.md
+++ b/docs/mkdocs/zh/session/mysql.md
@@ -29,7 +29,7 @@ MySQL 存储适用于生产环境和需要复杂查询的应用，MySQL 是广�
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。非正数表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | TTL 清理间隔，默认 5 分钟（如果配置了 TTL） |

--- a/docs/mkdocs/zh/session/mysql.md
+++ b/docs/mkdocs/zh/session/mysql.md
@@ -29,6 +29,7 @@ MySQL 存储适用于生产环境和需要复杂查询的应用，MySQL 是广�
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | TTL 清理间隔，默认 5 分钟（如果配置了 TTL） |

--- a/docs/mkdocs/zh/session/pgvector.md
+++ b/docs/mkdocs/zh/session/pgvector.md
@@ -41,7 +41,7 @@ PGVector 会话存储基于 `session/postgres` 扩展，在常规 PostgreSQL Ses
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。非正数表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | TTL 清理间隔；只要配置了任意 TTL，默认会回落到 5 分钟 |

--- a/docs/mkdocs/zh/session/pgvector.md
+++ b/docs/mkdocs/zh/session/pgvector.md
@@ -41,6 +41,7 @@ PGVector 会话存储基于 `session/postgres` 扩展，在常规 PostgreSQL Ses
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | TTL 清理间隔；只要配置了任意 TTL，默认会回落到 5 分钟 |

--- a/docs/mkdocs/zh/session/postgres.md
+++ b/docs/mkdocs/zh/session/postgres.md
@@ -35,6 +35,7 @@ PostgreSQL 存储适用于生产环境和需要复杂查询的应用，提供关
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | TTL 清理间隔，默认 5 分钟（如果配置了 TTL） |

--- a/docs/mkdocs/zh/session/postgres.md
+++ b/docs/mkdocs/zh/session/postgres.md
@@ -35,7 +35,7 @@ PostgreSQL 存储适用于生产环境和需要复杂查询的应用，提供关
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话 TTL |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。非正数表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用状态 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户状态 TTL |
 | `WithCleanupInterval(interval time.Duration)` | `time.Duration` | `0`（自动确定） | TTL 清理间隔，默认 5 分钟（如果配置了 TTL） |

--- a/docs/mkdocs/zh/session/redis.md
+++ b/docs/mkdocs/zh/session/redis.md
@@ -28,7 +28,7 @@ Redis 存储适用于生产环境和分布式应用，提供高性能和自动�
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话存储的最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话状态和事件的 TTL，负值等同于 0 |
-| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。非正数表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用级状态的 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户级状态的 TTL |
 | `WithKeyPrefix(prefix string)` | `string` | `""` | Redis key 前缀，所有 key 将以 `prefix:` 开头。适用于多应用共享同一 Redis 实例的场景 |

--- a/docs/mkdocs/zh/session/redis.md
+++ b/docs/mkdocs/zh/session/redis.md
@@ -6,7 +6,7 @@ Redis 存储适用于生产环境和分布式应用，提供高性能和自动�
 
 - 基于 Redis 的会话、事件、状态持久化存储
 - 支持 Redis Standalone / Sentinel / Cluster 部署模式
-- Session、AppState、UserState 独立 TTL 控制
+- Session、TrackEvent、AppState、UserState 独立 TTL 控制
 - 异步持久化（可选），降低写入延迟
 - OpenTelemetry 链路追踪（可选）
 - 会话摘要（Summary）异步生成
@@ -28,6 +28,7 @@ Redis 存储适用于生产环境和分布式应用，提供高性能和自动�
 | --- | --- | --- | --- |
 | `WithSessionEventLimit(limit int)` | `int` | `1000` | 每个会话存储的最大事件数量 |
 | `WithSessionTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 会话状态和事件的 TTL，负值等同于 0 |
+| `WithTrackEventTTL(ttl time.Duration)` | `time.Duration` | 继承 SessionTTL | Track event TTL。传入 `0` 表示 Track event 不过期 |
 | `WithAppStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 应用级状态的 TTL |
 | `WithUserStateTTL(ttl time.Duration)` | `time.Duration` | `0`（不过期） | 用户级状态的 TTL |
 | `WithKeyPrefix(prefix string)` | `string` | `""` | Redis key 前缀，所有 key 将以 `prefix:` 开头。适用于多应用共享同一 Redis 实例的场景 |

--- a/docs/mkdocs/zh/session/sqlite.md
+++ b/docs/mkdocs/zh/session/sqlite.md
@@ -45,7 +45,7 @@ defer sessionService.Close()
 
 ## 配置选项
 
-- TTL 与清理：`WithSessionTTL`、`WithTrackEventTTL`、`WithAppStateTTL`、`WithUserStateTTL`、`WithCleanupInterval`
+- TTL 与清理：`WithSessionTTL`、`WithTrackEventTTL`（默认继承 SessionTTL，非正数表示 Track event 不过期）、`WithAppStateTTL`、`WithUserStateTTL`、`WithCleanupInterval`
 - 保留策略：`WithSessionEventLimit`
 - 异步持久化：`WithEnableAsyncPersist`、`WithAsyncPersisterNum`
 - 软删除：`WithSoftDelete`（默认开启）

--- a/docs/mkdocs/zh/session/sqlite.md
+++ b/docs/mkdocs/zh/session/sqlite.md
@@ -45,7 +45,7 @@ defer sessionService.Close()
 
 ## 配置选项
 
-- TTL 与清理：`WithSessionTTL`、`WithAppStateTTL`、`WithUserStateTTL`、`WithCleanupInterval`
+- TTL 与清理：`WithSessionTTL`、`WithTrackEventTTL`、`WithAppStateTTL`、`WithUserStateTTL`、`WithCleanupInterval`
 - 保留策略：`WithSessionEventLimit`
 - 异步持久化：`WithEnableAsyncPersist`、`WithAsyncPersisterNum`
 - 软删除：`WithSoftDelete`（默认开启）

--- a/internal/session/externalization/service.go
+++ b/internal/session/externalization/service.go
@@ -181,6 +181,28 @@ func (s *searchableWindowTrackService) GetEventWindow(
 	return s.Service.getEventWindow(ctx, s.WindowService, req)
 }
 
+type searchableWindowTrackReaderService struct {
+	*Service
+	session.SearchableService
+	session.WindowService
+	session.TrackService
+	trackEventReader
+}
+
+func (s *searchableWindowTrackReaderService) SearchEvents(
+	ctx context.Context,
+	req session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return s.Service.searchEvents(ctx, s.SearchableService, req)
+}
+
+func (s *searchableWindowTrackReaderService) GetEventWindow(
+	ctx context.Context,
+	req session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return s.Service.getEventWindow(ctx, s.WindowService, req)
+}
+
 type searchableTrackReaderService struct {
 	*Service
 	session.SearchableService
@@ -250,6 +272,14 @@ func wrapTrackOptionalInterfaces(
 	hasReader bool,
 ) session.Service {
 	switch {
+	case hasSearch && hasWindow && hasReader:
+		return &searchableWindowTrackReaderService{
+			Service:           base,
+			SearchableService: searchable,
+			WindowService:     window,
+			TrackService:      track,
+			trackEventReader:  reader,
+		}
 	case hasSearch && hasWindow:
 		return &searchableWindowTrackService{
 			Service:           base,

--- a/internal/session/externalization/service.go
+++ b/internal/session/externalization/service.go
@@ -104,6 +104,10 @@ type trackService struct {
 	session.TrackService
 }
 
+type trackEventReader interface {
+	GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
+}
+
 type searchableWindowService struct {
 	*Service
 	session.SearchableService
@@ -150,6 +154,12 @@ func (s *windowTrackService) GetEventWindow(
 	return s.Service.getEventWindow(ctx, s.WindowService, req)
 }
 
+type trackReaderService struct {
+	*Service
+	session.TrackService
+	trackEventReader
+}
+
 type searchableWindowTrackService struct {
 	*Service
 	session.SearchableService
@@ -171,35 +181,48 @@ func (s *searchableWindowTrackService) GetEventWindow(
 	return s.Service.getEventWindow(ctx, s.WindowService, req)
 }
 
+type searchableTrackReaderService struct {
+	*Service
+	session.SearchableService
+	session.TrackService
+	trackEventReader
+}
+
+func (s *searchableTrackReaderService) SearchEvents(
+	ctx context.Context,
+	req session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return s.Service.searchEvents(ctx, s.SearchableService, req)
+}
+
+type windowTrackReaderService struct {
+	*Service
+	session.WindowService
+	session.TrackService
+	trackEventReader
+}
+
+func (s *windowTrackReaderService) GetEventWindow(
+	ctx context.Context,
+	req session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return s.Service.getEventWindow(ctx, s.WindowService, req)
+}
+
 func wrapOptionalInterfaces(base *Service, inner session.Service) session.Service {
 	searchable, hasSearch := inner.(session.SearchableService)
 	window, hasWindow := inner.(session.WindowService)
 	track, hasTrack := inner.(session.TrackService)
+	reader, hasReader := inner.(trackEventReader)
+	if hasTrack {
+		return wrapTrackOptionalInterfaces(base, searchable, hasSearch, window, hasWindow, track, reader, hasReader)
+	}
 	switch {
-	case hasSearch && hasWindow && hasTrack:
-		return &searchableWindowTrackService{
-			Service:           base,
-			SearchableService: searchable,
-			WindowService:     window,
-			TrackService:      track,
-		}
 	case hasSearch && hasWindow:
 		return &searchableWindowService{
 			Service:           base,
 			SearchableService: searchable,
 			WindowService:     window,
-		}
-	case hasSearch && hasTrack:
-		return &searchableTrackService{
-			Service:           base,
-			SearchableService: searchable,
-			TrackService:      track,
-		}
-	case hasWindow && hasTrack:
-		return &windowTrackService{
-			Service:       base,
-			WindowService: window,
-			TrackService:  track,
 		}
 	case hasSearch:
 		return &searchableService{
@@ -211,13 +234,66 @@ func wrapOptionalInterfaces(base *Service, inner session.Service) session.Servic
 			Service:       base,
 			WindowService: window,
 		}
-	case hasTrack:
+	default:
+		return base
+	}
+}
+
+func wrapTrackOptionalInterfaces(
+	base *Service,
+	searchable session.SearchableService,
+	hasSearch bool,
+	window session.WindowService,
+	hasWindow bool,
+	track session.TrackService,
+	reader trackEventReader,
+	hasReader bool,
+) session.Service {
+	switch {
+	case hasSearch && hasWindow:
+		return &searchableWindowTrackService{
+			Service:           base,
+			SearchableService: searchable,
+			WindowService:     window,
+			TrackService:      track,
+		}
+	case hasSearch && hasReader:
+		return &searchableTrackReaderService{
+			Service:           base,
+			SearchableService: searchable,
+			TrackService:      track,
+			trackEventReader:  reader,
+		}
+	case hasSearch:
+		return &searchableTrackService{
+			Service:           base,
+			SearchableService: searchable,
+			TrackService:      track,
+		}
+	case hasWindow && hasReader:
+		return &windowTrackReaderService{
+			Service:          base,
+			WindowService:    window,
+			TrackService:     track,
+			trackEventReader: reader,
+		}
+	case hasWindow:
+		return &windowTrackService{
+			Service:       base,
+			WindowService: window,
+			TrackService:  track,
+		}
+	case hasReader:
+		return &trackReaderService{
+			Service:          base,
+			TrackService:     track,
+			trackEventReader: reader,
+		}
+	default:
 		return &trackService{
 			Service:      base,
 			TrackService: track,
 		}
-	default:
-		return base
 	}
 }
 

--- a/internal/session/externalization/service_test.go
+++ b/internal/session/externalization/service_test.go
@@ -832,6 +832,17 @@ func TestWrapOptionalInterfaceCombinationMethods(t *testing.T) {
 				behavior: &optionalBehavior{window: windowResult},
 			},
 		},
+		{
+			name:       "search window track reader",
+			wantSearch: true,
+			wantWindow: true,
+			wantTrack:  true,
+			wantReader: true,
+			inner: &searchWindowTrackReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{results: searchResults, window: windowResult},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1535,6 +1546,44 @@ func (s *windowTrackReaderOnlyService) AppendTrackEvent(
 }
 
 func (s *windowTrackReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type searchWindowTrackReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *searchWindowTrackReaderOnlyService) SearchEvents(
+	ctx context.Context,
+	req session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return s.behavior.results, nil
+}
+
+func (s *searchWindowTrackReaderOnlyService) GetEventWindow(
+	ctx context.Context,
+	req session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return s.behavior.window, nil
+}
+
+func (s *searchWindowTrackReaderOnlyService) AppendTrackEvent(
+	ctx context.Context,
+	sess *session.Session,
+	event *session.TrackEvent,
+	opts ...session.Option,
+) error {
+	s.behavior.trackCalled = true
+	return nil
+}
+
+func (s *searchWindowTrackReaderOnlyService) GetTrackEvents(
 	ctx context.Context,
 	key session.Key,
 	track session.Track,

--- a/internal/session/externalization/service_test.go
+++ b/internal/session/externalization/service_test.go
@@ -636,6 +636,9 @@ func TestWrapPreservesOptionalInterfaces(t *testing.T) {
 	if _, ok := wrapped.(session.TrackService); !ok {
 		t.Fatal("wrapped inmemory service does not implement TrackService")
 	}
+	if _, ok := wrapped.(trackEventReader); !ok {
+		t.Fatal("wrapped inmemory service does not implement track event reader")
+	}
 	if _, ok := wrapped.(session.WindowService); !ok {
 		t.Fatal("wrapped inmemory service does not implement WindowService")
 	}
@@ -678,6 +681,9 @@ func TestWrapPreservesOptionalInterfaces(t *testing.T) {
 	}
 	if _, ok := searchWrapped.(session.TrackService); ok {
 		t.Fatal("wrapped search-only service unexpectedly implements TrackService")
+	}
+	if _, ok := searchWrapped.(trackEventReader); ok {
+		t.Fatal("wrapped search-only service unexpectedly implements track event reader")
 	}
 	results, err := searchable.SearchEvents(ctx, session.EventSearchRequest{
 		UserKey: session.UserKey{AppName: key.AppName, UserID: key.UserID},
@@ -726,6 +732,7 @@ func TestWrapOptionalInterfaceCombinationMethods(t *testing.T) {
 		wantSearch bool
 		wantWindow bool
 		wantTrack  bool
+		wantReader bool
 	}{
 		{
 			name:       "search window",
@@ -764,6 +771,67 @@ func TestWrapOptionalInterfaceCombinationMethods(t *testing.T) {
 				behavior: &optionalBehavior{results: searchResults, window: windowResult},
 			},
 		},
+		{
+			name: "reader",
+			inner: &readerOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{},
+			},
+		},
+		{
+			name:       "search reader",
+			wantSearch: true,
+			inner: &searchReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{results: searchResults},
+			},
+		},
+		{
+			name:       "window reader",
+			wantWindow: true,
+			inner: &windowReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{window: windowResult},
+			},
+		},
+		{
+			name:       "track reader",
+			wantTrack:  true,
+			wantReader: true,
+			inner: &trackReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{},
+			},
+		},
+		{
+			name:       "search window reader",
+			wantSearch: true,
+			wantWindow: true,
+			inner: &searchWindowReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{results: searchResults, window: windowResult},
+			},
+		},
+		{
+			name:       "search track reader",
+			wantSearch: true,
+			wantTrack:  true,
+			wantReader: true,
+			inner: &searchTrackReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{results: searchResults},
+			},
+		},
+		{
+			name:       "window track reader",
+			wantWindow: true,
+			wantTrack:  true,
+			wantReader: true,
+			inner: &windowTrackReaderOnlyService{
+				Service:  sessionmem.NewSessionService(),
+				behavior: &optionalBehavior{window: windowResult},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -798,6 +866,17 @@ func TestWrapOptionalInterfaceCombinationMethods(t *testing.T) {
 			} else if ok {
 				if err := track.AppendTrackEvent(ctx, &session.Session{}, &session.TrackEvent{Track: "trace"}); err != nil {
 					t.Fatalf("AppendTrackEvent() error = %v", err)
+				}
+			}
+			if reader, ok := wrapped.(trackEventReader); ok != tt.wantReader {
+				t.Fatalf("trackEventReader ok = %v, want %v", ok, tt.wantReader)
+			} else if ok {
+				result, err := reader.GetTrackEvents(ctx, key, "trace")
+				if err != nil {
+					t.Fatalf("GetTrackEvents() error = %v", err)
+				}
+				if result == nil || result.Track != "trace" {
+					t.Fatalf("GetTrackEvents() = %#v, want trace track", result)
 				}
 			}
 		})
@@ -1292,6 +1371,176 @@ func (s *searchWindowTrackService) AppendTrackEvent(
 ) error {
 	s.behavior.trackCalled = true
 	return nil
+}
+
+type readerOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *readerOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type searchReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *searchReaderOnlyService) SearchEvents(
+	ctx context.Context,
+	req session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return s.behavior.results, nil
+}
+
+func (s *searchReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type windowReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *windowReaderOnlyService) GetEventWindow(
+	ctx context.Context,
+	req session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return s.behavior.window, nil
+}
+
+func (s *windowReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type trackReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *trackReaderOnlyService) AppendTrackEvent(
+	ctx context.Context,
+	sess *session.Session,
+	event *session.TrackEvent,
+	opts ...session.Option,
+) error {
+	s.behavior.trackCalled = true
+	return nil
+}
+
+func (s *trackReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type searchWindowReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *searchWindowReaderOnlyService) SearchEvents(
+	ctx context.Context,
+	req session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return s.behavior.results, nil
+}
+
+func (s *searchWindowReaderOnlyService) GetEventWindow(
+	ctx context.Context,
+	req session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return s.behavior.window, nil
+}
+
+func (s *searchWindowReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type searchTrackReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *searchTrackReaderOnlyService) SearchEvents(
+	ctx context.Context,
+	req session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return s.behavior.results, nil
+}
+
+func (s *searchTrackReaderOnlyService) AppendTrackEvent(
+	ctx context.Context,
+	sess *session.Session,
+	event *session.TrackEvent,
+	opts ...session.Option,
+) error {
+	s.behavior.trackCalled = true
+	return nil
+}
+
+func (s *searchTrackReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
+}
+
+type windowTrackReaderOnlyService struct {
+	session.Service
+	behavior *optionalBehavior
+}
+
+func (s *windowTrackReaderOnlyService) GetEventWindow(
+	ctx context.Context,
+	req session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return s.behavior.window, nil
+}
+
+func (s *windowTrackReaderOnlyService) AppendTrackEvent(
+	ctx context.Context,
+	sess *session.Session,
+	event *session.TrackEvent,
+	opts ...session.Option,
+) error {
+	s.behavior.trackCalled = true
+	return nil
+}
+
+func (s *windowTrackReaderOnlyService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	return &session.TrackEvents{Track: track}, nil
 }
 
 type loadArtifactService struct {

--- a/server/agui/internal/track/tracker.go
+++ b/server/agui/internal/track/tracker.go
@@ -38,6 +38,10 @@ type Tracker interface {
 	Close(ctx context.Context, key session.Key) error
 }
 
+type trackEventReader interface {
+	GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
+}
+
 // tracker is the implementation of the Tracker interface.
 type tracker struct {
 	sessionService    session.Service               // sessionService handles session lifecycle.
@@ -93,6 +97,13 @@ func (t *tracker) AppendEvent(ctx context.Context, key session.Key, event aguiev
 func (t *tracker) GetEvents(ctx context.Context, key session.Key, opts ...session.Option) (*session.TrackEvents, error) {
 	if err := key.CheckSessionKey(); err != nil {
 		return nil, fmt.Errorf("session key: %w", err)
+	}
+	if reader, ok := t.sessionService.(trackEventReader); ok {
+		trackEvents, err := reader.GetTrackEvents(ctx, key, TrackAGUI, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("get track events: %w", err)
+		}
+		return trackEvents, nil
 	}
 	sess, err := t.sessionService.GetSession(ctx, key, opts...)
 	if err != nil {

--- a/server/agui/internal/track/tracker_test.go
+++ b/server/agui/internal/track/tracker_test.go
@@ -175,6 +175,39 @@ func TestTrackerGetEventsForwardsOptions(t *testing.T) {
 	afterTime := time.Now().Add(-time.Hour)
 
 	var got *session.Options
+	var gotKey session.Key
+	var gotTrack session.Track
+	svc.getSessionFn = func(context.Context, session.Key, ...session.Option) (*session.Session, error) {
+		return nil, errors.New("get session should not be called")
+	}
+	svc.getTrackEventsFn = func(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error) {
+		opt := &session.Options{}
+		for _, o := range opts {
+			o(opt)
+		}
+		got = opt
+		gotKey = key
+		gotTrack = track
+		return &session.TrackEvents{Track: track}, nil
+	}
+
+	tracker, err := New(svc)
+	require.NoError(t, err)
+
+	_, err = tracker.GetEvents(ctx, key, session.WithEventTime(afterTime))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.EventTime.Equal(afterTime))
+	require.Equal(t, key, gotKey)
+	require.Equal(t, TrackAGUI, gotTrack)
+}
+
+func TestTrackerGetEventsFallbackForwardsOptions(t *testing.T) {
+	ctx := context.Background()
+	svc := newTrackOnlyHookService()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	afterTime := time.Now().Add(-time.Hour)
+	var got *session.Options
 	svc.getSessionFn = func(ctx context.Context, key session.Key, opts ...session.Option) (*session.Session, error) {
 		opt := &session.Options{}
 		for _, o := range opts {
@@ -182,14 +215,11 @@ func TestTrackerGetEventsForwardsOptions(t *testing.T) {
 		}
 		got = opt
 		sess := session.NewSession(key.AppName, key.UserID, key.SessionID)
-		// Ensure the AG-UI track exists so that GetTrackEvents succeeds.
 		require.NoError(t, sess.AppendTrackEvent(&session.TrackEvent{Track: TrackAGUI, Timestamp: time.Now()}))
 		return sess, nil
 	}
-
 	tracker, err := New(svc)
 	require.NoError(t, err)
-
 	_, err = tracker.GetEvents(ctx, key, session.WithEventTime(afterTime))
 	require.NoError(t, err)
 	require.NotNil(t, got)
@@ -274,7 +304,7 @@ func TestTrackerGetEventsErrors(t *testing.T) {
 	require.ErrorContains(t, err, "session key")
 
 	t.Run("get session error", func(t *testing.T) {
-		svc := newHookSessionService()
+		svc := newTrackOnlyHookService()
 		svc.getSessionFn = func(context.Context, session.Key, ...session.Option) (*session.Session, error) {
 			return nil, errors.New("nope")
 		}
@@ -285,7 +315,7 @@ func TestTrackerGetEventsErrors(t *testing.T) {
 	})
 
 	t.Run("session not found", func(t *testing.T) {
-		svc := newHookSessionService()
+		svc := newTrackOnlyHookService()
 		svc.getSessionFn = func(context.Context, session.Key, ...session.Option) (*session.Session, error) {
 			return nil, nil
 		}
@@ -296,7 +326,7 @@ func TestTrackerGetEventsErrors(t *testing.T) {
 	})
 
 	t.Run("track events error", func(t *testing.T) {
-		svc := newHookSessionService()
+		svc := newTrackOnlyHookService()
 		svc.getSessionFn = func(context.Context, session.Key, ...session.Option) (*session.Session, error) {
 			return &session.Session{
 				AppName: validKey.AppName,
@@ -308,6 +338,16 @@ func TestTrackerGetEventsErrors(t *testing.T) {
 		require.NoError(t, err)
 		_, err = tracker.GetEvents(ctx, validKey)
 		require.ErrorContains(t, err, "tracks is empty")
+	})
+	t.Run("reader error", func(t *testing.T) {
+		svc := newHookSessionService()
+		svc.getTrackEventsFn = func(context.Context, session.Key, session.Track, ...session.Option) (*session.TrackEvents, error) {
+			return nil, errors.New("reader failed")
+		}
+		tracker, err := New(svc)
+		require.NoError(t, err)
+		_, err = tracker.GetEvents(ctx, validKey)
+		require.ErrorContains(t, err, "get track events: reader failed")
 	})
 }
 
@@ -581,9 +621,10 @@ func (s *stubAggregator) Flush(ctx context.Context) ([]aguievents.Event, error) 
 
 type hookSessionService struct {
 	*inmemory.SessionService
-	getSessionFn    func(context.Context, session.Key, ...session.Option) (*session.Session, error)
-	createSessionFn func(context.Context, session.Key, session.StateMap, ...session.Option) (*session.Session, error)
-	appendTrackFn   func(context.Context, *session.Session, *session.TrackEvent, ...session.Option) error
+	getSessionFn     func(context.Context, session.Key, ...session.Option) (*session.Session, error)
+	createSessionFn  func(context.Context, session.Key, session.StateMap, ...session.Option) (*session.Session, error)
+	appendTrackFn    func(context.Context, *session.Session, *session.TrackEvent, ...session.Option) error
+	getTrackEventsFn func(context.Context, session.Key, session.Track, ...session.Option) (*session.TrackEvents, error)
 }
 
 func newHookSessionService() *hookSessionService {
@@ -609,6 +650,46 @@ func (s *hookSessionService) AppendTrackEvent(ctx context.Context, sess *session
 		return s.appendTrackFn(ctx, sess, evt, opts...)
 	}
 	return s.SessionService.AppendTrackEvent(ctx, sess, evt, opts...)
+}
+
+func (s *hookSessionService) GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error) {
+	if s.getTrackEventsFn != nil {
+		return s.getTrackEventsFn(ctx, key, track, opts...)
+	}
+	return s.SessionService.GetTrackEvents(ctx, key, track, opts...)
+}
+
+type trackOnlyHookService struct {
+	serviceWithoutTrack
+	store           *inmemory.SessionService
+	getSessionFn    func(context.Context, session.Key, ...session.Option) (*session.Session, error)
+	createSessionFn func(context.Context, session.Key, session.StateMap, ...session.Option) (*session.Session, error)
+	appendTrackFn   func(context.Context, *session.Session, *session.TrackEvent, ...session.Option) error
+}
+
+func newTrackOnlyHookService() *trackOnlyHookService {
+	return &trackOnlyHookService{store: inmemory.NewSessionService()}
+}
+
+func (s *trackOnlyHookService) GetSession(ctx context.Context, key session.Key, opts ...session.Option) (*session.Session, error) {
+	if s.getSessionFn != nil {
+		return s.getSessionFn(ctx, key, opts...)
+	}
+	return s.store.GetSession(ctx, key, opts...)
+}
+
+func (s *trackOnlyHookService) CreateSession(ctx context.Context, key session.Key, state session.StateMap, opts ...session.Option) (*session.Session, error) {
+	if s.createSessionFn != nil {
+		return s.createSessionFn(ctx, key, state, opts...)
+	}
+	return s.store.CreateSession(ctx, key, state, opts...)
+}
+
+func (s *trackOnlyHookService) AppendTrackEvent(ctx context.Context, sess *session.Session, evt *session.TrackEvent, opts ...session.Option) error {
+	if s.appendTrackFn != nil {
+		return s.appendTrackFn(ctx, sess, evt, opts...)
+	}
+	return s.store.AppendTrackEvent(ctx, sess, evt, opts...)
 }
 
 type failingEvent struct {

--- a/session/inmemory/service.go
+++ b/session/inmemory/service.go
@@ -12,6 +12,7 @@ package inmemory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -880,6 +881,34 @@ func (s *SessionService) AppendTrackEvent(
 	storedSessionWithTTL.session = storedSession
 	storedSessionWithTTL.expiredAt = calculateExpiredAt(s.opts.sessionTTL)
 	return nil
+}
+
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *SessionService) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	sess, err := s.GetSession(ctx, key, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if sess == nil {
+		return &session.TrackEvents{Track: track}, nil
+	}
+	trackEvents, err := sess.GetTrackEvents(track)
+	if errors.Is(err, session.ErrTracksEmpty) ||
+		errors.Is(err, session.ErrTrackEventsNotFound) {
+		return &session.TrackEvents{Track: track}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return trackEvents, nil
 }
 
 // cleanupExpired removes all expired sessions and states.

--- a/session/inmemory/service_test.go
+++ b/session/inmemory/service_test.go
@@ -1492,6 +1492,67 @@ func TestSessionServiceGetSessionFiltersTrackEvents(t *testing.T) {
 	})
 }
 
+func TestSessionServiceGetTrackEvents(t *testing.T) {
+	service := NewSessionService()
+	defer service.Close()
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "track-app",
+		UserID:    "track-user",
+		SessionID: "track-session",
+	}
+	sess, err := service.CreateSession(ctx, key, session.StateMap{})
+	require.NoError(t, err)
+	base := time.Now().Add(-time.Hour)
+	require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"a1"`),
+		Timestamp: base,
+	}))
+	require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"a2"`),
+		Timestamp: base.Add(time.Second),
+	}))
+	got, err := service.GetTrackEvents(ctx, key, "alpha", session.WithEventNum(1))
+	require.NoError(t, err)
+	require.Equal(t, session.Track("alpha"), got.Track)
+	require.Len(t, got.Events, 1)
+	assert.Equal(t, json.RawMessage(`"a2"`), got.Events[0].Payload)
+	got, err = service.GetTrackEvents(ctx, key, "alpha", session.WithEventTime(base.Add(time.Second)))
+	require.NoError(t, err)
+	require.Len(t, got.Events, 1)
+	assert.Equal(t, json.RawMessage(`"a2"`), got.Events[0].Payload)
+	missing, err := service.GetTrackEvents(ctx, key, "missing")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("missing"), missing.Track)
+	require.Empty(t, missing.Events)
+}
+
+func TestSessionServiceGetTrackEventsEmptyAndErrors(t *testing.T) {
+	service := NewSessionService()
+	defer service.Close()
+	ctx := context.Background()
+	_, err := service.GetTrackEvents(ctx, session.Key{UserID: "track-user", SessionID: "track-session"}, "alpha")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, session.ErrAppNameRequired)
+	key := session.Key{AppName: "track-app", UserID: "track-user", SessionID: "missing-session"}
+	got, err := service.GetTrackEvents(ctx, key, "alpha")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("alpha"), got.Track)
+	require.Empty(t, got.Events)
+	_, err = service.GetTrackEvents(ctx, key, "alpha", session.WithGetSessionEventPage(0, 10))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, session.ErrEventPageUnsupported)
+	sess, err := service.CreateSession(ctx, key, session.StateMap{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	got, err = service.GetTrackEvents(ctx, key, "alpha")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("alpha"), got.Track)
+	require.Empty(t, got.Events)
+}
+
 func TestSessionServiceListSessionsFiltersTrackEvents(t *testing.T) {
 	service := NewSessionService()
 	defer service.Close()

--- a/session/mongodb/options.go
+++ b/session/mongodb/options.go
@@ -41,6 +41,7 @@ type serviceOpts struct {
 
 	sessionEventLimit int           // limit of events returned per session in context-window mode
 	sessionTTL        time.Duration // TTL for session state
+	trackEventTTL     *time.Duration
 	appStateTTL       time.Duration // TTL for app state
 	userStateTTL      time.Duration // TTL for user state
 
@@ -84,6 +85,13 @@ func (opts serviceOpts) shouldCascadeFullSessionSummary() bool {
 		return true
 	}
 	return *opts.cascadeFullSessionSummary
+}
+
+func (opts serviceOpts) effectiveTrackEventTTL() time.Duration {
+	if opts.trackEventTTL != nil {
+		return *opts.trackEventTTL
+	}
+	return opts.sessionTTL
 }
 
 // WithMongoClientURI sets the MongoDB connection URI directly (recommended).
@@ -135,6 +143,15 @@ func WithSessionEventLimit(limit int) ServiceOpt {
 func WithSessionTTL(ttl time.Duration) ServiceOpt {
 	return func(opts *serviceOpts) {
 		opts.sessionTTL = ttl
+	}
+}
+
+// WithTrackEventTTL sets the TTL for track events.
+// If unset, track events use the session TTL. A non-positive TTL disables track
+// event expiration.
+func WithTrackEventTTL(ttl time.Duration) ServiceOpt {
+	return func(opts *serviceOpts) {
+		opts.trackEventTTL = &ttl
 	}
 }
 

--- a/session/mongodb/options_test.go
+++ b/session/mongodb/options_test.go
@@ -65,11 +65,23 @@ func TestWithExtraOptions_Appends(t *testing.T) {
 func TestTTLOptions(t *testing.T) {
 	o := defaultOptions
 	WithSessionTTL(time.Hour)(&o)
+	WithTrackEventTTL(30 * time.Minute)(&o)
 	WithAppStateTTL(2 * time.Hour)(&o)
 	WithUserStateTTL(3 * time.Hour)(&o)
 	assert.Equal(t, time.Hour, o.sessionTTL)
+	require.NotNil(t, o.trackEventTTL)
+	assert.Equal(t, 30*time.Minute, o.effectiveTrackEventTTL())
 	assert.Equal(t, 2*time.Hour, o.appStateTTL)
 	assert.Equal(t, 3*time.Hour, o.userStateTTL)
+}
+
+func TestTrackEventTTLDefaultsToSessionTTL(t *testing.T) {
+	o := defaultOptions
+	WithSessionTTL(time.Hour)(&o)
+	assert.Equal(t, time.Hour, o.effectiveTrackEventTTL())
+	WithTrackEventTTL(0)(&o)
+	require.NotNil(t, o.trackEventTTL)
+	assert.Equal(t, time.Duration(0), o.effectiveTrackEventTTL())
 }
 
 func TestWithEnableAsyncPersist(t *testing.T) {

--- a/session/mongodb/service.go
+++ b/session/mongodb/service.go
@@ -127,7 +127,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	if database == "" {
 		database = defaultDatabase
 	}
-	if opts.sessionTTL > 0 && opts.cleanupInterval == 0 {
+	if (opts.sessionTTL > 0 || opts.effectiveTrackEventTTL() > 0) && opts.cleanupInterval == 0 {
 		opts.cleanupInterval = defaultCleanupIntervalSecond
 	}
 
@@ -169,7 +169,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 		})
 		s.asyncWorker.Start()
 	}
-	if opts.sessionTTL > 0 && opts.cleanupInterval > 0 {
+	if (opts.sessionTTL > 0 || opts.effectiveTrackEventTTL() > 0) && opts.cleanupInterval > 0 {
 		s.cleanupDone = make(chan struct{})
 		s.startCleanupRoutine()
 	}
@@ -1052,6 +1052,34 @@ func (s *Service) AppendTrackEvent(
 	return nil
 }
 
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *Service) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	trackEvents, err := s.getTrackEventsByTrackLists(
+		ctx,
+		[]session.Key{key},
+		[][]session.Track{{track}},
+		opt.EventNum,
+		opt.EventTime,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mongodb session service get track events failed: %w", err)
+	}
+	events := trackEvents[0][track]
+	if events == nil {
+		events = []session.TrackEvent{}
+	}
+	return &session.TrackEvents{Track: track, Events: events}, nil
+}
+
 func (s *Service) persistTrackEvent(ctx context.Context, key session.Key, trackEvent *session.TrackEvent) error {
 	if trackEvent == nil {
 		return fmt.Errorf("track event is nil")
@@ -1061,7 +1089,8 @@ func (s *Service) persistTrackEvent(ctx context.Context, key session.Key, trackE
 		return fmt.Errorf("marshal track event failed: %w", err)
 	}
 	now := time.Now()
-	expiresAt := expiresAtPtr(now, s.opts.sessionTTL)
+	sessionExpires := expiresAtPtr(now, s.opts.sessionTTL)
+	trackExpires := expiresAtPtr(now, s.opts.effectiveTrackEventTTL())
 
 	return s.client.Transaction(ctx, func(sc mongo.SessionContext) error {
 		var doc sessionStateDoc
@@ -1090,7 +1119,7 @@ func (s *Service) persistTrackEvent(ctx context.Context, key session.Key, trackE
 		}
 		res, err := s.client.UpdateOne(sc, s.database, s.collSessionStates,
 			activeFilterNoExpiry(sessionKeyFilter(key)),
-			sessionStateUpdate(set, expiresAt))
+			sessionStateUpdate(set, sessionExpires))
 		if err != nil {
 			return fmt.Errorf("update session state: %w", err)
 		}
@@ -1106,7 +1135,7 @@ func (s *Service) persistTrackEvent(ctx context.Context, key session.Key, trackE
 			Event:     eventBytes,
 			CreatedAt: trackEvent.Timestamp,
 			UpdatedAt: trackEvent.Timestamp,
-			ExpiresAt: expiresAt,
+			ExpiresAt: trackExpires,
 		}
 		if _, err := s.client.InsertOne(sc, s.database, s.collSessionTracks, trackDoc); err != nil {
 			return fmt.Errorf("insert track event: %w", err)
@@ -1198,9 +1227,10 @@ func (s *Service) Close() error {
 //
 // Other collections rely on MongoDB TTL indexes. Events and track events need
 // backend cleanup so histories stay all-or-nothing: a session group is cleaned
-// only when its latest row in that collection is older than the TTL cutoff.
+// only when its latest row in that collection is older than its TTL cutoff.
 func (s *Service) cleanupExpired(ctx context.Context) {
-	if s.opts.sessionTTL <= 0 {
+	trackTTL := s.opts.effectiveTrackEventTTL()
+	if s.opts.sessionTTL <= 0 && trackTTL <= 0 {
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -1215,18 +1245,18 @@ func (s *Service) cleanupExpired(ctx context.Context) {
 }
 
 func (s *Service) cleanupExpiredEvents(ctx context.Context, now time.Time) error {
-	return s.cleanupExpiredCollection(ctx, now, s.collSessionEvents, "events")
+	return s.cleanupExpiredCollection(ctx, now, s.opts.sessionTTL, s.collSessionEvents, "events")
 }
 
 func (s *Service) cleanupExpiredTracks(ctx context.Context, now time.Time) error {
-	return s.cleanupExpiredCollection(ctx, now, s.collSessionTracks, "tracks")
+	return s.cleanupExpiredCollection(ctx, now, s.opts.effectiveTrackEventTTL(), s.collSessionTracks, "tracks")
 }
 
-func (s *Service) cleanupExpiredCollection(ctx context.Context, now time.Time, collection string, label string) error {
-	if s.opts.sessionTTL <= 0 {
+func (s *Service) cleanupExpiredCollection(ctx context.Context, now time.Time, ttl time.Duration, collection string, label string) error {
+	if ttl <= 0 {
 		return nil
 	}
-	cutoff := now.Add(-s.opts.sessionTTL)
+	cutoff := now.Add(-ttl)
 	pipeline := bson.A{
 		bson.M{"$match": bson.M{"deleted_at": nil}},
 		bson.M{"$group": bson.M{

--- a/session/mongodb/service_helper.go
+++ b/session/mongodb/service_helper.go
@@ -504,19 +504,40 @@ func (s *Service) getTrackEvents(
 	if len(sessionStates) != len(sessionKeys) {
 		return nil, fmt.Errorf("session states count mismatch: %d != %d", len(sessionStates), len(sessionKeys))
 	}
-	if afterTime.IsZero() && s.opts.sessionTTL > 0 {
-		afterTime = time.Now().Add(-s.opts.sessionTTL)
-	}
-
-	results := make([]map[session.Track][]session.TrackEvent, len(sessionKeys))
-	sessionIDs := make([]string, 0, len(sessionKeys))
-	trackSet := make(map[session.Track]struct{})
-	allowed := make(map[string]map[session.Track]int)
-	for i, key := range sessionKeys {
+	trackLists := make([][]session.Track, len(sessionKeys))
+	for i := range sessionKeys {
 		tracks, err := session.TracksFromState(bsonToStateMap(sessionStates[i].State))
 		if err != nil {
 			return nil, fmt.Errorf("get track list failed: %w", err)
 		}
+		trackLists[i] = tracks
+	}
+	return s.getTrackEventsByTrackLists(ctx, sessionKeys, trackLists, limit, afterTime)
+}
+
+func (s *Service) getTrackEventsByTrackLists(
+	ctx context.Context,
+	sessionKeys []session.Key,
+	trackLists [][]session.Track,
+	limit int,
+	afterTime time.Time,
+) ([]map[session.Track][]session.TrackEvent, error) {
+	if len(sessionKeys) == 0 {
+		return nil, nil
+	}
+	if len(trackLists) != len(sessionKeys) {
+		return nil, fmt.Errorf("track lists count mismatch: %d != %d", len(trackLists), len(sessionKeys))
+	}
+	if trackTTL := s.opts.effectiveTrackEventTTL(); afterTime.IsZero() && trackTTL > 0 {
+		afterTime = time.Now().Add(-trackTTL)
+	}
+	results := make([]map[session.Track][]session.TrackEvent, len(sessionKeys))
+	sessionIDs := make([]string, 0, len(sessionKeys))
+	trackSet := make(map[session.Track]struct{})
+	allowed := make(map[string]map[session.Track]int)
+	queryPairCount := 0
+	for i, key := range sessionKeys {
+		tracks := trackLists[i]
 		results[i] = make(map[session.Track][]session.TrackEvent)
 		if len(tracks) == 0 {
 			continue
@@ -528,12 +549,12 @@ func (s *Service) getTrackEvents(
 		for _, track := range tracks {
 			allowed[key.SessionID][track] = i
 			trackSet[track] = struct{}{}
+			queryPairCount++
 		}
 	}
 	if len(sessionIDs) == 0 || len(trackSet) == 0 {
 		return results, nil
 	}
-
 	tracks := make([]session.Track, 0, len(trackSet))
 	for track := range trackSet {
 		tracks = append(tracks, track)
@@ -551,12 +572,14 @@ func (s *Service) getTrackEvents(
 		{Key: "created_at", Value: -1},
 		{Key: "_id", Value: -1},
 	})
+	if limit > 0 && queryPairCount == 1 {
+		findOpts.SetLimit(int64(limit))
+	}
 	cursor, err := s.client.Find(ctx, s.database, s.collSessionTracks, filter, findOpts)
 	if err != nil {
 		return nil, fmt.Errorf("query track events: %w", err)
 	}
 	defer cursor.Close(ctx)
-
 	for cursor.Next(ctx) {
 		var doc sessionTrackDoc
 		if err := cursor.Decode(&doc); err != nil {

--- a/session/mongodb/service_test.go
+++ b/session/mongodb/service_test.go
@@ -1619,6 +1619,49 @@ func TestAppendTrackEvent_TTLSetsExpiresAt(t *testing.T) {
 	assert.True(t, sawTrackExpiresAt)
 }
 
+func TestAppendTrackEvent_TrackTTLOverridesSessionTTL(t *testing.T) {
+	now := time.Now()
+	mc := &mockClient{
+		transactionFn: func(fn func(mongo.SessionContext) error) error {
+			return fn(mongo.NewSessionContext(context.Background(), nil))
+		},
+		findOneFn: func(_ any) *mongo.SingleResult {
+			return mongo.NewSingleResultFromDocument(sessionStateDoc{State: bson.M{}}, nil, nil)
+		},
+	}
+	trackTTL := time.Duration(0)
+	s := newServiceForTest(t, mc, func(o *serviceOpts) {
+		o.sessionTTL = time.Hour
+		o.trackEventTTL = &trackTTL
+	})
+	sess := newSessionForTest("app", "u", "s")
+
+	require.NoError(t, s.AppendTrackEvent(context.Background(), sess,
+		trackEventForTest("alpha", `"payload"`, now)))
+
+	var sawStateExpiresAt, sawTrackDoc bool
+	for _, op := range mc.recorded() {
+		switch op.coll {
+		case "session_states":
+			if op.name != "UpdateOne" {
+				continue
+			}
+			upd := op.update.(bson.M)
+			set := upd["$set"].(bson.M)
+			_, sawStateExpiresAt = set["expires_at"]
+		case "session_tracks":
+			if op.name != "InsertOne" {
+				continue
+			}
+			doc := op.doc.(sessionTrackDoc)
+			sawTrackDoc = true
+			assert.Nil(t, doc.ExpiresAt)
+		}
+	}
+	assert.True(t, sawStateExpiresAt)
+	assert.True(t, sawTrackDoc)
+}
+
 func TestAppendTrackEvent_AsyncPathDispatchesToChan(t *testing.T) {
 	mc := &mockClient{}
 	s := newServiceForTest(t, mc, func(o *serviceOpts) {
@@ -1734,6 +1777,85 @@ func TestGetSession_LoadsTrackEvents(t *testing.T) {
 	assert.Equal(t, json.RawMessage(`"payload"`), sess.Tracks["alpha"].Events[0].Payload)
 }
 
+func TestServiceGetTrackEventsReadsTrackStorage(t *testing.T) {
+	now := time.Now()
+	oldEvent := trackEventForTest("alpha", `"old"`, now.Add(-2*time.Minute))
+	newEvent := trackEventForTest("alpha", `"new"`, now.Add(-time.Minute))
+	oldBytes, err := json.Marshal(oldEvent)
+	require.NoError(t, err)
+	newBytes, err := json.Marshal(newEvent)
+	require.NoError(t, err)
+	mc := &mockClient{
+		findFn: func(filter any) (*mongo.Cursor, error) {
+			f := filter.(bson.M)
+			assert.Equal(t, "app", f["app_name"])
+			assert.Equal(t, "u", f["user_id"])
+			assert.Equal(t, bson.M{"$in": []string{"s"}}, f["session_id"])
+			assert.Equal(t, bson.M{"$in": []session.Track{"alpha"}}, f["track"])
+			assert.Contains(t, f, "created_at")
+			return docsCursor([]any{
+				sessionTrackDoc{SessionID: "s", Track: "alpha", Event: newBytes, CreatedAt: newEvent.Timestamp},
+				sessionTrackDoc{SessionID: "s", Track: "alpha", Event: oldBytes, CreatedAt: oldEvent.Timestamp},
+			})
+		},
+	}
+	s := newServiceForTest(t, mc)
+	got, err := s.GetTrackEvents(context.Background(),
+		session.Key{AppName: "app", UserID: "u", SessionID: "s"},
+		"alpha")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("alpha"), got.Track)
+	require.Len(t, got.Events, 2)
+	assert.Equal(t, json.RawMessage(`"old"`), got.Events[0].Payload)
+	assert.Equal(t, json.RawMessage(`"new"`), got.Events[1].Payload)
+	ops := mc.recorded()
+	require.Len(t, ops, 1)
+	assert.Equal(t, "Find", ops[0].name)
+	assert.Equal(t, "session_tracks", ops[0].coll)
+}
+
+func TestServiceGetTrackEventsErrorsAndEmpty(t *testing.T) {
+	t.Run("invalid key", func(t *testing.T) {
+		s := newServiceForTest(t, &mockClient{})
+		_, err := s.GetTrackEvents(
+			context.Background(),
+			session.Key{UserID: "u", SessionID: "s"},
+			"alpha",
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, session.ErrAppNameRequired)
+	})
+	t.Run("query error", func(t *testing.T) {
+		want := errors.New("find failed")
+		mc := &mockClient{
+			findFn: func(_ any) (*mongo.Cursor, error) {
+				return nil, want
+			},
+		}
+		s := newServiceForTest(t, mc)
+		_, err := s.GetTrackEvents(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u", SessionID: "s"},
+			"alpha",
+		)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, want)
+		assert.Contains(t, err.Error(), "mongodb session service get track events failed")
+	})
+	t.Run("empty events", func(t *testing.T) {
+		s := newServiceForTest(t, &mockClient{})
+		got, err := s.GetTrackEvents(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u", SessionID: "s"},
+			"alpha",
+		)
+		require.NoError(t, err)
+		require.Equal(t, session.Track("alpha"), got.Track)
+		require.Empty(t, got.Events)
+		require.NotNil(t, got.Events)
+	})
+}
+
 func TestGetTrackEvents_BatchesSessionsAndTracks(t *testing.T) {
 	now := time.Now()
 	alphaOld := trackEventForTest("alpha", `"old"`, now.Add(-2*time.Minute))
@@ -1780,6 +1902,73 @@ func TestGetTrackEvents_BatchesSessionsAndTracks(t *testing.T) {
 	assert.Equal(t, json.RawMessage(`"new"`), got[0]["alpha"][0].Payload)
 	require.Len(t, got[1]["beta"], 1)
 	assert.Equal(t, json.RawMessage(`"beta"`), got[1]["beta"][0].Payload)
+}
+
+func TestGetTrackEventsByTrackListsBoundaries(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "u", SessionID: "s"}
+	t.Run("empty keys", func(t *testing.T) {
+		s := newServiceForTest(t, &mockClient{})
+		got, err := s.getTrackEventsByTrackLists(context.Background(), nil, nil, 0, time.Time{})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+	t.Run("track list count mismatch", func(t *testing.T) {
+		s := newServiceForTest(t, &mockClient{})
+		_, err := s.getTrackEventsByTrackLists(context.Background(), []session.Key{key}, nil, 0, time.Time{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "track lists count mismatch")
+	})
+	t.Run("track ttl lower bound and limit", func(t *testing.T) {
+		ttl := time.Hour
+		mc := &mockClient{
+			findFn: func(filter any) (*mongo.Cursor, error) {
+				f := filter.(bson.M)
+				createdAt := f["created_at"].(bson.M)
+				afterTime, ok := createdAt["$gt"].(time.Time)
+				require.True(t, ok)
+				assert.WithinDuration(t, time.Now().Add(-ttl), afterTime, 5*time.Second)
+				return emptyCursor()
+			},
+		}
+		s := newServiceForTest(t, mc, func(o *serviceOpts) { o.trackEventTTL = &ttl })
+		got, err := s.getTrackEventsByTrackLists(
+			context.Background(),
+			[]session.Key{key},
+			[][]session.Track{{"alpha"}},
+			1,
+			time.Time{},
+		)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Empty(t, got[0])
+	})
+}
+
+func TestGetTrackEvents_TrackTTLZeroDoesNotApplySessionTTL(t *testing.T) {
+	trackTTL := time.Duration(0)
+	mc := &mockClient{
+		findFn: func(filter any) (*mongo.Cursor, error) {
+			f := filter.(bson.M)
+			createdAt := f["created_at"].(bson.M)
+			afterTime, ok := createdAt["$gt"].(time.Time)
+			require.True(t, ok)
+			assert.True(t, afterTime.IsZero())
+			return emptyCursor()
+		},
+	}
+	s := newServiceForTest(t, mc, func(o *serviceOpts) {
+		o.sessionTTL = time.Hour
+		o.trackEventTTL = &trackTTL
+	})
+	got, err := s.getTrackEvents(context.Background(),
+		[]session.Key{{AppName: "app", UserID: "u", SessionID: "s"}},
+		[]sessionStateDoc{{State: bson.M{"tracks": mustTrackIndex(t, []session.Track{"alpha"})}}},
+		0,
+		time.Time{},
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0])
 }
 
 func TestGetTrackEvents_ErrorsAndNoTrackFastPath(t *testing.T) {

--- a/session/mysql/options.go
+++ b/session/mysql/options.go
@@ -40,6 +40,7 @@ type ServiceOpts struct {
 	extraOptions []any  // Extra options passed to storage layer
 
 	sessionTTL         time.Duration // TTL for session state and event list
+	trackEventTTL      *time.Duration
 	appStateTTL        time.Duration // TTL for app state
 	userStateTTL       time.Duration // TTL for user state
 	enableAsyncPersist bool
@@ -102,6 +103,13 @@ func (opts ServiceOpts) shouldCascadeFullSessionSummary() bool {
 	return *opts.cascadeFullSessionSummary
 }
 
+func (opts ServiceOpts) effectiveTrackEventTTL() time.Duration {
+	if opts.trackEventTTL != nil {
+		return *opts.trackEventTTL
+	}
+	return opts.sessionTTL
+}
+
 // WithSessionEventLimit sets the limit of events in a session.
 func WithSessionEventLimit(limit int) ServiceOpt {
 	return func(opts *ServiceOpts) {
@@ -146,6 +154,15 @@ func WithExtraOptions(extraOptions ...any) ServiceOpt {
 func WithSessionTTL(ttl time.Duration) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.sessionTTL = ttl
+	}
+}
+
+// WithTrackEventTTL sets the TTL for track events.
+// If unset, track events use the session TTL. A non-positive TTL disables track
+// event expiration.
+func WithTrackEventTTL(ttl time.Duration) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.trackEventTTL = &ttl
 	}
 }
 

--- a/session/mysql/options_test.go
+++ b/session/mysql/options_test.go
@@ -53,6 +53,17 @@ func TestWithSessionTTL(t *testing.T) {
 	assert.Equal(t, ttl, opts.sessionTTL)
 }
 
+func TestWithTrackEventTTL(t *testing.T) {
+	opts := &ServiceOpts{sessionTTL: time.Hour}
+	assert.Equal(t, time.Hour, opts.effectiveTrackEventTTL())
+	WithTrackEventTTL(0)(opts)
+	require.NotNil(t, opts.trackEventTTL)
+	assert.Equal(t, time.Duration(0), opts.effectiveTrackEventTTL())
+	WithTrackEventTTL(30 * time.Minute)(opts)
+	require.NotNil(t, opts.trackEventTTL)
+	assert.Equal(t, 30*time.Minute, opts.effectiveTrackEventTTL())
+}
+
 func TestWithAppStateTTL(t *testing.T) {
 	opts := &ServiceOpts{}
 	ttl := 48 * time.Hour

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -154,7 +154,8 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	}
 
 	// Start cleanup routine if any TTL is configured
-	if opts.sessionTTL > 0 || opts.appStateTTL > 0 || opts.userStateTTL > 0 {
+	if opts.sessionTTL > 0 || opts.appStateTTL > 0 || opts.userStateTTL > 0 ||
+		opts.effectiveTrackEventTTL() > 0 {
 		s.startCleanupRoutine()
 	}
 
@@ -801,6 +802,30 @@ func (s *Service) AppendTrackEvent(
 	return nil
 }
 
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *Service) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	trackEvents, err := s.getTrackEventsByTrackLists(
+		ctx,
+		[]session.Key{key},
+		[][]session.Track{{track}},
+		opt.EventNum,
+		opt.EventTime,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mysql session service get track events failed: %w", err)
+	}
+	return &session.TrackEvents{Track: track, Events: trackEvents[0][track]}, nil
+}
+
 // startAsyncPersistWorker starts worker goroutines for async event persistence.
 func (s *Service) startAsyncPersistWorker() {
 	persisterNum := s.opts.asyncPersisterNum
@@ -935,6 +960,13 @@ func (s *Service) cleanupExpiredData(ctx context.Context) {
 			s.tdsqlCleanupExpiredSessions(ctx, now)
 		} else {
 			s.cleanupExpiredSessions(ctx, now)
+		}
+	}
+	if s.opts.trackEventTTL != nil && s.opts.effectiveTrackEventTTL() > 0 {
+		if s.opts.tdsqlSharding {
+			s.tdsqlCleanupExpiredTrackEvents(ctx, now)
+		} else {
+			s.cleanupExpiredTrackEvents(ctx, now)
 		}
 	}
 
@@ -1121,11 +1153,13 @@ func (s *Service) softDeleteSessions(
 		return fmt.Errorf("soft delete events: %w", err)
 	}
 
-	// Soft delete track events
-	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionTracks, childWhereClause),
-		append([]any{now}, childArgs...)...); err != nil {
-		return fmt.Errorf("soft delete track events: %w", err)
+	if s.opts.trackEventTTL == nil {
+		// Soft delete track events.
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionTracks, childWhereClause),
+			append([]any{now}, childArgs...)...); err != nil {
+			return fmt.Errorf("soft delete track events: %w", err)
+		}
 	}
 
 	return nil
@@ -1162,14 +1196,103 @@ func (s *Service) hardDeleteSessions(
 		return fmt.Errorf("hard delete events: %w", err)
 	}
 
-	// Hard delete track events
-	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionTracks, childWhereClause),
-		childArgs...); err != nil {
-		return fmt.Errorf("hard delete track events: %w", err)
+	if s.opts.trackEventTTL == nil {
+		// Hard delete track events.
+		if _, err := tx.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM %s WHERE %s`, s.tableSessionTracks, childWhereClause),
+			childArgs...); err != nil {
+			return fmt.Errorf("hard delete track events: %w", err)
+		}
 	}
 
 	return nil
+}
+
+func (s *Service) cleanupExpiredTrackEvents(ctx context.Context, now time.Time) {
+	if s.opts.softDelete {
+		_, err := s.mysqlClient.Exec(ctx,
+			fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE expires_at IS NOT NULL AND expires_at <= ? AND deleted_at IS NULL`, s.tableSessionTracks),
+			now, now)
+		if err != nil {
+			log.ErrorfContext(ctx, "cleanup expired track events failed: %v", err)
+		}
+		return
+	}
+	_, err := s.mysqlClient.Exec(ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE expires_at IS NOT NULL AND expires_at <= ?`, s.tableSessionTracks),
+		now)
+	if err != nil {
+		log.ErrorfContext(ctx, "cleanup expired track events failed: %v", err)
+	}
+}
+
+func (s *Service) tdsqlCleanupExpiredTrackEvents(ctx context.Context, now time.Time) {
+	type idPair struct {
+		id     int64
+		userID string
+	}
+	query := fmt.Sprintf(`SELECT id, user_id FROM %s
+		WHERE expires_at IS NOT NULL AND expires_at <= ? AND deleted_at IS NULL
+		LIMIT 1000`, s.tableSessionTracks)
+	var pairs []idPair
+	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
+		var p idPair
+		if err := rows.Scan(&p.id, &p.userID); err != nil {
+			return err
+		}
+		pairs = append(pairs, p)
+		return nil
+	}, query, now)
+	if err != nil {
+		log.ErrorfContext(ctx, "tdsql cleanup: scan expired track events failed: %v", err)
+		return
+	}
+	if len(pairs) == 0 {
+		return
+	}
+	grouped := make(map[string][]int64)
+	for _, p := range pairs {
+		grouped[p.userID] = append(grouped[p.userID], p.id)
+	}
+	var total int64
+	for userID, ids := range grouped {
+		placeholders := make([]string, len(ids))
+		for i := range ids {
+			placeholders[i] = "?"
+		}
+		idClause := strings.Join(placeholders, ",")
+		var err error
+		if s.opts.softDelete {
+			args := make([]any, 0, len(ids)+3)
+			args = append(args, now)
+			for _, id := range ids {
+				args = append(args, id)
+			}
+			args = append(args, userID, now)
+			_, err = s.mysqlClient.Exec(ctx,
+				fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE id IN (%s) AND user_id = ? AND expires_at IS NOT NULL AND expires_at <= ?`,
+					s.tableSessionTracks, idClause),
+				args...)
+		} else {
+			args := make([]any, 0, len(ids)+2)
+			for _, id := range ids {
+				args = append(args, id)
+			}
+			args = append(args, userID, now)
+			_, err = s.mysqlClient.Exec(ctx,
+				fmt.Sprintf(`DELETE FROM %s WHERE id IN (%s) AND user_id = ? AND expires_at IS NOT NULL AND expires_at <= ?`,
+					s.tableSessionTracks, idClause),
+				args...)
+		}
+		if err != nil {
+			log.ErrorfContext(ctx, "tdsql cleanup: delete track events failed: %v", err)
+			continue
+		}
+		total += int64(len(ids))
+	}
+	if total > 0 {
+		log.InfofContext(ctx, "tdsql cleanup: cleaned up %d expired track events", total)
+	}
 }
 
 // cleanupExpiredAppStates cleans up expired app states.

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -463,13 +463,14 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 		if err != nil {
 			return fmt.Errorf("marshal session state failed: %w", err)
 		}
-		expiresAt := calculateExpiresAt(s.opts.sessionTTL)
+		sessionExpires := calculateExpiresAt(s.opts.sessionTTL)
+		trackExpires := calculateExpiresAt(s.opts.effectiveTrackEventTTL())
 
 		// Update session state.
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = ?, updated_at = ?, expires_at = ?
 			 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionStates),
-			string(updatedStateBytes), updatedAt, expiresAt,
+			string(updatedStateBytes), updatedAt, sessionExpires,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -480,7 +481,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, s.tableSessionTracks),
 			key.AppName, key.UserID, key.SessionID, trackEvent.Track, string(eventBytes),
-			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
+			trackEvent.Timestamp, trackEvent.Timestamp, trackExpires)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)
 		}
@@ -1218,21 +1219,34 @@ func (s *Service) getTrackEvents(
 	if len(sessionStates) != len(sessionKeys) {
 		return nil, fmt.Errorf("session states count mismatch: %d != %d", len(sessionStates), len(sessionKeys))
 	}
+	trackLists := make([][]session.Track, len(sessionKeys))
+	for i := range sessionKeys {
+		tracks, err := session.TracksFromState(sessionStates[i].State)
+		if err != nil {
+			return nil, fmt.Errorf("get track list failed: %w", err)
+		}
+		trackLists[i] = tracks
+	}
+	return s.getTrackEventsByTrackLists(ctx, sessionKeys, trackLists, limit, afterTime)
+}
 
+func (s *Service) getTrackEventsByTrackLists(
+	ctx context.Context,
+	sessionKeys []session.Key,
+	trackLists [][]session.Track,
+	limit int,
+	afterTime time.Time,
+) ([]map[session.Track][]session.TrackEvent, error) {
 	type trackQuery struct {
 		sessionIdx int
 		track      session.Track
 		query      string
 		args       []any
 	}
-
 	queries := make([]*trackQuery, 0)
 	now := time.Now()
 	for i, key := range sessionKeys {
-		tracks, err := session.TracksFromState(sessionStates[i].State)
-		if err != nil {
-			return nil, fmt.Errorf("get track list failed: %w", err)
-		}
+		tracks := trackLists[i]
 		for _, track := range tracks {
 			query := fmt.Sprintf(`SELECT event FROM %s
 					WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
@@ -1262,7 +1276,6 @@ func (s *Service) getTrackEvents(
 			})
 		}
 	}
-
 	results := make([]map[session.Track][]session.TrackEvent, len(sessionKeys))
 	for _, q := range queries {
 		events := make([]session.TrackEvent, 0)
@@ -1281,7 +1294,6 @@ func (s *Service) getTrackEvents(
 		if err != nil {
 			return nil, fmt.Errorf("query track events failed: %w", err)
 		}
-
 		for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
 			events[i], events[j] = events[j], events[i]
 		}

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -741,6 +741,52 @@ func TestAppendTrackEvent_Sync(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAppendTrackEvent_TrackTTLOverridesSessionTTL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db, WithSessionTTL(time.Hour), WithTrackEventTTL(0))
+	ctx := context.Background()
+
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		State:   session.StateMap{},
+	}
+	trackEvent := &session.TrackEvent{
+		Track:     "agui",
+		Payload:   json.RawMessage(`{"delta":"hi"}`),
+		Timestamp: time.Now(),
+	}
+	sessState := &SessionState{
+		ID:    "test-session",
+		State: session.StateMap{},
+	}
+	stateBytes, _ := json.Marshal(sessState)
+	stateRows := sqlmock.NewRows([]string{"state", "expires_at"}).
+		AddRow(stateBytes, nil)
+	expectLoadSessionStateForUpdate(mock, session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "test-session",
+	}).WillReturnRows(stateRows)
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET state = ?, updated_at = ?, expires_at = ?")).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			"test-app", "test-user", "test-session").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_track_events")).
+		WithArgs("test-app", "test-user", "test-session", "agui",
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = s.AppendTrackEvent(ctx, sess, trackEvent)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestAppendTrackEvent_InvalidKey(t *testing.T) {
 	db, _, err := sqlmock.New()
 	require.NoError(t, err)
@@ -2868,6 +2914,46 @@ func TestCleanupExpiredData(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestCleanupExpiredData_TrackEventTTL(t *testing.T) {
+	tests := []struct {
+		name          string
+		tdsqlShard    bool
+		expectCleanup func(sqlmock.Sqlmock)
+	}{
+		{
+			name: "plain",
+			expectCleanup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+					WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			name:       "tdsql",
+			tdsqlShard: true,
+			expectCleanup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_track_events")).
+					WithArgs(sqlmock.AnyArg()).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			s := createTestService(t, db,
+				WithTrackEventTTL(time.Hour),
+				WithTDSQLSharding(tt.tdsqlShard),
+			)
+			tt.expectCleanup(mock)
+			s.cleanupExpiredData(context.Background())
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
 // TestCleanupExpiredSessions_HardDelete tests hard delete of sessions
 func TestCleanupExpiredSessions_HardDelete(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -2904,6 +2990,45 @@ func TestCleanupExpiredSessions_HardDelete(t *testing.T) {
 
 	s.cleanupExpiredSessions(ctx, now)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCleanupExpiredTrackEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		softDelete bool
+		expectExec func(sqlmock.Sqlmock, time.Time)
+	}{
+		{
+			name:       "soft delete",
+			softDelete: true,
+			expectExec: func(mock sqlmock.Sqlmock, now time.Time) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+					WithArgs(now, now).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+			},
+		},
+		{
+			name:       "hard delete",
+			softDelete: false,
+			expectExec: func(mock sqlmock.Sqlmock, now time.Time) {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
+					WithArgs(now).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			s := createTestService(t, db, WithSoftDelete(tt.softDelete))
+			now := time.Now()
+			tt.expectExec(mock, now)
+			s.cleanupExpiredTrackEvents(context.Background(), now)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
 }
 
 // TestDeleteAppState_HardDelete tests hard delete of app state
@@ -4292,6 +4417,107 @@ func TestTDSQLCleanupExpiredUserStates_DeleteError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestTDSQLCleanupExpiredTrackEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		softDelete bool
+		expectExec func(sqlmock.Sqlmock, time.Time)
+	}{
+		{
+			name:       "soft delete",
+			softDelete: true,
+			expectExec: func(mock sqlmock.Sqlmock, now time.Time) {
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+					WithArgs(now, int64(100), int64(101), "user-1", now).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+					WithArgs(now, int64(200), "user-2", now).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			name:       "hard delete",
+			softDelete: false,
+			expectExec: func(mock sqlmock.Sqlmock, now time.Time) {
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
+					WithArgs(int64(100), int64(101), "user-1", now).
+					WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_track_events")).
+					WithArgs(int64(200), "user-2", now).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			mock.MatchExpectationsInOrder(false)
+			s := createTestService(t, db,
+				WithSoftDelete(tt.softDelete),
+				WithTDSQLSharding(true),
+			)
+			now := time.Now()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_track_events")).
+				WithArgs(now).
+				WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+					AddRow(int64(100), "user-1").
+					AddRow(int64(101), "user-1").
+					AddRow(int64(200), "user-2"))
+			tt.expectExec(mock, now)
+			s.tdsqlCleanupExpiredTrackEvents(context.Background(), now)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestTDSQLCleanupExpiredTrackEvents_NoExpired(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db, WithTrackEventTTL(time.Hour), WithTDSQLSharding(true))
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_track_events")).
+		WithArgs(now).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}))
+	s.tdsqlCleanupExpiredTrackEvents(context.Background(), now)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredTrackEvents_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db, WithTrackEventTTL(time.Hour), WithTDSQLSharding(true))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_track_events")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+			AddRow(nil, "user-1"))
+	s.tdsqlCleanupExpiredTrackEvents(context.Background(), time.Now())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTDSQLCleanupExpiredTrackEvents_DeleteError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db,
+		WithTrackEventTTL(time.Hour),
+		WithTDSQLSharding(true),
+		WithSoftDelete(true),
+	)
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_track_events")).
+		WithArgs(now).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+			AddRow(int64(100), "user-1"))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+		WithArgs(now, int64(100), "user-1", now).
+		WillReturnError(assert.AnError)
+	s.tdsqlCleanupExpiredTrackEvents(context.Background(), now)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestTDSQLCleanupExpiredData(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -4338,4 +4564,64 @@ func TestTDSQLCleanupExpiredData(t *testing.T) {
 
 	s.cleanupExpiredData(ctx)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestServiceGetTrackEventsReadsTrackStorage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	svc := createTestService(t, db)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	track := session.Track("agui")
+	base := time.Now().Add(-time.Hour)
+	oldEvent := session.TrackEvent{Track: track, Payload: json.RawMessage(`"old"`), Timestamp: base}
+	newEvent := session.TrackEvent{Track: track, Payload: json.RawMessage(`"new"`), Timestamp: base.Add(time.Second)}
+	oldBytes, err := json.Marshal(oldEvent)
+	require.NoError(t, err)
+	newBytes, err := json.Marshal(newEvent)
+	require.NoError(t, err)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, track, sqlmock.AnyArg(), base.Add(-time.Minute), 2).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(newBytes).AddRow(oldBytes))
+	got, err := svc.GetTrackEvents(ctx, key, track, session.WithEventTime(base.Add(-time.Minute)), session.WithEventNum(2))
+	require.NoError(t, err)
+	require.Equal(t, track, got.Track)
+	require.Len(t, got.Events, 2)
+	require.Equal(t, oldEvent.Payload, got.Events[0].Payload)
+	require.Equal(t, newEvent.Payload, got.Events[1].Payload)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("missing"), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}))
+	missing, err := svc.GetTrackEvents(ctx, key, "missing")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("missing"), missing.Track)
+	require.Empty(t, missing.Events)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestServiceGetTrackEventsErrors(t *testing.T) {
+	t.Run("invalid key", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+		svc := createTestService(t, db)
+		_, err = svc.GetTrackEvents(context.Background(), session.Key{UserID: "user", SessionID: "sess"}, "agui")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, session.ErrAppNameRequired)
+	})
+	t.Run("query error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+		svc := createTestService(t, db)
+		key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+			WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("agui"), sqlmock.AnyArg()).
+			WillReturnError(assert.AnError)
+		_, err = svc.GetTrackEvents(context.Background(), key, "agui")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mysql session service get track events failed")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }

--- a/session/pgvector/options.go
+++ b/session/pgvector/options.go
@@ -75,6 +75,7 @@ type ServiceOpts struct {
 	extraOptions []any
 
 	sessionTTL         time.Duration
+	trackEventTTL      *time.Duration
 	appStateTTL        time.Duration
 	userStateTTL       time.Duration
 	enableAsyncPersist bool
@@ -146,6 +147,13 @@ func (opts ServiceOpts) shouldCascadeFullSessionSummary() bool {
 	return *opts.cascadeFullSessionSummary
 }
 
+func (opts ServiceOpts) effectiveTrackEventTTL() time.Duration {
+	if opts.trackEventTTL != nil {
+		return *opts.trackEventTTL
+	}
+	return opts.sessionTTL
+}
+
 // WithPostgresClientDSN sets the PostgreSQL DSN connection
 // string directly (recommended).
 func WithPostgresClientDSN(dsn string) ServiceOpt {
@@ -208,6 +216,13 @@ func WithSessionEventLimit(limit int) ServiceOpt {
 // event list.
 func WithSessionTTL(ttl time.Duration) ServiceOpt {
 	return func(o *ServiceOpts) { o.sessionTTL = ttl }
+}
+
+// WithTrackEventTTL sets the TTL for track events.
+// If unset, track events use the session TTL. A non-positive TTL disables track
+// event expiration.
+func WithTrackEventTTL(ttl time.Duration) ServiceOpt {
+	return func(o *ServiceOpts) { o.trackEventTTL = &ttl }
 }
 
 // WithAppStateTTL sets the TTL for app state.

--- a/session/pgvector/options_test.go
+++ b/session/pgvector/options_test.go
@@ -353,6 +353,17 @@ func TestWithSessionTTL(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, opts.sessionTTL)
 }
 
+func TestWithTrackEventTTL(t *testing.T) {
+	opts := ServiceOpts{sessionTTL: time.Hour}
+	assert.Equal(t, time.Hour, opts.effectiveTrackEventTTL())
+	WithTrackEventTTL(0)(&opts)
+	require.NotNil(t, opts.trackEventTTL)
+	assert.Equal(t, time.Duration(0), opts.effectiveTrackEventTTL())
+	WithTrackEventTTL(30 * time.Minute)(&opts)
+	require.NotNil(t, opts.trackEventTTL)
+	assert.Equal(t, 30*time.Minute, opts.effectiveTrackEventTTL())
+}
+
 func TestWithAppStateTTL(t *testing.T) {
 	opt := WithAppStateTTL(30 * time.Minute)
 	opts := ServiceOpts{}

--- a/session/pgvector/service.go
+++ b/session/pgvector/service.go
@@ -137,7 +137,8 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	if opts.cleanupInterval <= 0 {
 		if opts.sessionTTL > 0 ||
 			opts.appStateTTL > 0 ||
-			opts.userStateTTL > 0 {
+			opts.userStateTTL > 0 ||
+			opts.effectiveTrackEventTTL() > 0 {
 			opts.cleanupInterval =
 				defaultCleanupIntervalSecond
 		}
@@ -1018,6 +1019,30 @@ func (s *Service) AppendTrackEvent(
 	return nil
 }
 
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *Service) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	trackEvents, err := s.getTrackEventsByTrackLists(
+		ctx,
+		[]session.Key{key},
+		[][]session.Track{{track}},
+		opt.EventNum,
+		opt.EventTime,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("pgvector session service get track events failed: %w", err)
+	}
+	return &session.TrackEvents{Track: track, Events: trackEvents[0][track]}, nil
+}
+
 // Close closes the service.
 func (s *Service) Close() error {
 	s.once.Do(func() {
@@ -1297,7 +1322,7 @@ func (s *Service) cleanupExpiredData(
 	tasks := []cleanupTask{
 		{s.tableSessionStates, s.opts.sessionTTL},
 		{s.tableSessionEvents, s.opts.sessionTTL},
-		{s.tableSessionTracks, s.opts.sessionTTL},
+		{s.tableSessionTracks, s.opts.effectiveTrackEventTTL()},
 		{s.tableSessionSummaries, s.opts.sessionTTL},
 		{s.tableAppStates, s.opts.appStateTTL},
 		{s.tableUserStates, s.opts.userStateTTL},

--- a/session/pgvector/service_helper.go
+++ b/session/pgvector/service_helper.go
@@ -504,10 +504,15 @@ func (s *Service) addTrackEvent(
 		)
 	}
 
-	var expiresAt *time.Time
+	var sessionExpires *time.Time
 	if s.opts.sessionTTL > 0 {
 		t := now.Add(s.opts.sessionTTL)
-		expiresAt = &t
+		sessionExpires = &t
+	}
+	var trackExpires *time.Time
+	if trackTTL := s.opts.effectiveTrackEventTTL(); trackTTL > 0 {
+		t := now.Add(trackTTL)
+		trackExpires = &t
 	}
 
 	err = s.pgClient.Transaction(ctx,
@@ -589,7 +594,7 @@ func (s *Service) addTrackEvent(
 					s.tableSessionStates,
 				),
 				updatedStateBytes,
-				sessState.UpdatedAt, expiresAt,
+				sessState.UpdatedAt, sessionExpires,
 				key.AppName, key.UserID,
 				key.SessionID,
 			)
@@ -612,7 +617,7 @@ func (s *Service) addTrackEvent(
 				key.AppName, key.UserID,
 				key.SessionID, trackEvent.Track,
 				eventBytes, trackCreatedAt,
-				nowUTC, expiresAt,
+				nowUTC, trackExpires,
 			)
 			if err != nil {
 				return fmt.Errorf(
@@ -931,15 +936,8 @@ func (s *Service) getTrackEvents(
 			len(sessionStates), len(sessionKeys),
 		)
 	}
-
-	type trackQuery struct {
-		sessionIdx int
-		track      session.Track
-		query      string
-		args       []any
-	}
-	queries := make([]*trackQuery, 0)
-	for i, key := range sessionKeys {
+	trackLists := make([][]session.Track, len(sessionKeys))
+	for i := range sessionKeys {
 		tracks, err := session.TracksFromState(
 			sessionStates[i].State,
 		)
@@ -948,6 +946,38 @@ func (s *Service) getTrackEvents(
 				"get track list failed: %w", err,
 			)
 		}
+		trackLists[i] = tracks
+	}
+	return s.getTrackEventsByTrackLists(
+		ctx, sessionKeys, trackLists, limit, afterTime,
+	)
+}
+
+func (s *Service) getTrackEventsByTrackLists(
+	ctx context.Context,
+	sessionKeys []session.Key,
+	trackLists [][]session.Track,
+	limit int,
+	afterTime time.Time,
+) ([]map[session.Track][]session.TrackEvent, error) {
+	if len(sessionKeys) == 0 {
+		return nil, nil
+	}
+	if len(trackLists) != len(sessionKeys) {
+		return nil, fmt.Errorf(
+			"track lists count mismatch: %d != %d",
+			len(trackLists), len(sessionKeys),
+		)
+	}
+	type trackQuery struct {
+		sessionIdx int
+		track      session.Track
+		query      string
+		args       []any
+	}
+	queries := make([]*trackQuery, 0)
+	for i, key := range sessionKeys {
+		tracks := trackLists[i]
 		for _, track := range tracks {
 			var q string
 			var args []any
@@ -999,7 +1029,6 @@ func (s *Service) getTrackEvents(
 			})
 		}
 	}
-
 	results := make(
 		[]map[session.Track][]session.TrackEvent,
 		len(sessionKeys),

--- a/session/pgvector/service_helper_test.go
+++ b/session/pgvector/service_helper_test.go
@@ -681,6 +681,25 @@ func TestGetTrackEvents_MismatchedLengths(t *testing.T) {
 	assert.Contains(t, err.Error(), "count mismatch")
 }
 
+func TestGetTrackEventsByTrackLists_EmptyAndMismatch(t *testing.T) {
+	s, _, db := newTestService(t, nil)
+	defer db.Close()
+	got, err := s.getTrackEventsByTrackLists(
+		context.Background(), nil, nil, 0, time.Time{},
+	)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	_, err = s.getTrackEventsByTrackLists(
+		context.Background(),
+		[]session.Key{{AppName: "app", UserID: "user", SessionID: "s1"}},
+		nil,
+		0,
+		time.Time{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "track lists count mismatch")
+}
+
 func TestGetTrackEvents_NoTracks(t *testing.T) {
 	s, _, db := newTestService(t, nil)
 	defer db.Close()

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -15,6 +15,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -3752,6 +3753,48 @@ func TestAppendTrackEvent_SyncMode_Success(
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAppendTrackEvent_TrackTTLOverridesSessionTTL(
+	t *testing.T,
+) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+	s.opts.enableAsyncPersist = false
+	s.opts.sessionTTL = time.Hour
+	trackTTL := time.Duration(0)
+	s.opts.trackEventTTL = &trackTTL
+
+	sess := session.NewSession("app", "user", "sess")
+	sessState := SessionState{
+		ID:    "sess",
+		State: session.StateMap{},
+	}
+	stateBytes, _ := json.Marshal(sessState)
+	te := &session.TrackEvent{
+		Track:     "track1",
+		Timestamp: time.Now(),
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT state, expires_at FROM").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"state", "expires_at"},
+		).AddRow(stateBytes, nil))
+	mock.ExpectExec("UPDATE .* SET state").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), "app", "user", "sess").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO session_track").
+		WithArgs("app", "user", "sess", session.Track("track1"),
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := s.AppendTrackEvent(context.Background(), sess, te)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestAppendTrackEvent_SyncMode_AddError(
 	t *testing.T,
 ) {
@@ -4848,4 +4891,58 @@ func TestUpdateSessionState_EmptyStateBytes(
 		session.StateMap{"k": []byte("v")},
 	)
 	require.NoError(t, err)
+}
+
+func TestServiceGetTrackEventsReadsTrackStorage(t *testing.T) {
+	svc, mock, db := newTestService(t, nil)
+	defer db.Close()
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	track := session.Track("agui")
+	base := time.Now().Add(-time.Hour)
+	oldEvent := session.TrackEvent{Track: track, Payload: json.RawMessage(`"old"`), Timestamp: base}
+	newEvent := session.TrackEvent{Track: track, Payload: json.RawMessage(`"new"`), Timestamp: base.Add(time.Second)}
+	oldBytes, err := json.Marshal(oldEvent)
+	require.NoError(t, err)
+	newBytes, err := json.Marshal(newEvent)
+	require.NoError(t, err)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, track, base.Add(-time.Minute), 2).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(newBytes).AddRow(oldBytes))
+	got, err := svc.GetTrackEvents(ctx, key, track, session.WithEventTime(base.Add(-time.Minute)), session.WithEventNum(2))
+	require.NoError(t, err)
+	require.Equal(t, track, got.Track)
+	require.Len(t, got.Events, 2)
+	require.Equal(t, oldEvent.Payload, got.Events[0].Payload)
+	require.Equal(t, newEvent.Payload, got.Events[1].Payload)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("missing"), time.Time{}).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}))
+	missing, err := svc.GetTrackEvents(ctx, key, "missing")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("missing"), missing.Track)
+	require.Empty(t, missing.Events)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestServiceGetTrackEventsErrors(t *testing.T) {
+	t.Run("invalid key", func(t *testing.T) {
+		svc, _, db := newTestService(t, nil)
+		defer db.Close()
+		_, err := svc.GetTrackEvents(context.Background(), session.Key{UserID: "user", SessionID: "sess"}, "agui")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, session.ErrAppNameRequired)
+	})
+	t.Run("query error", func(t *testing.T) {
+		svc, mock, db := newTestService(t, nil)
+		defer db.Close()
+		key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+			WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("agui"), time.Time{}).
+			WillReturnError(assert.AnError)
+		_, err := svc.GetTrackEvents(context.Background(), key, "agui")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pgvector session service get track events failed")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }

--- a/session/postgres/options.go
+++ b/session/postgres/options.go
@@ -52,6 +52,7 @@ type ServiceOpts struct {
 	extraOptions []any
 
 	sessionTTL         time.Duration // TTL for session state and event list
+	trackEventTTL      *time.Duration
 	appStateTTL        time.Duration // TTL for app state
 	userStateTTL       time.Duration // TTL for user state
 	enableAsyncPersist bool
@@ -122,6 +123,13 @@ func (opts ServiceOpts) shouldCascadeFullSessionSummary() bool {
 		return true
 	}
 	return *opts.cascadeFullSessionSummary
+}
+
+func (opts ServiceOpts) effectiveTrackEventTTL() time.Duration {
+	if opts.trackEventTTL != nil {
+		return *opts.trackEventTTL
+	}
+	return opts.sessionTTL
 }
 
 // WithSessionEventLimit sets the limit of events in a session.
@@ -195,6 +203,15 @@ func WithExtraOptions(extraOptions ...any) ServiceOpt {
 func WithSessionTTL(ttl time.Duration) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.sessionTTL = ttl
+	}
+}
+
+// WithTrackEventTTL sets the TTL for track events.
+// If unset, track events use the session TTL. A non-positive TTL disables track
+// event expiration.
+func WithTrackEventTTL(ttl time.Duration) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.trackEventTTL = &ttl
 	}
 }
 

--- a/session/postgres/options_test.go
+++ b/session/postgres/options_test.go
@@ -257,6 +257,17 @@ func TestServiceOptions(t *testing.T) {
 		assert.Equal(t, ttl, opts.sessionTTL)
 	})
 
+	t.Run("WithTrackEventTTL", func(t *testing.T) {
+		opts := &ServiceOpts{sessionTTL: time.Hour}
+		assert.Equal(t, time.Hour, opts.effectiveTrackEventTTL())
+		WithTrackEventTTL(0)(opts)
+		require.NotNil(t, opts.trackEventTTL)
+		assert.Equal(t, time.Duration(0), opts.effectiveTrackEventTTL())
+		WithTrackEventTTL(30 * time.Minute)(opts)
+		require.NotNil(t, opts.trackEventTTL)
+		assert.Equal(t, 30*time.Minute, opts.effectiveTrackEventTTL())
+	})
+
 	t.Run("WithAppStateTTL", func(t *testing.T) {
 		opts := &ServiceOpts{}
 		ttl := 48 * time.Hour

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -118,7 +118,8 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 
 	// Set default cleanup interval if any TTL is configured and auto cleanup is not disabled
 	if opts.cleanupInterval <= 0 {
-		if opts.sessionTTL > 0 || opts.appStateTTL > 0 || opts.userStateTTL > 0 {
+		if opts.sessionTTL > 0 || opts.appStateTTL > 0 ||
+			opts.userStateTTL > 0 || opts.effectiveTrackEventTTL() > 0 {
 			opts.cleanupInterval = defaultCleanupIntervalSecond
 		}
 	}
@@ -776,6 +777,30 @@ func (s *Service) AppendTrackEvent(
 	return nil
 }
 
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *Service) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	trackEvents, err := s.getTrackEventsByTrackLists(
+		ctx,
+		[]session.Key{key},
+		[][]session.Track{{track}},
+		opt.EventNum,
+		opt.EventTime,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("postgres session service get track events failed: %w", err)
+	}
+	return &session.TrackEvents{Track: track, Events: trackEvents[0][track]}, nil
+}
+
 // Close closes the service.
 func (s *Service) Close() error {
 	s.once.Do(func() {
@@ -831,7 +856,7 @@ func (s *Service) cleanupExpiredData(ctx context.Context, userKey *session.UserK
 	tasks := []cleanupTask{
 		{s.tableSessionStates, s.opts.sessionTTL},
 		{s.tableSessionEvents, s.opts.sessionTTL},
-		{s.tableSessionTracks, s.opts.sessionTTL},
+		{s.tableSessionTracks, s.opts.effectiveTrackEventTTL()},
 		{s.tableSessionSummaries, s.opts.sessionTTL},
 		{s.tableAppStates, s.opts.appStateTTL},
 		{s.tableUserStates, s.opts.userStateTTL},

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -385,17 +385,22 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			return fmt.Errorf("marshal session state failed: %w", err)
 		}
 
-		var expiresAt *time.Time
+		var sessionExpires *time.Time
 		if s.opts.sessionTTL > 0 {
 			t := now.Add(s.opts.sessionTTL)
-			expiresAt = &t
+			sessionExpires = &t
+		}
+		var trackExpires *time.Time
+		if trackTTL := s.opts.effectiveTrackEventTTL(); trackTTL > 0 {
+			t := now.Add(trackTTL)
+			trackExpires = &t
 		}
 
 		// Update session state.
 		_, err = tx.ExecContext(ctx,
 			fmt.Sprintf(`UPDATE %s SET state = $1, updated_at = $2, expires_at = $3
 			 WHERE app_name = $4 AND user_id = $5 AND session_id = $6 AND deleted_at IS NULL`, s.tableSessionStates),
-			updatedStateBytes, updatedAt, expiresAt,
+			updatedStateBytes, updatedAt, sessionExpires,
 			key.AppName, key.UserID, key.SessionID)
 		if err != nil {
 			return fmt.Errorf("update session state failed: %w", err)
@@ -406,7 +411,7 @@ func (s *Service) addTrackEvent(ctx context.Context, key session.Key, trackEvent
 			fmt.Sprintf(`INSERT INTO %s (app_name, user_id, session_id, track, event, created_at, updated_at, expires_at)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, s.tableSessionTracks),
 			key.AppName, key.UserID, key.SessionID, trackEvent.Track, eventBytes,
-			trackEvent.Timestamp, trackEvent.Timestamp, expiresAt)
+			trackEvent.Timestamp, trackEvent.Timestamp, trackExpires)
 		if err != nil {
 			return fmt.Errorf("insert track event failed: %w", err)
 		}
@@ -789,7 +794,30 @@ func (s *Service) getTrackEvents(
 	if len(sessionStates) != len(sessionKeys) {
 		return nil, fmt.Errorf("session states count mismatch: %d != %d", len(sessionStates), len(sessionKeys))
 	}
+	trackLists := make([][]session.Track, len(sessionKeys))
+	for i := range sessionKeys {
+		tracks, err := session.TracksFromState(sessionStates[i].State)
+		if err != nil {
+			return nil, fmt.Errorf("get track list failed: %w", err)
+		}
+		trackLists[i] = tracks
+	}
+	return s.getTrackEventsByTrackLists(ctx, sessionKeys, trackLists, limit, afterTime)
+}
 
+func (s *Service) getTrackEventsByTrackLists(
+	ctx context.Context,
+	sessionKeys []session.Key,
+	trackLists [][]session.Track,
+	limit int,
+	afterTime time.Time,
+) ([]map[session.Track][]session.TrackEvent, error) {
+	if len(sessionKeys) == 0 {
+		return nil, nil
+	}
+	if len(trackLists) != len(sessionKeys) {
+		return nil, fmt.Errorf("track lists count mismatch: %d != %d", len(trackLists), len(sessionKeys))
+	}
 	type trackQuery struct {
 		sessionIdx int
 		track      session.Track
@@ -799,10 +827,7 @@ func (s *Service) getTrackEvents(
 	queries := make([]*trackQuery, 0)
 	now := time.Now()
 	for i, key := range sessionKeys {
-		tracks, err := session.TracksFromState(sessionStates[i].State)
-		if err != nil {
-			return nil, fmt.Errorf("get track list failed: %w", err)
-		}
+		tracks := trackLists[i]
 		for _, track := range tracks {
 			var query string
 			var args []any
@@ -832,7 +857,6 @@ func (s *Service) getTrackEvents(
 			})
 		}
 	}
-
 	results := make([]map[session.Track][]session.TrackEvent, len(sessionKeys))
 	for _, q := range queries {
 		events := make([]session.TrackEvent, 0)

--- a/session/postgres/service_helper_test.go
+++ b/session/postgres/service_helper_test.go
@@ -8,3 +8,33 @@
 //
 
 package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestGetTrackEventsByTrackLists_EmptyAndMismatch(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	s := createTestService(t, db)
+	got, err := s.getTrackEventsByTrackLists(context.Background(), nil, nil, 0, time.Time{})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	_, err = s.getTrackEventsByTrackLists(
+		context.Background(),
+		[]session.Key{{AppName: "app", UserID: "user", SessionID: "sess"}},
+		nil,
+		0,
+		time.Time{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "track lists count mismatch")
+}

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -249,6 +249,7 @@ func TestListSessions_EventPageValidation(t *testing.T) {
 // TestServiceOpts contains options for creating a test service
 type TestServiceOpts struct {
 	sessionTTL         time.Duration
+	trackEventTTL      *time.Duration
 	appStateTTL        time.Duration
 	userStateTTL       time.Duration
 	sessionEventLimit  int
@@ -366,6 +367,7 @@ func setupMockService(t *testing.T, opts *TestServiceOpts) (*Service, sqlmock.Sq
 		pgClient: client,
 		opts: ServiceOpts{
 			sessionTTL:         opts.sessionTTL,
+			trackEventTTL:      opts.trackEventTTL,
 			appStateTTL:        opts.appStateTTL,
 			userStateTTL:       opts.userStateTTL,
 			sessionEventLimit:  opts.sessionEventLimit,
@@ -1894,6 +1896,52 @@ func TestAppendTrackEvent_SyncMode(t *testing.T) {
 			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
+	mock.ExpectCommit()
+
+	err := s.AppendTrackEvent(context.Background(), sess, trackEvent)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAppendTrackEvent_TrackTTLOverridesSessionTTL(t *testing.T) {
+	trackTTL := time.Duration(0)
+	s, mock, db := setupMockService(t, &TestServiceOpts{
+		sessionTTL:    time.Hour,
+		trackEventTTL: &trackTTL,
+	})
+	defer db.Close()
+
+	sess := &session.Session{
+		ID:      "test-session",
+		AppName: "test-app",
+		UserID:  "test-user",
+		State:   session.StateMap{},
+	}
+	trackEvent := &session.TrackEvent{
+		Track:     "agui",
+		Payload:   json.RawMessage(`{"delta":"hi"}`),
+		Timestamp: time.Now(),
+	}
+	sessState := &SessionState{
+		ID:    "test-session",
+		State: session.StateMap{},
+	}
+	stateBytes, _ := json.Marshal(sessState)
+	stateRows := sqlmock.NewRows([]string{"state", "expires_at"}).
+		AddRow(stateBytes, nil)
+	expectLoadSessionStateForUpdate(mock, session.Key{
+		AppName:   "test-app",
+		UserID:    "test-user",
+		SessionID: "test-session",
+	}).WillReturnRows(stateRows)
+	mock.ExpectExec("UPDATE session_states SET state").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			"test-app", "test-user", "test-session").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO session_track_events").
+		WithArgs("test-app", "test-user", "test-session", "agui",
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	err := s.AppendTrackEvent(context.Background(), sess, trackEvent)
@@ -3530,4 +3578,64 @@ func TestUpdateSessionState_Success(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestServiceGetTrackEventsReadsTrackStorage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	svc := createTestService(t, db)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+	track := session.Track("agui")
+	base := time.Now().Add(-time.Hour)
+	oldEvent := session.TrackEvent{Track: track, Payload: json.RawMessage(`"old"`), Timestamp: base}
+	newEvent := session.TrackEvent{Track: track, Payload: json.RawMessage(`"new"`), Timestamp: base.Add(time.Second)}
+	oldBytes, err := json.Marshal(oldEvent)
+	require.NoError(t, err)
+	newBytes, err := json.Marshal(newEvent)
+	require.NoError(t, err)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, track, sqlmock.AnyArg(), base.Add(-time.Minute), 2).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(newBytes).AddRow(oldBytes))
+	got, err := svc.GetTrackEvents(ctx, key, track, session.WithEventTime(base.Add(-time.Minute)), session.WithEventNum(2))
+	require.NoError(t, err)
+	require.Equal(t, track, got.Track)
+	require.Len(t, got.Events, 2)
+	require.Equal(t, oldEvent.Payload, got.Events[0].Payload)
+	require.Equal(t, newEvent.Payload, got.Events[1].Payload)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("missing"), sqlmock.AnyArg(), time.Time{}).
+		WillReturnRows(sqlmock.NewRows([]string{"event"}))
+	missing, err := svc.GetTrackEvents(ctx, key, "missing")
+	require.NoError(t, err)
+	require.Equal(t, session.Track("missing"), missing.Track)
+	require.Empty(t, missing.Events)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestServiceGetTrackEventsErrors(t *testing.T) {
+	t.Run("invalid key", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+		svc := createTestService(t, db)
+		_, err = svc.GetTrackEvents(context.Background(), session.Key{UserID: "user", SessionID: "sess"}, "agui")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, session.ErrAppNameRequired)
+	})
+	t.Run("query error", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+		svc := createTestService(t, db)
+		key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
+		mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
+			WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("agui"), sqlmock.AnyArg(), time.Time{}).
+			WillReturnError(assert.AnError)
+		_, err = svc.GetTrackEvents(context.Background(), key, "agui")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "postgres session service get track events failed")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }

--- a/session/redis/internal/hashidx/keys.go
+++ b/session/redis/internal/hashidx/keys.go
@@ -93,6 +93,12 @@ func (b *keyBuilder) TrackTimeIndexKey(key session.Key, track session.Track) str
 	return fmt.Sprintf("%s:trkidx:time:%s:%s:%s:%s", b.fullPrefix(), key.AppName, b.hashTag(key.UserID), key.SessionID, track)
 }
 
+// TrackIndexKey returns the key for the session track name index.
+// Format: [userPrefix:]hashidx:trkidx:names:appName:{userID}:sessionID
+func (b *keyBuilder) TrackIndexKey(key session.Key) string {
+	return fmt.Sprintf("%s:trkidx:names:%s:%s:%s", b.fullPrefix(), key.AppName, b.hashTag(key.UserID), key.SessionID)
+}
+
 // TrackKeys returns all track-related keys for a given session and track.
 func (b *keyBuilder) TrackKeys(key session.Key, track session.Track) []string {
 	return []string{

--- a/session/redis/internal/hashidx/keys_test.go
+++ b/session/redis/internal/hashidx/keys_test.go
@@ -145,6 +145,14 @@ func TestKeyBuilder_TrackTimeIndexKey(t *testing.T) {
 	assert.Equal(t, "pfx:hashidx:trkidx:time:app:{u}:s:actions", kb2.TrackTimeIndexKey(key, "actions"))
 }
 
+func TestKeyBuilder_TrackIndexKey(t *testing.T) {
+	kb := newKeyBuilder("")
+	key := session.Key{AppName: "app", UserID: "u", SessionID: "s"}
+	assert.Equal(t, "hashidx:trkidx:names:app:{u}:s", kb.TrackIndexKey(key))
+	kb2 := newKeyBuilder("pfx")
+	assert.Equal(t, "pfx:hashidx:trkidx:names:app:{u}:s", kb2.TrackIndexKey(key))
+}
+
 func TestKeyBuilder_TrackKeys(t *testing.T) {
 	kb := newKeyBuilder("")
 	key := session.Key{AppName: "app", UserID: "u", SessionID: "s"}

--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -407,7 +407,8 @@ return 1
 // ARGV[1] = TrackEvent JSON
 // ARGV[2] = timestamp (UnixNano)
 // ARGV[3] = TTL (seconds, 0 = no TTL)
-// ARGV[4] = updated tracks value (base64-encoded JSON array, to set as state.tracks)
+// ARGV[4] = track TTL override set (1 or 0)
+// ARGV[5] = updated tracks value (base64-encoded JSON array, to set as state.tracks)
 // Returns: generated eventID (integer) on success, 0 if session not found.
 var luaAppendTrackEvent = redis.NewScript(`
 local dataKey = KEYS[1]
@@ -417,7 +418,8 @@ local metaKey = KEYS[3]
 local payload = ARGV[1]
 local ts = tonumber(ARGV[2])
 local ttl = tonumber(ARGV[3])
-local tracksVal = ARGV[4]
+local trackTTLSet = tonumber(ARGV[4]) == 1
+local tracksVal = ARGV[5]
 
 local function setPreserveTTL(key, value)
     local ttlMs = redis.call('PTTL', key)
@@ -452,6 +454,9 @@ setPreserveTTL(metaKey, cjson.encode(meta))
 if ttl > 0 then
     redis.call('EXPIRE', dataKey, ttl)
     redis.call('EXPIRE', idxKey, ttl)
+elseif trackTTLSet then
+    redis.call('PERSIST', dataKey)
+    redis.call('PERSIST', idxKey)
 end
 
 return id

--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -371,49 +371,6 @@ end
 return 1
 `)
 
-// luaCloseSessionForDelete makes a session unavailable to appends while
-// retaining discovered track names for the cleanup phase.
-// The first five keys are session meta, event data, event time index, summary,
-// and the track-name index.
-// The optional sixth key is the per-user session index hash.
-// The arguments are sessionID, track TTL seconds, whether TrackEventTTL is
-// explicitly set, and discovered track names.
-var luaCloseSessionForDelete = redis.NewScript(`
-local metaKey = KEYS[1]
-local eventDataKey = KEYS[2]
-local eventTimeKey = KEYS[3]
-local summaryKey = KEYS[4]
-local trackNamesKey = KEYS[5]
-local sessionID = ARGV[1]
-local ttl = tonumber(ARGV[2])
-local trackTTLSet = tonumber(ARGV[3]) == 1
-local seededTrack = false
-
-for i = 4, #ARGV do
-    local trackName = ARGV[i]
-    if trackName and trackName ~= '' then
-        redis.call('SADD', trackNamesKey, trackName)
-        seededTrack = true
-    end
-end
-
-if seededTrack then
-    if ttl > 0 then
-        redis.call('EXPIRE', trackNamesKey, ttl)
-    elseif trackTTLSet then
-        redis.call('PERSIST', trackNamesKey)
-    end
-end
-
-redis.call('DEL', metaKey, eventDataKey, eventTimeKey, summaryKey)
-
-if #KEYS >= 6 and sessionID and sessionID ~= '' then
-    redis.call('HDEL', KEYS[6], sessionID)
-end
-
-return 1
-`)
-
 // luaDeleteSession deletes all session data including any track keys,
 // and removes the session from the session index Hash.
 // KEYS[1..N-1] = keys to delete (meta, evtdata, evtidx:time, summary, track keys...)

--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -371,6 +371,49 @@ end
 return 1
 `)
 
+// luaCloseSessionForDelete makes a session unavailable to appends while
+// retaining discovered track names for the cleanup phase.
+// The first five keys are session meta, event data, event time index, summary,
+// and the track-name index.
+// The optional sixth key is the per-user session index hash.
+// The arguments are sessionID, track TTL seconds, whether TrackEventTTL is
+// explicitly set, and discovered track names.
+var luaCloseSessionForDelete = redis.NewScript(`
+local metaKey = KEYS[1]
+local eventDataKey = KEYS[2]
+local eventTimeKey = KEYS[3]
+local summaryKey = KEYS[4]
+local trackNamesKey = KEYS[5]
+local sessionID = ARGV[1]
+local ttl = tonumber(ARGV[2])
+local trackTTLSet = tonumber(ARGV[3]) == 1
+local seededTrack = false
+
+for i = 4, #ARGV do
+    local trackName = ARGV[i]
+    if trackName and trackName ~= '' then
+        redis.call('SADD', trackNamesKey, trackName)
+        seededTrack = true
+    end
+end
+
+if seededTrack then
+    if ttl > 0 then
+        redis.call('EXPIRE', trackNamesKey, ttl)
+    elseif trackTTLSet then
+        redis.call('PERSIST', trackNamesKey)
+    end
+end
+
+redis.call('DEL', metaKey, eventDataKey, eventTimeKey, summaryKey)
+
+if #KEYS >= 6 and sessionID and sessionID ~= '' then
+    redis.call('HDEL', KEYS[6], sessionID)
+end
+
+return 1
+`)
+
 // luaDeleteSession deletes all session data including any track keys,
 // and removes the session from the session index Hash.
 // KEYS[1..N-1] = keys to delete (meta, evtdata, evtidx:time, summary, track keys...)

--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -404,22 +404,26 @@ return 1
 // KEYS[1] = trkdata key (Hash, field=eventID value=TrackEvent JSON, field="_seq" = counter)
 // KEYS[2] = trkidx:time key (ZSet, member=eventID, score=timestamp)
 // KEYS[3] = sessionMeta key (String, for existence check and track registration)
+// KEYS[4] = trkidx:names key (Set, member=trackName)
 // ARGV[1] = TrackEvent JSON
 // ARGV[2] = timestamp (UnixNano)
 // ARGV[3] = TTL (seconds, 0 = no TTL)
 // ARGV[4] = track TTL override set (1 or 0)
 // ARGV[5] = updated tracks value (base64-encoded JSON array, to set as state.tracks)
+// ARGV[6] = track name
 // Returns: generated eventID (integer) on success, 0 if session not found.
 var luaAppendTrackEvent = redis.NewScript(`
 local dataKey = KEYS[1]
 local idxKey = KEYS[2]
 local metaKey = KEYS[3]
+local trackNamesKey = KEYS[4]
 
 local payload = ARGV[1]
 local ts = tonumber(ARGV[2])
 local ttl = tonumber(ARGV[3])
 local trackTTLSet = tonumber(ARGV[4]) == 1
 local tracksVal = ARGV[5]
+local trackName = ARGV[6]
 
 local function setPreserveTTL(key, value)
     local ttlMs = redis.call('PTTL', key)
@@ -441,6 +445,7 @@ local id = redis.call('HINCRBY', dataKey, '_seq', 1)
 -- Store event data and time index
 redis.call('HSET', dataKey, id, payload)
 redis.call('ZADD', idxKey, ts, id)
+redis.call('SADD', trackNamesKey, trackName)
 
 -- Update session meta's state.tracks with the Go-provided value
 local meta = cjson.decode(metaJSON)
@@ -454,9 +459,11 @@ setPreserveTTL(metaKey, cjson.encode(meta))
 if ttl > 0 then
     redis.call('EXPIRE', dataKey, ttl)
     redis.call('EXPIRE', idxKey, ttl)
+    redis.call('EXPIRE', trackNamesKey, ttl)
 elseif trackTTLSet then
     redis.call('PERSIST', dataKey)
     redis.call('PERSIST', idxKey)
+    redis.call('PERSIST', trackNamesKey)
 end
 
 return id

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -23,7 +23,9 @@ import (
 
 // Config holds configuration for HashIdx session storage client.
 type Config struct {
-	SessionTTL        time.Duration
+	SessionTTL time.Duration
+	// TrackEventTTL controls track event expiration. Nil falls back to
+	// SessionTTL, and non-positive values disable expiration.
 	TrackEventTTL     *time.Duration
 	AppStateTTL       time.Duration
 	UserStateTTL      time.Duration

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -411,34 +411,67 @@ func boolToInt(b bool) int {
 // including track keys discovered from session state and the track index.
 // When EnableUserSessionIndex is true, also removes the session index entry.
 func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
-	keys := c.keys.SessionKeys(key)
-	tracks, err := c.listTracksForDelete(ctx, key)
+	tracks, _ := c.ListTracksForSession(ctx, key)
+	if err := c.closeSessionForDelete(ctx, key, tracks); err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	indexedTracks, err := c.listTracksFromIndex(ctx, key)
 	if err != nil {
 		return fmt.Errorf("delete session: list tracks: %w", err)
 	}
-	for _, t := range tracks {
-		keys = append(keys, c.keys.TrackKeys(key, t)...)
+	tracks = mergeTrackNames(tracks, indexedTracks)
+	return c.deleteTrackStorage(ctx, key, tracks)
+}
+
+func (c *Client) closeSessionForDelete(ctx context.Context, key session.Key, tracks []session.Track) error {
+	keys := []string{
+		c.keys.SessionMetaKey(key),
+		c.keys.EventDataKey(key),
+		c.keys.EventTimeIndexKey(key),
+		c.keys.SummaryKey(key),
+		c.keys.TrackIndexKey(key),
 	}
-	keys = append(keys, c.keys.TrackIndexKey(key))
 	if c.cfg.EnableUserSessionIndex {
-		if err := c.removeSessionFromUserIndex(ctx, keys, key); err != nil {
-			return err
-		}
-	} else {
-		if _, err := c.runScript(ctx, luaDeleteSessionLegacy, keys).Result(); err != nil {
-			return fmt.Errorf("delete session: %w", err)
-		}
+		userKey := session.UserKey{AppName: key.AppName, UserID: key.UserID}
+		keys = append(keys, c.keys.SessionIndexKey(userKey))
+	}
+	ttlSeconds := int64(0)
+	trackTTL := c.cfg.effectiveTrackEventTTL()
+	if trackTTL > 0 {
+		ttlSeconds = ttlSecondsCeil(trackTTL)
+	}
+	args := []any{
+		key.SessionID,
+		ttlSeconds,
+		boolToInt(c.cfg.TrackEventTTL != nil),
+	}
+	for _, track := range tracks {
+		args = append(args, string(track))
+	}
+	if _, err := c.runScript(ctx, luaCloseSessionForDelete, keys, args...).Result(); err != nil {
+		return err
 	}
 	return nil
 }
 
-func (c *Client) listTracksForDelete(ctx context.Context, key session.Key) ([]session.Track, error) {
-	tracks, _ := c.ListTracksForSession(ctx, key)
+func (c *Client) deleteTrackStorage(ctx context.Context, key session.Key, tracks []session.Track) error {
+	keys := make([]string, 0, len(tracks)*2+1)
+	for _, t := range tracks {
+		keys = append(keys, c.keys.TrackKeys(key, t)...)
+	}
+	keys = append(keys, c.keys.TrackIndexKey(key))
+	if _, err := c.runScript(ctx, luaDeleteSessionLegacy, keys).Result(); err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) listTracksFromIndex(ctx context.Context, key session.Key) ([]string, error) {
 	indexedTracks, err := c.client.SMembers(ctx, c.keys.TrackIndexKey(key)).Result()
 	if err != nil && err != redis.Nil {
 		return nil, err
 	}
-	return mergeTrackNames(tracks, indexedTracks), nil
+	return indexedTracks, nil
 }
 
 func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.Track {

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -408,16 +408,18 @@ func boolToInt(b bool) int {
 }
 
 // DeleteSession deletes a session and all associated data in HashIdx storage,
-// including track keys discovered from session state.
+// including track keys discovered from session state and the track index.
 // When EnableUserSessionIndex is true, also removes the session index entry.
 func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
 	keys := c.keys.SessionKeys(key)
-
-	tracks, _ := c.ListTracksForSession(ctx, key)
+	tracks, err := c.listTracksForDelete(ctx, key)
+	if err != nil {
+		return fmt.Errorf("delete session: list tracks: %w", err)
+	}
 	for _, t := range tracks {
 		keys = append(keys, c.keys.TrackKeys(key, t)...)
 	}
-
+	keys = append(keys, c.keys.TrackIndexKey(key))
 	if c.cfg.EnableUserSessionIndex {
 		if err := c.removeSessionFromUserIndex(ctx, keys, key); err != nil {
 			return err
@@ -428,6 +430,39 @@ func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
 		}
 	}
 	return nil
+}
+
+func (c *Client) listTracksForDelete(ctx context.Context, key session.Key) ([]session.Track, error) {
+	tracks, _ := c.ListTracksForSession(ctx, key)
+	indexedTracks, err := c.client.SMembers(ctx, c.keys.TrackIndexKey(key)).Result()
+	if err != nil && err != redis.Nil {
+		return nil, err
+	}
+	return mergeTrackNames(tracks, indexedTracks), nil
+}
+
+func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.Track {
+	if len(indexedTracks) == 0 {
+		return tracks
+	}
+	result := make([]session.Track, 0, len(tracks)+len(indexedTracks))
+	seen := make(map[session.Track]struct{}, len(tracks)+len(indexedTracks))
+	for _, track := range tracks {
+		if _, ok := seen[track]; ok {
+			continue
+		}
+		seen[track] = struct{}{}
+		result = append(result, track)
+	}
+	for _, indexedTrack := range indexedTracks {
+		track := session.Track(indexedTrack)
+		if _, ok := seen[track]; ok {
+			continue
+		}
+		seen[track] = struct{}{}
+		result = append(result, track)
+	}
+	return result
 }
 
 // TrimConversations trims the most recent N conversations from the session (HashIdx).

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -411,67 +411,34 @@ func boolToInt(b bool) int {
 // including track keys discovered from session state and the track index.
 // When EnableUserSessionIndex is true, also removes the session index entry.
 func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
-	tracks, _ := c.ListTracksForSession(ctx, key)
-	if err := c.closeSessionForDelete(ctx, key, tracks); err != nil {
-		return fmt.Errorf("delete session: %w", err)
-	}
-	indexedTracks, err := c.listTracksFromIndex(ctx, key)
+	keys := c.keys.SessionKeys(key)
+	tracks, err := c.listTracksForDelete(ctx, key)
 	if err != nil {
 		return fmt.Errorf("delete session: list tracks: %w", err)
 	}
-	tracks = mergeTrackNames(tracks, indexedTracks)
-	return c.deleteTrackStorage(ctx, key, tracks)
-}
-
-func (c *Client) closeSessionForDelete(ctx context.Context, key session.Key, tracks []session.Track) error {
-	keys := []string{
-		c.keys.SessionMetaKey(key),
-		c.keys.EventDataKey(key),
-		c.keys.EventTimeIndexKey(key),
-		c.keys.SummaryKey(key),
-		c.keys.TrackIndexKey(key),
-	}
-	if c.cfg.EnableUserSessionIndex {
-		userKey := session.UserKey{AppName: key.AppName, UserID: key.UserID}
-		keys = append(keys, c.keys.SessionIndexKey(userKey))
-	}
-	ttlSeconds := int64(0)
-	trackTTL := c.cfg.effectiveTrackEventTTL()
-	if trackTTL > 0 {
-		ttlSeconds = ttlSecondsCeil(trackTTL)
-	}
-	args := []any{
-		key.SessionID,
-		ttlSeconds,
-		boolToInt(c.cfg.TrackEventTTL != nil),
-	}
-	for _, track := range tracks {
-		args = append(args, string(track))
-	}
-	if _, err := c.runScript(ctx, luaCloseSessionForDelete, keys, args...).Result(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *Client) deleteTrackStorage(ctx context.Context, key session.Key, tracks []session.Track) error {
-	keys := make([]string, 0, len(tracks)*2+1)
 	for _, t := range tracks {
 		keys = append(keys, c.keys.TrackKeys(key, t)...)
 	}
 	keys = append(keys, c.keys.TrackIndexKey(key))
-	if _, err := c.runScript(ctx, luaDeleteSessionLegacy, keys).Result(); err != nil {
-		return fmt.Errorf("delete session: %w", err)
+	if c.cfg.EnableUserSessionIndex {
+		if err := c.removeSessionFromUserIndex(ctx, keys, key); err != nil {
+			return err
+		}
+	} else {
+		if _, err := c.runScript(ctx, luaDeleteSessionLegacy, keys).Result(); err != nil {
+			return fmt.Errorf("delete session: %w", err)
+		}
 	}
 	return nil
 }
 
-func (c *Client) listTracksFromIndex(ctx context.Context, key session.Key) ([]string, error) {
+func (c *Client) listTracksForDelete(ctx context.Context, key session.Key) ([]session.Track, error) {
+	tracks, _ := c.ListTracksForSession(ctx, key)
 	indexedTracks, err := c.client.SMembers(ctx, c.keys.TrackIndexKey(key)).Result()
 	if err != nil && err != redis.Nil {
 		return nil, err
 	}
-	return indexedTracks, nil
+	return mergeTrackNames(tracks, indexedTracks), nil
 }
 
 func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.Track {

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -24,6 +24,7 @@ import (
 // Config holds configuration for HashIdx session storage client.
 type Config struct {
 	SessionTTL        time.Duration
+	TrackEventTTL     *time.Duration
 	AppStateTTL       time.Duration
 	UserStateTTL      time.Duration
 	SessionEventLimit int
@@ -39,6 +40,13 @@ type Config struct {
 	// cache is not reliably maintained (e.g. a Tendis cluster fronted by twemproxy),
 	// avoiding repeated NOSCRIPT round-trips and the resulting monitoring noise.
 	DisableScriptCache bool
+}
+
+func (cfg Config) effectiveTrackEventTTL() time.Duration {
+	if cfg.TrackEventTTL != nil {
+		return *cfg.TrackEventTTL
+	}
+	return cfg.SessionTTL
 }
 
 // Client implements HashIdx session storage logic.

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -419,6 +419,59 @@ func TestClient_DeleteSession_WithRetainedTracksAfterSessionMetaExpired(t *testi
 	assert.False(t, mr.Exists(trackNamesKey))
 }
 
+func TestClient_DeleteSession_DeletesTrackAppendedAfterInitialDiscovery(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "late-track-delete"}
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	alphaTracks, err := json.Marshal([]string{"alpha"})
+	require.NoError(t, err)
+	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"alpha"`),
+		Timestamp: time.Now(),
+	}, alphaTracks))
+	discoveredTracks, err := c.ListTracksForSession(ctx, key)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []session.Track{"alpha"}, discoveredTracks)
+	betaTracks, err := json.Marshal([]string{"alpha", "beta"})
+	require.NoError(t, err)
+	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "beta",
+		Payload:   json.RawMessage(`"beta"`),
+		Timestamp: time.Now(),
+	}, betaTracks))
+	require.NoError(t, c.closeSessionForDelete(ctx, key, discoveredTracks))
+	gammaTracks, err := json.Marshal([]string{"alpha", "beta", "gamma"})
+	require.NoError(t, err)
+	err = c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "gamma",
+		Payload:   json.RawMessage(`"gamma"`),
+		Timestamp: time.Now(),
+	}, gammaTracks)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session not found")
+	indexedTracks, err := c.listTracksFromIndex(ctx, key)
+	require.NoError(t, err)
+	tracks := mergeTrackNames(discoveredTracks, indexedTracks)
+	require.ElementsMatch(t, []session.Track{"alpha", "beta"}, tracks)
+	require.NoError(t, c.deleteTrackStorage(ctx, key, tracks))
+	got, err := c.GetTrackEvents(ctx, key, []session.Track{"alpha", "beta", "gamma"}, 0, time.Time{})
+	require.NoError(t, err)
+	assert.Empty(t, got["alpha"])
+	assert.Empty(t, got["beta"])
+	assert.Empty(t, got["gamma"])
+	assert.False(t, mr.Exists(c.keys.TrackDataKey(key, "alpha")))
+	assert.False(t, mr.Exists(c.keys.TrackTimeIndexKey(key, "alpha")))
+	assert.False(t, mr.Exists(c.keys.TrackDataKey(key, "beta")))
+	assert.False(t, mr.Exists(c.keys.TrackTimeIndexKey(key, "beta")))
+	assert.False(t, mr.Exists(c.keys.TrackDataKey(key, "gamma")))
+	assert.False(t, mr.Exists(c.keys.TrackTimeIndexKey(key, "gamma")))
+	assert.False(t, mr.Exists(c.keys.TrackIndexKey(key)))
+}
+
 func TestClient_DeleteEvent(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -419,59 +419,6 @@ func TestClient_DeleteSession_WithRetainedTracksAfterSessionMetaExpired(t *testi
 	assert.False(t, mr.Exists(trackNamesKey))
 }
 
-func TestClient_DeleteSession_DeletesTrackAppendedAfterInitialDiscovery(t *testing.T) {
-	mr, rdb := setupMiniredis(t)
-	c := NewClient(rdb, defaultConfig())
-	ctx := context.Background()
-	key := session.Key{AppName: "app", UserID: "u1", SessionID: "late-track-delete"}
-	_, err := c.CreateSession(ctx, key, nil)
-	require.NoError(t, err)
-	alphaTracks, err := json.Marshal([]string{"alpha"})
-	require.NoError(t, err)
-	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
-		Track:     "alpha",
-		Payload:   json.RawMessage(`"alpha"`),
-		Timestamp: time.Now(),
-	}, alphaTracks))
-	discoveredTracks, err := c.ListTracksForSession(ctx, key)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []session.Track{"alpha"}, discoveredTracks)
-	betaTracks, err := json.Marshal([]string{"alpha", "beta"})
-	require.NoError(t, err)
-	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
-		Track:     "beta",
-		Payload:   json.RawMessage(`"beta"`),
-		Timestamp: time.Now(),
-	}, betaTracks))
-	require.NoError(t, c.closeSessionForDelete(ctx, key, discoveredTracks))
-	gammaTracks, err := json.Marshal([]string{"alpha", "beta", "gamma"})
-	require.NoError(t, err)
-	err = c.AppendTrackEvent(ctx, key, &session.TrackEvent{
-		Track:     "gamma",
-		Payload:   json.RawMessage(`"gamma"`),
-		Timestamp: time.Now(),
-	}, gammaTracks)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "session not found")
-	indexedTracks, err := c.listTracksFromIndex(ctx, key)
-	require.NoError(t, err)
-	tracks := mergeTrackNames(discoveredTracks, indexedTracks)
-	require.ElementsMatch(t, []session.Track{"alpha", "beta"}, tracks)
-	require.NoError(t, c.deleteTrackStorage(ctx, key, tracks))
-	got, err := c.GetTrackEvents(ctx, key, []session.Track{"alpha", "beta", "gamma"}, 0, time.Time{})
-	require.NoError(t, err)
-	assert.Empty(t, got["alpha"])
-	assert.Empty(t, got["beta"])
-	assert.Empty(t, got["gamma"])
-	assert.False(t, mr.Exists(c.keys.TrackDataKey(key, "alpha")))
-	assert.False(t, mr.Exists(c.keys.TrackTimeIndexKey(key, "alpha")))
-	assert.False(t, mr.Exists(c.keys.TrackDataKey(key, "beta")))
-	assert.False(t, mr.Exists(c.keys.TrackTimeIndexKey(key, "beta")))
-	assert.False(t, mr.Exists(c.keys.TrackDataKey(key, "gamma")))
-	assert.False(t, mr.Exists(c.keys.TrackTimeIndexKey(key, "gamma")))
-	assert.False(t, mr.Exists(c.keys.TrackIndexKey(key)))
-}
-
 func TestClient_DeleteEvent(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -361,19 +361,62 @@ func TestClient_DeleteSession_WithTracks(t *testing.T) {
 	tracksJSON, _ := json.Marshal([]string{"alpha"})
 	require.NoError(t, c.AppendTrackEvent(ctx, key, te, tracksJSON))
 
-	// Verify track keys exist
+	// Verify track keys exist.
 	trkDataKey := c.keys.TrackDataKey(key, "alpha")
 	trkIdxKey := c.keys.TrackTimeIndexKey(key, "alpha")
-	n, err := rdb.Exists(ctx, trkDataKey, trkIdxKey).Result()
+	trkNamesKey := c.keys.TrackIndexKey(key)
+	n, err := rdb.Exists(ctx, trkDataKey, trkIdxKey, trkNamesKey).Result()
 	require.NoError(t, err)
-	assert.Equal(t, int64(2), n)
+	assert.Equal(t, int64(3), n)
 
 	require.NoError(t, c.DeleteSession(ctx, key))
 
-	// All keys should be gone
-	n, err = rdb.Exists(ctx, trkDataKey, trkIdxKey, c.keys.SessionMetaKey(key)).Result()
+	// All keys should be gone.
+	n, err = rdb.Exists(ctx, trkDataKey, trkIdxKey, trkNamesKey, c.keys.SessionMetaKey(key)).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n)
+}
+
+func TestClient_DeleteSession_WithRetainedTracksAfterSessionMetaExpired(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = time.Second
+	createClient := NewClient(rdb, createCfg)
+	trackTTL := time.Duration(0)
+	appendCfg := createCfg
+	appendCfg.TrackEventTTL = &trackTTL
+	appendClient := NewClient(rdb, appendCfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "retained-track-delete"}
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	tracksJSON, err := json.Marshal([]string{"alpha"})
+	require.NoError(t, err)
+	require.NoError(t, appendClient.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"payload"`),
+		Timestamp: time.Now(),
+	}, tracksJSON))
+	metaKey := createClient.keys.SessionMetaKey(key)
+	trackDataKey := createClient.keys.TrackDataKey(key, "alpha")
+	trackTimeIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	trackNamesKey := createClient.keys.TrackIndexKey(key)
+	assert.True(t, mr.Exists(metaKey))
+	assert.True(t, mr.Exists(trackDataKey))
+	assert.True(t, mr.Exists(trackTimeIndexKey))
+	assert.True(t, mr.Exists(trackNamesKey))
+	mr.FastForward(2 * time.Second)
+	assert.False(t, mr.Exists(metaKey))
+	got, err := appendClient.GetTrackEvents(ctx, key, []session.Track{"alpha"}, 0, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, got["alpha"], 1)
+	require.NoError(t, createClient.DeleteSession(ctx, key))
+	got, err = appendClient.GetTrackEvents(ctx, key, []session.Track{"alpha"}, 0, time.Time{})
+	require.NoError(t, err)
+	assert.Empty(t, got["alpha"])
+	assert.False(t, mr.Exists(trackDataKey))
+	assert.False(t, mr.Exists(trackTimeIndexKey))
+	assert.False(t, mr.Exists(trackNamesKey))
 }
 
 func TestClient_DeleteEvent(t *testing.T) {

--- a/session/redis/internal/hashidx/track.go
+++ b/session/redis/internal/hashidx/track.go
@@ -33,8 +33,9 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 	}
 
 	ttlSeconds := int64(0)
-	if c.cfg.SessionTTL > 0 {
-		ttlSeconds = int64(c.cfg.SessionTTL.Seconds())
+	trackTTL := c.cfg.effectiveTrackEventTTL()
+	if trackTTL > 0 {
+		ttlSeconds = int64(trackTTL.Seconds())
 	}
 
 	// Encode tracksState as base64 to match Go's json.Marshal behavior for []byte.
@@ -54,6 +55,7 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 		string(eventJSON),
 		trackEvent.Timestamp.UnixNano(),
 		ttlSeconds,
+		boolToInt(c.cfg.TrackEventTTL != nil),
 		tracksVal,
 	}
 

--- a/session/redis/internal/hashidx/track.go
+++ b/session/redis/internal/hashidx/track.go
@@ -50,6 +50,7 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 		c.keys.TrackDataKey(key, track),
 		c.keys.TrackTimeIndexKey(key, track),
 		c.keys.SessionMetaKey(key),
+		c.keys.TrackIndexKey(key),
 	}
 	args := []any{
 		string(eventJSON),
@@ -57,6 +58,7 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 		ttlSeconds,
 		boolToInt(c.cfg.TrackEventTTL != nil),
 		tracksVal,
+		string(track),
 	}
 
 	result, err := c.runScript(ctx, luaAppendTrackEvent, keys, args...).Int64()

--- a/session/redis/internal/hashidx/track.go
+++ b/session/redis/internal/hashidx/track.go
@@ -35,7 +35,7 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 	ttlSeconds := int64(0)
 	trackTTL := c.cfg.effectiveTrackEventTTL()
 	if trackTTL > 0 {
-		ttlSeconds = int64(trackTTL.Seconds())
+		ttlSeconds = ttlSecondsCeil(trackTTL)
 	}
 
 	// Encode tracksState as base64 to match Go's json.Marshal behavior for []byte.
@@ -67,6 +67,17 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 		return fmt.Errorf("session not found")
 	}
 	return nil
+}
+
+func ttlSecondsCeil(ttl time.Duration) int64 {
+	if ttl <= 0 {
+		return 0
+	}
+	seconds := ttl / time.Second
+	if ttl%time.Second != 0 {
+		seconds++
+	}
+	return int64(seconds)
 }
 
 // GetTrackEvents retrieves track events for a session using Hash+ZSet structure.

--- a/session/redis/internal/hashidx/track_test.go
+++ b/session/redis/internal/hashidx/track_test.go
@@ -133,6 +133,32 @@ func TestClient_AppendTrackEvent_TrackTTLZeroPersistsTrackKeys(t *testing.T) {
 	assert.Equal(t, time.Duration(0), mr.TTL(trackIndexKey))
 }
 
+func TestClient_AppendTrackEvent_SubSecondTrackTTLExpiresTrackKeys(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createClient := NewClient(rdb, createCfg)
+	trackTTL := 500 * time.Millisecond
+	appendCfg := createCfg
+	appendCfg.TrackEventTTL = &trackTTL
+	appendClient := NewClient(rdb, appendCfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "trk-ttl-sub-second"}
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	tracksJSON, err := json.Marshal([]string{"alpha"})
+	require.NoError(t, err)
+	err = appendClient.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"payload"`),
+		Timestamp: time.Now(),
+	}, tracksJSON)
+	require.NoError(t, err)
+	trackDataKey := createClient.keys.TrackDataKey(key, "alpha")
+	trackIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	assert.Equal(t, time.Second, mr.TTL(trackDataKey))
+	assert.Equal(t, time.Second, mr.TTL(trackIndexKey))
+}
+
 func TestClient_GetTrackEvents(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/hashidx/track_test.go
+++ b/session/redis/internal/hashidx/track_test.go
@@ -126,11 +126,14 @@ func TestClient_AppendTrackEvent_TrackTTLZeroPersistsTrackKeys(t *testing.T) {
 	}, tracksJSON)
 	require.NoError(t, err)
 	trackDataKey := createClient.keys.TrackDataKey(key, "alpha")
-	trackIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	trackTimeIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	trackNamesKey := createClient.keys.TrackIndexKey(key)
 	assert.True(t, mr.Exists(trackDataKey))
-	assert.True(t, mr.Exists(trackIndexKey))
+	assert.True(t, mr.Exists(trackTimeIndexKey))
+	assert.True(t, mr.Exists(trackNamesKey))
 	assert.Equal(t, time.Duration(0), mr.TTL(trackDataKey))
-	assert.Equal(t, time.Duration(0), mr.TTL(trackIndexKey))
+	assert.Equal(t, time.Duration(0), mr.TTL(trackTimeIndexKey))
+	assert.Equal(t, time.Duration(0), mr.TTL(trackNamesKey))
 }
 
 func TestClient_AppendTrackEvent_SubSecondTrackTTLExpiresTrackKeys(t *testing.T) {
@@ -154,9 +157,11 @@ func TestClient_AppendTrackEvent_SubSecondTrackTTLExpiresTrackKeys(t *testing.T)
 	}, tracksJSON)
 	require.NoError(t, err)
 	trackDataKey := createClient.keys.TrackDataKey(key, "alpha")
-	trackIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	trackTimeIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	trackNamesKey := createClient.keys.TrackIndexKey(key)
 	assert.Equal(t, time.Second, mr.TTL(trackDataKey))
-	assert.Equal(t, time.Second, mr.TTL(trackIndexKey))
+	assert.Equal(t, time.Second, mr.TTL(trackTimeIndexKey))
+	assert.Equal(t, time.Second, mr.TTL(trackNamesKey))
 }
 
 func TestClient_GetTrackEvents(t *testing.T) {

--- a/session/redis/internal/hashidx/track_test.go
+++ b/session/redis/internal/hashidx/track_test.go
@@ -104,6 +104,35 @@ func TestClient_AppendTrackEvent_PreservesExistingTTLWithoutRefresh(t *testing.T
 	assert.Contains(t, tracks, session.Track("alpha"))
 }
 
+func TestClient_AppendTrackEvent_TrackTTLZeroPersistsTrackKeys(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = 10 * time.Second
+	createClient := NewClient(rdb, createCfg)
+	trackTTL := time.Duration(0)
+	appendCfg := createCfg
+	appendCfg.TrackEventTTL = &trackTTL
+	appendClient := NewClient(rdb, appendCfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "trk-ttl-zero"}
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	tracksJSON, err := json.Marshal([]string{"alpha"})
+	require.NoError(t, err)
+	err = appendClient.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"payload"`),
+		Timestamp: time.Now(),
+	}, tracksJSON)
+	require.NoError(t, err)
+	trackDataKey := createClient.keys.TrackDataKey(key, "alpha")
+	trackIndexKey := createClient.keys.TrackTimeIndexKey(key, "alpha")
+	assert.True(t, mr.Exists(trackDataKey))
+	assert.True(t, mr.Exists(trackIndexKey))
+	assert.Equal(t, time.Duration(0), mr.TTL(trackDataKey))
+	assert.Equal(t, time.Duration(0), mr.TTL(trackIndexKey))
+}
+
 func TestClient_GetTrackEvents(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -362,20 +362,50 @@ func (c *Client) UpdateSessionState(ctx context.Context, key session.Key, state 
 
 // DeleteSession deletes a session in ZSet.
 func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
-	txPipe := c.client.TxPipeline()
-	txPipe.HDel(ctx, c.sessionStateKey(key), key.SessionID)
-	txPipe.HDel(ctx, c.sessionSummaryKey(key), key.SessionID)
-	txPipe.Del(ctx, c.eventKey(key))
-	tracks, err := c.listTracksForDelete(ctx, key)
+	tracks, err := c.listTracksForSession(ctx, key)
 	if err != nil {
 		return fmt.Errorf("list tracks: %w", err)
 	}
+	if err := c.closeSessionForDelete(ctx, key, tracks); err != nil {
+		return err
+	}
+	indexedTracks, err := c.listTracksFromIndex(ctx, key)
+	if err != nil {
+		return fmt.Errorf("list track index: %w", err)
+	}
+	tracks = mergeTrackNames(tracks, indexedTracks)
+	return c.deleteTrackStorage(ctx, key, tracks)
+}
+
+func (c *Client) closeSessionForDelete(ctx context.Context, key session.Key, tracks []session.Track) error {
+	txPipe := c.client.TxPipeline()
+	if len(tracks) > 0 {
+		trackIndexKey := c.trackIndexKey(key)
+		txPipe.SAdd(ctx, trackIndexKey, trackNameValues(tracks)...)
+		trackTTL := c.cfg.effectiveTrackEventTTL()
+		if trackTTL > 0 {
+			txPipe.Expire(ctx, trackIndexKey, trackTTL)
+		} else if c.cfg.TrackEventTTL != nil {
+			txPipe.Persist(ctx, trackIndexKey)
+		}
+	}
+	txPipe.HDel(ctx, c.sessionStateKey(key), key.SessionID)
+	txPipe.HDel(ctx, c.sessionSummaryKey(key), key.SessionID)
+	txPipe.Del(ctx, c.eventKey(key))
+	if _, err := txPipe.Exec(ctx); err != nil && err != redis.Nil {
+		return fmt.Errorf("delete session state failed: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) deleteTrackStorage(ctx context.Context, key session.Key, tracks []session.Track) error {
+	txPipe := c.client.TxPipeline()
 	for _, track := range tracks {
 		txPipe.Del(ctx, c.trackKey(key, track))
 	}
 	txPipe.Del(ctx, c.trackIndexKey(key))
 	if _, err := txPipe.Exec(ctx); err != nil && err != redis.Nil {
-		return fmt.Errorf("delete session state failed: %w", err)
+		return fmt.Errorf("delete track events failed: %w", err)
 	}
 	return nil
 }
@@ -615,16 +645,12 @@ func (c *Client) listTracksForSession(ctx context.Context, key session.Key) ([]s
 	return session.TracksFromState(sessState.State)
 }
 
-func (c *Client) listTracksForDelete(ctx context.Context, key session.Key) ([]session.Track, error) {
-	tracks, err := c.listTracksForSession(ctx, key)
-	if err != nil {
-		return nil, err
-	}
+func (c *Client) listTracksFromIndex(ctx context.Context, key session.Key) ([]string, error) {
 	indexedTracks, err := c.client.SMembers(ctx, c.trackIndexKey(key)).Result()
 	if err != nil && err != redis.Nil {
 		return nil, err
 	}
-	return mergeTrackNames(tracks, indexedTracks), nil
+	return indexedTracks, nil
 }
 
 func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.Track {
@@ -649,6 +675,14 @@ func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.T
 		result = append(result, track)
 	}
 	return result
+}
+
+func trackNameValues(tracks []session.Track) []any {
+	values := make([]any, 0, len(tracks))
+	for _, track := range tracks {
+		values = append(values, string(track))
+	}
+	return values
 }
 
 func (c *Client) getTrackEvents(

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -362,50 +362,20 @@ func (c *Client) UpdateSessionState(ctx context.Context, key session.Key, state 
 
 // DeleteSession deletes a session in ZSet.
 func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
-	tracks, err := c.listTracksForSession(ctx, key)
-	if err != nil {
-		return fmt.Errorf("list tracks: %w", err)
-	}
-	if err := c.closeSessionForDelete(ctx, key, tracks); err != nil {
-		return err
-	}
-	indexedTracks, err := c.listTracksFromIndex(ctx, key)
-	if err != nil {
-		return fmt.Errorf("list track index: %w", err)
-	}
-	tracks = mergeTrackNames(tracks, indexedTracks)
-	return c.deleteTrackStorage(ctx, key, tracks)
-}
-
-func (c *Client) closeSessionForDelete(ctx context.Context, key session.Key, tracks []session.Track) error {
 	txPipe := c.client.TxPipeline()
-	if len(tracks) > 0 {
-		trackIndexKey := c.trackIndexKey(key)
-		txPipe.SAdd(ctx, trackIndexKey, trackNameValues(tracks)...)
-		trackTTL := c.cfg.effectiveTrackEventTTL()
-		if trackTTL > 0 {
-			txPipe.Expire(ctx, trackIndexKey, trackTTL)
-		} else if c.cfg.TrackEventTTL != nil {
-			txPipe.Persist(ctx, trackIndexKey)
-		}
-	}
 	txPipe.HDel(ctx, c.sessionStateKey(key), key.SessionID)
 	txPipe.HDel(ctx, c.sessionSummaryKey(key), key.SessionID)
 	txPipe.Del(ctx, c.eventKey(key))
-	if _, err := txPipe.Exec(ctx); err != nil && err != redis.Nil {
-		return fmt.Errorf("delete session state failed: %w", err)
+	tracks, err := c.listTracksForDelete(ctx, key)
+	if err != nil {
+		return fmt.Errorf("list tracks: %w", err)
 	}
-	return nil
-}
-
-func (c *Client) deleteTrackStorage(ctx context.Context, key session.Key, tracks []session.Track) error {
-	txPipe := c.client.TxPipeline()
 	for _, track := range tracks {
 		txPipe.Del(ctx, c.trackKey(key, track))
 	}
 	txPipe.Del(ctx, c.trackIndexKey(key))
 	if _, err := txPipe.Exec(ctx); err != nil && err != redis.Nil {
-		return fmt.Errorf("delete track events failed: %w", err)
+		return fmt.Errorf("delete session state failed: %w", err)
 	}
 	return nil
 }
@@ -645,12 +615,16 @@ func (c *Client) listTracksForSession(ctx context.Context, key session.Key) ([]s
 	return session.TracksFromState(sessState.State)
 }
 
-func (c *Client) listTracksFromIndex(ctx context.Context, key session.Key) ([]string, error) {
+func (c *Client) listTracksForDelete(ctx context.Context, key session.Key) ([]session.Track, error) {
+	tracks, err := c.listTracksForSession(ctx, key)
+	if err != nil {
+		return nil, err
+	}
 	indexedTracks, err := c.client.SMembers(ctx, c.trackIndexKey(key)).Result()
 	if err != nil && err != redis.Nil {
 		return nil, err
 	}
-	return indexedTracks, nil
+	return mergeTrackNames(tracks, indexedTracks), nil
 }
 
 func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.Track {
@@ -675,14 +649,6 @@ func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.T
 		result = append(result, track)
 	}
 	return result
-}
-
-func trackNameValues(tracks []session.Track) []any {
-	values := make([]any, 0, len(tracks))
-	for _, track := range tracks {
-		values = append(values, string(track))
-	}
-	return values
 }
 
 func (c *Client) getTrackEvents(

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -366,15 +366,14 @@ func (c *Client) DeleteSession(ctx context.Context, key session.Key) error {
 	txPipe.HDel(ctx, c.sessionStateKey(key), key.SessionID)
 	txPipe.HDel(ctx, c.sessionSummaryKey(key), key.SessionID)
 	txPipe.Del(ctx, c.eventKey(key))
-
-	tracks, err := c.listTracksForSession(ctx, key)
+	tracks, err := c.listTracksForDelete(ctx, key)
 	if err != nil {
 		return fmt.Errorf("list tracks: %w", err)
 	}
 	for _, track := range tracks {
 		txPipe.Del(ctx, c.trackKey(key, track))
 	}
-
+	txPipe.Del(ctx, c.trackIndexKey(key))
 	if _, err := txPipe.Exec(ctx); err != nil && err != redis.Nil {
 		return fmt.Errorf("delete session state failed: %w", err)
 	}
@@ -407,15 +406,19 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 		},
 		func(pipe redis.Pipeliner) {
 			trackKey := c.trackKey(key, trackEvent.Track)
+			trackIndexKey := c.trackIndexKey(key)
 			pipe.ZAdd(ctx, trackKey, redis.Z{
 				Score:  float64(trackEvent.Timestamp.UnixNano()),
 				Member: eventBytes,
 			})
+			pipe.SAdd(ctx, trackIndexKey, string(trackEvent.Track))
 			trackTTL := c.cfg.effectiveTrackEventTTL()
 			if trackTTL > 0 {
 				pipe.Expire(ctx, trackKey, trackTTL)
+				pipe.Expire(ctx, trackIndexKey, trackTTL)
 			} else if c.cfg.TrackEventTTL != nil {
 				pipe.Persist(ctx, trackKey)
+				pipe.Persist(ctx, trackIndexKey)
 			}
 		},
 	)
@@ -612,6 +615,42 @@ func (c *Client) listTracksForSession(ctx context.Context, key session.Key) ([]s
 	return session.TracksFromState(sessState.State)
 }
 
+func (c *Client) listTracksForDelete(ctx context.Context, key session.Key) ([]session.Track, error) {
+	tracks, err := c.listTracksForSession(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	indexedTracks, err := c.client.SMembers(ctx, c.trackIndexKey(key)).Result()
+	if err != nil && err != redis.Nil {
+		return nil, err
+	}
+	return mergeTrackNames(tracks, indexedTracks), nil
+}
+
+func mergeTrackNames(tracks []session.Track, indexedTracks []string) []session.Track {
+	if len(indexedTracks) == 0 {
+		return tracks
+	}
+	result := make([]session.Track, 0, len(tracks)+len(indexedTracks))
+	seen := make(map[session.Track]struct{}, len(tracks)+len(indexedTracks))
+	for _, track := range tracks {
+		if _, ok := seen[track]; ok {
+			continue
+		}
+		seen[track] = struct{}{}
+		result = append(result, track)
+	}
+	for _, indexedTrack := range indexedTracks {
+		track := session.Track(indexedTrack)
+		if _, ok := seen[track]; ok {
+			continue
+		}
+		seen[track] = struct{}{}
+		result = append(result, track)
+	}
+	return result
+}
+
 func (c *Client) getTrackEvents(
 	ctx context.Context,
 	sessionKeys []session.Key,
@@ -720,6 +759,11 @@ func (c *Client) eventKey(key session.Key) string {
 // trackKey returns the Redis key for track events (with prefix).
 func (c *Client) trackKey(key session.Key, track session.Track) string {
 	return c.prefixedKey(fmt.Sprintf("track:{%s}:%s:%s:%s", key.AppName, key.UserID, key.SessionID, track))
+}
+
+// trackIndexKey returns the Redis key for session track names.
+func (c *Client) trackIndexKey(key session.Key) string {
+	return c.prefixedKey(fmt.Sprintf("trackidx:{%s}:%s:%s", key.AppName, key.UserID, key.SessionID))
 }
 
 // sessionStateKey returns the Redis key for session state (with prefix).

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -29,6 +29,7 @@ import (
 // Config holds configuration for ZSet session storage client.
 type Config struct {
 	SessionTTL        time.Duration
+	TrackEventTTL     *time.Duration
 	AppStateTTL       time.Duration
 	UserStateTTL      time.Duration
 	SessionEventLimit int
@@ -37,6 +38,13 @@ type Config struct {
 	// Script.Run. Enable for proxy/cluster backends whose script cache is not
 	// reliably maintained (e.g. a Tendis cluster fronted by twemproxy).
 	DisableScriptCache bool
+}
+
+func (cfg Config) effectiveTrackEventTTL() time.Duration {
+	if cfg.TrackEventTTL != nil {
+		return *cfg.TrackEventTTL
+	}
+	return cfg.SessionTTL
 }
 
 // Client implements ZSet session storage logic.
@@ -401,8 +409,11 @@ func (c *Client) AppendTrackEvent(ctx context.Context, key session.Key, trackEve
 				Score:  float64(trackEvent.Timestamp.UnixNano()),
 				Member: eventBytes,
 			})
-			if c.cfg.SessionTTL > 0 {
-				pipe.Expire(ctx, trackKey, c.cfg.SessionTTL)
+			trackTTL := c.cfg.effectiveTrackEventTTL()
+			if trackTTL > 0 {
+				pipe.Expire(ctx, trackKey, trackTTL)
+			} else if c.cfg.TrackEventTTL != nil {
+				pipe.Persist(ctx, trackKey)
 			}
 		},
 	)
@@ -613,12 +624,41 @@ func (c *Client) getTrackEvents(
 	if err != nil {
 		return nil, err
 	}
+	return c.getTrackEventsByTrackLists(ctx, sessionKeys, trackLists, limit, afterTime)
+}
 
+// GetTrackEvents retrieves persisted track events for the given session tracks.
+func (c *Client) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	tracks []session.Track,
+	limit int,
+	afterTime time.Time,
+) (map[session.Track][]session.TrackEvent, error) {
+	if len(tracks) == 0 {
+		return make(map[session.Track][]session.TrackEvent), nil
+	}
+	results, err := c.getTrackEventsByTrackLists(ctx, []session.Key{key}, [][]session.Track{tracks}, limit, afterTime)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return make(map[session.Track][]session.TrackEvent), nil
+	}
+	return results[0], nil
+}
+
+func (c *Client) getTrackEventsByTrackLists(
+	ctx context.Context,
+	sessionKeys []session.Key,
+	trackLists [][]session.Track,
+	limit int,
+	afterTime time.Time,
+) ([]map[session.Track][]session.TrackEvent, error) {
 	queries := make([]*trackQuery, 0)
 	dataPipe := c.client.Pipeline()
 	minScore := fmt.Sprintf("%d", afterTime.UnixNano())
 	maxScore := fmt.Sprintf("%d", time.Now().UnixNano())
-
 	for i, key := range sessionKeys {
 		tracks := trackLists[i]
 		for _, track := range tracks {

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -28,7 +28,9 @@ import (
 
 // Config holds configuration for ZSet session storage client.
 type Config struct {
-	SessionTTL        time.Duration
+	SessionTTL time.Duration
+	// TrackEventTTL controls track event expiration. Nil falls back to
+	// SessionTTL, and non-positive values disable expiration.
 	TrackEventTTL     *time.Duration
 	AppStateTTL       time.Duration
 	UserStateTTL      time.Duration

--- a/session/redis/internal/zset/session_test.go
+++ b/session/redis/internal/zset/session_test.go
@@ -731,6 +731,44 @@ func TestAppendTrackEvent(t *testing.T) {
 	})
 }
 
+func TestAppendTrackEvent_TrackTTLZeroPersistsTrackKey(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = 10 * time.Second
+	createClient := NewClient(rdb, createCfg)
+	trackTTL := time.Duration(0)
+	appendCfg := createCfg
+	appendCfg.TrackEventTTL = &trackTTL
+	appendClient := NewClient(rdb, appendCfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "track-ttl-zero"}
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	err = appendClient.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "tool_calls",
+		Payload:   json.RawMessage(`{"fn":"add"}`),
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, err)
+	trackKey := createClient.trackKey(key, "tool_calls")
+	assert.True(t, mr.Exists(trackKey))
+	assert.Equal(t, time.Duration(0), mr.TTL(trackKey))
+}
+
+func TestGetTrackEvents_EmptyAndMissingTracks(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	empty, err := c.GetTrackEvents(ctx, key, nil, 0, time.Time{})
+	require.NoError(t, err)
+	require.Empty(t, empty)
+	missing, err := c.GetTrackEvents(ctx, key, []session.Track{"missing"}, 0, time.Time{})
+	require.NoError(t, err)
+	require.Contains(t, missing, session.Track("missing"))
+	require.Empty(t, missing["missing"])
+}
+
 func TestUpdateSessionStateCAS_RetriesOnConflict(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/zset/session_test.go
+++ b/session/redis/internal/zset/session_test.go
@@ -454,6 +454,50 @@ func TestDeleteSession_WithRetainedTracksAfterSessionStateExpired(t *testing.T) 
 	assert.False(t, mr.Exists(trackIndexKey))
 }
 
+func TestDeleteSession_DeletesTrackAppendedAfterInitialDiscovery(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "late-track-delete"}
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"alpha"`),
+		Timestamp: time.Now(),
+	}))
+	discoveredTracks, err := c.listTracksForSession(ctx, key)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []session.Track{"alpha"}, discoveredTracks)
+	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "beta",
+		Payload:   json.RawMessage(`"beta"`),
+		Timestamp: time.Now(),
+	}))
+	require.NoError(t, c.closeSessionForDelete(ctx, key, discoveredTracks))
+	err = c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "gamma",
+		Payload:   json.RawMessage(`"gamma"`),
+		Timestamp: time.Now(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session not found")
+	indexedTracks, err := c.listTracksFromIndex(ctx, key)
+	require.NoError(t, err)
+	tracks := mergeTrackNames(discoveredTracks, indexedTracks)
+	require.ElementsMatch(t, []session.Track{"alpha", "beta"}, tracks)
+	require.NoError(t, c.deleteTrackStorage(ctx, key, tracks))
+	got, err := c.GetTrackEvents(ctx, key, []session.Track{"alpha", "beta", "gamma"}, 0, time.Time{})
+	require.NoError(t, err)
+	assert.Empty(t, got["alpha"])
+	assert.Empty(t, got["beta"])
+	assert.Empty(t, got["gamma"])
+	assert.False(t, mr.Exists(c.trackKey(key, "alpha")))
+	assert.False(t, mr.Exists(c.trackKey(key, "beta")))
+	assert.False(t, mr.Exists(c.trackKey(key, "gamma")))
+	assert.False(t, mr.Exists(c.trackIndexKey(key)))
+}
+
 // =============================================================================
 // UpdateSessionState
 // =============================================================================

--- a/session/redis/internal/zset/session_test.go
+++ b/session/redis/internal/zset/session_test.go
@@ -417,6 +417,43 @@ func TestDeleteSession_WithTracks(t *testing.T) {
 	assert.Equal(t, int64(0), n)
 }
 
+func TestDeleteSession_WithRetainedTracksAfterSessionStateExpired(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	createCfg := defaultConfig()
+	createCfg.SessionTTL = time.Second
+	createClient := NewClient(rdb, createCfg)
+	trackTTL := time.Duration(0)
+	appendCfg := createCfg
+	appendCfg.TrackEventTTL = &trackTTL
+	appendClient := NewClient(rdb, appendCfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "retained-track-delete"}
+	_, err := createClient.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	require.NoError(t, appendClient.AppendTrackEvent(ctx, key, &session.TrackEvent{
+		Track:     "tool_calls",
+		Payload:   json.RawMessage(`{"fn":"add"}`),
+		Timestamp: time.Now(),
+	}))
+	stateKey := createClient.sessionStateKey(key)
+	trackKey := createClient.trackKey(key, "tool_calls")
+	trackIndexKey := createClient.trackIndexKey(key)
+	assert.True(t, mr.Exists(stateKey))
+	assert.True(t, mr.Exists(trackKey))
+	assert.True(t, mr.Exists(trackIndexKey))
+	mr.FastForward(2 * time.Second)
+	assert.False(t, mr.Exists(stateKey))
+	got, err := appendClient.GetTrackEvents(ctx, key, []session.Track{"tool_calls"}, 0, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, got["tool_calls"], 1)
+	require.NoError(t, createClient.DeleteSession(ctx, key))
+	got, err = appendClient.GetTrackEvents(ctx, key, []session.Track{"tool_calls"}, 0, time.Time{})
+	require.NoError(t, err)
+	assert.Empty(t, got["tool_calls"])
+	assert.False(t, mr.Exists(trackKey))
+	assert.False(t, mr.Exists(trackIndexKey))
+}
+
 // =============================================================================
 // UpdateSessionState
 // =============================================================================
@@ -751,8 +788,11 @@ func TestAppendTrackEvent_TrackTTLZeroPersistsTrackKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 	trackKey := createClient.trackKey(key, "tool_calls")
+	trackIndexKey := createClient.trackIndexKey(key)
 	assert.True(t, mr.Exists(trackKey))
+	assert.True(t, mr.Exists(trackIndexKey))
 	assert.Equal(t, time.Duration(0), mr.TTL(trackKey))
+	assert.Equal(t, time.Duration(0), mr.TTL(trackIndexKey))
 }
 
 func TestGetTrackEvents_EmptyAndMissingTracks(t *testing.T) {

--- a/session/redis/internal/zset/session_test.go
+++ b/session/redis/internal/zset/session_test.go
@@ -454,50 +454,6 @@ func TestDeleteSession_WithRetainedTracksAfterSessionStateExpired(t *testing.T) 
 	assert.False(t, mr.Exists(trackIndexKey))
 }
 
-func TestDeleteSession_DeletesTrackAppendedAfterInitialDiscovery(t *testing.T) {
-	mr, rdb := setupMiniredis(t)
-	c := NewClient(rdb, defaultConfig())
-	ctx := context.Background()
-	key := session.Key{AppName: "app", UserID: "u1", SessionID: "late-track-delete"}
-	_, err := c.CreateSession(ctx, key, nil)
-	require.NoError(t, err)
-	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
-		Track:     "alpha",
-		Payload:   json.RawMessage(`"alpha"`),
-		Timestamp: time.Now(),
-	}))
-	discoveredTracks, err := c.listTracksForSession(ctx, key)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []session.Track{"alpha"}, discoveredTracks)
-	require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
-		Track:     "beta",
-		Payload:   json.RawMessage(`"beta"`),
-		Timestamp: time.Now(),
-	}))
-	require.NoError(t, c.closeSessionForDelete(ctx, key, discoveredTracks))
-	err = c.AppendTrackEvent(ctx, key, &session.TrackEvent{
-		Track:     "gamma",
-		Payload:   json.RawMessage(`"gamma"`),
-		Timestamp: time.Now(),
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "session not found")
-	indexedTracks, err := c.listTracksFromIndex(ctx, key)
-	require.NoError(t, err)
-	tracks := mergeTrackNames(discoveredTracks, indexedTracks)
-	require.ElementsMatch(t, []session.Track{"alpha", "beta"}, tracks)
-	require.NoError(t, c.deleteTrackStorage(ctx, key, tracks))
-	got, err := c.GetTrackEvents(ctx, key, []session.Track{"alpha", "beta", "gamma"}, 0, time.Time{})
-	require.NoError(t, err)
-	assert.Empty(t, got["alpha"])
-	assert.Empty(t, got["beta"])
-	assert.Empty(t, got["gamma"])
-	assert.False(t, mr.Exists(c.trackKey(key, "alpha")))
-	assert.False(t, mr.Exists(c.trackKey(key, "beta")))
-	assert.False(t, mr.Exists(c.trackKey(key, "gamma")))
-	assert.False(t, mr.Exists(c.trackIndexKey(key)))
-}
-
 // =============================================================================
 // UpdateSessionState
 // =============================================================================

--- a/session/redis/options.go
+++ b/session/redis/options.go
@@ -62,6 +62,7 @@ type ServiceOpts struct {
 	instanceName       string
 	extraOptions       []any
 	sessionTTL         time.Duration // TTL for session state and event list
+	trackEventTTL      *time.Duration
 	appStateTTL        time.Duration // TTL for app state
 	userStateTTL       time.Duration // TTL for user state
 	enableAsyncPersist bool
@@ -123,6 +124,13 @@ func (opts ServiceOpts) shouldCascadeFullSessionSummary() bool {
 	return *opts.cascadeFullSessionSummary
 }
 
+func (opts ServiceOpts) effectiveTrackEventTTL() time.Duration {
+	if opts.trackEventTTL != nil {
+		return *opts.trackEventTTL
+	}
+	return opts.sessionTTL
+}
+
 // WithSessionEventLimit sets the limit of events in a session.
 func WithSessionEventLimit(limit int) ServiceOpt {
 	return func(opts *ServiceOpts) {
@@ -160,6 +168,15 @@ func WithExtraOptions(extraOptions ...any) ServiceOpt {
 func WithSessionTTL(ttl time.Duration) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.sessionTTL = ttl
+	}
+}
+
+// WithTrackEventTTL sets the TTL for track events.
+// If unset, track events use the session TTL. A non-positive TTL disables track
+// event expiration.
+func WithTrackEventTTL(ttl time.Duration) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.trackEventTTL = &ttl
 	}
 }
 

--- a/session/redis/options_test.go
+++ b/session/redis/options_test.go
@@ -323,6 +323,17 @@ func TestWithSessionTTL(t *testing.T) {
 	}
 }
 
+func TestWithTrackEventTTL(t *testing.T) {
+	opts := ServiceOpts{sessionTTL: time.Hour}
+	assert.Equal(t, time.Hour, opts.effectiveTrackEventTTL())
+	WithTrackEventTTL(0)(&opts)
+	require.NotNil(t, opts.trackEventTTL)
+	assert.Equal(t, time.Duration(0), opts.effectiveTrackEventTTL())
+	WithTrackEventTTL(30 * time.Minute)(&opts)
+	require.NotNil(t, opts.trackEventTTL)
+	assert.Equal(t, 30*time.Minute, opts.effectiveTrackEventTTL())
+}
+
 func TestWithAppStateTTL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/session/redis/service.go
+++ b/session/redis/service.go
@@ -135,6 +135,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	// Initialize ZSet config
 	zsetCfg := zset.Config{
 		SessionTTL:         sessionTTL,
+		TrackEventTTL:      opts.trackEventTTL,
 		AppStateTTL:        appStateTTL,
 		UserStateTTL:       userStateTTL,
 		SessionEventLimit:  opts.sessionEventLimit,
@@ -145,6 +146,7 @@ func NewService(options ...ServiceOpt) (*Service, error) {
 	// Initialize HashIdx config
 	hashidxCfg := hashidx.Config{
 		SessionTTL:             sessionTTL,
+		TrackEventTTL:          opts.trackEventTTL,
 		AppStateTTL:            appStateTTL,
 		UserStateTTL:           userStateTTL,
 		SessionEventLimit:      opts.sessionEventLimit,

--- a/session/redis/service_track_test.go
+++ b/session/redis/service_track_test.go
@@ -87,6 +87,86 @@ func TestService_AppendTrackEvent_Persistence(t *testing.T) {
 	assert.Len(t, alpha.Events, 3)
 }
 
+func TestService_GetTrackEvents_ReadsTrackStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		mode CompatMode
+	}{
+		{name: "hashidx", mode: CompatModeNone},
+		{name: "zset", mode: CompatModeTransition},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redisURL, cleanup := setupTestRedis(t)
+			defer cleanup()
+			service, err := NewService(WithRedisClientURL(redisURL), WithCompatMode(tt.mode))
+			require.NoError(t, err)
+			defer service.Close()
+			ctx := context.Background()
+			key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "session123"}
+			sess, err := service.CreateSession(ctx, key, session.StateMap{})
+			require.NoError(t, err)
+			baseTime := time.Now().Add(-time.Hour)
+			require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+				Track:     "alpha",
+				Payload:   json.RawMessage(`"old"`),
+				Timestamp: baseTime,
+			}))
+			require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+				Track:     "alpha",
+				Payload:   json.RawMessage(`"new"`),
+				Timestamp: baseTime.Add(time.Second),
+			}))
+			require.NoError(t, service.UpdateSessionState(ctx, key, session.StateMap{"tracks": []byte("[]")}))
+			got, err := service.GetTrackEvents(ctx, key, "alpha", session.WithEventNum(1))
+			require.NoError(t, err)
+			require.Equal(t, session.Track("alpha"), got.Track)
+			require.Len(t, got.Events, 1)
+			require.JSONEq(t, `"new"`, string(got.Events[0].Payload))
+			missing, err := service.GetTrackEvents(ctx, key, "missing")
+			require.NoError(t, err)
+			require.Equal(t, session.Track("missing"), missing.Track)
+			require.Empty(t, missing.Events)
+		})
+	}
+}
+
+func TestService_GetTrackEvents_EmptyAndErrors(t *testing.T) {
+	t.Run("invalid key", func(t *testing.T) {
+		redisURL, cleanup := setupTestRedis(t)
+		defer cleanup()
+		service, err := NewService(WithRedisClientURL(redisURL))
+		require.NoError(t, err)
+		defer service.Close()
+		_, err = service.GetTrackEvents(context.Background(), session.Key{UserID: "user123", SessionID: "session123"}, "alpha")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, session.ErrAppNameRequired)
+	})
+	t.Run("missing session", func(t *testing.T) {
+		redisURL, cleanup := setupTestRedis(t)
+		defer cleanup()
+		service, err := NewService(WithRedisClientURL(redisURL))
+		require.NoError(t, err)
+		defer service.Close()
+		key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "missing"}
+		got, err := service.GetTrackEvents(context.Background(), key, "alpha")
+		require.NoError(t, err)
+		require.Equal(t, session.Track("alpha"), got.Track)
+		require.Empty(t, got.Events)
+	})
+	t.Run("exists check error", func(t *testing.T) {
+		redisURL, cleanup := setupTestRedis(t)
+		service, err := NewService(WithRedisClientURL(redisURL))
+		require.NoError(t, err)
+		defer service.Close()
+		cleanup()
+		key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "session123"}
+		_, err = service.GetTrackEvents(context.Background(), key, "alpha")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "check session exists")
+	})
+}
+
 func TestService_GetSessionTrackAfterTime(t *testing.T) {
 	redisURL, cleanup := setupTestRedis(t)
 	defer cleanup()

--- a/session/redis/service_track_test.go
+++ b/session/redis/service_track_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/hashidx"
+	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/zset"
 )
 
 func TestService_AppendTrackEvent_SessionError(t *testing.T) {
@@ -127,6 +128,62 @@ func TestService_GetTrackEvents_ReadsTrackStorage(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, session.Track("missing"), missing.Track)
 			require.Empty(t, missing.Events)
+		})
+	}
+}
+
+func TestService_GetTrackEvents_ReadsTrackStorageWithoutSessionState(t *testing.T) {
+	tests := []struct {
+		name               string
+		mode               CompatMode
+		removeSessionState func(context.Context, *testing.T, string, session.Key)
+	}{
+		{
+			name: "hashidx",
+			mode: CompatModeNone,
+			removeSessionState: func(ctx context.Context, t *testing.T, redisURL string, key session.Key) {
+				client := buildRedisClient(t, redisURL)
+				defer client.Close()
+				require.NoError(t, client.Del(ctx, hashidx.GetSessionMetaKey("", key)).Err())
+			},
+		},
+		{
+			name: "zset",
+			mode: CompatModeTransition,
+			removeSessionState: func(ctx context.Context, t *testing.T, redisURL string, key session.Key) {
+				client := buildRedisClient(t, redisURL)
+				defer client.Close()
+				require.NoError(t, client.HDel(ctx, zset.GetSessionStateKey(key), key.SessionID).Err())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redisURL, cleanup := setupTestRedis(t)
+			defer cleanup()
+			trackTTL := time.Duration(0)
+			service, err := NewService(
+				WithRedisClientURL(redisURL),
+				WithCompatMode(tt.mode),
+				WithTrackEventTTL(trackTTL),
+			)
+			require.NoError(t, err)
+			defer service.Close()
+			ctx := context.Background()
+			key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "session-track-only"}
+			sess, err := service.CreateSession(ctx, key, session.StateMap{})
+			require.NoError(t, err)
+			require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+				Track:     "alpha",
+				Payload:   json.RawMessage(`"persisted"`),
+				Timestamp: time.Now(),
+			}))
+			tt.removeSessionState(ctx, t, redisURL, key)
+			got, err := service.GetTrackEvents(ctx, key, "alpha")
+			require.NoError(t, err)
+			require.Equal(t, session.Track("alpha"), got.Track)
+			require.Len(t, got.Events, 1)
+			require.JSONEq(t, `"persisted"`, string(got.Events[0].Payload))
 		})
 	}
 }

--- a/session/redis/track_service.go
+++ b/session/redis/track_service.go
@@ -59,6 +59,40 @@ func (s *Service) AppendTrackEvent(
 	return s.persistTrackEvent(ctx, getSessionVersion(sess), key, trackEvent, tracksState)
 }
 
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *Service) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	ctx, span := s.startSpan(ctx, "get_track_events", key)
+	defer span.End()
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	zsetExists, hashidxExists, err := s.checkSessionExists(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("check session exists: %w", err)
+	}
+	if s.compatEnabled() && zsetExists {
+		events, err := s.zsetClient.GetTrackEvents(ctx, key, []session.Track{track}, opt.EventNum, opt.EventTime)
+		if err != nil {
+			return nil, fmt.Errorf("get track events (zset): %w", err)
+		}
+		return &session.TrackEvents{Track: track, Events: events[track]}, nil
+	}
+	if hashidxExists {
+		events, err := s.hashidxClient.GetTrackEvents(ctx, key, []session.Track{track}, opt.EventNum, opt.EventTime)
+		if err != nil {
+			return nil, fmt.Errorf("get track events (hashidx): %w", err)
+		}
+		return &session.TrackEvents{Track: track, Events: events[track]}, nil
+	}
+	return &session.TrackEvents{Track: track}, nil
+}
+
 // enqueueTrackEvent enqueues a track event for async persistence.
 func (s *Service) enqueueTrackEvent(ctx context.Context, sess *session.Session, key session.Key, trackEvent *session.TrackEvent, tracksState []byte) error {
 	defer func() {

--- a/session/redis/track_service.go
+++ b/session/redis/track_service.go
@@ -77,20 +77,47 @@ func (s *Service) GetTrackEvents(
 		return nil, fmt.Errorf("check session exists: %w", err)
 	}
 	if s.compatEnabled() && zsetExists {
-		events, err := s.zsetClient.GetTrackEvents(ctx, key, []session.Track{track}, opt.EventNum, opt.EventTime)
-		if err != nil {
-			return nil, fmt.Errorf("get track events (zset): %w", err)
-		}
-		return &session.TrackEvents{Track: track, Events: events[track]}, nil
+		return s.getZSetTrackEvents(ctx, key, track, opt)
 	}
 	if hashidxExists {
-		events, err := s.hashidxClient.GetTrackEvents(ctx, key, []session.Track{track}, opt.EventNum, opt.EventTime)
-		if err != nil {
-			return nil, fmt.Errorf("get track events (hashidx): %w", err)
-		}
-		return &session.TrackEvents{Track: track, Events: events[track]}, nil
+		return s.getHashIdxTrackEvents(ctx, key, track, opt)
 	}
-	return &session.TrackEvents{Track: track}, nil
+	if s.compatEnabled() {
+		trackEvents, err := s.getZSetTrackEvents(ctx, key, track, opt)
+		if err != nil {
+			return nil, err
+		}
+		if len(trackEvents.Events) > 0 {
+			return trackEvents, nil
+		}
+	}
+	return s.getHashIdxTrackEvents(ctx, key, track, opt)
+}
+
+func (s *Service) getZSetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opt *session.Options,
+) (*session.TrackEvents, error) {
+	events, err := s.zsetClient.GetTrackEvents(ctx, key, []session.Track{track}, opt.EventNum, opt.EventTime)
+	if err != nil {
+		return nil, fmt.Errorf("get track events (zset): %w", err)
+	}
+	return &session.TrackEvents{Track: track, Events: events[track]}, nil
+}
+
+func (s *Service) getHashIdxTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opt *session.Options,
+) (*session.TrackEvents, error) {
+	events, err := s.hashidxClient.GetTrackEvents(ctx, key, []session.Track{track}, opt.EventNum, opt.EventTime)
+	if err != nil {
+		return nil, fmt.Errorf("get track events (hashidx): %w", err)
+	}
+	return &session.TrackEvents{Track: track, Events: events[track]}, nil
 }
 
 // enqueueTrackEvent enqueues a track event for async persistence.

--- a/session/sqlite/cleanup.go
+++ b/session/sqlite/cleanup.go
@@ -72,6 +72,9 @@ func (s *Service) cleanupExpiredData(ctx context.Context) {
 	if s.opts.sessionTTL > 0 {
 		s.cleanupExpiredSessions(ctx, now)
 	}
+	if s.opts.trackEventTTL != nil && s.opts.effectiveTrackEventTTL() > 0 {
+		s.cleanupExpiredTrackEvents(ctx, now)
+	}
 	if s.opts.appStateTTL > 0 {
 		s.cleanupExpiredAppStates(ctx, now)
 	}
@@ -143,14 +146,16 @@ WHERE %s AND deleted_at IS NULL`,
 		nowNs, whereExpired); err != nil {
 		return err
 	}
-	if err := s.softDeleteExpiredBySession(
-		ctx,
-		tx,
-		s.tableSessionTracks,
-		nowNs,
-		whereExpired,
-	); err != nil {
-		return err
+	if s.opts.trackEventTTL == nil {
+		if err := s.softDeleteExpiredBySession(
+			ctx,
+			tx,
+			s.tableSessionTracks,
+			nowNs,
+			whereExpired,
+		); err != nil {
+			return err
+		}
 	}
 	if err := s.softDeleteExpiredBySession(
 		ctx,
@@ -238,14 +243,16 @@ func (s *Service) hardDeleteExpiredSessionsTx(
 	); err != nil {
 		return err
 	}
-	if err := s.hardDeleteExpiredBySession(
-		ctx,
-		tx,
-		s.tableSessionTracks,
-		nowNs,
-		whereExpired,
-	); err != nil {
-		return err
+	if s.opts.trackEventTTL == nil {
+		if err := s.hardDeleteExpiredBySession(
+			ctx,
+			tx,
+			s.tableSessionTracks,
+			nowNs,
+			whereExpired,
+		); err != nil {
+			return err
+		}
 	}
 	if err := s.hardDeleteExpiredBySession(
 		ctx,
@@ -297,6 +304,42 @@ WHERE EXISTS (
 		nowNs,
 	)
 	return err
+}
+
+func (s *Service) cleanupExpiredTrackEvents(
+	ctx context.Context,
+	now time.Time,
+) {
+	nowNs := now.UTC().UnixNano()
+	if s.opts.softDelete {
+		_, err := s.db.ExecContext(
+			ctx,
+			fmt.Sprintf(
+				`UPDATE %s SET deleted_at = ?
+WHERE expires_at IS NOT NULL AND expires_at <= ?
+AND deleted_at IS NULL`,
+				s.tableSessionTracks,
+			),
+			nowNs,
+			nowNs,
+		)
+		if err != nil {
+			log.ErrorfContext(ctx, "cleanup track events: %v", err)
+		}
+		return
+	}
+	_, err := s.db.ExecContext(
+		ctx,
+		fmt.Sprintf(
+			`DELETE FROM %s
+WHERE expires_at IS NOT NULL AND expires_at <= ?`,
+			s.tableSessionTracks,
+		),
+		nowNs,
+	)
+	if err != nil {
+		log.ErrorfContext(ctx, "cleanup track events: %v", err)
+	}
 }
 
 func (s *Service) cleanupExpiredAppStates(

--- a/session/sqlite/cleanup_test.go
+++ b/session/sqlite/cleanup_test.go
@@ -241,6 +241,91 @@ func TestSessionSQLite_CleanupExpiredData_Hard_AppUser(t *testing.T) {
 	}
 }
 
+func TestSessionSQLite_CleanupExpiredData_TrackTTL(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+	svc, err := NewService(db, WithTrackEventTTL(time.Hour))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, newTrackEvent("expired", 1)))
+	setSQLiteTrackExpires(t, svc, ctx, key, "expired", time.Now().Add(-time.Hour).UTC().UnixNano())
+	svc.cleanupExpiredData(ctx)
+	deleted := sqliteTrackDeletedAt(t, svc, ctx, key, "expired")
+	require.True(t, deleted.Valid)
+}
+
+func TestSessionSQLite_CleanupExpiredTrackEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		softDelete bool
+	}{
+		{name: "soft delete", softDelete: true},
+		{name: "hard delete", softDelete: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _, cleanup := openTempSQLiteDB(t)
+			defer cleanup()
+			svc, err := NewService(
+				db,
+				WithTrackEventTTL(time.Hour),
+				WithSoftDelete(tt.softDelete),
+			)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, svc.Close()) }()
+			ctx := context.Background()
+			key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+			sess, err := svc.CreateSession(ctx, key, nil)
+			require.NoError(t, err)
+			require.NoError(t, svc.AppendTrackEvent(ctx, sess, newTrackEvent("expired", 1)))
+			require.NoError(t, svc.AppendTrackEvent(ctx, sess, newTrackEvent("fresh", 2)))
+			now := time.Now().UTC()
+			setSQLiteTrackExpires(t, svc, ctx, key, "expired", now.Add(-time.Hour).UnixNano())
+			setSQLiteTrackExpires(t, svc, ctx, key, "fresh", now.Add(time.Hour).UnixNano())
+			svc.cleanupExpiredTrackEvents(ctx, now)
+			if tt.softDelete {
+				require.True(t, sqliteTrackDeletedAt(t, svc, ctx, key, "expired").Valid)
+				require.False(t, sqliteTrackDeletedAt(t, svc, ctx, key, "fresh").Valid)
+				return
+			}
+			require.Equal(t, 0, sqliteTrackCount(t, svc, ctx, key, "expired"))
+			require.Equal(t, 1, sqliteTrackCount(t, svc, ctx, key, "fresh"))
+		})
+	}
+}
+
+func TestSessionSQLite_CleanupExpiredSessionsKeepsTrackEventsWithTrackTTL(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+	svc, err := NewService(
+		db,
+		WithSessionTTL(time.Hour),
+		WithTrackEventTTL(time.Hour),
+		WithSoftDelete(false),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, newTrackEvent("fresh", 1)))
+	_, err = svc.db.ExecContext(
+		ctx,
+		"UPDATE "+svc.tableSessionStates+" SET expires_at = ?",
+		time.Now().Add(-time.Hour).UTC().UnixNano(),
+	)
+	require.NoError(t, err)
+	setSQLiteTrackExpires(t, svc, ctx, key, "fresh", time.Now().Add(time.Hour).UTC().UnixNano())
+	svc.cleanupExpiredData(ctx)
+	require.Equal(t, 0, sqliteSessionCount(t, svc, ctx, key))
+	require.Equal(t, 1, sqliteTrackCount(t, svc, ctx, key, "fresh"))
+}
+
 func TestSessionSQLite_StartCleanupRoutine_NoInterval(t *testing.T) {
 	db, _, cleanup := openTempSQLiteDB(t)
 	defer cleanup()
@@ -252,6 +337,95 @@ func TestSessionSQLite_StartCleanupRoutine_NoInterval(t *testing.T) {
 	require.Nil(t, svc.cleanupTicker)
 	svc.startCleanupRoutine()
 	require.Nil(t, svc.cleanupTicker)
+}
+
+func setSQLiteTrackExpires(
+	t *testing.T,
+	svc *Service,
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	expiresAt int64,
+) {
+	t.Helper()
+	_, err := svc.db.ExecContext(
+		ctx,
+		"UPDATE "+svc.tableSessionTracks+
+			" SET expires_at = ? WHERE app_name = ? AND user_id = ?"+
+			" AND session_id = ? AND track = ?",
+		expiresAt,
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		track,
+	)
+	require.NoError(t, err)
+}
+
+func sqliteTrackDeletedAt(
+	t *testing.T,
+	svc *Service,
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+) sql.NullInt64 {
+	t.Helper()
+	var deleted sql.NullInt64
+	err := svc.db.QueryRowContext(
+		ctx,
+		"SELECT deleted_at FROM "+svc.tableSessionTracks+
+			" WHERE app_name = ? AND user_id = ? AND session_id = ?"+
+			" AND track = ?",
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		track,
+	).Scan(&deleted)
+	require.NoError(t, err)
+	return deleted
+}
+
+func sqliteTrackCount(
+	t *testing.T,
+	svc *Service,
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+) int {
+	t.Helper()
+	var count int
+	err := svc.db.QueryRowContext(
+		ctx,
+		"SELECT COUNT(*) FROM "+svc.tableSessionTracks+
+			" WHERE app_name = ? AND user_id = ? AND session_id = ?"+
+			" AND track = ?",
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		track,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func sqliteSessionCount(
+	t *testing.T,
+	svc *Service,
+	ctx context.Context,
+	key session.Key,
+) int {
+	t.Helper()
+	var count int
+	err := svc.db.QueryRowContext(
+		ctx,
+		"SELECT COUNT(*) FROM "+svc.tableSessionStates+
+			" WHERE app_name = ? AND user_id = ? AND session_id = ?",
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count
 }
 
 func TestSessionSQLite_CleanupRoutine_Tick(t *testing.T) {

--- a/session/sqlite/event_query.go
+++ b/session/sqlite/event_query.go
@@ -142,23 +142,35 @@ func (s *Service) getTrackEvents(
 			len(sessionKeys),
 		)
 	}
+	trackLists := make([][]session.Track, len(sessionKeys))
+	for i := range sessionKeys {
+		tracks, err := session.TracksFromState(sessionStates[i].State)
+		if err != nil {
+			return nil, fmt.Errorf("get tracks from state: %w", err)
+		}
+		trackLists[i] = tracks
+	}
+	return s.getTrackEventsByTrackLists(ctx, sessionKeys, trackLists, limit, afterTime)
+}
 
+func (s *Service) getTrackEventsByTrackLists(
+	ctx context.Context,
+	sessionKeys []session.Key,
+	trackLists [][]session.Track,
+	limit int,
+	afterTime time.Time,
+) ([]map[session.Track][]session.TrackEvent, error) {
 	type trackQuery struct {
 		sessionIdx int
 		track      session.Track
 		query      string
 		args       []any
 	}
-
 	queries := make([]*trackQuery, 0)
 	nowNs := time.Now().UTC().UnixNano()
 	afterNs := afterTime.UTC().UnixNano()
-
 	for i, key := range sessionKeys {
-		tracks, err := session.TracksFromState(sessionStates[i].State)
-		if err != nil {
-			return nil, fmt.Errorf("get tracks from state: %w", err)
-		}
+		tracks := trackLists[i]
 		for _, track := range tracks {
 			var (
 				query string
@@ -209,7 +221,6 @@ ORDER BY created_at DESC`,
 			})
 		}
 	}
-
 	out := make(
 		[]map[session.Track][]session.TrackEvent,
 		len(sessionKeys),
@@ -219,7 +230,6 @@ ORDER BY created_at DESC`,
 		if err != nil {
 			return nil, fmt.Errorf("query track events: %w", err)
 		}
-
 		events := make([]session.TrackEvent, 0)
 		for rows.Next() {
 			var eventBytes []byte

--- a/session/sqlite/events.go
+++ b/session/sqlite/events.go
@@ -140,6 +140,30 @@ func (s *Service) AppendTrackEvent(
 	return nil
 }
 
+// GetTrackEvents returns persisted track events for the given session track.
+func (s *Service) GetTrackEvents(
+	ctx context.Context,
+	key session.Key,
+	track session.Track,
+	opts ...session.Option,
+) (*session.TrackEvents, error) {
+	if err := key.CheckSessionKey(); err != nil {
+		return nil, err
+	}
+	opt := applyOptions(opts...)
+	trackEvents, err := s.getTrackEventsByTrackLists(
+		ctx,
+		[]session.Key{key},
+		[][]session.Track{{track}},
+		opt.EventNum,
+		opt.EventTime,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite session service get track events failed: %w", err)
+	}
+	return &session.TrackEvents{Track: track, Events: trackEvents[0][track]}, nil
+}
+
 func (s *Service) enqueueTrackPersist(
 	ctx context.Context,
 	sess *session.Session,

--- a/session/sqlite/events_test.go
+++ b/session/sqlite/events_test.go
@@ -189,6 +189,36 @@ func TestSessionSQLite_AppendTrackEvent_SessionNotFound_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestSessionSQLite_GetTrackEvents_InvalidKey(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+	_, err = svc.GetTrackEvents(
+		context.Background(),
+		session.Key{UserID: "u1", SessionID: "s1"},
+		"t1",
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, session.ErrAppNameRequired)
+}
+
+func TestSessionSQLite_GetTrackEvents_QueryError(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	require.NoError(t, svc.Close())
+	_, err = svc.GetTrackEvents(
+		context.Background(),
+		session.Key{AppName: "app", UserID: "u1", SessionID: "s1"},
+		"t1",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sqlite session service get track events failed")
+}
+
 func TestSessionSQLite_AppendEvent_ResponseNil_SkipsInsert(t *testing.T) {
 	db, _, cleanup := openTempSQLiteDB(t)
 	defer cleanup()
@@ -302,6 +332,90 @@ func TestSessionSQLite_AppendTrack_Expired_ExtendsTTL(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, expires.Valid)
 	require.Greater(t, expires.Int64, expiredNs)
+}
+
+func TestSessionSQLite_AppendTrack_TrackTTLOverridesSessionTTL(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(
+		db,
+		WithSessionTTL(time.Hour),
+		WithTrackEventTTL(0),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.AppendTrackEvent(
+		ctx,
+		sess,
+		newTrackEvent("t1", 1),
+	))
+
+	var sessionExpires sql.NullInt64
+	err = svc.db.QueryRowContext(
+		ctx,
+		"SELECT expires_at FROM "+svc.tableSessionStates+
+			" WHERE app_name = ? AND user_id = ? AND session_id = ?",
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+	).Scan(&sessionExpires)
+	require.NoError(t, err)
+	require.True(t, sessionExpires.Valid)
+
+	var trackExpires sql.NullInt64
+	err = svc.db.QueryRowContext(
+		ctx,
+		"SELECT expires_at FROM "+svc.tableSessionTracks+
+			" WHERE app_name = ? AND user_id = ? AND session_id = ?"+
+			" AND track = ?",
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		"t1",
+	).Scan(&trackExpires)
+	require.NoError(t, err)
+	require.False(t, trackExpires.Valid)
+}
+
+func TestSessionSQLite_AppendTrack_NegativeTrackTTLDisablesExpiry(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+	svc, err := NewService(
+		db,
+		WithSessionTTL(time.Hour),
+		WithTrackEventTTL(-time.Hour),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	require.NoError(t, svc.AppendTrackEvent(
+		ctx,
+		sess,
+		newTrackEvent("t1", 1),
+	))
+	var trackExpires sql.NullInt64
+	err = svc.db.QueryRowContext(
+		ctx,
+		"SELECT expires_at FROM "+svc.tableSessionTracks+
+			" WHERE app_name = ? AND user_id = ? AND session_id = ?"+
+			" AND track = ?",
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		"t1",
+	).Scan(&trackExpires)
+	require.NoError(t, err)
+	require.False(t, trackExpires.Valid)
 }
 
 func TestSessionSQLite_AppendEvent_CorruptState_Error(t *testing.T) {

--- a/session/sqlite/options.go
+++ b/session/sqlite/options.go
@@ -41,6 +41,7 @@ type ServiceOpts struct {
 	sessionEventLimit int
 
 	sessionTTL         time.Duration
+	trackEventTTL      *time.Duration
 	appStateTTL        time.Duration
 	userStateTTL       time.Duration
 	enableAsyncPersist bool
@@ -85,6 +86,13 @@ func (opts ServiceOpts) shouldCascadeFullSessionSummary() bool {
 	return *opts.cascadeFullSessionSummary
 }
 
+func (opts ServiceOpts) effectiveTrackEventTTL() time.Duration {
+	if opts.trackEventTTL != nil {
+		return *opts.trackEventTTL
+	}
+	return opts.sessionTTL
+}
+
 // WithSessionEventLimit sets the event limit per session.
 func WithSessionEventLimit(limit int) ServiceOpt {
 	return func(opts *ServiceOpts) {
@@ -96,6 +104,15 @@ func WithSessionEventLimit(limit int) ServiceOpt {
 func WithSessionTTL(ttl time.Duration) ServiceOpt {
 	return func(opts *ServiceOpts) {
 		opts.sessionTTL = ttl
+	}
+}
+
+// WithTrackEventTTL sets the TTL for track events.
+// If unset, track events use the session TTL. A non-positive TTL disables track
+// event expiration.
+func WithTrackEventTTL(ttl time.Duration) ServiceOpt {
+	return func(opts *ServiceOpts) {
+		opts.trackEventTTL = &ttl
 	}
 }
 

--- a/session/sqlite/service.go
+++ b/session/sqlite/service.go
@@ -92,7 +92,7 @@ func NewService(db *sql.DB, options ...ServiceOpt) (*Service, error) {
 
 	if opts.cleanupInterval <= 0 {
 		if opts.sessionTTL > 0 || opts.appStateTTL > 0 ||
-			opts.userStateTTL > 0 {
+			opts.userStateTTL > 0 || opts.effectiveTrackEventTTL() > 0 {
 			opts.cleanupInterval = defaultCleanupInterval
 		}
 	}

--- a/session/sqlite/service_helper.go
+++ b/session/sqlite/service_helper.go
@@ -489,7 +489,8 @@ AND deleted_at IS NULL`,
 		return fmt.Errorf("marshal track event: %w", err)
 	}
 
-	newExpires := calculateExpiresAt(now, s.opts.sessionTTL)
+	sessionExpires := calculateExpiresAt(now, s.opts.sessionTTL)
+	trackExpires := calculateExpiresAt(now, s.opts.effectiveTrackEventTTL())
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -508,7 +509,7 @@ AND deleted_at IS NULL`,
 		),
 		updatedState,
 		sessState.UpdatedAt.UTC().UnixNano(),
-		newExpires,
+		sessionExpires,
 		key.AppName,
 		key.UserID,
 		key.SessionID,
@@ -534,7 +535,7 @@ AND deleted_at IS NULL`,
 		eventBytes,
 		tsNs,
 		tsNs,
-		newExpires,
+		trackExpires,
 	)
 	if err != nil {
 		return fmt.Errorf("insert track event: %w", err)

--- a/session/sqlite/service_test.go
+++ b/session/sqlite/service_test.go
@@ -586,6 +586,32 @@ func TestSessionSQLite_AppendTrackEvent(t *testing.T) {
 	require.Len(t, got.Tracks[trk].Events, 1)
 }
 
+func TestSessionSQLite_GetTrackEvents_ReadsTrackStorage(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	trk := session.Track("t1")
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, newTrackEvent(trk, 1)))
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, newTrackEvent(trk, 2)))
+	require.NoError(t, svc.UpdateSessionState(ctx, key, session.StateMap{"tracks": []byte("[]")}))
+	got, err := svc.GetTrackEvents(ctx, key, trk, session.WithEventNum(1))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, trk, got.Track)
+	require.Len(t, got.Events, 1)
+	require.JSONEq(t, "2", string(got.Events[0].Payload))
+	missing, err := svc.GetTrackEvents(ctx, key, "missing")
+	require.NoError(t, err)
+	require.NotNil(t, missing)
+	require.Empty(t, missing.Events)
+}
+
 func TestSessionSQLite_AppendTrackEvent_AsyncPersist(t *testing.T) {
 	db, path, cleanup := openTempSQLiteDB(t)
 	defer cleanup()


### PR DESCRIPTION
This change adds a separate track event TTL that defaults to session TTL, exposes direct persisted track event reads across supported session backends, and updates AG-UI history retrieval to prefer direct track storage while retaining session snapshot fallback. It also preserves optional reader capabilities through externalization wrappers and documents the new TTL and persisted history behavior.