### PR TITLE
{session/summary, internal/flow}: align summaries with model-visible context

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -36,6 +36,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/responseusage"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcall"
@@ -528,6 +529,9 @@ func (f *Flow) maybeSyncSummaryIntraRun(
 			summaryCtx,
 			parentRequest,
 		)
+	}
+	if view, ok := summaryview.Snapshot(invocation); ok {
+		summaryCtx = summaryview.ContextWithView(summaryCtx, view)
 	}
 
 	err = invocation.SessionService.CreateSessionSummary(
@@ -1596,6 +1600,9 @@ func (f *Flow) maybeCompactContextBeforeLLM(
 		f.contextCompactionThresholdRatio,
 		rebuildPlan.contentProcessor.ContextCompactionConfig.TokenCounter,
 	)
+	if decision.err == nil {
+		summaryview.Finalize(invocation, req, decision.tokenCount)
+	}
 	if started {
 		span.SetAttributes(contextCompactionAttrs(decision, req)...)
 	}
@@ -1651,6 +1658,9 @@ func (f *Flow) runContextCompaction(
 		contextCompactionAttrs(decision, req)...,
 	)
 	summaryCtx = summary.ContextWithCacheSafeForkRequest(summaryCtx, req)
+	if view, ok := summaryview.Snapshot(invocation); ok {
+		summaryCtx = summaryview.ContextWithView(summaryCtx, view)
+	}
 	err := invocation.SessionService.CreateSessionSummary(
 		summaryCtx,
 		invocation.Session,
@@ -1717,6 +1727,23 @@ func (f *Flow) runContextCompaction(
 			invocation.AgentName,
 		)
 		return req
+	}
+	postDecision := syncCompactContextDecision(
+		rebuildCtx,
+		invocation,
+		rebuilt,
+		f.contextCompactionThresholdRatio,
+		rebuildPlan.contentProcessor.ContextCompactionConfig.TokenCounter,
+	)
+	if postDecision.err == nil {
+		summaryview.Finalize(invocation, rebuilt, postDecision.tokenCount)
+	} else {
+		log.DebugfContext(
+			ctx,
+			"Post-compaction request token count failed for agent %s: %v",
+			invocation.AgentName,
+			postDecision.err,
+		)
 	}
 
 	if err != nil {
@@ -2366,12 +2393,34 @@ func (f *Flow) callLLM(
 		)
 	}
 	ctx = contextWithModelRetryCallbacks(ctx, f, invocation, callModel)
+	finalizeSummaryView(ctx, invocation, llmRequest)
 	summaryfork.Attach(invocation, llmRequest)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
 	if err != nil {
 		return ctx, nil, true, err
 	}
 	return ctx, seq, true, nil
+}
+
+func finalizeSummaryView(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+) {
+	if invocation == nil || req == nil || len(req.Messages) == 0 {
+		return
+	}
+	tokens, err := model.NewSimpleTokenCounter().CountTokensRange(
+		ctx,
+		req.Messages,
+		0,
+		len(req.Messages),
+	)
+	if err != nil {
+		log.DebugfContext(ctx, "final model-visible request token count failed: %v", err)
+		return
+	}
+	summaryview.Finalize(invocation, req, tokens)
 }
 
 func (f *Flow) runBeforeModelCallbacks(

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -2393,7 +2393,12 @@ func (f *Flow) callLLM(
 		)
 	}
 	ctx = contextWithModelRetryCallbacks(ctx, f, invocation, callModel)
