### PR TITLE
examples: add reusable Dynamic Workflow Skills

### DIFF
--- a/docs/mkdocs/en/dynamic-workflow.md
+++ b/docs/mkdocs/en/dynamic-workflow.md
@@ -122,6 +122,56 @@ tools are not automatically available inside the workflow. This keeps the
 workflow boundary explicit and avoids accidental access to writes,
 credentials, shell execution, or control-plane tools.
 
+## Use Skills as workflow recipes
+
+An Agent Skill can hold reusable process knowledge while Dynamic Workflow
+makes the current request's control flow explicit. For example, one Skill can
+describe a bounded draft/review/revise loop and another can describe parallel
+analysis followed by synthesis. After loading the matching text, the root
+Agent compiles it into one request-specific workflow with real loops, branches,
+or parallel stages rather than relying on a long Agent loop to remember every
+step.
+
+Keep both capabilities available on the root Agent:
+
+```go
+root := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithSkills(repo),
+    // This example loads process knowledge, not Skill commands or scripts.
+    llmagent.WithAllowedSkillTools(llmagent.SkillToolLoad),
+    // run_workflow is visible from the first request.
+    llmagent.WithTools([]tool.Tool{workflow}),
+)
+```
+
+The first model request can see the compact Skill summaries, `skill_load`, and
+the standard `run_workflow` tool. When a recipe matches, the model normally
+loads it first, waits for the `skill_load` result in the next model request,
+and then calls `run_workflow` once; it should not issue both calls in one
+response. Loading a Skill adds its body to subsequent requests in the current
+turn; it does not turn Markdown into an executable script or gate the workflow
+tool. If a recipe has optional Markdown or text references, `skill_load` can
+request them with `docs` or `include_all_docs`; keep summaries short so
+unrelated requests do not pay for large references.
+
+The complete [Dynamic Workflow with Skills example](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/dynamicworkflow/skills)
+includes a code-shaped bounded loop and a prose-only fan-out recipe. The
+workflow remains request-specific: the Skill contributes reusable decisions
+and guardrails, while the model adapts roles, inputs, criteria, and output.
+
+This root workflow recipe is distinct from child Agent Skills. A base Agent
+registered with Dynamic Workflow may have its own domain Skills; an
+`agent(...)` call can inherit them, disable them with `skills=[]`, or narrow
+them with `skills=["name"]`. Narrowing selects available capabilities but does
+not implicitly load a Skill. If the child template exposes `skill_load` and the
+role needs a Skill body, the child can load it; its Agent-scoped Skill state
+remains separate from the root.
+
+Child Agent model and tool events continue through the parent Runner event
+stream; the linked example also prints these events while the workflow runs.
+
 ## `agent(...)` in the current Python workflow
 
 Think of `agent(...)` as: run one Go-registered base Agent once.

