### PR TITLE
feat(sandbox): add controlled Linux network egress

### DIFF
--- a/codeexecutor/sandbox/backend_linux.go
+++ b/codeexecutor/sandbox/backend_linux.go
@@ -113,8 +113,8 @@ func openLinuxSandboxExtraFiles(setup linuxSandboxSetup) ([]*os.File, commandCle
 			files[i] = nil
 		}
 	}
-	// Append order must match linuxSandboxSetup descriptor numbering: ExtraFiles[i]
-	// becomes child FD 3+i (seccomp then deny-read /dev/null when both are needed).
+	// Append order must match linuxSandboxSetup descriptor numbering:
+	// ExtraFiles[i] becomes child FD 3+i (seccomp, then deny-read /dev/null).
 	if setup.needsSeccompFD {
 		seccompFile, err := openSeccompFilterMemfd()
 		if err != nil {
@@ -191,13 +191,22 @@ func (r *Runtime) linuxSandboxSetup(
 	} else {
 		args = appendInaccessibleDirMaskArgs(args, "/proc")
 	}
-	needsSeccomp := profile.network.Mode != NetworkEnabled
+	plan, err := resolveNetworkPolicy(profile)
+	if err != nil {
+		return linuxSandboxSetup{}, err
+	}
+	needsSeccomp := plan.isolateNetwork
 	// ExtraFiles descriptors start at 3 and must match the append order in
 	// openLinuxSandboxExtraFiles: seccomp memfd first, then deny-read /dev/null.
 	nextExtraFD := 3
+	seccompFD := -1
 	if needsSeccomp {
-		args = append(args, "--unshare-net", "--seccomp", strconv.Itoa(nextExtraFD))
+		seccompFD = nextExtraFD
 		nextExtraFD++
+		args = append(args, "--unshare-net")
+		if plan.mode != NetworkControlled {
+			args = append(args, "--seccomp", strconv.Itoa(seccompFD))
+		}
 	}
 	grantArgs, err := r.externalGrantArgs(profile, ws)
 	if err != nil {
@@ -225,6 +234,33 @@ func (r *Runtime) linuxSandboxSetup(
 		return linuxSandboxSetup{}, err
 	}
 	args = append(args, denySetup.args...)
+	if plan.mode == NetworkControlled {
+		socketPath, err := r.validateControlledEgressSocketPath(profile, ws, plan.unixPath)
+		if err != nil {
+			return linuxSandboxSetup{}, err
+		}
+		plan.unixPath = socketPath
+		relayPath := r.egressRelayPath
+		if relayPath == "" {
+			relayPath = os.Getenv("TRPC_AGENT_EGRESS_RELAY")
+		}
+		relayPath, err = r.validateControlledEgressRelayPath(profile, ws, relayPath)
+		if err != nil {
+			return linuxSandboxSetup{}, err
+		}
+		env = applyControlledEgressEnv(env, plan)
+		spec, err = wrapControlledEgressSpec(
+			plan,
+			relayPath,
+			r.bwrapPath,
+			seccompFD,
+			mountProc,
+			spec,
+		)
+		if err != nil {
+			return linuxSandboxSetup{}, err
+		}
+	}
 	args = append(args, "--clearenv")
 	for _, kv := range env {
 		k, v, ok := strings.Cut(kv, "=")
@@ -1057,4 +1093,163 @@ func (r *Runtime) workspaceMountTarget(
 	default:
 		return "", false, nil
 	}
+}
+
+func (r *Runtime) validateControlledEgressSocketPath(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+	unixPath string,
+) (string, error) {
+	socketAbs, err := filepath.Abs(unixPath)
+	if err != nil {
+		return "", deniedf(
+			ErrPolicyViolation,
+			"network",
+			unixPath,
+			"resolve controlled egress UnixPath: %v",
+			err,
+		)
+	}
+	writeTargets, err := r.linuxWriteMountTargets(profile, ws)
+	if err != nil {
+		return "", err
+	}
+	for _, target := range writeTargets {
+		targetAbs, err := filepath.Abs(target)
+		if err != nil {
+			return "", err
+		}
+		if sameOrChild(targetAbs, socketAbs) {
+			return "", deniedf(
+				ErrPolicyViolation,
+				"network",
+				socketAbs,
+				"controlled egress UnixPath must be outside guest-writable mounts",
+			)
+		}
+	}
+	socketResolved, err := resolveControlledEgressSocketPath(socketAbs)
+	if err != nil {
+		return "", deniedf(
+			ErrPolicyViolation,
+			"network",
+			socketAbs,
+			"resolve controlled egress UnixPath symlinks: %v",
+			err,
+		)
+	}
+	for _, target := range writeTargets {
+		targetAbs, err := filepath.Abs(target)
+		if err != nil {
+			return "", err
+		}
+		targetResolved, err := filepath.EvalSymlinks(targetAbs)
+		if err != nil {
+			return "", deniedf(
+				ErrPolicyViolation,
+				"network",
+				targetAbs,
+				"resolve guest-writable mount symlinks: %v",
+				err,
+			)
+		}
+		if sameOrChild(targetResolved, socketResolved) {
+			return "", deniedf(
+				ErrPolicyViolation,
+				"network",
+				socketAbs,
+				"controlled egress UnixPath must be outside guest-writable mounts",
+			)
+		}
+	}
+	return socketResolved, nil
+}
+
+func resolveControlledEgressSocketPath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	current := path
+	for i := 0; i < 255; i++ {
+		target, changed, resolveErr := resolvePotentialSymlinkTarget(current)
+		if resolveErr != nil {
+			return "", resolveErr
+		}
+		if !changed {
+			return current, nil
+		}
+		current = target
+		resolved, err = filepath.EvalSymlinks(current)
+		if err == nil {
+			return resolved, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("too many symlinks resolving %q", path)
+}
+
+func (r *Runtime) validateControlledEgressRelayPath(
+	profile PermissionProfile,
+	ws codeexecutor.Workspace,
+	relayPath string,
+) (string, error) {
+	if relayPath == "" {
+		return "", deniedf(
+			ErrSetupFailed,
+			"network",
+			"",
+			"controlled egress requires egress-relay helper (WithControlledEgressRelayPath or TRPC_AGENT_EGRESS_RELAY)",
+		)
+	}
+	relayAbs, err := filepath.Abs(relayPath)
+	if err != nil {
+		return "", deniedf(ErrSetupFailed, "network", relayPath, "resolve relay path: %v", err)
+	}
+	relayResolved, err := filepath.EvalSymlinks(relayAbs)
+	if err != nil {
+		return "", deniedf(ErrSetupFailed, "network", relayAbs, "resolve relay path symlinks: %v", err)
+	}
+	st, err := os.Stat(relayResolved)
+	if err != nil || !st.Mode().IsRegular() {
+		return "", deniedf(ErrSetupFailed, "network", relayResolved, "egress-relay helper not found")
+	}
+	if st.Mode().Perm()&0o111 == 0 {
+		return "", deniedf(ErrSetupFailed, "network", relayResolved, "egress-relay helper is not executable")
+	}
+	writeTargets, err := r.linuxWriteMountTargets(profile, ws)
+	if err != nil {
+		return "", err
+	}
+	for _, target := range writeTargets {
+		targetAbs, err := filepath.Abs(target)
+		if err != nil {
+			return "", err
+		}
+		targetResolved, err := filepath.EvalSymlinks(targetAbs)
+		if err != nil {
+			return "", deniedf(
+				ErrPolicyViolation,
+				"network",
+				targetAbs,
+				"resolve guest-writable mount symlinks: %v",
+				err,
+			)
+		}
+		if sameOrChild(targetAbs, relayAbs) ||
+			sameOrChild(targetResolved, relayResolved) {
+			return "", deniedf(
+				ErrSetupFailed,
+				"network",
+				relayResolved,
+				"egress-relay helper must be outside guest-writable mounts",
+			)
+		}
+	}
+	return relayResolved, nil
 }

--- a/codeexecutor/sandbox/backend_macos.go
+++ b/codeexecutor/sandbox/backend_macos.go
@@ -51,6 +51,13 @@ func (r *Runtime) osSandboxCommand(
 	spec codeexecutor.RunProgramSpec,
 	diagnostics sandboxDenialRun,
 ) (*exec.Cmd, string, commandCleanup, error) {
+	if profile.network.Mode == NetworkControlled {
+		return nil, string(BackendMacOSSandboxExec), nil, backendError(
+			ErrUnsupportedBackend,
+			string(BackendMacOSSandboxExec),
+			errors.New("controlled egress is not implemented on macOS"),
+		)
+	}
 	seatbelt, err := r.macosPreflightContext(ctx)
 	if err != nil {
 		return nil, string(BackendMacOSSandboxExec), nil, err

--- a/codeexecutor/sandbox/cmd/egress-relay/main.go
+++ b/codeexecutor/sandbox/cmd/egress-relay/main.go
@@ -1,0 +1,219 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Command egress-relay starts a trusted in-sandbox loopback→Unix bridge, then
+// runs the user command in a nested bubblewrap process with seccomp applied.
+// The relay starts before seccomp and remains outside the workload PID
+// namespace.
+//
+// Exit codes:
+//   - 2  usage error
+//   - 75 relay setup failure (listen/start)
+//   - other: user command exit code
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox/controlledegress"
+)
+
+const setupTokenBytes = 16
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr, runCommand))
+}
+
+type workloadRunner func(
+	args []string,
+	bwrapPath string,
+	seccompFD int,
+	mountProc bool,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+) int
+
+func run(
+	args []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	execute workloadRunner,
+) int {
+	flags := flag.NewFlagSet("egress-relay", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	unixPath := flags.String(
+		"unix",
+		"",
+		"host controlled-egress proxy Unix socket",
+	)
+	bwrapPath := flags.String(
+		"bwrap",
+		"",
+		"trusted absolute bubblewrap path",
+	)
+	seccompFD := flags.Int(
+		"seccomp-fd",
+		-1,
+		"inherited workload seccomp descriptor",
+	)
+	setupToken := flags.String(
+		"setup-token",
+		"",
+		"host-generated relay setup authentication token",
+	)
+	mountProc := flags.Bool(
+		"mount-proc",
+		false,
+		"mount a fresh procfs in the workload PID namespace",
+	)
+	port := flags.Int(
+		"port",
+		controlledegress.DefaultRelayPort,
+		"loopback listen port",
+	)
+	if err := flags.Parse(args); err != nil {
+		writeSetupError(stderr, *setupToken, "%v", err)
+		return controlledegress.ExitUsageError
+	}
+	command := flags.Args()
+	if *unixPath == "" || *bwrapPath == "" || *seccompFD < 3 ||
+		!validSetupToken(*setupToken) || len(command) == 0 {
+		writeSetupError(
+			stderr,
+			*setupToken,
+			"usage: egress-relay -unix PATH -bwrap PATH "+
+				"-seccomp-fd FD -setup-token TOKEN "+
+				"[-port PORT] -- COMMAND [ARGS...]",
+		)
+		return controlledegress.ExitUsageError
+	}
+	probe, err := net.DialTimeout("unix", *unixPath, time.Second)
+	if err != nil {
+		writeSetupError(
+			stderr,
+			*setupToken,
+			"connect proxy Unix socket: %v",
+			err,
+		)
+		return controlledegress.ExitSetupFailed
+	}
+	_ = probe.Close()
+	relay, err := controlledegress.StartRelay(*port, *unixPath)
+	if err != nil {
+		writeSetupError(stderr, *setupToken, "%v", err)
+		return controlledegress.ExitSetupFailed
+	}
+	defer func() { _ = relay.Close() }()
+	return execute(
+		command,
+		*bwrapPath,
+		*seccompFD,
+		*mountProc,
+		stdin,
+		stdout,
+		stderr,
+	)
+}
+
+func validSetupToken(token string) bool {
+	decoded, err := hex.DecodeString(token)
+	return err == nil && len(decoded) == setupTokenBytes
+}
+
+func writeSetupError(
+	stderr io.Writer,
+	setupToken string,
+	format string,
+	args ...any,
+) {
+	prefix := controlledegress.SetupErrorPrefix
+	if validSetupToken(setupToken) {
+		prefix += setupToken + ":"
+	}
+	fmt.Fprintf(stderr, "%s %s\n", prefix, fmt.Sprintf(format, args...))
+}
+
+func runCommand(
+	args []string,
+	bwrapPath string,
+	seccompFD int,
+	mountProc bool,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+) int {
+	if len(args) == 0 || bwrapPath == "" || seccompFD < 3 {
+		fmt.Fprintf(
+			stderr,
+			"%s invalid workload launcher arguments\n",
+			controlledegress.RunErrorPrefix,
+		)
+		return 1
+	}
+	if _, err := exec.LookPath(args[0]); err != nil {
+		fmt.Fprintf(stderr, "%s %v\n", controlledegress.RunErrorPrefix, err)
+		return 1
+	}
+	seccompFile := os.NewFile(uintptr(seccompFD), "controlled-egress-seccomp")
+	if seccompFile == nil {
+		fmt.Fprintf(
+			stderr,
+			"%s invalid seccomp descriptor %d\n",
+			controlledegress.RunErrorPrefix,
+			seccompFD,
+		)
+		return 1
+	}
+	defer seccompFile.Close()
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(
+			stderr,
+			"%s get working directory: %v\n",
+			controlledegress.RunErrorPrefix,
+			err,
+		)
+		return 1
+	}
+	bwrapArgs := []string{
+		"--die-with-parent",
+		"--unshare-pid",
+		"--new-session",
+		"--cap-drop", "ALL",
+		"--bind", "/", "/",
+		"--seccomp", "3",
+		"--chdir", cwd,
+	}
+	if mountProc {
+		bwrapArgs = append(bwrapArgs, "--proc", "/proc")
+	}
+	bwrapArgs = append(bwrapArgs, "--")
+	bwrapArgs = append(bwrapArgs, args...)
+	cmd := exec.Command(bwrapPath, bwrapArgs...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Env = os.Environ()
+	cmd.ExtraFiles = []*os.File{seccompFile}
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(stderr, "%s %v\n", controlledegress.RunErrorPrefix, err)
+		return 1
+	}
+	return 0
+}

--- a/codeexecutor/sandbox/cmd/egress-relay/main_test.go
+++ b/codeexecutor/sandbox/cmd/egress-relay/main_test.go
@@ -1,0 +1,210 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox/controlledegress"
+)
+
+const testSetupToken = "0123456789abcdef0123456789abcdef"
+
+func TestRunRejectsUsageAndSetupFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{
+			name: "invalid flag",
+			args: []string{"-setup-token", testSetupToken, "-unknown"},
+			want: controlledegress.ExitUsageError,
+		},
+		{
+			name: "missing command",
+			args: []string{
+				"-unix", "/tmp/proxy.sock",
+				"-bwrap", "/usr/bin/bwrap",
+				"-seccomp-fd", "3",
+				"-setup-token", testSetupToken,
+			},
+			want: controlledegress.ExitUsageError,
+		},
+		{
+			name: "listen failure",
+			args: []string{
+				"-unix", "/tmp/proxy.sock",
+				"-bwrap", "/usr/bin/bwrap",
+				"-seccomp-fd", "3",
+				"-setup-token", testSetupToken,
+				"-port", "70000",
+				"--", "/bin/true",
+			},
+			want: controlledegress.ExitSetupFailed,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			got := run(tt.args, strings.NewReader(""), io.Discard, &stderr, runCommand)
+			if got != tt.want {
+				t.Fatalf("run exit = %d, want %d stderr=%q", got, tt.want, stderr.String())
+			}
+			wantMarker := controlledegress.SetupErrorPrefix + testSetupToken + ":"
+			if !strings.Contains(stderr.String(), wantMarker) {
+				t.Fatalf("stderr = %q, want authenticated setup marker %q", stderr.String(), wantMarker)
+			}
+		})
+	}
+}
+
+func TestRunExecutesCommandAndClosesRelay(t *testing.T) {
+	unixPath := filepath.Join(t.TempDir(), "proxy.sock")
+	unixListener, err := net.Listen("unix", unixPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unixListener.Close()
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+
+	called := false
+	execute := func(
+		args []string,
+		bwrapPath string,
+		seccompFD int,
+		mountProc bool,
+		stdin io.Reader,
+		stdout, stderr io.Writer,
+	) int {
+		called = true
+		if strings.Join(args, " ") != "/bin/echo ok" {
+			t.Fatalf("command args = %#v", args)
+		}
+		if bwrapPath != "/trusted/bwrap" || seccompFD != 3 || !mountProc {
+			t.Fatalf(
+				"bwrap=%q seccompFD=%d mountProc=%v",
+				bwrapPath,
+				seccompFD,
+				mountProc,
+			)
+		}
+		return 0
+	}
+	got := run(
+		[]string{
+			"-unix", unixPath,
+			"-bwrap", "/trusted/bwrap",
+			"-seccomp-fd", "3",
+			"-setup-token", testSetupToken,
+			"-mount-proc=true",
+			"-port", fmt.Sprint(port),
+			"--", "/bin/echo", "ok",
+		},
+		strings.NewReader(""),
+		io.Discard,
+		io.Discard,
+		execute,
+	)
+	if got != 0 || !called {
+		t.Fatalf("run exit = %d called=%v", got, called)
+	}
+	rebound, err := net.Listen("tcp", "127.0.0.1:"+fmt.Sprint(port))
+	if err != nil {
+		t.Fatalf("relay listener was not closed: %v", err)
+	}
+	_ = rebound.Close()
+}
+
+func TestRunCommandExitAndStartFailure(t *testing.T) {
+	bwrap := writeFakeBwrap(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	seccomp := openTestSeccompFD(t)
+	if got := runCommand(
+		[]string{"/bin/sh", "-c", "printf ok; exit 75"},
+		bwrap,
+		int(seccomp.Fd()),
+		false,
+		strings.NewReader(""),
+		&stdout,
+		&stderr,
+	); got != controlledegress.ExitSetupFailed {
+		t.Fatalf("user exit = %d, want %d", got, controlledegress.ExitSetupFailed)
+	}
+	if stdout.String() != "ok" || stderr.String() != "" {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	stderr.Reset()
+	seccomp = openTestSeccompFD(t)
+	if got := runCommand(
+		[]string{"/definitely/missing-command"},
+		bwrap,
+		int(seccomp.Fd()),
+		false,
+		strings.NewReader(""),
+		io.Discard,
+		&stderr,
+	); got != 1 {
+		t.Fatalf("missing command exit = %d, want 1", got)
+	}
+	if !strings.Contains(stderr.String(), controlledegress.RunErrorPrefix) {
+		t.Fatalf("stderr = %q, want run error marker", stderr.String())
+	}
+
+	seccomp = openTestSeccompFD(t)
+	if got := runCommand(
+		[]string{"/bin/true"},
+		bwrap,
+		int(seccomp.Fd()),
+		false,
+		strings.NewReader(""),
+		io.Discard,
+		io.Discard,
+	); got != 0 {
+		t.Fatalf("successful command exit = %d, want 0", got)
+	}
+}
+
+func writeFakeBwrap(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bwrap")
+	script := `#!/bin/sh
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+[ "$#" -gt 0 ] && shift
+exec "$@"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func openTestSeccompFD(t *testing.T) *os.File {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "seccomp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return file
+}

--- a/codeexecutor/sandbox/controlled_egress.go
+++ b/codeexecutor/sandbox/controlled_egress.go
@@ -1,0 +1,334 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox/controlledegress"
+)
+
+const controlledEgressProxyProbeTimeout = 500 * time.Millisecond
+
+const controlledEgressSetupTokenBytes = 16
+
+var proxyEnvKeys = []string{
+	"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy",
+	"ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy",
+}
+
+// WithControlledEgressRelayPath sets the in-sandbox egress-relay helper binary.
+// Required for NetworkControlled on Linux.
+func WithControlledEgressRelayPath(path string) Option {
+	return func(r *Runtime) {
+		r.egressRelayPath = path
+	}
+}
+
+func (c ControlledEgressProxy) effectiveRelayPort() int {
+	if c.RelayPort > 0 {
+		return c.RelayPort
+	}
+	return controlledegress.DefaultRelayPort
+}
+
+func (c ControlledEgressProxy) validate() error {
+	if c.UnixPath == "" {
+		return deniedf(
+			ErrPolicyViolation,
+			"network",
+			"",
+			"controlled egress requires UnixPath",
+		)
+	}
+	if !filepath.IsAbs(c.UnixPath) {
+		return deniedf(
+			ErrPolicyViolation,
+			"network",
+			c.UnixPath,
+			"controlled egress UnixPath must be absolute",
+		)
+	}
+	if c.RelayPort < 0 || c.RelayPort > 65535 {
+		return deniedf(
+			ErrPolicyViolation,
+			"network",
+			"",
+			"controlled egress RelayPort must be between 0 and 65535",
+		)
+	}
+	return nil
+}
+
+func applyControlledEgressEnv(
+	env []string,
+	plan resolvedNetworkPolicy,
+) []string {
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d", plan.relayPort)
+	filtered := make([]string, 0, len(env)+8)
+	for _, kv := range env {
+		k, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		if isProxyEnvKey(k) {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	filtered = append(filtered,
+		"HTTP_PROXY="+proxyURL,
+		"HTTPS_PROXY="+proxyURL,
+		"http_proxy="+proxyURL,
+		"https_proxy="+proxyURL,
+	)
+	return filtered
+}
+
+func isProxyEnvKey(k string) bool {
+	for _, pk := range proxyEnvKeys {
+		if k == pk {
+			return true
+		}
+	}
+	return false
+}
+
+func probeControlledEgressProxy(unixPath string) error {
+	if unixPath == "" {
+		return deniedf(ErrPolicyViolation, "network", "", "controlled egress missing unix path")
+	}
+	conn, err := net.DialTimeout("unix", unixPath, controlledEgressProxyProbeTimeout)
+	if err != nil {
+		return deniedf(
+			ErrSetupFailed,
+			"network",
+			unixPath,
+			"controlled egress proxy unreachable: %v",
+			err,
+		)
+	}
+	_ = conn.Close()
+	return nil
+}
+
+func wrapControlledEgressSpec(
+	plan resolvedNetworkPolicy,
+	relayPath string,
+	bwrapPath string,
+	seccompFD int,
+	mountProc bool,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunProgramSpec, error) {
+	if err := probeControlledEgressProxy(plan.unixPath); err != nil {
+		return spec, err
+	}
+	if bwrapPath == "" {
+		return spec, deniedf(
+			ErrSetupFailed,
+			"network",
+			"",
+			"controlled egress missing bubblewrap path",
+		)
+	}
+	if seccompFD < 3 {
+		return spec, deniedf(
+			ErrSetupFailed,
+			"network",
+			"",
+			"controlled egress missing workload seccomp fd",
+		)
+	}
+	setupToken, err := newControlledEgressSetupToken()
+	if err != nil {
+		return spec, deniedf(
+			ErrSetupFailed,
+			"network",
+			"",
+			"generate controlled egress setup token: %v",
+			err,
+		)
+	}
+	wrapped := spec
+	wrapped.Cmd = relayPath
+	wrapped.Args = append([]string{
+		"-unix", plan.unixPath,
+		"-port", fmt.Sprintf("%d", plan.relayPort),
+		"-bwrap", bwrapPath,
+		"-seccomp-fd", fmt.Sprintf("%d", seccompFD),
+		"-setup-token", setupToken,
+		fmt.Sprintf("-mount-proc=%t", mountProc),
+		"--",
+		spec.Cmd,
+	}, spec.Args...)
+	return wrapped, nil
+}
+
+func newControlledEgressSetupToken() (string, error) {
+	var token [controlledEgressSetupTokenBytes]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(token[:]), nil
+}
+
+func controlledEgressSetupToken(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-setup-token" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func mapControlledEgressSetupExit(
+	profile PermissionProfile,
+	exitCode int,
+	setupMarkerSeen bool,
+) error {
+	if profile.network.Mode != NetworkControlled {
+		return nil
+	}
+	if !setupMarkerSeen {
+		return nil
+	}
+	switch exitCode {
+	case controlledegress.ExitSetupFailed:
+		return deniedf(
+			ErrSetupFailed,
+			"network",
+			"",
+			"controlled egress relay setup failed (exit %d)",
+			exitCode,
+		)
+	case controlledegress.ExitUsageError:
+		return deniedf(
+			ErrSetupFailed,
+			"network",
+			"",
+			"controlled egress relay usage error (exit %d)",
+			exitCode,
+		)
+	default:
+		return nil
+	}
+}
+
+type controlledEgressMarkerTracker struct {
+	mu          sync.Mutex
+	marker      string
+	setupMarker bool
+	tail        string
+}
+
+func newControlledEgressMarkerTracker(
+	setupToken string,
+) *controlledEgressMarkerTracker {
+	marker := ""
+	if setupToken != "" {
+		marker = controlledegress.SetupErrorPrefix + setupToken + ":"
+	}
+	return &controlledEgressMarkerTracker{marker: marker}
+}
+
+func (t *controlledEgressMarkerTracker) Write(chunk []byte) (int, error) {
+	if t == nil {
+		return len(chunk), nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	combined := t.tail + string(chunk)
+	if t.marker != "" && strings.Contains(combined, t.marker) {
+		t.setupMarker = true
+	}
+	keep := len(t.marker) - 1
+	if keep < 0 {
+		keep = 0
+	}
+	if len(combined) > keep {
+		combined = combined[len(combined)-keep:]
+	}
+	t.tail = combined
+	return len(chunk), nil
+}
+
+func (t *controlledEgressMarkerTracker) setupMarkerSeen() bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.setupMarker
+}
+
+type processStderrSetupTracker struct {
+	source io.ReadCloser
+	reader *os.File
+	writer *os.File
+	done   chan struct{}
+
+	markers controlledEgressMarkerTracker
+}
+
+func newProcessStderrSetupTracker(
+	source io.ReadCloser,
+	setupToken string,
+) (*processStderrSetupTracker, error) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	return &processStderrSetupTracker{
+		source:  source,
+		reader:  reader,
+		writer:  writer,
+		done:    make(chan struct{}),
+		markers: *newControlledEgressMarkerTracker(setupToken),
+	}, nil
+}
+
+func (t *processStderrSetupTracker) start() {
+	go func() {
+		defer close(t.done)
+		defer t.source.Close()
+		defer t.writer.Close()
+		buf := make([]byte, 32<<10)
+		for {
+			n, err := t.source.Read(buf)
+			if n > 0 {
+				_, _ = t.markers.Write(buf[:n])
+				if _, writeErr := t.writer.Write(buf[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+}
+
+func (t *processStderrSetupTracker) setupMarkerSeen() bool {
+	if t == nil {
+		return false
+	}
+	<-t.done
+	return t.markers.setupMarkerSeen()
+}

--- a/codeexecutor/sandbox/controlled_egress_linux_test.go
+++ b/codeexecutor/sandbox/controlled_egress_linux_test.go
@@ -1,0 +1,335 @@
+//go:build linux
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor"
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox/controlledegress"
+)
+
+func TestLinuxControlledDefersSeccompAndWrapsRelay(t *testing.T) {
+	sockDir := t.TempDir()
+	sock := filepath.Join(sockDir, "proxy.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	relayDir := t.TempDir()
+	relayPath := filepath.Join(relayDir, "egress-relay")
+	if err := os.WriteFile(relayPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := WorkspaceWriteProfile().WithControlledEgressProxy(ControlledEgressProxy{
+		UnixPath:  sock,
+		RelayPort: 17923,
+	})
+	rt := NewRuntime(
+		WithWorkspaceRoot(t.TempDir()),
+		WithPermissionProfile(profile),
+		WithControlledEgressRelayPath(relayPath),
+	)
+	rt.bwrapPath = "/trusted/bwrap"
+	ws, err := rt.CreateWorkspace(context.Background(), "controlled", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setup, err := rt.linuxSandboxSetup(
+		profile,
+		ws,
+		filepath.Join(ws.Path, codeexecutor.DirWork),
+		nil,
+		codeexecutor.RunProgramSpec{Cmd: "/bin/true"},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasArg(setup.args, "--unshare-net") {
+		t.Fatalf("controlled args missing network namespace isolation: %#v", setup.args)
+	}
+	if hasArgPair(setup.args, "--seccomp", "3") {
+		t.Fatalf("controlled outer bwrap applied workload seccomp too early: %#v", setup.args)
+	}
+	if !setup.needsSeccompFD {
+		t.Fatal("controlled setup did not inherit workload seccomp filter")
+	}
+	if !hasArgPair(setup.args, "-unix", sock) ||
+		!hasArgPair(setup.args, "-bwrap", "/trusted/bwrap") ||
+		!hasArgPair(setup.args, "-seccomp-fd", "3") ||
+		!hasArg(setup.args, "-mount-proc=true") {
+		t.Fatalf("controlled args missing direct relay/workload isolation: %#v", setup.args)
+	}
+	if token := controlledEgressSetupToken(setup.args); len(token) != 32 {
+		t.Fatalf("controlled args missing authenticated setup token: %#v", setup.args)
+	}
+	if indexOf(setup.args, relayPath) < 0 || indexOf(setup.args, "/bin/true") < 0 {
+		t.Fatalf("controlled args missing relay wrap: %#v", setup.args)
+	}
+	withoutProc, err := rt.linuxSandboxSetup(
+		profile,
+		ws,
+		filepath.Join(ws.Path, codeexecutor.DirWork),
+		nil,
+		codeexecutor.RunProgramSpec{Cmd: "/bin/true"},
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasArg(withoutProc.args, "-mount-proc=false") {
+		t.Fatalf("no-proc controlled args missing fallback: %#v", withoutProc.args)
+	}
+}
+
+func TestLinuxControlledRejectsWritableUnixPath(t *testing.T) {
+	rt := NewRuntime(WithWorkspaceRoot(t.TempDir()))
+	ws, err := rt.CreateWorkspace(context.Background(), "controlled-deny", codeexecutor.WorkspacePolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := WorkspaceWriteProfile().WithControlledEgressProxy(ControlledEgressProxy{
+		UnixPath: filepath.Join(ws.Path, "proxy.sock"),
+	})
+	_, err = rt.linuxSandboxSetup(
+		profile,
+		ws,
+		filepath.Join(ws.Path, codeexecutor.DirWork),
+		nil,
+		codeexecutor.RunProgramSpec{Cmd: "/bin/true"},
+		true,
+	)
+	if err == nil || !strings.Contains(err.Error(), "guest-writable") {
+		t.Fatalf("err = %v, want writable mount rejection", err)
+	}
+}
+
+func TestLinuxControlledDirectRelayEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping controlled-egress end-to-end test in short mode")
+	}
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Skipf("go tool unavailable: %v", err)
+	}
+	relayPath := filepath.Join(t.TempDir(), "egress-relay")
+	build := exec.Command(goPath, "build", "-o", relayPath, "./cmd/egress-relay")
+	build.Dir = "."
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build egress-relay: %v\n%s", err, output)
+	}
+
+	socketPath := filepath.Join(t.TempDir(), "proxy.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	echoDone := make(chan error, 1)
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				echoDone <- acceptErr
+				return
+			}
+			var request [4]byte
+			_, readErr := io.ReadFull(conn, request[:])
+			if readErr == io.EOF {
+				_ = conn.Close()
+				continue
+			}
+			if readErr != nil {
+				_ = conn.Close()
+				echoDone <- readErr
+				return
+			}
+			if string(request[:]) != "ping" {
+				_ = conn.Close()
+				echoDone <- fmt.Errorf("request = %q, want ping", request[:])
+				return
+			}
+			_, writeErr := conn.Write([]byte("pong"))
+			_ = conn.Close()
+			echoDone <- writeErr
+			return
+		}
+	}()
+
+	profile := WorkspaceWriteProfile().WithControlledEgressProxy(
+		ControlledEgressProxy{UnixPath: socketPath},
+	)
+	readOnlyPath := filepath.Join(t.TempDir(), "read-only-probe")
+	if err := os.WriteFile(readOnlyPath, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime := NewRuntime(
+		WithWorkspaceRoot(t.TempDir()),
+		WithPermissionProfile(profile),
+		WithControlledEgressRelayPath(relayPath),
+	)
+	bwrap, mountProc, err := runtime.linuxPreflight(context.Background())
+	if err != nil {
+		t.Skipf("bubblewrap unavailable: %v", err)
+	}
+	if err := runtime.linuxRestrictedPreflight(
+		context.Background(),
+		bwrap,
+		mountProc,
+	); err != nil {
+		t.Skipf("restricted seccomp unavailable: %v", err)
+	}
+	workspace, err := runtime.CreateWorkspace(
+		context.Background(),
+		"controlled-direct-relay",
+		codeexecutor.WorkspacePolicy{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.RunProgram(
+		context.Background(),
+		workspace,
+		codeexecutor.RunProgramSpec{
+			Cmd:  testBinary,
+			Args: []string{"-test.run=TestControlledEgressWorkloadHelperProcess"},
+			Env: map[string]string{
+				"TRPC_CONTROLLED_EGRESS_HELPER":      "1",
+				"TRPC_CONTROLLED_EGRESS_SOCKET_PATH": socketPath,
+				"TRPC_CONTROLLED_EGRESS_READONLY":    readOnlyPath,
+				"TRPC_CONTROLLED_EGRESS_RELAY_PORT": strconv.Itoa(
+					controlledegress.DefaultRelayPort,
+				),
+			},
+			Timeout: 15 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatalf("controlled run: %v; result=%+v", err, result)
+	}
+	if result.ExitCode != 0 || !strings.Contains(result.Stdout, "relay-ok") {
+		t.Fatalf("controlled result=%+v", result)
+	}
+	if content, err := os.ReadFile(readOnlyPath); err != nil ||
+		string(content) != "original" {
+		t.Fatalf("outer read-only file content=%q err=%v", content, err)
+	}
+	select {
+	case err := <-echoDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxy echo server did not finish")
+	}
+}
+
+func TestControlledEgressWorkloadHelperProcess(t *testing.T) {
+	if os.Getenv("TRPC_CONTROLLED_EGRESS_HELPER") != "1" {
+		return
+	}
+	port := os.Getenv("TRPC_CONTROLLED_EGRESS_RELAY_PORT")
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 2*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dial relay: %v\n", err)
+		os.Exit(10)
+	}
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		fmt.Fprintf(os.Stderr, "set relay deadline: %v\n", err)
+		os.Exit(11)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		fmt.Fprintf(os.Stderr, "write relay: %v\n", err)
+		os.Exit(12)
+	}
+	var response [4]byte
+	if _, err := io.ReadFull(conn, response[:]); err != nil {
+		fmt.Fprintf(os.Stderr, "read relay: %v\n", err)
+		os.Exit(13)
+	}
+	_ = conn.Close()
+	if string(response[:]) != "pong" {
+		fmt.Fprintf(os.Stderr, "relay response = %q\n", response[:])
+		os.Exit(14)
+	}
+	unixConn, unixErr := net.DialTimeout(
+		"unix",
+		os.Getenv("TRPC_CONTROLLED_EGRESS_SOCKET_PATH"),
+		time.Second,
+	)
+	if unixErr == nil {
+		_ = unixConn.Close()
+		fmt.Fprintln(os.Stderr, "workload unexpectedly opened AF_UNIX socket")
+		os.Exit(15)
+	}
+	if !errors.Is(unixErr, syscall.EPERM) {
+		fmt.Fprintf(os.Stderr, "AF_UNIX error = %v, want EPERM\n", unixErr)
+		os.Exit(16)
+	}
+	procEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read /proc: %v\n", err)
+		os.Exit(17)
+	}
+	for _, entry := range procEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		cmdline, _ := os.ReadFile(filepath.Join("/proc", entry.Name(), "cmdline"))
+		if strings.Contains(string(cmdline), "egress-relay") {
+			fmt.Fprintln(os.Stderr, "workload can see trusted relay process")
+			os.Exit(18)
+		}
+	}
+	if err := os.WriteFile(
+		os.Getenv("TRPC_CONTROLLED_EGRESS_READONLY"),
+		[]byte("changed"),
+		0o600,
+	); err == nil {
+		fmt.Fprintln(os.Stderr, "nested sandbox reopened outer read-only mount")
+		os.Exit(19)
+	}
+	fmt.Fprintln(os.Stdout, "relay-ok")
+	os.Exit(0)
+}
+
+func indexOf(args []string, want string) int {
+	for i, arg := range args {
+		if arg == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/codeexecutor/sandbox/controlled_egress_test.go
+++ b/codeexecutor/sandbox/controlled_egress_test.go
@@ -1,0 +1,82 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/codeexecutor/sandbox/controlledegress"
+)
+
+func TestMapControlledEgressSetupExit(t *testing.T) {
+	profile := WorkspaceWriteProfile().WithControlledEgressProxy(ControlledEgressProxy{
+		UnixPath: "/tmp/proxy.sock",
+	})
+	if err := mapControlledEgressSetupExit(profile, controlledegress.ExitSetupFailed, true); err == nil {
+		t.Fatal("expected setup failure mapping")
+	}
+	if err := mapControlledEgressSetupExit(WorkspaceWriteProfile(), 75, true); err != nil {
+		t.Fatalf("restricted should ignore relay markers: %v", err)
+	}
+}
+
+func TestControlledEgressEnvReplacesProxyVars(t *testing.T) {
+	env := applyControlledEgressEnv(
+		[]string{"HTTP_PROXY=http://evil", "FOO=bar", "NO_PROXY=*"},
+		resolvedNetworkPolicy{relayPort: 17923},
+	)
+	joined := strings.Join(env, ",")
+	if strings.Contains(joined, "evil") || strings.Contains(joined, "NO_PROXY") {
+		t.Fatalf("proxy env not replaced: %v", env)
+	}
+	if !strings.Contains(joined, "HTTP_PROXY=http://127.0.0.1:17923") {
+		t.Fatalf("missing injected proxy: %v", env)
+	}
+	if strings.Contains(joined, "TRPC_AGENT_CONTROLLED_EGRESS_FD") {
+		t.Fatalf("obsolete mux fd env was retained: %v", env)
+	}
+}
+
+func TestControlledEgressUserStderrCannotForgeSetupMarker(t *testing.T) {
+	profile := WorkspaceWriteProfile().WithControlledEgressProxy(
+		ControlledEgressProxy{UnixPath: "/host/proxy.sock"},
+	)
+	tracker := newControlledEgressMarkerTracker("trusted-token")
+	_, _ = tracker.Write([]byte(
+		controlledegress.SetupErrorPrefix + " text emitted by the workload\n",
+	))
+	err := mapControlledEgressSetupExit(
+		profile,
+		controlledegress.ExitSetupFailed,
+		tracker.setupMarkerSeen(),
+	)
+	if err != nil {
+		t.Fatalf("user-controlled stderr was misclassified: %v", err)
+	}
+}
+
+func TestControlledEgressTrustedSetupMarkerIsClassified(t *testing.T) {
+	profile := WorkspaceWriteProfile().WithControlledEgressProxy(
+		ControlledEgressProxy{UnixPath: "/host/proxy.sock"},
+	)
+	tracker := newControlledEgressMarkerTracker("trusted-token")
+	_, _ = tracker.Write([]byte(
+		controlledegress.SetupErrorPrefix + "trusted-token: relay failed\n",
+	))
+	err := mapControlledEgressSetupExit(
+		profile,
+		controlledegress.ExitSetupFailed,
+		tracker.setupMarkerSeen(),
+	)
+	if !isKind(err, ErrSetupFailed) {
+		t.Fatalf("trusted setup marker was not classified: %v", err)
+	}
+}

--- a/codeexecutor/sandbox/controlledegress/policy.go
+++ b/codeexecutor/sandbox/controlledegress/policy.go
@@ -1,0 +1,328 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package controlledegress implements host-side L4/L7 policy and transport
+// helpers for sandbox controlled network egress.
+package controlledegress
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// Target is a normalized outbound destination observed by the proxy.
+type Target struct {
+	Host       string // hostname or IP literal (no brackets)
+	Port       int
+	Scheme     string // http, https, or empty for CONNECT
+	Path       string // path+query for HTTP; empty for CONNECT
+	Connect    bool
+	Original   string
+	HostHeader string
+}
+
+// Authority returns host:port suitable for dialing / CONNECT.
+func (t Target) Authority() string {
+	return net.JoinHostPort(t.Host, strconv.Itoa(t.Port))
+}
+
+// ParseHTTPAbsoluteForm parses an HTTP absolute-form request URL.
+func ParseHTTPAbsoluteForm(raw string) (Target, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return Target{}, fmt.Errorf("parse absolute URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return Target{}, fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return Target{}, fmt.Errorf("missing host in absolute URL")
+	}
+	host, port, err := splitHostPort(u.Host, defaultPort(u.Scheme))
+	if err != nil {
+		return Target{}, err
+	}
+	path := u.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+	return Target{
+		Host:     host,
+		Port:     port,
+		Scheme:   u.Scheme,
+		Path:     path,
+		Original: raw,
+	}, nil
+}
+
+// ParseCONNECTTarget parses a CONNECT authority (host:port).
+func ParseCONNECTTarget(authority string) (Target, error) {
+	host, port, err := splitHostPort(authority, 443)
+	if err != nil {
+		return Target{}, err
+	}
+	return Target{
+		Host:     host,
+		Port:     port,
+		Scheme:   "https",
+		Connect:  true,
+		Original: authority,
+	}, nil
+}
+
+func defaultPort(scheme string) int {
+	if scheme == "https" {
+		return 443
+	}
+	return 80
+}
+
+func splitHostPort(hostport string, fallbackPort int) (string, int, error) {
+	hostport = strings.TrimSpace(hostport)
+	if hostport == "" {
+		return "", 0, fmt.Errorf("empty host")
+	}
+	if _, _, err := net.SplitHostPort(hostport); err != nil {
+		if ip := net.ParseIP(hostport); ip != nil && ip.To4() == nil {
+			return "", 0, fmt.Errorf(
+				"invalid host:port %q: IPv6 requires brackets",
+				hostport,
+			)
+		}
+		return strings.ToLower(hostport), fallbackPort, nil
+	}
+	host, portStr, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid host:port %q: %w", hostport, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port <= 0 || port > 65535 {
+		return "", 0, fmt.Errorf("invalid port %q", portStr)
+	}
+	return strings.ToLower(host), port, nil
+}
+
+// RunIdentity is trusted host-side correlation metadata for one proxy owner.
+// It must not be populated from guest-controlled request headers or payloads.
+type RunIdentity struct {
+	Principal string
+	Session   string
+	Request   string
+}
+
+// AuditEvent records a policy decision without bodies or credentials.
+type AuditEvent struct {
+	Principal string
+	Session   string
+	Request   string
+	Allow     bool
+	Reason    string
+	Target    Target
+	IPs       []string
+}
+
+// Auditor receives decision events. Implementations must support concurrent
+// calls and return promptly when ctx is canceled. Proxy.Close cancels the
+// context and waits for in-flight callbacks to return.
+type Auditor interface {
+	Record(ctx context.Context, event AuditEvent)
+}
+
+type runIdentityContextKey struct{}
+
+func withRunIdentity(ctx context.Context, identity RunIdentity) context.Context {
+	return context.WithValue(ctx, runIdentityContextKey{}, identity)
+}
+
+func runIdentityFromContext(ctx context.Context) RunIdentity {
+	identity, _ := ctx.Value(runIdentityContextKey{}).(RunIdentity)
+	return identity
+}
+
+// Decision is the result of a policy evaluation.
+type Decision struct {
+	Allow   bool
+	Reason  string
+	Target  Target
+	DialIPs []net.IP
+}
+
+// Authorizer is an optional per-request gate (e.g. human approval in PR C).
+// Implementations must support concurrent calls and return promptly when ctx is
+// canceled. Proxy.Close cancels the context and waits for in-flight callbacks
+// to return.
+type Authorizer interface {
+	Allow(ctx context.Context, target Target) error
+}
+
+// AllowFunc adapts a function to Authorizer.
+type AllowFunc func(ctx context.Context, target Target) error
+
+// Allow implements Authorizer.
+func (f AllowFunc) Allow(ctx context.Context, target Target) error {
+	return f(ctx, target)
+}
+
+// Policy evaluates whether a target may be dialed.
+type Policy struct {
+	// AllowedHosts are exact hosts or suffix patterns like "*.example.com".
+	// Empty means deny all hosts (fail closed).
+	AllowedHosts []string
+	// AllowedPorts, when non-empty, restricts destination ports.
+	AllowedPorts []int
+	Resolver     Resolver
+	Authorizer   Authorizer
+	Auditor      Auditor
+}
+
+// Validate checks policy syntax before a proxy starts serving.
+func (p Policy) Validate() error {
+	for _, raw := range p.AllowedHosts {
+		pattern := strings.ToLower(strings.TrimSpace(raw))
+		if pattern == "" {
+			return fmt.Errorf("allowed host pattern is empty")
+		}
+		if !strings.Contains(pattern, "*") {
+			continue
+		}
+		if !strings.HasPrefix(pattern, "*.") ||
+			strings.Count(pattern, "*") != 1 {
+			return fmt.Errorf("invalid wildcard host pattern %q", raw)
+		}
+		base := strings.TrimPrefix(pattern, "*.")
+		if _, err := publicsuffix.EffectiveTLDPlusOne(base); err != nil {
+			return fmt.Errorf("wildcard host pattern %q is too broad", raw)
+		}
+	}
+	for _, port := range p.AllowedPorts {
+		if port <= 0 || port > 65535 {
+			return fmt.Errorf("invalid allowed port %d", port)
+		}
+	}
+	return nil
+}
+
+// Decide validates L7 host/port rules, optional authorizer, then L4/DNS.
+func (p Policy) Decide(ctx context.Context, target Target) Decision {
+	d := Decision{Target: target}
+	if target.Host == "" || target.Port <= 0 {
+		d.Reason = "invalid target"
+		p.audit(ctx, d)
+		return d
+	}
+	if !p.hostAllowed(target.Host) {
+		d.Reason = "host not allowlisted"
+		p.audit(ctx, d)
+		return d
+	}
+	if !p.portAllowed(target.Port) {
+		d.Reason = "port not allowlisted"
+		p.audit(ctx, d)
+		return d
+	}
+	if p.Authorizer != nil {
+		if err := p.Authorizer.Allow(ctx, target); err != nil {
+			d.Reason = "authorizer denied"
+			p.audit(ctx, d)
+			return d
+		}
+	}
+	ips, err := resolveAndValidate(ctx, p.Resolver, target.Host)
+	if err != nil {
+		d.Reason = err.Error()
+		p.audit(ctx, d)
+		return d
+	}
+	d.Allow = true
+	d.Reason = "allow"
+	d.DialIPs = ips
+	p.audit(ctx, d)
+	return d
+}
+
+func (p Policy) hostAllowed(host string) bool {
+	host = strings.ToLower(host)
+	if len(p.AllowedHosts) == 0 {
+		return false
+	}
+	for _, pattern := range p.AllowedHosts {
+		pattern = strings.ToLower(strings.TrimSpace(pattern))
+		if pattern == "" {
+			continue
+		}
+		if pattern == host {
+			return true
+		}
+		if strings.HasPrefix(pattern, "*.") {
+			suffix := pattern[1:]
+			if strings.HasSuffix(host, suffix) &&
+				host != strings.TrimPrefix(suffix, ".") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p Policy) portAllowed(port int) bool {
+	if len(p.AllowedPorts) == 0 {
+		return port == 80 || port == 443
+	}
+	for _, allowed := range p.AllowedPorts {
+		if allowed == port {
+			return true
+		}
+	}
+	return false
+}
+
+func (p Policy) audit(ctx context.Context, d Decision) {
+	if p.Auditor == nil {
+		return
+	}
+	identity := runIdentityFromContext(ctx)
+	target := d.Target
+	target.Path = ""
+	target.Original = ""
+	target.HostHeader = ""
+	p.Auditor.Record(ctx, AuditEvent{
+		Principal: identity.Principal,
+		Session:   identity.Session,
+		Request:   identity.Request,
+		Allow:     d.Allow,
+		Reason:    d.Reason,
+		Target:    target,
+		IPs:       formatIPs(d.DialIPs),
+	})
+}
+
+func formatIPs(ips []net.IP) []string {
+	out := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		out = append(out, ip.String())
+	}
+	return out
+}
+
+// StaticAllowlist is a convenience constructor.
+func StaticAllowlist(hosts ...string) Policy {
+	return Policy{AllowedHosts: append([]string(nil), hosts...)}
+}
+
+// ErrDenied is returned by Authorizer implementations for a hard deny.
+var ErrDenied = fmt.Errorf("controlled egress denied")

--- a/codeexecutor/sandbox/controlledegress/policy_test.go
+++ b/codeexecutor/sandbox/controlledegress/policy_test.go
@@ -1,0 +1,165 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type memoryAuditor struct {
+	mu     sync.Mutex
+	Events []AuditEvent
+}
+
+func (a *memoryAuditor) Record(ctx context.Context, event AuditEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Events = append(a.Events, event)
+}
+
+type stubResolver struct {
+	addrs []net.IPAddr
+	err   error
+}
+
+func (s stubResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return s.addrs, s.err
+}
+
+func TestParseTargets(t *testing.T) {
+	t.Parallel()
+	httpTarget, err := ParseHTTPAbsoluteForm("http://Example.COM:8080/a?b=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if httpTarget.Host != "example.com" || httpTarget.Port != 8080 || httpTarget.Path != "/a?b=1" {
+		t.Fatalf("http target = %#v", httpTarget)
+	}
+	connect, err := ParseCONNECTTarget("api.github.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !connect.Connect || connect.Host != "api.github.com" || connect.Port != 443 {
+		t.Fatalf("connect target = %#v", connect)
+	}
+}
+
+func TestValidateDialIPBlocksPrivate(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"127.0.0.1", "10.0.0.1", "192.168.1.1", "169.254.1.1",
+		"100.64.0.1", "::1", "fec0::1",
+	} {
+		if err := ValidateDialIP(net.ParseIP(raw)); err == nil {
+			t.Fatalf("expected block for %s", raw)
+		}
+	}
+	if err := ValidateDialIP(net.ParseIP("1.1.1.1")); err != nil {
+		t.Fatalf("public IP blocked: %v", err)
+	}
+}
+
+func TestValidateDialIPBlocksNAT64(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"64:ff9b::a00:1",
+		"64:ff9b:1::a00:1",
+	} {
+		if err := ValidateDialIP(net.ParseIP(raw)); err == nil {
+			t.Fatalf("NAT64 address %s was not blocked", raw)
+		}
+	}
+}
+
+func TestPolicyDefaultDenyAndAllowlist(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	deny := Policy{Resolver: stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}}
+	d := deny.Decide(ctx, Target{Host: "example.com", Port: 443})
+	if d.Allow {
+		t.Fatalf("empty allowlist must deny")
+	}
+
+	allow := StaticAllowlist("example.com", "*.github.com")
+	allow.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	if !allow.Decide(ctx, Target{Host: "example.com", Port: 443}).Allow {
+		t.Fatal("exact host should allow")
+	}
+	if !allow.Decide(ctx, Target{Host: "api.github.com", Port: 443}).Allow {
+		t.Fatal("wildcard host should allow")
+	}
+	if allow.Decide(ctx, Target{Host: "github.com", Port: 443}).Allow {
+		t.Fatal("wildcard host must not allow the apex")
+	}
+	if allow.Decide(ctx, Target{Host: "evil.com", Port: 443}).Allow {
+		t.Fatal("other host should deny")
+	}
+}
+
+func TestPolicyValidateRejectsUnsafeConfiguration(t *testing.T) {
+	t.Parallel()
+	for _, policy := range []Policy{
+		{AllowedHosts: []string{"*.com"}},
+		{AllowedHosts: []string{"*example.com"}},
+		{AllowedHosts: []string{""}},
+		{AllowedHosts: []string{"example.com"}, AllowedPorts: []int{-1}},
+		{AllowedHosts: []string{"example.com"}, AllowedPorts: []int{65536}},
+	} {
+		if err := policy.Validate(); err == nil {
+			t.Fatalf("Validate(%#v) succeeded, want error", policy)
+		}
+	}
+	if err := StaticAllowlist("example.com", "*.example.com").Validate(); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+}
+
+func TestPolicyDefaultPortsAreHTTPOnly(t *testing.T) {
+	t.Parallel()
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	if !policy.Decide(context.Background(), Target{Host: "example.com", Port: 80}).Allow {
+		t.Fatal("default policy should allow port 80")
+	}
+	if !policy.Decide(context.Background(), Target{Host: "example.com", Port: 443}).Allow {
+		t.Fatal("default policy should allow port 443")
+	}
+	decision := policy.Decide(context.Background(), Target{Host: "example.com", Port: 22})
+	if decision.Allow || !strings.Contains(decision.Reason, "port") {
+		t.Fatalf("default policy decision = %#v, want port deny", decision)
+	}
+}
+
+func TestPolicyBlocksDNSToPrivate(t *testing.T) {
+	t.Parallel()
+	p := StaticAllowlist("internal.example")
+	p.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}}
+	d := p.Decide(context.Background(), Target{Host: "internal.example", Port: 443})
+	if d.Allow {
+		t.Fatalf("private DNS result must deny: %#v", d)
+	}
+}
+
+func TestAuthorizerHook(t *testing.T) {
+	t.Parallel()
+	p := StaticAllowlist("example.com")
+	p.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	p.Authorizer = AllowFunc(func(ctx context.Context, target Target) error {
+		return ErrDenied
+	})
+	d := p.Decide(context.Background(), Target{Host: "example.com", Port: 443})
+	if d.Allow {
+		t.Fatal("authorizer deny ignored")
+	}
+}

--- a/codeexecutor/sandbox/controlledegress/proxy.go
+++ b/codeexecutor/sandbox/controlledegress/proxy.go
@@ -1,0 +1,542 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultProxyMaxConnections  = 128
+	defaultProxyMaxHeaderBytes  = 64 << 10
+	defaultProxyHeaderTimeout   = 10 * time.Second
+	defaultProxyUpstreamTimeout = 10 * time.Second
+)
+
+// Proxy is a host-side HTTP forward/CONNECT proxy listening on a Unix socket.
+type Proxy struct {
+	UnixPath string
+
+	policy          Policy
+	testDialContext func(ctx context.Context, network, address string) (net.Conn, error)
+	identity        RunIdentity
+	ln              net.Listener
+	socketInfo      os.FileInfo
+	ctx             context.Context
+	cancel          context.CancelFunc
+	slots           chan struct{}
+	wg              sync.WaitGroup
+
+	mu     sync.Mutex
+	conns  map[net.Conn]struct{}
+	closed bool
+}
+
+type proxyConfig struct {
+	identity RunIdentity
+}
+
+// ProxyOption configures trusted host-side proxy behavior.
+type ProxyOption func(*proxyConfig)
+
+// WithRunIdentity attaches trusted host-side audit correlation metadata.
+func WithRunIdentity(identity RunIdentity) ProxyOption {
+	return func(config *proxyConfig) {
+		config.identity = identity
+	}
+}
+
+// StartProxy validates and snapshots policy, creates a caller-owned Unix socket
+// with mode 0600, and starts serving until Close. Resolver, Authorizer, and
+// Auditor implementations remain shared and must support concurrent calls.
+func StartProxy(
+	unixPath string,
+	policy Policy,
+	opts ...ProxyOption,
+) (*Proxy, error) {
+	config := proxyConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&config)
+		}
+	}
+	return startProxy(unixPath, policy, nil, config.identity)
+}
+
+func startTestProxy(
+	unixPath string,
+	policy Policy,
+	dial ...func(context.Context, string, string) (net.Conn, error),
+) (*Proxy, error) {
+	var testDial func(context.Context, string, string) (net.Conn, error)
+	if len(dial) > 0 {
+		testDial = dial[0]
+	}
+	return startProxy(unixPath, policy, testDial, RunIdentity{})
+}
+
+func startProxy(
+	unixPath string,
+	policy Policy,
+	testDial func(context.Context, string, string) (net.Conn, error),
+	identity RunIdentity,
+) (*Proxy, error) {
+	policy = clonePolicy(policy)
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+	if err := prepareUnixSocketPath(unixPath); err != nil {
+		return nil, err
+	}
+	ln, err := net.Listen("unix", unixPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(unixPath, 0o600); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	socketInfo, err := os.Lstat(unixPath)
+	if err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Proxy{
+		UnixPath:        unixPath,
+		policy:          policy,
+		testDialContext: testDial,
+		identity:        identity,
+		ln:              ln,
+		socketInfo:      socketInfo,
+		ctx:             ctx,
+		cancel:          cancel,
+		slots:           make(chan struct{}, defaultProxyMaxConnections),
+		conns:           make(map[net.Conn]struct{}),
+	}
+	go p.serve()
+	return p, nil
+}
+
+func clonePolicy(policy Policy) Policy {
+	cloned := policy
+	cloned.AllowedHosts = append([]string(nil), policy.AllowedHosts...)
+	cloned.AllowedPorts = append([]int(nil), policy.AllowedPorts...)
+	return cloned
+}
+
+func prepareUnixSocketPath(unixPath string) error {
+	if unixPath == "" {
+		return fmt.Errorf("unix socket path is empty")
+	}
+	st, err := os.Lstat(unixPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if st.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to replace non-socket path %q", unixPath)
+	}
+	conn, dialErr := net.DialTimeout("unix", unixPath, 100*time.Millisecond)
+	if dialErr == nil {
+		_ = conn.Close()
+		return fmt.Errorf("unix socket path %q is already in use", unixPath)
+	}
+	if errors.Is(dialErr, os.ErrNotExist) {
+		return nil
+	}
+	if errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return os.Remove(unixPath)
+	}
+	return fmt.Errorf(
+		"refusing to remove socket path %q after inconclusive probe: %w",
+		unixPath,
+		dialErr,
+	)
+}
+
+// Close cancels in-flight policy callbacks, closes active connections, waits
+// for handlers to exit, and removes the Unix socket. Policy callbacks must
+// return promptly when their context is canceled.
+func (p *Proxy) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	ln := p.ln
+	if p.cancel != nil {
+		p.cancel()
+	}
+	for conn := range p.conns {
+		_ = conn.Close()
+	}
+	p.mu.Unlock()
+
+	var closeErr error
+	if ln != nil {
+		closeErr = ln.Close()
+	}
+	p.wg.Wait()
+	if p.socketInfo != nil {
+		if current, err := os.Lstat(p.UnixPath); err == nil &&
+			os.SameFile(p.socketInfo, current) {
+			_ = os.Remove(p.UnixPath)
+		}
+	}
+	return closeErr
+}
+
+func (p *Proxy) serve() {
+	for {
+		c, err := p.ln.Accept()
+		if err != nil {
+			p.mu.Lock()
+			closed := p.closed
+			p.mu.Unlock()
+			if closed {
+				return
+			}
+			continue
+		}
+		select {
+		case p.slots <- struct{}{}:
+		default:
+			writeProxyError(c, http.StatusServiceUnavailable, "proxy connection limit reached")
+			_ = c.Close()
+			continue
+		}
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			<-p.slots
+			_ = c.Close()
+			return
+		}
+		p.conns[c] = struct{}{}
+		p.wg.Add(1)
+		p.mu.Unlock()
+		go func() {
+			defer p.wg.Done()
+			defer func() { <-p.slots }()
+			defer func() {
+				p.mu.Lock()
+				delete(p.conns, c)
+				p.mu.Unlock()
+			}()
+			p.handle(c)
+		}()
+	}
+}
+
+func (p *Proxy) handle(c net.Conn) {
+	defer c.Close()
+	_ = c.SetReadDeadline(time.Now().Add(defaultProxyHeaderTimeout))
+	headerReader := &proxyHeaderLimitReader{
+		reader:    c,
+		remaining: defaultProxyMaxHeaderBytes,
+	}
+	br := bufio.NewReader(headerReader)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		if headerReader.exceeded {
+			writeProxyError(c, http.StatusRequestHeaderFieldsTooLarge, "proxy request headers too large")
+		}
+		return
+	}
+	headerReader.unlimited = true
+	_ = c.SetReadDeadline(time.Time{})
+	ctx := withRunIdentity(p.ctx, p.identity)
+	if req.Method == http.MethodConnect {
+		p.handleCONNECT(ctx, c, br, req)
+		return
+	}
+	p.handleHTTP(ctx, c, req)
+}
+
+type proxyHeaderLimitReader struct {
+	reader    io.Reader
+	remaining int64
+	exceeded  bool
+	unlimited bool
+}
+
+func (r *proxyHeaderLimitReader) Read(p []byte) (int, error) {
+	if r.unlimited {
+		return r.reader.Read(p)
+	}
+	if r.remaining <= 0 {
+		r.exceeded = true
+		return 0, fmt.Errorf("proxy request headers exceed %d bytes", defaultProxyMaxHeaderBytes)
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.reader.Read(p)
+	r.remaining -= int64(n)
+	return n, err
+}
+
+func (p *Proxy) handleCONNECT(ctx context.Context, client net.Conn, br *bufio.Reader, req *http.Request) {
+	target, err := ParseCONNECTTarget(req.Host)
+	if err != nil {
+		writeProxyError(client, http.StatusBadRequest, err.Error())
+		return
+	}
+	dec := p.policy.Decide(ctx, target)
+	if !dec.Allow {
+		writeProxyError(client, http.StatusForbidden, dec.Reason)
+		return
+	}
+	upstream, err := p.dialUpstream(ctx, dec, target)
+	if err != nil {
+		writeProxyError(client, http.StatusBadGateway, err.Error())
+		return
+	}
+	if !p.trackConn(upstream) {
+		return
+	}
+	defer p.releaseConn(upstream)
+	_, _ = client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+	_ = client.SetReadDeadline(time.Now().Add(defaultProxyHeaderTimeout))
+	sni, clientHello, helloErr := readTLSClientHelloSNI(br)
+	_ = client.SetReadDeadline(time.Time{})
+	targetIP := net.ParseIP(target.Host)
+	validHello := helloErr == nil
+	if targetIP != nil && errors.Is(helloErr, errTLSClientHelloNoSNI) {
+		validHello = true
+	}
+	if !validHello ||
+		(sni != "" && !strings.EqualFold(sni, target.Host)) {
+		reason := "TLS SNI does not match CONNECT target"
+		if !validHello {
+			reason = "invalid TLS ClientHello after CONNECT"
+		}
+		p.policy.audit(ctx, Decision{Reason: reason, Target: target})
+		return
+	}
+	if _, err := upstream.Write(clientHello); err != nil {
+		return
+	}
+	if err := flushBufioReader(br, upstream); err != nil {
+		return
+	}
+	relayBidirectional(client, upstream)
+}
+
+func (p *Proxy) handleHTTP(ctx context.Context, client net.Conn, req *http.Request) {
+	rawURL := req.URL.String()
+	if req.URL.Scheme == "" || req.URL.Host == "" {
+		// Some clients send origin-form with Host header; treat as http.
+		if req.Host == "" {
+			writeProxyError(client, http.StatusBadRequest, "missing host")
+			return
+		}
+		rawURL = "http://" + req.Host + req.URL.RequestURI()
+	}
+	target, err := ParseHTTPAbsoluteForm(rawURL)
+	if err != nil {
+		writeProxyError(client, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Host != "" {
+		target.HostHeader = req.Host
+	}
+	if err := validateForwardHost(req.Host, target); err != nil {
+		writeProxyError(client, http.StatusBadRequest, err.Error())
+		return
+	}
+	dec := p.policy.Decide(ctx, target)
+	if !dec.Allow {
+		writeProxyError(client, http.StatusForbidden, dec.Reason)
+		return
+	}
+	upstream, err := p.dialUpstream(ctx, dec, target)
+	if err != nil {
+		writeProxyError(client, http.StatusBadGateway, err.Error())
+		return
+	}
+	if !p.trackConn(upstream) {
+		return
+	}
+	defer p.releaseConn(upstream)
+
+	outReq := req.Clone(ctx)
+	outReq.RequestURI = ""
+	outReq.URL.Scheme = target.Scheme
+	outReq.URL.Host = target.Authority()
+	outReq.Host = requestHost(target)
+	removeHopByHopHeaders(outReq.Header)
+	if err := outReq.Write(upstream); err != nil {
+		writeProxyError(client, http.StatusBadGateway, err.Error())
+		return
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(upstream), outReq)
+	if err != nil {
+		writeProxyError(client, http.StatusBadGateway, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	removeHopByHopHeaders(resp.Header)
+	if err := resp.Write(client); err != nil {
+		return
+	}
+}
+
+func (p *Proxy) dialUpstream(ctx context.Context, dec Decision, target Target) (net.Conn, error) {
+	addr := target.Authority()
+	if p.testDialContext != nil {
+		return p.testDialContext(ctx, "tcp", addr)
+	}
+	return dialFirst(ctx, dec.DialIPs, target.Port)
+}
+
+func (p *Proxy) trackConn(conn net.Conn) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		_ = conn.Close()
+		return false
+	}
+	p.conns[conn] = struct{}{}
+	return true
+}
+
+func (p *Proxy) releaseConn(conn net.Conn) {
+	_ = conn.Close()
+	p.mu.Lock()
+	delete(p.conns, conn)
+	p.mu.Unlock()
+}
+
+func dialFirst(ctx context.Context, ips []net.IP, port int) (net.Conn, error) {
+	var last error
+	dialer := &net.Dialer{Timeout: defaultProxyUpstreamTimeout}
+	for _, ip := range ips {
+		if err := ValidateDialIP(ip); err != nil {
+			last = err
+			continue
+		}
+		addr := net.JoinHostPort(ip.String(), fmt.Sprintf("%d", port))
+		c, err := dialer.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			return c, nil
+		}
+		last = err
+	}
+	if last == nil {
+		return nil, fmt.Errorf("no dial addresses")
+	}
+	return nil, last
+}
+
+func validateForwardHost(hostHeader string, target Target) error {
+	if hostHeader == "" {
+		return nil
+	}
+	host, port, err := splitHostPort(hostHeader, defaultPort(target.Scheme))
+	if err != nil {
+		return fmt.Errorf("invalid Host header: %w", err)
+	}
+	if !strings.EqualFold(host, target.Host) || port != target.Port {
+		return fmt.Errorf(
+			"Host header %q does not match request URL host %s",
+			hostHeader,
+			target.Authority(),
+		)
+	}
+	return nil
+}
+
+func requestHost(target Target) string {
+	if target.Port == defaultPort(target.Scheme) {
+		if ip := net.ParseIP(target.Host); ip != nil && ip.To4() == nil {
+			return "[" + target.Host + "]"
+		}
+		return target.Host
+	}
+	return target.Authority()
+}
+
+func removeHopByHopHeaders(header http.Header) {
+	for _, value := range header.Values("Connection") {
+		for _, name := range strings.Split(value, ",") {
+			header.Del(strings.TrimSpace(name))
+		}
+	}
+	for _, name := range []string{
+		"Connection",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"Proxy-Connection",
+		"Te",
+		"Transfer-Encoding",
+		"Upgrade",
+	} {
+		header.Del(name)
+	}
+}
+
+func flushBufioReader(br *bufio.Reader, w io.Writer) error {
+	if br == nil {
+		return nil
+	}
+	buffered := br.Buffered()
+	if buffered <= 0 {
+		return nil
+	}
+	peek, err := br.Peek(buffered)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(peek); err != nil {
+		return err
+	}
+	_, err = br.Discard(buffered)
+	return err
+}
+
+func writeProxyError(w net.Conn, code int, msg string) {
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	body := msg + "\n"
+	_, _ = fmt.Fprintf(w, "HTTP/1.1 %d %s\r\nContent-Type: text/plain\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+		code, http.StatusText(code), len(body), body)
+}
+
+func relayBidirectional(a, b net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	copyClose := func(dst, src net.Conn) {
+		defer wg.Done()
+		_, _ = io.Copy(dst, src)
+		type closeWriter interface{ CloseWrite() error }
+		if cw, ok := dst.(closeWriter); ok {
+			_ = cw.CloseWrite()
+		}
+	}
+	go copyClose(a, b)
+	go copyClose(b, a)
+	wg.Wait()
+}

--- a/codeexecutor/sandbox/controlledegress/proxy_relay_test.go
+++ b/codeexecutor/sandbox/controlledegress/proxy_relay_test.go
@@ -1,0 +1,1060 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPrepareUnixSocketPathSafety(t *testing.T) {
+	if err := prepareUnixSocketPath(""); err == nil {
+		t.Fatal("empty socket path was accepted")
+	}
+
+	regular := filepath.Join(t.TempDir(), "regular")
+	if err := os.WriteFile(regular, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareUnixSocketPath(regular); err == nil {
+		t.Fatal("regular file was accepted as replaceable socket")
+	}
+
+	activePath := filepath.Join(t.TempDir(), "active.sock")
+	active, err := net.Listen("unix", activePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareUnixSocketPath(activePath); err == nil {
+		t.Fatal("active socket was accepted as stale")
+	}
+	_ = active.Close()
+
+	stalePath := filepath.Join(t.TempDir(), "stale.sock")
+	stale, err := net.Listen("unix", stalePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.(*net.UnixListener).SetUnlinkOnClose(false)
+	_ = stale.Close()
+	if err := prepareUnixSocketPath(stalePath); err != nil {
+		t.Fatalf("stale socket cleanup: %v", err)
+	}
+	if _, err := os.Lstat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale socket still exists: %v", err)
+	}
+}
+
+func TestProxyReturnsProtocolAndDialErrors(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	proxy, err := startTestProxy(
+		sock,
+		policy,
+		func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("forced dial failure")
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{
+			name: "connect denied",
+			raw:  "CONNECT evil.example:443 HTTP/1.1\r\nHost: evil.example:443\r\n\r\n",
+			want: http.StatusForbidden,
+		},
+		{
+			name: "connect dial failure",
+			raw:  "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "unsupported HTTP scheme",
+			raw:  "GET ftp://example.com/file HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "HTTP dial failure",
+			raw:  "GET http://example.com/file HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			want: http.StatusBadGateway,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := net.Dial("unix", sock)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			if _, err := io.WriteString(conn, tt.raw); err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.ReadResponse(
+				bufio.NewReader(conn),
+				&http.Request{Method: strings.Fields(tt.raw)[0]},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != tt.want {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tt.want)
+			}
+		})
+	}
+
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		proxy.handleHTTP(
+			context.Background(),
+			server,
+			&http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Path: "/"},
+				Header: make(http.Header),
+			},
+		)
+		_ = server.Close()
+	}()
+	resp, err := http.ReadResponse(
+		bufio.NewReader(client),
+		&http.Request{Method: http.MethodGet},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	_ = client.Close()
+	<-done
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("origin-form missing host status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestDialFirstFailurePaths(t *testing.T) {
+	if _, err := dialFirst(context.Background(), nil, 443); err == nil {
+		t.Fatal("empty dial address list was accepted")
+	}
+	if _, err := dialFirst(
+		context.Background(),
+		[]net.IP{net.ParseIP("127.0.0.1")},
+		443,
+	); err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("private dial error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := dialFirst(
+		ctx,
+		[]net.IP{net.ParseIP("1.1.1.1")},
+		443,
+	); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled public dial error = %v, want context canceled", err)
+	}
+}
+
+func TestRelayPropagatesUpstreamCloseToTCPClient(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		_ = conn.Close()
+	}()
+
+	relay, err := StartRelay(0, sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = relay.Close() })
+	client, err := net.Dial("tcp", relay.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if err := client.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var buf [1]byte
+	if _, err := client.Read(buf[:]); err != io.EOF {
+		t.Fatalf("read error = %v, want EOF", err)
+	}
+	<-serverDone
+}
+
+func TestRelayCloseClosesActiveConnections(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "relay.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	accepted := make(chan struct{})
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		close(accepted)
+		_, _ = io.Copy(io.Discard, conn)
+		_ = conn.Close()
+	}()
+
+	relay, err := StartRelay(0, sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := net.Dial("tcp", relay.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("relay did not connect to upstream")
+	}
+	closed := make(chan error, 1)
+	go func() { closed <- relay.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("relay close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Relay.Close blocked with an active connection")
+	}
+	<-serverDone
+}
+
+func TestRelayCapsActiveConnections(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+	var dialed atomic.Int32
+	serverEnds := make(chan net.Conn, defaultRelayMaxConnections)
+	relay, err := startRelayWithDialer(
+		port,
+		"test",
+		func(context.Context) (net.Conn, error) {
+			clientEnd, serverEnd := net.Pipe()
+			serverEnds <- serverEnd
+			dialed.Add(1)
+			return clientEnd, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clients []net.Conn
+	for i := 0; i < defaultRelayMaxConnections+12; i++ {
+		conn, dialErr := net.Dial("tcp", relay.Addr())
+		if dialErr == nil {
+			clients = append(clients, conn)
+		}
+	}
+	deadline := time.Now().Add(time.Second)
+	for dialed.Load() < defaultRelayMaxConnections &&
+		time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := dialed.Load(); got != defaultRelayMaxConnections {
+		t.Fatalf("active upstreams = %d, want %d", got, defaultRelayMaxConnections)
+	}
+	for _, conn := range clients {
+		_ = conn.Close()
+	}
+	for i := int32(0); i < dialed.Load(); i++ {
+		_ = (<-serverEnds).Close()
+	}
+	if err := relay.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProxyCloseClosesActiveUpstream(t *testing.T) {
+	proxyEnd, serverEnd := net.Pipe()
+	t.Cleanup(func() { _ = serverEnd.Close() })
+	requestRead := make(chan struct{})
+	go func() {
+		_, _ = http.ReadRequest(bufio.NewReader(serverEnd))
+		close(requestRead)
+	}()
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{
+		addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}},
+	}
+	proxy, err := startTestProxy(
+		filepath.Join(t.TempDir(), "proxy.sock"),
+		policy,
+		func(context.Context, string, string) (net.Conn, error) {
+			return proxyEnd, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := net.Dial("unix", proxy.UnixPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	_, _ = io.WriteString(
+		client,
+		"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n",
+	)
+	<-requestRead
+	closed := make(chan error, 1)
+	go func() { closed <- proxy.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Proxy.Close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Proxy.Close blocked on an active upstream")
+	}
+}
+
+func TestProxyDenyAndRelayHTTP(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "proxy.sock")
+
+	auditor := &memoryAuditor{}
+	policy := StaticAllowlist("example.com")
+	policy.Auditor = auditor
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+
+	proxy, err := startTestProxy(sock, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	relay, err := StartRelay(port, sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = relay.Close() })
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: relay.Addr()}),
+		},
+	}
+	resp, err := client.Get("http://evil.example/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if len(auditor.Events) == 0 {
+		t.Fatal("expected audit events")
+	}
+}
+
+func TestProxyHTTPRejectsMismatchedHost(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	var dialed atomic.Bool
+	proxy, err := startTestProxy(
+		sock,
+		policy,
+		func(context.Context, string, string) (net.Conn, error) {
+			dialed.Store(true)
+			return nil, errors.New("should not dial mismatched Host")
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		proxy.handleHTTP(
+			context.Background(),
+			server,
+			&http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Scheme: "http", Host: "example.com", Path: "/path"},
+				Host:   "other.example",
+				Header: make(http.Header),
+			},
+		)
+		_ = server.Close()
+	}()
+	resp, err := http.ReadResponse(
+		bufio.NewReader(client),
+		&http.Request{Method: http.MethodGet},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	_ = client.Close()
+	<-done
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if dialed.Load() {
+		t.Fatal("mismatched Host reached upstream dial")
+	}
+}
+
+func TestProxyHTTPCanonicalizesMatchingHost(t *testing.T) {
+	var gotHost string
+	var gotProxyAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		gotProxyAuthorization = r.Header.Get("Proxy-Authorization")
+		_, _ = io.WriteString(w, "OK")
+	}))
+	t.Cleanup(upstream.Close)
+
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	proxy, err := startTestProxy(sock, policy, func(ctx context.Context, network, address string) (net.Conn, error) {
+		return net.Dial("tcp", upstream.Listener.Addr().String())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	raw := "GET http://example.com/path HTTP/1.1\r\n" +
+		"Host: EXAMPLE.COM:80\r\n" +
+		"Proxy-Authorization: Basic secret\r\n\r\n"
+	if _, err := io.WriteString(conn, raw); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if gotHost != "example.com" {
+		t.Fatalf("upstream Host = %q, want example.com", gotHost)
+	}
+	if gotProxyAuthorization != "" {
+		t.Fatalf("upstream received Proxy-Authorization %q", gotProxyAuthorization)
+	}
+}
+
+func TestProxyCONNECTIPRejectsNonTLS(t *testing.T) {
+	upstream, peer := net.Pipe()
+	t.Cleanup(func() {
+		_ = upstream.Close()
+		_ = peer.Close()
+	})
+	proxy, err := startTestProxy(
+		filepath.Join(t.TempDir(), "proxy.sock"),
+		StaticAllowlist("1.1.1.1"),
+		func(context.Context, string, string) (net.Conn, error) {
+			return upstream, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+	conn, err := net.Dial("unix", proxy.UnixPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	_, _ = io.WriteString(
+		conn,
+		"CONNECT 1.1.1.1:443 HTTP/1.1\r\nHost: 1.1.1.1:443\r\n\r\n",
+	)
+	resp, err := http.ReadResponse(
+		bufio.NewReader(conn),
+		&http.Request{Method: http.MethodConnect},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	_, _ = conn.Write([]byte("PLAIN"))
+	_ = peer.SetReadDeadline(time.Now().Add(time.Second))
+	var buf [5]byte
+	if n, _ := peer.Read(buf[:]); n != 0 {
+		t.Fatalf("non-TLS payload reached upstream: %q", buf[:n])
+	}
+}
+
+func TestProxyCONNECTFlushesBufferedBytesAfterSNI(t *testing.T) {
+	clientEnd, serverEnd := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientEnd.Close()
+		_ = serverEnd.Close()
+	})
+	received := make(chan []byte, 1)
+	go func() {
+		defer close(received)
+		_ = serverEnd.SetReadDeadline(time.Now().Add(2 * time.Second))
+		var got []byte
+		buf := make([]byte, 1024)
+		for {
+			n, err := serverEnd.Read(buf)
+			if n > 0 {
+				got = append(got, buf[:n]...)
+				if bytes.Contains(got, []byte("TRAILING")) {
+					received <- got
+					_ = serverEnd.Close()
+					return
+				}
+			}
+			if err != nil {
+				received <- got
+				return
+			}
+		}
+	}()
+
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	proxy, err := startTestProxy(sock, policy, func(context.Context, string, string) (net.Conn, error) {
+		return clientEnd, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hello := tlsClientHelloRecord("example.com")
+	payload := append(append([]byte(nil), hello...), []byte("TRAILING")...)
+	if _, err := fmt.Fprintf(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d", resp.StatusCode)
+	}
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	got := <-received
+	if !bytes.Contains(got, hello) {
+		t.Fatalf("upstream missing ClientHello: %q", got)
+	}
+	if !bytes.Contains(got, []byte("TRAILING")) {
+		t.Fatalf("upstream missing buffered trailing bytes: %q", got)
+	}
+}
+
+func TestProxyAllowViaDialHook(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "UPSTREAM_OK")
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "proxy.sock")
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+
+	proxy, err := startTestProxy(sock, policy, func(ctx context.Context, network, address string) (net.Conn, error) {
+		return net.Dial("tcp", upstream.Listener.Addr().String())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return net.Dial("unix", sock)
+			},
+		},
+	}
+	resp, err := client.Get("http://example.com/hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || string(body) != "UPSTREAM_OK" {
+		t.Fatalf("status=%d body=%q", resp.StatusCode, body)
+	}
+}
+
+func TestStartProxySnapshotsPolicySlices(t *testing.T) {
+	hosts := []string{"example.com"}
+	ports := []int{443}
+	policy := Policy{
+		AllowedHosts: hosts,
+		AllowedPorts: ports,
+	}
+	proxy, err := startTestProxy(
+		filepath.Join(t.TempDir(), "proxy.sock"),
+		policy,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	hosts[0] = "evil.example"
+	ports[0] = 22
+	if got := proxy.policy.AllowedHosts[0]; got != "example.com" {
+		t.Fatalf("proxy host policy changed to %q", got)
+	}
+	if got := proxy.policy.AllowedPorts[0]; got != 443 {
+		t.Fatalf("proxy port policy changed to %d", got)
+	}
+}
+
+func TestProxyCONNECTRequiresMatchingSNI(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "TLS_OK")
+	}))
+	t.Cleanup(upstream.Close)
+
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	policy := StaticAllowlist("example.com")
+	policy.Resolver = stubResolver{addrs: []net.IPAddr{{IP: net.ParseIP("1.1.1.1")}}}
+	proxy, err := startTestProxy(sock, policy, func(ctx context.Context, network, address string) (net.Conn, error) {
+		return net.Dial("tcp", upstream.Listener.Addr().String())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	client := &http.Client{Transport: &http.Transport{
+		Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: "proxy.invalid"}),
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return net.Dial("unix", sock)
+		},
+		TLSClientConfig: &tls.Config{ // #nosec G402 -- local test TLS server.
+			InsecureSkipVerify: true,
+		},
+	}}
+	resp, err := client.Get("https://example.com/")
+	if err != nil {
+		t.Fatalf("matching SNI request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "TLS_OK" {
+		t.Fatalf("body = %q, want TLS_OK", body)
+	}
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := fmt.Fprint(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	connectResp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = connectResp.Body.Close()
+	if connectResp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d", connectResp.StatusCode)
+	}
+	tlsConn := tls.Client(conn, &tls.Config{ // #nosec G402 -- local mismatch probe.
+		ServerName:         "evil.example",
+		InsecureSkipVerify: true,
+	})
+	if err := tlsConn.Handshake(); err == nil {
+		t.Fatal("mismatched SNI handshake succeeded")
+	}
+}
+
+func TestStartProxySecuresSocketAndRedactsAudit(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	auditor := &memoryAuditor{}
+	policy := StaticAllowlist("example.com")
+	policy.Auditor = auditor
+	identity := RunIdentity{
+		Principal: "principal",
+		Session:   "session",
+		Request:   "request",
+	}
+	proxy, err := StartProxy(sock, policy, WithRunIdentity(identity))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket mode = %o, want 600", got)
+	}
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprint(conn, "GET http://user:secret@evil.example/path?token=secret HTTP/1.1\r\nHost: evil.example\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	_ = conn.Close()
+	if len(auditor.Events) != 1 {
+		t.Fatalf("audit event count = %d, want 1", len(auditor.Events))
+	}
+	event := auditor.Events[0]
+	if event.Principal != identity.Principal ||
+		event.Session != identity.Session ||
+		event.Request != identity.Request {
+		t.Fatalf("audit identity = %#v, want %#v", event, identity)
+	}
+	if event.Target.Path != "" || event.Target.Original != "" ||
+		event.Target.HostHeader != "" {
+		t.Fatalf("audit target leaked request data: %#v", event.Target)
+	}
+}
+
+func TestProxyRejectsOversizedHeaders(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	proxy, err := StartProxy(sock, StaticAllowlist("example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = proxy.Close() })
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	request := "GET http://example.com/ HTTP/1.1\r\nX-Large: " +
+		strings.Repeat("a", defaultProxyMaxHeaderBytes) + "\r\n\r\n"
+	if _, err := io.WriteString(conn, request); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestHeaderFieldsTooLarge {
+		t.Fatalf("status = %d, want 431", resp.StatusCode)
+	}
+}
+
+func TestRelayForwardsToUnix(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "echo.sock")
+	ul, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ul.Close() })
+	go func() {
+		c, err := ul.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 64)
+		n, _ := c.Read(buf)
+		_, _ = c.Write([]byte("ECHO:" + string(buf[:n])))
+	}()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	relay, err := StartRelay(port, sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = relay.Close() })
+
+	c, err := net.Dial("tcp", relay.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	_, _ = c.Write([]byte("ping"))
+	buf := make([]byte, 64)
+	n, err := c.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != "ECHO:ping" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSSRFBlocksLoopbackLiteralHost(t *testing.T) {
+	p := StaticAllowlist("127.0.0.1")
+	d := p.Decide(context.Background(), Target{Host: "127.0.0.1", Port: 80})
+	if d.Allow {
+		t.Fatal("loopback literal must be denied")
+	}
+	if !strings.Contains(d.Reason, "blocked") {
+		t.Fatalf("reason = %q", d.Reason)
+	}
+}
+
+func tlsClientHelloRecord(sni string) []byte {
+	nameEntry := []byte{0}
+	var nameLen [2]byte
+	binary.BigEndian.PutUint16(nameLen[:], uint16(len(sni)))
+	nameEntry = append(nameEntry, nameLen[:]...)
+	nameEntry = append(nameEntry, sni...)
+	var listLen [2]byte
+	binary.BigEndian.PutUint16(listLen[:], uint16(len(nameEntry)))
+	list := append(listLen[:], nameEntry...)
+	ext := []byte{0, 0}
+	var extLen [2]byte
+	binary.BigEndian.PutUint16(extLen[:], uint16(len(list)))
+	ext = append(ext, extLen[:]...)
+	ext = append(ext, list...)
+	body := minimalClientHelloBody(ext)
+	handshake := []byte{
+		1,
+		byte(len(body) >> 16),
+		byte(len(body) >> 8),
+		byte(len(body)),
+	}
+	handshake = append(handshake, body...)
+	record := []byte{
+		22, 3, 3,
+		byte(len(handshake) >> 8),
+		byte(len(handshake)),
+	}
+	return append(record, handshake...)
+}
+
+func TestRelayCloseCancelsUpstreamDial(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+
+	dialStarted := make(chan struct{})
+	relay, err := startRelayWithDialer(
+		port,
+		"blocking-dial",
+		func(ctx context.Context) (net.Conn, error) {
+			close(dialStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := net.Dial("tcp", relay.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("relay did not enter upstream dial")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- relay.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Relay.Close did not cancel the upstream dial")
+	}
+}
+
+type contextBlockingAuditor struct {
+	started     chan struct{}
+	startedOnce sync.Once
+}
+
+func (a *contextBlockingAuditor) Record(ctx context.Context, _ AuditEvent) {
+	a.startedOnce.Do(func() { close(a.started) })
+	<-ctx.Done()
+}
+
+func TestProxyCloseCancelsAuditor(t *testing.T) {
+	auditor := &contextBlockingAuditor{started: make(chan struct{})}
+	policy := StaticAllowlist("allowed.example")
+	policy.Auditor = auditor
+	proxy, err := StartProxy(
+		filepath.Join(t.TempDir(), "proxy.sock"),
+		policy,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := net.Dial("unix", proxy.UnixPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if _, err := fmt.Fprint(
+		client,
+		"GET http://denied.example/ HTTP/1.1\r\nHost: denied.example\r\n\r\n",
+	); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-auditor.started:
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not enter auditor callback")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- proxy.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Proxy.Close did not cancel the auditor callback")
+	}
+	_, _ = io.Copy(io.Discard, client)
+}
+
+func TestProxyRemovesResponseHopByHopHeaders(t *testing.T) {
+	upstream, peer := net.Pipe()
+	defer peer.Close()
+	go func() {
+		defer peer.Close()
+		_, _ = http.ReadRequest(bufio.NewReader(peer))
+		_, _ = fmt.Fprint(
+			peer,
+			"HTTP/1.1 200 OK\r\n"+
+				"Content-Length: 0\r\n"+
+				"Connection: X-Test-Hop\r\n"+
+				"X-Test-Hop: leaked\r\n\r\n",
+		)
+	}()
+	proxy, err := startTestProxy(
+		filepath.Join(t.TempDir(), "proxy.sock"),
+		StaticAllowlist("1.1.1.1"),
+		func(context.Context, string, string) (net.Conn, error) {
+			return upstream, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+	client, err := net.Dial("unix", proxy.UnixPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if _, err := fmt.Fprint(
+		client,
+		"GET http://1.1.1.1/ HTTP/1.1\r\nHost: 1.1.1.1\r\n\r\n",
+	); err != nil {
+		t.Fatal(err)
+	}
+	response, err := http.ReadResponse(
+		bufio.NewReader(client),
+		&http.Request{Method: http.MethodGet},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if got := response.Header.Get("X-Test-Hop"); got != "" {
+		t.Fatalf("hop-by-hop response header leaked: %q", got)
+	}
+}

--- a/codeexecutor/sandbox/controlledegress/relay.go
+++ b/codeexecutor/sandbox/controlledegress/relay.go
@@ -1,0 +1,218 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// DefaultRelayPort is the guest loopback port used for HTTP_PROXY injection.
+const DefaultRelayPort = 17923
+
+const defaultRelayMaxConnections = 128
+
+// Exit codes for the egress-relay helper process.
+const (
+	// ExitUsageError is returned for invalid helper arguments.
+	ExitUsageError = 2
+	// ExitSetupFailed is returned when the loopback→UDS relay cannot start.
+	ExitSetupFailed = 75
+	// SetupErrorPrefix begins authenticated failures emitted before the user
+	// command starts. The relay appends a host-generated token.
+	SetupErrorPrefix = "egress-relay: setup:"
+	// RunErrorPrefix marks failures emitted while starting the user command.
+	RunErrorPrefix = "egress-relay: run:"
+)
+
+// Relay bridges TCP connections on 127.0.0.1:ListenPort to a Unix socket.
+// This is the in-sandbox equivalent of Claude Code's socat hop.
+type Relay struct {
+	ListenHost string
+	ListenPort int
+	UnixPath   string
+	dial       func(context.Context) (net.Conn, error)
+
+	ln net.Listener
+	wg sync.WaitGroup
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	conns  map[net.Conn]struct{}
+	slots  chan struct{}
+	closed bool
+}
+
+// StartRelay listens on 127.0.0.1:port and forwards each connection to unixPath.
+// Controlled egress starts this trusted relay before applying seccomp to the
+// user workload.
+func StartRelay(listenPort int, unixPath string) (*Relay, error) {
+	dialer := &net.Dialer{}
+	return startRelayWithDialer(listenPort, unixPath, func(ctx context.Context) (net.Conn, error) {
+		return dialer.DialContext(ctx, "unix", unixPath)
+	})
+}
+
+func startRelayWithDialer(
+	listenPort int,
+	name string,
+	dial func(context.Context) (net.Conn, error),
+) (*Relay, error) {
+	if listenPort <= 0 {
+		listenPort = DefaultRelayPort
+	}
+	if dial == nil {
+		return nil, fmt.Errorf("controlled egress relay missing dialer")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &Relay{
+		ListenHost: "127.0.0.1",
+		ListenPort: listenPort,
+		UnixPath:   name,
+		dial:       dial,
+		ctx:        ctx,
+		cancel:     cancel,
+		conns:      make(map[net.Conn]struct{}),
+		slots:      make(chan struct{}, defaultRelayMaxConnections),
+	}
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", r.ListenHost, r.ListenPort))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	r.ln = ln
+	go r.serve()
+	return r, nil
+}
+
+// Addr returns the HTTP proxy URL host:port (without scheme).
+func (r *Relay) Addr() string {
+	return fmt.Sprintf("%s:%d", r.ListenHost, r.ListenPort)
+}
+
+// ProxyURL returns http://127.0.0.1:port for HTTP_PROXY injection.
+func (r *Relay) ProxyURL() string {
+	return "http://" + r.Addr()
+}
+
+// Close stops the relay.
+func (r *Relay) Close() error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	if r.cancel != nil {
+		r.cancel()
+	}
+	ln := r.ln
+	conns := make([]net.Conn, 0, len(r.conns))
+	for conn := range r.conns {
+		conns = append(conns, conn)
+	}
+	r.mu.Unlock()
+
+	var closeErr error
+	if ln != nil {
+		closeErr = ln.Close()
+	}
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+	r.wg.Wait()
+	return closeErr
+}
+
+func (r *Relay) serve() {
+	for {
+		c, err := r.ln.Accept()
+		if err != nil {
+			r.mu.Lock()
+			closed := r.closed
+			r.mu.Unlock()
+			if closed {
+				return
+			}
+			continue
+		}
+		select {
+		case r.slots <- struct{}{}:
+		default:
+			_ = c.Close()
+			continue
+		}
+		r.mu.Lock()
+		if r.closed {
+			r.mu.Unlock()
+			<-r.slots
+			_ = c.Close()
+			return
+		}
+		r.conns[c] = struct{}{}
+		r.wg.Add(1)
+		r.mu.Unlock()
+		go func(conn net.Conn) {
+			defer r.wg.Done()
+			defer func() { <-r.slots }()
+			r.handle(conn)
+		}(c)
+	}
+}
+
+func (r *Relay) handle(client net.Conn) {
+	defer r.releaseConn(client)
+	upstream, err := r.dial(r.ctx)
+	if err != nil {
+		return
+	}
+	if !r.trackConn(upstream) {
+		return
+	}
+	defer r.releaseConn(upstream)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	pipe := func(dst, src net.Conn) {
+		defer wg.Done()
+		_, _ = io.Copy(dst, src)
+		type closeWriter interface{ CloseWrite() error }
+		if cw, ok := dst.(closeWriter); ok {
+			_ = cw.CloseWrite()
+			return
+		}
+		_ = dst.Close()
+	}
+	go pipe(upstream, client)
+	go pipe(client, upstream)
+	wg.Wait()
+}
+
+func (r *Relay) trackConn(conn net.Conn) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		_ = conn.Close()
+		return false
+	}
+	r.conns[conn] = struct{}{}
+	return true
+}
+
+func (r *Relay) releaseConn(conn net.Conn) {
+	_ = conn.Close()
+	r.mu.Lock()
+	delete(r.conns, conn)
+	r.mu.Unlock()
+}

--- a/codeexecutor/sandbox/controlledegress/resolver.go
+++ b/codeexecutor/sandbox/controlledegress/resolver.go
@@ -1,0 +1,123 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+)
+
+var blockedPrefixes = mustParsePrefixes(
+	"0.0.0.0/8",
+	"10.0.0.0/8",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"100.64.0.0/10",
+	"198.18.0.0/15",
+	"192.0.2.0/24",
+	"198.51.100.0/24",
+	"203.0.113.0/24",
+	"224.0.0.0/4",
+	"240.0.0.0/4",
+	"64:ff9b::/96",
+	"64:ff9b:1::/48",
+	"::1/128",
+	"fc00::/7",
+	"fe80::/10",
+	"fec0::/10",
+)
+
+// Resolver looks up host addresses. Implementations must support concurrent
+// calls and return promptly when ctx is canceled. Proxy.Close cancels the
+// context and waits for in-flight lookups to return. Tests may inject fakes.
+type Resolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+type defaultResolver struct{}
+
+func (defaultResolver) LookupIPAddr(
+	ctx context.Context,
+	host string,
+) ([]net.IPAddr, error) {
+	return net.DefaultResolver.LookupIPAddr(ctx, host)
+}
+
+func resolveAndValidate(
+	ctx context.Context,
+	resolver Resolver,
+	host string,
+) ([]net.IP, error) {
+	if resolver == nil {
+		resolver = defaultResolver{}
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if err := ValidateDialIP(ip); err != nil {
+			return nil, err
+		}
+		return []net.IP{ip}, nil
+	}
+	addrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("dns lookup %s: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("dns lookup %s: no addresses", host)
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		if err := ValidateDialIP(addr.IP); err != nil {
+			return nil, fmt.Errorf("dns %s: %w", host, err)
+		}
+		ips = append(ips, addr.IP)
+	}
+	return ips, nil
+}
+
+func mustParsePrefixes(cidrs ...string) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			panic(err)
+		}
+		out = append(out, prefix)
+	}
+	return out
+}
+
+// ValidateDialIP rejects private, loopback, link-local, CGNAT, and TEST-NET
+// addresses (including IPv4-mapped IPv6 after unmapping).
+func ValidateDialIP(ip net.IP) error {
+	if ip == nil {
+		return fmt.Errorf("nil IP")
+	}
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return fmt.Errorf("invalid IP %v", ip)
+	}
+	addr = addr.Unmap()
+	if !addr.IsValid() ||
+		addr.IsUnspecified() ||
+		addr.IsMulticast() ||
+		addr.IsLinkLocalUnicast() {
+		return fmt.Errorf("blocked address %s", addr)
+	}
+	for _, prefix := range blockedPrefixes {
+		if prefix.Contains(addr) {
+			return fmt.Errorf("blocked address %s", addr)
+		}
+	}
+	return nil
+}

--- a/codeexecutor/sandbox/controlledegress/socket_linux_test.go
+++ b/codeexecutor/sandbox/controlledegress/socket_linux_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPrepareUnixSocketPathPreservesBusyListener(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "busy.sock")
+	listener, err := unix.Socket(
+		unix.AF_UNIX,
+		unix.SOCK_STREAM|unix.SOCK_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(listener)
+	if err := unix.Bind(listener, &unix.SockaddrUnix{Name: path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Listen(listener, 1); err != nil {
+		t.Fatal(err)
+	}
+	var clients []int
+	defer func() {
+		for _, fd := range clients {
+			_ = unix.Close(fd)
+		}
+	}()
+	for i := 0; i < 16; i++ {
+		fd, socketErr := unix.Socket(
+			unix.AF_UNIX,
+			unix.SOCK_STREAM|unix.SOCK_CLOEXEC|unix.SOCK_NONBLOCK,
+			0,
+		)
+		if socketErr != nil {
+			t.Fatal(socketErr)
+		}
+		connectErr := unix.Connect(fd, &unix.SockaddrUnix{Name: path})
+		if connectErr != nil {
+			_ = unix.Close(fd)
+			break
+		}
+		clients = append(clients, fd)
+	}
+	prepareErr := prepareUnixSocketPath(path)
+	if prepareErr == nil {
+		t.Fatal("busy socket path was accepted as stale")
+	}
+	_, statErr := os.Lstat(path)
+	if statErr != nil {
+		t.Fatalf("busy socket path was removed: %v", statErr)
+	}
+}

--- a/codeexecutor/sandbox/controlledegress/tls_sni.go
+++ b/codeexecutor/sandbox/controlledegress/tls_sni.go
@@ -1,0 +1,147 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const maxTLSClientHelloBytes = 128 << 10
+
+var errTLSClientHelloNoSNI = errors.New("TLS ClientHello has no SNI")
+
+func readTLSClientHelloSNI(r io.Reader) (string, []byte, error) {
+	var raw []byte
+	var handshake []byte
+	for len(raw) < maxTLSClientHelloBytes {
+		header := make([]byte, 5)
+		if _, err := io.ReadFull(r, header); err != nil {
+			return "", raw, fmt.Errorf("read TLS record header: %w", err)
+		}
+		if header[0] != 22 {
+			return "", raw, fmt.Errorf("CONNECT payload is not a TLS handshake")
+		}
+		recordLen := int(binary.BigEndian.Uint16(header[3:5]))
+		if recordLen <= 0 || len(raw)+5+recordLen > maxTLSClientHelloBytes {
+			return "", raw, fmt.Errorf("TLS ClientHello exceeds %d bytes", maxTLSClientHelloBytes)
+		}
+		payload := make([]byte, recordLen)
+		if _, err := io.ReadFull(r, payload); err != nil {
+			return "", raw, fmt.Errorf("read TLS record: %w", err)
+		}
+		raw = append(raw, header...)
+		raw = append(raw, payload...)
+		handshake = append(handshake, payload...)
+		if len(handshake) < 4 {
+			continue
+		}
+		if handshake[0] != 1 {
+			return "", raw, fmt.Errorf("first TLS handshake message is not ClientHello")
+		}
+		helloLen := int(handshake[1])<<16 |
+			int(handshake[2])<<8 |
+			int(handshake[3])
+		if helloLen+4 > maxTLSClientHelloBytes {
+			return "", raw, fmt.Errorf("TLS ClientHello exceeds %d bytes", maxTLSClientHelloBytes)
+		}
+		if len(handshake) < helloLen+4 {
+			continue
+		}
+		sni, err := parseClientHelloSNI(handshake[4 : helloLen+4])
+		return sni, raw, err
+	}
+	return "", raw, fmt.Errorf("TLS ClientHello exceeds %d bytes", maxTLSClientHelloBytes)
+}
+
+func parseClientHelloSNI(hello []byte) (string, error) {
+	// legacy_version + random
+	if len(hello) < 34 {
+		return "", fmt.Errorf("truncated TLS ClientHello")
+	}
+	pos := 34
+	if pos >= len(hello) {
+		return "", fmt.Errorf("truncated TLS session id")
+	}
+	sessionLen := int(hello[pos])
+	pos++
+	if pos+sessionLen+2 > len(hello) {
+		return "", fmt.Errorf("truncated TLS session id")
+	}
+	pos += sessionLen
+	cipherLen := int(binary.BigEndian.Uint16(hello[pos : pos+2]))
+	pos += 2
+	if cipherLen == 0 || pos+cipherLen+1 > len(hello) {
+		return "", fmt.Errorf("truncated TLS cipher suites")
+	}
+	pos += cipherLen
+	compressionLen := int(hello[pos])
+	pos++
+	if pos+compressionLen > len(hello) {
+		return "", fmt.Errorf("truncated TLS compression methods")
+	}
+	pos += compressionLen
+	if pos == len(hello) {
+		return "", errTLSClientHelloNoSNI
+	}
+	if pos+2 > len(hello) {
+		return "", fmt.Errorf("truncated TLS extensions")
+	}
+	extensionsLen := int(binary.BigEndian.Uint16(hello[pos : pos+2]))
+	pos += 2
+	if pos+extensionsLen > len(hello) {
+		return "", fmt.Errorf("truncated TLS extensions")
+	}
+	end := pos + extensionsLen
+	for pos+4 <= end {
+		extensionType := binary.BigEndian.Uint16(hello[pos : pos+2])
+		extensionLen := int(binary.BigEndian.Uint16(hello[pos+2 : pos+4]))
+		pos += 4
+		if pos+extensionLen > end {
+			return "", fmt.Errorf("truncated TLS extension")
+		}
+		if extensionType == 0 {
+			return parseServerNameExtension(hello[pos : pos+extensionLen])
+		}
+		pos += extensionLen
+	}
+	return "", errTLSClientHelloNoSNI
+}
+
+func parseServerNameExtension(extension []byte) (string, error) {
+	if len(extension) < 2 {
+		return "", fmt.Errorf("truncated TLS server name extension")
+	}
+	listLen := int(binary.BigEndian.Uint16(extension[:2]))
+	if listLen+2 > len(extension) {
+		return "", fmt.Errorf("truncated TLS server name list")
+	}
+	pos := 2
+	end := pos + listLen
+	for pos+3 <= end {
+		nameType := extension[pos]
+		nameLen := int(binary.BigEndian.Uint16(extension[pos+1 : pos+3]))
+		pos += 3
+		if pos+nameLen > end {
+			return "", fmt.Errorf("truncated TLS server name")
+		}
+		if nameType == 0 {
+			if nameLen == 0 {
+				return "", fmt.Errorf("empty TLS server name")
+			}
+			return strings.ToLower(string(extension[pos : pos+nameLen])), nil
+		}
+		pos += nameLen
+	}
+	return "", errTLSClientHelloNoSNI
+}

--- a/codeexecutor/sandbox/controlledegress/tls_sni_test.go
+++ b/codeexecutor/sandbox/controlledegress/tls_sni_test.go
@@ -1,0 +1,112 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package controlledegress
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestReadTLSClientHelloSNIRejectsMalformedRecords(t *testing.T) {
+	oversizedHello := []byte{22, 3, 3, 0, 4, 1, 0xff, 0xff, 0xff}
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "missing header"},
+		{name: "not handshake", raw: []byte{23, 3, 3, 0, 1, 0}},
+		{name: "empty record", raw: []byte{22, 3, 3, 0, 0}},
+		{name: "truncated record", raw: []byte{22, 3, 3, 0, 2, 1}},
+		{name: "truncated handshake header", raw: []byte{22, 3, 3, 0, 1, 1}},
+		{name: "wrong handshake type", raw: []byte{22, 3, 3, 0, 4, 2, 0, 0, 0}},
+		{name: "oversized hello", raw: oversizedHello},
+		{name: "truncated hello", raw: []byte{22, 3, 3, 0, 4, 1, 0, 0, 8}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := readTLSClientHelloSNI(bytes.NewReader(tt.raw)); err == nil {
+				t.Fatal("malformed TLS record was accepted")
+			}
+		})
+	}
+}
+
+func TestParseClientHelloSNIRejectsMalformedBodies(t *testing.T) {
+	base := minimalClientHelloBody(nil)
+	tests := []struct {
+		name  string
+		hello []byte
+	}{
+		{name: "short fixed fields", hello: make([]byte, 33)},
+		{name: "missing session length", hello: make([]byte, 34)},
+		{name: "session overflow", hello: append(make([]byte, 34), 10)},
+		{name: "zero ciphers", hello: append(make([]byte, 35), 0, 0, 0)},
+		{name: "compression overflow", hello: append(append(make([]byte, 35), 0, 2, 0x13, 0x01), 2, 0)},
+		{name: "no extensions", hello: minimalClientHelloBody(nil)[:41]},
+		{name: "truncated extension length", hello: append(minimalClientHelloBody(nil)[:41], 0)},
+		{name: "extensions overflow", hello: append(minimalClientHelloBody(nil)[:41], 0, 8, 0)},
+		{name: "truncated extension", hello: minimalClientHelloBody([]byte{0, 0, 0, 4, 0})},
+		{name: "no sni", hello: minimalClientHelloBody([]byte{0, 1, 0, 0})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseClientHelloSNI(tt.hello); err == nil {
+				t.Fatalf("malformed ClientHello accepted: %x (base=%d)", tt.hello, len(base))
+			}
+		})
+	}
+}
+
+func TestParseServerNameExtensionValidation(t *testing.T) {
+	validName := "example.com"
+	valid := make([]byte, 2+3+len(validName))
+	binary.BigEndian.PutUint16(valid[:2], uint16(3+len(validName)))
+	valid[2] = 0
+	binary.BigEndian.PutUint16(valid[3:5], uint16(len(validName)))
+	copy(valid[5:], validName)
+	if got, err := parseServerNameExtension(valid); err != nil || got != validName {
+		t.Fatalf("valid SNI got=%q err=%v", got, err)
+	}
+
+	tests := [][]byte{
+		nil,
+		{0, 4, 0},
+		{0, 3, 0, 0, 2, 'x'},
+		{0, 3, 0, 0, 0},
+		{0, 3, 1, 0, 0},
+	}
+	for _, extension := range tests {
+		if _, err := parseServerNameExtension(extension); err == nil {
+			t.Fatalf("malformed SNI extension accepted: %x", extension)
+		}
+	}
+
+	upper := append([]byte(nil), valid...)
+	copy(upper[5:], strings.ToUpper(validName))
+	if got, err := parseServerNameExtension(upper); err != nil || got != validName {
+		t.Fatalf("uppercase SNI got=%q err=%v", got, err)
+	}
+}
+
+func minimalClientHelloBody(extensions []byte) []byte {
+	hello := make([]byte, 34)
+	hello = append(hello, 0)
+	hello = append(hello, 0, 2, 0x13, 0x01)
+	hello = append(hello, 1, 0)
+	if extensions == nil {
+		return hello
+	}
+	var length [2]byte
+	binary.BigEndian.PutUint16(length[:], uint16(len(extensions)))
+	hello = append(hello, length[:]...)
+	return append(hello, extensions...)
+}

--- a/codeexecutor/sandbox/docs/DEPLOYMENT_INSIDE_DOCKER.md
+++ b/codeexecutor/sandbox/docs/DEPLOYMENT_INSIDE_DOCKER.md
@@ -55,6 +55,14 @@ denials remain `EPERM`. Other namespace, mount, executable lookup, or policy set
 failures still make managed sandbox startup fail rather than falling back to
 unsandboxed execution.
 
+`NetworkControlled` starts its trusted TCP-to-Unix relay in the outer bwrap
+sandbox, then launches the user workload through a minimal inner bwrap that
+applies seccomp and creates a nested PID namespace. It does not create another
+user namespace. When the outer probe supports fresh procfs, the inner workload
+also receives a fresh `/proc`; in no-proc fallback mode it inherits the outer
+inaccessible `/proc` view. Container policies must therefore allow the
+additional PID/mount namespace operation as well as the outer bwrap setup.
+
 ## Default Docker
 
 Use default Docker only as a baseline. On many hosts it fails before the managed

--- a/codeexecutor/sandbox/docs/NETWORK_POLICY.md
+++ b/codeexecutor/sandbox/docs/NETWORK_POLICY.md
@@ -1,10 +1,10 @@
 # Sandbox Network Policy
 
 Sandbox profiles own network policy through `NetworkPolicy.Mode`, configured on
-a profile with `WithNetworkPolicy`. The policy is a binary switch:
-`NetworkRestricted` or `NetworkEnabled`. Managed profiles default to
-`NetworkRestricted`, so code runs without host network access unless the caller
-explicitly selects `NetworkEnabled`.
+a profile with `WithNetworkPolicy`. Managed profiles support
+`NetworkRestricted`, `NetworkEnabled`, and Linux-only `NetworkControlled`.
+Managed profiles default to `NetworkRestricted`, so code runs without host
+network access unless the caller explicitly selects another mode.
 
 ## Policy Model
 
@@ -14,6 +14,11 @@ explicitly selects `NetworkEnabled`.
 - `NetworkEnabled` allows the command to use the host network. On Linux this
   means the command is launched without network namespace isolation and without
   the AF_UNIX/AF_VSOCK seccomp filter described below.
+- `NetworkControlled` is Linux-only. It keeps the same isolation as
+  `NetworkRestricted` and allows HTTP/HTTPS egress only through a caller-owned
+  host proxy. Configure it with `PermissionProfile.WithControlledEgressProxy`,
+  not with extra fields on `NetworkPolicy`. `Describe().NetworkAllowed` stays
+  false.
 
 Profile enforcement is separate from network policy. `DangerFullAccessProfile()`
 intentionally runs without local sandbox enforcement and is normalized to
@@ -84,6 +89,45 @@ seccomp filter. The command then shares the host network namespace and may use
 visible host Unix sockets while still using the rest of the configured sandbox
 controls, such as user, PID, mount, environment, and filesystem policy.
 
+### controlled
+
+`NetworkControlled` is opt-in via `WithControlledEgressProxy`. It uses a
+two-stage process model: a trusted relay starts before seccomp, then the user
+workload runs in a nested PID namespace with the AF_UNIX filter applied:
+
+```text
+guest outer namespace (--unshare-net)
+  → HTTP_PROXY=http://127.0.0.1:<port>
+  → trusted egress-relay (loopback TCP → Unix socket)
+  → host HTTP proxy on AF_UNIX (L4/L7)
+  → internet
+
+guest workload (nested PID namespace + AF_UNIX seccomp)
+  → cannot see the relay or create arbitrary Unix sockets
+```
+
+- Only the trusted relay calls `socket(AF_UNIX)`. User code cannot see the
+  relay's outer PID namespace and cannot create AF_UNIX sockets. Host paths such
+  as `docker.sock` remain visible through `--ro-bind / /` but stay unusable.
+- The proxy `UnixPath` and `egress-relay` helper must be outside every
+  guest-writable mount.
+- Provide the helper with `WithControlledEgressRelayPath` or
+  `TRPC_AGENT_EGRESS_RELAY`.
+- Guest `HTTP(S)_PROXY` values are replaced; `ALL_PROXY` and `NO_PROXY` are
+  removed.
+- Start the caller-owned production proxy with `controlledegress.StartProxy`.
+- Keep that proxy alive for every run that references its Unix socket, then
+  call `Proxy.Close`. Custom resolvers, authorizers, and auditors must return
+  promptly when their context is canceled so shutdown can complete.
+- Relay setup errors include a host-generated authentication token. Workload
+  stderr cannot forge this internal setup-failure signal.
+- Wildcard policy entries such as `*.example.com` match subdomains only; add
+  `example.com` explicitly when the apex must also be allowed.
+- macOS `controlled` returns `ErrUnsupportedBackend`.
+
+Policy/proxy implementation lives in
+[`controlledegress`](../controlledegress/).
+
 ## macOS Enforcement
 
 The macOS backend keeps the same public binary model but projects it to
@@ -104,9 +148,7 @@ backend does not claim support for equivalent path-level Unix socket policy.
 
 ## Scope
 
-This design keeps the first Linux implementation intentionally binary:
-networking is either isolated or inherited from the host. It does not currently
-implement per-domain, per-IP, or per-port allow lists. If finer-grained egress
-control is needed later, it should be layered outside this backend or added as a
-new backend capability with explicit policy fields rather than overloading
-`NetworkRestricted`.
+Linux networking is `restricted`, `enabled`, or opt-in `controlled`. Per-domain
+and per-port allow lists belong in the caller-owned host proxy used by
+`controlled`, not in `NetworkRestricted`. Do not overload `NetworkRestricted`
+with proxy endpoints.

--- a/codeexecutor/sandbox/docs/README.md
+++ b/codeexecutor/sandbox/docs/README.md
@@ -41,6 +41,9 @@ host network access:
   sockets and AF_VSOCK through seccomp; anonymous stream and seqpacket
   socketpairs remain available. Pathname or abstract Unix IPC, or AF_VSOCK,
   requires `NetworkEnabled`.
+- `NetworkControlled` keeps that Linux isolation and allows HTTP/HTTPS only
+  through a caller-owned host proxy. A trusted loopback relay starts before the
+  user workload receives the AF_UNIX seccomp filter.
 - `NetworkEnabled` allows the command to use the host network. On Linux this
   means the command is launched without network namespace isolation and without
   the AF_UNIX/AF_VSOCK seccomp filter. On macOS this means the generated Seatbelt

--- a/codeexecutor/sandbox/network_policy.go
+++ b/codeexecutor/sandbox/network_policy.go
@@ -27,16 +27,86 @@ const (
 	NetworkRestricted NetworkMode = "restricted"
 	// NetworkEnabled allows the command to use the host network.
 	NetworkEnabled NetworkMode = "enabled"
+	// NetworkControlled keeps the Linux NetworkRestricted isolation (netns +
+	// AF_UNIX/AF_VSOCK/io_uring seccomp) and allows HTTP/HTTPS egress only
+	// through a caller-owned host proxy. The guest talks to loopback HTTP_PROXY;
+	// a trusted relay connects to the host proxy before the workload-only
+	// seccomp filter is applied. Describe().NetworkAllowed remains false.
+	//
+	// Compatibility: do not add proxy endpoint fields to NetworkPolicy; callers
+	// may use unkeyed literals. Configure the host proxy with
+	// PermissionProfile.WithControlledEgressProxy.
+	NetworkControlled NetworkMode = "controlled"
 )
 
 // NetworkPolicy describes network access for a profile.
+//
+// Compatibility: do not add fields to this struct; callers may use unkeyed
+// literals. Controlled egress endpoint configuration uses
+// PermissionProfile.WithControlledEgressProxy instead.
 type NetworkPolicy struct {
 	Mode NetworkMode
 }
 
+// ControlledEgressProxy configures the host controlled-egress proxy endpoint.
+type ControlledEgressProxy struct {
+	// UnixPath is the absolute path of the host AF_UNIX HTTP proxy socket.
+	// On Linux the runtime rejects paths inside guest-writable mounts. The
+	// trusted relay dials this path before workload-only seccomp is applied.
+	UnixPath string
+	// RelayPort is the guest loopback port for HTTP_PROXY (default 17923).
+	RelayPort int
+}
+
+type resolvedNetworkPolicy struct {
+	mode           NetworkMode
+	isolateNetwork bool
+	unixPath       string
+	relayPort      int
+}
+
+func resolveNetworkPolicy(
+	profile PermissionProfile,
+) (resolvedNetworkPolicy, error) {
+	mode := profile.network.Mode
+	if mode == "" {
+		mode = NetworkRestricted
+	}
+	switch mode {
+	case NetworkRestricted:
+		return resolvedNetworkPolicy{
+			mode:           NetworkRestricted,
+			isolateNetwork: true,
+		}, nil
+	case NetworkEnabled:
+		return resolvedNetworkPolicy{
+			mode:           NetworkEnabled,
+			isolateNetwork: false,
+		}, nil
+	case NetworkControlled:
+		if err := profile.controlledEgress.validate(); err != nil {
+			return resolvedNetworkPolicy{}, err
+		}
+		return resolvedNetworkPolicy{
+			mode:           NetworkControlled,
+			isolateNetwork: true,
+			unixPath:       profile.controlledEgress.UnixPath,
+			relayPort:      profile.controlledEgress.effectiveRelayPort(),
+		}, nil
+	default:
+		return resolvedNetworkPolicy{}, deniedf(
+			ErrPolicyViolation,
+			"network",
+			"",
+			"unsupported network mode %q: want restricted|enabled|controlled",
+			mode,
+		)
+	}
+}
+
 func validateNetworkPolicy(policy NetworkPolicy) error {
 	switch policy.Mode {
-	case NetworkRestricted, NetworkEnabled:
+	case "", NetworkRestricted, NetworkEnabled, NetworkControlled:
 		return nil
 	default:
 		return deniedf(
@@ -50,7 +120,7 @@ func validateNetworkPolicy(policy NetworkPolicy) error {
 }
 
 func validateProfileNetworkPolicy(profile PermissionProfile) error {
-	if err := validateNetworkPolicy(profile.network); err != nil {
+	if _, err := resolveNetworkPolicy(profile); err != nil {
 		return err
 	}
 	if profile.enforcement() == enforcementDisabled &&

--- a/codeexecutor/sandbox/network_policy_test.go
+++ b/codeexecutor/sandbox/network_policy_test.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package sandbox
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveNetworkPolicyModes(t *testing.T) {
+	restricted, err := resolveNetworkPolicy(WorkspaceWriteProfile())
+	if err != nil || restricted.mode != NetworkRestricted || !restricted.isolateNetwork {
+		t.Fatalf("restricted = %+v err=%v", restricted, err)
+	}
+	enabled, err := resolveNetworkPolicy(
+		WorkspaceWriteProfile().WithNetworkPolicy(NetworkPolicy{Mode: NetworkEnabled}),
+	)
+	if err != nil || enabled.mode != NetworkEnabled || enabled.isolateNetwork {
+		t.Fatalf("enabled = %+v err=%v", enabled, err)
+	}
+	sock := filepath.Join(t.TempDir(), "proxy.sock")
+	controlled, err := resolveNetworkPolicy(
+		WorkspaceWriteProfile().WithControlledEgressProxy(ControlledEgressProxy{
+			UnixPath: sock,
+		}),
+	)
+	if err != nil || controlled.mode != NetworkControlled || !controlled.isolateNetwork {
+		t.Fatalf("controlled = %+v err=%v", controlled, err)
+	}
+	if controlled.unixPath != sock || controlled.relayPort == 0 {
+		t.Fatalf("controlled endpoint = %+v", controlled)
+	}
+}
+
+func TestControlledEgressRequiresAbsoluteUnixPath(t *testing.T) {
+	_, err := resolveNetworkPolicy(
+		WorkspaceWriteProfile().WithControlledEgressProxy(ControlledEgressProxy{
+			UnixPath: "relative.sock",
+		}),
+	)
+	if err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("err = %v, want absolute path failure", err)
+	}
+}
+
+func TestUnknownNetworkModeFailsClosed(t *testing.T) {
+	_, err := resolveNetworkPolicy(PermissionProfile{
+		typ:     profileManaged,
+		network: NetworkPolicy{Mode: "weird"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported network mode") {
+		t.Fatalf("err = %v, want unsupported mode", err)
+	}
+}
+
+func TestDisabledProfileRejectsControlled(t *testing.T) {
+	err := validateProfileNetworkPolicy(
+		DangerFullAccessProfile().WithControlledEgressProxy(ControlledEgressProxy{
+			UnixPath: filepath.Join(t.TempDir(), "proxy.sock"),
+		}),
+	)
+	if err == nil || !strings.Contains(err.Error(), "disabled sandbox") {
+		t.Fatalf("err = %v, want disabled sandbox rejection", err)
+	}
+}

--- a/codeexecutor/sandbox/process.go
+++ b/codeexecutor/sandbox/process.go
@@ -59,10 +59,11 @@ func (s ProcessSpec) runProgramSpec() codeexecutor.RunProgramSpec {
 // Process without Wait can retain backend resources and, under serial workspace
 // concurrency, permanently block later runs on the same workspace.
 type Process struct {
-	prepared *preparedProcess
-	stdin    io.WriteCloser
-	stdout   io.ReadCloser
-	stderr   io.ReadCloser
+	prepared    *preparedProcess
+	stdin       io.WriteCloser
+	stdout      io.ReadCloser
+	stderr      io.ReadCloser
+	stderrSetup *processStderrSetupTracker
 
 	waitOnce sync.Once
 	waitDone chan struct{}
@@ -72,6 +73,7 @@ type Process struct {
 type preparedProcess struct {
 	cmd     *exec.Cmd
 	backend string
+	profile PermissionProfile
 	runCtx  context.Context
 	release func()
 	once    sync.Once
@@ -120,22 +122,45 @@ func (r *Runtime) StartProcess(
 		prepared.cleanup()
 		return nil, fmt.Errorf("sandbox: create process stderr: %w", err)
 	}
+	var stderrSetup *processStderrSetupTracker
+	if prepared.profile.network.Mode == NetworkControlled {
+		stderrSetup, err = newProcessStderrSetupTracker(
+			stderr,
+			controlledEgressSetupToken(prepared.cmd.Args),
+		)
+		if err != nil {
+			_ = stdin.Close()
+			_ = stdout.Close()
+			_ = stderr.Close()
+			prepared.cleanup()
+			return nil, fmt.Errorf("sandbox: track process stderr: %w", err)
+		}
+	}
 	if err := prepared.cmd.Start(); err != nil {
 		_ = stdin.Close()
 		_ = stdout.Close()
 		_ = stderr.Close()
+		if stderrSetup != nil {
+			_ = stderrSetup.reader.Close()
+			_ = stderrSetup.writer.Close()
+		}
 		prepared.cleanup()
 		return nil, backendError(ErrSetupFailed, prepared.backend, err)
+	}
+	if stderrSetup != nil {
+		stderrSetup.start()
+		stderr = stderrSetup.reader
 	}
 	// Drop parent ExtraFiles promptly; Wait still runs backend cleanup for
 	// synthetic deny-read targets and other release hooks.
 	releaseCmdExtraFiles(prepared.cmd)
 	return &Process{
-		prepared: prepared,
-		stdin:    stdin,
-		stdout:   stdout,
-		stderr:   stderr,
-		waitDone: make(chan struct{}),
+		prepared:    prepared,
+		stdin:       stdin,
+		stdout:      stdout,
+		stderr:      stderr,
+		stderrSetup: stderrSetup,
+		waitDone:    make(chan struct{}),
 	}, nil
 }
 
@@ -176,6 +201,7 @@ func (r *Runtime) prepareProcess(
 	return &preparedProcess{
 		cmd:     cmd,
 		backend: backendName,
+		profile: prep.profile,
 		runCtx:  runCtx,
 		release: func() {
 			if backendCleanup != nil {
@@ -237,6 +263,17 @@ func (p *Process) Wait() error {
 				}
 			case context.Canceled:
 				p.waitErr = errors.Join(context.Canceled, processErr)
+			default:
+				exitCode, exitErr := exitCodeFromWait(processErr, false)
+				if exitErr == nil {
+					if setupErr := mapControlledEgressSetupExit(
+						p.prepared.profile,
+						exitCode,
+						p.stderrSetup.setupMarkerSeen(),
+					); setupErr != nil {
+						p.waitErr = setupErr
+					}
+				}
 			}
 		}
 		p.prepared.cleanup()

--- a/codeexecutor/sandbox/profile.go
+++ b/codeexecutor/sandbox/profile.go
@@ -40,10 +40,11 @@ const (
 // owns both filesystem and network policy so callers cannot request contradictory
 // combinations such as read-only + disabled enforcement.
 type PermissionProfile struct {
-	typ        permissionProfileType
-	fileSystem fileSystemPolicy
-	network    NetworkPolicy
-	macOS      macOSProfilePolicy
+	typ              permissionProfileType
+	fileSystem       fileSystemPolicy
+	network          NetworkPolicy
+	macOS            macOSProfilePolicy
+	controlledEgress ControlledEgressProxy
 }
 
 // macOSProfilePolicy describes macOS Seatbelt-specific controls. It is kept off
@@ -129,6 +130,20 @@ func (p PermissionProfile) WithNetworkPolicy(policy NetworkPolicy) PermissionPro
 		policy.Mode = NetworkRestricted
 	}
 	p.network = policy
+	if policy.Mode != NetworkControlled {
+		p.controlledEgress = ControlledEgressProxy{}
+	}
+	return p
+}
+
+// WithControlledEgressProxy enables NetworkControlled and sets the host proxy
+// Unix socket used for controlled egress. Linux starts a trusted loopback relay
+// before applying restricted seccomp to the user workload.
+func (p PermissionProfile) WithControlledEgressProxy(
+	endpoint ControlledEgressProxy,
+) PermissionProfile {
+	p.network.Mode = NetworkControlled
+	p.controlledEgress = endpoint
 	return p
 }
 

--- a/codeexecutor/sandbox/runner.go
+++ b/codeexecutor/sandbox/runner.go
@@ -12,6 +12,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -106,7 +107,15 @@ func (r *Runtime) runProgram(
 	stdout := newLimitedBuffer(r.outputMaxBytes)
 	stderr := newLimitedBuffer(r.outputMaxBytes)
 	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	var stderrMarkers *controlledEgressMarkerTracker
+	if prep.profile.network.Mode == NetworkControlled {
+		stderrMarkers = newControlledEgressMarkerTracker(
+			controlledEgressSetupToken(cmd.Args),
+		)
+		cmd.Stderr = io.MultiWriter(stderr, stderrMarkers)
+	} else {
+		cmd.Stderr = stderr
+	}
 	if spec.Stdin != "" {
 		cmd.Stdin = strings.NewReader(spec.Stdin)
 	} else {
@@ -151,6 +160,13 @@ func (r *Runtime) runProgram(
 			Backend: backendName,
 			Err:     context.DeadlineExceeded,
 		}
+	}
+	if err := mapControlledEgressSetupExit(
+		prep.profile,
+		exitCode,
+		stderrMarkers.setupMarkerSeen(),
+	); err != nil {
+		return result, err
 	}
 	return result, nil
 }

--- a/codeexecutor/sandbox/runtime.go
+++ b/codeexecutor/sandbox/runtime.go
@@ -58,6 +58,8 @@ type Runtime struct {
 	restrictedPreflightDone  chan struct{}
 	restrictedPreflightReady bool
 	restrictedPreflightErr   error
+
+	egressRelayPath string
 }
 
 // NewRuntime constructs a sandbox runtime.


### PR DESCRIPTION
## Summary

This PR extends the sandbox network policy with a Linux-only `controlled` mode.

Before this change, managed profiles could either isolate network access with
`restricted` or use the host network with `enabled`. The new mode keeps the
guest in an isolated network namespace while providing an explicit HTTP/HTTPS
egress path through a host-managed policy proxy. A trusted relay runs outside
the workload's seccomp and PID boundary; the workload itself retains the
AF_UNIX/AF_VSOCK/io_uring restrictions used by `restricted`.

The resulting path is:

```text
guest HTTP(S) client
  → HTTP_PROXY=http://127.0.0.1:<port>
  → trusted egress-relay on guest loopback
  → host AF_UNIX proxy
  → approved public destination
```

Unknown network modes and incomplete controlled-egress configurations fail
closed. Existing `restricted` and `enabled` behavior remains unchanged.

## Motivation

Some sandboxed workloads need limited internet access without receiving the
host's full network capabilities. Enabling the host network is too broad, while
complete network isolation prevents legitimate package, API, and model access.

Controlled egress separates those concerns. Bubblewrap remains responsible for
IP isolation, while the host proxy makes destination-level authorization
decisions. The guest can request network access, but it cannot choose or replace
the policy endpoint through its environment.

## Design

`PermissionProfile.WithControlledEgressProxy` selects `NetworkControlled` and
configures the host proxy UDS. `WithControlledEgressRelayPath` configures the
trusted relay helper installed on the host.

On Linux, both `restricted` and `controlled` render `--unshare-net`.
Controlled mode then replaces guest-provided HTTP proxy variables with a
loopback endpoint. `ALL_PROXY` and `NO_PROXY` are removed so guest configuration
cannot bypass the intended path.

Controlled mode uses two Bubblewrap stages. The outer sandbox creates the
network and mount namespaces but defers the workload seccomp filter. The trusted
relay runs there, listens only on guest loopback, and forwards each TCP
connection directly to the configured UDS. It then starts the user command in
an inner Bubblewrap process with a nested PID namespace, dropped capabilities,
and the AF_UNIX/AF_VSOCK/io_uring seccomp filter. The workload cannot see the
relay process or create a pathname/abstract Unix socket itself.

The host proxy is caller-owned and must already be listening before Runtime
starts the sandbox. There is no custom mux protocol or inherited mux stream.

```go
proxy, err := controlledegress.StartProxy(
    "/run/trpc-agent/egress.sock",
    controlledegress.StaticAllowlist(
        "api.example.com",
        "*.github.com",
    ),
)
if err != nil {
    return err
}
defer proxy.Close()

profile := sandbox.WorkspaceWriteProfile().
    WithControlledEgressProxy(sandbox.ControlledEgressProxy{
        UnixPath: proxy.UnixPath,
    })

runtime := sandbox.NewRuntime(
    sandbox.WithPermissionProfile(profile),
    sandbox.WithControlledEgressRelayPath(
        "/usr/local/bin/egress-relay",
    ),
)
defer runtime.Close()
```

## Test plan

The sandbox, relay, and proxy suites cover mode resolution, fail-closed
configuration, Bubblewrap arguments, environment ownership, UDS readiness,
symlink and writable-mount rejection, HTTP authorization, CONNECT SNI, DNS and
SSRF filtering, NAT64, resource limits, connection shutdown, half-close,
cancelable relay dialing, callback-aware proxy shutdown, request/response
hop-by-hop header removal, authenticated setup-error mapping, user marker
spoofing, and user exit-code preservation. The Linux end-to-end test also
verifies direct TCP-to-UDS forwarding, workload AF_UNIX denial, nested PID
isolation, and preservation of the outer read-only mount.

```text
go test ./codeexecutor/sandbox/...       PASS
go test -race ./codeexecutor/sandbox/... PASS
go vet ./codeexecutor/sandbox/...        PASS
git diff --check                         PASS
```

## Follow-up work

Follow-ups include macOS controlled egress, optional `ALL_PROXY` compatibility.
