### PR TITLE
tool/hostexec: honor max lines on the foreground exec path

### DIFF
--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -61,28 +61,47 @@ func TestNewToolSet_ForegroundHonorsMaxLines(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	set, err := NewToolSet(WithMaxLines(3))
-	require.NoError(t, err)
-	defer set.Close()
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "trailing newline",
+			command: "printf 'l1\\nl2\\nl3\\nl4\\nl5\\n'",
+		},
+		{
+			// The last line arrives as a partial that markDone
+			// appends after the readers stop; it must be trimmed
+			// like any other line.
+			name:    "no trailing newline",
+			command: "printf 'l1\\nl2\\nl3\\nl4\\nl5'",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			set, err := NewToolSet(WithMaxLines(3))
+			require.NoError(t, err)
+			defer set.Close()
 
-	execTool, _, _, _ := toolSetTools(t, set)
-	out, err := execTool.Call(
-		context.Background(),
-		mustJSON(t, map[string]any{
-			"command": "printf 'l1\\nl2\\nl3\\nl4\\nl5\\n'",
-			"yieldMs": 0,
-		}),
-	)
-	require.NoError(t, err)
+			execTool, _, _, _ := toolSetTools(t, set)
+			out, err := execTool.Call(
+				context.Background(),
+				mustJSON(t, map[string]any{
+					"command": tc.command,
+					"yieldMs": 0,
+				}),
+			)
+			require.NoError(t, err)
 
-	res := out.(map[string]any)
-	require.Equal(t, programStatusExited, res["status"])
-	output := outputField(res)
-	require.Contains(t, output, "l5")
-	require.NotContains(
-		t, output, "l1",
-		"foreground output exceeded the configured max lines",
-	)
+			res := out.(map[string]any)
+			require.Equal(t, programStatusExited, res["status"])
+			require.Equal(
+				t, "l3\nl4\nl5", outputField(res),
+				"foreground output must be exactly the "+
+					"configured tail",
+			)
+		})
+	}
 }
 
 func TestNewToolSet_BaseDirAndRelativeWorkdir(t *testing.T) {
@@ -1052,8 +1071,10 @@ func TestSession_HelpersAndBranches(t *testing.T) {
 	require.False(t, doneAt.IsZero())
 	sess.markDone(9)
 
+	// markDone trims the appended partial like any other line, so the
+	// one-line cap keeps only the final line.
 	out, code := sess.allOutput()
-	require.Equal(t, "third\ntail", out)
+	require.Equal(t, "tail", out)
 	require.Equal(t, 7, code)
 
 	exited := sess.poll(nil)

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -56,6 +56,35 @@ func TestNewToolSet_Foreground(t *testing.T) {
 	require.Empty(t, mgr.sessions)
 }
 
+func TestNewToolSet_ForegroundHonorsMaxLines(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet(WithMaxLines(3))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command": "printf 'l1\\nl2\\nl3\\nl4\\nl5\\n'",
+			"yieldMs": 0,
+		}),
+	)
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	require.Equal(t, programStatusExited, res["status"])
+	output := outputField(res)
+	require.Contains(t, output, "l5")
+	require.NotContains(
+		t, output, "l1",
+		"foreground output exceeded the configured max lines",
+	)
+}
+
 func TestNewToolSet_BaseDirAndRelativeWorkdir(t *testing.T) {
 	if _, _, err := shellSpec(); err != nil {
 		t.Skip(err.Error())
@@ -524,6 +553,7 @@ func TestRunForeground_ContextCancel(t *testing.T) {
 		execParams{Command: "sleep 5"},
 		5*time.Second,
 		nil,
+		defaultMaxLines,
 	)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Empty(t, output)

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -105,6 +105,7 @@ func (m *manager) exec(
 			params,
 			timeout,
 			m.baseEnv,
+			m.maxLines,
 		)
 		if err != nil {
 			return execResult{}, err
@@ -174,13 +175,14 @@ func runForeground(
 	params execParams,
 	timeout time.Duration,
 	baseEnv map[string]string,
+	maxLines int,
 ) (string, int, error) {
 	sess, err := startSession(
 		"",
 		params,
 		timeout,
 		baseEnv,
-		0,
+		maxLines,
 	)
 	if err != nil {
 		return "", 0, err

--- a/tool/hostexec/session.go
+++ b/tool/hostexec/session.go
@@ -93,6 +93,7 @@ func (s *session) markDone(exitCode int) {
 	if s.partial != "" {
 		s.lines = append(s.lines, s.partial)
 		s.partial = ""
+		s.trimLocked()
 	}
 	s.exitCode = exitCode
 	s.finished = time.Now()


### PR DESCRIPTION
## What

`runForeground` starts its session with `maxLines: 0`, which disables the output ring's trim entirely (`trimLocked` early-returns when `maxLines <= 0`). A foreground `exec_command` therefore returns its complete, unbounded output regardless of `WithMaxLines`. Background sessions already receive the manager's configured cap (`startBackground` passes `m.maxLines`); this passes the same cap through `runForeground` so the `WithMaxLines` contract ("maximum retained output lines per session") holds on both paths.

## Why

- Version: v1.10.0 (present at current main, `fff1eedd`)
- What we did: configured `WithMaxLines(500)` and ran a chatty ~20-minute build as a foreground command (the default path — `Background` unset, `yieldMs: 0`)
- Expected: output bounded to the configured 500 lines
- Actual: the entire build log came back in the tool result, flooding the LLM context the toolset feeds

## Test

`TestNewToolSet_ForegroundHonorsMaxLines`: `WithMaxLines(3)` + a 5-line foreground command; asserts the last line is retained and the first is trimmed. `TestRunForeground_ContextCancel` updated for the new parameter.

`go test ./tool/hostexec/ -count=1` passes; `go vet` and `gofmt` clean. Happy to open a tracking issue first if that's preferred.