### PR TITLE
knowledge: support token-aware chunk sizing

### DIFF
--- a/docs/mkdocs/en/knowledge/source.md
+++ b/docs/mkdocs/en/knowledge/source.md
@@ -207,9 +207,9 @@ registry.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| ChunkSize | 1024 | Maximum Unicode runes for FixedSizeChunking, RecursiveChunking, and MarkdownChunking |
+| ChunkSize | 1024 | Maximum Unicode runes for FixedSizeChunking, RecursiveChunking, and MarkdownChunking; uses the configured length function's unit when one is set |
 | JSON ChunkSize | 2000 | Maximum serialized bytes for JSONChunking |
-| Overlap | 0 | Maximum overlapping Unicode runes between adjacent chunks |
+| Overlap | 0 | Maximum overlapping Unicode runes between adjacent chunks; uses the configured length function's unit when one is set |
 
 > `overlap` only applies to FixedSizeChunking, RecursiveChunking, and MarkdownChunking. It is a maximum: the strategy may move the overlap start to a natural boundary or reduce it so the final chunk remains within `chunkSize`. A large overlap leaves less room for new content and produces more chunks. JSONChunking does not support overlap.
 
@@ -246,11 +246,42 @@ fileSrc := filesource.New(
 )
 ```
 
+### Token-based Chunk Budgets
+
+FixedSizeChunking, RecursiveChunking, and MarkdownChunking can use a custom length function instead of counting Unicode runes. Configure it on a Source to keep the Reader's format-specific default strategy. For example, Markdown files still use MarkdownChunking and retain their heading paths:
+
+```go
+import (
+    tiktoken "trpc.group/trpc-go/trpc-agent-go/model/tiktoken"
+    filesource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/file"
+)
+
+counter, err := tiktoken.New("text-embedding-3-small")
+if err != nil {
+    return err
+}
+
+fileSrc := filesource.New(
+    []string{"./data/document.md"},
+    filesource.WithChunkSize(512),             // Maximum tokens
+    filesource.WithChunkOverlap(64),           // Maximum overlap tokens
+    filesource.WithChunkLengthFunc(counter.CountText),
+)
+```
+
+`WithChunkLengthFunc` is also available on DirSource, URLSource, AutoSource, and Reader. The text strategies measure each complete candidate, including separators and overlap, so each chunker's output `Document.Content` stays within the configured budget. The length function may be called repeatedly and concurrently; it should be local, deterministic, concurrency-safe, side-effect-free, and return a non-negative value that broadly grows with the input text. Local non-monotonic behavior from BPE tokenizers is supported, but arbitrary functions that do not behave like a text-length measurement are not. Errors are returned from `Chunk`.
+
+Choose a tokenizer that matches the embedding model and reserve margin for later processing. A Reader postprocessor can modify `Document.Content`, and the knowledge service can add file, chunk, and section metadata when it builds `EmbeddingText`; those later additions are outside the chunking budget.
+
+`MetaChunkSize` and `MetaOverlappedContentSize` remain Unicode-rune counts for backward compatibility; they do not change to token counts.
+
+This option affects the built-in FixedSizeChunking and MarkdownChunking selected by Readers. JSONChunking continues to use serialized bytes, and AST-based code Readers keep their structural chunking behavior. A custom strategy overrides the Source's size, overlap, and length-function options; configure its length function directly with `WithLengthFunc`, `WithRecursiveLengthFunc`, or `WithMarkdownLengthFunc`.
+
 ### Custom Chunking Strategy
 
 Use `WithCustomChunkingStrategy` to override the default chunking strategy.
 
-> **Note**: Custom chunking strategy completely overrides `WithChunkSize` and `WithChunkOverlap` configurations. Chunking parameters must be set within the custom strategy.
+> **Note**: Custom chunking strategy completely overrides `WithChunkSize`, `WithChunkOverlap`, and `WithChunkLengthFunc`. Chunking parameters must be set within the custom strategy.
 
 #### FixedSizeChunking - Fixed Size Chunking
 

--- a/docs/mkdocs/zh/knowledge/source.md
+++ b/docs/mkdocs/zh/knowledge/source.md
@@ -246,9 +246,9 @@ Reader，让它注册到 Reader registry。
 
 | 参数 | 默认值 | 说明 |
 |-----|-------|------|
-| ChunkSize | 1024 | FixedSizeChunking、RecursiveChunking、MarkdownChunking 的最大 Unicode rune 数 |
+| ChunkSize | 1024 | FixedSizeChunking、RecursiveChunking、MarkdownChunking 的最大 Unicode rune 数；配置长度函数后使用该函数的计量单位 |
 | JSON ChunkSize | 2000 | JSONChunking 序列化后的最大字节数 |
-| Overlap | 0 | 相邻分块之间的最大 Unicode rune 数 |
+| Overlap | 0 | 相邻分块之间的最大 Unicode rune 数；配置长度函数后使用该函数的计量单位 |
 
 > `overlap` 仅对 FixedSizeChunking、RecursiveChunking、MarkdownChunking 生效。它表示上限：策略可以把 overlap 起点移动到自然边界，也可以缩小实际 overlap，以保证最终分块不超过 `chunkSize`。较大的 overlap 会压缩新正文的空间，因此产生更多 chunk。JSONChunking 不支持 overlap。
 
@@ -281,11 +281,42 @@ fileSrc := filesource.New(
 )
 ```
 
+### 按 Token 限制分块预算
+
+FixedSizeChunking、RecursiveChunking 和 MarkdownChunking 支持使用自定义长度函数代替 Unicode rune 计数。推荐在 Source 上配置，这样 Reader 仍会根据文档格式选择默认策略。例如 Markdown 文件仍使用 MarkdownChunking，并保留标题路径：
+
+```go
+import (
+    tiktoken "trpc.group/trpc-go/trpc-agent-go/model/tiktoken"
+    filesource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/file"
+)
+
+counter, err := tiktoken.New("text-embedding-3-small")
+if err != nil {
+    return err
+}
+
+fileSrc := filesource.New(
+    []string{"./data/document.md"},
+    filesource.WithChunkSize(512),             // 最大 token 数
+    filesource.WithChunkOverlap(64),           // 最大重叠 token 数
+    filesource.WithChunkLengthFunc(counter.CountText),
+)
+```
+
+DirSource、URLSource、AutoSource 和 Reader 也提供 `WithChunkLengthFunc`。文本策略会对包含分隔符和 overlap 的完整候选内容重新计数，确保 chunker 输出的每个 `Document.Content` 不超过预算。长度函数可能被重复、并发调用，因此应在本地执行、结果确定、并发安全、无副作用，并返回随输入文本整体增长的非负值。实现支持 BPE tokenizer 局部不单调的情况，但不适用于不具备文本长度计量语义的任意函数；函数返回的错误会由 `Chunk` 向上传递。
+
+应选择与 embedding 模型匹配的 tokenizer，并为后续处理预留余量。Reader postprocessor 可以继续修改 `Document.Content`，knowledge service 构造 `EmbeddingText` 时也可能添加 file、chunk、section metadata；这些后续内容不属于 chunking 预算的保证范围。
+
+为保持向后兼容，`MetaChunkSize` 和 `MetaOverlappedContentSize` 仍记录 Unicode rune 数，不会切换为 token 数。
+
+这个 option 会作用于 Reader 默认选择的 FixedSizeChunking 和 MarkdownChunking。JSONChunking 仍按序列化字节数限制，基于 AST 的代码 Reader 也保持原有结构化分块语义。自定义策略会覆盖 Source 的 size、overlap 和长度函数配置；需要分别使用 `WithLengthFunc`、`WithRecursiveLengthFunc` 或 `WithMarkdownLengthFunc` 在策略内部配置。
+
 ### 自定义分块策略
 
 使用 `WithCustomChunkingStrategy` 可覆盖默认分块策略。
 
-> **注意**：自定义分块策略会完全覆盖 `WithChunkSize` 和 `WithChunkOverlap` 的配置，分块参数需在自定义策略内部设置。
+> **注意**：自定义分块策略会完全覆盖 `WithChunkSize`、`WithChunkOverlap` 和 `WithChunkLengthFunc` 的配置，分块参数需在自定义策略内部设置。
 
 #### FixedSizeChunking - 固定大小分块
 

--- a/examples/knowledge/README.md
+++ b/examples/knowledge/README.md
@@ -38,6 +38,7 @@ Different data source types:
 | directory-source/ | Recursively load entire directory |
 | url-source/ | Fetch and parse web pages |
 | auto-source/ | Auto-detect source type from path |
+| token-aware-chunking/ | Keep Markdown chunk content within a tokenizer-based budget |
 
 ### vectorstores/
 Persistent vector storage options:

--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -15,6 +15,7 @@ replace (
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector => ../../knowledge/vectorstore/pgvector
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec => ../../knowledge/vectorstore/sqlitevec
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector => ../../knowledge/vectorstore/tcvector
+	trpc.group/trpc-go/trpc-agent-go/model/tiktoken => ../../model/tiktoken
 	trpc.group/trpc-go/trpc-agent-go/storage/elasticsearch => ../../storage/elasticsearch
 	trpc.group/trpc-go/trpc-agent-go/storage/milvus => ../../storage/milvus
 	trpc.group/trpc-go/trpc-agent-go/storage/postgres => ../../storage/postgres
@@ -35,6 +36,7 @@ require (
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/pgvector v0.2.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/sqlitevec v1.9.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/tcvector v0.2.0
+	trpc.group/trpc-go/trpc-agent-go/model/tiktoken v0.0.0
 	trpc.group/trpc-go/trpc-agent-go/storage/postgres v1.9.0
 	trpc.group/trpc-go/trpc-mcp-go v0.0.10
 )
@@ -60,6 +62,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.7.0 // indirect
@@ -146,6 +149,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tiktoken-go/tokenizer v0.7.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect

--- a/examples/knowledge/go.sum
+++ b/examples/knowledge/go.sum
@@ -109,6 +109,8 @@ github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6ps
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -606,6 +608,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/tiktoken-go/tokenizer v0.7.0 h1:VMu6MPT0bXFDHr7UPh9uii7CNItVt3X9K90omxL54vw=
+github.com/tiktoken-go/tokenizer v0.7.0/go.mod h1:6UCYI/DtOallbmL7sSy30p6YQv60qNyU/4aVigPOx6w=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/examples/knowledge/sources/token-aware-chunking/README.md
+++ b/examples/knowledge/sources/token-aware-chunking/README.md
@@ -1,0 +1,22 @@
+# Token-Aware Chunking Example
+
+This offline example configures a tokenizer directly on `FileSource`. `MarkdownReader` still selects `MarkdownChunking`, so Markdown headings and header-path metadata are preserved while `chunkSize` and `overlap` are measured in tokens.
+
+## Run
+
+From `examples/knowledge`:
+
+```bash
+go run ./sources/token-aware-chunking
+```
+
+No model, embedding service, vector store, or API credentials are required.
+
+The example uses:
+
+- `tiktoken.New("text-embedding-3-small")` to create a token counter matching an embedding model
+- `file.WithChunkLengthFunc(counter.CountText)` to select token units
+- a 48-token chunk content budget and an 8-token maximum overlap
+- a bundled Markdown document containing nested headings and mixed English and Chinese text
+
+The output reports the original document size and each chunk's token count, rune count, Markdown header path, and content. The budget applies to the chunker's output `Document.Content`; later postprocessing or embedding metadata may add content, so production configurations should reserve margin.

--- a/examples/knowledge/sources/token-aware-chunking/main.go
+++ b/examples/knowledge/sources/token-aware-chunking/main.go
@@ -1,0 +1,102 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package main demonstrates token-aware Markdown chunking through FileSource.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"unicode/utf8"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
+	filesource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/file"
+	tiktoken "trpc.group/trpc-go/trpc-agent-go/model/tiktoken"
+)
+
+const (
+	modelName    = "text-embedding-3-small"
+	chunkSize    = 48
+	chunkOverlap = 8
+)
+
+func main() {
+	counter, err := tiktoken.New(modelName)
+	if err != nil {
+		log.Fatalf("Create tokenizer: %v", err)
+	}
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("Locate example directory")
+	}
+	filePath := filepath.Join(filepath.Dir(currentFile), "sample.md")
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Fatalf("Read sample: %v", err)
+	}
+	sourceTokens, err := counter.CountText(string(content))
+	if err != nil {
+		log.Fatalf("Count source tokens: %v", err)
+	}
+
+	fileSource := filesource.New(
+		[]string{filePath},
+		filesource.WithChunkSize(chunkSize),
+		filesource.WithChunkOverlap(chunkOverlap),
+		filesource.WithChunkLengthFunc(counter.CountText),
+	)
+	chunks, err := fileSource.ReadDocuments(context.Background())
+	if err != nil {
+		log.Fatalf("Chunk sample: %v", err)
+	}
+
+	fmt.Printf("Tokenizer: %s\n", modelName)
+	fmt.Printf(
+		"Source: %d tokens, %d runes\n",
+		sourceTokens,
+		utf8.RuneCount(content),
+	)
+	fmt.Printf(
+		"Budget: %d tokens, overlap: at most %d tokens\n",
+		chunkSize,
+		chunkOverlap,
+	)
+	fmt.Printf("Chunks: %d\n", len(chunks))
+
+	for i, chunk := range chunks {
+		tokens, err := counter.CountText(chunk.Content)
+		if err != nil {
+			log.Fatalf("Count chunk %d tokens: %v", i+1, err)
+		}
+		if tokens > chunkSize {
+			log.Fatalf(
+				"Chunk %d uses %d tokens, exceeding budget %d",
+				i+1,
+				tokens,
+				chunkSize,
+			)
+		}
+		headerPath, _ :=
+			chunk.Metadata[source.MetaMarkdownHeaderPath].(string)
+		fmt.Printf(
+			"\n--- Chunk %d: %d tokens, %d runes, header=%q ---\n%s\n",
+			i+1,
+			tokens,
+			utf8.RuneCountInString(chunk.Content),
+			headerPath,
+			chunk.Content,
+		)
+	}
+}

--- a/examples/knowledge/sources/token-aware-chunking/sample.md
+++ b/examples/knowledge/sources/token-aware-chunking/sample.md
@@ -1,0 +1,15 @@
+# Token-Aware Knowledge
+
+Token-aware chunking keeps each emitted chunk's content within a tokenizer budget instead of approximating its size with bytes or runes.
+
+## Markdown Structure
+
+The source still selects MarkdownChunking. Heading paths remain available as metadata, and the strategy continues to prefer Markdown and natural text boundaries.
+
+### Mixed Characters
+
+English words and 中文字符 consume different numbers of tokens. Emoji such as 🚀 can also span multiple tokens, so rune counts alone cannot predict the chunk's token size precisely.
+
+## Overlap
+
+The configured overlap is included in the chunk content budget. Each emitted chunk is recounted after its overlap and separator are attached.

