### PR TITLE
{codeexecutor, internal/workspaceprep, tool/workspaceexec}: scope prepared state per generation

### DIFF
--- a/codeexecutor/metadata.go
+++ b/codeexecutor/metadata.go
@@ -275,13 +275,6 @@ type WorkspaceMetadata struct {
 	// still present. The map is a local per-workspace cache; session
 	// state remains the authoritative source of "what should exist".
 	Prepared map[string]PreparedRecord `json:"prepared,omitempty"`
-	// InstanceID records the physical execution-environment generation
-	// for which Prepared was last converged. It mirrors
-	// [WorkspaceHandle.InstanceID] at reconcile time. When a
-	// [WorkspaceInstanceProvider] reports a different non-empty ID,
-	// workspaceprep clears Prepared before reconciling bootstrap work.
-	// Empty means legacy managers that do not expose instance identity.
-	InstanceID WorkspaceInstanceID `json:"instance_id,omitempty"`
 }
 
 // PreparedRecord captures a single successfully-applied workspace
@@ -293,6 +286,11 @@ type PreparedRecord struct {
 	Fingerprint string    `json:"fingerprint"`
 	Target      string    `json:"target,omitempty"`
 	PreparedAt  time.Time `json:"prepared_at"`
+	// Generation is an opaque, framework-owned identifier for the
+	// process-scoped physical workspace generation in which this record
+	// was prepared. Empty preserves the legacy behavior of managers
+	// without instance identity. Callers should not assign or reuse it.
+	Generation string `json:"generation,omitempty"`
 }
 
 // SkillMeta records a staged skill snapshot.

--- a/codeexecutor/metadata.go
+++ b/codeexecutor/metadata.go
@@ -275,12 +275,13 @@ type WorkspaceMetadata struct {
 	// still present. The map is a local per-workspace cache; session
 	// state remains the authoritative source of "what should exist".
 	Prepared map[string]PreparedRecord `json:"prepared,omitempty"`
-	// BackendInstanceID records the physical execution-environment
-	// generation for which Prepared was last converged. When a
+	// InstanceID records the physical execution-environment generation
+	// for which Prepared was last converged. It mirrors
+	// [WorkspaceHandle.InstanceID] at reconcile time. When a
 	// [WorkspaceInstanceProvider] reports a different non-empty ID,
 	// workspaceprep clears Prepared before reconciling bootstrap work.
 	// Empty means legacy managers that do not expose instance identity.
-	BackendInstanceID WorkspaceInstanceID `json:"backend_instance_id,omitempty"`
+	InstanceID WorkspaceInstanceID `json:"instance_id,omitempty"`
 }
 
 // PreparedRecord captures a single successfully-applied workspace

--- a/codeexecutor/metadata.go
+++ b/codeexecutor/metadata.go
@@ -284,8 +284,9 @@ type WorkspaceMetadata struct {
 }
 
 // InvalidatePreparedForInstance clears Prepared when instanceID differs
