### PR TITLE
{agent/codex, agent/claudecode, docs}: add CLI message builders

### DIFF
--- a/agent/claudecode/claude_agent.go
+++ b/agent/claudecode/claude_agent.go
@@ -27,14 +27,16 @@ import (
 
 // claudeCodeAgent invokes a locally installed Claude Code CLI and maps its transcript into trpc-agent-go events.
 type claudeCodeAgent struct {
-	name          string
-	description   string
-	bin           string
-	args          []string
-	env           []string
-	workDir       string
-	commandRunner commandRunner
-	rawOutputHook RawOutputHook
+	name           string
+	description    string
+	bin            string
+	args           []string
+	env            []string
+	workDir        string
+	commandRunner  commandRunner
+	rawOutputHook  RawOutputHook
+	messageBuilder MessageBuilder
+	resumeEnabled  bool
 }
 
 // New creates a Claude Code CLI agent with the provided options.
@@ -44,14 +46,16 @@ func New(opt ...Option) (agent.Agent, error) {
 		return nil, err
 	}
 	return &claudeCodeAgent{
-		name:          opts.name,
-		description:   opts.description,
-		bin:           opts.bin,
-		args:          opts.args,
-		env:           opts.env,
-		workDir:       opts.workDir,
-		commandRunner: opts.commandRunner,
-		rawOutputHook: opts.rawOutputHook,
+		name:           opts.name,
+		description:    opts.description,
+		bin:            opts.bin,
+		args:           opts.args,
+		env:            opts.env,
+		workDir:        opts.workDir,
+		commandRunner:  opts.commandRunner,
+		rawOutputHook:  opts.rawOutputHook,
+		messageBuilder: opts.messageBuilder,
+		resumeEnabled:  opts.resumeEnabled,
 	}, nil
 }
 
@@ -83,26 +87,54 @@ func (a *claudeCodeAgent) Run(ctx context.Context, invocation *agent.Invocation)
 	if invocation.Session.ID == "" {
 		return nil, errors.New("invocation session id is empty")
 	}
-	if invocation.Message.Content == "" {
-		return nil, errors.New("invocation prompt is empty")
+	prompt, err := a.buildPrompt(ctx, invocation)
+	if err != nil {
+		return nil, err
 	}
 	out := make(chan *event.Event)
 	runCtx := agent.CloneContext(ctx)
-	go a.runInvocation(runCtx, invocation, out)
+	go a.runInvocation(runCtx, invocation, prompt, out)
 	return out, nil
 }
 
