### PR TITLE
skill: support caller-declared invocation loads

### DIFF
--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -1140,6 +1140,13 @@ type RunOptions struct {
 	// (e.g., room ID, user context) without modifying the agent's base initial state.
 	RuntimeState map[string]any
 
+	// SkillLoads declares skills that the selected agent must load before its
+	// first model request. The declarations are validated and applied
+	// atomically against the invocation's effective skill repository.
+	//
+	// Use WithSkillLoads to avoid retaining caller-owned slices.
+	SkillLoads []skill.LoadRequest
+
 	// EventFilterKey overrides the invocation's event filter key used for
 	// scoping session events (event.FilterKey) included in LLM context.
 	//
@@ -1551,13 +1558,15 @@ func (inv *Invocation) Clone(invocationOpts ...InvocationOptions) *Invocation {
 	if inv == nil {
 		return nil
 	}
+	childRunOptions := inv.RunOptions
+	childRunOptions.SkillLoads = nil
 	newInv := &Invocation{
 		InvocationID:    uuid.NewString(),
 		ParentMetadata:  inv.ParentMetadata,
 		Session:         inv.Session,
 		SessionService:  inv.SessionService,
 		Message:         inv.Message,
-		RunOptions:      inv.RunOptions,
+		RunOptions:      childRunOptions,
 		MemoryService:   inv.MemoryService,
 		MemoryReader:    inv.MemoryReader,
 		ArtifactService: inv.ArtifactService,

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -1142,7 +1142,9 @@ type RunOptions struct {
 
 	// SkillLoads declares skills that the selected agent must load before its
 	// first model request. The declarations are validated and applied
-	// atomically against the invocation's effective skill repository.
+	// atomically against the invocation's effective skill repository. Equivalent
+	// declarations for one skill are coalesced; conflicting document sets are
+	// invalid.
 	//
 	// Use WithSkillLoads to avoid retaining caller-owned slices.
 	SkillLoads []skill.LoadRequest

--- a/agent/lazy_agent.go
+++ b/agent/lazy_agent.go
@@ -41,6 +41,12 @@ type lazyAgent struct {
 // still advertise the lazy agent through transfer_to_agent because Info is
 // available without constructing the concrete implementation.
 //
+// Do not use a lazy agent as the root of a Runner run that declares
+// invocation-scoped skill loads. The Runner must determine the selected
+// agent's capabilities before calling Run, while a lazy agent cannot know the
+// capabilities of its factory result until Run. Use runner.AgentFactory for a
+// request-scoped root agent instead.
+//
 // The factory should return an Agent with the same Info().Name as info.Name so
 // traces, transfer targets, and session branches remain easy to follow.
 func NewLazyAgent(

--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -388,6 +388,14 @@ func buildRequestProcessorsWithAgent(a *LLMAgent, options *Options) []flow.Reque
 			options.skillsFilePathHints,
 		),
 	)
+	if len(options.toolActivationRules) > 0 {
+		skillsOpts = append(
+			skillsOpts,
+			processor.WithSkillLoadStateDeltaHook(
+				a.handleToolActivationPostToolResult,
+			),
+		)
+	}
 	if options.MaxLoadedSkills > 0 {
 		skillsOpts = append(
 			skillsOpts,
@@ -1644,6 +1652,9 @@ func (a *LLMAgent) executeAgentFlow(ctx context.Context, invocation *agent.Invoc
 		}
 	}
 
+	if err := a.prepareSkillLoads(ctx, invocation); err != nil {
+		return ctx, nil, fmt.Errorf("prepare skill loads: %w", err)
+	}
 	ctx = a.withToolConcurrencyLimiter(ctx)
 
 	// Use the underlying flow to execute the agent logic.

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -934,6 +934,10 @@ func WithSkills(repo skill.Repository) Option {
 
 // WithSkillRepositoryProvider enables model-agnostic Agent Skills support
 // using a repository selected from the current app/user scope.
+//
+// When an invocation declares SkillLoads, LLMAgent resolves the effective
+// repository once after BeforeAgent callbacks and reuses it for preflight,
+// tool construction, and request processing in that invocation.
 func WithSkillRepositoryProvider(provider skill.RepositoryProvider) Option {
 	return func(opts *Options) {
 		opts.skillsRepositoryProvider = provider

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -936,8 +936,9 @@ func WithSkills(repo skill.Repository) Option {
 // using a repository selected from the current app/user scope.
 //
 // When an invocation declares SkillLoads, LLMAgent resolves the effective
-// repository once after BeforeAgent callbacks and reuses it for preflight,
-// tool construction, and request processing in that invocation.
+// repository once after BeforeAgent callbacks and retains the Skill contents
+// validated during preflight for tool construction and request processing in
+// that invocation.
 func WithSkillRepositoryProvider(provider skill.RepositoryProvider) Option {
 	return func(opts *Options) {
 		opts.skillsRepositoryProvider = provider

--- a/agent/llmagent/skill_load.go
+++ b/agent/llmagent/skill_load.go
@@ -18,6 +18,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 )
 
+// prepareSkillLoads validates and normalizes all declared loads before
+// updating the invocation or activating tools. If any request fails,
+// inv.RunOptions.SkillLoads remains unchanged and no partial load is committed.
 func (a *LLMAgent) prepareSkillLoads(
 	ctx context.Context,
 	inv *agent.Invocation,

--- a/agent/llmagent/skill_load.go
+++ b/agent/llmagent/skill_load.go
@@ -1,0 +1,173 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package llmagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+)
+
+func (a *LLMAgent) prepareSkillLoads(
+	ctx context.Context,
+	inv *agent.Invocation,
+) error {
+	if inv == nil || len(inv.RunOptions.SkillLoads) == 0 {
+		return nil
+	}
+	if inv.Session == nil {
+		return fmt.Errorf(
+			"%w: invocation session is required",
+			skill.ErrInvalidLoadRequest,
+		)
+	}
+
+	repo := a.skillRepositoryForInvocation(ctx, inv)
+	if repo == nil {
+		return fmt.Errorf(
+			"%w: no skill repository is configured",
+			skill.ErrSkillUnavailable,
+		)
+	}
+
+	if max := a.option.MaxLoadedSkills; max > 0 &&
+		len(inv.RunOptions.SkillLoads) > max {
+		return fmt.Errorf(
+			"%w: requested %d skills exceeds maximum %d",
+			skill.ErrInvalidLoadRequest,
+			len(inv.RunOptions.SkillLoads),
+			max,
+		)
+	}
+
+	normalized := make([]skill.LoadRequest, 0, len(inv.RunOptions.SkillLoads))
+	seenSkills := make(map[string]struct{}, len(inv.RunOptions.SkillLoads))
+	for _, requested := range inv.RunOptions.SkillLoads {
+		load, err := normalizeSkillLoadRequest(ctx, repo, requested)
+		if err != nil {
+			return err
+		}
+		if _, ok := seenSkills[load.Name]; ok {
+			return fmt.Errorf(
+				"%w: duplicate skill %q",
+				skill.ErrInvalidLoadRequest,
+				load.Name,
+			)
+		}
+		seenSkills[load.Name] = struct{}{}
+		normalized = append(normalized, load)
+	}
+
+	inv.RunOptions.SkillLoads = normalized
+	a.activatePreparedSkillLoads(inv, normalized)
+	return nil
+}
+
+func normalizeSkillLoadRequest(
+	ctx context.Context,
+	repo skill.Repository,
+	requested skill.LoadRequest,
+) (skill.LoadRequest, error) {
+	name := strings.TrimSpace(requested.Name)
+	if name == "" {
+		return skill.LoadRequest{}, fmt.Errorf(
+			"%w: skill name is required",
+			skill.ErrInvalidLoadRequest,
+		)
+	}
+	if requested.IncludeAllDocs && len(requested.Docs) > 0 {
+		return skill.LoadRequest{}, fmt.Errorf(
+			"%w: skill %q sets both docs and include all docs",
+			skill.ErrInvalidLoadRequest,
+			name,
+		)
+	}
+
+	if !skillSummaryAvailable(ctx, repo, name) {
+		return skill.LoadRequest{}, fmt.Errorf(
+			"%w: skill %q",
+			skill.ErrSkillUnavailable,
+			name,
+		)
+	}
+	resolved, err := skill.GetForContext(ctx, repo, name)
+	if err != nil {
+		return skill.LoadRequest{}, fmt.Errorf(
+			"load skill %q: %w",
+			name,
+			err,
+		)
+	}
+	if resolved == nil {
+		return skill.LoadRequest{}, fmt.Errorf(
+			"%w: skill %q",
+			skill.ErrSkillUnavailable,
+			name,
+		)
+	}
+
+	availableDocs := make(map[string]struct{}, len(resolved.Docs))
+	for _, doc := range resolved.Docs {
+		availableDocs[doc.Path] = struct{}{}
+	}
+	docs := make([]string, 0, len(requested.Docs))
+	seenDocs := make(map[string]struct{}, len(requested.Docs))
+	for _, requestedDoc := range requested.Docs {
+		doc := strings.TrimSpace(requestedDoc)
+		if doc == "" || doc == skill.SkillFile {
+			return skill.LoadRequest{}, fmt.Errorf(
+				"%w: invalid document %q for skill %q",
+				skill.ErrInvalidLoadRequest,
+				requestedDoc,
+				name,
+			)
+		}
+		if _, ok := seenDocs[doc]; ok {
+			return skill.LoadRequest{}, fmt.Errorf(
+				"%w: duplicate document %q for skill %q",
+				skill.ErrInvalidLoadRequest,
+				doc,
+				name,
+			)
+		}
+		if _, ok := availableDocs[doc]; !ok {
+			return skill.LoadRequest{}, fmt.Errorf(
+				"%w: document %q for skill %q",
+				skill.ErrSkillUnavailable,
+				doc,
+				name,
+			)
+		}
+		seenDocs[doc] = struct{}{}
+		docs = append(docs, doc)
+	}
+
+	return skill.LoadRequest{
+		Name:           name,
+		Docs:           docs,
+		IncludeAllDocs: requested.IncludeAllDocs,
+	}, nil
+}
+
+func skillSummaryAvailable(
+	ctx context.Context,
+	repo skill.Repository,
+	name string,
+) bool {
+	for _, summary := range skill.SummariesForContext(ctx, repo) {
+		if summary.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/llmagent/skill_load.go
+++ b/agent/llmagent/skill_load.go
@@ -25,6 +25,27 @@ type preparedSkillRepositoryState struct {
 	repository   skill.Repository
 }
 
+// preparedSkillRepository freezes the contents of declared skills while
+// delegating all other repository behavior to the invocation's effective
+// repository.
+type preparedSkillRepository struct {
+	base      skill.Repository
+	validated map[string]*skill.Skill
+}
+
+type preparedSkillRunEnvProvider interface {
+	SkillRunEnv(
+		ctx context.Context,
+		skillName string,
+	) (map[string]string, error)
+}
+
+var (
+	_ skill.ContextRepository     = (*preparedSkillRepository)(nil)
+	_ skill.RootedRepository      = (*preparedSkillRepository)(nil)
+	_ preparedSkillRunEnvProvider = (*preparedSkillRepository)(nil)
+)
+
 // prepareSkillLoads validates and normalizes all declared loads before
 // updating the invocation or activating tools. If any request fails,
 // inv.RunOptions.SkillLoads remains unchanged and no partial load is committed.
@@ -81,16 +102,19 @@ func (a *LLMAgent) prepareSkillLoads(
 			max,
 		)
 	}
+	validated := make(map[string]*skill.Skill, len(normalized))
 	for _, load := range normalized {
-		if err := validateSkillLoadRequest(ctx, repo, load); err != nil {
+		resolved, err := validateSkillLoadRequest(ctx, repo, load)
+		if err != nil {
 			return err
 		}
+		validated[load.Name] = resolved
 	}
 
 	inv.RunOptions.SkillLoads = normalized
 	inv.SetState(preparedSkillRepositoryStateKey, preparedSkillRepositoryState{
 		invocationID: inv.InvocationID,
-		repository:   repo,
+		repository:   newPreparedSkillRepository(repo, validated),
 	})
 	a.activatePreparedSkillLoads(inv, normalized)
 	return nil
@@ -129,6 +153,96 @@ func preparedSkillRepositoryForInvocation(
 		return nil, false
 	}
 	return prepared.repository, true
+}
+
+func repositoryWithoutPreparedSkills(repo skill.Repository) skill.Repository {
+	for {
+		prepared, ok := repo.(*preparedSkillRepository)
+		if !ok || prepared == nil {
+			return repo
+		}
+		repo = prepared.base
+	}
+}
+
+func newPreparedSkillRepository(
+	base skill.Repository,
+	validated map[string]*skill.Skill,
+) skill.Repository {
+	snapshots := make(map[string]*skill.Skill, len(validated))
+	for name, resolved := range validated {
+		snapshots[name] = clonePreparedSkill(resolved)
+	}
+	return &preparedSkillRepository{
+		base:      base,
+		validated: snapshots,
+	}
+}
+
+func clonePreparedSkill(resolved *skill.Skill) *skill.Skill {
+	if resolved == nil {
+		return nil
+	}
+	cloned := *resolved
+	cloned.Docs = append([]skill.Doc(nil), resolved.Docs...)
+	return &cloned
+}
+
+func (r *preparedSkillRepository) Summaries() []skill.Summary {
+	return r.base.Summaries()
+}
+
+func (r *preparedSkillRepository) Get(name string) (*skill.Skill, error) {
+	if resolved, ok := r.validated[name]; ok {
+		return clonePreparedSkill(resolved), nil
+	}
+	return r.base.Get(name)
+}
+
+func (r *preparedSkillRepository) Path(name string) (string, error) {
+	return r.base.Path(name)
+}
+
+func (r *preparedSkillRepository) Roots() []string {
+	rooted, ok := r.base.(skill.RootedRepository)
+	if !ok || rooted == nil {
+		return nil
+	}
+	return rooted.Roots()
+}
+
+func (r *preparedSkillRepository) SummariesForContext(
+	ctx context.Context,
+) []skill.Summary {
+	return skill.SummariesForContext(ctx, r.base)
+}
+
+func (r *preparedSkillRepository) GetForContext(
+	ctx context.Context,
+	name string,
+) (*skill.Skill, error) {
+	if resolved, ok := r.validated[name]; ok {
+		return clonePreparedSkill(resolved), nil
+	}
+	return skill.GetForContext(ctx, r.base, name)
+}
+
+func (r *preparedSkillRepository) PathForContext(
+	ctx context.Context,
+	name string,
+) (string, error) {
+	return skill.PathForContext(ctx, r.base, name)
+}
+
+func (r *preparedSkillRepository) SkillRunEnv(
+	ctx context.Context,
+	skillName string,
+) (map[string]string, error) {
+	provider, ok := r.base.(preparedSkillRunEnvProvider)
+	if !ok || provider == nil {
+		return nil, nil
+	}
+	return provider.SkillRunEnv(ctx, skillName)
 }
 
 func normalizeSkillLoadRequest(
@@ -184,9 +298,9 @@ func validateSkillLoadRequest(
 	ctx context.Context,
 	repo skill.Repository,
 	load skill.LoadRequest,
-) error {
+) (*skill.Skill, error) {
 	if !skillSummaryAvailable(ctx, repo, load.Name) {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: skill %q",
 			skill.ErrSkillUnavailable,
 			load.Name,
@@ -194,19 +308,20 @@ func validateSkillLoadRequest(
 	}
 	resolved, err := skill.GetForContext(ctx, repo, load.Name)
 	if err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"load skill %q: %w",
 			load.Name,
 			err,
 		)
 	}
 	if resolved == nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%w: skill %q",
 			skill.ErrSkillUnavailable,
 			load.Name,
 		)
 	}
+	resolved = clonePreparedSkill(resolved)
 
 	availableDocs := make(map[string]struct{}, len(resolved.Docs))
 	for _, doc := range resolved.Docs {
@@ -214,7 +329,7 @@ func validateSkillLoadRequest(
 	}
 	for _, doc := range load.Docs {
 		if _, ok := availableDocs[doc]; !ok {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"%w: document %q for skill %q",
 				skill.ErrSkillUnavailable,
 				doc,
@@ -222,7 +337,7 @@ func validateSkillLoadRequest(
 			)
 		}
 	}
-	return nil
+	return resolved, nil
 }
 
 func skillSummaryAvailable(

--- a/agent/llmagent/skill_load.go
+++ b/agent/llmagent/skill_load.go
@@ -18,6 +18,13 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 )
 
+const preparedSkillRepositoryStateKey = "__trpc_agent_internal_prepared_skill_repository__"
+
+type preparedSkillRepositoryState struct {
+	invocationID string
+	repository   skill.Repository
+}
+
 // prepareSkillLoads validates and normalizes all declared loads before
 // updating the invocation or activating tools. If any request fails,
 // inv.RunOptions.SkillLoads remains unchanged and no partial load is committed.
@@ -43,42 +50,88 @@ func (a *LLMAgent) prepareSkillLoads(
 		)
 	}
 
-	if max := a.option.MaxLoadedSkills; max > 0 &&
-		len(inv.RunOptions.SkillLoads) > max {
-		return fmt.Errorf(
-			"%w: requested %d skills exceeds maximum %d",
-			skill.ErrInvalidLoadRequest,
-			len(inv.RunOptions.SkillLoads),
-			max,
-		)
-	}
-
 	normalized := make([]skill.LoadRequest, 0, len(inv.RunOptions.SkillLoads))
-	seenSkills := make(map[string]struct{}, len(inv.RunOptions.SkillLoads))
+	seenSkills := make(
+		map[string]skill.LoadRequest,
+		len(inv.RunOptions.SkillLoads),
+	)
 	for _, requested := range inv.RunOptions.SkillLoads {
-		load, err := normalizeSkillLoadRequest(ctx, repo, requested)
+		load, err := normalizeSkillLoadRequest(requested)
 		if err != nil {
 			return err
 		}
-		if _, ok := seenSkills[load.Name]; ok {
-			return fmt.Errorf(
-				"%w: duplicate skill %q",
-				skill.ErrInvalidLoadRequest,
-				load.Name,
-			)
+		if existing, ok := seenSkills[load.Name]; ok {
+			if !sameSkillLoadRequest(existing, load) {
+				return fmt.Errorf(
+					"%w: conflicting declarations for skill %q",
+					skill.ErrInvalidLoadRequest,
+					load.Name,
+				)
+			}
+			continue
 		}
-		seenSkills[load.Name] = struct{}{}
+		seenSkills[load.Name] = load
 		normalized = append(normalized, load)
+	}
+	if max := a.option.MaxLoadedSkills; max > 0 && len(normalized) > max {
+		return fmt.Errorf(
+			"%w: requested %d skills exceeds maximum %d",
+			skill.ErrInvalidLoadRequest,
+			len(normalized),
+			max,
+		)
+	}
+	for _, load := range normalized {
+		if err := validateSkillLoadRequest(ctx, repo, load); err != nil {
+			return err
+		}
 	}
 
 	inv.RunOptions.SkillLoads = normalized
+	inv.SetState(preparedSkillRepositoryStateKey, preparedSkillRepositoryState{
+		invocationID: inv.InvocationID,
+		repository:   repo,
+	})
 	a.activatePreparedSkillLoads(inv, normalized)
 	return nil
 }
 
+func sameSkillLoadRequest(a, b skill.LoadRequest) bool {
+	if a.Name != b.Name || a.IncludeAllDocs != b.IncludeAllDocs ||
+		len(a.Docs) != len(b.Docs) {
+		return false
+	}
+	docs := make(map[string]struct{}, len(a.Docs))
+	for _, doc := range a.Docs {
+		docs[doc] = struct{}{}
+	}
+	for _, doc := range b.Docs {
+		if _, ok := docs[doc]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func preparedSkillRepositoryForInvocation(
+	inv *agent.Invocation,
+) (skill.Repository, bool) {
+	if inv == nil {
+		return nil, false
+	}
+	raw, ok := inv.GetState(preparedSkillRepositoryStateKey)
+	if !ok {
+		return nil, false
+	}
+	prepared, ok := raw.(preparedSkillRepositoryState)
+	if !ok || prepared.invocationID != inv.InvocationID ||
+		prepared.repository == nil {
+		return nil, false
+	}
+	return prepared.repository, true
+}
+
 func normalizeSkillLoadRequest(
-	ctx context.Context,
-	repo skill.Repository,
 	requested skill.LoadRequest,
 ) (skill.LoadRequest, error) {
 	name := strings.TrimSpace(requested.Name)
@@ -96,33 +149,6 @@ func normalizeSkillLoadRequest(
 		)
 	}
 
-	if !skillSummaryAvailable(ctx, repo, name) {
-		return skill.LoadRequest{}, fmt.Errorf(
-			"%w: skill %q",
-			skill.ErrSkillUnavailable,
-			name,
-		)
-	}
-	resolved, err := skill.GetForContext(ctx, repo, name)
-	if err != nil {
-		return skill.LoadRequest{}, fmt.Errorf(
-			"load skill %q: %w",
-			name,
-			err,
-		)
-	}
-	if resolved == nil {
-		return skill.LoadRequest{}, fmt.Errorf(
-			"%w: skill %q",
-			skill.ErrSkillUnavailable,
-			name,
-		)
-	}
-
-	availableDocs := make(map[string]struct{}, len(resolved.Docs))
-	for _, doc := range resolved.Docs {
-		availableDocs[doc.Path] = struct{}{}
-	}
 	docs := make([]string, 0, len(requested.Docs))
 	seenDocs := make(map[string]struct{}, len(requested.Docs))
 	for _, requestedDoc := range requested.Docs {
@@ -143,14 +169,6 @@ func normalizeSkillLoadRequest(
 				name,
 			)
 		}
-		if _, ok := availableDocs[doc]; !ok {
-			return skill.LoadRequest{}, fmt.Errorf(
-				"%w: document %q for skill %q",
-				skill.ErrSkillUnavailable,
-				doc,
-				name,
-			)
-		}
 		seenDocs[doc] = struct{}{}
 		docs = append(docs, doc)
 	}
@@ -160,6 +178,51 @@ func normalizeSkillLoadRequest(
 		Docs:           docs,
 		IncludeAllDocs: requested.IncludeAllDocs,
 	}, nil
+}
+
+func validateSkillLoadRequest(
+	ctx context.Context,
+	repo skill.Repository,
+	load skill.LoadRequest,
+) error {
+	if !skillSummaryAvailable(ctx, repo, load.Name) {
+		return fmt.Errorf(
+			"%w: skill %q",
+			skill.ErrSkillUnavailable,
+			load.Name,
+		)
+	}
+	resolved, err := skill.GetForContext(ctx, repo, load.Name)
+	if err != nil {
+		return fmt.Errorf(
+			"load skill %q: %w",
+			load.Name,
+			err,
+		)
+	}
+	if resolved == nil {
+		return fmt.Errorf(
+			"%w: skill %q",
+			skill.ErrSkillUnavailable,
+			load.Name,
+		)
+	}
+
+	availableDocs := make(map[string]struct{}, len(resolved.Docs))
+	for _, doc := range resolved.Docs {
+		availableDocs[doc.Path] = struct{}{}
+	}
+	for _, doc := range load.Docs {
+		if _, ok := availableDocs[doc]; !ok {
+			return fmt.Errorf(
+				"%w: document %q for skill %q",
+				skill.ErrSkillUnavailable,
+				doc,
+				load.Name,
+			)
+		}
+	}
+	return nil
 }
 
 func skillSummaryAvailable(

--- a/agent/llmagent/skill_load_test.go
+++ b/agent/llmagent/skill_load_test.go
@@ -288,7 +288,11 @@ func TestPrepareSkillLoadsRejectsInvalidRequests(t *testing.T) {
 			options := []Option{WithSkills(tt.repo)}
 			options = append(options, tt.options...)
 			agt := New("tester", options...)
-			original := append([]skill.LoadRequest(nil), tt.loads...)
+			original := make([]skill.LoadRequest, len(tt.loads))
+			for i, load := range tt.loads {
+				original[i] = load
+				original[i].Docs = append([]string(nil), load.Docs...)
+			}
 			inv := agent.NewInvocation(
 				agent.WithInvocationSession(tt.session),
 				agent.WithInvocationRunOptions(agent.RunOptions{

--- a/agent/llmagent/skill_load_test.go
+++ b/agent/llmagent/skill_load_test.go
@@ -25,11 +25,15 @@ import (
 )
 
 type skillLoadTestRepository struct {
-	skills map[string]*skill.Skill
-	err    error
+	skills    map[string]*skill.Skill
+	summaries []skill.Summary
+	err       error
 }
 
 func (r *skillLoadTestRepository) Summaries() []skill.Summary {
+	if r.summaries != nil {
+		return append([]skill.Summary(nil), r.summaries...)
+	}
 	var out []skill.Summary
 	for _, resolved := range r.skills {
 		out = append(out, resolved.Summary)
@@ -174,6 +178,135 @@ func TestPrepareSkillLoadsRejectsConflictingDocSelection(t *testing.T) {
 	require.Empty(t, inv.Session.SnapshotState())
 }
 
+func TestPrepareSkillLoadsRejectsInvalidRequests(t *testing.T) {
+	reviewSkill := &skill.Skill{
+		Summary: skill.Summary{Name: "review"},
+		Docs: []skill.Doc{{
+			Path: "guide.md",
+		}},
+	}
+	repo := &skillLoadTestRepository{
+		skills: map[string]*skill.Skill{"review": reviewSkill},
+	}
+	nilSkillRepo := &skillLoadTestRepository{
+		skills:    map[string]*skill.Skill{"review": nil},
+		summaries: []skill.Summary{{Name: "review"}},
+	}
+	tests := []struct {
+		name    string
+		repo    *skillLoadTestRepository
+		session *session.Session
+		loads   []skill.LoadRequest
+		options []Option
+		wantErr error
+	}{
+		{
+			name:    "missing session",
+			repo:    repo,
+			loads:   []skill.LoadRequest{{Name: "review"}},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "exceeds maximum",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{
+				{Name: "review"},
+				{Name: "other"},
+			},
+			options: []Option{WithMaxLoadedSkills(1)},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "duplicate skill",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{
+				{Name: "review"},
+				{Name: " review "},
+			},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "empty skill name",
+			repo:    repo,
+			session: &session.Session{},
+			loads:   []skill.LoadRequest{{Name: " "}},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "nil resolved skill",
+			repo:    nilSkillRepo,
+			session: &session.Session{},
+			loads:   []skill.LoadRequest{{Name: "review"}},
+			wantErr: skill.ErrSkillUnavailable,
+		},
+		{
+			name:    "empty document",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{{
+				Name: "review",
+				Docs: []string{" "},
+			}},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "skill file document",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{{
+				Name: "review",
+				Docs: []string{skill.SkillFile},
+			}},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "duplicate document",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{{
+				Name: "review",
+				Docs: []string{"guide.md", " guide.md "},
+			}},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "unavailable document",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{{
+				Name: "review",
+				Docs: []string{"missing.md"},
+			}},
+			wantErr: skill.ErrSkillUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := []Option{WithSkills(tt.repo)}
+			options = append(options, tt.options...)
+			agt := New("tester", options...)
+			original := append([]skill.LoadRequest(nil), tt.loads...)
+			inv := agent.NewInvocation(
+				agent.WithInvocationSession(tt.session),
+				agent.WithInvocationRunOptions(agent.RunOptions{
+					SkillLoads: tt.loads,
+				}),
+			)
+			agt.setupInvocation(inv)
+
+			err := agt.prepareSkillLoads(context.Background(), inv)
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, original, inv.RunOptions.SkillLoads)
+			if inv.Session != nil {
+				require.Empty(t, inv.Session.SnapshotState())
+			}
+		})
+	}
+}
+
 func TestDeclaredSkillLoadIncludesAllDocs(t *testing.T) {
 	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
 		"review": {
@@ -221,10 +354,16 @@ func TestDeclaredSkillLoadPreservesExistingDocs(t *testing.T) {
 		"review": {
 			Summary: skill.Summary{Name: "review"},
 			Body:    "Review body",
-			Docs: []skill.Doc{{
-				Path:    "old.md",
-				Content: "Old doc body",
-			}},
+			Docs: []skill.Doc{
+				{
+					Path:    "old.md",
+					Content: "Old doc body",
+				},
+				{
+					Path:    "other.md",
+					Content: "Other doc body",
+				},
+			},
 		},
 	}}
 	modelStub := &captureModel{}
@@ -252,11 +391,9 @@ func TestDeclaredSkillLoadPreservesExistingDocs(t *testing.T) {
 	}
 
 	require.NotNil(t, modelStub.got)
-	require.Contains(
-		t,
-		skillLoadTestSystemContent(modelStub.got),
-		"Old doc body",
-	)
+	system := skillLoadTestSystemContent(modelStub.got)
+	require.Contains(t, system, "Old doc body")
+	require.NotContains(t, system, "Other doc body")
 	docs, ok := inv.Session.GetState(skill.DocsKey("tester", "review"))
 	require.True(t, ok)
 	require.JSONEq(t, `["old.md"]`, string(docs))

--- a/agent/llmagent/skill_load_test.go
+++ b/agent/llmagent/skill_load_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,7 @@ type skillLoadTestRepository struct {
 	skills    map[string]*skill.Skill
 	summaries []skill.Summary
 	err       error
+	getCalls  *atomic.Int32
 }
 
 func (r *skillLoadTestRepository) Summaries() []skill.Summary {
@@ -42,6 +44,9 @@ func (r *skillLoadTestRepository) Summaries() []skill.Summary {
 }
 
 func (r *skillLoadTestRepository) Get(name string) (*skill.Skill, error) {
+	if r.getCalls != nil {
+		r.getCalls.Add(1)
+	}
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -123,8 +128,11 @@ func TestPrepareSkillLoadsNormalizesCompleteBatch(t *testing.T) {
 		Name: "review",
 		Docs: []string{"guide.md"},
 	}}, inv.RunOptions.SkillLoads)
-	_, loaded := inv.Session.GetState(skill.LoadedKey("tester", "review"))
-	require.False(t, loaded, "preflight must not partially commit state")
+	require.Empty(
+		t,
+		inv.Session.SnapshotState(),
+		"preflight must not partially commit state",
+	)
 }
 
 func TestPrepareSkillLoadsFailsAtomically(t *testing.T) {
@@ -181,12 +189,16 @@ func TestPrepareSkillLoadsRejectsConflictingDocSelection(t *testing.T) {
 func TestPrepareSkillLoadsRejectsInvalidRequests(t *testing.T) {
 	reviewSkill := &skill.Skill{
 		Summary: skill.Summary{Name: "review"},
-		Docs: []skill.Doc{{
-			Path: "guide.md",
-		}},
+		Docs: []skill.Doc{
+			{Path: "guide.md"},
+			{Path: "other.md"},
+		},
 	}
 	repo := &skillLoadTestRepository{
-		skills: map[string]*skill.Skill{"review": reviewSkill},
+		skills: map[string]*skill.Skill{
+			"review": reviewSkill,
+			"other":  {Summary: skill.Summary{Name: "other"}},
+		},
 	}
 	nilSkillRepo := &skillLoadTestRepository{
 		skills:    map[string]*skill.Skill{"review": nil},
@@ -218,12 +230,22 @@ func TestPrepareSkillLoadsRejectsInvalidRequests(t *testing.T) {
 			wantErr: skill.ErrInvalidLoadRequest,
 		},
 		{
-			name:    "duplicate skill",
+			name:    "conflicting skill declarations",
 			repo:    repo,
 			session: &session.Session{},
 			loads: []skill.LoadRequest{
+				{Name: "review", Docs: []string{"guide.md"}},
+				{Name: " review ", Docs: []string{"other.md"}},
+			},
+			wantErr: skill.ErrInvalidLoadRequest,
+		},
+		{
+			name:    "conflicting include all declarations",
+			repo:    repo,
+			session: &session.Session{},
+			loads: []skill.LoadRequest{
+				{Name: "review", IncludeAllDocs: true},
 				{Name: "review"},
-				{Name: " review "},
 			},
 			wantErr: skill.ErrInvalidLoadRequest,
 		},
@@ -307,6 +329,82 @@ func TestPrepareSkillLoadsRejectsInvalidRequests(t *testing.T) {
 			if inv.Session != nil {
 				require.Empty(t, inv.Session.SnapshotState())
 			}
+		})
+	}
+}
+
+func TestPrepareSkillLoadsCoalescesEquivalentDeclarations(t *testing.T) {
+	tests := []struct {
+		name  string
+		loads []skill.LoadRequest
+		want  skill.LoadRequest
+	}{
+		{
+			name: "same document set",
+			loads: []skill.LoadRequest{
+				{
+					Name: " review ",
+					Docs: []string{" guide.md ", "security.md"},
+				},
+				{
+					Name: "review",
+					Docs: []string{" security.md ", "guide.md"},
+				},
+			},
+			want: skill.LoadRequest{
+				Name: "review",
+				Docs: []string{"guide.md", "security.md"},
+			},
+		},
+		{
+			name: "include all documents",
+			loads: []skill.LoadRequest{
+				{Name: " review ", IncludeAllDocs: true},
+				{Name: "review", IncludeAllDocs: true},
+			},
+			want: skill.LoadRequest{
+				Name:           "review",
+				Docs:           []string{},
+				IncludeAllDocs: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var getCalls atomic.Int32
+			repo := &skillLoadTestRepository{
+				getCalls: &getCalls,
+				skills: map[string]*skill.Skill{
+					"review": {
+						Summary: skill.Summary{Name: "review"},
+						Docs: []skill.Doc{
+							{Path: "guide.md"},
+							{Path: "security.md"},
+						},
+					},
+				},
+			}
+			agt := New(
+				"tester",
+				WithSkills(repo),
+				WithMaxLoadedSkills(1),
+			)
+			runOptions := agent.NewRunOptions(
+				agent.WithSkillLoads(tt.loads[0]),
+				agent.WithSkillLoads(tt.loads[1]),
+			)
+			inv := agent.NewInvocation(
+				agent.WithInvocationSession(&session.Session{}),
+				agent.WithInvocationRunOptions(runOptions),
+			)
+			agt.setupInvocation(inv)
+
+			err := agt.prepareSkillLoads(context.Background(), inv)
+			require.NoError(t, err)
+			require.Equal(t, []skill.LoadRequest{tt.want}, inv.RunOptions.SkillLoads)
+			require.Empty(t, inv.Session.SnapshotState())
+			require.Equal(t, int32(1), getCalls.Load())
 		})
 	}
 }
@@ -416,12 +514,14 @@ func skillLoadTestSystemContent(req *model.Request) string {
 	return system
 }
 
-func TestPrepareSkillLoadsActivatesToolsForFirstModelRequest(t *testing.T) {
+func TestDeclaredSkillLoadActivatesToolsForFirstModelRequest(t *testing.T) {
 	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
 		"review": {Summary: skill.Summary{Name: "review"}},
 	}}
+	modelStub := &captureModel{}
 	agt := New(
 		"tester",
+		WithModel(modelStub),
 		WithSkills(repo),
 		WithActivatableToolSets([]tool.ToolSet{
 			activationToolSet{
@@ -436,17 +536,141 @@ func TestPrepareSkillLoadsActivatesToolsForFirstModelRequest(t *testing.T) {
 	)
 	inv := agent.NewInvocation(
 		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationMessage(model.NewUserMessage("review")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		}),
+	)
+
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.NotNil(t, modelStub.got)
+	require.Contains(t, modelStub.got.Tools, "review-tools_inspect")
+	records := invocationToolActivationRecords(inv)
+	require.Len(t, records, 1)
+	require.Equal(t, "review-tools", records[0].ToolSetName)
+}
+
+func TestDeclaredSkillLoadsReusePreparedRepository(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+			Body:    "Pinned review body",
+		},
+	}}
+	tests := []struct {
+		name    string
+		options []Option
+	}{
+		{name: "system prompt mode"},
+		{
+			name: "tool result mode",
+			options: []Option{
+				WithSkillsLoadedContentInToolResults(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var providerCalls atomic.Int32
+			provider := skill.RepositoryProviderFunc(
+				func(context.Context, skill.SkillScope) (skill.Repository, error) {
+					if providerCalls.Add(1) == 1 {
+						return repo, nil
+					}
+					return nil, errors.New("transient repository failure")
+				},
+			)
+			modelStub := &captureModel{}
+			options := []Option{
+				WithModel(modelStub),
+				WithSkillRepositoryProvider(provider),
+				WithSkillScopeMode(skill.SkillScopeApp),
+			}
+			options = append(options, tt.options...)
+			agt := New("tester", options...)
+			inv := agent.NewInvocation(
+				agent.WithInvocationSession(&session.Session{AppName: "app"}),
+				agent.WithInvocationMessage(model.NewUserMessage("review")),
+				agent.WithInvocationRunOptions(agent.RunOptions{
+					SkillLoads: []skill.LoadRequest{{Name: "review"}},
+				}),
+			)
+
+			events, err := agt.Run(context.Background(), inv)
+			require.NoError(t, err)
+			for range events {
+			}
+
+			require.Equal(t, int32(1), providerCalls.Load())
+			require.NotNil(t, modelStub.got)
+			require.Contains(
+				t,
+				skillLoadTestSystemContent(modelStub.got),
+				"Pinned review body",
+			)
+			require.Contains(t, modelStub.got.Tools, "skill_load")
+		})
+	}
+}
+
+func TestPreparedSkillRepositoryDoesNotLeakToClone(t *testing.T) {
+	repoA := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {Summary: skill.Summary{Name: "review"}},
+	}}
+	repoB := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"other": {Summary: skill.Summary{Name: "other"}},
+	}}
+	var providerCalls atomic.Int32
+	provider := skill.RepositoryProviderFunc(
+		func(context.Context, skill.SkillScope) (skill.Repository, error) {
+			if providerCalls.Add(1) == 1 {
+				return repoA, nil
+			}
+			return repoB, nil
+		},
+	)
+	agt := New(
+		"tester",
+		WithSkillRepositoryProvider(provider),
+		WithSkillScopeMode(skill.SkillScopeApp),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{AppName: "app"}),
 		agent.WithInvocationRunOptions(agent.RunOptions{
 			SkillLoads: []skill.LoadRequest{{Name: "review"}},
 		}),
 	)
 	agt.setupInvocation(inv)
 
-	err := agt.prepareSkillLoads(context.Background(), inv)
-	require.NoError(t, err)
-	records := invocationToolActivationRecords(inv)
-	require.Len(t, records, 1)
-	require.Equal(t, "review-tools", records[0].ToolSetName)
+	require.NoError(t, agt.prepareSkillLoads(context.Background(), inv))
+	require.Same(
+		t,
+		repoA,
+		agt.skillRepositoryForInvocation(context.Background(), inv),
+	)
+	require.Equal(t, int32(1), providerCalls.Load())
+
+	view := inv.View()
+	require.Same(
+		t,
+		repoA,
+		agt.skillRepositoryForInvocation(context.Background(), view),
+	)
+	require.Equal(t, int32(1), providerCalls.Load())
+
+	child := inv.Clone()
+	require.Empty(t, child.RunOptions.SkillLoads)
+	require.Same(
+		t,
+		repoB,
+		agt.skillRepositoryForInvocation(context.Background(), child),
+	)
+	require.Equal(t, int32(2), providerCalls.Load())
 }
 
 func TestSkillLoadsUseContextReturnedByBeforeAgent(t *testing.T) {

--- a/agent/llmagent/skill_load_test.go
+++ b/agent/llmagent/skill_load_test.go
@@ -30,6 +30,7 @@ type skillLoadTestRepository struct {
 	summaries []skill.Summary
 	err       error
 	getCalls  *atomic.Int32
+	getFunc   func(string, int32) (*skill.Skill, error)
 }
 
 func (r *skillLoadTestRepository) Summaries() []skill.Summary {
@@ -44,8 +45,12 @@ func (r *skillLoadTestRepository) Summaries() []skill.Summary {
 }
 
 func (r *skillLoadTestRepository) Get(name string) (*skill.Skill, error) {
+	var call int32
 	if r.getCalls != nil {
-		r.getCalls.Add(1)
+		call = r.getCalls.Add(1)
+	}
+	if r.getFunc != nil {
+		return r.getFunc(name, call)
 	}
 	if r.err != nil {
 		return nil, r.err
@@ -554,13 +559,39 @@ func TestDeclaredSkillLoadActivatesToolsForFirstModelRequest(t *testing.T) {
 	require.Equal(t, "review-tools", records[0].ToolSetName)
 }
 
-func TestDeclaredSkillLoadsReusePreparedRepository(t *testing.T) {
-	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
-		"review": {
-			Summary: skill.Summary{Name: "review"},
-			Body:    "Pinned review body",
-		},
+func TestPreparedSkillRepositoryCopiesValidatedContent(t *testing.T) {
+	resolved := &skill.Skill{
+		Summary: skill.Summary{Name: "review"},
+		Body:    "validated body",
+		Docs: []skill.Doc{{
+			Path:    "guide.md",
+			Content: "validated guide",
+		}},
+	}
+	base := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": resolved,
 	}}
+	repo := newPreparedSkillRepository(
+		base,
+		map[string]*skill.Skill{"review": resolved},
+	)
+
+	resolved.Body = "changed body"
+	resolved.Docs[0].Content = "changed guide"
+	first, err := repo.Get("review")
+	require.NoError(t, err)
+	require.Equal(t, "validated body", first.Body)
+	require.Equal(t, "validated guide", first.Docs[0].Content)
+
+	first.Body = "consumer mutation"
+	first.Docs[0].Content = "consumer mutation"
+	second, err := repo.Get("review")
+	require.NoError(t, err)
+	require.Equal(t, "validated body", second.Body)
+	require.Equal(t, "validated guide", second.Docs[0].Content)
+}
+
+func TestDeclaredSkillLoadsReusePreparedRepository(t *testing.T) {
 	tests := []struct {
 		name    string
 		options []Option
@@ -577,6 +608,24 @@ func TestDeclaredSkillLoadsReusePreparedRepository(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var providerCalls atomic.Int32
+			var getCalls atomic.Int32
+			repo := &skillLoadTestRepository{
+				summaries: []skill.Summary{{Name: "review"}},
+				getCalls:  &getCalls,
+				getFunc: func(_ string, call int32) (*skill.Skill, error) {
+					if call == 1 {
+						return &skill.Skill{
+							Summary: skill.Summary{Name: "review"},
+							Body:    "Pinned review body",
+							Docs: []skill.Doc{{
+								Path:    "guide.md",
+								Content: "Pinned guide body",
+							}},
+						}, nil
+					}
+					return nil, errors.New("transient skill read failure")
+				},
+			}
 			provider := skill.RepositoryProviderFunc(
 				func(context.Context, skill.SkillScope) (skill.Repository, error) {
 					if providerCalls.Add(1) == 1 {
@@ -597,7 +646,10 @@ func TestDeclaredSkillLoadsReusePreparedRepository(t *testing.T) {
 				agent.WithInvocationSession(&session.Session{AppName: "app"}),
 				agent.WithInvocationMessage(model.NewUserMessage("review")),
 				agent.WithInvocationRunOptions(agent.RunOptions{
-					SkillLoads: []skill.LoadRequest{{Name: "review"}},
+					SkillLoads: []skill.LoadRequest{{
+						Name: "review",
+						Docs: []string{"guide.md"},
+					}},
 				}),
 			)
 
@@ -607,12 +659,11 @@ func TestDeclaredSkillLoadsReusePreparedRepository(t *testing.T) {
 			}
 
 			require.Equal(t, int32(1), providerCalls.Load())
+			require.Equal(t, int32(1), getCalls.Load())
 			require.NotNil(t, modelStub.got)
-			require.Contains(
-				t,
-				skillLoadTestSystemContent(modelStub.got),
-				"Pinned review body",
-			)
+			system := skillLoadTestSystemContent(modelStub.got)
+			require.Contains(t, system, "Pinned review body")
+			require.Contains(t, system, "Pinned guide body")
 			require.Contains(t, modelStub.got.Tools, "skill_load")
 		})
 	}
@@ -648,17 +699,26 @@ func TestPreparedSkillRepositoryDoesNotLeakToClone(t *testing.T) {
 	agt.setupInvocation(inv)
 
 	require.NoError(t, agt.prepareSkillLoads(context.Background(), inv))
+	preparedRepo := agt.skillRepositoryForInvocation(context.Background(), inv)
+	require.NotSame(t, repoA, preparedRepo)
+	resolved, err := skill.GetForContext(
+		context.Background(),
+		preparedRepo,
+		"review",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "review", resolved.Summary.Name)
+	require.Equal(t, int32(1), providerCalls.Load())
 	require.Same(
 		t,
 		repoA,
-		agt.skillRepositoryForInvocation(context.Background(), inv),
+		agt.InvocationSkillRepository(context.Background(), inv),
 	)
-	require.Equal(t, int32(1), providerCalls.Load())
 
 	view := inv.View()
 	require.Same(
 		t,
-		repoA,
+		preparedRepo,
 		agt.skillRepositoryForInvocation(context.Background(), view),
 	)
 	require.Equal(t, int32(1), providerCalls.Load())

--- a/agent/llmagent/skill_load_test.go
+++ b/agent/llmagent/skill_load_test.go
@@ -1,0 +1,264 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package llmagent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type skillLoadTestRepository struct {
+	skills map[string]*skill.Skill
+	err    error
+}
+
+func (r *skillLoadTestRepository) Summaries() []skill.Summary {
+	var out []skill.Summary
+	for _, resolved := range r.skills {
+		out = append(out, resolved.Summary)
+	}
+	return out
+}
+
+func (r *skillLoadTestRepository) Get(name string) (*skill.Skill, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	resolved, ok := r.skills[name]
+	if !ok {
+		return nil, fmt.Errorf("skill %q not found", name)
+	}
+	return resolved, nil
+}
+
+func TestPrepareSkillLoadsPreservesRepositoryFailure(t *testing.T) {
+	repositoryErr := errors.New("repository unavailable")
+	repo := &skillLoadTestRepository{
+		skills: map[string]*skill.Skill{
+			"review": {Summary: skill.Summary{Name: "review"}},
+		},
+		err: repositoryErr,
+	}
+	agt := New("tester", WithSkills(repo))
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		}),
+	)
+	agt.setupInvocation(inv)
+
+	err := agt.prepareSkillLoads(context.Background(), inv)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, repositoryErr))
+	require.False(t, errors.Is(err, skill.ErrSkillUnavailable))
+	require.Empty(t, inv.Session.SnapshotState())
+}
+
+func TestPrepareSkillLoadsWithoutRepositoryIsUnavailable(t *testing.T) {
+	agt := New("tester")
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		}),
+	)
+	agt.setupInvocation(inv)
+
+	err := agt.prepareSkillLoads(context.Background(), inv)
+	require.ErrorIs(t, err, skill.ErrSkillUnavailable)
+	require.NotErrorIs(t, err, skill.ErrInvalidLoadRequest)
+	require.Empty(t, inv.Session.SnapshotState())
+}
+
+func (r *skillLoadTestRepository) Path(string) (string, error) {
+	return "", nil
+}
+
+func TestPrepareSkillLoadsNormalizesCompleteBatch(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+			Docs: []skill.Doc{{
+				Path: "guide.md",
+			}},
+		},
+	}}
+	agt := New("tester", WithSkills(repo))
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{
+				Name: " review ",
+				Docs: []string{" guide.md "},
+			}},
+		}),
+	)
+	agt.setupInvocation(inv)
+
+	err := agt.prepareSkillLoads(context.Background(), inv)
+	require.NoError(t, err)
+	require.Equal(t, []skill.LoadRequest{{
+		Name: "review",
+		Docs: []string{"guide.md"},
+	}}, inv.RunOptions.SkillLoads)
+	_, loaded := inv.Session.GetState(skill.LoadedKey("tester", "review"))
+	require.False(t, loaded, "preflight must not partially commit state")
+}
+
+func TestPrepareSkillLoadsFailsAtomically(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+		},
+	}}
+	agt := New("tester", WithSkills(repo))
+	original := []skill.LoadRequest{
+		{Name: "review"},
+		{Name: "missing"},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: original,
+		}),
+	)
+	agt.setupInvocation(inv)
+
+	err := agt.prepareSkillLoads(context.Background(), inv)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, skill.ErrSkillUnavailable))
+	require.Equal(t, original, inv.RunOptions.SkillLoads)
+	require.Empty(t, inv.Session.SnapshotState())
+}
+
+func TestPrepareSkillLoadsRejectsConflictingDocSelection(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+		},
+	}}
+	agt := New("tester", WithSkills(repo))
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{
+				Name:           "review",
+				Docs:           []string{"guide.md"},
+				IncludeAllDocs: true,
+			}},
+		}),
+	)
+	agt.setupInvocation(inv)
+
+	err := agt.prepareSkillLoads(context.Background(), inv)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, skill.ErrInvalidLoadRequest))
+	require.Empty(t, inv.Session.SnapshotState())
+}
+
+func TestPrepareSkillLoadsActivatesToolsForFirstModelRequest(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {Summary: skill.Summary{Name: "review"}},
+	}}
+	agt := New(
+		"tester",
+		WithSkills(repo),
+		WithActivatableToolSets([]tool.ToolSet{
+			activationToolSet{
+				name:  "review-tools",
+				tools: []tool.Tool{activationTool{name: "inspect"}},
+			},
+		}),
+		WithToolActivationOnSkillLoad(
+			"review",
+			[]string{"review-tools"},
+		),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		}),
+	)
+	agt.setupInvocation(inv)
+
+	err := agt.prepareSkillLoads(context.Background(), inv)
+	require.NoError(t, err)
+	records := invocationToolActivationRecords(inv)
+	require.Len(t, records, 1)
+	require.Equal(t, "review-tools", records[0].ToolSetName)
+}
+
+func TestSkillLoadsUseContextReturnedByBeforeAgent(t *testing.T) {
+	type visibilityKey struct{}
+	base := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+			Body:    "VISIBLE BODY",
+		},
+	}}
+	repo := skill.NewFilteredRepository(
+		base,
+		func(ctx context.Context, _ skill.Summary) bool {
+			visible, _ := ctx.Value(visibilityKey{}).(bool)
+			return visible
+		},
+	)
+	callbacks := agent.NewCallbacks()
+	callbacks.RegisterBeforeAgent(
+		func(
+			ctx context.Context,
+			_ *agent.BeforeAgentArgs,
+		) (*agent.BeforeAgentResult, error) {
+			return &agent.BeforeAgentResult{
+				Context: context.WithValue(ctx, visibilityKey{}, true),
+			}, nil
+		},
+	)
+	modelStub := &captureModel{}
+	agt := New(
+		"tester",
+		WithModel(modelStub),
+		WithSkills(repo),
+		WithAgentCallbacks(callbacks),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationMessage(model.NewUserMessage("review")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		}),
+	)
+
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.NotNil(t, modelStub.got)
+	var system string
+	for _, message := range modelStub.got.Messages {
+		if message.Role == model.RoleSystem {
+			system += message.Content
+		}
+	}
+	require.Contains(t, system, "VISIBLE BODY")
+}

