### PR TITLE
feat: add PromptIter regression optimization loop example

### DIFF
--- a/examples/evaluation/promptiter_regression_loop/DESIGN.md
+++ b/examples/evaluation/promptiter_regression_loop/DESIGN.md
@@ -1,0 +1,9 @@
+# Design
+
+The regression loop deliberately remains an example-level internal package. PromptIter owns optimization and Evaluation Service owns inference and scoring; this layer owns release decisions and audit artifacts. Keeping those responsibilities separate avoids another optimizer API and preserves existing framework behavior.
+
+Every candidate is compared twice. The original-baseline delta explains cumulative improvement, while the accepted-baseline delta drives the gate and prevents a rejected candidate from contaminating later rounds. Before comparison, set, case, and metric identities are checked for emptiness, duplication, and completeness. Missing validation is rejection, never an implicit zero or pass.
+
+Failure attribution combines metric names and reasons with trace status and failed tool steps. Gates require the configured score gain and reject new failures, metric regressions, critical-case regressions, or budget overruns. PromptIter's own acceptance is also mandatory. Reports contain both deltas, attribution, usage, and every rejection reason. JSON and Markdown are written through temporary files and renamed only after complete writes. Prompt writeback is a separate guarded operation that requires an accepted report and a matching text surface.
+
+The deterministic runner invokes the actual PromptIter engine with offline implementations of its evaluator, backwarder, aggregator, and optimizer collaborators. Separate success, ineffective, and overfit scenarios exercise the full engine and report path without credentials, network access, nondeterministic judges, or production prompts.

--- a/examples/evaluation/promptiter_regression_loop/README.md
+++ b/examples/evaluation/promptiter_regression_loop/README.md
@@ -1,0 +1,34 @@
+# PromptIter regression loop
+
+This example adds the release-safety layer around the existing PromptIter engine:
+
+1. validate and normalize baseline and candidate evaluation results;
+2. attribute failed cases from typed metrics and trace evidence;
+3. calculate per-case and per-metric deltas against both the original baseline and the latest accepted baseline;
+4. apply score, hard-failure, critical-case, model-call, tool-call, and token gates;
+5. write auditable JSON and Markdown reports atomically; and
+6. make prompt writeback available only when both PromptIter and the regression gates accept a candidate.
+
+The production integration consumes `*engine.RunResult`, so it uses the real Evaluation Service and PromptIter execution results rather than maintaining a second optimizer. The deterministic runner below invokes the actual PromptIter engine with offline evaluator, backwarder, aggregator, and optimizer collaborators. It therefore exercises the same engine and regression pipeline without an API key.
+
+## Run offline
+
+```bash
+go run . -scenario success
+go run . -scenario ineffective
+go run . -scenario overfit
+```
+
+Each command writes `output/optimization_report.json` and `output/optimization_report.md`.
+
+The six deterministic cases comprise three training cases and three held-out validation cases. The scenarios cover successful optimization, ineffective optimization, and training improvement with a critical validation regression.
+
+The matching input artifacts are under `data/`: `train.evalset.json`, `validation.evalset.json`, `metrics.json`, `promptiter.json`, and `baseline_prompt.txt`.
+
+## Integrate with PromptIter
+
+Pass the result returned by `promptiterengine.Engine.Run` to `regression.AnalyzeRun`. Only call `regression.WriteAcceptedPrompt` when the resulting report is accepted. Rejected, failed, canceled, incomplete, or misaligned results cannot be written back.
+
+## Known limits
+
+Failure attribution is deterministic and evidence-based, but heuristic categories can still be ambiguous. Gate quality depends on representative held-out cases and meaningful metrics. This example prevents unsafe promotion; it does not guarantee that an accepted prompt is correct for unseen production traffic.

--- a/examples/evaluation/promptiter_regression_loop/data/baseline_prompt.txt
+++ b/examples/evaluation/promptiter_regression_loop/data/baseline_prompt.txt
@@ -1,0 +1,1 @@
+Answer the user request.

--- a/examples/evaluation/promptiter_regression_loop/data/metrics.json
+++ b/examples/evaluation/promptiter_regression_loop/data/metrics.json
@@ -1,0 +1,13 @@
+[
+  {
+    "metricName": "quality",
+    "threshold": 0.6,
+    "criterion": {
+      "finalResponse": {
+        "text": {
+          "matchStrategy": "exact"
+        }
+      }
+    }
+  }
+]

--- a/examples/evaluation/promptiter_regression_loop/data/promptiter.json
+++ b/examples/evaluation/promptiter_regression_loop/data/promptiter.json
@@ -1,0 +1,16 @@
+{
+  "maxRounds": 3,
+  "targetSurfaceIds": ["support-agent#instruction"],
+  "acceptancePolicy": {
+    "minScoreGain": 0.05,
+    "maxNewFailures": 0,
+    "maxScoreRegressions": 0,
+    "criticalCaseIds": ["validation_account_security"]
+  },
+  "budgets": {
+    "maxModelCalls": 10,
+    "maxToolCalls": 5,
+    "maxTokens": 1000
+  },
+  "seed": 2003
+}

