### PR TITLE
internal/flow/llmflow: preserve compaction lineage through request transforms

### DIFF
--- a/.github/benchmarks/agentloop/suites.txt
+++ b/.github/benchmarks/agentloop/suites.txt
@@ -7,8 +7,9 @@ agent-loop|.|./event|^BenchmarkEmitEventWithTimeout
 agent-loop|.|./internal/flow/llmflow|^BenchmarkGenerateContentSeq$
 agent-loop|.|./internal/flow/processor|^Benchmark(ContentRequestProcessorProcessRequest|ContextCompaction|ParallelInvocationViewBatch|ParallelInvocationViewBatchWithSession|ParallelInvocationViewWithSession)$
 agent-loop|.|./internal/state/summaryfork|^Benchmark(Attach|Request)$
-agent-loop|.|./internal/state/summaryview|^Benchmark(Finalize|Snapshot)$
+agent-loop|.|./internal/state/summaryview|^Benchmark(Finalize|RebaseAfterTransform|RebaseItems|Snapshot)$
 agent-loop|.|./internal/telemetry|^BenchmarkTraceChatStreamingRequestAttributes
+agent-loop|.|./internal/toolcall|^BenchmarkSanitizeMessagesWithTools$
 agent-loop|.|./model|^BenchmarkCallbacksRunBeforeModel$
 agent-loop|.|./runner|^BenchmarkRunnerAgentLoop$
 agent-loop|.|./session/inmemory|^BenchmarkAppendEvent$

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -603,6 +603,7 @@ func TestMaybeCompactContextBeforeLLM_SummarizesSanitizedOrphanToolCall(
 	view, ok := summaryview.Snapshot(inv)
 	require.True(t, ok)
 	require.True(t, view.Bound)
+	require.Len(t, req.Messages, 3)
 	require.Contains(t, req.Messages[1].Content, "orphan_tool_call")
 
 	rebuilt := f.maybeCompactContextBeforeLLM(
@@ -624,10 +625,12 @@ func TestMaybeCompactContextBeforeLLM_SummarizesSanitizedOrphanToolCall(
 	storedSummary := sess.Summaries[""]
 	sess.SummariesMu.RUnlock()
 	require.NotNil(t, storedSummary)
+	boundary := storedSummary.CutoffBoundary()
+	require.NotNil(t, boundary)
 	require.Equal(
 		t,
 		orphanCall.ID,
-		storedSummary.CutoffBoundary().LastEventID,
+		boundary.LastEventID,
 	)
 }
 
@@ -1686,6 +1689,16 @@ func TestNormalizeContextCompactionThresholdRatio(t *testing.T) {
 }
 
 func TestContextCompactionThreshold(t *testing.T) {
+	t.Run("reports minimum token clamp", func(t *testing.T) {
+		threshold, basis := contextCompactionThresholdForWindow(10000, 0.1)
+		require.Equal(t, 2000, threshold)
+		require.Equal(
+			t,
+			contextCompactionThresholdBasisMinimumTokens,
+			basis,
+		)
+	})
+
 	t.Run("caps to small model window", func(t *testing.T) {
 		const modelName = "compact-threshold-small-window"
 		model.RegisterModelContextWindow(modelName, 1024)
@@ -1694,6 +1707,12 @@ func TestContextCompactionThreshold(t *testing.T) {
 			agent.WithInvocationModel(&compactingModel{name: modelName}),
 		)
 		require.Equal(t, 1024, contextCompactionThreshold(inv, 0.1))
+		_, basis := contextCompactionThresholdForWindow(1024, 0.1)
+		require.Equal(
+			t,
+			contextCompactionThresholdBasisContextWindow,
+			basis,
+		)
 	})
 
 	t.Run("uses fallback window for unknown model", func(t *testing.T) {

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/calllimit"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
@@ -514,6 +515,120 @@ func TestMaybeCompactContextBeforeLLM_RebuildsRequestWithSummary(t *testing.T) {
 	require.Equal(t, "completed", doneDiagnostic.Status)
 	require.NotNil(t, doneDiagnostic.Updated)
 	require.True(t, *doneDiagnostic.Updated)
+}
+
+func TestMaybeCompactContextBeforeLLM_SummarizesSanitizedOrphanToolCall(
+	t *testing.T,
+) {
+	summaryModel := &mockModel{responses: []*model.Response{{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("compressed orphan history"),
+		}},
+	}}}
+	service := inmemory.NewSessionService(inmemory.WithSummarizer(
+		summary.NewSummarizer(
+			summaryModel,
+			summary.WithTokenThreshold(1),
+			summary.WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		),
+	))
+	t.Cleanup(func() {
+		require.NoError(t, service.Close())
+	})
+
+	ctx := context.Background()
+	sess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "orphan-compaction",
+	}, nil)
+	require.NoError(t, err)
+	oldUser := event.New("inv-old", "user")
+	oldUser.RequestID = "req-old"
+	oldUser.Timestamp = time.Now().Add(-time.Hour)
+	oldUser.Response = &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage(strings.Repeat("history ", 2000)),
+		}},
+	}
+	require.NoError(t, service.AppendEvent(ctx, sess, oldUser))
+	orphanCall := event.New("inv-old", "assistant")
+	orphanCall.RequestID = "req-old"
+	orphanCall.Timestamp = oldUser.Timestamp.Add(time.Second)
+	orphanCall.Response = &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Message: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID:   "call_orphan",
+				Type: "function",
+				Function: model.FunctionDefinitionParam{
+					Name:      "shell",
+					Arguments: []byte(`{"command":"pwd"}`),
+				},
+			}},
+		}}},
+	}
+	require.NoError(t, service.AppendEvent(ctx, sess, orphanCall))
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req-current",
+		}),
+		agent.WithInvocationModel(&compactingModel{
+			name:   "orphan-compaction-model",
+			window: 10000,
+		}),
+	)
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(ctx, inv, req, nil)
+	view, ok := summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Contains(t, req.Messages[1].Content, "orphan_tool_call")
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		ctx,
+		inv,
+		nil,
+		req,
+		rebuildPlan,
+	)
+
+	require.NotSame(t, req, rebuilt)
+	require.Len(t, rebuilt.Messages, 2)
+	require.Contains(t, rebuilt.Messages[0].Content, "compressed orphan history")
+	require.Equal(t, "current", rebuilt.Messages[1].Content)
+	summaryRequest := summaryModel.LastRequest()
+	require.NotNil(t, summaryRequest)
+	require.Contains(t, summaryRequest.Messages[0].Content, "orphan_tool_call")
+	sess.SummariesMu.RLock()
+	storedSummary := sess.Summaries[""]
+	sess.SummariesMu.RUnlock()
+	require.NotNil(t, storedSummary)
+	require.Equal(
+		t,
+		orphanCall.ID,
+		storedSummary.CutoffBoundary().LastEventID,
+	)
 }
 
 func TestMaybeCompactContextBeforeLLM_PassesParentRequestForCacheSafeFork(t *testing.T) {

--- a/internal/flow/llmflow/diagnostics.go
+++ b/internal/flow/llmflow/diagnostics.go
@@ -192,12 +192,18 @@ func emitLatencyDiagnosticEvent(
 }
 
 type contextCompactionDecision struct {
-	shouldCompact bool
-	tokenCount    int
-	threshold     int
-	contextWindow int
-	err           error
+	shouldCompact  bool
+	tokenCount     int
+	threshold      int
+	contextWindow  int
+	thresholdBasis string
+	err            error
 }
+
+const (
+	contextCompactionThresholdBasisContextWindow = "context_window"
+	contextCompactionThresholdBasisMinimumTokens = "minimum_tokens"
+)
 
 func contextCompactionAttrs(
 	decision contextCompactionDecision,
@@ -224,7 +230,7 @@ func contextCompactionAttrs(
 		),
 		attribute.String(
 			"llmflow.context_compaction.threshold_basis",
-			"context_window",
+			decision.thresholdBasis,
 		),
 	)
 	return attrs

--- a/internal/flow/llmflow/diagnostics.go
+++ b/internal/flow/llmflow/diagnostics.go
@@ -19,6 +19,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -221,6 +222,39 @@ func contextCompactionAttrs(
 			"llmflow.context_compaction.context_window",
 			decision.contextWindow,
 		),
+		attribute.String(
+			"llmflow.context_compaction.threshold_basis",
+			"context_window",
+		),
 	)
 	return attrs
+}
+
+func tokenTailoringAttrs(
+	records []modelrequest.TokenTailoringRecord,
+) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Bool("llmflow.token_tailoring.applied", len(records) > 0),
+		attribute.Int("llmflow.token_tailoring.apply_count", len(records)),
+	}
+	if len(records) == 0 {
+		return attrs
+	}
+	last := records[len(records)-1]
+	return append(
+		attrs,
+		attribute.String("llmflow.token_tailoring.provider", last.Provider),
+		attribute.Int(
+			"llmflow.token_tailoring.max_input_tokens",
+			last.MaxInputTokens,
+		),
+		attribute.Int(
+			"llmflow.token_tailoring.before_messages",
+			last.BeforeMessages,
+		),
+		attribute.Int(
+			"llmflow.token_tailoring.after_messages",
+			last.AfterMessages,
+		),
+	)
 }

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1573,8 +1573,31 @@ func (f *Flow) preprocess(
 		finishLatencySpan(stageSpan, stageStarted, nil)
 	}
 	// Sanitize invalid tool calls in history to avoid poisoning future requests.
-	llmRequest.Messages = toolcall.SanitizeMessagesWithTools(ctx, llmRequest.Messages, llmRequest.Tools)
+	sanitizeRequestMessages(ctx, invocation, llmRequest)
 	return rebuildPlan
+}
+
+func sanitizeRequestMessages(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+) {
+	if req == nil {
+		return
+	}
+	before := req.Messages
+	result := toolcall.SanitizeMessagesWithToolsResult(
+		ctx,
+		before,
+		req.Tools,
+	)
+	req.Messages = result.Messages
+	summaryview.RebaseAfterTransform(
+		invocation,
+		before,
+		result.Messages,
+		result.SourceIndexes,
+	)
 }
 
 func normalizeContextCompactionThresholdRatio(ratio float64) float64 {
@@ -1826,11 +1849,7 @@ func (f *Flow) rebuildRequestForContextCompaction(
 			rebuilt,
 		)
 	}
-	rebuilt.Messages = toolcall.SanitizeMessagesWithTools(
-		ctx,
-		rebuilt.Messages,
-		rebuilt.Tools,
-	)
+	sanitizeRequestMessages(ctx, invocation, rebuilt)
 	return rebuilt
 }
 
@@ -2473,7 +2492,26 @@ func (f *Flow) callLLM(
 			finalizationMessage,
 		),
 	)
+	ctx, tailoringObserver := imodelrequest.ObserveTokenTailoring(
+		ctx,
+		func(record imodelrequest.TokenTailoringRecord) {
+			summaryview.InvalidateBinding(invocation)
+			summaryfork.Invalidate(invocation)
+			log.DebugfContext(
+				ctx,
+				"Model request token tailoring applied: provider=%s, "+
+					"max_input_tokens=%d, messages=%d->%d",
+				record.Provider,
+				record.MaxInputTokens,
+				record.BeforeMessages,
+				record.AfterMessages,
+			)
+		},
+	)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
+	if started {
+		span.SetAttributes(tokenTailoringAttrs(tailoringObserver.Snapshot())...)
+	}
 	if err != nil {
 		return ctx, nil, true, err
 	}

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -2429,13 +2430,19 @@ func (f *Flow) callLLM(
 		latencyRequestAttrs(llmRequest)...,
 	)
 	var err error
