### PR TITLE
session/summary: discard canceled summary results

### DIFF
--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -207,6 +207,9 @@ func SummarizeSession(
 	if err != nil {
 		return false, fmt.Errorf("summarize session %s failed: %w", base.ID, err)
 	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 	if text == "" {
 		return false, nil
 	}

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -896,7 +896,13 @@ func TestSummarizeSession_CanceledDuringSummarizationDoesNotPersist(t *testing.T
 		started: make(chan struct{}),
 		release: make(chan struct{}),
 	}
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(s.release) })
+	}
+	defer release()
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan struct {
 		updated bool
 		err     error
@@ -909,11 +915,23 @@ func TestSummarizeSession_CanceledDuringSummarizationDoesNotPersist(t *testing.T
 			err     error
 		}{updated: updated, err: err}
 	}()
-	<-s.started
+	select {
+	case <-s.started:
+	case <-time.After(time.Second):
+		t.Fatal("summarizer did not start")
+	}
 	cancel()
-	close(s.release)
+	release()
 
-	got := <-done
+	var got struct {
+		updated bool
+		err     error
+	}
+	select {
+	case got = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("canceled summary did not return")
+	}
 	require.ErrorIs(t, got.err, context.Canceled)
 	require.False(t, got.updated)
 	require.Empty(t, base.Summaries)

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -886,6 +886,39 @@ func TestSummarizeSession_CanceledWhileWaitingForSameKey(t *testing.T) {
 	require.NoError(t, <-firstDone)
 }
 
+func TestSummarizeSession_CanceledDuringSummarizationDoesNotPersist(t *testing.T) {
+	now := time.Now()
+	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}
+	base.Events = []event.Event{
+		makeEvent("e1", now.Add(-1*time.Minute), "b1"),
+	}
+	s := &blockingSummarizer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct {
+		updated bool
+		err     error
+	}, 1)
+
+	go func() {
+		updated, err := SummarizeSession(ctx, s, base, "b1", false)
+		done <- struct {
+			updated bool
+			err     error
+		}{updated: updated, err: err}
+	}()
+	<-s.started
+	cancel()
+	close(s.release)
+
+	got := <-done
+	require.ErrorIs(t, got.err, context.Canceled)
+	require.False(t, got.updated)
+	require.Empty(t, base.Summaries)
+}
+
 func TestSummarizeSession_EmptyDelta_WithForce(t *testing.T) {
 	now := time.Now()
 	base := &session.Session{ID: "s1", AppName: "a", UserID: "u"}


### PR DESCRIPTION
## What changed

- re-check the summary context after the summarizer callback returns and before mutating the session summary
- add a deterministic regression test for a callback that returns successfully after its caller cancels the context

## Why

`SummaryJobTimeout` propagates cancellation to summarizers, but custom implementations may ignore that signal and still return text. Previously, `SummarizeSession` accepted that text and persisted it even though the job had already been canceled or timed out.

The keyed summary lock remains held for the full callback, so a retry cannot write concurrently with the older callback. This change adds the missing cancellation fence without introducing a generation mechanism or changing public APIs.

## Testing

- `go test ./session/internal/summary -run 'TestSummarizeSession_(CanceledDuringSummarizationDoesNotPersist|CanceledWhileWaitingForSameKey|ConcurrentSameKeyRechecksDelta)$' -count=50`
- `go test -race ./session/internal/summary -count=1`
- `go test ./session/summary ./session/internal/summary ./session/inmemory -count=1`
- `go vet ./session/internal/summary`
- `go build ./...`

## Notes for reviewers

This addresses the canceled-result persistence part of #2453. It does not change event append idempotency or summary-job coalescing.

Updates #2453
