### PR TITLE
session/summary: summarize oversized histories in safe prefixes

### DIFF
--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -193,10 +193,10 @@ ceiling of 70% of the model context window. An oversized fork is reduced without
 mutating the parent request: unused tool schemas are removed first, and large
 tool argument/result payloads are replaced with explicit omission markers as
 needed. Source conversation turns are not dropped. If the fork still cannot
-fit, the summarizer rebuilds a bounded standalone request. The standalone path
-preserves newly uncovered conversation and, when `{previous_summary}` is used,
-may bound only that previous rolling summary; the fixed system prompt and
-user-prompt template remain intact.
+fit, the summarizer rebuilds a bounded standalone request. When that request can
+fit all newly uncovered conversation, the standalone path preserves it in full
+and, when `{previous_summary}` is used, may bound only that previous rolling
+summary; the fixed system prompt and user-prompt template remain intact.
 
 If all newly uncovered conversation cannot fit in one standalone request, the
 summarizer can process a complete older prefix and leave the remaining events

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -207,7 +207,8 @@ post-summary processing are complete. If even the smallest complete prefix does
 not fit, the request fails before calling the model and the existing boundary
 remains unchanged. Partial-prefix fallback is disabled when
 `WithPreSummaryHook(...)` is configured because hook-rewritten text cannot be
-mapped safely back to an event boundary.
+mapped safely back to an event boundary. Prefix summaries always use a
+standalone request; they do not reuse the cache-safe fork.
 
 Budget fitting and the fork-to-standalone decision happen before the
 `BeforeModel` callback. The callback therefore receives the actual request that