-// runInvocation executes the CLI invocation and emits tool events and the final response event.
-func (a *claudeCodeAgent) runInvocation(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event) {
-	defer close(out)
-	cliSessID := cliSessionID(invocation.Session)
-	if cliSessID == "" {
-		a.emitFlowError(ctx, invocation, out, nil, errors.New("claude cli session id is empty"))
-		return
+func (a *claudeCodeAgent) buildPrompt(ctx context.Context, invocation *agent.Invocation) (string, error) {
+	if a.messageBuilder == nil {
+		if invocation.Message.Content == "" {
+			return "", errors.New("invocation prompt is empty")
+		}
+		return invocation.Message.Content, nil
 	}
-	stdout, stderr, runErr := a.runWithSession(ctx, cliSessID, invocation.Message.Content)
+	prompt, err := a.messageBuilder(ctx, &MessageBuilderArgs{
+		InvocationID: invocation.InvocationID,
+		AppName:      invocation.Session.AppName,
+		UserID:       invocation.Session.UserID,
+		SessionID:    invocation.Session.ID,
+		Message:      invocation.Message,
+		Events:       invocation.Session.GetEvents(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("build message: %w", err)
+	}
+	if prompt == "" {
+		return "", errors.New("built prompt is empty")
+	}
+	return prompt, nil
+}
+
+// runInvocation executes the CLI invocation and emits tool events and the final response event.
+func (a *claudeCodeAgent) runInvocation(ctx context.Context, invocation *agent.Invocation, prompt string, out chan<- *event.Event) {
+	defer close(out)
+	var cliSessID string
+	if a.resumeEnabled {
+		cliSessID = cliSessionID(invocation.Session)
+		if cliSessID == "" {
+			a.emitFlowError(ctx, invocation, out, nil, errors.New("claude cli session id is empty"))
+			return
+		}
+	}
+	stdout, stderr, runErr := a.runWithSession(ctx, cliSessID, prompt)
 	combined := bytes.TrimSpace(append(append([]byte(nil), stdout...), stderr...))
-	if hookErr := a.handleRawOutputHook(ctx, invocation, cliSessID, stdout, stderr, runErr); hookErr != nil {
+	if hookErr := a.handleRawOutputHook(ctx, invocation, cliSessID, prompt, stdout, stderr, runErr); hookErr != nil {
 		err := fmt.Errorf("raw output hook: %w", hookErr)
 		if runErr != nil {
 			err = errors.Join(err, fmt.Errorf("command error: %w", runErr))
@@ -174,6 +206,7 @@ func (a *claudeCodeAgent) handleRawOutputHook(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	cliSessionID string,
+	prompt string,
 	stdout []byte,
 	stderr []byte,
 	runErr error,
@@ -185,7 +218,7 @@ func (a *claudeCodeAgent) handleRawOutputHook(
 		InvocationID: invocation.InvocationID,
 		SessionID:    invocation.Session.ID,
 		CLISessionID: cliSessionID,
-		Prompt:       invocation.Message.Content,
+		Prompt:       prompt,
 		Stdout:       stdout,
 		Stderr:       stderr,
 		Error:        runErr,
@@ -220,9 +253,20 @@ func (a *claudeCodeAgent) emitFlowError(
 	a.emitEvent(ctx, invocation, out, event.NewResponseEvent(invocation.InvocationID, a.name, rsp))
 }
 
-// runWithSession executes the CLI with resume-first semantics and returns stdout/stderr.
+// runWithSession executes the CLI and returns stdout/stderr.
 func (a *claudeCodeAgent) runWithSession(ctx context.Context, sessionID, prompt string) ([]byte, []byte, error) {
 	// Copy base args to avoid mutating shared backing arrays across concurrent invocations.
+	if !a.resumeEnabled {
+		args := make([]string, 0, len(a.args)+2)
+		args = append(args, a.args...)
+		args = append(args, "--no-session-persistence", prompt)
+		return a.commandRunner.Run(ctx, command{
+			bin:  a.bin,
+			args: args,
+			env:  a.env,
+			dir:  a.workDir,
+		})
+	}
 	resumeArgs := make([]string, 0, len(a.args)+3)
 	resumeArgs = append(resumeArgs, a.args...)
 	resumeArgs = append(resumeArgs, "--resume", sessionID, prompt)

--- a/agent/claudecode/claude_agent_test.go
+++ b/agent/claudecode/claude_agent_test.go
@@ -68,6 +68,18 @@ func drainEvents(ch <-chan *event.Event) []*event.Event {
 	return events
 }
 
+// newTestInvocation creates a test invocation with a user prompt.
+func newTestInvocation(invocationID string, sess *session.Session, prompt string) *agent.Invocation {
+	return &agent.Invocation{
+		InvocationID: invocationID,
+		Session:      sess,
+		Message: model.Message{
+			Role:    model.RoleUser,
+			Content: prompt,
+		},
+	}
+}
+
 // TestClaudeCodeAgent_Run_ResumeThenCreate verifies the agent retries with --session-id when --resume has no conversation.
 func TestClaudeCodeAgent_Run_ResumeThenCreate(t *testing.T) {
 	ctx := context.Background()
@@ -138,6 +150,7 @@ func TestClaudeCodeAgent_RunWithSession_DoesNotMutateArgsOnFallback(t *testing.T
 		bin:           "claude",
 		args:          baseArgs,
 		commandRunner: runner,
+		resumeEnabled: true,
 	}
 
 	_, _, err := ag.runWithSession(ctx, "session-1", "Hi.")
@@ -187,6 +200,128 @@ func TestClaudeCodeAgent_Run_ResumeSuccess(t *testing.T) {
 	calls := runner.Calls()
 	require.Len(t, calls, 1)
 	require.Contains(t, strings.Join(calls[0].args, " "), "--resume")
+}
+
+func TestClaudeCodeAgent_Run_MessageBuilderBuildsPromptAndRawHook(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-1")
+	sess.Events = []event.Event{{InvocationID: "history-event"}}
+	inv := newTestInvocation("inv-builder-1", sess, "current prompt")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`[{"type":"result","result":"built ok"}]`), nil, nil
+		},
+	}
+	var gotBuilder *MessageBuilderArgs
+	var gotHook RawOutputHookArgs
+	ag, err := New(
+		WithBin("claude"),
+		withCommandRunner(runner),
+		WithMessageBuilder(func(_ context.Context, args *MessageBuilderArgs) (string, error) {
+			got := *args
+			gotBuilder = &got
+			return "built prompt", nil
+		}),
+		WithRawOutputHook(func(_ context.Context, args *RawOutputHookArgs) error {
+			gotHook = *args
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.Equal(t, "built ok", events[0].Choices[0].Message.Content)
+	require.NotNil(t, gotBuilder)
+	require.Equal(t, "inv-builder-1", gotBuilder.InvocationID)
+	require.Equal(t, "app", gotBuilder.AppName)
+	require.Equal(t, "user", gotBuilder.UserID)
+	require.Equal(t, "sess-builder-1", gotBuilder.SessionID)
+	require.Equal(t, "current prompt", gotBuilder.Message.Content)
+	require.Len(t, gotBuilder.Events, 1)
+	require.Equal(t, "history-event", gotBuilder.Events[0].InvocationID)
+	require.Equal(t, "built prompt", gotHook.Prompt)
+	require.Equal(t, cliSessionID(sess), gotHook.CLISessionID)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Contains(t, calls[0].args, "--resume")
+	require.Contains(t, calls[0].args, cliSessionID(sess))
+	require.Equal(t, "built prompt", calls[0].args[len(calls[0].args)-1])
+}
+
+func TestClaudeCodeAgent_Run_MessageBuilderError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-error")
+	inv := newTestInvocation("inv-builder-error", sess, "current prompt")
+	runner := &scriptedRunner{}
+	builderErr := errors.New("builder failed")
+	ag, err := New(
+		withCommandRunner(runner),
+		WithMessageBuilder(func(context.Context, *MessageBuilderArgs) (string, error) {
+			return "", builderErr
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.ErrorIs(t, err, builderErr)
+	require.ErrorContains(t, err, "build message")
+	require.Nil(t, ch)
+	require.Empty(t, runner.Calls())
+}
+
+func TestClaudeCodeAgent_Run_MessageBuilderEmpty(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-empty")
+	inv := newTestInvocation("inv-builder-empty", sess, "current prompt")
+	runner := &scriptedRunner{}
+	ag, err := New(
+		withCommandRunner(runner),
+		WithMessageBuilder(func(context.Context, *MessageBuilderArgs) (string, error) {
+			return "", nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.ErrorContains(t, err, "built prompt is empty")
+	require.Nil(t, ch)
+	require.Empty(t, runner.Calls())
+}
+
+func TestClaudeCodeAgent_Run_ResumeDisabledUsesNoSessionPersistence(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-resume-disabled")
+	inv := newTestInvocation("inv-resume-disabled", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`[{"type":"result","result":"fresh"}]`), nil, nil
+		},
+	}
+	var gotHook RawOutputHookArgs
+	ag, err := New(
+		WithBin("claude"),
+		withCommandRunner(runner),
+		WithResumeEnabled(false),
+		WithRawOutputHook(func(_ context.Context, args *RawOutputHookArgs) error {
+			gotHook = *args
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	require.True(t, events[0].IsFinalResponse())
+	require.Equal(t, "fresh", events[0].Choices[0].Message.Content)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Contains(t, calls[0].args, "--no-session-persistence")
+	require.NotContains(t, calls[0].args, "--resume")
+	require.NotContains(t, calls[0].args, "--session-id")
+	require.Equal(t, "Hi.", calls[0].args[len(calls[0].args)-1])
+	require.Empty(t, gotHook.CLISessionID)
+	require.Equal(t, "Hi.", gotHook.Prompt)
 }
 
 // TestClaudeCodeAgent_Run_CommandError verifies CLI failures are surfaced via Response.Error.

--- a/agent/claudecode/options.go
+++ b/agent/claudecode/options.go
@@ -13,6 +13,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // OutputFormat is the Claude Code CLI transcript output format.
@@ -25,17 +28,42 @@ const (
 	OutputFormatStreamJSON OutputFormat = "stream-json"
 )
 
+// MessageBuilderArgs provides read-only context for building a Claude Code CLI prompt.
+type MessageBuilderArgs struct {
+	// InvocationID is the invocation identifier associated with this CLI execution.
+	InvocationID string
+	// AppName is the framework application name from the invocation session.
+	AppName string
+	// UserID is the framework user identifier from the invocation session.
+	UserID string
+	// SessionID is the framework session identifier from the invocation session.
+	SessionID string
+	// Message is the current invocation message.
+	Message model.Message
+	// Events is a shallow snapshot of session events and must not be mutated.
+	Events []event.Event
+}
+
+// MessageBuilder builds the complete user prompt string passed to the Claude Code CLI.
+//
+// When the agent is run through runner.Run, Events already includes the
+// current turn user message because the runner persists it before invoking the
+// agent. The builder must return the full prompt to pass to the CLI.
+type MessageBuilder func(ctx context.Context, args *MessageBuilderArgs) (string, error)
+
 // options stores ClaudeCodeAgent configuration.
 type options struct {
-	name          string
-	description   string
-	bin           string
-	args          []string
-	outputFormat  OutputFormat
-	env           []string
-	workDir       string
-	commandRunner commandRunner
-	rawOutputHook RawOutputHook
+	name           string
+	description    string
+	bin            string
+	args           []string
+	outputFormat   OutputFormat
+	env            []string
+	workDir        string
+	commandRunner  commandRunner
+	rawOutputHook  RawOutputHook
+	messageBuilder MessageBuilder
+	resumeEnabled  bool
 }
 
 // Option configures a ClaudeCodeAgent.
@@ -114,6 +142,23 @@ func WithRawOutputHook(hook RawOutputHook) Option {
 	}
 }
 
+// WithMessageBuilder sets a callback that builds the complete Claude Code CLI prompt.
+// If builder is nil, the agent uses invocation.Message.Content directly.
+func WithMessageBuilder(builder MessageBuilder) Option {
+	return func(o *options) {
+		o.messageBuilder = builder
+	}
+}
+
+// WithResumeEnabled controls whether the agent uses Claude Code CLI session resume.
+// Resume is enabled by default. When disabled, the agent runs with
+// --no-session-persistence instead of --resume or --session-id.
+func WithResumeEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.resumeEnabled = enabled
+	}
+}
+
 // newOptions applies options and validates the resulting configuration.
 func newOptions(opt ...Option) (*options, error) {
 	opts := &options{
@@ -126,6 +171,7 @@ func newOptions(opt ...Option) (*options, error) {
 		},
 		outputFormat:  OutputFormatJSON,
 		commandRunner: execCommandRunner{},
+		resumeEnabled: true,
 	}
 	for _, o := range opt {
 		o(opts)

--- a/agent/codex/codex_agent.go
+++ b/agent/codex/codex_agent.go
@@ -26,15 +26,17 @@ import (
 
 // codexAgent invokes a locally installed Codex CLI and maps its JSONL events into trpc-agent-go events.
 type codexAgent struct {
-	name          string
-	description   string
-	bin           string
-	globalArgs    []string
-	args          []string
-	env           []string
-	workDir       string
-	commandRunner commandRunner
-	rawOutputHook RawOutputHook
+	name           string
+	description    string
+	bin            string
+	globalArgs     []string
+	args           []string
+	env            []string
+	workDir        string
+	commandRunner  commandRunner
+	rawOutputHook  RawOutputHook
+	messageBuilder MessageBuilder
+	resumeEnabled  bool
 }
 
 // New creates a Codex CLI agent with the provided options.
@@ -44,15 +46,17 @@ func New(opt ...Option) (agent.Agent, error) {
 		return nil, err
 	}
 	return &codexAgent{
-		name:          opts.name,
-		description:   opts.description,
-		bin:           opts.bin,
-		globalArgs:    opts.globalArgs,
-		args:          opts.args,
-		env:           opts.env,
-		workDir:       opts.workDir,
-		commandRunner: opts.commandRunner,
-		rawOutputHook: opts.rawOutputHook,
+		name:           opts.name,
+		description:    opts.description,
+		bin:            opts.bin,
+		globalArgs:     opts.globalArgs,
+		args:           opts.args,
+		env:            opts.env,
+		workDir:        opts.workDir,
+		commandRunner:  opts.commandRunner,
+		rawOutputHook:  opts.rawOutputHook,
+		messageBuilder: opts.messageBuilder,
+		resumeEnabled:  opts.resumeEnabled,
 	}, nil
 }
 
@@ -84,28 +88,56 @@ func (a *codexAgent) Run(ctx context.Context, invocation *agent.Invocation) (<-c
 	if invocation.Session.ID == "" {
 		return nil, errors.New("invocation session id is empty")
 	}
-	if invocation.Message.Content == "" {
-		return nil, errors.New("invocation prompt is empty")
+	prompt, err := a.buildPrompt(ctx, invocation)
+	if err != nil {
+		return nil, err
 	}
 	out := make(chan *event.Event)
 	runCtx := agent.CloneContext(ctx)
-	go a.runInvocation(runCtx, invocation, out)
+	go a.runInvocation(runCtx, invocation, prompt, out)
 	return out, nil
 }
 
+func (a *codexAgent) buildPrompt(ctx context.Context, invocation *agent.Invocation) (string, error) {
+	if a.messageBuilder == nil {
+		if invocation.Message.Content == "" {
+			return "", errors.New("invocation prompt is empty")
+		}
+		return invocation.Message.Content, nil
+	}
+	prompt, err := a.messageBuilder(ctx, &MessageBuilderArgs{
+		InvocationID: invocation.InvocationID,
+		AppName:      invocation.Session.AppName,
+		UserID:       invocation.Session.UserID,
+		SessionID:    invocation.Session.ID,
+		Message:      invocation.Message,
+		Events:       invocation.Session.GetEvents(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("build message: %w", err)
+	}
+	if prompt == "" {
+		return "", errors.New("built prompt is empty")
+	}
+	return prompt, nil
+}
+
 // runInvocation executes the CLI invocation and emits tool events and the final response event.
-func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invocation, out chan<- *event.Event) {
+func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invocation, prompt string, out chan<- *event.Event) {
 	defer close(out)
-	resumeThreadID := sessionThreadID(invocation.Session)
+	var resumeThreadID string
+	if a.resumeEnabled {
+		resumeThreadID = sessionThreadID(invocation.Session)
+	}
 	streamer := newCodexStreamEmitter(ctx, a, invocation, out)
-	cmdResult := a.runWithSession(ctx, resumeThreadID, invocation.Message.Content, streamer)
+	cmdResult := a.runWithSession(ctx, resumeThreadID, prompt, streamer)
 	combined := bytes.TrimSpace(combineOutput(cmdResult.stdout, cmdResult.stderr))
 	result := streamer.Result()
 	observedThreadID := result.ThreadID
 	if observedThreadID == "" {
 		observedThreadID = extractThreadID(cmdResult.stdout)
 	}
-	if hookErr := a.handleRawOutputHook(ctx, invocation, resumeThreadID, observedThreadID, cmdResult.stdout, cmdResult.stderr, cmdResult.err()); hookErr != nil {
+	if hookErr := a.handleRawOutputHook(ctx, invocation, resumeThreadID, observedThreadID, prompt, cmdResult.stdout, cmdResult.stderr, cmdResult.err()); hookErr != nil {
 		err := fmt.Errorf("raw output hook: %w", hookErr)
 		if cmdErr := cmdResult.err(); cmdErr != nil {
 			err = errors.Join(err, fmt.Errorf("command error: %w", cmdErr))
@@ -129,7 +161,7 @@ func (a *codexAgent) runInvocation(ctx context.Context, invocation *agent.Invoca
 		a.emitCodexError(ctx, invocation, out, result.Error)
 		return
 	}
-	a.emitFinalResponse(ctx, invocation, out, combined, result, observedThreadID, resumeThreadID)
+	a.emitFinalResponse(ctx, invocation, out, combined, result, observedThreadID, resumeThreadID, a.resumeEnabled)
 }
 
 // combineOutput joins stdout and stderr with the same display rules as the previous buffered path.
@@ -151,6 +183,7 @@ func (a *codexAgent) emitFinalResponse(
 	result *transcriptResult,
 	threadID string,
 	resumeThreadID string,
+	persistThreadID bool,
 ) {
 	finalContent := string(combined)
 	if strings.TrimSpace(result.FinalMessage) != "" {
@@ -172,7 +205,7 @@ func (a *codexAgent) emitFinalResponse(
 		},
 	}
 	evt := event.NewResponseEvent(invocation.InvocationID, a.name, rsp)
-	if threadID != "" && threadID != resumeThreadID {
+	if persistThreadID && threadID != "" && threadID != resumeThreadID {
 		evt.StateDelta = map[string][]byte{StateKeyThreadID: []byte(threadID)}
 	}
 	a.emitEvent(ctx, invocation, out, evt)
@@ -238,6 +271,7 @@ func (a *codexAgent) handleRawOutputHook(
 	invocation *agent.Invocation,
 	resumeThreadID string,
 	threadID string,
+	prompt string,
 	stdout []byte,
 	stderr []byte,
 	runErr error,
@@ -250,7 +284,7 @@ func (a *codexAgent) handleRawOutputHook(
 		SessionID:      invocation.Session.ID,
 		ResumeThreadID: resumeThreadID,
 		ThreadID:       threadID,
-		Prompt:         invocation.Message.Content,
+		Prompt:         prompt,
 		Stdout:         stdout,
 		Stderr:         stderr,
 		Error:          runErr,

--- a/agent/codex/codex_agent_test.go
+++ b/agent/codex/codex_agent_test.go
@@ -430,6 +430,148 @@ func TestCodexAgent_Run_ResumeFromSessionState(t *testing.T) {
 	require.Equal(t, "Hi.", string(calls[0].stdin))
 }
 
+func TestCodexAgent_Run_MessageBuilderBuildsPromptAndRawHook(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-1")
+	sess.Events = []event.Event{{InvocationID: "history-event"}}
+	inv := newTestInvocation("inv-builder-1", sess, "current prompt")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`{"type":"thread.started","thread_id":"thread-builder"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"built ok"}}`), nil, nil
+		},
+	}
+	var gotBuilder *MessageBuilderArgs
+	var gotHook RawOutputHookArgs
+	ag, err := New(
+		withCommandRunner(runner),
+		WithMessageBuilder(func(_ context.Context, args *MessageBuilderArgs) (string, error) {
+			got := *args
+			gotBuilder = &got
+			return "built prompt", nil
+		}),
+		WithRawOutputHook(func(_ context.Context, args *RawOutputHookArgs) error {
+			gotHook = *args
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 2)
+	require.Equal(t, "built ok", events[1].Choices[0].Message.Content)
+	require.NotNil(t, gotBuilder)
+	require.Equal(t, "inv-builder-1", gotBuilder.InvocationID)
+	require.Equal(t, "app", gotBuilder.AppName)
+	require.Equal(t, "user", gotBuilder.UserID)
+	require.Equal(t, "sess-builder-1", gotBuilder.SessionID)
+	require.Equal(t, "current prompt", gotBuilder.Message.Content)
+	require.Len(t, gotBuilder.Events, 1)
+	require.Equal(t, "history-event", gotBuilder.Events[0].InvocationID)
+	require.Equal(t, "built prompt", gotHook.Prompt)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{"exec", "--json"}, calls[0].args)
+	require.Equal(t, "built prompt", string(calls[0].stdin))
+}
+
+func TestCodexAgent_Run_MessageBuilderError(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-error")
+	inv := newTestInvocation("inv-builder-error", sess, "current prompt")
+	runner := &scriptedRunner{}
+	builderErr := errors.New("builder failed")
+	ag, err := New(
+		withCommandRunner(runner),
+		WithMessageBuilder(func(context.Context, *MessageBuilderArgs) (string, error) {
+			return "", builderErr
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.ErrorIs(t, err, builderErr)
+	require.ErrorContains(t, err, "build message")
+	require.Nil(t, ch)
+	require.Empty(t, runner.Calls())
+}
+
+func TestCodexAgent_Run_MessageBuilderEmpty(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-empty")
+	inv := newTestInvocation("inv-builder-empty", sess, "current prompt")
+	runner := &scriptedRunner{}
+	ag, err := New(
+		withCommandRunner(runner),
+		WithMessageBuilder(func(context.Context, *MessageBuilderArgs) (string, error) {
+			return "", nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.ErrorContains(t, err, "built prompt is empty")
+	require.Nil(t, ch)
+	require.Empty(t, runner.Calls())
+}
+
+func TestCodexAgent_Run_MessageBuilderKeepsResumeEnabled(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-builder-resume")
+	sess.SetState(StateKeyThreadID, []byte("thread-resume"))
+	inv := newTestInvocation("inv-builder-resume", sess, "current prompt")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`{"type":"thread.started","thread_id":"thread-resume"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"resumed"}}`), nil, nil
+		},
+	}
+	ag, err := New(
+		withCommandRunner(runner),
+		WithMessageBuilder(func(context.Context, *MessageBuilderArgs) (string, error) {
+			return "built resume prompt", nil
+		}),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 2)
+	require.Empty(t, events[1].StateDelta)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{"exec", "resume", "--json", "thread-resume"}, calls[0].args)
+	require.Equal(t, "built resume prompt", string(calls[0].stdin))
+}
+
+func TestCodexAgent_Run_ResumeDisabledUsesCreateWithoutPersistingThread(t *testing.T) {
+	ctx := context.Background()
+	sess := session.NewSession("app", "user", "sess-resume-disabled")
+	sess.SetState(StateKeyThreadID, []byte("stale-thread"))
+	inv := newTestInvocation("inv-resume-disabled", sess, "Hi.")
+	runner := &scriptedRunner{
+		run: func(cmd command) ([]byte, []byte, error) {
+			return []byte(`{"type":"thread.started","thread_id":"thread-new"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"fresh"}}`), nil, nil
+		},
+	}
+	ag, err := New(
+		withCommandRunner(runner),
+		WithResumeEnabled(false),
+	)
+	require.NoError(t, err)
+	ch, err := ag.Run(ctx, inv)
+	require.NoError(t, err)
+	events := drainEvents(ch)
+	require.Len(t, events, 2)
+	require.True(t, events[1].IsFinalResponse())
+	require.Equal(t, "fresh", events[1].Choices[0].Message.Content)
+	require.Empty(t, events[1].StateDelta)
+	calls := runner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, []string{"exec", "--json"}, calls[0].args)
+	require.Equal(t, "Hi.", string(calls[0].stdin))
+}
+
 func TestCodexAgent_Run_ResumeErrorFallsBackToCreate(t *testing.T) {
 	ctx := context.Background()
 	sess := session.NewSession("app", "user", "sess-3")

--- a/agent/codex/options.go
+++ b/agent/codex/options.go
@@ -13,22 +13,50 @@ import (
 	"context"
 	"errors"
 	"slices"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // StateKeyThreadID is the session state key used to persist the Codex thread id.
 const StateKeyThreadID = "agent.codex.thread_id"
 
+// MessageBuilderArgs provides read-only context for building a Codex CLI prompt.
+type MessageBuilderArgs struct {
+	// InvocationID is the invocation identifier associated with this CLI execution.
+	InvocationID string
+	// AppName is the framework application name from the invocation session.
+	AppName string
+	// UserID is the framework user identifier from the invocation session.
+	UserID string
+	// SessionID is the framework session identifier from the invocation session.
+	SessionID string
+	// Message is the current invocation message.
+	Message model.Message
+	// Events is a shallow snapshot of session events and must not be mutated.
+	Events []event.Event
+}
+
+// MessageBuilder builds the complete user prompt string passed to the Codex CLI.
+//
+// When the agent is run through runner.Run, Events already includes the
+// current turn user message because the runner persists it before invoking the
+// agent. The builder must return the full prompt to pass to the CLI.
+type MessageBuilder func(ctx context.Context, args *MessageBuilderArgs) (string, error)
+
 // options stores CodexAgent configuration.
 type options struct {
-	name          string
-	description   string
-	bin           string
-	globalArgs    []string
-	args          []string
-	env           []string
-	workDir       string
-	commandRunner commandRunner
-	rawOutputHook RawOutputHook
+	name           string
+	description    string
+	bin            string
+	globalArgs     []string
+	args           []string
+	env            []string
+	workDir        string
+	commandRunner  commandRunner
+	rawOutputHook  RawOutputHook
+	messageBuilder MessageBuilder
+	resumeEnabled  bool
 }
 
 // Option configures a CodexAgent.
@@ -109,6 +137,23 @@ func WithRawOutputHook(hook RawOutputHook) Option {
 	}
 }
 
+// WithMessageBuilder sets a callback that builds the complete Codex CLI prompt.
+// If builder is nil, the agent uses invocation.Message.Content directly.
+func WithMessageBuilder(builder MessageBuilder) Option {
+	return func(o *options) {
+		o.messageBuilder = builder
+	}
+}
+
+// WithResumeEnabled controls whether the agent uses Codex CLI thread resume.
+// Resume is enabled by default. When disabled, the agent runs only codex exec
+// and does not persist newly observed thread ids into session state.
+func WithResumeEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.resumeEnabled = enabled
+	}
+}
+
 // newOptions applies options and validates the resulting configuration.
 func newOptions(opt ...Option) (*options, error) {
 	opts := &options{
@@ -116,6 +161,7 @@ func newOptions(opt ...Option) (*options, error) {
 		description:   "Invokes a locally installed Codex CLI and emits assistant and tool events from its JSONL output.",
 		bin:           "codex",
 		commandRunner: execCommandRunner{},
+		resumeEnabled: true,
 	}
 	for _, o := range opt {
 		o(opts)

--- a/docs/mkdocs/en/claudecode.md
+++ b/docs/mkdocs/en/claudecode.md
@@ -78,12 +78,57 @@ The agent emits tool events and one final response event. It does not emit inter
 
 Claude Code CLI requires UUID values for `--session-id`. The agent derives a deterministic UUID as the CLI session id from `invocation.Session.AppName`, `invocation.Session.UserID`, and `invocation.Session.ID`.
 
-Each run uses the following order:
+### Default mode: use Claude Code sessions
+
+By default, the agent uses Claude Code CLI's native session history. Each run uses the following order:
 
 1. `--resume <cli-session-id>`
 2. `--session-id <cli-session-id>`
 
-To keep context, use the same app name, user ID, and session ID in `runner`.
+If `--resume` cannot find an existing conversation, the agent creates one with `--session-id` and the same deterministic UUID. Later turns derive the same CLI session id when you keep using the same app name, user ID, and session ID.
+
+This mode is best for single-instance services, or for deployments where requests are always routed to the same machine, user home, and Claude Code configuration environment. To keep context in this mode, use the same app name, user ID, and session ID in `runner`.
+
+Use `WithResumeEnabled(false)` to disable native Claude Code CLI session resume. When disabled, the agent passes neither `--resume` nor `--session-id`; it passes `--no-session-persistence` instead, so the local CLI session is not an implicit context source.
+
+### Use framework session events as context
+
+If your service runs multiple instances, rebuilds containers, or does not route each conversation to the same machine, Claude Code CLI's local session history is not a reliable context source. In that case, keep context in a framework session service such as Redis or a database. All service instances can read the same session events by using the same app name, user ID, and session ID, and `WithMessageBuilder` can turn those events into the complete prompt passed to Claude Code CLI.
+
+Recommended configuration:
+
+1. Configure `runner` with a shared session service.
+2. Use `WithMessageBuilder` to build the complete prompt from `args.Events`.
+3. Use `WithResumeEnabled(false)` to disable local Claude Code session resume, so the same history does not come from both the prompt and the local session.
+
+`MessageBuilderArgs.Events` is a read-only shallow snapshot. Do not mutate events, responses, state deltas, or extensions inside it. When the agent is called through `runner.Run`, the runner persists the current-turn user message before invoking the agent, so the events already include the current user message. Do not append it again by default.
+
+The example below omits standard-library imports such as `context` and `strings`, and shows only the agent-specific import. It joins non-partial message text only; production builders can choose whether to include tool calls and tool results.
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
+
+ag, err := claudecode.New(
+  claudecode.WithMessageBuilder(func(ctx context.Context, args *claudecode.MessageBuilderArgs) (string, error) {
+    var prompt strings.Builder
+    for _, evt := range args.Events {
+      if evt.Response == nil || len(evt.Choices) == 0 || evt.IsPartial {
+        continue
+      }
+      msg := evt.Choices[0].Message
+      if msg.Content == "" {
+        continue
+      }
+      prompt.WriteString(string(msg.Role))
+      prompt.WriteString(": ")
+      prompt.WriteString(msg.Content)
+      prompt.WriteString("\n")
+    }
+    return prompt.String(), nil
+  }),
+  claudecode.WithResumeEnabled(false),
+)
+```
 
 ## Persist raw CLI output
 
@@ -111,3 +156,5 @@ ag, err := claudecode.New(
 | `WithEnv(env...)` | Adds CLI environment variables. Use `KEY=VALUE`. |
 | `WithWorkDir(dir)` | Sets the CLI working directory. |
 | `WithRawOutputHook(hook)` | Observes raw stdout and stderr. The hook runs after the CLI finishes and before parsing. |
+| `WithMessageBuilder(builder)` | Customizes the complete prompt passed to Claude Code CLI. |
+| `WithResumeEnabled(enabled)` | Controls whether the agent uses Claude Code CLI session resume. Default is `true`. |

--- a/docs/mkdocs/en/codex.md
+++ b/docs/mkdocs/en/codex.md
@@ -81,7 +81,7 @@ The agent emits assistant, tool, and error events as Codex JSONL records arrive,
 
 | Codex JSONL output | Framework event |
 | --- | --- |
-| `type == "thread.started"` | Persisted into session state key `codex.StateKeyThreadID` |
+| `type == "thread.started"` | Persisted by default into session state key `codex.StateKeyThreadID` |
 | `item.type == "command_execution"` | tool-call and tool-result response events |
 | `item.type == "mcp_tool_call"` | tool-call and tool-result response events |
 | Built-in tool items such as `web_search`, `file_change`, `image_view`, and `image_generation` | tool-call and tool-result response events |
@@ -95,14 +95,58 @@ Current Codex CLI skill usage is often injected as prompt context or handled thr
 
 ## Multi-turn sessions
 
-Codex creates its own thread id. The agent persists that id in session state under `codex.StateKeyThreadID` and uses it on later turns:
+### Default mode: use Codex threads
 
-1. First turn: write the prompt to stdin of `codex exec --json`
-2. Later turns: write the prompt to stdin of `codex exec resume --json <thread-id>`
+By default, the agent uses Codex CLI's native thread history:
+
+1. On the first turn, the agent writes the prompt to stdin of `codex exec --json`.
+2. When Codex returns `thread.started`, the agent stores the thread id in session state under `codex.StateKeyThreadID`.
+3. On later turns, if session state has a thread id, the agent writes the prompt to stdin of `codex exec resume --json <thread-id>`.
 
 If resume fails before any transcript event is emitted, the agent starts a fresh `codex exec` run and updates the stored thread id when the new run reports one. If resume has already emitted framework events, or if stdout parsing fails, the agent surfaces that failure instead of starting a fresh run to avoid duplicating visible progress or tool side effects. If both resume and create fail, the invocation returns a run error.
 
-To keep context, use the same app name, user ID, and session ID in `runner`.
+This mode is best for single-instance services, or for deployments where requests are always routed to the same machine, user home, and Codex configuration environment. To keep context in this mode, use the same app name, user ID, and session ID in `runner`.
+
+Use `WithResumeEnabled(false)` to disable native Codex CLI resume. When disabled, the agent does not read `codex.StateKeyThreadID`, does not call `codex exec resume`, and does not write newly observed thread ids back to session state. Each invocation runs a fresh `codex exec`.
+
+### Use framework session events as context
+
+If your service runs multiple instances, rebuilds containers, or does not route each conversation to the same machine, Codex CLI's local thread history is not a reliable context source. In that case, keep context in a framework session service such as Redis or a database. All service instances can read the same session events by using the same app name, user ID, and session ID, and `WithMessageBuilder` can turn those events into the complete prompt passed to Codex CLI.
+
+Recommended configuration:
+
+1. Configure `runner` with a shared session service.
+2. Use `WithMessageBuilder` to build the complete prompt from `args.Events`.
+3. Use `WithResumeEnabled(false)` to disable local Codex thread resume, so the same history does not come from both the prompt and the local thread.
+
+`MessageBuilderArgs.Events` is a read-only shallow snapshot. Do not mutate events, responses, state deltas, or extensions inside it. When the agent is called through `runner.Run`, the runner persists the current-turn user message before invoking the agent, so the events already include the current user message. Do not append it again by default.
+
+The example below omits standard-library imports such as `context` and `strings`, and shows only the agent-specific import. It joins non-partial message text only; production builders can choose whether to include tool calls and tool results.
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/agent/codex"
+
+ag, err := codex.New(
+  codex.WithMessageBuilder(func(ctx context.Context, args *codex.MessageBuilderArgs) (string, error) {
+    var prompt strings.Builder
+    for _, evt := range args.Events {
+      if evt.Response == nil || len(evt.Choices) == 0 || evt.IsPartial {
+        continue
+      }
+      msg := evt.Choices[0].Message
+      if msg.Content == "" {
+        continue
+      }
+      prompt.WriteString(string(msg.Role))
+      prompt.WriteString(": ")
+      prompt.WriteString(msg.Content)
+      prompt.WriteString("\n")
+    }
+    return prompt.String(), nil
+  }),
+  codex.WithResumeEnabled(false),
+)
+```
 
 ## Persist raw CLI output
 
@@ -130,3 +174,5 @@ ag, err := codex.New(
 | `WithEnv(env...)` | Adds CLI environment variables. Use `KEY=VALUE`. |
 | `WithWorkDir(dir)` | Sets the CLI process working directory. |
 | `WithRawOutputHook(hook)` | Observes raw stdout and stderr. The hook runs after the CLI finishes and after streamed transcript events are emitted; returning an error appends an error event and skips the final assistant response. |
+| `WithMessageBuilder(builder)` | Customizes the complete prompt passed to Codex CLI. |
+| `WithResumeEnabled(enabled)` | Controls whether the agent uses Codex CLI thread resume. Default is `true`. |

--- a/docs/mkdocs/zh/claudecode.md
+++ b/docs/mkdocs/zh/claudecode.md
@@ -78,12 +78,57 @@ ag, err := claudecode.New(
 
 Claude Code CLI 的 `--session-id` 要求是 UUID。该 Agent 会基于 `invocation.Session.AppName`、`invocation.Session.UserID`、`invocation.Session.ID` 生成确定性的 UUID 作为 CLI session id。
 
-每次运行按如下顺序尝试：
+### 默认方式：使用 Claude Code session
+
+默认情况下，该 Agent 使用 Claude Code CLI 原生 session 历史。每次运行按如下顺序尝试：
 
 1. `--resume <cli-session-id>`
 2. `--session-id <cli-session-id>`
 
-如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
+如果 `--resume` 找不到已有会话，该 Agent 会使用同一个 deterministic UUID 通过 `--session-id` 创建会话。后续轮次继续使用相同的 app name、user ID、session ID 时，会得到相同的 CLI session id。
+
+这种方式适合单实例服务，或请求总是固定路由到同一台机器、同一个用户目录和同一套 Claude Code 配置环境的场景。此时如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
+
+使用 `WithResumeEnabled(false)` 可以关闭 Claude Code CLI 原生 session resume。关闭后，该 Agent 不传 `--resume` 或 `--session-id`，而是传 `--no-session-persistence`，避免本地 CLI session 成为隐式上下文来源。
+
+### 使用框架 session events 构造上下文
+
+如果服务部署了多个实例、容器会重建，或者请求不会固定路由到同一台机器，Claude Code CLI 本地 session 就不能作为可靠的多轮上下文来源。此时应把上下文放在框架 session service 中，例如 Redis 或数据库。所有服务实例通过相同的 app name、user ID、session ID 读取同一份 session events，再由 `WithMessageBuilder` 把这些 events 拼成传给 Claude Code CLI 的完整 prompt。
+
+推荐配置方式：
+
+1. 给 `runner` 配置共享 session service。
+2. 使用 `WithMessageBuilder` 从 `args.Events` 构造完整 prompt。
+3. 使用 `WithResumeEnabled(false)` 关闭 Claude Code CLI 本地 session resume，避免同一段历史同时来自 prompt 和本地 session。
+
+`MessageBuilderArgs.Events` 是只读浅快照，不应修改其中的 event、response、state delta 或 extensions。通过 `runner.Run` 调用时，runner 会先持久化当前 turn 的 user message，再调用 Agent；因此 builder 看到的 events 已经包含当前 turn user message，不要默认再追加一遍。
+
+下面示例省略 `context`、`strings` 等标准库 import，只展示 Agent 相关配置。示例只拼接非 partial 的 message 文本；生产环境可以按业务需要选择是否加入工具调用和工具结果。
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/agent/claudecode"
+
+ag, err := claudecode.New(
+  claudecode.WithMessageBuilder(func(ctx context.Context, args *claudecode.MessageBuilderArgs) (string, error) {
+    var prompt strings.Builder
+    for _, evt := range args.Events {
+      if evt.Response == nil || len(evt.Choices) == 0 || evt.IsPartial {
+        continue
+      }
+      msg := evt.Choices[0].Message
+      if msg.Content == "" {
+        continue
+      }
+      prompt.WriteString(string(msg.Role))
+      prompt.WriteString(": ")
+      prompt.WriteString(msg.Content)
+      prompt.WriteString("\n")
+    }
+    return prompt.String(), nil
+  }),
+  claudecode.WithResumeEnabled(false),
+)
+```
 
 ## 原始日志落盘
 
@@ -111,3 +156,5 @@ ag, err := claudecode.New(
 | `WithEnv(env...)` | 追加 CLI 环境变量。格式为 `KEY=VALUE`。 |
 | `WithWorkDir(dir)` | 设置 CLI 工作目录。 |
 | `WithRawOutputHook(hook)` | 观测 raw stdout/stderr。回调会在 CLI 结束后、解析前调用。 |
+| `WithMessageBuilder(builder)` | 自定义传给 Claude Code CLI 的完整 prompt。 |
+| `WithResumeEnabled(enabled)` | 控制是否使用 Claude Code CLI session resume；默认 `true`。 |

--- a/docs/mkdocs/zh/codex.md
+++ b/docs/mkdocs/zh/codex.md
@@ -81,7 +81,7 @@ ag, err := codex.New(
 
 | Codex JSONL 输出 | 框架事件 |
 | --- | --- |
-| `type == "thread.started"` | 持久化到 session state key `codex.StateKeyThreadID` |
+| `type == "thread.started"` | 默认持久化到 session state key `codex.StateKeyThreadID` |
 | `item.type == "command_execution"` | tool-call 与 tool-result response 事件 |
 | `item.type == "mcp_tool_call"` | tool-call 与 tool-result response 事件 |
 | `web_search`、`file_change`、`image_view`、`image_generation` 等内置工具 item | tool-call 与 tool-result response 事件 |
@@ -95,14 +95,58 @@ MCP 工具调用会尽量归一化为与 Claude Code 兼容的工具名：`mcp__
 
 ## 多轮会话
 
-Codex 会自行创建 thread id。该 Agent 会把这个 id 存入 session state 的 `codex.StateKeyThreadID`，并在后续轮次使用：
+### 默认方式：使用 Codex thread
 
-1. 首轮：把 prompt 写入 `codex exec --json` 的 stdin
-2. 后续轮次：把 prompt 写入 `codex exec resume --json <thread-id>` 的 stdin
+默认情况下，该 Agent 使用 Codex CLI 原生 thread 历史：
+
+1. 首轮把 prompt 写入 `codex exec --json` 的 stdin。
+2. Codex 返回 `thread.started` 后，Agent 把 thread id 存入 session state 的 `codex.StateKeyThreadID`。
+3. 后续轮次如果 session state 中有 thread id，Agent 把 prompt 写入 `codex exec resume --json <thread-id>` 的 stdin。
 
 如果 resume 在发出任何 transcript 事件前失败，该 Agent 会重新发起一次新的 `codex exec`；如果新执行返回了 thread id，则更新已保存的 thread id。如果 resume 已经发出过框架事件，或 stdout 解析失败，则不会再启动新的执行，以避免重复暴露进度或重复执行工具副作用，而是直接返回本次失败。如果 resume 与新建执行都失败，本次调用会返回 run error。
 
-如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
+这种方式适合单实例服务，或请求总是固定路由到同一台机器、同一个用户目录和同一套 Codex 配置环境的场景。此时如需保持上下文，请在 `runner` 中持续使用相同的 app name、user ID、session ID。
+
+使用 `WithResumeEnabled(false)` 可以关闭 Codex CLI 原生 resume。关闭后，该 Agent 不读取已有 `codex.StateKeyThreadID`，不调用 `codex exec resume`，也不会把新观察到的 thread id 写回 session state；每次调用都会执行新的 `codex exec`。
+
+### 使用框架 session events 构造上下文
+
+如果服务部署了多个实例、容器会重建，或者请求不会固定路由到同一台机器，Codex CLI 本地 thread 就不能作为可靠的多轮上下文来源。此时应把上下文放在框架 session service 中，例如 Redis 或数据库。所有服务实例通过相同的 app name、user ID、session ID 读取同一份 session events，再由 `WithMessageBuilder` 把这些 events 拼成传给 Codex CLI 的完整 prompt。
+
+推荐配置方式：
+
+1. 给 `runner` 配置共享 session service。
+2. 使用 `WithMessageBuilder` 从 `args.Events` 构造完整 prompt。
+3. 使用 `WithResumeEnabled(false)` 关闭 Codex CLI 本地 thread resume，避免同一段历史同时来自 prompt 和本地 thread。
+
+`MessageBuilderArgs.Events` 是只读浅快照，不应修改其中的 event、response、state delta 或 extensions。通过 `runner.Run` 调用时，runner 会先持久化当前 turn 的 user message，再调用 Agent；因此 builder 看到的 events 已经包含当前 turn user message，不要默认再追加一遍。
+
+下面示例省略 `context`、`strings` 等标准库 import，只展示 Agent 相关配置。示例只拼接非 partial 的 message 文本；生产环境可以按业务需要选择是否加入工具调用和工具结果。
+
+```go
+import "trpc.group/trpc-go/trpc-agent-go/agent/codex"
+
+ag, err := codex.New(
+  codex.WithMessageBuilder(func(ctx context.Context, args *codex.MessageBuilderArgs) (string, error) {
+    var prompt strings.Builder
+    for _, evt := range args.Events {
+      if evt.Response == nil || len(evt.Choices) == 0 || evt.IsPartial {
+        continue
+      }
+      msg := evt.Choices[0].Message
+      if msg.Content == "" {
+        continue
+      }
+      prompt.WriteString(string(msg.Role))
+      prompt.WriteString(": ")
+      prompt.WriteString(msg.Content)
+      prompt.WriteString("\n")
+    }
+    return prompt.String(), nil
+  }),
+  codex.WithResumeEnabled(false),
+)
+```
 
 ## 原始日志落盘
 
@@ -130,3 +174,5 @@ ag, err := codex.New(
 | `WithEnv(env...)` | 追加 CLI 环境变量。格式为 `KEY=VALUE`。 |
 | `WithWorkDir(dir)` | 设置 CLI 进程工作目录。 |
 | `WithRawOutputHook(hook)` | 观测 raw stdout/stderr。回调会在 CLI 结束后、流式事件发出后调用；如果返回错误，会追加错误事件并跳过最终 assistant response。 |
+| `WithMessageBuilder(builder)` | 自定义传给 Codex CLI 的完整 prompt。 |
+| `WithResumeEnabled(enabled)` | 控制是否使用 Codex CLI thread resume；默认 `true`。 |

--- a/examples/claudecode/README.md
+++ b/examples/claudecode/README.md
@@ -10,6 +10,8 @@ The agent executes the CLI in `--print` mode and parses the JSON output to emit:
 
 It also uses `--resume <session-id>` and falls back to `--session-id <session-id>` to support multi-turn conversations in the same session.
 
+For deployments that build prompts from centralized framework history, configure `claudecode.WithMessageBuilder` and usually pair it with `claudecode.WithResumeEnabled(false)` so the CLI does not also restore local session context.
+
 The example includes a project-scoped MCP configuration file named `.mcp.json` that registers a local STDIO MCP server. The server exposes a calculator tool so you can see MCP tool calls in the JSON output.
 
 It also includes a project-level weather skill at `.claude/skills/weather-query/SKILL.md` and a project-level news subagent at `.claude/agents/news-query-agent.md` so you can see Skill/Task events in the JSON output without relying on pre-existing CLI configuration.

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -12,6 +12,8 @@ The agent executes `codex exec --json` and parses JSONL output to emit:
 
 It also uses `codex exec resume --json <thread-id>` on later turns in the same framework session. If resume fails before emitting any transcript events, it starts a fresh `codex exec` run and stores the new thread id when one is reported. If resume has already emitted events, the agent surfaces the failure instead of starting a fresh run to avoid duplicating visible progress or tool side effects.
 
+For deployments that build prompts from centralized framework history, configure `codex.WithMessageBuilder` and usually pair it with `codex.WithResumeEnabled(false)` so the CLI does not also restore local thread context.
+
 The example can configure two integrations:
 
 - a temporary streamable HTTP MCP server from `-mcp-url`, injected with `-c mcp_servers...` at runtime


### PR DESCRIPTION
## What changed

Adds opt-in message builders for the Codex and Claude Code CLI agents so callers can construct complete CLI prompts from framework session events. It also adds resume controls for disabling CLI-local thread or session resume, and updates the user documentation to explain the default CLI-local conversation model and the shared session-history deployment pattern.

## Why

CLI-local threads and sessions work well for single-instance or sticky-routing deployments, but multi-instance services need a way to source conversation context from shared framework session storage without also restoring stale or unavailable local CLI state. The new options keep existing defaults unchanged while making the shared-history mode explicit.

## Testing

- `/usr/local/go/bin/go test ./agent/codex ./agent/claudecode`
- `git diff --check`

## Notes for reviewers

This adds public options and builder callback types in both CLI agent packages. Resume remains enabled by default; disabling Codex resume also suppresses thread id state updates, and disabling Claude Code resume runs with `--no-session-persistence`.
