### PR TITLE
{session/summary, internal/flow/processor}: preserve conversation across summary cutoffs

### DIFF
--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1589,6 +1589,9 @@ func historyTurnKeyForEvent(evt event.Event) (historyTurnKey, bool) {
 func historyRoleForEvent(evt event.Event) (model.Role, bool) {
 	for _, choice := range evt.Choices {
 		msg := choice.Message
+		if userLikeRole(msg.Role) && model.HasPayload(msg) {
+			return model.RoleUser, true
+		}
 		if msg.Role.IsValid() {
 			return msg.Role, true
 		}

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1010,6 +1010,11 @@ type eventHistoryCutoff struct {
 	lastEventIndex int
 }
 
+type historyTurnKey struct {
+	requestID    string
+	invocationID string
+}
+
 func newEventHistoryCutoff(
 	events []event.Event,
 	cutoff summaryHistoryCutoff,
@@ -1322,6 +1327,13 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 			inv.AgentName,
 		)
 	}
+	resultEvents = p.restoreUserEventsAcrossCutoff(
+		resultEvents,
+		sessionEvents,
+		inv,
+		filter,
+		eventCutoff,
+	)
 
 	// Get current request ID for reasoning content filtering.
 	currentRequestID := inv.RunOptions.RequestID
@@ -1469,6 +1481,103 @@ func (p *ContentRequestProcessor) canMatchToolRound(
 	return isEventEligibleForInclusion(evt) &&
 		p.passTimelineFilter(evt, inv) &&
 		p.passBranchFilter(evt, filter)
+}
+
+// restoreUserEventsAcrossCutoff prepends the nearest covered user message to
+// each retained turn that would otherwise begin with an assistant or tool
+// message. It runs after transcript filtering and compaction so it does not
+// restore a user message whose remaining turn was omitted.
+func (p *ContentRequestProcessor) restoreUserEventsAcrossCutoff(
+	retained []event.Event,
+	all []event.Event,
+	inv *agent.Invocation,
+	filter string,
+	cutoff eventHistoryCutoff,
+) []event.Event {
+	if cutoff.IsZero() || len(retained) == 0 {
+		return retained
+	}
+
+	coveredUsers := make(map[historyTurnKey]event.Event)
+	tailStarted := make(map[historyTurnKey]struct{})
+	for i, evt := range all {
+		if !p.canMatchToolRound(evt, inv, filter) ||
+			messageorigin.IsSeedHistory(inv, evt.ID) {
+			continue
+		}
+		key, ok := historyTurnKeyForEvent(evt)
+		if !ok {
+			continue
+		}
+		role, ok := historyRoleForEvent(evt)
+		if !ok {
+			continue
+		}
+		if _, ok := tailStarted[key]; ok {
+			continue
+		}
+		if !cutoff.excludesEvent(i, evt) {
+			tailStarted[key] = struct{}{}
+			continue
+		}
+		if role == model.RoleUser {
+			coveredUsers[key] = evt
+		}
+	}
+	if len(coveredUsers) == 0 {
+		return retained
+	}
+
+	seen := make(map[historyTurnKey]struct{})
+	restored := make([]event.Event, 0, len(retained)+len(coveredUsers))
+	for _, evt := range retained {
+		key, ok := historyTurnKeyForEvent(evt)
+		if !ok {
+			restored = append(restored, evt)
+			continue
+		}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			role, hasRole := historyRoleForEvent(evt)
+			if hasRole && inv != nil &&
+				p.isOtherAgentReply(inv.AgentName, inv.Branch, &evt) {
+				role = model.RoleUser
+			}
+			userEvt, hasCoveredUser := coveredUsers[key]
+			if hasCoveredUser &&
+				(role == model.RoleAssistant || role == model.RoleTool) {
+				restored = append(restored, userEvt)
+			}
+		}
+		restored = append(restored, evt)
+	}
+	return restored
+}
+
+func historyTurnKeyForEvent(evt event.Event) (historyTurnKey, bool) {
+	if evt.RequestID == "" || evt.InvocationID == "" {
+		return historyTurnKey{}, false
+	}
+	return historyTurnKey{
+		requestID:    evt.RequestID,
+		invocationID: evt.InvocationID,
+	}, true
+}
+
+func historyRoleForEvent(evt event.Event) (model.Role, bool) {
+	for _, choice := range evt.Choices {
+		msg := choice.Message
+		if msg.Role.IsValid() {
+			return msg.Role, true
+		}
+		if msg.ToolID != "" {
+			return model.RoleTool, true
+		}
+		if len(msg.ToolCalls) > 0 {
+			return model.RoleAssistant, true
+		}
+	}
+	return "", false
 }
 
 func addToolCallIDToRestore(

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1547,6 +1547,8 @@ func (p *ContentRequestProcessor) coveredUserEventsBeforeCutoff(
 ) map[historyTurnKey]event.Event {
 	coveredUsers := make(map[historyTurnKey]event.Event)
 	tailStarted := make(map[historyTurnKey]struct{})
+	// Keep replacing each candidate until its retained tail begins, so only
+	// the final eligible pre-cutoff user event can be restored for that turn.
 	for i, evt := range events {
 		if !p.canMatchToolRound(evt, inv, filter) ||
 			messageorigin.IsSeedHistory(inv, evt.ID) {

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1498,9 +1498,56 @@ func (p *ContentRequestProcessor) restoreUserEventsAcrossCutoff(
 		return retained
 	}
 
+	coveredUsers := p.coveredUserEventsBeforeCutoff(
+		all,
+		inv,
+		filter,
+		cutoff,
+	)
+	if len(coveredUsers) == 0 {
+		return retained
+	}
+
+	seen := make(map[historyTurnKey]struct{})
+	restored := make([]event.Event, 0, len(retained)+len(coveredUsers))
+	for i := range retained {
+		evt := retained[i]
+		key, ok := historyTurnKeyForEvent(evt)
+		if !ok {
+			restored = append(restored, evt)
+			continue
+		}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			role, hasRole := historyRoleForEvent(evt)
+			if hasRole && inv != nil &&
+				p.isOtherAgentReply(
+					inv.AgentName,
+					inv.Branch,
+					&retained[i],
+				) {
+				role = model.RoleUser
+			}
+			userEvt, hasCoveredUser := coveredUsers[key]
+			if hasCoveredUser &&
+				(role == model.RoleAssistant || role == model.RoleTool) {
+				restored = append(restored, userEvt)
+			}
+		}
+		restored = append(restored, evt)
+	}
+	return restored
+}
+
+func (p *ContentRequestProcessor) coveredUserEventsBeforeCutoff(
+	events []event.Event,
+	inv *agent.Invocation,
+	filter string,
+	cutoff eventHistoryCutoff,
+) map[historyTurnKey]event.Event {
 	coveredUsers := make(map[historyTurnKey]event.Event)
 	tailStarted := make(map[historyTurnKey]struct{})
-	for i, evt := range all {
+	for i, evt := range events {
 		if !p.canMatchToolRound(evt, inv, filter) ||
 			messageorigin.IsSeedHistory(inv, evt.ID) {
 			continue
@@ -1524,34 +1571,7 @@ func (p *ContentRequestProcessor) restoreUserEventsAcrossCutoff(
 			coveredUsers[key] = evt
 		}
 	}
-	if len(coveredUsers) == 0 {
-		return retained
-	}
-
-	seen := make(map[historyTurnKey]struct{})
-	restored := make([]event.Event, 0, len(retained)+len(coveredUsers))
-	for _, evt := range retained {
-		key, ok := historyTurnKeyForEvent(evt)
-		if !ok {
-			restored = append(restored, evt)
-			continue
-		}
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
-			role, hasRole := historyRoleForEvent(evt)
-			if hasRole && inv != nil &&
-				p.isOtherAgentReply(inv.AgentName, inv.Branch, &evt) {
-				role = model.RoleUser
-			}
-			userEvt, hasCoveredUser := coveredUsers[key]
-			if hasCoveredUser &&
-				(role == model.RoleAssistant || role == model.RoleTool) {
-				restored = append(restored, userEvt)
-			}
-		}
-		restored = append(restored, evt)
-	}
-	return restored
+	return coveredUsers
 }
 
 func historyTurnKeyForEvent(evt event.Event) (historyTurnKey, bool) {

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1327,45 +1327,13 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 			inv.AgentName,
 		)
 	}
-	resultEvents = p.restoreUserEventsAcrossCutoff(
+	messages := p.projectMessagesAcrossSummaryCutoff(
 		resultEvents,
 		sessionEvents,
 		inv,
 		filter,
 		eventCutoff,
 	)
-
-	// Get current request ID for reasoning content filtering.
-	currentRequestID := inv.RunOptions.RequestID
-
-	toolCallRequestIDs := requestIDsWithToolCalls(resultEvents)
-
-	// Convert events to messages with reasoning content handling.
-	var messages []model.Message
-	for _, evt := range resultEvents {
-		// Convert foreign events or keep as-is.
-		ev := evt
-		if p.isOtherAgentReply(inv.AgentName, inv.Branch, &ev) {
-			ev = p.convertForeignEvent(&ev)
-		}
-		if len(ev.Choices) > 0 {
-			for _, choice := range ev.Choices {
-				msg := choice.Message
-				// Apply reasoning content stripping based on mode.
-				msg = p.processReasoningContent(
-					msg,
-					evt.RequestID,
-					currentRequestID,
-					requestHasToolCalls(toolCallRequestIDs, evt.RequestID),
-				)
-				msg = p.projectEventMessage(inv, evt, msg)
-				if message.IsEmptyAssistantMessage(msg) {
-					continue
-				}
-				messages = append(messages, msg)
-			}
-		}
-	}
 
 	messages = p.mergeUserMessages(messages)
 
@@ -1483,60 +1451,57 @@ func (p *ContentRequestProcessor) canMatchToolRound(
 		p.passBranchFilter(evt, filter)
 }
 
-// restoreUserEventsAcrossCutoff prepends the nearest covered user message to
-// each retained turn that would otherwise begin with an assistant or tool
-// message. It runs after transcript filtering and compaction so it does not
-// restore a user message whose remaining turn was omitted.
-func (p *ContentRequestProcessor) restoreUserEventsAcrossCutoff(
+func (p *ContentRequestProcessor) projectMessagesAcrossSummaryCutoff(
 	retained []event.Event,
 	all []event.Event,
 	inv *agent.Invocation,
 	filter string,
 	cutoff eventHistoryCutoff,
-) []event.Event {
-	if cutoff.IsZero() || len(retained) == 0 {
-		return retained
-	}
-
+) []model.Message {
+	// Decide whether a turn needs its covered user anchor only after projection.
+	// A projector may remove or rewrite the retained assistant or tool message.
+	currentRequestID := inv.RunOptions.RequestID
+	toolCallRequestIDs := requestIDsWithToolCalls(retained)
 	coveredUsers := p.coveredUserEventsBeforeCutoff(
 		all,
 		inv,
 		filter,
 		cutoff,
 	)
-	if len(coveredUsers) == 0 {
-		return retained
-	}
 
-	seen := make(map[historyTurnKey]struct{})
-	restored := make([]event.Event, 0, len(retained)+len(coveredUsers))
-	for i := range retained {
-		evt := retained[i]
-		key, ok := historyTurnKeyForEvent(evt)
-		if !ok {
-			restored = append(restored, evt)
+	var messages []model.Message
+	seenTurns := make(map[historyTurnKey]struct{})
+	for _, evt := range retained {
+		projected := p.projectMessagesForEvent(
+			inv,
+			evt,
+			currentRequestID,
+			toolCallRequestIDs,
+		)
+		if len(projected) == 0 {
 			continue
 		}
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
-			role, hasRole := historyRoleForEvent(evt)
-			if hasRole && inv != nil &&
-				p.isOtherAgentReply(
-					inv.AgentName,
-					inv.Branch,
-					&retained[i],
-				) {
-				role = model.RoleUser
-			}
-			userEvt, hasCoveredUser := coveredUsers[key]
-			if hasCoveredUser &&
+		key, hasKey := historyTurnKeyForEvent(evt)
+		_, seen := seenTurns[key]
+		if hasKey && !seen {
+			seenTurns[key] = struct{}{}
+			role, _ := historyRoleForMessages(projected)
+			if userEvt, ok := coveredUsers[key]; ok &&
 				(role == model.RoleAssistant || role == model.RoleTool) {
-				restored = append(restored, userEvt)
+				messages = append(
+					messages,
+					p.projectMessagesForEvent(
+						inv,
+						userEvt,
+						currentRequestID,
+						toolCallRequestIDs,
+					)...,
+				)
 			}
 		}
-		restored = append(restored, evt)
+		messages = append(messages, projected...)
 	}
-	return restored
+	return messages
 }
 
 func (p *ContentRequestProcessor) coveredUserEventsBeforeCutoff(
@@ -1577,7 +1542,7 @@ func (p *ContentRequestProcessor) coveredUserEventsBeforeCutoff(
 }
 
 func historyTurnKeyForEvent(evt event.Event) (historyTurnKey, bool) {
-	if evt.RequestID == "" || evt.InvocationID == "" {
+	if evt.InvocationID == "" {
 		return historyTurnKey{}, false
 	}
 	return historyTurnKey{
@@ -1588,19 +1553,34 @@ func historyTurnKeyForEvent(evt event.Event) (historyTurnKey, bool) {
 
 func historyRoleForEvent(evt event.Event) (model.Role, bool) {
 	for _, choice := range evt.Choices {
-		msg := choice.Message
-		if userLikeRole(msg.Role) && model.HasPayload(msg) {
-			return model.RoleUser, true
+		if role, ok := historyRoleForMessage(choice.Message); ok {
+			return role, true
 		}
-		if msg.Role.IsValid() {
-			return msg.Role, true
+	}
+	return "", false
+}
+
+func historyRoleForMessages(messages []model.Message) (model.Role, bool) {
+	for _, msg := range messages {
+		if role, ok := historyRoleForMessage(msg); ok {
+			return role, true
 		}
-		if msg.ToolID != "" {
-			return model.RoleTool, true
-		}
-		if len(msg.ToolCalls) > 0 {
-			return model.RoleAssistant, true
-		}
+	}
+	return "", false
+}
+
+func historyRoleForMessage(msg model.Message) (model.Role, bool) {
+	if userLikeRole(msg.Role) && model.HasPayload(msg) {
+		return model.RoleUser, true
+	}
+	if msg.Role.IsValid() {
+		return msg.Role, true
+	}
+	if msg.ToolID != "" {
+		return model.RoleTool, true
+	}
+	if len(msg.ToolCalls) > 0 {
+		return model.RoleAssistant, true
 	}
 	return "", false
 }

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4476,6 +4476,7 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 		events    []event.Event
 		cutoff    summaryHistoryCutoff
 		configure func(*agent.Invocation)
+		projector EventMessageProjector
 		wantRole  []model.Role
 		wantText  []string
 	}{
@@ -4615,7 +4616,7 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			wantText: []string{"answer"},
 		},
 		{
-			name: "missing turn identifier skips restoration",
+			name: "missing request identifier restores by invocation",
 			events: []event.Event{
 				messageEvent(
 					"legacy-user",
@@ -4635,8 +4636,88 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			cutoff: summaryHistoryCutoffFromTime(
 				baseTime.Add(time.Second),
 			),
+			wantRole: []model.Role{model.RoleUser, model.RoleAssistant},
+			wantText: []string{"legacy question", "answer"},
+		},
+		{
+			name: "missing request identifier keeps invocations isolated",
+			events: []event.Event{
+				messageEvent(
+					"legacy-user",
+					"",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("unrelated question"),
+				),
+				messageEvent(
+					"legacy-assistant",
+					"",
+					"invocation-2",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
 			wantRole: []model.Role{model.RoleAssistant},
 			wantText: []string{"answer"},
+		},
+		{
+			name: "missing invocation identifier skips restoration",
+			events: []event.Event{
+				messageEvent(
+					"user",
+					"request-1",
+					"",
+					baseTime,
+					model.NewUserMessage("question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			wantRole: []model.Role{model.RoleAssistant},
+			wantText: []string{"answer"},
+		},
+		{
+			name: "projected away tail does not restore covered user",
+			events: []event.Event{
+				messageEvent(
+					"user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			projector: func(
+				_ *agent.Invocation,
+				_ event.Event,
+				msg model.Message,
+			) model.Message {
+				if msg.Role == model.RoleAssistant {
+					msg.Content = ""
+				}
+				return msg
+			},
 		},
 		{
 			name: "seed history user is not restored",
@@ -4708,7 +4789,10 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			if tt.configure != nil {
 				tt.configure(inv)
 			}
-			p := NewContentRequestProcessor(WithAddSessionSummary(true))
+			p := NewContentRequestProcessor(
+				WithAddSessionSummary(true),
+				WithEventMessageProjector(tt.projector),
+			)
 
 			messages := p.getIncrementMessagesAfterCutoff(
 				inv,

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4442,6 +4442,266 @@ func TestContentRequestProcessor_getIncrementMessages_ExactBoundaryKeepsSameTime
 	assert.Equal(t, "same timestamp tail", messages[0].Content)
 }
 
+func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryCutoff(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	messageEvent := func(
+		id string,
+		requestID string,
+		invocationID string,
+		timestamp time.Time,
+		msg model.Message,
+	) event.Event {
+		return event.Event{
+			ID:           id,
+			Author:       "test-agent",
+			RequestID:    requestID,
+			InvocationID: invocationID,
+			Timestamp:    timestamp,
+			Version:      event.CurrentVersion,
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: msg,
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		events   []event.Event
+		cutoff   summaryHistoryCutoff
+		wantRole []model.Role
+		wantText []string
+	}{
+		{
+			name: "legacy timestamp restores latest user in split turn",
+			events: []event.Event{
+				messageEvent(
+					"old-user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("old question"),
+				),
+				messageEvent(
+					"latest-user",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(time.Second),
+					model.NewUserMessage("latest question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(3*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(2 * time.Second),
+			),
+			wantRole: []model.Role{model.RoleUser, model.RoleAssistant},
+			wantText: []string{"latest question", "answer"},
+		},
+		{
+			name: "exact boundary restores user before same timestamp assistant",
+			events: []event.Event{
+				messageEvent(
+					"user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoff{
+				at:          baseTime,
+				lastEventID: "user",
+			},
+			wantRole: []model.Role{model.RoleUser, model.RoleAssistant},
+			wantText: []string{"question", "answer"},
+		},
+		{
+			name: "retained user already anchors turn",
+			events: []event.Event{
+				messageEvent(
+					"covered-user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("covered question"),
+				),
+				messageEvent(
+					"retained-user",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(2*time.Second),
+					model.NewUserMessage("retained question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(3*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			wantRole: []model.Role{model.RoleUser, model.RoleAssistant},
+			wantText: []string{"retained question", "answer"},
+		},
+		{
+			name: "different invocation remains isolated",
+			events: []event.Event{
+				messageEvent(
+					"user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("unrelated question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-2",
+					"invocation-2",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			wantRole: []model.Role{model.RoleAssistant},
+			wantText: []string{"answer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := agent.NewInvocation(
+				agent.WithInvocationSession(getSession(tt.events...)),
+			)
+			p := NewContentRequestProcessor(WithAddSessionSummary(true))
+
+			messages := p.getIncrementMessagesAfterCutoff(
+				inv,
+				nil,
+				tt.cutoff,
+			)
+
+			require.Len(t, messages, len(tt.wantRole))
+			for i := range messages {
+				assert.Equal(t, tt.wantRole[i], messages[i].Role)
+				assert.Equal(t, tt.wantText[i], messages[i].Content)
+			}
+		})
+	}
+}
+
+func TestContentRequestProcessor_getIncrementMessages_RestoresUserForToolContinuation(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	toolCall := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{{
+			Type: "function",
+			ID:   "call-1",
+			Function: model.FunctionDefinitionParam{
+				Name:      "lookup",
+				Arguments: []byte(`{"query":"status"}`),
+			},
+		}},
+	}
+	events := []event.Event{
+		{
+			ID:           "user",
+			Author:       "test-agent",
+			RequestID:    "request-1",
+			InvocationID: "invocation-1",
+			Timestamp:    baseTime,
+			Version:      event.CurrentVersion,
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage("check status"),
+				}},
+			},
+		},
+		{
+			ID:           "tool-call",
+			Author:       "test-agent",
+			RequestID:    "request-1",
+			InvocationID: "invocation-1",
+			Timestamp:    baseTime.Add(time.Second),
+			Version:      event.CurrentVersion,
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: toolCall,
+				}},
+			},
+		},
+		{
+			ID:           "tool-result",
+			Author:       "test-agent",
+			RequestID:    "request-1",
+			InvocationID: "invocation-1",
+			Timestamp:    baseTime.Add(3 * time.Second),
+			Version:      event.CurrentVersion,
+			Response: &model.Response{
+				Done:   true,
+				Object: model.ObjectTypeToolResponse,
+				Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						"call-1",
+						"lookup",
+						"ready",
+					),
+				}},
+			},
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(getSession(events...)),
+	)
+	p := NewContentRequestProcessor(WithAddSessionSummary(true))
+
+	messages := p.getIncrementMessagesAfterCutoff(
+		inv,
+		nil,
+		summaryHistoryCutoffFromTime(baseTime.Add(2*time.Second)),
+	)
+
+	require.Len(t, messages, 3)
+	assert.Equal(t, model.RoleUser, messages[0].Role)
+	assert.Equal(t, "check status", messages[0].Content)
+	assert.Equal(t, model.RoleAssistant, messages[1].Role)
+	require.Len(t, messages[1].ToolCalls, 1)
+	assert.Equal(t, "call-1", messages[1].ToolCalls[0].ID)
+	assert.Equal(t, model.RoleTool, messages[2].Role)
+	assert.Equal(t, "ready", messages[2].Content)
+
+	omitted := NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithToolTranscriptMode(ToolTranscriptModeOmitPreviousCompleted),
+	).getIncrementMessagesAfterCutoff(
+		inv,
+		nil,
+		summaryHistoryCutoffFromTime(baseTime.Add(2*time.Second)),
+	)
+	assert.Empty(t, omitted)
+}
+
 func TestContentRequestProcessor_getIncrementMessages_RestoresNeededPreCutoffToolCall(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
 	toolCall := model.Message{

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4591,6 +4591,30 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			wantText: []string{"answer"},
 		},
 		{
+			name: "missing turn identifier skips restoration",
+			events: []event.Event{
+				messageEvent(
+					"legacy-user",
+					"",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("legacy question"),
+				),
+				messageEvent(
+					"legacy-assistant",
+					"",
+					"invocation-1",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			wantRole: []model.Role{model.RoleAssistant},
+			wantText: []string{"answer"},
+		},
+		{
 			name: "seed history user is not restored",
 			events: []event.Event{
 				messageEvent(

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4466,13 +4466,18 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			},
 		}
 	}
+	withAuthor := func(evt event.Event, author string) event.Event {
+		evt.Author = author
+		return evt
+	}
 
 	tests := []struct {
-		name     string
-		events   []event.Event
-		cutoff   summaryHistoryCutoff
-		wantRole []model.Role
-		wantText []string
+		name      string
+		events    []event.Event
+		cutoff    summaryHistoryCutoff
+		configure func(*agent.Invocation)
+		wantRole  []model.Role
+		wantText  []string
 	}{
 		{
 			name: "legacy timestamp restores latest user in split turn",
@@ -4585,6 +4590,66 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			wantRole: []model.Role{model.RoleAssistant},
 			wantText: []string{"answer"},
 		},
+		{
+			name: "seed history user is not restored",
+			events: []event.Event{
+				messageEvent(
+					"seed-user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.NewUserMessage("seed question"),
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			configure: func(inv *agent.Invocation) {
+				messageorigin.MarkSeedHistory(inv, "seed-user")
+			},
+			wantRole: []model.Role{model.RoleAssistant},
+			wantText: []string{"answer"},
+		},
+		{
+			name: "foreign assistant does not trigger user restoration",
+			events: []event.Event{
+				withAuthor(
+					messageEvent(
+						"user",
+						"request-1",
+						"invocation-1",
+						baseTime,
+						model.NewUserMessage("question"),
+					),
+					"user",
+				),
+				withAuthor(
+					messageEvent(
+						"assistant",
+						"request-1",
+						"invocation-1",
+						baseTime.Add(2*time.Second),
+						model.NewAssistantMessage("answer"),
+					),
+					"other-agent",
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			configure: func(inv *agent.Invocation) {
+				inv.AgentName = "current-agent"
+			},
+			wantRole: []model.Role{model.RoleUser},
+			wantText: []string{"For context: [other-agent] said: answer"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -4592,6 +4657,9 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			inv := agent.NewInvocation(
 				agent.WithInvocationSession(getSession(tt.events...)),
 			)
+			if tt.configure != nil {
+				tt.configure(inv)
+			}
 			p := NewContentRequestProcessor(WithAddSessionSummary(true))
 
 			messages := p.getIncrementMessagesAfterCutoff(

--- a/internal/flow/processor/content_test.go
+++ b/internal/flow/processor/content_test.go
@@ -4536,6 +4536,30 @@ func TestContentRequestProcessor_getIncrementMessages_RestoresUserAcrossSummaryC
 			wantText: []string{"question", "answer"},
 		},
 		{
+			name: "empty role payload restores user-like anchor",
+			events: []event.Event{
+				messageEvent(
+					"user",
+					"request-1",
+					"invocation-1",
+					baseTime,
+					model.Message{Content: "question"},
+				),
+				messageEvent(
+					"assistant",
+					"request-1",
+					"invocation-1",
+					baseTime.Add(2*time.Second),
+					model.NewAssistantMessage("answer"),
+				),
+			},
+			cutoff: summaryHistoryCutoffFromTime(
+				baseTime.Add(time.Second),
+			),
+			wantRole: []model.Role{"", model.RoleAssistant},
+			wantText: []string{"question", "answer"},
+		},
+		{
 			name: "retained user already anchors turn",
 			events: []event.Event{
 				messageEvent(

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -88,8 +88,7 @@ const (
 	summaryToolArgumentsOmitted = `{"_trpc_summary_note":"tool arguments omitted to fit the summary context"}`
 	summaryToolResultOmittedFmt = "[Tool result omitted to fit the summary context; " +
 		"tool_name=%q, tool_call_id=%q. The tool call completed before summarization.]"
-	summaryConversationOmitted = "\n[... middle conversation omitted to fit the summary context ...]\n"
-	summaryPreviousOmitted     = "\n[... previous summary omitted to fit the summary context ...]\n"
+	summaryPreviousOmitted = "\n[... previous summary omitted to fit the summary context ...]\n"
 )
 
 // formatResponseError formats a model.ResponseError into a human-readable error.
@@ -1357,29 +1356,41 @@ func (s *sessionSummarizer) buildBoundedStandaloneSummaryRequest(
 		return request, nil
 	}
 
-	minimal, err := s.buildStandaloneSummaryRequest(summaryPromptInput{})
+	sourceOnlyInput := summaryPromptInput{
+		conversationText: input.conversationText,
+	}
+	sourceOnly, err := s.buildStandaloneSummaryRequest(sourceOnlyInput)
 	if err != nil {
 		return nil, err
 	}
-	minimalTokens, err := countSummaryRequestTokens(ctx, minimal)
+	sourceTokens, err := countSummaryRequestTokens(ctx, sourceOnly)
 	if err != nil {
 		return nil, err
 	}
-	if minimalTokens >= budget {
+	if sourceTokens > budget {
 		return nil, fmt.Errorf(
-			"summary prompt requires %d tokens but input budget is %d",
-			minimalTokens,
+			"summary source conversation requires %d tokens but input budget is %d; refusing to omit unsummarized conversation",
+			sourceTokens,
 			budget,
 		)
 	}
+	if input.previousSummary == "" {
+		return sourceOnly, nil
+	}
 
-	totalRunes := len([]rune(input.conversationText)) + len([]rune(input.previousSummary))
-	best := (*model.Request)(nil)
-	low, high := 1, totalRunes
+	previousRunes := []rune(input.previousSummary)
+	best := sourceOnly
+	low, high := 1, len(previousRunes)
 	for low <= high {
 		mid := low + (high-low)/2
 		candidate, buildErr := s.buildStandaloneSummaryRequest(
-			truncateSummaryPromptInput(input, mid),
+			summaryPromptInput{
+				conversationText: input.conversationText,
+				previousSummary: truncatePreviousSummary(
+					previousRunes,
+					mid,
+				),
+			},
 		)
 		if buildErr != nil {
 			return nil, buildErr
@@ -1395,17 +1406,7 @@ func (s *sessionSummarizer) buildBoundedStandaloneSummaryRequest(
 		}
 		high = mid - 1
 	}
-	if best == nil {
-		return nil, fmt.Errorf(
-			"summary input cannot fit a non-empty source within budget %d",
-			budget,
-		)
-	}
 	return best, nil
-}
-
-func truncateSummaryConversation(runes []rune, retain int) string {
-	return truncateSummaryText(runes, retain, summaryConversationOmitted)
 }
 
 func truncatePreviousSummary(runes []rune, retain int) string {
@@ -1427,43 +1428,6 @@ func truncateSummaryText(runes []rune, retain int, marker string) string {
 	result = append(result, markerRunes...)
 	result = append(result, runes[len(runes)-tail:]...)
 	return string(result)
-}
-
-func truncateSummaryPromptInput(input summaryPromptInput, retain int) summaryPromptInput {
-	conversationRunes := []rune(input.conversationText)
-	previousRunes := []rune(input.previousSummary)
-	total := len(conversationRunes) + len(previousRunes)
-	if retain >= total {
-		return input
-	}
-	if retain <= 0 {
-		return summaryPromptInput{}
-	}
-	if len(previousRunes) == 0 {
-		return summaryPromptInput{
-			conversationText: truncateSummaryConversation(conversationRunes, retain),
-		}
-	}
-	if len(conversationRunes) == 0 {
-		return summaryPromptInput{
-			previousSummary: truncatePreviousSummary(previousRunes, retain),
-		}
-	}
-
-	previousRetain := 0
-	conversationRetain := 1
-	if retain > 1 {
-		previousRetain = retain * len(previousRunes) / total
-		if previousRetain < 1 {
-			previousRetain = 1
-		}
-		conversationRetain = retain - previousRetain
-	}
-
-	return summaryPromptInput{
-		conversationText: truncateSummaryConversation(conversationRunes, conversationRetain),
-		previousSummary:  truncatePreviousSummary(previousRunes, previousRetain),
-	}
 }
 
 func summaryRequestFits(

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -1313,18 +1313,24 @@ func (s *sessionSummarizer) prepareSummaryRequest(
 		)
 		return bounded, mode, err
 	}
-	if err := s.ensureSummaryRequestFits(
+	fitErr := s.ensureSummaryRequestFits(
 		ctx,
 		request,
 		true,
 		budget,
-	); err == nil {
+	)
+	if fitErr == nil {
 		return request, mode, nil
 	}
 
 	// Cache-safe forking is an optimization. When the parent prefix cannot be
 	// made safe without dropping source conversation, fall back to a bounded
 	// standalone prompt whose final user message contains the source itself.
+	log.DebugfContext(
+		ctx,
+		"cache-safe summary request does not fit; falling back to standalone summary request: %v",
+		fitErr,
+	)
 	bounded, err := s.buildBoundedStandaloneSummaryRequest(
 		ctx,
 		input,

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -1323,7 +1323,7 @@ func (s *sessionSummarizer) prepareSummaryRequest(
 	}
 
 	// Cache-safe forking is an optimization. When the parent prefix cannot be
-	// made safe without dropping its last source round, fall back to a bounded
+	// made safe without dropping source conversation, fall back to a bounded
 	// standalone prompt whose final user message contains the source itself.
 	bounded, err := s.buildBoundedStandaloneSummaryRequest(
 		ctx,
@@ -1503,17 +1503,9 @@ func (s *sessionSummarizer) ensureSummaryRequestFits(
 	if tokens <= budget {
 		return nil
 	}
-	// Prefer dropping source rounds already represented by newer context before
-	// erasing payloads from the latest complete round.
-	for dropOldestSummarySourceRound(request) {
-		tokens, err = countSummaryRequestTokens(ctx, request)
-		if err != nil {
-			return fmt.Errorf("count pruned summary request tokens: %w", err)
-		}
-		if tokens <= budget {
-			return nil
-		}
-	}
+	// Preserve every source turn. Tool payloads may be represented by explicit
+	// omission markers, but the conversation structure must remain intact so a
+	// successful summary can safely advance the history cutoff.
 	candidates, err := summaryToolPayloadCandidates(ctx, request.Messages)
 	if err != nil {
 		return fmt.Errorf("build summary payload candidates: %w", err)
@@ -1529,7 +1521,7 @@ func (s *sessionSummarizer) ensureSummaryRequestFits(
 		}
 	}
 	return fmt.Errorf(
-		"cache-safe summary request input too large after semantic compaction: estimated %d tokens exceeds budget %d",
+		"cache-safe summary request input too large without dropping source conversation after semantic compaction: estimated %d tokens exceeds budget %d",
 		tokens,
 		budget,
 	)
@@ -1561,45 +1553,6 @@ func (s *sessionSummarizer) summaryRequestInputBudget(
 		return 1
 	}
 	return budget
-}
-
-func dropOldestSummarySourceRound(request *model.Request) bool {
-	if request == nil || len(request.Messages) < 3 {
-		return false
-	}
-	sourceEnd := len(request.Messages) - 1
-	rounds := summarySourceRounds(request.Messages[:sourceEnd])
-	if len(rounds) <= 1 {
-		return false
-	}
-	drop := make(map[int]struct{}, len(rounds[0]))
-	for _, index := range rounds[0] {
-		drop[index] = struct{}{}
-	}
-	messages := make([]model.Message, 0, len(request.Messages)-len(drop))
-	for i, message := range request.Messages {
-		if _, ok := drop[i]; ok {
-			continue
-		}
-		messages = append(messages, message)
-	}
-	request.Messages = messages
-	return true
-}
-
-func summarySourceRounds(messages []model.Message) [][]int {
-	var rounds [][]int
-	for i, message := range messages {
-		if message.Role == model.RoleSystem {
-			continue
-		}
-		if len(rounds) == 0 ||
-			(message.Role == model.RoleUser && len(rounds[len(rounds)-1]) > 0) {
-			rounds = append(rounds, nil)
-		}
-		rounds[len(rounds)-1] = append(rounds[len(rounds)-1], i)
-	}
-	return rounds
 }
 
 func isSummaryContextLengthError(err error, response *model.Response) bool {

--- a/session/summary/summarizer_hook_test.go
+++ b/session/summary/summarizer_hook_test.go
@@ -401,16 +401,13 @@ func TestSessionSummarizer_ModelCallbacks_Before_CustomResponseSkipsModel(t *tes
 	)
 
 	sess := &session.Session{
-		ID: "sess",
-		Events: []event.Event{newEventWithContent(
-			strings.Repeat("oversized-origin ", 1000),
-		)},
+		ID:     "sess",
+		Events: []event.Event{newEventWithContent("origin")},
 	}
 	summary, err := s.Summarize(context.Background(), sess)
 	require.NoError(t, err)
 	assert.Equal(t, "FROM_CALLBACK", summary)
-	assert.Contains(t, callbackInput, summaryConversationOmitted)
-	assert.Less(t, strings.Count(callbackInput, "oversized-origin"), 900)
+	assert.Contains(t, callbackInput, "origin")
 }
 
 func TestSessionSummarizer_ModelCallbacks_Before_AppliesToFallbackRequest(
@@ -440,15 +437,15 @@ func TestSessionSummarizer_ModelCallbacks_Before_AppliesToFallbackRequest(
 		WithCacheSafeForking(true),
 		WithModelCallbacks(callbacks),
 	)
-	oversized := strings.Repeat("oversized-origin ", 1000)
+	oversizedParent := strings.Repeat("oversized-parent ", 1000)
 	parent := &model.Request{Messages: []model.Message{
 		model.NewSystemMessage("stable system"),
-		model.NewUserMessage(oversized),
+		model.NewUserMessage(oversizedParent),
 	}}
 	ctx := ContextWithCacheSafeForkRequest(context.Background(), parent)
 	sess := &session.Session{
 		ID:     "fallback-callback",
-		Events: []event.Event{newEventWithContent(oversized)},
+		Events: []event.Event{newEventWithContent("event text for fallback")},
 	}
 
 	summary, err := s.Summarize(ctx, sess)
@@ -457,7 +454,7 @@ func TestSessionSummarizer_ModelCallbacks_Before_AppliesToFallbackRequest(
 	require.NotNil(t, capture.request)
 	require.Len(t, capture.request.Messages, 1)
 	require.Contains(t, capture.request.Messages[0].Content,
-		summaryConversationOmitted)
+		"event text for fallback")
 	require.NotNil(t, capture.request.GenerationConfig.MaxTokens)
 	require.Equal(t, maxTokens,
 		*capture.request.GenerationConfig.MaxTokens)

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -931,8 +931,9 @@ func TestEnsureSummaryRequestFitsPreservesSourceRounds(t *testing.T) {
 			ToolCalls: []model.ToolCall{{
 				ID: "old-call",
 				Function: model.FunctionDefinitionParam{
-					Name:      "lookup",
-					Arguments: []byte(`{"query":"old"}`),
+					Name: "lookup",
+					Arguments: []byte(`{"query":"` +
+						strings.Repeat("old ", 100) + `"}`),
 				},
 			}},
 		},
@@ -948,10 +949,15 @@ func TestEnsureSummaryRequestFitsPreservesSourceRounds(t *testing.T) {
 		true,
 		200,
 	)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "without dropping source conversation")
 	require.Len(t, request.Messages, 7)
 	require.Equal(t, model.RoleSystem, request.Messages[0].Role)
 	require.Contains(t, request.Messages[1].Content, "old source")
+	require.JSONEq(
+		t,
+		summaryToolArgumentsOmitted,
+		string(request.Messages[2].ToolCalls[0].Function.Arguments),
+	)
 	require.Equal(t, "latest source", request.Messages[4].Content)
 	require.Equal(t, "latest answer", request.Messages[5].Content)
 	require.Equal(t, "Summarize the conversation above.", request.Messages[6].Content)

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -921,7 +921,7 @@ func TestSessionSummarizer_RetriesEmptyStandaloneSummary(t *testing.T) {
 		"event text for standalone fallback")
 }
 
-func TestEnsureSummaryRequestFitsDropsOldestCompleteRound(t *testing.T) {
+func TestEnsureSummaryRequestFitsPreservesSourceRounds(t *testing.T) {
 	s := NewSummarizer(&cacheSafeCaptureModel{}).(*sessionSummarizer)
 	request := &model.Request{Messages: []model.Message{
 		model.NewSystemMessage("stable system"),
@@ -948,17 +948,44 @@ func TestEnsureSummaryRequestFitsDropsOldestCompleteRound(t *testing.T) {
 		true,
 		200,
 	)
-	require.NoError(t, err)
-	require.Len(t, request.Messages, 4)
+	require.Error(t, err)
+	require.Len(t, request.Messages, 7)
 	require.Equal(t, model.RoleSystem, request.Messages[0].Role)
-	require.Equal(t, "latest source", request.Messages[1].Content)
-	require.Equal(t, "latest answer", request.Messages[2].Content)
-	require.Equal(t, "Summarize the conversation above.", request.Messages[3].Content)
-	for _, message := range request.Messages {
-		require.NotContains(t, message.Content, "old source")
-		require.Empty(t, message.ToolCalls)
-		require.NotEqual(t, "old-call", message.ToolID)
+	require.Contains(t, request.Messages[1].Content, "old source")
+	require.Equal(t, "latest source", request.Messages[4].Content)
+	require.Equal(t, "latest answer", request.Messages[5].Content)
+	require.Equal(t, "Summarize the conversation above.", request.Messages[6].Content)
+}
+
+func TestPrepareSummaryRequestFallsBackBeforeDroppingSourceRounds(t *testing.T) {
+	s := NewSummarizer(
+		&cacheSafeCaptureModel{},
+		WithPrompt("Conversation:\n{conversation_text}"),
+	).(*sessionSummarizer)
+	request := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable system"),
+		model.NewUserMessage(strings.Repeat("large source ", 400)),
+		model.NewAssistantMessage("latest progress"),
+		model.NewUserMessage("continue"),
+		model.NewUserMessage("Summarize the conversation above."),
+	}}
+	input := summaryPromptInput{
+		conversationText: "user: original request\nassistant: latest progress",
 	}
+
+	prepared, mode, err := s.prepareSummaryRequest(
+		context.Background(),
+		request,
+		callModeCacheSafeFork,
+		input,
+		200,
+	)
+	require.NoError(t, err)
+	require.Equal(t, callModeStandalone, mode)
+	require.Len(t, prepared.Messages, 1)
+	require.Contains(t, prepared.Messages[0].Content, "original request")
+	require.Contains(t, prepared.Messages[0].Content, "latest progress")
+	require.NotContains(t, prepared.Messages[0].Content, "continue")
 }
 
 // fakeModel is a minimal model that returns the conversation content back to simulate LLM.

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -626,13 +626,18 @@ func TestSessionSummarizer_CacheSafeForking(t *testing.T) {
 			inputBudget:   220,
 		}
 		s := NewSummarizer(capture, WithCacheSafeForking(true))
-		oversized := strings.Repeat("provider-budget-content ", 200)
+		oversizedParent := strings.Repeat("provider-budget-content ", 200)
 		parent := &model.Request{Messages: []model.Message{
 			model.NewSystemMessage("stable system"),
-			model.NewUserMessage(oversized),
+			model.NewUserMessage(oversizedParent),
 		}}
 		ctx := ContextWithCacheSafeForkRequest(context.Background(), parent)
-		sess := &session.Session{ID: "provider-budget", Events: []event.Event{newEventWithContent(oversized)}}
+		sess := &session.Session{
+			ID: "provider-budget",
+			Events: []event.Event{newEventWithContent(
+				strings.Repeat("provider event ", 20),
+			)},
+		}
 
 		text, err := s.Summarize(ctx, sess)
 		require.NoError(t, err)
@@ -672,9 +677,9 @@ func TestSessionSummarizer_CacheSafeForking(t *testing.T) {
 		require.Nil(t, capture.request)
 	})
 
-	t.Run("falls back to a bounded standalone request for oversized source content", func(t *testing.T) {
+	t.Run("rejects oversized standalone source without advancing boundary", func(t *testing.T) {
 		capture := &cacheSafeCaptureModel{
-			response:      "bounded standalone summary",
+			response:      "must not be called",
 			contextWindow: 1000,
 		}
 		s := NewSummarizer(capture, WithCacheSafeForking(true))
@@ -684,18 +689,20 @@ func TestSessionSummarizer_CacheSafeForking(t *testing.T) {
 			model.NewUserMessage(oversized),
 		}}
 		ctx := ContextWithCacheSafeForkRequest(context.Background(), parent)
-		sess := &session.Session{ID: "oversized-cache-safe", Events: []event.Event{newEventWithContent(oversized)}}
+		first := newEventWithContent(strings.Repeat("first event ", 500))
+		first.ID = "event-1"
+		second := newEventWithContent(strings.Repeat("second event ", 500))
+		second.ID = "event-2"
+		sess := &session.Session{
+			ID:     "oversized-cache-safe",
+			Events: []event.Event{first, second},
+		}
 
-		text, err := s.Summarize(ctx, sess)
-		require.NoError(t, err)
-		require.Equal(t, "bounded standalone summary", text)
-		require.NotNil(t, capture.request)
-		require.Len(t, capture.request.Messages, 1)
-		require.Contains(t, capture.request.Messages[0].Content, summaryConversationOmitted)
-		require.NotContains(t, capture.request.Messages[0].Content, "Summarize the user, assistant")
-		tokens, err := countSummaryRequestTokens(context.Background(), capture.request)
-		require.NoError(t, err)
-		require.LessOrEqual(t, tokens, 700)
+		_, err := s.Summarize(ctx, sess)
+		require.ErrorContains(t, err, "refusing to omit unsummarized conversation")
+		require.Nil(t, capture.request)
+		assert.NotContains(t, sess.State, lastIncludedTsKey)
+		assert.NotContains(t, sess.State, lastIncludedEventIDKey)
 	})
 }
 
@@ -760,9 +767,9 @@ func TestSessionSummarizer_RetriesCacheSafeFailureWithStandaloneSource(t *testin
 	}
 }
 
-func TestSessionSummarizer_BoundsOversizedStandaloneRequest(t *testing.T) {
+func TestSessionSummarizer_RejectsOversizedStandaloneRequest(t *testing.T) {
 	capture := &cacheSafeCaptureModel{
-		response:      "bounded standalone summary",
+		response:      "must not be called",
 		contextWindow: 1000,
 	}
 	s := NewSummarizer(
@@ -777,14 +784,11 @@ func TestSessionSummarizer_BoundsOversizedStandaloneRequest(t *testing.T) {
 		}}},
 	}}}
 
-	text, err := s.Summarize(context.Background(), sess)
-	require.NoError(t, err)
-	require.Equal(t, "bounded standalone summary", text)
-	require.NotNil(t, capture.request)
-	require.Contains(t, capture.request.Messages[0].Content, summaryConversationOmitted)
-	tokens, err := countSummaryRequestTokens(context.Background(), capture.request)
-	require.NoError(t, err)
-	require.LessOrEqual(t, tokens, 700)
+	_, err := s.Summarize(context.Background(), sess)
+	require.ErrorContains(t, err, "refusing to omit unsummarized conversation")
+	require.Nil(t, capture.request)
+	assert.NotContains(t, sess.State, lastIncludedTsKey)
+	assert.NotContains(t, sess.State, lastIncludedEventIDKey)
 }
 
 func TestSessionSummarizer_BoundsPreviousSummaryAndConversation(t *testing.T) {
@@ -797,7 +801,7 @@ func TestSessionSummarizer_BoundsPreviousSummaryAndConversation(t *testing.T) {
 		WithPrompt("Previous:\n{previous_summary}\n\nConversation:\n{conversation_text}\n\nSummary:"),
 	)
 	previous := strings.Repeat("large-previous-summary ", 1000)
-	conversation := strings.Repeat("large-conversation-event ", 1000)
+	conversation := "new conversation event"
 	sess := &session.Session{ID: "oversized-previous", Events: []event.Event{
 		{
 			Author:    authorSystem,
@@ -816,48 +820,24 @@ func TestSessionSummarizer_BoundsPreviousSummaryAndConversation(t *testing.T) {
 	require.NotNil(t, capture.request)
 	prompt := capture.request.Messages[0].Content
 	require.Contains(t, prompt, summaryPreviousOmitted)
-	require.Contains(t, prompt, summaryConversationOmitted)
+	require.Contains(t, prompt, conversation)
 	tokens, err := countSummaryRequestTokens(context.Background(), capture.request)
 	require.NoError(t, err)
 	require.LessOrEqual(t, tokens, 700)
 }
 
-func TestTruncateSummaryPromptInput(t *testing.T) {
-	input := summaryPromptInput{
-		conversationText: "conversation",
-		previousSummary:  "previous",
-	}
+func TestTruncatePreviousSummary(t *testing.T) {
+	previous := []rune("previous")
 
-	require.Equal(t, input, truncateSummaryPromptInput(input, 20))
-	require.Equal(t, summaryPromptInput{}, truncateSummaryPromptInput(input, 0))
-
-	conversationOnly := truncateSummaryPromptInput(summaryPromptInput{
-		conversationText: "conversation",
-	}, 4)
-	require.Empty(t, conversationOnly.previousSummary)
-	require.Contains(t, conversationOnly.conversationText,
-		summaryConversationOmitted)
-
-	previousOnly := truncateSummaryPromptInput(summaryPromptInput{
-		previousSummary: "previous",
-	}, 4)
-	require.Empty(t, previousOnly.conversationText)
-	require.Contains(t, previousOnly.previousSummary,
+	require.Equal(t, "previous", truncatePreviousSummary(previous, 8))
+	require.Empty(t, truncatePreviousSummary(previous, 0))
+	require.Contains(t, truncatePreviousSummary(previous, 4),
 		summaryPreviousOmitted)
-
-	oneRune := truncateSummaryPromptInput(input, 1)
-	require.Empty(t, oneRune.previousSummary)
-	require.Contains(t, oneRune.conversationText,
-		summaryConversationOmitted)
-
-	both := truncateSummaryPromptInput(input, 6)
-	require.Contains(t, both.previousSummary, summaryPreviousOmitted)
-	require.Contains(t, both.conversationText, summaryConversationOmitted)
 }
 
-func TestSessionSummarizer_BoundsOnlyStandaloneConversationContent(t *testing.T) {
+func TestSessionSummarizer_RejectsOversizedSourceWithFixedPrompt(t *testing.T) {
 	capture := &cacheSafeCaptureModel{
-		response:      "bounded standalone summary",
+		response:      "must not be called",
 		contextWindow: 1000,
 	}
 	s := NewSummarizer(
@@ -873,21 +853,11 @@ func TestSessionSummarizer_BoundsOnlyStandaloneConversationContent(t *testing.T)
 		Events: []event.Event{newEventWithContent(oversized)},
 	}
 
-	text, err := s.Summarize(context.Background(), sess)
-	require.NoError(t, err)
-	require.Equal(t, "bounded standalone summary", text)
-	require.NotNil(t, capture.request)
-	require.Len(t, capture.request.Messages, 1)
-	require.True(t, strings.HasPrefix(
-		capture.request.Messages[0].Content,
-		"fixed-prefix\n<conversation>\n",
-	))
-	require.True(t, strings.HasSuffix(
-		capture.request.Messages[0].Content,
-		"\n</conversation>\nfixed-suffix",
-	))
-	require.Contains(t, capture.request.Messages[0].Content,
-		summaryConversationOmitted)
+	_, err := s.Summarize(context.Background(), sess)
+	require.ErrorContains(t, err, "refusing to omit unsummarized conversation")
+	require.Nil(t, capture.request)
+	assert.NotContains(t, sess.State, lastIncludedTsKey)
+	assert.NotContains(t, sess.State, lastIncludedEventIDKey)
 }
 
 func TestSessionSummarizer_RetriesEmptyStandaloneSummary(t *testing.T) {


### PR DESCRIPTION
## What changed

Summary compaction now preserves every newly uncovered source event when a cache-safe fork exceeds its input budget. It first performs semantic tool-payload compaction and then falls back to a standalone request. If the complete unsummarized conversation still cannot fit, the attempt fails without invoking the model or advancing the summary boundary. Only an already generated previous summary may be bounded.

History projection now decides whether to restore a covered user anchor after foreign-event conversion and event-message projection. It restores an anchor only when the first retained model-facing message for that turn is an assistant or tool message, preventing projected-away tails from leaving an orphaned user request.

Legacy histories without a request ID use their non-empty invocation ID as the restoration key, while events with both identifiers keep the composite key.

## Why

The previous cache-safe fitting path could discard or truncate source conversation before invoking the summary model while still advancing the history cutoff across the complete event range. Separately, a cutoff inside a turn could retain assistant or tool output while removing the user message that gave it meaning.

These paths could produce a compacted main-agent request with missing context or replay an already summarized user request. The updated fitting and projection rules keep the summary boundary aligned with content actually seen by the model.

## Testing

- `go test ./session/summary ./internal/flow/processor`
- `go test ./...`
- `go build ./...`
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m` with a configuration-compatible v1 release
- `gofmt -r 'interface{} -> any' -l` on changed files
- `goimports -l` on changed files

## Compatibility

No exported symbols, serialization formats, persistence contracts, or protocol contracts change. Oversized standalone attempts now return an error rather than committing a summary boundary for omitted source conversation.