### PR TITLE
tool/function: let function tools declare that they are not concurrency-safe

### DIFF
--- a/tool/function/concurrency_test.go
+++ b/tool/function/concurrency_test.go
@@ -1,0 +1,89 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package function
+
+import (
+	"context"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type concurrencyInput struct{}
+
+type concurrencyOutput struct{}
+
+func concurrencyFn(context.Context, concurrencyInput) (concurrencyOutput, error) {
+	return concurrencyOutput{}, nil
+}
+
+func concurrencyStreamFn(context.Context, concurrencyInput) (*tool.StreamReader, error) {
+	return nil, nil
+}
+
+// The default must stay true. A function tool now always satisfies
+// tool.ConcurrencyAware, so a false default would take every existing function
+// tool off the parallel path without its author changing anything.
+func TestFunctionToolConcurrencySafeDefaultsToTrue(t *testing.T) {
+	ft := NewFunctionTool(concurrencyFn, WithName("f"), WithDescription("d"))
+	if !ft.IsConcurrencySafe() {
+		t.Error("a function tool must default to concurrency-safe")
+	}
+	if !tool.MetadataOf(tool.Tool(ft)).ConcurrencySafe {
+		t.Error("the default must also resolve as safe through tool.MetadataOf")
+	}
+}
+
+func TestFunctionToolConcurrencySafeOptIn(t *testing.T) {
+	tests := []struct {
+		name string
+		safe bool
+	}{
+		{"declared unsafe", false},
+		{"declared safe", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ft := NewFunctionTool(
+				concurrencyFn,
+				WithName("f"),
+				WithDescription("d"),
+				WithConcurrencySafe(tt.safe),
+			)
+			if got := ft.IsConcurrencySafe(); got != tt.safe {
+				t.Fatalf("IsConcurrencySafe() = %v, want %v", got, tt.safe)
+			}
+			if got := tool.MetadataOf(tool.Tool(ft)).ConcurrencySafe; got != tt.safe {
+				t.Fatalf("tool.MetadataOf().ConcurrencySafe = %v, want %v", got, tt.safe)
+			}
+		})
+	}
+}
+
+// The streamable tool shares the option type, so it must share the behavior.
+func TestStreamableFunctionToolConcurrencySafe(t *testing.T) {
+	st := NewStreamableFunctionTool[concurrencyInput, concurrencyOutput](
+		concurrencyStreamFn,
+		WithName("s"),
+		WithDescription("d"),
+	)
+	if !st.IsConcurrencySafe() {
+		t.Error("a streamable function tool must default to concurrency-safe")
+	}
+
+	unsafe := NewStreamableFunctionTool[concurrencyInput, concurrencyOutput](
+		concurrencyStreamFn,
+		WithName("s"),
+		WithDescription("d"),
+		WithConcurrencySafe(false),
+	)
+	if tool.MetadataOf(tool.Tool(unsafe)).ConcurrencySafe {
+		t.Error("WithConcurrencySafe(false) must reach tool.MetadataOf")
+	}
+}

--- a/tool/function/function_tool.go
+++ b/tool/function/function_tool.go
@@ -38,6 +38,10 @@ type FunctionTool[I, O any] struct {
 	// skipSummarization indicates whether the outer flow should skip
 	// the post-tool summarization step after this tool returns.
 	skipSummarization bool
+	// concurrencySafe reports whether this tool may share a turn with others on
+	// the parallel tool path. It defaults to true, which is how a tool that
+	// publishes nothing at all is already read.
+	concurrencySafe bool
 }
 
 // Option is a function that configures a FunctionTool.
@@ -50,6 +54,7 @@ type functionToolOptions struct {
 	unmarshaler       unmarshaler
 	longRunning       bool
 	skipSummarization bool
+	concurrencySafe   bool
 	inputSchema       *tool.Schema
 	outputSchema      *tool.Schema
 }
@@ -93,6 +98,20 @@ func WithSkipSummarization(skip bool) Option {
 	}
 }
 
