### PR TITLE
model/openai: gate GLM reasoning fallback on normal completion

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1957,7 +1957,7 @@ The framework currently supports the following Variants:
 
 - GLM OpenAI-compatible API adaptation
 - Serializes the thinking toggle using GLM's `thinking` object format
-- Falls back to exposing `reasoning_content` as visible content when some GLM gateways return an empty `content` field without tool calls
+- Falls back to exposing `reasoning_content` as visible content when some GLM gateways return an empty `content` field without tool calls and finish normally (`finish_reason=stop`)
 
 **6. VariantKimi**
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1930,7 +1930,7 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 
 - GLM OpenAI-compatible 接口适配
 - 使用 GLM 的 `thinking` 对象格式序列化思考开关
-- 当部分 GLM 网关把最终答案放在 `reasoning_content`、`content` 为空且正常结束（`finish_reason=stop`）时，框架会将其回退为可见内容
+- 当部分 GLM 网关把最终答案放在 `reasoning_content`，且 `content` 为空、没有工具调用并正常结束（`finish_reason=stop`）时，框架会将其回退为可见内容
 
 **6. VariantKimi**
 

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1930,7 +1930,7 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 
 - GLM OpenAI-compatible 接口适配
 - 使用 GLM 的 `thinking` 对象格式序列化思考开关
