### PR TITLE
model: add Claude Opus 5 token limits

### DIFF
--- a/model/internal/model/model_info.go
+++ b/model/internal/model/model_info.go
@@ -121,6 +121,7 @@ var ModelContextWindows = map[string]int{
 	// Anthropic Claude 5
 	"claude-fable-5":  1000000,
 	"claude-mythos-5": 1000000,
+	"claude-opus-5":   1000000,
 	"claude-sonnet-5": 1000000,
 
 	// Anthropic Claude 4.8
@@ -712,6 +713,7 @@ var ModelMaxOutputTokens = map[string]int{
 	// Anthropic Claude 5
 	"claude-fable-5":  128000,
 	"claude-mythos-5": 128000,
+	"claude-opus-5":   128000,
 	"claude-sonnet-5": 128000,
 
 	// Anthropic Claude 4.8

--- a/model/internal/model/model_info_test.go
+++ b/model/internal/model/model_info_test.go
@@ -127,6 +127,11 @@ func TestResolveContextWindow(t *testing.T) {
 			expected:  1000000,
 		},
 		{
+			name:      "exact match - Claude Opus 5",
+			modelName: "claude-opus-5",
+			expected:  1000000,
+		},
+		{
 			name:      "exact match - Claude Sonnet 5",
 			modelName: "claude-sonnet-5",
 			expected:  1000000,
@@ -610,6 +615,7 @@ func TestResolveMaxOutputTokens(t *testing.T) {
 		{name: "gpt-5.4 mini", modelName: "gpt-5.4-mini", expected: 128000},
 		{name: "claude fable 5", modelName: "claude-fable-5", expected: 128000},
 		{name: "claude mythos 5", modelName: "claude-mythos-5", expected: 128000},
+		{name: "claude opus 5", modelName: "claude-opus-5", expected: 128000},
 		{name: "claude sonnet 5", modelName: "claude-sonnet-5", expected: 128000},
 		{name: "claude opus 4.8", modelName: "claude-opus-4-8", expected: 128000},
 		{name: "claude sonnet 4.6", modelName: "claude-sonnet-4-6", expected: 128000},


### PR DESCRIPTION
## What changed

- Add `claude-opus-5` to the model context-window mapping with a 1,000,000-token limit.
- Add its 128,000-token synchronous output limit to the matching output-cap mapping.
- Cover both values with resolver tests.

## Why

Claude Opus 5 was recognized by the Anthropic provider but was missing from the shared model metadata. As a result, context-window and max-output-token resolution returned the unknown-model fallback instead of the documented limits.

## Impact

Callers using `claude-opus-5` now receive the same complete token-limit metadata already available for the other Claude 5 models.

## Testing

- `go test ./model/internal/model`
- `go build ./...`
- `goimports -l model/internal/model/model_info.go model/internal/model/model_info_test.go`
