### PR TITLE
internal/flow/llmflow: avoid state clones in streaming telemetry

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -717,7 +717,7 @@ func (f *Flow) runOneStep(
 	if invocation.EndInvocation {
 		return lastEvent, nil
 	}
-	observabilityInvocation := invocationViewForModel(invocation, callModel)
+	observabilityInvocation := observabilityInvocationForModel(invocation, callModel)
 	var span oteltrace.Span
 	var modelName string
 	if callModel != nil {
@@ -1071,10 +1071,7 @@ func (p *streamingResponseProcessor) updateMetricsState() {
 		return
 	}
 	p.tracker.SetInvocationState(
-		metricsInvocationForCurrent(
-			p.currentInvocation,
-			p.observabilityInvocation,
-		),
+		p.currentInvocation,
 		p.timingInfo,
 	)
 }
@@ -1343,24 +1340,18 @@ func invocationFromContextOrDefault(
 	return invocation
 }
 
-func invocationViewForModel(
+func observabilityInvocationForModel(
 	invocation *agent.Invocation,
 	callModel model.Model,
 ) *agent.Invocation {
 	if invocation == nil {
 		return nil
 	}
-	return invocation.View(agent.WithInvocationModel(callModel))
-}
-
-func metricsInvocationForCurrent(
-	current *agent.Invocation,
-	base *agent.Invocation,
-) *agent.Invocation {
-	if base == nil {
-		return current
-	}
-	return observabilityInvocationForCurrent(current, base)
+	return newObservabilityInvocation(
+		invocation,
+		invocation.Session,
+		callModel,
+	)
 }
 
 func observabilityInvocationForCurrent(
@@ -1370,13 +1361,27 @@ func observabilityInvocationForCurrent(
 	if base == nil {
 		return current
 	}
-	if current == nil || current.Session == nil {
+	if current == nil || current.Session == nil ||
+		current.Session == base.Session {
 		return base
 	}
-	return base.View(
-		agent.WithInvocationSession(current.Session),
-		agent.WithInvocationModel(base.Model),
-	)
+	return newObservabilityInvocation(base, current.Session, base.Model)
+}
+
+// newObservabilityInvocation intentionally excludes invocation state: metrics
+// and tracing consume only identity, session, and model metadata, while state
+// can contain large model-visible history snapshots.
+func newObservabilityInvocation(
+	base *agent.Invocation,
+	sess *session.Session,
+	callModel model.Model,
+) *agent.Invocation {
+	return &agent.Invocation{
+		AgentName:    base.AgentName,
+		InvocationID: base.InvocationID,
+		Session:      sess,
+		Model:        callModel,
+	}
 }
 
 func trackModelResponseTelemetry(

--- a/internal/flow/llmflow/llmflow_bench_test.go
+++ b/internal/flow/llmflow/llmflow_bench_test.go
@@ -15,7 +15,11 @@ import (
 	"testing"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 var (
@@ -116,6 +120,67 @@ func BenchmarkGenerateContentSeq(b *testing.B) {
 					b.Fatal(err)
 				}
 				benchCountSink, benchRespSink = consumeSeq(seq)
+			}
+		})
+	}
+}
+
+func BenchmarkStreamingResponseProcessorUpdateMetricsState(b *testing.B) {
+	for _, itemCount := range []int{16, 256} {
+		b.Run(fmt.Sprintf("SummaryItems/%d", itemCount), func(b *testing.B) {
+			base := &agent.Invocation{
+				InvocationID: "invocation-id",
+				AgentName:    "bench-agent",
+				Session: &session.Session{
+					ID:      "session-id",
+					UserID:  "user-id",
+					AppName: "app-name",
+				},
+			}
+			items := make([]summaryview.Item, itemCount)
+			for i := range items {
+				items[i] = summaryview.Item{
+					Message: model.Message{
+						Role:    model.RoleUser,
+						Content: "benchmark model-visible history",
+					},
+					EffectiveEvent: event.Event{
+						ID: fmt.Sprintf("event-%d", i),
+						StateDelta: map[string][]byte{
+							"benchmark": make([]byte, 1024),
+						},
+					},
+					RequestIndex: i,
+				}
+			}
+			summaryview.AttachProjection(base, &summaryview.View{
+				SessionID: "session-id",
+				Items:     items,
+			})
+			current := &agent.Invocation{
+				Session: &session.Session{
+					ID:      "updated-session-id",
+					UserID:  "updated-user-id",
+					AppName: "updated-app-name",
+				},
+			}
+			processor := &streamingResponseProcessor{
+				currentInvocation:       current,
+				observabilityInvocation: base,
+				tracker: itelemetry.NewChatMetricsTracker(
+					context.Background(),
+					base,
+					&model.Request{},
+					nil,
+					nil,
+					nil,
+				),
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				processor.updateMetricsState()
 			}
 		})
 	}

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -1174,6 +1174,53 @@ func TestProcessStreamingResponses_DisableResponseUsageTrackingStillRecordsMetri
 	require.NotEmpty(t, rm.ScopeMetrics)
 }
 
+func TestObservabilityInvocationViewsExcludeState(t *testing.T) {
+	const stateKey = "benchmark:large-state"
+	baseModel := &mockModel{}
+	selectedModel := &mockIterModel{}
+	baseSession := &session.Session{
+		ID:      "session-base",
+		UserID:  "user-base",
+		AppName: "app-base",
+	}
+	base := agent.NewInvocation(
+		agent.WithInvocationID("invocation-base"),
+		agent.WithInvocationModel(baseModel),
+		agent.WithInvocationSession(baseSession),
+	)
+	base.AgentName = "agent-base"
+	base.SetState(stateKey, make([]byte, 1024))
+
+	callView := observabilityInvocationForModel(base, selectedModel)
+	require.NotSame(t, base, callView)
+	require.Equal(t, base.InvocationID, callView.InvocationID)
+	require.Equal(t, base.AgentName, callView.AgentName)
+	require.Same(t, baseSession, callView.Session)
+	require.Same(t, selectedModel, callView.Model)
+	_, ok := agent.GetStateValue[[]byte](callView, stateKey)
+	require.False(t, ok)
+
+	require.Same(t, callView, observabilityInvocationForCurrent(base, callView))
+	updatedSession := &session.Session{
+		ID:      "session-updated",
+		UserID:  "user-updated",
+		AppName: "app-updated",
+	}
+	updated := agent.NewInvocation(
+		agent.WithInvocationID("invocation-updated"),
+		agent.WithInvocationModel(baseModel),
+		agent.WithInvocationSession(updatedSession),
+	)
+	updated.AgentName = "agent-updated"
+	updatedView := observabilityInvocationForCurrent(updated, callView)
+	require.Equal(t, base.InvocationID, updatedView.InvocationID)
+	require.Equal(t, base.AgentName, updatedView.AgentName)
+	require.Same(t, updatedSession, updatedView.Session)
+	require.Same(t, selectedModel, updatedView.Model)
+	_, ok = agent.GetStateValue[[]byte](updatedView, stateKey)
+	require.False(t, ok)
+}
+
 func TestProcessStreamingResponses_UsesStableInvocationForMetricsMetadata(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))

--- a/internal/telemetry/metric_chat.go
+++ b/internal/telemetry/metric_chat.go
@@ -309,15 +309,18 @@ func mergeMetricsSessionView(
 	if current == nil {
 		return previous
 	}
-	sessionView := &session.Session{
-		ID:      firstNonEmptyString(previous.ID, current.ID),
-		UserID:  firstNonEmptyString(previous.UserID, current.UserID),
-		AppName: firstNonEmptyString(previous.AppName, current.AppName),
-	}
-	if sameMetricsSessionView(previous, sessionView) {
+	id := firstNonEmptyString(previous.ID, current.ID)
+	userID := firstNonEmptyString(previous.UserID, current.UserID)
+	appName := firstNonEmptyString(previous.AppName, current.AppName)
+	if previous.ID == id && previous.UserID == userID &&
+		previous.AppName == appName {
 		return previous
 	}
-	return sessionView
+	return &session.Session{
+		ID:      id,
+		UserID:  userID,
+		AppName: appName,
+	}
 }
 
 func mergeInvocationForMetrics(


### PR DESCRIPTION
## What changed

Streaming metrics now refresh from the current invocation without constructing a full invocation view for every response chunk. Model-call observability snapshots retain only the identity, session, and selected-model metadata consumed by metrics and tracing, and unchanged metric session metadata is reused without allocation.

A regression benchmark models large `summaryview` state and verifies that metric refresh cost remains independent of invocation state size.

## Why

Streaming response processing refreshes metric state before and after callbacks for each chunk. The previous observability merge used `Invocation.View`, which recursively cloned all invocation state even though telemetry reads only a few metadata fields. Large model-visible history snapshots therefore made CPU time and allocations grow with both state size and chunk count.

The change preserves stable per-call model and invocation metadata, keeps the existing sparse metadata merge behavior, and removes unused state from the telemetry hot path.

## Testing

Benchmark medians from five runs on darwin/arm64:

| Summary items | Before | After |
| --- | --- | --- |
| 16 | 369,260 ns/op, 56,624 B/op, 175 allocs/op | 12.02 ns/op, 0 B/op, 0 allocs/op |
| 256 | 5,930,695 ns/op, 874,161 B/op, 2,583 allocs/op | 12.16 ns/op, 0 B/op, 0 allocs/op |

Validation performed:

- `go test ./internal/flow/llmflow ./internal/telemetry -count=1`
- `go test ./...`
- `go build ./...`
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m`
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`
- `.github/scripts/run-go-tests.sh` exercised all library modules; affected modules passed, while unrelated macOS sandbox integration tests could not launch their sandboxed Python guests in this host environment

## Notes for reviewers

There is no public API change. Invocation state remains available on the execution invocation; it is intentionally excluded only from internal telemetry snapshots that do not consume it.
