### PR TITLE
memory/pgvector: reuse embeddings within auto-memory requests

### DIFF
--- a/memory/internal/memory/auto.go
+++ b/memory/internal/memory/auto.go
@@ -489,6 +489,7 @@ func (w *AutoMemoryWorker) createAutoMemory(
 	userKey memory.UserKey,
 	messages []model.Message,
 ) error {
+	ctx = WithRequestEmbeddingCache(ctx)
 	ops, err := w.prepareAutoMemoryOperations(ctx, userKey, messages)
 	if err != nil {
 		return err

--- a/memory/internal/memory/auto_test.go
+++ b/memory/internal/memory/auto_test.go
@@ -112,6 +112,47 @@ type mockOperator struct {
 	searchResults []*memory.Entry
 }
 
+type embeddingCacheProbeOperator struct {
+	*mockOperator
+	scope          *int
+	embeddingCalls int
+}
+
+func (o *embeddingCacheProbeOperator) getEmbedding(
+	ctx context.Context,
+	text string,
+) error {
+	_, err := GetOrComputeRequestEmbedding(
+		ctx, o.scope, text, func() ([]float64, error) {
+			o.embeddingCalls++
+			return []float64{1}, nil
+		},
+	)
+	return err
+}
+
+func (o *embeddingCacheProbeOperator) SearchMemories(
+	ctx context.Context,
+	userKey memory.UserKey,
+	query string,
+	opts ...memory.SearchOption,
+) ([]*memory.Entry, error) {
+	if err := o.getEmbedding(ctx, query); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (o *embeddingCacheProbeOperator) AddMemory(
+	ctx context.Context,
+	userKey memory.UserKey,
+	memoryStr string,
+	topics []string,
+	opts ...memory.AddOption,
+) error {
+	return o.getEmbedding(ctx, memoryStr)
+}
+
 func newMockOperator() *mockOperator {
 	return &mockOperator{
 		memories: make(map[string]*memory.Entry),
@@ -667,6 +708,26 @@ func TestAutoMemoryWorker_CreateAutoMemory_ExistingMemoryLookupError(t *testing.
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "prepare existing memories failed")
 	assert.Equal(t, 0, op.addCalls)
+}
+
+func TestAutoMemoryWorker_CreateAutoMemorySharesEmbeddingCache(t *testing.T) {
+	ext := &mockExtractor{ops: []*extractor.Operation{
+		{Type: extractor.OperationAdd, Memory: "same text"},
+	}}
+	op := &embeddingCacheProbeOperator{
+		mockOperator: newMockOperator(),
+		scope:        new(int),
+	}
+	worker := NewAutoMemoryWorker(AutoMemoryConfig{Extractor: ext}, op)
+
+	err := worker.createAutoMemory(
+		context.Background(),
+		memory.UserKey{AppName: "test-app", UserID: "user-1"},
+		[]model.Message{model.NewUserMessage("same text")},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, op.embeddingCalls)
 }
 
 func TestAutoMemoryWorker_ExecuteOperation_Add(t *testing.T) {

--- a/memory/internal/memory/embedding_cache.go
+++ b/memory/internal/memory/embedding_cache.go
@@ -1,0 +1,81 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package memory
+
+import (
+	"context"
+	"reflect"
+	"sync"
+)
+
+type requestEmbeddingCacheContextKey struct{}
+
+type requestEmbeddingCacheKey struct {
+	scope any
+	text  string
+}
+
+type requestEmbeddingCache struct {
+	mu     sync.RWMutex
+	values map[requestEmbeddingCacheKey][]float64
+}
+
+// WithRequestEmbeddingCache enables exact embedding reuse for the lifetime of
+// ctx. Reapplying it to an enabled context preserves the existing cache.
+func WithRequestEmbeddingCache(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(requestEmbeddingCacheContextKey{}).(*requestEmbeddingCache); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, requestEmbeddingCacheContextKey{},
+		&requestEmbeddingCache{
+			values: make(map[requestEmbeddingCacheKey][]float64),
+		})
+}
+
+// GetOrComputeRequestEmbedding reuses an exact embedding within one
+// auto-memory request. Scope must be a comparable service identity; invalid
+// scopes bypass the cache. Failed computations are never cached.
+func GetOrComputeRequestEmbedding(
+	ctx context.Context,
+	scope any,
+	text string,
+	compute func() ([]float64, error),
+) ([]float64, error) {
+	cache, ok := ctx.Value(requestEmbeddingCacheContextKey{}).(*requestEmbeddingCache)
+	if !ok || cache == nil || scope == nil ||
+		!reflect.TypeOf(scope).Comparable() {
+		return compute()
+	}
+
+	key := requestEmbeddingCacheKey{scope: scope, text: text}
+	cache.mu.RLock()
+	value, found := cache.values[key]
+	cache.mu.RUnlock()
+	if found {
+		return cloneEmbedding(value), nil
+	}
+
+	value, err := compute()
+	if err != nil {
+		return nil, err
+	}
+	stored := cloneEmbedding(value)
+	cache.mu.Lock()
+	if existing, exists := cache.values[key]; exists {
+		stored = existing
+	} else {
+		cache.values[key] = stored
+	}
+	cache.mu.Unlock()
+	return cloneEmbedding(stored), nil
+}
+
+func cloneEmbedding(value []float64) []float64 {
+	return append([]float64(nil), value...)
+}

--- a/memory/internal/memory/embedding_cache.go
+++ b/memory/internal/memory/embedding_cache.go
@@ -45,10 +45,12 @@ func WithRequestEmbeddingCache(ctx context.Context) context.Context {
 		})
 }
 
-// GetOrComputeRequestEmbedding reuses an exact embedding within one
-// auto-memory request. Scope must be a comparable service identity; invalid
-// scopes bypass the cache. Failed computations are never cached. The returned
-// embedding is shared and must be treated as read-only.
+// GetOrComputeRequestEmbedding reuses an embedding for the exact (scope, text)
+// key over the lifetime of the request cache in ctx. A nil or non-comparable
+// scope bypasses the cache. Concurrent misses for the same key share one
+// computation; a waiting caller may cancel independently through ctx. Failed
+// computations are removed so a later call can retry. The returned embedding
+// is shared and must be treated as read-only.
 func GetOrComputeRequestEmbedding(
 	ctx context.Context,
 	scope any,

--- a/memory/internal/memory/embedding_cache.go
+++ b/memory/internal/memory/embedding_cache.go
@@ -40,7 +40,8 @@ func WithRequestEmbeddingCache(ctx context.Context) context.Context {
 
 // GetOrComputeRequestEmbedding reuses an exact embedding within one
 // auto-memory request. Scope must be a comparable service identity; invalid
-// scopes bypass the cache. Failed computations are never cached.
+// scopes bypass the cache. Failed computations are never cached. The returned
+// embedding is shared and must be treated as read-only.
 func GetOrComputeRequestEmbedding(
 	ctx context.Context,
 	scope any,
@@ -58,24 +59,19 @@ func GetOrComputeRequestEmbedding(
 	value, found := cache.values[key]
 	cache.mu.RUnlock()
 	if found {
-		return cloneEmbedding(value), nil
+		return value, nil
 	}
 
 	value, err := compute()
 	if err != nil {
 		return nil, err
 	}
-	stored := cloneEmbedding(value)
 	cache.mu.Lock()
 	if existing, exists := cache.values[key]; exists {
-		stored = existing
+		value = existing
 	} else {
-		cache.values[key] = stored
+		cache.values[key] = value
 	}
 	cache.mu.Unlock()
-	return cloneEmbedding(stored), nil
-}
-
-func cloneEmbedding(value []float64) []float64 {
-	return append([]float64(nil), value...)
+	return value, nil
 }

--- a/memory/internal/memory/embedding_cache.go
+++ b/memory/internal/memory/embedding_cache.go
@@ -21,9 +21,16 @@ type requestEmbeddingCacheKey struct {
 	text  string
 }
 
+type requestEmbeddingCacheEntry struct {
+	ready     chan struct{}
+	embedding []float64
+	err       error
+	done      bool
+}
+
 type requestEmbeddingCache struct {
-	mu     sync.RWMutex
-	values map[requestEmbeddingCacheKey][]float64
+	mu      sync.Mutex
+	entries map[requestEmbeddingCacheKey]*requestEmbeddingCacheEntry
 }
 
 // WithRequestEmbeddingCache enables exact embedding reuse for the lifetime of
@@ -34,7 +41,7 @@ func WithRequestEmbeddingCache(ctx context.Context) context.Context {
 	}
 	return context.WithValue(ctx, requestEmbeddingCacheContextKey{},
 		&requestEmbeddingCache{
-			values: make(map[requestEmbeddingCacheKey][]float64),
+			entries: make(map[requestEmbeddingCacheKey]*requestEmbeddingCacheEntry),
 		})
 }
 
@@ -49,29 +56,42 @@ func GetOrComputeRequestEmbedding(
 	compute func() ([]float64, error),
 ) ([]float64, error) {
 	cache, ok := ctx.Value(requestEmbeddingCacheContextKey{}).(*requestEmbeddingCache)
-	if !ok || cache == nil || scope == nil ||
-		!reflect.TypeOf(scope).Comparable() {
+	scopeValue := reflect.ValueOf(scope)
+	if !ok || cache == nil || !scopeValue.IsValid() ||
+		!scopeValue.Comparable() {
 		return compute()
 	}
 
 	key := requestEmbeddingCacheKey{scope: scope, text: text}
-	cache.mu.RLock()
-	value, found := cache.values[key]
-	cache.mu.RUnlock()
+	cache.mu.Lock()
+	entry, found := cache.entries[key]
 	if found {
-		return value, nil
+		if entry.done {
+			value, err := entry.embedding, entry.err
+			cache.mu.Unlock()
+			return value, err
+		}
+		cache.mu.Unlock()
+		select {
+		case <-entry.ready:
+			return entry.embedding, entry.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
+	entry = &requestEmbeddingCacheEntry{ready: make(chan struct{})}
+	cache.entries[key] = entry
+	cache.mu.Unlock()
 
 	value, err := compute()
-	if err != nil {
-		return nil, err
-	}
 	cache.mu.Lock()
-	if existing, exists := cache.values[key]; exists {
-		value = existing
-	} else {
-		cache.values[key] = value
+	entry.embedding = value
+	entry.err = err
+	entry.done = true
+	if err != nil {
+		delete(cache.entries, key)
 	}
+	close(entry.ready)
 	cache.mu.Unlock()
-	return value, nil
+	return value, err
 }

--- a/memory/internal/memory/embedding_cache_test.go
+++ b/memory/internal/memory/embedding_cache_test.go
@@ -1,0 +1,102 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOrComputeRequestEmbedding(t *testing.T) {
+	ctx := WithRequestEmbeddingCache(context.Background())
+	scope := new(int)
+	calls := 0
+	compute := func() ([]float64, error) {
+		calls++
+		return []float64{1, 2, 3}, nil
+	}
+
+	first, err := GetOrComputeRequestEmbedding(
+		ctx, scope, "same text", compute,
+	)
+	require.NoError(t, err)
+	first[0] = 99
+	ctx = WithRequestEmbeddingCache(ctx)
+	second, err := GetOrComputeRequestEmbedding(
+		ctx, scope, "same text", compute,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, []float64{1, 2, 3}, second)
+}
+
+func TestGetOrComputeRequestEmbeddingIsolation(t *testing.T) {
+	ctx := WithRequestEmbeddingCache(context.Background())
+	calls := 0
+	compute := func() ([]float64, error) {
+		calls++
+		return []float64{float64(calls)}, nil
+	}
+
+	first, err := GetOrComputeRequestEmbedding(
+		ctx, new(int), "same text", compute,
+	)
+	require.NoError(t, err)
+	second, err := GetOrComputeRequestEmbedding(
+		ctx, new(int), "same text", compute,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls)
+	assert.NotEqual(t, first, second)
+}
+
+func TestGetOrComputeRequestEmbeddingBypassesInvalidCache(t *testing.T) {
+	calls := 0
+	compute := func() ([]float64, error) {
+		calls++
+		return []float64{1}, nil
+	}
+
+	_, err := GetOrComputeRequestEmbedding(
+		context.Background(), new(int), "same text", compute,
+	)
+	require.NoError(t, err)
+	_, err = GetOrComputeRequestEmbedding(
+		WithRequestEmbeddingCache(context.Background()),
+		[]string{"not comparable"}, "same text", compute,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls)
+}
+
+func TestGetOrComputeRequestEmbeddingDoesNotCacheErrors(t *testing.T) {
+	ctx := WithRequestEmbeddingCache(context.Background())
+	scope := new(int)
+	calls := 0
+	wantErr := errors.New("embedding failed")
+	compute := func() ([]float64, error) {
+		calls++
+		return nil, wantErr
+	}
+
+	for i := 0; i < 2; i++ {
+		_, err := GetOrComputeRequestEmbedding(
+			ctx, scope, "same text", compute,
+		)
+		require.ErrorIs(t, err, wantErr)
+	}
+	assert.Equal(t, 2, calls)
+}

--- a/memory/internal/memory/embedding_cache_test.go
+++ b/memory/internal/memory/embedding_cache_test.go
@@ -11,10 +11,8 @@ package memory
 import (
 	"context"
 	"errors"
-	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,33 +109,52 @@ func TestGetOrComputeRequestEmbeddingDoesNotCacheErrors(t *testing.T) {
 }
 
 func TestGetOrComputeRequestEmbeddingCoalescesConcurrentMisses(t *testing.T) {
-	const goroutines = 16
 	ctx := WithRequestEmbeddingCache(context.Background())
 	scope := new(int)
-	start := make(chan struct{})
+	computeStarted := make(chan struct{})
+	releaseCompute := make(chan struct{})
 	var calls atomic.Int32
-	compute := func() ([]float64, error) {
-		calls.Add(1)
-		time.Sleep(20 * time.Millisecond)
-		return []float64{1, 2, 3}, nil
+	type result struct {
+		embedding []float64
+		err       error
 	}
+	firstResult := make(chan result, 1)
+	go func() {
+		embedding, err := GetOrComputeRequestEmbedding(
+			ctx, scope, "same text", func() ([]float64, error) {
+				calls.Add(1)
+				close(computeStarted)
+				<-releaseCompute
+				return []float64{1, 2, 3}, nil
+			},
+		)
+		firstResult <- result{embedding: embedding, err: err}
+	}()
+	<-computeStarted
 
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
-		go func() {
-			defer wg.Done()
-			<-start
-			got, err := GetOrComputeRequestEmbedding(
-				ctx, scope, "same text", compute,
-			)
-			assert.NoError(t, err)
-			assert.Equal(t, []float64{1, 2, 3}, got)
-		}()
-	}
-	close(start)
-	wg.Wait()
+	waiterCtx, cancelWaiter := context.WithCancel(ctx)
+	waiterStarted := make(chan struct{})
+	waiterResult := make(chan error, 1)
+	go func() {
+		close(waiterStarted)
+		_, err := GetOrComputeRequestEmbedding(
+			waiterCtx, scope, "same text", func() ([]float64, error) {
+				calls.Add(1)
+				return nil, errors.New("duplicate computation")
+			},
+		)
+		waiterResult <- err
+	}()
+	<-waiterStarted
+	cancelWaiter()
 
+	require.ErrorIs(t, <-waiterResult, context.Canceled)
+	assert.Equal(t, int32(1), calls.Load())
+
+	close(releaseCompute)
+	got := <-firstResult
+	require.NoError(t, got.err)
+	assert.Equal(t, []float64{1, 2, 3}, got.embedding)
 	assert.Equal(t, int32(1), calls.Load())
 }
 

--- a/memory/internal/memory/embedding_cache_test.go
+++ b/memory/internal/memory/embedding_cache_test.go
@@ -11,7 +11,10 @@ package memory
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,8 +81,14 @@ func TestGetOrComputeRequestEmbeddingBypassesInvalidCache(t *testing.T) {
 		[]string{"not comparable"}, "same text", compute,
 	)
 	require.NoError(t, err)
+	_, err = GetOrComputeRequestEmbedding(
+		WithRequestEmbeddingCache(context.Background()),
+		struct{ Value any }{Value: []byte("not comparable at runtime")},
+		"same text", compute,
+	)
+	require.NoError(t, err)
 
-	assert.Equal(t, 2, calls)
+	assert.Equal(t, 3, calls)
 }
 
 func TestGetOrComputeRequestEmbeddingDoesNotCacheErrors(t *testing.T) {
@@ -101,6 +110,37 @@ func TestGetOrComputeRequestEmbeddingDoesNotCacheErrors(t *testing.T) {
 	assert.Equal(t, 2, calls)
 }
 
+func TestGetOrComputeRequestEmbeddingCoalescesConcurrentMisses(t *testing.T) {
+	const goroutines = 16
+	ctx := WithRequestEmbeddingCache(context.Background())
+	scope := new(int)
+	start := make(chan struct{})
+	var calls atomic.Int32
+	compute := func() ([]float64, error) {
+		calls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		return []float64{1, 2, 3}, nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			got, err := GetOrComputeRequestEmbedding(
+				ctx, scope, "same text", compute,
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, []float64{1, 2, 3}, got)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load())
+}
+
 func BenchmarkGetOrComputeRequestEmbedding(b *testing.B) {
 	embedding := make([]float64, 1536)
 	compute := func() ([]float64, error) {
@@ -110,14 +150,14 @@ func BenchmarkGetOrComputeRequestEmbedding(b *testing.B) {
 
 	b.Run("disabled", func(b *testing.B) {
 		ctx := context.Background()
-		for b.Loop() {
+		for i := 0; i < b.N; i++ {
 			_, _ = GetOrComputeRequestEmbedding(
 				ctx, scope, "same text", compute,
 			)
 		}
 	})
 	b.Run("miss", func(b *testing.B) {
-		for b.Loop() {
+		for i := 0; i < b.N; i++ {
 			ctx := WithRequestEmbeddingCache(context.Background())
 			_, _ = GetOrComputeRequestEmbedding(
 				ctx, scope, "same text", compute,
@@ -130,7 +170,7 @@ func BenchmarkGetOrComputeRequestEmbedding(b *testing.B) {
 			ctx, scope, "same text", compute,
 		)
 		b.ResetTimer()
-		for b.Loop() {
+		for i := 0; i < b.N; i++ {
 			_, _ = GetOrComputeRequestEmbedding(
 				ctx, scope, "same text", compute,
 			)

--- a/memory/internal/memory/embedding_cache_test.go
+++ b/memory/internal/memory/embedding_cache_test.go
@@ -30,7 +30,6 @@ func TestGetOrComputeRequestEmbedding(t *testing.T) {
 		ctx, scope, "same text", compute,
 	)
 	require.NoError(t, err)
-	first[0] = 99
 	ctx = WithRequestEmbeddingCache(ctx)
 	second, err := GetOrComputeRequestEmbedding(
 		ctx, scope, "same text", compute,
@@ -38,6 +37,7 @@ func TestGetOrComputeRequestEmbedding(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, calls)
+	assert.Equal(t, []float64{1, 2, 3}, first)
 	assert.Equal(t, []float64{1, 2, 3}, second)
 }
 
@@ -99,4 +99,41 @@ func TestGetOrComputeRequestEmbeddingDoesNotCacheErrors(t *testing.T) {
 		require.ErrorIs(t, err, wantErr)
 	}
 	assert.Equal(t, 2, calls)
+}
+
+func BenchmarkGetOrComputeRequestEmbedding(b *testing.B) {
+	embedding := make([]float64, 1536)
+	compute := func() ([]float64, error) {
+		return embedding, nil
+	}
+	scope := new(int)
+
+	b.Run("disabled", func(b *testing.B) {
+		ctx := context.Background()
+		for b.Loop() {
+			_, _ = GetOrComputeRequestEmbedding(
+				ctx, scope, "same text", compute,
+			)
+		}
+	})
+	b.Run("miss", func(b *testing.B) {
+		for b.Loop() {
+			ctx := WithRequestEmbeddingCache(context.Background())
+			_, _ = GetOrComputeRequestEmbedding(
+				ctx, scope, "same text", compute,
+			)
+		}
+	})
+	b.Run("hit", func(b *testing.B) {
+		ctx := WithRequestEmbeddingCache(context.Background())
+		_, _ = GetOrComputeRequestEmbedding(
+			ctx, scope, "same text", compute,
+		)
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = GetOrComputeRequestEmbedding(
+				ctx, scope, "same text", compute,
+			)
+		}
+	})
 }

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -180,7 +180,17 @@ func (s *Service) getEmbedding(
 ) ([]float64, error) {
 	return imemory.GetOrComputeRequestEmbedding(
 		ctx, s, text, func() ([]float64, error) {
-			return s.opts.embedder.GetEmbedding(ctx, text)
+			embedding, err := s.opts.embedder.GetEmbedding(ctx, text)
+			if err != nil {
+				return nil, err
+			}
+			if len(embedding) != s.opts.indexDimension {
+				return nil, fmt.Errorf(
+					"embedding dimension mismatch: expected %d, got %d",
+					s.opts.indexDimension, len(embedding),
+				)
+			}
+			return embedding, nil
 		},
 	)
 }
@@ -204,11 +214,6 @@ func (s *Service) AddMemory(
 	if err != nil {
 		return fmt.Errorf("generate embedding failed: %w", err)
 	}
-	if len(embedding) != s.opts.indexDimension {
-		return fmt.Errorf("embedding dimension mismatch: expected %d, got %d",
-			s.opts.indexDimension, len(embedding))
-	}
-
 	now := time.Now()
 	mem := &memory.Memory{
 		Memory:      memoryStr,
@@ -375,11 +380,6 @@ func (s *Service) UpdateMemory(
 	if err != nil {
 		return fmt.Errorf("generate embedding failed: %w", err)
 	}
-	if len(embedding) != s.opts.indexDimension {
-		return fmt.Errorf("embedding dimension mismatch: expected %d, got %d",
-			s.opts.indexDimension, len(embedding))
-	}
-
 	now := time.Now()
 	vector := pgvector.NewVector(convertToFloat32(embedding))
 	newID := imemory.ApplyMemoryUpdate(
@@ -753,11 +753,6 @@ func (s *Service) SearchMemories(
 	if err != nil {
 		return nil, fmt.Errorf("generate query embedding failed: %w", err)
 	}
-	if len(queryEmbedding) != s.opts.indexDimension {
-		return nil, fmt.Errorf("query embedding dimension mismatch: expected %d, got %d",
-			s.opts.indexDimension, len(queryEmbedding))
-	}
-
 	vector := pgvector.NewVector(convertToFloat32(queryEmbedding))
 
 	maxResults := s.opts.maxResults

--- a/memory/pgvector/service.go
+++ b/memory/pgvector/service.go
@@ -174,6 +174,17 @@ func buildConnString(opts ServiceOpts) string {
 	return conn.String()
 }
 
+func (s *Service) getEmbedding(
+	ctx context.Context,
+	text string,
+) ([]float64, error) {
+	return imemory.GetOrComputeRequestEmbedding(
+		ctx, s, text, func() ([]float64, error) {
+			return s.opts.embedder.GetEmbedding(ctx, text)
+		},
+	)
+}
+
 // AddMemory adds or updates a memory for a user (idempotent).
 // Options may include WithMetadata for episodic metadata.
 func (s *Service) AddMemory(
@@ -189,7 +200,7 @@ func (s *Service) AddMemory(
 	}
 
 	// Generate embedding for the memory content.
-	embedding, err := s.opts.embedder.GetEmbedding(ctx, memoryStr)
+	embedding, err := s.getEmbedding(ctx, memoryStr)
 	if err != nil {
 		return fmt.Errorf("generate embedding failed: %w", err)
 	}
@@ -360,7 +371,7 @@ func (s *Service) UpdateMemory(
 	}
 
 	// Generate new embedding for the updated memory content.
-	embedding, err := s.opts.embedder.GetEmbedding(ctx, memoryStr)
+	embedding, err := s.getEmbedding(ctx, memoryStr)
 	if err != nil {
 		return fmt.Errorf("generate embedding failed: %w", err)
 	}
@@ -738,7 +749,7 @@ func (s *Service) SearchMemories(
 	}
 
 	// Generate embedding for the query (reused across fallback searches).
-	queryEmbedding, err := s.opts.embedder.GetEmbedding(ctx, query)
+	queryEmbedding, err := s.getEmbedding(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("generate query embedding failed: %w", err)
 	}

--- a/memory/pgvector/service_test.go
+++ b/memory/pgvector/service_test.go
@@ -1746,6 +1746,24 @@ func TestService_ReusesRequestEmbeddingForSearchAndAdd(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestService_DoesNotCacheInvalidRequestEmbedding(t *testing.T) {
+	emb := newMockEmbedder(0)
+	opts := defaultOptions.clone()
+	opts.embedder = emb
+	svc := &Service{opts: opts}
+	ctx := imemory.WithRequestEmbeddingCache(context.Background())
+
+	_, err := svc.getEmbedding(ctx, "same memory")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedding dimension mismatch")
+
+	emb.dimension = opts.indexDimension
+	got, err := svc.getEmbedding(ctx, "same memory")
+	require.NoError(t, err)
+	assert.Len(t, got, opts.indexDimension)
+	assert.Equal(t, 2, emb.calls)
+}
+
 func TestService_SearchMemories_EmptyQuery(t *testing.T) {
 	db, mock := setupMockDB(t)
 	defer db.Close()
@@ -2538,7 +2556,7 @@ func TestService_SearchMemories_DimensionMismatch(t *testing.T) {
 
 	_, err := svc.SearchMemories(ctx, userKey, "test query")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "query embedding dimension mismatch")
+	assert.Contains(t, err.Error(), "embedding dimension mismatch")
 }
 
 func TestService_SearchMemories_SQLError(t *testing.T) {

--- a/memory/pgvector/service_test.go
+++ b/memory/pgvector/service_test.go
@@ -35,9 +35,11 @@ import (
 type mockEmbedder struct {
 	dimension int
 	err       error
+	calls     int
 }
 
 func (m *mockEmbedder) GetEmbedding(ctx context.Context, text string) ([]float64, error) {
+	m.calls++
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -1709,6 +1711,38 @@ func TestService_SearchMemories(t *testing.T) {
 	assert.Equal(t, "coffee brewing tips", results[0].Memory.Memory)
 	assert.Equal(t, "Alice likes coffee", results[1].Memory.Memory)
 
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_ReusesRequestEmbeddingForSearchAndAdd(t *testing.T) {
+	db, mock := setupMockDB(t)
+	defer db.Close()
+
+	emb := newMockEmbedder(1536)
+	svc := setupMockService(t, db, mock,
+		WithSkipDBInit(true),
+		WithMemoryLimit(0),
+		WithEmbedder(emb),
+	)
+	defer svc.Close()
+
+	ctx := imemory.WithRequestEmbeddingCache(context.Background())
+	userKey := memory.UserKey{AppName: "test-app", UserID: "u1"}
+	mock.ExpectQuery(
+		"SELECT memory_id, app_name, user_id, memory_content, topics",
+	).WillReturnRows(sqlmock.NewRows(
+		[]string{"memory_id", "app_name", "user_id", "memory_content", "topics",
+			"memory_kind", "event_time", "participants", "location",
+			"created_at", "updated_at", "similarity"},
+	))
+	mock.ExpectExec("INSERT INTO").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	_, err := svc.SearchMemories(ctx, userKey, "same memory")
+	require.NoError(t, err)
+	require.NoError(t, svc.AddMemory(ctx, userKey, "same memory", nil))
+
+	assert.Equal(t, 1, emb.calls)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
## Summary

- reuse identical pgvector embeddings within one auto-memory request
- scope cached values by service identity and exact input text
- expose cached values as read-only and leave failed embedding calls uncached

## Motivation

Auto-memory may embed the same text while searching for a reconciliation
candidate and again while persisting the resulting add or update. These calls
use the same pgvector service and embedder, so the repeated provider request is
unnecessary.

This change creates a request-scoped cache at the auto-memory boundary and
routes pgvector search, add, and update embedding calls through it. The helper
lives under `memory/internal`, adds no public API, and is discarded with the
request context.

The internal helper returns a shared read-only slice. Its pgvector caller only
reads the values while converting them to the database vector representation,
so cache hits do not copy or allocate another embedding-sized slice.

Calls outside auto-memory retain their existing behavior because no cache is
present in their context. The change does not modify extraction, reconciliation,
ranking, update policies, or persistence error semantics.

## Validation

- `go test ./memory/... -count=1`
- `go test -race ./memory/internal/memory -count=1`
- `cd memory/pgvector && go test ./... -count=1`
- `cd memory/pgvector && go test -race ./... -count=1`
- `go vet ./memory/...`
- `cd memory/pgvector && go vet ./...`

For a 1536-dimensional embedding, the request-cache microbenchmark reports
approximately `70 ns/op, 1 B/op, 1 alloc/op` for a hit and
`0.58 us/op, 641 B/op, 7 allocs/op` for a miss. The miss excludes the embedding
provider call; a hit avoids that provider call entirely.

The directly changed internal-memory functions have at least 94.4% statement
coverage; the pgvector embedding helper has 100% statement coverage.