-	defer func() {
+	finishSpanOnReturn := true
+	finishCallSpan := func(finishErr error) {
 		if started && callModel != nil {
 			span.SetAttributes(
 				attribute.String("llmflow.model", callModel.Info().Name),
 			)
 		}
-		finishLatencySpan(span, started, err)
+		finishLatencySpan(span, started, finishErr)
+	}
+	defer func() {
+		if finishSpanOnReturn {
+			finishCallSpan(err)
+		}
 	}()
 	if callModel == nil {
 		err = errors.New("no model available for LLM call")
@@ -2523,13 +2530,30 @@ func (f *Flow) callLLM(
 		},
 	)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
-	if started {
-		span.SetAttributes(tokenTailoringAttrs(tailoringObserver.Snapshot())...)
-	}
 	if err != nil {
 		return ctx, nil, true, err
 	}
+	if started {
+		finishSpanOnReturn = false
+		seq = withResponseSeqFinalizer(seq, func() {
+			span.SetAttributes(
+				tokenTailoringAttrs(tailoringObserver.Snapshot())...,
+			)
+			finishCallSpan(nil)
+		})
+	}
 	return ctx, seq, true, nil
+}
+
+func withResponseSeqFinalizer(
+	seq model.Seq[*model.Response],
+	finalize func(),
+) model.Seq[*model.Response] {
+	var once sync.Once
+	return func(yield func(*model.Response) bool) {
+		defer once.Do(finalize)
+		seq(yield)
+	}
 }
 
 type callLimitFinalizationMessage struct {

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -2114,8 +2114,11 @@ func syncCompactContextDecision(
 		return decision
 	}
 
-	decision.threshold = contextCompactionThreshold(inv, ratio)
 	decision.contextWindow = contextCompactionWindow(inv)
+	decision.threshold, decision.thresholdBasis = contextCompactionThresholdForWindow(
+		decision.contextWindow,
+		ratio,
+	)
 	if counter == nil {
 		counter = model.NewSimpleTokenCounter()
 	}
@@ -2152,14 +2155,25 @@ func contextCompactionWindow(inv *agent.Invocation) int {
 
 func contextCompactionThreshold(inv *agent.Invocation, ratio float64) int {
 	contextWindow := contextCompactionWindow(inv)
+	threshold, _ := contextCompactionThresholdForWindow(contextWindow, ratio)
+	return threshold
+}
+
+func contextCompactionThresholdForWindow(
+	contextWindow int,
+	ratio float64,
+) (int, string) {
 	threshold := int(float64(contextWindow) * normalizeContextCompactionThresholdRatio(ratio))
+	basis := contextCompactionThresholdBasisContextWindow
 	if threshold < contextCompactionMinTokens {
 		threshold = contextCompactionMinTokens
+		basis = contextCompactionThresholdBasisMinimumTokens
 	}
 	if threshold > contextWindow {
 		threshold = contextWindow
+		basis = contextCompactionThresholdBasisContextWindow
 	}
-	return threshold
+	return threshold, basis
 }
 
 // getFilteredTools returns the list of tools for this invocation after applying the filter.

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -316,10 +316,11 @@ func TestEmitLatencyDiagnosticEventAndContextAttrs(t *testing.T) {
 	}
 	attrs := contextCompactionAttrs(
 		contextCompactionDecision{
-			shouldCompact: true,
-			tokenCount:    10,
-			threshold:     8,
-			contextWindow: 16,
+			shouldCompact:  true,
+			tokenCount:     10,
+			threshold:      8,
+			contextWindow:  16,
+			thresholdBasis: contextCompactionThresholdBasisContextWindow,
 		},
 		req,
 	)
@@ -359,6 +360,29 @@ func TestEmitLatencyDiagnosticEventAndContextAttrs(t *testing.T) {
 		tailoringAttrs,
 		"llmflow.token_tailoring.after_messages",
 		4,
+	))
+	emptyTailoringAttrs := tokenTailoringAttrs(nil)
+	require.Len(t, emptyTailoringAttrs, 2)
+	require.True(t, flowHasAttr(
+		emptyTailoringAttrs,
+		"llmflow.token_tailoring.applied",
+		false,
+	))
+	require.True(t, flowHasAttr(
+		emptyTailoringAttrs,
+		"llmflow.token_tailoring.apply_count",
+		0,
+	))
+	minimumAttrs := contextCompactionAttrs(
+		contextCompactionDecision{
+			thresholdBasis: contextCompactionThresholdBasisMinimumTokens,
+		},
+		req,
+	)
+	require.True(t, flowHasAttr(
+		minimumAttrs,
+		"llmflow.context_compaction.threshold_basis",
+		"minimum_tokens",
 	))
 }
 

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -34,6 +34,7 @@ import (
 	imodelrequest "trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/internal/tracecapture"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -338,6 +339,27 @@ func TestEmitLatencyDiagnosticEventAndContextAttrs(t *testing.T) {
 		t,
 		flowHasAttr(attrs, "llmflow.context_compaction.context_window", 16),
 	)
+	require.True(t, flowHasAttr(
+		attrs,
+		"llmflow.context_compaction.threshold_basis",
+		"context_window",
+	))
+	tailoringAttrs := tokenTailoringAttrs([]imodelrequest.TokenTailoringRecord{{
+		Provider:       "test.Model",
+		MaxInputTokens: 100,
+		BeforeMessages: 10,
+		AfterMessages:  4,
+	}})
+	require.True(t, flowHasAttr(
+		tailoringAttrs,
+		"llmflow.token_tailoring.applied",
+		true,
+	))
+	require.True(t, flowHasAttr(
+		tailoringAttrs,
+		"llmflow.token_tailoring.after_messages",
+		4,
+	))
 }
 
 func TestPreprocess_AddsAgentToolsWhenPresent(t *testing.T) {
@@ -1005,6 +1027,39 @@ func TestRunOneStep_AttachesCacheSafeSummaryForkRequest(t *testing.T) {
 		},
 		parent.Messages,
 	)
+}
+
+func TestCallLLM_TokenTailoringInvalidatesSummarySnapshots(t *testing.T) {
+	callModel := &tailoringModel{}
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(agent.WithInvocationModel(callModel))
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("history"),
+	}}
+	summaryview.AttachProjection(inv, &summaryview.View{
+		ContentRequestLength: len(req.Messages),
+		Items: []summaryview.Item{{
+			Message:      req.Messages[1],
+			RequestIndex: 1,
+		}},
+	})
+
+	_, seq, modelCalled, err := f.callLLM(
+		context.Background(),
+		inv,
+		req,
+		callModel,
+	)
+
+	require.NoError(t, err)
+	require.True(t, modelCalled)
+	require.NotNil(t, seq)
+	view, ok := summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	_, ok = summaryfork.Request(inv)
+	require.False(t, ok)
 }
 
 func TestRunOneStep_LeavesExecutionTraceFinalizationToOwnerWhenModelFails(t *testing.T) {
@@ -2336,6 +2391,38 @@ type mockModel struct {
 	currentIdx  int
 	mu          sync.Mutex
 	requests    []*model.Request
+}
+
+type tailoringModel struct{}
+
+func (m *tailoringModel) Info() model.Info {
+	return model.Info{Name: "tailoring-model"}
+}
+
+func (m *tailoringModel) GenerateContent(
+	ctx context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	beforeMessages := len(req.Messages)
+	req.Messages = req.Messages[:1]
+	imodelrequest.RecordTokenTailoring(
+		ctx,
+		imodelrequest.TokenTailoringRecord{
+			Provider:       "tailoringModel",
+			MaxInputTokens: 100,
+			BeforeMessages: beforeMessages,
+			AfterMessages:  len(req.Messages),
+		},
+	)
+	respChan := make(chan *model.Response, 1)
+	respChan <- &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("ok"),
+		}},
+	}
+	close(respChan)
+	return respChan, nil
 }
 
 type namedFlowModel struct {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -1086,6 +1086,80 @@ func TestCallLLM_TokenTailoringInvalidatesSummarySnapshots(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestCallLLM_LazyTokenTailoringFinalizesDiagnosticsAfterIteration(
+	t *testing.T,
+) {
+	recorder := useSpanRecorder(t)
+	callModel := &lazyTailoringModel{}
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(
+		agent.WithInvocationModel(callModel),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			LatencyDiagnosticsEnabled: true,
+		}),
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("history"),
+	}}
+	summaryview.AttachProjection(inv, &summaryview.View{
+		ContentRequestLength: len(req.Messages),
+		Items: []summaryview.Item{{
+			Message:      req.Messages[1],
+			RequestIndex: 1,
+		}},
+	})
+
+	_, seq, modelCalled, err := f.callLLM(
+		context.Background(),
+		inv,
+		req,
+		callModel,
+	)
+	require.NoError(t, err)
+	require.True(t, modelCalled)
+	require.NotNil(t, seq)
+	for _, ended := range recorder.Ended() {
+		require.NotEqual(t, latencySpanCallLLM, ended.Name())
+	}
+	view, ok := summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	_, ok = summaryfork.Request(inv)
+	require.True(t, ok)
+
+	var responses int
+	seq(func(*model.Response) bool {
+		responses++
+		return true
+	})
+	require.Equal(t, 1, responses)
+	view, ok = summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	_, ok = summaryfork.Request(inv)
+	require.False(t, ok)
+
+	var callAttrs []attribute.KeyValue
+	for _, ended := range recorder.Ended() {
+		if ended.Name() == latencySpanCallLLM {
+			callAttrs = ended.Attributes()
+			break
+		}
+	}
+	require.NotNil(t, callAttrs)
+	require.True(t, flowHasAttr(
+		callAttrs,
+		"llmflow.token_tailoring.applied",
+		true,
+	))
+	require.True(t, flowHasAttr(
+		callAttrs,
+		"llmflow.token_tailoring.apply_count",
+		1,
+	))
+}
+
 func TestRunOneStep_LeavesExecutionTraceFinalizationToOwnerWhenModelFails(t *testing.T) {
 	f := New(
 		[]flow.RequestProcessor{
@@ -2447,6 +2521,44 @@ func (m *tailoringModel) GenerateContent(
 	}
 	close(respChan)
 	return respChan, nil
+}
+
+type lazyTailoringModel struct{}
+
+func (m *lazyTailoringModel) Info() model.Info {
+	return model.Info{Name: "lazy-tailoring-model"}
+}
+
+func (m *lazyTailoringModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	return nil, errors.New("unexpected GenerateContent call")
+}
+
+func (m *lazyTailoringModel) GenerateContentIter(
+	ctx context.Context,
+	req *model.Request,
+) (model.Seq[*model.Response], error) {
+	return func(yield func(*model.Response) bool) {
+		beforeMessages := len(req.Messages)
+		req.Messages = req.Messages[:1]
+		imodelrequest.RecordTokenTailoring(
+			ctx,
+			imodelrequest.TokenTailoringRecord{
+				Provider:       "lazyTailoringModel",
+				MaxInputTokens: 100,
+				BeforeMessages: beforeMessages,
+				AfterMessages:  len(req.Messages),
+			},
+		)
+		yield(&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("ok"),
+			}},
+		})
+	}, nil
 }
 
 type namedFlowModel struct {

--- a/internal/modelrequest/token_tailoring.go
+++ b/internal/modelrequest/token_tailoring.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package modelrequest
+
+import (
+	"context"
+	"sync"
+)
+
+type tokenTailoringObserverKey struct{}
+
+// TokenTailoringRecord describes one provider-side request transformation.
+type TokenTailoringRecord struct {
+	Provider       string
+	MaxInputTokens int
+	BeforeMessages int
+	AfterMessages  int
+}
+
+// TokenTailoringObserver collects provider-side request transformations.
+type TokenTailoringObserver struct {
+	mu       sync.Mutex
+	records  []TokenTailoringRecord
+	onRecord func(TokenTailoringRecord)
+}
+
+// ObserveTokenTailoring attaches a new observer to ctx. onRecord is called
+// after each record has been stored and may be nil.
+func ObserveTokenTailoring(
+	ctx context.Context,
+	onRecord func(TokenTailoringRecord),
+) (context.Context, *TokenTailoringObserver) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	observer := &TokenTailoringObserver{onRecord: onRecord}
+	return context.WithValue(ctx, tokenTailoringObserverKey{}, observer), observer
+}
+
+// RecordTokenTailoring records a provider-side request transformation when an
+// observer is attached to ctx.
+func RecordTokenTailoring(ctx context.Context, record TokenTailoringRecord) {
+	if ctx == nil {
+		return
+	}
+	observer, ok := ctx.Value(tokenTailoringObserverKey{}).(*TokenTailoringObserver)
+	if !ok || observer == nil {
+		return
+	}
+	observer.mu.Lock()
+	observer.records = append(observer.records, record)
+	onRecord := observer.onRecord
+	observer.mu.Unlock()
+	if onRecord != nil {
+		onRecord(record)
+	}
+}
+
+// Snapshot returns an isolated copy of the records collected so far.
+func (o *TokenTailoringObserver) Snapshot() []TokenTailoringRecord {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]TokenTailoringRecord(nil), o.records...)
+}