--- a/knowledge/chunking/chunking.go
+++ b/knowledge/chunking/chunking.go
@@ -11,6 +11,7 @@
 package chunking
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,26 @@ func validateChunkConfig(chunkSize, overlap int) error {
 	default:
 		return nil
 	}
+}
+
+func measureTextLength(
+	lengthFunc func(string) (int, error),
+	content string,
+) (int, error) {
+	if lengthFunc == nil {
+		return encoding.RuneCount(content), nil
+	}
+	length, err := lengthFunc(content)
+	if err != nil {
+		return 0, fmt.Errorf("measure text length: %w", err)
+	}
+	if length < 0 {
+		return 0, fmt.Errorf(
+			"measure text length: length function returned negative length %d",
+			length,
+		)
+	}
+	return length, nil
 }
 
 // cleanText normalizes whitespace in text content while ensuring UTF-8 safety.
@@ -171,6 +192,148 @@ func joinWithOverlapSeparator(
 	return overlapContent + separator + current, actualOverlap
 }
 
+func joinWithOverlapSeparatorByLength(
+	previous string,
+	current string,
+	maxOverlap int,
+	maxSize int,
+	separator string,
+	preserveSeparator bool,
+	lengthFunc func(string) (int, error),
+) (string, int, error) {
+	currentSize, err := measureTextLength(lengthFunc, current)
+	if err != nil {
+		return "", 0, err
+	}
+	if currentSize > maxSize {
+		return "", 0, fmt.Errorf(
+			"current content length %d exceeds chunk size %d",
+			currentSize,
+			maxSize,
+		)
+	}
+	if maxOverlap <= 0 || previous == "" {
+		return current, 0, nil
+	}
+
+	previousRunes := []rune(previous)
+	previousSize, err := measureTextLength(lengthFunc, previous)
+	if err != nil {
+		return "", 0, err
+	}
+	estimatedRunes := len(previousRunes)
+	if previousSize > maxOverlap {
+		estimatedRunes = max(
+			1,
+			len(previousRunes)*maxOverlap/previousSize,
+		)
+	}
+	estimatedStart := len(previousRunes) - estimatedRunes
+	starts := lengthBoundaryCandidates(previousRunes, estimatedStart)
+	if estimatedStart <= 0 {
+		starts = append([]int{0}, starts...)
+	}
+
+	bestContent := ""
+	bestSize := 0
+	bestRunes := 0
+	bestNatural := false
+	for _, start := range starts {
+		combined, overlapSize, runeSize, natural, ok, err :=
+			evaluateOverlapCandidateByLength(
+				previousRunes,
+				current,
+				start,
+				maxOverlap,
+				maxSize,
+				separator,
+				preserveSeparator,
+				lengthFunc,
+			)
+		if err != nil {
+			return "", 0, err
+		}
+		if !ok {
+			continue
+		}
+		if betterOverlapCandidate(
+			natural,
+			bestNatural,
+			overlapSize,
+			bestSize,
+			runeSize,
+			bestRunes,
+		) {
+			bestContent = combined
+			bestSize = overlapSize
+			bestRunes = runeSize
+			bestNatural = natural
+		}
+	}
+
+	if bestContent != "" {
+		return bestContent, bestSize, nil
+	}
+	return current, 0, nil
+}
+
+func evaluateOverlapCandidateByLength(
+	previous []rune,
+	current string,
+	start int,
+	maxOverlap int,
+	maxSize int,
+	separator string,
+	preserveSeparator bool,
+	lengthFunc func(string) (int, error),
+) (string, int, int, bool, bool, error) {
+	overlapContent := strings.TrimLeftFunc(
+		string(previous[start:]),
+		unicode.IsSpace,
+	)
+	if overlapContent == "" {
+		return "", 0, 0, false, false, nil
+	}
+	overlapSize, err := measureTextLength(lengthFunc, overlapContent)
+	if err != nil {
+		return "", 0, 0, false, false, err
+	}
+	if overlapSize <= 0 || overlapSize > maxOverlap {
+		return "", 0, 0, false, false, nil
+	}
+
+	natural := isNaturalTextStart(previous, start)
+	if !natural && !preserveSeparator {
+		separator = ""
+	}
+	combined := overlapContent + separator + current
+	combinedSize, err := measureTextLength(lengthFunc, combined)
+	if err != nil {
+		return "", 0, 0, false, false, err
+	}
+	if combinedSize > maxSize {
+		return "", 0, 0, false, false, nil
+	}
+	return combined, overlapSize, len([]rune(overlapContent)), natural, true, nil
+}
+
+func betterOverlapCandidate(
+	natural bool,
+	bestNatural bool,
+	size int,
+	bestSize int,
+	runes int,
+	bestRunes int,
+) bool {
+	if natural != bestNatural {
+		return natural
+	}
+	if size != bestSize {
+		return size > bestSize
+	}
+	return runes > bestRunes
+}
+
 func sourceChunkSeparators(
 	content string,
 	chunks []string,
@@ -231,6 +394,232 @@ func splitTextAtNaturalBoundary(content string, maxSize int) (string, string) {
 	prefix := strings.TrimSpace(string(contentRunes[:splitPosition]))
 	remaining := strings.TrimSpace(string(contentRunes[splitPosition:]))
 	return prefix, remaining
+}
+
+func splitTextAtNaturalBoundaryByLength(
+	content string,
+	maxSize int,
+	lengthFunc func(string) (int, error),
+) (string, string, error) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return "", "", nil
+	}
+	if maxSize <= 0 {
+		return "", content, nil
+	}
+	contentRunes := []rune(content)
+	estimate, searchEnd, fits, err := estimateTextSplitByLength(
+		contentRunes,
+		maxSize,
+		lengthFunc,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	if fits {
+		return content, "", nil
+	}
+	candidateContent := contentRunes[:searchEnd+1]
+	candidates := lengthBoundaryCandidates(candidateContent, estimate)
+	best, err := findTextSplitPositionByLength(
+		contentRunes,
+		candidates,
+		maxSize,
+		lengthFunc,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	if best == 0 {
+		first := string(contentRunes[:1])
+		firstSize, err := measureTextLength(lengthFunc, first)
+		if err != nil {
+			return "", "", err
+		}
+		return "", "", fmt.Errorf(
+			"indivisible rune %q has length %d, exceeds chunk size %d",
+			first,
+			firstSize,
+			maxSize,
+		)
+	}
+
+	prefix := strings.TrimSpace(string(contentRunes[:best]))
+	prefixSize, err := measureTextLength(lengthFunc, prefix)
+	if err != nil {
+		return "", "", err
+	}
+	if prefix == "" || prefixSize > maxSize {
+		return "", "", fmt.Errorf(
+			"unable to split text within chunk size %d",
+			maxSize,
+		)
+	}
+	remaining := strings.TrimSpace(string(contentRunes[best:]))
+	return prefix, remaining, nil
+}
+
+func estimateTextSplitByLength(
+	content []rune,
+	maxSize int,
+	lengthFunc func(string) (int, error),
+) (int, int, bool, error) {
+	position := min(len(content), max(1, maxSize))
+	for {
+		prefix := strings.TrimSpace(string(content[:position]))
+		prefixSize, err := measureTextLength(lengthFunc, prefix)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if prefixSize > maxSize {
+			estimate := position
+			if prefixSize > 0 {
+				estimate = max(1, position*maxSize/prefixSize)
+			}
+			searchEnd := min(len(content)-1, position+32)
+			return estimate, searchEnd, false, nil
+		}
+		if position == len(content) {
+			return position, position - 1, true, nil
+		}
+		position = min(len(content), position*2)
+	}
+}
+
+func findTextSplitPositionByLength(
+	content []rune,
+	candidates []int,
+	maxSize int,
+	lengthFunc func(string) (int, error),
+) (int, error) {
+	bestHardPosition := 0
+	bestNaturalPosition := 0
+	bestNaturalTier := 0
+	minimumNaturalSize := max(1, maxSize/2)
+	for _, position := range candidates {
+		prefix := strings.TrimSpace(string(content[:position]))
+		if prefix == "" {
+			continue
+		}
+		prefixSize, err := measureTextLength(lengthFunc, prefix)
+		if err != nil {
+			return 0, err
+		}
+		if prefixSize <= 0 || prefixSize > maxSize {
+			continue
+		}
+		if position > bestHardPosition {
+			bestHardPosition = position
+		}
+		tier := textBoundaryTier(content, position)
+		if tier > 0 && prefixSize >= minimumNaturalSize &&
+			(tier > bestNaturalTier ||
+				(tier == bestNaturalTier &&
+					position > bestNaturalPosition)) {
+			bestNaturalTier = tier
+			bestNaturalPosition = position
+		}
+	}
+
+	best := bestNaturalPosition
+	if best == 0 {
+		best = bestHardPosition
+	}
+	return best, nil
+}
+
+// lengthBoundaryCandidates returns a bounded set of rune positions around an
+// estimated split. Length functions such as BPE tokenizers are not guaranteed
+// to be monotonic for every prefix, so callers measure every returned complete
+// candidate instead of relying on binary search.
+func lengthBoundaryCandidates(content []rune, estimate int) []int {
+	if len(content) <= 1 {
+		return nil
+	}
+	estimate = max(1, min(estimate, len(content)-1))
+	seen := make(map[int]struct{})
+	candidates := make([]int, 0, 64)
+	add := func(position int) {
+		position = max(1, min(position, len(content)-1))
+		position = safeTextSplitPosition(content, position)
+		if _, ok := seen[position]; ok {
+			return
+		}
+		seen[position] = struct{}{}
+		candidates = append(candidates, position)
+	}
+
+	add(estimate)
+	add(1)
+	add(len(content) - 1)
+	for _, offset := range []int{1, 2, 4, 8, 16, 32} {
+		add(estimate - offset)
+		add(estimate + offset)
+	}
+	for position := estimate; position > 1; {
+		next := max(1, position/2)
+		add(next)
+		if next == position {
+			break
+		}
+		position = next
+	}
+	for position := estimate; position < len(content)-1; {
+		next := position + max(1, (len(content)-position)/2)
+		add(next)
+		if next == position || next >= len(content)-1 {
+			break
+		}
+		position = next
+	}
+
+	var before [5][]int
+	var after [5][]int
+	for position := 1; position < len(content); position++ {
+		tier := textBoundaryTier(content, position)
+		if tier == 0 {
+			continue
+		}
+		if position <= estimate {
+			before[tier] = append(before[tier], position)
+			if len(before[tier]) > 4 {
+				before[tier] = before[tier][1:]
+			}
+			continue
+		}
+		if len(after[tier]) < 4 {
+			after[tier] = append(after[tier], position)
+		}
+	}
+	for tier := 4; tier >= 1; tier-- {
+		for _, position := range before[tier] {
+			add(position)
+		}
+		for _, position := range after[tier] {
+			add(position)
+		}
+	}
+	return candidates
+}
+
+func textBoundaryTier(content []rune, position int) int {
+	if position <= 0 || position >= len(content) {
+		return 0
+	}
+	previous := content[position-1]
+	switch {
+	case previous == '\n':
+		return 4
+	case isSentenceBoundary(content, position-1):
+		return 3
+	case strings.ContainsRune(",，;；:：、", previous):
+		return 2
+	case unicode.IsSpace(previous):
+		return 1
+	default:
+		return 0
+	}
 }
 
 // splitTextWithBalancedTail avoids leaving a very small final piece when one
@@ -301,6 +690,109 @@ func splitTextWithBalancedTail(
 		return hardPrefix, hardRemaining
 	}
 	return prefix, remaining
+}
+
+func splitTextWithBalancedTailByLength(
+	content string,
+	maxSize int,
+	lengthFunc func(string) (int, error),
+) (string, string, error) {
+	prefix, remaining, err := splitTextAtNaturalBoundaryByLength(
+		content,
+		maxSize,
+		lengthFunc,
+	)
+	if err != nil || remaining == "" || maxSize <= 1 {
+		return prefix, remaining, err
+	}
+
+	largeEnough, err := textLengthAtLeastByLength(
+		remaining,
+		max(1, maxSize/2),
+		lengthFunc,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	if largeEnough {
+		return prefix, remaining, nil
+	}
+
+	contentRunes := []rune(strings.TrimSpace(content))
+	candidates := lengthBoundaryCandidates(contentRunes, len(contentRunes)/2)
+	minimumNaturalSize := max(1, maxSize*2/5)
+	bestPosition := 0
+	bestTier := -1
+	bestDifference := int(^uint(0) >> 1)
+	for _, position := range candidates {
+		candidatePrefix := strings.TrimSpace(
+			string(contentRunes[:position]),
+		)
+		candidateRemaining := strings.TrimSpace(
+			string(contentRunes[position:]),
+		)
+		if candidatePrefix == "" || candidateRemaining == "" {
+			continue
+		}
+		prefixSize, err := measureTextLength(
+			lengthFunc,
+			candidatePrefix,
+		)
+		if err != nil {
+			return "", "", err
+		}
+		remainingSize, err := measureTextLength(
+			lengthFunc,
+			candidateRemaining,
+		)
+		if err != nil {
+			return "", "", err
+		}
+		if prefixSize > maxSize ||
+			prefixSize < minimumNaturalSize ||
+			remainingSize < minimumNaturalSize {
+			continue
+		}
+		tier := textBoundaryTier(contentRunes, position)
+		difference := absInt(prefixSize - remainingSize)
+		if tier > bestTier ||
+			(tier == bestTier && difference < bestDifference) {
+			bestPosition = position
+			bestTier = tier
+			bestDifference = difference
+		}
+	}
+	if bestPosition > 0 {
+		return strings.TrimSpace(string(contentRunes[:bestPosition])),
+			strings.TrimSpace(string(contentRunes[bestPosition:])), nil
+	}
+	return prefix, remaining, nil
+}
+
+func textLengthAtLeastByLength(
+	content string,
+	minimum int,
+	lengthFunc func(string) (int, error),
+) (bool, error) {
+	contentRunes := []rune(strings.TrimSpace(content))
+	if len(contentRunes) == 0 {
+		return false, nil
+	}
+	position := min(len(contentRunes), max(1, minimum))
+	for {
+		prefix := strings.TrimSpace(string(contentRunes[:position]))
+		prefixSize, err := measureTextLength(lengthFunc, prefix)
+		if err != nil {
+			return false, err
+		}
+		if prefixSize >= minimum {
+			return true, nil
+		}
+		if position == len(contentRunes) {
+			return false, nil
+		}
+		position = min(len(contentRunes), position*2)
+	}
 }
 
 func preferredTextBoundary(content []rune, maxSize int) int {

--- a/knowledge/chunking/chunking_test.go
+++ b/knowledge/chunking/chunking_test.go
@@ -10,6 +10,7 @@
 package chunking
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -327,6 +328,128 @@ func TestSplitTextAtNaturalBoundaryPreservesSentenceAtoms(t *testing.T) {
 	}
 }
 
+func TestSplitTextAtNaturalBoundaryByLengthHandlesNonMonotonicPrefixes(
+	t *testing.T,
+) {
+	lengths := map[string]int{
+		"c":      1,
+		"ct":     1,
+		"cti":    2,
+		"ctio":   2,
+		"ction":  1,
+		"ctionX": 2,
+	}
+	lengthFunc := func(text string) (int, error) {
+		if length, ok := lengths[text]; ok {
+			return length, nil
+		}
+		return utf8.RuneCountInString(text), nil
+	}
+
+	prefix, remaining, err := splitTextAtNaturalBoundaryByLength(
+		"ctionX",
+		1,
+		lengthFunc,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "ction", prefix)
+	require.Equal(t, "X", remaining)
+}
+
+func TestSplitTextAtNaturalBoundaryByLengthPreservesSentenceAtoms(
+	t *testing.T,
+) {
+	tests := []struct {
+		name          string
+		content       string
+		maxSize       int
+		wantPrefix    string
+		wantRemaining string
+	}{
+		{
+			name:          "decimal",
+			content:       "prefix 12.6 suffix",
+			maxSize:       10,
+			wantPrefix:    "prefix",
+			wantRemaining: "12.6 suffix",
+		},
+		{
+			name:          "dotted section",
+			content:       "prefix 2.8.12 suffix",
+			maxSize:       11,
+			wantPrefix:    "prefix",
+			wantRemaining: "2.8.12 suffix",
+		},
+		{
+			name:          "semantic version",
+			content:       "prefix v1.2.3 suffix",
+			maxSize:       11,
+			wantPrefix:    "prefix",
+			wantRemaining: "v1.2.3 suffix",
+		},
+		{
+			name:          "CJK punctuation cluster",
+			content:       "12345678？！ tail",
+			maxSize:       9,
+			wantPrefix:    "12345678",
+			wantRemaining: "？！ tail",
+		},
+	}
+	lengthFunc := func(text string) (int, error) {
+		return utf8.RuneCountInString(text), nil
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix, remaining, err :=
+				splitTextAtNaturalBoundaryByLength(
+					tt.content,
+					tt.maxSize,
+					lengthFunc,
+				)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPrefix, prefix)
+			require.Equal(t, tt.wantRemaining, remaining)
+		})
+	}
+}
+
+func TestJoinWithOverlapByLengthUsesBoundedCandidates(t *testing.T) {
+	calls := 0
+	lengthFunc := func(text string) (int, error) {
+		calls++
+		return utf8.RuneCountInString(text), nil
+	}
+	previous := strings.Repeat("alpha beta gamma ", 250) +
+		"final sentence."
+
+	content, overlap, err := joinWithOverlapSeparatorByLength(
+		previous,
+		"next",
+		20,
+		30,
+		"\n\n",
+		false,
+		lengthFunc,
+	)
+
+	require.NoError(t, err)
+	require.Positive(t, overlap)
+	require.Contains(t, content, "\n\nnext")
+	require.LessOrEqual(t, utf8.RuneCountInString(content), 30)
+	require.Less(t, calls, 200,
+		"overlap selection should not tokenize every rune suffix")
+}
+
+func TestMeasureTextLengthRejectsNegativeLength(t *testing.T) {
+	_, err := measureTextLength(func(string) (int, error) {
+		return -1, nil
+	}, "content")
+
+	require.ErrorContains(t, err, "negative length")
+}
+
 // TestDefaultConstants tests the default constants
 func TestDefaultConstants(t *testing.T) {
 	assert.Equal(t, 1024, defaultChunkSize)
@@ -385,4 +508,12 @@ func boundaryOverlap(previous, current string, limit int) int {
 		}
 	}
 	return 0
