### PR TITLE
{model, server/agui}: support typed multimodal inputs

### DIFF
--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -209,6 +209,7 @@ func TestCloneEvalSetResult_NilInput(t *testing.T) {
 func TestCloneEvalCase_DeepCopy(t *testing.T) {
 	srcText := "hello"
 	audioBytes := []byte{3, 2, 1}
+	videoBytes := []byte{4, 5, 6}
 	fileBytes := []byte{7, 8, 9}
 	src := &evalset.EvalCase{
 		EvalID: "case-1",
@@ -220,6 +221,7 @@ func TestCloneEvalCase_DeepCopy(t *testing.T) {
 					{Type: model.ContentTypeText, Text: &srcText},
 					{Type: model.ContentTypeImage, Image: &model.Image{Data: []byte{1, 2, 3}}},
 					{Type: model.ContentTypeAudio, Audio: &model.Audio{Data: audioBytes, Format: "wav"}},
+					{Type: model.ContentTypeVideo, Video: &model.Video{Data: videoBytes, Format: "mp4"}},
 					{Type: model.ContentTypeFile, File: &model.File{Name: "input.txt", Data: fileBytes, MimeType: "text/plain"}},
 				},
 				ToolCalls: []model.ToolCall{
@@ -374,8 +376,11 @@ func TestCloneEvalCase_DeepCopy(t *testing.T) {
 	dst.ContextMessages[0].ContentParts[2].Audio.Data[0] = 0
 	assert.Equal(t, byte(3), src.ContextMessages[0].ContentParts[2].Audio.Data[0])
 
-	dst.ContextMessages[0].ContentParts[3].File.Data[0] = 0
-	assert.Equal(t, byte(7), src.ContextMessages[0].ContentParts[3].File.Data[0])
+	dst.ContextMessages[0].ContentParts[3].Video.Data[0] = 0
+	assert.Equal(t, byte(4), src.ContextMessages[0].ContentParts[3].Video.Data[0])
+
+	dst.ContextMessages[0].ContentParts[4].File.Data[0] = 0
+	assert.Equal(t, byte(7), src.ContextMessages[0].ContentParts[4].File.Data[0])
 
 	dst.ContextMessages[0].ToolCalls[0].Function.Arguments[0] = 'X'
 	assert.Equal(t, byte('{'), src.ContextMessages[0].ToolCalls[0].Function.Arguments[0])
@@ -1003,6 +1008,7 @@ func TestCloneHelpers_NilInputs(t *testing.T) {
 	assert.Nil(t, cloneStringPtr(nil))
 	assert.Nil(t, cloneImage(nil))
 	assert.Nil(t, cloneAudio(nil))
+	assert.Nil(t, cloneVideo(nil))
 	assert.Nil(t, cloneFile(nil))
 }
 

--- a/evaluation/internal/clone/model.go
+++ b/evaluation/internal/clone/model.go
@@ -56,6 +56,9 @@ func cloneContentParts(src []model.ContentPart) []model.ContentPart {
 		if part.Audio != nil {
 			part.Audio = cloneAudio(part.Audio)
 		}
+		if part.Video != nil {
+			part.Video = cloneVideo(part.Video)
+		}
 		if part.File != nil {
 			part.File = cloneFile(part.File)
 		}
@@ -74,6 +77,15 @@ func cloneImage(src *model.Image) *model.Image {
 }
 
 func cloneAudio(src *model.Audio) *model.Audio {
+	if src == nil {
+		return nil
+	}
+	copied := *src
+	copied.Data = cloneBytes(src.Data)
+	return &copied
+}
+
+func cloneVideo(src *model.Video) *model.Video {
 	if src == nil {
 		return nil
 	}

--- a/examples/a2ui/go.mod
+++ b/examples/a2ui/go.mod
@@ -13,7 +13,7 @@ require (
 )
 
 require (
-	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9 // indirect
+	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/examples/a2ui/go.sum
+++ b/examples/a2ui/go.sum
@@ -1,5 +1,5 @@
-github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9 h1:70eYJzrmomfCBxj0GdpYXmU2bP3zV98Y014u1/PKemw=
-github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9 h1:DQFhA6IAPabs7cQ/Ryv1DfhfnGQ5cZLCBtf8YRqx2FY=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=

--- a/examples/agui/go.mod
+++ b/examples/agui/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9
+	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9
 	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.3
 	go.opentelemetry.io/otel v1.40.0

--- a/examples/agui/go.sum
+++ b/examples/agui/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9 h1:70eYJzrmomfCBxj0GdpYXmU2bP3zV98Y014u1/PKemw=
-github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9 h1:DQFhA6IAPabs7cQ/Ryv1DfhfnGQ5cZLCBtf8YRqx2FY=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=

--- a/examples/session/externalization/main.go
+++ b/examples/session/externalization/main.go
@@ -307,6 +307,11 @@ func cloneContentPart(part model.ContentPart) model.ContentPart {
 		audio.Data = append([]byte(nil), part.Audio.Data...)
 		clone.Audio = &audio
 	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = append([]byte(nil), part.Video.Data...)
+		clone.Video = &video
+	}
 	if part.File != nil {
 		file := *part.File
 		file.Data = append([]byte(nil), part.File.Data...)

--- a/graph/utils.go
+++ b/graph/utils.go
@@ -470,6 +470,9 @@ func deepCopyModelContentPartsWithVisited(
 			if in[i].Audio != nil {
 				out[i].Audio = deepCopyModelAudioWithVisited(in[i].Audio, visited)
 			}
+			if in[i].Video != nil {
+				out[i].Video = deepCopyModelVideoWithVisited(in[i].Video, visited)
+			}
 			if in[i].File != nil {
 				out[i].File = deepCopyModelFileWithVisited(in[i].File, visited)
 			}
@@ -487,6 +490,9 @@ func deepCopyModelContentPartsWithVisited(
 		}
 		if in[i].Audio != nil {
 			out[i].Audio = deepCopyModelAudioWithVisited(in[i].Audio, visited)
+		}
+		if in[i].Video != nil {
+			out[i].Video = deepCopyModelVideoWithVisited(in[i].Video, visited)
 		}
 		if in[i].File != nil {
 			out[i].File = deepCopyModelFileWithVisited(in[i].File, visited)
@@ -534,6 +540,25 @@ func deepCopyModelAudioWithVisited(
 	key := pointerVisitKey(reflect.ValueOf(in).Pointer(), reflect.TypeOf(in))
 	if cached, ok := visited[key]; ok {
 		return cached.(*model.Audio)
+	}
+	out := *in
+	visited[key] = &out
+	if in.Data != nil {
+		out.Data = deepCopyBytesWithVisited(in.Data, visited)
+	}
+	return &out
+}
+
+func deepCopyModelVideoWithVisited(
+	in *model.Video,
+	visited visitedMap,
+) *model.Video {
+	if in == nil {
+		return nil
+	}
+	key := pointerVisitKey(reflect.ValueOf(in).Pointer(), reflect.TypeOf(in))
+	if cached, ok := visited[key]; ok {
+		return cached.(*model.Video)
 	}
 	out := *in
 	visited[key] = &out

--- a/graph/utils_test.go
+++ b/graph/utils_test.go
@@ -515,6 +515,7 @@ func TestDeepCopyAny_MessageNestedValuesPreserveSharing(t *testing.T) {
 	args := []byte("args")
 	imageData := []byte("img")
 	audioData := []byte("aud")
+	videoData := []byte("vid")
 	fileData := []byte("file")
 	parts := []model.ContentPart{
 		{
@@ -522,7 +523,12 @@ func TestDeepCopyAny_MessageNestedValuesPreserveSharing(t *testing.T) {
 			Text:  &text,
 			Image: &model.Image{Data: imageData},
 			Audio: &model.Audio{Data: audioData, Format: "wav"},
-			File:  &model.File{Name: "f.txt", Data: fileData},
+			Video: &model.Video{
+				URL:    "https://example.com/video.mp4",
+				Data:   videoData,
+				Format: "mp4",
+			},
+			File: &model.File{Name: "f.txt", Data: fileData},
 		},
 	}
 	calls := []model.ToolCall{
@@ -559,6 +565,21 @@ func TestDeepCopyAny_MessageNestedValuesPreserveSharing(t *testing.T) {
 		reflect.ValueOf(copiedMsgs[0].ContentParts[0].Image.Data).Pointer(),
 		reflect.ValueOf(copiedMsgs[1].ContentParts[0].Image.Data).Pointer(),
 	)
+	require.Same(
+		t,
+		copiedMsgs[0].ContentParts[0].Video,
+		copiedMsgs[1].ContentParts[0].Video,
+	)
+	require.NotSame(
+		t,
+		parts[0].Video,
+		copiedMsgs[0].ContentParts[0].Video,
+	)
+	require.Equal(
+		t,
+		reflect.ValueOf(copiedMsgs[0].ContentParts[0].Video.Data).Pointer(),
+		reflect.ValueOf(copiedMsgs[1].ContentParts[0].Video.Data).Pointer(),
+	)
 	require.Equal(
 		t,
 		reflect.ValueOf(copiedMsgs[0].ToolCalls).Pointer(),
@@ -573,6 +594,16 @@ func TestDeepCopyAny_MessageNestedValuesPreserveSharing(t *testing.T) {
 	*copiedMsgs[0].ContentParts[0].Text = "updated"
 	require.Equal(t, "updated", *copiedMsgs[1].ContentParts[0].Text)
 	require.Equal(t, "shared", text)
+	copiedMsgs[0].ContentParts[0].Video.URL = "https://example.com/changed.mp4"
+	copiedMsgs[0].ContentParts[0].Video.Data[0] = 'X'
+	require.Equal(
+		t,
+		"https://example.com/changed.mp4",
+		copiedMsgs[1].ContentParts[0].Video.URL,
+	)
+	require.Equal(t, byte('X'), copiedMsgs[1].ContentParts[0].Video.Data[0])
+	require.Equal(t, "https://example.com/video.mp4", parts[0].Video.URL)
+	require.Equal(t, []byte("vid"), videoData)
 	copiedMsgs[0].ToolCalls[0].Function.Arguments[0] = 'X'
 	require.Equal(t, byte('X'), copiedMsgs[1].ToolCalls[0].Function.Arguments[0])
 	require.Equal(t, []byte("args"), args)

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -1631,7 +1631,7 @@ func TestCloneRequestForContextCompaction_DeepCopiesMutableFields(t *testing.T) 
 	req.Messages[0].ContentParts[0].Text = nil
 	req.Messages[0].ContentParts[1].Image.Data[0] = 9
 	req.Messages[0].ContentParts[2].Audio.Data[0] = 8
-	req.Messages[0].ContentParts[3].Video.Data[0] = 7
+	req.Messages[0].ContentParts[3].Video.Data[0] = 0
 	req.Messages[0].ContentParts[4].File.Data[0] = 'z'
 	req.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
 	req.Messages[0].ToolCalls[0].ExtraFields["nested"] = map[string]any{"k": "changed"}

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -1586,6 +1586,12 @@ func TestCloneRequestForContextCompaction_DeepCopiesMutableFields(t *testing.T) 
 					Format: "wav",
 				},
 			}, {
+				Type: model.ContentTypeVideo,
+				Video: &model.Video{
+					Data:   []byte{7, 8, 9},
+					Format: "mp4",
+				},
+			}, {
 				Type: model.ContentTypeFile,
 				File: &model.File{
 					Name: "test.txt",
@@ -1625,7 +1631,8 @@ func TestCloneRequestForContextCompaction_DeepCopiesMutableFields(t *testing.T) 
 	req.Messages[0].ContentParts[0].Text = nil
 	req.Messages[0].ContentParts[1].Image.Data[0] = 9
 	req.Messages[0].ContentParts[2].Audio.Data[0] = 8
-	req.Messages[0].ContentParts[3].File.Data[0] = 'z'
+	req.Messages[0].ContentParts[3].Video.Data[0] = 7
+	req.Messages[0].ContentParts[4].File.Data[0] = 'z'
 	req.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
 	req.Messages[0].ToolCalls[0].ExtraFields["nested"] = map[string]any{"k": "changed"}
 	req.Messages[0].ToolCalls[0].Index = nil
@@ -1637,7 +1644,8 @@ func TestCloneRequestForContextCompaction_DeepCopiesMutableFields(t *testing.T) 
 	require.Equal(t, "hello", *cloned.Messages[0].ContentParts[0].Text)
 	require.Equal(t, []byte{1, 2, 3}, cloned.Messages[0].ContentParts[1].Image.Data)
 	require.Equal(t, []byte{4, 5, 6}, cloned.Messages[0].ContentParts[2].Audio.Data)
-	require.Equal(t, []byte("abc"), cloned.Messages[0].ContentParts[3].File.Data)
+	require.Equal(t, []byte{7, 8, 9}, cloned.Messages[0].ContentParts[3].Video.Data)
+	require.Equal(t, []byte("abc"), cloned.Messages[0].ContentParts[4].File.Data)
 	require.Equal(
 		t,
 		[]byte(`{"q":"go"}`),

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1864,6 +1864,13 @@ func cloneContentPartForContextCompaction(
 		}
 		cloned.Audio = &audio
 	}
+	if part.Video != nil {
+		video := *part.Video
+		if part.Video.Data != nil {
+			video.Data = append([]byte(nil), part.Video.Data...)
+		}
+		cloned.Video = &video
+	}
 	if part.File != nil {
 		file := *part.File
 		if part.File.Data != nil {

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -1069,6 +1069,11 @@ func cloneToolResultContentParts(
 			audio.Data = append([]byte(nil), part.Audio.Data...)
 			cloned[i].Audio = &audio
 		}
+		if part.Video != nil {
+			video := *part.Video
+			video.Data = append([]byte(nil), part.Video.Data...)
+			cloned[i].Video = &video
+		}
 		if part.File != nil {
 			file := *part.File
 			file.Data = append([]byte(nil), part.File.Data...)

--- a/internal/session/externalization/service.go
+++ b/internal/session/externalization/service.go
@@ -996,6 +996,11 @@ func cloneContentPart(part model.ContentPart) model.ContentPart {
 		audio.Data = cloneBytes(part.Audio.Data)
 		clone.Audio = &audio
 	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = cloneBytes(part.Video.Data)
+		clone.Video = &video
+	}
 	if part.File != nil {
 		file := *part.File
 		file.Data = cloneBytes(part.File.Data)

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -158,6 +158,11 @@ func cloneContentPart(part model.ContentPart) model.ContentPart {
 		audio.Data = append([]byte(nil), part.Audio.Data...)
 		cloned.Audio = &audio
 	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = append([]byte(nil), part.Video.Data...)
+		cloned.Video = &video
+	}
 	if part.File != nil {
 		file := *part.File
 		file.Data = append([]byte(nil), part.File.Data...)

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -35,6 +35,12 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 			ContentParts: []model.ContentPart{{
 				Type: model.ContentTypeText,
 				Text: &text,
+			}, {
+				Type: model.ContentTypeVideo,
+				Video: &model.Video{
+					Data:   []byte("video"),
+					Format: "mp4",
+				},
 			}},
 			ToolCalls: []model.ToolCall{{
 				Index: &index,
@@ -66,6 +72,7 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 	Attach(inv, req)
 
 	*req.Messages[0].ContentParts[0].Text = "mutated"
+	req.Messages[0].ContentParts[1].Video.Data[0] = 'V'
 	req.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
 	req.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"] = "changed"
 	*req.GenerationConfig.MaxTokens = 20
@@ -77,6 +84,7 @@ func TestAttachSnapshotsRequest(t *testing.T) {
 	got, ok := Request(inv)
 	require.True(t, ok)
 	require.Equal(t, "part", *got.Messages[0].ContentParts[0].Text)
+	require.Equal(t, []byte("video"), got.Messages[0].ContentParts[1].Video.Data)
 	require.Equal(t, byte('{'), got.Messages[0].ToolCalls[0].Function.Arguments[0])
 	require.Equal(t, "v", got.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"])
 	require.Equal(t, 10, *got.GenerationConfig.MaxTokens)

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -1004,7 +1004,18 @@ func (m *Model) convertContentPart(part model.ContentPart) *genai.Part {
 		if part.Audio == nil {
 			return nil
 		}
+		if part.Audio.URL != "" {
+			return genai.NewPartFromURI(part.Audio.URL, part.Audio.Format)
+		}
 		return genai.NewPartFromBytes(part.Audio.Data, part.Audio.Format)
+	case model.ContentTypeVideo:
+		if part.Video == nil {
+			return nil
+		}
+		if part.Video.URL != "" {
+			return genai.NewPartFromURI(part.Video.URL, part.Video.Format)
+		}
+		return genai.NewPartFromBytes(part.Video.Data, part.Video.Format)
 	case model.ContentTypeFile:
 		if part.File == nil {
 			return nil

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -1008,6 +1008,9 @@ func (m *Model) convertContentPart(part model.ContentPart) *genai.Part {
 		if part.Audio.URL != "" {
 			return genai.NewPartFromURI(part.Audio.URL, mimeType)
 		}
+		if len(part.Audio.Data) == 0 {
+			return nil
+		}
 		return genai.NewPartFromBytes(part.Audio.Data, mimeType)
 	case model.ContentTypeVideo:
 		if part.Video == nil {
@@ -1016,6 +1019,9 @@ func (m *Model) convertContentPart(part model.ContentPart) *genai.Part {
 		mimeType := mediaMIMEType(part.Video.Format, "video")
 		if part.Video.URL != "" {
 			return genai.NewPartFromURI(part.Video.URL, mimeType)
+		}
+		if len(part.Video.Data) == 0 {
+			return nil
 		}
 		return genai.NewPartFromBytes(part.Video.Data, mimeType)
 	case model.ContentTypeFile:

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -1004,18 +1004,20 @@ func (m *Model) convertContentPart(part model.ContentPart) *genai.Part {
 		if part.Audio == nil {
 			return nil
 		}
+		mimeType := mediaMIMEType(part.Audio.Format, "audio")
 		if part.Audio.URL != "" {
-			return genai.NewPartFromURI(part.Audio.URL, part.Audio.Format)
+			return genai.NewPartFromURI(part.Audio.URL, mimeType)
 		}
-		return genai.NewPartFromBytes(part.Audio.Data, part.Audio.Format)
+		return genai.NewPartFromBytes(part.Audio.Data, mimeType)
 	case model.ContentTypeVideo:
 		if part.Video == nil {
 			return nil
 		}
+		mimeType := mediaMIMEType(part.Video.Format, "video")
 		if part.Video.URL != "" {
-			return genai.NewPartFromURI(part.Video.URL, part.Video.Format)
+			return genai.NewPartFromURI(part.Video.URL, mimeType)
 		}
-		return genai.NewPartFromBytes(part.Video.Data, part.Video.Format)
+		return genai.NewPartFromBytes(part.Video.Data, mimeType)
 	case model.ContentTypeFile:
 		if part.File == nil {
 			return nil
@@ -1031,4 +1033,12 @@ func (m *Model) convertContentPart(part model.ContentPart) *genai.Part {
 		return genai.NewPartFromBytes(part.File.Data, part.File.MimeType)
 	}
 	return nil
+}
+
+func mediaMIMEType(format, mediaType string) string {
+	format = strings.TrimSpace(format)
+	if format == "" || strings.Contains(format, "/") {
+		return format
+	}
+	return mediaType + "/" + format
 }

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -253,7 +253,7 @@ func TestModel_convertMessages(t *testing.T) {
 								Type: model.ContentTypeAudio,
 								Audio: &model.Audio{
 									URL:    audioURL,
-									Format: "audio/mpeg",
+									Format: "mpeg",
 								},
 							},
 							{
@@ -290,7 +290,7 @@ func TestModel_convertMessages(t *testing.T) {
 								Type: model.ContentTypeVideo,
 								Video: &model.Video{
 									URL:    videoURL,
-									Format: "video/mp4",
+									Format: "mp4",
 								},
 							},
 							{

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -263,6 +263,10 @@ func TestModel_convertMessages(t *testing.T) {
 									Format: "audio/wav",
 								},
 							},
+							{
+								Type:  model.ContentTypeAudio,
+								Audio: &model.Audio{Format: " "},
+							},
 						},
 					},
 				},
@@ -299,6 +303,10 @@ func TestModel_convertMessages(t *testing.T) {
 									Data:   []byte(videoData),
 									Format: "video/mp4",
 								},
+							},
+							{
+								Type:  model.ContentTypeVideo,
+								Video: &model.Video{Format: " "},
 							},
 						},
 					},

--- a/model/gemini/gemini_test.go
+++ b/model/gemini/gemini_test.go
@@ -163,6 +163,9 @@ func TestModel_convertMessages(t *testing.T) {
 		imageURL  = "imageURL"
 		imageData = "imageData"
 		audioURL  = "audioURL"
+		audioData = "audioData"
+		videoURL  = "videoURL"
+		videoData = "videoData"
 		fileURL   = "fileURL"
 	)
 	type fields struct {
@@ -249,7 +252,15 @@ func TestModel_convertMessages(t *testing.T) {
 							{
 								Type: model.ContentTypeAudio,
 								Audio: &model.Audio{
-									Data: []byte(audioURL),
+									URL:    audioURL,
+									Format: "audio/mpeg",
+								},
+							},
+							{
+								Type: model.ContentTypeAudio,
+								Audio: &model.Audio{
+									Data:   []byte(audioData),
+									Format: "audio/wav",
 								},
 							},
 						},
@@ -258,7 +269,47 @@ func TestModel_convertMessages(t *testing.T) {
 			},
 			want: []*genai.Content{
 				genai.NewContentFromParts([]*genai.Part{
-					genai.NewPartFromBytes([]byte(audioURL), ""),
+					genai.NewPartFromURI(audioURL, "audio/mpeg"),
+				}, genai.RoleUser),
+				genai.NewContentFromParts([]*genai.Part{
+					genai.NewPartFromBytes([]byte(audioData), "audio/wav"),
+				}, genai.RoleUser),
+			},
+		},
+		{
+			name: "video",
+			fields: fields{
+				m: &Model{},
+			},
+			args: args{
+				messages: []model.Message{
+					{
+						Role: model.RoleUser,
+						ContentParts: []model.ContentPart{
+							{
+								Type: model.ContentTypeVideo,
+								Video: &model.Video{
+									URL:    videoURL,
+									Format: "video/mp4",
+								},
+							},
+							{
+								Type: model.ContentTypeVideo,
+								Video: &model.Video{
+									Data:   []byte(videoData),
+									Format: "video/mp4",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []*genai.Content{
+				genai.NewContentFromParts([]*genai.Part{
+					genai.NewPartFromURI(videoURL, "video/mp4"),
+				}, genai.RoleUser),
+				genai.NewContentFromParts([]*genai.Part{
+					genai.NewPartFromBytes([]byte(videoData), "video/mp4"),
 				}, genai.RoleUser),
 			},
 		},

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -613,7 +613,16 @@ func convertMessage(msg model.Message) (*hunyuan.ChatCompletionMessageParam, err
 					contents = append(contents, &hunyuan.ChatCompletionMessageContentParam{
 						Type: "audio_url",
 						VideoUrl: &hunyuan.ChatCompletionContentVideoUrlParam{
-							Url: audioToBase64(part.Audio),
+							Url: audioToURLOrBase64(part.Audio),
+						},
+					})
+				}
+			case model.ContentTypeVideo:
+				if part.Video != nil {
+					contents = append(contents, &hunyuan.ChatCompletionMessageContentParam{
+						Type: "video_url",
+						VideoUrl: &hunyuan.ChatCompletionContentVideoUrlParam{
+							Url: videoToURLOrBase64(part.Video),
 						},
 					})
 				}
@@ -681,6 +690,24 @@ func imageToURLOrBase64(image *model.Image) string {
 	return "data:image/" + format + ";base64," + base64.StdEncoding.EncodeToString(image.Data)
 }
 
-func audioToBase64(audio *model.Audio) string {
-	return "data:" + audio.Format + ";base64," + base64.StdEncoding.EncodeToString(audio.Data)
+func audioToURLOrBase64(audio *model.Audio) string {
+	if audio.URL != "" {
+		return audio.URL
+	}
+	return mediaToBase64("audio", audio.Format, audio.Data)
+}
+
+func videoToURLOrBase64(video *model.Video) string {
+	if video.URL != "" {
+		return video.URL
+	}
+	return mediaToBase64("video", video.Format, video.Data)
+}
+
+func mediaToBase64(mediaType, format string, data []byte) string {
+	mimeType := format
+	if !strings.HasPrefix(mimeType, mediaType+"/") {
+		mimeType = mediaType + "/" + mimeType
+	}
+	return "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
 }

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -757,7 +757,14 @@ func TestConvertMessage(t *testing.T) {
 		{
 			Type: model.ContentTypeAudio,
 			Audio: &model.Audio{
-				Data: []byte("audio data"),
+				URL: "https://example.com/audio.mp3",
+			},
+		},
+		{
+			Type: model.ContentTypeVideo,
+			Video: &model.Video{
+				Data:   []byte("video data"),
+				Format: "mp4",
 			},
 		},
 	}
@@ -766,9 +773,13 @@ func TestConvertMessage(t *testing.T) {
 		t.Fatalf("convertMessage failed: %v", err)
 	}
 
-	if len(hMsg.Contents) != 3 {
-		t.Fatalf("Expected 3 content parts, got %d", len(hMsg.Contents))
+	if len(hMsg.Contents) != 4 {
+		t.Fatalf("Expected 4 content parts, got %d", len(hMsg.Contents))
 	}
+	assert.Equal(t, "audio_url", hMsg.Contents[2].Type)
+	assert.Equal(t, "https://example.com/audio.mp3", hMsg.Contents[2].VideoUrl.Url)
+	assert.Equal(t, "video_url", hMsg.Contents[3].Type)
+	assert.Equal(t, "data:video/mp4;base64,dmlkZW8gZGF0YQ==", hMsg.Contents[3].VideoUrl.Url)
 }
 
 func TestTokenTailoringOptions(t *testing.T) {
@@ -1482,18 +1493,14 @@ func TestImageToURLOrBase64(t *testing.T) {
 	}
 }
 
-func TestAudioToBase64(t *testing.T) {
-	audio := &model.Audio{
-		Format: "audio/mp3",
+func TestAudioToURLOrBase64(t *testing.T) {
+	assert.Equal(t, "https://example.com/audio.mp3", audioToURLOrBase64(&model.Audio{
+		URL: "https://example.com/audio.mp3",
+	}))
+	assert.Equal(t, "data:audio/mp3;base64,dGVzdCBhdWRpbyBkYXRh", audioToURLOrBase64(&model.Audio{
+		Format: "mp3",
 		Data:   []byte("test audio data"),
-	}
-
-	result := audioToBase64(audio)
-	expected := "data:audio/mp3;base64,dGVzdCBhdWRpbyBkYXRh"
-
-	if result != expected {
-		t.Errorf("Expected %s, got %s", expected, result)
-	}
+	}))
 }
 
 // Test_buildToolDescription tests tool description building.

--- a/model/hunyuan/hunyuan_test.go
+++ b/model/hunyuan/hunyuan_test.go
@@ -763,8 +763,8 @@ func TestConvertMessage(t *testing.T) {
 		{
 			Type: model.ContentTypeVideo,
 			Video: &model.Video{
-				Data:   []byte("video data"),
-				Format: "mp4",
+				URL:  "https://example.com/video.mp4",
+				Data: []byte("ignored video data"),
 			},
 		},
 	}
@@ -779,7 +779,7 @@ func TestConvertMessage(t *testing.T) {
 	assert.Equal(t, "audio_url", hMsg.Contents[2].Type)
 	assert.Equal(t, "https://example.com/audio.mp3", hMsg.Contents[2].VideoUrl.Url)
 	assert.Equal(t, "video_url", hMsg.Contents[3].Type)
-	assert.Equal(t, "data:video/mp4;base64,dmlkZW8gZGF0YQ==", hMsg.Contents[3].VideoUrl.Url)
+	assert.Equal(t, "https://example.com/video.mp4", hMsg.Contents[3].VideoUrl.Url)
 }
 
 func TestTokenTailoringOptions(t *testing.T) {
@@ -1495,11 +1495,23 @@ func TestImageToURLOrBase64(t *testing.T) {
 
 func TestAudioToURLOrBase64(t *testing.T) {
 	assert.Equal(t, "https://example.com/audio.mp3", audioToURLOrBase64(&model.Audio{
-		URL: "https://example.com/audio.mp3",
+		URL:  "https://example.com/audio.mp3",
+		Data: []byte("ignored audio data"),
 	}))
 	assert.Equal(t, "data:audio/mp3;base64,dGVzdCBhdWRpbyBkYXRh", audioToURLOrBase64(&model.Audio{
 		Format: "mp3",
 		Data:   []byte("test audio data"),
+	}))
+}
+
+func TestVideoToURLOrBase64(t *testing.T) {
+	assert.Equal(t, "https://example.com/video.mp4", videoToURLOrBase64(&model.Video{
+		URL:  "https://example.com/video.mp4",
+		Data: []byte("ignored video data"),
+	}))
+	assert.Equal(t, "data:video/mp4;base64,dGVzdCB2aWRlbyBkYXRh", videoToURLOrBase64(&model.Video{
+		Format: "mp4",
+		Data:   []byte("test video data"),
 	}))
 }
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1292,13 +1292,15 @@ func (m *Model) omittedContentHint(parts []model.ContentPart) string {
 		return ""
 	}
 
-	var imageCount, audioCount, fileCount int
+	var imageCount, audioCount, videoCount, fileCount int
 	for _, part := range parts {
 		switch part.Type {
 		case model.ContentTypeImage:
 			imageCount++
 		case model.ContentTypeAudio:
 			audioCount++
+		case model.ContentTypeVideo:
+			videoCount++
 		case model.ContentTypeFile:
 			if fileURLFallbackText(part.File) != "" {
 				continue
@@ -1306,12 +1308,13 @@ func (m *Model) omittedContentHint(parts []model.ContentPart) string {
 			fileCount++
 		}
 	}
-	return omittedAttachmentHint(imageCount, audioCount, fileCount)
+	return omittedAttachmentHint(imageCount, audioCount, videoCount, fileCount)
 }
 
 func omittedAttachmentHint(
 	imageCount int,
 	audioCount int,
+	videoCount int,
 	fileCount int,
 ) string {
 	const (
@@ -1321,11 +1324,13 @@ func omittedAttachmentHint(
 		omittedImagePlural = "%d images"
 		omittedAudioSingle = "1 audio clip"
 		omittedAudioPlural = "%d audio clips"
+		omittedVideoSingle = "1 video"
+		omittedVideoPlural = "%d videos"
 		omittedFileSingle  = "1 file"
 		omittedFilePlural  = "%d files"
 	)
 
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 4)
 	if imageCount == 1 {
 		parts = append(parts, omittedImageSingle)
 	} else if imageCount > 1 {
@@ -1335,6 +1340,11 @@ func omittedAttachmentHint(
 		parts = append(parts, omittedAudioSingle)
 	} else if audioCount > 1 {
 		parts = append(parts, fmt.Sprintf(omittedAudioPlural, audioCount))
+	}
+	if videoCount == 1 {
+		parts = append(parts, omittedVideoSingle)
+	} else if videoCount > 1 {
+		parts = append(parts, fmt.Sprintf(omittedVideoPlural, videoCount))
 	}
 	if fileCount == 1 {
 		parts = append(parts, omittedFileSingle)
@@ -1477,7 +1487,7 @@ func (m *Model) convertContentPart(part model.ContentPart) *openai.ChatCompletio
 			}
 		}
 	case model.ContentTypeAudio:
-		if part.Audio != nil {
+		if part.Audio != nil && part.Audio.URL == "" && len(part.Audio.Data) > 0 {
 			return &openai.ChatCompletionContentPartUnionParam{
 				OfInputAudio: &openai.ChatCompletionContentPartInputAudioParam{
 					InputAudio: openai.ChatCompletionContentPartInputAudioInputAudioParam{
@@ -1487,6 +1497,9 @@ func (m *Model) convertContentPart(part model.ContentPart) *openai.ChatCompletio
 				},
 			}
 		}
+	case model.ContentTypeVideo:
+		// Chat Completions does not define a video input content part.
+		return nil
 	case model.ContentTypeFile:
 		if part.File != nil {
 			params, ok := fileToParamsOK(part.File)

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -1288,20 +1288,26 @@ func (m *Model) appendUserContentParts(
 }
 
 func (m *Model) omittedContentHint(parts []model.ContentPart) string {
-	if !m.variantConfig.textOnlyMessageContent {
-		return ""
-	}
-
 	var imageCount, audioCount, videoCount, fileCount int
 	for _, part := range parts {
 		switch part.Type {
 		case model.ContentTypeImage:
-			imageCount++
+			if m.variantConfig.textOnlyMessageContent {
+				imageCount++
+			}
 		case model.ContentTypeAudio:
-			audioCount++
+			if m.variantConfig.textOnlyMessageContent ||
+				(part.Audio != nil && part.Audio.URL != "") {
+				audioCount++
+			}
 		case model.ContentTypeVideo:
-			videoCount++
+			if m.variantConfig.textOnlyMessageContent || part.Video != nil {
+				videoCount++
+			}
 		case model.ContentTypeFile:
+			if !m.variantConfig.textOnlyMessageContent {
+				continue
+			}
 			if fileURLFallbackText(part.File) != "" {
 				continue
 			}

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -405,6 +405,7 @@ func TestOmittedAttachmentHint(t *testing.T) {
 		name       string
 		imageCount int
 		audioCount int
+		videoCount int
 		fileCount  int
 		want       string
 	}{
@@ -422,9 +423,10 @@ func TestOmittedAttachmentHint(t *testing.T) {
 			name:       "plural attachments",
 			imageCount: 2,
 			audioCount: 2,
+			videoCount: 2,
 			fileCount:  2,
 			want: "Omitted non-text attachments for this provider: " +
-				"2 images, 2 audio clips, 2 files.",
+				"2 images, 2 audio clips, 2 videos, 2 files.",
 		},
 	}
 
@@ -436,6 +438,7 @@ func TestOmittedAttachmentHint(t *testing.T) {
 				omittedAttachmentHint(
 					tt.imageCount,
 					tt.audioCount,
+					tt.videoCount,
 					tt.fileCount,
 				),
 			)
@@ -3395,6 +3398,19 @@ func TestConvertContentPart(t *testing.T) {
 	assert.NotNilf(t, contentPart, "Expected image content part to be converted")
 
 	assert.NotNilf(t, contentPart.OfImageURL, "Expected image content part to be set")
+
+	// Chat Completions does not support URL-based audio or video inputs.
+	audioURLPart := model.ContentPart{
+		Type:  model.ContentTypeAudio,
+		Audio: &model.Audio{URL: "https://example.com/audio.mp3"},
+	}
+	assert.Nil(t, m.convertContentPart(audioURLPart))
+
+	videoPart := model.ContentPart{
+		Type:  model.ContentTypeVideo,
+		Video: &model.Video{URL: "https://example.com/video.mp4"},
+	}
+	assert.Nil(t, m.convertContentPart(videoPart))
 
 	// Test unknown content part type
 	unknownPart := model.ContentPart{

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -3298,6 +3298,37 @@ func TestConvertUserMessageContentWithAudio(t *testing.T) {
 	assert.NotNilf(t, contentPart.OfInputAudio, "Expected audio content part to be set")
 }
 
+func TestConvertUserMessageContentAddsUnsupportedMediaHint(t *testing.T) {
+	text := "Describe the attachments"
+	message := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeText, Text: &text},
+			{
+				Type:  model.ContentTypeAudio,
+				Audio: &model.Audio{URL: "https://example.com/audio.mp3"},
+			},
+			{
+				Type:  model.ContentTypeVideo,
+				Video: &model.Video{URL: "https://example.com/video.mp4"},
+			},
+		},
+	}
+
+	m := &Model{}
+	content, extraFields := m.convertUserMessageContent(message)
+
+	assert.Empty(t, extraFields)
+	require.Len(t, content.OfArrayOfContentParts, 2)
+	require.NotNil(t, content.OfArrayOfContentParts[0].OfText)
+	assert.Equal(t,
+		"Omitted non-text attachments for this provider: 1 audio clip, 1 video.",
+		content.OfArrayOfContentParts[0].OfText.Text,
+	)
+	require.NotNil(t, content.OfArrayOfContentParts[1].OfText)
+	assert.Equal(t, text, content.OfArrayOfContentParts[1].OfText.Text)
+}
+
 func TestConvertUserMessageContentWithFile(t *testing.T) {
 	// Test converting user message with file content parts
 	filePart := model.ContentPart{

--- a/model/request.go
+++ b/model/request.go
@@ -218,6 +218,20 @@ func (m *Message) AddImageData(data []byte, detail, format string) {
 	})
 }
 
+// AddAudioURL adds URL-based audio to the message.
+// Format may be a media subtype such as "mpeg" or a full MIME type such as
+// "audio/mpeg". An empty format leaves media type resolution to the model
+// provider.
+func (m *Message) AddAudioURL(url, format string) {
+	m.ContentParts = append(m.ContentParts, ContentPart{
+		Type: ContentTypeAudio,
+		Audio: &Audio{
+			URL:    url,
+			Format: format,
+		},
+	})
+}
+
 // AddAudioFilePath adds an audio file path to the message.
 func (m *Message) AddAudioFilePath(path string) error {
 	content, err := os.ReadFile(path)
@@ -251,6 +265,32 @@ func (m *Message) AddAudioData(data []byte, format string) {
 	})
 }
 
+// AddVideoURL adds URL-based video to the message.
+// Format may be a media subtype such as "mp4" or a full MIME type such as
+// "video/mp4". An empty format leaves media type resolution to the model
+// provider.
+func (m *Message) AddVideoURL(url, format string) {
+	m.ContentParts = append(m.ContentParts, ContentPart{
+		Type: ContentTypeVideo,
+		Video: &Video{
+			URL:    url,
+			Format: format,
+		},
+	})
+}
+
+// AddVideoData adds inline video data to the message.
+// The argument of data is the raw video data without base64 encoding.
+func (m *Message) AddVideoData(data []byte, format string) {
+	m.ContentParts = append(m.ContentParts, ContentPart{
+		Type: ContentTypeVideo,
+		Video: &Video{
+			Data:   data,
+			Format: format,
+		},
+	})
+}
+
 // ContentType represents the type of content.
 type ContentType string
 
@@ -259,12 +299,13 @@ const (
 	ContentTypeText  ContentType = "text"
 	ContentTypeImage ContentType = "image"
 	ContentTypeAudio ContentType = "audio"
+	ContentTypeVideo ContentType = "video"
 	ContentTypeFile  ContentType = "file"
 )
 
 // ContentPart represents a single content part in a multimodal message.
 type ContentPart struct {
-	// Type is the type of content: "text", "image", "audio", "file"
+	// Type is the type of content: "text", "image", "audio", "video", "file".
 	Type ContentType `json:"type"`
 	// Text is the text content.
 	Text *string `json:"text,omitempty"`
@@ -272,6 +313,8 @@ type ContentPart struct {
 	Image *Image `json:"image,omitempty"`
 	// Audio is the audio data.
 	Audio *Audio `json:"audio,omitempty"`
+	// Video is the video data.
+	Video *Video `json:"video,omitempty"`
 	// File is the file data.
 	File *File `json:"file,omitempty"`
 	// ContentRef is an internal reference to externalized content.
@@ -355,10 +398,26 @@ type Image struct {
 
 // Audio represents audio input for audio models.
 type Audio struct {
+	// URL is the URL of the audio.
+	URL string `json:"url,omitempty"`
 	// Data is the raw audio data.
 	Data []byte `json:"data"`
-	// Format is the format of the encoded audio data. Currently supports "wav" and "mp3".
+	// Format is the format of the encoded audio data.
+	// Data-backed audio usually uses a subtype such as "wav" or "mp3".
+	// URL-backed audio may use a full MIME type such as "audio/mpeg".
 	Format string `json:"format"`
+}
+
+// Video represents video input for multimodal models.
+type Video struct {
+	// URL is the URL of the video.
+	URL string `json:"url,omitempty"`
+	// Data is the raw video data.
+	Data []byte `json:"data"`
+	// Format is the video format.
+	// Data-backed video usually uses a subtype such as "mp4".
+	// URL-backed video may use a full MIME type such as "video/mp4".
+	Format string `json:"format,omitempty"`
 }
 
 // NewSystemMessage creates a new system message.

--- a/model/request.go
+++ b/model/request.go
@@ -299,6 +299,7 @@ const (
 	ContentTypeText  ContentType = "text"
 	ContentTypeImage ContentType = "image"
 	ContentTypeAudio ContentType = "audio"
+	// ContentTypeVideo identifies video content.
 	ContentTypeVideo ContentType = "video"
 	ContentTypeFile  ContentType = "file"
 )
@@ -398,7 +399,8 @@ type Image struct {
 
 // Audio represents audio input for audio models.
 type Audio struct {
-	// URL is the URL of the audio.
+	// URL is the URL of the audio. When URL and Data are both set, URL takes
+	// precedence.
 	URL string `json:"url,omitempty"`
 	// Data is the raw audio data.
 	Data []byte `json:"data"`
@@ -410,7 +412,8 @@ type Audio struct {
 
 // Video represents video input for multimodal models.
 type Video struct {
-	// URL is the URL of the video.
+	// URL is the URL of the video. When URL and Data are both set, URL takes
+	// precedence.
 	URL string `json:"url,omitempty"`
 	// Data is the raw video data.
 	Data []byte `json:"data"`

--- a/model/request_test.go
+++ b/model/request_test.go
@@ -809,6 +809,40 @@ func TestMessage_AddAudioData(t *testing.T) {
 	}
 }
 
+func TestMessage_AddAudioURL(t *testing.T) {
+	msg := &Message{}
+	msg.AddAudioURL("https://example.com/audio.mp3", "audio/mpeg")
+
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, ContentTypeAudio, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Audio)
+	assert.Equal(t, "https://example.com/audio.mp3", msg.ContentParts[0].Audio.URL)
+	assert.Equal(t, "audio/mpeg", msg.ContentParts[0].Audio.Format)
+}
+
+func TestMessage_AddVideoURL(t *testing.T) {
+	msg := &Message{}
+	msg.AddVideoURL("https://example.com/video.mp4", "video/mp4")
+
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, ContentTypeVideo, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Video)
+	assert.Equal(t, "https://example.com/video.mp4", msg.ContentParts[0].Video.URL)
+	assert.Equal(t, "video/mp4", msg.ContentParts[0].Video.Format)
+}
+
+func TestMessage_AddVideoData(t *testing.T) {
+	data := []byte("video data")
+	msg := &Message{}
+	msg.AddVideoData(data, "mp4")
+
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, ContentTypeVideo, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Video)
+	assert.Equal(t, data, msg.ContentParts[0].Video.Data)
+	assert.Equal(t, "mp4", msg.ContentParts[0].Video.Format)
+}
+
 func TestMessage_AddFilePath(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -3423,6 +3423,11 @@ func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
 			audio.Data = append([]byte(nil), part.Audio.Data...)
 			cloned[i].Audio = &audio
 		}
+		if part.Video != nil {
+			video := *part.Video
+			video.Data = append([]byte(nil), part.Video.Data...)
+			cloned[i].Video = &video
+		}
 		if part.File != nil {
 			file := *part.File
 			file.Data = append([]byte(nil), part.File.Data...)
@@ -4097,7 +4102,10 @@ func queuedUserMessageContentPartsSupported(parts []model.ContentPart) bool {
 				return false
 			}
 		case model.ContentTypeAudio:
-			if part.Audio == nil || len(part.Audio.Data) == 0 {
+			if part.Audio == nil {
+				return false
+			}
+			if strings.TrimSpace(part.Audio.URL) == "" && len(part.Audio.Data) == 0 {
 				return false
 			}
 		case model.ContentTypeFile:

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4098,21 +4098,21 @@ func queuedUserMessageContentPartsSupported(parts []model.ContentPart) bool {
 			if part.Image == nil {
 				return false
 			}
-			if strings.TrimSpace(part.Image.URL) == "" && len(part.Image.Data) == 0 {
+			if !queuedUserMessageURLOrDataSupported(part.Image.URL, part.Image.Data) {
 				return false
 			}
 		case model.ContentTypeAudio:
 			if part.Audio == nil {
 				return false
 			}
-			if strings.TrimSpace(part.Audio.URL) == "" && len(part.Audio.Data) == 0 {
+			if !queuedUserMessageURLOrDataSupported(part.Audio.URL, part.Audio.Data) {
 				return false
 			}
 		case model.ContentTypeVideo:
 			if part.Video == nil {
 				return false
 			}
-			if strings.TrimSpace(part.Video.URL) == "" && len(part.Video.Data) == 0 {
+			if !queuedUserMessageURLOrDataSupported(part.Video.URL, part.Video.Data) {
 				return false
 			}
 		case model.ContentTypeFile:
@@ -4129,6 +4129,10 @@ func queuedUserMessageContentPartsSupported(parts []model.ContentPart) bool {
 		}
 	}
 	return true
+}
+
+func queuedUserMessageURLOrDataSupported(url string, data []byte) bool {
+	return strings.TrimSpace(url) != "" || len(data) > 0
 }
 
 // ensureErrorEventContent ensures that error events have valid content.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4108,6 +4108,13 @@ func queuedUserMessageContentPartsSupported(parts []model.ContentPart) bool {
 			if strings.TrimSpace(part.Audio.URL) == "" && len(part.Audio.Data) == 0 {
 				return false
 			}
+		case model.ContentTypeVideo:
+			if part.Video == nil {
+				return false
+			}
+			if strings.TrimSpace(part.Video.URL) == "" && len(part.Video.Data) == 0 {
+				return false
+			}
 		case model.ContentTypeFile:
 			if part.File == nil {
 				return false

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -464,6 +464,19 @@ func TestEnqueueUserMessage_Errors(t *testing.T) {
 	)
 	require.ErrorIs(t, err, ErrInvalidQueuedUserMessage)
 
+	err = EnqueueUserMessage(
+		r,
+		"req-1",
+		model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeVideo,
+				Video: &model.Video{URL: " "},
+			}},
+		},
+	)
+	require.ErrorIs(t, err, ErrInvalidQueuedUserMessage)
+
 	textPart := "hello from part"
 	err = EnqueueUserMessage(
 		r,
@@ -473,6 +486,32 @@ func TestEnqueueUserMessage_Errors(t *testing.T) {
 			ContentParts: []model.ContentPart{{
 				Type: model.ContentTypeText,
 				Text: &textPart,
+			}},
+		},
+	)
+	require.ErrorIs(t, err, ErrRunNotFound)
+
+	err = EnqueueUserMessage(
+		r,
+		"req-1",
+		model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeVideo,
+				Video: &model.Video{URL: "https://example.com/video.mp4"},
+			}},
+		},
+	)
+	require.ErrorIs(t, err, ErrRunNotFound)
+
+	err = EnqueueUserMessage(
+		r,
+		"req-1",
+		model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeVideo,
+				Video: &model.Video{Data: []byte("video")},
 			}},
 		},
 	)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -481,6 +481,19 @@ func TestEnqueueUserMessage_Errors(t *testing.T) {
 	err = EnqueueUserMessage(
 		r,
 		"req-1",
+		model.Message{
+			Role: model.RoleUser,
+			ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeAudio,
+				Audio: &model.Audio{URL: "https://example.com/audio.mp3"},
+			}},
+		},
+	)
+	require.ErrorIs(t, err, ErrRunNotFound)
+
+	err = EnqueueUserMessage(
+		r,
+		"req-1",
 		model.NewUserMessage("hello"),
 	)
 	require.ErrorIs(t, err, ErrRunNotFound)
@@ -4997,6 +5010,25 @@ func TestCloneResponseError(t *testing.T) {
 		require.Equal(t, "p", *got.Param)
 		require.Equal(t, "c", *got.Code)
 	})
+}
+
+func TestCloneContentPartsDeepCopiesVideo(t *testing.T) {
+	parts := []model.ContentPart{{
+		Type: model.ContentTypeVideo,
+		Video: &model.Video{
+			URL:    "https://example.com/video.mp4",
+			Data:   []byte("video"),
+			Format: "mp4",
+		},
+	}}
+
+	cloned := cloneContentParts(parts)
+
+	require.Len(t, cloned, 1)
+	require.NotSame(t, parts[0].Video, cloned[0].Video)
+	require.Equal(t, parts[0].Video, cloned[0].Video)
+	cloned[0].Video.Data[0] = 'V'
+	require.Equal(t, []byte("video"), parts[0].Video.Data)
 }
 
 func TestGraphCompletionNotPersistedAsMessage(t *testing.T) {

--- a/server/agui/adapter/adapter_test.go
+++ b/server/agui/adapter/adapter_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 )
 
@@ -46,6 +47,42 @@ func TestRunAgentInputJSONUnmarshal(t *testing.T) {
 	metadata, ok := forwardedProps["metadata"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "trace-01", metadata["traceId"])
+}
+
+func TestRunAgentInputJSONUnmarshalTypedImage(t *testing.T) {
+	raw := `{
+		"threadId": "thread-123",
+		"runId": "run-456",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{
+					"type": "image",
+					"source": {
+						"type": "data",
+						"value": "AQID",
+						"mimeType": "image/png"
+					},
+					"metadata": {"filename": "demo.png"}
+				},
+				{"type": "text", "text": "describe this image"}
+			]
+		}]
+	}`
+
+	var input adapter.RunAgentInput
+	require.NoError(t, json.Unmarshal([]byte(raw), &input))
+	require.Len(t, input.Messages, 1)
+	contents, ok := input.Messages[0].ContentInputContents()
+	require.True(t, ok)
+	require.Len(t, contents, 2)
+	assert.Equal(t, types.InputContentTypeImage, contents[0].Type)
+	require.NotNil(t, contents[0].Source)
+	assert.Equal(t, types.InputContentSourceTypeData, contents[0].Source.Type)
+	assert.Equal(t, "AQID", contents[0].Source.Value)
+	assert.Equal(t, "image/png", contents[0].Source.MimeType)
+	assert.Equal(t, types.InputContentTypeText, contents[1].Type)
+	assert.Equal(t, "describe this image", contents[1].Text)
 }
 
 func TestRunAgentInputJSONMarshal(t *testing.T) {

--- a/server/agui/go.mod
+++ b/server/agui/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 replace trpc.group/trpc-go/trpc-agent-go => ../../
 
 require (
-	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9
+	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/trace v1.40.0

--- a/server/agui/go.sum
+++ b/server/agui/go.sum
@@ -1,5 +1,5 @@
-github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9 h1:70eYJzrmomfCBxj0GdpYXmU2bP3zV98Y014u1/PKemw=
-github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9 h1:DQFhA6IAPabs7cQ/Ryv1DfhfnGQ5cZLCBtf8YRqx2FY=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=

--- a/server/agui/internal/multimodal/multimodal.go
+++ b/server/agui/internal/multimodal/multimodal.go
@@ -62,9 +62,127 @@ func contentPartFromInputContent(part types.InputContent) (*model.ContentPart, e
 		}, nil
 	case types.InputContentTypeBinary:
 		return contentPartFromBinaryInput(part)
+	case types.InputContentTypeImage,
+		types.InputContentTypeAudio,
+		types.InputContentTypeVideo,
+		types.InputContentTypeDocument:
+		return contentPartFromTypedInput(part)
 	default:
 		return nil, nil
 	}
+}
+
+func contentPartFromTypedInput(part types.InputContent) (*model.ContentPart, error) {
+	if part.Source == nil {
+		return nil, fmt.Errorf("%s input content requires source", part.Type)
+	}
+
+	sourceType := strings.ToLower(strings.TrimSpace(part.Source.Type))
+	value := strings.TrimSpace(part.Source.Value)
+	if value == "" {
+		return nil, fmt.Errorf("%s input content source value is empty", part.Type)
+	}
+	mimeType := strings.ToLower(strings.TrimSpace(part.Source.MimeType))
+
+	switch sourceType {
+	case types.InputContentSourceTypeURL:
+		return contentPartFromTypedURL(part, value, mimeType)
+	case types.InputContentSourceTypeData:
+		if mimeType == "" {
+			return nil, fmt.Errorf("%s data source requires mime type", part.Type)
+		}
+		payload, err := decodeBase64Payload(value)
+		if err != nil {
+			return nil, fmt.Errorf("decode %s payload: %w", part.Type, err)
+		}
+		return contentPartFromTypedData(part, payload, mimeType)
+	default:
+		return nil, fmt.Errorf("unsupported %s input content source type %q", part.Type, part.Source.Type)
+	}
+}
+
+func contentPartFromTypedURL(
+	part types.InputContent,
+	url string,
+	mimeType string,
+) (*model.ContentPart, error) {
+	switch part.Type {
+	case types.InputContentTypeImage:
+		return &model.ContentPart{
+			Type:  model.ContentTypeImage,
+			Image: &model.Image{URL: url, Format: mimeType},
+		}, nil
+	case types.InputContentTypeAudio:
+		return &model.ContentPart{
+			Type:  model.ContentTypeAudio,
+			Audio: &model.Audio{URL: url, Format: mimeType},
+		}, nil
+	case types.InputContentTypeVideo:
+		return &model.ContentPart{
+			Type:  model.ContentTypeVideo,
+			Video: &model.Video{URL: url, Format: mimeType},
+		}, nil
+	default:
+		return &model.ContentPart{
+			Type: model.ContentTypeFile,
+			File: &model.File{
+				URL:      url,
+				MimeType: mimeType,
+			},
+		}, nil
+	}
+}
+
+func contentPartFromTypedData(
+	part types.InputContent,
+	payload []byte,
+	mimeType string,
+) (*model.ContentPart, error) {
+	switch part.Type {
+	case types.InputContentTypeImage:
+		format, err := mediaSubtype(mimeType, "image/", part.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &model.ContentPart{
+			Type:  model.ContentTypeImage,
+			Image: &model.Image{Data: payload, Format: format},
+		}, nil
+	case types.InputContentTypeAudio:
+		format, err := mediaSubtype(mimeType, "audio/", part.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &model.ContentPart{
+			Type:  model.ContentTypeAudio,
+			Audio: &model.Audio{Data: payload, Format: format},
+		}, nil
+	case types.InputContentTypeVideo:
+		format, err := mediaSubtype(mimeType, "video/", part.Type)
+		if err != nil {
+			return nil, err
+		}
+		return &model.ContentPart{
+			Type:  model.ContentTypeVideo,
+			Video: &model.Video{Data: payload, Format: format},
+		}, nil
+	default:
+		return &model.ContentPart{
+			Type: model.ContentTypeFile,
+			File: &model.File{
+				Data:     payload,
+				MimeType: mimeType,
+			},
+		}, nil
+	}
+}
+
+func mediaSubtype(mimeType, prefix, contentType string) (string, error) {
+	format, ok := strings.CutPrefix(mimeType, prefix)
+	if !ok || format == "" {
+		return "", fmt.Errorf("%s data source requires %s mime type", contentType, contentType)
+	}
+	return format, nil
 }
 
 func contentPartFromBinaryInput(part types.InputContent) (*model.ContentPart, error) {

--- a/server/agui/internal/multimodal/multimodal_test.go
+++ b/server/agui/internal/multimodal/multimodal_test.go
@@ -97,6 +97,103 @@ func TestUserMessageFromInputContentsTextAndImageURL(t *testing.T) {
 	assert.Equal(t, "image/jpeg", msg.ContentParts[1].Image.Format)
 }
 
+func TestUserMessageFromInputContentsTypedImageData(t *testing.T) {
+	payload := []byte{0x01, 0x02, 0x03}
+	msg, err := UserMessageFromInputContents([]types.InputContent{
+		{
+			Type: types.InputContentTypeImage,
+			Source: &types.InputContentSource{
+				Type:     types.InputContentSourceTypeData,
+				Value:    base64.StdEncoding.EncodeToString(payload),
+				MimeType: "image/png",
+			},
+			Metadata: map[string]any{"filename": "demo.png"},
+		},
+		{Type: types.InputContentTypeText, Text: "describe this image"},
+	})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 2)
+
+	assert.Equal(t, model.ContentTypeImage, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Image)
+	assert.Equal(t, payload, msg.ContentParts[0].Image.Data)
+	assert.Equal(t, "png", msg.ContentParts[0].Image.Format)
+
+	assert.Equal(t, model.ContentTypeText, msg.ContentParts[1].Type)
+	require.NotNil(t, msg.ContentParts[1].Text)
+	assert.Equal(t, "describe this image", *msg.ContentParts[1].Text)
+}
+
+func TestUserMessageFromInputContentsTypedImageURL(t *testing.T) {
+	msg, err := UserMessageFromInputContents([]types.InputContent{{
+		Type: types.InputContentTypeImage,
+		Source: &types.InputContentSource{
+			Type:  types.InputContentSourceTypeURL,
+			Value: " https://example.com/a.jpg ",
+		},
+	}})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, model.ContentTypeImage, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Image)
+	assert.Equal(t, "https://example.com/a.jpg", msg.ContentParts[0].Image.URL)
+}
+
+func TestUserMessageFromInputContentsTypedAudioURL(t *testing.T) {
+	msg, err := UserMessageFromInputContents([]types.InputContent{{
+		Type: types.InputContentTypeAudio,
+		Source: &types.InputContentSource{
+			Type:     types.InputContentSourceTypeURL,
+			Value:    "https://example.com/audio.mp3",
+			MimeType: "audio/mpeg",
+		},
+	}})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, model.ContentTypeAudio, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Audio)
+	assert.Equal(t, "https://example.com/audio.mp3", msg.ContentParts[0].Audio.URL)
+	assert.Equal(t, "audio/mpeg", msg.ContentParts[0].Audio.Format)
+}
+
+func TestUserMessageFromInputContentsTypedVideoData(t *testing.T) {
+	payload := []byte("video")
+	msg, err := UserMessageFromInputContents([]types.InputContent{{
+		Type: types.InputContentTypeVideo,
+		Source: &types.InputContentSource{
+			Type:     types.InputContentSourceTypeData,
+			Value:    base64.StdEncoding.EncodeToString(payload),
+			MimeType: "video/mp4",
+		},
+	}})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, model.ContentTypeVideo, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Video)
+	assert.Equal(t, payload, msg.ContentParts[0].Video.Data)
+	assert.Equal(t, "mp4", msg.ContentParts[0].Video.Format)
+}
+
+func TestUserMessageFromInputContentsTypedDocumentData(t *testing.T) {
+	payload := []byte("document")
+	msg, err := UserMessageFromInputContents([]types.InputContent{{
+		Type: types.InputContentTypeDocument,
+		Source: &types.InputContentSource{
+			Type:     types.InputContentSourceTypeData,
+			Value:    base64.StdEncoding.EncodeToString(payload),
+			MimeType: "application/pdf",
+		},
+		Metadata: map[string]any{"filename": "demo.pdf"},
+	}})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, model.ContentTypeFile, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].File)
+	assert.Empty(t, msg.ContentParts[0].File.Name)
+	assert.Equal(t, payload, msg.ContentParts[0].File.Data)
+	assert.Equal(t, "application/pdf", msg.ContentParts[0].File.MimeType)
+}
+
 func TestUserMessageFromInputContentsBinaryURLFile(t *testing.T) {
 	msg, err := UserMessageFromInputContents([]types.InputContent{
 		{

--- a/server/agui/internal/multimodal/multimodal_test.go
+++ b/server/agui/internal/multimodal/multimodal_test.go
@@ -75,6 +75,54 @@ func TestUserMessageFromInputContentsErrors(t *testing.T) {
 		assert.ErrorContains(t, err, "decode binary payload")
 		assert.ErrorContains(t, err, "illegal base64 data")
 	})
+	t.Run("typed input requires source", func(t *testing.T) {
+		_, err := UserMessageFromInputContents([]types.InputContent{{
+			Type: types.InputContentTypeImage,
+		}})
+		assert.ErrorContains(t, err, "image input content requires source")
+	})
+	t.Run("typed input requires source value", func(t *testing.T) {
+		_, err := UserMessageFromInputContents([]types.InputContent{{
+			Type: types.InputContentTypeImage,
+			Source: &types.InputContentSource{
+				Type:  types.InputContentSourceTypeURL,
+				Value: " ",
+			},
+		}})
+		assert.ErrorContains(t, err, "image input content source value is empty")
+	})
+	t.Run("typed data requires mime type", func(t *testing.T) {
+		_, err := UserMessageFromInputContents([]types.InputContent{{
+			Type: types.InputContentTypeAudio,
+			Source: &types.InputContentSource{
+				Type:  types.InputContentSourceTypeData,
+				Value: "AQID",
+			},
+		}})
+		assert.ErrorContains(t, err, "audio data source requires mime type")
+	})
+	t.Run("typed data rejects invalid base64", func(t *testing.T) {
+		_, err := UserMessageFromInputContents([]types.InputContent{{
+			Type: types.InputContentTypeVideo,
+			Source: &types.InputContentSource{
+				Type:     types.InputContentSourceTypeData,
+				Value:    "not-base64",
+				MimeType: "video/mp4",
+			},
+		}})
+		assert.ErrorContains(t, err, "decode video payload")
+	})
+	t.Run("typed data requires matching mime type", func(t *testing.T) {
+		_, err := UserMessageFromInputContents([]types.InputContent{{
+			Type: types.InputContentTypeImage,
+			Source: &types.InputContentSource{
+				Type:     types.InputContentSourceTypeData,
+				Value:    "AQID",
+				MimeType: "audio/mpeg",
+			},
+		}})
+		assert.ErrorContains(t, err, "image data source requires image mime type")
+	})
 }
 
 func TestUserMessageFromInputContentsTextAndImageURL(t *testing.T) {
@@ -174,6 +222,23 @@ func TestUserMessageFromInputContentsTypedVideoData(t *testing.T) {
 	assert.Equal(t, "mp4", msg.ContentParts[0].Video.Format)
 }
 
+func TestUserMessageFromInputContentsTypedVideoURL(t *testing.T) {
+	msg, err := UserMessageFromInputContents([]types.InputContent{{
+		Type: types.InputContentTypeVideo,
+		Source: &types.InputContentSource{
+			Type:     types.InputContentSourceTypeURL,
+			Value:    "https://example.com/video.mp4",
+			MimeType: "video/mp4",
+		},
+	}})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, model.ContentTypeVideo, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].Video)
+	assert.Equal(t, "https://example.com/video.mp4", msg.ContentParts[0].Video.URL)
+	assert.Equal(t, "video/mp4", msg.ContentParts[0].Video.Format)
+}
+
 func TestUserMessageFromInputContentsTypedDocumentData(t *testing.T) {
 	payload := []byte("document")
 	msg, err := UserMessageFromInputContents([]types.InputContent{{
@@ -191,6 +256,23 @@ func TestUserMessageFromInputContentsTypedDocumentData(t *testing.T) {
 	require.NotNil(t, msg.ContentParts[0].File)
 	assert.Empty(t, msg.ContentParts[0].File.Name)
 	assert.Equal(t, payload, msg.ContentParts[0].File.Data)
+	assert.Equal(t, "application/pdf", msg.ContentParts[0].File.MimeType)
+}
+
+func TestUserMessageFromInputContentsTypedDocumentURL(t *testing.T) {
+	msg, err := UserMessageFromInputContents([]types.InputContent{{
+		Type: types.InputContentTypeDocument,
+		Source: &types.InputContentSource{
+			Type:     types.InputContentSourceTypeURL,
+			Value:    "https://example.com/document.pdf",
+			MimeType: "application/pdf",
+		},
+	}})
+	require.NoError(t, err)
+	require.Len(t, msg.ContentParts, 1)
+	assert.Equal(t, model.ContentTypeFile, msg.ContentParts[0].Type)
+	require.NotNil(t, msg.ContentParts[0].File)
+	assert.Equal(t, "https://example.com/document.pdf", msg.ContentParts[0].File.URL)
 	assert.Equal(t, "application/pdf", msg.ContentParts[0].File.MimeType)
 }
 

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -3116,7 +3116,13 @@ func TestRunLastMessageContentArray(t *testing.T) {
 		Messages: []types.Message{{
 			Role: types.RoleUser,
 			Content: []types.InputContent{
-				{Type: types.InputContentTypeBinary, MimeType: "image/jpeg", URL: "https://example.com/resource/download?id=1"},
+				{
+					Type: types.InputContentTypeImage,
+					Source: &types.InputContentSource{
+						Type:  types.InputContentSourceTypeURL,
+						Value: "https://example.com/resource/download?id=1",
+					},
+				},
 				{Type: types.InputContentTypeText, Text: "图中有哪些信息?"},
 			},
 		}},

--- a/server/agui/translator/queued_user_message.go
+++ b/server/agui/translator/queued_user_message.go
@@ -69,6 +69,8 @@ func inputContentFromPart(part model.ContentPart) (aguitypes.InputContent, error
 		return inputContentFromImage(part.Image)
 	case model.ContentTypeAudio:
 		return inputContentFromAudio(part.Audio)
+	case model.ContentTypeVideo:
+		return inputContentFromVideo(part.Video)
 	case model.ContentTypeFile:
 		return inputContentFromFile(part.File)
 	default:
@@ -111,6 +113,24 @@ func inputContentFromAudio(audio *model.Audio) (aguitypes.InputContent, error) {
 	}
 	if content.URL == "" && content.Data == "" {
 		return aguitypes.InputContent{}, errors.New("queued user message audio content part is empty")
+	}
+	return content, nil
+}
+
+func inputContentFromVideo(video *model.Video) (aguitypes.InputContent, error) {
+	if video == nil {
+		return aguitypes.InputContent{}, errors.New("queued user message video content part is nil")
+	}
+	content := aguitypes.InputContent{
+		Type:     aguitypes.InputContentTypeBinary,
+		MimeType: binaryMimeType("video", video.Format),
+		URL:      strings.TrimSpace(video.URL),
+	}
+	if len(video.Data) > 0 {
+		content.Data = base64.StdEncoding.EncodeToString(video.Data)
+	}
+	if content.URL == "" && content.Data == "" {
+		return aguitypes.InputContent{}, errors.New("queued user message video content part is empty")
 	}
 	return content, nil
 }

--- a/server/agui/translator/queued_user_message.go
+++ b/server/agui/translator/queued_user_message.go
@@ -101,14 +101,18 @@ func inputContentFromAudio(audio *model.Audio) (aguitypes.InputContent, error) {
 	if audio == nil {
 		return aguitypes.InputContent{}, errors.New("queued user message audio content part is nil")
 	}
-	if len(audio.Data) == 0 {
-		return aguitypes.InputContent{}, errors.New("queued user message audio content part is empty")
-	}
-	return aguitypes.InputContent{
+	content := aguitypes.InputContent{
 		Type:     aguitypes.InputContentTypeBinary,
 		MimeType: binaryMimeType("audio", audio.Format),
-		Data:     base64.StdEncoding.EncodeToString(audio.Data),
-	}, nil
+		URL:      strings.TrimSpace(audio.URL),
+	}
+	if len(audio.Data) > 0 {
+		content.Data = base64.StdEncoding.EncodeToString(audio.Data)
+	}
+	if content.URL == "" && content.Data == "" {
+		return aguitypes.InputContent{}, errors.New("queued user message audio content part is empty")
+	}
+	return content, nil
 }
 
 func inputContentFromFile(file *model.File) (aguitypes.InputContent, error) {

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -344,6 +344,20 @@ func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
 				},
 			},
 			{
+				Type: model.ContentTypeVideo,
+				Video: &model.Video{
+					Data:   []byte("video"),
+					Format: "mp4",
+				},
+			},
+			{
+				Type: model.ContentTypeVideo,
+				Video: &model.Video{
+					URL:    " https://example.com/video.webm ",
+					Format: "video/webm",
+				},
+			},
+			{
 				Type: model.ContentTypeFile,
 				File: &model.File{
 					Name:     "report.pdf",
@@ -380,7 +394,7 @@ func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
 	assert.Equal(t, aguitypes.RoleUser, userMessage.Role)
 	contents, ok := userMessage.ContentInputContents()
 	require.True(t, ok)
-	require.Len(t, contents, 7)
+	require.Len(t, contents, 9)
 	assert.Equal(t, aguitypes.InputContentTypeText, contents[0].Type)
 	assert.Equal(t, "context", contents[0].Text)
 	assert.Equal(t, aguitypes.InputContentTypeText, contents[1].Type)
@@ -395,13 +409,19 @@ func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
 	assert.Equal(t, "audio/mpeg", contents[4].MimeType)
 	assert.Equal(t, "https://example.com/audio.mp3", contents[4].URL)
 	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[5].Type)
-	assert.Equal(t, "application/pdf", contents[5].MimeType)
-	assert.Equal(t, "report.pdf", contents[5].Filename)
-	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("file")), contents[5].Data)
+	assert.Equal(t, "video/mp4", contents[5].MimeType)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("video")), contents[5].Data)
 	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[6].Type)
-	assert.Equal(t, "application/octet-stream", contents[6].MimeType)
-	assert.Equal(t, "uploaded.pdf", contents[6].Filename)
-	assert.Equal(t, "file-123", contents[6].ID)
+	assert.Equal(t, "video/webm", contents[6].MimeType)
+	assert.Equal(t, "https://example.com/video.webm", contents[6].URL)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[7].Type)
+	assert.Equal(t, "application/pdf", contents[7].MimeType)
+	assert.Equal(t, "report.pdf", contents[7].Filename)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("file")), contents[7].Data)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[8].Type)
+	assert.Equal(t, "application/octet-stream", contents[8].MimeType)
+	assert.Equal(t, "uploaded.pdf", contents[8].Filename)
+	assert.Equal(t, "file-123", contents[8].ID)
 
 	activity, ok := events[1].(*aguievents.ActivitySnapshotEvent)
 	require.True(t, ok)
@@ -457,6 +477,21 @@ func TestQueuedUserMessageContentPartsConversionErrors(t *testing.T) {
 			want: "queued user message audio content part is empty",
 		},
 		{
+			name: "nil video",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type: model.ContentTypeVideo,
+			}}},
+			want: "queued user message video content part is nil",
+		},
+		{
+			name: "empty video",
+			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
+				Type:  model.ContentTypeVideo,
+				Video: &model.Video{},
+			}}},
+			want: "queued user message video content part is empty",
+		},
+		{
 			name: "nil file",
 			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
 				Type: model.ContentTypeFile,
@@ -474,7 +509,7 @@ func TestQueuedUserMessageContentPartsConversionErrors(t *testing.T) {
 		{
 			name: "unsupported",
 			message: model.Message{Role: model.RoleUser, ContentParts: []model.ContentPart{{
-				Type: "video",
+				Type: "unknown",
 			}}},
 			want: "queued user message content part type unsupported",
 		},

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -337,6 +337,13 @@ func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
 				},
 			},
 			{
+				Type: model.ContentTypeAudio,
+				Audio: &model.Audio{
+					URL:    " https://example.com/audio.mp3 ",
+					Format: "audio/mpeg",
+				},
+			},
+			{
 				Type: model.ContentTypeFile,
 				File: &model.File{
 					Name:     "report.pdf",
@@ -373,7 +380,7 @@ func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
 	assert.Equal(t, aguitypes.RoleUser, userMessage.Role)
 	contents, ok := userMessage.ContentInputContents()
 	require.True(t, ok)
-	require.Len(t, contents, 6)
+	require.Len(t, contents, 7)
 	assert.Equal(t, aguitypes.InputContentTypeText, contents[0].Type)
 	assert.Equal(t, "context", contents[0].Text)
 	assert.Equal(t, aguitypes.InputContentTypeText, contents[1].Type)
@@ -385,13 +392,16 @@ func TestTranslateQueuedUserMessageConsumedWithContentParts(t *testing.T) {
 	assert.Equal(t, "audio/wav", contents[3].MimeType)
 	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("audio")), contents[3].Data)
 	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[4].Type)
-	assert.Equal(t, "application/pdf", contents[4].MimeType)
-	assert.Equal(t, "report.pdf", contents[4].Filename)
-	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("file")), contents[4].Data)
+	assert.Equal(t, "audio/mpeg", contents[4].MimeType)
+	assert.Equal(t, "https://example.com/audio.mp3", contents[4].URL)
 	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[5].Type)
-	assert.Equal(t, "application/octet-stream", contents[5].MimeType)
-	assert.Equal(t, "uploaded.pdf", contents[5].Filename)
-	assert.Equal(t, "file-123", contents[5].ID)
+	assert.Equal(t, "application/pdf", contents[5].MimeType)
+	assert.Equal(t, "report.pdf", contents[5].Filename)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("file")), contents[5].Data)
+	assert.Equal(t, aguitypes.InputContentTypeBinary, contents[6].Type)
+	assert.Equal(t, "application/octet-stream", contents[6].MimeType)
+	assert.Equal(t, "uploaded.pdf", contents[6].Filename)
+	assert.Equal(t, "file-123", contents[6].ID)
 
 	activity, ok := events[1].(*aguievents.ActivitySnapshotEvent)
 	require.True(t, ok)

--- a/session/summary/cache_safe_fork.go
+++ b/session/summary/cache_safe_fork.go
@@ -126,6 +126,13 @@ func cloneContentPartForCacheSafeFork(part model.ContentPart) model.ContentPart 
 		}
 		cloned.Audio = &audio
 	}
+	if part.Video != nil {
+		video := *part.Video
+		if part.Video.Data != nil {
+			video.Data = append([]byte(nil), part.Video.Data...)
+		}
+		cloned.Video = &video
+	}
 	if part.File != nil {
 		file := *part.File
 		if part.File.Data != nil {

--- a/session/summary/cache_safe_fork_test.go
+++ b/session/summary/cache_safe_fork_test.go
@@ -75,8 +75,12 @@ func TestCloneRequestForCacheSafeFork_DeepClonesMutableFields(t *testing.T) {
 						Audio: &model.Audio{Data: []byte{3, 4}, Format: "wav"},
 					},
 					{
+						Type:  model.ContentTypeVideo,
+						Video: &model.Video{Data: []byte{5, 6}, Format: "mp4"},
+					},
+					{
 						Type: model.ContentTypeFile,
-						File: &model.File{Name: "a.txt", Data: []byte{5, 6}, MimeType: "text/plain"},
+						File: &model.File{Name: "a.txt", Data: []byte{7, 8}, MimeType: "text/plain"},
 					},
 				},
 				ToolCalls: []model.ToolCall{{
@@ -109,7 +113,8 @@ func TestCloneRequestForCacheSafeFork_DeepClonesMutableFields(t *testing.T) {
 	require.NotSame(t, parent.Messages[0].ContentParts[0].Text, cloned.Messages[0].ContentParts[0].Text)
 	require.NotSame(t, parent.Messages[0].ContentParts[1].Image, cloned.Messages[0].ContentParts[1].Image)
 	require.NotSame(t, parent.Messages[0].ContentParts[2].Audio, cloned.Messages[0].ContentParts[2].Audio)
-	require.NotSame(t, parent.Messages[0].ContentParts[3].File, cloned.Messages[0].ContentParts[3].File)
+	require.NotSame(t, parent.Messages[0].ContentParts[3].Video, cloned.Messages[0].ContentParts[3].Video)
+	require.NotSame(t, parent.Messages[0].ContentParts[4].File, cloned.Messages[0].ContentParts[4].File)
 	require.NotSame(t, parent.Messages[0].ToolCalls[0].Index, cloned.Messages[0].ToolCalls[0].Index)
 	require.NotSame(t, parent.StructuredOutput, cloned.StructuredOutput)
 	require.NotSame(t, parent.StructuredOutput.JSONSchema, cloned.StructuredOutput.JSONSchema)
@@ -117,7 +122,8 @@ func TestCloneRequestForCacheSafeFork_DeepClonesMutableFields(t *testing.T) {
 	*cloned.Messages[0].ContentParts[0].Text = "changed"
 	cloned.Messages[0].ContentParts[1].Image.Data[0] = 9
 	cloned.Messages[0].ContentParts[2].Audio.Data[0] = 9
-	cloned.Messages[0].ContentParts[3].File.Data[0] = 9
+	cloned.Messages[0].ContentParts[3].Video.Data[0] = 9
+	cloned.Messages[0].ContentParts[4].File.Data[0] = 9
 	cloned.Messages[0].ToolCalls[0].Function.Arguments[0] = '['
 	*cloned.Messages[0].ToolCalls[0].Index = 8
 	cloned.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"] = "changed"
@@ -131,7 +137,8 @@ func TestCloneRequestForCacheSafeFork_DeepClonesMutableFields(t *testing.T) {
 	require.Equal(t, "text part", *parent.Messages[0].ContentParts[0].Text)
 	require.Equal(t, byte(1), parent.Messages[0].ContentParts[1].Image.Data[0])
 	require.Equal(t, byte(3), parent.Messages[0].ContentParts[2].Audio.Data[0])
-	require.Equal(t, byte(5), parent.Messages[0].ContentParts[3].File.Data[0])
+	require.Equal(t, byte(5), parent.Messages[0].ContentParts[3].Video.Data[0])
+	require.Equal(t, byte(7), parent.Messages[0].ContentParts[4].File.Data[0])
 	require.Equal(t, byte('{'), parent.Messages[0].ToolCalls[0].Function.Arguments[0])
 	require.Equal(t, 3, *parent.Messages[0].ToolCalls[0].Index)
 	require.Equal(t, "v", parent.Messages[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["k"])

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module trpc.group/trpc-go/trpc-agent-go/test
 go 1.24.4
 
 require (
-	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260305114736-115a967b66a9
+	github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/stretchr/testify v1.11.1
@@ -84,8 +84,6 @@ require (
 )
 
 replace trpc.group/trpc-go/trpc-agent-go => ../
-
-replace github.com/ag-ui-protocol/ag-ui/sdks/community/go => github.com/Flash-LHR/ag-ui/sdks/community/go v0.0.0-20260226100332-50dd0f7a7764
 
 replace trpc.group/trpc-go/trpc-agent-go/server/agui => ../server/agui
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,5 +1,5 @@
-github.com/Flash-LHR/ag-ui/sdks/community/go v0.0.0-20260226100332-50dd0f7a7764 h1:U0gRia/az+x1HSctdGpMskiRE65kRYFSCuJ6jVJ9Vsg=
-github.com/Flash-LHR/ag-ui/sdks/community/go v0.0.0-20260226100332-50dd0f7a7764/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9 h1:DQFhA6IAPabs7cQ/Ryv1DfhfnGQ5cZLCBtf8YRqx2FY=
+github.com/ag-ui-protocol/ag-ui/sdks/community/go v0.0.0-20260514093510-e9e910b230b9/go.mod h1:ERAMOexUee4AIuoxksuuGoEcHl3aqLwaazjGwlR9ZCI=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=

--- a/test/session_externalization_e2e_test.go
+++ b/test/session_externalization_e2e_test.go
@@ -530,6 +530,11 @@ func cloneContentPart(part model.ContentPart) model.ContentPart {
 		audio.Data = append([]byte(nil), part.Audio.Data...)
 		clone.Audio = &audio
 	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = append([]byte(nil), part.Video.Data...)
+		clone.Video = &video
+	}
 	if part.File != nil {
 		file := *part.File
 		file.Data = append([]byte(nil), part.File.Data...)


### PR DESCRIPTION
## What changed

AG-UI typed image, audio, video, and document inputs now reach model providers without being collapsed into legacy binary content. Generic model messages support URL-based audio and URL/data-backed video, with provider-specific conversion for Gemini, Hunyuan, and OpenAI Chat Completions.

## Why

Current AG-UI clients send multimodal content through typed source objects. The server only handled text and legacy binary content, so uploaded images and other typed attachments could be dropped before model invocation. Keeping the AG-UI conversion provider-neutral also lets each model adapter apply its own input capabilities.

## Testing

- `go build ./...`
- `TMPDIR=/private/tmp go test ./...`
- `cd model/gemini && go test ./...`
- `cd server/agui && go test ./...`

## Notes for reviewers

This adds the public `ContentTypeVideo`, `Video`, `Audio.URL`, and message helper APIs without changing existing defaults. Document inputs map to ordinary files, and metadata is not interpreted as filename data. OpenAI Chat Completions omits unsupported video and URL-based audio while preserving an attachment hint; Hunyuan follows its existing URL-or-data-URL conversion pattern.

Updates ag-ui-protocol/ag-ui#1224
