### PR TITLE
examples/session: handle nil graph completion

### DIFF
--- a/examples/session/graph/main.go
+++ b/examples/session/graph/main.go
@@ -317,7 +317,10 @@ func lastRunnerCompletion(events <-chan *event.Event) *event.Event {
 }
 
 func completionText(completion *event.Event) string {
-	if completion != nil && completion.Response != nil && len(completion.Response.Choices) > 0 {
+	if completion == nil {
+		return "(no assistant text)"
+	}
+	if completion.Response != nil && len(completion.Response.Choices) > 0 {
 		if content := completion.Response.Choices[0].Message.Content; content != "" {
 			return content
 		}


### PR DESCRIPTION
## What changed

Guard the session graph example completion text extraction against a missing runner completion event.

## Why

The fallback path read `completion.StateDelta` after the response path rejected a nil completion, which could panic when an event stream ended without a runner completion event.

## Testing

- `go test ./graph` from `examples/session`
- `go test ./...` from `examples/session`