### PR TITLE
memory/inmemory: fix extractor test race

### DIFF
--- a/memory/inmemory/service_test.go
+++ b/memory/inmemory/service_test.go
@@ -850,6 +850,7 @@ func TestSearchMemories_NilUser(t *testing.T) {
 
 // mockExtractor is a mock implementation of extractor.MemoryExtractor.
 type mockExtractor struct {
+	mu            sync.RWMutex
 	extractCalled bool
 }
 
@@ -858,8 +859,16 @@ func (m *mockExtractor) Extract(
 	messages []model.Message,
 	existing []*memory.Entry,
 ) ([]*extractor.Operation, error) {
+	m.mu.Lock()
 	m.extractCalled = true
+	m.mu.Unlock()
 	return nil, nil
+}
+
+func (m *mockExtractor) wasExtractCalled() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.extractCalled
 }
 
 func (m *mockExtractor) ShouldExtract(ctx *extractor.ExtractionContext) bool {
@@ -963,9 +972,13 @@ func TestEnqueueAutoMemoryJob_WithExtractor(t *testing.T) {
 	err := service.EnqueueAutoMemoryJob(ctx, sess)
 	assert.NoError(t, err)
 
-	// Wait for async processing.
-	time.Sleep(50 * time.Millisecond)
-	assert.True(t, ext.extractCalled)
+	require.Eventually(
+		t,
+		ext.wasExtractCalled,
+		time.Second,
+		time.Millisecond,
+		"extractor was not called",
+	)
 }
 
 func TestEnqueueAutoMemoryJob_DisableOnExternalContext(t *testing.T) {
@@ -991,7 +1004,7 @@ func TestEnqueueAutoMemoryJob_DisableOnExternalContext(t *testing.T) {
 	err := service.EnqueueAutoMemoryJob(ctx, sess)
 	require.NoError(t, err)
 
-	assert.False(t, ext.extractCalled)
+	assert.False(t, ext.wasExtractCalled())
 }
 
 func TestClose(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix a data race in the in-memory memory service auto-extraction test.

The mock extractor state was written by the background auto-memory worker while
the test goroutine read the same state without synchronization. The existing
fixed sleep did not establish a happens-before relationship.

The change synchronizes access to the mock state and replaces the fixed sleep
with a bounded condition-based wait.

## Reproduction

On the current main branch, `TestEnqueueAutoMemoryJob_WithExtractor` reports a
data race under:

```bash
go test -race ./memory/inmemory \
  -run TestEnqueueAutoMemoryJob_WithExtractor -count=1
```

The race detector identifies an unsynchronized read by the test goroutine and
write by the background auto-memory worker.

## Testing

- Targeted race test before the fix: fails with a race.
- Targeted race test after the fix, 30 repetitions: passes.
- `go test ./memory/inmemory -count=1`: passes.
- `go test -race ./memory/inmemory -count=1`: passes.
- `go vet ./memory/inmemory`: passes.

## Scope

- Test-only change.
- No public API changes.
- No production behavior changes.
- No dependency changes.

## Notes for reviewers

The synchronization is limited to the test mock state. The production worker,
public contracts, dependencies, and runtime behavior are unchanged.
