### PR TITLE
openclaw/app: support request-scoped model selection

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -834,6 +834,97 @@ go run ./cmd/openclaw \
 By default, `-model` uses `$OPENAI_MODEL` if set, otherwise it falls
 back to `gpt-5`.
 
+### Request-scoped model selection
+
+An OpenClaw runtime can pre-register multiple models under stable aliases:
+
+```yaml
+model:
+  default: balanced
+  models:
+    balanced:
+      mode: openai
+      name: deepseek-v4-pro
+      openai_variant: deepseek
+      base_url: "${DEEPSEEK_BASE_URL}"
+    fast:
+      mode: openai
+      name: deepseek-v4-flash
+      openai_variant: deepseek
+      base_url: "${DEEPSEEK_BASE_URL}"
+    strong:
+      mode: openai
+      name: gpt-5
+      openai_variant: openai
+      base_url: "${OPENAI_BASE_URL}"
+```
+
+Request-scoped selection is available for the default `agent-type: llm`.
+`model.default` must name an entry in `model.models`. A `generation_config`
+alongside `default` is shared by all entries. The legacy single-model fields
+(`model.mode`, `model.name`, and related provider fields) remain supported,
+but must not be mixed with `model.models`.
+
+For OpenAI-compatible YAML entries, OpenClaw uses the variant-specific
+credential when configured (`DEEPSEEK_API_KEY`, `DASHSCOPE_API_KEY`,
+`MINIMAX_API_KEY`, or `MOONSHOT_API_KEY`) and otherwise falls back to
+`OPENAI_API_KEY`.
+
+Gateway callers select one configured alias for a single run with the
+top-level `model` field:
+
+```json
+{
+  "from": "user-1",
+  "session_id": "conversation-1",
+  "text": "Analyze this issue",
+  "model": "strong"
+}
+```
+
+Omitting `model` uses `model.default`. An unknown alias is rejected with HTTP
+400 and `error.type = "invalid_model"`; the OpenClaw Gateway never silently
+falls back to the default model. Explicit request selection takes precedence
+over a runtime profile's `model_name`. The selection applies to the current
+main-agent run; session summaries, automatic memory processing, titles, and
+separately hosted subagents continue to use their configured defaults.
+
+Embedded distributions may supply already constructed model instances:
+
+```go
+rt, err := app.NewRuntimeWithOptions(
+    ctx,
+    args,
+    app.WithModelCatalog(app.ModelCatalog{
+        Default: "balanced",
+        Models: map[string]model.Model{
+            "balanced": balancedModel,
+            "strong": strongModel,
+        },
+        Metadata: map[string]app.ModelMetadata{
+            "balanced": {
+                Mode:          "openai",
+                OpenAIVariant: "deepseek",
+                BaseURL:       "https://api.deepseek.com/v1",
+            },
+            "strong": {
+                Mode:          "openai",
+                OpenAIVariant: "openai",
+            },
+        },
+    }),
+)
+```
+
+`WithModelCatalog` is mutually exclusive with YAML `model.models`. Requests
+only carry aliases; model base URLs, credentials, headers, and other provider
+configuration remain server-side. `Metadata` is optional and defaults to the
+legacy top-level model settings. Embedded catalogs should provide it when
+entries use different provider variants or base URLs so OpenClaw can apply
+provider-specific gateway compatibility and deadline-finalization behavior for
+the selected alias. To explicitly clear an inherited base URL, set
+`BaseURLSet: true` with an empty `BaseURL`.
+
 You can override the OpenAI-compatible base URL with:
 
 - `OPENAI_BASE_URL` (environment), or

--- a/openclaw/README.zh_CN.md
+++ b/openclaw/README.zh_CN.md
@@ -679,6 +679,94 @@ go run ./cmd/openclaw \
 
 默认情况下，`-model` 使用 `$OPENAI_MODEL`（如已设置），否则回退到 `gpt-5`。
 
+### 请求级模型选择
+
+OpenClaw runtime 可以通过稳定别名预注册多个模型：
+
+```yaml
+model:
+  default: balanced
+  models:
+    balanced:
+      mode: openai
+      name: deepseek-v4-pro
+      openai_variant: deepseek
+      base_url: "${DEEPSEEK_BASE_URL}"
+    fast:
+      mode: openai
+      name: deepseek-v4-flash
+      openai_variant: deepseek
+      base_url: "${DEEPSEEK_BASE_URL}"
+    strong:
+      mode: openai
+      name: gpt-5
+      openai_variant: openai
+      base_url: "${OPENAI_BASE_URL}"
+```
+
+请求级选择适用于默认的 `agent-type: llm`。`model.default` 必须指向
+`model.models` 中的一个条目。与 `default` 同级的
+`generation_config` 由所有条目共享。原有的单模型字段
+（`model.mode`、`model.name` 及相关 provider 字段）继续受支持，
+但不能与 `model.models` 混用。
+
+对于 OpenAI 兼容的 YAML 条目，OpenClaw 会优先使用已配置的
+variant 专属凭据（`DEEPSEEK_API_KEY`、`DASHSCOPE_API_KEY`、
+`MINIMAX_API_KEY` 或 `MOONSHOT_API_KEY`），否则回退到
+`OPENAI_API_KEY`。
+
+Gateway 调用方可以通过顶层 `model` 字段为单次 run 选择一个已配置别名：
+
+```json
+{
+  "from": "user-1",
+  "session_id": "conversation-1",
+  "text": "分析这个问题",
+  "model": "strong"
+}
+```
+
+省略 `model` 时使用 `model.default`。未知别名会返回 HTTP 400，且
+`error.type = "invalid_model"`；OpenClaw Gateway 不会静默回退到默认
+模型。请求显式选择的优先级高于 runtime profile 的 `model_name`。
+该选择作用于当前主 agent run；session 摘要、自动 memory 处理、标题和
+独立托管的 subagent 继续使用各自配置的默认模型。
+
+嵌入式发行版可以提供已经构造好的模型实例：
+
+```go
+rt, err := app.NewRuntimeWithOptions(
+    ctx,
+    args,
+    app.WithModelCatalog(app.ModelCatalog{
+        Default: "balanced",
+        Models: map[string]model.Model{
+            "balanced": balancedModel,
+            "strong": strongModel,
+        },
+        Metadata: map[string]app.ModelMetadata{
+            "balanced": {
+                Mode:          "openai",
+                OpenAIVariant: "deepseek",
+                BaseURL:       "https://api.deepseek.com/v1",
+            },
+            "strong": {
+                Mode:          "openai",
+                OpenAIVariant: "openai",
+            },
+        },
+    }),
+)
+```
+
+`WithModelCatalog` 与 YAML `model.models` 互斥。请求只携带别名；
+模型 base URL、凭据、header 及其他 provider 配置继续保留在服务端。
+`Metadata` 是可选字段，默认继承原有顶层模型设置。嵌入式模型目录中的
+条目使用不同 provider 变体或 base URL 时，应提供对应元数据，以便
+OpenClaw 根据本次选择的别名应用 provider 专属的 Gateway 兼容处理和
+deadline finalization 行为。如需显式清空继承的 base URL，请将
+`BaseURLSet` 设为 `true`，并将 `BaseURL` 留空。
+
 你可以通过以下方式覆盖 OpenAI 兼容的 base URL：
 
 - `OPENAI_BASE_URL`（环境变量），或

