### PR TITLE
tool/agent: support dynamic model profiles

### DIFF
--- a/docs/mkdocs/en/blog/multiagent-boundaries.md
+++ b/docs/mkdocs/en/blog/multiagent-boundaries.md
@@ -63,7 +63,7 @@ The table below is a boundary index, not an API reference. It shows where the re
 | --- | --- | --- | --- |
 | Single LLMAgent | One Agent advances with its own instruction and tool surface | Controlled tools and simple flow | Tool surface, context, permission, model, or runtime boundary grows |
 | AgentTool | A fixed child Agent runs as a synchronous tool; history is isolated by default; result returns as tool result | Search, review, analysis, small specialist work | Parent history, persistent child history, result trimming, inner stream forwarding, skip outer summarization |
-| Dynamic AgentTool | One `dynamic_agent` entrypoint creates a short-lived child Agent per call; isolated by default; no stable child history | Per-task narrowing of instruction, tools, or skills | Capability bounds, providers, exposed fields, timeout, response mode |
+| Dynamic AgentTool | One `dynamic_agent` entrypoint creates a short-lived child Agent per call; isolated by default; no stable child history | Per-task narrowing of instruction, tools, skills, or a host-authorized model profile | Capability bounds, providers, model profiles, exposed fields, timeout, response mode |
 | `transfer_to_agent` | `WithSubAgents` exposes transfer; the target Agent takes over the current invocation; the source Agent ends the turn by default | The specialist should continue answering the current turn | Default handoff message, whether to end, message projection, cross-turn owner |
 | Coordinator Team | Members are wrapped as tools; results return to the coordinator | A coordinator calls multiple members in one turn | Member history, inner events, member text visibility, coordinator summarization |
 | Swarm | Entry member starts; members hand off via transfer; the next user turn starts from entry by default | Handoff chains inside the current turn | Cross-request transfer, independent member history, custom handoff input |
@@ -101,9 +101,9 @@ Read common options by output path:
 
 ### 5.2 Dynamic AgentTool: Per-Call Capability Assembly
 
-Dynamic AgentTool is for tasks where each call needs a narrower instruction, tool set, or skill set. It exposes a default entrypoint named `dynamic_agent` and creates one short-lived child Agent for the current tool call.
+Dynamic AgentTool is for tasks where each call needs a narrower instruction, tool set, skill set, or host-authorized model profile. It exposes a default entrypoint named `dynamic_agent` and creates one short-lived child Agent for the current tool call.
 
-"Dynamic" does not mean the model can create arbitrary Agents. Code still defines the maximum boundary. The boundary can come from the parent invocation's effective capability surface, or from explicit options such as `WithCapabilityTools`, `WithCapabilityProvider`, `WithCapabilitySurfaceProvider`, and `WithCapabilitySkills`. The model can only select a subset within that boundary. It cannot choose arbitrary models, executors, or remote targets.
+"Dynamic" does not mean the model can create arbitrary Agents. Code still defines the maximum boundary. The boundary can come from the parent invocation's effective capability surface, or from explicit options such as `WithCapabilityTools`, `WithCapabilityProvider`, `WithCapabilitySurfaceProvider`, and `WithCapabilitySkills`. The model can only select a subset within that boundary. It cannot choose arbitrary models, executors, or remote targets; when `WithAgentModelProfile` is configured, it may select only one of those host-authorized aliases for the current child call.
 
 This solves capability-surface narrowing, not long-term memory. `NewDynamicTool` is short-lived, and `WithPersistentHistory*` is ignored. If the requirement is "the same child should keep editing the same artifact next time," prefer a fixed AgentTool with persistent history, or put artifact state in an external object.
 

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1816,11 +1816,12 @@ including its model, tools, skills, permissions, and runtime policy, then expose
 that Agent as a tool to the parent.
 
 Use `agenttool.NewDynamicTool()` when the application cannot predefine every
-specialist role, and the parent Agent should choose a tool subset or per-call
-instruction for each task. It exposes a model-facing tool named `dynamic_agent`
-by default. Calling this tool does not create arbitrary Go objects and does not
-select one pre-registered Agent by name; it runs one short-lived child Agent
-invocation within a boundary defined by application code.
+specialist role, and the parent Agent should choose a tool subset, per-call
+instruction, or an explicitly registered model profile for each task. It
+exposes a model-facing tool named `dynamic_agent` by default. Calling this tool
+does not create arbitrary Go objects and does not select one pre-registered
+Agent by name; it runs one short-lived child Agent invocation within a boundary
+defined by application code.
 
 Typical setup:
 
@@ -1860,6 +1861,9 @@ The default model-facing arguments are:
   child invocation.
 - `tools`: Optional exact tool names allowed for this invocation. An empty array
   means the child receives no user tools.
+- `model`: Present only when the host registers model profiles. It selects one
+  allowlisted profile for this invocation; omission keeps the existing
+  base/template model behavior.
 
 If the default parent-derived boundary is not the right business boundary, set a
 template Agent or explicit maximum capability surface in code:
