### PR TITLE
server/agui: scope message streams by message ID

### DIFF
--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -38,7 +38,8 @@ type reducer struct {
 type textPhase int
 
 const (
-	textReceiving textPhase = iota
+	textNotStarted textPhase = iota
+	textReceiving
 	textEnded
 )
 
@@ -78,11 +79,12 @@ const (
 
 // toolCallState is the state of the tool call.
 type toolCallState struct {
-	messageID string
-	name      string
-	content   strings.Builder
-	phase     toolPhase
-	index     int
+	messageID    string
+	name         string
+	content      strings.Builder
+	phase        toolPhase
+	index        int
+	messageIndex int
 }
 
 // Reduce reduces the AG-UI track events into message snapshots.
@@ -255,14 +257,10 @@ func (r *reducer) finalizePartial() {
 		if state.phase != toolAwaitingArgs || state.content.Len() == 0 {
 			continue
 		}
-		parentState, ok := r.texts[state.messageID]
-		if !ok {
+		if state.messageIndex < 0 || state.messageIndex >= len(r.messages) {
 			continue
 		}
-		if parentState.index < 0 || parentState.index >= len(r.messages) {
-			continue
-		}
-		parent := r.messages[parentState.index]
+		parent := r.messages[state.messageIndex]
 		if state.index < 0 || state.index >= len(parent.ToolCalls) {
 			continue
 		}
@@ -348,21 +346,23 @@ func (r *reducer) handleTextStart(e *aguievents.TextMessageStartEvent) error {
 	if e.MessageID == "" {
 		return fmt.Errorf("text message start missing id")
 	}
-	if _, exists := r.texts[e.MessageID]; exists {
-		return fmt.Errorf("duplicate text message start: %s", e.MessageID)
-	}
 	role := string(model.RoleAssistant)
 	if e.Role != nil && *e.Role != "" {
 		role = string(*e.Role)
 	}
-	name := ""
-	switch role {
-	case string(model.RoleUser):
-		name = r.userID
-	case string(model.RoleAssistant):
-		name = r.appName
-	default:
-		return fmt.Errorf("unsupported role: %s", role)
+	role, name, err := r.textIdentity(role)
+	if err != nil {
+		return err
+	}
+	if state, exists := r.texts[e.MessageID]; exists {
+		if state.phase == textReceiving {
+			return fmt.Errorf("duplicate text message start: %s", e.MessageID)
+		}
+		if err := validateTextIdentity(state, e.MessageID, role, name); err != nil {
+			return err
+		}
+		state.phase = textReceiving
+		return nil
 	}
 	r.messages = append(r.messages, &aguievents.Message{
 		ID:   e.MessageID,
@@ -381,7 +381,7 @@ func (r *reducer) handleTextStart(e *aguievents.TextMessageStartEvent) error {
 // handleTextContent handles the text message content event.
 func (r *reducer) handleTextContent(e *aguievents.TextMessageContentEvent) error {
 	state, ok := r.texts[e.MessageID]
-	if !ok {
+	if !ok || state.phase == textNotStarted {
 		return fmt.Errorf("text message content without start: %s", e.MessageID)
 	}
 	if state.phase != textReceiving {
@@ -394,7 +394,7 @@ func (r *reducer) handleTextContent(e *aguievents.TextMessageContentEvent) error
 // handleTextEnd handles the text message end event.
 func (r *reducer) handleTextEnd(e *aguievents.TextMessageEndEvent) error {
 	state, ok := r.texts[e.MessageID]
-	if !ok {
+	if !ok || state.phase == textNotStarted {
 		return fmt.Errorf("text message end without start: %s", e.MessageID)
 	}
 	if state.phase != textReceiving {
@@ -411,59 +411,86 @@ func (r *reducer) handleTextChunk(e *aguievents.TextMessageChunkEvent) error {
 	if e.MessageID == nil || *e.MessageID == "" {
 		return fmt.Errorf("text message chunk missing id")
 	}
-	if _, exists := r.texts[*e.MessageID]; exists {
+	messageID := *e.MessageID
+	if state, exists := r.texts[messageID]; exists && state.phase == textReceiving {
 		return fmt.Errorf("duplicate text message chunk: %s", *e.MessageID)
 	}
 	role := string(model.RoleAssistant)
 	if e.Role != nil && *e.Role != "" {
 		role = string(*e.Role)
 	}
-	name := ""
-	switch role {
-	case string(model.RoleUser):
-		name = r.userID
-	case string(model.RoleAssistant):
-		name = r.appName
-	default:
-		return fmt.Errorf("unsupported role: %s", role)
+	role, name, err := r.textIdentity(role)
+	if err != nil {
+		return err
 	}
 	content := ""
 	if e.Delta != nil {
 		content = strings.Clone(*e.Delta)
 	}
+	if state, exists := r.texts[messageID]; exists {
+		if err := validateTextIdentity(state, messageID, role, name); err != nil {
+			return err
+		}
+		state.content.WriteString(content)
+		state.phase = textEnded
+		text := strings.Clone(state.content.String())
+		r.messages[state.index].Content = &text
+		return nil
+	}
 	r.messages = append(r.messages, &aguievents.Message{
-		ID:      *e.MessageID,
+		ID:      messageID,
 		Role:    types.Role(role),
 		Name:    name,
 		Content: &content,
 	})
-	builder := strings.Builder{}
-	builder.WriteString(content)
-	r.texts[*e.MessageID] = &textState{
-		role:    role,
-		name:    name,
-		content: builder,
-		phase:   textEnded,
-		index:   len(r.messages) - 1,
+	state := &textState{
+		role:  role,
+		name:  name,
+		phase: textEnded,
+		index: len(r.messages) - 1,
 	}
+	state.content.WriteString(content)
+	r.texts[messageID] = state
 	return nil
+}
+
+func (r *reducer) textIdentity(role string) (string, string, error) {
+	switch role {
+	case string(model.RoleUser):
+		return role, r.userID, nil
+	case string(model.RoleAssistant):
+		return role, r.appName, nil
+	default:
+		return "", "", fmt.Errorf("unsupported role: %s", role)
+	}
+}
+
+func validateTextIdentity(state *textState, messageID, role, name string) error {
+	if state.role == role && state.name == name {
+		return nil
+	}
+	return fmt.Errorf("text message identity mismatch: %s", messageID)
 }
 
 func (r *reducer) handleReasoningMessageStart(e *aguievents.ReasoningMessageStartEvent) error {
 	if e.MessageID == "" {
 		return fmt.Errorf("reasoning message start missing id")
 	}
-	if _, exists := r.reasonings[e.MessageID]; exists {
-		return fmt.Errorf("duplicate reasoning message start: %s", e.MessageID)
+	role, name, err := r.reasoningIdentity(e.Role)
+	if err != nil {
+		return err
 	}
-	role := e.Role
-	switch role {
-	case "", string(types.RoleReasoning), string(model.RoleAssistant):
-		role = string(types.RoleReasoning)
-	default:
-		return fmt.Errorf("unsupported role: %s", role)
+	if state, exists := r.reasonings[e.MessageID]; exists {
+		if state.phase == reasoningReceiving {
+			return fmt.Errorf("duplicate reasoning message start: %s", e.MessageID)
+		}
+		if err := validateReasoningIdentity(state, e.MessageID, role, name); err != nil {
+			return err
+		}
+		state.phase = reasoningReceiving
+		state.started = true
+		return nil
 	}
-	name := r.appName
 	msg := &aguievents.Message{
 		ID:   e.MessageID,
 		Role: types.RoleReasoning,
@@ -522,11 +549,17 @@ func (r *reducer) handleReasoningChunk(e *aguievents.ReasoningMessageChunkEvent)
 
 	state, ok := r.reasonings[messageID]
 	if ok {
-		if state.phase != reasoningReceiving {
-			return fmt.Errorf("reasoning message chunk after end: %s", messageID)
-		}
 		if e.Delta == nil {
 			return nil
+		}
+		if state.phase == reasoningEnded {
+			if *e.Delta == "" {
+				return fmt.Errorf("duplicate reasoning message end: %s", messageID)
+			}
+			state.phase = reasoningReceiving
+		}
+		if state.phase != reasoningReceiving {
+			return fmt.Errorf("reasoning message chunk after end: %s", messageID)
 		}
 		if *e.Delta == "" {
 			state.phase = reasoningEnded
@@ -566,6 +599,22 @@ func (r *reducer) handleReasoningChunk(e *aguievents.ReasoningMessageChunkEvent)
 		}
 	}
 	return nil
+}
+
+func (r *reducer) reasoningIdentity(role string) (string, string, error) {
+	switch role {
+	case "", string(types.RoleReasoning), string(model.RoleAssistant):
+		return string(types.RoleReasoning), r.appName, nil
+	default:
+		return "", "", fmt.Errorf("unsupported role: %s", role)
+	}
+}
+
+func validateReasoningIdentity(state *reasoningState, messageID, role, name string) error {
+	if state.role == role && state.name == name {
+		return nil
+	}
+	return fmt.Errorf("reasoning message identity mismatch: %s", messageID)
 }
 
 func (r *reducer) handleReasoningEncryptedValue(e *aguievents.ReasoningEncryptedValueEvent) error {
@@ -624,7 +673,7 @@ func (r *reducer) handleToolStart(e *aguievents.ToolCallStartEvent) error {
 		parentState = &textState{
 			role:  string(model.RoleAssistant),
 			name:  r.appName,
-			phase: textEnded,
+			phase: textNotStarted,
 			index: len(r.messages) - 1,
 		}
 		r.texts[*e.ParentMessageID] = parentState
@@ -637,10 +686,11 @@ func (r *reducer) handleToolStart(e *aguievents.ToolCallStartEvent) error {
 		},
 	})
 	r.toolCalls[e.ToolCallID] = &toolCallState{
-		messageID: *e.ParentMessageID,
-		name:      e.ToolCallName,
-		phase:     toolAwaitingArgs,
-		index:     len(r.messages[parentState.index].ToolCalls) - 1,
+		messageID:    *e.ParentMessageID,
+		name:         e.ToolCallName,
+		phase:        toolAwaitingArgs,
+		index:        len(r.messages[parentState.index].ToolCalls) - 1,
+		messageIndex: parentState.index,
 	}
 	return nil
 }
@@ -667,11 +717,14 @@ func (r *reducer) handleToolEnd(e *aguievents.ToolCallEndEvent) error {
 	if state.phase != toolAwaitingArgs {
 		return fmt.Errorf("duplicate tool call end: %s", e.ToolCallID)
 	}
-	parentState, ok := r.texts[state.messageID]
-	if !ok {
+	if state.messageIndex < 0 || state.messageIndex >= len(r.messages) {
 		return fmt.Errorf("tool call end missing parent message: %s", state.messageID)
 	}
-	r.messages[parentState.index].ToolCalls[state.index].Function.Arguments = strings.Clone(state.content.String())
+	parent := r.messages[state.messageIndex]
+	if state.index < 0 || state.index >= len(parent.ToolCalls) {
+		return fmt.Errorf("tool call end missing parent tool call: %s", e.ToolCallID)
+	}
+	parent.ToolCalls[state.index].Function.Arguments = strings.Clone(state.content.String())
 	state.phase = toolAwaitingResult
 	return nil
 }
@@ -697,9 +750,57 @@ func (r *reducer) handleToolResult(e *aguievents.ToolCallResultEvent) error {
 		Content:    &content,
 		ToolCallID: toolCallID,
 	}
-	r.messages = append(r.messages, msg)
+	r.insertMessage(r.toolResultInsertIndex(state.messageIndex, state.messageID), msg)
 	state.phase = toolCompleted
 	return nil
+}
+
+func (r *reducer) toolResultInsertIndex(parentIndex int, parentMessageID string) int {
+	if parentIndex < 0 || parentIndex >= len(r.messages) {
+		return len(r.messages)
+	}
+	index := parentIndex + 1
+	for index < len(r.messages) {
+		message := r.messages[index]
+		if message == nil || message.Role != types.RoleTool || message.ToolCallID == "" {
+			break
+		}
+		state, ok := r.toolCalls[message.ToolCallID]
+		if !ok || state.messageID != parentMessageID {
+			break
+		}
+		index++
+	}
+	return index
+}
+
+func (r *reducer) insertMessage(index int, message *aguievents.Message) {
+	if index < 0 || index >= len(r.messages) {
+		r.messages = append(r.messages, message)
+		return
+	}
+	r.messages = append(r.messages, nil)
+	copy(r.messages[index+1:], r.messages[index:])
+	r.messages[index] = message
+	r.shiftMessageIndexes(index)
+}
+
+func (r *reducer) shiftMessageIndexes(insertIndex int) {
+	for _, state := range r.texts {
+		if state.index >= insertIndex {
+			state.index++
+		}
+	}
+	for _, state := range r.reasonings {
+		if state.index >= insertIndex {
+			state.index++
+		}
+	}
+	for _, state := range r.toolCalls {
+		if state.messageIndex >= insertIndex {
+			state.messageIndex++
+		}
+	}
 }
 
 // handleActivity handles the activity event.

--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -257,10 +257,10 @@ func (r *reducer) finalizePartial() {
 		if state.phase != toolAwaitingArgs || state.content.Len() == 0 {
 			continue
 		}
-		if state.messageIndex < 0 || state.messageIndex >= len(r.messages) {
+		parent, ok := r.toolCallParent(state)
+		if !ok {
 			continue
 		}
-		parent := r.messages[state.messageIndex]
 		if state.index < 0 || state.index >= len(parent.ToolCalls) {
 			continue
 		}
@@ -717,10 +717,10 @@ func (r *reducer) handleToolEnd(e *aguievents.ToolCallEndEvent) error {
 	if state.phase != toolAwaitingArgs {
 		return fmt.Errorf("duplicate tool call end: %s", e.ToolCallID)
 	}
-	if state.messageIndex < 0 || state.messageIndex >= len(r.messages) {
+	parent, ok := r.toolCallParent(state)
+	if !ok {
 		return fmt.Errorf("tool call end missing parent message: %s", state.messageID)
 	}
-	parent := r.messages[state.messageIndex]
 	if state.index < 0 || state.index >= len(parent.ToolCalls) {
 		return fmt.Errorf("tool call end missing parent tool call: %s", e.ToolCallID)
 	}
@@ -738,6 +738,10 @@ func (r *reducer) handleToolResult(e *aguievents.ToolCallResultEvent) error {
 	if !ok || state.phase != toolAwaitingResult {
 		return fmt.Errorf("tool call result without completed call: %s", e.ToolCallID)
 	}
+	parent, ok := r.toolCallParent(state)
+	if !ok {
+		return fmt.Errorf("tool call result missing parent message: %s", state.messageID)
+	}
 	role := string(model.RoleTool)
 	if e.Role != nil && *e.Role != "" {
 		role = *e.Role
@@ -750,14 +754,33 @@ func (r *reducer) handleToolResult(e *aguievents.ToolCallResultEvent) error {
 		Content:    &content,
 		ToolCallID: toolCallID,
 	}
-	r.insertMessage(r.toolResultInsertIndex(state.messageIndex, state.messageID), msg)
+	r.insertMessage(r.toolResultInsertIndex(state.messageIndex, parent, e.ToolCallID), msg)
 	state.phase = toolCompleted
 	return nil
 }
 
-func (r *reducer) toolResultInsertIndex(parentIndex int, parentMessageID string) int {
-	if parentIndex < 0 || parentIndex >= len(r.messages) {
-		return len(r.messages)
+func (r *reducer) toolCallParent(state *toolCallState) (*aguievents.Message, bool) {
+	if state.messageIndex < 0 || state.messageIndex >= len(r.messages) {
+		return nil, false
+	}
+	parent := r.messages[state.messageIndex]
+	if parent == nil || parent.ID != state.messageID {
+		return nil, false
+	}
+	return parent, true
+}
+
+func (r *reducer) toolResultInsertIndex(parentIndex int, parent *aguievents.Message, toolCallID string) int {
+	toolCallOrder := make(map[string]int, len(parent.ToolCalls))
+	targetOrder := -1
+	for i, call := range parent.ToolCalls {
+		toolCallOrder[call.ID] = i
+		if call.ID == toolCallID {
+			targetOrder = i
+		}
+	}
+	if targetOrder < 0 {
+		return parentIndex + 1
 	}
 	index := parentIndex + 1
 	for index < len(r.messages) {
@@ -765,8 +788,8 @@ func (r *reducer) toolResultInsertIndex(parentIndex int, parentMessageID string)
 		if message == nil || message.Role != types.RoleTool || message.ToolCallID == "" {
 			break
 		}
-		state, ok := r.toolCalls[message.ToolCallID]
-		if !ok || state.messageID != parentMessageID {
+		order, ok := toolCallOrder[message.ToolCallID]
+		if !ok || order >= targetOrder {
 			break
 		}
 		index++

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -325,6 +325,23 @@ func TestReduceReasoningMessageLifecycleWithStartEndEvents(t *testing.T) {
 	assert.Equal(t, "summary", content)
 }
 
+func TestReduceReasoningMessageStartContinuesEndedMessage(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
+		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "a"),
+		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", "reasoning"),
+		aguievents.NewReasoningMessageContentEvent("reasoning-msg-1", "b"),
+		aguievents.NewReasoningMessageEndEvent("reasoning-msg-1"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	content, ok := msgs[0].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "ab", content)
+}
+
 func TestReduceReasoningMessageStartDefaultsRole(t *testing.T) {
 	events := trackEventsFrom(
 		aguievents.NewReasoningMessageStartEvent("reasoning-msg-1", ""),
@@ -448,7 +465,7 @@ func TestReduceReasoningMessageChunkUsesPreviousID(t *testing.T) {
 	assert.Equal(t, "ab", content)
 }
 
-func TestReduceReasoningMessageChunkEmptyDeltaClosesMessage(t *testing.T) {
+func TestReduceReasoningMessageChunkContinuesAfterEmptyDelta(t *testing.T) {
 	messageID := "reasoning-msg-1"
 	first := "a"
 	end := ""
@@ -459,12 +476,21 @@ func TestReduceReasoningMessageChunkEmptyDeltaClosesMessage(t *testing.T) {
 	next := aguievents.NewReasoningMessageChunkEvent(&messageID, &after)
 
 	msgs, err := Reduce(testAppName, testUserID, trackEventsFrom(start, close, next))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reasoning message chunk after end: reasoning-msg-1")
+	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	content, ok := msgs[0].ContentString()
 	require.True(t, ok)
-	assert.Equal(t, "a", content)
+	assert.Equal(t, "ab", content)
+}
+
+func TestReduceReasoningMessageChunkRejectsDuplicateEnd(t *testing.T) {
+	messageID := "reasoning-msg-1"
+	first := "a"
+	end := ""
+	start := aguievents.NewReasoningMessageChunkEvent(&messageID, &first)
+	close := aguievents.NewReasoningMessageChunkEvent(&messageID, &end)
+	duplicateClose := aguievents.NewReasoningMessageChunkEvent(&messageID, &end)
+	assertReduceError(t, trackEventsFrom(start, close, duplicateClose), "duplicate reasoning message end: reasoning-msg-1")
 }
 
 func TestReduceReasoningMessageChunkRequiresIDInitially(t *testing.T) {
@@ -640,7 +666,7 @@ func TestHandleTextChunkErrors(t *testing.T) {
 	t.Run("duplicate id", func(t *testing.T) {
 		chunk := aguievents.NewTextMessageChunkEvent(stringPtr("msg-1"), stringPtr("assistant"), stringPtr(""))
 		r := new(testAppName, testUserID, options{})
-		require.NoError(t, r.handleTextChunk(chunk))
+		require.NoError(t, r.handleTextStart(aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant"))))
 		err := r.handleTextChunk(chunk)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate text message chunk: msg-1")
@@ -696,6 +722,44 @@ func TestReduceInterleavedTextMessageEvents(t *testing.T) {
 	contentB, ok := msgs[1].ContentString()
 	require.True(t, ok)
 	assert.Equal(t, "b1b2", contentB)
+}
+
+func TestReduceTextMessageStartContinuesEndedMessage(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewTextMessageStartEvent("msg-a", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("msg-a", "a1"),
+		aguievents.NewTextMessageEndEvent("msg-a"),
+		aguievents.NewTextMessageStartEvent("msg-b", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("msg-b", "b1"),
+		aguievents.NewTextMessageEndEvent("msg-b"),
+		aguievents.NewTextMessageStartEvent("msg-a", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("msg-a", "a2"),
+		aguievents.NewTextMessageEndEvent("msg-a"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "msg-a", msgs[0].ID)
+	contentA, ok := msgs[0].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "a1a2", contentA)
+	assert.Equal(t, "msg-b", msgs[1].ID)
+	contentB, ok := msgs[1].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "b1", contentB)
+}
+
+func TestReduceTextMessageChunkContinuesEndedMessage(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewTextMessageChunkEvent(stringPtr("msg-1"), stringPtr("assistant"), stringPtr("a")),
+		aguievents.NewTextMessageChunkEvent(stringPtr("msg-1"), stringPtr("assistant"), stringPtr("b")),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	content, ok := msgs[0].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "ab", content)
 }
 
 func TestAssistantOnlyToolCall(t *testing.T) {
@@ -754,6 +818,65 @@ func TestAssistantInterleavesTextAfterToolEnd(t *testing.T) {
 	assert.Equal(t, "done", content)
 	require.NotNil(t, tool.ToolCallID)
 	assert.Equal(t, "tool-call-1", tool.ToolCallID)
+}
+
+func TestReduceToolStartParentCanReceiveLaterTextStart(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewToolCallStartEvent("tool-call-1", "search", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewToolCallArgsEvent("tool-call-1", "{\"q\":\"hi\"}"),
+		aguievents.NewToolCallEndEvent("tool-call-1"),
+		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("assistant-1", "checking"),
+		aguievents.NewTextMessageEndEvent("assistant-1"),
+		aguievents.NewToolCallResultEvent("tool-msg-1", "tool-call-1", "done"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assistant := msgs[0]
+	assert.Equal(t, "assistant-1", assistant.ID)
+	content, ok := assistant.ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "checking", content)
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, "search", assistant.ToolCalls[0].Function.Name)
+	assert.Equal(t, "{\"q\":\"hi\"}", assistant.ToolCalls[0].Function.Arguments)
+	tool := msgs[1]
+	assert.Equal(t, types.RoleTool, tool.Role)
+	assert.Equal(t, "tool-call-1", tool.ToolCallID)
+}
+
+func TestReduceToolStartParentRequiresTextStartBeforeContent(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewToolCallStartEvent("tool-call-1", "search", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewTextMessageContentEvent("assistant-1", "late"),
+	)
+	assertReduceError(t, events, "text message content without start: assistant-1")
+}
+
+func TestReduceToolResultInsertedAfterOwnerAssistant(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+		aguievents.NewToolCallStartEvent("tool-call-1", "search", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewToolCallArgsEvent("tool-call-1", "{\"q\":\"hi\"}"),
+		aguievents.NewToolCallEndEvent("tool-call-1"),
+		aguievents.NewTextMessageEndEvent("assistant-1"),
+		aguievents.NewTextMessageStartEvent("assistant-2", aguievents.WithRole("assistant")),
+		aguievents.NewTextMessageContentEvent("assistant-2", "next"),
+		aguievents.NewToolCallResultEvent("tool-msg-1", "tool-call-1", "done"),
+		aguievents.NewTextMessageEndEvent("assistant-2"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "assistant-1", msgs[0].ID)
+	assert.Equal(t, "tool-msg-1", msgs[1].ID)
+	assert.Equal(t, types.RoleTool, msgs[1].Role)
+	assert.Equal(t, "tool-call-1", msgs[1].ToolCallID)
+	assert.Equal(t, "assistant-2", msgs[2].ID)
+	content, ok := msgs[2].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "next", content)
 }
 
 func TestAssistantMultipleToolCalls(t *testing.T) {
@@ -817,6 +940,15 @@ func TestReduceTextStartErrors(t *testing.T) {
 				aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")),
 			),
 			want: "duplicate text message start: msg-1",
+		},
+		{
+			name: "identity mismatch after end",
+			events: trackEventsFrom(
+				aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("user")),
+				aguievents.NewTextMessageEndEvent("msg-1"),
+				aguievents.NewTextMessageStartEvent("msg-1", aguievents.WithRole("assistant")),
+			),
+			want: "text message identity mismatch: msg-1",
 		},
 		{
 			name:   "unsupported role",

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -879,6 +879,74 @@ func TestReduceToolResultInsertedAfterOwnerAssistant(t *testing.T) {
 	assert.Equal(t, "next", content)
 }
 
+func TestReduceToolResultsKeepOwnerOrderAcrossRunBoundaries(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewRunStartedEvent("thread", "run-1"),
+		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+		aguievents.NewToolCallStartEvent("call-1", "first", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewToolCallArgsEvent("call-1", "{\"step\":1}"),
+		aguievents.NewToolCallEndEvent("call-1"),
+		aguievents.NewToolCallStartEvent("call-2", "second", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewToolCallArgsEvent("call-2", "{\"step\":2}"),
+		aguievents.NewToolCallEndEvent("call-2"),
+		aguievents.NewTextMessageEndEvent("assistant-1"),
+		aguievents.NewRunFinishedEvent("thread", "run-1"),
+		aguievents.NewRunStartedEvent("thread", "run-2"),
+		aguievents.NewToolCallResultEvent("tool-msg-1", "call-1", "first-result"),
+		aguievents.NewRunFinishedEvent("thread", "run-2"),
+		aguievents.NewRunStartedEvent("thread", "run-3"),
+		aguievents.NewToolCallResultEvent("tool-msg-2", "call-2", "second-result"),
+		aguievents.NewRunFinishedEvent("thread", "run-3"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	// Assert that tool result siblings stay in parent ToolCalls order after pruning.
+	assistant := msgs[0]
+	require.Len(t, assistant.ToolCalls, 2)
+	assert.Equal(t, "call-1", assistant.ToolCalls[0].ID)
+	assert.Equal(t, "call-2", assistant.ToolCalls[1].ID)
+	assert.Equal(t, "tool-msg-1", msgs[1].ID)
+	assert.Equal(t, types.RoleTool, msgs[1].Role)
+	assert.Equal(t, "call-1", msgs[1].ToolCallID)
+	firstContent, ok := msgs[1].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "first-result", firstContent)
+	assert.Equal(t, "tool-msg-2", msgs[2].ID)
+	assert.Equal(t, types.RoleTool, msgs[2].Role)
+	assert.Equal(t, "call-2", msgs[2].ToolCallID)
+	secondContent, ok := msgs[2].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "second-result", secondContent)
+}
+
+func TestReduceToolResultInsertionShiftsOpenReasoningIndex(t *testing.T) {
+	events := trackEventsFrom(
+		aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+		aguievents.NewToolCallStartEvent("call-1", "search", aguievents.WithParentMessageID("assistant-1")),
+		aguievents.NewToolCallArgsEvent("call-1", "{\"q\":\"hi\"}"),
+		aguievents.NewToolCallEndEvent("call-1"),
+		aguievents.NewTextMessageEndEvent("assistant-1"),
+		aguievents.NewReasoningMessageStartEvent("reasoning-1", "reasoning"),
+		aguievents.NewToolCallResultEvent("tool-msg-1", "call-1", "done"),
+		aguievents.NewReasoningMessageContentEvent("reasoning-1", "thinking"),
+		aguievents.NewReasoningMessageEndEvent("reasoning-1"),
+	)
+	msgs, err := Reduce(testAppName, testUserID, events)
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "assistant-1", msgs[0].ID)
+	assert.Equal(t, "tool-msg-1", msgs[1].ID)
+	toolContent, ok := msgs[1].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "done", toolContent)
+	assert.Equal(t, "reasoning-1", msgs[2].ID)
+	assert.Equal(t, types.RoleReasoning, msgs[2].Role)
+	reasoningContent, ok := msgs[2].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "thinking", reasoningContent)
+}
+
 func TestAssistantMultipleToolCalls(t *testing.T) {
 	events := []session.TrackEvent{
 		newTrackEvent(aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))),

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -259,8 +259,8 @@ func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 }
 
 // WithConcurrentMessageStreamsEnabled controls whether text and reasoning
-// message streams are scoped by message ID. Disable it for legacy serial
-// message-stream boundaries.
+// message streams are scoped by message ID. It is enabled by default; pass false
+// to preserve the previous legacy serial message-stream boundaries.
 func WithConcurrentMessageStreamsEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithConcurrentMessageStreamsEnabled(enabled))

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -258,8 +258,9 @@ func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 	}
 }
 
-// WithConcurrentMessageStreamsEnabled controls whether multiple text and reasoning
-// message streams with different message IDs may stay open concurrently.
+// WithConcurrentMessageStreamsEnabled controls whether text and reasoning
+// message streams are scoped by message ID. Disable it for legacy serial
+// message-stream boundaries.
 func WithConcurrentMessageStreamsEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithConcurrentMessageStreamsEnabled(enabled))

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -184,9 +184,9 @@ func TestWithStreamingToolResultActivityEnabled(t *testing.T) {
 }
 
 func TestWithConcurrentMessageStreamsEnabled(t *testing.T) {
-	opts := newOptions(WithConcurrentMessageStreamsEnabled(true))
+	opts := newOptions(WithConcurrentMessageStreamsEnabled(false))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
-	assert.True(t, ro.ConcurrentMessageStreamsEnabled)
+	assert.False(t, ro.ConcurrentMessageStreamsEnabled)
 }
 
 func TestWithMessagesSnapshotFollowEnabled(t *testing.T) {

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -346,8 +346,8 @@ func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 }
 
 // WithConcurrentMessageStreamsEnabled controls whether text and reasoning
-// message streams are scoped by message ID. Disable it for legacy serial
-// message-stream boundaries.
+// message streams are scoped by message ID. It is enabled by default; pass false
+// to preserve the previous legacy serial message-stream boundaries.
 func WithConcurrentMessageStreamsEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.ConcurrentMessageStreamsEnabled = enabled

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -34,7 +34,7 @@ const (
 	defaultToolResultInputTranslationEnabled      = false
 	defaultToolCallDeltaStreamingEnabled          = false
 	defaultStreamingToolResultActivityEnabled     = false
-	defaultConcurrentMessageStreamsEnabled        = false
+	defaultConcurrentMessageStreamsEnabled        = true
 	defaultDistributedCancelEnabled               = false
 	defaultDistributedCancelPollInterval          = time.Second
 )
@@ -345,8 +345,9 @@ func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 	}
 }
 
-// WithConcurrentMessageStreamsEnabled controls whether multiple text and reasoning
-// message streams with different message IDs may stay open concurrently.
+// WithConcurrentMessageStreamsEnabled controls whether text and reasoning
+// message streams are scoped by message ID. Disable it for legacy serial
+// message-stream boundaries.
 func WithConcurrentMessageStreamsEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.ConcurrentMessageStreamsEnabled = enabled

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -83,7 +83,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.ToolResultInputTranslationEnabled)
 	assert.False(t, opts.ToolCallDeltaStreamingEnabled)
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
-	assert.False(t, opts.ConcurrentMessageStreamsEnabled)
+	assert.True(t, opts.ConcurrentMessageStreamsEnabled)
 	assert.False(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
 	assert.False(t, opts.DistributedCancelEnabled)
 	assert.Equal(t, time.Second, opts.DistributedCancelPollInterval)
@@ -192,12 +192,12 @@ func TestWithStreamingToolResultActivityEnabled(t *testing.T) {
 }
 
 func TestWithConcurrentMessageStreamsEnabled(t *testing.T) {
-	opts := NewOptions(WithConcurrentMessageStreamsEnabled(true))
-	assert.True(t, opts.ConcurrentMessageStreamsEnabled)
-	run := New(nil, WithConcurrentMessageStreamsEnabled(true))
+	opts := NewOptions(WithConcurrentMessageStreamsEnabled(false))
+	assert.False(t, opts.ConcurrentMessageStreamsEnabled)
+	run := New(nil, WithConcurrentMessageStreamsEnabled(false))
 	impl, ok := run.(*runner)
 	require.True(t, ok)
-	assert.True(t, impl.concurrentMessageStreamsEnabled)
+	assert.False(t, impl.concurrentMessageStreamsEnabled)
 }
 
 func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {

--- a/server/agui/translator/a2ui/translator.go
+++ b/server/agui/translator/a2ui/translator.go
@@ -33,6 +33,7 @@ func NewFactory(innerFactory runner.TranslatorFactory, baseOpts []translator.Opt
 	}
 	return func(ctx context.Context, input *adapter.RunAgentInput, opts ...translator.Option) (translator.Translator, error) {
 		allOpts := append(slices.Clone(baseOpts), opts...)
+		allOpts = append(allOpts, translator.WithConcurrentMessageStreamsEnabled(false))
 		inner, err := innerFactory(ctx, input, allOpts...)
 		if err != nil {
 			return nil, err

--- a/server/agui/translator/a2ui/translator_test.go
+++ b/server/agui/translator/a2ui/translator_test.go
@@ -95,7 +95,7 @@ func TestNewFactory(t *testing.T) {
 	}, translator.WithGraphNodeLifecycleActivityEnabled(true))
 	assert.NoError(t, err)
 	assert.NotNil(t, translated)
-	assert.Len(t, receivedOpts, 1)
+	assert.Len(t, receivedOpts, 2)
 }
 
 func TestNewFactoryNilInnerFactory(t *testing.T) {

--- a/server/agui/translator/a2ui/translator_test.go
+++ b/server/agui/translator/a2ui/translator_test.go
@@ -15,7 +15,9 @@ import (
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	agentevent "trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
 )
@@ -81,21 +83,43 @@ func makeStreamingTextEvents() [][]aguievents.Event {
 }
 
 func TestNewFactory(t *testing.T) {
-	inner := &fakeTranslator{
-		events: makeTextEvents(),
-	}
-	var receivedOpts []translator.Option
 	factory := NewFactory(func(_ context.Context, _ *adapter.RunAgentInput, topts ...translator.Option) (translator.Translator, error) {
-		receivedOpts = append(receivedOpts, topts...)
-		return inner, nil
+		return translator.New(context.Background(), "thread", "run", topts...)
 	}, nil)
 	translated, err := factory(context.Background(), &adapter.RunAgentInput{
 		ThreadID: "thread",
 		RunID:    "run",
 	}, translator.WithGraphNodeLifecycleActivityEnabled(true))
-	assert.NoError(t, err)
-	assert.NotNil(t, translated)
-	assert.Len(t, receivedOpts, 2)
+	require.NoError(t, err)
+	require.NotNil(t, translated)
+	// Assert that the wrapper applies serial boundaries before A2UI parsing.
+	first, err := translated.Translate(context.Background(), streamingJSONTextEvent("msg-1", `{"type":"a"}`+"\n"))
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	firstRaw, ok := first[0].(*aguievents.RawEvent)
+	require.True(t, ok)
+	assert.Equal(t, "a", firstRaw.Event.(map[string]any)["type"])
+	second, err := translated.Translate(context.Background(), streamingJSONTextEvent("msg-2", `{"type":"b"}`+"\n"))
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	secondRaw, ok := second[0].(*aguievents.RawEvent)
+	require.True(t, ok)
+	assert.Equal(t, "b", secondRaw.Event.(map[string]any)["type"])
+}
+
+func streamingJSONTextEvent(messageID, content string) *agentevent.Event {
+	return &agentevent.Event{
+		Response: &model.Response{
+			ID:     messageID,
+			Object: model.ObjectTypeChatCompletionChunk,
+			Choices: []model.Choice{{
+				Delta: model.Message{
+					Role:    model.RoleAssistant,
+					Content: content,
+				},
+			}},
+		},
+	}
 }
 
 func TestNewFactoryNilInnerFactory(t *testing.T) {

--- a/server/agui/translator/message_lifecycle.go
+++ b/server/agui/translator/message_lifecycle.go
@@ -53,9 +53,7 @@ func (t *translator) closeTextStreamsBeforeQueuedUserMessage() []aguievents.Even
 
 func (t *translator) closeTextStreamsBeforeToolEvent() []aguievents.Event {
 	if t.concurrentMessageStreamsEnabled {
-		events := t.closeOpenTextStreams()
-		t.clearGraphTextAppendTarget()
-		return events
+		return nil
 	}
 	return t.closeCurrentTextStream()
 }
@@ -245,9 +243,6 @@ func (t *translator) concurrentReasoningEvents(rsp *model.Response) ([]aguievent
 		if t.reasoningStreams.isOpen(reasoningID) {
 			shouldEnd := false
 			if contentDelta != "" {
-				shouldEnd = true
-			}
-			if rsp.IsToolCallResponse() {
 				shouldEnd = true
 			}
 			if choice.FinishReason != nil && *choice.FinishReason != "" {

--- a/server/agui/translator/options.go
+++ b/server/agui/translator/options.go
@@ -93,8 +93,8 @@ func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 }
 
 // WithConcurrentMessageStreamsEnabled controls whether text and reasoning
-// message streams are scoped by message ID. Disable it for legacy serial
-// message-stream boundaries.
+// message streams are scoped by message ID. It is enabled by default; pass false
+// to preserve the previous legacy serial message-stream boundaries.
 func WithConcurrentMessageStreamsEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.concurrentMessageStreamsEnabled = enabled

--- a/server/agui/translator/options.go
+++ b/server/agui/translator/options.go
@@ -18,7 +18,7 @@ type options struct {
 	eventSourceMetadataEnabled             bool // eventSourceMetadataEnabled attaches trpc-agent-go source metadata to translated AG-UI events.
 	toolCallDeltaStreamingEnabled          bool // toolCallDeltaStreamingEnabled streams partial tool-call arguments.
 	streamingToolResultActivityEnabled     bool // streamingToolResultActivityEnabled rewrites partial tool results as activity events.
-	concurrentMessageStreamsEnabled        bool // concurrentMessageStreamsEnabled keeps multiple message streams open by message ID.
+	concurrentMessageStreamsEnabled        bool // concurrentMessageStreamsEnabled scopes message streams by message ID.
 }
 
 // Option is a function that configures the options.
@@ -26,7 +26,9 @@ type Option func(*options)
 
 // newOptions creates a new options instance.
 func newOptions(opt ...Option) options {
-	opts := options{}
+	opts := options{
+		concurrentMessageStreamsEnabled: true,
+	}
 	for _, o := range opt {
 		o(&opts)
 	}
@@ -90,8 +92,9 @@ func WithStreamingToolResultActivityEnabled(enabled bool) Option {
 	}
 }
 
-// WithConcurrentMessageStreamsEnabled controls whether multiple text and reasoning
-// message streams with different message IDs may stay open concurrently.
+// WithConcurrentMessageStreamsEnabled controls whether text and reasoning
+// message streams are scoped by message ID. Disable it for legacy serial
+// message-stream boundaries.
 func WithConcurrentMessageStreamsEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.concurrentMessageStreamsEnabled = enabled

--- a/server/agui/translator/translator_test.go
+++ b/server/agui/translator/translator_test.go
@@ -750,8 +750,8 @@ func TestTranslateErrorObservationClosesOnTerminalError(t *testing.T) {
 	assert.Equal(t, "final failure", runErr.Message)
 }
 
-func TestTranslateAssistantToolAssistantClosesTextBoundary(t *testing.T) {
-	translator := newTranslatorForTest(t)
+func TestTranslateAssistantToolAssistantClosesTextBoundaryWhenConcurrentDisabled(t *testing.T) {
+	translator := newTranslatorForTest(t, WithConcurrentMessageStreamsEnabled(false))
 	if translator == nil {
 		return
 	}
@@ -1269,6 +1269,41 @@ func TestTextMessageEventInterleavedStreamsEndOnOwnFinishReason(t *testing.T) {
 	endB, ok := allEvents[7].(*aguievents.TextMessageEndEvent)
 	require.True(t, ok)
 	assert.Equal(t, "msg-b", endB.MessageID)
+}
+
+func TestTranslateInterleavedTextStreamsDefaultKeepsPreviousMessageOpen(t *testing.T) {
+	translator := newTranslatorImplForTest(t)
+	if translator == nil {
+		return
+	}
+	first := &model.Response{
+		ID:     "msg-a",
+		Object: model.ObjectTypeChatCompletionChunk,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, Content: "a1"},
+		}},
+	}
+	events, err := translator.Translate(context.Background(), &agentevent.Event{Response: first})
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	next := &model.Response{
+		ID:     "msg-b",
+		Object: model.ObjectTypeChatCompletionChunk,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, Content: "b1"},
+		}},
+	}
+	events, err = translator.Translate(context.Background(), &agentevent.Event{Response: next})
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	start, ok := events[0].(*aguievents.TextMessageStartEvent)
+	require.True(t, ok)
+	assert.Equal(t, "msg-b", start.MessageID)
+	content, ok := events[1].(*aguievents.TextMessageContentEvent)
+	require.True(t, ok)
+	assert.Equal(t, "msg-b", content.MessageID)
+	assert.True(t, translator.textStreams.isOpen("msg-a"))
+	assert.True(t, translator.textStreams.isOpen("msg-b"))
 }
 
 func TestTextMessageEventConcurrentModeSkipsEmptyResponseID(t *testing.T) {
@@ -2767,6 +2802,36 @@ func TestTranslateToolResultResponse(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
+	assert.Len(t, events, 1)
+	result, ok := events[0].(*aguievents.ToolCallResultEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "evt-tool-1", result.MessageID)
+	assert.Equal(t, "tool-1", result.ToolCallID)
+	assert.Equal(t, "done", result.Content)
+}
+
+func TestTranslateToolResultResponseClosesOpenTextStreamWhenConcurrentDisabled(t *testing.T) {
+	translator := newTranslatorForTest(t, WithConcurrentMessageStreamsEnabled(false))
+	if translator == nil {
+		return
+	}
+	_, err := translator.Translate(context.Background(), &agentevent.Event{Response: &model.Response{
+		ID:     "msg-1",
+		Object: model.ObjectTypeChatCompletionChunk,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, Content: "partial"},
+		}},
+	}})
+	assert.NoError(t, err)
+	events, err := translator.Translate(context.Background(), &agentevent.Event{
+		ID: "evt-tool-1",
+		Response: &model.Response{
+			Choices: []model.Choice{{
+				Message: model.Message{ToolID: "tool-1", Content: "done"},
+			}},
+		},
+	})
+	assert.NoError(t, err)
 	assert.Len(t, events, 2)
 	endText, ok := events[0].(*aguievents.TextMessageEndEvent)
 	assert.True(t, ok)
@@ -3063,8 +3128,11 @@ func TestTranslateReasoningStreamingDoesNotDuplicateOnFinalCompletion(t *testing
 	assert.Empty(t, events)
 }
 
-func TestTranslateReasoningStreamEndsOnToolCall(t *testing.T) {
-	tr := newTranslatorImplForTest(t, WithReasoningContentEnabled(true))
+func TestTranslateReasoningStreamEndsOnToolCallWhenConcurrentDisabled(t *testing.T) {
+	tr := newTranslatorImplForTest(t,
+		WithReasoningContentEnabled(true),
+		WithConcurrentMessageStreamsEnabled(false),
+	)
 	if tr == nil {
 		return
 	}
@@ -3085,7 +3153,7 @@ func TestTranslateReasoningStreamEndsOnToolCall(t *testing.T) {
 		ID:     "msg-1",
 		Object: model.ObjectTypeChatCompletionChunk,
 		Choices: []model.Choice{{
-			Delta: model.Message{
+			Message: model.Message{
 				Role: model.RoleAssistant,
 				ToolCalls: []model.ToolCall{{
 					ID:   "tool-1",
@@ -3105,6 +3173,53 @@ func TestTranslateReasoningStreamEndsOnToolCall(t *testing.T) {
 	assert.IsType(t, (*aguievents.ReasoningMessageEndEvent)(nil), events[0])
 	assert.IsType(t, (*aguievents.ReasoningEndEvent)(nil), events[1])
 	assert.False(t, tr.receivingReasoning)
+}
+
+func TestTranslateReasoningStreamStaysOpenOnToolCallByDefault(t *testing.T) {
+	tr := newTranslatorImplForTest(t, WithReasoningContentEnabled(true))
+	if tr == nil {
+		return
+	}
+	first := &model.Response{
+		ID:     "msg-1",
+		Object: model.ObjectTypeChatCompletionChunk,
+		Choices: []model.Choice{{
+			Delta: model.Message{Role: model.RoleAssistant, ReasoningContent: "think"},
+		}},
+		IsPartial: true,
+	}
+	events, err := tr.Translate(context.Background(), &agentevent.Event{Response: first})
+	assert.NoError(t, err)
+	assert.Len(t, events, 3)
+	assert.True(t, tr.receivingReasoning)
+	reasoningID := reasoningMessageID(first.ID)
+	assert.True(t, tr.reasoningStreams.isOpen(reasoningID))
+	toolCallRsp := &model.Response{
+		ID:     "msg-1",
+		Object: model.ObjectTypeChatCompletionChunk,
+		Choices: []model.Choice{{
+			Message: model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID:   "tool-1",
+					Type: "function",
+					Function: model.FunctionDefinitionParam{
+						Name:      "tool",
+						Arguments: []byte(`{}`),
+					},
+				}},
+			},
+		}},
+		IsPartial: true,
+	}
+	events, err = tr.Translate(context.Background(), &agentevent.Event{Response: toolCallRsp})
+	assert.NoError(t, err)
+	assert.Len(t, events, 3)
+	assert.IsType(t, (*aguievents.ToolCallStartEvent)(nil), events[0])
+	assert.IsType(t, (*aguievents.ToolCallArgsEvent)(nil), events[1])
+	assert.IsType(t, (*aguievents.ToolCallEndEvent)(nil), events[2])
+	assert.True(t, tr.receivingReasoning)
+	assert.True(t, tr.reasoningStreams.isOpen(reasoningID))
 }
 
 func TestTranslateReasoningStreamEndsOnFinishReason(t *testing.T) {
@@ -3143,7 +3258,10 @@ func TestTranslateReasoningStreamEndsOnFinishReason(t *testing.T) {
 }
 
 func TestTranslateReasoningStreamClosesOnIDChange(t *testing.T) {
-	tr := newTranslatorImplForTest(t, WithReasoningContentEnabled(true))
+	tr := newTranslatorImplForTest(t,
+		WithReasoningContentEnabled(true),
+		WithConcurrentMessageStreamsEnabled(false),
+	)
 	if tr == nil {
 		return
 	}
@@ -4582,7 +4700,7 @@ func TestGraphNodeCustomEvents_TextCategory_NotReceivingMessage(t *testing.T) {
 }
 
 func TestGraphNodeCustomEvents_TextCategory_WhileReceivingMessage(t *testing.T) {
-	translator := newTranslatorImplForTest(t)
+	translator := newTranslatorImplForTest(t, WithConcurrentMessageStreamsEnabled(false))
 	if translator == nil {
 		return
 	}


### PR DESCRIPTION
This updates AG-UI translation to keep text and reasoning streams scoped by message ID by default, avoids closing open streams around tool events, and keeps A2UI on the legacy serial path. It also teaches message snapshot reduction to merge ended stream continuations, preserve strict active-duplicate validation, support tool-first assistant placeholders, and place tool results next to their owning assistant message.