### PR TITLE
docs/a2a: document v1 migration and legacy compatibility

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -100,7 +100,8 @@ nav:
       - Real-Time Conversation Route: agui/chat.md
       - Messages Snapshot Route: agui/history.md
       - Cancel Route: agui/cancel.md
-    - A2A: a2a.md
+    - A2A v1.0: a2a_v1.md
+    - A2A v0.2.x (Legacy): a2a.md
     - A2UI: a2ui.md
     - OpenClaw Runtime: openclaw-runtime.md
   - Observability:
@@ -231,7 +232,8 @@ plugins:
                 - 实时对话路由: agui/chat.md
                 - 消息快照路由: agui/history.md
                 - 取消路由: agui/cancel.md
-              - A2A: a2a.md
+              - A2A v1.0: a2a_v1.md
+              - A2A v0.2.x（旧版）: a2a.md
               - A2UI: a2ui.md
               - OpenClaw Runtime: openclaw-runtime.md
             - 可观测:

--- a/docs/mkdocs/en/a2a-interaction.md
+++ b/docs/mkdocs/en/a2a-interaction.md
@@ -6,7 +6,7 @@
 
 ## Background
 
-The [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org/latest/specification/) defines the basic data models (Message, Task, Part, etc.) and operation interfaces (SendMessage, StreamMessage, etc.) for inter-Agent communication. The A2A specification states its design goals at the very beginning:
+The [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org/latest/specification/) defines the basic data models (Message, Task, Part, etc.) and wire operations for inter-Agent communication. Operation names depend on the protocol generation: v0.2.x uses methods such as `message/send` and `message/stream`, while v1 uses operations such as `SendMessage` and `SendStreamingMessage`. The A2A specification states its design goals at the very beginning:
 
 > *The Agent2Agent (A2A) Protocol is an open standard designed to facilitate communication and interoperability between independent, potentially opaque AI agent systems.*
 >
@@ -44,7 +44,7 @@ The `trpc-a2a-version` extension, interaction version `0.1`, and shared metadata
 | Agent Card declaration | `AgentCard.capabilities.extensions` | `AgentCard.capabilities.extensions` |
 | Request version | Message metadata | Message metadata |
 | Extended event data | Legacy `TextPart`, `DataPart`, and streaming envelopes | Unified Part metadata plus Message, Artifact, and Task update event metadata |
-| Operation names | Lowercase slash-delimited methods such as `message/send` | v1 operations such as `SendMessage` and `SubscribeToTask` |
+| Operation names | Lowercase slash-delimited methods such as `message/send` and `message/stream` | v1 operations such as `SendMessage` and `SendStreamingMessage` |
 
 Unless a section explicitly describes v1, the JSON shapes, concrete Part types, method names, and streaming envelopes in the remainder of this document are v0.2.x wire examples. The metadata key definitions remain the shared interoperability contract.
 
