### PR TITLE
a2a/v1: harden response conversion edge cases

### DIFF
--- a/agent/a2aagent/v1/a2a_agent.go
+++ b/agent/a2aagent/v1/a2a_agent.go
@@ -52,7 +52,7 @@ type A2AAgent struct {
 	name                string
 	description         string
 	agentCard           *server.AgentCard      // Agent card and resolution state
-	agentURL            string                 // URL of the remote A2A agent
+	agentCardURL        string                 // URL used to discover the remote agent
 	eventConverter      A2AEventConverter      // Custom A2A event converters
 	dataPartMappers     []A2ADataPartMapper    // Lightweight inbound DataPart mappers for default converter
 	a2aMessageConverter InvocationA2AConverter // Custom A2A message converters for requests
@@ -94,12 +94,14 @@ func New(opts ...Option) (*A2AAgent, error) {
 	}
 
 	var agentURL string
+	var agentCardURL string
 	if agent.agentCard != nil {
 		// v1.0 cards advertise endpoints via supportedInterfaces; the top-level
 		// URL is deprecated. PrimaryURL prefers the former and falls back.
 		agentURL = agent.agentCard.PrimaryURL()
-	} else if agent.agentURL != "" {
-		agentURL = agent.agentURL
+	} else if agent.agentCardURL != "" {
+		agentCardURL = ia2a.NormalizeURL(agent.agentCardURL)
+		agentURL = agentCardURL
 	} else {
 		log.Info("agent card or agent card url not set")
 	}
@@ -116,9 +118,16 @@ func New(opts ...Option) (*A2AAgent, error) {
 
 	// If agent card is not set, fetch it using A2A client's GetAgentCard method
 	if agent.agentCard == nil {
-		agentCard, err := a2aClient.GetAgentCard(context.Background(), "")
+		agentCard, err := a2aClient.GetAgentCard(
+			context.Background(),
+			agentCardURL,
+		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch agent card from %s: %w", agentURL, err)
+			return nil, fmt.Errorf(
+				"failed to fetch agent card from %s: %w",
+				agentCardURL,
+				err,
+			)
 		}
 
 		agent.agentCard = agentCard
@@ -501,6 +510,10 @@ func (r *A2AAgent) processStreamingEvents(
 		result.observeTaskLifecycle(streamEvent.Result)
 
 		artifactUpdate, _ := streamEvent.Result.(*protocol.TaskArtifactUpdateEvent)
+		replacesArtifact := artifactUpdateReplacesSnapshot(
+			artifactUpdate,
+			artifactContent,
+		)
 		var artifactChunk strings.Builder
 		var artifactChunkParts []model.ContentPart
 
@@ -545,6 +558,10 @@ func (r *A2AAgent) processStreamingEvents(
 				&artifactChunk,
 				&artifactChunkParts,
 			)
+			// A repeated append=false update replaces the previous artifact
+			// value. Expose it as a Message snapshot so consumers do not append
+			// it to an earlier Delta.
+			markArtifactReplacementSnapshot(evt, replacesArtifact)
 			agent.EmitEvent(ctx, invocation, eventChan, evt)
 			if evt.Response != nil &&
 				evt.Response.Error != nil &&
@@ -571,6 +588,29 @@ func (r *A2AAgent) processStreamingEvents(
 		)
 	}
 	return result
+}
+
+func artifactUpdateReplacesSnapshot(
+	update *protocol.TaskArtifactUpdateEvent,
+	artifactContent map[string]string,
+) bool {
+	if update == nil {
+		return false
+	}
+	_, seen := artifactContent[update.Artifact.ArtifactID]
+	appendChunk := update.Append != nil && *update.Append
+	return seen && !appendChunk
+}
+
+func markArtifactReplacementSnapshot(evt *event.Event, replacement bool) {
+	if !replacement || evt == nil || evt.Response == nil ||
+		!evt.Response.IsPartial {
+		return
+	}
+	for i := range evt.Response.Choices {
+		evt.Response.Choices[i].Message = evt.Response.Choices[i].Delta
+		evt.Response.Choices[i].Delta = model.Message{}
+	}
 }
 
 func finalizeStreamingContent(

--- a/agent/a2aagent/v1/a2a_agent.go
+++ b/agent/a2aagent/v1/a2a_agent.go
@@ -7,7 +7,22 @@
 //
 //
 
-// Package a2aagent provides an agent that can communicate with remote A2A agents.
+// Package a2aagent adapts a remote A2A Protocol v1.0 agent to the agent.Agent
+// interface.
+//
+// An A2AAgent discovers the remote endpoint from an Agent Card, selects
+// blocking or streaming message delivery, and converts A2A messages, task
+// updates, artifacts, and tool calls to trpc-agent-go events. When it is used
+// with a Runner, the Runner's session service remains responsible for local
+// conversation history.
+//
+// This package handles message delivery only. Use trpc-a2a-go/v2/client
+// directly for the retained task control plane, including lookup, listing,
+// cancellation, resubscription, and push configuration.
+//
+// The /v1 import-path suffix identifies the A2A Protocol v1.0 integration; it
+// does not require a v1 module tag for trpc-agent-go. The trpc-a2a-go/v2 module
+// version is independent of the A2A protocol version.
 package a2aagent
 
 import (

--- a/agent/a2aagent/v1/a2a_agent_option.go
+++ b/agent/a2aagent/v1/a2a_agent_option.go
@@ -212,10 +212,10 @@ func WithDescription(description string) Option {
 	}
 }
 
-// WithAgentCardURL set the agent card URL
+// WithAgentCardURL sets the complete URL used to fetch the agent card.
 func WithAgentCardURL(url string) Option {
 	return func(a *A2AAgent) {
-		a.agentURL = strings.TrimSpace(url)
+		a.agentCardURL = strings.TrimSpace(url)
 	}
 }
 

--- a/agent/a2aagent/v1/a2a_agent_test.go
+++ b/agent/a2aagent/v1/a2a_agent_test.go
@@ -421,10 +421,11 @@ func TestProcessStreamingEventsReplacesArtifactSnapshot(t *testing.T) {
 	stream <- protocol.NewStreamResponseStatusUpdate(&completed)
 	close(stream)
 
+	eventChan := make(chan *event.Event, 4)
 	result := remote.processStreamingEvents(
 		context.Background(),
 		&agent.Invocation{InvocationID: "invocation"},
-		make(chan *event.Event, 4),
+		eventChan,
 		stream,
 	)
 	if result.terminalError != nil {
@@ -432,6 +433,23 @@ func TestProcessStreamingEventsReplacesArtifactSnapshot(t *testing.T) {
 	}
 	if result.aggregatedContent != "replacement" {
 		t.Fatalf("aggregated content = %q, want replacement", result.aggregatedContent)
+	}
+	if len(eventChan) != 2 {
+		t.Fatalf("emitted event count = %d, want 2", len(eventChan))
+	}
+	staleEvent := <-eventChan
+	if got := staleEvent.Response.Choices[0].Delta.Content; got != "stale" {
+		t.Fatalf("initial artifact delta = %q, want stale", got)
+	}
+	replacementEvent := <-eventChan
+	replacementChoice := replacementEvent.Response.Choices[0]
+	if !replacementEvent.Response.IsPartial ||
+		replacementChoice.Message.Content != "replacement" ||
+		replacementChoice.Delta.Content != "" {
+		t.Fatalf(
+			"replacement event = %#v, want partial Message snapshot",
+			replacementEvent,
+		)
 	}
 }
 

--- a/agent/a2aagent/v1/a2a_converter.go
+++ b/agent/a2aagent/v1/a2a_converter.go
@@ -401,9 +401,10 @@ type parseResult struct {
 
 // toolResponseData holds tool response information
 type toolResponseData struct {
-	id      string
-	name    string
-	content string
+	id           string
+	name         string
+	content      string
+	contentParts []model.ContentPart
 }
 
 func newDataPartMappingResult(result *parseResult) *A2ADataPartMappingResult {
@@ -658,11 +659,12 @@ func processDataPartWithMappers(
 			}
 			builtInHandled = true
 		case ia2a.DataPartMetadataTypeFunctionResp:
-			content, id, name := processFunctionResponse(d)
+			content, contentParts, id, name := processFunctionResponse(d)
 			result.toolResponses = append(result.toolResponses, toolResponseData{
-				id:      id,
-				name:    name,
-				content: content,
+				id:           id,
+				name:         name,
+				content:      content,
+				contentParts: contentParts,
 			})
 			builtInHandled = true
 		case ia2a.DataPartMetadataTypeExecutableCode:
@@ -747,7 +749,9 @@ func processFunctionCall(d *protocol.Part) *model.ToolCall {
 }
 
 // processFunctionResponse processes a function response DataPart and returns the response content and metadata
-func processFunctionResponse(d *protocol.Part) (content string, id string, name string) {
+func processFunctionResponse(
+	d *protocol.Part,
+) (content string, contentParts []model.ContentPart, id string, name string) {
 	data, ok := d.DataContent().(map[string]any)
 	if !ok {
 		log.Warnf("DataPart data is not a map: %T", d.DataContent())
@@ -775,6 +779,17 @@ func processFunctionResponse(d *protocol.Part) (content string, id string, name 
 				response,
 				err,
 			)
+		}
+	}
+	if rawParts, ok := data[ia2a.ToolCallFieldContentParts]; ok {
+		encoded, err := json.Marshal(rawParts)
+		if err != nil {
+			log.Infof("Tool response content parts JSON marshal failed: %v", err)
+			return
+		}
+		if err := json.Unmarshal(encoded, &contentParts); err != nil {
+			log.Infof("Tool response content parts JSON unmarshal failed: %v", err)
+			contentParts = nil
 		}
 	}
 
@@ -917,10 +932,11 @@ func buildStreamingResponse(messageID string, result *parseResult, role protocol
 		for _, resp := range result.toolResponses {
 			choices = append(choices, model.Choice{
 				Message: model.Message{
-					Role:     model.RoleTool,
-					Content:  resp.content,
-					ToolID:   resp.id,
-					ToolName: resp.name,
+					Role:         model.RoleTool,
+					Content:      resp.content,
+					ContentParts: resp.contentParts,
+					ToolID:       resp.id,
+					ToolName:     resp.name,
 				},
 			})
 		}
@@ -1058,10 +1074,11 @@ func buildNonStreamingResponse(messageID string, result *parseResult, role proto
 		for _, resp := range result.toolResponses {
 			choices = append(choices, model.Choice{
 				Message: model.Message{
-					Role:     model.RoleTool,
-					Content:  resp.content,
-					ToolID:   resp.id,
-					ToolName: resp.name,
+					Role:         model.RoleTool,
+					Content:      resp.content,
+					ContentParts: resp.contentParts,
+					ToolID:       resp.id,
+					ToolName:     resp.name,
 				},
 			})
 		}

--- a/agent/a2aagent/v1/a2a_converter_test.go
+++ b/agent/a2aagent/v1/a2a_converter_test.go
@@ -311,6 +311,7 @@ func TestConvertResponseFileParts(t *testing.T) {
 }
 
 func TestConvertPackedToolRoundPreservesFinalAssistantMessage(t *testing.T) {
+	toolResultText := "content-parts result"
 	toolCall := protocol.NewDataPart(map[string]any{
 		ia2a.ToolCallFieldID:   "call-1",
 		ia2a.ToolCallFieldName: "lookup",
@@ -323,6 +324,10 @@ func TestConvertPackedToolRoundPreservesFinalAssistantMessage(t *testing.T) {
 		ia2a.ToolCallFieldID:       "call-1",
 		ia2a.ToolCallFieldName:     "lookup",
 		ia2a.ToolCallFieldResponse: map[string]any{"temperature": 30},
+		ia2a.ToolCallFieldContentParts: []map[string]any{{
+			"type": "text",
+			"text": toolResultText,
+		}},
 	})
 	toolResponse.Metadata = map[string]any{
 		ia2a.DataPartMetadataTypeKey: ia2a.DataPartMetadataTypeFunctionResp,
@@ -354,7 +359,10 @@ func TestConvertPackedToolRoundPreservesFinalAssistantMessage(t *testing.T) {
 		t.Fatalf("tool call choice = %#v", choices[0])
 	}
 	if choices[1].Message.Role != model.RoleTool ||
-		choices[1].Message.Content != `{"temperature":30}` {
+		choices[1].Message.Content != `{"temperature":30}` ||
+		len(choices[1].Message.ContentParts) != 1 ||
+		choices[1].Message.ContentParts[0].Text == nil ||
+		*choices[1].Message.ContentParts[0].Text != toolResultText {
 		t.Fatalf("tool response choice = %#v", choices[1])
 	}
 	if choices[2].Message.Role != model.RoleAssistant ||

--- a/agent/a2aagent/v1/agent_runtime_test.go
+++ b/agent/a2aagent/v1/agent_runtime_test.go
@@ -67,6 +67,10 @@ func TestNewFetchesCardAndInstallsDefaultMapper(t *testing.T) {
 		Description: "description",
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/custom-card.json" {
+			http.NotFound(w, r)
+			return
+		}
 		card.URL = "http://" + r.Host
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(card); err != nil {
@@ -79,7 +83,7 @@ func TestNewFetchesCardAndInstallsDefaultMapper(t *testing.T) {
 		return false, nil
 	}
 	remote, err := New(
-		WithAgentCardURL(server.URL),
+		WithAgentCardURL(server.URL+"/custom-card.json"),
 		WithA2ADataPartMapper(mapper),
 	)
 	if err != nil {

--- a/agent/a2aagent/v1/converter_branches_test.go
+++ b/agent/a2aagent/v1/converter_branches_test.go
@@ -372,16 +372,27 @@ func TestDataPartAndTextHelperBranches(t *testing.T) {
 		t.Fatalf("string-argument function call = %#v", got)
 	}
 
-	content, id, name := processFunctionResponse(protocol.NewDataPart("invalid"))
-	if content != "" || id != "" || name != "" {
+	content, contentParts, id, name := processFunctionResponse(
+		protocol.NewDataPart("invalid"),
+	)
+	if content != "" || len(contentParts) != 0 || id != "" || name != "" {
 		t.Fatalf("invalid function response = (%q, %q, %q)", content, id, name)
 	}
+	partText := "content-parts-only result"
 	response := protocol.NewDataPart(map[string]any{
 		ia2a.ToolCallFieldResponse: map[string]any{"ok": true},
+		ia2a.ToolCallFieldContentParts: []map[string]any{{
+			"type": "text",
+			"text": partText,
+		}},
 	})
-	content, _, _ = processFunctionResponse(response)
+	content, contentParts, _, _ = processFunctionResponse(response)
 	if content != `{"ok":true}` {
 		t.Fatalf("structured function response = %q", content)
+	}
+	if len(contentParts) != 1 || contentParts[0].Text == nil ||
+		*contentParts[0].Text != partText {
+		t.Fatalf("function response content parts = %#v", contentParts)
 	}
 
 	data := map[string]any{"fallback": "value"}

--- a/agent/a2aagent/v1/options_test.go
+++ b/agent/a2aagent/v1/options_test.go
@@ -140,7 +140,7 @@ func TestA2AAgentOptions(t *testing.T) {
 		option(a)
 	}
 	if a.name != "agent" || a.description != "description" ||
-		a.agentURL != "http://localhost:8080" || a.agentCard != card ||
+		a.agentCardURL != "http://localhost:8080" || a.agentCard != card ||
 		a.eventConverter != eventConverter || len(a.dataPartMappers) != 1 ||
 		a.a2aMessageConverter != messageConverter ||
 		a.streamingBufSize != defaultStreamingChannelSize ||

--- a/examples/a2aagent/v1/client/main.go
+++ b/examples/a2aagent/v1/client/main.go
@@ -33,10 +33,10 @@ const (
 )
 
 var (
-	serverURL = flag.String(
+	agentCardURL = flag.String(
 		"url",
-		"http://127.0.0.1:8888",
-		"A2A server URL",
+		"http://127.0.0.1:8888/.well-known/agent-card.json",
+		"A2A agent card URL",
 	)
 	initialSessionID = flag.String(
 		"session",
@@ -49,7 +49,7 @@ func main() {
 	flag.Parse()
 
 	remoteAgent, err := a2aagent.New(
-		a2aagent.WithAgentCardURL(*serverURL),
+		a2aagent.WithAgentCardURL(*agentCardURL),
 	)
 	if err != nil {
 		log.Fatalf("connect A2A agent: %v", err)
@@ -165,7 +165,15 @@ func printResponse(events <-chan *event.Event) error {
 			}
 			var content string
 			if isPartial {
-				content = choice.Delta.Content
+				if model.HasPayload(choice.Message) {
+					if printed {
+						fmt.Println()
+						printed = false
+					}
+					content = choice.Message.Content
+				} else {
+					content = choice.Delta.Content
+				}
 			} else if !sawPartial {
 				content = choice.Message.Content
 			}

--- a/internal/a2a/a2a.go
+++ b/internal/a2a/a2a.go
@@ -52,6 +52,10 @@ const (
 	// ToolCallFieldResponse is the data field key for tool call response.
 	ToolCallFieldResponse = "response"
 
+	// ToolCallFieldContentParts is the data field key for multimodal tool
+	// response content.
+	ToolCallFieldContentParts = "content_parts"
+
 	// CodeExecutionFieldCode is the data field key for executable code content.
 	// Used in ADK mode for code execution scenarios.
 	CodeExecutionFieldCode = "code"

--- a/server/a2a/server.go
+++ b/server/a2a/server.go
@@ -1397,11 +1397,20 @@ func normalizeStreamingResult(
 ) protocol.StreamingMessageResult {
 	switch v := result.(type) {
 	case *protocol.Message:
-		return normalizeProtocolMessage(v)
+		if normalized := normalizeProtocolMessage(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	case *protocol.TaskArtifactUpdateEvent:
-		return normalizeTaskArtifactUpdateEvent(v)
+		if normalized := normalizeTaskArtifactUpdateEvent(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	case *protocol.TaskStatusUpdateEvent:
-		return normalizeTaskStatusUpdateEvent(v)
+		if normalized := normalizeTaskStatusUpdateEvent(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	default:
 		return result
 	}
@@ -1412,9 +1421,15 @@ func normalizeUnaryResult(
 ) protocol.UnaryMessageResult {
 	switch v := result.(type) {
 	case *protocol.Message:
-		return normalizeProtocolMessage(v)
+		if normalized := normalizeProtocolMessage(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	case *protocol.Task:
-		return normalizeTask(v)
+		if normalized := normalizeTask(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	default:
 		return result
 	}

--- a/server/a2a/server_test.go
+++ b/server/a2a/server_test.go
@@ -5007,6 +5007,23 @@ func TestNormalizeResponseResults(t *testing.T) {
 		assert.Nil(t, normalizeArtifact(nil))
 	})
 
+	t.Run("typed nil results", func(t *testing.T) {
+		var message *protocol.Message
+		var artifact *protocol.TaskArtifactUpdateEvent
+		var status *protocol.TaskStatusUpdateEvent
+		var task *protocol.Task
+		assert.Nil(t, normalizeStreamingResult(message))
+		assert.Nil(t, normalizeStreamingResult(artifact))
+		assert.Nil(t, normalizeStreamingResult(status))
+		assert.Nil(t, normalizeUnaryResult(message))
+		assert.Nil(t, normalizeUnaryResult(task))
+		assert.Nil(t, normalizeStreamingResult(&protocol.Message{}))
+		assert.Nil(t, normalizeStreamingResult(
+			&protocol.TaskArtifactUpdateEvent{},
+		))
+		assert.Nil(t, normalizeUnaryResult(&protocol.Message{}))
+	})
+
 	t.Run("empty message with only response id is dropped", func(t *testing.T) {
 		msg := &protocol.Message{
 			Metadata: map[string]any{

--- a/server/a2a/v1/agent_card.go
+++ b/server/a2a/v1/agent_card.go
@@ -123,7 +123,7 @@ func buildSkillsFromCardTools(
 
 	skills := make([]a2aprotocolserver.AgentSkill, 0, len(tools)+1)
 	skills = append(skills, defaultSkill)
-	skillIDCounts := make(map[string]int)
+	usedSkillIDs := map[string]struct{}{defaultSkill.ID: {}}
 
 	for _, t := range tools {
 		if t == nil {
@@ -133,11 +133,15 @@ func buildSkillsFromCardTools(
 		if decl == nil {
 			continue
 		}
-		skillID := "tool-" + decl.Name
-		skillIDCounts[skillID]++
-		if count := skillIDCounts[skillID]; count > 1 {
-			skillID = fmt.Sprintf("%s-%d", skillID, count)
+		baseSkillID := "tool-" + decl.Name
+		skillID := baseSkillID
+		for suffix := 2; ; suffix++ {
+			if _, exists := usedSkillIDs[skillID]; !exists {
+				break
+			}
+			skillID = fmt.Sprintf("%s-%d", baseSkillID, suffix)
 		}
+		usedSkillIDs[skillID] = struct{}{}
 		toolDesc := decl.Description
 		skills = append(skills, a2aprotocolserver.AgentSkill{
 			ID:          skillID,

--- a/server/a2a/v1/converter.go
+++ b/server/a2a/v1/converter.go
@@ -613,6 +613,9 @@ func (c *defaultEventToA2AMessage) convertToolCallToA2AMessage(
 			if message.Content != "" {
 				toolResponseData[ia2a.ToolCallFieldResponse] = message.Content
 			}
+			if len(message.ContentParts) > 0 {
+				toolResponseData[ia2a.ToolCallFieldContentParts] = message.ContentParts
+			}
 
 			dataPart := protocol.NewDataPart(toolResponseData)
 			c.setPartTypeMetadata(dataPart, ia2a.DataPartMetadataTypeFunctionResp)

--- a/server/a2a/v1/converter_test.go
+++ b/server/a2a/v1/converter_test.go
@@ -368,6 +368,7 @@ func TestDefaultEventConverterForwardsContentParts(t *testing.T) {
 func TestDefaultEventConverterToolAndCodeEvents(t *testing.T) {
 	converter := &defaultEventToA2AMessage{adkCompatibility: true}
 	options := EventToA2AStreamingOptions{CtxID: "context", TaskID: "task"}
+	toolResultText := "content-parts-only result"
 
 	toolEvent := event.New("inv", "agent", event.WithResponse(&model.Response{
 		ID: "tool-response",
@@ -387,7 +388,10 @@ func TestDefaultEventConverterToolAndCodeEvents(t *testing.T) {
 				Role:     model.RoleTool,
 				ToolID:   "call",
 				ToolName: "lookup",
-				Content:  `{"temperature":30}`,
+				ContentParts: []model.ContentPart{{
+					Type: model.ContentTypeText,
+					Text: &toolResultText,
+				}},
 			}},
 		},
 	}))
@@ -404,6 +408,18 @@ func TestDefaultEventConverterToolAndCodeEvents(t *testing.T) {
 			part.Metadata[ia2a.GetADKMetadataKey(ia2a.DataPartMetadataTypeKey)] == nil {
 			t.Fatalf("tool part metadata = %#v", part.Metadata)
 		}
+	}
+	responseData, ok := message.Parts[1].DataContent().(map[string]any)
+	if !ok {
+		t.Fatalf("tool response data = %#v", message.Parts[1].DataContent())
+	}
+	contentParts, ok := responseData[ia2a.ToolCallFieldContentParts].([]model.ContentPart)
+	if !ok || len(contentParts) != 1 || contentParts[0].Text == nil ||
+		*contentParts[0].Text != toolResultText {
+		t.Fatalf("tool response content parts = %#v", responseData)
+	}
+	if _, exists := responseData[ia2a.ToolCallFieldResponse]; exists {
+		t.Fatalf("empty tool response content was serialized: %#v", responseData)
 	}
 	deltaToolEvent := event.New("inv", "agent", event.WithResponse(&model.Response{
 		ID:        "delta-tool-response",

--- a/server/a2a/v1/options_agent_card_test.go
+++ b/server/a2a/v1/options_agent_card_test.go
@@ -82,19 +82,25 @@ func TestAgentCardValidationToolsAndHandler(t *testing.T) {
 				Name:        "lookup",
 				Description: "look things up again",
 			}},
+			&cardTestTool{declaration: &tool.Declaration{
+				Name:        "lookup-2",
+				Description: "look things up by alternate name",
+			}},
 		),
 	)
 	if err != nil {
 		t.Fatalf("NewAgentCard failed: %v", err)
 	}
-	if len(card.Skills) != 3 || card.Skills[0].Name != "agent" ||
-		card.Skills[1].Name != "lookup" || card.Skills[2].Name != "lookup" {
+	if len(card.Skills) != 4 || card.Skills[0].Name != "agent" ||
+		card.Skills[1].Name != "lookup" || card.Skills[2].Name != "lookup" ||
+		card.Skills[3].Name != "lookup-2" {
 		t.Fatalf("skills = %#v", card.Skills)
 	}
-	if card.Version != "1.0.0" || card.Skills[0].ID == "" ||
-		card.Skills[1].ID == "" || card.Skills[2].ID == "" ||
-		card.Skills[0].ID == card.Skills[1].ID ||
-		card.Skills[1].ID == card.Skills[2].ID {
+	if card.Version != "1.0.0" ||
+		card.Skills[0].ID != "agent" ||
+		card.Skills[1].ID != "tool-lookup" ||
+		card.Skills[2].ID != "tool-lookup-2" ||
+		card.Skills[3].ID != "tool-lookup-2-2" {
 		t.Fatalf("card identity fields = %#v", card)
 	}
 	if card.Capabilities.Streaming == nil || !*card.Capabilities.Streaming {
@@ -223,6 +229,7 @@ func TestServerContextAuthenticationAndOptions(t *testing.T) {
 		WithEventToA2APartMapper(partMapper),
 		WithDebugLogging(true),
 		WithErrorHandler(handler),
+		WithErrorHandler(nil),
 	} {
 		option(opts)
 	}
@@ -236,6 +243,13 @@ func TestServerContextAuthenticationAndOptions(t *testing.T) {
 		len(opts.eventPartMappers) != 1 || !opts.debugLogging ||
 		opts.errorHandler == nil {
 		t.Fatalf("options not applied: %#v", opts)
+	}
+	if _, err := opts.errorHandler(
+		context.Background(),
+		nil,
+		errors.New("source"),
+	); err == nil || err.Error() != "handled" {
+		t.Fatalf("nil error handler replaced custom handler: %v", err)
 	}
 	opts.processorHook(nil)
 	if !hookCalled {

--- a/server/a2a/v1/server.go
+++ b/server/a2a/v1/server.go
@@ -7,7 +7,19 @@
 //
 //
 
-// Package a2a provides utilities for creating a2a servers.
+// Package a2a exposes a runner.Runner as an A2A Protocol v1.0 server.
+//
+// The Runner and its session service own agent execution and conversation
+// context. The A2A task manager is a separate protocol concern. By default,
+// New installs a stateless task manager: the current request can return or
+// stream a task lifecycle, but task state is not retained for later lookup,
+// listing, cancellation, or resubscription. Use WithTaskManagerBuilder with a
+// memory, Redis, or custom manager when the retained A2A task control plane is
+// required; doing so does not replace Runner session storage.
+//
+// The /v1 import-path suffix identifies the A2A Protocol v1.0 integration; it
+// does not require a v1 module tag for trpc-agent-go. The trpc-a2a-go/v2 module
+// version is independent of the A2A protocol version.
 package a2a
 
 import (

--- a/server/a2a/v1/server.go
+++ b/server/a2a/v1/server.go
@@ -1112,12 +1112,21 @@ func recordTaskOutputEvent(
 ) {
 	switch converted := outbound.(type) {
 	case *protocol.TaskArtifactUpdateEvent:
+		if converted == nil {
+			return
+		}
 		artifactID := converted.Artifact.ArtifactID
 		state.seenArtifactIDs[artifactID] = struct{}{}
 		state.lastArtifactID = artifactID
 	case *protocol.TaskStatusUpdateEvent:
+		if converted == nil {
+			return
+		}
 		state.roundEnded = taskStateEndsRound(converted.Status.State)
 	case *protocol.Message:
+		if converted == nil {
+			return
+		}
 		if state.finalMessage == nil {
 			message := protocol.NewMessageWithContext(
 				protocol.MessageRoleAgent,
@@ -1194,11 +1203,20 @@ func normalizeStreamingResult(
 ) protocol.StreamEvent {
 	switch v := result.(type) {
 	case *protocol.Message:
-		return normalizeProtocolMessage(v)
+		if normalized := normalizeProtocolMessage(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	case *protocol.TaskArtifactUpdateEvent:
-		return normalizeTaskArtifactUpdateEvent(v)
+		if normalized := normalizeTaskArtifactUpdateEvent(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	case *protocol.TaskStatusUpdateEvent:
-		return normalizeTaskStatusUpdateEvent(v)
+		if normalized := normalizeTaskStatusUpdateEvent(v); normalized != nil {
+			return normalized
+		}
+		return nil
 	default:
 		return result
 	}

--- a/server/a2a/v1/server_helpers_test.go
+++ b/server/a2a/v1/server_helpers_test.go
@@ -535,6 +535,42 @@ func TestNormalizationAndTaskMetadataBranches(t *testing.T) {
 	}
 }
 
+func TestNormalizeStreamingResultDropsTypedNil(t *testing.T) {
+	var message *protocol.Message
+	var artifact *protocol.TaskArtifactUpdateEvent
+	var status *protocol.TaskStatusUpdateEvent
+	for name, result := range map[string]protocol.StreamEvent{
+		"message":  message,
+		"artifact": artifact,
+		"status":   status,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := normalizeStreamingResult(result); got != nil {
+				t.Fatalf("normalizeStreamingResult() = %#v, want nil", got)
+			}
+		})
+	}
+
+	emptyMessage := &protocol.Message{}
+	if got := normalizeStreamingResult(emptyMessage); got != nil {
+		t.Fatalf("empty message result = %#v, want nil", got)
+	}
+	emptyArtifact := &protocol.TaskArtifactUpdateEvent{}
+	if got := normalizeStreamingResult(emptyArtifact); got != nil {
+		t.Fatalf("empty artifact result = %#v, want nil", got)
+	}
+}
+
+func TestRecordTaskOutputEventIgnoresTypedNil(t *testing.T) {
+	var message *protocol.Message
+	var artifact *protocol.TaskArtifactUpdateEvent
+	var status *protocol.TaskStatusUpdateEvent
+	state := &taskOutputState{}
+	for _, result := range []protocol.StreamEvent{message, artifact, status} {
+		recordTaskOutputEvent(result, state, "task", nil)
+	}
+}
+
 func TestTaskErrorHelperBranches(t *testing.T) {
 	if taskErrorState(&model.ResponseError{
 		Type: agent.ErrorTypeStopAgentError,

--- a/server/a2a/v1/server_mode_test.go
+++ b/server/a2a/v1/server_mode_test.go
@@ -452,6 +452,63 @@ func TestResponseRewriterRunsBeforeTaskAggregation(t *testing.T) {
 	}
 }
 
+func TestResponseRewriterCanEmptyArtifactParts(t *testing.T) {
+	runner := &modeTestRunner{events: []*event.Event{
+		{
+			Response: &model.Response{
+				ID:        "response",
+				IsPartial: true,
+				Choices: []model.Choice{{
+					Delta: model.Message{Content: "secret"},
+				}},
+			},
+		},
+		{
+			Response: &model.Response{
+				Object: model.ObjectTypeRunnerCompletion,
+				Done:   true,
+			},
+		},
+	}}
+	processor, err := buildProcessor("agent", &options{
+		runner:       runner,
+		errorHandler: defaultErrorHandler,
+		responseRewriter: func(
+			_ context.Context,
+			result protocol.StreamEvent,
+		) protocol.StreamEvent {
+			if update, ok := result.(*protocol.TaskArtifactUpdateEvent); ok {
+				update.Artifact.Parts = nil
+			}
+			return result
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildProcessor failed: %v", err)
+	}
+	manager, err := stateless.NewTaskManager(processor)
+	if err != nil {
+		t.Fatalf("stateless.NewTaskManager failed: %v", err)
+	}
+	response, err := manager.OnSendMessage(
+		NewContextWithUserID(context.Background(), "user"),
+		protocol.SendMessageParams{Message: protocol.NewMessage(
+			protocol.MessageRoleUser,
+			[]*protocol.Part{protocol.NewTextPart("hi")},
+		)},
+	)
+	if err != nil {
+		t.Fatalf("OnSendMessage failed: %v", err)
+	}
+	task := response.GetTask()
+	if task == nil {
+		t.Fatal("response did not contain a Task")
+	}
+	if task.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("task state = %s, want completed", task.Status.State)
+	}
+}
+
 func TestTaskManagerBuilderPropagatesError(t *testing.T) {
 	wantErr := errors.New("task manager unavailable")
 	_, err := New(

--- a/server/a2a/v1/server_option.go
+++ b/server/a2a/v1/server_option.go
@@ -305,6 +305,9 @@ func WithDebugLogging(debug bool) Option {
 // WithErrorHandler sets a custom error handler.
 func WithErrorHandler(handler ErrorHandler) Option {
 	return func(opts *options) {
+		if handler == nil {
+			return
+		}
 		opts.errorHandler = handler
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up hardening for the A2A v1 integration added in #2058.

- preserve tool-result `ContentParts` across the A2A server/client boundary
- expose repeated `append=false` artifact updates as replacement snapshots instead of append-only deltas
- fetch the exact URL supplied to `WithAgentCardURL`
- guarantee globally unique generated Agent Card skill IDs
- ignore `WithErrorHandler(nil)` instead of replacing the default handler
- prevent typed-nil normalized results from escaping in both v1 and legacy v0, with defensive request-local task aggregation guards
- document the `/v1` package version boundary, Runner session ownership, and stateless versus retained A2A task management

The v1 client example now uses a complete Agent Card URL and handles replacement snapshots without concatenating stale and replacement content.

## Testing

- `go test -race ./agent/a2aagent/v1 ./server/a2a/v1 ./server/a2a ./internal/a2a -count=1`
- `go vet ./agent/a2aagent/v1 ./server/a2a/v1 ./server/a2a ./internal/a2a`
- `golangci-lint run --timeout=10m ./agent/a2aagent/v1/... ./server/a2a/v1/... ./server/a2a/... ./internal/a2a/...`
- targeted regressions repeated with `-count=20`
- `(cd examples && go test ./a2aagent/v1/... -count=1)`
- `go mod tidy -diff`

Relevant package coverage after the changes:

- `agent/a2aagent/v1`: 93.0%
- `server/a2a/v1`: 91.0%
- `server/a2a`: 97.6%
- `internal/a2a`: 95.1%

A full root `go test ./... -count=1` also exercised the changed packages successfully. The remaining local failures were unrelated environment-sensitive tests: workspace/skill subprocesses read a stale `.bashrc` completion entry, and two file-mode assertions observe the host umask.
