### PR TITLE
session/redis: document Redis compatibility

### DIFF
--- a/docs/mkdocs/en/session/redis.md
+++ b/docs/mkdocs/en/session/redis.md
@@ -12,6 +12,30 @@ Redis storage is suitable for production environments and distributed applicatio
 - Async session summary generation
 - AppendEvent / GetSession hook extension points
 
+## Redis Compatibility
+
+The Redis Session service is command-compatible with Redis OSS 4.0 and later. Redis 4.0 is the documented compatibility floor, not a production recommendation; use a release that is still maintained by your Redis vendor in production.
+
+The service currently relies on the following data-path commands:
+
+| Capability | Commands |
+| --- | --- |
+| Keys and strings | `DEL`, `EXISTS`, `EXPIRE`, `GET`, `PERSIST`, `PEXPIRE`, `PTTL`, `SCAN`, `SET`, `SETNX` |
+| Hashes | `HDEL`, `HEXISTS`, `HGET`, `HGETALL`, `HINCRBY`, `HMGET`, `HSCAN`, `HSET` |
+| Sets | `SADD`, `SMEMBERS` |
+| Sorted sets | `ZADD`, `ZRANGE`, `ZRANGEBYSCORE`, `ZRANK`, `ZREM`, `ZREVRANGE`, `ZREVRANGEBYSCORE` |
+| Scripting and transactions | `EVAL`, `EVALSHA`, `WATCH`, `UNWATCH`, `MULTI`, `EXEC` |
+
+Only the command forms used by this service are required; optional modifiers introduced in later Redis releases are not prerequisites. The Lua scripts use the Redis Lua 5.1 environment and `cjson`.
+
+Redis Standalone, Sentinel, and Cluster deployments are compatible when the client builder returns the corresponding `go-redis` client. The default builder used by `WithRedisClientURL` creates a single-node client from one address. Configure Sentinel or Cluster with a custom builder through `storage/redis.SetClientBuilder`.
+
+In Cluster mode, all keys used by a multi-key Lua script or transaction must be in the same hash slot. The built-in key formats use `{userID}` or `{appName}` hash tags to satisfy this requirement, and the user-scoped `SCAN` pattern contains the same fixed hash tag so that the cluster client can route it to the slot owner.
+
+For Redis-compatible proxies or alternative backends, validate `SCAN`/`HSCAN`, Lua 5.1 with `cjson`, transactions, and script-cache behavior separately. Use `WithDisableScriptCache(true)` to execute scripts with `EVAL` only when `EVALSHA` caching is unreliable. Depending on the connection URL, the bundled `go-redis` client may also issue `AUTH`, `SELECT`, and `CLIENT SETNAME`, and probe newer commands such as `HELLO` and `CLIENT SETINFO`. Redis OSS 4.0 returns normal errors for unsupported probes and the client falls back or continues, while proxies that close connections on unknown commands require separate validation.
+
+Redis 4.x and 5.x do not support ACL usernames. When authentication is enabled on these versions, use password-only authentication, for example `redis://:password@127.0.0.1:6379/0`. Username-and-password authentication requires Redis 6.0 or later.
+
 ## Configuration Options
 
 **Connection:**

--- a/docs/mkdocs/zh/session/redis.md
+++ b/docs/mkdocs/zh/session/redis.md
@@ -12,6 +12,30 @@ Redis 存储适用于生产环境和分布式应用，提供高性能和自动�
 - 会话摘要（Summary）异步生成
 - AppendEvent / GetSession Hook 扩展点
 