@@ -159,7 +159,7 @@ sequenceDiagram
     S-->>C: SSE: TaskStatusUpdateEvent (completed)
 ```
 
-`SendMessage` waits for the complete response before returning it all at once, while `StreamMessage` pushes incremental events in real-time via SSE. The framework automatically handles format conversion on both ends.
+The `trpc-a2a-go` client methods `SendMessage` and `StreamMessage` wait for a complete response and push incremental SSE events, respectively. In this v0.2.x flow they map to the wire methods `message/send` and `message/stream`; the corresponding v1 streaming operation is `SendStreamingMessage`. The framework automatically handles format conversion on both ends.
 
 ---
 

--- a/docs/mkdocs/en/a2a-interaction.md
+++ b/docs/mkdocs/en/a2a-interaction.md
@@ -2,7 +2,7 @@
 
 > **Note**
 >
-> This document defines the extended implementation specification for the A2A protocol within the trpc-agent-go framework. Regular users do not need to read this document when using A2A Client/Server — the framework automatically handles all protocol conversion details. You only need to refer to this specification when developing a non-trpc-agent-go A2A Client/Server that interoperates with this framework.
+> This document defines the extended implementation specification shared by the legacy and v1 A2A packages in tRPC-Agent-Go. Regular users do not need to read it because the framework handles the conversions. Refer to it when implementing a non-tRPC-Agent-Go Client or Server that must interoperate with these extensions; version-specific carriers are identified below.
 
 ## Background
 
@@ -31,7 +31,22 @@ This document defines the **interaction specification** of trpc-agent-go on top 
 
 > For the complete A2A protocol specification, see: https://a2a-protocol.org/latest/specification/
 >
-> For the framework usage guide, see: [A2A Integration Guide](a2a.md)
+> For framework usage, see the [A2A v0.2.x Integration Guide](a2a.md) or [A2A v1.0 Integration and Migration Guide](a2a_v1.md).
+
+---
+
+## Protocol Version Scope
+
+The `trpc-a2a-version` extension, interaction version `0.1`, and shared metadata keys such as `interaction_spec_version`, `type`, `thought`, `object_type`, `llm_response_id`, and `state_delta` are used by both package generations. Their wire carriers differ:
+
+| Contract area | A2A v0.2.x packages | A2A v1.0 packages |
+|---|---|---|
+| Agent Card declaration | `AgentCard.capabilities.extensions` | `AgentCard.capabilities.extensions` |
+| Request version | Message metadata | Message metadata |
+| Extended event data | Legacy `TextPart`, `DataPart`, and streaming envelopes | Unified Part metadata plus Message, Artifact, and Task update event metadata |
+| Operation names | Lowercase slash-delimited methods such as `message/send` | v1 operations such as `SendMessage` and `SubscribeToTask` |
+
+Unless a section explicitly describes v1, the JSON shapes, concrete Part types, method names, and streaming envelopes in the remainder of this document are v0.2.x wire examples. The metadata key definitions remain the shared interoperability contract.
 
 ---
 

--- a/docs/mkdocs/en/a2a.md
+++ b/docs/mkdocs/en/a2a.md
@@ -1,5 +1,7 @@
 # tRPC-Agent-Go A2A Integration Guide
 
+> This guide covers the legacy `server/a2a` and `agent/a2aagent` packages for A2A v0.2.x. For new integrations and migration guidance, see [A2A v1.0 Integration and Migration Guide](a2a_v1.md).
+
 ## Overview
 
 tRPC-Agent-Go provides a complete A2A (Agent-to-Agent) solution with two core components:

--- a/docs/mkdocs/en/a2a_v1.md
+++ b/docs/mkdocs/en/a2a_v1.md
@@ -1,0 +1,729 @@
+# tRPC-Agent-Go A2A v1.0 Integration and Migration Guide
+
+This guide introduces the A2A protocol, `trpc-a2a-go`, and the tRPC-Agent-Go integration architecture from an application developer's perspective. It then covers the recommended A2A v1.0 integration, Task and multi-node deployment boundaries, the legacy A2A v0.2.x integration, and migration. For the existing v0.2.x integration guide, see [A2A Integration Guide](a2a.md).
+
+## A2A protocol overview
+
+A2A (Agent-to-Agent) is a protocol for discovering and calling remote AI agents. The caller does not need to know which framework, model, or tools the remote agent uses.
+
+The main protocol concepts are:
+
+| Concept | Meaning |
+|---|---|
+| Agent Card | Public description of an Agent's identity, capabilities, and how to invoke it |
+| Message | One message exchanged between a user and an Agent |
+| Part | Text, file, or structured data carried by a Message or Artifact |
+| Task | One observable unit of work with a lifecycle and follow-up operations |
+| Artifact | Output produced by a Task |
+| Context ID | Conversation identity shared by multiple Messages or Tasks |
+| Task ID | Identity of one Task lifecycle |
+
+A typical A2A v1.0 interaction has two steps:
+
+1. Fetch the remote **Agent Card** to learn its address, identity, skills, input/output modes, streaming support, and authentication requirements.
+2. Send a message to an endpoint advertised by the Agent Card and receive either a direct `Message` or a tracked `Task`.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Card as A2A v1 Agent Card endpoint
+    participant Server as A2A v1 endpoint
+
+    Client->>Card: GET /.well-known/agent-card.json
+    Card-->>Client: v1 Agent Card
+    Client->>Server: SendMessage / SendStreamingMessage
+    alt Simple Message result
+        Server-->>Client: Message
+    else Task workflow
+        Server-->>Client: Task or Task update events
+        opt Server retains the Task
+            Client->>Server: GetTask / ListTasks / CancelTask / SubscribeToTask
+            Server-->>Client: Task snapshot or subsequent event stream
+        end
+    end
+```
+
+A short question may return a plain `Message`. Work that needs progress, Artifacts, interruption, cancellation, or later lookup may use a `Task`. Both are protocol results, and a Task is not a replacement for a conversation session.
+
+A2A v1.0 supports blocking `SendMessage`, live `SendStreamingMessage`, and workflows that start work and later query, cancel, or resubscribe through the Task API. Continuing a suspended Task instead requires sending another Message with the original Task ID. The choice depends on whether the server retains the Task after the request; the [protocol usage guide](#protocol-usage-guide) summarizes the options.
+
+### From v0.x to v1.0
+
+The A2A protocol has evolved from the v0.x line to v1.0. The [official v1.0 announcement](https://a2a-protocol.org/latest/announcing-1.0/) explicitly states that the interaction protocol includes breaking changes. The [official migration guide](https://a2a-protocol.org/latest/whats-new-v1/) uses v0.3.0 as its comparison baseline and documents the core changes below. The legacy tRPC-Agent-Go integration implements the earlier v0.2.x protocol, which belongs to the same v0.x line that requires migration, but exact fields remain specific to each protocol version.
+
+| Area | v0.3.0 (official migration baseline) | v1.0 |
+|---|---|---|
+| Part content model | `TextPart`, `FilePart`, and `DataPart` are separate types selected by `kind` | One unified `Part` carries content in its `text`, `raw`, `url`, or `data` member |
+| Streaming events | Events carry `kind`, and `TaskStatusUpdateEvent` uses `final` to indicate completion | The enclosing member identifies the event type; `kind` and `final` are removed, and stream closure indicates completion |
+| Enum values | Lowercase values such as `user` and `completed` | Type-prefixed values such as `ROLE_USER` and `TASK_STATE_COMPLETED` |
+| Agent Card | Top-level fields primarily describe the endpoint, transport, and protocol version | `supportedInterfaces` declares the URL, binding, and protocol version and can advertise multiple interfaces |
+| Operations and Tasks | Slash-delimited methods such as `message/send` and `tasks/get`, no `ListTasks`, and looser definitions for some Task behavior | Operations such as `SendMessage` and `GetTask`, a new `ListTasks` operation, and precise Message/Task return, subscription, and cancellation semantics |
+| Protocol bindings | `a2a.proto` is closer to a gRPC implementation definition, with weaker equivalence guarantees across bindings | Treats `a2a.proto` as the protocol-neutral normative source and formally defines equivalent JSON-RPC, HTTP+JSON/REST, and gRPC mappings |
+
+A2A v1.0 is therefore more than a method rename: it changes the serialization model, event discrimination, Agent discovery structure, and Task interaction semantics. Without a compatibility layer, a v1.0 server cannot directly process a v0.x client's request.
+
+## trpc-a2a-go overview
+
+[`trpc-a2a-go`](https://github.com/trpc-group/trpc-a2a-go) is the tRPC Go implementation of the A2A protocol. It provides protocol types and the foundations for both clients and servers.
+
+To support incremental migration, `trpc-a2a-go` implements A2A v1.0 in a new `/v2` Go module while the original module continues to carry v0.2.x. tRPC-Agent-Go correspondingly adds `server/a2a/v1` and `agent/a2aagent/v1`; the existing `server/a2a` and `agent/a2aagent` packages will remain maintained until most users have migrated to v1.
+
+For legacy clients that must remain operational during migration, `trpc-a2a-go/v2` provides the `compat/v0` translation layer, which tRPC-Agent-Go can explicitly enable on a new v1 server.
+
+The package and protocol versions map as follows:
+
+| A2A protocol | tRPC-Agent-Go Server | tRPC-Agent-Go remote Agent | `trpc-a2a-go` module |
+|---|---|---|---|
+| v1.0 | `server/a2a/v1` | `agent/a2aagent/v1` | `trpc-a2a-go/v2` |
+| v0.2.x | `server/a2a` | `agent/a2aagent` | `trpc-a2a-go` |
+
+The tRPC-Agent-Go `/v1` suffix means A2A protocol v1.0. The `/v2` in `trpc-a2a-go/v2` is the Go module major version. These are version names from different repositories; `/v2` does not mean A2A protocol v2.
+
+The main layers of `trpc-a2a-go/v2` are:
+
+| Layer | Responsibility |
+|---|---|
+| `protocol` | Agent Card, Message, Task, Artifact, events, and request types |
+| `client` | Agent discovery, JSON-RPC calls, and SSE streams |
+| `server` | Agent Card endpoints, authentication, JSON-RPC dispatch, and SSE |
+| `taskmanager` | Request execution policy, Task lifecycle, retention, and event fan-out |
+| `compat/v0` | Translation between the v0.2.x wire protocol and v1.0 core |
+
+The server delegates concrete work to a `MessageProcessor`, which reads an `ExecContext` and emits one protocol event stream. The `TaskManager` consumes that stream, decides whether execution is request-bound or retained, and implements blocking, streaming, lookup, and subscription behavior. The server itself owns the Agent Card, wire protocol, routing, and middleware. The tRPC-Agent-Go integration builds on these extension boundaries.
+
+`trpc-a2a-go` creates Tasks lazily: a `MessageProcessor` that emits only a Message creates no Task, while the first status or artifact event causes the TaskManager to create an execution-local Task. A retaining TaskManager preserves that Task after the request; the stateless TaskManager handles it only within the current request.
+
+## tRPC-Agent-Go integration architecture
+
+tRPC-Agent-Go supplies adapters around `trpc-a2a-go`; it does not implement a second A2A transport or Task system. This integration is a protocol boundary between local Agents and remote services, not a third local execution engine alongside LLMAgent and GraphAgent.
+
+On the server side, the adapter turns an A2A request into a Runner invocation and converts Runner events back into A2A events, so the Runner can execute an LLMAgent, GraphAgent, or any other Agent. On the client side, `A2AAgent` presents a remote A2A service through the standard tRPC-Agent-Go Agent interface, allowing a Runner, parent Agent, or Graph node to invoke it like a local Agent.
+
+```mermaid
+flowchart LR
+    subgraph Remote["Remote service"]
+        SA["server/a2a/v1"]
+        MP["MessageProcessor adapter"]
+        TM["A2A TaskManager<br/>stateless by default / optional retaining TaskManager"]
+        R1["Runner<br/>server session"]
+        LA["LLMAgent / GraphAgent / other Agent"]
+        SA <--> TM
+        TM <--> MP
+        MP <--> R1
+        R1 <--> LA
+    end
+
+    subgraph Caller["Calling application"]
+        CA["agent/a2aagent/v1"]
+        CA <--> R2["Runner<br/>caller session"]
+        R2 <--> APP["Application / parent Agent"]
+        TC["trpc-a2a-go/v2/client<br/>complete Task API"]
+    end
+
+    CA -->|"SendMessage / SendStreamingMessage"| SA
+    SA -->|"Task / event stream"| CA
+    TC -->|"Task API (cross-request only with a retaining TaskManager)"| SA
+    SA -->|"Task snapshot / event stream"| TC
+```
+
+### Capabilities provided by the A2A integration
+
+The integration provides three groups of capabilities:
+
+- **Publish a local Agent as an A2A service:** `server/a2a/v1` publishes the Agent Card, converts the A2A Message, context ID, user identity, and metadata into a Runner invocation, and converts Runner text, multimodal content, tool calls, status, and errors into A2A events. W3C trace context crosses the protocol boundary in HTTP headers. An LLMAgent, GraphAgent, or custom Agent can use the same Runner integration.
+- **Invoke a remote service like a local Agent:** `agent/a2aagent/v1` discovers the remote Agent Card and implements the common `agent.Agent` interface. It converts a local invocation into a blocking or streaming A2A request and converts remote Messages, Tasks, Artifacts, tool calls, and errors back into tRPC-Agent-Go events.
+- **Use the complete A2A Task API when needed:** `A2AAgent` wraps normal Agent invocation only. Use the `trpc-a2a-go/v2/client` methods directly when the application needs Task lookup, listing, cancellation, resubscription, or push notifications: `GetTasks` invokes the v1 `GetTask` operation, `ListTasks` invokes `ListTasks`, `CancelTasks` invokes `CancelTask`, and `ResubscribeTask` invokes `SubscribeToTask`.
+
+The server adapter joins the `trpc-a2a-go` middleware chain and reads the Runner user ID from the `X-User-ID` request header by default. This is identity propagation, not business authorization. Production services must still authenticate callers, authorize operations, and verify Task ownership in a gateway or underlying A2A server middleware.
+
+One `server/a2a/v1` instance binds one Agent Card and one Runner. Configuring tenant Agent Cards in the underlying `trpc-a2a-go` server does not make this adapter dispatch tenants to different Runners automatically. To host multiple Agents, route to separate service instances outside the adapter or let the Agent behind the bound Runner perform application-level routing. The latter approach does not read or preserve the protocol-level dispatch semantics of the A2A `tenant`.
+
+### Differences from LLMAgent and GraphAgent
+
+A2AAgent differs from local Agents as follows:
+
+| Agent type | Primary role | Execution location | Primary state |
+|---|---|---|---|
+| LLMAgent | Model reasoning, tool selection, and multi-turn interaction | Current process | Runner session |
+| GraphAgent | Controlled workflow execution through nodes, edges, and state transitions | Current process | Runner session plus Graph state/checkpoint |
+| A2AAgent | Forwards an Agent invocation to a remote A2A service | Remote service | Caller-side Runner session; other state is managed by the remote implementation |
+
+LLMAgent directly owns its Model, Tool, and SubAgent configuration. GraphAgent owns the workflow structure and supports checkpoints, interruption, and resume. A2AAgent does not own the remote model or tool configuration locally; its `Tools()` and `SubAgents()` are empty, and the remote service advertises its capabilities through the Agent Card. Whether the remote service retains A2A Tasks depends on its implementation; with `trpc-a2a-go`, the TaskManager makes that decision. These types compose with each other: an LLMAgent or GraphAgent can be exposed through a Runner and A2A Server, while an A2AAgent can be used as a parent Agent's SubAgent or as an Agent node in a Graph.
+
+The distinction is not relative capability but whether execution is local or remote and whether the invocation crosses an A2A protocol boundary. A2A solves remote discovery and interoperability; LLMAgent and GraphAgent solve local reasoning and orchestration.
+
+### State boundaries
+
+From the server integration point of view, the default stateless TaskManager does not retain A2A Tasks across requests, so Runner sessions are the only category of cross-request state by default. A retaining memory, Redis, or custom TaskManager adds a second, independent category of state for complete A2A Task management.
+
+When one tRPC-Agent-Go application calls another, the caller and server usually own separate Runner session stores. The A2A context ID correlates the two sides of an invocation but does not merge those stores. The following sections describe the optional A2A Task state and multi-node deployment requirements.
+
+## A2A v1.0 integration
+
+Use the v1 packages for new applications.
+
+### Create a v1 Server
+
+The v1 server takes a caller-owned Runner and an explicit Agent Card. This makes Runner ownership, session configuration, and the public A2A identity visible when the server is constructed.
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a/v1"
+)
+
+agentRunner := runner.NewRunner(
+    "my-app",
+    llmAgent,
+    runner.WithSessionService(inmemory.NewSessionService()),
+)
+defer agentRunner.Close()
+
+card, err := a2aserver.NewAgentCard(
+    llmAgent.Info().Name,
+    llmAgent.Info().Description,
+    "1.0.0",                  // Agent implementation version.
+    "agent.example.com:8888", // Address advertised to clients.
+    true,                     // Advertise streaming support.
+    a2aserver.WithCardTools(llmAgent.Tools()...),
+)
+if err != nil {
+    return err
+}
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+)
+if err != nil {
+    return err
+}
+return server.Start("0.0.0.0:8888")
+```
+
+The Agent Card address is used for discovery and routing. It may differ from the listen address passed to `Start`.
+
+The built-in converters support multimodal image, audio, and file content, but `NewAgentCard` advertises only `text` input and output modes by default. To make multimodal support discoverable, explicitly declare the applicable input/output modes in the Agent Card passed to `WithAgentCard`.
+
+The caller owns the Runner lifecycle. It must close the Runner if server construction fails or after the server stops.
+
+### Call a remote A2A Agent
+
+`agent/a2aagent/v1` discovers the remote Agent Card and implements the normal tRPC-Agent-Go Agent interface:
+
+```go
+import (
+    "context"
+
+    a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent/v1"
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+remoteAgent, err := a2aagent.New(
+    a2aagent.WithAgentCardURL("https://agent.example.com"),
+)
+if err != nil {
+    return err
+}
+
+remoteRunner := runner.NewRunner(
+    "a2a-client",
+    remoteAgent,
+    runner.WithSessionService(inmemory.NewSessionService()),
+)
+defer remoteRunner.Close()
+
+events, err := remoteRunner.Run(
+    context.Background(),
+    "user-1",
+    "session-1",
+    model.NewUserMessage("What time is it?"),
+)
+if err != nil {
+    return err
+}
+for event := range events {
+    // Handle the same tRPC-Agent-Go events produced by a local Agent.
+    _ = event
+}
+```
+
+The adapter maps:
+
+- local session ID to A2A context ID;
+- local user ID to the `X-User-ID` request header;
+- local text and multimodal `ContentPart` input to A2A Parts;
+- tool calls and results produced by the remote Runner to structured data Parts on the server, then back to local events in A2AAgent;
+- remote A2A Messages, Tasks, and events back to tRPC-Agent-Go events.
+
+Unless explicitly overridden, A2AAgent selects streaming or blocking invocation from the Agent Card. It handles one normal Agent invocation; applications that need Task lookup, cancellation, or resubscription should use the underlying `trpc-a2a-go/v2/client` directly.
+
+### Run the normal Agent invocation example
+
+The example uses a session-aware LLMAgent with a `current_time` tool. Configure a model first:
+
+```bash
+export OPENAI_API_KEY="<your-api-key>"
+export MODEL_NAME="<your-model>"
+# Set OPENAI_BASE_URL when using an OpenAI-compatible service.
+```
+
+Start the server:
+
+```bash
+cd examples
+go run ./a2aagent/v1/server
+```
+
+In another terminal, start the client:
+
+```bash
+cd examples
+go run ./a2aagent/v1/client
+```
+
+Ask for the current time to observe the tool call and result crossing the A2A boundary. Keeping the same session ID continues the same remote Runner session; use `/new` or `/use` to switch sessions. Add `-streaming=false` to the server to exercise blocking `SendMessage`.
+
+### Request lifecycle
+
+The built-in adapter implements the `trpc-a2a-go` `MessageProcessor` interface. Non-streaming and streaming requests follow the same path:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server as A2A server
+    participant TM as TaskManager
+    participant Adapter as tRPC-Agent-Go processor
+    participant Runner
+
+    Client->>Server: SendMessage / SendStreamingMessage
+    Server->>TM: execute request
+    TM->>Adapter: ProcessMessage(ExecContext)
+    Adapter->>Runner: Run(userID, contextID, message)
+    Runner-->>Adapter: Agent events
+    Adapter-->>TM: status / artifact events
+    TM-->>Server: Task or event stream
+    Server-->>Client: JSON-RPC response or SSE
+```
+
+The adapter always converts Runner output through one event pipeline rather than implementing separate `MessageProcessor` paths for streaming and non-streaming requests. A successful execution typically moves through `submitted → output → completed`; a failure moves to `failed`, while suspended states such as `input-required` and `auth-required` use the same event stream.
+
+### Default stateless TaskManager
+
+The v1 server uses `taskmanager/stateless` by default. More precisely, the **TaskManager is stateless**; the `MessageProcessor` still executes the Runner and emits a complete Task lifecycle.
+
+The default TaskManager:
+
+- runs the `MessageProcessor` within the lifetime of the incoming HTTP request;
+- builds an execution-local Task from status and artifact events;
+- returns the terminal Task or forwards events in real time;
+- discards the Task, event log, and protocol history when the request ends;
+- rejects operations that must continue beyond the current request, read Task state from a later request, or suspend in `input-required` or `auth-required` while waiting for a continuation.
+
+The underlying stateless TaskManager allows a custom `MessageProcessor` to return a direct Message, but the built-in tRPC-Agent-Go adapter starts every Runner invocation with a `submitted` Task state and ends successful invocations with `completed`. A blocking call to the default server therefore returns a terminal Task that exists only for that request. Stateless means that Tasks are not retained across requests; it does not mean that only Messages are returned.
+
+This default is suitable for ordinary request/response Agent calls: it has no Task cleanup cost, no storage dependency, and no cross-request Task affinity. `returnImmediately=true` is rejected not because A2A cannot return an immediate Message, but because the stateless TaskManager binds execution to the current request and cannot reliably continue after the HTTP response ends. Conversation continuity still comes from the Runner session service.
+
+### Retained Task management
+
+Configure a retaining TaskManager when clients need asynchronous execution, Task lookup, or cancellation, resubscription, and continuation of unfinished Tasks. Push notifications must also be enabled separately on the selected TaskManager; retaining a Task does not enable push delivery automatically.
+
+For a single-process service, use the memory TaskManager:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+    memorytaskmanager "trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
+)
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithTaskManagerBuilder(func(
+        processor taskmanager.MessageProcessor,
+    ) (taskmanager.TaskManager, error) {
+        return memorytaskmanager.NewTaskManager(processor)
+    }),
+)
+```
+
+Memory Task state is process-local and is lost on restart. Terminal Tasks are not cleaned up automatically by default; production services should set a retention duration with `memorytaskmanager.WithTaskTTL(...)` when appropriate.
+
+A retaining TaskManager gives the system two independent state categories:
+
+| State system | Owner | Used for |
+|---|---|---|
+| Runner session | Each tRPC-Agent-Go application's own session service | Conversation history, application state, and multi-turn Agent context |
+| A2A Task | `trpc-a2a-go` TaskManager | Protocol Task status, Artifacts, lookup, cancel, resubscribe, and push configuration |
+
+Keeping an A2A Task does not replace the Runner session. Likewise, a durable Runner session does not make `GetTask` work after the originating request. Choose storage for conversation continuity and protocol Task operations independently.
+
+### Multi-node deployment
+
+The v1 adapter can run behind a load balancer, but the correct topology depends on which state features the application uses.
+
+| Deployment | What works across replicas | Additional requirement |
+|---|---|---|
+| Stateless TaskManager | Blocking and streaming requests | Share the Runner session store or use session affinity when conversation context must survive node changes |
+| Memory TaskManager | No Task operation crosses replicas | Route all operations for a Task to the node that owns it |
+| Redis TaskManager | Shared Task snapshots, protocol history, lookup, and listing | Use the separate Redis TaskManager module and a shared Redis deployment |
+| Redis with cross-node resubscribe | `SubscribeToTask` may reconnect through another replica | Enable `WithCrossNodeResubscribe(true)` on every replica |
+
+Example Redis builder:
+
+The Redis TaskManager is a separate Go module. Add `trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2` to the application first:
+
+```bash
+go get trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2
+```
+
+```go
+import (
+    redisclient "github.com/redis/go-redis/v9"
+    "trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+    redistaskmanager "trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2"
+)
+
+redisClient := redisclient.NewClient(&redisclient.Options{
+    Addr: "redis.example.com:6379",
+})
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithTaskManagerBuilder(func(
+        processor taskmanager.MessageProcessor,
+    ) (taskmanager.TaskManager, error) {
+        return redistaskmanager.NewTaskManager(
+            processor,
+            redisClient,
+            redistaskmanager.WithCrossNodeResubscribe(true),
+        )
+    }),
+)
+```
+
+Cross-node resubscription is not distributed execution. When every replica uses an equivalent `MessageProcessor` and there is no concurrent continuation, any node that can read a suspended Task from Redis can begin its next execution round. Redis TaskManager does not provide exactly-once coordination across replicas, a global live-execution registry, or cross-node routing for live cancellation. Applications that need those guarantees still require sticky routing or a separate execution-coordination design.
+
+Runner sessions are independent of A2A Task storage. If the server uses an in-memory session service, moving the next request to a different replica loses conversation context even when A2A Tasks are stored in Redis. Use a shared session service for a genuinely stateless service tier.
+
+### Common v1 configuration
+
+Common Server adapter options are:
+
+| Option | Purpose |
+|---|---|
+| `WithRunner` | Set the caller-owned Runner |
+| `WithAgentCard` | Set the public Agent identity and capabilities |
+| `WithTaskManagerBuilder` | Replace the default stateless TaskManager |
+| `WithV0Compatibility` | Serve v0.2.x methods on the v1 endpoint |
+| `WithUserIDHeader` | Change the user identity header |
+| `WithRunOptions` | Add Runner options to every invocation |
+| `WithProcessMessageHook` | Wrap inbound A2A message processing |
+| `WithResponseRewriter` | Rewrite outbound A2A events |
+| `WithExtraA2AOptions` | Pass authentication, middleware, and other options to the underlying A2A server |
+
+Common A2AAgent options are:
+
+| Option | Purpose |
+|---|---|
+| `WithAgentCardURL`, `WithAgentCard` | Discover the remote Agent Card by URL or provide it directly |
+| `WithEnableStreaming` | Override streaming selection from the Agent Card |
+| `WithUserIDHeader` | Change the request header carrying the user identity |
+| `WithTransferStateKey` | Select invocation `RuntimeState` values to transfer in Message metadata |
+| `WithA2AClientExtraOptions` | Pass options to the underlying A2A client |
+| `WithBuildMessageHook` | Rewrite the outbound A2A Message before sending |
+
+Use custom converters, Part mappers, hooks, or response rewriters only when the built-in text, multimodal, tool, code-execution, and metadata mappings are insufficient.
+
+## Legacy protocol v0.2.x integration
+
+Existing applications can continue to use `server/a2a` and `agent/a2aagent` without the `/v1` suffix. These packages depend on the `trpc-a2a-go` root module and implement A2A v0.2.x.
+
+These packages are in compatibility maintenance, but they remain standalone A2A adapters rather than compatibility aliases for v1. New applications should use the v1 packages directly; users who still maintain v0.2.x services or clients can continue to use the capabilities below.
+
+### v0.2.x capability scope
+
+| Capability | Legacy integration behavior |
+|---|---|
+| Publish a local Agent | `server/a2a` publishes a legacy Agent Card, handles JSON-RPC and SSE, and passes A2A requests to a Runner |
+| Call a remote Agent | `agent/a2aagent` discovers the legacy Agent Card and exposes blocking or streaming calls through the standard `agent.Agent` interface |
+| Runner and session | Applications can use an implicit Runner or provide an application-owned Runner; the A2A context ID becomes the server-side Runner session ID |
+| Identity, state, and tracing | The user ID and W3C trace context propagate through HTTP headers, while invocation `RuntimeState` propagates through Message metadata |
+| Content and event conversion | Supports text, image, audio, and file input, together with extended events for text, reasoning, tool calls, tool results, code execution, and state updates |
+| Extension points | Supports hooks, custom converters, Part mappers, response rewriting, a Graph event allowlist, ADK metadata, dynamic Agent Cards, and underlying A2A options |
+
+An `A2AAgent` does not hold the remote Model, Tools, or SubAgents locally, so its `Tools()` and `SubAgents()` are empty; the Agent Card continues to describe the remote capabilities. It can run behind a Runner, serve as a SubAgent of a parent Agent, or act as an Agent node in a Graph.
+
+`NewAgentCard` advertises only `text` input and output modes by default, even though the built-in converter can process images, audio, and files. When a legacy service actually accepts these types, the application should provide an accurate custom Agent Card so clients do not infer the wrong capabilities from the default Card.
+
+### Create a legacy A2A Server
+
+The legacy server retains the convenience entry point that accepts an Agent directly. When the caller supplies neither a Runner nor a session service, the server creates a default Runner and in-memory session service:
+
+```go
+import a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a"
+
+server, err := a2aserver.New(
+    a2aserver.WithHost("127.0.0.1:8888"),
+    a2aserver.WithAgent(llmAgent, true),
+)
+if err != nil {
+    return err
+}
+return server.Start("127.0.0.1:8888")
+```
+
+The Boolean argument in `WithAgent(llmAgent, true)` only declares streaming support on the generated Agent Card; it does not control Runner execution. Whether the server handles a streaming request is determined by the client's use of `message/stream`.
+
+When the application needs to configure the session service, memory service, or Runner lifecycle itself, it can instead provide an explicit Runner and Agent Card:
+
+```go
+sessionService := sessionmemory.NewSessionService()
+agentRunner := runner.NewRunner(
+    llmAgent.Info().Name,
+    llmAgent,
+    runner.WithSessionService(sessionService),
+)
+defer agentRunner.Close()
+
+card, err := a2aserver.NewAgentCard(
+    llmAgent.Info().Name,
+    llmAgent.Info().Description,
+    "127.0.0.1:8888",
+    true,
+    a2aserver.WithCardTools(llmAgent.Tools()...),
+)
+if err != nil {
+    return err
+}
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+)
+```
+
+`WithAgent` and `WithRunner` are mutually exclusive. With an explicit Runner, the application manages Runner shutdown, sessions, and memory, and it also maintains the Agent Card address, streaming capability, and skills. `WithSessionService` applies only to the legacy path in which the server creates an implicit Runner.
+
+`WithHost` accepts a URL with a path, which becomes the base path of that A2A Server. To host multiple legacy Agents on one port, create a separate Server and Agent Card for each Runner, then attach each `Handler()` to the same HTTP mux.
+
+### Call a legacy A2A service
+
+The legacy remote Agent uses the package without `/v1` and can discover an Agent Card automatically from a URL:
+
+```go
+import a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent"
+
+remoteAgent, err := a2aagent.New(
+    a2aagent.WithAgentCardURL("http://127.0.0.1:8888"),
+)
+```
+
+After creation, invoke it through a Runner like any other Agent:
+
+```go
+clientRunner := runner.NewRunner(
+    "caller-app",
+    remoteAgent,
+    runner.WithSessionService(sessionmemory.NewSessionService()),
+)
+defer clientRunner.Close()
+
+events, err := clientRunner.Run(
+    ctx,
+    "user-1",
+    "session-1",
+    model.NewUserMessage("What tasks can you help me with?"),
+)
+```
+
+The legacy `A2AAgent` chooses between `message/send` and `message/stream` in the following priority order:
+
+1. `agent.WithStream(...)` on the current Runner invocation.
+2. `WithEnableStreaming(...)` supplied when creating the A2AAgent.
+3. The remote Agent Card's streaming capability.
+4. Non-streaming when none of the above declares a preference.
+
+The Agent Card declares a server capability, while the caller can still override the choice for an individual call through either of the first two levels. If the caller forces streaming, the remote server must actually support `message/stream`.
+
+### State, identity, and request extensions
+
+The legacy call path writes the caller's session ID into the A2A context ID, and the server then uses that context ID as its own Runner session ID. The caller and server still have independent session stores: the protocol transfers only the identifier and does not merge conversation history between the two sides.
+
+The caller's session user ID is sent through `X-User-ID` by default, and the server uses it as the Runner user ID. Both sides can change the header name with `WithUserIDHeader`. When that header is absent, the current legacy server creates a random `A2A_ANONYMOUS_...` principal and returns it in the HttpOnly `trpc_agent_a2a_anon` cookie; the A2A context ID remains the Runner session ID and is not used as anonymous identity. For Cookie Jar reuse and cross-instance initialization details, see the [legacy A2A guide](a2a.md). Identity propagation does not provide authentication or authorization.
+
+`WithTransferStateKey` selects values to copy from the current invocation `RuntimeState` into Message metadata. It supports exact keys, `*`, and prefix or suffix wildcards. The server merges the Message metadata into the new invocation `RuntimeState`, with metadata values overriding values of the same name supplied through `WithRunOptions`.
+
+Treat all transferred Message metadata as client-controlled input. Tenant, role, policy, and other authorization state must come from authenticated or immutable server-side context and must not be accepted through this transfer path.
+
+```go
+token := os.Getenv("A2A_TOKEN")
+
+remoteAgent, err := a2aagent.New(
+    a2aagent.WithAgentCardURL("https://agent.example.com:8888"),
+    a2aagent.WithEnableStreaming(true),
+    a2aagent.WithTransferStateKey("tenant_id", "workflow.*"),
+    a2aagent.WithA2AClientExtraOptions(
+        client.WithTimeout(30*time.Second),
+    ),
+)
+
+events, err := clientRunner.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    agent.WithRuntimeState(map[string]any{
+        "tenant_id":      "tenant-a",
+        "workflow.stage": "review",
+    }),
+    agent.WithA2ARequestOptions(
+        client.WithRequestHeader("Authorization", "Bearer "+token),
+    ),
+)
+```
+
+W3C trace context propagates automatically through HTTP headers. In production, use authentication settings on the underlying client and server, or a gateway, to enforce authentication, authorization, and resource ownership; do not treat `X-User-ID` as a trusted credential.
+
+Common legacy extension points include:
+
+| Scenario | Configuration |
+|---|---|
+| Inbound and outbound metadata | `WithProcessMessageHook`, `WithBuildMessageHook` |
+| Every server-side Runner invocation | `WithRunOptions` |
+| Request headers, timeouts, and underlying authentication | `agent.WithA2ARequestOptions`, `WithA2AClientExtraOptions` |
+| Custom Message and event conversion | `WithA2AToAgentConverter`, `WithEventToA2AConverter`, `WithCustomA2AConverter`, `WithCustomEventConverter` |
+| Extended DataPart or Event Part mappings | `WithA2ADataPartMapper`, `WithEventToA2APartMapper` |
+| Outbound filtering or rewriting | `WithResponseRewriter`, `WithErrorHandler` |
+| Graph and ADK compatibility | `WithGraphEventObjectAllowlist`, `WithADKCompatibility` |
+| Dynamic Agent Cards, authentication, and middleware | `WithExtraA2AOptions` |
+
+The legacy packages also retain compatibility extension points such as `WithProcessorBuilder`, `WithTaskManagerBuilder`, `WithStreamingEventType`, `WithStreamingRespHandler`, and `WithStructuredTaskErrors`. They preserve existing v0 application behavior and do not represent the recommended v1 design. New code should prefer the unified v1 MessageProcessor, TaskManager, and converter extension boundaries.
+
+The shared metadata extension for tool calls, code execution, reasoning, and `state_delta` is documented in the [A2A Protocol Interaction Specification](a2a-interaction.md). Its metadata keys and interaction version apply to both the legacy and v1 packages; its `TextPart`, `DataPart`, lowercase method, and streaming-envelope examples describe the v0.2.x wire model, while v1 carries the shared metadata through unified Parts, Messages, Artifacts, and Task update events.
+
+### v0 Task management boundaries
+
+The legacy server creates a memory TaskManager internally by default, but this is not equivalent to retaining Task management in v1. The built-in non-streaming adapter waits for the Runner event channel to close: it returns a Message directly when there is one result and combines multiple results into a completed Task. That completed Task is not registered as a retained Task that can later be queried through `tasks/get`.
+
+The streaming adapter creates a Task for the current `message/stream` request, emits submitted, artifact, and completed events, and removes the Task when the event stream ends. It therefore primarily provides a Task envelope for the current SSE stream and does not promise that the Task remains queryable, cancellable, or resubscribable after the request.
+
+The protocol client in the `trpc-a2a-go` root module still provides `GetTasks`, `CancelTasks`, `ResubscribeTask`, and push notification methods, but these operations are meaningful only when the server's processor and TaskManager actually retain and manage the corresponding Task. v0.2.x does not provide `ListTasks`. For reliable cross-request queries, continuation, multi-node storage, or cancellation, prefer migrating to v1 and configuring a memory, Redis, or custom retaining TaskManager.
+
+The v0 wire protocol defaults `blocking` to false for `message/send`, but the built-in tRPC-Agent-Go v0 adapter's unary path still waits for the Runner to complete within the current request. Do not rely on this adapter-specific behavior when using the underlying v0 protocol client against another implementation; explicitly set `blocking=true` when the caller needs the final result.
+
+### Legacy examples
+
+| Example | Demonstrates |
+|---|---|
+| `examples/a2aagent` | Complete Server/A2AAgent setup, implicit or explicit Runner, sessions, and tool calls |
+| `examples/a2aagent/customdatapart` | Custom DataPart and Event extensions |
+| `examples/a2amultipath` | Hosting multiple Agents on one port with base paths |
+| `examples/a2asubagent` | Using a remote A2AAgent as a coordinating Agent's SubAgent |
+| `examples/a2aadk` | Interoperability with ADK tool and code-execution events |
+| `examples/a2acodeexecution` | Transporting code-execution events through legacy extensions |
+| `examples/graph/a2a_agent` | A remote Graph Agent and `state_delta` |
+
+These examples support maintenance of v0.2.x applications. Do not copy their legacy-specific configuration directly into a v1 integration.
+
+## v1.0 and v0.2.x integration differences
+
+| Area | v0.2.x | v1.0 |
+|---|---|---|
+| Server input | Agent or Runner | Explicit caller-owned Runner |
+| Runner lifecycle | Created implicitly by the server when given an Agent, so the caller cannot manage it directly | Created and closed by the caller |
+| Agent Card | Usually derived from Agent and host | Explicit public identity and implementation version |
+| Event processing | Multiple result shapes and callback-style `TaskHandler` | One `ExecContext` to one event channel |
+| Streaming selection | `MessageProcessor`/API branches can select response shape | TaskManager derives non-streaming and streaming responses from the same events |
+| Task lifecycle | The built-in adapter creates request-local Task envelopes and does not retain them across requests by default | TaskManager owns lazy creation, retention, and fan-out |
+| Default `message/send` timing | Wire `blocking` defaults to false, while the built-in adapter's unary path still waits for the Runner | `returnImmediately` defaults to false, so send blocks |
+| Wire method names | Slash-delimited, such as `message/send` | PascalCase, such as `SendMessage` |
+| Task listing | Not provided | `ListTasks` |
+| Multi-node Task storage | The default path does not retain Tasks; applications must supply their own processor and backend | Explicit stateless, memory, or Redis strategy |
+
+### Serve v0 clients from a v1 Server
+
+The v1 `trpc-a2a-go` module contains `compat/v0`, which parses the frozen v0.2.x wire types, translates them into v1 requests, calls the same TaskManager, and translates the result back.
+
+tRPC-Agent-Go exposes this as an opt-in server option:
+
+```go
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithV0Compatibility(),
+)
+```
+
+Both protocol generations use the same endpoint, authentication chain, `MessageProcessor`, and TaskManager.
+
+The raw `compat/v0` converter preserves the v0 default: an omitted `blocking` means non-blocking. The tRPC-Agent-Go compatibility option deliberately adapts only that omitted value to blocking so unchanged v0 clients can use the default request-bound TaskManager. Explicit `blocking=false` remains non-blocking.
+
+| v0.2.x client operation | Default stateless TaskManager | Retaining TaskManager |
+|---|---:|---:|
+| Agent Card discovery | Supported | Supported |
+| `message/send` with omitted or true `blocking` | Supported, blocks | Supported, blocks |
+| `message/stream` | Supported | Supported |
+| `message/send` with explicit `blocking=false` | Not supported | Supported |
+| Look up a retained Task after the request | Not supported | Supported |
+| Cancel a non-terminal Task | Not supported | Supported; live cancellation must reach the execution owner |
+| Resubscribe to a non-terminal Task | Not supported | Supported; cross-node reconnect requires Redis resubscribe configuration |
+| Push notification configuration | Not supported | Supported after push is enabled separately on the TaskManager |
+
+The stateless TaskManager rejects an explicit non-blocking request because request-bound execution cannot continue reliably after the HTTP response ends. A streaming request must also reach a terminal state within the current request; `input-required` and `auth-required` states that need a later continuation require a retaining TaskManager.
+
+The compatibility layer lets a legacy wire request enter the new execution path, but it does not guarantee lossless field-by-field conversion between the two data models. For example, `filename` and `mediaType` on v1 text/data Parts cannot be preserved in v0, the v0 `final` value in a streaming response is derived from v1 events, and only the first authentication scheme from a multi-scheme v0 push-notification configuration is retained in v1. Migration tests should cover real text, multimodal, tool-call, error, and Task workflows rather than checking only whether a request succeeds.
+
+### Migration checklist
+
+- [ ] Change server and remote Agent imports to the `/v1` packages.
+- [ ] Construct and own the Runner explicitly.
+- [ ] Publish a reachable Agent Card address and implementation version.
+- [ ] Keep conversation state in the Runner's session service.
+- [ ] Choose stateless, memory, or Redis Task management based on client needs.
+- [ ] Enable `WithV0Compatibility` while v0.2.x clients remain.
+- [ ] Test blocking, streaming, asynchronous, and retained Task flows separately.
+
+## Protocol usage guide
+
+Choose the simplest interaction that satisfies the client:
+
+| Client need | Protocol operation | State requirement |
+|---|---|---|
+| Wait for one answer | Blocking `SendMessage` | Stateless is sufficient |
+| Render tokens or progress live | `SendStreamingMessage` | Stateless is sufficient |
+| Start work and disconnect | `SendMessage` with `returnImmediately=true` | Retaining TaskManager |
+| Poll later | `GetTask` or `ListTasks` | Retaining TaskManager; terminal Tasks remain queryable |
+| Reconnect to updates | `SubscribeToTask` | Non-terminal Task; Redis configuration for cross-node reconnect |
+| Stop running work | `CancelTask` | Cancelable non-terminal Task and routing to the execution owner |
+| Answer an Agent's follow-up question | Send a Message with the same Task ID | Retained suspended Task |
+
+Identifier rules:
+
+- The A2A context ID becomes the server Runner's session ID.
+- `X-User-ID` becomes the Runner user ID. If it is absent, the server derives a stable user ID from the context ID.
+- A Task ID identifies one A2A Task lifecycle, not a conversation session; the same Task can span multiple continuation rounds.
+- A continuation for `input-required` or `auth-required` must carry the original Task ID.
+
+Task retention alone does not make an Agent interruptible. The `MessageProcessor` or converter must emit `input-required` or `auth-required`, and the application must preserve any state needed to continue.
+
+## More examples
+
+The earlier v1 example uses A2AAgent for a normal Agent invocation. To observe asynchronous Task creation, lookup, and listing, run the server with the memory TaskManager and start `taskclient`:
+
+```bash
+cd examples
+go run ./a2aagent/v1/server -retain-tasks
+
+# In another terminal.
+cd examples
+go run ./a2aagent/v1/taskclient
+```
+
+The "Legacy examples" section above lists v0.2.x Server, A2AAgent, multi-Agent hosting, and extension-event examples.
+
+For lower-level protocol examples, including Redis, authentication, push notifications, input-required continuation, and direct `MessageProcessor` implementations, see the [`trpc-a2a-go` examples](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples).

--- a/docs/mkdocs/en/a2a_v1.md
+++ b/docs/mkdocs/en/a2a_v1.md
@@ -630,7 +630,11 @@ The v0 wire protocol defaults `blocking` to false for `message/send`, but the bu
 
 These examples support maintenance of v0.2.x applications. Do not copy their legacy-specific configuration directly into a v1 integration.
 
-## v1.0 and v0.2.x integration differences
+## Migrate from v0.2.x to v1.0
+
+Migrating to v1.0 requires more than changing import paths. The wire model, Server construction, Runner ownership, Agent Card, TaskManager defaults, and several extension interfaces changed. Upgrade the Server first and expose the v0 compatibility path, then migrate Clients incrementally.
+
+### v1.0 and v0.2.x integration differences
 
 | Area | v0.2.x | v1.0 |
 |---|---|---|
@@ -644,6 +648,132 @@ These examples support maintenance of v0.2.x applications. Do not copy their leg
 | Wire method names | Slash-delimited, such as `message/send` | PascalCase, such as `SendMessage` |
 | Task listing | Not provided | `ListTasks` |
 | Multi-node Task storage | The default path does not retain Tasks; applications must supply their own processor and backend | Explicit stateless, memory, or Redis strategy |
+
+### Compatibility matrix
+
+For the built-in tRPC-Agent-Go `server/a2a/v1` and `agent/a2aagent/v1` packages, v0 compatibility is one-way: a v1 Server can accept v0.2.x Client requests through the compatibility layer, but a v1 Client cannot call a legacy v0.2.x Server directly.
+
+| Client | v0.2.x Server | v1 Server | v1 Server + `WithV0Compatibility` |
+|---|---:|---:|---:|
+| v0.2.x Client | Supported | Not supported | Supported |
+| v1 Client | Not supported | Supported | Supported |
+
+Here, "Supported" means blocking and streaming message calls can enter the corresponding protocol path. Non-blocking calls and Task control operations additionally require the v1 Server to use a retaining TaskManager.
+
+Enable `WithV0Compatibility()` on the v1 Server while v0.2.x Clients remain, and remove it after that traffic is retired. A v1 Client cannot call a legacy v0.2.x Server, so mixed-version deployment and rollback routing must send v1 Clients only to v1 Servers.
+
+### Migrate the Server
+
+The legacy Server can accept an Agent directly and create its Runner internally:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a"
+)
+
+server, err := a2aserver.New(
+    a2aserver.WithHost("agent.example.com:8888"),
+    a2aserver.WithAgent(llmAgent, true),
+    a2aserver.WithSessionService(inmemory.NewSessionService()),
+)
+```
+
+A v1 Server requires the application to construct the Runner and Agent Card explicitly:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a/v1"
+)
+
+agentRunner := runner.NewRunner(
+    llmAgent.Info().Name,
+    llmAgent,
+    runner.WithSessionService(inmemory.NewSessionService()),
+)
+defer agentRunner.Close()
+
+card, err := a2aserver.NewAgentCard(
+    llmAgent.Info().Name,
+    llmAgent.Info().Description,
+    "1.0.0",
+    "agent.example.com:8888",
+    true,
+    a2aserver.WithCardTools(llmAgent.Tools()...),
+)
+if err != nil {
+    return err
+}
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithV0Compatibility(),
+)
+```
+
+The `"1.0.0"` argument to `NewAgentCard` is the Agent implementation version, not the A2A protocol version. The Agent Card address is the client-reachable address and determines the Server base path; the address passed to `Start` only determines where the current process listens.
+
+The application now owns the Runner session service, memory, and shutdown. Keep `WithV0Compatibility()` during migration, then remove it after all v0.2.x Clients are retired.
+
+The legacy `WithAgent` path uses the Agent Card name as the Runner app name. When using persistent session storage, pass the same app name to the migrated `runner.NewRunner`; changing it changes storage keys and prevents existing sessions from being read.
+
+### Migrate the A2AAgent Client
+
+Clients that only use the default `A2AAgent` behavior usually need only an import-path change:
+
+```diff
+- a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent"
++ a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent/v1"
+```
+
+`WithAgentCardURL`, `WithEnableStreaming`, `WithTransferStateKey`, and `WithUserIDHeader` retain their purpose. Code that uses `WithAgentCard`, underlying client options, custom converters, mappers, or hooks must also migrate the related types and imports to `trpc-a2a-go/v2` and update signatures as described below.
+
+### Migrate configuration and extension interfaces
+
+Users of the default Server and A2AAgent behavior only need the regular configuration changes below. Skip the advanced extension table when the application has no custom converters, mappers, hooks, or legacy branch configuration.
+
+#### Regular configuration
+
+| v0.2.x configuration | v1 migration |
+|---|---|
+| `WithAgent` | Remove it; construct the Runner and configure `WithRunner` plus `WithAgentCard` |
+| `WithSessionService` | Remove it; use `runner.WithSessionService` |
+| `WithHost` | Remove it; publish the public address and base path in the Agent Card |
+| `NewAgentCard(name, description, host, streaming)` | Add the required Agent implementation version argument |
+| `WithTaskManagerBuilder` | Return `(taskmanager.TaskManager, error)` and migrate related types to `trpc-a2a-go/v2` |
+
+#### Advanced extensions
+
+| v0.2.x interface | v1 migration |
+|---|---|
+| `WithProcessorBuilder` | No one-to-one replacement; wrap the built-in processor with `WithProcessMessageHook`, or use `trpc-a2a-go/v2/server.NewA2AServer(customTaskManager, ...)` for a fully custom execution path |
+| `WithStreamingEventType` | Remove it; the built-in v1 converter uses artifact/status events, so Clients that consumed Message-shaped streams must consume those events or install a custom `EventToA2AConverter` |
+| `WithStructuredTaskErrors` | Remove it; v1 uses unified Task failure and structured-error semantics, and generated failures can be rewritten through `WithResponseRewriter` or a processor hook |
+| `WithStreamingRespHandler` | Remove it; the unified `A2AEventConverter` converts remote responses and the application continues to consume tRPC-Agent-Go events |
+| `EventToA2AMessage` | Remove the unary conversion method; retain only `ConvertStreamingToA2AMessage`, which returns `protocol.StreamEvent` |
+| `EventToA2APartMapper` | Change the return type from `[]protocol.Part` to `[]*protocol.Part` |
+| `A2AEventConverter` | Change inputs from v0 `MessageResult`/`StreamingMessageEvent` to v1 `SendMessageResponse`/`StreamResponse` |
+| `ResponseRewriter` | Change from separate unary/streaming methods to a function that handles each `StreamEvent` |
+| `BuildMessageHook`, `InvocationA2AConverter` | Remove the `isStream` argument; message construction is independent of transport selection |
+| `A2ADataPartMapper` | Change the input from v0 `*DataPart` to the unified v1 `*Part` |
+| Underlying `client`, `server`, `protocol`, and `taskmanager` imports | Migrate all of them to `trpc.group/trpc-go/trpc-a2a-go/v2/...` |
+
+`agent.WithA2ARequestOptions` accepts `...any`, so passing a legacy `trpc-a2a-go/client.RequestOption` can still compile while the v1 A2AAgent rejects the type at runtime. Check indirectly supplied options during migration instead of relying on compilation alone.
+
+### Choose a TaskManager during migration
+
+Do not configure the v1 memory TaskManager solely because the legacy Server created one internally. Choose the simplest implementation based on whether Clients need Task operations after the request ends.
+
+| Usage | Recommended TaskManager | Migration note |
+|---|---|---|
+| Ordinary blocking and streaming calls | Default stateless | Conversation context remains in the Runner session service |
+| Single-instance non-blocking calls, lookup, cancellation, resubscription, or continuation | Memory | Restarting the process loses Tasks |
+| Multi-node lookup, listing, and cross-node resubscription | Redis | Configure the Runner session store separately as shared storage; live cancellation must still reach the execution owner |
+
+A retaining TaskManager is required when a legacy Client explicitly sends `blocking=false` or depends on `tasks/get`, cancellation, resubscription, push notifications, `input-required`, or `auth-required`.
 
 ### Serve v0 clients from a v1 Server
 
@@ -676,16 +806,34 @@ The raw `compat/v0` converter preserves the v0 default: an omitted `blocking` me
 
 The stateless TaskManager rejects an explicit non-blocking request because request-bound execution cannot continue reliably after the HTTP response ends. A streaming request must also reach a terminal state within the current request; `input-required` and `auth-required` states that need a later continuation require a retaining TaskManager.
 
-The compatibility layer lets a legacy wire request enter the new execution path, but it does not guarantee lossless field-by-field conversion between the two data models. For example, `filename` and `mediaType` on v1 text/data Parts cannot be preserved in v0, the v0 `final` value in a streaming response is derived from v1 events, and only the first authentication scheme from a multi-scheme v0 push-notification configuration is retained in v1. Migration tests should cover real text, multimodal, tool-call, error, and Task workflows rather than checking only whether a request succeeds.
+With a retaining TaskManager, both protocol generations connected through the same compatible Server see the same Tasks: a Task created through v0.2.x can be queried through v1, a Task created through v1 can be queried through v0.2.x, and both observe the same cancellation state. This applies only to one v1 Server and its TaskManager; it does not mean a legacy v0.2.x Server can read the v1 TaskManager's internal storage.
+
+### Compatibility guarantees and known differences
+
+The compatibility layer preserves business semantics when legacy requests enter the new execution path; it does not reproduce every legacy Server wire response byte for byte.
+
+Integration tests with the current tRPC-Agent-Go legacy and v1 A2AAgent cover Agent Card discovery, blocking and streaming text, user and context/session IDs, RuntimeState, reasoning, tool calls and results, code execution, `state_delta`, files, and multimodal content. Both A2AAgent generations convert protocol results into common tRPC-Agent-Go events, so the parent Agent usually does not need to distinguish the underlying result type.
+
+Migration still needs to account for these observable differences:
+
+- The legacy built-in Server can return a direct `Message` when a unary call has one result, while the v1 Server's v0 compatibility path returns a request-local completed `Task`; code that type-asserts `MessageResult.Result` must handle both.
+- `filename` and `mediaType` on v1 text/data Parts cannot be preserved completely when converted to v0.
+- File references can be normalized between `FileID` and URL, and the compatibility Server can return more complete `ContentParts` than the legacy Server.
+- The v0 `final` value in a streaming response is derived from v1 events, so frame boundaries are not guaranteed to match the legacy Server.
+- Only the first authentication scheme from a multi-scheme v0 push-notification configuration is retained in v1.
+- Message IDs, Task IDs, timestamps, enum values, and raw JSON shapes are not guaranteed to be field-for-field equal across protocol generations.
+
+The compatibility layer targets the v0.2.x wire protocol used by tRPC-Agent-Go, and the current automated direct-protocol compatibility baseline is `trpc-a2a-go v0.2.5`. Historical tRPC-Agent-Go legacy A2AAgent releases, other v0.2.x versions, custom converters or hooks, gateway authentication, real push delivery, continuation, Redis restart, and cross-node execution must be tested end to end with the application's own dependency versions and deployment topology.
 
 ### Migration checklist
 
-- [ ] Change server and remote Agent imports to the `/v1` packages.
-- [ ] Construct and own the Runner explicitly.
+- [ ] Upgrade the Server first and enable `WithV0Compatibility()` while v0.2.x Clients remain.
+- [ ] Change Server and remote Agent imports to the `/v1` packages.
+- [ ] Construct and own the Runner explicitly, preserving its previous app name when sessions are persistent.
 - [ ] Publish a reachable Agent Card address and implementation version.
 - [ ] Keep conversation state in the Runner's session service.
 - [ ] Choose stateless, memory, or Redis Task management based on client needs.
-- [ ] Enable `WithV0Compatibility` while v0.2.x clients remain.
+- [ ] Migrate underlying client options and custom extension types to `trpc-a2a-go/v2`.
 - [ ] Test blocking, streaming, asynchronous, and retained Task flows separately.
 
 ## Protocol usage guide

--- a/docs/mkdocs/en/a2a_v1.md
+++ b/docs/mkdocs/en/a2a_v1.md
@@ -437,6 +437,8 @@ Common A2AAgent options are:
 | `WithA2AClientExtraOptions` | Pass options to the underlying A2A client |
 | `WithBuildMessageHook` | Rewrite the outbound A2A Message before sending |
 
+Inbound Message metadata is caller-controlled input. On the Server, use a custom processor installed with `WithProcessMessageHook` to filter it before calling the built-in processor; on the Client, limit `WithTransferStateKey` to non-security-sensitive keys. Tenant, role, policy, and other authorization state must come from authenticated or immutable server-side context.
+
 Use custom converters, Part mappers, hooks, or response rewriters only when the built-in text, multimodal, tool, code-execution, and metadata mappings are insufficient.
 
 ## Legacy protocol v0.2.x integration
@@ -712,6 +714,10 @@ server, err := a2aserver.New(
     a2aserver.WithAgentCard(card),
     a2aserver.WithV0Compatibility(),
 )
+if err != nil {
+    return err
+}
+return server.Start(":8888")
 ```
 
 The `"1.0.0"` argument to `NewAgentCard` is the Agent implementation version, not the A2A protocol version. The Agent Card address is the client-reachable address and determines the Server base path; the address passed to `Start` only determines where the current process listens.
