### PR TITLE
graph: inject invocation fields into custom events

### DIFF
--- a/graph/emitter.go
+++ b/graph/emitter.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"time"
 
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 )
@@ -47,6 +48,7 @@ type eventEmitter struct {
 	eventChan    chan<- *event.Event
 	nodeID       string
 	invocationID string
+	invocation   *agent.Invocation
 	stepNumber   int
 	branch       string
 	timeout      time.Duration
@@ -73,6 +75,12 @@ func WithEmitterNodeID(nodeID string) EventEmitterOption {
 func WithEmitterInvocationID(invocationID string) EventEmitterOption {
 	return func(e *eventEmitter) {
 		e.invocationID = invocationID
+	}
+}
+
+func withEmitterInvocation(invocation *agent.Invocation) EventEmitterOption {
+	return func(e *eventEmitter) {
+		e.invocation = invocation
 	}
 }
 
@@ -125,13 +133,13 @@ func (e *eventEmitter) Emit(evt *event.Event) error {
 
 	// Inject context information if not already set
 	if evt.InvocationID == "" {
-		evt.InvocationID = e.invocationID
+		evt.InvocationID = e.eventInvocationID()
 	}
 	if evt.Author == "" {
 		evt.Author = e.nodeID
 	}
-	if evt.Branch == "" && e.branch != "" {
-		evt.Branch = e.branch
+	if evt.Branch == "" && e.shouldFillInvocationFields(evt) && e.eventBranch() != "" {
+		evt.Branch = e.eventBranch()
 	}
 
 	return e.emitWithRecover(evt)
@@ -139,24 +147,25 @@ func (e *eventEmitter) Emit(evt *event.Event) error {
 
 // EmitCustom sends a custom event with the specified event type and payload.
 func (e *eventEmitter) EmitCustom(eventType string, payload any) error {
+	invocationID := e.eventInvocationID()
 	metadata := NodeCustomEventMetadata{
 		EventType:    eventType,
 		Category:     NodeCustomEventCategoryCustom,
 		NodeID:       e.nodeID,
-		InvocationID: e.invocationID,
+		InvocationID: invocationID,
 		StepNumber:   e.stepNumber,
 		Timestamp:    time.Now(),
 		Payload:      payload,
 	}
 
 	evt := NewGraphEvent(
-		e.invocationID,
+		invocationID,
 		e.nodeID,
 		ObjectTypeGraphNodeCustom,
 		WithNodeCustomMetadata(metadata),
 	)
-	if e.branch != "" {
-		evt.Branch = e.branch
+	if e.eventBranch() != "" {
+		evt.Branch = e.eventBranch()
 	}
 
 	return e.emitWithRecover(evt)
@@ -172,11 +181,12 @@ func (e *eventEmitter) EmitProgress(progress float64, message string) error {
 		progress = 100
 	}
 
+	invocationID := e.eventInvocationID()
 	metadata := NodeCustomEventMetadata{
 		EventType:    "progress",
 		Category:     NodeCustomEventCategoryProgress,
 		NodeID:       e.nodeID,
-		InvocationID: e.invocationID,
+		InvocationID: invocationID,
 		StepNumber:   e.stepNumber,
 		Timestamp:    time.Now(),
 		Progress:     progress,
@@ -184,13 +194,13 @@ func (e *eventEmitter) EmitProgress(progress float64, message string) error {
 	}
 
 	evt := NewGraphEvent(
-		e.invocationID,
+		invocationID,
 		e.nodeID,
 		ObjectTypeGraphNodeCustom,
 		WithNodeCustomMetadata(metadata),
 	)
-	if e.branch != "" {
-		evt.Branch = e.branch
+	if e.eventBranch() != "" {
+		evt.Branch = e.eventBranch()
 	}
 
 	return e.emitWithRecover(evt)
@@ -198,24 +208,25 @@ func (e *eventEmitter) EmitProgress(progress float64, message string) error {
 
 // EmitText sends a streaming text event.
 func (e *eventEmitter) EmitText(text string) error {
+	invocationID := e.eventInvocationID()
 	metadata := NodeCustomEventMetadata{
 		EventType:    "text",
 		Category:     NodeCustomEventCategoryText,
 		NodeID:       e.nodeID,
-		InvocationID: e.invocationID,
+		InvocationID: invocationID,
 		StepNumber:   e.stepNumber,
 		Timestamp:    time.Now(),
 		Message:      text,
 	}
 
 	evt := NewGraphEvent(
-		e.invocationID,
+		invocationID,
 		e.nodeID,
 		ObjectTypeGraphNodeCustom,
 		WithNodeCustomMetadata(metadata),
 	)
-	if e.branch != "" {
-		evt.Branch = e.branch
+	if e.eventBranch() != "" {
+		evt.Branch = e.eventBranch()
 	}
 
 	return e.emitWithRecover(evt)
@@ -226,6 +237,47 @@ func (e *eventEmitter) Context() context.Context {
 	return e.ctx
 }
 
+func (e *eventEmitter) eventInvocationID() string {
+	if e.invocation != nil && e.invocation.InvocationID != "" {
+		return e.invocation.InvocationID
+	}
+	return e.invocationID
+}
+
+func (e *eventEmitter) eventBranch() string {
+	if e.invocation != nil && e.invocation.Branch != "" {
+		return e.invocation.Branch
+	}
+	return e.branch
+}
+
+func (e *eventEmitter) shouldFillInvocationFields(evt *event.Event) bool {
+	invocationID := e.eventInvocationID()
+	return evt.InvocationID == "" || evt.InvocationID == invocationID
+}
+
+func fillEventInvocationFields(invocation *agent.Invocation, evt *event.Event) {
+	if invocation == nil {
+		return
+	}
+	if evt.RequestID == "" {
+		evt.RequestID = invocation.RunOptions.RequestID
+	}
+	parent := invocation.GetParentInvocation()
+	if evt.ParentInvocationID == "" && parent != nil {
+		evt.ParentInvocationID = parent.InvocationID
+	}
+	if evt.Branch == "" {
+		evt.Branch = invocation.Branch
+	}
+	if evt.FilterKey == "" {
+		evt.FilterKey = invocation.GetEventFilterKey()
+	}
+	if evt.ParentMetadata == nil && invocation.ParentMetadata != nil {
+		evt.ParentMetadata = invocation.ParentMetadata
+	}
+}
+
 // emitWithRecover sends an event to the channel with panic recovery.
 func (e *eventEmitter) emitWithRecover(evt *event.Event) (err error) {
 	defer func() {
@@ -234,7 +286,15 @@ func (e *eventEmitter) emitWithRecover(evt *event.Event) (err error) {
 			err = nil // Don't propagate panic as error
 		}
 	}()
-
+	if e.shouldFillInvocationFields(evt) {
+		fillEventInvocationFields(e.invocation, evt)
+	}
+	if evt.InvocationID == "" {
+		evt.InvocationID = e.eventInvocationID()
+	}
+	if evt.Branch == "" && e.shouldFillInvocationFields(evt) {
+		evt.Branch = e.eventBranch()
+	}
 	return event.EmitEventWithTimeout(e.ctx, e.eventChan, evt, e.timeout)
 }
 
@@ -277,6 +337,8 @@ func GetEventEmitter(state State) EventEmitter {
 }
 
 // GetEventEmitterWithContext retrieves an EventEmitter from the given State with a custom context.
+// It prefers the execution-context invocation, then the context invocation,
+// and finally the execution-context invocation ID.
 func GetEventEmitterWithContext(ctx context.Context, state State) EventEmitter {
 	if state == nil {
 		return &noopEmitter{}
@@ -296,11 +358,20 @@ func GetEventEmitterWithContext(ctx context.Context, state State) EventEmitter {
 	// Get current node ID from state
 	nodeID, _ := GetStateValue[string](state, StateKeyCurrentNodeID)
 
-	// Create EventEmitter with context information
-	return NewEventEmitter(
-		execCtx.EventChan,
+	invocation := execCtx.Invocation
+	if invocation == nil && ctx != nil {
+		invocation, _ = agent.InvocationFromContext(ctx)
+	}
+
+	opts := []EventEmitterOption{
 		WithEmitterContext(ctx),
 		WithEmitterNodeID(nodeID),
-		WithEmitterInvocationID(execCtx.InvocationID),
-	)
+	}
+	if invocation != nil {
+		opts = append(opts, withEmitterInvocation(invocation))
+	}
+	if invocation == nil || invocation.InvocationID == "" {
+		opts = append(opts, WithEmitterInvocationID(execCtx.InvocationID))
+	}
+	return NewEventEmitter(execCtx.EventChan, opts...)
 }

--- a/graph/emitter_test.go
+++ b/graph/emitter_test.go
@@ -11,13 +11,26 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 )
+
+func requireEmitterEvent(t *testing.T, eventChan <-chan *event.Event) *event.Event {
+	t.Helper()
+	select {
+	case evt := <-eventChan:
+		return evt
+	case <-time.After(time.Second):
+		require.FailNow(t, "timeout waiting for event")
+	}
+	return nil
+}
 
 func TestEventEmitter_EmitCustom(t *testing.T) {
 	eventChan := make(chan *event.Event, 10)
@@ -49,6 +62,7 @@ func TestEventEmitter_EmitProgress(t *testing.T) {
 		eventChan,
 		WithEmitterNodeID("test-node"),
 		WithEmitterInvocationID("test-invocation"),
+		WithEmitterBranch("test-branch"),
 	)
 
 	// Test normal progress
@@ -58,6 +72,7 @@ func TestEventEmitter_EmitProgress(t *testing.T) {
 	select {
 	case evt := <-eventChan:
 		assert.Equal(t, ObjectTypeGraphNodeCustom, evt.Object)
+		assert.Equal(t, "test-branch", evt.Branch)
 		assert.Contains(t, evt.StateDelta, MetadataKeyNodeCustom)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for event")
@@ -77,6 +92,7 @@ func TestEventEmitter_EmitText(t *testing.T) {
 		eventChan,
 		WithEmitterNodeID("test-node"),
 		WithEmitterInvocationID("test-invocation"),
+		WithEmitterBranch("test-branch"),
 	)
 
 	err := emitter.EmitText("Hello, World!")
@@ -85,6 +101,7 @@ func TestEventEmitter_EmitText(t *testing.T) {
 	select {
 	case evt := <-eventChan:
 		assert.Equal(t, ObjectTypeGraphNodeCustom, evt.Object)
+		assert.Equal(t, "test-branch", evt.Branch)
 		assert.Contains(t, evt.StateDelta, MetadataKeyNodeCustom)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for event")
@@ -112,6 +129,93 @@ func TestEventEmitter_Emit(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for event")
 	}
+}
+
+func TestEventEmitter_EmitPreservesExplicitEventFields(t *testing.T) {
+	eventChan := make(chan *event.Event, 10)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("injected-invocation"),
+		agent.WithInvocationBranch("injected-branch"),
+		agent.WithInvocationEventFilterKey("injected-filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "injected-request",
+		}),
+	)
+	emitter := NewEventEmitter(
+		eventChan,
+		WithEmitterNodeID("test-node"),
+		WithEmitterInvocationID("fallback-invocation"),
+		WithEmitterBranch("fallback-branch"),
+		withEmitterInvocation(inv),
+	)
+	evt := event.New("explicit-invocation", "", event.WithBranch("explicit-branch"))
+	evt.RequestID = "explicit-request"
+	evt.ParentInvocationID = "explicit-parent"
+	evt.FilterKey = "explicit-filter"
+	err := emitter.Emit(evt)
+	require.NoError(t, err)
+	received := requireEmitterEvent(t, eventChan)
+	require.Equal(t, "explicit-request", received.RequestID)
+	require.Equal(t, "explicit-parent", received.ParentInvocationID)
+	require.Equal(t, "explicit-invocation", received.InvocationID)
+	require.Equal(t, "explicit-branch", received.Branch)
+	require.Equal(t, "explicit-filter", received.FilterKey)
+	require.Equal(t, "test-node", received.Author)
+}
+
+func TestEventEmitter_EmitDoesNotMixDifferentInvocationFields(t *testing.T) {
+	eventChan := make(chan *event.Event, 10)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("current-invocation"),
+		agent.WithInvocationBranch("current-branch"),
+		agent.WithInvocationEventFilterKey("current-filter"),
+		agent.WithInvocationParentMetadata(&event.ParentInvocationMetadata{
+			TriggerType: event.TriggerTypeToolCall,
+			TriggerID:   "current-trigger",
+			TriggerName: "current-tool",
+		}),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "current-request",
+		}),
+	)
+	emitter := NewEventEmitter(
+		eventChan,
+		WithEmitterNodeID("test-node"),
+		withEmitterInvocation(inv),
+	)
+	err := emitter.Emit(event.New("other-invocation", ""))
+	require.NoError(t, err)
+	received := requireEmitterEvent(t, eventChan)
+	require.Equal(t, "other-invocation", received.InvocationID)
+	require.Empty(t, received.RequestID)
+	require.Empty(t, received.Branch)
+	require.Empty(t, received.FilterKey)
+	require.Nil(t, received.ParentMetadata)
+	require.Equal(t, "test-node", received.Author)
+}
+
+func TestEventEmitter_EmitCustomInheritsParentFields(t *testing.T) {
+	eventChan := make(chan *event.Event, 10)
+	parent := agent.NewInvocation(agent.WithInvocationID("parent-invocation"))
+	parentMetadata := &event.ParentInvocationMetadata{
+		TriggerType: event.TriggerTypeToolCall,
+		TriggerID:   "tool-call",
+		TriggerName: "tool-name",
+	}
+	child := parent.Clone(
+		agent.WithInvocationID("child-invocation"),
+		agent.WithInvocationParentMetadata(parentMetadata),
+	)
+	emitter := NewEventEmitter(
+		eventChan,
+		WithEmitterNodeID("test-node"),
+		withEmitterInvocation(child),
+	)
+	err := emitter.EmitCustom("test-type", nil)
+	require.NoError(t, err)
+	received := requireEmitterEvent(t, eventChan)
+	require.Equal(t, "parent-invocation", received.ParentInvocationID)
+	require.Same(t, parentMetadata, received.ParentMetadata)
 }
 
 func TestEventEmitter_NilEvent(t *testing.T) {
@@ -190,6 +294,76 @@ func TestGetEventEmitter_WithValidContext(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for event")
 	}
+}
+
+func TestGetEventEmitterWithContext_InjectsInvocation(t *testing.T) {
+	eventChan := make(chan *event.Event, 10)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("test-invocation"),
+		agent.WithInvocationBranch("test-branch"),
+		agent.WithInvocationEventFilterKey("test-filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "test-request",
+		}),
+	)
+	execCtx := &ExecutionContext{
+		InvocationID: "stale-invocation",
+		Invocation:   inv,
+		EventChan:    eventChan,
+	}
+	state := State{
+		StateKeyExecContext:   execCtx,
+		StateKeyCurrentNodeID: "test-node",
+	}
+
+	emitter := GetEventEmitterWithContext(context.Background(), state)
+	err := emitter.EmitCustom("test-type", map[string]any{"foo": "bar"})
+	require.NoError(t, err)
+
+	evt := requireEmitterEvent(t, eventChan)
+	require.Equal(t, "test-request", evt.RequestID)
+	require.Equal(t, "test-invocation", evt.InvocationID)
+	require.Equal(t, "test-branch", evt.Branch)
+	require.Equal(t, "test-filter", evt.FilterKey)
+	require.Contains(t, evt.StateDelta, MetadataKeyNodeCustom)
+	var metadata NodeCustomEventMetadata
+	require.NoError(t, json.Unmarshal(evt.StateDelta[MetadataKeyNodeCustom], &metadata))
+	require.Equal(t, "test-invocation", metadata.InvocationID)
+	require.Equal(t, "test-node", metadata.NodeID)
+}
+
+func TestGetEventEmitterWithContext_InjectsContextInvocation(t *testing.T) {
+	eventChan := make(chan *event.Event, 10)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("ctx-invocation"),
+		agent.WithInvocationBranch("ctx-branch"),
+		agent.WithInvocationEventFilterKey("ctx-filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "ctx-request",
+		}),
+	)
+	execCtx := &ExecutionContext{
+		InvocationID: "stale-invocation",
+		EventChan:    eventChan,
+	}
+	state := State{
+		StateKeyExecContext:   execCtx,
+		StateKeyCurrentNodeID: "test-node",
+	}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	emitter := GetEventEmitterWithContext(ctx, state)
+	err := emitter.EmitCustom("test-type", map[string]any{"foo": "bar"})
+	require.NoError(t, err)
+	evt := requireEmitterEvent(t, eventChan)
+	require.Equal(t, "ctx-request", evt.RequestID)
+	require.Equal(t, "ctx-invocation", evt.InvocationID)
+	require.Equal(t, "ctx-branch", evt.Branch)
+	require.Equal(t, "ctx-filter", evt.FilterKey)
+	require.Contains(t, evt.StateDelta, MetadataKeyNodeCustom)
+	var metadata NodeCustomEventMetadata
+	require.NoError(t, json.Unmarshal(evt.StateDelta[MetadataKeyNodeCustom], &metadata))
+	require.Equal(t, "ctx-invocation", metadata.InvocationID)
+	require.Equal(t, "test-node", metadata.NodeID)
 }
 
 func TestGetEventEmitterWithContext(t *testing.T) {

--- a/graph/state_delta_event.go
+++ b/graph/state_delta_event.go
@@ -94,23 +94,28 @@ func EmitCustomStateDelta(
 	}
 
 	nodeID, _ := GetStateValue[string](state, StateKeyCurrentNodeID)
+	invocationID := execCtx.InvocationID
+	if execCtx.Invocation != nil && execCtx.Invocation.InvocationID != "" {
+		invocationID = execCtx.Invocation.InvocationID
+	}
 	metadata := NodeCustomEventMetadata{
 		EventType:    options.EventType,
 		Category:     NodeCustomEventCategoryCustom,
 		NodeID:       nodeID,
-		InvocationID: execCtx.InvocationID,
+		InvocationID: invocationID,
 		Timestamp:    time.Now(),
 		Payload:      options.Payload,
 		Message:      options.Message,
 	}
 
 	evt := NewGraphEvent(
-		execCtx.InvocationID,
+		invocationID,
 		formatNodeAuthor(nodeID, AuthorGraphNode),
 		ObjectTypeGraphNodeCustom,
 		WithNodeCustomMetadata(metadata),
 	)
 	evt.StateDelta = mergeStateDeltaMaps(evt.StateDelta, stateDelta)
+	fillEventInvocationFields(execCtx.Invocation, evt)
 	return event.EmitEvent(ctx, execCtx.EventChan, evt)
 }
 

--- a/graph/state_delta_event_test.go
+++ b/graph/state_delta_event_test.go
@@ -11,17 +11,28 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 )
 
 func TestEmitCustomStateDelta_EmitsEvent(t *testing.T) {
 	eventCh := make(chan *event.Event, 1)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID("inv-from-invocation"),
+		agent.WithInvocationBranch("branch"),
+		agent.WithInvocationEventFilterKey("filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req",
+		}),
+	)
 	state := State{
 		StateKeyExecContext: &ExecutionContext{
-			InvocationID: "inv",
+			InvocationID: "stale-invocation",
+			Invocation:   inv,
 			EventChan:    eventCh,
 		},
 		StateKeyCurrentNodeID: "step",
@@ -36,11 +47,54 @@ func TestEmitCustomStateDelta_EmitsEvent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	evt := <-eventCh
+	evt := requireEmitterEvent(t, eventCh)
 	require.NotNil(t, evt)
+	require.Equal(t, "req", evt.RequestID)
+	require.Equal(t, "inv-from-invocation", evt.InvocationID)
+	require.Equal(t, "branch", evt.Branch)
+	require.Equal(t, "filter", evt.FilterKey)
 	require.Equal(t, ObjectTypeGraphNodeCustom, evt.Object)
 	require.Contains(t, evt.StateDelta, "result")
 	require.Contains(t, evt.StateDelta, MetadataKeyNodeCustom)
+	var metadata NodeCustomEventMetadata
+	require.NoError(t, json.Unmarshal(evt.StateDelta[MetadataKeyNodeCustom], &metadata))
+	require.Equal(t, "inv-from-invocation", metadata.InvocationID)
+}
+
+func TestEmitCustomStateDelta_PreservesFallbackInvocationID(t *testing.T) {
+	eventCh := make(chan *event.Event, 1)
+	inv := agent.NewInvocation(
+		agent.WithInvocationID(""),
+		agent.WithInvocationBranch("branch"),
+		agent.WithInvocationEventFilterKey("filter"),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req",
+		}),
+	)
+	state := State{
+		StateKeyExecContext: &ExecutionContext{
+			InvocationID: "fallback-invocation",
+			Invocation:   inv,
+			EventChan:    eventCh,
+		},
+		StateKeyCurrentNodeID: "step",
+	}
+
+	err := EmitCustomStateDelta(
+		context.Background(),
+		state,
+		State{"result": true},
+	)
+	require.NoError(t, err)
+
+	evt := requireEmitterEvent(t, eventCh)
+	require.Equal(t, "fallback-invocation", evt.InvocationID)
+	require.Equal(t, "req", evt.RequestID)
+	require.Equal(t, "branch", evt.Branch)
+	require.Equal(t, "filter", evt.FilterKey)
+	var metadata NodeCustomEventMetadata
+	require.NoError(t, json.Unmarshal(evt.StateDelta[MetadataKeyNodeCustom], &metadata))
+	require.Equal(t, "fallback-invocation", metadata.InvocationID)
 }
 
 func TestEmitCustomStateDelta_NoExecutionContextIsNoop(t *testing.T) {


### PR DESCRIPTION
This updates graph custom event emission to inject invocation-derived fields such as request ID, invocation ID, branch, and filter key, including state-delta custom events, so downstream server protocols can validate runner events consistently.