--- a/docs/mkdocs/zh/dynamic-workflow.md
+++ b/docs/mkdocs/zh/dynamic-workflow.md
@@ -111,6 +111,50 @@ root := llmagent.New(
 这段代码只把 `run_workflow` 暴露给根 Agent。根 Agent 的其他工具不会自动进入
 workflow。这样可以避免 workflow 意外获得写操作、凭证、shell 执行或控制面工具。
 
+## 用 Skills 描述 workflow 经验
+
+Agent Skill 可以保存可复用的流程经验，Dynamic Workflow 则把它编译成当前请求的
+显式控制流。例如，一个 Skill 可以用文字描述有上限的“撰写-审核-修订”循环，另一个
+Skill 可以描述并行分析再汇总。根 Agent 加载匹配的内容后，可以为当前请求生成带真实
+循环、分支或并行阶段的一次性 workflow，而不必依赖一个长程 Agent loop 始终记住每一步。
+
+根 Agent 同时配置这两种能力：
+
+```go
+root := llmagent.New(
+    "assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithSkills(repo),
+    // 这个示例只加载流程知识，不执行 Skill 内的命令或脚本。
+    llmagent.WithAllowedSkillTools(llmagent.SkillToolLoad),
+    // 第一轮请求就能看到标准 run_workflow。
+    llmagent.WithTools([]tool.Tool{workflow}),
+)
+```
+
+第一次模型请求可以同时看到简短的 Skill 概览、`skill_load` 和标准的
+`run_workflow`。如果匹配到某个流程，模型通常先加载它，等待 `skill_load` 的结果进入
+下一次模型请求，再单独调用一次 `run_workflow`；不要在同一次响应中同时发起两个调用。
+加载 Skill 会把正文加入当前 turn 后续的请求，但不会把 Markdown 变成可执行脚本，也不会
+把 workflow 工具变成某个 Skill 的开关。如果 Skill 有可选的 Markdown 或文本参考资料，
+可以通过 `skill_load` 的 `docs` 或 `include_all_docs` 请求；应保持概览简短，避免无关请求
+承担完整参考资料的 context 成本。
+
+[Dynamic Workflow 与 Skills 示例](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/dynamicworkflow/skills)
+同时展示了一个带代码形状的有界循环和一个只有流程文字的并行分析配方。workflow
+仍然是面向当前请求生成的：Skill 贡献可复用的判断和约束，模型负责适配角色、输入、
+标准和输出。
+
+这里根 Agent 使用的是“workflow 流程 Skill”，不要和子 Agent 自己的领域 Skill
+混为一谈。Dynamic Workflow 注册的基础 Agent 仍可以拥有自己的 Skill；
+`agent(...)` 可以省略 `skills` 以继承、用 `skills=[]` 禁用，或用
+`skills=["name"]` 在已有能力中收窄。收窄只是在选择可用能力，不会隐式加载正文；如果子
+Agent 模板暴露了 `skill_load` 且角色需要正文，子 Agent 可以再加载它，而且它的 Agent 级
+Skill 状态与根 Agent 隔离。
+
+子 Agent 的模型输出和工具事件仍会通过父 Runner 的事件流向外传递；上面的示例也会
+在 workflow 运行时打印这些事件。
+
 ## 当前 Python workflow 里的 `agent(...)`
 
 `agent(...)` 可以理解成：运行一次 Go 侧已注册的基础 Agent。

--- a/examples/dynamicworkflow/skills/README.md
+++ b/examples/dynamicworkflow/skills/README.md
@@ -1,0 +1,229 @@
+# Dynamic Workflow with reusable Skills
+
+This example shows a normal Agent with two reusable workflow recipes. The
+Dynamic Workflow tool is available from the first model request. A Skill is
+not a tool gate and it is not a stored script: it is human-readable process
+knowledge that helps the root Agent decide how to build a request-specific
+workflow.
+
+```text
+user request
+    -> compact summaries of available Skills
+    -> root Agent chooses and loads the best recipe
+    -> root Agent compiles the recipe for this request
+    -> one standard run_workflow call
+    -> explicit loop or parallel control flow
+    -> child Agent events and final result
+```
+
+The repository contains two deliberately different recipes:
+
+- `quality-loop` describes a bounded draft/review/revise loop and includes a
+  small illustrative code shape. The model adapts its roles, criteria, inputs,
+  and output to the current request.
+- `fanout-analysis` describes a parallel analysis and synthesis process in
+  prose only. It demonstrates that a recipe does not require the author to
+  write workflow code.
+
+The recipe is a reusable starting point, not a fixed business case. A request
+about a notice, plan, design, investigation, or another deliverable can use the
+same quality loop. A request needing independent perspectives can use the
+fan-out recipe. If neither applies, the root Agent may construct a workflow on
+its own.
+
+## Key configuration
+
+The root Agent keeps the workflow capability and Skill knowledge separate:
+
+```go
+root := llmagent.New(
+    "workflow_assistant",
+    llmagent.WithModel(modelInstance),
+    llmagent.WithSkills(repo),
+    // This example needs to load knowledge, not execute files from a Skill.
+    llmagent.WithAllowedSkillTools(llmagent.SkillToolLoad),
+    // run_workflow is visible from the first request.
+    llmagent.WithTools([]tool.Tool{workflowTool}),
+)
+```
+
+With this configuration, the first request can see both `skill_load` and the
+standard `run_workflow`. When a recipe matches, the model normally loads it
+first, waits for the `skill_load` result in the next model request, and then
+calls `run_workflow` once; it should not issue both calls in one response.
+Loading a Skill adds its body to subsequent model requests in the current
+turn; it does not replace the workflow tool or turn the Markdown into
+executable code.
+
+Simple requests can still be answered directly; they do not need to load a
+Skill or call `run_workflow`.
+
+`WithAllowedSkillTools(llmagent.SkillToolLoad)` is intentional. It keeps the
+root tool surface small and avoids automatically adding Skill execution,
+workspace, or session-control tools. If a recipe has a short reference file,
+the model can request it through the `docs` or `include_all_docs` arguments of
+`skill_load`; this example keeps the second recipe prose-only.
+
+## Typical compiled shapes
+
+After loading `quality-loop`, the generated workflow may have a shape like
+this (the concrete role instructions and request data are supplied by the
+current task):
+
+```python
+review_schema = {
+    "type": "object",
+    "properties": {
+        "approved": {"type": "boolean"},
+        "feedback": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["approved", "feedback"],
+    "additionalProperties": False,
+}
+
+draft = await agent(request, instruction="Write the first draft.", tools=[])
+previous_feedback = []
+for attempt in range(1, 4):
+    review = await agent(
+        {
+            "request": request,
+            "draft": draft["text"],
+            "previous_feedback": previous_feedback,
+        },
+        instruction=(
+            "Review against the requested criteria. If the user did not provide "
+            "factual values such as dates, URLs, or contacts, clear placeholders "
+            "are acceptable: do not reject solely because they are not concrete "
+            "and do not ask the writer to invent facts. Check that placeholders "
+            "are clear and required fields or steps are complete."
+        ),
+        schema=review_schema,
+        tools=[],
+    )
+    decision = review["structured"]
+    approved = decision["approved"] and not decision["feedback"]
+    if approved or attempt == 3 or not decision["feedback"]:
+        break
+    previous_feedback = decision["feedback"]
+    draft = await agent(
+        {"draft": draft["text"], "feedback": previous_feedback},
+        instruction="Revise the draft using every required change.",
+        tools=[],
+    )
+return {
+    "draft": draft["text"],
+    "approved": approved,
+    "reviews": attempt,
+    "remaining_feedback": decision["feedback"],
+}
+```
+
+After loading `fanout-analysis`, the generated workflow can use
+`parallel([...])` for independent branches, then pass the ordered results and
+the original constraints to a separate synthesis Agent. The Skill explains
+the data handoff and bounded failure handling in prose; it does not prescribe
+the number of branches or a particular domain.
+
+The code is only orchestration glue. The child Agents perform the substantive
+writing, analysis, review, or synthesis, and structured outputs are used when
+the workflow needs a reliable branch or loop decision.
+
+## Add a reusable workflow recipe
+
+An application can add a directory under its Skills root containing a
+`SKILL.md` with a short front matter summary and a body that answers:
+
+1. When is this process a good match, and what should the model do when it is
+   not a match?
+2. Which roles or stages are independent, sequential, or conditional?
+3. Which values must be structured for branching, and what are the exit and
+   retry limits?
+4. Which inputs and previous results must be passed explicitly to each stage?
+5. Which capabilities are allowed, and which side effects require serial
+   handling or user confirmation?
+
+Prefer process prose when it is enough. Include a short fenced code shape when
+it prevents a recurring syntax or data-flow mistake. Longer examples or
+reference material can be placed in Markdown or text docs and loaded on
+demand; keep the summary compact so unrelated requests do not pay for the
+entire recipe.
+
+Do not store secrets, credentials, or unrestricted commands in a Skill. A
+recipe guides model-generated orchestration; the registered Agent templates
+and Runtime still enforce the capabilities available to the workflow.
+
+## Root workflow Skills and child Agent Skills
+
+The Skill used by the root Agent in this example describes *how to orchestrate
+the current task*. A registered child Agent may separately have domain Skills
+that describe *how that role performs its work*. Dynamic Workflow code can
+omit `skills` to inherit the template's eligible Skills, pass `skills=[]` to
+disable them for one child, or pass a non-empty list to narrow the existing
+set. Selection is a capability boundary, not an implicit load. If the child
+template exposes `skill_load` and the role needs a selected Skill's body, the
+child can load it; its loaded state is isolated from the root Agent.
+
+## Events and execution boundary
+
+The root Runner receives the Dynamic Workflow tool event and the child Agent's
+model and tool events through the same event stream. Applications can therefore
+show child progress without treating the generated workflow as a detached
+script. The local Runtime executes one temporary program and routes each
+`agent(...)` call through explicitly registered templates; workflow code does
+not gain arbitrary access to the host Agent or undeclared tools.
+
+This pattern makes control flow explicit and preserves reusable process
+knowledge, but it does not make model output mathematically deterministic. The
+model still chooses the recipe, adapts instructions, and produces content.
+Keep loops bounded, use structured decisions, inspect generated code when
+appropriate, and choose a sandboxed or remote Runtime when the code is not
+trusted.
+
+## Prerequisites
+
+- Go 1.24.4 or later
+- Python 3 available as `python3` (the example uses
+  `dynamicworkflow.LocalRunner`)
+- An OpenAI-compatible model endpoint
+
+## Run
+
+From the `examples` module:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+# Optional for an OpenAI-compatible endpoint:
+export OPENAI_BASE_URL="https://your-endpoint/v1"
+
+go run ./dynamicworkflow/skills -model gpt-5
+```
+
+With no `-prompt`, the example starts an interactive chat loop. Commands:
+
+- `/new`: start a fresh session
+- `/exit`: quit the example
+
+The example prints the model-visible tools before every root model request.
+The first trace includes both `skill_load` and `run_workflow`; later traces
+show the corresponding tool calls and results while the workflow runs.
+Generated workflow code is printed by default, so you can inspect how the
+recipe shaped the one-shot control flow. Disable either diagnostic with
+`-trace-tools=false` or `-show-workflow-code=false`.
+
+Try the same recipe with a different request:
+
+```bash
+go run ./dynamicworkflow/skills -model gpt-5 \
+  -prompt 'Prepare a concise rollout plan for replacing recurring status meetings with async updates and one weekly decision meeting. Have it independently reviewed for clarity, feasibility, ownership, and rollback readiness, and revise it until approved.'
+```
+
+The recipe remains unchanged while the generated roles, criteria, data, and
+final deliverable adapt to the new request.
+
+To exercise the prose-only recipe, ask for independent perspectives and a
+synthesis:
+
+```bash
+go run ./dynamicworkflow/skills -model gpt-5 \
+  -prompt 'Compare two reasonable approaches to introducing a new service boundary. Analyze feasibility, operational impact, migration risk, and open questions from independent perspectives, then synthesize a recommendation with the evidence and uncertainties.'
+```

--- a/examples/dynamicworkflow/skills/main.go
+++ b/examples/dynamicworkflow/skills/main.go
@@ -1,0 +1,236 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main demonstrates compiling a reusable Skill recipe into a
+// request-specific Dynamic Workflow.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/dynamicworkflow"
+)
+
+const (
+	appName        = "dynamic-workflow-skills-example"
+	rootAgentName  = "workflow_assistant"
+	childAgentName = "general_agent"
+	userID         = "demo-user"
+)
+
+var (
+	modelName = flag.String(
+		"model",
+		"gpt-5",
+		"Model name for the OpenAI-compatible endpoint",
+	)
+	prompt = flag.String(
+		"prompt",
+		"",
+		"Optional single-turn prompt. If empty, start interactive chat.",
+	)
+	skillsRoot = flag.String(
+		"skills-root",
+		defaultExamplePath("skills"),
+		"Skills root directory",
+	)
+	showWorkflowCode = flag.Bool(
+		"show-workflow-code",
+		true,
+		"Print generated workflow code before executing it",
+	)
+	traceTools = flag.Bool(
+		"trace-tools",
+		true,
+		"Print model-visible tools before each root model request",
+	)
+)
+
+const rootInstruction = `You are a helpful assistant that can turn reusable Skill instructions into temporary workflows.
+
+Answer simple requests directly. When an available Skill matches the request,
+load the best match and wait for its result before planning or calling
+run_workflow; do not issue skill_load and run_workflow in the same response. If
+a workflow is useful but no Skill matches, construct it directly without
+loading an unrelated Skill:
+1. Use the standard run_workflow tool once to compile the selected recipe, or
+   your direct plan, into a temporary workflow for this request.
+2. Preserve a selected recipe's role separation, structured decisions, attempt
+   limit, and exit conditions while adapting role instructions and inputs to
+   the user's task.
+3. Keep workflow code as short orchestration glue. Delegate substantive
+   drafting, analysis, review, and revision to agent(...).
+4. Return the workflow result to the user; do not merely describe the recipe or
+   answer with workflow source.
+
+Skills are reusable process knowledge, not executable scripts. They may contain prose, a small code shape, or optional reference material; adapt the guidance instead of copying it verbatim. Use explicit structured result objects for schema-backed branch and loop decisions. Usually make one run_workflow call for one user request.`
+
+const childInstruction = `Follow the dynamic instruction as the complete definition of your current workflow-local role. Treat the input as JSON context and work only on the requested analysis, writing, review, revision, or synthesis step. Pass conclusions, assumptions, and uncertainty explicitly when the role calls for them. When structured output is requested, return data that conforms to the schema. Otherwise return the requested content directly.`
+
+func main() {
+	flag.Parse()
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
+		log.Fatal("OPENAI_API_KEY is required")
+	}
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) error {
+	repo, err := skill.NewFSRepository(*skillsRoot)
+	if err != nil {
+		return fmt.Errorf("load Skills: %w", err)
+	}
+	modelInstance := openai.New(*modelName)
+
+	child := llmagent.New(
+		childAgentName,
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription(
+			"A neutral template for workflow-local analysis, writing, review, revision, and synthesis roles.",
+		),
+		llmagent.WithInstruction(childInstruction),
+		llmagent.WithMessageFilterMode(llmagent.IsolatedRequest),
+	)
+	workflowTool, err := dynamicworkflow.NewTool(
+		dynamicworkflow.LocalRunner{},
+		[]agent.Agent{child},
+	)
+	if err != nil {
+		return fmt.Errorf("create Dynamic Workflow tool: %w", err)
+	}
+	if *showWorkflowCode {
+		workflowTool = workflowCodePrintingTool{inner: workflowTool}
+	}
+
+	root := llmagent.New(
+		rootAgentName,
+		llmagent.WithModel(modelInstance),
+		llmagent.WithDescription(
+			"Loads reusable workflow recipes and executes them as temporary Dynamic Workflows.",
+		),
+		llmagent.WithInstruction(rootInstruction),
+		llmagent.WithSkills(repo),
+		// This recipe only needs progressive disclosure. Avoid adding Skill
+		// execution or workspace tools to the root Agent's tool surface.
+		llmagent.WithAllowedSkillTools(llmagent.SkillToolLoad),
+		// Dynamic Workflow is available from the first request. Skills are
+		// reusable recipes that guide its use; they are not capability gates.
+		llmagent.WithTools([]tool.Tool{workflowTool}),
+		llmagent.WithModelCallbacks(traceToolCallbacks(*traceTools)),
+	)
+	r := runner.NewRunner(
+		appName,
+		root,
+		runner.WithSessionService(inmemory.NewSessionService()),
+	)
+	defer r.Close()
+
+	chat := &dynamicWorkflowChat{
+		runner:         r,
+		userID:         userID,
+		sessionID:      newSessionID(),
+		modelName:      *modelName,
+		workflowSkills: skillSummaryNames(repo.Summaries()),
+	}
+	if strings.TrimSpace(*prompt) != "" {
+		chat.printStartup()
+		fmt.Printf("User: %s\n\n", *prompt)
+		return chat.processMessage(ctx, *prompt)
+	}
+	chat.printBanner()
+	return chat.startChat(ctx)
+}
+
+type dynamicWorkflowChat struct {
+	runner         runner.Runner
+	userID         string
+	sessionID      string
+	modelName      string
+	workflowSkills []string
+}
+
+func newSessionID() string {
+	return fmt.Sprintf("dynamic-workflow-skills-%d", time.Now().UnixNano())
+}
+
+func (c *dynamicWorkflowChat) startChat(ctx context.Context) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for {
+		fmt.Print("You: ")
+		if !scanner.Scan() {
+			break
+		}
+		userInput := strings.TrimSpace(scanner.Text())
+		if userInput == "" {
+			continue
+		}
+		switch strings.ToLower(userInput) {
+		case "/exit":
+			fmt.Println("Goodbye.")
+			return nil
+		case "/new":
+			c.sessionID = newSessionID()
+			fmt.Printf("Started new session: %s\n\n", c.sessionID)
+			continue
+		}
+		if err := c.processMessage(ctx, userInput); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("input scanner error: %w", err)
+	}
+	return nil
+}
+
+func (c *dynamicWorkflowChat) processMessage(
+	ctx context.Context,
+	userMessage string,
+) error {
+	events, err := c.runner.Run(
+		ctx,
+		c.userID,
+		c.sessionID,
+		model.NewUserMessage(userMessage),
+	)
+	if err != nil {
+		return fmt.Errorf("run Agent: %w", err)
+	}
+	printEvents(events)
+	return nil
+}
+
+func defaultExamplePath(name string) string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return name
+	}
+	return filepath.Join(filepath.Dir(filename), name)
+}

--- a/examples/dynamicworkflow/skills/main.go
+++ b/examples/dynamicworkflow/skills/main.go
@@ -1,10 +1,10 @@
 //
-// Tencent is pleased to support the open source community by making
-// trpc-agent-go available.
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
 //
 // Copyright (C) 2026 Tencent.  All rights reserved.
 //
 // trpc-agent-go is licensed under the Apache License Version 2.0.
+//
 //
 
 // Package main demonstrates compiling a reusable Skill recipe into a
@@ -103,7 +103,7 @@ func main() {
 func run(ctx context.Context) error {
 	repo, err := skill.NewFSRepository(*skillsRoot)
 	if err != nil {
-		return fmt.Errorf("load Skills: %w", err)
+		return fmt.Errorf("load skills: %w", err)
 	}
 	modelInstance := openai.New(*modelName)
 
@@ -121,7 +121,7 @@ func run(ctx context.Context) error {
 		[]agent.Agent{child},
 	)
 	if err != nil {
-		return fmt.Errorf("create Dynamic Workflow tool: %w", err)
+		return fmt.Errorf("create dynamic workflow tool: %w", err)
 	}
 	if *showWorkflowCode {
 		workflowTool = workflowCodePrintingTool{inner: workflowTool}
@@ -221,10 +221,9 @@ func (c *dynamicWorkflowChat) processMessage(
 		model.NewUserMessage(userMessage),
 	)
 	if err != nil {
-		return fmt.Errorf("run Agent: %w", err)
+		return fmt.Errorf("run agent: %w", err)
 	}
-	printEvents(events)
-	return nil
+	return printEvents(events)
 }
 
 func defaultExamplePath(name string) string {

--- a/examples/dynamicworkflow/skills/print.go
+++ b/examples/dynamicworkflow/skills/print.go
@@ -1,10 +1,10 @@
 //
-// Tencent is pleased to support the open source community by making
-// trpc-agent-go available.
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
 //
 // Copyright (C) 2026 Tencent.  All rights reserved.
 //
 // trpc-agent-go is licensed under the Apache License Version 2.0.
+//
 //
 
 package main
@@ -12,6 +12,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -21,6 +22,13 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/skill"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const (
+	runWorkflowToolName     = "run_workflow"
+	omittedWorkflowCodeJSON = `"[omitted]"`
+	omittedWorkflowArgs     = "[workflow code omitted]"
+	toolResultMaxRunes      = 500
 )
 
 func (c *dynamicWorkflowChat) printStartup() {
@@ -133,8 +141,10 @@ func (t workflowCodePrintingTool) printWorkflowCode(raw []byte) {
 	fmt.Fprintln(os.Stderr)
 }
 
-func printEvents(events <-chan *event.Event) {
+func printEvents(events <-chan *event.Event) error {
+	var runErr error
 	for evt := range events {
+		runErr = updateRunOutcome(runErr, evt)
 		if evt == nil {
 			continue
 		}
@@ -168,6 +178,30 @@ func printEvents(events <-chan *event.Event) {
 			fmt.Printf("[%s] %s\n", eventLabel(evt), content)
 		}
 	}
+	return runErr
+}
+
+// updateRunOutcome mirrors Runner stream semantics for this example: the last
+// terminal error is retained, a later non-partial successful non-runner
+// response may recover, and a clean runner.completion must not erase an
+// already-streamed terminal error.
+func updateRunOutcome(runErr error, evt *event.Event) error {
+	if evt == nil || evt.Response == nil || evt.IsPartial {
+		return runErr
+	}
+	if evt.IsRunnerCompletion() {
+		if evt.IsTerminalError() {
+			return errors.New(evt.Response.Error.Message)
+		}
+		return runErr
+	}
+	if evt.IsTerminalError() {
+		return errors.New(evt.Response.Error.Message)
+	}
+	if evt.Response.Error == nil {
+		return nil
+	}
+	return runErr
 }
 
 func printToolEvent(evt *event.Event) bool {
@@ -182,7 +216,7 @@ func printToolEvent(evt *event.Event) bool {
 					"[%s] tool call: %s args: %s\n",
 					eventLabel(evt),
 					call.Function.Name,
-					string(call.Function.Arguments),
+					formatToolCallArgs(call.Function.Name, call.Function.Arguments),
 				)
 			}
 		}
@@ -199,10 +233,7 @@ func printToolEvent(evt *event.Event) bool {
 		if msg.ToolID == "" {
 			continue
 		}
-		content := strings.TrimSpace(msg.Content)
-		if len(content) > 500 {
-			content = content[:500] + "..."
-		}
+		content := truncateRunes(strings.TrimSpace(msg.Content), toolResultMaxRunes)
 		fmt.Printf(
 			"[%s] tool result: %s: %s\n",
 			eventLabel(evt),
@@ -211,6 +242,32 @@ func printToolEvent(evt *event.Event) bool {
 		)
 	}
 	return true
+}
+
+func formatToolCallArgs(name string, args []byte) string {
+	if name != runWorkflowToolName || *showWorkflowCode {
+		return string(args)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(args, &obj); err != nil {
+		return omittedWorkflowArgs
+	}
+	if _, ok := obj["code"]; ok {
+		obj["code"] = json.RawMessage(omittedWorkflowCodeJSON)
+	}
+	redacted, err := json.Marshal(obj)
+	if err != nil {
+		return omittedWorkflowArgs
+	}
+	return string(redacted)
+}
+
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if max < 0 || len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "..."
 }
 
 func eventLabel(evt *event.Event) string {

--- a/examples/dynamicworkflow/skills/print.go
+++ b/examples/dynamicworkflow/skills/print.go
@@ -1,0 +1,224 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/skill"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+func (c *dynamicWorkflowChat) printStartup() {
+	fmt.Println("Dynamic Workflow with Skills")
+	fmt.Printf("Model: %s\n", c.modelName)
+	fmt.Printf("Workflow recipes: %s\n", strings.Join(c.workflowSkills, ", "))
+	fmt.Printf("Session: %s\n", c.sessionID)
+}
+
+func (c *dynamicWorkflowChat) printBanner() {
+	c.printStartup()
+	fmt.Println("Type '/new' to start a new session or '/exit' to quit.")
+	fmt.Println("Sample prompts:")
+	fmt.Println("  Explain the difference between a Go interface and a struct in one sentence.")
+	fmt.Println("  Draft a concise API deprecation notice for replacing v1 with v2. Have an independent reviewer check migration clarity, ownership, timeline, and rollback safety, and revise it until approved.")
+	fmt.Println("  Compare two approaches to introducing a new service boundary. Analyze feasibility, operational impact, migration risk, and open questions from independent perspectives, then synthesize a recommendation.")
+	fmt.Println(strings.Repeat("=", 72))
+}
+
+func skillSummaryNames(summaries []skill.Summary) []string {
+	names := make([]string, 0, len(summaries))
+	for _, summary := range summaries {
+		if name := strings.TrimSpace(summary.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func traceToolCallbacks(enabled bool) *model.Callbacks {
+	if !enabled {
+		return nil
+	}
+	var call int
+	return model.NewCallbacks().RegisterBeforeModel(func(
+		_ context.Context,
+		args *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		call++
+		fmt.Printf("[before root model #%d] visible tools:\n", call)
+		for _, name := range requestToolNames(args.Request) {
+			fmt.Printf("  - %s\n", name)
+		}
+		fmt.Println()
+		return nil, nil
+	})
+}
+
+func requestToolNames(req *model.Request) []string {
+	if req == nil {
+		return nil
+	}
+	names := make([]string, 0, len(req.Tools))
+	for name := range req.Tools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+type workflowCodePrintingTool struct {
+	inner tool.CallableTool
+}
+
+func (t workflowCodePrintingTool) Declaration() *tool.Declaration {
+	return t.inner.Declaration()
+}
+
+func (t workflowCodePrintingTool) Call(
+	ctx context.Context,
+	raw []byte,
+) (any, error) {
+	t.printWorkflowCode(raw)
+	return t.inner.Call(ctx, raw)
+}
+
+func (t workflowCodePrintingTool) StreamableCall(
+	ctx context.Context,
+	raw []byte,
+) (*tool.StreamReader, error) {
+	t.printWorkflowCode(raw)
+	streamable, ok := t.inner.(tool.StreamableTool)
+	if !ok {
+		return nil, fmt.Errorf(
+			"workflow code printer: inner tool is not streamable",
+		)
+	}
+	return streamable.StreamableCall(ctx, raw)
+}
+
+func (t workflowCodePrintingTool) TRPCAgentGoStructuredStreamErrorsOptIn() bool {
+	structured, ok := t.inner.(interface {
+		TRPCAgentGoStructuredStreamErrorsOptIn() bool
+	})
+	return ok && structured.TRPCAgentGoStructuredStreamErrorsOptIn()
+}
+
+func (t workflowCodePrintingTool) printWorkflowCode(raw []byte) {
+	var input struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &input); err != nil ||
+		strings.TrimSpace(input.Code) == "" {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "\n===== generated dynamic workflow code =====")
+	fmt.Fprintln(os.Stderr, input.Code)
+	fmt.Fprintln(os.Stderr, "===== end generated dynamic workflow code =====")
+	fmt.Fprintln(os.Stderr)
+}
+
+func printEvents(events <-chan *event.Event) {
+	for evt := range events {
+		if evt == nil {
+			continue
+		}
+		if evt.Response != nil && evt.Response.Error != nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"[%s] error: %s\n",
+				eventLabel(evt),
+				evt.Response.Error.Message,
+			)
+			continue
+		}
+		if printToolEvent(evt) {
+			continue
+		}
+		if evt.StructuredOutput != nil {
+			raw, err := json.Marshal(evt.StructuredOutput)
+			if err == nil {
+				fmt.Printf("[%s] structured: %s\n", eventLabel(evt), raw)
+			}
+		}
+		if evt.Response == nil || len(evt.Response.Choices) == 0 {
+			continue
+		}
+		choice := evt.Response.Choices[0]
+		content := choice.Delta.Content
+		if content == "" {
+			content = choice.Message.Content
+		}
+		if strings.TrimSpace(content) != "" {
+			fmt.Printf("[%s] %s\n", eventLabel(evt), content)
+		}
+	}
+}
+
+func printToolEvent(evt *event.Event) bool {
+	if evt == nil || evt.Response == nil {
+		return false
+	}
+	if evt.Response.IsToolCallResponse() {
+		for _, choice := range evt.Response.Choices {
+			calls := append(choice.Message.ToolCalls, choice.Delta.ToolCalls...)
+			for _, call := range calls {
+				fmt.Printf(
+					"[%s] tool call: %s args: %s\n",
+					eventLabel(evt),
+					call.Function.Name,
+					string(call.Function.Arguments),
+				)
+			}
+		}
+		return true
+	}
+	if !evt.Response.IsToolResultResponse() {
+		return false
+	}
+	for _, choice := range evt.Response.Choices {
+		msg := choice.Message
+		if msg.ToolID == "" {
+			msg = choice.Delta
+		}
+		if msg.ToolID == "" {
+			continue
+		}
+		content := strings.TrimSpace(msg.Content)
+		if len(content) > 500 {
+			content = content[:500] + "..."
+		}
+		fmt.Printf(
+			"[%s] tool result: %s: %s\n",
+			eventLabel(evt),
+			msg.ToolName,
+			content,
+		)
+	}
+	return true
+}
+
+func eventLabel(evt *event.Event) string {
+	if evt == nil {
+		return "event"
+	}
+	if strings.TrimSpace(evt.Author) != "" {
+		return evt.Author
+	}
+	return "event"
+}

--- a/examples/dynamicworkflow/skills/print_test.go
+++ b/examples/dynamicworkflow/skills/print_test.go
@@ -1,0 +1,380 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+type stubRunner struct {
+	events []*event.Event
+	err    error
+}
+
+func (s stubRunner) Run(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ model.Message,
+	_ ...agent.RunOption,
+) (<-chan *event.Event, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	ch := make(chan *event.Event, len(s.events))
+	for _, evt := range s.events {
+		ch <- evt
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (stubRunner) Close() error { return nil }
+
+func TestProcessMessage_RunOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		events     []*event.Event
+		wantErr    string
+		wantOutput string
+		notErr     string
+	}{
+		{
+			name: "terminal error then clean completion",
+			events: []*event.Event{
+				newTerminalError("first failed"),
+				newPartialContent("DRAIN_MARKER"),
+				newRunnerCompletion(nil),
+			},
+			wantErr:    "first failed",
+			wantOutput: "DRAIN_MARKER",
+		},
+		{
+			name: "terminal error then complete success recovers",
+			events: []*event.Event{
+				newTerminalError("recovered failure"),
+				newCompleteSuccess("all good"),
+				newRunnerCompletion(nil),
+			},
+		},
+		{
+			name: "terminal error then non-final success recovers",
+			events: []*event.Event{
+				newTerminalError("recovered failure"),
+				newToolCall("continue_work", []byte(`{"step":2}`)),
+				newRunnerCompletion(nil),
+			},
+		},
+		{
+			name: "latest terminal error wins",
+			events: []*event.Event{
+				newTerminalError("first failed"),
+				newTerminalError("second failed"),
+				newRunnerCompletion(nil),
+			},
+			wantErr: "second failed",
+			notErr:  "first failed",
+		},
+		{
+			name: "non-terminal error promoted on completion",
+			events: []*event.Event{
+				newNonTerminalError("soft failed"),
+				newRunnerCompletion(&model.ResponseError{Message: "soft failed"}),
+			},
+			wantErr: "soft failed",
+		},
+		{
+			name: "non-terminal error then success recovers",
+			events: []*event.Event{
+				newNonTerminalError("soft failed"),
+				newCompleteSuccess("recovered"),
+				newRunnerCompletion(nil),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := processEvents(t, tt.events...)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("processMessage() error = %v, want nil", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("processMessage() error = nil, want error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("processMessage() error = %q, want to contain %q", err, tt.wantErr)
+				}
+				if tt.notErr != "" && strings.Contains(err.Error(), tt.notErr) {
+					t.Fatalf("processMessage() error = %q, should not contain %q", err, tt.notErr)
+				}
+			}
+			if tt.wantOutput != "" && !strings.Contains(out, tt.wantOutput) {
+				t.Fatalf("processMessage() output %q, want to contain %q", out, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestTruncateRunes_UTF8Boundary(t *testing.T) {
+	exact := strings.Repeat("a", toolResultMaxRunes-1) + "世"
+	if got := truncateRunes(exact, toolResultMaxRunes); got != exact {
+		t.Fatalf("truncateRunes() = %q, want unchanged 500-rune input", got)
+	}
+	if !utf8.ValidString(exact) {
+		t.Fatal("fixture is not valid UTF-8")
+	}
+
+	over := strings.Repeat("a", toolResultMaxRunes-1) + "世界"
+	got := truncateRunes(over, toolResultMaxRunes)
+	want := strings.Repeat("a", toolResultMaxRunes-1) + "世" + "..."
+	if got != want {
+		t.Fatalf("truncateRunes() = %q, want %q", got, want)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncateRunes() produced invalid UTF-8: %q", got)
+	}
+	if strings.Contains(got, "界") {
+		t.Fatalf("truncateRunes() kept the overflow rune: %q", got)
+	}
+
+	out, err := processEvents(t,
+		newToolResult("skill_load", exact),
+		newToolResult("skill_load", over),
+		newRunnerCompletion(nil),
+	)
+	if err != nil {
+		t.Fatalf("processMessage() error = %v", err)
+	}
+	if !utf8.ValidString(out) {
+		t.Fatalf("tool result output is not valid UTF-8: %q", out)
+	}
+	if !strings.Contains(out, "世") {
+		t.Fatalf("tool result lost the UTF-8 boundary rune: %q", out)
+	}
+	if strings.Count(out, "界") != 0 {
+		t.Fatalf("tool result kept the overflow rune: %q", out)
+	}
+}
+
+func TestShowWorkflowCodeFlag(t *testing.T) {
+	const secret = "SECRET_WORKFLOW"
+	args := []byte(`{"code":"return '` + secret + `'","foo":1}`)
+
+	t.Run("disabled omits code and keeps other args", func(t *testing.T) {
+		withShowWorkflowCode(t, false)
+		out, err := processEvents(t,
+			newToolCall(runWorkflowToolName, args),
+			newRunnerCompletion(nil),
+		)
+		if err != nil {
+			t.Fatalf("processMessage() error = %v", err)
+		}
+		if strings.Contains(out, secret) {
+			t.Fatalf("disabled flag leaked workflow code: %s", out)
+		}
+		if !strings.Contains(out, "[omitted]") {
+			t.Fatalf("disabled flag missing omit marker: %s", out)
+		}
+		if !strings.Contains(out, `"foo":1`) {
+			t.Fatalf("disabled flag dropped non-code args: %s", out)
+		}
+	})
+
+	t.Run("disabled fail closed on invalid json", func(t *testing.T) {
+		withShowWorkflowCode(t, false)
+		out, err := processEvents(t,
+			newToolCall(runWorkflowToolName, []byte("return '"+secret+"'")),
+			newRunnerCompletion(nil),
+		)
+		if err != nil {
+			t.Fatalf("processMessage() error = %v", err)
+		}
+		if strings.Contains(out, secret) {
+			t.Fatalf("invalid JSON leaked workflow code: %s", out)
+		}
+		if !strings.Contains(out, omittedWorkflowArgs) {
+			t.Fatalf("invalid JSON missing fail-closed marker: %s", out)
+		}
+	})
+
+	t.Run("other tools stay visible when disabled", func(t *testing.T) {
+		withShowWorkflowCode(t, false)
+		out, err := processEvents(t,
+			newToolCall("skill_load", []byte(`{"name":"quality-loop"}`)),
+			newRunnerCompletion(nil),
+		)
+		if err != nil {
+			t.Fatalf("processMessage() error = %v", err)
+		}
+		if !strings.Contains(out, "quality-loop") {
+			t.Fatalf("non-workflow tool args were hidden: %s", out)
+		}
+	})
+
+	t.Run("enabled prints full source through wrapper", func(t *testing.T) {
+		withShowWorkflowCode(t, true)
+		out, err := captureOutput(t, func() error {
+			workflowCodePrintingTool{}.printWorkflowCode(args)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("printWorkflowCode() error = %v", err)
+		}
+		if !strings.Contains(out, secret) {
+			t.Fatalf("enabled wrapper omitted workflow source: %s", out)
+		}
+	})
+}
+
+func processEvents(t *testing.T, events ...*event.Event) (string, error) {
+	t.Helper()
+	chat := &dynamicWorkflowChat{
+		runner:    stubRunner{events: events},
+		userID:    userID,
+		sessionID: "test-session",
+	}
+	return captureOutput(t, func() error {
+		return chat.processMessage(context.Background(), "hello")
+	})
+}
+
+func withShowWorkflowCode(t *testing.T, enabled bool) {
+	t.Helper()
+	original := *showWorkflowCode
+	*showWorkflowCode = enabled
+	t.Cleanup(func() { *showWorkflowCode = original })
+}
+
+func newTerminalError(message string) *event.Event {
+	return event.NewErrorEvent("inv", "agent", "test_error", message)
+}
+
+func newNonTerminalError(message string) *event.Event {
+	return event.NewResponseEvent("inv", "agent", &model.Response{
+		Object:    model.ObjectTypeChatCompletion,
+		Done:      false,
+		IsPartial: false,
+		Error:     &model.ResponseError{Message: message},
+	})
+}
+
+func newCompleteSuccess(content string) *event.Event {
+	return event.NewResponseEvent("inv", "agent", &model.Response{
+		Object:    model.ObjectTypeChatCompletion,
+		Done:      true,
+		IsPartial: false,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage(content),
+		}},
+	})
+}
+
+func newPartialContent(content string) *event.Event {
+	return event.NewResponseEvent("inv", "agent", &model.Response{
+		Object:    model.ObjectTypeChatCompletionChunk,
+		Done:      false,
+		IsPartial: true,
+		Choices: []model.Choice{{
+			Delta: model.Message{Content: content},
+		}},
+	})
+}
+
+func newRunnerCompletion(err *model.ResponseError) *event.Event {
+	return event.NewResponseEvent("inv", appName, &model.Response{
+		Object:    model.ObjectTypeRunnerCompletion,
+		Done:      true,
+		IsPartial: false,
+		Error:     err,
+	})
+}
+
+func newToolCall(name string, args []byte) *event.Event {
+	return event.NewResponseEvent("inv", "agent", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				ToolCalls: []model.ToolCall{{
+					Function: model.FunctionDefinitionParam{
+						Name:      name,
+						Arguments: args,
+					},
+				}},
+			},
+		}},
+	})
+}
+
+func newToolResult(name, content string) *event.Event {
+	return event.NewResponseEvent("inv", "agent", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role:     model.RoleTool,
+				ToolID:   "call-1",
+				ToolName: name,
+				Content:  content,
+			},
+		}},
+	})
+}
+
+func captureOutput(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	origOut, origErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = stdoutW, stderrW
+	defer func() {
+		os.Stdout = origOut
+		os.Stderr = origErr
+	}()
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	stdoutDone := make(chan error, 1)
+	stderrDone := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&stdoutBuf, stdoutR)
+		stdoutDone <- copyErr
+	}()
+	go func() {
+		_, copyErr := io.Copy(&stderrBuf, stderrR)
+		stderrDone <- copyErr
+	}()
+
+	runErr := fn()
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	if copyErr := <-stdoutDone; copyErr != nil {
+		t.Fatalf("read stdout: %v", copyErr)
+	}
+	if copyErr := <-stderrDone; copyErr != nil {
+		t.Fatalf("read stderr: %v", copyErr)
+	}
+	_ = stdoutR.Close()
+	_ = stderrR.Close()
+	return stdoutBuf.String() + stderrBuf.String(), runErr
+}

--- a/examples/dynamicworkflow/skills/skills/fanout-analysis/SKILL.md
+++ b/examples/dynamicworkflow/skills/skills/fanout-analysis/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fanout-analysis
+description: Use this workflow recipe when a question benefits from several independent perspectives followed by a single evidence-based synthesis.
+---
+
+# Parallel Analysis and Synthesis
+
+Turn the user's request into a temporary fan-out/fan-in workflow. Keep the
+number and focus of branches appropriate to the request; do not create roles
+just to make the workflow look larger.
+
+## Process
+
+1. Extract the decision or question, the relevant constraints, and the output
+   format from the user's request.
+2. Choose two to four independent analysis angles that cover different
+   evidence or reasoning needs. Give every branch the same core question and
+   only the context it needs. Do not let one branch depend on another branch's
+   unfinished answer.
+3. Run those branches in parallel. Each branch should return concise findings,
+   assumptions, and unresolved uncertainty rather than a polished final
+   answer.
+4. Pass the ordered branch results, the original request, and the explicit
+   decision criteria to a separate synthesis role. The synthesizer must
+   distinguish agreement, disagreement, and missing evidence; it must not
+   silently turn an unsupported claim into a fact.
+5. If the request requires a decision, have the synthesizer return a small
+   structured object with `recommendation`, `reasons`, and `uncertainties`.
+   Keep branch content as text unless a later control-flow decision genuinely
+   needs typed fields.
+6. Return the synthesis and the key evidence trail. If a branch fails, keep
+   that missing evidence explicit and follow the application's bounded failure
+   policy; do not silently treat it as support or retry indefinitely.
+
+## Compilation Rules
+
+- Express independent branches with `parallel([...])`; preserve the input
+  order when passing results to the synthesizer.
+- Use separate workflow-local Agent instances for each branch and for the
+  synthesizer. Do not ask the synthesizer to redo every branch from memory.
+- Pass the original question, constraints, and branch outputs explicitly as
+  inputs. A later stage must not depend on context that was only present in a
+  previous Agent's prompt.
+- `parallel` returns `None` for a failed independent branch. Handle that value
+  explicitly, and let the workflow or its caller decide whether a single,
+  bounded rerun is appropriate; do not rely on exception-catching syntax or
+  unbounded retries.
+- Keep the glue code small: create roles, pass JSON-compatible values, fan out,
+  fan in, and return the result. Delegate substantive analysis to Agents.
+- Use `tools=[]` for roles that only reason over supplied inputs. Select a
+  declared tool only for a branch whose task genuinely needs it, and keep
+  mutating tools out of parallel branches unless their independence is clear.
+- If a structured synthesis is requested, read the Agent result's explicit
+  `structured` object. Do not ask for JSON-looking text and parse it in the
+  workflow.

--- a/examples/dynamicworkflow/skills/skills/quality-loop/SKILL.md
+++ b/examples/dynamicworkflow/skills/skills/quality-loop/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: quality-loop
+description: Use this workflow recipe when a draft, plan, proposal, or other deliverable should be independently reviewed and revised until it satisfies explicit quality criteria.
+---
+
+# Bounded Quality Loop
+
+Turn the user's request into a temporary, request-specific workflow. Preserve
+the user's subject, constraints, and desired output rather than replacing them
+with a fixed example.
+
+## Process
+
+1. Create a writer role that produces the requested deliverable.
+2. Create a separate reviewer role. Give it the original request and the latest
+   draft. On later reviews, also give it the previous required feedback so it
+   can verify that the revision addressed those items. The writer must not
+   review its own work.
+3. Ask the reviewer for structured output using a small object schema:
+   - `approved`: required boolean
+   - `feedback`: required array containing only changes that must be made
+   - no additional properties
+4. If the user did not provide factual values such as dates, URLs, or contacts,
+   accept clear placeholders. Do not reject solely because those values are not
+   concrete, and do not ask the writer to invent them. Check that the
+   placeholders are clear and the required fields or steps are complete.
+5. Treat the result as approved only when `approved` is true and `feedback` is
+   empty. If the fields disagree, the feedback wins.
+6. If approved, stop immediately. If the reviewer rejects without actionable
+   feedback, stop as unapproved instead of asking for an empty revision.
+7. Otherwise, if another review is still available, pass the complete latest
+   draft and every feedback item to the writer, then review the revision again.
+8. Allow at most three reviews. After the third rejected review, stop without
+   creating an unreviewed revision. This keeps the remaining feedback aligned
+   with the returned draft.
+9. Return the latest reviewed draft, approval status, number of reviews, and any
+   remaining feedback.
+
+## Illustrative workflow shape
+
+Keep the loop explicit and bounded; the request supplies the actual content
+and criteria.
+
+```python
+review_schema = {
+    "type": "object",
+    "properties": {
+        "approved": {"type": "boolean"},
+        "feedback": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["approved", "feedback"],
+    "additionalProperties": False,
+}
+
+draft = await agent(request, instruction="Write the first draft.", tools=[])
+previous_feedback = []
+for attempt in range(1, 4):
+    review = await agent(
+        {
+            "request": request,
+            "draft": draft["text"],
+            "previous_feedback": previous_feedback,
+        },
+        instruction=(
+            "Review against the requested criteria. If the user did not provide "
+            "factual values such as dates, URLs, or contacts, clear placeholders "
+            "are acceptable: do not reject solely because they are not concrete "
+            "and do not ask the writer to invent facts. Check that placeholders "
+            "are clear and required fields or steps are complete."
+        ),
+        schema=review_schema,
+        tools=[],
+    )
+    decision = review["structured"]
+    approved = decision["approved"] and not decision["feedback"]
+    if approved or attempt == 3 or not decision["feedback"]:
+        break
+    previous_feedback = decision["feedback"]
+    draft = await agent(
+        {"draft": draft["text"], "feedback": previous_feedback},
+        instruction="Revise the draft using every required change.",
+        tools=[],
+    )
+return {
+    "draft": draft["text"],
+    "approved": approved,
+    "reviews": attempt,
+    "remaining_feedback": decision["feedback"],
+}
+```
+
+On the third rejected review, return the latest reviewed draft and feedback;
+do not create a fourth, unreviewed revision. Adapt the role instructions and
+inputs to the current request rather than copying this shape as a fixed task.
+
+## Review Discipline
+
+- Review only against the user's original request and its explicit quality
+  criteria. Do not invent a broader deliverable.
+- When the user did not provide real names, dates, URLs, contacts, tools, or
+  organization-specific facts, treat clear placeholders as acceptable. Do not
+  reject solely for missing concrete values or ask the writer to invent them;
+  check that the placeholders are clear and the required content is complete.
+- Return at most three material required changes per review. Do not reject for
+  optional polish.
+- After a revision, first verify the previous required changes. Do not move the
+  goalposts by adding unrelated requirements; add a new item only for a material
+  regression introduced by the revision.
+- Approve once the required criteria and previous feedback are satisfied.
+
+## Compilation Rules
+
+- Express the review cycle as an explicit bounded loop in one Dynamic Workflow.
+- Use separate workflow-local Agent instances for writer and reviewer.
+- Keep both roles tool-free unless the user's request clearly needs a capability
+  already allowed by the registered Agent template.
+- Use model-native structured output for the approval decision. Do not parse a
+  JSON-looking text response.
+- Read the branch fields from the Agent result's explicit `structured` object.
+- Pass task facts and feedback through Agent inputs. Do not rely on a role to
+  remember facts that were never provided to it.


### PR DESCRIPTION
Dynamic Workflow makes request-specific control flow explicit, while Skills preserve reusable process knowledge across tasks.

This adds an interactive example with a bounded quality loop and a prose-only fan-out recipe, plus documentation for progressive disclosure, child Agent boundaries, and Runner event streaming.

Tests: `go test` and `go vet` for the example and related Dynamic Workflow/Skill packages.