### PR TITLE
model/openai: support provider-scoped context windows

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1688,7 +1688,7 @@ for request-scoped output limits and tool definitions:
 
 > **Context Window Registration**
 >
-> Token Tailoring and session summary `WithContextThreshold` both need a model context window. Built-in model names are resolved automatically. Token Tailoring uses a 128000-token fallback for unknown model names. For private deployments, tenant-provided models, endpoint IDs, or smaller unknown models, prefer model-instance configuration such as `openai.WithContextWindow(32768)` or the unified `provider.WithContextWindow(32768)`. For one-off runs, use `agent.WithModelContextWindow(32768)`. Use `model.RegisterModelContextWindow("my-model", 32768)` only when the name has a stable process-wide meaning. See the [Session Summary documentation](session/summary.md) for a full example.
+> Token Tailoring and session summary `WithContextThreshold` both need a model context window. Built-in model names are resolved automatically. Token Tailoring uses a 128000-token fallback for unknown model names. For private deployments, tenant-provided models, endpoint IDs, or smaller unknown models, prefer model-instance configuration such as `openai.WithContextWindow(32768)` or the unified `provider.WithContextWindow(32768)`. OpenAI-compatible provider adapters can use `openai.WithContextWindowResolver` to resolve their own model metadata without changing the process-wide model-name registry. For one-off runs, use `agent.WithModelContextWindow(32768)`. Use `model.RegisterModelContextWindow("my-model", 32768)` only when the name has a stable process-wide meaning. See the [Session Summary documentation](session/summary.md) for a full example.
 
 ```text
 outputReserve = max(ReserveOutputTokens, request.MaxTokens, request.ThinkingTokens)

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1672,7 +1672,7 @@ model := openai.New("deepseek-v4-flash",
 
 > **Context Window 注册**
 >
-> Token 裁剪和会话摘要的 `WithContextThreshold` 都需要模型 context window。内置模型名会自动解析。Token 裁剪对未知模型名使用 128000 tokens 的 fallback。对于私有部署、租户自定义模型、endpoint ID 或更小的未知模型，优先使用模型实例配置，例如 `openai.WithContextWindow(32768)` 或统一入口的 `provider.WithContextWindow(32768)`；对于单次运行覆盖，使用 `agent.WithModelContextWindow(32768)`。只有当模型名在当前进程中有稳定全局含义时，才使用 `model.RegisterModelContextWindow("my-model", 32768)`。完整示例参见[会话摘要文档](session/summary.md)。
+> Token 裁剪和会话摘要的 `WithContextThreshold` 都需要模型 context window。内置模型名会自动解析。Token 裁剪对未知模型名使用 128000 tokens 的 fallback。对于私有部署、租户自定义模型、endpoint ID 或更小的未知模型，优先使用模型实例配置，例如 `openai.WithContextWindow(32768)` 或统一入口的 `provider.WithContextWindow(32768)`；OpenAI-compatible provider 适配层可以使用 `openai.WithContextWindowResolver` 解析自己的模型元数据，避免修改进程级模型名注册表。对于单次运行覆盖，使用 `agent.WithModelContextWindow(32768)`。只有当模型名在当前进程中有稳定全局含义时，才使用 `model.RegisterModelContextWindow("my-model", 32768)`。完整示例参见[会话摘要文档](session/summary.md)。
 
 ```text
 outputReserve = max(ReserveOutputTokens, request.MaxTokens, request.ThinkingTokens)

--- a/model/model.go
+++ b/model/model.go
@@ -56,10 +56,17 @@ type Model interface {
 	Info() Info
 }
 
-// ContextWindowResolver resolves context-window metadata for a model name.
+// ContextWindowRequest contains model metadata used to resolve a context
+// window.
+type ContextWindowRequest struct {
+	// ModelName is the model identifier used by the provider.
+	ModelName string
+}
+
+// ContextWindowResolver resolves context-window metadata for a model.
 // It returns ok=false when the model is unknown.
 type ContextWindowResolver func(
-	modelName string,
+	request ContextWindowRequest,
 ) (tokens int, ok bool)
 
 // Seq is a callback-based sequence that yields values.

