### PR TITLE
test: make QueueModel consume one call per invocation

### DIFF
--- a/test/agui_server_e2e_test.go
+++ b/test/agui_server_e2e_test.go
@@ -132,19 +132,9 @@ func TestAGUIServer_MockModel_RunAndSnapshot(t *testing.T) {
 }
 
 func TestAGUIServer_MockModel_CancelStopsRun(t *testing.T) {
-	modelInstance := &QueueModel{}
-	modelInstance.Push(Call{
-		Responses: []*model.Response{
-			{
-				ID:        "mock-stream-1",
-				Object:    model.ObjectTypeChatCompletionChunk,
-				IsPartial: true,
-				Choices: []model.Choice{{
-					Delta: model.Message{Role: model.RoleAssistant, Content: "x"},
-				}},
-			},
-		},
-	})
+	modelInstance := &waitModel{delta: model.Message{
+		Role: model.RoleAssistant, Content: "x",
+	}}
 
 	httpServer := newAGUIHTTPServer(t, modelInstance)
 
@@ -231,7 +221,9 @@ func TestAGUIServer_MockModel_CancelDuringReasoningKeepsHistoryValid(t *testing.
 		Service:      baseSessionService,
 		TrackService: baseSessionService,
 	}
-	modelInstance := &reasoningWaitModel{reasoningDelta: "thinking"}
+	modelInstance := &waitModel{delta: model.Message{
+		Role: model.RoleAssistant, ReasoningContent: "thinking",
+	}}
 	httpServer := newAGUIHTTPServerWithOptions(
 		t,
 		modelInstance,
@@ -465,11 +457,11 @@ func (s *ctxAwareTrackSessionService) AppendTrackEvent(
 	return s.TrackService.AppendTrackEvent(ctx, sess, event, opts...)
 }
 
-type reasoningWaitModel struct {
-	reasoningDelta string
+type waitModel struct {
+	delta model.Message
 }
 
-func (m *reasoningWaitModel) GenerateContent(ctx context.Context, request *model.Request) (<-chan *model.Response, error) {
+func (m *waitModel) GenerateContent(ctx context.Context, request *model.Request) (<-chan *model.Response, error) {
 	if request == nil {
 		return nil, errors.New("mock model: request is nil")
 	}
@@ -480,11 +472,11 @@ func (m *reasoningWaitModel) GenerateContent(ctx context.Context, request *model
 		case <-ctx.Done():
 			return
 		case ch <- &model.Response{
-			ID:        "reasoning-msg-1",
+			ID:        "wait-msg-1",
 			Object:    model.ObjectTypeChatCompletionChunk,
 			IsPartial: true,
 			Choices: []model.Choice{{
-				Delta: model.Message{Role: model.RoleAssistant, ReasoningContent: m.reasoningDelta},
+				Delta: m.delta,
 			}},
 		}:
 		}
@@ -493,6 +485,6 @@ func (m *reasoningWaitModel) GenerateContent(ctx context.Context, request *model
 	return ch, nil
 }
 
-func (m *reasoningWaitModel) Info() model.Info {
-	return model.Info{Name: "reasoning-wait-model"}
+func (m *waitModel) Info() model.Info {
+	return model.Info{Name: "wait-model"}
 }

--- a/test/mock_model.go
+++ b/test/mock_model.go
@@ -21,17 +21,23 @@ type Call struct {
 	Responses []*model.Response
 }
 
+// QueueModel is a synchronized FIFO of model calls. Each GenerateContent call
+// consumes one Call previously added with Push.
 type QueueModel struct {
 	mu    sync.Mutex
 	Calls []Call
 }
 
+// Push adds a Call to the end of the queue. It is safe to call concurrently
+// with Push or GenerateContent.
 func (m *QueueModel) Push(call Call) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.Calls = append(m.Calls, call)
 }
 
+// GenerateContent consumes and returns the next queued Call. A nil request is
+// rejected without consuming a Call, and an empty queue returns an error.
 func (m *QueueModel) GenerateContent(ctx context.Context, request *model.Request) (<-chan *model.Response, error) {
 	if request == nil {
 		return nil, errors.New("mock model: request is nil")

--- a/test/mock_model.go
+++ b/test/mock_model.go
@@ -12,6 +12,7 @@ package e2e
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -21,10 +22,13 @@ type Call struct {
 }
 
 type QueueModel struct {
+	mu    sync.Mutex
 	Calls []Call
 }
 
 func (m *QueueModel) Push(call Call) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.Calls = append(m.Calls, call)
 }
 
@@ -32,20 +36,24 @@ func (m *QueueModel) GenerateContent(ctx context.Context, request *model.Request
 	if request == nil {
 		return nil, errors.New("mock model: request is nil")
 	}
+	m.mu.Lock()
 	if len(m.Calls) == 0 {
+		m.mu.Unlock()
 		return nil, errors.New("mock model: no queued calls")
 	}
+	call := m.Calls[0]
+	m.Calls[0] = Call{}
+	m.Calls = m.Calls[1:]
+	m.mu.Unlock()
 
 	ch := make(chan *model.Response)
 	go func() {
 		defer close(ch)
-		for _, call := range m.Calls {
-			for _, resp := range call.Responses {
-				select {
-				case <-ctx.Done():
-					return
-				case ch <- resp:
-				}
+		for _, resp := range call.Responses {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- resp:
 			}
 		}
 	}()

--- a/test/mock_model_test.go
+++ b/test/mock_model_test.go
@@ -1,0 +1,102 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestQueueModelConsumesCallsInOrder(t *testing.T) {
+	m := &QueueModel{}
+	m.Push(responseCall("first"))
+	m.Push(responseCall("second"))
+
+	ids, err := generateResponseIDs(m)
+	require.NoError(t, err)
+	require.Equal(t, []string{"first"}, ids)
+
+	ids, err = generateResponseIDs(m)
+	require.NoError(t, err)
+	require.Equal(t, []string{"second"}, ids)
+
+	_, err = m.GenerateContent(context.Background(), &model.Request{})
+	require.ErrorContains(t, err, "no queued calls")
+}
+
+func TestQueueModelNilRequestDoesNotConsumeCall(t *testing.T) {
+	m := &QueueModel{}
+	m.Push(responseCall("first"))
+
+	_, err := m.GenerateContent(context.Background(), nil)
+	require.ErrorContains(t, err, "request is nil")
+
+	ids, err := generateResponseIDs(m)
+	require.NoError(t, err)
+	require.Equal(t, []string{"first"}, ids)
+}
+
+func TestQueueModelConcurrentCallsConsumeEachCallOnce(t *testing.T) {
+	const callCount = 8
+
+	m := &QueueModel{}
+	for i := 0; i < callCount; i++ {
+		m.Push(responseCall(fmt.Sprintf("response-%d", i)))
+	}
+
+	type result struct {
+		ids []string
+		err error
+	}
+	results := make(chan result, callCount)
+	var wg sync.WaitGroup
+	for i := 0; i < callCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ids, err := generateResponseIDs(m)
+			results <- result{ids: ids, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	seen := make(map[string]int, callCount)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.Len(t, result.ids, 1)
+		seen[result.ids[0]]++
+	}
+	for i := 0; i < callCount; i++ {
+		require.Equal(t, 1, seen[fmt.Sprintf("response-%d", i)])
+	}
+}
+
+func responseCall(id string) Call {
+	return Call{Responses: []*model.Response{{ID: id}}}
+}
+
+func generateResponseIDs(m *QueueModel) ([]string, error) {
+	responses, err := m.GenerateContent(context.Background(), &model.Request{})
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for response := range responses {
+		ids = append(ids, response.ID)
+	}
+	return ids, nil
+}

--- a/test/mock_model_test.go
+++ b/test/mock_model_test.go
@@ -84,6 +84,54 @@ func TestQueueModelConcurrentCallsConsumeEachCallOnce(t *testing.T) {
 	}
 }
 
+func TestQueueModelConcurrentPushAndGenerate(t *testing.T) {
+	const callCount = 32
+
+	m := &QueueModel{}
+	start := make(chan struct{})
+	queued := make(chan struct{}, callCount)
+	type result struct {
+		ids []string
+		err error
+	}
+	results := make(chan result, callCount)
+
+	var wg sync.WaitGroup
+	for i := 0; i < callCount; i++ {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			<-start
+			m.Push(responseCall(id))
+			queued <- struct{}{}
+		}(fmt.Sprintf("response-%d", i))
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			<-queued
+			ids, err := generateResponseIDs(m)
+			results <- result{ids: ids, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	seen := make(map[string]int, callCount)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.Len(t, result.ids, 1)
+		seen[result.ids[0]]++
+	}
+	for i := 0; i < callCount; i++ {
+		require.Equal(t, 1, seen[fmt.Sprintf("response-%d", i)])
+	}
+	_, err := m.GenerateContent(context.Background(), &model.Request{})
+	require.ErrorContains(t, err, "no queued calls")
+}
+
 func responseCall(id string) Call {
 	return Call{Responses: []*model.Response{{ID: id}}}
 }


### PR DESCRIPTION
## What changed

`QueueModel` now atomically consumes one queued `Call` per model invocation in FIFO order, so multi-turn E2E tests can script responses without later turns being emitted early or replayed. Concurrent pushes and call consumption are synchronized.

The AG-UI cancellation tests now use a dedicated context-blocking stream model instead of relying on queued calls being replayed to keep a run alive.

## Why

`GenerateContent` previously iterated over the complete `Calls` slice without removing entries. With two queued turns, the first invocation emitted both turns and every later invocation replayed both again. Concurrent invocations also observed the same calls.

Separating finite queued responses from an intentionally blocking stream gives both test helpers a single, explicit lifecycle contract.

Fixes #2444.

## Testing

- `cd test && go test ./...`
- `cd test && go test -race ./...`
- `cd test && go test -race . -run "^TestQueueModel" -count=10`
- `cd test && go vet ./...`
- `gofmt -r "interface{} -> any" -l test/agui_server_e2e_test.go test/mock_model.go test/mock_model_test.go`
- `go run golang.org/x/tools/cmd/goimports@latest -l test/agui_server_e2e_test.go test/mock_model.go test/mock_model_test.go`

## Notes for reviewers

This changes only the independent E2E test module. Runtime model APIs and behavior are unchanged.