+## Redis 兼容性
+
+Redis Session Service 使用的命令兼容 Redis OSS 4.0 及以上版本。Redis 4.0 是文档声明的兼容下限，并非生产环境推荐版本；生产环境应使用 Redis 厂商仍在维护的版本。
+
+当前服务依赖以下数据访问命令：
+
+| 能力 | 命令 |
+| --- | --- |
+| Key 与字符串 | `DEL`、`EXISTS`、`EXPIRE`、`GET`、`PERSIST`、`PEXPIRE`、`PTTL`、`SCAN`、`SET`、`SETNX` |
+| Hash | `HDEL`、`HEXISTS`、`HGET`、`HGETALL`、`HINCRBY`、`HMGET`、`HSCAN`、`HSET` |
+| Set | `SADD`、`SMEMBERS` |
+| Sorted Set | `ZADD`、`ZRANGE`、`ZRANGEBYSCORE`、`ZRANK`、`ZREM`、`ZREVRANGE`、`ZREVRANGEBYSCORE` |
+| Lua 与事务 | `EVAL`、`EVALSHA`、`WATCH`、`UNWATCH`、`MULTI`、`EXEC` |
+
+这里只要求当前服务实际使用的命令形式，不依赖后续 Redis 版本新增的可选参数。Lua 脚本使用 Redis 的 Lua 5.1 环境和 `cjson`。
+
+Redis Standalone、Sentinel 和 Cluster 均可兼容，但 client builder 必须返回与部署模式对应的 `go-redis` 客户端。`WithRedisClientURL` 使用的默认 builder 只会根据单个地址创建单节点客户端；使用 Sentinel 或 Cluster 时，需要通过 `storage/redis.SetClientBuilder` 配置自定义 builder。
+
+在 Cluster 模式下，同一个多 Key Lua 脚本或事务涉及的所有 Key 必须位于同一 hash slot。内置 Key 格式通过 `{userID}` 或 `{appName}` hash tag 满足该要求；按用户执行的 `SCAN` pattern 也包含相同的固定 hash tag，Cluster 客户端可以将其路由到对应 slot 所在节点。
+
+对于 Redis 兼容代理或其他兼容实现，需要单独验证 `SCAN`/`HSCAN`、Lua 5.1 与 `cjson`、事务及脚本缓存行为。若后端的 `EVALSHA` 缓存不可靠，可使用 `WithDisableScriptCache(true)` 仅通过 `EVAL` 执行脚本。根据连接 URL 的配置，内置 `go-redis` 客户端还可能发送 `AUTH`、`SELECT`、`CLIENT SETNAME`，并探测 `HELLO`、`CLIENT SETINFO` 等较新的命令。Redis OSS 4.0 会为不支持的探测命令返回普通错误，客户端随后回退或继续初始化，但遇到未知命令时直接断开连接的代理需要另行验证。
+
+Redis 4.x 和 5.x 不支持 ACL 用户名。这些版本启用鉴权时应仅配置密码，例如 `redis://:password@127.0.0.1:6379/0`；用户名加密码的鉴权方式要求 Redis 6.0 及以上版本。
+
 ## 配置选项
 
 **连接配置：**


### PR DESCRIPTION
## Summary

- document Redis OSS 4.0+ command compatibility for the Redis Session service
- list the current data-path commands, including the latest Set and TTL operations
- clarify Standalone, Sentinel, and Cluster client requirements and same-slot behavior
- document Redis-compatible proxy checks, connection probes, and pre-Redis 6 authentication constraints

## Why

The Redis Session documentation described supported deployment modes but did not state a version compatibility floor or the command and client assumptions behind that support. This made it difficult to assess older Redis deployments and Redis-compatible proxies.

## Impact

Users can now distinguish command compatibility from production version recommendations, configure Cluster or Sentinel with the required custom client builder, and identify the capabilities that alternative backends must provide.

## Validation

- `mkdocs build --strict`
- `cd session/redis && go test ./...`
- Redis 4.0.14 three-master Cluster smoke, run five times, covering HashIdx `SCAN`/`HSCAN`, `EVALSHA` fallback to `EVAL`, TTL, window, summary, track, trim, delete, legacy `WATCH`/`MULTI`/`EXEC`, and the latest `SADD`/`SMEMBERS`/`PERSIST` paths