### PR TITLE
server/agui: prevent abandoned proxy streams from blocking runs

### DIFF
--- a/server/agui/agui_test.go
+++ b/server/agui/agui_test.go
@@ -84,6 +84,128 @@ func TestEndToEndServerSendsSSEEvents(t *testing.T) {
 	assert.Equal(t, model.RoleUser, agent.lastInvocation.Message.Role)
 }
 
+func TestCustomRunnerDisconnectReleasesInnerSessionKey(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		cancelOnContextDone bool
+	}{
+		{name: "run continues"},
+		{name: "run is canceled", cancelOnContextDone: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testCustomRunnerDisconnectReleasesInnerSessionKey(t, tc.cancelOnContextDone)
+		})
+	}
+}
+
+func testCustomRunnerDisconnectReleasesInnerSessionKey(t *testing.T, cancelOnContextDone bool) {
+	firstAgentRunContext := make(chan context.Context, 1)
+	releaseFirstAgentRun := make(chan struct{})
+	releaseFirst := func() {
+		select {
+		case <-releaseFirstAgentRun:
+		default:
+			close(releaseFirstAgentRun)
+		}
+	}
+
+	agt := &mockAgent{info: agent.Info{Name: "demo"}}
+	agt.run = func(ctx context.Context, invocation *agent.Invocation) (<-chan *event.Event, error) {
+		if agt.runCalls == 1 {
+			firstAgentRunContext <- ctx
+			<-releaseFirstAgentRun
+		}
+		events := make(chan *event.Event, 1)
+		events <- event.NewResponseEvent(
+			invocation.InvocationID,
+			invocation.AgentName,
+			&model.Response{
+				ID:     "completion",
+				Object: model.ObjectTypeRunnerCompletion,
+				Done:   true,
+			},
+		)
+		close(events)
+		return events, nil
+	}
+	baseRunner := runner.NewRunner(agt.Info().Name, agt)
+	t.Cleanup(func() {
+		releaseFirst()
+		assert.NoError(t, baseRunner.Close())
+	})
+	relayCompleted := make(chan struct{}, 2)
+	runnerFactory := func(
+		base runner.Runner,
+		opts ...aguirunner.Option,
+	) (aguirunner.Runner, error) {
+		return &requestCancelRelayRunner{
+			inner:     aguirunner.New(base, opts...),
+			completed: relayCompleted,
+		}, nil
+	}
+	serverOptions := []Option{
+		WithTimeout(0),
+		WithRunnerFactory(runnerFactory),
+	}
+	if cancelOnContextDone {
+		serverOptions = append(serverOptions, WithCancelOnContextDoneEnabled(true))
+	}
+	srv, err := New(baseRunner, serverOptions...)
+	if !assert.NoError(t, err) || !assert.NotNil(t, srv) {
+		return
+	}
+
+	firstPayload := `{"threadId":"thread","runId":"run-1","messages":[{"role":"user","content":"hi"}]}`
+	firstBaseReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(firstPayload))
+	firstRequestCtx, cancelFirstRequest := context.WithCancel(firstBaseReq.Context())
+	firstReq := firstBaseReq.WithContext(firstRequestCtx)
+	firstRecorder := httptest.NewRecorder()
+	firstHandlerDone := make(chan struct{})
+	go func() {
+		srv.Handler().ServeHTTP(firstRecorder, firstReq)
+		close(firstHandlerDone)
+	}()
+
+	var agentRunContext context.Context
+	select {
+	case agentRunContext = <-firstAgentRunContext:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for first agent run context")
+	}
+	cancelFirstRequest()
+	waitForAGUISignal(t, firstHandlerDone, "first HTTP handler return")
+	waitForAGUISignal(t, relayCompleted, "first relay completion")
+	if cancelOnContextDone {
+		assert.Eventually(t, func() bool {
+			return errors.Is(agentRunContext.Err(), context.Canceled)
+		}, time.Second, 10*time.Millisecond)
+	} else {
+		assert.NoError(t, agentRunContext.Err())
+	}
+	releaseFirst()
+
+	var secondRecorder *httptest.ResponseRecorder
+	ok := assert.Eventually(t, func() bool {
+		payload := `{"threadId":"thread","runId":"run-2","messages":[{"role":"user","content":"again"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
+		ctx, cancel := context.WithTimeout(req.Context(), 500*time.Millisecond)
+		defer cancel()
+		req = req.WithContext(ctx)
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		if recorder.Code != http.StatusOK {
+			return false
+		}
+		secondRecorder = recorder
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+	if !ok {
+		return
+	}
+	assert.NotContains(t, secondRecorder.Body.String(), "run already exists")
+	assert.Contains(t, secondRecorder.Body.String(), `"type":"RUN_FINISHED"`)
+}
+
 func TestWithToolCallDeltaStreamingEnabledPropagatesToRunner(t *testing.T) {
 	agt := &mockAgent{info: agent.Info{Name: "demo"}}
 	agt.run = func(ctx context.Context, invocation *agent.Invocation) (<-chan *event.Event, error) {
@@ -583,6 +705,53 @@ func (*testAGUIRunner) Run(context.Context, *adapter.RunAgentInput) (<-chan agui
 	events := make(chan aguievents.Event)
 	close(events)
 	return events, nil
+}
+
+type requestCancelRelayRunner struct {
+	inner     aguirunner.Runner
+	completed chan<- struct{}
+}
+
+func (r *requestCancelRelayRunner) Run(
+	ctx context.Context,
+	input *adapter.RunAgentInput,
+) (<-chan aguievents.Event, error) {
+	innerEvents, err := r.inner.Run(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	outerEvents := make(chan aguievents.Event)
+	go func() {
+		defer func() {
+			close(outerEvents)
+			r.completed <- struct{}{}
+		}()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-innerEvents:
+				if !ok {
+					return
+				}
+				select {
+				case outerEvents <- event:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return outerEvents, nil
+}
+
+func waitForAGUISignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for %s", name)
+	}
 }
 
 type fakeSessionService struct{}

--- a/server/agui/internal/eventstream/context.go
+++ b/server/agui/internal/eventstream/context.go
@@ -1,0 +1,42 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package eventstream coordinates internal ownership of AG-UI event streams.
+package eventstream
+
+import (
+	"context"
+	"sync"
+)
+
+type consumerDoneKey struct{}
+
+// WithConsumer returns a context carrying an event-consumer lifetime signal
+// and an idempotent function that ends that lifetime.
+func WithConsumer(ctx context.Context) (context.Context, func()) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	done := make(chan struct{})
+	var once sync.Once
+	return context.WithValue(ctx, consumerDoneKey{}, (<-chan struct{})(done)), func() {
+		once.Do(func() {
+			close(done)
+		})
+	}
+}
+
+// ConsumerDone returns the event-consumer lifetime signal carried by ctx.
+func ConsumerDone(ctx context.Context) <-chan struct{} {
+	if ctx == nil {
+		return nil
+	}
+	done, _ := ctx.Value(consumerDoneKey{}).(<-chan struct{})
+	return done
+}

--- a/server/agui/internal/eventstream/context_test.go
+++ b/server/agui/internal/eventstream/context_test.go
@@ -1,0 +1,46 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package eventstream
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithConsumer(t *testing.T) {
+	type contextKey struct{}
+	ctx, consumerDone := WithConsumer(
+		context.WithValue(context.Background(), contextKey{}, "value"),
+	)
+	done := ConsumerDone(ctx)
+	require.NotNil(t, done)
+	assert.Equal(t, "value", ctx.Value(contextKey{}))
+	select {
+	case <-done:
+		assert.Fail(t, "consumer lifetime ended early")
+	default:
+	}
+
+	consumerDone()
+	consumerDone()
+	select {
+	case <-done:
+	default:
+		assert.Fail(t, "consumer lifetime did not end")
+	}
+}
+
+func TestConsumerDoneAbsent(t *testing.T) {
+	assert.Nil(t, ConsumerDone(context.Background()))
+	assert.Nil(t, ConsumerDone(nil))
+}

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -29,6 +29,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	trunner "trpc.group/trpc-go/trpc-agent-go/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/eventstream"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
 	aguitool "trpc.group/trpc-go/trpc-agent-go/server/agui/internal/tool"
@@ -170,6 +171,7 @@ type runInput struct {
 	terminalEmitted bool
 	runAgentInput   *adapter.RunAgentInput
 	done            chan struct{}
+	consumerDone    <-chan struct{}
 }
 
 type runAgentResult struct {
@@ -355,6 +357,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 	if runAgentInput == nil {
 		return nil, errors.New("run input cannot be nil")
 	}
+	consumerDone := eventstream.ConsumerDone(ctx)
 	runAgentInput, err := r.applyRunAgentInputHook(ctx, runAgentInput)
 	if err != nil {
 		return nil, fmt.Errorf("run input hook: %w", err)
@@ -431,6 +434,7 @@ func (r *runner) Run(ctx context.Context, runAgentInput *adapter.RunAgentInput) 
 		resume:        parseResumeInfo(runOption),
 		runAgentInput: runAgentInput,
 		done:          make(chan struct{}),
+		consumerDone:  consumerDone,
 	}
 	events := make(chan aguievents.Event)
 	ctx, cancel := r.newExecutionContext(ctx, r.timeout)
@@ -1182,6 +1186,23 @@ func (r *runner) writeEvent(ctx context.Context, events chan<- aguievents.Event,
 	select {
 	case events <- event:
 		if input != nil && isTerminal {
+			input.terminalEmitted = true
+		}
+		return true
+	case <-input.consumerDone:
+		if ctx.Err() != nil {
+			log.ErrorfContext(ctx, "agui emit event: context done, threadID: %s, runID: %s, err: %v",
+				input.threadID, input.runID, ctx.Err())
+			return false
+		}
+		// A proxy may close its outer stream without draining this one. Once
+		// the transport has finished that outer stream, delivery is no longer
+		// guaranteed; avoid blocking run cleanup on the abandoned reader.
+		select {
+		case events <- event:
+		default:
+		}
+		if isTerminal {
 			input.terminalEmitted = true
 		}
 		return true

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1491,6 +1491,63 @@ func TestRunIgnoresRequestCancelButRespectsBackendTimeout(t *testing.T) {
 	assert.True(t, hasRunErrorEvent(evts))
 }
 
+func TestWriteEventAfterConsumerDone(t *testing.T) {
+	t.Run("active run does not block", func(t *testing.T) {
+		consumerDone := make(chan struct{})
+		close(consumerDone)
+		input := &runInput{
+			threadID:     "thread",
+			runID:        "run",
+			consumerDone: consumerDone,
+		}
+		events := make(chan aguievents.Event)
+		event := aguievents.NewRunFinishedEvent("thread", "run")
+
+		written := (&runner{}).writeEvent(context.Background(), events, event, input)
+
+		assert.True(t, written)
+		assert.True(t, input.terminalEmitted)
+	})
+
+	t.Run("canceled run still stops", func(t *testing.T) {
+		consumerDone := make(chan struct{})
+		close(consumerDone)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		input := &runInput{
+			threadID:     "thread",
+			runID:        "run",
+			consumerDone: consumerDone,
+		}
+		events := make(chan aguievents.Event)
+		event := aguievents.NewRunFinishedEvent("thread", "run")
+
+		written := (&runner{}).writeEvent(ctx, events, event, input)
+
+		assert.False(t, written)
+		assert.False(t, input.terminalEmitted)
+	})
+
+	t.Run("expired deadline still stops", func(t *testing.T) {
+		consumerDone := make(chan struct{})
+		close(consumerDone)
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		input := &runInput{
+			threadID:     "thread",
+			runID:        "run",
+			consumerDone: consumerDone,
+		}
+		events := make(chan aguievents.Event)
+		event := aguievents.NewRunFinishedEvent("thread", "run")
+
+		written := (&runner{}).writeEvent(ctx, events, event, input)
+
+		assert.False(t, written)
+		assert.False(t, input.terminalEmitted)
+	})
+}
+
 func TestRunCancelsOnRequestCancelWhenEnabled(t *testing.T) {
 	ctxCh := make(chan context.Context, 1)
 	underlying := &fakeRunner{

--- a/server/agui/service/sse/sse.go
+++ b/server/agui/service/sse/sse.go
@@ -22,6 +22,7 @@ import (
 	aguisse "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/encoding/sse"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/eventstream"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service"
 )
@@ -116,8 +117,10 @@ func (s *sse) handle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	eventsCh, err := s.runner.Run(ctx, runAgentInput)
+	runCtx, finishConsuming := eventstream.WithConsumer(ctx)
+	eventsCh, err := s.runner.Run(runCtx, runAgentInput)
 	if err != nil {
+		finishConsuming()
 		log.ErrorfContext(
 			ctx,
 			"agui handle: threadID: %s, runID: %s, run agent: %v",
@@ -132,11 +135,24 @@ func (s *sse) handle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), status)
 		return
 	}
+	if eventsCh == nil {
+		finishConsuming()
+		const message = "runner returned nil event channel"
+		log.ErrorfContext(
+			ctx,
+			"agui handle: threadID: %s, runID: %s, run agent: %s",
+			runAgentInput.ThreadID,
+			runAgentInput.RunID,
+			message,
+		)
+		http.Error(w, message, http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if err := s.handleEvents(ctx, w, eventsCh, true); err != nil {
+	if err := s.handleEvents(ctx, w, eventsCh, true, finishConsuming); err != nil {
 		log.ErrorfContext(
 			ctx,
 			"agui handle: threadID: %s, runID: %s, write event: %v",
@@ -227,7 +243,7 @@ func (s *sse) handleMessagesSnapshot(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if err := s.handleEvents(ctx, w, eventsCh, false); err != nil {
+	if err := s.handleEvents(ctx, w, eventsCh, false, nil); err != nil {
 		log.ErrorfContext(
 			ctx,
 			"agui handle messages snapshot: threadID: %s, "+
@@ -245,6 +261,7 @@ func (s *sse) handleEvents(
 	w http.ResponseWriter,
 	events <-chan aguievents.Event,
 	drain bool,
+	finishConsuming func(),
 ) error {
 	var heartbeat <-chan time.Time
 	if s.heartbeatInterval > 0 {
@@ -255,25 +272,22 @@ func (s *sse) handleEvents(
 	for {
 		select {
 		case <-ctx.Done():
-			if drain {
-				go drainEvents(events)
-			}
+			finishEventConsumption(events, drain, finishConsuming)
 			return nil
 		case <-heartbeat:
 			if err := writeHeartbeat(w); err != nil {
-				if drain {
-					go drainEvents(events)
-				}
+				finishEventConsumption(events, drain, finishConsuming)
 				return err
 			}
 		case evt, ok := <-events:
 			if !ok {
+				if finishConsuming != nil {
+					finishConsuming()
+				}
 				return nil
 			}
 			if err := s.writer.WriteEvent(ctx, w, evt); err != nil {
-				if drain {
-					go drainEvents(events)
-				}
+				finishEventConsumption(events, drain, finishConsuming)
 				return err
 			}
 		}
@@ -378,4 +392,23 @@ func runAgentInputFromReader(r io.Reader) (*adapter.RunAgentInput, error) {
 func drainEvents(events <-chan aguievents.Event) {
 	for range events {
 	}
+}
+
+func finishEventConsumption(
+	events <-chan aguievents.Event,
+	drain bool,
+	finishConsuming func(),
+) {
+	if !drain {
+		if finishConsuming != nil {
+			finishConsuming()
+		}
+		return
+	}
+	go func() {
+		drainEvents(events)
+		if finishConsuming != nil {
+			finishConsuming()
+		}
+	}()
 }

--- a/server/agui/service/sse/sse_test.go
+++ b/server/agui/service/sse/sse_test.go
@@ -75,6 +75,22 @@ func TestHandleRunnerError(t *testing.T) {
 	assert.Equal(t, 1, runner.calls)
 }
 
+func TestHandleRunnerNilEventChannel(t *testing.T) {
+	runner := &stubRunner{}
+	srv := &sse{runner: runner, writer: aguisse.NewSSEWriter()}
+	payload := `{"threadId":"thread","runId":"run","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/agui", strings.NewReader(payload))
+	rr := httptest.NewRecorder()
+
+	srv.handle(rr, req)
+
+	res := rr.Result()
+	defer res.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	assert.Contains(t, rr.Body.String(), "runner returned nil event channel")
+	assert.Equal(t, 1, runner.calls)
+}
+
 func TestHandleRunnerDuplicateKeyReturnsConflict(t *testing.T) {
 	runner := &stubRunner{
 		runFn: func(ctx context.Context, input *adapter.RunAgentInput) (<-chan aguievents.Event, error) {
@@ -140,7 +156,7 @@ func TestHandleEventsHeartbeatDisabledByDefault(t *testing.T) {
 	}()
 	srv := &sse{writer: aguisse.NewSSEWriter()}
 	rr := httptest.NewRecorder()
-	err := srv.handleEvents(context.Background(), rr, eventsCh, false)
+	err := srv.handleEvents(context.Background(), rr, eventsCh, false, nil)
 	assert.NoError(t, err)
 	assert.Empty(t, rr.Body.String())
 }
@@ -153,7 +169,7 @@ func TestHandleEventsHeartbeatWritesCommentFrame(t *testing.T) {
 	}()
 	srv := &sse{writer: aguisse.NewSSEWriter(), heartbeatInterval: 5 * time.Millisecond}
 	rr := httptest.NewRecorder()
-	err := srv.handleEvents(context.Background(), rr, eventsCh, false)
+	err := srv.handleEvents(context.Background(), rr, eventsCh, false, nil)
 	assert.NoError(t, err)
 	body := rr.Body.String()
 	assert.Contains(t, body, ":\n\n")
@@ -164,7 +180,7 @@ func TestHandleEventsHeartbeatWriteError(t *testing.T) {
 	eventsCh := make(chan aguievents.Event)
 	srv := &sse{writer: aguisse.NewSSEWriter(), heartbeatInterval: 5 * time.Millisecond}
 	errWriter := newErrorResponseWriter(errors.New("write failure"))
-	err := srv.handleEvents(context.Background(), errWriter, eventsCh, false)
+	err := srv.handleEvents(context.Background(), errWriter, eventsCh, false, nil)
 	assert.ErrorContains(t, err, "write failure")
 }
 
@@ -279,6 +295,39 @@ func TestHandleClientDisconnectDoesNotBlockRunner(t *testing.T) {
 			return false
 		}
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandleEventsSignalsConsumerDoneAfterDrain(t *testing.T) {
+	eventsCh := make(chan aguievents.Event)
+	consumerDone := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := &sse{writer: aguisse.NewSSEWriter()}
+	handleDone := make(chan error, 1)
+	go func() {
+		handleDone <- srv.handleEvents(ctx, httptest.NewRecorder(), eventsCh, true, func() {
+			close(consumerDone)
+		})
+	}()
+
+	cancel()
+	select {
+	case err := <-handleDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		assert.FailNow(t, "timeout waiting for event handler")
+	}
+	select {
+	case <-consumerDone:
+		assert.FailNow(t, "consumer signaled done before the event stream was drained")
+	default:
+	}
+
+	close(eventsCh)
+	select {
+	case <-consumerDone:
+	case <-time.After(time.Second):
+		assert.FailNow(t, "timeout waiting for consumer done signal")
+	}
 }
 
 func TestHandleMethodNotAllowed(t *testing.T) {


### PR DESCRIPTION
## What changed

AG-UI runs can now complete cleanup when a custom Runner proxy closes its outer stream after an SSE disconnect. The bundled SSE transport communicates top-level stream completion to the bundled Runner, preventing an abandoned nested event reader from blocking the run while preserving normal delivery, cancellation, deadlines, tracking, and option behavior.

A successful custom Runner response with a nil event channel now returns HTTP 500 instead of hanging.

## Why

A proxy that returned on request `ctx.Done()` could stop reading the bundled inner Runner. Because the inner Runner detaches request cancellation by default and emits through an unbuffered channel, its next event could block forever before SessionKey cleanup. Later runs for the same session would then return HTTP 409.

The internal consumer signal closes only after the outer stream is fully drained, so correct proxies continue to receive all events. It does not parse or replay Runner options or change request context cancellation and deadline semantics.

Fixes #2430

## Testing

- `go test ./...`
- `go vet ./...`
- `go test -race ./... -run '^(TestCustomRunnerDisconnectReleasesInnerSessionKey|TestWriteEventAfterConsumerDone|TestHandleEventsSignalsConsumerDoneAfterDrain|TestHandleRunnerNilEventChannel)$' -count=50`

## Notes for reviewers

The safeguard applies to the bundled SSE transport and bundled Runner when proxy contexts preserve the supplied context values. Fully custom transports or producers still own their stream lifecycle. No new public API or option is added.