@@ -966,6 +967,12 @@ type PostSummaryHookContext struct {
 
 type PostSummaryHook func(in *PostSummaryHookContext) error
 ```
+
+The hook observes the provisional boundary for the source used to generate the
+summary. When the hook succeeds, or when its error is configured as non-aborting,
+the summarizer restores that exact source boundary after the hook; hook writes to
+the summary boundary state therefore do not persist. An aborting error or panic
+restores the boundary that existed before the summary attempt.
 
 ### Usage Example
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -190,13 +190,24 @@ Before sending either form of request, the summarizer admits it against the
 summary model's effective input budget. The framework uses the smaller of the
 provider-specific input budget, when the model exposes one, and a conservative
 ceiling of 70% of the model context window. An oversized fork is reduced without
-mutating the parent request: unused tool schemas are removed first, older
-complete source rounds can be dropped while the latest round is protected, and
-large tool argument/result payloads are replaced as needed. If the fork still
-cannot fit, the summarizer rebuilds a bounded standalone request. This fallback
-truncates the `{conversation_text}` and `{previous_summary}` payloads with
-head-and-tail preservation; the fixed system prompt and user-prompt template
-remain intact.
+mutating the parent request: unused tool schemas are removed first, and large
+tool argument/result payloads are replaced with explicit omission markers as
+needed. Source conversation turns are not dropped. If the fork still cannot
+fit, the summarizer rebuilds a bounded standalone request. The standalone path
+preserves newly uncovered conversation and, when `{previous_summary}` is used,
+may bound only that previous rolling summary; the fixed system prompt and
+user-prompt template remain intact.
+
+If all newly uncovered conversation cannot fit in one standalone request, the
+summarizer can process a complete older prefix and leave the remaining events
+uncovered for a later summary pass. A prefix must end at a stable event boundary
+and cannot split response chunks or an open tool call/result round. The summary
+boundary advances only through the selected prefix after model generation and
+post-summary processing are complete. If even the smallest complete prefix does
+not fit, the request fails before calling the model and the existing boundary
+remains unchanged. Partial-prefix fallback is disabled when
+`WithPreSummaryHook(...)` is configured because hook-rewritten text cannot be
+mapped safely back to an event boundary.
 
 Budget fitting and the fork-to-standalone decision happen before the
 `BeforeModel` callback. The callback therefore receives the actual request that
@@ -205,7 +216,8 @@ callback makes it exceed the budget, the call fails explicitly instead of
 silently replacing the callback-modified request. If a provider still returns a
 context-length error, or a non-custom model call returns an empty summary, the
 summarizer makes one bounded standalone retry at half of the first attempt's
-input budget.
+input budget. That retry may select a smaller complete prefix under the same
+boundary rules.
 
 One important branch-summary behavior: after `WithCacheSafeForking(true)` is
 enabled, a non-empty branch trigger may fork the current parent request for the

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -198,7 +198,8 @@ system prompt 和 user prompt 模板也会保持完整。
 只有模型生成与 post-summary 处理都完成后，summary boundary 才会推进到所选前缀。
 如果连最小的完整前缀都放不下，请求会在调用模型前失败，原 boundary 保持不变。
 配置 `WithPreSummaryHook(...)` 时不会启用部分前缀 fallback，因为 hook 重写后的文本
-无法安全映射回 event boundary。
+无法安全映射回 event boundary。前缀摘要始终使用 standalone 请求，不会复用
+cache-safe fork。
 
 预算适配和 fork → standalone 的选择发生在 `BeforeModel` callback 之前，因此
 callback 看到并修改的就是最终准备送模的请求。callback 返回后框架会再次计数；
@@ -915,6 +916,11 @@ type PostSummaryHookContext struct {
 
 type PostSummaryHook func(in *PostSummaryHookContext) error
 ```
+
+Hook 会看到本次 summary source 对应的临时 boundary。Hook 成功，或其错误被配置为
+不中断流程时，摘要器会在 Hook 返回后恢复该 source 的精确 boundary，因此 Hook 对
+summary boundary state 的写入不会保留。Hook 以错误中断或发生 panic 时，则恢复本次
+摘要尝试前的 boundary。
 
 ### 使用示例
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -188,9 +188,9 @@ summarizer := summary.NewSummarizer(
 70%”这层保守上限中的较小值。fork 请求超预算时，框架只修改 clone，不会污染父
 请求：先移除摘要调用不会使用的 tool schemas，必要时再用明确的省略标记替换较大
 的 tool arguments/results payload，但不会删除 source conversation turn。如果仍然
-放不下，再重建为 bounded standalone 请求。standalone 路径会完整保留尚未覆盖的
-新对话；使用 `{previous_summary}` 时，只允许压缩这块上一版滚动摘要。固定的
-system prompt 和 user prompt 模板也会保持完整。
+放不下，再重建为 bounded standalone 请求。当预算能够容纳全部尚未覆盖的新对话时，
+standalone 路径会完整保留这些内容；使用 `{previous_summary}` 时，只允许压缩这块
+上一版滚动摘要。固定的 system prompt 和 user prompt 模板也会保持完整。
 
 如果尚未覆盖的新对话无法一次放进 standalone 请求，摘要器可以先处理较旧的完整
 前缀，其余 events 保持未覆盖，留待后续摘要。前缀只能结束在稳定的 event 边界，

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -186,18 +186,26 @@ summarizer := summary.NewSummarizer(
 无论最终使用哪种请求，发送前都会按摘要模型的有效输入预算做准入检查：如果模型
 能够提供 provider-specific input budget，框架会取它与“模型 context window 的
 70%”这层保守上限中的较小值。fork 请求超预算时，框架只修改 clone，不会污染父
-请求：先移除摘要调用不会使用的 tool schemas，再按完整 source round 从旧到新
-缩减并保护最新一轮，必要时替换较大的 tool arguments/results payload。如果仍然
-放不下，再重建为 bounded standalone 请求。standalone fallback 会对
-`{conversation_text}` 和 `{previous_summary}` 两块 payload 做首尾保留截断，
-固定的 system prompt 和 user prompt 模板不会被截坏。
+请求：先移除摘要调用不会使用的 tool schemas，必要时再用明确的省略标记替换较大
+的 tool arguments/results payload，但不会删除 source conversation turn。如果仍然
+放不下，再重建为 bounded standalone 请求。standalone 路径会完整保留尚未覆盖的
+新对话；使用 `{previous_summary}` 时，只允许压缩这块上一版滚动摘要。固定的
+system prompt 和 user prompt 模板也会保持完整。
+
+如果尚未覆盖的新对话无法一次放进 standalone 请求，摘要器可以先处理较旧的完整
+前缀，其余 events 保持未覆盖，留待后续摘要。前缀只能结束在稳定的 event 边界，
+不能拆开同一 response 的 chunks，也不能拆开仍未闭合的 tool call/result round。
+只有模型生成与 post-summary 处理都完成后，summary boundary 才会推进到所选前缀。
+如果连最小的完整前缀都放不下，请求会在调用模型前失败，原 boundary 保持不变。
+配置 `WithPreSummaryHook(...)` 时不会启用部分前缀 fallback，因为 hook 重写后的文本
+无法安全映射回 event boundary。
 
 预算适配和 fork → standalone 的选择发生在 `BeforeModel` callback 之前，因此
 callback 看到并修改的就是最终准备送模的请求。callback 返回后框架会再次计数；
 如果 callback 自己把请求扩到超预算，会明确失败，而不是再次换请求并静默丢失
 callback 的修改。如果 provider 仍返回 context-length error，或者非 custom 的
 模型调用返回空 summary，摘要器会用第一次输入预算的一半再做一次 bounded
-standalone 重试。
+standalone 重试；这次重试也可以按相同的边界规则选择更小的完整前缀。
 
 这里有一个重要的 branch 摘要行为：开启 `WithCacheSafeForking(true)` 后，非空
 branch 触发摘要时，可以用当前父请求 fork 来生成 branch 摘要；但同一轮 summary

--- a/session/summary/options.go
+++ b/session/summary/options.go
@@ -220,7 +220,11 @@ func WithPreSummaryHook(h PreSummaryHook) Option {
 	}
 }
 
-// WithPostSummaryHook sets a post-summary hook to modify the summary before returning.
+// WithPostSummaryHook sets a post-summary hook to modify the summary before
+// returning. The hook observes the provisional boundary for the summarized
+// source. A successful or non-aborting hook keeps that exact boundary, replacing
+// any hook changes to the summary boundary state. An aborting or panicking hook
+// restores the boundary that existed before the summary attempt.
 func WithPostSummaryHook(h PostSummaryHook) Option {
 	return func(s *sessionSummarizer) {
 		s.postHook = h

--- a/session/summary/safe_prefix.go
+++ b/session/summary/safe_prefix.go
@@ -63,13 +63,6 @@ func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
 	if len(ends) == 0 {
 		return nil, false, nil
 	}
-	for len(ends) > 0 &&
-		joinSummaryEventTexts(source.prefixTexts[:ends[0]]) == "" {
-		ends = ends[1:]
-	}
-	if len(ends) == 0 {
-		return nil, false, nil
-	}
 
 	buildCandidate := func(end int) (
 		*model.Request,
@@ -160,7 +153,23 @@ func safeSummaryPrefixEndsForSource(source *summarySource) ([]int, error) {
 	for len(ends) > 0 && ends[len(ends)-1] >= len(source.prefixEvents) {
 		ends = ends[:len(ends)-1]
 	}
-	return ends, nil
+	return summaryPrefixEndsWithNewText(ends, source.prefixTexts), nil
+}
+
+func summaryPrefixEndsWithNewText(ends []int, texts []string) []int {
+	textIndex := 0
+	out := ends[:0]
+	for _, end := range ends {
+		for textIndex < end && texts[textIndex] == "" {
+			textIndex++
+		}
+		if textIndex >= end {
+			continue
+		}
+		out = append(out, end)
+		textIndex = end
+	}
+	return out
 }
 
 func (s *sessionSummarizer) extractConversationEventTexts(

--- a/session/summary/safe_prefix.go
+++ b/session/summary/safe_prefix.go
@@ -1,0 +1,265 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type summarySourceTooLargeError struct {
+	sourceTokens int
+	budget       int
+}
+
+func (e *summarySourceTooLargeError) Error() string {
+	return fmt.Sprintf(
+		"summary source conversation requires %d tokens but input budget is %d; refusing to omit unsummarized conversation",
+		e.sourceTokens,
+		e.budget,
+	)
+}
+
+func isSummarySourceTooLarge(err error) bool {
+	var target *summarySourceTooLargeError
+	return errors.As(err, &target)
+}
+
+type summarySource struct {
+	input            summaryPromptInput
+	boundaryEvents   []event.Event
+	boundary         summaryview.Boundary
+	hasBoundary      bool
+	prefixEvents     []event.Event
+	prefixTexts      []string
+	prefixBoundaries []summaryview.Boundary
+	allowPrefix      bool
+}
+
+func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
+	ctx context.Context,
+	source *summarySource,
+	budget int,
+) (*model.Request, bool, error) {
+	if source == nil || len(source.prefixEvents) == 0 {
+		return nil, false, nil
+	}
+	if len(source.prefixTexts) != len(source.prefixEvents) {
+		return nil, false, errors.New("summary prefix text does not match events")
+	}
+	if source.prefixBoundaries != nil &&
+		len(source.prefixBoundaries) != len(source.prefixEvents) {
+		return nil, false, errors.New("summary prefix boundary does not match events")
+	}
+	ends := safeSummaryPrefixEnds(source.prefixEvents)
+	if source.prefixBoundaries != nil {
+		mappedEnds := ends[:0]
+		for _, end := range ends {
+			if !source.prefixBoundaries[end-1].IsZero() {
+				mappedEnds = append(mappedEnds, end)
+			}
+		}
+		ends = mappedEnds
+	}
+	if len(ends) == 0 {
+		return nil, false, nil
+	}
+
+	buildCandidate := func(end int) (
+		*model.Request,
+		summaryPromptInput,
+		bool,
+		error,
+	) {
+		input := summaryPromptInput{
+			conversationText: joinSummaryEventTexts(source.prefixTexts[:end]),
+			previousSummary:  source.input.previousSummary,
+		}
+		if input.conversationText == "" {
+			return nil, input, false, nil
+		}
+		request, err := s.buildBoundedStandaloneSummaryRequest(
+			ctx,
+			input,
+			budget,
+		)
+		if isSummarySourceTooLarge(err) {
+			return nil, input, false, nil
+		}
+		if err != nil {
+			return nil, input, false, err
+		}
+		return request, input, true, nil
+	}
+
+	// Verify the smallest complete prefix first. This guarantees that the
+	// fallback either makes structural progress or keeps the original
+	// fail-closed behavior, independently of tokenization at later boundaries.
+	request, input, fits, err := buildCandidate(ends[0])
+	if err != nil || !fits {
+		return nil, false, err
+	}
+	bestRequest, bestInput, bestEnd := request, input, ends[0]
+
+	// Conversation prefixes grow monotonically in source content. Use bounded
+	// search to minimize repeated tokenization of large histories, validating
+	// every candidate against the fully rendered standalone request.
+	low, high := 1, len(ends)-1
+	for low <= high {
+		mid := low + (high-low)/2
+		request, input, fits, err = buildCandidate(ends[mid])
+		if err != nil {
+			return nil, false, err
+		}
+		if fits {
+			bestRequest, bestInput, bestEnd = request, input, ends[mid]
+			low = mid + 1
+			continue
+		}
+		high = mid - 1
+	}
+
+	source.input = bestInput
+	source.prefixEvents = source.prefixEvents[:bestEnd]
+	source.prefixTexts = source.prefixTexts[:bestEnd]
+	if source.prefixBoundaries != nil {
+		source.prefixBoundaries = source.prefixBoundaries[:bestEnd]
+		source.boundary = source.prefixBoundaries[bestEnd-1]
+		source.hasBoundary = true
+	} else {
+		source.boundaryEvents = source.prefixEvents
+		source.hasBoundary = false
+	}
+	return bestRequest, true, nil
+}
+
+func (s *sessionSummarizer) extractConversationEventTexts(
+	events []event.Event,
+) []string {
+	texts := make([]string, len(events))
+	for i := range events {
+		texts[i] = s.extractConversationText(events[i : i+1])
+	}
+	return texts
+}
+
+func joinSummaryEventTexts(texts []string) string {
+	nonEmpty := make([]string, 0, len(texts))
+	for _, text := range texts {
+		if text != "" {
+			nonEmpty = append(nonEmpty, text)
+		}
+	}
+	return strings.Join(nonEmpty, "\n")
+}
+
+// safeSummaryPrefixEnds returns exclusive event indexes where the raw tail
+// can begin without splitting a response stream or a tool call/result round.
+func safeSummaryPrefixEnds(events []event.Event) []int {
+	pendingToolCalls := make(map[string]struct{})
+	seenToolCalls := make(map[string]struct{})
+	hasUnmatchableToolCall := false
+	ends := make([]int, 0, len(events))
+	for i := range events {
+		evt := events[i]
+		for _, id := range summaryToolCallIDs(evt.Response) {
+			if id == "" {
+				hasUnmatchableToolCall = true
+				continue
+			}
+			if _, ok := seenToolCalls[id]; ok {
+				// Reused IDs make a later result ambiguous: it may complete
+				// either call. Keep the remainder raw instead of guessing.
+				hasUnmatchableToolCall = true
+				continue
+			}
+			seenToolCalls[id] = struct{}{}
+			pendingToolCalls[id] = struct{}{}
+		}
+		for _, id := range summaryToolResultIDs(evt.Response) {
+			delete(pendingToolCalls, id)
+		}
+
+		if hasUnmatchableToolCall || len(pendingToolCalls) != 0 ||
+			!canEndSummaryPrefix(events, i) {
+			continue
+		}
+		ends = append(ends, i+1)
+	}
+	return ends
+}
+
+func canEndSummaryPrefix(events []event.Event, index int) bool {
+	evt := events[index]
+	if evt.ID == "" || evt.Timestamp.IsZero() || evt.Response == nil ||
+		!evt.Response.IsValidContent() || evt.Response.IsPartial ||
+		evt.Response.IsUserMessage() ||
+		summaryResponseHasRole(evt.Response, model.RoleSystem) ||
+		evt.Author == authorUser || evt.Author == authorSystem ||
+		len(summaryToolCallIDs(evt.Response)) != 0 {
+		return false
+	}
+	if index+1 >= len(events) || evt.Response.ID == "" ||
+		events[index+1].Response == nil {
+		return true
+	}
+	return events[index+1].Response.ID != evt.Response.ID
+}
+
+func summaryResponseHasRole(response *model.Response, role model.Role) bool {
+	if response == nil {
+		return false
+	}
+	for _, choice := range response.Choices {
+		if choice.Message.Role == role || choice.Delta.Role == role {
+			return true
+		}
+	}
+	return false
+}
+
+func summaryToolCallIDs(response *model.Response) []string {
+	if response == nil {
+		return nil
+	}
+	var ids []string
+	for _, choice := range response.Choices {
+		for _, call := range choice.Message.ToolCalls {
+			ids = append(ids, call.ID)
+		}
+		for _, call := range choice.Delta.ToolCalls {
+			ids = append(ids, call.ID)
+		}
+	}
+	return ids
+}
+
+func summaryToolResultIDs(response *model.Response) []string {
+	if response == nil {
+		return nil
+	}
+	var ids []string
+	for _, choice := range response.Choices {
+		for _, message := range []model.Message{
+			choice.Message,
+			choice.Delta,
+		} {
+			if message.ToolID != "" {
+				ids = append(ids, message.ToolID)
+			}
+		}
+	}
+	return ids
+}

--- a/session/summary/safe_prefix.go
+++ b/session/summary/safe_prefix.go
@@ -63,6 +63,13 @@ func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
 	if len(ends) == 0 {
 		return nil, false, nil
 	}
+	for len(ends) > 0 &&
+		joinSummaryEventTexts(source.prefixTexts[:ends[0]]) == "" {
+		ends = ends[1:]
+	}
+	if len(ends) == 0 {
+		return nil, false, nil
+	}
 
 	buildCandidate := func(end int) (
 		*model.Request,
@@ -73,9 +80,6 @@ func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
 		input := summaryPromptInput{
 			conversationText: joinSummaryEventTexts(source.prefixTexts[:end]),
 			previousSummary:  source.input.previousSummary,
-		}
-		if input.conversationText == "" {
-			return nil, input, false, nil
 		}
 		request, err := s.buildBoundedStandaloneSummaryRequest(
 			ctx,

--- a/session/summary/safe_prefix.go
+++ b/session/summary/safe_prefix.go
@@ -73,6 +73,12 @@ func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
 		}
 		ends = mappedEnds
 	}
+	// A fallback must consume fewer events than the request that just failed.
+	// Exclude the full source even if it is itself a structurally safe boundary,
+	// so callers can treat selected=true as a strict progress guarantee.
+	for len(ends) > 0 && ends[len(ends)-1] >= len(source.prefixEvents) {
+		ends = ends[:len(ends)-1]
+	}
 	if len(ends) == 0 {
 		return nil, false, nil
 	}

--- a/session/summary/safe_prefix.go
+++ b/session/summary/safe_prefix.go
@@ -56,28 +56,9 @@ func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
 	if source == nil || len(source.prefixEvents) == 0 {
 		return nil, false, nil
 	}
-	if len(source.prefixTexts) != len(source.prefixEvents) {
-		return nil, false, errors.New("summary prefix text does not match events")
-	}
-	if source.prefixBoundaries != nil &&
-		len(source.prefixBoundaries) != len(source.prefixEvents) {
-		return nil, false, errors.New("summary prefix boundary does not match events")
-	}
-	ends := safeSummaryPrefixEnds(source.prefixEvents)
-	if source.prefixBoundaries != nil {
-		mappedEnds := ends[:0]
-		for _, end := range ends {
-			if !source.prefixBoundaries[end-1].IsZero() {
-				mappedEnds = append(mappedEnds, end)
-			}
-		}
-		ends = mappedEnds
-	}
-	// A fallback must consume fewer events than the request that just failed.
-	// Exclude the full source even if it is itself a structurally safe boundary,
-	// so callers can treat selected=true as a strict progress guarantee.
-	for len(ends) > 0 && ends[len(ends)-1] >= len(source.prefixEvents) {
-		ends = ends[:len(ends)-1]
+	ends, err := safeSummaryPrefixEndsForSource(source)
+	if err != nil {
+		return nil, false, err
 	}
 	if len(ends) == 0 {
 		return nil, false, nil
@@ -149,6 +130,33 @@ func (s *sessionSummarizer) buildSafeSummaryPrefixRequest(
 		source.hasBoundary = false
 	}
 	return bestRequest, true, nil
+}
+
+func safeSummaryPrefixEndsForSource(source *summarySource) ([]int, error) {
+	if len(source.prefixTexts) != len(source.prefixEvents) {
+		return nil, errors.New("summary prefix text does not match events")
+	}
+	if source.prefixBoundaries != nil &&
+		len(source.prefixBoundaries) != len(source.prefixEvents) {
+		return nil, errors.New("summary prefix boundary does not match events")
+	}
+	ends := safeSummaryPrefixEnds(source.prefixEvents)
+	if source.prefixBoundaries != nil {
+		mappedEnds := ends[:0]
+		for _, end := range ends {
+			if !source.prefixBoundaries[end-1].IsZero() {
+				mappedEnds = append(mappedEnds, end)
+			}
+		}
+		ends = mappedEnds
+	}
+	// A fallback must consume fewer events than the request that just failed.
+	// Exclude the full source even if it is itself a structurally safe boundary,
+	// so callers can treat selected=true as a strict progress guarantee.
+	for len(ends) > 0 && ends[len(ends)-1] >= len(source.prefixEvents) {
+		ends = ends[:len(ends)-1]
+	}
+	return ends, nil
 }
 
 func (s *sessionSummarizer) extractConversationEventTexts(

--- a/session/summary/safe_prefix_test.go
+++ b/session/summary/safe_prefix_test.go
@@ -339,6 +339,73 @@ func TestSessionSummarizer_SafePrefixFormatsEachToolPayloadOnce(t *testing.T) {
 	)
 }
 
+func TestSessionSummarizer_SafePrefixSkipsEmptyBoundaries(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "prefix summary",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		WithToolCallFormatter(func(model.ToolCall) string { return "" }),
+		WithToolResultFormatter(func(model.Message) string { return "" }),
+	).(*sessionSummarizer)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	events := []event.Event{
+		{
+			ID:        "tool-call-event",
+			Author:    "agent",
+			Timestamp: now,
+			Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+				Role:      model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{ID: "call-1"}},
+			}}}},
+		},
+		{
+			ID:        "tool-result-event",
+			Author:    "agent",
+			Timestamp: now.Add(time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "lookup", "result"),
+			}}},
+		},
+		newSummaryPrefixEvent(
+			"user-event", "user-response", authorUser, model.RoleUser,
+			"small request", now.Add(2*time.Second),
+		),
+		newSummaryPrefixEvent(
+			"assistant-event", "assistant-response", "agent",
+			model.RoleAssistant, "small response", now.Add(3*time.Second),
+		),
+		newSummaryPrefixEvent(
+			"large-user-event", "large-user-response", authorUser,
+			model.RoleUser, strings.Repeat("later request ", 96),
+			now.Add(4*time.Second),
+		),
+		newSummaryPrefixEvent(
+			"large-assistant-event", "large-assistant-response", "agent",
+			model.RoleAssistant, strings.Repeat("later response ", 96),
+			now.Add(5*time.Second),
+		),
+	}
+	prefixTokens := summaryPrefixRequestTokens(t, s, events[:4])
+	allTokens := summaryPrefixRequestTokens(t, s, events)
+	require.Greater(t, allTokens, prefixTokens)
+	capture.inputBudget = prefixTokens + (allTokens-prefixTokens)/2
+	sess := &session.Session{ID: "empty-boundary-session", Events: events}
+
+	text, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	require.Equal(t, "prefix summary", text)
+	require.Contains(t, capture.request.Messages[0].Content, "small response")
+	require.NotContains(t, capture.request.Messages[0].Content, "later request")
+	require.Equal(
+		t,
+		"assistant-event",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
 func TestSafeSummaryPrefixEnds_RejectsIncompleteBoundaries(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/session/summary/safe_prefix_test.go
+++ b/session/summary/safe_prefix_test.go
@@ -406,6 +406,73 @@ func TestSessionSummarizer_SafePrefixSkipsEmptyBoundaries(t *testing.T) {
 	)
 }
 
+func TestSessionSummarizer_SafePrefixDoesNotEndAfterEmptyBoundary(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "prefix summary",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		WithToolCallFormatter(func(model.ToolCall) string { return "" }),
+		WithToolResultFormatter(func(model.Message) string { return "" }),
+	).(*sessionSummarizer)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	events := []event.Event{
+		newSummaryPrefixEvent(
+			"user-event", "user-response", authorUser, model.RoleUser,
+			"small request", now,
+		),
+		newSummaryPrefixEvent(
+			"assistant-event", "assistant-response", "agent",
+			model.RoleAssistant, "small response", now.Add(time.Second),
+		),
+		{
+			ID:        "tool-call-event",
+			Author:    "agent",
+			Timestamp: now.Add(2 * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+				Role:      model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{ID: "call-1"}},
+			}}}},
+		},
+		{
+			ID:        "tool-result-event",
+			Author:    "agent",
+			Timestamp: now.Add(3 * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "lookup", "result"),
+			}}},
+		},
+		newSummaryPrefixEvent(
+			"large-user-event", "large-user-response", authorUser,
+			model.RoleUser, strings.Repeat("later request ", 96),
+			now.Add(4*time.Second),
+		),
+		newSummaryPrefixEvent(
+			"large-assistant-event", "large-assistant-response", "agent",
+			model.RoleAssistant, strings.Repeat("later response ", 96),
+			now.Add(5*time.Second),
+		),
+	}
+	prefixTokens := summaryPrefixRequestTokens(t, s, events[:4])
+	allTokens := summaryPrefixRequestTokens(t, s, events)
+	require.Greater(t, allTokens, prefixTokens)
+	capture.inputBudget = prefixTokens + (allTokens-prefixTokens)/2
+	sess := &session.Session{ID: "trailing-empty-boundary-session", Events: events}
+
+	text, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	require.Equal(t, "prefix summary", text)
+	require.Contains(t, capture.request.Messages[0].Content, "small response")
+	require.NotContains(t, capture.request.Messages[0].Content, "later request")
+	require.Equal(
+		t,
+		"assistant-event",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
 func TestSafeSummaryPrefixEnds_RejectsIncompleteBoundaries(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/session/summary/safe_prefix_test.go
+++ b/session/summary/safe_prefix_test.go
@@ -590,6 +590,36 @@ func TestSessionSummarizer_RetryShrinksSafePrefix(t *testing.T) {
 	)
 }
 
+func TestSessionSummarizer_SafePrefixRequiresStrictProgress(t *testing.T) {
+	s := NewSummarizer(
+		&cacheSafeCaptureModel{response: "summary", contextWindow: 100_000},
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+	).(*sessionSummarizer)
+	events := newSummaryPrefixRounds(1, 8)
+	texts := s.extractConversationEventTexts(events)
+	input := summaryPromptInput{conversationText: joinSummaryEventTexts(texts)}
+	source := &summarySource{
+		input:          input,
+		boundaryEvents: events,
+		prefixEvents:   events,
+		prefixTexts:    texts,
+		allowPrefix:    true,
+	}
+	budget := summaryPrefixRequestTokens(t, s, events)
+
+	request, selected, err := s.buildSafeSummaryPrefixRequest(
+		context.Background(),
+		source,
+		budget,
+	)
+	require.NoError(t, err)
+	require.False(t, selected)
+	require.Nil(t, request)
+	require.Equal(t, input, source.input)
+	require.Len(t, source.prefixEvents, len(events))
+	require.Len(t, source.boundaryEvents, len(events))
+}
+
 func TestSessionSummarizer_CommitsBoundaryAfterPostHook(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	evt := newSummaryPrefixEvent(

--- a/session/summary/safe_prefix_test.go
+++ b/session/summary/safe_prefix_test.go
@@ -1,0 +1,743 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summary
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummarycontext "trpc.group/trpc-go/trpc-agent-go/session/internal/summarycontext"
+)
+
+func TestSessionSummarizer_UsesLargestCompletePrefix(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		cacheSafeFork bool
+	}{
+		{name: "standalone"},
+		{name: "cache-safe fork", cacheSafeFork: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			capture := &cacheSafeCaptureModel{
+				response:      "prefix summary",
+				contextWindow: 100_000,
+			}
+			opts := []Option{
+				WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+			}
+			if test.cacheSafeFork {
+				opts = append(opts, WithCacheSafeForking(true))
+			}
+			s := NewSummarizer(capture, opts...).(*sessionSummarizer)
+			events := newSummaryPrefixRounds(3, 48)
+
+			twoRoundTokens := summaryPrefixRequestTokens(t, s, events[:4])
+			allRoundTokens := summaryPrefixRequestTokens(t, s, events)
+			require.Greater(t, allRoundTokens, twoRoundTokens)
+			capture.inputBudget = twoRoundTokens +
+				(allRoundTokens-twoRoundTokens)/2
+
+			ctx := context.Background()
+			if test.cacheSafeFork {
+				parent := &model.Request{Messages: []model.Message{
+					model.NewSystemMessage("stable system instruction"),
+					model.NewUserMessage(strings.Repeat("parent history ", 2_000)),
+				}}
+				ctx = ContextWithCacheSafeForkRequest(ctx, parent)
+			}
+			sess := &session.Session{ID: "prefix-session", Events: events}
+
+			text, err := s.Summarize(ctx, sess)
+			require.NoError(t, err)
+			require.Equal(t, "prefix summary", text)
+			require.NotNil(t, capture.request)
+			require.Len(t, capture.request.Messages, 1)
+			prompt := capture.request.Messages[0].Content
+			require.Contains(t, prompt, "user-marker-1")
+			require.Contains(t, prompt, "assistant-marker-2")
+			require.NotContains(t, prompt, "user-marker-3")
+			require.NotContains(t, prompt, "assistant-marker-3")
+			tokens, err := countSummaryRequestTokens(ctx, capture.request)
+			require.NoError(t, err)
+			require.LessOrEqual(t, tokens, capture.inputBudget)
+			require.Equal(
+				t,
+				"assistant-event-2",
+				string(sess.State[lastIncludedEventIDKey]),
+			)
+		})
+	}
+}
+
+func TestSessionSummarizer_SafePrefixUsesStoredBoundary(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "prefix summary",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+	).(*sessionSummarizer)
+	rawEvents := newSummaryPrefixRounds(3, 48)
+	effectiveEvents := append([]event.Event(nil), rawEvents...)
+	items := make([]summaryview.Item, len(effectiveEvents))
+	for i := range effectiveEvents {
+		effectiveEvents[i].ID = fmt.Sprintf("effective-event-%d", i+1)
+		items[i] = summaryview.Item{
+			Message:        effectiveEvents[i].Response.Choices[0].Message,
+			EffectiveEvent: effectiveEvents[i],
+			Boundary: summaryview.Boundary{
+				EventID:   rawEvents[i].ID,
+				Timestamp: rawEvents[i].Timestamp,
+			},
+		}
+	}
+	twoRoundTokens := summaryPrefixRequestTokens(t, s, effectiveEvents[:4])
+	allRoundTokens := summaryPrefixRequestTokens(t, s, effectiveEvents)
+	require.Greater(t, allRoundTokens, twoRoundTokens)
+	capture.inputBudget = twoRoundTokens +
+		(allRoundTokens-twoRoundTokens)/2
+	sess := &session.Session{ID: "mapped-prefix-session", Events: rawEvents}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID: sess.ID,
+		Items:     items,
+		Bound:     true,
+	})
+
+	text, err := s.Summarize(ctx, sess)
+	require.NoError(t, err)
+	require.Equal(t, "prefix summary", text)
+	require.Contains(t, capture.request.Messages[0].Content, "assistant-marker-2")
+	require.NotContains(t, capture.request.Messages[0].Content, "assistant-marker-3")
+	require.Equal(
+		t,
+		"assistant-event-2",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
+func TestSessionSummarizer_SafePrefixRollsPreviousSummary(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "rolling prefix summary",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt(
+			"Previous:\n{previous_summary}\n\nConversation:\n"+
+				"{conversation_text}\n\nSummary:",
+		),
+	).(*sessionSummarizer)
+	conversation := newSummaryPrefixRounds(3, 48)
+	twoRoundTokens := summaryPrefixRequestTokens(t, s, conversation[:4])
+	allRoundTokens := summaryPrefixRequestTokens(t, s, conversation)
+	require.Greater(t, allRoundTokens, twoRoundTokens)
+	capture.inputBudget = twoRoundTokens +
+		(allRoundTokens-twoRoundTokens)/2
+	previous := strings.Repeat("historical summary ", 2_000)
+	sess := &session.Session{
+		ID: "rolling-prefix-session",
+		Events: append([]event.Event{{
+			Author:    authorSystem,
+			Timestamp: time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{Content: previous},
+			}}},
+		}}, conversation...),
+	}
+	ctx := isummarycontext.WithPreviousSummary(context.Background(), previous)
+
+	text, err := s.Summarize(ctx, sess)
+	require.NoError(t, err)
+	require.Equal(t, "rolling prefix summary", text)
+	require.NotNil(t, capture.request)
+	prompt := capture.request.Messages[0].Content
+	require.Contains(t, prompt, "assistant-marker-2")
+	require.NotContains(t, prompt, "assistant-marker-3")
+	require.Contains(t, prompt, summaryPreviousOmitted)
+	require.Equal(
+		t,
+		"assistant-event-2",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
+func TestSessionSummarizer_SafePrefixKeepsConfiguredRecentEvents(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "prefix summary",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		WithSkipRecent(func([]event.Event) int { return 2 }),
+	).(*sessionSummarizer)
+	events := newSummaryPrefixRounds(4, 48)
+	twoRoundTokens := summaryPrefixRequestTokens(t, s, events[:4])
+	threeRoundTokens := summaryPrefixRequestTokens(t, s, events[:6])
+	require.Greater(t, threeRoundTokens, twoRoundTokens)
+	capture.inputBudget = twoRoundTokens +
+		(threeRoundTokens-twoRoundTokens)/2
+	sess := &session.Session{ID: "skip-recent-prefix-session", Events: events}
+
+	text, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	require.Equal(t, "prefix summary", text)
+	prompt := capture.request.Messages[0].Content
+	require.Contains(t, prompt, "assistant-marker-2")
+	require.NotContains(t, prompt, "assistant-marker-3")
+	require.NotContains(t, prompt, "assistant-marker-4")
+	require.Equal(
+		t,
+		"assistant-event-2",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
+func TestSessionSummarizer_SafePrefixPreservesToolRounds(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	events := []event.Event{
+		newSummaryPrefixEvent(
+			"user-event", "user-response", authorUser, model.RoleUser,
+			"request", now,
+		),
+		{
+			ID:           "tool-call-event",
+			RequestID:    "request-1",
+			InvocationID: "invocation-1",
+			Author:       "agent",
+			Timestamp:    now.Add(time.Second),
+			Response: &model.Response{
+				ID: "tool-call-response",
+				Choices: []model.Choice{{Message: model.Message{
+					Role: model.RoleAssistant,
+					ToolCalls: []model.ToolCall{
+						{ID: "call-1"},
+						{ID: "call-2"},
+					},
+				}}},
+			},
+		},
+		{
+			ID:           "first-tool-result",
+			RequestID:    "request-1",
+			InvocationID: "invocation-1",
+			Author:       "agent",
+			Timestamp:    now.Add(2 * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "lookup", "first"),
+			}}},
+		},
+		{
+			ID:           "second-tool-result",
+			RequestID:    "request-1",
+			InvocationID: "invocation-1",
+			Author:       "agent",
+			Timestamp:    now.Add(3 * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-2", "lookup", "second"),
+			}}},
+		},
+		newSummaryPrefixEvent(
+			"assistant-event", "assistant-response", "agent",
+			model.RoleAssistant, "complete", now.Add(4*time.Second),
+		),
+	}
+
+	require.Equal(t, []int{4, 5}, safeSummaryPrefixEnds(events))
+}
+
+func TestSessionSummarizer_SafePrefixFormatsEachToolPayloadOnce(t *testing.T) {
+	callFormats := 0
+	resultFormats := 0
+	capture := &cacheSafeCaptureModel{
+		response:      "prefix summary",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		WithToolCallFormatter(func(model.ToolCall) string {
+			callFormats++
+			return "[tool call]"
+		}),
+		WithToolResultFormatter(func(model.Message) string {
+			resultFormats++
+			return "[tool result]"
+		}),
+	).(*sessionSummarizer)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	events := []event.Event{
+		newSummaryPrefixEvent(
+			"user-event-1", "user-response-1", authorUser, model.RoleUser,
+			"request", now,
+		),
+		{
+			ID:        "tool-call-event",
+			Author:    "agent",
+			Timestamp: now.Add(time.Second),
+			Response: &model.Response{Choices: []model.Choice{{Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID: "call-1",
+				}},
+			}}}},
+		},
+		{
+			ID:        "tool-result-event",
+			Author:    "agent",
+			Timestamp: now.Add(2 * time.Second),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewToolMessage("call-1", "lookup", "result"),
+			}}},
+		},
+		newSummaryPrefixEvent(
+			"assistant-event-1", "assistant-response-1", "agent",
+			model.RoleAssistant, "complete", now.Add(3*time.Second),
+		),
+		newSummaryPrefixEvent(
+			"user-event-2", "user-response-2", authorUser, model.RoleUser,
+			strings.Repeat("later request ", 96), now.Add(4*time.Second),
+		),
+		newSummaryPrefixEvent(
+			"assistant-event-2", "assistant-response-2", "agent",
+			model.RoleAssistant, strings.Repeat("later response ", 96),
+			now.Add(5*time.Second),
+		),
+	}
+	prefixTokens := summaryPrefixRequestTokens(t, s, events[:4])
+	allTokens := summaryPrefixRequestTokens(t, s, events)
+	require.Greater(t, allTokens, prefixTokens)
+	capture.inputBudget = prefixTokens + (allTokens-prefixTokens)/2
+	callFormats = 0
+	resultFormats = 0
+	sess := &session.Session{ID: "formatter-prefix-session", Events: events}
+
+	_, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	require.Equal(t, 1, callFormats)
+	require.Equal(t, 1, resultFormats)
+	require.Equal(
+		t,
+		"assistant-event-1",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
+func TestSafeSummaryPrefixEnds_RejectsIncompleteBoundaries(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("response chunks stay together", func(t *testing.T) {
+		events := []event.Event{
+			newSummaryPrefixEvent(
+				"user-event", "user-response", authorUser, model.RoleUser,
+				"request", now,
+			),
+			newSummaryPrefixEvent(
+				"assistant-chunk-1", "shared-response", "agent",
+				model.RoleAssistant, "first", now.Add(time.Second),
+			),
+			newSummaryPrefixEvent(
+				"assistant-chunk-2", "shared-response", "agent",
+				model.RoleAssistant, "second", now.Add(2*time.Second),
+			),
+		}
+		events[1].Response.IsPartial = true
+
+		require.Equal(t, []int{3}, safeSummaryPrefixEnds(events))
+	})
+
+	t.Run("delta tool round stays together", func(t *testing.T) {
+		events := []event.Event{
+			{
+				ID:        "delta-call",
+				Author:    "agent",
+				Timestamp: now,
+				Response: &model.Response{Choices: []model.Choice{{
+					Delta: model.Message{
+						Role:      model.RoleAssistant,
+						ToolCalls: []model.ToolCall{{ID: "call-1"}},
+					},
+				}}},
+			},
+			{
+				ID:        "delta-result",
+				Author:    "agent",
+				Timestamp: now.Add(time.Second),
+				Response: &model.Response{Choices: []model.Choice{{
+					Delta: model.Message{
+						Role:    model.RoleTool,
+						ToolID:  "call-1",
+						Content: "result",
+					},
+				}}},
+			},
+		}
+
+		require.Equal(t, []int{2}, safeSummaryPrefixEnds(events))
+	})
+
+	t.Run("anonymous tool call stays open", func(t *testing.T) {
+		events := []event.Event{
+			newSummaryPrefixEvent(
+				"assistant-event-1", "assistant-response-1", "agent",
+				model.RoleAssistant, "complete", now,
+			),
+			{
+				ID:        "anonymous-call",
+				Author:    "agent",
+				Timestamp: now.Add(time.Second),
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						Role:      model.RoleAssistant,
+						ToolCalls: []model.ToolCall{{}},
+					},
+				}}},
+			},
+			newSummaryPrefixEvent(
+				"assistant-event-2", "assistant-response-2", "agent",
+				model.RoleAssistant, "later", now.Add(2*time.Second),
+			),
+		}
+
+		require.Equal(t, []int{1}, safeSummaryPrefixEnds(events))
+	})
+
+	t.Run("reused tool call ID stays ambiguous", func(t *testing.T) {
+		toolCall := func(id string, timestamp time.Time) event.Event {
+			return event.Event{
+				ID:        id,
+				Author:    "agent",
+				Timestamp: timestamp,
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.Message{
+						Role: model.RoleAssistant,
+						ToolCalls: []model.ToolCall{{
+							ID: "reused-call",
+						}},
+					},
+				}}},
+			}
+		}
+		toolResult := func(id string, timestamp time.Time) event.Event {
+			return event.Event{
+				ID:        id,
+				Author:    "agent",
+				Timestamp: timestamp,
+				Response: &model.Response{Choices: []model.Choice{{
+					Message: model.NewToolMessage(
+						"reused-call", "lookup", "result",
+					),
+				}}},
+			}
+		}
+		events := []event.Event{
+			toolCall("call-event-1", now),
+			toolResult("result-event-1", now.Add(time.Second)),
+			toolCall("call-event-2", now.Add(2*time.Second)),
+			toolResult("result-event-2", now.Add(3*time.Second)),
+			newSummaryPrefixEvent(
+				"assistant-event", "assistant-response", "agent",
+				model.RoleAssistant, "later", now.Add(4*time.Second),
+			),
+		}
+
+		require.Equal(t, []int{2}, safeSummaryPrefixEnds(events))
+	})
+
+	t.Run("unstable events are not cut points", func(t *testing.T) {
+		missingID := newSummaryPrefixEvent(
+			"", "assistant-response-1", "agent", model.RoleAssistant,
+			"first", now,
+		)
+		missingTimestamp := newSummaryPrefixEvent(
+			"assistant-event-2", "assistant-response-2", "agent",
+			model.RoleAssistant, "second", time.Time{},
+		)
+
+		require.Empty(
+			t,
+			safeSummaryPrefixEnds([]event.Event{missingID, missingTimestamp}),
+		)
+	})
+
+	t.Run("system event is not a cut point", func(t *testing.T) {
+		evt := newSummaryPrefixEvent(
+			"system-event", "system-response", "agent", model.RoleSystem,
+			"instruction", now,
+		)
+
+		require.Empty(t, safeSummaryPrefixEnds([]event.Event{evt}))
+	})
+}
+
+func TestSessionSummarizer_DoesNotPrefixHookRewrittenInput(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "must not be called",
+		contextWindow: 100_000,
+	}
+	events := newSummaryPrefixRounds(3, 48)
+	hookCalls := 0
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		WithPreSummaryHook(func(*PreSummaryHookContext) error {
+			hookCalls++
+			return nil
+		}),
+	).(*sessionSummarizer)
+	twoRoundTokens := summaryPrefixRequestTokens(t, s, events[:4])
+	allRoundTokens := summaryPrefixRequestTokens(t, s, events)
+	capture.inputBudget = twoRoundTokens + (allRoundTokens-twoRoundTokens)/2
+	sess := &session.Session{ID: "hook-session", Events: events}
+
+	_, err := s.Summarize(context.Background(), sess)
+	require.ErrorContains(t, err, "refusing to omit unsummarized conversation")
+	require.Equal(t, 1, hookCalls)
+	require.Nil(t, capture.request)
+	assert.NotContains(t, sess.State, lastIncludedTsKey)
+	assert.NotContains(t, sess.State, lastIncludedEventIDKey)
+}
+
+func TestSessionSummarizer_RejectsOversizedCompletePrefix(t *testing.T) {
+	capture := &cacheSafeCaptureModel{
+		response:      "must not be called",
+		contextWindow: 100_000,
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+	).(*sessionSummarizer)
+	events := newSummaryPrefixRounds(2, 96)
+	oneRoundTokens := summaryPrefixRequestTokens(t, s, events[:2])
+	require.Greater(t, oneRoundTokens, 1)
+	capture.inputBudget = oneRoundTokens - 1
+	sess := &session.Session{ID: "oversized-prefix-session", Events: events}
+
+	_, err := s.Summarize(context.Background(), sess)
+	require.ErrorContains(t, err, "refusing to omit unsummarized conversation")
+	require.Nil(t, capture.request)
+	assert.NotContains(t, sess.State, lastIncludedTsKey)
+	assert.NotContains(t, sess.State, lastIncludedEventIDKey)
+}
+
+func TestSessionSummarizer_RetryShrinksSafePrefix(t *testing.T) {
+	code := "context_length_exceeded"
+	capture := &retrySummaryModel{
+		contextWindow: 100_000,
+		responses: []*model.Response{
+			{
+				Done: true,
+				Error: &model.ResponseError{
+					Message: "maximum context length exceeded",
+					Code:    &code,
+				},
+			},
+			{
+				Done: true,
+				Choices: []model.Choice{{Message: model.Message{
+					Role:    model.RoleAssistant,
+					Content: "smaller prefix summary",
+				}}},
+			},
+		},
+	}
+	s := NewSummarizer(
+		capture,
+		WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+	).(*sessionSummarizer)
+	events := newSummaryPrefixRounds(3, 48)
+	oneRoundTokens := summaryPrefixRequestTokens(t, s, events[:2])
+	twoRoundTokens := summaryPrefixRequestTokens(t, s, events[:4])
+	allRoundTokens := summaryPrefixRequestTokens(t, s, events)
+	minimumBudget := max(twoRoundTokens, 2*oneRoundTokens)
+	maximumBudget := min(allRoundTokens-1, 2*twoRoundTokens-1)
+	require.LessOrEqual(t, minimumBudget, maximumBudget)
+	capture.inputBudget = minimumBudget
+	sess := &session.Session{ID: "retry-prefix-session", Events: events}
+
+	text, err := s.Summarize(context.Background(), sess)
+	require.NoError(t, err)
+	require.Equal(t, "smaller prefix summary", text)
+	require.Len(t, capture.requests, 2)
+	require.Contains(t, capture.requests[0].Messages[0].Content,
+		"assistant-marker-2")
+	require.NotContains(t, capture.requests[0].Messages[0].Content,
+		"assistant-marker-3")
+	require.Contains(t, capture.requests[1].Messages[0].Content,
+		"assistant-marker-1")
+	require.NotContains(t, capture.requests[1].Messages[0].Content,
+		"assistant-marker-2")
+	require.Equal(
+		t,
+		"assistant-event-1",
+		string(sess.State[lastIncludedEventIDKey]),
+	)
+}
+
+func TestSessionSummarizer_CommitsBoundaryAfterPostHook(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	evt := newSummaryPrefixEvent(
+		"event-1", "response-1", authorUser, model.RoleUser, "request", now,
+	)
+
+	t.Run("aborting hook leaves boundary unchanged", func(t *testing.T) {
+		var hookBoundary string
+		s := NewSummarizer(
+			&cacheSafeCaptureModel{response: "summary", contextWindow: 1_000},
+			WithPostSummaryHook(func(in *PostSummaryHookContext) error {
+				hookBoundary = string(
+					in.Session.State[lastIncludedEventIDKey],
+				)
+				return assert.AnError
+			}),
+			WithSummaryHookAbortOnError(true),
+		)
+		sess := &session.Session{ID: "post-hook-error", Events: []event.Event{evt}}
+		sess.SetState(lastIncludedTsKey, []byte("previous-timestamp"))
+		sess.SetState(lastIncludedEventIDKey, []byte("previous-event"))
+
+		_, err := s.Summarize(context.Background(), sess)
+		require.ErrorContains(t, err, "post-summary hook failed")
+		require.Equal(t, "event-1", hookBoundary)
+		require.Equal(
+			t,
+			"previous-timestamp",
+			string(sess.State[lastIncludedTsKey]),
+		)
+		require.Equal(
+			t,
+			"previous-event",
+			string(sess.State[lastIncludedEventIDKey]),
+		)
+	})
+
+	t.Run("non-aborting hook commits successful summary", func(t *testing.T) {
+		s := NewSummarizer(
+			&cacheSafeCaptureModel{response: "summary", contextWindow: 1_000},
+			WithPostSummaryHook(func(in *PostSummaryHookContext) error {
+				in.Session.SetState(
+					lastIncludedEventIDKey,
+					[]byte("hook-boundary"),
+				)
+				return assert.AnError
+			}),
+			WithSummaryHookAbortOnError(false),
+		)
+		sess := &session.Session{ID: "post-hook-ignored", Events: []event.Event{evt}}
+
+		text, err := s.Summarize(context.Background(), sess)
+		require.NoError(t, err)
+		require.Equal(t, "summary", text)
+		require.Equal(t, "event-1", string(sess.State[lastIncludedEventIDKey]))
+	})
+
+	t.Run("panicking hook restores previous boundary", func(t *testing.T) {
+		s := NewSummarizer(
+			&cacheSafeCaptureModel{response: "summary", contextWindow: 1_000},
+			WithPostSummaryHook(func(*PostSummaryHookContext) error {
+				panic("hook panic")
+			}),
+		)
+		sess := &session.Session{ID: "post-hook-panic", Events: []event.Event{evt}}
+		sess.SetState(lastIncludedTsKey, []byte("previous-timestamp"))
+		sess.SetState(lastIncludedEventIDKey, []byte("previous-event"))
+
+		require.Panics(t, func() {
+			_, _ = s.Summarize(context.Background(), sess)
+		})
+		require.Equal(
+			t,
+			"previous-timestamp",
+			string(sess.State[lastIncludedTsKey]),
+		)
+		require.Equal(
+			t,
+			"previous-event",
+			string(sess.State[lastIncludedEventIDKey]),
+		)
+	})
+}
+
+func newSummaryPrefixRounds(rounds int, repeatedWords int) []event.Event {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	events := make([]event.Event, 0, rounds*2)
+	for i := 1; i <= rounds; i++ {
+		events = append(
+			events,
+			newSummaryPrefixEvent(
+				fmt.Sprintf("user-event-%d", i),
+				fmt.Sprintf("user-response-%d", i),
+				authorUser,
+				model.RoleUser,
+				fmt.Sprintf("user-marker-%d %s", i,
+					strings.Repeat("request ", repeatedWords)),
+				now.Add(time.Duration(len(events))*time.Second),
+			),
+			newSummaryPrefixEvent(
+				fmt.Sprintf("assistant-event-%d", i),
+				fmt.Sprintf("assistant-response-%d", i),
+				"agent",
+				model.RoleAssistant,
+				fmt.Sprintf("assistant-marker-%d %s", i,
+					strings.Repeat("response ", repeatedWords)),
+				now.Add(time.Duration(len(events)+1)*time.Second),
+			),
+		)
+	}
+	return events
+}
+
+func newSummaryPrefixEvent(
+	eventID string,
+	responseID string,
+	author string,
+	role model.Role,
+	content string,
+	timestamp time.Time,
+) event.Event {
+	return event.Event{
+		ID:           eventID,
+		RequestID:    "request-1",
+		InvocationID: "invocation-1",
+		Author:       author,
+		Timestamp:    timestamp,
+		Response: &model.Response{
+			ID: responseID,
+			Choices: []model.Choice{{Message: model.Message{
+				Role:    role,
+				Content: content,
+			}}},
+		},
+	}
+}
+
+func summaryPrefixRequestTokens(
+	t *testing.T,
+	s *sessionSummarizer,
+	events []event.Event,
+) int {
+	t.Helper()
+	request, err := s.buildStandaloneSummaryRequest(summaryPromptInput{
+		conversationText: s.extractConversationText(events),
+	})
+	require.NoError(t, err)
+	tokens, err := countSummaryRequestTokens(context.Background(), request)
+	require.NoError(t, err)
+	return tokens
+}

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -1381,7 +1381,7 @@ func (s *sessionSummarizer) runSummaryAttemptWithPrefixFallback(
 			result.err = fmt.Errorf("build safe summary prefix request: %w", err)
 			return result
 		}