--- a/internal/modelrequest/token_tailoring_test.go
+++ b/internal/modelrequest/token_tailoring_test.go
@@ -1,0 +1,49 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package modelrequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenTailoringObserver(t *testing.T) {
+	var callbacks []TokenTailoringRecord
+	ctx, observer := ObserveTokenTailoring(
+		context.Background(),
+		func(record TokenTailoringRecord) {
+			callbacks = append(callbacks, record)
+		},
+	)
+	record := TokenTailoringRecord{
+		Provider:       "test.Model",
+		MaxInputTokens: 100,
+		BeforeMessages: 3,
+		AfterMessages:  2,
+	}
+
+	RecordTokenTailoring(ctx, record)
+
+	require.Equal(t, []TokenTailoringRecord{record}, observer.Snapshot())
+	require.Equal(t, []TokenTailoringRecord{record}, callbacks)
+	copyOfSnapshot := observer.Snapshot()
+	copyOfSnapshot[0].Provider = "mutated"
+	require.Equal(t, "test.Model", observer.Snapshot()[0].Provider)
+}
+
+func TestTokenTailoringObserverHandlesMissingObserver(t *testing.T) {
+	RecordTokenTailoring(nil, TokenTailoringRecord{})
+	RecordTokenTailoring(context.Background(), TokenTailoringRecord{})
+	ctx, observer := ObserveTokenTailoring(nil, nil)
+	RecordTokenTailoring(ctx, TokenTailoringRecord{Provider: "test.Model"})
+	require.Len(t, observer.Snapshot(), 1)
+	require.Nil(t, (*TokenTailoringObserver)(nil).Snapshot())
+}

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -31,10 +31,12 @@ type contextKey struct{}
 // generic state cloner. Mutations must replace the holder instead of changing
 // the stored view in place.
 type invocationState struct {
-	view *View
+	view               *View
+	bindingInvalidated bool
 }
 
-// Boundary identifies the latest stored event represented by an item.
+// Boundary identifies the latest stored event completely represented by the
+// model request prefix ending at an item.
 type Boundary struct {
 	EventID   string
 	Timestamp time.Time
@@ -99,8 +101,164 @@ func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 	view := state.view
 	next := cloneView(view)
 	next.RequestTokens = requestTokens
-	next.Bound = bindItems(next, req.Messages)
+	next.Bound = !state.bindingInvalidated && bindItems(next, req.Messages)
+	inv.SetState(stateKey, &invocationState{
+		view:               next,
+		bindingInvalidated: state.bindingInvalidated,
+	})
+}
+
+// RebaseAfterTransform maps a projected view through a message transform.
+// sourceIndexes must contain one input-message index for every output message.
+// The view remains unbound when the provenance does not completely represent
+// every projected history item.
+func RebaseAfterTransform(
+	inv *agent.Invocation,
+	before []model.Message,
+	after []model.Message,
+	sourceIndexes []int,
+) bool {
+	if inv == nil {
+		return false
+	}
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
+		return false
+	}
+	next := cloneView(state.view)
+	next.ContentRequestLength = len(after)
+	next.Bound = false
+	if len(after) != len(sourceIndexes) || !bindItems(next, before) {
+		storeInvalidated(inv, next)
+		return false
+	}
+	transformed, ok := rebaseItems(next.Items, after, sourceIndexes, len(before))
+	if !ok {
+		storeInvalidated(inv, next)
+		return false
+	}
+	next.Items = transformed
+	next.Bound = true
 	inv.SetState(stateKey, &invocationState{view: next})
+	return true
+}
+
+func rebaseItems(
+	items []Item,
+	after []model.Message,
+	sourceIndexes []int,
+	beforeLength int,
+) ([]Item, bool) {
+	itemBySource, ok := indexItemsBySource(items)
+	if !ok {
+		return nil, false
+	}
+	remaining, ok := countOutputsByItem(
+		sourceIndexes,
+		beforeLength,
+		itemBySource,
+		len(items),
+	)
+	if !ok {
+		return nil, false
+	}
+
+	transformed := make([]Item, 0, len(after))
+	completed := make([]bool, len(items))
+	frontier := 0
+	for outputIndex, sourceIndex := range sourceIndexes {
+		itemIndex, exists := itemBySource[sourceIndex]
+		if !exists {
+			continue
+		}
+		item := items[itemIndex]
+		item.Message = statecopy.Message(after[outputIndex])
+		item.EffectiveEvent = cloneEvent(item.EffectiveEvent)
+		setEffectiveMessage(&item.EffectiveEvent, item.Message)
+		item.RequestIndex = outputIndex
+		item.Boundary = Boundary{}
+		transformed = append(transformed, item)
+
+		remaining[itemIndex]--
+		completed[itemIndex] = remaining[itemIndex] == 0
+		safeBoundary := advanceCompletedFrontier(items, completed, &frontier)
+		if !safeBoundary.IsZero() {
+			transformed[len(transformed)-1].Boundary = safeBoundary
+		}
+	}
+	return transformed, frontier == len(items) && len(transformed) > 0
+}
+
+func indexItemsBySource(items []Item) (map[int]int, bool) {
+	itemBySource := make(map[int]int, len(items))
+	for i := range items {
+		requestIndex := items[i].RequestIndex
+		if _, exists := itemBySource[requestIndex]; exists {
+			return nil, false
+		}
+		itemBySource[requestIndex] = i
+	}
+	return itemBySource, true
+}
+
+func countOutputsByItem(
+	sourceIndexes []int,
+	beforeLength int,
+	itemBySource map[int]int,
+	itemCount int,
+) ([]int, bool) {
+	remaining := make([]int, itemCount)
+	for _, sourceIndex := range sourceIndexes {
+		if sourceIndex < 0 || sourceIndex >= beforeLength {
+			return nil, false
+		}
+		if itemIndex, exists := itemBySource[sourceIndex]; exists {
+			remaining[itemIndex]++
+		}
+	}
+	for _, count := range remaining {
+		if count == 0 {
+			return nil, false
+		}
+	}
+	return remaining, true
+}
+
+func advanceCompletedFrontier(
+	items []Item,
+	completed []bool,
+	frontier *int,
+) Boundary {
+	var safeBoundary Boundary
+	for *frontier < len(items) && completed[*frontier] {
+		if !items[*frontier].Boundary.IsZero() {
+			safeBoundary = items[*frontier].Boundary
+		}
+		*frontier++
+	}
+	return safeBoundary
+}
+
+// InvalidateBinding prevents the current projected view from being used as
+// proof of model-visible history.
+func InvalidateBinding(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
+		return
+	}
+	next := cloneView(state.view)
+	next.Bound = false
+	storeInvalidated(inv, next)
+}
+
+func storeInvalidated(inv *agent.Invocation, view *View) {
+	inv.SetState(stateKey, &invocationState{
+		view:               view,
+		bindingInvalidated: true,
+	})
 }
 
 // Snapshot returns an isolated copy of the latest model-visible view.

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -109,7 +109,8 @@ func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 }
 
 // RebaseAfterTransform maps a projected view through a message transform.
