### PR TITLE
{internal/state/summaryfork, internal/state/summaryview}: avoid cloning immutable invocation snapshots

### DIFF
--- a/internal/flow/processor/functioncall_bench_test.go
+++ b/internal/flow/processor/functioncall_bench_test.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package processor
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+var parallelInvocationViewSink *agent.Invocation
+
+func BenchmarkParallelInvocationView(b *testing.B) {
+	for _, historySize := range []int{256, 1024} {
+		b.Run(fmt.Sprintf("history=%d", historySize), func(b *testing.B) {
+			invocation := parallelInvocationBenchmarkInput(historySize)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				parallelInvocationViewSink = newParallelInvocationView(invocation)
+			}
+		})
+	}
+}
+
+func parallelInvocationBenchmarkInput(historySize int) *agent.Invocation {
+	invocation := agent.NewInvocation(agent.WithInvocationSession(&session.Session{}))
+	messages := make([]model.Message, historySize)
+	items := make([]summaryview.Item, historySize)
+	for i := 0; i < historySize; i++ {
+		arguments := bytes.Repeat([]byte{'a' + byte(i%26)}, 256)
+		message := model.Message{
+			Role:    model.RoleAssistant,
+			Content: "parallel tool call history",
+			ToolCalls: []model.ToolCall{{
+				ID: fmt.Sprintf("call-%d", i),
+				Function: model.FunctionDefinitionParam{
+					Name:      "write_file",
+					Arguments: arguments,
+				},
+			}},
+		}
+		messages[i] = message
+		items[i] = summaryview.Item{
+			Message: message,
+			EffectiveEvent: event.Event{
+				Response: &model.Response{Choices: []model.Choice{{Message: message}}},
+				StateDelta: map[string][]byte{
+					"history": bytes.Repeat([]byte{'v'}, 256),
+				},
+			},
+		}
+	}
+	summaryview.AttachProjection(invocation, &summaryview.View{Items: items})
+	summaryfork.Attach(invocation, &model.Request{Messages: messages})
+	return invocation
+}

--- a/internal/state/statecopy/message.go
+++ b/internal/state/statecopy/message.go
@@ -1,0 +1,100 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package statecopy provides deep-copy helpers for state snapshot boundaries.
+package statecopy
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Message returns a deep copy of message.
+func Message(message model.Message) model.Message {
+	cloned := message
+	cloned.ContentParts = cloneContentParts(message.ContentParts)
+	cloned.ToolCalls = cloneToolCalls(message.ToolCalls)
+	return cloned
+}
+
+// Messages returns deep copies of messages and preserves a nil input.
+func Messages(messages []model.Message) []model.Message {
+	if messages == nil {
+		return nil
+	}
+	cloned := make([]model.Message, len(messages))
+	for i := range messages {
+		cloned[i] = Message(messages[i])
+	}
+	return cloned
+}
+
+func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]model.ContentPart, len(parts))
+	for i := range parts {
+		cloned[i] = cloneContentPart(parts[i])
+	}
+	return cloned
+}
+
+func cloneContentPart(part model.ContentPart) model.ContentPart {
+	cloned := part
+	if part.Text != nil {
+		text := *part.Text
+		cloned.Text = &text
+	}
+	if part.Image != nil {
+		image := *part.Image
+		image.Data = append([]byte(nil), part.Image.Data...)
+		cloned.Image = &image
+	}
+	if part.Audio != nil {
+		audio := *part.Audio
+		audio.Data = append([]byte(nil), part.Audio.Data...)
+		cloned.Audio = &audio
+	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = append([]byte(nil), part.Video.Data...)
+		cloned.Video = &video
+	}
+	if part.File != nil {
+		file := *part.File
+		file.Data = append([]byte(nil), part.File.Data...)
+		cloned.File = &file
+	}
+	if part.ContentRef != nil {
+		contentRef := *part.ContentRef
+		cloned.ContentRef = &contentRef
+	}
+	return cloned
+}
+
+func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+	cloned := make([]model.ToolCall, len(toolCalls))
+	for i := range toolCalls {
+		cloned[i] = toolCalls[i]
+		cloned[i].Function.Arguments = append(
+			[]byte(nil),
+			toolCalls[i].Function.Arguments...,
+		)
+		if toolCalls[i].Index != nil {
+			index := *toolCalls[i].Index
+			cloned[i].Index = &index
+		}
+		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
+	}
+	return cloned
+}