-		if !selected {
+		if !selected || len(source.prefixEvents) >= totalEvents {
 			return result
 		}
 

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -445,6 +445,7 @@ type summaryEventSelection struct {
 	events       []event.Event
 	sourceEvents []event.Event
 	itemIndexes  []int
+	boundaries   []summaryview.Boundary
 	boundary     summaryview.Boundary
 	effective    bool
 }
@@ -472,6 +473,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 	viewEvents := view.Events()
 	events := make([]event.Event, 0, len(viewEvents)+1)
 	itemIndexes := make([]int, 0, len(viewEvents))
+	boundaries := make([]summaryview.Boundary, 0, len(viewEvents)+1)
 	for i := range viewEvents {
 		if len(filterSummaryInputEventsForSession(
 			[]event.Event{viewEvents[i]},
@@ -481,6 +483,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		}
 		events = append(events, viewEvents[i])
 		itemIndexes = append(itemIndexes, i)
+		boundaries = append(boundaries, view.Items[i].Boundary)
 	}
 	hasPreviousSummaryHead := view.PreviousSummary != "" &&
 		!view.PreviousSummaryInItems
@@ -489,8 +492,12 @@ func (s *sessionSummarizer) selectSummaryEvents(
 			[]event.Event{previousSummaryEvent(view.PreviousSummary)},
 			events...,
 		)
+		boundaries = append([]summaryview.Boundary{{}}, boundaries...)
 	}
 	events = s.filterEventsForSummary(events)
+	if len(boundaries) > len(events) {
+		boundaries = boundaries[:len(events)]
+	}
 	itemCount := len(events)
 	if hasPreviousSummaryHead && itemCount > 0 {
 		itemCount--
@@ -502,6 +509,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		events:       events,
 		sourceEvents: events,
 		itemIndexes:  itemIndexes,
+		boundaries:   boundaries,
 		effective:    true,
 	}
 	if boundary, found := view.BoundaryForItems(itemIndexes); found {
@@ -516,6 +524,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		selection.events = nil
 		selection.sourceEvents = nil
 		selection.itemIndexes = nil
+		selection.boundaries = nil
 	}
 	return selection
 }
