### PR TITLE
tool/function: allow disabling automatic output schema

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -234,6 +234,24 @@ For Function Tools, the input `req` is automatically converted into a JSON Schem
 - **Compatibility**: `description:"..."` is also supported for legacy code. If both `jsonschema:"description=..."` and `description:"..."` are present, the `jsonschema` description wins.
 - **More flexible schema**: if you need full control over the input schema (e.g. complex JSON Schema constraints), use `function.WithInputSchema(customInputSchema)` to bypass auto-generation.
 
+### Output Schema
+
+`FunctionTool` and `StreamableFunctionTool` automatically derive `Declaration.OutputSchema` from the output type by default. Model adapters with native tool output-schema support can use it directly, while adapters without a native field may append the serialized schema to the tool description. For agents with many tools or large repeated output structures, this can add significant input tokens to every model request that includes those tools.
+
+If the model does not need the return structure, disable automatic generation:
+
+```go
+documentTool := function.NewFunctionTool(
+    getDocument,
+    function.WithDisableOutputSchemaGen(),
+)
+```
+
+- This disables only automatic output schema generation; input schema generation is unchanged.
+- An explicit schema supplied with `function.WithOutputSchema(customOutputSchema)` always takes precedence, including when `WithDisableOutputSchemaGen()` is also present.
+- Without an explicit schema, disabling generation makes `Declaration.OutputSchema` nil, so model adapters neither send it through a native field nor append it to the tool description.
+- Components that reuse `Declaration.OutputSchema` are also affected: Gemini function declarations will not receive `responseJsonSchema`, and CodeAct will skip output validation. Keep automatic generation enabled or provide an explicit schema when those behaviors are required.
+
 ### Streaming Tool Example
 
 ```go

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -221,6 +221,24 @@ Function Tool 的入参 `req` 会自动生成对应的 JSON Schema（用于模�
 - **兼容**：也支持 `description:"..."` 作为字段描述（用于历史代码）；若同时配置 `jsonschema:"description=..."` 与 `description:"..."`，以 `jsonschema` 中的 `description` 为准。
 - **更灵活的 schema**：如果想完全自定义入参 schema（例如需要更复杂的 JSON Schema 结构/约束），可使用 `function.WithInputSchema(customInputSchema)` 跳过自动生成。
 
+### Output Schema（返回值 schema）
+
+`FunctionTool` 和 `StreamableFunctionTool` 默认会根据输出类型自动生成 `Declaration.OutputSchema`。支持原生工具输出 schema 的模型适配器可以直接使用它；不支持原生字段的适配器可能把序列化后的 schema 追加到工具 description。对于工具数量较多，或输出结构较大且重复的 Agent，这会在每次包含这些工具的模型请求中增加较多输入 Token。
+
+如果模型不需要了解工具的返回结构，可以关闭自动生成：
+
+```go
+documentTool := function.NewFunctionTool(
+    getDocument,
+    function.WithDisableOutputSchemaGen(),
+)
+```
+
+- 该选项只关闭 OutputSchema 自动生成，不影响 InputSchema 自动生成。
+- 通过 `function.WithOutputSchema(customOutputSchema)` 显式提供的 schema 始终优先，包括同时传入 `WithDisableOutputSchemaGen()` 的情况。
+- 未显式提供 schema 时，禁用生成会使 `Declaration.OutputSchema` 为 nil，因此模型适配器既不会通过原生字段发送，也不会将其追加到工具 description。
+- 复用 `Declaration.OutputSchema` 的能力也会受影响：Gemini 工具声明将不再包含 `responseJsonSchema`，CodeAct 将跳过输出校验；如果需要这些能力，应保留自动生成或显式提供 schema。
+
 ### 流式工具示例
 
 ```go

--- a/tool/function/function_tool.go
+++ b/tool/function/function_tool.go
@@ -62,6 +62,7 @@ type functionToolOptions struct {
 	inputSchema       *tool.Schema
 	outputSchema      *tool.Schema
 	resultFormatter   resultformat.Formatter
+	disableOutputGen  bool
 }
 
 // WithName sets the name of the function tool.
@@ -133,6 +134,14 @@ func WithOutputSchema(schema *tool.Schema) Option {
 	}
 }
 
+// WithDisableOutputSchemaGen disables automatic output schema generation. A
+// custom schema provided with WithOutputSchema always takes precedence.
+func WithDisableOutputSchemaGen() Option {
+	return func(opts *functionToolOptions) {
+		opts.disableOutputGen = true
+	}
+}
+
 // WithResultFormatter sets the formatter for the function tool's final result.
 // It is currently supported by LLMAgent's default tool-call flow. Graph
 // ToolsNode, ToolPipe, wrappers that replace tool instances, and direct