--- a/internal/state/statecopy/message_test.go
+++ b/internal/state/statecopy/message_test.go
@@ -1,0 +1,78 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package statecopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestMessagesAreIsolated(t *testing.T) {
+	require.Nil(t, Messages(nil))
+	zero := Message(model.Message{})
+	require.Nil(t, zero.ContentParts)
+	require.Nil(t, zero.ToolCalls)
+
+	text := "text"
+	index := 1
+	original := []model.Message{{
+		ContentParts: []model.ContentPart{
+			{Text: &text},
+			{
+				Image: &model.Image{Data: []byte("image")},
+				ContentRef: &model.ContentRef{
+					ArtifactName: "original",
+				},
+			},
+			{Audio: &model.Audio{Data: []byte("audio")}},
+			{Video: &model.Video{Data: []byte("video")}},
+			{File: &model.File{Data: []byte("file")}},
+		},
+		ToolCalls: []model.ToolCall{{
+			Index: &index,
+			Function: model.FunctionDefinitionParam{
+				Arguments: []byte("arguments"),
+			},
+			ExtraFields: map[string]any{
+				"nested": map[string]any{"value": "original"},
+			},
+		}},
+	}}
+
+	cloned := Messages(original)
+	*cloned[0].ContentParts[0].Text = "mutated"
+	cloned[0].ContentParts[1].Image.Data[0] = 'X'
+	cloned[0].ContentParts[1].ContentRef.ArtifactName = "mutated"
+	cloned[0].ContentParts[2].Audio.Data[0] = 'X'
+	cloned[0].ContentParts[3].Video.Data[0] = 'X'
+	cloned[0].ContentParts[4].File.Data[0] = 'X'
+	cloned[0].ToolCalls[0].Function.Arguments[0] = 'X'
+	*cloned[0].ToolCalls[0].Index = 2
+	cloned[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"] =
+		"mutated"
+
+	require.Equal(t, "text", *original[0].ContentParts[0].Text)
+	require.Equal(t, "image", string(original[0].ContentParts[1].Image.Data))
+	require.Equal(t, "original",
+		original[0].ContentParts[1].ContentRef.ArtifactName,
+	)
+	require.Equal(t, "audio", string(original[0].ContentParts[2].Audio.Data))
+	require.Equal(t, "video", string(original[0].ContentParts[3].Video.Data))
+	require.Equal(t, "file", string(original[0].ContentParts[4].File.Data))
+	require.Equal(t, "arguments", string(
+		original[0].ToolCalls[0].Function.Arguments,
+	))
+	require.Equal(t, 1, *original[0].ToolCalls[0].Index)
+	require.Equal(t, "original",
+		original[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"],
+	)
+}

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -13,6 +13,7 @@ package summaryfork
 import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/statecopy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -65,7 +66,7 @@ func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
 	}
 
 	next := cloneRequest(state.request)
-	next.Messages = append(next.Messages, cloneMessages(messages)...)
+	next.Messages = append(next.Messages, statecopy.Messages(messages)...)
 	inv.SetState(stateKey, &invocationState{request: next})
 }
 
@@ -111,95 +112,13 @@ func cloneRequest(req *model.Request) *model.Request {
 	}
 
 	cloned := *req
-	cloned.Messages = cloneMessages(req.Messages)
+	cloned.Messages = statecopy.Messages(req.Messages)
 	cloned.GenerationConfig = cloneGenerationConfig(req.GenerationConfig)
 	cloned.StructuredOutput = cloneStructuredOutput(req.StructuredOutput)
 	cloned.ExtraFields = jsonmap.Clone(req.ExtraFields)
 	cloned.Headers = cloneHeaders(req.Headers)
 	cloned.Tools = cloneTools(req.Tools)
 	return &cloned
