### PR TITLE
agent: add execution trace step node type setter

### DIFF
--- a/agent/execution_trace.go
+++ b/agent/execution_trace.go
@@ -188,6 +188,19 @@ func SetExecutionTraceStepAppliedSurfaceIDs(inv *Invocation, stepID string) {
 	capture.SetStepAppliedSurfaceIDs(stepID, reporter.ExecutionTraceAppliedSurfaceIDs(inv))
 }
 
+// SetExecutionTraceStepNodeType records the semantic node type for one execution trace step.
+func SetExecutionTraceStepNodeType(inv *Invocation, stepID string, nodeType string) {
+	if inv == nil || stepID == "" || nodeType == "" {
+		return
+	}
+	inv.initializeExecutionTrace()
+	capture := inv.executionTraceCapture()
+	if capture == nil {
+		return
+	}
+	capture.SetStepNodeType(stepID, nodeType)
+}
+
 // SetExecutionTraceStepUsage records token usage for one execution trace step.
 func SetExecutionTraceStepUsage(inv *Invocation, stepID string, usage *model.Usage) {
 	if inv == nil || stepID == "" || usage == nil {

--- a/agent/execution_trace.go
+++ b/agent/execution_trace.go
@@ -189,6 +189,8 @@ func SetExecutionTraceStepAppliedSurfaceIDs(inv *Invocation, stepID string) {
 }
 
 // SetExecutionTraceStepNodeType records the semantic node type for one execution trace step.
+// It has no error return and silently does nothing when inv is nil, tracing is disabled or
+// unavailable, inputs are empty, or stepID is unknown.
 func SetExecutionTraceStepNodeType(inv *Invocation, stepID string, nodeType string) {
 	if inv == nil || stepID == "" || nodeType == "" {
 		return

--- a/agent/execution_trace_test.go
+++ b/agent/execution_trace_test.go
@@ -299,6 +299,7 @@ func TestExecutionTraceHelpers_RecordStepNodeType(t *testing.T) {
 	)
 	require.NotEmpty(t, stepID)
 	SetExecutionTraceStepNodeType(inv, stepID, "agent")
+	SetExecutionTraceStepNodeType(inv, "missing-step", "tool")
 	FinishExecutionTraceStep(inv, stepID, &atrace.Snapshot{Text: "output"}, nil)
 	executionTrace := BuildExecutionTrace(inv, atrace.TraceStatusCompleted)
 	require.NotNil(t, executionTrace)

--- a/agent/execution_trace_test.go
+++ b/agent/execution_trace_test.go
@@ -217,6 +217,7 @@ func TestExecutionTraceHelpers_HandleNilAndDisabledInvocation(t *testing.T) {
 	assert.Empty(t, StartExecutionTraceStep(nilInv, "assistant", nil, nil))
 	FinishExecutionTraceStep(nilInv, "step-1", nil, nil)
 	SetExecutionTraceStepAppliedSurfaceIDs(nilInv, "step-1")
+	SetExecutionTraceStepNodeType(nilInv, "step-1", "agent")
 	SetExecutionTraceStepUsage(nilInv, "step-1", &model.Usage{TotalTokens: 1})
 	assert.Nil(t, NextExecutionTracePredecessors(nilInv))
 	assert.Nil(t, BuildExecutionTrace(nilInv, atrace.TraceStatusCompleted))
@@ -231,6 +232,9 @@ func TestExecutionTraceHelpers_HandleNilAndDisabledInvocation(t *testing.T) {
 	FinishExecutionTraceStep(disabled, "step-1", nil, nil)
 	FinishExecutionTraceStep(disabled, "", nil, nil)
 	SetExecutionTraceStepAppliedSurfaceIDs(disabled, "step-1")
+	SetExecutionTraceStepNodeType(disabled, "step-1", "agent")
+	SetExecutionTraceStepNodeType(disabled, "", "agent")
+	SetExecutionTraceStepNodeType(disabled, "step-1", "")
 	SetExecutionTraceStepUsage(disabled, "step-1", &model.Usage{TotalTokens: 1})
 	SetExecutionTraceStepUsage(disabled, "", &model.Usage{TotalTokens: 1})
 	SetExecutionTraceStepUsage(disabled, "step-1", nil)
@@ -279,6 +283,27 @@ func TestExecutionTraceHelpers_RecordAppliedSurfaceIDs(t *testing.T) {
 	require.NotNil(t, executionTrace)
 	require.Len(t, executionTrace.Steps, 1)
 	assert.Equal(t, []string{"assistant#instruction", "assistant#model"}, executionTrace.Steps[0].AppliedSurfaceIDs)
+}
+
+func TestExecutionTraceHelpers_RecordStepNodeType(t *testing.T) {
+	inv := NewInvocation(
+		WithInvocationAgent(&mockAgent{name: "assistant"}),
+		WithInvocationRunOptions(RunOptions{ExecutionTraceEnabled: true}),
+		WithInvocationMessage(model.NewUserMessage("hello")),
+	)
+	stepID := StartExecutionTraceStep(
+		inv,
+		InvocationTraceNodeID(inv),
+		&atrace.Snapshot{Text: "input"},
+		nil,
+	)
+	require.NotEmpty(t, stepID)
+	SetExecutionTraceStepNodeType(inv, stepID, "agent")
+	FinishExecutionTraceStep(inv, stepID, &atrace.Snapshot{Text: "output"}, nil)
+	executionTrace := BuildExecutionTrace(inv, atrace.TraceStatusCompleted)
+	require.NotNil(t, executionTrace)
+	require.Len(t, executionTrace.Steps, 1)
+	assert.Equal(t, "agent", executionTrace.Steps[0].NodeType)
 }
 
 func TestExecutionTraceHelpers_RecordStepUsage(t *testing.T) {

--- a/internal/tracecapture/capture.go
+++ b/internal/tracecapture/capture.go
@@ -185,8 +185,8 @@ func (c *Capture) setStepInput(stepID string, input *trace.Snapshot) {
 	c.steps[idx].Input = cloneSnapshot(input)
 }
 
-// setStepNodeType updates the semantic node type of one recorded step.
-func (c *Capture) setStepNodeType(stepID string, nodeType string) {
+// SetStepNodeType updates the semantic node type of one recorded step.
+func (c *Capture) SetStepNodeType(stepID string, nodeType string) {
 	if c == nil || stepID == "" || nodeType == "" {
 		return
 	}

--- a/internal/tracecapture/capture.go
+++ b/internal/tracecapture/capture.go
@@ -186,6 +186,8 @@ func (c *Capture) setStepInput(stepID string, input *trace.Snapshot) {
 }
 
 // SetStepNodeType updates the semantic node type of one recorded step.
+// It has no error return and silently does nothing for nil receivers, empty inputs,
+// or unknown step IDs.
 func (c *Capture) SetStepNodeType(stepID string, nodeType string) {
 	if c == nil || stepID == "" || nodeType == "" {
 		return

--- a/internal/tracecapture/invocation_step.go
+++ b/internal/tracecapture/invocation_step.go
@@ -138,7 +138,7 @@ func SetStepNodeType(ctx context.Context, stepID string, nodeType string) {
 	if !ok || runtime.capture == nil || stepID == "" || nodeType == "" {
 		return
 	}
-	runtime.capture.setStepNodeType(stepID, nodeType)
+	runtime.capture.SetStepNodeType(stepID, nodeType)
 }
 
 // MergeInvocationStepAppliedSurfaceIDs merges applied surface IDs into the


### PR DESCRIPTION
Expose a public execution trace helper for recording step node types, allowing external agent implementations to populate NodeType without importing internal trace capture packages while preserving existing no-op behavior for nil, empty, disabled, or missing trace inputs.