### PR TITLE
agent/llmagent: keep request-time context out of cacheable prompts

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -636,6 +636,7 @@ func appendTimeProcessor(options *Options, requestProcessors []flow.RequestProce
 		processor.WithAddCurrentTime(true),
 		processor.WithTimezone(options.Timezone),
 		processor.WithTimeFormat(options.TimeFormat),
+		processor.WithTimePromptPlacement(options.TimePromptPlacement),
 		processor.WithCurrentTimeTool(
 			toolcurrenttime.ToolName,
 			options.OutputSchema == nil,

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -345,6 +345,24 @@ func TestBuildRequestProcessors_TimePromptPlacementUserWiring(t *testing.T) {
 	require.Contains(t, req.Messages[1].Content, "The current date is:")
 }
 
+func TestWithTimePromptPlacement_NormalizesUnsupportedPlacement(t *testing.T) {
+	for _, placement := range []TimePromptPlacement{"", "assistant"} {
+		opts := &Options{}
+		WithAddCurrentTime(true)(opts)
+		WithTimePromptPlacement(placement)(opts)
+		require.Equal(t, TimePromptPlacementSystem, opts.TimePromptPlacement)
+
+		var timeProc *processor.TimeRequestProcessor
+		for _, p := range buildRequestProcessors("test-agent", opts) {
+			if v, ok := p.(*processor.TimeRequestProcessor); ok {
+				timeProc = v
+			}
+		}
+		require.NotNil(t, timeProc)
+		require.Equal(t, TimePromptPlacementSystem, timeProc.PromptPlacement)
+	}
+}
+
 // Test that buildRequestProcessors wires MaxHistoryRuns into
 // ContentRequestProcessor correctly.
 func TestBuildRequestProcessors_MaxHistoryRunsWiring(t *testing.T) {

--- a/agent/llmagent/llm_agent_test.go
+++ b/agent/llmagent/llm_agent_test.go
@@ -315,6 +315,34 @@ func TestBuildRequestProcessors_AddCurrentTimeToolGuidanceWiring(t *testing.T) {
 	require.True(t, timeProc.AddCurrentTime)
 	require.Equal(t, "environment_context_current_time", timeProc.CurrentTimeToolName)
 	require.True(t, timeProc.CurrentTimeToolAvailable)
+	require.Equal(t, TimePromptPlacementSystem, timeProc.PromptPlacement)
+}
+
+func TestBuildRequestProcessors_TimePromptPlacementUserWiring(t *testing.T) {
+	opts := &Options{}
+	WithAddCurrentTime(true)(opts)
+	WithTimePromptPlacement(TimePromptPlacementUser)(opts)
+
+	var timeProc *processor.TimeRequestProcessor
+	for _, p := range buildRequestProcessors("test-agent", opts) {
+		if v, ok := p.(*processor.TimeRequestProcessor); ok {
+			timeProc = v
+		}
+	}
+	require.NotNil(t, timeProc)
+	require.Equal(t, TimePromptPlacementUser, timeProc.PromptPlacement)
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Stable persona and instructions"),
+			model.NewUserMessage("Investigate the alert"),
+		},
+	}
+	timeProc.ProcessRequest(context.Background(), nil, req, nil)
+
+	require.Equal(t, "Stable persona and instructions", req.Messages[0].Content)
+	require.Contains(t, req.Messages[1].Content, "Investigate the alert")
+	require.Contains(t, req.Messages[1].Content, "The current date is:")
 }
 
 // Test that buildRequestProcessors wires MaxHistoryRuns into

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -116,7 +116,9 @@ const (
 	// prompt. This is the backward-compatible default.
 	TimePromptPlacementSystem = processor.TimePromptPlacementSystem
 	// TimePromptPlacementUser adds request-time clock context to the latest user
-	// turn, preserving a cache-stable system prefix.
+	// turn, preserving a cache-stable system prefix. When the request has no
+	// user message, a user message holding the clock context is appended, which
+	// changes the provider-visible message roles.
 	TimePromptPlacementUser = processor.TimePromptPlacementUser
 )
 
@@ -357,7 +359,7 @@ type Options struct {
 	// TimeFormat specifies the format for time display.
 	TimeFormat string
 	// TimePromptPlacement controls whether clock context is added to the system
-	// prompt or latest user turn.
+	// prompt or latest user turn. The zero value keeps system placement.
 	TimePromptPlacement TimePromptPlacement
 	// OutputKey is the key in session state to store the output of the agent.
 	OutputKey string
@@ -1746,10 +1748,24 @@ func WithTimeFormat(timeFormat string) Option {
 }
 
 // WithTimePromptPlacement selects the message role that receives request-time
-// clock context. User placement keeps the stable system prefix cacheable.
+// clock context.
+//
+// Available placements:
+//   - TimePromptPlacementSystem (default): adds clock context to the system
+//     prompt.
+//   - TimePromptPlacementUser: keeps the stable system prefix cacheable by
+//     appending clock context to the latest user turn, or by appending a user
+//     message holding it when the request has no user message.
+//
+// Unsupported placements fall back to TimePromptPlacementSystem.
 func WithTimePromptPlacement(placement TimePromptPlacement) Option {
 	return func(opts *Options) {
-		opts.TimePromptPlacement = placement
+		switch placement {
+		case TimePromptPlacementUser:
+			opts.TimePromptPlacement = TimePromptPlacementUser
+		default:
+			opts.TimePromptPlacement = TimePromptPlacementSystem
+		}
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -111,6 +111,13 @@ const (
 	// user/history. This is more prompt-cache friendly, but recall context
 	// participates in token-budget trimming.
 	PreloadSessionRecallInjectionUser = processor.PreloadSessionRecallInjectionUser
+
+	// TimePromptPlacementSystem adds request-time clock context to the system
+	// prompt. This is the backward-compatible default.
+	TimePromptPlacementSystem = processor.TimePromptPlacementSystem
+	// TimePromptPlacementUser adds request-time clock context to the latest user
+	// turn, preserving a cache-stable system prefix.
+	TimePromptPlacementUser = processor.TimePromptPlacementUser
 )
 
 // SessionSummaryInjectionMode controls where session summaries are injected.
@@ -122,6 +129,9 @@ type PreloadMemoryInjectionMode = processor.PreloadMemoryInjectionMode
 // PreloadSessionRecallInjectionMode controls where recalled session events are
 // injected.
 type PreloadSessionRecallInjectionMode = processor.PreloadSessionRecallInjectionMode
+
+// TimePromptPlacement controls which message receives request-time clock data.
+type TimePromptPlacement = processor.TimePromptPlacement
 
 // ToolTranscriptMode controls how historical tool-call/tool-result transcripts
 // are projected into model requests.
@@ -345,6 +355,9 @@ type Options struct {
 	Timezone string
 	// TimeFormat specifies the format for time display.
 	TimeFormat string
+	// TimePromptPlacement controls whether clock context is added to the system
+	// prompt or latest user turn.
+	TimePromptPlacement TimePromptPlacement
 	// OutputKey is the key in session state to store the output of the agent.
 	OutputKey string
 	// OutputSchema is the JSON schema for validating agent output.
@@ -1727,6 +1740,14 @@ func WithTimezone(timezone string) Option {
 func WithTimeFormat(timeFormat string) Option {
 	return func(opts *Options) {
 		opts.TimeFormat = timeFormat
+	}
+}
+
+// WithTimePromptPlacement selects the message role that receives request-time
+// clock context. User placement keeps the stable system prefix cacheable.
+func WithTimePromptPlacement(placement TimePromptPlacement) Option {
+	return func(opts *Options) {
+		opts.TimePromptPlacement = placement
 	}
 }
 

--- a/agent/llmagent/option.go
+++ b/agent/llmagent/option.go
@@ -349,7 +349,8 @@ type Options struct {
 	// EnableParallelTools enables parallel tool execution if true.
 	// If false (default), tools will execute serially for safety.
 	EnableParallelTools bool
-	// AddCurrentTime adds the current time to the system prompt if true.
+	// AddCurrentTime adds the current time to the request if true.
+	// TimePromptPlacement selects the message that receives it.
 	AddCurrentTime bool
 	// Timezone specifies the timezone to use for time display.
 	Timezone string
@@ -1720,7 +1721,8 @@ func newStructuredOutput(name string, schema map[string]any, strict bool, descri
 	}
 }
 
-// WithAddCurrentTime adds the current time to the system prompt if true.
+// WithAddCurrentTime adds the current time to the request if true. It goes to
+// the system prompt unless WithTimePromptPlacement selects another placement.
 func WithAddCurrentTime(addCurrentTime bool) Option {
 	return func(opts *Options) {
 		opts.AddCurrentTime = addCurrentTime

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -319,7 +319,7 @@ Recommended capabilities:
 | `summary.WithCacheSafeForking(true)` | summary generation request | Clones the parent request and appends a compaction message, reusing the parent prefix |
 | `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | near history | Reduces prefix rewrite when summary changes frequently, with trimming tradeoff |
 | `llmagent.WithAddCurrentTime(true)` default date-only | system message / time tool | Date-level context is stable; precise time is available through `environment_context_current_time` when tools are enabled. Legacy `WithOutputSchema` disables this tool |
-| `llmagent.WithTimePromptPlacement(TimePromptPlacementUser)` | latest user turn | Keeps a full timestamp out of the stable system prefix; system placement remains the default |
+| `llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser)` | latest user turn | Keeps a full timestamp out of the stable system prefix; system placement remains the default |
 | `agent.WithModelRequestExtraFields` with `prompt_cache_key` | request body | A stable key may help providers route similar long-prefix requests |
 | default `llmagent.WithReasoningContentMode` | assistant history | Drops historical reasoning content by default, reducing unnecessary input tokens |
 
@@ -331,7 +331,7 @@ Dynamic capabilities to use carefully:
 | `llmagent.WithRefreshToolSetsOnRun(true)` | tools schema | Re-fetching tools can change the visible tool surface | Fix the tool surface in cache-sensitive paths when possible |
 | `llmagent.WithSkillLoadMode` / `WithMaxLoadedSkills` | loaded Skills context | Affects how long dynamic Skill content stays in context | Control residency and size |
 | `llmagent.WithPreloadMemory` / `WithPreloadSessionRecall` | system message or history | Query-dependent recall in system message rewrites the prefix | Prefer user/history injection in cache-sensitive scenarios |
-| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message by default | Full timestamp changes frequently | Pair with `WithTimePromptPlacement(TimePromptPlacementUser)` unless exact time must stay in system context |
+| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message by default | Full timestamp changes frequently | Pair with `llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser)` unless exact time must stay in system context |
 | dynamic `WithPostToolPrompt` | system message | Turns stable guidance into a dynamic prefix | Keep it stable; put temporary instructions later |
 | `agent.WithInjectedContextMessages` / `WithLateContextMessages` | near history | Injected messages can appear before stable history | Prefer late injection for temporary context |
 | `BeforeModel` / `EventMessageProjector` | any request message | Can rewrite system, tools, or history | Prefer append-only changes near the end |

--- a/docs/mkdocs/en/blog/promptcache.md
+++ b/docs/mkdocs/en/blog/promptcache.md
@@ -220,7 +220,18 @@ agent := llmagent.New(
 )
 ```
 
-**Suggestion**: The default date-only path is more cache-friendly. If you explicitly configure a full time format such as `WithTimeFormat("2006-01-02 15:04:05 MST")`, the old full timestamp behavior is still available, but it changes the request prefix more often.
+**Suggestion**: The default date-only path is more cache-friendly, and system placement remains the default. If you need a full timestamp such as `WithTimeFormat("2006-01-02 15:04:05 MST")`, keep it off the stable system prefix:
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithAddCurrentTime(true),
+    llmagent.WithTimeFormat("2006-01-02 15:04:05 MST"),
+    llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser),
+)
+```
+
+Use system placement with a full format only when exact time must remain in the system context.
 
 ## 5. What Users Can Configure and Observe
 
@@ -308,6 +319,7 @@ Recommended capabilities:
 | `summary.WithCacheSafeForking(true)` | summary generation request | Clones the parent request and appends a compaction message, reusing the parent prefix |
 | `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | near history | Reduces prefix rewrite when summary changes frequently, with trimming tradeoff |
 | `llmagent.WithAddCurrentTime(true)` default date-only | system message / time tool | Date-level context is stable; precise time is available through `environment_context_current_time` when tools are enabled. Legacy `WithOutputSchema` disables this tool |
+| `llmagent.WithTimePromptPlacement(TimePromptPlacementUser)` | latest user turn | Keeps a full timestamp out of the stable system prefix; system placement remains the default |
 | `agent.WithModelRequestExtraFields` with `prompt_cache_key` | request body | A stable key may help providers route similar long-prefix requests |
 | default `llmagent.WithReasoningContentMode` | assistant history | Drops historical reasoning content by default, reducing unnecessary input tokens |
 
@@ -319,7 +331,7 @@ Dynamic capabilities to use carefully:
 | `llmagent.WithRefreshToolSetsOnRun(true)` | tools schema | Re-fetching tools can change the visible tool surface | Fix the tool surface in cache-sensitive paths when possible |
 | `llmagent.WithSkillLoadMode` / `WithMaxLoadedSkills` | loaded Skills context | Affects how long dynamic Skill content stays in context | Control residency and size |
 | `llmagent.WithPreloadMemory` / `WithPreloadSessionRecall` | system message or history | Query-dependent recall in system message rewrites the prefix | Prefer user/history injection in cache-sensitive scenarios |
-| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message | Full timestamp changes frequently | Use only when exact time must be in system context |
+| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message by default | Full timestamp changes frequently | Pair with `WithTimePromptPlacement(TimePromptPlacementUser)` unless exact time must stay in system context |
 | dynamic `WithPostToolPrompt` | system message | Turns stable guidance into a dynamic prefix | Keep it stable; put temporary instructions later |
 | `agent.WithInjectedContextMessages` / `WithLateContextMessages` | near history | Injected messages can appear before stable history | Prefer late injection for temporary context |
 | `BeforeModel` / `EventMessageProjector` | any request message | Can rewrite system, tools, or history | Prefer append-only changes near the end |

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -338,7 +338,7 @@ agent := llmagent.New(
 | `summary.WithCacheSafeForking(true)` | summary 生成请求 | 克隆父请求并追加 compaction user message，让 summary 生成也复用父会话前缀 |
 | `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | history 附近 | Summary 频繁变化时可减少对 request prefix 的改写，但需要接受可能被 token tailoring 裁剪的取舍 |
 | `llmagent.WithAddCurrentTime(true)` 默认 date-only | system message / time tool | 日期级上下文同一天内稳定；工具启用时可通过 `environment_context_current_time` 获取精确时间。遗留的 `WithOutputSchema` 会禁用这个工具 |
-| `llmagent.WithTimePromptPlacement(TimePromptPlacementUser)` | 最新 user turn | 把完整时间戳移出稳定 system prefix；system placement 仍是默认行为 |
+| `llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser)` | 最新 user turn | 把完整时间戳移出稳定 system prefix；system placement 仍是默认行为 |
 | `agent.WithModelRequestExtraFields` 中的 `prompt_cache_key` | request body | 对支持该参数的服务方，稳定 key 可能帮助同类长前缀请求聚合；不要使用 request id / trace id |
 | `llmagent.WithReasoningContentMode` 默认模式 | assistant history | 默认丢弃历史 reasoning content，可减少历史体积，避免无谓增加输入 tokens |
 
@@ -350,7 +350,7 @@ agent := llmagent.New(
 | `llmagent.WithRefreshToolSetsOnRun(true)` | tools schema | 每次 Run 重新拉取 ToolSet，适合动态 MCP，但工具面变化会降低缓存复用 | cache-sensitive 场景尽量固定工具面；动态工具按场景分桶 |
 | `llmagent.WithSkillLoadMode` / `WithMaxLoadedSkills` | loaded Skills context | 影响动态 Skill 内容驻留轮次和体积 | 控制驻留时长和数量，避免无关 Skill 长期污染前缀 |
 | `llmagent.WithPreloadMemory` / `WithPreloadSessionRecall` | system message 或 history | 召回内容随 query 变化，放 system message 会更容易改写 request prefix | cache-sensitive 场景优先评估 user/history injection mode |
-| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | 默认写在 system message | 完整时间戳会按秒变化，容易破坏 request prefix | 搭配 `WithTimePromptPlacement(TimePromptPlacementUser)`；只有明确需要每轮 system message 内含精确时间时才保留 system placement |
+| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | 默认写在 system message | 完整时间戳会按秒变化，容易破坏 request prefix | 搭配 `llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser)`；只有明确需要每轮 system message 内含精确时间时才保留 system placement |
 | 动态 `WithPostToolPrompt` | system message | 如果按请求生成，会把本来稳定的 post-tool guidance 变成动态前缀 | 按 Agent/版本固定；请求级临时要求放到 tool result 或后置 user/history |
 | `agent.WithInjectedContextMessages` / `WithLateContextMessages` | history 附近的临时消息 | 前者在 session history 之前，位置更靠前；后者贴近最新用户回合 | 临时上下文优先 late 注入，避免改写稳定前缀 |
 | `BeforeModel` callback / `EventMessageProjector` | 任意 request message | 这是强扩展点，可能重写 system、tools 或 history | 遵守 append-only 思路；尽量只在靠后位置追加动态上下文 |

--- a/docs/mkdocs/zh/blog/promptcache.md
+++ b/docs/mkdocs/zh/blog/promptcache.md
@@ -233,7 +233,18 @@ agent := llmagent.New(
 )
 ```
 
-**使用建议**：默认 date-only 路径更 cache-friendly；如果显式配置完整时间格式，例如 `WithTimeFormat("2006-01-02 15:04:05 MST")`，仍然可以得到旧式完整时间戳，但需要接受 request prefix 随时间变化带来的缓存影响。
+**使用建议**：默认 date-only 路径更 cache-friendly，system 注入仍是默认行为。如果需要完整时间戳，例如 `WithTimeFormat("2006-01-02 15:04:05 MST")`，请把它放到动态 user turn，而不是稳定 system prefix：
+
+```go
+agent := llmagent.New(
+    "assistant",
+    llmagent.WithAddCurrentTime(true),
+    llmagent.WithTimeFormat("2006-01-02 15:04:05 MST"),
+    llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser),
+)
+```
+
+只有明确需要每轮 system message 内含精确时间时，才继续使用默认的 system placement。
 
 ## 五、用户能配置和观测什么
 
@@ -327,6 +338,7 @@ agent := llmagent.New(
 | `summary.WithCacheSafeForking(true)` | summary 生成请求 | 克隆父请求并追加 compaction user message，让 summary 生成也复用父会话前缀 |
 | `llmagent.WithSessionSummaryInjectionMode(SessionSummaryInjectionUser)` | history 附近 | Summary 频繁变化时可减少对 request prefix 的改写，但需要接受可能被 token tailoring 裁剪的取舍 |
 | `llmagent.WithAddCurrentTime(true)` 默认 date-only | system message / time tool | 日期级上下文同一天内稳定；工具启用时可通过 `environment_context_current_time` 获取精确时间。遗留的 `WithOutputSchema` 会禁用这个工具 |
+| `llmagent.WithTimePromptPlacement(TimePromptPlacementUser)` | 最新 user turn | 把完整时间戳移出稳定 system prefix；system placement 仍是默认行为 |
 | `agent.WithModelRequestExtraFields` 中的 `prompt_cache_key` | request body | 对支持该参数的服务方，稳定 key 可能帮助同类长前缀请求聚合；不要使用 request id / trace id |
 | `llmagent.WithReasoningContentMode` 默认模式 | assistant history | 默认丢弃历史 reasoning content，可减少历史体积，避免无谓增加输入 tokens |
 
@@ -338,7 +350,7 @@ agent := llmagent.New(
 | `llmagent.WithRefreshToolSetsOnRun(true)` | tools schema | 每次 Run 重新拉取 ToolSet，适合动态 MCP，但工具面变化会降低缓存复用 | cache-sensitive 场景尽量固定工具面；动态工具按场景分桶 |
 | `llmagent.WithSkillLoadMode` / `WithMaxLoadedSkills` | loaded Skills context | 影响动态 Skill 内容驻留轮次和体积 | 控制驻留时长和数量，避免无关 Skill 长期污染前缀 |
 | `llmagent.WithPreloadMemory` / `WithPreloadSessionRecall` | system message 或 history | 召回内容随 query 变化，放 system message 会更容易改写 request prefix | cache-sensitive 场景优先评估 user/history injection mode |
-| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | system message | 完整时间戳会按秒变化，容易破坏 request prefix | 只有明确需要每轮 system message 内含精确时间时才使用 |
+| `llmagent.WithTimeFormat("2006-01-02 15:04:05 MST")` | 默认写在 system message | 完整时间戳会按秒变化，容易破坏 request prefix | 搭配 `WithTimePromptPlacement(TimePromptPlacementUser)`；只有明确需要每轮 system message 内含精确时间时才保留 system placement |
 | 动态 `WithPostToolPrompt` | system message | 如果按请求生成，会把本来稳定的 post-tool guidance 变成动态前缀 | 按 Agent/版本固定；请求级临时要求放到 tool result 或后置 user/history |
 | `agent.WithInjectedContextMessages` / `WithLateContextMessages` | history 附近的临时消息 | 前者在 session history 之前，位置更靠前；后者贴近最新用户回合 | 临时上下文优先 late 注入，避免改写稳定前缀 |
 | `BeforeModel` callback / `EventMessageProjector` | 任意 request message | 这是强扩展点，可能重写 system、tools 或 history | 遵守 append-only 思路；尽量只在靠后位置追加动态上下文 |

--- a/examples/promptcache/timeprocessor/README.md
+++ b/examples/promptcache/timeprocessor/README.md
@@ -12,7 +12,11 @@ OpenAI prompt-cache demo remains unchanged.
 - `date-only`: `WithAddCurrentTime(true)` with the new default date-only system
   prompt.
 - `full-datetime`: `WithAddCurrentTime(true)` plus an explicit full timestamp
-  format, which changes every turn and is expected to be less cache-friendly.
+  format. System placement remains the default, so the timestamp changes the
+  system prompt every turn and is expected to be less cache-friendly.
+- `full-datetime-user`: the same full timestamp format with
+  `WithTimePromptPlacement(TimePromptPlacementUser)`, so the clock sits on the
+  latest user turn and the system prefix stays stable.
 - `precise-tool`: date-only system context plus the built-in
   `environment_context_current_time` tool for exact clock time.
 
@@ -39,6 +43,7 @@ Run a single case:
 ```bash
 go run . -case date-only
 go run . -case full-datetime
+go run . -case full-datetime-user
 go run . -case precise-tool
 ```
 
@@ -62,14 +67,17 @@ comparison for this demo is `date-only` versus `full-datetime`.
 | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
 | `baseline` | No time processor. Stable system prompt only. | Not available | 15,878 | 11,200 | 3/4 | 0 | 70.5% |
 | `date-only` | `WithAddCurrentTime(true)` with default date-only system context. | Available but not called in this case | 17,125 | 15,872 | 4/4 | 0 | 92.7% |
-| `full-datetime` | `WithAddCurrentTime(true)` with `WithTimeFormat("2006-01-02 15:04:05 MST")`; timestamp changes every turn. | Available but not called in this case | 17,112 | 10,752 | 3/4 | 0 | 62.8% |
+| `full-datetime` | `WithAddCurrentTime(true)` with `WithTimeFormat("2006-01-02 15:04:05 MST")`; default system placement, so the timestamp changes every turn. | Available but not called in this case | 17,112 | 10,752 | 3/4 | 0 | 62.8% |
+| `full-datetime-user` | Same full format with `WithTimePromptPlacement(TimePromptPlacementUser)`. | Available but not called in this case | — | — | — | — | not in this sample |
 | `precise-tool` | Date-only system context; exact time fetched only on demand. | `environment_context_current_time` called on time questions | 17,693 | 13,120 | 3/4 | 2 | 74.2% |
 
 The important comparison is `date-only` versus `full-datetime`, not
 `date-only` versus `baseline`: keeping the system prompt stable at date
-granularity preserves more of the prompt-cache prefix, while full datetime
-invalidates more of the prefix as the timestamp changes. `precise-tool` keeps
-the stable date context and still supports exact clock time via
+granularity preserves more of the prompt-cache prefix, while full datetime in
+the system message invalidates more of the prefix as the timestamp changes.
+`full-datetime-user` keeps the same full timestamp but moves it to the latest
+user turn so the system prefix can stay cacheable. `precise-tool` keeps the
+stable date context and still supports exact clock time via
 `environment_context_current_time`.
 
 For the sample above, `date-only` improves the cache rate by 29.9 percentage
@@ -81,7 +89,8 @@ precise clock values stayed out of the stable system prompt.
 
 The `date-only` case should keep a stable prompt prefix within the same day,
 while `full-datetime` changes the system prompt on every turn. The
-`precise-tool` case demonstrates that exact time can be fetched on demand via
-`environment_context_current_time` without embedding a volatile timestamp into
-every request.
+`full-datetime-user` case keeps a full timestamp without rewriting that system
+prefix. The `precise-tool` case demonstrates that exact time can be fetched on
+demand via `environment_context_current_time` without embedding a volatile
+timestamp into every request.
 

--- a/examples/promptcache/timeprocessor/main.go
+++ b/examples/promptcache/timeprocessor/main.go
@@ -73,7 +73,7 @@ func main() {
 	}
 
 	modelName := flag.String("model", defaultModel, "OpenAI-compatible model name")
-	caseName := flag.String("case", "all", "case to run: all, baseline, date-only, full-datetime, precise-tool")
+	caseName := flag.String("case", "all", "case to run: all, baseline, date-only, full-datetime, full-datetime-user, precise-tool")
 	turnDelay := flag.Duration("turn-delay", 1200*time.Millisecond, "delay between turns so full-datetime changes")
 	flag.Parse()
 
@@ -155,11 +155,22 @@ func buildCases() []cacheCase {
 		},
 		{
 			Name:        "full-datetime",
-			Description: "Legacy-style full timestamp in the system prompt. This changes each turn and is less cache-friendly.",
+			Description: "Legacy-style full timestamp in the system prompt. This changes each turn and is less cache-friendly. System placement remains the default.",
 			QueryPrefix: "Answer briefly.",
 			Options: []llmagent.Option{
 				llmagent.WithAddCurrentTime(true),
 				llmagent.WithTimeFormat("2006-01-02 15:04:05 MST"),
+			},
+			Queries: regularQueries(),
+		},
+		{
+			Name:        "full-datetime-user",
+			Description: "Full timestamp on the latest user turn via WithTimePromptPlacement(TimePromptPlacementUser), keeping the system prefix stable.",
+			QueryPrefix: "Answer briefly.",
+			Options: []llmagent.Option{
+				llmagent.WithAddCurrentTime(true),
+				llmagent.WithTimeFormat("2006-01-02 15:04:05 MST"),
+				llmagent.WithTimePromptPlacement(llmagent.TimePromptPlacementUser),
 			},
 			Queries: regularQueries(),
 		},

--- a/internal/flow/processor/time.go
+++ b/internal/flow/processor/time.go
@@ -27,7 +27,9 @@ const (
 	// context to the last system message.
 	TimePromptPlacementSystem TimePromptPlacement = "system"
 	// TimePromptPlacementUser adds clock context to the latest user turn so the
-	// stable system prefix remains eligible for provider prompt caching.
+	// stable system prefix remains eligible for provider prompt caching. When
+	// the request carries no user message, a user message holding the clock
+	// context is appended instead.
 	TimePromptPlacementUser TimePromptPlacement = "user"
 )
 
@@ -79,13 +81,15 @@ func WithTimeFormat(format string) TimeOption {
 }
 
 // WithTimePromptPlacement selects the message role that receives clock context.
-// An empty placement keeps the default system placement.
+// Empty and unsupported placements keep the default system placement.
 func WithTimePromptPlacement(placement TimePromptPlacement) TimeOption {
 	return func(p *TimeRequestProcessor) {
-		if placement == "" {
-			placement = TimePromptPlacementSystem
+		switch placement {
+		case TimePromptPlacementUser:
+			p.PromptPlacement = TimePromptPlacementUser
+		default:
+			p.PromptPlacement = TimePromptPlacementSystem
 		}
-		p.PromptPlacement = placement
 	}
 }
 
@@ -115,7 +119,9 @@ func NewTimeRequestProcessor(opts ...TimeOption) *TimeRequestProcessor {
 
 // ProcessRequest implements the flow.RequestProcessor interface.
 // It adds current time information to the system prompt if enabled, or to the
-// latest user turn when PromptPlacement is TimePromptPlacementUser.
+// latest user turn when PromptPlacement is TimePromptPlacementUser. User
+// placement appends a user message holding the clock context when the request
+// has no user message.
 func (p *TimeRequestProcessor) ProcessRequest(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -251,7 +257,8 @@ func (p *TimeRequestProcessor) addTimeToSystemMessage(req *model.Request, timeCo
 	}
 }
 
-// addTimeToUserMessage adds clock context to the latest user turn.
+// addTimeToUserMessage adds clock context to the latest user turn, or appends a
+// user message carrying it when the request has no user message.
 func (p *TimeRequestProcessor) addTimeToUserMessage(req *model.Request, timeContent string) {
 	for i := len(req.Messages) - 1; i >= 0; i-- {
 		msg := &req.Messages[i]
@@ -265,7 +272,13 @@ func (p *TimeRequestProcessor) addTimeToUserMessage(req *model.Request, timeCont
 		// a message, never both, so the clock block has to use the same
 		// representation as the user input it is attached to.
 		if len(msg.ContentParts) > 0 {
+			// Some providers flatten text parts by concatenation, so the clock
+			// block carries the same separator as the scalar path to keep its
+			// boundary with the caller text.
 			text := timeContent
+			if hasTextContentPart(msg.ContentParts) {
+				text = "\n\n" + timeContent
+			}
 			msg.ContentParts = append(msg.ContentParts, model.ContentPart{
 				Type: model.ContentTypeText,
 				Text: &text,
@@ -276,6 +289,16 @@ func (p *TimeRequestProcessor) addTimeToUserMessage(req *model.Request, timeCont
 		return
 	}
 	req.Messages = append(req.Messages, model.NewUserMessage(timeContent))
+}
+
+// hasTextContentPart reports whether any content part carries non-empty text.
+func hasTextContentPart(parts []model.ContentPart) bool {
+	for _, part := range parts {
+		if part.Type == model.ContentTypeText && part.Text != nil && *part.Text != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // messageContainsTimeInfo reports whether the message already carries this

--- a/internal/flow/processor/time.go
+++ b/internal/flow/processor/time.go
@@ -22,7 +22,17 @@ import (
 
 const (
 	defaultCurrentDateFormat = "2006-01-02"
+
+	// TimePromptPlacementSystem keeps the historical behavior of adding clock
+	// context to the last system message.
+	TimePromptPlacementSystem TimePromptPlacement = "system"
+	// TimePromptPlacementUser adds clock context to the latest user turn so the
+	// stable system prefix remains eligible for provider prompt caching.
+	TimePromptPlacementUser TimePromptPlacement = "user"
 )
+
+// TimePromptPlacement controls which message receives request-time clock data.
+type TimePromptPlacement string
 
 // TimeRequestProcessor implements time processing logic.
 type TimeRequestProcessor struct {
@@ -32,6 +42,9 @@ type TimeRequestProcessor struct {
 	Timezone string
 	// TimeFormat specifies the format for time display.
 	TimeFormat string
+	// PromptPlacement controls whether clock context mutates system or user
+	// content. The zero value preserves system placement.
+	PromptPlacement TimePromptPlacement
 	// CurrentTimeToolName is the exact-time tool the model should call when it
 	// needs clock-level precision.
 	CurrentTimeToolName string
@@ -64,6 +77,13 @@ func WithTimeFormat(format string) TimeOption {
 	}
 }
 
+// WithTimePromptPlacement selects the message role that receives clock context.
+func WithTimePromptPlacement(placement TimePromptPlacement) TimeOption {
+	return func(p *TimeRequestProcessor) {
+		p.PromptPlacement = placement
+	}
+}
+
 // WithCurrentTimeTool configures the exact-time tool guidance.
 func WithCurrentTimeTool(name string, available bool) TimeOption {
 	return func(p *TimeRequestProcessor) {
@@ -78,6 +98,7 @@ func NewTimeRequestProcessor(opts ...TimeOption) *TimeRequestProcessor {
 		AddCurrentTime:           false,
 		Timezone:                 "",
 		TimeFormat:               defaultCurrentDateFormat,
+		PromptPlacement:          TimePromptPlacementSystem,
 		CurrentTimeToolName:      "",
 		CurrentTimeToolAvailable: false,
 	}
@@ -121,7 +142,10 @@ func (p *TimeRequestProcessor) ProcessRequest(
 	currentTime := p.getCurrentTime()
 	timeContent := p.formatTimePrompt(currentTime)
 
-	// Add time information to the system message.
+	if p.PromptPlacement == TimePromptPlacementUser {
+		p.addTimeToUserMessage(req, timeContent)
+		return
+	}
 	p.addTimeToSystemMessage(req, timeContent)
 }
 
@@ -219,6 +243,19 @@ func (p *TimeRequestProcessor) addTimeToSystemMessage(req *model.Request, timeCo
 		timeMsg := model.NewSystemMessage(timeContent)
 		req.Messages = append([]model.Message{timeMsg}, req.Messages...)
 	}
+}
+
+func (p *TimeRequestProcessor) addTimeToUserMessage(req *model.Request, timeContent string) {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != model.RoleUser {
+			continue
+		}
+		if !containsTimeInfo(req.Messages[i].Content, timeContent) {
+			req.Messages[i].Content += "\n\n" + timeContent
+		}
+		return
+	}
+	req.Messages = append(req.Messages, model.NewUserMessage(timeContent))
 }
 
 // containsTimeInfo checks if the given content already contains the time information.

--- a/internal/flow/processor/time.go
+++ b/internal/flow/processor/time.go
@@ -258,9 +258,13 @@ func (p *TimeRequestProcessor) addTimeToUserMessage(req *model.Request, timeCont
 	req.Messages = append(req.Messages, model.NewUserMessage(timeContent))
 }
 
-// containsTimeInfo checks if the given content already contains the time information.
+// containsTimeInfo reports whether content already has this request's clock
+// block. A raw timestamp in user text is not enough; skip only when the
+// official current-time or current-date label is present.
 func containsTimeInfo(content, timeInfo string) bool {
-	// Extract just the time part for comparison.
-	timePart := strings.TrimPrefix(timeInfo, "The current time is: ")
-	return strings.Contains(content, timePart)
+	if !strings.Contains(content, "The current time is:") &&
+		!strings.Contains(content, "The current date is:") {
+		return false
+	}
+	return strings.Contains(content, timeInfo)
 }

--- a/internal/flow/processor/time.go
+++ b/internal/flow/processor/time.go
@@ -36,7 +36,8 @@ type TimePromptPlacement string
 
 // TimeRequestProcessor implements time processing logic.
 type TimeRequestProcessor struct {
-	// AddCurrentTime controls whether to add current time to the system prompt.
+	// AddCurrentTime controls whether to add current time to the request.
+	// PromptPlacement selects the message that receives it.
 	AddCurrentTime bool
 	// Timezone specifies the timezone to use for time display.
 	Timezone string
@@ -48,7 +49,7 @@ type TimeRequestProcessor struct {
 	// CurrentTimeToolName is the exact-time tool the model should call when it
 	// needs clock-level precision.
 	CurrentTimeToolName string
-	// CurrentTimeToolAvailable controls whether the system prompt should guide
+	// CurrentTimeToolAvailable controls whether the clock context should guide
 	// the model to call CurrentTimeToolName for exact time.
 	CurrentTimeToolAvailable bool
 }
@@ -56,7 +57,7 @@ type TimeRequestProcessor struct {
 // TimeOption is a function that can be used to configure the time request processor.
 type TimeOption func(*TimeRequestProcessor)
 
-// WithAddCurrentTime enables or disables adding current time to the system prompt.
+// WithAddCurrentTime enables or disables adding current time to the request.
 func WithAddCurrentTime(add bool) TimeOption {
 	return func(p *TimeRequestProcessor) {
 		p.AddCurrentTime = add
@@ -78,8 +79,12 @@ func WithTimeFormat(format string) TimeOption {
 }
 
 // WithTimePromptPlacement selects the message role that receives clock context.
+// An empty placement keeps the default system placement.
 func WithTimePromptPlacement(placement TimePromptPlacement) TimeOption {
 	return func(p *TimeRequestProcessor) {
+		if placement == "" {
+			placement = TimePromptPlacementSystem
+		}
 		p.PromptPlacement = placement
 	}
 }
@@ -109,7 +114,8 @@ func NewTimeRequestProcessor(opts ...TimeOption) *TimeRequestProcessor {
 }
 
 // ProcessRequest implements the flow.RequestProcessor interface.
-// It adds current time information to the system prompt if enabled.
+// It adds current time information to the system prompt if enabled, or to the
+// latest user turn when PromptPlacement is TimePromptPlacementUser.
 func (p *TimeRequestProcessor) ProcessRequest(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -245,17 +251,48 @@ func (p *TimeRequestProcessor) addTimeToSystemMessage(req *model.Request, timeCo
 	}
 }
 
+// addTimeToUserMessage adds clock context to the latest user turn.
 func (p *TimeRequestProcessor) addTimeToUserMessage(req *model.Request, timeContent string) {
 	for i := len(req.Messages) - 1; i >= 0; i-- {
-		if req.Messages[i].Role != model.RoleUser {
+		msg := &req.Messages[i]
+		if msg.Role != model.RoleUser {
 			continue
 		}
-		if !containsTimeInfo(req.Messages[i].Content, timeContent) {
-			req.Messages[i].Content += "\n\n" + timeContent
+		if messageContainsTimeInfo(msg, timeContent) {
+			return
 		}
+		// Providers serialize either the content parts or the scalar content of
+		// a message, never both, so the clock block has to use the same
+		// representation as the user input it is attached to.
+		if len(msg.ContentParts) > 0 {
+			text := timeContent
+			msg.ContentParts = append(msg.ContentParts, model.ContentPart{
+				Type: model.ContentTypeText,
+				Text: &text,
+			})
+			return
+		}
+		msg.Content += "\n\n" + timeContent
 		return
 	}
 	req.Messages = append(req.Messages, model.NewUserMessage(timeContent))
+}
+
+// messageContainsTimeInfo reports whether the message already carries this
+// request's clock block in its scalar content or in any text content part.
+func messageContainsTimeInfo(msg *model.Message, timeInfo string) bool {
+	if containsTimeInfo(msg.Content, timeInfo) {
+		return true
+	}
+	for _, part := range msg.ContentParts {
+		if part.Type != model.ContentTypeText || part.Text == nil {
+			continue
+		}
+		if containsTimeInfo(*part.Text, timeInfo) {
+			return true
+		}
+	}
+	return false
 }
 
 // containsTimeInfo reports whether content already has this request's clock

--- a/internal/flow/processor/time_test.go
+++ b/internal/flow/processor/time_test.go
@@ -225,6 +225,10 @@ func TestTimeRequestProcessor_ProcessRequest_AppendsTextPartToMultimodalUser(t *
 	if len(got.ContentParts) != 3 {
 		t.Fatalf("expected clock context as an extra text part, got %d parts", len(got.ContentParts))
 	}
+	if got.ContentParts[0].Type != model.ContentTypeText || got.ContentParts[0].Text == nil ||
+		*got.ContentParts[0].Text != userText {
+		t.Fatalf("expected original text part to be preserved, got: %#v", got.ContentParts[0])
+	}
 	if got.ContentParts[1].Type != model.ContentTypeImage || got.ContentParts[1].Image == nil {
 		t.Fatalf("expected image part to be preserved, got: %#v", got.ContentParts[1])
 	}
@@ -232,6 +236,9 @@ func TestTimeRequestProcessor_ProcessRequest_AppendsTextPartToMultimodalUser(t *
 	if clockPart.Type != model.ContentTypeText || clockPart.Text == nil ||
 		!strings.Contains(*clockPart.Text, "The current date is:") {
 		t.Fatalf("expected clock text part on the user turn, got: %#v", clockPart)
+	}
+	if !strings.HasPrefix(*clockPart.Text, "\n\n") {
+		t.Fatalf("expected clock part to keep a boundary after caller text, got: %q", *clockPart.Text)
 	}
 
 	// A replayed request must not append the same clock block twice.
@@ -267,29 +274,31 @@ func TestTimeRequestProcessor_ProcessRequest_CreatesUserForStablePrefix(t *testi
 	}
 }
 
-func TestTimeRequestProcessor_EmptyPlacementKeepsSystemDefault(t *testing.T) {
-	processor := NewTimeRequestProcessor(
-		WithAddCurrentTime(true),
-		WithTimePromptPlacement(""),
-	)
-	if processor.PromptPlacement != TimePromptPlacementSystem {
-		t.Fatalf("expected system placement default, got %q", processor.PromptPlacement)
-	}
+func TestTimeRequestProcessor_UnsupportedPlacementKeepsSystemDefault(t *testing.T) {
+	for _, placement := range []TimePromptPlacement{"", "assistant"} {
+		processor := NewTimeRequestProcessor(
+			WithAddCurrentTime(true),
+			WithTimePromptPlacement(placement),
+		)
+		if processor.PromptPlacement != TimePromptPlacementSystem {
+			t.Fatalf("expected system placement for %q, got %q", placement, processor.PromptPlacement)
+		}
 
-	req := &model.Request{
-		Messages: []model.Message{
-			model.NewSystemMessage("Stable persona and instructions"),
-			model.NewUserMessage("Investigate the alert"),
-		},
-	}
+		req := &model.Request{
+			Messages: []model.Message{
+				model.NewSystemMessage("Stable persona and instructions"),
+				model.NewUserMessage("Investigate the alert"),
+			},
+		}
 
-	processor.ProcessRequest(context.Background(), nil, req, nil)
+		processor.ProcessRequest(context.Background(), nil, req, nil)
 
-	if !strings.Contains(req.Messages[0].Content, "The current date is:") {
-		t.Fatalf("expected clock context on the system message, got: %s", req.Messages[0].Content)
-	}
-	if req.Messages[1].Content != "Investigate the alert" {
-		t.Fatalf("expected user turn to stay unchanged, got: %s", req.Messages[1].Content)
+		if !strings.Contains(req.Messages[0].Content, "The current date is:") {
+			t.Fatalf("expected clock context on the system message, got: %s", req.Messages[0].Content)
+		}
+		if req.Messages[1].Content != "Investigate the alert" {
+			t.Fatalf("expected user turn to stay unchanged, got: %s", req.Messages[1].Content)
+		}
 	}
 }
 

--- a/internal/flow/processor/time_test.go
+++ b/internal/flow/processor/time_test.go
@@ -215,6 +215,16 @@ func TestTimeRequestProcessor_ProcessRequest_CreatesUserForStablePrefix(t *testi
 	}
 }
 
+func TestContainsTimeInfo_RequiresClockLabel(t *testing.T) {
+	timeInfo := "The current time is: Monday, January 02, 2006 15:04:05 MST"
+	if containsTimeInfo("Alert started at Monday, January 02, 2006 15:04:05 MST", timeInfo) {
+		t.Fatal("raw timestamp in user text must not skip clock injection")
+	}
+	if !containsTimeInfo("Investigate the alert\n\n"+timeInfo, timeInfo) {
+		t.Fatal("an official clock block should skip a second injection")
+	}
+}
+
 func TestTimeRequestProcessor_RebuildRequestForContextCompaction(t *testing.T) {
 	processor := NewTimeRequestProcessor(WithAddCurrentTime(true))
 	req := &model.Request{

--- a/internal/flow/processor/time_test.go
+++ b/internal/flow/processor/time_test.go
@@ -182,11 +182,63 @@ func TestTimeRequestProcessor_ProcessRequest_AppendsToUserForStablePrefix(t *tes
 	if strings.Contains(req.Messages[0].Content, "The current date is:") {
 		t.Fatalf("expected stable system prefix to remain unchanged, got: %s", req.Messages[0].Content)
 	}
+	if req.Messages[1].Role != model.RoleUser {
+		t.Fatalf("expected clock context to stay on the user turn, got: %#v", req.Messages[1])
+	}
+	if !strings.Contains(req.Messages[1].Content, "Investigate the alert") {
+		t.Fatalf("expected original user content to be preserved, got: %s", req.Messages[1].Content)
+	}
 	if !strings.Contains(req.Messages[1].Content, "The current date is:") {
 		t.Fatalf("expected current date on dynamic user turn, got: %s", req.Messages[1].Content)
 	}
 	if !strings.Contains(req.Messages[1].Content, "call the built-in environment_context_current_time tool") {
 		t.Fatalf("expected exact-time tool guidance to be preserved, got: %s", req.Messages[1].Content)
+	}
+}
+
+func TestTimeRequestProcessor_ProcessRequest_AppendsTextPartToMultimodalUser(t *testing.T) {
+	processor := NewTimeRequestProcessor(
+		WithAddCurrentTime(true),
+		WithTimePromptPlacement(TimePromptPlacementUser),
+	)
+	userText := "Describe this screenshot"
+	userMsg := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeText, Text: &userText},
+			{Type: model.ContentTypeImage, Image: &model.Image{URL: "https://example.com/a.png"}},
+		},
+	}
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Stable persona and instructions"),
+			userMsg,
+		},
+	}
+
+	processor.ProcessRequest(context.Background(), nil, req, nil)
+
+	got := req.Messages[1]
+	if got.Content != "" {
+		t.Fatalf("expected multimodal message to keep using content parts, got scalar content: %s", got.Content)
+	}
+	if len(got.ContentParts) != 3 {
+		t.Fatalf("expected clock context as an extra text part, got %d parts", len(got.ContentParts))
+	}
+	if got.ContentParts[1].Type != model.ContentTypeImage || got.ContentParts[1].Image == nil {
+		t.Fatalf("expected image part to be preserved, got: %#v", got.ContentParts[1])
+	}
+	clockPart := got.ContentParts[2]
+	if clockPart.Type != model.ContentTypeText || clockPart.Text == nil ||
+		!strings.Contains(*clockPart.Text, "The current date is:") {
+		t.Fatalf("expected clock text part on the user turn, got: %#v", clockPart)
+	}
+
+	// A replayed request must not append the same clock block twice.
+	processor.ProcessRequest(context.Background(), nil, req, nil)
+
+	if len(req.Messages[1].ContentParts) != 3 {
+		t.Fatalf("expected duplicate clock injection to be skipped, got %d parts", len(req.Messages[1].ContentParts))
 	}
 }
 
@@ -215,6 +267,32 @@ func TestTimeRequestProcessor_ProcessRequest_CreatesUserForStablePrefix(t *testi
 	}
 }
 
+func TestTimeRequestProcessor_EmptyPlacementKeepsSystemDefault(t *testing.T) {
+	processor := NewTimeRequestProcessor(
+		WithAddCurrentTime(true),
+		WithTimePromptPlacement(""),
+	)
+	if processor.PromptPlacement != TimePromptPlacementSystem {
+		t.Fatalf("expected system placement default, got %q", processor.PromptPlacement)
+	}
+
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Stable persona and instructions"),
+			model.NewUserMessage("Investigate the alert"),
+		},
+	}
+
+	processor.ProcessRequest(context.Background(), nil, req, nil)
+
+	if !strings.Contains(req.Messages[0].Content, "The current date is:") {
+		t.Fatalf("expected clock context on the system message, got: %s", req.Messages[0].Content)
+	}
+	if req.Messages[1].Content != "Investigate the alert" {
+		t.Fatalf("expected user turn to stay unchanged, got: %s", req.Messages[1].Content)
+	}
+}
+
 func TestContainsTimeInfo_RequiresClockLabel(t *testing.T) {
 	timeInfo := "The current time is: Monday, January 02, 2006 15:04:05 MST"
 	if containsTimeInfo("Alert started at Monday, January 02, 2006 15:04:05 MST", timeInfo) {
@@ -222,6 +300,14 @@ func TestContainsTimeInfo_RequiresClockLabel(t *testing.T) {
 	}
 	if !containsTimeInfo("Investigate the alert\n\n"+timeInfo, timeInfo) {
 		t.Fatal("an official clock block should skip a second injection")
+	}
+
+	dateInfo := "The current date is: 2006-01-02"
+	if containsTimeInfo("The incident started on 2006-01-02", dateInfo) {
+		t.Fatal("raw date in user text must not skip clock injection")
+	}
+	if !containsTimeInfo("Investigate the alert\n\n"+dateInfo, dateInfo) {
+		t.Fatal("an official clock block should skip a second date injection")
 	}
 }
 

--- a/internal/flow/processor/time_test.go
+++ b/internal/flow/processor/time_test.go
@@ -164,6 +164,57 @@ func TestTimeRequestProcessor_ProcessRequest_WithExistingSystemMessage(t *testin
 	}
 }
 
+func TestTimeRequestProcessor_ProcessRequest_AppendsToUserForStablePrefix(t *testing.T) {
+	processor := NewTimeRequestProcessor(
+		WithAddCurrentTime(true),
+		WithTimePromptPlacement(TimePromptPlacementUser),
+		WithCurrentTimeTool("environment_context_current_time", true),
+	)
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Stable persona and instructions"),
+			model.NewUserMessage("Investigate the alert"),
+		},
+	}
+
+	processor.ProcessRequest(context.Background(), nil, req, make(chan *event.Event, 1))
+
+	if strings.Contains(req.Messages[0].Content, "The current date is:") {
+		t.Fatalf("expected stable system prefix to remain unchanged, got: %s", req.Messages[0].Content)
+	}
+	if !strings.Contains(req.Messages[1].Content, "The current date is:") {
+		t.Fatalf("expected current date on dynamic user turn, got: %s", req.Messages[1].Content)
+	}
+	if !strings.Contains(req.Messages[1].Content, "call the built-in environment_context_current_time tool") {
+		t.Fatalf("expected exact-time tool guidance to be preserved, got: %s", req.Messages[1].Content)
+	}
+}
+
+func TestTimeRequestProcessor_ProcessRequest_CreatesUserForStablePrefix(t *testing.T) {
+	processor := NewTimeRequestProcessor(
+		WithAddCurrentTime(true),
+		WithTimePromptPlacement(TimePromptPlacementUser),
+	)
+	req := &model.Request{
+		Messages: []model.Message{
+			model.NewSystemMessage("Stable persona and instructions"),
+		},
+	}
+
+	processor.ProcessRequest(context.Background(), nil, req, make(chan *event.Event, 1))
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("expected clock user turn after system prefix, got %d messages", len(req.Messages))
+	}
+	if req.Messages[0].Content != "Stable persona and instructions" {
+		t.Fatalf("expected system prefix to remain byte-stable, got: %s", req.Messages[0].Content)
+	}
+	if req.Messages[1].Role != model.RoleUser ||
+		!strings.Contains(req.Messages[1].Content, "The current date is:") {
+		t.Fatalf("expected a dynamic clock user turn, got: %#v", req.Messages[1])
+	}
+}
+
 func TestTimeRequestProcessor_RebuildRequestForContextCompaction(t *testing.T) {
 	processor := NewTimeRequestProcessor(WithAddCurrentTime(true))
 	req := &model.Request{

--- a/model/ollama/ollama_test.go
+++ b/model/ollama/ollama_test.go
@@ -477,6 +477,26 @@ func Test_convertMessage(t *testing.T) {
 	}
 }
 
+// Test_convertMessage_TextImageAndAppendedContext checks that flattening text
+// parts keeps the boundary between caller text and framework-appended context.
+func Test_convertMessage_TextImageAndAppendedContext(t *testing.T) {
+	userText := "Describe this screenshot"
+	clockText := "\n\nThe current date is: 2006-01-02"
+	msg := model.Message{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{
+			{Type: model.ContentTypeText, Text: &userText},
+			{Type: model.ContentTypeImage, Image: &model.Image{Data: []byte("image-bytes"), Format: "png"}},
+			{Type: model.ContentTypeText, Text: &clockText},
+		},
+	}
+
+	result, err := convertMessage(msg)
+	assert.NoError(t, err)
+	assert.Len(t, result.Images, 1)
+	assert.Equal(t, userText+clockText, result.Content)
+}
+
 // Test_convertTools tests tool conversion.
 func Test_convertTools(t *testing.T) {
 	toolsMap := map[string]tool.Tool{


### PR DESCRIPTION
## Summary
- add `WithTimePromptPlacement` so current-time context can be appended to the latest user turn
- keep system-message placement as the backward-compatible default
- preserve exact-time tool guidance when user placement is enabled
- keep multimodal user messages intact by appending the clock block as a text content part

`WithAddCurrentTime(true)` currently writes clock context into the last system
message. That is correct for date-only defaults, but callers that pass a full
datetime format (`WithTimeFormat`) still invalidate the provider prompt-cache
prefix on every request.

User placement keeps the same clock text and `environment_context_current_time`
guidance, but moves the changing suffix off the stable system prefix.

When the latest user message carries `ContentParts`, the clock block is appended
as a text content part instead of the scalar `Content` field, because providers
serialize either the content parts or the scalar content, never both. Duplicate
detection inspects text parts as well, so replay and compaction rebuilds do not
append the same block twice.

An empty placement normalizes to system placement, so the documented default
survives option forwarding from `llmagent`.

Fixes #2526

## Test plan
- [x] `go test ./internal/flow/processor ./agent/llmagent`
- [x] multimodal regression coverage: image part preserved, clock block added as a text part, second pass does not duplicate it
- [x] `llmagent`-level coverage for the public `WithTimePromptPlacement(TimePromptPlacementUser)` wiring
- [x] `go build ./...`, `go vet`, `gofmt`/`goimports` clean

I do not have permission to set labels on this repository. Could a maintainer
please add `type/api-change`?