@@ -1872,8 +1876,8 @@ workerTemplate := llmagent.New(
 )
 
 dynamicAgent := agenttool.NewDynamicTool(
-    // Optional: define the child Agent execution boundary: model, executor,
-    // callbacks, permission policy, and similar runtime settings.
+    // Optional: define the child Agent execution boundary: default model,
+    // executor, callbacks, permission policy, and similar runtime settings.
     agenttool.WithTemplateAgent(workerTemplate),
     // Optional: restrict the maximum tool set the model can choose from.
     agenttool.WithCapabilityTools([]tool.Tool{readFileTool, searchCodeTool}),
@@ -1881,9 +1885,55 @@ dynamicAgent := agenttool.NewDynamicTool(
 ```
 
 `WithTemplateAgent` is a code-side boundary, not a model parameter. The model
-cannot use `dynamic_agent` to choose arbitrary Agents, models, or executors. It
-can only fill `request`, optionally set `instruction`, and optionally narrow the
-tools/skills subset inside the boundary configured by the developer.
+cannot use `dynamic_agent` to choose arbitrary Agents, provider model names, or
+executors. It can only fill `request`, optionally set `instruction`, optionally
+narrow the tools/skills subset, and select an explicitly registered model
+profile inside the boundary configured by the developer.
+
+To let the parent choose among host-approved model roles, register stable
+aliases with descriptions:
+
+```go
+dynamicAgent := agenttool.NewDynamicTool(
+    agenttool.WithTemplateAgent(workerTemplate),
+    agenttool.WithAgentModelProfile(
+        "fast",
+        "Low-latency model for extraction and first drafts.",
+        fastModel,
+    ),
+    agenttool.WithAgentModelProfile(
+        "deep",
+        "Higher-capability model for synthesis and strict review.",
+        deepModel,
+    ),
+)
+```
+
+The option adds an enum-backed `model` field to the tool schema. A call may use
+`"model": "fast"` or `"model": "deep"`; an unknown alias fails before the
+child runs. The selected model is attached through an invocation-scoped surface
+patch, so it does not mutate the shared template and concurrent calls may choose
+different profiles safely. Omission keeps the template default when a template
+is configured, or the parent's effective model selection when it is not.
+Profile names and descriptions are visible to the parent model; do not put
+credentials or private provider configuration in them.
+
+An explicit profile selection starts a new model request boundary. It does not
+inherit the parent's `ModelContextWindow`, `ModelRequestExtraFields`, or
+`ModelRequestHeaders`; configure provider-specific settings on the registered
+model instead. Calls that omit `model` retain the existing inheritance behavior.
+
+`llmagent.WithModels` remains useful for host-controlled model switching, but
+its registry is not automatically exposed through `dynamic_agent`. This is
+intentional: model-visible aliases need task-oriented descriptions and an
+explicit allowlist. A profile may point to a model already present in that
+registry, but the two configurations have different boundaries. With a template,
+the existing template boundary still prevents parent RunOptions model overrides
+from leaking into the child; set its default in host code or register profiles.
+Without a template, omitting `model` preserves the inherited RunOptions behavior.
+Profile selection is consumed by LLMAgent. Other Agent implementations retain
+their own model semantics, so use an LLMAgent base or template when model routing
+is required.
 
 Common options:
 
@@ -1891,8 +1941,12 @@ Common options:
   `NewDynamicTool`; regular `NewTool(agent)` always uses the wrapped Agent's
   `Info().Name`.
 - `WithTemplateAgent(agent)`: set the dynamic child Agent template, commonly used
-  to fix the model, executor, callbacks, permission policy, and other runtime
-  boundaries.
+  to fix the default model, executor, callbacks, permission policy, and other
+  runtime boundaries.
+- `WithAgentModelProfile(name, description, model)`: register one
+  host-authorized model alias that may override the model for one child call.
+  Repeat the option to add profiles. No `model` field is exposed when no profile
+  is registered.
 - `WithCapabilityTools(tools)`: set the maximum tool surface the model may choose
   from. When omitted, it is derived from the parent Agent's effective user tools
   for the current run. When set, the tool names are enumerated in the `tools`
@@ -1929,7 +1983,7 @@ Dynamic AgentTool has a different boundary from the other multi-Agent mechanisms
 | --- | --- | --- | --- |
 | `agenttool.NewTool(agent)` | one fixed tool entrypoint | per tool call | returns a tool result to the parent Agent |
 | `transfer_to_agent` | one registered sub-agent | target Agent continues the current turn | hands off control |
-| `agenttool.NewDynamicTool()` | `request`, `instruction`, and a tools/skills subset for this call | per tool call | returns a tool result to the parent Agent |
+| `agenttool.NewDynamicTool()` | `request`, `instruction`, a tools/skills subset, and optionally one registered model profile for this call | per tool call | returns a tool result to the parent Agent |
 
 If the same specialist Agent is exposed through both `WithSubAgents` and
 `agenttool.NewTool(agent)`, the parent model sees two different paths:

--- a/docs/mkdocs/zh/blog/multiagent-boundaries.md
+++ b/docs/mkdocs/zh/blog/multiagent-boundaries.md
@@ -63,7 +63,7 @@ Multi-Agent 真正变成工程问题，通常是因为单 Agent 的某条边界�
 | --- | --- | --- | --- |
 | 单 LLMAgent | 一个 Agent 用自己的 instruction 和工具面推进 | 工具面可控、链路不复杂 | 工具面过大、上下文污染、权限、模型或环境不同 |
 | AgentTool | 固定子 Agent 作为同步 tool；默认隔离历史，结果以 tool result 回父 Agent | 查一下、审一下、分析一段内容 | 继承父历史、稳定子历史、裁剪结果、转发内部 stream、跳过外层总结 |
-| Dynamic AgentTool | 一个 `dynamic_agent` 入口；按次创建短生命周期子 Agent；默认隔离，不保留稳定子历史 | 子任务需要临时收窄 instruction、tools 或 skills | 固定能力上限、能力 provider、字段暴露、超时、结果模式 |
+| Dynamic AgentTool | 一个 `dynamic_agent` 入口；按次创建短生命周期子 Agent；默认隔离，不保留稳定子历史 | 子任务需要临时收窄 instruction、tools、skills 或宿主授权的模型 profile | 固定能力上限、能力 provider、模型 profile、字段暴露、超时、结果模式 |
 | `transfer_to_agent` | `WithSubAgents` 暴露 transfer；目标 Agent 接管当前 invocation；默认原 Agent 结束当前轮 | 当前轮应该由专家继续回答 | 默认交接消息、是否结束、消息投影、跨轮 owner |
 | Coordinator Team | 成员被包装成 member tools；结果回 coordinator | 协调者调用多个成员完成当前轮 | 成员历史、内部事件、成员正文展示、coordinator 是否总结 |
 | Swarm | entry member 开始；成员间 transfer 接力；默认下一轮仍从 entry 开始 | 当前轮内多专家接力 | 跨轮接管、独立成员历史、自定义 handoff 输入 |
@@ -101,9 +101,9 @@ AgentTool 适合“我需要一个专家结果，然后主 Agent 继续判断”
 
 ### 5.2 Dynamic AgentTool：按次装配能力
 
-Dynamic AgentTool 适合“每次子任务都要临时收窄 instruction、tools 或 skills”。它暴露一个默认名为 `dynamic_agent` 的入口，运行时按本次 tool call 创建短生命周期子 Agent。
+Dynamic AgentTool 适合“每次子任务都要临时收窄 instruction、tools、skills 或宿主授权的模型 profile”。它暴露一个默认名为 `dynamic_agent` 的入口，运行时按本次 tool call 创建短生命周期子 Agent。
 
-“动态”不是让模型任意创建 Agent。代码仍然定义能力上限：可以来自父 invocation 的有效能力面，也可以通过 `WithCapabilityTools`、`WithCapabilityProvider`、`WithCapabilitySurfaceProvider`、`WithCapabilitySkills` 等方式指定。模型只能在这个边界内选择子集，不能任意选择模型、executor 或远程目标。
+“动态”不是让模型任意创建 Agent。代码仍然定义能力上限：可以来自父 invocation 的有效能力面，也可以通过 `WithCapabilityTools`、`WithCapabilityProvider`、`WithCapabilitySurfaceProvider`、`WithCapabilitySkills` 等方式指定。模型只能在这个边界内选择子集，不能任意选择模型、executor 或远程目标；配置 `WithAgentModelProfile` 后，也只能为当前子调用选择宿主授权的别名。
 
 它解决的是能力面问题，不解决长期记忆问题。`NewDynamicTool` 设计上是短生命周期，`WithPersistentHistory*` 会被忽略。如果需求是“同一个子 Agent 下次继续改同一份产物”，优先考虑固定 AgentTool 的 persistent history，或者把产物状态外置成 artifact / 数据库对象。
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1710,9 +1710,10 @@ child := agenttool.NewTool(
 Agent、模型、工具、skills、权限等配置好，再把它包装成父 Agent 的一个工具。
 
 当你的应用无法提前穷举所有专家角色，而是希望父 Agent 在每次调用时按任务临时选择
-工具子集或指定本次执行指令，可以使用 `agenttool.NewDynamicTool()`。它会向模型暴露
-一个默认名为 `dynamic_agent` 的工具；模型调用它时，不是在创建任意 Go 对象，也不是
-选择某个已注册 Agent，而是在代码定义的边界内运行一次短生命周期的子 Agent invocation。
+工具子集、指定本次执行指令，或选择一个显式注册的模型 profile，可以使用
+`agenttool.NewDynamicTool()`。它会向模型暴露一个默认名为 `dynamic_agent` 的工具；模型
+调用它时，不是在创建任意 Go 对象，也不是选择某个已注册 Agent，而是在代码定义的边界
+内运行一次短生命周期的子 Agent invocation。
 
 典型接入方式如下：
 
@@ -1750,6 +1751,8 @@ parent := llmagent.New(
 - `instruction`：可选，作为本次子 Agent invocation 的角色、约束或执行指令。
 - `tools`：可选，精确指定本次允许子 Agent 使用哪些工具名。传空数组表示本次不授予
   任何业务工具。
+- `model`：仅在宿主注册了模型 profile 时出现，用于给本次 invocation 选择一个白名单
+  profile；省略时保持原有的 base/template 模型行为。
 
 如果默认从父 Agent 派生能力面不符合业务边界，可以在代码侧显式设置模板 Agent 或最大
 能力面：
@@ -1762,7 +1765,7 @@ workerTemplate := llmagent.New(
 )
 
 dynamicAgent := agenttool.NewDynamicTool(
-    // 可选：定义子 Agent 的模型、executor、callbacks、权限策略等执行边界。
+    // 可选：定义子 Agent 的默认模型、executor、callbacks、权限策略等执行边界。
     agenttool.WithTemplateAgent(workerTemplate),
     // 可选：限制模型最多只能从这些工具里选择。
     agenttool.WithCapabilityTools([]tool.Tool{readFileTool, searchCodeTool}),
@@ -1770,15 +1773,54 @@ dynamicAgent := agenttool.NewDynamicTool(
 ```
 
 `WithTemplateAgent` 是代码侧边界，不是模型参数。模型不能通过 `dynamic_agent` 选择任意
-Agent、模型或 executor；它只能在开发者配置好的边界内，为这一次调用填写 `request`、
-`instruction`，并按需选择 tools/skills 子集。
+Agent、provider 模型名或 executor；它只能在开发者配置好的边界内，为这一次调用填写
+`request`、`instruction`，按需选择 tools/skills 子集，并选择显式注册的模型 profile。
+
+如果希望父 Agent 在宿主批准的模型角色之间选择，可以注册带说明的稳定别名：
+
+```go
+dynamicAgent := agenttool.NewDynamicTool(
+    agenttool.WithTemplateAgent(workerTemplate),
+    agenttool.WithAgentModelProfile(
+        "fast",
+        "适合抽取信息和快速起草的低延迟模型。",
+        fastModel,
+    ),
+    agenttool.WithAgentModelProfile(
+        "deep",
+        "适合综合分析和严格评审的高能力模型。",
+        deepModel,
+    ),
+)
+```
+
+注册后，工具 schema 会增加带 enum 的 `model` 字段。调用可以传
+`"model": "fast"` 或 `"model": "deep"`；未知别名会在子 Agent 运行前失败。
+所选模型通过 invocation-scoped surface patch 挂载，不会修改共享模板，因此并发调用可以
+安全地选择不同 profile。省略 `model` 时：配置了模板就继续使用模板默认模型；未配置模板
+则继续使用父 Agent 当前有效的模型选择。
+profile 名称和说明会暴露给父模型，请勿在其中放入凭据或私有 provider 配置。
+
+显式选择 profile 会形成新的模型请求边界，不会继承父请求的 `ModelContextWindow`、
+`ModelRequestExtraFields` 或 `ModelRequestHeaders`；provider 专属配置应放在注册的模型实例
+上。省略 `model` 的调用继续保持原有继承行为。
+
+`llmagent.WithModels` 仍可用于宿主控制的模型切换，但其中的 registry 不会自动通过
+`dynamic_agent` 暴露。这是有意的：模型可见的别名需要面向任务的说明和显式白名单。
+profile 可以指向 registry 中已经存在的同一个模型实例，但两者的能力边界不同。配置模板
+时，原有模板边界仍会阻止父 RunOptions 的模型覆盖泄漏到子 Agent；应由宿主设置模板默认
+模型，或显式注册 profile。未配置模板时，省略 `model` 会保留继承的 RunOptions 行为。
+profile 选择由 LLMAgent 消费；其他 Agent 实现保留自己的模型语义，因此需要模型路由时应
+使用 LLMAgent 作为 base 或 template。
 
 常用选项：
 
 - `WithName(name)`：修改模型可见工具名。仅对 `NewDynamicTool` 生效；普通
   `NewTool(agent)` 的工具名始终来自被包装 Agent 的 `Info().Name`。
-- `WithTemplateAgent(agent)`：设置动态子 Agent 的模板，常用于固定模型、executor、
+- `WithTemplateAgent(agent)`：设置动态子 Agent 的模板，常用于固定默认模型、executor、
   callbacks、权限策略等执行边界。
+- `WithAgentModelProfile(name, description, model)`：注册一个宿主授权的模型别名，可对
+  单次子 Agent 调用覆盖模型；可重复添加。未注册任何 profile 时不会暴露 `model` 字段。
 - `WithCapabilityTools(tools)`：设置模型可选择的最大工具集合。未设置时默认从父 Agent
   本轮有效业务工具派生。显式设置后，这些工具名会被枚举进 `tools` 字段的 schema，模型从
   已知集合中选择而非猜测字符串（父派生工具面与 `WithCapabilityProvider` 在每次调用时
@@ -1807,7 +1849,7 @@ Dynamic AgentTool 与另外两种多 Agent 机制的边界不同：
 | --- | --- | --- | --- |
 | `agenttool.NewTool(agent)` | 一个固定的工具入口 | 每次工具调用 | 返回工具结果给父 Agent |
 | `transfer_to_agent` | 一个已注册 sub-agent | 当前轮继续由目标 Agent 处理 | 控制权移交 |
-| `agenttool.NewDynamicTool()` | 本次调用的 `request`、`instruction` 和 tools/skills 子集 | 每次工具调用 | 返回工具结果给父 Agent |
+| `agenttool.NewDynamicTool()` | 本次调用的 `request`、`instruction`、tools/skills 子集，以及可选的已注册模型 profile | 每次工具调用 | 返回工具结果给父 Agent |
 
 如果同一个专家 Agent 同时通过 `WithSubAgents` 和 `agenttool.NewTool(agent)` 暴露给父
 Agent，模型会看到两条不同路径：`transfer_to_agent` 和普通 AgentTool。框架可以运行，

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -53,9 +53,9 @@ type Tool struct {
 
 	// dynamic enables the dynamic AgentTool mode created by NewDynamicTool.
 	// In this mode the tool runs a short-lived sub-agent whose
-	// capability surface (tools / skills / instruction) is selected per call
-	// within a code-defined safety boundary, rather than wrapping one
-	// pre-defined agent.
+	// capability surface (tools / skills / instruction and, when configured,
+	// a model profile) is selected per call within a code-defined safety
+	// boundary, rather than wrapping one pre-defined agent.
 	dynamic bool
 	// dynamicCfg holds the dynamic-mode configuration. It is only consulted
 	// when dynamic is true.
@@ -92,6 +92,7 @@ type dynamicOptions struct {
 	capabilitySkillProvider   CapabilitySkillsProvider
 	capabilityTools           []tool.Tool
 	capabilitySkills          skillRepository
+	modelProfiles             []agentModelProfile
 	capabilityToolsSet        bool
 	exposeToolSelection       bool
 	exposeSkillSelection      bool

--- a/tool/agent/dynamic_model_profile.go
+++ b/tool/agent/dynamic_model_profile.go
@@ -1,0 +1,164 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+const defaultModelDescription = "Optional host-authorized model profile for " +
+	"this sub-agent invocation. Omit to keep the base/template agent's " +
+	"existing model selection."
+
+type agentModelProfile struct {
+	name        string
+	description string
+	model       model.Model
+}
+
+// WithAgentModelProfile registers one host-authorized model profile that the
+// parent model may select for a dynamic sub-agent invocation with the "model"
+// field. The name is a stable model-facing alias; the model instance and
+// description remain owned by application code. This option may be repeated.
+//
+// The name and description are included in the tool declaration visible to
+// the parent model. Do not put credentials or private provider configuration
+// in either value. Profile aliases are an allowlist and are never interpreted
+// as provider model identifiers. Omitting "model" preserves the existing
+// behavior: a configured template keeps its default model, while a
+// parent-derived child keeps the parent's effective model selection.
+// Selecting a profile clears inherited ModelContextWindow,
+// ModelRequestExtraFields, and ModelRequestHeaders so provider-specific parent
+// settings cannot rewrite or leak into the selected model request. Configure
+// such settings on the registered model instead.
+//
+// Selected profiles are consumed by LLMAgent. Other Agent implementations keep
+// their own model semantics; use an LLMAgent base or template when model routing
+// is required. This option is only meaningful for NewDynamicTool; NewTool
+// ignores it.
+//
+// NewDynamicTool panics if a registered profile has an empty name or
+// description, a nil model, or a duplicate name after trimming whitespace.
+// Profile names are matched exactly and case-sensitively after surrounding
+// whitespace is removed.
+func WithAgentModelProfile(
+	name string,
+	description string,
+	m model.Model,
+) Option {
+	return func(opts *agentToolOptions) {
+		cfg := opts.ensureDynamicOptions()
+		cfg.modelProfiles = append(cfg.modelProfiles, agentModelProfile{
+			name:        name,
+			description: description,
+			model:       m,
+		})
+	}
+}
+
+func mustNormalizeAgentModelProfiles(
+	profiles []agentModelProfile,
+) []agentModelProfile {
+	if len(profiles) == 0 {
+		return nil
+	}
+	normalized := make([]agentModelProfile, 0, len(profiles))
+	seen := make(map[string]bool, len(profiles))
+	for _, profile := range profiles {
+		name := strings.TrimSpace(profile.name)
+		description := strings.TrimSpace(profile.description)
+		switch {
+		case name == "":
+			panic("Invalid Dynamic AgentTool configuration: agent model profile name is required")
+		case description == "":
+			panic(fmt.Sprintf(
+				"Invalid Dynamic AgentTool configuration: agent model profile %q description is required",
+				name,
+			))
+		case isNilAgentModel(profile.model):
+			panic(fmt.Sprintf(
+				"Invalid Dynamic AgentTool configuration: agent model profile %q model is required",
+				name,
+			))
+		case seen[name]:
+			panic(fmt.Sprintf(
+				"Invalid Dynamic AgentTool configuration: duplicate agent model profile %q",
+				name,
+			))
+		}
+		seen[name] = true
+		normalized = append(normalized, agentModelProfile{
+			name:        name,
+			description: description,
+			model:       profile.model,
+		})
+	}
+	return normalized
+}
+
+func isNilAgentModel(m model.Model) bool {
+	if m == nil {
+		return true
+	}
+	value := reflect.ValueOf(m)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func agentModelProfileSchema(profiles []agentModelProfile) *tool.Schema {
+	values := make([]any, 0, len(profiles))
+	lines := make([]string, 0, len(profiles))
+	for _, profile := range profiles {
+		values = append(values, profile.name)
+		lines = append(lines, profile.name+": "+profile.description)
+	}
+	description := defaultModelDescription
+	if len(lines) > 0 {
+		description += " Available profiles: " + strings.Join(lines, "; ") + "."
+	}
+	return &tool.Schema{
+		Type:        "string",
+		Description: description,
+		Enum:        values,
+	}
+}
+
+func (at *Tool) resolveAgentModelProfile(alias string) (model.Model, error) {
+	if alias == "" {
+		return nil, nil
+	}
+	available := make([]string, 0, len(at.dynamicCfg.modelProfiles))
+	for _, profile := range at.dynamicCfg.modelProfiles {
+		available = append(available, profile.name)
+		if profile.name == alias {
+			return profile.model, nil
+		}
+	}
+	if len(available) == 0 {
+		return nil, fmt.Errorf(
+			"agenttool: unknown agent model profile %q; available: (none)",
+			alias,
+		)
+	}
+	return nil, fmt.Errorf(
+		"agenttool: unknown agent model profile %q; available: %s",
+		alias,
+		strings.Join(available, ", "),
+	)
+}

--- a/tool/agent/dynamic_model_profile_test.go
+++ b/tool/agent/dynamic_model_profile_test.go
@@ -1,0 +1,506 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	coreagent "trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestDynamicAgentModelProfileDeclarationIsOptIn(t *testing.T) {
+	withoutProfiles := NewDynamicTool().Declaration()
+	require.NotContains(t, withoutProfiles.InputSchema.Properties, fieldModel)
+	require.Contains(t, withoutProfiles.Description, "cannot select arbitrary agents, models")
+	require.NotContains(t, withoutProfiles.Description, "'model'")
+
+	fast := &dynRecordingModel{name: "provider-fast"}
+	deep := &dynRecordingModel{name: "provider-deep"}
+	withProfiles := NewDynamicTool(
+		WithAgentModelProfile(" fast ", " Low-latency drafting. ", fast),
+		WithAgentModelProfile("deep", "Careful review.", deep),
+	).Declaration()
+
+	modelSchema := withProfiles.InputSchema.Properties[fieldModel]
+	require.NotNil(t, modelSchema)
+	require.Equal(t, "string", modelSchema.Type)
+	require.Equal(t, []any{"fast", "deep"}, modelSchema.Enum)
+	require.Contains(t, modelSchema.Description, "fast: Low-latency drafting.")
+	require.Contains(t, modelSchema.Description, "deep: Careful review.")
+	require.Contains(t, modelSchema.Description, "Omit to keep")
+	require.NotContains(t, modelSchema.Description, "provider-fast")
+	require.NotContains(t, modelSchema.Description, "provider-deep")
+	require.Contains(t, withProfiles.Description, "host-authorized model profile")
+	require.Contains(t, withProfiles.Description, "'model'")
+	require.Equal(t, []string{fieldRequest}, withProfiles.InputSchema.Required)
+}
+
+func TestDynamicAgentModelProfileValidation(t *testing.T) {
+	valid := &dynRecordingModel{name: "valid"}
+	tests := []struct {
+		name    string
+		opts    []Option
+		message string
+	}{
+		{
+			name: "empty name",
+			opts: []Option{WithAgentModelProfile(" ", "description", valid)},
+			message: "Invalid Dynamic AgentTool configuration: " +
+				"agent model profile name is required",
+		},
+		{
+			name: "empty description",
+			opts: []Option{WithAgentModelProfile("fast", " ", valid)},
+			message: "Invalid Dynamic AgentTool configuration: " +
+				"agent model profile \"fast\" description is required",
+		},
+		{
+			name: "nil model",
+			opts: []Option{WithAgentModelProfile("fast", "description", nil)},
+			message: "Invalid Dynamic AgentTool configuration: " +
+				"agent model profile \"fast\" model is required",
+		},
+		{
+			name: "typed nil model",
+			opts: []Option{WithAgentModelProfile(
+				"fast",
+				"description",
+				(*dynRecordingModel)(nil),
+			)},
+			message: "Invalid Dynamic AgentTool configuration: " +
+				"agent model profile \"fast\" model is required",
+		},
+		{
+			name: "duplicate normalized name",
+			opts: []Option{
+				WithAgentModelProfile("fast", "one", valid),
+				WithAgentModelProfile(" fast ", "two", valid),
+			},
+			message: "Invalid Dynamic AgentTool configuration: " +
+				"duplicate agent model profile \"fast\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.PanicsWithValue(t, tt.message, func() {
+				NewDynamicTool(tt.opts...)
+			})
+		})
+	}
+}
+
+func TestDynamicAgentModelProfileOverridesTemplateForOneCall(t *testing.T) {
+	parentModel := &dynRecordingModel{name: "parent", response: "parent"}
+	parentOverride := &dynRecordingModel{name: "parent-override", response: "override"}
+	templateModel := &dynRecordingModel{name: "template", response: "template"}
+	fastModel := &dynRecordingModel{name: "provider-fast", response: "fast"}
+
+	parentAgent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	templateAgent := llmagent.New("worker", llmagent.WithModel(templateModel))
+	dynamicTool := NewDynamicTool(
+		WithTemplateAgent(templateAgent),
+		WithAgentModelProfile("fast", "Low-latency work.", fastModel),
+	)
+	parent := newDynamicModelProfileParent(parentAgent, "selected-profile")
+	parent.RunOptions.Model = parentOverride
+
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"request":"draft","model":"fast"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast", got)
+	require.Len(t, fastModel.snapshot(), 1)
+	require.Empty(t, templateModel.snapshot())
+	require.Empty(t, parentOverride.snapshot())
+	require.Empty(t, parentModel.snapshot())
+}
+
+func TestDynamicAgentModelProfileComposesWithToolSelection(t *testing.T) {
+	templateModel := &dynRecordingModel{name: "template", response: "template"}
+	profileModel := &dynRecordingModel{name: "provider-fast", response: "fast"}
+	templateAgent := llmagent.New("worker", llmagent.WithModel(templateModel))
+	dynamicTool := NewDynamicTool(
+		WithTemplateAgent(templateAgent),
+		WithCapabilityTools(stubTools("read_file", "search_code")),
+		WithAgentModelProfile("fast", "Low-latency work.", profileModel),
+	)
+	parentAgent := llmagent.New(
+		"parent",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+	)
+	parent := newDynamicModelProfileParent(parentAgent, "profile-and-tools")
+
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{
+			"request":"find the declaration",
+			"instruction":"Act as a focused code explorer.",
+			"tools":["search_code"],
+			"model":"fast"
+		}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast", got)
+	require.Equal(t, [][]string{{"search_code"}}, profileModel.snapshot())
+	require.Empty(t, templateModel.snapshot())
+}
+
+func TestDynamicAgentModelProfileOmissionPreservesTemplateDefault(t *testing.T) {
+	templateDefault := &dynRecordingModel{name: "template-default", response: "default"}
+	templateHiddenAlternative := &dynRecordingModel{name: "template-hidden", response: "hidden"}
+	profileModel := &dynRecordingModel{name: "provider-fast", response: "fast"}
+	templateAgent := llmagent.New(
+		"worker",
+		llmagent.WithModel(templateDefault),
+		llmagent.WithModels(map[string]model.Model{
+			"internal-alternative": templateHiddenAlternative,
+		}),
+	)
+	dynamicTool := NewDynamicTool(
+		WithTemplateAgent(templateAgent),
+		WithAgentModelProfile("fast", "Low-latency work.", profileModel),
+	)
+
+	modelSchema := dynamicTool.Declaration().InputSchema.Properties[fieldModel]
+	require.Equal(t, []any{"fast"}, modelSchema.Enum)
+	require.NotContains(t, modelSchema.Description, "internal-alternative")
+
+	parentAgent := llmagent.New(
+		"parent",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+	)
+	parent := newDynamicModelProfileParent(parentAgent, "default-profile")
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"request":"use the default"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "default", got)
+	require.Len(t, templateDefault.snapshot(), 1)
+	require.Empty(t, templateHiddenAlternative.snapshot())
+	require.Empty(t, profileModel.snapshot())
+}
+
+func TestDynamicAgentModelProfileOverridesInheritedModelWithoutTemplate(t *testing.T) {
+	parentDefault := &dynRecordingModel{name: "parent-default", response: "default"}
+	parentOverride := &dynRecordingModel{name: "parent-override", response: "override"}
+	profileModel := &dynRecordingModel{name: "provider-deep", response: "deep"}
+	parentAgent := llmagent.New("parent", llmagent.WithModel(parentDefault))
+	dynamicTool := NewDynamicTool(
+		WithAgentModelProfile("deep", "Careful reasoning.", profileModel),
+	)
+
+	selectedParent := newDynamicModelProfileParent(parentAgent, "selected")
+	selectedParent.RunOptions.Model = parentOverride
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), selectedParent),
+		[]byte(`{"request":"review","model":"deep"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "deep", got)
+	require.Len(t, profileModel.snapshot(), 1)
+	require.Empty(t, parentOverride.snapshot())
+
+	omittedParent := newDynamicModelProfileParent(parentAgent, "omitted")
+	omittedParent.RunOptions.Model = parentOverride
+	got, err = dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), omittedParent),
+		[]byte(`{"request":"review"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "override", got)
+	require.Len(t, parentOverride.snapshot(), 1)
+	require.Empty(t, parentDefault.snapshot())
+}
+
+func TestDynamicAgentModelProfileOverridesInheritedModelNameWithoutTemplate(
+	t *testing.T,
+) {
+	parentDefault := &dynRecordingModel{name: "parent-default", response: "default"}
+	parentNamed := &dynRecordingModel{name: "parent-named", response: "named"}
+	profileModel := &dynRecordingModel{name: "provider-deep", response: "deep"}
+	parentAgent := llmagent.New(
+		"parent",
+		llmagent.WithModel(parentDefault),
+		llmagent.WithModels(map[string]model.Model{"named": parentNamed}),
+	)
+	dynamicTool := NewDynamicTool(
+		WithAgentModelProfile("deep", "Careful reasoning.", profileModel),
+	)
+
+	selectedParent := newDynamicModelProfileParent(parentAgent, "selected-name")
+	selectedParent.RunOptions.ModelName = "named"
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), selectedParent),
+		[]byte(`{"request":"review","model":"deep"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "deep", got)
+	require.Len(t, profileModel.snapshot(), 1)
+	require.Empty(t, parentNamed.snapshot())
+
+	omittedParent := newDynamicModelProfileParent(parentAgent, "omitted-name")
+	omittedParent.RunOptions.ModelName = "named"
+	got, err = dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), omittedParent),
+		[]byte(`{"request":"review"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "named", got)
+	require.Len(t, parentNamed.snapshot(), 1)
+}
+
+func TestDynamicAgentModelProfileOverridesInheritedRunModelSelector(t *testing.T) {
+	parentDefault := &dynRecordingModel{name: "parent-default", response: "default"}
+	selectorModel := &dynRecordingModel{name: "selector", response: "selector"}
+	profileModel := &dynRecordingModel{name: "provider-fast", response: "fast"}
+	parentAgent := llmagent.New("parent", llmagent.WithModel(parentDefault))
+	dynamicTool := NewDynamicTool(
+		WithAgentModelProfile("fast", "Low-latency work.", profileModel),
+	)
+	var selectorCalls atomic.Int32
+	selector := func(
+		context.Context,
+		*coreagent.Invocation,
+	) (model.Model, error) {
+		selectorCalls.Add(1)
+		return selectorModel, nil
+	}
+
+	selectedParent := newDynamicModelProfileParent(parentAgent, "selected-selector")
+	selectedParent.RunOptions.ModelSelector = selector
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), selectedParent),
+		[]byte(`{"request":"draft","model":"fast"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast", got)
+	require.Zero(t, selectorCalls.Load())
+	require.Len(t, profileModel.snapshot(), 1)
+	require.Empty(t, selectorModel.snapshot())
+
+	omittedParent := newDynamicModelProfileParent(parentAgent, "omitted-selector")
+	omittedParent.RunOptions.ModelSelector = selector
+	got, err = dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), omittedParent),
+		[]byte(`{"request":"draft"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "selector", got)
+	require.Equal(t, int32(1), selectorCalls.Load())
+	require.Len(t, selectorModel.snapshot(), 1)
+}
+
+func TestDynamicAgentModelProfileOverridesTemplateModelSelector(t *testing.T) {
+	templateDefault := &dynRecordingModel{name: "template-default", response: "default"}
+	templateSelected := &dynRecordingModel{name: "template-selector", response: "selector"}
+	profileModel := &dynRecordingModel{name: "provider-fast", response: "fast"}
+	var selectorCalls atomic.Int32
+	templateAgent := llmagent.New(
+		"worker",
+		llmagent.WithModel(templateDefault),
+		llmagent.WithModelSelector(func(
+			context.Context,
+			*coreagent.Invocation,
+		) (model.Model, error) {
+			selectorCalls.Add(1)
+			return templateSelected, nil
+		}),
+	)
+	dynamicTool := NewDynamicTool(
+		WithTemplateAgent(templateAgent),
+		WithAgentModelProfile("fast", "Low-latency work.", profileModel),
+	)
+	parentAgent := llmagent.New(
+		"parent",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+	)
+
+	selectedParent := newDynamicModelProfileParent(parentAgent, "selected-template-selector")
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), selectedParent),
+		[]byte(`{"request":"draft","model":"fast"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "fast", got)
+	require.Zero(t, selectorCalls.Load())
+	require.Len(t, profileModel.snapshot(), 1)
+	require.Empty(t, templateSelected.snapshot())
+
+	omittedParent := newDynamicModelProfileParent(parentAgent, "omitted-template-selector")
+	got, err = dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), omittedParent),
+		[]byte(`{"request":"draft"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "selector", got)
+	require.Equal(t, int32(1), selectorCalls.Load())
+	require.Len(t, templateSelected.snapshot(), 1)
+}
+
+func TestDynamicAgentModelProfileClearsInheritedProviderRequestOptions(
+	t *testing.T,
+) {
+	parentModel := &dynRecordingModel{name: "parent", response: "parent"}
+	profileModel := &dynRecordingModel{name: "profile", response: "profile"}
+	parentAgent := llmagent.New("parent", llmagent.WithModel(parentModel))
+	dynamicTool := NewDynamicTool(
+		WithAgentModelProfile("deep", "Careful reasoning.", profileModel),
+	)
+	parent := newDynamicModelProfileParent(parentAgent, "provider-options")
+	parent.RunOptions.ModelContextWindow = 4096
+	parent.RunOptions.ModelRequestExtraFields = map[string]any{
+		"model":           "unapproved-provider-model",
+		"provider_option": "parent",
+	}
+	parent.RunOptions.ModelRequestHeaders = map[string]string{
+		"X-Provider-Route": "parent",
+	}
+
+	_, child, _, err := dynamicTool.buildDynamicSubInvocation(
+		coreagent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"request":"review","model":"deep"}`),
+	)
+	require.NoError(t, err)
+	require.Zero(t, child.RunOptions.ModelContextWindow)
+	require.Nil(t, child.RunOptions.ModelRequestExtraFields)
+	require.Nil(t, child.RunOptions.ModelRequestHeaders)
+}
+
+func TestDynamicAgentUnknownModelProfileFailsClosed(t *testing.T) {
+	templateModel := &dynRecordingModel{name: "template", response: "template"}
+	fastModel := &dynRecordingModel{name: "fast", response: "fast"}
+	deepModel := &dynRecordingModel{name: "deep", response: "deep"}
+	templateAgent := llmagent.New("worker", llmagent.WithModel(templateModel))
+	dynamicTool := NewDynamicTool(
+		WithTemplateAgent(templateAgent),
+		WithAgentModelProfile("fast", "Fast work.", fastModel),
+		WithAgentModelProfile("deep", "Deep work.", deepModel),
+	)
+	parentAgent := llmagent.New(
+		"parent",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+	)
+	parent := newDynamicModelProfileParent(parentAgent, "unknown")
+
+	_, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"request":"work","model":"provider-model-id"}`),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unknown agent model profile "provider-model-id"`)
+	require.Contains(t, err.Error(), "available: fast, deep")
+	require.Empty(t, templateModel.snapshot())
+	require.Empty(t, fastModel.snapshot())
+	require.Empty(t, deepModel.snapshot())
+}
+
+func TestDynamicAgentModelProfilesAreInvocationScopedUnderConcurrency(t *testing.T) {
+	const callsPerProfile = 12
+	templateModel := &dynRecordingModel{name: "template", response: "template"}
+	fastModel := &dynRecordingModel{name: "fast", response: "fast"}
+	deepModel := &dynRecordingModel{name: "deep", response: "deep"}
+	templateAgent := llmagent.New("worker", llmagent.WithModel(templateModel))
+	dynamicTool := NewDynamicTool(
+		WithTemplateAgent(templateAgent),
+		WithAgentModelProfile("fast", "Fast work.", fastModel),
+		WithAgentModelProfile("deep", "Deep work.", deepModel),
+	)
+	parentAgent := llmagent.New(
+		"parent",
+		llmagent.WithModel(&dynRecordingModel{name: "parent"}),
+	)
+
+	type callResult struct {
+		want string
+		got  any
+		err  error
+	}
+	results := make(chan callResult, callsPerProfile*2)
+	var wg sync.WaitGroup
+	for i := 0; i < callsPerProfile*2; i++ {
+		alias := "fast"
+		if i%2 == 1 {
+			alias = "deep"
+		}
+		wg.Add(1)
+		go func(index int, profile string) {
+			defer wg.Done()
+			parent := newDynamicModelProfileParent(
+				parentAgent,
+				fmt.Sprintf("concurrent-%d", index),
+			)
+			got, err := dynamicTool.Call(
+				coreagent.NewInvocationContext(context.Background(), parent),
+				[]byte(fmt.Sprintf(
+					`{"request":"work","model":%q}`,
+					profile,
+				)),
+			)
+			results <- callResult{want: profile, got: got, err: err}
+		}(i, alias)
+	}
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.Equal(t, result.want, result.got)
+	}
+	require.Len(t, fastModel.snapshot(), callsPerProfile)
+	require.Len(t, deepModel.snapshot(), callsPerProfile)
+	require.Empty(t, templateModel.snapshot())
+
+	// Profile selection must not mutate the shared template. A later call that
+	// omits model still uses the template default.
+	parent := newDynamicModelProfileParent(parentAgent, "after-concurrency")
+	got, err := dynamicTool.Call(
+		coreagent.NewInvocationContext(context.Background(), parent),
+		[]byte(`{"request":"default"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "template", got)
+	require.Len(t, templateModel.snapshot(), 1)
+}
+
+func TestDynamicAgentModelArgumentIgnoredWhenProfilesAreNotConfigured(t *testing.T) {
+	dynamicTool := NewDynamicTool()
+	spec := dynamicTool.parseDynamicArgs([]byte(
+		`{"request":"work","model":"provider-model-id"}`,
+	))
+	require.Equal(t, "work", spec.request)
+	require.Empty(t, spec.model)
+	require.NotContains(
+		t,
+		dynamicTool.Declaration().InputSchema.Properties,
+		fieldModel,
+	)
+}
+
+func newDynamicModelProfileParent(
+	parentAgent coreagent.Agent,
+	sessionID string,
+) *coreagent.Invocation {
+	return coreagent.NewInvocation(
+		coreagent.WithInvocationAgent(parentAgent),
+		coreagent.WithInvocationSession(
+			session.NewSession("app", "user", strings.TrimSpace(sessionID)),
+		),
+		coreagent.WithInvocationEventFilterKey("parent"),
+	)
+}