-}
-
-func cloneMessages(messages []model.Message) []model.Message {
-	if messages == nil {
-		return nil
-	}
-	cloned := make([]model.Message, len(messages))
-	for i := range messages {
-		cloned[i] = cloneMessage(messages[i])
-	}
-	return cloned
-}
-
-func cloneMessage(msg model.Message) model.Message {
-	cloned := msg
-	cloned.ContentParts = cloneContentParts(msg.ContentParts)
-	cloned.ToolCalls = cloneToolCalls(msg.ToolCalls)
-	return cloned
-}
-
-func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
-	if parts == nil {
-		return nil
-	}
-	cloned := make([]model.ContentPart, len(parts))
-	for i := range parts {
-		cloned[i] = cloneContentPart(parts[i])
-	}
-	return cloned
-}
-
-func cloneContentPart(part model.ContentPart) model.ContentPart {
-	cloned := part
-	if part.Text != nil {
-		text := *part.Text
-		cloned.Text = &text
-	}
-	if part.Image != nil {
-		image := *part.Image
-		image.Data = append([]byte(nil), part.Image.Data...)
-		cloned.Image = &image
-	}
-	if part.Audio != nil {
-		audio := *part.Audio
-		audio.Data = append([]byte(nil), part.Audio.Data...)
-		cloned.Audio = &audio
-	}
-	if part.Video != nil {
-		video := *part.Video
-		video.Data = append([]byte(nil), part.Video.Data...)
-		cloned.Video = &video
-	}
-	if part.File != nil {
-		file := *part.File
-		file.Data = append([]byte(nil), part.File.Data...)
-		cloned.File = &file
-	}
-	if part.ContentRef != nil {
-		contentRef := *part.ContentRef
-		cloned.ContentRef = &contentRef
-	}
-	return cloned
-}
-
-func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
-	if toolCalls == nil {
-		return nil
-	}
-	cloned := make([]model.ToolCall, len(toolCalls))
-	for i := range toolCalls {
-		cloned[i] = toolCalls[i]
-		cloned[i].Function.Arguments = append(
-			[]byte(nil),
-			toolCalls[i].Function.Arguments...,
-		)
-		if toolCalls[i].Index != nil {
-			index := *toolCalls[i].Index
-			cloned[i].Index = &index
-		}
-		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
-	}
-	return cloned
 }
 
 func cloneGenerationConfig(cfg model.GenerationConfig) model.GenerationConfig {

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -19,21 +19,28 @@ import (
 
 const stateKey = "trpc_agent.summary.cache_safe_fork_request"
 
+// invocationState keeps an immutable snapshot opaque to Invocation.View's
+// generic state cloner. Mutations must replace the holder instead of changing
+// the stored request in place.
+type invocationState struct {
+	request *model.Request
+}
+
 // Attach stores a snapshot of the parent model request on the invocation.
 func Attach(inv *agent.Invocation, req *model.Request) {
 	if inv == nil || req == nil {
 		return
 	}
-	inv.SetState(stateKey, cloneRequest(req))
+	inv.SetState(stateKey, &invocationState{request: cloneRequest(req)})
 }
 
 // Request returns a snapshot of the parent model request, if one exists.
 func Request(inv *agent.Invocation) (*model.Request, bool) {
-	req, ok := agent.GetStateValue[*model.Request](inv, stateKey)
-	if !ok || req == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.request == nil {
 		return nil, false
 	}
-	return cloneRequest(req), true
+	return cloneRequest(state.request), true
 }
 
 // Invalidate removes the current cache-safe request snapshot. Summarization
@@ -48,8 +55,8 @@ func Invalidate(inv *agent.Invocation) {
 // AppendResponse appends persisted response messages to the stored request
 // snapshot. It is a no-op when no snapshot is present.
 func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
-	req, ok := agent.GetStateValue[*model.Request](inv, stateKey)
-	if !ok || req == nil || rsp == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.request == nil || rsp == nil {
 		return
 	}
 	messages := responseMessages(rsp)
@@ -57,9 +64,9 @@ func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
 		return
 	}
 
-	next := cloneRequest(req)
+	next := cloneRequest(state.request)
 	next.Messages = append(next.Messages, cloneMessages(messages)...)
-	inv.SetState(stateKey, next)
+	inv.SetState(stateKey, &invocationState{request: next})
 }
 
 func responseMessages(rsp *model.Response) []model.Message {

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -175,6 +175,10 @@ func cloneContentPart(part model.ContentPart) model.ContentPart {
 		file.Data = append([]byte(nil), part.File.Data...)
 		cloned.File = &file
 	}
+	if part.ContentRef != nil {
+		contentRef := *part.ContentRef
+		cloned.ContentRef = &contentRef
+	}
 	return cloned
 }
 

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -233,6 +233,26 @@ func TestInvocationViewAppendIsIsolated(t *testing.T) {
 	require.Equal(t, "question", originalRequest.Messages[0].Content)
 }
 
+func TestInvocationViewRequestContentRefIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	Attach(invocation, &model.Request{Messages: []model.Message{{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{{
+			ContentRef: &model.ContentRef{ArtifactName: "original"},
+		}},
+	}}})
+
+	viewRequest, ok := Request(invocation.View())
+	require.True(t, ok)
+	viewRequest.Messages[0].ContentParts[0].ContentRef.ArtifactName = "mutated"
+
+	originalRequest, ok := Request(invocation)
+	require.True(t, ok)
+	require.Equal(t, "original",
+		originalRequest.Messages[0].ContentParts[0].ContentRef.ArtifactName,
+	)
+}
+
 func TestInvalidateClearsSnapshotUntilNextAttach(t *testing.T) {
 	inv := agent.NewInvocation()
 	req := &model.Request{

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -212,6 +212,27 @@ func TestAppendResponseExtendsSnapshot(t *testing.T) {
 	require.Equal(t, "result", got.Messages[3].Content)
 }
 
+func TestInvocationViewAppendIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	Attach(invocation, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+	})
+
+	view := invocation.View()
+	AppendResponse(view, &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage("answer"),
+	}}})
+
+	viewRequest, ok := Request(view)
+	require.True(t, ok)
+	require.Len(t, viewRequest.Messages, 2)
+
+	originalRequest, ok := Request(invocation)
+	require.True(t, ok)
+	require.Len(t, originalRequest.Messages, 1)
+	require.Equal(t, "question", originalRequest.Messages[0].Content)
+}
+
 func TestInvalidateClearsSnapshotUntilNextAttach(t *testing.T) {
 	inv := agent.NewInvocation()
 	req := &model.Request{

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -19,7 +19,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
-	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/statecopy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -241,7 +241,7 @@ func bindItems(view *View, messages []model.Message) bool {
 			return false
 		}
 		item.RequestIndex = index
-		item.Message = cloneMessage(messages[index])
+		item.Message = statecopy.Message(messages[index])
 		setEffectiveMessage(&item.EffectiveEvent, item.Message)
 		previous = index
 	}
@@ -308,7 +308,7 @@ func cloneView(view *View) *View {
 	cloned.Items = make([]Item, len(view.Items))
 	for i := range view.Items {
 		cloned.Items[i] = view.Items[i]
-		cloned.Items[i].Message = cloneMessage(view.Items[i].Message)
+		cloned.Items[i].Message = statecopy.Message(view.Items[i].Message)
 		cloned.Items[i].EffectiveEvent = cloneEvent(view.Items[i].EffectiveEvent)
 	}
 	return &cloned
@@ -320,11 +320,21 @@ func cloneEvent(evt event.Event) event.Event {
 		cloned.Response = evt.Response.Clone()
 		for i := range cloned.Response.Choices {
 			choice := &cloned.Response.Choices[i]
-			choice.Message = cloneMessage(evt.Response.Choices[i].Message)
-			choice.Delta = cloneMessage(evt.Response.Choices[i].Delta)
+			choice.Message = statecopy.Message(evt.Response.Choices[i].Message)
+			choice.Delta = statecopy.Message(evt.Response.Choices[i].Delta)
 			if evt.Response.Choices[i].FinishReason != nil {
 				finishReason := *evt.Response.Choices[i].FinishReason
 				choice.FinishReason = &finishReason
+			}
+		}
+		if evt.Response.Error != nil {
+			if evt.Response.Error.Param != nil {
+				param := *evt.Response.Error.Param
+				cloned.Response.Error.Param = &param
+			}
+			if evt.Response.Error.Code != nil {
+				code := *evt.Response.Error.Code
+				cloned.Response.Error.Code = &code
 			}
 		}
 	}
@@ -357,77 +367,6 @@ func cloneEvent(evt event.Event) event.Event {
 	return cloned
 }
 
-func cloneMessage(message model.Message) model.Message {
-	cloned := message
-	cloned.ContentParts = cloneContentParts(message.ContentParts)
-	cloned.ToolCalls = cloneToolCalls(message.ToolCalls)
-	return cloned
-}
-
-func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
-	if parts == nil {
-		return nil
-	}
-	cloned := make([]model.ContentPart, len(parts))
-	for i := range parts {
-		cloned[i] = cloneContentPart(parts[i])
-	}
-	return cloned
-}
-
-func cloneContentPart(part model.ContentPart) model.ContentPart {
-	cloned := part
-	if part.Text != nil {
-		text := *part.Text
-		cloned.Text = &text
-	}
-	if part.Image != nil {
-		image := *part.Image
-		image.Data = append([]byte(nil), part.Image.Data...)
-		cloned.Image = &image
-	}
-	if part.Audio != nil {
-		audio := *part.Audio
-		audio.Data = append([]byte(nil), part.Audio.Data...)
-		cloned.Audio = &audio
-	}
-	if part.Video != nil {
-		video := *part.Video
-		video.Data = append([]byte(nil), part.Video.Data...)
-		cloned.Video = &video
-	}
-	if part.File != nil {
-		file := *part.File
-		file.Data = append([]byte(nil), part.File.Data...)
-		cloned.File = &file
-	}
-	if part.ContentRef != nil {
-		contentRef := *part.ContentRef
-		cloned.ContentRef = &contentRef
-	}
-	return cloned
-}
-
-func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
-	if toolCalls == nil {
-		return nil
-	}
-	cloned := make([]model.ToolCall, len(toolCalls))
-	for i := range toolCalls {
-		cloned[i] = toolCalls[i]
-		cloned[i].Function.Arguments = append(
-			[]byte(nil),
-			toolCalls[i].Function.Arguments...,
-		)
-		if toolCalls[i].Index != nil {
-			index := *toolCalls[i].Index
-			cloned[i].Index = &index
-		}
-		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
-	}
-	return cloned
-}
-
 func setEffectiveMessage(evt *event.Event, message model.Message) {
 	if evt == nil {
 		return
@@ -437,5 +376,5 @@ func setEffectiveMessage(evt *event.Event, message model.Message) {
 	} else {
 		evt.Response = evt.Response.Clone()
 	}
-	evt.Response.Choices = []model.Choice{{Message: cloneMessage(message)}}
+	evt.Response.Choices = []model.Choice{{Message: statecopy.Message(message)}}
 }

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -19,6 +19,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -317,6 +318,19 @@ func cloneEvent(evt event.Event) event.Event {
 	cloned := evt
 	if evt.Response != nil {
 		cloned.Response = evt.Response.Clone()
+		for i := range cloned.Response.Choices {
+			choice := &cloned.Response.Choices[i]
+			choice.Message = cloneMessage(evt.Response.Choices[i].Message)
+			choice.Delta = cloneMessage(evt.Response.Choices[i].Delta)
+			if evt.Response.Choices[i].FinishReason != nil {
+				finishReason := *evt.Response.Choices[i].FinishReason
+				choice.FinishReason = &finishReason
+			}
+		}
+	}
+	if evt.ParentMetadata != nil {
+		parentMetadata := *evt.ParentMetadata
+		cloned.ParentMetadata = &parentMetadata
 	}
 	if evt.LongRunningToolIDs != nil {
 		cloned.LongRunningToolIDs = make(map[string]struct{}, len(evt.LongRunningToolIDs))
@@ -344,8 +358,74 @@ func cloneEvent(evt event.Event) event.Event {
 }
 
 func cloneMessage(message model.Message) model.Message {
-	response := (&model.Response{Choices: []model.Choice{{Message: message}}}).Clone()
-	return response.Choices[0].Message
+	cloned := message
+	cloned.ContentParts = cloneContentParts(message.ContentParts)
+	cloned.ToolCalls = cloneToolCalls(message.ToolCalls)
+	return cloned
+}
+
+func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]model.ContentPart, len(parts))
+	for i := range parts {
+		cloned[i] = cloneContentPart(parts[i])
+	}
+	return cloned
+}
+
+func cloneContentPart(part model.ContentPart) model.ContentPart {
+	cloned := part
+	if part.Text != nil {
+		text := *part.Text
+		cloned.Text = &text
+	}
+	if part.Image != nil {
+		image := *part.Image
+		image.Data = append([]byte(nil), part.Image.Data...)
+		cloned.Image = &image
+	}
+	if part.Audio != nil {
+		audio := *part.Audio
+		audio.Data = append([]byte(nil), part.Audio.Data...)
+		cloned.Audio = &audio
+	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = append([]byte(nil), part.Video.Data...)
+		cloned.Video = &video
+	}
+	if part.File != nil {
+		file := *part.File
+		file.Data = append([]byte(nil), part.File.Data...)
+		cloned.File = &file
+	}
+	if part.ContentRef != nil {
+		contentRef := *part.ContentRef
+		cloned.ContentRef = &contentRef
+	}
+	return cloned
+}
+
+func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+	cloned := make([]model.ToolCall, len(toolCalls))
+	for i := range toolCalls {
+		cloned[i] = toolCalls[i]
+		cloned[i].Function.Arguments = append(
+			[]byte(nil),
+			toolCalls[i].Function.Arguments...,
+		)
+		if toolCalls[i].Index != nil {
+			index := *toolCalls[i].Index
+			cloned[i].Index = &index
+		}
+		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
+	}
+	return cloned
 }
 
 func setEffectiveMessage(evt *event.Event, message model.Message) {

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -26,6 +26,13 @@ const stateKey = "trpc_agent.summary.model_visible_view"
 
 type contextKey struct{}
 
+// invocationState keeps an immutable snapshot opaque to Invocation.View's
+// generic state cloner. Mutations must replace the holder instead of changing
+// the stored view in place.
+type invocationState struct {
+	view *View
+}
+
 // Boundary identifies the latest stored event represented by an item.
 type Boundary struct {
 	EventID   string
@@ -65,7 +72,7 @@ func AttachProjection(inv *agent.Invocation, view *View) {
 	if inv == nil || view == nil {
 		return
 	}
-	inv.SetState(stateKey, cloneView(view))
+	inv.SetState(stateKey, &invocationState{view: cloneView(view)})
 }
 
 // Clear removes the current projection and finalized view.
@@ -84,23 +91,24 @@ func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 	if inv == nil || req == nil {
 		return
 	}
-	view, ok := agent.GetStateValue[*View](inv, stateKey)
-	if !ok || view == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
 		return
 	}
+	view := state.view
 	next := cloneView(view)
 	next.RequestTokens = requestTokens
 	next.Bound = bindItems(next, req.Messages)
-	inv.SetState(stateKey, next)
+	inv.SetState(stateKey, &invocationState{view: next})
 }
 
 // Snapshot returns an isolated copy of the latest model-visible view.
 func Snapshot(inv *agent.Invocation) (*View, bool) {
-	view, ok := agent.GetStateValue[*View](inv, stateKey)
-	if !ok || view == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
 		return nil, false
 	}