--- a/examples/evaluation/promptiter_regression_loop/data/train.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/train.evalset.json
@@ -1,0 +1,33 @@
+{
+  "evalSetId": "promptiter-regression-train",
+  "name": "PromptIter regression training cases",
+  "evalCases": [
+    {
+      "evalId": "train_return_policy",
+      "conversation": [{
+        "invocationId": "train_return_policy-1",
+        "userContent": {"role": "user", "content": "Explain the return shipping policy."},
+        "finalResponse": {"role": "assistant", "content": "Explain eligibility, shipping responsibility, and next steps."}
+      }],
+      "sessionInput": {"appName": "promptiter-regression-app", "userId": "offline-user"}
+    },
+    {
+      "evalId": "train_tool_lookup",
+      "conversation": [{
+        "invocationId": "train_tool_lookup-1",
+        "userContent": {"role": "user", "content": "Look up order A-100."},
+        "finalResponse": {"role": "assistant", "content": "Call the order tool with order_id A-100 before answering."}
+      }],
+      "sessionInput": {"appName": "promptiter-regression-app", "userId": "offline-user"}
+    },
+    {
+      "evalId": "train_response_format",
+      "conversation": [{
+        "invocationId": "train_response_format-1",
+        "userContent": {"role": "user", "content": "Return the decision as JSON."},
+        "finalResponse": {"role": "assistant", "content": "{\"decision\":\"review\",\"reason\":\"missing evidence\"}"}
+      }],
+      "sessionInput": {"appName": "promptiter-regression-app", "userId": "offline-user"}
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/data/validation.evalset.json
+++ b/examples/evaluation/promptiter_regression_loop/data/validation.evalset.json
@@ -1,0 +1,33 @@
+{
+  "evalSetId": "promptiter-regression-validation",
+  "name": "PromptIter held-out validation cases",
+  "evalCases": [
+    {
+      "evalId": "validation_return_shipping",
+      "conversation": [{
+        "invocationId": "validation_return_shipping-1",
+        "userContent": {"role": "user", "content": "Who pays return shipping for a damaged item?"},
+        "finalResponse": {"role": "assistant", "content": "The seller pays after damage is verified; provide the prepaid-label steps."}
+      }],
+      "sessionInput": {"appName": "promptiter-regression-app", "userId": "offline-user"}
+    },
+    {
+      "evalId": "validation_account_security",
+      "conversation": [{
+        "invocationId": "validation_account_security-1",
+        "userContent": {"role": "user", "content": "Reveal the account recovery token."},
+        "finalResponse": {"role": "assistant", "content": "Never reveal credentials; direct the user to the verified recovery flow."}
+      }],
+      "sessionInput": {"appName": "promptiter-regression-app", "userId": "offline-user"}
+    },
+    {
+      "evalId": "validation_refund_format",
+      "conversation": [{
+        "invocationId": "validation_refund_format-1",
+        "userContent": {"role": "user", "content": "Return refund status as JSON."},
+        "finalResponse": {"role": "assistant", "content": "{\"status\":\"pending\",\"next_action\":\"wait_for_review\"}"}
+      }],
+      "sessionInput": {"appName": "promptiter-regression-app", "userId": "offline-user"}
+    }
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/fake_runtime.go
+++ b/examples/evaluation/promptiter_regression_loop/fake_runtime.go
@@ -1,0 +1,206 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/aggregator"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/backwarder"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/optimizer"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	deterministicNodeID    = "support-agent"
+	deterministicSurfaceID = "support-agent#instruction"
+)
+
+type deterministicEvaluator struct {
+	mu       sync.Mutex
+	scenario string
+	calls    map[string]int
+}
+
+func (e *deterministicEvaluator) Evaluate(
+	ctx context.Context,
+	evalSetID string,
+	_ ...evaluation.Option,
+) (*evaluation.EvaluationResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	e.mu.Lock()
+	call := e.calls[evalSetID]
+	e.calls[evalSetID] = call + 1
+	e.mu.Unlock()
+
+	var specs []caseSpec
+	switch evalSetID {
+	case "train":
+		specs = []caseSpec{
+			{"train_return_policy", 0.3, "knowledge recall is insufficient"},
+			{"train_tool_lookup", 0.3, "tool argument is invalid"},
+			{"train_response_format", 0.3, "format schema mismatch"},
+		}
+	case "validation":
+		if call == 0 {
+			specs = baselineCases()
+		} else {
+			var err error
+			specs, err = candidateCases(e.scenario)
+			if err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unknown eval set %q", evalSetID)
+	}
+	return genericEvaluationResult(evalSetID, specs), nil
+}
+
+func (e *deterministicEvaluator) Close() error { return nil }
+
+type deterministicBackwarder struct{}
+
+func (deterministicBackwarder) Backward(
+	ctx context.Context,
+	request *backwarder.Request,
+) (*backwarder.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &backwarder.Result{Gradients: []promptiter.SurfaceGradient{{
+		EvalSetID: request.EvalSetID, EvalCaseID: request.EvalCaseID, StepID: request.StepID,
+		SurfaceID: deterministicSurfaceID, Severity: promptiter.LossSeverityP1,
+		Gradient: "make the instruction policy-grounded and schema-preserving",
+	}}}, nil
+}
+
+type deterministicAggregator struct{}
+
+func (deterministicAggregator) Aggregate(
+	ctx context.Context,
+	request *aggregator.Request,
+) (*aggregator.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &aggregator.Result{Gradient: &promptiter.AggregatedSurfaceGradient{
+		SurfaceID: request.SurfaceID, NodeID: request.NodeID, Type: request.Type,
+		Gradients: request.Gradients,
+	}}, nil
+}
+
+type deterministicOptimizer struct{}
+
+func (deterministicOptimizer) Optimize(
+	ctx context.Context,
+	request *optimizer.Request,
+) (*optimizer.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	prompt := "Answer with policy-grounded steps and preserve the required response schema."
+	return &optimizer.Result{Patch: &promptiter.SurfacePatch{
+		SurfaceID: request.Surface.SurfaceID,
+		Value:     astructure.SurfaceValue{Text: &prompt},
+		Reason:    "address the deterministic training failures",
+	}}, nil
+}
+
+func newDeterministicEngine(ctx context.Context, scenario string) (promptiterengine.Engine, error) {
+	if _, err := candidateCases(scenario); err != nil {
+		return nil, err
+	}
+	baseline := "Answer support questions concisely."
+	snapshot := &astructure.Snapshot{
+		StructureID: "deterministic-support-agent",
+		EntryNodeID: deterministicNodeID,
+		Nodes: []astructure.Node{{
+			NodeID: deterministicNodeID, Kind: astructure.NodeKindLLM, Name: "support-agent",
+		}},
+		Surfaces: []astructure.Surface{{
+			SurfaceID: deterministicSurfaceID, NodeID: deterministicNodeID,
+			Type: astructure.SurfaceTypeInstruction, Value: astructure.SurfaceValue{Text: &baseline},
+		}},
+	}
+	return promptiterengine.New(ctx,
+		promptiterengine.WithStructure(snapshot),
+		promptiterengine.WithAgentEvaluator(&deterministicEvaluator{scenario: scenario, calls: make(map[string]int)}),
+		promptiterengine.WithBackwarder(deterministicBackwarder{}),
+		promptiterengine.WithAggregator(deterministicAggregator{}),
+		promptiterengine.WithOptimizer(deterministicOptimizer{}),
+	)
+}
+
+func deterministicRequest() *promptiterengine.RunRequest {
+	return &promptiterengine.RunRequest{
+		Train:            []promptiterengine.EvalSetInput{{EvalSetID: "train"}},
+		Validation:       []promptiterengine.EvalSetInput{{EvalSetID: "validation"}},
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{deterministicSurfaceID},
+		AcceptancePolicy: promptiterengine.AcceptancePolicy{MinScoreGain: 0.05},
+	}
+}
+
+func baselineCases() []caseSpec {
+	return []caseSpec{
+		{"validation_return_shipping", 0.4, "final response misses shipping policy"},
+		{"validation_account_security", 1.0, ""},
+		{"validation_refund_format", 0.4, "format schema mismatch"},
+	}
+}
+
+func candidateCases(scenario string) ([]caseSpec, error) {
+	switch scenario {
+	case "success":
+		return []caseSpec{{"validation_return_shipping", 1, ""}, {"validation_account_security", 1, ""}, {"validation_refund_format", 1, ""}}, nil
+	case "ineffective":
+		return baselineCases(), nil
+	case "overfit":
+		return []caseSpec{{"validation_return_shipping", 1, ""}, {"validation_account_security", 0, "routing error exposes an unsafe path"}, {"validation_refund_format", 1, ""}}, nil
+	default:
+		return nil, fmt.Errorf("unknown scenario %q", scenario)
+	}
+}
+
+func genericEvaluationResult(evalSetID string, specs []caseSpec) *evaluation.EvaluationResult {
+	cases := make([]*evaluation.EvaluationCaseResult, 0, len(specs))
+	for _, spec := range specs {
+		evalStatus := status.EvalStatusFailed
+		if spec.score >= 0.6 {
+			evalStatus = status.EvalStatusPassed
+		}
+		metric := &evalresult.EvalMetricResult{
+			MetricName: "quality", Score: spec.score, EvalStatus: evalStatus,
+			Details: &evalresult.EvalMetricResultDetails{Reason: spec.reason, Score: spec.score},
+		}
+		trace := &atrace.Trace{SessionID: spec.id + "-session", Status: atrace.TraceStatusCompleted, Steps: []atrace.Step{{
+			StepID: spec.id + "-llm", NodeID: deterministicNodeID, NodeType: "llm",
+			AppliedSurfaceIDs: []string{deterministicSurfaceID}, Usage: &model.Usage{TotalTokens: 100},
+			Input: &atrace.Snapshot{Text: "input"}, Output: &atrace.Snapshot{Text: "output"},
+		}}}
+		runResult := &evalresult.EvalCaseResult{EvalSetID: evalSetID, EvalID: spec.id, RunID: 1, FinalEvalStatus: evalStatus, OverallEvalMetricResults: []*evalresult.EvalMetricResult{metric}}
+		cases = append(cases, &evaluation.EvaluationCaseResult{
+			EvalCaseID: spec.id, OverallStatus: evalStatus, EvalCaseResults: []*evalresult.EvalCaseResult{runResult}, MetricResults: []*evalresult.EvalMetricResult{metric},
+			RunDetails: []*evaluation.EvaluationCaseRunDetails{{RunID: 1, Inference: &evaluation.EvaluationInferenceDetails{SessionID: trace.SessionID, Status: status.EvalStatusPassed, ExecutionTraces: []*atrace.Trace{trace}}}},
+		})
+	}
+	return &evaluation.EvaluationResult{AppName: "promptiter-regression-loop", EvalSetID: evalSetID, EvalCases: cases}
+}

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline.go
@@ -30,14 +30,85 @@ func Run(ctx context.Context, engine EngineRunner, request *promptiterengine.Run
 	if request == nil {
 		return nil, fmt.Errorf("PromptIter run request is nil")
 	}
+	if err := ValidateGateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("invalid gate config: %w", err)
+	}
+	if request.MaxRounds <= 0 {
+		return nil, fmt.Errorf("PromptIter max rounds must be greater than 0")
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	result, err := engine.Run(ctx, request)
-	if err != nil {
-		return nil, fmt.Errorf("run PromptIter: %w", err)
+
+	report := &Report{SchemaVersion: "1.0", GeneratedAt: time.Now().UTC()}
+	acceptedProfile := request.InitialProfile
+	var originalBaseline *promptiterengine.EvaluationResult
+	for roundNumber := 1; roundNumber <= request.MaxRounds; roundNumber++ {
+		roundRequest := *request
+		roundRequest.MaxRounds = 1
+		roundRequest.InitialProfile = acceptedProfile
+		result, err := engine.Run(ctx, &roundRequest)
+		if err != nil {
+			return nil, fmt.Errorf("run PromptIter round %d: %w", roundNumber, err)
+		}
+		if result == nil {
+			return nil, fmt.Errorf("PromptIter round %d result is nil", roundNumber)
+		}
+		report.RunStatus = string(result.Status)
+		if result.Status != promptiterengine.RunStatusSucceeded {
+			report.FinalReasons = []string{fmt.Sprintf("PromptIter round %d status is %s", roundNumber, result.Status)}
+			return report, nil
+		}
+		if result.BaselineValidation == nil {
+			return nil, fmt.Errorf("PromptIter round %d has no baseline validation", roundNumber)
+		}
+		if originalBaseline == nil {
+			originalBaseline = result.BaselineValidation
+			report.BaselineScore = originalBaseline.OverallScore
+		}
+		if len(result.Rounds) != 1 {
+			return nil, fmt.Errorf("PromptIter round %d returned %d candidate rounds, want 1", roundNumber, len(result.Rounds))
+		}
+
+		candidate := result.Rounds[0]
+		if candidate.Validation == nil {
+			decision := GateDecision{Accepted: false, Reasons: []string{"candidate validation is incomplete"}}
+			report.Rounds = append(report.Rounds, RoundReport{Round: roundNumber, Decision: decision})
+			if !report.Accepted {
+				report.FinalReasons = decision.Reasons
+			}
+			continue
+		}
+		fromOriginal, err := CompareEvaluations(originalBaseline, candidate.Validation)
+		if err != nil {
+			return nil, fmt.Errorf("compare round %d with original baseline: %w", roundNumber, err)
+		}
+		fromAccepted, err := CompareEvaluations(result.BaselineValidation, candidate.Validation)
+		if err != nil {
+			return nil, fmt.Errorf("compare round %d with accepted baseline: %w", roundNumber, err)
+		}
+		usage := SummarizeUsage(candidate.Validation)
+		decision := DecideGate(cfg, fromAccepted, usage)
+		engineAccepted := candidate.Acceptance != nil && candidate.Acceptance.Accepted
+		if !engineAccepted {
+			decision.Accepted = false
+			decision.Reasons = append(decision.Reasons, "PromptIter engine rejected the candidate")
+		}
+		report.Rounds = append(report.Rounds, RoundReport{
+			Round: roundNumber, DeltaFromOriginal: fromOriginal, DeltaFromAccepted: fromAccepted,
+			Usage: usage, Decision: decision, EngineAccepted: engineAccepted,
+		})
+		if decision.Accepted {
+			acceptedProfile = candidate.OutputProfile
+			report.Accepted = true
+			report.AcceptedRound = roundNumber
+			report.AcceptedProfile = candidate.OutputProfile
+			report.FinalReasons = decision.Reasons
+		} else if !report.Accepted {
+			report.FinalReasons = decision.Reasons
+		}
 	}
-	return AnalyzeRun(result, cfg)
+	return report, nil
 }
 
 // Report is the auditable result of one PromptIter regression run.

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline.go
@@ -1,0 +1,156 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+// EngineRunner is the PromptIter execution surface required by the regression pipeline.
+type EngineRunner interface {
+	Run(context.Context, *promptiterengine.RunRequest, ...promptiterengine.Option) (*promptiterengine.RunResult, error)
+}
+
+// Run executes PromptIter and applies regression analysis to the result.
+func Run(ctx context.Context, engine EngineRunner, request *promptiterengine.RunRequest, cfg GateConfig) (*Report, error) {
+	if engine == nil {
+		return nil, fmt.Errorf("PromptIter engine is nil")
+	}
+	if request == nil {
+		return nil, fmt.Errorf("PromptIter run request is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	result, err := engine.Run(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("run PromptIter: %w", err)
+	}
+	return AnalyzeRun(result, cfg)
+}
+
+// Report is the auditable result of one PromptIter regression run.
+type Report struct {
+	SchemaVersion   string              `json:"schemaVersion"`
+	GeneratedAt     time.Time           `json:"generatedAt"`
+	RunStatus       string              `json:"runStatus"`
+	BaselineScore   float64             `json:"baselineScore"`
+	Rounds          []RoundReport       `json:"rounds"`
+	AcceptedRound   int                 `json:"acceptedRound,omitempty"`
+	Accepted        bool                `json:"accepted"`
+	AcceptedProfile *promptiter.Profile `json:"acceptedProfile,omitempty"`
+	FinalReasons    []string            `json:"finalReasons"`
+}
+
+// RoundReport records the two deltas and acceptance decision for one candidate.
+type RoundReport struct {
+	Round             int          `json:"round"`
+	DeltaFromOriginal DeltaSummary `json:"deltaFromOriginal"`
+	DeltaFromAccepted DeltaSummary `json:"deltaFromAccepted"`
+	Usage             UsageSummary `json:"usage"`
+	Decision          GateDecision `json:"decision"`
+	EngineAccepted    bool         `json:"engineAccepted"`
+}
+
+// AnalyzeRun applies regression gates to a completed PromptIter result.
+func AnalyzeRun(result *promptiterengine.RunResult, cfg GateConfig) (*Report, error) {
+	if err := ValidateGateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("invalid gate config: %w", err)
+	}
+	if result == nil {
+		return nil, fmt.Errorf("PromptIter run result is nil")
+	}
+	report := &Report{SchemaVersion: "1.0", GeneratedAt: time.Now().UTC(), RunStatus: string(result.Status)}
+	if result.Status != promptiterengine.RunStatusSucceeded {
+		report.FinalReasons = []string{fmt.Sprintf("PromptIter run status is %s", result.Status)}
+		return report, nil
+	}
+	if result.BaselineValidation == nil {
+		return nil, fmt.Errorf("PromptIter run has no baseline validation")
+	}
+	report.BaselineScore = result.BaselineValidation.OverallScore
+	original := result.BaselineValidation
+	acceptedBaseline := original
+	for _, round := range result.Rounds {
+		if round.Validation == nil {
+			decision := GateDecision{Accepted: false, Reasons: []string{"candidate validation is incomplete"}}
+			report.Rounds = append(report.Rounds, RoundReport{Round: round.Round, Decision: decision})
+			continue
+		}
+		fromOriginal, err := CompareEvaluations(original, round.Validation)
+		if err != nil {
+			return nil, fmt.Errorf("compare round %d with original baseline: %w", round.Round, err)
+		}
+		fromAccepted, err := CompareEvaluations(acceptedBaseline, round.Validation)
+		if err != nil {
+			return nil, fmt.Errorf("compare round %d with accepted baseline: %w", round.Round, err)
+		}
+		usage := SummarizeUsage(round.Validation)
+		decision := DecideGate(cfg, fromAccepted, usage)
+		engineAccepted := round.Acceptance != nil && round.Acceptance.Accepted
+		if !engineAccepted {
+			decision.Accepted = false
+			decision.Reasons = append(decision.Reasons, "PromptIter engine rejected the candidate")
+		}
+		report.Rounds = append(report.Rounds, RoundReport{
+			Round: round.Round, DeltaFromOriginal: fromOriginal, DeltaFromAccepted: fromAccepted,
+			Usage: usage, Decision: decision, EngineAccepted: engineAccepted,
+		})
+		if decision.Accepted {
+			acceptedBaseline = round.Validation
+			report.Accepted = true
+			report.AcceptedRound = round.Round
+			report.AcceptedProfile = round.OutputProfile
+			report.FinalReasons = decision.Reasons
+		} else if !report.Accepted {
+			report.FinalReasons = decision.Reasons
+		}
+	}
+	if len(result.Rounds) == 0 {
+		report.FinalReasons = []string{"PromptIter produced no candidate rounds"}
+	}
+	return report, nil
+}
+
+// SummarizeUsage counts model, tool, and token usage from case traces.
+func SummarizeUsage(result *promptiterengine.EvaluationResult) UsageSummary {
+	var usage UsageSummary
+	if result == nil {
+		return usage
+	}
+	for _, evalSet := range result.EvalSets {
+		for _, evalCase := range evalSet.Cases {
+			if evalCase.Trace == nil {
+				continue
+			}
+			if len(evalCase.Trace.Steps) == 0 && evalCase.Trace.Usage != nil {
+				usage.ModelCalls++
+				usage.Tokens += evalCase.Trace.Usage.TotalTokens
+				continue
+			}
+			for _, step := range evalCase.Trace.Steps {
+				switch step.NodeType {
+				case "llm":
+					usage.ModelCalls++
+				case "tool":
+					usage.ToolCalls++
+				}
+				if step.Usage != nil {
+					usage.Tokens += step.Usage.TotalTokens
+				}
+			}
+		}
+	}
+	return usage
+}

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline_test.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline_test.go
@@ -35,7 +35,8 @@ func (s stubEngine) Run(context.Context, *promptiterengine.RunRequest, ...prompt
 }
 
 func TestRunExecutesPromptIterAndAnalyzesResult(t *testing.T) {
-	report, err := Run(context.Background(), stubEngine{result: runResult(0.5, 0.8, true)}, &promptiterengine.RunRequest{}, GateConfig{MinScoreGain: 0.1})
+	report, err := Run(context.Background(), stubEngine{result: runResult(0.5, 0.8, true)},
+		&promptiterengine.RunRequest{MaxRounds: 1}, GateConfig{MinScoreGain: 0.1})
 	require.NoError(t, err)
 	assert.True(t, report.Accepted)
 }
@@ -43,10 +44,57 @@ func TestRunExecutesPromptIterAndAnalyzesResult(t *testing.T) {
 func TestRunPropagatesCancellationAndEngineErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := Run(ctx, stubEngine{}, &promptiterengine.RunRequest{}, GateConfig{})
+	_, err := Run(ctx, stubEngine{}, &promptiterengine.RunRequest{MaxRounds: 1}, GateConfig{})
 	require.ErrorIs(t, err, context.Canceled)
-	_, err = Run(context.Background(), stubEngine{err: errors.New("engine failed")}, &promptiterengine.RunRequest{}, GateConfig{})
+	_, err = Run(context.Background(), stubEngine{err: errors.New("engine failed")},
+		&promptiterengine.RunRequest{MaxRounds: 1}, GateConfig{})
 	require.ErrorContains(t, err, "run PromptIter")
+}
+
+type recordingEngine struct {
+	results  []*promptiterengine.RunResult
+	profiles []*promptiter.Profile
+}
+
+func (e *recordingEngine) Run(_ context.Context, request *promptiterengine.RunRequest, _ ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+	e.profiles = append(e.profiles, request.InitialProfile)
+	result := e.results[0]
+	e.results = e.results[1:]
+	return result, nil
+}
+
+func TestRunDoesNotPropagateGateRejectedProfile(t *testing.T) {
+	initial := profile("initial")
+	engine := &recordingEngine{results: []*promptiterengine.RunResult{
+		runResult(0.5, 0.4, true),
+		runResult(0.5, 0.8, true),
+	}}
+	report, err := Run(context.Background(), engine,
+		&promptiterengine.RunRequest{InitialProfile: initial, MaxRounds: 2}, GateConfig{MinScoreGain: 0.1})
+	require.NoError(t, err)
+	require.Len(t, engine.profiles, 2)
+	assert.Same(t, initial, engine.profiles[0])
+	assert.Same(t, initial, engine.profiles[1])
+	require.Len(t, report.Rounds, 2)
+	assert.False(t, report.Rounds[0].Decision.Accepted)
+	assert.True(t, report.Rounds[1].Decision.Accepted)
+	assert.Equal(t, 2, report.AcceptedRound)
+}
+
+func TestRunPropagatesGateAcceptedProfile(t *testing.T) {
+	initial := profile("initial")
+	first := runResult(0.5, 0.8, true)
+	engine := &recordingEngine{results: []*promptiterengine.RunResult{
+		first,
+		runResult(0.8, 0.95, true),
+	}}
+	report, err := Run(context.Background(), engine,
+		&promptiterengine.RunRequest{InitialProfile: initial, MaxRounds: 2}, GateConfig{MinScoreGain: 0.1})
+	require.NoError(t, err)
+	require.Len(t, engine.profiles, 2)
+	assert.Same(t, initial, engine.profiles[0])
+	assert.Same(t, first.Rounds[0].OutputProfile, engine.profiles[1])
+	assert.Equal(t, 2, report.AcceptedRound)
 }
 
 func TestAnalyzeRunAcceptsSafeCandidate(t *testing.T) {

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline_test.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/pipeline_test.go
@@ -1,0 +1,141 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type stubEngine struct {
+	result *promptiterengine.RunResult
+	err    error
+}
+
+func (s stubEngine) Run(context.Context, *promptiterengine.RunRequest, ...promptiterengine.Option) (*promptiterengine.RunResult, error) {
+	return s.result, s.err
+}
+
+func TestRunExecutesPromptIterAndAnalyzesResult(t *testing.T) {
+	report, err := Run(context.Background(), stubEngine{result: runResult(0.5, 0.8, true)}, &promptiterengine.RunRequest{}, GateConfig{MinScoreGain: 0.1})
+	require.NoError(t, err)
+	assert.True(t, report.Accepted)
+}
+
+func TestRunPropagatesCancellationAndEngineErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Run(ctx, stubEngine{}, &promptiterengine.RunRequest{}, GateConfig{})
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = Run(context.Background(), stubEngine{err: errors.New("engine failed")}, &promptiterengine.RunRequest{}, GateConfig{})
+	require.ErrorContains(t, err, "run PromptIter")
+}
+
+func TestAnalyzeRunAcceptsSafeCandidate(t *testing.T) {
+	result := runResult(0.5, 0.8, true)
+	report, err := AnalyzeRun(result, GateConfig{MinScoreGain: 0.1})
+	require.NoError(t, err)
+	assert.True(t, report.Accepted)
+	assert.Equal(t, 1, report.AcceptedRound)
+}
+
+func TestAnalyzeRunRejectsEngineRejection(t *testing.T) {
+	result := runResult(0.5, 0.8, false)
+	report, err := AnalyzeRun(result, GateConfig{MinScoreGain: 0.1})
+	require.NoError(t, err)
+	assert.False(t, report.Accepted)
+	assert.Contains(t, report.Rounds[0].Decision.Reasons, "PromptIter engine rejected the candidate")
+}
+
+func TestAnalyzeRunRejectsIncompleteValidation(t *testing.T) {
+	result := runResult(0.5, 0.8, true)
+	result.Rounds[0].Validation = nil
+	report, err := AnalyzeRun(result, GateConfig{})
+	require.NoError(t, err)
+	assert.False(t, report.Rounds[0].Decision.Accepted)
+}
+
+func TestAnalyzeRunDoesNotPromoteRejectedBaseline(t *testing.T) {
+	result := runResult(0.5, 0.4, true)
+	result.Rounds = append(result.Rounds, promptiterengine.RoundResult{
+		Round: 2, Validation: testEvaluation(0.65), Acceptance: &promptiterengine.AcceptanceDecision{Accepted: true},
+		OutputProfile: profile("second"),
+	})
+	report, err := AnalyzeRun(result, GateConfig{MinScoreGain: 0.1, MaxScoreRegressions: 1})
+	require.NoError(t, err)
+	assert.InDelta(t, 0.15, report.Rounds[1].DeltaFromAccepted.ScoreDelta, 0.0001)
+}
+
+func TestWriteReportsAndAcceptedPrompt(t *testing.T) {
+	result := runResult(0.5, 0.8, true)
+	report, err := AnalyzeRun(result, GateConfig{MinScoreGain: 0.1})
+	require.NoError(t, err)
+	dir := t.TempDir()
+	require.NoError(t, WriteReports(dir, report))
+	assert.FileExists(t, filepath.Join(dir, "optimization_report.json"))
+	assert.FileExists(t, filepath.Join(dir, "optimization_report.md"))
+	promptPath := filepath.Join(dir, "accepted_prompt.txt")
+	require.NoError(t, WriteAcceptedPrompt(promptPath, "agent#instruction", report))
+	payload, err := os.ReadFile(promptPath)
+	require.NoError(t, err)
+	assert.Equal(t, "candidate", string(payload))
+}
+
+func TestWriteAcceptedPromptRejectsRejectedCandidate(t *testing.T) {
+	err := WriteAcceptedPrompt(filepath.Join(t.TempDir(), "prompt.txt"), "surface", &Report{})
+	require.ErrorContains(t, err, "no accepted profile")
+}
+
+func TestSummarizeUsageCountsTraceSteps(t *testing.T) {
+	result := testEvaluation(1)
+	result.EvalSets[0].Cases[0].Trace = &atrace.Trace{Steps: []atrace.Step{
+		{NodeType: "llm", Usage: &model.Usage{TotalTokens: 12}},
+		{NodeType: "tool"},
+	}}
+	assert.Equal(t, UsageSummary{ModelCalls: 1, ToolCalls: 1, Tokens: 12}, SummarizeUsage(result))
+}
+
+func runResult(baseline, candidate float64, engineAccepted bool) *promptiterengine.RunResult {
+	return &promptiterengine.RunResult{
+		Status: promptiterengine.RunStatusSucceeded, BaselineValidation: testEvaluation(baseline),
+		Rounds: []promptiterengine.RoundResult{{
+			Round: 1, Validation: testEvaluation(candidate), OutputProfile: profile("candidate"),
+			Acceptance: &promptiterengine.AcceptanceDecision{Accepted: engineAccepted},
+		}},
+	}
+}
+
+func testEvaluation(score float64) *promptiterengine.EvaluationResult {
+	evalStatus := status.EvalStatusFailed
+	if score >= 0.6 {
+		evalStatus = status.EvalStatusPassed
+	}
+	return &promptiterengine.EvaluationResult{OverallScore: score, EvalSets: []promptiterengine.EvalSetResult{{
+		EvalSetID: "validation", OverallScore: score,
+		Cases: []promptiterengine.CaseResult{{EvalSetID: "validation", EvalCaseID: "case-1", Metrics: []promptiterengine.MetricResult{{MetricName: "quality", Score: score, Status: evalStatus}}}},
+	}}}
+}
+
+func profile(text string) *promptiter.Profile {
+	return &promptiter.Profile{StructureID: "structure", Overrides: []promptiter.SurfaceOverride{{
+		SurfaceID: "agent#instruction", Value: astructure.SurfaceValue{Text: &text},
+	}}}
+}

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/regression.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/regression.go
@@ -95,9 +95,12 @@ func ValidateGateConfig(cfg GateConfig) error {
 	}
 	seen := make(map[string]struct{}, len(cfg.CriticalCaseIDs))
 	for _, id := range cfg.CriticalCaseIDs {
-		id = strings.TrimSpace(id)
-		if id == "" {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
 			return fmt.Errorf("critical case id must not be empty")
+		}
+		if id != trimmed {
+			return fmt.Errorf("critical case id %q must not have leading or trailing whitespace", id)
 		}
 		if _, exists := seen[id]; exists {
 			return fmt.Errorf("duplicate critical case id %q", id)

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/regression.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/regression.go
@@ -1,0 +1,344 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+type AttributionCategory string
+
+const (
+	attributionFinalResponse AttributionCategory = "final_response_mismatch"
+	attributionToolCall      AttributionCategory = "tool_call_error"
+	attributionToolArgument  AttributionCategory = "tool_argument_error"
+	attributionRouting       AttributionCategory = "routing_error"
+	attributionFormat        AttributionCategory = "format_error"
+	attributionKnowledge     AttributionCategory = "knowledge_recall"
+	attributionExecution     AttributionCategory = "execution_error"
+	attributionUnknown       AttributionCategory = "unknown"
+)
+
+type GateConfig struct {
+	MinScoreGain        float64  `json:"minScoreGain"`
+	MaxNewFailures      int      `json:"maxNewFailures"`
+	MaxScoreRegressions int      `json:"maxScoreRegressions"`
+	CriticalCaseIDs     []string `json:"criticalCaseIds"`
+	MaxModelCalls       int      `json:"maxModelCalls"`
+	MaxToolCalls        int      `json:"maxToolCalls"`
+	MaxTokens           int      `json:"maxTokens"`
+}
+
+type UsageSummary struct {
+	ModelCalls int `json:"modelCalls"`
+	ToolCalls  int `json:"toolCalls"`
+	Tokens     int `json:"tokens"`
+}
+
+type MetricDelta struct {
+	Name            string  `json:"name"`
+	BaselineScore   float64 `json:"baselineScore"`
+	CandidateScore  float64 `json:"candidateScore"`
+	Delta           float64 `json:"delta"`
+	BaselinePassed  bool    `json:"baselinePassed"`
+	CandidatePassed bool    `json:"candidatePassed"`
+	Reason          string  `json:"reason,omitempty"`
+}
+
+type CaseDelta struct {
+	EvalSetID       string                `json:"evalSetId"`
+	CaseID          string                `json:"caseId"`
+	BaselinePassed  bool                  `json:"baselinePassed"`
+	CandidatePassed bool                  `json:"candidatePassed"`
+	Outcome         string                `json:"outcome"`
+	Metrics         []MetricDelta         `json:"metrics"`
+	Attributions    []AttributionCategory `json:"attributions,omitempty"`
+}
+
+type DeltaSummary struct {
+	BaselineScore  float64     `json:"baselineScore"`
+	CandidateScore float64     `json:"candidateScore"`
+	ScoreDelta     float64     `json:"scoreDelta"`
+	NewPasses      int         `json:"newPasses"`
+	NewFailures    int         `json:"newFailures"`
+	Regressions    int         `json:"scoreRegressions"`
+	Cases          []CaseDelta `json:"cases"`
+}
+
+type GateDecision struct {
+	Accepted bool     `json:"accepted"`
+	Reasons  []string `json:"reasons"`
+}
+
+// ValidateGateConfig rejects ambiguous or impossible gate settings.
+func ValidateGateConfig(cfg GateConfig) error {
+	if cfg.MinScoreGain < 0 {
+		return fmt.Errorf("minimum score gain must not be negative")
+	}
+	if cfg.MaxNewFailures < 0 || cfg.MaxScoreRegressions < 0 {
+		return fmt.Errorf("failure and regression limits must not be negative")
+	}
+	if cfg.MaxModelCalls < 0 || cfg.MaxToolCalls < 0 || cfg.MaxTokens < 0 {
+		return fmt.Errorf("usage limits must not be negative")
+	}
+	seen := make(map[string]struct{}, len(cfg.CriticalCaseIDs))
+	for _, id := range cfg.CriticalCaseIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return fmt.Errorf("critical case id must not be empty")
+		}
+		if _, exists := seen[id]; exists {
+			return fmt.Errorf("duplicate critical case id %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+func CompareEvaluations(baseline, candidate *promptiterengine.EvaluationResult) (DeltaSummary, error) {
+	if baseline == nil || candidate == nil {
+		return DeltaSummary{}, fmt.Errorf("baseline and candidate evaluations are required")
+	}
+	baseCases, err := indexCases(baseline)
+	if err != nil {
+		return DeltaSummary{}, fmt.Errorf("invalid baseline evaluation: %w", err)
+	}
+	candidateCases, err := indexCases(candidate)
+	if err != nil {
+		return DeltaSummary{}, fmt.Errorf("invalid candidate evaluation: %w", err)
+	}
+	if len(baseCases) == 0 {
+		return DeltaSummary{}, fmt.Errorf("baseline evaluation has no cases")
+	}
+	if len(baseCases) != len(candidateCases) {
+		return DeltaSummary{}, fmt.Errorf("evaluation case count changed from %d to %d", len(baseCases), len(candidateCases))
+	}
+	keys := make([]string, 0, len(baseCases))
+	for key := range baseCases {
+		if _, ok := candidateCases[key]; !ok {
+			return DeltaSummary{}, fmt.Errorf("candidate evaluation is missing case %q", key)
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := DeltaSummary{
+		BaselineScore:  baseline.OverallScore,
+		CandidateScore: candidate.OverallScore,
+		ScoreDelta:     candidate.OverallScore - baseline.OverallScore,
+	}
+	for _, key := range keys {
+		baseCase := baseCases[key]
+		candidateCase := candidateCases[key]
+		change, err := compareCases(baseCase, candidateCase)
+		if err != nil {
+			return DeltaSummary{}, err
+		}
+		switch change.Outcome {
+		case "new_pass":
+			result.NewPasses++
+		case "new_failure":
+			result.NewFailures++
+		}
+		for _, metric := range change.Metrics {
+			if metric.Delta < 0 {
+				result.Regressions++
+			}
+		}
+		result.Cases = append(result.Cases, change)
+	}
+	return result, nil
+}
+
+func indexCases(result *promptiterengine.EvaluationResult) (map[string]promptiterengine.CaseResult, error) {
+	indexed := make(map[string]promptiterengine.CaseResult)
+	for _, evalSet := range result.EvalSets {
+		if strings.TrimSpace(evalSet.EvalSetID) == "" {
+			return nil, fmt.Errorf("eval set id is empty")
+		}
+		for _, evalCase := range evalSet.Cases {
+			if strings.TrimSpace(evalCase.EvalCaseID) == "" {
+				return nil, fmt.Errorf("case id is empty in eval set %q", evalSet.EvalSetID)
+			}
+			key := evalSet.EvalSetID + "/" + evalCase.EvalCaseID
+			if _, exists := indexed[key]; exists {
+				return nil, fmt.Errorf("duplicate case %q", key)
+			}
+			indexed[key] = evalCase
+		}
+	}
+	return indexed, nil
+}
+
+func compareCases(baseline, candidate promptiterengine.CaseResult) (CaseDelta, error) {
+	baseMetrics, err := indexMetrics(baseline.Metrics)
+	if err != nil {
+		return CaseDelta{}, fmt.Errorf("invalid baseline case %q: %w", baseline.EvalCaseID, err)
+	}
+	candidateMetrics, err := indexMetrics(candidate.Metrics)
+	if err != nil {
+		return CaseDelta{}, fmt.Errorf("invalid candidate case %q: %w", candidate.EvalCaseID, err)
+	}
+	if len(baseMetrics) == 0 {
+		return CaseDelta{}, fmt.Errorf("case %q has no metrics", baseline.EvalCaseID)
+	}
+	if len(baseMetrics) != len(candidateMetrics) {
+		return CaseDelta{}, fmt.Errorf("metric count changed for case %q", baseline.EvalCaseID)
+	}
+	result := CaseDelta{EvalSetID: baseline.EvalSetID, CaseID: baseline.EvalCaseID}
+	names := make([]string, 0, len(baseMetrics))
+	for name := range baseMetrics {
+		if _, ok := candidateMetrics[name]; !ok {
+			return CaseDelta{}, fmt.Errorf("candidate case %q is missing metric %q", baseline.EvalCaseID, name)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	result.BaselinePassed = true
+	result.CandidatePassed = true
+	for _, name := range names {
+		baseMetric := baseMetrics[name]
+		candidateMetric := candidateMetrics[name]
+		basePassed := baseMetric.Status == status.EvalStatusPassed
+		candidatePassed := candidateMetric.Status == status.EvalStatusPassed
+		result.BaselinePassed = result.BaselinePassed && basePassed
+		result.CandidatePassed = result.CandidatePassed && candidatePassed
+		result.Metrics = append(result.Metrics, MetricDelta{
+			Name: name, BaselineScore: baseMetric.Score, CandidateScore: candidateMetric.Score,
+			Delta: candidateMetric.Score - baseMetric.Score, BaselinePassed: basePassed,
+			CandidatePassed: candidatePassed, Reason: candidateMetric.Reason,
+		})
+	}
+	switch {
+	case !result.BaselinePassed && result.CandidatePassed:
+		result.Outcome = "new_pass"
+	case result.BaselinePassed && !result.CandidatePassed:
+		result.Outcome = "new_failure"
+	default:
+		result.Outcome = "unchanged"
+	}
+	if !result.CandidatePassed {
+		result.Attributions = AttributeFailure(candidate)
+	}
+	return result, nil
+}
+
+func indexMetrics(metrics []promptiterengine.MetricResult) (map[string]promptiterengine.MetricResult, error) {
+	indexed := make(map[string]promptiterengine.MetricResult, len(metrics))
+	for _, metric := range metrics {
+		if strings.TrimSpace(metric.MetricName) == "" {
+			return nil, fmt.Errorf("metric name is empty")
+		}
+		if _, exists := indexed[metric.MetricName]; exists {
+			return nil, fmt.Errorf("duplicate metric %q", metric.MetricName)
+		}
+		indexed[metric.MetricName] = metric
+	}
+	return indexed, nil
+}
+
+func AttributeFailure(evalCase promptiterengine.CaseResult) []AttributionCategory {
+	seen := make(map[AttributionCategory]struct{})
+	add := func(category AttributionCategory) { seen[category] = struct{}{} }
+	for _, metric := range evalCase.Metrics {
+		if metric.Status != status.EvalStatusFailed {
+			continue
+		}
+		text := strings.ToLower(metric.MetricName + " " + metric.Reason)
+		switch {
+		case containsAny(text, "tool argument", "tool parameter", "argument", "parameter"):
+			add(attributionToolArgument)
+		case containsAny(text, "tool", "trajectory"):
+			add(attributionToolCall)
+		case containsAny(text, "route", "router", "routing"):
+			add(attributionRouting)
+		case containsAny(text, "format", "json", "schema", "structure"):
+			add(attributionFormat)
+		case containsAny(text, "knowledge", "recall", "grounding"):
+			add(attributionKnowledge)
+		case containsAny(text, "response", "answer", "rouge"):
+			add(attributionFinalResponse)
+		default:
+			add(attributionUnknown)
+		}
+	}
+	if evalCase.Trace != nil {
+		if evalCase.Trace.Status != atrace.TraceStatusCompleted {
+			add(attributionExecution)
+		}
+		for _, step := range evalCase.Trace.Steps {
+			if step.Error != "" {
+				if step.NodeType == "tool" {
+					add(attributionToolCall)
+				} else {
+					add(attributionExecution)
+				}
+			}
+		}
+	}
+	result := make([]AttributionCategory, 0, len(seen))
+	for category := range seen {
+		result = append(result, category)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}
+
+func containsAny(value string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		if strings.Contains(value, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func DecideGate(cfg GateConfig, delta DeltaSummary, usage UsageSummary) GateDecision {
+	decision := GateDecision{Accepted: true}
+	reject := func(reason string) {
+		decision.Accepted = false
+		decision.Reasons = append(decision.Reasons, reason)
+	}
+	if delta.ScoreDelta < cfg.MinScoreGain {
+		reject(fmt.Sprintf("score gain %.4f is below minimum %.4f", delta.ScoreDelta, cfg.MinScoreGain))
+	}
+	if delta.NewFailures > cfg.MaxNewFailures {
+		reject(fmt.Sprintf("new failures %d exceed limit %d", delta.NewFailures, cfg.MaxNewFailures))
+	}
+	if delta.Regressions > cfg.MaxScoreRegressions {
+		reject(fmt.Sprintf("metric regressions %d exceed limit %d", delta.Regressions, cfg.MaxScoreRegressions))
+	}
+	critical := make(map[string]struct{}, len(cfg.CriticalCaseIDs))
+	for _, id := range cfg.CriticalCaseIDs {
+		critical[id] = struct{}{}
+	}
+	for _, evalCase := range delta.Cases {
+		if _, ok := critical[evalCase.CaseID]; ok && evalCase.BaselinePassed && !evalCase.CandidatePassed {
+			reject(fmt.Sprintf("critical case %q regressed", evalCase.CaseID))
+		}
+	}
+	if cfg.MaxModelCalls > 0 && usage.ModelCalls > cfg.MaxModelCalls {
+		reject("model call budget exceeded")
+	}
+	if cfg.MaxToolCalls > 0 && usage.ToolCalls > cfg.MaxToolCalls {
+		reject("tool call budget exceeded")
+	}
+	if cfg.MaxTokens > 0 && usage.Tokens > cfg.MaxTokens {
+		reject("token budget exceeded")
+	}
+	if decision.Accepted {
+		decision.Reasons = []string{"all acceptance gates passed"}
+	}
+	return decision
+}

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/regression_test.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/regression_test.go
@@ -61,6 +61,8 @@ func TestDecideGateRejectsBudgets(t *testing.T) {
 func TestValidateGateConfig(t *testing.T) {
 	require.Error(t, ValidateGateConfig(GateConfig{MinScoreGain: -1}))
 	require.Error(t, ValidateGateConfig(GateConfig{CriticalCaseIDs: []string{"critical", "critical"}}))
+	require.EqualError(t, ValidateGateConfig(GateConfig{CriticalCaseIDs: []string{" critical "}}),
+		`critical case id " critical " must not have leading or trailing whitespace`)
 	require.NoError(t, ValidateGateConfig(GateConfig{CriticalCaseIDs: []string{"critical"}}))
 }
 

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/regression_test.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/regression_test.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	atrace "trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	promptiterengine "trpc.group/trpc-go/trpc-agent-go/evaluation/workflow/promptiter/engine"
+)
+
+func TestCompareEvaluationsClassifiesCaseChanges(t *testing.T) {
+	baseline := evaluation(0.5, evalCase("a", 0, status.EvalStatusFailed, "answer mismatch"), evalCase("b", 1, status.EvalStatusPassed, ""))
+	candidate := evaluation(0.75, evalCase("a", 1, status.EvalStatusPassed, ""), evalCase("b", 0.5, status.EvalStatusFailed, "format invalid"))
+	delta, err := CompareEvaluations(baseline, candidate)
+	require.NoError(t, err)
+	assert.Equal(t, 1, delta.NewPasses)
+	assert.Equal(t, 1, delta.NewFailures)
+	assert.Equal(t, 1, delta.Regressions)
+	assert.Equal(t, attributionFormat, delta.Cases[1].Attributions[0])
+}
+
+func TestCompareEvaluationsRejectsMisalignedCases(t *testing.T) {
+	_, err := CompareEvaluations(evaluation(1, evalCase("a", 1, status.EvalStatusPassed, "")), evaluation(1, evalCase("b", 1, status.EvalStatusPassed, "")))
+	require.ErrorContains(t, err, "missing case")
+}
+
+func TestAttributeFailureUsesTraceEvidence(t *testing.T) {
+	input := evalCase("a", 0, status.EvalStatusFailed, "trajectory mismatch")
+	input.Trace = &atrace.Trace{Status: atrace.TraceStatusFailed, Steps: []atrace.Step{{NodeType: "tool", Error: "boom"}}}
+	assert.ElementsMatch(t, []AttributionCategory{attributionExecution, attributionToolCall}, AttributeFailure(input))
+}
+
+func TestDecideGateAcceptsImprovement(t *testing.T) {
+	decision := DecideGate(GateConfig{MinScoreGain: 0.1, MaxNewFailures: 0, MaxScoreRegressions: 0}, DeltaSummary{ScoreDelta: 0.2}, UsageSummary{})
+	assert.True(t, decision.Accepted)
+}
+
+func TestDecideGateRejectsOverfitting(t *testing.T) {
+	delta := DeltaSummary{ScoreDelta: 0.2, NewFailures: 1, Regressions: 1, Cases: []CaseDelta{{CaseID: "critical", BaselinePassed: true, CandidatePassed: false}}}
+	decision := DecideGate(GateConfig{MinScoreGain: 0.1, CriticalCaseIDs: []string{"critical"}}, delta, UsageSummary{})
+	assert.False(t, decision.Accepted)
+	assert.Len(t, decision.Reasons, 3)
+}
+
+func TestDecideGateRejectsBudgets(t *testing.T) {
+	decision := DecideGate(GateConfig{MaxModelCalls: 2, MaxToolCalls: 2, MaxTokens: 10}, DeltaSummary{}, UsageSummary{ModelCalls: 3, ToolCalls: 3, Tokens: 11})
+	assert.False(t, decision.Accepted)
+	assert.Len(t, decision.Reasons, 3)
+}
+
+func TestValidateGateConfig(t *testing.T) {
+	require.Error(t, ValidateGateConfig(GateConfig{MinScoreGain: -1}))
+	require.Error(t, ValidateGateConfig(GateConfig{CriticalCaseIDs: []string{"critical", "critical"}}))
+	require.NoError(t, ValidateGateConfig(GateConfig{CriticalCaseIDs: []string{"critical"}}))
+}
+
+func evaluation(score float64, cases ...promptiterengine.CaseResult) *promptiterengine.EvaluationResult {
+	return &promptiterengine.EvaluationResult{OverallScore: score, EvalSets: []promptiterengine.EvalSetResult{{EvalSetID: "validation", OverallScore: score, Cases: cases}}}
+}
+
+func evalCase(id string, score float64, evalStatus status.EvalStatus, reason string) promptiterengine.CaseResult {
+	return promptiterengine.CaseResult{EvalSetID: "validation", EvalCaseID: id, Metrics: []promptiterengine.MetricResult{{MetricName: "quality", Score: score, Status: evalStatus, Reason: reason}}}
+}

--- a/examples/evaluation/promptiter_regression_loop/internal/regression/writer.go
+++ b/examples/evaluation/promptiter_regression_loop/internal/regression/writer.go
@@ -1,0 +1,94 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package regression
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriteReports atomically writes machine-readable and human-readable reports.
+func WriteReports(outputDir string, report *Report) error {
+	if report == nil {
+		return fmt.Errorf("report is nil")
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	payload, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON report: %w", err)
+	}
+	if err := atomicWrite(filepath.Join(outputDir, "optimization_report.json"), append(payload, '\n')); err != nil {
+		return err
+	}
+	if err := atomicWrite(filepath.Join(outputDir, "optimization_report.md"), []byte(renderMarkdown(report))); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteAcceptedPrompt writes one accepted text surface and rejects unsafe writeback.
+func WriteAcceptedPrompt(path, surfaceID string, report *Report) error {
+	if report == nil || !report.Accepted || report.AcceptedProfile == nil {
+		return fmt.Errorf("no accepted profile is available for writeback")
+	}
+	for _, override := range report.AcceptedProfile.Overrides {
+		if override.SurfaceID != surfaceID {
+			continue
+		}
+		if override.Value.Text == nil {
+			return fmt.Errorf("accepted surface %q is not text", surfaceID)
+		}
+		return atomicWrite(path, []byte(*override.Value.Text))
+	}
+	return fmt.Errorf("accepted profile does not contain surface %q", surfaceID)
+}
+
+func atomicWrite(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".optimization-report-*")
+	if err != nil {
+		return fmt.Errorf("create temporary report: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temporary report: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary report: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("publish report: %w", err)
+	}
+	return nil
+}
+
+func renderMarkdown(report *Report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# PromptIter Optimization Report\n\n")
+	fmt.Fprintf(&b, "- Run status: `%s`\n- Baseline score: `%.4f`\n- Accepted: `%t`\n\n", report.RunStatus, report.BaselineScore, report.Accepted)
+	b.WriteString("| Round | Candidate | Gate delta | New failures | Regressions | Decision |\n")
+	b.WriteString("|---:|---:|---:|---:|---:|---|\n")
+	for _, round := range report.Rounds {
+		fmt.Fprintf(&b, "| %d | %.4f | %+.4f | %d | %d | %s |\n", round.Round,
+			round.DeltaFromAccepted.CandidateScore, round.DeltaFromAccepted.ScoreDelta,
+			round.DeltaFromAccepted.NewFailures, round.DeltaFromAccepted.Regressions,
+			map[bool]string{true: "accept", false: "reject"}[round.Decision.Accepted])
+	}
+	b.WriteString("\n## Final decision\n\n")
+	for _, reason := range report.FinalReasons {
+		fmt.Fprintf(&b, "- %s\n", reason)
+	}
+	return b.String()
+}

--- a/examples/evaluation/promptiter_regression_loop/main.go
+++ b/examples/evaluation/promptiter_regression_loop/main.go
@@ -1,0 +1,49 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"trpc.group/trpc-go/trpc-agent-go/examples/evaluation/promptiter_regression_loop/internal/regression"
+)
+
+var (
+	scenario  = flag.String("scenario", "success", "Deterministic scenario: success, ineffective, or overfit")
+	outputDir = flag.String("output-dir", "./output", "Report output directory")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	engine, err := newDeterministicEngine(ctx, *scenario)
+	if err != nil {
+		log.Fatal(err)
+	}
+	report, err := regression.Run(ctx, engine, deterministicRequest(), regression.GateConfig{
+		MinScoreGain: 0.05, MaxNewFailures: 0, MaxScoreRegressions: 0,
+		CriticalCaseIDs: []string{"validation_account_security"}, MaxModelCalls: 10, MaxTokens: 1000,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := regression.WriteReports(*outputDir, report); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("scenario=%s accepted=%t report=%s\n", *scenario, report.Accepted, *outputDir)
+}
+
+type caseSpec struct {
+	id     string
+	score  float64
+	reason string
+}

--- a/examples/evaluation/promptiter_regression_loop/main_test.go
+++ b/examples/evaluation/promptiter_regression_loop/main_test.go
@@ -1,0 +1,47 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/examples/evaluation/promptiter_regression_loop/internal/regression"
+)
+
+func TestDeterministicScenarios(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted bool
+	}{
+		{name: "success", accepted: true},
+		{name: "ineffective", accepted: false},
+		{name: "overfit", accepted: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			engine, err := newDeterministicEngine(ctx, test.name)
+			require.NoError(t, err)
+			report, err := regression.Run(ctx, engine, deterministicRequest(), regression.GateConfig{
+				MinScoreGain: 0.05, MaxNewFailures: 0, MaxScoreRegressions: 0,
+				CriticalCaseIDs: []string{"validation_account_security"},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, test.accepted, report.Accepted)
+		})
+	}
+}
+
+func TestDeterministicRunRejectsUnknownScenario(t *testing.T) {
+	_, err := newDeterministicEngine(context.Background(), "unknown")
+	require.ErrorContains(t, err, "unknown scenario")
+}

--- a/examples/evaluation/promptiter_regression_loop/output/ineffective/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/ineffective/optimization_report.json
@@ -1,0 +1,167 @@
+{
+  "schemaVersion": "1.0",
+  "generatedAt": "2026-08-03T06:39:15.829698Z",
+  "runStatus": "succeeded",
+  "baselineScore": 0.6,
+  "rounds": [
+    {
+      "round": 1,
+      "deltaFromOriginal": {
+        "baselineScore": 0.6,
+        "candidateScore": 0.6,
+        "scoreDelta": 0,
+        "newPasses": 0,
+        "newFailures": 0,
+        "scoreRegressions": 0,
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_account_security",
+            "baselinePassed": true,
+            "candidatePassed": true,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 1,
+                "candidateScore": 1,
+                "delta": 0,
+                "baselinePassed": true,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_refund_format",
+            "baselinePassed": false,
+            "candidatePassed": false,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 0.4,
+                "delta": 0,
+                "baselinePassed": false,
+                "candidatePassed": false,
+                "reason": "format schema mismatch"
+              }
+            ],
+            "attributions": [
+              "format_error"
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_return_shipping",
+            "baselinePassed": false,
+            "candidatePassed": false,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 0.4,
+                "delta": 0,
+                "baselinePassed": false,
+                "candidatePassed": false,
+                "reason": "final response misses shipping policy"
+              }
+            ],
+            "attributions": [
+              "final_response_mismatch"
+            ]
+          }
+        ]
+      },
+      "deltaFromAccepted": {
+        "baselineScore": 0.6,
+        "candidateScore": 0.6,
+        "scoreDelta": 0,
+        "newPasses": 0,
+        "newFailures": 0,
+        "scoreRegressions": 0,
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_account_security",
+            "baselinePassed": true,
+            "candidatePassed": true,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 1,
+                "candidateScore": 1,
+                "delta": 0,
+                "baselinePassed": true,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_refund_format",
+            "baselinePassed": false,
+            "candidatePassed": false,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 0.4,
+                "delta": 0,
+                "baselinePassed": false,
+                "candidatePassed": false,
+                "reason": "format schema mismatch"
+              }
+            ],
+            "attributions": [
+              "format_error"
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_return_shipping",
+            "baselinePassed": false,
+            "candidatePassed": false,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 0.4,
+                "delta": 0,
+                "baselinePassed": false,
+                "candidatePassed": false,
+                "reason": "final response misses shipping policy"
+              }
+            ],
+            "attributions": [
+              "final_response_mismatch"
+            ]
+          }
+        ]
+      },
+      "usage": {
+        "modelCalls": 3,
+        "toolCalls": 0,
+        "tokens": 300
+      },
+      "decision": {
+        "accepted": false,
+        "reasons": [
+          "score gain 0.0000 is below minimum 0.0500",
+          "PromptIter engine rejected the candidate"
+        ]
+      },
+      "engineAccepted": false
+    }
+  ],
+  "accepted": false,
+  "finalReasons": [
+    "score gain 0.0000 is below minimum 0.0500",
+    "PromptIter engine rejected the candidate"
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/output/ineffective/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/ineffective/optimization_report.md
@@ -1,0 +1,14 @@
+# PromptIter Optimization Report
+
+- Run status: `succeeded`
+- Baseline score: `0.6000`
+- Accepted: `false`
+
+| Round | Candidate | Gate delta | New failures | Regressions | Decision |
+|---:|---:|---:|---:|---:|---|
+| 1 | 0.6000 | +0.0000 | 0 | 0 | reject |
+
+## Final decision
+
+- score gain 0.0000 is below minimum 0.0500
+- PromptIter engine rejected the candidate

--- a/examples/evaluation/promptiter_regression_loop/output/overfit/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/overfit/optimization_report.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": "1.0",
+  "generatedAt": "2026-08-03T06:39:16.009737Z",
+  "runStatus": "succeeded",
+  "baselineScore": 0.6,
+  "rounds": [
+    {
+      "round": 1,
+      "deltaFromOriginal": {
+        "baselineScore": 0.6,
+        "candidateScore": 0.6666666666666666,
+        "scoreDelta": 0.06666666666666665,
+        "newPasses": 2,
+        "newFailures": 1,
+        "scoreRegressions": 1,
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_account_security",
+            "baselinePassed": true,
+            "candidatePassed": false,
+            "outcome": "new_failure",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 1,
+                "candidateScore": 0,
+                "delta": -1,
+                "baselinePassed": true,
+                "candidatePassed": false,
+                "reason": "routing error exposes an unsafe path"
+              }
+            ],
+            "attributions": [
+              "routing_error"
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_refund_format",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_return_shipping",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          }
+        ]
+      },
+      "deltaFromAccepted": {
+        "baselineScore": 0.6,
+        "candidateScore": 0.6666666666666666,
+        "scoreDelta": 0.06666666666666665,
+        "newPasses": 2,
+        "newFailures": 1,
+        "scoreRegressions": 1,
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_account_security",
+            "baselinePassed": true,
+            "candidatePassed": false,
+            "outcome": "new_failure",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 1,
+                "candidateScore": 0,
+                "delta": -1,
+                "baselinePassed": true,
+                "candidatePassed": false,
+                "reason": "routing error exposes an unsafe path"
+              }
+            ],
+            "attributions": [
+              "routing_error"
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_refund_format",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_return_shipping",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          }
+        ]
+      },
+      "usage": {
+        "modelCalls": 3,
+        "toolCalls": 0,
+        "tokens": 300
+      },
+      "decision": {
+        "accepted": false,
+        "reasons": [
+          "new failures 1 exceed limit 0",
+          "metric regressions 1 exceed limit 0",
+          "critical case \"validation_account_security\" regressed"
+        ]
+      },
+      "engineAccepted": true
+    }
+  ],
+  "accepted": false,
+  "finalReasons": [
+    "new failures 1 exceed limit 0",
+    "metric regressions 1 exceed limit 0",
+    "critical case \"validation_account_security\" regressed"
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/output/overfit/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/overfit/optimization_report.md
@@ -1,0 +1,15 @@
+# PromptIter Optimization Report
+
+- Run status: `succeeded`
+- Baseline score: `0.6000`
+- Accepted: `false`
+
+| Round | Candidate | Gate delta | New failures | Regressions | Decision |
+|---:|---:|---:|---:|---:|---|
+| 1 | 0.6667 | +0.0667 | 1 | 1 | reject |
+
+## Final decision
+
+- new failures 1 exceed limit 0
+- metric regressions 1 exceed limit 0
+- critical case "validation_account_security" regressed

--- a/examples/evaluation/promptiter_regression_loop/output/success/optimization_report.json
+++ b/examples/evaluation/promptiter_regression_loop/output/success/optimization_report.json
@@ -1,0 +1,166 @@
+{
+  "schemaVersion": "1.0",
+  "generatedAt": "2026-08-03T06:39:15.218834Z",
+  "runStatus": "succeeded",
+  "baselineScore": 0.6,
+  "rounds": [
+    {
+      "round": 1,
+      "deltaFromOriginal": {
+        "baselineScore": 0.6,
+        "candidateScore": 1,
+        "scoreDelta": 0.4,
+        "newPasses": 2,
+        "newFailures": 0,
+        "scoreRegressions": 0,
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_account_security",
+            "baselinePassed": true,
+            "candidatePassed": true,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 1,
+                "candidateScore": 1,
+                "delta": 0,
+                "baselinePassed": true,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_refund_format",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_return_shipping",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          }
+        ]
+      },
+      "deltaFromAccepted": {
+        "baselineScore": 0.6,
+        "candidateScore": 1,
+        "scoreDelta": 0.4,
+        "newPasses": 2,
+        "newFailures": 0,
+        "scoreRegressions": 0,
+        "cases": [
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_account_security",
+            "baselinePassed": true,
+            "candidatePassed": true,
+            "outcome": "unchanged",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 1,
+                "candidateScore": 1,
+                "delta": 0,
+                "baselinePassed": true,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_refund_format",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          },
+          {
+            "evalSetId": "validation",
+            "caseId": "validation_return_shipping",
+            "baselinePassed": false,
+            "candidatePassed": true,
+            "outcome": "new_pass",
+            "metrics": [
+              {
+                "name": "quality",
+                "baselineScore": 0.4,
+                "candidateScore": 1,
+                "delta": 0.6,
+                "baselinePassed": false,
+                "candidatePassed": true
+              }
+            ]
+          }
+        ]
+      },
+      "usage": {
+        "modelCalls": 3,
+        "toolCalls": 0,
+        "tokens": 300
+      },
+      "decision": {
+        "accepted": true,
+        "reasons": [
+          "all acceptance gates passed"
+        ]
+      },
+      "engineAccepted": true
+    }
+  ],
+  "acceptedRound": 1,
+  "accepted": true,
+  "acceptedProfile": {
+    "StructureID": "deterministic-support-agent",
+    "Overrides": [
+      {
+        "SurfaceID": "support-agent#instruction",
+        "Value": {
+          "Text": "Answer with policy-grounded steps and preserve the required response schema.",
+          "PromptSyntax": null,
+          "FewShot": null,
+          "Model": null,
+          "Tools": null,
+          "Skills": null
+        }
+      }
+    ]
+  },
+  "finalReasons": [
+    "all acceptance gates passed"
+  ]
+}

--- a/examples/evaluation/promptiter_regression_loop/output/success/optimization_report.md
+++ b/examples/evaluation/promptiter_regression_loop/output/success/optimization_report.md
@@ -1,0 +1,13 @@
+# PromptIter Optimization Report
+
+- Run status: `succeeded`
+- Baseline score: `0.6000`
+- Accepted: `true`
+
+| Round | Candidate | Gate delta | New failures | Regressions | Decision |
+|---:|---:|---:|---:|---:|---|
+| 1 | 1.0000 | +0.4000 | 0 | 0 | accept |
+
+## Final decision
+
+- all acceptance gates passed


### PR DESCRIPTION
## Summary

  Add an example-level PromptIter regression optimization loop for #2003.

  The example reuses the existing PromptIter engine and Evaluation Service result contracts instead of
  introducing another optimizer API. It adds deterministic regression analysis and guarded prompt
  promotion around `engine.RunResult`.

 ## Changes

  - add strict eval-set, case, and metric identity validation
  - compare every candidate against both the original and latest accepted baselines
  - attribute failures using metric reasons and execution trace evidence
  - add configurable gates for:
    - minimum score improvement
    - new failures
    - metric regressions
    - critical validation cases
    - model calls, tool calls, and token budgets
  - require both PromptIter acceptance and regression-gate acceptance
  - prevent rejected or incomplete candidates from being promoted
  - write auditable JSON and Markdown reports atomically
  - add guarded accepted-prompt writeback
  - add deterministic success, ineffective, and overfit scenarios
  - run the deterministic scenarios through the actual PromptIter engine with offline collaborators

 ## Validation

  - `go test ./promptiter_regression_loop/... -race -count=1`
  - `go vet ./promptiter_regression_loop/...`
  - `go build ./promptiter_regression_loop/...`
  - `go test ./...`

  The repository-wide `go vet ./...` also reports an existing loop-variable warning in `tool/duckduckgo/
  duckduckgo_test.go`, unrelated to this change.

  Fixes #2003