--- a/openclaw/app/admin_runtime_config.go
+++ b/openclaw/app/admin_runtime_config.go
@@ -48,8 +48,9 @@ var runtimeAdminOptionsStore sync.Map
 const AdminSourceConfigPathEnvName = "TRPC_CLAW_ADMIN_SOURCE_CONFIG_PATH"
 
 type adminRuntimeConfigProvider struct {
-	configPath string
-	opts       runOptions
+	configPath         string
+	opts               runOptions
+	modelCatalogActive bool
 }
 
 type adminRuntimeConfigKeyRef struct {
@@ -85,14 +86,16 @@ type adminRuntimeConfiguredValue struct {
 
 func buildAdminRuntimeConfigProvider(
 	opts runOptions,
+	catalogs ...resolvedModelCatalog,
 ) admin.RuntimeConfigProvider {
 	path := adminWritableConfigPath(opts.ConfigPath)
 	if path == "" {
 		return nil
 	}
 	return &adminRuntimeConfigProvider{
-		configPath: path,
-		opts:       opts,
+		configPath:         path,
+		opts:               opts,
+		modelCatalogActive: explicitModelCatalogConfigured(catalogs),
 	}
 }
 
@@ -106,8 +109,11 @@ func adminWritableConfigPath(configPath string) string {
 	return strings.TrimSpace(configPath)
 }
 
-func buildAdminOptions(opts runOptions) []admin.Option {
-	provider := buildAdminRuntimeConfigProvider(opts)
+func buildAdminOptions(
+	opts runOptions,
+	catalogs ...resolvedModelCatalog,
+) []admin.Option {
+	provider := buildAdminRuntimeConfigProvider(opts, catalogs...)
 	if provider == nil {
 		return nil
 	}
@@ -171,8 +177,13 @@ func (p *adminRuntimeConfigProvider) RuntimeConfigStatus() (
 			len(adminRuntimeConfigSectionSpecs()),
 		),
 	}
+	modelCatalogActive := p.modelCatalogActive ||
+		adminRuntimeConfigHasModelCatalog(root)
 	visibleValues := map[string]string{}
 	for _, section := range adminRuntimeConfigSectionSpecs() {
+		if modelCatalogActive && section.Key == "model" {
+			continue
+		}
 		view := admin.RuntimeConfigSection{
 			Key:     section.Key,
 			Title:   section.Title,
@@ -247,6 +258,13 @@ func (p *adminRuntimeConfigProvider) SaveRuntimeConfigValue(
 	if err != nil {
 		return err
 	}
+	if (p.modelCatalogActive || adminRuntimeConfigHasModelCatalog(root)) &&
+		strings.HasPrefix(spec.Key, "model.") {
+		return fmt.Errorf(
+			"model runtime config fields are unavailable " +
+				"when a model catalog is configured",
+		)
+	}
 	if spec.Key == "tools.code_executor.type" && strings.TrimSpace(value) == "" {
 		adminRuntimeDeleteField(root, spec.Path)
 	} else {
@@ -284,6 +302,23 @@ func (p *adminRuntimeConfigProvider) ResetRuntimeConfigValue(
 		return err
 	}
 	return writeConfigDocument(p.configPath, &doc)
+}
+
+func explicitModelCatalogConfigured(
+	catalogs []resolvedModelCatalog,
+) bool {
+	return len(catalogs) > 0 && catalogs[0].explicit
+}
+
+func adminRuntimeConfigHasModelCatalog(root *yaml.Node) bool {
+	modelNode := adminRuntimeLookupMappingValue(
+		root,
+		adminRuntimeKey("model"),
+	)
+	return adminRuntimeLookupMappingValue(
+		modelNode,
+		adminRuntimeKey("models"),
+	) != nil
 }
 
 func adminRuntimeConfigSectionSpecs() []adminRuntimeConfigSectionSpec {

--- a/openclaw/app/admin_runtime_config_test.go
+++ b/openclaw/app/admin_runtime_config_test.go
@@ -105,6 +105,94 @@ func TestBuildAdminOptions_UsesAdminSourceConfigPathEnv(t *testing.T) {
 	require.Contains(t, string(runtimeData), "max_loaded_skills: 7")
 }
 
+func TestAdminRuntimeConfigProvider_ModelCatalogHidesAndRejectsLegacyModelFields(
+	t *testing.T,
+) {
+	cfgPath := writeAdminRuntimeConfigTestFile(
+		t,
+		"model:\n  base_url: https://legacy.example.com/v1\n",
+	)
+	opts := adminRuntimeConfigTestOptions(cfgPath)
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+		resolvedModelCatalog{explicit: true},
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	for _, section := range status.Sections {
+		require.NotEqual(t, "model", section.Key)
+	}
+
+	err = provider.SaveRuntimeConfigValue(
+		"model.base_url",
+		"https://api.example.com/v1",
+	)
+	require.ErrorContains(
+		t,
+		err,
+		"unavailable when a model catalog is configured",
+	)
+	require.NoError(t, provider.ResetRuntimeConfigValue("model.base_url"))
+
+	data, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "base_url")
+	require.NotContains(t, string(data), "openai_variant")
+}
+
+func TestAdminRuntimeConfigProvider_SourceCatalogProtectedForLegacyRuntime(
+	t *testing.T,
+) {
+	sourcePath := writeAdminRuntimeConfigTestFile(
+		t,
+		"model:\n"+
+			"  default: fast\n"+
+			"  models:\n"+
+			"    fast:\n"+
+			"      mode: mock\n"+
+			"  base_url: https://stale.example.com/v1\n",
+	)
+	runtimePath := writeAdminRuntimeConfigTestFile(
+		t,
+		"model:\n  mode: mock\n",
+	)
+	t.Setenv(AdminSourceConfigPathEnvName, sourcePath)
+
+	opts := adminRuntimeConfigTestOptions(runtimePath)
+	provider, ok := buildAdminRuntimeConfigProvider(
+		opts,
+	).(*adminRuntimeConfigProvider)
+	require.True(t, ok)
+	require.False(t, provider.modelCatalogActive)
+
+	status, err := provider.RuntimeConfigStatus()
+	require.NoError(t, err)
+	for _, section := range status.Sections {
+		require.NotEqual(t, "model", section.Key)
+	}
+	err = provider.SaveRuntimeConfigValue(
+		"model.openai_variant",
+		"openai",
+	)
+	require.ErrorContains(
+		t,
+		err,
+		"unavailable when a model catalog is configured",
+	)
+
+	require.NoError(t, provider.ResetRuntimeConfigValue("model.base_url"))
+	sourceData, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	require.NotContains(t, string(sourceData), "base_url")
+	require.Contains(t, string(sourceData), "models:")
+
+	runtimeData, err := os.ReadFile(runtimePath)
+	require.NoError(t, err)
+	require.Contains(t, string(runtimeData), "mode: mock")
+}
+
 func TestBuildAdminOptions_WithoutConfigPath(t *testing.T) {
 	t.Parallel()
 

--- a/openclaw/app/app.go
+++ b/openclaw/app/app.go
@@ -532,10 +532,14 @@ const (
 	kimiAPIHost      = "api.moonshot.ai"
 	kimiCNAPIHost    = "api.moonshot.cn"
 
-	openAIAPIKeyEnvName  = "OPENAI_API_KEY"
-	openAIBaseURLEnvName = "OPENAI_BASE_URL"
-	openAIHeadersEnvName = "OPENAI_HEADERS"
-	openAIModelEnvName   = "OPENAI_MODEL"
+	openAIAPIKeyEnvName   = "OPENAI_API_KEY"
+	deepSeekAPIKeyEnvName = "DEEPSEEK_API_KEY"
+	qwenAPIKeyEnvName     = "DASHSCOPE_API_KEY"
+	miniMaxAPIKeyEnvName  = "MINIMAX_API_KEY"
+	kimiAPIKeyEnvName     = "MOONSHOT_API_KEY"
+	openAIBaseURLEnvName  = "OPENAI_BASE_URL"
+	openAIHeadersEnvName  = "OPENAI_HEADERS"
+	openAIModelEnvName    = "OPENAI_MODEL"
 
 	errClaudeCodeAgentNoPrompts = "claude-code agent does not support " +
 		"agent prompts"
@@ -660,6 +664,7 @@ func runtimeStartupLines(
 	stateDir string,
 	channels []channel.Channel,
 	needsModel bool,
+	catalogs ...resolvedModelCatalog,
 ) []startupLogLine {
 	return []startupLogLine{
 		{text: fmt.Sprintf("App name: %s", strings.TrimSpace(opts.AppName))},
@@ -674,7 +679,7 @@ func runtimeStartupLines(
 		)},
 		{text: fmt.Sprintf(
 			"Model: %s",
-			modelStartupSummary(opts, needsModel),
+			modelStartupSummary(opts, needsModel, catalogs...),
 		)},
 		{text: fmt.Sprintf(
 			"Storage: session=%s memory=%s",
@@ -715,9 +720,17 @@ func channelStartupSummary(channels []channel.Channel) string {
 func modelStartupSummary(
 	opts runOptions,
 	needsModel bool,
+	catalogs ...resolvedModelCatalog,
 ) string {
 	if !needsModel {
 		return "disabled"
+	}
+	if len(catalogs) > 0 && catalogs[0].explicit {
+		return fmt.Sprintf(
+			"%s (%d configured)",
+			catalogs[0].defaultAlias(),
+			len(catalogs[0].models),
+		)
 	}
 	mode := strings.ToLower(strings.TrimSpace(opts.ModelMode))
 	if mode == "" {
@@ -820,6 +833,8 @@ type Runtime struct {
 	modelCallBudgetFinalizeOnLast bool
 	modelCallBudgetDeadlineWindow time.Duration
 	modelCallBudgetFinalRequest   modelCallBudgetFinalRequestConfig
+	modelCatalog                  resolvedModelCatalog
+	modelRunOptions               runOptions
 }
 
 // Gateway provides the HTTP handler and routes served by OpenClaw.
@@ -1064,6 +1079,16 @@ func NewRuntimeWithOptions(
 			Err:  fmt.Errorf("agent config failed: %w", err),
 		}
 	}
+	if err := validateModelCatalogAgentType(
+		agentType,
+		opts,
+		runtimeOpts,
+	); err != nil {
+		return nil, &exitError{
+			Code: 1,
+			Err:  fmt.Errorf("agent config failed: %w", err),
+		}
+	}
 
 	mentionPatterns := splitCSV(opts.Mention)
 
@@ -1100,16 +1125,29 @@ func NewRuntimeWithOptions(
 		opts.SessionSummaryEnabled ||
 		opts.MemoryAutoEnabled
 
-	var mdl model.Model
+	var (
+		mdl          model.Model
+		modelCatalog resolvedModelCatalog
+	)
 	if needsModel {
-		mdl, err = modelFromOptions(opts)
+		modelCatalog, err = resolveModelCatalog(opts, runtimeOpts)
 		if err != nil {
 			return nil, &exitError{
 				Code: 1,
 				Err:  fmt.Errorf("create model failed: %w", err),
 			}
 		}
-		mdl = newModelCallBudgetModel(mdl)
+		mdl = modelCatalog.defaultModel()
+		if err := validateRuntimeProfileModels(
+			agentType,
+			opts.RuntimeProfiles,
+			modelCatalog,
+		); err != nil {
+			return nil, &exitError{
+				Code: 1,
+				Err:  fmt.Errorf("model catalog validation failed: %w", err),
+			}
+		}
 	}
 
 	instanceID := runtimeInstanceID(
@@ -1117,6 +1155,7 @@ func NewRuntimeWithOptions(
 		opts,
 		needsModel,
 		resolvedStateDir,
+		modelCatalog,
 	)
 	log.Infof("Instance: %s", instanceID)
 	rt.appName = opts.AppName
@@ -1225,6 +1264,7 @@ func NewRuntimeWithOptions(
 		)
 		agentCfg := agentConfig{
 			AppName:                 opts.AppName,
+			Models:                  modelCatalog.models,
 			AddSessionSummary:       opts.AddSessionSummary,
 			EnableContextCompaction: opts.EnableContextCompaction,
 			ContextCompactionOversizedToolResultMaxTokens: opts.
@@ -1324,8 +1364,10 @@ func NewRuntimeWithOptions(
 	rt.modelCallBudgetLimit = opts.MaxLLMCalls
 	rt.modelCallBudgetFinalizeOnLast = opts.FinalizeBeforeMaxLLMCalls
 	rt.modelCallBudgetDeadlineWindow = opts.DeadlineFinalizationWindow
+	rt.modelCatalog = modelCatalog
+	rt.modelRunOptions = opts
 	rt.modelCallBudgetFinalRequest = modelCallBudgetFinalRequestFromOptions(
-		opts,
+		modelCatalog.runOptionsForModel(opts, modelCatalog.defaultName),
 	)
 	rt.toolSets = toolSets
 	rt.tools = runtimeTools
@@ -1396,12 +1438,16 @@ func NewRuntimeWithOptions(
 		runtimeProfileResolver,
 		runtimeProfileRequired,
 	)
-	gwOpts = appendModelCallBudgetGatewayOption(
+	if agentType == agentTypeLLM {
+		gwOpts = appendModelCatalogGatewayOptions(gwOpts, modelCatalog)
+	}
+	gwOpts = appendModelCatalogCallBudgetGatewayOption(
 		gwOpts,
+		opts,
+		modelCatalog,
 		opts.MaxLLMCalls,
 		opts.FinalizeBeforeMaxLLMCalls,
 		opts.DeadlineFinalizationWindow,
-		modelCallBudgetFinalRequestFromOptions(opts),
 	)
 	if langfuseRT != nil && langfuseRT.runOptionResolver != nil {
 		gwOpts = append(
@@ -1442,7 +1488,11 @@ func NewRuntimeWithOptions(
 			),
 		),
 	)
-	gwOpts = appendModelCompatibilityGatewayRunOptions(gwOpts, opts)
+	gwOpts = appendModelCompatibilityGatewayRunOptions(
+		gwOpts,
+		opts,
+		modelCatalog,
+	)
 	gwOpts = appendRuntimeGatewayRunOptions(gwOpts, runtimeOpts)
 	gwSrv, err := gateway.New(r, gwOpts...)
 	if err != nil {
@@ -1564,7 +1614,7 @@ func NewRuntimeWithOptions(
 	if opts.AdminEnabled {
 		adminURL := listenURL(opts.AdminAddr)
 		adminCfg := buildAdminConfig(
-			opts,
+			modelCatalog.adminRunOptions(opts),
 			agentType,
 			instanceID,
 			langfuseStatus,
@@ -1589,7 +1639,7 @@ func NewRuntimeWithOptions(
 			fileMemoryStore,
 			rt.SessionService(),
 		)
-		setRuntimeAdminOptions(rt, buildAdminOptions(opts))
+		setRuntimeAdminOptions(rt, buildAdminOptions(opts, modelCatalog))
 		rt.applyAdminConfig(adminCfg)
 	}
 
@@ -1607,6 +1657,10 @@ func (r *Runtime) Run(
 	if r == nil || r.runner == nil {
 		return nil, errors.New("openclaw runtime runner is not configured")
 	}
+	if r.modelCatalog.explicit {
+		runOpts = append(runOpts, r.modelCatalogRunOption())
+		return r.runner.Run(ctx, userID, sessionID, message, runOpts...)
+	}
 	defaultRunOpts := modelCallBudgetRunOptions(
 		r.modelCallBudgetLimit,
 		r.modelCallBudgetFinalizeOnLast,
@@ -1620,6 +1674,86 @@ func (r *Runtime) Run(
 		runOpts = merged
 	}
 	return r.runner.Run(ctx, userID, sessionID, message, runOpts...)
+}
+
+func (r *Runtime) modelCatalogRunOption() agent.RunOption {
+	return func(opts *agent.RunOptions) {
+		if opts == nil {
+			return
+		}
+		name := r.modelCatalog.defaultName
+		if opts.Model != nil {
+			selected := r.modelCatalog.runOptionsForModel(
+				r.modelRunOptions,
+				name,
+			)
+			r.applyModelCallBudgetDefaults(opts, selected)
+			return
+		}
+		requested := strings.TrimSpace(opts.ModelName)
+		opts.ModelName = requested
+		if requested != "" {
+			name = requested
+		}
+		if _, ok := r.modelCatalog.models[name]; !ok {
+			opts.ModelName = ""
+			message := fmt.Sprintf("model %q is not configured", name)
+			if opts.ModelSelector != nil {
+				message += " and cannot be combined with a custom model selector"
+			}
+			opts.ModelSelector = func(
+				context.Context,
+				*agent.Invocation,
+			) (model.Model, error) {
+				return nil, errors.New(message)
+			}
+			return
+		}
+		selected := r.modelCatalog.runOptionsForModel(
+			r.modelRunOptions,
+			name,
+		)
+		r.applyModelCallBudgetDefaults(opts, selected)
+		if opts.ModelSelector == nil {
+			applyModelCompatibilityDefaults(opts, selected)
+		}
+	}
+}
+
+func (r *Runtime) applyModelCallBudgetDefaults(
+	opts *agent.RunOptions,
+	selected runOptions,
+) {
+	factory := newModelCallBudgetFactory(
+		r.modelCallBudgetLimit,
+		r.modelCallBudgetFinalizeOnLast,
+		r.modelCallBudgetDeadlineWindow,
+		modelCallBudgetFinalRequestFromOptions(selected),
+	)
+	if factory == nil {
+		return
+	}
+	if opts.RuntimeState == nil {
+		opts.RuntimeState = make(map[string]any, 1)
+	}
+	if _, exists := opts.RuntimeState[modelCallBudgetRuntimeStateKey]; !exists {
+		opts.RuntimeState[modelCallBudgetRuntimeStateKey] = factory
+	}
+}
+
+func applyModelCompatibilityDefaults(
+	opts *agent.RunOptions,
+	selected runOptions,
+) {
+	if len(modelCompatibilityRunOptions(selected)) == 0 {
+		return
+	}
+	if opts.ToolCallArgumentsJSONRepairEnabled == nil {
+		agent.WithToolCallArgumentsJSONRepairEnabled(true)(opts)
+	}
+	if opts.ToolCallTextRepairEnabled == nil {
+		agent.WithToolCallTextRepairEnabled(true)(opts)
+	}
 }
 
 // Close releases owned resources (session/memory services, toolsets, runner).
@@ -1691,6 +1825,16 @@ func run(
 			Err:  fmt.Errorf("agent config failed: %w", err),
 		}
 	}
+	if err := validateModelCatalogAgentType(
+		agentType,
+		opts,
+		runtimeOpts,
+	); err != nil {
+		return &exitError{
+			Code: 1,
+			Err:  fmt.Errorf("agent config failed: %w", err),
+		}
+	}
 
 	mentionPatterns := splitCSV(opts.Mention)
 
@@ -1749,16 +1893,29 @@ func run(
 		opts.SessionSummaryEnabled ||
 		opts.MemoryAutoEnabled
 
-	var mdl model.Model
+	var (
+		mdl          model.Model
+		modelCatalog resolvedModelCatalog
+	)
 	if needsModel {
-		mdl, err = modelFromOptions(opts)
+		modelCatalog, err = resolveModelCatalog(opts, runtimeOpts)
 		if err != nil {
 			return &exitError{
 				Code: 1,
 				Err:  fmt.Errorf("create model failed: %w", err),
 			}
 		}
-		mdl = newModelCallBudgetModel(mdl)
+		mdl = modelCatalog.defaultModel()
+		if err := validateRuntimeProfileModels(
+			agentType,
+			opts.RuntimeProfiles,
+			modelCatalog,
+		); err != nil {
+			return &exitError{
+				Code: 1,
+				Err:  fmt.Errorf("model catalog validation failed: %w", err),
+			}
+		}
 	}
 
 	instanceID := runtimeInstanceID(
@@ -1766,6 +1923,7 @@ func run(
 		opts,
 		needsModel,
 		resolvedStateDir,
+		modelCatalog,
 	)
 	log.Infof("Instance: %s", instanceID)
 
@@ -1885,6 +2043,7 @@ func run(
 		)
 		agentCfg := agentConfig{
 			AppName:                 opts.AppName,
+			Models:                  modelCatalog.models,
 			AddSessionSummary:       opts.AddSessionSummary,
 			EnableContextCompaction: opts.EnableContextCompaction,
 			ContextCompactionOversizedToolResultMaxTokens: opts.
@@ -2044,12 +2203,16 @@ func run(
 		runtimeProfileResolver,
 		runtimeProfileRequired,
 	)
-	gwOpts = appendModelCallBudgetGatewayOption(
+	if agentType == agentTypeLLM {
+		gwOpts = appendModelCatalogGatewayOptions(gwOpts, modelCatalog)
+	}
+	gwOpts = appendModelCatalogCallBudgetGatewayOption(
 		gwOpts,
+		opts,
+		modelCatalog,
 		opts.MaxLLMCalls,
 		opts.FinalizeBeforeMaxLLMCalls,
 		opts.DeadlineFinalizationWindow,
-		modelCallBudgetFinalRequestFromOptions(opts),
 	)
 	if langfuseRT != nil && langfuseRT.runOptionResolver != nil {
 		gwOpts = append(
@@ -2090,7 +2253,11 @@ func run(
 			),
 		),
 	)
-	gwOpts = appendModelCompatibilityGatewayRunOptions(gwOpts, opts)
+	gwOpts = appendModelCompatibilityGatewayRunOptions(
+		gwOpts,
+		opts,
+		modelCatalog,
+	)
 	gwOpts = appendRuntimeGatewayRunOptions(gwOpts, runtimeOpts)
 	gwSrv, err := gateway.New(r, gwOpts...)
 	if err != nil {
@@ -2252,7 +2419,7 @@ func run(
 		}
 		adminSvc := admin.New(
 			buildAdminConfig(
-				opts,
+				modelCatalog.adminRunOptions(opts),
 				agentType,
 				instanceID,
 				langfuseStatus,
@@ -2277,7 +2444,7 @@ func run(
 				fileMemoryStore,
 				bridgedSessionSvc,
 			),
-			buildAdminOptions(opts)...,
+			buildAdminOptions(opts, modelCatalog)...,
 		)
 		adminSrv = &http.Server{
 			Handler:           adminSvc.Handler(),
@@ -2296,6 +2463,7 @@ func run(
 		resolvedStateDir,
 		channels,
 		needsModel,
+		modelCatalog,
 	))
 	logStartupLines(browserServerSup.startupLines())
 	logStartupLines(gatewayStartupLines(httpSrv.Addr, gwSrv))
@@ -2512,8 +2680,14 @@ func runtimeInstanceID(
 	opts runOptions,
 	needsModel bool,
 	stateDir string,
+	catalogs ...resolvedModelCatalog,
 ) string {
 	if agentType == agentTypeLLM {
+		if len(catalogs) > 0 && catalogs[0].explicit {
+			parts := []string{agentType, stateDir}
+			parts = append(parts, catalogs[0].identityParts()...)
+			return configFingerprint(parts...)
+		}
 		return configFingerprint(
 			opts.ModelMode,
 			opts.OpenAIModel,
@@ -2528,7 +2702,11 @@ func runtimeInstanceID(
 		stateDir,
 	}
 	if needsModel {
-		parts = append(parts, opts.ModelMode, opts.OpenAIModel)
+		if len(catalogs) > 0 && catalogs[0].explicit {
+			parts = append(parts, catalogs[0].identityParts()...)
+		} else {
+			parts = append(parts, opts.ModelMode, opts.OpenAIModel)
+		}
 	}
 	return configFingerprint(parts...)
 }
@@ -3425,6 +3603,7 @@ func channelsFromRegistry(
 
 type agentConfig struct {
 	AppName string
+	Models  map[string]model.Model
 
 	AddSessionSummary                             bool
 	EnableContextCompaction                       bool
@@ -3906,10 +4085,7 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 		return nil, fmt.Errorf("unsupported mode: %s", mode)
 	}
 
-	baseURL := strings.TrimSpace(opts.OpenAIBaseURL)
-	if baseURL == "" {
-		baseURL = strings.TrimSpace(os.Getenv(openAIBaseURLEnvName))
-	}
+	baseURL := resolvedOpenAIBaseURL(opts)
 	var headers map[string]string
 	if mode == modeOpenAI {
 		resolved, err := resolveOpenAIHeaders(opts.OpenAIHeaders)
@@ -3919,7 +4095,10 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 		headers = resolved
 	}
 
-	apiKey := strings.TrimSpace(os.Getenv(openAIAPIKeyEnvName))
+	apiKey, err := openAIAPIKeyFromOptions(opts)
+	if err != nil {
+		return nil, err
+	}
 	spec := registry.ModelSpec{
 		Type:                         mode,
 		Name:                         opts.OpenAIModel,
@@ -3941,6 +4120,44 @@ func modelFromOptions(opts runOptions) (model.Model, error) {
 		return nil, err
 	}
 	return newModelTimeoutModel(mdl, opts.OpenAITimeout), nil
+}
+
+func openAIAPIKeyFromOptions(opts runOptions) (string, error) {
+	envName := openAIAPIKeyEnvName
+	if opts.OpenAIUseVariantAPIKey &&
+		strings.EqualFold(strings.TrimSpace(opts.ModelMode), modeOpenAI) {
+		variant, err := parseOpenAIVariant(
+			opts.OpenAIVariant,
+			resolvedOpenAIBaseURL(opts),
+		)
+		if err != nil {
+			return "", err
+		}
+		switch variant {
+		case openai.VariantDeepSeek:
+			envName = deepSeekAPIKeyEnvName
+		case openai.VariantQwen:
+			envName = qwenAPIKeyEnvName
+		case openai.VariantMiniMax:
+			envName = miniMaxAPIKeyEnvName
+		case openai.VariantKimi:
+			envName = kimiAPIKeyEnvName
+		}
+	}
+	if envName != openAIAPIKeyEnvName {
+		if apiKey := strings.TrimSpace(os.Getenv(envName)); apiKey != "" {
+			return apiKey, nil
+		}
+	}
+	return strings.TrimSpace(os.Getenv(openAIAPIKeyEnvName)), nil
+}
+
+func resolvedOpenAIBaseURL(opts runOptions) string {
+	baseURL := strings.TrimSpace(opts.OpenAIBaseURL)
+	if baseURL != "" {
+		return baseURL
+	}
+	return strings.TrimSpace(os.Getenv(openAIBaseURLEnvName))
 }
 
 func openAIMaxRetriesPtr(maxRetries int, set bool) *int {
@@ -4102,7 +4319,21 @@ func parseOpenAIVariant(
 func appendModelCompatibilityGatewayRunOptions(
 	opts []gateway.Option,
 	runOpts runOptions,
+	catalog resolvedModelCatalog,
 ) []gateway.Option {
+	if catalog.explicit && len(catalog.models) > 0 {
+		return append(
+			opts,
+			gateway.WithRunOptionResolver(func(
+				ctx context.Context,
+				input gateway.RunOptionInput,
+			) (context.Context, []agent.RunOption, error) {
+				name := catalog.selectedModelName(ctx, input.ModelName)
+				selected := catalog.runOptionsForModel(runOpts, name)
+				return ctx, modelCompatibilityRunOptions(selected), nil
+			}),
+		)
+	}
 	staticRunOpts := modelCompatibilityRunOptions(runOpts)
 	if len(staticRunOpts) == 0 {
 		return opts

--- a/openclaw/app/deferred_tools.go
+++ b/openclaw/app/deferred_tools.go
@@ -87,6 +87,13 @@ func baseLLMAgentOptions(
 			runtimeprofile.SkillVisibilityFilterForRepository(repo),
 		),
 	}
+	if len(cfg.Models) > 0 {
+		models := make(map[string]model.Model, len(cfg.Models))
+		for name, candidate := range cfg.Models {
+			models[name] = candidate
+		}
+		opts = append(opts, llmagent.WithModels(models))
+	}
 	if cfg.MaxLLMCalls > 0 || cfg.DeadlineFinalizationWindow > 0 {
 		opts = append(opts, llmagent.WithModelCallbacks(
 			modelCallBudgetCallbacks(),

--- a/openclaw/app/model_catalog.go
+++ b/openclaw/app/model_catalog.go
@@ -1,0 +1,552 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
+)
+
+const legacyDefaultModelAlias = "default"
+
+type resolvedModelCatalog struct {
+	defaultName string
+	models      map[string]model.Model
+	metadata    map[string]ModelMetadata
+	explicit    bool
+}
+
+func validateModelCatalogAgentType(
+	agentType string,
+	opts runOptions,
+	runtimeOpts runtimeOptions,
+) error {
+	if agentType == agentTypeLLM {
+		return nil
+	}
+	if len(opts.ModelEntries) == 0 && runtimeOpts.modelCatalog == nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"request-scoped model catalogs require agent-type %q",
+		agentTypeLLM,
+	)
+}
+
+func resolveModelCatalog(
+	opts runOptions,
+	runtimeOpts runtimeOptions,
+) (resolvedModelCatalog, error) {
+	if runtimeOpts.modelCatalog != nil && len(opts.ModelEntries) > 0 {
+		return resolvedModelCatalog{}, fmt.Errorf(
+			"WithModelCatalog cannot be combined with model.models",
+		)
+	}
+	if runtimeOpts.modelCatalog != nil {
+		return resolveInjectedModelCatalog(opts, *runtimeOpts.modelCatalog)
+	}
+	if len(opts.ModelEntries) > 0 {
+		return resolveConfiguredModelCatalog(opts)
+	}
+
+	mdl, err := modelFromOptions(opts)
+	if err != nil {
+		return resolvedModelCatalog{}, err
+	}
+	alias := strings.TrimSpace(mdl.Info().Name)
+	if alias == "" {
+		alias = strings.TrimSpace(opts.OpenAIModel)
+	}
+	if alias == "" {
+		alias = legacyDefaultModelAlias
+	}
+	return resolvedModelCatalog{
+		defaultName: alias,
+		models: map[string]model.Model{
+			alias: newModelCallBudgetModel(mdl),
+		},
+		metadata: map[string]ModelMetadata{
+			alias: modelMetadataFromRunOptions(opts),
+		},
+	}, nil
+}
+
+func resolveInjectedModelCatalog(
+	opts runOptions,
+	catalog ModelCatalog,
+) (resolvedModelCatalog, error) {
+	defaultName := strings.TrimSpace(catalog.Default)
+	if defaultName == "" {
+		return resolvedModelCatalog{}, fmt.Errorf(
+			"model catalog default is required",
+		)
+	}
+	models, err := normalizeModelMap(catalog.Models)
+	if err != nil {
+		return resolvedModelCatalog{}, err
+	}
+	if _, ok := models[defaultName]; !ok {
+		return resolvedModelCatalog{}, fmt.Errorf(
+			"model catalog default %q is not configured",
+			defaultName,
+		)
+	}
+	for name, mdl := range models {
+		models[name] = newModelCallBudgetModel(mdl)
+	}
+	metadata, err := normalizeModelMetadata(
+		catalog.Metadata,
+		models,
+		modelMetadataFromRunOptions(opts),
+	)
+	if err != nil {
+		return resolvedModelCatalog{}, err
+	}
+	return resolvedModelCatalog{
+		defaultName: defaultName,
+		models:      models,
+		metadata:    metadata,
+		explicit:    true,
+	}, nil
+}
+
+func resolveConfiguredModelCatalog(
+	opts runOptions,
+) (resolvedModelCatalog, error) {
+	defaultName := strings.TrimSpace(opts.ModelDefault)
+	if defaultName == "" {
+		return resolvedModelCatalog{}, fmt.Errorf(
+			"model.default is required when model.models is configured",
+		)
+	}
+	names := make([]string, 0, len(opts.ModelEntries))
+	for name := range opts.ModelEntries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	models := make(map[string]model.Model, len(names))
+	metadata := make(map[string]ModelMetadata, len(names))
+	for _, rawName := range names {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return resolvedModelCatalog{}, fmt.Errorf(
+				"model.models contains an empty alias",
+			)
+		}
+		if _, exists := models[name]; exists {
+			return resolvedModelCatalog{}, fmt.Errorf(
+				"model.models contains duplicate alias %q after trimming",
+				name,
+			)
+		}
+		entryOpts, err := modelRunOptionsForEntry(
+			opts,
+			name,
+			opts.ModelEntries[rawName],
+		)
+		if err != nil {
+			return resolvedModelCatalog{}, err
+		}
+		mdl, err := modelFromOptions(entryOpts)
+		if err != nil {
+			return resolvedModelCatalog{}, fmt.Errorf(
+				"model.models.%s: %w",
+				name,
+				err,
+			)
+		}
+		models[name] = newModelCallBudgetModel(mdl)
+		metadata[name] = modelMetadataFromRunOptions(entryOpts)
+	}
+	if _, ok := models[defaultName]; !ok {
+		return resolvedModelCatalog{}, fmt.Errorf(
+			"model.default %q is not present in model.models",
+			defaultName,
+		)
+	}
+	return resolvedModelCatalog{
+		defaultName: defaultName,
+		models:      models,
+		metadata:    metadata,
+		explicit:    true,
+	}, nil
+}
+
+func normalizeModelMetadata(
+	src map[string]ModelMetadata,
+	models map[string]model.Model,
+	fallback ModelMetadata,
+) (map[string]ModelMetadata, error) {
+	normalizedSrc := make(map[string]ModelMetadata, len(src))
+	for rawName, metadata := range src {
+		name := strings.TrimSpace(rawName)
+		if _, ok := models[name]; !ok {
+			return nil, fmt.Errorf(
+				"model catalog metadata entry %q has no matching model",
+				name,
+			)
+		}
+		if _, exists := normalizedSrc[name]; exists {
+			return nil, fmt.Errorf(
+				"model catalog metadata contains duplicate alias %q after trimming",
+				name,
+			)
+		}
+		normalizedSrc[name] = metadata
+	}
+	out := make(map[string]ModelMetadata, len(models))
+	for name := range models {
+		metadata := fallback
+		if configured, ok := normalizedSrc[name]; ok {
+			if value := strings.TrimSpace(configured.Mode); value != "" {
+				metadata.Mode = value
+			}
+			if value := strings.TrimSpace(configured.BaseURL); value != "" ||
+				configured.BaseURLSet {
+				metadata.BaseURL = value
+			}
+			if value := strings.TrimSpace(configured.OpenAIVariant); value != "" {
+				metadata.OpenAIVariant = value
+			}
+		}
+		metadata = normalizeModelMetadataEntry(metadata)
+		if metadata.Mode == modeOpenAI {
+			if _, err := parseOpenAIVariant(
+				metadata.OpenAIVariant,
+				metadata.BaseURL,
+			); err != nil {
+				return nil, fmt.Errorf(
+					"model catalog metadata entry %q: %w",
+					name,
+					err,
+				)
+			}
+		}
+		out[name] = metadata
+	}
+	return out, nil
+}
+
+func normalizeModelMetadataEntry(metadata ModelMetadata) ModelMetadata {
+	metadata.Mode = strings.ToLower(strings.TrimSpace(metadata.Mode))
+	if metadata.Mode == "" {
+		metadata.Mode = modeOpenAI
+	}
+	metadata.BaseURL = strings.TrimSpace(metadata.BaseURL)
+	metadata.OpenAIVariant = strings.TrimSpace(metadata.OpenAIVariant)
+	if metadata.OpenAIVariant == "" {
+		metadata.OpenAIVariant = defaultOpenAIVariant
+	}
+	return metadata
+}
+
+func modelMetadataFromRunOptions(opts runOptions) ModelMetadata {
+	return normalizeModelMetadataEntry(ModelMetadata{
+		Mode:          opts.ModelMode,
+		BaseURL:       resolvedOpenAIBaseURL(opts),
+		OpenAIVariant: opts.OpenAIVariant,
+	})
+}
+
+func normalizeModelMap(
+	src map[string]model.Model,
+) (map[string]model.Model, error) {
+	if len(src) == 0 {
+		return nil, fmt.Errorf("model catalog models are required")
+	}
+	out := make(map[string]model.Model, len(src))
+	for rawName, mdl := range src {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return nil, fmt.Errorf("model catalog contains an empty alias")
+		}
+		if mdl == nil {
+			return nil, fmt.Errorf("model catalog entry %q is nil", name)
+		}
+		if _, exists := out[name]; exists {
+			return nil, fmt.Errorf(
+				"model catalog contains duplicate alias %q after trimming",
+				name,
+			)
+		}
+		out[name] = mdl
+	}
+	return out, nil
+}
+
+func modelRunOptionsForEntry(
+	parent runOptions,
+	alias string,
+	cfg modelEntryConfig,
+) (runOptions, error) {
+	opts := runOptions{
+		ModelMode:              modeOpenAI,
+		OpenAIModel:            defaultOpenAIModelName(),
+		OpenAIVariant:          defaultOpenAIVariant,
+		OpenAIMaxRetries:       -1,
+		OpenAIUseVariantAPIKey: true,
+		DebugRecorderEnabled:   parent.DebugRecorderEnabled,
+	}
+	if cfg.Mode != nil {
+		opts.ModelMode = strings.TrimSpace(*cfg.Mode)
+	}
+	if cfg.Name != nil {
+		opts.OpenAIModel = strings.TrimSpace(*cfg.Name)
+	}
+	if cfg.BaseURL != nil {
+		opts.OpenAIBaseURL = strings.TrimSpace(*cfg.BaseURL)
+	}
+	if cfg.OpenAIVariant != nil {
+		opts.OpenAIVariant = strings.TrimSpace(*cfg.OpenAIVariant)
+	}
+	if cfg.TextOnlyContent != nil {
+		opts.OpenAITextOnlyMessageContent = *cfg.TextOnlyContent
+	}
+	if cfg.Timeout != nil {
+		timeout, err := parseDuration(*cfg.Timeout)
+		if err != nil {
+			return runOptions{}, fmt.Errorf(
+				"model.models.%s.timeout: %w",
+				alias,
+				err,
+			)
+		}
+		if timeout < 0 {
+			return runOptions{}, fmt.Errorf(
+				"model.models.%s.timeout must be >= 0",
+				alias,
+			)
+		}
+		opts.OpenAITimeout = timeout
+	}
+	if cfg.MaxRetries != nil {
+		if *cfg.MaxRetries < 0 {
+			return runOptions{}, fmt.Errorf(
+				"model.models.%s.max_retries must be >= 0",
+				alias,
+			)
+		}
+		opts.OpenAIMaxRetries = *cfg.MaxRetries
+		opts.OpenAIMaxRetriesSet = true
+	}
+	opts.OpenAIHeaders = cleanHeaderMap(cfg.Headers)
+	if cfg.Config != nil {
+		opts.ModelConfig = cfg.Config.Node
+	}
+	return opts, nil
+}
+
+func (c resolvedModelCatalog) defaultModel() model.Model {
+	return c.models[c.defaultName]
+}
+
+func (c resolvedModelCatalog) modelNames() []string {
+	names := make([]string, 0, len(c.models))
+	for name := range c.models {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (c resolvedModelCatalog) selectedModelName(
+	ctx context.Context,
+	requestModelName string,
+) string {
+	if name := strings.TrimSpace(requestModelName); name != "" {
+		return name
+	}
+	if profile, ok := runtimeprofile.ProfileFromContext(ctx); ok {
+		if name := strings.TrimSpace(profile.ModelName); name != "" {
+			return name
+		}
+	}
+	return c.defaultName
+}
+
+func (c resolvedModelCatalog) runOptionsForModel(
+	base runOptions,
+	name string,
+) runOptions {
+	metadata, ok := c.metadata[strings.TrimSpace(name)]
+	if !ok {
+		return base
+	}
+	base.ModelMode = metadata.Mode
+	base.OpenAIBaseURL = metadata.BaseURL
+	base.OpenAIVariant = metadata.OpenAIVariant
+	return base
+}
+
+func (c resolvedModelCatalog) defaultAlias() string {
+	return strings.TrimSpace(c.defaultName)
+}
+
+func (c resolvedModelCatalog) adminRunOptions(base runOptions) runOptions {
+	if !c.explicit {
+		return base
+	}
+	base.OpenAIModel = c.defaultAlias()
+	if metadata, ok := c.metadata[c.defaultName]; ok {
+		base.ModelMode = metadata.Mode
+		base.OpenAIVariant = metadata.OpenAIVariant
+		base.OpenAIBaseURL = metadata.BaseURL
+	}
+	return base
+}
+
+func (c resolvedModelCatalog) identityParts() []string {
+	names := c.modelNames()
+	parts := make([]string, 0, 1+(len(names)*5))
+	parts = append(parts, "default="+c.defaultAlias())
+	for _, name := range names {
+		metadata := c.metadata[name]
+		modelName := ""
+		if mdl := c.models[name]; mdl != nil {
+			modelName = strings.TrimSpace(mdl.Info().Name)
+		}
+		parts = append(
+			parts,
+			"alias="+name,
+			"model="+modelName,
+			"mode="+metadata.Mode,
+			"variant="+metadata.OpenAIVariant,
+			"base_url="+metadata.BaseURL,
+		)
+	}
+	return parts
+}
+
+func appendModelCatalogGatewayOptions(
+	opts []gateway.Option,
+	catalog resolvedModelCatalog,
+) []gateway.Option {
+	if !catalog.explicit || len(catalog.models) == 0 {
+		return opts
+	}
+	opts = append(
+		opts,
+		gateway.WithSelectableModels(catalog.modelNames()...),
+		gateway.WithRunOptionResolver(
+			func(
+				ctx context.Context,
+				input gateway.RunOptionInput,
+			) (context.Context, []agent.RunOption, error) {
+				requestModelName := strings.TrimSpace(input.ModelName)
+				if requestModelName != "" {
+					return ctx, []agent.RunOption{
+						agent.WithModelName(requestModelName),
+					}, nil
+				}
+				if err := validateResolvedRuntimeProfileModel(
+					ctx,
+					catalog,
+				); err != nil {
+					return ctx, nil, err
+				}
+				return ctx, nil, nil
+			},
+		),
+	)
+	return opts
+}
+
+func appendModelCatalogCallBudgetGatewayOption(
+	opts []gateway.Option,
+	runOpts runOptions,
+	catalog resolvedModelCatalog,
+	limit int,
+	finalizeOnLast bool,
+	deadlineWindow time.Duration,
+) []gateway.Option {
+	if limit <= 0 && deadlineWindow <= 0 {
+		return opts
+	}
+	if !catalog.explicit || len(catalog.models) == 0 {
+		return appendModelCallBudgetGatewayOption(
+			opts,
+			limit,
+			finalizeOnLast,
+			deadlineWindow,
+			modelCallBudgetFinalRequestFromOptions(runOpts),
+		)
+	}
+	return append(opts, gateway.WithRunOptionResolver(func(
+		ctx context.Context,
+		input gateway.RunOptionInput,
+	) (context.Context, []agent.RunOption, error) {
+		name := catalog.selectedModelName(ctx, input.ModelName)
+		selected := catalog.runOptionsForModel(runOpts, name)
+		finalRequest := modelCallBudgetFinalRequestFromOptions(selected)
+		return ctx, modelCallBudgetRunOptions(
+			limit,
+			finalizeOnLast,
+			deadlineWindow,
+			finalRequest,
+		), nil
+	}))
+}
+
+func validateResolvedRuntimeProfileModel(
+	ctx context.Context,
+	catalog resolvedModelCatalog,
+) error {
+	if !catalog.explicit {
+		return nil
+	}
+	profile, ok := runtimeprofile.ProfileFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	name := strings.TrimSpace(profile.ModelName)
+	if name == "" {
+		return nil
+	}
+	if _, ok := catalog.models[name]; ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"runtime profile model %q is not configured",
+		name,
+	)
+}
+
+func validateRuntimeProfileModels(
+	agentType string,
+	cfg *runtimeprofile.Config,
+	catalog resolvedModelCatalog,
+) error {
+	if agentType != agentTypeLLM || cfg == nil || !catalog.explicit {
+		return nil
+	}
+	for profileID, profile := range cfg.Profiles {
+		name := strings.TrimSpace(profile.ModelName)
+		if name == "" {
+			continue
+		}
+		if _, ok := catalog.models[name]; !ok {
+			return fmt.Errorf(
+				"runtime_profiles.profiles.%s.model_name %q is not configured",
+				profileID,
+				name,
+			)
+		}
+	}
+	return nil
+}

--- a/openclaw/app/model_catalog_test.go
+++ b/openclaw/app/model_catalog_test.go
@@ -1,0 +1,1849 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwclient"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/gateway"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/registry"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/runtimeprofile"
+)
+
+type catalogResponseModel struct {
+	name  string
+	reply string
+}
+
+var (
+	registerEmptyNameModelOnce sync.Once
+	registerEmptyNameModelErr  error
+)
+
+func (m *catalogResponseModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{
+		Object: model.ObjectTypeChatCompletion,
+		Model:  m.name,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage(m.reply),
+		}},
+		Done: true,
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (m *catalogResponseModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+func TestResolveModelCatalog_Injected(t *testing.T) {
+	fast := &echoModel{name: "fast-model"}
+	strong := &echoModel{name: "strong-model"}
+
+	catalog, err := resolveModelCatalog(
+		runOptions{
+			ModelMode:     modeOpenAI,
+			OpenAIVariant: "openai",
+		},
+		buildRuntimeOptions([]RuntimeOption{
+			WithModelCatalog(ModelCatalog{
+				Default: "fast",
+				Models: map[string]model.Model{
+					"fast":   fast,
+					"strong": strong,
+				},
+				Metadata: map[string]ModelMetadata{
+					"strong": {
+						OpenAIVariant: "glm",
+						BaseURL:       "https://open.bigmodel.cn/api/paas/v4",
+					},
+				},
+			}),
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast", catalog.defaultName)
+	require.Equal(t, []string{"fast", "strong"}, catalog.modelNames())
+	require.Equal(t, "fast-model", catalog.defaultModel().Info().Name)
+	require.Equal(t, "openai", catalog.metadata["fast"].OpenAIVariant)
+	require.Equal(t, "glm", catalog.metadata["strong"].OpenAIVariant)
+	require.Equal(
+		t,
+		"https://open.bigmodel.cn/api/paas/v4",
+		catalog.metadata["strong"].BaseURL,
+	)
+}
+
+func TestResolveModelCatalog_InjectedValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		catalog ModelCatalog
+		wantErr string
+	}{
+		{
+			name:    "missing default",
+			catalog: ModelCatalog{Models: map[string]model.Model{"fast": &echoModel{}}},
+			wantErr: "default is required",
+		},
+		{
+			name:    "missing models",
+			catalog: ModelCatalog{Default: "fast"},
+			wantErr: "models are required",
+		},
+		{
+			name: "unknown default",
+			catalog: ModelCatalog{
+				Default: "strong",
+				Models:  map[string]model.Model{"fast": &echoModel{}},
+			},
+			wantErr: `default "strong" is not configured`,
+		},
+		{
+			name: "nil model",
+			catalog: ModelCatalog{
+				Default: "fast",
+				Models:  map[string]model.Model{"fast": nil},
+			},
+			wantErr: `entry "fast" is nil`,
+		},
+		{
+			name: "empty alias",
+			catalog: ModelCatalog{
+				Default: "fast",
+				Models:  map[string]model.Model{" ": &echoModel{}},
+			},
+			wantErr: "contains an empty alias",
+		},
+		{
+			name: "duplicate trimmed alias",
+			catalog: ModelCatalog{
+				Default: "fast",
+				Models: map[string]model.Model{
+					"fast":   &echoModel{},
+					" fast ": &echoModel{},
+				},
+			},
+			wantErr: `duplicate alias "fast"`,
+		},
+		{
+			name: "metadata without model",
+			catalog: ModelCatalog{
+				Default: "fast",
+				Models:  map[string]model.Model{"fast": &echoModel{}},
+				Metadata: map[string]ModelMetadata{
+					"unknown": {OpenAIVariant: "glm"},
+				},
+			},
+			wantErr: `metadata entry "unknown" has no matching model`,
+		},
+		{
+			name: "invalid metadata variant",
+			catalog: ModelCatalog{
+				Default: "fast",
+				Models:  map[string]model.Model{"fast": &echoModel{}},
+				Metadata: map[string]ModelMetadata{
+					"fast": {OpenAIVariant: "deepseekk"},
+				},
+			},
+			wantErr: `metadata entry "fast": unsupported openai variant`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveModelCatalog(
+				runOptions{},
+				buildRuntimeOptions([]RuntimeOption{
+					WithModelCatalog(tt.catalog),
+				}),
+			)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestResolveModelCatalog_LegacyAliasFallbacks(t *testing.T) {
+	const emptyNameMode = "model_catalog_empty_name_test"
+	registerEmptyNameModelOnce.Do(func() {
+		registerEmptyNameModelErr = registry.RegisterModel(
+			emptyNameMode,
+			func(registry.ModelSpec) (model.Model, error) {
+				return &echoModel{}, nil
+			},
+		)
+	})
+	require.NoError(t, registerEmptyNameModelErr)
+
+	catalog, err := resolveModelCatalog(runOptions{
+		ModelMode:   emptyNameMode,
+		OpenAIModel: " configured-name ",
+	}, runtimeOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "configured-name", catalog.defaultName)
+	require.False(t, catalog.explicit)
+
+	catalog, err = resolveModelCatalog(
+		runOptions{ModelMode: emptyNameMode},
+		runtimeOptions{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, legacyDefaultModelAlias, catalog.defaultName)
+
+	_, err = resolveModelCatalog(
+		runOptions{ModelMode: "unsupported-catalog-model"},
+		runtimeOptions{},
+	)
+	require.ErrorContains(t, err, "unsupported mode")
+}
+
+func TestResolveConfiguredModelCatalogValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    runOptions
+		wantErr string
+	}{
+		{
+			name: "missing default",
+			opts: runOptions{
+				ModelEntries: map[string]modelEntryConfig{
+					"fast": {Mode: modelCatalogStringPtr(modeMock)},
+				},
+			},
+			wantErr: "model.default is required",
+		},
+		{
+			name: "empty alias",
+			opts: runOptions{
+				ModelDefault: "fast",
+				ModelEntries: map[string]modelEntryConfig{
+					" ": {Mode: modelCatalogStringPtr(modeMock)},
+				},
+			},
+			wantErr: "contains an empty alias",
+		},
+		{
+			name: "duplicate trimmed alias",
+			opts: runOptions{
+				ModelDefault: "fast",
+				ModelEntries: map[string]modelEntryConfig{
+					"fast":   {Mode: modelCatalogStringPtr(modeMock)},
+					" fast ": {Mode: modelCatalogStringPtr(modeMock)},
+				},
+			},
+			wantErr: `duplicate alias "fast"`,
+		},
+		{
+			name: "invalid entry",
+			opts: runOptions{
+				ModelDefault: "fast",
+				ModelEntries: map[string]modelEntryConfig{
+					"fast": {
+						Timeout: modelCatalogStringPtr("not-a-duration"),
+					},
+				},
+			},
+			wantErr: "model.models.fast.timeout",
+		},
+		{
+			name: "model creation failure",
+			opts: runOptions{
+				ModelDefault: "fast",
+				ModelEntries: map[string]modelEntryConfig{
+					"fast": {
+						Mode: modelCatalogStringPtr("unsupported-mode"),
+					},
+				},
+			},
+			wantErr: "model.models.fast: unsupported mode",
+		},
+		{
+			name: "default absent",
+			opts: runOptions{
+				ModelDefault: "strong",
+				ModelEntries: map[string]modelEntryConfig{
+					"fast": {Mode: modelCatalogStringPtr(modeMock)},
+				},
+			},
+			wantErr: `model.default "strong" is not present`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveConfiguredModelCatalog(tt.opts)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestNormalizeModelMetadataRejectsDuplicateTrimmedAlias(t *testing.T) {
+	_, err := normalizeModelMetadata(
+		map[string]ModelMetadata{
+			"fast":   {},
+			" fast ": {},
+		},
+		map[string]model.Model{"fast": &echoModel{}},
+		ModelMetadata{},
+	)
+	require.ErrorContains(t, err, `duplicate alias "fast"`)
+}
+
+func TestModelRunOptionsForEntry(t *testing.T) {
+	var configNode yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("setting: value"), &configNode))
+	textOnly := true
+	maxRetries := 3
+	opts, err := modelRunOptionsForEntry(
+		runOptions{DebugRecorderEnabled: true},
+		"full",
+		modelEntryConfig{
+			Mode:            modelCatalogStringPtr(" mock "),
+			Name:            modelCatalogStringPtr(" model-name "),
+			BaseURL:         modelCatalogStringPtr(" https://example.com/v1 "),
+			OpenAIVariant:   modelCatalogStringPtr(" openai "),
+			TextOnlyContent: &textOnly,
+			Timeout:         modelCatalogStringPtr("2s"),
+			MaxRetries:      &maxRetries,
+			Headers: map[string]string{
+				" X-Test ": " value ",
+			},
+			Config: &rawYAMLNode{Node: &configNode},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, modeMock, opts.ModelMode)
+	require.Equal(t, "model-name", opts.OpenAIModel)
+	require.Equal(t, "https://example.com/v1", opts.OpenAIBaseURL)
+	require.Equal(t, "openai", opts.OpenAIVariant)
+	require.True(t, opts.OpenAITextOnlyMessageContent)
+	require.Equal(t, 2*time.Second, opts.OpenAITimeout)
+	require.Equal(t, 3, opts.OpenAIMaxRetries)
+	require.True(t, opts.OpenAIMaxRetriesSet)
+	require.True(t, opts.OpenAIUseVariantAPIKey)
+	require.Equal(t, map[string]string{"X-Test": "value"}, opts.OpenAIHeaders)
+	require.Same(t, &configNode, opts.ModelConfig)
+	require.True(t, opts.DebugRecorderEnabled)
+
+	_, err = modelRunOptionsForEntry(
+		runOptions{},
+		"negative-timeout",
+		modelEntryConfig{Timeout: modelCatalogStringPtr("-1s")},
+	)
+	require.ErrorContains(t, err, "timeout must be >= 0")
+
+	negativeRetries := -1
+	_, err = modelRunOptionsForEntry(
+		runOptions{},
+		"negative-retries",
+		modelEntryConfig{MaxRetries: &negativeRetries},
+	)
+	require.ErrorContains(t, err, "max_retries must be >= 0")
+}
+
+func TestResolveModelCatalog_InjectedCustomModeIgnoresOpenAIVariant(
+	t *testing.T,
+) {
+	catalog, err := resolveModelCatalog(
+		runOptions{},
+		buildRuntimeOptions([]RuntimeOption{
+			WithModelCatalog(ModelCatalog{
+				Default: "custom",
+				Models: map[string]model.Model{
+					"custom": &echoModel{name: "custom-model"},
+				},
+				Metadata: map[string]ModelMetadata{
+					"custom": {
+						Mode:          modeMock,
+						OpenAIVariant: "provider-specific",
+					},
+				},
+			}),
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, modeMock, catalog.metadata["custom"].Mode)
+	require.Equal(
+		t,
+		"provider-specific",
+		catalog.metadata["custom"].OpenAIVariant,
+	)
+}
+
+func TestResolveModelCatalog_InjectedMetadataCanClearInheritedBaseURL(
+	t *testing.T,
+) {
+	t.Setenv("OPENAI_BASE_URL", "https://api.deepseek.com/v1")
+	catalog, err := resolveModelCatalog(
+		runOptions{
+			ModelMode:     modeOpenAI,
+			OpenAIVariant: openAIVariantAuto,
+		},
+		buildRuntimeOptions([]RuntimeOption{
+			WithModelCatalog(ModelCatalog{
+				Default: "openai",
+				Models: map[string]model.Model{
+					"openai": &echoModel{name: "openai-model"},
+				},
+				Metadata: map[string]ModelMetadata{
+					"openai": {
+						BaseURLSet:    true,
+						OpenAIVariant: openAIVariantAuto,
+					},
+				},
+			}),
+		}),
+	)
+	require.NoError(t, err)
+	require.Empty(t, catalog.metadata["openai"].BaseURL)
+
+	selected := catalog.runOptionsForModel(runOptions{
+		DeadlineFinalizationWindow: time.Minute,
+	}, "openai")
+	require.False(
+		t,
+		modelCallBudgetFinalRequestFromOptions(selected).DisableThinking,
+	)
+}
+
+func TestModelMetadataFromRunOptions_UsesEnvironmentBaseURL(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "https://api.deepseek.com/v1")
+	metadata := modelMetadataFromRunOptions(runOptions{
+		ModelMode:     modeOpenAI,
+		OpenAIVariant: openAIVariantAuto,
+	})
+	require.Equal(
+		t,
+		"https://api.deepseek.com/v1",
+		metadata.BaseURL,
+	)
+
+	cfg := modelCallBudgetFinalRequestFromOptions(runOptions{
+		ModelMode:                  metadata.Mode,
+		OpenAIBaseURL:              metadata.BaseURL,
+		OpenAIVariant:              metadata.OpenAIVariant,
+		DeadlineFinalizationWindow: time.Minute,
+	})
+	require.True(t, cfg.DisableThinking)
+}
+
+func TestParseRunOptions_ModelCatalog(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+model:
+  default: strong
+  generation_config:
+    max_tokens: 256
+  models:
+    fast:
+      mode: mock
+      name: ignored
+    strong:
+      mode: mock
+`)
+
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	require.Equal(t, "strong", opts.ModelDefault)
+	require.Len(t, opts.ModelEntries, 2)
+	require.NotNil(t, opts.GenerationConfig)
+	require.Equal(t, 256, *opts.GenerationConfig.MaxTokens)
+
+	catalog, err := resolveModelCatalog(opts, runtimeOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "strong", catalog.defaultName)
+	require.Equal(t, []string{"fast", "strong"}, catalog.modelNames())
+}
+
+func TestResolveConfiguredModelCatalog_PreservesProviderMetadata(
+	t *testing.T,
+) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	cfgPath := writeTempConfig(t, `
+model:
+  default: deepseek
+  models:
+    deepseek:
+      mode: openai
+      name: deepseek-chat
+      openai_variant: deepseek
+      base_url: https://api.deepseek.com/v1
+    glm:
+      mode: openai
+      name: glm-4
+      openai_variant: auto
+      base_url: https://open.bigmodel.cn/api/paas/v4
+`)
+
+	opts, err := parseRunOptions([]string{"-config", cfgPath})
+	require.NoError(t, err)
+	catalog, err := resolveModelCatalog(opts, runtimeOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "deepseek", catalog.defaultName)
+	require.Equal(t, "deepseek", catalog.metadata["deepseek"].OpenAIVariant)
+	require.Equal(
+		t,
+		"https://api.deepseek.com/v1",
+		catalog.metadata["deepseek"].BaseURL,
+	)
+	require.Equal(t, "auto", catalog.metadata["glm"].OpenAIVariant)
+	require.Equal(
+		t,
+		"https://open.bigmodel.cn/api/paas/v4",
+		catalog.metadata["glm"].BaseURL,
+	)
+}
+
+func TestConfiguredModelCatalogUsesVariantCredential(t *testing.T) {
+	authorization := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		authorization <- r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":123,
+			"model":"deepseek-chat",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"ok"},
+				"finish_reason":"stop"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv(openAIAPIKeyEnvName, "openai-key")
+	t.Setenv(deepSeekAPIKeyEnvName, "deepseek-key")
+	t.Setenv(openAIHeadersEnvName, "")
+	entryOpts, err := modelRunOptionsForEntry(
+		runOptions{},
+		"deepseek",
+		modelEntryConfig{
+			Name:          modelCatalogStringPtr("deepseek-chat"),
+			BaseURL:       modelCatalogStringPtr(server.URL),
+			OpenAIVariant: modelCatalogStringPtr("deepseek"),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, entryOpts.OpenAIUseVariantAPIKey)
+	mdl, err := modelFromOptions(entryOpts)
+	require.NoError(t, err)
+
+	ch, err := mdl.GenerateContent(context.Background(), &model.Request{
+		Messages: []model.Message{model.NewUserMessage("hello")},
+		GenerationConfig: model.GenerationConfig{
+			Stream: false,
+		},
+	})
+	require.NoError(t, err)
+	for rsp := range ch {
+		require.Nil(t, rsp.Error)
+	}
+	require.Equal(t, "Bearer deepseek-key", <-authorization)
+}
+
+func TestOpenAIAPIKeyFromOptionsSelectsVariantEnvironment(t *testing.T) {
+	t.Setenv(openAIAPIKeyEnvName, "openai-key")
+	t.Setenv(deepSeekAPIKeyEnvName, "deepseek-key")
+	t.Setenv(qwenAPIKeyEnvName, "qwen-key")
+	t.Setenv(miniMaxAPIKeyEnvName, "minimax-key")
+	t.Setenv(kimiAPIKeyEnvName, "kimi-key")
+
+	tests := []struct {
+		name    string
+		opts    runOptions
+		wantKey string
+	}{
+		{
+			name: "legacy keeps openai credential",
+			opts: runOptions{
+				ModelMode:     modeOpenAI,
+				OpenAIVariant: "deepseek",
+			},
+			wantKey: "openai-key",
+		},
+		{
+			name: "deepseek",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "deepseek",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "deepseek-key",
+		},
+		{
+			name: "qwen",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "qwen",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "qwen-key",
+		},
+		{
+			name: "minimax",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "minimax",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "minimax-key",
+		},
+		{
+			name: "kimi",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "kimi",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "kimi-key",
+		},
+		{
+			name: "auto infers deepseek",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIBaseURL:          "https://api.deepseek.com/v1",
+				OpenAIVariant:          openAIVariantAuto,
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "deepseek-key",
+		},
+		{
+			name: "openai variant",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "openai",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "openai-key",
+		},
+		{
+			name: "glm uses openai credential",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "glm",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "openai-key",
+		},
+		{
+			name: "hunyuan uses openai credential",
+			opts: runOptions{
+				ModelMode:              modeOpenAI,
+				OpenAIVariant:          "hunyuan",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "openai-key",
+		},
+		{
+			name: "custom mode keeps legacy credential",
+			opts: runOptions{
+				ModelMode:              modeMock,
+				OpenAIVariant:          "deepseek",
+				OpenAIUseVariantAPIKey: true,
+			},
+			wantKey: "openai-key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := openAIAPIKeyFromOptions(tt.opts)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantKey, got)
+		})
+	}
+
+	t.Run("provider credential falls back to openai", func(t *testing.T) {
+		t.Setenv(deepSeekAPIKeyEnvName, "")
+		got, err := openAIAPIKeyFromOptions(runOptions{
+			ModelMode:              modeOpenAI,
+			OpenAIVariant:          "deepseek",
+			OpenAIUseVariantAPIKey: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "openai-key", got)
+	})
+
+	_, err := openAIAPIKeyFromOptions(runOptions{
+		ModelMode:              modeOpenAI,
+		OpenAIVariant:          "invalid",
+		OpenAIUseVariantAPIKey: true,
+	})
+	require.ErrorContains(t, err, "unsupported openai variant")
+}
+
+func TestResolvedModelCatalog_ProviderBehaviorFollowsSelectedAlias(
+	t *testing.T,
+) {
+	catalog := resolvedModelCatalog{
+		defaultName: "openai",
+		models: map[string]model.Model{
+			"openai":   &echoModel{name: "openai-model"},
+			"deepseek": &echoModel{name: "deepseek-model"},
+			"glm":      &echoModel{name: "glm-model"},
+		},
+		metadata: map[string]ModelMetadata{
+			"openai": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "openai",
+			},
+			"deepseek": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "deepseek",
+			},
+			"glm": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "auto",
+				BaseURL:       "https://open.bigmodel.cn/api/paas/v4",
+			},
+		},
+		explicit: true,
+	}
+	base := runOptions{DeadlineFinalizationWindow: time.Minute}
+
+	require.Empty(
+		t,
+		modelCompatibilityRunOptions(
+			catalog.runOptionsForModel(base, "deepseek"),
+		),
+	)
+	require.NotEmpty(
+		t,
+		modelCompatibilityRunOptions(catalog.runOptionsForModel(base, "glm")),
+	)
+	require.True(
+		t,
+		modelCallBudgetFinalRequestFromOptions(
+			catalog.runOptionsForModel(base, "deepseek"),
+		).DisableThinking,
+	)
+	require.False(
+		t,
+		modelCallBudgetFinalRequestFromOptions(
+			catalog.runOptionsForModel(base, "openai"),
+		).DisableThinking,
+	)
+
+	profileCtx := runtimeprofile.WithProfile(
+		context.Background(),
+		runtimeprofile.Profile{ModelName: "deepseek"},
+	)
+	require.Equal(t, "openai", catalog.selectedModelName(
+		context.Background(),
+		"",
+	))
+	require.Equal(t, "deepseek", catalog.selectedModelName(profileCtx, ""))
+	require.Equal(t, "glm", catalog.selectedModelName(profileCtx, "glm"))
+}
+
+func TestResolvedModelCatalogHelperFallbacks(t *testing.T) {
+	base := runOptions{
+		ModelMode:     modeMock,
+		OpenAIModel:   "legacy",
+		OpenAIVariant: "openai",
+	}
+	implicit := resolvedModelCatalog{
+		defaultName: " default ",
+		models: map[string]model.Model{
+			"default": nil,
+		},
+	}
+	require.Equal(t, base, implicit.runOptionsForModel(base, "missing"))
+	require.Equal(t, base, implicit.adminRunOptions(base))
+	require.Equal(t, "default", implicit.defaultAlias())
+	require.Contains(t, implicit.identityParts(), "model=")
+
+	explicitWithoutMetadata := implicit
+	explicitWithoutMetadata.explicit = true
+	adminOpts := explicitWithoutMetadata.adminRunOptions(base)
+	require.Equal(t, "default", adminOpts.OpenAIModel)
+	require.Equal(t, modeMock, adminOpts.ModelMode)
+}
+
+func TestAppendModelCatalogGatewayOptionsExplicitOnly(t *testing.T) {
+	catalog := resolvedModelCatalog{
+		defaultName: "fast",
+		models: map[string]model.Model{
+			"fast": &echoModel{name: "fast-model"},
+		},
+		metadata: map[string]ModelMetadata{
+			"fast": {Mode: modeMock},
+		},
+	}
+	require.Empty(t, appendModelCatalogGatewayOptions(nil, catalog))
+
+	catalog.explicit = true
+	require.Len(t, appendModelCatalogGatewayOptions(nil, catalog), 2)
+	catalog.models = nil
+	require.Empty(t, appendModelCatalogGatewayOptions(nil, catalog))
+}
+
+func TestAppendModelCatalogCallBudgetGatewayOptionUsesSelectedAlias(
+	t *testing.T,
+) {
+	runner := &capturingRuntimeRunOptionRunner{reply: "ok"}
+	catalog := resolvedModelCatalog{
+		defaultName: "openai",
+		models: map[string]model.Model{
+			"openai":   &echoModel{name: "openai-model"},
+			"deepseek": &echoModel{name: "deepseek-model"},
+		},
+		metadata: map[string]ModelMetadata{
+			"openai": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "openai",
+			},
+			"deepseek": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "deepseek",
+			},
+		},
+		explicit: true,
+	}
+	base := runOptions{DeadlineFinalizationWindow: time.Minute}
+	gwOpts := appendModelCatalogCallBudgetGatewayOption(
+		nil,
+		base,
+		catalog,
+		0,
+		false,
+		time.Minute,
+	)
+	srv, err := gateway.New(runner, gwOpts...)
+	require.NoError(t, err)
+
+	_, status := srv.ProcessMessage(
+		context.Background(),
+		gwproto.MessageRequest{
+			From:  "u1",
+			Text:  "hello",
+			Model: "deepseek",
+		},
+	)
+	require.Equal(t, http.StatusOK, status)
+	factory, ok := runner.opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudgetFactory)
+	require.True(t, ok)
+	require.True(t, factory.finalRequest.DisableThinking)
+
+	profileCtx := runtimeprofile.WithProfile(
+		context.Background(),
+		runtimeprofile.Profile{ModelName: "openai"},
+	)
+	_, status = srv.ProcessMessage(profileCtx, gwproto.MessageRequest{
+		From: "u1",
+		Text: "hello",
+	})
+	require.Equal(t, http.StatusOK, status)
+	factory, ok = runner.opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudgetFactory)
+	require.True(t, ok)
+	require.False(t, factory.finalRequest.DisableThinking)
+}
+
+func TestAppendModelCatalogCallBudgetGatewayOptionLegacyAndDisabled(
+	t *testing.T,
+) {
+	require.Empty(t, appendModelCatalogCallBudgetGatewayOption(
+		nil,
+		runOptions{},
+		resolvedModelCatalog{},
+		0,
+		false,
+		0,
+	))
+
+	runner := &capturingRuntimeRunOptionRunner{reply: "ok"}
+	gwOpts := appendModelCatalogCallBudgetGatewayOption(
+		nil,
+		runOptions{
+			ModelMode:                  modeOpenAI,
+			OpenAIVariant:              "deepseek",
+			DeadlineFinalizationWindow: time.Minute,
+		},
+		resolvedModelCatalog{
+			defaultName: "legacy",
+			models: map[string]model.Model{
+				"legacy": &echoModel{name: "legacy-model"},
+			},
+		},
+		0,
+		false,
+		time.Minute,
+	)
+	srv, err := gateway.New(runner, gwOpts...)
+	require.NoError(t, err)
+	_, status := srv.ProcessMessage(
+		context.Background(),
+		gwproto.MessageRequest{From: "u1", Text: "hello"},
+	)
+	require.Equal(t, http.StatusOK, status)
+	factory, ok := runner.opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudgetFactory)
+	require.True(t, ok)
+	require.True(t, factory.finalRequest.DisableThinking)
+}
+
+func TestResolvedModelCatalog_AdminStartupAndIdentity(t *testing.T) {
+	base := runOptions{
+		ModelMode:     modeOpenAI,
+		OpenAIModel:   "unrelated-legacy-default",
+		OpenAIVariant: "openai",
+	}
+	catalog := resolvedModelCatalog{
+		defaultName: "fast",
+		models: map[string]model.Model{
+			"fast":   &echoModel{name: "fast-model"},
+			"strong": &echoModel{name: "strong-model"},
+		},
+		metadata: map[string]ModelMetadata{
+			"fast": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "deepseek",
+			},
+			"strong": {
+				Mode:          modeOpenAI,
+				OpenAIVariant: "openai",
+			},
+		},
+		explicit: true,
+	}
+
+	adminOpts := catalog.adminRunOptions(base)
+	require.Equal(t, "fast", adminModelName(adminOpts, agentTypeLLM))
+	require.Equal(t, "deepseek", adminOpts.OpenAIVariant)
+	require.Equal(t, "fast (2 configured)", modelStartupSummary(
+		base,
+		true,
+		catalog,
+	))
+
+	firstID := runtimeInstanceID(
+		agentTypeLLM,
+		base,
+		true,
+		"/state",
+		catalog,
+	)
+	changed := catalog
+	changed.metadata = map[string]ModelMetadata{
+		"fast": {
+			Mode:          modeOpenAI,
+			OpenAIVariant: "glm",
+		},
+		"strong": catalog.metadata["strong"],
+	}
+	require.NotEqual(t, firstID, runtimeInstanceID(
+		agentTypeLLM,
+		base,
+		true,
+		"/state",
+		changed,
+	))
+}
+
+func TestRuntimeRunCatalogDefaultsFollowSelectedAlias(
+	t *testing.T,
+) {
+	runner := &capturingRuntimeRunOptionRunner{reply: "ok"}
+	rt := &Runtime{
+		runner: runner,
+		modelCatalog: resolvedModelCatalog{
+			defaultName: "openai",
+			models: map[string]model.Model{
+				"openai":   &echoModel{name: "openai-model"},
+				"deepseek": &echoModel{name: "deepseek-model"},
+				"glm":      &echoModel{name: "glm-model"},
+			},
+			metadata: map[string]ModelMetadata{
+				"openai": {
+					Mode:          modeOpenAI,
+					OpenAIVariant: "openai",
+				},
+				"deepseek": {
+					Mode:          modeOpenAI,
+					OpenAIVariant: "deepseek",
+				},
+				"glm": {
+					Mode:          modeOpenAI,
+					OpenAIVariant: "glm",
+				},
+			},
+			explicit: true,
+		},
+		modelCallBudgetDeadlineWindow: time.Minute,
+		modelRunOptions: runOptions{
+			DeadlineFinalizationWindow: time.Minute,
+		},
+	}
+	require.NotPanics(t, func() {
+		rt.modelCatalogRunOption()(nil)
+	})
+
+	_, err := rt.Run(
+		context.Background(),
+		"u1",
+		"default",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	factory, ok := runner.opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudgetFactory)
+	require.True(t, ok)
+	require.False(t, factory.finalRequest.DisableThinking)
+
+	_, err = rt.Run(
+		context.Background(),
+		"u1",
+		"deepseek",
+		model.NewUserMessage("hello"),
+		agent.WithModelName("deepseek"),
+	)
+	require.NoError(t, err)
+	factory, ok = runner.opts.RuntimeState[modelCallBudgetRuntimeStateKey].(*modelCallBudgetFactory)
+	require.True(t, ok)
+	require.True(t, factory.finalRequest.DisableThinking)
+
+	_, err = rt.Run(
+		context.Background(),
+		"u1",
+		"glm",
+		model.NewUserMessage("hello"),
+		agent.WithModelName(" glm "),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "glm", runner.opts.ModelName)
+	require.NotNil(t, runner.opts.ToolCallArgumentsJSONRepairEnabled)
+	require.True(t, *runner.opts.ToolCallArgumentsJSONRepairEnabled)
+	require.NotNil(t, runner.opts.ToolCallTextRepairEnabled)
+	require.True(t, *runner.opts.ToolCallTextRepairEnabled)
+}
+
+func TestRuntimeRunCatalogExecutesCallerOptionsOnceAndPreservesOverrides(
+	t *testing.T,
+) {
+	runner := &capturingRuntimeRunOptionRunner{reply: "ok"}
+	rt := &Runtime{
+		runner: runner,
+		modelCatalog: resolvedModelCatalog{
+			defaultName: "glm",
+			models: map[string]model.Model{
+				"glm": &echoModel{name: "glm-model"},
+			},
+			metadata: map[string]ModelMetadata{
+				"glm": {
+					Mode:          modeOpenAI,
+					OpenAIVariant: "glm",
+				},
+			},
+			explicit: true,
+		},
+		modelCallBudgetDeadlineWindow: time.Minute,
+		modelRunOptions: runOptions{
+			DeadlineFinalizationWindow: time.Minute,
+		},
+	}
+	const callerBudget = "caller-budget"
+	calls := 0
+	callerOption := func(opts *agent.RunOptions) {
+		calls++
+		agent.MergeRuntimeState(map[string]any{
+			modelCallBudgetRuntimeStateKey: callerBudget,
+		})(opts)
+		agent.WithToolCallArgumentsJSONRepairEnabled(false)(opts)
+		agent.WithToolCallTextRepairEnabled(false)(opts)
+	}
+
+	_, err := rt.Run(
+		context.Background(),
+		"u1",
+		"once",
+		model.NewUserMessage("hello"),
+		callerOption,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.Equal(
+		t,
+		callerBudget,
+		runner.opts.RuntimeState[modelCallBudgetRuntimeStateKey],
+	)
+	require.NotNil(t, runner.opts.ToolCallArgumentsJSONRepairEnabled)
+	require.False(t, *runner.opts.ToolCallArgumentsJSONRepairEnabled)
+	require.NotNil(t, runner.opts.ToolCallTextRepairEnabled)
+	require.False(t, *runner.opts.ToolCallTextRepairEnabled)
+}
+
+func TestRuntimeRunCatalogRejectsUnknownModelName(t *testing.T) {
+	runner := &capturingRuntimeRunOptionRunner{reply: "ok"}
+	rt := &Runtime{
+		runner: runner,
+		modelCatalog: resolvedModelCatalog{
+			defaultName: "fast",
+			models: map[string]model.Model{
+				"fast": &echoModel{name: "fast-model"},
+			},
+			metadata: map[string]ModelMetadata{
+				"fast": {
+					Mode:          modeOpenAI,
+					OpenAIVariant: "glm",
+				},
+			},
+			explicit: true,
+		},
+	}
+
+	_, err := rt.Run(
+		context.Background(),
+		"u1",
+		"unknown",
+		model.NewUserMessage("hello"),
+		agent.WithModelName("missing"),
+	)
+	require.NoError(t, err)
+	require.Empty(t, runner.opts.ModelName)
+	require.NotNil(t, runner.opts.ModelSelector)
+	_, err = runner.opts.ModelSelector(
+		context.Background(),
+		&agent.Invocation{},
+	)
+	require.ErrorContains(t, err, `model "missing" is not configured`)
+
+	custom := &echoModel{name: "custom-model"}
+	_, err = rt.Run(
+		context.Background(),
+		"u1",
+		"custom",
+		model.NewUserMessage("hello"),
+		agent.WithModelName("missing"),
+		agent.WithModel(custom),
+	)
+	require.NoError(t, err)
+	require.Same(t, custom, runner.opts.Model)
+	require.Nil(t, runner.opts.ModelSelector)
+	require.Nil(t, runner.opts.ToolCallArgumentsJSONRepairEnabled)
+	require.Nil(t, runner.opts.ToolCallTextRepairEnabled)
+
+	selectorCalled := false
+	_, err = rt.Run(
+		context.Background(),
+		"u1",
+		"conflict",
+		model.NewUserMessage("hello"),
+		agent.WithModelName("missing"),
+		agent.WithModelSelector(func(
+			context.Context,
+			*agent.Invocation,
+		) (model.Model, error) {
+			selectorCalled = true
+			return custom, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, runner.opts.ModelSelector)
+	_, err = runner.opts.ModelSelector(
+		context.Background(),
+		&agent.Invocation{},
+	)
+	require.ErrorContains(
+		t,
+		err,
+		`model "missing" is not configured and cannot be combined `+
+			`with a custom model selector`,
+	)
+	require.False(t, selectorCalled)
+}
+
+func TestRuntimeRunCatalogCustomSelectorSkipsCompatibilityDefaults(
+	t *testing.T,
+) {
+	runner := &capturingRuntimeRunOptionRunner{reply: "ok"}
+	rt := &Runtime{
+		runner: runner,
+		modelCatalog: resolvedModelCatalog{
+			defaultName: "glm",
+			models: map[string]model.Model{
+				"glm": &echoModel{name: "glm-model"},
+			},
+			metadata: map[string]ModelMetadata{
+				"glm": {
+					Mode:          modeOpenAI,
+					OpenAIVariant: "glm",
+				},
+			},
+			explicit: true,
+		},
+	}
+	custom := &echoModel{name: "custom-model"}
+	selector := func(
+		context.Context,
+		*agent.Invocation,
+	) (model.Model, error) {
+		return custom, nil
+	}
+
+	_, err := rt.Run(
+		context.Background(),
+		"u1",
+		"selector",
+		model.NewUserMessage("hello"),
+		agent.WithModelSelector(selector),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, runner.opts.ModelSelector)
+	selected, err := runner.opts.ModelSelector(
+		context.Background(),
+		&agent.Invocation{},
+	)
+	require.NoError(t, err)
+	require.Same(t, custom, selected)
+	require.Nil(t, runner.opts.ToolCallArgumentsJSONRepairEnabled)
+	require.Nil(t, runner.opts.ToolCallTextRepairEnabled)
+}
+
+func TestParseRunOptions_ModelCatalogRequiresDefault(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+model:
+  models:
+    strong:
+      mode: mock
+`)
+
+	_, err := parseRunOptions([]string{"-config", cfgPath})
+	require.ErrorContains(t, err, "model.default is required")
+}
+
+func TestParseRunOptions_ModelDefaultRequiresModels(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+model:
+  default: strong
+`)
+	_, err := parseRunOptions([]string{"-config", cfgPath})
+	require.ErrorContains(t, err, "model.default requires model.models")
+}
+
+func TestModelCatalogConfigHelpers(t *testing.T) {
+	require.False(t, modelConfigHasLegacyFields(nil))
+	require.False(t, modelConfigHasLegacyFields(&modelConfig{}))
+	require.True(t, modelConfigHasLegacyFields(&modelConfig{
+		Mode: modelCatalogStringPtr(modeMock),
+	}))
+	require.False(t, modelFlagsWereSet(nil))
+	require.True(t, modelFlagsWereSet(map[string]struct{}{
+		"openai-variant": {},
+	}))
+	require.Nil(t, cloneModelEntryConfigs(nil))
+
+	cloned := cloneModelEntryConfigs(map[string]modelEntryConfig{
+		"fast": {
+			Headers: map[string]string{
+				" X-Test ": " value ",
+				"X-Blank":  " ",
+			},
+		},
+	})
+	require.Equal(
+		t,
+		map[string]string{"X-Test": "value"},
+		cloned["fast"].Headers,
+	)
+}
+
+func TestParseRunOptions_ModelCatalogRejectsLegacyMix(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+model:
+  name: legacy
+  default: strong
+  models:
+    strong:
+      mode: mock
+`)
+
+	_, err := parseRunOptions([]string{"-config", cfgPath})
+	require.ErrorContains(t, err, "cannot be combined")
+}
+
+func TestResolveModelCatalog_RejectsYAMLAndRuntimeCatalog(t *testing.T) {
+	_, err := resolveModelCatalog(
+		runOptions{
+			ModelDefault: "fast",
+			ModelEntries: map[string]modelEntryConfig{
+				"fast": {Mode: modelCatalogStringPtr(modeMock)},
+			},
+		},
+		buildRuntimeOptions([]RuntimeOption{
+			WithModelCatalog(ModelCatalog{
+				Default: "fast",
+				Models: map[string]model.Model{
+					"fast": &echoModel{},
+				},
+			}),
+		}),
+	)
+	require.ErrorContains(t, err, "cannot be combined")
+}
+
+func TestValidateModelCatalogAgentType(t *testing.T) {
+	err := validateModelCatalogAgentType(
+		agentTypeClaudeCode,
+		runOptions{},
+		buildRuntimeOptions([]RuntimeOption{
+			WithModelCatalog(ModelCatalog{
+				Default: "fast",
+				Models: map[string]model.Model{
+					"fast": &echoModel{},
+				},
+			}),
+		}),
+	)
+	require.ErrorContains(t, err, `require agent-type "llm"`)
+	require.NoError(t, validateModelCatalogAgentType(
+		agentTypeLLM,
+		runOptions{
+			ModelEntries: map[string]modelEntryConfig{
+				"fast": {},
+			},
+		},
+		runtimeOptions{},
+	))
+}
+
+func TestNewRuntime_ModelCatalogGatewaySelection(t *testing.T) {
+	rt, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+			"-enable-openclaw-tools=false",
+		},
+		WithModelCatalog(ModelCatalog{
+			Default: "fast",
+			Models: map[string]model.Model{
+				"fast": &catalogResponseModel{
+					name:  "fast-model",
+					reply: "fast reply",
+				},
+				"strong": &catalogResponseModel{
+					name:  "strong-model",
+					reply: "strong reply",
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Close())
+	})
+
+	client, err := gwclient.New(
+		rt.Gateway.Handler,
+		rt.Gateway.MessagesPath,
+		rt.Gateway.CancelPath,
+	)
+	require.NoError(t, err)
+
+	rsp, err := client.SendMessage(
+		context.Background(),
+		gwclient.MessageRequest{
+			From:      "u1",
+			SessionID: "session-strong",
+			Text:      "hello",
+			Model:     "strong",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "strong reply", rsp.Reply)
+
+	rsp, err = client.SendMessage(
+		context.Background(),
+		gwclient.MessageRequest{
+			From:      "u1",
+			SessionID: "session-default",
+			Text:      "hello",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast reply", rsp.Reply)
+
+	rsp, err = client.SendMessage(
+		context.Background(),
+		gwclient.MessageRequest{
+			From:      "u1",
+			SessionID: "session-unknown",
+			Text:      "hello",
+			Model:     "unknown",
+		},
+	)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rsp.StatusCode)
+	require.NotNil(t, rsp.Error)
+	require.Equal(t, "invalid_model", rsp.Error.Type)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i, name := range []string{"fast", "strong"} {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			got, sendErr := client.SendMessage(
+				context.Background(),
+				gwclient.MessageRequest{
+					From:      "u1",
+					SessionID: fmt.Sprintf("concurrent-%d", i),
+					Text:      "hello",
+					Model:     name,
+				},
+			)
+			if sendErr != nil {
+				errs <- sendErr
+				return
+			}
+			if got.Reply != name+" reply" {
+				errs <- fmt.Errorf(
+					"model %s returned %q",
+					name,
+					got.Reply,
+				)
+			}
+		}(i, name)
+	}
+	wg.Wait()
+	close(errs)
+	for concurrentErr := range errs {
+		require.NoError(t, concurrentErr)
+	}
+}
+
+func TestNewRuntime_ModelCatalogDirectRunSelection(t *testing.T) {
+	rt, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+			"-enable-openclaw-tools=false",
+		},
+		WithModelCatalog(ModelCatalog{
+			Default: "fast",
+			Models: map[string]model.Model{
+				"fast": &catalogResponseModel{
+					name:  "fast-model",
+					reply: "fast reply",
+				},
+				"strong": &catalogResponseModel{
+					name:  "strong-model",
+					reply: "strong reply",
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Close())
+	})
+
+	events, err := rt.Run(
+		context.Background(),
+		"u1",
+		"direct-strong",
+		model.NewUserMessage("hello"),
+		agent.WithModelName("strong"),
+	)
+	require.NoError(t, err)
+	var reply string
+	for evt := range events {
+		if evt == nil || evt.Response == nil ||
+			len(evt.Response.Choices) == 0 {
+			continue
+		}
+		reply = evt.Response.Choices[0].Message.Content
+	}
+	require.Equal(t, "strong reply", reply)
+
+	events, err = rt.Run(
+		context.Background(),
+		"u1",
+		"direct-unknown",
+		model.NewUserMessage("hello"),
+		agent.WithModelName("missing"),
+	)
+	require.NoError(t, err)
+	var runError string
+	for evt := range events {
+		if evt == nil || evt.Response == nil ||
+			evt.Response.Error == nil {
+			continue
+		}
+		runError = evt.Response.Error.Message
+	}
+	require.Contains(t, runError, `model "missing" is not configured`)
+}
+
+func TestNewRuntime_LegacyGatewayIgnoresRequestModel(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+runtime_profiles:
+  profiles:
+    legacy:
+      model_name: formerly-ignored-profile-model
+`)
+	rt, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-config", cfgPath,
+			"-mode", modeMock,
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+			"-enable-openclaw-tools=false",
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Close())
+	})
+	client, err := gwclient.New(
+		rt.Gateway.Handler,
+		rt.Gateway.MessagesPath,
+		rt.Gateway.CancelPath,
+	)
+	require.NoError(t, err)
+	profileExtension, err := json.Marshal(runtimeprofile.Extension{
+		ProfileID: "legacy",
+	})
+	require.NoError(t, err)
+
+	rsp, err := client.SendMessage(
+		context.Background(),
+		gwclient.MessageRequest{
+			From:      "u1",
+			SessionID: "legacy-model-field",
+			Text:      "hello",
+			Model:     "formerly-ignored",
+			Extensions: map[string]json.RawMessage{
+				runtimeprofile.ExtensionKey: profileExtension,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Contains(t, rsp.Reply, "hello")
+}
+
+func TestNewRuntime_RequestModelOverridesRuntimeProfile(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+runtime_profiles:
+  profiles:
+    premium:
+      model_name: strong
+`)
+	rt, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-config", cfgPath,
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+			"-enable-openclaw-tools=false",
+		},
+		WithModelCatalog(ModelCatalog{
+			Default: "fast",
+			Models: map[string]model.Model{
+				"fast": &catalogResponseModel{
+					name:  "fast-model",
+					reply: "fast reply",
+				},
+				"strong": &catalogResponseModel{
+					name:  "strong-model",
+					reply: "strong reply",
+				},
+			},
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Close())
+	})
+	client, err := gwclient.New(
+		rt.Gateway.Handler,
+		rt.Gateway.MessagesPath,
+		rt.Gateway.CancelPath,
+	)
+	require.NoError(t, err)
+
+	profileExtension, err := json.Marshal(runtimeprofile.Extension{
+		ProfileID: "premium",
+	})
+	require.NoError(t, err)
+	baseRequest := gwclient.MessageRequest{
+		From:      "u1",
+		SessionID: "profile-default",
+		Text:      "hello",
+		Extensions: map[string]json.RawMessage{
+			runtimeprofile.ExtensionKey: profileExtension,
+		},
+	}
+	rsp, err := client.SendMessage(context.Background(), baseRequest)
+	require.NoError(t, err)
+	require.Equal(t, "strong reply", rsp.Reply)
+
+	baseRequest.SessionID = "profile-overridden"
+	baseRequest.Model = "fast"
+	rsp, err = client.SendMessage(context.Background(), baseRequest)
+	require.NoError(t, err)
+	require.Equal(t, "fast reply", rsp.Reply)
+}
+
+func TestNewRuntime_DynamicRuntimeProfileModelValidation(t *testing.T) {
+	rt, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+			"-enable-openclaw-tools=false",
+		},
+		WithModelCatalog(ModelCatalog{
+			Default: "fast",
+			Models: map[string]model.Model{
+				"fast": &catalogResponseModel{
+					name:  "fast-model",
+					reply: "fast reply",
+				},
+			},
+		}),
+		WithRuntimeProfileResolver(
+			runtimeprofile.ResolverFunc(func(
+				context.Context,
+				runtimeprofile.Request,
+			) (runtimeprofile.Profile, error) {
+				return runtimeprofile.Profile{
+					ID:        "dynamic",
+					ModelName: "unknown",
+				}, nil
+			}),
+			false,
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rt.Close())
+	})
+	client, err := gwclient.New(
+		rt.Gateway.Handler,
+		rt.Gateway.MessagesPath,
+		rt.Gateway.CancelPath,
+	)
+	require.NoError(t, err)
+
+	_, err = client.SendMessage(
+		context.Background(),
+		gwclient.MessageRequest{
+			From:      "u1",
+			SessionID: "dynamic-profile-invalid",
+			Text:      "hello",
+		},
+	)
+	require.ErrorContains(
+		t,
+		err,
+		`runtime profile model "unknown" is not configured`,
+	)
+
+	rsp, err := client.SendMessage(
+		context.Background(),
+		gwclient.MessageRequest{
+			From:      "u1",
+			SessionID: "dynamic-profile-overridden",
+			Text:      "hello",
+			Model:     "fast",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast reply", rsp.Reply)
+}
+
+func TestNewRuntime_StaticRuntimeProfileModelValidation(t *testing.T) {
+	cfgPath := writeTempConfig(t, `
+runtime_profiles:
+  profiles:
+    premium:
+      model_name: missing
+`)
+	_, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-config", cfgPath,
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+			"-enable-openclaw-tools=false",
+		},
+		WithModelCatalog(ModelCatalog{
+			Default: "fast",
+			Models: map[string]model.Model{
+				"fast": &catalogResponseModel{
+					name:  "fast-model",
+					reply: "fast reply",
+				},
+			},
+		}),
+	)
+	require.ErrorContains(t, err, "model catalog validation failed")
+	require.ErrorContains(t, err, `model_name "missing" is not configured`)
+}
+
+func TestNewRuntime_ModelCatalogRejectsClaudeCodeAgent(t *testing.T) {
+	_, err := NewRuntimeWithOptions(
+		context.Background(),
+		[]string{
+			"-agent-type", agentTypeClaudeCode,
+			"-state-dir", t.TempDir(),
+			"-admin-enabled=false",
+		},
+		WithModelCatalog(ModelCatalog{
+			Default: "fast",
+			Models: map[string]model.Model{
+				"fast": &echoModel{name: "fast-model"},
+			},
+		}),
+	)
+	require.ErrorContains(t, err, `require agent-type "llm"`)
+}
+
+func TestValidateRuntimeProfileModelsRejectsUnknown(t *testing.T) {
+	err := validateRuntimeProfileModels(
+		agentTypeLLM,
+		&runtimeprofile.Config{
+			Profiles: map[string]runtimeprofile.Profile{
+				"premium": {ModelName: "unknown"},
+			},
+		},
+		resolvedModelCatalog{
+			defaultName: "fast",
+			models: map[string]model.Model{
+				"fast": &echoModel{},
+			},
+			explicit: true,
+		},
+	)
+	require.ErrorContains(t, err, `model_name "unknown" is not configured`)
+
+	require.NoError(t, validateRuntimeProfileModels(
+		agentTypeClaudeCode,
+		&runtimeprofile.Config{
+			Profiles: map[string]runtimeprofile.Profile{
+				"premium": {ModelName: "unknown"},
+			},
+		},
+		resolvedModelCatalog{
+			defaultName: "fast",
+			models: map[string]model.Model{
+				"fast": &echoModel{},
+			},
+			explicit: true,
+		},
+	))
+
+	require.NoError(t, validateRuntimeProfileModels(
+		agentTypeLLM,
+		&runtimeprofile.Config{
+			Profiles: map[string]runtimeprofile.Profile{
+				"legacy": {ModelName: "formerly-ignored"},
+			},
+		},
+		resolvedModelCatalog{
+			defaultName: "default",
+			models: map[string]model.Model{
+				"default": &echoModel{},
+			},
+		},
+	))
+
+	require.NoError(t, validateRuntimeProfileModels(
+		agentTypeLLM,
+		&runtimeprofile.Config{
+			Profiles: map[string]runtimeprofile.Profile{
+				"blank": {},
+				"known": {ModelName: "fast"},
+			},
+		},
+		resolvedModelCatalog{
+			defaultName: "fast",
+			models: map[string]model.Model{
+				"fast": &echoModel{},
+			},
+			explicit: true,
+		},
+	))
+}
+
+func TestValidateResolvedRuntimeProfileModel(t *testing.T) {
+	catalog := resolvedModelCatalog{
+		defaultName: "default",
+		models: map[string]model.Model{
+			"default": &echoModel{},
+		},
+		explicit: true,
+	}
+	require.NoError(t, validateResolvedRuntimeProfileModel(
+		context.Background(),
+		catalog,
+	))
+	require.NoError(t, validateResolvedRuntimeProfileModel(
+		runtimeprofile.WithProfile(
+			context.Background(),
+			runtimeprofile.Profile{},
+		),
+		catalog,
+	))
+	require.NoError(t, validateResolvedRuntimeProfileModel(
+		runtimeprofile.WithProfile(
+			context.Background(),
+			runtimeprofile.Profile{ModelName: "default"},
+		),
+		catalog,
+	))
+	err := validateResolvedRuntimeProfileModel(
+		runtimeprofile.WithProfile(
+			context.Background(),
+			runtimeprofile.Profile{ModelName: "missing"},
+		),
+		catalog,
+	)
+	require.ErrorContains(t, err, `model "missing" is not configured`)
+
+	legacyCtx := runtimeprofile.WithProfile(
+		context.Background(),
+		runtimeprofile.Profile{ModelName: "formerly-ignored"},
+	)
+	require.NoError(t, validateResolvedRuntimeProfileModel(
+		legacyCtx,
+		resolvedModelCatalog{
+			defaultName: "default",
+			models: map[string]model.Model{
+				"default": &echoModel{},
+			},
+		},
+	))
+}
+
+func modelCatalogStringPtr(value string) *string {
+	return &value
+}

--- a/openclaw/app/run_options.go
+++ b/openclaw/app/run_options.go
@@ -236,9 +236,12 @@ type runOptions struct {
 	OpenAITimeout                time.Duration
 	OpenAIMaxRetries             int
 	OpenAIMaxRetriesSet          bool
+	OpenAIUseVariantAPIKey       bool
 	OpenAIHeaders                map[string]string
 	GenerationConfig             *model.GenerationConfig
 	ModelConfig                  *yaml.Node
+	ModelDefault                 string
+	ModelEntries                 map[string]modelEntryConfig
 	KnowledgesConfig             []knowledgeEntry
 	SkillsRoot                   string
 	SkillsExtraDir               string
@@ -1305,16 +1308,78 @@ type ralphLoopVerifyConfig struct {
 }
 
 type modelConfig struct {
-	Mode             *string               `yaml:"mode,omitempty"`
-	Name             *string               `yaml:"name,omitempty"`
-	BaseURL          *string               `yaml:"base_url,omitempty"`
-	OpenAIVariant    *string               `yaml:"openai_variant,omitempty"`
-	TextOnlyContent  *bool                 `yaml:"text_only_content,omitempty"`
-	Timeout          *string               `yaml:"timeout,omitempty"`
-	MaxRetries       *int                  `yaml:"max_retries,omitempty"`
-	Headers          map[string]string     `yaml:"headers,omitempty"`
-	GenerationConfig *generationConfigYAML `yaml:"generation_config,omitempty"`
-	Config           *rawYAMLNode          `yaml:"config,omitempty"`
+	Mode             *string                     `yaml:"mode,omitempty"`
+	Name             *string                     `yaml:"name,omitempty"`
+	BaseURL          *string                     `yaml:"base_url,omitempty"`
+	OpenAIVariant    *string                     `yaml:"openai_variant,omitempty"`
+	TextOnlyContent  *bool                       `yaml:"text_only_content,omitempty"`
+	Timeout          *string                     `yaml:"timeout,omitempty"`
+	MaxRetries       *int                        `yaml:"max_retries,omitempty"`
+	Headers          map[string]string           `yaml:"headers,omitempty"`
+	GenerationConfig *generationConfigYAML       `yaml:"generation_config,omitempty"`
+	Config           *rawYAMLNode                `yaml:"config,omitempty"`
+	Default          *string                     `yaml:"default,omitempty"`
+	Models           map[string]modelEntryConfig `yaml:"models,omitempty"`
+}
+
+type modelEntryConfig struct {
+	Mode            *string           `yaml:"mode,omitempty"`
+	Name            *string           `yaml:"name,omitempty"`
+	BaseURL         *string           `yaml:"base_url,omitempty"`
+	OpenAIVariant   *string           `yaml:"openai_variant,omitempty"`
+	TextOnlyContent *bool             `yaml:"text_only_content,omitempty"`
+	Timeout         *string           `yaml:"timeout,omitempty"`
+	MaxRetries      *int              `yaml:"max_retries,omitempty"`
+	Headers         map[string]string `yaml:"headers,omitempty"`
+	Config          *rawYAMLNode      `yaml:"config,omitempty"`
+}
+
+// modelConfigHasLegacyFields intentionally excludes GenerationConfig because
+// one generation_config is shared by all catalog entries.
+func modelConfigHasLegacyFields(cfg *modelConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Mode != nil ||
+		cfg.Name != nil ||
+		cfg.BaseURL != nil ||
+		cfg.OpenAIVariant != nil ||
+		cfg.TextOnlyContent != nil ||
+		cfg.Timeout != nil ||
+		cfg.MaxRetries != nil ||
+		len(cfg.Headers) > 0 ||
+		cfg.Config != nil
+}
+
+func modelFlagsWereSet(set map[string]struct{}) bool {
+	for _, name := range []string{
+		"mode",
+		"model",
+		"openai-base-url",
+		"openai-variant",
+		flagOpenAITextOnlyMessageContent,
+		flagOpenAITimeout,
+		flagOpenAIMaxRetries,
+	} {
+		if flagWasSet(set, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneModelEntryConfigs(
+	src map[string]modelEntryConfig,
+) map[string]modelEntryConfig {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]modelEntryConfig, len(src))
+	for name, entry := range src {
+		entry.Headers = cleanHeaderMap(entry.Headers)
+		out[name] = entry
+	}
+	return out
 }
 
 type generationConfigYAML struct {
@@ -1922,6 +1987,31 @@ func (cfg *fileConfig) apply(
 	}
 
 	if cfg.Model != nil {
+		if cfg.Model.Default != nil && len(cfg.Model.Models) == 0 {
+			return fmt.Errorf(
+				"model.default requires model.models",
+			)
+		}
+		if len(cfg.Model.Models) > 0 {
+			if modelConfigHasLegacyFields(cfg.Model) ||
+				modelFlagsWereSet(set) {
+				return fmt.Errorf(
+					"model.models cannot be combined with legacy model " +
+						"fields or model CLI flags",
+				)
+			}
+			defaultName := ""
+			if cfg.Model.Default != nil {
+				defaultName = strings.TrimSpace(*cfg.Model.Default)
+			}
+			if defaultName == "" {
+				return fmt.Errorf(
+					"model.default is required when model.models is configured",
+				)
+			}
+			opts.ModelDefault = defaultName
+			opts.ModelEntries = cloneModelEntryConfigs(cfg.Model.Models)
+		}
 		if cfg.Model.Mode != nil && !flagWasSet(set, "mode") {
 			opts.ModelMode = strings.TrimSpace(*cfg.Model.Mode)
 		}

--- a/openclaw/app/runtime_options.go
+++ b/openclaw/app/runtime_options.go
@@ -45,6 +45,7 @@ type GatewayRunOptionInput struct {
 	UserID     string
 	SessionID  string
 	RequestID  string
+	ModelName  string
 	Message    model.Message
 	Extensions map[string]json.RawMessage
 }
@@ -63,6 +64,53 @@ type runtimeOptions struct {
 	gatewayResolvers       []GatewayRunOptionResolver
 	postToolPromptEnabled  *bool
 	codeExecutorLoader     codeExecutorConfigLoader
+	modelCatalog           *ModelCatalog
+}
+
+// ModelCatalog is a set of pre-built models addressable by stable aliases.
+// Default must name one entry in Models. OpenClaw uses the default model for
+// auxiliary services and registers all entries on the main LLM agent for
+// request-scoped selection. Metadata keys, when present, must match Models
+// aliases.
+type ModelCatalog struct {
+	Default  string
+	Models   map[string]model.Model
+	Metadata map[string]ModelMetadata
+}
+
+// ModelMetadata describes provider behavior that OpenClaw must apply outside
+// the model client itself. Entries are optional; omitted fields fall back to
+// the legacy top-level model settings. OpenAIVariant accepts auto, openai,
+// deepseek, hunyuan, qwen, glm, minimax, or kimi when Mode is openai.
+type ModelMetadata struct {
+	Mode    string
+	BaseURL string
+	// BaseURLSet makes an empty BaseURL override, rather than inherit, the
+	// legacy top-level base URL.
+	BaseURLSet    bool
+	OpenAIVariant string
+}
+
+// WithModelCatalog injects a model catalog into an embedded OpenClaw runtime.
+// It is mutually exclusive with the model.models YAML configuration.
+func WithModelCatalog(catalog ModelCatalog) RuntimeOption {
+	return func(opts *runtimeOptions) {
+		cloned := ModelCatalog{
+			Default: catalog.Default,
+			Models:  make(map[string]model.Model, len(catalog.Models)),
+			Metadata: make(
+				map[string]ModelMetadata,
+				len(catalog.Metadata),
+			),
+		}
+		for name, mdl := range catalog.Models {
+			cloned.Models[name] = mdl
+		}
+		for name, metadata := range catalog.Metadata {
+			cloned.Metadata[name] = metadata
+		}
+		opts.modelCatalog = &cloned
+	}
 }
 
 // WithRuntimeProfileResolver injects per-request runtime profile resolution.
@@ -220,6 +268,7 @@ func gatewayRunOptionInput(
 		UserID:     input.UserID,
 		SessionID:  input.SessionID,
 		RequestID:  input.RequestID,
+		ModelName:  input.ModelName,
 		Message:    input.Message,
 		Extensions: cloneGatewayRunOptionExtensions(input.Extensions),
 	}

--- a/openclaw/gwproto/types.go
+++ b/openclaw/gwproto/types.go
@@ -38,6 +38,10 @@ type MessageRequest struct {
 	UserID    string `json:"user_id,omitempty"`
 	SessionID string `json:"session_id,omitempty"`
 	RequestID string `json:"request_id,omitempty"`
+	// Model selects an alias from an explicitly configured model catalog.
+	// Empty delegates selection to the runtime profile and catalog default;
+	// an unknown alias is rejected with an invalid_model error.
+	Model string `json:"model,omitempty"`
 
 	Extensions map[string]json.RawMessage `json:"extensions,omitempty"`
 }

--- a/openclaw/internal/gateway/model_selection_test.go
+++ b/openclaw/internal/gateway/model_selection_test.go
@@ -1,0 +1,112 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/openclaw/gwproto"
+)
+
+func TestServer_RequestModelSelection(t *testing.T) {
+	r := &runOptionsRunner{}
+	s, err := New(
+		r,
+		WithSelectableModels("fast", "strong"),
+		WithRunOptionResolver(func(
+			ctx context.Context,
+			input RunOptionInput,
+		) (context.Context, []agent.RunOption, error) {
+			if input.ModelName == "" {
+				return ctx, nil, nil
+			}
+			return ctx, []agent.RunOption{
+				agent.WithModelName(input.ModelName),
+			}, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	rsp, status := s.ProcessMessage(context.Background(), gwproto.MessageRequest{
+		From:  "u1",
+		Text:  "hello",
+		Model: "strong",
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Nil(t, rsp.Error)
+	require.Equal(t, "strong", r.opts.ModelName)
+}
+
+func TestServer_RequestModelSelectionRejectsUnknown(t *testing.T) {
+	r := &runOptionsRunner{}
+	s, err := New(r, WithSelectableModels("fast", "strong"))
+	require.NoError(t, err)
+
+	req := gwproto.MessageRequest{
+		From:  "u1",
+		Text:  "hello",
+		Model: "unknown",
+	}
+	rsp, status := s.ProcessMessage(context.Background(), req)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.NotNil(t, rsp.Error)
+	require.Equal(t, errTypeInvalidModel, rsp.Error.Type)
+	require.Contains(t, rsp.Error.Message, `"unknown"`)
+
+	stream, apiErr, status := s.StreamMessage(context.Background(), req)
+	require.Nil(t, stream)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.NotNil(t, apiErr)
+	require.Equal(t, errTypeInvalidModel, apiErr.Type)
+}
+
+func TestServer_RequestModelWithoutSelectableModelsReachesResolver(
+	t *testing.T,
+) {
+	r := &runOptionsRunner{}
+	s, err := New(
+		r,
+		WithRunOptionResolver(func(
+			ctx context.Context,
+			input RunOptionInput,
+		) (context.Context, []agent.RunOption, error) {
+			return ctx, []agent.RunOption{
+				agent.WithModelName(input.ModelName),
+			}, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	rsp, status := s.ProcessMessage(context.Background(), gwproto.MessageRequest{
+		From:  "u1",
+		Text:  "hello",
+		Model: "resolver-owned",
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Nil(t, rsp.Error)
+	require.Equal(t, "resolver-owned", r.opts.ModelName)
+}
+
+func TestWithSelectableModelsNormalizesNames(t *testing.T) {
+	opts := newOptions(WithSelectableModels(" fast ", " ", "strong"))
+	require.Equal(
+		t,
+		map[string]struct{}{"fast": {}, "strong": {}},
+		opts.selectableModels,
+	)
+
+	opts = newOptions(WithSelectableModels())
+	require.Nil(t, opts.selectableModels)
+}

--- a/openclaw/internal/gateway/options.go
+++ b/openclaw/internal/gateway/options.go
@@ -33,6 +33,7 @@ type RunOptionInput struct {
 	UserID     string
 	SessionID  string
 	RequestID  string
+	ModelName  string
 	Message    model.Message
 	Trace      *debugrecorder.Trace
 	Extensions map[string]json.RawMessage
@@ -69,12 +70,31 @@ type options struct {
 	mentionPatterns []string
 
 	runOptionResolver RunOptionResolver
+	selectableModels  map[string]struct{}
 
 	recorder *debugrecorder.Recorder
 	uploads  *uploads.Store
 
 	personaStore    *persona.Store
 	memoryFileStore *memoryfile.Store
+}
+
+// WithSelectableModels configures the model aliases accepted from gateway
+// requests. When configured, a non-empty MessageRequest.model must match one
+// of these aliases.
+func WithSelectableModels(names ...string) Option {
+	return func(o *options) {
+		if len(names) == 0 {
+			o.selectableModels = nil
+			return
+		}
+		o.selectableModels = make(map[string]struct{}, len(names))
+		for _, rawName := range names {
+			if name := strings.TrimSpace(rawName); name != "" {
+				o.selectableModels[name] = struct{}{}
+			}
+		}
+	}
 }
 
 // Option is a function that configures a gateway server.

--- a/openclaw/internal/gateway/process.go
+++ b/openclaw/internal/gateway/process.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -28,6 +29,7 @@ type preparedMessageRun struct {
 	userID                   string
 	sessionID                string
 	requestID                string
+	modelName                string
 	requestSystemPrompt      string
 	requestLateContextPrompt string
 	inbound                  InboundMessage
@@ -271,10 +273,28 @@ func (s *Server) prepareMessageRun(
 		}
 	}
 
+	modelName := strings.TrimSpace(req.Model)
+	if modelName != "" && len(s.selectableModels) > 0 {
+		if _, ok := s.selectableModels[modelName]; !ok {
+			errMsg := fmt.Sprintf("model %q is not available", modelName)
+			if trace != nil {
+				_ = trace.RecordError(errString(errMsg))
+			}
+			rsp := gwproto.MessageResponse{
+				Error: &gwproto.APIError{
+					Type:    errTypeInvalidModel,
+					Message: errMsg,
+				},
+			}
+			return preparedMessageRun{}, &rsp, http.StatusBadRequest
+		}
+	}
+
 	return preparedMessageRun{
 		userID:                   userID,
 		sessionID:                sessionID,
 		requestID:                strings.TrimSpace(req.RequestID),
+		modelName:                modelName,
 		requestSystemPrompt:      strings.TrimSpace(req.RequestSystemPrompt),
 		requestLateContextPrompt: strings.TrimSpace(req.RequestLateContextPrompt),
 		inbound:                  msg,

--- a/openclaw/internal/gateway/server.go
+++ b/openclaw/internal/gateway/server.go
@@ -87,6 +87,7 @@ var errEmptyReplyValue = errors.New(errEmptyReply)
 
 const (
 	errTypeInvalidRequest = "invalid_request"
+	errTypeInvalidModel   = "invalid_model"
 	errTypeUnauthorized   = "unauthorized"
 	errTypeInternal       = "internal_error"
 	errTypeUnsupported    = "unsupported"
@@ -148,6 +149,7 @@ type Server struct {
 	requireMention    bool
 	mentionPatterns   []string
 	runOptionResolver RunOptionResolver
+	selectableModels  map[string]struct{}
 
 	lanes *laneLocker
 
@@ -238,6 +240,7 @@ func New(r runner.Runner, opts ...Option) (*Server, error) {
 		requireMention:    options.requireMention,
 		mentionPatterns:   options.mentionPatterns,
 		runOptionResolver: options.runOptionResolver,
+		selectableModels:  options.selectableModels,
 		lanes:             newLaneLocker(),
 		canceled:          newCancelTracker(),
 		recorder:          options.recorder,
@@ -579,6 +582,7 @@ func (s *Server) resolveRunOptions(
 				UserID:    run.userID,
 				SessionID: run.sessionID,
 				RequestID: run.requestID,
+				ModelName: run.modelName,
 				Message:   run.userMsg,
 				Trace:     debugrecorder.TraceFromContext(ctx),
 				Extensions: cloneExtensions(


### PR DESCRIPTION
## Summary
- add YAML and embedded model catalogs with stable aliases for request-scoped selection
- accept a Gateway model field with request > runtime profile > default precedence and reject unknown aliases
- preserve per-model provider compatibility, deadline finalization, runtime identity, and Admin reporting
- protect catalog configurations from legacy Admin model edits
- document YAML and Go usage in English and Chinese

## Validation
- cd openclaw && go test ./app -skip '^TestAbsPathOrOriginalFallbacks$' -count=1
- cd openclaw && go test ./internal/gateway ./gwproto ./gwclient -count=1
- cd openclaw && go test -race ./app -run 'TestNewRuntime_ModelCatalogGatewaySelection|TestNewRuntime_RequestModelOverridesRuntimeProfile|TestResolvedModelCatalog|TestAdminRuntimeConfigProvider_ModelCatalog|TestAdminRuntimeConfigProvider_SourceCatalog|TestResolveModelCatalog_InjectedMetadataCanClear' -count=1
- cd openclaw && go vet ./app ./internal/gateway ./gwproto ./gwclient
- git diff --check

TestAbsPathOrOriginalFallbacks is excluded because of the existing macOS /var versus /private/var path assertion.