--- a/agent/llmagent/skill_load_test.go
+++ b/agent/llmagent/skill_load_test.go
@@ -174,6 +174,107 @@ func TestPrepareSkillLoadsRejectsConflictingDocSelection(t *testing.T) {
 	require.Empty(t, inv.Session.SnapshotState())
 }
 
+func TestDeclaredSkillLoadIncludesAllDocs(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+			Body:    "Review body",
+			Docs: []skill.Doc{
+				{Path: "a.md", Content: "Doc A"},
+				{Path: "b.md", Content: "Doc B"},
+			},
+		},
+	}}
+	modelStub := &captureModel{}
+	agt := New(
+		"tester",
+		WithModel(modelStub),
+		WithSkills(repo),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationMessage(model.NewUserMessage("review")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{
+				Name:           "review",
+				IncludeAllDocs: true,
+			}},
+		}),
+	)
+
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.NotNil(t, modelStub.got)
+	system := skillLoadTestSystemContent(modelStub.got)
+	require.Contains(t, system, "Doc A")
+	require.Contains(t, system, "Doc B")
+	docs, ok := inv.Session.GetState(skill.DocsKey("tester", "review"))
+	require.True(t, ok)
+	require.Equal(t, []byte("*"), docs)
+}
+
+func TestDeclaredSkillLoadPreservesExistingDocs(t *testing.T) {
+	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
+		"review": {
+			Summary: skill.Summary{Name: "review"},
+			Body:    "Review body",
+			Docs: []skill.Doc{{
+				Path:    "old.md",
+				Content: "Old doc body",
+			}},
+		},
+	}}
+	modelStub := &captureModel{}
+	agt := New(
+		"tester",
+		WithModel(modelStub),
+		WithSkills(repo),
+		WithSkillLoadMode(SkillLoadModeSession),
+	)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{
+			State: session.StateMap{
+				skill.DocsKey("tester", "review"): []byte(`["old.md"]`),
+			},
+		}),
+		agent.WithInvocationMessage(model.NewUserMessage("review")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		}),
+	)
+
+	events, err := agt.Run(context.Background(), inv)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	require.NotNil(t, modelStub.got)
+	require.Contains(
+		t,
+		skillLoadTestSystemContent(modelStub.got),
+		"Old doc body",
+	)
+	docs, ok := inv.Session.GetState(skill.DocsKey("tester", "review"))
+	require.True(t, ok)
+	require.JSONEq(t, `["old.md"]`, string(docs))
+}
+
+func skillLoadTestSystemContent(req *model.Request) string {
+	if req == nil {
+		return ""
+	}
+	var system string
+	for _, message := range req.Messages {
+		if message.Role == model.RoleSystem {
+			system += message.Content
+		}
+	}
+	return system
+}
+
 func TestPrepareSkillLoadsActivatesToolsForFirstModelRequest(t *testing.T) {
 	repo := &skillLoadTestRepository{skills: map[string]*skill.Skill{
 		"review": {Summary: skill.Summary{Name: "review"}},

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -60,6 +60,9 @@ func (a *LLMAgent) skillRepositoryForInvocation(
 	ctx context.Context,
 	inv *agent.Invocation,
 ) skill.Repository {
+	if repo, ok := preparedSkillRepositoryForInvocation(inv); ok {
+		return repo
+	}
 	if patch, ok := a.rootSurfacePatch(inv); ok {
 		if repo, ok := patch.SkillRepository(); ok {
 			return repo

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -149,7 +149,9 @@ func (a *LLMAgent) InvocationSkillRepository(
 	if a == nil {
 		return nil
 	}
-	return a.skillRepositoryForInvocation(ctx, inv)
+	return repositoryWithoutPreparedSkills(
+		a.skillRepositoryForInvocation(ctx, inv),
+	)
 }
 
 // SupportsInvocationSkillLoads reports that LLMAgent consumes invocation

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -149,6 +149,14 @@ func (a *LLMAgent) InvocationSkillRepository(
 	return a.skillRepositoryForInvocation(ctx, inv)
 }
 
+// SupportsInvocationSkillLoads reports that LLMAgent consumes invocation
+// skill load declarations before its first model request.
+func (a *LLMAgent) SupportsInvocationSkillLoads() bool {
+	return a != nil
+}
+
+var _ agent.InvocationSkillLoadSupport = (*LLMAgent)(nil)
+
 // InvocationCodeExecutor returns the effective code executor for the
 // invocation, honoring a per-run override when present. It implements
 // agent.InvocationCodeExecutorProvider so callers can check executor

--- a/agent/llmagent/tool_activation.go
+++ b/agent/llmagent/tool_activation.go
@@ -368,6 +368,26 @@ func (a *LLMAgent) handleToolActivationPostToolResult(
 	}
 }
 
+func (a *LLMAgent) activatePreparedSkillLoads(
+	inv *agent.Invocation,
+	loads []skill.LoadRequest,
+) {
+	if inv == nil || len(loads) == 0 {
+		return
+	}
+	loaded := make(map[string]bool, len(loads))
+	for _, load := range loads {
+		loaded[load.Name] = true
+	}
+	records := a.activationRecordsForLoadedSkills(loaded)
+	if len(records) == 0 {
+		return
+	}
+	if addInvocationToolActivationRecords(inv, records) {
+		toolsnapshot.Invalidate(inv)
+	}
+}
+
 func loadedSkillsFromStateDelta(
 	agentName string,
 	delta map[string][]byte,

--- a/agent/skill_load.go
+++ b/agent/skill_load.go
@@ -1,0 +1,68 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"errors"
+
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+)
+
+// ErrSkillLoadingUnsupported indicates that the selected agent does not
+// support invocation-scoped skill loading.
+var ErrSkillLoadingUnsupported = errors.New(
+	"agent does not support skill loading",
+)
+
+// InvocationSkillLoadSupport is implemented by agents that consume
+// RunOptions.SkillLoads before their first model request.
+//
+// Wrapping agents should delegate this capability to the agent that performs
+// the model invocation. Returning true is a behavioral commitment: declared
+// skill loads must either be applied atomically or cause the run to fail
+// without issuing a model request.
+type InvocationSkillLoadSupport interface {
+	SupportsInvocationSkillLoads() bool
+}
+
+// WithSkillLoads appends skills that the selected agent must load before its
+// first model request.
+//
+// The selected agent validates the complete declaration before changing skill
+// state. Empty loads are a no-op. Skill load declarations apply only to the
+// entry invocation and are not inherited by cloned child invocations.
+//
+// Runner enforces InvocationSkillLoadSupport for the selected entry agent.
+// Callers that construct an Invocation and invoke Agent.Run directly are
+// responsible for selecting an agent that supports these declarations.
+func WithSkillLoads(loads ...skill.LoadRequest) RunOption {
+	copied := cloneSkillLoads(loads)
+	return func(opts *RunOptions) {
+		if len(copied) == 0 {
+			return
+		}
+		opts.SkillLoads = append(
+			cloneSkillLoads(opts.SkillLoads),
+			cloneSkillLoads(copied)...,
+		)
+	}
+}
+
+func cloneSkillLoads(loads []skill.LoadRequest) []skill.LoadRequest {
+	if len(loads) == 0 {
+		return nil
+	}
+	out := make([]skill.LoadRequest, len(loads))
+	for i, load := range loads {
+		out[i] = load
+		out[i].Docs = append([]string(nil), load.Docs...)
+	}
+	return out
+}

--- a/agent/skill_load.go
+++ b/agent/skill_load.go
@@ -36,8 +36,11 @@ type InvocationSkillLoadSupport interface {
 // first model request.
 //
 // The selected agent validates the complete declaration before changing skill
-// state. Empty loads are a no-op. Skill load declarations apply only to the
-// entry invocation and are not inherited by cloned child invocations.
+// state. Repeated declarations for the same skill are coalesced when their
+// normalized Docs sets and IncludeAllDocs values match; conflicting selections
+// are invalid.
+// Empty loads are a no-op. Skill load declarations apply only to the entry
+// invocation and are not inherited by cloned child invocations.
 //
 // Runner enforces InvocationSkillLoadSupport for the selected entry agent.
 // Callers that construct an Invocation and invoke Agent.Run directly are

--- a/agent/skill_load_test.go
+++ b/agent/skill_load_test.go
@@ -1,0 +1,59 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+)
+
+func TestWithSkillLoadsCopiesInputAndCloneDoesNotInherit(t *testing.T) {
+	docs := []string{"guide.md"}
+	loads := []skill.LoadRequest{{
+		Name: "review",
+		Docs: docs,
+	}}
+	var opts RunOptions
+	WithSkillLoads(loads...)(&opts)
+
+	docs[0] = "changed.md"
+	loads[0].Name = "changed"
+	require.Equal(t, "review", opts.SkillLoads[0].Name)
+	require.Equal(t, []string{"guide.md"}, opts.SkillLoads[0].Docs)
+
+	inv := NewInvocation(WithInvocationRunOptions(opts))
+	child := inv.Clone()
+	require.Empty(t, child.RunOptions.SkillLoads)
+	require.Equal(t, "review", inv.RunOptions.SkillLoads[0].Name)
+}
+
+func TestWithSkillLoadsEmptyIsNoOp(t *testing.T) {
+	existing := []skill.LoadRequest{{Name: "review"}}
+	opts := RunOptions{SkillLoads: existing}
+
+	WithSkillLoads()(&opts)
+
+	require.Equal(t, existing, opts.SkillLoads)
+}
+
+func TestWithSkillLoadsAppends(t *testing.T) {
+	var opts RunOptions
+
+	WithSkillLoads(skill.LoadRequest{Name: "review"})(&opts)
+	WithSkillLoads(skill.LoadRequest{Name: "security"})(&opts)
+
+	require.Equal(t, []skill.LoadRequest{
+		{Name: "review"},
+		{Name: "security"},
+	}, opts.SkillLoads)
+}

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -66,13 +66,16 @@ request processing throughout that invocation. `SKILL.md` is always loaded;
 `Docs` selects additional skill-relative documents, while `IncludeAllDocs`
 selects all supporting documents and cannot be combined with `Docs`. A
 non-empty `Docs` replaces the current document selection. When both fields are
-unset, the existing selection is preserved, matching `skill_load`; under the
-default `turn` mode, the previous turn's selection has already been cleared.
-Equivalent declarations for the same skill are coalesced after normalization,
-including when separate `WithSkillLoads` options append them. Equivalence
-requires the same normalized `Docs` set and `IncludeAllDocs` value. Conflicting
-selections for one skill are invalid, and `MaxLoadedSkills` counts the
-coalesced skills. A failed declaration prevents the first model request and
+unset, the declaration itself leaves any current selection unchanged, matching
+`skill_load`. In the default `turn` mode, the turn reset and declaration are
+applied atomically; the reset removes the previous turn's selection, so it is
+not inherited. Modes without a turn reset, including `session`, preserve a
+selection that is still present. Equivalent declarations for the same skill
+are coalesced after normalization, including when separate `WithSkillLoads`
+options append them. Equivalence requires the same normalized `Docs` set and
+`IncludeAllDocs` value. Conflicting selections for one skill are invalid, and
+`MaxLoadedSkills` counts the coalesced skills. A failed declaration prevents
+the first model request and
 can be classified with `skill.ErrInvalidLoadRequest` or
 `skill.ErrSkillUnavailable` when the agent returns the setup error directly.
 Runner wrappers that execute inner agents asynchronously, such as candidate

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -60,14 +60,20 @@ events, err := runner.Run(
 ```
 
 The declarations are validated as one atomic batch against the invocation's
-effective repository, including context-aware visibility filters. `SKILL.md`
-is always loaded; `Docs` selects additional skill-relative documents, while
-`IncludeAllDocs` selects all supporting documents and cannot be combined with
-`Docs`. A non-empty `Docs` replaces the current document selection. When both
-fields are unset, the existing selection is preserved, matching `skill_load`;
-under the default `turn` mode, the previous turn's selection has already been
-cleared. A failed declaration prevents the first model request and can be
-classified with `skill.ErrInvalidLoadRequest` or
+effective repository, including context-aware visibility filters. The
+repository selected during preflight is reused for tool construction and
+request processing throughout that invocation. `SKILL.md` is always loaded;
+`Docs` selects additional skill-relative documents, while `IncludeAllDocs`
+selects all supporting documents and cannot be combined with `Docs`. A
+non-empty `Docs` replaces the current document selection. When both fields are
+unset, the existing selection is preserved, matching `skill_load`; under the
+default `turn` mode, the previous turn's selection has already been cleared.
+Equivalent declarations for the same skill are coalesced after normalization,
+including when separate `WithSkillLoads` options append them. Equivalence
+requires the same normalized `Docs` set and `IncludeAllDocs` value. Conflicting
+selections for one skill are invalid, and `MaxLoadedSkills` counts the
+coalesced skills. A failed declaration prevents the first model request and
+can be classified with `skill.ErrInvalidLoadRequest` or
 `skill.ErrSkillUnavailable` when the agent returns the setup error directly.
 Runner wrappers that execute inner agents asynchronously, such as candidate
 selection and Ralph Loop, retain their existing error-event delivery

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -41,6 +41,47 @@ Background references:
      `skill_select_docs`). Scripts are not inlined; they are executed
      inside a workspace, returning results and output files.
 
+### Caller-Declared Skill Loads
+
+Applications that already know which skill a request requires can load it
+without asking the model to choose or call `skill_load`:
+
+```go
+events, err := runner.Run(
+    ctx,
+    userID,
+    sessionID,
+    model.NewUserMessage("Review this change"),
+    agent.WithSkillLoads(skill.LoadRequest{
+        Name: "code-review",
+        Docs: []string{"references/security.md"},
+    }),
+)
+```
+
+The declarations are validated as one atomic batch against the invocation's
+effective repository, including context-aware visibility filters. `SKILL.md`
+is always loaded; `Docs` selects additional skill-relative documents, while
+`IncludeAllDocs` selects all supporting documents and cannot be combined with
+`Docs`. A non-empty `Docs` replaces the current document selection. When both
+fields are unset, the existing selection is preserved, matching `skill_load`;
+under the default `turn` mode, the previous turn's selection has already been
+cleared. A failed declaration prevents the first model request and can be
+classified with `skill.ErrInvalidLoadRequest` or
+`skill.ErrSkillUnavailable` when the agent returns the setup error directly.
+Runner wrappers that execute inner agents asynchronously, such as candidate
+selection and Ralph Loop, retain their existing error-event delivery
+semantics while still preventing the model request.
+
+Declared loads use the same state, materialization, load-mode, workspace, and
+tool-activation behavior as `skill_load`, but do not fabricate a model tool
+call or tool result. They apply only to the selected entry invocation and are
+not inherited by cloned child-agent invocations. A selected agent that does
+not implement `agent.InvocationSkillLoadSupport` (or reports false) is rejected
+with `agent.ErrSkillLoadingUnsupported`. Custom agents that implement this
+interface commit to consuming the declarations atomically before their first
+model request.
+
 ### Token Cost
 
 If you inline a full skills repo (all `SKILL.md` bodies and docs) into

--- a/docs/mkdocs/en/skill.md
+++ b/docs/mkdocs/en/skill.md
@@ -61,8 +61,9 @@ events, err := runner.Run(
 
 The declarations are validated as one atomic batch against the invocation's
 effective repository, including context-aware visibility filters. The
-repository selected during preflight is reused for tool construction and
-request processing throughout that invocation. `SKILL.md` is always loaded;
+repository selected during preflight and the validated contents of declared
+skills are reused for tool construction and request processing throughout that
+invocation. `SKILL.md` is always loaded;
 `Docs` selects additional skill-relative documents, while `IncludeAllDocs`
 selects all supporting documents and cannot be combined with `Docs`. A
 non-empty `Docs` replaces the current document selection. When both fields are

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -61,8 +61,9 @@ events, err := runner.Run(
 
 框架会基于本次 invocation 的有效 repository（包括上下文可见性过滤）
 对整批声明做原子校验，并在本次 invocation 的工具构建与请求处理过程中
-复用预检选中的 repository。`SKILL.md` 始终加载；`Docs` 选择额外的
-Skill 相对路径文档，`IncludeAllDocs` 选择全部辅助文档，二者不能同时
+复用预检选中的 repository 以及声明 Skill 的已验证内容。`SKILL.md` 始终
+加载；`Docs` 选择额外的 Skill 相对路径文档，`IncludeAllDocs` 选择全部辅助
+文档，二者不能同时
 设置。非空 `Docs` 会替换当前文档选择；二者都未设置时，声明本身不会改写
 当前选择，与 `skill_load` 保持一致。在默认 `turn` 模式下，框架会将本轮
 重置与声明合并为同一个原子更新；重置会移除上一轮选择，因此不会继承该

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -63,12 +63,14 @@ events, err := runner.Run(
 对整批声明做原子校验，并在本次 invocation 的工具构建与请求处理过程中
 复用预检选中的 repository。`SKILL.md` 始终加载；`Docs` 选择额外的
 Skill 相对路径文档，`IncludeAllDocs` 选择全部辅助文档，二者不能同时
-设置。非空 `Docs` 会替换当前文档选择；二者都未设置时会沿用已有选择，
-与 `skill_load` 保持一致。在默认 `turn` 模式下，上一轮选择会先被清空。
-同一 Skill 的等价声明会在规范化后合并，包括由多个 `WithSkillLoads`
-追加的声明；等价要求规范化后的 `Docs` 集合与 `IncludeAllDocs` 值相同。
-同一 Skill 的选择冲突则视为无效，`MaxLoadedSkills` 按合并后的 Skill 数量
-计算。任一声明失败都会阻止第一次模型请求，业务可通过
+设置。非空 `Docs` 会替换当前文档选择；二者都未设置时，声明本身不会改写
+当前选择，与 `skill_load` 保持一致。在默认 `turn` 模式下，框架会将本轮
+重置与声明合并为同一个原子更新；重置会移除上一轮选择，因此不会继承该
+选择。不执行 `turn` 重置的模式（包括 `session`）会保留仍然存在的选择。
+同一 Skill 的等价声明会在规范化后合并，包括由多个 `WithSkillLoads` 追加的
+声明；等价要求规范化后的 `Docs` 集合与 `IncludeAllDocs` 值相同。同一
+Skill 的选择冲突则视为无效，`MaxLoadedSkills` 按合并后的 Skill 数量计算。
+任一声明失败都会阻止第一次模型请求，业务可通过
 `skill.ErrInvalidLoadRequest` 或 `skill.ErrSkillUnavailable` 识别直接返回的
 初始化错误。Candidate Selector、Ralph Loop 等异步执行 inner Agent 的
 Runner wrapper 仍沿用既有错误事件语义，但同样不会发起模型请求。

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -41,6 +41,41 @@ Agent Skills 把可复用的任务封装为“技能目录”，用 `SKILL.md`
      仅把文本内容物化到提示词；脚本不会被内联，而是在工作区中
      执行，并回传结果与输出文件。
 
+### 调用方声明必加载 Skill
+
+如果业务在收到请求时已经确定要使用哪个 Skill，可以直接声明必加载，
+无需再让模型判断或调用 `skill_load`：
+
+```go
+events, err := runner.Run(
+    ctx,
+    userID,
+    sessionID,
+    model.NewUserMessage("审查这个改动"),
+    agent.WithSkillLoads(skill.LoadRequest{
+        Name: "code-review",
+        Docs: []string{"references/security.md"},
+    }),
+)
+```
+
+框架会基于本次 invocation 的有效 repository（包括上下文可见性过滤）
+对整批声明做原子校验。`SKILL.md` 始终加载；`Docs` 选择额外的
+Skill 相对路径文档，`IncludeAllDocs` 选择全部辅助文档，二者不能同时
+设置。非空 `Docs` 会替换当前文档选择；二者都未设置时会沿用已有选择，
+与 `skill_load` 保持一致。在默认 `turn` 模式下，上一轮选择会先被清空。
+任一声明失败都会阻止第一次模型请求，业务可通过
+`skill.ErrInvalidLoadRequest` 或 `skill.ErrSkillUnavailable` 识别直接返回的
+初始化错误。Candidate Selector、Ralph Loop 等异步执行 inner Agent 的
+Runner wrapper 仍沿用既有错误事件语义，但同样不会发起模型请求。
+
+声明式加载复用 `skill_load` 的状态、内容物化、load mode、workspace
+和工具激活语义，但不会伪造模型 tool call/tool result。声明只作用于
+Runner 选中的入口 invocation，不会被克隆出的子 Agent invocation 继承。
+如果选中的 Agent 未实现 `agent.InvocationSkillLoadSupport`（或返回
+false），Runner 返回 `agent.ErrSkillLoadingUnsupported`。自定义 Agent
+一旦声明支持，就必须在第一次模型请求前原子消费这些声明。
+
 ### Token 成本
 
 如果把一个技能仓库的全部内容（所有 `SKILL.md` 正文与 docs）

--- a/docs/mkdocs/zh/skill.md
+++ b/docs/mkdocs/zh/skill.md
@@ -60,11 +60,15 @@ events, err := runner.Run(
 ```
 
 框架会基于本次 invocation 的有效 repository（包括上下文可见性过滤）
-对整批声明做原子校验。`SKILL.md` 始终加载；`Docs` 选择额外的
+对整批声明做原子校验，并在本次 invocation 的工具构建与请求处理过程中
+复用预检选中的 repository。`SKILL.md` 始终加载；`Docs` 选择额外的
 Skill 相对路径文档，`IncludeAllDocs` 选择全部辅助文档，二者不能同时
 设置。非空 `Docs` 会替换当前文档选择；二者都未设置时会沿用已有选择，
 与 `skill_load` 保持一致。在默认 `turn` 模式下，上一轮选择会先被清空。
-任一声明失败都会阻止第一次模型请求，业务可通过
+同一 Skill 的等价声明会在规范化后合并，包括由多个 `WithSkillLoads`
+追加的声明；等价要求规范化后的 `Docs` 集合与 `IncludeAllDocs` 值相同。
+同一 Skill 的选择冲突则视为无效，`MaxLoadedSkills` 按合并后的 Skill 数量
+计算。任一声明失败都会阻止第一次模型请求，业务可通过
 `skill.ErrInvalidLoadRequest` 或 `skill.ErrSkillUnavailable` 识别直接返回的
 初始化错误。Candidate Selector、Ralph Loop 等异步执行 inner Agent 的
 Runner wrapper 仍沿用既有错误事件语义，但同样不会发起模型请求。

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -3982,6 +3982,9 @@ func applyAgentNodeRunOptions(runOptions *agent.RunOptions, opts []agent.RunOpti
 
 func detachAgentNodeMutableRunOptions(in agent.RunOptions) agent.RunOptions {
 	out := in
+	// Caller-declared skill loads target the entry invocation. A graph node
+	// may opt in explicitly through its own node run options.
+	out.SkillLoads = nil
 	// Detach only parent-owned mutable containers.
 	// Standard run options can append to or merge into these containers.
 	out.InjectedContextMessages = slices.Clip(out.InjectedContextMessages)

--- a/internal/flow/processor/skills.go
+++ b/internal/flow/processor/skills.go
@@ -79,6 +79,7 @@ type skillsRequestProcessorOptions struct {
 	hasToolFlags       bool
 	execToolsDisabled  bool
 	repoResolver       func(context.Context, *agent.Invocation) skill.Repository
+	loadStateDeltaHook func(context.Context, *agent.Invocation, *event.Event)
 	directoryHints     bool
 	filePathHints      bool
 }
@@ -211,6 +212,16 @@ func WithSkillsRepositoryResolver(
 	}
 }
 
+// WithSkillLoadStateDeltaHook installs an internal hook that observes and may
+// extend the state update produced for invocation-declared skill loads.
+func WithSkillLoadStateDeltaHook(
+	hook func(context.Context, *agent.Invocation, *event.Event),
+) SkillsRequestProcessorOption {
+	return func(o *skillsRequestProcessorOptions) {
+		o.loadStateDeltaHook = hook
+	}
+}
+
 // WithMaxLoadedSkills caps how many skills remain "loaded" in session
 // state.
 //
@@ -280,6 +291,7 @@ func WithSkillsFilePathHints(
 type SkillsRequestProcessor struct {
 	repo               skill.Repository
 	repoResolver       func(context.Context, *agent.Invocation) skill.Repository
+	loadStateDeltaHook func(context.Context, *agent.Invocation, *event.Event)
 	capabilityGuidance *string
 	protocolGuidance   *string
 	toolingGuidance    *string
@@ -294,7 +306,8 @@ type SkillsRequestProcessor struct {
 }
 
 const (
-	skillsTurnInitStateKey = "processor:skills:turn_init"
+	skillsTurnInitStateKey         = "processor:skills:turn_init"
+	skillsRequestedLoadsAppliedKey = "processor:skills:requested_loads_applied"
 )
 
 // NewSkillsRequestProcessor creates a processor instance.
@@ -324,6 +337,7 @@ func NewSkillsRequestProcessor(
 	return &SkillsRequestProcessor{
 		repo:               repo,
 		repoResolver:       options.repoResolver,
+		loadStateDeltaHook: options.loadStateDeltaHook,
 		capabilityGuidance: options.capabilityGuidance,
 		protocolGuidance:   options.protocolGuidance,
 		toolingGuidance:    options.toolingGuidance,
@@ -365,6 +379,7 @@ func (p *SkillsRequestProcessor) ProcessRequest(
 	maybeMigrateLegacySkillState(ctx, inv, ch)
 
 	p.maybeClearSkillStateForTurn(ctx, inv, ch)
+	p.applyRequestedSkillLoads(ctx, inv, ch)
 
 	promptCtx, promptSpan, promptStarted := startProcessorLatencySpan(
 		ctx,
@@ -483,6 +498,66 @@ func (p *SkillsRequestProcessor) ProcessRequest(
 		inv.InvocationID, inv.AgentName,
 		event.WithObject(model.ObjectTypePreprocessingInstruction),
 	))
+}
+
+func (p *SkillsRequestProcessor) applyRequestedSkillLoads(
+	ctx context.Context,
+	inv *agent.Invocation,
+	ch chan<- *event.Event,
+) {
+	if inv == nil || inv.Session == nil || len(inv.RunOptions.SkillLoads) == 0 {
+		return
+	}
+	if _, ok := inv.GetState(skillsRequestedLoadsAppliedKey); ok {
+		return
+	}
+	inv.SetState(skillsRequestedLoadsAppliedKey, true)
+
+	// In turn mode, combine the turn reset and the declared loads into one
+	// state update. Emitting a reset event followed by a load event allows an
+	// outer asynchronous event consumer (for example, Ralph Loop under Runner)
+	// to apply the stale reset after the next continuation has already loaded
+	// the skill into the shared session.
+	delta := make(map[string][]byte, len(inv.RunOptions.SkillLoads)*2+1)
+	if p.loadMode == SkillLoadModeTurn {
+		for key, value := range clearSkillState(inv) {
+			delta[key] = value
+		}
+	}
+	orderKey := skill.LoadedOrderKey(inv.AgentName)
+	var order []string
+	if raw, ok := inv.Session.GetState(orderKey); ok {
+		order = skill.ParseLoadedOrder(raw)
+	}
+	for _, load := range inv.RunOptions.SkillLoads {
+		delta[skill.LoadedKey(inv.AgentName, load.Name)] = []byte("1")
+		switch {
+		case load.IncludeAllDocs:
+			delta[skill.DocsKey(inv.AgentName, load.Name)] = []byte("*")
+		case len(load.Docs) > 0:
+			// json.Marshal cannot fail for a string slice.
+			docs, _ := json.Marshal(load.Docs)
+			delta[skill.DocsKey(inv.AgentName, load.Name)] = docs
+		}
+		order = skill.TouchLoadedOrder(order, load.Name)
+	}
+	if encoded := skill.MarshalLoadedOrder(order); len(encoded) > 0 {
+		delta[orderKey] = encoded
+	}
+
+	ev := event.New(
+		inv.InvocationID,
+		inv.AgentName,
+		event.WithObject(model.ObjectTypeStateUpdate),
+		event.WithStateDelta(delta),
+	)
+	if p.loadStateDeltaHook != nil {
+		p.loadStateDeltaHook(ctx, inv, ev)
+	}
+	for key, value := range ev.StateDelta {
+		inv.Session.SetState(key, value)
+	}
+	agent.EmitEvent(ctx, inv, ch, ev)
 }
 
 func (p *SkillsRequestProcessor) repositoryForInvocation(
@@ -746,6 +821,13 @@ func (p *SkillsRequestProcessor) maybeClearSkillStateForTurn(
 		return
 	}
 	inv.SetState(skillsTurnInitStateKey, true)
+
+	// A declared load is committed together with the turn reset by
+	// applyRequestedSkillLoads so asynchronous consumers observe only the
+	// final atomic state.
+	if len(inv.RunOptions.SkillLoads) > 0 {
+		return
+	}
 
 	delta := clearSkillState(inv)
 	if len(delta) == 0 {

--- a/internal/flow/processor/skills_test.go
+++ b/internal/flow/processor/skills_test.go
@@ -137,6 +137,164 @@ func TestSkillsRequestProcessor_ProcessRequest_OverviewAndDocs(
 	require.Equal(t, model.ObjectTypePreprocessingInstruction, ev.Object)
 }
 
+func TestSkillsRequestProcessor_AppliesDeclaredLoadsAfterTurnClear(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "review"}},
+		full: map[string]*skill.Skill{
+			"review": {
+				Summary: skill.Summary{Name: "review"},
+				Body:    "Review body",
+				Docs: []skill.Doc{{
+					Path:    "guide.md",
+					Content: "Guide body",
+				}},
+			},
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		AgentName:    "tester",
+		Session: &session.Session{State: session.StateMap{
+			skill.LoadedKey("tester", "old"): []byte("1"),
+		}},
+		RunOptions: agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{
+				Name: "review",
+				Docs: []string{"guide.md"},
+			}},
+		},
+	}
+	req := &model.Request{}
+	ch := make(chan *event.Event, 8)
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeTurn),
+	)
+
+	p.ProcessRequest(context.Background(), inv, req, ch)
+
+	oldLoaded, _ := inv.Session.GetState(skill.LoadedKey("tester", "old"))
+	require.Empty(t, oldLoaded)
+	loaded, ok := inv.Session.GetState(skill.LoadedKey("tester", "review"))
+	require.True(t, ok)
+	require.Equal(t, []byte("1"), loaded)
+	docs, ok := inv.Session.GetState(skill.DocsKey("tester", "review"))
+	require.True(t, ok)
+	require.JSONEq(t, `["guide.md"]`, string(docs))
+	require.Contains(t, req.Messages[0].Content, "Review body")
+	require.Contains(t, req.Messages[0].Content, "Guide body")
+	require.Len(t, ch, 2)
+	stateUpdate := <-ch
+	require.Contains(
+		t,
+		stateUpdate.StateDelta,
+		skill.LoadedKey("tester", "old"),
+	)
+	require.Empty(
+		t,
+		stateUpdate.StateDelta[skill.LoadedKey("tester", "old")],
+	)
+	require.Equal(
+		t,
+		[]byte("1"),
+		stateUpdate.StateDelta[skill.LoadedKey("tester", "review")],
+	)
+	require.JSONEq(
+		t,
+		`["guide.md"]`,
+		string(stateUpdate.StateDelta[skill.DocsKey("tester", "review")]),
+	)
+
+	p.ProcessRequest(context.Background(), inv, req, ch)
+	require.Len(t, ch, 2, "declared loads must be committed only once")
+}
+
+func TestSkillsRequestProcessor_DeclaredLoadPreservesSessionDocs(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "review"}},
+		full: map[string]*skill.Skill{
+			"review": {
+				Summary: skill.Summary{Name: "review"},
+				Body:    "Review body",
+				Docs: []skill.Doc{{
+					Path:    "old.md",
+					Content: "Old doc body",
+				}},
+			},
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		AgentName:    "tester",
+		Session: &session.Session{State: session.StateMap{
+			skill.DocsKey("tester", "review"): []byte(`["old.md"]`),
+		}},
+		RunOptions: agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "review"}},
+		},
+	}
+	req := &model.Request{}
+	ch := make(chan *event.Event, 4)
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeSession),
+	)
+
+	p.ProcessRequest(context.Background(), inv, req, ch)
+
+	docs, ok := inv.Session.GetState(skill.DocsKey("tester", "review"))
+	require.True(t, ok)
+	require.JSONEq(t, `["old.md"]`, string(docs))
+	require.Contains(t, req.Messages[0].Content, "Old doc body")
+}
+
+func TestSkillsRequestProcessor_DeclaredLoadStaysWithinMaxLoadedSkills(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+		full: map[string]*skill.Skill{
+			"a": {Summary: skill.Summary{Name: "a"}, Body: "Body A"},
+			"b": {Summary: skill.Summary{Name: "b"}, Body: "Body B"},
+			"c": {Summary: skill.Summary{Name: "c"}, Body: "Body C"},
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv",
+		AgentName:    "tester",
+		Session: &session.Session{State: session.StateMap{
+			skill.LoadedKey("tester", "a"): []byte("1"),
+			skill.LoadedKey("tester", "b"): []byte("1"),
+			skill.LoadedOrderKey("tester"): []byte(`["a","b"]`),
+		}},
+		RunOptions: agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "c"}},
+		},
+	}
+	req := &model.Request{}
+	ch := make(chan *event.Event, 4)
+	p := NewSkillsRequestProcessor(
+		repo,
+		WithSkillLoadMode(SkillLoadModeSession),
+		WithMaxLoadedSkills(2),
+	)
+
+	p.ProcessRequest(context.Background(), inv, req, ch)
+
+	aLoaded, _ := inv.Session.GetState(skill.LoadedKey("tester", "a"))
+	require.Empty(t, aLoaded)
+	bLoaded, _ := inv.Session.GetState(skill.LoadedKey("tester", "b"))
+	require.NotEmpty(t, bLoaded)
+	cLoaded, _ := inv.Session.GetState(skill.LoadedKey("tester", "c"))
+	require.NotEmpty(t, cLoaded)
+	require.Contains(t, req.Messages[0].Content, "Body C")
+	require.NotContains(t, req.Messages[0].Content, "Body A")
+}
+
 func TestSkillsRequestProcessor_ProcessRequest_PrioritizesRelevantSkillsBeforeOverviewCap(
 	t *testing.T,
 ) {
@@ -2613,6 +2771,49 @@ func TestSkillsToolResultRequestProcessor_SessionSummary_DisablesFallbackWithout
 		}
 		require.NotContains(t, m.Content, skillsLoadedContextHeader)
 	}
