### PR TITLE
{docs, examples/evaluation/trpcagent}: add remote agent evaluation example

### DIFF
--- a/docs/mkdocs/en/evaluation/methods.md
+++ b/docs/mkdocs/en/evaluation/methods.md
@@ -252,6 +252,70 @@ Metric file example below:
 
 See [examples/evaluation/claudecode](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/claudecode) for a runnable example.
 
+## Remote Agent Evaluation
+
+Remote Agent evaluation is useful when the evaluation platform and the candidate Agent are deployed separately. The evaluation process reads EvalSets and Metrics, calls the candidate Agent, runs judge scoring, and stores evaluation results; the remote Agent service is only responsible for real inference for each input. For the remote service side, see [tRPC-Agent API Server](../trpcagent.md). For creating the remote Runner, see [Remote tRPC-Agent Runner](../runner.md#remote-trpc-agent-runner). On the evaluation side, `runner/trpcagent` wraps the remote service as a normal `runner.Runner`.
+
+See [examples/evaluation/trpcagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/trpcagent) for a complete example. It provides a Go `server/trpcagent` reference service, plus ADK and LangGraph services that implement the compatible tRPC-Agent protocol. The evaluation client uses `runner/trpcagent` to call the candidate service.
+
+On the business side, expose the candidate Agent with `server/trpcagent`:
+
+```go
+import (
+	"net/http"
+
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	servertrpcagent "trpc.group/trpc-go/trpc-agent-go/server/trpcagent"
+)
+
+agentRunner := runner.NewRunner(appName, candidateAgent)
+defer agentRunner.Close()
+
+server, err := servertrpcagent.New(
+	servertrpcagent.WithAppName(appName),
+	servertrpcagent.WithAgent(candidateAgent),
+	servertrpcagent.WithRunner(agentRunner),
+)
+if err != nil {
+	return err
+}
+if err := http.ListenAndServe(":8081", server.Handler()); err != nil {
+	return err
+}
+```
+
+On the evaluation side, create a remote Runner and pass it to `AgentEvaluator` as the candidate Runner:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	trpcagentrunner "trpc.group/trpc-go/trpc-agent-go/runner/trpcagent"
+)
+
+candidateRunner, err := trpcagentrunner.New(
+	appName,
+	trpcagentrunner.WithTarget(candidateTarget),
+)
+if err != nil {
+	return err
+}
+defer candidateRunner.Close()
+
+agentEvaluator, err := evaluation.New(
+	appName,
+	candidateRunner,
+	evaluation.WithEvalSetManager(evalSetManager),
+	evaluation.WithMetricManager(metricManager),
+	evaluation.WithEvalResultManager(evalResultManager),
+	evaluation.WithRegistry(registry.New()),
+	evaluation.WithJudgeRunner(judgeRunner),
+)
+if err != nil {
+	return err
+}
+```
+
 ## pass@k and pass^k
 
 When evaluation repeats runs with `NumRuns`, each run can be viewed as an independent Bernoulli trial. Two derived metrics `pass@k` and `pass^k` provide measures closer to capability and stability. Let `n` be total runs, `c` be the number of passes, and `k` be the number of attempts of interest.

--- a/docs/mkdocs/zh/evaluation/methods.md
+++ b/docs/mkdocs/zh/evaluation/methods.md
@@ -252,6 +252,70 @@ Metric 的 `toolTrajectory` 配置示例如下：
 
 完整可运行示例参见 [examples/evaluation/claudecode](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/claudecode)。
 
+## 远程 Agent 评估
+
+远程 Agent 评估适用于评估平台与待测 Agent 分开部署的场景。运行评估的进程负责读取评估集和指标、调用待测 Agent、执行裁判打分并保存评估结果；远端 Agent 服务只负责根据输入完成一次真实推理。接入时，远端服务接入见 [tRPC-Agent API 服务](../trpcagent.md)，远程 Runner 创建见 [远程 tRPC-Agent Runner](../runner.md#远程-trpc-agent-runner)；评估侧通过 `runner/trpcagent` 将远端服务包装成普通 `runner.Runner`。
+
+完整示例见 [examples/evaluation/trpcagent](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/evaluation/trpcagent)。该示例提供 Go `server/trpcagent` 参考服务，以及 ADK、LangGraph 两个兼容 tRPC-Agent 协议的服务；评估客户端统一使用 `runner/trpcagent` 调用候选服务。
+
+业务侧先用 `server/trpcagent` 暴露待测 Agent：
+
+```go
+import (
+	"net/http"
+
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	servertrpcagent "trpc.group/trpc-go/trpc-agent-go/server/trpcagent"
+)
+
+agentRunner := runner.NewRunner(appName, candidateAgent)
+defer agentRunner.Close()
+
+server, err := servertrpcagent.New(
+	servertrpcagent.WithAppName(appName),
+	servertrpcagent.WithAgent(candidateAgent),
+	servertrpcagent.WithRunner(agentRunner),
+)
+if err != nil {
+	return err
+}
+if err := http.ListenAndServe(":8081", server.Handler()); err != nil {
+	return err
+}
+```
+
+评估侧创建远程 Runner，并将其作为待测 Runner 传给 `AgentEvaluator`：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	trpcagentrunner "trpc.group/trpc-go/trpc-agent-go/runner/trpcagent"
+)
+
+candidateRunner, err := trpcagentrunner.New(
+	appName,
+	trpcagentrunner.WithTarget(candidateTarget),
+)
+if err != nil {
+	return err
+}
+defer candidateRunner.Close()
+
+agentEvaluator, err := evaluation.New(
+	appName,
+	candidateRunner,
+	evaluation.WithEvalSetManager(evalSetManager),
+	evaluation.WithMetricManager(metricManager),
+	evaluation.WithEvalResultManager(evalResultManager),
+	evaluation.WithRegistry(registry.New()),
+	evaluation.WithJudgeRunner(judgeRunner),
+)
+if err != nil {
+	return err
+}
+```
+
 ## pass@k 与 pass^k
 
 当评估通过 `NumRuns` 对同一评估集重复运行时，可以将每次运行视为一次独立的伯努利试验，并在通过与失败的统计之上给出更贴近能力与稳定性的两个派生指标 `pass@k` 与 `pass^k`。设 `n` 表示采样到的总运行次数，`c` 表示其中通过的次数，`k` 表示关注的尝试次数。

--- a/examples/evaluation/trpcagent/README.md
+++ b/examples/evaluation/trpcagent/README.md
@@ -1,0 +1,115 @@
+# tRPC-Agent Remote Evaluation Example
+
+This example shows how to evaluate a remote agent served through the tRPC-Agent HTTP protocol.
+
+The Go evaluation client uses `runner/trpcagent` to call a candidate server, requests an execution trace for each run, and scores the result with a local judge runner. The metric file only describes what to evaluate; the judge runner is configured in `main.go` with `model/openai`.
+
+The same client can evaluate one of three candidate server implementations:
+
+- `servers/trpcagentgo`: Go `llmagent` exposed with `server/trpcagent`.
+- `servers/adk`: Python ADK agent exposed with the same wire protocol.
+- `servers/langgraph`: Python LangGraph agent exposed with the same wire protocol.
+
+All implementations use a real OpenAI-compatible LLM and the same travel-advice scenario. There are no mocked tools or mocked model responses.
+
+## What Is Evaluated
+
+The eval set contains one user turn asking for Shanghai travel advice. The expected answer checks for four facts: sunny weather at 26C, downtown festival traffic disruption, museum ticket availability with 25 seats left, and practical booking or routing advice.
+
+The metric file contains two LLM judge metrics:
+
+- `llm_final_response` compares the candidate final answer with the reference answer.
+- `trace_io_template` uses `llm_judge_template` and binds only `actual.traceStepInput` and `actual.traceStepOutput` from the selected trace step.
+
+The template metric selects the root agent step with `nodeID: "trpcagent-travel-agent"`.
+
+## Layout
+
+```text
+examples/evaluation/trpcagent/
+├── main.go
+├── data/
+│   └── trpcagent-travel-agent/
+│       ├── travel-advice-basic.evalset.json
+│       └── travel-advice-basic.metrics.json
+└── servers/
+    ├── trpcagentgo/
+    ├── adk/
+    └── langgraph/
+```
+
+## Requirements
+
+Set the standard OpenAI-compatible environment variables before running the Go server or the evaluation client:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
+```
+
+`OPENAI_BASE_URL` is optional when the provider uses the default OpenAI endpoint. The Go server and the judge runner both use `gpt-5.2` by default.
+
+For Python servers, create a virtual environment in the selected server directory and install its `requirements.txt`.
+
+## Start a Candidate Server
+
+Run one server at a time. Each implementation listens on `http://127.0.0.1:8081/trpc-agent/v1/apps/trpcagent-travel-agent` by default.
+
+### Go Reference Server
+
+```bash
+cd examples/evaluation/trpcagent/servers/trpcagentgo
+go run . -model "gpt-5.2"
+```
+
+### ADK Server
+
+```bash
+cd examples/evaluation/trpcagent/servers/adk
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_BASE="${OPENAI_BASE_URL}"
+export ADK_MODEL="openai/gpt-5.2"
+python server.py
+```
+
+### LangGraph Server
+
+```bash
+cd examples/evaluation/trpcagent/servers/langgraph
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+export LANGGRAPH_MODEL="gpt-5.2"
+python server.py
+```
+
+## Run the Evaluation Client
+
+In another terminal:
+
+```bash
+cd examples/evaluation/trpcagent
+go run . -target "http://127.0.0.1:8081"
+```
+
+The client loads eval sets and metrics from `./data`, writes results to `./output`, and injects a local judge runner into all LLM judge metrics with `evaluation.WithJudgeRunner(...)`.
+
+## Execution Trace
+
+The client enables `agent.WithExecutionTraceEnabled(true)` for the remote run. Evaluation results include the trace under each case run detail.
+
+The Go server produces native tRPC-Agent traces. ADK and LangGraph servers return protocol-compatible traces with the same non-empty fields used by this example: root input, root output, step input, step output, applied surfaces, status, and token usage when the underlying framework reports it.
+
+Trace snapshot contents can differ by implementation. For example, the Go server records model message and response JSON, while the Python adapters use simpler text snapshots.
+
+## Flags
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-target` | Remote tRPC-Agent service target | `http://localhost:8081` |
+| `-base-path` | Remote service base path | `/trpc-agent/v1/apps` |
+| `-data-dir` | Directory containing `.evalset.json` and `.metrics.json` | `./data` |
+| `-output-dir` | Directory where evaluation results are written | `./output` |
+| `-eval-set` | Evaluation set ID to execute | `travel-advice-basic` |

