### PR TITLE
feat(sandbox): add Runtime.Explain for compact operator status

### DIFF
--- a/codeexecutor/sandbox/backend_linux.go
+++ b/codeexecutor/sandbox/backend_linux.go
@@ -170,6 +170,14 @@ func (r *Runtime) linuxSandboxSetup(
 	}, nil
 }
 
+func (r *Runtime) explainManagedPreflight(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, _, err := r.linuxPreflight()
+	return err
+}
+
 func (r *Runtime) linuxPreflight() (string, bool, error) {
 	r.preflightOnce.Do(func() {
 		if r.backend != BackendAuto && r.backend != BackendLinuxBubblewrap {

--- a/codeexecutor/sandbox/backend_macos.go
+++ b/codeexecutor/sandbox/backend_macos.go
@@ -77,6 +77,14 @@ func (r *Runtime) osSandboxCommand(
 	return cmd, string(BackendMacOSSandboxExec), cleanup, nil
 }
 
+func (r *Runtime) explainManagedPreflight(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := r.macosPreflight()
+	return err
+}
+
 func (r *Runtime) macosPreflight() (string, error) {
 	r.preflightOnce.Do(func() {
 		if r.backend != BackendAuto && r.backend != BackendMacOSSandboxExec {

--- a/codeexecutor/sandbox/backend_other.go
+++ b/codeexecutor/sandbox/backend_other.go
@@ -60,13 +60,16 @@ func (r *Runtime) osSandboxCommand(
 }
 
 func (r *Runtime) explainManagedPreflight(ctx context.Context) error {
-	_ = r
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	backend := r.backend
+	if backend == "" {
+		backend = BackendAuto
+	}
 	return backendError(
 		ErrUnsupportedBackend,
-		runtime.GOOS,
-		errors.New("managed OS sandbox backend is not implemented for this platform"),
+		string(backend),
+		errors.New("managed OS sandbox backend is not implemented for this platform ("+runtime.GOOS+")"),
 	)
 }

--- a/codeexecutor/sandbox/backend_other.go
+++ b/codeexecutor/sandbox/backend_other.go
@@ -58,3 +58,15 @@ func (r *Runtime) osSandboxCommand(
 		errors.New("managed OS sandbox backend is not implemented for this platform"),
 	)
 }
+
+func (r *Runtime) explainManagedPreflight(ctx context.Context) error {
+	_ = r
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return backendError(
+		ErrUnsupportedBackend,
+		runtime.GOOS,
+		errors.New("managed OS sandbox backend is not implemented for this platform"),
+	)
+}

--- a/codeexecutor/sandbox/doc.go
+++ b/codeexecutor/sandbox/doc.go
@@ -14,7 +14,9 @@
 // Runtime.Explain reports a high-level status summary for operators: requested
 // and resolved backend, filesystem sandbox type, network mode, and managed
 // backend preflight readiness. On managed profiles it may run the same short
-// backend probe used by execution and cache the result on the Runtime. It is
-// not a full policy dump and does not describe path grants, environment
-// inheritance, timeouts, or resource quotas.
+// backend probe used by execution and cache the result on the Runtime.
+// PreflightReady means the core backend probe succeeded, not that every
+// reported policy boundary is enforceable. It is not a full policy dump and
+// does not describe path grants, environment inheritance, timeouts, or
+// resource quotas.
 package sandbox

--- a/codeexecutor/sandbox/doc.go
+++ b/codeexecutor/sandbox/doc.go
@@ -10,4 +10,11 @@
 // Package sandbox provides an OS-level sandbox code executor. Runtime supports
 // both buffered RunProgram calls and full-duplex StartProcess calls; both use
 // the same workspace, permission, environment, and native-backend enforcement.
+//
+// Runtime.Explain reports a high-level status summary for operators: requested
+// and resolved backend, filesystem sandbox type, network mode, and managed
+// backend preflight readiness. On managed profiles it may run the same short
+// backend probe used by execution and cache the result on the Runtime. It is
+// not a full policy dump and does not describe path grants, environment
+// inheritance, timeouts, or resource quotas.
 package sandbox

--- a/codeexecutor/sandbox/docs/README.md
+++ b/codeexecutor/sandbox/docs/README.md
@@ -73,6 +73,45 @@ behavior and does not advertise generic `CleanEnv` support. The new
 process starts without host environment variables; explicit policy settings,
 per-run variables, and sandbox-owned workspace variables are still applied.
 
+## Explain Status
+
+`Runtime.Explain` returns a compact operator-facing status summary:
+
+- requested backend and platform-resolved backend
+- filesystem sandbox type (`workspace-write`, `read-only`, `disabled`, or
+  `external`)
+- network mode (`restricted` or `enabled`)
+- managed backend preflight status (`ready`, `failed`, `not-required`, or
+  `unsupported`)
+
+Explain reuses the same normalized permission profile and managed-backend
+preflight paths that execution uses: `linuxPreflight` on Linux and
+`macosPreflight` on macOS. Restricted network does not run a separate seccomp
+probe. Explain never runs a caller command, never acquires a workspace run
+lock, and never creates a workspace. On managed profiles it may run the same
+short backend probe used by execution (for example `/bin/true` under
+bubblewrap) and cache that result on the Runtime, which can change when the
+first execution probe happens.
+
+When managed preflight fails, Explain still returns the configured status
+fields together with a short `PreflightError`. That summary includes the error
+kind, backend name, and a sanitized cause; probe stderr is omitted.
+
+Explain is intentionally not a full policy dump. It does not list read/write
+paths, no-access rules, environment inheritance, timeouts, output limits,
+resource quotas, bubblewrap argv, or Seatbelt profiles. Use it to answer "which
+sandbox mode is active and is the backend ready?", not to audit every grant.
+
+Example:
+
+```text
+Sandbox
+  backend:    auto -> linux-bubblewrap
+  filesystem: workspace-write
+  network:    restricted
+  preflight:  ready
+```
+
 ## Full-duplex Processes
 
 `Runtime.StartProcess` starts a program through the same permission checks and

--- a/codeexecutor/sandbox/docs/README.md
+++ b/codeexecutor/sandbox/docs/README.md
@@ -84,14 +84,20 @@ per-run variables, and sandbox-owned workspace variables are still applied.
 - managed backend preflight status (`ready`, `failed`, `not-required`, or
   `unsupported`)
 
-Explain reuses the same normalized permission profile and managed-backend
-preflight paths that execution uses: `linuxPreflight` on Linux and
-`macosPreflight` on macOS. Restricted network does not run a separate seccomp
-probe. Explain never runs a caller command, never acquires a workspace run
-lock, and never creates a workspace. On managed profiles it may run the same
+Explain reuses the same normalized permission profile and the same
+platform-specific preflight probe used by execution. Restricted network does
+not run a separate namespace or seccomp probe. `PreflightReady` means the
+core backend probe succeeded; it does not prove that every reported
+boundary, such as `NetworkRestricted` isolation, can be established.
+Explain never runs a caller command, never acquires a workspace run lock,
+and never creates a workspace. On managed profiles it may run the same
 short backend probe used by execution (for example `/bin/true` under
 bubblewrap) and cache that result on the Runtime, which can change when the
 first execution probe happens.
+
+`workspace-write` includes workspace special-path writes and
+workspace-relative `WithWritePaths` grants. Host-absolute write grants alone
+keep the filesystem type `read-only`.
 
 When managed preflight fails, Explain still returns the configured status
 fields together with a short `PreflightError`. That summary includes the error

--- a/codeexecutor/sandbox/explain.go
+++ b/codeexecutor/sandbox/explain.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -22,15 +23,19 @@ import (
 type PreflightStatus string
 
 const (
-	// PreflightReady means managed backend preflight succeeded.
+	// PreflightReady means the managed backend core probe succeeded. It does
+	// not verify every reported policy boundary, such as network-namespace
+	// isolation for NetworkRestricted.
 	PreflightReady PreflightStatus = "ready"
 	// PreflightFailed means managed backend preflight ran and failed.
 	PreflightFailed PreflightStatus = "failed"
 	// PreflightNotRequired means the active profile does not need a managed
 	// OS sandbox backend.
 	PreflightNotRequired PreflightStatus = "not-required"
-	// PreflightUnsupported means the profile or platform cannot use a managed
-	// OS sandbox backend.
+	// PreflightUnsupported means a managed OS sandbox backend is not used.
+	// External profiles return this status with a nil error because an outside
+	// sandbox is expected to enforce policy. Unsupported platforms and
+	// incompatible backends return this status with a non-nil error.
 	PreflightUnsupported PreflightStatus = "unsupported"
 )
 
@@ -40,10 +45,11 @@ type FileSystemSandboxType string
 
 const (
 	// FileSystemSandboxWorkspaceWrite means the managed profile grants write
-	// access to workspace special paths.
+	// access inside the workspace, via special paths or workspace-relative
+	// path rules. Host-absolute write grants alone do not select this type.
 	FileSystemSandboxWorkspaceWrite FileSystemSandboxType = "workspace-write"
 	// FileSystemSandboxReadOnly means the managed profile does not grant
-	// workspace special-path writes.
+	// workspace writes.
 	FileSystemSandboxReadOnly FileSystemSandboxType = "read-only"
 	// FileSystemSandboxDisabled means OS sandbox enforcement is off.
 	FileSystemSandboxDisabled FileSystemSandboxType = "disabled"
@@ -56,11 +62,22 @@ const (
 // It is intentionally small: it reports backend selection, filesystem sandbox
 // type, network mode, and preflight readiness. It is not a full policy dump.
 type ExplainReport struct {
-	RequestedBackend  BackendType
-	ResolvedBackend   BackendType
+	// RequestedBackend is the backend selected by the caller. An empty value
+	// means the caller did not set WithBackend and is treated as BackendAuto.
+	RequestedBackend BackendType
+	// ResolvedBackend is the backend the current platform would use for the
+	// requested value. It is BackendAuto when the platform has no managed
+	// backend.
+	ResolvedBackend BackendType
+	// FileSystemSandbox is the reported filesystem sandbox mode. An empty
+	// value is treated as FileSystemSandboxDisabled by String().
 	FileSystemSandbox FileSystemSandboxType
-	NetworkMode       NetworkMode
-	PreflightStatus   PreflightStatus
+	// NetworkMode is the effective network mode of the normalized profile. An
+	// empty value is treated as NetworkRestricted by String().
+	NetworkMode NetworkMode
+	// PreflightStatus is the managed backend readiness status. An empty value
+	// is treated as PreflightNotRequired by String().
+	PreflightStatus PreflightStatus
 	// PreflightError is a short operator-facing summary when PreflightStatus
 	// is failed or unsupported after a managed backend probe. It includes the
 	// error kind, backend name, and a sanitized cause. Probe stderr, host
@@ -71,12 +88,19 @@ type ExplainReport struct {
 
 // Explain reports high-level sandbox status for the runtime.
 //
-// It reuses the same normalized PermissionProfile and managed-backend
-// preflight paths that execution uses (linuxPreflight / macosPreflight).
-// Explain never runs a caller command, never acquires a workspace run lock,
-// and never creates a workspace. On managed profiles it may run the same
-// short backend probe used by execution (for example /bin/true under
-// bubblewrap) and cache the result on the Runtime.
+// It reuses the same normalized PermissionProfile and the same
+// platform-specific preflight probe used by execution. Explain never runs a
+// caller command, never acquires a workspace run lock, and never creates a
+// workspace. On managed profiles it may run that short backend probe (for
+// example /bin/true under bubblewrap) and cache the result on the Runtime.
+// PreflightReady means the core backend probe succeeded; it does not prove
+// that every reported boundary, such as NetworkRestricted isolation, can be
+// established.
+//
+// Context cancellation is checked before the managed probe starts. If the
+// caller cancels after the probe has started, Explain does not interrupt it
+// and may wait for the probe's bounded timeout before returning the probe
+// result.
 //
 // When managed preflight fails, Explain still returns a populated report so
 // callers can inspect the configured status, and also returns the preflight
@@ -190,13 +214,20 @@ func fileSystemSandboxType(profile PermissionProfile) FileSystemSandboxType {
 
 func hasWorkspaceWrite(profile PermissionProfile) bool {
 	for _, rule := range profile.fileSystem.Rules {
-		if rule.Kind != ruleSpecial || rule.Access != accessWrite {
+		if rule.Access != accessWrite {
 			continue
 		}
-		switch rule.Special {
-		case specialWorkspace, specialWork, specialHome, specialTmp,
-			specialRuns, specialOut, specialSkills:
-			return true
+		switch rule.Kind {
+		case ruleSpecial:
+			switch rule.Special {
+			case specialWorkspace, specialWork, specialHome, specialTmp,
+				specialRuns, specialOut, specialSkills:
+				return true
+			}
+		case rulePath:
+			if rule.Path != "" && !filepath.IsAbs(rule.Path) {
+				return true
+			}
 		}
 	}
 	return false

--- a/codeexecutor/sandbox/explain.go
+++ b/codeexecutor/sandbox/explain.go
@@ -62,8 +62,11 @@ const (
 // It is intentionally small: it reports backend selection, filesystem sandbox
 // type, network mode, and preflight readiness. It is not a full policy dump.
 type ExplainReport struct {
-	// RequestedBackend is the backend selected by the caller. An empty value
-	// means the caller did not set WithBackend and is treated as BackendAuto.
+	// RequestedBackend is the backend configured on the Runtime. NewRuntime
+	// defaults it to BackendAuto, including when WithBackend is omitted, so
+	// Explain never reports an empty value for a Runtime from NewRuntime.
+	// An empty value only appears on a zero ExplainReport; String() renders
+	// it as BackendAuto.
 	RequestedBackend BackendType
 	// ResolvedBackend is the backend the current platform would use for the
 	// requested value. It is BackendAuto when the platform has no managed

--- a/codeexecutor/sandbox/explain.go
+++ b/codeexecutor/sandbox/explain.go
@@ -1,0 +1,260 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// PreflightStatus describes whether managed sandbox backend dependencies are
+// ready for execution.
+type PreflightStatus string
+
+const (
+	// PreflightReady means managed backend preflight succeeded.
+	PreflightReady PreflightStatus = "ready"
+	// PreflightFailed means managed backend preflight ran and failed.
+	PreflightFailed PreflightStatus = "failed"
+	// PreflightNotRequired means the active profile does not need a managed
+	// OS sandbox backend.
+	PreflightNotRequired PreflightStatus = "not-required"
+	// PreflightUnsupported means the profile or platform cannot use a managed
+	// OS sandbox backend.
+	PreflightUnsupported PreflightStatus = "unsupported"
+)
+
+// FileSystemSandboxType is the high-level filesystem sandbox mode reported by
+// Explain. It is a status label, not a complete grant list.
+type FileSystemSandboxType string
+
+const (
+	// FileSystemSandboxWorkspaceWrite means the managed profile grants write
+	// access to workspace special paths.
+	FileSystemSandboxWorkspaceWrite FileSystemSandboxType = "workspace-write"
+	// FileSystemSandboxReadOnly means the managed profile does not grant
+	// workspace special-path writes.
+	FileSystemSandboxReadOnly FileSystemSandboxType = "read-only"
+	// FileSystemSandboxDisabled means OS sandbox enforcement is off.
+	FileSystemSandboxDisabled FileSystemSandboxType = "disabled"
+	// FileSystemSandboxExternal means an external sandbox is expected to
+	// enforce filesystem policy.
+	FileSystemSandboxExternal FileSystemSandboxType = "external"
+)
+
+// ExplainReport is a high-level sandbox status summary for operators.
+// It is intentionally small: it reports backend selection, filesystem sandbox
+// type, network mode, and preflight readiness. It is not a full policy dump.
+type ExplainReport struct {
+	RequestedBackend  BackendType
+	ResolvedBackend   BackendType
+	FileSystemSandbox FileSystemSandboxType
+	NetworkMode       NetworkMode
+	PreflightStatus   PreflightStatus
+	// PreflightError is a short operator-facing summary when PreflightStatus
+	// is failed or unsupported after a managed backend probe. It includes the
+	// error kind, backend name, and a sanitized cause. Probe stderr, host
+	// paths from probe output, and environment values are omitted. It must
+	// not be treated as a stable machine-readable protocol.
+	PreflightError string
+}
+
+// Explain reports high-level sandbox status for the runtime.
+//
+// It reuses the same normalized PermissionProfile and managed-backend
+// preflight paths that execution uses (linuxPreflight / macosPreflight).
+// Explain never runs a caller command, never acquires a workspace run lock,
+// and never creates a workspace. On managed profiles it may run the same
+// short backend probe used by execution (for example /bin/true under
+// bubblewrap) and cache the result on the Runtime.
+//
+// When managed preflight fails, Explain still returns a populated report so
+// callers can inspect the configured status, and also returns the preflight
+// error.
+func (r *Runtime) Explain(ctx context.Context) (ExplainReport, error) {
+	if r == nil {
+		return ExplainReport{}, errors.New("nil sandbox runtime")
+	}
+	if err := ctx.Err(); err != nil {
+		return ExplainReport{}, err
+	}
+
+	profile := normalizeProfile(r.profile)
+	report := ExplainReport{
+		RequestedBackend:  r.backend,
+		ResolvedBackend:   resolveExplainBackend(r.backend),
+		FileSystemSandbox: fileSystemSandboxType(profile),
+		NetworkMode:       profile.network.Mode,
+	}
+
+	switch profile.enforcement() {
+	case enforcementDisabled:
+		report.PreflightStatus = PreflightNotRequired
+		return report, nil
+	case enforcementExternal:
+		report.PreflightStatus = PreflightUnsupported
+		return report, nil
+	default:
+		err := r.explainManagedPreflight(ctx)
+		if err != nil {
+			report.PreflightStatus = preflightStatusFromError(err)
+			report.PreflightError = summarizePreflightError(err)
+			return report, err
+		}
+		report.PreflightStatus = PreflightReady
+		return report, nil
+	}
+}
+
+// String returns a concise human-readable status summary. The format is for
+// diagnostics only and is not a stable machine protocol.
+func (report ExplainReport) String() string {
+	backend := string(report.RequestedBackend)
+	if backend == "" {
+		backend = string(BackendAuto)
+	}
+	resolved := string(report.ResolvedBackend)
+	if resolved == "" {
+		resolved = backend
+	}
+	backendLine := backend
+	if resolved != backend {
+		backendLine = backend + " -> " + resolved
+	}
+
+	preflight := string(report.PreflightStatus)
+	if preflight == "" {
+		preflight = string(PreflightNotRequired)
+	}
+	if report.PreflightError != "" &&
+		(report.PreflightStatus == PreflightFailed ||
+			report.PreflightStatus == PreflightUnsupported) {
+		preflight = string(report.PreflightStatus) + ": " + report.PreflightError
+	}
+
+	fs := report.FileSystemSandbox
+	if fs == "" {
+		fs = FileSystemSandboxDisabled
+	}
+	network := string(report.NetworkMode)
+	if network == "" {
+		network = string(NetworkRestricted)
+	}
+
+	return fmt.Sprintf(
+		"Sandbox\n  backend:    %s\n  filesystem: %s\n  network:    %s\n  preflight:  %s",
+		backendLine,
+		fs,
+		network,
+		preflight,
+	)
+}
+
+func resolveExplainBackend(requested BackendType) BackendType {
+	if requested != "" && requested != BackendAuto {
+		return requested
+	}
+	switch runtime.GOOS {
+	case "linux":
+		return BackendLinuxBubblewrap
+	case "darwin":
+		return BackendMacOSSandboxExec
+	default:
+		return BackendAuto
+	}
+}
+
+func fileSystemSandboxType(profile PermissionProfile) FileSystemSandboxType {
+	switch profile.enforcement() {
+	case enforcementDisabled:
+		return FileSystemSandboxDisabled
+	case enforcementExternal:
+		return FileSystemSandboxExternal
+	default:
+		if hasWorkspaceWrite(profile) {
+			return FileSystemSandboxWorkspaceWrite
+		}
+		return FileSystemSandboxReadOnly
+	}
+}
+
+func hasWorkspaceWrite(profile PermissionProfile) bool {
+	for _, rule := range profile.fileSystem.Rules {
+		if rule.Kind != ruleSpecial || rule.Access != accessWrite {
+			continue
+		}
+		switch rule.Special {
+		case specialWorkspace, specialWork, specialHome, specialTmp,
+			specialRuns, specialOut, specialSkills:
+			return true
+		}
+	}
+	return false
+}
+
+func preflightStatusFromError(err error) PreflightStatus {
+	if err == nil {
+		return PreflightReady
+	}
+	if isKind(err, ErrUnsupportedBackend) {
+		return PreflightUnsupported
+	}
+	return PreflightFailed
+}
+
+func summarizePreflightError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var se *sandboxError
+	if errors.As(err, &se) && se != nil {
+		parts := []string{string(se.Kind)}
+		if se.Backend != "" {
+			parts = append(parts, "backend="+se.Backend)
+		}
+		if cause := sanitizedPreflightCause(se.Err); cause != "" {
+			parts = append(parts, cause)
+		}
+		return truncateExplainText(strings.Join(parts, " "))
+	}
+	return truncateExplainText(firstLine(err.Error()))
+}
+
+// sanitizedPreflightCause keeps a short operator-facing cause. Probe errors
+// wrap the exec failure and attach stderr; Unwrap drops that attached output
+// so host paths and mount details do not leak into Explain.
+func sanitizedPreflightCause(err error) string {
+	if err == nil {
+		return ""
+	}
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		err = unwrapped
+	}
+	return firstLine(err.Error())
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+func truncateExplainText(s string) string {
+	const maxLen = 200
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/codeexecutor/sandbox/explain_test.go
+++ b/codeexecutor/sandbox/explain_test.go
@@ -1,0 +1,409 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestExplainProfilesAndNetworkModes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		profile    PermissionProfile
+		wantFS     FileSystemSandboxType
+		wantNet    NetworkMode
+		wantStatus PreflightStatus
+		wantErr    bool
+	}{
+		{
+			name:       "workspace-write restricted",
+			profile:    WorkspaceWriteProfile(),
+			wantFS:     FileSystemSandboxWorkspaceWrite,
+			wantNet:    NetworkRestricted,
+			wantStatus: "", // platform-dependent managed status
+		},
+		{
+			name:       "read-only restricted",
+			profile:    ReadOnlyProfile(),
+			wantFS:     FileSystemSandboxReadOnly,
+			wantNet:    NetworkRestricted,
+			wantStatus: "",
+		},
+		{
+			name:       "disabled",
+			profile:    DangerFullAccessProfile(),
+			wantFS:     FileSystemSandboxDisabled,
+			wantNet:    NetworkEnabled,
+			wantStatus: PreflightNotRequired,
+		},
+		{
+			name: "external",
+			profile: ExternalSandboxProfile(NetworkPolicy{
+				Mode: NetworkEnabled,
+			}),
+			wantFS:     FileSystemSandboxExternal,
+			wantNet:    NetworkEnabled,
+			wantStatus: PreflightUnsupported,
+		},
+		{
+			name: "workspace-write enabled network",
+			profile: WorkspaceWriteProfile().WithNetworkPolicy(NetworkPolicy{
+				Mode: NetworkEnabled,
+			}),
+			wantFS:     FileSystemSandboxWorkspaceWrite,
+			wantNet:    NetworkEnabled,
+			wantStatus: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rt := NewRuntime(WithPermissionProfile(tc.profile))
+			report, err := rt.Explain(context.Background())
+			if report.FileSystemSandbox != tc.wantFS {
+				t.Fatalf("filesystem = %q, want %q", report.FileSystemSandbox, tc.wantFS)
+			}
+			if report.NetworkMode != tc.wantNet {
+				t.Fatalf("network = %q, want %q", report.NetworkMode, tc.wantNet)
+			}
+			if tc.wantStatus != "" {
+				if report.PreflightStatus != tc.wantStatus {
+					t.Fatalf("preflight = %q, want %q", report.PreflightStatus, tc.wantStatus)
+				}
+				if err != nil {
+					t.Fatalf("Explain() unexpected error: %v", err)
+				}
+				return
+			}
+			assertManagedExplainStatus(t, report, err)
+		})
+	}
+}
+
+func TestExplainBackendAutoAndExplicit(t *testing.T) {
+	t.Parallel()
+
+	auto := NewRuntime()
+	report, err := auto.Explain(context.Background())
+	if report.RequestedBackend != BackendAuto {
+		t.Fatalf("requested = %q, want %q", report.RequestedBackend, BackendAuto)
+	}
+	wantResolved := resolveExplainBackend(BackendAuto)
+	if report.ResolvedBackend != wantResolved {
+		t.Fatalf("resolved = %q, want %q", report.ResolvedBackend, wantResolved)
+	}
+	assertManagedExplainStatus(t, report, err)
+
+	explicit := BackendLinuxBubblewrap
+	if runtime.GOOS == "darwin" {
+		explicit = BackendMacOSSandboxExec
+	}
+	rt := NewRuntime(WithBackend(explicit))
+	report, err = rt.Explain(context.Background())
+	if report.RequestedBackend != explicit || report.ResolvedBackend != explicit {
+		t.Fatalf("backend = %q -> %q, want %q -> %q",
+			report.RequestedBackend, report.ResolvedBackend, explicit, explicit)
+	}
+	assertManagedExplainStatus(t, report, err)
+}
+
+func TestExplainUnsupportedBackend(t *testing.T) {
+	t.Parallel()
+
+	var wrong BackendType
+	switch runtime.GOOS {
+	case "linux":
+		wrong = BackendMacOSSandboxExec
+	case "darwin":
+		wrong = BackendLinuxBubblewrap
+	default:
+		wrong = BackendLinuxBubblewrap
+	}
+	rt := NewRuntime(
+		WithBackend(wrong),
+		WithPermissionProfile(WorkspaceWriteProfile()),
+	)
+	report, err := rt.Explain(context.Background())
+	if report.RequestedBackend != wrong || report.ResolvedBackend != wrong {
+		t.Fatalf("backend = %q -> %q, want %q",
+			report.RequestedBackend, report.ResolvedBackend, wrong)
+	}
+	if report.PreflightStatus != PreflightUnsupported {
+		t.Fatalf("preflight = %q, want %q", report.PreflightStatus, PreflightUnsupported)
+	}
+	if err == nil {
+		t.Fatal("Explain() error = nil, want unsupported backend error")
+	}
+	if report.PreflightError == "" {
+		t.Fatal("PreflightError is empty")
+	}
+	if !isKind(err, ErrUnsupportedBackend) {
+		t.Fatalf("error kind = %v, want %s", err, ErrUnsupportedBackend)
+	}
+}
+
+func TestExplainContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	rt := NewRuntime(WithPermissionProfile(WorkspaceWriteProfile()))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	report, err := rt.Explain(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if report.FileSystemSandbox != "" || report.PreflightStatus != "" {
+		// Before preflight starts, canceled context returns immediately.
+		t.Fatalf("unexpected partial report on canceled context: %+v", report)
+	}
+}
+
+func TestExplainReportString(t *testing.T) {
+	t.Parallel()
+
+	report := ExplainReport{
+		RequestedBackend:  BackendAuto,
+		ResolvedBackend:   BackendLinuxBubblewrap,
+		FileSystemSandbox: FileSystemSandboxWorkspaceWrite,
+		NetworkMode:       NetworkRestricted,
+		PreflightStatus:   PreflightReady,
+	}
+	got := report.String()
+	for _, want := range []string{
+		"Sandbox",
+		"backend:    auto -> linux-bubblewrap",
+		"filesystem: workspace-write",
+		"network:    restricted",
+		"preflight:  ready",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("String() missing %q\n%s", want, got)
+		}
+	}
+
+	failed := ExplainReport{
+		RequestedBackend:  BackendLinuxBubblewrap,
+		ResolvedBackend:   BackendLinuxBubblewrap,
+		FileSystemSandbox: FileSystemSandboxReadOnly,
+		NetworkMode:       NetworkEnabled,
+		PreflightStatus:   PreflightFailed,
+		PreflightError:    "SetupFailed backend=linux-bubblewrap bubblewrap executable not found in PATH",
+	}
+	text := failed.String()
+	if !strings.Contains(text, "preflight:  failed:") {
+		t.Fatalf("failed String() = %q", text)
+	}
+	for _, secret := range []string{
+		"PASSWORD=",
+		"TOKEN=",
+		"API_KEY=",
+		"--setenv",
+		"HOME=/",
+	} {
+		if strings.Contains(text, secret) {
+			t.Fatalf("String() leaked %q\n%s", secret, text)
+		}
+	}
+
+	unsupported := ExplainReport{
+		RequestedBackend:  BackendLinuxBubblewrap,
+		ResolvedBackend:   BackendLinuxBubblewrap,
+		FileSystemSandbox: FileSystemSandboxExternal,
+		NetworkMode:       NetworkEnabled,
+		PreflightStatus:   PreflightUnsupported,
+		PreflightError:    "UnsupportedBackend backend=linux-bubblewrap",
+	}
+	if !strings.Contains(unsupported.String(), "preflight:  unsupported:") {
+		t.Fatalf("unsupported String() = %q", unsupported.String())
+	}
+}
+
+func TestExplainNilRuntime(t *testing.T) {
+	t.Parallel()
+
+	var rt *Runtime
+	report, err := rt.Explain(context.Background())
+	if err == nil || err.Error() != "nil sandbox runtime" {
+		t.Fatalf("error = %v, want nil sandbox runtime", err)
+	}
+	if report != (ExplainReport{}) {
+		t.Fatalf("report = %+v, want zero value", report)
+	}
+}
+
+func TestExplainSetupFailed(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux bubblewrap PATH probe only")
+	}
+	t.Setenv("PATH", "")
+	rt := NewRuntime(WithPermissionProfile(WorkspaceWriteProfile()))
+	report, err := rt.Explain(context.Background())
+	if report.PreflightStatus != PreflightFailed {
+		t.Fatalf("preflight = %q, want %q", report.PreflightStatus, PreflightFailed)
+	}
+	if err == nil || !isKind(err, ErrSetupFailed) {
+		t.Fatalf("error = %v, want ErrSetupFailed", err)
+	}
+	if report.PreflightError == "" {
+		t.Fatal("PreflightError is empty")
+	}
+	if !strings.Contains(report.PreflightError, string(ErrSetupFailed)) {
+		t.Fatalf("PreflightError missing kind: %q", report.PreflightError)
+	}
+	if strings.Contains(report.PreflightError, "\n") {
+		t.Fatalf("PreflightError contains newline: %q", report.PreflightError)
+	}
+}
+
+func TestExplainManagedPreflightHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	rt := NewRuntime(WithPermissionProfile(WorkspaceWriteProfile()))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := rt.explainManagedPreflight(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestExplainReportStringZeroValues(t *testing.T) {
+	t.Parallel()
+
+	got := ExplainReport{}.String()
+	for _, want := range []string{
+		"backend:    auto",
+		"filesystem: disabled",
+		"network:    restricted",
+		"preflight:  not-required",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("zero-value String() missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestPreflightStatusFromError(t *testing.T) {
+	t.Parallel()
+
+	if got := preflightStatusFromError(nil); got != PreflightReady {
+		t.Fatalf("nil = %q, want %q", got, PreflightReady)
+	}
+	if got := preflightStatusFromError(backendError(ErrUnsupportedBackend, "linux-bubblewrap", errors.New("no"))); got != PreflightUnsupported {
+		t.Fatalf("unsupported = %q", got)
+	}
+	if got := preflightStatusFromError(backendError(ErrSetupFailed, "linux-bubblewrap", errors.New("missing"))); got != PreflightFailed {
+		t.Fatalf("setup failed = %q", got)
+	}
+}
+
+func TestSummarizePreflightErrorTruncates(t *testing.T) {
+	t.Parallel()
+
+	err := backendError(
+		ErrSetupFailed,
+		string(BackendLinuxBubblewrap),
+		errors.New(strings.Repeat("x", 300)+"\nsecond-line"),
+	)
+	got := summarizePreflightError(err)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("summary contains newline: %q", got)
+	}
+	if len(got) > 210 {
+		t.Fatalf("summary too long: %d", len(got))
+	}
+	if !strings.Contains(got, string(ErrSetupFailed)) {
+		t.Fatalf("summary missing kind: %q", got)
+	}
+}
+
+type probeCause struct {
+	err    error
+	stderr string
+}
+
+func (e probeCause) Error() string {
+	return e.err.Error() + ": " + e.stderr
+}
+
+func (e probeCause) Unwrap() error {
+	return e.err
+}
+
+func TestSummarizePreflightErrorOmitsProbeStderr(t *testing.T) {
+	t.Parallel()
+
+	if got := summarizePreflightError(nil); got != "" {
+		t.Fatalf("nil summary = %q", got)
+	}
+	if got := summarizePreflightError(errors.New("plain cause")); got != "plain cause" {
+		t.Fatalf("plain summary = %q", got)
+	}
+
+	got := summarizePreflightError(backendError(
+		ErrSetupFailed,
+		string(BackendLinuxBubblewrap),
+		probeCause{
+			err:    errors.New("exit status 1"),
+			stderr: "bwrap: Can't mount proc on /host/secret/path: Permission denied",
+		},
+	))
+	if strings.Contains(got, "/host/secret/path") || strings.Contains(got, "Can't mount proc") {
+		t.Fatalf("summary leaked probe stderr: %q", got)
+	}
+	if !strings.Contains(got, string(ErrSetupFailed)) || !strings.Contains(got, "exit status 1") {
+		t.Fatalf("summary = %q, want kind and unwrapped cause", got)
+	}
+
+	emptyCause := summarizePreflightError(backendError(ErrSetupFailed, string(BackendLinuxBubblewrap), nil))
+	if emptyCause != string(ErrSetupFailed)+" backend="+string(BackendLinuxBubblewrap) {
+		t.Fatalf("empty cause summary = %q", emptyCause)
+	}
+}
+
+func assertManagedExplainStatus(t *testing.T, report ExplainReport, err error) {
+	t.Helper()
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		switch report.PreflightStatus {
+		case PreflightReady:
+			if err != nil {
+				t.Fatalf("ready status with error: %v", err)
+			}
+			if report.PreflightError != "" {
+				t.Fatalf("ready status with PreflightError %q", report.PreflightError)
+			}
+		case PreflightFailed, PreflightUnsupported:
+			if err == nil {
+				t.Fatal("non-ready managed status requires an error")
+			}
+			if report.PreflightError == "" {
+				t.Fatal("non-ready managed status requires PreflightError")
+			}
+		default:
+			t.Fatalf("unexpected managed preflight status %q", report.PreflightStatus)
+		}
+	default:
+		if report.PreflightStatus != PreflightUnsupported {
+			t.Fatalf("preflight = %q, want %q", report.PreflightStatus, PreflightUnsupported)
+		}
+		if err == nil {
+			t.Fatal("unsupported platform requires an error")
+		}
+	}
+}

--- a/codeexecutor/sandbox/explain_test.go
+++ b/codeexecutor/sandbox/explain_test.go
@@ -12,9 +12,13 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
 )
 
 func TestExplainProfilesAndNetworkModes(t *testing.T) {
@@ -26,7 +30,6 @@ func TestExplainProfilesAndNetworkModes(t *testing.T) {
 		wantFS     FileSystemSandboxType
 		wantNet    NetworkMode
 		wantStatus PreflightStatus
-		wantErr    bool
 	}{
 		{
 			name:       "workspace-write restricted",
@@ -38,6 +41,20 @@ func TestExplainProfilesAndNetworkModes(t *testing.T) {
 		{
 			name:       "read-only restricted",
 			profile:    ReadOnlyProfile(),
+			wantFS:     FileSystemSandboxReadOnly,
+			wantNet:    NetworkRestricted,
+			wantStatus: "",
+		},
+		{
+			name:       "read-only with workspace-relative write path",
+			profile:    ReadOnlyProfile().WithWritePaths("work"),
+			wantFS:     FileSystemSandboxWorkspaceWrite,
+			wantNet:    NetworkRestricted,
+			wantStatus: "",
+		},
+		{
+			name:       "read-only with host-absolute write path",
+			profile:    ReadOnlyProfile().WithWritePaths("/tmp/host-write"),
 			wantFS:     FileSystemSandboxReadOnly,
 			wantNet:    NetworkRestricted,
 			wantStatus: "",
@@ -170,6 +187,60 @@ func TestExplainContextCanceled(t *testing.T) {
 	if report.FileSystemSandbox != "" || report.PreflightStatus != "" {
 		// Before preflight starts, canceled context returns immediately.
 		t.Fatalf("unexpected partial report on canceled context: %+v", report)
+	}
+}
+
+func TestExplainDoesNotCreateWorkspace(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	rt := NewRuntime(
+		WithWorkspaceRoot(root),
+		WithPermissionProfile(WorkspaceWriteProfile()),
+	)
+	if _, err := rt.Explain(context.Background()); err != nil &&
+		!isKind(err, ErrUnsupportedBackend) && !isKind(err, ErrSetupFailed) {
+		t.Fatalf("Explain() unexpected error: %v", err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("Explain created files under workspace root: %v", names)
+	}
+}
+
+func TestExplainDoesNotAcquireRunLock(t *testing.T) {
+	t.Parallel()
+
+	rt := NewRuntime(
+		WithWorkspaceRoot(t.TempDir()),
+		WithPermissionProfile(WorkspaceWriteProfile()),
+	)
+	ws := codeexecutor.Workspace{ID: "explain-lock", Path: t.TempDir()}
+	unlock, err := rt.lockWorkspaceRunContext(context.Background(), ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, explainErr := rt.Explain(context.Background())
+		done <- explainErr
+	}()
+	select {
+	case err := <-done:
+		if err != nil && !isKind(err, ErrUnsupportedBackend) && !isKind(err, ErrSetupFailed) {
+			t.Fatalf("Explain() unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Explain blocked on workspace run lock")
 	}
 }
 

--- a/codeexecutor/sandbox/explain_test.go
+++ b/codeexecutor/sandbox/explain_test.go
@@ -222,6 +222,12 @@ func TestExplainDoesNotAcquireRunLock(t *testing.T) {
 		WithWorkspaceRoot(t.TempDir()),
 		WithPermissionProfile(WorkspaceWriteProfile()),
 	)
+	// Prime the shared preflight cache so this assertion does not wait on a
+	// real backend probe (Linux probes can take up to 5s, with a retry).
+	rt.preflightOnce.Do(func() {
+		rt.bwrapPath = "/bin/true"
+		rt.seatbeltPath = "/usr/bin/sandbox-exec"
+	})
 	ws := codeexecutor.Workspace{ID: "explain-lock", Path: t.TempDir()}
 	unlock, err := rt.lockWorkspaceRunContext(context.Background(), ws)
 	if err != nil {

--- a/knowledge/document/reader/python/go.mod
+++ b/knowledge/document/reader/python/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace trpc.group/trpc-go/trpc-agent-go => ../../../..
 
-require trpc.group/trpc-go/trpc-agent-go v1.10.1-0.20260605075142-de51b6b2b584
+require trpc.group/trpc-go/trpc-agent-go v1.11.1
 
 require (
 	github.com/yuin/goldmark v1.4.13 // indirect


### PR DESCRIPTION
## Summary

- Add `Runtime.Explain` to report compact sandbox status: requested/resolved backend, filesystem sandbox type, network mode, and managed preflight readiness.
- Reuse existing `linuxPreflight` / `macosPreflight`. Explain does not run caller commands, acquire a workspace run lock, or create a workspace. On preflight failure it still returns a populated report plus a short error summary with probe stderr stripped.
- Add `explain.go` tests and update sandbox README / Godoc.

## Why

Operators need a quick view of the active backend, filesystem and network boundaries, and whether sandbox dependencies are ready. Explain reports only this core status so sandbox setup can be diagnosed without dumping the full policy.

## Test plan

- [ ] `go test ./codeexecutor/sandbox -count=1`
- [ ] `go test -race ./codeexecutor/sandbox -count=1`