+}
+
+func TestSkillsToolResultRequestProcessor_DeclaredLoadOverridesSummaryFallbackSkip(
+	t *testing.T,
+) {
+	repo := &mockRepo{
+		sums: []skill.Summary{{Name: "calc", Description: "math"}},
+		full: map[string]*skill.Skill{
+			"calc": {Summary: skill.Summary{Name: "calc"}, Body: "B"},
+		},
+	}
+	inv := &agent.Invocation{
+		InvocationID: "inv1",
+		AgentName:    "tester",
+		Session: &session.Session{State: session.StateMap{
+			skill.LoadedKey("tester", "calc"): []byte("1"),
+		}},
+		RunOptions: agent.RunOptions{
+			SkillLoads: []skill.LoadRequest{{Name: "calc"}},
+		},
+	}
+	inv.SetState(contentHasSessionSummaryStateKey, true)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("u"),
+	}}
+
+	p := NewSkillsToolResultRequestProcessor(
+		repo,
+		WithSkillsToolResultLoadMode(SkillLoadModeSession),
+	)
+	p.ProcessRequest(context.Background(), inv, req, nil)
+
+	var found bool
+	for _, message := range req.Messages {
+		if message.Role == model.RoleSystem &&
+			strings.Contains(message.Content, skillsLoadedContextHeader) {
+			found = true
+			require.Contains(t, message.Content, "[Loaded] calc")
+			require.Contains(t, message.Content, "B")
+		}
+	}
+	require.True(t, found)
 }
 
 func TestSkillsToolResultRequestProcessor_SessionSummary_SkipsFallbackWhenMaterialized(

--- a/internal/flow/processor/skills_tool_result.go
+++ b/internal/flow/processor/skills_tool_result.go
@@ -246,6 +246,7 @@ func (p *SkillsToolResultRequestProcessor) applyLoadedSkillContext(
 	if fallbackContent == "" {
 		p.removeLoadedContextMessage(req)
 	} else if p.skipFallbackOnSessionSummary &&
+		len(inv.RunOptions.SkillLoads) == 0 &&
 		hasSessionSummary(inv) &&
 		!hasCompactedToolResultMessages(inv) {
 		p.removeLoadedContextMessage(req)

--- a/runner/candidate_selector.go
+++ b/runner/candidate_selector.go
@@ -113,6 +113,8 @@ type candidateSelectorAgent struct {
 	opts     candidateSelectOptions
 }
 
+var _ agent.InvocationSkillLoadSupport = (*candidateSelectorAgent)(nil)
+
 func (a *candidateSelectorAgent) Info() agent.Info {
 	if a == nil || a.inner == nil {
 		return agent.Info{}
@@ -139,6 +141,14 @@ func (a *candidateSelectorAgent) FindSubAgent(name string) agent.Agent {
 		return nil
 	}
 	return a.inner.FindSubAgent(name)
+}
+
+func (a *candidateSelectorAgent) SupportsInvocationSkillLoads() bool {
+	if a == nil || a.inner == nil {
+		return false
+	}
+	support, ok := a.inner.(agent.InvocationSkillLoadSupport)
+	return ok && support.SupportsInvocationSkillLoads()
 }
 
 func (a *candidateSelectorAgent) Run(

--- a/runner/ralph_loop.go
+++ b/runner/ralph_loop.go
@@ -174,6 +174,8 @@ type ralphLoopAgent struct {
 	cfg   RalphLoopConfig
 }
 
+var _ agent.InvocationSkillLoadSupport = (*ralphLoopAgent)(nil)
+
 func (a *ralphLoopAgent) Info() agent.Info {
 	if a == nil || a.inner == nil {
 		return agent.Info{}
@@ -206,6 +208,14 @@ func (a *ralphLoopAgent) FindSubAgent(name string) agent.Agent {
 		return nil
 	}
 	return a.inner.FindSubAgent(name)
+}
+
+func (a *ralphLoopAgent) SupportsInvocationSkillLoads() bool {
+	if a == nil || a.inner == nil {
+		return false
+	}
+	support, ok := a.inner.(agent.InvocationSkillLoadSupport)
+	return ok && support.SupportsInvocationSkillLoads()
 }
 
 func (a *ralphLoopAgent) Run(
@@ -299,6 +309,11 @@ func (a *ralphLoopAgent) newInnerInvocation(
 		invocationOpts = append(invocationOpts, agent.WithInvocationEntryPredecessorStepIDs(entryPredecessors))
 	}
 	inner := base.Clone(invocationOpts...)
+	if len(base.RunOptions.SkillLoads) > 0 {
+		runOptions := inner.RunOptions
+		agent.WithSkillLoads(base.RunOptions.SkillLoads...)(&runOptions)
+		inner.RunOptions = runOptions
+	}
 
 	// Carry the run's steer queue across the iteration boundary so user
 	// messages enqueued onto the run (Runner.EnqueueUserMessage) reach the inner

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -640,6 +640,17 @@ func (r *runner) Run(
 		execCancel()
 		return nil, fmt.Errorf("select agent: %w", err)
 	}
+	if len(ro.SkillLoads) > 0 {
+		support, ok := ag.(agent.InvocationSkillLoadSupport)
+		if !ok || !support.SupportsInvocationSkillLoads() {
+			execCancel()
+			return nil, fmt.Errorf(
+				"%w: %s",
+				agent.ErrSkillLoadingUnsupported,
+				ag.Info().Name,
+			)
+		}
+	}
 	resolveCtx, resolveSpan, resolveStarted := startRunnerRunOptionsLatencySpan(
 		execCtx,
 		ro,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -631,25 +631,14 @@ func (r *runner) Run(
 		ro,
 		runnerLatencySpanSelectAgent,
 	)
-	ag, err := r.selectAgent(selectCtx, ro)
+	ag, err := r.selectAgentForRun(selectCtx, ro)
 	if selectStarted && ag != nil {
 		selectSpan.SetAttributes(attribute.String("runner.agent", ag.Info().Name))
 	}
 	finishRunnerLatencySpan(selectSpan, selectStarted, err)
 	if err != nil {
 		execCancel()
-		return nil, fmt.Errorf("select agent: %w", err)
-	}
-	if len(ro.SkillLoads) > 0 {
-		support, ok := ag.(agent.InvocationSkillLoadSupport)
-		if !ok || !support.SupportsInvocationSkillLoads() {
-			execCancel()
-			return nil, fmt.Errorf(
-				"%w: %s",
-				agent.ErrSkillLoadingUnsupported,
-				ag.Info().Name,
-			)
-		}
+		return nil, err
 	}
 	resolveCtx, resolveSpan, resolveStarted := startRunnerRunOptionsLatencySpan(
 		execCtx,
@@ -1162,6 +1151,30 @@ func (r *runner) lookupCancel(requestID string) context.CancelFunc {
 		return nil
 	}
 	return handle.cancel
+}
+
+// selectAgentForRun resolves the selected agent and validates capabilities
+// that must be known before the invocation is constructed.
+func (r *runner) selectAgentForRun(
+	ctx context.Context,
+	ro agent.RunOptions,
+) (agent.Agent, error) {
+	ag, err := r.selectAgent(ctx, ro)
+	if err != nil {
+		return nil, fmt.Errorf("select agent: %w", err)
+	}
+	if len(ro.SkillLoads) == 0 {
+		return ag, nil
+	}
+	support, ok := ag.(agent.InvocationSkillLoadSupport)
+	if !ok || !support.SupportsInvocationSkillLoads() {
+		return ag, fmt.Errorf(
+			"%w: %s",
+			agent.ErrSkillLoadingUnsupported,
+			ag.Info().Name,
+		)
+	}
+	return ag, nil
 }
 
 // resolveAgent decides which agent to use for this run.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -58,6 +58,49 @@ type mockAgent struct {
 	name string
 }
 
+type repositoryOnlyAgent struct {
+	*mockAgent
+}
+
+func (a *repositoryOnlyAgent) InvocationSkillRepository(
+	context.Context,
+	*agent.Invocation,
+) skill.Repository {
+	return nil
+}
+
+func TestRunnerRejectsSkillLoadsForUnsupportedAgent(t *testing.T) {
+	r := NewRunner("app", &mockAgent{name: "plain"})
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+		agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+	)
+
+	require.Nil(t, events)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, agent.ErrSkillLoadingUnsupported))
+}
+
+func TestRunnerRejectsRepositoryProviderWithoutSkillLoadSupport(t *testing.T) {
+	ag := &repositoryOnlyAgent{mockAgent: &mockAgent{name: "repository-only"}}
+	r := NewRunner("app", ag)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+		agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+	)
+
+	require.Nil(t, events)
+	require.ErrorIs(t, err, agent.ErrSkillLoadingUnsupported)
+}
+
 type staticSessionRouter struct {
 	sess *session.Session
 }
@@ -280,6 +323,7 @@ type realStructuredOutputMapPayload struct {
 type capturedModelRequest struct {
 	messages         []model.Message
 	structuredOutput *model.StructuredOutput
+	toolNames        []string
 }
 
 type sequentialModel struct {
@@ -381,6 +425,10 @@ func cloneCapturedModelRequest(req *model.Request) *capturedModelRequest {
 	cloned := &capturedModelRequest{
 		messages: append([]model.Message(nil), req.Messages...),
 	}
+	for name := range req.Tools {
+		cloned.toolNames = append(cloned.toolNames, name)
+	}
+	sort.Strings(cloned.toolNames)
 	if req.StructuredOutput != nil {
 		structuredOutput := *req.StructuredOutput
 		if req.StructuredOutput.JSONSchema != nil {
@@ -390,6 +438,380 @@ func cloneCapturedModelRequest(req *model.Request) *capturedModelRequest {
 		cloned.structuredOutput = &structuredOutput
 	}
 	return cloned
+}
+
+func TestRunnerRunWithSkillLoadsMaterializesFirstRequest(t *testing.T) {
+	repo := createRunnerDeclaredSkillRepository(t)
+	modelStub := &sequentialModel{
+		name: "declared-skill",
+		responses: []*model.Response{{
+			ID:   "declared-skill-response",
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("done"),
+			}},
+		}},
+	}
+	activatedTool := &callCountingTool{
+		name:   "review_inspect",
+		result: "ok",
+	}
+	activatedSet := &candidateToolSet{
+		name:  "review-tools",
+		tools: []tool.Tool{activatedTool},
+	}
+	agt := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(modelStub),
+		llmagent.WithSkills(repo),
+		llmagent.WithActivatableToolSets([]tool.ToolSet{activatedSet}),
+		llmagent.WithToolActivationOnSkillLoad(
+			"review",
+			[]string{"review-tools"},
+		),
+	)
+	r := NewRunner("app", agt)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("review this"),
+		agent.WithSkillLoads(skill.LoadRequest{
+			Name: "review",
+			Docs: []string{"guide.md"},
+		}),
+	)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	requests := modelStub.Requests()
+	require.Len(t, requests, 1)
+	system := firstSystemMessageContent(requests[0].messages)
+	require.Contains(t, system, "REVIEW BODY")
+	require.Contains(t, system, "GUIDE BODY")
+	require.Contains(t, requests[0].toolNames, "review-tools_review_inspect")
+}
+
+func TestRunnerWrappersPreserveSkillLoads(t *testing.T) {
+	tests := []struct {
+		name      string
+		runnerOpt Option
+		response  string
+		requests  int
+	}{
+		{
+			name: "ralph loop",
+			runnerOpt: WithRalphLoop(RalphLoopConfig{
+				CompletionPromise: "DONE",
+			}),
+			response: "<promise>DONE</promise>",
+			requests: 1,
+		},
+		{
+			name: "candidate selector",
+			runnerOpt: WithCandidateSelector(
+				&fixedCandidateSelector{winner: 0},
+				WithCandidateAttempts(2),
+			),
+			response: "done",
+			requests: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responses := make([]*model.Response, test.requests)
+			for i := range responses {
+				responses[i] = &model.Response{
+					ID:   fmt.Sprintf("%s-%d", test.name, i),
+					Done: true,
+					Choices: []model.Choice{{
+						Message: model.NewAssistantMessage(test.response),
+					}},
+				}
+			}
+			modelStub := &sequentialModel{
+				name:      test.name,
+				responses: responses,
+			}
+			agt := llmagent.New(
+				"reviewer",
+				llmagent.WithModel(modelStub),
+				llmagent.WithSkills(createRunnerDeclaredSkillRepository(t)),
+			)
+			r := NewRunner("app", agt, test.runnerOpt)
+
+			events, err := r.Run(
+				context.Background(),
+				"user",
+				"session",
+				model.NewUserMessage("review"),
+				agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+			)
+			require.NoError(t, err)
+			for range events {
+			}
+
+			requests := modelStub.Requests()
+			require.Len(t, requests, test.requests)
+			for _, request := range requests {
+				require.Contains(
+					t,
+					firstSystemMessageContent(request.messages),
+					"REVIEW BODY",
+				)
+			}
+		})
+	}
+}
+
+func TestRunnerRalphLoopPreservesSkillLoadsAcrossIterations(t *testing.T) {
+	modelStub := &sequentialModel{
+		name: "ralph-multi-iteration",
+		responses: []*model.Response{
+			{
+				ID:   "ralph-working",
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage("still working"),
+				}},
+			},
+			{
+				ID:   "ralph-done",
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(
+						"<promise>DONE</promise>",
+					),
+				}},
+			},
+		},
+	}
+	agt := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(modelStub),
+		llmagent.WithSkills(createRunnerDeclaredSkillRepository(t)),
+	)
+	r := NewRunner(
+		"app",
+		agt,
+		WithRalphLoop(RalphLoopConfig{
+			MaxIterations:     2,
+			CompletionPromise: "DONE",
+		}),
+	)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("review"),
+		agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+	)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	requests := modelStub.Requests()
+	require.Len(t, requests, 2)
+	for _, request := range requests {
+		require.Contains(
+			t,
+			firstSystemMessageContent(request.messages),
+			"REVIEW BODY",
+		)
+	}
+}
+
+func TestRunnerNestedCandidateAndRalphPreserveSkillLoads(t *testing.T) {
+	const attempts = 2
+	responses := make([]*model.Response, 0, attempts*2)
+	for i := 0; i < attempts; i++ {
+		responses = append(
+			responses,
+			&model.Response{
+				ID:   fmt.Sprintf("candidate-%d-working", i),
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage("still working"),
+				}},
+			},
+			&model.Response{
+				ID:   fmt.Sprintf("candidate-%d-done", i),
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewAssistantMessage(
+						"<promise>DONE</promise>",
+					),
+				}},
+			},
+		)
+	}
+	modelStub := &sequentialModel{
+		name:      "candidate-ralph",
+		responses: responses,
+	}
+	agt := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(modelStub),
+		llmagent.WithSkills(createRunnerDeclaredSkillRepository(t)),
+	)
+	r := NewRunner(
+		"app",
+		agt,
+		WithRalphLoop(RalphLoopConfig{
+			MaxIterations:     2,
+			CompletionPromise: "DONE",
+		}),
+		WithCandidateSelector(
+			&fixedCandidateSelector{winner: 0},
+			WithCandidateAttempts(attempts),
+		),
+	)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("review"),
+		agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+	)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	requests := modelStub.Requests()
+	require.Len(t, requests, attempts*2)
+	for _, request := range requests {
+		require.Contains(
+			t,
+			firstSystemMessageContent(request.messages),
+			"REVIEW BODY",
+		)
+	}
+}
+
+func TestRunnerWrappersRejectInvalidSkillBeforeModelRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		runnerOpt Option
+	}{
+		{
+			name: "ralph loop",
+			runnerOpt: WithRalphLoop(RalphLoopConfig{
+				CompletionPromise: "DONE",
+			}),
+		},
+		{
+			name: "candidate selector",
+			runnerOpt: WithCandidateSelector(
+				&fixedCandidateSelector{winner: 0},
+				WithCandidateAttempts(2),
+			),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modelStub := &sequentialModel{name: test.name}
+			agt := llmagent.New(
+				"reviewer",
+				llmagent.WithModel(modelStub),
+				llmagent.WithSkills(createRunnerDeclaredSkillRepository(t)),
+			)
+			r := NewRunner("app", agt, test.runnerOpt)
+
+			events, err := r.Run(
+				context.Background(),
+				"user",
+				"session",
+				model.NewUserMessage("review"),
+				agent.WithSkillLoads(skill.LoadRequest{Name: "missing"}),
+			)
+			require.NoError(t, err)
+			for range events {
+			}
+
+			require.Empty(t, modelStub.Requests())
+		})
+	}
+}
+
+func TestRunnerRejectsSkillLoadsForLazyRootBeforeFactoryRun(t *testing.T) {
+	factoryCalled := false
+	lazy := agent.NewLazyAgent(
+		agent.Info{Name: "lazy-root"},
+		func(
+			context.Context,
+			agent.RunOptions,
+		) (agent.Agent, error) {
+			factoryCalled = true
+			return llmagent.New(
+				"lazy-root",
+				llmagent.WithModel(&sequentialModel{name: "lazy-root"}),
+				llmagent.WithSkills(createRunnerDeclaredSkillRepository(t)),
+			), nil
+		},
+	)
+	r := NewRunner("app", lazy)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("review"),
+		agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+	)
+
+	require.Nil(t, events)
+	require.ErrorIs(t, err, agent.ErrSkillLoadingUnsupported)
+	require.False(t, factoryCalled)
+}
+
+func TestRunnerAgentFactorySupportsSkillLoads(t *testing.T) {
+	modelStub := &sequentialModel{
+		name: "factory-root",
+		responses: []*model.Response{{
+			ID:   "factory-root-response",
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("done"),
+			}},
+		}},
+	}
+	r := NewRunnerWithAgentFactory(
+		"app",
+		"factory-root",
+		func(
+			context.Context,
+			agent.RunOptions,
+		) (agent.Agent, error) {
+			return llmagent.New(
+				"factory-root",
+				llmagent.WithModel(modelStub),
+				llmagent.WithSkills(createRunnerDeclaredSkillRepository(t)),
+			), nil
+		},
+	)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("review"),
+		agent.WithSkillLoads(skill.LoadRequest{Name: "review"}),
+	)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	requests := modelStub.Requests()
+	require.Len(t, requests, 1)
+	require.Contains(
+		t,
+		firstSystemMessageContent(requests[0].messages),
+		"REVIEW BODY",
+	)
 }
 
 func firstSystemMessageContent(messages []model.Message) string {
@@ -11111,6 +11533,29 @@ func createNamedRunnerTestSkillRepository(
 			0o644,
 		),
 	)
