### PR TITLE
tool/hostexec: return from write_stdin when the process exits

### DIFF
--- a/tool/hostexec/hostexec.go
+++ b/tool/hostexec/hostexec.go
@@ -405,11 +405,19 @@ func (t *writeStdinTool) Call(
 		yield = *v
 	}
 	if yield > 0 {
+		sess, err := t.mgr.get(sessionID)
+		if err != nil {
+			return nil, err
+		}
 		timer := time.NewTimer(time.Duration(yield) * time.Millisecond)
 		defer timer.Stop()
+		// Return as soon as the process exits: sleeping out the full
+		// yield after exit only delays the result the caller is
+		// waiting for. Mirrors the manager's own exec yield path.
 		select {
 		case <-ctx.Done():
 		case <-timer.C:
+		case <-sess.doneCh:
 		}
 	}
 

--- a/tool/hostexec/hostexec.go
+++ b/tool/hostexec/hostexec.go
@@ -391,8 +391,11 @@ func (t *writeStdinTool) Call(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := t.mgr.write(
-		sessionID,
+	sess, err := t.mgr.get(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if err := sess.write(
 		in.Chars,
 		firstBool(in.AppendNewline, in.Submit),
 	); err != nil {
@@ -405,10 +408,6 @@ func (t *writeStdinTool) Call(
 		yield = *v
 	}
 	if yield > 0 {
-		sess, err := t.mgr.get(sessionID)
-		if err != nil {
-			return nil, err
-		}
 		timer := time.NewTimer(time.Duration(yield) * time.Millisecond)
 		defer timer.Stop()
 		// Return as soon as the process exits: sleeping out the full
@@ -421,11 +420,7 @@ func (t *writeStdinTool) Call(
 		}
 	}
 
-	poll, err := t.mgr.poll(sessionID, nil)
-	if err != nil {
-		return nil, err
-	}
-	return mapPollResult(sessionID, poll), nil
+	return mapPollResult(sessionID, sess.poll(nil)), nil
 }
 
 type killSessionTool struct {

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -841,6 +841,18 @@ func TestToolCalls_NotConfigured(t *testing.T) {
 	require.EqualError(t, err, errKillToolNotConfigured)
 }
 
+func TestWriteStdin_UnknownSession(t *testing.T) {
+	tool := &writeStdinTool{mgr: newManager()}
+	_, err := tool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"session_id": "missing",
+			"chars":      "hello",
+		}),
+	)
+	require.ErrorIs(t, err, errUnknownSession)
+}
+
 func TestWriteStdin_CanceledBeforePoll(t *testing.T) {
 	mgr := newManager()
 	sess := newSession("session", "cat", defaultMaxLines)

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -174,6 +174,51 @@ func TestNewToolSet_WriteStdin(t *testing.T) {
 	require.Contains(t, all, "got:hi")
 }
 
+func TestNewToolSet_WriteStdin_ReturnsWhenProcessExits(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet(WithJobTTL(10 * time.Second))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, writeTool, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command":    "sleep 0.3; echo finished",
+			"background": true,
+		}),
+	)
+	require.NoError(t, err)
+
+	sessionID := out.(map[string]any)["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	// A yield far longer than the command: the wait must end when the
+	// process exits, not when the yield timer fires.
+	start := time.Now()
+	writeOut, err := writeTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"session_id":    sessionID,
+			"chars":         "",
+			"yield_time_ms": 30_000,
+		}),
+	)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	res := writeOut.(map[string]any)
+	require.Equal(t, programStatusExited, res["status"])
+	require.Contains(t, outputField(res), "finished")
+	require.Less(
+		t, elapsed, 10*time.Second,
+		"write_stdin slept out its yield instead of returning on exit",
+	)
+}
+
 func TestNewToolSet_WriteStdin_NoRepeatedInitialOutput(t *testing.T) {
 	if _, _, err := shellSpec(); err != nil {
 		t.Skip(err.Error())


### PR DESCRIPTION
## What

`write_stdin`'s yield wait selects only on the context and the yield timer, so a poll with a long `yield_time_ms` sleeps its **entire** yield even when the command exits moments in. This adds the session's `doneCh` to the select — mirroring the manager's own exec yield path (`manager.exec`, which already selects on `ctx` / `doneCh` / timer) — so the call returns and polls the final status the moment the process finishes.

## Why

- Version: v1.10.0 (bug present at current main, `fff1eedd`)
- OS/arch: observed on linux/arm64 and darwin/arm64
- What we did: an LLM agent waiting on a long build called `write_stdin` with `chars: ""` and `yield_time_ms: 240000` (the tool description suggests it "acts like a lightweight poll")
- Expected: the call returns when the command exits
- Actual: every poll sleeps its full yield; across three production agent runs this cost ~26 minutes of pure wall-clock waiting on commands that had already finished

## Test

`TestNewToolSet_WriteStdin_ReturnsWhenProcessExits`: backgrounds `sleep 0.3; echo finished`, then polls with a 30s yield. Fails on main (returns after 30.0s), passes with this change (returns in ~0.4s).

`go test ./tool/hostexec/ -count=1` passes; `go vet` and `gofmt` clean. Happy to open a tracking issue first if that's preferred.