-	finalizeSummaryView(ctx, invocation, llmRequest)
+	finalizeSummaryView(
+		ctx,
+		invocation,
+		llmRequest,
+		f.summaryViewTokenCounter(),
+	)
 	summaryfork.Attach(invocation, llmRequest)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
 	if err != nil {
@@ -2406,11 +2411,15 @@ func finalizeSummaryView(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	req *model.Request,
+	counter model.TokenCounter,
 ) {
 	if invocation == nil || req == nil || len(req.Messages) == 0 {
 		return
 	}
-	tokens, err := model.NewSimpleTokenCounter().CountTokensRange(
+	if counter == nil {
+		counter = model.NewSimpleTokenCounter()
+	}
+	tokens, err := counter.CountTokensRange(
 		ctx,
 		req.Messages,
 		0,
@@ -2421,6 +2430,16 @@ func finalizeSummaryView(
 		return
 	}
 	summaryview.Finalize(invocation, req, tokens)
+}
+
+func (f *Flow) summaryViewTokenCounter() model.TokenCounter {
+	for i := len(f.requestProcessors) - 1; i >= 0; i-- {
+		contentProcessor, ok := f.requestProcessors[i].(*processor.ContentRequestProcessor)
+		if ok {
+			return contentProcessor.ContextCompactionConfig.TokenCounter
+		}
+	}
+	return nil
 }
 
 func (f *Flow) runBeforeModelCallbacks(

--- a/internal/flow/llmflow/summary_view_test.go
+++ b/internal/flow/llmflow/summary_view_test.go
@@ -80,14 +80,26 @@ func TestFinalizeSummaryViewUsesFinalRequest(t *testing.T) {
 
 func TestFinalizeSummaryViewHandlesUnavailableInputs(t *testing.T) {
 	counter := fixedSummaryViewTokenCounter{tokens: 42}
-	finalizeSummaryView(context.Background(), nil, &model.Request{}, counter)
-	finalizeSummaryView(context.Background(), agent.NewInvocation(), nil, counter)
+	require.NotPanics(t, func() {
+		finalizeSummaryView(context.Background(), nil, &model.Request{}, counter)
+	})
+
+	nilRequest := agent.NewInvocation()
+	finalizeSummaryView(context.Background(), nilRequest, nil, counter)
+	_, ok := summaryview.Snapshot(nilRequest)
+	require.False(t, ok)
+
+	missingProjection := agent.NewInvocation()
 	finalizeSummaryView(
 		context.Background(),
-		agent.NewInvocation(),
-		&model.Request{},
+		missingProjection,
+		&model.Request{Messages: []model.Message{
+			model.NewUserMessage("visible"),
+		}},
 		counter,
 	)
+	_, ok = summaryview.Snapshot(missingProjection)
+	require.False(t, ok)
 }
 
 func TestFinalizeSummaryViewLeavesProjectionOnCountFailure(t *testing.T) {

--- a/internal/flow/llmflow/summary_view_test.go
+++ b/internal/flow/llmflow/summary_view_test.go
@@ -11,6 +11,7 @@ package llmflow
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,13 +25,14 @@ import (
 
 type fixedSummaryViewTokenCounter struct {
 	tokens int
+	err    error
 }
 
 func (c fixedSummaryViewTokenCounter) CountTokens(
 	context.Context,
 	model.Message,
 ) (int, error) {
-	return c.tokens, nil
+	return c.tokens, c.err
 }
 
 func (c fixedSummaryViewTokenCounter) CountTokensRange(
@@ -39,7 +41,7 @@ func (c fixedSummaryViewTokenCounter) CountTokensRange(
 	int,
 	int,
 ) (int, error) {
-	return c.tokens, nil
+	return c.tokens, c.err
 }
 
 func TestFinalizeSummaryViewUsesFinalRequest(t *testing.T) {
@@ -74,4 +76,66 @@ func TestFinalizeSummaryViewUsesFinalRequest(t *testing.T) {
 	require.True(t, view.Bound)
 	require.Equal(t, 42, view.RequestTokens)
 	require.Equal(t, 1, view.Items[0].RequestIndex)
+}
+
+func TestFinalizeSummaryViewHandlesUnavailableInputs(t *testing.T) {
+	counter := fixedSummaryViewTokenCounter{tokens: 42}
+	finalizeSummaryView(context.Background(), nil, &model.Request{}, counter)
+	finalizeSummaryView(context.Background(), agent.NewInvocation(), nil, counter)
+	finalizeSummaryView(
+		context.Background(),
+		agent.NewInvocation(),
+		&model.Request{},
+		counter,
+	)
+}
+
+func TestFinalizeSummaryViewLeavesProjectionOnCountFailure(t *testing.T) {
+	invocation := agent.NewInvocation()
+	summaryview.AttachProjection(invocation, &summaryview.View{
+		ContentRequestLength: 1,
+		Items: []summaryview.Item{{
+			Message:      model.NewUserMessage("visible"),
+			RequestIndex: 0,
+		}},
+	})
+
+	finalizeSummaryView(
+		context.Background(),
+		invocation,
+		&model.Request{Messages: []model.Message{
+			model.NewUserMessage("visible"),
+		}},
+		fixedSummaryViewTokenCounter{err: errors.New("count failed")},
+	)
+
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	require.Zero(t, view.RequestTokens)
+}
+
+func TestFinalizeSummaryViewUsesDefaultCounter(t *testing.T) {
+	invocation := agent.NewInvocation()
+	summaryview.AttachProjection(invocation, &summaryview.View{
+		ContentRequestLength: 1,
+		Items: []summaryview.Item{{
+			Message:      model.NewUserMessage("visible"),
+			RequestIndex: 0,
+		}},
+	})
+
+	finalizeSummaryView(
+		context.Background(),
+		invocation,
+		&model.Request{Messages: []model.Message{
+			model.NewUserMessage("visible"),
+		}},
+		nil,
+	)
+
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Positive(t, view.RequestTokens)
 }

--- a/internal/flow/llmflow/summary_view_test.go
+++ b/internal/flow/llmflow/summary_view_test.go
@@ -1,0 +1,44 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package llmflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestFinalizeSummaryViewUsesFinalRequest(t *testing.T) {
+	invocation := agent.NewInvocation()
+	summaryview.AttachProjection(invocation, &summaryview.View{
+		ContentRequestLength: 1,
+		Items: []summaryview.Item{{
+			Message:      model.NewUserMessage("visible"),
+			RequestIndex: 0,
+		}},
+	})
+	request := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("added after content processing"),
+		model.NewUserMessage("visible"),
+	}}
+
+	finalizeSummaryView(context.Background(), invocation, request)
+
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Positive(t, view.RequestTokens)
+	require.Equal(t, 1, view.Items[0].RequestIndex)
+}

--- a/internal/flow/llmflow/summary_view_test.go
+++ b/internal/flow/llmflow/summary_view_test.go
@@ -16,9 +16,31 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	iflow "trpc.group/trpc-go/trpc-agent-go/internal/flow"
+	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
+
+type fixedSummaryViewTokenCounter struct {
+	tokens int
+}
+
+func (c fixedSummaryViewTokenCounter) CountTokens(
+	context.Context,
+	model.Message,
+) (int, error) {
+	return c.tokens, nil
+}
+
+func (c fixedSummaryViewTokenCounter) CountTokensRange(
+	context.Context,
+	[]model.Message,
+	int,
+	int,
+) (int, error) {
+	return c.tokens, nil
+}
 
 func TestFinalizeSummaryViewUsesFinalRequest(t *testing.T) {
 	invocation := agent.NewInvocation()
@@ -33,12 +55,23 @@ func TestFinalizeSummaryViewUsesFinalRequest(t *testing.T) {
 		model.NewSystemMessage("added after content processing"),
 		model.NewUserMessage("visible"),
 	}}
+	counter := fixedSummaryViewTokenCounter{tokens: 42}
+	flow := &Flow{requestProcessors: []iflow.RequestProcessor{
+		processor.NewContentRequestProcessor(
+			processor.WithContextCompactionTokenCounter(counter),
+		),
+	}}
 
-	finalizeSummaryView(context.Background(), invocation, request)
+	finalizeSummaryView(
+		context.Background(),
+		invocation,
+		request,
+		flow.summaryViewTokenCounter(),
+	)
 
 	view, ok := summaryview.Snapshot(invocation)
 	require.True(t, ok)
 	require.True(t, view.Bound)
-	require.Positive(t, view.RequestTokens)
+	require.Equal(t, 42, view.RequestTokens)
 	require.Equal(t, 1, view.Items[0].RequestIndex)
 }

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -29,6 +29,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
 	iflow "trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/messageorigin"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/toolresultround"
 	"trpc.group/trpc-go/trpc-agent-go/internal/util/message"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -236,6 +237,11 @@ type ContentRequestProcessor struct {
 
 type contentRequestRuntimeConfig struct {
 	includeMode string
+}
+
+type projectedHistory struct {
+	messages []model.Message
+	items    []summaryview.Item
 }
 
 // EventMessageProjector projects one event-derived message into the
@@ -662,6 +668,7 @@ func (p *ContentRequestProcessor) ProcessRequest(
 		return
 	}
 	invocation.DeleteState(contentHasCompactedToolResultsStateKey)
+	summaryview.Clear(invocation)
 
 	cfg := p.runtimeConfigFromInvocation(invocation)
 	skipHistory := cfg.includeMode == "none"
@@ -669,7 +676,7 @@ func (p *ContentRequestProcessor) ProcessRequest(
 	p.injectInjectedContextMessages(invocation, req)
 	p.injectFewShotMessages(invocation, req)
 	// Append per-filter messages from session events when allowed.
-	needToAddInvocationMessage := p.appendSessionMessages(
+	needToAddInvocationMessage, modelVisibleView := p.appendSessionMessages(
 		ctx,
 		invocation,
 		req,
@@ -694,6 +701,10 @@ func (p *ContentRequestProcessor) ProcessRequest(
 	}
 
 	p.injectLateContextMessages(invocation, req)
+	if modelVisibleView != nil {
+		modelVisibleView.ContentRequestLength = len(req.Messages)
+		summaryview.AttachProjection(invocation, modelVisibleView)
+	}
 
 	// Send a preprocessing event.
 	agent.EmitEvent(ctx, invocation, ch, event.New(
@@ -741,9 +752,9 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 	req *model.Request,
 	skipHistory bool,
 	includeInvocationMessage bool,
-) bool {
+) (bool, *summaryview.View) {
 	if invocation == nil || invocation.Session == nil {
-		return true
+		return true, nil
 	}
 
 	var userContextBlocks []string
@@ -768,13 +779,14 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 		userContextBlocks,
 	)
 
-	messages := p.sessionMessagesAfterCutoff(
+	history := p.sessionHistoryAfterCutoff(
 		invocation,
 		req,
 		skipHistory,
 		includeInvocationMessage,
 		summaryCutoff,
 	)
+	messages := history.messages
 
 	// When user-mode injection is active for summary or preload context, prepend
 	// it as user content near history. Prefer merging into the first user
@@ -790,8 +802,60 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 		)
 	}
 
+	messageStart := len(req.Messages)
 	req.Messages = append(req.Messages, messages...)
-	return len(messages) == 0
+	view := modelVisibleHistoryView(
+		invocation,
+		history,
+		messages,
+		messageStart,
+		summaryText,
+		p.SessionSummaryInjectionMode == SessionSummaryInjectionUser,
+	)
+	return len(messages) == 0, view
+}
+
+func modelVisibleHistoryView(
+	invocation *agent.Invocation,
+	history projectedHistory,
+	appended []model.Message,
+	messageStart int,
+	previousSummary string,
+	previousSummaryInItems bool,
+) *summaryview.View {
+	if invocation == nil || invocation.Session == nil || len(history.items) == 0 {
+		return nil
+	}
+	offset := len(appended) - len(history.items)
+	if offset < 0 || offset > 1 {
+		return nil
+	}
+	items := make([]summaryview.Item, len(history.items))
+	summaryMergedIntoItems := false
+	for i := range history.items {
+		messageIndex := i + offset
+		if messageIndex >= len(appended) {
+			return nil
+		}
+		items[i] = history.items[i]
+		if previousSummary != "" && previousSummaryInItems &&
+			items[i].Message.Content != appended[messageIndex].Content {
+			summaryMergedIntoItems = true
+		}
+		items[i].Message = appended[messageIndex]
+		items[i].RequestIndex = messageStart + messageIndex
+		items[i].EffectiveEvent = effectiveEventForMessage(
+			items[i].EffectiveEvent,
+			items[i].Message,
+		)
+	}
+	return &summaryview.View{
+		SessionID:              invocation.Session.ID,
+		FilterKey:              invocation.GetEventFilterKey(),
+		Items:                  items,
+		PreviousSummary:        previousSummary,
+		PreviousSummaryInItems: summaryMergedIntoItems,
+	}
 }
 
 func (p *ContentRequestProcessor) sessionSummaryForRequest(
@@ -874,24 +938,24 @@ func (p *ContentRequestProcessor) appendPreloadSessionRecallContext(
 	return userContextBlocks
 }
 
-func (p *ContentRequestProcessor) sessionMessagesAfterCutoff(
+func (p *ContentRequestProcessor) sessionHistoryAfterCutoff(
 	invocation *agent.Invocation,
 	req *model.Request,
 	skipHistory bool,
 	includeInvocationMessage bool,
 	summaryCutoff summaryHistoryCutoff,
-) []model.Message {
+) projectedHistory {
 	if skipHistory {
 		// When include_contents=none, only get events from current invocation to
 		// preserve tool call history within the current ReAct loop. This fixes
 		// the infinite loop issue where the agent doesn't see its own tool calls
 		// when running as an isolated subgraph.
 		if includeInvocationMessage {
-			return p.getCurrentInvocationMessages(invocation)
+			return p.getCurrentInvocationHistory(invocation)
 		}
-		return nil
+		return projectedHistory{}
 	}
-	messages := p.getIncrementMessagesAfterCutoff(
+	history := p.getIncrementHistoryAfterCutoff(
 		invocation,
 		req,
 		summaryCutoff,
@@ -899,7 +963,7 @@ func (p *ContentRequestProcessor) sessionMessagesAfterCutoff(
 	if p.hasCompactedCurrentInvocationToolResultsAfterCutoff(invocation, summaryCutoff) {
 		invocation.SetState(contentHasCompactedToolResultsStateKey, true)
 	}
-	return messages
+	return history
 }
 
 // injectSystemContextMessage injects summary or memory context into request.
@@ -1238,8 +1302,16 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 	req *model.Request,
 	cutoff summaryHistoryCutoff,
 ) []model.Message {
+	return p.getIncrementHistoryAfterCutoff(inv, req, cutoff).messages
+}
+
+func (p *ContentRequestProcessor) getIncrementHistoryAfterCutoff(
+	inv *agent.Invocation,
+	req *model.Request,
+	cutoff summaryHistoryCutoff,
+) projectedHistory {
 	if inv.Session == nil {
-		return nil
+		return projectedHistory{}
 	}
 	filter := inv.GetEventFilterKey()
 	var includedInvocationMessage bool
@@ -1327,7 +1399,7 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 			inv.AgentName,
 		)
 	}
-	messages := p.projectMessagesAcrossSummaryCutoff(
+	history := p.projectHistoryAcrossSummaryCutoff(
 		resultEvents,
 		sessionEvents,
 		inv,
@@ -1335,14 +1407,28 @@ func (p *ContentRequestProcessor) getIncrementMessagesAfterCutoff(
 		eventCutoff,
 	)
 
-	messages = p.mergeUserMessages(messages)
+	history = p.mergeProjectedUserMessages(history)
 
 	// Apply MaxHistoryRuns limit when AddSessionSummary is false.
 	if !p.AddSessionSummary && p.MaxHistoryRuns > 0 {
-		messages = applyMaxHistoryRuns(messages, p.MaxHistoryRuns)
+		trimmed := applyMaxHistoryRuns(history.messages, p.MaxHistoryRuns)
+		if len(history.items) == len(history.messages) &&
+			len(trimmed) <= len(history.items) {
+			history.items = history.items[len(history.items)-len(trimmed):]
+		}
+		history.messages = trimmed
 	}
-	messages = annotateUserMessagesWithAttachedFiles(messages)
-	return messages
+	history.messages = annotateUserMessagesWithAttachedFiles(history.messages)
+	for i := range history.items {
+		history.items[i].Message = annotateUserMessageWithAttachedFiles(
+			history.items[i].Message,
+		)
+		history.items[i].EffectiveEvent = effectiveEventForMessage(
+			history.items[i].EffectiveEvent,
+			history.items[i].Message,
+		)
+	}
+	return history
 }
 
 func sessionEventsSnapshot(sess *session.Session) []event.Event {
@@ -1451,13 +1537,13 @@ func (p *ContentRequestProcessor) canMatchToolRound(
 		p.passBranchFilter(evt, filter)
 }
 
-func (p *ContentRequestProcessor) projectMessagesAcrossSummaryCutoff(
+func (p *ContentRequestProcessor) projectHistoryAcrossSummaryCutoff(
 	retained []event.Event,
 	all []event.Event,
 	inv *agent.Invocation,
 	filter string,
 	cutoff eventHistoryCutoff,
-) []model.Message {
+) projectedHistory {
 	// Decide whether a turn needs its covered user anchor only after projection.
 	// A projector may remove or rewrite the retained assistant or tool message.
 	currentRequestID := inv.RunOptions.RequestID
@@ -1469,7 +1555,34 @@ func (p *ContentRequestProcessor) projectMessagesAcrossSummaryCutoff(
 		cutoff,
 	)
 
-	var messages []model.Message
+	eligibleBoundaries := make(map[string]summaryview.Boundary)
+	for i, evt := range all {
+		if evt.ID == "" || cutoff.excludesEvent(i, evt) {
+			continue
+		}
+		eligibleBoundaries[evt.ID] = summaryview.Boundary{
+			EventID:   evt.ID,
+			Timestamp: evt.Timestamp,
+		}
+	}
+
+	var history projectedHistory
+	appendEvent := func(evt event.Event, boundary summaryview.Boundary) {
+		for _, msg := range p.projectMessagesForEvent(
+			inv,
+			evt,
+			currentRequestID,
+			toolCallRequestIDs,
+		) {
+			effective := effectiveEventForMessage(evt, msg)
+			history.messages = append(history.messages, msg)
+			history.items = append(history.items, summaryview.Item{
+				Message:        msg,
+				EffectiveEvent: effective,
+				Boundary:       boundary,
+			})
+		}
+	}
 	seenTurns := make(map[historyTurnKey]struct{})
 	for _, evt := range retained {
 		projected := p.projectMessagesForEvent(
@@ -1488,20 +1601,95 @@ func (p *ContentRequestProcessor) projectMessagesAcrossSummaryCutoff(
 			role, _ := historyRoleForMessages(projected)
 			if userEvt, ok := coveredUsers[key]; ok &&
 				(role == model.RoleAssistant || role == model.RoleTool) {
-				messages = append(
-					messages,
-					p.projectMessagesForEvent(
-						inv,
-						userEvt,
-						currentRequestID,
-						toolCallRequestIDs,
-					)...,
-				)
+				appendEvent(userEvt, summaryview.Boundary{})
 			}
 		}
-		messages = append(messages, projected...)
+		boundary := eligibleBoundaries[evt.ID]
+		for _, msg := range projected {
+			effective := effectiveEventForMessage(evt, msg)
+			history.messages = append(history.messages, msg)
+			history.items = append(history.items, summaryview.Item{
+				Message:        msg,
+				EffectiveEvent: effective,
+				Boundary:       boundary,
+			})
+		}
 	}
-	return messages
+	return history
+}
+
+func effectiveEventForMessage(
+	evt event.Event,
+	msg model.Message,
+) event.Event {
+	effective := cloneEventForContentSnapshot(evt)
+	if effective.Response == nil {
+		effective.Response = &model.Response{}
+	}
+	effective.Response.Choices = []model.Choice{{Message: msg}}
+	return effective
+}
+
+func (p *ContentRequestProcessor) mergeProjectedUserMessages(
+	history projectedHistory,
+) projectedHistory {
+	if len(history.messages) <= 1 || !p.AddContextPrefix {
+		return history
+	}
+	if len(history.messages) != len(history.items) {
+		history.messages = p.mergeUserMessages(history.messages)
+		history.items = nil
+		return history
+	}
+
+	var merged projectedHistory
+	var current *summaryview.Item
+	appendCurrent := func() {
+		if current == nil {
+			return
+		}
+		current.EffectiveEvent = effectiveEventForMessage(
+			current.EffectiveEvent,
+			current.Message,
+		)
+		merged.messages = append(merged.messages, current.Message)
+		merged.items = append(merged.items, *current)
+		current = nil
+	}
+	for i := range history.items {
+		item := history.items[i]
+		msg := item.Message
+		if msg.Role != model.RoleUser ||
+			!strings.HasPrefix(msg.Content, contextPrefix) {
+			appendCurrent()
+			merged.messages = append(merged.messages, msg)
+			merged.items = append(merged.items, item)
+			continue
+		}
+		if current == nil {
+			cloned := item
+			current = &cloned
+			continue
+		}
+		if msg.Content != "" {
+			if current.Message.Content == "" {
+				current.Message.Content = msg.Content
+			} else {
+				current.Message.Content += mergedUserSeparator + msg.Content
+			}
+		}
+		if len(msg.ContentParts) > 0 {
+			current.Message.ContentParts = append(
+				current.Message.ContentParts,
+				msg.ContentParts...,
+			)
+		}
+		if !item.Boundary.IsZero() {
+			current.Boundary = item.Boundary
+		}
+	}
+	appendCurrent()
+	return merged
 }
 
 func (p *ContentRequestProcessor) coveredUserEventsBeforeCutoff(
@@ -2166,21 +2354,66 @@ func (p *ContentRequestProcessor) projectEventMessage(
 // This is used when include_contents=none to preserve tool call history within
 // the current ReAct loop while isolating from parent/other branch history.
 func (p *ContentRequestProcessor) getCurrentInvocationMessages(inv *agent.Invocation) []model.Message {
+	return p.getCurrentInvocationHistory(inv).messages
+}
+
+func (p *ContentRequestProcessor) getCurrentInvocationHistory(
+	inv *agent.Invocation,
+) projectedHistory {
 	if inv.Session == nil {
-		return nil
+		return projectedHistory{}
 	}
 
 	events := p.collectCurrentInvocationEvents(inv)
+	persistedBoundaries := make(map[string]summaryview.Boundary, len(events))
+	for _, evt := range events {
+		if evt.ID == "" {
+			continue
+		}
+		persistedBoundaries[evt.ID] = summaryview.Boundary{
+			EventID:   evt.ID,
+			Timestamp: evt.Timestamp,
+		}
+	}
 	if !containsInvocationMessage(events, inv.Message) &&
 		model.HasPayload(inv.Message) {
 		events = p.insertInvocationMessage(events, inv)
 	}
 
-	messages := p.projectCurrentInvocationMessages(inv, events)
-	messages = p.mergeUserMessages(messages)
-	messages = p.truncateOversizedToolResultMessages(messages)
-	messages = annotateUserMessagesWithAttachedFiles(messages)
-	return messages
+	resultEvents := p.rearrangeLatestFuncResp(events)
+	resultEvents = p.rearrangeAsyncFuncRespHist(resultEvents)
+	currentRequestID := inv.RunOptions.RequestID
+	toolCallRequestIDs := requestIDsWithToolCalls(resultEvents)
+	var history projectedHistory
+	for _, evt := range resultEvents {
+		for _, msg := range p.projectMessagesForEvent(
+			inv,
+			evt,
+			currentRequestID,
+			toolCallRequestIDs,
+		) {
+			history.messages = append(history.messages, msg)
+			history.items = append(history.items, summaryview.Item{
+				Message:        msg,
+				EffectiveEvent: effectiveEventForMessage(evt, msg),
+				Boundary:       persistedBoundaries[evt.ID],
+			})
+		}
+	}
+	history = p.mergeProjectedUserMessages(history)
+	for i := range history.items {
+		truncated := p.truncateOversizedToolResultMessages(
+			[]model.Message{history.items[i].Message},
+		)[0]
+		truncated = annotateUserMessageWithAttachedFiles(truncated)
+		history.items[i].Message = truncated
+		history.items[i].EffectiveEvent = effectiveEventForMessage(
+			history.items[i].EffectiveEvent,
+			truncated,
+		)
+		history.messages[i] = truncated
+	}
+	return history
 }
 
 func (p *ContentRequestProcessor) collectCurrentInvocationEvents(
@@ -2234,30 +2467,6 @@ func containsInvocationMessage(
 		}
 	}
 	return false
-}
-
-func (p *ContentRequestProcessor) projectCurrentInvocationMessages(
-	inv *agent.Invocation,
-	events []event.Event,
-) []model.Message {
-	resultEvents := p.rearrangeLatestFuncResp(events)
-	resultEvents = p.rearrangeAsyncFuncRespHist(resultEvents)
-
-	currentRequestID := inv.RunOptions.RequestID
-	toolCallRequestIDs := requestIDsWithToolCalls(resultEvents)
-	var messages []model.Message
-	for _, evt := range resultEvents {
-		messages = append(
-			messages,
-			p.projectMessagesForEvent(
-				inv,
-				evt,
-				currentRequestID,
-				toolCallRequestIDs,
-			)...,
-		)
-	}
-	return messages
 }
 
 func (p *ContentRequestProcessor) projectMessagesForEvent(

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -1411,12 +1411,14 @@ func (p *ContentRequestProcessor) getIncrementHistoryAfterCutoff(
 
 	// Apply MaxHistoryRuns limit when AddSessionSummary is false.
 	if !p.AddSessionSummary && p.MaxHistoryRuns > 0 {
-		trimmed := applyMaxHistoryRuns(history.messages, p.MaxHistoryRuns)
-		if len(history.items) == len(history.messages) &&
-			len(trimmed) <= len(history.items) {
-			history.items = history.items[len(history.items)-len(trimmed):]
+		startIdx := maxHistoryRunsStartIndex(
+			history.messages,
+			p.MaxHistoryRuns,
+		)
+		if len(history.items) == len(history.messages) {
+			history.items = history.items[startIdx:]
 		}
-		history.messages = trimmed
+		history.messages = history.messages[startIdx:]
 	}
 	history.messages = annotateUserMessagesWithAttachedFiles(history.messages)
 	for i := range history.items {
@@ -2266,20 +2268,21 @@ func fileNameFromArtifactRef(fileID string) string {
 	return base
 }
 
-// applyMaxHistoryRuns trims messages to at most maxRuns entries from the tail.
+// maxHistoryRunsStartIndex returns the first retained message when trimming to
+// at most maxRuns entries from the tail.
 // If the trim boundary falls on a tool-result message whose corresponding
 // tool_use was truncated, the boundary is advanced past any such orphaned
 // results to prevent API 400 "unexpected tool_use_id" errors.
-func applyMaxHistoryRuns(messages []model.Message, maxRuns int) []model.Message {
+func maxHistoryRunsStartIndex(messages []model.Message, maxRuns int) int {
 	if len(messages) <= maxRuns {
-		return messages
+		return 0
 	}
 	startIdx := len(messages) - maxRuns
 
 	// Only scan the truncated prefix when the boundary actually falls on a
 	// tool-result message; otherwise there's nothing to skip.
 	if messages[startIdx].Role != model.RoleTool || messages[startIdx].ToolID == "" {
-		return messages[startIdx:]
+		return startIdx
 	}
 
 	// Collect tool-call IDs that will be truncated (before startIdx).
@@ -2303,7 +2306,7 @@ func applyMaxHistoryRuns(messages []model.Message, maxRuns int) []model.Message 
 		break
 	}
 
-	return messages[startIdx:]
+	return startIdx
 }
 
 // processReasoningContent applies reasoning content stripping based on the
@@ -2401,6 +2404,15 @@ func (p *ContentRequestProcessor) getCurrentInvocationHistory(
 		}
 	}
 	history = p.mergeProjectedUserMessages(history)
+	if len(history.items) != len(history.messages) {
+		history.messages = p.truncateOversizedToolResultMessages(
+			history.messages,
+		)
+		history.messages = annotateUserMessagesWithAttachedFiles(
+			history.messages,
+		)
+		return history
+	}
 	for i := range history.items {
 		truncated := p.truncateOversizedToolResultMessages(
 			[]model.Message{history.items[i].Message},

--- a/internal/flow/processor/summary_view_test.go
+++ b/internal/flow/processor/summary_view_test.go
@@ -1,0 +1,187 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package processor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestContentRequestProcessorCapturesProjectedSummaryView(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{
+		ID: "session",
+		Events: []event.Event{
+			{
+				ID:        "event-1",
+				Author:    "user",
+				Timestamp: now,
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewUserMessage("goal"),
+				}}},
+			},
+			{
+				ID:        "event-2",
+				Author:    "assistant",
+				Timestamp: now.Add(time.Second),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{{
+							ID: "call-1",
+							Function: model.FunctionDefinitionParam{
+								Name: "lookup",
+							},
+						}},
+					},
+				}}},
+			},
+			{
+				ID:        "event-3",
+				Author:    "tool",
+				Timestamp: now.Add(2 * time.Second),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						"call-1",
+						"lookup",
+						"large raw result",
+					),
+				}}},
+			},
+		},
+	}
+	processor := NewContentRequestProcessor(
+		WithEventMessageProjector(func(
+			_ *agent.Invocation,
+			_ event.Event,
+			message model.Message,
+		) model.Message {
+			if message.ToolID != "" {
+				message.Content = "projected tool result"
+			}
+			return message
+		}),
+	)
+	invocation := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+	)
+	request := &model.Request{}
+
+	processor.ProcessRequest(
+		context.Background(),
+		invocation,
+		request,
+		nil,
+	)
+
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.Equal(t, sess.ID, view.SessionID)
+	require.Len(t, view.Items, 3)
+	require.Equal(t, "event-1", view.Items[0].Boundary.EventID)
+	require.Equal(t, "event-2", view.Items[1].Boundary.EventID)
+	require.Equal(t, "event-3", view.Items[2].Boundary.EventID)
+	require.Equal(t, "projected tool result", view.Items[2].Message.Content)
+	require.Equal(
+		t,
+		"projected tool result",
+		view.Items[2].EffectiveEvent.Response.Choices[0].Message.Content,
+	)
+	require.Equal(t, request.Messages, []model.Message{
+		view.Items[0].Message,
+		view.Items[1].Message,
+		view.Items[2].Message,
+	})
+}
+
+func TestContentRequestProcessorSummaryViewFollowsMaxHistoryRuns(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{ID: "session"}
+	for i, content := range []string{"old", "middle", "recent"} {
+		sess.Events = append(sess.Events, event.Event{
+			ID:        "event-" + content,
+			Author:    "user",
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage(content),
+			}}},
+		})
+	}
+	processor := NewContentRequestProcessor(
+		WithAddContextPrefix(false),
+		WithMaxHistoryRuns(2),
+	)
+	invocation := agent.NewInvocation(agent.WithInvocationSession(sess))
+	request := &model.Request{}
+
+	processor.ProcessRequest(context.Background(), invocation, request, nil)
+
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.Len(t, view.Items, 2)
+	require.Equal(t, "event-middle", view.Items[0].Boundary.EventID)
+	require.Equal(t, "event-recent", view.Items[1].Boundary.EventID)
+	require.Equal(t, "middle", view.Items[0].Message.Content)
+	require.Equal(t, "recent", view.Items[1].Message.Content)
+}
+
+func TestContentRequestProcessorSummaryViewSupportsIsolatedHistory(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{ID: "session"}
+	invocation := agent.NewInvocation(agent.WithInvocationSession(sess))
+	invocation.RunOptions.RuntimeState = map[string]any{
+		"include_contents": "none",
+	}
+	sess.Events = []event.Event{
+		{
+			ID:           "event-user",
+			InvocationID: invocation.InvocationID,
+			Author:       "user",
+			Timestamp:    now,
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("isolated goal"),
+			}}},
+		},
+		{
+			ID:           "event-answer",
+			InvocationID: invocation.InvocationID,
+			Author:       "assistant",
+			Timestamp:    now.Add(time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("isolated answer"),
+			}}},
+		},
+	}
+	request := &model.Request{}
+
+	NewContentRequestProcessor().ProcessRequest(
+		context.Background(),
+		invocation,
+		request,
+		nil,
+	)
+
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.Len(t, view.Items, 2)
+	require.Equal(t, "event-user", view.Items[0].Boundary.EventID)
+	require.Equal(t, "event-answer", view.Items[1].Boundary.EventID)
+	require.Equal(t, request.Messages[0], view.Items[0].Message)
+	require.Equal(t, request.Messages[1], view.Items[1].Message)
+}

--- a/internal/flow/processor/summary_view_test.go
+++ b/internal/flow/processor/summary_view_test.go
@@ -141,6 +141,60 @@ func TestContentRequestProcessorSummaryViewFollowsMaxHistoryRuns(t *testing.T) {
 	require.Equal(t, "recent", view.Items[1].Message.Content)
 }
 
+func TestContentRequestProcessorSummaryViewSkipsOrphanedToolResult(t *testing.T) {
+	now := time.Now()
+	sess := &session.Session{ID: "session", Events: []event.Event{
+		{
+			ID:        "event-call",
+			Author:    "assistant",
+			Timestamp: now,
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{{
+						ID: "call-1",
+						Function: model.FunctionDefinitionParam{
+							Name: "lookup",
+						},
+					}},
+				},
+			}}},
+		},
+		{
+			ID:        "event-result",
+			Author:    "tool",
+			Timestamp: now.Add(time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "lookup", "orphaned"),
+			}}},
+		},
+		{
+			ID:        "event-user",
+			Author:    "user",
+			Timestamp: now.Add(2 * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("retained"),
+			}}},
+		},
+	}}
+	processor := NewContentRequestProcessor(
+		WithAddContextPrefix(false),
+		WithMaxHistoryRuns(2),
+	)
+	invocation := agent.NewInvocation(agent.WithInvocationSession(sess))
+	request := &model.Request{}
+
+	processor.ProcessRequest(context.Background(), invocation, request, nil)
+
+	require.Len(t, request.Messages, 1)
+	require.Equal(t, "retained", request.Messages[0].Content)
+	view, ok := summaryview.Snapshot(invocation)
+	require.True(t, ok)
+	require.Len(t, view.Items, 1)
+	require.Equal(t, "event-user", view.Items[0].Boundary.EventID)
+	require.Equal(t, request.Messages[0], view.Items[0].Message)
+}
+
 func TestContentRequestProcessorSummaryViewSupportsIsolatedHistory(t *testing.T) {
 	now := time.Now()
 	sess := &session.Session{ID: "session"}

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -1,0 +1,345 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package summaryview stores the model-visible session history used by
+// request-driven session summarization.
+package summaryview
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const stateKey = "trpc_agent.summary.model_visible_view"
+
+type contextKey struct{}
+
+// Boundary identifies the latest stored event represented by an item.
+type Boundary struct {
+	EventID   string
+	Timestamp time.Time
+}
+
+// IsZero reports whether the boundary identifies no stored event.
+func (b Boundary) IsZero() bool {
+	return b.EventID == "" && b.Timestamp.IsZero()
+}
+
+// Item maps one model-visible history message to its stored-event boundary.
+type Item struct {
+	Message        model.Message
+	EffectiveEvent event.Event
+	Boundary       Boundary
+	RequestIndex   int
+}
+
+// View is a snapshot of the session-derived history in one model request.
+// It intentionally remains unchanged when model responses are appended after
+// the request, so asynchronous summary checks use only content the model has
+// actually seen.
+type View struct {
+	SessionID              string
+	FilterKey              string
+	Items                  []Item
+	PreviousSummary        string
+	PreviousSummaryInItems bool
+	RequestTokens          int
+	ContentRequestLength   int
+	Bound                  bool
+}
+
+// AttachProjection stores the content processor's pre-finalization projection.
+func AttachProjection(inv *agent.Invocation, view *View) {
+	if inv == nil || view == nil {
+		return
+	}
+	inv.SetState(stateKey, cloneView(view))
+}
+
+// Clear removes the current projection and finalized view.
+func Clear(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	inv.DeleteState(stateKey)
+}
+
+// Finalize binds projected history items to their positions in the final model
+// request and records the request token count. A view remains useful for token
+// checks and standalone summarization when binding is unavailable.
+func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
+	if inv == nil || req == nil {
+		return
+	}
+	view, ok := agent.GetStateValue[*View](inv, stateKey)
+	if !ok || view == nil {
+		return
+	}
+	next := cloneView(view)
+	next.RequestTokens = requestTokens
+	next.Bound = bindItems(next, req.Messages)
+	inv.SetState(stateKey, next)
+}
+
+// Snapshot returns an isolated copy of the latest model-visible view.
+func Snapshot(inv *agent.Invocation) (*View, bool) {
+	view, ok := agent.GetStateValue[*View](inv, stateKey)
+	if !ok || view == nil {
+		return nil, false
+	}
+	return cloneView(view), true
+}
+
+// ContextWithView attaches an isolated model-visible view to ctx.
+func ContextWithView(ctx context.Context, view *View) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if view == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKey{}, cloneView(view))
+}
+
+// FromContext returns an isolated model-visible view attached to ctx.
+func FromContext(ctx context.Context) (*View, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	view, ok := ctx.Value(contextKey{}).(*View)
+	if !ok || view == nil {
+		return nil, false
+	}
+	return cloneView(view), true
+}
+
+// Events returns the model-visible history as event-shaped callback input.
+func (v *View) Events() []event.Event {
+	if v == nil || len(v.Items) == 0 {
+		return nil
+	}
+	events := make([]event.Event, len(v.Items))
+	for i := range v.Items {
+		events[i] = cloneEvent(v.Items[i].EffectiveEvent)
+	}
+	return events
+}
+
+// PrefixBoundary returns the latest stored-event boundary in the first count
+// items. Context-only anchors covered by an older summary have zero boundaries
+// and are ignored.
+func (v *View) PrefixBoundary(count int) (Boundary, bool) {
+	if v == nil || count <= 0 {
+		return Boundary{}, false
+	}
+	if count > len(v.Items) {
+		count = len(v.Items)
+	}
+	indexes := make([]int, count)
+	for i := range indexes {
+		indexes[i] = i
+	}
+	return v.BoundaryForItems(indexes)
+}
+
+// BoundaryForItems returns the latest stored-event boundary represented by
+// the selected view item indexes.
+func (v *View) BoundaryForItems(indexes []int) (Boundary, bool) {
+	if v == nil {
+		return Boundary{}, false
+	}
+	for i := len(indexes) - 1; i >= 0; i-- {
+		index := indexes[i]
+		if index < 0 || index >= len(v.Items) {
+			return Boundary{}, false
+		}
+		if !v.Items[index].Boundary.IsZero() {
+			return v.Items[index].Boundary, true
+		}
+	}
+	return Boundary{}, false
+}
+
+// PrefixMessages returns the parent request prefix containing fixed messages
+// followed by exactly the first count model-visible history items. It returns
+// false when the projection could not be bound safely to the parent request.
+func (v *View) PrefixMessages(parent []model.Message, count int) ([]model.Message, bool) {
+	if v == nil || !v.Bound || count <= 0 || count > len(v.Items) {
+		return nil, false
+	}
+	indexes := make([]int, count)
+	for i := range indexes {
+		indexes[i] = i
+	}
+	return v.MessagesForItems(parent, indexes)
+}
+
+// MessagesForItems returns the fixed request prefix followed by the selected
+// model-visible history items in their original order.
+func (v *View) MessagesForItems(
+	parent []model.Message,
+	indexes []int,
+) ([]model.Message, bool) {
+	if v == nil || !v.Bound || len(v.Items) == 0 || len(indexes) == 0 {
+		return nil, false
+	}
+	first := v.Items[0].RequestIndex
+	if first < 0 || first > len(parent) {
+		return nil, false
+	}
+	messages := make([]model.Message, 0, first+len(indexes))
+	messages = append(messages, parent[:first]...)
+	previous := first - 1
+	previousItem := -1
+	for _, itemIndex := range indexes {
+		if itemIndex <= previousItem || itemIndex < 0 || itemIndex >= len(v.Items) {
+			return nil, false
+		}
+		index := v.Items[itemIndex].RequestIndex
+		if index <= previous || index < first || index >= len(parent) {
+			return nil, false
+		}
+		messages = append(messages, parent[index])
+		previous = index
+		previousItem = itemIndex
+	}
+	return messages, true
+}
+
+func bindItems(view *View, messages []model.Message) bool {
+	if view == nil || len(view.Items) == 0 || len(messages) == 0 {
+		return false
+	}
+	shift := len(messages) - view.ContentRequestLength
+	previous := -1
+	for i := range view.Items {
+		item := &view.Items[i]
+		index := findItem(messages, item.Message, item.RequestIndex, shift, previous+1)
+		if index < 0 {
+			return false
+		}
+		item.RequestIndex = index
+		item.Message = cloneMessage(messages[index])
+		setEffectiveMessage(&item.EffectiveEvent, item.Message)
+		previous = index
+	}
+	return true
+}
+
+func findItem(
+	messages []model.Message,
+	want model.Message,
+	original int,
+	shift int,
+	start int,
+) int {
+	for _, candidate := range []int{original + shift, original} {
+		if candidate >= start && candidate < len(messages) &&
+			messageIdentityMatches(messages[candidate], want) {
+			return candidate
+		}
+	}
+	for i := start; i < len(messages); i++ {
+		if messageIdentityMatches(messages[i], want) {
+			return i
+		}
+	}
+	return -1
+}
+
+func messageIdentityMatches(got, want model.Message) bool {
+	if reflect.DeepEqual(got, want) {
+		return true
+	}
+	if got.Role != want.Role {
+		return false
+	}
+	if want.ToolID != "" || got.ToolID != "" {
+		return want.ToolID != "" && got.ToolID == want.ToolID
+	}
+	wantIDs := toolCallIDs(want.ToolCalls)
+	gotIDs := toolCallIDs(got.ToolCalls)
+	if len(wantIDs) > 0 || len(gotIDs) > 0 {
+		return reflect.DeepEqual(gotIDs, wantIDs)
+	}
+	return got.Content == want.Content &&
+		got.ReasoningContent == want.ReasoningContent &&
+		reflect.DeepEqual(got.ContentParts, want.ContentParts)
+}
+
+func toolCallIDs(calls []model.ToolCall) []string {
+	if len(calls) == 0 {
+		return nil
+	}
+	ids := make([]string, len(calls))
+	for i := range calls {
+		ids[i] = calls[i].ID
+	}
+	return ids
+}
+
+func cloneView(view *View) *View {
+	if view == nil {
+		return nil
+	}
+	cloned := *view
+	cloned.Items = make([]Item, len(view.Items))
+	for i := range view.Items {
+		cloned.Items[i] = view.Items[i]
+		cloned.Items[i].Message = cloneMessage(view.Items[i].Message)
+		cloned.Items[i].EffectiveEvent = cloneEvent(view.Items[i].EffectiveEvent)
+	}
+	return &cloned
+}
+
+func cloneEvent(evt event.Event) event.Event {
+	cloned := evt
+	if evt.Response != nil {
+		cloned.Response = evt.Response.Clone()
+	}
+	if evt.LongRunningToolIDs != nil {
+		cloned.LongRunningToolIDs = make(map[string]struct{}, len(evt.LongRunningToolIDs))
+		for id := range evt.LongRunningToolIDs {
+			cloned.LongRunningToolIDs[id] = struct{}{}
+		}
+	}
+	if evt.StateDelta != nil {
+		cloned.StateDelta = make(map[string][]byte, len(evt.StateDelta))
+		for key, value := range evt.StateDelta {
+			cloned.StateDelta[key] = append([]byte(nil), value...)
+		}
+	}
+	if evt.Actions != nil {
+		actions := *evt.Actions
+		cloned.Actions = &actions
+	}
+	return cloned
+}
+
+func cloneMessage(message model.Message) model.Message {
+	response := (&model.Response{Choices: []model.Choice{{Message: message}}}).Clone()
+	return response.Choices[0].Message
+}
+
+func setEffectiveMessage(evt *event.Event, message model.Message) {
+	if evt == nil {
+		return
+	}
+	if evt.Response == nil {
+		evt.Response = &model.Response{}
+	} else {
+		evt.Response = evt.Response.Clone()
+	}
+	evt.Response.Choices = []model.Choice{{Message: cloneMessage(message)}}
+}

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -77,8 +77,9 @@ func Clear(inv *agent.Invocation) {
 }
 
 // Finalize binds projected history items to their positions in the final model