+	repo, err := skill.NewFSRepository(root)
+	require.NoError(t, err)
+	return repo
+}
+
+func createRunnerDeclaredSkillRepository(t *testing.T) skill.Repository {
+	t.Helper()
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "review")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, skill.SkillFile),
+		[]byte(
+			"---\nname: review\ndescription: review changes\n---\n"+
+				"REVIEW BODY\n",
+		),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, "guide.md"),
+		[]byte("GUIDE BODY\n"),
+		0o644,
+	))
 	repo, err := skill.NewFSRepository(root)
 	require.NoError(t, err)
 	return repo

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -696,12 +696,14 @@ func TestRunnerWrappersRejectInvalidSkillBeforeModelRequest(t *testing.T) {
 	tests := []struct {
 		name      string
 		runnerOpt Option
+		errorType string
 	}{
 		{
 			name: "ralph loop",
 			runnerOpt: WithRalphLoop(RalphLoopConfig{
 				CompletionPromise: "DONE",
 			}),
+			errorType: agent.ErrorTypeStopAgentError,
 		},
 		{
 			name: "candidate selector",
@@ -709,6 +711,7 @@ func TestRunnerWrappersRejectInvalidSkillBeforeModelRequest(t *testing.T) {
 				&fixedCandidateSelector{winner: 0},
 				WithCandidateAttempts(2),
 			),
+			errorType: model.ErrorTypeRunError,
 		},
 	}
 	for _, test := range tests {
@@ -729,9 +732,24 @@ func TestRunnerWrappersRejectInvalidSkillBeforeModelRequest(t *testing.T) {
 				agent.WithSkillLoads(skill.LoadRequest{Name: "missing"}),
 			)
 			require.NoError(t, err)
-			for range events {
+			var skillLoadError *model.ResponseError
+			for evt := range events {
+				if evt != nil && evt.Response != nil &&
+					evt.Response.Error != nil &&
+					strings.Contains(
+						evt.Response.Error.Message,
+						skill.ErrSkillUnavailable.Error(),
+					) {
+					skillLoadError = evt.Response.Error
+				}
 			}
 
+			require.NotNil(
+				t,
+				skillLoadError,
+				"wrapper must deliver the skill-load failure",
+			)
+			require.Equal(t, test.errorType, skillLoadError.Type)
 			require.Empty(t, modelStub.Requests())
 		})
 	}