--- a/model/model.go
+++ b/model/model.go
@@ -56,6 +56,12 @@ type Model interface {
 	Info() Info
 }
 
+// ContextWindowResolver resolves context-window metadata for a model name.
+// It returns ok=false when the model is unknown.
+type ContextWindowResolver func(
+	modelName string,
+) (tokens int, ok bool)
+
 // Seq is a callback-based sequence that yields values.
 type Seq[T any] func(yield func(T) bool)
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -482,6 +482,12 @@ func New(name string, opts ...Option) *Model {
 	if o.TailoringStrategy == nil {
 		o.TailoringStrategy = model.NewMiddleOutStrategy(o.TokenCounter)
 	}
+	contextWindow := o.ContextWindow
+	if contextWindow <= 0 && o.ContextWindowResolver != nil {
+		if resolved, ok := o.ContextWindowResolver(name); ok && resolved > 0 {
+			contextWindow = resolved
+		}
+	}
 	variantCfg := variantConfigs[o.Variant]
 	if o.textOnlyMessageContent != nil {
 		variantCfg.textOnlyMessageContent = *o.textOnlyMessageContent
@@ -508,7 +514,7 @@ func New(name string, opts ...Option) *Model {
 		batchMetadata:              o.BatchMetadata,
 		batchBaseURL:               o.BatchBaseURL,
 		enableTokenTailoring:       o.EnableTokenTailoring,
-		contextWindow:              o.ContextWindow,
+		contextWindow:              contextWindow,
 		tokenCounter:               o.TokenCounter,
 		tailoringStrategy:          o.TailoringStrategy,
 		maxInputTokens:             o.MaxInputTokens,

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -484,7 +484,8 @@ func New(name string, opts ...Option) *Model {
 	}
 	contextWindow := o.ContextWindow
 	if contextWindow <= 0 && o.ContextWindowResolver != nil {
-		if resolved, ok := o.ContextWindowResolver(name); ok && resolved > 0 {
+		request := model.ContextWindowRequest{ModelName: name}
+		if resolved, ok := o.ContextWindowResolver(request); ok && resolved > 0 {
 			contextWindow = resolved
 		}
 	}

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1105,6 +1105,21 @@ func TestWithContextWindowResolver(t *testing.T) {
 	m = New("unknown-model", WithContextWindowResolver(resolver))
 	require.Zero(t, m.Info().ContextWindow)
 
+	const registeredModelName = "gpt-4o"
+	m = New(
+		registeredModelName,
+		WithContextWindowResolver(func(model.ContextWindowRequest) (int, bool) {
+			return 0, false
+		}),
+	)
+	registeredWindow := imodel.ResolveContextWindow(registeredModelName)
+	require.Positive(t, registeredWindow)
+	require.Equal(
+		t,
+		imodel.CalculateMaxInputTokens(registeredWindow),
+		m.InputTokenBudget(context.Background(), nil),
+	)
+
 	m = New(
 		modelName,
 		WithContextWindowResolver(func(model.ContextWindowRequest) (int, bool) {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1085,6 +1085,40 @@ func TestWithContextWindow(t *testing.T) {
 	require.Zero(t, m.Info().ContextWindow)
 }
 
+func TestWithContextWindowResolver(t *testing.T) {
+	const (
+		modelName = "provider-model"
+		window    = 65536
+	)
+	resolver := func(name string) (int, bool) {
+		if name == modelName {
+			return window, true
+		}
+		return 0, false
+	}
+
+	m := New(modelName, WithContextWindowResolver(resolver))
+	require.Equal(t, window, m.Info().ContextWindow)
+
+	m = New("unknown-model", WithContextWindowResolver(resolver))
+	require.Zero(t, m.Info().ContextWindow)
+
+	m = New(
+		modelName,
+		WithContextWindowResolver(func(string) (int, bool) {
+			return 0, true
+		}),
+	)
+	require.Zero(t, m.Info().ContextWindow)
+
+	m = New(
+		modelName,
+		WithContextWindow(204800),
+		WithContextWindowResolver(resolver),
+	)
+	require.Equal(t, 204800, m.Info().ContextWindow)
+}
+
 // stubTool implements tool.Tool for testing purposes.
 type stubTool struct{ decl *tool.Declaration }
 

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1090,7 +1090,7 @@ func TestWithContextWindowResolver(t *testing.T) {
 		modelName = "provider-model"
 		window    = 65536
 	)
-	resolver := func(name string) (int, bool) {
+	var resolver model.ContextWindowResolver = func(name string) (int, bool) {
 		if name == modelName {
 			return window, true
 		}

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -1090,8 +1090,10 @@ func TestWithContextWindowResolver(t *testing.T) {
 		modelName = "provider-model"
 		window    = 65536
 	)
-	var resolver model.ContextWindowResolver = func(name string) (int, bool) {
-		if name == modelName {
+	var resolver model.ContextWindowResolver = func(
+		request model.ContextWindowRequest,
+	) (int, bool) {
+		if request.ModelName == modelName {
 			return window, true
 		}
 		return 0, false
@@ -1105,7 +1107,7 @@ func TestWithContextWindowResolver(t *testing.T) {
 
 	m = New(
 		modelName,
-		WithContextWindowResolver(func(string) (int, bool) {
+		WithContextWindowResolver(func(model.ContextWindowRequest) (int, bool) {
 			return 0, true
 		}),
 	)

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -109,6 +109,8 @@ type options struct {
 	MaxInputTokens int
 	// ContextWindow is the model context window size in tokens.
 	ContextWindow int
+	// ContextWindowResolver resolves provider-scoped model context windows.
+	ContextWindowResolver func(modelName string) (int, bool)
 	// TokenTailoringConfig allows customization of token tailoring parameters.
 	TokenTailoringConfig *model.TokenTailoringConfig
 	// ShowToolCallDelta controls whether to expose tool call
@@ -394,6 +396,18 @@ func WithContextWindow(tokens int) Option {
 		if tokens > 0 {
 			opts.ContextWindow = tokens
 		}
+	}
+}
+
+// WithContextWindowResolver sets a provider-scoped context window resolver.
+// The resolver is used only when WithContextWindow does not set a positive
+// value. Returning ok=false or a non-positive value preserves the default
+// model-name lookup behavior.
+func WithContextWindowResolver(
+	resolver func(modelName string) (tokens int, ok bool),
+) Option {
+	return func(opts *options) {
+		opts.ContextWindowResolver = resolver
 	}
 }
 

--- a/model/openai/options.go
+++ b/model/openai/options.go
@@ -110,7 +110,7 @@ type options struct {
 	// ContextWindow is the model context window size in tokens.
 	ContextWindow int
 	// ContextWindowResolver resolves provider-scoped model context windows.
-	ContextWindowResolver func(modelName string) (int, bool)
+	ContextWindowResolver model.ContextWindowResolver
 	// TokenTailoringConfig allows customization of token tailoring parameters.
 	TokenTailoringConfig *model.TokenTailoringConfig
 	// ShowToolCallDelta controls whether to expose tool call
@@ -404,7 +404,7 @@ func WithContextWindow(tokens int) Option {
 // value. Returning ok=false or a non-positive value preserves the default
 // model-name lookup behavior.
 func WithContextWindowResolver(
-	resolver func(modelName string) (tokens int, ok bool),
+	resolver model.ContextWindowResolver,
 ) Option {
 	return func(opts *options) {
 		opts.ContextWindowResolver = resolver


### PR DESCRIPTION
## Summary

- define protocol-neutral `model.ContextWindowRequest` and `model.ContextWindowResolver` types
- add `openai.WithContextWindowResolver` for OpenAI-compatible provider adapters
- pass model metadata through a request object so the resolver contract can evolve without changing its function signature
- keep a positive `WithContextWindow` value authoritative
- preserve the existing model-name registry fallback when the resolver does not return a valid window
- document the provider-scoped alternative to process-wide registration

## Validation

- `go test ./model ./model/openai -count=1`
- `go test -race ./model ./model/openai -count=1`
- `go vet ./model ./model/openai`
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m`
- `goimports -l model/model.go model/openai/options.go model/openai/openai.go model/openai/openai_test.go`

The full module script reaches unrelated macOS sandbox and Unix-socket temporary-path constraints; the affected Unix-socket test passes with a shorter temporary root.

Fixes #2360