-// sourceIndexes must contain one input-message index for every output message.
+// When non-nil, sourceIndexes must contain one input-message index for every
+// output message. A nil slice means output message i came from input message i.
 // The view remains unbound when the provenance does not completely represent
 // every projected history item.
 func RebaseAfterTransform(
@@ -125,24 +126,63 @@ func RebaseAfterTransform(
 	if !ok || state == nil || state.view == nil {
 		return false
 	}
-	next := cloneView(state.view)
-	next.Bound = false
-	provenanceMatches := len(after) == len(sourceIndexes)
-	boundBefore := provenanceMatches && bindItems(next, before)
-	next.ContentRequestLength = len(after)
+	boundItems, boundBefore := bindItemsForTransform(state.view, before)
+	boundBefore = boundBefore && sourceIndexesMatch(
+		sourceIndexes,
+		len(after),
+		len(before),
+	)
 	if !boundBefore {
+		next := cloneView(state.view)
+		next.Bound = false
+		next.ContentRequestLength = len(after)
 		storeInvalidated(inv, next)
 		return false
 	}
-	transformed, ok := rebaseItems(next.Items, after, sourceIndexes, len(before))
+	transformed, ok := rebaseItems(
+		boundItems,
+		after,
+		sourceIndexes,
+		len(before),
+	)
 	if !ok {
+		next := cloneView(state.view)
+		next.Bound = false
+		next.ContentRequestLength = len(after)
 		storeInvalidated(inv, next)
 		return false
 	}
+	next := *state.view
 	next.Items = transformed
+	next.ContentRequestLength = len(after)
 	next.Bound = true
-	inv.SetState(stateKey, &invocationState{view: next})
+	inv.SetState(stateKey, &invocationState{view: &next})
 	return true
+}
+
+func bindItemsForTransform(view *View, messages []model.Message) ([]Item, bool) {
+	if view == nil || len(view.Items) == 0 || len(messages) == 0 {
+		return nil, false
+	}
+	items := make([]Item, len(view.Items))
+	shift := len(messages) - view.ContentRequestLength
+	previous := -1
+	for i := range view.Items {
+		index := findItem(
+			messages,
+			view.Items[i].Message,
+			view.Items[i].RequestIndex,
+			shift,
+			previous+1,
+		)
+		if index < 0 {
+			return nil, false
+		}
+		items[i] = view.Items[i]
+		items[i].RequestIndex = index
+		previous = index
+	}
+	return items, true
 }
 
 func rebaseItems(
@@ -157,6 +197,7 @@ func rebaseItems(
 	}
 	remaining, ok := countOutputsByItem(
 		sourceIndexes,
+		len(after),
 		beforeLength,
 		itemBySource,
 		len(items),
@@ -168,7 +209,8 @@ func rebaseItems(
 	transformed := make([]Item, 0, len(after))
 	completed := make([]bool, len(items))
 	frontier := 0
-	for outputIndex, sourceIndex := range sourceIndexes {
+	for outputIndex := range after {
+		sourceIndex := sourceIndexForOutput(sourceIndexes, outputIndex)
 		itemIndex, exists := itemBySource[sourceIndex]
 		if !exists {
 			continue
@@ -205,12 +247,17 @@ func indexItemsBySource(items []Item) (map[int]int, bool) {
 
 func countOutputsByItem(
 	sourceIndexes []int,
+	outputCount int,
 	beforeLength int,
 	itemBySource map[int]int,
 	itemCount int,
 ) ([]int, bool) {
+	if !sourceIndexesMatch(sourceIndexes, outputCount, beforeLength) {
+		return nil, false
+	}
 	remaining := make([]int, itemCount)
-	for _, sourceIndex := range sourceIndexes {
+	for outputIndex := 0; outputIndex < outputCount; outputIndex++ {
+		sourceIndex := sourceIndexForOutput(sourceIndexes, outputIndex)
 		if sourceIndex < 0 || sourceIndex >= beforeLength {
 			return nil, false
 		}
@@ -224,6 +271,24 @@ func countOutputsByItem(
 		}
 	}
 	return remaining, true
+}
+
+func sourceIndexesMatch(
+	sourceIndexes []int,
+	outputCount int,
+	inputCount int,
+) bool {
+	if len(sourceIndexes) == 0 {
+		return outputCount == inputCount
+	}
+	return len(sourceIndexes) == outputCount
+}
+
+func sourceIndexForOutput(sourceIndexes []int, outputIndex int) int {
+	if len(sourceIndexes) == 0 {
+		return outputIndex
+	}
+	return sourceIndexes[outputIndex]
 }
 
 func advanceCompletedFrontier(

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -126,6 +126,9 @@ func RebaseAfterTransform(
 	if !ok || state == nil || state.view == nil {
 		return false
 	}
+	if state.bindingInvalidated {
+		return false
+	}
 	boundItems, boundBefore := bindItemsForTransform(state.view, before)
 	boundBefore = boundBefore && sourceIndexesMatch(
 		sourceIndexes,
@@ -278,14 +281,14 @@ func sourceIndexesMatch(
 	outputCount int,
 	inputCount int,
 ) bool {
-	if len(sourceIndexes) == 0 {
+	if sourceIndexes == nil {
 		return outputCount == inputCount
 	}
 	return len(sourceIndexes) == outputCount
 }
 
 func sourceIndexForOutput(sourceIndexes []int, outputIndex int) int {
-	if len(sourceIndexes) == 0 {
+	if sourceIndexes == nil {
 		return outputIndex
 	}
 	return sourceIndexes[outputIndex]

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -126,9 +126,11 @@ func RebaseAfterTransform(
 		return false
 	}
 	next := cloneView(state.view)
-	next.ContentRequestLength = len(after)
 	next.Bound = false
-	if len(after) != len(sourceIndexes) || !bindItems(next, before) {
+	provenanceMatches := len(after) == len(sourceIndexes)
+	boundBefore := provenanceMatches && bindItems(next, before)
+	next.ContentRequestLength = len(after)
+	if !boundBefore {
 		storeInvalidated(inv, next)
 		return false
 	}

--- a/internal/state/summaryview/summaryview_bench_test.go
+++ b/internal/state/summaryview/summaryview_bench_test.go
@@ -21,6 +21,11 @@ import (
 
 var summaryViewBenchmarkSink *View
 
+var (
+	summaryViewItemsBenchmarkSink []Item
+	summaryViewBoolBenchmarkSink  bool
+)
+
 func BenchmarkSnapshot(b *testing.B) {
 	for _, historySize := range []int{16, 256, 1024} {
 		b.Run(fmt.Sprintf("history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {
@@ -49,6 +54,66 @@ func BenchmarkFinalize(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkRebaseAfterTransform(b *testing.B) {
+	for _, historySize := range []int{16, 256, 1024} {
+		b.Run(fmt.Sprintf("identity/history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {
+			invocation, request := summaryViewBenchmarkInput(historySize, 1024)
+			sourceIndexes := make([]int, len(request.Messages))
+			for i := range sourceIndexes {
+				sourceIndexes[i] = i
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				summaryViewBoolBenchmarkSink = RebaseAfterTransform(
+					invocation,
+					request.Messages,
+					request.Messages,
+					sourceIndexes,
+				)
+			}
+		})
+	}
+}
+
+func BenchmarkRebaseItems(b *testing.B) {
+	for _, historySize := range []int{16, 256, 1024} {
+		b.Run(fmt.Sprintf("split/history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {
+			invocation, request := summaryViewBenchmarkInput(historySize, 1024)
+			view, ok := Snapshot(invocation)
+			if !ok {
+				b.Fatal("summary view is missing")
+			}
+			after, sourceIndexes := summaryViewSplitBenchmarkMessages(request.Messages)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				summaryViewItemsBenchmarkSink, summaryViewBoolBenchmarkSink = rebaseItems(
+					view.Items,
+					after,
+					sourceIndexes,
+					len(request.Messages),
+				)
+			}
+		})
+	}
+}
+
+func summaryViewSplitBenchmarkMessages(messages []model.Message) ([]model.Message, []int) {
+	after := make([]model.Message, 0, len(messages)*2-1)
+	sourceIndexes := make([]int, 0, len(messages)*2-1)
+	for i := range messages {
+		after = append(after, messages[i])
+		sourceIndexes = append(sourceIndexes, i)
+		if i == 0 {
+			continue
+		}
+		after = append(after, messages[i])
+		sourceIndexes = append(sourceIndexes, i)
+	}
+	return after, sourceIndexes
 }
 
 func summaryViewBenchmarkInput(

--- a/internal/state/summaryview/summaryview_bench_test.go
+++ b/internal/state/summaryview/summaryview_bench_test.go
@@ -58,12 +58,8 @@ func BenchmarkFinalize(b *testing.B) {
 
 func BenchmarkRebaseAfterTransform(b *testing.B) {
 	for _, historySize := range []int{16, 256, 1024} {
-		b.Run(fmt.Sprintf("identity/history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {
+		b.Run(fmt.Sprintf("implicit_identity/history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {
 			invocation, request := summaryViewBenchmarkInput(historySize, 1024)
-			sourceIndexes := make([]int, len(request.Messages))
-			for i := range sourceIndexes {
-				sourceIndexes[i] = i
-			}
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -71,7 +67,7 @@ func BenchmarkRebaseAfterTransform(b *testing.B) {
 					invocation,
 					request.Messages,
 					request.Messages,
-					sourceIndexes,
+					nil,
 				)
 			}
 		})

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -188,6 +188,57 @@ func TestRebaseAfterTransformAcceptsImplicitIdentitySources(t *testing.T) {
 	require.Equal(t, 1, view.Items[0].RequestIndex)
 }
 
+func TestRebaseAfterTransformRejectsInvalidatedBinding(t *testing.T) {
+	message := model.NewUserMessage("history")
+	messages := []model.Message{message}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(messages),
+		Items: []Item{{
+			Message:      message,
+			RequestIndex: 0,
+		}},
+	})
+	InvalidateBinding(invocation)
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		messages,
+		messages,
+		nil,
+	)
+
+	require.False(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+}
+
+func TestRebaseAfterTransformRejectsEmptyExplicitSources(t *testing.T) {
+	message := model.NewUserMessage("history")
+	messages := []model.Message{message}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(messages),
+		Items: []Item{{
+			Message:      message,
+			RequestIndex: 0,
+		}},
+	})
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		messages,
+		messages,
+		[]int{},
+	)
+
+	require.False(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+}
+
 func TestRebaseAfterTransformUsesOriginalProjectionLength(t *testing.T) {
 	duplicate := model.NewUserMessage("duplicate")
 	current := model.NewUserMessage("current")

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -159,6 +159,45 @@ func TestRebaseAfterTransformTracksSafeCompletedPrefix(t *testing.T) {
 	require.Equal(t, 100, view.RequestTokens)
 }
 
+func TestRebaseAfterTransformUsesOriginalProjectionLength(t *testing.T) {
+	duplicate := model.NewUserMessage("duplicate")
+	current := model.NewUserMessage("current")
+	before := []model.Message{duplicate, duplicate, current}
+	after := []model.Message{
+		before[0],
+		model.NewUserMessage("split one"),
+		model.NewUserMessage("split two"),
+		current,
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: 2,
+		Items: []Item{{
+			Message: duplicate,
+			Boundary: Boundary{
+				EventID:   "event-1",
+				Timestamp: time.Now(),
+			},
+			RequestIndex: 0,
+		}},
+	})
+
+	require.True(t, RebaseAfterTransform(
+		invocation,
+		before,
+		after,
+		[]int{0, 1, 1, 2},
+	))
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Len(t, view.Items, 2)
+	require.Equal(t, 1, view.Items[0].RequestIndex)
+	require.Equal(t, 2, view.Items[1].RequestIndex)
+	require.True(t, view.Items[0].Boundary.IsZero())
+	require.Equal(t, "event-1", view.Items[1].Boundary.EventID)
+}
+
 func TestRebaseAfterTransformFailsClosedWithoutCompleteProvenance(t *testing.T) {
 	invocation := agent.NewInvocation()
 	before := []model.Message{model.NewUserMessage("visible")}

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -65,6 +65,124 @@ func TestFinalizeBindsModelVisiblePrefix(t *testing.T) {
 
 }
 
+func TestRebaseAfterTransformTracksSafeCompletedPrefix(t *testing.T) {
+	now := time.Now()
+	assistant := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{ID: "call_keep"},
+			{ID: "call_orphan"},
+		},
+	}
+	toolResult := model.NewToolMessage("call_keep", "lookup", "ok")
+	before := []model.Message{
+		model.NewSystemMessage("fixed"),
+		assistant,
+		toolResult,
+	}
+	filteredAssistant := assistant
+	filteredAssistant.ToolCalls = filteredAssistant.ToolCalls[:1]
+	after := []model.Message{
+		before[0],
+		filteredAssistant,
+		toolResult,
+		model.NewUserMessage("downgraded orphan call"),
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(before),
+		Items: []Item{
+			{
+				Message: assistant,
+				EffectiveEvent: event.Event{
+					ID: "event-1",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: assistant,
+					}}},
+				},
+				Boundary:     Boundary{EventID: "event-1", Timestamp: now},
+				RequestIndex: 1,
+			},
+			{
+				Message: toolResult,
+				EffectiveEvent: event.Event{
+					ID: "event-2",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: toolResult,
+					}}},
+				},
+				Boundary: Boundary{
+					EventID:   "event-2",
+					Timestamp: now.Add(time.Second),
+				},
+				RequestIndex: 2,
+			},
+		},
+	})
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		before,
+		after,
+		[]int{0, 1, 2, 1},
+	)
+
+	require.True(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, len(after), view.ContentRequestLength)
+	require.Len(t, view.Items, 3)
+	require.Equal(t, []int{1, 2, 3}, []int{
+		view.Items[0].RequestIndex,
+		view.Items[1].RequestIndex,
+		view.Items[2].RequestIndex,
+	})
+	require.True(t, view.Items[0].Boundary.IsZero())
+	require.True(t, view.Items[1].Boundary.IsZero())
+	require.Equal(t, "event-2", view.Items[2].Boundary.EventID)
+	require.Equal(
+		t,
+		"downgraded orphan call",
+		view.Items[2].EffectiveEvent.Response.Choices[0].Message.Content,
+	)
+	_, ok = view.PrefixBoundary(2)
+	require.False(t, ok)
+	boundary, ok := view.PrefixBoundary(3)
+	require.True(t, ok)
+	require.Equal(t, "event-2", boundary.EventID)
+
+	Finalize(invocation, &model.Request{Messages: after}, 100)
+	view, ok = Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, 100, view.RequestTokens)
+}
+
+func TestRebaseAfterTransformFailsClosedWithoutCompleteProvenance(t *testing.T) {
+	invocation := agent.NewInvocation()
+	before := []model.Message{model.NewUserMessage("visible")}
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(before),
+		Items: []Item{{
+			Message:      before[0],
+			RequestIndex: 0,
+		}},
+	})
+
+	require.False(t, RebaseAfterTransform(
+		invocation,
+		before,
+		[]model.Message{model.NewUserMessage("rewritten")},
+		[]int{},
+	))
+	Finalize(invocation, &model.Request{Messages: before}, 100)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	require.Equal(t, 100, view.RequestTokens)
+}
+
 func TestSnapshotIsIsolated(t *testing.T) {
 	invocation := agent.NewInvocation()
 	AttachProjection(invocation, &View{

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -159,6 +159,35 @@ func TestRebaseAfterTransformTracksSafeCompletedPrefix(t *testing.T) {
 	require.Equal(t, 100, view.RequestTokens)
 }
 
+func TestRebaseAfterTransformAcceptsImplicitIdentitySources(t *testing.T) {
+	message := model.NewUserMessage("history")
+	messages := []model.Message{
+		model.NewSystemMessage("fixed"),
+		message,
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(messages),
+		Items: []Item{{
+			Message:      message,
+			RequestIndex: 1,
+		}},
+	})
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		messages,
+		messages,
+		nil,
+	)
+
+	require.True(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, 1, view.Items[0].RequestIndex)
+}
+
 func TestRebaseAfterTransformUsesOriginalProjectionLength(t *testing.T) {
 	duplicate := model.NewUserMessage("duplicate")
 	current := model.NewUserMessage("current")
@@ -212,8 +241,11 @@ func TestRebaseAfterTransformFailsClosedWithoutCompleteProvenance(t *testing.T) 
 	require.False(t, RebaseAfterTransform(
 		invocation,
 		before,
-		[]model.Message{model.NewUserMessage("rewritten")},
-		[]int{},
+		[]model.Message{
+			model.NewUserMessage("rewritten one"),
+			model.NewUserMessage("rewritten two"),
+		},
+		nil,
 	))
 	Finalize(invocation, &model.Request{Messages: before}, 100)
 	view, ok := Snapshot(invocation)

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -55,8 +55,9 @@ func SanitizeMessagesWithTools(ctx context.Context, messages []model.Message, to
 }
 
 // SanitizeResult contains sanitized messages and their input provenance.
-// SourceIndexes has one entry per message and identifies the corresponding
-// index in the input message slice.
+// When non-nil, SourceIndexes has one entry per message and identifies the
+// corresponding index in the input message slice. A nil slice represents an
+// identity mapping: output message i came from input message i.
 type SanitizeResult struct {
 	Messages      []model.Message
 	SourceIndexes []int
@@ -72,7 +73,14 @@ func SanitizeMessagesWithToolsResult(
 	if len(messages) == 0 {
 		return SanitizeResult{Messages: messages}
 	}
-	out := make([]indexedMessage, 0, len(messages))
+	if !containsToolMessages(messages) {
+		out := make([]model.Message, len(messages))
+		copy(out, messages)
+		return SanitizeResult{Messages: out}
+	}
+	builder := sanitizeResultBuilder{
+		messages: make([]model.Message, 0, len(messages)),
+	}
 	for i := 0; i < len(messages); {
 		msg := messages[i]
 		if msg.Role == model.RoleAssistant && len(msg.ToolCalls) > 0 {
@@ -80,47 +88,75 @@ func SanitizeMessagesWithToolsResult(
 			for next < len(messages) && messages[next].Role == model.RoleTool {
 				next++
 			}
-			toolResults := make([]indexedMessage, 0, next-i-1)
-			for resultIndex := i + 1; resultIndex < next; resultIndex++ {
-				toolResults = append(toolResults, indexedMessage{
-					message:     messages[resultIndex],
-					sourceIndex: resultIndex,
-				})
-			}
-			out = append(out, sanitizeToolRound(
+			builder.appendAll(sanitizeToolRound(
 				ctx,
 				indexedMessage{message: msg, sourceIndex: i},
-				toolResults,
+				messages[i+1:next],
+				i+1,
 				tools,
-			)...)
+			))
 			i = next
 			continue
 		}
 		if msg.Role == model.RoleTool {
-			out = append(out, indexedMessage{
+			builder.append(indexedMessage{
 				message:     downgradeOrphanToolResult(ctx, msg),
 				sourceIndex: i,
 			})
 			i++
 			continue
 		}
-		out = append(out, indexedMessage{message: msg, sourceIndex: i})
+		builder.append(indexedMessage{message: msg, sourceIndex: i})
 		i++
 	}
-	result := SanitizeResult{
-		Messages:      make([]model.Message, len(out)),
-		SourceIndexes: make([]int, len(out)),
+	return SanitizeResult{
+		Messages:      builder.messages,
+		SourceIndexes: builder.sourceIndexes,
 	}
-	for i := range out {
-		result.Messages[i] = out[i].message
-		result.SourceIndexes[i] = out[i].sourceIndex
+}
+
+func containsToolMessages(messages []model.Message) bool {
+	for i := range messages {
+		if messages[i].Role == model.RoleTool ||
+			(messages[i].Role == model.RoleAssistant &&
+				len(messages[i].ToolCalls) > 0) {
+			return true
+		}
 	}
-	return result
+	return false
 }
 
 type indexedMessage struct {
 	message     model.Message
 	sourceIndex int
+}
+
+type sanitizeResultBuilder struct {
+	messages      []model.Message
+	sourceIndexes []int
+}
+
+func (b *sanitizeResultBuilder) append(message indexedMessage) {
+	outputIndex := len(b.messages)
+	b.messages = append(b.messages, message.message)
+	if b.sourceIndexes != nil {
+		b.sourceIndexes = append(b.sourceIndexes, message.sourceIndex)
+		return
+	}
+	if message.sourceIndex == outputIndex {
+		return
+	}
+	b.sourceIndexes = make([]int, outputIndex, cap(b.messages))
+	for i := range b.sourceIndexes {
+		b.sourceIndexes[i] = i
+	}
+	b.sourceIndexes = append(b.sourceIndexes, message.sourceIndex)
+}
+
+func (b *sanitizeResultBuilder) appendAll(messages []indexedMessage) {
+	for _, message := range messages {
+		b.append(message)
+	}
 }
 
 type toolCallValidation struct {
@@ -150,11 +186,17 @@ type toolCallSplit struct {
 func sanitizeToolRound(
 	ctx context.Context,
 	assistant indexedMessage,
-	toolResults []indexedMessage,
+	toolResults []model.Message,
+	firstToolResultSourceIndex int,
 	tools map[string]tool.Tool,
 ) []indexedMessage {
 	validation := validateToolCalls(assistant.message.ToolCalls, tools)
-	split := splitToolResults(toolResults, validation.validIDs, validation.invalidIDs)
+	split := splitToolResults(
+		toolResults,
+		firstToolResultSourceIndex,
+		validation.validIDs,
+		validation.invalidIDs,
+	)
 	toolCallSplit := splitToolCalls(validation.validToolCalls, split.kept)
 	filteredAssistant := assistant.message
 	filteredAssistant.ToolCalls = toolCallSplit.kept
@@ -479,7 +521,8 @@ func validateNumberValueAgainstSchema(value any, path string) (bool, string) {
 
 // splitToolResults groups tool result messages by tool_call_id based on tool call validity.
 func splitToolResults(
-	toolResults []indexedMessage,
+	toolResults []model.Message,
+	firstSourceIndex int,
 	validIDs map[string]struct{},
 	invalidIDs map[string]struct{},
 ) toolResultSplit {
@@ -488,23 +531,27 @@ func splitToolResults(
 		invalidByID: make(map[string][]indexedMessage),
 	}
 	respondedValidIDs := make(map[string]struct{}, len(validIDs))
-	for _, tr := range toolResults {
-		if tr.message.ToolID == "" {
+	for i, message := range toolResults {
+		tr := indexedMessage{
+			message:     message,
+			sourceIndex: firstSourceIndex + i,
+		}
+		if message.ToolID == "" {
 			out.orphan = append(out.orphan, tr)
 			continue
 		}
-		if _, ok := validIDs[tr.message.ToolID]; ok {
-			if _, responded := respondedValidIDs[tr.message.ToolID]; responded {
+		if _, ok := validIDs[message.ToolID]; ok {
+			if _, responded := respondedValidIDs[message.ToolID]; responded {
 				out.orphan = append(out.orphan, tr)
 				continue
 			}
-			respondedValidIDs[tr.message.ToolID] = struct{}{}
+			respondedValidIDs[message.ToolID] = struct{}{}
 			out.kept = append(out.kept, tr)
 			continue
 		}
-		if _, ok := invalidIDs[tr.message.ToolID]; ok {
-			out.invalidByID[tr.message.ToolID] = append(
-				out.invalidByID[tr.message.ToolID],
+		if _, ok := invalidIDs[message.ToolID]; ok {
+			out.invalidByID[message.ToolID] = append(
+				out.invalidByID[message.ToolID],
 				tr,
 			)
 			continue

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -51,10 +51,28 @@ var (
 // kept tool call message, to avoid invalid tool message sequences in strict chat APIs.
 // The context is used to attach request-scoped metadata to downgrade warnings.
 func SanitizeMessagesWithTools(ctx context.Context, messages []model.Message, tools map[string]tool.Tool) []model.Message {
+	return SanitizeMessagesWithToolsResult(ctx, messages, tools).Messages
+}
+
+// SanitizeResult contains sanitized messages and their input provenance.
+// SourceIndexes has one entry per message and identifies the corresponding
+// index in the input message slice.
+type SanitizeResult struct {
+	Messages      []model.Message
+	SourceIndexes []int
+}
+
+// SanitizeMessagesWithToolsResult sanitizes messages and preserves the input
+// index from which every output message was derived.
+func SanitizeMessagesWithToolsResult(
+	ctx context.Context,
+	messages []model.Message,
+	tools map[string]tool.Tool,
+) SanitizeResult {
 	if len(messages) == 0 {
-		return messages
+		return SanitizeResult{Messages: messages}
 	}
-	out := make([]model.Message, 0, len(messages))
+	out := make([]indexedMessage, 0, len(messages))
 	for i := 0; i < len(messages); {
 		msg := messages[i]
 		if msg.Role == model.RoleAssistant && len(msg.ToolCalls) > 0 {
@@ -62,19 +80,47 @@ func SanitizeMessagesWithTools(ctx context.Context, messages []model.Message, to
 			for next < len(messages) && messages[next].Role == model.RoleTool {
 				next++
 			}
-			out = append(out, sanitizeToolRound(ctx, msg, messages[i+1:next], tools)...)
+			toolResults := make([]indexedMessage, 0, next-i-1)
+			for resultIndex := i + 1; resultIndex < next; resultIndex++ {
+				toolResults = append(toolResults, indexedMessage{
+					message:     messages[resultIndex],
+					sourceIndex: resultIndex,
+				})
+			}
+			out = append(out, sanitizeToolRound(
+				ctx,
+				indexedMessage{message: msg, sourceIndex: i},
+				toolResults,
+				tools,
+			)...)
 			i = next
 			continue
 		}
 		if msg.Role == model.RoleTool {
-			out = append(out, downgradeOrphanToolResult(ctx, msg))
+			out = append(out, indexedMessage{
+				message:     downgradeOrphanToolResult(ctx, msg),
+				sourceIndex: i,
+			})
 			i++
 			continue
 		}
-		out = append(out, msg)
+		out = append(out, indexedMessage{message: msg, sourceIndex: i})
 		i++
 	}
-	return out
+	result := SanitizeResult{
+		Messages:      make([]model.Message, len(out)),
+		SourceIndexes: make([]int, len(out)),
+	}
+	for i := range out {
+		result.Messages[i] = out[i].message
+		result.SourceIndexes[i] = out[i].sourceIndex
+	}
+	return result
+}
+
+type indexedMessage struct {
+	message     model.Message
+	sourceIndex int
 }
 
 type toolCallValidation struct {
@@ -90,9 +136,9 @@ type invalidToolCall struct {
 }
 
 type toolResultSplit struct {
-	kept        []model.Message
-	invalidByID map[string][]model.Message
-	orphan      []model.Message
+	kept        []indexedMessage
+	invalidByID map[string][]indexedMessage
+	orphan      []indexedMessage
 }
 
 type toolCallSplit struct {
@@ -101,49 +147,73 @@ type toolCallSplit struct {
 }
 
 // sanitizeToolRound sanitizes a single assistant tool-call round with its following tool results.
-func sanitizeToolRound(ctx context.Context, assistant model.Message, toolResults []model.Message, tools map[string]tool.Tool) []model.Message {
-	validation := validateToolCalls(assistant.ToolCalls, tools)
+func sanitizeToolRound(
+	ctx context.Context,
+	assistant indexedMessage,
+	toolResults []indexedMessage,
+	tools map[string]tool.Tool,
+) []indexedMessage {
+	validation := validateToolCalls(assistant.message.ToolCalls, tools)
 	split := splitToolResults(toolResults, validation.validIDs, validation.invalidIDs)
 	toolCallSplit := splitToolCalls(validation.validToolCalls, split.kept)
-	filteredAssistant := assistant
+	filteredAssistant := assistant.message
 	filteredAssistant.ToolCalls = toolCallSplit.kept
 	if len(filteredAssistant.ToolCalls) == 0 {
 		filteredAssistant.ToolCalls = nil
 	}
 	out := make(
-		[]model.Message,
+		[]indexedMessage,
 		0,
 		1+len(toolResults)+len(validation.invalidToolCalls)+len(toolCallSplit.orphan)+len(split.orphan),
 	)
 	if !message.IsEmptyAssistantMessage(filteredAssistant) {
-		out = append(out, filteredAssistant)
+		out = append(out, indexedMessage{
+			message:     filteredAssistant,
+			sourceIndex: assistant.sourceIndex,
+		})
 		out = append(out, split.kept...)
 	}
 	for _, orphanCall := range toolCallSplit.orphan {
-		out = append(out, downgradeOrphanToolCall(ctx, orphanCall))
+		out = append(out, indexedMessage{
+			message:     downgradeOrphanToolCall(ctx, orphanCall),
+			sourceIndex: assistant.sourceIndex,
+		})
 	}
 	for _, invalid := range validation.invalidToolCalls {
-		out = append(out, downgradeInvalidToolCall(ctx, invalid.call, invalid.reason))
+		out = append(out, indexedMessage{
+			message: downgradeInvalidToolCall(
+				ctx,
+				invalid.call,
+				invalid.reason,
+			),
+			sourceIndex: assistant.sourceIndex,
+		})
 		for _, tr := range split.invalidByID[invalid.call.ID] {
-			out = append(out, downgradeInvalidToolResult(ctx, tr))
+			out = append(out, indexedMessage{
+				message:     downgradeInvalidToolResult(ctx, tr.message),
+				sourceIndex: tr.sourceIndex,
+			})
 		}
 	}
 	for _, orphan := range split.orphan {
-		out = append(out, downgradeOrphanToolResult(ctx, orphan))
+		out = append(out, indexedMessage{
+			message:     downgradeOrphanToolResult(ctx, orphan.message),
+			sourceIndex: orphan.sourceIndex,
+		})
 	}
 	return out
 }
 
-func splitToolCalls(toolCalls []model.ToolCall, toolResults []model.Message) toolCallSplit {
+func splitToolCalls(toolCalls []model.ToolCall, toolResults []indexedMessage) toolCallSplit {
 	out := toolCallSplit{
 		kept: make([]model.ToolCall, 0, len(toolCalls)),
 	}
 	respondedIDs := make(map[string]struct{}, len(toolResults))
 	for _, tr := range toolResults {
-		if tr.ToolID == "" {
+		if tr.message.ToolID == "" {
 			continue
 		}
-		respondedIDs[tr.ToolID] = struct{}{}
+		respondedIDs[tr.message.ToolID] = struct{}{}
 	}
 	for _, tc := range toolCalls {
 		if tc.ID != "" {
@@ -408,28 +478,35 @@ func validateNumberValueAgainstSchema(value any, path string) (bool, string) {
 }
 
 // splitToolResults groups tool result messages by tool_call_id based on tool call validity.
-func splitToolResults(toolResults []model.Message, validIDs map[string]struct{}, invalidIDs map[string]struct{}) toolResultSplit {
+func splitToolResults(
+	toolResults []indexedMessage,
+	validIDs map[string]struct{},
+	invalidIDs map[string]struct{},
+) toolResultSplit {
 	out := toolResultSplit{
-		kept:        make([]model.Message, 0, len(toolResults)),
-		invalidByID: make(map[string][]model.Message),
+		kept:        make([]indexedMessage, 0, len(toolResults)),
+		invalidByID: make(map[string][]indexedMessage),
 	}
 	respondedValidIDs := make(map[string]struct{}, len(validIDs))
 	for _, tr := range toolResults {
-		if tr.ToolID == "" {
+		if tr.message.ToolID == "" {
 			out.orphan = append(out.orphan, tr)
 			continue
 		}
-		if _, ok := validIDs[tr.ToolID]; ok {
-			if _, responded := respondedValidIDs[tr.ToolID]; responded {
+		if _, ok := validIDs[tr.message.ToolID]; ok {
+			if _, responded := respondedValidIDs[tr.message.ToolID]; responded {
 				out.orphan = append(out.orphan, tr)
 				continue
 			}
-			respondedValidIDs[tr.ToolID] = struct{}{}
+			respondedValidIDs[tr.message.ToolID] = struct{}{}
 			out.kept = append(out.kept, tr)
 			continue
 		}
-		if _, ok := invalidIDs[tr.ToolID]; ok {
-			out.invalidByID[tr.ToolID] = append(out.invalidByID[tr.ToolID], tr)
+		if _, ok := invalidIDs[tr.message.ToolID]; ok {
+			out.invalidByID[tr.message.ToolID] = append(
+				out.invalidByID[tr.message.ToolID],
+				tr,
+			)
 			continue
 		}
 		out.orphan = append(out.orphan, tr)

--- a/internal/toolcall/sanitize_bench_test.go
+++ b/internal/toolcall/sanitize_bench_test.go
@@ -1,0 +1,189 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package toolcall
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+var sanitizeMessagesBenchmarkSink []model.Message
+
+func BenchmarkSanitizeMessagesWithTools(b *testing.B) {
+	originalWarnfContext := log.WarnfContext
+	log.WarnfContext = func(context.Context, string, ...any) {}
+	b.Cleanup(func() {
+		log.WarnfContext = originalWarnfContext
+	})
+
+	benchmarks := []struct {
+		name     string
+		messages []model.Message
+		bytes    int64
+	}{
+		{
+			name:     "text/messages=32",
+			messages: sanitizeBenchmarkTextMessages(32, 64),
+		},
+		{
+			name:     "text/messages=512",
+			messages: sanitizeBenchmarkTextMessages(512, 64),
+		},
+		{
+			name:     "text/messages=2048",
+			messages: sanitizeBenchmarkTextMessages(2048, 64),
+		},
+		{
+			name:     "large_text/messages=512/payload_bytes=3145728",
+			messages: sanitizeBenchmarkTextMessages(512, 6*1024),
+			bytes:    3 * 1024 * 1024,
+		},
+		{
+			name:     "valid_tool_rounds/messages=32",
+			messages: sanitizeBenchmarkValidToolRounds(16),
+		},
+		{
+			name:     "valid_tool_rounds/messages=512",
+			messages: sanitizeBenchmarkValidToolRounds(256),
+		},
+		{
+			name:     "valid_tool_rounds/messages=2048",
+			messages: sanitizeBenchmarkValidToolRounds(1024),
+		},
+		{
+			name:     "mixed_tool_rounds/messages=32",
+			messages: sanitizeBenchmarkMixedToolRounds(8),
+		},
+		{
+			name:     "mixed_tool_rounds/messages=512",
+			messages: sanitizeBenchmarkMixedToolRounds(128),
+		},
+		{
+			name:     "mixed_tool_rounds/messages=2048",
+			messages: sanitizeBenchmarkMixedToolRounds(512),
+		},
+	}
+	ctx := context.Background()
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			if benchmark.bytes > 0 {
+				b.SetBytes(benchmark.bytes)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sanitizeMessagesBenchmarkSink = SanitizeMessagesWithTools(
+					ctx,
+					benchmark.messages,
+					nil,
+				)
+			}
+		})
+	}
+}
+
+func sanitizeBenchmarkTextMessages(count int, contentBytes int) []model.Message {
+	messages := make([]model.Message, count)
+	content := strings.Repeat("t", contentBytes)
+	for i := range messages {
+		role := model.RoleUser
+		if i%2 == 1 {
+			role = model.RoleAssistant
+		}
+		messages[i] = model.Message{Role: role, Content: content}
+	}
+	return messages
+}
+
+func sanitizeBenchmarkValidToolRounds(rounds int) []model.Message {
+	messages := make([]model.Message, 0, rounds*2)
+	for i := 0; i < rounds; i++ {
+		callID := fmt.Sprintf("valid-call-%d", i)
+		messages = append(messages,
+			model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID: callID,
+					Function: model.FunctionDefinitionParam{
+						Name:      "benchmark_tool",
+						Arguments: []byte(`{"value":"benchmark"}`),
+					},
+				}},
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   callID,
+				ToolName: "benchmark_tool",
+				Content:  "benchmark result",
+			},
+		)
+	}
+	return messages
+}
+
+func sanitizeBenchmarkMixedToolRounds(rounds int) []model.Message {
+	messages := make([]model.Message, 0, rounds*4)
+	for i := 0; i < rounds; i++ {
+		validID := fmt.Sprintf("valid-call-%d", i)
+		invalidID := fmt.Sprintf("invalid-call-%d", i)
+		orphanID := fmt.Sprintf("orphan-call-%d", i)
+		messages = append(messages,
+			model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{
+					{
+						ID: validID,
+						Function: model.FunctionDefinitionParam{
+							Name:      "benchmark_tool",
+							Arguments: []byte(`{"value":"benchmark"}`),
+						},
+					},
+					{
+						ID: invalidID,
+						Function: model.FunctionDefinitionParam{
+							Arguments: []byte(`{"value":"benchmark"}`),
+						},
+					},
+					{
+						ID: orphanID,
+						Function: model.FunctionDefinitionParam{
+							Name:      "benchmark_tool",
+							Arguments: []byte(`{"value":"benchmark"}`),
+						},
+					},
+				},
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   validID,
+				ToolName: "benchmark_tool",
+				Content:  "valid result",
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   invalidID,
+				ToolName: "benchmark_tool",
+				Content:  "invalid result",
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   fmt.Sprintf("unknown-call-%d", i),
+				ToolName: "benchmark_tool",
+				Content:  "orphan result",
+			},
+		)
+	}
+	return messages
+}

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -332,6 +332,42 @@ func TestSanitizeMessagesWithTools_SplitsMixedValidityToolRound(t *testing.T) {
 	}
 }
 
+func TestSanitizeMessagesWithToolsResult_TracksSplitRoundSources(t *testing.T) {
+	in := []model.Message{
+		model.NewUserMessage("start"),
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_ok",
+					Function: model.FunctionDefinitionParam{
+						Name:      "ok_tool",
+						Arguments: []byte(`{"a":1}`),
+					},
+				},
+				{
+					ID: "call_bad",
+					Function: model.FunctionDefinitionParam{
+						Name:      "bad_tool",
+						Arguments: []byte("not-json"),
+					},
+				},
+			},
+		},
+		{Role: model.RoleTool, ToolID: "call_ok", Content: "ok"},
+		{Role: model.RoleTool, ToolID: "call_bad", Content: "bad"},
+	}
+
+	result := SanitizeMessagesWithToolsResult(
+		context.Background(),
+		in,
+		nil,
+	)
+
+	assert.Len(t, result.Messages, 5)
+	assert.Equal(t, []int{0, 1, 2, 1, 3}, result.SourceIndexes)
+}
+
 func TestSanitizeMessagesWithTools_DowngradesOrphanToolResult(t *testing.T) {
 	in := []model.Message{
 		{
@@ -924,11 +960,11 @@ func TestValidateValueAgainstSchema_ArrayTypeMismatch(t *testing.T) {
 }
 
 func TestSplitToolResults_GroupsByIDs(t *testing.T) {
-	toolResults := []model.Message{
-		{Role: model.RoleTool, ToolID: ""},
-		{Role: model.RoleTool, ToolID: "valid"},
-		{Role: model.RoleTool, ToolID: "invalid"},
-		{Role: model.RoleTool, ToolID: "unknown"},
+	toolResults := []indexedMessage{
+		{message: model.Message{Role: model.RoleTool, ToolID: ""}},
+		{message: model.Message{Role: model.RoleTool, ToolID: "valid"}},
+		{message: model.Message{Role: model.RoleTool, ToolID: "invalid"}},
+		{message: model.Message{Role: model.RoleTool, ToolID: "unknown"}},
 	}
 	validIDs := map[string]struct{}{"valid": {}}
 	invalidIDs := map[string]struct{}{"invalid": {}}

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -368,6 +368,47 @@ func TestSanitizeMessagesWithToolsResult_TracksSplitRoundSources(t *testing.T) {
 	assert.Equal(t, []int{0, 1, 2, 1, 3}, result.SourceIndexes)
 }
 
+func TestSanitizeMessagesWithToolsResultOmitsIdentitySources(t *testing.T) {
+	in := []model.Message{
+		model.NewUserMessage("start"),
+		model.NewAssistantMessage("answer"),
+	}
+
+	result := SanitizeMessagesWithToolsResult(
+		context.Background(),
+		in,
+		nil,
+	)
+
+	assert.Equal(t, in, result.Messages)
+	assert.Nil(t, result.SourceIndexes)
+}
+
+func TestSanitizeMessagesWithToolsResultOmitsIdentityToolRoundSources(t *testing.T) {
+	in := []model.Message{
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID: "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"query":"benchmark"}`),
+				},
+			}},
+		},
+		model.NewToolMessage("call_1", "lookup", "result"),
+	}
+
+	result := SanitizeMessagesWithToolsResult(
+		context.Background(),
+		in,
+		nil,
+	)
+
+	assert.Equal(t, in, result.Messages)
+	assert.Nil(t, result.SourceIndexes)
+}
+
 func TestSanitizeMessagesWithTools_DowngradesOrphanToolResult(t *testing.T) {
 	in := []model.Message{
 		{
@@ -960,17 +1001,19 @@ func TestValidateValueAgainstSchema_ArrayTypeMismatch(t *testing.T) {
 }
 
 func TestSplitToolResults_GroupsByIDs(t *testing.T) {
-	toolResults := []indexedMessage{
-		{message: model.Message{Role: model.RoleTool, ToolID: ""}},
-		{message: model.Message{Role: model.RoleTool, ToolID: "valid"}},
-		{message: model.Message{Role: model.RoleTool, ToolID: "invalid"}},
-		{message: model.Message{Role: model.RoleTool, ToolID: "unknown"}},
+	toolResults := []model.Message{
+		{Role: model.RoleTool, ToolID: ""},
+		{Role: model.RoleTool, ToolID: "valid"},
+		{Role: model.RoleTool, ToolID: "invalid"},
+		{Role: model.RoleTool, ToolID: "unknown"},
 	}
 	validIDs := map[string]struct{}{"valid": {}}
 	invalidIDs := map[string]struct{}{"invalid": {}}
-	split := splitToolResults(toolResults, validIDs, invalidIDs)
+	split := splitToolResults(toolResults, 10, validIDs, invalidIDs)
 	assert.Len(t, split.kept, 1)
+	assert.Equal(t, 11, split.kept[0].sourceIndex)
 	assert.Len(t, split.invalidByID["invalid"], 1)
+	assert.Equal(t, 12, split.invalidByID["invalid"][0].sourceIndex)
 	assert.Len(t, split.orphan, 2)
 }
 

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -278,6 +278,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "anthropic.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -289,7 +293,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				err,
 			)
 			modeltailoring.ApplyResult(
-				ctx, "anthropic.Model", request, tailored, maxInputTokens,
+				ctx, "anthropic.Model", request, tailored,
 			)
 			return
 		}
@@ -302,7 +306,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	}
 
 	modeltailoring.ApplyResult(
-		ctx, "anthropic.Model", request, tailored, maxInputTokens,
+		ctx, "anthropic.Model", request, tailored,
 	)
 }
 

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -288,7 +288,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in anthropic.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "anthropic.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "anthropic.Model", request, tailored, maxInputTokens,
+			)
 			return
 		}
 		log.WarnContext(
@@ -299,7 +301,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "anthropic.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "anthropic.Model", request, tailored, maxInputTokens,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -630,7 +630,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in gemini.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "gemini.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "gemini.Model", request, tailored, maxInputTokens,
+			)
 			return
 		}
 		log.WarnContext(
@@ -641,7 +643,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "gemini.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "gemini.Model", request, tailored, maxInputTokens,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -620,6 +620,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "gemini.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -631,7 +635,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				err,
 			)
 			modeltailoring.ApplyResult(
-				ctx, "gemini.Model", request, tailored, maxInputTokens,
+				ctx, "gemini.Model", request, tailored,
 			)
 			return
 		}
@@ -644,7 +648,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	}
 
 	modeltailoring.ApplyResult(
-		ctx, "gemini.Model", request, tailored, maxInputTokens,
+		ctx, "gemini.Model", request, tailored,
 	)
 }
 

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -492,14 +492,18 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	if err != nil {
 		if len(tailored) > 0 {
 			log.WarnContext(ctx, "token tailoring returned best-effort messages in huggingface.Model", err)
-			modeltailoring.ApplyResult(ctx, "huggingface.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "huggingface.Model", request, tailored, maxInputTokens,
+			)
 			return
 		}
 		log.Warn("token tailoring failed in huggingface.Model", err)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "huggingface.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "huggingface.Model", request, tailored, maxInputTokens,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -486,6 +486,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		log.DebugfContext(ctx, "auto-calculated max input tokens: model=%s, maxInputTokens=%d",
 			m.name, maxInputTokens)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "huggingface.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -493,7 +497,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		if len(tailored) > 0 {
 			log.WarnContext(ctx, "token tailoring returned best-effort messages in huggingface.Model", err)
 			modeltailoring.ApplyResult(
-				ctx, "huggingface.Model", request, tailored, maxInputTokens,
+				ctx, "huggingface.Model", request, tailored,
 			)
 			return
 		}
@@ -502,7 +506,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	}
 
 	modeltailoring.ApplyResult(
-		ctx, "huggingface.Model", request, tailored, maxInputTokens,
+		ctx, "huggingface.Model", request, tailored,
 	)
 }
 

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -296,6 +296,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		log.DebugfContext(ctx, "auto-calculated max input tokens: model=%s, maxInputTokens=%d",
 			m.name, maxInputTokens)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "hunyuan.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -303,7 +307,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		if len(tailored) > 0 {
 			log.WarnContext(ctx, "token tailoring returned best-effort messages in hunyuan.Model", err)
 			modeltailoring.ApplyResult(
-				ctx, "hunyuan.Model", request, tailored, maxInputTokens,
+				ctx, "hunyuan.Model", request, tailored,
 			)
 			return
 		}
@@ -312,7 +316,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	}
 
 	modeltailoring.ApplyResult(
-		ctx, "hunyuan.Model", request, tailored, maxInputTokens,
+		ctx, "hunyuan.Model", request, tailored,
 	)
 }
 

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -302,14 +302,18 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	if err != nil {
 		if len(tailored) > 0 {
 			log.WarnContext(ctx, "token tailoring returned best-effort messages in hunyuan.Model", err)
-			modeltailoring.ApplyResult(ctx, "hunyuan.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "hunyuan.Model", request, tailored, maxInputTokens,
+			)
 			return
 		}
 		log.WarnContext(ctx, "token tailoring failed in hunyuan.Model", "error", err)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "hunyuan.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "hunyuan.Model", request, tailored, maxInputTokens,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/internal/modeltailoring/modeltailoring.go
+++ b/model/internal/modeltailoring/modeltailoring.go
@@ -12,7 +12,9 @@ package modeltailoring
 
 import (
 	"context"
+	"reflect"
 
+	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -25,6 +27,7 @@ func ApplyResult(
 	provider string,
 	request *model.Request,
 	tailored []model.Message,
+	maxInputTokens int,
 ) bool {
 	if request == nil {
 		return false
@@ -37,6 +40,19 @@ func ApplyResult(
 		)
 		return false
 	}
+	changed := !reflect.DeepEqual(request.Messages, tailored)
+	beforeMessages := len(request.Messages)
 	request.Messages = tailored
+	if changed {
+		modelrequest.RecordTokenTailoring(
+			ctx,
+			modelrequest.TokenTailoringRecord{
+				Provider:       provider,
+				MaxInputTokens: maxInputTokens,
+				BeforeMessages: beforeMessages,
+				AfterMessages:  len(tailored),
+			},
+		)
+	}
 	return true
 }

--- a/model/internal/modeltailoring/modeltailoring.go
+++ b/model/internal/modeltailoring/modeltailoring.go
@@ -15,9 +15,39 @@ import (
 	"reflect"
 
 	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/statecopy"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
+
+// ObserveChanges snapshots request messages and returns a function that records
+// any provider-side change. Callers should defer the returned function before
+// invoking a token tailoring strategy.
+func ObserveChanges(
+	ctx context.Context,
+	provider string,
+	request *model.Request,
+	maxInputTokens int,
+) func() {
+	if request == nil {
+		return func() {}
+	}
+	before := statecopy.Messages(request.Messages)
+	return func() {
+		if reflect.DeepEqual(before, request.Messages) {
+			return
+		}
+		modelrequest.RecordTokenTailoring(
+			ctx,
+			modelrequest.TokenTailoringRecord{
+				Provider:       provider,
+				MaxInputTokens: maxInputTokens,
+				BeforeMessages: len(before),
+				AfterMessages:  len(request.Messages),
+			},
+		)
+	}
+}
 
 // ApplyResult applies a token-tailored message slice when it is safe to do so.
 // It preserves the original non-empty request if a tailoring strategy returns an
@@ -27,7 +57,6 @@ func ApplyResult(
 	provider string,
 	request *model.Request,
 	tailored []model.Message,
-	maxInputTokens int,
 ) bool {
 	if request == nil {
 		return false
@@ -40,19 +69,6 @@ func ApplyResult(
 		)
 		return false
 	}
-	changed := !reflect.DeepEqual(request.Messages, tailored)
-	beforeMessages := len(request.Messages)
 	request.Messages = tailored
-	if changed {
-		modelrequest.RecordTokenTailoring(
-			ctx,
-			modelrequest.TokenTailoringRecord{
-				Provider:       provider,
-				MaxInputTokens: maxInputTokens,
-				BeforeMessages: beforeMessages,
-				AfterMessages:  len(tailored),
-			},
-		)
-	}
 	return true
 }

--- a/model/internal/modeltailoring/modeltailoring_test.go
+++ b/model/internal/modeltailoring/modeltailoring_test.go
@@ -24,7 +24,6 @@ func TestApplyResult_NilRequest(t *testing.T) {
 		"test.Model",
 		nil,
 		[]model.Message{model.NewUserMessage("q")},
-		100,
 	)
 
 	require.False(t, updated)
@@ -48,7 +47,7 @@ func TestApplyResult_PreservesOriginalOnEmptyResult(t *testing.T) {
 			req := &model.Request{Messages: append([]model.Message(nil), original...)}
 
 			updated := ApplyResult(
-				context.Background(), "test.Model", req, tt.tailored, 100,
+				context.Background(), "test.Model", req, tt.tailored,
 			)
 
 			require.False(t, updated)
@@ -65,7 +64,7 @@ func TestApplyResult_AppliesTailoredMessages(t *testing.T) {
 	}}
 
 	updated := ApplyResult(
-		context.Background(), "test.Model", req, tailored, 100,
+		context.Background(), "test.Model", req, tailored,
 	)
 
 	require.True(t, updated)
@@ -77,40 +76,34 @@ func TestApplyResult_AllowsEmptyResultForEmptyOriginal(t *testing.T) {
 	tailored := []model.Message{}
 
 	updated := ApplyResult(
-		context.Background(), "test.Model", req, tailored, 100,
+		context.Background(), "test.Model", req, tailored,
 	)
 
 	require.True(t, updated)
 	require.Equal(t, tailored, req.Messages)
 }
 
-func TestApplyResultReportsChangedRequest(t *testing.T) {
+func TestObserveChangesReportsMutatingStrategy(t *testing.T) {
 	ctx, observer := modelrequest.ObserveTokenTailoring(
 		context.Background(),
 		nil,
 	)
 	req := &model.Request{Messages: []model.Message{
-		model.NewSystemMessage("sys"),
 		model.NewUserMessage("question"),
 	}}
-
-	require.True(t, ApplyResult(
-		ctx,
-		"test.Model",
-		req,
-		[]model.Message{req.Messages[0]},
-		100,
-	))
+	finishObservation := ObserveChanges(ctx, "test.Model", req, 100)
+	req.Messages[0].Content = "mutated in place"
+	finishObservation()
 
 	require.Equal(t, []modelrequest.TokenTailoringRecord{{
 		Provider:       "test.Model",
 		MaxInputTokens: 100,
-		BeforeMessages: 2,
+		BeforeMessages: 1,
 		AfterMessages:  1,
 	}}, observer.Snapshot())
 }
 
-func TestApplyResultDoesNotReportUnchangedRequest(t *testing.T) {
+func TestObserveChangesDoesNotReportUnchangedRequest(t *testing.T) {
 	ctx, observer := modelrequest.ObserveTokenTailoring(
 		context.Background(),
 		nil,
@@ -118,6 +111,7 @@ func TestApplyResultDoesNotReportUnchangedRequest(t *testing.T) {
 	messages := []model.Message{model.NewUserMessage("question")}
 	req := &model.Request{Messages: messages}
 
-	require.True(t, ApplyResult(ctx, "test.Model", req, messages, 100))
+	finishObservation := ObserveChanges(ctx, "test.Model", req, 100)
+	finishObservation()
 	require.Empty(t, observer.Snapshot())
 }

--- a/model/internal/modeltailoring/modeltailoring_test.go
+++ b/model/internal/modeltailoring/modeltailoring_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -23,6 +24,7 @@ func TestApplyResult_NilRequest(t *testing.T) {
 		"test.Model",
 		nil,
 		[]model.Message{model.NewUserMessage("q")},
+		100,
 	)
 
 	require.False(t, updated)
@@ -45,7 +47,9 @@ func TestApplyResult_PreservesOriginalOnEmptyResult(t *testing.T) {
 			}
 			req := &model.Request{Messages: append([]model.Message(nil), original...)}
 
-			updated := ApplyResult(context.Background(), "test.Model", req, tt.tailored)
+			updated := ApplyResult(
+				context.Background(), "test.Model", req, tt.tailored, 100,
+			)
 
 			require.False(t, updated)
 			require.Equal(t, original, req.Messages)
@@ -60,7 +64,9 @@ func TestApplyResult_AppliesTailoredMessages(t *testing.T) {
 		model.NewUserMessage("q"),
 	}}
 
-	updated := ApplyResult(context.Background(), "test.Model", req, tailored)
+	updated := ApplyResult(
+		context.Background(), "test.Model", req, tailored, 100,
+	)
 
 	require.True(t, updated)
 	require.Equal(t, tailored, req.Messages)
@@ -70,8 +76,48 @@ func TestApplyResult_AllowsEmptyResultForEmptyOriginal(t *testing.T) {
 	req := &model.Request{}
 	tailored := []model.Message{}
 
-	updated := ApplyResult(context.Background(), "test.Model", req, tailored)
+	updated := ApplyResult(
+		context.Background(), "test.Model", req, tailored, 100,
+	)
 
 	require.True(t, updated)
 	require.Equal(t, tailored, req.Messages)
+}
+
+func TestApplyResultReportsChangedRequest(t *testing.T) {
+	ctx, observer := modelrequest.ObserveTokenTailoring(
+		context.Background(),
+		nil,
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("sys"),
+		model.NewUserMessage("question"),
+	}}
+
+	require.True(t, ApplyResult(
+		ctx,
+		"test.Model",
+		req,
+		[]model.Message{req.Messages[0]},
+		100,
+	))
+
+	require.Equal(t, []modelrequest.TokenTailoringRecord{{
+		Provider:       "test.Model",
+		MaxInputTokens: 100,
+		BeforeMessages: 2,
+		AfterMessages:  1,
+	}}, observer.Snapshot())
+}
+
+func TestApplyResultDoesNotReportUnchangedRequest(t *testing.T) {
+	ctx, observer := modelrequest.ObserveTokenTailoring(
+		context.Background(),
+		nil,
+	)
+	messages := []model.Message{model.NewUserMessage("question")}
+	req := &model.Request{Messages: messages}
+
+	require.True(t, ApplyResult(ctx, "test.Model", req, messages, 100))
+	require.Empty(t, observer.Snapshot())
 }

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -286,7 +286,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in ollama.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "ollama.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "ollama.Model", request, tailored, maxInputTokens,
+			)
 			return
 		}
 		log.WarnContext(
@@ -297,7 +299,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "ollama.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "ollama.Model", request, tailored, maxInputTokens,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -276,6 +276,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "ollama.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -287,7 +291,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				err,
 			)
 			modeltailoring.ApplyResult(
-				ctx, "ollama.Model", request, tailored, maxInputTokens,
+				ctx, "ollama.Model", request, tailored,
 			)
 			return
 		}
@@ -300,7 +304,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	}
 
 	modeltailoring.ApplyResult(
-		ctx, "ollama.Model", request, tailored, maxInputTokens,
+		ctx, "ollama.Model", request, tailored,
 	)
 }
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -784,6 +784,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "openai.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -795,7 +799,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				err,
 			)
 			modeltailoring.ApplyResult(
-				ctx, "openai.Model", request, tailored, maxInputTokens,
+				ctx, "openai.Model", request, tailored,
 			)
 			return
 		}
@@ -808,7 +812,7 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 	}
 
 	modeltailoring.ApplyResult(
-		ctx, "openai.Model", request, tailored, maxInputTokens,
+		ctx, "openai.Model", request, tailored,
 	)
 }
 

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -794,7 +794,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in openai.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "openai.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "openai.Model", request, tailored, maxInputTokens,
+			)
 			return
 		}
 		log.WarnContext(
@@ -805,7 +807,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "openai.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "openai.Model", request, tailored, maxInputTokens,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.


### PR DESCRIPTION
## What changed

- Preserve message provenance across tool-call sanitation and safely rebase the model-visible summary view, including one-to-many rewrites of mixed or orphaned tool rounds.
- Fail closed when a request transform cannot prove complete history lineage.
- Invalidate cached summary snapshots when provider-side token tailoring actually changes the model request, and expose diagnostic attributes for tailoring and compaction threshold basis.

## Why

Tool-call sanitation can rewrite one persisted history message into multiple model-visible messages. The previous summary view could no longer bind that rewritten request, so pre-LLM compaction found no eligible persisted events even when the request was well above its threshold. Provider-side token tailoring could then mutate the request without invalidating snapshots that described the pre-tailored request.

## Testing

- `go build ./...`
- `go test ./internal/state/summaryview ./internal/toolcall ./internal/modelrequest ./model/internal/modeltailoring ./internal/flow/llmflow -count=1`
- `cd test && go test ./... -count=1`
- Affected provider module tests and the repository library-module matrix
- Example module dependency and build checks
- `golangci-lint run --timeout=10m`
- `gofmt` and `goimports` checks

## Notes for reviewers

This changes no public API, default configuration, or compaction threshold semantics. The threshold remains a ratio of the model context window. Transforms without complete provenance keep summary state unbound until a new projection is attached.
