### PR TITLE
model/openai: use max_tokens for DeepSeek

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1944,7 +1944,7 @@ The framework currently supports the following Variants:
 - Default BaseURL：`https://api.deepseek.com`
 - API Key environment variable name：`DEEPSEEK_API_KEY`
 - DeepSeek-specific behavior is enabled when you explicitly set `WithVariant(openai.VariantDeepSeek)` or use the official DeepSeek API BaseURL
-- Serializes `GenerationConfig.MaxTokens` as `max_tokens`, as required by the DeepSeek Chat Completions API; other variants continue to use `max_completion_tokens`
+- Serializes `GenerationConfig.MaxTokens` as `max_tokens`, the field documented by the [DeepSeek Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion); other variants continue to use `max_completion_tokens`
 - Other behaviors are consistent with standard OpenAI
 
 **4. VariantQwen（Qwen）**

--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1944,6 +1944,7 @@ The framework currently supports the following Variants:
 - Default BaseURL：`https://api.deepseek.com`
 - API Key environment variable name：`DEEPSEEK_API_KEY`
 - DeepSeek-specific behavior is enabled when you explicitly set `WithVariant(openai.VariantDeepSeek)` or use the official DeepSeek API BaseURL
+- Serializes `GenerationConfig.MaxTokens` as `max_tokens`, as required by the DeepSeek Chat Completions API; other variants continue to use `max_completion_tokens`
 - Other behaviors are consistent with standard OpenAI
 
 **4. VariantQwen（Qwen）**

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1917,6 +1917,7 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 - 默认 BaseURL：`https://api.deepseek.com`
 - API Key 环境变量名：`DEEPSEEK_API_KEY`
 - 显式设置 `WithVariant(openai.VariantDeepSeek)`，或使用官方 DeepSeek API BaseURL 时，才会启用 DeepSeek 特有行为
+- 按 DeepSeek Chat Completions API 要求，将 `GenerationConfig.MaxTokens` 序列化为 `max_tokens`；其他 variant 继续使用 `max_completion_tokens`
 - 其他行为与标准 OpenAI 一致
 
 **4. VariantQwen（千问）**

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1917,7 +1917,7 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 - 默认 BaseURL：`https://api.deepseek.com`
 - API Key 环境变量名：`DEEPSEEK_API_KEY`
 - 显式设置 `WithVariant(openai.VariantDeepSeek)`，或使用官方 DeepSeek API BaseURL 时，才会启用 DeepSeek 特有行为
-- 按 DeepSeek Chat Completions API 要求，将 `GenerationConfig.MaxTokens` 序列化为 `max_tokens`；其他 variant 继续使用 `max_completion_tokens`
+- 按 [DeepSeek Chat Completions API](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion) 文档定义，将 `GenerationConfig.MaxTokens` 序列化为 `max_tokens`；其他 variant 继续使用 `max_completion_tokens`
 - 其他行为与标准 OpenAI 一致
 
 **4. VariantQwen（千问）**

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -959,10 +959,16 @@ func (m *Model) buildChatRequestWithToolControl(
 		}
 	}
 