-// request and records the request token count. A view remains useful for token
-// checks and standalone summarization when binding is unavailable.
+// request and records the request token count. RequestTokens remains useful
+// when binding is unavailable, but unbound items must not be treated as content
+// proven to be visible to the model.
 func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 	if inv == nil || req == nil {
 		return

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -13,6 +13,7 @@ package summaryview
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"time"
 
@@ -323,6 +324,12 @@ func cloneEvent(evt event.Event) event.Event {
 	if evt.Actions != nil {
 		actions := *evt.Actions
 		cloned.Actions = &actions
+	}
+	if evt.Extensions != nil {
+		cloned.Extensions = make(map[string]json.RawMessage, len(evt.Extensions))
+		for key, value := range evt.Extensions {
+			cloned.Extensions[key] = append(json.RawMessage(nil), value...)
+		}
 	}
 	return cloned
 }

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -249,3 +249,111 @@ func TestFinalizeLeavesUnmatchedProjectionUnbound(t *testing.T) {
 	Finalize(nil, &model.Request{}, 1)
 	Finalize(invocation, nil, 1)
 }
+
+func TestViewBoundaryAndBindingEdgeCases(t *testing.T) {
+	view := &View{Items: []Item{{Boundary: Boundary{}}}}
+	_, ok := view.PrefixBoundary(2)
+	require.False(t, ok)
+
+	parent := []model.Message{model.NewUserMessage("visible")}
+	invalidFirst := &View{
+		Bound: true,
+		Items: []Item{{
+			RequestIndex: -1,
+		}},
+	}
+	_, ok = invalidFirst.MessagesForItems(parent, []int{0})
+	require.False(t, ok)
+	invalidFirst.Items[0].RequestIndex = len(parent) + 1
+	_, ok = invalidFirst.MessagesForItems(parent, []int{0})
+	require.False(t, ok)
+
+	invalidItem := &View{
+		Bound: true,
+		Items: []Item{
+			{RequestIndex: 0},
+			{RequestIndex: len(parent)},
+		},
+	}
+	_, ok = invalidItem.MessagesForItems(parent, []int{1})
+	require.False(t, ok)
+
+	require.False(t, bindItems(nil, parent))
+	require.False(t, bindItems(&View{}, parent))
+	require.False(t, bindItems(view, nil))
+
+	messages := []model.Message{
+		model.NewUserMessage("different"),
+		model.NewUserMessage("visible"),
+	}
+	require.Equal(t, 1, findItem(
+		messages,
+		model.NewUserMessage("visible"),
+		0,
+		0,
+		0,
+	))
+	require.Equal(t, -1, findItem(
+		messages,
+		model.NewAssistantMessage("missing"),
+		0,
+		0,
+		0,
+	))
+
+	require.Nil(t, cloneView(nil))
+	setEffectiveMessage(nil, model.NewUserMessage("ignored"))
+	effective := event.Event{Response: &model.Response{
+		Choices: []model.Choice{{Message: model.NewAssistantMessage("old")}},
+	}}
+	setEffectiveMessage(&effective, model.NewAssistantMessage("new"))
+	require.Equal(
+		t,
+		"new",
+		effective.Response.Choices[0].Message.Content,
+	)
+}
+
+func TestMessageIdentityMatchesStableFields(t *testing.T) {
+	require.False(t, messageIdentityMatches(
+		model.NewAssistantMessage("same"),
+		model.NewUserMessage("same"),
+	))
+	require.True(t, messageIdentityMatches(
+		model.NewToolMessage("call", "renamed", "new payload"),
+		model.NewToolMessage("call", "lookup", "old payload"),
+	))
+	require.False(t, messageIdentityMatches(
+		model.NewToolMessage("other", "lookup", "payload"),
+		model.NewToolMessage("call", "lookup", "payload"),
+	))
+
+	wantToolCalls := model.NewAssistantMessage("old")
+	wantToolCalls.ToolCalls = []model.ToolCall{{ID: "call"}}
+	gotToolCalls := model.NewAssistantMessage("new")
+	gotToolCalls.ToolCalls = []model.ToolCall{{
+		ID: "call",
+		Function: model.FunctionDefinitionParam{
+			Name:      "lookup",
+			Arguments: []byte(`{"query":"new"}`),
+		},
+	}}
+	require.True(t, messageIdentityMatches(gotToolCalls, wantToolCalls))
+	gotToolCalls.ToolCalls[0].ID = "other"
+	require.False(t, messageIdentityMatches(gotToolCalls, wantToolCalls))
+
+	wantContent := model.NewUserMessage("same")
+	wantContent.ReasoningContent = "reasoning"
+	gotContent := wantContent
+	gotContent.ReasoningSignature = "provider-specific-signature"
+	require.True(t, messageIdentityMatches(gotContent, wantContent))
+	gotContent.Content = "different"
+	require.False(t, messageIdentityMatches(gotContent, wantContent))
+
+	require.Nil(t, toolCallIDs(nil))
+	require.Equal(
+		t,
+		[]string{"first", "second"},
+		toolCallIDs([]model.ToolCall{{ID: "first"}, {ID: "second"}}),
+	)
+}

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -11,6 +11,7 @@ package summaryview
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -200,7 +201,10 @@ func TestSnapshotClonesEffectiveEventMetadata(t *testing.T) {
 			}}},
 			LongRunningToolIDs: map[string]struct{}{"call": {}},
 			StateDelta:         map[string][]byte{"key": []byte("value")},
