### PR TITLE
docs: clarify caller-executed tool options

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -2569,13 +2569,34 @@ execute tools instead. You can interrupt tool execution with
 
 **Key idea:**
 
-- `agent.WithToolFilter(...)` controls **tool visibility** (what the model can
-  see and call).
-- `agent.WithToolExecutionFilter(...)` controls **tool execution** (what the
-  framework will auto-run after the model requests it).
-- `agent.WithAdditionalTools(...)` appends temporary tools for one run.
-- `agent.WithExternalTools(...)` appends temporary tools and marks them as
-  caller-executed.
+| Option | Model visibility | Adds a tool for this run | Execution owner |
+| --- | --- | --- | --- |
+| `WithToolFilter` | Filters user tools; framework tools remain visible | No | Does not change execution ownership |
+| `WithToolExecutionFilter` | Does not change visibility | No | The framework when the filter returns `true`; the caller when it returns `false` |
+| `WithAdditionalTools` | Visible unless hidden by `WithToolFilter` | Yes | The framework by default |
+| `WithExternalTools` | Visible unless hidden by `WithToolFilter` | Yes | Always the caller |
+
+Choose the option based on where the tool declaration comes from and who owns
+execution:
+
+- Use `WithToolExecutionFilter` when the tool is already registered on the
+  Agent, or was added with `WithAdditionalTools`, and only its execution policy
+  should change for this run.
+- Use `WithExternalTools` when the caller dynamically supplies a tool
+  declaration that is not already present on the Agent.
+- Use `WithToolFilter` when the model must not see a user tool at all.
+- Use `WithAdditionalTools` for a temporary tool that the framework should
+  execute by default.
+
+For example, the following keeps `client_search` visible but leaves its tool
+calls for the caller. `NewExcludeToolNamesFilter` returns `false` for the named
+tool, and `WithToolExecutionFilter` interprets `false` as "do not execute":
+
+```go
+agent.WithToolExecutionFilter(
+    tool.NewExcludeToolNamesFilter("client_search"),
+)
+```
 
 #### Basic Flow
 
@@ -2636,6 +2657,41 @@ messages. If an external tool has the same name as an existing tool, the
 existing tool wins; the external declaration does not override or intercept it.
 This includes tools registered on the Agent and tools added with
 `WithAdditionalTools`.
+
+#### Frequently Asked Questions
+
+**Does `WithToolExecutionFilter` hide tools from the model?**
+
+No. It is evaluated only after the model requests a visible tool. A `false`
+result prevents framework execution and ends the current invocation after the
+assistant `tool_calls` response. The caller then executes the tool and starts a
+continuation with a matching `role=tool` message. Use `WithToolFilter` to
+control visibility.
+
+**Can `WithToolExecutionFilter` and `WithExternalTools` be used together?**
+
+Yes, for different tools in the same run. External tools are always
+caller-executed. The execution filter is evaluated only for non-external tools.
+In a mixed tool-call response, the framework can execute allowed tools, but the
+invocation still ends when any call is external or deferred so the caller can
+complete the remaining calls.
+
+**Can `WithExternalTools` make an already registered tool caller-executed?**
+
+No. Existing Agent tools and `WithAdditionalTools` take precedence by name. An
+external declaration with the same name neither replaces the existing tool nor
+marks it external. Use `WithToolExecutionFilter` to defer an existing tool.
+
+**Is this interruption the same as `graph.Interrupt`?**
+
+No. Caller-executed tool handling ends the current invocation after emitting
+the assistant tool call; no framework tool execution is suspended. The caller
+executes the tool and continues with `model.NewToolMessage(...)` in another
+`Run`. `graph.Interrupt` is a graph checkpoint and resume mechanism.
+
+These options route tool execution; they are not authorization boundaries.
+Framework-executed tools must enforce permissions in their implementations,
+and caller-executed tools must do so in the caller's tool runtime.
 
 The `server/openai` adapter only implements `tool_choice: "none"` (skip
 exposing tools to the model) and `tool_choice: "auto"` or an omitted value

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -2331,10 +2331,31 @@ Model Context Protocol (MCP)）来执行工具。此时可以使用
 
 **核心区别：**
 