-- 当部分 GLM 网关把最终答案放在 `reasoning_content` 且 `content` 为空时，框架会将其回退为可见内容
+- 当部分 GLM 网关把最终答案放在 `reasoning_content`、`content` 为空且正常结束（`finish_reason=stop`）时，框架会将其回退为可见内容
 
 **6. VariantKimi**
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -167,8 +167,8 @@ type variantConfig struct {
 	// defaultReasoningContentBackfill controls replay-time empty
 	// reasoning_content backfill for assistant messages.
 	defaultReasoningContentBackfill bool
-	// reasoningContentAsContentFallback copies reasoning_content into
-	// content only when content is empty and the response has no tool calls.
+	// reasoningContentAsContentFallback copies reasoning_content into content
+	// only for normally completed responses with empty content and no tool calls.
 	reasoningContentAsContentFallback bool
 }
 type fileDeletionBodyConvertor func(
@@ -2623,6 +2623,7 @@ func (m *Model) emitStreamingFinalResponse(
 							Content: m.contentWithReasoningFallback(
 								"",
 								aggregatedReasoning,
+								"",
 								false,
 							),
 							ReasoningContent: aggregatedReasoning,
@@ -2736,6 +2737,7 @@ func (m *Model) createFinalResponse(
 		content := m.contentWithReasoningFallback(
 			choice.Message.Content,
 			reasoningContent,
+			choice.FinishReason,
 			choiceHasToolCalls,
 		)
 
@@ -2825,6 +2827,7 @@ func (m *Model) createResponseFromCompletion(chatCompletion *openai.ChatCompleti
 			content := m.contentWithReasoningFallback(
 				choice.Message.Content,
 				reasoningContent,
+				choice.FinishReason,
 				len(choice.Message.ToolCalls) > 0,
 			)
 
@@ -2885,9 +2888,11 @@ func (m *Model) createResponseFromCompletion(chatCompletion *openai.ChatCompleti
 func (m *Model) contentWithReasoningFallback(
 	content string,
 	reasoningContent string,
+	finishReason string,
 	hasToolCall bool,
 ) string {
-	if content != "" || reasoningContent == "" || hasToolCall {
+	if content != "" || reasoningContent == "" ||
+		finishReason != "stop" || hasToolCall {
 		return content
 	}
 	if m == nil || !m.variantConfig.reasoningContentAsContentFallback {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -7253,6 +7253,36 @@ func TestCreateFinalResponseGLMReasoningContentFallback(t *testing.T) {
 	require.Equal(t, "收到", resp.Choices[0].Message.ReasoningContent)
 }
 
+func TestCreateFinalResponseGLMReasoningContentFallbackSkipsLength(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	acc := openai.ChatCompletionAccumulator{
+		ChatCompletion: openai.ChatCompletion{
+			ID:    "acc-id",
+			Model: "glm50",
+			Choices: []openai.ChatCompletionChoice{{
+				Index:        0,
+				FinishReason: "length",
+				Message: openai.ChatCompletionMessage{
+					Content: "",
+				},
+			}},
+		},
+	}
+
+	resp := m.createFinalResponse(acc, false, nil, "truncated reasoning")
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Empty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, "truncated reasoning",
+		resp.Choices[0].Message.ReasoningContent)
+	require.NotNil(t, resp.Choices[0].FinishReason)
+	require.Equal(t, "length", *resp.Choices[0].FinishReason)
+}
+
 func TestCreateFinalResponseGLMReasoningContentFallbackSkipsToolCall(
 	t *testing.T,
 ) {
@@ -7347,6 +7377,39 @@ func TestCreateResponseFromCompletionGLMReasoningContentFallback(
 	require.Equal(t, "收到", resp.Choices[0].Message.ReasoningContent)
 }
 
+func TestCreateResponseFromCompletionGLMReasoningContentFallbackSkipsLength(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	var completion openai.ChatCompletion
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "completion-id",
+		"object": "chat.completion",
+		"created": 1699200000,
+		"model": "glm50",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"reasoning_content": "truncated reasoning"
+			},
+			"finish_reason": "length"
+		}]
+	}`), &completion))
+
+	resp := m.createResponseFromCompletion(&completion)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Choices, 1)
+	require.Empty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, "truncated reasoning",
+		resp.Choices[0].Message.ReasoningContent)
+	require.NotNil(t, resp.Choices[0].FinishReason)
+	require.Equal(t, "length", *resp.Choices[0].FinishReason)
+}
+
 func TestCreateResponseFromCompletionGLMReasoningContentSkipsToolCall(
 	t *testing.T,
 ) {
@@ -7401,6 +7464,10 @@ func TestEmitStreamingFinalResponseGLMReasoningContentFallback(
 			ChatCompletion: openai.ChatCompletion{
 				ID:    "acc-id",
 				Model: "glm50",
+				Choices: []openai.ChatCompletionChoice{{
+					Index:        0,
+					FinishReason: "stop",
+				}},
 			},
 		},
 		nil,
@@ -7416,6 +7483,38 @@ func TestEmitStreamingFinalResponseGLMReasoningContentFallback(
 	require.Len(t, got.Choices, 1)
 	require.Equal(t, "收到", got.Choices[0].Message.Content)
 	require.Equal(t, "收到", got.Choices[0].Message.ReasoningContent)
+}
+
+func TestEmitStreamingFinalResponseGLMReasoningContentFallbackSkipsWithoutFinishReason(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	m := New("glm50", WithVariant(VariantGLM))
+	var got *model.Response
+	m.emitStreamingFinalResponse(
+		context.Background(),
+		&ssestream.Stream[openai.ChatCompletionChunk]{},
+		openai.ChatCompletionAccumulator{
+			ChatCompletion: openai.ChatCompletion{
+				ID:    "acc-id",
+				Model: "glm50",
+			},
+		},
+		nil,
+		nil,
+		"unfinished reasoning",
+		func(resp *model.Response) bool {
+			got = resp
+			return true
+		},
+	)
+
+	require.NotNil(t, got)
+	require.Len(t, got.Choices, 1)
+	require.Empty(t, got.Choices[0].Message.Content)
+	require.Equal(t, "unfinished reasoning",
+		got.Choices[0].Message.ReasoningContent)
 }
 
 // TestCreateFinalResponseUsageConditional verifies that Usage is only set on the

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -7294,7 +7294,8 @@ func TestCreateFinalResponseGLMReasoningContentFallbackSkipsToolCall(
 			ID:    "acc-id",
 			Model: "glm50",
 			Choices: []openai.ChatCompletionChoice{{
-				Index: 0,
+				Index:        0,
+				FinishReason: "stop",
 				Message: openai.ChatCompletionMessage{
 					Content: "",
 				},
@@ -7332,7 +7333,8 @@ func TestCreateFinalResponseReasoningContentNoFallbackForOpenAI(
 			ID:    "acc-id",
 			Model: "gpt-5",
 			Choices: []openai.ChatCompletionChoice{{
-				Index: 0,
+				Index:        0,
+				FinishReason: "stop",
 				Message: openai.ChatCompletionMessage{
 					Content: "",
 				},
@@ -7437,7 +7439,7 @@ func TestCreateResponseFromCompletionGLMReasoningContentSkipsToolCall(
 					}
 				}]
 			},
-			"finish_reason": "tool_calls"
+			"finish_reason": "stop"
 		}]
 	}`), &completion))
 


### PR DESCRIPTION
## What changed

GLM reasoning-only responses are exposed as visible assistant content only when the provider reports a normal `finish_reason=stop`. Truncated or otherwise unfinished reasoning remains available through `ReasoningContent` without being presented as a completed answer.

## Why

The GLM compatibility fallback previously treated `finish_reason=length` like a successful completion. When a thinking model exhausted its token budget before producing visible content, consumers could render and persist a partial chain of thought as the final answer.

Fixes #2410

## Testing

- `go test -race ./model/openai`
- targeted GLM fallback tests repeated 10 times
- `go build ./...`
- `go vet ./model/openai`
- `gofmt`, `goimports`, and `git diff --check`

The full suite was also exercised locally. Unrelated macOS-only cleanup and `sandbox-exec` tests failed because of host runtime and sandbox restrictions; all model packages passed, and the repository build completed successfully.

## Notes for reviewers

This changes no exported Go API. The provider-specific observable behavior changes only for responses without an explicit successful finish reason; the existing `stop` fallback, tool-call behavior, visible content, and non-GLM variants remain unchanged.