@@ -577,13 +586,19 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	selection := s.selectSummaryEvents(ctx, sess)
 	eventsToSummarize := selection.events
 	conversationEvents := eventsToSummarize
+	conversationBoundaries := selection.boundaries
 	sourceEvents := selection.sourceEvents
 	input := summaryPromptInput{}
 	if separatePreviousSummary {
+		conversationEventCount := len(conversationEvents)
 		conversationEvents = removePreviousSummaryEvent(
 			conversationEvents,
 			previousSummary,
 		)
+		if len(conversationBoundaries) == conversationEventCount &&
+			len(conversationEvents) < conversationEventCount {
+			conversationBoundaries = conversationBoundaries[1:]
+		}
 		sourceEvents = removePreviousSummaryEvent(
 			sourceEvents,
 			previousSummary,
@@ -591,7 +606,8 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 		input.previousSummary = previousSummary
 	}
 
-	input.conversationText = s.extractConversationText(conversationEvents)
+	conversationEventTexts := s.extractConversationEventTexts(conversationEvents)
+	input.conversationText = joinSummaryEventTexts(conversationEventTexts)
 	ctx, input, err := s.runPreSummaryHook(
 		ctx,
 		sess,
@@ -610,32 +626,54 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 		ctx = contextWithModelVisibleItems(ctx, selection.itemIndexes)
 	}
 
-	ctx, summaryText, err := s.generateSummary(ctx, sess, input)
+	source := &summarySource{
+		input:            input,
+		boundaryEvents:   eventsToSummarize,
+		boundary:         selection.boundary,
+		hasBoundary:      selection.effective && !selection.boundary.IsZero(),
+		prefixEvents:     conversationEvents,
+		prefixTexts:      conversationEventTexts,
+		prefixBoundaries: conversationBoundaries,
+		// Pre-summary hooks may rewrite the source text independently of the
+		// event slice. Without an explicit mapping, advancing a partial event
+		// boundary would not prove what the model actually summarized.
+		allowPrefix: s.preHook == nil,
+	}
+	ctx, summaryText, err := s.generateSummary(ctx, sess, source)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate summary for session %s: %w", sess.ID, err)
 	}
