### PR TITLE
dynamicworkflow: add agent model profiles

### DIFF
--- a/docs/mkdocs/en/dynamic-workflow.md
+++ b/docs/mkdocs/en/dynamic-workflow.md
@@ -169,12 +169,61 @@ review = await agent(
 The common options are:
 
 - `instruction`: the temporary role instruction for this child Agent call.
+- `model`: optional host-authorized model profile alias when the host registered
+  profiles with `WithAgentModelProfile`. Omit it to inherit the template model.
 - `tools` / `skills`: omitted means inherit from the base Agent; `[]` disables
   that capability for this call; a non-empty list narrows the base Agent's
   existing capabilities.
 - `structured_output` / `schema`: asks this child Agent to return structured
   JSON.
 - `instance_id`: reuses the same child Agent history within one workflow.
+
+### Host-authorized model profiles
+
+By default, each child call uses the template Agent's registered model. To let
+workflow code choose among a few host-owned models, register profile aliases:
+
+```go
+fast := openai.New("gpt-5-mini")
+deep := openai.New("gpt-5")
+
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.LocalRunner{},
+    []agent.Agent{general},
+    dynamicworkflow.WithAgentModelProfile(
+        "fast",
+        "Low-latency drafting and simple extraction.",
+        fast,
+    ),
+    dynamicworkflow.WithAgentModelProfile(
+        "deep",
+        "Careful review and multi-step reasoning.",
+        deep,
+    ),
+)
+```
+
+A workflow may then select a profile for one child call:
+
+```python
+draft = await agent(
+    "Write a short draft.",
+    instruction="Draft quickly.",
+    model="fast",
+)
+review = await agent(
+    {"draft": draft["text"]},
+    instruction="Review carefully.",
+    model="deep",
+)
+```
+
+Profiles are an allowlist. The host owns each `model.Model` instance; workflow
+code cannot pass a provider model identifier or construct a model. Omitting
+`model` preserves the template model exactly. Choose an override only for a
+clear task-specific reason. Selected profiles apply to `LLMAgent` templates and
+to custom Agents that honor invocation surface patches; other Agents keep their
+configured model.
 
 When `instance_id` is omitted, each `agent(...)` call creates an independent
 child Agent history, which is the right default for parallel branches. For
@@ -189,8 +238,9 @@ The shared history contains child inputs and emitted events. A dynamic
 conversation message. Put facts that a later call must remember in `input`.
 
 These options affect only the current child Agent call. A workflow cannot use
-them to change the model, permission policy, or add host capabilities that the
-base Agent did not already have.
+them to change permission policy, invent model endpoints, or add host
+capabilities that the base Agent did not already have. Model selection is
+limited to aliases the host registered with `WithAgentModelProfile`.
 
 `agent(...)` returns an envelope containing `text`, optional `structured`
 output, and execution metadata. Pass `result["text"]` downstream for plain text

--- a/docs/mkdocs/zh/dynamic-workflow.md
+++ b/docs/mkdocs/zh/dynamic-workflow.md
@@ -156,9 +156,56 @@ review = await agent(
 常用选项只有几个：
 
 - `instruction`：这次子 Agent 的临时角色说明。
+- `model`：宿主通过 `WithAgentModelProfile` 注册 profile 后可选的模型别名；
+  省略则继承模板模型。
 - `tools` / `skills`：省略表示继承基础 Agent；`[]` 表示这次禁用；非空列表表示在基础 Agent 已有能力上收窄。
 - `structured_output` / `schema`：要求这次子 Agent 返回结构化 JSON。
 - `instance_id`：同一个 workflow 内多次调用复用同一个子 Agent 历史。
+
+### 宿主授权的模型 profile
+
+默认情况下，每次子 Agent 调用使用模板 Agent 已注册的模型。若要让 workflow
+在少数宿主持有模型之间选择，可注册 profile 别名：
+
+```go
+fast := openai.New("gpt-5-mini")
+deep := openai.New("gpt-5")
+
+workflow, err := dynamicworkflow.NewTool(
+    dynamicworkflow.LocalRunner{},
+    []agent.Agent{general},
+    dynamicworkflow.WithAgentModelProfile(
+        "fast",
+        "Low-latency drafting and simple extraction.",
+        fast,
+    ),
+    dynamicworkflow.WithAgentModelProfile(
+        "deep",
+        "Careful review and multi-step reasoning.",
+        deep,
+    ),
+)
+```
+
+workflow 可在单次子 Agent 调用中选择 profile：
+
+```python
+draft = await agent(
+    "Write a short draft.",
+    instruction="Draft quickly.",
+    model="fast",
+)
+review = await agent(
+    {"draft": draft["text"]},
+    instruction="Review carefully.",
+    model="deep",
+)
+```
+
+profile 是白名单。每个 `model.Model` 实例由宿主持有；workflow 代码不能传入
+提供商模型标识符，也不能自行构造模型。省略 `model` 会完整保留模板模型。只有
+在有明确任务原因时才应选择覆盖。选中的 profile 对 `LLMAgent` 模板，以及会遵守
+invocation surface patch 的自定义 Agent 生效；其他 Agent 仍使用各自已配置的模型。
 
 默认不传 `instance_id` 时，每次 `agent(...)` 调用都会创建独立的子 Agent
 历史，适合并发分支。对于 `LLMAgent` 模板，如果临时角色不应继承根分支对话，
@@ -169,8 +216,9 @@ review = await agent(
 复用的历史包含子 Agent 的输入和产生的事件。动态 `instruction` 只配置当前这次
 调用，不会作为对话消息持久化；后续调用必须记住的事实应放在 `input` 中。
 
-这些选项只影响当前这次子 Agent 调用。workflow 不能借它改变模型、权限策略，
-也不能新增基础 Agent 本来没有的宿主能力。
+这些选项只影响当前这次子 Agent 调用。workflow 不能借它改变权限策略、发明模型
+接入点，也不能新增基础 Agent 本来没有的宿主能力。模型选择仅限于宿主通过
+`WithAgentModelProfile` 注册的别名。
 
 `agent(...)` 返回的 envelope 包含 `text`、可选的 `structured` 结果和执行元数据。
 下游需要普通文本时应传 `result["text"]`，需要稳定字段时传

--- a/examples/dynamicworkflow/modelrouting/README.md
+++ b/examples/dynamicworkflow/modelrouting/README.md
@@ -1,0 +1,204 @@
+# Dynamic Workflow Model Routing Example
+
+This example shows host-authorized child-Agent model profiles for Dynamic
+Workflow. The application registers one neutral `general_agent` template and
+two profile aliases. Workflow code may select an alias per `agent(...)` call,
+or omit `model` to keep the template default.
+
+```text
+workflow_assistant
+└── run_workflow
+    └── registered base agent: general_agent
+        ├── template default model: -model
+        ├── model profile "fast": -fast-model (or -model when empty)
+        └── model profile "deep": -deep-model (or -model when empty)
+```
+
+## Host-owned profile aliases
+
+A profile name such as `fast` or `deep` is a host-owned workflow alias, not a
+provider model identifier. `WithAgentModelProfile` is an allowlist: the host
+maps each alias to a concrete `model.Model` instance, and unknown aliases fail
+before the child Agent runs. Workflow code cannot invent endpoints, API keys,
+or provider model strings; it may only pass registered aliases.
+
+This example builds every model through the same OpenAI-compatible environment
+(`OPENAI_API_KEY`, optional `OPENAI_BASE_URL`). That is an example convenience,
+not a framework limit: other applications may register profile models from
+different providers or endpoints.
+
+## Per-call override
+
+Selecting `model="fast"` or `model="deep"` overrides the model for that child
+call only. It does not mutate the registered template. Omitting `model`
+preserves the template model exactly, which this example demonstrates with a
+final summary role that leaves the field unset.
+
+The root prompt stays lean: answer simple tasks directly, call `run_workflow`
+for temporary collaboration, and apply a compact host routing policy
+(`fast` / `deep` / omit). The tool declaration still carries the profile
+catalog. Primary sample prompts state semantic needs only; they do not name
+aliases. This example focuses on per-child model selection with a short
+sequential workflow, not on concurrency primitives. Structured review with
+`schema` depends on provider JSON Schema support; when that is unavailable,
+use a plain-text review child as the portable fallback.
+
+## Event stream and observability
+
+Child Agent events remain in the same Runner stream as the parent. Event
+authors are template Agent names such as `general_agent`, optionally annotated
+with `via dynamic_workflow`. They are not profile aliases.
+
+Profile selection is visible in the generated workflow source and in the
+`run_workflow` tool-call arguments (`model="fast"`, `model="deep"`, or
+omitted). When the provider returns a response model field, the event printer
+emits one `provider model: <name>` notice per invocation
+(`InvocationID`, with a safe fallback key). That field is the provider-reported
+response model value, which may be generic; it is not the workflow alias. The
+startup mapping remains the host-side source of truth for alias configuration.
+
+## Prerequisites
+
+- Go 1.24.4 or later
+- Python 3 available as `python3` (the demo uses `dynamicworkflow.LocalRunner`)
+- An OpenAI-compatible model endpoint
+
+```bash
+export OPENAI_API_KEY="<your-api-key>"
+# Optional for a compatible endpoint:
+export OPENAI_BASE_URL="https://your-endpoint/v1"
+```
+
+## Run
+
+From the `examples` module:
+
+```bash
+cd examples
+go run ./dynamicworkflow/modelrouting -model gpt-5
+```
+
+With no `-prompt`, the example starts an interactive chat loop. Commands:
+
+- `/new`: start a fresh session
+- `/exit`: quit the demo
+
+Startup output prints the root model, the template default model, and the
+alias-to-concrete-model mapping.
+
+### One-model fallback
+
+When `-fast-model` and `-deep-model` are empty, both profiles resolve to
+`-model`. The alias allowlist and per-call selection still apply; only the
+concrete model names coincide:
+
+```bash
+go run ./dynamicworkflow/modelrouting -model gpt-5 \
+  -prompt 'Compare sharded LRU and W-TinyLFU for a Go local cache. Use run_workflow once: run two independent quick analyses in sequence, then a rigorous structured review, then a balanced concise summary.'
+```
+
+### Multi-model use
+
+Pass distinct provider model names for the two profiles:
+
+```bash
+go run ./dynamicworkflow/modelrouting \
+  -model gpt-5 \
+  -fast-model gpt-5-mini \
+  -deep-model gpt-5 \
+  -prompt 'Compare sharded LRU and W-TinyLFU for a Go local cache. Use run_workflow once: run two independent quick analyses in sequence, then a rigorous structured review, then a balanced concise summary.'
+```
+
+### Other sample prompts
+
+Simple direct answer (no workflow required):
+
+```bash
+go run ./dynamicworkflow/modelrouting -model gpt-5 \
+  -prompt 'In one sentence, what is the difference between a mutex and a channel for mutual exclusion in Go?'
+```
+
+Bounded draft, review, and revision loop:
+
+```bash
+go run ./dynamicworkflow/modelrouting \
+  -model gpt-5 \
+  -fast-model gpt-5-mini \
+  -deep-model gpt-5 \
+  -prompt 'Draft a short Go local-cache API proposal with an efficient drafter, have a rigorous reviewer return structured approval and issues, revise for at most two review rounds, and finish with a balanced concise summary.'
+```
+
+Optional explicit routing check (deterministic troubleshooting, not the main
+experience):
+
+```bash
+go run ./dynamicworkflow/modelrouting \
+  -model gpt-5 \
+  -fast-model gpt-5-mini \
+  -deep-model gpt-5 \
+  -prompt 'Use run_workflow once: analyze sharded LRU with model="fast", analyze W-TinyLFU with model="fast", then model="deep" for a structured review, and omit model for a concise summary.'
+```
+
+`-show-workflow-code` defaults to `true` so the generated Python, including
+profile selections, is easy to inspect. Pass `-show-workflow-code=false` to
+suppress that separate print; tool-call arguments still include the code.
+
+## Expected workflow shape
+
+Exact roles and schemas are model-generated. After the root model chooses
+profiles from the host catalog, a comparison workflow may look like this:
+
+```python
+lru = await agent(
+    "Analyze sharded LRU for a Go local cache.",
+    instruction="Act as an independent analyst. Cover hit-rate behavior, concurrency, and operational tradeoffs.",
+    model="fast",
+    tools=[],
+)
+
+tinylfu = await agent(
+    "Analyze W-TinyLFU for a Go local cache.",
+    instruction="Act as an independent analyst. Cover hit-rate behavior, concurrency, and operational tradeoffs.",
+    model="fast",
+    tools=[],
+)
+
+comparison = await agent(
+    {"lru": lru["text"], "tinylfu": tinylfu["text"]},
+    instruction="Synthesize the analyses into a structured comparison and recommendation.",
+    model="deep",
+    schema={
+        "type": "object",
+        "properties": {
+            "recommendation": {"type": "string"},
+            "tradeoffs": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["recommendation", "tradeoffs"],
+    },
+    tools=[],
+)
+
+summary = await agent(
+    {"comparison": comparison["structured"]},
+    instruction="Write a concise executive summary for engineering leads.",
+    tools=[],
+)
+
+return {
+    "lru": lru["text"],
+    "tinylfu": tinylfu["text"],
+    "comparison": comparison["structured"],
+    "summary": summary["text"],
+}
+```
+
+The final summary omits `model`, so it uses the template default. Profile
+selection never changes the template registration itself.
+
+## Runtime notes
+
+`LocalRunner` starts a local Python process and is not a security sandbox. This
+example registers no child tools and no code-callable tools; the focus is model
+profile selection only. In production, provide a `dynamicworkflow.Runtime`
+suited to your trust boundary and register only the model profiles your host is
+willing to expose.

--- a/examples/dynamicworkflow/modelrouting/main.go
+++ b/examples/dynamicworkflow/modelrouting/main.go
@@ -1,0 +1,422 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates host-authorized Dynamic Workflow child-Agent
+// model profiles. One neutral template may select registered aliases per
+// call, or omit model to keep the template default.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/dynamicworkflow"
+)
+
+var (
+	modelName = flag.String(
+		"model",
+		"gpt-5",
+		"Model name for the root Agent and the template default",
+	)
+	fastModelName = flag.String(
+		"fast-model",
+		"",
+		"Provider model name for the fast profile; empty uses -model",
+	)
+	deepModelName = flag.String(
+		"deep-model",
+		"",
+		"Provider model name for the deep profile; empty uses -model",
+	)
+	prompt = flag.String(
+		"prompt",
+		"",
+		"Optional single-turn prompt. If empty, start interactive chat.",
+	)
+	showWorkflowCode = flag.Bool(
+		"show-workflow-code",
+		true,
+		"Print the generated Python workflow code before executing it",
+	)
+)
+
+func main() {
+	flag.Parse()
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		fmt.Fprintln(os.Stderr, "OPENAI_API_KEY is required (OPENAI_BASE_URL is optional).")
+		os.Exit(2)
+	}
+
+	fastName := resolveModelName(*fastModelName, *modelName)
+	deepName := resolveModelName(*deepModelName, *modelName)
+
+	rootModel := openai.New(*modelName)
+	templateModel := openai.New(*modelName)
+	fastModel := openai.New(fastName)
+	deepModel := openai.New(deepName)
+
+	ctx := context.Background()
+	workflowTool, err := buildWorkflowTool(templateModel, fastModel, deepModel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build workflow tool: %v\n", err)
+		os.Exit(1)
+	}
+	if *showWorkflowCode {
+		workflowTool = workflowCodePrintingTool{inner: workflowTool}
+	}
+
+	root := llmagent.New(
+		"workflow_assistant",
+		llmagent.WithModel(rootModel),
+		llmagent.WithDescription("Creates temporary collaboration workflows and may select host-authorized child-Agent model profiles."),
+		llmagent.WithInstruction(`Answer simple requests directly. For tasks that need temporary collaboration, independent analysis, structured review, or revision loops, call run_workflow exactly once and do not answer with Python source. This example registers one neutral general_agent template, so template is usually omitted. Every agent(...) call should provide a concrete instruction and tools=[]. Host model routing: use model="fast" for independent low-latency analysis, extraction, and first drafts; use model="deep" for synthesis, strict review, and final decisions; omit model for a balanced ordinary summary that should use the template default. Prefer a short sequential chain of agent(...) calls. Use schema for values that control later branches or loops.`),
+		llmagent.WithTools([]tool.Tool{workflowTool}),
+	)
+	r := runner.NewRunner("dynamic-workflow-modelrouting-example", root)
+	defer r.Close()
+
+	chat := &dynamicWorkflowChat{
+		runner:           r,
+		userID:           "demo-user",
+		sessionID:        newSessionID(),
+		rootModel:        *modelName,
+		templateModel:    *modelName,
+		fastProfileModel: fastName,
+		deepProfileModel: deepName,
+	}
+	if strings.TrimSpace(*prompt) != "" {
+		chat.printStartup()
+		if err := chat.processMessage(ctx, *prompt); err != nil {
+			fmt.Fprintf(os.Stderr, "run agent: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	chat.printBanner()
+	if err := chat.startChat(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "interactive chat failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func resolveModelName(override, fallback string) string {
+	if strings.TrimSpace(override) == "" {
+		return fallback
+	}
+	return strings.TrimSpace(override)
+}
+
+type dynamicWorkflowChat struct {
+	runner           runner.Runner
+	userID           string
+	sessionID        string
+	rootModel        string
+	templateModel    string
+	fastProfileModel string
+	deepProfileModel string
+}
+
+func newSessionID() string {
+	return "dynamic-workflow-" + uuid.NewString()
+}
+
+func (c *dynamicWorkflowChat) printStartup() {
+	fmt.Printf("Root model: %s\n", c.rootModel)
+	fmt.Printf("Template default model: %s\n", c.templateModel)
+	fmt.Printf("Model profiles:\n")
+	fmt.Printf("  fast -> %s\n", c.fastProfileModel)
+	fmt.Printf("  deep -> %s\n", c.deepProfileModel)
+}
+
+func (c *dynamicWorkflowChat) printBanner() {
+	fmt.Printf("Dynamic Workflow Model Routing Example\n")
+	c.printStartup()
+	fmt.Printf("Session: %s\n", c.sessionID)
+	fmt.Println("Type '/new' to start a new session or '/exit' to quit.")
+	fmt.Println("Sample prompts:")
+	fmt.Println("  In one sentence, what is the difference between a mutex and a channel for mutual exclusion in Go?")
+	fmt.Println("  Compare sharded LRU and W-TinyLFU for a Go local cache. Use run_workflow once: run two independent quick analyses in sequence, then a rigorous structured review, then a balanced concise summary.")
+	fmt.Println("  Draft a short Go local-cache API proposal with an efficient drafter, have a rigorous reviewer return structured approval and issues, revise for at most two review rounds, and finish with a balanced concise summary.")
+	fmt.Println("  Optional explicit routing check (troubleshooting): Use run_workflow once: analyze each cache option with model=\"fast\", then model=\"deep\" for a structured review, then omit model for the summary.")
+	fmt.Println(strings.Repeat("=", 72))
+}
+
+func (c *dynamicWorkflowChat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+		switch strings.ToLower(userInput) {
+		case "/exit":
+			fmt.Println("Goodbye.")
+			return nil
+		case "/new":
+			c.sessionID = newSessionID()
+			fmt.Printf("Started new session: %s\n\n", c.sessionID)
+			continue
+		}
+		if err := c.processMessage(ctx, userInput); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *dynamicWorkflowChat) processMessage(
+	ctx context.Context,
+	userMessage string,
+) error {
+	events, err := c.runner.Run(
+		ctx,
+		c.userID,
+		c.sessionID,
+		model.NewUserMessage(userMessage),
+	)
+	if err != nil {
+		return fmt.Errorf("run agent: %w", err)
+	}
+	printEvents(events)
+	return nil
+}
+
+func buildWorkflowTool(
+	templateModel, fastModel, deepModel model.Model,
+) (tool.CallableTool, error) {
+	generalAgent := llmagent.New(
+		"general_agent",
+		llmagent.WithModel(templateModel),
+		llmagent.WithDescription("A neutral execution template for one workflow-local role defined by its dynamic instruction."),
+		llmagent.WithInstruction(`Follow the dynamic instance instruction as the complete definition of your current role. Treat the input as JSON context. Do not assume a business domain from this template. Unless structured output is requested, return the requested content directly instead of wrapping it in a JSON object. When a structured output contract is requested, return data that conforms to it.`),
+		llmagent.WithMessageFilterMode(llmagent.IsolatedRequest),
+	)
+
+	return dynamicworkflow.NewTool(
+		dynamicworkflow.LocalRunner{},
+		[]agent.Agent{generalAgent},
+		dynamicworkflow.WithAgentModelProfile(
+			"fast",
+			"Low-latency model for independent analysis, extraction, and first drafts.",
+			fastModel,
+		),
+		dynamicworkflow.WithAgentModelProfile(
+			"deep",
+			"Higher-capability model for synthesis, strict review, and final decisions.",
+			deepModel,
+		),
+	)
+}
+
+type workflowCodePrintingTool struct {
+	inner tool.CallableTool
+}
+
+func (t workflowCodePrintingTool) Declaration() *tool.Declaration {
+	return t.inner.Declaration()
+}
+
+func (t workflowCodePrintingTool) Call(
+	ctx context.Context,
+	raw []byte,
+) (any, error) {
+	t.printWorkflowCode(raw)
+	return t.inner.Call(ctx, raw)
+}
+
+func (t workflowCodePrintingTool) StreamableCall(
+	ctx context.Context,
+	raw []byte,
+) (*tool.StreamReader, error) {
+	t.printWorkflowCode(raw)
+	streamable, ok := t.inner.(tool.StreamableTool)
+	if !ok {
+		return nil, fmt.Errorf(
+			"workflow code printer: inner tool is not streamable",
+		)
+	}
+	return streamable.StreamableCall(ctx, raw)
+}
+
+func (t workflowCodePrintingTool) TRPCAgentGoStructuredStreamErrorsOptIn() bool {
+	structured, ok := t.inner.(interface {
+		TRPCAgentGoStructuredStreamErrorsOptIn() bool
+	})
+	return ok && structured.TRPCAgentGoStructuredStreamErrorsOptIn()
+}
+
+func (t workflowCodePrintingTool) printWorkflowCode(raw []byte) {
+	var input struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &input); err == nil &&
+		strings.TrimSpace(input.Code) != "" {
+		fmt.Fprintln(os.Stderr, "\n===== generated dynamic workflow code =====")
+		fmt.Fprintln(os.Stderr, input.Code)
+		fmt.Fprintln(os.Stderr, "===== end generated dynamic workflow code =====")
+		fmt.Fprintln(os.Stderr)
+	}
+}
+
+func printEvents(events <-chan *event.Event) {
+	eventCount := 0
+	seenModels := make(map[string]string)
+	for evt := range events {
+		if evt == nil {
+			continue
+		}
+		eventCount++
+		maybePrintResponseModel(evt, seenModels)
+		if evt.Response != nil && evt.Response.Error != nil {
+			fmt.Fprintf(os.Stderr, "[%s] error: %s\n", evt.Author, evt.Response.Error.Message)
+			continue
+		}
+		if printToolEvent(evt) {
+			continue
+		}
+		if evt.StructuredOutput != nil {
+			if raw, err := json.Marshal(evt.StructuredOutput); err == nil {
+				fmt.Printf("[%s] structured: %s\n", eventLabel(evt), raw)
+			}
+		}
+		if evt.Response == nil {
+			continue
+		}
+		if len(evt.Response.Choices) == 0 {
+			continue
+		}
+		choice := evt.Response.Choices[0]
+		content := choice.Delta.Content
+		if content == "" {
+			content = choice.Message.Content
+		}
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		fmt.Printf("[%s] %s\n", eventLabel(evt), content)
+	}
+	if eventCount == 0 {
+		fmt.Fprintln(os.Stderr, "no events were emitted")
+	}
+}
+
+// maybePrintResponseModel emits one provider-model notice per child/root
+// invocation when Response.Model first becomes non-empty. This is the
+// provider-reported response value, not the workflow profile alias; event
+// authors remain template Agent names.
+func maybePrintResponseModel(evt *event.Event, seen map[string]string) {
+	if evt == nil || evt.Response == nil || seen == nil {
+		return
+	}
+	name := strings.TrimSpace(evt.Response.Model)
+	if name == "" {
+		return
+	}
+	key := strings.TrimSpace(evt.InvocationID)
+	if key == "" {
+		// Fallback when InvocationID is absent: author path plus provider model.
+		key = eventLabel(evt) + "|" + name
+	}
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = name
+	fmt.Printf("[%s] provider model: %s\n", eventLabel(evt), name)
+}
+
+func printToolEvent(evt *event.Event) bool {
+	if evt == nil || evt.Response == nil {
+		return false
+	}
+	if evt.Response.IsToolCallResponse() {
+		printToolCalls(evt)
+		return true
+	}
+	if evt.Response.IsToolResultResponse() {
+		printToolResults(evt)
+		return true
+	}
+	return false
+}
+
+func printToolCalls(evt *event.Event) {
+	for _, choice := range evt.Response.Choices {
+		for _, call := range append(choice.Message.ToolCalls, choice.Delta.ToolCalls...) {
+			fmt.Printf("[%s] tool call: %s", eventLabel(evt), call.Function.Name)
+			if call.ID != "" {
+				fmt.Printf(" (id: %s)", call.ID)
+			}
+			if len(call.Function.Arguments) > 0 {
+				fmt.Printf(" args: %s", string(call.Function.Arguments))
+			}
+			fmt.Println()
+		}
+	}
+}
+
+func printToolResults(evt *event.Event) {
+	for _, choice := range evt.Response.Choices {
+		msg := choice.Message
+		if msg.ToolID == "" && choice.Delta.ToolID != "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID == "" {
+			continue
+		}
+		name := msg.ToolName
+		if name == "" {
+			name = "tool"
+		}
+		content := strings.TrimSpace(msg.Content)
+		if len(content) > 240 {
+			runes := []rune(content)
+			if len(runes) > 240 {
+				content = string(runes[:240]) + "..."
+			}
+		}
+		fmt.Printf("[%s] tool result: %s (id: %s) %s\n", eventLabel(evt), name, msg.ToolID, content)
+	}
+}
+
+func eventLabel(evt *event.Event) string {
+	if evt == nil {
+		return "unknown"
+	}
+	label := evt.Author
+	if label == "" {
+		label = "unknown"
+	}
+	if evt.ParentMetadata != nil && evt.ParentMetadata.TriggerType != "" {
+		label += " via " + evt.ParentMetadata.TriggerType
+	}
+	return label
+}

--- a/tool/dynamicworkflow/agent_spec.go
+++ b/tool/dynamicworkflow/agent_spec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/uuid"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/transfer"
@@ -194,7 +195,7 @@ func decodeAgentOptions(raw json.RawMessage) (AgentSpec, error) {
 
 func isSupportedAgentOption(name string) bool {
 	switch name {
-	case "template", "instance_id", "instruction", "tools", "skills", "structured_output", "schema":
+	case "template", "instance_id", "instruction", "model", "tools", "skills", "structured_output", "schema":
 		return true
 	default:
 		return false
@@ -290,13 +291,18 @@ func normalizeAgentSpec(spec *AgentSpec) error {
 	}
 	spec.InstanceID = cleanPathSegment(spec.InstanceID)
 	spec.Instruction = strings.TrimSpace(spec.Instruction)
+	spec.Model = strings.TrimSpace(spec.Model)
 	spec.Tools = normalizeSelection(spec.Tools)
 	spec.Skills = normalizeSelection(spec.Skills)
 	return normalizeStructuredOutputSpec(spec.Template, spec.StructuredOutput)
 }
 
 func agentSpecHasOverrides(spec AgentSpec) bool {
-	return spec.Instruction != "" || spec.Tools != nil || spec.Skills != nil || spec.StructuredOutput != nil
+	return spec.Instruction != "" ||
+		spec.Model != "" ||
+		spec.Tools != nil ||
+		spec.Skills != nil ||
+		spec.StructuredOutput != nil
 }
 
 func normalizeStructuredOutputSpec(template string, spec *StructuredOutputSpec) error {
@@ -507,6 +513,13 @@ func (g *workflowGateway) workflowChildPatch(
 	if spec.Instruction != "" {
 		patch.SetInstruction(spec.Instruction)
 	}
+	selectedModel, err := g.resolveAgentModelProfile(spec.Model)
+	if err != nil {
+		return patch, err
+	}
+	if selectedModel != nil {
+		patch.SetModel(selectedModel)
+	}
 	if spec.Skills != nil {
 		repo, err := g.selectAgentSkills(ctx, tmpl, spec.Skills)
 		if err != nil {
@@ -515,6 +528,32 @@ func (g *workflowGateway) workflowChildPatch(
 		patch.SetSkillRepository(repo)
 	}
 	return patch, nil
+}
+
+func (g *workflowGateway) resolveAgentModelProfile(alias string) (model.Model, error) {
+	if alias == "" {
+		return nil, nil
+	}
+	for _, profile := range g.modelProfiles {
+		if profile.name == alias {
+			return profile.model, nil
+		}
+	}
+	available := make([]string, 0, len(g.modelProfiles))
+	for _, profile := range g.modelProfiles {
+		available = append(available, profile.name)
+	}
+	if len(available) == 0 {
+		return nil, fmt.Errorf(
+			"dynamicworkflow: unknown agent model profile %q; available: (none)",
+			alias,
+		)
+	}
+	return nil, fmt.Errorf(
+		"dynamicworkflow: unknown agent model profile %q; available: %s",
+		alias,
+		strings.Join(available, ", "),
+	)
 }
 
 func (g *workflowGateway) selectAgentTools(

--- a/tool/dynamicworkflow/model_profile_test.go
+++ b/tool/dynamicworkflow/model_profile_test.go
@@ -1,0 +1,483 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package dynamicworkflow
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/appender"
+	"trpc.group/trpc-go/trpc-agent-go/internal/surfacepatch"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func TestAgentModelProfilesZeroProfilesPreservesPriorContract(t *testing.T) {
+	templateModel := &recordingModel{name: "template", content: "from-template"}
+	reviewer := llmagent.New("reviewer", llmagent.WithModel(templateModel))
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"review it"}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{reviewer})
+	require.NoError(t, err)
+
+	decl := workflow.Declaration()
+	require.NotContains(t, decl.Description, "Host-authorized agent model profiles")
+	require.NotContains(t, decl.Description, "model profile")
+	codeDescription := decl.InputSchema.Properties["code"].Description
+	require.NotContains(t, codeDescription, "model,")
+	require.NotContains(t, codeDescription, agentModelProfileGuidance)
+	require.Contains(t, decl.Description, "Registered templates fix model")
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), templateModel.callCount())
+}
+
+func TestAgentModelProfileSelectionInvokesProfileModel(t *testing.T) {
+	templateModel := &recordingModel{name: "template", content: "from-template"}
+	fastModel := &recordingModel{name: "fast", content: "from-fast"}
+	reviewer := llmagent.New("reviewer", llmagent.WithModel(templateModel))
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer", "model": "fast"},
+				"input": "review it"
+			}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{reviewer}, WithAgentModelProfile(
+		"fast",
+		"Low-latency drafting.",
+		fastModel,
+	))
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.JSONEq(t, `{"text":"from-fast","session_id":"session-1","history_key":"root/dynamic_workflow/<workflow>/agent-1","invocation_id":"<invocation-id>"}`, normalizeSingleAgentResult(t, result.Value))
+	require.Equal(t, int32(0), templateModel.callCount())
+	require.Equal(t, int32(1), fastModel.callCount())
+}
+
+func TestAgentModelProfileOverridesTemplateWithModelsForOneCall(t *testing.T) {
+	templateDefault := &recordingModel{name: "template-default", content: "from-default"}
+	templateAlternate := &recordingModel{name: "template-alternate", content: "from-alternate"}
+	profileModel := &recordingModel{name: "profile", content: "from-profile"}
+	reviewer := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(templateDefault),
+		llmagent.WithModels(map[string]model.Model{
+			"default":   templateDefault,
+			"alternate": templateAlternate,
+		}),
+	)
+	require.NoError(t, reviewer.SetModelByName("alternate"))
+
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		profileRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-profile", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer", "model": "fast"},
+				"input": "profile path"
+			}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		defaultRaw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-default", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer"},
+				"input": "template path"
+			}`),
+		})
+		if err != nil {
+			return Result{}, err
+		}
+		combined, err := json.Marshal(map[string]json.RawMessage{
+			"profile": profileRaw,
+			"default": defaultRaw,
+		})
+		return Result{Value: combined}, err
+	}}, []agent.Agent{reviewer}, WithAgentModelProfile(
+		"fast",
+		"Low-latency drafting.",
+		profileModel,
+	))
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(
+		agent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"code":"return None"}`),
+	)
+	require.NoError(t, err)
+	result := value.(Result)
+	require.Contains(t, string(result.Value), `"text":"from-profile"`)
+	require.Contains(t, string(result.Value), `"text":"from-alternate"`)
+	require.Equal(t, int32(0), templateDefault.callCount())
+	require.Equal(t, int32(1), templateAlternate.callCount())
+	require.Equal(t, int32(1), profileModel.callCount())
+}
+
+func TestAgentModelProfilesConcurrentCallsDoNotCrossContaminate(t *testing.T) {
+	templateModel := &recordingModel{name: "template", content: "from-template"}
+	fastModel := &recordingModel{name: "fast", content: "from-fast"}
+	deepModel := &recordingModel{name: "deep", content: "from-deep"}
+	reviewer := llmagent.New("reviewer", llmagent.WithModel(templateModel))
+
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		var wg sync.WaitGroup
+		var fastRaw, deepRaw json.RawMessage
+		var fastErr, deepErr error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			fastRaw, fastErr = handler.HandleWorkflowCall(ctx, Call{
+				ID: "agent-fast", Kind: CallKindAgent,
+				Args: json.RawMessage(`{
+					"options": {"template": "reviewer", "model": "fast", "instruction": "Draft."},
+					"input": "fast path"
+				}`),
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			deepRaw, deepErr = handler.HandleWorkflowCall(ctx, Call{
+				ID: "agent-deep", Kind: CallKindAgent,
+				Args: json.RawMessage(`{
+					"options": {"template": "reviewer", "model": "deep", "instruction": "Review."},
+					"input": "deep path"
+				}`),
+			})
+		}()
+		wg.Wait()
+		if fastErr != nil {
+			return Result{}, fastErr
+		}
+		if deepErr != nil {
+			return Result{}, deepErr
+		}
+		combined, err := json.Marshal(map[string]json.RawMessage{
+			"fast": fastRaw,
+			"deep": deepRaw,
+		})
+		return Result{Value: combined}, err
+	}}, []agent.Agent{reviewer},
+		WithAgentModelProfile("fast", "Fast path.", fastModel),
+		WithAgentModelProfile("deep", "Deep path.", deepModel),
+	)
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result.Value, &got))
+	require.Contains(t, string(got["fast"]), `"text":"from-fast"`)
+	require.Contains(t, string(got["deep"]), `"text":"from-deep"`)
+	require.Equal(t, int32(0), templateModel.callCount())
+	require.Equal(t, int32(1), fastModel.callCount())
+	require.Equal(t, int32(1), deepModel.callCount())
+
+	// A later omitted-model call must still use the unchanged template model.
+	followUp, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-default", Kind: CallKindAgent,
+			Args: json.RawMessage(`{"input":"default path"}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{reviewer},
+		WithAgentModelProfile("fast", "Fast path.", fastModel),
+		WithAgentModelProfile("deep", "Deep path.", deepModel),
+	)
+	require.NoError(t, err)
+	_, err = followUp.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), templateModel.callCount())
+}
+
+func TestAgentModelProfileUnknownFailsBeforeChildExecution(t *testing.T) {
+	var ran atomic.Bool
+	reviewer := &testAgent{
+		name: "reviewer",
+		runFn: func(context.Context, *agent.Invocation) (<-chan *event.Event, error) {
+			ran.Store(true)
+			ch := make(chan *event.Event)
+			close(ch)
+			return ch, nil
+		},
+	}
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		_, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {"template": "reviewer", "model": "missing"},
+				"input": "review it"
+			}`),
+		})
+		return Result{}, err
+	}}, []agent.Agent{reviewer},
+		WithAgentModelProfile("fast", "Fast path.", &recordingModel{name: "fast"}),
+		WithAgentModelProfile("deep", "Deep path.", &recordingModel{name: "deep"}),
+	)
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	_, err = workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.ErrorContains(t, err, `unknown agent model profile "missing"`)
+	require.ErrorContains(t, err, "available: fast, deep")
+	require.False(t, ran.Load())
+}
+
+func TestAgentModelProfileRegistrationValidation(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer"}
+	valid := &recordingModel{name: "fast"}
+
+	_, err := NewTool(scriptedRuntime{}, []agent.Agent{reviewer}, WithAgentModelProfile(" ", "desc", valid))
+	require.ErrorContains(t, err, "agent model profile name is required")
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{reviewer}, WithAgentModelProfile("fast", " ", valid))
+	require.ErrorContains(t, err, `agent model profile "fast" description is required`)
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{reviewer}, WithAgentModelProfile("fast", "desc", nil))
+	require.ErrorContains(t, err, `agent model profile "fast" model is required`)
+
+	_, err = NewTool(scriptedRuntime{}, []agent.Agent{reviewer},
+		WithAgentModelProfile("fast", "one", valid),
+		WithAgentModelProfile(" fast ", "two", &recordingModel{name: "other"}),
+	)
+	require.ErrorContains(t, err, `duplicate agent model profile "fast"`)
+}
+
+func TestAgentModelProfileComposesWithInstructionToolsAndStructuredOutput(t *testing.T) {
+	templateModel := &recordingModel{name: "template", content: `{"approved":false}`}
+	fastModel := &structuredOutputCaptureModel{content: `{"approved":true}`}
+	lookup := &testTool{name: "lookup"}
+	unused := &testTool{name: "unused"}
+	reviewer := llmagent.New(
+		"reviewer",
+		llmagent.WithModel(templateModel),
+		llmagent.WithTools([]tool.Tool{lookup, unused}),
+	)
+
+	workflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-1", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {
+					"template": "reviewer",
+					"model": "fast",
+					"instruction": "Be strict.",
+					"tools": ["lookup"],
+					"structured_output": {
+						"type": "object",
+						"required": ["approved"],
+						"properties": {"approved": {"type": "boolean"}}
+					}
+				},
+				"input": "review it"
+			}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{reviewer}, WithAgentModelProfile("fast", "Fast path.", fastModel))
+	require.NoError(t, err)
+
+	parent := agent.NewInvocation(
+		agent.WithInvocationAgent(&testAgent{name: "root"}),
+		agent.WithInvocationSession(&session.Session{ID: "session-1", AppName: "app", UserID: "user"}),
+	)
+	appender.Attach(parent, func(context.Context, *event.Event) error { return nil })
+
+	value, err := workflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+	result := value.(Result)
+	require.Contains(t, string(result.Value), `"structured":{"approved":true}`)
+	require.Equal(t, int32(0), templateModel.callCount())
+
+	structuredOutput := fastModel.latestStructuredOutput()
+	require.NotNil(t, structuredOutput)
+	require.NotNil(t, structuredOutput.JSONSchema)
+	require.Equal(t, "reviewer_output", structuredOutput.JSONSchema.Name)
+
+	capture := &testAgent{
+		name:  "reviewer",
+		tools: []tool.Tool{lookup, unused},
+		skills: &testSkillRepo{summaries: []skill.Summary{
+			{Name: "risk"},
+			{Name: "style"},
+		}},
+		response: "ok",
+	}
+	captureWorkflow, err := NewTool(scriptedRuntime{run: func(ctx context.Context, handler CallHandler) (Result, error) {
+		raw, err := handler.HandleWorkflowCall(ctx, Call{
+			ID: "agent-2", Kind: CallKindAgent,
+			Args: json.RawMessage(`{
+				"options": {
+					"template": "reviewer",
+					"model": "fast",
+					"instruction": "Be strict.",
+					"tools": ["lookup"],
+					"skills": ["risk"]
+				},
+				"input": "review it"
+			}`),
+		})
+		return Result{Value: raw}, err
+	}}, []agent.Agent{capture}, WithAgentModelProfile("fast", "Fast path.", fastModel))
+	require.NoError(t, err)
+	_, err = captureWorkflow.Call(agent.NewInvocationContext(context.Background(), parent), []byte(`{"code":"return None"}`))
+	require.NoError(t, err)
+
+	child := capture.lastInvocation()
+	require.NotNil(t, child)
+	rootNode := agent.InvocationSurfaceRootNodeID(child)
+	patch, ok := surfacepatch.PatchForNode(child.RunOptions.CustomAgentConfigs, rootNode)
+	require.True(t, ok)
+	instruction, ok := patch.Instruction()
+	require.True(t, ok)
+	require.Equal(t, "Be strict.", instruction)
+	selectedModel, ok := patch.Model()
+	require.True(t, ok)
+	require.Equal(t, fastModel, selectedModel)
+	selectedTools, ok := patch.Tools()
+	require.True(t, ok)
+	require.Equal(t, []string{"lookup"}, toolNames(selectedTools))
+	selectedSkills, ok := patch.SkillRepository()
+	require.True(t, ok)
+	require.Equal(t, []string{"risk"}, skillNames(skill.SummariesForContext(context.Background(), selectedSkills)))
+}
+
+func TestAgentModelProfileDeclarationListsAliasesOnceInOrder(t *testing.T) {
+	reviewer := &testAgent{name: "reviewer"}
+	workflow, err := NewTool(scriptedRuntime{}, []agent.Agent{reviewer},
+		WithAgentModelProfile("fast", "Fast drafting.", &recordingModel{name: "fast"}),
+		WithAgentModelProfile("deep", "Deep review.", &recordingModel{name: "deep"}),
+	)
+	require.NoError(t, err)
+
+	decl := workflow.Declaration()
+	require.Contains(t, decl.Description, "Registered templates fix the default model")
+	require.Equal(t, 1, strings.Count(decl.Description, "Host-authorized agent model profiles:"))
+	require.Equal(t, 1, strings.Count(decl.Description, `- model "fast": Fast drafting.`))
+	require.Equal(t, 1, strings.Count(decl.Description, `- model "deep": Deep review.`))
+	require.NotContains(t, decl.Description, agentModelProfileGuidance)
+	fastIdx := strings.Index(decl.Description, `- model "fast":`)
+	deepIdx := strings.Index(decl.Description, `- model "deep":`)
+	require.Greater(t, deepIdx, fastIdx)
+
+	codeDescription := decl.InputSchema.Properties["code"].Description
+	require.Contains(
+		t,
+		codeDescription,
+		"template, instruction, model, instance_id, tools, skills, and structured_output",
+	)
+	require.Equal(t, 1, strings.Count(codeDescription, agentModelProfileGuidance))
+	require.NotContains(t, codeDescription, `- model "fast":`)
+	require.NotContains(t, codeDescription, `- model "deep":`)
+}
+
+func TestAgentModelProfileNormalizeAndHasOverrides(t *testing.T) {
+	spec, err := decodeAgentOptions(json.RawMessage(`{
+		"template": "reviewer",
+		"model": " fast "
+	}`))
+	require.NoError(t, err)
+	require.NoError(t, normalizeAgentSpec(&spec))
+	require.Equal(t, "fast", spec.Model)
+	require.True(t, agentSpecHasOverrides(spec))
+
+	spec = AgentSpec{Template: "reviewer", Model: " "}
+	require.NoError(t, normalizeAgentSpec(&spec))
+	require.Empty(t, spec.Model)
+	require.False(t, agentSpecHasOverrides(spec))
+}
+
+type recordingModel struct {
+	name    string
+	content string
+
+	calls atomic.Int32
+}
+
+func (m *recordingModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	m.calls.Add(1)
+	content := m.content
+	if content == "" {
+		content = m.name
+	}
+	responses := make(chan *model.Response, 1)
+	responses <- &model.Response{
+		ID:   "recording-" + m.name,
+		Done: true,
+		Choices: []model.Choice{{
+			Index:   0,
+			Message: model.NewAssistantMessage(content),
+		}},
+	}
+	close(responses)
+	return responses, nil
+}
+
+func (m *recordingModel) Info() model.Info {
+	return model.Info{Name: m.name}
+}
+
+func (m *recordingModel) callCount() int32 {
+	return m.calls.Load()
+}