@@ -196,7 +205,7 @@ func NewFunctionTool[I, O any](fn func(context.Context, I) (O, error), opts ...O
 	var oSchema *tool.Schema
 	if options.outputSchema != nil {
 		oSchema = options.outputSchema
-	} else {
+	} else if !options.disableOutputGen {
 		oSchema = itool.GenerateJSONSchema(reflect.TypeOf(emptyO))
 	}
 
@@ -336,7 +345,7 @@ func NewStreamableFunctionTool[I, O any](fn func(context.Context, I) (*tool.Stre
 	var oSchema *tool.Schema
 	if options.outputSchema != nil {
 		oSchema = options.outputSchema
-	} else {
+	} else if !options.disableOutputGen {
 		oSchema = itool.GenerateJSONSchema(reflect.TypeOf(emptyO))
 	}
 

--- a/tool/function/function_tool_test.go
+++ b/tool/function/function_tool_test.go
@@ -771,6 +771,52 @@ func TestFunctionTool_WithOutputSchema(t *testing.T) {
 	}
 }
 
+func TestFunctionTool_WithDisableOutputSchemaGen(t *testing.T) {
+	type inputArgs struct {
+		A int `json:"a"`
+	}
+	type outputArgs struct {
+		Result int `json:"result"`
+	}
+
+	fn := func(_ context.Context, args inputArgs) (outputArgs, error) {
+		return outputArgs{Result: args.A * 2}, nil
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		fTool := function.NewFunctionTool(
+			fn,
+			function.WithDisableOutputSchemaGen(),
+		)
+		decl := fTool.Declaration()
+		if decl.InputSchema == nil {
+			t.Fatal("expected non-nil InputSchema")
+		}
+		if decl.OutputSchema != nil {
+			t.Fatalf("expected nil OutputSchema, got %#v", decl.OutputSchema)
+		}
+	})
+
+	t.Run("enabled by default", func(t *testing.T) {
+		fTool := function.NewFunctionTool(fn)
+		if fTool.Declaration().OutputSchema == nil {
+			t.Fatal("expected non-nil OutputSchema")
+		}
+	})
+
+	t.Run("custom schema takes precedence", func(t *testing.T) {
+		customOutputSchema := &tool.Schema{Type: "string"}
+		fTool := function.NewFunctionTool(
+			fn,
+			function.WithOutputSchema(customOutputSchema),
+			function.WithDisableOutputSchemaGen(),
+		)
+		if fTool.Declaration().OutputSchema != customOutputSchema {
+			t.Fatal("expected custom OutputSchema")
+		}
+	})
+}
+
 func TestFunctionTool_WithBothCustomSchemas(t *testing.T) {
 	type inputArgs struct {
 		X int `json:"x"`
@@ -925,6 +971,34 @@ func TestStreamableFunctionTool_WithOutputSchema(t *testing.T) {
 	if decl.OutputSchema.Type != "object" {
 		t.Errorf("expected schema type 'object', got %q", decl.OutputSchema.Type)
 	}
+}
+
+func TestStreamableFunctionTool_WithDisableOutputSchemaGen(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		st := function.NewStreamableFunctionTool[streamTestInput, streamTestOutput](
+			streamableFunc,
+			function.WithDisableOutputSchemaGen(),
+		)
+		decl := st.Declaration()
+		if decl.InputSchema == nil {
+			t.Fatal("expected non-nil InputSchema")
+		}
+		if decl.OutputSchema != nil {
+			t.Fatalf("expected nil OutputSchema, got %#v", decl.OutputSchema)
+		}
+	})
+
+	t.Run("custom schema takes precedence", func(t *testing.T) {
+		customOutputSchema := &tool.Schema{Type: "string"}
+		st := function.NewStreamableFunctionTool[streamTestInput, streamTestOutput](
+			streamableFunc,
+			function.WithOutputSchema(customOutputSchema),
+			function.WithDisableOutputSchemaGen(),
+		)
+		if st.Declaration().OutputSchema != customOutputSchema {
+			t.Fatal("expected custom OutputSchema")
+		}
+	})
 }
 
 func TestStreamableFunctionTool_WithBothCustomSchemas(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `function.WithDisableOutputSchemaGen` to opt out of automatic output schema generation
- preserve automatic generation by default for existing callers
- apply the same behavior to regular and streamable function tools
- document the option, precedence rules, and downstream effects in the English and Chinese tool guides

## Why

`NewFunctionTool` automatically derives `Declaration.OutputSchema` from the return type. Providers without native tool output-schema support append that schema to the tool description, which can duplicate large schemas across many tools and every model request that includes them.

Callers that do not need output-shape guidance can now disable the generated schema with `function.WithDisableOutputSchemaGen()`, reducing repeated tool-definition tokens. Explicit schemas supplied with `WithOutputSchema` still take precedence.

Disabling the schema removes it from `Declaration.OutputSchema`. Gemini function declarations will not receive `responseJsonSchema`, and CodeAct will skip output validation unless the caller supplies an explicit schema.

## Testing

- `go test ./tool/function ./codeexecutor/codeact ./model/openai ./model/hunyuan -count=1`
- targeted output-schema conversion tests in `model/anthropic`, `model/bedrock`, `model/ollama`, and `model/gemini`
- `mkdocs build --strict -f docs/mkdocs.yml`
- `typos docs/mkdocs/en/tool.md docs/mkdocs/zh/tool.md tool/function/function_tool.go tool/function/function_tool_test.go`
