### PR TITLE
knowledge: support pluggable resource and graph stores

### DIFF
--- a/knowledge/default.go
+++ b/knowledge/default.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -28,10 +29,12 @@ import (
 	"github.com/panjf2000/ants/v2"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/embedder"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/loader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/query"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/reranker"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/reranker/topk"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/retriever"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
@@ -52,6 +55,8 @@ const (
 // BuiltinKnowledge implements the Knowledge interface with a built-in retriever.
 type BuiltinKnowledge struct {
 	vectorStore   vectorstore.VectorStore
+	graphStore    graphstore.Store
+	resourceStore resourcestore.Store
 	embedder      embedder.Embedder
 	retriever     retriever.Retriever
 	queryEnhancer query.Enhancer
@@ -67,6 +72,8 @@ type BuiltinKnowledge struct {
 	processingIDMu   sync.Mutex                       // mutex for make consistent of read and write processingDocIDs
 	enableSourceSync bool                             // enable source sync, if true, will keep document in vectorstore be synced with source
 	dataOperationMu  sync.RWMutex                     // mutex for make sequence of data operations
+	closeOnce        sync.Once
+	closeErr         error
 }
 
 // BuiltinDocumentInfo stores the basic information of a document for incremental sync
@@ -119,8 +126,10 @@ func New(opts ...Option) *BuiltinKnowledge {
 		opt(dk)
 	}
 
-	// Create built-in retriever if not provided.
-	if dk.retriever == nil {
+	// Create the built-in retriever only when its required vector backend is
+	// configured. Graph-only and resource-only instances remain valid and make
+	// document Search fail explicitly instead of dereferencing a nil store.
+	if dk.retriever == nil && dk.vectorStore != nil {
 		// Use defaults if not specified.
 		if dk.queryEnhancer == nil {
 			dk.queryEnhancer = query.NewPassthroughEnhancer()
@@ -1134,21 +1143,34 @@ func hasSearchFilter(filter *SearchFilter) bool {
 
 // Close closes the knowledge base and releases resources.
 func (dk *BuiltinKnowledge) Close() error {
-	dk.dataOperationMu.Lock()
-	defer dk.dataOperationMu.Unlock()
+	dk.closeOnce.Do(func() {
+		dk.dataOperationMu.Lock()
+		defer dk.dataOperationMu.Unlock()
 
-	// Close components if they support closing.
-	if dk.retriever != nil {
-		if err := dk.retriever.Close(); err != nil {
-			return fmt.Errorf("failed to close retriever: %w", err)
+		var errs []error
+		if dk.retriever != nil {
+			if err := dk.retriever.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to close retriever: %w", err))
+			}
 		}
-	}
-	if dk.vectorStore != nil {
-		if err := dk.vectorStore.Close(); err != nil {
-			return fmt.Errorf("failed to close vector store: %w", err)
+		if dk.vectorStore != nil {
+			if err := dk.vectorStore.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to close vector store: %w", err))
+			}
 		}
-	}
-	return nil
+		if dk.graphStore != nil {
+			if err := dk.graphStore.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to close graph store: %w", err))
+			}
+		}
+		if dk.resourceStore != nil {
+			if err := dk.resourceStore.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to close resource store: %w", err))
+			}
+		}
+		dk.closeErr = errors.Join(errs...)
+	})
+	return dk.closeErr
 }
 
 // convertQueryFilter converts retriever.QueryFilter to vectorstore.SearchFilter.

--- a/knowledge/default.go
+++ b/knowledge/default.go
@@ -126,10 +126,7 @@ func New(opts ...Option) *BuiltinKnowledge {
 		opt(dk)
 	}
 
-	// Create the built-in retriever only when its required vector backend is
-	// configured. Graph-only and resource-only instances remain valid and make
-	// document Search fail explicitly instead of dereferencing a nil store.
-	if dk.retriever == nil && dk.vectorStore != nil {
+	if dk.retriever == nil {
 		// Use defaults if not specified.
 		if dk.queryEnhancer == nil {
 			dk.queryEnhancer = query.NewPassthroughEnhancer()
@@ -206,6 +203,9 @@ func (dk *BuiltinKnowledge) AddSource(ctx context.Context, src source.Source, op
 	if src == nil {
 		return fmt.Errorf("source cannot be nil")
 	}
+	if dk.vectorStore == nil {
+		return fmt.Errorf("vector store not configured")
+	}
 
 	// check if source already exists
 	for _, dkSrc := range dk.sources {
@@ -213,13 +213,16 @@ func (dk *BuiltinKnowledge) AddSource(ctx context.Context, src source.Source, op
 			return fmt.Errorf("source with name %s already exists", src.Name())
 		}
 	}
+	if err := dk.validateResourceSourceIDs(append(slices.Clone(dk.sources), src)); err != nil {
+		return fmt.Errorf("invalid resource source: %w", err)
+	}
 	if dk.enableSourceSync {
 		if err := dk.refreshSourceDocInfo(ctx, src.Name()); err != nil {
 			return fmt.Errorf("failed to update vector store metadata: %w", err)
 		}
 	}
 	config := dk.buildLoadConfig(1, opts...)
-	if err := dk.loadSourceInternal(ctx, []source.Source{src}, config); err != nil {
+	if _, err := dk.loadSourceInternal(ctx, []source.Source{src}, config); err != nil {
 		return fmt.Errorf("failed to load source: %w", err)
 	}
 	if dk.enableSourceSync {
@@ -239,21 +242,30 @@ func (dk *BuiltinKnowledge) ReloadSource(ctx context.Context, src source.Source,
 	if src == nil {
 		return fmt.Errorf("source cannot be nil")
 	}
+	if dk.vectorStore == nil {
+		return fmt.Errorf("vector store not configured")
+	}
 
 	// Find the source by name
 	sourceName := src.Name()
 	var oldSource source.Source
+	sourceIndex := -1
 
-	// find and remove old source from sources list
+	// Keep the old source registered until the replacement is fully loaded.
 	for i, existingSource := range dk.sources {
 		if existingSource.Name() == sourceName {
 			oldSource = existingSource
-			dk.sources = append(dk.sources[:i], dk.sources[i+1:]...)
+			sourceIndex = i
 			break
 		}
 	}
 	if oldSource == nil {
 		return fmt.Errorf("source with name %s not found", sourceName)
+	}
+	candidateSources := slices.Clone(dk.sources)
+	candidateSources[sourceIndex] = src
+	if err := dk.validateResourceSourceIDs(candidateSources); err != nil {
+		return fmt.Errorf("invalid resource source: %w", err)
 	}
 
 	config := dk.buildLoadConfig(1, opts...)
@@ -268,16 +280,22 @@ func (dk *BuiltinKnowledge) ReloadSource(ctx context.Context, src source.Source,
 			return err
 		}
 	}
+	_, oldHasResources := oldSource.(source.ResourceSource)
+	_, newHasResources := src.(source.ResourceSource)
+	if oldHasResources && !newHasResources {
+		if err := dk.deleteStoredResourceSource(ctx, sourceName); err != nil {
+			return fmt.Errorf("failed to delete replaced source resources: %w", err)
+		}
+	}
 
-	// Add the new source to the sources list
-	dk.sources = append(dk.sources, src)
+	dk.sources[sourceIndex] = src
 	return nil
 }
 
 // syncReloadSource reloads a source using incremental sync strategy
 func (dk *BuiltinKnowledge) syncReloadSource(
 	ctx context.Context,
-	oldSource source.Source,
+	targetSource source.Source,
 	sourceName string,
 	config *loadConfig,
 ) error {
@@ -291,14 +309,17 @@ func (dk *BuiltinKnowledge) syncReloadSource(
 	dk.markSourceUnprocessed(sourceName)
 
 	// Load source with incremental sync
-	if err := dk.loadSourceInternal(ctx, []source.Source{oldSource}, config); err != nil {
+	resourcePaths, err := dk.loadSourceInternal(ctx, []source.Source{targetSource}, config)
+	if err != nil {
 		return fmt.Errorf("failed to reload source %s: %w", sourceName, err)
 	}
 
 	// Cleanup orphan documents
 	if err := dk.cleanupOrphanDocuments(ctx); err != nil {
-		log.WarnfContext(ctx,
-			"Failed to cleanup orphan documents after reloading source %s: %v", sourceName, err)
+		return fmt.Errorf("failed to cleanup orphan documents after reloading source %s: %w", sourceName, err)
+	}
+	if err := dk.cleanupStaleResources(ctx, resourcePaths); err != nil {
+		return fmt.Errorf("failed to cleanup stale resources after reloading source %s: %w", sourceName, err)
 	}
 
 	// refresh DocumentInfo to load latest document info
@@ -328,8 +349,12 @@ func (dk *BuiltinKnowledge) reloadSource(
 	}
 
 	// Load source
-	if err := dk.loadSourceInternal(ctx, []source.Source{targetSource}, config); err != nil {
+	resourcePaths, err := dk.loadSourceInternal(ctx, []source.Source{targetSource}, config)
+	if err != nil {
 		return fmt.Errorf("failed to reload source %s: %w", sourceName, err)
+	}
+	if err := dk.cleanupStaleResources(ctx, resourcePaths); err != nil {
+		return fmt.Errorf("failed to cleanup stale resources after reloading source %s: %w", sourceName, err)
 	}
 
 	log.InfofContext(ctx, "Successfully reloaded source %s directly", sourceName)
@@ -337,7 +362,14 @@ func (dk *BuiltinKnowledge) reloadSource(
 }
 
 // loadSourceInternal loads sources with proper concurrency handling
-func (dk *BuiltinKnowledge) loadSourceInternal(ctx context.Context, sources []source.Source, config *loadConfig) error {
+func (dk *BuiltinKnowledge) loadSourceInternal(
+	ctx context.Context,
+	sources []source.Source,
+	config *loadConfig,
+) (map[string][]string, error) {
+	if err := dk.validateResourceSourceIDs(sources); err != nil {
+		return nil, err
+	}
 	dk.processingDocIDs = sync.Map{}
 	defer func() {
 		// reset processingDocIDs after loading sources
@@ -345,17 +377,18 @@ func (dk *BuiltinKnowledge) loadSourceInternal(ctx context.Context, sources []so
 	}()
 
 	if config.srcParallelism > 1 || config.docParallelism > 1 {
-		_, err := dk.loadConcurrent(ctx, config, sources)
-		return err
+		return dk.loadConcurrent(ctx, config, sources)
 	}
-	_, err := dk.loadSequential(ctx, config, sources)
-	return err
+	return dk.loadSequential(ctx, config, sources)
 }
 
 // RemoveSource removes a source from the knowledge base by name.
 func (dk *BuiltinKnowledge) RemoveSource(ctx context.Context, sourceName string) error {
 	dk.dataOperationMu.Lock()
 	defer dk.dataOperationMu.Unlock()
+	if dk.vectorStore == nil {
+		return fmt.Errorf("vector store not configured")
+	}
 
 	// Find and remove source from sources list
 	var targetSource source.Source
@@ -387,6 +420,11 @@ func (dk *BuiltinKnowledge) RemoveSource(ctx context.Context, sourceName string)
 			return fmt.Errorf("failed to update vector store metadata: %w", err)
 		}
 	}
+	if _, ok := targetSource.(source.ResourceSource); ok {
+		if err := dk.deleteStoredResourceSource(ctx, sourceName); err != nil {
+			return fmt.Errorf("failed to delete source resources: %w", err)
+		}
+	}
 	dk.sources = append(dk.sources[:sourceIndex], dk.sources[sourceIndex+1:]...)
 	return nil
 }
@@ -415,6 +453,9 @@ func (dk *BuiltinKnowledge) Load(ctx context.Context, opts ...LoadOption) error 
 }
 
 func (dk *BuiltinKnowledge) loadWithRecreate(ctx context.Context, config *loadConfig) error {
+	if err := dk.validateResourceSourceIDs(dk.sources); err != nil {
+		return fmt.Errorf("failed to validate sources: %w", err)
+	}
 	// clear vector store data
 	count, err := dk.vectorStore.Count(ctx)
 	if err != nil {
@@ -430,8 +471,12 @@ func (dk *BuiltinKnowledge) loadWithRecreate(ctx context.Context, config *loadCo
 		dk.clearVectorStoreMetadata()
 	}
 
-	if err := dk.loadSourceInternal(ctx, dk.sources, config); err != nil {
+	resourcePaths, err := dk.loadSourceInternal(ctx, dk.sources, config)
+	if err != nil {
 		return fmt.Errorf("failed to load source: %w", err)
+	}
+	if err := dk.cleanupStaleResources(ctx, resourcePaths); err != nil {
+		return fmt.Errorf("failed to cleanup stale resources: %w", err)
 	}
 
 	if dk.enableSourceSync {
@@ -450,13 +495,17 @@ func (dk *BuiltinKnowledge) load(ctx context.Context, config *loadConfig) error 
 		}
 	}
 
-	if err := dk.loadSourceInternal(ctx, dk.sources, config); err != nil {
+	resourcePaths, err := dk.loadSourceInternal(ctx, dk.sources, config)
+	if err != nil {
 		return fmt.Errorf("failed to load source: %w", err)
 	}
 
 	if dk.enableSourceSync {
 		if err := dk.cleanupOrphanDocuments(ctx); err != nil {
 			return fmt.Errorf("failed to cleanup orphan documents: %w", err)
+		}
+		if err := dk.cleanupStaleResources(ctx, resourcePaths); err != nil {
+			return fmt.Errorf("failed to cleanup stale resources: %w", err)
 		}
 		if err := dk.refreshAllDocInfo(ctx); err != nil {
 			return fmt.Errorf("failed to update vector store metadata: %w", err)
@@ -469,7 +518,7 @@ func (dk *BuiltinKnowledge) load(ctx context.Context, config *loadConfig) error 
 func (dk *BuiltinKnowledge) loadSequential(
 	ctx context.Context,
 	config *loadConfig,
-	sources []source.Source) ([]string, error) {
+	sources []source.Source) (map[string][]string, error) {
 	// Timing variables.
 	startTime := time.Now()
 
@@ -484,7 +533,7 @@ func (dk *BuiltinKnowledge) loadSequential(
 		sourceNames = append(sourceNames, s.Name())
 	}
 
-	var allAddedIDs []string
+	resourcePaths := make(map[string][]string)
 	var processedDocs int
 	reporter := newLoadReporter(config, sourceNames, startTime, sizeBuckets, func() int { return processedDocs })
 	defer reporter.Close()
@@ -495,12 +544,15 @@ func (dk *BuiltinKnowledge) loadSequential(
 		log.InfofContext(ctx, "Loading source %d/%d: %s (type: %s)",
 			i+1, totalSources, sourceName, sourceType)
 
-		docs, err := src.ReadDocuments(ctx)
+		docs, paths, err := dk.readSourceDocuments(ctx, src)
 		if err != nil {
 			log.ErrorfContext(ctx, "Failed to read documents from source %s: %v",
 				sourceName, err)
 			reporter.Error(ctx, LoadProgressEvent{SourceName: sourceName}, err)
 			return nil, fmt.Errorf("failed to read documents from source %s: %w", sourceName, err)
+		}
+		if paths != nil {
+			resourcePaths[sourceName] = paths
 		}
 
 		log.InfofContext(ctx, "Fetched %d document(s) from source %s", len(docs), sourceName)
@@ -538,7 +590,6 @@ func (dk *BuiltinKnowledge) loadSequential(
 				return nil, fmt.Errorf("failed to add document from source %s: %w", sourceName, err)
 			}
 
-			allAddedIDs = append(allAddedIDs, doc.ID)
 			processedDocs++
 
 			srcProcessed := j + 1
@@ -561,14 +612,14 @@ func (dk *BuiltinKnowledge) loadSequential(
 		elapsedTotal, totalSources)
 
 	reporter.Done(ctx)
-	return allAddedIDs, nil
+	return resourcePaths, nil
 }
 
 // loadSourcesConcurrent loads sources concurrently
 func (dk *BuiltinKnowledge) loadConcurrent(
 	ctx context.Context,
 	config *loadConfig,
-	sources []source.Source) ([]string, error) {
+	sources []source.Source) (map[string][]string, error) {
 	// Create worker pool for source processing
 	srcPool, err := ants.NewPool(config.srcParallelism)
 	if err != nil {
@@ -584,7 +635,7 @@ func (dk *BuiltinKnowledge) loadConcurrent(
 	defer docPool.Release()
 
 	var wg sync.WaitGroup
-	var allAddedIDs []string
+	resourcePaths := make(map[string][]string)
 	var mu sync.Mutex
 	errCh := make(chan error, len(sources))
 	var globalProcessed atomic.Int64
@@ -611,11 +662,16 @@ func (dk *BuiltinKnowledge) loadConcurrent(
 			sourceType := source.Type()
 			log.InfofContext(ctx, "Loading source %d/%d: %s (type: %s)",
 				srcIdx+1, len(sources), sourceName, sourceType)
-			docs, err := source.ReadDocuments(ctx)
+			docs, paths, err := dk.readSourceDocuments(ctx, source)
 			if err != nil {
 				reporter.Error(ctx, LoadProgressEvent{SourceName: sourceName}, err)
 				errCh <- fmt.Errorf("failed to read documents from source %s: %w", sourceName, err)
 				return
+			}
+			if paths != nil {
+				mu.Lock()
+				resourcePaths[sourceName] = paths
+				mu.Unlock()
 			}
 			log.InfofContext(ctx, "Fetched %d document(s) from source %s", len(docs), sourceName)
 			processed, err := dk.processDocuments(ctx, docs, docPool, source, &globalProcessed, reporter)
@@ -630,12 +686,6 @@ func (dk *BuiltinKnowledge) loadConcurrent(
 			}
 			log.InfofContext(ctx, "Successfully loaded source %s", sourceName)
 
-			// Collect document IDs
-			mu.Lock()
-			for _, doc := range docs {
-				allAddedIDs = append(allAddedIDs, doc.ID)
-			}
-			mu.Unlock()
 		})
 		if err != nil {
 			wg.Done()
@@ -655,7 +705,7 @@ func (dk *BuiltinKnowledge) loadConcurrent(
 
 	reporter.Done(ctx)
 
-	return allAddedIDs, nil
+	return resourcePaths, nil
 }
 
 // processDocuments embeds and stores all documents from a single source using
@@ -898,8 +948,24 @@ func (dk *BuiltinKnowledge) resetDocumentID(doc *document.Document, src source.S
 	}
 
 	// generate document ID by source name, uri, content, chunk index and source metadata
-	// we cal hash with metadata that user set
-	doc.ID = generateDocumentID(src.Name(), uri, doc.Content, chunkIndexInt, src.GetMetadata())
+	identityMetadata := src.GetMetadata()
+	if resourcePath, ok := doc.Metadata[source.MetaResourcePath]; ok {
+		withResourceIdentity := make(map[string]any, len(identityMetadata)+3)
+		for key, value := range identityMetadata {
+			withResourceIdentity[key] = value
+		}
+		withResourceIdentity[source.MetaResourcePath] = resourcePath
+		if startLine, ok := doc.Metadata[source.MetaResourceStartLine]; ok {
+			withResourceIdentity[source.MetaResourceStartLine] = startLine
+		}
+		if endLine, ok := doc.Metadata[source.MetaResourceEndLine]; ok {
+			withResourceIdentity[source.MetaResourceEndLine] = endLine
+		}
+		identityMetadata = withResourceIdentity
+	}
+	// Hash user metadata and resource location so incremental sync refreshes
+	// stored line references when the source text shifts around an unchanged chunk.
+	doc.ID = generateDocumentID(src.Name(), uri, doc.Content, chunkIndexInt, identityMetadata)
 	return nil
 }
 

--- a/knowledge/graph_knowledge.go
+++ b/knowledge/graph_knowledge.go
@@ -21,3 +21,11 @@ type GraphKnowledge interface {
 	Traverse(ctx context.Context, query *graph.TraverseQuery) (*graph.TraverseResult, error)
 	FindPaths(ctx context.Context, query *graph.PathQuery) (*graph.PathResult, error)
 }
+
+// GraphProvider is an optional capability for discovering a graph-native view
+// without changing the document-RAG semantics of Knowledge.Search.
+type GraphProvider interface {
+	// Graph returns the graph view and whether its store and seed-search
+	// capability are both configured.
+	Graph() (GraphKnowledge, bool)
+}

--- a/knowledge/graph_knowledge_default.go
+++ b/knowledge/graph_knowledge_default.go
@@ -442,6 +442,9 @@ func (gk *BuiltinGraphKnowledge) retrieveSeedNodes(
 	ctx context.Context,
 	req *SearchRequest,
 ) ([]*graphSeed, error) {
+	if searcher, ok := gk.store.(graphstore.Searcher); ok {
+		return gk.retrieveNativeSeedNodes(ctx, searcher, req)
+	}
 	if gk.vectorStore == nil {
 		return nil, errors.New("graph vector store is not configured")
 	}
@@ -498,6 +501,67 @@ func (gk *BuiltinGraphKnowledge) retrieveSeedNodes(
 		})
 	}
 	return seeds, nil
+}
+
+func (gk *BuiltinGraphKnowledge) retrieveNativeSeedNodes(
+	ctx context.Context,
+	searcher graphstore.Searcher,
+	req *SearchRequest,
+) ([]*graphSeed, error) {
+	maxSeeds := resolvePositiveInt(req.MaxResults, defaultGraphSearchMaxSeeds)
+	result, err := searcher.SearchNodes(ctx, &graphstore.SearchNodesRequest{
+		Query:    strings.TrimSpace(req.Query),
+		Mode:     nativeGraphSearchMode(req),
+		Limit:    maxSeeds,
+		MinScore: req.MinScore,
+		Filter:   convertGraphSearchFilter(req.SearchFilter),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search graph seeds: %w", err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	seeds := make([]*graphSeed, 0, len(result.Nodes))
+	seen := make(map[string]struct{}, len(result.Nodes))
+	for _, scored := range result.Nodes {
+		if scored == nil || scored.Node == nil || scored.Node.ID == "" {
+			continue
+		}
+		if _, ok := seen[scored.Node.ID]; ok {
+			continue
+		}
+		seen[scored.Node.ID] = struct{}{}
+		seeds = append(seeds, &graphSeed{node: scored.Node, score: scored.Score})
+	}
+	return seeds, nil
+}
+
+func nativeGraphSearchMode(req *SearchRequest) graphstore.SearchMode {
+	if strings.TrimSpace(req.Query) == "" && hasSearchFilter(req.SearchFilter) {
+		return graphstore.SearchModeFilter
+	}
+	switch vectorstore.SearchMode(req.SearchMode) {
+	case vectorstore.SearchModeVector:
+		return graphstore.SearchModeVector
+	case vectorstore.SearchModeKeyword:
+		return graphstore.SearchModeKeyword
+	case vectorstore.SearchModeFilter:
+		return graphstore.SearchModeFilter
+	default:
+		return graphstore.SearchModeHybrid
+	}
+}
+
+func convertGraphSearchFilter(filter *SearchFilter) *graphstore.SearchNodesFilter {
+	if filter == nil {
+		return nil
+	}
+	return &graphstore.SearchNodesFilter{
+		NodeIDs:         filter.DocumentIDs,
+		Metadata:        filter.Metadata,
+		FilterCondition: filter.FilterCondition,
+	}
 }
 
 type graphSeed struct {

--- a/knowledge/graphstore/graphstore.go
+++ b/knowledge/graphstore/graphstore.go
@@ -65,7 +65,7 @@ const (
 // requested retrieval semantics. Query always carries the original text;
 // Vector optionally carries a caller-produced embedding. In vector or hybrid
 // mode, a backend that encapsulates its own embedder may receive Query with an
-// empty Vector and produce the vector internally. Filter is ANDed with the
+// empty Vector and produce the vector internally. Filter is combined with the
 // retrieval condition. The request must be non-nil.
 type SearchNodesRequest struct {
 	// Query is the original text query for keyword or hybrid search.

--- a/knowledge/graphstore/graphstore.go
+++ b/knowledge/graphstore/graphstore.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/graph"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/searchfilter"
 )
 
 // Store defines graph storage operations.
@@ -33,4 +34,80 @@ type Store interface {
 	// Close releases any resources held by the store (e.g. database connections).
 	// Implementations that hold no resources may return nil.
 	Close() error
+}
+
+// Searcher is an optional native graph-node retrieval capability. Stores that
+// do not implement it can still support Traverse and FindPaths, but must be
+// wrapped by a Searcher before backing a complete GraphProvider view.
+type Searcher interface {
+	// SearchNodes searches graph nodes by text, vector, or both.
+	SearchNodes(ctx context.Context, req *SearchNodesRequest) (*SearchNodesResult, error)
+}
+
+// SearchMode tells a graph backend how to interpret Query and Vector. A
+// backend that owns its embedder may accept a text Query in vector or hybrid
+// mode and produce the vector internally.
+type SearchMode string
+
+const (
+	// SearchModeHybrid combines backend-native text and vector retrieval.
+	SearchModeHybrid SearchMode = "hybrid"
+	// SearchModeVector uses vector retrieval, embedding Query internally when
+	// Vector is empty and the backend supports that operation.
+	SearchModeVector SearchMode = "vector"
+	// SearchModeKeyword uses backend-native keyword retrieval.
+	SearchModeKeyword SearchMode = "keyword"
+	// SearchModeFilter applies only Filter and does not require Query or Vector.
+	SearchModeFilter SearchMode = "filter"
+)
+
+// SearchNodesRequest configures native graph-node retrieval. Mode declares the
+// requested retrieval semantics. Query always carries the original text;
+// Vector optionally carries a caller-produced embedding. In vector or hybrid
+// mode, a backend that encapsulates its own embedder may receive Query with an
+// empty Vector and produce the vector internally. Filter is ANDed with the
+// retrieval condition. The request must be non-nil.
+type SearchNodesRequest struct {
+	// Query is the original text query for keyword or hybrid search.
+	Query string
+	// Vector is a caller-produced embedding for vector or hybrid search.
+	Vector []float64
+	// Mode is hybrid, vector, keyword, or filter. Empty selects the backend's
+	// default mode for direct Searcher callers.
+	Mode SearchMode
+	// Limit bounds the number of nodes returned. Non-positive values select an
+	// implementation-defined bounded default.
+	Limit int
+	// MinScore is the minimum normalized relevance score in the range [0, 1].
+	// Values outside that range are invalid.
+	MinScore float64
+	// Filter limits candidate graph nodes.
+	Filter *SearchNodesFilter
+}
+
+// SearchNodesFilter describes portable graph-node filters. FilterCondition
+// fields use id, name, content, or metadata.<key>.
+type SearchNodesFilter struct {
+	// NodeIDs limits results to specific node IDs.
+	NodeIDs []string
+	// Metadata matches node metadata by key and value.
+	Metadata map[string]any
+	// FilterCondition expresses nested portable metadata conditions.
+	FilterCondition *searchfilter.UniversalFilterCondition
+}
+
+// SearchNodesResult contains native graph-node matches sorted by descending
+// score, with Node.ID as the deterministic tie-breaker. Filter-only results use
+// score 1.
+type SearchNodesResult struct {
+	// Nodes contains matching nodes and their relevance scores.
+	Nodes []*ScoredNode
+}
+
+// ScoredNode associates a graph node with a normalized relevance score.
+type ScoredNode struct {
+	// Node is the matched graph node.
+	Node *graph.Node
+	// Score is in the range [0, 1], where larger values are more relevant.
+	Score float64
 }

--- a/knowledge/resource.go
+++ b/knowledge/resource.go
@@ -1,0 +1,182 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"path"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+)
+
+var (
+	// ErrResourceNotFound means the requested source or path is not persisted.
+	ErrResourceNotFound = resourcestore.ErrNotFound
+	// ErrResourceRepresentationUnavailable means the resource cannot be read as text.
+	ErrResourceRepresentationUnavailable = resourcestore.ErrRepresentationUnavailable
+	// ErrResourcePermissionDenied means the store rejected access to the resource.
+	ErrResourcePermissionDenied = resourcestore.ErrPermissionDenied
+	// ErrResourceStoreUnavailable means the resource store cannot currently be reached.
+	ErrResourceStoreUnavailable = resourcestore.ErrUnavailable
+	// ErrResourceCapabilityUnavailable means no ResourceStore is configured.
+	ErrResourceCapabilityUnavailable = errors.New("knowledge resource capability unavailable")
+	// ErrResourceLimitExceeded means a resource operation exceeded a service limit.
+	ErrResourceLimitExceeded = errors.New("knowledge resource limit exceeded")
+)
+
+// ResourceKnowledge is an optional, independent capability for browsing and
+// reading persisted file-like content. It does not imply semantic Search
+// support, and Knowledge does not require implementations to provide it.
+type ResourceKnowledge interface {
+	// ListSources lists sources persisted in the resource store.
+	ListSources(ctx context.Context, req *ListSourcesRequest) (*ListSourcesResult, error)
+
+	// ListResources lists direct children from a persisted source tree.
+	ListResources(ctx context.Context, req *ListResourcesRequest) (*ListResourcesResult, error)
+
+	// ReadResource reads a bounded line range from persisted resource content.
+	ReadResource(ctx context.Context, req *ReadResourceRequest) (*ReadResourceResult, error)
+
+	// GrepResource finds bounded context blocks in persisted resource content.
+	GrepResource(ctx context.Context, req *GrepResourceRequest) (*GrepResourceResult, error)
+}
+
+// SourceInfo describes one persisted source without exposing provider details.
+type SourceInfo = resourcestore.SourceInfo
+
+// ResourceInfo describes one persisted file or directory.
+type ResourceInfo = resourcestore.ResourceInfo
+
+// ListSourcesRequest is reserved for future source filters.
+type ListSourcesRequest struct{}
+
+// ListSourcesResult contains persisted resource sources.
+type ListSourcesResult struct {
+	Sources []*SourceInfo `json:"sources"`
+}
+
+// ListResourcesRequest configures direct-child resource listing. An empty
+// ParentPath addresses the persisted source root.
+type ListResourcesRequest struct {
+	// SourceID identifies the source to browse and is required.
+	SourceID string `json:"source_id" jsonschema:"description=Stable source ID to browse,required"`
+	// ParentPath is a source-relative directory path. Empty means the source root.
+	ParentPath string `json:"parent_path,omitempty" jsonschema:"description=Source-relative parent path; omit for the source root"`
+}
+
+// ListResourcesResult contains direct children from the persisted source snapshot.
+type ListResourcesResult struct {
+	Resources []*ResourceInfo `json:"resources"`
+}
+
+// ReadResourceRequest requests an inclusive, one-based line range from persisted content.
+type ReadResourceRequest struct {
+	// SourceID identifies the source and is required.
+	SourceID string `json:"source_id" jsonschema:"description=Stable source ID,required"`
+	// Path is a safe source-relative resource path and is required.
+	Path string `json:"path" jsonschema:"description=Source-relative resource path,required"`
+	// StartLine is the inclusive one-based start line. Non-positive values mean line 1.
+	StartLine int `json:"start_line,omitempty" jsonschema:"description=Inclusive one-based start line; defaults to 1"`
+	// EndLine is the inclusive one-based end line. Non-positive values select a bounded window.
+	EndLine int `json:"end_line,omitempty" jsonschema:"description=Inclusive one-based end line; defaults to a bounded window"`
+}
+
+// ReadResourceResult contains a bounded line range from persisted resource content.
+type ReadResourceResult struct {
+	SourceID  string   `json:"source_id"`
+	Path      string   `json:"path"`
+	Lines     []string `json:"lines"`
+	StartLine int      `json:"start_line"`
+	// EndLine is zero when the requested range contains no persisted lines.
+	EndLine       int  `json:"end_line"`
+	NextStartLine int  `json:"next_start_line,omitempty"`
+	EOF           bool `json:"eof"`
+}
+
+// GrepResourceRequest configures a bounded pattern search over persisted content.
+type GrepResourceRequest struct {
+	SourceID   string `json:"source_id" jsonschema:"description=Stable source ID,required"`
+	Path       string `json:"path" jsonschema:"description=Source-relative resource path,required"`
+	Pattern    string `json:"pattern" jsonschema:"description=Non-empty literal or regular expression,required"`
+	Regex      bool   `json:"regex,omitempty" jsonschema:"description=Treat pattern as a regular expression"`
+	Before     int    `json:"before,omitempty" jsonschema:"description=Context lines before each match"`
+	After      int    `json:"after,omitempty" jsonschema:"description=Context lines after each match"`
+	MaxMatches int    `json:"max_matches,omitempty" jsonschema:"description=Maximum number of matches to return"`
+}
+
+// GrepBlock is one merged context range. MatchLines contains the one-based
+// lines that matched Pattern within the block.
+type GrepBlock struct {
+	StartLine  int      `json:"start_line"`
+	EndLine    int      `json:"end_line"`
+	Lines      []string `json:"lines"`
+	MatchLines []int    `json:"match_lines"`
+}
+
+// GrepResourceResult contains bounded matches from persisted resource content.
+type GrepResourceResult struct {
+	SourceID  string       `json:"source_id"`
+	Path      string       `json:"path"`
+	Blocks    []*GrepBlock `json:"blocks"`
+	Truncated bool         `json:"truncated"`
+}
+
+func cleanResourcePath(value string) (string, bool) {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\\", "/")
+	if value == "" || strings.HasPrefix(value, "/") || strings.ContainsRune(value, '\x00') {
+		return "", false
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == ".." {
+			return "", false
+		}
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") ||
+		strings.HasPrefix(cleaned, "/") || hasResourceScheme(cleaned) || isWindowsAbsolutePath(cleaned) {
+		return "", false
+	}
+	return cleaned, true
+}
+
+func cleanOptionalResourcePath(value string) (string, bool) {
+	if strings.TrimSpace(value) == "" {
+		return "", true
+	}
+	return cleanResourcePath(value)
+}
+
+func isWindowsAbsolutePath(value string) bool {
+	if len(value) < 3 || value[1] != ':' || value[2] != '/' {
+		return false
+	}
+	return (value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')
+}
+
+func hasResourceScheme(value string) bool {
+	colon := strings.IndexByte(value, ':')
+	if colon <= 0 {
+		return false
+	}
+	if slash := strings.IndexByte(value, '/'); slash >= 0 && slash < colon {
+		return false
+	}
+	for index := 0; index < colon; index++ {
+		character := value[index]
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(index > 0 && ((character >= '0' && character <= '9') || character == '+' || character == '-' || character == '.')) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/knowledge/resource_default.go
+++ b/knowledge/resource_default.go
@@ -1,0 +1,434 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+)
+
+const (
+	defaultResourceReadLines = 200
+	maxResourceListEntries   = 1000
+	maxResourceReadLines     = 1000
+	maxResourceReadBytes     = 8 << 20
+	maxResourceLineBytes     = 1 << 20
+	defaultResourceMatches   = 20
+	maxResourceMatches       = 100
+	maxResourceGrepContext   = 20
+	maxResourceGrepBytes     = 16 << 20
+	maxResourceGrepLines     = 250000
+	maxResourcePatternBytes  = 4096
+)
+
+// ListSources lists sources persisted in the configured resource store.
+func (dk *BuiltinKnowledge) ListSources(
+	ctx context.Context,
+	req *ListSourcesRequest,
+) (*ListSourcesResult, error) {
+	if req == nil {
+		return nil, errors.New("list sources request cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	store, err := dk.configuredResourceStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listed, err := store.ListSources(ctx)
+	if err != nil {
+		return nil, publicResourceStoreError(ctx, err)
+	}
+	if len(listed) > maxResourceListEntries {
+		return nil, ErrResourceLimitExceeded
+	}
+	result := &ListSourcesResult{Sources: make([]*SourceInfo, 0, len(listed))}
+	seen := make(map[string]struct{}, len(listed))
+	for _, info := range listed {
+		if info == nil {
+			return nil, ErrResourceStoreUnavailable
+		}
+		sourceID := strings.TrimSpace(info.ID)
+		if sourceID == "" {
+			return nil, ErrResourceStoreUnavailable
+		}
+		if _, duplicate := seen[sourceID]; duplicate {
+			return nil, ErrResourceStoreUnavailable
+		}
+		seen[sourceID] = struct{}{}
+		projected := *info
+		projected.ID = sourceID
+		projected.Name = strings.TrimSpace(projected.Name)
+		projected.Type = strings.TrimSpace(projected.Type)
+		result.Sources = append(result.Sources, &projected)
+	}
+	sort.Slice(result.Sources, func(i, j int) bool {
+		return result.Sources[i].ID < result.Sources[j].ID
+	})
+	return result, nil
+}
+
+// ListResources lists direct children from a persisted source snapshot.
+func (dk *BuiltinKnowledge) ListResources(
+	ctx context.Context,
+	req *ListResourcesRequest,
+) (*ListResourcesResult, error) {
+	if req == nil {
+		return nil, errors.New("list resources request cannot be nil")
+	}
+	sourceID := strings.TrimSpace(req.SourceID)
+	if sourceID == "" {
+		return nil, errors.New("source ID cannot be empty")
+	}
+	parentPath, ok := cleanOptionalResourcePath(req.ParentPath)
+	if !ok {
+		return nil, errors.New("invalid parent path")
+	}
+	store, err := dk.configuredResourceStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listed, err := store.ListResources(ctx, sourceID, parentPath)
+	if err != nil {
+		return nil, publicResourceStoreError(ctx, err)
+	}
+	if len(listed) > maxResourceListEntries {
+		return nil, ErrResourceLimitExceeded
+	}
+	result := &ListResourcesResult{Resources: make([]*resourcestore.ResourceInfo, 0, len(listed))}
+	seen := make(map[string]struct{}, len(listed))
+	for _, info := range listed {
+		projected, valid := projectListedResource(sourceID, parentPath, info)
+		if !valid {
+			return nil, ErrResourceStoreUnavailable
+		}
+		if _, duplicate := seen[projected.Path]; duplicate {
+			return nil, ErrResourceStoreUnavailable
+		}
+		seen[projected.Path] = struct{}{}
+		result.Resources = append(result.Resources, projected)
+	}
+	sort.Slice(result.Resources, func(i, j int) bool {
+		return result.Resources[i].Path < result.Resources[j].Path
+	})
+	return result, nil
+}
+
+// ReadResource reads a bounded, inclusive line range from persisted content.
+func (dk *BuiltinKnowledge) ReadResource(
+	ctx context.Context,
+	req *ReadResourceRequest,
+) (*ReadResourceResult, error) {
+	if req == nil {
+		return nil, errors.New("read resource request cannot be nil")
+	}
+	startLine := req.StartLine
+	if startLine <= 0 {
+		startLine = 1
+	}
+	endLine := req.EndLine
+	if endLine <= 0 {
+		endLine = startLine + defaultResourceReadLines - 1
+	}
+	if endLine < startLine {
+		return nil, errors.New("end line must not be before start line")
+	}
+	if endLine-startLine+1 > maxResourceReadLines {
+		return nil, ErrResourceLimitExceeded
+	}
+	sourceID, resourcePath, content, err := dk.openStoredResource(ctx, req.SourceID, req.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer content.Close()
+
+	lines, eof, err := readResourceLines(ctx, content, startLine, endLine)
+	if err != nil {
+		return nil, err
+	}
+	actualEnd := 0
+	if len(lines) > 0 {
+		actualEnd = startLine + len(lines) - 1
+	}
+	result := &ReadResourceResult{
+		SourceID:  sourceID,
+		Path:      resourcePath,
+		Lines:     lines,
+		StartLine: startLine,
+		EndLine:   actualEnd,
+		EOF:       eof,
+	}
+	if !eof {
+		result.NextStartLine = endLine + 1
+	}
+	return result, nil
+}
+
+// GrepResource finds bounded literal or regular-expression matches in persisted content.
+func (dk *BuiltinKnowledge) GrepResource(
+	ctx context.Context,
+	req *GrepResourceRequest,
+) (*GrepResourceResult, error) {
+	if req == nil {
+		return nil, errors.New("grep resource request cannot be nil")
+	}
+	if strings.TrimSpace(req.Pattern) == "" {
+		return nil, errors.New("grep pattern cannot be empty")
+	}
+	if len(req.Pattern) > maxResourcePatternBytes {
+		return nil, ErrResourceLimitExceeded
+	}
+	if req.Before < 0 || req.After < 0 {
+		return nil, errors.New("grep context cannot be negative")
+	}
+	if req.Before > maxResourceGrepContext || req.After > maxResourceGrepContext {
+		return nil, ErrResourceLimitExceeded
+	}
+	maxMatches := req.MaxMatches
+	if maxMatches <= 0 {
+		maxMatches = defaultResourceMatches
+	}
+	if maxMatches > maxResourceMatches {
+		return nil, ErrResourceLimitExceeded
+	}
+	matcher, err := buildResourceMatcher(req.Pattern, req.Regex)
+	if err != nil {
+		return nil, err
+	}
+	sourceID, resourcePath, content, err := dk.openStoredResource(ctx, req.SourceID, req.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer content.Close()
+	lines, err := readAllResourceLines(ctx, content)
+	if err != nil {
+		return nil, err
+	}
+	matchLines := make([]int, 0, maxMatches+1)
+	for index, line := range lines {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !matcher(line) {
+			continue
+		}
+		matchLines = append(matchLines, index+1)
+		if len(matchLines) > maxMatches {
+			break
+		}
+	}
+	truncated := len(matchLines) > maxMatches
+	if truncated {
+		matchLines = matchLines[:maxMatches]
+	}
+	return &GrepResourceResult{
+		SourceID:  sourceID,
+		Path:      resourcePath,
+		Blocks:    buildGrepBlocks(lines, matchLines, req.Before, req.After),
+		Truncated: truncated,
+	}, nil
+}
+
+func (dk *BuiltinKnowledge) openStoredResource(
+	ctx context.Context,
+	sourceID string,
+	resourcePath string,
+) (string, string, io.ReadCloser, error) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return "", "", nil, errors.New("source ID cannot be empty")
+	}
+	cleanedPath, ok := cleanResourcePath(resourcePath)
+	if !ok {
+		return "", "", nil, errors.New("invalid resource path")
+	}
+	store, err := dk.configuredResourceStore(ctx)
+	if err != nil {
+		return "", "", nil, err
+	}
+	content, err := store.OpenResource(ctx, sourceID, cleanedPath)
+	if err != nil {
+		return "", "", nil, publicResourceStoreError(ctx, err)
+	}
+	if content == nil {
+		return "", "", nil, ErrResourceRepresentationUnavailable
+	}
+	return sourceID, cleanedPath, content, nil
+}
+
+func (dk *BuiltinKnowledge) configuredResourceStore(ctx context.Context) (resourcestore.Store, error) {
+	if dk == nil || dk.resourceStore == nil {
+		return nil, ErrResourceCapabilityUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return dk.resourceStore, nil
+}
+
+func projectListedResource(
+	sourceID string,
+	parentPath string,
+	info *resourcestore.ResourceInfo,
+) (*resourcestore.ResourceInfo, bool) {
+	if info == nil {
+		return nil, false
+	}
+	if listedSourceID := strings.TrimSpace(info.SourceID); listedSourceID != "" && listedSourceID != sourceID {
+		return nil, false
+	}
+	resourcePath, ok := cleanResourcePath(info.Path)
+	if !ok || parentResourcePath(resourcePath) != parentPath {
+		return nil, false
+	}
+	projected := *info
+	projected.SourceID = sourceID
+	projected.Path = resourcePath
+	if projected.Name == "" {
+		projected.Name = path.Base(resourcePath)
+	}
+	return &projected, true
+}
+
+func parentResourcePath(value string) string {
+	parent := path.Dir(value)
+	if parent == "." || parent == "/" {
+		return ""
+	}
+	return parent
+}
+
+func readResourceLines(ctx context.Context, reader io.Reader, startLine, endLine int) ([]string, bool, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), maxResourceLineBytes)
+	lines := make([]string, 0, endLine-startLine+1)
+	lineNumber := 0
+	bytesRead := 0
+	more := false
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		lineNumber++
+		bytesRead += len(scanner.Bytes()) + 1
+		if bytesRead > maxResourceReadBytes {
+			return nil, false, ErrResourceLimitExceeded
+		}
+		if lineNumber < startLine {
+			continue
+		}
+		if lineNumber > endLine {
+			more = true
+			break
+		}
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, false, ctxErr
+		}
+		if errors.Is(err, bufio.ErrTooLong) {
+			return nil, false, ErrResourceLimitExceeded
+		}
+		return nil, false, ErrResourceStoreUnavailable
+	}
+	if more {
+		return lines, false, nil
+	}
+	return lines, true, nil
+}
+
+func readAllResourceLines(ctx context.Context, reader io.Reader) ([]string, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), maxResourceLineBytes)
+	lines := make([]string, 0)
+	bytesRead := 0
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		bytesRead += len(scanner.Bytes()) + 1
+		if bytesRead > maxResourceGrepBytes || len(lines) >= maxResourceGrepLines {
+			return nil, ErrResourceLimitExceeded
+		}
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if errors.Is(err, bufio.ErrTooLong) {
+			return nil, ErrResourceLimitExceeded
+		}
+		return nil, ErrResourceStoreUnavailable
+	}
+	return lines, nil
+}
+
+func buildResourceMatcher(pattern string, regex bool) (func(string) bool, error) {
+	if !regex {
+		return func(line string) bool { return strings.Contains(line, pattern) }, nil
+	}
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("compile grep pattern: %w", err)
+	}
+	return compiled.MatchString, nil
+}
+
+func publicResourceStoreError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	for _, publicErr := range []error{
+		ErrResourceNotFound,
+		ErrResourceRepresentationUnavailable,
+		ErrResourcePermissionDenied,
+		ErrResourceStoreUnavailable,
+	} {
+		if errors.Is(err, publicErr) {
+			return publicErr
+		}
+	}
+	return ErrResourceStoreUnavailable
+}
+
+func buildGrepBlocks(lines []string, matches []int, before, after int) []*GrepBlock {
+	blocks := make([]*GrepBlock, 0, len(matches))
+	for _, matchLine := range matches {
+		start := max(1, matchLine-before)
+		end := min(len(lines), matchLine+after)
+		if len(blocks) > 0 && start <= blocks[len(blocks)-1].EndLine+1 {
+			block := blocks[len(blocks)-1]
+			if end > block.EndLine {
+				block.Lines = append(block.Lines, lines[block.EndLine:end]...)
+				block.EndLine = end
+			}
+			block.MatchLines = append(block.MatchLines, matchLine)
+			continue
+		}
+		blocks = append(blocks, &GrepBlock{
+			StartLine:  start,
+			EndLine:    end,
+			Lines:      append([]string(nil), lines[start-1:end]...),
+			MatchLines: []int{matchLine},
+		})
+	}
+	return blocks
+}

--- a/knowledge/resource_default_test.go
+++ b/knowledge/resource_default_test.go
@@ -1,0 +1,376 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+)
+
+const resourceTestSourceID = "source-a"
+
+type resourceTestStore struct {
+	mu sync.Mutex
+
+	sources        []*resourcestore.SourceInfo
+	listResults    map[string][]*resourcestore.ResourceInfo
+	contents       map[string]string
+	listSourcesErr error
+	listErr        error
+	openErr        error
+	listRequests   []string
+	openPaths      []string
+	contentCloses  int
+	closeErr       error
+	closeCalls     int
+}
+
+func (*resourceTestStore) PutSource(context.Context, *resourcestore.SourceInfo) error {
+	return nil
+}
+
+func (*resourceTestStore) PutResource(context.Context, *resourcestore.ResourceInfo, io.Reader) error {
+	return nil
+}
+
+func (*resourceTestStore) DeleteResource(context.Context, string, string) error {
+	return nil
+}
+
+func (*resourceTestStore) DeleteSource(context.Context, string) error {
+	return nil
+}
+
+func (s *resourceTestStore) ListSources(context.Context) ([]*resourcestore.SourceInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sources, s.listSourcesErr
+}
+
+func (s *resourceTestStore) ListResources(
+	_ context.Context,
+	sourceID string,
+	parentPath string,
+) ([]*resourcestore.ResourceInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listRequests = append(s.listRequests, sourceID+":"+parentPath)
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.listResults[parentPath], nil
+}
+
+func (s *resourceTestStore) OpenResource(
+	_ context.Context,
+	sourceID string,
+	resourcePath string,
+) (io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.openPaths = append(s.openPaths, sourceID+":"+resourcePath)
+	if s.openErr != nil {
+		return nil, s.openErr
+	}
+	content, ok := s.contents[resourcePath]
+	if !ok {
+		return nil, resourcestore.ErrNotFound
+	}
+	return &resourceTestReadCloser{
+		Reader: strings.NewReader(content),
+		onClose: func() {
+			s.mu.Lock()
+			s.contentCloses++
+			s.mu.Unlock()
+		},
+	}, nil
+}
+
+func (s *resourceTestStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeCalls++
+	return s.closeErr
+}
+
+func (s *resourceTestStore) snapshot() ([]string, []string, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.listRequests...), append([]string(nil), s.openPaths...), s.contentCloses
+}
+
+type resourceTestReadCloser struct {
+	io.Reader
+	once    sync.Once
+	onClose func()
+}
+
+func (r *resourceTestReadCloser) Close() error {
+	r.once.Do(r.onClose)
+	return nil
+}
+
+func TestBuiltinKnowledgeResourcesUseStoreWithoutSourcesOrVectorStore(t *testing.T) {
+	store := &resourceTestStore{
+		sources: []*resourcestore.SourceInfo{{
+			ID: resourceTestSourceID, Name: "product docs", Type: "dir",
+		}},
+		listResults: map[string][]*resourcestore.ResourceInfo{
+			"":     {{Path: "docs", Name: "docs", IsDir: true, Size: -1}},
+			"docs": {{Path: "docs/config.md", Size: 42}},
+		},
+	}
+	kb := New(WithStores(Stores{Resource: store}))
+
+	sources, err := kb.ListSources(context.Background(), &ListSourcesRequest{})
+	if err != nil {
+		t.Fatalf("ListSources() error = %v", err)
+	}
+	if len(sources.Sources) != 1 {
+		t.Fatalf("ListSources() sources = %d, want 1", len(sources.Sources))
+	}
+	gotSource := sources.Sources[0]
+	if gotSource.ID != resourceTestSourceID || gotSource.Name != "product docs" || gotSource.Type != "dir" {
+		t.Fatalf("ListSources() source = %+v", gotSource)
+	}
+
+	root, err := kb.ListResources(context.Background(), &ListResourcesRequest{SourceID: resourceTestSourceID})
+	if err != nil {
+		t.Fatalf("ListResources(root) error = %v", err)
+	}
+	if len(root.Resources) != 1 || root.Resources[0].SourceID != resourceTestSourceID ||
+		root.Resources[0].Path != "docs" || !root.Resources[0].IsDir {
+		t.Fatalf("ListResources(root) = %+v", root)
+	}
+	docs, err := kb.ListResources(context.Background(), &ListResourcesRequest{
+		SourceID: resourceTestSourceID, ParentPath: "docs",
+	})
+	if err != nil {
+		t.Fatalf("ListResources(docs) error = %v", err)
+	}
+	if len(docs.Resources) != 1 || docs.Resources[0].Path != "docs/config.md" ||
+		docs.Resources[0].Name != "config.md" {
+		t.Fatalf("ListResources(docs) = %+v", docs)
+	}
+	requests, _, _ := store.snapshot()
+	if len(requests) != 2 || requests[0] != resourceTestSourceID+":" ||
+		requests[1] != resourceTestSourceID+":docs" {
+		t.Fatalf("ListResources() forwarded requests = %+v", requests)
+	}
+}
+
+func TestBuiltinKnowledgeResourceLookupDoesNotWaitForDataOperation(t *testing.T) {
+	store := &resourceTestStore{sources: []*resourcestore.SourceInfo{{ID: resourceTestSourceID}}}
+	kb := New(WithStores(Stores{Resource: store}))
+	kb.dataOperationMu.Lock()
+	defer kb.dataOperationMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := kb.ListSources(context.Background(), &ListSourcesRequest{})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ListSources() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ListSources() waited for an unrelated data operation")
+	}
+}
+
+func TestBuiltinKnowledgeReadAndGrepPersistedResource(t *testing.T) {
+	store := &resourceTestStore{contents: map[string]string{
+		"docs/config.md": "header\nalpha one\nmiddle\nalpha two\nfooter\n",
+	}}
+	kb := New(WithStores(Stores{Resource: store}))
+
+	read, err := kb.ReadResource(context.Background(), &ReadResourceRequest{
+		SourceID: resourceTestSourceID, Path: "docs/config.md", StartLine: 2, EndLine: 3,
+	})
+	if err != nil {
+		t.Fatalf("ReadResource() error = %v", err)
+	}
+	if strings.Join(read.Lines, "|") != "alpha one|middle" || read.EOF || read.NextStartLine != 4 {
+		t.Fatalf("ReadResource() = %+v", read)
+	}
+
+	grep, err := kb.GrepResource(context.Background(), &GrepResourceRequest{
+		SourceID: resourceTestSourceID,
+		Path:     "docs/config.md", Pattern: "alpha", Before: 1, After: 1, MaxMatches: 1,
+	})
+	if err != nil {
+		t.Fatalf("GrepResource() error = %v", err)
+	}
+	if !grep.Truncated || len(grep.Blocks) != 1 ||
+		strings.Join(grep.Blocks[0].Lines, "|") != "header|alpha one|middle" {
+		t.Fatalf("GrepResource() = %+v", grep)
+	}
+	_, paths, closes := store.snapshot()
+	if len(paths) != 2 || paths[0] != resourceTestSourceID+":docs/config.md" ||
+		paths[1] != resourceTestSourceID+":docs/config.md" || closes != 2 {
+		t.Fatalf("OpenResource() paths = %v, closes = %d", paths, closes)
+	}
+}
+
+func TestBuiltinKnowledgeReadPastEOFReturnsEmptyRange(t *testing.T) {
+	store := &resourceTestStore{contents: map[string]string{"a.txt": "only line\n"}}
+	kb := New(WithStores(Stores{Resource: store}))
+	result, err := kb.ReadResource(context.Background(), &ReadResourceRequest{
+		SourceID: resourceTestSourceID, Path: "a.txt", StartLine: 10, EndLine: 20,
+	})
+	if err != nil {
+		t.Fatalf("ReadResource() error = %v", err)
+	}
+	if len(result.Lines) != 0 || !result.EOF || result.StartLine != 10 || result.EndLine != 0 {
+		t.Fatalf("ReadResource() = %+v, want an empty EOF range", result)
+	}
+}
+
+func TestBuiltinKnowledgeRejectsOverlongResourceLines(t *testing.T) {
+	store := &resourceTestStore{contents: map[string]string{
+		"large.txt": strings.Repeat("x", maxResourceLineBytes+1),
+	}}
+	kb := New(WithStores(Stores{Resource: store}))
+
+	_, err := kb.ReadResource(context.Background(), &ReadResourceRequest{
+		SourceID: resourceTestSourceID, Path: "large.txt",
+	})
+	if !errors.Is(err, ErrResourceLimitExceeded) {
+		t.Fatalf("ReadResource() error = %v, want %v", err, ErrResourceLimitExceeded)
+	}
+	_, err = kb.GrepResource(context.Background(), &GrepResourceRequest{
+		SourceID: resourceTestSourceID, Path: "large.txt", Pattern: "x",
+	})
+	if !errors.Is(err, ErrResourceLimitExceeded) {
+		t.Fatalf("GrepResource() error = %v, want %v", err, ErrResourceLimitExceeded)
+	}
+}
+
+func TestBuiltinKnowledgeGrepValidatesRegexBeforeOpen(t *testing.T) {
+	store := &resourceTestStore{contents: map[string]string{"a.txt": "a"}}
+	kb := New(WithStores(Stores{Resource: store}))
+	_, err := kb.GrepResource(context.Background(), &GrepResourceRequest{
+		SourceID: resourceTestSourceID, Path: "a.txt", Pattern: "[", Regex: true,
+	})
+	if err == nil {
+		t.Fatal("GrepResource() error = nil, want invalid regex")
+	}
+	_, paths, _ := store.snapshot()
+	if len(paths) != 0 {
+		t.Fatalf("OpenResource() paths = %v, want none", paths)
+	}
+}
+
+func TestBuiltinKnowledgeRejectsUnsafeResourcePaths(t *testing.T) {
+	store := &resourceTestStore{}
+	kb := New(WithStores(Stores{Resource: store}))
+	unsafePaths := []string{
+		"", "/etc/passwd", "../secret", "docs/../secret", `C:\\secret.txt`,
+		"hdfs://cluster/secret", "file:/etc/passwd", "./hdfs://cluster/secret",
+		"./file:/etc/passwd", "./C:/secret", "bad\x00path",
+	}
+	for _, resourcePath := range unsafePaths {
+		t.Run(resourcePath, func(t *testing.T) {
+			_, err := kb.ReadResource(context.Background(), &ReadResourceRequest{
+				SourceID: resourceTestSourceID, Path: resourcePath,
+			})
+			if err == nil {
+				t.Fatal("ReadResource() error = nil, want invalid path")
+			}
+		})
+	}
+	_, paths, _ := store.snapshot()
+	if len(paths) != 0 {
+		t.Fatalf("OpenResource() paths = %v, want none", paths)
+	}
+}
+
+func TestBuiltinKnowledgeResourceStoreResolution(t *testing.T) {
+	kb := New()
+	if _, err := kb.ListSources(context.Background(), &ListSourcesRequest{}); !errors.Is(err, ErrResourceCapabilityUnavailable) {
+		t.Fatalf("ListSources() error = %v, want %v", err, ErrResourceCapabilityUnavailable)
+	}
+	if _, err := kb.ReadResource(context.Background(), &ReadResourceRequest{
+		SourceID: resourceTestSourceID, Path: "a.txt",
+	}); !errors.Is(err, ErrResourceCapabilityUnavailable) {
+		t.Fatalf("ReadResource() error = %v, want %v", err, ErrResourceCapabilityUnavailable)
+	}
+}
+
+func TestBuiltinKnowledgeResourceBackendErrorsAreRedacted(t *testing.T) {
+	backendErr := errors.New("dial hdfs://private-host with secret token")
+	store := &resourceTestStore{openErr: backendErr}
+	kb := New(WithStores(Stores{Resource: store}))
+	_, err := kb.ReadResource(context.Background(), &ReadResourceRequest{
+		SourceID: resourceTestSourceID, Path: "a.txt",
+	})
+	if !errors.Is(err, ErrResourceStoreUnavailable) {
+		t.Fatalf("ReadResource() error = %v, want %v", err, ErrResourceStoreUnavailable)
+	}
+	if strings.Contains(err.Error(), "private-host") || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("ReadResource() exposed backend details: %v", err)
+	}
+}
+
+func TestBuiltinKnowledgeRejectsUnsafeStoreListing(t *testing.T) {
+	store := &resourceTestStore{listResults: map[string][]*resourcestore.ResourceInfo{
+		"": {{Path: "/private/root/a.txt"}},
+	}}
+	kb := New(WithStores(Stores{Resource: store}))
+	_, err := kb.ListResources(context.Background(), &ListResourcesRequest{SourceID: resourceTestSourceID})
+	if !errors.Is(err, ErrResourceStoreUnavailable) {
+		t.Fatalf("ListResources() error = %v, want %v", err, ErrResourceStoreUnavailable)
+	}
+}
+
+func TestBuiltinKnowledgeRejectsCrossSourceStoreListing(t *testing.T) {
+	store := &resourceTestStore{listResults: map[string][]*resourcestore.ResourceInfo{
+		"": {{SourceID: "another-source", Path: "a.txt"}},
+	}}
+	kb := New(WithStores(Stores{Resource: store}))
+	_, err := kb.ListResources(context.Background(), &ListResourcesRequest{SourceID: resourceTestSourceID})
+	if !errors.Is(err, ErrResourceStoreUnavailable) {
+		t.Fatalf("ListResources() error = %v, want %v", err, ErrResourceStoreUnavailable)
+	}
+}
+
+func TestBuiltinKnowledgeRejectsUnboundedStoreListing(t *testing.T) {
+	store := &resourceTestStore{listResults: map[string][]*resourcestore.ResourceInfo{
+		"": make([]*resourcestore.ResourceInfo, maxResourceListEntries+1),
+	}}
+	kb := New(WithStores(Stores{Resource: store}))
+	_, err := kb.ListResources(context.Background(), &ListResourcesRequest{SourceID: resourceTestSourceID})
+	if !errors.Is(err, ErrResourceLimitExceeded) {
+		t.Fatalf("ListResources() error = %v, want %v", err, ErrResourceLimitExceeded)
+	}
+}
+
+func TestBuiltinKnowledgeRejectsInvalidStoreSources(t *testing.T) {
+	for _, sources := range [][]*resourcestore.SourceInfo{
+		{nil},
+		{{ID: " "}},
+		{{ID: resourceTestSourceID}, {ID: " " + resourceTestSourceID + " "}},
+	} {
+		store := &resourceTestStore{sources: sources}
+		kb := New(WithStores(Stores{Resource: store}))
+		_, err := kb.ListSources(context.Background(), &ListSourcesRequest{})
+		if !errors.Is(err, ErrResourceStoreUnavailable) {
+			t.Fatalf("ListSources(%+v) error = %v, want %v", sources, err, ErrResourceStoreUnavailable)
+		}
+	}
+}

--- a/knowledge/resource_load.go
+++ b/knowledge/resource_load.go
@@ -1,0 +1,328 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/codeast"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
+)
+
+const maxResourceIngestionEntries = 1_000_000
+
+func (dk *BuiltinKnowledge) validateResourceSourceIDs(sources []source.Source) error {
+	if dk.resourceStore == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	for _, src := range sources {
+		if src == nil {
+			return errors.New("source cannot be nil")
+		}
+		_, isResourceSource := src.(source.ResourceSource)
+		sourceID := src.Name()
+		if previousIsResourceSource, duplicate := seen[sourceID]; duplicate {
+			if previousIsResourceSource || isResourceSource {
+				return fmt.Errorf("duplicate resource source ID %q", sourceID)
+			}
+		} else {
+			seen[sourceID] = isResourceSource
+		}
+		if !isResourceSource {
+			continue
+		}
+		if strings.TrimSpace(sourceID) == "" {
+			return errors.New("resource source name cannot be empty")
+		}
+		if sourceID != strings.TrimSpace(sourceID) {
+			return fmt.Errorf("resource source name %q has surrounding whitespace", sourceID)
+		}
+	}
+	return nil
+}
+
+// readSourceDocuments persists source-level text before returning the derived
+// documents that may reference it. Legacy Sources remain vector-only.
+func (dk *BuiltinKnowledge) readSourceDocuments(
+	ctx context.Context,
+	src source.Source,
+) ([]*document.Document, []string, error) {
+	resourceSource, ok := src.(source.ResourceSource)
+	if dk.resourceStore == nil || !ok {
+		documents, err := src.ReadDocuments(ctx)
+		return documents, nil, err
+	}
+	resources, err := resourceSource.ReadResources(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	sourceID := src.Name()
+	documents, resourcePaths, err := prepareSourceResources(sourceID, resources)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := dk.resourceStore.PutSource(ctx, &resourcestore.SourceInfo{
+		ID:   sourceID,
+		Name: sourceID,
+		Type: strings.TrimSpace(src.Type()),
+	}); err != nil {
+		return nil, nil, publicResourceStoreError(ctx, err)
+	}
+	for index, resource := range resources {
+		resourcePath := resourcePaths[index]
+		info := &resourcestore.ResourceInfo{
+			SourceID:   sourceID,
+			Path:       resourcePath,
+			Name:       path.Base(resourcePath),
+			Size:       int64(len(resource.Content)),
+			ModifiedAt: resource.ModifiedAt,
+		}
+		if err := dk.resourceStore.PutResource(ctx, info, strings.NewReader(resource.Content)); err != nil {
+			return nil, nil, publicResourceStoreError(ctx, err)
+		}
+	}
+	return documents, resourcePaths, nil
+}
+
+func prepareSourceResources(
+	sourceID string,
+	resources []*source.Resource,
+) ([]*document.Document, []string, error) {
+	seenPaths := make(map[string]struct{}, len(resources))
+	documentPaths := make(map[*document.Document]string)
+	resourcePaths := make([]string, 0, len(resources))
+	var documents []*document.Document
+	for _, resource := range resources {
+		if resource == nil {
+			return nil, nil, errors.New("resource source returned a nil resource")
+		}
+		resourcePath, ok := cleanResourcePath(resource.Path)
+		if !ok {
+			return nil, nil, fmt.Errorf("invalid resource path %q", resource.Path)
+		}
+		if _, duplicate := seenPaths[resourcePath]; duplicate {
+			return nil, nil, fmt.Errorf("duplicate resource path %q", resourcePath)
+		}
+		if !utf8.ValidString(resource.Content) {
+			return nil, nil, fmt.Errorf("resource %q is not valid UTF-8", resourcePath)
+		}
+		seenPaths[resourcePath] = struct{}{}
+		resourcePaths = append(resourcePaths, resourcePath)
+		for _, doc := range resource.Documents {
+			if doc == nil {
+				return nil, nil, fmt.Errorf("resource %q returned a nil document", resourcePath)
+			}
+			if previousPath, duplicate := documentPaths[doc]; duplicate {
+				return nil, nil, fmt.Errorf(
+					"document is shared by resources %q and %q",
+					previousPath,
+					resourcePath,
+				)
+			}
+			documentPaths[doc] = resourcePath
+			preparedDocument := doc.Clone()
+			annotateResourceDocument(preparedDocument, sourceID, resourcePath, resource.Content)
+			documents = append(documents, preparedDocument)
+		}
+	}
+	return documents, resourcePaths, nil
+}
+
+func annotateResourceDocument(
+	doc *document.Document,
+	sourceID string,
+	resourcePath string,
+	resourceContent string,
+) {
+	if doc.Metadata == nil {
+		doc.Metadata = make(map[string]any)
+	}
+	totalLines := resourceLineCount(resourceContent)
+	start, end, hasResourceRange := metadataLineRange(
+		doc.Metadata,
+		source.MetaResourceStartLine,
+		source.MetaResourceEndLine,
+		totalLines,
+	)
+	doc.Metadata[source.MetaSourceID] = sourceID
+	doc.Metadata[source.MetaSourceName] = sourceID
+	doc.Metadata[source.MetaResourcePath] = resourcePath
+	delete(doc.Metadata, source.MetaResourceStartLine)
+	delete(doc.Metadata, source.MetaResourceEndLine)
+
+	if hasResourceRange {
+		doc.Metadata[source.MetaResourceStartLine] = start
+		doc.Metadata[source.MetaResourceEndLine] = end
+		return
+	}
+	if start, end, ok := metadataResourceLineRange(doc.Metadata, totalLines); ok {
+		doc.Metadata[source.MetaResourceStartLine] = start
+		doc.Metadata[source.MetaResourceEndLine] = end
+		return
+	}
+	if start, end, ok := uniqueDocumentLineRange(resourceContent, doc.Content); ok {
+		doc.Metadata[source.MetaResourceStartLine] = start
+		doc.Metadata[source.MetaResourceEndLine] = end
+	}
+}
+
+func metadataResourceLineRange(metadata map[string]any, totalLines int) (int, int, bool) {
+	return metadataLineRange(
+		metadata,
+		codeast.TrpcAstMetaPrefix+"line_start",
+		codeast.TrpcAstMetaPrefix+"line_end",
+		totalLines,
+	)
+}
+
+func metadataLineRange(
+	metadata map[string]any,
+	startKey string,
+	endKey string,
+	totalLines int,
+) (int, int, bool) {
+	start, startOK := convertToInt(metadata[startKey])
+	end, endOK := convertToInt(metadata[endKey])
+	if !startOK || !endOK || start <= 0 || end < start || end > totalLines {
+		return 0, 0, false
+	}
+	return start, end, true
+}
+
+func uniqueDocumentLineRange(content string, documentContent string) (int, int, bool) {
+	if documentContent == "" {
+		return 0, 0, false
+	}
+	startOffset := strings.Index(content, documentContent)
+	if startOffset < 0 || startOffset != strings.LastIndex(content, documentContent) {
+		return 0, 0, false
+	}
+	startLine := 1 + strings.Count(content[:startOffset], "\n")
+	endOffset := startOffset + len(documentContent) - 1
+	endLine := 1 + strings.Count(content[:endOffset], "\n")
+	return startLine, endLine, true
+}
+
+func resourceLineCount(content string) int {
+	if content == "" {
+		return 0
+	}
+	lineCount := strings.Count(content, "\n")
+	if !strings.HasSuffix(content, "\n") {
+		lineCount++
+	}
+	return lineCount
+}
+
+func (dk *BuiltinKnowledge) cleanupStaleResources(
+	ctx context.Context,
+	currentPaths map[string][]string,
+) error {
+	if dk.resourceStore == nil || len(currentPaths) == 0 {
+		return nil
+	}
+	for sourceID, paths := range currentPaths {
+		existingPaths, err := dk.listStoredResourcePaths(ctx, sourceID)
+		if err != nil {
+			return err
+		}
+		current := make(map[string]struct{}, len(paths))
+		for _, resourcePath := range paths {
+			current[resourcePath] = struct{}{}
+		}
+		stale := make([]string, 0)
+		for _, resourcePath := range existingPaths {
+			if _, ok := current[resourcePath]; !ok {
+				stale = append(stale, resourcePath)
+			}
+		}
+		sort.Strings(stale)
+		for _, resourcePath := range stale {
+			if err := dk.resourceStore.DeleteResource(ctx, sourceID, resourcePath); err != nil &&
+				!errors.Is(err, resourcestore.ErrNotFound) {
+				return publicResourceStoreError(ctx, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (dk *BuiltinKnowledge) listStoredResourcePaths(
+	ctx context.Context,
+	sourceID string,
+) ([]string, error) {
+	queue := []string{""}
+	seenDirectories := map[string]struct{}{"": {}}
+	seenEntries := make(map[string]struct{})
+	var paths []string
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		parentPath := queue[0]
+		queue = queue[1:]
+		entries, err := dk.resourceStore.ListResources(ctx, sourceID, parentPath)
+		if err != nil {
+			if parentPath == "" && errors.Is(err, resourcestore.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, publicResourceStoreError(ctx, err)
+		}
+		for _, entry := range entries {
+			projected, valid := projectListedResource(sourceID, parentPath, entry)
+			if !valid {
+				return nil, ErrResourceStoreUnavailable
+			}
+			if _, duplicate := seenEntries[projected.Path]; duplicate {
+				return nil, ErrResourceStoreUnavailable
+			}
+			seenEntries[projected.Path] = struct{}{}
+			if len(seenEntries) > maxResourceIngestionEntries {
+				return nil, ErrResourceLimitExceeded
+			}
+			if projected.IsDir {
+				if _, duplicate := seenDirectories[projected.Path]; duplicate {
+					return nil, ErrResourceStoreUnavailable
+				}
+				seenDirectories[projected.Path] = struct{}{}
+				queue = append(queue, projected.Path)
+				continue
+			}
+			paths = append(paths, projected.Path)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func (dk *BuiltinKnowledge) deleteStoredResourceSource(ctx context.Context, sourceID string) error {
+	if dk.resourceStore == nil {
+		return nil
+	}
+	if strings.TrimSpace(sourceID) == "" {
+		return errors.New("source ID cannot be empty")
+	}
+	if sourceID != strings.TrimSpace(sourceID) {
+		return errors.New("source ID cannot have surrounding whitespace")
+	}
+	if err := dk.resourceStore.DeleteSource(ctx, sourceID); err != nil &&
+		!errors.Is(err, resourcestore.ErrNotFound) {
+		return publicResourceStoreError(ctx, err)
+	}
+	return nil
+}

--- a/knowledge/resource_load_test.go
+++ b/knowledge/resource_load_test.go
@@ -1,0 +1,923 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
+)
+
+func TestLoadPersistsResourcesBeforeVectorDocuments(t *testing.T) {
+	events := &resourceLoadEvents{}
+	exact := &document.Document{ID: "exact", Content: "line two"}
+	ast := &document.Document{ID: "ast", Content: "structured entity", Metadata: map[string]any{
+		"trpc_ast_line_start": 3,
+		"trpc_ast_line_end":   3,
+	}}
+	src := &resourceLoadSource{
+		name:   "docs",
+		events: events,
+		resources: []*source.Resource{{
+			Path:      "guide.txt",
+			Content:   "line one\nline two\nline three\n",
+			Documents: []*document.Document{exact, ast},
+		}},
+	}
+	resourceStore := newResourceLoadStore(events)
+	vectorStore := &resourceLoadVectorStore{events: events}
+	kb := New(
+		WithSources([]source.Source{src}),
+		WithStores(Stores{Vector: vectorStore, Resource: resourceStore}),
+	)
+
+	err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if src.readDocumentsCalls != 0 || src.readResourcesCalls != 1 {
+		t.Fatalf(
+			"source calls = ReadDocuments:%d ReadResources:%d, want 0 and 1",
+			src.readDocumentsCalls,
+			src.readResourcesCalls,
+		)
+	}
+	wantPrefix := []string{"read_resources", "put_source:docs", "put_resource:guide.txt"}
+	gotEvents := events.snapshot()
+	if len(gotEvents) < len(wantPrefix)+2 {
+		t.Fatalf("events = %v, want resource writes followed by vector writes", gotEvents)
+	}
+	for i, want := range wantPrefix {
+		if gotEvents[i] != want {
+			t.Fatalf("events[%d] = %q, want %q; all events: %v", i, gotEvents[i], want, gotEvents)
+		}
+	}
+	for _, event := range gotEvents[len(wantPrefix):] {
+		if !strings.HasPrefix(event, "vector_add:") {
+			t.Fatalf("event after resource persistence = %q, want vector_add; all events: %v", event, gotEvents)
+		}
+	}
+	if got := resourceStore.content("docs", "guide.txt"); got != "line one\nline two\nline three\n" {
+		t.Fatalf("persisted resource content = %q", got)
+	}
+	assertResourceDocumentMetadata(t, vectorStore.document("exact"), "docs", "guide.txt", 2, 2)
+	assertResourceDocumentMetadata(t, vectorStore.document("ast"), "docs", "guide.txt", 3, 3)
+	if _, mutated := exact.Metadata[source.MetaSourceID]; mutated {
+		t.Fatalf("source document was mutated: %+v", exact.Metadata)
+	}
+}
+
+func TestLoadKeepsLegacySourcesVectorOnly(t *testing.T) {
+	events := &resourceLoadEvents{}
+	legacy := &resourceLegacySource{doc: &document.Document{ID: "legacy", Content: "legacy"}}
+	resourceStore := newResourceLoadStore(events)
+	vectorStore := &resourceLoadVectorStore{events: events}
+	kb := New(
+		WithSources([]source.Source{legacy}),
+		WithStores(Stores{Vector: vectorStore, Resource: resourceStore}),
+	)
+	if err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if legacy.calls != 1 {
+		t.Fatalf("ReadDocuments() calls = %d, want 1", legacy.calls)
+	}
+	for _, event := range events.snapshot() {
+		if strings.HasPrefix(event, "put_") {
+			t.Fatalf("legacy source caused resource write: %v", events.snapshot())
+		}
+	}
+}
+
+func TestLoadWithoutResourceStoreUsesLegacyRead(t *testing.T) {
+	events := &resourceLoadEvents{}
+	src := &resourceLoadSource{
+		name:      "docs",
+		events:    events,
+		legacyDoc: &document.Document{ID: "legacy", Content: "legacy"},
+		resources: []*source.Resource{{Path: "guide.txt", Content: "full"}},
+	}
+	kb := New(
+		WithSources([]source.Source{src}),
+		WithVectorStore(&resourceLoadVectorStore{events: events}),
+	)
+	if err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if src.readDocumentsCalls != 1 || src.readResourcesCalls != 0 {
+		t.Fatalf(
+			"source calls = ReadDocuments:%d ReadResources:%d, want 1 and 0",
+			src.readDocumentsCalls,
+			src.readResourcesCalls,
+		)
+	}
+}
+
+func TestLoadValidatesAllResourcesBeforeWriting(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []*source.Resource
+	}{
+		{
+			name:      "unsafe path",
+			resources: []*source.Resource{{Path: "../secret", Content: "secret"}},
+		},
+		{
+			name: "duplicate path",
+			resources: []*source.Resource{
+				{Path: "same.txt", Content: "one"},
+				{Path: "./same.txt", Content: "two"},
+			},
+		},
+		{
+			name: "shared document",
+			resources: func() []*source.Resource {
+				doc := &document.Document{Content: "shared"}
+				return []*source.Resource{
+					{Path: "one.txt", Content: "shared", Documents: []*document.Document{doc}},
+					{Path: "two.txt", Content: "shared", Documents: []*document.Document{doc}},
+				}
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := &resourceLoadEvents{}
+			src := &resourceLoadSource{name: "docs", events: events, resources: tt.resources}
+			kb := New(
+				WithSources([]source.Source{src}),
+				WithStores(Stores{
+					Vector:   &resourceLoadVectorStore{events: events},
+					Resource: newResourceLoadStore(events),
+				}),
+			)
+			err := kb.Load(
+				context.Background(),
+				WithSourceConcurrency(1),
+				WithDocConcurrency(1),
+				WithShowProgress(false),
+				WithShowStats(false),
+			)
+			if err == nil {
+				t.Fatal("Load() error = nil, want validation error")
+			}
+			for _, event := range events.snapshot() {
+				if strings.HasPrefix(event, "put_") || strings.HasPrefix(event, "vector_add:") {
+					t.Fatalf("validation failure wrote a store: %v", events.snapshot())
+				}
+			}
+		})
+	}
+}
+
+func TestLoadResourceWriteFailurePreventsVectorWrite(t *testing.T) {
+	events := &resourceLoadEvents{}
+	src := &resourceLoadSource{
+		name:   "docs",
+		events: events,
+		resources: []*source.Resource{{
+			Path:      "guide.txt",
+			Content:   "full",
+			Documents: []*document.Document{{ID: "chunk", Content: "full"}},
+		}},
+	}
+	store := newResourceLoadStore(events)
+	store.putResourceErr = errors.New("private backend failure")
+	kb := New(
+		WithSources([]source.Source{src}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: store,
+		}),
+	)
+	err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	)
+	if !errors.Is(err, ErrResourceStoreUnavailable) {
+		t.Fatalf("Load() error = %v, want %v", err, ErrResourceStoreUnavailable)
+	}
+	for _, event := range events.snapshot() {
+		if strings.HasPrefix(event, "vector_add:") {
+			t.Fatalf("resource write failure was followed by vector write: %v", events.snapshot())
+		}
+	}
+}
+
+func TestLoadPartialResourceWriteFailurePreventsVectorWrite(t *testing.T) {
+	events := &resourceLoadEvents{}
+	src := &resourceLoadSource{
+		name:   "docs",
+		events: events,
+		resources: []*source.Resource{
+			{
+				Path:      "one.txt",
+				Content:   "one",
+				Documents: []*document.Document{{ID: "one", Content: "one"}},
+			},
+			{
+				Path:      "two.txt",
+				Content:   "two",
+				Documents: []*document.Document{{ID: "two", Content: "two"}},
+			},
+		},
+	}
+	store := newResourceLoadStore(events)
+	store.putResourceErrAt = 2
+	kb := New(
+		WithSources([]source.Source{src}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: store,
+		}),
+	)
+	err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	)
+	if !errors.Is(err, ErrResourceStoreUnavailable) {
+		t.Fatalf("Load() error = %v, want %v", err, ErrResourceStoreUnavailable)
+	}
+	if got := store.content("docs", "one.txt"); got != "one" {
+		t.Fatalf("first idempotent resource write = %q, want one", got)
+	}
+	for _, event := range events.snapshot() {
+		if strings.HasPrefix(event, "vector_add:") {
+			t.Fatalf("partial resource write failure was followed by vector write: %v", events.snapshot())
+		}
+	}
+}
+
+func TestLoadVectorFailureKeepsRetryableResourceWrite(t *testing.T) {
+	events := &resourceLoadEvents{}
+	src := &resourceLoadSource{
+		name:   "docs",
+		events: events,
+		resources: []*source.Resource{{
+			Path:      "guide.txt",
+			Content:   "full",
+			Documents: []*document.Document{{ID: "chunk", Content: "full"}},
+		}},
+	}
+	store := newResourceLoadStore(events)
+	kb := New(
+		WithSources([]source.Source{src}),
+		WithStores(Stores{
+			Vector: &resourceLoadVectorStore{
+				events: events,
+				addErr: errors.New("vector failed"),
+			},
+			Resource: store,
+		}),
+	)
+	if err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	); err == nil {
+		t.Fatal("Load() error = nil, want vector failure")
+	}
+	if got := store.content("docs", "guide.txt"); got != "full" {
+		t.Fatalf("retryable resource write = %q, want full", got)
+	}
+}
+
+func TestLoadRecreateCleansStaleResourcesAfterVectorWrite(t *testing.T) {
+	events := &resourceLoadEvents{}
+	store := newResourceLoadStore(events)
+	store.resources["docs"] = map[string]string{"old.txt": "old"}
+	store.sources["docs"] = &resourcestore.SourceInfo{ID: "docs", Name: "docs"}
+	src := &resourceLoadSource{
+		name:   "docs",
+		events: events,
+		resources: []*source.Resource{{
+			Path:      "new.txt",
+			Content:   "new",
+			Documents: []*document.Document{{ID: "new", Content: "new"}},
+		}},
+	}
+	kb := New(
+		WithSources([]source.Source{src}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: store,
+		}),
+	)
+	if err := kb.Load(
+		context.Background(),
+		WithRecreate(true),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := store.content("docs", "old.txt"); got != "" {
+		t.Fatalf("stale resource remained: %q", got)
+	}
+	if got := store.content("docs", "new.txt"); got != "new" {
+		t.Fatalf("new resource = %q, want new", got)
+	}
+	gotEvents := events.snapshot()
+	vectorIndex := eventIndex(gotEvents, "vector_add:new")
+	deleteIndex := eventIndex(gotEvents, "delete_resource:old.txt")
+	if vectorIndex < 0 || deleteIndex <= vectorIndex {
+		t.Fatalf("events = %v, want stale deletion after vector add", gotEvents)
+	}
+}
+
+func TestReloadFailureKeepsOldSourceRegistered(t *testing.T) {
+	events := &resourceLoadEvents{}
+	oldSource := &resourceLoadSource{name: "docs", events: events}
+	newSource := &resourceLoadSource{
+		name:   "docs",
+		events: events,
+		resources: []*source.Resource{{
+			Path:      "new.txt",
+			Content:   "new",
+			Documents: []*document.Document{{ID: "new", Content: "new"}},
+		}},
+	}
+	store := newResourceLoadStore(events)
+	store.putResourceErr = errors.New("write failed")
+	kb := New(
+		WithSources([]source.Source{oldSource}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: store,
+		}),
+	)
+	if err := kb.ReloadSource(
+		context.Background(),
+		newSource,
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	); err == nil {
+		t.Fatal("ReloadSource() error = nil, want write failure")
+	}
+	if len(kb.sources) != 1 || kb.sources[0] != oldSource {
+		t.Fatalf("sources = %v, want original source retained", kb.sources)
+	}
+}
+
+func TestLoadRejectsDuplicateResourceSourceNames(t *testing.T) {
+	events := &resourceLoadEvents{}
+	sources := []source.Source{
+		&resourceLoadSource{name: "docs", events: events},
+		&resourceLoadSource{name: "docs", events: events},
+	}
+	kb := New(
+		WithSources(sources),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: newResourceLoadStore(events),
+		}),
+	)
+	err := kb.Load(
+		context.Background(),
+		WithRecreate(true),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	)
+	if err == nil || !strings.Contains(err.Error(), "duplicate resource source ID") {
+		t.Fatalf("Load() error = %v, want duplicate source ID", err)
+	}
+	if len(events.snapshot()) != 0 {
+		t.Fatalf("duplicate source IDs performed I/O: %v", events.snapshot())
+	}
+}
+
+func TestLoadRejectsResourceAndLegacySourceNameCollision(t *testing.T) {
+	events := &resourceLoadEvents{}
+	kb := New(
+		WithSources([]source.Source{
+			&resourceLoadSource{name: "docs", events: events},
+			&resourceLegacySource{name: "docs"},
+		}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: newResourceLoadStore(events),
+		}),
+	)
+	err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	)
+	if err == nil || !strings.Contains(err.Error(), "duplicate resource source ID") {
+		t.Fatalf("Load() error = %v, want source name collision", err)
+	}
+	if len(events.snapshot()) != 0 {
+		t.Fatalf("source name collision performed I/O: %v", events.snapshot())
+	}
+}
+
+func TestLoadRejectsNonCanonicalResourceSourceName(t *testing.T) {
+	events := &resourceLoadEvents{}
+	kb := New(
+		WithSources([]source.Source{&resourceLoadSource{name: " docs ", events: events}}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: newResourceLoadStore(events),
+		}),
+	)
+	err := kb.Load(
+		context.Background(),
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	)
+	if err == nil || !strings.Contains(err.Error(), "surrounding whitespace") {
+		t.Fatalf("Load() error = %v, want canonical source name error", err)
+	}
+	if len(events.snapshot()) != 0 {
+		t.Fatalf("invalid source name performed I/O: %v", events.snapshot())
+	}
+}
+
+func TestRemoveLegacySourceDoesNotDeleteStoredResources(t *testing.T) {
+	events := &resourceLoadEvents{}
+	store := newResourceLoadStore(events)
+	store.sources["legacy"] = &resourcestore.SourceInfo{ID: "legacy", Name: "legacy"}
+	store.resources["legacy"] = map[string]string{"external.txt": "external"}
+	kb := New(
+		WithSources([]source.Source{&resourceLegacySource{}}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: store,
+		}),
+	)
+	if err := kb.RemoveSource(context.Background(), "legacy"); err != nil {
+		t.Fatalf("RemoveSource() error = %v", err)
+	}
+	if got := store.content("legacy", "external.txt"); got != "external" {
+		t.Fatalf("legacy source removed external resource content: %q", got)
+	}
+	if eventIndex(events.snapshot(), "delete_source:legacy") >= 0 {
+		t.Fatalf("legacy source deleted a resource source: %v", events.snapshot())
+	}
+}
+
+func TestResourceMutationsRequireVectorStore(t *testing.T) {
+	events := &resourceLoadEvents{}
+	store := newResourceLoadStore(events)
+	src := &resourceLoadSource{name: "docs", events: events}
+
+	addKnowledge := New(WithStores(Stores{Resource: store}))
+	if err := addKnowledge.AddSource(context.Background(), src); err == nil ||
+		err.Error() != "vector store not configured" {
+		t.Fatalf("AddSource() error = %v, want vector store not configured", err)
+	}
+
+	configuredKnowledge := New(
+		WithSources([]source.Source{src}),
+		WithStores(Stores{Resource: store}),
+	)
+	if err := configuredKnowledge.ReloadSource(context.Background(), src); err == nil ||
+		err.Error() != "vector store not configured" {
+		t.Fatalf("ReloadSource() error = %v, want vector store not configured", err)
+	}
+	if err := configuredKnowledge.RemoveSource(context.Background(), "docs"); err == nil ||
+		err.Error() != "vector store not configured" {
+		t.Fatalf("RemoveSource() error = %v, want vector store not configured", err)
+	}
+	if len(events.snapshot()) != 0 {
+		t.Fatalf("resource-only mutation performed I/O: %v", events.snapshot())
+	}
+}
+
+func TestReloadResourceSourceWithLegacyDeletesStoredResources(t *testing.T) {
+	events := &resourceLoadEvents{}
+	store := newResourceLoadStore(events)
+	store.sources["docs"] = &resourcestore.SourceInfo{ID: "docs", Name: "docs"}
+	store.resources["docs"] = map[string]string{"old.txt": "old"}
+	oldSource := &resourceLoadSource{name: "docs", events: events}
+	newSource := &resourceLegacySource{
+		name: "docs",
+		doc:  &document.Document{ID: "new", Content: "new"},
+	}
+	kb := New(
+		WithSources([]source.Source{oldSource}),
+		WithStores(Stores{
+			Vector:   &resourceLoadVectorStore{events: events},
+			Resource: store,
+		}),
+	)
+	if err := kb.ReloadSource(
+		context.Background(),
+		newSource,
+		WithSourceConcurrency(1),
+		WithDocConcurrency(1),
+		WithShowProgress(false),
+		WithShowStats(false),
+	); err != nil {
+		t.Fatalf("ReloadSource() error = %v", err)
+	}
+	if _, ok := store.sources["docs"]; ok {
+		t.Fatal("replaced resource source metadata remained")
+	}
+	eventList := events.snapshot()
+	if vectorIndex, deleteIndex := eventIndex(eventList, "vector_add:new"), eventIndex(eventList, "delete_source:docs"); vectorIndex < 0 || deleteIndex <= vectorIndex {
+		t.Fatalf("events = %v, want resource deletion after vector add", eventList)
+	}
+}
+
+func TestResourceLineCountMatchesScannerLines(t *testing.T) {
+	tests := []struct {
+		content string
+		want    int
+	}{
+		{content: "", want: 0},
+		{content: "one", want: 1},
+		{content: "one\n", want: 1},
+		{content: "one\ntwo", want: 2},
+		{content: "one\ntwo\n", want: 2},
+	}
+	for _, tt := range tests {
+		if got := resourceLineCount(tt.content); got != tt.want {
+			t.Fatalf("resourceLineCount(%q) = %d, want %d", tt.content, got, tt.want)
+		}
+	}
+}
+
+func TestResetDocumentIDIncludesResourceLocation(t *testing.T) {
+	src := &resourceLoadSource{name: "docs"}
+	baseMetadata := map[string]any{
+		source.MetaURI:               "file:///guide.txt",
+		source.MetaChunkIndex:        1,
+		source.MetaResourcePath:      "guide.txt",
+		source.MetaResourceStartLine: 10,
+		source.MetaResourceEndLine:   12,
+	}
+	first := &document.Document{Content: "unchanged chunk", Metadata: baseMetadata}
+	shifted := first.Clone()
+	shifted.Metadata[source.MetaResourceStartLine] = 11
+	shifted.Metadata[source.MetaResourceEndLine] = 13
+
+	kb := &BuiltinKnowledge{}
+	if err := kb.resetDocumentID(first, src); err != nil {
+		t.Fatalf("resetDocumentID(first) error = %v", err)
+	}
+	if err := kb.resetDocumentID(shifted, src); err != nil {
+		t.Fatalf("resetDocumentID(shifted) error = %v", err)
+	}
+	if first.ID == shifted.ID {
+		t.Fatalf("resource line shift kept document ID %q", first.ID)
+	}
+}
+
+func assertResourceDocumentMetadata(
+	t *testing.T,
+	doc *document.Document,
+	sourceID string,
+	resourcePath string,
+	startLine int,
+	endLine int,
+) {
+	t.Helper()
+	if doc == nil {
+		t.Fatal("stored document is nil")
+	}
+	if doc.Metadata[source.MetaSourceID] != sourceID ||
+		doc.Metadata[source.MetaSourceName] != sourceID ||
+		doc.Metadata[source.MetaResourcePath] != resourcePath ||
+		doc.Metadata[source.MetaResourceStartLine] != startLine ||
+		doc.Metadata[source.MetaResourceEndLine] != endLine {
+		t.Fatalf("document metadata = %+v", doc.Metadata)
+	}
+}
+
+func eventIndex(events []string, target string) int {
+	for i, event := range events {
+		if event == target {
+			return i
+		}
+	}
+	return -1
+}
+
+type resourceLoadSource struct {
+	name               string
+	events             *resourceLoadEvents
+	legacyDoc          *document.Document
+	resources          []*source.Resource
+	readDocumentsCalls int
+	readResourcesCalls int
+}
+
+func (s *resourceLoadSource) ReadDocuments(context.Context) ([]*document.Document, error) {
+	s.readDocumentsCalls++
+	if s.events != nil {
+		s.events.add("read_documents")
+	}
+	if s.legacyDoc == nil {
+		return nil, nil
+	}
+	return []*document.Document{s.legacyDoc}, nil
+}
+
+func (s *resourceLoadSource) ReadResources(context.Context) ([]*source.Resource, error) {
+	s.readResourcesCalls++
+	if s.events != nil {
+		s.events.add("read_resources")
+	}
+	return s.resources, nil
+}
+
+func (s *resourceLoadSource) Name() string { return s.name }
+
+func (*resourceLoadSource) Type() string { return source.TypeFile }
+
+func (*resourceLoadSource) GetMetadata() map[string]any { return nil }
+
+type resourceLegacySource struct {
+	name  string
+	doc   *document.Document
+	calls int
+}
+
+func (s *resourceLegacySource) ReadDocuments(context.Context) ([]*document.Document, error) {
+	s.calls++
+	return []*document.Document{s.doc}, nil
+}
+
+func (s *resourceLegacySource) Name() string {
+	if s.name != "" {
+		return s.name
+	}
+	return "legacy"
+}
+
+func (*resourceLegacySource) Type() string { return source.TypeFile }
+
+func (*resourceLegacySource) GetMetadata() map[string]any { return nil }
+
+type resourceLoadEvents struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (e *resourceLoadEvents) add(event string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(e.events, event)
+}
+
+func (e *resourceLoadEvents) snapshot() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.events...)
+}
+
+type resourceLoadStore struct {
+	mu sync.Mutex
+
+	events           *resourceLoadEvents
+	sources          map[string]*resourcestore.SourceInfo
+	resources        map[string]map[string]string
+	putResourceErr   error
+	putResourceErrAt int
+	putResourceCalls int
+}
+
+func newResourceLoadStore(events *resourceLoadEvents) *resourceLoadStore {
+	return &resourceLoadStore{
+		events:    events,
+		sources:   make(map[string]*resourcestore.SourceInfo),
+		resources: make(map[string]map[string]string),
+	}
+}
+
+func (s *resourceLoadStore) PutSource(_ context.Context, info *resourcestore.SourceInfo) error {
+	s.events.add("put_source:" + info.ID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cloned := *info
+	s.sources[info.ID] = &cloned
+	return nil
+}
+
+func (s *resourceLoadStore) PutResource(
+	_ context.Context,
+	info *resourcestore.ResourceInfo,
+	content io.Reader,
+) error {
+	s.events.add("put_resource:" + info.Path)
+	if s.putResourceErr != nil {
+		return s.putResourceErr
+	}
+	s.mu.Lock()
+	s.putResourceCalls++
+	shouldFail := s.putResourceErrAt > 0 && s.putResourceCalls == s.putResourceErrAt
+	s.mu.Unlock()
+	if shouldFail {
+		return errors.New("injected resource write failure")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.resources[info.SourceID] == nil {
+		s.resources[info.SourceID] = make(map[string]string)
+	}
+	s.resources[info.SourceID][info.Path] = string(data)
+	return nil
+}
+
+func (s *resourceLoadStore) DeleteResource(_ context.Context, sourceID, resourcePath string) error {
+	s.events.add("delete_resource:" + resourcePath)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.resources[sourceID], resourcePath)
+	return nil
+}
+
+func (s *resourceLoadStore) DeleteSource(_ context.Context, sourceID string) error {
+	s.events.add("delete_source:" + sourceID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sources, sourceID)
+	delete(s.resources, sourceID)
+	return nil
+}
+
+func (s *resourceLoadStore) ListSources(context.Context) ([]*resourcestore.SourceInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]*resourcestore.SourceInfo, 0, len(s.sources))
+	for _, info := range s.sources {
+		cloned := *info
+		result = append(result, &cloned)
+	}
+	return result, nil
+}
+
+func (s *resourceLoadStore) ListResources(
+	_ context.Context,
+	sourceID string,
+	parentPath string,
+) ([]*resourcestore.ResourceInfo, error) {
+	s.events.add("list_resources:" + parentPath)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	files, ok := s.resources[sourceID]
+	if !ok {
+		return nil, resourcestore.ErrNotFound
+	}
+	entries := make(map[string]*resourcestore.ResourceInfo)
+	for resourcePath, content := range files {
+		remainder := resourcePath
+		if parentPath != "" {
+			prefix := parentPath + "/"
+			if !strings.HasPrefix(resourcePath, prefix) {
+				continue
+			}
+			remainder = strings.TrimPrefix(resourcePath, prefix)
+		}
+		segment, rest, _ := strings.Cut(remainder, "/")
+		entryPath := segment
+		if parentPath != "" {
+			entryPath = parentPath + "/" + segment
+		}
+		if rest != "" {
+			entries[entryPath] = &resourcestore.ResourceInfo{
+				SourceID: sourceID,
+				Path:     entryPath,
+				Name:     path.Base(entryPath),
+				IsDir:    true,
+				Size:     -1,
+			}
+			continue
+		}
+		entries[entryPath] = &resourcestore.ResourceInfo{
+			SourceID: sourceID,
+			Path:     entryPath,
+			Name:     path.Base(entryPath),
+			Size:     int64(len(content)),
+		}
+	}
+	result := make([]*resourcestore.ResourceInfo, 0, len(entries))
+	for _, info := range entries {
+		result = append(result, info)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Path < result[j].Path })
+	return result, nil
+}
+
+func (s *resourceLoadStore) OpenResource(
+	_ context.Context,
+	sourceID string,
+	resourcePath string,
+) (io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	content, ok := s.resources[sourceID][resourcePath]
+	if !ok {
+		return nil, resourcestore.ErrNotFound
+	}
+	return io.NopCloser(strings.NewReader(content)), nil
+}
+
+func (*resourceLoadStore) Close() error { return nil }
+
+func (s *resourceLoadStore) content(sourceID, resourcePath string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.resources[sourceID][resourcePath]
+}
+
+type resourceLoadVectorStore struct {
+	storesTestVectorStore
+	events *resourceLoadEvents
+	mu     sync.Mutex
+	docs   map[string]*document.Document
+	addErr error
+}
+
+func (s *resourceLoadVectorStore) Add(
+	_ context.Context,
+	doc *document.Document,
+	_ []float64,
+) error {
+	s.events.add("vector_add:" + doc.ID)
+	if s.addErr != nil {
+		return s.addErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.docs == nil {
+		s.docs = make(map[string]*document.Document)
+	}
+	s.docs[doc.ID] = doc.Clone()
+	return nil
+}
+
+func (s *resourceLoadVectorStore) DeleteByFilter(
+	_ context.Context,
+	_ ...vectorstore.DeleteOption,
+) error {
+	s.events.add("vector_delete")
+	return nil
+}
+
+func (s *resourceLoadVectorStore) document(id string) *document.Document {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	doc := s.docs[id]
+	if doc == nil {
+		return nil
+	}
+	return doc.Clone()
+}

--- a/knowledge/resource_test.go
+++ b/knowledge/resource_test.go
@@ -1,0 +1,30 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"testing"
+)
+
+func TestCleanResourcePathRejectsTraversalAndProviderLocators(t *testing.T) {
+	for _, value := range []string{
+		"/etc/passwd",
+		"docs/../secret",
+		"hdfs://cluster/secret",
+		"file:/etc/passwd",
+		"C:/secret",
+		"./hdfs://cluster/secret",
+		"./file:/etc/passwd",
+		"./C:/secret",
+	} {
+		if cleaned, ok := cleanResourcePath(value); ok {
+			t.Fatalf("cleanResourcePath(%q) = %q, want rejection", value, cleaned)
+		}
+	}
+}

--- a/knowledge/resourcestore/resourcestore.go
+++ b/knowledge/resourcestore/resourcestore.go
@@ -61,7 +61,9 @@ type ResourceInfo struct {
 // indexes. Write methods are used by ingestion; read methods are used at Agent
 // runtime. Implementations must be safe for concurrent use and honor context
 // cancellation. All writes and deletes should be idempotent so a failed import
-// can be retried safely.
+// can be retried safely. This interface does not provide an atomic transaction
+// with vector stores; a failed import may leave completed resource writes that
+// a retry must replace.
 type Store interface {
 	// PutSource inserts or updates safe metadata for one logical source.
 	PutSource(ctx context.Context, source *SourceInfo) error

--- a/knowledge/resourcestore/resourcestore.go
+++ b/knowledge/resourcestore/resourcestore.go
@@ -1,0 +1,95 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package resourcestore defines persistent storage for source-level text
+// resources and their safe metadata.
+package resourcestore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+var (
+	// ErrNotFound means the requested source or resource does not exist.
+	ErrNotFound = errors.New("resource not found")
+	// ErrRepresentationUnavailable means a resource has no readable text representation.
+	ErrRepresentationUnavailable = errors.New("resource representation unavailable")
+	// ErrPermissionDenied means the store rejected access to the resource.
+	ErrPermissionDenied = errors.New("resource permission denied")
+	// ErrUnavailable means the resource store cannot currently serve the request.
+	ErrUnavailable = errors.New("resource store unavailable")
+)
+
+// SourceInfo describes one persisted logical source without exposing provider
+// connection details.
+type SourceInfo struct {
+	// ID is the stable source identifier used by resource calls and chunk metadata.
+	ID string `json:"id"`
+	// Name is the human-readable source name.
+	Name string `json:"name"`
+	// Type is the source type, such as file, dir, repo, or url.
+	Type string `json:"type,omitempty"`
+}
+
+// ResourceInfo describes one persisted file or directory. Path is relative to
+// the source root. Size is the stored text representation size in bytes; a
+// negative value means unknown.
+type ResourceInfo struct {
+	// SourceID identifies the source that owns the resource.
+	SourceID string `json:"source_id"`
+	// Path is a safe path relative to the source root.
+	Path string `json:"path"`
+	// Name is the display name of the resource.
+	Name string `json:"name"`
+	// IsDir reports whether the resource is a directory.
+	IsDir bool `json:"is_dir"`
+	// Size is the stored text representation size in bytes. A negative value means unknown.
+	Size int64 `json:"size"`
+	// ModifiedAt is the source modification time when available.
+	ModifiedAt time.Time `json:"modified_at,omitempty"`
+}
+
+// Store persists source-level text resources separately from chunks and vector
+// indexes. Write methods are used by ingestion; read methods are used at Agent
+// runtime. Implementations must be safe for concurrent use and honor context
+// cancellation. All writes and deletes should be idempotent so a failed import
+// can be retried safely.
+type Store interface {
+	// PutSource inserts or updates safe metadata for one logical source.
+	PutSource(ctx context.Context, source *SourceInfo) error
+
+	// PutResource inserts or replaces one normalized text file. Info.IsDir must
+	// be false. The method consumes content before returning and must not retain
+	// the reader. Stores derive directory entries from persisted file paths;
+	// empty directories are not represented.
+	PutResource(ctx context.Context, info *ResourceInfo, content io.Reader) error
+
+	// DeleteResource deletes one resource by its stable source-relative key.
+	DeleteResource(ctx context.Context, sourceID, path string) error
+
+	// DeleteSource deletes a source and all resources owned by it.
+	DeleteSource(ctx context.Context, sourceID string) error
+
+	// ListSources lists persisted logical sources.
+	ListSources(ctx context.Context) ([]*SourceInfo, error)
+
+	// ListResources lists direct children of parentPath. An empty parentPath
+	// addresses the source root.
+	ListResources(ctx context.Context, sourceID, parentPath string) ([]*ResourceInfo, error)
+
+	// OpenResource opens the persisted UTF-8 text representation at path. The
+	// caller owns and must close the returned stream. Reads from the stream must
+	// unblock when ctx is canceled.
+	OpenResource(ctx context.Context, sourceID, path string) (io.ReadCloser, error)
+
+	// Close releases resources held by the store.
+	Close() error
+}

--- a/knowledge/retriever/default.go
+++ b/knowledge/retriever/default.go
@@ -11,6 +11,7 @@ package retriever
 
 import (
 	"context"
+	"errors"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/embedder"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/query"
@@ -71,6 +72,9 @@ func New(opts ...Option) *DefaultRetriever {
 
 // Retrieve implements the Retriever interface by executing the complete RAG pipeline.
 func (dr *DefaultRetriever) Retrieve(ctx context.Context, q *Query) (*Result, error) {
+	if dr.vectorStore == nil {
+		return nil, errors.New("vector store not configured")
+	}
 	// Step 1: Enhance query (if enhancer is available).
 	finalQuery := q.Text
 	if dr.queryEnhancer != nil && shouldEnhanceQuery(q) {

--- a/knowledge/retriever/default_test.go
+++ b/knowledge/retriever/default_test.go
@@ -61,6 +61,14 @@ func TestDefaultRetriever(t *testing.T) {
 	}
 }
 
+func TestDefaultRetrieverWithoutVectorStore(t *testing.T) {
+	d := New()
+	_, err := d.Retrieve(context.Background(), &Query{Text: "test"})
+	if err == nil || err.Error() != "vector store not configured" {
+		t.Fatalf("Retrieve() error = %v, want vector store not configured", err)
+	}
+}
+
 // TestDefaultRetriever_WithNilFilter tests retrieving with nil query filter.
 func TestDefaultRetriever_WithNilFilter(t *testing.T) {
 	vs := inmemory.New()

--- a/knowledge/source/auto/auto_source.go
+++ b/knowledge/source/auto/auto_source.go
@@ -19,12 +19,14 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/text"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/extractor"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/encoding"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/ocr"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	dirsource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/dir"
@@ -44,6 +46,7 @@ type Source struct {
 	name                   string
 	metadata               map[string]any
 	textReader             reader.Reader
+	resourceTextReader     reader.Reader
 	chunkSize              int
 	chunkOverlap           int
 	customChunkingStrategy chunking.Strategy
@@ -52,6 +55,8 @@ type Source struct {
 	fileReaderType         source.FileReaderType
 	contentExtractor       extractor.Extractor
 }
+
+var _ source.ResourceSource = (*Source)(nil)
 
 // New creates a new auto knowledge source.
 func New(inputs []string, opts ...Option) *Source {
@@ -114,6 +119,17 @@ func (s *Source) initializeReaders() {
 				s.fileReaderType, available)
 		}
 	}
+
+	resourceOpts := []reader.Option{reader.WithChunk(false)}
+	if len(s.transformers) > 0 {
+		resourceOpts = append(resourceOpts, reader.WithTransformers(s.transformers...))
+	}
+	s.resourceTextReader = text.New(resourceOpts...)
+	if s.fileReaderType != "" {
+		if resourceReader, exists := reader.GetAllReaders(resourceOpts...)[string(s.fileReaderType)]; exists {
+			s.resourceTextReader = resourceReader
+		}
+	}
 }
 
 // ReadDocuments automatically detects the source type and reads documents.
@@ -130,6 +146,69 @@ func (s *Source) ReadDocuments(ctx context.Context) ([]*document.Document, error
 		allDocuments = append(allDocuments, documents...)
 	}
 	return allDocuments, nil
+}
+
+// ReadResources delegates file, directory, and URL inputs to their native
+// resource readers. Direct text inputs are stored under a stable content hash.
+func (s *Source) ReadResources(ctx context.Context) ([]*source.Resource, error) {
+	if len(s.inputs) == 0 {
+		return nil, nil
+	}
+
+	var resources []*source.Resource
+	seenPaths := make(map[string]struct{})
+	for _, input := range s.inputs {
+		inputResources, err := s.processInputResources(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process input %s: %w", input, err)
+		}
+		for _, resource := range inputResources {
+			if resource == nil {
+				return nil, fmt.Errorf("input %s returned a nil resource", input)
+			}
+			if _, exists := seenPaths[resource.Path]; exists {
+				return nil, fmt.Errorf("duplicate resource path %q", resource.Path)
+			}
+			seenPaths[resource.Path] = struct{}{}
+			for _, doc := range resource.Documents {
+				if doc == nil {
+					return nil, fmt.Errorf("resource %q returned a nil document", resource.Path)
+				}
+				if doc.Metadata == nil {
+					doc.Metadata = make(map[string]any)
+				}
+				doc.Metadata[source.MetaSourceName] = s.name
+				doc.Metadata[source.MetaResourcePath] = resource.Path
+			}
+			resources = append(resources, resource)
+		}
+	}
+	return resources, nil
+}
+
+func (s *Source) processInputResources(ctx context.Context, input string) ([]*source.Resource, error) {
+	if s.isURL(input) {
+		return readDelegatedResources(ctx, s.newURLSource(input))
+	}
+	if s.isDirectory(input) {
+		return readDelegatedResources(ctx, s.newDirectorySource(input))
+	}
+	if s.isFile(input) {
+		return readDelegatedResources(ctx, s.newFileSource(input))
+	}
+	resource, err := s.processAsTextResource(input)
+	if err != nil {
+		return nil, err
+	}
+	return []*source.Resource{resource}, nil
+}
+
+func readDelegatedResources(ctx context.Context, src source.Source) ([]*source.Resource, error) {
+	resourceSource, ok := src.(source.ResourceSource)
+	if !ok {
+		return nil, fmt.Errorf("source type %s does not support resources", src.Type())
+	}
+	return resourceSource.ReadResources(ctx)
 }
 
 // Name returns the name of this source.
@@ -180,6 +259,10 @@ func (s *Source) isFile(input string) bool {
 
 // processAsURL processes the input as a URL.
 func (s *Source) processAsURL(ctx context.Context, input string) ([]*document.Document, error) {
+	return s.newURLSource(input).ReadDocuments(ctx)
+}
+
+func (s *Source) newURLSource(input string) *urlsource.Source {
 	var opts []urlsource.Option
 	opts = append(opts, urlsource.WithChunkSize(s.chunkSize))
 	opts = append(opts, urlsource.WithChunkOverlap(s.chunkOverlap))
@@ -195,11 +278,15 @@ func (s *Source) processAsURL(ctx context.Context, input string) ([]*document.Do
 	for k, v := range s.metadata {
 		urlSource.SetMetadata(k, v)
 	}
-	return urlSource.ReadDocuments(ctx)
+	return urlSource
 }
 
 // processAsDirectory processes the input as a directory.
 func (s *Source) processAsDirectory(ctx context.Context, input string) ([]*document.Document, error) {
+	return s.newDirectorySource(input).ReadDocuments(ctx)
+}
+
+func (s *Source) newDirectorySource(input string) *dirsource.Source {
 	var opts []dirsource.Option
 
 	// If a custom chunking strategy is set, use it
@@ -229,11 +316,15 @@ func (s *Source) processAsDirectory(ctx context.Context, input string) ([]*docum
 	for k, v := range s.metadata {
 		dirSource.SetMetadata(k, v)
 	}
-	return dirSource.ReadDocuments(ctx)
+	return dirSource
 }
 
 // processAsFile processes the input as a file.
 func (s *Source) processAsFile(ctx context.Context, input string) ([]*document.Document, error) {
+	return s.newFileSource(input).ReadDocuments(ctx)
+}
+
+func (s *Source) newFileSource(input string) *filesource.Source {
 	var opts []filesource.Option
 
 	// If a custom chunking strategy is set, use it
@@ -264,7 +355,7 @@ func (s *Source) processAsFile(ctx context.Context, input string) ([]*document.D
 	for k, v := range s.metadata {
 		fileSource.SetMetadata(k, v)
 	}
-	return fileSource.ReadDocuments(ctx)
+	return fileSource
 }
 
 // processAsText processes the input as text content.
@@ -297,6 +388,47 @@ func (s *Source) processAsText(input string) ([]*document.Document, error) {
 	}
 
 	return docs, nil
+}
+
+func (s *Source) processAsTextResource(input string) (*source.Resource, error) {
+	hash := sha256.Sum256([]byte(input))
+	resourcePath := "text/" + hex.EncodeToString(hash[:]) + ".txt"
+	if input == "" {
+		return &source.Resource{Path: resourcePath}, nil
+	}
+	documents, err := s.processAsText(input)
+	if err != nil {
+		return nil, err
+	}
+	resourceDocuments, err := s.resourceTextReader.ReadFromReader("text_input", strings.NewReader(input))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read complete text resource: %w", err)
+	}
+	if len(resourceDocuments) != 1 || resourceDocuments[0] == nil {
+		return nil, fmt.Errorf(
+			"resource reader returned %d documents, want exactly one",
+			len(resourceDocuments),
+		)
+	}
+
+	for _, doc := range documents {
+		if doc == nil {
+			return nil, fmt.Errorf("text reader returned a nil document")
+		}
+		if doc.Metadata == nil {
+			doc.Metadata = make(map[string]any)
+		}
+		doc.Metadata[source.MetaResourcePath] = resourcePath
+	}
+	content, _ := encoding.SmartProcessText(resourceDocuments[0].Content)
+	if !utf8.ValidString(content) {
+		content = strings.ToValidUTF8(content, "\uFFFD")
+	}
+	return &source.Resource{
+		Path:      resourcePath,
+		Content:   content,
+		Documents: documents,
+	}, nil
 }
 
 // SetMetadata sets metadata for this source.

--- a/knowledge/source/auto/auto_source_test.go
+++ b/knowledge/source/auto/auto_source_test.go
@@ -11,6 +11,8 @@ package auto
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -69,6 +71,122 @@ func (m *mockContentExtractor) SupportedFormats() []string {
 
 func (m *mockContentExtractor) Close() error {
 	return nil
+}
+
+func TestReadResourcesForTextUsesStableHashPath(t *testing.T) {
+	input := strings.Repeat("resource text ", 10)
+	src := New([]string{input}, WithChunkSize(20), WithName("auto-resources"))
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("ReadResources() returned %d resources, want 1", len(resources))
+	}
+
+	hash := sha256.Sum256([]byte(input))
+	wantPath := "text/" + hex.EncodeToString(hash[:]) + ".txt"
+	resource := resources[0]
+	if resource.Path != wantPath {
+		t.Fatalf("resource path = %q, want %q", resource.Path, wantPath)
+	}
+	if resource.Content != input {
+		t.Fatalf("resource content = %q, want original input", resource.Content)
+	}
+	if len(resource.Documents) <= 1 {
+		t.Fatalf("resource documents = %d, want multiple chunks", len(resource.Documents))
+	}
+	for _, doc := range resource.Documents {
+		if got := doc.Metadata[source.MetaResourcePath]; got != wantPath {
+			t.Fatalf("document resource path = %v, want %q", got, wantPath)
+		}
+		if got := doc.Metadata[source.MetaSourceName]; got != "auto-resources" {
+			t.Fatalf("document source name = %v, want auto-resources", got)
+		}
+	}
+
+	again, err := New([]string{input}).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("second ReadResources() error = %v", err)
+	}
+	if len(again) != 1 || again[0].Path != wantPath {
+		t.Fatalf("second resource path = %+v, want %q", again, wantPath)
+	}
+}
+
+func TestReadResourcesDelegatesBuiltInSources(t *testing.T) {
+	fileDir := t.TempDir()
+	filePath := filepath.Join(fileDir, "single.txt")
+	if err := os.WriteFile(filePath, []byte("file content"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	dirPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirPath, "nested.txt"), []byte("directory content"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("URL content"))
+	}))
+	defer server.Close()
+
+	src := New([]string{filePath, dirPath, server.URL + "/remote.txt"}, WithName("combined"))
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 3 {
+		t.Fatalf("ReadResources() returned %d resources, want 3", len(resources))
+	}
+	if requestCount != 1 {
+		t.Fatalf("HTTP request count = %d, want 1", requestCount)
+	}
+
+	seenContent := make(map[string]bool)
+	for _, resource := range resources {
+		seenContent[resource.Content] = true
+		if resource.Path == "" {
+			t.Fatal("delegated resource has an empty path")
+		}
+		for _, doc := range resource.Documents {
+			if got := doc.Metadata[source.MetaResourcePath]; got != resource.Path {
+				t.Fatalf("document resource path = %v, want %q", got, resource.Path)
+			}
+			if got := doc.Metadata[source.MetaSourceName]; got != "combined" {
+				t.Fatalf("document source name = %v, want combined", got)
+			}
+		}
+	}
+	for _, content := range []string{"file content", "directory content", "URL content"} {
+		if !seenContent[content] {
+			t.Fatalf("delegated resource content %q not found", content)
+		}
+	}
+}
+
+func TestReadResourcesRejectsInputPathCollisions(t *testing.T) {
+	input := "same text input"
+	_, err := New([]string{input, input}).ReadResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "duplicate resource path") {
+		t.Fatalf("ReadResources() error = %v, want duplicate resource path", err)
+	}
+}
+
+func TestReadResourcesPreservesEmptyTextInput(t *testing.T) {
+	resources, err := New([]string{""}).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Content != "" || len(resources[0].Documents) != 0 {
+		t.Fatalf("empty text resource = %+v", resources)
+	}
+	if !strings.HasPrefix(resources[0].Path, "text/") {
+		t.Fatalf("empty text resource path = %q", resources[0].Path)
+	}
 }
 
 func TestWithTransformers(t *testing.T) {

--- a/knowledge/source/dir/dir_source.go
+++ b/knowledge/source/dir/dir_source.go
@@ -11,17 +11,22 @@
 package dir
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/extractor"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/encoding"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/ocr"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	isource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/internal/source"
@@ -38,6 +43,7 @@ type Source struct {
 	name                   string
 	metadata               map[string]any
 	readers                map[string]reader.Reader
+	resourceReaders        map[string]reader.Reader
 	fileExtensions         []string // Optional: filter by file extensions
 	recursive              bool     // Whether to process subdirectories
 	chunkSize              int
@@ -48,6 +54,8 @@ type Source struct {
 	fileReaderType         source.FileReaderType
 	contentExtractor       extractor.Extractor
 }
+
+var _ source.ResourceSource = (*Source)(nil)
 
 // New creates a new directory knowledge source.
 func New(dirPaths []string, opts ...Option) *Source {
@@ -93,6 +101,15 @@ func (s *Source) initializeReaders() {
 
 	// Initialize readers with configuration
 	s.readers = isource.GetReaders(readerOpts...)
+
+	resourceReaderOpts := []isource.ReaderOption{isource.WithChunk(false)}
+	if s.ocrExtractor != nil {
+		resourceReaderOpts = append(resourceReaderOpts, isource.WithOCRExtractor(s.ocrExtractor))
+	}
+	if len(s.transformers) > 0 {
+		resourceReaderOpts = append(resourceReaderOpts, isource.WithTransformers(s.transformers...))
+	}
+	s.resourceReaders = isource.GetReaders(resourceReaderOpts...)
 }
 
 // getFileType determines the file type based on the file extension.
@@ -145,6 +162,80 @@ func (s *Source) ReadDocuments(ctx context.Context) ([]*document.Document, error
 	}
 
 	return allDocuments, nil
+}
+
+// ReadResources reads complete source representations and the documents
+// derived from the same file snapshots.
+func (s *Source) ReadResources(ctx context.Context) ([]*source.Resource, error) {
+	if len(s.dirPaths) == 0 {
+		return nil, nil
+	}
+
+	var resources []*source.Resource
+	seenRoots := make(map[string]string, len(s.dirPaths))
+	seenPaths := make(map[string]string)
+	seenFiles := make(map[string]string)
+	totalFiles := 0
+	for _, dirPath := range s.dirPaths {
+		if dirPath == "" {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		absRoot, err := filepath.Abs(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve directory %s: %w", dirPath, err)
+		}
+		rootName := filepath.Base(filepath.Clean(absRoot))
+		if rootName == "." || rootName == string(filepath.Separator) {
+			return nil, fmt.Errorf("directory %q has no usable resource root name", dirPath)
+		}
+		if previous, ok := seenRoots[rootName]; ok {
+			return nil, fmt.Errorf("duplicate resource root %q from directories %q and %q", rootName, previous, dirPath)
+		}
+		seenRoots[rootName] = dirPath
+
+		filePaths, err := s.getFilePaths(dirPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get file paths from directory %s: %w", dirPath, err)
+		}
+		totalFiles += len(filePaths)
+		for _, filePath := range filePaths {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			absFile, err := filepath.Abs(filePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve file %s: %w", filePath, err)
+			}
+			if previous, ok := seenFiles[absFile]; ok {
+				return nil, fmt.Errorf("file %q is included by both %q and %q", absFile, previous, dirPath)
+			}
+			seenFiles[absFile] = dirPath
+
+			relPath, err := filepath.Rel(dirPath, filePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build directory-relative path: %w", err)
+			}
+			resourcePath := path.Join(rootName, filepath.ToSlash(relPath))
+			if previous, ok := seenPaths[resourcePath]; ok {
+				return nil, fmt.Errorf("duplicate resource path %q from files %q and %q", resourcePath, previous, filePath)
+			}
+			seenPaths[resourcePath] = filePath
+
+			resource, err := s.processResource(ctx, filePath, resourcePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to process resource %s: %w", filePath, err)
+			}
+			resources = append(resources, resource)
+		}
+	}
+
+	if totalFiles == 0 {
+		return nil, fmt.Errorf("no files found in any of the provided directories")
+	}
+	return resources, nil
 }
 
 // Name returns the name of this source.
@@ -228,28 +319,10 @@ func (s *Source) processFile(ctx context.Context, filePath string) ([]*document.
 		return nil, err
 	}
 
-	// Create metadata for this file.
-	metadata := make(map[string]any)
-	for k, v := range s.metadata {
-		metadata[k] = v
-	}
-	metadata[source.MetaSource] = source.TypeDir
-	metadata[source.MetaFilePath] = filePath
-	metadata[source.MetaFileName] = filepath.Base(filePath)
-	metadata[source.MetaFileExt] = filepath.Ext(filePath)
-	metadata[source.MetaFileSize] = fileInfo.Size()
-	metadata[source.MetaFileMode] = fileInfo.Mode().String()
-	metadata[source.MetaModifiedAt] = fileInfo.ModTime().UTC()
-
-	// Get absolute path for URI
-	// Not include ip address and port
-	absPath, err := filepath.Abs(filePath)
+	metadata, err := s.buildFileMetadata(filePath, fileInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+		return nil, err
 	}
-	fileURL := (&url.URL{Scheme: "file", Path: absPath}).String()
-	metadata[source.MetaURI] = fileURL
-	metadata[source.MetaSourceName] = s.name
 
 	// Add metadata to all documents.
 	for _, doc := range documents {
@@ -262,6 +335,144 @@ func (s *Source) processFile(ctx context.Context, filePath string) ([]*document.
 	}
 
 	return documents, nil
+}
+
+func (s *Source) processResource(
+	ctx context.Context,
+	filePath string,
+	resourcePath string,
+) (*source.Resource, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file: %s", filePath)
+	}
+
+	snapshot, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file snapshot: %w", err)
+	}
+	if len(snapshot) == 0 {
+		return &source.Resource{
+			Path:       resourcePath,
+			ModifiedAt: fileInfo.ModTime().UTC(),
+		}, nil
+	}
+	fileType := s.getFileType(filePath)
+	readerName := resourceReaderName(filePath, fileType)
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if s.contentExtractor != nil && extractor.Supports(s.contentExtractor, ext) {
+		result, err := s.contentExtractor.ExtractFromReader(ctx, bytes.NewReader(snapshot))
+		if err != nil {
+			return nil, fmt.Errorf("content extraction failed: %w", err)
+		}
+		if result == nil || result.Reader == nil {
+			return nil, fmt.Errorf("content extraction returned no content")
+		}
+		snapshot, err = io.ReadAll(result.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read extracted content: %w", err)
+		}
+		fileType = result.Format
+		readerName = filepath.Base(filePath)
+	}
+
+	chunkReader, ok := s.readers[fileType]
+	if !ok {
+		return nil, fmt.Errorf("no reader available for file type: %s", fileType)
+	}
+	resourceReader, ok := s.resourceReaders[fileType]
+	if !ok {
+		return nil, fmt.Errorf("no resource reader available for file type: %s", fileType)
+	}
+	fullDocuments, err := resourceReader.ReadFromReader(readerName, bytes.NewReader(snapshot))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read complete resource: %w", err)
+	}
+	content, err := completeResourceContent(fullDocuments)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := chunkReader.ReadFromReader(readerName, bytes.NewReader(snapshot))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resource documents: %w", err)
+	}
+
+	metadata, err := s.buildFileMetadata(filePath, fileInfo)
+	if err != nil {
+		return nil, err
+	}
+	metadata[source.MetaResourcePath] = resourcePath
+	if err := addMetadata(documents, metadata); err != nil {
+		return nil, err
+	}
+
+	return &source.Resource{
+		Path:       resourcePath,
+		Content:    content,
+		ModifiedAt: fileInfo.ModTime().UTC(),
+		Documents:  documents,
+	}, nil
+}
+
+func (s *Source) buildFileMetadata(filePath string, fileInfo os.FileInfo) (map[string]any, error) {
+	metadata := make(map[string]any, len(s.metadata)+10)
+	for k, v := range s.metadata {
+		metadata[k] = v
+	}
+	metadata[source.MetaSource] = source.TypeDir
+	metadata[source.MetaFilePath] = filePath
+	metadata[source.MetaFileName] = filepath.Base(filePath)
+	metadata[source.MetaFileExt] = filepath.Ext(filePath)
+	metadata[source.MetaFileSize] = fileInfo.Size()
+	metadata[source.MetaFileMode] = fileInfo.Mode().String()
+	metadata[source.MetaModifiedAt] = fileInfo.ModTime().UTC()
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	metadata[source.MetaURI] = (&url.URL{Scheme: "file", Path: absPath}).String()
+	metadata[source.MetaSourceName] = s.name
+	return metadata, nil
+}
+
+func addMetadata(documents []*document.Document, metadata map[string]any) error {
+	for _, doc := range documents {
+		if doc == nil {
+			return fmt.Errorf("reader returned a nil document")
+		}
+		if doc.Metadata == nil {
+			doc.Metadata = make(map[string]any)
+		}
+		for k, v := range metadata {
+			doc.Metadata[k] = v
+		}
+	}
+	return nil
+}
+
+func completeResourceContent(documents []*document.Document) (string, error) {
+	if len(documents) != 1 || documents[0] == nil {
+		return "", fmt.Errorf("resource reader returned %d documents, want exactly one", len(documents))
+	}
+	content, _ := encoding.SmartProcessText(documents[0].Content)
+	if !utf8.ValidString(content) {
+		content = strings.ToValidUTF8(content, "\uFFFD")
+	}
+	return content, nil
+}
+
+func resourceReaderName(filePath, fileType string) string {
+	switch fileType {
+	case "go", "proto", "python":
+		return filePath
+	default:
+		return strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+	}
 }
 
 // extractAndRead uses the content extractor to convert the file, then pipes

--- a/knowledge/source/dir/dir_source_test.go
+++ b/knowledge/source/dir/dir_source_test.go
@@ -57,6 +57,7 @@ func (m *mockOCRExtractor) Close() error {
 type recordingExtractor struct {
 	format string
 	err    error
+	calls  int
 }
 
 func (r *recordingExtractor) Extract(ctx context.Context, data []byte, opts ...extractor.Option) (*extractor.Result, error) {
@@ -64,6 +65,7 @@ func (r *recordingExtractor) Extract(ctx context.Context, data []byte, opts ...e
 }
 
 func (r *recordingExtractor) ExtractFromReader(ctx context.Context, reader io.Reader, opts ...extractor.Option) (*extractor.Result, error) {
+	r.calls++
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -863,5 +865,113 @@ func TestWithTransformers(t *testing.T) {
 	}
 	if len(docs) == 0 {
 		t.Fatal("expected at least one document")
+	}
+}
+
+func TestReadResourcesUsesRootRelativePaths(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "docs")
+	nested := filepath.Join(root, "guides")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+	filePath := filepath.Join(nested, "config.txt")
+	content := strings.Repeat("configuration line\n", 20)
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	resources, err := New([]string{root}, WithRecursive(true), WithChunkSize(64)).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources = %d, want 1", len(resources))
+	}
+	resource := resources[0]
+	if resource.Path != "docs/guides/config.txt" {
+		t.Fatalf("resource path = %q, want docs/guides/config.txt", resource.Path)
+	}
+	if resource.Content != content {
+		t.Fatalf("resource content was not preserved: got %q", resource.Content)
+	}
+	if len(resource.Documents) < 2 {
+		t.Fatalf("documents = %d, want multiple chunks", len(resource.Documents))
+	}
+	for _, doc := range resource.Documents {
+		if doc.Metadata[source.MetaFilePath] != filePath {
+			t.Fatalf("file path metadata = %v, want %s", doc.Metadata[source.MetaFilePath], filePath)
+		}
+		if doc.Metadata[source.MetaResourcePath] != "docs/guides/config.txt" {
+			t.Fatalf("resource path metadata = %v, want docs/guides/config.txt", doc.Metadata[source.MetaResourcePath])
+		}
+	}
+}
+
+func TestReadResourcesRejectsDuplicateRootNames(t *testing.T) {
+	parent := t.TempDir()
+	firstRoot := filepath.Join(parent, "first", "docs")
+	secondRoot := filepath.Join(parent, "second", "docs")
+	if err := os.MkdirAll(firstRoot, 0o755); err != nil {
+		t.Fatalf("create first root: %v", err)
+	}
+	if err := os.MkdirAll(secondRoot, 0o755); err != nil {
+		t.Fatalf("create second root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(firstRoot, "first.txt"), []byte("first"), 0o600); err != nil {
+		t.Fatalf("write first file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secondRoot, "second.txt"), []byte("second"), 0o600); err != nil {
+		t.Fatalf("write second file: %v", err)
+	}
+
+	_, err := New([]string{firstRoot, secondRoot}).ReadResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "duplicate resource root") {
+		t.Fatalf("ReadResources error = %v, want duplicate resource root", err)
+	}
+}
+
+func TestReadResourcesPreservesEmptyFile(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "docs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "empty.txt"), nil, 0o600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+	resources, err := New([]string{root}).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Path != "docs/empty.txt" ||
+		resources[0].Content != "" || len(resources[0].Documents) != 0 {
+		t.Fatalf("empty resource = %+v", resources)
+	}
+}
+
+func TestReadResourcesRunsExtractorOncePerFile(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "docs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	filePath := filepath.Join(root, "manual.pdf")
+	if err := os.WriteFile(filePath, []byte("raw pdf snapshot"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	recorder := &recordingExtractor{format: extractor.FormatMarkdown}
+
+	resources, err := New([]string{root}, WithExtractor(recorder)).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources failed: %v", err)
+	}
+	if recorder.calls != 1 {
+		t.Fatalf("extractor calls = %d, want 1", recorder.calls)
+	}
+	if len(resources) != 1 || resources[0].Content != "# extracted" {
+		t.Fatalf("unexpected resources: %+v", resources)
+	}
+	if resources[0].Path != "docs/manual.pdf" {
+		t.Fatalf("resource path = %q, want docs/manual.pdf", resources[0].Path)
 	}
 }

--- a/knowledge/source/file/file_source.go
+++ b/knowledge/source/file/file_source.go
@@ -11,17 +11,21 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/extractor"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/encoding"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/ocr"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	isource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/internal/source"
@@ -38,6 +42,7 @@ type Source struct {
 	name                   string
 	metadata               map[string]any
 	readers                map[string]reader.Reader
+	resourceReaders        map[string]reader.Reader
 	chunkSize              int
 	chunkOverlap           int
 	customChunkingStrategy chunking.Strategy
@@ -46,6 +51,8 @@ type Source struct {
 	fileReaderType         source.FileReaderType
 	contentExtractor       extractor.Extractor
 }
+
+var _ source.ResourceSource = (*Source)(nil)
 
 // New creates a new file knowledge source.
 func New(filePaths []string, opts ...Option) *Source {
@@ -83,6 +90,18 @@ func New(filePaths []string, opts ...Option) *Source {
 	// Initialize readers with configuration
 	s.readers = isource.GetReaders(readerOpts...)
 
+	// Resource readers return the complete normalized representation. Keep them
+	// separate from the chunking readers so ReadResources never reconstructs the
+	// source text from chunks.
+	resourceReaderOpts := []isource.ReaderOption{isource.WithChunk(false)}
+	if s.ocrExtractor != nil {
+		resourceReaderOpts = append(resourceReaderOpts, isource.WithOCRExtractor(s.ocrExtractor))
+	}
+	if len(s.transformers) > 0 {
+		resourceReaderOpts = append(resourceReaderOpts, isource.WithTransformers(s.transformers...))
+	}
+	s.resourceReaders = isource.GetReaders(resourceReaderOpts...)
+
 	return s
 }
 
@@ -100,6 +119,34 @@ func (s *Source) ReadDocuments(ctx context.Context) ([]*document.Document, error
 		allDocuments = append(allDocuments, documents...)
 	}
 	return allDocuments, nil
+}
+
+// ReadResources reads complete source representations and the documents
+// derived from the same file snapshots.
+func (s *Source) ReadResources(ctx context.Context) ([]*source.Resource, error) {
+	if len(s.filePaths) == 0 {
+		return nil, nil
+	}
+
+	resources := make([]*source.Resource, 0, len(s.filePaths))
+	seenPaths := make(map[string]string, len(s.filePaths))
+	for _, filePath := range s.filePaths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		resourcePath := filepath.ToSlash(filepath.Base(filepath.Clean(filePath)))
+		if previous, ok := seenPaths[resourcePath]; ok {
+			return nil, fmt.Errorf("duplicate resource path %q from files %q and %q", resourcePath, previous, filePath)
+		}
+		seenPaths[resourcePath] = filePath
+
+		resource, err := s.processResource(ctx, filePath, resourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process resource %s: %w", filePath, err)
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
 }
 
 // Name returns the name of this source.
@@ -137,28 +184,10 @@ func (s *Source) processFile(ctx context.Context, filePath string) ([]*document.
 		return nil, err
 	}
 
-	// Create metadata for this file.
-	metadata := make(map[string]any)
-	for k, v := range s.metadata {
-		metadata[k] = v
-	}
-	metadata[source.MetaSource] = source.TypeFile
-	metadata[source.MetaFilePath] = filePath
-	metadata[source.MetaFileName] = filepath.Base(filePath)
-	metadata[source.MetaFileExt] = filepath.Ext(filePath)
-	metadata[source.MetaFileSize] = fileInfo.Size()
-	metadata[source.MetaFileMode] = fileInfo.Mode().String()
-	metadata[source.MetaModifiedAt] = fileInfo.ModTime().UTC()
-
-	// Get absolute path for URI
-	// Not include ip address and port
-	absPath, err := filepath.Abs(filePath)
+	metadata, err := s.buildFileMetadata(filePath, fileInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+		return nil, err
 	}
-	fileURL := (&url.URL{Scheme: "file", Path: absPath}).String()
-	metadata[source.MetaURI] = fileURL
-	metadata[source.MetaSourceName] = s.name
 
 	// Add metadata to all documents.
 	for _, doc := range documents {
@@ -170,6 +199,145 @@ func (s *Source) processFile(ctx context.Context, filePath string) ([]*document.
 		}
 	}
 	return documents, nil
+}
+
+func (s *Source) processResource(
+	ctx context.Context,
+	filePath string,
+	resourcePath string,
+) (*source.Resource, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file: %s", filePath)
+	}
+
+	snapshot, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file snapshot: %w", err)
+	}
+	if len(snapshot) == 0 {
+		return &source.Resource{
+			Path:       resourcePath,
+			ModifiedAt: fileInfo.ModTime().UTC(),
+		}, nil
+	}
+	fileType := isource.ResolveFileType(string(s.fileReaderType), isource.GetFileType(filePath))
+	readerName := resourceReaderName(filePath, fileType)
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if s.contentExtractor != nil && extractor.Supports(s.contentExtractor, ext) {
+		result, err := s.contentExtractor.ExtractFromReader(ctx, bytes.NewReader(snapshot))
+		if err != nil {
+			return nil, fmt.Errorf("content extraction failed: %w", err)
+		}
+		if result == nil || result.Reader == nil {
+			return nil, fmt.Errorf("content extraction returned no content")
+		}
+		snapshot, err = io.ReadAll(result.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read extracted content: %w", err)
+		}
+		fileType = result.Format
+		readerName = filepath.Base(filePath)
+	}
+
+	chunkReader, ok := s.readers[fileType]
+	if !ok {
+		return nil, fmt.Errorf("no reader available for file type: %s", fileType)
+	}
+	resourceReader, ok := s.resourceReaders[fileType]
+	if !ok {
+		return nil, fmt.Errorf("no resource reader available for file type: %s", fileType)
+	}
+
+	fullDocuments, err := resourceReader.ReadFromReader(readerName, bytes.NewReader(snapshot))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read complete resource: %w", err)
+	}
+	content, err := completeResourceContent(fullDocuments)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := chunkReader.ReadFromReader(readerName, bytes.NewReader(snapshot))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resource documents: %w", err)
+	}
+
+	metadata, err := s.buildFileMetadata(filePath, fileInfo)
+	if err != nil {
+		return nil, err
+	}
+	metadata[source.MetaResourcePath] = resourcePath
+	if err := addMetadata(documents, metadata); err != nil {
+		return nil, err
+	}
+
+	return &source.Resource{
+		Path:       resourcePath,
+		Content:    content,
+		ModifiedAt: fileInfo.ModTime().UTC(),
+		Documents:  documents,
+	}, nil
+}
+
+func (s *Source) buildFileMetadata(filePath string, fileInfo os.FileInfo) (map[string]any, error) {
+	metadata := make(map[string]any, len(s.metadata)+10)
+	for k, v := range s.metadata {
+		metadata[k] = v
+	}
+	metadata[source.MetaSource] = source.TypeFile
+	metadata[source.MetaFilePath] = filePath
+	metadata[source.MetaFileName] = filepath.Base(filePath)
+	metadata[source.MetaFileExt] = filepath.Ext(filePath)
+	metadata[source.MetaFileSize] = fileInfo.Size()
+	metadata[source.MetaFileMode] = fileInfo.Mode().String()
+	metadata[source.MetaModifiedAt] = fileInfo.ModTime().UTC()
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	metadata[source.MetaURI] = (&url.URL{Scheme: "file", Path: absPath}).String()
+	metadata[source.MetaSourceName] = s.name
+	return metadata, nil
+}
+
+func addMetadata(documents []*document.Document, metadata map[string]any) error {
+	for _, doc := range documents {
+		if doc == nil {
+			return fmt.Errorf("reader returned a nil document")
+		}
+		if doc.Metadata == nil {
+			doc.Metadata = make(map[string]any)
+		}
+		for k, v := range metadata {
+			doc.Metadata[k] = v
+		}
+	}
+	return nil
+}
+
+func completeResourceContent(documents []*document.Document) (string, error) {
+	if len(documents) != 1 || documents[0] == nil {
+		return "", fmt.Errorf("resource reader returned %d documents, want exactly one", len(documents))
+	}
+	content, _ := encoding.SmartProcessText(documents[0].Content)
+	if !utf8.ValidString(content) {
+		content = strings.ToValidUTF8(content, "\uFFFD")
+	}
+	return content, nil
+}
+
+func resourceReaderName(filePath, fileType string) string {
+	switch fileType {
+	case "go", "proto", "python":
+		return filePath
+	default:
+		return strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+	}
 }
 
 // extractAndRead uses the content extractor to convert the file, then pipes
@@ -212,6 +380,20 @@ func (s *Source) readWithReader(filePath string) ([]*document.Document, error) {
 // SetReader sets a custom reader for a specific file type.
 func (s *Source) SetReader(fileType string, reader reader.Reader) {
 	s.readers[fileType] = reader
+	// A chunk reader does not necessarily expose an unchunked representation.
+	// Require callers that enable resource ingestion to provide the matching
+	// reader explicitly instead of silently pairing incompatible readers.
+	delete(s.resourceReaders, fileType)
+}
+
+// SetResourceReader sets the reader that must return exactly one complete
+// representation for a file type configured through SetReader.
+func (s *Source) SetResourceReader(fileType string, resourceReader reader.Reader) {
+	if resourceReader == nil {
+		delete(s.resourceReaders, fileType)
+		return
+	}
+	s.resourceReaders[fileType] = resourceReader
 }
 
 // SetMetadata sets metadata for this source.

--- a/knowledge/source/file/file_source_test.go
+++ b/knowledge/source/file/file_source_test.go
@@ -71,6 +71,7 @@ func (m *mockTransformer) Name() string {
 type recordingExtractor struct {
 	format string
 	err    error
+	calls  int
 }
 
 func (r *recordingExtractor) Extract(ctx context.Context, data []byte, opts ...extractor.Option) (*extractor.Result, error) {
@@ -78,6 +79,7 @@ func (r *recordingExtractor) Extract(ctx context.Context, data []byte, opts ...e
 }
 
 func (r *recordingExtractor) ExtractFromReader(ctx context.Context, reader io.Reader, opts ...extractor.Option) (*extractor.Result, error) {
+	r.calls++
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -788,5 +790,132 @@ func TestWithMetadata_EmptyMap(t *testing.T) {
 	src := New([]string{"test.txt"}, WithMetadata(map[string]any{}))
 	if src.metadata == nil {
 		t.Error("metadata should not be nil after WithMetadata")
+	}
+}
+
+func TestReadResourcesReturnsCompleteContentAndChunks(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "guide.txt")
+	content := strings.Repeat("configuration line\n", 20)
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	src := New([]string{filePath}, WithChunkSize(64))
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources failed: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources = %d, want 1", len(resources))
+	}
+	resource := resources[0]
+	if resource.Path != "guide.txt" {
+		t.Fatalf("resource path = %q, want guide.txt", resource.Path)
+	}
+	if resource.Content != content {
+		t.Fatalf("resource content was not preserved: got %q", resource.Content)
+	}
+	if len(resource.Documents) < 2 {
+		t.Fatalf("documents = %d, want multiple chunks", len(resource.Documents))
+	}
+	for _, doc := range resource.Documents {
+		if doc.Metadata[source.MetaFilePath] != filePath {
+			t.Fatalf("file path metadata = %v, want %s", doc.Metadata[source.MetaFilePath], filePath)
+		}
+		if doc.Metadata[source.MetaResourcePath] != "guide.txt" {
+			t.Fatalf("resource path metadata = %v, want guide.txt", doc.Metadata[source.MetaResourcePath])
+		}
+		if _, ok := doc.Metadata[source.MetaURI].(string); !ok {
+			t.Fatalf("missing URI metadata: %v", doc.Metadata)
+		}
+	}
+	resource.Documents[0].Content = "changed chunk"
+	if resource.Content != content {
+		t.Fatal("resource content must not be reconstructed from chunk documents")
+	}
+}
+
+func TestReadResourcesRejectsDuplicateBasenames(t *testing.T) {
+	root := t.TempDir()
+	firstDir := filepath.Join(root, "first")
+	secondDir := filepath.Join(root, "second")
+	if err := os.MkdirAll(firstDir, 0o755); err != nil {
+		t.Fatalf("create first dir: %v", err)
+	}
+	if err := os.MkdirAll(secondDir, 0o755); err != nil {
+		t.Fatalf("create second dir: %v", err)
+	}
+	first := filepath.Join(firstDir, "same.txt")
+	second := filepath.Join(secondDir, "same.txt")
+	if err := os.WriteFile(first, []byte("first"), 0o600); err != nil {
+		t.Fatalf("write first file: %v", err)
+	}
+	if err := os.WriteFile(second, []byte("second"), 0o600); err != nil {
+		t.Fatalf("write second file: %v", err)
+	}
+
+	_, err := New([]string{first, second}).ReadResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "duplicate resource path") {
+		t.Fatalf("ReadResources error = %v, want duplicate resource path", err)
+	}
+}
+
+func TestReadResourcesPreservesEmptyFile(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "empty.txt")
+	if err := os.WriteFile(filePath, nil, 0o600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+	resources, err := New([]string{filePath}).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Path != "empty.txt" ||
+		resources[0].Content != "" || len(resources[0].Documents) != 0 {
+		t.Fatalf("empty resource = %+v", resources)
+	}
+}
+
+func TestCustomReaderRequiresResourceReader(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "custom.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	src := New([]string{filePath})
+	src.SetReader("text", stubReader{})
+	if _, err := src.ReadResources(context.Background()); err == nil ||
+		!strings.Contains(err.Error(), "no resource reader") {
+		t.Fatalf("ReadResources() error = %v, want missing resource reader", err)
+	}
+	src.SetResourceReader("text", stubReader{})
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() with paired reader error = %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("resources = %d, want 1", len(resources))
+	}
+}
+
+func TestReadResourcesRunsExtractorOnce(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "manual.pdf")
+	if err := os.WriteFile(filePath, []byte("raw pdf snapshot"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	recorder := &recordingExtractor{format: extractor.FormatMarkdown}
+
+	resources, err := New([]string{filePath}, WithExtractor(recorder)).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources failed: %v", err)
+	}
+	if recorder.calls != 1 {
+		t.Fatalf("extractor calls = %d, want 1", recorder.calls)
+	}
+	if len(resources) != 1 || resources[0].Content != "# extracted" {
+		t.Fatalf("unexpected resources: %+v", resources)
+	}
+	if len(resources[0].Documents) == 0 {
+		t.Fatal("expected documents derived from extracted content")
 	}
 }

--- a/knowledge/source/internal/source/source.go
+++ b/knowledge/source/internal/source/source.go
@@ -40,10 +40,18 @@ type ReaderConfig struct {
 	customChunkingStrategy chunking.Strategy
 	ocrExtractor           ocr.Extractor
 	transformers           []transform.Transformer
+	chunk                  *bool
 }
 
 // ReaderOption is a functional option for configuring readers.
 type ReaderOption func(*ReaderConfig)
+
+// WithChunk enables or disables reader chunking.
+func WithChunk(enabled bool) ReaderOption {
+	return func(c *ReaderConfig) {
+		c.chunk = &enabled
+	}
+}
 
 // WithChunkSize sets the chunk size for readers.
 func WithChunkSize(size int) ReaderOption {
@@ -115,6 +123,11 @@ func buildReaderOptions(config *ReaderConfig) []reader.Option {
 
 	if len(config.transformers) > 0 {
 		opts = append(opts, reader.WithTransformers(config.transformers...))
+	}
+	if config.chunk != nil {
+		// Apply the explicit switch last so WithChunk(false) can produce a full
+		// representation even when the caller also supplied chunk sizing options.
+		opts = append(opts, reader.WithChunk(*config.chunk))
 	}
 
 	return opts

--- a/knowledge/source/internal/source/source_test.go
+++ b/knowledge/source/internal/source/source_test.go
@@ -83,6 +83,19 @@ func TestWithTransformers(t *testing.T) {
 	require.Len(t, config.transformers, 2)
 }
 
+func TestWithChunkOverridesChunkSizing(t *testing.T) {
+	config := &ReaderConfig{}
+	WithChunkSize(128)(config)
+	WithChunk(false)(config)
+
+	readerConfig := &reader.Config{}
+	for _, option := range buildReaderOptions(config) {
+		option(readerConfig)
+	}
+	require.False(t, readerConfig.Chunk)
+	require.Equal(t, 128, readerConfig.ChunkSize)
+}
+
 func (m *mockChunkingStrategy) Chunk(doc *document.Document) ([]*document.Document, error) {
 	return []*document.Document{doc}, nil
 }

--- a/knowledge/source/repo/repo_source.go
+++ b/knowledge/source/repo/repo_source.go
@@ -20,9 +20,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/encoding"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	isource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/internal/source"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/transform"
@@ -36,6 +39,7 @@ type Source struct {
 	name             string
 	metadata         map[string]any
 	readers          map[string]reader.Reader
+	resourceReaders  map[string]reader.Reader
 	fileExtensions   []string
 	recursive        bool
 	transformers     []transform.Transformer
@@ -44,6 +48,8 @@ type Source struct {
 	docExtensions    []string
 	parseConcurrency int
 }
+
+var _ source.ResourceSource = (*Source)(nil)
 
 // Repository describes one repository input and its version/scope configuration.
 type Repository struct {
@@ -79,6 +85,9 @@ func (s *Source) initializeReaders() {
 		readerOpts = append(readerOpts, isource.WithTransformers(s.transformers...))
 	}
 	s.readers = isource.GetReaders(readerOpts...)
+	resourceReaderOpts := append([]isource.ReaderOption(nil), readerOpts...)
+	resourceReaderOpts = append(resourceReaderOpts, isource.WithChunk(false))
+	s.resourceReaders = isource.GetReaders(resourceReaderOpts...)
 }
 
 // ReadDocuments reads all repository inputs and returns documents.
@@ -107,6 +116,228 @@ func (s *Source) ReadDocuments(ctx context.Context) ([]*document.Document, error
 	if err != nil {
 		return nil, err
 	}
+	return s.readClassifiedDocuments(rootToScan, repoRoot, repoInfo, fc)
+}
+
+// ReadResources reads one repository snapshot as complete, source-relative
+// resources together with the documents derived from those resources.
+func (s *Source) ReadResources(ctx context.Context) ([]*source.Resource, error) {
+	repository := s.repository
+	repoRoot, repoInfo, cleanup, err := s.resolveRepository(ctx, repository)
+	if err != nil {
+		return nil, err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	rootToScan, err := resolveScanRoot(repoRoot, repository.Subdir)
+	if err != nil {
+		return nil, err
+	}
+	filePaths, err := s.getFilePaths(rootToScan)
+	if err != nil {
+		return nil, err
+	}
+	contextFilePaths, err := s.getSnapshotFilePaths(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	identityRepoRoot := repoRoot
+	if cleanup == nil {
+		var snapshotCleanup func()
+		repoRoot, rootToScan, filePaths, contextFilePaths, snapshotCleanup, err = snapshotLocalRepository(
+			ctx,
+			repoRoot,
+			rootToScan,
+			filePaths,
+			contextFilePaths,
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer snapshotCleanup()
+	}
+	documentContextPaths, restoreEmptyFiles, err := detachEmptyRepositoryFiles(contextFilePaths)
+	if err != nil {
+		return nil, err
+	}
+	documentContextSet := make(map[string]struct{}, len(documentContextPaths))
+	for _, filePath := range documentContextPaths {
+		documentContextSet[filePath] = struct{}{}
+	}
+	documentFilePaths := make([]string, 0, len(filePaths))
+	for _, filePath := range filePaths {
+		if _, ok := documentContextSet[filePath]; ok {
+			documentFilePaths = append(documentFilePaths, filePath)
+		}
+	}
+	fc, err := s.classifyFiles(repoRoot, documentFilePaths)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := s.readClassifiedDocuments(rootToScan, repoRoot, repoInfo, fc)
+	if err != nil {
+		return nil, err
+	}
+	if err := restoreEmptyFiles(); err != nil {
+		return nil, err
+	}
+	if repoRoot != identityRepoRoot {
+		restoreLocalRepositoryIdentity(documents, repoRoot, identityRepoRoot)
+	}
+	return s.buildResources(repoRoot, filePaths, documents)
+}
+
+type emptyRepositoryFile struct {
+	path       string
+	mode       os.FileMode
+	modifiedAt time.Time
+}
+
+func detachEmptyRepositoryFiles(filePaths []string) ([]string, func() error, error) {
+	documentFilePaths := make([]string, 0, len(filePaths))
+	var emptyFiles []emptyRepositoryFile
+	restore := func() error {
+		for _, file := range emptyFiles {
+			if err := os.WriteFile(file.path, nil, file.mode.Perm()); err != nil {
+				return fmt.Errorf("failed to restore empty repository file: %w", err)
+			}
+			if err := os.Chtimes(file.path, file.modifiedAt, file.modifiedAt); err != nil {
+				return fmt.Errorf("failed to restore empty repository file time: %w", err)
+			}
+		}
+		emptyFiles = nil
+		return nil
+	}
+	for _, filePath := range filePaths {
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			_ = restore()
+			return nil, nil, fmt.Errorf("failed to stat repository file: %w", err)
+		}
+		if fileInfo.Size() != 0 {
+			documentFilePaths = append(documentFilePaths, filePath)
+			continue
+		}
+		emptyFiles = append(emptyFiles, emptyRepositoryFile{
+			path:       filePath,
+			mode:       fileInfo.Mode(),
+			modifiedAt: fileInfo.ModTime(),
+		})
+		if err := os.Remove(filePath); err != nil {
+			_ = restore()
+			return nil, nil, fmt.Errorf("failed to detach empty repository file: %w", err)
+		}
+	}
+	return documentFilePaths, restore, nil
+}
+
+func snapshotLocalRepository(
+	ctx context.Context,
+	repoRoot string,
+	rootToScan string,
+	resourceFilePaths []string,
+	contextFilePaths []string,
+) (string, string, []string, []string, func(), error) {
+	snapshotRoot, err := os.MkdirTemp("", "trpc-agent-go-repo-snapshot-*")
+	if err != nil {
+		return "", "", nil, nil, nil, fmt.Errorf("failed to create repository snapshot: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(snapshotRoot) }
+
+	scanRelativePath, err := filepath.Rel(repoRoot, rootToScan)
+	if err != nil {
+		cleanup()
+		return "", "", nil, nil, nil, fmt.Errorf("failed to locate repository scan root: %w", err)
+	}
+	snapshotScanRoot := filepath.Join(snapshotRoot, scanRelativePath)
+	if err := os.MkdirAll(snapshotScanRoot, 0o755); err != nil {
+		cleanup()
+		return "", "", nil, nil, nil, fmt.Errorf("failed to create snapshot scan root: %w", err)
+	}
+
+	snapshotContextFiles := make([]string, 0, len(contextFilePaths))
+	snapshotByRelativePath := make(map[string]string, len(contextFilePaths))
+	for _, filePath := range contextFilePaths {
+		if err := ctx.Err(); err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, err
+		}
+		relativePath, err := filepath.Rel(repoRoot, filePath)
+		if err != nil || relativePath == "." || relativePath == ".." ||
+			strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("file escapes repository root: %s", filePath)
+		}
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("failed to stat repository file: %w", err)
+		}
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("failed to read repository file: %w", err)
+		}
+		snapshotPath := filepath.Join(snapshotRoot, relativePath)
+		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("failed to create snapshot directory: %w", err)
+		}
+		if err := os.WriteFile(snapshotPath, content, fileInfo.Mode().Perm()); err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("failed to write repository snapshot: %w", err)
+		}
+		if err := os.Chtimes(snapshotPath, fileInfo.ModTime(), fileInfo.ModTime()); err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("failed to preserve repository file time: %w", err)
+		}
+		snapshotContextFiles = append(snapshotContextFiles, snapshotPath)
+		snapshotByRelativePath[filepath.Clean(relativePath)] = snapshotPath
+	}
+	snapshotResourceFiles := make([]string, 0, len(resourceFilePaths))
+	for _, filePath := range resourceFilePaths {
+		relativePath, err := filepath.Rel(repoRoot, filePath)
+		if err != nil {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("failed to locate resource file in snapshot: %w", err)
+		}
+		snapshotPath, ok := snapshotByRelativePath[filepath.Clean(relativePath)]
+		if !ok {
+			cleanup()
+			return "", "", nil, nil, nil, fmt.Errorf("resource file missing from repository snapshot: %s", filePath)
+		}
+		snapshotResourceFiles = append(snapshotResourceFiles, snapshotPath)
+	}
+	return snapshotRoot, snapshotScanRoot, snapshotResourceFiles, snapshotContextFiles, cleanup, nil
+}
+
+func restoreLocalRepositoryIdentity(
+	documents []*document.Document,
+	snapshotRoot string,
+	identityRoot string,
+) {
+	for _, doc := range documents {
+		if doc == nil || doc.Metadata == nil {
+			continue
+		}
+		relativePath := repositoryDocumentPath(snapshotRoot, doc)
+		doc.Metadata[source.MetaRepoPath] = identityRoot
+		if relativePath == "" {
+			continue
+		}
+		identityPath := filepath.Join(identityRoot, filepath.FromSlash(relativePath))
+		doc.Metadata[source.MetaURI] = (&url.URL{Scheme: "file", Path: identityPath}).String()
+	}
+}
+
+func (s *Source) readClassifiedDocuments(
+	rootToScan string,
+	repoRoot string,
+	repoInfo *repoInfo,
+	fc *fileClassification,
+) ([]*document.Document, error) {
 
 	var allDocuments []*document.Document
 
@@ -138,6 +369,103 @@ func (s *Source) ReadDocuments(ctx context.Context) ([]*document.Document, error
 	}
 
 	return allDocuments, nil
+}
+
+func (s *Source) buildResources(
+	repoRoot string,
+	filePaths []string,
+	documents []*document.Document,
+) ([]*source.Resource, error) {
+	filesByPath := make(map[string]string, len(filePaths))
+	for _, filePath := range filePaths {
+		relPath, err := filepath.Rel(repoRoot, filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build repo-relative resource path: %w", err)
+		}
+		relPath = filepath.ToSlash(filepath.Clean(relPath))
+		if relPath == "." || relPath == ".." || strings.HasPrefix(relPath, "../") {
+			return nil, fmt.Errorf("resource path escapes repository root: %s", filePath)
+		}
+		if _, exists := filesByPath[relPath]; exists {
+			return nil, fmt.Errorf("duplicate repository resource path: %s", relPath)
+		}
+		filesByPath[relPath] = filePath
+	}
+
+	documentsByPath := make(map[string][]*document.Document, len(filesByPath))
+	for _, doc := range documents {
+		if doc == nil {
+			return nil, fmt.Errorf("repository document cannot be nil")
+		}
+		relPath := repositoryDocumentPath(repoRoot, doc)
+		if relPath == "" {
+			return nil, fmt.Errorf("repository document %q has no resource path", doc.Name)
+		}
+		if _, exists := filesByPath[relPath]; !exists {
+			return nil, fmt.Errorf("repository document %q references unknown resource %q", doc.Name, relPath)
+		}
+		documentsByPath[relPath] = append(documentsByPath[relPath], doc)
+	}
+
+	resourcePaths := make([]string, 0, len(filesByPath))
+	for relPath := range filesByPath {
+		resourcePaths = append(resourcePaths, relPath)
+	}
+	slices.Sort(resourcePaths)
+
+	resources := make([]*source.Resource, 0, len(resourcePaths))
+	for _, relPath := range resourcePaths {
+		filePath := filesByPath[relPath]
+		content, modifiedAt, err := s.readResourceRepresentation(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource %s: %w", relPath, err)
+		}
+		resources = append(resources, &source.Resource{
+			Path:       relPath,
+			Content:    content,
+			ModifiedAt: modifiedAt,
+			Documents:  documentsByPath[relPath],
+		})
+	}
+	return resources, nil
+}
+
+func repositoryDocumentPath(repoRoot string, doc *document.Document) string {
+	if doc.Metadata == nil {
+		return ""
+	}
+	relPath := toRelativeRepoPath(repoRoot, doc.Metadata[source.MetaFilePath])
+	if relPath == "" {
+		relPath = toRelativeRepoPath(repoRoot, doc.Metadata["trpc_ast_file_path"])
+	}
+	return relPath
+}
+
+func (s *Source) readResourceRepresentation(filePath string) (string, time.Time, error) {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if fileInfo.Size() == 0 {
+		return "", fileInfo.ModTime().UTC(), nil
+	}
+	fileType := isource.GetFileType(filePath)
+	r, exists := s.resourceReaders[fileType]
+	if !exists {
+		return "", time.Time{}, missingReaderError(fileType)
+	}
+	docs, err := r.ReadFromFile(filePath)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to read file with unchunked reader: %w", err)
+	}
+	if len(docs) != 1 || docs[0] == nil {
+		return "", time.Time{}, fmt.Errorf("unchunked reader returned %d documents, want exactly one", len(docs))
+	}
+	content, _ := encoding.SmartProcessText(docs[0].Content)
+	if !utf8.ValidString(content) {
+		content = strings.ToValidUTF8(content, "\uFFFD")
+	}
+	return content, fileInfo.ModTime().UTC(), nil
 }
 
 // fileClassification groups file paths by processing priority, matching trpc-ast-rag order:
@@ -370,6 +698,31 @@ func cloneRemoteRepository(ctx context.Context, repository Repository, tmpDir st
 }
 
 func (s *Source) getFilePaths(dirPath string) ([]string, error) {
+	return s.collectFilePaths(dirPath, true)
+}
+
+func (s *Source) getSnapshotFilePaths(dirPath string) ([]string, error) {
+	var filePaths []string
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if path != dirPath && info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !info.Mode().IsRegular() || info.Name() == ".git" {
+			return nil
+		}
+		filePaths = append(filePaths, path)
+		return nil
+	})
+	return filePaths, err
+}
+
+func (s *Source) collectFilePaths(dirPath string, filterExtensions bool) ([]string, error) {
 	var filePaths []string
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -392,7 +745,7 @@ func (s *Source) getFilePaths(dirPath string) ([]string, error) {
 		if !info.Mode().IsRegular() || s.shouldSkipFile(info.Name()) {
 			return nil
 		}
-		if len(s.fileExtensions) > 0 {
+		if filterExtensions && len(s.fileExtensions) > 0 {
 			ext := strings.ToLower(filepath.Ext(path))
 			if !slices.Contains(s.fileExtensions, ext) {
 				return nil

--- a/knowledge/source/repo/repo_source_test.go
+++ b/knowledge/source/repo/repo_source_test.go
@@ -17,6 +17,7 @@ import (
 	goparser "go/parser"
 	"go/token"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,7 +35,11 @@ import (
 
 func init() {
 	docreader.RegisterReader([]string{".go"}, func(opts ...docreader.Option) docreader.Reader {
-		return &testGoReader{}
+		config := &docreader.Config{Chunk: true}
+		for _, opt := range opts {
+			opt(config)
+		}
+		return &testGoReader{chunk: config.Chunk}
 	})
 	docreader.RegisterReader([]string{".proto"}, func(opts ...docreader.Option) docreader.Reader {
 		return &testProtoReader{}
@@ -247,6 +252,301 @@ func (s *Service) Do(ctx context.Context) error { return nil }
 	}
 	if !methodDocFound {
 		t.Fatal("expected method document not found")
+	}
+}
+
+func TestReadResourcesFromLocalRepo(t *testing.T) {
+	repoRoot := t.TempDir()
+	goModContent := "module example.com/demo\n\ngo 1.21\n"
+	serviceContent := `package demo
+
+// Service serves requests.
+type Service struct{}
+
+// Do runs the service logic.
+func (s *Service) Do() {}
+`
+	writeRepoFile(t, filepath.Join(repoRoot, "go.mod"), goModContent)
+	writeRepoFile(t, filepath.Join(repoRoot, "service.go"), serviceContent)
+
+	src := New(WithRepository(Repository{Dir: repoRoot}))
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("len(resources) = %d, want 2", len(resources))
+	}
+	if resources[0].Path != "go.mod" || resources[1].Path != "service.go" {
+		t.Fatalf("resource paths = [%s %s], want [go.mod service.go]", resources[0].Path, resources[1].Path)
+	}
+
+	wantContents := map[string]string{
+		"go.mod":     goModContent,
+		"service.go": serviceContent,
+	}
+	var resourceDocumentCount int
+	for _, resource := range resources {
+		if resource.Content != wantContents[resource.Path] {
+			t.Fatalf("resource %s content = %q, want complete unchunked content %q", resource.Path, resource.Content, wantContents[resource.Path])
+		}
+		if resource.ModifiedAt.IsZero() {
+			t.Fatalf("resource %s has zero ModifiedAt", resource.Path)
+		}
+		for _, doc := range resource.Documents {
+			resourceDocumentCount++
+			if got := doc.Metadata[source.MetaFilePath]; got != resource.Path {
+				t.Fatalf("document resource path = %v, want %s", got, resource.Path)
+			}
+		}
+	}
+	if resourceDocumentCount == 0 {
+		t.Fatal("expected documents to be grouped under resources")
+	}
+
+	documents, err := src.ReadDocuments(context.Background())
+	if err != nil {
+		t.Fatalf("ReadDocuments() error = %v", err)
+	}
+	if len(documents) != resourceDocumentCount {
+		t.Fatalf("ReadDocuments() returned %d documents, resources contain %d", len(documents), resourceDocumentCount)
+	}
+}
+
+func TestReadResourcesSnapshotKeepsParserContext(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeRepoFile(t, filepath.Join(repoRoot, "go.mod"), "module example.com/context\n\ngo 1.21\n")
+	writeRepoFile(t, filepath.Join(repoRoot, "service.go"), "package demo\n\ntype Service struct{}\n")
+
+	resources, err := New(
+		WithRepository(Repository{Dir: repoRoot}),
+		WithFileExtensions([]string{".go"}),
+	).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Path != "service.go" {
+		t.Fatalf("resources = %+v, want only service.go", resources)
+	}
+	foundModuleIdentity := false
+	for _, doc := range resources[0].Documents {
+		if doc.Metadata["trpc_ast_full_name"] == "example.com/context.Service" {
+			foundModuleIdentity = true
+			break
+		}
+	}
+	if !foundModuleIdentity {
+		t.Fatalf("parser lost go.mod context: %+v", resources[0].Documents)
+	}
+}
+
+func TestReadResourcesSnapshotKeepsParentParserContext(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeRepoFile(t, filepath.Join(repoRoot, "go.mod"), "module example.com/context\n\ngo 1.21\n")
+	writeRepoFile(t, filepath.Join(repoRoot, "internal", "service.go"), "package internal\n\ntype Service struct{}\n")
+
+	resources, err := New(
+		WithRepository(Repository{Dir: repoRoot, Subdir: "internal"}),
+		WithFileExtensions([]string{".go"}),
+	).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Path != "internal/service.go" {
+		t.Fatalf("resources = %+v, want only internal/service.go", resources)
+	}
+	foundModuleIdentity := false
+	for _, doc := range resources[0].Documents {
+		if doc.Metadata["trpc_ast_full_name"] == "example.com/context/internal.Service" {
+			foundModuleIdentity = true
+			break
+		}
+	}
+	if !foundModuleIdentity {
+		t.Fatalf("parser lost parent go.mod context: %+v", resources[0].Documents)
+	}
+}
+
+func TestReadResourcesUsesUnchunkedReaderContent(t *testing.T) {
+	repoRoot := t.TempDir()
+	filePath := filepath.Join(repoRoot, "notes.txt")
+	writeRepoFile(t, filePath, "raw file content")
+
+	src := New(
+		WithRepository(Repository{Dir: repoRoot}),
+		WithFileExtensions([]string{".txt"}),
+	)
+	src.readers["text"] = &stubReader{fileDocs: []*document.Document{
+		{Content: "chunk one"},
+		{Content: "chunk two"},
+	}}
+	src.resourceReaders["text"] = &stubReader{fileDocs: []*document.Document{{
+		Content: "normalized complete text",
+	}}}
+
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("len(resources) = %d, want 1", len(resources))
+	}
+	resource := resources[0]
+	if resource.Content != "normalized complete text" {
+		t.Fatalf("resource content = %q, want unchunked reader content", resource.Content)
+	}
+	if len(resource.Documents) != 2 {
+		t.Fatalf("len(resource.Documents) = %d, want 2 chunks", len(resource.Documents))
+	}
+}
+
+func TestReadResourcesSnapshotsLocalRepository(t *testing.T) {
+	repoRoot := t.TempDir()
+	filePath := filepath.Join(repoRoot, "notes.txt")
+	writeRepoFile(t, filePath, "snapshot content")
+
+	src := New(
+		WithRepository(Repository{Dir: repoRoot}),
+		WithFileExtensions([]string{".txt"}),
+	)
+	src.readers["text"] = &mutatingRepoReader{afterRead: func() error {
+		return os.WriteFile(filePath, []byte("changed content"), 0o644)
+	}}
+	src.resourceReaders["text"] = &mutatingRepoReader{}
+
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || len(resources[0].Documents) != 1 {
+		t.Fatalf("resources = %+v, want one resource with one document", resources)
+	}
+	if resources[0].Content != "snapshot content" ||
+		resources[0].Documents[0].Content != "snapshot content" {
+		t.Fatalf(
+			"resource/doc content = %q/%q, want the same snapshot",
+			resources[0].Content,
+			resources[0].Documents[0].Content,
+		)
+	}
+	if got := resources[0].Documents[0].Metadata[source.MetaRepoPath]; got != repoRoot {
+		t.Fatalf("repo path metadata = %v, want %s", got, repoRoot)
+	}
+	wantURI := (&url.URL{Scheme: "file", Path: filePath}).String()
+	if got := resources[0].Documents[0].Metadata[source.MetaURI]; got != wantURI {
+		t.Fatalf("URI metadata = %v, want %s", got, wantURI)
+	}
+}
+
+func TestReadResourcesPreservesEmptyFile(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeRepoFile(t, filepath.Join(repoRoot, "empty.txt"), "")
+
+	resources, err := New(
+		WithRepository(Repository{Dir: repoRoot}),
+		WithFileExtensions([]string{".txt"}),
+	).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Path != "empty.txt" ||
+		resources[0].Content != "" || len(resources[0].Documents) != 0 {
+		t.Fatalf("empty resource = %+v", resources)
+	}
+}
+
+func TestReadResourcesRejectsMultipleUnchunkedDocuments(t *testing.T) {
+	repoRoot := t.TempDir()
+	writeRepoFile(t, filepath.Join(repoRoot, "notes.txt"), "raw file content")
+
+	src := New(
+		WithRepository(Repository{Dir: repoRoot}),
+		WithFileExtensions([]string{".txt"}),
+	)
+	src.readers["text"] = &stubReader{fileDocs: []*document.Document{{Content: "chunk"}}}
+	src.resourceReaders["text"] = &stubReader{fileDocs: []*document.Document{
+		{Content: "first"},
+		{Content: "second"},
+	}}
+
+	_, err := src.ReadResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "want exactly one") {
+		t.Fatalf("ReadResources() error = %v, want unchunked document count error", err)
+	}
+}
+
+func TestBuildResourcesRejectsUngroupedDocuments(t *testing.T) {
+	repoRoot := t.TempDir()
+	filePath := filepath.Join(repoRoot, "notes.txt")
+	writeRepoFile(t, filePath, "notes")
+	src := New()
+
+	tests := []struct {
+		name      string
+		documents []*document.Document
+		wantError string
+	}{
+		{name: "nil document", documents: []*document.Document{nil}, wantError: "cannot be nil"},
+		{name: "missing path", documents: []*document.Document{{Name: "orphan"}}, wantError: "has no resource path"},
+		{name: "unknown path", documents: []*document.Document{{
+			Name:     "unknown",
+			Metadata: map[string]any{source.MetaFilePath: "missing.txt"},
+		}}, wantError: "references unknown resource"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := src.buildResources(repoRoot, []string{filePath}, test.documents)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("buildResources() error = %v, want containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestReadResourcesFromRemoteRepoKeepsOneSnapshot(t *testing.T) {
+	serviceContent := "package demo\n\nfunc Remote() {}\n"
+	remoteURL, _ := createRemoteRepo(t, []repoCommit{{
+		branch: "main",
+		files: map[string]string{
+			"go.mod":     "module example.com/demo\n\ngo 1.21\n",
+			"service.go": serviceContent,
+		},
+	}}, nil)
+
+	src := New(WithRepository(Repository{URL: remoteURL, Branch: "main"}))
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	var service *source.Resource
+	var snapshotPath string
+	for _, resource := range resources {
+		if resource.Path == "service.go" {
+			service = resource
+		}
+		for _, doc := range resource.Documents {
+			path, _ := doc.Metadata[source.MetaRepoPath].(string)
+			if path == "" {
+				t.Fatalf("document for %s has no repository snapshot path", resource.Path)
+			}
+			if snapshotPath == "" {
+				snapshotPath = path
+			} else if path != snapshotPath {
+				t.Fatalf("documents use multiple repository snapshots: %q and %q", snapshotPath, path)
+			}
+		}
+	}
+	if service == nil {
+		t.Fatal("service.go resource not found")
+	}
+	if service.Content != serviceContent {
+		t.Fatalf("service.go content = %q, want %q", service.Content, serviceContent)
+	}
+	if snapshotPath == "" {
+		t.Fatal("repository snapshot path not found")
+	}
+	if _, err := os.Stat(snapshotPath); !os.IsNotExist(err) {
+		t.Fatalf("temporary repository snapshot still exists after ReadResources: stat error = %v", err)
 	}
 }
 
@@ -922,12 +1222,17 @@ func TestResolveRepositoryRejectsInvalidStructuredInputs(t *testing.T) {
 	}
 }
 
-type testGoReader struct{}
+type testGoReader struct {
+	chunk bool
+}
 
 func (r *testGoReader) ReadFromReader(name string, rd io.Reader) ([]*document.Document, error) {
 	content, err := io.ReadAll(rd)
 	if err != nil {
 		return nil, err
+	}
+	if !r.chunk {
+		return []*document.Document{{Name: filepath.Base(name), Content: string(content)}}, nil
 	}
 	result, err := r.parseFiles(filepath.Dir(name), []testGoFile{{path: name, content: string(content)}})
 	if err != nil {
@@ -940,6 +1245,9 @@ func (r *testGoReader) ReadFromFile(filePath string) ([]*document.Document, erro
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
+	}
+	if !r.chunk {
+		return []*document.Document{{Name: filepath.Base(filePath), Content: string(content)}}, nil
 	}
 	result, err := r.parseFiles(filepath.Dir(filePath), []testGoFile{{path: filePath, content: string(content)}})
 	if err != nil {
@@ -1264,6 +1572,36 @@ type stubReader struct {
 	fileDocs []*document.Document
 	fileErr  error
 }
+
+type mutatingRepoReader struct {
+	afterRead func() error
+}
+
+func (r *mutatingRepoReader) ReadFromReader(_ string, input io.Reader) ([]*document.Document, error) {
+	content, err := io.ReadAll(input)
+	if err != nil {
+		return nil, err
+	}
+	return []*document.Document{{Content: string(content)}}, nil
+}
+
+func (r *mutatingRepoReader) ReadFromFile(filePath string) ([]*document.Document, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if r.afterRead != nil {
+		if err := r.afterRead(); err != nil {
+			return nil, err
+		}
+		r.afterRead = nil
+	}
+	return []*document.Document{{Content: string(content)}}, nil
+}
+
+func (*mutatingRepoReader) ReadFromURL(string) ([]*document.Document, error) { return nil, nil }
+func (*mutatingRepoReader) Name() string                                     { return "snapshot" }
+func (*mutatingRepoReader) SupportedExtensions() []string                    { return []string{".txt"} }
 
 func (s *stubReader) ReadFromReader(_ string, _ io.Reader) ([]*document.Document, error) {
 	return nil, nil

--- a/knowledge/source/resource.go
+++ b/knowledge/source/resource.go
@@ -1,0 +1,41 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package source
+
+import (
+	"context"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
+)
+
+// Resource is one normalized, source-relative text resource together with the
+// documents produced from the same captured source input.
+type Resource struct {
+	// Path is the stable path relative to the logical source root.
+	Path string
+	// Content is the complete normalized UTF-8 text before chunking.
+	Content string
+	// ModifiedAt is the source modification time when available.
+	ModifiedAt time.Time
+	// Documents are chunks or structured entities produced from the resource.
+	Documents []*document.Document
+}
+
+// ResourceSource is an optional Source capability for loading persistent
+// source-level text together with its derived vector documents. Sources that
+// do not implement it remain valid vector-only sources.
+type ResourceSource interface {
+	Source
+
+	// ReadResources captures source input once per resource and produces both
+	// Content and Documents from that input. Implementations must not reconstruct
+	// Content from Documents.
+	ReadResources(ctx context.Context) ([]*Resource, error)
+}

--- a/knowledge/source/source.go
+++ b/knowledge/source/source.go
@@ -95,6 +95,15 @@ const (
 	MetaRepoURL    = codeast.TrpcAstMetaPrefix + "repo_url"
 	MetaBranch     = codeast.TrpcAstMetaPrefix + "branch"
 	MetaRepoPath   = MetaPrefix + "repo_path"
+
+	// MetaSourceID identifies the persisted source that owns a chunk.
+	MetaSourceID = MetaPrefix + "source_id"
+	// MetaResourcePath is the persisted resource path relative to its source root.
+	MetaResourcePath = MetaPrefix + "resource_path"
+	// MetaResourceStartLine is the first one-based resource line covered by a chunk.
+	MetaResourceStartLine = MetaPrefix + "resource_start_line"
+	// MetaResourceEndLine is the last one-based resource line covered by a chunk.
+	MetaResourceEndLine = MetaPrefix + "resource_end_line"
 )
 
 // Source represents a knowledge source that can provide documents.

--- a/knowledge/source/url/url_source.go
+++ b/knowledge/source/url/url_source.go
@@ -11,19 +11,23 @@
 package url
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/extractor"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/internal/encoding"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	isource "trpc.group/trpc-go/trpc-agent-go/knowledge/source/internal/source"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/transform"
@@ -42,6 +46,7 @@ type Source struct {
 	name                   string
 	metadata               map[string]any
 	readers                map[string]reader.Reader
+	resourceReaders        map[string]reader.Reader
 	httpClient             *http.Client
 	chunkSize              int
 	chunkOverlap           int
@@ -50,6 +55,8 @@ type Source struct {
 	fileReaderType         source.FileReaderType
 	contentExtractor       extractor.Extractor
 }
+
+var _ source.ResourceSource = (*Source)(nil)
 
 // New creates a new URL knowledge source.
 func New(urls []string, opts ...Option) *Source {
@@ -84,6 +91,12 @@ func New(urls []string, opts ...Option) *Source {
 
 	// Initialize readers with configuration
 	s.readers = isource.GetReaders(readerOpts...)
+
+	resourceReaderOpts := []isource.ReaderOption{isource.WithChunk(false)}
+	if len(s.transformers) > 0 {
+		resourceReaderOpts = append(resourceReaderOpts, isource.WithTransformers(s.transformers...))
+	}
+	s.resourceReaders = isource.GetReaders(resourceReaderOpts...)
 	return s
 }
 
@@ -112,6 +125,240 @@ func (s *Source) ReadDocuments(ctx context.Context) ([]*document.Document, error
 	}
 
 	return allDocuments, nil
+}
+
+// ReadResources downloads each URL once and returns its complete normalized
+// text together with the documents derived from the same response snapshot.
+func (s *Source) ReadResources(ctx context.Context) ([]*source.Resource, error) {
+	if len(s.identifierURLs) == 0 {
+		return nil, nil
+	}
+	if len(s.fetchURLs) > 0 && len(s.identifierURLs) != len(s.fetchURLs) {
+		return nil, fmt.Errorf("fetchURLs and urls must have the same count")
+	}
+
+	resources := make([]*source.Resource, 0, len(s.identifierURLs))
+	seenPaths := make(map[string]struct{}, len(s.identifierURLs))
+	for i, identifierURL := range s.identifierURLs {
+		fetchingURL := identifierURL
+		if len(s.fetchURLs) > 0 {
+			fetchingURL = s.fetchURLs[i]
+		}
+		resource, err := s.processURLResource(ctx, fetchingURL, identifierURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process URL %s: %w", identifierURL, err)
+		}
+		if _, exists := seenPaths[resource.Path]; exists {
+			return nil, fmt.Errorf("duplicate resource path %q", resource.Path)
+		}
+		seenPaths[resource.Path] = struct{}{}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
+func (s *Source) processURLResource(
+	ctx context.Context,
+	fetchingURL string,
+	identifierURL string,
+) (*source.Resource, error) {
+	if _, err := url.Parse(fetchingURL); err != nil {
+		return nil, fmt.Errorf("failed to parse fetching URL: %w", err)
+	}
+	parsedIdentifierURL, err := url.Parse(identifierURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse identifier URL: %w", err)
+	}
+
+	fileName := s.getFileName(parsedIdentifierURL, "")
+	documents, content, fileName, modifiedAt, err := s.fetchAndReadResource(
+		ctx,
+		fetchingURL,
+		parsedIdentifierURL,
+		fileName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	resourcePath, err := buildURLResourcePath(parsedIdentifierURL, fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := make(map[string]any, len(s.metadata)+8)
+	for k, v := range s.metadata {
+		metadata[k] = v
+	}
+	metadata[source.MetaSource] = source.TypeURL
+	metadata[source.MetaURL] = identifierURL
+	metadata[source.MetaURLHost] = parsedIdentifierURL.Host
+	metadata[source.MetaURLPath] = parsedIdentifierURL.Path
+	metadata[source.MetaURLScheme] = parsedIdentifierURL.Scheme
+	metadata[source.MetaURI] = identifierURL
+	metadata[source.MetaSourceName] = s.name
+	metadata[source.MetaResourcePath] = resourcePath
+	for _, doc := range documents {
+		if doc == nil {
+			return nil, fmt.Errorf("reader returned a nil document")
+		}
+		if doc.Metadata == nil {
+			doc.Metadata = make(map[string]any)
+		}
+		for k, v := range metadata {
+			doc.Metadata[k] = v
+		}
+	}
+
+	return &source.Resource{
+		Path:       resourcePath,
+		Content:    content,
+		ModifiedAt: modifiedAt,
+		Documents:  documents,
+	}, nil
+}
+
+func (s *Source) fetchAndReadResource(
+	ctx context.Context,
+	fetchingURL string,
+	parsedIdentifierURL *url.URL,
+	fileName string,
+) ([]*document.Document, string, string, time.Time, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchingURL, nil)
+	if err != nil {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; KnowledgeSource/1.0)")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("failed to download URL: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("HTTP error: %d", resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	fileName = s.getFileName(parsedIdentifierURL, contentType)
+	fileType := isource.ResolveFileType(
+		string(s.fileReaderType),
+		isource.GetFileTypeFromContentType(contentType, fileName),
+	)
+
+	var payload []byte
+	ext := strings.ToLower(filepath.Ext(fileName))
+	if s.contentExtractor != nil && !extractor.Supports(s.contentExtractor, ext) {
+		if inferredExt := extractorExtFromContentType(contentType); inferredExt != "" {
+			ext = inferredExt
+		}
+	}
+	if s.contentExtractor != nil && extractor.Supports(s.contentExtractor, ext) {
+		result, extractErr := s.contentExtractor.ExtractFromReader(ctx, resp.Body)
+		if extractErr != nil {
+			return nil, "", fileName, time.Time{}, fmt.Errorf("content extraction failed: %w", extractErr)
+		}
+		if result == nil || result.Reader == nil {
+			return nil, "", fileName, time.Time{}, fmt.Errorf("content extractor returned no content")
+		}
+		fileType = result.Format
+		payload, err = io.ReadAll(result.Reader)
+	} else {
+		payload, err = io.ReadAll(resp.Body)
+	}
+	if err != nil {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("failed to read URL content: %w", err)
+	}
+	var modifiedAt time.Time
+	if value := resp.Header.Get("Last-Modified"); value != "" {
+		modifiedAt, _ = http.ParseTime(value)
+	}
+	if len(payload) == 0 {
+		return nil, "", fileName, modifiedAt, nil
+	}
+
+	resourceReader, exists := s.resourceReaders[fileType]
+	if !exists {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("no reader available for resource type: %s", fileType)
+	}
+	resourceDocuments, err := resourceReader.ReadFromReader(fileName, bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("failed to read complete resource content: %w", err)
+	}
+	if len(resourceDocuments) != 1 || resourceDocuments[0] == nil {
+		return nil, "", fileName, time.Time{}, fmt.Errorf(
+			"resource reader returned %d documents, want exactly one",
+			len(resourceDocuments),
+		)
+	}
+
+	documentReader, exists := s.readers[fileType]
+	if !exists {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("no reader available for file type: %s", fileType)
+	}
+	documents, err := documentReader.ReadFromReader(fileName, bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", fileName, time.Time{}, fmt.Errorf("failed to read content with reader: %w", err)
+	}
+
+	content, _ := encoding.SmartProcessText(resourceDocuments[0].Content)
+	if !utf8.ValidString(content) {
+		content = strings.ToValidUTF8(content, "\uFFFD")
+	}
+	return documents, content, fileName, modifiedAt, nil
+}
+
+func buildURLResourcePath(parsedURL *url.URL, fileName string) (string, error) {
+	host := strings.ToLower(parsedURL.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("identifier URL host cannot be empty")
+	}
+	if port := parsedURL.Port(); port != "" {
+		host += ":" + port
+	}
+
+	parts := []string{escapeURLResourceSegment(host)}
+	escapedPath := strings.Trim(parsedURL.EscapedPath(), "/")
+	if escapedPath != "" {
+		for _, rawSegment := range strings.Split(escapedPath, "/") {
+			segment, err := url.PathUnescape(rawSegment)
+			if err != nil {
+				return "", fmt.Errorf("failed to decode identifier URL path: %w", err)
+			}
+			if segment == "" {
+				continue
+			}
+			parts = append(parts, escapeURLResourceSegment(segment))
+		}
+	}
+	if escapedPath == "" || strings.HasSuffix(parsedURL.EscapedPath(), "/") {
+		parts = append(parts, escapeURLResourceSegment(fileName))
+	}
+	return path.Join(parts...), nil
+}
+
+func escapeURLResourceSegment(value string) string {
+	if value == "" {
+		return "_"
+	}
+	forceEscapeDots := value == "." || value == ".."
+	const hexDigits = "0123456789ABCDEF"
+	var escaped strings.Builder
+	for i := 0; i < len(value); i++ {
+		character := value[i]
+		allowed := (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			character == '-' || character == '_' || character == '~' ||
+			(character == '.' && !forceEscapeDots)
+		if allowed {
+			escaped.WriteByte(character)
+			continue
+		}
+		escaped.WriteByte('%')
+		escaped.WriteByte(hexDigits[character>>4])
+		escaped.WriteByte(hexDigits[character&0x0f])
+	}
+	return escaped.String()
 }
 
 // Name returns the name of this source.

--- a/knowledge/source/url/url_source_test.go
+++ b/knowledge/source/url/url_source_test.go
@@ -88,6 +88,147 @@ func (m *pngContentExtractor) Close() error {
 	return nil
 }
 
+type countingResourceExtractor struct {
+	calls int
+}
+
+func (e *countingResourceExtractor) Extract(
+	ctx context.Context,
+	data []byte,
+	opts ...extractor.Option,
+) (*extractor.Result, error) {
+	return e.ExtractFromReader(ctx, strings.NewReader(string(data)), opts...)
+}
+
+func (e *countingResourceExtractor) ExtractFromReader(
+	context.Context,
+	io.Reader,
+	...extractor.Option,
+) (*extractor.Result, error) {
+	e.calls++
+	return &extractor.Result{
+		Reader: strings.NewReader("# Extracted\n\ncomplete resource content"),
+		Format: extractor.FormatMarkdown,
+	}, nil
+}
+
+func (*countingResourceExtractor) SupportedFormats() []string {
+	return []string{".pdf"}
+}
+
+func (*countingResourceExtractor) Close() error {
+	return nil
+}
+
+func TestReadResourcesUsesOneFetchAndExtraction(t *testing.T) {
+	requestCount := 0
+	lastModified := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Last-Modified", lastModified.Format(http.TimeFormat))
+		_, _ = w.Write([]byte("%PDF-source"))
+	}))
+	defer server.Close()
+
+	extractor := &countingResourceExtractor{}
+	identifierURL := "https://user:secret@Example.com/docs/manual.pdf?token=hidden"
+	src := New(
+		[]string{identifierURL},
+		WithContentFetchingURL([]string{server.URL}),
+		WithExtractor(extractor),
+		WithChunkSize(12),
+	)
+	resources, err := src.ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("HTTP request count = %d, want 1", requestCount)
+	}
+	if extractor.calls != 1 {
+		t.Fatalf("extractor call count = %d, want 1", extractor.calls)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("ReadResources() returned %d resources, want 1", len(resources))
+	}
+	resource := resources[0]
+	if resource.Path != "example.com/docs/manual.pdf" {
+		t.Fatalf("resource path = %q, want %q", resource.Path, "example.com/docs/manual.pdf")
+	}
+	if strings.Contains(resource.Path, "user") || strings.Contains(resource.Path, "secret") ||
+		strings.Contains(resource.Path, "token") || strings.Contains(resource.Path, "?") {
+		t.Fatalf("resource path exposes URL credentials or query: %q", resource.Path)
+	}
+	if resource.Content != "# Extracted\n\ncomplete resource content" {
+		t.Fatalf("resource content = %q", resource.Content)
+	}
+	if !resource.ModifiedAt.Equal(lastModified) {
+		t.Fatalf("resource modified time = %v, want %v", resource.ModifiedAt, lastModified)
+	}
+	if len(resource.Documents) == 0 {
+		t.Fatal("resource documents are empty")
+	}
+	for _, doc := range resource.Documents {
+		if got := doc.Metadata[source.MetaResourcePath]; got != resource.Path {
+			t.Fatalf("document resource path = %v, want %q", got, resource.Path)
+		}
+	}
+}
+
+func TestReadResourcesRejectsDuplicateSafePaths(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	src := New([]string{
+		server.URL + "/guide.txt?version=1",
+		server.URL + "/guide.txt?version=2",
+	})
+	_, err := src.ReadResources(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "duplicate resource path") {
+		t.Fatalf("ReadResources() error = %v, want duplicate resource path", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("HTTP request count = %d, want one per URL", requestCount)
+	}
+}
+
+func TestReadResourcesPreservesEmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resources, err := New([]string{server.URL + "/empty.txt"}).ReadResources(context.Background())
+	if err != nil {
+		t.Fatalf("ReadResources() error = %v", err)
+	}
+	if len(resources) != 1 || resources[0].Content != "" || len(resources[0].Documents) != 0 {
+		t.Fatalf("empty resource = %+v", resources)
+	}
+}
+
+func TestBuildURLResourcePathEscapesUnsafeSegments(t *testing.T) {
+	parsed, err := neturl.Parse("https://user:secret@example.com:8443/a%2Fb/%2E%2E/?token=hidden")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	got, err := buildURLResourcePath(parsed, "index.html")
+	if err != nil {
+		t.Fatalf("buildURLResourcePath() error = %v", err)
+	}
+	want := "example.com%3A8443/a%2Fb/%2E%2E/index.html"
+	if got != want {
+		t.Fatalf("buildURLResourcePath() = %q, want %q", got, want)
+	}
+}
+
 // TestReadDocuments verifies URL Source with and without custom chunk
 // configuration.
 func TestReadDocuments(t *testing.T) {

--- a/knowledge/stores.go
+++ b/knowledge/stores.go
@@ -1,0 +1,50 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
+)
+
+// Stores groups the stable storage roles used by BuiltinKnowledge. Each field
+// remains strongly typed; Stores is configuration, not a common store API.
+type Stores struct {
+	// Vector stores normal document chunks, embeddings, and chunk metadata.
+	Vector vectorstore.VectorStore
+	// Graph stores graph nodes, edges, and graph-native query capabilities.
+	Graph graphstore.Store
+	// Resource stores source-level text, safe metadata, and directory relationships.
+	Resource resourcestore.Store
+}
+
+// WithStores configures BuiltinKnowledge storage roles. Options are applied in
+// order. A later WithStores call replaces all fields, while a later
+// WithVectorStore call replaces only the vector field.
+func WithStores(stores Stores) Option {
+	return func(dk *BuiltinKnowledge) {
+		dk.vectorStore = stores.Vector
+		dk.graphStore = stores.Graph
+		dk.resourceStore = stores.Resource
+	}
+}
+
+// Graph returns the graph-native view when the configured graph store also
+// implements graphstore.Searcher. The returned view borrows the store;
+// BuiltinKnowledge remains its lifecycle owner.
+func (dk *BuiltinKnowledge) Graph() (GraphKnowledge, bool) {
+	if dk == nil || dk.graphStore == nil {
+		return nil, false
+	}
+	if _, ok := dk.graphStore.(graphstore.Searcher); !ok {
+		return nil, false
+	}
+	return NewGraphKnowledge(WithGraphStore(dk.graphStore)), true
+}

--- a/knowledge/stores_test.go
+++ b/knowledge/stores_test.go
@@ -1,0 +1,337 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/graph"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/retriever"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/inmemory"
+)
+
+func TestWithStoresOptionOrder(t *testing.T) {
+	vectorA := inmemory.New()
+	vectorB := inmemory.New()
+	graphA := &storesTestGraphStore{}
+	graphB := &storesTestGraphStore{}
+	resourceA := &resourceTestStore{}
+	resourceB := &resourceTestStore{}
+
+	tests := []struct {
+		name         string
+		opts         []Option
+		wantVector   vectorstore.VectorStore
+		wantGraph    graphstore.Store
+		wantResource *resourceTestStore
+	}{
+		{
+			name: "later vector option only replaces vector",
+			opts: []Option{
+				WithStores(Stores{Vector: vectorA, Graph: graphA, Resource: resourceA}),
+				WithVectorStore(vectorB),
+			},
+			wantVector:   vectorB,
+			wantGraph:    graphA,
+			wantResource: resourceA,
+		},
+		{
+			name: "later stores option replaces vector",
+			opts: []Option{
+				WithVectorStore(vectorB),
+				WithStores(Stores{Vector: vectorA, Graph: graphA, Resource: resourceA}),
+			},
+			wantVector:   vectorA,
+			wantGraph:    graphA,
+			wantResource: resourceA,
+		},
+		{
+			name: "later stores option replaces all fields",
+			opts: []Option{
+				WithStores(Stores{Vector: vectorA, Graph: graphA, Resource: resourceA}),
+				WithStores(Stores{Vector: vectorB, Graph: graphB, Resource: resourceB}),
+			},
+			wantVector:   vectorB,
+			wantGraph:    graphB,
+			wantResource: resourceB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kb := New(tt.opts...)
+			if kb.vectorStore != tt.wantVector {
+				t.Fatalf("vector store = %p, want %p", kb.vectorStore, tt.wantVector)
+			}
+			if kb.graphStore != tt.wantGraph {
+				t.Fatalf("graph store = %p, want %p", kb.graphStore, tt.wantGraph)
+			}
+			if kb.resourceStore != tt.wantResource {
+				t.Fatalf("resource store = %p, want %p", kb.resourceStore, tt.wantResource)
+			}
+		})
+	}
+}
+
+func TestBuiltinKnowledgeGraphAvailability(t *testing.T) {
+	tests := []struct {
+		name      string
+		graph     graphstore.Store
+		available bool
+	}{
+		{name: "not configured"},
+		{name: "store without native search", graph: &storesTestGraphStore{}},
+		{name: "store with native search", graph: &storesTestSearchableGraphStore{}, available: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kb := New(WithStores(Stores{Graph: tt.graph}))
+			view, ok := kb.Graph()
+			if ok != tt.available {
+				t.Fatalf("Graph() available = %v, want %v", ok, tt.available)
+			}
+			if (view != nil) != tt.available {
+				t.Fatalf("Graph() view nil = %v, want availability %v", view == nil, tt.available)
+			}
+			if tt.available {
+				builtin, ok := view.(*BuiltinGraphKnowledge)
+				if !ok {
+					t.Fatalf("Graph() view type = %T, want *BuiltinGraphKnowledge", view)
+				}
+				if builtin.store != tt.graph {
+					t.Fatal("Graph() view does not borrow the configured graph store")
+				}
+			}
+		})
+	}
+}
+
+func TestBuiltinKnowledgeGraphOnlySearchFailsExplicitly(t *testing.T) {
+	kb := New(WithStores(Stores{Graph: &storesTestSearchableGraphStore{}}))
+	_, err := kb.Search(context.Background(), &SearchRequest{Query: "document query"})
+	if err == nil || err.Error() != "retriever not configured" {
+		t.Fatalf("Search() error = %v, want retriever not configured", err)
+	}
+}
+
+func TestBuiltinKnowledgeGraphNativeSearchMappingAndDeduplication(t *testing.T) {
+	store := &storesTestSearchableGraphStore{
+		searchResult: &graphstore.SearchNodesResult{Nodes: []*graphstore.ScoredNode{
+			{Node: &graph.Node{ID: "node-a", Name: "first", Content: "first content", Metadata: map[string]any{"kind": "method"}}, Score: 0.91},
+			nil,
+			{Node: nil, Score: 0.8},
+			{Node: &graph.Node{}, Score: 0.7},
+			{Node: &graph.Node{ID: "node-a", Name: "duplicate", Content: "duplicate content"}, Score: 0.99},
+			{Node: &graph.Node{ID: "node-b", Name: "second", Content: "second content"}, Score: 0.62},
+		}},
+	}
+	kb := New(WithStores(Stores{Graph: store}))
+	view, ok := kb.Graph()
+	if !ok {
+		t.Fatal("Graph() is unavailable for a native searchable store")
+	}
+
+	filter := &SearchFilter{
+		DocumentIDs: []string{"node-a", "node-b"},
+		Metadata:    map[string]any{"visibility": "public"},
+	}
+	result, err := view.Search(context.Background(), &SearchRequest{
+		Query:        "  graph query  ",
+		MaxResults:   7,
+		MinScore:     0.4,
+		SearchFilter: filter,
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+
+	wantRequest := &graphstore.SearchNodesRequest{
+		Query:    "graph query",
+		Mode:     graphstore.SearchModeHybrid,
+		Limit:    7,
+		MinScore: 0.4,
+		Filter: &graphstore.SearchNodesFilter{
+			NodeIDs:  []string{"node-a", "node-b"},
+			Metadata: map[string]any{"visibility": "public"},
+		},
+	}
+	if !reflect.DeepEqual(store.searchRequest, wantRequest) {
+		t.Fatalf("SearchNodes() request = %#v, want %#v", store.searchRequest, wantRequest)
+	}
+	if len(result.Documents) != 2 {
+		t.Fatalf("Search() document count = %d, want 2", len(result.Documents))
+	}
+	if got := result.Documents[0]; got.Document.ID != "node-a" || got.Document.Name != "first" || got.Score != 0.91 {
+		t.Fatalf("first result = %+v, want first occurrence of node-a", got)
+	}
+	if got := result.Documents[1]; got.Document.ID != "node-b" || got.Score != 0.62 {
+		t.Fatalf("second result = %+v, want node-b", got)
+	}
+	if result.Document != result.Documents[0].Document || result.Score != 0.91 || result.Text != "first content" {
+		t.Fatalf("top-level result = %+v, want first deduplicated node", result)
+	}
+}
+
+func TestNativeGraphSearchModeMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *SearchRequest
+		want graphstore.SearchMode
+	}{
+		{name: "default hybrid", req: &SearchRequest{Query: "q"}, want: graphstore.SearchModeHybrid},
+		{name: "vector", req: &SearchRequest{Query: "q", SearchMode: vectorstore.SearchModeVector}, want: graphstore.SearchModeVector},
+		{name: "keyword", req: &SearchRequest{Query: "q", SearchMode: vectorstore.SearchModeKeyword}, want: graphstore.SearchModeKeyword},
+		{name: "explicit filter", req: &SearchRequest{Query: "q", SearchMode: vectorstore.SearchModeFilter}, want: graphstore.SearchModeFilter},
+		{name: "filter only", req: &SearchRequest{SearchFilter: &SearchFilter{DocumentIDs: []string{"n1"}}}, want: graphstore.SearchModeFilter},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nativeGraphSearchMode(tt.req); got != tt.want {
+				t.Fatalf("nativeGraphSearchMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuiltinKnowledgeCloseOnceAggregatesErrorsAndClosesGraph(t *testing.T) {
+	retrieverErr := errors.New("retriever close failed")
+	vectorErr := errors.New("vector close failed")
+	graphErr := errors.New("graph close failed")
+	resourceErr := errors.New("resource close failed")
+	r := &storesTestRetriever{closeErr: retrieverErr}
+	v := &storesTestVectorStore{closeErr: vectorErr}
+	g := &storesTestSearchableGraphStore{
+		storesTestGraphStore: storesTestGraphStore{closeErr: graphErr},
+	}
+	resource := &resourceTestStore{closeErr: resourceErr}
+	kb := New(
+		WithRetriever(r),
+		WithStores(Stores{Vector: v, Graph: g, Resource: resource}),
+	)
+
+	firstErr := kb.Close()
+	secondErr := kb.Close()
+	if firstErr == nil {
+		t.Fatal("Close() error = nil, want joined close errors")
+	}
+	if secondErr != firstErr {
+		t.Fatalf("second Close() error = %v, want cached error %v", secondErr, firstErr)
+	}
+	for _, wantErr := range []error{retrieverErr, vectorErr, graphErr, resourceErr} {
+		if !errors.Is(firstErr, wantErr) {
+			t.Errorf("Close() error %q does not contain %q", firstErr, wantErr)
+		}
+	}
+	if r.closeCalls != 1 || v.closeCalls != 1 || g.closeCalls != 1 || resource.closeCalls != 1 {
+		t.Fatalf(
+			"close calls = retriever:%d vector:%d graph:%d resource:%d, want each exactly once",
+			r.closeCalls, v.closeCalls, g.closeCalls, resource.closeCalls,
+		)
+	}
+}
+
+type storesTestGraphStore struct {
+	closeErr   error
+	closeCalls int
+}
+
+func (*storesTestGraphStore) AddNodes(context.Context, []*graph.Node) error { return nil }
+
+func (*storesTestGraphStore) AddEdges(context.Context, []*graph.Edge) error { return nil }
+
+func (*storesTestGraphStore) Traverse(context.Context, *graph.TraverseQuery) (*graph.TraverseResult, error) {
+	return &graph.TraverseResult{}, nil
+}
+
+func (*storesTestGraphStore) FindPaths(context.Context, *graph.PathQuery) (*graph.PathResult, error) {
+	return &graph.PathResult{}, nil
+}
+
+func (s *storesTestGraphStore) Close() error {
+	s.closeCalls++
+	return s.closeErr
+}
+
+type storesTestSearchableGraphStore struct {
+	storesTestGraphStore
+	searchRequest *graphstore.SearchNodesRequest
+	searchResult  *graphstore.SearchNodesResult
+	searchErr     error
+}
+
+func (s *storesTestSearchableGraphStore) SearchNodes(
+	_ context.Context,
+	req *graphstore.SearchNodesRequest,
+) (*graphstore.SearchNodesResult, error) {
+	s.searchRequest = req
+	return s.searchResult, s.searchErr
+}
+
+type storesTestRetriever struct {
+	closeErr   error
+	closeCalls int
+}
+
+func (*storesTestRetriever) Retrieve(context.Context, *retriever.Query) (*retriever.Result, error) {
+	return &retriever.Result{}, nil
+}
+
+func (r *storesTestRetriever) Close() error {
+	r.closeCalls++
+	return r.closeErr
+}
+
+type storesTestVectorStore struct {
+	closeErr   error
+	closeCalls int
+}
+
+func (*storesTestVectorStore) Add(context.Context, *document.Document, []float64) error { return nil }
+
+func (*storesTestVectorStore) Get(context.Context, string) (*document.Document, []float64, error) {
+	return nil, nil, nil
+}
+
+func (*storesTestVectorStore) Update(context.Context, *document.Document, []float64) error {
+	return nil
+}
+
+func (*storesTestVectorStore) Delete(context.Context, string) error { return nil }
+
+func (*storesTestVectorStore) Search(context.Context, *vectorstore.SearchQuery) (*vectorstore.SearchResult, error) {
+	return &vectorstore.SearchResult{}, nil
+}
+
+func (*storesTestVectorStore) DeleteByFilter(context.Context, ...vectorstore.DeleteOption) error {
+	return nil
+}
+
+func (*storesTestVectorStore) UpdateByFilter(context.Context, ...vectorstore.UpdateByFilterOption) (int64, error) {
+	return 0, nil
+}
+
+func (*storesTestVectorStore) Count(context.Context, ...vectorstore.CountOption) (int, error) {
+	return 0, nil
+}
+
+func (*storesTestVectorStore) GetMetadata(context.Context, ...vectorstore.GetMetadataOption) (map[string]vectorstore.DocumentMetadata, error) {
+	return nil, nil
+}
+
+func (s *storesTestVectorStore) Close() error {
+	s.closeCalls++
+	return s.closeErr
+}

--- a/knowledge/stores_test.go
+++ b/knowledge/stores_test.go
@@ -122,8 +122,8 @@ func TestBuiltinKnowledgeGraphAvailability(t *testing.T) {
 func TestBuiltinKnowledgeGraphOnlySearchFailsExplicitly(t *testing.T) {
 	kb := New(WithStores(Stores{Graph: &storesTestSearchableGraphStore{}}))
 	_, err := kb.Search(context.Background(), &SearchRequest{Query: "document query"})
-	if err == nil || err.Error() != "retriever not configured" {
-		t.Fatalf("Search() error = %v, want retriever not configured", err)
+	if err == nil || err.Error() != "retrieval failed: vector store not configured" {
+		t.Fatalf("Search() error = %v, want missing vector store error", err)
 	}
 }
 

--- a/knowledge/tool/graphtool.go
+++ b/knowledge/tool/graphtool.go
@@ -13,9 +13,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/graph"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
 )
@@ -197,19 +199,19 @@ func NewGraphFindPathsTool(kb knowledge.GraphKnowledge, opts ...GraphToolOption)
 }
 
 func graphTraverseToolResult(result *graph.TraverseResult, includeContent bool) *graph.TraverseResult {
-	if result == nil || includeContent {
+	if result == nil {
 		return result
 	}
 	return &graph.TraverseResult{
 		Nodes:     graphToolNodes(result.Nodes, includeContent),
-		Edges:     result.Edges,
+		Edges:     graphToolEdges(result.Edges),
 		Truncated: result.Truncated,
 		Message:   result.Message,
 	}
 }
 
 func graphPathToolResult(result *graph.PathResult, includeContent bool) *graph.PathResult {
-	if result == nil || includeContent {
+	if result == nil {
 		return result
 	}
 	paths := make([]*graph.Path, 0, len(result.Paths))
@@ -220,7 +222,7 @@ func graphPathToolResult(result *graph.PathResult, includeContent bool) *graph.P
 		}
 		paths = append(paths, &graph.Path{
 			Nodes: graphToolNodes(path.Nodes, includeContent),
-			Edges: path.Edges,
+			Edges: graphToolEdges(path.Edges),
 		})
 	}
 	return &graph.PathResult{
@@ -231,9 +233,6 @@ func graphPathToolResult(result *graph.PathResult, includeContent bool) *graph.P
 }
 
 func graphToolNodes(nodes []*graph.Node, includeContent bool) []*graph.Node {
-	if includeContent {
-		return nodes
-	}
 	cloned := make([]*graph.Node, 0, len(nodes))
 	for _, node := range nodes {
 		if node == nil {
@@ -241,10 +240,44 @@ func graphToolNodes(nodes []*graph.Node, includeContent bool) []*graph.Node {
 			continue
 		}
 		next := *node
-		next.Content = ""
+		if !includeContent {
+			next.Content = ""
+		}
+		next.Metadata = graphToolMetadata(node.Metadata)
 		cloned = append(cloned, &next)
 	}
 	return cloned
+}
+
+func graphToolEdges(edges []*graph.Edge) []*graph.Edge {
+	cloned := make([]*graph.Edge, 0, len(edges))
+	for _, edge := range edges {
+		if edge == nil {
+			cloned = append(cloned, nil)
+			continue
+		}
+		next := *edge
+		next.Metadata = graphToolMetadata(edge.Metadata)
+		cloned = append(cloned, &next)
+	}
+	return cloned
+}
+
+func graphToolMetadata(metadata map[string]any) map[string]any {
+	if metadata == nil {
+		return nil
+	}
+	filtered := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		if !strings.HasPrefix(key, source.MetaPrefix) {
+			filtered[key] = value
+		}
+	}
+	copyResourceMetadata(filtered, metadata, nil)
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 func buildGraphToolOptions(

--- a/knowledge/tool/graphtool_test.go
+++ b/knowledge/tool/graphtool_test.go
@@ -19,6 +19,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/knowledge"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/graph"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
 	ctool "trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -437,6 +438,35 @@ func TestGraphToolNodesPreservesNodeMetadata(t *testing.T) {
 	require.Equal(t, "MyFunc", got[0].Name)
 	require.Empty(t, got[0].Content)
 	require.Equal(t, map[string]any{"type": "Function"}, got[0].Metadata)
+}
+
+func TestGraphToolResultsSanitizeInternalResourceMetadata(t *testing.T) {
+	metadata := map[string]any{
+		"kind":                       "function",
+		source.MetaSourceID:          "source-1",
+		source.MetaSourceName:        "docs",
+		source.MetaResourcePath:      "docs/config.md",
+		source.MetaURI:               "hdfs://private-cluster/secret/config.md",
+		source.MetaFilePath:          "/private/root/docs/config.md",
+		source.MetaResourceStartLine: 10,
+		source.MetaResourceEndLine:   20,
+	}
+	result := graphTraverseToolResult(&graph.TraverseResult{
+		Nodes: []*graph.Node{{ID: "node-1", Content: "body", Metadata: metadata}},
+		Edges: []*graph.Edge{{FromID: "node-1", ToID: "node-2", Type: "CALLS", Metadata: metadata}},
+	}, true)
+
+	require.Equal(t, "body", result.Nodes[0].Content)
+	for _, projected := range []map[string]any{result.Nodes[0].Metadata, result.Edges[0].Metadata} {
+		require.Equal(t, "function", projected["kind"])
+		require.Equal(t, "source-1", projected[source.MetaSourceID])
+		require.Equal(t, "docs/config.md", projected[source.MetaResourcePath])
+		require.Equal(t, 10, projected[source.MetaResourceStartLine])
+		require.Equal(t, 20, projected[source.MetaResourceEndLine])
+		require.NotContains(t, projected, source.MetaSourceName)
+		require.NotContains(t, projected, source.MetaURI)
+		require.NotContains(t, projected, source.MetaFilePath)
+	}
 }
 
 func TestGraphTraverseToolReturnsKBError(t *testing.T) {

--- a/knowledge/tool/resourcetool.go
+++ b/knowledge/tool/resourcetool.go
@@ -1,0 +1,142 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+const defaultResourceToolSetName = "knowledge"
+
+type resourceToolSet struct {
+	kb    knowledge.ResourceKnowledge
+	tools []tool.Tool
+}
+
+// NewResourceToolSet creates tools for browsing and reading persisted resource
+// content. Search remains separate because ResourceKnowledge is optional and
+// independent from semantic retrieval. The tool set does not own kb.
+func NewResourceToolSet(kb knowledge.ResourceKnowledge) tool.ToolSet {
+	return &resourceToolSet{
+		kb: kb,
+		tools: []tool.Tool{
+			newListSourcesTool(kb),
+			newListResourcesTool(kb),
+			newReadResourceTool(kb),
+			newGrepResourceTool(kb),
+		},
+	}
+}
+
+func (s *resourceToolSet) Tools(_ context.Context) []tool.Tool {
+	return s.tools
+}
+
+func (s *resourceToolSet) Close() error {
+	return nil
+}
+
+func (s *resourceToolSet) Name() string {
+	return defaultResourceToolSetName
+}
+
+func newListSourcesTool(kb knowledge.ResourceKnowledge) tool.Tool {
+	fn := func(ctx context.Context, req *knowledge.ListSourcesRequest) (*knowledge.ListSourcesResult, error) {
+		if kb == nil {
+			return nil, knowledge.ErrResourceCapabilityUnavailable
+		}
+		if req == nil {
+			return nil, errors.New("list sources request cannot be nil")
+		}
+		result, err := kb.ListSources(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("list knowledge sources: %w", err)
+		}
+		return result, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName("list_sources"),
+		function.WithDescription("List persisted knowledge sources that support file browsing and reading."),
+	)
+}
+
+func newListResourcesTool(kb knowledge.ResourceKnowledge) tool.Tool {
+	fn := func(ctx context.Context, req *knowledge.ListResourcesRequest) (*knowledge.ListResourcesResult, error) {
+		if kb == nil {
+			return nil, knowledge.ErrResourceCapabilityUnavailable
+		}
+		if req == nil || strings.TrimSpace(req.SourceID) == "" {
+			return nil, errors.New("source_id is required")
+		}
+		result, err := kb.ListResources(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("list knowledge resources: %w", err)
+		}
+		return result, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName("list_resources"),
+		function.WithDescription("List direct children in a persisted source tree. Pass parent_path to browse a directory."),
+	)
+}
+
+func newReadResourceTool(kb knowledge.ResourceKnowledge) tool.Tool {
+	fn := func(ctx context.Context, req *knowledge.ReadResourceRequest) (*knowledge.ReadResourceResult, error) {
+		if kb == nil {
+			return nil, knowledge.ErrResourceCapabilityUnavailable
+		}
+		if req == nil || strings.TrimSpace(req.SourceID) == "" || strings.TrimSpace(req.Path) == "" {
+			return nil, errors.New("source_id and path are required")
+		}
+		result, err := kb.ReadResource(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("read knowledge resource: %w", err)
+		}
+		return result, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName("read"),
+		function.WithDescription("Read a bounded line range from the persisted text resource identified by source_id and path."),
+	)
+}
+
+func newGrepResourceTool(kb knowledge.ResourceKnowledge) tool.Tool {
+	fn := func(ctx context.Context, req *knowledge.GrepResourceRequest) (*knowledge.GrepResourceResult, error) {
+		if kb == nil {
+			return nil, knowledge.ErrResourceCapabilityUnavailable
+		}
+		if req == nil || strings.TrimSpace(req.SourceID) == "" ||
+			strings.TrimSpace(req.Path) == "" || strings.TrimSpace(req.Pattern) == "" {
+			return nil, errors.New("source_id, path, and pattern are required")
+		}
+		if req.Before < 0 || req.After < 0 {
+			return nil, errors.New("before and after cannot be negative")
+		}
+		result, err := kb.GrepResource(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("grep knowledge resource: %w", err)
+		}
+		return result, nil
+	}
+	return function.NewFunctionTool(
+		fn,
+		function.WithName("grep"),
+		function.WithDescription("Find a bounded literal or regular-expression match in a persisted text resource."),
+	)
+}

--- a/knowledge/tool/resourcetool_test.go
+++ b/knowledge/tool/resourcetool_test.go
@@ -1,0 +1,296 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/knowledge"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/resourcestore"
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/source"
+	ctool "trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+type stubResourceKnowledge struct {
+	listSourcesRequest   *knowledge.ListSourcesRequest
+	listResourcesRequest *knowledge.ListResourcesRequest
+	readResourceRequest  *knowledge.ReadResourceRequest
+	grepResourceRequest  *knowledge.GrepResourceRequest
+
+	listSourcesResult   *knowledge.ListSourcesResult
+	listResourcesResult *knowledge.ListResourcesResult
+	readResourceResult  *knowledge.ReadResourceResult
+	grepResourceResult  *knowledge.GrepResourceResult
+
+	listSourcesError   error
+	listResourcesError error
+	readResourceError  error
+	grepResourceError  error
+}
+
+var _ knowledge.ResourceKnowledge = (*stubResourceKnowledge)(nil)
+
+func (s *stubResourceKnowledge) ListSources(
+	_ context.Context,
+	req *knowledge.ListSourcesRequest,
+) (*knowledge.ListSourcesResult, error) {
+	s.listSourcesRequest = req
+	return s.listSourcesResult, s.listSourcesError
+}
+
+func (s *stubResourceKnowledge) ListResources(
+	_ context.Context,
+	req *knowledge.ListResourcesRequest,
+) (*knowledge.ListResourcesResult, error) {
+	s.listResourcesRequest = req
+	return s.listResourcesResult, s.listResourcesError
+}
+
+func (s *stubResourceKnowledge) ReadResource(
+	_ context.Context,
+	req *knowledge.ReadResourceRequest,
+) (*knowledge.ReadResourceResult, error) {
+	s.readResourceRequest = req
+	return s.readResourceResult, s.readResourceError
+}
+
+func (s *stubResourceKnowledge) GrepResource(
+	_ context.Context,
+	req *knowledge.GrepResourceRequest,
+) (*knowledge.GrepResourceResult, error) {
+	s.grepResourceRequest = req
+	return s.grepResourceResult, s.grepResourceError
+}
+
+func TestResourceToolSetDeclarations(t *testing.T) {
+	toolSet := NewResourceToolSet(&stubResourceKnowledge{})
+	require.Equal(t, defaultResourceToolSetName, toolSet.Name())
+	require.NoError(t, toolSet.Close())
+	tests := []struct {
+		name     string
+		required []string
+	}{
+		{name: "list_sources"},
+		{name: "list_resources", required: []string{"source_id"}},
+		{name: "read", required: []string{"source_id", "path"}},
+		{name: "grep", required: []string{"source_id", "path", "pattern"}},
+	}
+	tools := toolSet.Tools(context.Background())
+	require.Len(t, tools, len(tests))
+	for i, tt := range tests {
+		declaration := tools[i].Declaration()
+		require.Equal(t, tt.name, declaration.Name)
+		require.NotEmpty(t, declaration.Description)
+		require.NotNil(t, declaration.InputSchema)
+		require.Equal(t, "object", declaration.InputSchema.Type)
+		require.ElementsMatch(t, tt.required, declaration.InputSchema.Required)
+	}
+}
+
+func TestResourceToolsValidateRequiredArguments(t *testing.T) {
+	toolSet := NewResourceToolSet(&stubResourceKnowledge{})
+	tests := []struct {
+		name    string
+		args    string
+		wantErr string
+	}{
+		{name: "list_sources", args: "null", wantErr: "list sources request cannot be nil"},
+		{name: "list_resources", args: `{}`, wantErr: "source_id is required"},
+		{name: "read", args: `{"source_id":"source-1"}`, wantErr: "source_id and path are required"},
+		{name: "grep", args: `{"source_id":"source-1","path":"a.txt"}`, wantErr: "source_id, path, and pattern are required"},
+		{name: "grep", args: `{"source_id":"source-1","path":"a.txt","pattern":"key","before":-1}`, wantErr: "before and after cannot be negative"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name+"_"+tt.wantErr, func(t *testing.T) {
+			_, err := resourceToolByName(t, toolSet, tt.name).(ctool.CallableTool).Call(
+				context.Background(), []byte(tt.args),
+			)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestResourceToolsDispatch(t *testing.T) {
+	stub := &stubResourceKnowledge{
+		listSourcesResult: &knowledge.ListSourcesResult{Sources: []*knowledge.SourceInfo{{ID: "source-1"}}},
+		listResourcesResult: &knowledge.ListResourcesResult{
+			Resources: []*resourcestore.ResourceInfo{{SourceID: "source-1", Path: "docs"}},
+		},
+		readResourceResult: &knowledge.ReadResourceResult{SourceID: "source-1", Path: "docs/config.md"},
+		grepResourceResult: &knowledge.GrepResourceResult{SourceID: "source-1", Path: "docs/config.md"},
+	}
+	toolSet := NewResourceToolSet(stub)
+
+	listSourcesRequest := &knowledge.ListSourcesRequest{}
+	require.Same(t, stub.listSourcesResult, callResourceTool(t, toolSet, "list_sources", listSourcesRequest))
+	require.Equal(t, listSourcesRequest, stub.listSourcesRequest)
+
+	listResourcesRequest := &knowledge.ListResourcesRequest{
+		SourceID:   "source-1",
+		ParentPath: "docs",
+	}
+	require.Same(t, stub.listResourcesResult, callResourceTool(t, toolSet, "list_resources", listResourcesRequest))
+	require.Equal(t, listResourcesRequest, stub.listResourcesRequest)
+
+	readResourceRequest := &knowledge.ReadResourceRequest{
+		SourceID:  "source-1",
+		Path:      "docs/config.md",
+		StartLine: 11,
+		EndLine:   20,
+	}
+	require.Same(t, stub.readResourceResult, callResourceTool(t, toolSet, "read", readResourceRequest))
+	require.Equal(t, readResourceRequest, stub.readResourceRequest)
+
+	grepResourceRequest := &knowledge.GrepResourceRequest{
+		SourceID:   "source-1",
+		Path:       "docs/config.md",
+		Pattern:    "timeout",
+		Regex:      true,
+		Before:     2,
+		After:      3,
+		MaxMatches: 4,
+	}
+	require.Same(t, stub.grepResourceResult, callResourceTool(t, toolSet, "grep", grepResourceRequest))
+	require.Equal(t, grepResourceRequest, stub.grepResourceRequest)
+}
+
+func TestResourceToolsWrapKnowledgeErrors(t *testing.T) {
+	backendError := errors.New("backend unavailable")
+	stub := &stubResourceKnowledge{
+		listSourcesError:   backendError,
+		listResourcesError: backendError,
+		readResourceError:  backendError,
+		grepResourceError:  backendError,
+	}
+	toolSet := NewResourceToolSet(stub)
+	tests := []struct {
+		name       string
+		args       any
+		wantPrefix string
+	}{
+		{name: "list_sources", args: &knowledge.ListSourcesRequest{}, wantPrefix: "list knowledge sources"},
+		{name: "list_resources", args: &knowledge.ListResourcesRequest{SourceID: "source-1"}, wantPrefix: "list knowledge resources"},
+		{name: "read", args: &knowledge.ReadResourceRequest{SourceID: "source-1", Path: "a.txt"}, wantPrefix: "read knowledge resource"},
+		{name: "grep", args: &knowledge.GrepResourceRequest{SourceID: "source-1", Path: "a.txt", Pattern: "key"}, wantPrefix: "grep knowledge resource"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := callResourceToolWithError(t, toolSet, tt.name, tt.args)
+			require.ErrorIs(t, err, backendError)
+			require.ErrorContains(t, err, tt.wantPrefix)
+		})
+	}
+}
+
+func TestConvertSearchResultsProjectsResourceStoreReference(t *testing.T) {
+	const providerURI = "hdfs://private-cluster/secret/config.md"
+	result := &knowledge.SearchResult{Documents: []*knowledge.Result{{
+		Document: &document.Document{
+			ID:      "chunk-1",
+			Content: "resource metadata",
+			Metadata: map[string]any{
+				"owner":                      "platform",
+				source.MetaSourceID:          "source-1",
+				source.MetaResourcePath:      "guides/config.md",
+				source.MetaResourceStartLine: 21,
+				source.MetaResourceEndLine:   40,
+				source.MetaURI:               providerURI,
+			},
+		},
+		Score: 0.91,
+	}}}
+
+	response, err := convertSearchResults(result, nil, true)
+	require.NoError(t, err)
+	require.Len(t, response.Documents, 1)
+	require.Equal(t, map[string]any{
+		"owner":                      "platform",
+		source.MetaSourceID:          "source-1",
+		source.MetaResourcePath:      "guides/config.md",
+		source.MetaResourceStartLine: 21,
+		source.MetaResourceEndLine:   40,
+	}, response.Documents[0].Metadata)
+	encoded, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), source.MetaURI)
+	require.NotContains(t, string(encoded), providerURI)
+}
+
+func TestConvertSearchResultsRejectsUnsafeResourceMetadata(t *testing.T) {
+	const providerURI = "hdfs://private-cluster/secret/config.md"
+	result := &knowledge.SearchResult{Documents: []*knowledge.Result{{
+		Document: &document.Document{
+			ID: "chunk-1",
+			Metadata: map[string]any{
+				"owner":                 "platform",
+				source.MetaSourceID:     "source-1",
+				source.MetaResourcePath: "./" + providerURI,
+				source.MetaURI:          providerURI,
+			},
+		},
+	}}}
+
+	response, err := convertSearchResults(result, nil, true)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"owner": "platform"}, response.Documents[0].Metadata)
+	encoded, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), providerURI)
+}
+
+func TestConvertSearchResultsDropsInvalidResourceLineRange(t *testing.T) {
+	result := &knowledge.SearchResult{Documents: []*knowledge.Result{{
+		Document: &document.Document{Metadata: map[string]any{
+			source.MetaSourceID:          "source-1",
+			source.MetaResourcePath:      "guides/config.md",
+			source.MetaResourceStartLine: 40,
+			source.MetaResourceEndLine:   21,
+		}},
+	}}}
+
+	response, err := convertSearchResults(result, nil, true)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		source.MetaSourceID:     "source-1",
+		source.MetaResourcePath: "guides/config.md",
+	}, response.Documents[0].Metadata)
+}
+
+func resourceToolByName(t *testing.T, toolSet ctool.ToolSet, name string) ctool.Tool {
+	t.Helper()
+	for _, resourceTool := range toolSet.Tools(context.Background()) {
+		if resourceTool.Declaration().Name == name {
+			return resourceTool
+		}
+	}
+	require.FailNow(t, "resource tool not found", "name=%q", name)
+	return nil
+}
+
+func callResourceTool(t *testing.T, toolSet ctool.ToolSet, name string, args any) any {
+	t.Helper()
+	result, err := callResourceToolWithError(t, toolSet, name, args)
+	require.NoError(t, err)
+	return result
+}
+
+func callResourceToolWithError(t *testing.T, toolSet ctool.ToolSet, name string, args any) (any, error) {
+	t.Helper()
+	payload, err := json.Marshal(args)
+	require.NoError(t, err)
+	callable, ok := resourceToolByName(t, toolSet, name).(ctool.CallableTool)
+	require.True(t, ok)
+	return callable.Call(context.Background(), payload)
+}

--- a/knowledge/tool/searchtool.go
+++ b/knowledge/tool/searchtool.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+	"strconv"
 	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
@@ -591,7 +593,95 @@ func filterMetadata(metadata map[string]any, excludeKeys map[string]struct{}) ma
 			filtered[k] = v
 		}
 	}
+	copyResourceMetadata(filtered, metadata, excludeKeys)
 	return filtered
+}
+
+// copyResourceMetadata exposes only the source-relative fields an agent needs
+// for a follow-up read or grep. Other internal metadata remains hidden.
+func copyResourceMetadata(target, metadata map[string]any, excludeKeys map[string]struct{}) {
+	if _, excluded := excludeKeys[source.MetaSourceID]; excluded {
+		return
+	}
+	if _, excluded := excludeKeys[source.MetaResourcePath]; excluded {
+		return
+	}
+	sourceID, ok := metadata[source.MetaSourceID].(string)
+	if !ok || strings.TrimSpace(sourceID) == "" {
+		return
+	}
+	resourcePath, ok := metadata[source.MetaResourcePath].(string)
+	if !ok {
+		return
+	}
+	resourcePath, ok = cleanResourceMetadataPath(resourcePath)
+	if !ok {
+		return
+	}
+	target[source.MetaSourceID] = strings.TrimSpace(sourceID)
+	target[source.MetaResourcePath] = resourcePath
+	startLine, startOK := positiveResourceMetadataInt(metadata[source.MetaResourceStartLine])
+	endLine, endOK := positiveResourceMetadataInt(metadata[source.MetaResourceEndLine])
+	if startOK && endOK && endLine < startLine {
+		return
+	}
+	if _, excluded := excludeKeys[source.MetaResourceStartLine]; startOK && !excluded {
+		target[source.MetaResourceStartLine] = startLine
+	}
+	if _, excluded := excludeKeys[source.MetaResourceEndLine]; endOK && !excluded {
+		target[source.MetaResourceEndLine] = endLine
+	}
+}
+
+func positiveResourceMetadataInt(value any) (int, bool) {
+	converted, err := strconv.Atoi(fmt.Sprint(value))
+	return converted, err == nil && converted > 0
+}
+
+func cleanResourceMetadataPath(value string) (string, bool) {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\\", "/")
+	if value == "" || strings.HasPrefix(value, "/") || strings.ContainsRune(value, '\x00') {
+		return "", false
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == ".." {
+			return "", false
+		}
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") ||
+		strings.HasPrefix(cleaned, "/") || isResourceMetadataWindowsPath(cleaned) ||
+		hasResourceMetadataScheme(cleaned) {
+		return "", false
+	}
+	return cleaned, true
+}
+
+func isResourceMetadataWindowsPath(value string) bool {
+	if len(value) < 3 || value[1] != ':' || value[2] != '/' {
+		return false
+	}
+	return (value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')
+}
+
+func hasResourceMetadataScheme(value string) bool {
+	colon := strings.IndexByte(value, ':')
+	if colon <= 0 {
+		return false
+	}
+	if slash := strings.IndexByte(value, '/'); slash >= 0 && slash < colon {
+		return false
+	}
+	for index := 0; index < colon; index++ {
+		character := value[index]
+		if (character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(index > 0 && ((character >= '0' && character <= '9') || character == '+' || character == '-' || character == '.')) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func generateAgenticFilterPrompt(agenticFilterInfo map[string][]any) string {


### PR DESCRIPTION
## Summary

- add typed `Stores` / `WithStores` configuration for vector, graph, and resource backends
- introduce `resourcestore.Store` plus Agent-facing APIs for listing sources, browsing directory trees, reading line ranges, and grepping persisted text
- add the optional `source.ResourceSource` capability and implement it for file, directory, URL, auto, and repository sources
- persist normalized source text before indexing its derived documents, then attach `source_id`, resource path, and best-effort line ranges to vector document metadata
- keep resource state aligned across load, add, reload, recreate, and remove operations, including stale-resource cleanup after successful vector writes
- support graph-native seed search through an optional `graphstore.Searcher` capability and close all configured stores once

## Notes

- existing `WithVectorStore` behavior remains supported
- resource-only and graph-only Knowledge instances remain valid; document Search returns `vector store not configured` when no vector backend exists
- resource identity is `source_id` plus a canonical source-relative path
- the initial resource representation is normalized UTF-8 text; directory entries are derived from persisted file paths, so empty directories are not represented
- ResourceStore and VectorStore do not share an atomic transaction; write and delete methods are required to be idempotent so interrupted imports can be retried safely

## Testing

- `go test ./knowledge/... -count=1`
- `go test -race ./knowledge ./knowledge/source/file ./knowledge/source/dir ./knowledge/source/url ./knowledge/source/auto ./knowledge/source/repo -count=1`
- `go vet ./knowledge/...`
- `typos`
- `git diff --check`