-			Actions:            &event.EventActions{SkipSummarization: true},
+			Extensions: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`{"value":"original"}`),
+			},
+			Actions: &event.EventActions{SkipSummarization: true},
 		},
 	}}})
 
@@ -208,12 +212,18 @@ func TestSnapshotClonesEffectiveEventMetadata(t *testing.T) {
 	require.True(t, ok)
 	first.Items[0].EffectiveEvent.LongRunningToolIDs["other"] = struct{}{}
 	first.Items[0].EffectiveEvent.StateDelta["key"][0] = 'x'
+	first.Items[0].EffectiveEvent.Extensions["metadata"][10] = 'x'
 	first.Items[0].EffectiveEvent.Actions.SkipSummarization = false
 
 	second, ok := Snapshot(invocation)
 	require.True(t, ok)
 	require.NotContains(t, second.Items[0].EffectiveEvent.LongRunningToolIDs, "other")
 	require.Equal(t, "value", string(second.Items[0].EffectiveEvent.StateDelta["key"]))
+	require.JSONEq(
+		t,
+		`{"value":"original"}`,
+		string(second.Items[0].EffectiveEvent.Extensions["metadata"]),
+	)
 	require.True(t, second.Items[0].EffectiveEvent.Actions.SkipSummarization)
 	require.Len(t, second.Events(), 1)
 }

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -1,0 +1,241 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summaryview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestFinalizeBindsModelVisiblePrefix(t *testing.T) {
+	timestamp := time.Now()
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		SessionID:            "session",
+		ContentRequestLength: 3,
+		Items: []Item{
+			{
+				Message:      model.NewUserMessage("old"),
+				Boundary:     Boundary{EventID: "event-1", Timestamp: timestamp},
+				RequestIndex: 1,
+			},
+			{
+				Message:      model.NewAssistantMessage("answer"),
+				Boundary:     Boundary{EventID: "event-2", Timestamp: timestamp.Add(time.Second)},
+				RequestIndex: 2,
+			},
+		},
+	})
+	request := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("inserted"),
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("old"),
+		model.NewAssistantMessage("answer"),
+	}}
+
+	Finalize(invocation, request, 41_959)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, 41_959, view.RequestTokens)
+	require.Equal(t, 2, view.Items[0].RequestIndex)
+	require.Equal(t, 3, view.Items[1].RequestIndex)
+
+	prefix, ok := view.PrefixMessages(request.Messages, 1)
+	require.True(t, ok)
+	require.Equal(t, request.Messages[:3], prefix)
+	boundary, ok := view.PrefixBoundary(1)
+	require.True(t, ok)
+	require.Equal(t, "event-1", boundary.EventID)
+
+}
+
+func TestSnapshotIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		Items: []Item{{
+			Message: model.NewUserMessage("visible"),
+			EffectiveEvent: event.Event{
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewUserMessage("visible"),
+				}}},
+			},
+		}},
+	})
+
+	first, ok := Snapshot(invocation)
+	require.True(t, ok)
+	first.Items[0].Message.Content = "mutated"
+	first.Items[0].EffectiveEvent.Response.Choices[0].Message.Content = "mutated"
+
+	second, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.Equal(t, "visible", second.Items[0].Message.Content)
+	require.Equal(
+		t,
+		"visible",
+		second.Items[0].EffectiveEvent.Response.Choices[0].Message.Content,
+	)
+}
+
+func TestContextAndInvocationLifecycle(t *testing.T) {
+	invocation := agent.NewInvocation()
+	_, ok := Snapshot(invocation)
+	require.False(t, ok)
+	Finalize(invocation, &model.Request{}, 1)
+	Clear(nil)
+	AttachProjection(nil, &View{})
+	AttachProjection(invocation, nil)
+
+	view := &View{
+		SessionID: "session",
+		Items: []Item{{
+			Message: model.NewUserMessage("visible"),
+		}},
+	}
+	AttachProjection(invocation, view)
+	view.Items[0].Message.Content = "mutated source"
+	stored, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.Equal(t, "visible", stored.Items[0].Message.Content)
+
+	ctx := ContextWithView(nil, stored)
+	fromContext, ok := FromContext(ctx)
+	require.True(t, ok)
+	fromContext.Items[0].Message.Content = "mutated context copy"
+	again, ok := FromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "visible", again.Items[0].Message.Content)
+	require.Same(t, ctx, ContextWithView(ctx, nil))
+	_, ok = FromContext(nil)
+	require.False(t, ok)
+	_, ok = FromContext(context.Background())
+	require.False(t, ok)
+
+	Clear(invocation)
+	_, ok = Snapshot(invocation)
+	require.False(t, ok)
+}
+
+func TestViewSelectsNonContiguousItems(t *testing.T) {
+	now := time.Now()
+	view := &View{
+		Bound: true,
+		Items: []Item{
+			{
+				RequestIndex: 1,
+				Boundary:     Boundary{EventID: "first", Timestamp: now},
+			},
+			{
+				RequestIndex: 2,
+				Boundary:     Boundary{},
+			},
+			{
+				RequestIndex: 3,
+				Boundary: Boundary{
+					EventID:   "third",
+					Timestamp: now.Add(time.Second),
+				},
+			},
+		},
+	}
+	parent := []model.Message{
+		model.NewSystemMessage("fixed"),
+		model.NewUserMessage("first"),
+		model.NewAssistantMessage("excluded"),
+		model.NewUserMessage("third"),
+	}
+
+	messages, ok := view.MessagesForItems(parent, []int{0, 2})
+	require.True(t, ok)
+	require.Equal(t, []model.Message{parent[0], parent[1], parent[3]}, messages)
+	boundary, ok := view.BoundaryForItems([]int{0, 1, 2})
+	require.True(t, ok)
+	require.Equal(t, "third", boundary.EventID)
+	boundary, ok = view.BoundaryForItems([]int{0, 1})
+	require.True(t, ok)
+	require.Equal(t, "first", boundary.EventID)
+
+	_, ok = view.MessagesForItems(parent, nil)
+	require.False(t, ok)
+	_, ok = view.MessagesForItems(parent, []int{2, 1})
+	require.False(t, ok)
+	_, ok = view.MessagesForItems(parent, []int{3})
+	require.False(t, ok)
+	_, ok = (&View{}).MessagesForItems(parent, []int{0})
+	require.False(t, ok)
+	_, ok = view.BoundaryForItems([]int{3})
+	require.False(t, ok)
+	_, ok = (*View)(nil).BoundaryForItems([]int{0})
+	require.False(t, ok)
+	_, ok = view.PrefixMessages(parent, 0)
+	require.False(t, ok)
+	_, ok = view.PrefixMessages(parent, 4)
+	require.False(t, ok)
+	_, ok = view.PrefixBoundary(0)
+	require.False(t, ok)
+	require.Nil(t, (*View)(nil).Events())
+}
+
+func TestSnapshotClonesEffectiveEventMetadata(t *testing.T) {
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{Items: []Item{{
+		EffectiveEvent: event.Event{
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("answer"),
+			}}},
+			LongRunningToolIDs: map[string]struct{}{"call": {}},
+			StateDelta:         map[string][]byte{"key": []byte("value")},
+			Actions:            &event.EventActions{SkipSummarization: true},
+		},
+	}}})
+
+	first, ok := Snapshot(invocation)
+	require.True(t, ok)
+	first.Items[0].EffectiveEvent.LongRunningToolIDs["other"] = struct{}{}
+	first.Items[0].EffectiveEvent.StateDelta["key"][0] = 'x'
+	first.Items[0].EffectiveEvent.Actions.SkipSummarization = false
+
+	second, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.NotContains(t, second.Items[0].EffectiveEvent.LongRunningToolIDs, "other")
+	require.Equal(t, "value", string(second.Items[0].EffectiveEvent.StateDelta["key"]))
+	require.True(t, second.Items[0].EffectiveEvent.Actions.SkipSummarization)
+	require.Len(t, second.Events(), 1)
+}
+
+func TestFinalizeLeavesUnmatchedProjectionUnbound(t *testing.T) {
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: 1,
+		Items: []Item{{
+			Message:      model.NewUserMessage("expected"),
+			RequestIndex: 0,
+		}},
+	})
+
+	Finalize(invocation, &model.Request{Messages: []model.Message{
+		model.NewAssistantMessage("different"),
+	}}, 10)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	require.Equal(t, 10, view.RequestTokens)
+
+	Finalize(nil, &model.Request{}, 1)
+	Finalize(invocation, nil, 1)
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -41,6 +41,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/sessionroute"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/toolresultround"
 	"trpc.group/trpc-go/trpc-agent-go/internal/summarytrigger"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -2597,7 +2598,6 @@ func (r *runner) handleEventPersistence(
 		return false
 	}
 	finishRunnerLatencySpan(appendSpan, appendStarted, nil)