--- a/tool/agent/dynamic_tool.go
+++ b/tool/agent/dynamic_tool.go
@@ -35,21 +35,27 @@ import (
 // short-lived sub-agent and returns its result synchronously.
 const DefaultDynamicToolName = "dynamic_agent"
 
-// defaultDynamicDescription is the default tool description exposed to the
-// model. It pins the semantic boundary so the model does not confuse this with
-// a transfer, a background task, or running a pre-registered sub-agent. It
-// deliberately does not name the optional "tools"/"skills" fields (those are
-// only present when exposed via the schema); it states the boundary as a fact
-// that holds whether or not the model can narrow the surface.
-const defaultDynamicDescription = "Run one short-lived sub-agent for a " +
+// defaultDynamicDescriptionPrefix is shared by the default descriptions with
+// and without model profiles. It pins the semantic boundary so the model does
+// not confuse this with a transfer, a background task, or running a
+// pre-registered sub-agent. Field-specific hints are appended separately so
+// they stay aligned with the generated schema.
+const defaultDynamicDescriptionPrefix = "Run one short-lived sub-agent for a " +
 	"single focused task and return its result. The sub-agent is created on the " +
 	"fly for this call only and is destroyed afterward. It does NOT transfer " +
 	"control, does NOT run a pre-registered agent by name, and does NOT start a " +
 	"background task. To run several tasks, call this tool multiple times. Its " +
 	"tools and skills stay within a code-defined capability boundary, which by " +
 	"default is derived from what the current agent is already allowed to use " +
-	"(or set explicitly in code), and it cannot select arbitrary agents, models, " +
+	"(or set explicitly in code)"
+
+const defaultDynamicDescription = defaultDynamicDescriptionPrefix +
+	", and it cannot select arbitrary agents, models, " +
 	"or executors."
+
+const defaultDynamicDescriptionWithModelProfiles = defaultDynamicDescriptionPrefix + ". It cannot select " +
+	"arbitrary agents, models, or executors; it may select only a " +
+	"host-authorized model profile configured for this tool."
 
 const (
 	defaultRequestDescription = "The task for the sub-agent. Include all the " +
@@ -68,6 +74,7 @@ const (
 	fieldInstruction = "instruction"
 	fieldTools       = "tools"
 	fieldSkills      = "skills"
+	fieldModel       = "model"
 )
 
 // skillRepository is a local alias so the dynamic option struct (declared in
@@ -156,8 +163,8 @@ type DetailedCapabilitySurfaceProvider func(
 ) CapabilitySurface
 
 // WithTemplateAgent sets the base/template agent that defines the execution
-// boundary for the dynamic sub-agent (model, executor, callbacks, permission
-// policy, max calls, ...).
+// boundary for the dynamic sub-agent (default model, executor, callbacks,
+// permission policy, max calls, ...).
 //
 // When omitted, the dynamic tool lazily derives the base agent from the parent
 // invocation at call time. The model can never select an arbitrary agent; it
@@ -310,7 +317,8 @@ func WithSkillsDescription(description string) Option {
 
 // NewDynamicTool creates a dynamic AgentTool: a single, code-defined entrypoint
 // that runs a short-lived sub-agent whose capability surface (tools,
-// skills, instruction) is selected per invocation within a safety boundary.
+// skills, instruction and, when configured, a model profile) is selected per
+// invocation within a safety boundary.
 //
 // The default behavior is to lazily derive the sub-agent from the parent
 // invocation at call time:
@@ -321,10 +329,12 @@ func WithSkillsDescription(description string) Option {
 //   - skills: the parent invocation's effective skills, optionally narrowed by
 //     the model's "skills" field,
 //   - instruction: the model's "instruction" field (when exposed),
+//   - model: an optional host-authorized profile registered with
+//     WithAgentModelProfile; omitted by default,
 //   - context: isolated by default (HistoryScopeIsolated).
 //
 // The model cannot pick an arbitrary agent, model, or executor; it can only run
-// within the configured boundary.
+// within the configured boundary and any explicitly registered model profiles.
 //
 // Minimal usage exposes a tool named "dynamic_agent":
 //
@@ -353,6 +363,9 @@ func NewDynamicTool(opts ...Option) *Tool {
 		)
 	}
 	dynamicCfg := options.ensureDynamicOptions()
+	dynamicCfg.modelProfiles = mustNormalizeAgentModelProfiles(
+		dynamicCfg.modelProfiles,
+	)
 	description := buildDynamicDescription(dynamicCfg, options.historyScope)
 	if options.description != nil {
 		description = *options.description
@@ -387,7 +400,11 @@ func NewDynamicTool(opts ...Option) *Tool {
 // schema omits.
 func buildDynamicDescription(cfg *dynamicOptions, historyScope HistoryScope) string {
 	var b strings.Builder
-	b.WriteString(defaultDynamicDescription)
+	if len(cfg.modelProfiles) > 0 {
+		b.WriteString(defaultDynamicDescriptionWithModelProfiles)
+	} else {
+		b.WriteString(defaultDynamicDescription)
+	}
 	if historyScope == HistoryScopeParentBranch {
 		b.WriteString(" It can see the current conversation's history; still " +
 			"describe the task in 'request'. Use it when delegated tool work " +
@@ -411,6 +428,10 @@ func buildDynamicDescription(cfg *dynamicOptions, historyScope HistoryScope) str
 	if cfg.exposeSkillSelection {
 		b.WriteString(" Optionally set 'skills' to the exact subset of skill " +
 			"names it may use; omit to allow all permitted skills.")
+	}
+	if len(cfg.modelProfiles) > 0 {
+		b.WriteString(" Optionally set 'model' to a configured profile for this " +
+			"sub-agent only; omit it to keep the base/template model selection.")
 	}
 	return b.String()
 }
@@ -460,6 +481,9 @@ func buildDynamicInputSchema(name string, cfg *dynamicOptions) *tool.Schema {
 			Description: optionalString(cfg.skillsDescription, defaultSkillsDescription),
 			Items:       &tool.Schema{Type: "string"},
 		}
+	}
+	if len(cfg.modelProfiles) > 0 {
+		properties[fieldModel] = agentModelProfileSchema(cfg.modelProfiles)
 	}
 	return &tool.Schema{
 		Type:        "object",
@@ -521,6 +545,7 @@ type dynamicArgs struct {
 	Instruction string    `json:"instruction"`
 	Tools       *[]string `json:"tools"`
 	Skills      *[]string `json:"skills"`
+	Model       string    `json:"model"`
 }
 
 // dynamicSpec is the parsed, validated form of a single dynamic invocation.
@@ -531,6 +556,7 @@ type dynamicSpec struct {
 	toolsProvided  bool
 	skills         []string
 	skillsProvided bool
+	model          string
 }
 
 func (at *Tool) parseDynamicArgs(jsonArgs []byte) dynamicSpec {
@@ -551,6 +577,9 @@ func (at *Tool) parseDynamicArgs(jsonArgs []byte) dynamicSpec {
 	if at.dynamicCfg.exposeSkillSelection && raw.Skills != nil {
 		spec.skillsProvided = true
 		spec.skills = dedupeNonEmpty(*raw.Skills)
+	}
+	if len(at.dynamicCfg.modelProfiles) > 0 {
+		spec.model = strings.TrimSpace(raw.Model)
 	}
 	return spec
 }
@@ -677,14 +706,21 @@ func (at *Tool) buildDynamicSubInvocation(
 	childKey := at.buildDynamicChildFilterKey(parentInv, baseAgent)
 	nodeID := dynamicSurfaceNodeID(at.name)
 	subInv := parentInv.Clone(
-		at.dynamicChildInvocationOptions(baseAgent, message, childKey, nodeID, patch)...,
+		at.dynamicChildInvocationOptions(
+			baseAgent,
+			message,
+			childKey,
+			nodeID,
+			patch,
+			spec.model != "",
+		)...,
 	)
 	subCtx := agent.NewInvocationContext(ctx, subInv)
 	return subCtx, subInv, warnings, nil
 }
 
 // buildDynamicPatch builds the surface patch that scopes the child invocation's
-// tools, skills and instruction.
+// tools, skills, instruction and an optional model profile.
 func (at *Tool) buildDynamicPatch(
 	ctx context.Context,
 	parentInv *agent.Invocation,
@@ -695,6 +731,14 @@ func (at *Tool) buildDynamicPatch(
 
 	if at.dynamicCfg.exposeInstruction && spec.instruction != "" {
 		patch.SetInstruction(spec.instruction)
+	}
+
+	selectedModel, err := at.resolveAgentModelProfile(spec.model)
+	if err != nil {
+		return agent.SurfacePatch{}, nil, err
+	}
+	if selectedModel != nil {
+		patch.SetModel(selectedModel)
 	}
 
 	// Tools: always set so the dynamic tool itself (and transfer_to_agent) are
@@ -1020,6 +1064,7 @@ func (at *Tool) dynamicChildInvocationOptions(
 	childKey string,
 	nodeID string,
 	patch agent.SurfacePatch,
+	modelProfileSelected bool,
 ) []agent.InvocationOptions {
 	// With a template agent the template defines the execution boundary
 	// (model, executor, ...), so parent run-scoped overrides must not leak in.
@@ -1033,7 +1078,11 @@ func (at *Tool) dynamicChildInvocationOptions(
 			agent.SetInvocationSurfaceRootNodeID(inv, nodeID)
 			runOpts := inv.RunOptions
 			agent.WithSurfacePatchForNode(nodeID, patch)(&runOpts)
-			at.sanitizeChildRunOptions(&runOpts, enforceTemplateBoundary)
+			at.sanitizeChildRunOptions(
+				&runOpts,
+				enforceTemplateBoundary,
+				modelProfileSelected,
+			)
 			inv.RunOptions = runOpts
 		},
 	}
@@ -1050,11 +1099,17 @@ func (at *Tool) dynamicChildInvocationOptions(
 // WithCapabilityTools/WithCapabilityProvider tools that never passed through it
 // (the parent filter was already applied when deriving the candidate surface).
 //
-// Template boundary (cleared only when a template agent is configured): the
-// template defines model, prompt and execution, so parent run-scoped overrides
-// must not leak in:
-//   - model: Model/ModelName/ModelSelector all outrank the template's own
-//     model resolution;
+// Model boundary: Model/ModelName/ModelSelector are cleared when a template is
+// configured or the call explicitly selects a model profile. A template owns
+// its default model. A selected profile owns this child call; in particular,
+// a run-level ModelSelector would otherwise run after surface resolution and
+// replace the selected profile. A selected profile also clears inherited
+// provider-specific request options and the explicit context window so parent
+// settings cannot rewrite or leak into a different profile model.
+//
+// Remaining template boundary (cleared only when a template agent is
+// configured): the template defines prompt and execution, so parent run-scoped
+// overrides must not leak in:
 //   - prompt: Instruction/GlobalInstruction outrank the template prompt — a
 //     model-provided instruction still applies because it travels via the
 //     surface patch, which is resolved before RunOptions;
@@ -1065,17 +1120,25 @@ func (at *Tool) dynamicChildInvocationOptions(
 func (at *Tool) sanitizeChildRunOptions(
 	runOpts *agent.RunOptions,
 	enforceTemplateBoundary bool,
+	modelProfileSelected bool,
 ) {
 	runOpts.AdditionalTools = nil
 	runOpts.ExternalTools = nil
 	runOpts.ExternalToolNames = nil
 	runOpts.ToolFilter = nil
+	if enforceTemplateBoundary || modelProfileSelected {
+		runOpts.Model = nil
+		runOpts.ModelName = ""
+		runOpts.ModelSelector = nil
+	}
+	if modelProfileSelected {
+		runOpts.ModelContextWindow = 0
+		runOpts.ModelRequestExtraFields = nil
+		runOpts.ModelRequestHeaders = nil
+	}
 	if !enforceTemplateBoundary {
 		return
 	}
-	runOpts.Model = nil
-	runOpts.ModelName = ""
-	runOpts.ModelSelector = nil
 	runOpts.Instruction = ""
 	runOpts.GlobalInstruction = ""
 	runOpts.CodeExecutor = nil

--- a/tool/agent/dynamic_tool_test.go
+++ b/tool/agent/dynamic_tool_test.go
@@ -1823,6 +1823,12 @@ func fullyPopulatedChildRunOptions() agent.RunOptions {
 		ModelSelector: func(context.Context, *agent.Invocation) (model.Model, error) {
 			return nil, nil
 		},
+		ModelContextWindow: 4096,
+		ModelRequestExtraFields: map[string]any{
+			"model":           "unapproved-provider-model",
+			"provider_option": "value",
+		},
+		ModelRequestHeaders: map[string]string{"X-Provider-Route": "parent"},
 		Instruction:         "inst",
 		GlobalInstruction:   "ginst",
 		CodeExecutor:        fakeDynCodeExecutor{},
@@ -1842,7 +1848,7 @@ func fullyPopulatedChildRunOptions() agent.RunOptions {
 func TestSanitizeChildRunOptions_TemplateBoundaryClearsAll(t *testing.T) {
 	at := NewDynamicTool()
 	runOpts := fullyPopulatedChildRunOptions()
-	at.sanitizeChildRunOptions(&runOpts, true)
+	at.sanitizeChildRunOptions(&runOpts, true, false)
 
 	// Tool surface: patch is the single source of truth.
 	require.Nil(t, runOpts.AdditionalTools)
@@ -1853,6 +1859,11 @@ func TestSanitizeChildRunOptions_TemplateBoundaryClearsAll(t *testing.T) {
 	require.Nil(t, runOpts.Model)
 	require.Empty(t, runOpts.ModelName)
 	require.Nil(t, runOpts.ModelSelector)
+	// Existing template-only behavior keeps run-wide provider request options.
+	// Profile selection below defines the stronger cross-model boundary.
+	require.Equal(t, 4096, runOpts.ModelContextWindow)
+	require.NotNil(t, runOpts.ModelRequestExtraFields)
+	require.NotNil(t, runOpts.ModelRequestHeaders)
 	require.Empty(t, runOpts.Instruction)
 	require.Empty(t, runOpts.GlobalInstruction)
 	// Execution boundary.
@@ -1867,7 +1878,7 @@ func TestSanitizeChildRunOptions_TemplateBoundaryClearsAll(t *testing.T) {
 func TestSanitizeChildRunOptions_NoTemplateKeepsBoundaryFields(t *testing.T) {
 	at := NewDynamicTool()
 	runOpts := fullyPopulatedChildRunOptions()
-	at.sanitizeChildRunOptions(&runOpts, false)
+	at.sanitizeChildRunOptions(&runOpts, false, false)
 
 	// Tool surface is always cleared (patch is authoritative; parent filter
 	// already applied while deriving the candidate surface).
@@ -1879,6 +1890,33 @@ func TestSanitizeChildRunOptions_NoTemplateKeepsBoundaryFields(t *testing.T) {
 	require.NotNil(t, runOpts.Model)
 	require.Equal(t, "mname", runOpts.ModelName)
 	require.NotNil(t, runOpts.ModelSelector)
+	require.Equal(t, 4096, runOpts.ModelContextWindow)
+	require.NotNil(t, runOpts.ModelRequestExtraFields)
+	require.NotNil(t, runOpts.ModelRequestHeaders)
+	require.Equal(t, "inst", runOpts.Instruction)
+	require.Equal(t, "ginst", runOpts.GlobalInstruction)
+	require.NotNil(t, runOpts.CodeExecutor)
+	require.NotNil(t, runOpts.ToolExecutionFilter)
+	require.NotNil(t, runOpts.ToolPermissionPolicy)
+}
+
+// TestSanitizeChildRunOptions_ProfileClearsProviderRequestOptions verifies that
+// selecting a host-authorized profile also removes parent model request
+// settings that could target or authenticate a different provider. Calls that
+// omit model retain the existing inheritance behavior above.
+func TestSanitizeChildRunOptions_ProfileClearsProviderRequestOptions(t *testing.T) {
+	at := NewDynamicTool()
+	runOpts := fullyPopulatedChildRunOptions()
+	at.sanitizeChildRunOptions(&runOpts, false, true)
+
+	require.Nil(t, runOpts.Model)
+	require.Empty(t, runOpts.ModelName)
+	require.Nil(t, runOpts.ModelSelector)
+	require.Zero(t, runOpts.ModelContextWindow)
+	require.Nil(t, runOpts.ModelRequestExtraFields)
+	require.Nil(t, runOpts.ModelRequestHeaders)
+
+	// With no template, non-model execution settings still inherit as before.
 	require.Equal(t, "inst", runOpts.Instruction)
 	require.Equal(t, "ginst", runOpts.GlobalInstruction)
 	require.NotNil(t, runOpts.CodeExecutor)


### PR DESCRIPTION
## What changed

Add host-authorized model profiles to Dynamic AgentTool, allowing the parent model to select a task-oriented profile for each short-lived child invocation. Omitting the profile preserves the existing base or template model behavior.

## Why

Dynamic specialists may benefit from different model capabilities, but provider model identifiers should remain application-owned. Explicit aliases provide a model-visible allowlist without mutating shared Agent templates.

## Testing

- `go test -count=1 ./tool/agent`
- Targeted `go test -race` for model-profile and RunOptions boundaries
- `go vet ./tool/agent`
- MkDocs strict build

## Notes for reviewers

Profile selection is invocation-scoped and clears inherited provider-specific request fields. Applications that do not register or select profiles retain the existing behavior.