### PR TITLE
model/anthropic: recognize the Claude 5 family as adaptive-thinking models

### DIFF
--- a/model/anthropic/adaptive_thinking_test.go
+++ b/model/anthropic/adaptive_thinking_test.go
@@ -35,6 +35,7 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		"claude-opus-4-8",
 		"claude-4.8-opus",
 		"claude-opus-4-7",
+		"claude-4.7-opus",
 		"claude-opus-4-6",
 		"claude-4.6-opus",
 		"claude-sonnet-4-6",
@@ -96,7 +97,11 @@ func TestApplyThinkingConfigDisabled(t *testing.T) {
 	// An adaptive model that CAN be disabled says so explicitly, so the server-side
 	// default does not decide instead.
 	t.Run("disableable adaptive models send disabled", func(t *testing.T) {
-		for _, name := range []string{"claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-4.8-opus"} {
+		for _, name := range []string{
+			"claude-opus-5", "claude-sonnet-5",
+			"claude-opus-4-8", "claude-4.8-opus",
+			"claude-opus-4-7", "claude-4.7-opus",
+		} {
 			t.Run(name, func(t *testing.T) {
 				chatReq, err := disabledThinkingRequest(t, name)
 				require.NoError(t, err)

--- a/model/anthropic/adaptive_thinking_test.go
+++ b/model/anthropic/adaptive_thinking_test.go
@@ -33,6 +33,7 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		"claude-opus-5",
 		"claude-sonnet-5",
 		"claude-opus-4-8",
+		"claude-4.8-opus",
 		"claude-opus-4-7",
 		"claude-opus-4-6",
 		"claude-4.6-opus",
@@ -73,4 +74,54 @@ func TestApplyThinkingConfigAdaptiveCarriesEffort(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, chatReq.Thinking.OfAdaptive, "adaptive thinking config was not applied")
 	assert.Equal(t, anthropicsdk.OutputConfigEffort("medium"), chatReq.OutputConfig.Effort)
+}
+
+// ThinkingEnabled=false takes three different paths, and only one of them is a
+// no-op — so the false branch needs covering per model family, not once.
+func TestApplyThinkingConfigDisabled(t *testing.T) {
+	// Always-on models reject `thinking.type=disabled` with a 400, so the request
+	// is refused here rather than sent. Anthropic documents Fable 5 and Mythos 5
+	// alongside Mythos Preview as always-on:
+	// https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#supported-models
+	t.Run("always-on models are refused", func(t *testing.T) {
+		for _, name := range []string{"claude-mythos-preview", "claude-fable-5", "claude-mythos-5"} {
+			t.Run(name, func(t *testing.T) {
+				_, err := disabledThinkingRequest(t, name)
+				require.Error(t, err, "%s cannot have thinking disabled", name)
+				assert.Contains(t, err.Error(), name, "the error must name the model the caller passed")
+			})
+		}
+	})
+
+	// An adaptive model that CAN be disabled says so explicitly, so the server-side
+	// default does not decide instead.
+	t.Run("disableable adaptive models send disabled", func(t *testing.T) {
+		for _, name := range []string{"claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-4.8-opus"} {
+			t.Run(name, func(t *testing.T) {
+				chatReq, err := disabledThinkingRequest(t, name)
+				require.NoError(t, err)
+				assert.NotNil(t, chatReq.Thinking.OfDisabled, "%s should send thinking.type=disabled", name)
+			})
+		}
+	})
+
+	// A pre-adaptive model has no thinking field to disable; sending one would be
+	// rejected, so the request carries nothing.
+	t.Run("pre-adaptive models send no thinking field", func(t *testing.T) {
+		chatReq, err := disabledThinkingRequest(t, "claude-haiku-4-5")
+		require.NoError(t, err)
+		assert.Nil(t, chatReq.Thinking.OfDisabled)
+		assert.Nil(t, chatReq.Thinking.OfAdaptive)
+		assert.Nil(t, chatReq.Thinking.OfEnabled)
+	})
+}
+
+func disabledThinkingRequest(t *testing.T, modelName string) (*anthropicsdk.MessageNewParams, error) {
+	t.Helper()
+	thinking := false
+	return New(modelName).buildChatRequest(&model.Request{
+		Messages:         []model.Message{model.NewUserMessage("u")},
+		GenerationConfig: model.GenerationConfig{ThinkingEnabled: &thinking},
+		Tools:            map[string]tool.Tool{},
+	})
 }

--- a/model/anthropic/adaptive_thinking_test.go
+++ b/model/anthropic/adaptive_thinking_test.go
@@ -1,0 +1,76 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package anthropic
+
+import (
+	"testing"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// The adaptive-thinking model list decides whether ReasoningEffort reaches the
+// API at all: a model missing from it falls through to the fixed-budget branch,
+// which needs ThinkingTokens, and with none set the request carries NO thinking
+// field — so the server-side default silently decides how much the model thinks,
+// and the caller's effort setting is dropped without an error. Newer models
+// reject a fixed budget outright, so the list is the only path they have.
+func TestSupportsAdaptiveThinking(t *testing.T) {
+	adaptive := []string{
+		"claude-fable-5",
+		"claude-mythos-5",
+		"claude-opus-5",
+		"claude-sonnet-5",
+		"claude-opus-4-8",
+		"claude-opus-4-7",
+		"claude-opus-4-6",
+		"claude-4.6-opus",
+		"claude-sonnet-4-6",
+		"claude-4.6-sonnet",
+		"claude-mythos-preview",
+		// Dated snapshots share the family prefix.
+		"claude-opus-5-20260101",
+	}
+	for _, name := range adaptive {
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, supportsAdaptiveThinking(name), "%s should support adaptive thinking", name)
+		})
+	}
+
+	older := []string{"claude-haiku-4-5", "claude-3-7-sonnet", "claude-test"}
+	for _, name := range older {
+		t.Run(name, func(t *testing.T) {
+			assert.False(t, supportsAdaptiveThinking(name), "%s predates adaptive thinking", name)
+		})
+	}
+}
+
+// An adaptive model must carry both the adaptive config and the caller's effort.
+func TestApplyThinkingConfigAdaptiveCarriesEffort(t *testing.T) {
+	m := New("claude-opus-5")
+	thinking := true
+	effort := "medium"
+	req := &model.Request{
+		Messages: []model.Message{model.NewUserMessage("u")},
+		GenerationConfig: model.GenerationConfig{
+			ThinkingEnabled: &thinking,
+			ReasoningEffort: &effort,
+		},
+		Tools: map[string]tool.Tool{},
+	}
+	chatReq, err := m.buildChatRequest(req)
+	require.NoError(t, err)
+	require.NotNil(t, chatReq.Thinking.OfAdaptive, "adaptive thinking config was not applied")
+	assert.Equal(t, anthropicsdk.OutputConfigEffort("medium"), chatReq.OutputConfig.Effort)
+}

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -40,6 +40,11 @@ import (
 const (
 	functionToolType       = "function"
 	claudeMythosPreview    = "claude-mythos-preview"
+	claudeFable5           = "claude-fable-5"
+	claudeMythos5          = "claude-mythos-5"
+	claudeOpus5            = "claude-opus-5"
+	claudeSonnet5          = "claude-sonnet-5"
+	claudeOpus48           = "claude-opus-4-8"
 	claudeOpus47           = "claude-opus-4-7"
 	claudeOpus46           = "claude-opus-4-6"
 	claudeOpus46Alias      = "claude-4.6-opus"
@@ -414,6 +419,11 @@ func supportsAdaptiveThinking(modelName string) bool {
 	return modelNameMatches(
 		modelName,
 		claudeMythosPreview,
+		claudeFable5,
+		claudeMythos5,
+		claudeOpus5,
+		claudeSonnet5,
+		claudeOpus48,
 		claudeOpus47,
 		claudeOpus46,
 		claudeOpus46Alias,

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -45,6 +45,7 @@ const (
 	claudeOpus5            = "claude-opus-5"
 	claudeSonnet5          = "claude-sonnet-5"
 	claudeOpus48           = "claude-opus-4-8"
+	claudeOpus48Alias      = "claude-4.8-opus"
 	claudeOpus47           = "claude-opus-4-7"
 	claudeOpus46           = "claude-opus-4-6"
 	claudeOpus46Alias      = "claude-4.6-opus"
@@ -383,7 +384,7 @@ func (m *Model) applyThinkingConfig(
 		return nil
 	}
 	if !*request.ThinkingEnabled {
-		if isClaudeMythosPreview(m.name) {
+		if isAlwaysThinking(m.name) {
 			return fmt.Errorf("anthropic: thinking cannot be disabled for model %s", m.name)
 		}
 		if !supportsAdaptiveThinking(m.name) {
@@ -424,6 +425,7 @@ func supportsAdaptiveThinking(modelName string) bool {
 		claudeOpus5,
 		claudeSonnet5,
 		claudeOpus48,
+		claudeOpus48Alias,
 		claudeOpus47,
 		claudeOpus46,
 		claudeOpus46Alias,
@@ -432,8 +434,12 @@ func supportsAdaptiveThinking(modelName string) bool {
 	)
 }
 
-func isClaudeMythosPreview(modelName string) bool {
-	return modelNameMatches(modelName, claudeMythosPreview)
+// isAlwaysThinking reports whether a model thinks unconditionally, so that
+// `thinking.type=disabled` is not merely ignored but rejected by the API.
+// Sending it for one of these turns a caller's explicit ThinkingEnabled=false
+// into a 400, so the request is refused here with a message naming the model.
+func isAlwaysThinking(modelName string) bool {
+	return modelNameMatches(modelName, claudeMythosPreview, claudeFable5, claudeMythos5)
 }
 
 func modelNameMatches(modelName string, targets ...string) bool {

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -47,6 +47,7 @@ const (
 	claudeOpus48           = "claude-opus-4-8"
 	claudeOpus48Alias      = "claude-4.8-opus"
 	claudeOpus47           = "claude-opus-4-7"
+	claudeOpus47Alias      = "claude-4.7-opus"
 	claudeOpus46           = "claude-opus-4-6"
 	claudeOpus46Alias      = "claude-4.6-opus"
 	claudeSonnet46         = "claude-sonnet-4-6"
@@ -427,6 +428,7 @@ func supportsAdaptiveThinking(modelName string) bool {
 		claudeOpus48,
 		claudeOpus48Alias,
 		claudeOpus47,
+		claudeOpus47Alias,
 		claudeOpus46,
 		claudeOpus46Alias,
 		claudeSonnet46,


### PR DESCRIPTION
## What changed

`claude-fable-5`, `claude-mythos-5`, `claude-opus-5`, `claude-sonnet-5` and
`claude-opus-4-8` now resolve as adaptive-thinking models, so a caller's
`ReasoningEffort` reaches the API on those models. Dated snapshots match by
family prefix, as with the models already on the list.

## Why

`supportsAdaptiveThinking` is what decides whether `ReasoningEffort` is sent at
all. A model missing from the list falls through to the fixed-budget branch,
which requires `ThinkingTokens`; with none set, the request carries no thinking
field whatsoever. The caller's effort setting is dropped without an error, and
the server-side default silently decides how much the model thinks.

That is a quiet correctness problem rather than a missing feature: a caller can
set high effort, observe no error, and get default-effort responses. It is
unrecoverable on newer models, which reject a fixed thinking budget outright —
the adaptive path is the only one they have, so an unlisted model cannot be
given a thinking configuration by any means.

`claude-mythos-preview` was already listed; the released members of the same
generation were not.

## Testing

- `go test ./...` in `model/anthropic`.
- `TestSupportsAdaptiveThinking` asserts every adaptive model in the list,
  including a dated snapshot, and asserts that pre-adaptive models
  (`claude-haiku-4-5`, `claude-3-7-sonnet`) and an unknown name still return
  false.
- `TestApplyThinkingConfigAdaptiveCarriesEffort` builds a real chat request for
  `claude-opus-5` and asserts the adaptive thinking config is present and
  carries the caller's effort, which is the behavior that was silently missing.

## Notes for reviewers

- No public API change; the model list is internal.
- This is a list that must be extended for each new model generation. If
  maintainers would prefer a rule (for example, treating an unrecognized
  `claude-` model as adaptive and letting the API reject it) rather than an
  explicit allowlist, this is the natural place to discuss it — the current
  failure mode of an unlisted model is silent, which argues against an
  allowlist that must be kept current.