### PR TITLE
ci: skip star history updates in forks

### DIFF
--- a/.github/workflows/update-star-history.yml
+++ b/.github/workflows/update-star-history.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   update:
     name: update
+    if: github.repository == 'trpc-group/trpc-agent-go'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## What changed

Restrict the Star History update job to the canonical
`trpc-group/trpc-agent-go` repository. Forks now skip the job before checkout,
API access, or asset-branch preparation.

## Why

The seed history belongs to `trpc-group/trpc-agent-go`, while the workflow
previously passed the runtime `github.repository` value to the generator. When
the inherited workflow ran in a fork without an asset branch, the canonical
seed failed repository validation against the fork name.

Keeping this repository-owned asset pipeline canonical-only avoids failed fork
runs and prevents duplicate `star-history` branches across forks.

## Testing

- `actionlint .github/workflows/update-star-history.yml`
- `node .github/scripts/update-star-history.mjs test`
- `git diff --check`

## Notes for reviewers

The upstream push, schedule, and manual triggers are unchanged. This does not
change the generated data format or any public Go API.