--- a/examples/evaluation/trpcagent/data/trpcagent-travel-agent/travel-advice-basic.evalset.json
+++ b/examples/evaluation/trpcagent/data/trpcagent-travel-agent/travel-advice-basic.evalset.json
@@ -1,0 +1,26 @@
+{
+  "evalSetId": "travel-advice-basic",
+  "name": "travel-advice-basic",
+  "evalCases": [
+    {
+      "evalId": "shanghai_travel_advice",
+      "conversation": [
+        {
+          "invocationId": "shanghai_travel_advice-1",
+          "userContent": {
+            "role": "user",
+            "content": "I am traveling to Shanghai today. What should I watch out for, and can I still get a museum ticket?"
+          },
+          "finalResponse": {
+            "role": "assistant",
+            "content": "Shanghai is sunny at 26C. There are festival events downtown, so expect traffic disruptions. Museum tickets are still available with 25 seats left. Leave early, avoid the city center if possible, and reserve now."
+          }
+        }
+      ],
+      "sessionInput": {
+        "appName": "trpcagent-travel-agent",
+        "userId": "demo-user"
+      }
+    }
+  ]
+}

--- a/examples/evaluation/trpcagent/data/trpcagent-travel-agent/travel-advice-basic.metrics.json
+++ b/examples/evaluation/trpcagent/data/trpcagent-travel-agent/travel-advice-basic.metrics.json
@@ -1,0 +1,44 @@
+[
+  {
+    "metricName": "llm_final_response",
+    "threshold": 0.9,
+    "criterion": {
+      "llmJudge": {}
+    }
+  },
+  {
+    "metricName": "trace_io_template",
+    "evaluatorName": "llm_judge_template",
+    "threshold": 1.0,
+    "criterion": {
+      "llmJudge": {
+        "template": {
+          "prompt": "You are grading whether the selected execution trace step output answers the selected execution trace step input. The trace snapshots may be plain text or JSON.\\n\\nTrace step input snapshot:\\n{{trace_input}}\\n\\nTrace step output snapshot:\\n{{trace_output}}\\n\\nReturn JSON with:\\n- score: 1 if the output answers the input.\\n- score: 0 otherwise.\\n- reason: one concise sentence.",
+          "responseScorerName": "single_score",
+          "variableBindings": [
+            {
+              "templateVariable": "trace_input",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepInput",
+                "selector": {
+                  "nodeID": "trpcagent-travel-agent"
+                }
+              }
+            },
+            {
+              "templateVariable": "trace_output",
+              "source": {
+                "scope": "actual",
+                "field": "traceStepOutput",
+                "selector": {
+                  "nodeID": "trpcagent-travel-agent"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/examples/evaluation/trpcagent/main.go
+++ b/examples/evaluation/trpcagent/main.go
@@ -1,0 +1,123 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main runs a tRPC-Agent remote evaluation client.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	evalresultlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
+	evalsetlocal "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/local"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
+	metriclocal "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/local"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	"trpc.group/trpc-go/trpc-agent-go/runner"
+	trpcagentrunner "trpc.group/trpc-go/trpc-agent-go/runner/trpcagent"
+)
+
+const (
+	appName   = "trpcagent-travel-agent"
+	modelName = "gpt-5.2"
+)
+
+var (
+	target    = flag.String("target", "http://localhost:8081", "Target of the remote tRPC-Agent service")
+	basePath  = flag.String("base-path", "/trpc-agent/v1/apps", "Base path of the remote tRPC-Agent service")
+	dataDir   = flag.String("data-dir", "./data", "Directory containing evaluation set and metric files")
+	outputDir = flag.String("output-dir", "./output", "Directory where evaluation results will be stored")
+	evalSetID = flag.String("eval-set", "travel-advice-basic", "Evaluation set identifier to execute")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	remoteRunner, err := trpcagentrunner.New(appName, trpcagentrunner.WithTarget(*target), trpcagentrunner.WithBasePath(*basePath))
+	if err != nil {
+		log.Fatalf("create tRPC-Agent runner: %v", err)
+	}
+	defer remoteRunner.Close()
+	judgeRunner := runner.NewRunner(appName+"-judge", newJudgeAgent())
+	defer judgeRunner.Close()
+	evalSetManager := evalsetlocal.New(evalset.WithBaseDir(*dataDir))
+	metricManager := metriclocal.New(metric.WithBaseDir(*dataDir))
+	evalResultManager := evalresultlocal.New(evalresult.WithBaseDir(*outputDir))
+	reg := registry.New()
+	evalOptions := []evaluation.Option{
+		evaluation.WithEvalSetManager(evalSetManager),
+		evaluation.WithMetricManager(metricManager),
+		evaluation.WithEvalResultManager(evalResultManager),
+		evaluation.WithRegistry(reg),
+		evaluation.WithJudgeRunner(judgeRunner),
+		evaluation.WithRunDetailsEnabled(true),
+		evaluation.WithRunOptions(agent.WithExecutionTraceEnabled(true)),
+	}
+	agentEvaluator, err := evaluation.New(appName, remoteRunner, evalOptions...)
+	if err != nil {
+		log.Fatalf("create evaluator: %v", err)
+	}
+	defer func() { agentEvaluator.Close() }()
+	result, err := agentEvaluator.Evaluate(ctx, *evalSetID)
+	if err != nil {
+		log.Fatalf("evaluate: %v", err)
+	}
+	printSummary(result, *outputDir)
+}
+
+func printSummary(result *evaluation.EvaluationResult, outDir string) {
+	fmt.Println("tRPC-Agent remote evaluation completed")
+	fmt.Printf("App: %s\n", result.AppName)
+	fmt.Printf("Eval Set: %s\n", result.EvalSetID)
+	fmt.Printf("Overall Status: %s\n", result.OverallStatus)
+	runs := 0
+	if len(result.EvalCases) > 0 {
+		runs = len(result.EvalCases[0].EvalCaseResults)
+	}
+	fmt.Printf("Runs: %d\n", runs)
+	for _, caseResult := range result.EvalCases {
+		fmt.Printf("Case %s -> %s\n", caseResult.EvalCaseID, caseResult.OverallStatus)
+		for _, metricResult := range caseResult.MetricResults {
+			fmt.Printf("  Metric %s: score %.2f (threshold %.2f) => %s\n", metricResult.MetricName, metricResult.Score, metricResult.Threshold, metricResult.EvalStatus)
+		}
+		fmt.Println()
+	}
+	fmt.Printf("Results saved under: %s\n", outDir)
+}
+
+func newJudgeAgent() agent.Agent {
+	genCfg := model.GenerationConfig{
+		MaxTokens:   intPtr(512),
+		Temperature: floatPtr(0),
+		Stream:      false,
+	}
+	return llmagent.New(
+		appName+"-judge",
+		llmagent.WithModel(openai.New(modelName)),
+		llmagent.WithInstruction("Follow the provided evaluation instructions exactly and return only the requested judge output."),
+		llmagent.WithDescription("Judge agent used by the tRPC-Agent evaluation example."),
+		llmagent.WithGenerationConfig(genCfg),
+	)
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}

--- a/examples/evaluation/trpcagent/output/trpcagent-travel-agent/trpcagent-travel-agent_travel-advice-basic_0542c931-cbbe-4b14-9752-394b14811642.evalset_result.json
+++ b/examples/evaluation/trpcagent/output/trpcagent-travel-agent/trpcagent-travel-agent_travel-advice-basic_0542c931-cbbe-4b14-9752-394b14811642.evalset_result.json
@@ -1,0 +1,305 @@
+{
+  "evalSetResultId": "trpcagent-travel-agent_travel-advice-basic_0542c931-cbbe-4b14-9752-394b14811642",
+  "evalSetResultName": "trpcagent-travel-agent_travel-advice-basic_0542c931-cbbe-4b14-9752-394b14811642",
+  "evalSetId": "travel-advice-basic",
+  "evalCaseResults": [
+    {
+      "evalSetId": "travel-advice-basic",
+      "evalId": "shanghai_travel_advice",
+      "runId": 1,
+      "score": 1,
+      "finalEvalStatus": "passed",
+      "overallEvalMetricResults": [
+        {
+          "metricName": "llm_final_response",
+          "score": 1,
+          "evalStatus": "passed",
+          "threshold": 0.9,
+          "criterion": {
+            "llmJudge": {}
+          },
+          "details": {
+            "reason": "The agent response matches all key points in the reference: sunny at 26C, festival events downtown causing traffic disruptions, museum tickets available with 25 seats left, and advice to leave extra time/avoid downtown and reserve ASAP.",
+            "score": 1
+          }
+        },
+        {
+          "metricName": "trace_io_template",
+          "score": 1,
+          "evalStatus": "passed",
+          "threshold": 1,
+          "criterion": {
+            "llmJudge": {
+              "template": {
+                "prompt": "You are grading whether the selected execution trace step output answers the selected execution trace step input. The trace snapshots may be plain text or JSON.\\n\\nTrace step input snapshot:\\n{{trace_input}}\\n\\nTrace step output snapshot:\\n{{trace_output}}\\n\\nReturn JSON with:\\n- score: 1 if the output answers the input.\\n- score: 0 otherwise.\\n- reason: one concise sentence.",
+                "responseScorerName": "single_score",
+                "variableBindings": [
+                  {
+                    "templateVariable": "trace_input",
+                    "source": {
+                      "scope": "actual",
+                      "field": "traceStepInput",
+                      "selector": {
+                        "nodeID": "trpcagent-travel-agent"
+                      }
+                    }
+                  },
+                  {
+                    "templateVariable": "trace_output",
+                    "source": {
+                      "scope": "actual",
+                      "field": "traceStepOutput",
+                      "selector": {
+                        "nodeID": "trpcagent-travel-agent"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "details": {
+            "reason": "It directly addresses today’s Shanghai weather (sunny 26°C), warns about downtown festival traffic disruptions, confirms museum ticket availability with 25 seats left, and gives practical travel advice.",
+            "score": 1
+          }
+        }
+      ],
+      "evalMetricResultPerInvocation": [
+        {
+          "actualInvocation": {
+            "invocationId": "c57d5c79-9ffc-493b-b4bf-9cfbd229b020",
+            "userContent": {
+              "role": "user",
+              "content": "I am traveling to Shanghai today. What should I watch out for, and can I still get a museum ticket?"
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "Shanghai today is sunny around **26°C**—comfortable, but bring **sunscreen** and **water**, and consider a light layer for indoor A/C.\n\n**Watch outs / alerts**\n- **Festival events downtown** are likely to cause **traffic disruptions** (road closures, slower taxis/rideshares, crowded metro stations).\n- If you need to cross downtown, **leave extra time** and prefer the **metro** over driving; plan alternate routes and avoid peak event hours if possible.\n\n**Museum tickets**\n- Yes—tickets are still available, with **about 25 seats left**. If you’re going today, **book ASAP** to lock in a time slot.\n\n**Practical tips**\n- Aim to arrive **15–30 minutes early** for security lines and crowds.\n- Keep a backup plan (another museum/attraction nearby) in case your preferred slot sells out."
+            },
+            "executionTrace": {
+              "RootAgentName": "trpcagent-travel-agent",
+              "RootInvocationID": "c57d5c79-9ffc-493b-b4bf-9cfbd229b020",
+              "SessionID": "9eb1d160-c8f0-45ac-8b67-f5e9e2c2ca3f",
+              "StartedAt": "2026-08-17T16:22:11.382277423+08:00",
+              "EndedAt": "2026-08-17T16:22:16.213014184+08:00",
+              "Status": "completed",
+              "Input": {
+                "Text": "{\"role\":\"user\",\"content\":\"I am traveling to Shanghai today. What should I watch out for, and can I still get a museum ticket?\"}"
+              },
+              "Output": {
+                "Text": "{\"role\":\"assistant\",\"content\":\"Shanghai today is sunny around **26°C**—comfortable, but bring **sunscreen** and **water**, and consider a light layer for indoor A/C.\\n\\n**Watch outs / alerts**\\n- **Festival events downtown** are likely to cause **traffic disruptions** (road closures, slower taxis/rideshares, crowded metro stations).\\n- If you need to cross downtown, **leave extra time** and prefer the **metro** over driving; plan alternate routes and avoid peak event hours if possible.\\n\\n**Museum tickets**\\n- Yes—tickets are still available, with **about 25 seats left**. If you’re going today, **book ASAP** to lock in a time slot.\\n\\n**Practical tips**\\n- Aim to arrive **15–30 minutes early** for security lines and crowds.\\n- Keep a backup plan (another museum/attraction nearby) in case your preferred slot sells out.\"}"
+              },
+              "Usage": {
+                "prompt_tokens": 104,
+                "completion_tokens": 185,
+                "total_tokens": 289,
+                "prompt_tokens_details": {
+                  "cached_tokens": 0
+                },
+                "completion_tokens_details": {}
+              },
+              "Steps": [
+                {
+                  "StepID": "s1",
+                  "InvocationID": "c57d5c79-9ffc-493b-b4bf-9cfbd229b020",
+                  "ParentInvocationID": "",
+                  "AgentName": "trpcagent-travel-agent",
+                  "Branch": "trpcagent-travel-agent",
+                  "NodeID": "trpcagent-travel-agent",
+                  "NodeType": "agent",
+                  "StartedAt": "2026-08-17T16:22:11.382325759+08:00",
+                  "EndedAt": "2026-08-17T16:22:16.212913263+08:00",
+                  "PredecessorStepIDs": null,
+                  "AppliedSurfaceIDs": [
+                    "trpcagent-travel-agent#instruction",
+                    "trpcagent-travel-agent#model"
+                  ],
+                  "Input": {
+                    "Text": "[{\"role\":\"system\",\"content\":\"Travel agent used by the tRPC-Agent evaluation example.\\n\\nYou are a concise travel assistant.\\nUse this scenario when answering: Shanghai is sunny at 26C, festival events will be held downtown with likely traffic disruptions, and museum tickets are available with 25 seats left.\\nAnswer the user's travel question with weather, alert, ticket availability, and practical advice.\"},{\"role\":\"user\",\"content\":\"I am traveling to Shanghai today. What should I watch out for, and can I still get a museum ticket?\"}]"
+                  },
+                  "Output": {
+                    "Text": "{\"id\":\"chatcmpl-EDmtfNXQKCzyIM4JAhT92ctBLl7ch\",\"object\":\"chat.completion\",\"created\":1786954931,\"model\":\"gpt-5.2-2025-12-11\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Shanghai today is sunny around **26°C**—comfortable, but bring **sunscreen** and **water**, and consider a light layer for indoor A/C.\\n\\n**Watch outs / alerts**\\n- **Festival events downtown** are likely to cause **traffic disruptions** (road closures, slower taxis/rideshares, crowded metro stations).\\n- If you need to cross downtown, **leave extra time** and prefer the **metro** over driving; plan alternate routes and avoid peak event hours if possible.\\n\\n**Museum tickets**\\n- Yes—tickets are still available, with **about 25 seats left**. If you’re going today, **book ASAP** to lock in a time slot.\\n\\n**Practical tips**\\n- Aim to arrive **15–30 minutes early** for security lines and crowds.\\n- Keep a backup plan (another museum/attraction nearby) in case your preferred slot sells out.\"},\"delta\":{\"role\":\"\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":104,\"completion_tokens\":185,\"total_tokens\":289,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{},\"timing_info\":{\"time_to_first_token\":4830072175}},\"timestamp\":\"2026-08-17T16:22:16.212800365+08:00\",\"done\":true,\"is_partial\":false}"
+                  },
+                  "Usage": {
+                    "prompt_tokens": 104,
+                    "completion_tokens": 185,
+                    "total_tokens": 289,
+                    "prompt_tokens_details": {
+                      "cached_tokens": 0
+                    },
+                    "completion_tokens_details": {}
+                  },
+                  "Tools": null,
+                  "Skills": null,
+                  "Error": ""
+                }
+              ]
+            }
+          },
+          "expectedInvocation": {
+            "invocationId": "shanghai_travel_advice-1",
+            "userContent": {
+              "role": "user",
+              "content": "I am traveling to Shanghai today. What should I watch out for, and can I still get a museum ticket?"
+            },
+            "finalResponse": {
+              "role": "assistant",
+              "content": "Shanghai is sunny at 26C. There are festival events downtown, so expect traffic disruptions. Museum tickets are still available with 25 seats left. Leave early, avoid the city center if possible, and reserve now."
+            }
+          },
+          "evalMetricResults": [
+            {
+              "metricName": "llm_final_response",
+              "score": 1,
+              "evalStatus": "passed",
+              "threshold": 0.9,
+              "criterion": {
+                "llmJudge": {}
+              },
+              "details": {
+                "reason": "The agent response matches all key points in the reference: sunny at 26C, festival events downtown causing traffic disruptions, museum tickets available with 25 seats left, and advice to leave extra time/avoid downtown and reserve ASAP.",
+                "score": 1,
+                "value": {
+                  "kind": "numeric",
+                  "numeric": 1
+                }
+              }
+            },
+            {
+              "metricName": "trace_io_template",
+              "score": 1,
+              "evalStatus": "passed",
+              "threshold": 1,
+              "criterion": {
+                "llmJudge": {
+                  "template": {
+                    "prompt": "You are grading whether the selected execution trace step output answers the selected execution trace step input. The trace snapshots may be plain text or JSON.\\n\\nTrace step input snapshot:\\n[{\"role\":\"system\",\"content\":\"Travel agent used by the tRPC-Agent evaluation example.\\n\\nYou are a concise travel assistant.\\nUse this scenario when answering: Shanghai is sunny at 26C, festival events will be held downtown with likely traffic disruptions, and museum tickets are available with 25 seats left.\\nAnswer the user's travel question with weather, alert, ticket availability, and practical advice.\"},{\"role\":\"user\",\"content\":\"I am traveling to Shanghai today. What should I watch out for, and can I still get a museum ticket?\"}]\\n\\nTrace step output snapshot:\\n{\"id\":\"chatcmpl-EDmtfNXQKCzyIM4JAhT92ctBLl7ch\",\"object\":\"chat.completion\",\"created\":1786954931,\"model\":\"gpt-5.2-2025-12-11\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Shanghai today is sunny around **26°C**—comfortable, but bring **sunscreen** and **water**, and consider a light layer for indoor A/C.\\n\\n**Watch outs / alerts**\\n- **Festival events downtown** are likely to cause **traffic disruptions** (road closures, slower taxis/rideshares, crowded metro stations).\\n- If you need to cross downtown, **leave extra time** and prefer the **metro** over driving; plan alternate routes and avoid peak event hours if possible.\\n\\n**Museum tickets**\\n- Yes—tickets are still available, with **about 25 seats left**. If you’re going today, **book ASAP** to lock in a time slot.\\n\\n**Practical tips**\\n- Aim to arrive **15–30 minutes early** for security lines and crowds.\\n- Keep a backup plan (another museum/attraction nearby) in case your preferred slot sells out.\"},\"delta\":{\"role\":\"\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":104,\"completion_tokens\":185,\"total_tokens\":289,\"prompt_tokens_details\":{\"cached_tokens\":0},\"completion_tokens_details\":{},\"timing_info\":{\"time_to_first_token\":4830072175}},\"timestamp\":\"2026-08-17T16:22:16.212800365+08:00\",\"done\":true,\"is_partial\":false}\\n\\nReturn JSON with:\\n- score: 1 if the output answers the input.\\n- score: 0 otherwise.\\n- reason: one concise sentence.",
+                    "responseScorerName": "single_score",
+                    "variableBindings": [
+                      {
+                        "templateVariable": "trace_input",
+                        "source": {
+                          "scope": "actual",
+                          "field": "traceStepInput",
+                          "selector": {
+                            "nodeID": "trpcagent-travel-agent"
+                          }
+                        }
+                      },
+                      {
+                        "templateVariable": "trace_output",
+                        "source": {
+                          "scope": "actual",
+                          "field": "traceStepOutput",
+                          "selector": {
+                            "nodeID": "trpcagent-travel-agent"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "details": {
+                "reason": "It directly addresses today’s Shanghai weather (sunny 26°C), warns about downtown festival traffic disruptions, confirms museum ticket availability with 25 seats left, and gives practical travel advice.",
+                "score": 1,
+                "value": {
+                  "kind": "numeric",
+                  "numeric": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "sessionId": "9eb1d160-c8f0-45ac-8b67-f5e9e2c2ca3f",
+      "userId": "demo-user"
+    }
+  ],
+  "summary": {
+    "overallStatus": "passed",
+    "numRuns": 1,
+    "runStatusCounts": {
+      "passed": 1
+    },
+    "runSummaries": [
+      {
+        "runId": 1,
+        "overallStatus": "passed",
+        "caseStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "llm_final_response",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 0.9,
+            "statusCounts": {
+              "passed": 1
+            }
+          },
+          {
+            "metricName": "trace_io_template",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          }
+        ]
+      }
+    ],
+    "evalCaseSummaries": [
+      {
+        "evalId": "shanghai_travel_advice",
+        "overallStatus": "passed",
+        "runStatusCounts": {
+          "passed": 1
+        },
+        "metricSummaries": [
+          {
+            "metricName": "llm_final_response",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 0.9,
+            "statusCounts": {
+              "passed": 1
+            }
+          },
+          {
+            "metricName": "trace_io_template",
+            "averageScore": 1,
+            "evalStatus": "passed",
+            "threshold": 1,
+            "statusCounts": {
+              "passed": 1
+            }
+          }
+        ],
+        "runSummaries": [
+          {
+            "runId": 1,
+            "finalEvalStatus": "passed",
+            "metricResults": [
+              {
+                "metricName": "llm_final_response",
+                "score": 1,
+                "evalStatus": "passed",
+                "threshold": 0.9
+              },
+              {
+                "metricName": "trace_io_template",
+                "score": 1,
+                "evalStatus": "passed",
+                "threshold": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "creationTimestamp": 1786954943.3877184
+}

--- a/examples/evaluation/trpcagent/servers/adk/README.md
+++ b/examples/evaluation/trpcagent/servers/adk/README.md
@@ -1,0 +1,20 @@
+# ADK tRPC-Agent Server
+
+This is the ADK candidate server for `examples/evaluation/trpcagent`. It builds a real Python ADK `Agent`, calls an OpenAI-compatible LLM through `LiteLlm`, and exposes the same HTTP protocol used by `server/trpcagent`.
+
+## Run
+
+```bash
+cd examples/evaluation/trpcagent/servers/adk
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_API_BASE="https://your-openai-compatible-endpoint/v1"
+export ADK_MODEL="openai/gpt-5.2"
+python server.py
+```
+
+`OPENAI_API_BASE` is optional when the provider uses the default OpenAI endpoint.
+
+The server listens on `http://127.0.0.1:8081/trpc-agent/v1/apps/trpcagent-travel-agent` by default. Its `/runs` response includes an execution trace when the client sends `executionTraceEnabled: true`; token usage is included when ADK returns usage metadata.

--- a/examples/evaluation/trpcagent/servers/adk/agent.py
+++ b/examples/evaluation/trpcagent/servers/adk/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 import uuid
 from typing import Any
 
@@ -23,6 +24,8 @@ INSTRUCTION = """You are a concise travel assistant.
 Use this scenario when answering: Shanghai is sunny at 26C, festival events will be held downtown with likely traffic disruptions, and museum tickets are available with 25 seats left.
 Answer the user's travel question with weather, alert, ticket availability, and practical advice."""
 SESSION_SERVICE = InMemorySessionService()
+SESSION_LOCK = threading.Lock()
+KNOWN_SESSIONS: set[tuple[str, str]] = set()
 TRAVEL_AGENT = Agent(
     name=ADK_AGENT_NAME,
     description="Travel agent used by the tRPC-Agent evaluation example.",
@@ -37,8 +40,8 @@ TRAVEL_AGENT = Agent(
 
 def run_agent(request: dict) -> tuple[str, dict | None]:
     user_id = (request.get("session") or {}).get("userId") or "trpcagent"
-    session_id = request_id_from(request)
-    asyncio.run(SESSION_SERVICE.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id))
+    session_id = session_id_from(request)
+    ensure_session(user_id, session_id)
     runner = Runner(agent=TRAVEL_AGENT, app_name=APP_NAME, session_service=SESSION_SERVICE)
     message = types.Content(role="user", parts=[types.Part(text=input_text(request))])
     final_text = ""
@@ -56,6 +59,20 @@ def run_agent(request: dict) -> tuple[str, dict | None]:
 def request_id_from(request: dict) -> str:
     run_options = request.get("runOptions") or {}
     return run_options.get("requestID") or run_options.get("requestId") or str(uuid.uuid4())
+
+
+def session_id_from(request: dict) -> str:
+    session = request.get("session") or {}
+    return session.get("sessionId") or request_id_from(request)
+
+
+def ensure_session(user_id: str, session_id: str) -> None:
+    key = (user_id, session_id)
+    with SESSION_LOCK:
+        if key in KNOWN_SESSIONS:
+            return
+        asyncio.run(SESSION_SERVICE.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id))
+        KNOWN_SESSIONS.add(key)
 
 
 def input_text(request: dict) -> str:

--- a/examples/evaluation/trpcagent/servers/adk/agent.py
+++ b/examples/evaluation/trpcagent/servers/adk/agent.py
@@ -1,0 +1,108 @@
+"""ADK travel agent used by the tRPC-Agent evaluation example."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import Any
+
+from google.adk import Agent
+from google.adk.models.lite_llm import LiteLlm
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+
+APP_NAME = "trpcagent-travel-agent"
+ADK_AGENT_NAME = "trpcagent_travel_agent"
+MODEL_NAME = os.getenv("ADK_MODEL", "openai/gpt-5.2")
+MAX_OUTPUT_TOKENS = 512
+STRUCTURE_ID = f"{APP_NAME}:adk:v1"
+INSTRUCTION = """You are a concise travel assistant.
+Use this scenario when answering: Shanghai is sunny at 26C, festival events will be held downtown with likely traffic disruptions, and museum tickets are available with 25 seats left.
+Answer the user's travel question with weather, alert, ticket availability, and practical advice."""
+SESSION_SERVICE = InMemorySessionService()
+TRAVEL_AGENT = Agent(
+    name=ADK_AGENT_NAME,
+    description="Travel agent used by the tRPC-Agent evaluation example.",
+    instruction=INSTRUCTION,
+    model=LiteLlm(model=MODEL_NAME),
+    generate_content_config=types.GenerateContentConfig(
+        max_output_tokens=MAX_OUTPUT_TOKENS,
+        temperature=0.0,
+    ),
+)
+
+
+def run_agent(request: dict) -> tuple[str, dict | None]:
+    user_id = (request.get("session") or {}).get("userId") or "trpcagent"
+    session_id = request_id_from(request)
+    asyncio.run(SESSION_SERVICE.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id))
+    runner = Runner(agent=TRAVEL_AGENT, app_name=APP_NAME, session_service=SESSION_SERVICE)
+    message = types.Content(role="user", parts=[types.Part(text=input_text(request))])
+    final_text = ""
+    usage = None
+    for event in runner.run(user_id=user_id, session_id=session_id, new_message=message):
+        if current_usage := event_usage(event):
+            usage = current_usage
+        if event.is_final_response() and event.content and event.content.parts:
+            final_text = parts_text(event.content.parts).strip()
+    if not final_text:
+        raise RuntimeError("agent did not return a final response")
+    return final_text, usage
+
+
+def request_id_from(request: dict) -> str:
+    run_options = request.get("runOptions") or {}
+    return run_options.get("requestID") or run_options.get("requestId") or str(uuid.uuid4())
+
+
+def input_text(request: dict) -> str:
+    return ((request.get("input") or {}).get("content") or "").strip()
+
+
+def parts_text(parts: list[Any]) -> str:
+    return "\n".join(getattr(part, "text", "") or "" for part in parts)
+
+
+def event_usage(event: Any) -> dict | None:
+    return usage_from_metadata(getattr(event, "usage_metadata", None))
+
+
+def usage_from_metadata(metadata: Any) -> dict | None:
+    if metadata is None:
+        return None
+    prompt_tokens = token_count(metadata, "prompt_token_count", "input_tokens", "prompt_tokens")
+    completion_tokens = token_count(
+        metadata,
+        "candidates_token_count",
+        "output_tokens",
+        "completion_tokens",
+    )
+    total_tokens = token_count(metadata, "total_token_count", "total_tokens")
+    if total_tokens == 0 and (prompt_tokens or completion_tokens):
+        total_tokens = prompt_tokens + completion_tokens
+    if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "prompt_tokens_details": {
+            "cached_tokens": token_count(metadata, "cached_content_token_count", "cached_tokens"),
+        },
+        "completion_tokens_details": {},
+    }
+
+
+def token_count(source: Any, *names: str) -> int:
+    for name in names:
+        value = source.get(name) if isinstance(source, dict) else getattr(source, name, None)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return 0

--- a/examples/evaluation/trpcagent/servers/adk/protocol.py
+++ b/examples/evaluation/trpcagent/servers/adk/protocol.py
@@ -29,6 +29,7 @@ def structure_payload() -> dict:
 def run_response(request: dict) -> tuple[int, dict]:
     request_id = request_id_from(request)
     invocation_id = request_id
+    started_at = now()
     try:
         output, usage = run_agent(request)
     except Exception as exc:
@@ -36,12 +37,12 @@ def run_response(request: dict) -> tuple[int, dict]:
         events = [error_event(request_id, invocation_id, message), completion_event(request_id, invocation_id, message)]
         response = {"status": "failed", "events": events, "errorMessage": message}
         if trace_enabled(request):
-            response["executionTrace"] = trace_payload(request, invocation_id, "", "failed", message)
+            response["executionTrace"] = trace_payload(request, invocation_id, "", "failed", message, started_at=started_at)
         return 200, response
     events = [final_event(request_id, invocation_id, output), completion_event(request_id, invocation_id)]
     response = {"status": "completed", "events": events}
     if trace_enabled(request):
-        response["executionTrace"] = trace_payload(request, invocation_id, output, "completed", usage=usage)
+        response["executionTrace"] = trace_payload(request, invocation_id, output, "completed", usage=usage, started_at=started_at)
     return 200, response
 
 
@@ -66,8 +67,10 @@ def trace_payload(
     status: str,
     error: str = "",
     usage: dict | None = None,
+    started_at: str = "",
 ) -> dict:
-    timestamp = now()
+    ended_at = now()
+    started_at = started_at or ended_at
     user_input = ((request.get("input") or {}).get("content") or "").strip()
     session_id = (request.get("session") or {}).get("sessionId") or ""
     step = {
@@ -76,8 +79,8 @@ def trace_payload(
         "AgentName": APP_NAME,
         "NodeID": APP_NAME,
         "NodeType": "agent",
-        "StartedAt": timestamp,
-        "EndedAt": timestamp,
+        "StartedAt": started_at,
+        "EndedAt": ended_at,
         "AppliedSurfaceIDs": [SURFACE_ID, MODEL_SURFACE_ID],
         "Input": {"Text": user_input},
         "Output": {"Text": output},
@@ -87,8 +90,8 @@ def trace_payload(
         "RootAgentName": APP_NAME,
         "RootInvocationID": invocation_id,
         "SessionID": session_id,
-        "StartedAt": timestamp,
-        "EndedAt": timestamp,
+        "StartedAt": started_at,
+        "EndedAt": ended_at,
         "Status": status,
         "Input": {"Text": user_input},
         "Output": {"Text": output},

--- a/examples/evaluation/trpcagent/servers/adk/protocol.py
+++ b/examples/evaluation/trpcagent/servers/adk/protocol.py
@@ -1,0 +1,147 @@
+"""tRPC-Agent HTTP protocol helpers for the ADK example server."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+from agent import APP_NAME, INSTRUCTION, MODEL_NAME, STRUCTURE_ID, run_agent
+
+SURFACE_ID = f"{APP_NAME}#instruction"
+MODEL_SURFACE_ID = f"{APP_NAME}#model"
+
+
+def structure_payload() -> dict:
+    return {
+        "structure": {
+            "StructureID": STRUCTURE_ID,
+            "EntryNodeID": APP_NAME,
+            "Nodes": [{"NodeID": APP_NAME, "Kind": "agent", "Name": APP_NAME}],
+            "Edges": [],
+            "Surfaces": [
+                {"SurfaceID": SURFACE_ID, "NodeID": APP_NAME, "Type": "instruction", "Value": {"Text": INSTRUCTION}},
+                {"SurfaceID": MODEL_SURFACE_ID, "NodeID": APP_NAME, "Type": "model", "Value": {"Model": {"Name": MODEL_NAME}}},
+            ],
+        }
+    }
+
+
+def run_response(request: dict) -> tuple[int, dict]:
+    request_id = request_id_from(request)
+    invocation_id = request_id
+    try:
+        output, usage = run_agent(request)
+    except Exception as exc:
+        message = str(exc)
+        events = [error_event(request_id, invocation_id, message), completion_event(request_id, invocation_id, message)]
+        response = {"status": "failed", "events": events, "errorMessage": message}
+        if trace_enabled(request):
+            response["executionTrace"] = trace_payload(request, invocation_id, "", "failed", message)
+        return 200, response
+    events = [final_event(request_id, invocation_id, output), completion_event(request_id, invocation_id)]
+    response = {"status": "completed", "events": events}
+    if trace_enabled(request):
+        response["executionTrace"] = trace_payload(request, invocation_id, output, "completed", usage=usage)
+    return 200, response
+
+
+def request_id_from(request: dict) -> str:
+    run_options = request.get("runOptions") or {}
+    return run_options.get("requestID") or run_options.get("requestId") or str(uuid.uuid4())
+
+
+def trace_enabled(request: dict) -> bool:
+    run_options = request.get("runOptions") or {}
+    return bool(run_options.get("executionTraceEnabled") or run_options.get("ExecutionTraceEnabled"))
+
+
+def now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def trace_payload(
+    request: dict,
+    invocation_id: str,
+    output: str,
+    status: str,
+    error: str = "",
+    usage: dict | None = None,
+) -> dict:
+    timestamp = now()
+    user_input = ((request.get("input") or {}).get("content") or "").strip()
+    session_id = (request.get("session") or {}).get("sessionId") or ""
+    step = {
+        "StepID": f"{invocation_id}:root",
+        "InvocationID": invocation_id,
+        "AgentName": APP_NAME,
+        "NodeID": APP_NAME,
+        "NodeType": "agent",
+        "StartedAt": timestamp,
+        "EndedAt": timestamp,
+        "AppliedSurfaceIDs": [SURFACE_ID, MODEL_SURFACE_ID],
+        "Input": {"Text": user_input},
+        "Output": {"Text": output},
+        "Error": error,
+    }
+    trace = {
+        "RootAgentName": APP_NAME,
+        "RootInvocationID": invocation_id,
+        "SessionID": session_id,
+        "StartedAt": timestamp,
+        "EndedAt": timestamp,
+        "Status": status,
+        "Input": {"Text": user_input},
+        "Output": {"Text": output},
+        "Steps": [step],
+    }
+    if usage:
+        trace["Usage"] = usage
+        step["Usage"] = usage
+    return trace
+
+
+def final_event(request_id: str, invocation_id: str, output: str) -> dict:
+    return {
+        "requestID": request_id,
+        "invocationId": invocation_id,
+        "author": APP_NAME,
+        "id": f"{invocation_id}:final",
+        "timestamp": now(),
+        "object": "chat.completion",
+        "done": True,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": output or ""},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def error_event(request_id: str, invocation_id: str, message: str) -> dict:
+    return {
+        "requestID": request_id,
+        "invocationId": invocation_id,
+        "author": APP_NAME,
+        "id": f"{invocation_id}:error",
+        "timestamp": now(),
+        "object": "error",
+        "done": True,
+        "error": {"type": "run_error", "message": message},
+    }
+
+
+def completion_event(request_id: str, invocation_id: str, error_message: str = "") -> dict:
+    event = {
+        "requestID": request_id,
+        "invocationId": invocation_id,
+        "author": APP_NAME,
+        "id": f"{invocation_id}:done",
+        "timestamp": now(),
+        "object": "runner.completion",
+        "done": True,
+    }
+    if error_message:
+        event["error"] = {"type": "run_error", "message": error_message}
+    return event

--- a/examples/evaluation/trpcagent/servers/adk/requirements.txt
+++ b/examples/evaluation/trpcagent/servers/adk/requirements.txt
@@ -1,0 +1,2 @@
+google-adk>=1.5.0
+litellm>=1.75.0

--- a/examples/evaluation/trpcagent/servers/adk/server.py
+++ b/examples/evaluation/trpcagent/servers/adk/server.py
@@ -48,7 +48,6 @@ class Handler(BaseHTTPRequestHandler):
         raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Content-Length", str(len(raw)))
         self.end_headers()
         self.wfile.write(raw)

--- a/examples/evaluation/trpcagent/servers/adk/server.py
+++ b/examples/evaluation/trpcagent/servers/adk/server.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""ADK-compatible tRPC-Agent HTTP service for evaluation."""
+
+from __future__ import annotations
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote, urlparse
+
+from agent import APP_NAME
+from protocol import run_response, structure_payload
+
+
+HOST = os.getenv("HOST", "127.0.0.1")
+PORT = int(os.getenv("PORT", "8081"))
+BASE_PATH = os.getenv("TRPC_AGENT_BASE_PATH", "/trpc-agent/v1/apps")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.route("structure"):
+            self.write_json(200, structure_payload())
+            return
+        self.write_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if not self.route("runs"):
+            self.write_json(404, {"error": "not found"})
+            return
+        status, payload = run_response(self.read_json())
+        self.write_json(status, payload)
+
+    def route(self, resource: str) -> bool:
+        path = urlparse(self.path).path
+        prefix = f"{BASE_PATH}/{APP_NAME}/"
+        if not path.startswith(prefix):
+            return False
+        return unquote(path[len(prefix) :]) == resource
+
+    def read_json(self) -> dict:
+        length = int(self.headers.get("Content-Length") or "0")
+        if length == 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def write_json(self, status: int, payload: dict) -> None:
+        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+def main() -> None:
+    server = ThreadingHTTPServer((HOST, PORT), Handler)
+    print(f"ADK tRPC-Agent service listening on http://{HOST}:{PORT}{BASE_PATH}/{APP_NAME}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/evaluation/trpcagent/servers/langgraph/README.md
+++ b/examples/evaluation/trpcagent/servers/langgraph/README.md
@@ -1,0 +1,20 @@
+# LangGraph tRPC-Agent Server
+
+This is the LangGraph candidate server for `examples/evaluation/trpcagent`. It builds a real `StateGraph`, calls an OpenAI-compatible LLM through `ChatOpenAI`, and exposes the same HTTP protocol used by `server/trpcagent`.
+
+## Run
+
+```bash
+cd examples/evaluation/trpcagent/servers/langgraph
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
+export LANGGRAPH_MODEL="gpt-5.2"
+python server.py
+```
+
+`OPENAI_BASE_URL` is optional when the provider uses the default OpenAI endpoint.
+
+The server listens on `http://127.0.0.1:8081/trpc-agent/v1/apps/trpcagent-travel-agent` by default. Its `/runs` response includes an execution trace when the client sends `executionTraceEnabled: true`; token usage is included when LangChain returns usage metadata.

--- a/examples/evaluation/trpcagent/servers/langgraph/agent.py
+++ b/examples/evaluation/trpcagent/servers/langgraph/agent.py
@@ -1,0 +1,98 @@
+"""LangGraph travel agent used by the tRPC-Agent evaluation example."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+
+APP_NAME = "trpcagent-travel-agent"
+MODEL_NAME = os.getenv("LANGGRAPH_MODEL", "gpt-5.2")
+MAX_OUTPUT_TOKENS = 512
+STRUCTURE_ID = f"{APP_NAME}:langgraph:v1"
+INSTRUCTION = """You are a concise travel assistant.
+Use this scenario when answering: Shanghai is sunny at 26C, festival events will be held downtown with likely traffic disruptions, and museum tickets are available with 25 seats left.
+Answer the user's travel question with weather, alert, ticket availability, and practical advice."""
+
+
+class TravelState(TypedDict, total=False):
+    user_input: str
+    final_response: str
+    usage: dict
+
+
+def build_graph():
+    model = ChatOpenAI(
+        model=MODEL_NAME,
+        temperature=0.0,
+        max_completion_tokens=MAX_OUTPUT_TOKENS,
+    )
+
+    def answer(state: TravelState) -> dict:
+        response = model.invoke(
+            [
+                SystemMessage(content=INSTRUCTION),
+                HumanMessage(content=state.get("user_input", "")),
+            ]
+        )
+        return {"final_response": str(response.content).strip(), "usage": usage_from_message(response)}
+
+    graph = StateGraph(TravelState)
+    graph.add_node("answer", answer)
+    graph.add_edge(START, "answer")
+    graph.add_edge("answer", END)
+    return graph.compile()
+
+
+def run_agent(request: dict) -> tuple[str, dict | None]:
+    result = build_graph().invoke({"user_input": input_text(request)})
+    final = result.get("final_response", "").strip()
+    if not final:
+        raise RuntimeError("agent did not return a final response")
+    return final, result.get("usage")
+
+
+def input_text(request: dict) -> str:
+    return ((request.get("input") or {}).get("content") or "").strip()
+
+
+def usage_from_message(message: Any) -> dict | None:
+    metadata = getattr(message, "usage_metadata", None) or {}
+    response_metadata = getattr(message, "response_metadata", None) or {}
+    token_usage = response_metadata.get("token_usage") or response_metadata.get("usage") or {}
+    prompt_tokens = token_count(metadata, "input_tokens", "prompt_tokens") or token_count(token_usage, "prompt_tokens")
+    completion_tokens = token_count(metadata, "output_tokens", "completion_tokens") or token_count(
+        token_usage,
+        "completion_tokens",
+    )
+    total_tokens = token_count(metadata, "total_tokens") or token_count(token_usage, "total_tokens")
+    if total_tokens == 0 and (prompt_tokens or completion_tokens):
+        total_tokens = prompt_tokens + completion_tokens
+    if prompt_tokens == 0 and completion_tokens == 0 and total_tokens == 0:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "prompt_tokens_details": {
+            "cached_tokens": 0,
+        },
+        "completion_tokens_details": {},
+    }
+
+
+def token_count(source: Any, *names: str) -> int:
+    for name in names:
+        value = source.get(name) if isinstance(source, dict) else getattr(source, name, None)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return 0

--- a/examples/evaluation/trpcagent/servers/langgraph/protocol.py
+++ b/examples/evaluation/trpcagent/servers/langgraph/protocol.py
@@ -29,6 +29,7 @@ def structure_payload() -> dict:
 def run_response(request: dict) -> tuple[int, dict]:
     request_id = request_id_from(request)
     invocation_id = request_id
+    started_at = now()
     try:
         output, usage = run_agent(request)
     except Exception as exc:
@@ -36,12 +37,12 @@ def run_response(request: dict) -> tuple[int, dict]:
         events = [error_event(request_id, invocation_id, message), completion_event(request_id, invocation_id, message)]
         response = {"status": "failed", "events": events, "errorMessage": message}
         if trace_enabled(request):
-            response["executionTrace"] = trace_payload(request, invocation_id, "", "failed", message)
+            response["executionTrace"] = trace_payload(request, invocation_id, "", "failed", message, started_at=started_at)
         return 200, response
     events = [final_event(request_id, invocation_id, output), completion_event(request_id, invocation_id)]
     response = {"status": "completed", "events": events}
     if trace_enabled(request):
-        response["executionTrace"] = trace_payload(request, invocation_id, output, "completed", usage=usage)
+        response["executionTrace"] = trace_payload(request, invocation_id, output, "completed", usage=usage, started_at=started_at)
     return 200, response
 
 
@@ -66,8 +67,10 @@ def trace_payload(
     status: str,
     error: str = "",
     usage: dict | None = None,
+    started_at: str = "",
 ) -> dict:
-    timestamp = now()
+    ended_at = now()
+    started_at = started_at or ended_at
     user_input = ((request.get("input") or {}).get("content") or "").strip()
     session_id = (request.get("session") or {}).get("sessionId") or ""
     step = {
@@ -76,8 +79,8 @@ def trace_payload(
         "AgentName": APP_NAME,
         "NodeID": APP_NAME,
         "NodeType": "agent",
-        "StartedAt": timestamp,
-        "EndedAt": timestamp,
+        "StartedAt": started_at,
+        "EndedAt": ended_at,
         "AppliedSurfaceIDs": [SURFACE_ID, MODEL_SURFACE_ID],
         "Input": {"Text": user_input},
         "Output": {"Text": output},
@@ -87,8 +90,8 @@ def trace_payload(
         "RootAgentName": APP_NAME,
         "RootInvocationID": invocation_id,
         "SessionID": session_id,
-        "StartedAt": timestamp,
-        "EndedAt": timestamp,
+        "StartedAt": started_at,
+        "EndedAt": ended_at,
         "Status": status,
         "Input": {"Text": user_input},
         "Output": {"Text": output},

--- a/examples/evaluation/trpcagent/servers/langgraph/protocol.py
+++ b/examples/evaluation/trpcagent/servers/langgraph/protocol.py
@@ -1,0 +1,147 @@
+"""tRPC-Agent HTTP protocol helpers for the LangGraph example server."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+from agent import APP_NAME, INSTRUCTION, MODEL_NAME, STRUCTURE_ID, run_agent
+
+SURFACE_ID = f"{APP_NAME}#instruction"
+MODEL_SURFACE_ID = f"{APP_NAME}#model"
+
+
+def structure_payload() -> dict:
+    return {
+        "structure": {
+            "StructureID": STRUCTURE_ID,
+            "EntryNodeID": APP_NAME,
+            "Nodes": [{"NodeID": APP_NAME, "Kind": "agent", "Name": APP_NAME}],
+            "Edges": [],
+            "Surfaces": [
+                {"SurfaceID": SURFACE_ID, "NodeID": APP_NAME, "Type": "instruction", "Value": {"Text": INSTRUCTION}},
+                {"SurfaceID": MODEL_SURFACE_ID, "NodeID": APP_NAME, "Type": "model", "Value": {"Model": {"Name": MODEL_NAME}}},
+            ],
+        }
+    }
+
+
+def run_response(request: dict) -> tuple[int, dict]:
+    request_id = request_id_from(request)
+    invocation_id = request_id
+    try:
+        output, usage = run_agent(request)
+    except Exception as exc:
+        message = str(exc)
+        events = [error_event(request_id, invocation_id, message), completion_event(request_id, invocation_id, message)]
+        response = {"status": "failed", "events": events, "errorMessage": message}
+        if trace_enabled(request):
+            response["executionTrace"] = trace_payload(request, invocation_id, "", "failed", message)
+        return 200, response
+    events = [final_event(request_id, invocation_id, output), completion_event(request_id, invocation_id)]
+    response = {"status": "completed", "events": events}
+    if trace_enabled(request):
+        response["executionTrace"] = trace_payload(request, invocation_id, output, "completed", usage=usage)
+    return 200, response
+
+
+def request_id_from(request: dict) -> str:
+    run_options = request.get("runOptions") or {}
+    return run_options.get("requestID") or run_options.get("requestId") or str(uuid.uuid4())
+
+
+def trace_enabled(request: dict) -> bool:
+    run_options = request.get("runOptions") or {}
+    return bool(run_options.get("executionTraceEnabled") or run_options.get("ExecutionTraceEnabled"))
+
+
+def now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def trace_payload(
+    request: dict,
+    invocation_id: str,
+    output: str,
+    status: str,
+    error: str = "",
+    usage: dict | None = None,
+) -> dict:
+    timestamp = now()
+    user_input = ((request.get("input") or {}).get("content") or "").strip()
+    session_id = (request.get("session") or {}).get("sessionId") or ""
+    step = {
+        "StepID": f"{invocation_id}:root",
+        "InvocationID": invocation_id,
+        "AgentName": APP_NAME,
+        "NodeID": APP_NAME,
+        "NodeType": "agent",
+        "StartedAt": timestamp,
+        "EndedAt": timestamp,
+        "AppliedSurfaceIDs": [SURFACE_ID, MODEL_SURFACE_ID],
+        "Input": {"Text": user_input},
+        "Output": {"Text": output},
+        "Error": error,
+    }
+    trace = {
+        "RootAgentName": APP_NAME,
+        "RootInvocationID": invocation_id,
+        "SessionID": session_id,
+        "StartedAt": timestamp,
+        "EndedAt": timestamp,
+        "Status": status,
+        "Input": {"Text": user_input},
+        "Output": {"Text": output},
+        "Steps": [step],
+    }
+    if usage:
+        trace["Usage"] = usage
+        step["Usage"] = usage
+    return trace
+
+
+def final_event(request_id: str, invocation_id: str, output: str) -> dict:
+    return {
+        "requestID": request_id,
+        "invocationId": invocation_id,
+        "author": APP_NAME,
+        "id": f"{invocation_id}:final",
+        "timestamp": now(),
+        "object": "chat.completion",
+        "done": True,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": output or ""},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def error_event(request_id: str, invocation_id: str, message: str) -> dict:
+    return {
+        "requestID": request_id,
+        "invocationId": invocation_id,
+        "author": APP_NAME,
+        "id": f"{invocation_id}:error",
+        "timestamp": now(),
+        "object": "error",
+        "done": True,
+        "error": {"type": "run_error", "message": message},
+    }
+
+
+def completion_event(request_id: str, invocation_id: str, error_message: str = "") -> dict:
+    event = {
+        "requestID": request_id,
+        "invocationId": invocation_id,
+        "author": APP_NAME,
+        "id": f"{invocation_id}:done",
+        "timestamp": now(),
+        "object": "runner.completion",
+        "done": True,
+    }
+    if error_message:
+        event["error"] = {"type": "run_error", "message": error_message}
+    return event

--- a/examples/evaluation/trpcagent/servers/langgraph/requirements.txt
+++ b/examples/evaluation/trpcagent/servers/langgraph/requirements.txt
@@ -1,0 +1,4 @@
+langchain>=1.0.0
+langchain-openai>=1.0.0
+langgraph>=1.0.0
+typing-extensions>=4.12.0

--- a/examples/evaluation/trpcagent/servers/langgraph/server.py
+++ b/examples/evaluation/trpcagent/servers/langgraph/server.py
@@ -48,7 +48,6 @@ class Handler(BaseHTTPRequestHandler):
         raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Content-Length", str(len(raw)))
         self.end_headers()
         self.wfile.write(raw)

--- a/examples/evaluation/trpcagent/servers/langgraph/server.py
+++ b/examples/evaluation/trpcagent/servers/langgraph/server.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""LangGraph tRPC-Agent HTTP service for evaluation."""
+
+from __future__ import annotations
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote, urlparse
+
+from agent import APP_NAME
+from protocol import run_response, structure_payload
+
+
+HOST = os.getenv("HOST", "127.0.0.1")
+PORT = int(os.getenv("PORT", "8081"))
+BASE_PATH = os.getenv("TRPC_AGENT_BASE_PATH", "/trpc-agent/v1/apps")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.route("structure"):
+            self.write_json(200, structure_payload())
+            return
+        self.write_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if not self.route("runs"):
+            self.write_json(404, {"error": "not found"})
+            return
+        status, payload = run_response(self.read_json())
+        self.write_json(status, payload)
+
+    def route(self, resource: str) -> bool:
+        path = urlparse(self.path).path
+        prefix = f"{BASE_PATH}/{APP_NAME}/"
+        if not path.startswith(prefix):
+            return False
+        return unquote(path[len(prefix) :]) == resource
+
+    def read_json(self) -> dict:
+        length = int(self.headers.get("Content-Length") or "0")
+        if length == 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def write_json(self, status: int, payload: dict) -> None:
+        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+def main() -> None:
+    server = ThreadingHTTPServer((HOST, PORT), Handler)
+    print(f"LangGraph tRPC-Agent service listening on http://{HOST}:{PORT}{BASE_PATH}/{APP_NAME}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/evaluation/trpcagent/servers/trpcagentgo/README.md
+++ b/examples/evaluation/trpcagent/servers/trpcagentgo/README.md
@@ -1,0 +1,16 @@
+# Go tRPC-Agent Server
+
+This is the Go candidate server for `examples/evaluation/trpcagent`. It builds a real `llmagent`, uses `gpt-5.2` by default, and exposes the agent through `server/trpcagent`.
+
+## Run
+
+```bash
+cd examples/evaluation/trpcagent/servers/trpcagentgo
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
+go run . -model "gpt-5.2"
+```
+
+`OPENAI_BASE_URL` is optional when the provider uses the default OpenAI endpoint.
+
+The server listens on `http://127.0.0.1:8081/trpc-agent/v1/apps/trpcagent-travel-agent` by default. Its `/runs` response includes the native tRPC-Agent execution trace when the client sends `executionTraceEnabled: true`.

--- a/examples/evaluation/trpcagent/servers/trpcagentgo/agent.go
+++ b/examples/evaluation/trpcagent/servers/trpcagentgo/agent.go
@@ -1,0 +1,45 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const (
+	appName          = "trpcagent-travel-agent"
+	agentInstruction = `You are a concise travel assistant.
+Use this scenario when answering: Shanghai is sunny at 26C, festival events will be held downtown with likely traffic disruptions, and museum tickets are available with 25 seats left.
+Answer the user's travel question with weather, alert, ticket availability, and practical advice.`
+)
+
+func newTravelAgent(m model.Model, stream bool) agent.Agent {
+	genCfg := model.GenerationConfig{
+		MaxTokens:   intPtr(512),
+		Temperature: floatPtr(0),
+		Stream:      stream,
+	}
+	return llmagent.New(
+		appName,
+		llmagent.WithModel(m),
+		llmagent.WithDescription("Travel agent used by the tRPC-Agent evaluation example."),
+		llmagent.WithInstruction(agentInstruction),
+		llmagent.WithGenerationConfig(genCfg),
+	)
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}

--- a/examples/evaluation/trpcagent/servers/trpcagentgo/main.go
+++ b/examples/evaluation/trpcagent/servers/trpcagentgo/main.go
@@ -1,0 +1,69 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package main exposes the Go reference service for the tRPC-Agent evaluation example.
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"net/url"
+
+	"trpc.group/trpc-go/trpc-agent-go/model/openai"
+	rootrunner "trpc.group/trpc-go/trpc-agent-go/runner"
+	servertrpcagent "trpc.group/trpc-go/trpc-agent-go/server/trpcagent"
+)
+
+var (
+	addr      = flag.String("addr", ":8081", "Listen address for the tRPC-Agent service")
+	basePath  = flag.String("base-path", "/trpc-agent/v1/apps", "Base path exposed by the tRPC-Agent service")
+	modelName = flag.String("model", "gpt-5.2", "Model identifier used by the travel agent")
+	streaming = flag.Bool("streaming", false, "Stream model responses from the travel agent")
+)
+
+func main() {
+	flag.Parse()
+	travelAgent := newTravelAgent(openai.New(*modelName), *streaming)
+	travelRunner := rootrunner.NewRunner(appName, travelAgent)
+	defer travelRunner.Close()
+	server, err := servertrpcagent.New(
+		servertrpcagent.WithAppName(appName),
+		servertrpcagent.WithBasePath(*basePath),
+		servertrpcagent.WithAgent(travelAgent),
+		servertrpcagent.WithRunner(travelRunner),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := logServerRoutes(*addr, *basePath); err != nil {
+		log.Fatal(err)
+	}
+	if err := http.ListenAndServe(*addr, server.Handler()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func logServerRoutes(addr string, basePath string) error {
+	servicePath, err := url.JoinPath(basePath, appName)
+	if err != nil {
+		return err
+	}
+	structurePath, err := url.JoinPath(basePath, appName, "structure")
+	if err != nil {
+		return err
+	}
+	runsPath, err := url.JoinPath(basePath, appName, "runs")
+	if err != nil {
+		return err
+	}
+	log.Printf("tRPC-Agent service listening on %s%s", addr, servicePath)
+	log.Printf("tRPC-Agent structure route: GET %s", structurePath)
+	log.Printf("tRPC-Agent runs route: POST %s", runsPath)
+	return nil
+}

--- a/examples/evaluation/trpcagent/servers/trpcagentgo/main.go
+++ b/examples/evaluation/trpcagent/servers/trpcagentgo/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	addr      = flag.String("addr", ":8081", "Listen address for the tRPC-Agent service")
+	addr      = flag.String("addr", "127.0.0.1:8081", "Listen address for the tRPC-Agent service")
 	basePath  = flag.String("base-path", "/trpc-agent/v1/apps", "Base path exposed by the tRPC-Agent service")
 	modelName = flag.String("model", "gpt-5.2", "Model identifier used by the travel agent")
 	streaming = flag.Bool("streaming", false, "Stream model responses from the travel agent")


### PR DESCRIPTION
This adds a remote Agent evaluation example that evaluates tRPC-Agent-compatible services through runner/trpcagent, including a Go server/trpcagent reference service and ADK and LangGraph protocol-compatible services. It also documents the remote Agent evaluation flow in the English and Chinese evaluation methods guides, showing how the business service exposes the candidate Agent and how the evaluation side wires the remote Runner into AgentEvaluator.