### PR TITLE
knowledge: align root module versions

### DIFF
--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -24,7 +24,7 @@ replace (
 require (
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/jackc/pgx/v5 v5.7.2
-	trpc.group/trpc-go/trpc-agent-go v1.10.1-0.20260605075142-de51b6b2b584
+	trpc.group/trpc-go/trpc-agent-go v1.11.1
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/python v0.0.0

--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -27,7 +27,7 @@ require (
 	trpc.group/trpc-go/trpc-agent-go v1.11.1
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
-	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/python v0.0.0
+	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/python v1.11.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v0.2.1

--- a/knowledge/document/reader/python/go.mod
+++ b/knowledge/document/reader/python/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace trpc.group/trpc-go/trpc-agent-go => ../../../..
 
-require trpc.group/trpc-go/trpc-agent-go v1.10.1-0.20260605075142-de51b6b2b584
+require trpc.group/trpc-go/trpc-agent-go v1.11.1
 
 require (
 	github.com/yuin/goldmark v1.4.13 // indirect


### PR DESCRIPTION
Align the Python reader and knowledge example with the released root module version so their module files remain tidy and build with `-mod=readonly`.