### PR TITLE
{server/agui, docs}: merge object state into runtime state by default

### DIFF
--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -22,7 +22,7 @@ type RunAgentInput struct {
 	ThreadID       string          // Conversation thread ID. The framework uses it as SessionID.
 	RunID          string          // Run ID, used to correlate run lifecycle events.
 	ParentRunID    *string         // Parent run ID. Optional.
-	State          any             // Arbitrary state that can be written into RuntimeState through StateResolver.
+	State          any             // Arbitrary state; object-shaped values are merged into RuntimeState by default.
 	Messages       []Message       // Message list used to pass the current user input or external tool results.
 	Tools          []Tool          // Tool definitions. Protocol field. Optional.
 	Context        []Context       // Context list. Protocol field. Optional.
@@ -315,11 +315,13 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithRunOptio
 
 ## Custom `StateResolver`
 
-`StateResolver` converts `RunAgentInput.State` into RuntimeState for the current run. The returned map is passed to Runner as `agent.WithRuntimeState(...)` and only affects the current run.
+By default, object-shaped `RunAgentInput.State` is merged into RuntimeState for the current run. Existing RuntimeState keys are preserved, while AG-UI state wins when the same key is present in both maps. Non-object state is not projected automatically.
+
+`StateResolver` customizes this conversion when the state must be filtered, renamed, or converted. Its returned map is merged into RuntimeState with `agent.MergeRuntimeState(...)` and only affects the current run. AG-UI state is supplied by the client; filter security-sensitive values instead of treating them as trusted server context.
 
 An LLMAgent can read a resolved value in its `Instruction` or `SystemPrompt` with a `{runtime:key}` placeholder. Use `{runtime:key?}` when the value is optional.
 
-Returning `nil` means RuntimeState is not set. Returning an empty map sets an empty RuntimeState.
+Returning `nil` means no state is merged. Returning an empty map does not add any values.
 
 ```go
 import (

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -22,7 +22,7 @@ type RunAgentInput struct {
 	ThreadID       string          // 会话线程 ID，框架会将其作为 SessionID。
 	RunID          string          // 本次运行 ID，用于关联运行生命周期事件。
 	ParentRunID    *string         // 父运行 ID，可选。
-	State          any             // 任意状态，可通过 StateResolver 写入 RuntimeState。
+	State          any             // 任意状态；对象类型的值默认会合并到 RuntimeState。
 	Messages       []Message       // 消息列表，用于传递本次用户输入或外部工具结果。
 	Tools          []Tool          // 工具定义列表，协议字段，可选。
 	Context        []Context       // 上下文列表，协议字段，可选。
@@ -315,11 +315,13 @@ server, _ := agui.New(runner, agui.WithAGUIRunnerOptions(aguirunner.WithRunOptio
 
 ## 自定义 `StateResolver`
 
-`StateResolver` 用于把 `RunAgentInput.State` 转换为本次运行的 RuntimeState。返回的 map 会作为 `agent.WithRuntimeState(...)` 传入 Runner，只作用于当前这次运行。
+默认情况下，对象类型的 `RunAgentInput.State` 会合并到本次运行的 RuntimeState 中。RuntimeState 中不冲突的已有字段会保留；如果存在同名字段，则以 AG-UI state 为准。非对象类型的 state 不会被自动投影。
+
+当需要过滤、重命名或转换 state 时，可以通过 `StateResolver` 自定义转换逻辑。它返回的 map 会通过 `agent.MergeRuntimeState(...)` 合并到 RuntimeState 中，只作用于当前这次运行。AG-UI state 由客户端提供；涉及安全敏感值时，应先进行过滤，不应将其当作可信的服务端上下文。
 
 LLMAgent 可以在 `Instruction` 或 `SystemPrompt` 中通过 `{runtime:key}` 读取解析后的值；如果该值可选，则使用 `{runtime:key?}`。
 
-返回 `nil` 表示不设置 RuntimeState；返回空 map 表示设置一个空的 RuntimeState。
+返回 `nil` 表示不合并 state；返回空 map 不会添加任何字段。
 
 ```go
 import (

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -180,10 +180,13 @@ func WithSessionService(s session.Service) Option {
 	}
 }
 
-// StateResolver is a function that derives runtime state for an AG-UI run.
+// StateResolver derives runtime state for an AG-UI run.
 type StateResolver func(ctx context.Context, input *adapter.RunAgentInput) (map[string]any, error)
 
-// WithStateResolver sets the runtime state resolver.
+// WithStateResolver sets a custom runtime state resolver.
+//
+// By default, object-shaped AG-UI state is merged into runtime state. A custom
+// resolver can filter, rename, or convert the client-provided state.
 func WithStateResolver(r StateResolver) Option {
 	return func(o *Options) {
 		o.StateResolver = r
@@ -390,9 +393,13 @@ func defaultRunOptionResolver(ctx context.Context, input *adapter.RunAgentInput)
 	return nil, nil
 }
 
-// defaultStateResolver returns no runtime state.
-func defaultStateResolver(ctx context.Context, input *adapter.RunAgentInput) (map[string]any, error) {
-	return nil, nil
+// defaultStateResolver forwards object-shaped AG-UI state as runtime state.
+func defaultStateResolver(_ context.Context, input *adapter.RunAgentInput) (map[string]any, error) {
+	if input == nil {
+		return nil, nil
+	}
+	state, _ := input.State.(map[string]any)
+	return state, nil
 }
 
 // defaultStartSpan returns the original context and a non-recording span.

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -89,6 +89,31 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Equal(t, time.Second, opts.DistributedCancelPollInterval)
 }
 
+func TestDefaultStateResolver(t *testing.T) {
+	t.Run("object state", func(t *testing.T) {
+		state := map[string]any{"document": "hello"}
+		resolved, err := defaultStateResolver(context.Background(), &adapter.RunAgentInput{
+			State: state,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, state, resolved)
+	})
+
+	t.Run("non-object state", func(t *testing.T) {
+		resolved, err := defaultStateResolver(context.Background(), &adapter.RunAgentInput{
+			State: "hello",
+		})
+		require.NoError(t, err)
+		assert.Nil(t, resolved)
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		resolved, err := defaultStateResolver(context.Background(), nil)
+		require.NoError(t, err)
+		assert.Nil(t, resolved)
+	})
+}
+
 func TestWithUserIDResolver(t *testing.T) {
 	wantErr := errors.New("resolver error")
 	called := false

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -386,7 +386,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 		return nil, fmt.Errorf("resolve state: %w", err)
 	}
 	if runtimeState != nil {
-		runOption = append(runOption, agent.WithRuntimeState(runtimeState))
+		runOption = append(runOption, agent.MergeRuntimeState(runtimeState))
 	}
 	if len(messages.toolMessages) > 0 {
 		runOption = append(runOption, withToolResultMessageRewriter(messages.toolMessages))

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -3524,7 +3524,7 @@ func TestRunRunOptionResolverOptions(t *testing.T) {
 	assert.Equal(t, 1, underlying.calls)
 }
 
-func TestRunStateResolverOverridesRuntimeState(t *testing.T) {
+func TestRunStateResolverMergesRuntimeState(t *testing.T) {
 	var runOpts agent.RunOptions
 	underlying := &fakeRunner{
 		run: func(ctx context.Context,
@@ -3568,8 +3568,37 @@ func TestRunStateResolverOverridesRuntimeState(t *testing.T) {
 	require.NotNil(t, runOpts.RuntimeState)
 	assert.Equal(t, "v1", runOpts.RuntimeState["k1"])
 	assert.Equal(t, "from-state", runOpts.RuntimeState[graph.CfgKeyLineageID])
-	_, ok := runOpts.RuntimeState["k2"]
-	assert.False(t, ok)
+	assert.Equal(t, "v2", runOpts.RuntimeState["k2"])
+}
+
+func TestRunDefaultStateResolverForwardsObjectState(t *testing.T) {
+	var runOpts agent.RunOptions
+	underlying := &fakeRunner{
+		run: func(ctx context.Context,
+			userID, sessionID string,
+			message model.Message,
+			opts ...agent.RunOption) (<-chan *agentevent.Event, error) {
+			for _, opt := range opts {
+				opt(&runOpts)
+			}
+			ch := make(chan *agentevent.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	r := New(underlying)
+	input := &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		State:    map[string]any{"document": "hello"},
+		Messages: []types.Message{{Role: types.RoleUser, Content: "hi"}},
+	}
+	eventsCh, err := r.Run(context.Background(), input)
+	require.NoError(t, err)
+	_ = collectEvents(t, eventsCh)
+
+	require.NotNil(t, runOpts.RuntimeState)
+	assert.Equal(t, "hello", runOpts.RuntimeState["document"])
 }
 
 func TestRunStateResolverError(t *testing.T) {


### PR DESCRIPTION
## What changed

Object-shaped AG-UI `RunAgentInput.State` is now merged into the current run's `RuntimeState` by default. Applications can use `{runtime:key}` placeholders without configuring a pass-through `StateResolver`; custom resolvers remain available for filtering, renaming, and conversion.

## Why

AG-UI state is a standard run input, and integrations that consume it currently have to repeat the same resolver solely to expose it to agents. Providing the common object-state mapping by default keeps integrations focused on their behavior while preserving the customization point for other state shapes and trust policies.

Updates ag-ui-protocol/ag-ui#1224

## Testing

- `cd server/agui && go test ./...`
- `gofmt -l runner/options.go runner/options_test.go runner/runner.go runner/runner_test.go`
- `git diff --check`

## Notes for reviewers

This changes the default AG-UI runner contract. Object state is merged rather than replacing the complete `RuntimeState`: existing non-conflicting server values are retained, and AG-UI state wins on key collisions. Non-object state is not projected automatically. Because AG-UI state is client-provided, applications should continue using `WithStateResolver` when security-sensitive values require filtering or remapping.
