### PR TITLE
internal/skillstage: tolerate chmod denial when restaging skills

### DIFF
--- a/internal/skillstage/stager.go
+++ b/internal/skillstage/stager.go
@@ -363,8 +363,15 @@ func (s *Stager) linkWorkspaceDirs(
 	return runProgramExitError("link workspace dirs", res, err)
 }
 
-// RemoveWorkspacePath removes a workspace-relative path after first making
-// non-symlink files writable so cleanup can succeed on read-only staged trees.
+// RemoveWorkspacePath removes a workspace-relative path after first
+// attempting to make non-symlink entries writable so cleanup can succeed
+// on read-only staged trees.
+//
+// chmod is best-effort. POSIX chmod requires the file owner (or
+// privilege), but ProgramRunner may run as a session-isolated identity
+// that does not own the staged tree. Deletion only needs write permission
+// on parent directories, which those backends typically already grant.
+// rm -rf remains mandatory: a chmod failure must not skip the delete.
 func (s *Stager) RemoveWorkspacePath(
 	ctx context.Context,
 	eng codeexecutor.Engine,
@@ -383,7 +390,7 @@ func (s *Stager) RemoveWorkspacePath(
 	sb.WriteString(shellQuote(target))
 	sb.WriteString(" ]; then find ")
 	sb.WriteString(shellQuote(target))
-	sb.WriteString(" -type l -prune -o -exec chmod u+w {} +; fi")
+	sb.WriteString(" -type l -prune -o -exec chmod u+w {} + || true; fi")
 	sb.WriteString("; rm -rf ")
 	sb.WriteString(shellQuote(target))
 	res, err := eng.Runner().RunProgram(

--- a/internal/skillstage/stager_test.go
+++ b/internal/skillstage/stager_test.go
@@ -505,3 +505,155 @@ func TestSkillStagingHelpers_ReturnExitCodeErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exit code 1")
 }
+
+// pathPrefixRunner prepends a directory to PATH inside bash -lc scripts
+// so the login shell's profile cannot clobber the test shim.
+type pathPrefixRunner struct {
+	inner  codeexecutor.ProgramRunner
+	prefix string
+}
+
+func (r *pathPrefixRunner) RunProgram(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	if spec.Cmd == "bash" && len(spec.Args) >= 2 && spec.Args[0] == "-lc" {
+		args := append([]string(nil), spec.Args...)
+		args[1] = "export PATH=" + shellQuote(r.prefix) + ":\"$PATH\"; " + args[1]
+		spec.Args = args
+	}
+	return r.inner.RunProgram(ctx, ws, spec)
+}
+
+func chmodDeniedShimDir(t *testing.T) (binDir, marker string) {
+	t.Helper()
+	binDir = t.TempDir()
+	marker = filepath.Join(t.TempDir(), "chmod.called")
+	script := "#!/bin/sh\n" +
+		"echo called >> " + shellQuote(marker) + "\n" +
+		"echo \"chmod: changing permissions of '$2': " +
+		"Operation not permitted\" >&2\n" +
+		"exit 1\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, "chmod"),
+		[]byte(script),
+		0o755,
+	))
+	return binDir, marker
+}
+
+func engineWithChmodDenied(
+	t *testing.T,
+	rt *localexec.Runtime,
+) (codeexecutor.Engine, string) {
+	t.Helper()
+	binDir, marker := chmodDeniedShimDir(t)
+	return codeexecutor.NewEngine(rt, rt, &pathPrefixRunner{
+		inner:  rt,
+		prefix: binDir,
+	}), marker
+}
+
+func writeSkillDir(t *testing.T, root, body string) string {
+	t.Helper()
+	skillRoot := filepath.Join(root, "echoer")
+	require.NoError(t, os.MkdirAll(skillRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillRoot, "SKILL.md"),
+		[]byte(body),
+		0o644,
+	))
+	return skillRoot
+}
+
+func TestRemoveWorkspacePath_ChmodDeniedStillRemoves(t *testing.T) {
+	ctx := context.Background()
+	rt := localexec.NewRuntime("")
+	eng, marker := engineWithChmodDenied(t, rt)
+	ws, err := rt.CreateWorkspace(
+		ctx, "remove-chmod-denied", codeexecutor.WorkspacePolicy{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Cleanup(ctx, ws)
+	})
+
+	st := New()
+	err = st.StageSkill(
+		ctx, eng, ws, writeSkillDir(t, t.TempDir(), "v1"), "echoer",
+	)
+	require.NoError(t, err)
+
+	dest := filepath.Join(ws.Path, "skills", "echoer")
+	require.DirExists(t, dest)
+
+	err = st.RemoveWorkspacePath(ctx, eng, ws, "skills/echoer")
+	require.NoError(t, err)
+	require.NoDirExists(t, dest)
+	_, statErr := os.Stat(marker)
+	require.NoError(t, statErr, "chmod shim must have been invoked")
+}
+
+func TestRemoveWorkspacePath_RemoveFailureStillReported(t *testing.T) {
+	ctx := context.Background()
+	rt := localexec.NewRuntime("")
+	eng, _ := engineWithChmodDenied(t, rt)
+	ws, err := rt.CreateWorkspace(
+		ctx, "remove-rm-denied", codeexecutor.WorkspacePolicy{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Cleanup(ctx, ws)
+	})
+
+	dest := filepath.Join(ws.Path, "skills", "echoer")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dest, "SKILL.md"),
+		[]byte("body"),
+		0o644,
+	))
+	// Directory write is required to unlink children. The chmod shim
+	// cannot restore u+w, so rm -rf must fail and be reported.
+	require.NoError(t, os.Chmod(dest, 0o555))
+	t.Cleanup(func() {
+		_ = os.Chmod(dest, 0o755)
+	})
+
+	err = New().RemoveWorkspacePath(ctx, eng, ws, "skills/echoer")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remove workspace path")
+	require.DirExists(t, dest)
+}
+
+func TestStager_StageSkill_RestagesWhenChmodDenied(t *testing.T) {
+	ctx := context.Background()
+	rt := localexec.NewRuntime("")
+	eng, marker := engineWithChmodDenied(t, rt)
+	ws, err := rt.CreateWorkspace(
+		ctx, "restage-chmod-denied", codeexecutor.WorkspacePolicy{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Cleanup(ctx, ws)
+	})
+
+	st := New()
+	err = st.StageSkill(
+		ctx, eng, ws, writeSkillDir(t, t.TempDir(), "v1"), "echoer",
+	)
+	require.NoError(t, err)
+
+	err = st.StageSkill(
+		ctx, eng, ws, writeSkillDir(t, t.TempDir(), "v2"), "echoer",
+	)
+	require.NoError(t, err)
+
+	files, err := rt.Collect(ctx, ws, []string{"skills/echoer/SKILL.md"})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "v2", files[0].Content)
+	_, statErr := os.Stat(marker)
+	require.NoError(t, statErr, "restage must attempt chmod on the old tree")
+}


