### PR TITLE
knowledge/chunking: preserve whitespace-sensitive content

### DIFF
--- a/docs/mkdocs/en/knowledge/source.md
+++ b/docs/mkdocs/en/knowledge/source.md
@@ -224,6 +224,34 @@ overlap option, then re-ingest the affected documents. Because overlap now
 counts inside `chunkSize`, even an explicit value of `128` may not reproduce
 the old over-budget chunks byte for byte.
 
+FixedSizeChunking, RecursiveChunking, and MarkdownChunking preserve leading and
+trailing spaces and tabs in source lines by default. This keeps indentation in
+Python, YAML, Makefiles, nested Markdown, and fenced code intact. The strategies
+still normalize text encoding and `CRLF`/`CR` line endings, and reject documents
+that contain only whitespace.
+
+This default changes chunk content, boundaries, metadata sizes, and embedding
+inputs compared with releases that trimmed every line. Clear and re-ingest
+persistent vector data after upgrading; do not mix chunks produced by the two
+behaviors. Applications that must retain the previous lossy normalization can
+construct a custom strategy with the corresponding compatibility option:
+
+```go
+fixed := chunking.NewFixedSizeChunking(
+    chunking.WithWhitespaceTrimming(),
+)
+recursive := chunking.NewRecursiveChunking(
+    chunking.WithRecursiveWhitespaceTrimming(),
+)
+markdown := chunking.NewMarkdownChunking(
+    chunking.WithMarkdownWhitespaceTrimming(),
+)
+```
+
+Pass the selected strategy through `WithCustomChunkingStrategy`. Each option
+trims the document, every line, and retained chunk boundaries as earlier
+releases did.
+
 The text strategies validate their configuration when `Chunk` is called:
 `chunkSize` must be greater than zero, and `overlap` must be in
 `[0, chunkSize)`. Invalid values return `ErrInvalidChunkSize`,

--- a/docs/mkdocs/en/knowledge/source.md
+++ b/docs/mkdocs/en/knowledge/source.md
@@ -228,13 +228,19 @@ FixedSizeChunking, RecursiveChunking, and MarkdownChunking preserve leading and
 trailing spaces and tabs in source lines by default. This keeps indentation in
 Python, YAML, Makefiles, nested Markdown, and fenced code intact. The strategies
 still normalize text encoding and `CRLF`/`CR` line endings, and reject documents
-that contain only whitespace.
+that contain only whitespace. Every emitted chunk contains at least one
+non-whitespace character and stays within `chunkSize`, including configured
+overlap. Whitespace-only fragments are attached to adjacent semantic content
+when the active chunk budget permits. Leading, trailing, or unusually long
+whitespace that cannot be attached without producing an empty or oversized
+chunk is discarded.
 
