### PR TITLE
{internal, docs}: support runtime state placeholders for instruction

### DIFF
--- a/docs/mkdocs/en/agent.md
+++ b/docs/mkdocs/en/agent.md
@@ -96,19 +96,22 @@ llmAgent := llmagent.New(
 )
 ```
 
-### Placeholder Variables (Session State Injection)
+### Placeholder Variables (State Injection)
 
-LLMAgent automatically injects session state into `Instruction` and the optional `SystemPrompt` via placeholder variables. Supported patterns:
+LLMAgent automatically injects state into `Instruction` and the optional `SystemPrompt` via placeholder variables. Supported patterns:
 
 - `{key}`: Replaced with the string value corresponding to the key `key` in the session state (write via `invocation.Session.SetState("key", ...)` or SessionService)
 - `{key?}`: Optional; if missing, replaced with an empty string
 - `{user:subkey}` / `{app:subkey}` / `{temp:subkey}`: Use user/app/temp scoped keys (session services merge app/user state into session with these prefixes)
 - `{invocation:subkey}`: Replaces with the value of fmt.Sprintf("%+v", `invocation.state["subkey"]`). (The state can be set via invocation.SetState(k, v))
+- `{runtime:subkey}`: Reads request-scoped data from `RunOptions.RuntimeState` (set via `agent.WithRuntimeState` or `agent.MergeRuntimeState`)
 
 Notes:
 
 - If a non-optional key is not found, the original `{key}` is preserved (helps the LLM notice missing context)
-- Values are read from session state (Runner + SessionService set/merge this automatically)
+- Add `?` before the closing brace to make any supported placeholder optional, for example `{runtime:document?}`
+- Bare and app/user/temp-prefixed keys read session state; `invocation:` and `runtime:` read only their respective state stores and do not fall back to session state
+- Runtime strings are injected as plain text; primitive values use their JSON text representation, and objects and arrays are injected as JSON
 
 Example:
 
@@ -118,12 +121,17 @@ llm := llmagent.New(
   llmagent.WithModel(modelInstance),
   llmagent.WithInstruction(
     "You are a research assistant. Focus: {research_topics}. " +
-    "User interests: {user:topics?}. App banner: {app:banner?}.",
+    "User interests: {user:topics?}. App banner: {app:banner?}. " +
+    "Draft: {runtime:document?}.",
   ),
 )
 
 inv := agent.NewInvocation()
 inv.SetState("case", "case-1")
+
+runOptions := []agent.RunOption{
+  agent.WithRuntimeState(map[string]any{"document": "Current draft"}),
+}
 
 // Initialize session state (Runner + SessionService)
 _ = sessionService.UpdateUserState(ctx, session.UserKey{AppName: app, UserID: user}, session.StateMap{

--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -317,6 +317,8 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithRunOptio
 
 `StateResolver` converts `RunAgentInput.State` into RuntimeState for the current run. The returned map is passed to Runner as `agent.WithRuntimeState(...)` and only affects the current run.
 
+An LLMAgent can read a resolved value in its `Instruction` or `SystemPrompt` with a `{runtime:key}` placeholder. Use `{runtime:key?}` when the value is optional.
+
 Returning `nil` means RuntimeState is not set. Returning an empty map sets an empty RuntimeState.
 
 ```go