@@ -823,7 +829,7 @@ Migration still needs to account for these observable differences:
 - Only the first authentication scheme from a multi-scheme v0 push-notification configuration is retained in v1.
 - Message IDs, Task IDs, timestamps, enum values, and raw JSON shapes are not guaranteed to be field-for-field equal across protocol generations.
 
-The compatibility layer targets the v0.2.x wire protocol used by tRPC-Agent-Go, and the current automated direct-protocol compatibility baseline is `trpc-a2a-go v0.2.5`. Historical tRPC-Agent-Go legacy A2AAgent releases, other v0.2.x versions, custom converters or hooks, gateway authentication, real push delivery, continuation, Redis restart, and cross-node execution must be tested end to end with the application's own dependency versions and deployment topology.
+The compatibility layer targets the v0.2.x wire protocol used by tRPC-Agent-Go, and the automated direct-protocol suite runs against the current `trpc-a2a-go` v0.2.x dependency selected by this repository. Historical tRPC-Agent-Go legacy A2AAgent releases, other v0.2.x versions, custom converters or hooks, gateway authentication, real push delivery, continuation, Redis restart, and cross-node execution must be tested end to end with the application's own dependency versions and deployment topology.
 
 ### Migration checklist
 

--- a/docs/mkdocs/en/blog/multiagent-boundaries.md
+++ b/docs/mkdocs/en/blog/multiagent-boundaries.md
@@ -200,5 +200,5 @@ Once the boundary is clear, the API choice becomes much less ambiguous.
 - [Team documentation](../team.md)
 - [TaskRun documentation](../taskrun.md)
 - [Graph documentation](../graph.md)