+}
+
+func documentContents(documents []*document.Document) []string {
+	contents := make([]string, len(documents))
+	for i, doc := range documents {
+		contents[i] = doc.Content
+	}
+	return contents
 }

--- a/knowledge/chunking/fixed.go
+++ b/knowledge/chunking/fixed.go
@@ -10,6 +10,7 @@
 package chunking
 
 import (
+	"fmt"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
@@ -22,19 +23,22 @@ type FixedSizeChunking struct {
 	chunkSize     int
 	overlap       int
 	preserveLines bool
+	lengthFunc    func(string) (int, error)
 }
 
 // Option represents a functional option for configuring FixedSizeChunking.
 type Option func(*FixedSizeChunking)
 
-// WithChunkSize sets the maximum size of each chunk in Unicode runes.
+// WithChunkSize sets the maximum size of each chunk. The unit is Unicode runes
+// unless WithLengthFunc is configured.
 func WithChunkSize(size int) Option {
 	return func(fsc *FixedSizeChunking) {
 		fsc.chunkSize = size
 	}
 }
 
-// WithOverlap sets the maximum number of Unicode runes to overlap between chunks.
+// WithOverlap sets the maximum overlap between chunks. The unit is Unicode
+// runes unless WithLengthFunc is configured.
 func WithOverlap(overlap int) Option {
 	return func(fsc *FixedSizeChunking) {
 		fsc.overlap = overlap
@@ -46,6 +50,16 @@ func WithOverlap(overlap int) Option {
 func WithPreserveLines() Option {
 	return func(fsc *FixedSizeChunking) {
 		fsc.preserveLines = true
+	}
+}
+
+// WithLengthFunc sets the function used to measure chunk size and overlap.
+// By default, FixedSizeChunking measures Unicode runes. The function must
+// return a deterministic, non-negative length that broadly grows with its
+// input. Local non-monotonic behavior from tokenizers is supported.
+func WithLengthFunc(lengthFunc func(string) (int, error)) Option {
+	return func(fsc *FixedSizeChunking) {
+		fsc.lengthFunc = lengthFunc
 	}
 }
 
@@ -76,6 +90,9 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 	}
 
 	content := cleanText(doc.Content)
+	if f.lengthFunc != nil {
+		return f.chunkByLength(doc, content)
+	}
 	contentLength := encoding.RuneCount(content)
 
 	// If content is smaller than chunk size, return as single chunk.
@@ -130,6 +147,106 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 				f.chunkSize,
 				separator,
 				preserveSeparator,
+			)
+		}
+		chunk := createChunk(doc, textChunk.content, i+1)
+		chunk.Content = finalContent
+		if actualOverlap > 0 {
+			chunk.Metadata[source.MetaOverlappedContentSize] =
+				encoding.RuneCount(finalContent)
+		}
+		chunks = append(chunks, chunk)
+	}
+	return chunks, nil
+}
+
+func (f *FixedSizeChunking) chunkByLength(
+	doc *document.Document,
+	content string,
+) ([]*document.Document, error) {
+	contentLength, err := measureTextLength(f.lengthFunc, content)
+	if err != nil {
+		return nil, fmt.Errorf("fixed-size chunking: %w", err)
+	}
+	if contentLength <= f.chunkSize {
+		return []*document.Document{createChunk(doc, content, 1)}, nil
+	}
+
+	coreSize := f.chunkSize
+	if f.overlap > 0 {
+		coreSize = f.chunkSize - f.overlap
+	}
+	var textChunks []fixedTextChunk
+	if f.preserveLines {
+		textChunks, err = splitFixedLinesByLength(
+			content,
+			f.chunkSize,
+			coreSize,
+			f.lengthFunc,
+		)
+	} else {
+		var chunks []string
+		chunks, err = splitFixedTextByLength(
+			content,
+			f.chunkSize,
+			coreSize,
+			f.lengthFunc,
+		)
+		textChunks = make([]fixedTextChunk, 0, len(chunks))
+		for _, chunk := range chunks {
+			textChunks = append(textChunks, fixedTextChunk{content: chunk})
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fixed-size chunking: %w", err)
+	}
+
+	rawContents := make([]string, len(textChunks))
+	for i, textChunk := range textChunks {
+		rawContents[i] = textChunk.content
+	}
+	separators := sourceChunkSeparators(content, rawContents, " ")
+	chunks := make([]*document.Document, 0, len(textChunks))
+	for i, textChunk := range textChunks {
+		finalContent := textChunk.content
+		actualOverlap := 0
+		if i > 0 {
+			separator := separators[i]
+			preserveSeparator := false
+			if f.preserveLines {
+				separator = ""
+				if textChunk.startsNewLine {
+					separator = "\n"
+					preserveSeparator = true
+				}
+			}
+			finalContent, actualOverlap, err =
+				joinWithOverlapSeparatorByLength(
+					chunks[i-1].Content,
+					textChunk.content,
+					f.overlap,
+					f.chunkSize,
+					separator,
+					preserveSeparator,
+					f.lengthFunc,
+				)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"fixed-size chunking: add overlap: %w",
+					err,
+				)
+			}
+		}
+		finalSize, err := measureTextLength(f.lengthFunc, finalContent)
+		if err != nil {
+			return nil, fmt.Errorf("fixed-size chunking: %w", err)
+		}
+		if finalSize > f.chunkSize {
+			return nil, fmt.Errorf(
+				"fixed-size chunking: final chunk %d has length %d, exceeds chunk size %d",
+				i+1,
+				finalSize,
+				f.chunkSize,
 			)
 		}
 		chunk := createChunk(doc, textChunk.content, i+1)
@@ -254,4 +371,120 @@ func splitFixedText(
 		remaining = rest
 	}
 	return chunks
+}
+
+func splitFixedLinesByLength(
+	content string,
+	firstChunkSize int,
+	nextChunkSize int,
+	lengthFunc func(string) (int, error),
+) ([]fixedTextChunk, error) {
+	if nextChunkSize <= 0 {
+		nextChunkSize = firstChunkSize
+	}
+	var chunks []fixedTextChunk
+	var current string
+	hasCurrent := false
+
+	chunkSize := func() int {
+		if len(chunks) == 0 {
+			return firstChunkSize
+		}
+		return nextChunkSize
+	}
+	flush := func() {
+		if !hasCurrent || strings.TrimSpace(current) == "" {
+			current = ""
+			hasCurrent = false
+			return
+		}
+		chunks = append(chunks, fixedTextChunk{
+			content:       current,
+			startsNewLine: true,
+		})
+		current = ""
+		hasCurrent = false
+	}
+
+	for _, line := range strings.Split(content, "\n") {
+		if hasCurrent {
+			candidate := current + "\n" + line
+			candidateSize, err := measureTextLength(
+				lengthFunc,
+				candidate,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if candidateSize <= chunkSize() {
+				current = candidate
+				continue
+			}
+			flush()
+		}
+
+		lineSize, err := measureTextLength(lengthFunc, line)
+		if err != nil {
+			return nil, err
+		}
+		if lineSize <= chunkSize() {
+			current = line
+			hasCurrent = true
+			continue
+		}
+
+		pieces, err := splitFixedTextByLength(
+			line,
+			chunkSize(),
+			nextChunkSize,
+			lengthFunc,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for i, piece := range pieces {
+			chunks = append(chunks, fixedTextChunk{
+				content:       piece,
+				startsNewLine: i == 0,
+			})
+		}
+	}
+	flush()
+	return chunks, nil
+}
+
+func splitFixedTextByLength(
+	content string,
+	firstChunkSize int,
+	nextChunkSize int,
+	lengthFunc func(string) (int, error),
+) ([]string, error) {
+	if nextChunkSize <= 0 {
+		nextChunkSize = firstChunkSize
+	}
+	var chunks []string
+	remaining := content
+	for remaining != "" {
+		chunkSize := nextChunkSize
+		if len(chunks) == 0 {
+			chunkSize = firstChunkSize
+		}
+		chunk, rest, err := splitTextWithBalancedTailByLength(
+			remaining,
+			chunkSize,
+			lengthFunc,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if chunk == "" {
+			return nil, fmt.Errorf(
+				"unable to make progress with chunk size %d",
+				chunkSize,
+			)
+		}
+		chunks = append(chunks, chunk)
+		remaining = rest
+	}
+	return chunks, nil
 }

--- a/knowledge/chunking/fixed_test.go
+++ b/knowledge/chunking/fixed_test.go
@@ -10,6 +10,7 @@
 package chunking
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -417,4 +418,166 @@ func TestFixedSizeChunking_OverlapStartsAtWordBoundary(t *testing.T) {
 		require.True(t, actualOverlap == len(contentRunes) ||
 			contentRunes[actualOverlap] == ' ')
 	}
+}
+
+func TestFixedSizeChunking_CustomLengthFunc(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return 2 * utf8.RuneCountInString(text), nil
+	}
+	const (
+		chunkSize = 8
+		overlap   = 2
+	)
+	chunker := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithOverlap(overlap),
+		WithLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "custom-length",
+		Content: "甲乙丙丁戊己庚辛",
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+	for i, chunk := range chunks {
+		size, err := lengthFunc(chunk.Content)
+		require.NoError(t, err)
+		require.LessOrEqual(t, size, chunkSize,
+			"chunk %d exceeds the custom length budget", i)
+		runeCount := utf8.RuneCountInString(chunk.Content)
+		if overlappedSize, ok :=
+			chunk.Metadata[source.MetaOverlappedContentSize]; ok {
+			require.Equal(t, runeCount, overlappedSize)
+		} else {
+			require.Equal(t, runeCount,
+				chunk.Metadata[source.MetaChunkSize])
+		}
+	}
+}
+
+func TestFixedSizeChunking_CustomLengthFuncMeasuresWholeCandidate(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		if text == "ab" {
+			return 1, nil
+		}
+		return utf8.RuneCountInString(text), nil
+	}
+	chunker := NewFixedSizeChunking(
+		WithChunkSize(1),
+		WithLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "whole-candidate",
+		Content: "abc",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"ab", "c"}, []string{
+		chunks[0].Content,
+		chunks[1].Content,
+	})
+}
+
+func TestFixedSizeChunking_CustomLengthFuncError(t *testing.T) {
+	wantErr := errors.New("length failed")
+	chunker := NewFixedSizeChunking(
+		WithChunkSize(4),
+		WithLengthFunc(func(string) (int, error) {
+			return 0, wantErr
+		}),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "length-error",
+		Content: "content",
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, chunks)
+}
+
+func TestFixedSizeChunking_CustomLengthPreservesRecordBoundary(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return utf8.RuneCountInString(text), nil
+	}
+	const (
+		chunkSize = 60
+		overlap   = 20
+	)
+	firstRecord := strings.Repeat("a", 50)
+	secondRecord := "2 | " + strings.Repeat("b", 50)
+	chunker := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithOverlap(overlap),
+		WithPreserveLines(),
+		WithLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "custom-record-boundary",
+		Content: firstRecord + "\n" + secondRecord,
+	})
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(chunks), 3)
+	require.Contains(t, chunks[1].Content,
+		strings.Repeat("a", overlap-1)+"\n2 | ")
+	require.NotContains(t, chunks[1].Content,
+		strings.Repeat("a", overlap)+"2 | ")
+	for i, chunk := range chunks {
+		size, err := lengthFunc(chunk.Content)
+		require.NoError(t, err)
+		require.LessOrEqual(t, size, chunkSize,
+			"chunk %d exceeds the custom length budget", i)
+	}
+}
+
+func TestFixedSizeChunking_CustomRuneLengthMatchesDefault(t *testing.T) {
+	content := "Alpha beta gamma delta epsilon zeta eta theta. " +
+		"Second sentence keeps the boundary readable."
+	doc := &document.Document{ID: "rune-parity", Content: content}
+	defaultChunks, err := NewFixedSizeChunking(
+		WithChunkSize(32),
+		WithOverlap(6),
+	).Chunk(doc)
+	require.NoError(t, err)
+	customChunks, err := NewFixedSizeChunking(
+		WithChunkSize(32),
+		WithOverlap(6),
+		WithLengthFunc(func(text string) (int, error) {
+			return utf8.RuneCountInString(text), nil
+		}),
+	).Chunk(doc)
+	require.NoError(t, err)
+
+	require.Equal(t, documentContents(defaultChunks),
+		documentContents(customChunks))
+}
+
+func TestFixedSizeChunking_CustomLengthUsesBoundedInput(t *testing.T) {
+	content := strings.Repeat("abcdefghij", 5000)
+	sourceRunes := utf8.RuneCountInString(content)
+	measuredRunes := 0
+	lengthFunc := func(text string) (int, error) {
+		length := utf8.RuneCountInString(text)
+		measuredRunes += length
+		return length, nil
+	}
+	chunker := NewFixedSizeChunking(
+		WithChunkSize(64),
+		WithLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "bounded-length-input",
+		Content: content,
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+	require.Less(t, measuredRunes, sourceRunes*100,
+		"splitting should not repeatedly measure the full remaining text")
 }

--- a/knowledge/chunking/markdown.go
+++ b/knowledge/chunking/markdown.go
@@ -12,6 +12,7 @@ package chunking
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -37,25 +38,40 @@ func (c *chunkCounter) Count() int {
 
 // MarkdownChunking implements a chunking strategy optimized for markdown documents.
 type MarkdownChunking struct {
-	chunkSize int
-	overlap   int
-	md        goldmark.Markdown
+	chunkSize  int
+	overlap    int
+	md         goldmark.Markdown
+	lengthFunc func(string) (int, error)
 }
 
 // MarkdownOption represents a functional option for configuring MarkdownChunking.
 type MarkdownOption func(*MarkdownChunking)
 
-// WithMarkdownChunkSize sets the maximum size of each chunk in Unicode runes.
+// WithMarkdownChunkSize sets the maximum size of each chunk. The unit is
+// Unicode runes unless WithMarkdownLengthFunc is configured.
 func WithMarkdownChunkSize(size int) MarkdownOption {
 	return func(mc *MarkdownChunking) {
 		mc.chunkSize = size
 	}
 }
 
-// WithMarkdownOverlap sets the maximum number of Unicode runes to overlap between chunks.
+// WithMarkdownOverlap sets the maximum overlap between chunks. The unit is
+// Unicode runes unless WithMarkdownLengthFunc is configured.
 func WithMarkdownOverlap(overlap int) MarkdownOption {
 	return func(mc *MarkdownChunking) {
 		mc.overlap = overlap
+	}
+}
+
+// WithMarkdownLengthFunc sets the function used to measure chunk size and
+// overlap. By default, MarkdownChunking measures Unicode runes. The function
+// must return a deterministic, non-negative length that broadly grows with its
+// input. Local non-monotonic behavior from tokenizers is supported.
+func WithMarkdownLengthFunc(
+	lengthFunc func(string) (int, error),
+) MarkdownOption {
+	return func(mc *MarkdownChunking) {
+		mc.lengthFunc = lengthFunc
 	}
 }
 
@@ -89,14 +105,24 @@ func (m *MarkdownChunking) Chunk(doc *document.Document) ([]*document.Document, 
 	content := cleanText(doc.Content)
 
 	// If content is small enough, return as single chunk.
-	if encoding.RuneCount(content) <= m.chunkSize {
+	contentSize, err := measureTextLength(m.lengthFunc, content)
+	if err != nil {
+		return nil, fmt.Errorf("markdown chunking: %w", err)
+	}
+	if contentSize <= m.chunkSize {
 		chunk := m.createMarkdownChunk(doc, content, 1)
 		return []*document.Document{chunk}, nil
 	}
 
 	// Parse Markdown structure, then pack adjacent semantic units.
-	rawChunks := m.splitRecursively(content)
-	rawChunks = m.mergeAdjacentChunks(content, rawChunks)
+	rawChunks, err := m.splitRecursively(content)
+	if err != nil {
+		return nil, fmt.Errorf("markdown chunking: %w", err)
+	}
+	rawChunks, err = m.mergeAdjacentChunks(content, rawChunks)
+	if err != nil {
+		return nil, fmt.Errorf("markdown chunking: %w", err)
+	}
 	chunks := make([]*document.Document, len(rawChunks))
 	for i, chunk := range rawChunks {
 		chunks[i] = m.createMarkdownChunkWithPath(
@@ -109,7 +135,24 @@ func (m *MarkdownChunking) Chunk(doc *document.Document) ([]*document.Document, 
 
 	// Apply overlap if specified.
 	if m.overlap > 0 {
-		chunks = m.applyOverlap(content, chunks)
+		chunks, err = m.applyOverlap(content, chunks)
+		if err != nil {
+			return nil, fmt.Errorf("markdown chunking: %w", err)
+		}
+	}
+	for i, chunk := range chunks {
+		size, err := measureTextLength(m.lengthFunc, chunk.Content)
+		if err != nil {
+			return nil, fmt.Errorf("markdown chunking: %w", err)
+		}
+		if size > m.chunkSize {
+			return nil, fmt.Errorf(
+				"markdown chunking: final chunk %d has length %d, exceeds chunk size %d",
+				i+1,
+				size,
+				m.chunkSize,
+			)
+		}
 	}
 
 	return chunks, nil
@@ -132,7 +175,9 @@ type markdownChunk struct {
 
 // splitRecursively splits content by headers recursively (similar to LangChain).
 // It tries to split by headers from level 1 to 6, then by double newlines, then by fixed size.
-func (m *MarkdownChunking) splitRecursively(content string) []markdownChunk {
+func (m *MarkdownChunking) splitRecursively(
+	content string,
+) ([]markdownChunk, error) {
 	counter := new(chunkCounter)
 	return m.splitRecursivelyWithPath(content, nil, counter, 1)
 }
@@ -143,16 +188,19 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 	headerPath []string,
 	counter *chunkCounter,
 	startHeaderLevel int,
-) []markdownChunk {
+) ([]markdownChunk, error) {
 	var chunks []markdownChunk
 
-	contentSize := encoding.RuneCount(content)
+	contentSize, err := measureTextLength(m.lengthFunc, content)
+	if err != nil {
+		return nil, err
+	}
 	chunkSize := m.nextChunkSize(counter)
 
 	// Base case: content fits in one chunk
 	if contentSize <= chunkSize {
 		counter.Advance()
-		return []markdownChunk{newMarkdownChunk(content, headerPath)}
+		return []markdownChunk{newMarkdownChunk(content, headerPath)}, nil
 	}
 
 	// Try splitting by headers from the next unprocessed level to level 6.
@@ -181,7 +229,13 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 					fullContent = sectionContent
 				}
 
-				sectionSize := encoding.RuneCount(fullContent)
+				sectionSize, err := measureTextLength(
+					m.lengthFunc,
+					fullContent,
+				)
+				if err != nil {
+					return nil, err
+				}
 				chunkSize = m.nextChunkSize(counter)
 
 				// Build new header path
@@ -199,16 +253,19 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 					chunks = append(chunks, newMarkdownChunk(fullContent, newPath))
 				} else {
 					// Section is too large, split recursively
-					subChunks := m.splitRecursivelyWithPath(
+					subChunks, err := m.splitRecursivelyWithPath(
 						fullContent,
 						newPath,
 						counter,
 						level+1,
 					)
+					if err != nil {
+						return nil, err
+					}
 					chunks = append(chunks, subChunks...)
 				}
 			}
-			return chunks
+			return chunks, nil
 		}
 	}
 
@@ -217,27 +274,63 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 	// create unrelated, undersized chunks.
 	paragraphs := splitMarkdownParagraphs(content)
 	if len(paragraphs) > 1 {
-		chunks = m.mergeSmallParagraphsWithPath(
+		chunks, err = m.mergeSmallParagraphsWithPath(
 			paragraphs,
 			headerPath,
 			counter,
 		)
+		if err != nil {
+			return nil, err
+		}
 		if len(chunks) > 0 {
-			return chunks
+			return chunks, nil
 		}
 	}
 
-	// Still too large, split at the best available text boundary. Balance the
-	// final pair instead of leaving a tiny hard-split tail.
+	return m.splitRemainingTextWithPath(
+		content,
+		headerPath,
+		counter,
+	)
+}
+
+// splitRemainingTextWithPath splits content at the best available text
+// boundary after structural Markdown splitters have been exhausted.
+func (m *MarkdownChunking) splitRemainingTextWithPath(
+	content string,
+	headerPath []string,
+	counter *chunkCounter,
+) ([]markdownChunk, error) {
+	var chunks []markdownChunk
 	remainingText := content
 	for remainingText != "" {
-		chunkSize = m.nextChunkSize(counter)
-		chunkText, rest := splitTextWithBalancedTail(
-			remainingText,
-			chunkSize,
-			splitMarkdownText,
-		)
+		chunkSize := m.nextChunkSize(counter)
+		var chunkText, rest string
+		var err error
+		if m.lengthFunc == nil {
+			chunkText, rest = splitTextWithBalancedTail(
+				remainingText,
+				chunkSize,
+				splitMarkdownText,
+			)
+		} else {
+			chunkText, rest, err =
+				splitTextWithBalancedTailByLength(
+					remainingText,
+					chunkSize,
+					m.lengthFunc,
+				)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if strings.TrimSpace(chunkText) == "" {
+			if m.lengthFunc != nil {
+				return nil, fmt.Errorf(
+					"unable to split markdown within chunk size %d",
+					chunkSize,
+				)
+			}
 			textChunks := encoding.SafeSplitBySize(remainingText, chunkSize)
 			chunkText = textChunks[0]
 			rest = remainingText[len(chunkText):]
@@ -247,7 +340,7 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 		remainingText = rest
 	}
 
-	return chunks
+	return chunks, nil
 }
 
 // splitByHeader splits content by a specific header level.
@@ -710,7 +803,14 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 	paragraphs []string,
 	headerPath []string,
 	counter *chunkCounter,
-) []markdownChunk {
+) ([]markdownChunk, error) {
+	if m.lengthFunc != nil {
+		return m.mergeSmallParagraphsWithPathByLength(
+			paragraphs,
+			headerPath,
+			counter,
+		)
+	}
 	var chunks []markdownChunk
 	var currentChunk strings.Builder
 
@@ -774,7 +874,106 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 		}
 	}
 	flush()
-	return chunks
+	return chunks, nil
+}
+
+func (m *MarkdownChunking) mergeSmallParagraphsWithPathByLength(
+	paragraphs []string,
+	headerPath []string,
+	counter *chunkCounter,
+) ([]markdownChunk, error) {
+	var chunks []markdownChunk
+	var currentChunk string
+
+	flush := func() {
+		if currentChunk == "" {
+			return
+		}
+		counter.Advance()
+		chunks = append(chunks, newMarkdownChunk(currentChunk, headerPath))
+		currentChunk = ""
+	}
+
+	for _, paragraph := range paragraphs {
+		remainingText := strings.TrimSpace(paragraph)
+		for remainingText != "" {
+			chunkSize := m.nextChunkSize(counter)
+			candidate := remainingText
+			if currentChunk != "" {
+				candidate = currentChunk + "\n\n" + remainingText
+			}
+			candidateSize, err := measureTextLength(
+				m.lengthFunc,
+				candidate,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if candidateSize <= chunkSize {
+				currentChunk = candidate
+				break
+			}
+
+			if currentChunk != "" {
+				if isMarkdownHeading(currentChunk) {
+					current := currentChunk
+					firstRune := string([]rune(remainingText)[:1])
+					incrementalLength := func(
+						text string,
+					) (int, error) {
+						return measureTextLength(
+							m.lengthFunc,
+							current+"\n\n"+text,
+						)
+					}
+					firstSize, err := incrementalLength(firstRune)
+					if err != nil {
+						return nil, err
+					}
+					if firstSize <= chunkSize {
+						prefix, rest, err :=
+							splitTextAtNaturalBoundaryByLength(
+								remainingText,
+								chunkSize,
+								incrementalLength,
+							)
+						if err != nil {
+							return nil, err
+						}
+						if prefix != "" {
+							currentChunk += "\n\n" + prefix
+							remainingText = rest
+						}
+					}
+				}
+				flush()
+				continue
+			}
+
+			prefix, rest, err :=
+				splitTextWithBalancedTailByLength(
+					remainingText,
+					chunkSize,
+					m.lengthFunc,
+				)
+			if err != nil {
+				return nil, err
+			}
+			if prefix == "" {
+				return nil, fmt.Errorf(
+					"unable to split markdown paragraph within chunk size %d",
+					chunkSize,
+				)
+			}
+			currentChunk = prefix
+			remainingText = rest
+			if remainingText != "" {
+				flush()
+			}
+		}
+	}
+	flush()
+	return chunks, nil
 }
 
 func (m *MarkdownChunking) nextChunkSize(counter *chunkCounter) int {
@@ -825,9 +1024,9 @@ func newMarkdownChunk(content string, headerPath []string) markdownChunk {
 func (m *MarkdownChunking) mergeAdjacentChunks(
 	content string,
 	chunks []markdownChunk,
-) []markdownChunk {
+) ([]markdownChunk, error) {
 	if len(chunks) <= 1 {
-		return chunks
+		return chunks, nil
 	}
 
 	rawContents := make([]string, len(chunks))
@@ -841,7 +1040,7 @@ func (m *MarkdownChunking) mergeAdjacentChunks(
 
 	groups := make([][]markdownChunk, 0, len(chunks))
 	currentGroup := []markdownChunk{chunks[0]}
-	currentSize := encoding.RuneCount(chunks[0].content)
+	currentContent := chunks[0].content
 
 	for i := 1; i < len(chunks); i++ {
 		nextChunk := chunks[i]
@@ -857,30 +1056,40 @@ func (m *MarkdownChunking) mergeAdjacentChunks(
 			!markdownChunksOnlyHeadings(currentGroup) {
 			groups = append(groups, currentGroup)
 			currentGroup = []markdownChunk{nextChunk}
-			currentSize = encoding.RuneCount(nextChunk.content)
+			currentContent = nextChunk.content
 			continue
 		}
 
-		nextSize := encoding.RuneCount(nextChunk.separator) +
-			encoding.RuneCount(nextChunk.content)
-		if currentSize+nextSize <= limit {
+		candidateContent := currentContent + nextChunk.separator +
+			nextChunk.content
+		candidateSize, err := measureTextLength(
+			m.lengthFunc,
+			candidateContent,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if candidateSize <= limit {
 			currentGroup = append(currentGroup, nextChunk)
-			currentSize += nextSize
+			currentContent = candidateContent
 			continue
 		}
 
 		groups = append(groups, currentGroup)
 		currentGroup = []markdownChunk{nextChunk}
-		currentSize = encoding.RuneCount(nextChunk.content)
+		currentContent = nextChunk.content
 	}
 	groups = append(groups, currentGroup)
-	groups = m.rebalanceMarkdownTail(groups)
+	groups, err := m.rebalanceMarkdownTail(groups)
+	if err != nil {
+		return nil, err
+	}
 
 	mergedChunks := make([]markdownChunk, len(groups))
 	for i, group := range groups {
 		mergedChunks[i] = mergeMarkdownChunkGroup(group)
 	}
-	return mergedChunks
+	return mergedChunks, nil
 }
 
 func markdownChunksOnlyHeadings(chunks []markdownChunk) bool {
@@ -897,9 +1106,9 @@ func markdownChunksOnlyHeadings(chunks []markdownChunk) bool {
 
 func (m *MarkdownChunking) rebalanceMarkdownTail(
 	groups [][]markdownChunk,
-) [][]markdownChunk {
+) ([][]markdownChunk, error) {
 	if len(groups) < 2 {
-		return groups
+		return groups, nil
 	}
 
 	leftIndex := len(groups) - 2
@@ -907,12 +1116,18 @@ func (m *MarkdownChunking) rebalanceMarkdownTail(
 	left := groups[leftIndex]
 	right := groups[rightIndex]
 	if markdownChunksOnlyHeadings(right) {
-		return groups
+		return groups, nil
 	}
 
 	rightLimit := m.chunkSize - m.overlap
-	leftSize := markdownChunkGroupSize(left)
-	rightSize := markdownChunkGroupSize(right)
+	leftSize, err := m.markdownChunkGroupSize(left)
+	if err != nil {
+		return nil, err
+	}
+	rightSize, err := m.markdownChunkGroupSize(right)
+	if err != nil {
+		return nil, err
+	}
 	for len(left) > 1 {
 		nextLeft := left[:len(left)-1]
 		moved := left[len(left)-1]
@@ -920,8 +1135,14 @@ func (m *MarkdownChunking) rebalanceMarkdownTail(
 		nextRight = append(nextRight, moved)
 		nextRight = append(nextRight, right...)
 
-		nextLeftSize := markdownChunkGroupSize(nextLeft)
-		nextRightSize := markdownChunkGroupSize(nextRight)
+		nextLeftSize, err := m.markdownChunkGroupSize(nextLeft)
+		if err != nil {
+			return nil, err
+		}
+		nextRightSize, err := m.markdownChunkGroupSize(nextRight)
+		if err != nil {
+			return nil, err
+		}
 		if nextRightSize > rightLimit ||
 			absInt(nextLeftSize-nextRightSize) >=
 				absInt(leftSize-rightSize) {
@@ -935,19 +1156,19 @@ func (m *MarkdownChunking) rebalanceMarkdownTail(
 	}
 	groups[leftIndex] = left
 	groups[rightIndex] = right
-	return groups
+	return groups, nil
 }
 
-func markdownChunkGroupSize(chunks []markdownChunk) int {
+func (m *MarkdownChunking) markdownChunkGroupSize(
+	chunks []markdownChunk,
+) (int, error) {
 	if len(chunks) == 0 {
-		return 0
+		return 0, nil
 	}
-	size := encoding.RuneCount(chunks[0].content)
-	for i := 1; i < len(chunks); i++ {
-		size += encoding.RuneCount(chunks[i].separator)
-		size += encoding.RuneCount(chunks[i].content)
-	}
-	return size
+	return measureTextLength(
+		m.lengthFunc,
+		mergeMarkdownChunkGroup(chunks).content,
+	)
 }
 
 func mergeMarkdownChunkGroup(chunks []markdownChunk) markdownChunk {
@@ -1041,9 +1262,9 @@ func (m *MarkdownChunking) createMarkdownChunkWithPath(
 func (m *MarkdownChunking) applyOverlap(
 	content string,
 	chunks []*document.Document,
-) []*document.Document {
+) ([]*document.Document, error) {
 	if len(chunks) <= 1 {
-		return chunks
+		return chunks, nil
 	}
 
 	rawContents := make([]string, len(chunks))
@@ -1060,13 +1281,32 @@ func (m *MarkdownChunking) applyOverlap(
 			metadata[k] = v
 		}
 
-		overlappedContent, actualOverlap := joinWithOverlap(
-			overlappedChunks[len(overlappedChunks)-1].Content,
-			chunks[i].Content,
-			m.overlap,
-			m.chunkSize,
-			separators[i],
-		)
+		var overlappedContent string
+		var actualOverlap int
+		if m.lengthFunc == nil {
+			overlappedContent, actualOverlap = joinWithOverlap(
+				overlappedChunks[len(overlappedChunks)-1].Content,
+				chunks[i].Content,
+				m.overlap,
+				m.chunkSize,
+				separators[i],
+			)
+		} else {
+			var err error
+			overlappedContent, actualOverlap, err =
+				joinWithOverlapSeparatorByLength(
+					overlappedChunks[len(overlappedChunks)-1].Content,
+					chunks[i].Content,
+					m.overlap,
+					m.chunkSize,
+					separators[i],
+					false,
+					m.lengthFunc,
+				)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if actualOverlap > 0 {
 			metadata[source.MetaOverlappedContentSize] = encoding.RuneCount(overlappedContent)
 		}
@@ -1081,5 +1321,5 @@ func (m *MarkdownChunking) applyOverlap(
 		}
 		overlappedChunks = append(overlappedChunks, overlappedChunk)
 	}
-	return overlappedChunks
+	return overlappedChunks, nil
 }

--- a/knowledge/chunking/markdown_test.go
+++ b/knowledge/chunking/markdown_test.go
@@ -10,6 +10,7 @@
 package chunking
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -628,10 +629,41 @@ func TestMarkdownChunkingRebalancesSemanticTail(t *testing.T) {
 		content.WriteString(parts[i].content)
 	}
 
-	chunks := NewMarkdownChunking(
+	chunks, err := NewMarkdownChunking(
 		WithMarkdownChunkSize(chunkSize),
 	).mergeAdjacentChunks(content.String(), parts)
+	require.NoError(t, err)
 
+	require.Len(t, chunks, 2)
+	require.Equal(t, 1002, utf8.RuneCountInString(chunks[0].content))
+	require.Equal(t, 602, utf8.RuneCountInString(chunks[1].content))
+	require.Equal(t, []string{"Root"}, chunks[0].headerPath)
+	require.Equal(t, []string{"Root"}, chunks[1].headerPath)
+}
+
+func TestMarkdownChunkingCustomLengthRebalancesSemanticTail(t *testing.T) {
+	parts := []markdownChunk{
+		newMarkdownChunk(strings.Repeat("a", 600), []string{"Root"}),
+		newMarkdownChunk(strings.Repeat("b", 400), []string{"Root", "One"}),
+		newMarkdownChunk(strings.Repeat("c", 350), []string{"Root", "Two"}),
+		newMarkdownChunk(strings.Repeat("d", 250), []string{"Root", "Three"}),
+	}
+	var content strings.Builder
+	for i := range parts {
+		if i > 0 {
+			content.WriteString("\n\n")
+		}
+		content.WriteString(parts[i].content)
+	}
+
+	chunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(3000),
+		WithMarkdownLengthFunc(func(text string) (int, error) {
+			return 2 * utf8.RuneCountInString(text), nil
+		}),
+	).mergeAdjacentChunks(content.String(), parts)
+
+	require.NoError(t, err)
 	require.Len(t, chunks, 2)
 	require.Equal(t, 1002, utf8.RuneCountInString(chunks[0].content))
 	require.Equal(t, 602, utf8.RuneCountInString(chunks[1].content))
@@ -2225,5 +2257,135 @@ func TestMarkdownChunking_ReservesBudgetForExplicitOverlap(t *testing.T) {
 		)
 		require.Contains(t, chunk.Metadata,
 			source.MetaOverlappedContentSize)
+	}
+}
+
+func TestMarkdownChunking_CustomLengthFunc(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return 2 * utf8.RuneCountInString(text), nil
+	}
+	const (
+		chunkSize = 80
+		overlap   = 20
+	)
+	chunker := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownOverlap(overlap),
+		WithMarkdownLengthFunc(lengthFunc),
+	)
+	content := `# Root
+
+Root context.
+
+## Mixed
+
+English and 中文 content should keep its Markdown structure while the custom length function controls the final budget. ` +
+		strings.Repeat("More mixed content. ", 10)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "custom-markdown-length",
+		Content: content,
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+	var foundMixedPath bool
+	for i, chunk := range chunks {
+		size, err := lengthFunc(chunk.Content)
+		require.NoError(t, err)
+		require.LessOrEqual(t, size, chunkSize,
+			"chunk %d exceeds the custom length budget", i)
+		if chunk.Metadata[source.MetaMarkdownHeaderPath] == "Root > Mixed" {
+			foundMixedPath = true
+		}
+	}
+	require.True(t, foundMixedPath)
+}
+
+func TestMarkdownChunking_CustomLengthLargeOverlapWithinBudget(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return 2 * utf8.RuneCountInString(text), nil
+	}
+	const (
+		chunkSize = 120
+		overlap   = 100
+	)
+	chunker := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownOverlap(overlap),
+		WithMarkdownLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "custom-large-overlap",
+		Content: strings.Repeat("token aware content ", 40),
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+	for i, chunk := range chunks {
+		size, err := lengthFunc(chunk.Content)
+		require.NoError(t, err)
+		require.LessOrEqual(t, size, chunkSize,
+			"chunk %d exceeds the custom length budget", i)
+	}
+}
+
+func TestMarkdownChunking_CustomLengthFuncError(t *testing.T) {
+	wantErr := errors.New("length failed")
+	chunker := NewMarkdownChunking(
+		WithMarkdownChunkSize(20),
+		WithMarkdownLengthFunc(func(string) (int, error) {
+			return 0, wantErr
+		}),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "length-error",
+		Content: "# Header\n\nContent",
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, chunks)
+}
+
+func TestMarkdownChunking_CustomRuneLengthKeepsSemanticPacking(
+	t *testing.T,
+) {
+	content := `# Root
+
+Root introduction.
+
+## First
+
+First section has enough text to represent one semantic unit.
+
+## Second
+
+Second section has enough text to represent another semantic unit.
+
+## Third
+
+Third section has enough text to represent the final semantic unit.`
+	doc := &document.Document{ID: "markdown-rune-parity", Content: content}
+	defaultChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(180),
+	).Chunk(doc)
+	require.NoError(t, err)
+	customChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(180),
+		WithMarkdownLengthFunc(func(text string) (int, error) {
+			return utf8.RuneCountInString(text), nil
+		}),
+	).Chunk(doc)
+	require.NoError(t, err)
+
+	require.Equal(t, documentContents(defaultChunks),
+		documentContents(customChunks))
+	for i := range defaultChunks {
+		require.Equal(t,
+			defaultChunks[i].Metadata[source.MetaMarkdownHeaderPath],
+			customChunks[i].Metadata[source.MetaMarkdownHeaderPath],
+		)
 	}
 }

--- a/knowledge/chunking/recursive.go
+++ b/knowledge/chunking/recursive.go
@@ -11,6 +11,7 @@
 package chunking
 
 import (
+	"fmt"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
@@ -23,19 +24,22 @@ type RecursiveChunking struct {
 	chunkSize  int
 	overlap    int
 	separators []string
+	lengthFunc func(string) (int, error)
 }
 
 // RecursiveOption represents a functional option for configuring RecursiveChunking.
 type RecursiveOption func(*RecursiveChunking)
 
-// WithRecursiveChunkSize sets the maximum size of each chunk in Unicode runes.
+// WithRecursiveChunkSize sets the maximum size of each chunk. The unit is
+// Unicode runes unless WithRecursiveLengthFunc is configured.
 func WithRecursiveChunkSize(size int) RecursiveOption {
 	return func(rc *RecursiveChunking) {
 		rc.chunkSize = size
 	}
 }
 
-// WithRecursiveOverlap sets the maximum number of Unicode runes to overlap between chunks.
+// WithRecursiveOverlap sets the maximum overlap between chunks. The unit is
+// Unicode runes unless WithRecursiveLengthFunc is configured.
 func WithRecursiveOverlap(overlap int) RecursiveOption {
 	return func(rc *RecursiveChunking) {
 		rc.overlap = overlap
@@ -46,6 +50,18 @@ func WithRecursiveOverlap(overlap int) RecursiveOption {
 func WithRecursiveSeparators(separators []string) RecursiveOption {
 	return func(rc *RecursiveChunking) {
 		rc.separators = separators
+	}
+}
+
+// WithRecursiveLengthFunc sets the function used to measure chunk size and
+// overlap. By default, RecursiveChunking measures Unicode runes. The function
+// must return a deterministic, non-negative length that broadly grows with its
+// input. Local non-monotonic behavior from tokenizers is supported.
+func WithRecursiveLengthFunc(
+	lengthFunc func(string) (int, error),
+) RecursiveOption {
+	return func(rc *RecursiveChunking) {
+		rc.lengthFunc = lengthFunc
 	}
 }
 
@@ -86,6 +102,9 @@ func (r *RecursiveChunking) Chunk(doc *document.Document) ([]*document.Document,
 	}
 
 	content := cleanText(doc.Content)
+	if r.lengthFunc != nil {
+		return r.chunkByLength(doc, content)
+	}
 	coreSize := r.chunkSize
 	if r.overlap > 0 {
 		coreSize = r.chunkSize - r.overlap
@@ -102,6 +121,288 @@ func (r *RecursiveChunking) Chunk(doc *document.Document) ([]*document.Document,
 		chunks = r.applyOverlap(content, chunks)
 	}
 	return chunks, nil
+}
+
+func (r *RecursiveChunking) chunkByLength(
+	doc *document.Document,
+	content string,
+) ([]*document.Document, error) {
+	coreSize := r.chunkSize
+	if r.overlap > 0 {
+		coreSize = r.chunkSize - r.overlap
+	}
+	fragments, err := r.recursiveSplitByLength(
+		content,
+		r.separators,
+		coreSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recursive chunking: %w", err)
+	}
+	textChunks, err := r.mergeFragmentsByLength(
+		fragments,
+		r.chunkSize,
+		coreSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recursive chunking: %w", err)
+	}
+	chunks := make([]*document.Document, 0, len(textChunks))
+	for i, chunkText := range textChunks {
+		chunks = append(chunks, createChunk(doc, chunkText, i+1))
+	}
+	if r.overlap > 0 {
+		chunks, err = r.applyOverlapByLength(content, chunks)
+		if err != nil {
+			return nil, fmt.Errorf("recursive chunking: %w", err)
+		}
+	}
+	for i, chunk := range chunks {
+		size, err := measureTextLength(r.lengthFunc, chunk.Content)
+		if err != nil {
+			return nil, fmt.Errorf("recursive chunking: %w", err)
+		}
+		if size > r.chunkSize {
+			return nil, fmt.Errorf(
+				"recursive chunking: final chunk %d has length %d, exceeds chunk size %d",
+				i+1,
+				size,
+				r.chunkSize,
+			)
+		}
+	}
+	return chunks, nil
+}
+
+func (r *RecursiveChunking) recursiveSplitByLength(
+	text string,
+	separators []string,
+	maxSize int,
+) ([]string, error) {
+	textSize, err := measureTextLength(r.lengthFunc, text)
+	if err != nil {
+		return nil, err
+	}
+	if textSize <= maxSize {
+		return []string{text}, nil
+	}
+	if len(separators) == 0 {
+		return []string{text}, nil
+	}
+
+	separator := separators[0]
+	if separator == "" {
+		return []string{text}, nil
+	}
+	if !strings.Contains(text, separator) {
+		return r.recursiveSplitByLength(
+			text,
+			separators[1:],
+			maxSize,
+		)
+	}
+
+	splits := strings.SplitAfter(text, separator)
+	separatorRunes := []rune(separator)
+	if len(separatorRunes) == 1 &&
+		isSentencePunctuation(separatorRunes[0]) {
+		lastNonEmpty := -1
+		for i := range splits {
+			splitRunes := []rune(splits[i])
+			clusterEnd := 0
+			for clusterEnd < len(splitRunes) &&
+				isSentencePunctuation(splitRunes[clusterEnd]) {
+				clusterEnd++
+			}
+			if lastNonEmpty >= 0 && clusterEnd > 0 {
+				splits[lastNonEmpty] += string(splitRunes[:clusterEnd])
+				splits[i] = string(splitRunes[clusterEnd:])
+			}
+			if splits[i] != "" {
+				lastNonEmpty = i
+			}
+		}
+	}
+
+	var fragments []string
+	for _, split := range splits {
+		if split == "" {
+			continue
+		}
+		splitSize, err := measureTextLength(r.lengthFunc, split)
+		if err != nil {
+			return nil, err
+		}
+		if splitSize <= maxSize {
+			fragments = append(fragments, split)
+			continue
+		}
+		refined, err := r.recursiveSplitByLength(
+			split,
+			separators[1:],
+			maxSize,
+		)
+		if err != nil {
+			return nil, err
+		}
+		fragments = append(fragments, refined...)
+	}
+	return fragments, nil
+}
+
+func (r *RecursiveChunking) mergeFragmentsByLength(
+	fragments []string,
+	firstChunkSize int,
+	nextChunkSize int,
+) ([]string, error) {
+	var chunks []string
+	var current string
+
+	flush := func() {
+		content := strings.TrimSpace(current)
+		if content != "" {
+			chunks = append(chunks, content)
+		}
+		current = ""
+	}
+
+	for _, fragment := range fragments {
+		remaining := fragment
+		for remaining != "" {
+			chunkSize := nextChunkSize
+			if len(chunks) == 0 {
+				chunkSize = firstChunkSize
+			}
+			candidate := current + remaining
+			candidateSize, err := measureTextLength(
+				r.lengthFunc,
+				candidate,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if candidateSize <= chunkSize {
+				current = candidate
+				break
+			}
+
+			remainingSize, err := measureTextLength(
+				r.lengthFunc,
+				remaining,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if current != "" && remainingSize <= nextChunkSize {
+				flush()
+				continue
+			}
+
+			lengthFunc := r.lengthFunc
+			if current != "" {
+				currentContent := current
+				firstRune := string([]rune(remaining)[:1])
+				firstSize, err := measureTextLength(
+					r.lengthFunc,
+					currentContent+firstRune,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if firstSize > chunkSize {
+					flush()
+					continue
+				}
+				lengthFunc = func(text string) (int, error) {
+					return measureTextLength(
+						r.lengthFunc,
+						currentContent+text,
+					)
+				}
+			}
+
+			var prefix, rest string
+			if current == "" {
+				prefix, rest, err = splitTextWithBalancedTailByLength(
+					remaining,
+					chunkSize,
+					lengthFunc,
+				)
+			} else {
+				prefix, rest, err = splitTextAtNaturalBoundaryByLength(
+					remaining,
+					chunkSize,
+					lengthFunc,
+				)
+			}
+			if err != nil {
+				return nil, err
+			}
+			if prefix == "" {
+				return nil, fmt.Errorf(
+					"unable to split recursive fragment within chunk size %d",
+					chunkSize,
+				)
+			}
+			current += prefix
+			remaining = rest
+			if remaining != "" {
+				flush()
+			}
+		}
+	}
+	flush()
+	return chunks, nil
+}
+
+func (r *RecursiveChunking) applyOverlapByLength(
+	content string,
+	chunks []*document.Document,
+) ([]*document.Document, error) {
+	if len(chunks) <= 1 {
+		return chunks, nil
+	}
+	rawContents := make([]string, len(chunks))
+	for i, chunk := range chunks {
+		rawContents[i] = chunk.Content
+	}
+	separators := sourceChunkSeparators(content, rawContents, " ")
+	overlappedChunks := []*document.Document{chunks[0]}
+	for i := 1; i < len(chunks); i++ {
+		metadata := make(map[string]any)
+		for key, value := range chunks[i].Metadata {
+			metadata[key] = value
+		}
+		overlappedContent, actualOverlap, err :=
+			joinWithOverlapSeparatorByLength(
+				overlappedChunks[len(overlappedChunks)-1].Content,
+				chunks[i].Content,
+				r.overlap,
+				r.chunkSize,
+				separators[i],
+				false,
+				r.lengthFunc,
+			)
+		if err != nil {
+			return nil, err
+		}
+		if actualOverlap > 0 {
+			metadata[source.MetaOverlappedContentSize] =
+				encoding.RuneCount(overlappedContent)
+		}
+		overlappedChunks = append(
+			overlappedChunks,
+			&document.Document{
+				ID:        chunks[i].ID,
+				Name:      chunks[i].Name,
+				Content:   overlappedContent,
+				Metadata:  metadata,
+				CreatedAt: chunks[i].CreatedAt,
+				UpdatedAt: chunks[i].UpdatedAt,
+			},
+		)
+	}
+	return overlappedChunks, nil
 }
 
 // recursiveSplit is the core recursive function that splits text using separator hierarchy.

--- a/knowledge/chunking/recursive_test.go
+++ b/knowledge/chunking/recursive_test.go
@@ -420,3 +420,139 @@ func TestRecursiveChunking_ConfigValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestRecursiveChunking_CustomLengthFunc(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return 2 * utf8.RuneCountInString(text), nil
+	}
+	const (
+		chunkSize = 8
+		overlap   = 2
+	)
+	chunker := NewRecursiveChunking(
+		WithRecursiveChunkSize(chunkSize),
+		WithRecursiveOverlap(overlap),
+		WithRecursiveSeparators([]string{""}),
+		WithRecursiveLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "custom-length",
+		Content: "甲乙丙丁戊己庚辛",
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1)
+	for i, chunk := range chunks {
+		size, err := lengthFunc(chunk.Content)
+		require.NoError(t, err)
+		require.LessOrEqual(t, size, chunkSize,
+			"chunk %d exceeds the custom length budget", i)
+	}
+}
+
+func TestRecursiveChunking_CustomLengthFuncMeasuresWholeCandidate(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		if text == "ab" {
+			return 1, nil
+		}
+		return utf8.RuneCountInString(text), nil
+	}
+	chunker := NewRecursiveChunking(
+		WithRecursiveChunkSize(1),
+		WithRecursiveSeparators([]string{""}),
+		WithRecursiveLengthFunc(lengthFunc),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "whole-candidate",
+		Content: "abc",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"ab", "c"}, []string{
+		chunks[0].Content,
+		chunks[1].Content,
+	})
+}
+
+func TestRecursiveChunking_CustomLengthFuncError(t *testing.T) {
+	wantErr := errors.New("length failed")
+	chunker := NewRecursiveChunking(
+		WithRecursiveChunkSize(4),
+		WithRecursiveLengthFunc(func(string) (int, error) {
+			return 0, wantErr
+		}),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "length-error",
+		Content: "content",
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, chunks)
+}
+
+func TestRecursiveChunking_CustomLengthRejectsIndivisibleRune(t *testing.T) {
+	chunker := NewRecursiveChunking(
+		WithRecursiveChunkSize(1),
+		WithRecursiveSeparators([]string{""}),
+		WithRecursiveLengthFunc(func(text string) (int, error) {
+			return 2 * utf8.RuneCountInString(text), nil
+		}),
+	)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "indivisible",
+		Content: "甲",
+	})
+
+	require.ErrorContains(t, err, "indivisible rune")
+	require.Nil(t, chunks)
+}
+
+func TestRecursiveChunking_CustomRuneLengthMatchesDefault(t *testing.T) {
+	content := "Alpha beta gamma. Delta epsilon zeta. " +
+		"中文句子一。中文句子二？！ Final sentence."
+	doc := &document.Document{ID: "recursive-rune-parity", Content: content}
+	defaultChunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(32),
+		WithRecursiveOverlap(6),
+	).Chunk(doc)
+	require.NoError(t, err)
+	customChunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(32),
+		WithRecursiveOverlap(6),
+		WithRecursiveLengthFunc(func(text string) (int, error) {
+			return utf8.RuneCountInString(text), nil
+		}),
+	).Chunk(doc)
+	require.NoError(t, err)
+
+	require.Equal(t, documentContents(defaultChunks),
+		documentContents(customChunks))
+}
+
+func TestRecursiveChunking_CustomLengthFillsCurrentBudget(t *testing.T) {
+	chunker := NewRecursiveChunking(
+		WithRecursiveChunkSize(8),
+		WithRecursiveSeparators([]string{"|", ""}),
+		WithRecursiveLengthFunc(func(text string) (int, error) {
+			return utf8.RuneCountInString(text), nil
+		}),
+	)
+	content := "abc|" + strings.Repeat("x", 12)
+
+	chunks, err := chunker.Chunk(&document.Document{
+		ID:      "fill-current-budget",
+		Content: content,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []int{8, 8}, []int{
+		utf8.RuneCountInString(chunks[0].Content),
+		utf8.RuneCountInString(chunks[1].Content),
+	})
+	require.Equal(t, content, chunks[0].Content+chunks[1].Content)
+}

--- a/knowledge/document/reader/csv/csv_reader.go
+++ b/knowledge/document/reader/csv/csv_reader.go
@@ -57,7 +57,16 @@ func New(opts ...reader.Option) reader.Reader {
 	}
 
 	// Build chunking strategy using the default builder for CSV
-	strategy := reader.BuildChunkingStrategy(config, buildDefaultChunkingStrategy)
+	strategy := reader.BuildChunkingStrategy(
+		config,
+		func(chunkSize, overlap int) chunking.Strategy {
+			return buildDefaultChunkingStrategyWithLength(
+				chunkSize,
+				overlap,
+				config.ChunkLengthFunc,
+			)
+		},
+	)
 
 	// Create reader from config
 	return &Reader{
@@ -71,12 +80,27 @@ func New(opts ...reader.Option) reader.Reader {
 // Newlines keep complete records together whenever one record fits the budget.
 // Oversized records are refined by natural text boundaries.
 func buildDefaultChunkingStrategy(chunkSize, overlap int) chunking.Strategy {
+	return buildDefaultChunkingStrategyWithLength(
+		chunkSize,
+		overlap,
+		nil,
+	)
+}
+
+func buildDefaultChunkingStrategyWithLength(
+	chunkSize int,
+	overlap int,
+	lengthFunc func(string) (int, error),
+) chunking.Strategy {
 	opts := []chunking.Option{chunking.WithPreserveLines()}
 	if chunkSize != 0 {
 		opts = append(opts, chunking.WithChunkSize(chunkSize))
 	}
 	if overlap != 0 {
 		opts = append(opts, chunking.WithOverlap(overlap))
+	}
+	if lengthFunc != nil {
+		opts = append(opts, chunking.WithLengthFunc(lengthFunc))
 	}
 	return chunking.NewFixedSizeChunking(opts...)
 }

--- a/knowledge/document/reader/docx/docx_reader.go
+++ b/knowledge/document/reader/docx/docx_reader.go
@@ -57,7 +57,16 @@ func New(opts ...reader.Option) reader.Reader {
 	}
 
 	// Build chunking strategy using the default builder for DOCX
-	strategy := reader.BuildChunkingStrategy(config, buildDefaultChunkingStrategy)
+	strategy := reader.BuildChunkingStrategy(
+		config,
+		func(chunkSize, overlap int) chunking.Strategy {
+			return buildDefaultChunkingStrategyWithLength(
+				chunkSize,
+				overlap,
+				config.ChunkLengthFunc,
+			)
+		},
+	)
 
 	// Create reader from config
 	return &Reader{
@@ -70,12 +79,27 @@ func New(opts ...reader.Option) reader.Reader {
 // buildDefaultChunkingStrategy builds the default chunking strategy for DOCX reader.
 // DOCX uses FixedSizeChunking with configurable size and overlap.
 func buildDefaultChunkingStrategy(chunkSize, overlap int) chunking.Strategy {
+	return buildDefaultChunkingStrategyWithLength(
+		chunkSize,
+		overlap,
+		nil,
+	)
+}
+
+func buildDefaultChunkingStrategyWithLength(
+	chunkSize int,
+	overlap int,
+	lengthFunc func(string) (int, error),
+) chunking.Strategy {
 	var opts []chunking.Option
 	if chunkSize != 0 {
 		opts = append(opts, chunking.WithChunkSize(chunkSize))
 	}
 	if overlap != 0 {
 		opts = append(opts, chunking.WithOverlap(overlap))
+	}
+	if lengthFunc != nil {
+		opts = append(opts, chunking.WithLengthFunc(lengthFunc))
 	}
 	return chunking.NewFixedSizeChunking(opts...)
 }

--- a/knowledge/document/reader/markdown/markdown_reader.go
+++ b/knowledge/document/reader/markdown/markdown_reader.go
@@ -56,7 +56,16 @@ func New(opts ...reader.Option) reader.Reader {
 	}
 
 	// Build chunking strategy using the default builder for markdown
-	strategy := reader.BuildChunkingStrategy(config, buildDefaultChunkingStrategy)
+	strategy := reader.BuildChunkingStrategy(
+		config,
+		func(chunkSize, overlap int) chunking.Strategy {
+			return buildDefaultChunkingStrategyWithLength(
+				chunkSize,
+				overlap,
+				config.ChunkLengthFunc,
+			)
+		},
+	)
 
 	// Create reader from config
 	return &Reader{
@@ -69,12 +78,30 @@ func New(opts ...reader.Option) reader.Reader {
 // buildDefaultChunkingStrategy builds the default chunking strategy for markdown reader.
 // Markdown uses MarkdownChunking with configurable chunk size and overlap.
 func buildDefaultChunkingStrategy(chunkSize, overlap int) chunking.Strategy {
+	return buildDefaultChunkingStrategyWithLength(
+		chunkSize,
+		overlap,
+		nil,
+	)
+}
+
+func buildDefaultChunkingStrategyWithLength(
+	chunkSize int,
+	overlap int,
+	lengthFunc func(string) (int, error),
+) chunking.Strategy {
 	var opts []chunking.MarkdownOption
 	if chunkSize != 0 {
 		opts = append(opts, chunking.WithMarkdownChunkSize(chunkSize))
 	}
 	if overlap != 0 {
 		opts = append(opts, chunking.WithMarkdownOverlap(overlap))
+	}
+	if lengthFunc != nil {
+		opts = append(
+			opts,
+			chunking.WithMarkdownLengthFunc(lengthFunc),
+		)
 	}
 	return chunking.NewMarkdownChunking(opts...)
 }

--- a/knowledge/document/reader/markdown/markdown_reader_test.go
+++ b/knowledge/document/reader/markdown/markdown_reader_test.go
@@ -16,9 +16,11 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/transform"
 )
 
@@ -110,6 +112,49 @@ func TestMarkdownReader_WithTransformers(t *testing.T) {
 	// Expect "# TitleContent" because newline is removed
 	if docs[0].Content != "# TitleContent" {
 		t.Errorf("expected '# TitleContent', got '%s'", docs[0].Content)
+	}
+}
+
+func TestMarkdownReader_WithChunkLengthFunc(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return 2 * utf8.RuneCountInString(text), nil
+	}
+	const chunkSize = 60
+	rdr := New(
+		reader.WithChunkSize(chunkSize),
+		reader.WithChunkOverlap(10),
+		reader.WithChunkLengthFunc(lengthFunc),
+	)
+	content := "# Root\n\n## Section\n\n" +
+		strings.Repeat("Token-aware markdown content. ", 12)
+
+	docs, err := rdr.ReadFromReader(
+		"token-aware.md",
+		strings.NewReader(content),
+	)
+
+	if err != nil {
+		t.Fatalf("ReadFromReader() error = %v", err)
+	}
+	if len(docs) <= 1 {
+		t.Fatalf("ReadFromReader() returned %d document, want multiple", len(docs))
+	}
+	foundPath := false
+	for i, doc := range docs {
+		size, err := lengthFunc(doc.Content)
+		if err != nil {
+			t.Fatalf("lengthFunc() error = %v", err)
+		}
+		if size > chunkSize {
+			t.Fatalf("document %d size = %d, exceeds %d", i, size, chunkSize)
+		}
+		if doc.Metadata[source.MetaMarkdownHeaderPath] ==
+			"Root > Section" {
+			foundPath = true
+		}
+	}
+	if !foundPath {
+		t.Fatal("Markdown header path was not preserved")
 	}
 }
 

--- a/knowledge/document/reader/pdf/pdf_reader.go
+++ b/knowledge/document/reader/pdf/pdf_reader.go
@@ -65,7 +65,16 @@ func New(opts ...reader.Option) reader.Reader {
 	}
 
 	// Build chunking strategy using the default builder for PDF
-	strategy := reader.BuildChunkingStrategy(config, buildDefaultChunkingStrategy)
+	strategy := reader.BuildChunkingStrategy(
+		config,
+		func(chunkSize, overlap int) chunking.Strategy {
+			return buildDefaultChunkingStrategyWithLength(
+				chunkSize,
+				overlap,
+				config.ChunkLengthFunc,
+			)
+		},
+	)
 
 	// Create reader from config
 	return &Reader{
@@ -79,12 +88,27 @@ func New(opts ...reader.Option) reader.Reader {
 // buildDefaultChunkingStrategy builds the default chunking strategy for PDF reader.
 // PDF uses FixedSizeChunking with configurable size and overlap.
 func buildDefaultChunkingStrategy(chunkSize, overlap int) chunking.Strategy {
+	return buildDefaultChunkingStrategyWithLength(
+		chunkSize,
+		overlap,
+		nil,
+	)
+}
+
+func buildDefaultChunkingStrategyWithLength(
+	chunkSize int,
+	overlap int,
+	lengthFunc func(string) (int, error),
+) chunking.Strategy {
 	var opts []chunking.Option
 	if chunkSize != 0 {
 		opts = append(opts, chunking.WithChunkSize(chunkSize))
 	}
 	if overlap != 0 {
 		opts = append(opts, chunking.WithOverlap(overlap))
+	}
+	if lengthFunc != nil {
+		opts = append(opts, chunking.WithLengthFunc(lengthFunc))
 	}
 	return chunking.NewFixedSizeChunking(opts...)
 }

--- a/knowledge/document/reader/reader.go
+++ b/knowledge/document/reader/reader.go
@@ -25,6 +25,7 @@ type Config struct {
 	Chunk                  bool
 	ChunkSize              int
 	ChunkOverlap           int
+	ChunkLengthFunc        func(string) (int, error)
 	CustomChunkingStrategy chunking.Strategy
 	OCRExtractor           ocr.Extractor
 	Transformers           []transform.Transformer
@@ -54,6 +55,19 @@ func WithChunkSize(size int) Option {
 func WithChunkOverlap(overlap int) Option {
 	return func(c *Config) {
 		c.ChunkOverlap = overlap
+		c.Chunk = true
+	}
+}
+
+// WithChunkLengthFunc sets the function used by supported default chunking
+// strategies to measure chunk size and overlap. By default, text strategies
+// measure Unicode runes. The function must return a deterministic,
+// non-negative length that broadly grows with its input.
+func WithChunkLengthFunc(
+	lengthFunc func(string) (int, error),
+) Option {
+	return func(c *Config) {
+		c.ChunkLengthFunc = lengthFunc
 		c.Chunk = true
 	}
 }

--- a/knowledge/document/reader/reader_test.go
+++ b/knowledge/document/reader/reader_test.go
@@ -150,6 +150,26 @@ func TestWithChunkSize(t *testing.T) {
 	}
 }
 
+func TestWithChunkLengthFunc(t *testing.T) {
+	lengthFunc := func(text string) (int, error) {
+		return len(text), nil
+	}
+	config := &Config{}
+
+	WithChunkLengthFunc(lengthFunc)(config)
+
+	if config.ChunkLengthFunc == nil {
+		t.Fatal("WithChunkLengthFunc() did not set the length function")
+	}
+	if got, err := config.ChunkLengthFunc("text"); err != nil || got != 4 {
+		t.Fatalf("configured length function returned (%d, %v), want (4, nil)",
+			got, err)
+	}
+	if !config.Chunk {
+		t.Fatal("WithChunkLengthFunc() should enable chunking")
+	}
+}
+
 func TestWithChunkOverlap(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/knowledge/document/reader/text/text_reader.go
+++ b/knowledge/document/reader/text/text_reader.go
@@ -56,7 +56,16 @@ func New(opts ...reader.Option) reader.Reader {
 	}
 
 	// Build chunking strategy using the default builder for text
-	strategy := reader.BuildChunkingStrategy(config, buildDefaultChunkingStrategy)
+	strategy := reader.BuildChunkingStrategy(
+		config,
+		func(chunkSize, overlap int) chunking.Strategy {
+			return buildDefaultChunkingStrategyWithLength(
+				chunkSize,
+				overlap,
+				config.ChunkLengthFunc,
+			)
+		},
+	)
 
 	// Create reader from config
 	return &Reader{
@@ -69,12 +78,27 @@ func New(opts ...reader.Option) reader.Reader {
 // buildDefaultChunkingStrategy builds the default chunking strategy for text reader.
 // Text uses FixedSizeChunking with configurable size and overlap.
 func buildDefaultChunkingStrategy(chunkSize, overlap int) chunking.Strategy {
+	return buildDefaultChunkingStrategyWithLength(
+		chunkSize,
+		overlap,
+		nil,
+	)
+}
+
+func buildDefaultChunkingStrategyWithLength(
+	chunkSize int,
+	overlap int,
+	lengthFunc func(string) (int, error),
+) chunking.Strategy {
 	var opts []chunking.Option
 	if chunkSize != 0 {
 		opts = append(opts, chunking.WithChunkSize(chunkSize))
 	}
 	if overlap != 0 {
 		opts = append(opts, chunking.WithOverlap(overlap))
+	}
+	if lengthFunc != nil {
+		opts = append(opts, chunking.WithLengthFunc(lengthFunc))
 	}
 	return chunking.NewFixedSizeChunking(opts...)
 }

--- a/knowledge/source/auto/auto_source.go
+++ b/knowledge/source/auto/auto_source.go
@@ -46,6 +46,7 @@ type Source struct {
 	textReader             reader.Reader
 	chunkSize              int
 	chunkOverlap           int
+	chunkLengthFunc        func(string) (int, error)
 	customChunkingStrategy chunking.Strategy
 	ocrExtractor           ocr.Extractor
 	transformers           []transform.Transformer
@@ -83,6 +84,12 @@ func (s *Source) initializeReaders() {
 	}
 	if s.chunkOverlap != 0 {
 		opts = append(opts, reader.WithChunkOverlap(s.chunkOverlap))
+	}
+	if s.chunkLengthFunc != nil {
+		opts = append(
+			opts,
+			reader.WithChunkLengthFunc(s.chunkLengthFunc),
+		)
 	}
 	if s.customChunkingStrategy != nil {
 		opts = append(opts, reader.WithCustomChunkingStrategy(s.customChunkingStrategy))
@@ -181,8 +188,23 @@ func (s *Source) isFile(input string) bool {
 // processAsURL processes the input as a URL.
 func (s *Source) processAsURL(ctx context.Context, input string) ([]*document.Document, error) {
 	var opts []urlsource.Option
-	opts = append(opts, urlsource.WithChunkSize(s.chunkSize))
-	opts = append(opts, urlsource.WithChunkOverlap(s.chunkOverlap))
+	if s.customChunkingStrategy != nil {
+		opts = append(
+			opts,
+			urlsource.WithCustomChunkingStrategy(
+				s.customChunkingStrategy,
+			),
+		)
+	} else {
+		opts = append(opts, urlsource.WithChunkSize(s.chunkSize))
+		opts = append(opts, urlsource.WithChunkOverlap(s.chunkOverlap))
+		if s.chunkLengthFunc != nil {
+			opts = append(
+				opts,
+				urlsource.WithChunkLengthFunc(s.chunkLengthFunc),
+			)
+		}
+	}
 	if len(s.transformers) > 0 {
 		opts = append(opts, urlsource.WithTransformers(s.transformers...))
 	}
@@ -212,6 +234,12 @@ func (s *Source) processAsDirectory(ctx context.Context, input string) ([]*docum
 		}
 		if s.chunkOverlap != 0 {
 			opts = append(opts, dirsource.WithChunkOverlap(s.chunkOverlap))
+		}
+		if s.chunkLengthFunc != nil {
+			opts = append(
+				opts,
+				dirsource.WithChunkLengthFunc(s.chunkLengthFunc),
+			)
 		}
 	}
 
@@ -246,6 +274,12 @@ func (s *Source) processAsFile(ctx context.Context, input string) ([]*document.D
 		}
 		if s.chunkOverlap != 0 {
 			opts = append(opts, filesource.WithChunkOverlap(s.chunkOverlap))
+		}
+		if s.chunkLengthFunc != nil {
+			opts = append(
+				opts,
+				filesource.WithChunkLengthFunc(s.chunkLengthFunc),
+			)
 		}
 	}
 

--- a/knowledge/source/auto/auto_source_test.go
+++ b/knowledge/source/auto/auto_source_test.go
@@ -11,6 +11,7 @@ package auto
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
@@ -27,9 +29,12 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 )
 
-type mockChunkingStrategy struct{}
+type mockChunkingStrategy struct {
+	called bool
+}
 
 func (m *mockChunkingStrategy) Chunk(doc *document.Document) ([]*document.Document, error) {
+	m.called = true
 	return []*document.Document{doc}, nil
 }
 
@@ -171,6 +176,37 @@ func TestReadDocuments(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("custom-chunk-length-function", func(t *testing.T) {
+		const chunkSize = 20
+		lengthFunc := func(text string) (int, error) {
+			return 2 * utf8.RuneCountInString(text), nil
+		}
+		src := New(
+			[]string{input},
+			WithChunkSize(chunkSize),
+			WithChunkLengthFunc(lengthFunc),
+		)
+
+		docs, err := src.ReadDocuments(ctx)
+
+		if err != nil {
+			t.Fatalf("ReadDocuments returned error: %v", err)
+		}
+		if len(docs) <= 1 {
+			t.Fatalf("expected multiple chunks, got %d", len(docs))
+		}
+		for i, doc := range docs {
+			size, err := lengthFunc(doc.Content)
+			if err != nil {
+				t.Fatalf("length function returned error: %v", err)
+			}
+			if size > chunkSize {
+				t.Fatalf("chunk %d size %d exceeds expected max %d",
+					i, size, chunkSize)
+			}
+		}
+	})
 }
 
 // TestProcessAsURLError verifies error handling in processAsURL.
@@ -187,6 +223,33 @@ func TestProcessAsURLError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error from failed URL processing")
 	}
+}
+
+func TestProcessAsURLWithCustomChunking(t *testing.T) {
+	ctx := context.Background()
+	ts := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		_ *http.Request,
+	) {
+		_, _ = w.Write([]byte("custom strategy content"))
+	}))
+	defer ts.Close()
+
+	strategy := &mockChunkingStrategy{}
+	src := New(
+		[]string{},
+		WithCustomChunkingStrategy(strategy),
+		WithChunkSize(1),
+		WithChunkLengthFunc(func(string) (int, error) {
+			return 0, errors.New("default length function should not run")
+		}),
+	)
+
+	docs, err := src.processAsURL(ctx, ts.URL)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, docs)
+	require.True(t, strategy.called)
 }
 
 // TestProcessAsDirectoryError verifies error handling in processAsDirectory.

--- a/knowledge/source/auto/options.go
+++ b/knowledge/source/auto/options.go
@@ -56,16 +56,28 @@ func WithCustomChunkingStrategy(strategy chunking.Strategy) Option {
 }
 
 // WithChunkSize sets the chunk size for the reader's default chunking strategy.
+// The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkSize(size int) Option {
 	return func(s *Source) {
 		s.chunkSize = size
 	}
 }
 
-// WithChunkOverlap sets the chunk overlap for the reader's default chunking strategy.
+// WithChunkOverlap sets the chunk overlap for the reader's default chunking
+// strategy. The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkOverlap(overlap int) Option {
 	return func(s *Source) {
 		s.chunkOverlap = overlap
+	}
+}
+
+// WithChunkLengthFunc sets the function used by supported default chunking
+// strategies to measure chunk size and overlap.
+func WithChunkLengthFunc(
+	lengthFunc func(string) (int, error),
+) Option {
+	return func(s *Source) {
+		s.chunkLengthFunc = lengthFunc
 	}
 }
 

--- a/knowledge/source/dir/dir_source.go
+++ b/knowledge/source/dir/dir_source.go
@@ -42,6 +42,7 @@ type Source struct {
 	recursive              bool     // Whether to process subdirectories
 	chunkSize              int
 	chunkOverlap           int
+	chunkLengthFunc        func(string) (int, error)
 	customChunkingStrategy chunking.Strategy
 	ocrExtractor           ocr.Extractor
 	transformers           []transform.Transformer
@@ -80,6 +81,12 @@ func (s *Source) initializeReaders() {
 	}
 	if s.chunkOverlap != 0 {
 		readerOpts = append(readerOpts, isource.WithChunkOverlap(s.chunkOverlap))
+	}
+	if s.chunkLengthFunc != nil {
+		readerOpts = append(
+			readerOpts,
+			isource.WithChunkLengthFunc(s.chunkLengthFunc),
+		)
 	}
 	if s.customChunkingStrategy != nil {
 		readerOpts = append(readerOpts, isource.WithCustomChunkingStrategy(s.customChunkingStrategy))

--- a/knowledge/source/dir/options.go
+++ b/knowledge/source/dir/options.go
@@ -71,16 +71,28 @@ func WithCustomChunkingStrategy(strategy chunking.Strategy) Option {
 }
 
 // WithChunkSize sets the chunk size for the reader's default chunking strategy.
+// The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkSize(size int) Option {
 	return func(s *Source) {
 		s.chunkSize = size
 	}
 }
 
-// WithChunkOverlap sets the chunk overlap for the reader's default chunking strategy.
+// WithChunkOverlap sets the chunk overlap for the reader's default chunking
+// strategy. The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkOverlap(overlap int) Option {
 	return func(s *Source) {
 		s.chunkOverlap = overlap
+	}
+}
+
+// WithChunkLengthFunc sets the function used by supported default chunking
+// strategies to measure chunk size and overlap.
+func WithChunkLengthFunc(
+	lengthFunc func(string) (int, error),
+) Option {
+	return func(s *Source) {
+		s.chunkLengthFunc = lengthFunc
 	}
 }
 

--- a/knowledge/source/file/file_source.go
+++ b/knowledge/source/file/file_source.go
@@ -40,6 +40,7 @@ type Source struct {
 	readers                map[string]reader.Reader
 	chunkSize              int
 	chunkOverlap           int
+	chunkLengthFunc        func(string) (int, error)
 	customChunkingStrategy chunking.Strategy
 	ocrExtractor           ocr.Extractor
 	transformers           []transform.Transformer
@@ -69,6 +70,12 @@ func New(filePaths []string, opts ...Option) *Source {
 	}
 	if s.chunkOverlap != 0 {
 		readerOpts = append(readerOpts, isource.WithChunkOverlap(s.chunkOverlap))
+	}
+	if s.chunkLengthFunc != nil {
+		readerOpts = append(
+			readerOpts,
+			isource.WithChunkLengthFunc(s.chunkLengthFunc),
+		)
 	}
 	if s.customChunkingStrategy != nil {
 		readerOpts = append(readerOpts, isource.WithCustomChunkingStrategy(s.customChunkingStrategy))

--- a/knowledge/source/file/file_source_test.go
+++ b/knowledge/source/file/file_source_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
@@ -178,6 +179,41 @@ func TestReadDocuments(t *testing.T) {
 		_, err := src.ReadDocuments(ctx)
 		if !errors.Is(err, chunking.ErrInvalidOverlap) {
 			t.Fatalf("ReadDocuments() error = %v, want %v", err, chunking.ErrInvalidOverlap)
+		}
+	})
+
+	t.Run("custom-chunk-length-function", func(t *testing.T) {
+		const (
+			chunkSize = 20
+			overlap   = 4
+		)
+		lengthFunc := func(text string) (int, error) {
+			return 2 * utf8.RuneCountInString(text), nil
+		}
+		src := New(
+			[]string{filePath},
+			WithChunkSize(chunkSize),
+			WithChunkOverlap(overlap),
+			WithChunkLengthFunc(lengthFunc),
+		)
+
+		docs, err := src.ReadDocuments(ctx)
+
+		if err != nil {
+			t.Fatalf("ReadDocuments returned error: %v", err)
+		}
+		if len(docs) <= 1 {
+			t.Fatalf("expected multiple chunks, got %d", len(docs))
+		}
+		for i, doc := range docs {
+			size, err := lengthFunc(doc.Content)
+			if err != nil {
+				t.Fatalf("length function returned error: %v", err)
+			}
+			if size > chunkSize {
+				t.Fatalf("chunk %d size %d exceeds expected max %d",
+					i, size, chunkSize)
+			}
 		}
 	})
 }

--- a/knowledge/source/file/options.go
+++ b/knowledge/source/file/options.go
@@ -61,17 +61,28 @@ func WithCustomChunkingStrategy(strategy chunking.Strategy) Option {
 }
 
 // WithChunkSize sets the chunk size for the reader's default chunking strategy.
-// Each reader will use its own optimal chunking strategy with this size parameter.
+// The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkSize(size int) Option {
 	return func(s *Source) {
 		s.chunkSize = size
 	}
 }
 
-// WithChunkOverlap sets the chunk overlap for the reader's default chunking strategy.
+// WithChunkOverlap sets the chunk overlap for the reader's default chunking
+// strategy. The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkOverlap(overlap int) Option {
 	return func(s *Source) {
 		s.chunkOverlap = overlap
+	}
+}
+
+// WithChunkLengthFunc sets the function used by supported default chunking
+// strategies to measure chunk size and overlap.
+func WithChunkLengthFunc(
+	lengthFunc func(string) (int, error),
+) Option {
+	return func(s *Source) {
+		s.chunkLengthFunc = lengthFunc
 	}
 }
 

--- a/knowledge/source/internal/source/source.go
+++ b/knowledge/source/internal/source/source.go
@@ -37,6 +37,7 @@ var (
 type ReaderConfig struct {
 	chunkSize              int
 	chunkOverlap           int
+	chunkLengthFunc        func(string) (int, error)
 	customChunkingStrategy chunking.Strategy
 	ocrExtractor           ocr.Extractor
 	transformers           []transform.Transformer
@@ -56,6 +57,15 @@ func WithChunkSize(size int) ReaderOption {
 func WithChunkOverlap(overlap int) ReaderOption {
 	return func(c *ReaderConfig) {
 		c.chunkOverlap = overlap
+	}
+}
+
+// WithChunkLengthFunc sets the chunk length function for readers.
+func WithChunkLengthFunc(
+	lengthFunc func(string) (int, error),
+) ReaderOption {
+	return func(c *ReaderConfig) {
+		c.chunkLengthFunc = lengthFunc
 	}
 }
 
@@ -104,6 +114,12 @@ func buildReaderOptions(config *ReaderConfig) []reader.Option {
 	}
 	if config.chunkOverlap != 0 {
 		opts = append(opts, reader.WithChunkOverlap(config.chunkOverlap))
+	}
+	if config.chunkLengthFunc != nil {
+		opts = append(
+			opts,
+			reader.WithChunkLengthFunc(config.chunkLengthFunc),
+		)
 	}
 	if config.customChunkingStrategy != nil {
 		opts = append(opts, reader.WithCustomChunkingStrategy(config.customChunkingStrategy))

--- a/knowledge/source/url/options.go
+++ b/knowledge/source/url/options.go
@@ -75,16 +75,28 @@ func WithCustomChunkingStrategy(strategy chunking.Strategy) Option {
 }
 
 // WithChunkSize sets the chunk size for the reader's default chunking strategy.
+// The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkSize(size int) Option {
 	return func(s *Source) {
 		s.chunkSize = size
 	}
 }
 
-// WithChunkOverlap sets the chunk overlap for the reader's default chunking strategy.
+// WithChunkOverlap sets the chunk overlap for the reader's default chunking
+// strategy. The unit is Unicode runes unless WithChunkLengthFunc is configured.
 func WithChunkOverlap(overlap int) Option {
 	return func(s *Source) {
 		s.chunkOverlap = overlap
+	}
+}
+
+// WithChunkLengthFunc sets the function used by supported default chunking
+// strategies to measure chunk size and overlap.
+func WithChunkLengthFunc(
+	lengthFunc func(string) (int, error),
+) Option {
+	return func(s *Source) {
+		s.chunkLengthFunc = lengthFunc
 	}
 }
 

--- a/knowledge/source/url/url_source.go
+++ b/knowledge/source/url/url_source.go
@@ -45,6 +45,7 @@ type Source struct {
 	httpClient             *http.Client
 	chunkSize              int
 	chunkOverlap           int
+	chunkLengthFunc        func(string) (int, error)
 	customChunkingStrategy chunking.Strategy
 	transformers           []transform.Transformer
 	fileReaderType         source.FileReaderType
@@ -74,6 +75,12 @@ func New(urls []string, opts ...Option) *Source {
 	}
 	if s.chunkOverlap != 0 {
 		readerOpts = append(readerOpts, isource.WithChunkOverlap(s.chunkOverlap))
+	}
+	if s.chunkLengthFunc != nil {
+		readerOpts = append(
+			readerOpts,
+			isource.WithChunkLengthFunc(s.chunkLengthFunc),
+		)
 	}
 	if s.customChunkingStrategy != nil {
 		readerOpts = append(readerOpts, isource.WithCustomChunkingStrategy(s.customChunkingStrategy))

--- a/model/tiktoken/tiktoken.go
+++ b/model/tiktoken/tiktoken.go
@@ -46,6 +46,16 @@ func New(modelName string) (*Counter, error) {
 	return &Counter{encoding: enc}, nil
 }
 
+// CountText returns the token count for plain text using the configured
+// tokenizer.
+func (c *Counter) CountText(text string) (int, error) {
+	count, err := c.encoding.Count(text)
+	if err != nil {
+		return 0, fmt.Errorf("count text tokens failed: %w", err)
+	}
+	return count, nil
+}
+
 // CountTokens returns the token count for a single message using tiktoken-go.
 // It encodes Message.Content, Message.ReasoningContent, text ContentParts, and ToolCalls.
 func (c *Counter) CountTokens(_ context.Context, message model.Message) (int, error) {

--- a/model/tiktoken/tiktoken_test.go
+++ b/model/tiktoken/tiktoken_test.go
@@ -70,6 +70,57 @@ func TestTiktokenCounter_CountTokens(t *testing.T) {
 	require.Greater(t, used, 0)
 }
 
+func TestTiktokenCounter_CountText(t *testing.T) {
+	counter := &Counter{encoding: &mockCodec{}}
+
+	used, err := counter.CountText("plain text")
+
+	require.NoError(t, err)
+	require.Equal(t, len("plain text"), used)
+}
+
+func TestTiktokenCounter_CountTextWithTokenizer(t *testing.T) {
+	counter, err := New("gpt-4o")
+	if err != nil {
+		t.Skip("tiktoken-go not available: ", err)
+	}
+
+	used, err := counter.CountText("English and 中文")
+
+	require.NoError(t, err)
+	require.Greater(t, used, 0)
+}
+
+func TestTiktokenCounter_CountTextMatchesMessageContent(t *testing.T) {
+	counter, err := New("text-embedding-3-small")
+	if err != nil {
+		t.Skip("tiktoken-go not available: ", err)
+	}
+	for _, text := range []string{
+		"plain English text",
+		"English 与中文混合 🚀",
+		"12.6, 2.8.12, v1.2.3, ？！",
+	} {
+		textCount, err := counter.CountText(text)
+		require.NoError(t, err)
+		messageCount, err := counter.CountTokens(
+			context.Background(),
+			model.Message{Content: text},
+		)
+		require.NoError(t, err)
+		require.Equal(t, messageCount, textCount, text)
+	}
+}
+
+func TestTiktokenCounter_CountTextError(t *testing.T) {
+	counter := &Counter{encoding: &mockCodec{shouldFail: true}}
+
+	used, err := counter.CountText("plain text")
+
+	require.ErrorContains(t, err, "count text tokens failed")
+	require.Zero(t, used)
+}
+
 func TestTiktokenCounter_ModelFallback(t *testing.T) {
 	counter, err := New("unknown-model-name-xyz")
 	if err != nil {


### PR DESCRIPTION
## Summary

- allow `FixedSizeChunking`, `RecursiveChunking`, and `MarkdownChunking` to measure `chunkSize` and `overlap` with a custom length function while preserving Unicode-rune defaults
- propagate token-aware sizing through Reader, FileSource, DirSource, URLSource, and AutoSource without replacing each format's default chunking strategy
- expose `tiktoken.Counter.CountText` and add an offline Markdown example using the tokenizer for `text-embedding-3-small`
- preserve Markdown semantic packing, heading paths, tail rebalancing, natural boundaries, and strict final overlap budgets

## Behavior and scope

The text chunkers remeasure complete candidates, including separators and overlap, before emitting a chunk. Candidate selection is bounded so long documents do not repeatedly tokenize the complete remaining suffix, and it handles local BPE prefix non-monotonicity without relying on binary search.

The configured budget applies to the chunker's output `Document.Content`. Reader postprocessing and knowledge embedding metadata may add content later, so applications should reserve margin for those steps.

`MetaChunkSize` and `MetaOverlappedContentSize` remain Unicode-rune counts for compatibility. JSON chunking continues to use serialized bytes, and AST-based code readers keep their structural behavior.

## Validation

- `go test ./knowledge/... -count=1`
- `go test -race ./knowledge/chunking ./knowledge/document/reader/csv ./knowledge/document/reader/markdown ./knowledge/document/reader/text ./knowledge/source/file ./knowledge/source/auto -count=1`
- `go vet ./knowledge/chunking ./knowledge/document/reader/... ./knowledge/source/...`
- `golangci-lint run --timeout=10m ./knowledge/chunking/... ./knowledge/document/reader/... ./knowledge/source/...`
- `go test -race ./... -count=1`, `go vet ./...`, and `golangci-lint run --timeout=10m ./...` in `model/tiktoken`
- `go build ./sources/token-aware-chunking` and `go run ./sources/token-aware-chunking` in `examples/knowledge`
- `mkdocs build --strict`
- `bash .github/scripts/check-file-size.sh`

Related to #2200.