-	return cloneView(view), true
+	return cloneView(state.view), true
 }
 
 // ContextWithView attaches an isolated model-visible view to ctx.

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -93,6 +93,32 @@ func TestSnapshotIsIsolated(t *testing.T) {
 	)
 }
 
+func TestInvocationViewFinalizationIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: 1,
+		Items: []Item{{
+			Message:      model.NewUserMessage("visible"),
+			RequestIndex: 0,
+		}},
+	})
+
+	view := invocation.View()
+	Finalize(view, &model.Request{Messages: []model.Message{
+		model.NewUserMessage("visible"),
+	}}, 42)
+
+	viewSnapshot, ok := Snapshot(view)
+	require.True(t, ok)
+	require.True(t, viewSnapshot.Bound)
+	require.Equal(t, 42, viewSnapshot.RequestTokens)
+
+	originalSnapshot, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, originalSnapshot.Bound)
+	require.Zero(t, originalSnapshot.RequestTokens)
+}
+
 func TestContextAndInvocationLifecycle(t *testing.T) {
 	invocation := agent.NewInvocation()
 	_, ok := Snapshot(invocation)

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -121,6 +121,8 @@ func TestInvocationViewFinalizationIsIsolated(t *testing.T) {
 
 func TestInvocationViewSnapshotNestedStateIsIsolated(t *testing.T) {
 	finishReason := "stop"
+	errorParam := "param"
+	errorCode := "code"
 	text := "text"
 	toolCallIndex := 1
 	message := model.Message{
@@ -156,6 +158,10 @@ func TestInvocationViewSnapshotNestedStateIsIsolated(t *testing.T) {
 				Delta:        message,
 				FinishReason: &finishReason,
 			}},
+			Error: &model.ResponseError{
+				Param: &errorParam,
+				Code:  &errorCode,
+			},
 		}, ParentMetadata: &event.ParentInvocationMetadata{TriggerID: "original"}},
 	}}})
 