-// from the metadata's recorded backend generation. Legacy callers pass
-// an empty instanceID, which preserves existing Prepared semantics.
+// from the metadata's recorded backend generation. An empty instanceID
+// preserves existing Prepared semantics for legacy managers. An empty
+// recorded BackendInstanceID is treated as an unknown generation.
 func InvalidatePreparedForInstance(
 	md *WorkspaceMetadata,
 	instanceID WorkspaceInstanceID,
@@ -293,9 +294,13 @@ func InvalidatePreparedForInstance(
 	if md == nil || instanceID == "" {
 		return
 	}
-	if md.BackendInstanceID != "" && md.BackendInstanceID != instanceID {
-		md.Prepared = map[string]PreparedRecord{}
+	if md.BackendInstanceID == instanceID {
+		return
 	}
+	if len(md.Prepared) == 0 {
+		return
+	}
+	md.Prepared = map[string]PreparedRecord{}
 }
 
 // PreparedRecord captures a single successfully-applied workspace

--- a/codeexecutor/metadata.go
+++ b/codeexecutor/metadata.go
@@ -275,6 +275,27 @@ type WorkspaceMetadata struct {
 	// still present. The map is a local per-workspace cache; session
 	// state remains the authoritative source of "what should exist".
 	Prepared map[string]PreparedRecord `json:"prepared,omitempty"`
+	// BackendInstanceID records the physical execution-environment
+	// generation for which Prepared was last converged. When a
+	// [WorkspaceInstanceProvider] reports a different non-empty ID,
+	// workspaceprep clears Prepared before reconciling bootstrap work.
+	// Empty means legacy managers that do not expose instance identity.
+	BackendInstanceID WorkspaceInstanceID `json:"backend_instance_id,omitempty"`
+}
+
+// InvalidatePreparedForInstance clears Prepared when instanceID differs
+// from the metadata's recorded backend generation. Legacy callers pass
+// an empty instanceID, which preserves existing Prepared semantics.
+func InvalidatePreparedForInstance(
+	md *WorkspaceMetadata,
+	instanceID WorkspaceInstanceID,
+) {
+	if md == nil || instanceID == "" {
+		return
+	}
+	if md.BackendInstanceID != "" && md.BackendInstanceID != instanceID {
+		md.Prepared = map[string]PreparedRecord{}
+	}
 }
 
 // PreparedRecord captures a single successfully-applied workspace

--- a/codeexecutor/metadata.go
+++ b/codeexecutor/metadata.go
@@ -283,26 +283,6 @@ type WorkspaceMetadata struct {
 	BackendInstanceID WorkspaceInstanceID `json:"backend_instance_id,omitempty"`
 }
 
-// InvalidatePreparedForInstance clears Prepared when instanceID differs
-// from the metadata's recorded backend generation. An empty instanceID
-// preserves existing Prepared semantics for legacy managers. An empty
-// recorded BackendInstanceID is treated as an unknown generation.
-func InvalidatePreparedForInstance(
-	md *WorkspaceMetadata,
-	instanceID WorkspaceInstanceID,
-) {
-	if md == nil || instanceID == "" {
-		return
-	}
-	if md.BackendInstanceID == instanceID {
-		return
-	}
-	if len(md.Prepared) == 0 {
-		return
-	}
-	md.Prepared = map[string]PreparedRecord{}
-}
-
 // PreparedRecord captures a single successfully-applied workspace
 // requirement. It is written by the reconciler after a successful
 // apply and read on subsequent reconciles to decide whether to skip.

--- a/codeexecutor/metadata_test.go
+++ b/codeexecutor/metadata_test.go
@@ -340,32 +340,3 @@ func TestWithWorkspaceMetadataLock_CanceledContext(t *testing.T) {
 
 	require.ErrorIs(t, err, context.Canceled)
 }
-
-func TestInvalidatePreparedForInstance(t *testing.T) {
-	md := WorkspaceMetadata{
-		BackendInstanceID: "instance-1",
-		Prepared: map[string]PreparedRecord{
-			"bootstrap": {Key: "bootstrap"},
-		},
-	}
-	require.False(t, func() bool {
-		before := len(md.Prepared)
-		InvalidatePreparedForInstance(&md, "")
-		return before != len(md.Prepared)
-	}())
-	require.Len(t, md.Prepared, 1)
-
-	InvalidatePreparedForInstance(&md, "instance-1")
-	require.Len(t, md.Prepared, 1)
-
-	InvalidatePreparedForInstance(&md, "instance-2")
-	require.Empty(t, md.Prepared)
-
-	md = WorkspaceMetadata{
-		Prepared: map[string]PreparedRecord{
-			"bootstrap": {Key: "bootstrap"},
-		},
-	}
-	InvalidatePreparedForInstance(&md, "instance-1")
-	require.Empty(t, md.Prepared)
-}

--- a/codeexecutor/metadata_test.go
+++ b/codeexecutor/metadata_test.go
@@ -46,11 +46,28 @@ func TestEnsureLayout_LoadSaveMetadata(t *testing.T) {
 		Mode:      "copy",
 		Timestamp: time.Now(),
 	})
+	md.Prepared = map[string]PreparedRecord{
+		"bootstrap": {
+			Key:         "bootstrap",
+			Fingerprint: "v1",
+			Generation:  "process-and-instance-generation",
+		},
+	}
 	require.NoError(t, SaveMetadata(root, md))
 	md2, err := LoadMetadata(root)
 	require.NoError(t, err)
 	require.Equal(t, md.Version, md2.Version)
 	require.Equal(t, len(md.Inputs), len(md2.Inputs))
+	require.Equal(t, "process-and-instance-generation",
+		md2.Prepared["bootstrap"].Generation)
+}
+
+func TestPreparedRecord_LegacyJSONHasEmptyGeneration(t *testing.T) {
+	var record PreparedRecord
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"key":"bootstrap","fingerprint":"v1"}`,
+	), &record))
+	require.Empty(t, record.Generation)
 }
 
 func TestLoadMetadata_MissingFileReturnsDefault(t *testing.T) {

--- a/codeexecutor/metadata_test.go
+++ b/codeexecutor/metadata_test.go
@@ -340,3 +340,20 @@ func TestWithWorkspaceMetadataLock_CanceledContext(t *testing.T) {
 
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestInvalidatePreparedForInstance(t *testing.T) {
+	md := WorkspaceMetadata{
+		BackendInstanceID: "instance-1",
+		Prepared: map[string]PreparedRecord{
+			"bootstrap": {Key: "bootstrap"},
+		},
+	}
+	InvalidatePreparedForInstance(&md, "")
+	require.Len(t, md.Prepared, 1)
+
+	InvalidatePreparedForInstance(&md, "instance-1")
+	require.Len(t, md.Prepared, 1)
+
+	InvalidatePreparedForInstance(&md, "instance-2")
+	require.Empty(t, md.Prepared)
+}

--- a/codeexecutor/metadata_test.go
+++ b/codeexecutor/metadata_test.go
@@ -348,12 +348,24 @@ func TestInvalidatePreparedForInstance(t *testing.T) {
 			"bootstrap": {Key: "bootstrap"},
 		},
 	}
-	InvalidatePreparedForInstance(&md, "")
+	require.False(t, func() bool {
+		before := len(md.Prepared)
+		InvalidatePreparedForInstance(&md, "")
+		return before != len(md.Prepared)
+	}())
 	require.Len(t, md.Prepared, 1)
 
 	InvalidatePreparedForInstance(&md, "instance-1")
 	require.Len(t, md.Prepared, 1)
 
 	InvalidatePreparedForInstance(&md, "instance-2")
+	require.Empty(t, md.Prepared)
+
+	md = WorkspaceMetadata{
+		Prepared: map[string]PreparedRecord{
+			"bootstrap": {Key: "bootstrap"},
+		},
+	}
+	InvalidatePreparedForInstance(&md, "instance-1")
 	require.Empty(t, md.Prepared)
 }

--- a/codeexecutor/workspace_bootstrap.go
+++ b/codeexecutor/workspace_bootstrap.go
@@ -28,7 +28,12 @@ import "time"
 // (also in declaration order). The reconciler fingerprints each entry and
 // skips work whose fingerprint plus on-disk sentinel are still satisfied. This
 // provides eventual convergence, not exactly-once execution: callers remain
-// responsible for making initialization commands replay-safe.
+// responsible for making initialization commands replay-safe. For an
+// instance-aware workspace manager, each prepared record is scoped to both the
+// physical instance and the current process. A backend rotation or process
+// restart therefore makes that requirement eligible to run again on its next
+// reconciliation. Legacy managers without instance identity retain the prior
+// persisted-cache behavior.
 type WorkspaceBootstrapSpec struct {
 	// Files are static inputs that must exist before commands run.
 	// Each entry maps a workspace-relative Target to either inline

--- a/internal/workspaceprep/providers_test.go
+++ b/internal/workspaceprep/providers_test.go
@@ -48,7 +48,7 @@ func TestBootstrapProvider_FilesAndCommands(t *testing.T) {
 	require.Len(t, reqs, 2)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, "", reqs)
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", reqs)
 	require.NoError(t, err)
 
 	seed, err := os.ReadFile(filepath.Join(ws.Path, "work/seed.txt"))

--- a/internal/workspaceprep/providers_test.go
+++ b/internal/workspaceprep/providers_test.go
@@ -48,7 +48,7 @@ func TestBootstrapProvider_FilesAndCommands(t *testing.T) {
 	require.Len(t, reqs, 2)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, reqs)
+	_, err = rec.Reconcile(ctx, eng, ws, "", reqs)
 	require.NoError(t, err)
 
 	seed, err := os.ReadFile(filepath.Join(ws.Path, "work/seed.txt"))

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -74,16 +74,16 @@ func (r *defaultReconciler) Reconcile(
 	ws codeexecutor.Workspace,
 	instanceID codeexecutor.WorkspaceInstanceID,
 	reqs []Requirement,
-) ([]string, error) {
+) ([]string, bool, error) {
 	if len(reqs) == 0 {
-		return nil, nil
+		return nil, false, nil
 	}
 	if eng == nil {
-		return nil, fmt.Errorf("workspaceprep: engine is required")
+		return nil, false, fmt.Errorf("workspaceprep: engine is required")
 	}
 	generation, err := r.preparationGeneration(instanceID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	reqs = dedupeRequirements(reqs)
@@ -94,7 +94,7 @@ func (r *defaultReconciler) Reconcile(
 
 	md, err := r.stager.LoadWorkspaceMetadata(ctx, eng, ws)
 	if err != nil {
-		return nil, fmt.Errorf("workspaceprep: load metadata: %w", err)
+		return nil, false, fmt.Errorf("workspaceprep: load metadata: %w", err)
 	}
 	if md.Prepared == nil {
 		md.Prepared = map[string]codeexecutor.PreparedRecord{}
@@ -114,7 +114,7 @@ func (r *defaultReconciler) Reconcile(
 		ctx, eng, ws, baseMD, rctx, generation, reqs,
 	)
 	if err != nil {
-		return run.warnings, err
+		return run.warnings, run.commandMayHaveStarted, err
 	}
 	if run.changed {
 		if err := r.saveReconcileMetadata(
@@ -124,14 +124,14 @@ func (r *defaultReconciler) Reconcile(
 				err,
 				run.commandMayHaveStarted,
 			); staleErr != nil {
-				return run.warnings, staleErr
+				return run.warnings, run.commandMayHaveStarted, staleErr
 			}
 			run.warnings = append(run.warnings, fmt.Sprintf(
 				"save metadata: %v", err,
 			))
 		}
 	}
-	return run.warnings, nil
+	return run.warnings, run.commandMayHaveStarted, nil
 }
 
 type reconcileRunResult struct {

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -83,6 +83,9 @@ func (r *defaultReconciler) Reconcile(
 	loadedBackendInstanceID := md.BackendInstanceID
 	invalidatePreparedForInstance(&md, instanceID)
 	baseMD := cloneReconcileMetadata(md)
+	if instanceID != "" {
+		md.BackendInstanceID = instanceID
+	}
 
 	rctx := ApplyContext{
 		Engine:    eng,
@@ -151,9 +154,6 @@ func (r *defaultReconciler) Reconcile(
 	}
 	instanceBackendChanged := instanceID != "" &&
 		instanceID != loadedBackendInstanceID
-	if instanceID != "" {
-		md.BackendInstanceID = instanceID
-	}
 	if changed || instanceBackendChanged {
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, changedKeys,

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -80,6 +80,7 @@ func (r *defaultReconciler) Reconcile(
 	if md.Prepared == nil {
 		md.Prepared = map[string]codeexecutor.PreparedRecord{}
 	}
+	loadedBackendInstanceID := md.BackendInstanceID
 	codeexecutor.InvalidatePreparedForInstance(&md, instanceID)
 	baseMD := cloneReconcileMetadata(md)
 
@@ -148,10 +149,12 @@ func (r *defaultReconciler) Reconcile(
 			changedKeys = append(changedKeys, req.Key())
 		}
 	}
-	if changed {
-		if instanceID != "" {
-			md.BackendInstanceID = instanceID
-		}
+	instanceBackendChanged := instanceID != "" &&
+		instanceID != loadedBackendInstanceID
+	if instanceID != "" {
+		md.BackendInstanceID = instanceID
+	}
+	if changed || instanceBackendChanged {
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, changedKeys,
 		); err != nil {
@@ -218,6 +221,18 @@ func mergeReconcileMetadata(
 ) codeexecutor.WorkspaceMetadata {
 	merged := latest
 	mergeDirectMetadataChanges(&merged, base, updated)
+	if updated.BackendInstanceID != "" &&
+		updated.BackendInstanceID != latest.BackendInstanceID {
+		prepared := make(
+			map[string]codeexecutor.PreparedRecord,
+			len(updated.Prepared),
+		)
+		for key, rec := range updated.Prepared {
+			prepared[key] = rec
+		}
+		merged.Prepared = prepared
+		return merged
+	}
 	prepared := make(
 		map[string]codeexecutor.PreparedRecord,
 		len(merged.Prepared)+len(changedKeys),

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -262,7 +262,19 @@ func mergeReconcileMetadata(
 ) codeexecutor.WorkspaceMetadata {
 	merged := latest
 	mergeDirectMetadataChanges(&merged, base, updated)
+
+	rotationInWriter := updated.InstanceID != "" &&
+		updated.InstanceID != base.InstanceID
 	if updated.InstanceID != "" &&
+		latest.InstanceID != "" &&
+		updated.InstanceID != latest.InstanceID &&
+		!rotationInWriter {
+		// A newer generation already persisted; ignore this writer's
+		// Prepared overlay so stale records cannot replace the latest
+		// map while mergeDirectMetadataChanges keeps latest.InstanceID.
+		return merged
+	}
+	if rotationInWriter &&
 		updated.InstanceID != latest.InstanceID {
 		prepared := make(
 			map[string]codeexecutor.PreparedRecord,

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -96,80 +96,101 @@ func (r *defaultReconciler) Reconcile(
 		rctx.Invocation = inv
 	}
 
-	var warnings []string
-	changed := false
-	commandMayHaveStarted := false
-	var changedKeys []string
+	run, err := r.runReconcileRequirements(
+		ctx, eng, ws, baseMD, rctx, reqs,
+	)
+	if err != nil {
+		return run.warnings, err
+	}
+	instanceBackendChanged := instanceID != "" &&
+		instanceID != loadedBackendInstanceID
+	if run.changed || instanceBackendChanged {
+		if err := r.saveReconcileMetadata(
+			ctx, eng, ws, baseMD, md, run.changedKeys,
+		); err != nil {
+			if staleErr := staleRetryError(
+				err,
+				run.commandMayHaveStarted,
+			); staleErr != nil {
+				return run.warnings, staleErr
+			}
+			run.warnings = append(run.warnings, fmt.Sprintf(
+				"save metadata: %v", err,
+			))
+		}
+	}
+	return run.warnings, nil
+}
+
+type reconcileRunResult struct {
+	warnings              []string
+	changed               bool
+	changedKeys           []string
+	commandMayHaveStarted bool
+}
+
+func (r *defaultReconciler) runReconcileRequirements(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	ws codeexecutor.Workspace,
+	baseMD codeexecutor.WorkspaceMetadata,
+	rctx ApplyContext,
+	reqs []Requirement,
+) (reconcileRunResult, error) {
+	var run reconcileRunResult
 	for _, req := range reqs {
 		applied, applyAttempted, warn, err := r.runOne(ctx, rctx, req)
 		if warn != "" {
-			warnings = append(warnings, warn)
+			run.warnings = append(run.warnings, warn)
 		}
 		if staleErr := staleRetryError(
 			err,
-			commandMayHaveStarted,
+			run.commandMayHaveStarted,
 		); staleErr != nil {
-			return warnings, staleErr
+			return run, staleErr
 		}
 		if applyAttempted && req.Kind() == KindCommand {
 			// A non-stale command result does not prove that the command
 			// avoided side effects. This includes optional timeouts,
 			// non-zero exits, and failures after successful execution.
-			commandMayHaveStarted = true
+			run.commandMayHaveStarted = true
 		}
 		if err != nil {
 			if !req.Required() {
-				warnings = append(warnings, fmt.Sprintf(
+				run.warnings = append(run.warnings, fmt.Sprintf(
 					"optional requirement %q failed: %v",
 					req.Key(), err,
 				))
 				continue
 			}
-			if changed {
+			if run.changed {
 				if saveErr := r.saveReconcileMetadata(
-					ctx, eng, ws, baseMD, md, changedKeys,
+					ctx, eng, ws, baseMD, *rctx.Metadata, run.changedKeys,
 				); saveErr != nil {
 					if staleErr := staleRetryError(
 						saveErr,
-						commandMayHaveStarted,
+						run.commandMayHaveStarted,
 					); staleErr != nil {
-						return warnings, staleErr
+						return run, staleErr
 					}
-					return warnings, fmt.Errorf(
+					return run, fmt.Errorf(
 						"workspaceprep: save metadata after "+
 							"partial apply: %w",
 						saveErr,
 					)
 				}
 			}
-			return warnings, fmt.Errorf(
+			return run, fmt.Errorf(
 				"workspaceprep: required requirement %q failed: %w",
 				req.Key(), err,
 			)
 		}
 		if applied {
-			changed = true
-			changedKeys = append(changedKeys, req.Key())
+			run.changed = true
+			run.changedKeys = append(run.changedKeys, req.Key())
 		}
 	}
-	instanceBackendChanged := instanceID != "" &&
-		instanceID != loadedBackendInstanceID
-	if changed || instanceBackendChanged {
-		if err := r.saveReconcileMetadata(
-			ctx, eng, ws, baseMD, md, changedKeys,
-		); err != nil {
-			if staleErr := staleRetryError(
-				err,
-				commandMayHaveStarted,
-			); staleErr != nil {
-				return warnings, staleErr
-			}
-			warnings = append(warnings, fmt.Sprintf(
-				"save metadata: %v", err,
-			))
-		}
-	}
-	return warnings, nil
+	return run, nil
 }
 
 // invalidatePreparedForInstance clears Prepared when instanceID differs

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -81,7 +81,7 @@ func (r *defaultReconciler) Reconcile(
 		md.Prepared = map[string]codeexecutor.PreparedRecord{}
 	}
 	loadedBackendInstanceID := md.BackendInstanceID
-	codeexecutor.InvalidatePreparedForInstance(&md, instanceID)
+	invalidatePreparedForInstance(&md, instanceID)
 	baseMD := cloneReconcileMetadata(md)
 
 	rctx := ApplyContext{
@@ -170,6 +170,26 @@ func (r *defaultReconciler) Reconcile(
 		}
 	}
 	return warnings, nil
+}
+
+// invalidatePreparedForInstance clears Prepared when instanceID differs
+// from the metadata's recorded backend generation. An empty instanceID
+// preserves existing Prepared semantics for legacy managers. An empty
+// recorded BackendInstanceID is treated as an unknown generation.
+func invalidatePreparedForInstance(
+	md *codeexecutor.WorkspaceMetadata,
+	instanceID codeexecutor.WorkspaceInstanceID,
+) {
+	if md == nil || instanceID == "" {
+		return
+	}
+	if md.BackendInstanceID == instanceID {
+		return
+	}
+	if len(md.Prepared) == 0 {
+		return
+	}
+	md.Prepared = map[string]codeexecutor.PreparedRecord{}
 }
 
 func staleRetryError(err error, unsafe bool) error {

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -80,11 +80,11 @@ func (r *defaultReconciler) Reconcile(
 	if md.Prepared == nil {
 		md.Prepared = map[string]codeexecutor.PreparedRecord{}
 	}
-	loadedBackendInstanceID := md.BackendInstanceID
+	loadedInstanceID := md.InstanceID
 	invalidatePreparedForInstance(&md, instanceID)
 	baseMD := cloneReconcileMetadata(md)
 	if instanceID != "" {
-		md.BackendInstanceID = instanceID
+		md.InstanceID = instanceID
 	}
 
 	rctx := ApplyContext{
@@ -102,9 +102,9 @@ func (r *defaultReconciler) Reconcile(
 	if err != nil {
 		return run.warnings, err
 	}
-	instanceBackendChanged := instanceID != "" &&
-		instanceID != loadedBackendInstanceID
-	if run.changed || instanceBackendChanged {
+	instanceIDChanged := instanceID != "" &&
+		instanceID != loadedInstanceID
+	if run.changed || instanceIDChanged {
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, run.changedKeys,
 		); err != nil {
@@ -196,7 +196,7 @@ func (r *defaultReconciler) runReconcileRequirements(
 // invalidatePreparedForInstance clears Prepared when instanceID differs
 // from the metadata's recorded backend generation. An empty instanceID
 // preserves existing Prepared semantics for legacy managers. An empty
-// recorded BackendInstanceID is treated as an unknown generation.
+// recorded InstanceID is treated as an unknown generation.
 func invalidatePreparedForInstance(
 	md *codeexecutor.WorkspaceMetadata,
 	instanceID codeexecutor.WorkspaceInstanceID,
@@ -204,7 +204,7 @@ func invalidatePreparedForInstance(
 	if md == nil || instanceID == "" {
 		return
 	}
-	if md.BackendInstanceID == instanceID {
+	if md.InstanceID == instanceID {
 		return
 	}
 	if len(md.Prepared) == 0 {
@@ -262,8 +262,8 @@ func mergeReconcileMetadata(
 ) codeexecutor.WorkspaceMetadata {
 	merged := latest
 	mergeDirectMetadataChanges(&merged, base, updated)
-	if updated.BackendInstanceID != "" &&
-		updated.BackendInstanceID != latest.BackendInstanceID {
+	if updated.InstanceID != "" &&
+		updated.InstanceID != latest.InstanceID {
 		prepared := make(
 			map[string]codeexecutor.PreparedRecord,
 			len(updated.Prepared),
@@ -317,8 +317,8 @@ func mergeDirectMetadataChanges(
 	if !reflect.DeepEqual(updated.Outputs, base.Outputs) {
 		merged.Outputs = updated.Outputs
 	}
-	if updated.BackendInstanceID != base.BackendInstanceID {
-		merged.BackendInstanceID = updated.BackendInstanceID
+	if updated.InstanceID != base.InstanceID {
+		merged.InstanceID = updated.InstanceID
 	}
 }
 

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -57,6 +57,7 @@ func (r *defaultReconciler) Reconcile(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
+	instanceID codeexecutor.WorkspaceInstanceID,
 	reqs []Requirement,
 ) ([]string, error) {
 	if len(reqs) == 0 {
@@ -79,6 +80,7 @@ func (r *defaultReconciler) Reconcile(
 	if md.Prepared == nil {
 		md.Prepared = map[string]codeexecutor.PreparedRecord{}
 	}
+	codeexecutor.InvalidatePreparedForInstance(&md, instanceID)
 	baseMD := cloneReconcileMetadata(md)
 
 	rctx := ApplyContext{
@@ -147,6 +149,9 @@ func (r *defaultReconciler) Reconcile(
 		}
 	}
 	if changed {
+		if instanceID != "" {
+			md.BackendInstanceID = instanceID
+		}
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, changedKeys,
 		); err != nil {
@@ -255,6 +260,9 @@ func mergeDirectMetadataChanges(
 	}
 	if !reflect.DeepEqual(updated.Outputs, base.Outputs) {
 		merged.Outputs = updated.Outputs
+	}
+	if updated.BackendInstanceID != base.BackendInstanceID {
+		merged.BackendInstanceID = updated.BackendInstanceID
 	}
 }
 

--- a/internal/workspaceprep/reconciler.go
+++ b/internal/workspaceprep/reconciler.go
@@ -11,6 +11,9 @@ package workspaceprep
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
@@ -39,16 +42,28 @@ var ErrReconcileRetryUnsafe = codeexecutor.ErrWorkspaceRetryUnsafe
 // through the shared skillstage helpers, and enforces a fixed phase
 // order (PhaseFile -> PhaseSkill -> PhaseCommand).
 type defaultReconciler struct {
-	locker *keyedLocker
-	stager *skillstage.Stager
+	locker          *keyedLocker
+	stager          *skillstage.Stager
+	generationEpoch string
+	generationErr   error
 }
+
+// processGenerationEpoch keeps persisted prepared records within the lifetime
+// in which WorkspaceInstanceID uniqueness is guaranteed by its provider.
+var processGenerationEpoch, processGenerationErr = newProcessGenerationEpoch()
 
 // NewReconciler returns the default Reconciler used by workspace_exec
 // and other workspace-aware tools.
 func NewReconciler() Reconciler {
+	return newReconciler(processGenerationEpoch, processGenerationErr)
+}
+
+func newReconciler(epoch string, epochErr error) *defaultReconciler {
 	return &defaultReconciler{
-		locker: newKeyedLocker(),
-		stager: skillstage.New(),
+		locker:          newKeyedLocker(),
+		stager:          skillstage.New(),
+		generationEpoch: epoch,
+		generationErr:   epochErr,
 	}
 }
 
@@ -66,6 +81,10 @@ func (r *defaultReconciler) Reconcile(
 	if eng == nil {
 		return nil, fmt.Errorf("workspaceprep: engine is required")
 	}
+	generation, err := r.preparationGeneration(instanceID)
+	if err != nil {
+		return nil, err
+	}
 
 	reqs = dedupeRequirements(reqs)
 	sortRequirements(reqs)
@@ -80,12 +99,7 @@ func (r *defaultReconciler) Reconcile(
 	if md.Prepared == nil {
 		md.Prepared = map[string]codeexecutor.PreparedRecord{}
 	}
-	loadedInstanceID := md.InstanceID
-	invalidatePreparedForInstance(&md, instanceID)
 	baseMD := cloneReconcileMetadata(md)
-	if instanceID != "" {
-		md.InstanceID = instanceID
-	}
 
 	rctx := ApplyContext{
 		Engine:    eng,
@@ -97,14 +111,12 @@ func (r *defaultReconciler) Reconcile(
 	}
 
 	run, err := r.runReconcileRequirements(
-		ctx, eng, ws, baseMD, rctx, reqs,
+		ctx, eng, ws, baseMD, rctx, generation, reqs,
 	)
 	if err != nil {
 		return run.warnings, err
 	}
-	instanceIDChanged := instanceID != "" &&
-		instanceID != loadedInstanceID
-	if run.changed || instanceIDChanged {
+	if run.changed {
 		if err := r.saveReconcileMetadata(
 			ctx, eng, ws, baseMD, md, run.changedKeys,
 		); err != nil {
@@ -135,11 +147,14 @@ func (r *defaultReconciler) runReconcileRequirements(
 	ws codeexecutor.Workspace,
 	baseMD codeexecutor.WorkspaceMetadata,
 	rctx ApplyContext,
+	generation string,
 	reqs []Requirement,
 ) (reconcileRunResult, error) {
 	var run reconcileRunResult
 	for _, req := range reqs {
-		applied, applyAttempted, warn, err := r.runOne(ctx, rctx, req)
+		applied, applyAttempted, warn, err := r.runOne(
+			ctx, rctx, generation, req,
+		)
 		if warn != "" {
 			run.warnings = append(run.warnings, warn)
 		}
@@ -193,24 +208,35 @@ func (r *defaultReconciler) runReconcileRequirements(
 	return run, nil
 }
 
-// invalidatePreparedForInstance clears Prepared when instanceID differs
-// from the metadata's recorded backend generation. An empty instanceID
-// preserves existing Prepared semantics for legacy managers. An empty
-// recorded InstanceID is treated as an unknown generation.
-func invalidatePreparedForInstance(
-	md *codeexecutor.WorkspaceMetadata,
+func (r *defaultReconciler) preparationGeneration(
 	instanceID codeexecutor.WorkspaceInstanceID,
-) {
-	if md == nil || instanceID == "" {
-		return
+) (string, error) {
+	if instanceID == "" {
+		return "", nil
 	}
-	if md.InstanceID == instanceID {
-		return
+	if r.generationErr != nil {
+		return "", fmt.Errorf(
+			"workspaceprep: create process generation epoch: %w",
+			r.generationErr,
+		)
 	}
-	if len(md.Prepared) == 0 {
-		return
+	if r.generationEpoch == "" {
+		return "", errors.New(
+			"workspaceprep: process generation epoch is empty",
+		)
 	}
-	md.Prepared = map[string]codeexecutor.PreparedRecord{}
+	sum := sha256.Sum256([]byte(
+		r.generationEpoch + "\x00" + string(instanceID),
+	))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func newProcessGenerationEpoch() (string, error) {
+	var epoch [16]byte
+	if _, err := rand.Read(epoch[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(epoch[:]), nil
 }
 
 func staleRetryError(err error, unsafe bool) error {
@@ -262,30 +288,6 @@ func mergeReconcileMetadata(
 ) codeexecutor.WorkspaceMetadata {
 	merged := latest
 	mergeDirectMetadataChanges(&merged, base, updated)
-
-	rotationInWriter := updated.InstanceID != "" &&
-		updated.InstanceID != base.InstanceID
-	if updated.InstanceID != "" &&
-		latest.InstanceID != "" &&
-		updated.InstanceID != latest.InstanceID &&
-		!rotationInWriter {
-		// A newer generation already persisted; ignore this writer's
-		// Prepared overlay so stale records cannot replace the latest
-		// map while mergeDirectMetadataChanges keeps latest.InstanceID.
-		return merged
-	}
-	if rotationInWriter &&
-		updated.InstanceID != latest.InstanceID {
-		prepared := make(
-			map[string]codeexecutor.PreparedRecord,
-			len(updated.Prepared),
-		)
-		for key, rec := range updated.Prepared {
-			prepared[key] = rec
-		}
-		merged.Prepared = prepared
-		return merged
-	}
 	prepared := make(
 		map[string]codeexecutor.PreparedRecord,
 		len(merged.Prepared)+len(changedKeys),
@@ -329,9 +331,6 @@ func mergeDirectMetadataChanges(
 	if !reflect.DeepEqual(updated.Outputs, base.Outputs) {
 		merged.Outputs = updated.Outputs
 	}
-	if updated.InstanceID != base.InstanceID {
-		merged.InstanceID = updated.InstanceID
-	}
 }
 
 func cloneReconcileMetadata(
@@ -368,6 +367,7 @@ func cloneReconcileMetadata(
 func (r *defaultReconciler) runOne(
 	ctx context.Context,
 	rctx ApplyContext,
+	generation string,
 	req Requirement,
 ) (bool, bool, string, error) {
 	key := req.Key()
@@ -376,7 +376,8 @@ func (r *defaultReconciler) runOne(
 		return false, false, "", fmt.Errorf("fingerprint: %w", err)
 	}
 	prev, hasPrev := rctx.Metadata.Prepared[key]
-	if hasPrev && prev.Fingerprint == expected {
+	if hasPrev && prev.Generation == generation &&
+		prev.Fingerprint == expected {
 		ok, err := req.SentinelExists(ctx, rctx)
 		if err != nil {
 			return false, false, "", fmt.Errorf("sentinel: %w", err)
@@ -394,6 +395,7 @@ func (r *defaultReconciler) runOne(
 		Fingerprint: expected,
 		Target:      req.Target(),
 		PreparedAt:  time.Now(),
+		Generation:  generation,
 	}
 	return true, true, "", nil
 }

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -58,7 +58,7 @@ func TestFileRequirement_InlineContentAppliesAndSkips(t *testing.T) {
 	rec := NewReconciler()
 
 	warnings, err := rec.Reconcile(
-		ctx, eng, ws, []Requirement{req},
+		ctx, eng, ws, "", []Requirement{req},
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -72,7 +72,7 @@ func TestFileRequirement_InlineContentAppliesAndSkips(t *testing.T) {
 	// counting FS writes via a new fingerprint.
 	infoBefore, err := os.Stat(filepath.Join(ws.Path, "work/config.json"))
 	require.NoError(t, err)
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	infoAfter, err := os.Stat(filepath.Join(ws.Path, "work/config.json"))
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestFileRequirement_InlineContentAppliesAndSkips(t *testing.T) {
 		Content: []byte(`{"v":2}`),
 	})
 	require.NoError(t, err)
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req2})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req2})
 	require.NoError(t, err)
 	got, err = os.ReadFile(filepath.Join(ws.Path, "work/config.json"))
 	require.NoError(t, err)
@@ -104,13 +104,13 @@ func TestFileRequirement_SentinelMissingTriggersReapply(t *testing.T) {
 	require.NoError(t, err)
 	rec := NewReconciler()
 
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	require.NoError(t, os.Remove(
 		filepath.Join(ws.Path, "work/marker.txt"),
 	))
 
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err := os.ReadFile(filepath.Join(ws.Path, "work/marker.txt"))
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestCommandRequirement_MarkerPathSelfHeals(t *testing.T) {
 	require.NoError(t, err)
 	rec := NewReconciler()
 
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{cmd})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
 	require.NoError(t, err)
 	logBefore, err := os.ReadFile(filepath.Join(ws.Path, "work/cmd.log"))
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestCommandRequirement_MarkerPathSelfHeals(t *testing.T) {
 		filepath.Join(ws.Path, "work/cmd.log"),
 		[]byte("preserved"), 0o644,
 	))
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{cmd})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
 	require.NoError(t, err)
 	got, err := os.ReadFile(filepath.Join(ws.Path, "work/cmd.log"))
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestCommandRequirement_MarkerPathSelfHeals(t *testing.T) {
 	require.NoError(t, os.Remove(
 		filepath.Join(ws.Path, "work/.cmd-marker"),
 	))
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{cmd})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
 	require.NoError(t, err)
 	got, err = os.ReadFile(filepath.Join(ws.Path, "work/cmd.log"))
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestReconciler_FixedPhaseOrder(t *testing.T) {
 		recordPhase("file-2"),
 	}
 	rec := NewReconciler()
-	_, err := rec.Reconcile(ctx, eng, ws, reqs)
+	_, err := rec.Reconcile(ctx, eng, ws, "", reqs)
 	require.NoError(t, err)
 	require.Equal(t,
 		[]string{"file-1", "file-2", "skill-1", "cmd-1", "cmd-2"},
@@ -261,7 +261,7 @@ func TestReconciler_ConcurrentReconcileIsSerialized(t *testing.T) {
 			defer wg.Done()
 			req := makeReq(fmt.Sprintf("serialize-%d", i))
 			_, err := rec.Reconcile(
-				ctx, eng, ws, []Requirement{req},
+				ctx, eng, ws, "", []Requirement{req},
 			)
 			require.NoError(t, err)
 		}()
@@ -309,6 +309,7 @@ func TestReconciler_ConcurrentInstancesMergePreparedMetadata(
 				ctx,
 				eng,
 				ws,
+				"",
 				[]Requirement{req},
 			)
 			errs <- err
@@ -528,6 +529,7 @@ func TestReconciler_RequiredFailurePropagatesPartialSaveError(
 		ctx,
 		eng,
 		ws,
+		"",
 		[]Requirement{metadataDirectory, requiredFail},
 	)
 	require.Empty(t, warnings)
@@ -554,7 +556,7 @@ func TestReconciler_OptionalRequirementFailureIsWarning(t *testing.T) {
 	}
 	rec := NewReconciler()
 	warnings, err := rec.Reconcile(
-		ctx, eng, ws, []Requirement{bad, good},
+		ctx, eng, ws, "", []Requirement{bad, good},
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, warnings)
@@ -576,6 +578,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			context.Background(),
 			eng,
 			codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
+			"",
 			[]Requirement{req},
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -592,7 +595,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 		}
 
 		warnings, err := NewReconciler().Reconcile(
-			context.Background(), eng, ws, []Requirement{req},
+			context.Background(), eng, ws, "", []Requirement{req},
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
 		require.False(t, errors.Is(err, ErrReconcileRetryUnsafe))
@@ -617,7 +620,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 		}
 
 		_, err := NewReconciler().Reconcile(
-			context.Background(), eng, ws,
+			context.Background(), eng, ws, "",
 			[]Requirement{success, later},
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -645,7 +648,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			}
 
 			warnings, err := NewReconciler().Reconcile(
-				context.Background(), eng, ws,
+				context.Background(), eng, ws, "",
 				[]Requirement{optionalFailure, laterStale},
 			)
 			require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -673,7 +676,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 		}
 
 		warnings, err := NewReconciler().Reconcile(
-			context.Background(), eng, ws,
+			context.Background(), eng, ws, "",
 			[]Requirement{optional, next},
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -705,6 +708,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 					ID:   "ws",
 					Path: t.TempDir(),
 				},
+				"",
 				[]Requirement{req},
 			)
 			require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -731,6 +735,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			context.Background(),
 			eng,
 			codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
+			"",
 			[]Requirement{req},
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -738,7 +743,56 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 	})
 }
 
-// orderReq is a minimal Requirement implementation used by tests to
+func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+	rec := NewReconciler()
+
+	req, err := NewFileRequirement(FileSpec{
+		Target:  "work/seed.txt",
+		Content: []byte("seed"),
+	})
+	require.NoError(t, err)
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{req},
+	)
+	require.NoError(t, err)
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
+		md.BackendInstanceID)
+
+	target := filepath.Join(ws.Path, "work/seed.txt")
+	infoBefore, err := os.Stat(target)
+	require.NoError(t, err)
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{req},
+	)
+	require.NoError(t, err)
+	infoUnchanged, err := os.Stat(target)
+	require.NoError(t, err)
+	require.Equal(t, infoBefore.ModTime(), infoUnchanged.ModTime(),
+		"same instance should skip unchanged bootstrap files")
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-2", []Requirement{req},
+	)
+	require.NoError(t, err)
+
+	md, err = codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
+		md.BackendInstanceID)
+
+	infoAfter, err := os.Stat(target)
+	require.NoError(t, err)
+	require.NotEqual(t, infoBefore.ModTime(), infoAfter.ModTime(),
+		"instance rotation must re-apply bootstrap files")
+}
+
 // observe the reconciler's phase ordering and locking semantics.
 type orderReq struct {
 	key      string

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -58,7 +58,7 @@ func TestFileRequirement_InlineContentAppliesAndSkips(t *testing.T) {
 	require.NoError(t, err)
 	rec := NewReconciler()
 
-	warnings, err := rec.Reconcile(
+	warnings, _, err := rec.Reconcile(
 		ctx, eng, ws, "", []Requirement{req},
 	)
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestFileRequirement_InlineContentAppliesAndSkips(t *testing.T) {
 	// counting FS writes via a new fingerprint.
 	infoBefore, err := os.Stat(filepath.Join(ws.Path, "work/config.json"))
 	require.NoError(t, err)
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	infoAfter, err := os.Stat(filepath.Join(ws.Path, "work/config.json"))
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestFileRequirement_InlineContentAppliesAndSkips(t *testing.T) {
 		Content: []byte(`{"v":2}`),
 	})
 	require.NoError(t, err)
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req2})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req2})
 	require.NoError(t, err)
 	got, err = os.ReadFile(filepath.Join(ws.Path, "work/config.json"))
 	require.NoError(t, err)
@@ -105,13 +105,13 @@ func TestFileRequirement_SentinelMissingTriggersReapply(t *testing.T) {
 	require.NoError(t, err)
 	rec := NewReconciler()
 
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	require.NoError(t, os.Remove(
 		filepath.Join(ws.Path, "work/marker.txt"),
 	))
 
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err := os.ReadFile(filepath.Join(ws.Path, "work/marker.txt"))
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestCommandRequirement_MarkerPathSelfHeals(t *testing.T) {
 	require.NoError(t, err)
 	rec := NewReconciler()
 
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
 	require.NoError(t, err)
 	logBefore, err := os.ReadFile(filepath.Join(ws.Path, "work/cmd.log"))
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestCommandRequirement_MarkerPathSelfHeals(t *testing.T) {
 		filepath.Join(ws.Path, "work/cmd.log"),
 		[]byte("preserved"), 0o644,
 	))
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
 	require.NoError(t, err)
 	got, err := os.ReadFile(filepath.Join(ws.Path, "work/cmd.log"))
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestCommandRequirement_MarkerPathSelfHeals(t *testing.T) {
 	require.NoError(t, os.Remove(
 		filepath.Join(ws.Path, "work/.cmd-marker"),
 	))
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{cmd})
 	require.NoError(t, err)
 	got, err = os.ReadFile(filepath.Join(ws.Path, "work/cmd.log"))
 	require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestReconciler_FixedPhaseOrder(t *testing.T) {
 		recordPhase("file-2"),
 	}
 	rec := NewReconciler()
-	_, err := rec.Reconcile(ctx, eng, ws, "", reqs)
+	_, _, err := rec.Reconcile(ctx, eng, ws, "", reqs)
 	require.NoError(t, err)
 	require.Equal(t,
 		[]string{"file-1", "file-2", "skill-1", "cmd-1", "cmd-2"},
@@ -261,7 +261,7 @@ func TestReconciler_ConcurrentReconcileIsSerialized(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			req := makeReq(fmt.Sprintf("serialize-%d", i))
-			_, err := rec.Reconcile(
+			_, _, err := rec.Reconcile(
 				ctx, eng, ws, "", []Requirement{req},
 			)
 			require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestReconciler_ConcurrentInstancesMergePreparedMetadata(
 				phase: PhaseCommand,
 				apply: func() {},
 			}
-			_, err := NewReconciler().Reconcile(
+			_, _, err := NewReconciler().Reconcile(
 				ctx,
 				eng,
 				ws,
@@ -526,7 +526,7 @@ func TestReconciler_RequiredFailurePropagatesPartialSaveError(
 		applyErr: fmt.Errorf("boom"),
 	}
 
-	warnings, err := NewReconciler().Reconcile(
+	warnings, _, err := NewReconciler().Reconcile(
 		ctx,
 		eng,
 		ws,
@@ -556,7 +556,7 @@ func TestReconciler_OptionalRequirementFailureIsWarning(t *testing.T) {
 		apply: func() {},
 	}
 	rec := NewReconciler()
-	warnings, err := rec.Reconcile(
+	warnings, _, err := rec.Reconcile(
 		ctx, eng, ws, "", []Requirement{bad, good},
 	)
 	require.NoError(t, err)
@@ -575,7 +575,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			phase: PhaseFile,
 		}
 
-		_, err := NewReconciler().Reconcile(
+		_, _, err := NewReconciler().Reconcile(
 			context.Background(),
 			eng,
 			codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
@@ -595,7 +595,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			applyErr: stale,
 		}
 
-		warnings, err := NewReconciler().Reconcile(
+		warnings, _, err := NewReconciler().Reconcile(
 			context.Background(), eng, ws, "", []Requirement{req},
 		)
 		require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
@@ -620,7 +620,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			applyErr: stale,
 		}
 
-		_, err := NewReconciler().Reconcile(
+		_, _, err := NewReconciler().Reconcile(
 			context.Background(), eng, ws, "",
 			[]Requirement{success, later},
 		)
@@ -648,7 +648,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 				applyErr: stale,
 			}
 
-			warnings, err := NewReconciler().Reconcile(
+			warnings, _, err := NewReconciler().Reconcile(
 				context.Background(), eng, ws, "",
 				[]Requirement{optionalFailure, laterStale},
 			)
@@ -676,7 +676,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			apply: func() { nextCalls++ },
 		}
 
-		warnings, err := NewReconciler().Reconcile(
+		warnings, _, err := NewReconciler().Reconcile(
 			context.Background(), eng, ws, "",
 			[]Requirement{optional, next},
 		)
@@ -702,7 +702,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 				apply: func() {},
 			}
 
-			_, err := NewReconciler().Reconcile(
+			_, _, err := NewReconciler().Reconcile(
 				context.Background(),
 				eng,
 				codeexecutor.Workspace{
@@ -732,7 +732,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 			},
 		}
 
-		_, err = NewReconciler().Reconcile(
+		_, _, err = NewReconciler().Reconcile(
 			context.Background(),
 			eng,
 			codeexecutor.Workspace{ID: "ws", Path: t.TempDir()},
@@ -773,6 +773,10 @@ func TestPreparationGeneration(t *testing.T) {
 	require.Empty(t, legacy)
 	_, err = broken.preparationGeneration("instance-1")
 	require.ErrorContains(t, err, "entropy unavailable")
+
+	empty := newReconciler("", nil)
+	_, err = empty.preparationGeneration("instance-1")
+	require.ErrorContains(t, err, "process generation epoch is empty")
 }
 
 func TestReconciler_InstanceRotationInvalidatesPreparedRecord(t *testing.T) {
@@ -786,7 +790,7 @@ func TestReconciler_InstanceRotationInvalidatesPreparedRecord(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{req},
 	)
 	require.NoError(t, err)
@@ -800,7 +804,7 @@ func TestReconciler_InstanceRotationInvalidatesPreparedRecord(t *testing.T) {
 	infoBefore, err := os.Stat(target)
 	require.NoError(t, err)
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{req},
 	)
 	require.NoError(t, err)
@@ -809,7 +813,7 @@ func TestReconciler_InstanceRotationInvalidatesPreparedRecord(t *testing.T) {
 	require.Equal(t, infoBefore.ModTime(), infoUnchanged.ModTime(),
 		"same instance should skip unchanged bootstrap files")
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-2", []Requirement{req},
 	)
 	require.NoError(t, err)
@@ -850,21 +854,21 @@ func TestReconciler_InstanceRotationRerunsMarkerlessCommand(t *testing.T) {
 		return strings.Count(string(data), "run\n")
 	}
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{cmd},
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, countRuns(),
 		"first reconcile on instance-1 must run marker-less command")
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{cmd},
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, countRuns(),
 		"same instance must skip marker-less command via Prepared")
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-2", []Requirement{cmd},
 	)
 	require.NoError(t, err)
@@ -892,7 +896,7 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{req},
 	)
 	require.NoError(t, err)
@@ -913,7 +917,7 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 		0o644,
 	))
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-2", []Requirement{req},
 	)
 	require.NoError(t, err)
@@ -947,7 +951,7 @@ func TestReconciler_PartialSaveRecordsGeneration(t *testing.T) {
 		applyErr: fmt.Errorf("boom"),
 	}
 
-	_, err := rec.Reconcile(
+	_, _, err := rec.Reconcile(
 		ctx,
 		eng,
 		ws,
@@ -964,7 +968,7 @@ func TestReconciler_PartialSaveRecordsGeneration(t *testing.T) {
 	require.Equal(t, wantGeneration,
 		md.Prepared[applied.Key()].Generation)
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{applied},
 	)
 	require.NoError(t, err)
@@ -990,7 +994,7 @@ func TestReconciler_InstanceRotationRetainsInactivePreparedRecords(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-1", []Requirement{reqA, reqB},
 	)
 	require.NoError(t, err)
@@ -998,7 +1002,7 @@ func TestReconciler_InstanceRotationRetainsInactivePreparedRecords(t *testing.T)
 	require.NoError(t, err)
 	oldBGeneration := before.Prepared[reqB.Key()].Generation
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-2", []Requirement{reqA},
 	)
 	require.NoError(t, err)
@@ -1010,7 +1014,7 @@ func TestReconciler_InstanceRotationRetainsInactivePreparedRecords(t *testing.T)
 		"inactive records remain cached but cannot satisfy another generation")
 	require.Equal(t, oldBGeneration, md.Prepared[reqB.Key()].Generation)
 
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		ctx, eng, ws, "instance-2", []Requirement{reqB},
 	)
 	require.NoError(t, err)
@@ -1033,17 +1037,17 @@ func TestReconciler_ProcessRestartInvalidatesReusedInstanceID(t *testing.T) {
 	require.NoError(t, err)
 
 	recA := newReconciler("process-a", nil)
-	_, err = recA.Reconcile(
+	_, _, err = recA.Reconcile(
 		ctx, eng, ws, "reused-instance", []Requirement{cmd},
 	)
 	require.NoError(t, err)
-	_, err = recA.Reconcile(
+	_, _, err = recA.Reconcile(
 		ctx, eng, ws, "reused-instance", []Requirement{cmd},
 	)
 	require.NoError(t, err)
 
 	recB := newReconciler("process-b", nil)
-	_, err = recB.Reconcile(
+	_, _, err = recB.Reconcile(
 		ctx, eng, ws, "reused-instance", []Requirement{cmd},
 	)
 	require.NoError(t, err)
@@ -1079,7 +1083,7 @@ func TestReconciler_ConcurrentRotationsDoNotTrustStaleRecord(t *testing.T) {
 
 	oldDone := make(chan error, 1)
 	go func() {
-		_, err := recA.Reconcile(
+		_, _, err := recA.Reconcile(
 			ctx, eng, ws, "instance-2", []Requirement{oldReq},
 		)
 		oldDone <- err
@@ -1090,7 +1094,7 @@ func TestReconciler_ConcurrentRotationsDoNotTrustStaleRecord(t *testing.T) {
 		t.Fatal("old-generation reconcile did not reach Apply")
 	}
 
-	_, err := recB.Reconcile(
+	_, _, err := recB.Reconcile(
 		ctx, eng, ws, "instance-3", []Requirement{newReq},
 	)
 	require.NoError(t, err)
@@ -1112,7 +1116,7 @@ func TestReconciler_ConcurrentRotationsDoNotTrustStaleRecord(t *testing.T) {
 		phase: PhaseCommand,
 		apply: func() { reapplied.Add(1) },
 	}
-	_, err = recB.Reconcile(
+	_, _, err = recB.Reconcile(
 		ctx, eng, ws, "instance-3", []Requirement{currentReq},
 	)
 	require.NoError(t, err)

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -793,6 +793,86 @@ func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 		"instance rotation must re-apply bootstrap files")
 }
 
+func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+	rec := NewReconciler()
+
+	req, err := NewFileRequirement(FileSpec{
+		Target:  "work/seed.txt",
+		Content: []byte("seed-v2"),
+	})
+	require.NoError(t, err)
+
+	legacy := codeexecutor.WorkspaceMetadata{
+		Version: 1,
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			req.Key(): {Key: req.Key(), Fingerprint: "stale"},
+		},
+	}
+	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, legacy))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(ws.Path, "work/seed.txt"),
+		[]byte("seed-v1"),
+		0o644,
+	))
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-2", []Requirement{req},
+	)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(ws.Path, "work/seed.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "seed-v2", string(got))
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
+		md.BackendInstanceID)
+}
+
+func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+	rec := NewReconciler()
+
+	reqA, err := NewFileRequirement(FileSpec{
+		Key:     "file-a",
+		Target:  "work/a.txt",
+		Content: []byte("a"),
+	})
+	require.NoError(t, err)
+	reqB, err := NewFileRequirement(FileSpec{
+		Key:     "file-b",
+		Target:  "work/b.txt",
+		Content: []byte("b"),
+	})
+	require.NoError(t, err)
+
+	legacy := codeexecutor.WorkspaceMetadata{
+		Version:           1,
+		BackendInstanceID: "instance-1",
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			reqA.Key(): {Key: reqA.Key()},
+			reqB.Key(): {Key: reqB.Key()},
+		},
+	}
+	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, legacy))
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-2", []Requirement{reqA},
+	)
+	require.NoError(t, err)
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
+		md.BackendInstanceID)
+	require.Contains(t, md.Prepared, reqA.Key())
+	require.NotContains(t, md.Prepared, reqB.Key())
+}
+
 // observe the reconciler's phase ordering and locking semantics.
 type orderReq struct {
 	key      string

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -820,6 +821,58 @@ func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, infoBefore.ModTime(), infoAfter.ModTime(),
 		"instance rotation must re-apply bootstrap files")
+}
+
+func TestReconciler_InstanceRotationRerunsMarkerlessCommand(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+	rec := NewReconciler()
+	logPath := filepath.Join(ws.Path, "work/bootstrap.log")
+
+	cmd, err := NewCommandRequirement(CommandSpec{
+		Cmd:  "bash",
+		Args: []string{"-lc", "mkdir -p work && echo run >> work/bootstrap.log"},
+	})
+	require.NoError(t, err)
+
+	countRuns := func() int {
+		data, err := os.ReadFile(logPath)
+		if os.IsNotExist(err) {
+			return 0
+		}
+		require.NoError(t, err)
+		if len(data) == 0 {
+			return 0
+		}
+		return strings.Count(string(data), "run\n")
+	}
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{cmd},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, countRuns(),
+		"first reconcile on instance-1 must run marker-less command")
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{cmd},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, countRuns(),
+		"same instance must skip marker-less command via Prepared")
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-2", []Requirement{cmd},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, countRuns(),
+		"instance rotation must rerun marker-less command")
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
+		md.InstanceID)
+	require.Contains(t, md.Prepared, cmd.Key())
 }
 
 func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -489,6 +489,58 @@ func TestReconciler_MergePreservesAllDirectMetadataChanges(t *testing.T) {
 	require.Contains(t, got.Prepared, "changed")
 }
 
+func TestMergeReconcileMetadata_WriterRotationReplacesPrepared(t *testing.T) {
+	latest := codeexecutor.WorkspaceMetadata{
+		InstanceID: "instance-1",
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			"stale-b": {Key: "stale-b"},
+		},
+	}
+	base := codeexecutor.WorkspaceMetadata{
+		InstanceID: "instance-1",
+	}
+	updated := codeexecutor.WorkspaceMetadata{
+		InstanceID: "instance-2",
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			"fresh-a": {Key: "fresh-a"},
+		},
+	}
+
+	got := mergeReconcileMetadata(latest, base, updated, nil)
+
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
+		got.InstanceID)
+	require.Contains(t, got.Prepared, "fresh-a")
+	require.NotContains(t, got.Prepared, "stale-b")
+}
+
+func TestMergeReconcileMetadata_RejectsStaleGenerationPrepared(t *testing.T) {
+	latest := codeexecutor.WorkspaceMetadata{
+		InstanceID: "instance-2",
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			"new-gen": {Key: "new-gen", Fingerprint: "v2"},
+		},
+	}
+	base := codeexecutor.WorkspaceMetadata{
+		InstanceID: "instance-1",
+	}
+	updated := codeexecutor.WorkspaceMetadata{
+		InstanceID: "instance-1",
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			"old-gen": {Key: "old-gen", Fingerprint: "v1"},
+		},
+	}
+
+	got := mergeReconcileMetadata(
+		latest, base, updated, []string{"old-gen"},
+	)
+
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
+		got.InstanceID)
+	require.Contains(t, got.Prepared, "new-gen")
+	require.NotContains(t, got.Prepared, "old-gen")
+}
+
 func TestReconciler_SavePreparedReturnsLoadMetadataError(t *testing.T) {
 	rec := NewReconciler().(*defaultReconciler)
 	err := rec.saveReconcileMetadata(

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -833,13 +833,20 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	legacy := codeexecutor.WorkspaceMetadata{
-		Version: 1,
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			req.Key(): {Key: req.Key(), Fingerprint: "stale"},
-		},
-	}
-	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, legacy))
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{req},
+	)
+	require.NoError(t, err)
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
+		md.BackendInstanceID)
+	require.Contains(t, md.Prepared, req.Key())
+	require.NotEmpty(t, md.Prepared[req.Key()].Fingerprint)
+
+	md.BackendInstanceID = ""
+	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, md))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(ws.Path, "work/seed.txt"),
 		[]byte("seed-v1"),
@@ -855,10 +862,43 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "seed-v2", string(got))
 
-	md, err := codeexecutor.LoadMetadata(ws.Path)
+	md, err = codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
 		md.BackendInstanceID)
+}
+
+func TestReconciler_PartialSaveRecordsBackendInstanceID(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+
+	applied := &orderReq{
+		key:   "applied",
+		kind:  KindCommand,
+		phase: PhaseCommand,
+		apply: func() {},
+	}
+	requiredFail := &orderReq{
+		key:      "bad",
+		kind:     KindCommand,
+		phase:    PhaseCommand,
+		applyErr: fmt.Errorf("boom"),
+	}
+
+	_, err := NewReconciler().Reconcile(
+		ctx,
+		eng,
+		ws,
+		"instance-1",
+		[]Requirement{applied, requiredFail},
+	)
+	require.ErrorContains(t, err, "required requirement \"bad\" failed")
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
+		md.BackendInstanceID)
+	require.Contains(t, md.Prepared, applied.Key())
 }
 
 func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -489,58 +489,6 @@ func TestReconciler_MergePreservesAllDirectMetadataChanges(t *testing.T) {
 	require.Contains(t, got.Prepared, "changed")
 }
 
-func TestMergeReconcileMetadata_WriterRotationReplacesPrepared(t *testing.T) {
-	latest := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-1",
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			"stale-b": {Key: "stale-b"},
-		},
-	}
-	base := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-1",
-	}
-	updated := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-2",
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			"fresh-a": {Key: "fresh-a"},
-		},
-	}
-
-	got := mergeReconcileMetadata(latest, base, updated, nil)
-
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		got.InstanceID)
-	require.Contains(t, got.Prepared, "fresh-a")
-	require.NotContains(t, got.Prepared, "stale-b")
-}
-
-func TestMergeReconcileMetadata_RejectsStaleGenerationPrepared(t *testing.T) {
-	latest := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-2",
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			"new-gen": {Key: "new-gen", Fingerprint: "v2"},
-		},
-	}
-	base := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-1",
-	}
-	updated := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-1",
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			"old-gen": {Key: "old-gen", Fingerprint: "v1"},
-		},
-	}
-
-	got := mergeReconcileMetadata(
-		latest, base, updated, []string{"old-gen"},
-	)
-
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		got.InstanceID)
-	require.Contains(t, got.Prepared, "new-gen")
-	require.NotContains(t, got.Prepared, "old-gen")
-}
-
 func TestReconciler_SavePreparedReturnsLoadMetadataError(t *testing.T) {
 	rec := NewReconciler().(*defaultReconciler)
 	err := rec.saveReconcileMetadata(
@@ -796,39 +744,41 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 	})
 }
 
-func TestInvalidatePreparedForInstance(t *testing.T) {
-	md := codeexecutor.WorkspaceMetadata{
-		InstanceID: "instance-1",
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			"bootstrap": {Key: "bootstrap"},
-		},
-	}
-	require.False(t, func() bool {
-		before := len(md.Prepared)
-		invalidatePreparedForInstance(&md, "")
-		return before != len(md.Prepared)
-	}())
-	require.Len(t, md.Prepared, 1)
+func TestPreparationGeneration(t *testing.T) {
+	recA := newReconciler("process-a", nil)
+	recB := newReconciler("process-b", nil)
 
-	invalidatePreparedForInstance(&md, "instance-1")
-	require.Len(t, md.Prepared, 1)
+	legacy, err := recA.preparationGeneration("")
+	require.NoError(t, err)
+	require.Empty(t, legacy)
 
-	invalidatePreparedForInstance(&md, "instance-2")
-	require.Empty(t, md.Prepared)
+	a1, err := recA.preparationGeneration("instance-1")
+	require.NoError(t, err)
+	a1Again, err := recA.preparationGeneration("instance-1")
+	require.NoError(t, err)
+	a2, err := recA.preparationGeneration("instance-2")
+	require.NoError(t, err)
+	b1, err := recB.preparationGeneration("instance-1")
+	require.NoError(t, err)
 
-	md = codeexecutor.WorkspaceMetadata{
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			"bootstrap": {Key: "bootstrap"},
-		},
-	}
-	invalidatePreparedForInstance(&md, "instance-1")
-	require.Empty(t, md.Prepared)
+	require.NotEmpty(t, a1)
+	require.Equal(t, a1, a1Again)
+	require.NotEqual(t, a1, a2)
+	require.NotEqual(t, a1, b1,
+		"a reused instance ID must not match metadata from another process")
+
+	broken := newReconciler("", errors.New("entropy unavailable"))
+	legacy, err = broken.preparationGeneration("")
+	require.NoError(t, err)
+	require.Empty(t, legacy)
+	_, err = broken.preparationGeneration("instance-1")
+	require.ErrorContains(t, err, "entropy unavailable")
 }
 
-func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
+func TestReconciler_InstanceRotationInvalidatesPreparedRecord(t *testing.T) {
 	ctx := context.Background()
 	eng, ws := newTestEngine(t)
-	rec := NewReconciler()
+	rec := newReconciler("process-a", nil)
 
 	req, err := NewFileRequirement(FileSpec{
 		Target:  "work/seed.txt",
@@ -843,8 +793,8 @@ func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
-		md.InstanceID)
+	generation1 := md.Prepared[req.Key()].Generation
+	require.NotEmpty(t, generation1)
 
 	target := filepath.Join(ws.Path, "work/seed.txt")
 	infoBefore, err := os.Stat(target)
@@ -866,8 +816,9 @@ func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 
 	md, err = codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.InstanceID)
+	generation2 := md.Prepared[req.Key()].Generation
+	require.NotEmpty(t, generation2)
+	require.NotEqual(t, generation1, generation2)
 
 	infoAfter, err := os.Stat(target)
 	require.NoError(t, err)
@@ -922,15 +873,18 @@ func TestReconciler_InstanceRotationRerunsMarkerlessCommand(t *testing.T) {
 
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.InstanceID)
 	require.Contains(t, md.Prepared, cmd.Key())
+	wantGeneration, err := rec.(*defaultReconciler).preparationGeneration(
+		"instance-2",
+	)
+	require.NoError(t, err)
+	require.Equal(t, wantGeneration, md.Prepared[cmd.Key()].Generation)
 }
 
 func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 	ctx := context.Background()
 	eng, ws := newTestEngine(t)
-	rec := NewReconciler()
+	rec := newReconciler("process-a", nil)
 
 	req, err := NewFileRequirement(FileSpec{
 		Target:  "work/seed.txt",
@@ -945,12 +899,13 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
-		md.InstanceID)
 	require.Contains(t, md.Prepared, req.Key())
 	require.NotEmpty(t, md.Prepared[req.Key()].Fingerprint)
+	require.NotEmpty(t, md.Prepared[req.Key()].Generation)
 
-	md.InstanceID = ""
+	legacyRecord := md.Prepared[req.Key()]
+	legacyRecord.Generation = ""
+	md.Prepared[req.Key()] = legacyRecord
 	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, md))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(ws.Path, "work/seed.txt"),
@@ -969,19 +924,21 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 
 	md, err = codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.InstanceID)
+	require.NotEmpty(t, md.Prepared[req.Key()].Generation)
 }
 
-func TestReconciler_PartialSaveRecordsInstanceID(t *testing.T) {
+func TestReconciler_PartialSaveRecordsGeneration(t *testing.T) {
 	ctx := context.Background()
 	eng, ws := newTestEngine(t)
+	rec := newReconciler("process-a", nil)
 
+	var applyCount atomic.Int32
 	applied := &orderReq{
-		key:   "applied",
-		kind:  KindCommand,
-		phase: PhaseCommand,
-		apply: func() {},
+		key:      "applied",
+		kind:     KindCommand,
+		phase:    PhaseCommand,
+		apply:    func() { applyCount.Add(1) },
+		sentinel: true,
 	}
 	requiredFail := &orderReq{
 		key:      "bad",
@@ -990,7 +947,7 @@ func TestReconciler_PartialSaveRecordsInstanceID(t *testing.T) {
 		applyErr: fmt.Errorf("boom"),
 	}
 
-	_, err := NewReconciler().Reconcile(
+	_, err := rec.Reconcile(
 		ctx,
 		eng,
 		ws,
@@ -1001,15 +958,24 @@ func TestReconciler_PartialSaveRecordsInstanceID(t *testing.T) {
 
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
-		md.InstanceID)
 	require.Contains(t, md.Prepared, applied.Key())
+	wantGeneration, err := rec.preparationGeneration("instance-1")
+	require.NoError(t, err)
+	require.Equal(t, wantGeneration,
+		md.Prepared[applied.Key()].Generation)
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{applied},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), applyCount.Load(),
+		"partial progress must be reused on the same generation")
 }
 
-func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
+func TestReconciler_InstanceRotationRetainsInactivePreparedRecords(t *testing.T) {
 	ctx := context.Background()
 	eng, ws := newTestEngine(t)
-	rec := NewReconciler()
+	rec := newReconciler("process-a", nil)
 
 	reqA, err := NewFileRequirement(FileSpec{
 		Key:     "file-a",
@@ -1024,15 +990,13 @@ func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	legacy := codeexecutor.WorkspaceMetadata{
-		Version:    1,
-		InstanceID: "instance-1",
-		Prepared: map[string]codeexecutor.PreparedRecord{
-			reqA.Key(): {Key: reqA.Key()},
-			reqB.Key(): {Key: reqB.Key()},
-		},
-	}
-	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, legacy))
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-1", []Requirement{reqA, reqB},
+	)
+	require.NoError(t, err)
+	before, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	oldBGeneration := before.Prepared[reqB.Key()].Generation
 
 	_, err = rec.Reconcile(
 		ctx, eng, ws, "instance-2", []Requirement{reqA},
@@ -1041,10 +1005,119 @@ func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
 
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
-	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.InstanceID)
 	require.Contains(t, md.Prepared, reqA.Key())
-	require.NotContains(t, md.Prepared, reqB.Key())
+	require.Contains(t, md.Prepared, reqB.Key(),
+		"inactive records remain cached but cannot satisfy another generation")
+	require.Equal(t, oldBGeneration, md.Prepared[reqB.Key()].Generation)
+
+	_, err = rec.Reconcile(
+		ctx, eng, ws, "instance-2", []Requirement{reqB},
+	)
+	require.NoError(t, err)
+	md, err = codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	require.NotEqual(t, oldBGeneration,
+		md.Prepared[reqB.Key()].Generation)
+}
+
+func TestReconciler_ProcessRestartInvalidatesReusedInstanceID(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+	logPath := filepath.Join(ws.Path, "work/restart.log")
+	cmd, err := NewCommandRequirement(CommandSpec{
+		Cmd: "bash",
+		Args: []string{
+			"-lc", "mkdir -p work && echo run >> work/restart.log",
+		},
+	})
+	require.NoError(t, err)
+
+	recA := newReconciler("process-a", nil)
+	_, err = recA.Reconcile(
+		ctx, eng, ws, "reused-instance", []Requirement{cmd},
+	)
+	require.NoError(t, err)
+	_, err = recA.Reconcile(
+		ctx, eng, ws, "reused-instance", []Requirement{cmd},
+	)
+	require.NoError(t, err)
+
+	recB := newReconciler("process-b", nil)
+	_, err = recB.Reconcile(
+		ctx, eng, ws, "reused-instance", []Requirement{cmd},
+	)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Equal(t, 2, strings.Count(string(data), "run\n"))
+}
+
+func TestReconciler_ConcurrentRotationsDoNotTrustStaleRecord(t *testing.T) {
+	ctx := context.Background()
+	eng, ws := newTestEngine(t)
+	recA := newReconciler("process-a", nil)
+	recB := newReconciler("process-a", nil)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	oldReq := &orderReq{
+		key:   "shared-bootstrap",
+		kind:  KindCommand,
+		phase: PhaseCommand,
+		apply: func() {
+			close(entered)
+			<-release
+		},
+	}
+	newReq := &orderReq{
+		key:   oldReq.key,
+		kind:  KindCommand,
+		phase: PhaseCommand,
+		apply: func() {},
+	}
+
+	oldDone := make(chan error, 1)
+	go func() {
+		_, err := recA.Reconcile(
+			ctx, eng, ws, "instance-2", []Requirement{oldReq},
+		)
+		oldDone <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("old-generation reconcile did not reach Apply")
+	}
+
+	_, err := recB.Reconcile(
+		ctx, eng, ws, "instance-3", []Requirement{newReq},
+	)
+	require.NoError(t, err)
+	close(release)
+	require.NoError(t, <-oldDone)
+
+	md, err := codeexecutor.LoadMetadata(ws.Path)
+	require.NoError(t, err)
+	oldGeneration, err := recA.preparationGeneration("instance-2")
+	require.NoError(t, err)
+	require.Equal(t, oldGeneration,
+		md.Prepared[oldReq.Key()].Generation,
+		"the late writer may win storage, but its provenance remains stale")
+
+	var reapplied atomic.Int32
+	currentReq := &orderReq{
+		key:   oldReq.key,
+		kind:  KindCommand,
+		phase: PhaseCommand,
+		apply: func() { reapplied.Add(1) },
+	}
+	_, err = recB.Reconcile(
+		ctx, eng, ws, "instance-3", []Requirement{currentReq},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), reapplied.Load(),
+		"a stale writer must not authorize a skip on the current generation")
 }
 
 // observe the reconciler's phase ordering and locking semantics.
@@ -1053,6 +1126,7 @@ type orderReq struct {
 	kind     Kind
 	phase    Phase
 	optional bool
+	sentinel bool
 	apply    func()
 	applyErr error
 }
@@ -1074,7 +1148,7 @@ func (r *orderReq) Fingerprint(
 func (r *orderReq) SentinelExists(
 	_ context.Context, _ ApplyContext,
 ) (bool, error) {
-	return false, nil
+	return r.sentinel, nil
 }
 
 func (r *orderReq) Apply(_ context.Context, _ ApplyContext) error {

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -743,6 +743,35 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 	})
 }
 
+func TestInvalidatePreparedForInstance(t *testing.T) {
+	md := codeexecutor.WorkspaceMetadata{
+		BackendInstanceID: "instance-1",
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			"bootstrap": {Key: "bootstrap"},
+		},
+	}
+	require.False(t, func() bool {
+		before := len(md.Prepared)
+		invalidatePreparedForInstance(&md, "")
+		return before != len(md.Prepared)
+	}())
+	require.Len(t, md.Prepared, 1)
+
+	invalidatePreparedForInstance(&md, "instance-1")
+	require.Len(t, md.Prepared, 1)
+
+	invalidatePreparedForInstance(&md, "instance-2")
+	require.Empty(t, md.Prepared)
+
+	md = codeexecutor.WorkspaceMetadata{
+		Prepared: map[string]codeexecutor.PreparedRecord{
+			"bootstrap": {Key: "bootstrap"},
+		},
+	}
+	invalidatePreparedForInstance(&md, "instance-1")
+	require.Empty(t, md.Prepared)
+}
+
 func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 	ctx := context.Background()
 	eng, ws := newTestEngine(t)

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -745,7 +745,7 @@ func TestReconciler_StaleRetryDisposition(t *testing.T) {
 
 func TestInvalidatePreparedForInstance(t *testing.T) {
 	md := codeexecutor.WorkspaceMetadata{
-		BackendInstanceID: "instance-1",
+		InstanceID: "instance-1",
 		Prepared: map[string]codeexecutor.PreparedRecord{
 			"bootstrap": {Key: "bootstrap"},
 		},
@@ -791,7 +791,7 @@ func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
-		md.BackendInstanceID)
+		md.InstanceID)
 
 	target := filepath.Join(ws.Path, "work/seed.txt")
 	infoBefore, err := os.Stat(target)
@@ -814,7 +814,7 @@ func TestReconciler_InstanceRotationClearsPrepared(t *testing.T) {
 	md, err = codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.BackendInstanceID)
+		md.InstanceID)
 
 	infoAfter, err := os.Stat(target)
 	require.NoError(t, err)
@@ -841,11 +841,11 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
-		md.BackendInstanceID)
+		md.InstanceID)
 	require.Contains(t, md.Prepared, req.Key())
 	require.NotEmpty(t, md.Prepared[req.Key()].Fingerprint)
 
-	md.BackendInstanceID = ""
+	md.InstanceID = ""
 	require.NoError(t, codeexecutor.SaveMetadata(ws.Path, md))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(ws.Path, "work/seed.txt"),
@@ -865,10 +865,10 @@ func TestReconciler_LegacyPreparedMetadataRotatesBootstrap(t *testing.T) {
 	md, err = codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.BackendInstanceID)
+		md.InstanceID)
 }
 
-func TestReconciler_PartialSaveRecordsBackendInstanceID(t *testing.T) {
+func TestReconciler_PartialSaveRecordsInstanceID(t *testing.T) {
 	ctx := context.Background()
 	eng, ws := newTestEngine(t)
 
@@ -897,7 +897,7 @@ func TestReconciler_PartialSaveRecordsBackendInstanceID(t *testing.T) {
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-1"),
-		md.BackendInstanceID)
+		md.InstanceID)
 	require.Contains(t, md.Prepared, applied.Key())
 }
 
@@ -921,7 +921,7 @@ func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
 
 	legacy := codeexecutor.WorkspaceMetadata{
 		Version:           1,
-		BackendInstanceID: "instance-1",
+		InstanceID: "instance-1",
 		Prepared: map[string]codeexecutor.PreparedRecord{
 			reqA.Key(): {Key: reqA.Key()},
 			reqB.Key(): {Key: reqB.Key()},
@@ -937,7 +937,7 @@ func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
 	md, err := codeexecutor.LoadMetadata(ws.Path)
 	require.NoError(t, err)
 	require.Equal(t, codeexecutor.WorkspaceInstanceID("instance-2"),
-		md.BackendInstanceID)
+		md.InstanceID)
 	require.Contains(t, md.Prepared, reqA.Key())
 	require.NotContains(t, md.Prepared, reqB.Key())
 }

--- a/internal/workspaceprep/reconciler_test.go
+++ b/internal/workspaceprep/reconciler_test.go
@@ -973,7 +973,7 @@ func TestReconciler_InstanceRotationReplacesPreparedOnDisk(t *testing.T) {
 	require.NoError(t, err)
 
 	legacy := codeexecutor.WorkspaceMetadata{
-		Version:           1,
+		Version:    1,
 		InstanceID: "instance-1",
 		Prepared: map[string]codeexecutor.PreparedRecord{
 			reqA.Key(): {Key: reqA.Key()},

--- a/internal/workspaceprep/requirement.go
+++ b/internal/workspaceprep/requirement.go
@@ -146,6 +146,7 @@ type Reconciler interface {
 		ctx context.Context,
 		eng codeexecutor.Engine,
 		ws codeexecutor.Workspace,
+		instanceID codeexecutor.WorkspaceInstanceID,
 		reqs []Requirement,
 	) ([]string, error)
 }

--- a/internal/workspaceprep/requirement.go
+++ b/internal/workspaceprep/requirement.go
@@ -148,7 +148,7 @@ type Reconciler interface {
 	// preserves legacy behavior for managers without
 	// [codeexecutor.WorkspaceInstanceProvider]. A different non-empty
 	// instanceID invalidates previously prepared records before
-	// reconciliation and is persisted as backend_instance_id.
+	// reconciliation and is persisted as instance_id.
 	Reconcile(
 		ctx context.Context,
 		eng codeexecutor.Engine,

--- a/internal/workspaceprep/requirement.go
+++ b/internal/workspaceprep/requirement.go
@@ -142,6 +142,13 @@ type Reconciler interface {
 	// requirement failures. When a required requirement fails Apply,
 	// Reconcile returns the corresponding error and the remaining
 	// requirements are skipped.
+	//
+	// instanceID carries the physical workspace generation from
+	// [codeexecutor.WorkspaceHandle.InstanceID]. An empty value
+	// preserves legacy behavior for managers without
+	// [codeexecutor.WorkspaceInstanceProvider]. A different non-empty
+	// instanceID invalidates previously prepared records before
+	// reconciliation and is persisted as backend_instance_id.
 	Reconcile(
 		ctx context.Context,
 		eng codeexecutor.Engine,

--- a/internal/workspaceprep/requirement.go
+++ b/internal/workspaceprep/requirement.go
@@ -139,9 +139,11 @@ type Reconciler interface {
 	// Reconcile collects requirements from the provided list, decides
 	// which ones already satisfy the workspace, applies the rest in
 	// phase order, and returns warnings collected from optional
-	// requirement failures. When a required requirement fails Apply,
-	// Reconcile returns the corresponding error and the remaining
-	// requirements are skipped.
+	// requirement failures. commandMayHaveStarted reports whether an
+	// arbitrary bootstrap command may have started, so callers can avoid
+	// unsafe automatic replay after a later workspace generation change.
+	// When a required requirement fails Apply, Reconcile returns the
+	// corresponding error and the remaining requirements are skipped.
 	//
 	// instanceID carries the physical workspace generation from
 	// [codeexecutor.WorkspaceHandle.InstanceID]. An empty value
@@ -155,5 +157,5 @@ type Reconciler interface {
 		ws codeexecutor.Workspace,
 		instanceID codeexecutor.WorkspaceInstanceID,
 		reqs []Requirement,
-	) ([]string, error)
+	) (warnings []string, commandMayHaveStarted bool, err error)
 }

--- a/internal/workspaceprep/requirement.go
+++ b/internal/workspaceprep/requirement.go
@@ -146,9 +146,9 @@ type Reconciler interface {
 	// instanceID carries the physical workspace generation from
 	// [codeexecutor.WorkspaceHandle.InstanceID]. An empty value
 	// preserves legacy behavior for managers without
-	// [codeexecutor.WorkspaceInstanceProvider]. A different non-empty
-	// instanceID invalidates previously prepared records before
-	// reconciliation and is persisted as instance_id.
+	// [codeexecutor.WorkspaceInstanceProvider]. For a non-empty value,
+	// only prepared records from the same process-scoped generation
+	// may be reused.
 	Reconcile(
 		ctx context.Context,
 		eng codeexecutor.Engine,

--- a/internal/workspaceprep/skill_test.go
+++ b/internal/workspaceprep/skill_test.go
@@ -233,7 +233,7 @@ func TestSkillRequirement_EndToEndViaReconciler(t *testing.T) {
 	})
 	require.NoError(t, err)
 	rec := NewReconciler()
-	warnings, err := rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	warnings, _, err := rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	require.Empty(t, warnings)
 
@@ -244,7 +244,7 @@ func TestSkillRequirement_EndToEndViaReconciler(t *testing.T) {
 		ws.Path, "skills", "echoer", "SKILL.md",
 	))
 	require.NoError(t, err)
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	info2, err := os.Stat(filepath.Join(
 		ws.Path, "skills", "echoer", "SKILL.md",

--- a/internal/workspaceprep/skill_test.go
+++ b/internal/workspaceprep/skill_test.go
@@ -233,7 +233,7 @@ func TestSkillRequirement_EndToEndViaReconciler(t *testing.T) {
 	})
 	require.NoError(t, err)
 	rec := NewReconciler()
-	warnings, err := rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	warnings, err := rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	require.Empty(t, warnings)
 
@@ -244,7 +244,7 @@ func TestSkillRequirement_EndToEndViaReconciler(t *testing.T) {
 		ws.Path, "skills", "echoer", "SKILL.md",
 	))
 	require.NoError(t, err)
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	info2, err := os.Stat(filepath.Join(
 		ws.Path, "skills", "echoer", "SKILL.md",

--- a/internal/workspaceprep/specs_test.go
+++ b/internal/workspaceprep/specs_test.go
@@ -149,12 +149,12 @@ func TestCommandRequirement_FingerprintInputsChangeForcesReRun(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 
 	// Second reconcile with identical requirements.txt is a pure
 	// fingerprint+marker skip.
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err := os.ReadFile(counterPath)
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestCommandRequirement_FingerprintInputsChangeForcesReRun(t *testing.T) {
 
 	// Edit the input file; the next reconcile must re-run the command.
 	require.NoError(t, os.WriteFile(reqsPath, []byte("v2"), 0o644))
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err = os.ReadFile(counterPath)
 	require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestCommandRequirement_NonZeroExitFails(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exited 3")
 	require.Contains(t, err.Error(), "boom")
@@ -210,7 +210,7 @@ func TestCommandRequirement_NonZeroExitStdoutFallback(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exited 7")
 	require.Contains(t, err.Error(), "only-stdout")
@@ -242,13 +242,13 @@ func TestCommandRequirement_ObservedPathsSentinel(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 
 	require.NoError(t, os.Remove(
 		filepath.Join(ws.Path, "work/observed.txt"),
 	))
-	_, err = rec.Reconcile(ctx, eng, ws, []Requirement{req})
+	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err := os.ReadFile(filepath.Join(ws.Path, "work/observed.txt"))
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestReconciler_NilEngineReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	rec := NewReconciler()
 	_, err = rec.Reconcile(
-		context.Background(), nil, ws, []Requirement{req},
+		context.Background(), nil, ws, "", []Requirement{req},
 	)
 	require.Error(t, err)
 }
@@ -308,7 +308,7 @@ func TestReconciler_EmptyReqsIsNoop(t *testing.T) {
 	eng, ws := newTestEngine(t)
 	rec := NewReconciler()
 	warnings, err := rec.Reconcile(
-		context.Background(), eng, ws, nil,
+		context.Background(), eng, ws, "", nil,
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -331,7 +331,7 @@ func TestReconciler_DropsNilAndEmptyKeyedRequirements(t *testing.T) {
 
 	rec := NewReconciler()
 	warnings, err := rec.Reconcile(
-		ctx, eng, ws, []Requirement{nil, emptyKey, good},
+		ctx, eng, ws, "", []Requirement{nil, emptyKey, good},
 	)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
@@ -357,7 +357,7 @@ func TestReconciler_RequiredRequirementErrorBubbles(t *testing.T) {
 		applyErr: fmt.Errorf("boom"),
 	}
 	rec := NewReconciler()
-	_, err := rec.Reconcile(ctx, eng, ws, []Requirement{bad})
+	_, err := rec.Reconcile(ctx, eng, ws, "", []Requirement{bad})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bad")
 	require.Contains(t, err.Error(), "boom")

--- a/internal/workspaceprep/specs_test.go
+++ b/internal/workspaceprep/specs_test.go
@@ -149,12 +149,12 @@ func TestCommandRequirement_FingerprintInputsChangeForcesReRun(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 
 	// Second reconcile with identical requirements.txt is a pure
 	// fingerprint+marker skip.
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err := os.ReadFile(counterPath)
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestCommandRequirement_FingerprintInputsChangeForcesReRun(t *testing.T) {
 
 	// Edit the input file; the next reconcile must re-run the command.
 	require.NoError(t, os.WriteFile(reqsPath, []byte("v2"), 0o644))
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err = os.ReadFile(counterPath)
 	require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestCommandRequirement_NonZeroExitFails(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exited 3")
 	require.Contains(t, err.Error(), "boom")
@@ -210,7 +210,7 @@ func TestCommandRequirement_NonZeroExitStdoutFallback(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exited 7")
 	require.Contains(t, err.Error(), "only-stdout")
@@ -242,13 +242,13 @@ func TestCommandRequirement_ObservedPathsSentinel(t *testing.T) {
 	require.NoError(t, err)
 
 	rec := NewReconciler()
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 
 	require.NoError(t, os.Remove(
 		filepath.Join(ws.Path, "work/observed.txt"),
 	))
-	_, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
+	_, _, err = rec.Reconcile(ctx, eng, ws, "", []Requirement{req})
 	require.NoError(t, err)
 	got, err := os.ReadFile(filepath.Join(ws.Path, "work/observed.txt"))
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestReconciler_NilEngineReturnsError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	rec := NewReconciler()
-	_, err = rec.Reconcile(
+	_, _, err = rec.Reconcile(
 		context.Background(), nil, ws, "", []Requirement{req},
 	)
 	require.Error(t, err)
@@ -307,7 +307,7 @@ func TestReconciler_NilEngineReturnsError(t *testing.T) {
 func TestReconciler_EmptyReqsIsNoop(t *testing.T) {
 	eng, ws := newTestEngine(t)
 	rec := NewReconciler()
-	warnings, err := rec.Reconcile(
+	warnings, _, err := rec.Reconcile(
 		context.Background(), eng, ws, "", nil,
 	)
 	require.NoError(t, err)
@@ -330,7 +330,7 @@ func TestReconciler_DropsNilAndEmptyKeyedRequirements(t *testing.T) {
 	emptyKey := &orderReq{key: "", kind: KindFile, phase: PhaseFile}
 
 	rec := NewReconciler()
-	warnings, err := rec.Reconcile(
+	warnings, _, err := rec.Reconcile(
 		ctx, eng, ws, "", []Requirement{nil, emptyKey, good},
 	)
 	require.NoError(t, err)
@@ -357,7 +357,7 @@ func TestReconciler_RequiredRequirementErrorBubbles(t *testing.T) {
 		applyErr: fmt.Errorf("boom"),
 	}
 	rec := NewReconciler()
-	_, err := rec.Reconcile(ctx, eng, ws, "", []Requirement{bad})
+	_, _, err := rec.Reconcile(ctx, eng, ws, "", []Requirement{bad})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bad")
 	require.Contains(t, err.Error(), "boom")

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -704,7 +704,12 @@ func (t *ExecTool) executeWorkspaceAttempt(
 	}
 	req.workspaceHandle = handle
 	req.ws = handle.Workspace
-	if err := t.reconcileWorkspace(ctx, req.eng, req.ws); err != nil {
+	if err := t.reconcileWorkspace(
+		ctx,
+		req.eng,
+		req.ws,
+		req.workspaceHandle.InstanceID,
+	); err != nil {
 		return execOutput{}, true, err
 	}
 	if t.sessional {
@@ -1009,6 +1014,7 @@ func (t *ExecTool) reconcileWorkspace(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
+	instanceID codeexecutor.WorkspaceInstanceID,
 ) error {
 	if t == nil || len(t.providers) == 0 {
 		_, warnings, err := workspaceinput.StageConversationFiles(ctx, eng, ws)
@@ -1032,7 +1038,9 @@ func (t *ExecTool) reconcileWorkspace(
 		}
 		all = append(all, reqs...)
 	}
-	warnings, err := t.reconciler.Reconcile(ctx, eng, ws, all)
+	warnings, err := t.reconciler.Reconcile(
+		ctx, eng, ws, instanceID, all,
+	)
 	for _, warning := range warnings {
 		log.WarnfContext(
 			ctx,

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -704,6 +704,9 @@ func (t *ExecTool) executeWorkspaceAttempt(
 	}
 	req.workspaceHandle = handle
 	req.ws = handle.Workspace
+	if err := validateWorkspaceHandle(ctx, req.eng, handle); err != nil {
+		return execOutput{}, true, err
+	}
 	if err := t.reconcileWorkspace(
 		ctx,
 		req.eng,
@@ -712,12 +715,64 @@ func (t *ExecTool) executeWorkspaceAttempt(
 	); err != nil {
 		return execOutput{}, true, err
 	}
+	if err := validateWorkspaceHandle(ctx, req.eng, handle); err != nil {
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
+			// Reconcile may have started an arbitrary bootstrap command.
+			// Without an explicit success disposition, a post-reconcile
+			// generation change is invalidation-only and must not replay.
+			err = errors.Join(err, codeexecutor.ErrWorkspaceRetryUnsafe)
+		}
+		return execOutput{}, true, err
+	}
 	if t.sessional {
 		out, err := t.callSessional(ctx, *req)
 		return out, true, err
 	}
 	out, err := t.callNonSessional(ctx, *req)
 	return out, true, err
+}
+
+func validateWorkspaceHandle(
+	ctx context.Context,
+	eng codeexecutor.Engine,
+	handle codeexecutor.WorkspaceHandle,
+) error {
+	if handle.InstanceID == "" {
+		return nil
+	}
+	if eng == nil {
+		return errors.New("workspaceexec: workspace manager is unavailable")
+	}
+	manager := eng.Manager()
+	if manager == nil {
+		return errors.New("workspaceexec: workspace manager is unavailable")
+	}
+	provider, ok := manager.(codeexecutor.WorkspaceInstanceProvider)
+	if !ok {
+		return errors.New(
+			"workspaceexec: workspace manager lost instance identity capability",
+		)
+	}
+	current, err := provider.InstanceID(ctx)
+	if err != nil {
+		return fmt.Errorf("workspaceexec: validate workspace instance: %w", err)
+	}
+	if current == "" {
+		return errors.New(
+			"workspaceexec: workspace instance provider returned an empty instance ID",
+		)
+	}
+	if current == handle.InstanceID {
+		return nil
+	}
+	return errors.Join(
+		codeexecutor.ErrWorkspaceStale,
+		fmt.Errorf(
+			"workspaceexec: workspace instance changed from %q to %q",
+			handle.InstanceID,
+			current,
+		),
+	)
 }
 
 // checkCommandPolicy enforces the optional allow/deny lists. When no

--- a/tool/workspaceexec/workspace_exec.go
+++ b/tool/workspaceexec/workspace_exec.go
@@ -707,19 +707,21 @@ func (t *ExecTool) executeWorkspaceAttempt(
 	if err := validateWorkspaceHandle(ctx, req.eng, handle); err != nil {
 		return execOutput{}, true, err
 	}
-	if err := t.reconcileWorkspace(
+	commandMayHaveStarted, err := t.reconcileWorkspace(
 		ctx,
 		req.eng,
 		req.ws,
 		req.workspaceHandle.InstanceID,
-	); err != nil {
+	)
+	if err != nil {
 		return execOutput{}, true, err
 	}
 	if err := validateWorkspaceHandle(ctx, req.eng, handle); err != nil {
-		if errors.Is(err, codeexecutor.ErrWorkspaceStale) {
-			// Reconcile may have started an arbitrary bootstrap command.
-			// Without an explicit success disposition, a post-reconcile
-			// generation change is invalidation-only and must not replay.
+		if errors.Is(err, codeexecutor.ErrWorkspaceStale) &&
+			commandMayHaveStarted {
+			// Reconcile may have started an arbitrary bootstrap command,
+			// so a post-reconcile generation change is invalidation-only
+			// and must not replay automatically.
 			err = errors.Join(err, codeexecutor.ErrWorkspaceRetryUnsafe)
 		}
 		return execOutput{}, true, err
@@ -1064,13 +1066,14 @@ func (t *KillSessionTool) Call(_ context.Context, args []byte) (any, error) {
 // the function preserves the legacy behavior of staging conversation
 // files inline; otherwise it delegates to the reconciler which
 // collects Requirements from every provider and applies them in
-// phase order (file -> skill -> command).
+// phase order (file -> skill -> command). The returned boolean reports
+// whether a bootstrap command may have started.
 func (t *ExecTool) reconcileWorkspace(
 	ctx context.Context,
 	eng codeexecutor.Engine,
 	ws codeexecutor.Workspace,
 	instanceID codeexecutor.WorkspaceInstanceID,
-) error {
+) (bool, error) {
 	if t == nil || len(t.providers) == 0 {
 		_, warnings, err := workspaceinput.StageConversationFiles(ctx, eng, ws)
 		for _, warning := range warnings {
@@ -1080,20 +1083,20 @@ func (t *ExecTool) reconcileWorkspace(
 				warning,
 			)
 		}
-		return err
+		return false, err
 	}
 	inv, _ := agent.InvocationFromContext(ctx)
 	var all []workspaceprep.Requirement
 	for _, p := range t.providers {
 		reqs, err := p.Requirements(ctx, inv)
 		if err != nil {
-			return fmt.Errorf(
+			return false, fmt.Errorf(
 				"workspace_exec provider %s: %w", p.Name(), err,
 			)
 		}
 		all = append(all, reqs...)
 	}
-	warnings, err := t.reconciler.Reconcile(
+	warnings, commandMayHaveStarted, err := t.reconciler.Reconcile(
 		ctx, eng, ws, instanceID, all,
 	)
 	for _, warning := range warnings {
@@ -1104,9 +1107,11 @@ func (t *ExecTool) reconcileWorkspace(
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("workspace_exec reconcile: %w", err)
+		return commandMayHaveStarted, fmt.Errorf(
+			"workspace_exec reconcile: %w", err,
+		)
 	}
-	return nil
+	return commandMayHaveStarted, nil
 }
 
 func (t *ExecTool) liveEngine() (codeexecutor.Engine, error) {

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1925,6 +1925,144 @@ func (r *nonInteractiveRunner) RunProgram(
 	}, nil
 }
 
+func TestExecTool_InstanceRotationReRunsBootstrapCommand(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	rt := localexec.NewRuntimeWithOptions(
+		root,
+		localexec.WithRuntimeWorkspaceMode(
+			localexec.WorkspaceModeTrustedLocal,
+		),
+		localexec.WithAutoInputs(false),
+	)
+	manager := &instanceAwareTrustedManager{
+		Runtime:    rt,
+		instanceID: "instance-1",
+	}
+	reg := codeexecutor.NewWorkspaceRegistry()
+	runner := &bootstrapCountingRunner{inner: rt}
+	exec := &instanceAwareExec{
+		eng: codeexecutor.NewEngine(manager, rt, runner),
+	}
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceRegistry(reg),
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Commands: []codeexecutor.WorkspaceCommand{{
+				Cmd: "true",
+			}},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 1, runner.bootstrapCount(),
+		"bootstrap must run once on first workspace use")
+	require.Equal(t, 1, manager.createCount())
+
+	bootstrapBeforeRotate := runner.bootstrapCount()
+	manager.setInstanceID("instance-2")
+
+	got, err = tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount(),
+		"instance change must recreate the workspace")
+	require.Equal(t, bootstrapBeforeRotate+1, runner.bootstrapCount(),
+		"bootstrap must rerun after instance rotation")
+}
+
+type instanceAwareTrustedManager struct {
+	*localexec.Runtime
+
+	mu         sync.Mutex
+	instanceID codeexecutor.WorkspaceInstanceID
+	creates    int
+}
+
+func (m *instanceAwareTrustedManager) CreateWorkspace(
+	ctx context.Context,
+	id string,
+	pol codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.mu.Lock()
+	m.creates++
+	m.mu.Unlock()
+	return m.Runtime.CreateWorkspace(ctx, id, pol)
+}
+
+func (m *instanceAwareTrustedManager) InstanceID(
+	context.Context,
+) (codeexecutor.WorkspaceInstanceID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.instanceID, nil
+}
+
+func (m *instanceAwareTrustedManager) setInstanceID(
+	id codeexecutor.WorkspaceInstanceID,
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.instanceID = id
+}
+
+func (m *instanceAwareTrustedManager) createCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.creates
+}
+
+type instanceAwareExec struct {
+	eng codeexecutor.Engine
+}
+
+func (*instanceAwareExec) ExecuteCode(
+	context.Context,
+	codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	return codeexecutor.CodeExecutionResult{}, nil
+}
+
+func (*instanceAwareExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
+}
+
+func (e *instanceAwareExec) Engine() codeexecutor.Engine {
+	return e.eng
+}
+
+type bootstrapCountingRunner struct {
+	inner codeexecutor.ProgramRunner
+
+	mu     sync.Mutex
+	starts int
+}
+
+func (r *bootstrapCountingRunner) RunProgram(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	if spec.Cmd == "true" && len(spec.Args) == 0 {
+		r.mu.Lock()
+		r.starts++
+		r.mu.Unlock()
+	}
+	if r.inner == nil {
+		return codeexecutor.RunResult{ExitCode: 0}, nil
+	}
+	return r.inner.RunProgram(ctx, ws, spec)
+}
+
+func (r *bootstrapCountingRunner) bootstrapCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.starts
+}
+
 func boolPtr(v bool) *bool { return &v }
 
 func intPtr(v int) *int { return &v }

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1981,6 +1981,104 @@ func TestExecTool_InstanceRotationReRunsBootstrapCommand(t *testing.T) {
 		"bootstrap must rerun after instance rotation")
 }
 
+func TestExecTool_RotationAfterAcquireReconcilesReplacementBeforeUserCommand(
+	t *testing.T,
+) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	rt := localexec.NewRuntimeWithOptions(
+		root,
+		localexec.WithRuntimeWorkspaceMode(
+			localexec.WorkspaceModeTrustedLocal,
+		),
+		localexec.WithAutoInputs(false),
+	)
+	manager := &scriptedInstanceManager{
+		Runtime: rt,
+		probes: []codeexecutor.WorkspaceInstanceID{
+			"instance-1", // first create: before
+			"instance-1", // first create: after
+			"instance-2", // pre-reconcile fence observes rotation
+			"instance-2", // replacement create: before
+			"instance-2", // replacement create: after
+			"instance-2", // replacement pre-reconcile fence
+			"instance-2", // replacement post-reconcile fence
+		},
+	}
+	runner := &fenceOrderRunner{inner: rt}
+	exec := &instanceAwareExec{
+		eng: codeexecutor.NewEngine(manager, rt, runner),
+	}
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceRegistry(codeexecutor.NewWorkspaceRegistry()),
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Commands: []codeexecutor.WorkspaceCommand{{Cmd: "true"}},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount(),
+		"the stale acquired handle must be replaced exactly once")
+	require.Equal(t, []string{"bootstrap", "user"}, runner.eventsSnapshot(),
+		"the user command must start only after replacement bootstrap")
+}
+
+func TestExecTool_RotationDuringReconcileStopsBeforeUserCommand(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	rt := localexec.NewRuntimeWithOptions(
+		root,
+		localexec.WithRuntimeWorkspaceMode(
+			localexec.WorkspaceModeTrustedLocal,
+		),
+		localexec.WithAutoInputs(false),
+	)
+	manager := &scriptedInstanceManager{
+		Runtime: rt,
+		probes: []codeexecutor.WorkspaceInstanceID{
+			"instance-1", // first create: before
+			"instance-1", // first create: after
+			"instance-1", // first pre-reconcile fence
+			"instance-2", // first post-reconcile fence observes rotation
+			"instance-2", // next call create: before
+			"instance-2", // next call create: after
+			"instance-2", // next call pre-reconcile fence
+			"instance-2", // next call post-reconcile fence
+		},
+	}
+	runner := &fenceOrderRunner{inner: rt}
+	exec := &instanceAwareExec{
+		eng: codeexecutor.NewEngine(manager, rt, runner),
+	}
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceRegistry(codeexecutor.NewWorkspaceRegistry()),
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Commands: []codeexecutor.WorkspaceCommand{{Cmd: "true"}},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	_, err = tl.Call(context.Background(), args)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+	require.ErrorIs(t, err, codeexecutor.ErrWorkspaceRetryUnsafe)
+	require.Equal(t, []string{"bootstrap"}, runner.eventsSnapshot(),
+		"a post-reconcile rotation must stop before the user command")
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t,
+		[]string{"bootstrap", "bootstrap", "user"},
+		runner.eventsSnapshot(),
+		"the next call must reconcile the replacement before user execution",
+	)
+}
+
 type instanceAwareTrustedManager struct {
 	*localexec.Runtime
 
@@ -2022,6 +2120,48 @@ func (m *instanceAwareTrustedManager) createCount() int {
 	return m.creates
 }
 
+type scriptedInstanceManager struct {
+	*localexec.Runtime
+
+	mu      sync.Mutex
+	probes  []codeexecutor.WorkspaceInstanceID
+	current codeexecutor.WorkspaceInstanceID
+	creates int
+}
+
+func (m *scriptedInstanceManager) CreateWorkspace(
+	ctx context.Context,
+	id string,
+	pol codeexecutor.WorkspacePolicy,
+) (codeexecutor.Workspace, error) {
+	m.mu.Lock()
+	m.creates++
+	m.mu.Unlock()
+	return m.Runtime.CreateWorkspace(ctx, id, pol)
+}
+
+func (m *scriptedInstanceManager) InstanceID(
+	context.Context,
+) (codeexecutor.WorkspaceInstanceID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.probes) == 0 {
+		if m.current == "" {
+			return "", errors.New("unexpected instance probe")
+		}
+		return m.current, nil
+	}
+	m.current = m.probes[0]
+	m.probes = m.probes[1:]
+	return m.current, nil
+}
+
+func (m *scriptedInstanceManager) createCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.creates
+}
+
 type instanceAwareExec struct {
 	eng codeexecutor.Engine
 }
@@ -2046,6 +2186,38 @@ type bootstrapCountingRunner struct {
 
 	mu     sync.Mutex
 	starts int
+}
+
+type fenceOrderRunner struct {
+	inner codeexecutor.ProgramRunner
+
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *fenceOrderRunner) RunProgram(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	event := ""
+	if spec.Cmd == "true" && len(spec.Args) == 0 {
+		event = "bootstrap"
+	} else if spec.Cmd == "sh" {
+		event = "user"
+	}
+	if event != "" {
+		r.mu.Lock()
+		r.events = append(r.events, event)
+		r.mu.Unlock()
+	}
+	return r.inner.RunProgram(ctx, ws, spec)
+}
+
+func (r *fenceOrderRunner) eventsSnapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
 }
 
 func (r *bootstrapCountingRunner) RunProgram(

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1962,6 +1962,13 @@ func TestExecTool_InstanceRotationReRunsBootstrapCommand(t *testing.T) {
 		"bootstrap must run once on first workspace use")
 	require.Equal(t, 1, manager.createCount())
 
+	got, err = tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 1, runner.bootstrapCount(),
+		"same instance should skip bootstrap on cache hit")
+	require.Equal(t, 1, manager.createCount())
+
 	bootstrapBeforeRotate := runner.bootstrapCount()
 	manager.setInstanceID("instance-2")
 

--- a/tool/workspaceexec/workspace_exec_test.go
+++ b/tool/workspaceexec/workspace_exec_test.go
@@ -1925,6 +1925,97 @@ func (r *nonInteractiveRunner) RunProgram(
 	}, nil
 }
 
+func TestValidateWorkspaceHandle(t *testing.T) {
+	handle := codeexecutor.WorkspaceHandle{
+		InstanceID: "instance-1",
+	}
+	tests := []struct {
+		name    string
+		eng     codeexecutor.Engine
+		handle  codeexecutor.WorkspaceHandle
+		wantErr string
+		stale   bool
+	}{
+		{
+			name:   "legacy handle needs no provider",
+			handle: codeexecutor.WorkspaceHandle{},
+		},
+		{
+			name:    "missing engine",
+			handle:  handle,
+			wantErr: "workspace manager is unavailable",
+		},
+		{
+			name: "missing manager",
+			eng: codeexecutor.NewEngine(
+				nil, nil, nil,
+			),
+			handle:  handle,
+			wantErr: "workspace manager is unavailable",
+		},
+		{
+			name: "manager loses instance identity capability",
+			eng: codeexecutor.NewEngine(
+				&nonInteractiveMgr{}, nil, nil,
+			),
+			handle:  handle,
+			wantErr: "lost instance identity capability",
+		},
+		{
+			name: "instance probe fails",
+			eng: codeexecutor.NewEngine(
+				&scriptedInstanceManager{}, nil, nil,
+			),
+			handle:  handle,
+			wantErr: "validate workspace instance: unexpected instance probe",
+		},
+		{
+			name: "instance provider returns empty ID",
+			eng: codeexecutor.NewEngine(
+				&instanceAwareTrustedManager{}, nil, nil,
+			),
+			handle:  handle,
+			wantErr: "instance provider returned an empty instance ID",
+		},
+		{
+			name: "instance remains current",
+			eng: codeexecutor.NewEngine(
+				&instanceAwareTrustedManager{instanceID: "instance-1"},
+				nil,
+				nil,
+			),
+			handle: handle,
+		},
+		{
+			name: "instance changed",
+			eng: codeexecutor.NewEngine(
+				&instanceAwareTrustedManager{instanceID: "instance-2"},
+				nil,
+				nil,
+			),
+			handle:  handle,
+			wantErr: "workspace instance changed from \"instance-1\" to \"instance-2\"",
+			stale:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWorkspaceHandle(
+				context.Background(), tt.eng, tt.handle,
+			)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+			if tt.stale {
+				require.ErrorIs(t, err, codeexecutor.ErrWorkspaceStale)
+			}
+		})
+	}
+}
+
 func TestExecTool_InstanceRotationReRunsBootstrapCommand(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "workspace")
 	rt := localexec.NewRuntimeWithOptions(
@@ -2076,6 +2167,62 @@ func TestExecTool_RotationDuringReconcileStopsBeforeUserCommand(t *testing.T) {
 		[]string{"bootstrap", "bootstrap", "user"},
 		runner.eventsSnapshot(),
 		"the next call must reconcile the replacement before user execution",
+	)
+}
+
+func TestExecTool_RotationAfterCachedReconcileRetriesSafely(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	rt := localexec.NewRuntimeWithOptions(
+		root,
+		localexec.WithRuntimeWorkspaceMode(
+			localexec.WorkspaceModeTrustedLocal,
+		),
+		localexec.WithAutoInputs(false),
+	)
+	manager := &scriptedInstanceManager{
+		Runtime: rt,
+		probes: []codeexecutor.WorkspaceInstanceID{
+			"instance-1", // initial create: before
+			"instance-1", // initial create: after
+			"instance-1", // initial pre-reconcile fence
+			"instance-1", // initial post-reconcile fence
+			"instance-1", // cached acquire
+			"instance-1", // cached pre-reconcile fence
+			"instance-2", // cached post-reconcile fence observes rotation
+			"instance-2", // replacement create: before
+			"instance-2", // replacement create: after
+			"instance-2", // replacement pre-reconcile fence
+			"instance-2", // replacement post-reconcile fence
+		},
+	}
+	runner := &fenceOrderRunner{inner: rt}
+	exec := &instanceAwareExec{
+		eng: codeexecutor.NewEngine(manager, rt, runner),
+	}
+	tl := NewExecTool(
+		exec,
+		WithWorkspaceRegistry(codeexecutor.NewWorkspaceRegistry()),
+		WithWorkspaceBootstrap(codeexecutor.WorkspaceBootstrapSpec{
+			Commands: []codeexecutor.WorkspaceCommand{{Cmd: "true"}},
+		}),
+	)
+	args, err := json.Marshal(execInput{Command: "printf ok"})
+	require.NoError(t, err)
+
+	got, err := tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 1, manager.createCount())
+
+	got, err = tl.Call(context.Background(), args)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got.(execOutput).Output)
+	require.Equal(t, 2, manager.createCount(),
+		"a safe post-reconcile rotation must reacquire exactly once")
+	require.Equal(t,
+		[]string{"bootstrap", "user", "bootstrap", "user"},
+		runner.eventsSnapshot(),
+		"a skipped cached command must permit replacement reconciliation",
 	)
 }
 


### PR DESCRIPTION
## Summary

- Scope every persisted `PreparedRecord` to an opaque, process-scoped workspace generation derived from the process epoch and `WorkspaceHandle.InstanceID`.
- Keep metadata merging per record; do not persist a global workspace instance ID and do not clear the complete `Prepared` table on rotation.
- Fence instance rotation both before and after workspace reconciliation.
- Automatically reacquire and retry after a post-reconcile rotation only when no bootstrap command may have started; otherwise return the existing retry-unsafe disposition.
- Preserve the historical persisted-cache behavior for managers that do not implement `WorkspaceInstanceProvider`.

## Why

PR #2301 refreshes cached workspace handles when a `WorkspaceInstanceProvider` reports a replacement physical instance. Deterministic workspace paths can still retain `Prepared` metadata from the previous instance, so marker-less bootstrap commands could be skipped on an instance where they never ran.

A workspace-wide persisted instance ID is not sufficient:

- provider IDs are guaranteed unique only within one process, while metadata may survive process restart;
- clearing or replacing the complete `Prepared` table couples unrelated records;
- two independent rotation writers can save in an order that lets stale prepared state appear current.

Per-record generation provenance makes the skip decision local: a record is reusable only when its fingerprint, sentinel, and generation all match. A late old-generation writer may cause a safe reapply, but cannot authorize a false skip on the current generation.

## Behavior and compatibility

| Area | Behavior |
| --- | --- |
| Legacy managers without `WorkspaceInstanceProvider` | Unchanged. Generation remains empty and existing persisted records retain their prior cache behavior. |
| Instance-aware managers | Existing legacy records are treated as untrusted once and active requirements are reconciled into the current generation. |
| Backend rotation | Active bootstrap requirements are reconciled again for the replacement generation. |
| Process restart | The process epoch changes, so instance-aware records are reconciled again even if the provider reuses the same instance ID. |
| Concurrent rotation writers | Metadata remains a per-key overlay. A stale record retains its stale generation and therefore cannot satisfy a later current-generation reconcile. |
| Rotation before reconcile | The stale handle is invalidated and safely reacquired. |
| Rotation after reconcile | Automatic retry occurs when no bootstrap command may have started. If a command may have started, the error is marked retry-unsafe and the user command is not started. |
| JSON metadata | `PreparedRecord.Generation` is additive and uses `omitempty`; old metadata remains readable and legacy records deserialize with an empty generation. |
| Go source API | `PreparedRecord` gains the exported `Generation` field. Keyed composite literals remain compatible; external unkeyed literals must add the new field or migrate to keyed literals. |

Bootstrap commands already have eventual-convergence rather than exactly-once semantics and should be replay-safe. For instance-aware deployments, plan for reconciliation after upgrade, backend rotation, and each process restart.

## Test coverage

Regression coverage includes:

- unchanged instance and backend rotation;
- legacy managers and legacy JSON records;
- process restart with a reused provider instance ID;
- marker-less commands;
- partial metadata saves;
- two independent concurrent rotation writers with the older writer saving last;
- rotation after handle acquisition;
- rotation during reconciliation after a command may have started;
- safe automatic retry when a cached command was skipped before the post-reconcile rotation;
- workspace-handle validation failures and generation edge cases.

Incremental coverage against `main`:

- executable lines: **94.6%**;
- overlapping-block statements: **93.3%**.

## Validation

- `go test ./...`
- `go test -race ./internal/workspaceprep ./tool/workspaceexec -count=1`
- `go build ./...`
- `git diff --check`
- `gofmt` on all changed Go files
