### PR TITLE
tool/hostexec: detach stdin on the foreground exec path

### DIFF
--- a/tool/hostexec/hostexec_linux_test.go
+++ b/tool/hostexec/hostexec_linux_test.go
@@ -29,7 +29,7 @@ func TestApplyParentDeathSignal(t *testing.T) {
 
 func TestPrepareCommandsParentDeathSignal(t *testing.T) {
 	pipeCmd := &exec.Cmd{}
-	preparePipeCommand(pipeCmd)
+	preparePipeCommand(pipeCmd, keepStdin)
 	require.NotNil(t, pipeCmd.SysProcAttr)
 	require.Equal(t, syscall.SIGTERM, pipeCmd.SysProcAttr.Pdeathsig)
 

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -222,6 +222,42 @@ func TestNewToolSet_WriteStdin(t *testing.T) {
 	require.Contains(t, all, "got:hi")
 }
 
+// A foreground session is never registered with the manager, so write_stdin can
+// never reach it. Holding a stdin pipe open for it only lets a command that
+// prompts block until the run timeout kills it; detached, the read hits EOF and
+// the command returns. Without the detach this test fails by timing out.
+func TestNewToolSet_ForegroundDetachesStdin(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet()
+	require.NoError(t, err)
+	defer set.Close()
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		15*time.Second,
+	)
+	defer cancel()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		ctx,
+		mustJSON(t, map[string]any{
+			"command": `if read -r line; ` +
+				`then echo prompted:$line; ` +
+				`else echo reached-eof; fi`,
+			"yieldMs": 0,
+		}),
+	)
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	require.Equal(t, programStatusExited, res["status"])
+	require.Contains(t, outputField(res), "reached-eof")
+}
+
 func TestNewToolSet_WriteStdin_ReturnsWhenProcessExits(t *testing.T) {
 	if _, _, err := shellSpec(); err != nil {
 		t.Skip(err.Error())

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -222,43 +222,6 @@ func TestNewToolSet_WriteStdin(t *testing.T) {
 	require.Contains(t, all, "got:hi")
 }
 
-// A foreground session is never registered with the manager, so write_stdin can
-// never reach it. Holding a stdin pipe open for it only lets a command that
-// prompts block until the run timeout kills it; detached, the read hits EOF and
-// the command returns. Without the detach this test fails by timing out.
-func TestNewToolSet_ForegroundDetachesStdin(t *testing.T) {
-	if _, _, err := shellSpec(); err != nil {
-		t.Skip(err.Error())
-	}
-
-	set, err := NewToolSet()
-	require.NoError(t, err)
-	defer set.Close()
-
-	ctx, cancel := context.WithTimeout(
-		context.Background(),
-		15*time.Second,
-	)
-	defer cancel()
-
-	execTool, _, _, _ := toolSetTools(t, set)
-	out, err := execTool.Call(
-		ctx,
-		mustJSON(t, map[string]any{
-			"command": `if read -r line; ` +
-				`then echo prompted:$line; ` +
-				`else echo reached-eof; fi`,
-			"yieldMs": 0,
-		}),
-	)
-	require.NoError(t, err)
-
-	res := out.(map[string]any)
-	require.Equal(t, programStatusExited, res["status"])
-	require.Contains(t, outputField(res), "reached-eof")
-	require.EqualValues(t, 0, res["exit_code"])
-}
-
 func TestNewToolSet_WriteStdin_ReturnsWhenProcessExits(t *testing.T) {
 	if _, _, err := shellSpec(); err != nil {
 		t.Skip(err.Error())

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -256,6 +256,7 @@ func TestNewToolSet_ForegroundDetachesStdin(t *testing.T) {
 	res := out.(map[string]any)
 	require.Equal(t, programStatusExited, res["status"])
 	require.Contains(t, outputField(res), "reached-eof")
+	require.EqualValues(t, 0, res["exit_code"])
 }
 
 func TestNewToolSet_WriteStdin_ReturnsWhenProcessExits(t *testing.T) {

--- a/tool/hostexec/hostexec_tty_unix_test.go
+++ b/tool/hostexec/hostexec_tty_unix_test.go
@@ -1,0 +1,177 @@
+//go:build !windows
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hostexec
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/require"
+)
+
+// ttyProbeEnv marks the inner run of this test, the one that actually has a
+// controlling terminal to lose.
+const ttyProbeEnv = "TRPC_HOSTEXEC_TTY_PROBE"
+
+// Markers the inner run prints so the outer run can tell the two outcomes apart
+// without depending on the shell's wording.
+const (
+	ttyReachableMarker = "hostexec-tty-reachable"
+	ttyDetachedMarker  = "hostexec-tty-detached"
+)
+
+// ttyProbeResultPrefix labels the one line the inner run writes to the PTY, so
+// the outer run reads the probe's verdict rather than scraping test output.
+const ttyProbeResultPrefix = "hostexec-tty-probe:"
+
+// A nil stdin is not enough to keep a prompt away from a foreground command.
+//
+// Leaving cmd.Stdin nil points fd 0 at the null device, but the child still
+// inherits the host process's controlling terminal, and the prompts that matter
+// bypass fd 0 entirely: sudo, ssh, git, and Python's getpass open /dev/tty
+// directly. Setpgid only moves the child into a background process group, which
+// makes it worse — a read from the terminal there raises SIGTTIN and stops the
+// child, so the prompt hangs until the run's timeout rather than failing.
+//
+// The test needs a controlling terminal to prove that, and a Go test process
+// does not have one. So it re-runs itself under a PTY: pty.Start gives the inner
+// run a new session with the PTY as its controlling terminal, and the inner run
+// then goes through the ordinary foreground exec path and reports whether its
+// child could still reach /dev/tty.
+//
+// Opening is the assertion rather than reading, because opening is the
+// precondition for the hang and it fails fast in both directions — a read would
+// make the pre-fix case prove itself by timing out.
+func TestForegroundDetachesControllingTerminal(t *testing.T) {
+	if os.Getenv(ttyProbeEnv) == "1" {
+		runControllingTerminalProbe(t)
+		return
+	}
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	inner := exec.Command(
+		os.Args[0],
+		"-test.run=^TestForegroundDetachesControllingTerminal$",
+		"-test.timeout=60s",
+	)
+	inner.Env = append(os.Environ(), ttyProbeEnv+"=1")
+
+	master, err := pty.Start(inner)
+	if err != nil {
+		t.Skipf("no PTY available on this host: %v", err)
+	}
+	defer func() {
+		_ = master.Close()
+		_ = inner.Process.Kill()
+		_, _ = inner.Process.Wait()
+	}()
+
+	output := readUntilExit(t, master, inner, 60*time.Second)
+
+	require.Contains(t, output, ttyProbeResultPrefix,
+		"the inner run never reported a verdict; output:\n%s", output)
+	require.Contains(t, output, ttyProbeResultPrefix+ttyDetachedMarker,
+		"a foreground child must not be able to open the caller's terminal;\n"+
+			"inner run output:\n%s", output)
+	require.NotContains(t, output, ttyReachableMarker)
+}
+
+// runControllingTerminalProbe is the inner half. It has a controlling terminal
+// because pty.Start gave it one, and it checks whether the foreground exec path
+// passes that terminal on to the command it runs.
+func runControllingTerminalProbe(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+	// Without a controlling terminal of its own there is nothing for the child to
+	// inherit, so the probe would pass for the wrong reason.
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("inner run has no controlling terminal: %v", err)
+	}
+	_ = tty.Close()
+
+	set, err := NewToolSet()
+	require.NoError(t, err)
+	defer set.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		ctx,
+		mustJSON(t, map[string]any{
+			"command": "if (exec 3</dev/tty) 2>/dev/null; " +
+				"then echo " + ttyReachableMarker + "; " +
+				"else echo " + ttyDetachedMarker + "; fi",
+			"yieldMs": 0,
+		}),
+	)
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	// Report to the PTY before asserting, so the outer run sees the outcome
+	// whichever way it went and can name it in its own failure message.
+	fmt.Printf("%s%s\n", ttyProbeResultPrefix, outputField(res))
+
+	require.Equal(t, programStatusExited, res["status"])
+	require.Contains(t, outputField(res), ttyDetachedMarker)
+}
+
+// readUntilExit drains the PTY until the inner run exits. A PTY read returns
+// EIO rather than EOF once the last slave handle closes, so any read error ends
+// the loop and the collected output is what the caller inspects.
+func readUntilExit(
+	t *testing.T,
+	master *os.File,
+	inner *exec.Cmd,
+	timeout time.Duration,
+) string {
+	t.Helper()
+
+	var builder strings.Builder
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := master.Read(buf)
+			if n > 0 {
+				builder.Write(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		_ = inner.Process.Kill()
+		<-done
+		t.Fatalf("inner run did not finish within %s; output so far:\n%s",
+			timeout, builder.String())
+	}
+	_, _ = io.Copy(io.Discard, master)
+	return builder.String()
+}

--- a/tool/hostexec/hostexec_tty_unix_test.go
+++ b/tool/hostexec/hostexec_tty_unix_test.go
@@ -40,6 +40,11 @@ const (
 // the outer run reads the probe's verdict rather than scraping test output.
 const ttyProbeResultPrefix = "hostexec-tty-probe:"
 
+// ttyProbeSkipPrefix labels an unmet precondition in the inner run. Without it
+// the outer run sees only a missing verdict and reports a failure, when what
+// happened is that the probe never ran.
+const ttyProbeSkipPrefix = "hostexec-tty-skip:"
+
 // A nil stdin is not enough to keep a prompt away from a foreground command.
 //
 // Leaving cmd.Stdin nil points fd 0 at the null device, but the child still
@@ -86,6 +91,10 @@ func TestForegroundDetachesControllingTerminal(t *testing.T) {
 
 	output := readUntilExit(t, master, inner, 60*time.Second)
 
+	if idx := strings.Index(output, ttyProbeSkipPrefix); idx >= 0 {
+		t.Skipf("inner run could not run the probe: %s",
+			strings.SplitN(output[idx:], "\n", 2)[0])
+	}
 	require.Contains(t, output, ttyProbeResultPrefix,
 		"the inner run never reported a verdict; output:\n%s", output)
 	require.Contains(t, output, ttyProbeResultPrefix+ttyDetachedMarker,
@@ -99,13 +108,13 @@ func TestForegroundDetachesControllingTerminal(t *testing.T) {
 // passes that terminal on to the command it runs.
 func runControllingTerminalProbe(t *testing.T) {
 	if _, _, err := shellSpec(); err != nil {
-		t.Skip(err.Error())
+		skipProbe(t, err.Error())
 	}
 	// Without a controlling terminal of its own there is nothing for the child to
 	// inherit, so the probe would pass for the wrong reason.
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
 	if err != nil {
-		t.Skipf("inner run has no controlling terminal: %v", err)
+		skipProbe(t, fmt.Sprintf("inner run has no controlling terminal: %v", err))
 	}
 	_ = tty.Close()
 
@@ -135,6 +144,15 @@ func runControllingTerminalProbe(t *testing.T) {
 
 	require.Equal(t, programStatusExited, res["status"])
 	require.Contains(t, outputField(res), ttyDetachedMarker)
+}
+
+// skipProbe tells the outer run over the PTY why the probe did not run, then
+// skips. The marker is what keeps an unmet precondition from surfacing as a
+// missing verdict.
+func skipProbe(t *testing.T, reason string) {
+	t.Helper()
+	fmt.Printf("%s%s\n", ttyProbeSkipPrefix, reason)
+	t.Skip(reason)
 }
 
 // readUntilExit drains the PTY until the inner run exits. A PTY read returns

--- a/tool/hostexec/hostexec_unix_test.go
+++ b/tool/hostexec/hostexec_unix_test.go
@@ -57,13 +57,24 @@ func waitForProcessExit(
 }
 
 func TestPrepareCommands(t *testing.T) {
-	preparePipeCommand(nil)
+	preparePipeCommand(nil, keepStdin)
+	preparePipeCommand(nil, detachStdin)
 	preparePTYCommand(nil)
 
 	pipeCmd := &exec.Cmd{}
-	preparePipeCommand(pipeCmd)
+	preparePipeCommand(pipeCmd, keepStdin)
 	require.NotNil(t, pipeCmd.SysProcAttr)
 	require.True(t, pipeCmd.SysProcAttr.Setpgid)
+	require.False(t, pipeCmd.SysProcAttr.Setsid)
+
+	// The detached child gives up the controlling terminal instead. Setsid makes
+	// it a process-group leader too, so terminateProcessTree still reaches the
+	// tree; setting Setpgid alongside it would make the exec fail with EPERM.
+	detachedCmd := &exec.Cmd{}
+	preparePipeCommand(detachedCmd, detachStdin)
+	require.NotNil(t, detachedCmd.SysProcAttr)
+	require.True(t, detachedCmd.SysProcAttr.Setsid)
+	require.False(t, detachedCmd.SysProcAttr.Setpgid)
 
 	ptyCmd := &exec.Cmd{}
 	preparePTYCommand(ptyCmd)

--- a/tool/hostexec/hostexec_unix_test.go
+++ b/tool/hostexec/hostexec_unix_test.go
@@ -206,3 +206,45 @@ func TestProcessTreeAlive(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, processTreeAlive(cmd.Process, 0))
 }
+
+// The probe reads with POSIX `read` and branches with `then`/`fi`, which cmd.exe
+// does not parse, so it lives here rather than in the cross-platform file: on
+// Windows shellSpec succeeds and the test would fail on syntax before reaching
+// the behaviour it is checking.
+//
+// A foreground session is never registered with the manager, so write_stdin can
+// never reach it. Holding a stdin pipe open for it only lets a command that
+// prompts block until the run timeout kills it; detached, the read hits EOF and
+// the command returns. Without the detach this test fails by timing out.
+func TestNewToolSet_ForegroundDetachesStdin(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet()
+	require.NoError(t, err)
+	defer set.Close()
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		15*time.Second,
+	)
+	defer cancel()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		ctx,
+		mustJSON(t, map[string]any{
+			"command": `if read -r line; ` +
+				`then echo prompted:$line; ` +
+				`else echo reached-eof; fi`,
+			"yieldMs": 0,
+		}),
+	)
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	require.Equal(t, programStatusExited, res["status"])
+	require.Contains(t, outputField(res), "reached-eof")
+	require.EqualValues(t, 0, res["exit_code"])
+}

--- a/tool/hostexec/hostexec_windows_test.go
+++ b/tool/hostexec/hostexec_windows_test.go
@@ -12,8 +12,13 @@
 package hostexec
 
 import (
+	"os/exec"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
 )
 
 func processExists(_ int) bool {
@@ -26,4 +31,41 @@ func waitForProcessExit(
 	_ time.Duration,
 ) {
 	t.Helper()
+}
+
+// The detached foreground child must start without a console. Redirecting the
+// standard handles leaves CONIN$ open to it, and a prompt that reads the console
+// there waits out the run timeout that this disposition exists to avoid.
+func TestPrepareCommands(t *testing.T) {
+	preparePipeCommand(nil, keepStdin)
+	preparePipeCommand(nil, detachStdin)
+	preparePTYCommand(nil)
+
+	// The background path stays attached: its session is registered with the
+	// manager, so write_stdin can answer whatever it asks.
+	pipeCmd := &exec.Cmd{}
+	preparePipeCommand(pipeCmd, keepStdin)
+	if pipeCmd.SysProcAttr != nil {
+		require.Zero(t,
+			pipeCmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS)
+	}
+
+	detachedCmd := &exec.Cmd{}
+	preparePipeCommand(detachedCmd, detachStdin)
+	require.NotNil(t, detachedCmd.SysProcAttr)
+	require.NotZero(t,
+		detachedCmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS)
+
+	// A caller's own flags survive: the disposition adds one bit rather than
+	// replacing the field.
+	preservedCmd := &exec.Cmd{
+		SysProcAttr: &syscall.SysProcAttr{
+			CreationFlags: windows.CREATE_UNICODE_ENVIRONMENT,
+		},
+	}
+	preparePipeCommand(preservedCmd, detachStdin)
+	require.NotZero(t,
+		preservedCmd.SysProcAttr.CreationFlags&windows.CREATE_UNICODE_ENVIRONMENT)
+	require.NotZero(t,
+		preservedCmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS)
 }

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -177,12 +177,16 @@ func runForeground(
 	baseEnv map[string]string,
 	maxLines int,
 ) (string, int, error) {
+	// A foreground session is never registered with the manager, so write_stdin
+	// can never reach it: detach its stdin rather than hand the command a pipe
+	// nothing can write to or close.
 	sess, err := startSession(
 		"",
 		params,
 		timeout,
 		baseEnv,
 		maxLines,
+		detachStdin,
 	)
 	if err != nil {
 		return "", 0, err
@@ -290,6 +294,7 @@ func (m *manager) startBackground(
 		timeout,
 		m.baseEnv,
 		m.maxLines,
+		keepStdin,
 	)
 	if err != nil {
 		return nil, err
@@ -301,12 +306,20 @@ func (m *manager) startBackground(
 	return sess, nil
 }
 
+// startSession's stdin dispositions, named at the call site so the two paths
+// read as a deliberate choice rather than a bare boolean.
+const (
+	keepStdin   = false
+	detachStdin = true
+)
+
 func startSession(
 	id string,
 	params execParams,
 	timeout time.Duration,
 	baseEnv map[string]string,
 	maxLines int,
+	detach bool,
 ) (*session, error) {
 	runCtx, cancel := context.WithTimeout(
 		context.Background(),
@@ -339,7 +352,7 @@ func startSession(
 			sess.readFrom(master)
 		}()
 	} else {
-		stdin, stdout, stderr, err := startPipes(cmd)
+		stdin, stdout, stderr, err := startPipes(cmd, detach)
 		if err != nil {
 			cancel()
 			return nil, err
@@ -347,7 +360,9 @@ func startSession(
 		preparePipeCommand(cmd)
 		sess.stdin = stdin
 		sess.closeIO = func() error {
-			_ = stdin.Close()
+			if stdin != nil {
+				_ = stdin.Close()
+			}
 			_ = stdout.Close()
 			_ = stderr.Close()
 			return nil
@@ -426,21 +441,34 @@ func waitDone(
 	}
 }
 
+// startPipes wires the command's standard streams. A detached stdin is left nil,
+// which os/exec backs with the null device, so a command that prompts reads EOF
+// and fails instead of blocking on a pipe that never delivers.
 func startPipes(
 	cmd *exec.Cmd,
+	detach bool,
 ) (io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, nil, nil, err
+	var stdin io.WriteCloser
+	closeStdin := func() {
+		if stdin != nil {
+			_ = stdin.Close()
+		}
+	}
+	if !detach {
+		pipe, err := cmd.StdinPipe()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		stdin = pipe
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		_ = stdin.Close()
+		closeStdin()
 		return nil, nil, nil, err
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		_ = stdin.Close()
+		closeStdin()
 		_ = stdout.Close()
 		return nil, nil, nil, err
 	}

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -178,8 +178,12 @@ func runForeground(
 	maxLines int,
 ) (string, int, error) {
 	// A foreground session is never registered with the manager, so write_stdin
-	// can never reach it: detach its stdin rather than hand the command a pipe
-	// nothing can write to or close.
+	// can never reach it and no caller can answer a prompt it raises. Detach it
+	// rather than leave it looking answerable: stdin becomes the null device
+	// instead of a pipe nothing can write to or close, and preparePipeCommand
+	// puts the child in its own session so it cannot reach the host's terminal
+	// behind fd 0 either. A prompting command then fails promptly instead of
+	// waiting out the run timeout.
 	sess, err := startSession(
 		"",
 		params,
@@ -357,7 +361,7 @@ func startSession(
 			cancel()
 			return nil, err
 		}
-		preparePipeCommand(cmd)
+		preparePipeCommand(cmd, detach)
 		sess.stdin = stdin
 		sess.closeIO = func() error {
 			if stdin != nil {
@@ -443,7 +447,12 @@ func waitDone(
 
 // startPipes wires the command's standard streams. A detached stdin is left nil,
 // which os/exec backs with the null device, so a command that prompts reads EOF
-// and fails instead of blocking on a pipe that never delivers.
+// instead of blocking on a pipe that never delivers.
+//
+// That covers fd 0 only. Prompts that open /dev/tty directly are kept away by
+// preparePipeCommand, which gives the same detached child a session with no
+// controlling terminal; the two together are what make a prompt fail rather
+// than hang.
 func startPipes(
 	cmd *exec.Cmd,
 	detach bool,

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -181,9 +181,9 @@ func runForeground(
 	// can never reach it and no caller can answer a prompt it raises. Detach it
 	// rather than leave it looking answerable: stdin becomes the null device
 	// instead of a pipe nothing can write to or close, and preparePipeCommand
-	// puts the child in its own session so it cannot reach the host's terminal
-	// behind fd 0 either. A prompting command then fails promptly instead of
-	// waiting out the run timeout.
+	// takes away the terminal the child would otherwise reach around it — a new
+	// session on Unix, no console on Windows. A prompting command then fails
+	// promptly instead of waiting out the run timeout.
 	sess, err := startSession(
 		"",
 		params,
@@ -449,10 +449,10 @@ func waitDone(
 // which os/exec backs with the null device, so a command that prompts reads EOF
 // instead of blocking on a pipe that never delivers.
 //
-// That covers fd 0 only. Prompts that open /dev/tty directly are kept away by
-// preparePipeCommand, which gives the same detached child a session with no
-// controlling terminal; the two together are what make a prompt fail rather
-// than hang.
+// That covers fd 0 only. Prompts reach the terminal around it — /dev/tty on
+// Unix, CONIN$ on Windows — and preparePipeCommand is what takes that terminal
+// away from the same detached child; the two together are what make a prompt
+// fail rather than hang.
 func startPipes(
 	cmd *exec.Cmd,
 	detach bool,

--- a/tool/hostexec/pipes_test.go
+++ b/tool/hostexec/pipes_test.go
@@ -70,17 +70,37 @@ func TestStartPipesDetachLeavesStdinNil(t *testing.T) {
 	cmd := &exec.Cmd{}
 	stdin, stdout, stderr, err := startPipes(cmd, detachStdin)
 	require.NoError(t, err)
+	// Registered before the assertions, and holding this call's pipes rather
+	// than the variables, so a failing assertion still closes them.
+	closePipes(t, stdin, stdout, stderr)
 	require.Nil(t, stdin)
 	require.NotNil(t, stdout)
 	require.NotNil(t, stderr)
-	_ = stdout.Close()
-	_ = stderr.Close()
 
 	cmd = &exec.Cmd{}
 	stdin, stdout, stderr, err = startPipes(cmd, keepStdin)
 	require.NoError(t, err)
+	closePipes(t, stdin, stdout, stderr)
 	require.NotNil(t, stdin, "the background path keeps a writable stdin")
-	_ = stdin.Close()
-	_ = stdout.Close()
-	_ = stderr.Close()
+}
+
+// closePipes closes one startPipes call's streams when the test ends.
+func closePipes(
+	t *testing.T,
+	stdin io.WriteCloser,
+	stdout io.ReadCloser,
+	stderr io.ReadCloser,
+) {
+	t.Helper()
+	t.Cleanup(func() {
+		if stdin != nil {
+			_ = stdin.Close()
+		}
+		if stdout != nil {
+			_ = stdout.Close()
+		}
+		if stderr != nil {
+			_ = stderr.Close()
+		}
+	})
 }

--- a/tool/hostexec/pipes_test.go
+++ b/tool/hostexec/pipes_test.go
@@ -1,0 +1,86 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hostexec
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startPipes opens three pipes in sequence, and a failure partway through has to
+// close the ones already opened rather than leak them. os/exec refuses to hand
+// out a pipe for a stream the caller already wired up, which is what makes each
+// of those partial failures reachable.
+func TestStartPipesClosesOpenedPipesOnFailure(t *testing.T) {
+	t.Run("stdin pipe fails", func(t *testing.T) {
+		cmd := &exec.Cmd{Stdin: strings.NewReader("")}
+		stdin, stdout, stderr, err := startPipes(cmd, keepStdin)
+		require.Error(t, err)
+		require.Nil(t, stdin)
+		require.Nil(t, stdout)
+		require.Nil(t, stderr)
+	})
+
+	t.Run("stdout pipe fails after stdin opened", func(t *testing.T) {
+		// The stdin pipe is already open here, so this is the case that needs
+		// closeStdin to actually close something.
+		cmd := &exec.Cmd{Stdout: io.Discard}
+		stdin, stdout, stderr, err := startPipes(cmd, keepStdin)
+		require.Error(t, err)
+		require.Nil(t, stdin)
+		require.Nil(t, stdout)
+		require.Nil(t, stderr)
+	})
+
+	t.Run("stderr pipe fails after stdin and stdout opened", func(t *testing.T) {
+		cmd := &exec.Cmd{Stderr: io.Discard}
+		stdin, stdout, stderr, err := startPipes(cmd, keepStdin)
+		require.Error(t, err)
+		require.Nil(t, stdin)
+		require.Nil(t, stdout)
+		require.Nil(t, stderr)
+	})
+
+	t.Run("detached failure has no stdin to close", func(t *testing.T) {
+		// closeStdin must tolerate the detached case, where stdin was never
+		// opened and the nil it holds is the normal state rather than a bug.
+		cmd := &exec.Cmd{Stdout: io.Discard}
+		stdin, stdout, stderr, err := startPipes(cmd, detachStdin)
+		require.Error(t, err)
+		require.Nil(t, stdin)
+		require.Nil(t, stdout)
+		require.Nil(t, stderr)
+	})
+}
+
+// The detached path must not open a stdin pipe at all: a nil WriteCloser is what
+// makes os/exec back fd 0 with the null device.
+func TestStartPipesDetachLeavesStdinNil(t *testing.T) {
+	cmd := &exec.Cmd{}
+	stdin, stdout, stderr, err := startPipes(cmd, detachStdin)
+	require.NoError(t, err)
+	require.Nil(t, stdin)
+	require.NotNil(t, stdout)
+	require.NotNil(t, stderr)
+	_ = stdout.Close()
+	_ = stderr.Close()
+
+	cmd = &exec.Cmd{}
+	stdin, stdout, stderr, err = startPipes(cmd, keepStdin)
+	require.NoError(t, err)
+	require.NotNil(t, stdin, "the background path keeps a writable stdin")
+	_ = stdin.Close()
+	_ = stdout.Close()
+	_ = stderr.Close()
+}

--- a/tool/hostexec/procgroup_unix.go
+++ b/tool/hostexec/procgroup_unix.go
@@ -25,13 +25,40 @@ const (
 	processKillPoll       = 10 * time.Millisecond
 )
 
-func preparePipeCommand(cmd *exec.Cmd) {
+// preparePipeCommand isolates a pipe-mode child so the manager can clean up its
+// whole tree, and — when detached — so it cannot reach a terminal no one is
+// there to answer.
+//
+// Setpgid alone gives the child its own process group but leaves it attached to
+// whatever controlling terminal the host process inherited. A command that
+// prompts by opening /dev/tty directly — sudo, ssh, git, Python's getpass —
+// never touches fd 0 and still finds that terminal, so a nil stdin does not
+// reach it. Worse, reading a terminal from a background process group raises
+// SIGTTIN and stops the child, so the prompt hangs until the run times out
+// instead of failing.
+//
+// Setsid puts the child in a new session with no controlling terminal, so that
+// open fails with ENXIO and the command reports the error immediately. It also
+// makes the child a session and process-group leader, so PGID == PID and
+// terminateProcessTree still signals the whole tree. The two attributes cannot
+// be combined: Go issues setsid before setpgid, and setpgid rejects a session
+// leader with EPERM.
+//
+// Only the detached path gives up the terminal. A background session is
+// registered with the manager and remains addressable — write_stdin can answer
+// its prompts, and the caller can see it waiting and kill it — so it keeps the
+// terminal it has always had.
+func preparePipeCommand(cmd *exec.Cmd, detach bool) {
 	if cmd == nil {
 		return
 	}
 
 	attrs := ensureSysProcAttr(cmd)
-	attrs.Setpgid = true
+	if detach {
+		attrs.Setsid = true
+	} else {
+		attrs.Setpgid = true
+	}
 	applyParentDeathSignal(attrs)
 }
 

--- a/tool/hostexec/procgroup_windows.go
+++ b/tool/hostexec/procgroup_windows.go
@@ -15,13 +15,43 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
-// preparePipeCommand takes the detach disposition for parity with the Unix
-// build. Windows has no controlling-terminal device a child can open behind the
-// standard handles, so there is nothing to detach from.
-func preparePipeCommand(_ *exec.Cmd, _ bool) {}
+// preparePipeCommand isolates a pipe-mode child, and — when detached — keeps it
+// away from a console no one is there to answer.
+//
+// Redirecting the standard handles is not enough on Windows any more than a nil
+// stdin is on Unix. A console child inherits its parent's console by default,
+// and the prompts that matter reach it through the console rather than fd 0:
+// they open CONIN$, which returns the console's input buffer whatever the
+// standard input handle was set to. Started from a terminal, hostexec would
+// hand that buffer to a foreground child no caller can write to.
+//
+// DETACHED_PROCESS starts the child with no console at all, so opening CONIN$
+// fails and the command reports the error instead of waiting out the run
+// timeout. It is the flag that matches Setsid on Unix; CREATE_NO_WINDOW would
+// give the child a console of its own, which is a worse outcome — invisible,
+// unreachable, and still readable by the child. Nothing else about the child
+// changes: stdout and stderr are inherited pipe handles, which a console has no
+// part in, and terminateProcessTree kills the process directly here rather than
+// through a console control event.
+//
+// Only the detached path gives up the console. A background session is
+// registered with the manager and stays addressable — write_stdin can answer
+// its prompts — so it keeps what it has always had.
+func preparePipeCommand(cmd *exec.Cmd, detach bool) {
+	if cmd == nil || !detach {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.DETACHED_PROCESS
+}
 
 func preparePTYCommand(_ *exec.Cmd) {}
 

--- a/tool/hostexec/procgroup_windows.go
+++ b/tool/hostexec/procgroup_windows.go
@@ -18,7 +18,10 @@ import (
 	"time"
 )
 
-func preparePipeCommand(_ *exec.Cmd) {}
+// preparePipeCommand takes the detach disposition for parity with the Unix
+// build. Windows has no controlling-terminal device a child can open behind the
+// standard handles, so there is nothing to detach from.
+func preparePipeCommand(_ *exec.Cmd, _ bool) {}
 
 func preparePTYCommand(_ *exec.Cmd) {}
 


### PR DESCRIPTION
## What

`runForeground` starts its session with an empty id and never registers it in `manager.sessions`, so `write_stdin` can never resolve it (`m.get("")` returns `errUnknownSession`). `startPipes` nonetheless gives the command a live `cmd.StdinPipe()`, and the manager holds the write end open for the life of the session. A foreground command that reads stdin therefore blocks on a pipe that has a writer nobody can reach and that never sees EOF — it can only end when the run timeout fires and the process tree is killed.

This leaves stdin nil on that path, which `os/exec` backs with the null device. Background and pty sessions are registered and steerable, so they keep their pipe unchanged.

## Why

- Version: v1.10.0 (present at current main, `777fdb0b`)
- What we did: ran `make decrypt-local-secrets` as a foreground command (the default path — `Background` unset, `yieldMs: 0`). It shells out to `ansible-playbook --ask-vault-password`, which prompts via `getpass`.
- Expected: the prompt fails on EOF and the command returns an error the caller can act on
- Actual: it hung for the full `defaultTimeoutS` (30 minutes) before being SIGKILLed, burning the whole run

On the affected host, the child was parked in `pipe_read` on the manager's stdin pipe:

```
21526  bash -lc make decrypt-local-secrets
21535  python3 /usr/bin/ansible-playbook local-env-decrypt-playbook.yml --ask-vault-password
       fd 0 -> pipe:[78004]     stack: pipe_read -> vfs_read -> ksys_read
```

Any prompting command reaches this — `sudo`, a git credential read, an unanswered `apt` confirmation. The caller cannot avoid it by construction, because the foreground path is exactly the one with no way to answer.

## Test

`TestNewToolSet_ForegroundDetachesStdin`: a foreground `if read -r line; then ...; else echo reached-eof; fi` under a 15s context; asserts it exits and reports `reached-eof`. With `detachStdin` flipped back to `false` the test fails with `context deadline exceeded`, i.e. it reproduces the hang.

`TestNewToolSet_WriteStdin` (unchanged) covers the background side: a registered session still receives `write_stdin`.

`go test ./tool/hostexec/ -count=1` passes; `go vet` and `gofmt` clean.