@@ -175,6 +181,8 @@ func TestInvocationViewSnapshotNestedStateIsIsolated(t *testing.T) {
 	choice.Message.ToolCalls[0].Function.Arguments[0] = 'X'
 	choice.Delta.ContentParts[1].Image.Data[0] = 'X'
 	*choice.FinishReason = "mutated"
+	*viewSnapshot.Items[0].EffectiveEvent.Response.Error.Param = "mutated"
+	*viewSnapshot.Items[0].EffectiveEvent.Response.Error.Code = "mutated"
 	viewSnapshot.Items[0].EffectiveEvent.ParentMetadata.TriggerID = "mutated"
 
 	originalSnapshot, ok := Snapshot(invocation)
@@ -205,6 +213,12 @@ func TestInvocationViewSnapshotNestedStateIsIsolated(t *testing.T) {
 		originalChoice.Delta.ContentParts[1].Image.Data,
 	))
 	require.Equal(t, "stop", *originalChoice.FinishReason)
+	require.Equal(t, "param",
+		*originalSnapshot.Items[0].EffectiveEvent.Response.Error.Param,
+	)
+	require.Equal(t, "code",
+		*originalSnapshot.Items[0].EffectiveEvent.Response.Error.Code,
+	)
 	require.Equal(t, "original",
 		originalSnapshot.Items[0].EffectiveEvent.ParentMetadata.TriggerID,
 	)

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -119,6 +119,97 @@ func TestInvocationViewFinalizationIsIsolated(t *testing.T) {
 	require.Zero(t, originalSnapshot.RequestTokens)
 }
 
