### PR TITLE
docs/model: clarify custom streaming usage aggregation

### DIFF
--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -396,7 +396,7 @@ Most applications should use the default accumulator. Nonstandard providers
 may report increments, cumulative totals, or a final total; the custom
 accumulator must match that behavior and return a complete usage state. See
 [Custom Streaming Usage Aggregation](../model.md#custom-streaming-usage-aggregation)
-for the reduce-style mental model, every `model.Usage` field, and complete
+for the callback execution order, every `model.Usage` field, and complete
 examples.
 
 When `Stream` is true, the OpenAI-compatible adapter requests usage

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -397,12 +397,19 @@ provider requires "latest chunk wins" semantics, preserve every usage field by
 returning the complete delta:
 
 ```go
-openai.WithAccumulateChunkTokenUsage(func(
-    _ model.Usage,
-    delta model.Usage,
-) model.Usage {
-    return delta
-})
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+llm := openai.New("your-model",
+    openai.WithAccumulateChunkTokenUsage(func(
+        _ model.Usage,
+        delta model.Usage,
+    ) model.Usage {
+        return delta
+    }),
+)
 ```
 
 When `Stream` is true, the OpenAI-compatible adapter requests usage

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -392,25 +392,12 @@ the complete accumulated `model.Usage`; returning only `PromptTokens`,
 `CompletionTokens`, and `TotalTokens` discards
 `PromptTokensDetails.CachedTokens`.
 
-Most applications should use the default accumulator. If a nonstandard
-provider requires "latest chunk wins" semantics, preserve every usage field by
-returning the complete delta:
-
-```go
-import (
-    "trpc.group/trpc-go/trpc-agent-go/model"
-    "trpc.group/trpc-go/trpc-agent-go/model/openai"
-)
-
-llm := openai.New("your-model",
-    openai.WithAccumulateChunkTokenUsage(func(
-        _ model.Usage,
-        delta model.Usage,
-    ) model.Usage {
-        return delta
-    }),
-)
-```
+Most applications should use the default accumulator. Nonstandard providers
+may report increments, cumulative totals, or a final total; the custom
+accumulator must match that behavior and return a complete usage state. See
+[Custom Streaming Usage Aggregation](../model.md#custom-streaming-usage-aggregation)
+for the reduce-style mental model, every `model.Usage` field, and complete
+examples.
 
 When `Stream` is true, the OpenAI-compatible adapter requests usage
 automatically. Provider-specific request inspection can still be useful to

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -379,6 +379,38 @@ Telemetry also splits token types:
 - `input_cache_creation`
 - `output`
 
+#### Troubleshooting Streaming Usage
+
+For streaming requests, OpenAI-compatible providers commonly send usage in a
+final usage-only chunk. tRPC-Agent-Go consumes that chunk and attaches the
+accumulated usage to the final `model.Response`.
+
+If the raw stream contains a nonzero `cached_tokens` value but the final
+response reports zero, check whether the model was configured with
+`openai.WithAccumulateChunkTokenUsage`. The callback's return value replaces
+the complete accumulated `model.Usage`; returning only `PromptTokens`,
+`CompletionTokens`, and `TotalTokens` discards
+`PromptTokensDetails.CachedTokens`.
+
+Most applications should use the default accumulator. If a nonstandard
+provider requires "latest chunk wins" semantics, preserve every usage field by
+returning the complete delta:
+
+```go
+openai.WithAccumulateChunkTokenUsage(func(
+    _ model.Usage,
+    delta model.Usage,
+) model.Usage {
+    return delta
+})
+```
+
+When `Stream` is true, the OpenAI-compatible adapter requests usage
+automatically. Provider-specific request inspection can still be useful to
+confirm that the final usage chunk reaches the client, but adding another
+`stream_options.include_usage` field does not restore details discarded by a
+custom accumulator.
+
 A simple aggregate view is:
 
 ```text

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -594,27 +594,104 @@ model := openai.New("deepseek-v4-flash",
 
 ##### Custom Streaming Usage Aggregation
 
-The OpenAI-compatible adapter enables streaming usage collection and
-accumulates the provider's usage chunks by default. Most applications should
-keep this default.
+The OpenAI-compatible adapter requests streaming usage and accumulates the
+provider's usage chunks by default. Most applications should keep this
+behavior. Configure `WithAccumulateChunkTokenUsage` only when a compatible
+provider gives usage chunks nonstandard semantics. The option only affects
+streaming chunk aggregation; non-streaming usage is read directly from the
+complete response.
 
-`WithAccumulateChunkTokenUsage` is intended for providers with nonstandard
-streaming usage semantics, such as a provider that reports cumulative totals
-in every chunk. Its callback receives the usage accumulated before the current
-chunk and the current chunk's usage:
+###### Mental Model: Reduce Usage Chunks into One Result
+
+The option works like a reduce or fold operation over the stream—the same
+mental model as Python's `functools.reduce` or Java's `Stream.reduce`.
+`current` is the accumulator, the current chunk is the next element, and the
+return value becomes the next accumulator:
+
+```go
+state0 := model.Usage{}
+state1 := accumulate(state0, chunk1.Usage)
+state2 := accumulate(state1, chunk2.Usage)
+// ...
+finalResponse.Usage = accumulate(stateN, lastChunk.Usage)
+```
+
+The callback signature is:
 
 ```go
 func(current model.Usage, delta model.Usage) model.Usage
 ```
 
-The returned `model.Usage` replaces the complete accumulated usage value.
-Fields omitted from the returned value are not copied from `current` or
-`delta`. This includes nested details such as
-`PromptTokensDetails.CachedTokens` and
-`CompletionTokensDetails.ReasoningTokens`.
+| Value | Meaning |
+| --- | --- |
+| `current` | The accumulated state before the current chunk |
+| `delta` | The `Usage` value carried by the current chunk |
+| return value | The complete state to use after the current chunk |
 
-For a provider where the latest usage chunk is authoritative, return the
-complete `delta` value:
+For each chunk, the OpenAI-compatible adapter first lets the upstream SDK
+accumulate the chunk. When a custom callback is configured, the adapter then
+reconstructs the usage state from before that chunk, maps the current chunk's
+usage to `delta`, calls the callback, and replaces the SDK accumulator's usage
+with the returned value. The next chunk therefore sees that returned value as
+`current`, and the final model response receives the last returned value.
+
+`delta` is the API parameter name, but it does not guarantee that the provider
+sent a mathematical increment. Depending on the provider, it can be an
+increment, a cumulative total, a final total, or an empty value.
+
+The return value replaces the complete accumulated `model.Usage`. Fields
+omitted from it are not copied from `current` or `delta`.
+
+For a standard OpenAI-compatible stream, content chunks usually contain no
+usage and the last usage-only chunk contains the complete totals:
+
+```text
+chunk 1..N: delta = {0, 0, 0}
+last chunk: delta = {prompt: 100, completion: 20, total: 120, cached: 80}
+final usage:        {prompt: 100, completion: 20, total: 120, cached: 80}
+```
+
+The default accumulator handles this shape. A custom accumulator is not needed.
+
+###### `model.Usage` Fields
+
+The accumulator state is a complete `model.Usage` value:
+
+| Field | Meaning |
+| --- | --- |
+| `PromptTokens` | Total input tokens reported for the request. Cached input tokens are normally included in this total, not added on top of it |
+| `CompletionTokens` | Total generated output tokens reported by the provider |
+| `TotalTokens` | Provider-reported total, normally prompt plus completion tokens |
+| `PromptTokensDetails.CachedTokens` | Prompt tokens served from an OpenAI-compatible prompt cache; normally a subset of `PromptTokens` |
+| `PromptTokensDetails.CacheCreationTokens` | Tokens used to create an explicit provider cache, primarily for Anthropic-style caching |
+| `PromptTokensDetails.CacheReadTokens` | Tokens read from an explicit provider cache, primarily for Anthropic-style caching |
+| `CompletionTokensDetails.ReasoningTokens` | Reasoning tokens reported within the completion usage |
+| `TimingInfo` | Optional framework timing metadata, not billable token usage |
+| `TimingInfo.FirstTokenDuration` | Accumulated time from request start to the first meaningful reasoning, content, or tool-call chunk for each model call |
+| `TimingInfo.ReasoningDuration` | Accumulated duration of streaming reasoning phases; it remains zero for non-streaming requests because the interval cannot be measured precisely |
+
+These fields form a provider-agnostic structure.
+`WithAccumulateChunkTokenUsage` belongs to the OpenAI-compatible adapter, so
+its callback only receives fields that the upstream OpenAI-compatible response
+and adapter mapping support. Other provider-specific fields remain zero.
+
+`TimingInfo` contains `FirstTokenDuration` and `ReasoningDuration`. The
+framework attaches this timing metadata outside the OpenAI chunk-usage
+accumulator, so custom token accumulation normally does not need to create or
+merge it.
+
+Token accounting details remain provider-defined. For example, do not add
+`CachedTokens` to `PromptTokens`, and do not recompute `TotalTokens` unless the
+provider contract requires it.
+
+###### Choose the Strategy that Matches the Provider
+
+Use the default accumulator when the provider follows standard OpenAI
+streaming usage behavior.
+
+If every streamed chunk contains the latest cumulative total, or the provider
+guarantees an authoritative final usage chunk, summing the chunks would double
+count. Use latest-chunk-wins semantics and return the complete `delta`:
 
 ```go
 import (
@@ -632,11 +709,42 @@ llm := openai.New("your-model",
 )
 ```
 
-Avoid rebuilding only the top-level token counts. Doing so resets omitted
-details to zero, so a provider can return a nonzero `cached_tokens` value while
-the final `model.Response.Usage` reports zero. If the provider follows standard
-OpenAI streaming usage semantics, remove this option and use the default
-accumulator.
+If cumulative usage appears only on some chunks, keep `current` when `delta`
+is empty instead of resetting the state. Define "empty" from the fields that
+the provider can report.
+
+If each usage chunk contains only a true increment, add every field exposed by
+the OpenAI-compatible chunk mapping:
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+func addUsage(current, delta model.Usage) model.Usage {
+    current.PromptTokens += delta.PromptTokens
+    current.CompletionTokens += delta.CompletionTokens
+    current.TotalTokens += delta.TotalTokens
+    current.PromptTokensDetails.CachedTokens +=
+        delta.PromptTokensDetails.CachedTokens
+    current.CompletionTokensDetails.ReasoningTokens +=
+        delta.CompletionTokensDetails.ReasoningTokens
+    return current
+}
+
+llm := openai.New("your-model",
+    openai.WithAccumulateChunkTokenUsage(addUsage),
+)
+```
+
+Do not rebuild only `PromptTokens`, `CompletionTokens`, and `TotalTokens`.
+Doing so resets omitted nested details to zero. A provider can then return
+nonzero `cached_tokens` while the final `model.Response.Usage` reports zero.
+
+Before choosing a custom strategy, inspect the provider's raw chunks across a
+complete stream. In particular, check whether usage is incremental or
+cumulative and whether a final usage-only chunk is present.
 
 ##### Dynamically Modifying Request Body via Callback
 

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -592,6 +592,47 @@ model := openai.New("deepseek-v4-flash",
 )
 ```
 
+##### Custom Streaming Usage Aggregation
+
+The OpenAI-compatible adapter enables streaming usage collection and
+accumulates the provider's usage chunks by default. Most applications should
+keep this default.
+
+`WithAccumulateChunkTokenUsage` is intended for providers with nonstandard
+streaming usage semantics, such as a provider that reports cumulative totals
+in every chunk. Its callback receives the usage accumulated before the current
+chunk and the current chunk's usage:
+
+```go
+func(current model.Usage, delta model.Usage) model.Usage
+```
+
+The returned `model.Usage` replaces the complete accumulated usage value.
+Fields omitted from the returned value are not copied from `current` or
+`delta`. This includes nested details such as
+`PromptTokensDetails.CachedTokens` and
+`CompletionTokensDetails.ReasoningTokens`.
+
+For a provider where the latest usage chunk is authoritative, return the
+complete `delta` value:
+
+```go
+llm := openai.New("your-model",
+    openai.WithAccumulateChunkTokenUsage(func(
+        _ model.Usage,
+        delta model.Usage,
+    ) model.Usage {
+        return delta
+    }),
+)
+```
+
+Avoid rebuilding only the top-level token counts. Doing so resets omitted
+details to zero, so a provider can return a nonzero `cached_tokens` value while
+the final `model.Response.Usage` reports zero. If the provider follows standard
+OpenAI streaming usage semantics, remove this option and use the default
+accumulator.
+
 ##### Dynamically Modifying Request Body via Callback
 
 `WithChatRequestCallback` receives a `*openai.ChatCompletionNewParams` pointer,

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -617,6 +617,11 @@ For a provider where the latest usage chunk is authoritative, return the
 complete `delta` value:
 
 ```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
 llm := openai.New("your-model",
     openai.WithAccumulateChunkTokenUsage(func(
         _ model.Usage,

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -601,22 +601,10 @@ provider gives usage chunks nonstandard semantics. The option only affects
 streaming chunk aggregation; non-streaming usage is read directly from the
 complete response.
 
-###### Mental Model: Reduce Usage Chunks into One Result
+###### How `WithAccumulateChunkTokenUsage` Processes Each Chunk
 
-The option works like a reduce or fold operation over the stream—the same
-mental model as Python's `functools.reduce` or Java's `Stream.reduce`.
-`current` is the accumulator, the current chunk is the next element, and the
-return value becomes the next accumulator:
-
-```go
-state0 := model.Usage{}
-state1 := accumulate(state0, chunk1.Usage)
-state2 := accumulate(state1, chunk2.Usage)
-// ...
-finalResponse.Usage = accumulate(stateN, lastChunk.Usage)
-```
-
-The callback signature is:
+When configured, the callback runs once for each streaming chunk, in order.
+Its signature is:
 
 ```go
 func(current model.Usage, delta model.Usage) model.Usage
@@ -642,13 +630,16 @@ increment, a cumulative total, a final total, or an empty value.
 The return value replaces the complete accumulated `model.Usage`. Fields
 omitted from it are not copied from `current` or `delta`.
 
-For a standard OpenAI-compatible stream, content chunks usually contain no
-usage and the last usage-only chunk contains the complete totals:
+For a standard OpenAI-compatible stream, the raw content chunks contain
+`usage: null`. The adapter maps that absence to a zero-value `model.Usage`
+before invoking the callback. The final usage-only chunk contains the complete
+totals:
 
 ```text
-chunk 1..N: delta = {0, 0, 0}
-last chunk: delta = {prompt: 100, completion: 20, total: 120, cached: 80}
-final usage:        {prompt: 100, completion: 20, total: 120, cached: 80}
+raw content chunk:       usage = null
+callback for that chunk: delta = model.Usage{}
+raw final chunk:         usage = {prompt: 100, completion: 20, total: 120, cached: 80}
+callback for final chunk: delta = {prompt: 100, completion: 20, total: 120, cached: 80}
 ```
 
 The default accumulator handles this shape. A custom accumulator is not needed.
@@ -686,35 +677,17 @@ provider contract requires it.
 
 ###### Choose the Strategy that Matches the Provider
 
-Use the default accumulator when the provider follows standard OpenAI
-streaming usage behavior.
+Start with the provider's response format:
 
-If every streamed chunk contains the latest cumulative total, or the provider
-guarantees an authoritative final usage chunk, summing the chunks would double
-count. Use latest-chunk-wins semantics and return the complete `delta`:
+| Provider response format | Can direct summation count tokens more than once? | Recommended configuration |
+| --- | --- | --- |
+| A final usage-only chunk contains the complete totals | No; earlier chunks have no usage | Use the default accumulator |
+| Each usage chunk contains an independent increment | No | Use the default accumulator |
+| Usage chunks contain cumulative snapshots or repeat fields already reported | Yes | Use a latest-nonzero custom accumulator |
 
-```go
-import (
-    "trpc.group/trpc-go/trpc-agent-go/model"
-    "trpc.group/trpc-go/trpc-agent-go/model/openai"
-)
-
-llm := openai.New("your-model",
-    openai.WithAccumulateChunkTokenUsage(func(
-        _ model.Usage,
-        delta model.Usage,
-    ) model.Usage {
-        return delta
-    }),
-)
-```
-
-If cumulative usage appears only on some chunks, keep `current` when `delta`
-is empty instead of resetting the state. Define "empty" from the fields that
-the provider can report.
-
-If each usage chunk contains only a true increment, add every field exposed by
-the OpenAI-compatible chunk mapping:
+For cumulative snapshots or repeated fields, keep the most recent nonzero
+usage value. Empty chunks must preserve `current`; otherwise an empty chunk
+after the last usage update can clear the result.
 
 ```go
 import (
@@ -722,25 +695,27 @@ import (
     "trpc.group/trpc-go/trpc-agent-go/model/openai"
 )
 
-func addUsage(current, delta model.Usage) model.Usage {
-    current.PromptTokens += delta.PromptTokens
-    current.CompletionTokens += delta.CompletionTokens
-    current.TotalTokens += delta.TotalTokens
-    current.PromptTokensDetails.CachedTokens +=
-        delta.PromptTokensDetails.CachedTokens
-    current.CompletionTokensDetails.ReasoningTokens +=
-        delta.CompletionTokensDetails.ReasoningTokens
-    return current
+func latestNonZeroUsage(current, delta model.Usage) model.Usage {
+    if delta.PromptTokens == 0 &&
+        delta.CompletionTokens == 0 &&
+        delta.TotalTokens == 0 &&
+        delta.PromptTokensDetails.CachedTokens == 0 &&
+        delta.PromptTokensDetails.CacheCreationTokens == 0 &&
+        delta.PromptTokensDetails.CacheReadTokens == 0 &&
+        delta.CompletionTokensDetails.ReasoningTokens == 0 {
+        return current
+    }
+    return delta
 }
 
 llm := openai.New("your-model",
-    openai.WithAccumulateChunkTokenUsage(addUsage),
+    openai.WithAccumulateChunkTokenUsage(latestNonZeroUsage),
 )
 ```
 
-Do not rebuild only `PromptTokens`, `CompletionTokens`, and `TotalTokens`.
-Doing so resets omitted nested details to zero. A provider can then return
-nonzero `cached_tokens` while the final `model.Response.Usage` reports zero.
+Returning the complete `delta` preserves nested details such as
+`CachedTokens` and `ReasoningTokens`. Define "empty" from every field that the
+provider can report.
 
 Before choosing a custom strategy, inspect the provider's raw chunks across a
 complete stream. In particular, check whether usage is incremental or

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -415,12 +415,19 @@ Telemetry 层也会拆分 token 类型。`internal/telemetry` 包会记录：
 返回完整的 delta，以保留所有 usage 字段：
 
 ```go
-openai.WithAccumulateChunkTokenUsage(func(
-    _ model.Usage,
-    delta model.Usage,
-) model.Usage {
-    return delta
-})
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+llm := openai.New("your-model",
+    openai.WithAccumulateChunkTokenUsage(func(
+        _ model.Usage,
+        delta model.Usage,
+    ) model.Usage {
+        return delta
+    }),
+)
 ```
 
 当 `Stream` 为 true 时，OpenAI-compatible adapter 会自动请求 usage。

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -411,24 +411,10 @@ Telemetry 层也会拆分 token 类型。`internal/telemetry` 包会记录：
 `model.Usage`；如果只返回 `PromptTokens`、`CompletionTokens` 和
 `TotalTokens`，就会丢失 `PromptTokensDetails.CachedTokens`。
 
-大多数应用应使用默认聚合器。如果非标准服务方要求“最新 chunk 为准”，应直接
-返回完整的 delta，以保留所有 usage 字段：
-
-```go
-import (
-    "trpc.group/trpc-go/trpc-agent-go/model"
-    "trpc.group/trpc-go/trpc-agent-go/model/openai"
-)
-
-llm := openai.New("your-model",
-    openai.WithAccumulateChunkTokenUsage(func(
-        _ model.Usage,
-        delta model.Usage,
-    ) model.Usage {
-        return delta
-    }),
-)
-```
+大多数应用应使用默认聚合器。非标准服务方可能返回增量、累计总量或最后一次完整
+总量；自定义 accumulator 必须匹配对应行为，并返回完整 usage 状态。完整的
+reduce 心智模型、`model.Usage` 字段说明和示例见
+[自定义流式 Usage 聚合](../model.md#usage)。
 
 当 `Stream` 为 true 时，OpenAI-compatible adapter 会自动请求 usage。
 仍可通过检查服务方请求和原始响应确认最终 usage chunk 是否到达客户端，但重复

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -400,6 +400,33 @@ Telemetry 层也会拆分 token 类型。`internal/telemetry` 包会记录：
 - `input_cache_creation`
 - `output`
 
+#### 流式 Usage 排障
+
+在流式请求中，OpenAI-compatible 服务通常会在最后发送一个只包含 usage
+的 chunk。tRPC-Agent-Go 会消费该 chunk，并把累计结果放入最终
+`model.Response`。
+
+如果原始流中 `cached_tokens` 非零，但最终响应中变成零，应检查模型是否配置了
+`openai.WithAccumulateChunkTokenUsage`。该回调的返回值会整体替换累计后的
+`model.Usage`；如果只返回 `PromptTokens`、`CompletionTokens` 和
+`TotalTokens`，就会丢失 `PromptTokensDetails.CachedTokens`。
+
+大多数应用应使用默认聚合器。如果非标准服务方要求“最新 chunk 为准”，应直接
+返回完整的 delta，以保留所有 usage 字段：
+
+```go
+openai.WithAccumulateChunkTokenUsage(func(
+    _ model.Usage,
+    delta model.Usage,
+) model.Usage {
+    return delta
+})
+```
+
+当 `Stream` 为 true 时，OpenAI-compatible adapter 会自动请求 usage。
+仍可通过检查服务方请求和原始响应确认最终 usage chunk 是否到达客户端，但重复
+添加 `stream_options.include_usage` 无法恢复已经被自定义聚合器丢弃的明细。
+
 一个简单的统计口径是：
 
 ```text

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -413,7 +413,7 @@ Telemetry 层也会拆分 token 类型。`internal/telemetry` 包会记录：
 
 大多数应用应使用默认聚合器。非标准服务方可能返回增量、累计总量或最后一次完整
 总量；自定义 accumulator 必须匹配对应行为，并返回完整 usage 状态。完整的
-reduce 心智模型、`model.Usage` 字段说明和示例见
+回调执行顺序、`model.Usage` 字段说明和示例见
 [自定义流式 Usage 聚合](../model.md#usage)。
 
 当 `Stream` 为 true 时，OpenAI-compatible adapter 会自动请求 usage。

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -609,6 +609,11 @@ func(current model.Usage, delta model.Usage) model.Usage
 如果服务方以最新 usage chunk 为准，应直接返回完整的 `delta`：
 
 ```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
 llm := openai.New("your-model",
     openai.WithAccumulateChunkTokenUsage(func(
         _ model.Usage,

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -590,23 +590,98 @@ model := openai.New("deepseek-v4-flash",
 
 ##### 自定义流式 Usage 聚合
 
-OpenAI-compatible adapter 默认会开启流式 usage 收集，并聚合服务方返回的
-usage chunks。大多数应用应保留这一默认行为。
+OpenAI-compatible adapter 默认会请求流式 usage，并聚合服务方返回的
+usage chunks。大多数应用应保留这一行为。只有兼容服务方对 usage chunks
+采用了非标准语义时，才需要配置 `WithAccumulateChunkTokenUsage`。该 option
+只影响流式 chunks 的聚合；非流式 usage 直接来自完整响应。
 
-`WithAccumulateChunkTokenUsage` 只适合流式 usage 语义不标准的服务方，
-例如每个 chunk 都返回累计总量的服务。回调接收当前 chunk 之前已经累计的
-usage，以及当前 chunk 的 usage：
+###### 心智模型：把 Usage Chunks Reduce 成一个结果
+
+这个 option 的工作方式类似对 stream 执行 reduce 或 fold，与 Python 的
+`functools.reduce`、Java 的 `Stream.reduce` 是同一种心智模型。`current`
+是 accumulator，当前 chunk 是下一个元素，返回值会成为下一次调用的
+accumulator：
+
+```go
+state0 := model.Usage{}
+state1 := accumulate(state0, chunk1.Usage)
+state2 := accumulate(state1, chunk2.Usage)
+// ...
+finalResponse.Usage = accumulate(stateN, lastChunk.Usage)
+```
+
+回调签名是：
 
 ```go
 func(current model.Usage, delta model.Usage) model.Usage
 ```
 
-回调返回的 `model.Usage` 会整体替换累计结果。返回值中没有填写的字段，
-不会自动从 `current` 或 `delta` 补回，其中包括
-`PromptTokensDetails.CachedTokens`、
-`CompletionTokensDetails.ReasoningTokens` 等嵌套明细。
+| 参数 | 含义 |
+| --- | --- |
+| `current` | 处理当前 chunk 之前的累计状态 |
+| `delta` | 当前 chunk 携带的 `Usage` |
+| 返回值 | 处理当前 chunk 之后要保存的完整状态 |
 
-如果服务方以最新 usage chunk 为准，应直接返回完整的 `delta`：
+对于每个 chunk，OpenAI-compatible adapter 会先让上游 SDK 聚合这个 chunk。
+如果配置了自定义回调，adapter 随后会还原出处理该 chunk 之前的 usage 状态，
+把当前 chunk 的 usage 映射成 `delta`，调用回调，再用回调返回值整体替换 SDK
+accumulator 中的 usage。因此，下一个 chunk 看到的 `current` 就是上一次的
+返回值，最终模型响应拿到的是最后一次返回值。
+
+`delta` 只是 API 中的参数名，不代表服务方一定发送了数学意义上的增量。
+它可能是真正的增量、截至当前的累计总量、最后一次完整总量，也可能是空值，
+具体取决于服务方。
+
+回调返回值会整体替换累计后的 `model.Usage`。返回值中没有填写的字段，
+不会自动从 `current` 或 `delta` 补回。
+
+标准 OpenAI-compatible stream 通常在普通内容 chunks 中不携带 usage，
+最后再发送一个只包含完整 usage 的 chunk：
+
+```text
+chunk 1..N: delta = {0, 0, 0}
+最后的 chunk: delta = {prompt: 100, completion: 20, total: 120, cached: 80}
+最终 usage:           {prompt: 100, completion: 20, total: 120, cached: 80}
+```
+
+默认聚合器可以直接处理这种形态，不需要自定义 accumulator。
+
+###### `model.Usage` 字段说明
+
+Accumulator 保存的是一个完整的 `model.Usage`：
+
+| 字段 | 含义 |
+| --- | --- |
+| `PromptTokens` | 服务方上报的本次请求输入 token 总量。缓存命中的输入 token 通常已经包含在该值中，不应再次相加 |
+| `CompletionTokens` | 服务方上报的模型输出 token 总量 |
+| `TotalTokens` | 服务方上报的总 token，通常等于 prompt 加 completion |
+| `PromptTokensDetails.CachedTokens` | OpenAI-compatible Prompt Cache 命中的输入 token，通常是 `PromptTokens` 的子集 |
+| `PromptTokensDetails.CacheCreationTokens` | 用于创建显式缓存的 token，主要对应 Anthropic 风格缓存 |
+| `PromptTokensDetails.CacheReadTokens` | 从显式缓存中读取的 token，主要对应 Anthropic 风格缓存 |
+| `CompletionTokensDetails.ReasoningTokens` | Completion usage 中服务方上报的推理 token |
+| `TimingInfo` | 可选的框架耗时信息，不属于计费 token |
+| `TimingInfo.FirstTokenDuration` | 每次模型调用从请求开始到第一个有效 reasoning、content 或 tool-call chunk 的耗时，多个模型调用会累加 |
+| `TimingInfo.ReasoningDuration` | 流式 reasoning 阶段的累计耗时；非流式请求无法精确计算区间，因此保持为零 |
+
+这些字段组成 provider-agnostic 结构。
+`WithAccumulateChunkTokenUsage` 属于 OpenAI-compatible adapter，因此回调
+只会收到上游 OpenAI-compatible 响应和 adapter 映射支持的字段；其他服务方
+专用字段保持为零。
+
+`TimingInfo` 包含 `FirstTokenDuration` 和 `ReasoningDuration`。框架会在
+OpenAI chunk usage 聚合之外附加这些耗时，因此自定义 token accumulator
+通常不需要创建或合并 `TimingInfo`。
+
+Token 计数细节仍以具体服务方定义为准。例如，不应把 `CachedTokens` 再加到
+`PromptTokens` 上，也不应在服务方没有要求时自行重算 `TotalTokens`。
+
+###### 根据服务方选择聚合策略
+
+服务方遵循标准 OpenAI 流式 usage 行为时，使用默认聚合器。
+
+如果每个 stream chunk 都包含截至当前的累计总量，或者服务方保证最后会发送
+一个权威的完整 usage chunk，继续求和会造成重复计算。此时采用“最新 chunk
+为准”的语义，直接返回完整的 `delta`：
 
 ```go
 import (
@@ -624,10 +699,40 @@ llm := openai.New("your-model",
 )
 ```
 
-不要只重新构造顶层 token 计数，否则未填写的明细会被重置为零，可能出现
-服务方已经返回非零 `cached_tokens`，但最终
-`model.Response.Usage` 中仍为零的现象。如果服务方遵循标准 OpenAI 流式
-usage 语义，应删除该 option，使用默认聚合器。
+如果累计 usage 只出现在部分 chunks 中，遇到空 `delta` 时应保留 `current`，
+不要把状态清零；“空”的判断应覆盖该服务方可能上报的字段。
+
+如果每个 usage chunk 携带的确实只是增量，应累加 OpenAI-compatible chunk
+映射已经暴露的每个字段：
+
+```go
+import (
+    "trpc.group/trpc-go/trpc-agent-go/model"
+    "trpc.group/trpc-go/trpc-agent-go/model/openai"
+)
+
+func addUsage(current, delta model.Usage) model.Usage {
+    current.PromptTokens += delta.PromptTokens
+    current.CompletionTokens += delta.CompletionTokens
+    current.TotalTokens += delta.TotalTokens
+    current.PromptTokensDetails.CachedTokens +=
+        delta.PromptTokensDetails.CachedTokens
+    current.CompletionTokensDetails.ReasoningTokens +=
+        delta.CompletionTokensDetails.ReasoningTokens
+    return current
+}
+
+llm := openai.New("your-model",
+    openai.WithAccumulateChunkTokenUsage(addUsage),
+)
+```
+
+不要只重新构造 `PromptTokens`、`CompletionTokens` 和 `TotalTokens`，
+否则没有填写的嵌套明细会被重置为零，可能出现服务方已经返回非零
+`cached_tokens`，但最终 `model.Response.Usage` 中仍为零的现象。
+
+选择自定义策略前，应检查服务方一次完整请求的原始 chunks，确认 usage
+究竟是增量还是累计值，以及是否存在最后的 usage-only chunk。
 
 ##### 通过回调动态修改请求体
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -588,6 +588,42 @@ model := openai.New("deepseek-v4-flash",
 )
 ```
 
+##### 自定义流式 Usage 聚合
+
+OpenAI-compatible adapter 默认会开启流式 usage 收集，并聚合服务方返回的
+usage chunks。大多数应用应保留这一默认行为。
+
+`WithAccumulateChunkTokenUsage` 只适合流式 usage 语义不标准的服务方，
+例如每个 chunk 都返回累计总量的服务。回调接收当前 chunk 之前已经累计的
+usage，以及当前 chunk 的 usage：
+
+```go
+func(current model.Usage, delta model.Usage) model.Usage
+```
+
+回调返回的 `model.Usage` 会整体替换累计结果。返回值中没有填写的字段，
+不会自动从 `current` 或 `delta` 补回，其中包括
+`PromptTokensDetails.CachedTokens`、
+`CompletionTokensDetails.ReasoningTokens` 等嵌套明细。
+
+如果服务方以最新 usage chunk 为准，应直接返回完整的 `delta`：
+
+```go
+llm := openai.New("your-model",
+    openai.WithAccumulateChunkTokenUsage(func(
+        _ model.Usage,
+        delta model.Usage,
+    ) model.Usage {
+        return delta
+    }),
+)
+```
+
+不要只重新构造顶层 token 计数，否则未填写的明细会被重置为零，可能出现
+服务方已经返回非零 `cached_tokens`，但最终
+`model.Response.Usage` 中仍为零的现象。如果服务方遵循标准 OpenAI 流式
+usage 语义，应删除该 option，使用默认聚合器。
+
 ##### 通过回调动态修改请求体
 
 `WithChatRequestCallback` 接收 `*openai.ChatCompletionNewParams` 指针，

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -591,26 +591,13 @@ model := openai.New("deepseek-v4-flash",
 ##### 自定义流式 Usage 聚合
 
 OpenAI-compatible adapter 默认会请求流式 usage，并聚合服务方返回的
-usage chunks。大多数应用应保留这一行为。只有兼容服务方对 usage chunks
+usage chunk。大多数应用应保留这一行为。只有兼容服务方对 usage chunk
 采用了非标准语义时，才需要配置 `WithAccumulateChunkTokenUsage`。该 option
-只影响流式 chunks 的聚合；非流式 usage 直接来自完整响应。
+只影响流式 chunk 的聚合；非流式 usage 直接来自完整响应。
 
-###### 心智模型：把 Usage Chunks Reduce 成一个结果
+###### `WithAccumulateChunkTokenUsage` 的执行方式
 
-这个 option 的工作方式类似对 stream 执行 reduce 或 fold，与 Python 的
-`functools.reduce`、Java 的 `Stream.reduce` 是同一种心智模型。`current`
-是 accumulator，当前 chunk 是下一个元素，返回值会成为下一次调用的
-accumulator：
-
-```go
-state0 := model.Usage{}
-state1 := accumulate(state0, chunk1.Usage)
-state2 := accumulate(state1, chunk2.Usage)
-// ...
-finalResponse.Usage = accumulate(stateN, lastChunk.Usage)
-```
-
-回调签名是：
+配置后，回调会按顺序处理每个流式 chunk。回调签名是：
 
 ```go
 func(current model.Usage, delta model.Usage) model.Usage
@@ -635,13 +622,15 @@ accumulator 中的 usage。因此，下一个 chunk 看到的 `current` 就是�
 回调返回值会整体替换累计后的 `model.Usage`。返回值中没有填写的字段，
 不会自动从 `current` 或 `delta` 补回。
 
-标准 OpenAI-compatible stream 通常在普通内容 chunks 中不携带 usage，
-最后再发送一个只包含完整 usage 的 chunk：
+标准 OpenAI-compatible stream 的原始内容 chunk 中，`usage` 为 `null`。
+adapter 在调用回调前，会把这个空值映射为零值 `model.Usage`。最后的
+usage-only chunk 才包含完整总量：
 
 ```text
-chunk 1..N: delta = {0, 0, 0}
-最后的 chunk: delta = {prompt: 100, completion: 20, total: 120, cached: 80}
-最终 usage:           {prompt: 100, completion: 20, total: 120, cached: 80}
+原始内容 chunk:     usage = null
+回调收到的内容 chunk: delta = model.Usage{}
+原始最后一个 chunk:  usage = {prompt: 100, completion: 20, total: 120, cached: 80}
+回调收到的最后 chunk: delta = {prompt: 100, completion: 20, total: 120, cached: 80}
 ```
 
 默认聚合器可以直接处理这种形态，不需要自定义 accumulator。
@@ -677,33 +666,16 @@ Token 计数细节仍以具体服务方定义为准。例如，不应把 `Cached
 
 ###### 根据服务方选择聚合策略
 
-服务方遵循标准 OpenAI 流式 usage 行为时，使用默认聚合器。
+先根据服务方的响应格式选择配置：
 
-如果每个 stream chunk 都包含截至当前的累计总量，或者服务方保证最后会发送
-一个权威的完整 usage chunk，继续求和会造成重复计算。此时采用“最新 chunk
-为准”的语义，直接返回完整的 `delta`：
+| 服务方响应格式 | 直接累加会重复计数吗 | 推荐配置 |
+| --- | --- | --- |
+| 最后的 usage-only chunk 包含完整总量 | 不会，之前的 chunk 不携带 usage | 使用默认聚合器 |
+| 每个 usage chunk 都是独立增量 | 不会 | 使用默认聚合器 |
+| usage chunk 是累计快照，或重复上报已经出现的字段 | 会 | 自定义“最新非零值”聚合器 |
 
-```go
-import (
-    "trpc.group/trpc-go/trpc-agent-go/model"
-    "trpc.group/trpc-go/trpc-agent-go/model/openai"
-)
-
-llm := openai.New("your-model",
-    openai.WithAccumulateChunkTokenUsage(func(
-        _ model.Usage,
-        delta model.Usage,
-    ) model.Usage {
-        return delta
-    }),
-)
-```
-
-如果累计 usage 只出现在部分 chunks 中，遇到空 `delta` 时应保留 `current`，
-不要把状态清零；“空”的判断应覆盖该服务方可能上报的字段。
-
-如果每个 usage chunk 携带的确实只是增量，应累加 OpenAI-compatible chunk
-映射已经暴露的每个字段：
+对于累计快照或重复字段，保留最新的非零 usage。空 chunk 必须保留
+`current`，否则最后一次有效 usage 后的空 chunk 可能把结果清零。
 
 ```go
 import (
@@ -711,27 +683,28 @@ import (
     "trpc.group/trpc-go/trpc-agent-go/model/openai"
 )
 
-func addUsage(current, delta model.Usage) model.Usage {
-    current.PromptTokens += delta.PromptTokens
-    current.CompletionTokens += delta.CompletionTokens
-    current.TotalTokens += delta.TotalTokens
-    current.PromptTokensDetails.CachedTokens +=
-        delta.PromptTokensDetails.CachedTokens
-    current.CompletionTokensDetails.ReasoningTokens +=
-        delta.CompletionTokensDetails.ReasoningTokens
-    return current
+func latestNonZeroUsage(current, delta model.Usage) model.Usage {
+    if delta.PromptTokens == 0 &&
+        delta.CompletionTokens == 0 &&
+        delta.TotalTokens == 0 &&
+        delta.PromptTokensDetails.CachedTokens == 0 &&
+        delta.PromptTokensDetails.CacheCreationTokens == 0 &&
+        delta.PromptTokensDetails.CacheReadTokens == 0 &&
+        delta.CompletionTokensDetails.ReasoningTokens == 0 {
+        return current
+    }
+    return delta
 }
 
 llm := openai.New("your-model",
-    openai.WithAccumulateChunkTokenUsage(addUsage),
+    openai.WithAccumulateChunkTokenUsage(latestNonZeroUsage),
 )
 ```
 
-不要只重新构造 `PromptTokens`、`CompletionTokens` 和 `TotalTokens`，
-否则没有填写的嵌套明细会被重置为零，可能出现服务方已经返回非零
-`cached_tokens`，但最终 `model.Response.Usage` 中仍为零的现象。
+返回完整 `delta` 可以保留 `CachedTokens`、`ReasoningTokens` 等嵌套明细；
+“空”的判断应覆盖服务方可能上报的每个字段。
 
-选择自定义策略前，应检查服务方一次完整请求的原始 chunks，确认 usage
+选择自定义策略前，应检查服务方一次完整请求的原始 chunk，确认 usage
 究竟是增量还是累计值，以及是否存在最后的 usage-only chunk。
 
 ##### 通过回调动态修改请求体


### PR DESCRIPTION
## What changed

- Explain the per-chunk execution order and full-value replacement contract of WithAccumulateChunkTokenUsage in the English and Chinese Model guides.
- Document every model.Usage token-detail and timing field, including provider-specific mapping limits and accounting cautions.
- Add a response-format decision table: standard final totals and independent increments use the default accumulator; cumulative snapshots or repeated fields use latest-nonzero handling.
- Distinguish raw usage: null values from the zero-value model.Usage passed to callbacks.
- Add bilingual Prompt Cache troubleshooting for cases where raw streaming responses contain cached_tokens but the final usage reports zero.

## Why

A custom streaming usage accumulator can accidentally rebuild only the top-level token counts and discard nested fields such as PromptTokensDetails.CachedTokens. The existing documentation did not clearly separate provider response formats or show how the callback return value becomes the complete state for the next chunk.

## Testing

- git diff --check
- uv run --with-requirements docs/mkdocs/assets/requirements.txt mkdocs build --strict -f docs/mkdocs.yml

## Notes for reviewers

This is a documentation-only change and does not modify API behavior.