### PR TITLE
runner: deduplicate event persistence

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1308,6 +1308,7 @@ type eventLoopContext struct {
 	emittedAssistantChoiceSignatures   map[string]struct{}
 	visibleCompletionResponseIDs       map[string]struct{}
 	visibleCompletionChoiceSignatures  map[string]struct{}
+	persistedEvents                    eventPersistenceDeduper
 	sawTerminalError                   bool
 	streamFilter                       graph.StreamModeFilter
 	interruptedAssistants              map[string]*interruptedAssistantAccumulator
@@ -1325,6 +1326,73 @@ type eventLoopContext struct {
 	errorEventCount     int
 	emittedEventCount   int
 	detailSpanCount     int
+}
+
+// eventPersistenceDeduper coordinates event persistence within one runner
+// event loop. Successful IDs remain recorded for the loop lifetime, while a
+// failed append releases the ID so another delivery can retry it.
+type eventPersistenceDeduper struct {
+	mu      sync.Mutex
+	records map[string]*eventPersistenceRecord
+}
+
+type eventPersistenceRecord struct {
+	done      chan struct{}
+	persisted bool
+}
+
+func (d *eventPersistenceDeduper) start(
+	ctx context.Context,
+	eventID string,
+) (complete func(bool), proceed bool) {
+	if d == nil || eventID == "" {
+		return func(bool) {}, true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		d.mu.Lock()
+		if d.records == nil {
+			d.records = make(map[string]*eventPersistenceRecord)
+		}
+		record, ok := d.records[eventID]
+		if !ok {
+			record = &eventPersistenceRecord{done: make(chan struct{})}
+			d.records[eventID] = record
+			d.mu.Unlock()
+			return func(persisted bool) {
+				d.finish(eventID, record, persisted)
+			}, true
+		}
+		d.mu.Unlock()
+
+		select {
+		case <-record.done:
+			if record.persisted {
+				return nil, false
+			}
+		case <-ctx.Done():
+			return nil, false
+		}
+	}
+}
+
+func (d *eventPersistenceDeduper) finish(
+	eventID string,
+	record *eventPersistenceRecord,
+	persisted bool,
+) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.records[eventID] != record {
+		return
+	}
+	record.persisted = persisted
+	if !persisted {
+		delete(d.records, eventID)
+	}
+	close(record.done)
 }
 
 type interruptedAssistantAccumulator struct {
@@ -1551,12 +1619,13 @@ func (r *runner) processSingleAgentEvent(
 	shouldForwardEvent := loop.streamFilter.Allows(agentEvent)
 
 	// Append qualifying events to session and trigger summarization.
-	persisted := r.handleEventPersistence(
+	persisted := r.handleEventPersistenceOnce(
 		ctx,
 		loop.invocation,
 		loop.sess,
 		persistSession,
 		agentEvent,
+		&loop.persistedEvents,
 	)
 	if !excludeRootCompletion {
 		r.recordPersistedAssistantEvent(
@@ -2357,12 +2426,13 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 			) {
 			continue
 		}
-		if !r.handleEventPersistence(
+		if !r.handleEventPersistenceOnce(
 			persistCtx,
 			loop.invocation,
 			loop.sess,
 			persistSession,
 			interruptedEvent,
+			&loop.persistedEvents,
 		) {
 			continue
 		}
@@ -2577,6 +2647,50 @@ func (r *runner) handleFlushRequest(
 // handleEventPersistence appends qualifying events to the session and triggers
 // asynchronous summarization.
 func (r *runner) handleEventPersistence(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	sess *session.Session,
+	persistSession *session.Session,
+	agentEvent *event.Event,
+) bool {
+	return r.handleEventPersistenceCore(
+		ctx,
+		invocation,
+		sess,
+		persistSession,
+		agentEvent,
+	)
+}
+
+func (r *runner) handleEventPersistenceOnce(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	sess *session.Session,
+	persistSession *session.Session,
+	agentEvent *event.Event,
+	deduper *eventPersistenceDeduper,
+) (persisted bool) {
+	eventID := ""
+	if agentEvent != nil {
+		eventID = agentEvent.ID
+	}
+	complete, proceed := deduper.start(ctx, eventID)
+	if !proceed {
+		return false
+	}
+	defer func() {
+		complete(persisted)
+	}()
+	return r.handleEventPersistenceCore(
+		ctx,
+		invocation,
+		sess,
+		persistSession,
+		agentEvent,
+	)
+}
+
+func (r *runner) handleEventPersistenceCore(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	sess *session.Session,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1332,21 +1332,22 @@ type eventLoopContext struct {
 // event loop. Successful IDs remain recorded for the loop lifetime, while a
 // failed append releases the ID so another delivery can retry it.
 type eventPersistenceDeduper struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+	// records tracks in-flight and completed persistence by event ID. A nil
+	// record marks an event that was persisted successfully.
 	records map[string]*eventPersistenceRecord
 }
 
 type eventPersistenceRecord struct {
-	done      chan struct{}
-	persisted bool
+	done chan struct{}
 }
 
 func (d *eventPersistenceDeduper) start(
 	ctx context.Context,
 	eventID string,
-) (complete func(bool), proceed bool) {
+) (record *eventPersistenceRecord, proceed bool) {
 	if d == nil || eventID == "" {
-		return func(bool) {}, true
+		return nil, true
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -1358,20 +1359,23 @@ func (d *eventPersistenceDeduper) start(
 		}
 		record, ok := d.records[eventID]
 		if !ok {
-			record = &eventPersistenceRecord{done: make(chan struct{})}
+			record = &eventPersistenceRecord{}
 			d.records[eventID] = record
 			d.mu.Unlock()
-			return func(persisted bool) {
-				d.finish(eventID, record, persisted)
-			}, true
+			return record, true
 		}
+		if record == nil {
+			d.mu.Unlock()
+			return nil, false
+		}
+		if record.done == nil {
+			record.done = make(chan struct{})
+		}
+		done := record.done
 		d.mu.Unlock()
 
 		select {
-		case <-record.done:
-			if record.persisted {
-				return nil, false
-			}
+		case <-done:
 		case <-ctx.Done():
 			return nil, false
 		}
@@ -1388,11 +1392,14 @@ func (d *eventPersistenceDeduper) finish(
 	if d.records[eventID] != record {
 		return
 	}
-	record.persisted = persisted
-	if !persisted {
+	if persisted {
+		d.records[eventID] = nil
+	} else {
 		delete(d.records, eventID)
 	}
-	close(record.done)
+	if record.done != nil {
+		close(record.done)
+	}
 }
 
 type interruptedAssistantAccumulator struct {
@@ -2659,13 +2666,15 @@ func (r *runner) handleEventPersistenceOnce(
 	if agentEvent != nil {
 		eventID = agentEvent.ID
 	}
-	complete, proceed := deduper.start(ctx, eventID)
+	record, proceed := deduper.start(ctx, eventID)
 	if !proceed {
 		return false
 	}
-	defer func() {
-		complete(persisted)
-	}()
+	if record != nil {
+		defer func() {
+			deduper.finish(eventID, record, persisted)
+		}()
+	}
 	return r.handleEventPersistence(
 		ctx,
 		invocation,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2644,24 +2644,9 @@ func (r *runner) handleFlushRequest(
 	}
 }
 
-// handleEventPersistence appends qualifying events to the session and triggers
-// asynchronous summarization.
-func (r *runner) handleEventPersistence(
-	ctx context.Context,
-	invocation *agent.Invocation,
-	sess *session.Session,
-	persistSession *session.Session,
-	agentEvent *event.Event,
-) bool {
-	return r.handleEventPersistenceCore(
-		ctx,
-		invocation,
-		sess,
-		persistSession,
-		agentEvent,
-	)
-}
-
+// handleEventPersistenceOnce coordinates persistence by event ID. Successful
+// persistence is not repeated within the deduper's lifetime, while failed
+// attempts remain retryable.
 func (r *runner) handleEventPersistenceOnce(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -2681,7 +2666,7 @@ func (r *runner) handleEventPersistenceOnce(
 	defer func() {
 		complete(persisted)
 	}()
-	return r.handleEventPersistenceCore(
+	return r.handleEventPersistence(
 		ctx,
 		invocation,
 		sess,
@@ -2690,7 +2675,9 @@ func (r *runner) handleEventPersistenceOnce(
 	)
 }
 
-func (r *runner) handleEventPersistenceCore(
+// handleEventPersistence appends qualifying events to the session and triggers
+// asynchronous summarization.
+func (r *runner) handleEventPersistence(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	sess *session.Session,

--- a/runner/runner_persistence_dedupe_test.go
+++ b/runner/runner_persistence_dedupe_test.go
@@ -66,6 +66,22 @@ func TestRunnerDoesNotDeduplicateAcrossEventLoops(t *testing.T) {
 	require.Len(t, service.enqueueSummaryJobCalls, 2)
 }
 
+func TestRunnerReleasesCompletedEventPersistenceRecord(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	deduper.mu.Lock()
+	record, ok := deduper.records[evt.ID]
+	deduper.mu.Unlock()
+	require.True(t, ok)
+	require.Nil(t, record)
+}
+
 func TestRunnerDeduplicatesEventWhileAppendIsInFlight(t *testing.T) {
 	service := &blockingPersistenceSessionService{
 		mockSessionService: &mockSessionService{},

--- a/runner/runner_persistence_dedupe_test.go
+++ b/runner/runner_persistence_dedupe_test.go
@@ -1,0 +1,236 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestRunnerDeduplicatesEventPersistence(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	loop := &eventLoopContext{
+		sess:             sess,
+		invocation:       invocation,
+		processedEventCh: make(chan *event.Event, 2),
+		streamFilter:     graph.NewStreamModeFilter(false, nil),
+	}
+
+	require.NoError(t, r.processSingleAgentEvent(context.Background(), loop, evt))
+	require.NoError(t, r.processSingleAgentEvent(context.Background(), loop, evt))
+	require.Len(t, service.appendEventCalls, 1)
+	require.Len(t, service.enqueueSummaryJobCalls, 1)
+}
+
+func TestRunnerDoesNotDeduplicateAcrossEventLoops(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(),
+		invocation,
+		sess,
+		sess,
+		evt,
+		&eventPersistenceDeduper{},
+	))
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(),
+		invocation,
+		sess,
+		sess,
+		evt,
+		&eventPersistenceDeduper{},
+	))
+	require.Len(t, service.appendEventCalls, 2)
+	require.Len(t, service.enqueueSummaryJobCalls, 2)
+}
+
+func TestRunnerDeduplicatesEventWhileAppendIsInFlight(t *testing.T) {
+	service := &blockingPersistenceSessionService{
+		mockSessionService: &mockSessionService{},
+		appendStarted:      make(chan struct{}),
+		appendRelease:      make(chan struct{}),
+	}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+	firstDone := make(chan bool, 1)
+	secondDone := make(chan bool, 1)
+
+	go func() {
+		firstDone <- r.handleEventPersistenceOnce(
+			context.Background(), invocation, sess, sess, evt, deduper,
+		)
+	}()
+	select {
+	case <-service.appendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first append did not start")
+	}
+	go func() {
+		secondDone <- r.handleEventPersistenceOnce(
+			context.Background(), invocation, sess, sess, evt, deduper,
+		)
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("duplicate persistence completed before the in-flight append")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(service.appendRelease)
+
+	require.True(t, receivePersistenceResult(t, firstDone))
+	require.False(t, receivePersistenceResult(t, secondDone))
+	require.EqualValues(t, 1, service.appendCalls.Load())
+	require.EqualValues(t, 1, service.enqueueCalls.Load())
+}
+
+func TestRunnerRetriesEventAfterAppendFailure(t *testing.T) {
+	service := &failFirstPersistenceSessionService{
+		mockSessionService: &mockSessionService{},
+	}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+
+	require.False(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.EqualValues(t, 2, service.appendCalls.Load())
+	require.EqualValues(t, 1, service.enqueueCalls.Load())
+}
+
+func TestRunnerDoesNotDeduplicateEmptyEventID(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	evt.ID = ""
+	deduper := &eventPersistenceDeduper{}
+
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.Len(t, service.appendEventCalls, 2)
+	require.Len(t, service.enqueueSummaryJobCalls, 2)
+}
+
+func newPersistenceDedupTestInput() (
+	*session.Session,
+	*agent.Invocation,
+	*event.Event,
+) {
+	sess := session.NewSession("app", "user", "session")
+	invocation := agent.NewInvocation(agent.WithInvocationSession(sess))
+	evt := event.NewResponseEvent(
+		invocation.InvocationID,
+		"assistant",
+		&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("answer"),
+			}},
+		},
+	)
+	evt.ID = "stable-event-id"
+	return sess, invocation, evt
+}
+
+func receivePersistenceResult(t *testing.T, result <-chan bool) bool {
+	t.Helper()
+	select {
+	case persisted := <-result:
+		return persisted
+	case <-time.After(time.Second):
+		t.Fatal("event persistence did not complete")
+		return false
+	}
+}
+
+type blockingPersistenceSessionService struct {
+	*mockSessionService
+	appendStarted chan struct{}
+	appendRelease chan struct{}
+	startOnce     sync.Once
+	appendCalls   atomic.Int32
+	enqueueCalls  atomic.Int32
+}
+
+func (s *blockingPersistenceSessionService) AppendEvent(
+	context.Context,
+	*session.Session,
+	*event.Event,
+	...session.Option,
+) error {
+	s.appendCalls.Add(1)
+	s.startOnce.Do(func() {
+		close(s.appendStarted)
+	})
+	<-s.appendRelease
+	return nil
+}
+
+func (s *blockingPersistenceSessionService) EnqueueSummaryJob(
+	context.Context,
+	*session.Session,
+	string,
+	bool,
+) error {
+	s.enqueueCalls.Add(1)
+	return nil
+}
+
+type failFirstPersistenceSessionService struct {
+	*mockSessionService
+	appendCalls  atomic.Int32
+	enqueueCalls atomic.Int32
+}
+
+func (s *failFirstPersistenceSessionService) AppendEvent(
+	context.Context,
+	*session.Session,
+	*event.Event,
+	...session.Option,
+) error {
+	if s.appendCalls.Add(1) == 1 {
+		return errors.New("append failed")
+	}
+	return nil
+}
+
+func (s *failFirstPersistenceSessionService) EnqueueSummaryJob(
+	context.Context,
+	*session.Session,
+	string,
+	bool,
+) error {
+	s.enqueueCalls.Add(1)
+	return nil
+}

--- a/runner/runner_persistence_dedupe_test.go
+++ b/runner/runner_persistence_dedupe_test.go
@@ -77,6 +77,13 @@ func TestRunnerDeduplicatesEventWhileAppendIsInFlight(t *testing.T) {
 	deduper := &eventPersistenceDeduper{}
 	firstDone := make(chan bool, 1)
 	secondDone := make(chan bool, 1)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(service.appendRelease)
+		})
+	}
+	defer release()
 
 	go func() {
 		firstDone <- r.handleEventPersistenceOnce(
@@ -99,10 +106,55 @@ func TestRunnerDeduplicatesEventWhileAppendIsInFlight(t *testing.T) {
 		t.Fatal("duplicate persistence completed before the in-flight append")
 	case <-time.After(50 * time.Millisecond):
 	}
-	close(service.appendRelease)
+	release()
 
 	require.True(t, receivePersistenceResult(t, firstDone))
 	require.False(t, receivePersistenceResult(t, secondDone))
+	require.EqualValues(t, 1, service.appendCalls.Load())
+	require.EqualValues(t, 1, service.enqueueCalls.Load())
+}
+
+func TestRunnerDuplicateWaiterHonorsCancellation(t *testing.T) {
+	service := &blockingPersistenceSessionService{
+		mockSessionService: &mockSessionService{},
+		appendStarted:      make(chan struct{}),
+		appendRelease:      make(chan struct{}),
+	}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+	ownerDone := make(chan bool, 1)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(service.appendRelease)
+		})
+	}
+	defer release()
+
+	go func() {
+		ownerDone <- r.handleEventPersistenceOnce(
+			context.Background(), invocation, sess, sess, evt, deduper,
+		)
+	}()
+	select {
+	case <-service.appendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("owner append did not start")
+	}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	duplicateDone := make(chan bool, 1)
+	go func() {
+		duplicateDone <- r.handleEventPersistenceOnce(
+			canceledCtx, invocation, sess, sess, evt, deduper,
+		)
+	}()
+
+	require.False(t, receivePersistenceResult(t, duplicateDone))
+	require.EqualValues(t, 1, service.appendCalls.Load())
+	release()
+	require.True(t, receivePersistenceResult(t, ownerDone))
 	require.EqualValues(t, 1, service.appendCalls.Load())
 	require.EqualValues(t, 1, service.enqueueCalls.Load())
 }


### PR DESCRIPTION
## What changed

- deduplicate non-empty event IDs within a runner event loop before session persistence
- retain successful IDs for the event-loop lifetime while allowing a failed append to be retried
- cover sequential duplicates, in-flight duplicates, append failures, empty IDs, and cross-run compatibility

## Why

#2455 fixed the canceled-summary-result part of #2453, but duplicate event deliveries could still append the same event twice and enqueue two summary jobs. The deduplication state is scoped to one runner event loop so duplicate deliveries are coalesced without changing session-service APIs or established cross-run replay behavior.

## Testing

- `go test ./... -count=1`
- `go build ./...`
- `cd test && go test ./... -count=1`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m`
- targeted runner tests with `-race -count=10`

## Notes for reviewers

Only persistence and automatic-summary triggering are deduplicated. Event forwarding and completion signaling remain unchanged. Events with an empty ID preserve their previous behavior, and separate runner event loops remain independent.

Fixes #2453