--- a/skill/load_request.go
+++ b/skill/load_request.go
@@ -32,7 +32,9 @@ var (
 // the repository and is mutually exclusive with Docs. When Docs is empty and
 // IncludeAllDocs is false, an existing document selection is preserved. Under
 // the default turn load mode, the previous turn's selection is cleared before
-// this request is applied.
+// this request is applied. Within one declaration batch, entries with the same
+// normalized Name, Docs set, and IncludeAllDocs value are coalesced; conflicting
+// selections for the same skill are invalid.
 type LoadRequest struct {
 	Name           string
 	Docs           []string

--- a/skill/load_request.go
+++ b/skill/load_request.go
@@ -30,11 +30,14 @@ var (
 // path. SKILL.md is always loaded. Docs contains additional paths relative to
 // the skill root. IncludeAllDocs loads every supporting document exposed by
 // the repository and is mutually exclusive with Docs. When Docs is empty and
-// IncludeAllDocs is false, an existing document selection is preserved. Under
-// the default turn load mode, the previous turn's selection is cleared before
-// this request is applied. Within one declaration batch, entries with the same
-// normalized Name, Docs set, and IncludeAllDocs value are coalesced; conflicting
-// selections for the same skill are invalid.
+// IncludeAllDocs is false, the request itself leaves any current document
+// selection unchanged. In the default turn load mode, the turn reset and this
+// request are applied atomically; the reset removes the previous turn's
+// selection, so it is not inherited. Modes without a turn reset, including
+// session mode, preserve a selection that is still present. Within one
+// declaration batch, entries with the same normalized Name, Docs set, and
+// IncludeAllDocs value are coalesced; conflicting selections for the same
+// skill are invalid.
 type LoadRequest struct {
 	Name           string
 	Docs           []string

--- a/skill/load_request.go
+++ b/skill/load_request.go
@@ -1,0 +1,40 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package skill
+
+import "errors"
+
+var (
+	// ErrInvalidLoadRequest indicates that a skill load declaration is
+	// malformed or cannot be satisfied together with the other declarations.
+	ErrInvalidLoadRequest = errors.New("invalid skill load request")
+
+	// ErrSkillUnavailable indicates that a requested skill or supporting
+	// document is not available through the invocation's effective repository.
+	// Implementations intentionally do not distinguish missing content from
+	// content hidden by an invocation-scoped visibility policy.
+	ErrSkillUnavailable = errors.New("skill unavailable")
+)
+
+// LoadRequest declares a skill that must be loaded before the first model
+// request of an invocation.
+//
+// Name identifies a skill in the effective repository; it is not a filesystem
+// path. SKILL.md is always loaded. Docs contains additional paths relative to
+// the skill root. IncludeAllDocs loads every supporting document exposed by
+// the repository and is mutually exclusive with Docs. When Docs is empty and
+// IncludeAllDocs is false, an existing document selection is preserved. Under
+// the default turn load mode, the previous turn's selection is cleared before
+// this request is applied.
+type LoadRequest struct {
+	Name           string
+	Docs           []string
+	IncludeAllDocs bool
+}


### PR DESCRIPTION
## What changed

Applications can now declare skills that the selected agent must load before its first model request through agent.WithSkillLoads. LLMAgent validates each declaration against the invocation-scoped repository, materializes skill bodies and selected docs through the existing skill state machinery, and activates configured skill tool sets without fabricating model tool calls.

Runner rejects agents that do not explicitly advertise invocation skill-load support. Ralph Loop and Candidate Selector preserve and delegate that capability, while cloned child invocations and graph nodes do not inherit entry declarations unless they opt in explicitly.

English and Chinese Skills documentation describe the public API, document-selection behavior, load modes, wrapper error delivery, and custom-agent capability contract.

## Why

Some applications know which skill a request requires before invoking the model. Requiring the model to rediscover that decision through skill_load adds latency and makes a business routing decision probabilistic.

The capability remains explicit at the framework boundary so unsupported agents cannot silently ignore declarations. Validation is atomic and uses context-aware visibility, keeping missing and hidden content indistinguishable. In turn mode, clearing previous skill state and applying declared loads share one final state delta so asynchronous wrapper event persistence cannot overwrite a continuation with a stale clear.

## Testing

- go test ./agent ./agent/llmagent ./internal/flow/processor ./runner ./graph
- race-tested the three new Runner wrapper regressions five times
- repeated the Ralph Loop and nested Candidate Selector regressions 30 times
- git diff --check

## Notes for reviewers

- The API is additive. Runs without SkillLoads retain their previous behavior.
- InvocationSkillLoadSupport is a behavioral commitment; wrappers delegate it to the agent that performs the model request.
- NewLazyAgent remains intended for lazy sub-agents and cannot advertise a request-dependent factory result before Runner capability checks. Request-scoped root agents should use runner.AgentFactory.
- Direct Agent.Run callers construct the lower-level invocation themselves and are responsible for selecting an agent that supports declared loads.

<!-- markdownlint-disable MD041 -->

<!--
Write the pull request title and description in English.

The title must identify the primary affected package or repository area.

Preferred form:
  package: lowercase summary

For multiple equally affected packages:
  {package/a, package/b}: lowercase summary

For a coherent cross-cutting change spanning many packages with no primary
package:
  lsc: lowercase summary
-->

## What changed

Summarize the outcome and its user or developer impact. Do not restate the
implementation or enumerate changed files.

## Why

Explain the problem and any non-obvious design rationale.

## Testing

List the automated and manual validation that was actually performed. If a
check is not applicable, explain why.

## Notes for reviewers

Optionally call out risks or design decisions that are not obvious from the
diff, such as public API, compatibility, concurrency, persistence, protocol, or
security concerns.