--- a/tool/dynamicworkflow/runtime_test.go
+++ b/tool/dynamicworkflow/runtime_test.go
@@ -204,6 +204,57 @@ return await agent("review", unsupported_option=True)
 	require.ErrorContains(t, err, "unsupported agent option(s): unsupported_option")
 }
 
+func TestLocalRunnerRoutesKeywordAgentModelOption(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		require.JSONEq(t, `{
+			"input": "review it",
+			"options": {
+				"instruction": "Be strict.",
+				"model": "fast"
+			}
+		}`, string(call.Args))
+		return json.RawMessage(`{"text":"approved"}`), nil
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+return await agent("review it", instruction="Be strict.", model="fast")
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"text":"approved"}`, string(result.Value))
+}
+
+func TestLocalRunnerRoutesOptionsDictAgentModelOption(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		require.JSONEq(t, `{
+			"input": {"answer": 42},
+			"options": {
+				"template": "reviewer",
+				"model": "deep",
+				"instruction": "Review carefully."
+			}
+		}`, string(call.Args))
+		return json.RawMessage(`{"text":"approved"}`), nil
+	})
+
+	result, err := Execute(context.Background(), LocalRunner{}, handler, `
+return await agent({"answer": 42}, {
+    "template": "reviewer",
+    "model": "deep",
+    "instruction": "Review carefully.",
+})
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"text":"approved"}`, string(result.Value))
+}
+
 func TestLocalRunnerRunsConventionalWorkflowWrapper(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 is not installed")

--- a/tool/dynamicworkflow/sandbox_test.go
+++ b/tool/dynamicworkflow/sandbox_test.go
@@ -75,6 +75,32 @@ return {"review": review["text"]}
 	require.JSONEq(t, `{"review":"approved"}`, string(result.Value))
 }
 
+func TestSandboxRunnerRoutesAgentModelOption(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is not installed")
+	}
+	runner := NewSandboxRunner(
+		sandbox.WithPermissionProfile(sandbox.DangerFullAccessProfile()),
+	)
+	handler := callHandlerFunc(func(_ context.Context, call Call) (json.RawMessage, error) {
+		require.Equal(t, CallKindAgent, call.Kind)
+		require.JSONEq(t, `{
+			"input": "review it",
+			"options": {
+				"instruction": "Be strict.",
+				"model": "fast"
+			}
+		}`, string(call.Args))
+		return json.RawMessage(`{"text":"approved"}`), nil
+	})
+
+	result, err := Execute(context.Background(), runner, handler, `
+return await agent("review it", instruction="Be strict.", model="fast")
+`)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"text":"approved"}`, string(result.Value))
+}
+
 func TestSandboxRunnerUsesCleanEnvironment(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell wrapper is Unix-specific")

--- a/tool/dynamicworkflow/stdio.go
+++ b/tool/dynamicworkflow/stdio.go
@@ -727,7 +727,7 @@ async def call_tool(name, **kwargs):
     return await _call("tool", name, kwargs)
 
 _AGENT_OPTION_NAMES = {
-    "template", "instance_id", "instruction", "tools", "skills",
+    "template", "instance_id", "instruction", "model", "tools", "skills",
     "structured_output", "schema",
 }
 

--- a/tool/dynamicworkflow/tool.go
+++ b/tool/dynamicworkflow/tool.go
@@ -32,9 +32,16 @@ import (
 type Option func(*config)
 
 type config struct {
+	name          string
+	description   string
+	tools         []tool.CallableTool
+	modelProfiles []agentModelProfile
+}
+
+type agentModelProfile struct {
 	name        string
 	description string
-	tools       []tool.CallableTool
+	model       model.Model
 }
 
 const defaultMaxConcurrentAgents = 8
@@ -45,6 +52,29 @@ const defaultMaxConcurrentAgents = 8
 func WithCodeCallableTools(tools ...tool.CallableTool) Option {
 	return func(c *config) {
 		c.tools = append(c.tools, tools...)
+	}
+}
+
+// WithAgentModelProfile registers one host-authorized model profile that
+// workflow code may select with agent(..., model="<name>") or the equivalent
+// options mapping. The name is the stable workflow-facing alias; the model
+// instance and description are host-owned. The option may be repeated.
+// The name and description are included in the tool declaration visible to
+// the root model; do not put credentials or private provider configuration in
+// either value.
+// Omitting model in workflow code preserves the registered template model
+// exactly. Profile names are an allowlist only and are never treated as
+// provider model identifiers.
+//
+// Selected profiles apply to LLMAgent templates and to custom Agents that
+// honor invocation surface patches. Other Agents keep their configured model.
+func WithAgentModelProfile(name, description string, m model.Model) Option {
+	return func(c *config) {
+		c.modelProfiles = append(c.modelProfiles, agentModelProfile{
+			name:        name,
+			description: description,
+			model:       m,
+		})
 	}
 }
 
@@ -77,6 +107,14 @@ func NewTool(runtime Runtime, agents []agent.Agent, opts ...Option) (tool.Callab
 	if strings.TrimSpace(cfg.name) == "" {
 		return nil, required("tool name")
 	}
+	modelProfiles, err := normalizeAgentModelProfiles(cfg.modelProfiles)
+	if err != nil {
+		return nil, err
+	}
+	cfg.modelProfiles = modelProfiles
+	if len(cfg.modelProfiles) > 0 && cfg.description == defaultDescription {
+		cfg.description = defaultDescriptionWithModelProfiles
+	}
 	agentRegistry, err := registerAgentTemplates(agents)
 	if err != nil {
 		return nil, err
@@ -100,9 +138,54 @@ func NewTool(runtime Runtime, agents []agent.Agent, opts ...Option) (tool.Callab
 	}, nil
 }
 
-const defaultDescription = "Run one temporary Python workflow for tasks that need role delegation, parallel analysis, conditional iteration, or data flow between workflow-local child agents. Keep Python as short orchestration glue: delegate substantive work to child agents instead of embedding task deliverables, source files, reports, or large scripts. Registered templates fix model, executor, callbacks, permissions, and other runtime policy; each agent call's dynamic instruction defines that child role's temporary business job. The code argument is executable workflow code, not a code sample. Use only declared workflow capabilities and return a JSON-compatible value. Execution is not transactional; later failures or retries do not roll back side effects."
+func normalizeAgentModelProfiles(profiles []agentModelProfile) ([]agentModelProfile, error) {
+	if len(profiles) == 0 {
+		return nil, nil
+	}
+	normalized := make([]agentModelProfile, 0, len(profiles))
+	seen := make(map[string]bool, len(profiles))
+	for _, profile := range profiles {
+		name := strings.TrimSpace(profile.name)
+		description := strings.TrimSpace(profile.description)
+		switch {
+		case name == "":
+			return nil, fmt.Errorf("dynamicworkflow: agent model profile name is required")
+		case description == "":
+			return nil, fmt.Errorf("dynamicworkflow: agent model profile %q description is required", name)
+		case profile.model == nil:
+			return nil, fmt.Errorf("dynamicworkflow: agent model profile %q model is required", name)
+		case seen[name]:
+			return nil, fmt.Errorf("dynamicworkflow: duplicate agent model profile %q", name)
+		}
+		seen[name] = true
+		normalized = append(normalized, agentModelProfile{
+			name:        name,
+			description: description,
+			model:       profile.model,
+		})
+	}
+	return normalized, nil
+}
+
+const defaultDescriptionPrefix = "Run one temporary Python workflow for tasks that need role delegation, parallel analysis, conditional iteration, or data flow between workflow-local child agents. Keep Python as short orchestration glue: delegate substantive work to child agents instead of embedding task deliverables, source files, reports, or large scripts. "
+
+const defaultDescriptionTemplatePolicy = "Registered templates fix model, executor, callbacks, permissions, and other runtime policy; each agent call's dynamic instruction defines that child role's temporary business job. "
+
+const defaultDescriptionTemplatePolicyWithModelProfiles = "Registered templates fix the default model, executor, callbacks, permissions, and other runtime policy; host-authorized model profiles may override the model for one child call. Each agent call's dynamic instruction defines that child role's temporary business job. "
+
+const defaultDescriptionSuffix = "The code argument is executable workflow code, not a code sample. Use only declared workflow capabilities and return a JSON-compatible value. Execution is not transactional; later failures or retries do not roll back side effects."
+
+const defaultDescription = defaultDescriptionPrefix +
+	defaultDescriptionTemplatePolicy +
+	defaultDescriptionSuffix
+
+const defaultDescriptionWithModelProfiles = defaultDescriptionPrefix +
+	defaultDescriptionTemplatePolicyWithModelProfiles +
+	defaultDescriptionSuffix
 
 const codeCallableToolDescription = "Code-callable host tools are enabled for this workflow. Call await call_tool(\"tool_name\", **json_arguments) only for the documented allowlisted tools below. Do not parallelize mutating tool calls; use child agents for concurrent work."
+
+const agentModelProfileGuidance = "Omit model to use the template default. Choose a host-authorized model profile only for a clear task-specific reason."
 
 type workflowTool struct {
 	runtime Runtime
@@ -125,23 +208,13 @@ func (t *workflowTool) Declaration() *tool.Declaration {
 	if capabilities := buildCapabilityHelp(t.agents, t.tools); capabilities != "" {
 		description += "\n\nHost capabilities available inside Python:\n" + capabilities
 	}
+	if modelProfiles := buildModelProfileHelp(t.cfg.modelProfiles); modelProfiles != "" {
+		description += "\n\n" + modelProfiles
+	}
 	// Keep model guidance on the canonical direct-body form. LocalRunner
 	// separately tolerates a sole run/main wrapper as a recovery path for
 	// common non-canonical model output.
-	codeDescription := `Write a short executable workflow body: use await directly and finish with return. Python is orchestration glue only; delegate substantive work to agent(...) and use Python for control flow and small JSON data shaping. Do not assign the program to code, put it in a quoted string or Markdown fence, return Python source, define an uncalled wrapper, call asyncio.run(), import modules, use class/with/try/global/nonlocal, embed task deliverables or large scripts, or access undeclared host capabilities. Use Python True/False/None in source (JSON-style true/false/null aliases are also accepted in generated AgentSpec dictionaries). Use await agent(input, options=None) or await agent(input, **options) to create and run one child Agent. options may set template, instruction, instance_id, tools, skills, and structured_output; schema is shorthand for structured_output.schema. If exactly one template is registered, template may be omitted. Omitted tools and skills inherit eligible template capabilities; use [] to disable a capability type or a non-empty list to narrow it. For values used by later conditions or loops, request schema as a Python dict and read result["structured"]; do not ask for JSON text or parse JSON in workflow code. For provider-portable visible tool use, first collect unstructured tool-grounded text, then pass it to a tools=[] agent call with schema instead of combining non-empty tools with schema/structured_output. agent returns an envelope with text and optional structured fields. Pass or return result["text"] for plain text and result["structured"] for typed data; do not forward the full envelope unless its metadata is needed. Missing result["field"] / result.get("field") fall back to structured.
-
-Canonical one-shot pattern:
-draft = await agent("Write a concise draft.", instruction="Write the first draft.", tools=[])
-draft_text = draft["text"]
-for attempt in range(3):
-    review = await agent({"draft": draft_text}, instruction="Review the draft and return approved plus feedback.", schema={"type": "object", "properties": {"approved": {"type": "boolean"}, "feedback": {"type": "string"}}}, tools=[])
-    if review["approved"] or attempt == 2:
-        break
-    revised = await agent({"draft": draft_text, "feedback": review["feedback"]}, instruction="Revise the draft using every feedback item.", tools=[])
-    draft_text = revised["text"]
-return {"draft": draft_text, "review": review["structured"]}
-
-Short parallel idiom: analyses = await parallel([lambda: agent("Option A", instruction="Analyze"), lambda: agent("Option B", instruction="Analyze")]). parallel([lambda: agent(...), ...]) runs independent branches concurrently, preserves input order, and returns None for a failed branch. pipeline(items, stage1, ...) runs each item through async stages; a stage may accept previous, (previous, original), or (previous, original, index), and a failed item becomes None.`
+	codeDescription := workflowCodeDescription(len(t.cfg.modelProfiles) > 0)
 	if len(t.tools) > 0 {
 		codeDescription += " Code-callable host tools are enabled: use await call_tool(name, **json_arguments) only for the documented allowlisted tools."
 	}
@@ -166,6 +239,29 @@ Short parallel idiom: analyses = await parallel([lambda: agent("Option A", instr
 			},
 		},
 	}
+}
+
+func workflowCodeDescription(hasModelProfiles bool) string {
+	options := "template, instruction, instance_id, tools, skills, and structured_output"
+	modelGuidance := ""
+	if hasModelProfiles {
+		options = "template, instruction, model, instance_id, tools, skills, and structured_output"
+		modelGuidance = " " + agentModelProfileGuidance
+	}
+	return `Write a short executable workflow body: use await directly and finish with return. Python is orchestration glue only; delegate substantive work to agent(...) and use Python for control flow and small JSON data shaping. Do not assign the program to code, put it in a quoted string or Markdown fence, return Python source, define an uncalled wrapper, call asyncio.run(), import modules, use class/with/try/global/nonlocal, embed task deliverables or large scripts, or access undeclared host capabilities. Use Python True/False/None in source (JSON-style true/false/null aliases are also accepted in generated AgentSpec dictionaries). Use await agent(input, options=None) or await agent(input, **options) to create and run one child Agent. options may set ` + options + `; schema is shorthand for structured_output.schema. If exactly one template is registered, template may be omitted.` + modelGuidance + ` Omitted tools and skills inherit eligible template capabilities; use [] to disable a capability type or a non-empty list to narrow it. For values used by later conditions or loops, request schema as a Python dict and read result["structured"]; do not ask for JSON text or parse JSON in workflow code. For provider-portable visible tool use, first collect unstructured tool-grounded text, then pass it to a tools=[] agent call with schema instead of combining non-empty tools with schema/structured_output. agent returns an envelope with text and optional structured fields. Pass or return result["text"] for plain text and result["structured"] for typed data; do not forward the full envelope unless its metadata is needed. Missing result["field"] / result.get("field") fall back to structured.
+
+Canonical one-shot pattern:
+draft = await agent("Write a concise draft.", instruction="Write the first draft.", tools=[])
+draft_text = draft["text"]
+for attempt in range(3):
+    review = await agent({"draft": draft_text}, instruction="Review the draft and return approved plus feedback.", schema={"type": "object", "properties": {"approved": {"type": "boolean"}, "feedback": {"type": "string"}}}, tools=[])
+    if review["approved"] or attempt == 2:
+        break
+    revised = await agent({"draft": draft_text, "feedback": review["feedback"]}, instruction="Revise the draft using every feedback item.", tools=[])
+    draft_text = revised["text"]
+return {"draft": draft_text, "review": review["structured"]}
+
+Short parallel idiom: analyses = await parallel([lambda: agent("Option A", instruction="Analyze"), lambda: agent("Option B", instruction="Analyze")]). parallel([lambda: agent(...), ...]) runs independent branches concurrently, preserves input order, and returns None for a failed branch. pipeline(items, stage1, ...) runs each item through async stages; a stage may accept previous, (previous, original), or (previous, original, index), and a failed item becomes None.`
 }
 
 // Call executes a workflow without streaming child Agent events and returns
@@ -319,6 +415,7 @@ func (t *workflowTool) execute(
 		parent:            parent,
 		agents:            t.agents,
 		tools:             t.tools,
+		modelProfiles:     t.cfg.modelProfiles,
 		workflow:          uuid.NewString(),
 		toolName:          t.cfg.name,
 		emitEvent:         emitEvent,
@@ -436,6 +533,7 @@ type workflowGateway struct {
 	parent            *agent.Invocation
 	agents            map[string]agentTemplate
 	tools             map[string]tool.CallableTool
+	modelProfiles     []agentModelProfile
 	workflow          string
 	toolName          string
 	emitEvent         func(*event.Event) error
@@ -882,6 +980,20 @@ func buildCapabilityHelp(agents map[string]agentTemplate, tools map[string]tool.
 			line += "\n  Output JSON Schema: " + marshalOrNull(decl.OutputSchema)
 		}
 		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func buildModelProfileHelp(profiles []agentModelProfile) string {
+	if len(profiles) == 0 {
+		return ""
+	}
+	// Keep the alias catalog only here. Omission/selection guidance belongs
+	// on the code field so the same generic sentence is not repeated.
+	lines := make([]string, 0, len(profiles)+1)
+	lines = append(lines, "Host-authorized agent model profiles:")
+	for _, profile := range profiles {
+		lines = append(lines, fmt.Sprintf("- model %q: %s", profile.name, profile.description))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/tool/dynamicworkflow/types.go
+++ b/tool/dynamicworkflow/types.go
@@ -45,16 +45,22 @@ type Result struct {
 //
 // Template names the registered agent template. InstanceID optionally gives
 // repeated calls within the same workflow a shared workflow-local history key.
-// Instruction overrides the child instruction for this run. When Tools or
-// Skills is omitted (or null in workflow JSON), the instance inherits the
-// template's eligible user tools or configured skills. An explicit empty list
-// disables that capability type; a non-empty list narrows it. Neither field
-// can add capabilities. StructuredOutput overrides the template's structured
-// output configuration for this workflow-local instance only.
+// Instruction overrides the child instruction for this run. Model optionally
+// selects a host-authorized model profile alias registered with
+// WithAgentModelProfile; omit it to keep the template's registered model.
+// Model selection applies to LLMAgent templates and to custom Agents that
+// honor invocation surface patches; other Agents keep their configured model.
+// When Tools or Skills is omitted (or null in workflow JSON), the instance
+// inherits the template's eligible user tools or configured skills. An
+// explicit empty list disables that capability type; a non-empty list narrows
+// it. Neither field can add capabilities. StructuredOutput overrides the
+// template's structured output configuration for this workflow-local instance
+// only.
 type AgentSpec struct {
 	Template         string                `json:"template"`
 	InstanceID       string                `json:"instance_id,omitempty"`
 	Instruction      string                `json:"instruction,omitempty"`
+	Model            string                `json:"model,omitempty"`
 	Tools            []string              `json:"tools,omitempty"`
 	Skills           []string              `json:"skills,omitempty"`
 	StructuredOutput *StructuredOutputSpec `json:"structured_output,omitempty"`
@@ -66,8 +72,9 @@ type AgentSpec struct {
 // returned result.Structured value.
 //
 // This is intentionally declarative data rather than a way for workflow code
-// to construct an arbitrary Go agent. The registered template still owns the
-// model, executor, callbacks, and all host capabilities.
+// to construct an arbitrary Go agent. StructuredOutputSpec configures only
+// this instance's structured output. The registered template still owns the
+// executor, callbacks, permissions, and all host capabilities.
 type StructuredOutputSpec struct {
 	Name        string          `json:"name,omitempty"`
 	Schema      json.RawMessage `json:"schema"`


### PR DESCRIPTION
## Summary

- allow workflow code to select host-authorized model profiles per child Agent call
- preserve the template default when omitted and reject unknown profiles
- add tests, documentation, and a runnable model-routing example

## Testing

- `go test ./tool/dynamicworkflow`
- `go test -race ./tool/dynamicworkflow`