### PR TITLE
session/pgvector: remove localtime dependency from TTL checks

### DIFF
--- a/session/pgvector/search.go
+++ b/session/pgvector/search.go
@@ -250,7 +250,10 @@ func (s *Service) buildSearchEventsSQL(
 	vector pgvector.Vector,
 	topK int,
 ) (string, []any) {
-	args := []any{vector, req.UserKey.AppName, req.UserKey.UserID}
+	args := []any{
+		vector, req.UserKey.AppName, req.UserKey.UserID,
+		time.Now(),
+	}
 	placeholder := func(v any) string {
 		args = append(args, v)
 		return fmt.Sprintf("$%d", len(args))
@@ -265,13 +268,13 @@ func (s *Service) buildSearchEventsSQL(
 		`ON ss.app_name = se.app_name`,
 		`AND ss.user_id = se.user_id`,
 		`AND ss.session_id = se.session_id`,
-		`AND (ss.expires_at IS NULL OR ss.expires_at > NOW() AT TIME ZONE 'localtime')`,
+		`AND (ss.expires_at IS NULL OR ss.expires_at > $4)`,
 		`AND ss.deleted_at IS NULL`,
 		`WHERE se.app_name = $2`,
 		`AND se.user_id = $3`,
 		`AND se.embedding IS NOT NULL`,
 		`AND se.deleted_at IS NULL`,
-		`AND (se.expires_at IS NULL OR se.expires_at > NOW() AT TIME ZONE 'localtime')`,
+		`AND (se.expires_at IS NULL OR se.expires_at > $4)`,
 	}
 	parts = appendSearchEventFilters(
 		parts,
@@ -291,7 +294,10 @@ func (s *Service) buildKeywordSearchEventsSQL(
 	query string,
 	topK int,
 ) (string, []any) {
-	args := []any{query, req.UserKey.AppName, req.UserKey.UserID}
+	args := []any{
+		query, req.UserKey.AppName, req.UserKey.UserID,
+		time.Now(),
+	}
 	placeholder := func(v any) string {
 		args = append(args, v)
 		return fmt.Sprintf("$%d", len(args))
@@ -306,12 +312,12 @@ func (s *Service) buildKeywordSearchEventsSQL(
 		`ON ss.app_name = se.app_name`,
 		`AND ss.user_id = se.user_id`,
 		`AND ss.session_id = se.session_id`,
-		`AND (ss.expires_at IS NULL OR ss.expires_at > NOW() AT TIME ZONE 'localtime')`,
+		`AND (ss.expires_at IS NULL OR ss.expires_at > $4)`,
 		`AND ss.deleted_at IS NULL`,
 		`WHERE se.app_name = $2`,
 		`AND se.user_id = $3`,
 		`AND se.deleted_at IS NULL`,
-		`AND (se.expires_at IS NULL OR se.expires_at > NOW() AT TIME ZONE 'localtime')`,
+		`AND (se.expires_at IS NULL OR se.expires_at > $4)`,
 		`AND se.search_vector @@ plainto_tsquery('english', $1)`,
 	}
 	parts = appendSearchEventFilters(

--- a/session/pgvector/search_test.go
+++ b/session/pgvector/search_test.go
@@ -202,7 +202,7 @@ func TestSearchEvents_Success(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(rows)
 
 	results, err := s.SearchEvents(
@@ -288,10 +288,10 @@ func TestSearchEvents_HybridSuccess(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(denseRows)
 	mock.ExpectQuery(`ts_rank\(se\.search_vector`).
-		WithArgs("hello", "app", "user").
+		WithArgs("hello", "app", "user", timeArg{}).
 		WillReturnRows(keywordRows)
 
 	results, err := s.SearchEvents(
@@ -353,10 +353,10 @@ func TestSearchEvents_HybridKeywordErrorFallsBackToDense(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(denseRows)
 	mock.ExpectQuery(`ts_rank\(se\.search_vector`).
-		WithArgs("hello", "app", "user").
+		WithArgs("hello", "app", "user", timeArg{}).
 		WillReturnError(fmt.Errorf("keyword query failed"))
 
 	results, err := s.SearchEvents(
@@ -412,7 +412,7 @@ func TestSearchEvents_FallbackTextAndRoleFromEvent(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(rows)
 
 	results, err := s.SearchEvents(
@@ -440,7 +440,7 @@ func TestSearchEvents_QueryError(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnError(fmt.Errorf("db connection lost"))
 
 	results, err := s.SearchEvents(
@@ -478,7 +478,7 @@ func TestSearchEvents_InvalidEventJSON(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(rows)
 
 	results, err := s.SearchEvents(
@@ -516,7 +516,7 @@ func TestSearchEvents_ScanError(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(rows)
 
 	results, err := s.SearchEvents(
@@ -549,7 +549,7 @@ func TestSearchEvents_TrimmedQuery(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(rows)
 
 	_, err := s.SearchEvents(
@@ -583,7 +583,7 @@ func TestSearchEvents_UsesEmbedTimeout(t *testing.T) {
 		},
 	)
 	mock.ExpectQuery(`SELECT se\.app_name`).
-		WithArgs(anyVectorArg{}, "app", "user").
+		WithArgs(anyVectorArg{}, "app", "user", timeArg{}).
 		WillReturnRows(rows)
 
 	_, err := s.SearchEvents(
@@ -638,18 +638,23 @@ func TestBuildSearchEventsSQL_Filters(t *testing.T) {
 	assert.Contains(t, sql, "1 - (se.embedding <=> $1) >=")
 	assert.Contains(t, sql, "filterKey")
 	assert.Contains(t, sql, "LIMIT 7")
-	require.Len(t, args, 12)
+	assert.NotContains(t, sql, "localtime")
+	assert.Contains(t, sql, "ss.expires_at > $4")
+	assert.Contains(t, sql, "se.expires_at > $4")
+	require.Len(t, args, 13)
 	assert.Equal(t, "app", args[1])
 	assert.Equal(t, "user", args[2])
-	assert.Equal(t, []string{"sess-1", "sess-2"}, args[3])
-	assert.Equal(t, []string{"sess-3"}, args[4])
-	assert.Equal(t, []string{"assistant"}, args[5])
-	assert.Equal(t, after, args[6])
-	assert.Equal(t, before, args[7])
-	assert.Equal(t, 0.7, args[8])
-	assert.Equal(t, "branch/a", args[9])
-	assert.Equal(t, "branch/a/%", args[10])
-	assert.Equal(t, "branch/a", args[11])
+	_, ok := args[3].(time.Time)
+	require.True(t, ok)
+	assert.Equal(t, []string{"sess-1", "sess-2"}, args[4])
+	assert.Equal(t, []string{"sess-3"}, args[5])
+	assert.Equal(t, []string{"assistant"}, args[6])
+	assert.Equal(t, after, args[7])
+	assert.Equal(t, before, args[8])
+	assert.Equal(t, 0.7, args[9])
+	assert.Equal(t, "branch/a", args[10])
+	assert.Equal(t, "branch/a/%", args[11])
+	assert.Equal(t, "branch/a", args[12])
 }
 
 func TestBuildSearchEventsSQL_DefaultTopKAndTableName(t *testing.T) {
@@ -672,7 +677,9 @@ func TestBuildSearchEventsSQL_DefaultTopKAndTableName(t *testing.T) {
 	assert.Contains(t, sql, "FROM custom_session_events se")
 	assert.Contains(t, sql, "JOIN custom_session_states ss")
 	assert.Contains(t, sql, fmt.Sprintf("LIMIT %d", defaultMaxResults))
-	require.Len(t, args, 3)
+	require.Len(t, args, 4)
+	_, ok := args[3].(time.Time)
+	require.True(t, ok)
 }
 
 func TestBuildKeywordSearchEventsSQL_Filters(t *testing.T) {
@@ -708,18 +715,23 @@ func TestBuildKeywordSearchEventsSQL_Filters(t *testing.T) {
 	assert.Contains(t, sql, "se.created_at <= ")
 	assert.NotContains(t, sql, "embedding <=>")
 	assert.Contains(t, sql, "LIMIT 9")
-	require.Len(t, args, 11)
+	assert.NotContains(t, sql, "localtime")
+	assert.Contains(t, sql, "ss.expires_at > $4")
+	assert.Contains(t, sql, "se.expires_at > $4")
+	require.Len(t, args, 12)
 	assert.Equal(t, "kyoto trip", args[0])
 	assert.Equal(t, "app", args[1])
 	assert.Equal(t, "user", args[2])
-	assert.Equal(t, []string{"sess-1", "sess-2"}, args[3])
-	assert.Equal(t, []string{"sess-3"}, args[4])
-	assert.Equal(t, []string{"assistant"}, args[5])
-	assert.Equal(t, after, args[6])
-	assert.Equal(t, before, args[7])
-	assert.Equal(t, "branch/a", args[8])
-	assert.Equal(t, "branch/a/%", args[9])
-	assert.Equal(t, "branch/a", args[10])
+	_, ok := args[3].(time.Time)
+	require.True(t, ok)
+	assert.Equal(t, []string{"sess-1", "sess-2"}, args[4])
+	assert.Equal(t, []string{"sess-3"}, args[5])
+	assert.Equal(t, []string{"assistant"}, args[6])
+	assert.Equal(t, after, args[7])
+	assert.Equal(t, before, args[8])
+	assert.Equal(t, "branch/a", args[9])
+	assert.Equal(t, "branch/a/%", args[10])
+	assert.Equal(t, "branch/a", args[11])
 }
 
 func TestResolveHybridCandidateLimit(t *testing.T) {

--- a/session/pgvector/service.go
+++ b/session/pgvector/service.go
@@ -567,11 +567,11 @@ func (s *Service) ListAppStates(
 			`SELECT key, value FROM %s
 			WHERE app_name = $1
 			AND (expires_at IS NULL
-				OR expires_at > NOW() AT TIME ZONE 'localtime')
+				OR expires_at > $2)
 			AND deleted_at IS NULL`,
 			s.tableAppStates,
 		),
-		appName,
+		appName, time.Now(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -694,11 +694,11 @@ func (s *Service) ListUserStates(
 			`SELECT key, value FROM %s
 			WHERE app_name = $1 AND user_id = $2
 			AND (expires_at IS NULL
-				OR expires_at > NOW() AT TIME ZONE 'localtime')
+				OR expires_at > $3)
 			AND deleted_at IS NULL`,
 			s.tableUserStates,
 		),
-		userKey.AppName, userKey.UserID,
+		userKey.AppName, userKey.UserID, time.Now(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/session/pgvector/service_helper.go
+++ b/session/pgvector/service_helper.go
@@ -29,21 +29,19 @@ func (s *Service) getSession(
 	afterTime time.Time,
 ) (*session.Session, error) {
 	// Query session state.
-	// Use NOW() AT TIME ZONE 'localtime' to get the server's local
-	// time without timezone, matching the TIMESTAMP column type.
 	var sessState *SessionState
 	stateQuery := fmt.Sprintf(
 		`SELECT state, created_at, updated_at
 		FROM %s
 		WHERE app_name = $1 AND user_id = $2
 		AND session_id = $3
-		AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'localtime')
+		AND (expires_at IS NULL OR expires_at > $4)
 		AND deleted_at IS NULL`,
 		s.tableSessionStates,
 	)
 	stateArgs := []any{
 		key.AppName, key.UserID,
-		key.SessionID,
+		key.SessionID, time.Now(),
 	}
 
 	err := s.pgClient.Query(ctx,
@@ -174,13 +172,13 @@ func (s *Service) listSessions(
 		created_at, updated_at
 		FROM %s
 		WHERE app_name = $1 AND user_id = $2
-		AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'localtime')
+		AND (expires_at IS NULL OR expires_at > $3)
 		AND deleted_at IS NULL
 		ORDER BY updated_at DESC, session_id DESC`,
 		s.tableSessionStates,
 	)
 	listArgs := []any{
-		key.AppName, key.UserID,
+		key.AppName, key.UserID, time.Now(),
 	}
 	if page != nil && page.Limit > 0 {
 		listQuery += fmt.Sprintf(" LIMIT $%d OFFSET $%d", len(listArgs)+1, len(listArgs)+2)
@@ -989,17 +987,17 @@ func (s *Service) getTrackEventsByTrackLists(
 					AND session_id = $3
 					AND track = $4
 					AND (expires_at IS NULL
-						OR expires_at > NOW() AT TIME ZONE 'localtime')
-					AND created_at > $5
+						OR expires_at > $5)
+					AND created_at > $6
 					AND deleted_at IS NULL
 					ORDER BY created_at DESC
-					LIMIT $6`,
+					LIMIT $7`,
 					s.tableSessionTracks,
 				)
 				args = []any{
 					key.AppName, key.UserID,
 					key.SessionID, track,
-					afterTime, limit,
+					time.Now(), afterTime, limit,
 				}
 			} else {
 				q = fmt.Sprintf(
@@ -1009,8 +1007,8 @@ func (s *Service) getTrackEventsByTrackLists(
 					AND session_id = $3
 					AND track = $4
 					AND (expires_at IS NULL
-						OR expires_at > NOW() AT TIME ZONE 'localtime')
-					AND created_at > $5
+						OR expires_at > $5)
+					AND created_at > $6
 					AND deleted_at IS NULL
 					ORDER BY created_at DESC`,
 					s.tableSessionTracks,
@@ -1018,7 +1016,7 @@ func (s *Service) getTrackEventsByTrackLists(
 				args = []any{
 					key.AppName, key.UserID,
 					key.SessionID, track,
-					afterTime,
+					time.Now(), afterTime,
 				}
 			}
 			queries = append(queries, &trackQuery{
@@ -1124,7 +1122,7 @@ func (s *Service) getSummariesList(
 		FROM %s
 		WHERE app_name = $1 AND user_id = $2
 		AND session_id = ANY($3::varchar[])
-		AND (expires_at IS NULL OR expires_at > NOW() AT TIME ZONE 'localtime')
+		AND (expires_at IS NULL OR expires_at > $4)
 		AND deleted_at IS NULL`,
 		summaryColumns,
 		s.tableSessionSummaries,
@@ -1182,6 +1180,7 @@ func (s *Service) getSummariesList(
 		sessionKeys[0].AppName,
 		sessionKeys[0].UserID,
 		sessionIDs,
+		time.Now(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/session/pgvector/service_helper_test.go
+++ b/session/pgvector/service_helper_test.go
@@ -499,6 +499,10 @@ func TestGetSummariesList_Success(t *testing.T) {
 	sumBytes, _ := json.Marshal(sum)
 
 	mock.ExpectQuery("SELECT session_id, filter_key").
+		WithArgs(
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), timeArg{},
+		).
 		WillReturnRows(sqlmock.NewRows(
 			[]string{
 				"session_id", "filter_key", "summary",
@@ -639,7 +643,7 @@ func TestGetSummariesList_QueryError(t *testing.T) {
 	mock.ExpectQuery("SELECT session_id, filter_key").
 		WithArgs(
 			sqlmock.AnyArg(), sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
+			sqlmock.AnyArg(), timeArg{},
 		).
 		WillReturnError(fmt.Errorf("db error"))
 

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -167,6 +167,13 @@ func (a anyVectorArg) Match(_ driver.Value) bool {
 	return true
 }
 
+type timeArg struct{}
+
+func (a timeArg) Match(v driver.Value) bool {
+	_, ok := v.(time.Time)
+	return ok
+}
+
 type utcTimeArg struct{}
 
 func (a utcTimeArg) Match(v driver.Value) bool {
@@ -1237,6 +1244,7 @@ func TestCreateSession_GeneratesSessionID(t *testing.T) {
 
 	// ListAppStates.
 	mock.ExpectQuery("SELECT key, value FROM app_states").
+		WithArgs("app", timeArg{}).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"key", "value"}),
 		)
@@ -1244,9 +1252,10 @@ func TestCreateSession_GeneratesSessionID(t *testing.T) {
 	// ListUserStates.
 	mock.ExpectQuery(
 		"SELECT key, value FROM user_states",
-	).WillReturnRows(
-		sqlmock.NewRows([]string{"key", "value"}),
-	)
+	).WithArgs("app", "user", timeArg{}).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"key", "value"}),
+		)
 
 	sess, err := s.CreateSession(
 		context.Background(), key, nil,
@@ -1277,6 +1286,7 @@ func TestGetSession_NotFound(t *testing.T) {
 
 	// Session state query returns no rows.
 	mock.ExpectQuery("SELECT state, created_at").
+		WithArgs("app", "user", "sess", timeArg{}).
 		WillReturnRows(sqlmock.NewRows(
 			[]string{"state", "created_at", "updated_at"},
 		))
@@ -1298,6 +1308,7 @@ func TestGetSession_QueryError(t *testing.T) {
 	}
 
 	mock.ExpectQuery("SELECT state, created_at").
+		WithArgs("app", "user", "sess", timeArg{}).
 		WillReturnError(fmt.Errorf("db error"))
 
 	_, err := s.GetSession(
@@ -1401,17 +1412,20 @@ func TestListSessions_Empty(t *testing.T) {
 
 	// ListAppStates.
 	mock.ExpectQuery("SELECT key, value FROM app_states").
+		WithArgs("app", timeArg{}).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"key", "value"}),
 		)
 	// ListUserStates.
 	mock.ExpectQuery(
 		"SELECT key, value FROM user_states",
-	).WillReturnRows(
-		sqlmock.NewRows([]string{"key", "value"}),
-	)
+	).WithArgs("app", "user", timeArg{}).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"key", "value"}),
+		)
 	// List session states returns empty.
 	mock.ExpectQuery("SELECT session_id, state").
+		WithArgs("app", "user", timeArg{}).
 		WillReturnRows(sqlmock.NewRows(
 			[]string{
 				"session_id", "state",
@@ -1598,6 +1612,7 @@ func TestListAppStates_Success(t *testing.T) {
 		AddRow("k2", []byte("v2"))
 
 	mock.ExpectQuery("SELECT key, value FROM app_states").
+		WithArgs("app", timeArg{}).
 		WillReturnRows(rows)
 
 	result, err := s.ListAppStates(
@@ -1615,6 +1630,7 @@ func TestListAppStates_QueryError(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectQuery("SELECT key, value FROM app_states").
+		WithArgs("app", timeArg{}).
 		WillReturnError(fmt.Errorf("db error"))
 
 	_, err := s.ListAppStates(
@@ -1766,7 +1782,8 @@ func TestListUserStates_Success(t *testing.T) {
 
 	mock.ExpectQuery(
 		"SELECT key, value FROM user_states",
-	).WillReturnRows(rows)
+	).WithArgs("app", "user", timeArg{}).
+		WillReturnRows(rows)
 
 	result, err := s.ListUserStates(
 		context.Background(),
@@ -1784,7 +1801,8 @@ func TestListUserStates_QueryError(t *testing.T) {
 
 	mock.ExpectQuery(
 		"SELECT key, value FROM user_states",
-	).WillReturnError(fmt.Errorf("db error"))
+	).WithArgs("app", "user", timeArg{}).
+		WillReturnError(fmt.Errorf("db error"))
 
 	_, err := s.ListUserStates(
 		context.Background(),
@@ -4907,7 +4925,7 @@ func TestServiceGetTrackEventsReadsTrackStorage(t *testing.T) {
 	newBytes, err := json.Marshal(newEvent)
 	require.NoError(t, err)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs(key.AppName, key.UserID, key.SessionID, track, base.Add(-time.Minute), 2).
+		WithArgs(key.AppName, key.UserID, key.SessionID, track, timeArg{}, base.Add(-time.Minute), 2).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}).AddRow(newBytes).AddRow(oldBytes))
 	got, err := svc.GetTrackEvents(ctx, key, track, session.WithEventTime(base.Add(-time.Minute)), session.WithEventNum(2))
 	require.NoError(t, err)
@@ -4916,7 +4934,7 @@ func TestServiceGetTrackEventsReadsTrackStorage(t *testing.T) {
 	require.Equal(t, oldEvent.Payload, got.Events[0].Payload)
 	require.Equal(t, newEvent.Payload, got.Events[1].Payload)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("missing"), time.Time{}).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("missing"), timeArg{}, time.Time{}).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}))
 	missing, err := svc.GetTrackEvents(ctx, key, "missing")
 	require.NoError(t, err)
@@ -4938,7 +4956,7 @@ func TestServiceGetTrackEventsErrors(t *testing.T) {
 		defer db.Close()
 		key := session.Key{AppName: "app", UserID: "user", SessionID: "sess"}
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT event FROM session_track_events")).
-			WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("agui"), time.Time{}).
+			WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("agui"), timeArg{}, time.Time{}).
 			WillReturnError(assert.AnError)
 		_, err := svc.GetTrackEvents(context.Background(), key, "agui")
 		require.Error(t, err)

--- a/session/pgvector/service_test.go
+++ b/session/pgvector/service_test.go
@@ -170,8 +170,8 @@ func (a anyVectorArg) Match(_ driver.Value) bool {
 type timeArg struct{}
 
 func (a timeArg) Match(v driver.Value) bool {
-	_, ok := v.(time.Time)
-	return ok
+	t, ok := v.(time.Time)
+	return ok && !t.IsZero()
 }
 
 type utcTimeArg struct{}

--- a/session/pgvector/summary.go
+++ b/session/pgvector/summary.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
@@ -206,13 +207,13 @@ func (s *Service) GetSessionSummaryText(
 			WHERE app_name = $1 AND user_id = $2
 			AND session_id = $3 AND filter_key = $4
 			AND (expires_at IS NULL
-				OR expires_at > NOW() AT TIME ZONE 'localtime')
-			AND updated_at >= $5
+				OR expires_at > $5)
+			AND updated_at >= $6
 			AND deleted_at IS NULL`,
 			s.tableSessionSummaries,
 		),
 		key.AppName, key.UserID, key.SessionID,
-		filterKey, sess.CreatedAt,
+		filterKey, time.Now(), sess.CreatedAt,
 	)
 	if err == nil && summaryText != "" {
 		return summaryText, true
@@ -251,14 +252,14 @@ func (s *Service) GetSessionSummaryText(
 				AND session_id = $3
 				AND filter_key = $4
 				AND (expires_at IS NULL
-					OR expires_at > NOW() AT TIME ZONE 'localtime')
-				AND updated_at >= $5
+					OR expires_at > $5)
+				AND updated_at >= $6
 				AND deleted_at IS NULL`,
 				s.tableSessionSummaries,
 			),
 			key.AppName, key.UserID, key.SessionID,
 			session.SummaryFilterKeyAllContents,
-			sess.CreatedAt,
+			time.Now(), sess.CreatedAt,
 		)
 		if err == nil && summaryText != "" {
 			return summaryText, true

--- a/session/pgvector/summary_test.go
+++ b/session/pgvector/summary_test.go
@@ -202,7 +202,11 @@ func TestGetSessionSummaryText_FromDB(t *testing.T) {
 	s, mock, db := newTestService(t, nil)
 	defer db.Close()
 
-	sess := session.NewSession("app", "user", "sess")
+	createdAt := time.Date(2025, 4, 7, 9, 0, 0, 0, time.UTC)
+	sess := session.NewSession(
+		"app", "user", "sess",
+		session.WithSessionCreatedAt(createdAt),
+	)
 
 	sum := session.Summary{Summary: "db summary"}
 	sumBytes, _ := json.Marshal(sum)
@@ -210,6 +214,11 @@ func TestGetSessionSummaryText_FromDB(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"summary"}).
 		AddRow(sumBytes)
 	mock.ExpectQuery("SELECT summary FROM").
+		WithArgs(
+			"app", "user", "sess",
+			session.SummaryFilterKeyAllContents,
+			timeArg{}, createdAt,
+		).
 		WillReturnRows(rows)
 
 	text, ok := s.GetSessionSummaryText(
@@ -223,15 +232,28 @@ func TestGetSessionSummaryText_NotFound(t *testing.T) {
 	s, mock, db := newTestService(t, nil)
 	defer db.Close()
 
-	sess := session.NewSession("app", "user", "sess")
+	createdAt := time.Date(2025, 4, 7, 9, 0, 0, 0, time.UTC)
+	sess := session.NewSession(
+		"app", "user", "sess",
+		session.WithSessionCreatedAt(createdAt),
+	)
 
 	// Primary query returns no rows.
 	mock.ExpectQuery("SELECT summary FROM").
+		WithArgs(
+			"app", "user", "sess", "custom",
+			timeArg{}, createdAt,
+		).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"summary"}),
 		)
 	// Fallback query returns no rows.
 	mock.ExpectQuery("SELECT summary FROM").
+		WithArgs(
+			"app", "user", "sess",
+			session.SummaryFilterKeyAllContents,
+			timeArg{}, createdAt,
+		).
 		WillReturnRows(
 			sqlmock.NewRows([]string{"summary"}),
 		)

--- a/session/pgvector/window.go
+++ b/session/pgvector/window.go
@@ -122,13 +122,16 @@ func (s *Service) loadWindowAnchor(
 		WHERE se.app_name = $1 AND se.user_id = $2
 		AND se.session_id = $3
 		AND se.deleted_at IS NULL
-		AND (se.expires_at IS NULL OR se.expires_at > NOW() AT TIME ZONE 'localtime')
+		AND (se.expires_at IS NULL OR se.expires_at > $5)
 		AND se.content_text <> ''
 		AND se.event->>'id' = $4`,
 		s.tableSessionEvents,
 	)
 
-	args := []any{key.AppName, key.UserID, key.SessionID, anchorEventID}
+	args := []any{
+		key.AppName, key.UserID, key.SessionID,
+		anchorEventID, time.Now(),
+	}
 	if len(roles) > 0 {
 		query += fmt.Sprintf(
 			` AND se.role = ANY($%d::varchar[])`,
@@ -209,14 +212,17 @@ func (s *Service) loadWindowNeighbors(
 		WHERE se.app_name = $1 AND se.user_id = $2
 		AND se.session_id = $3
 		AND se.deleted_at IS NULL
-		AND (se.expires_at IS NULL OR se.expires_at > NOW() AT TIME ZONE 'localtime')
+		AND (se.expires_at IS NULL OR se.expires_at > $6)
 		AND se.content_text <> ''
 		AND %s`,
 		s.tableSessionEvents,
 		comparator,
 	)
 
-	args := []any{key.AppName, key.UserID, key.SessionID, anchorCreatedAt, anchorRowID}
+	args := []any{
+		key.AppName, key.UserID, key.SessionID,
+		anchorCreatedAt, anchorRowID, time.Now(),
+	}
 	if len(roles) > 0 {
 		query += fmt.Sprintf(
 			` AND se.role = ANY($%d::varchar[])`,

--- a/session/pgvector/window_test.go
+++ b/session/pgvector/window_test.go
@@ -112,13 +112,13 @@ func TestGetEventWindow_Success(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.id, se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", "evt-2", []string{"user", "assistant"}).
+		WithArgs("app", "user", "sess", "evt-2", timeArg{}, []string{"user", "assistant"}).
 		WillReturnRows(anchorRows)
 	mock.ExpectQuery(`SELECT se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", base.Add(2*time.Minute), int64(22), []string{"user", "assistant"}).
+		WithArgs("app", "user", "sess", base.Add(2*time.Minute), int64(22), timeArg{}, []string{"user", "assistant"}).
 		WillReturnRows(beforeRows)
 	mock.ExpectQuery(`SELECT se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", base.Add(2*time.Minute), int64(22), []string{"user", "assistant"}).
+		WithArgs("app", "user", "sess", base.Add(2*time.Minute), int64(22), timeArg{}, []string{"user", "assistant"}).
 		WillReturnRows(afterRows)
 
 	window, err := s.GetEventWindow(
@@ -157,7 +157,7 @@ func TestGetEventWindow_AnchorNotFound(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.id, se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", "evt-tool", []string{"user", "assistant"}).
+		WithArgs("app", "user", "sess", "evt-tool", timeArg{}, []string{"user", "assistant"}).
 		WillReturnRows(rows)
 
 	_, err := s.GetEventWindow(
@@ -244,13 +244,13 @@ func TestGetEventWindow_IncludesToolResultsWhenRequested(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.id, se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", "evt-tool", []string{"user", "assistant", "tool"}).
+		WithArgs("app", "user", "sess", "evt-tool", timeArg{}, []string{"user", "assistant", "tool"}).
 		WillReturnRows(anchorRows)
 	mock.ExpectQuery(`SELECT se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", base.Add(time.Minute), int64(11), []string{"user", "assistant", "tool"}).
+		WithArgs("app", "user", "sess", base.Add(time.Minute), int64(11), timeArg{}, []string{"user", "assistant", "tool"}).
 		WillReturnRows(beforeRows)
 	mock.ExpectQuery(`SELECT se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", base.Add(time.Minute), int64(11), []string{"user", "assistant", "tool"}).
+		WithArgs("app", "user", "sess", base.Add(time.Minute), int64(11), timeArg{}, []string{"user", "assistant", "tool"}).
 		WillReturnRows(afterRows)
 
 	window, err := s.GetEventWindow(
@@ -282,7 +282,7 @@ func TestGetEventWindow_QueryError(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectQuery(`SELECT se\.id, se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", "evt-1").
+		WithArgs("app", "user", "sess", "evt-1", timeArg{}).
 		WillReturnError(assert.AnError)
 
 	_, err := s.GetEventWindow(
@@ -465,7 +465,7 @@ func TestLoadWindowHelpers_EdgeBranches(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`SELECT se\.id, se\.event, se\.created_at`).
-		WithArgs("app", "user", "sess", "evt-1").
+		WithArgs("app", "user", "sess", "evt-1", timeArg{}).
 		WillReturnRows(anchorRows)
 
 	_, err = s.loadWindowAnchor(


### PR DESCRIPTION
## What changed

Make pgvector TTL filters portable across self-hosted and managed PostgreSQL deployments by passing the application current time as a query parameter. Session, state, event, search, summary, and window reads no longer depend on a PostgreSQL time zone named `localtime`.

## Why

PostgreSQL interprets `'localtime'` in `AT TIME ZONE 'localtime'` as a named time zone, but that name is not guaranteed to exist. Managed deployments such as the reported Alibaba Cloud RDS instance reject these queries before session loading can complete.

Binding `time.Now()` matches how pgx encodes the existing `TIMESTAMP` expiry values and follows the established `session/postgres` implementation. It also avoids changing the schema or making TTL behavior depend on the database session time zone.

## Testing

- `go test ./...` in `session/pgvector`
- `go test -race ./...` in `session/pgvector`
- `TZ=Asia/Shanghai go test ./... -count=1` in `session/pgvector`
- `./.github/scripts/run-go-tests.sh --module ./session/pgvector/go.mod` (94.2% package coverage)
- `go build ./...` for the root module
- Isolated PostgreSQL 16 regression: removed the container-only `localtime` time zone entry, confirmed the old expression fails, then created and loaded a TTL-enabled pgvector session successfully with the application in `Asia/Shanghai` and PostgreSQL in UTC

The full multi-module test script was also attempted. Unchanged root sandbox tests failed because the host `bwrap` does not support `--clearenv`, and unchanged file-mode tests observed the host umask; the affected pgvector module passed independently.

## Notes for reviewers

This is limited to the clock source used by TTL read filters. It adds no public API, configuration, schema, serialization, protocol, or migration changes.

Fixes #2388
