### PR TITLE
tool/dynamicworkflow: stabilize sandbox stderr test

### DIFF
--- a/tool/dynamicworkflow/sandbox_test.go
+++ b/tool/dynamicworkflow/sandbox_test.go
@@ -221,6 +221,10 @@ func TestSandboxRunnerKillsDescendantHoldingStderr(t *testing.T) {
 	require.NoError(t, os.WriteFile(
 		wrapper,
 		[]byte(`#!/bin/sh
+# Wait for the host's initial run message before exiting. Without this
+# handshake, the wrapper can close stdin before the host writes it and fail
+# with EPIPE before exercising descendant stderr cleanup.
+IFS= read -r request || exit 98
 /bin/sleep 30 &
 printf '{"type":"done","result":"done"}\n'
 exit 0


### PR DESCRIPTION
## What changed

Synchronize the sandbox stderr-cleanup test with the host workflow protocol before starting its long-lived descendant process.

## Why

The test wrapper exited without reading the initial workflow message from stdin. Depending on scheduling, the wrapper could close the pipe before the host wrote the message, causing an intermittent `broken pipe` failure before the test reached the process-group cleanup scenario.

The handshake keeps the existing test behavior intact: the descendant still holds stderr open, and the test still verifies that the sandbox terminates the process group promptly.

## Testing

- `go test ./tool/dynamicworkflow -run '^TestSandboxRunnerKillsDescendantHoldingStderr$' -count=20`
- `go test ./tool/dynamicworkflow`
- `git diff --check`

## Notes for reviewers

- Test-only change; no production runtime behavior is modified.
- The wrapper remains Unix-specific, and the test continues to skip on Windows.
- The change is limited to synchronizing the test wrapper with the existing stdin protocol.