### PR DESCRIPTION
## What changed

`skillstage.RemoveWorkspacePath` now treats the `chmod u+w` pass as best-effort. Skill restage and `workspace_exec` reconcile can replace an old staged tree when the runner is not the file owner. `rm -rf` is still mandatory: a real delete failure still returns `remove workspace path`.

## Why

### Production background

A session loaded a user Skill, later updated that Skill (`create_skill` with an existing id), then called `workspace_exec`. The update changed the Skill content hash / directory digest, so workspace reconcile correctly decided to replace the staged working copy.

Replacement goes through `RemoveWorkspacePath` then `StageDirectory`. The remove script was:

```sh
set -e
if [ -e <skill-dir> ]; then
  find <skill-dir> -type l -prune -o -exec chmod u+w {} +
fi
rm -rf <skill-dir>
```

On a session-isolated workspace backend, `chmod u+w` returned `Operation not permitted`. `set -e` aborted before `rm -rf`, so the old tree was never deleted. Every later `workspace_exec` retried the same reconcile and failed the same way.

This is not a caller misuse of `skill_load` / `workspace_exec`. Loaded Skills are staged as writable working copies; content-hash changes are supposed to restage. The failure came from an identity assumption inside the generic stager.

### Two identities, two syscalls

Session-isolated engines (for example pcg123 with default session isolation) split workspace identity on purpose:

- **FS / control plane** owns staged files (sandbox default user). `StageDirectory` / `PutFiles` run as that owner.
- **Compute / runner** drops to a per-session UID/GID before user commands. Isolation is group mode `2770` plus setgid, not ownership transfer.

POSIX then diverges:

- `chmod(2)` is owner-or-privilege only. A non-owner gets `EPERM` even if the mode already has `u+w`.
- `unlink` / `rmdir` only need write+search on the parent directory. After the backend's privileged directory-mode sweep, the session identity can delete those files.

`chmod u+w` exists only as a compatibility shim for historical read-only staged trees, where directory write bits were cleared and `rm -rf` otherwise cannot empty the tree. It is not a correctness requirement for the current writable Skill contract.

The bug was treating that shim as mandatory and assuming `ProgramRunner` is the same principal that staged the tree. Session isolation breaks that assumption.

### Why this fix

Making chmod best-effort (`find … -exec chmod u+w {} + || true`) keeps the read-only compatibility path on backends where the runner *is* the owner, and lets delete proceed when chmod is denied but parent directories are writable. Swallowing chmod and then requiring `rm -rf` is the right generic contract: success means the path is gone.

Not chosen:

- Disabling session isolation, or chowning staged files to the session UID, would weaken the backend's isolation/ownership invariants.
- Adding `WorkspaceFS.Remove` is a cleaner long-term control-plane API, but it is a new public surface across every engine. It is not needed to fix this failure.

## Testing

- [x] `go test ./internal/skillstage/ -count=1`
- [x] Local POSIX reproduction: a `chmod` shim that always returns EPERM. Old script exits 1 and leaves the tree; new script deletes the tree.
- [x] `TestRemoveWorkspacePath_ChmodDeniedStillRemoves`: chmod is denied, path is still removed
- [x] `TestRemoveWorkspacePath_RemoveFailureStillReported`: directory is not writable, `rm -rf` failure still surfaces
- [x] `TestStager_StageSkill_RestagesWhenChmodDenied`: digest change restages through the chmod-denied runner

## Notes for reviewers

`RemoveWorkspacePath` is exported. Callers that treated a chmod-only failure as a hard error will now succeed when `rm -rf` can still delete the path. That is the intended contract: the method exists to remove a workspace path, not to require chmod.

`readOnlyExceptSymlinks` is unchanged. The default Skill staging path is a writable working copy; the production failure was on that path.

Made with [Cursor](https://cursor.com)