-- [A2A documentation](../a2a.md)
+- [A2A v1.0 documentation](../a2a_v1.md)
 - [Tool documentation](../tool.md)

--- a/docs/mkdocs/en/dify.md
+++ b/docs/mkdocs/en/dify.md
@@ -550,4 +550,4 @@ func (c *MyConverter) ConvertToDifyRequest(...) (*dify.ChatMessageRequest, error
 - [Dify Official Documentation](https://docs.dify.ai/)
 - [Dify SDK Go](https://github.com/cloudernative/dify-sdk-go)
 - [tRPC-Agent-Go Documentation](https://github.com/trpc-group/trpc-agent-go/blob/main/README.md)
-- [A2A Integration Guide](./a2a.md)
+- [A2A v1.0 Integration Guide](./a2a_v1.md)

--- a/docs/mkdocs/zh/a2a-interaction.md
+++ b/docs/mkdocs/zh/a2a-interaction.md
@@ -6,7 +6,7 @@
 
 ## 背景
 
-[A2A (Agent-to-Agent) 协议](https://a2a-protocol.org/latest/specification/) 定义了 Agent 间通信的基础数据模型（Message、Task、Part 等）和操作接口（SendMessage、StreamMessage 等）。A2A 规范在开篇明确了协议的设计目标：
+[A2A (Agent-to-Agent) 协议](https://a2a-protocol.org/latest/specification/) 定义了 Agent 间通信的基础数据模型（Message、Task、Part 等）和 wire operation。operation 名称取决于协议代际：v0.2.x 使用 `message/send`、`message/stream` 等 method，v1 使用 `SendMessage`、`SendStreamingMessage` 等 operation。A2A 规范在开篇明确了协议的设计目标：
 
 > *The Agent2Agent (A2A) Protocol is an open standard designed to facilitate communication and interoperability between independent, potentially opaque AI agent systems.*
 >
@@ -44,7 +44,7 @@
 | Agent Card 声明 | `AgentCard.capabilities.extensions` | `AgentCard.capabilities.extensions` |
 | 请求版本 | Message metadata | Message metadata |
 | 扩展事件数据 | 旧版 `TextPart`、`DataPart` 和流式 envelope | 统一 Part metadata，以及 Message、Artifact 和 Task update event metadata |
-| operation 名称 | `message/send` 等小写斜杠形式 method | `SendMessage`、`SubscribeToTask` 等 v1 operation |
+| operation 名称 | `message/send`、`message/stream` 等小写斜杠形式 method | `SendMessage`、`SendStreamingMessage` 等 v1 operation |
 
 除非章节明确说明 v1，本文后续的 JSON 结构、具体 Part 类型、method 名和流式 envelope 都是 v0.2.x wire 示例；metadata key 定义仍是两代包共享的互操作契约。
 
@@ -106,7 +106,14 @@ A2A Client 在发送请求（`message/send` 或 `message/stream`）时，会在 
 
 Server 端可以根据此字段判断 Client 的能力：
 - **字段存在**：Client 是 trpc-agent-go 客户端，支持对应版本的交互规范（如 tool call、reasoning content 等扩展编码）
-- **字段不存在**：Client 是标准 A2A 客户端或其他框架的客户端
+- **字段不存在**：Client 是标准 A2A 客户端或其他框架的客户端，Server 应按基础 A2A 协议行为返回响应
+
+### 兼容策略
+
+- **Major 版本变更**（例如 `1.0` → `2.0`）：表示存在不兼容的协议变更，Client 应检查版本并降级处理或拒绝请求
+- **Minor 版本变更**（例如 `1.0` → `1.1`）：表示向后兼容的扩展，Client 可以安全忽略未知字段
+- Client 未发现此 extension 时，应回退到基础 A2A 协议行为
+- Server 收到缺少 `interaction_spec_version` 的请求时，应按基础 A2A 协议行为返回响应
 
 ---
 
@@ -152,7 +159,7 @@ sequenceDiagram
     S-->>C: SSE: TaskStatusUpdateEvent (completed)
 ```
 
-`SendMessage` 等待完整响应后一次性返回，`StreamMessage` 通过 SSE 实时推送增量事件。框架在两端自动完成格式转换。
+`trpc-a2a-go` Client 方法 `SendMessage` 会等待完整响应后一次性返回，`StreamMessage` 则通过 SSE 实时推送增量事件。在这条 v0.2.x 链路中，它们分别映射到 wire method `message/send` 和 `message/stream`；对应的 v1 流式 operation 是 `SendStreamingMessage`。框架在两端自动完成格式转换。
 
 ---
 

--- a/docs/mkdocs/zh/a2a-interaction.md
+++ b/docs/mkdocs/zh/a2a-interaction.md
@@ -2,7 +2,7 @@
 
 > **说明**
 >
-> 本文档定义了 trpc-agent-go 框架内部对 A2A 协议的扩展实现规范。普通用户在使用 A2A Client/Server 时无需关注此文档内容，框架已自动处理所有协议转换细节。仅当您需要开发非 trpc-agent-go 的 A2A Client/Server 对接本框架时，才需参考此规范。
+> 本文档定义 tRPC-Agent-Go 旧版与 v1 A2A 包共享的扩展实现规范。普通用户无需关注，框架会自动完成转换；只有开发非 tRPC-Agent-Go 的 Client 或 Server 并需要与这些扩展互通时才需参考，具体版本的承载方式见下文。
 
 ## 背景
 
@@ -31,7 +31,22 @@
 
 > 完整的 A2A 协议规范请参考：https://a2a-protocol.org/latest/specification/
 >
-> 框架使用指南请参考：[A2A 集成指南](a2a.md)
+> 框架使用请参考 [A2A v0.2.x 集成指南](a2a.md) 或 [A2A v1.0 接入与迁移指南](a2a_v1.md)。
+
+---
+
+## 协议版本适用范围
+
+`trpc-a2a-version` extension、交互规范版本 `0.1`，以及 `interaction_spec_version`、`type`、`thought`、`object_type`、`llm_response_id`、`state_delta` 等共享 metadata key 会同时用于两代包，但 wire carrier 不同：
+
+| 契约范围 | A2A v0.2.x 包 | A2A v1.0 包 |
+|---|---|---|
+| Agent Card 声明 | `AgentCard.capabilities.extensions` | `AgentCard.capabilities.extensions` |
+| 请求版本 | Message metadata | Message metadata |
+| 扩展事件数据 | 旧版 `TextPart`、`DataPart` 和流式 envelope | 统一 Part metadata，以及 Message、Artifact 和 Task update event metadata |
+| operation 名称 | `message/send` 等小写斜杠形式 method | `SendMessage`、`SubscribeToTask` 等 v1 operation |
+
+除非章节明确说明 v1，本文后续的 JSON 结构、具体 Part 类型、method 名和流式 envelope 都是 v0.2.x wire 示例；metadata key 定义仍是两代包共享的互操作契约。
 
 ---
 

--- a/docs/mkdocs/zh/a2a.md
+++ b/docs/mkdocs/zh/a2a.md
@@ -1,5 +1,7 @@
 # tRPC-Agent-Go A2A 集成指南
 
+> 本文介绍面向 A2A v0.2.x 的旧版 `server/a2a` 与 `agent/a2aagent` 包。新接入和迁移说明请参考 [A2A v1.0 接入与迁移指南](a2a_v1.md)。
+
 ## 概述
 
 tRPC-Agent-Go 提供了完整的 A2A (Agent-to-Agent) 解决方案，包含两个核心组件：

--- a/docs/mkdocs/zh/a2a_v1.md
+++ b/docs/mkdocs/zh/a2a_v1.md
@@ -403,6 +403,8 @@ A2AAgent 的常用配置如下：
 | `WithA2AClientExtraOptions` | 向底层 A2A 客户端传递配置 |
 | `WithBuildMessageHook` | 在发送前改写 A2A Message |
 
+入站 Message metadata 属于调用方可控输入。服务端应通过 `WithProcessMessageHook` 安装自定义 processor，并在调用内置 processor 前过滤 metadata；客户端应将 `WithTransferStateKey` 限制为非安全敏感键。tenant、role、policy 等授权状态必须来自已认证或不可变的服务端上下文。
+
 只有内置的文本、多模态内容、工具、代码执行和 metadata 映射无法满足需求时，才需要使用自定义 converter、Part mapper、hook 或 response rewriter。
 
 ## 旧版协议 v0.2.x 接入
@@ -678,6 +680,10 @@ server, err := a2aserver.New(
     a2aserver.WithAgentCard(card),
     a2aserver.WithV0Compatibility(),
 )
+if err != nil {
+    return err
+}
+return server.Start(":8888")
 ```
 
 `NewAgentCard` 的 `"1.0.0"` 是 Agent 实现版本，不是 A2A 协议版本。Agent Card 中的地址是发布给客户端的可达地址，并决定 Server 的 base path；传给 `Start` 的地址只决定当前进程监听的位置。
@@ -789,7 +795,7 @@ stateless TaskManager 会拒绝显式非阻塞请求，因为 request-bound exec
 - v0 push notification 配置中的多个 authentication scheme 转换为 v1 时只能保留第一个。
 - Message ID、Task ID、时间戳、枚举值和原始 JSON 结构不属于跨协议逐字段相等的保证。
 
-兼容层面向 tRPC-Agent-Go 使用的 v0.2.x wire，当前直接协议客户端的自动化兼容回归基线为 `trpc-a2a-go v0.2.5`。历史 tRPC-Agent-Go 版本中的 legacy `A2AAgent`、其他 v0.2.x 版本、自定义 converter/hook、网关鉴权、真实 push 投递、continuation、Redis 重启和跨节点执行等场景，应使用应用自身的依赖版本和部署拓扑做端到端回归。
+兼容层面向 tRPC-Agent-Go 使用的 v0.2.x wire，自动化直接协议测试使用仓库当前选定的 `trpc-a2a-go` v0.2.x 依赖。历史 tRPC-Agent-Go 版本中的 legacy `A2AAgent`、其他 v0.2.x 版本、自定义 converter/hook、网关鉴权、真实 push 投递、continuation、Redis 重启和跨节点执行等场景，应使用应用自身的依赖版本和部署拓扑做端到端回归。
 
 ## 协议使用指南
 

--- a/docs/mkdocs/zh/a2a_v1.md
+++ b/docs/mkdocs/zh/a2a_v1.md
@@ -1,0 +1,832 @@
+# tRPC-Agent-Go A2A v1.0 接入与迁移指南
+
+本文从使用者的角度介绍 A2A 协议、`trpc-a2a-go` 与 tRPC-Agent-Go 的接入架构，然后给出推荐使用的 A2A v1.0 接入方式、Task 与多节点部署边界、旧版 A2A v0.2.x 接入和迁移指南。现有 v0.2.x 接入说明请参考 [A2A 集成指南](a2a.md)。
+
+## A2A 协议介绍
+
+A2A（Agent-to-Agent）是用于发现和调用远程 AI Agent 的协议。调用方不需要了解远程 Agent 使用了什么框架、模型或工具。
+
+主要协议概念如下：
+
+| 概念 | 含义 |
+|---|---|
+| Agent Card | 描述 Agent 身份、能力和调用方式的公开信息 |
+| Message | 用户与 Agent 之间的一轮消息 |
+| Part | Message 或 Artifact 携带的文本、文件或结构化数据 |
+| Task | 具有生命周期、可以观察和继续操作的一次工作 |
+| Artifact | Task 产生的交付物 |
+| Context ID | 多个 Message 或 Task 共享的会话标识 |
+| Task ID | 一次 Task 生命周期的标识 |
+
+一次典型的 A2A v1.0 调用分为两步：
+
+1. 获取远程 **Agent Card**，了解服务地址、身份、技能、输入输出类型、流式能力和鉴权要求。
+2. 向 Agent Card 声明的端点发送消息，接收直接 `Message` 或可跟踪的 `Task`。
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Card as A2A v1 Agent Card endpoint
+    participant Server as A2A v1 endpoint
+
+    Client->>Card: GET /.well-known/agent-card.json
+    Card-->>Client: v1 Agent Card
+    Client->>Server: SendMessage / SendStreamingMessage
+    alt 简单消息结果
+        Server-->>Client: Message
+    else Task 工作流
+        Server-->>Client: Task 或 Task 更新事件
+        opt 服务端保留 Task
+            Client->>Server: GetTask / ListTasks / CancelTask / SubscribeToTask
+            Server-->>Client: Task 快照或后续事件流
+        end
+    end
+```
+
+简单问答可以直接返回 `Message`；需要进度、Artifact、中断、取消或后续查询的工作可以使用 `Task`。两者都属于协议结果，Task 也不是对话 session 的替代品。
+
+A2A v1.0 支持阻塞 `SendMessage`、实时 `SendStreamingMessage`，以及发起后通过 Task API 查询、取消或重新订阅的交互方式；继续挂起的 Task 则需要携带原 Task ID 再次发送 Message。具体选择取决于服务端是否在请求结束后保留 Task，后文会给出选择方式。
+
+### 从 v0.x 到 v1.0
+
+A2A 协议已经从 v0.x 演进到 v1.0。[官方 v1.0 公告](https://a2a-protocol.org/latest/announcing-1.0/)明确说明 interaction protocol 包含破坏性变更；[官方迁移指南](https://a2a-protocol.org/latest/whats-new-v1/)以 v0.3.0 为对比基线，列出了下面这些核心变化。tRPC-Agent-Go 的旧版接入实现更早的 v0.2.x，它与 v0.3.0 同属需要迁移的 v0.x 协议线，但具体字段仍应以各自版本的协议定义为准。
+
+| 维度 | v0.3.0（官方迁移基线） | v1.0 |
+|---|---|---|
+| Part 内容模型 | `TextPart`、`FilePart` 和 `DataPart` 是不同类型，通过 `kind` 区分 | 统一为一个 `Part`，通过 `text`、`raw`、`url` 或 `data` 成员表达内容 |
+| 流式事件 | 事件自身携带 `kind`，`TaskStatusUpdateEvent` 使用 `final` 表示结束 | 事件使用成员名区分具体类型，移除 `kind` 和 `final`，由 stream 关闭表达结束 |
+| 枚举值 | `user`、`completed` 等小写值 | `ROLE_USER`、`TASK_STATE_COMPLETED` 等带类型前缀的枚举值 |
+| Agent Card | 端点、传输和协议版本主要由顶层字段表达 | 使用 `supportedInterfaces` 声明 URL、binding 和协议版本，可以同时公布多种接口 |
+| 操作和 Task | `message/send`、`tasks/get` 等斜杠形式 method，没有 `ListTasks`，部分 Task 行为定义较宽松 | 使用 `SendMessage`、`GetTask` 等 operation，增加 `ListTasks`，并明确 Message/Task 返回、订阅和取消语义 |
+| 协议 binding | `a2a.proto` 更接近 gRPC 实现定义，不同 binding 的等价性约束较弱 | 以 `a2a.proto` 作为协议无关的规范来源，正式定义 JSON-RPC、HTTP+JSON/REST 与 gRPC 的等价映射 |
+
+因此，A2A v1.0 并非只调整 method 名称，而是同时改变了序列化模型、事件判别方式、Agent 发现结构和 Task 交互语义。在没有兼容层时，v0.x 客户端的请求不能直接由 v1.0 服务端处理。
+
+## trpc-a2a-go 介绍
+
+[`trpc-a2a-go`](https://github.com/trpc-group/trpc-a2a-go) 是 tRPC 的 A2A 协议 Go 实现，提供协议类型以及客户端和服务端两侧的基础能力。
+
+为了让应用渐进迁移，`trpc-a2a-go` 使用新的 `/v2` Go module 实现 A2A v1.0，原有 module 继续承载 v0.2.x；tRPC-Agent-Go 相应新增 `server/a2a/v1` 和 `agent/a2aagent/v1`，原有 `server/a2a` 和 `agent/a2aagent` 将继续维护，直到大部分用户迁移至 v1。
+
+对于迁移期间仍需服务的旧版客户端，`trpc-a2a-go/v2` 提供 `compat/v0` 转换层，tRPC-Agent-Go 可以在新的 v1 服务端上显式启用该兼容能力。
+
+包和协议版本的对应关系如下：
+
+| A2A 协议 | tRPC-Agent-Go Server | tRPC-Agent-Go 远程 Agent | `trpc-a2a-go` module |
+|---|---|---|---|
+| v1.0 | `server/a2a/v1` | `agent/a2aagent/v1` | `trpc-a2a-go/v2` |
+| v0.2.x | `server/a2a` | `agent/a2aagent` | `trpc-a2a-go` |
+
+tRPC-Agent-Go 的 `/v1` 后缀表示 A2A 协议 v1.0；`trpc-a2a-go/v2` 中的 `/v2` 是 Go module major version。两者属于不同仓库的版本命名，不要把 `/v2` 理解为 A2A 协议 v2。
+
+`trpc-a2a-go/v2` 的主要层次如下：
+
+| 层次 | 职责 |
+|---|---|
+| `protocol` | Agent Card、Message、Task、Artifact、事件和请求类型 |
+| `client` | Agent 发现、JSON-RPC 调用和 SSE 事件流 |
+| `server` | Agent Card 端点、鉴权、JSON-RPC 分发和 SSE |
+| `taskmanager` | 请求执行策略、Task 生命周期、保留和事件分发 |
+| `compat/v0` | 在 v0.2.x wire 协议与 v1.0 核心模型之间转换 |
+
+服务端把具体工作交给 `MessageProcessor`，后者读取 `ExecContext` 并产生一条协议事件流。`TaskManager` 消费同一条事件流，决定当前调用是请求内执行还是需要保留 Task，并生成阻塞、流式、查询和订阅等协议行为；服务端本身负责 Agent Card、wire 协议、路由和中间件。tRPC-Agent-Go 接入使用的正是这些扩展边界。
+
+`trpc-a2a-go` 使用 lazy Task 机制：`MessageProcessor` 只产生 Message 时不会创建 Task；首次产生 status 或 artifact 事件时，TaskManager 才创建本次执行使用的 Task。保留型 TaskManager 会在请求结束后继续保存这个 Task，stateless TaskManager 则只在当前请求内处理它。
+
+## tRPC-Agent-Go 的 A2A 接入架构
+
+tRPC-Agent-Go 在 `trpc-a2a-go` 之上提供适配器，并没有重新实现另一套 A2A 传输或 Task 系统。这套接入是连接本地 Agent 与远程服务的协议边界，不是与 LLMAgent、GraphAgent 并列的第三种本地执行引擎。
+
+服务端适配器把 A2A 请求转换为 Runner invocation，再把 Runner event 转换回 A2A event，因此 Runner 后面可以是 LLMAgent、GraphAgent 或任何其他 Agent。客户端 `A2AAgent` 把远程 A2A 服务封装为标准的 tRPC-Agent-Go Agent，Runner、父 Agent 或 Graph 节点可以像调用本地 Agent 一样调用它。
+
+```mermaid
+flowchart LR
+    subgraph Remote["远程服务"]
+        SA["server/a2a/v1"]
+        MP["MessageProcessor adapter"]
+        TM["A2A TaskManager<br/>默认 stateless / 可配置保留型 TaskManager"]
+        R1["Runner<br/>服务端 session"]
+        LA["LLMAgent / GraphAgent / 其他 Agent"]
+        SA <--> TM
+        TM <--> MP
+        MP <--> R1
+        R1 <--> LA
+    end
+
+    subgraph Caller["调用方应用"]
+        CA["agent/a2aagent/v1"]
+        CA <--> R2["Runner<br/>调用方 session"]
+        R2 <--> APP["应用 / 上层 Agent"]
+        TC["trpc-a2a-go/v2/client<br/>完整 Task API"]
+    end
+
+    CA -->|"SendMessage / SendStreamingMessage"| SA
+    SA -->|"Task / 事件流"| CA
+    TC -->|"Task API（仅保留型 TaskManager 可跨请求使用）"| SA
+    SA -->|"Task 快照 / 事件流"| TC
+```
+
+### A2A 接入提供的能力
+
+这套接入提供三类能力：
+
+- **把本地 Agent 发布为 A2A 服务：** `server/a2a/v1` 发布 Agent Card，把 A2A Message、context ID、用户身份和 metadata 转换为 Runner invocation，再把 Runner 产生的文本、多模态内容、工具调用、状态和错误转换为 A2A 事件。W3C trace context 则通过 HTTP 请求头跨越协议边界传播。LLMAgent、GraphAgent 和自定义 Agent 都可以通过同一个 Runner 接入。
+- **像本地 Agent 一样调用远程服务：** `agent/a2aagent/v1` 发现远程 Agent Card 并实现统一的 `agent.Agent` 接口，把本地 invocation 转换为阻塞或流式 A2A 请求，再把远程 Message、Task、Artifact、工具调用和错误转换回 tRPC-Agent-Go 事件。
+- **按需使用完整 A2A Task API：** `A2AAgent` 只封装普通 Agent invocation；需要 Task 查询、列表、取消、重新订阅或 push notification 时，直接使用 `trpc-a2a-go/v2/client`：`GetTasks` 调用 v1 `GetTask` operation，`ListTasks` 调用 `ListTasks`，`CancelTasks` 调用 `CancelTask`，`ResubscribeTask` 调用 `SubscribeToTask`。
+
+服务端适配器会接入 `trpc-a2a-go` 的中间件链，并默认从 `X-User-ID` 请求头解析 Runner user ID；这个默认行为只是身份传递，不等于业务鉴权。生产服务仍需要通过网关或底层 A2A 服务端中间件完成认证、授权和 Task 归属校验。
+
+当前 `server/a2a/v1` 实例绑定一个 Agent Card 和一个 Runner。底层 `trpc-a2a-go` 即使配置了 tenant Agent Card，也不会让这个适配器自动按 tenant 分发到不同 Runner；需要多 Agent 托管时，应用应在适配器外路由到不同服务实例，或者让固定 Runner 后面的 Agent 完成应用级业务路由。后一种方式不会读取或保留 A2A `tenant` 的协议分发语义。
+
+### 与 LLMAgent、GraphAgent 的区别
+
+A2AAgent 与本地 Agent 的区别如下：
+
+| Agent 类型 | 核心职责 | 实际执行位置 | 主要状态 |
+|---|---|---|---|
+| LLMAgent | 基于模型进行推理、选择工具和多轮交互 | 当前进程 | Runner session |
+| GraphAgent | 按节点、边和状态转换执行可控工作流 | 当前进程 | Runner session 和 Graph state/checkpoint |
+| A2AAgent | 把 Agent invocation 转发给远程 A2A 服务 | 远程服务 | 调用方 Runner session；其他状态由远端实现管理 |
+
+LLMAgent 直接持有 Model、Tool 和 SubAgent 配置；GraphAgent 持有工作流结构并支持 checkpoint、中断和恢复；A2AAgent 本地不持有远端的模型或工具配置，其 `Tools()` 和 `SubAgents()` 为空，远端能力由 Agent Card 声明，远端是否保留 A2A Task 则取决于其实现，使用 `trpc-a2a-go` 时由 TaskManager 决定。这些类型可以组合使用：LLMAgent 或 GraphAgent 可以通过 Runner 暴露为 A2A 服务，A2AAgent 也可以作为父 Agent 的 SubAgent 或 Graph 中的 Agent 节点。
+
+它们的主要区别不是能力强弱，而是执行逻辑位于本地还是远端，以及调用是否跨越 A2A 协议边界。A2A 解决的是远程发现和互操作问题；LLMAgent 与 GraphAgent 解决的是本地推理和编排问题。
+
+### 状态边界
+
+从服务端接入点看，默认 stateless TaskManager 不会跨请求保留 A2A Task，因此默认只有 Runner session 这一类跨请求状态。只有配置 memory、Redis 或自定义保留型 TaskManager，开启完整 A2A Task 管理能力后，服务端才会同时存在 Runner session 和 A2A Task 两类相互独立的状态。
+
+在 tRPC-Agent-Go 调用另一套 tRPC-Agent-Go 服务的完整链路中，调用方和服务端通常各自拥有独立的 Runner session store；A2A context ID 用于关联两端调用，但不会合并这两个存储。后文会继续说明可选的 A2A Task 状态和多节点部署要求。
+
+## A2A v1.0 接入
+
+新应用应使用 v1 包。
+
+### 创建 v1 Server
+
+v1 服务端接收由调用方持有的 Runner 和显式 Agent Card。这样可以在创建服务端时明确 Runner 所有权、session 配置和对外发布的 A2A 身份。
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a/v1"
+)
+
+agentRunner := runner.NewRunner(
+    "my-app",
+    llmAgent,
+    runner.WithSessionService(inmemory.NewSessionService()),
+)
+defer agentRunner.Close()
+
+card, err := a2aserver.NewAgentCard(
+    llmAgent.Info().Name,
+    llmAgent.Info().Description,
+    "1.0.0",                  // Agent 实现版本。
+    "agent.example.com:8888", // 对客户端发布的可达地址。
+    true,                     // 声明支持流式响应。
+    a2aserver.WithCardTools(llmAgent.Tools()...),
+)
+if err != nil {
+    return err
+}
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+)
+if err != nil {
+    return err
+}
+return server.Start("0.0.0.0:8888")
+```
+
+Agent Card 地址用于服务发现和路由，可以与传给 `Start` 的监听地址不同。
+
+内置 converter 可以映射 image、audio 和 file 等多模态内容，但 `NewAgentCard` 默认只声明 `text` 输入输出模式。服务需要让客户端发现多模态能力时，应在传给 `WithAgentCard` 的 Agent Card 中显式声明对应的 input/output modes。
+
+Runner 生命周期归调用方所有。服务端创建失败或者停止后，调用方都需要关闭 Runner。
+
+### 调用远程 A2A Agent
+
+`agent/a2aagent/v1` 会发现远程 Agent Card，并实现普通的 tRPC-Agent-Go Agent 接口：
+
+```go
+import (
+    "context"
+
+    a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent/v1"
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+)
+
+remoteAgent, err := a2aagent.New(
+    a2aagent.WithAgentCardURL("https://agent.example.com"),
+)
+if err != nil {
+    return err
+}
+
+remoteRunner := runner.NewRunner(
+    "a2a-client",
+    remoteAgent,
+    runner.WithSessionService(inmemory.NewSessionService()),
+)
+defer remoteRunner.Close()
+
+events, err := remoteRunner.Run(
+    context.Background(),
+    "user-1",
+    "session-1",
+    model.NewUserMessage("What time is it?"),
+)
+if err != nil {
+    return err
+}
+for event := range events {
+    // 与本地 Agent 一样消费 tRPC-Agent-Go 事件。
+    _ = event
+}
+```
+
+适配器会进行以下映射：
+
+- 本地 session ID → A2A context ID；
+- 本地 user ID → `X-User-ID` 请求头；
+- 本地输入的 text 和多模态 `ContentPart` → A2A Part；
+- 远端 Runner 产生的工具调用和工具结果 → 服务端编码的结构化 data Part → A2AAgent 恢复的本地事件；
+- 远程 A2A Message、Task 和事件 → tRPC-Agent-Go event。
+
+除非业务显式覆盖，否则 A2AAgent 会根据 Agent Card 自动选择流式或阻塞调用。它处理的是一次普通 Agent invocation；需要 Task 查询、取消或重新订阅时，应直接使用底层 `trpc-a2a-go/v2/client`。
+
+### 运行普通 Agent 调用示例
+
+示例使用支持 session 的 LLMAgent，并配置了 `current_time` 工具。先设置模型配置：
+
+```bash
+export OPENAI_API_KEY="<your-api-key>"
+export MODEL_NAME="<your-model>"
+# 使用 OpenAI 兼容服务时再设置 OPENAI_BASE_URL。
+```
+
+启动服务端：
+
+```bash
+cd examples
+go run ./a2aagent/v1/server
+```
+
+在另一个终端启动客户端：
+
+```bash
+cd examples
+go run ./a2aagent/v1/client
+```
+
+询问当前时间可以观察工具调用和工具结果通过 A2A 传递。客户端保留同一个 session ID 时，远端 Runner session 会继续同一段对话；使用 `/new` 或 `/use` 可以切换 session。服务端增加 `-streaming=false` 可以验证阻塞 `SendMessage`。
+
+### 请求生命周期
+
+内置适配器实现 `trpc-a2a-go` 的 `MessageProcessor` 接口。非流式和流式请求都经过同一条链路：
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server as A2A server
+    participant TM as TaskManager
+    participant Adapter as tRPC-Agent-Go processor
+    participant Runner
+
+    Client->>Server: SendMessage / SendStreamingMessage
+    Server->>TM: 执行请求
+    TM->>Adapter: ProcessMessage(ExecContext)
+    Adapter->>Runner: Run(userID, contextID, message)
+    Runner-->>Adapter: Agent events
+    Adapter-->>TM: status / artifact events
+    TM-->>Server: Task 或事件流
+    Server-->>Client: JSON-RPC response 或 SSE
+```
+
+适配器始终通过同一条事件链转换 Runner 输出，不再为流式和非流式请求分别实现 `MessageProcessor`。成功执行通常经历 `submitted → 输出 → completed`；失败会进入 `failed`，`input-required` 或 `auth-required` 等挂起状态也通过同一条事件流表达。
+
+### 默认 stateless TaskManager
+
+v1 服务端默认使用 `taskmanager/stateless`。准确地说，**stateless 的是 TaskManager**；`MessageProcessor` 仍负责执行 Runner 并产生完整 Task 生命周期。
+
+默认 TaskManager 会：
+
+- 在当前 HTTP 请求生命周期内运行 `MessageProcessor`；
+- 根据 status 和 artifact 事件构造本次执行使用的 Task；
+- 返回终态 Task 或实时转发事件；
+- 请求结束后丢弃 Task、事件日志和协议 history；
+- 拒绝需要脱离当前 HTTP 请求继续执行、需要跨请求读取 Task 状态，或者进入 `input-required`、`auth-required` 等等待后续请求继续执行的操作。
+
+底层 stateless TaskManager 允许自定义 `MessageProcessor` 直接返回 Message，但 tRPC-Agent-Go 内置适配器会从 `submitted` 开始为 Runner 调用产生 Task 生命周期，成功时以 `completed` 结束。因此，默认服务端的阻塞调用返回的是仅在本次请求内存在的终态 Task；stateless 表示不跨请求保留 Task，并不表示只返回 Message。
+
+这个默认值适合普通的请求/响应 Agent 调用：没有 Task 清理成本、没有存储依赖，也不需要跨请求保持 Task 亲和性。`returnImmediately=true` 会被拒绝，不是因为 A2A 不能立即返回 Message，而是 stateless TaskManager 将执行绑定在当前请求，无法在 HTTP 响应结束后继续可靠执行。对话连续性仍由 Runner session service 提供。
+
+### 保留型 Task 管理
+
+客户端需要异步执行、Task 查询，或者对未结束 Task 进行取消、重新订阅和 continuation 时，再配置保留型 TaskManager。push notification 还需要在所选 TaskManager 上单独启用，不能仅靠“保留 Task”自动获得。
+
+单进程服务可以使用 memory TaskManager：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+    memorytaskmanager "trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
+)
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithTaskManagerBuilder(func(
+        processor taskmanager.MessageProcessor,
+    ) (taskmanager.TaskManager, error) {
+        return memorytaskmanager.NewTaskManager(processor)
+    }),
+)
+```
+
+memory Task 状态只存在于当前进程，重启后会丢失，并且默认不会自动清理终态 Task。生产服务应根据需要通过 `memorytaskmanager.WithTaskTTL(...)` 配置留存时间。
+
+开启保留型 TaskManager 后，系统中会同时存在两套相互独立的状态：
+
+| 状态系统 | 所有者 | 用途 |
+|---|---|---|
+| Runner session | 每个 tRPC-Agent-Go 应用自己的 session service | 对话历史、应用状态和多轮 Agent 上下文 |
+| A2A Task | `trpc-a2a-go` TaskManager | 协议 Task 状态、Artifact、查询、取消、重新订阅和 push 配置 |
+
+保留 A2A Task 不会替代 Runner session；同样，Runner session 可以持久化也不代表原请求结束后还能调用 `GetTask`。应用需要根据对话连续性和协议 Task 操作两个维度分别选择存储。
+
+### 多节点部署
+
+v1 adapter 可以部署在负载均衡器后面，但正确拓扑取决于应用实际使用的状态能力。
+
+| 部署方式 | 可跨副本工作的能力 | 额外要求 |
+|---|---|---|
+| Stateless TaskManager | 阻塞和流式请求 | 对话上下文需要跨节点连续时，共享 Runner session store 或使用会话亲和性 |
+| Memory TaskManager | Task 操作均不能跨副本 | 同一 Task 的所有操作必须路由到持有它的节点 |
+| Redis TaskManager | 共享 Task 快照、协议历史、查询和列表 | 使用独立的 Redis TaskManager module，并让所有副本连接同一套 Redis |
+| Redis + 跨节点 resubscribe | `SubscribeToTask` 可以通过其他副本重新连接 | 每个副本都启用 `WithCrossNodeResubscribe(true)` |
+
+Redis TaskManager 只解决 Task 状态共享，跨节点重新订阅也不等于分布式执行。它不提供跨副本 exactly-once 协调、全局实时执行注册表或实时取消路由；需要这些保证时，应用仍需使用粘性路由或独立的执行协调方案。
+
+A2A Task 与 Runner session 是两套独立状态。如果对话也需要跨节点连续，Runner 仍需使用共享 session service 或配置会话亲和性。
+
+### v1 常用配置
+
+服务端适配器的常用配置如下：
+
+| 配置 | 用途 |
+|---|---|
+| `WithRunner` | 设置由调用方持有的 Runner |
+| `WithAgentCard` | 设置对外发布的 Agent 身份和能力 |
+| `WithTaskManagerBuilder` | 替换默认 stateless TaskManager |
+| `WithV0Compatibility` | 在 v1 端点上处理 v0.2.x method |
+| `WithUserIDHeader` | 修改用户身份请求头 |
+| `WithRunOptions` | 为每次 Runner invocation 增加 option |
+| `WithProcessMessageHook` | 包装入站 A2A 消息处理 |
+| `WithResponseRewriter` | 改写出站 A2A 事件 |
+| `WithExtraA2AOptions` | 向底层 A2A 服务端传递鉴权、中间件等配置 |
+
+A2AAgent 的常用配置如下：
+
+| 配置 | 用途 |
+|---|---|
+| `WithAgentCardURL`、`WithAgentCard` | 通过 URL 发现或直接提供远程 Agent Card |
+| `WithEnableStreaming` | 覆盖 Agent Card 声明的流式能力选择 |
+| `WithUserIDHeader` | 修改传递用户身份的请求头 |
+| `WithTransferStateKey` | 选择需要通过 Message metadata 传递的 invocation `RuntimeState` |
+| `WithA2AClientExtraOptions` | 向底层 A2A 客户端传递配置 |
+| `WithBuildMessageHook` | 在发送前改写 A2A Message |
+
+只有内置的文本、多模态内容、工具、代码执行和 metadata 映射无法满足需求时，才需要使用自定义 converter、Part mapper、hook 或 response rewriter。
+
+## 旧版协议 v0.2.x 接入
+
+已有应用可以继续使用不带 `/v1` 后缀的 `server/a2a` 和 `agent/a2aagent`，它们依赖 `trpc-a2a-go` 根 module 并实现 A2A v0.2.x。
+
+这些包处于兼容维护阶段，但仍然是可以独立使用的 A2A 适配器，而不只是指向 v1 的兼容别名。新应用应该直接使用 v1 包；仍在维护 v0.2.x 服务或客户端的用户可以继续使用下面的能力。
+
+### v0.2.x 能力范围
+
+| 能力 | 旧版接入行为 |
+|---|---|
+| 发布本地 Agent | `server/a2a` 发布旧版 Agent Card，处理 JSON-RPC 与 SSE，并把 A2A 请求交给 Runner |
+| 调用远程 Agent | `agent/a2aagent` 自动发现旧版 Agent Card，并以标准 `agent.Agent` 接口提供阻塞或流式调用 |
+| Runner 与 session | 可以使用隐式 Runner，也可以传入应用持有的 Runner；A2A context ID 成为服务端 Runner session ID |
+| 身份、状态和追踪 | 通过 HTTP header 传递 user ID 和 W3C trace context，通过 Message metadata 传递 invocation `RuntimeState` |
+| 内容和事件转换 | 支持文本、图片、音频、文件输入，以及文本、reasoning、工具调用、工具结果、代码执行和状态增量等扩展事件 |
+| 扩展能力 | 支持 hook、自定义 converter、Part mapper、响应改写、Graph event allowlist、ADK metadata、动态 Agent Card 和底层 A2A 选项 |
+
+`A2AAgent` 本地不持有远端 Model、Tool 或 SubAgent，其 `Tools()` 和 `SubAgents()` 为空；远端能力仍由 Agent Card 描述。它可以放在 Runner 后面，也可以作为父 Agent 的 SubAgent 或 Graph 中的 Agent 节点。
+
+`NewAgentCard` 默认只声明 `text` 输入输出模式，即使内置 converter 可以处理图片、音频和文件。旧版服务确实接收这些类型时，应用应提供准确的自定义 Agent Card，避免客户端只根据默认 Card 得出错误的能力判断。
+
+### 创建旧版 A2A Server
+
+旧版服务端保留了直接接收 Agent 的便捷入口。调用方没有提供 Runner 和 session service 时，服务端会自动创建默认 Runner 和 in-memory session service：
+
+```go
+import a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a"
+
+server, err := a2aserver.New(
+    a2aserver.WithHost("127.0.0.1:8888"),
+    a2aserver.WithAgent(llmAgent, true),
+)
+if err != nil {
+    return err
+}
+return server.Start("127.0.0.1:8888")
+```
+
+`WithAgent(llmAgent, true)` 中的布尔值只用于声明自动生成的 Agent Card 支持 streaming，不是 Runner 的执行开关。服务端是否处理流式请求由客户端调用的 `message/stream` 决定。
+
+需要自行配置 session service、memory service 或 Runner 生命周期时，可以改用显式 Runner 和 Agent Card：
+
+```go
+sessionService := sessionmemory.NewSessionService()
+agentRunner := runner.NewRunner(
+    llmAgent.Info().Name,
+    llmAgent,
+    runner.WithSessionService(sessionService),
+)
+defer agentRunner.Close()
+
+card, err := a2aserver.NewAgentCard(
+    llmAgent.Info().Name,
+    llmAgent.Info().Description,
+    "127.0.0.1:8888",
+    true,
+    a2aserver.WithCardTools(llmAgent.Tools()...),
+)
+if err != nil {
+    return err
+}
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+)
+```
+
+`WithAgent` 与 `WithRunner` 互斥。使用显式 Runner 时，Runner 的关闭、session 和 memory 由应用管理，Agent Card 中的地址、streaming capability 和 skills 也由应用维护；`WithSessionService` 只用于旧版服务端隐式创建 Runner 的路径。
+
+`WithHost` 支持带 path 的 URL，path 会成为这个 A2A Server 的 base path。需要在一个端口托管多个旧版 Agent 时，可以为每个 Runner 创建独立的 Server 和 Agent Card，再通过各自的 `Handler()` 挂到同一个 HTTP mux。
+
+### 调用旧版 A2A 服务
+
+旧版远程 Agent 使用不带 `/v1` 的包，并可以通过 URL 自动发现 Agent Card：
+
+```go
+import a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent"
+
+remoteAgent, err := a2aagent.New(
+    a2aagent.WithAgentCardURL("http://127.0.0.1:8888"),
+)
+```
+
+创建完成后，它与其他 Agent 一样通过 Runner 调用：
+
+```go
+clientRunner := runner.NewRunner(
+    "caller-app",
+    remoteAgent,
+    runner.WithSessionService(sessionmemory.NewSessionService()),
+)
+defer clientRunner.Close()
+
+events, err := clientRunner.Run(
+    ctx,
+    "user-1",
+    "session-1",
+    model.NewUserMessage("请介绍一下你能完成的任务"),
+)
+```
+
+旧版 `A2AAgent` 按下面的优先级决定使用 `message/send` 还是 `message/stream`：
+
+1. 单次 Runner 调用传入的 `agent.WithStream(...)`。
+2. 创建 A2AAgent 时传入的 `WithEnableStreaming(...)`。
+3. 远端 Agent Card 的 streaming capability。
+4. 都没有声明时使用非流式调用。
+
+Agent Card 声明的是服务端能力，调用方仍可以通过前两级配置覆盖本次选择；覆盖为 streaming 时，远端服务必须实际支持 `message/stream`。
+
+### 状态、身份和请求扩展
+
+旧版调用链会把调用方 session ID 写入 A2A context ID，服务端再使用这个 context ID 作为自己的 Runner session ID。调用方与服务端仍然拥有相互独立的 session store，协议只传递标识，不会合并两端的对话历史。
+
+调用方 session 中的 user ID 默认通过 `X-User-ID` 发送，服务端将其作为 Runner user ID；两端都可以使用 `WithUserIDHeader` 修改 header 名。缺少该 header 时，当前旧版服务端会创建随机的 `A2A_ANONYMOUS_...` principal，并通过 HttpOnly `trpc_agent_a2a_anon` Cookie 返回；A2A context ID 仍作为 Runner session ID，不再用于生成匿名身份。Cookie Jar 复用和跨实例初始化细节见 [旧版 A2A 指南](a2a.md)。身份传递本身不等于认证和授权。
+
+`WithTransferStateKey` 可以选择需要从当前 invocation `RuntimeState` 写入 Message metadata 的键，支持精确键、`*`、前缀和后缀通配。服务端会把 Message metadata 合入新的 invocation `RuntimeState`，并让 metadata 中的同名值覆盖 `WithRunOptions` 设置的值。
+
+所有传入的 Message metadata 都必须视为客户端可控输入。tenant、role、policy 等鉴权状态必须来自已认证或不可变的服务端上下文，不能通过这条状态传递路径接收。
+
+```go
+token := os.Getenv("A2A_TOKEN")
+
+remoteAgent, err := a2aagent.New(
+    a2aagent.WithAgentCardURL("https://agent.example.com:8888"),
+    a2aagent.WithEnableStreaming(true),
+    a2aagent.WithTransferStateKey("tenant_id", "workflow.*"),
+    a2aagent.WithA2AClientExtraOptions(
+        client.WithTimeout(30*time.Second),
+    ),
+)
+
+events, err := clientRunner.Run(
+    ctx,
+    userID,
+    sessionID,
+    message,
+    agent.WithRuntimeState(map[string]any{
+        "tenant_id":      "tenant-a",
+        "workflow.stage": "review",
+    }),
+    agent.WithA2ARequestOptions(
+        client.WithRequestHeader("Authorization", "Bearer "+token),
+    ),
+)
+```
+
+W3C trace context 会自动通过 HTTP header 传播。生产环境仍应通过底层客户端和服务端的鉴权配置或网关完成认证、授权和资源归属校验；不要把 `X-User-ID` 当作可信凭证。
+
+旧版常用扩展入口如下：
+
+| 场景 | 配置 |
+|---|---|
+| 入站与出站 metadata | `WithProcessMessageHook`、`WithBuildMessageHook` |
+| 每次服务端 Runner 调用 | `WithRunOptions` |
+| 请求 header、超时和底层认证 | `agent.WithA2ARequestOptions`、`WithA2AClientExtraOptions` |
+| 自定义消息和事件转换 | `WithA2AToAgentConverter`、`WithEventToA2AConverter`、`WithCustomA2AConverter`、`WithCustomEventConverter` |
+| 扩展 DataPart 或 Event Part | `WithA2ADataPartMapper`、`WithEventToA2APartMapper` |
+| 出站过滤或改写 | `WithResponseRewriter`、`WithErrorHandler` |
+| Graph 和 ADK 兼容 | `WithGraphEventObjectAllowlist`、`WithADKCompatibility` |
+| 动态 Agent Card、鉴权和中间件 | `WithExtraA2AOptions` |
+
+旧版包还保留 `WithProcessorBuilder`、`WithTaskManagerBuilder`、`WithStreamingEventType`、`WithStreamingRespHandler` 和 `WithStructuredTaskErrors` 等兼容扩展点。它们用于维持既有 v0 应用行为，不代表 v1 的推荐设计；新代码应优先使用 v1 的统一 MessageProcessor、TaskManager 和 converter 扩展边界。
+
+工具调用、代码执行、reasoning 和 `state_delta` 使用的共享 metadata extension 见 [A2A 协议交互规范](a2a-interaction.md)。其中的 metadata key 与交互规范版本同时适用于旧版和 v1 包；`TextPart`、`DataPart`、小写 method 和流式 envelope 示例描述的是 v0.2.x wire model，v1 则通过统一 Part、Message、Artifact 和 Task update event 承载这些共享 metadata。
+
+### v0 Task 管理边界
+
+旧版服务端内部默认创建 memory TaskManager，但这不等于 v1 的保留型 Task 管理。内置非流式适配器会等待 Runner event channel 关闭：只有一个结果时直接返回 Message，有多个结果时合成一个 completed Task；这个 completed Task 没有登记为可供后续 `tasks/get` 查询的保留型 Task。
+
+流式适配器会在当前 `message/stream` 请求期间创建 Task，发送 submitted、artifact 和 completed 事件，并在事件流结束时清理 Task。因此它主要是本次 SSE 的 Task envelope，不能承诺请求结束后仍可查询、取消或重新订阅。
+
+`trpc-a2a-go` 根 module 的协议客户端仍提供 `GetTasks`、`CancelTasks`、`ResubscribeTask` 和 push notification 方法，但这些操作只有在服务端的 processor 和 TaskManager 实际保留并管理对应 Task 时才有意义；v0.2.x 不提供 `ListTasks`。需要稳定的跨请求查询、continuation、多节点存储或取消能力时，优先迁移到 v1，并配置 memory、Redis 或自定义保留型 TaskManager。
+
+v0 wire protocol 中 `message/send` 的 `blocking` 缺省值是 false，但 tRPC-Agent-Go 内置 v0 adapter 的 unary 路径仍会在当前请求中等待 Runner 完成。直接使用底层 v0 protocol client 调用其他实现时，不要依赖这个 adapter 行为；需要等待最终结果应显式设置 `blocking=true`。
+
+### 旧版示例
+
+| 示例 | 内容 |
+|---|---|
+| `examples/a2aagent` | 完整 Server/A2AAgent、隐式或显式 Runner、session 和工具调用 |
+| `examples/a2aagent/customdatapart` | 自定义 DataPart 与 Event extension |
+| `examples/a2amultipath` | 使用 base path 在一个端口托管多个 Agent |
+| `examples/a2asubagent` | 把远程 A2AAgent 用作协调 Agent 的 SubAgent |
+| `examples/a2aadk` | 与 ADK 的工具和代码执行事件互通 |
+| `examples/a2acodeexecution` | 通过旧版扩展传递代码执行事件 |
+| `examples/graph/a2a_agent` | 远程 Graph Agent 与 `state_delta` |
+
+这些示例用于维护 v0.2.x 应用，其中的旧版专有配置不应直接复制到 v1 接入。
+
+## 从 v0.2.x 迁移到 v1.0
+
+迁移到 v1.0 不只是替换 import path。协议 wire model、Server 创建方式、Runner 所有权、Agent Card、TaskManager 默认值以及部分扩展接口都发生了变化，因此应先升级 Server 并提供 v0 兼容入口，再逐步升级 Client。
+
+### v1.0 与 v0.2.x 的接入差异
+
+| 维度 | v0.2.x | v1.0 |
+|---|---|---|
+| Server 输入 | Agent 或 Runner | 显式、由调用方持有的 Runner |
+| Runner 生命周期 | 使用 Agent 时由服务端隐式创建，调用方无法直接管理 | 由调用方创建和关闭 |
+| Agent Card | 通常根据 Agent 和 host 生成 | 显式对外身份和实现版本 |
+| 事件处理 | 多种 result shape 和 callback 风格 `TaskHandler` | 一个 `ExecContext` 对应一条事件 channel |
+| 流式选择 | `MessageProcessor`/API 分支可以选择响应形态 | TaskManager 从同一事件流生成非流式和流式响应 |
+| Task 生命周期 | 内置适配器创建请求内 Task envelope，不提供默认的跨请求保留 | TaskManager 负责 lazy creation、保留和事件分发 |
+| `message/send` 缺省时序 | wire `blocking` 缺省 false；内置 adapter 的 unary 路径仍等待 Runner 完成 | `returnImmediately` 缺省 false，因此阻塞 |
+| wire method 名 | 斜杠分隔，例如 `message/send` | PascalCase，例如 `SendMessage` |
+| Task 列表 | 不提供 | `ListTasks` |
+| 多节点 Task 存储 | 默认链路不保留 Task，需要自行实现 processor 和 backend | 显式选择 stateless、memory 或 Redis |
+
+### 兼容矩阵
+
+在 tRPC-Agent-Go 内置的 `server/a2a/v1` 与 `agent/a2aagent/v1` 之间，v0 兼容是单向的：v1 Server 可以通过兼容层接收 v0.2.x Client 请求，但 v1 Client 不能直接调用旧版 v0.2.x Server。
+
+| Client | v0.2.x Server | v1 Server | v1 Server + `WithV0Compatibility` |
+|---|---:|---:|---:|
+| v0.2.x Client | 支持 | 不支持 | 支持 |
+| v1 Client | 不支持 | 支持 | 支持 |
+
+表中的“支持”表示阻塞和流式消息调用能够进入对应协议链路；非阻塞调用和 Task 控制操作还取决于 v1 Server 是否配置保留型 TaskManager。
+
+仍需服务 v0.2.x Client 时，应在 v1 Server 开启 `WithV0Compatibility()`；不再存在 v0.2.x 流量后可以移除该配置。v1 Client 不能直接调用旧版 v0.2.x Server，因此混部和回滚期间应确保 v1 Client 只被路由到 v1 Server。
+
+### 迁移 Server
+
+旧版 Server 可以直接接收 Agent，并在内部创建 Runner：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a"
+)
+
+server, err := a2aserver.New(
+    a2aserver.WithHost("agent.example.com:8888"),
+    a2aserver.WithAgent(llmAgent, true),
+    a2aserver.WithSessionService(inmemory.NewSessionService()),
+)
+```
+
+v1 Server 要求应用显式创建 Runner 和 Agent Card：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/runner"
+    "trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+    a2aserver "trpc.group/trpc-go/trpc-agent-go/server/a2a/v1"
+)
+
+agentRunner := runner.NewRunner(
+    llmAgent.Info().Name,
+    llmAgent,
+    runner.WithSessionService(inmemory.NewSessionService()),
+)
+defer agentRunner.Close()
+
+card, err := a2aserver.NewAgentCard(
+    llmAgent.Info().Name,
+    llmAgent.Info().Description,
+    "1.0.0",
+    "agent.example.com:8888",
+    true,
+    a2aserver.WithCardTools(llmAgent.Tools()...),
+)
+if err != nil {
+    return err
+}
+
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithV0Compatibility(),
+)
+```
+
+`NewAgentCard` 的 `"1.0.0"` 是 Agent 实现版本，不是 A2A 协议版本。Agent Card 中的地址是发布给客户端的可达地址，并决定 Server 的 base path；传给 `Start` 的地址只决定当前进程监听的位置。
+
+Runner 的 session service、memory 和关闭时机现在都由应用管理。迁移期间保留 `WithV0Compatibility()`，等 v0.2.x Client 全部下线后再移除。
+
+旧版 `WithAgent` 路径使用 Agent Card name 作为 Runner app name。使用持久化 session store 时，迁移后的 `runner.NewRunner` 应继续使用原来的 app name，否则存储 key 会变化，已有会话将无法继续读取。
+
+### 迁移 A2AAgent Client
+
+只使用 `A2AAgent` 默认能力的 Client 通常只需要切换 import path：
+
+```diff
+- a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent"
++ a2aagent "trpc.group/trpc-go/trpc-agent-go/agent/a2aagent/v1"
+```
+
+`WithAgentCardURL`、`WithEnableStreaming`、`WithTransferStateKey` 和 `WithUserIDHeader` 的用途保持不变。使用 `WithAgentCard`、底层 client option、自定义 converter、mapper 或 hook 时，还需要把相关类型和 import 切换到 `trpc-a2a-go/v2`，并按照下一节调整接口签名。
+
+### 配置和扩展接口迁移
+
+只使用默认 Server 和 A2AAgent 能力的用户完成下面的常规配置迁移即可；没有使用自定义 converter、mapper、hook 或旧版分支配置时，可以跳过高级扩展表。
+
+#### 常规配置
+
+| v0.2.x 配置 | v1 迁移方式 |
+|---|---|
+| `WithAgent` | 删除；应用创建 Runner，并配置 `WithRunner` 和 `WithAgentCard` |
+| `WithSessionService` | 删除；改用 `runner.WithSessionService` |
+| `WithHost` | 删除；把公开地址和 base path 写入 Agent Card |
+| `NewAgentCard(name, description, host, streaming)` | 增加必填的 Agent 实现版本参数 |
+| `WithTaskManagerBuilder` | builder 改为返回 `(taskmanager.TaskManager, error)`，相关类型切换到 `trpc-a2a-go/v2` |
+
+#### 高级扩展
+
+| v0.2.x 接口 | v1 迁移方式 |
+|---|---|
+| `WithProcessorBuilder` | 没有一对一替代；包装内置 processor 使用 `WithProcessMessageHook`，完全自定义执行链路时使用 `trpc-a2a-go/v2/server.NewA2AServer(customTaskManager, ...)` |
+| `WithStreamingEventType` | 删除；v1 内置 converter 使用 artifact/status 事件，原来消费 Message 模式流的客户端需要改为消费这些事件，确需其他形态时使用自定义 `EventToA2AConverter` |
+| `WithStructuredTaskErrors` | 删除；v1 使用统一的 Task failure 和结构化错误语义，需要改写已生成的 failure 时使用 `WithResponseRewriter` 或 processor hook |
+| `WithStreamingRespHandler` | 删除；通过统一的 `A2AEventConverter` 转换远程响应，应用继续消费 tRPC-Agent-Go event |
+| `EventToA2AMessage` | 删除 unary 转换方法，只保留返回 `protocol.StreamEvent` 的 `ConvertStreamingToA2AMessage` |
+| `EventToA2APartMapper` | 返回值从 `[]protocol.Part` 改为 `[]*protocol.Part` |
+| `A2AEventConverter` | 输入从 v0 `MessageResult`/`StreamingMessageEvent` 改为 v1 `SendMessageResponse`/`StreamResponse` |
+| `ResponseRewriter` | 从分别处理 unary/streaming 的接口改为处理每个 `StreamEvent` 的函数 |
+| `BuildMessageHook`、`InvocationA2AConverter` | 不再接收 `isStream`；消息构建与传输方式解耦 |
+| `A2ADataPartMapper` | 输入从 v0 `*DataPart` 改为 v1 统一的 `*Part` |
+| 底层 `client`、`server`、`protocol`、`taskmanager` import | 全部切换到 `trpc.group/trpc-go/trpc-a2a-go/v2/...` |
+
+`agent.WithA2ARequestOptions` 接收 `...any`，因此误传旧版 `trpc-a2a-go/client.RequestOption` 仍可能编译，但 v1 A2AAgent 会在运行时拒绝该类型。迁移时应检查这些间接传入的 option，而不能只依赖编译是否成功。
+
+### 迁移时选择 TaskManager
+
+不要因为旧版 Server 内部默认创建 memory TaskManager，就在 v1 中机械地配置 memory。应根据客户端是否需要请求结束后的 Task 操作选择最简单的实现。
+
+| 使用方式 | 推荐 TaskManager | 迁移注意事项 |
+|---|---|---|
+| 普通阻塞调用和流式调用 | 默认 stateless | 对话上下文继续由 Runner session service 保存 |
+| 单实例上的非阻塞调用、Task 查询、取消、重订阅或 continuation | memory | 进程重启会丢失 Task |
+| 多节点上的 Task 查询、列表和跨节点重订阅 | Redis | Runner session store 也要独立配置为共享存储；实时取消仍需路由到执行节点 |
+
+旧版 Client 显式发送 `blocking=false`，或者依赖 `tasks/get`、取消、重新订阅、push notification、`input-required` 和 `auth-required` 时，v1 Server 必须配置保留型 TaskManager。
+
+### 在 v1 Server 上兼容 v0 客户端
+
+v1 `trpc-a2a-go` module 中的 `compat/v0` 会解析冻结的 v0.2.x wire type，转换为 v1 request，调用同一个 TaskManager，再把结果转换回 v0。
+
+tRPC-Agent-Go 通过一个显式配置开启该能力：
+
+```go
+server, err := a2aserver.New(
+    a2aserver.WithRunner(agentRunner),
+    a2aserver.WithAgentCard(card),
+    a2aserver.WithV0Compatibility(),
+)
+```
+
+两代协议使用同一个端点、鉴权链、`MessageProcessor` 和 TaskManager。
+
+原始 `compat/v0` converter 保留 v0 默认语义：未设置 `blocking` 表示非阻塞。tRPC-Agent-Go 的兼容配置只把这个未设置值适配为阻塞，使未修改的 v0 客户端可以使用默认 request-bound TaskManager；显式 `blocking=false` 仍保持非阻塞。
+
+| v0.2.x 客户端操作 | 默认 stateless TaskManager | 保留型 TaskManager |
+|---|---:|---:|
+| 获取 Agent Card | 支持 | 支持 |
+| `message/send` 且未设置 `blocking` 或设置为 true | 支持，阻塞执行 | 支持，阻塞执行 |
+| `message/stream` | 支持 | 支持 |
+| `message/send` 且显式设置 `blocking=false` | 不支持 | 支持 |
+| 请求结束后查询已保留 Task | 不支持 | 支持 |
+| 取消非终态 Task | 不支持 | 支持；实时取消必须路由到执行节点 |
+| 重新订阅非终态 Task | 不支持 | 支持；跨节点重连需要 Redis resubscribe 配置 |
+| push notification 配置 | 不支持 | TaskManager 另行开启 push 后支持 |
+
+stateless TaskManager 会拒绝显式非阻塞请求，因为 request-bound execution 无法在 HTTP 响应结束后继续可靠执行。流式请求也必须在当前请求内到达终态；`input-required` 和 `auth-required` 等需要后续 continuation 的状态仍需要保留型 TaskManager。
+
+配置保留型 TaskManager 后，两代协议通过同一个兼容 Server 看到的是同一组 Task：v0.2.x 创建的 Task 可以通过 v1 查询，v1 创建的 Task 也可以通过 v0.2.x 查询，两代协议也能观察同一个 Task 的取消状态。这个结论只适用于同一个 v1 Server 和同一个 TaskManager，不表示旧版 v0.2.x Server 可以读取 v1 TaskManager 的内部存储。
+
+### 兼容保证和已知差异
+
+兼容层的目标是让旧版请求进入新的执行链路并保持业务语义，不是逐字节复刻旧版 Server 的 wire 响应。
+
+使用当前版本的 tRPC-Agent-Go legacy `A2AAgent` 和 v1 `A2AAgent` 调用时，集成测试覆盖了 Agent Card 发现、阻塞和流式文本、user ID、context/session ID、RuntimeState、reasoning、工具调用和结果、代码执行、`state_delta`、文件和多模态内容。`A2AAgent` 会把两代协议结果转换为统一的 tRPC-Agent-Go event，因此上层 Agent 通常不需要感知底层结果类型。
+
+迁移时仍需处理下列可观察差异：
+
+- 旧版内置 Server 的 unary 调用在只有一个结果时可能直接返回 `Message`，而 v1 Server 的 v0 兼容路径会返回 request-local completed `Task`；直接对 `MessageResult.Result` 做具体类型断言的代码需要同时处理两种结果。
+- v1 text/data Part 上的 `filename` 和 `mediaType` 转换为 v0 时无法完整保留。
+- 文件标识可能在 `FileID` 和 URL 之间归一化，兼容 Server 也可能返回旧版 Server 没有提供的更完整 `ContentParts`。
+- 流式响应中的 v0 `final` 由 v1 事件流推导，不能假定与旧版每个 frame 的边界完全相同。
+- v0 push notification 配置中的多个 authentication scheme 转换为 v1 时只能保留第一个。
+- Message ID、Task ID、时间戳、枚举值和原始 JSON 结构不属于跨协议逐字段相等的保证。
+
+兼容层面向 tRPC-Agent-Go 使用的 v0.2.x wire，当前直接协议客户端的自动化兼容回归基线为 `trpc-a2a-go v0.2.5`。历史 tRPC-Agent-Go 版本中的 legacy `A2AAgent`、其他 v0.2.x 版本、自定义 converter/hook、网关鉴权、真实 push 投递、continuation、Redis 重启和跨节点执行等场景，应使用应用自身的依赖版本和部署拓扑做端到端回归。
+
+## 协议使用指南
+
+按照客户端的实际需求选择最简单的交互方式：
+
+| 客户端需求 | 协议操作 | 状态要求 |
+|---|---|---|
+| 等待一次回答 | 阻塞 `SendMessage` | stateless 即可 |
+| 实时渲染 token 或进度 | `SendStreamingMessage` | stateless 即可 |
+| 发起工作后断开 | `SendMessage` + `returnImmediately=true` | 保留型 TaskManager |
+| 后续轮询 | `GetTask` 或 `ListTasks` | 保留型 TaskManager；终态 Task 也可以查询 |
+| 重新连接事件流 | `SubscribeToTask` | 非终态 Task；跨节点重连需要 Redis 配置 |
+| 停止正在执行的工作 | `CancelTask` | 可取消的非终态 Task，并能路由到执行节点 |
+| 回答 Agent 的追问 | 携带相同 Task ID 发送 Message | 已保留的挂起 Task |
+
+标识符规则：
+
+- A2A context ID 会成为服务端 Runner 的 session ID。
+- `X-User-ID` 会成为 Runner user ID；缺省时服务端根据 context ID 生成稳定 user ID。
+- Task ID 标识一个 A2A Task 生命周期，不是对话 session；同一个 Task 可以跨越多个 continuation round。
+- 继续 `input-required` 或 `auth-required` 时必须携带原 Task ID。
+
+仅仅保留 Task 不会让 Agent 自动支持中断。`MessageProcessor` 或 converter 必须产生 `input-required` 或 `auth-required`，应用也要保存继续执行所需的业务状态。
+
+## 更多示例
+
+前面的 v1 示例使用 A2AAgent 完成普通 Agent invocation。需要观察异步 Task 创建、查询和列表时，可以让服务端改用 Memory TaskManager 并运行 taskclient：
+
+```bash
+cd examples
+go run ./a2aagent/v1/server -retain-tasks
+
+# 在另一个终端中执行。
+cd examples
+go run ./a2aagent/v1/taskclient
+```
+
+旧版 v0.2.x 的 Server、A2AAgent、多 Agent 托管和扩展事件示例已经在前面的“旧版示例”章节列出。
+
+更底层的协议示例，包括 Redis、鉴权、push notification、input-required continuation 和直接实现 `MessageProcessor`，请参考 [`trpc-a2a-go` examples](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples)。

--- a/docs/mkdocs/zh/blog/multiagent-boundaries.md
+++ b/docs/mkdocs/zh/blog/multiagent-boundaries.md
@@ -200,5 +200,5 @@ UI 不展示内部过程，不代表父 Agent 不需要结果；trace 里有完�
 - [Team 文档](../team.md)
 - [TaskRun 文档](../taskrun.md)
 - [Graph 文档](../graph.md)
-- [A2A 文档](../a2a.md)
+- [A2A v1.0 文档](../a2a_v1.md)
 - [Tool 文档](../tool.md)

--- a/docs/mkdocs/zh/dify.md
+++ b/docs/mkdocs/zh/dify.md
@@ -550,4 +550,4 @@ func (c *MyConverter) ConvertToDifyRequest(...) (*dify.ChatMessageRequest, error
 - [Dify 官方文档](https://docs.dify.ai/)
 - [Dify SDK Go](https://github.com/cloudernative/dify-sdk-go)
 - [tRPC-Agent-Go 文档](https://github.com/trpc-group/trpc-agent-go/blob/main/README.zh_CN.md)
-- [A2A 集成指南](./a2a.md)
+- [A2A v1.0 集成指南](./a2a_v1.md)

--- a/examples/a2aagent/v1/README.md
+++ b/examples/a2aagent/v1/README.md
@@ -57,7 +57,7 @@ The client keeps using the same session ID until you switch it:
 Ask for the current time (for example, "What time is it in Asia/Shanghai?")
 to see the `current_time` tool call and tool result cross the A2A boundary.
 
-Use `-streaming=false` on the server to exercise blocking `message/send`.
+Use `-streaming=false` on the server to exercise blocking `SendMessage`.
 The client discovers the streaming capability from the Agent Card.
 
 The example uses in-memory session storage, so restarting the server clears its
@@ -86,14 +86,8 @@ go run ./a2aagent/v1/taskclient \
 
 The server and task client read retained-task credentials only from these environment variables; command-line credential flags are intentionally not provided.
 
-The task client sends `message/send` with `returnImmediately=true`, receives an
-immediate Task snapshot, polls it with `tasks/get`, and finally verifies it with
-`tasks/list`. The memory TaskManager also enables retained lookup, cancellation,
-and resubscription. Continuation still requires a processor that emits an
-interrupted state, and push delivery requires additional push configuration.
+The task client calls `SendMessage` with `returnImmediately=true`, receives an immediate Task snapshot, polls it through the Go method `GetTasks` (v1 wire operation `GetTask`), and verifies it through `ListTasks`. The memory TaskManager also retains the state required by `CancelTasks` (`CancelTask`) and `ResubscribeTask` (`SubscribeToTask`), but those operations only apply to eligible non-terminal Tasks and are not exercised by this client. Continuation still requires a processor that emits an interrupted state, and push delivery requires additional push configuration.
 
 The retained example authenticates `X-API-Key`, maps it to a trusted user ID on the server, and scopes Tasks to that identity. All send, lookup, list, cancel, and resubscribe requests for one Task must use a key mapped to the same user; a caller-supplied `X-User-ID` does not grant access.
 
-Session state and A2A Task state remain independent: the Runner's session
-service owns conversation context, while the memory TaskManager retains A2A
-Task lifecycle state. Both are cleared when the server process restarts.
+Session state and A2A Task state remain independent: the Runner's session service owns conversation context, while the memory TaskManager retains A2A Task lifecycle state. Both are cleared when the server process restarts.


### PR DESCRIPTION
## Summary

- preserve the existing English and Chinese A2A v0.2.x guides at `docs/mkdocs/{en,zh}/a2a.md`
- add `docs/mkdocs/{en,zh}/a2a_v1.md` for A2A v1.0 architecture, TaskManager boundaries, legacy compatibility, and migration
- clarify the shared interaction-extension metadata and the version-specific wire carriers
- refresh the v1 taskclient README with Go method names and their wire operations

## Why

The original update replaced the existing A2A guide and conflicted with newer legacy documentation on `main`. Keeping separate versioned guides preserves the current v0.2.x material while making v1.0 the recommended path.

## Compatibility

The v1 guide documents opt-in `WithV0Compatibility()`, stateless and retaining TaskManagers, Runner session ownership, and multi-node storage boundaries. The interaction extension remains shared across v0.2.x and v1.0; only legacy Part types, method names, and streaming envelopes are v0.2.x-specific.

## Checks

- `mkdocs build --strict -f docs/mkdocs.yml`
- `typos docs/mkdocs.yml docs/mkdocs/{en,zh}/a2a.md docs/mkdocs/{en,zh}/a2a_v1.md docs/mkdocs/{en,zh}/a2a-interaction.md examples/a2aagent/v1/README.md`
- `GOWORK=off go test ./server/a2a/v1 ./agent/a2aagent/v1`
- `GOWORK=off go test ./a2aagent/v1/...` (from `examples/`)
- `git diff --check`