+func TestInvocationViewSnapshotNestedStateIsIsolated(t *testing.T) {
+	finishReason := "stop"
+	text := "text"
+	toolCallIndex := 1
+	message := model.Message{
+		Role: model.RoleAssistant,
+		ContentParts: []model.ContentPart{
+			{Text: &text},
+			{
+				Image: &model.Image{Data: []byte("image")},
+				ContentRef: &model.ContentRef{
+					ArtifactName: "original",
+				},
+			},
+			{Audio: &model.Audio{Data: []byte("audio")}},
+			{Video: &model.Video{Data: []byte("video")}},
+			{File: &model.File{Data: []byte("file")}},
+		},
+		ToolCalls: []model.ToolCall{{
+			Index: &toolCallIndex,
+			Function: model.FunctionDefinitionParam{
+				Arguments: []byte("original"),
+			},
+			ExtraFields: map[string]any{
+				"nested": map[string]any{"value": "original"},
+			},
+		}},
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{Items: []Item{{
+		Message: message,
+		EffectiveEvent: event.Event{Response: &model.Response{
+			Choices: []model.Choice{{
+				Message:      message,
+				Delta:        message,
+				FinishReason: &finishReason,
+			}},
+		}, ParentMetadata: &event.ParentInvocationMetadata{TriggerID: "original"}},
+	}}})
+
+	viewSnapshot, ok := Snapshot(invocation.View())
+	require.True(t, ok)
+	viewMessage := &viewSnapshot.Items[0].Message
+	viewMessage.ToolCalls[0].Function.Arguments[0] = 'X'
+	*viewMessage.ToolCalls[0].Index = 2
+	viewMessage.ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"] = "mutated"
+	*viewMessage.ContentParts[0].Text = "mutated"
+	viewMessage.ContentParts[1].Image.Data[0] = 'X'
+	viewMessage.ContentParts[1].ContentRef.ArtifactName = "mutated"
+	viewMessage.ContentParts[2].Audio.Data[0] = 'X'
+	viewMessage.ContentParts[3].Video.Data[0] = 'X'
+	viewMessage.ContentParts[4].File.Data[0] = 'X'
+	choice := &viewSnapshot.Items[0].EffectiveEvent.Response.Choices[0]
+	choice.Message.ToolCalls[0].Function.Arguments[0] = 'X'
+	choice.Delta.ContentParts[1].Image.Data[0] = 'X'
+	*choice.FinishReason = "mutated"
+	viewSnapshot.Items[0].EffectiveEvent.ParentMetadata.TriggerID = "mutated"
+
+	originalSnapshot, ok := Snapshot(invocation)
+	require.True(t, ok)
+	originalMessage := originalSnapshot.Items[0].Message
+	require.Equal(t, "original", string(
+		originalMessage.ToolCalls[0].Function.Arguments,
+	))
+	require.Equal(t, 1, *originalMessage.ToolCalls[0].Index)
+	require.Equal(t, "original",
+		originalMessage.ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"],
+	)
+	require.Equal(t, "text", *originalMessage.ContentParts[0].Text)
+	require.Equal(t, "image", string(
+		originalMessage.ContentParts[1].Image.Data,
+	))
+	require.Equal(t, "original",
+		originalMessage.ContentParts[1].ContentRef.ArtifactName,
+	)
+	require.Equal(t, "audio", string(originalMessage.ContentParts[2].Audio.Data))
+	require.Equal(t, "video", string(originalMessage.ContentParts[3].Video.Data))
+	require.Equal(t, "file", string(originalMessage.ContentParts[4].File.Data))
+	originalChoice := originalSnapshot.Items[0].EffectiveEvent.Response.Choices[0]
+	require.Equal(t, "original", string(
+		originalChoice.Message.ToolCalls[0].Function.Arguments,
+	))
+	require.Equal(t, "image", string(
+		originalChoice.Delta.ContentParts[1].Image.Data,
+	))
+	require.Equal(t, "stop", *originalChoice.FinishReason)
+	require.Equal(t, "original",
+		originalSnapshot.Items[0].EffectiveEvent.ParentMetadata.TriggerID,
+	)
+}
+
 func TestContextAndInvocationLifecycle(t *testing.T) {
 	invocation := agent.NewInvocation()
 	_, ok := Snapshot(invocation)


### PR DESCRIPTION
## What changed

Prevent parallel tool-call invocation views from recursively cloning the immutable model-visible summary and cache-safe request snapshots. The snapshots now use private copy-on-write holders, so worker views share read-only history while finalization and response appends remain isolated.

This also adds isolation regression coverage and a `testing.B` benchmark for parallel invocation view creation with 256 and 1,024 history entries.

## Why

Parallel tool execution creates one invocation view per tool call. The generic invocation state cloner previously deep-copied both summary snapshots for every worker, so CPU time and allocations grew with both history length and tool-call fan-out.

These snapshots are already immutable internally: attach operations clone their inputs, readers return clones, and mutators clone then replace the stored value. Sharing an opaque holder between invocation views therefore avoids redundant work without changing isolation semantics.

## Testing

- `go test ./internal/state/summaryview ./internal/state/summaryfork ./internal/flow/processor`
- `go test -race ./internal/state/summaryview ./internal/state/summaryfork`
- `go build ./...`
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=10m`
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`

Benchmark command: `go test ./internal/flow/processor -run '^$' -bench '^BenchmarkParallelInvocationView$' -benchmem -count=5`

The table reports the median of five runs on the same darwin/arm64 host.

| History entries | Before time | After time | Before bytes | After bytes | Before allocs | After allocs |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 256 | 5,556,795 ns/op | 656 ns/op | 1,675,159 B/op | 1,936 B/op | 7,729 | 7 |
| 1,024 | 22,502,135 ns/op | 575 ns/op | 6,638,192 B/op | 1,936 B/op | 30,809 | 7 |

The full root and multi-module test runs reached 10,805 passing root tests and all affected packages passed with 93.2% to 100% package coverage. One unrelated macOS-only DuckDuckGo test hit the Unix socket temporary-path length limit; the isolated test passes with a shorter temporary directory.

## Notes for reviewers

There is no public API, serialization, persistence, or protocol change. The holders are private, and regression tests verify that finalizing or appending through one invocation view does not mutate the original invocation snapshot.
