### PR TITLE
{internal/flow/llmflow, internal/toolcall}: reject empty tool call names

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -943,6 +943,11 @@ func (p *streamingResponseProcessor) process(
 	responseusage.AttachTiming(response, p.timingInfo, &p.partialUsageState)
 	p.repairToolCallArguments(response)
 	p.repairToolCallTextAndStats(response)
+	if err := validateCompletedToolCallNames(response); err != nil {
+		*p.err = err
+		responseErr = err
+		return false
+	}
 	if p.shouldBufferToolCallTextPartial(response) {
 		if err := agent.CheckContextCancelled(p.ctx); err != nil {
 			*p.err = err
@@ -988,6 +993,37 @@ func (p *streamingResponseProcessor) process(
 		responseSpan.SetAttributes(latencyResponseAttrs(response)...)
 	}
 	return true
+}
+
+func validateCompletedToolCallNames(response *model.Response) error {
+	if response == nil || response.IsPartial {
+		return nil
+	}
+	for choiceIndex, choice := range response.Choices {
+		messages := []struct {
+			location  string
+			toolCalls []model.ToolCall
+		}{
+			{location: "message", toolCalls: choice.Message.ToolCalls},
+			{location: "delta", toolCalls: choice.Delta.ToolCalls},
+		}
+		for _, message := range messages {
+			for toolCallIndex, toolCall := range message.toolCalls {
+				if strings.TrimSpace(toolCall.Function.Name) != "" {
+					continue
+				}
+				return fmt.Errorf(
+					"invalid model response: tool call function name is empty: response_id=%q choice=%d location=%s tool_call=%d id=%q",
+					response.ID,
+					choiceIndex,
+					message.location,
+					toolCallIndex,
+					toolCall.ID,
+				)
+			}
+		}
+	}
+	return nil
 }
 
 func (p *streamingResponseProcessor) recordResponseStats(response *model.Response) {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -607,6 +607,119 @@ func TestProcessStreamingResponses_RepairsToolCallArgumentsWhenEnabled(t *testin
 	require.Equal(t, "{\"a\":2}", string(response.Choices[0].Message.ToolCalls[0].Function.Arguments))
 }
 
+func TestProcessStreamingResponses_RejectsEmptyCompletedToolCallNameBeforeEmit(t *testing.T) {
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(agent.WithInvocationID("inv-empty-tool-name"))
+	response := &model.Response{
+		Done: true,
+		Choices: []model.Choice{
+			{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{
+						{
+							ID: "call-empty-name",
+							Function: model.FunctionDefinitionParam{
+								Arguments: []byte(`{"command":"pwd"}`),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	responseSeq := func(yield func(*model.Response) bool) {
+		yield(response)
+	}
+
+	eventChan := make(chan *event.Event, 1)
+	tracer := oteltrace.NewNoopTracerProvider().Tracer("t")
+	ctx, span := tracer.Start(context.Background(), "s")
+	defer span.End()
+
+	lastEvent, err := f.processStreamingResponses(
+		ctx,
+		inv,
+		nil,
+		&model.Request{},
+		responseSeq,
+		eventChan,
+		span,
+		true,
+	)
+	require.ErrorContains(t, err, "tool call function name is empty")
+	require.ErrorContains(t, err, `id="call-empty-name"`)
+	require.Nil(t, lastEvent)
+	require.Empty(t, eventChan)
+}
+
+func TestValidateCompletedToolCallNames(t *testing.T) {
+	validCall := model.ToolCall{
+		ID: "call-valid",
+		Function: model.FunctionDefinitionParam{
+			Name:      "shell",
+			Arguments: []byte(`{"command":"pwd"}`),
+		},
+	}
+	emptyCall := validCall
+	emptyCall.ID = "call-empty"
+	emptyCall.Function.Name = " \t"
+
+	tests := []struct {
+		name     string
+		response *model.Response
+		wantErr  bool
+	}{
+		{name: "nil response"},
+		{
+			name: "partial response may have incomplete name",
+			response: &model.Response{
+				IsPartial: true,
+				Choices: []model.Choice{{
+					Delta: model.Message{ToolCalls: []model.ToolCall{emptyCall}},
+				}},
+			},
+		},
+		{
+			name: "completed message with valid name",
+			response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{ToolCalls: []model.ToolCall{validCall}},
+				}},
+			},
+		},
+		{
+			name: "completed message with empty name",
+			response: &model.Response{
+				Choices: []model.Choice{{
+					Message: model.Message{ToolCalls: []model.ToolCall{emptyCall}},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "completed delta with empty name",
+			response: &model.Response{
+				Choices: []model.Choice{{
+					Delta: model.Message{ToolCalls: []model.ToolCall{emptyCall}},
+				}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCompletedToolCallNames(tt.response)
+			if tt.wantErr {
+				require.ErrorContains(t, err, "tool call function name is empty")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestRunOneStep_DisableTracingSkipsSpanCreation(t *testing.T) {
 	recorder := useSpanRecorder(t)
 	f := New([]flow.RequestProcessor{&seedMessagesRequestProcessor{

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -34,16 +34,17 @@ const (
 
 var (
 	errArgumentsNotValidJSON = errors.New("arguments are not valid JSON")
+	errFunctionNameEmpty     = errors.New("function name is empty")
 )
 
 // SanitizeMessagesWithTools downgrades invalid tool calls and tool results into user messages.
 //
-// Some model providers require tool call arguments to be valid JSON, and often a JSON object.
-// When a model produces invalid tool call arguments (for example, malformed JSON or a JSON
-// value that does not match the tool input schema), the tool call can poison the conversation
-// history and cause future model requests to fail (e.g., HTTP 400 Bad Request). This function
-// removes such tool calls from assistant messages and emits equivalent user messages that
-// preserve the original payload for context.
+// Some model providers require tool call function names to be non-empty and arguments to be
+// valid JSON, often a JSON object. When a model produces an invalid tool call (for example, an
+// empty function name, malformed JSON, or a value that does not match the tool input schema),
+// the tool call can poison the conversation history and cause future model requests to fail
+// (e.g., HTTP 400 Bad Request). This function removes such tool calls from assistant messages
+// and emits equivalent user messages that preserve the original payload for context.
 //
 // This function also downgrades orphan tool calls that are not associated with a kept
 // tool result message, and orphan tool result messages that are not associated with a
@@ -178,6 +179,9 @@ func validateToolCalls(toolCalls []model.ToolCall, tools map[string]tool.Tool) t
 
 // validateToolCall validates and normalizes a single tool call.
 func validateToolCall(tc model.ToolCall, tools map[string]tool.Tool) (model.ToolCall, bool, string) {
+	if strings.TrimSpace(tc.Function.Name) == "" {
+		return tc, false, errFunctionNameEmpty.Error()
+	}
 	normalizedArgs, decoded, err := normalizeAndDecodeArguments(tc.Function.Arguments)
 	if err != nil {
 		return tc, false, err.Error()

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -68,6 +68,46 @@ func TestSanitizeMessagesWithTools_DowngradesInvalidToolCallAndResult(t *testing
 	}
 }
 
+func TestSanitizeMessagesWithTools_DowngradesEmptyToolNameAndResult(t *testing.T) {
+	for _, name := range []string{"", " \t\n"} {
+		t.Run(fmt.Sprintf("name_%q", name), func(t *testing.T) {
+			in := []model.Message{
+				{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{
+						{
+							ID: "call_empty_name",
+							Function: model.FunctionDefinitionParam{
+								Name:      name,
+								Arguments: []byte(`{"command":"pwd"}`),
+							},
+						},
+					},
+				},
+				{
+					Role:     model.RoleTool,
+					ToolID:   "call_empty_name",
+					ToolName: name,
+					Content:  "tool error",
+				},
+			}
+
+			out := SanitizeMessagesWithTools(context.Background(), in, nil)
+			if assert.Len(t, out, 2) {
+				assert.Equal(t, model.RoleUser, out[0].Role)
+				assert.Contains(t, out[0].Content, invalidToolCallTag)
+				assert.Contains(t, out[0].Content, errFunctionNameEmpty.Error())
+				assert.Equal(t, model.RoleUser, out[1].Role)
+				assert.Contains(t, out[1].Content, invalidToolResultTag)
+			}
+			for _, msg := range out {
+				assert.NotEqual(t, model.RoleTool, msg.Role)
+				assert.Empty(t, msg.ToolCalls)
+			}
+		})
+	}
+}
+
 func TestSanitizeMessagesWithTools_WarnsOnDowngradeWithoutPayload(t *testing.T) {
 	original := agentlog.WarnfContext
 	var messages []string


### PR DESCRIPTION
## What changed

Reject completed model responses whose tool calls have empty or whitespace-only function names before those responses are emitted or executed. Existing conversation history containing such calls is downgraded to ordinary user context together with the matching tool results, allowing subsequent model requests to recover.

## Why

An OpenAI-compatible provider can return a tool call ID and valid JSON arguments while omitting the function name. The flow previously treated that response as an unknown tool, emitted and persisted it, and could repeatedly call the model with poisoned history. Strict providers then reject that history because `function.name` is required.

Validation runs after existing after-model callbacks and repair hooks so applications can still correct provider output. Incomplete streaming deltas remain allowed, while an unrepaired completed response fails closed without guessing a tool name.

## Testing

- `go test ./internal/toolcall ./internal/flow/llmflow ./internal/flow/processor`
- `go build ./...`
- `go test ./...` (10,935 passed and 5 skipped; two unrelated `codeexecutor/local` PATH tests failed in the aggregate run and both passed when rerun directly)

## Notes for reviewers

This adds no exported symbols. It intentionally changes the observable handling of malformed model responses: a completed tool call with an empty function name now returns an error before event emission, tool execution, or session persistence. Valid tool calls, unknown non-empty tool names, and partial streaming tool-call deltas retain their existing behavior.