-
-	if selection.effective && !selection.boundary.IsZero() {
-		s.recordIncludedBoundary(sess, selection.boundary)
-	} else {
-		s.recordLastIncludedBoundary(sess, eventsToSummarize)
+	if s.postHook == nil {
+		s.recordSummarySourceBoundary(sess, source)
+		return summaryText, nil
 	}
 
-	if s.postHook != nil {
-		hookCtx := &PostSummaryHookContext{
-			Ctx:     ctx,
-			Session: sess,
-			Summary: summaryText,
+	previousBoundary := captureSummaryBoundaryState(sess)
+	s.recordSummarySourceBoundary(sess, source)
+	boundaryCommitted := false
+	defer func() {
+		if !boundaryCommitted {
+			previousBoundary.restore(sess)
 		}
-		hookErr := s.postHook(hookCtx)
-		if hookErr != nil && s.hookAbortOnError {
-			return "", fmt.Errorf("post-summary hook failed: %w", hookErr)
-		}
-		if hookErr == nil && hookCtx.Summary != "" {
-			summaryText = hookCtx.Summary
-		}
+	}()
+
+	hookCtx := &PostSummaryHookContext{
+		Ctx:     ctx,
+		Session: sess,
+		Summary: summaryText,
+	}
+	hookErr := s.postHook(hookCtx)
+	if hookErr != nil && s.hookAbortOnError {
+		return "", fmt.Errorf("post-summary hook failed: %w", hookErr)
+	}
+	if hookErr == nil && hookCtx.Summary != "" {
+		summaryText = hookCtx.Summary
 	}
 
+	// The cutoff must describe the source that produced summaryText even when a
+	// hook mutates session state for other purposes.
+	s.recordSummarySourceBoundary(sess, source)
+	boundaryCommitted = true
 	return summaryText, nil
 }
 
@@ -773,6 +811,57 @@ func (s *sessionSummarizer) recordIncludedBoundary(
 		return
 	}
 	sess.SetState(lastIncludedEventIDKey, []byte(boundary.EventID))
+}
+
+func (s *sessionSummarizer) recordSummarySourceBoundary(
+	sess *session.Session,
+	source *summarySource,
+) {
+	if source == nil {
+		return
+	}
+	if source.hasBoundary {
+		s.recordIncludedBoundary(sess, source.boundary)
+		return
+	}
+	s.recordLastIncludedBoundary(sess, source.boundaryEvents)
+}
+
+type summaryBoundaryState struct {
+	timestamp    []byte
+	hasTimestamp bool
+	eventID      []byte
+	hasEventID   bool
+}
+
+func captureSummaryBoundaryState(sess *session.Session) summaryBoundaryState {
+	if sess == nil {
+		return summaryBoundaryState{}
+	}
+	timestamp, hasTimestamp := sess.GetState(lastIncludedTsKey)
+	eventID, hasEventID := sess.GetState(lastIncludedEventIDKey)
+	return summaryBoundaryState{
+		timestamp:    timestamp,
+		hasTimestamp: hasTimestamp,
+		eventID:      eventID,
+		hasEventID:   hasEventID,
+	}
+}
+
+func (state summaryBoundaryState) restore(sess *session.Session) {
+	if sess == nil {
+		return
+	}
+	if state.hasTimestamp {
+		sess.SetState(lastIncludedTsKey, state.timestamp)
+	} else {
+		sess.DeleteState(lastIncludedTsKey)
+	}
+	if state.hasEventID {
+		sess.SetState(lastIncludedEventIDKey, state.eventID)
+	} else {
+		sess.DeleteState(lastIncludedEventIDKey)
+	}
 }
 
 func (s *sessionSummarizer) buildCheckSession(
@@ -1084,7 +1173,7 @@ func extractReasoningContent(events []event.Event) string {
 func (s *sessionSummarizer) generateSummary(
 	ctx context.Context,
 	sess *session.Session,
-	input summaryPromptInput,
+	source *summarySource,
 ) (context.Context, string, error) {
 	// Telemetry trace + metrics tracking (aligned with toolsearch/llm_search.go).
 	var err error
@@ -1095,7 +1184,7 @@ func (s *sessionSummarizer) generateSummary(
 	_, span := trace.Tracer.Start(ctx, itelemetry.NewChatSpanName(modelName))
 	defer span.End()
 
-	request, mode, err := s.buildSummaryRequest(ctx, input)
+	request, mode, err := s.buildSummaryRequest(ctx, source.input)
 	if err != nil {
 		err = fmt.Errorf("failed to build summary request: %w", err)
 		s.emitReport(ctx, err)
@@ -1169,7 +1258,7 @@ func (s *sessionSummarizer) generateSummary(
 		ctx,
 		request,
 		mode,
-		input,
+		source,
 		trackResponse,
 		ensureTimingInfo,
 	)
@@ -1180,15 +1269,15 @@ func (s *sessionSummarizer) runSummaryAttempts(
 	ctx context.Context,
 	request *model.Request,
 	mode string,
-	input summaryPromptInput,
+	source *summarySource,
 	trackResponse func(*model.Response),
 	ensureTimingInfo func(*model.Response),
 ) (context.Context, string, *model.Response, error) {
-	result := s.runSummaryAttempt(
+	result := s.runSummaryAttemptWithPrefixFallback(
 		ctx,
 		request,
 		mode,
-		input,
+		source,
 		0,
 		trackResponse,
 		ensureTimingInfo,
@@ -1203,7 +1292,7 @@ func (s *sessionSummarizer) runSummaryAttempts(
 	) {
 		return result.ctx, "", result.response, summaryAttemptError(
 			result.err,
-			input,
+			source.input,
 		)
 	}
 
@@ -1213,9 +1302,22 @@ func (s *sessionSummarizer) runSummaryAttempts(
 	)
 	retryRequest, buildErr := s.buildBoundedStandaloneSummaryRequest(
 		result.ctx,
-		input,
+		source.input,
 		retryBudget,
 	)
+	if buildErr != nil && source.allowPrefix &&
+		isSummarySourceTooLarge(buildErr) {
+		originalBuildErr := buildErr
+		var selected bool
+		retryRequest, selected, buildErr = s.buildSafeSummaryPrefixRequest(
+			result.ctx,
+			source,
+			retryBudget,
+		)
+		if !selected && buildErr == nil {
+			buildErr = originalBuildErr
+		}
+	}
 	if buildErr != nil {
 		return result.ctx, "", result.response, fmt.Errorf(
 			"build summary retry request: %w",
@@ -1227,11 +1329,11 @@ func (s *sessionSummarizer) runSummaryAttempts(
 		"retrying summary with standalone bounded input: budget=%d",
 		retryBudget,
 	)
-	result = s.runSummaryAttempt(
+	result = s.runSummaryAttemptWithPrefixFallback(
 		result.ctx,
 		retryRequest,
 		callModeStandalone,
-		input,
+		source,
 		retryBudget,
 		trackResponse,
 		ensureTimingInfo,
@@ -1239,10 +1341,61 @@ func (s *sessionSummarizer) runSummaryAttempts(
 	if result.err != nil || result.summaryText == "" {
 		return result.ctx, "", result.response, summaryAttemptError(
 			result.err,
-			input,
+			source.input,
 		)
 	}
 	return result.ctx, result.summaryText, result.response, nil
+}
+
+func (s *sessionSummarizer) runSummaryAttemptWithPrefixFallback(
+	ctx context.Context,
+	request *model.Request,
+	mode string,
+	source *summarySource,
+	budgetLimit int,
+	trackResponse func(*model.Response),
+	ensureTimingInfo func(*model.Response),
+) summaryAttemptResult {
+	for {
+		result := s.runSummaryAttempt(
+			ctx,
+			request,
+			mode,
+			source.input,
+			budgetLimit,
+			trackResponse,
+			ensureTimingInfo,
+		)
+		if result.err == nil || !source.allowPrefix ||
+			!isSummarySourceTooLarge(result.err) {
+			return result
+		}
+
+		totalEvents := len(source.prefixEvents)
+		bounded, selected, err := s.buildSafeSummaryPrefixRequest(
+			result.ctx,
+			source,
+			result.budget,
+		)
+		if err != nil {
+			result.err = fmt.Errorf("build safe summary prefix request: %w", err)
+			return result
+		}
+		if !selected {
+			return result
+		}
+
+		log.DebugfContext(
+			result.ctx,
+			"summary source exceeds input budget; retrying a complete prefix: included_events=%d total_events=%d budget=%d",
+			len(source.boundaryEvents),
+			totalEvents,
+			result.budget,
+		)
+		*request = *bounded
+		ctx = result.ctx
+		mode = callModeStandalone
+	}
 }
 
 func shouldRetrySummary(
@@ -1564,11 +1717,10 @@ func (s *sessionSummarizer) buildBoundedStandaloneSummaryRequest(
 		return nil, err
 	}
 	if sourceTokens > budget {
-		return nil, fmt.Errorf(
-			"summary source conversation requires %d tokens but input budget is %d; refusing to omit unsummarized conversation",
-			sourceTokens,
-			budget,
-		)
+		return nil, &summarySourceTooLargeError{
+			sourceTokens: sourceTokens,
+			budget:       budget,
+		}
 	}
 	if input.previousSummary == "" {
 		return sourceOnly, nil

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -643,6 +643,15 @@ func (s *sessionSummarizer) Summarize(ctx context.Context, sess *session.Session
 	if err != nil {
 		return "", fmt.Errorf("failed to generate summary for session %s: %w", sess.ID, err)
 	}
+	return s.finalizeSummary(ctx, sess, source, summaryText)
+}
+
+func (s *sessionSummarizer) finalizeSummary(
+	ctx context.Context,
+	sess *session.Session,
+	source *summarySource,
+	summaryText string,
+) (string, error) {
 	if s.postHook == nil {
 		s.recordSummarySourceBoundary(sess, source)
 		return summaryText, nil
@@ -1388,7 +1397,7 @@ func (s *sessionSummarizer) runSummaryAttemptWithPrefixFallback(
 		log.DebugfContext(
 			result.ctx,
 			"summary source exceeds input budget; retrying a complete prefix: included_events=%d total_events=%d budget=%d",
-			len(source.boundaryEvents),
+			len(source.prefixEvents),
 			totalEvents,
 			result.budget,
 		)

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -1028,6 +1028,7 @@ func (m *cacheSafeCaptureModel) InputTokenBudget(
 
 type retrySummaryModel struct {
 	contextWindow int
+	inputBudget   int
 	requests      []*model.Request
 	responses     []*model.Response
 }
@@ -1050,6 +1051,13 @@ func (m *retrySummaryModel) GenerateContent(
 	ch <- response
 	close(ch)
 	return ch, nil
+}
+
+func (m *retrySummaryModel) InputTokenBudget(
+	context.Context,
+	*model.Request,
+) int {
+	return m.inputBudget
 }
 
 type testTool struct {


### PR DESCRIPTION
## What changed

Oversized session histories can now be summarized in complete older prefixes instead of failing or omitting conversation that the model did not see. The remaining events stay uncovered for a later pass, and the persisted cutoff matches the exact prefix used to produce the summary.

The same boundary guarantees apply when the provider rejects the first request for context length. When summary input comes from the finalized model-visible projection, every eligible prefix retains its mapping to the corresponding stored-event boundary. Empty formatted boundaries are skipped when a later complete prefix contains summarizable text. Documentation now describes the prefix behavior and its hook-related safety constraints.

## Why

A standalone summary request previously had to contain all newly uncovered conversation. Once that source alone exceeded the input budget, the framework correctly refused to truncate it, but compaction could no longer make progress.

Selecting a complete prefix restores progress without weakening the no-data-loss invariant. Prefixes never split response chunks or an open tool call/result round, and an unsuccessful model call or aborting post-summary hook leaves the previous cutoff unchanged.

## Testing

- `go test ./session/summary ./session/internal/summary -count=1`
- `go test -race ./session/summary ./session/internal/summary -count=1`
- `go build ./...`
- `go test ./... -count=1`
- `.github/scripts/run-go-tests.sh`
- `cd test && go test ./... -count=1`
- `.github/scripts/check-examples.sh`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=10m`
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`

The two full-root test commands encounter the repository's macOS Unix-socket path-length failure in `tool/duckduckgo` when the default temporary directory is long. That package passes when rerun with a short temporary directory; all other packages pass in those runs.

## Notes for reviewers

This change adds no exported API. Requests that already fit retain their existing request shape and callback behavior. Partial-prefix fallback remains disabled when a pre-summary hook is configured because hook-rewritten text cannot be proven to correspond to an event boundary.

For model-visible summary input, safe-prefix selection advances persistence only to the stored-event boundary mapped to the selected prefix. A prefix without a stored boundary is not eligible.