+// WithConcurrencySafe sets whether the function tool tolerates running at the
+// same time as the other tool calls in a turn. It defaults to true.
+//
+// Set it to false for a tool whose calls contend for something the caller cannot
+// see — a shared working directory, an external process, a session the tool
+// reads back after writing. The value is published through tool.ConcurrencyAware
+// so schedulers and host policies can honor it; a tool that says nothing is read
+// as safe, which is why the default here is true.
+func WithConcurrencySafe(safe bool) Option {
+	return func(opts *functionToolOptions) {
+		opts.concurrencySafe = safe
+	}
+}
+
 // WithInputSchema sets a custom input schema for the function tool.
 // When provided, the automatic schema generation will be skipped.
 func WithInputSchema(schema *tool.Schema) Option {
@@ -120,7 +139,8 @@ func WithOutputSchema(schema *tool.Schema) Option {
 func NewFunctionTool[I, O any](fn func(context.Context, I) (O, error), opts ...Option) *FunctionTool[I, O] {
 	// Set default options
 	options := &functionToolOptions{
-		unmarshaler: &jsonUnmarshaler{},
+		unmarshaler:     &jsonUnmarshaler{},
+		concurrencySafe: true,
 	}
 
 	// Apply provided options
@@ -162,6 +182,7 @@ func NewFunctionTool[I, O any](fn func(context.Context, I) (O, error), opts ...O
 		inputSchema:       iSchema,
 		outputSchema:      oSchema,
 		skipSummarization: options.skipSummarization,
+		concurrencySafe:   options.concurrencySafe,
 	}
 }
 
@@ -193,6 +214,13 @@ func (ft *FunctionTool[I, O]) LongRunning() bool {
 // outer-agent summarization after tool.response.
 func (ft *FunctionTool[I, O]) SkipSummarization() bool {
 	return ft.skipSummarization
+}
+
+// IsConcurrencySafe reports whether this tool may run at the same time as the
+// other tool calls in a turn, implementing tool.ConcurrencyAware. It is true
+// unless WithConcurrencySafe(false) was given.
+func (ft *FunctionTool[I, O]) IsConcurrencySafe() bool {
+	return ft.concurrencySafe
 }
 
 // Declaration returns the tool's declaration information.
@@ -230,6 +258,8 @@ type StreamableFunctionTool[I, O any] struct {
 	unmarshaler  unmarshaler
 	// skipSummarization has the same meaning as in FunctionTool.
 	skipSummarization bool
+	// concurrencySafe has the same meaning as in FunctionTool.
+	concurrencySafe bool
 }
 
 // NewStreamableFunctionTool creates a new StreamableFunctionTool instance.
@@ -244,7 +274,8 @@ type StreamableFunctionTool[I, O any] struct {
 func NewStreamableFunctionTool[I, O any](fn func(context.Context, I) (*tool.StreamReader, error), opts ...Option) *StreamableFunctionTool[I, O] {
 	// Set default options
 	options := &functionToolOptions{
-		unmarshaler: &jsonUnmarshaler{},
+		unmarshaler:     &jsonUnmarshaler{},
+		concurrencySafe: true,
 	}
 
 	// Apply provided options
@@ -280,6 +311,7 @@ func NewStreamableFunctionTool[I, O any](fn func(context.Context, I) (*tool.Stre
 		inputSchema:       iSchema,
 		outputSchema:      oSchema,
 		skipSummarization: options.skipSummarization,
+		concurrencySafe:   options.concurrencySafe,
 	}
 }
 
@@ -337,6 +369,13 @@ func (t *StreamableFunctionTool[I, O]) LongRunning() bool {
 // outer-agent summarization after tool.response.
 func (t *StreamableFunctionTool[I, O]) SkipSummarization() bool {
 	return t.skipSummarization
+}
+
+// IsConcurrencySafe reports whether this tool may run at the same time as the
+// other tool calls in a turn, implementing tool.ConcurrencyAware. It is true
+// unless WithConcurrencySafe(false) was given.
+func (t *StreamableFunctionTool[I, O]) IsConcurrencySafe() bool {
+	return t.concurrencySafe
 }
 
 type unmarshaler interface {


### PR DESCRIPTION
## What changed

`function.WithConcurrencySafe(bool)` lets a function tool publish whether it
tolerates running at the same time as the other tool calls in a turn. Both
`FunctionTool` and `StreamableFunctionTool` now implement
`tool.ConcurrencyAware`, and both default to true.

## Why

`tool.ConcurrencyAware` and `ToolMetadata.ConcurrencySafe` already exist, but
`tool/function` had no way to reach them. That leaves the framework's most
common tool type unable to say the one thing about itself that a scheduler or a
host policy most needs to know, so the property is only available to authors who
hand-roll a type implementing `tool.Tool`.

The tools that need it are not exotic. A tool that rewrites a shared working
directory, drives a single external process, or writes to a session and then
reads it back cannot be run beside its siblings, and today the only way to
express that is to stop using `tool/function`.

**On the default.** A function tool now always satisfies
`tool.ConcurrencyAware`, so the default is not a style choice — it decides what
every existing function tool reports. True is the only safe value: it is how a
tool that publishes nothing is already treated, so no existing tool changes
behavior.

## Testing

- `go test ./tool/... ./agent/... ./internal/flow/...`
- `TestFunctionToolConcurrencySafeDefaultsToTrue` pins the default, which is the
  compatibility-critical part.
- `TestFunctionToolConcurrencySafeOptIn` covers both explicit values through the
  method and through `tool.MetadataOf`.
- `TestStreamableFunctionToolConcurrencySafe` covers the streamable variant,
  which shares the option type and so must share the behavior.

The one failure in that run, `tool/duckduckgo`'s
`TestNewDefaultHTTPClient_UsesTransportNetwork`, is a pre-existing local
environment problem (a macOS temp path too long for a unix socket) and is
unrelated to this change.

## Notes for reviewers

- **Public API.** Adds `function.WithConcurrencySafe` and an
  `IsConcurrencySafe()` method on both function tool types.
- **One observable change.** `tool.MetadataOf` on a function tool previously
  returned the zero `ToolMetadata`; it now returns
  `{ConcurrencySafe: true}`, because the type satisfies `ConcurrencyAware`. A
  host policy that reads `MetadataOf(t).ConcurrencySafe` on function tools would
  have been reading false for every one of them, which was never accurate — but
  it is a change, and worth a second opinion on whether it needs a release note.
- This makes the property expressible; it does not by itself change scheduling.
  #2415 is the change that acts on it.