-
 	if shouldAppendSummaryForkResponse(agentEvent) {
 		summaryfork.AppendResponse(invocation, agentEvent.Response)
 	}
@@ -2648,6 +2648,9 @@ func (r *runner) handleEventPersistence(
 			summaryCtx,
 			parentRequest,
 		)
+	}
+	if view, ok := summaryview.Snapshot(invocation); ok {
+		summaryCtx = summaryview.ContextWithView(summaryCtx, view)
 	}
 	if err := r.sessionService.EnqueueSummaryJob(
 		summaryCtx, persistSession, agentEvent.FilterKey, false,

--- a/runner/runner_summary_test.go
+++ b/runner/runner_summary_test.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/summaryrestore"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/toolresultround"
 	"trpc.group/trpc-go/trpc-agent-go/internal/summarytrigger"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -27,6 +28,42 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session/summary"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+func TestRunnerEnqueuesModelVisibleSummaryView(t *testing.T) {
+	service := &mockSessionService{}
+	r := NewRunner(
+		"test-app",
+		&mockAgent{name: "test-agent"},
+		WithSessionService(service),
+	).(*runner)
+	sess := &session.Session{ID: "session"}
+	invocation := agent.NewInvocation(agent.WithInvocationSession(sess))
+	summaryview.AttachProjection(invocation, &summaryview.View{
+		SessionID:     sess.ID,
+		RequestTokens: 13_310,
+	})
+	evt := &event.Event{
+		Author: "assistant",
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("answer"),
+			}},
+		},
+	}
+
+	require.True(t, r.handleEventPersistence(
+		context.Background(),
+		invocation,
+		sess,
+		sess,
+		evt,
+	))
+	require.Len(t, service.enqueueSummaryJobCalls, 1)
+	view, ok := summaryview.FromContext(service.enqueueSummaryJobCalls[0].ctx)
+	require.True(t, ok)
+	require.Equal(t, 13_310, view.RequestTokens)
+}
 
 func TestRunner_EnqueueSummaryJob_Calls(t *testing.T) {
 	t.Run("calls EnqueueSummaryJob for qualifying events", func(t *testing.T) {
@@ -740,6 +777,7 @@ type mockSessionService struct {
 }
 
 type enqueueSummaryJobCall struct {
+	ctx       context.Context
 	sess      *session.Session
 	filterKey string
 	force     bool
@@ -838,7 +876,12 @@ func (m *mockSessionService) CreateSessionSummary(ctx context.Context, sess *ses
 }
 
 func (m *mockSessionService) EnqueueSummaryJob(ctx context.Context, sess *session.Session, filterKey string, force bool) error {
-	m.enqueueSummaryJobCalls = append(m.enqueueSummaryJobCalls, enqueueSummaryJobCall{sess, filterKey, force})
+	m.enqueueSummaryJobCalls = append(m.enqueueSummaryJobCalls, enqueueSummaryJobCall{
+		ctx:       ctx,
+		sess:      sess,
+		filterKey: filterKey,
+		force:     force,
+	})
 	return nil
 }
 

--- a/session/summary/checker.go
+++ b/session/summary/checker.go
@@ -285,7 +285,8 @@ func countTokenThresholdMessage(
 // threshold. Full-session checks count only primary-agent activity, while
 // branch-scoped checks count the scoped branch and its descendants. When a
 // summarizer injects effective summary text into the session state, that text
-// takes precedence over the default event extraction logic.
+// takes precedence over the default event extraction logic. Context-aware
+// framework calls use the finalized model request size when available.
 //
 // Note:
 // Token accounting via model usage is not stable once session summary
@@ -326,6 +327,12 @@ func evaluateTokenThreshold(tokenCount int) checkEvaluator {
 			Metric:    metricTokens,
 			Threshold: tokenCount,
 			Unit:      unitTokens,
+		}
+		if view, ok := modelVisibleViewForSession(ctx, sess); ok &&
+			view.RequestTokens > 0 {
+			check.Value = view.RequestTokens
+			check.Passed = view.RequestTokens > tokenCount
+			return check
 		}
 
 		var message model.Message

--- a/session/summary/hook.go
+++ b/session/summary/hook.go
@@ -15,13 +15,14 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
-// PreSummaryHookContext carries all inputs for pre-summary hooks. When the
-// prompt contains {previous_summary}, Events and Text contain only newly
-// uncovered conversation content and PreviousSummary carries the prior rolling
-// summary. Prompts without that placeholder retain the legacy merged view in
-// Events and Text. When request-side projection is available, Events and Text
-// reflect the model-visible conversation while SourceEvents retains the stored
-// source prefix for hooks that need persistence-level metadata or payloads.
+// PreSummaryHookContext carries all inputs for pre-summary hooks. Events and
+// Text reflect the conversation rendered for summarization. With request-side
+// projection, that conversation is model-visible while SourceEvents retains
+// the stored source events through the selected summary boundary. Without
+// request-side projection, SourceEvents equals Events. When the prompt contains
+// {previous_summary}, Events and Text contain only newly uncovered conversation
+// content and PreviousSummary carries the prior rolling summary. Prompts
+// without that placeholder retain the legacy merged view in Events and Text.
 type PreSummaryHookContext struct {
 	Ctx     context.Context
 	Session *session.Session

--- a/session/summary/hook.go
+++ b/session/summary/hook.go
@@ -19,11 +19,16 @@ import (
 // prompt contains {previous_summary}, Events and Text contain only newly
 // uncovered conversation content and PreviousSummary carries the prior rolling
 // summary. Prompts without that placeholder retain the legacy merged view in
-// Events and Text.
+// Events and Text. When request-side projection is available, Events and Text
+// reflect the model-visible conversation while SourceEvents retains the stored
+// source prefix for hooks that need persistence-level metadata or payloads.
 type PreSummaryHookContext struct {
-	Ctx             context.Context
-	Session         *session.Session
-	Events          []event.Event
+	Ctx     context.Context
+	Session *session.Session
+	Events  []event.Event
+	// SourceEvents contains stored source events through the selected summary
+	// boundary. Without a request-side projection, it is the same as Events.
+	SourceEvents    []event.Event
 	Text            string
 	PreviousSummary string
 }

--- a/session/summary/model_visible.go
+++ b/session/summary/model_visible.go
@@ -1,0 +1,72 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummarycontext "trpc.group/trpc-go/trpc-agent-go/session/internal/summarycontext"
+	isummaryscope "trpc.group/trpc-go/trpc-agent-go/session/internal/summaryscope"
+)
+
+type modelVisibleItemsContextKey struct{}
+
+func modelVisibleViewForSession(
+	ctx context.Context,
+	sess *session.Session,
+) (*summaryview.View, bool) {
+	if sess == nil {
+		return nil, false
+	}
+	view, ok := summaryview.FromContext(ctx)
+	if !ok {
+		return nil, false
+	}
+	filterKey := isummaryscope.GetScopeFilterKey(sess)
+	if view.FilterKey != filterKey {
+		return nil, false
+	}
+	if previousSummary, present := isummarycontext.PreviousSummary(ctx); present &&
+		view.PreviousSummary != previousSummary {
+		return nil, false
+	}
+	if view.SessionID != sess.ID &&
+		sess.ID != view.SessionID+":"+filterKey {
+		return nil, false
+	}
+	return view, true
+}
+
+func contextWithModelVisibleItems(
+	ctx context.Context,
+	indexes []int,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(
+		ctx,
+		modelVisibleItemsContextKey{},
+		append([]int(nil), indexes...),
+	)
+}
+
+func modelVisibleItemsFromContext(ctx context.Context) ([]int, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	indexes, ok := ctx.Value(modelVisibleItemsContextKey{}).([]int)
+	if !ok || len(indexes) == 0 {
+		return nil, false
+	}
+	return append([]int(nil), indexes...), true
+}

--- a/session/summary/model_visible_test.go
+++ b/session/summary/model_visible_test.go
@@ -94,6 +94,58 @@ func TestSummaryDoesNotAdvanceWithoutStoredBoundary(t *testing.T) {
 	))
 }
 
+func TestUnboundModelVisibleViewDoesNotSummarize(t *testing.T) {
+	now := time.Now()
+	raw := modelVisibleTestEvent(
+		"event-1",
+		"user",
+		model.NewUserMessage("stored history"),
+		now,
+	)
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     "session",
+		RequestTokens: 130_000,
+		Items: []summaryview.Item{{
+			Message: model.NewUserMessage("stale projected history"),
+			EffectiveEvent: modelVisibleTestEvent(
+				"event-1",
+				"user",
+				model.NewUserMessage("stale projected history"),
+				now,
+			),
+			Boundary: summaryview.Boundary{
+				EventID:   raw.ID,
+				Timestamp: raw.Timestamp,
+			},
+		}},
+	})
+	sess := &session.Session{ID: "session", Events: []event.Event{raw}}
+	skipCalls := 0
+	summarizer := NewSummarizer(
+		&fakeModel{},
+		WithTokenThreshold(1),
+		WithSkipRecent(func([]event.Event) int {
+			skipCalls++
+			return 0
+		}),
+	)
+
+	selection := summarizer.(*sessionSummarizer).selectSummaryEvents(ctx, sess)
+	require.True(t, selection.effective)
+	require.Empty(t, selection.events)
+	require.Empty(t, selection.itemIndexes)
+	require.True(t, selection.boundary.IsZero())
+	require.False(t, summarizer.(ContextAwareSummarizer).ShouldSummarizeWithContext(
+		ctx,
+		sess,
+	))
+	_, err := summarizer.Summarize(ctx, sess)
+	require.ErrorContains(t, err, "no conversation text extracted")
+	require.Zero(t, skipCalls)
+	_, ok := sess.GetState(lastIncludedEventIDKey)
+	require.False(t, ok)
+}
+
 func TestPreSummaryHookSeparatesModelVisibleAndSourceEvents(t *testing.T) {
 	now := time.Now()
 	raw := modelVisibleTestEvent(
@@ -425,6 +477,7 @@ func TestSelectSummaryEventsPrependsPreviousSummary(t *testing.T) {
 	view := &summaryview.View{
 		SessionID:       "session",
 		PreviousSummary: "previous summary",
+		Bound:           true,
 		Items: []summaryview.Item{{
 			Message:        raw.Response.Choices[0].Message,
 			EffectiveEvent: raw,

--- a/session/summary/model_visible_test.go
+++ b/session/summary/model_visible_test.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummarycontext "trpc.group/trpc-go/trpc-agent-go/session/internal/summarycontext"
 	isummaryscope "trpc.group/trpc-go/trpc-agent-go/session/internal/summaryscope"
 )
 
@@ -349,6 +350,185 @@ func TestSummarizeScopesModelVisibleItemsBeforeSkipping(t *testing.T) {
 	lastEventID, ok := sess.GetState(lastIncludedEventIDKey)
 	require.True(t, ok)
 	require.Equal(t, "event-branch", string(lastEventID))
+}
+
+func TestModelVisibleViewMatchesSummaryScope(t *testing.T) {
+	view := &summaryview.View{
+		SessionID:       "session",
+		FilterKey:       "branch",
+		PreviousSummary: "previous",
+	}
+	ctx := summaryview.ContextWithView(context.Background(), view)
+
+	sess := &session.Session{ID: "session"}
+	_, ok := modelVisibleViewForSession(ctx, sess)
+	require.False(t, ok)
+
+	isummaryscope.SetScopeFilterKey(sess, "branch")
+	_, ok = modelVisibleViewForSession(
+		isummarycontext.WithPreviousSummary(ctx, "different"),
+		sess,
+	)
+	require.False(t, ok)
+
+	other := &session.Session{ID: "other"}
+	isummaryscope.SetScopeFilterKey(other, "branch")
+	_, ok = modelVisibleViewForSession(ctx, other)
+	require.False(t, ok)
+
+	composite := &session.Session{ID: "session:branch"}
+	isummaryscope.SetScopeFilterKey(composite, "branch")
+	matched, ok := modelVisibleViewForSession(
+		isummarycontext.WithPreviousSummary(ctx, "previous"),
+		composite,
+	)
+	require.True(t, ok)
+	require.Equal(t, "session", matched.SessionID)
+}
+
+func TestModelVisibleItemContextIsIsolated(t *testing.T) {
+	ctx := contextWithModelVisibleItems(nil, []int{1, 3})
+	indexes, ok := modelVisibleItemsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, []int{1, 3}, indexes)
+
+	indexes[0] = 99
+	again, ok := modelVisibleItemsFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, []int{1, 3}, again)
+
+	_, ok = modelVisibleItemsFromContext(nil)
+	require.False(t, ok)
+	_, ok = modelVisibleItemsFromContext(context.Background())
+	require.False(t, ok)
+	_, ok = modelVisibleItemsFromContext(contextWithModelVisibleItems(
+		context.Background(),
+		nil,
+	))
+	require.False(t, ok)
+	_, ok = modelVisibleItemsFromContext(context.WithValue(
+		context.Background(),
+		modelVisibleItemsContextKey{},
+		"invalid",
+	))
+	require.False(t, ok)
+}
+
+func TestSelectSummaryEventsPrependsPreviousSummary(t *testing.T) {
+	now := time.Now()
+	raw := modelVisibleTestEvent(
+		"event-1",
+		"user",
+		model.NewUserMessage("visible"),
+		now,
+	)
+	view := &summaryview.View{
+		SessionID:       "session",
+		PreviousSummary: "previous summary",
+		Items: []summaryview.Item{{
+			Message:        raw.Response.Choices[0].Message,
+			EffectiveEvent: raw,
+			Boundary: summaryview.Boundary{
+				EventID:   raw.ID,
+				Timestamp: raw.Timestamp,
+			},
+		}},
+	}
+	sess := &session.Session{ID: "session", Events: []event.Event{raw}}
+	selection := (&sessionSummarizer{}).selectSummaryEvents(
+		summaryview.ContextWithView(context.Background(), view),
+		sess,
+	)
+
+	require.True(t, selection.effective)
+	require.Len(t, selection.events, 2)
+	require.Equal(t, model.RoleSystem, selection.events[0].Response.Choices[0].Message.Role)
+	require.Equal(
+		t,
+		"previous summary",
+		selection.events[0].Response.Choices[0].Message.Content,
+	)
+	require.Equal(t, []int{0}, selection.itemIndexes)
+	require.Equal(t, "event-1", selection.boundary.EventID)
+	require.Equal(t, []event.Event{raw}, selection.sourceEvents)
+}
+
+func TestSourceEventsThroughBoundaryFallbacks(t *testing.T) {
+	baseTime := time.Now()
+	events := []event.Event{
+		{ID: "first", Timestamp: baseTime},
+		{ID: "second", Timestamp: baseTime.Add(time.Second)},
+		{ID: "third", Timestamp: baseTime.Add(2 * time.Second)},
+	}
+
+	require.Nil(t, sourceEventsThroughBoundary(events, summaryview.Boundary{}))
+	require.Equal(t, events[:2], sourceEventsThroughBoundary(
+		events,
+		summaryview.Boundary{EventID: "second"},
+	))
+	require.Nil(t, sourceEventsThroughBoundary(
+		events,
+		summaryview.Boundary{EventID: "missing"},
+	))
+	require.Equal(t, events[:2], sourceEventsThroughBoundary(
+		events,
+		summaryview.Boundary{
+			EventID:   "missing",
+			Timestamp: baseTime.Add(time.Second),
+		},
+	))
+	require.Equal(t, events, sourceEventsThroughBoundary(
+		events,
+		summaryview.Boundary{Timestamp: baseTime.Add(3 * time.Second)},
+	))
+}
+
+func TestSummaryBoundaryAndEffectiveCheckSession(t *testing.T) {
+	now := time.Now()
+	summarizer := &sessionSummarizer{}
+	summarizer.recordIncludedBoundary(nil, summaryview.Boundary{Timestamp: now})
+
+	sess := &session.Session{ID: "session"}
+	sess.SetState(lastIncludedEventIDKey, []byte("old"))
+	summarizer.recordIncludedBoundary(sess, summaryview.Boundary{})
+	lastEventID, ok := sess.GetState(lastIncludedEventIDKey)
+	require.True(t, ok)
+	require.Equal(t, "old", string(lastEventID))
+
+	summarizer.recordIncludedBoundary(sess, summaryview.Boundary{Timestamp: now})
+	_, ok = sess.GetState(lastIncludedEventIDKey)
+	require.False(t, ok)
+	lastTimestamp, ok := sess.GetState(lastIncludedTsKey)
+	require.True(t, ok)
+	require.Equal(t, now.UTC().Format(time.RFC3339Nano), string(lastTimestamp))
+
+	summarizer.recordIncludedBoundary(sess, summaryview.Boundary{
+		EventID:   "event-1",
+		Timestamp: now,
+	})
+	lastEventID, ok = sess.GetState(lastIncludedEventIDKey)
+	require.True(t, ok)
+	require.Equal(t, "event-1", string(lastEventID))
+
+	effective := modelVisibleTestEvent(
+		"event-1",
+		"user",
+		model.NewUserMessage("effective"),
+		now,
+	)
+	check := summarizer.buildCheckSessionWithSelection(
+		sess,
+		summaryEventSelection{
+			events:    []event.Event{effective},
+			effective: true,
+		},
+	)
+	require.Len(t, check.Events, 1)
+	require.Equal(
+		t,
+		"effective",
+		check.Events[0].Response.Choices[0].Message.Content,
+	)
 }
 
 func modelVisibleTestEvent(

--- a/session/summary/model_visible_test.go
+++ b/session/summary/model_visible_test.go
@@ -93,6 +93,70 @@ func TestSummaryDoesNotAdvanceWithoutStoredBoundary(t *testing.T) {
 	))
 }
 
+func TestPreSummaryHookSeparatesModelVisibleAndSourceEvents(t *testing.T) {
+	now := time.Now()
+	raw := modelVisibleTestEvent(
+		"event-1",
+		"tool",
+		model.NewToolMessage(
+			"call-1",
+			"lookup",
+			"raw tool payload",
+		),
+		now,
+	)
+	effectiveMessage := model.NewToolMessage(
+		"call-1",
+		"lookup",
+		"projected tool result",
+	)
+	effective := modelVisibleTestEvent(
+		raw.ID,
+		raw.Author,
+		effectiveMessage,
+		now,
+	)
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID: "session",
+		Bound:     true,
+		Items: []summaryview.Item{{
+			Message:        effectiveMessage,
+			EffectiveEvent: effective,
+			Boundary: summaryview.Boundary{
+				EventID:   raw.ID,
+				Timestamp: raw.Timestamp,
+			},
+		}},
+	})
+	mdl := &echoPromptModel{}
+	summarizer := NewSummarizer(
+		mdl,
+		WithPreSummaryHook(func(in *PreSummaryHookContext) error {
+			require.Len(t, in.Events, 1)
+			require.Equal(
+				t,
+				"projected tool result",
+				in.Events[0].Response.Choices[0].Message.Content,
+			)
+			require.Len(t, in.SourceEvents, 1)
+			require.Equal(
+				t,
+				"raw tool payload",
+				in.SourceEvents[0].Response.Choices[0].Message.Content,
+			)
+			// Rebuild from Events to exercise the hook fallback path.
+			in.Text = ""
+			return nil
+		}),
+	)
+	sess := &session.Session{ID: "session", Events: []event.Event{raw}}
+
+	result, err := summarizer.Summarize(ctx, sess)
+	require.NoError(t, err)
+	require.Contains(t, result, "projected tool result")
+	require.NotContains(t, result, "raw tool payload")
+}
+
 func TestSummarizeUsesModelVisiblePrefix(t *testing.T) {
 	baseTime := time.Now().Add(-time.Minute)
 	rawEvents := []event.Event{

--- a/session/summary/model_visible_test.go
+++ b/session/summary/model_visible_test.go
@@ -1,0 +1,304 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummaryscope "trpc.group/trpc-go/trpc-agent-go/session/internal/summaryscope"
+)
+
+func TestTokenThresholdUsesModelVisibleRequestTokens(t *testing.T) {
+	sess := &session.Session{
+		ID: "session",
+		Events: []event.Event{
+			modelVisibleTestEvent(
+				"raw",
+				"user",
+				model.NewUserMessage(strings.Repeat("raw ", 1000)),
+				time.Now(),
+			),
+		},
+	}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     sess.ID,
+		RequestTokens: 130_000,
+		Items: []summaryview.Item{{
+			EffectiveEvent: modelVisibleTestEvent(
+				"raw",
+				"user",
+				model.NewUserMessage("projected"),
+				time.Now(),
+			),
+		}},
+	})
+
+	check := evaluateTokenThreshold(129_999)(ctx, sess)
+	require.True(t, check.Passed)
+	require.Equal(t, 130_000, check.Value)
+
+	check = evaluateTokenThreshold(130_000)(ctx, sess)
+	require.False(t, check.Passed)
+	require.Equal(t, 130_000, check.Value)
+}
+
+func TestSummaryDoesNotAdvanceWithoutStoredBoundary(t *testing.T) {
+	sess := &session.Session{
+		ID: "session",
+		Events: []event.Event{
+			modelVisibleTestEvent(
+				"raw-event",
+				"user",
+				model.NewUserMessage("raw history"),
+				time.Now(),
+			),
+		},
+	}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     sess.ID,
+		RequestTokens: 100_000,
+		Items: []summaryview.Item{{
+			EffectiveEvent: modelVisibleTestEvent(
+				"",
+				"user",
+				model.NewUserMessage("unpersisted request"),
+				time.Now(),
+			),
+		}},
+	})
+	summarizer := NewSummarizer(
+		&fakeModel{},
+		WithTokenThreshold(1),
+	)
+
+	require.False(t, summarizer.(ContextAwareSummarizer).ShouldSummarizeWithContext(
+		ctx,
+		sess,
+	))
+}
+
+func TestSummarizeUsesModelVisiblePrefix(t *testing.T) {
+	baseTime := time.Now().Add(-time.Minute)
+	rawEvents := []event.Event{
+		modelVisibleTestEvent(
+			"event-1",
+			"user",
+			model.NewUserMessage("original goal"),
+			baseTime,
+		),
+		modelVisibleTestEvent(
+			"event-2",
+			"tool",
+			model.NewToolMessage(
+				"call-1",
+				"lookup",
+				strings.Repeat("raw tool payload ", 1000),
+			),
+			baseTime.Add(time.Second),
+		),
+		modelVisibleTestEvent(
+			"event-3",
+			"user",
+			model.NewUserMessage("recent request"),
+			baseTime.Add(2*time.Second),
+		),
+	}
+	effectiveMessages := []model.Message{
+		model.NewUserMessage("original goal"),
+		model.NewToolMessage(
+			"call-1",
+			"lookup",
+			"tool result omitted from model-visible history",
+		),
+		model.NewUserMessage("recent request"),
+	}
+	items := make([]summaryview.Item, len(effectiveMessages))
+	for i := range effectiveMessages {
+		items[i] = summaryview.Item{
+			Message: effectiveMessages[i],
+			EffectiveEvent: modelVisibleTestEvent(
+				rawEvents[i].ID,
+				rawEvents[i].Author,
+				effectiveMessages[i],
+				rawEvents[i].Timestamp,
+			),
+			Boundary: summaryview.Boundary{
+				EventID:   rawEvents[i].ID,
+				Timestamp: rawEvents[i].Timestamp,
+			},
+			RequestIndex: i + 1,
+		}
+	}
+	view := &summaryview.View{
+		SessionID: "session",
+		Items:     items,
+		Bound:     true,
+	}
+	parent := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable system prompt"),
+		effectiveMessages[0],
+		effectiveMessages[1],
+		effectiveMessages[2],
+		model.NewAssistantMessage("response appended after the request"),
+	}}
+
+	var skipInput []event.Event
+	capture := &cacheSafeCaptureModel{response: "summary"}
+	summarizer := NewSummarizer(
+		capture,
+		WithCacheSafeForking(true),
+		WithSkipRecent(func(events []event.Event) int {
+			skipInput = events
+			return 1
+		}),
+	)
+	sess := &session.Session{ID: "session", Events: rawEvents}
+	ctx := summaryview.ContextWithView(context.Background(), view)
+	ctx = ContextWithCacheSafeForkRequest(ctx, parent)
+
+	result, err := summarizer.Summarize(ctx, sess)
+	require.NoError(t, err)
+	require.Equal(t, "summary", result)
+	require.Len(t, skipInput, 3)
+	require.Equal(
+		t,
+		"tool result omitted from model-visible history",
+		skipInput[1].Response.Choices[0].Message.Content,
+	)
+	require.NotContains(
+		t,
+		skipInput[1].Response.Choices[0].Message.Content,
+		"raw tool payload",
+	)
+
+	require.NotNil(t, capture.request)
+	require.Len(t, capture.request.Messages, 4)
+	require.Equal(t, "stable system prompt", capture.request.Messages[0].Content)
+	require.Equal(t, "original goal", capture.request.Messages[1].Content)
+	require.Equal(
+		t,
+		"tool result omitted from model-visible history",
+		capture.request.Messages[2].Content,
+	)
+	require.NotContains(t, capture.request.Messages[3].Content, "recent request")
+	require.NotContains(
+		t,
+		capture.request.Messages[3].Content,
+		"response appended after the request",
+	)
+
+	lastEventID, ok := sess.GetState(lastIncludedEventIDKey)
+	require.True(t, ok)
+	require.Equal(t, "event-2", string(lastEventID))
+}
+
+func TestSummarizeScopesModelVisibleItemsBeforeSkipping(t *testing.T) {
+	now := time.Now()
+	root := modelVisibleTestEvent(
+		"event-root",
+		"user",
+		model.NewUserMessage("ancestor context"),
+		now,
+	)
+	root.FilterKey = "app"
+	branch := modelVisibleTestEvent(
+		"event-branch",
+		"user",
+		model.NewUserMessage("branch goal"),
+		now.Add(time.Second),
+	)
+	branch.FilterKey = "app/sub"
+	recent := modelVisibleTestEvent(
+		"event-recent",
+		"assistant",
+		model.NewAssistantMessage("branch recent"),
+		now.Add(2*time.Second),
+	)
+	recent.FilterKey = "app/sub"
+	events := []event.Event{root, branch, recent}
+	items := make([]summaryview.Item, len(events))
+	for i := range events {
+		items[i] = summaryview.Item{
+			Message:        events[i].Response.Choices[0].Message,
+			EffectiveEvent: events[i],
+			Boundary: summaryview.Boundary{
+				EventID:   events[i].ID,
+				Timestamp: events[i].Timestamp,
+			},
+			RequestIndex: i + 1,
+		}
+	}
+	view := &summaryview.View{
+		SessionID: "session",
+		FilterKey: "app/sub",
+		Items:     items,
+		Bound:     true,
+	}
+	parent := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		items[0].Message,
+		items[1].Message,
+		items[2].Message,
+	}}
+	sess := &session.Session{ID: "session", Events: events}
+	isummaryscope.SetScopeFilterKey(sess, "app/sub")
+	var skipInput []event.Event
+	capture := &cacheSafeCaptureModel{response: "summary"}
+	summarizer := NewSummarizer(
+		capture,
+		WithCacheSafeForking(true),
+		WithSkipRecent(func(events []event.Event) int {
+			skipInput = events
+			return 1
+		}),
+	)
+	ctx := summaryview.ContextWithView(context.Background(), view)
+	ctx = ContextWithCacheSafeForkRequest(ctx, parent)
+
+	_, err := summarizer.Summarize(ctx, sess)
+	require.NoError(t, err)
+	require.Len(t, skipInput, 2)
+	require.Equal(t, "branch goal", skipInput[0].Response.Choices[0].Message.Content)
+	require.Equal(t, "branch recent", skipInput[1].Response.Choices[0].Message.Content)
+	require.Len(t, capture.request.Messages, 3)
+	require.Equal(t, "stable", capture.request.Messages[0].Content)
+	require.Equal(t, "branch goal", capture.request.Messages[1].Content)
+	require.NotContains(t, capture.request.Messages[2].Content, "ancestor context")
+	require.NotContains(t, capture.request.Messages[2].Content, "branch recent")
+
+	lastEventID, ok := sess.GetState(lastIncludedEventIDKey)
+	require.True(t, ok)
+	require.Equal(t, "event-branch", string(lastEventID))
+}
+
+func modelVisibleTestEvent(
+	id string,
+	author string,
+	message model.Message,
+	timestamp time.Time,
+) event.Event {
+	return event.Event{
+		ID:        id,
+		Author:    author,
+		Timestamp: timestamp,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: message,
+		}}},
+	}
+}