-	// MaxTokens is deprecated and not compatible with o-series models.
-	// Use MaxCompletionTokens instead.
 	if mt := imodel.ClampMaxTokensForModel(m.name, request.MaxTokens); mt != nil {
-		chatRequest.MaxCompletionTokens = openai.Int(int64(*mt))
+		if m.variant == VariantDeepSeek {
+			// DeepSeek Chat Completions supports max_tokens rather than
+			// OpenAI's max_completion_tokens parameter.
+			chatRequest.MaxTokens = openai.Int(int64(*mt))
+		} else {
+			// max_tokens is deprecated and incompatible with OpenAI o-series
+			// models. Use max_completion_tokens for other variants.
+			chatRequest.MaxCompletionTokens = openai.Int(int64(*mt))
+		}
 	}
 	if request.Temperature != nil {
 		chatRequest.Temperature = openai.Float(*request.Temperature)

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -961,8 +961,8 @@ func (m *Model) buildChatRequestWithToolControl(
 
 	if mt := imodel.ClampMaxTokensForModel(m.name, request.MaxTokens); mt != nil {
 		if m.variant == VariantDeepSeek {
-			// DeepSeek Chat Completions supports max_tokens rather than
-			// OpenAI's max_completion_tokens parameter.
+			// DeepSeek's Chat Completions API documents max_tokens as the
+			// output limit: https://api-docs.deepseek.com/api/create-chat-completion.
 			chatRequest.MaxTokens = openai.Int(int64(*mt))
 		} else {
 			// max_tokens is deprecated and incompatible with OpenAI o-series

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5502,7 +5502,55 @@ func TestBuildChatRequest_EdgeCases(t *testing.T) {
 		chatReq, _ := m.buildChatRequest(req)
 		require.NotNil(t, chatReq.MaxCompletionTokens)
 		assert.Equal(t, int64(16384), chatReq.MaxCompletionTokens.Value)
+		assert.False(t, chatReq.MaxTokens.Valid())
+
+		raw, err := chatReq.MarshalJSON()
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(raw, &body))
+		assert.Equal(t, float64(16384), body["max_completion_tokens"])
+		assert.NotContains(t, body, "max_tokens")
 	})
+
+	for _, tt := range []struct {
+		name string
+		opts []Option
+	}{
+		{
+			name: "official base URL",
+			opts: []Option{WithBaseURL(defaultDeepSeekBaseURL)},
+		},
+		{
+			name: "custom proxy with explicit variant",
+			opts: []Option{
+				WithBaseURL("https://proxy.example.com/v1"),
+				WithVariant(VariantDeepSeek),
+			},
+		},
+	} {
+		t.Run("DeepSeek uses max_tokens with "+tt.name, func(t *testing.T) {
+			m := New("deepseek-v4-flash", tt.opts...)
+			maxTokens := 2048
+			req := &model.Request{
+				Messages: []model.Message{model.NewUserMessage("hi")},
+				GenerationConfig: model.GenerationConfig{
+					MaxTokens: &maxTokens,
+				},
+			}
+
+			chatReq, _ := m.buildChatRequest(req)
+			require.True(t, chatReq.MaxTokens.Valid())
+			assert.Equal(t, int64(maxTokens), chatReq.MaxTokens.Value)
+			assert.False(t, chatReq.MaxCompletionTokens.Valid())
+
+			raw, err := chatReq.MarshalJSON()
+			require.NoError(t, err)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(raw, &body))
+			assert.Equal(t, float64(maxTokens), body["max_tokens"])
+			assert.NotContains(t, body, "max_completion_tokens")
+		})
+	}
 
 	t.Run("empty messages", func(t *testing.T) {
 		req := &model.Request{
@@ -5512,6 +5560,8 @@ func TestBuildChatRequest_EdgeCases(t *testing.T) {
 
 		chatReq, _ := m.buildChatRequest(req)
 		assert.Empty(t, chatReq.Messages, "expected empty messages")
+		assert.False(t, chatReq.MaxTokens.Valid())
+		assert.False(t, chatReq.MaxCompletionTokens.Valid())
 	})
 
 	t.Run("with all generation config options", func(t *testing.T) {


### PR DESCRIPTION
## What changed

- Serialize `GenerationConfig.MaxTokens` as `max_tokens` for `VariantDeepSeek`.
- Preserve `max_completion_tokens` for OpenAI and all other variants.
- Cover both official DeepSeek endpoint inference and custom proxies with an explicit DeepSeek variant.
- Document the provider-specific request mapping in the English and Chinese model guides.

## Why

DeepSeek's Chat Completions API documents `max_tokens` as the output-limit
field and does not define OpenAI's newer `max_completion_tokens` parameter.
The OpenAI-compatible adapter previously sent `max_completion_tokens` for
every variant, so DeepSeek did not enforce the configured output limit.

## Source

- [DeepSeek Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion)
- [DeepSeek Chat Completions API（中文）](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion)

## Testing

- `go test ./model/openai -count=1`
- `go build ./...`
- `cd test && go test ./... -count=1`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m` with golangci-lint v1.64.8
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`

## Notes for reviewers

This changes only the DeepSeek wire parameter. It does not add or modify any
exported API, and token clamping, nil behavior, serialization of framework
configuration, and other model variants remain unchanged. Custom proxy URLs
must opt into `VariantDeepSeek`, consistent with existing variant inference
behavior.