--- a/docs/mkdocs/zh/agent.md
+++ b/docs/mkdocs/zh/agent.md
@@ -80,19 +80,22 @@ llmAgent := llmagent.New(
 
 <a id="placeholder-variables-session-state-injection"></a>
 
-### 占位符变量（会话状态注入）
+### 占位符变量（状态注入）
 
-LLMAgent 会自动在 `Instruction` 和可选的 `SystemPrompt` 中注入会话状态。支持的占位符语法：
+LLMAgent 会自动在 `Instruction` 和可选的 `SystemPrompt` 中注入状态。支持的占位符语法：
 
 - `{key}`：替换为会话状态中键 `key` 对应的字符串值（可通过 `invocation.Session.SetState("key", ...)` 或 SessionService 写入）
 - `{key?}`：可选；如果不存在，替换为空字符串
 - `{user:subkey}` / `{app:subkey}` / `{temp:subkey}`：访问用户/应用/临时命名空间（SessionService 会把 app/user 作用域的状态合并进 session，并带上前缀）
 - `{invocation:subkey}` ：替换为 fmt.Sprintf("%+v",`invocation.state["subkey"]`) 的值，（可以通过 invocation.SetState(k,v) 来设置）。
+- `{runtime:subkey}`：读取 `RunOptions.RuntimeState` 中的请求级状态（通过 `agent.WithRuntimeState` 或 `agent.MergeRuntimeState` 设置）
 
 注意：
 
 - 对于非可选的 `{key}`，若找不到则保留原样（便于 LLM 感知缺失上下文）
-- 值读取自会话状态（Runner + SessionService 会自动设置/合并）
+- 所有受支持的占位符都可以在右花括号前添加 `?` 表示可选，例如 `{runtime:document?}`
+- 无前缀及 app/user/temp 前缀读取会话状态；`invocation:` 和 `runtime:` 只读取各自的状态，不会回退到会话状态
+- RuntimeState 中的字符串按原文注入，基本类型使用 JSON 文本表示，对象和数组以 JSON 注入
 
 示例：
 
@@ -103,12 +106,16 @@ llm := llmagent.New(
   llmagent.WithInstruction(
     "You are a research assistant. Focus: {research_topics}. " +
     "User interests: {user:topics?}. App banner: {app:banner?}." +
-    "Invocation case: {invocation:case}",
+    "Invocation case: {invocation:case}. Draft: {runtime:document?}",
   ),
 )
 
 inv := agent.NewInvocation()
 inv.SetState("case", "case-1")
+
+runOptions := []agent.RunOption{
+  agent.WithRuntimeState(map[string]any{"document": "Current draft"}),
+}
 
 // 通过 SessionService 初始化状态（用户态/应用态 + 会话本地键）
 _ = sessionService.UpdateUserState(ctx, session.UserKey{AppName: app, UserID: user}, session.StateMap{

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -317,6 +317,8 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithRunOptio
 
 `StateResolver` 用于把 `RunAgentInput.State` 转换为本次运行的 RuntimeState。返回的 map 会作为 `agent.WithRuntimeState(...)` 传入 Runner，只作用于当前这次运行。
 
+LLMAgent 可以在 `Instruction` 或 `SystemPrompt` 中通过 `{runtime:key}` 读取解析后的值；如果该值可选，则使用 `{runtime:key?}`。
+
 返回 `nil` 表示不设置 RuntimeState；返回空 map 表示设置一个空的 RuntimeState。
 
 ```go

--- a/internal/flow/processor/instruction.go
+++ b/internal/flow/processor/instruction.go
@@ -293,7 +293,7 @@ func (p *InstructionRequestProcessor) combineInstructions(
 	return jsonInstructions
 }
 
-// injectStateIntoContent injects session state into the given content.
+// injectStateIntoContent injects supported state into the given content.
 func (p *InstructionRequestProcessor) injectStateIntoContent(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/instruction_test.go
+++ b/internal/flow/processor/instruction_test.go
@@ -170,6 +170,37 @@ func TestInstructionProc_Request(t *testing.T) {
 	}
 }
 
+func TestInstructionProcessor_RuntimeStatePlaceholders(t *testing.T) {
+	invocation := &agent.Invocation{
+		AgentName:    testAgentName,
+		InvocationID: testInvocationID,
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			"document": "Current draft",
+			"version":  2,
+		}},
+	}
+	req := &model.Request{}
+	processor := NewInstructionRequestProcessor(
+		"Draft: {runtime:document}",
+		"Version: {runtime:version}",
+	)
+
+	processor.ProcessRequest(
+		context.Background(),
+		invocation,
+		req,
+		make(chan *event.Event, 1),
+	)
+
+	require.Len(t, req.Messages, 1)
+	require.Equal(t, model.RoleSystem, req.Messages[0].Role)
+	require.Equal(
+		t,
+		"Version: 2\n\nDraft: Current draft",
+		req.Messages[0].Content,
+	)
+}
+
 func TestFindSystemMessageIndex(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/prompt/adapter/state/render.go
+++ b/internal/prompt/adapter/state/render.go
@@ -23,6 +23,8 @@ import (
 const (
 	// Prefix for current invocation-scoped state variables from invocation.state
 	stateInvocationKey = "invocation:"
+	// Prefix for run-scoped state variables from RunOptions.RuntimeState.
+	stateRuntimeKey = "runtime:"
 )
 
 // Option configures [Render].
@@ -32,8 +34,9 @@ type renderConfig struct {
 	session *session.Session
 }
 
-// WithSession overrides the session used for non-invocation placeholders.
-// {invocation:*} placeholders continue to read from invocation state.
+// WithSession overrides the session used for session-backed placeholders.
+// {invocation:*} and {runtime:*} placeholders continue to read from the
+// invocation.
 func WithSession(sess *session.Session) Option {
 	return func(cfg *renderConfig) {
 		cfg.session = sess
@@ -41,7 +44,7 @@ func WithSession(sess *session.Session) Option {
 }
 
 // Render replaces supported placeholders in template with values from
-// invocation state and session state.
+// invocation state, runtime state, and session state.
 //
 // This adapter accepts the legacy state-injection subset of mixed-brace
 // placeholders:
@@ -49,9 +52,11 @@ func WithSession(sess *session.Session) Option {
 //   - {name?} or {{name?}} for optional identifiers
 //   - {app:key}, {user:key}, or {temp:key} for namespaced session state
 //   - {invocation:key} for invocation-scoped state
+//   - {runtime:key} for run-scoped state from RunOptions.RuntimeState
 //   - {artifact.filename} or {artifact.filename?} for artifact references
 //
-// {invocation:*} placeholders are resolved only from invocation state. Other
+// {invocation:*} placeholders are resolved only from invocation state, and
+// {runtime:*} placeholders only from invocation.RunOptions.RuntimeState. Other
 // supported placeholders are resolved from invocation.Session. Supported
 // optional placeholders collapse to an empty string when unresolved, while
 // unresolved non-optional placeholders remain literal. Placeholders outside
@@ -120,6 +125,18 @@ func (r stateResolver) Resolve(name string) (string, bool, error) {
 		}
 		return "", false, nil
 	}
+	if stateKey, ok := strings.CutPrefix(name, stateRuntimeKey); ok {
+		if r.invocation != nil && r.invocation.RunOptions.RuntimeState != nil {
+			if val, exists := r.invocation.RunOptions.RuntimeState[stateKey]; exists && val != nil {
+				rendered, err := renderRuntimeStateValue(val)
+				if err != nil {
+					return "", false, err
+				}
+				return rendered, true, nil
+			}
+		}
+		return "", false, nil
+	}
 
 	// Get the value from session state.
 	sessionToUse := r.session
@@ -164,6 +181,20 @@ func renderStateValue(raw []byte) string {
 	}
 }
 
+// renderRuntimeStateValue converts a runtime-state value to a stable prompt
+// representation. Strings are rendered without JSON quotes, objects and arrays
+// remain JSON, and raw byte slices retain the session-state rendering behavior.
+func renderRuntimeStateValue(value any) (string, error) {
+	if raw, ok := value.([]byte); ok {
+		return renderStateValue(raw), nil
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal runtime state value: %w", err)
+	}
+	return renderStateValue(raw), nil
+}
+
 // isValidStateName checks whether a placeholder name belongs to the legacy
 // state-injection subset.
 //
@@ -192,6 +223,7 @@ func isValidStateName(varName string) bool {
 			session.StateUserPrefix,
 			session.StateTempPrefix,
 			stateInvocationKey,
+			stateRuntimeKey,
 		}
 		for _, validPrefix := range validPrefixes {
 			if prefix == validPrefix {

--- a/internal/prompt/adapter/state/render.go
+++ b/internal/prompt/adapter/state/render.go
@@ -52,7 +52,7 @@ func WithSession(sess *session.Session) Option {
 //   - {name?} or {{name?}} for optional identifiers
 //   - {app:key}, {user:key}, or {temp:key} for namespaced session state
 //   - {invocation:key} for invocation-scoped state
-//   - {runtime:key} for run-scoped state from RunOptions.RuntimeState
+//   - {runtime:key} or {runtime:key?} for run-scoped state from RunOptions.RuntimeState
 //   - {artifact.filename} or {artifact.filename?} for artifact references
 //
 // {invocation:*} placeholders are resolved only from invocation state, and

--- a/internal/prompt/adapter/state/render_test.go
+++ b/internal/prompt/adapter/state/render_test.go
@@ -19,12 +19,13 @@ import (
 
 func TestRender(t *testing.T) {
 	tests := []struct {
-		name        string
-		template    string
-		state       map[string]any
-		expected    string
-		expectError bool
-		invState    map[string]any
+		name         string
+		template     string
+		state        map[string]any
+		expected     string
+		expectError  bool
+		invState     map[string]any
+		runtimeState map[string]any
 	}{
 		{
 			name:        "empty template",
@@ -145,6 +146,13 @@ func TestRender(t *testing.T) {
 			expected:    "Enabled: true, name: name-123",
 			expectError: false,
 		},
+		{
+			name:         "runtime values",
+			template:     "Document: {runtime:document}",
+			runtimeState: map[string]any{"document": "hello"},
+			expected:     "Document: hello",
+			expectError:  false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +176,7 @@ func TestRender(t *testing.T) {
 					invocation.SetState(k, v)
 				}
 			}
+			invocation.RunOptions.RuntimeState = tt.runtimeState
 
 			result, err := Render(tt.template, invocation)
 
@@ -211,6 +220,7 @@ func TestIsValidStateName(t *testing.T) {
 		{"app:setting", true},
 		{"temp:value", true},
 		{"invocation:key", true},
+		{"runtime:key", true},
 		{"invalid-name", false},
 		{"invalid name", false},
 		{"123invalid", false},
@@ -233,6 +243,66 @@ func TestIsValidStateName(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestRender_RuntimePlaceholders(t *testing.T) {
+	inv := &agent.Invocation{
+		Session: &session.Session{State: session.StateMap{
+			"document":         []byte(`"session document"`),
+			"runtime:document": []byte(`"session fallback"`),
+		}},
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			"document": "runtime document",
+			"count":    42,
+			"enabled":  true,
+			"metadata": map[string]any{"version": 1},
+			"items":    []string{"a", "b"},
+			"raw":      []byte(`{"nested":true}`),
+		}},
+	}
+
+	const template = "D={runtime:document}; C={runtime:count}; E={runtime:enabled}; " +
+		"M={runtime:metadata}; I={runtime:items}; R={runtime:raw}; " +
+		"O={runtime:missing?}; X={runtime:missing}"
+	const want = `D=runtime document; C=42; E=true; M={"version":1}; ` +
+		`I=["a","b"]; R={"nested":true}; O=; X={runtime:missing}`
+
+	got, err := Render(template, inv)
+	if err != nil {
+		t.Fatalf("Render runtime placeholders: unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Render runtime placeholders: got %q, want %q", got, want)
+	}
+}
+
+func TestRender_RuntimePlaceholderDoesNotFallbackToSession(t *testing.T) {
+	inv := &agent.Invocation{
+		Session: &session.Session{State: session.StateMap{
+			"runtime:document": []byte(`"session fallback"`),
+		}},
+	}
+
+	got, err := Render("{runtime:document}", inv)
+	if err != nil {
+		t.Fatalf("Render runtime fallback: unexpected error: %v", err)
+	}
+	if got != "{runtime:document}" {
+		t.Fatalf("Render runtime fallback: got %q", got)
+	}
+}
+
+func TestRender_RuntimePlaceholderMarshalError(t *testing.T) {
+	inv := &agent.Invocation{
+		RunOptions: agent.RunOptions{RuntimeState: map[string]any{
+			"invalid": make(chan struct{}),
+		}},
+	}
+
+	_, err := Render("{runtime:invalid}", inv)
+	if err == nil {
+		t.Fatal("Render runtime marshal error: expected error")
 	}
 }
 


### PR DESCRIPTION
## What changed

LLMAgent instructions and system prompts can now read request-scoped RuntimeState through `{runtime:key}` placeholders, including optional `{runtime:key?}` placeholders. Runtime strings are injected as plain text, primitive values use their JSON text representation, and objects and arrays remain JSON.

## Why

AG-UI's StateResolver maps frontend state to RuntimeState for the current run. Previously, LLMAgent prompt placeholders could only read session or invocation state, so integrations had to rebuild instructions per request or conflate transient frontend state with persisted session state.

The explicit `runtime:` namespace keeps state ownership visible and preserves all existing placeholder behavior.

Updates ag-ui-protocol/ag-ui#1224.

## Testing

- `go test ./internal/prompt/adapter/state ./internal/flow/processor`
- `go build ./...`
- `go test ./...` (the affected packages passed; the overall command is blocked in this restricted environment because unrelated existing tests require local TCP/Unix socket listeners or macOS `sandbox-exec`)
- `gofmt -l internal/prompt/adapter/state/render.go internal/prompt/adapter/state/render_test.go internal/flow/processor/instruction.go internal/flow/processor/instruction_test.go` (no output)

## Notes for reviewers

This adds no exported Go symbols. The new prompt syntax is explicit and opt-in: `runtime:` placeholders read only `RunOptions.RuntimeState` and never fall back to session state. Existing bare, namespaced session, and `invocation:` placeholders are unchanged.