-This default changes chunk content, boundaries, metadata sizes, and embedding
-inputs compared with releases that trimmed every line. Clear and re-ingest
-persistent vector data after upgrading; do not mix chunks produced by the two
-behaviors. Applications that must retain the previous lossy normalization can
-construct a custom strategy with the corresponding compatibility option:
+This is an intentional default behavior change. It changes chunk content,
+boundaries, metadata sizes, and embedding inputs compared with releases that
+trimmed every line. Clear and re-ingest persistent vector data after upgrading;
+do not mix chunks produced by the two behaviors. The opt-in compatibility mode
+remains available for applications that must retain the previous lossy
+normalization:
 
 ```go
 fixed := chunking.NewFixedSizeChunking(

--- a/docs/mkdocs/zh/knowledge/source.md
+++ b/docs/mkdocs/zh/knowledge/source.md
@@ -261,6 +261,31 @@ chunk 的头尾分别追加一段重叠内容。
 所需值，然后重新导入受影响的文档。由于 overlap 现在计入 `chunkSize`，
 即使显式配置为 `128`，也不一定能逐字节复现旧的超预算 chunk。
 
+FixedSizeChunking、RecursiveChunking 和 MarkdownChunking 默认保留源文本
+每行首尾的空格与 Tab，避免破坏 Python、YAML、Makefile、Markdown 嵌套结构
+以及 fenced code 的缩进。策略仍会统一文本编码和 `CRLF`/`CR` 换行，并拒绝
+只包含空白字符的文档。
+
+相较于逐行裁剪空白的旧版本，这项默认行为会改变 chunk 正文、边界、metadata
+大小和 embedding 输入。升级后应清理持久化向量数据并重新导入，不能混用两种
+行为生成的索引。如果应用必须保留旧的有损规范化结果，可使用对应的兼容选项
+构造自定义策略：
+
+```go
+fixed := chunking.NewFixedSizeChunking(
+    chunking.WithWhitespaceTrimming(),
+)
+recursive := chunking.NewRecursiveChunking(
+    chunking.WithRecursiveWhitespaceTrimming(),
+)
+markdown := chunking.NewMarkdownChunking(
+    chunking.WithMarkdownWhitespaceTrimming(),
+)
+```
+
+通过 `WithCustomChunkingStrategy` 传入实际使用的策略。每个兼容选项都会按
+旧版本行为裁剪整个文档、每一行和保留的 chunk 边界。
+
 文本分块策略会在调用 `Chunk` 时校验配置：`chunkSize` 必须大于 0，
 `overlap` 必须位于 `[0, chunkSize)`。无效配置会返回
 `ErrInvalidChunkSize`、`ErrInvalidOverlap` 或 `ErrOverlapTooLarge`，而不是

--- a/docs/mkdocs/zh/knowledge/source.md
+++ b/docs/mkdocs/zh/knowledge/source.md
@@ -264,12 +264,15 @@ chunk 的头尾分别追加一段重叠内容。
 FixedSizeChunking、RecursiveChunking 和 MarkdownChunking 默认保留源文本
 每行首尾的空格与 Tab，避免破坏 Python、YAML、Makefile、Markdown 嵌套结构
 以及 fenced code 的缩进。策略仍会统一文本编码和 `CRLF`/`CR` 换行，并拒绝
-只包含空白字符的文档。
+只包含空白字符的文档。所有输出 chunk 都至少包含一个非空白字符，并且在计入
+配置的 overlap 后不超过 `chunkSize`。纯空白片段会在当前预算允许时附着到相邻
+有效内容；如果首尾空白或超长空白无法在不产生纯空白、超预算 chunk 的前提下
+附着，则会被丢弃。
 
-相较于逐行裁剪空白的旧版本，这项默认行为会改变 chunk 正文、边界、metadata
-大小和 embedding 输入。升级后应清理持久化向量数据并重新导入，不能混用两种
-行为生成的索引。如果应用必须保留旧的有损规范化结果，可使用对应的兼容选项
-构造自定义策略：
+这是项目明确采用的默认行为变更。相较于逐行裁剪空白的旧版本，它会改变 chunk
+正文、边界、metadata 大小和 embedding 输入。升级后应清理持久化向量数据并
+重新导入，不能混用两种行为生成的索引。对于必须保留旧有损规范化结果的应用，
+必要的 opt-in 兼容模式仍然保留，可使用对应选项构造自定义策略：
 
 ```go
 fixed := chunking.NewFixedSizeChunking(

--- a/examples/knowledge/chunking/web/main.go
+++ b/examples/knowledge/chunking/web/main.go
@@ -406,14 +406,9 @@ func strategyDisplayName(strategyName string) string {
 }
 
 func normalizeSource(content string) string {
-	content = strings.TrimSpace(content)
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	content = strings.ReplaceAll(content, "\r", "\n")
-	lines := strings.Split(content, "\n")
-	for i, line := range lines {
-		lines[i] = strings.TrimSpace(line)
-	}
-	return strings.Join(lines, "\n")
+	return content
 }
 
 func mapSourceRanges(
@@ -431,18 +426,29 @@ func mapSourceRanges(
 	for i := range chunks {
 		chunkRunes := []rune(chunks[i].Content)
 		coreOffset := min(chunks[i].ActualOverlap, len(chunkRunes))
-		if chunks[i].ActualOverlap > 0 {
-			for coreOffset < len(chunkRunes) &&
-				unicode.IsSpace(chunkRunes[coreOffset]) {
-				coreOffset++
-			}
-		}
 		coreRunes := chunkRunes[coreOffset:]
 		sourceStart, sourceEnd := findRuneRange(
 			sourceRunes,
 			coreRunes,
 			cursor,
 		)
+		if sourceStart < 0 && chunks[i].ActualOverlap > 0 {
+			for _, separator := range []string{"\n\n", "\n", " "} {
+				separatorRunes := []rune(separator)
+				if len(coreRunes) < len(separatorRunes) ||
+					!equalRunes(coreRunes[:len(separatorRunes)], separatorRunes) {
+					continue
+				}
+				sourceStart, sourceEnd = findRuneRange(
+					sourceRunes,
+					coreRunes[len(separatorRunes):],
+					cursor,
+				)
+				if sourceStart >= 0 {
+					break
+				}
+			}
+		}
 		if sourceStart < 0 {
 			continue
 		}

--- a/knowledge/chunking/chunking.go
+++ b/knowledge/chunking/chunking.go
@@ -46,9 +46,16 @@ func validateChunkConfig(chunkSize, overlap int) error {
 	}
 }
 
-// cleanText normalizes whitespace in text content while ensuring UTF-8 safety.
-// It automatically detects encoding and converts to UTF-8 if necessary.
+// cleanText normalizes encoding and line breaks while preserving source
+// whitespace.
 func cleanText(content string) string {
+	return cleanTextWithWhitespaceTrimming(content, false)
+}
+
+func cleanTextWithWhitespaceTrimming(
+	content string,
+	trimWhitespace bool,
+) string {
 	// Intelligently process text based on detected encoding
 	processed, encodingInfo := encoding.SmartProcessText(content)
 
@@ -58,19 +65,28 @@ func cleanText(content string) string {
 			encodingInfo.Encoding, encodingInfo.Confidence, encodingInfo.IsValid)
 	}
 
-	// Trim leading and trailing whitespace.
-	processed = strings.TrimSpace(processed)
+	if trimWhitespace {
+		// Preserve the whitespace normalization used before indentation became
+		// source content by default.
+		processed = strings.TrimSpace(processed)
+	}
 
 	// Normalize line breaks.
 	processed = strings.ReplaceAll(processed, "\r\n", "\n")
 	processed = strings.ReplaceAll(processed, "\r", "\n")
 
-	// Remove excessive whitespace while preserving line breaks.
-	lines := strings.Split(processed, "\n")
-	for i, line := range lines {
-		lines[i] = strings.TrimSpace(line)
+	if trimWhitespace {
+		lines := strings.Split(processed, "\n")
+		for i, line := range lines {
+			lines[i] = strings.TrimSpace(line)
+		}
+		processed = strings.Join(lines, "\n")
 	}
-	return strings.Join(lines, "\n")
+	return processed
+}
+
+func isBlankText(content string) bool {
+	return strings.TrimSpace(content) == ""
 }
 
 // createChunk creates a new document chunk with appropriate metadata.
@@ -112,13 +128,32 @@ func joinWithOverlap(
 	maxSize int,
 	separator string,
 ) (string, int) {
-	return joinWithOverlapSeparator(
+	return joinWithOverlapMode(
 		previous,
 		current,
 		maxOverlap,
 		maxSize,
 		separator,
 		false,
+	)
+}
+
+func joinWithOverlapMode(
+	previous string,
+	current string,
+	maxOverlap int,
+	maxSize int,
+	separator string,
+	trimWhitespace bool,
+) (string, int) {
+	return joinWithOverlapSeparatorMode(
+		previous,
+		current,
+		maxOverlap,
+		maxSize,
+		separator,
+		false,
+		trimWhitespace,
 	)
 }
 
@@ -129,6 +164,26 @@ func joinWithOverlapSeparator(
 	maxSize int,
 	separator string,
 	preserveSeparator bool,
+) (string, int) {
+	return joinWithOverlapSeparatorMode(
+		previous,
+		current,
+		maxOverlap,
+		maxSize,
+		separator,
+		preserveSeparator,
+		false,
+	)
+}
+
+func joinWithOverlapSeparatorMode(
+	previous string,
+	current string,
+	maxOverlap int,
+	maxSize int,
+	separator string,
+	preserveSeparator bool,
+	trimWhitespace bool,
 ) (string, int) {
 	currentSize := encoding.RuneCount(current)
 	separatorSize := encoding.RuneCount(separator)
@@ -152,7 +207,11 @@ func joinWithOverlapSeparator(
 	if overlapSize <= 0 {
 		return current, 0
 	}
-	overlapContent, naturalBoundary := naturalTextSuffix(previous, overlapSize)
+	overlapContent, naturalBoundary := naturalTextSuffixWithWhitespaceTrimming(
+		previous,
+		overlapSize,
+		trimWhitespace,
+	)
 	if !naturalBoundary && separator != "" && !preserveSeparator {
 		// For an unbroken token, preserve the exact source text rather than
 		// inserting a separator in the middle of the token.
@@ -162,7 +221,11 @@ func joinWithOverlapSeparator(
 			maxOverlap,
 			min(availableOverlap, encoding.RuneCount(previous)),
 		)
-		overlapContent, _ = naturalTextSuffix(previous, overlapSize)
+		overlapContent, _ = naturalTextSuffixWithWhitespaceTrimming(
+			previous,
+			overlapSize,
+			trimWhitespace,
+		)
 	}
 	actualOverlap := encoding.RuneCount(overlapContent)
 	if actualOverlap <= 0 {
@@ -221,15 +284,34 @@ func sourceGapSeparator(gap string, fallback string) string {
 // falling back to an exact rune boundary only when the text has no suitable
 // natural boundary.
 func splitTextAtNaturalBoundary(content string, maxSize int) (string, string) {
-	content = strings.TrimSpace(content)
-	contentRunes := []rune(content)
+	return splitTextAtNaturalBoundaryWithWhitespaceTrimming(
+		content,
+		maxSize,
+		false,
+	)
+}
+
+func splitTextAtNaturalBoundaryWithWhitespaceTrimming(
+	content string,
+	maxSize int,
+	trimWhitespace bool,
+) (string, string) {
+	processed := content
+	if trimWhitespace {
+		processed = strings.TrimSpace(processed)
+	}
+	contentRunes := []rune(processed)
 	if maxSize <= 0 || len(contentRunes) <= maxSize {
-		return content, ""
+		return processed, ""
 	}
 
 	splitPosition := preferredTextBoundary(contentRunes, maxSize)
-	prefix := strings.TrimSpace(string(contentRunes[:splitPosition]))
-	remaining := strings.TrimSpace(string(contentRunes[splitPosition:]))
+	prefix := string(contentRunes[:splitPosition])
+	remaining := string(contentRunes[splitPosition:])
+	if trimWhitespace {
+		prefix = strings.TrimSpace(prefix)
+		remaining = strings.TrimSpace(remaining)
+	}
 	return prefix, remaining
 }
 
@@ -242,6 +324,20 @@ func splitTextWithBalancedTail(
 	maxSize int,
 	split func(string, int) (string, string),
 ) (string, string) {
+	return splitTextWithBalancedTailAndWhitespaceTrimming(
+		content,
+		maxSize,
+		split,
+		false,
+	)
+}
+
+func splitTextWithBalancedTailAndWhitespaceTrimming(
+	content string,
+	maxSize int,
+	split func(string, int) (string, string),
+	trimWhitespace bool,
+) (string, string) {
 	prefix, remaining := split(content, maxSize)
 	if remaining == "" || maxSize <= 1 {
 		return prefix, remaining
@@ -252,14 +348,18 @@ func splitTextWithBalancedTail(
 		return prefix, remaining
 	}
 
-	contentSize := encoding.RuneCount(strings.TrimSpace(content))
+	processed := content
+	if trimWhitespace {
+		processed = strings.TrimSpace(processed)
+	}
+	contentSize := encoding.RuneCount(processed)
 	balancedLimit := contentSize - minimumSize
 	if balancedLimit <= 0 || balancedLimit >= maxSize {
 		return prefix, remaining
 	}
 	balancedPrefix, balancedRemaining := split(content, balancedLimit)
 	minimumNaturalSize := max(1, maxSize*2/5)
-	contentRunes := []rune(strings.TrimSpace(content))
+	contentRunes := []rune(processed)
 	balancedPrefixSize := encoding.RuneCount(balancedPrefix)
 	balancedRemainingSize := encoding.RuneCount(balancedRemaining)
 	balancedStart := len(contentRunes) - balancedRemainingSize
@@ -277,8 +377,12 @@ func splitTextWithBalancedTail(
 		if !isNaturalTextStart(contentRunes, position) {
 			continue
 		}
-		naturalPrefix := strings.TrimSpace(string(contentRunes[:position]))
-		naturalRemaining := strings.TrimSpace(string(contentRunes[position:]))
+		naturalPrefix := string(contentRunes[:position])
+		naturalRemaining := string(contentRunes[position:])
+		if trimWhitespace {
+			naturalPrefix = strings.TrimSpace(naturalPrefix)
+			naturalRemaining = strings.TrimSpace(naturalRemaining)
+		}
 		if encoding.RuneCount(naturalPrefix) < minimumNaturalSize ||
 			encoding.RuneCount(naturalRemaining) < minimumNaturalSize {
 			continue
@@ -288,12 +392,12 @@ func splitTextWithBalancedTail(
 
 	for position := min(balancedLimit, len(contentRunes)-1); position >= minimumSize; position-- {
 		position = safeTextSplitPosition(contentRunes, position)
-		hardPrefix := strings.TrimSpace(
-			string(contentRunes[:position]),
-		)
-		hardRemaining := strings.TrimSpace(
-			string(contentRunes[position:]),
-		)
+		hardPrefix := string(contentRunes[:position])
+		hardRemaining := string(contentRunes[position:])
+		if trimWhitespace {
+			hardPrefix = strings.TrimSpace(hardPrefix)
+			hardRemaining = strings.TrimSpace(hardRemaining)
+		}
 		if encoding.RuneCount(hardPrefix) < minimumSize ||
 			encoding.RuneCount(hardRemaining) < minimumSize {
 			continue
@@ -377,6 +481,14 @@ func safeTextSplitPosition(content []rune, position int) int {
 // start would cut through a word, it advances to the next natural boundary.
 // An unbroken token still uses an exact rune suffix so overlap remains useful.
 func naturalTextSuffix(content string, maxSize int) (string, bool) {
+	return naturalTextSuffixWithWhitespaceTrimming(content, maxSize, false)
+}
+
+func naturalTextSuffixWithWhitespaceTrimming(
+	content string,
+	maxSize int,
+	trimWhitespace bool,
+) (string, bool) {
 	contentRunes := []rune(content)
 	if maxSize <= 0 || len(contentRunes) == 0 {
 		return "", false
@@ -387,17 +499,19 @@ func naturalTextSuffix(content string, maxSize int) (string, bool) {
 
 	start := len(contentRunes) - maxSize
 	if isNaturalTextStart(contentRunes, start) {
-		return strings.TrimLeftFunc(
-			string(contentRunes[start:]),
-			unicode.IsSpace,
-		), true
+		suffix := string(contentRunes[start:])
+		if trimWhitespace {
+			suffix = strings.TrimLeftFunc(suffix, unicode.IsSpace)
+		}
+		return suffix, true
 	}
 	for candidate := start + 1; candidate < len(contentRunes); candidate++ {
 		if isNaturalTextStart(contentRunes, candidate) {
-			return strings.TrimLeftFunc(
-				string(contentRunes[candidate:]),
-				unicode.IsSpace,
-			), true
+			suffix := string(contentRunes[candidate:])
+			if trimWhitespace {
+				suffix = strings.TrimLeftFunc(suffix, unicode.IsSpace)
+			}
+			return suffix, true
 		}
 	}
 	return string(contentRunes[start:]), false

--- a/knowledge/chunking/chunking.go
+++ b/knowledge/chunking/chunking.go
@@ -46,12 +46,6 @@ func validateChunkConfig(chunkSize, overlap int) error {
 	}
 }
 
-// cleanText normalizes encoding and line breaks while preserving source
-// whitespace.
-func cleanText(content string) string {
-	return cleanTextWithWhitespaceTrimming(content, false)
-}
-
 func cleanTextWithWhitespaceTrimming(
 	content string,
 	trimWhitespace bool,
@@ -89,6 +83,110 @@ func isBlankText(content string) bool {
 	return strings.TrimSpace(content) == ""
 }
 
+func attachLeadingWhitespace(
+	pending string,
+	content string,
+	maxSize int,
+) (string, string) {
+	if pending == "" || maxSize <= 0 || isBlankText(content) {
+		return content, ""
+	}
+
+	contentRunes := []rune(content)
+	firstContent := 0
+	for firstContent < len(contentRunes) &&
+		unicode.IsSpace(contentRunes[firstContent]) {
+		firstContent++
+	}
+	if firstContent == len(contentRunes) {
+		return "", ""
+	}
+
+	leading := append([]rune(pending), contentRunes[:firstContent]...)
+	maxLeading := maxSize - 1
+	if len(leading) > maxLeading {
+		leading = leading[len(leading)-maxLeading:]
+	}
+
+	contentCapacity := maxSize - len(leading)
+	contentEnd := min(len(contentRunes), firstContent+contentCapacity)
+	attached := string(leading) + string(contentRunes[firstContent:contentEnd])
+	return attached, string(contentRunes[contentEnd:])
+}
+
+func attachTrailingWhitespace(content string, pending string, maxSize int) string {
+	available := maxSize - encoding.RuneCount(content)
+	if available <= 0 || pending == "" {
+		return content
+	}
+	pendingRunes := []rune(pending)
+	return content + string(pendingRunes[:min(available, len(pendingRunes))])
+}
+
+func coalesceWhitespaceChunks(
+	chunks []string,
+	firstChunkSize int,
+	nextChunkSize int,
+) []string {
+	if nextChunkSize <= 0 {
+		nextChunkSize = firstChunkSize
+	}
+	queue := append([]string(nil), chunks...)
+	result := make([]string, 0, len(chunks))
+	var pending strings.Builder
+
+	for len(queue) > 0 {
+		content := queue[0]
+		queue = queue[1:]
+		if content == "" {
+			continue
+		}
+		if isBlankText(content) {
+			pending.WriteString(content)
+			continue
+		}
+
+		chunkSize := nextChunkSize
+		if len(result) == 0 {
+			chunkSize = firstChunkSize
+		}
+		if encoding.RuneCount(content) > chunkSize {
+			pieces := encoding.SafeSplitBySize(content, chunkSize)
+			queue = append(pieces, queue...)
+			continue
+		}
+
+		if pending.Len() > 0 {
+			attached, remaining := attachLeadingWhitespace(
+				pending.String(),
+				content,
+				chunkSize,
+			)
+			pending.Reset()
+			result = append(result, attached)
+			if remaining != "" {
+				queue = append([]string{remaining}, queue...)
+			}
+			continue
+		}
+		result = append(result, content)
+	}
+
+	if pending.Len() > 0 && len(result) > 0 {
+		last := len(result) - 1
+		chunkSize := nextChunkSize
+		if last == 0 {
+			chunkSize = firstChunkSize
+		}
+		result[last] = attachTrailingWhitespace(
+			result[last],
+			pending.String(),
+			chunkSize,
+		)
+	}
+	return result
+}
+
 // createChunk creates a new document chunk with appropriate metadata.
 func createChunk(originalDoc *document.Document, content string, chunkNumber int) *document.Document {
 	// Create a copy of the original metadata.
@@ -121,23 +219,6 @@ func createChunk(originalDoc *document.Document, content string, chunkNumber int
 	}
 }
 
-func joinWithOverlap(
-	previous string,
-	current string,
-	maxOverlap int,
-	maxSize int,
-	separator string,
-) (string, int) {
-	return joinWithOverlapMode(
-		previous,
-		current,
-		maxOverlap,
-		maxSize,
-		separator,
-		false,
-	)
-}
-
 func joinWithOverlapMode(
 	previous string,
 	current string,
@@ -154,25 +235,6 @@ func joinWithOverlapMode(
 		separator,
 		false,
 		trimWhitespace,
-	)
-}
-
-func joinWithOverlapSeparator(
-	previous string,
-	current string,
-	maxOverlap int,
-	maxSize int,
-	separator string,
-	preserveSeparator bool,
-) (string, int) {
-	return joinWithOverlapSeparatorMode(
-		previous,
-		current,
-		maxOverlap,
-		maxSize,
-		separator,
-		preserveSeparator,
-		false,
 	)
 }
 
@@ -282,18 +344,6 @@ func sourceGapSeparator(gap string, fallback string) string {
 	return " "
 }
 
-// splitTextAtNaturalBoundary splits one prefix from content without exceeding
-// maxSize. It prefers line, sentence, punctuation, and whitespace boundaries,
-// falling back to an exact rune boundary only when the text has no suitable
-// natural boundary.
-func splitTextAtNaturalBoundary(content string, maxSize int) (string, string) {
-	return splitTextAtNaturalBoundaryWithWhitespaceTrimming(
-		content,
-		maxSize,
-		false,
-	)
-}
-
 func splitTextAtNaturalBoundaryWithWhitespaceTrimming(
 	content string,
 	maxSize int,
@@ -316,23 +366,6 @@ func splitTextAtNaturalBoundaryWithWhitespaceTrimming(
 		remaining = strings.TrimSpace(remaining)
 	}
 	return prefix, remaining
-}
-
-// splitTextWithBalancedTail avoids leaving a very small final piece when one
-// logical block needs multiple chunks. It first keeps the splitter's normal
-// boundary choice. Only when that choice would leave less than half a chunk
-// does it move the boundary earlier, without crossing the size budget.
-func splitTextWithBalancedTail(
-	content string,
-	maxSize int,
-	split func(string, int) (string, string),
-) (string, string) {
-	return splitTextWithBalancedTailAndWhitespaceTrimming(
-		content,
-		maxSize,
-		split,
-		false,
-	)
 }
 
 func splitTextWithBalancedTailAndWhitespaceTrimming(
@@ -478,13 +511,6 @@ func safeTextSplitPosition(content []rune, position int) int {
 		return originalPosition
 	}
 	return position
-}
-
-// naturalTextSuffix returns at most maxSize trailing runes. When the exact
-// start would cut through a word, it advances to the next natural boundary.
-// An unbroken token still uses an exact rune suffix so overlap remains useful.
-func naturalTextSuffix(content string, maxSize int) (string, bool) {
-	return naturalTextSuffixWithWhitespaceTrimming(content, maxSize, false)
 }
 
 func naturalTextSuffixWithWhitespaceTrimming(

--- a/knowledge/chunking/chunking.go
+++ b/knowledge/chunking/chunking.go
@@ -123,6 +123,35 @@ func attachTrailingWhitespace(content string, pending string, maxSize int) strin
 	return content + string(pendingRunes[:min(available, len(pendingRunes))])
 }
 
+func preserveLeadingWhitespaceWithPrevious(
+	previous string,
+	pending string,
+	content string,
+	previousMaxSize int,
+	currentMaxSize int,
+) (string, string, string) {
+	previousCapacity := previousMaxSize - encoding.RuneCount(previous)
+	if previousCapacity <= 0 || pending == "" || currentMaxSize <= 0 {
+		return previous, pending, content
+	}
+
+	contentRunes := []rune(content)
+	firstContent := 0
+	for firstContent < len(contentRunes) &&
+		unicode.IsSpace(contentRunes[firstContent]) {
+		firstContent++
+	}
+	leading := append([]rune(pending), contentRunes[:firstContent]...)
+	overflow := len(leading) - (currentMaxSize - 1)
+	if overflow <= 0 {
+		return previous, pending, content
+	}
+
+	preserved := min(previousCapacity, overflow)
+	previous += string(leading[:preserved])
+	return previous, string(leading[preserved:]), string(contentRunes[firstContent:])
+}
+
 func coalesceWhitespaceChunks(
 	chunks []string,
 	firstChunkSize int,
@@ -157,6 +186,25 @@ func coalesceWhitespaceChunks(
 		}
 
 		if pending.Len() > 0 {
+			if len(result) > 0 {
+				previous := len(result) - 1
+				previousSize := nextChunkSize
+				if previous == 0 {
+					previousSize = firstChunkSize
+				}
+				updatedPrevious, remainingPending, remainingContent :=
+					preserveLeadingWhitespaceWithPrevious(
+						result[previous],
+						pending.String(),
+						content,
+						previousSize,
+						chunkSize,
+					)
+				result[previous] = updatedPrevious
+				pending.Reset()
+				pending.WriteString(remainingPending)
+				content = remainingContent
+			}
 			attached, remaining := attachLeadingWhitespace(
 				pending.String(),
 				content,

--- a/knowledge/chunking/chunking.go
+++ b/knowledge/chunking/chunking.go
@@ -238,6 +238,7 @@ func sourceChunkSeparators(
 	content string,
 	chunks []string,
 	fallback string,
+	trimWhitespace bool,
 ) []string {
 	separators := make([]string, len(chunks))
 	searchFrom := 0
@@ -252,10 +253,12 @@ func sourceChunkSeparators(
 		}
 		start := searchFrom + position
 		if i > 0 {
-			separators[i] = sourceGapSeparator(
-				content[previousEnd:start],
-				fallback,
-			)
+			gap := content[previousEnd:start]
+			if !trimWhitespace && strings.TrimSpace(gap) == "" {
+				separators[i] = gap
+			} else {
+				separators[i] = sourceGapSeparator(gap, fallback)
+			}
 		}
 		previousEnd = start + len(chunk)
 		searchFrom = previousEnd

--- a/knowledge/chunking/chunking_test.go
+++ b/knowledge/chunking/chunking_test.go
@@ -385,6 +385,22 @@ func TestJoinWithOverlapPreservesIndentedSuffix(t *testing.T) {
 	require.Equal(t, 8, legacyOverlapSize)
 }
 
+func TestSourceChunkSeparatorsWhitespaceModes(t *testing.T) {
+	content := "before\n \t\nafter"
+	chunks := []string{"before", "after"}
+
+	separators := sourceChunkSeparators(content, chunks, "\n\n", false)
+	require.Equal(t, []string{"", "\n \t\n"}, separators)
+
+	legacySeparators := sourceChunkSeparators(
+		content,
+		chunks,
+		"\n\n",
+		true,
+	)
+	require.Equal(t, []string{"", "\n"}, legacySeparators)
+}
+
 // TestDefaultConstants tests the default constants
 func TestDefaultConstants(t *testing.T) {
 	assert.Equal(t, 1024, defaultChunkSize)

--- a/knowledge/chunking/chunking_test.go
+++ b/knowledge/chunking/chunking_test.go
@@ -10,6 +10,7 @@
 package chunking
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -70,7 +71,7 @@ func TestCleanText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := cleanText(tt.input)
+			result := cleanTextWithWhitespaceTrimming(tt.input, false)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -273,12 +274,13 @@ func TestJoinWithOverlap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, overlapSize := joinWithOverlap(
+			content, overlapSize := joinWithOverlapMode(
 				tt.previous,
 				tt.current,
 				tt.maxOverlap,
 				tt.maxSize,
 				tt.separator,
+				false,
 			)
 			assert.Equal(t, tt.wantContent, content)
 			assert.Equal(t, tt.wantOverlapSize, overlapSize)
@@ -327,9 +329,10 @@ func TestSplitTextAtNaturalBoundaryPreservesSentenceAtoms(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefix, remaining := splitTextAtNaturalBoundary(
+			prefix, remaining := splitTextAtNaturalBoundaryWithWhitespaceTrimming(
 				tt.content,
 				tt.maxSize,
+				false,
 			)
 			require.Equal(t, tt.wantPrefix, prefix)
 			require.Equal(t, tt.wantRemaining, remaining)
@@ -338,9 +341,10 @@ func TestSplitTextAtNaturalBoundaryPreservesSentenceAtoms(t *testing.T) {
 }
 
 func TestSplitTextAtNaturalBoundaryPreservesIndentation(t *testing.T) {
-	prefix, remaining := splitTextAtNaturalBoundary(
+	prefix, remaining := splitTextAtNaturalBoundaryWithWhitespaceTrimming(
 		"header line\n\treturn value",
 		12,
+		false,
 	)
 
 	require.Equal(t, "header line\n", prefix)
@@ -348,7 +352,11 @@ func TestSplitTextAtNaturalBoundaryPreservesIndentation(t *testing.T) {
 }
 
 func TestNaturalTextSuffixPreservesIndentation(t *testing.T) {
-	suffix, natural := naturalTextSuffix("header\n\treturn 1", 9)
+	suffix, natural := naturalTextSuffixWithWhitespaceTrimming(
+		"header\n\treturn 1",
+		9,
+		false,
+	)
 	require.True(t, natural)
 	require.Equal(t, "\treturn 1", suffix)
 
@@ -399,6 +407,178 @@ func TestSourceChunkSeparatorsWhitespaceModes(t *testing.T) {
 		true,
 	)
 	require.Equal(t, []string{"", "\n"}, legacySeparators)
+}
+
+func TestCoalesceWhitespaceChunks(t *testing.T) {
+	tests := []struct {
+		name           string
+		chunks         []string
+		firstChunkSize int
+		nextChunkSize  int
+		expected       []string
+	}{
+		{
+			name:           "long boundary whitespace",
+			chunks:         []string{"      ", "界ab", "   "},
+			firstChunkSize: 4,
+			nextChunkSize:  4,
+			expected:       []string{"   界", "ab  "},
+		},
+		{
+			name:           "long internal whitespace",
+			chunks:         []string{"A", "      ", "BC"},
+			firstChunkSize: 4,
+			nextChunkSize:  3,
+			expected:       []string{"A", "  B", "C"},
+		},
+		{
+			name:           "one rune budget",
+			chunks:         []string{"  ", "界", " \t"},
+			firstChunkSize: 1,
+			nextChunkSize:  1,
+			expected:       []string{"界"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := coalesceWhitespaceChunks(
+				tt.chunks,
+				tt.firstChunkSize,
+				tt.nextChunkSize,
+			)
+			require.Equal(t, tt.expected, actual)
+			for i, content := range actual {
+				require.NotEmpty(t, strings.TrimSpace(content))
+				maxSize := tt.nextChunkSize
+				if i == 0 {
+					maxSize = tt.firstChunkSize
+				}
+				require.LessOrEqual(
+					t,
+					utf8.RuneCountInString(content),
+					maxSize,
+				)
+			}
+		})
+	}
+}
+
+func TestChunkingStrategiesNeverEmitWhitespaceOnlyChunks(t *testing.T) {
+	const (
+		chunkSize = 6
+		overlap   = 2
+	)
+	type chunker interface {
+		Chunk(*document.Document) ([]*document.Document, error)
+	}
+	type strategy struct {
+		name string
+		new  func(trimWhitespace bool, withOverlap bool) chunker
+	}
+	strategies := []strategy{
+		{
+			name: "fixed",
+			new: func(trimWhitespace bool, withOverlap bool) chunker {
+				options := []Option{WithChunkSize(chunkSize)}
+				if trimWhitespace {
+					options = append(options, WithWhitespaceTrimming())
+				}
+				if withOverlap {
+					options = append(options, WithOverlap(overlap))
+				}
+				return NewFixedSizeChunking(options...)
+			},
+		},
+		{
+			name: "recursive",
+			new: func(trimWhitespace bool, withOverlap bool) chunker {
+				options := []RecursiveOption{
+					WithRecursiveChunkSize(chunkSize),
+					WithRecursiveSeparators([]string{" ", ""}),
+				}
+				if trimWhitespace {
+					options = append(
+						options,
+						WithRecursiveWhitespaceTrimming(),
+					)
+				}
+				if withOverlap {
+					options = append(
+						options,
+						WithRecursiveOverlap(overlap),
+					)
+				}
+				return NewRecursiveChunking(options...)
+			},
+		},
+		{
+			name: "markdown",
+			new: func(trimWhitespace bool, withOverlap bool) chunker {
+				options := []MarkdownOption{
+					WithMarkdownChunkSize(chunkSize),
+				}
+				if trimWhitespace {
+					options = append(
+						options,
+						WithMarkdownWhitespaceTrimming(),
+					)
+				}
+				if withOverlap {
+					options = append(
+						options,
+						WithMarkdownOverlap(overlap),
+					)
+				}
+				return NewMarkdownChunking(options...)
+			},
+		},
+	}
+	contents := []string{
+		"          A          B          ",
+		"\t\t界\t\tA\t\t",
+		"     a",
+		"a     ",
+	}
+
+	for _, strategy := range strategies {
+		for _, trimWhitespace := range []bool{false, true} {
+			for _, withOverlap := range []bool{false, true} {
+				name := strategy.name
+				if trimWhitespace {
+					name += "/legacy"
+				} else {
+					name += "/preserve"
+				}
+				if withOverlap {
+					name += "/overlap"
+				} else {
+					name += "/no-overlap"
+				}
+				t.Run(name, func(t *testing.T) {
+					for _, content := range contents {
+						chunks, err := strategy.new(
+							trimWhitespace,
+							withOverlap,
+						).Chunk(&document.Document{Content: content})
+						require.NoError(t, err)
+						require.NotEmpty(t, chunks)
+						for _, chunk := range chunks {
+							require.NotEmpty(
+								t,
+								strings.TrimSpace(chunk.Content),
+							)
+							require.LessOrEqual(
+								t,
+								utf8.RuneCountInString(chunk.Content),
+								chunkSize,
+							)
+						}
+					}
+				})
+			}
+		}
+	}
 }
 
 // TestDefaultConstants tests the default constants

--- a/knowledge/chunking/chunking_test.go
+++ b/knowledge/chunking/chunking_test.go
@@ -425,11 +425,18 @@ func TestCoalesceWhitespaceChunks(t *testing.T) {
 			expected:       []string{"   界", "ab  "},
 		},
 		{
+			name:           "preceding capacity avoids loss",
+			chunks:         []string{"A", "   ", "B"},
+			firstChunkSize: 4,
+			nextChunkSize:  3,
+			expected:       []string{"A ", "  B"},
+		},
+		{
 			name:           "long internal whitespace",
 			chunks:         []string{"A", "      ", "BC"},
 			firstChunkSize: 4,
 			nextChunkSize:  3,
-			expected:       []string{"A", "  B", "C"},
+			expected:       []string{"A   ", "  B", "C"},
 		},
 		{
 			name:           "one rune budget",

--- a/knowledge/chunking/chunking_test.go
+++ b/knowledge/chunking/chunking_test.go
@@ -44,12 +44,12 @@ func TestCleanText(t *testing.T) {
 		{
 			name:     "text_with_leading_trailing_spaces",
 			input:    "  Hello World  ",
-			expected: "Hello World",
+			expected: "  Hello World  ",
 		},
 		{
 			name:     "text_with_extra_spaces_in_lines",
 			input:    "Line1  \n  Line2  \n  Line3  ",
-			expected: "Line1\nLine2\nLine3",
+			expected: "Line1  \n  Line2  \n  Line3  ",
 		},
 		{
 			name:     "empty_string",
@@ -74,6 +74,16 @@ func TestCleanText(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestCleanTextWithWhitespaceTrimming(t *testing.T) {
+	input := "  def f():  \r\n\treturn 1\t\r\n"
+
+	require.Equal(
+		t,
+		"def f():\nreturn 1",
+		cleanTextWithWhitespaceTrimming(input, true),
+	)
 }
 
 // TestCreateChunk tests the createChunk function
@@ -290,21 +300,21 @@ func TestSplitTextAtNaturalBoundaryPreservesSentenceAtoms(t *testing.T) {
 			content:       "prefix 12.6 suffix",
 			maxSize:       10,
 			wantPrefix:    "prefix",
-			wantRemaining: "12.6 suffix",
+			wantRemaining: " 12.6 suffix",
 		},
 		{
 			name:          "dotted section",
 			content:       "prefix 2.8.12 suffix",
 			maxSize:       11,
 			wantPrefix:    "prefix",
-			wantRemaining: "2.8.12 suffix",
+			wantRemaining: " 2.8.12 suffix",
 		},
 		{
 			name:          "semantic version",
 			content:       "prefix v1.2.3 suffix",
 			maxSize:       11,
 			wantPrefix:    "prefix",
-			wantRemaining: "v1.2.3 suffix",
+			wantRemaining: " v1.2.3 suffix",
 		},
 		{
 			name:          "CJK punctuation cluster",
@@ -325,6 +335,54 @@ func TestSplitTextAtNaturalBoundaryPreservesSentenceAtoms(t *testing.T) {
 			require.Equal(t, tt.wantRemaining, remaining)
 		})
 	}
+}
+
+func TestSplitTextAtNaturalBoundaryPreservesIndentation(t *testing.T) {
+	prefix, remaining := splitTextAtNaturalBoundary(
+		"header line\n\treturn value",
+		12,
+	)
+
+	require.Equal(t, "header line\n", prefix)
+	require.Equal(t, "\treturn value", remaining)
+}
+
+func TestNaturalTextSuffixPreservesIndentation(t *testing.T) {
+	suffix, natural := naturalTextSuffix("header\n\treturn 1", 9)
+	require.True(t, natural)
+	require.Equal(t, "\treturn 1", suffix)
+
+	legacySuffix, natural := naturalTextSuffixWithWhitespaceTrimming(
+		"header\n\treturn 1",
+		9,
+		true,
+	)
+	require.True(t, natural)
+	require.Equal(t, "return 1", legacySuffix)
+}
+
+func TestJoinWithOverlapPreservesIndentedSuffix(t *testing.T) {
+	content, overlapSize := joinWithOverlapMode(
+		"header\n\treturn 1",
+		"next",
+		9,
+		14,
+		"\n",
+		false,
+	)
+	require.Equal(t, "\treturn 1\nnext", content)
+	require.Equal(t, 9, overlapSize)
+
+	legacyContent, legacyOverlapSize := joinWithOverlapMode(
+		"header\n\treturn 1",
+		"next",
+		9,
+		14,
+		"\n",
+		true,
+	)
+	require.Equal(t, "return 1\nnext", legacyContent)
+	require.Equal(t, 8, legacyOverlapSize)
 }
 
 // TestDefaultConstants tests the default constants

--- a/knowledge/chunking/fixed.go
+++ b/knowledge/chunking/fixed.go
@@ -119,6 +119,13 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 			split,
 			f.trimWhitespace,
 		)
+		if !f.trimWhitespace {
+			textChunks = coalesceFixedWhitespaceChunks(
+				textChunks,
+				f.chunkSize,
+				coreSize,
+			)
+		}
 	} else {
 		splitChunks := splitFixedText(
 			content,
@@ -193,8 +200,9 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 }
 
 type fixedTextChunk struct {
-	content       string
-	startsNewLine bool
+	content         string
+	startsNewLine   bool
+	separatorBefore string
 }
 
 func splitFixedLines(
@@ -209,6 +217,7 @@ func splitFixedLines(
 	}
 	var chunks []fixedTextChunk
 	var current string
+	var currentSeparator string
 	hasCurrent := false
 
 	chunkSize := func() int {
@@ -218,25 +227,33 @@ func splitFixedLines(
 		return nextChunkSize
 	}
 	flush := func() {
-		if !hasCurrent || current == "" {
+		if !hasCurrent {
 			current = ""
+			currentSeparator = ""
 			hasCurrent = false
 			return
 		}
-		if strings.TrimSpace(current) == "" {
+		if trimWhitespace && strings.TrimSpace(current) == "" {
 			current = ""
+			currentSeparator = ""
 			hasCurrent = false
 			return
 		}
 		chunks = append(chunks, fixedTextChunk{
-			content:       current,
-			startsNewLine: true,
+			content:         current,
+			startsNewLine:   true,
+			separatorBefore: currentSeparator,
 		})
 		current = ""
+		currentSeparator = ""
 		hasCurrent = false
 	}
 
-	for _, line := range strings.Split(content, "\n") {
+	for lineIndex, line := range strings.Split(content, "\n") {
+		lineSeparator := ""
+		if lineIndex > 0 {
+			lineSeparator = "\n"
+		}
 		if hasCurrent {
 			candidate := current + "\n" + line
 			if encoding.RuneCount(candidate) <= chunkSize() {
@@ -248,6 +265,7 @@ func splitFixedLines(
 
 		if encoding.RuneCount(line) <= chunkSize() {
 			current = line
+			currentSeparator = lineSeparator
 			hasCurrent = true
 			continue
 		}
@@ -261,14 +279,122 @@ func splitFixedLines(
 			trimWhitespace,
 		)
 		for i, piece := range pieces {
+			separatorBefore := ""
+			if i == 0 {
+				separatorBefore = lineSeparator
+			}
 			chunks = append(chunks, fixedTextChunk{
-				content:       piece,
-				startsNewLine: i == 0,
+				content:         piece,
+				startsNewLine:   i == 0,
+				separatorBefore: separatorBefore,
 			})
 		}
 	}
 	flush()
 	return chunks
+}
+
+func coalesceFixedWhitespaceChunks(
+	chunks []fixedTextChunk,
+	firstChunkSize int,
+	nextChunkSize int,
+) []fixedTextChunk {
+	if nextChunkSize <= 0 {
+		nextChunkSize = firstChunkSize
+	}
+	queue := append([]fixedTextChunk(nil), chunks...)
+	result := make([]fixedTextChunk, 0, len(chunks))
+	var pending strings.Builder
+	pendingActive := false
+
+	for len(queue) > 0 {
+		chunk := queue[0]
+		queue = queue[1:]
+		if isBlankText(chunk.content) {
+			pending.WriteString(chunk.separatorBefore)
+			pending.WriteString(chunk.content)
+			pendingActive = true
+			continue
+		}
+
+		chunkSize := nextChunkSize
+		if len(result) == 0 {
+			chunkSize = firstChunkSize
+		}
+		if encoding.RuneCount(chunk.content) > chunkSize {
+			pieces := encoding.SafeSplitBySize(chunk.content, chunkSize)
+			replacement := make([]fixedTextChunk, 0, len(pieces)+len(queue))
+			for i, piece := range pieces {
+				separatorBefore := ""
+				startsNewLine := false
+				if i == 0 {
+					separatorBefore = chunk.separatorBefore
+					startsNewLine = chunk.startsNewLine
+				}
+				replacement = append(replacement, fixedTextChunk{
+					content:         piece,
+					startsNewLine:   startsNewLine,
+					separatorBefore: separatorBefore,
+				})
+			}
+			queue = append(replacement, queue...)
+			continue
+		}
+
+		if pendingActive {
+			pending.WriteString(chunk.separatorBefore)
+			content := chunk.content
+			if len(result) > 0 {
+				previous := len(result) - 1
+				previousSize := nextChunkSize
+				if previous == 0 {
+					previousSize = firstChunkSize
+				}
+				updatedPrevious, remainingPending, remainingContent :=
+					preserveLeadingWhitespaceWithPrevious(
+						result[previous].content,
+						pending.String(),
+						content,
+						previousSize,
+						chunkSize,
+					)
+				result[previous].content = updatedPrevious
+				pending.Reset()
+				pending.WriteString(remainingPending)
+				content = remainingContent
+			}
+			attached, remaining := attachLeadingWhitespace(
+				pending.String(),
+				content,
+				chunkSize,
+			)
+			pending.Reset()
+			pendingActive = false
+			result = append(result, fixedTextChunk{
+				content:       attached,
+				startsNewLine: len(result) == 0 && chunk.startsNewLine,
+			})
+			if remaining != "" {
+				queue = append([]fixedTextChunk{{content: remaining}}, queue...)
+			}
+			continue
+		}
+		result = append(result, chunk)
+	}
+
+	if pendingActive && len(result) > 0 {
+		last := len(result) - 1
+		chunkSize := nextChunkSize
+		if last == 0 {
+			chunkSize = firstChunkSize
+		}
+		result[last].content = attachTrailingWhitespace(
+			result[last].content,
+			pending.String(),
+			chunkSize,
+		)
+	}
+	return result
 }
 
 func splitFixedText(

--- a/knowledge/chunking/fixed.go
+++ b/knowledge/chunking/fixed.go
@@ -138,7 +138,12 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 	for i, textChunk := range textChunks {
 		rawContents[i] = textChunk.content
 	}
-	separators := sourceChunkSeparators(content, rawContents, " ")
+	separators := sourceChunkSeparators(
+		content,
+		rawContents,
+		" ",
+		f.trimWhitespace,
+	)
 	for i, textChunk := range textChunks {
 		finalContent := textChunk.content
 		actualOverlap := 0
@@ -199,7 +204,12 @@ func splitFixedLines(
 		return nextChunkSize
 	}
 	flush := func() {
-		if !hasCurrent || strings.TrimSpace(current) == "" {
+		if !hasCurrent {
+			current = ""
+			hasCurrent = false
+			return
+		}
+		if trimWhitespace && strings.TrimSpace(current) == "" {
 			current = ""
 			hasCurrent = false
 			return

--- a/knowledge/chunking/fixed.go
+++ b/knowledge/chunking/fixed.go
@@ -128,11 +128,25 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 			true,
 			f.trimWhitespace,
 		)
+		if !f.trimWhitespace {
+			splitChunks = coalesceWhitespaceChunks(
+				splitChunks,
+				f.chunkSize,
+				coreSize,
+			)
+		}
 		textChunks = make([]fixedTextChunk, 0, len(splitChunks))
 		for _, chunk := range splitChunks {
 			textChunks = append(textChunks, fixedTextChunk{content: chunk})
 		}
 	}
+	semanticChunks := textChunks[:0]
+	for _, textChunk := range textChunks {
+		if !isBlankText(textChunk.content) {
+			semanticChunks = append(semanticChunks, textChunk)
+		}
+	}
+	textChunks = semanticChunks
 	chunks := make([]*document.Document, 0, len(textChunks))
 	rawContents := make([]string, len(textChunks))
 	for i, textChunk := range textChunks {
@@ -209,7 +223,7 @@ func splitFixedLines(
 			hasCurrent = false
 			return
 		}
-		if trimWhitespace && strings.TrimSpace(current) == "" {
+		if strings.TrimSpace(current) == "" {
 			current = ""
 			hasCurrent = false
 			return

--- a/knowledge/chunking/fixed.go
+++ b/knowledge/chunking/fixed.go
@@ -19,9 +19,10 @@ import (
 
 // FixedSizeChunking implements a chunking strategy that splits text into fixed-size chunks.
 type FixedSizeChunking struct {
-	chunkSize     int
-	overlap       int
-	preserveLines bool
+	chunkSize      int
+	overlap        int
+	preserveLines  bool
+	trimWhitespace bool
 }
 
 // Option represents a functional option for configuring FixedSizeChunking.
@@ -46,6 +47,14 @@ func WithOverlap(overlap int) Option {
 func WithPreserveLines() Option {
 	return func(fsc *FixedSizeChunking) {
 		fsc.preserveLines = true
+	}
+}
+
+// WithWhitespaceTrimming enables the legacy behavior that trims leading and
+// trailing whitespace from the document, every line, and chunk boundaries.
+func WithWhitespaceTrimming() Option {
+	return func(fsc *FixedSizeChunking) {
+		fsc.trimWhitespace = true
 	}
 }
 
@@ -75,7 +84,13 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 		return nil, ErrEmptyDocument
 	}
 
-	content := cleanText(doc.Content)
+	content := cleanTextWithWhitespaceTrimming(
+		doc.Content,
+		f.trimWhitespace,
+	)
+	if isBlankText(content) {
+		return nil, ErrEmptyDocument
+	}
 	contentLength := encoding.RuneCount(content)
 
 	// If content is smaller than chunk size, return as single chunk.
@@ -89,15 +104,29 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 		coreSize = f.chunkSize - f.overlap
 	}
 	var textChunks []fixedTextChunk
+	split := func(content string, maxSize int) (string, string) {
+		return splitTextAtNaturalBoundaryWithWhitespaceTrimming(
+			content,
+			maxSize,
+			f.trimWhitespace,
+		)
+	}
 	if f.preserveLines {
-		textChunks = splitFixedLines(content, f.chunkSize, coreSize)
+		textChunks = splitFixedLines(
+			content,
+			f.chunkSize,
+			coreSize,
+			split,
+			f.trimWhitespace,
+		)
 	} else {
 		splitChunks := splitFixedText(
 			content,
 			f.chunkSize,
 			coreSize,
-			splitTextAtNaturalBoundary,
+			split,
 			true,
+			f.trimWhitespace,
 		)
 		textChunks = make([]fixedTextChunk, 0, len(splitChunks))
 		for _, chunk := range splitChunks {
@@ -123,13 +152,14 @@ func (f *FixedSizeChunking) Chunk(doc *document.Document) ([]*document.Document,
 					preserveSeparator = true
 				}
 			}
-			finalContent, actualOverlap = joinWithOverlapSeparator(
+			finalContent, actualOverlap = joinWithOverlapSeparatorMode(
 				chunks[i-1].Content,
 				textChunk.content,
 				f.overlap,
 				f.chunkSize,
 				separator,
 				preserveSeparator,
+				f.trimWhitespace,
 			)
 		}
 		chunk := createChunk(doc, textChunk.content, i+1)
@@ -152,6 +182,8 @@ func splitFixedLines(
 	content string,
 	firstChunkSize int,
 	nextChunkSize int,
+	split func(string, int) (string, string),
+	trimWhitespace bool,
 ) []fixedTextChunk {
 	if nextChunkSize <= 0 {
 		nextChunkSize = firstChunkSize
@@ -200,8 +232,9 @@ func splitFixedLines(
 			line,
 			chunkSize(),
 			nextChunkSize,
-			splitTextAtNaturalBoundary,
+			split,
 			true,
+			trimWhitespace,
 		)
 		for i, piece := range pieces {
 			chunks = append(chunks, fixedTextChunk{
@@ -220,6 +253,7 @@ func splitFixedText(
 	nextChunkSize int,
 	split func(string, int) (string, string),
 	balanceTail bool,
+	trimWhitespace bool,
 ) []string {
 	if firstChunkSize <= 0 {
 		return []string{content}
@@ -237,15 +271,16 @@ func splitFixedText(
 		}
 		chunk, rest := split(remaining, chunkSize)
 		if balanceTail {
-			chunk, rest = splitTextWithBalancedTail(
+			chunk, rest = splitTextWithBalancedTailAndWhitespaceTrimming(
 				remaining,
 				chunkSize,
 				split,
+				trimWhitespace,
 			)
 		}
 		if chunk == "" {
-			// The natural-boundary helper trims whitespace. Keep a hard-split
-			// fallback to guarantee progress for whitespace-only input.
+			// Keep a hard-split fallback to guarantee progress when a custom
+			// splitter returns an empty prefix.
 			hardChunks := encoding.SafeSplitBySize(remaining, chunkSize)
 			chunk = hardChunks[0]
 			rest = remaining[len(chunk):]

--- a/knowledge/chunking/fixed.go
+++ b/knowledge/chunking/fixed.go
@@ -204,7 +204,7 @@ func splitFixedLines(
 		return nextChunkSize
 	}
 	flush := func() {
-		if !hasCurrent {
+		if !hasCurrent || current == "" {
 			current = ""
 			hasCurrent = false
 			return

--- a/knowledge/chunking/fixed_test.go
+++ b/knowledge/chunking/fixed_test.go
@@ -319,7 +319,7 @@ func TestFixedSizeChunking_WhitespaceOnlyDocument(t *testing.T) {
 	require.Nil(t, chunks)
 }
 
-func TestFixedSizeChunking_PreserveLinesKeepsWhitespaceBoundaries(t *testing.T) {
+func TestFixedSizeChunking_PreserveLinesDropsWhitespaceOnlyChunks(t *testing.T) {
 	const chunkSize = 5
 	content := " \t\naaaaa\n\t "
 	doc := &document.Document{ID: "blank-lines", Content: content}
@@ -329,11 +329,10 @@ func TestFixedSizeChunking_PreserveLinesKeepsWhitespaceBoundaries(t *testing.T) 
 		WithPreserveLines(),
 	).Chunk(doc)
 	require.NoError(t, err)
-	require.Len(t, chunks, 3)
-	require.Equal(t, " \t", chunks[0].Content)
-	require.Equal(t, "aaaaa", chunks[1].Content)
-	require.Equal(t, "\t ", chunks[2].Content)
+	require.Len(t, chunks, 1)
+	require.Equal(t, "aaaaa", chunks[0].Content)
 	for _, chunk := range chunks {
+		require.NotEmpty(t, strings.TrimSpace(chunk.Content))
 		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
 	}
 
@@ -345,6 +344,23 @@ func TestFixedSizeChunking_PreserveLinesKeepsWhitespaceBoundaries(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, legacyChunks, 1)
 	require.Equal(t, "aaaaa", legacyChunks[0].Content)
+}
+
+func TestFixedSizeChunking_PreserveLinesAttachesWhitespaceWhenItFits(t *testing.T) {
+	const chunkSize = 5
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithPreserveLines(),
+	).Chunk(&document.Document{Content: " \nAA\nBBBB"})
+
+	require.NoError(t, err)
+	require.Len(t, chunks, 2)
+	require.Equal(t, " \nAA", chunks[0].Content)
+	require.Equal(t, "BBBB", chunks[1].Content)
+	for _, chunk := range chunks {
+		require.NotEmpty(t, strings.TrimSpace(chunk.Content))
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+	}
 }
 
 func TestFixedSizeChunking_PreserveLinesSkipsEmptyChunks(t *testing.T) {

--- a/knowledge/chunking/fixed_test.go
+++ b/knowledge/chunking/fixed_test.go
@@ -347,6 +347,56 @@ func TestFixedSizeChunking_PreserveLinesKeepsWhitespaceBoundaries(t *testing.T) 
 	require.Equal(t, "aaaaa", legacyChunks[0].Content)
 }
 
+func TestFixedSizeChunking_PreserveLinesSkipsEmptyChunks(t *testing.T) {
+	const chunkSize = 5
+	doc := &document.Document{
+		ID:      "empty-line-boundary",
+		Content: "aaaaa\n\nbbbbb",
+	}
+
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithPreserveLines(),
+	).Chunk(doc)
+
+	require.NoError(t, err)
+	require.Len(t, chunks, 2)
+	require.Equal(t, []string{"aaaaa", "bbbbb"}, []string{
+		chunks[0].Content,
+		chunks[1].Content,
+	})
+	for _, chunk := range chunks {
+		require.NotEmpty(t, chunk.Content)
+		require.NotZero(t, chunk.Metadata[source.MetaChunkSize])
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+	}
+}
+
+func TestFixedSizeChunking_PreserveLinesOverlapSkipsEmptyChunks(t *testing.T) {
+	const (
+		chunkSize = 5
+		overlap   = 2
+	)
+	doc := &document.Document{
+		ID:      "empty-line-overlap",
+		Content: "aaaaa\n\nbbbbb",
+	}
+
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithOverlap(overlap),
+		WithPreserveLines(),
+	).Chunk(doc)
+
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(chunks), 2)
+	for _, chunk := range chunks {
+		require.NotEmpty(t, chunk.Content)
+		require.NotZero(t, chunk.Metadata[source.MetaChunkSize])
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+	}
+}
+
 func TestFixedSizeChunking_PreservesCompleteLines(t *testing.T) {
 	const chunkSize = 120
 	lines := []string{

--- a/knowledge/chunking/fixed_test.go
+++ b/knowledge/chunking/fixed_test.go
@@ -245,6 +245,22 @@ func TestFixedSizeChunking_PrefersNearbyWordBoundary(t *testing.T) {
 
 	chunks, err := fsc.Chunk(doc)
 	require.NoError(t, err)
+	require.Equal(t, []string{"alpha beta", " gamma delta"}, []string{
+		chunks[0].Content,
+		chunks[1].Content,
+	})
+}
+
+func TestFixedSizeChunking_WhitespaceTrimmingRestoresBoundaries(t *testing.T) {
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(12),
+		WithWhitespaceTrimming(),
+	).Chunk(&document.Document{
+		ID:      "legacy-boundary",
+		Content: "alpha beta gamma delta",
+	})
+
+	require.NoError(t, err)
 	require.Equal(t, []string{"alpha beta", "gamma delta"}, []string{
 		chunks[0].Content,
 		chunks[1].Content,
@@ -268,7 +284,39 @@ func TestFixedSizeChunking_PrefersSentenceBoundary(t *testing.T) {
 	for _, chunk := range chunks {
 		contents = append(contents, chunk.Content)
 	}
-	require.Equal(t, content, strings.Join(contents, " "))
+	require.Equal(t, content, strings.Join(contents, ""))
+}
+
+func TestFixedSizeChunking_WhitespaceModes(t *testing.T) {
+	content := "def f():  \n\tif enabled:\n\t\treturn 1  "
+	doc := &document.Document{ID: "python", Content: content}
+
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(128),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	require.Equal(t, content, chunks[0].Content)
+
+	legacyChunks, err := NewFixedSizeChunking(
+		WithChunkSize(128),
+		WithWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 1)
+	require.Equal(
+		t,
+		"def f():\nif enabled:\nreturn 1",
+		legacyChunks[0].Content,
+	)
+}
+
+func TestFixedSizeChunking_WhitespaceOnlyDocument(t *testing.T) {
+	chunks, err := NewFixedSizeChunking().Chunk(
+		&document.Document{Content: " \n\t "},
+	)
+	require.ErrorIs(t, err, ErrEmptyDocument)
+	require.Nil(t, chunks)
 }
 
 func TestFixedSizeChunking_PreservesCompleteLines(t *testing.T) {

--- a/knowledge/chunking/fixed_test.go
+++ b/knowledge/chunking/fixed_test.go
@@ -319,6 +319,34 @@ func TestFixedSizeChunking_WhitespaceOnlyDocument(t *testing.T) {
 	require.Nil(t, chunks)
 }
 
+func TestFixedSizeChunking_PreserveLinesKeepsWhitespaceBoundaries(t *testing.T) {
+	const chunkSize = 5
+	content := " \t\naaaaa\n\t "
+	doc := &document.Document{ID: "blank-lines", Content: content}
+
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithPreserveLines(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, chunks, 3)
+	require.Equal(t, " \t", chunks[0].Content)
+	require.Equal(t, "aaaaa", chunks[1].Content)
+	require.Equal(t, "\t ", chunks[2].Content)
+	for _, chunk := range chunks {
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+	}
+
+	legacyChunks, err := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithPreserveLines(),
+		WithWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 1)
+	require.Equal(t, "aaaaa", legacyChunks[0].Content)
+}
+
 func TestFixedSizeChunking_PreservesCompleteLines(t *testing.T) {
 	const chunkSize = 120
 	lines := []string{

--- a/knowledge/chunking/fixed_test.go
+++ b/knowledge/chunking/fixed_test.go
@@ -329,8 +329,11 @@ func TestFixedSizeChunking_PreserveLinesDropsWhitespaceOnlyChunks(t *testing.T) 
 		WithPreserveLines(),
 	).Chunk(doc)
 	require.NoError(t, err)
-	require.Len(t, chunks, 1)
-	require.Equal(t, "aaaaa", chunks[0].Content)
+	require.Len(t, chunks, 2)
+	require.Equal(t, []string{" \t\naa", "aaa\n\t"}, []string{
+		chunks[0].Content,
+		chunks[1].Content,
+	})
 	for _, chunk := range chunks {
 		require.NotEmpty(t, strings.TrimSpace(chunk.Content))
 		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
@@ -363,6 +366,24 @@ func TestFixedSizeChunking_PreserveLinesAttachesWhitespaceWhenItFits(t *testing.
 	}
 }
 
+func TestFixedSizeChunking_PreserveLinesRebalancesWhitespaceOnlyLine(t *testing.T) {
+	const chunkSize = 5
+	content := " \nAAAAAA"
+	chunks, err := NewFixedSizeChunking(
+		WithChunkSize(chunkSize),
+		WithPreserveLines(),
+	).Chunk(&document.Document{Content: content})
+
+	require.NoError(t, err)
+	var rebuilt strings.Builder
+	for _, chunk := range chunks {
+		require.NotEmpty(t, strings.TrimSpace(chunk.Content))
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+		rebuilt.WriteString(chunk.Content)
+	}
+	require.Equal(t, content, rebuilt.String())
+}
+
 func TestFixedSizeChunking_PreserveLinesSkipsEmptyChunks(t *testing.T) {
 	const chunkSize = 5
 	doc := &document.Document{
@@ -376,10 +397,11 @@ func TestFixedSizeChunking_PreserveLinesSkipsEmptyChunks(t *testing.T) {
 	).Chunk(doc)
 
 	require.NoError(t, err)
-	require.Len(t, chunks, 2)
-	require.Equal(t, []string{"aaaaa", "bbbbb"}, []string{
+	require.Len(t, chunks, 3)
+	require.Equal(t, []string{"aaaaa", "\n\nbbb", "bb"}, []string{
 		chunks[0].Content,
 		chunks[1].Content,
+		chunks[2].Content,
 	})
 	for _, chunk := range chunks {
 		require.NotEmpty(t, chunk.Content)

--- a/knowledge/chunking/markdown.go
+++ b/knowledge/chunking/markdown.go
@@ -133,10 +133,11 @@ func (m *MarkdownChunking) Chunk(doc *document.Document) ([]*document.Document, 
 
 // headerSection represents a section split by a specific header level.
 type headerSection struct {
-	Header  string   // The header text (e.g., "## Title")
-	Content string   // The content under this header
-	Level   int      // Header level (1-6)
-	Path    []string // Header path (e.g., ["Main", "Sub", "Current"])
+	Header    string   // The header text (e.g., "## Title")
+	separator string   // The source separator after the header
+	Content   string   // The content under this header
+	Level     int      // Header level (1-6)
+	Path      []string // Header path (e.g., ["Main", "Sub", "Current"])
 }
 
 // markdownChunk keeps structural metadata until semantic units are packed.
@@ -180,7 +181,7 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 				// Skip only a genuinely empty preamble. A header without
 				// body text is still source content and must be preserved.
 				if section.Header == "" &&
-					strings.TrimSpace(section.Content) == "" {
+					!m.keepSectionContent(section.Content) {
 					continue
 				}
 
@@ -320,7 +321,7 @@ func (m *MarkdownChunking) splitByHeader(content string, level int) []headerSect
 				// Content before first header
 				if headingLineStart > 0 {
 					beforeContent := string(source[0:headingLineStart])
-					if strings.TrimSpace(beforeContent) != "" {
+					if m.keepSectionContent(beforeContent) {
 						sections = append(sections, headerSection{
 							Header:  "",
 							Content: beforeContent,
@@ -331,26 +332,18 @@ func (m *MarkdownChunking) splitByHeader(content string, level int) []headerSect
 				}
 			}
 
-			// Calculate position after the header line (after the newline)
-			var contentStartPos int
-			if heading.Lines().Len() > 0 {
-				lastLine := heading.Lines().At(heading.Lines().Len() - 1)
-				contentStartPos = lastLine.Stop
-				// Skip the newline after the header
-				if contentStartPos < len(source) && source[contentStartPos] == '\n' {
-					contentStartPos++
-				}
-			} else {
-				// Fallback: move to the beginning of the next line so the header line
-				// itself is not duplicated in section content.
-				contentStartPos = findLineContentStartPos(source, headingLineStart)
-			}
+			contentStartPos, headerSeparator := markdownHeaderBoundary(
+				heading,
+				source,
+				headingLineStart,
+			)
 
 			lastHeader = &headerSection{
-				Header:  markdownHeaderContent(source, headingLineStart, level, headerText),
-				Level:   level,
-				Path:    []string{headerText},
-				Content: "", // Will be filled when we find the next header or reach the end
+				Header:    markdownHeaderContent(source, headingLineStart, level, headerText),
+				separator: headerSeparator,
+				Level:     level,
+				Path:      []string{headerText},
+				Content:   "", // Will be filled when we find the next header or reach the end
 			}
 			lastHeaderPos = contentStartPos
 		}
@@ -389,6 +382,27 @@ func markdownHeaderContent(
 		return fallback
 	}
 	return string(bytes.TrimSuffix(rawHeader, []byte{'\r'}))
+}
+
+func markdownHeaderBoundary(
+	heading ast.Node,
+	source []byte,
+	lineStart int,
+) (int, string) {
+	if heading.Lines().Len() > 0 {
+		lastLine := heading.Lines().At(heading.Lines().Len() - 1)
+		contentStart := lastLine.Stop
+		if contentStart < len(source) && source[contentStart] == '\n' {
+			return contentStart + 1, "\n"
+		}
+		return contentStart, ""
+	}
+
+	contentStart := findLineContentStartPos(source, lineStart)
+	if contentStart > lineStart && source[contentStart-1] == '\n' {
+		return contentStart, "\n"
+	}
+	return contentStart, ""
 }
 
 // findNodeStartPos tries to determine the start position of a heading node
@@ -919,10 +933,10 @@ func (m *MarkdownChunking) trimBlockEdges(content string) string {
 
 func (m *MarkdownChunking) combineSectionContent(section headerSection) string {
 	if section.Header == "" {
-		return m.trimBlockEdges(section.Content)
-	}
-	if section.Content == "" {
-		return section.Header
+		if m.trimWhitespace {
+			return m.trimBlockEdges(section.Content)
+		}
+		return section.Content
 	}
 	if m.trimWhitespace {
 		content := strings.TrimSpace(section.Content)
@@ -931,10 +945,18 @@ func (m *MarkdownChunking) combineSectionContent(section headerSection) string {
 		}
 		return section.Header + "\n\n" + content
 	}
-	return section.Header + "\n" + section.Content
+	return section.Header + section.separator + section.Content
+}
+
+func (m *MarkdownChunking) keepSectionContent(content string) bool {
+	if m.trimWhitespace {
+		return strings.TrimSpace(content) != ""
+	}
+	return content != ""
 }
 
 func isMarkdownHeading(content string) bool {
+	content = strings.TrimSuffix(content, "\n")
 	if strings.ContainsRune(content, '\n') {
 		return false
 	}

--- a/knowledge/chunking/markdown.go
+++ b/knowledge/chunking/markdown.go
@@ -1003,6 +1003,25 @@ func (m *MarkdownChunking) coalesceWhitespaceChunks(
 		}
 
 		if pending.Len() > 0 {
+			if len(result) > 0 {
+				previous := len(result) - 1
+				previousSize := coreSize
+				if previous == 0 {
+					previousSize = m.chunkSize
+				}
+				updatedPrevious, remainingPending, remainingContent :=
+					preserveLeadingWhitespaceWithPrevious(
+						result[previous].content,
+						pending.String(),
+						chunk.content,
+						previousSize,
+						chunkSize,
+					)
+				result[previous].content = updatedPrevious
+				pending.Reset()
+				pending.WriteString(remainingPending)
+				chunk.content = remainingContent
+			}
 			attached, remaining := attachLeadingWhitespace(
 				pending.String(),
 				chunk.content,

--- a/knowledge/chunking/markdown.go
+++ b/knowledge/chunking/markdown.go
@@ -112,15 +112,21 @@ func (m *MarkdownChunking) Chunk(doc *document.Document) ([]*document.Document, 
 
 	// Parse Markdown structure, then pack adjacent semantic units.
 	rawChunks := m.splitRecursively(content)
+	if !m.trimWhitespace {
+		rawChunks = m.coalesceWhitespaceChunks(rawChunks)
+	}
 	rawChunks = m.mergeAdjacentChunks(content, rawChunks)
-	chunks := make([]*document.Document, len(rawChunks))
-	for i, chunk := range rawChunks {
-		chunks[i] = m.createMarkdownChunkWithPath(
+	chunks := make([]*document.Document, 0, len(rawChunks))
+	for _, chunk := range rawChunks {
+		if isBlankText(chunk.content) {
+			continue
+		}
+		chunks = append(chunks, m.createMarkdownChunkWithPath(
 			doc,
 			chunk.content,
-			i+1,
+			len(chunks)+1,
 			chunk.headerPath,
-		)
+		))
 	}
 
 	// Apply overlap if specified.
@@ -650,10 +656,6 @@ func findLineContentStartPos(source []byte, lineStart int) int {
 	return pos
 }
 
-func splitMarkdownParagraphs(content string) []string {
-	return splitMarkdownParagraphsWithWhitespaceTrimming(content, false)
-}
-
 type markdownParagraph struct {
 	content   string
 	separator string
@@ -886,10 +888,6 @@ func (m *MarkdownChunking) nextChunkSize(counter *chunkCounter) int {
 	return m.chunkSize
 }
 
-func splitMarkdownText(content string, chunkSize int) (string, string) {
-	return splitTextAtNaturalBoundary(content, chunkSize)
-}
-
 func (m *MarkdownChunking) splitMarkdownText(
 	content string,
 	chunkSize int,
@@ -898,17 +896,6 @@ func (m *MarkdownChunking) splitMarkdownText(
 		content,
 		chunkSize,
 		m.trimWhitespace,
-	)
-}
-
-func splitMarkdownTextWithBalancedTail(
-	content string,
-	chunkSize int,
-) (string, string) {
-	return splitTextWithBalancedTail(
-		content,
-		chunkSize,
-		splitMarkdownText,
 	)
 }
 
@@ -974,6 +961,84 @@ func newMarkdownChunk(content string, headerPath []string) markdownChunk {
 		content:    content,
 		headerPath: append([]string(nil), headerPath...),
 	}
+}
+
+func (m *MarkdownChunking) coalesceWhitespaceChunks(
+	chunks []markdownChunk,
+) []markdownChunk {
+	coreSize := m.chunkSize
+	if m.overlap > 0 {
+		coreSize = m.chunkSize - m.overlap
+	}
+	queue := append([]markdownChunk(nil), chunks...)
+	result := make([]markdownChunk, 0, len(chunks))
+	var pending strings.Builder
+
+	for len(queue) > 0 {
+		chunk := queue[0]
+		queue = queue[1:]
+		if chunk.content == "" {
+			continue
+		}
+		if isBlankText(chunk.content) {
+			pending.WriteString(chunk.content)
+			continue
+		}
+
+		chunkSize := coreSize
+		if len(result) == 0 {
+			chunkSize = m.chunkSize
+		}
+		if encoding.RuneCount(chunk.content) > chunkSize {
+			pieces := encoding.SafeSplitBySize(chunk.content, chunkSize)
+			replacement := make([]markdownChunk, 0, len(pieces)+len(queue))
+			for _, piece := range pieces {
+				replacement = append(
+					replacement,
+					newMarkdownChunk(piece, chunk.headerPath),
+				)
+			}
+			queue = append(replacement, queue...)
+			continue
+		}
+
+		if pending.Len() > 0 {
+			attached, remaining := attachLeadingWhitespace(
+				pending.String(),
+				chunk.content,
+				chunkSize,
+			)
+			pending.Reset()
+			result = append(
+				result,
+				newMarkdownChunk(attached, chunk.headerPath),
+			)
+			if remaining != "" {
+				queue = append(
+					[]markdownChunk{
+						newMarkdownChunk(remaining, chunk.headerPath),
+					},
+					queue...,
+				)
+			}
+			continue
+		}
+		result = append(result, chunk)
+	}
+
+	if pending.Len() > 0 && len(result) > 0 {
+		last := len(result) - 1
+		chunkSize := coreSize
+		if last == 0 {
+			chunkSize = m.chunkSize
+		}
+		result[last].content = attachTrailingWhitespace(
+			result[last].content,
+			pending.String(),
+			chunkSize,
+		)
+	}
+	return result
 }
 
 // mergeAdjacentChunks treats headings as preferred split points rather than

--- a/knowledge/chunking/markdown.go
+++ b/knowledge/chunking/markdown.go
@@ -37,9 +37,10 @@ func (c *chunkCounter) Count() int {
 
 // MarkdownChunking implements a chunking strategy optimized for markdown documents.
 type MarkdownChunking struct {
-	chunkSize int
-	overlap   int
-	md        goldmark.Markdown
+	chunkSize      int
+	overlap        int
+	md             goldmark.Markdown
+	trimWhitespace bool
 }
 
 // MarkdownOption represents a functional option for configuring MarkdownChunking.
@@ -56,6 +57,15 @@ func WithMarkdownChunkSize(size int) MarkdownOption {
 func WithMarkdownOverlap(overlap int) MarkdownOption {
 	return func(mc *MarkdownChunking) {
 		mc.overlap = overlap
+	}
+}
+
+// WithMarkdownWhitespaceTrimming enables the legacy behavior that trims
+// leading and trailing whitespace from the document, every line, and chunk
+// boundaries.
+func WithMarkdownWhitespaceTrimming() MarkdownOption {
+	return func(mc *MarkdownChunking) {
+		mc.trimWhitespace = true
 	}
 }
 
@@ -86,7 +96,13 @@ func (m *MarkdownChunking) Chunk(doc *document.Document) ([]*document.Document, 
 		return nil, ErrEmptyDocument
 	}
 
-	content := cleanText(doc.Content)
+	content := cleanTextWithWhitespaceTrimming(
+		doc.Content,
+		m.trimWhitespace,
+	)
+	if isBlankText(content) {
+		return nil, ErrEmptyDocument
+	}
 
 	// If content is small enough, return as single chunk.
 	if encoding.RuneCount(content) <= m.chunkSize {
@@ -168,18 +184,7 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 					continue
 				}
 
-				// Combine header and content for the full section text. Trim
-				// only the section edges so blank lines already represented by
-				// the separator are not duplicated.
-				var fullContent string
-				sectionContent := strings.TrimSpace(section.Content)
-				if section.Header != "" && sectionContent != "" {
-					fullContent = section.Header + "\n\n" + sectionContent
-				} else if section.Header != "" {
-					fullContent = section.Header
-				} else {
-					fullContent = sectionContent
-				}
+				fullContent := m.combineSectionContent(section)
 
 				sectionSize := encoding.RuneCount(fullContent)
 				chunkSize = m.nextChunkSize(counter)
@@ -215,7 +220,10 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 	// No headers found or only one section, try splitting by Markdown blocks.
 	// Keep fenced code intact here so blank lines inside the fence do not
 	// create unrelated, undersized chunks.
-	paragraphs := splitMarkdownParagraphs(content)
+	paragraphs := splitMarkdownParagraphsWithWhitespaceTrimming(
+		content,
+		m.trimWhitespace,
+	)
 	if len(paragraphs) > 1 {
 		chunks = m.mergeSmallParagraphsWithPath(
 			paragraphs,
@@ -232,10 +240,11 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 	remainingText := content
 	for remainingText != "" {
 		chunkSize = m.nextChunkSize(counter)
-		chunkText, rest := splitTextWithBalancedTail(
+		chunkText, rest := splitTextWithBalancedTailAndWhitespaceTrimming(
 			remainingText,
 			chunkSize,
-			splitMarkdownText,
+			m.splitMarkdownText,
+			m.trimWhitespace,
 		)
 		if strings.TrimSpace(chunkText) == "" {
 			textChunks := encoding.SafeSplitBySize(remainingText, chunkSize)
@@ -628,6 +637,13 @@ func findLineContentStartPos(source []byte, lineStart int) int {
 }
 
 func splitMarkdownParagraphs(content string) []string {
+	return splitMarkdownParagraphsWithWhitespaceTrimming(content, false)
+}
+
+func splitMarkdownParagraphsWithWhitespaceTrimming(
+	content string,
+	trimWhitespace bool,
+) []string {
 	lines := strings.SplitAfter(content, "\n")
 	paragraphs := make([]string, 0, len(lines))
 	var current strings.Builder
@@ -635,8 +651,13 @@ func splitMarkdownParagraphs(content string) []string {
 	fenceLength := 0
 
 	flush := func() {
-		paragraph := strings.TrimSpace(current.String())
-		if paragraph != "" {
+		paragraph := current.String()
+		if trimWhitespace {
+			paragraph = strings.TrimSpace(paragraph)
+		} else {
+			paragraph = strings.Trim(paragraph, "\n")
+		}
+		if !isBlankText(paragraph) {
 			paragraphs = append(paragraphs, paragraph)
 		}
 		current.Reset()
@@ -727,7 +748,7 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 	}
 
 	for _, paragraph := range paragraphs {
-		remainingText := strings.TrimSpace(paragraph)
+		remainingText := m.trimBlockEdges(paragraph)
 		for remainingText != "" {
 			chunkSize := m.nextChunkSize(counter)
 			currentSize := encoding.RuneCount(currentChunk.String())
@@ -749,7 +770,7 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 				availableSize := chunkSize - currentSize - separatorSize
 				if isMarkdownHeading(currentChunk.String()) && availableSize > 0 {
 					var prefix string
-					prefix, remainingText = splitMarkdownTextWithBalancedTail(
+					prefix, remainingText = m.splitMarkdownTextWithBalancedTail(
 						remainingText,
 						availableSize,
 					)
@@ -763,7 +784,7 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 			}
 
 			var prefix string
-			prefix, remainingText = splitMarkdownTextWithBalancedTail(
+			prefix, remainingText = m.splitMarkdownTextWithBalancedTail(
 				remainingText,
 				chunkSize,
 			)
@@ -788,6 +809,17 @@ func splitMarkdownText(content string, chunkSize int) (string, string) {
 	return splitTextAtNaturalBoundary(content, chunkSize)
 }
 
+func (m *MarkdownChunking) splitMarkdownText(
+	content string,
+	chunkSize int,
+) (string, string) {
+	return splitTextAtNaturalBoundaryWithWhitespaceTrimming(
+		content,
+		chunkSize,
+		m.trimWhitespace,
+	)
+}
+
 func splitMarkdownTextWithBalancedTail(
 	content string,
 	chunkSize int,
@@ -797,6 +829,42 @@ func splitMarkdownTextWithBalancedTail(
 		chunkSize,
 		splitMarkdownText,
 	)
+}
+
+func (m *MarkdownChunking) splitMarkdownTextWithBalancedTail(
+	content string,
+	chunkSize int,
+) (string, string) {
+	return splitTextWithBalancedTailAndWhitespaceTrimming(
+		content,
+		chunkSize,
+		m.splitMarkdownText,
+		m.trimWhitespace,
+	)
+}
+
+func (m *MarkdownChunking) trimBlockEdges(content string) string {
+	if m.trimWhitespace {
+		return strings.TrimSpace(content)
+	}
+	return strings.Trim(content, "\n")
+}
+
+func (m *MarkdownChunking) combineSectionContent(section headerSection) string {
+	if section.Header == "" {
+		return m.trimBlockEdges(section.Content)
+	}
+	if section.Content == "" {
+		return section.Header
+	}
+	if m.trimWhitespace {
+		content := strings.TrimSpace(section.Content)
+		if content == "" {
+			return section.Header
+		}
+		return section.Header + "\n\n" + content
+	}
+	return section.Header + "\n" + section.Content
 }
 
 func isMarkdownHeading(content string) bool {
@@ -1060,12 +1128,13 @@ func (m *MarkdownChunking) applyOverlap(
 			metadata[k] = v
 		}
 
-		overlappedContent, actualOverlap := joinWithOverlap(
+		overlappedContent, actualOverlap := joinWithOverlapMode(
 			overlappedChunks[len(overlappedChunks)-1].Content,
 			chunks[i].Content,
 			m.overlap,
 			m.chunkSize,
 			separators[i],
+			m.trimWhitespace,
 		)
 		if actualOverlap > 0 {
 			metadata[source.MetaOverlappedContentSize] = encoding.RuneCount(overlappedContent)

--- a/knowledge/chunking/markdown.go
+++ b/knowledge/chunking/markdown.go
@@ -220,7 +220,7 @@ func (m *MarkdownChunking) splitRecursivelyWithPath(
 	// No headers found or only one section, try splitting by Markdown blocks.
 	// Keep fenced code intact here so blank lines inside the fence do not
 	// create unrelated, undersized chunks.
-	paragraphs := splitMarkdownParagraphsWithWhitespaceTrimming(
+	paragraphs := splitMarkdownParagraphsWithSeparators(
 		content,
 		m.trimWhitespace,
 	)
@@ -640,27 +640,77 @@ func splitMarkdownParagraphs(content string) []string {
 	return splitMarkdownParagraphsWithWhitespaceTrimming(content, false)
 }
 
+type markdownParagraph struct {
+	content   string
+	separator string
+}
+
 func splitMarkdownParagraphsWithWhitespaceTrimming(
 	content string,
 	trimWhitespace bool,
 ) []string {
+	paragraphs := splitMarkdownParagraphsWithSeparators(
+		content,
+		trimWhitespace,
+	)
+	contents := make([]string, 0, len(paragraphs))
+	for _, paragraph := range paragraphs {
+		contents = append(contents, paragraph.content)
+	}
+	return contents
+}
+
+func splitMarkdownParagraphsWithSeparators(
+	content string,
+	trimWhitespace bool,
+) []markdownParagraph {
 	lines := strings.SplitAfter(content, "\n")
-	paragraphs := make([]string, 0, len(lines))
+	paragraphs := make([]markdownParagraph, 0, len(lines))
 	var current strings.Builder
+	var pendingSeparator strings.Builder
 	var fenceMarker byte
 	fenceLength := 0
 
 	flush := func() {
 		paragraph := current.String()
+		current.Reset()
+		if paragraph == "" {
+			return
+		}
 		if trimWhitespace {
 			paragraph = strings.TrimSpace(paragraph)
+			if paragraph == "" {
+				return
+			}
+			separator := ""
+			if len(paragraphs) > 0 {
+				separator = "\n\n"
+			}
+			paragraphs = append(paragraphs, markdownParagraph{
+				content:   paragraph,
+				separator: separator,
+			})
+			pendingSeparator.Reset()
+			return
+		}
+
+		body := strings.TrimSuffix(paragraph, "\n")
+		trailingSeparator := paragraph[len(body):]
+		separator := pendingSeparator.String()
+		pendingSeparator.Reset()
+		if len(paragraphs) == 0 {
+			body = separator + body
+			separator = ""
+		}
+		if body != "" {
+			paragraphs = append(paragraphs, markdownParagraph{
+				content:   body,
+				separator: separator,
+			})
 		} else {
-			paragraph = strings.Trim(paragraph, "\n")
+			pendingSeparator.WriteString(separator)
 		}
-		if !isBlankText(paragraph) {
-			paragraphs = append(paragraphs, paragraph)
-		}
-		current.Reset()
+		pendingSeparator.WriteString(trailingSeparator)
 	}
 
 	for _, line := range lines {
@@ -679,11 +729,19 @@ func splitMarkdownParagraphsWithWhitespaceTrimming(
 
 		if fenceMarker == 0 && strings.TrimSpace(line) == "" {
 			flush()
+			if !trimWhitespace {
+				pendingSeparator.WriteString(line)
+			}
 			continue
 		}
 		current.WriteString(line)
 	}
 	flush()
+	if !trimWhitespace && pendingSeparator.Len() > 0 {
+		paragraphs = append(paragraphs, markdownParagraph{
+			content: pendingSeparator.String(),
+		})
+	}
 	return paragraphs
 }
 
@@ -728,7 +786,7 @@ func (m *MarkdownChunking) extractText(node ast.Node, source []byte) string {
 
 // mergeSmallParagraphsWithPath merges paragraphs with header path tracking.
 func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
-	paragraphs []string,
+	paragraphs []markdownParagraph,
 	headerPath []string,
 	counter *chunkCounter,
 ) []markdownChunk {
@@ -748,25 +806,30 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 	}
 
 	for _, paragraph := range paragraphs {
-		remainingText := m.trimBlockEdges(paragraph)
+		remainingText := paragraph.content
+		if m.trimWhitespace {
+			remainingText = m.trimBlockEdges(remainingText)
+		}
 		for remainingText != "" {
 			chunkSize := m.nextChunkSize(counter)
 			currentSize := encoding.RuneCount(currentChunk.String())
-			remainingSize := encoding.RuneCount(remainingText)
-			separatorSize := 0
+			separator := ""
 			if currentSize > 0 {
-				separatorSize = 2
+				separator = paragraph.separator
 			}
+			remainingSize := encoding.RuneCount(remainingText)
+			separatorSize := encoding.RuneCount(separator)
 
 			if currentSize+separatorSize+remainingSize <= chunkSize {
 				if separatorSize > 0 {
-					currentChunk.WriteString("\n\n")
+					currentChunk.WriteString(separator)
 				}
 				currentChunk.WriteString(remainingText)
 				break
 			}
 
 			if currentSize > 0 {
+				separatorAdded := false
 				availableSize := chunkSize - currentSize - separatorSize
 				if isMarkdownHeading(currentChunk.String()) && availableSize > 0 {
 					var prefix string
@@ -775,11 +838,15 @@ func (m *MarkdownChunking) mergeSmallParagraphsWithPath(
 						availableSize,
 					)
 					if prefix != "" {
-						currentChunk.WriteString("\n\n")
+						currentChunk.WriteString(separator)
 						currentChunk.WriteString(prefix)
+						separatorAdded = true
 					}
 				}
 				flush()
+				if !m.trimWhitespace && separator != "" && !separatorAdded {
+					remainingText = separator + remainingText
+				}
 				continue
 			}
 
@@ -902,7 +969,12 @@ func (m *MarkdownChunking) mergeAdjacentChunks(
 	for i, chunk := range chunks {
 		rawContents[i] = chunk.content
 	}
-	separators := sourceChunkSeparators(content, rawContents, "\n\n")
+	separators := sourceChunkSeparators(
+		content,
+		rawContents,
+		"\n\n",
+		m.trimWhitespace,
+	)
 	for i := range chunks {
 		chunks[i].separator = separators[i]
 	}
@@ -1118,7 +1190,12 @@ func (m *MarkdownChunking) applyOverlap(
 	for i, chunk := range chunks {
 		rawContents[i] = chunk.Content
 	}
-	separators := sourceChunkSeparators(content, rawContents, "\n\n")
+	separators := sourceChunkSeparators(
+		content,
+		rawContents,
+		"\n\n",
+		m.trimWhitespace,
+	)
 	overlappedChunks := []*document.Document{chunks[0]}
 
 	for i := 1; i < len(chunks); i++ {

--- a/knowledge/chunking/markdown_test.go
+++ b/knowledge/chunking/markdown_test.go
@@ -272,6 +272,7 @@ func TestMarkdownChunking_DoesNotEmitStandaloneHeading(t *testing.T) {
 }
 
 func TestSplitMarkdownText_PrefersNaturalBoundary(t *testing.T) {
+	chunker := NewMarkdownChunking()
 	tests := []struct {
 		name          string
 		content       string
@@ -318,7 +319,10 @@ func TestSplitMarkdownText_PrefersNaturalBoundary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefix, remaining := splitMarkdownText(tt.content, tt.chunkSize)
+			prefix, remaining := chunker.splitMarkdownText(
+				tt.content,
+				tt.chunkSize,
+			)
 			require.Equal(t, tt.wantPrefix, prefix)
 			require.Equal(t, tt.wantRemaining, remaining)
 		})
@@ -333,7 +337,8 @@ func TestSplitMarkdownTextWithBalancedTail(t *testing.T) {
 		strings.Repeat("d", 55),
 	}, "\n")
 
-	prefix, remaining := splitMarkdownTextWithBalancedTail(content, 240)
+	prefix, remaining := NewMarkdownChunking().
+		splitMarkdownTextWithBalancedTail(content, 240)
 
 	require.Equal(t, strings.Join([]string{
 		strings.Repeat("a", 75),
@@ -350,7 +355,8 @@ func TestSplitMarkdownTextWithBalancedTail(t *testing.T) {
 func TestSplitMarkdownTextWithBalancedTailPrefersNearbyLineBoundary(t *testing.T) {
 	content := strings.Repeat("a", 128) + "|\n" + strings.Repeat("b", 118)
 
-	prefix, remaining := splitMarkdownTextWithBalancedTail(content, 240)
+	prefix, remaining := NewMarkdownChunking().
+		splitMarkdownTextWithBalancedTail(content, 240)
 
 	require.Equal(t, strings.Repeat("a", 128)+"|\n", prefix)
 	require.Equal(t, strings.Repeat("b", 118), remaining)
@@ -397,7 +403,10 @@ func TestMarkdownChunkingBalancesLongBlockAfterHeading(t *testing.T) {
 func TestSplitMarkdownParagraphsKeepsFencedCodeTogether(t *testing.T) {
 	content := "before\n\n```python\ndef f():\n\treturn 1\n\nsecond()\n```\n\nafter"
 
-	paragraphs := splitMarkdownParagraphs(content)
+	paragraphs := splitMarkdownParagraphsWithWhitespaceTrimming(
+		content,
+		false,
+	)
 
 	require.Equal(t, []string{
 		"before",

--- a/knowledge/chunking/markdown_test.go
+++ b/knowledge/chunking/markdown_test.go
@@ -527,8 +527,9 @@ func TestMarkdownChunking_PreservesSeparatorAtChunkBoundary(t *testing.T) {
 
 func TestMarkdownChunking_CombineSectionPreservesWhitespace(t *testing.T) {
 	section := headerSection{
-		Header:  "# Title",
-		Content: " \n\treturn 1  \n",
+		Header:    "# Title",
+		separator: "\n",
+		Content:   " \n\treturn 1  \n",
 	}
 
 	require.Equal(
@@ -543,6 +544,81 @@ func TestMarkdownChunking_CombineSectionPreservesWhitespace(t *testing.T) {
 			WithMarkdownWhitespaceTrimming(),
 		).combineSectionContent(section),
 	)
+}
+
+func TestMarkdownChunking_PreservesWhitespacePreambleBeforeHeader(t *testing.T) {
+	const chunkSize = 24
+	content := "  \n\t  \n# Header\n\n" + strings.Repeat("x", 80)
+	doc := &document.Document{ID: "whitespace-preamble", Content: content}
+
+	chunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+	).Chunk(doc)
+	require.NoError(t, err)
+
+	var rebuilt strings.Builder
+	for _, chunk := range chunks {
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+		rebuilt.WriteString(chunk.Content)
+	}
+	require.Equal(t, content, rebuilt.String())
+
+	legacyChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.NotEmpty(t, legacyChunks)
+	require.True(t, strings.HasPrefix(legacyChunks[0].Content, "# Header"))
+}
+
+func TestMarkdownChunking_HeaderOnlyPreservesSourceTerminator(t *testing.T) {
+	const chunkSize = 16
+	header := "## " + strings.Repeat("H", 50)
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "without newline", content: header},
+		{name: "with newline", content: header + "\n"},
+		{name: "consecutive headings", content: "# One\n# Two\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &document.Document{ID: tt.name, Content: tt.content}
+			chunks, err := NewMarkdownChunking(
+				WithMarkdownChunkSize(chunkSize),
+			).Chunk(doc)
+			require.NoError(t, err)
+
+			var rebuilt strings.Builder
+			for _, chunk := range chunks {
+				require.NotEmpty(t, chunk.Content)
+				require.LessOrEqual(
+					t,
+					utf8.RuneCountInString(chunk.Content),
+					chunkSize,
+				)
+				rebuilt.WriteString(chunk.Content)
+			}
+			require.Equal(t, tt.content, rebuilt.String())
+
+			legacyChunks, err := NewMarkdownChunking(
+				WithMarkdownChunkSize(chunkSize),
+				WithMarkdownWhitespaceTrimming(),
+			).Chunk(doc)
+			require.NoError(t, err)
+			require.NotEmpty(t, legacyChunks)
+			require.False(
+				t,
+				strings.HasSuffix(
+					legacyChunks[len(legacyChunks)-1].Content,
+					"\n",
+				),
+			)
+		})
+	}
 }
 
 func TestMarkdownChunking_WhitespaceOnlyDocument(t *testing.T) {
@@ -1898,14 +1974,8 @@ func TestMarkdownChunking_OnlyWhitespace(t *testing.T) {
 			mc := NewMarkdownChunking(WithMarkdownChunkSize(50), WithMarkdownOverlap(5))
 
 			chunks, err := mc.Chunk(doc)
-			// cleanText will trim all whitespace, making the document empty
-			// So this should either return ErrEmptyDocument or a single empty chunk
-			if err != nil {
-				require.ErrorIs(t, err, ErrEmptyDocument, "Whitespace-only document should be treated as empty")
-			} else {
-				// If no error, should return valid chunks (some implementations may handle this differently)
-				require.NotEmpty(t, chunks, "Should return at least one chunk")
-			}
+			require.ErrorIs(t, err, ErrEmptyDocument)
+			require.Empty(t, chunks)
 		})
 	}
 }

--- a/knowledge/chunking/markdown_test.go
+++ b/knowledge/chunking/markdown_test.go
@@ -228,14 +228,26 @@ func TestMarkdownChunking_LargeParagraphPrefersSentenceBoundary(t *testing.T) {
 	require.Len(t, chunks, 2)
 	require.Contains(t, chunks[0].Content, "another step is required.")
 	require.Equal(t,
-		"Sentence-aware splitting should prefer these punctuation boundaries "+
+		" Sentence-aware splitting should prefer these punctuation boundaries "+
 			"instead of cutting through arbitrary words.",
 		chunks[1].Content,
 	)
 	for _, chunk := range chunks {
-		require.Equal(t, strings.TrimSpace(chunk.Content), chunk.Content)
+		require.NotEmpty(t, strings.TrimSpace(chunk.Content))
 		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), 240)
 	}
+
+	legacyChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(240),
+		WithMarkdownWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 2)
+	require.Equal(t,
+		"Sentence-aware splitting should prefer these punctuation boundaries "+
+			"instead of cutting through arbitrary words.",
+		legacyChunks[1].Content,
+	)
 }
 
 func TestMarkdownChunking_DoesNotEmitStandaloneHeading(t *testing.T) {
@@ -271,7 +283,7 @@ func TestSplitMarkdownText_PrefersNaturalBoundary(t *testing.T) {
 			name:          "line boundary",
 			content:       "aaaaaa\nbbbbbb",
 			chunkSize:     10,
-			wantPrefix:    "aaaaaa",
+			wantPrefix:    "aaaaaa\n",
 			wantRemaining: "bbbbbb",
 		},
 		{
@@ -279,7 +291,7 @@ func TestSplitMarkdownText_PrefersNaturalBoundary(t *testing.T) {
 			content:       "First one. Second sentence",
 			chunkSize:     15,
 			wantPrefix:    "First one.",
-			wantRemaining: "Second sentence",
+			wantRemaining: " Second sentence",
 		},
 		{
 			name:          "punctuation boundary",
@@ -293,7 +305,7 @@ func TestSplitMarkdownText_PrefersNaturalBoundary(t *testing.T) {
 			content:       "alpha betaGamma",
 			chunkSize:     10,
 			wantPrefix:    "alpha",
-			wantRemaining: "betaGamma",
+			wantRemaining: " betaGamma",
 		},
 		{
 			name:          "hard rune boundary",
@@ -326,7 +338,7 @@ func TestSplitMarkdownTextWithBalancedTail(t *testing.T) {
 	require.Equal(t, strings.Join([]string{
 		strings.Repeat("a", 75),
 		strings.Repeat("b", 75),
-	}, "\n"), prefix)
+	}, "\n")+"\n", prefix)
 	require.Equal(t, strings.Join([]string{
 		strings.Repeat("c", 70),
 		strings.Repeat("d", 55),
@@ -340,7 +352,7 @@ func TestSplitMarkdownTextWithBalancedTailPrefersNearbyLineBoundary(t *testing.T
 
 	prefix, remaining := splitMarkdownTextWithBalancedTail(content, 240)
 
-	require.Equal(t, strings.Repeat("a", 128)+"|", prefix)
+	require.Equal(t, strings.Repeat("a", 128)+"|\n", prefix)
 	require.Equal(t, strings.Repeat("b", 118), remaining)
 }
 
@@ -383,15 +395,67 @@ func TestMarkdownChunkingBalancesLongBlockAfterHeading(t *testing.T) {
 }
 
 func TestSplitMarkdownParagraphsKeepsFencedCodeTogether(t *testing.T) {
-	content := "before\n\n```go\nfirst()\n\nsecond()\n```\n\nafter"
+	content := "before\n\n```python\ndef f():\n\treturn 1\n\nsecond()\n```\n\nafter"
 
 	paragraphs := splitMarkdownParagraphs(content)
 
 	require.Equal(t, []string{
 		"before",
-		"```go\nfirst()\n\nsecond()\n```",
+		"```python\ndef f():\n\treturn 1\n\nsecond()\n```",
 		"after",
 	}, paragraphs)
+}
+
+func TestMarkdownChunking_WhitespaceModes(t *testing.T) {
+	content := "```python  \ndef f():\n\tif enabled:\n\t\treturn 1  \n```"
+	doc := &document.Document{ID: "python", Content: content}
+
+	chunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(128),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	require.Equal(t, content, chunks[0].Content)
+
+	legacyChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(128),
+		WithMarkdownWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 1)
+	require.Equal(
+		t,
+		"```python\ndef f():\nif enabled:\nreturn 1\n```",
+		legacyChunks[0].Content,
+	)
+}
+
+func TestMarkdownChunking_CombineSectionPreservesWhitespace(t *testing.T) {
+	section := headerSection{
+		Header:  "# Title",
+		Content: " \n\treturn 1  \n",
+	}
+
+	require.Equal(
+		t,
+		"# Title\n \n\treturn 1  \n",
+		NewMarkdownChunking().combineSectionContent(section),
+	)
+	require.Equal(
+		t,
+		"# Title\n\nreturn 1",
+		NewMarkdownChunking(
+			WithMarkdownWhitespaceTrimming(),
+		).combineSectionContent(section),
+	)
+}
+
+func TestMarkdownChunking_WhitespaceOnlyDocument(t *testing.T) {
+	chunks, err := NewMarkdownChunking().Chunk(
+		&document.Document{Content: " \n\t "},
+	)
+	require.ErrorIs(t, err, ErrEmptyDocument)
+	require.Nil(t, chunks)
 }
 
 func TestMarkdownChunkingBalancesLongFencedCodeTail(t *testing.T) {

--- a/knowledge/chunking/markdown_test.go
+++ b/knowledge/chunking/markdown_test.go
@@ -430,6 +430,101 @@ func TestMarkdownChunking_WhitespaceModes(t *testing.T) {
 	)
 }
 
+func TestMarkdownChunking_WhitespaceModesWithOverlap(t *testing.T) {
+	const (
+		chunkSize = 30
+		overlap   = 10
+	)
+	content := "prefix line\n\treturn 1\n\n" + strings.Repeat("next ", 10)
+	doc := &document.Document{ID: "overlap-whitespace", Content: content}
+
+	chunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownOverlap(overlap),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(chunks), 2)
+	require.Contains(t, chunks[1].Content, "\treturn 1")
+	for _, chunk := range chunks {
+		require.LessOrEqual(
+			t,
+			utf8.RuneCountInString(chunk.Content),
+			chunkSize,
+		)
+	}
+
+	legacyChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownOverlap(overlap),
+		WithMarkdownWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(legacyChunks), 2)
+	require.NotContains(t, legacyChunks[1].Content, "\treturn 1")
+	require.Contains(t, legacyChunks[1].Content, "return 1")
+	for _, chunk := range legacyChunks {
+		require.LessOrEqual(
+			t,
+			utf8.RuneCountInString(chunk.Content),
+			chunkSize,
+		)
+	}
+}
+
+func TestMarkdownChunking_PreservesWhitespaceOnlyParagraphBoundary(t *testing.T) {
+	const chunkSize = 20
+	content := "first\n \t\nsecond\n\n" + strings.Repeat("x", 30)
+	doc := &document.Document{ID: "paragraph-boundary", Content: content}
+
+	chunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(chunks), 2)
+	require.Equal(t, "first\n \t\nsecond", chunks[0].Content)
+
+	legacyChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(legacyChunks), 2)
+	require.Equal(t, "first\n\nsecond", legacyChunks[0].Content)
+}
+
+func TestMarkdownChunking_PreservesSeparatorAtChunkBoundary(t *testing.T) {
+	const chunkSize = 5
+	content := "aaaa\n \t\nbbbb"
+	doc := &document.Document{ID: "separator-boundary", Content: content}
+
+	chunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(chunks), 2)
+	var rebuilt strings.Builder
+	for _, chunk := range chunks {
+		require.LessOrEqual(
+			t,
+			utf8.RuneCountInString(chunk.Content),
+			chunkSize,
+		)
+		rebuilt.WriteString(chunk.Content)
+	}
+	require.Equal(t, content, rebuilt.String())
+
+	legacyChunks, err := NewMarkdownChunking(
+		WithMarkdownChunkSize(chunkSize),
+		WithMarkdownWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	var legacyContent strings.Builder
+	for _, chunk := range legacyChunks {
+		legacyContent.WriteString(chunk.Content)
+	}
+	require.NotContains(t, legacyContent.String(), " \t")
+}
+
 func TestMarkdownChunking_CombineSectionPreservesWhitespace(t *testing.T) {
 	section := headerSection{
 		Header:  "# Title",

--- a/knowledge/chunking/recursive.go
+++ b/knowledge/chunking/recursive.go
@@ -108,9 +108,19 @@ func (r *RecursiveChunking) Chunk(doc *document.Document) ([]*document.Document,
 	}
 	fragments := r.recursiveSplit(content, r.separators, coreSize)
 	textChunks := r.mergeFragments(fragments, r.chunkSize, coreSize)
+	if !r.trimWhitespace {
+		textChunks = coalesceWhitespaceChunks(
+			textChunks,
+			r.chunkSize,
+			coreSize,
+		)
+	}
 	chunks := make([]*document.Document, 0, len(textChunks))
-	for i, chunkText := range textChunks {
-		chunks = append(chunks, createChunk(doc, chunkText, i+1))
+	for _, chunkText := range textChunks {
+		if isBlankText(chunkText) {
+			continue
+		}
+		chunks = append(chunks, createChunk(doc, chunkText, len(chunks)+1))
 	}
 
 	// Apply overlap if specified.

--- a/knowledge/chunking/recursive.go
+++ b/knowledge/chunking/recursive.go
@@ -20,9 +20,10 @@ import (
 
 // RecursiveChunking implements a recursive chunking strategy that uses a hierarchy of separators.
 type RecursiveChunking struct {
-	chunkSize  int
-	overlap    int
-	separators []string
+	chunkSize      int
+	overlap        int
+	separators     []string
+	trimWhitespace bool
 }
 
 // RecursiveOption represents a functional option for configuring RecursiveChunking.
@@ -46,6 +47,15 @@ func WithRecursiveOverlap(overlap int) RecursiveOption {
 func WithRecursiveSeparators(separators []string) RecursiveOption {
 	return func(rc *RecursiveChunking) {
 		rc.separators = separators
+	}
+}
+
+// WithRecursiveWhitespaceTrimming enables the legacy behavior that trims
+// leading and trailing whitespace from the document, every line, and chunk
+// boundaries.
+func WithRecursiveWhitespaceTrimming() RecursiveOption {
+	return func(rc *RecursiveChunking) {
+		rc.trimWhitespace = true
 	}
 }
 
@@ -85,7 +95,13 @@ func (r *RecursiveChunking) Chunk(doc *document.Document) ([]*document.Document,
 		return nil, ErrEmptyDocument
 	}
 
-	content := cleanText(doc.Content)
+	content := cleanTextWithWhitespaceTrimming(
+		doc.Content,
+		r.trimWhitespace,
+	)
+	if isBlankText(content) {
+		return nil, ErrEmptyDocument
+	}
 	coreSize := r.chunkSize
 	if r.overlap > 0 {
 		coreSize = r.chunkSize - r.overlap
@@ -178,8 +194,11 @@ func (r *RecursiveChunking) mergeFragments(
 	currentSize := 0
 
 	flush := func() {
-		content := strings.TrimSpace(current.String())
-		if content != "" {
+		content := current.String()
+		if r.trimWhitespace {
+			content = strings.TrimSpace(content)
+		}
+		if !isBlankText(content) {
 			chunks = append(chunks, content)
 		}
 		current.Reset()
@@ -271,12 +290,13 @@ func (r *RecursiveChunking) applyOverlap(
 			metadata[k] = v
 		}
 
-		overlappedContent, actualOverlap := joinWithOverlap(
+		overlappedContent, actualOverlap := joinWithOverlapMode(
 			overlappedChunks[len(overlappedChunks)-1].Content,
 			chunks[i].Content,
 			r.overlap,
 			r.chunkSize,
 			separators[i],
+			r.trimWhitespace,
 		)
 		if actualOverlap > 0 {
 			metadata[source.MetaOverlappedContentSize] =

--- a/knowledge/chunking/recursive.go
+++ b/knowledge/chunking/recursive.go
@@ -194,11 +194,8 @@ func (r *RecursiveChunking) mergeFragments(
 	currentSize := 0
 
 	flush := func() {
-		content := current.String()
-		if r.trimWhitespace {
-			content = strings.TrimSpace(content)
-		}
-		if !isBlankText(content) {
+		content, ok := r.finalizeFragment(current.String())
+		if ok {
 			chunks = append(chunks, content)
 		}
 		current.Reset()
@@ -269,6 +266,13 @@ func (r *RecursiveChunking) mergeFragments(
 	return chunks
 }
 
+func (r *RecursiveChunking) finalizeFragment(content string) (string, bool) {
+	if r.trimWhitespace {
+		content = strings.TrimSpace(content)
+	}
+	return content, content != ""
+}
+
 // applyOverlap applies overlap between consecutive chunks.
 func (r *RecursiveChunking) applyOverlap(
 	content string,
@@ -281,7 +285,12 @@ func (r *RecursiveChunking) applyOverlap(
 	for i, chunk := range chunks {
 		rawContents[i] = chunk.Content
 	}
-	separators := sourceChunkSeparators(content, rawContents, " ")
+	separators := sourceChunkSeparators(
+		content,
+		rawContents,
+		" ",
+		r.trimWhitespace,
+	)
 	overlappedChunks := []*document.Document{chunks[0]}
 	for i := 1; i < len(chunks); i++ {
 		// Create new metadata for overlapped chunk.

--- a/knowledge/chunking/recursive_test.go
+++ b/knowledge/chunking/recursive_test.go
@@ -337,11 +337,11 @@ func TestRecursiveChunking_PreservesWhitespaceBoundaryFragments(t *testing.T) {
 		WithRecursiveSeparators([]string{" "}),
 	).Chunk(doc)
 	require.NoError(t, err)
-	require.Len(t, chunks, 3)
-	require.Equal(t, "   ", chunks[0].Content)
-	require.Equal(t, "aaa ", chunks[1].Content)
-	require.Equal(t, "  ", chunks[2].Content)
+	require.Len(t, chunks, 2)
+	require.Equal(t, "   a", chunks[0].Content)
+	require.Equal(t, "aa  ", chunks[1].Content)
 	for _, chunk := range chunks {
+		require.NotEmpty(t, strings.TrimSpace(chunk.Content))
 		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
 	}
 

--- a/knowledge/chunking/recursive_test.go
+++ b/knowledge/chunking/recursive_test.go
@@ -327,6 +327,34 @@ func TestRecursiveChunking_WhitespaceOnlyDocument(t *testing.T) {
 	require.Nil(t, chunks)
 }
 
+func TestRecursiveChunking_PreservesWhitespaceBoundaryFragments(t *testing.T) {
+	const chunkSize = 4
+	content := "   aaa   "
+	doc := &document.Document{ID: "boundary-whitespace", Content: content}
+
+	chunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(chunkSize),
+		WithRecursiveSeparators([]string{" "}),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, chunks, 3)
+	require.Equal(t, "   ", chunks[0].Content)
+	require.Equal(t, "aaa ", chunks[1].Content)
+	require.Equal(t, "  ", chunks[2].Content)
+	for _, chunk := range chunks {
+		require.LessOrEqual(t, utf8.RuneCountInString(chunk.Content), chunkSize)
+	}
+
+	legacyChunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(chunkSize),
+		WithRecursiveSeparators([]string{" "}),
+		WithRecursiveWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 1)
+	require.Equal(t, "aaa", legacyChunks[0].Content)
+}
+
 func TestRecursiveChunking_PreservesSentenceAtoms(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/knowledge/chunking/recursive_test.go
+++ b/knowledge/chunking/recursive_test.go
@@ -281,8 +281,50 @@ func TestRecursiveChunking_MergesSmallSeparatorFragments(t *testing.T) {
 	chunks, err := rc.Chunk(doc)
 	require.NoError(t, err)
 	require.Len(t, chunks, 2)
-	require.Equal(t, "alpha beta gamma delta", chunks[0].Content)
+	require.Equal(t, "alpha beta gamma delta ", chunks[0].Content)
 	require.Equal(t, "epsilon zeta eta theta", chunks[1].Content)
+
+	legacyChunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(24),
+		WithRecursiveSeparators([]string{" ", ""}),
+		WithRecursiveWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 2)
+	require.Equal(t, "alpha beta gamma delta", legacyChunks[0].Content)
+	require.Equal(t, "epsilon zeta eta theta", legacyChunks[1].Content)
+}
+
+func TestRecursiveChunking_WhitespaceModes(t *testing.T) {
+	content := "def f():  \n\tif enabled:\n\t\treturn 1  "
+	doc := &document.Document{ID: "python", Content: content}
+
+	chunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(128),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	require.Equal(t, content, chunks[0].Content)
+
+	legacyChunks, err := NewRecursiveChunking(
+		WithRecursiveChunkSize(128),
+		WithRecursiveWhitespaceTrimming(),
+	).Chunk(doc)
+	require.NoError(t, err)
+	require.Len(t, legacyChunks, 1)
+	require.Equal(
+		t,
+		"def f():\nif enabled:\nreturn 1",
+		legacyChunks[0].Content,
+	)
+}
+
+func TestRecursiveChunking_WhitespaceOnlyDocument(t *testing.T) {
+	chunks, err := NewRecursiveChunking().Chunk(
+		&document.Document{Content: " \n\t "},
+	)
+	require.ErrorIs(t, err, ErrEmptyDocument)
+	require.Nil(t, chunks)
 }
 
 func TestRecursiveChunking_PreservesSentenceAtoms(t *testing.T) {

--- a/tool/arxivsearch/arxiv_search.go
+++ b/tool/arxivsearch/arxiv_search.go
@@ -19,7 +19,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf"
@@ -208,11 +207,7 @@ func (t *ToolSet) search(
 	var pdfReader reader.Reader
 	maxContentRunes := normalizedMaxContentRunes(req.MaxContentRunes)
 	if req.ReadArxivPapers {
-		pdfReader = pdf.New(reader.WithCustomChunkingStrategy(
-			chunking.NewFixedSizeChunking(
-				chunking.WithWhitespaceTrimming(),
-			),
-		))
+		pdfReader = pdf.New()
 	}
 	for _, result := range results {
 		arti := article{
@@ -286,7 +281,10 @@ func appendArticleContent(
 		if doc == nil {
 			continue
 		}
-		text := doc.Content
+		text := normalizePDFText(doc.Content)
+		if text == "" {
+			continue
+		}
 		contentRunes := utf8.RuneCountInString(text)
 		arti.ContentRunes += contentRunes
 		page := content{
@@ -309,6 +307,19 @@ func appendArticleContent(
 		remaining -= returnedRunes
 		arti.Content = append(arti.Content, page)
 	}
+}
+
+// normalizePDFText preserves arxivsearch's historical whitespace normalization
+// after the shared chunking strategies stopped trimming by default.
+func normalizePDFText(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func truncateRunes(text string, maxRunes int) string {

--- a/tool/arxivsearch/arxiv_search.go
+++ b/tool/arxivsearch/arxiv_search.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"trpc.group/trpc-go/trpc-agent-go/knowledge/chunking"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader"
 	"trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf"
@@ -207,7 +208,11 @@ func (t *ToolSet) search(
 	var pdfReader reader.Reader
 	maxContentRunes := normalizedMaxContentRunes(req.MaxContentRunes)
 	if req.ReadArxivPapers {
-		pdfReader = pdf.New()
+		pdfReader = pdf.New(reader.WithCustomChunkingStrategy(
+			chunking.NewFixedSizeChunking(
+				chunking.WithWhitespaceTrimming(),
+			),
+		))
 	}
 	for _, result := range results {
 		arti := article{

--- a/tool/arxivsearch/arxiv_search_test.go
+++ b/tool/arxivsearch/arxiv_search_test.go
@@ -637,6 +637,57 @@ func TestAppendArticleContentKeepsShortDocuments(t *testing.T) {
 	assert.Equal(t, 11, got.ReturnedContentRunes)
 }
 
+func TestNormalizePDFText(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "unchanged",
+			text: "Hello World",
+			want: "Hello World",
+		},
+		{
+			name: "line whitespace",
+			text: "  def f():  \n\treturn 1\t  ",
+			want: "def f():\nreturn 1",
+		},
+		{
+			name: "line endings",
+			text: "  first  \r\n\tsecond \r third  ",
+			want: "first\nsecond\nthird",
+		},
+		{
+			name: "blank",
+			text: " \n\t ",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizePDFText(tt.text))
+		})
+	}
+}
+
+func TestAppendArticleContentNormalizesBeforeRuneBudget(t *testing.T) {
+	var got article
+	appendArticleContent(&got, []*document.Document{
+		{Content: " \n\t "},
+		{Content: "  αβγ  \r\n\tδε  "},
+	}, 3)
+
+	require.Len(t, got.Content, 1)
+	assert.Equal(t, 2, got.Content[0].Page)
+	assert.Equal(t, "αβγ", got.Content[0].Text)
+	assert.True(t, got.Content[0].Truncated)
+	assert.True(t, got.ContentTruncated)
+	assert.Equal(t, 6, got.ContentRunes)
+	assert.Equal(t, 3, got.ReturnedContentRunes)
+}
+
 // TestNewTool tests the NewToolSet function
 func TestNewTool(t *testing.T) {
 	tool, err := NewToolSet()


### PR DESCRIPTION
## Summary

- preserve leading and trailing spaces and tabs by default in fixed, recursive, and Markdown chunking
- retain whitespace across natural boundaries, balanced tails, overlap, and Markdown section reconstruction
- add explicit compatibility options for legacy trimming and document the required vector-store re-ingestion

## Testing

- [x] `go test ./knowledge/chunking ./knowledge/document/reader/text ./knowledge/document/reader/markdown`
- [x] `go build ./...`
- [x] `.github/scripts/check-examples.sh`
- [x] `go test ./...` reached all affected knowledge packages successfully; unrelated macOS `sandbox-exec` tests fail under the current environment
- [x] `gofmt`, `goimports`, IDE diagnostics, and `git diff --check`

## Notes for reviewers

This intentionally changes default chunk content and embedding input. Persisted vector stores should be cleared and re-ingested after upgrading. `WithWhitespaceTrimming`, `WithRecursiveWhitespaceTrimming`, and `WithMarkdownWhitespaceTrimming` restore the previous lossy behavior when compatibility is required.

Fixes #2429

Made with [Cursor](https://cursor.com)