### PR TITLE
tool/file: read text files containing invalid UTF-8 instead of rejecting them

### DIFF
--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -11,7 +11,6 @@
 package file
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -93,9 +92,25 @@ func validateReadFileRequest(req *readFileRequest) error {
 const (
 	errNotTextFile     = "file is not a UTF-8 text file"
 	errNotTextFileTmpl = "file is not a UTF-8 text file (mime: %s)"
+
+	// utf8Replacement stands in for byte sequences that are not valid UTF-8.
+	utf8Replacement = "\uFFFD"
+
+	// invalidUTF8Note marks a read whose returned contents differ from the
+	// source content because invalid UTF-8 was substituted.
+	invalidUTF8Note = " (invalid UTF-8 replaced with U+FFFD)"
 )
 
-func validateTextString(content string, mimeType string) error {
+// rejectNonText reports content that is not a text file at all, and so cannot
+// be repaired by substitution: a non-text MIME type, or an embedded NUL byte.
+//
+// Invalid UTF-8 on its own is not rejected. A handful of malformed bytes, such
+// as a stray byte left by a non-UTF-8 editor or a truncated multi-byte rune,
+// would otherwise make an entire readable file unreadable through this tool and
+// leave a caller with no way to inspect it; sanitizeText repairs those instead.
+//
+// Empty content is accepted whatever the MIME type, as it always has been.
+func rejectNonText(content string, mimeType string) error {
 	if content == "" {
 		return nil
 	}
@@ -103,25 +118,23 @@ func validateTextString(content string, mimeType string) error {
 		!codeexecutor.IsTextMIME(mimeType) {
 		return notTextFileErr(mimeType)
 	}
-	if strings.IndexByte(content, 0) >= 0 ||
-		!utf8.ValidString(content) {
+	if strings.IndexByte(content, 0) >= 0 {
 		return notTextFileErr(mimeType)
 	}
 	return nil
 }
 
-func validateTextBytes(data []byte, mimeType string) error {
-	if len(data) == 0 {
-		return nil
+// sanitizeText returns content with each run of invalid UTF-8 bytes replaced by
+// U+FFFD, reporting whether any substitution was made.
+//
+// Callers run this on the slice they are about to return rather than on the
+// whole file, so that size limits and line numbering stay measured in source
+// bytes: U+FFFD is three bytes wide and so can be wider than what it replaces.
+func sanitizeText(content string) (string, bool) {
+	if utf8.ValidString(content) {
+		return content, false
 	}
-	if strings.TrimSpace(mimeType) != "" &&
-		!codeexecutor.IsTextMIME(mimeType) {
-		return notTextFileErr(mimeType)
-	}
-	if bytes.IndexByte(data, 0) >= 0 || !utf8.Valid(data) {
-		return notTextFileErr(mimeType)
-	}
-	return nil
+	return strings.ToValidUTF8(content, utf8Replacement), true
 }
 
 func notTextFileErr(mimeType string) error {
@@ -146,7 +159,7 @@ func (f *fileToolSet) readFileFromRef(
 		return true, err
 	}
 
-	if err := validateTextString(content, mimeType); err != nil {
+	if err := rejectNonText(content, mimeType); err != nil {
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return true, err
 	}
@@ -165,6 +178,7 @@ func (f *fileToolSet) readFileFromRef(
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return true, err
 	}
+	chunk, replaced := sanitizeText(chunk)
 	rsp.Contents = chunk
 	if empty {
 		rsp.Message = fmt.Sprintf(
@@ -183,6 +197,9 @@ func (f *fileToolSet) readFileFromRef(
 		end,
 		total,
 	)
+	if replaced {
+		rsp.Message += invalidUTF8Note
+	}
 	return true, nil
 }
 
@@ -245,7 +262,7 @@ func (f *fileToolSet) readFileFromDiskOrCache(
 		return fmt.Errorf("reading file: %w", err)
 	}
 	mimeType := http.DetectContentType(contents)
-	if err := validateTextBytes(contents, mimeType); err != nil {
+	if err := rejectNonText(string(contents), mimeType); err != nil {
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return err
 	}
@@ -257,6 +274,7 @@ func (f *fileToolSet) readFileFromDiskOrCache(
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return err
 	}
+	chunk, replaced := sanitizeText(chunk)
 	rsp.Contents = chunk
 	if empty {
 		rsp.Message = fmt.Sprintf(
@@ -273,6 +291,9 @@ func (f *fileToolSet) readFileFromDiskOrCache(
 		endLine,
 		total,
 	)
+	if replaced {
+		rsp.Message += invalidUTF8Note
+	}
 	return nil
 }
 
@@ -289,7 +310,7 @@ func (f *fileToolSet) readFileFromCache(
 		return false, nil
 	}
 
-	if err := validateTextString(content, mime); err != nil {
+	if err := rejectNonText(content, mime); err != nil {
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return true, err
 	}
@@ -299,6 +320,7 @@ func (f *fileToolSet) readFileFromCache(
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return true, err
 	}
+	chunk, replaced := sanitizeText(chunk)
 	rsp.Contents = chunk
 	if empty {
 		rsp.Message = fmt.Sprintf(
@@ -317,6 +339,9 @@ func (f *fileToolSet) readFileFromCache(
 		total,
 		mime,
 	)
+	if replaced {
+		rsp.Message += invalidUTF8Note
+	}
 	return true, nil
 }
 

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -16,7 +16,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 
@@ -610,7 +612,7 @@ func TestFileTool_ReadFile_FromRef_InvalidUTF8(t *testing.T) {
 	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
 		{
 			Name:     outATxt,
-			Content:  string([]byte{invalidByte}),
+			Content:  "before" + string([]byte{invalidByte}) + "after",
 			MIMEType: mimeTextPlain,
 		},
 	})
@@ -618,10 +620,16 @@ func TestFileTool_ReadFile_FromRef_InvalidUTF8(t *testing.T) {
 	rsp, err := fileToolSet.readFile(ctx, &readFileRequest{
 		FileName: refATxt,
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, rsp)
-	assert.Empty(t, rsp.Contents)
-	assert.Contains(t, rsp.Message, mimeTextPlain)
+	assert.Equal(t, "before\uFFFDafter", rsp.Contents)
+	assert.Contains(
+		t,
+		rsp.Message,
+		"Successfully read workspace://out/a.txt from workspace://, "+
+			"start line: 1, end line: 1, total lines: 1"+
+			" (invalid UTF-8 replaced with U+FFFD)",
+	)
 }
 
 func TestFileTool_ReadFile_InvalidUTF8FromDisk(t *testing.T) {
@@ -634,7 +642,6 @@ func TestFileTool_ReadFile_InvalidUTF8FromDisk(t *testing.T) {
 		fileName    = "invalid.txt"
 		sniffLen    = 512
 		invalidByte = byte(0xff)
-		mimeText    = "text/plain"
 	)
 
 	prefix := make([]byte, sniffLen)
@@ -653,10 +660,15 @@ func TestFileTool_ReadFile_InvalidUTF8FromDisk(t *testing.T) {
 		context.Background(),
 		&readFileRequest{FileName: fileName},
 	)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, rsp)
-	assert.Empty(t, rsp.Contents)
-	assert.Contains(t, rsp.Message, mimeText)
+	assert.Equal(t, string(prefix)+"\uFFFD", rsp.Contents)
+	assert.Equal(
+		t,
+		"Successfully read invalid.txt, start line: 1, end line: 1, "+
+			"total lines: 1 (invalid UTF-8 replaced with U+FFFD)",
+		rsp.Message,
+	)
 }
 
 func TestFileTool_ReadFile_FromCache_EmptyFile(t *testing.T) {
@@ -700,7 +712,7 @@ func TestFileTool_ReadFile_FromCache_InvalidUTF8(t *testing.T) {
 	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
 		{
 			Name:     outATxt,
-			Content:  string([]byte{invalidByte}),
+			Content:  "line one" + string([]byte{invalidByte}) + "\nline two",
 			MIMEType: mimeTextPlain,
 		},
 	})
@@ -708,10 +720,17 @@ func TestFileTool_ReadFile_FromCache_InvalidUTF8(t *testing.T) {
 	rsp, err := fileToolSet.readFile(ctx, &readFileRequest{
 		FileName: outATxt,
 	})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, rsp)
-	assert.Empty(t, rsp.Contents)
-	assert.Contains(t, rsp.Message, mimeTextPlain)
+	assert.Equal(t, "line one\uFFFD\nline two", rsp.Contents)
+	assert.Equal(
+		t,
+		"Loaded out/a.txt from a prior skill_run output_files cache, "+
+			"start line: 1, end line: 2, total lines: 2 "+
+			"(mime: text/plain)"+
+			" (invalid UTF-8 replaced with U+FFFD)",
+		rsp.Message,
+	)
 }
 
 func TestFileTool_ReadFile_FromRef_ParseError(t *testing.T) {
@@ -807,4 +826,249 @@ func TestFileTool_ReadFile_ArtifactRef(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "hi", rsp.Contents)
+}
+
+func TestRejectNonText(t *testing.T) {
+	const (
+		mimeTextPlain = "text/plain"
+		mimePNG       = "image/png"
+	)
+	tests := []struct {
+		name     string
+		content  string
+		mimeType string
+		wantErr  string
+	}{
+		{
+			name:     "plain text is accepted",
+			content:  "hello",
+			mimeType: mimeTextPlain,
+		},
+		{
+			name:     "invalid utf8 alone is not a rejection",
+			content:  "before" + string([]byte{0xd1}) + "after",
+			mimeType: mimeTextPlain,
+		},
+		{
+			name:     "an empty mime type skips the mime check",
+			content:  "hello",
+			mimeType: "",
+		},
+		{
+			name:     "empty content is accepted whatever the mime type",
+			content:  "",
+			mimeType: mimePNG,
+		},
+		{
+			name:     "an embedded NUL byte is rejected",
+			content:  "text" + string([]byte{0x00}) + "more",
+			mimeType: mimeTextPlain,
+			wantErr:  "file is not a UTF-8 text file (mime: text/plain)",
+		},
+		{
+			name:     "a non-text mime type is rejected",
+			content:  "\x89PNG\r\n\x1a\n",
+			mimeType: mimePNG,
+			wantErr:  "file is not a UTF-8 text file (mime: image/png)",
+		},
+		{
+			name:     "an embedded NUL byte with no mime type is rejected",
+			content:  "text" + string([]byte{0x00}) + "more",
+			mimeType: "",
+			wantErr:  "file is not a UTF-8 text file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rejectNonText(tt.content, tt.mimeType)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestSanitizeText(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantContent  string
+		wantReplaced bool
+	}{
+		{
+			name:    "empty content is left alone",
+			content: "",
+		},
+		{
+			name:        "valid utf8 passes through untouched",
+			content:     "héllo wörld",
+			wantContent: "héllo wörld",
+		},
+		{
+			name:         "a stray byte is replaced",
+			content:      "before" + string([]byte{0xd1}) + "after",
+			wantContent:  "before\uFFFDafter",
+			wantReplaced: true,
+		},
+		{
+			name:         "a truncated multi-byte rune is replaced",
+			content:      "prefix" + string([]byte{0xe4, 0xb8}),
+			wantContent:  "prefix\uFFFD",
+			wantReplaced: true,
+		},
+		{
+			name:         "a run of invalid bytes collapses to one replacement",
+			content:      string([]byte{0xff, 0xfe, 0xfd}) + "tail",
+			wantContent:  "\uFFFDtail",
+			wantReplaced: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, replaced := sanitizeText(tt.content)
+			assert.Equal(t, tt.wantContent, got)
+			assert.Equal(t, tt.wantReplaced, replaced)
+			assert.True(t, utf8.ValidString(got))
+		})
+	}
+}
+
+func TestFileTool_ReadFile_InvalidUTF8ScriptKeepsSurroundingLines(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	const fileName = "cloud-init.sh"
+	script := "#!/usr/bin/env bash\n" +
+		"# run as" + string([]byte{0xd1}) + "root\n" +
+		"set -o pipefail\n" +
+		"export HOME=/root\n"
+	err = os.WriteFile(
+		filepath.Join(tempDir, fileName),
+		[]byte(script),
+		0644,
+	)
+	assert.NoError(t, err)
+
+	startLine, numLines := 2, 2
+	rsp, err := fileToolSet.readFile(context.Background(), &readFileRequest{
+		FileName:  fileName,
+		StartLine: &startLine,
+		NumLines:  &numLines,
+	})
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rsp.Contents)
+	assert.Equal(t, "# run as�root\nset -o pipefail", rsp.Contents)
+	assert.Equal(
+		t,
+		"Successfully read cloud-init.sh, start line: 2, end line: 3, "+
+			"total lines: 5 (invalid UTF-8 replaced with U+FFFD)",
+		rsp.Message,
+	)
+}
+
+func TestFileTool_ReadFile_ValidUTF8IsNotAnnotated(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	const fileName = "valid.txt"
+	err = os.WriteFile(
+		filepath.Join(tempDir, fileName),
+		[]byte("héllo\nwörld\n"),
+		0644,
+	)
+	assert.NoError(t, err)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: fileName},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "héllo\nwörld\n", rsp.Contents)
+	assert.Equal(
+		t,
+		"Successfully read valid.txt, start line: 1, end line: 3, "+
+			"total lines: 3",
+		rsp.Message,
+	)
+}
+
+func TestFileTool_ReadFile_FromCache_NULByteRejected(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+
+	const (
+		outABin       = "out/a.bin"
+		mimeTextPlain = "text/plain"
+	)
+	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
+		{
+			Name:     outABin,
+			Content:  "text" + string([]byte{0x00}) + "more",
+			MIMEType: mimeTextPlain,
+		},
+	})
+
+	rsp, err := fileToolSet.readFile(ctx, &readFileRequest{
+		FileName: outABin,
+	})
+
+	assert.Error(t, err)
+	assert.Empty(t, rsp.Contents)
+	assert.Equal(
+		t,
+		"Error: file is not a UTF-8 text file (mime: text/plain)",
+		rsp.Message,
+	)
+}
+
+func TestFileTool_ReadFile_InvalidUTF8AtMaxFileSize(t *testing.T) {
+	tempDir := t.TempDir()
+	const (
+		fileName    = "atlimit.txt"
+		maxFileSize = 16
+	)
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(maxFileSize),
+	)
+	assert.NoError(t, err)
+	fileToolSet := toolSet.(*fileToolSet)
+
+	// Exactly maxFileSize source bytes, one of them invalid. U+FFFD is three
+	// bytes wide, so measuring the size after substitution would reject a file
+	// that is within the configured limit.
+	content := append(
+		[]byte(strings.Repeat("a", maxFileSize-1)),
+		byte(0xd1),
+	)
+	assert.Len(t, content, maxFileSize)
+	err = os.WriteFile(filepath.Join(tempDir, fileName), content, 0644)
+	assert.NoError(t, err)
+
+	rsp, err := fileToolSet.readFile(
+		context.Background(),
+		&readFileRequest{FileName: fileName},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, strings.Repeat("a", maxFileSize-1)+"�", rsp.Contents)
+	assert.Equal(
+		t,
+		"Successfully read atlimit.txt, start line: 1, end line: 1, "+
+			"total lines: 1 (invalid UTF-8 replaced with U+FFFD)",
+		rsp.Message,
+	)
 }


### PR DESCRIPTION
## What changed

`read_file` now returns text files that contain invalid UTF-8, with each run of
invalid bytes replaced by U+FFFD, instead of failing the call. The response
message records that a substitution happened, so a caller can tell the returned
contents apart from the bytes on disk.

Content that is not text is still rejected exactly as before: a non-text MIME
type, or an embedded NUL byte, returns `file is not a UTF-8 text file`.

## Why

A single mis-encoded byte made an entire readable file unreadable through this
tool, with no way to recover. A shell script whose comment carried one stray
`0xD1` byte — every other byte plain ASCII, and `http.DetectContentType`
reporting `text/plain; charset=utf-8` — failed every `read_file` call against
it. There is no flag, line range, or encoding argument that lets the caller see
the file anyway, and the error names a property of the whole file, so retrying a
narrower range does not help either.

Rejecting is the right answer for binary content, where returning mangled text
would be worse than an error. It is the wrong answer for encoding damage inside
a file that is otherwise plain text, which is what invalid UTF-8 under a text
MIME type almost always is. The two signals this change keeps — a non-text MIME
type and an embedded NUL byte — are the ones that actually distinguish binary
content from a text file with a few bad bytes; `utf8.Valid` does not.

The practical effect of rejecting is worse than an unreadable file. A caller
that cannot read a file through this tool falls back to shelling out to
`sed`/`cat`, which bypasses every path restriction and size limit in this
package, or edits the file blind.

## Testing

- `go test ./tool/file/... -count=1` passes, package coverage 93.6%.
- Every line added by this change is covered: `sanitizeText` reports 100% in
  `go tool cover -func`, and no uncovered block in the coverage profile
  intersects an added line.
- Root module suite via `bash .github/scripts/run-go-tests.sh --module ./go.mod`.
  One failure, `tool/duckduckgo/TestNewDefaultHTTPClient_UsesTransportNetwork`,
  which reproduces unchanged on `main` at the same commit: it binds a unix
  socket under the per-test temp directory, whose path exceeds the platform
  `sun_path` limit on macOS. Unrelated to this change and not touched by it.
- `gofmt -l ./tool/file` clean, `go vet ./tool/file` clean.
- New tests cover the sanitizing path on all three read sources (workspace and
  artifact refs, disk, and the `skill_run` output-files cache), the surviving
  rejections, the boundary cases (empty content, empty MIME type, a truncated
  multi-byte rune, a run of consecutive invalid bytes), and a negative case
  asserting that a valid file's message is not annotated.

## Notes for reviewers

- **Behavior change.** Three existing tests asserted the old rejection for
  invalid UTF-8 — `TestFileTool_ReadFile_FromRef_InvalidUTF8`,
  `TestFileTool_ReadFile_InvalidUTF8FromDisk`, and
  `TestFileTool_ReadFile_FromCache_InvalidUTF8`. They now assert the
  substitution instead. That is the contract this PR intends to change; the
  binary-rejection tests alongside them are untouched and still pass.
- **`strings.ToValidUTF8` replaces a run, not a byte.** Three consecutive
  invalid bytes collapse into one U+FFFD, so returned contents can be shorter
  than the file. A test pins this so the behavior is deliberate rather than
  incidental.
- **The round trip is lossy.** A caller that reads a sanitized file and writes
  it back persists U+FFFD where the original bytes were. That leaves the file
  valid UTF-8, which is usually the desired repair, but it does modify bytes the
  caller did not set out to change. The message annotation exists so this is at
  least visible; a caller that must not alter such a file can check it.
- **`read_multiple_files` never validated UTF-8 at all**, so it already returns
  files this tool rejected — invalid bytes and all, silently substituted later
  by JSON encoding. That inconsistency is real but out of scope here; I left it
  alone to keep this change focused, and am happy to follow up separately.