-- `agent.WithToolFilter(...)` 控制**工具可见性**（模型能看到/能调用哪些工具）
-- `agent.WithToolExecutionFilter(...)` 控制**工具执行**（模型请求后，框架是否自动执行）
-- `agent.WithAdditionalTools(...)` 为本次运行追加临时可见工具
-- `agent.WithExternalTools(...)` 追加临时可见工具，并声明这些工具由调用方执行
+| Option | 模型可见性 | 是否为本次运行添加工具 | 执行方 |
+| --- | --- | --- | --- |
+| `WithToolFilter` | 过滤用户工具；框架工具仍然可见 | 否 | 不改变执行归属 |
+| `WithToolExecutionFilter` | 不改变可见性 | 否 | filter 返回 `true` 时由框架执行，返回 `false` 时由调用方执行 |
+| `WithAdditionalTools` | 可见，除非被 `WithToolFilter` 隐藏 | 是 | 默认由框架执行 |
+| `WithExternalTools` | 可见，除非被 `WithToolFilter` 隐藏 | 是 | 始终由调用方执行 |
+
+应根据工具声明的来源和执行归属选择 Option：
+
+- 工具已经注册在 Agent 上，或者通过 `WithAdditionalTools` 添加，只想在本次
+  运行中改变执行方时，使用 `WithToolExecutionFilter`。
+- 调用方动态提供了一个 Agent 上原本不存在的工具声明时，使用
+  `WithExternalTools`。
+- 需要让模型完全看不到某个用户工具时，使用 `WithToolFilter`。
+- 需要临时添加一个默认由框架执行的工具时，使用 `WithAdditionalTools`。
+
+例如，下面的配置会让 `client_search` 对模型保持可见，但由调用方执行其 tool
+call。`NewExcludeToolNamesFilter` 会对指定工具返回 `false`，而
+`WithToolExecutionFilter` 将 `false` 解释为“不执行”：
+
+```go
+agent.WithToolExecutionFilter(
+    tool.NewExcludeToolNamesFilter("client_search"),
+)
+```
 
 #### 基本流程
 
@@ -2387,6 +2408,38 @@ ch, err = r.Run(ctx, userID, sessionID, toolMsg,
 `WithExternalTools` 更适合 AG-UI、浏览器、移动端或上游服务在每次请求中动态声明
 工具的场景。AG-UI runner 默认会把请求里的 `input.Tools` 映射为
 `WithExternalTools`；OpenAI Chat Completions adapter（`server/openai`）同样会把请求里的 `tools` 映射为 `WithExternalTools`，服务端不执行这些工具，由调用方在收到 `tool_calls` 后外部执行并用 `role=tool` 消息续聊。外部工具与已有工具同名时，已有工具优先，外部声明不会覆盖或拦截它。这里的已有工具包括 Agent 上注册的工具，以及通过 `WithAdditionalTools` 追加的工具。
+
+#### 常见问题
+
+**`WithToolExecutionFilter` 会让模型看不到工具吗？**
+
+不会。它只会在模型请求一个可见工具之后才参与判断。filter 返回 `false` 时，
+框架不会执行该工具，并在输出 assistant `tool_calls` 响应后结束当前
+invocation。调用方随后执行工具，再用匹配的 `role=tool` 消息发起续跑。需要控制
+可见性时应使用 `WithToolFilter`。
+
+**`WithToolExecutionFilter` 和 `WithExternalTools` 可以一起使用吗？**
+
+可以，同一次运行中的不同工具可以分别使用两种机制。external tool 始终由调用方
+执行；`WithToolExecutionFilter` 只会检查非 external tool。如果模型在同一条响应
+里同时调用两类工具，框架可以执行允许自动执行的工具，但只要存在 external 或被
+延迟的调用，当前 invocation 仍会结束，让调用方完成剩余调用。
+
+**`WithExternalTools` 能把已经注册的工具改成由调用方执行吗？**
+
+不能。Agent 已注册工具和 `WithAdditionalTools` 添加的工具按名称优先；同名的
+external 声明既不会替换已有工具，也不会把它标记成 external。需要延迟已有工具
+时，应使用 `WithToolExecutionFilter`。
+
+**这里的“中断”和 `graph.Interrupt` 是一回事吗？**
+
+不是。caller-executed tool 流程会在输出 assistant tool call 后结束当前
+invocation，并不会挂起某个框架内工具的执行。调用方执行工具后，在另一次 `Run`
+中通过 `model.NewToolMessage(...)` 继续；`graph.Interrupt` 则是 Graph 的检查点与
+恢复机制。
+
+这些 Option 只负责路由工具执行，不是鉴权边界。由框架执行的工具必须在自身实现
+中完成权限检查；由调用方执行的工具则必须在调用方的工具运行时中完成权限检查。
 
 `server/openai` adapter 目前只实现了 `tool_choice: "none"`（不把 tools 暴露给模型）和 `tool_choice: "auto"` 或省略该字段（由模型自行决定，这也是该 adapter 能提供的唯一行为，因为它自身从不执行工具）。当请求同时带有 `tools` 时，`tool_choice: "required"` 以及强制指定函数的写法（`{"type":"function","function":{"name":"..."}}`）会被拒绝并返回 HTTP 400，而不会被静默当作 `"auto"` 处理。
 


### PR DESCRIPTION
## What changed

- Added an English and Chinese comparison table for `WithToolFilter`,
  `WithToolExecutionFilter`, `WithAdditionalTools`, and `WithExternalTools`.
- Documented option-selection guidance and the execution filter's boolean
  semantics.
- Added FAQs covering visibility, mixed usage, same-name precedence, graph
  interruption, and authorization boundaries.

## Why

The existing manual tool execution section described these options, but the
distinction between hiding a tool and deferring its execution was easy to
misread. The caller-executed lifecycle, same-name behavior, and interaction
between external tools and the execution filter also needed a concise reference.

## Testing

- `mkdocs build --strict`
- `git diff --check`

## Notes for reviewers

This is a documentation-only clarification and does not change public APIs or
runtime behavior.