--- a/session/summary/options.go
+++ b/session/summary/options.go
@@ -67,7 +67,9 @@ func WithSystemPrompt(prompt string) Option {
 // summarizer clones the parent request and appends a compacting user message
 // instead of sending a standalone summary prompt. If no parent request is
 // available, or the parent cannot fit the summary model's input budget,
-// summarization falls back to a bounded standalone prompt.
+// summarization falls back to a bounded standalone prompt. Framework-provided
+// model-request views restrict the fork to the same history prefix selected by
+// WithSkipRecent, excluding later responses appended after that request.
 //
 // This is disabled by default.
 func WithCacheSafeForking(enable bool) Option {
@@ -101,9 +103,11 @@ func WithMaxSummaryWords(maxWords int) Option {
 }
 
 // WithSkipRecent sets a custom function to determine how many of the most recent
-// events (from the tail) should be skipped during summarization. The function
-// receives all events and returns the count of tail events to skip. Return 0 to
-// skip none.
+// events (from the tail) should be skipped during summarization. In the normal
+// Runner LLM flow, the function receives the projected session history visible
+// to the model, after history filtering and request-side compaction. Standalone
+// summarization without a model-request view preserves the legacy raw-session
+// input. Return 0 to skip none.
 //
 // Example:
 //
@@ -131,7 +135,10 @@ func WithSkipRecent(skipFunc SkipRecentFunc) Option {
 	}
 }
 
-// WithTokenThreshold appends a token-based check.
+// WithTokenThreshold appends a token-based check. When the normal Runner LLM
+// flow provides a finalized model-request view, the check uses that request's
+// estimated token count, including the retained recent tail. Standalone
+// summarization preserves legacy event-text estimation.
 // Note: all checks in a summarizer are combined with global AND semantics.
 // If you call multiple threshold options (e.g. token + event), all must pass.
 func WithTokenThreshold(tokenCount int) Option {

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/modelcontext"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
@@ -352,15 +353,13 @@ func (s *sessionSummarizer) evaluateTrigger(
 	if sess == nil || len(sess.Events) == 0 {
 		return Trigger{}
 	}
-	summaryInputEvents := filterSummaryInputEventsForSession(
-		s.filterEventsForSummary(sess.Events),
-		sess,
-	)
+	selection := s.selectSummaryEvents(ctx, sess)
+	summaryInputEvents := selection.events
 	if !s.hasSummarizableContent(summaryInputEvents) {
 		return Trigger{}
 	}
 
-	checkSess := s.buildCheckSession(sess)
+	checkSess := s.buildCheckSessionWithSelection(sess, selection)
 	if len(s.checks) == 0 {
 		return Trigger{
 			Fired:     true,
@@ -442,6 +441,114 @@ type summaryPromptInput struct {
 	previousSummary  string
 }
 
+type summaryEventSelection struct {
+	events      []event.Event
+	hookEvents  []event.Event
+	itemIndexes []int
+	boundary    summaryview.Boundary
+	effective   bool
+}
+
+func (s *sessionSummarizer) selectSummaryEvents(
+	ctx context.Context,
+	sess *session.Session,
+) summaryEventSelection {
+	view, ok := modelVisibleViewForSession(ctx, sess)
+	if !ok {
+		events := filterSummaryInputEventsForSession(
+			s.filterEventsForSummary(sess.Events),
+			sess,
+		)
+		return summaryEventSelection{events: events, hookEvents: events}
+	}
+
+	viewEvents := view.Events()
+	events := make([]event.Event, 0, len(viewEvents)+1)
+	itemIndexes := make([]int, 0, len(viewEvents))
+	for i := range viewEvents {
+		if len(filterSummaryInputEventsForSession(
+			[]event.Event{viewEvents[i]},
+			sess,
+		)) == 0 {
+			continue
+		}
+		events = append(events, viewEvents[i])
+		itemIndexes = append(itemIndexes, i)
+	}
+	hasPreviousSummaryHead := view.PreviousSummary != "" &&
+		!view.PreviousSummaryInItems
+	if hasPreviousSummaryHead {
+		events = append(
+			[]event.Event{previousSummaryEvent(view.PreviousSummary)},
+			events...,
+		)
+	}
+	events = s.filterEventsForSummary(events)
+	itemCount := len(events)
+	if hasPreviousSummaryHead && itemCount > 0 {
+		itemCount--
+	}
+	if itemCount < len(itemIndexes) {
+		itemIndexes = itemIndexes[:itemCount]
+	}
+	selection := summaryEventSelection{
+		events:      events,
+		hookEvents:  events,
+		itemIndexes: itemIndexes,
+		effective:   true,
+	}
+	if boundary, found := view.BoundaryForItems(itemIndexes); found {
+		selection.boundary = boundary
+		if source := sourceEventsThroughBoundary(sess.Events, boundary); len(source) > 0 {
+			selection.hookEvents = filterSummaryInputEventsForSession(source, sess)
+		}
+	} else if len(itemIndexes) > 0 {
+		// A summary must never advance persistence past content that has no
+		// structural mapping to a stored event. This can happen for context-only
+		// anchors or a user message that has not been persisted yet.
+		selection.events = nil
+		selection.hookEvents = nil
+		selection.itemIndexes = nil
+	}
+	return selection
+}
+
+func previousSummaryEvent(text string) event.Event {
+	return event.Event{
+		Author: authorSystem,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.NewSystemMessage(text),
+		}}},
+	}
+}
+
+func sourceEventsThroughBoundary(
+	events []event.Event,
+	boundary summaryview.Boundary,
+) []event.Event {
+	if boundary.IsZero() {
+		return nil
+	}
+	if boundary.EventID != "" {
+		for i := range events {
+			if events[i].ID == boundary.EventID {
+				return events[:i+1]
+			}
+		}
+	}
+	if boundary.Timestamp.IsZero() {
+		return nil
+	}
+	end := 0
+	for i := range events {
+		if events[i].Timestamp.After(boundary.Timestamp) {
+			break
+		}
+		end = i + 1
+	}
+	return events[:end]
+}
+
 func (in summaryPromptInput) characterCount() int {
 	return len(in.conversationText) + len(in.previousSummary)
 }
@@ -460,15 +567,18 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 
 	// Extract conversation text from events. Use filtered events for summarization
 	// to skip recent events while ensuring proper context.
-	eventsToSummarize := filterSummaryInputEventsForSession(
-		s.filterEventsForSummary(sess.Events),
-		sess,
-	)
+	selection := s.selectSummaryEvents(ctx, sess)
+	eventsToSummarize := selection.events
 	conversationEvents := eventsToSummarize
+	hookEvents := selection.hookEvents
 	input := summaryPromptInput{}
 	if separatePreviousSummary {
 		conversationEvents = removePreviousSummaryEvent(
 			conversationEvents,
+			previousSummary,
+		)
+		hookEvents = removePreviousSummaryEvent(
+			hookEvents,
 			previousSummary,
 		)
 		input.previousSummary = previousSummary
@@ -478,7 +588,7 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	ctx, input, err := s.runPreSummaryHook(
 		ctx,
 		sess,
-		conversationEvents,
+		hookEvents,
 		input,
 		separatePreviousSummary,
 	)
@@ -488,13 +598,20 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	if input.conversationText == "" && input.previousSummary == "" {
 		return "", fmt.Errorf("no conversation text extracted for session %s (events=%d)", sess.ID, len(eventsToSummarize))
 	}
+	if selection.effective && len(selection.itemIndexes) > 0 {
+		ctx = contextWithModelVisibleItems(ctx, selection.itemIndexes)
+	}
 
 	ctx, summaryText, err := s.generateSummary(ctx, sess, input)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate summary for session %s: %w", sess.ID, err)
 	}
 
-	s.recordLastIncludedBoundary(sess, eventsToSummarize)
+	if selection.effective && !selection.boundary.IsZero() {
+		s.recordIncludedBoundary(sess, selection.boundary)
+	} else {
+		s.recordLastIncludedBoundary(sess, eventsToSummarize)
+	}
 
 	if s.postHook != nil {
 		hookCtx := &PostSummaryHookContext{
@@ -630,15 +747,52 @@ func (s *sessionSummarizer) recordLastIncludedBoundary(sess *session.Session, ev
 	sess.SetState(lastIncludedEventIDKey, []byte(last.ID))
 }
 
+func (s *sessionSummarizer) recordIncludedBoundary(
+	sess *session.Session,
+	boundary summaryview.Boundary,
+) {
+	if sess == nil || boundary.Timestamp.IsZero() {
+		return
+	}
+	sess.SetState(
+		lastIncludedTsKey,
+		[]byte(boundary.Timestamp.UTC().Format(time.RFC3339Nano)),
+	)
+	if boundary.EventID == "" {
+		sess.DeleteState(lastIncludedEventIDKey)
+		return
+	}
+	sess.SetState(lastIncludedEventIDKey, []byte(boundary.EventID))
+}
+
 func (s *sessionSummarizer) buildCheckSession(
 	sess *session.Session,
 ) *session.Session {
 	if sess == nil {
 		return nil
 	}
+	return s.buildCheckSessionWithSelection(
+		sess,
+		s.selectSummaryEvents(context.Background(), sess),
+	)
+}
+
+func (s *sessionSummarizer) buildCheckSessionWithSelection(
+	sess *session.Session,
+	selection summaryEventSelection,
+) *session.Session {
+	if sess == nil {
+		return nil
+	}
 	checkSess := sess.Clone()
-	delta := filterDeltaEvents(checkSess)
-	filtered := s.filterEventsForSummary(delta)
+	var filtered []event.Event
+	if selection.effective {
+		filtered = selection.events
+		checkSess.Events = append([]event.Event(nil), filtered...)
+	} else {
+		delta := filterDeltaEvents(checkSess)
+		filtered = s.filterEventsForSummary(delta)
+	}
 	thresholdEvents := filterThresholdEventsForSession(filtered, checkSess)
 	var thresholdMessage model.Message
 	summaryInputEvents := filterSummaryInputEventsForSession(filtered, checkSess)
@@ -1242,6 +1396,28 @@ func (s *sessionSummarizer) buildSummaryRequest(
 ) (*model.Request, string, error) {
 	if s.cacheSafeForking {
 		if parent, ok := CacheSafeForkRequestFromContext(ctx); ok {
+			if itemIndexes, hasItems := modelVisibleItemsFromContext(ctx); hasItems {
+				view, hasView := summaryview.FromContext(ctx)
+				if hasView {
+					messages, bound := view.MessagesForItems(
+						parent.Messages,
+						itemIndexes,
+					)
+					if bound {
+						request, err := s.buildCacheSafeForkRequestWithMessages(
+							parent,
+							messages,
+						)
+						return request, callModeCacheSafeFork, err
+					}
+				}
+				log.DebugfContext(
+					ctx,
+					"cache-safe summary prefix could not be bound to the parent request; falling back to standalone summary request",
+				)
+				request, err := s.buildStandaloneSummaryRequest(input)
+				return request, callModeStandalone, err
+			}
 			request, err := s.buildCacheSafeForkRequest(parent)
 			return request, callModeCacheSafeFork, err
 		}
@@ -1274,9 +1450,19 @@ func (s *sessionSummarizer) buildStandaloneSummaryRequest(
 func (s *sessionSummarizer) buildCacheSafeForkRequest(
 	parent *model.Request,
 ) (*model.Request, error) {
+	return s.buildCacheSafeForkRequestWithMessages(parent, nil)
+}
+
+func (s *sessionSummarizer) buildCacheSafeForkRequestWithMessages(
+	parent *model.Request,
+	messages []model.Message,
+) (*model.Request, error) {
 	request := cloneRequestForCacheSafeFork(parent)
 	if request == nil {
 		return nil, errors.New("parent request is nil")
+	}
+	if messages != nil {
+		request.Messages = cloneMessagesForCacheSafeFork(messages)
 	}
 	if !hasSummarySourceContent(request.Messages) {
 		return nil, errors.New("cache-safe summary request has no conversation content")

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -461,6 +461,13 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		)
 		return summaryEventSelection{events: events, sourceEvents: events}
 	}
+	if !view.Bound {
+		// Final request tokens are still trustworthy when binding fails, but
+		// projected items may differ from messages changed by later processors
+		// or before-model callbacks. Do not summarize or advance persistence
+		// from content that is not proven to have been visible to the model.
+		return summaryEventSelection{effective: true}
+	}
 
 	viewEvents := view.Events()
 	events := make([]event.Event, 0, len(viewEvents)+1)

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -442,11 +442,11 @@ type summaryPromptInput struct {
 }
 
 type summaryEventSelection struct {
-	events      []event.Event
-	hookEvents  []event.Event
-	itemIndexes []int
-	boundary    summaryview.Boundary
-	effective   bool
+	events       []event.Event
+	sourceEvents []event.Event
+	itemIndexes  []int
+	boundary     summaryview.Boundary
+	effective    bool
 }
 
 func (s *sessionSummarizer) selectSummaryEvents(
@@ -459,7 +459,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 			s.filterEventsForSummary(sess.Events),
 			sess,
 		)
-		return summaryEventSelection{events: events, hookEvents: events}
+		return summaryEventSelection{events: events, sourceEvents: events}
 	}
 
 	viewEvents := view.Events()
@@ -492,22 +492,22 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		itemIndexes = itemIndexes[:itemCount]
 	}
 	selection := summaryEventSelection{
-		events:      events,
-		hookEvents:  events,
-		itemIndexes: itemIndexes,
-		effective:   true,
+		events:       events,
+		sourceEvents: events,
+		itemIndexes:  itemIndexes,
+		effective:    true,
 	}
 	if boundary, found := view.BoundaryForItems(itemIndexes); found {
 		selection.boundary = boundary
 		if source := sourceEventsThroughBoundary(sess.Events, boundary); len(source) > 0 {
-			selection.hookEvents = filterSummaryInputEventsForSession(source, sess)
+			selection.sourceEvents = filterSummaryInputEventsForSession(source, sess)
 		}
 	} else if len(itemIndexes) > 0 {
 		// A summary must never advance persistence past content that has no
 		// structural mapping to a stored event. This can happen for context-only
 		// anchors or a user message that has not been persisted yet.
 		selection.events = nil
-		selection.hookEvents = nil
+		selection.sourceEvents = nil
 		selection.itemIndexes = nil
 	}
 	return selection
@@ -570,15 +570,15 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	selection := s.selectSummaryEvents(ctx, sess)
 	eventsToSummarize := selection.events
 	conversationEvents := eventsToSummarize
-	hookEvents := selection.hookEvents
+	sourceEvents := selection.sourceEvents
 	input := summaryPromptInput{}
 	if separatePreviousSummary {
 		conversationEvents = removePreviousSummaryEvent(
 			conversationEvents,
 			previousSummary,
 		)
-		hookEvents = removePreviousSummaryEvent(
-			hookEvents,
+		sourceEvents = removePreviousSummaryEvent(
+			sourceEvents,
 			previousSummary,
 		)
 		input.previousSummary = previousSummary
@@ -588,7 +588,8 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	ctx, input, err := s.runPreSummaryHook(
 		ctx,
 		sess,
-		hookEvents,
+		conversationEvents,
+		sourceEvents,
 		input,
 		separatePreviousSummary,
 	)
@@ -637,6 +638,7 @@ func (s *sessionSummarizer) runPreSummaryHook(
 	ctx context.Context,
 	sess *session.Session,
 	events []event.Event,
+	sourceEvents []event.Event,
 	input summaryPromptInput,
 	separatePreviousSummary bool,
 ) (context.Context, summaryPromptInput, error) {
@@ -647,6 +649,7 @@ func (s *sessionSummarizer) runPreSummaryHook(
 		Ctx:             ctx,
 		Session:         sess,
 		Events:          events,
+		SourceEvents:    sourceEvents,
 		Text:            input.conversationText,
 		PreviousSummary: input.previousSummary,
 	}


### PR DESCRIPTION
## What changed

Session summarization now uses the finalized model-visible request view when the framework has one:

- token/context thresholds use the final request size, including the protected recent tail;
- `skipRecent` and summary input operate on projected history after filtering, reasoning cleanup, tool-transcript projection, and tool-result compaction;
- cache-safe forks include only the selected summary prefix and exclude skipped or post-request tail messages;
- structural event boundaries remain tied to the stored source events.
- pre-summary hooks receive model-visible `Events`/`Text` and can access the corresponding stored prefix through `SourceEvents`.

Standalone summarizer calls without a request view retain the legacy event-based behavior.

## Why

The session service stores raw events, while the model may receive a much smaller projected request. Counting and slicing raw events could trigger summaries at the wrong size, summarize content the model never saw, and immediately compact again after a large raw tool result. Carrying an internal request view keeps the trigger, skip policy, summary input, and persisted cutoff aligned without adding public configuration.

## Testing

- `go build ./...`
- `go test ./...`
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- targeted race tests for the new summary-view paths
- changed-code lint, `gofmt`, and `goimports`
- new `internal/state/summaryview` package coverage: 85.2%

## Compatibility

This intentionally changes the request-context-aware semantics of `WithTokenThreshold`, `WithSkipRecent`, cache-safe forking, and pre-summary hook events. `PreSummaryHookContext.SourceEvents` is an additive field for hooks that need the stored source payload. Standalone calls and callers without a framework-provided request view preserve the existing behavior. The existing strict token-threshold boundary is unchanged: the measured request must exceed the configured threshold.
