### PR TITLE
lsc: backport fixes for v1.11.2

### DIFF
--- a/docs/mkdocs/en/model.md
+++ b/docs/mkdocs/en/model.md
@@ -1944,6 +1944,7 @@ The framework currently supports the following Variants:
 - Default BaseURL：`https://api.deepseek.com`
 - API Key environment variable name：`DEEPSEEK_API_KEY`
 - DeepSeek-specific behavior is enabled when you explicitly set `WithVariant(openai.VariantDeepSeek)` or use the official DeepSeek API BaseURL
+- Serializes `GenerationConfig.MaxTokens` as `max_tokens`, the field documented by the [DeepSeek Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion); other variants continue to use `max_completion_tokens`
 - Other behaviors are consistent with standard OpenAI
 
 **4. VariantQwen（Qwen）**

--- a/docs/mkdocs/en/observability.md
+++ b/docs/mkdocs/en/observability.md
@@ -279,7 +279,7 @@ Default (unset) behavior is unchanged.
 | `MaxBytes(n)` + `Omit()` | JSON: no; `[]byte`: yes | JSON paths marshal fully before comparing size; `[]byte` paths use `len` only |
 | `Truncate(n)` | No | Full marshal, then truncate on export |
 
-To reduce memory, prefer `Drop()` on attributes you do not need (for example redundant `*.otel`).
+To reduce memory, prefer `Drop()` on attributes **this backend will not read**. Do not copy another backend's sample blindly: Langfuse and Jaeger / generic OTLP consume different keys.
 
 ### Coverage
 
@@ -290,11 +290,27 @@ Large payload attributes are wired for `chat`, `invoke_agent`, `workflow`, and `
 ```go
 import atrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 
+// Langfuse: keep *.otel (including multimodal parts). Drop deprecated legacy messages.
+// On chat/generation spans, do not Drop .otel, legacy messages, and llm_request/llm_response together, or Input/Output may be empty.
+clean, err := atrace.Start(ctx,
+    atrace.WithSpanAttributePolicy(
+        atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrInputMessages, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrOutputMessages, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrInputMessages, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrOutputMessages, atrace.Drop()),
+    ),
+)
+```
+
+Jaeger / Galileo / generic OTLP consume raw span attributes. If the UI only uses `gen_ai.input.messages` / `gen_ai.output.messages`, Drop `*.otel` to skip that marshal:
+
+```go
 clean, err := atrace.Start(ctx,
     atrace.WithSpanAttributePolicy(
         atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrInputMessagesOTel, atrace.Drop()),
         atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrOutputMessagesOTel, atrace.Drop()),
         atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrInputMessagesOTel, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrOutputMessagesOTel, atrace.Drop()),
     ),
 )
 ```
@@ -317,7 +333,11 @@ atrace.WithAttributeRule(atrace.OperationWorkflow, atrace.AttributeKey("gen_ai.w
 
 ### Compatibility
 
-Drop/Omit/Truncate may prevent some backends from reconstructing structured full text from attributes. Opt in based on your backend and memory budget.
+Drop/Omit/Truncate may prevent some backends from reconstructing structured full text from attributes. Opt in based on **the keys your backend actually reads** and your memory budget.
+
+- On chat/generation spans, the Langfuse exporter reads `*.otel` first, then legacy `gen_ai.*.messages`, then `trpc.go.agent.llm_request` / `llm_response`. InvokeAgent only falls back from `*.otel` to legacy messages. If none of the applicable sources are present, Input/Output may be empty.
+- Jaeger / generic OTLP usually display raw keys. The official GenAI field is `gen_ai.input.messages`; `*.otel` is a framework extension.
+- When fanning out to Langfuse **and** Jaeger, do not Drop a family that either backend still needs.
 
 ## Advanced Features
 

--- a/docs/mkdocs/en/telemetry-multimodal.md
+++ b/docs/mkdocs/en/telemetry-multimodal.md
@@ -51,6 +51,10 @@ Supported part types include:
 
 ## Langfuse Conversion
 
-The Langfuse exporter only converts `gen_ai.input.messages.otel` and `gen_ai.output.messages.otel` into the displayed input/output payload. Deprecated compatibility fields remain available on raw spans for other consumers, but Langfuse does not parse them.
+The Langfuse exporter folds messages into `langfuse.observation.input` / `output` in this order:
 
-This keeps existing raw attributes available while making the OTel payload the only Langfuse conversion path.
+1. `gen_ai.input.messages.otel` / `gen_ai.output.messages.otel` (GenAI `role` + `parts`, passed through for Langfuse to convert)
+2. If `.otel` is missing: legacy `gen_ai.input.messages` / `gen_ai.output.messages` (passed through as-is; output is conversation-shaped and preferred over `llm_response`)
+3. On chat/generation spans only: `trpc.go.agent.llm_request` / `llm_response`
+
+Jaeger and other generic OTLP backends still read raw span attributes, so their Drop policy differs from Langfuse. See Span Attribute Policy in [Observability](observability.md).

--- a/docs/mkdocs/zh/model.md
+++ b/docs/mkdocs/zh/model.md
@@ -1917,6 +1917,7 @@ Variant 机制是 Model 模块的重要优化，用于处理不同 OpenAI 兼容
 - 默认 BaseURL：`https://api.deepseek.com`
 - API Key 环境变量名：`DEEPSEEK_API_KEY`
 - 显式设置 `WithVariant(openai.VariantDeepSeek)`，或使用官方 DeepSeek API BaseURL 时，才会启用 DeepSeek 特有行为
+- 按 [DeepSeek Chat Completions API](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion) 文档定义，将 `GenerationConfig.MaxTokens` 序列化为 `max_tokens`；其他 variant 继续使用 `max_completion_tokens`
 - 其他行为与标准 OpenAI 一致
 
 **4. VariantQwen（千问）**

--- a/docs/mkdocs/zh/observability.md
+++ b/docs/mkdocs/zh/observability.md
@@ -281,7 +281,7 @@ Agent Request
 | `MaxBytes(n)` + `Omit()` | JSON：否；`[]byte`：是 | JSON 路径需完整 marshal 后再比阈值；`[]byte` 路径仅 `len` 判断 |
 | `Truncate(n)` | 否 | 完整序列化后截断导出 |
 
-想降内存，优先 `Drop()` 去掉不需要的 attribute（如冗余 `*.otel`）。
+想降内存，优先 `Drop()` 当前后端**不会读取**的 attribute。不要把某一套示例当成通用配置：Langfuse 与 Jaeger / 通用 OTLP 读的 key 不同。
 
 ### 覆盖范围
 
@@ -292,11 +292,27 @@ Agent Request
 ```go
 import atrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
 
+// Langfuse：保留 *.otel（含 multimodal parts）。可 Drop 废弃的 legacy messages。
+// chat/generation span 上不要把 .otel、legacy messages 和 llm_request/llm_response 全部 Drop，否则 Input/Output 可能为空。
+clean, err := atrace.Start(ctx,
+    atrace.WithSpanAttributePolicy(
+        atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrInputMessages, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrOutputMessages, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrInputMessages, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrOutputMessages, atrace.Drop()),
+    ),
+)
+```
+
+Jaeger / Galileo / 通用 OTLP 消费的是原始 span attribute。若 UI 只认 `gen_ai.input.messages` / `gen_ai.output.messages`，可以 Drop `*.otel` 以降低 marshal 成本：
+
+```go
 clean, err := atrace.Start(ctx,
     atrace.WithSpanAttributePolicy(
         atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrInputMessagesOTel, atrace.Drop()),
         atrace.WithAttributeRule(atrace.OperationChat, atrace.AttrOutputMessagesOTel, atrace.Drop()),
         atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrInputMessagesOTel, atrace.Drop()),
+        atrace.WithAttributeRule(atrace.OperationInvokeAgent, atrace.AttrOutputMessagesOTel, atrace.Drop()),
     ),
 )
 ```
@@ -319,7 +335,11 @@ atrace.WithAttributeRule(atrace.OperationWorkflow, atrace.AttributeKey("gen_ai.w
 
 ### 兼容性说明
 
-启用 Drop/Omit/Truncate 后，部分监控后端可能无法从 attribute 还原结构化全文；请按自身后端与内存预算 opt-in 评估。
+启用 Drop/Omit/Truncate 后，部分监控后端可能无法从 attribute 还原结构化全文；请按**当前后端实际读取的 key** 与内存预算 opt-in 评估。
+
+- chat/generation span 上，Langfuse exporter 读取顺序：`*.otel` → legacy `gen_ai.*.messages` → `trpc.go.agent.llm_request` / `llm_response`。InvokeAgent 只从 `*.otel` 回退到 legacy messages。适用来源都缺失时 Input/Output 可能为空。
+- Jaeger / 通用 OTLP 通常展示原始 key。官方 GenAI 字段是 `gen_ai.input.messages`；`*.otel` 是框架扩展。
+- 同时 fan-out 到 Langfuse 和 Jaeger 时，任何一端还要用的字段都不能 Drop。
 
 ## 进阶功能
 

--- a/docs/mkdocs/zh/telemetry-multimodal.md
+++ b/docs/mkdocs/zh/telemetry-multimodal.md
@@ -51,6 +51,10 @@ tRPC-Agent-Go 会上报两组消息属性：
 
 ## Langfuse 转换
 
-Langfuse exporter 只会把 `gen_ai.input.messages.otel` 和 `gen_ai.output.messages.otel` 转换为最终展示的 input/output 内容。废弃兼容字段仍保留在原始 span 上，供其他消费方读取，但 Langfuse 不再解析它们。
+Langfuse exporter 把消息折叠进 `langfuse.observation.input` / `output`，读取顺序：
 
-这样既保留了原始兼容属性，也让 OTel payload 成为 Langfuse 唯一的转换路径。
+1. `gen_ai.input.messages.otel` / `gen_ai.output.messages.otel`（GenAI `role` + `parts`，原样上报，由 Langfuse 转换）
+2. 若 `.otel` 缺失：legacy `gen_ai.input.messages` / `gen_ai.output.messages`（原样上报；output 更接近对话形态，优先于 `llm_response`）
+3. 仅 chat/generation span：`trpc.go.agent.llm_request` / `llm_response`
+
+Jaeger 等通用 OTLP 后端仍读取原始 span attribute，Drop 策略与 Langfuse 不同，见 [可观测性](observability.md) 中的 Span Attribute 策略。

--- a/examples/knowledge/go.mod
+++ b/examples/knowledge/go.mod
@@ -24,10 +24,10 @@ replace (
 require (
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/jackc/pgx/v5 v5.7.2
-	trpc.group/trpc-go/trpc-agent-go v1.10.1-0.20260605075142-de51b6b2b584
+	trpc.group/trpc-go/trpc-agent-go v1.11.1
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/golang v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/pdf v0.5.0
-	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/python v0.0.0
+	trpc.group/trpc-go/trpc-agent-go/knowledge/document/reader/python v1.11.0
 	trpc.group/trpc-go/trpc-agent-go/knowledge/graphstore/age v0.0.0-20260602121024-664ebd0ab56d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/ocr/tesseract v0.0.0-20251203120347-0b4d62cb115d
 	trpc.group/trpc-go/trpc-agent-go/knowledge/vectorstore/elasticsearch v0.2.1

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/calllimit"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
@@ -514,6 +515,123 @@ func TestMaybeCompactContextBeforeLLM_RebuildsRequestWithSummary(t *testing.T) {
 	require.Equal(t, "completed", doneDiagnostic.Status)
 	require.NotNil(t, doneDiagnostic.Updated)
 	require.True(t, *doneDiagnostic.Updated)
+}
+
+func TestMaybeCompactContextBeforeLLM_SummarizesSanitizedOrphanToolCall(
+	t *testing.T,
+) {
+	summaryModel := &mockModel{responses: []*model.Response{{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("compressed orphan history"),
+		}},
+	}}}
+	service := inmemory.NewSessionService(inmemory.WithSummarizer(
+		summary.NewSummarizer(
+			summaryModel,
+			summary.WithTokenThreshold(1),
+			summary.WithPrompt("Conversation:\n{conversation_text}\n\nSummary:"),
+		),
+	))
+	t.Cleanup(func() {
+		require.NoError(t, service.Close())
+	})
+
+	ctx := context.Background()
+	sess, err := service.CreateSession(ctx, session.Key{
+		AppName:   "app",
+		UserID:    "user",
+		SessionID: "orphan-compaction",
+	}, nil)
+	require.NoError(t, err)
+	oldUser := event.New("inv-old", "user")
+	oldUser.RequestID = "req-old"
+	oldUser.Timestamp = time.Now().Add(-time.Hour)
+	oldUser.Response = &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewUserMessage(strings.Repeat("history ", 2000)),
+		}},
+	}
+	require.NoError(t, service.AppendEvent(ctx, sess, oldUser))
+	orphanCall := event.New("inv-old", "assistant")
+	orphanCall.RequestID = "req-old"
+	orphanCall.Timestamp = oldUser.Timestamp.Add(time.Second)
+	orphanCall.Response = &model.Response{
+		Done: true,
+		Choices: []model.Choice{{Message: model.Message{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID:   "call_orphan",
+				Type: "function",
+				Function: model.FunctionDefinitionParam{
+					Name:      "shell",
+					Arguments: []byte(`{"command":"pwd"}`),
+				},
+			}},
+		}}},
+	}
+	require.NoError(t, service.AppendEvent(ctx, sess, orphanCall))
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			RequestID: "req-current",
+		}),
+		agent.WithInvocationModel(&compactingModel{
+			name:   "orphan-compaction-model",
+			window: 10000,
+		}),
+	)
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(ctx, inv, req, nil)
+	view, ok := summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Len(t, req.Messages, 3)
+	require.Contains(t, req.Messages[1].Content, "orphan_tool_call")
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		ctx,
+		inv,
+		nil,
+		req,
+		rebuildPlan,
+	)
+
+	require.NotSame(t, req, rebuilt)
+	require.Len(t, rebuilt.Messages, 2)
+	require.Contains(t, rebuilt.Messages[0].Content, "compressed orphan history")
+	require.Equal(t, "current", rebuilt.Messages[1].Content)
+	summaryRequest := summaryModel.LastRequest()
+	require.NotNil(t, summaryRequest)
+	require.Contains(t, summaryRequest.Messages[0].Content, "orphan_tool_call")
+	sess.SummariesMu.RLock()
+	storedSummary := sess.Summaries[""]
+	sess.SummariesMu.RUnlock()
+	require.NotNil(t, storedSummary)
+	boundary := storedSummary.CutoffBoundary()
+	require.NotNil(t, boundary)
+	require.Equal(
+		t,
+		orphanCall.ID,
+		boundary.LastEventID,
+	)
 }
 
 func TestMaybeCompactContextBeforeLLM_PassesParentRequestForCacheSafeFork(t *testing.T) {
@@ -1571,6 +1689,16 @@ func TestNormalizeContextCompactionThresholdRatio(t *testing.T) {
 }
 
 func TestContextCompactionThreshold(t *testing.T) {
+	t.Run("reports minimum token clamp", func(t *testing.T) {
+		threshold, basis := contextCompactionThresholdForWindow(10000, 0.1)
+		require.Equal(t, 2000, threshold)
+		require.Equal(
+			t,
+			contextCompactionThresholdBasisMinimumTokens,
+			basis,
+		)
+	})
+
 	t.Run("caps to small model window", func(t *testing.T) {
 		const modelName = "compact-threshold-small-window"
 		model.RegisterModelContextWindow(modelName, 1024)
@@ -1579,6 +1707,12 @@ func TestContextCompactionThreshold(t *testing.T) {
 			agent.WithInvocationModel(&compactingModel{name: modelName}),
 		)
 		require.Equal(t, 1024, contextCompactionThreshold(inv, 0.1))
+		_, basis := contextCompactionThresholdForWindow(1024, 0.1)
+		require.Equal(
+			t,
+			contextCompactionThresholdBasisContextWindow,
+			basis,
+		)
 	})
 
 	t.Run("uses fallback window for unknown model", func(t *testing.T) {

--- a/internal/flow/llmflow/diagnostics.go
+++ b/internal/flow/llmflow/diagnostics.go
@@ -19,6 +19,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	itrace "trpc.group/trpc-go/trpc-agent-go/internal/trace"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -191,12 +192,18 @@ func emitLatencyDiagnosticEvent(
 }
 
 type contextCompactionDecision struct {
-	shouldCompact bool
-	tokenCount    int
-	threshold     int
-	contextWindow int
-	err           error
+	shouldCompact  bool
+	tokenCount     int
+	threshold      int
+	contextWindow  int
+	thresholdBasis string
+	err            error
 }
+
+const (
+	contextCompactionThresholdBasisContextWindow = "context_window"
+	contextCompactionThresholdBasisMinimumTokens = "minimum_tokens"
+)
 
 func contextCompactionAttrs(
 	decision contextCompactionDecision,
@@ -221,6 +228,39 @@ func contextCompactionAttrs(
 			"llmflow.context_compaction.context_window",
 			decision.contextWindow,
 		),
+		attribute.String(
+			"llmflow.context_compaction.threshold_basis",
+			decision.thresholdBasis,
+		),
 	)
 	return attrs
+}
+
+func tokenTailoringAttrs(
+	records []modelrequest.TokenTailoringRecord,
+) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Bool("llmflow.token_tailoring.applied", len(records) > 0),
+		attribute.Int("llmflow.token_tailoring.apply_count", len(records)),
+	}
+	if len(records) == 0 {
+		return attrs
+	}
+	last := records[len(records)-1]
+	return append(
+		attrs,
+		attribute.String("llmflow.token_tailoring.provider", last.Provider),
+		attribute.Int(
+			"llmflow.token_tailoring.max_input_tokens",
+			last.MaxInputTokens,
+		),
+		attribute.Int(
+			"llmflow.token_tailoring.before_messages",
+			last.BeforeMessages,
+		),
+		attribute.Int(
+			"llmflow.token_tailoring.after_messages",
+			last.AfterMessages,
+		),
+	)
 }

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -1573,8 +1574,31 @@ func (f *Flow) preprocess(
 		finishLatencySpan(stageSpan, stageStarted, nil)
 	}
 	// Sanitize invalid tool calls in history to avoid poisoning future requests.
-	llmRequest.Messages = toolcall.SanitizeMessagesWithTools(ctx, llmRequest.Messages, llmRequest.Tools)
+	sanitizeRequestMessages(ctx, invocation, llmRequest)
 	return rebuildPlan
+}
+
+func sanitizeRequestMessages(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+) {
+	if req == nil {
+		return
+	}
+	before := req.Messages
+	result := toolcall.SanitizeMessagesWithToolsResult(
+		ctx,
+		before,
+		req.Tools,
+	)
+	req.Messages = result.Messages
+	summaryview.RebaseAfterTransform(
+		invocation,
+		before,
+		result.Messages,
+		result.SourceIndexes,
+	)
 }
 
 func normalizeContextCompactionThresholdRatio(ratio float64) float64 {
@@ -1826,11 +1850,7 @@ func (f *Flow) rebuildRequestForContextCompaction(
 			rebuilt,
 		)
 	}
-	rebuilt.Messages = toolcall.SanitizeMessagesWithTools(
-		ctx,
-		rebuilt.Messages,
-		rebuilt.Tools,
-	)
+	sanitizeRequestMessages(ctx, invocation, rebuilt)
 	return rebuilt
 }
 
@@ -2095,8 +2115,11 @@ func syncCompactContextDecision(
 		return decision
 	}
 
-	decision.threshold = contextCompactionThreshold(inv, ratio)
 	decision.contextWindow = contextCompactionWindow(inv)
+	decision.threshold, decision.thresholdBasis = contextCompactionThresholdForWindow(
+		decision.contextWindow,
+		ratio,
+	)
 	if counter == nil {
 		counter = model.NewSimpleTokenCounter()
 	}
@@ -2133,14 +2156,25 @@ func contextCompactionWindow(inv *agent.Invocation) int {
 
 func contextCompactionThreshold(inv *agent.Invocation, ratio float64) int {
 	contextWindow := contextCompactionWindow(inv)
+	threshold, _ := contextCompactionThresholdForWindow(contextWindow, ratio)
+	return threshold
+}
+
+func contextCompactionThresholdForWindow(
+	contextWindow int,
+	ratio float64,
+) (int, string) {
 	threshold := int(float64(contextWindow) * normalizeContextCompactionThresholdRatio(ratio))
+	basis := contextCompactionThresholdBasisContextWindow
 	if threshold < contextCompactionMinTokens {
 		threshold = contextCompactionMinTokens
+		basis = contextCompactionThresholdBasisMinimumTokens
 	}
 	if threshold > contextWindow {
 		threshold = contextWindow
+		basis = contextCompactionThresholdBasisContextWindow
 	}
-	return threshold
+	return threshold, basis
 }
 
 // getFilteredTools returns the list of tools for this invocation after applying the filter.
@@ -2396,13 +2430,19 @@ func (f *Flow) callLLM(
 		latencyRequestAttrs(llmRequest)...,
 	)
 	var err error
-	defer func() {
+	finishSpanOnReturn := true
+	finishCallSpan := func(finishErr error) {
 		if started && callModel != nil {
 			span.SetAttributes(
 				attribute.String("llmflow.model", callModel.Info().Name),
 			)
 		}
-		finishLatencySpan(span, started, err)
+		finishLatencySpan(span, started, finishErr)
+	}
+	defer func() {
+		if finishSpanOnReturn {
+			finishCallSpan(err)
+		}
 	}()
 	if callModel == nil {
 		err = errors.New("no model available for LLM call")
@@ -2473,11 +2513,47 @@ func (f *Flow) callLLM(
 			finalizationMessage,
 		),
 	)
+	ctx, tailoringObserver := imodelrequest.ObserveTokenTailoring(
+		ctx,
+		func(record imodelrequest.TokenTailoringRecord) {
+			summaryview.InvalidateBinding(invocation)
+			summaryfork.Invalidate(invocation)
+			log.DebugfContext(
+				ctx,
+				"Model request token tailoring applied: provider=%s, "+
+					"max_input_tokens=%d, messages=%d->%d",
+				record.Provider,
+				record.MaxInputTokens,
+				record.BeforeMessages,
+				record.AfterMessages,
+			)
+		},
+	)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
 	if err != nil {
 		return ctx, nil, true, err
 	}
+	if started {
+		finishSpanOnReturn = false
+		seq = withResponseSeqFinalizer(seq, func() {
+			span.SetAttributes(
+				tokenTailoringAttrs(tailoringObserver.Snapshot())...,
+			)
+			finishCallSpan(nil)
+		})
+	}
 	return ctx, seq, true, nil
+}
+
+func withResponseSeqFinalizer(
+	seq model.Seq[*model.Response],
+	finalize func(),
+) model.Seq[*model.Response] {
+	var once sync.Once
+	return func(yield func(*model.Response) bool) {
+		defer once.Do(finalize)
+		seq(yield)
+	}
 }
 
 type callLimitFinalizationMessage struct {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -34,6 +34,7 @@ import (
 	imodelrequest "trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	"trpc.group/trpc-go/trpc-agent-go/internal/tracecapture"
 	"trpc.group/trpc-go/trpc-agent-go/log"
@@ -315,10 +316,11 @@ func TestEmitLatencyDiagnosticEventAndContextAttrs(t *testing.T) {
 	}
 	attrs := contextCompactionAttrs(
 		contextCompactionDecision{
-			shouldCompact: true,
-			tokenCount:    10,
-			threshold:     8,
-			contextWindow: 16,
+			shouldCompact:  true,
+			tokenCount:     10,
+			threshold:      8,
+			contextWindow:  16,
+			thresholdBasis: contextCompactionThresholdBasisContextWindow,
 		},
 		req,
 	)
@@ -338,6 +340,50 @@ func TestEmitLatencyDiagnosticEventAndContextAttrs(t *testing.T) {
 		t,
 		flowHasAttr(attrs, "llmflow.context_compaction.context_window", 16),
 	)
+	require.True(t, flowHasAttr(
+		attrs,
+		"llmflow.context_compaction.threshold_basis",
+		"context_window",
+	))
+	tailoringAttrs := tokenTailoringAttrs([]imodelrequest.TokenTailoringRecord{{
+		Provider:       "test.Model",
+		MaxInputTokens: 100,
+		BeforeMessages: 10,
+		AfterMessages:  4,
+	}})
+	require.True(t, flowHasAttr(
+		tailoringAttrs,
+		"llmflow.token_tailoring.applied",
+		true,
+	))
+	require.True(t, flowHasAttr(
+		tailoringAttrs,
+		"llmflow.token_tailoring.after_messages",
+		4,
+	))
+	emptyTailoringAttrs := tokenTailoringAttrs(nil)
+	require.Len(t, emptyTailoringAttrs, 2)
+	require.True(t, flowHasAttr(
+		emptyTailoringAttrs,
+		"llmflow.token_tailoring.applied",
+		false,
+	))
+	require.True(t, flowHasAttr(
+		emptyTailoringAttrs,
+		"llmflow.token_tailoring.apply_count",
+		0,
+	))
+	minimumAttrs := contextCompactionAttrs(
+		contextCompactionDecision{
+			thresholdBasis: contextCompactionThresholdBasisMinimumTokens,
+		},
+		req,
+	)
+	require.True(t, flowHasAttr(
+		minimumAttrs,
+		"llmflow.context_compaction.threshold_basis",
+		"minimum_tokens",
+	))
 }
 
 func TestPreprocess_AddsAgentToolsWhenPresent(t *testing.T) {
@@ -1005,6 +1051,113 @@ func TestRunOneStep_AttachesCacheSafeSummaryForkRequest(t *testing.T) {
 		},
 		parent.Messages,
 	)
+}
+
+func TestCallLLM_TokenTailoringInvalidatesSummarySnapshots(t *testing.T) {
+	callModel := &tailoringModel{}
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(agent.WithInvocationModel(callModel))
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("history"),
+	}}
+	summaryview.AttachProjection(inv, &summaryview.View{
+		ContentRequestLength: len(req.Messages),
+		Items: []summaryview.Item{{
+			Message:      req.Messages[1],
+			RequestIndex: 1,
+		}},
+	})
+
+	_, seq, modelCalled, err := f.callLLM(
+		context.Background(),
+		inv,
+		req,
+		callModel,
+	)
+
+	require.NoError(t, err)
+	require.True(t, modelCalled)
+	require.NotNil(t, seq)
+	view, ok := summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	_, ok = summaryfork.Request(inv)
+	require.False(t, ok)
+}
+
+func TestCallLLM_LazyTokenTailoringFinalizesDiagnosticsAfterIteration(
+	t *testing.T,
+) {
+	recorder := useSpanRecorder(t)
+	callModel := &lazyTailoringModel{}
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation(
+		agent.WithInvocationModel(callModel),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			LatencyDiagnosticsEnabled: true,
+		}),
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("history"),
+	}}
+	summaryview.AttachProjection(inv, &summaryview.View{
+		ContentRequestLength: len(req.Messages),
+		Items: []summaryview.Item{{
+			Message:      req.Messages[1],
+			RequestIndex: 1,
+		}},
+	})
+
+	_, seq, modelCalled, err := f.callLLM(
+		context.Background(),
+		inv,
+		req,
+		callModel,
+	)
+	require.NoError(t, err)
+	require.True(t, modelCalled)
+	require.NotNil(t, seq)
+	for _, ended := range recorder.Ended() {
+		require.NotEqual(t, latencySpanCallLLM, ended.Name())
+	}
+	view, ok := summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	_, ok = summaryfork.Request(inv)
+	require.True(t, ok)
+
+	var responses int
+	seq(func(*model.Response) bool {
+		responses++
+		return true
+	})
+	require.Equal(t, 1, responses)
+	view, ok = summaryview.Snapshot(inv)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	_, ok = summaryfork.Request(inv)
+	require.False(t, ok)
+
+	var callAttrs []attribute.KeyValue
+	for _, ended := range recorder.Ended() {
+		if ended.Name() == latencySpanCallLLM {
+			callAttrs = ended.Attributes()
+			break
+		}
+	}
+	require.NotNil(t, callAttrs)
+	require.True(t, flowHasAttr(
+		callAttrs,
+		"llmflow.token_tailoring.applied",
+		true,
+	))
+	require.True(t, flowHasAttr(
+		callAttrs,
+		"llmflow.token_tailoring.apply_count",
+		1,
+	))
 }
 
 func TestRunOneStep_LeavesExecutionTraceFinalizationToOwnerWhenModelFails(t *testing.T) {
@@ -2336,6 +2489,76 @@ type mockModel struct {
 	currentIdx  int
 	mu          sync.Mutex
 	requests    []*model.Request
+}
+
+type tailoringModel struct{}
+
+func (m *tailoringModel) Info() model.Info {
+	return model.Info{Name: "tailoring-model"}
+}
+
+func (m *tailoringModel) GenerateContent(
+	ctx context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	beforeMessages := len(req.Messages)
+	req.Messages = req.Messages[:1]
+	imodelrequest.RecordTokenTailoring(
+		ctx,
+		imodelrequest.TokenTailoringRecord{
+			Provider:       "tailoringModel",
+			MaxInputTokens: 100,
+			BeforeMessages: beforeMessages,
+			AfterMessages:  len(req.Messages),
+		},
+	)
+	respChan := make(chan *model.Response, 1)
+	respChan <- &model.Response{
+		Done: true,
+		Choices: []model.Choice{{
+			Message: model.NewAssistantMessage("ok"),
+		}},
+	}
+	close(respChan)
+	return respChan, nil
+}
+
+type lazyTailoringModel struct{}
+
+func (m *lazyTailoringModel) Info() model.Info {
+	return model.Info{Name: "lazy-tailoring-model"}
+}
+
+func (m *lazyTailoringModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	return nil, errors.New("unexpected GenerateContent call")
+}
+
+func (m *lazyTailoringModel) GenerateContentIter(
+	ctx context.Context,
+	req *model.Request,
+) (model.Seq[*model.Response], error) {
+	return func(yield func(*model.Response) bool) {
+		beforeMessages := len(req.Messages)
+		req.Messages = req.Messages[:1]
+		imodelrequest.RecordTokenTailoring(
+			ctx,
+			imodelrequest.TokenTailoringRecord{
+				Provider:       "lazyTailoringModel",
+				MaxInputTokens: 100,
+				BeforeMessages: beforeMessages,
+				AfterMessages:  len(req.Messages),
+			},
+		)
+		yield(&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("ok"),
+			}},
+		})
+	}, nil
 }
 
 type namedFlowModel struct {

--- a/internal/flow/processor/functioncall_bench_test.go
+++ b/internal/flow/processor/functioncall_bench_test.go
@@ -1,0 +1,70 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package processor
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+var parallelInvocationViewSink *agent.Invocation
+
+func BenchmarkParallelInvocationView(b *testing.B) {
+	for _, historySize := range []int{256, 1024} {
+		b.Run(fmt.Sprintf("history=%d", historySize), func(b *testing.B) {
+			invocation := parallelInvocationBenchmarkInput(historySize)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				parallelInvocationViewSink = newParallelInvocationView(invocation)
+			}
+		})
+	}
+}
+
+func parallelInvocationBenchmarkInput(historySize int) *agent.Invocation {
+	invocation := agent.NewInvocation(agent.WithInvocationSession(&session.Session{}))
+	messages := make([]model.Message, historySize)
+	items := make([]summaryview.Item, historySize)
+	for i := 0; i < historySize; i++ {
+		arguments := bytes.Repeat([]byte{'a' + byte(i%26)}, 256)
+		message := model.Message{
+			Role:    model.RoleAssistant,
+			Content: "parallel tool call history",
+			ToolCalls: []model.ToolCall{{
+				ID: fmt.Sprintf("call-%d", i),
+				Function: model.FunctionDefinitionParam{
+					Name:      "write_file",
+					Arguments: arguments,
+				},
+			}},
+		}
+		messages[i] = message
+		items[i] = summaryview.Item{
+			Message: message,
+			EffectiveEvent: event.Event{
+				Response: &model.Response{Choices: []model.Choice{{Message: message}}},
+				StateDelta: map[string][]byte{
+					"history": bytes.Repeat([]byte{'v'}, 256),
+				},
+			},
+		}
+	}
+	summaryview.AttachProjection(invocation, &summaryview.View{Items: items})
+	summaryfork.Attach(invocation, &model.Request{Messages: messages})
+	return invocation
+}

--- a/internal/modelrequest/token_tailoring.go
+++ b/internal/modelrequest/token_tailoring.go
@@ -1,0 +1,73 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package modelrequest
+
+import (
+	"context"
+	"sync"
+)
+
+type tokenTailoringObserverKey struct{}
+
+// TokenTailoringRecord describes one provider-side request transformation.
+type TokenTailoringRecord struct {
+	Provider       string
+	MaxInputTokens int
+	BeforeMessages int
+	AfterMessages  int
+}
+
+// TokenTailoringObserver collects provider-side request transformations.
+type TokenTailoringObserver struct {
+	mu       sync.Mutex
+	records  []TokenTailoringRecord
+	onRecord func(TokenTailoringRecord)
+}
+
+// ObserveTokenTailoring attaches a new observer to ctx. onRecord is called
+// after each record has been stored and may be nil.
+func ObserveTokenTailoring(
+	ctx context.Context,
+	onRecord func(TokenTailoringRecord),
+) (context.Context, *TokenTailoringObserver) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	observer := &TokenTailoringObserver{onRecord: onRecord}
+	return context.WithValue(ctx, tokenTailoringObserverKey{}, observer), observer
+}
+
+// RecordTokenTailoring records a provider-side request transformation when an
+// observer is attached to ctx.
+func RecordTokenTailoring(ctx context.Context, record TokenTailoringRecord) {
+	if ctx == nil {
+		return
+	}
+	observer, ok := ctx.Value(tokenTailoringObserverKey{}).(*TokenTailoringObserver)
+	if !ok || observer == nil {
+		return
+	}
+	observer.mu.Lock()
+	observer.records = append(observer.records, record)
+	onRecord := observer.onRecord
+	observer.mu.Unlock()
+	if onRecord != nil {
+		onRecord(record)
+	}
+}
+
+// Snapshot returns an isolated copy of the records collected so far.
+func (o *TokenTailoringObserver) Snapshot() []TokenTailoringRecord {
+	if o == nil {
+		return nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]TokenTailoringRecord(nil), o.records...)
+}

--- a/internal/modelrequest/token_tailoring_test.go
+++ b/internal/modelrequest/token_tailoring_test.go
@@ -1,0 +1,49 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package modelrequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenTailoringObserver(t *testing.T) {
+	var callbacks []TokenTailoringRecord
+	ctx, observer := ObserveTokenTailoring(
+		context.Background(),
+		func(record TokenTailoringRecord) {
+			callbacks = append(callbacks, record)
+		},
+	)
+	record := TokenTailoringRecord{
+		Provider:       "test.Model",
+		MaxInputTokens: 100,
+		BeforeMessages: 3,
+		AfterMessages:  2,
+	}
+
+	RecordTokenTailoring(ctx, record)
+
+	require.Equal(t, []TokenTailoringRecord{record}, observer.Snapshot())
+	require.Equal(t, []TokenTailoringRecord{record}, callbacks)
+	copyOfSnapshot := observer.Snapshot()
+	copyOfSnapshot[0].Provider = "mutated"
+	require.Equal(t, "test.Model", observer.Snapshot()[0].Provider)
+}
+
+func TestTokenTailoringObserverHandlesMissingObserver(t *testing.T) {
+	RecordTokenTailoring(nil, TokenTailoringRecord{})
+	RecordTokenTailoring(context.Background(), TokenTailoringRecord{})
+	ctx, observer := ObserveTokenTailoring(nil, nil)
+	RecordTokenTailoring(ctx, TokenTailoringRecord{Provider: "test.Model"})
+	require.Len(t, observer.Snapshot(), 1)
+	require.Nil(t, (*TokenTailoringObserver)(nil).Snapshot())
+}

--- a/internal/skillstage/stager.go
+++ b/internal/skillstage/stager.go
@@ -363,8 +363,15 @@ func (s *Stager) linkWorkspaceDirs(
 	return runProgramExitError("link workspace dirs", res, err)
 }
 
-// RemoveWorkspacePath removes a workspace-relative path after first making
-// non-symlink files writable so cleanup can succeed on read-only staged trees.
+// RemoveWorkspacePath removes a workspace-relative path after first
+// attempting to make non-symlink entries writable so cleanup can succeed
+// on read-only staged trees.
+//
+// chmod is best-effort. POSIX chmod requires the file owner (or
+// privilege), but ProgramRunner may run as a session-isolated identity
+// that does not own the staged tree. Deletion only needs write permission
+// on parent directories, which those backends typically already grant.
+// rm -rf remains mandatory: a chmod failure must not skip the delete.
 func (s *Stager) RemoveWorkspacePath(
 	ctx context.Context,
 	eng codeexecutor.Engine,
@@ -383,7 +390,7 @@ func (s *Stager) RemoveWorkspacePath(
 	sb.WriteString(shellQuote(target))
 	sb.WriteString(" ]; then find ")
 	sb.WriteString(shellQuote(target))
-	sb.WriteString(" -type l -prune -o -exec chmod u+w {} +; fi")
+	sb.WriteString(" -type l -prune -o -exec chmod u+w {} + || true; fi")
 	sb.WriteString("; rm -rf ")
 	sb.WriteString(shellQuote(target))
 	res, err := eng.Runner().RunProgram(

--- a/internal/skillstage/stager_test.go
+++ b/internal/skillstage/stager_test.go
@@ -505,3 +505,155 @@ func TestSkillStagingHelpers_ReturnExitCodeErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exit code 1")
 }
+
+// pathPrefixRunner prepends a directory to PATH inside bash -lc scripts
+// so the login shell's profile cannot clobber the test shim.
+type pathPrefixRunner struct {
+	inner  codeexecutor.ProgramRunner
+	prefix string
+}
+
+func (r *pathPrefixRunner) RunProgram(
+	ctx context.Context,
+	ws codeexecutor.Workspace,
+	spec codeexecutor.RunProgramSpec,
+) (codeexecutor.RunResult, error) {
+	if spec.Cmd == "bash" && len(spec.Args) >= 2 && spec.Args[0] == "-lc" {
+		args := append([]string(nil), spec.Args...)
+		args[1] = "export PATH=" + shellQuote(r.prefix) + ":\"$PATH\"; " + args[1]
+		spec.Args = args
+	}
+	return r.inner.RunProgram(ctx, ws, spec)
+}
+
+func chmodDeniedShimDir(t *testing.T) (binDir, marker string) {
+	t.Helper()
+	binDir = t.TempDir()
+	marker = filepath.Join(t.TempDir(), "chmod.called")
+	script := "#!/bin/sh\n" +
+		"echo called >> " + shellQuote(marker) + "\n" +
+		"echo \"chmod: changing permissions of '$2': " +
+		"Operation not permitted\" >&2\n" +
+		"exit 1\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, "chmod"),
+		[]byte(script),
+		0o755,
+	))
+	return binDir, marker
+}
+
+func engineWithChmodDenied(
+	t *testing.T,
+	rt *localexec.Runtime,
+) (codeexecutor.Engine, string) {
+	t.Helper()
+	binDir, marker := chmodDeniedShimDir(t)
+	return codeexecutor.NewEngine(rt, rt, &pathPrefixRunner{
+		inner:  rt,
+		prefix: binDir,
+	}), marker
+}
+
+func writeSkillDir(t *testing.T, root, body string) string {
+	t.Helper()
+	skillRoot := filepath.Join(root, "echoer")
+	require.NoError(t, os.MkdirAll(skillRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillRoot, "SKILL.md"),
+		[]byte(body),
+		0o644,
+	))
+	return skillRoot
+}
+
+func TestRemoveWorkspacePath_ChmodDeniedStillRemoves(t *testing.T) {
+	ctx := context.Background()
+	rt := localexec.NewRuntime("")
+	eng, marker := engineWithChmodDenied(t, rt)
+	ws, err := rt.CreateWorkspace(
+		ctx, "remove-chmod-denied", codeexecutor.WorkspacePolicy{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Cleanup(ctx, ws)
+	})
+
+	st := New()
+	err = st.StageSkill(
+		ctx, eng, ws, writeSkillDir(t, t.TempDir(), "v1"), "echoer",
+	)
+	require.NoError(t, err)
+
+	dest := filepath.Join(ws.Path, "skills", "echoer")
+	require.DirExists(t, dest)
+
+	err = st.RemoveWorkspacePath(ctx, eng, ws, "skills/echoer")
+	require.NoError(t, err)
+	require.NoDirExists(t, dest)
+	_, statErr := os.Stat(marker)
+	require.NoError(t, statErr, "chmod shim must have been invoked")
+}
+
+func TestRemoveWorkspacePath_RemoveFailureStillReported(t *testing.T) {
+	ctx := context.Background()
+	rt := localexec.NewRuntime("")
+	eng, _ := engineWithChmodDenied(t, rt)
+	ws, err := rt.CreateWorkspace(
+		ctx, "remove-rm-denied", codeexecutor.WorkspacePolicy{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Cleanup(ctx, ws)
+	})
+
+	dest := filepath.Join(ws.Path, "skills", "echoer")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dest, "SKILL.md"),
+		[]byte("body"),
+		0o644,
+	))
+	// Directory write is required to unlink children. The chmod shim
+	// cannot restore u+w, so rm -rf must fail and be reported.
+	require.NoError(t, os.Chmod(dest, 0o555))
+	t.Cleanup(func() {
+		_ = os.Chmod(dest, 0o755)
+	})
+
+	err = New().RemoveWorkspacePath(ctx, eng, ws, "skills/echoer")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remove workspace path")
+	require.DirExists(t, dest)
+}
+
+func TestStager_StageSkill_RestagesWhenChmodDenied(t *testing.T) {
+	ctx := context.Background()
+	rt := localexec.NewRuntime("")
+	eng, marker := engineWithChmodDenied(t, rt)
+	ws, err := rt.CreateWorkspace(
+		ctx, "restage-chmod-denied", codeexecutor.WorkspacePolicy{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rt.Cleanup(ctx, ws)
+	})
+
+	st := New()
+	err = st.StageSkill(
+		ctx, eng, ws, writeSkillDir(t, t.TempDir(), "v1"), "echoer",
+	)
+	require.NoError(t, err)
+
+	err = st.StageSkill(
+		ctx, eng, ws, writeSkillDir(t, t.TempDir(), "v2"), "echoer",
+	)
+	require.NoError(t, err)
+
+	files, err := rt.Collect(ctx, ws, []string{"skills/echoer/SKILL.md"})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, "v2", files[0].Content)
+	_, statErr := os.Stat(marker)
+	require.NoError(t, statErr, "restage must attempt chmod on the old tree")
+}

--- a/internal/state/statecopy/message.go
+++ b/internal/state/statecopy/message.go
@@ -1,0 +1,100 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package statecopy provides deep-copy helpers for state snapshot boundaries.
+package statecopy
+
+import (
+	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Message returns a deep copy of message.
+func Message(message model.Message) model.Message {
+	cloned := message
+	cloned.ContentParts = cloneContentParts(message.ContentParts)
+	cloned.ToolCalls = cloneToolCalls(message.ToolCalls)
+	return cloned
+}
+
+// Messages returns deep copies of messages and preserves a nil input.
+func Messages(messages []model.Message) []model.Message {
+	if messages == nil {
+		return nil
+	}
+	cloned := make([]model.Message, len(messages))
+	for i := range messages {
+		cloned[i] = Message(messages[i])
+	}
+	return cloned
+}
+
+func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
+	if parts == nil {
+		return nil
+	}
+	cloned := make([]model.ContentPart, len(parts))
+	for i := range parts {
+		cloned[i] = cloneContentPart(parts[i])
+	}
+	return cloned
+}
+
+func cloneContentPart(part model.ContentPart) model.ContentPart {
+	cloned := part
+	if part.Text != nil {
+		text := *part.Text
+		cloned.Text = &text
+	}
+	if part.Image != nil {
+		image := *part.Image
+		image.Data = append([]byte(nil), part.Image.Data...)
+		cloned.Image = &image
+	}
+	if part.Audio != nil {
+		audio := *part.Audio
+		audio.Data = append([]byte(nil), part.Audio.Data...)
+		cloned.Audio = &audio
+	}
+	if part.Video != nil {
+		video := *part.Video
+		video.Data = append([]byte(nil), part.Video.Data...)
+		cloned.Video = &video
+	}
+	if part.File != nil {
+		file := *part.File
+		file.Data = append([]byte(nil), part.File.Data...)
+		cloned.File = &file
+	}
+	if part.ContentRef != nil {
+		contentRef := *part.ContentRef
+		cloned.ContentRef = &contentRef
+	}
+	return cloned
+}
+
+func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+	cloned := make([]model.ToolCall, len(toolCalls))
+	for i := range toolCalls {
+		cloned[i] = toolCalls[i]
+		cloned[i].Function.Arguments = append(
+			[]byte(nil),
+			toolCalls[i].Function.Arguments...,
+		)
+		if toolCalls[i].Index != nil {
+			index := *toolCalls[i].Index
+			cloned[i].Index = &index
+		}
+		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
+	}
+	return cloned
+}

--- a/internal/state/statecopy/message_test.go
+++ b/internal/state/statecopy/message_test.go
@@ -1,0 +1,78 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package statecopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestMessagesAreIsolated(t *testing.T) {
+	require.Nil(t, Messages(nil))
+	zero := Message(model.Message{})
+	require.Nil(t, zero.ContentParts)
+	require.Nil(t, zero.ToolCalls)
+
+	text := "text"
+	index := 1
+	original := []model.Message{{
+		ContentParts: []model.ContentPart{
+			{Text: &text},
+			{
+				Image: &model.Image{Data: []byte("image")},
+				ContentRef: &model.ContentRef{
+					ArtifactName: "original",
+				},
+			},
+			{Audio: &model.Audio{Data: []byte("audio")}},
+			{Video: &model.Video{Data: []byte("video")}},
+			{File: &model.File{Data: []byte("file")}},
+		},
+		ToolCalls: []model.ToolCall{{
+			Index: &index,
+			Function: model.FunctionDefinitionParam{
+				Arguments: []byte("arguments"),
+			},
+			ExtraFields: map[string]any{
+				"nested": map[string]any{"value": "original"},
+			},
+		}},
+	}}
+
+	cloned := Messages(original)
+	*cloned[0].ContentParts[0].Text = "mutated"
+	cloned[0].ContentParts[1].Image.Data[0] = 'X'
+	cloned[0].ContentParts[1].ContentRef.ArtifactName = "mutated"
+	cloned[0].ContentParts[2].Audio.Data[0] = 'X'
+	cloned[0].ContentParts[3].Video.Data[0] = 'X'
+	cloned[0].ContentParts[4].File.Data[0] = 'X'
+	cloned[0].ToolCalls[0].Function.Arguments[0] = 'X'
+	*cloned[0].ToolCalls[0].Index = 2
+	cloned[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"] =
+		"mutated"
+
+	require.Equal(t, "text", *original[0].ContentParts[0].Text)
+	require.Equal(t, "image", string(original[0].ContentParts[1].Image.Data))
+	require.Equal(t, "original",
+		original[0].ContentParts[1].ContentRef.ArtifactName,
+	)
+	require.Equal(t, "audio", string(original[0].ContentParts[2].Audio.Data))
+	require.Equal(t, "video", string(original[0].ContentParts[3].Video.Data))
+	require.Equal(t, "file", string(original[0].ContentParts[4].File.Data))
+	require.Equal(t, "arguments", string(
+		original[0].ToolCalls[0].Function.Arguments,
+	))
+	require.Equal(t, 1, *original[0].ToolCalls[0].Index)
+	require.Equal(t, "original",
+		original[0].ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"],
+	)
+}

--- a/internal/state/summaryfork/summaryfork.go
+++ b/internal/state/summaryfork/summaryfork.go
@@ -13,27 +13,35 @@ package summaryfork
 import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/internal/jsonmap"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/statecopy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
 const stateKey = "trpc_agent.summary.cache_safe_fork_request"
 
+// invocationState keeps an immutable snapshot opaque to Invocation.View's
+// generic state cloner. Mutations must replace the holder instead of changing
+// the stored request in place.
+type invocationState struct {
+	request *model.Request
+}
+
 // Attach stores a snapshot of the parent model request on the invocation.
 func Attach(inv *agent.Invocation, req *model.Request) {
 	if inv == nil || req == nil {
 		return
 	}
-	inv.SetState(stateKey, cloneRequest(req))
+	inv.SetState(stateKey, &invocationState{request: cloneRequest(req)})
 }
 
 // Request returns a snapshot of the parent model request, if one exists.
 func Request(inv *agent.Invocation) (*model.Request, bool) {
-	req, ok := agent.GetStateValue[*model.Request](inv, stateKey)
-	if !ok || req == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.request == nil {
 		return nil, false
 	}
-	return cloneRequest(req), true
+	return cloneRequest(state.request), true
 }
 
 // Invalidate removes the current cache-safe request snapshot. Summarization
@@ -48,8 +56,8 @@ func Invalidate(inv *agent.Invocation) {
 // AppendResponse appends persisted response messages to the stored request
 // snapshot. It is a no-op when no snapshot is present.
 func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
-	req, ok := agent.GetStateValue[*model.Request](inv, stateKey)
-	if !ok || req == nil || rsp == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.request == nil || rsp == nil {
 		return
 	}
 	messages := responseMessages(rsp)
@@ -57,9 +65,9 @@ func AppendResponse(inv *agent.Invocation, rsp *model.Response) {
 		return
 	}
 
-	next := cloneRequest(req)
-	next.Messages = append(next.Messages, cloneMessages(messages)...)
-	inv.SetState(stateKey, next)
+	next := cloneRequest(state.request)
+	next.Messages = append(next.Messages, statecopy.Messages(messages)...)
+	inv.SetState(stateKey, &invocationState{request: next})
 }
 
 func responseMessages(rsp *model.Response) []model.Message {
@@ -104,91 +112,13 @@ func cloneRequest(req *model.Request) *model.Request {
 	}
 
 	cloned := *req
-	cloned.Messages = cloneMessages(req.Messages)
+	cloned.Messages = statecopy.Messages(req.Messages)
 	cloned.GenerationConfig = cloneGenerationConfig(req.GenerationConfig)
 	cloned.StructuredOutput = cloneStructuredOutput(req.StructuredOutput)
 	cloned.ExtraFields = jsonmap.Clone(req.ExtraFields)
 	cloned.Headers = cloneHeaders(req.Headers)
 	cloned.Tools = cloneTools(req.Tools)
 	return &cloned
-}
-
-func cloneMessages(messages []model.Message) []model.Message {
-	if messages == nil {
-		return nil
-	}
-	cloned := make([]model.Message, len(messages))
-	for i := range messages {
-		cloned[i] = cloneMessage(messages[i])
-	}
-	return cloned
-}
-
-func cloneMessage(msg model.Message) model.Message {
-	cloned := msg
-	cloned.ContentParts = cloneContentParts(msg.ContentParts)
-	cloned.ToolCalls = cloneToolCalls(msg.ToolCalls)
-	return cloned
-}
-
-func cloneContentParts(parts []model.ContentPart) []model.ContentPart {
-	if parts == nil {
-		return nil
-	}
-	cloned := make([]model.ContentPart, len(parts))
-	for i := range parts {
-		cloned[i] = cloneContentPart(parts[i])
-	}
-	return cloned
-}
-
-func cloneContentPart(part model.ContentPart) model.ContentPart {
-	cloned := part
-	if part.Text != nil {
-		text := *part.Text
-		cloned.Text = &text
-	}
-	if part.Image != nil {
-		image := *part.Image
-		image.Data = append([]byte(nil), part.Image.Data...)
-		cloned.Image = &image
-	}
-	if part.Audio != nil {
-		audio := *part.Audio
-		audio.Data = append([]byte(nil), part.Audio.Data...)
-		cloned.Audio = &audio
-	}
-	if part.Video != nil {
-		video := *part.Video
-		video.Data = append([]byte(nil), part.Video.Data...)
-		cloned.Video = &video
-	}
-	if part.File != nil {
-		file := *part.File
-		file.Data = append([]byte(nil), part.File.Data...)
-		cloned.File = &file
-	}
-	return cloned
-}
-
-func cloneToolCalls(toolCalls []model.ToolCall) []model.ToolCall {
-	if toolCalls == nil {
-		return nil
-	}
-	cloned := make([]model.ToolCall, len(toolCalls))
-	for i := range toolCalls {
-		cloned[i] = toolCalls[i]
-		cloned[i].Function.Arguments = append(
-			[]byte(nil),
-			toolCalls[i].Function.Arguments...,
-		)
-		if toolCalls[i].Index != nil {
-			index := *toolCalls[i].Index
-			cloned[i].Index = &index
-		}
-		cloned[i].ExtraFields = jsonmap.Clone(toolCalls[i].ExtraFields)
-	}
-	return cloned
 }
 
 func cloneGenerationConfig(cfg model.GenerationConfig) model.GenerationConfig {

--- a/internal/state/summaryfork/summaryfork_test.go
+++ b/internal/state/summaryfork/summaryfork_test.go
@@ -212,6 +212,47 @@ func TestAppendResponseExtendsSnapshot(t *testing.T) {
 	require.Equal(t, "result", got.Messages[3].Content)
 }
 
+func TestInvocationViewAppendIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	Attach(invocation, &model.Request{
+		Messages: []model.Message{model.NewUserMessage("question")},
+	})
+
+	view := invocation.View()
+	AppendResponse(view, &model.Response{Choices: []model.Choice{{
+		Message: model.NewAssistantMessage("answer"),
+	}}})
+
+	viewRequest, ok := Request(view)
+	require.True(t, ok)
+	require.Len(t, viewRequest.Messages, 2)
+
+	originalRequest, ok := Request(invocation)
+	require.True(t, ok)
+	require.Len(t, originalRequest.Messages, 1)
+	require.Equal(t, "question", originalRequest.Messages[0].Content)
+}
+
+func TestInvocationViewRequestContentRefIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	Attach(invocation, &model.Request{Messages: []model.Message{{
+		Role: model.RoleUser,
+		ContentParts: []model.ContentPart{{
+			ContentRef: &model.ContentRef{ArtifactName: "original"},
+		}},
+	}}})
+
+	viewRequest, ok := Request(invocation.View())
+	require.True(t, ok)
+	viewRequest.Messages[0].ContentParts[0].ContentRef.ArtifactName = "mutated"
+
+	originalRequest, ok := Request(invocation)
+	require.True(t, ok)
+	require.Equal(t, "original",
+		originalRequest.Messages[0].ContentParts[0].ContentRef.ArtifactName,
+	)
+}
+
 func TestInvalidateClearsSnapshotUntilNextAttach(t *testing.T) {
 	inv := agent.NewInvocation()
 	req := &model.Request{

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -19,12 +19,20 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/statecopy"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 const stateKey = "trpc_agent.summary.model_visible_view"
 
 type contextKey struct{}
+
+// invocationState keeps an immutable snapshot opaque to Invocation.View's
+// generic state cloner. Mutations must replace the holder instead of changing
+// the stored view in place.
+type invocationState struct {
+	view *View
+}
 
 // Boundary identifies the latest stored event represented by an item.
 type Boundary struct {
@@ -65,7 +73,7 @@ func AttachProjection(inv *agent.Invocation, view *View) {
 	if inv == nil || view == nil {
 		return
 	}
-	inv.SetState(stateKey, cloneView(view))
+	inv.SetState(stateKey, &invocationState{view: cloneView(view)})
 }
 
 // Clear removes the current projection and finalized view.
@@ -84,23 +92,24 @@ func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 	if inv == nil || req == nil {
 		return
 	}
-	view, ok := agent.GetStateValue[*View](inv, stateKey)
-	if !ok || view == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
 		return
 	}
+	view := state.view
 	next := cloneView(view)
 	next.RequestTokens = requestTokens
 	next.Bound = bindItems(next, req.Messages)
-	inv.SetState(stateKey, next)
+	inv.SetState(stateKey, &invocationState{view: next})
 }
 
 // Snapshot returns an isolated copy of the latest model-visible view.
 func Snapshot(inv *agent.Invocation) (*View, bool) {
-	view, ok := agent.GetStateValue[*View](inv, stateKey)
-	if !ok || view == nil {
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
 		return nil, false
 	}
-	return cloneView(view), true
+	return cloneView(state.view), true
 }
 
 // ContextWithView attaches an isolated model-visible view to ctx.
@@ -232,7 +241,7 @@ func bindItems(view *View, messages []model.Message) bool {
 			return false
 		}
 		item.RequestIndex = index
-		item.Message = cloneMessage(messages[index])
+		item.Message = statecopy.Message(messages[index])
 		setEffectiveMessage(&item.EffectiveEvent, item.Message)
 		previous = index
 	}
@@ -299,7 +308,7 @@ func cloneView(view *View) *View {
 	cloned.Items = make([]Item, len(view.Items))
 	for i := range view.Items {
 		cloned.Items[i] = view.Items[i]
-		cloned.Items[i].Message = cloneMessage(view.Items[i].Message)
+		cloned.Items[i].Message = statecopy.Message(view.Items[i].Message)
 		cloned.Items[i].EffectiveEvent = cloneEvent(view.Items[i].EffectiveEvent)
 	}
 	return &cloned
@@ -309,6 +318,29 @@ func cloneEvent(evt event.Event) event.Event {
 	cloned := evt
 	if evt.Response != nil {
 		cloned.Response = evt.Response.Clone()
+		for i := range cloned.Response.Choices {
+			choice := &cloned.Response.Choices[i]
+			choice.Message = statecopy.Message(evt.Response.Choices[i].Message)
+			choice.Delta = statecopy.Message(evt.Response.Choices[i].Delta)
+			if evt.Response.Choices[i].FinishReason != nil {
+				finishReason := *evt.Response.Choices[i].FinishReason
+				choice.FinishReason = &finishReason
+			}
+		}
+		if evt.Response.Error != nil {
+			if evt.Response.Error.Param != nil {
+				param := *evt.Response.Error.Param
+				cloned.Response.Error.Param = &param
+			}
+			if evt.Response.Error.Code != nil {
+				code := *evt.Response.Error.Code
+				cloned.Response.Error.Code = &code
+			}
+		}
+	}
+	if evt.ParentMetadata != nil {
+		parentMetadata := *evt.ParentMetadata
+		cloned.ParentMetadata = &parentMetadata
 	}
 	if evt.LongRunningToolIDs != nil {
 		cloned.LongRunningToolIDs = make(map[string]struct{}, len(evt.LongRunningToolIDs))
@@ -335,11 +367,6 @@ func cloneEvent(evt event.Event) event.Event {
 	return cloned
 }
 
-func cloneMessage(message model.Message) model.Message {
-	response := (&model.Response{Choices: []model.Choice{{Message: message}}}).Clone()
-	return response.Choices[0].Message
-}
-
 func setEffectiveMessage(evt *event.Event, message model.Message) {
 	if evt == nil {
 		return
@@ -349,5 +376,5 @@ func setEffectiveMessage(evt *event.Event, message model.Message) {
 	} else {
 		evt.Response = evt.Response.Clone()
 	}
-	evt.Response.Choices = []model.Choice{{Message: cloneMessage(message)}}
+	evt.Response.Choices = []model.Choice{{Message: statecopy.Message(message)}}
 }

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -31,10 +31,12 @@ type contextKey struct{}
 // generic state cloner. Mutations must replace the holder instead of changing
 // the stored view in place.
 type invocationState struct {
-	view *View
+	view               *View
+	bindingInvalidated bool
 }
 
-// Boundary identifies the latest stored event represented by an item.
+// Boundary identifies the latest stored event completely represented by the
+// model request prefix ending at an item.
 type Boundary struct {
 	EventID   string
 	Timestamp time.Time
@@ -99,8 +101,234 @@ func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 	view := state.view
 	next := cloneView(view)
 	next.RequestTokens = requestTokens
-	next.Bound = bindItems(next, req.Messages)
-	inv.SetState(stateKey, &invocationState{view: next})
+	next.Bound = !state.bindingInvalidated && bindItems(next, req.Messages)
+	inv.SetState(stateKey, &invocationState{
+		view:               next,
+		bindingInvalidated: state.bindingInvalidated,
+	})
+}
+
+// RebaseAfterTransform maps a projected view through a message transform.
+// When non-nil, sourceIndexes must contain one input-message index for every
+// output message. A nil slice means output message i came from input message i.
+// The view remains unbound when the provenance does not completely represent
+// every projected history item.
+func RebaseAfterTransform(
+	inv *agent.Invocation,
+	before []model.Message,
+	after []model.Message,
+	sourceIndexes []int,
+) bool {
+	if inv == nil {
+		return false
+	}
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
+		return false
+	}
+	if state.bindingInvalidated {
+		return false
+	}
+	boundItems, boundBefore := bindItemsForTransform(state.view, before)
+	boundBefore = boundBefore && sourceIndexesMatch(
+		sourceIndexes,
+		len(after),
+		len(before),
+	)
+	if !boundBefore {
+		next := cloneView(state.view)
+		next.Bound = false
+		next.ContentRequestLength = len(after)
+		storeInvalidated(inv, next)
+		return false
+	}
+	transformed, ok := rebaseItems(
+		boundItems,
+		after,
+		sourceIndexes,
+		len(before),
+	)
+	if !ok {
+		next := cloneView(state.view)
+		next.Bound = false
+		next.ContentRequestLength = len(after)
+		storeInvalidated(inv, next)
+		return false
+	}
+	next := *state.view
+	next.Items = transformed
+	next.ContentRequestLength = len(after)
+	next.Bound = true
+	inv.SetState(stateKey, &invocationState{view: &next})
+	return true
+}
+
+func bindItemsForTransform(view *View, messages []model.Message) ([]Item, bool) {
+	if view == nil || len(view.Items) == 0 || len(messages) == 0 {
+		return nil, false
+	}
+	items := make([]Item, len(view.Items))
+	shift := len(messages) - view.ContentRequestLength
+	previous := -1
+	for i := range view.Items {
+		index := findItem(
+			messages,
+			view.Items[i].Message,
+			view.Items[i].RequestIndex,
+			shift,
+			previous+1,
+		)
+		if index < 0 {
+			return nil, false
+		}
+		items[i] = view.Items[i]
+		items[i].RequestIndex = index
+		previous = index
+	}
+	return items, true
+}
+
+func rebaseItems(
+	items []Item,
+	after []model.Message,
+	sourceIndexes []int,
+	beforeLength int,
+) ([]Item, bool) {
+	itemBySource, ok := indexItemsBySource(items)
+	if !ok {
+		return nil, false
+	}
+	remaining, ok := countOutputsByItem(
+		sourceIndexes,
+		len(after),
+		beforeLength,
+		itemBySource,
+		len(items),
+	)
+	if !ok {
+		return nil, false
+	}
+
+	transformed := make([]Item, 0, len(after))
+	completed := make([]bool, len(items))
+	frontier := 0
+	for outputIndex := range after {
+		sourceIndex := sourceIndexForOutput(sourceIndexes, outputIndex)
+		itemIndex, exists := itemBySource[sourceIndex]
+		if !exists {
+			continue
+		}
+		item := items[itemIndex]
+		item.Message = statecopy.Message(after[outputIndex])
+		item.EffectiveEvent = cloneEvent(item.EffectiveEvent)
+		setEffectiveMessage(&item.EffectiveEvent, item.Message)
+		item.RequestIndex = outputIndex
+		item.Boundary = Boundary{}
+		transformed = append(transformed, item)
+
+		remaining[itemIndex]--
+		completed[itemIndex] = remaining[itemIndex] == 0
+		safeBoundary := advanceCompletedFrontier(items, completed, &frontier)
+		if !safeBoundary.IsZero() {
+			transformed[len(transformed)-1].Boundary = safeBoundary
+		}
+	}
+	return transformed, frontier == len(items) && len(transformed) > 0
+}
+
+func indexItemsBySource(items []Item) (map[int]int, bool) {
+	itemBySource := make(map[int]int, len(items))
+	for i := range items {
+		requestIndex := items[i].RequestIndex
+		if _, exists := itemBySource[requestIndex]; exists {
+			return nil, false
+		}
+		itemBySource[requestIndex] = i
+	}
+	return itemBySource, true
+}
+
+func countOutputsByItem(
+	sourceIndexes []int,
+	outputCount int,
+	beforeLength int,
+	itemBySource map[int]int,
+	itemCount int,
+) ([]int, bool) {
+	if !sourceIndexesMatch(sourceIndexes, outputCount, beforeLength) {
+		return nil, false
+	}
+	remaining := make([]int, itemCount)
+	for outputIndex := 0; outputIndex < outputCount; outputIndex++ {
+		sourceIndex := sourceIndexForOutput(sourceIndexes, outputIndex)
+		if sourceIndex < 0 || sourceIndex >= beforeLength {
+			return nil, false
+		}
+		if itemIndex, exists := itemBySource[sourceIndex]; exists {
+			remaining[itemIndex]++
+		}
+	}
+	for _, count := range remaining {
+		if count == 0 {
+			return nil, false
+		}
+	}
+	return remaining, true
+}
+
+func sourceIndexesMatch(
+	sourceIndexes []int,
+	outputCount int,
+	inputCount int,
+) bool {
+	if sourceIndexes == nil {
+		return outputCount == inputCount
+	}
+	return len(sourceIndexes) == outputCount
+}
+
+func sourceIndexForOutput(sourceIndexes []int, outputIndex int) int {
+	if sourceIndexes == nil {
+		return outputIndex
+	}
+	return sourceIndexes[outputIndex]
+}
+
+func advanceCompletedFrontier(
+	items []Item,
+	completed []bool,
+	frontier *int,
+) Boundary {
+	var safeBoundary Boundary
+	for *frontier < len(items) && completed[*frontier] {
+		if !items[*frontier].Boundary.IsZero() {
+			safeBoundary = items[*frontier].Boundary
+		}
+		*frontier++
+	}
+	return safeBoundary
+}
+
+// InvalidateBinding prevents the current projected view from being used as
+// proof of model-visible history.
+func InvalidateBinding(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
+		return
+	}
+	next := cloneView(state.view)
+	next.Bound = false
+	storeInvalidated(inv, next)
+}
+
+func storeInvalidated(inv *agent.Invocation, view *View) {
+	inv.SetState(stateKey, &invocationState{
+		view:               view,
+		bindingInvalidated: true,
+	})
 }
 
 // Snapshot returns an isolated copy of the latest model-visible view.

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -65,6 +65,246 @@ func TestFinalizeBindsModelVisiblePrefix(t *testing.T) {
 
 }
 
+func TestRebaseAfterTransformTracksSafeCompletedPrefix(t *testing.T) {
+	now := time.Now()
+	assistant := model.Message{
+		Role: model.RoleAssistant,
+		ToolCalls: []model.ToolCall{
+			{ID: "call_keep"},
+			{ID: "call_orphan"},
+		},
+	}
+	toolResult := model.NewToolMessage("call_keep", "lookup", "ok")
+	before := []model.Message{
+		model.NewSystemMessage("fixed"),
+		assistant,
+		toolResult,
+	}
+	filteredAssistant := assistant
+	filteredAssistant.ToolCalls = filteredAssistant.ToolCalls[:1]
+	after := []model.Message{
+		before[0],
+		filteredAssistant,
+		toolResult,
+		model.NewUserMessage("downgraded orphan call"),
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(before),
+		Items: []Item{
+			{
+				Message: assistant,
+				EffectiveEvent: event.Event{
+					ID: "event-1",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: assistant,
+					}}},
+				},
+				Boundary:     Boundary{EventID: "event-1", Timestamp: now},
+				RequestIndex: 1,
+			},
+			{
+				Message: toolResult,
+				EffectiveEvent: event.Event{
+					ID: "event-2",
+					Response: &model.Response{Choices: []model.Choice{{
+						Message: toolResult,
+					}}},
+				},
+				Boundary: Boundary{
+					EventID:   "event-2",
+					Timestamp: now.Add(time.Second),
+				},
+				RequestIndex: 2,
+			},
+		},
+	})
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		before,
+		after,
+		[]int{0, 1, 2, 1},
+	)
+
+	require.True(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, len(after), view.ContentRequestLength)
+	require.Len(t, view.Items, 3)
+	require.Equal(t, []int{1, 2, 3}, []int{
+		view.Items[0].RequestIndex,
+		view.Items[1].RequestIndex,
+		view.Items[2].RequestIndex,
+	})
+	require.True(t, view.Items[0].Boundary.IsZero())
+	require.True(t, view.Items[1].Boundary.IsZero())
+	require.Equal(t, "event-2", view.Items[2].Boundary.EventID)
+	require.Equal(
+		t,
+		"downgraded orphan call",
+		view.Items[2].EffectiveEvent.Response.Choices[0].Message.Content,
+	)
+	_, ok = view.PrefixBoundary(2)
+	require.False(t, ok)
+	boundary, ok := view.PrefixBoundary(3)
+	require.True(t, ok)
+	require.Equal(t, "event-2", boundary.EventID)
+
+	Finalize(invocation, &model.Request{Messages: after}, 100)
+	view, ok = Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, 100, view.RequestTokens)
+}
+
+func TestRebaseAfterTransformAcceptsImplicitIdentitySources(t *testing.T) {
+	message := model.NewUserMessage("history")
+	messages := []model.Message{
+		model.NewSystemMessage("fixed"),
+		message,
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(messages),
+		Items: []Item{{
+			Message:      message,
+			RequestIndex: 1,
+		}},
+	})
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		messages,
+		messages,
+		nil,
+	)
+
+	require.True(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Equal(t, 1, view.Items[0].RequestIndex)
+}
+
+func TestRebaseAfterTransformRejectsInvalidatedBinding(t *testing.T) {
+	message := model.NewUserMessage("history")
+	messages := []model.Message{message}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(messages),
+		Items: []Item{{
+			Message:      message,
+			RequestIndex: 0,
+		}},
+	})
+	InvalidateBinding(invocation)
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		messages,
+		messages,
+		nil,
+	)
+
+	require.False(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+}
+
+func TestRebaseAfterTransformRejectsEmptyExplicitSources(t *testing.T) {
+	message := model.NewUserMessage("history")
+	messages := []model.Message{message}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(messages),
+		Items: []Item{{
+			Message:      message,
+			RequestIndex: 0,
+		}},
+	})
+
+	rebased := RebaseAfterTransform(
+		invocation,
+		messages,
+		messages,
+		[]int{},
+	)
+
+	require.False(t, rebased)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+}
+
+func TestRebaseAfterTransformUsesOriginalProjectionLength(t *testing.T) {
+	duplicate := model.NewUserMessage("duplicate")
+	current := model.NewUserMessage("current")
+	before := []model.Message{duplicate, duplicate, current}
+	after := []model.Message{
+		before[0],
+		model.NewUserMessage("split one"),
+		model.NewUserMessage("split two"),
+		current,
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: 2,
+		Items: []Item{{
+			Message: duplicate,
+			Boundary: Boundary{
+				EventID:   "event-1",
+				Timestamp: time.Now(),
+			},
+			RequestIndex: 0,
+		}},
+	})
+
+	require.True(t, RebaseAfterTransform(
+		invocation,
+		before,
+		after,
+		[]int{0, 1, 1, 2},
+	))
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.True(t, view.Bound)
+	require.Len(t, view.Items, 2)
+	require.Equal(t, 1, view.Items[0].RequestIndex)
+	require.Equal(t, 2, view.Items[1].RequestIndex)
+	require.True(t, view.Items[0].Boundary.IsZero())
+	require.Equal(t, "event-1", view.Items[1].Boundary.EventID)
+}
+
+func TestRebaseAfterTransformFailsClosedWithoutCompleteProvenance(t *testing.T) {
+	invocation := agent.NewInvocation()
+	before := []model.Message{model.NewUserMessage("visible")}
+	AttachProjection(invocation, &View{
+		ContentRequestLength: len(before),
+		Items: []Item{{
+			Message:      before[0],
+			RequestIndex: 0,
+		}},
+	})
+
+	require.False(t, RebaseAfterTransform(
+		invocation,
+		before,
+		[]model.Message{
+			model.NewUserMessage("rewritten one"),
+			model.NewUserMessage("rewritten two"),
+		},
+		nil,
+	))
+	Finalize(invocation, &model.Request{Messages: before}, 100)
+	view, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, view.Bound)
+	require.Equal(t, 100, view.RequestTokens)
+}
+
 func TestSnapshotIsIsolated(t *testing.T) {
 	invocation := agent.NewInvocation()
 	AttachProjection(invocation, &View{

--- a/internal/state/summaryview/summaryview_test.go
+++ b/internal/state/summaryview/summaryview_test.go
@@ -93,6 +93,137 @@ func TestSnapshotIsIsolated(t *testing.T) {
 	)
 }
 
+func TestInvocationViewFinalizationIsIsolated(t *testing.T) {
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{
+		ContentRequestLength: 1,
+		Items: []Item{{
+			Message:      model.NewUserMessage("visible"),
+			RequestIndex: 0,
+		}},
+	})
+
+	view := invocation.View()
+	Finalize(view, &model.Request{Messages: []model.Message{
+		model.NewUserMessage("visible"),
+	}}, 42)
+
+	viewSnapshot, ok := Snapshot(view)
+	require.True(t, ok)
+	require.True(t, viewSnapshot.Bound)
+	require.Equal(t, 42, viewSnapshot.RequestTokens)
+
+	originalSnapshot, ok := Snapshot(invocation)
+	require.True(t, ok)
+	require.False(t, originalSnapshot.Bound)
+	require.Zero(t, originalSnapshot.RequestTokens)
+}
+
+func TestInvocationViewSnapshotNestedStateIsIsolated(t *testing.T) {
+	finishReason := "stop"
+	errorParam := "param"
+	errorCode := "code"
+	text := "text"
+	toolCallIndex := 1
+	message := model.Message{
+		Role: model.RoleAssistant,
+		ContentParts: []model.ContentPart{
+			{Text: &text},
+			{
+				Image: &model.Image{Data: []byte("image")},
+				ContentRef: &model.ContentRef{
+					ArtifactName: "original",
+				},
+			},
+			{Audio: &model.Audio{Data: []byte("audio")}},
+			{Video: &model.Video{Data: []byte("video")}},
+			{File: &model.File{Data: []byte("file")}},
+		},
+		ToolCalls: []model.ToolCall{{
+			Index: &toolCallIndex,
+			Function: model.FunctionDefinitionParam{
+				Arguments: []byte("original"),
+			},
+			ExtraFields: map[string]any{
+				"nested": map[string]any{"value": "original"},
+			},
+		}},
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, &View{Items: []Item{{
+		Message: message,
+		EffectiveEvent: event.Event{Response: &model.Response{
+			Choices: []model.Choice{{
+				Message:      message,
+				Delta:        message,
+				FinishReason: &finishReason,
+			}},
+			Error: &model.ResponseError{
+				Param: &errorParam,
+				Code:  &errorCode,
+			},
+		}, ParentMetadata: &event.ParentInvocationMetadata{TriggerID: "original"}},
+	}}})
+
+	viewSnapshot, ok := Snapshot(invocation.View())
+	require.True(t, ok)
+	viewMessage := &viewSnapshot.Items[0].Message
+	viewMessage.ToolCalls[0].Function.Arguments[0] = 'X'
+	*viewMessage.ToolCalls[0].Index = 2
+	viewMessage.ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"] = "mutated"
+	*viewMessage.ContentParts[0].Text = "mutated"
+	viewMessage.ContentParts[1].Image.Data[0] = 'X'
+	viewMessage.ContentParts[1].ContentRef.ArtifactName = "mutated"
+	viewMessage.ContentParts[2].Audio.Data[0] = 'X'
+	viewMessage.ContentParts[3].Video.Data[0] = 'X'
+	viewMessage.ContentParts[4].File.Data[0] = 'X'
+	choice := &viewSnapshot.Items[0].EffectiveEvent.Response.Choices[0]
+	choice.Message.ToolCalls[0].Function.Arguments[0] = 'X'
+	choice.Delta.ContentParts[1].Image.Data[0] = 'X'
+	*choice.FinishReason = "mutated"
+	*viewSnapshot.Items[0].EffectiveEvent.Response.Error.Param = "mutated"
+	*viewSnapshot.Items[0].EffectiveEvent.Response.Error.Code = "mutated"
+	viewSnapshot.Items[0].EffectiveEvent.ParentMetadata.TriggerID = "mutated"
+
+	originalSnapshot, ok := Snapshot(invocation)
+	require.True(t, ok)
+	originalMessage := originalSnapshot.Items[0].Message
+	require.Equal(t, "original", string(
+		originalMessage.ToolCalls[0].Function.Arguments,
+	))
+	require.Equal(t, 1, *originalMessage.ToolCalls[0].Index)
+	require.Equal(t, "original",
+		originalMessage.ToolCalls[0].ExtraFields["nested"].(map[string]any)["value"],
+	)
+	require.Equal(t, "text", *originalMessage.ContentParts[0].Text)
+	require.Equal(t, "image", string(
+		originalMessage.ContentParts[1].Image.Data,
+	))
+	require.Equal(t, "original",
+		originalMessage.ContentParts[1].ContentRef.ArtifactName,
+	)
+	require.Equal(t, "audio", string(originalMessage.ContentParts[2].Audio.Data))
+	require.Equal(t, "video", string(originalMessage.ContentParts[3].Video.Data))
+	require.Equal(t, "file", string(originalMessage.ContentParts[4].File.Data))
+	originalChoice := originalSnapshot.Items[0].EffectiveEvent.Response.Choices[0]
+	require.Equal(t, "original", string(
+		originalChoice.Message.ToolCalls[0].Function.Arguments,
+	))
+	require.Equal(t, "image", string(
+		originalChoice.Delta.ContentParts[1].Image.Data,
+	))
+	require.Equal(t, "stop", *originalChoice.FinishReason)
+	require.Equal(t, "param",
+		*originalSnapshot.Items[0].EffectiveEvent.Response.Error.Param,
+	)
+	require.Equal(t, "code",
+		*originalSnapshot.Items[0].EffectiveEvent.Response.Error.Code,
+	)
+	require.Equal(t, "original",
+		originalSnapshot.Items[0].EffectiveEvent.ParentMetadata.TriggerID,
+	)
+}
+
 func TestContextAndInvocationLifecycle(t *testing.T) {
 	invocation := agent.NewInvocation()
 	_, ok := Snapshot(invocation)

--- a/internal/toolcall/sanitize.go
+++ b/internal/toolcall/sanitize.go
@@ -51,10 +51,36 @@ var (
 // kept tool call message, to avoid invalid tool message sequences in strict chat APIs.
 // The context is used to attach request-scoped metadata to downgrade warnings.
 func SanitizeMessagesWithTools(ctx context.Context, messages []model.Message, tools map[string]tool.Tool) []model.Message {
+	return SanitizeMessagesWithToolsResult(ctx, messages, tools).Messages
+}
+
+// SanitizeResult contains sanitized messages and their input provenance.
+// When non-nil, SourceIndexes has one entry per message and identifies the
+// corresponding index in the input message slice. A nil slice represents an
+// identity mapping: output message i came from input message i.
+type SanitizeResult struct {
+	Messages      []model.Message
+	SourceIndexes []int
+}
+
+// SanitizeMessagesWithToolsResult sanitizes messages and preserves the input
+// index from which every output message was derived.
+func SanitizeMessagesWithToolsResult(
+	ctx context.Context,
+	messages []model.Message,
+	tools map[string]tool.Tool,
+) SanitizeResult {
 	if len(messages) == 0 {
-		return messages
+		return SanitizeResult{Messages: messages}
 	}
-	out := make([]model.Message, 0, len(messages))
+	if !containsToolMessages(messages) {
+		out := make([]model.Message, len(messages))
+		copy(out, messages)
+		return SanitizeResult{Messages: out}
+	}
+	builder := sanitizeResultBuilder{
+		messages: make([]model.Message, 0, len(messages)),
+	}
 	for i := 0; i < len(messages); {
 		msg := messages[i]
 		if msg.Role == model.RoleAssistant && len(msg.ToolCalls) > 0 {
@@ -62,19 +88,75 @@ func SanitizeMessagesWithTools(ctx context.Context, messages []model.Message, to
 			for next < len(messages) && messages[next].Role == model.RoleTool {
 				next++
 			}
-			out = append(out, sanitizeToolRound(ctx, msg, messages[i+1:next], tools)...)
+			builder.appendAll(sanitizeToolRound(
+				ctx,
+				indexedMessage{message: msg, sourceIndex: i},
+				messages[i+1:next],
+				i+1,
+				tools,
+			))
 			i = next
 			continue
 		}
 		if msg.Role == model.RoleTool {
-			out = append(out, downgradeOrphanToolResult(ctx, msg))
+			builder.append(indexedMessage{
+				message:     downgradeOrphanToolResult(ctx, msg),
+				sourceIndex: i,
+			})
 			i++
 			continue
 		}
-		out = append(out, msg)
+		builder.append(indexedMessage{message: msg, sourceIndex: i})
 		i++
 	}
-	return out
+	return SanitizeResult{
+		Messages:      builder.messages,
+		SourceIndexes: builder.sourceIndexes,
+	}
+}
+
+func containsToolMessages(messages []model.Message) bool {
+	for i := range messages {
+		if messages[i].Role == model.RoleTool ||
+			(messages[i].Role == model.RoleAssistant &&
+				len(messages[i].ToolCalls) > 0) {
+			return true
+		}
+	}
+	return false
+}
+
+type indexedMessage struct {
+	message     model.Message
+	sourceIndex int
+}
+
+type sanitizeResultBuilder struct {
+	messages      []model.Message
+	sourceIndexes []int
+}
+
+func (b *sanitizeResultBuilder) append(message indexedMessage) {
+	outputIndex := len(b.messages)
+	b.messages = append(b.messages, message.message)
+	if b.sourceIndexes != nil {
+		b.sourceIndexes = append(b.sourceIndexes, message.sourceIndex)
+		return
+	}
+	if message.sourceIndex == outputIndex {
+		return
+	}
+	b.sourceIndexes = make([]int, outputIndex, cap(b.messages))
+	for i := range b.sourceIndexes {
+		b.sourceIndexes[i] = i
+	}
+	b.sourceIndexes = append(b.sourceIndexes, message.sourceIndex)
+}
+
+func (b *sanitizeResultBuilder) appendAll(messages []indexedMessage) {
+	for _, message := range messages {
+		b.append(message)
+	}
 }
 
 type toolCallValidation struct {
@@ -90,9 +172,9 @@ type invalidToolCall struct {
 }
 
 type toolResultSplit struct {
-	kept        []model.Message
-	invalidByID map[string][]model.Message
-	orphan      []model.Message
+	kept        []indexedMessage
+	invalidByID map[string][]indexedMessage
+	orphan      []indexedMessage
 }
 
 type toolCallSplit struct {
@@ -101,49 +183,79 @@ type toolCallSplit struct {
 }
 
 // sanitizeToolRound sanitizes a single assistant tool-call round with its following tool results.
-func sanitizeToolRound(ctx context.Context, assistant model.Message, toolResults []model.Message, tools map[string]tool.Tool) []model.Message {
-	validation := validateToolCalls(assistant.ToolCalls, tools)
-	split := splitToolResults(toolResults, validation.validIDs, validation.invalidIDs)
+func sanitizeToolRound(
+	ctx context.Context,
+	assistant indexedMessage,
+	toolResults []model.Message,
+	firstToolResultSourceIndex int,
+	tools map[string]tool.Tool,
+) []indexedMessage {
+	validation := validateToolCalls(assistant.message.ToolCalls, tools)
+	split := splitToolResults(
+		toolResults,
+		firstToolResultSourceIndex,
+		validation.validIDs,
+		validation.invalidIDs,
+	)
 	toolCallSplit := splitToolCalls(validation.validToolCalls, split.kept)
-	filteredAssistant := assistant
+	filteredAssistant := assistant.message
 	filteredAssistant.ToolCalls = toolCallSplit.kept
 	if len(filteredAssistant.ToolCalls) == 0 {
 		filteredAssistant.ToolCalls = nil
 	}
 	out := make(
-		[]model.Message,
+		[]indexedMessage,
 		0,
 		1+len(toolResults)+len(validation.invalidToolCalls)+len(toolCallSplit.orphan)+len(split.orphan),
 	)
 	if !message.IsEmptyAssistantMessage(filteredAssistant) {
-		out = append(out, filteredAssistant)
+		out = append(out, indexedMessage{
+			message:     filteredAssistant,
+			sourceIndex: assistant.sourceIndex,
+		})
 		out = append(out, split.kept...)
 	}
 	for _, orphanCall := range toolCallSplit.orphan {
-		out = append(out, downgradeOrphanToolCall(ctx, orphanCall))
+		out = append(out, indexedMessage{
+			message:     downgradeOrphanToolCall(ctx, orphanCall),
+			sourceIndex: assistant.sourceIndex,
+		})
 	}
 	for _, invalid := range validation.invalidToolCalls {
-		out = append(out, downgradeInvalidToolCall(ctx, invalid.call, invalid.reason))
+		out = append(out, indexedMessage{
+			message: downgradeInvalidToolCall(
+				ctx,
+				invalid.call,
+				invalid.reason,
+			),
+			sourceIndex: assistant.sourceIndex,
+		})
 		for _, tr := range split.invalidByID[invalid.call.ID] {
-			out = append(out, downgradeInvalidToolResult(ctx, tr))
+			out = append(out, indexedMessage{
+				message:     downgradeInvalidToolResult(ctx, tr.message),
+				sourceIndex: tr.sourceIndex,
+			})
 		}
 	}
 	for _, orphan := range split.orphan {
-		out = append(out, downgradeOrphanToolResult(ctx, orphan))
+		out = append(out, indexedMessage{
+			message:     downgradeOrphanToolResult(ctx, orphan.message),
+			sourceIndex: orphan.sourceIndex,
+		})
 	}
 	return out
 }
 
-func splitToolCalls(toolCalls []model.ToolCall, toolResults []model.Message) toolCallSplit {
+func splitToolCalls(toolCalls []model.ToolCall, toolResults []indexedMessage) toolCallSplit {
 	out := toolCallSplit{
 		kept: make([]model.ToolCall, 0, len(toolCalls)),
 	}
 	respondedIDs := make(map[string]struct{}, len(toolResults))
 	for _, tr := range toolResults {
-		if tr.ToolID == "" {
+		if tr.message.ToolID == "" {
 			continue
 		}
-		respondedIDs[tr.ToolID] = struct{}{}
+		respondedIDs[tr.message.ToolID] = struct{}{}
 	}
 	for _, tc := range toolCalls {
 		if tc.ID != "" {
@@ -408,28 +520,40 @@ func validateNumberValueAgainstSchema(value any, path string) (bool, string) {
 }
 
 // splitToolResults groups tool result messages by tool_call_id based on tool call validity.
-func splitToolResults(toolResults []model.Message, validIDs map[string]struct{}, invalidIDs map[string]struct{}) toolResultSplit {
+func splitToolResults(
+	toolResults []model.Message,
+	firstSourceIndex int,
+	validIDs map[string]struct{},
+	invalidIDs map[string]struct{},
+) toolResultSplit {
 	out := toolResultSplit{
-		kept:        make([]model.Message, 0, len(toolResults)),
-		invalidByID: make(map[string][]model.Message),
+		kept:        make([]indexedMessage, 0, len(toolResults)),
+		invalidByID: make(map[string][]indexedMessage),
 	}
 	respondedValidIDs := make(map[string]struct{}, len(validIDs))
-	for _, tr := range toolResults {
-		if tr.ToolID == "" {
+	for i, message := range toolResults {
+		tr := indexedMessage{
+			message:     message,
+			sourceIndex: firstSourceIndex + i,
+		}
+		if message.ToolID == "" {
 			out.orphan = append(out.orphan, tr)
 			continue
 		}
-		if _, ok := validIDs[tr.ToolID]; ok {
-			if _, responded := respondedValidIDs[tr.ToolID]; responded {
+		if _, ok := validIDs[message.ToolID]; ok {
+			if _, responded := respondedValidIDs[message.ToolID]; responded {
 				out.orphan = append(out.orphan, tr)
 				continue
 			}
-			respondedValidIDs[tr.ToolID] = struct{}{}
+			respondedValidIDs[message.ToolID] = struct{}{}
 			out.kept = append(out.kept, tr)
 			continue
 		}
-		if _, ok := invalidIDs[tr.ToolID]; ok {
-			out.invalidByID[tr.ToolID] = append(out.invalidByID[tr.ToolID], tr)
+		if _, ok := invalidIDs[message.ToolID]; ok {
+			out.invalidByID[message.ToolID] = append(
+				out.invalidByID[message.ToolID],
+				tr,
+			)
 			continue
 		}
 		out.orphan = append(out.orphan, tr)

--- a/internal/toolcall/sanitize_bench_test.go
+++ b/internal/toolcall/sanitize_bench_test.go
@@ -1,0 +1,189 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package toolcall
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+var sanitizeMessagesBenchmarkSink []model.Message
+
+func BenchmarkSanitizeMessagesWithTools(b *testing.B) {
+	originalWarnfContext := log.WarnfContext
+	log.WarnfContext = func(context.Context, string, ...any) {}
+	b.Cleanup(func() {
+		log.WarnfContext = originalWarnfContext
+	})
+
+	benchmarks := []struct {
+		name     string
+		messages []model.Message
+		bytes    int64
+	}{
+		{
+			name:     "text/messages=32",
+			messages: sanitizeBenchmarkTextMessages(32, 64),
+		},
+		{
+			name:     "text/messages=512",
+			messages: sanitizeBenchmarkTextMessages(512, 64),
+		},
+		{
+			name:     "text/messages=2048",
+			messages: sanitizeBenchmarkTextMessages(2048, 64),
+		},
+		{
+			name:     "large_text/messages=512/payload_bytes=3145728",
+			messages: sanitizeBenchmarkTextMessages(512, 6*1024),
+			bytes:    3 * 1024 * 1024,
+		},
+		{
+			name:     "valid_tool_rounds/messages=32",
+			messages: sanitizeBenchmarkValidToolRounds(16),
+		},
+		{
+			name:     "valid_tool_rounds/messages=512",
+			messages: sanitizeBenchmarkValidToolRounds(256),
+		},
+		{
+			name:     "valid_tool_rounds/messages=2048",
+			messages: sanitizeBenchmarkValidToolRounds(1024),
+		},
+		{
+			name:     "mixed_tool_rounds/messages=32",
+			messages: sanitizeBenchmarkMixedToolRounds(8),
+		},
+		{
+			name:     "mixed_tool_rounds/messages=512",
+			messages: sanitizeBenchmarkMixedToolRounds(128),
+		},
+		{
+			name:     "mixed_tool_rounds/messages=2048",
+			messages: sanitizeBenchmarkMixedToolRounds(512),
+		},
+	}
+	ctx := context.Background()
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			if benchmark.bytes > 0 {
+				b.SetBytes(benchmark.bytes)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sanitizeMessagesBenchmarkSink = SanitizeMessagesWithTools(
+					ctx,
+					benchmark.messages,
+					nil,
+				)
+			}
+		})
+	}
+}
+
+func sanitizeBenchmarkTextMessages(count int, contentBytes int) []model.Message {
+	messages := make([]model.Message, count)
+	content := strings.Repeat("t", contentBytes)
+	for i := range messages {
+		role := model.RoleUser
+		if i%2 == 1 {
+			role = model.RoleAssistant
+		}
+		messages[i] = model.Message{Role: role, Content: content}
+	}
+	return messages
+}
+
+func sanitizeBenchmarkValidToolRounds(rounds int) []model.Message {
+	messages := make([]model.Message, 0, rounds*2)
+	for i := 0; i < rounds; i++ {
+		callID := fmt.Sprintf("valid-call-%d", i)
+		messages = append(messages,
+			model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{{
+					ID: callID,
+					Function: model.FunctionDefinitionParam{
+						Name:      "benchmark_tool",
+						Arguments: []byte(`{"value":"benchmark"}`),
+					},
+				}},
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   callID,
+				ToolName: "benchmark_tool",
+				Content:  "benchmark result",
+			},
+		)
+	}
+	return messages
+}
+
+func sanitizeBenchmarkMixedToolRounds(rounds int) []model.Message {
+	messages := make([]model.Message, 0, rounds*4)
+	for i := 0; i < rounds; i++ {
+		validID := fmt.Sprintf("valid-call-%d", i)
+		invalidID := fmt.Sprintf("invalid-call-%d", i)
+		orphanID := fmt.Sprintf("orphan-call-%d", i)
+		messages = append(messages,
+			model.Message{
+				Role: model.RoleAssistant,
+				ToolCalls: []model.ToolCall{
+					{
+						ID: validID,
+						Function: model.FunctionDefinitionParam{
+							Name:      "benchmark_tool",
+							Arguments: []byte(`{"value":"benchmark"}`),
+						},
+					},
+					{
+						ID: invalidID,
+						Function: model.FunctionDefinitionParam{
+							Arguments: []byte(`{"value":"benchmark"}`),
+						},
+					},
+					{
+						ID: orphanID,
+						Function: model.FunctionDefinitionParam{
+							Name:      "benchmark_tool",
+							Arguments: []byte(`{"value":"benchmark"}`),
+						},
+					},
+				},
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   validID,
+				ToolName: "benchmark_tool",
+				Content:  "valid result",
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   invalidID,
+				ToolName: "benchmark_tool",
+				Content:  "invalid result",
+			},
+			model.Message{
+				Role:     model.RoleTool,
+				ToolID:   fmt.Sprintf("unknown-call-%d", i),
+				ToolName: "benchmark_tool",
+				Content:  "orphan result",
+			},
+		)
+	}
+	return messages
+}

--- a/internal/toolcall/sanitize_test.go
+++ b/internal/toolcall/sanitize_test.go
@@ -332,6 +332,83 @@ func TestSanitizeMessagesWithTools_SplitsMixedValidityToolRound(t *testing.T) {
 	}
 }
 
+func TestSanitizeMessagesWithToolsResult_TracksSplitRoundSources(t *testing.T) {
+	in := []model.Message{
+		model.NewUserMessage("start"),
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{
+				{
+					ID: "call_ok",
+					Function: model.FunctionDefinitionParam{
+						Name:      "ok_tool",
+						Arguments: []byte(`{"a":1}`),
+					},
+				},
+				{
+					ID: "call_bad",
+					Function: model.FunctionDefinitionParam{
+						Name:      "bad_tool",
+						Arguments: []byte("not-json"),
+					},
+				},
+			},
+		},
+		{Role: model.RoleTool, ToolID: "call_ok", Content: "ok"},
+		{Role: model.RoleTool, ToolID: "call_bad", Content: "bad"},
+	}
+
+	result := SanitizeMessagesWithToolsResult(
+		context.Background(),
+		in,
+		nil,
+	)
+
+	assert.Len(t, result.Messages, 5)
+	assert.Equal(t, []int{0, 1, 2, 1, 3}, result.SourceIndexes)
+}
+
+func TestSanitizeMessagesWithToolsResultOmitsIdentitySources(t *testing.T) {
+	in := []model.Message{
+		model.NewUserMessage("start"),
+		model.NewAssistantMessage("answer"),
+	}
+
+	result := SanitizeMessagesWithToolsResult(
+		context.Background(),
+		in,
+		nil,
+	)
+
+	assert.Equal(t, in, result.Messages)
+	assert.Nil(t, result.SourceIndexes)
+}
+
+func TestSanitizeMessagesWithToolsResultOmitsIdentityToolRoundSources(t *testing.T) {
+	in := []model.Message{
+		{
+			Role: model.RoleAssistant,
+			ToolCalls: []model.ToolCall{{
+				ID: "call_1",
+				Function: model.FunctionDefinitionParam{
+					Name:      "lookup",
+					Arguments: []byte(`{"query":"benchmark"}`),
+				},
+			}},
+		},
+		model.NewToolMessage("call_1", "lookup", "result"),
+	}
+
+	result := SanitizeMessagesWithToolsResult(
+		context.Background(),
+		in,
+		nil,
+	)
+
+	assert.Equal(t, in, result.Messages)
+	assert.Nil(t, result.SourceIndexes)
+}
+
 func TestSanitizeMessagesWithTools_DowngradesOrphanToolResult(t *testing.T) {
 	in := []model.Message{
 		{
@@ -932,9 +1009,11 @@ func TestSplitToolResults_GroupsByIDs(t *testing.T) {
 	}
 	validIDs := map[string]struct{}{"valid": {}}
 	invalidIDs := map[string]struct{}{"invalid": {}}
-	split := splitToolResults(toolResults, validIDs, invalidIDs)
+	split := splitToolResults(toolResults, 10, validIDs, invalidIDs)
 	assert.Len(t, split.kept, 1)
+	assert.Equal(t, 11, split.kept[0].sourceIndex)
 	assert.Len(t, split.invalidByID["invalid"], 1)
+	assert.Equal(t, 12, split.invalidByID["invalid"][0].sourceIndex)
 	assert.Len(t, split.orphan, 2)
 }
 

--- a/knowledge/document/reader/python/go.mod
+++ b/knowledge/document/reader/python/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace trpc.group/trpc-go/trpc-agent-go => ../../../..
 
-require trpc.group/trpc-go/trpc-agent-go v1.10.1-0.20260605075142-de51b6b2b584
+require trpc.group/trpc-go/trpc-agent-go v1.11.1
 
 require (
 	github.com/yuin/goldmark v1.4.13 // indirect

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -278,6 +278,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "anthropic.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -288,7 +292,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in anthropic.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "anthropic.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "anthropic.Model", request, tailored,
+			)
 			return
 		}
 		log.WarnContext(
@@ -299,7 +305,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "anthropic.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "anthropic.Model", request, tailored,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/gemini/gemini.go
+++ b/model/gemini/gemini.go
@@ -620,6 +620,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "gemini.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -630,7 +634,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in gemini.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "gemini.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "gemini.Model", request, tailored,
+			)
 			return
 		}
 		log.WarnContext(
@@ -641,7 +647,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "gemini.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "gemini.Model", request, tailored,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/huggingface/huggingface.go
+++ b/model/huggingface/huggingface.go
@@ -486,20 +486,28 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		log.DebugfContext(ctx, "auto-calculated max input tokens: model=%s, maxInputTokens=%d",
 			m.name, maxInputTokens)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "huggingface.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
 		if len(tailored) > 0 {
 			log.WarnContext(ctx, "token tailoring returned best-effort messages in huggingface.Model", err)
-			modeltailoring.ApplyResult(ctx, "huggingface.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "huggingface.Model", request, tailored,
+			)
 			return
 		}
 		log.Warn("token tailoring failed in huggingface.Model", err)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "huggingface.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "huggingface.Model", request, tailored,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/hunyuan/hunyuan.go
+++ b/model/hunyuan/hunyuan.go
@@ -296,20 +296,28 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		log.DebugfContext(ctx, "auto-calculated max input tokens: model=%s, maxInputTokens=%d",
 			m.name, maxInputTokens)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "hunyuan.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
 	if err != nil {
 		if len(tailored) > 0 {
 			log.WarnContext(ctx, "token tailoring returned best-effort messages in hunyuan.Model", err)
-			modeltailoring.ApplyResult(ctx, "hunyuan.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "hunyuan.Model", request, tailored,
+			)
 			return
 		}
 		log.WarnContext(ctx, "token tailoring failed in hunyuan.Model", "error", err)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "hunyuan.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "hunyuan.Model", request, tailored,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/internal/modeltailoring/modeltailoring.go
+++ b/model/internal/modeltailoring/modeltailoring.go
@@ -12,10 +12,42 @@ package modeltailoring
 
 import (
 	"context"
+	"reflect"
 
+	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/statecopy"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
+
+// ObserveChanges snapshots request messages and returns a function that records
+// any provider-side change. Callers should defer the returned function before
+// invoking a token tailoring strategy.
+func ObserveChanges(
+	ctx context.Context,
+	provider string,
+	request *model.Request,
+	maxInputTokens int,
+) func() {
+	if request == nil {
+		return func() {}
+	}
+	before := statecopy.Messages(request.Messages)
+	return func() {
+		if reflect.DeepEqual(before, request.Messages) {
+			return
+		}
+		modelrequest.RecordTokenTailoring(
+			ctx,
+			modelrequest.TokenTailoringRecord{
+				Provider:       provider,
+				MaxInputTokens: maxInputTokens,
+				BeforeMessages: len(before),
+				AfterMessages:  len(request.Messages),
+			},
+		)
+	}
+}
 
 // ApplyResult applies a token-tailored message slice when it is safe to do so.
 // It preserves the original non-empty request if a tailoring strategy returns an

--- a/model/internal/modeltailoring/modeltailoring_test.go
+++ b/model/internal/modeltailoring/modeltailoring_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
@@ -45,7 +46,9 @@ func TestApplyResult_PreservesOriginalOnEmptyResult(t *testing.T) {
 			}
 			req := &model.Request{Messages: append([]model.Message(nil), original...)}
 
-			updated := ApplyResult(context.Background(), "test.Model", req, tt.tailored)
+			updated := ApplyResult(
+				context.Background(), "test.Model", req, tt.tailored,
+			)
 
 			require.False(t, updated)
 			require.Equal(t, original, req.Messages)
@@ -60,7 +63,9 @@ func TestApplyResult_AppliesTailoredMessages(t *testing.T) {
 		model.NewUserMessage("q"),
 	}}
 
-	updated := ApplyResult(context.Background(), "test.Model", req, tailored)
+	updated := ApplyResult(
+		context.Background(), "test.Model", req, tailored,
+	)
 
 	require.True(t, updated)
 	require.Equal(t, tailored, req.Messages)
@@ -70,8 +75,43 @@ func TestApplyResult_AllowsEmptyResultForEmptyOriginal(t *testing.T) {
 	req := &model.Request{}
 	tailored := []model.Message{}
 
-	updated := ApplyResult(context.Background(), "test.Model", req, tailored)
+	updated := ApplyResult(
+		context.Background(), "test.Model", req, tailored,
+	)
 
 	require.True(t, updated)
 	require.Equal(t, tailored, req.Messages)
+}
+
+func TestObserveChangesReportsMutatingStrategy(t *testing.T) {
+	ctx, observer := modelrequest.ObserveTokenTailoring(
+		context.Background(),
+		nil,
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("question"),
+	}}
+	finishObservation := ObserveChanges(ctx, "test.Model", req, 100)
+	req.Messages[0].Content = "mutated in place"
+	finishObservation()
+
+	require.Equal(t, []modelrequest.TokenTailoringRecord{{
+		Provider:       "test.Model",
+		MaxInputTokens: 100,
+		BeforeMessages: 1,
+		AfterMessages:  1,
+	}}, observer.Snapshot())
+}
+
+func TestObserveChangesDoesNotReportUnchangedRequest(t *testing.T) {
+	ctx, observer := modelrequest.ObserveTokenTailoring(
+		context.Background(),
+		nil,
+	)
+	messages := []model.Message{model.NewUserMessage("question")}
+	req := &model.Request{Messages: messages}
+
+	finishObservation := ObserveChanges(ctx, "test.Model", req, 100)
+	finishObservation()
+	require.Empty(t, observer.Snapshot())
 }

--- a/model/ollama/ollama.go
+++ b/model/ollama/ollama.go
@@ -276,6 +276,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "ollama.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -286,7 +290,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in ollama.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "ollama.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "ollama.Model", request, tailored,
+			)
 			return
 		}
 		log.WarnContext(
@@ -297,7 +303,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "ollama.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "ollama.Model", request, tailored,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -959,10 +959,16 @@ func (m *Model) buildChatRequestWithToolControl(
 		}
 	}
 
-	// MaxTokens is deprecated and not compatible with o-series models.
-	// Use MaxCompletionTokens instead.
 	if mt := imodel.ClampMaxTokensForModel(m.name, request.MaxTokens); mt != nil {
-		chatRequest.MaxCompletionTokens = openai.Int(int64(*mt))
+		if m.variant == VariantDeepSeek {
+			// DeepSeek's Chat Completions API documents max_tokens as the
+			// output limit: https://api-docs.deepseek.com/api/create-chat-completion.
+			chatRequest.MaxTokens = openai.Int(int64(*mt))
+		} else {
+			// max_tokens is deprecated and incompatible with OpenAI o-series
+			// models. Use max_completion_tokens for other variants.
+			chatRequest.MaxCompletionTokens = openai.Int(int64(*mt))
+		}
 	}
 	if request.Temperature != nil {
 		chatRequest.Temperature = openai.Float(*request.Temperature)

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -784,6 +784,10 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 			maxInputTokens,
 		)
 	}
+	finishObservation := modeltailoring.ObserveChanges(
+		ctx, "openai.Model", request, maxInputTokens,
+	)
+	defer finishObservation()
 
 	// Apply token tailoring.
 	tailored, err := m.tailoringStrategy.TailorMessages(ctx, request.Messages, maxInputTokens)
@@ -794,7 +798,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 				"token tailoring returned best-effort messages in openai.Model",
 				err,
 			)
-			modeltailoring.ApplyResult(ctx, "openai.Model", request, tailored)
+			modeltailoring.ApplyResult(
+				ctx, "openai.Model", request, tailored,
+			)
 			return
 		}
 		log.WarnContext(
@@ -805,7 +811,9 @@ func (m *Model) applyTokenTailoring(ctx context.Context, request *model.Request)
 		return
 	}
 
-	modeltailoring.ApplyResult(ctx, "openai.Model", request, tailored)
+	modeltailoring.ApplyResult(
+		ctx, "openai.Model", request, tailored,
+	)
 }
 
 // InputTokenBudget returns the same input budget used by token tailoring.

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -5501,7 +5501,55 @@ func TestBuildChatRequest_EdgeCases(t *testing.T) {
 		chatReq, _ := m.buildChatRequest(req)
 		require.NotNil(t, chatReq.MaxCompletionTokens)
 		assert.Equal(t, int64(16384), chatReq.MaxCompletionTokens.Value)
+		assert.False(t, chatReq.MaxTokens.Valid())
+
+		raw, err := chatReq.MarshalJSON()
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(raw, &body))
+		assert.Equal(t, float64(16384), body["max_completion_tokens"])
+		assert.NotContains(t, body, "max_tokens")
 	})
+
+	for _, tt := range []struct {
+		name string
+		opts []Option
+	}{
+		{
+			name: "official base URL",
+			opts: []Option{WithBaseURL(defaultDeepSeekBaseURL)},
+		},
+		{
+			name: "custom proxy with explicit variant",
+			opts: []Option{
+				WithBaseURL("https://proxy.example.com/v1"),
+				WithVariant(VariantDeepSeek),
+			},
+		},
+	} {
+		t.Run("DeepSeek uses max_tokens with "+tt.name, func(t *testing.T) {
+			m := New("deepseek-v4-flash", tt.opts...)
+			maxTokens := 2048
+			req := &model.Request{
+				Messages: []model.Message{model.NewUserMessage("hi")},
+				GenerationConfig: model.GenerationConfig{
+					MaxTokens: &maxTokens,
+				},
+			}
+
+			chatReq, _ := m.buildChatRequest(req)
+			require.True(t, chatReq.MaxTokens.Valid())
+			assert.Equal(t, int64(maxTokens), chatReq.MaxTokens.Value)
+			assert.False(t, chatReq.MaxCompletionTokens.Valid())
+
+			raw, err := chatReq.MarshalJSON()
+			require.NoError(t, err)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(raw, &body))
+			assert.Equal(t, float64(maxTokens), body["max_tokens"])
+			assert.NotContains(t, body, "max_completion_tokens")
+		})
+	}
 
 	t.Run("empty messages", func(t *testing.T) {
 		req := &model.Request{
@@ -5511,6 +5559,8 @@ func TestBuildChatRequest_EdgeCases(t *testing.T) {
 
 		chatReq, _ := m.buildChatRequest(req)
 		assert.Empty(t, chatReq.Messages, "expected empty messages")
+		assert.False(t, chatReq.MaxTokens.Valid())
+		assert.False(t, chatReq.MaxCompletionTokens.Valid())
 	})
 
 	t.Run("with all generation config options", func(t *testing.T) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1308,6 +1308,7 @@ type eventLoopContext struct {
 	emittedAssistantChoiceSignatures   map[string]struct{}
 	visibleCompletionResponseIDs       map[string]struct{}
 	visibleCompletionChoiceSignatures  map[string]struct{}
+	persistedEvents                    eventPersistenceDeduper
 	sawTerminalError                   bool
 	streamFilter                       graph.StreamModeFilter
 	interruptedAssistants              map[string]*interruptedAssistantAccumulator
@@ -1325,6 +1326,80 @@ type eventLoopContext struct {
 	errorEventCount     int
 	emittedEventCount   int
 	detailSpanCount     int
+}
+
+// eventPersistenceDeduper coordinates event persistence within one runner
+// event loop. Successful IDs remain recorded for the loop lifetime, while a
+// failed append releases the ID so another delivery can retry it.
+type eventPersistenceDeduper struct {
+	mu sync.Mutex
+	// records tracks in-flight and completed persistence by event ID. A nil
+	// record marks an event that was persisted successfully.
+	records map[string]*eventPersistenceRecord
+}
+
+type eventPersistenceRecord struct {
+	done chan struct{}
+}
+
+func (d *eventPersistenceDeduper) start(
+	ctx context.Context,
+	eventID string,
+) (record *eventPersistenceRecord, proceed bool) {
+	if d == nil || eventID == "" {
+		return nil, true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		d.mu.Lock()
+		if d.records == nil {
+			d.records = make(map[string]*eventPersistenceRecord)
+		}
+		record, ok := d.records[eventID]
+		if !ok {
+			record = &eventPersistenceRecord{}
+			d.records[eventID] = record
+			d.mu.Unlock()
+			return record, true
+		}
+		if record == nil {
+			d.mu.Unlock()
+			return nil, false
+		}
+		if record.done == nil {
+			record.done = make(chan struct{})
+		}
+		done := record.done
+		d.mu.Unlock()
+
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return nil, false
+		}
+	}
+}
+
+func (d *eventPersistenceDeduper) finish(
+	eventID string,
+	record *eventPersistenceRecord,
+	persisted bool,
+) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.records[eventID] != record {
+		return
+	}
+	if persisted {
+		d.records[eventID] = nil
+	} else {
+		delete(d.records, eventID)
+	}
+	if record.done != nil {
+		close(record.done)
+	}
 }
 
 type interruptedAssistantAccumulator struct {
@@ -1551,12 +1626,13 @@ func (r *runner) processSingleAgentEvent(
 	shouldForwardEvent := loop.streamFilter.Allows(agentEvent)
 
 	// Append qualifying events to session and trigger summarization.
-	persisted := r.handleEventPersistence(
+	persisted := r.handleEventPersistenceOnce(
 		ctx,
 		loop.invocation,
 		loop.sess,
 		persistSession,
 		agentEvent,
+		&loop.persistedEvents,
 	)
 	if !excludeRootCompletion {
 		r.recordPersistedAssistantEvent(
@@ -2357,12 +2433,13 @@ func (r *runner) persistInterruptedAssistant(ctx context.Context, loop *eventLoo
 			) {
 			continue
 		}
-		if !r.handleEventPersistence(
+		if !r.handleEventPersistenceOnce(
 			persistCtx,
 			loop.invocation,
 			loop.sess,
 			persistSession,
 			interruptedEvent,
+			&loop.persistedEvents,
 		) {
 			continue
 		}
@@ -2572,6 +2649,39 @@ func (r *runner) handleFlushRequest(
 			return nil
 		}
 	}
+}
+
+// handleEventPersistenceOnce coordinates persistence by event ID. Successful
+// persistence is not repeated within the deduper's lifetime, while failed
+// attempts remain retryable.
+func (r *runner) handleEventPersistenceOnce(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	sess *session.Session,
+	persistSession *session.Session,
+	agentEvent *event.Event,
+	deduper *eventPersistenceDeduper,
+) (persisted bool) {
+	eventID := ""
+	if agentEvent != nil {
+		eventID = agentEvent.ID
+	}
+	record, proceed := deduper.start(ctx, eventID)
+	if !proceed {
+		return false
+	}
+	if record != nil {
+		defer func() {
+			deduper.finish(eventID, record, persisted)
+		}()
+	}
+	return r.handleEventPersistence(
+		ctx,
+		invocation,
+		sess,
+		persistSession,
+		agentEvent,
+	)
 }
 
 // handleEventPersistence appends qualifying events to the session and triggers

--- a/runner/runner_persistence_dedupe_test.go
+++ b/runner/runner_persistence_dedupe_test.go
@@ -1,0 +1,304 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/graph"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestRunnerDeduplicatesEventPersistence(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	loop := &eventLoopContext{
+		sess:             sess,
+		invocation:       invocation,
+		processedEventCh: make(chan *event.Event, 2),
+		streamFilter:     graph.NewStreamModeFilter(false, nil),
+	}
+
+	require.NoError(t, r.processSingleAgentEvent(context.Background(), loop, evt))
+	require.NoError(t, r.processSingleAgentEvent(context.Background(), loop, evt))
+	require.Len(t, service.appendEventCalls, 1)
+	require.Len(t, service.enqueueSummaryJobCalls, 1)
+}
+
+func TestRunnerDoesNotDeduplicateAcrossEventLoops(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(),
+		invocation,
+		sess,
+		sess,
+		evt,
+		&eventPersistenceDeduper{},
+	))
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(),
+		invocation,
+		sess,
+		sess,
+		evt,
+		&eventPersistenceDeduper{},
+	))
+	require.Len(t, service.appendEventCalls, 2)
+	require.Len(t, service.enqueueSummaryJobCalls, 2)
+}
+
+func TestRunnerReleasesCompletedEventPersistenceRecord(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	deduper.mu.Lock()
+	record, ok := deduper.records[evt.ID]
+	deduper.mu.Unlock()
+	require.True(t, ok)
+	require.Nil(t, record)
+}
+
+func TestRunnerDeduplicatesEventWhileAppendIsInFlight(t *testing.T) {
+	service := &blockingPersistenceSessionService{
+		mockSessionService: &mockSessionService{},
+		appendStarted:      make(chan struct{}),
+		appendRelease:      make(chan struct{}),
+	}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+	firstDone := make(chan bool, 1)
+	secondDone := make(chan bool, 1)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(service.appendRelease)
+		})
+	}
+	defer release()
+
+	go func() {
+		firstDone <- r.handleEventPersistenceOnce(
+			context.Background(), invocation, sess, sess, evt, deduper,
+		)
+	}()
+	select {
+	case <-service.appendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first append did not start")
+	}
+	go func() {
+		secondDone <- r.handleEventPersistenceOnce(
+			context.Background(), invocation, sess, sess, evt, deduper,
+		)
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("duplicate persistence completed before the in-flight append")
+	case <-time.After(50 * time.Millisecond):
+	}
+	release()
+
+	require.True(t, receivePersistenceResult(t, firstDone))
+	require.False(t, receivePersistenceResult(t, secondDone))
+	require.EqualValues(t, 1, service.appendCalls.Load())
+	require.EqualValues(t, 1, service.enqueueCalls.Load())
+}
+
+func TestRunnerDuplicateWaiterHonorsCancellation(t *testing.T) {
+	service := &blockingPersistenceSessionService{
+		mockSessionService: &mockSessionService{},
+		appendStarted:      make(chan struct{}),
+		appendRelease:      make(chan struct{}),
+	}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+	ownerDone := make(chan bool, 1)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(service.appendRelease)
+		})
+	}
+	defer release()
+
+	go func() {
+		ownerDone <- r.handleEventPersistenceOnce(
+			context.Background(), invocation, sess, sess, evt, deduper,
+		)
+	}()
+	select {
+	case <-service.appendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("owner append did not start")
+	}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	duplicateDone := make(chan bool, 1)
+	go func() {
+		duplicateDone <- r.handleEventPersistenceOnce(
+			canceledCtx, invocation, sess, sess, evt, deduper,
+		)
+	}()
+
+	require.False(t, receivePersistenceResult(t, duplicateDone))
+	require.EqualValues(t, 1, service.appendCalls.Load())
+	release()
+	require.True(t, receivePersistenceResult(t, ownerDone))
+	require.EqualValues(t, 1, service.appendCalls.Load())
+	require.EqualValues(t, 1, service.enqueueCalls.Load())
+}
+
+func TestRunnerRetriesEventAfterAppendFailure(t *testing.T) {
+	service := &failFirstPersistenceSessionService{
+		mockSessionService: &mockSessionService{},
+	}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	deduper := &eventPersistenceDeduper{}
+
+	require.False(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.EqualValues(t, 2, service.appendCalls.Load())
+	require.EqualValues(t, 1, service.enqueueCalls.Load())
+}
+
+func TestRunnerDoesNotDeduplicateEmptyEventID(t *testing.T) {
+	service := &mockSessionService{}
+	r := &runner{sessionService: service}
+	sess, invocation, evt := newPersistenceDedupTestInput()
+	evt.ID = ""
+	deduper := &eventPersistenceDeduper{}
+
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.True(t, r.handleEventPersistenceOnce(
+		context.Background(), invocation, sess, sess, evt, deduper,
+	))
+	require.Len(t, service.appendEventCalls, 2)
+	require.Len(t, service.enqueueSummaryJobCalls, 2)
+}
+
+func newPersistenceDedupTestInput() (
+	*session.Session,
+	*agent.Invocation,
+	*event.Event,
+) {
+	sess := session.NewSession("app", "user", "session")
+	invocation := agent.NewInvocation(agent.WithInvocationSession(sess))
+	evt := event.NewResponseEvent(
+		invocation.InvocationID,
+		"assistant",
+		&model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewAssistantMessage("answer"),
+			}},
+		},
+	)
+	evt.ID = "stable-event-id"
+	return sess, invocation, evt
+}
+
+func receivePersistenceResult(t *testing.T, result <-chan bool) bool {
+	t.Helper()
+	select {
+	case persisted := <-result:
+		return persisted
+	case <-time.After(time.Second):
+		t.Fatal("event persistence did not complete")
+		return false
+	}
+}
+
+type blockingPersistenceSessionService struct {
+	*mockSessionService
+	appendStarted chan struct{}
+	appendRelease chan struct{}
+	startOnce     sync.Once
+	appendCalls   atomic.Int32
+	enqueueCalls  atomic.Int32
+}
+
+func (s *blockingPersistenceSessionService) AppendEvent(
+	context.Context,
+	*session.Session,
+	*event.Event,
+	...session.Option,
+) error {
+	s.appendCalls.Add(1)
+	s.startOnce.Do(func() {
+		close(s.appendStarted)
+	})
+	<-s.appendRelease
+	return nil
+}
+
+func (s *blockingPersistenceSessionService) EnqueueSummaryJob(
+	context.Context,
+	*session.Session,
+	string,
+	bool,
+) error {
+	s.enqueueCalls.Add(1)
+	return nil
+}
+
+type failFirstPersistenceSessionService struct {
+	*mockSessionService
+	appendCalls  atomic.Int32
+	enqueueCalls atomic.Int32
+}
+
+func (s *failFirstPersistenceSessionService) AppendEvent(
+	context.Context,
+	*session.Session,
+	*event.Event,
+	...session.Option,
+) error {
+	if s.appendCalls.Add(1) == 1 {
+		return errors.New("append failed")
+	}
+	return nil
+}
+
+func (s *failFirstPersistenceSessionService) EnqueueSummaryJob(
+	context.Context,
+	*session.Session,
+	string,
+	bool,
+) error {
+	s.enqueueCalls.Add(1)
+	return nil
+}

--- a/session/mysql/init.go
+++ b/session/mysql/init.go
@@ -218,6 +218,16 @@ type tableIndex struct {
 	unique  bool     // Whether this is a unique index
 }
 
+type summaryIndexLayout uint8
+
+const (
+	summaryIndexUnknown summaryIndexLayout = iota
+	summaryIndexCurrent
+	summaryIndexIncompatibleCurrent
+	summaryIndexLegacyUnique
+	summaryIndexLegacyLookup
+)
+
 // tableSchema defines the expected schema for a table.
 type tableSchema struct {
 	columns []tableColumn
@@ -652,9 +662,9 @@ func (s *Service) verifySchema(ctx context.Context) error {
 			return fmt.Errorf("verify columns for table %s failed: %w", fullTableName, err)
 		}
 
-		// Verify indexes. A missing/incorrect UNIQUE index is fatal (uniqueness is
-		// no longer enforced); non-unique index drift is logged as a warning
-		// inside verifyIndexes and does not return an error.
+		// Verify indexes. Missing or incorrect UNIQUE indexes are fatal except
+		// for known historical summary layouts supported by serialized writes;
+		// non-unique index drift is logged as a warning inside verifyIndexes.
 		if err := s.verifyIndexes(ctx, fullTableName, schema.indexes); err != nil {
 			return fmt.Errorf("verify indexes for table %s failed: %w", fullTableName, err)
 		}
@@ -782,20 +792,24 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 		expectedIndexNames[expectedIndexName] = true
 	}
 
-	// Get actual indexes from database, including whether each is non-unique
-	// (NON_UNIQUE: 0 = unique, 1 = non-unique; same value on every column row).
+	// Get actual indexes, including uniqueness and per-column prefix lengths.
+	// NON_UNIQUE is repeated on every row for an index (0 means unique), while a
+	// NULL SUB_PART means the full column is indexed.
 	actualIndexes := make(map[string][]string)
 	actualNonUnique := make(map[string]bool)
+	actualSubParts := make(map[string][]sql.NullInt64)
 	err := s.mysqlClient.Query(ctx, func(rows *sql.Rows) error {
 		var indexName, columnName string
 		var nonUnique int
-		if err := rows.Scan(&indexName, &columnName, &nonUnique); err != nil {
+		var subPart sql.NullInt64
+		if err := rows.Scan(&indexName, &columnName, &nonUnique, &subPart); err != nil {
 			return err
 		}
 		actualIndexes[indexName] = append(actualIndexes[indexName], columnName)
 		actualNonUnique[indexName] = nonUnique != 0
+		actualSubParts[indexName] = append(actualSubParts[indexName], subPart)
 		return nil
-	}, `SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE
+	}, `SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SUB_PART
 		FROM information_schema.statistics
 		WHERE table_schema = DATABASE()
 		AND table_name = ?
@@ -805,11 +819,29 @@ func (s *Service) verifyIndexes(ctx context.Context, fullTableName string, expec
 		return fmt.Errorf("query indexes failed: %w", err)
 	}
 
+	// Summary writes are serialized through their parent session row, so the
+	// service can safely start on the two historical index layouts while an
+	// operator performs an online migration. Index detection is intentionally
+	// used only for validation and diagnostics; the write path is identical for
+	// every supported layout.
+	summaryIndexName, summaryUniqueCompatible, err := s.compatibleSummaryIndex(
+		ctx, fullTableName, expectedIndexes, actualIndexes, actualNonUnique, actualSubParts,
+	)
+	if err != nil {
+		return err
+	}
+	if summaryUniqueCompatible {
+		expectedIndexNames[summaryIndexName] = true
+	}
+
 	// Check each expected index. A missing/incorrect UNIQUE index is collected
-	// and returned as an error (fatal) because uniqueness is correctness-critical;
-	// non-unique index drift is only logged as a warning.
+	// and returned as an error unless a known historical summary layout was
+	// accepted above; non-unique index drift is only logged as a warning.
 	var invalidUnique []string
 	for _, expected := range expectedIndexes {
+		if summaryUniqueCompatible && isSummaryUniqueIndex(expected) {
+			continue
+		}
 		expectedIndexName := sqldb.BuildIndexName(s.opts.tablePrefix, expected.table, expected.suffix)
 		actualColumns, exists := actualIndexes[expectedIndexName]
 		if !exists {
@@ -893,6 +925,142 @@ func stringSlicesEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func expectsSummaryUniqueIndex(indexes []tableIndex) bool {
+	for _, index := range indexes {
+		if isSummaryUniqueIndex(index) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) compatibleSummaryIndex(
+	ctx context.Context,
+	fullTableName string,
+	expectedIndexes []tableIndex,
+	actualIndexes map[string][]string,
+	actualNonUnique map[string]bool,
+	actualSubParts map[string][]sql.NullInt64,
+) (string, bool, error) {
+	if fullTableName != s.tableSessionSummaries || !expectsSummaryUniqueIndex(expectedIndexes) {
+		return "", false, nil
+	}
+
+	indexName, layout := classifySummaryIndexLayout(
+		actualIndexes, actualNonUnique, actualSubParts, s.opts.tdsqlSharding,
+	)
+	if layout == summaryIndexUnknown {
+		return "", false, nil
+	}
+
+	canonicalName := sqldb.BuildIndexName(
+		s.opts.tablePrefix,
+		sqldb.TableNameSessionSummaries,
+		sqldb.IndexSuffixUniqueActive,
+	)
+	switch layout {
+	case summaryIndexCurrent:
+		if indexName != canonicalName {
+			log.InfofContext(ctx, "using equivalent summary UNIQUE index %s on table %s",
+				indexName, fullTableName)
+		}
+	case summaryIndexIncompatibleCurrent:
+		expectedPrefix := fmt.Sprintf("full columns or prefixes of at least %d characters",
+			mysqlVarCharIndexPrefixLen)
+		if s.opts.tdsqlSharding {
+			expectedPrefix = "full columns"
+		}
+		log.ErrorfContext(ctx, "summary UNIQUE index %s on table %s has unsupported prefix lengths %s; "+
+			"expected %s", indexName, fullTableName,
+			formatIndexSubParts(actualSubParts[indexName]), expectedPrefix)
+		return "", false, fmt.Errorf("summary UNIQUE index %s has unsupported prefix lengths", indexName)
+	case summaryIndexLegacyUnique:
+		log.WarnfContext(ctx, "legacy five-column summary UNIQUE index %s detected on table %s; "+
+			"enabling serialized writes for compatibility; duplicate active rows should be removed before adding a "+
+			"four-column UNIQUE index", indexName, fullTableName)
+	case summaryIndexLegacyLookup:
+		log.WarnfContext(ctx, "legacy summary lookup index %s detected on table %s without a "+
+			"business-key UNIQUE constraint; enabling serialized writes for compatibility, but an "+
+			"online migration to a four-column UNIQUE index is recommended", indexName, fullTableName)
+	}
+	return indexName, true, nil
+}
+
+func isSummaryUniqueIndex(index tableIndex) bool {
+	return index.table == sqldb.TableNameSessionSummaries &&
+		index.suffix == sqldb.IndexSuffixUniqueActive && index.unique
+}
+
+func classifySummaryIndexLayout(
+	actualIndexes map[string][]string,
+	actualNonUnique map[string]bool,
+	actualSubParts map[string][]sql.NullInt64,
+	tdsqlSharding bool,
+) (string, summaryIndexLayout) {
+	currentColumns := []string{"app_name", "user_id", "session_id", "filter_key"}
+	legacyUniqueColumns := []string{"app_name", "user_id", "session_id", "filter_key", "deleted_at"}
+	legacyLookupColumns := []string{"app_name", "user_id", "session_id", "deleted_at"}
+
+	// Every matching four-column UNIQUE index participates in writes, even when
+	// another valid or legacy index also exists. Reject any one whose shorter
+	// prefixes can report a duplicate for distinct full business keys.
+	for name, columns := range actualIndexes {
+		if !actualNonUnique[name] && stringSlicesEqual(columns, currentColumns) &&
+			!summaryIndexSubPartsCompatible(actualSubParts[name], tdsqlSharding) {
+			return name, summaryIndexIncompatibleCurrent
+		}
+	}
+
+	// Prefer the current capability even when a legacy index remains during an
+	// online migration or the replacement index uses a temporary name.
+	for name, columns := range actualIndexes {
+		if !actualNonUnique[name] && stringSlicesEqual(columns, currentColumns) {
+			return name, summaryIndexCurrent
+		}
+	}
+	for name, columns := range actualIndexes {
+		if !actualNonUnique[name] && stringSlicesEqual(columns, legacyUniqueColumns) {
+			return name, summaryIndexLegacyUnique
+		}
+	}
+	for name, columns := range actualIndexes {
+		if actualNonUnique[name] && stringSlicesEqual(columns, legacyLookupColumns) {
+			return name, summaryIndexLegacyLookup
+		}
+	}
+	return "", summaryIndexUnknown
+}
+
+func summaryIndexSubPartsCompatible(subParts []sql.NullInt64, tdsqlSharding bool) bool {
+	if len(subParts) != 4 {
+		return false
+	}
+	for _, subPart := range subParts {
+		if tdsqlSharding {
+			if subPart.Valid {
+				return false
+			}
+			continue
+		}
+		if subPart.Valid && subPart.Int64 < mysqlVarCharIndexPrefixLen {
+			return false
+		}
+	}
+	return true
+}
+
+func formatIndexSubParts(subParts []sql.NullInt64) string {
+	formatted := make([]string, len(subParts))
+	for i, subPart := range subParts {
+		if subPart.Valid {
+			formatted[i] = fmt.Sprintf("%d", subPart.Int64)
+		} else {
+			formatted[i] = "full"
+		}
+	}
+	return "[" + strings.Join(formatted, ", ") + "]"
 }
 
 // buildIndexColumnsStr builds a comma-separated column list with appropriate

--- a/session/mysql/init_test.go
+++ b/session/mysql/init_test.go
@@ -64,8 +64,8 @@ func mockVerifySchemaQueries(mock sqlmock.Sqlmock, tablePrefix string) {
 			WithArgs(fullTableName).
 			WillReturnRows(colRows)
 
-		// 3. verifyIndexes query (INDEX_NAME, COLUMN_NAME, NON_UNIQUE)
-		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
+		// 3. verifyIndexes query (INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SUB_PART)
+		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "SUB_PART"})
 		for _, idx := range schema.indexes {
 			idxName := sqldb.BuildIndexName(tablePrefix, idx.table, idx.suffix)
 			nonUnique := 1
@@ -73,10 +73,10 @@ func mockVerifySchemaQueries(mock sqlmock.Sqlmock, tablePrefix string) {
 				nonUnique = 0
 			}
 			for _, col := range idx.columns {
-				idxRows.AddRow(idxName, col, nonUnique)
+				idxRows.AddRow(idxName, col, nonUnique, nil)
 			}
 		}
-		idxRows.AddRow("PRIMARY", "id", 0)
+		idxRows.AddRow("PRIMARY", "id", 0, nil)
 		mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
 			WithArgs(fullTableName).
 			WillReturnRows(idxRows)
@@ -386,7 +386,7 @@ func TestVerifySchema_Success(t *testing.T) {
 		WillReturnRows(rows)
 
 	// 3. verifyIndexes
-	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
+	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "SUB_PART"})
 	for _, idx := range expectedSchema[testTable].indexes {
 		idxName := sqldb.BuildIndexName(s.opts.tablePrefix, idx.table, idx.suffix)
 		nonUnique := 1
@@ -394,11 +394,11 @@ func TestVerifySchema_Success(t *testing.T) {
 			nonUnique = 0
 		}
 		for _, col := range idx.columns {
-			idxRows.AddRow(idxName, col, nonUnique)
+			idxRows.AddRow(idxName, col, nonUnique, nil)
 		}
 	}
 	// Add PRIMARY key (should be ignored by unexpected check)
-	idxRows.AddRow("PRIMARY", "id", 0)
+	idxRows.AddRow("PRIMARY", "id", 0, nil)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
 		WithArgs(fullTableName).
@@ -443,17 +443,17 @@ func TestVerifySchema_MissingUniqueIndexFatal(t *testing.T) {
 		WithArgs(fullTableName).
 		WillReturnRows(colRows)
 	// Indexes: omit the unique_active index so verification fails fatally.
-	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
+	idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "SUB_PART"})
 	for _, idx := range expectedSchema[testTable].indexes {
 		if idx.suffix == sqldb.IndexSuffixUniqueActive {
 			continue
 		}
 		idxName := sqldb.BuildIndexName(s.opts.tablePrefix, idx.table, idx.suffix)
 		for _, col := range idx.columns {
-			idxRows.AddRow(idxName, col, 1)
+			idxRows.AddRow(idxName, col, 1, nil)
 		}
 	}
-	idxRows.AddRow("PRIMARY", "id", 0)
+	idxRows.AddRow("PRIMARY", "id", 0, nil)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
 		WithArgs(fullTableName).
 		WillReturnRows(idxRows)
@@ -596,14 +596,14 @@ func TestVerifyIndexes_Scenarios(t *testing.T) {
 			fullTableName := "session_states"
 
 			// Build mock rows from actualIndexes
-			idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
+			idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "SUB_PART"})
 			for idxName, cols := range tt.actualIndexes {
 				nonUnique := 0
 				if tt.actualNonUnique[idxName] {
 					nonUnique = 1
 				}
 				for _, col := range cols {
-					idxRows.AddRow(idxName, col, nonUnique)
+					idxRows.AddRow(idxName, col, nonUnique, nil)
 				}
 			}
 
@@ -614,6 +614,181 @@ func TestVerifyIndexes_Scenarios(t *testing.T) {
 			err = s.verifyIndexes(ctx, fullTableName, tt.expectedIndexes)
 			if tt.wantError {
 				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestVerifyIndexes_SummaryLayouts(t *testing.T) {
+	currentColumns := []string{"app_name", "user_id", "session_id", "filter_key"}
+	legacyUniqueColumns := []string{"app_name", "user_id", "session_id", "filter_key", "deleted_at"}
+	legacyLookupColumns := []string{"app_name", "user_id", "session_id", "deleted_at"}
+	canonicalName := "idx_session_summaries_unique_active"
+	expected := []tableIndex{{
+		table:   sqldb.TableNameSessionSummaries,
+		suffix:  sqldb.IndexSuffixUniqueActive,
+		columns: currentColumns,
+		unique:  true,
+	}}
+
+	tests := []struct {
+		name            string
+		actualIndexes   map[string][]string
+		actualNonUnique map[string]bool
+		actualSubParts  map[string][]any
+		tdsqlSharding   bool
+		wantError       bool
+		wantErrContains string
+	}{
+		{
+			name: "current canonical unique index",
+			actualIndexes: map[string][]string{
+				canonicalName: currentColumns,
+				"PRIMARY":     {"id"},
+			},
+		},
+		{
+			name: "current unique index with migration name",
+			actualIndexes: map[string][]string{
+				canonicalName:         legacyUniqueColumns,
+				canonicalName + "_v2": currentColumns,
+				"PRIMARY":             {"id"},
+			},
+			actualSubParts: map[string][]any{
+				canonicalName + "_v2": {int64(191), int64(191), int64(192), int64(191)},
+			},
+		},
+		{
+			name: "current unique index with short canonical prefixes",
+			actualIndexes: map[string][]string{
+				canonicalName: currentColumns,
+				"PRIMARY":     {"id"},
+			},
+			actualSubParts: map[string][]any{
+				canonicalName: {int64(191), int64(191), int64(190), int64(191)},
+			},
+			wantError:       true,
+			wantErrContains: "unsupported prefix lengths",
+		},
+		{
+			name: "migration unique index with short prefixes",
+			actualIndexes: map[string][]string{
+				canonicalName:         legacyUniqueColumns,
+				canonicalName + "_v2": currentColumns,
+				"PRIMARY":             {"id"},
+			},
+			actualSubParts: map[string][]any{
+				canonicalName + "_v2": {int64(190), int64(190), int64(190), int64(190)},
+			},
+			wantError:       true,
+			wantErrContains: "unsupported prefix lengths",
+		},
+		{
+			name: "unsafe extra unique index is rejected",
+			actualIndexes: map[string][]string{
+				canonicalName:         currentColumns,
+				canonicalName + "_v2": currentColumns,
+				"PRIMARY":             {"id"},
+			},
+			actualSubParts: map[string][]any{
+				canonicalName:         {int64(191), int64(191), int64(191), int64(191)},
+				canonicalName + "_v2": {int64(190), int64(190), int64(190), int64(190)},
+			},
+			wantError:       true,
+			wantErrContains: "unsupported prefix lengths",
+		},
+		{
+			name: "tdsql current unique index with full columns",
+			actualIndexes: map[string][]string{
+				canonicalName: currentColumns,
+				"PRIMARY":     {"id"},
+			},
+			tdsqlSharding: true,
+		},
+		{
+			name: "tdsql current unique index with prefixes",
+			actualIndexes: map[string][]string{
+				canonicalName: currentColumns,
+				"PRIMARY":     {"id"},
+			},
+			actualSubParts: map[string][]any{
+				canonicalName: {int64(128), int64(128), int64(128), int64(128)},
+			},
+			tdsqlSharding:   true,
+			wantError:       true,
+			wantErrContains: "unsupported prefix lengths",
+		},
+		{
+			name: "legacy five-column unique index",
+			actualIndexes: map[string][]string{
+				canonicalName: legacyUniqueColumns,
+				"PRIMARY":     {"id"},
+			},
+		},
+		{
+			name: "legacy lookup index",
+			actualIndexes: map[string][]string{
+				"idx_session_summaries_lookup": legacyLookupColumns,
+				"PRIMARY":                      {"id"},
+			},
+			actualNonUnique: map[string]bool{
+				"idx_session_summaries_lookup": true,
+			},
+		},
+		{
+			name: "four-column non-unique index remains unsupported",
+			actualIndexes: map[string][]string{
+				canonicalName: currentColumns,
+				"PRIMARY":     {"id"},
+			},
+			actualNonUnique: map[string]bool{
+				canonicalName: true,
+			},
+			wantError: true,
+		},
+		{
+			name: "missing summary lookup remains unsupported",
+			actualIndexes: map[string][]string{
+				"PRIMARY": {"id"},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db)
+			s.opts.tdsqlSharding = tt.tdsqlSharding
+			rows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "SUB_PART"})
+			for indexName, columns := range tt.actualIndexes {
+				nonUnique := 0
+				if tt.actualNonUnique[indexName] {
+					nonUnique = 1
+				}
+				subParts := tt.actualSubParts[indexName]
+				for i, column := range columns {
+					var subPart any
+					if i < len(subParts) {
+						subPart = subParts[i]
+					}
+					rows.AddRow(indexName, column, nonUnique, subPart)
+				}
+			}
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT INDEX_NAME")).
+				WithArgs(s.tableSessionSummaries).
+				WillReturnRows(rows)
+
+			err = s.verifyIndexes(context.Background(), s.tableSessionSummaries, expected)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrContains)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	drivermysql "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/session/hook"
@@ -1139,10 +1140,9 @@ func (s *Service) softDeleteSessions(
 		return fmt.Errorf("soft delete sessions: %w", err)
 	}
 
-	// Soft delete summaries
-	if _, err := tx.ExecContext(ctx,
-		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionSummaries, childWhereClause),
-		append([]any{now}, childArgs...)...); err != nil {
+	// Soft delete summaries. Legacy schemas may contain duplicate active rows
+	// that collide when assigned the same deleted_at value.
+	if err := s.softDeleteSummaries(ctx, tx, childWhereClause, childArgs, now); err != nil {
 		return fmt.Errorf("soft delete summaries: %w", err)
 	}
 
@@ -1163,6 +1163,97 @@ func (s *Service) softDeleteSessions(
 	}
 
 	return nil
+}
+
+func (s *Service) softDeleteSummaries(
+	ctx context.Context,
+	tx *sql.Tx,
+	whereClause string,
+	args []any,
+	now time.Time,
+) error {
+	activeWhereClause := fmt.Sprintf("(%s) AND deleted_at IS NULL", whereClause)
+	_, err := tx.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE %s SET deleted_at = ? WHERE %s`, s.tableSessionSummaries, activeWhereClause),
+		append([]any{now}, args...)...)
+	if err == nil {
+		return nil
+	}
+	if !isDuplicateEntryError(err) {
+		return err
+	}
+
+	// MySQL rolls back the failed UPDATE statement without aborting the
+	// transaction. Retry each row so healthy summaries retain their soft-delete
+	// history and only a row that still conflicts is physically removed.
+	log.WarnfContext(ctx, "soft deleting summaries hit duplicate legacy rows; "+
+		"retrying the affected active summaries individually: %v", err)
+	return s.softDeleteSummariesIndividually(ctx, tx, activeWhereClause, args, now)
+}
+
+func (s *Service) softDeleteSummariesIndividually(
+	ctx context.Context,
+	tx *sql.Tx,
+	activeWhereClause string,
+	args []any,
+	now time.Time,
+) error {
+	type summaryRowKey struct {
+		id     int64
+		userID string
+	}
+
+	rows, err := tx.QueryContext(ctx,
+		fmt.Sprintf(`SELECT id, user_id FROM %s WHERE %s ORDER BY id ASC FOR UPDATE`,
+			s.tableSessionSummaries, activeWhereClause),
+		args...)
+	if err != nil {
+		return fmt.Errorf("query active summaries after soft-delete conflict: %w", err)
+	}
+	var keys []summaryRowKey
+	for rows.Next() {
+		var key summaryRowKey
+		if err := rows.Scan(&key.id, &key.userID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan active summary after soft-delete conflict: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate active summaries after soft-delete conflict: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close active summaries after soft-delete conflict: %w", err)
+	}
+
+	for _, key := range keys {
+		_, err := tx.ExecContext(ctx,
+			fmt.Sprintf(`UPDATE %s SET deleted_at = ?
+				WHERE id = ? AND user_id = ? AND deleted_at IS NULL`, s.tableSessionSummaries),
+			now, key.id, key.userID)
+		if err == nil {
+			continue
+		}
+		if !isDuplicateEntryError(err) {
+			return fmt.Errorf("soft delete summary %d individually: %w", key.id, err)
+		}
+
+		log.WarnfContext(ctx, "soft deleting summary %d still hit a duplicate legacy row; "+
+			"deleting only that active row: %v", key.id, err)
+		if _, deleteErr := tx.ExecContext(ctx,
+			fmt.Sprintf(`DELETE FROM %s
+				WHERE id = ? AND user_id = ? AND deleted_at IS NULL`, s.tableSessionSummaries),
+			key.id, key.userID); deleteErr != nil {
+			return fmt.Errorf("delete duplicate active summary %d: %w", key.id, deleteErr)
+		}
+	}
+	return nil
+}
+
+func isDuplicateEntryError(err error) bool {
+	var mysqlErr *drivermysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == sqldb.MySQLErrDuplicateEntry
 }
 
 // hardDeleteSessions performs hard delete on session tables.

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -1018,7 +1018,7 @@ func TestGetSummariesList(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "filter_key", "summary", "updated_at"}).
 		AddRow("app1", "user1", "sess1", "filter1", []byte("invalid-json"), time.Now())
 
-	mock.ExpectQuery("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries").
+	mock.ExpectQuery("ORDER BY updated_at ASC, id ASC").
 		WithArgs("app1", "user1", "sess1", "user1", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -539,12 +539,15 @@ func (s *Service) deleteSessionState(ctx context.Context, key session.Key) error
 				return err
 			}
 
-			// Soft delete session summaries
-			_, err = tx.ExecContext(ctx,
-				fmt.Sprintf(`UPDATE %s SET deleted_at = ?
-				 WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL`, s.tableSessionSummaries),
-				now, key.AppName, key.UserID, key.SessionID)
-			if err != nil {
+			// Soft delete session summaries. Legacy schemas may contain duplicate
+			// active rows that require the compatibility fallback.
+			if err = s.softDeleteSummaries(
+				ctx,
+				tx,
+				"app_name = ? AND user_id = ? AND session_id = ? AND deleted_at IS NULL",
+				[]any{key.AppName, key.UserID, key.SessionID},
+				now,
+			); err != nil {
 				return err
 			}
 
@@ -1334,11 +1337,14 @@ func (s *Service) getSummariesList(
 	// add explicit user_id for shard routing. Harmless on MySQL.
 	args = append(args, sessionKeys[0].UserID, time.Now())
 
+	// Sort oldest-first so later map assignments deterministically retain the
+	// newest active copy when a legacy schema contains duplicates.
 	query := fmt.Sprintf(`SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
 		AND user_id = ?
 		AND (expires_at IS NULL OR expires_at > ?)
-		AND deleted_at IS NULL`,
+		AND deleted_at IS NULL
+		ORDER BY updated_at ASC, id ASC`,
 		s.tableSessionSummaries, strings.Join(placeholders, ","))
 
 	// Build a map of session key to created_at for filtering

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/event"
@@ -1407,6 +1408,155 @@ func TestSoftDeleteSessionsChildErrors(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 			assert.NoError(t, tx.Rollback())
 			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSoftDeleteSessionsFallsBackForLegacySummaryDuplicates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_states SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+		WillReturnError(&mysql.MySQLError{
+			Number:  sqldb.MySQLErrDuplicateEntry,
+			Message: "duplicate active summary",
+		})
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT id, user_id FROM session_summaries WHERE (app_name = ?) AND deleted_at IS NULL ORDER BY id ASC FOR UPDATE",
+	)).
+		WithArgs("app-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+			AddRow(int64(101), "user-1").
+			AddRow(int64(102), "user-1").
+			AddRow(int64(201), "user-2"))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+		WithArgs(sqlmock.AnyArg(), int64(101), "user-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+		WithArgs(sqlmock.AnyArg(), int64(102), "user-1").
+		WillReturnError(&mysql.MySQLError{
+			Number:  sqldb.MySQLErrDuplicateEntry,
+			Message: "duplicate active summary",
+		})
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
+		WithArgs(int64(102), "user-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+		WithArgs(sqlmock.AnyArg(), int64(201), "user-2").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_events SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_track_events SET deleted_at = ?")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	err = s.softDeleteSessions(
+		context.Background(),
+		tx,
+		"app_name = ? AND expires_at IS NOT NULL AND expires_at <= ?",
+		[]any{"app-1", time.Now()},
+		"app_name = ?",
+		[]any{"app-1"},
+		time.Now(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSoftDeleteSummariesIndividualFallbackErrors(t *testing.T) {
+	duplicateErr := &mysql.MySQLError{
+		Number:  sqldb.MySQLErrDuplicateEntry,
+		Message: "duplicate active summary",
+	}
+	tests := []struct {
+		name           string
+		expectFallback func(sqlmock.Sqlmock)
+		wantErr        string
+	}{
+		{
+			name: "query rows",
+			expectFallback: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_summaries")).
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "query active summaries",
+		},
+		{
+			name: "scan row",
+			expectFallback: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_summaries")).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).AddRow(nil, "user-1"))
+			},
+			wantErr: "scan active summary",
+		},
+		{
+			name: "iterate rows",
+			expectFallback: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_summaries")).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+						AddRow(int64(101), "user-1").
+						RowError(0, assert.AnError))
+			},
+			wantErr: "iterate active summaries",
+		},
+		{
+			name: "update row",
+			expectFallback: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_summaries")).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+						AddRow(int64(101), "user-1"))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+					WithArgs(sqlmock.AnyArg(), int64(101), "user-1").
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "soft delete summary 101 individually",
+		},
+		{
+			name: "delete duplicate row",
+			expectFallback: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT id, user_id FROM session_summaries")).
+					WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).
+						AddRow(int64(101), "user-1"))
+				mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+					WithArgs(sqlmock.AnyArg(), int64(101), "user-1").
+					WillReturnError(duplicateErr)
+				mock.ExpectExec(regexp.QuoteMeta("DELETE FROM session_summaries")).
+					WithArgs(int64(101), "user-1").
+					WillReturnError(assert.AnError)
+			},
+			wantErr: "delete duplicate active summary 101",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			s := createTestService(t, db)
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries SET deleted_at = ?")).
+				WillReturnError(duplicateErr)
+			tt.expectFallback(mock)
+			mock.ExpectRollback()
+
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			err = s.softDeleteSummaries(
+				context.Background(), tx, "app_name = ?", []any{"app-1"}, time.Now(),
+			)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.NoError(t, tx.Rollback())
+			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
 }
@@ -3670,8 +3820,8 @@ func mockDBInitWithPrefix(mock sqlmock.Sqlmock, tablePrefix string) {
 			WithArgs(fullTableName).
 			WillReturnRows(colRows)
 
-		// 3. verifyIndexes query (INDEX_NAME, COLUMN_NAME, NON_UNIQUE)
-		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE"})
+		// 3. verifyIndexes query (INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SUB_PART)
+		idxRows := sqlmock.NewRows([]string{"INDEX_NAME", "COLUMN_NAME", "NON_UNIQUE", "SUB_PART"})
 		for _, idx := range schema.indexes {
 			idxName := sqldb.BuildIndexName(tablePrefix, idx.table, idx.suffix)
 			nonUnique := 1
@@ -3679,10 +3829,10 @@ func mockDBInitWithPrefix(mock sqlmock.Sqlmock, tablePrefix string) {
 				nonUnique = 0
 			}
 			for _, col := range idx.columns {
-				idxRows.AddRow(idxName, col, nonUnique)
+				idxRows.AddRow(idxName, col, nonUnique, nil)
 			}
 		}
-		idxRows.AddRow("PRIMARY", "id", 0)
+		idxRows.AddRow("PRIMARY", "id", 0, nil)
 		mock.ExpectQuery("SELECT INDEX_NAME").
 			WithArgs(fullTableName).
 			WillReturnRows(idxRows)

--- a/session/mysql/summary.go
+++ b/session/mysql/summary.go
@@ -51,8 +51,6 @@ func (s *Service) CreateSessionSummary(
 		return err
 	}
 
-	// Persist to MySQL using INSERT ... ON DUPLICATE KEY UPDATE for atomic upsert.
-	// This ensures no duplicate records can be created even under concurrent writes.
 	sess.SummariesMu.RLock()
 	sum := sess.Summaries[filterKey]
 	sess.SummariesMu.RUnlock()
@@ -66,25 +64,136 @@ func (s *Service) CreateSessionSummary(
 		return fmt.Errorf("marshal summary failed: %w", err)
 	}
 
-	// Note: expires_at is set to NULL - summaries are bound to session
-	// lifecycle and will be deleted when session is deleted or expires.
-	_, err = s.mysqlClient.Exec(ctx,
-		fmt.Sprintf(
-			`INSERT INTO %s (app_name, user_id, session_id, filter_key, summary, updated_at, expires_at, deleted_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
-			ON DUPLICATE KEY UPDATE
-				summary = VALUES(summary),
-				updated_at = VALUES(updated_at),
-				expires_at = VALUES(expires_at),
-				deleted_at = NULL`,
-			s.tableSessionSummaries,
-		),
-		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), sum.UpdatedAt, nil)
+	return s.upsertSessionSummary(ctx, key, filterKey, summaryBytes, sum.UpdatedAt)
+}
+
+// upsertSessionSummary serializes summary persistence through the parent
+// session row. This keeps writes correct for both the current four-column
+// unique index and legacy schemas whose nullable deleted_at column does not
+// prevent duplicate active summaries.
+func (s *Service) upsertSessionSummary(
+	ctx context.Context,
+	key session.Key,
+	filterKey string,
+	summaryBytes []byte,
+	updatedAt time.Time,
+) error {
+	err := s.mysqlClient.Transaction(ctx, func(tx *sql.Tx) error {
+		if err := s.lockActiveSessionForSummary(ctx, tx, key); err != nil {
+			return err
+		}
+
+		persistedUpdatedAt, exists, err := s.latestActiveSummaryUpdatedAtForUpdate(
+			ctx, tx, key, filterKey,
+		)
+		if err != nil {
+			return err
+		}
+		if exists {
+			// A summary may be generated before waiting for this transaction's
+			// parent-session lock. Do not let an older cutoff overwrite a newer
+			// committed summary. Equal cutoffs remain last-write-wins so callers
+			// can force regeneration for the same summarized history.
+			if persistedUpdatedAt.After(updatedAt) {
+				return nil
+			}
+
+			// Update every active copy so reads remain consistent while legacy
+			// duplicate rows are being cleaned up online.
+			_, err = tx.ExecContext(ctx,
+				fmt.Sprintf(`UPDATE %s
+					SET summary = ?, updated_at = ?, expires_at = NULL
+					WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
+					AND deleted_at IS NULL`, s.tableSessionSummaries),
+				string(summaryBytes), updatedAt,
+				key.AppName, key.UserID, key.SessionID, filterKey)
+			if err != nil {
+				return fmt.Errorf("update active summaries failed: %w", err)
+			}
+			return nil
+		}
+
+		// Keep ON DUPLICATE KEY UPDATE for the current schema: when only a
+		// soft-deleted row exists, its four-column unique key must be revived.
+		// Legacy indexes do not conflict with that row and insert a new active
+		// summary instead.
+		_, err = tx.ExecContext(ctx,
+			fmt.Sprintf(`INSERT INTO %s
+					(app_name, user_id, session_id, filter_key, summary, updated_at, expires_at, deleted_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+				ON DUPLICATE KEY UPDATE
+					summary = VALUES(summary),
+					updated_at = VALUES(updated_at),
+					expires_at = VALUES(expires_at),
+					deleted_at = NULL`, s.tableSessionSummaries),
+			key.AppName, key.UserID, key.SessionID, filterKey,
+			string(summaryBytes), updatedAt, nil)
+		if err != nil {
+			return fmt.Errorf("insert or revive summary failed: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("upsert summary failed: %w", err)
 	}
-
 	return nil
+}
+
+func (s *Service) lockActiveSessionForSummary(
+	ctx context.Context,
+	tx *sql.Tx,
+	key session.Key,
+) error {
+	rows, err := tx.QueryContext(ctx,
+		fmt.Sprintf(`SELECT id FROM %s
+			WHERE app_name = ? AND user_id = ? AND session_id = ?
+			AND deleted_at IS NULL
+			FOR UPDATE`, s.tableSessionStates),
+		key.AppName, key.UserID, key.SessionID)
+	if err != nil {
+		return fmt.Errorf("lock session for summary failed: %w", err)
+	}
+	defer rows.Close()
+
+	found := false
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scan session lock row failed: %w", err)
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate session lock rows failed: %w", err)
+	}
+	if !found {
+		return errSessionNotFound
+	}
+	return nil
+}
+
+func (s *Service) latestActiveSummaryUpdatedAtForUpdate(
+	ctx context.Context,
+	tx *sql.Tx,
+	key session.Key,
+	filterKey string,
+) (time.Time, bool, error) {
+	var updatedAt time.Time
+	err := tx.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT updated_at FROM %s
+			WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
+			AND deleted_at IS NULL
+			ORDER BY updated_at DESC, id DESC
+			LIMIT 1
+			FOR UPDATE`, s.tableSessionSummaries),
+		key.AppName, key.UserID, key.SessionID, filterKey).Scan(&updatedAt)
+	if err == sql.ErrNoRows {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("lock active summaries failed: %w", err)
+	}
+	return updatedAt, true, nil
 }
 
 // EnqueueSummaryJob enqueues a summary job for asynchronous processing.
@@ -164,7 +273,9 @@ func (s *Service) GetSessionSummaryText(
 		WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
 		AND (expires_at IS NULL OR expires_at > ?)
 		AND updated_at >= ?
-		AND deleted_at IS NULL`, s.tableSessionSummaries),
+		AND deleted_at IS NULL
+		ORDER BY updated_at DESC, id DESC
+		LIMIT 1`, s.tableSessionSummaries),
 		key.AppName, key.UserID, key.SessionID, filterKey, time.Now(), sess.CreatedAt)
 
 	if err != nil {
@@ -193,7 +304,9 @@ func (s *Service) GetSessionSummaryText(
 			WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
 			AND (expires_at IS NULL OR expires_at > ?)
 			AND updated_at >= ?
-			AND deleted_at IS NULL`, s.tableSessionSummaries),
+			AND deleted_at IS NULL
+			ORDER BY updated_at DESC, id DESC
+			LIMIT 1`, s.tableSessionSummaries),
 			key.AppName, key.UserID, key.SessionID, session.SummaryFilterKeyAllContents, time.Now(), sess.CreatedAt)
 
 		if err == nil && summaryText != "" {

--- a/session/mysql/summary_integration_test.go
+++ b/session/mysql/summary_integration_test.go
@@ -1,0 +1,394 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	drivermysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/internal/session/sqldb"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestSessionSummarySchemaCompatibilityIntegration(t *testing.T) {
+	dsn := mysqlIntegrationDSN(t)
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	pingCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	require.NoError(t, db.PingContext(pingCtx))
+	cancel()
+
+	t.Run("current index with migration name", func(t *testing.T) {
+		ctx := summaryIntegrationContext(t)
+		prefix := prepareSummaryIntegrationSchema(t, db, dsn)
+		tableName := sqldb.BuildTableName(prefix, sqldb.TableNameSessionSummaries)
+		canonicalName := sqldb.BuildIndexName(
+			prefix, sqldb.TableNameSessionSummaries, sqldb.IndexSuffixUniqueActive,
+		)
+		migrationName := canonicalName + "_v2"
+		_, err := db.ExecContext(ctx, fmt.Sprintf(
+			"ALTER TABLE `%s` RENAME INDEX `%s` TO `%s`",
+			tableName, canonicalName, migrationName,
+		))
+		require.NoError(t, err)
+
+		svc := newSummaryIntegrationService(t, dsn, prefix)
+		require.NoError(t, svc.Close())
+	})
+
+	t.Run("current index with short migration prefixes is rejected", func(t *testing.T) {
+		ctx := summaryIntegrationContext(t)
+		prefix := prepareSummaryIntegrationSchema(t, db, dsn)
+		tableName := sqldb.BuildTableName(prefix, sqldb.TableNameSessionSummaries)
+		canonicalName := sqldb.BuildIndexName(
+			prefix, sqldb.TableNameSessionSummaries, sqldb.IndexSuffixUniqueActive,
+		)
+		migrationName := canonicalName + "_v2"
+		_, err := db.ExecContext(ctx, fmt.Sprintf(
+			"ALTER TABLE `%s` DROP INDEX `%s`, ADD UNIQUE INDEX `%s` "+
+				"(app_name(190), user_id(190), session_id(190), filter_key(190))",
+			tableName, canonicalName, migrationName,
+		))
+		require.NoError(t, err)
+
+		svc, err := NewService(
+			WithMySQLClientDSN(dsn),
+			WithTablePrefix(prefix),
+			WithSessionTTL(time.Hour),
+		)
+		require.ErrorContains(t, err, "unsupported prefix lengths")
+		require.Nil(t, svc)
+	})
+
+	t.Run("legacy unique soft delete preserves history", func(t *testing.T) {
+		ctx := summaryIntegrationContext(t)
+		prefix := prepareSummaryIntegrationSchema(t, db, dsn)
+		tableName := sqldb.BuildTableName(prefix, sqldb.TableNameSessionSummaries)
+		replaceSummaryIndexWithLegacyUnique(t, ctx, db, prefix)
+
+		svc := newSummaryIntegrationService(t, dsn, prefix)
+		t.Cleanup(func() { require.NoError(t, svc.Close()) })
+		key := createSummaryIntegrationSession(t, ctx, svc)
+		healthyKey := session.Key{
+			AppName: key.AppName, UserID: key.UserID, SessionID: "integration-healthy-session",
+		}
+		_, err := svc.CreateSession(ctx, healthyKey, nil)
+		require.NoError(t, err)
+
+		updatedAt := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+		deletedAt := updatedAt.Add(-time.Hour)
+		softDeletedAt := updatedAt.Add(time.Hour)
+		insertSummaryIntegrationRow(t, ctx, db, tableName, key, "active-1", updatedAt, nil)
+		insertSummaryIntegrationRow(t, ctx, db, tableName, key, "active-2", updatedAt, nil)
+		insertSummaryIntegrationRow(t, ctx, db, tableName, key, "historical", updatedAt, deletedAt)
+		insertSummaryIntegrationRow(t, ctx, db, tableName, healthyKey, "healthy", updatedAt, nil)
+
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, svc.softDeleteSummaries(
+			ctx, tx, "app_name = ?", []any{key.AppName}, softDeletedAt,
+		))
+		require.NoError(t, tx.Commit())
+
+		var activeCount int
+		err = db.QueryRowContext(ctx, fmt.Sprintf(
+			"SELECT COUNT(*) FROM `%s` WHERE app_name = ? AND deleted_at IS NULL", tableName,
+		), key.AppName).Scan(&activeCount)
+		require.NoError(t, err)
+		require.Zero(t, activeCount)
+
+		var duplicateRows int
+		err = db.QueryRowContext(ctx, fmt.Sprintf(
+			"SELECT COUNT(*) FROM `%s` WHERE app_name = ? AND user_id = ? AND session_id = ?", tableName,
+		), key.AppName, key.UserID, key.SessionID).Scan(&duplicateRows)
+		require.NoError(t, err)
+		require.Equal(t, 2, duplicateRows)
+
+		requireSummaryIntegrationDeletedAtCount(t, ctx, db, tableName, key, deletedAt, 1)
+		requireSummaryIntegrationDeletedAtCount(t, ctx, db, tableName, key, softDeletedAt, 1)
+		requireSummaryIntegrationDeletedAtCount(t, ctx, db, tableName, healthyKey, softDeletedAt, 1)
+	})
+
+	t.Run("legacy lookup keeps deterministic newest summary", func(t *testing.T) {
+		ctx := summaryIntegrationContext(t)
+		prefix := prepareSummaryIntegrationSchema(t, db, dsn)
+		tableName := sqldb.BuildTableName(prefix, sqldb.TableNameSessionSummaries)
+		replaceSummaryIndexWithLegacyLookup(t, ctx, db, prefix)
+
+		svc := newSummaryIntegrationService(t, dsn, prefix)
+		t.Cleanup(func() { require.NoError(t, svc.Close()) })
+		key := createSummaryIntegrationSession(t, ctx, svc)
+
+		createdAt := time.Date(2026, time.August, 14, 7, 0, 0, 0, time.UTC)
+		duplicateUpdatedAt := createdAt.Add(time.Hour)
+		insertSummaryIntegrationRow(t, ctx, db, tableName, key, "first", duplicateUpdatedAt, nil)
+		insertSummaryIntegrationRow(t, ctx, db, tableName, key, "second", duplicateUpdatedAt, nil)
+
+		sess := &session.Session{
+			ID: key.SessionID, AppName: key.AppName, UserID: key.UserID, CreatedAt: createdAt,
+		}
+		text, ok := svc.GetSessionSummaryText(ctx, sess)
+		require.True(t, ok)
+		require.Equal(t, "second", text)
+
+		summaries, err := svc.getSummariesList(ctx, []session.Key{key}, []time.Time{createdAt})
+		require.NoError(t, err)
+		require.Len(t, summaries, 1)
+		require.Equal(t, "second", summaries[0][""].Summary)
+
+		olderUpdatedAt := duplicateUpdatedAt.Add(time.Minute)
+		newerUpdatedAt := olderUpdatedAt.Add(time.Minute)
+		olderBytes := marshalSummaryIntegration(t, "older", olderUpdatedAt)
+		newerBytes := marshalSummaryIntegration(t, "newer", newerUpdatedAt)
+
+		// Publish the newer summary while holding the parent-session lock. The
+		// already-started older writer must wait, then observe and preserve it.
+		newerTx, err := db.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		require.NoError(t, svc.lockActiveSessionForSummary(ctx, newerTx, key))
+
+		olderStarted := make(chan struct{})
+		olderErr := make(chan error, 1)
+		olderDone := make(chan struct{})
+		t.Cleanup(func() {
+			select {
+			case <-olderDone:
+			case <-time.After(5 * time.Second):
+				t.Error("timed out waiting for older summary writer")
+			}
+		})
+		// Cleanups run in reverse order: release the lock before waiting for
+		// the writer, and wait for the writer before dropping its tables.
+		t.Cleanup(func() { _ = newerTx.Rollback() })
+		go func() {
+			defer close(olderDone)
+			close(olderStarted)
+			olderErr <- svc.upsertSessionSummary(ctx, key, "", olderBytes, olderUpdatedAt)
+		}()
+		<-olderStarted
+		select {
+		case err := <-olderErr:
+			require.Failf(t, "older write was not blocked", "unexpected result: %v", err)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		_, err = newerTx.ExecContext(ctx, fmt.Sprintf(
+			`UPDATE %s SET summary = ?, updated_at = ?
+			WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
+			AND deleted_at IS NULL`, tableName,
+		), string(newerBytes), newerUpdatedAt,
+			key.AppName, key.UserID, key.SessionID, "")
+		require.NoError(t, err)
+		require.NoError(t, newerTx.Commit())
+		require.NoError(t, <-olderErr)
+		requireSummaryIntegrationRows(t, ctx, db, tableName, key, "newer", newerUpdatedAt, 2)
+
+		regeneratedBytes := marshalSummaryIntegration(t, "regenerated", newerUpdatedAt)
+		require.NoError(t, svc.upsertSessionSummary(
+			ctx, key, "", regeneratedBytes, newerUpdatedAt,
+		))
+		requireSummaryIntegrationRows(t, ctx, db, tableName, key, "regenerated", newerUpdatedAt, 2)
+	})
+}
+
+func summaryIntegrationContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func mysqlIntegrationDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("TRPC_AGENT_GO_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set TRPC_AGENT_GO_MYSQL_TEST_DSN to run MySQL integration tests")
+	}
+	cfg, err := drivermysql.ParseDSN(dsn)
+	require.NoError(t, err)
+	cfg.ParseTime = true
+	cfg.Loc = time.UTC
+	return cfg.FormatDSN()
+}
+
+func prepareSummaryIntegrationSchema(
+	t *testing.T,
+	db *sql.DB,
+	dsn string,
+) string {
+	t.Helper()
+	prefix := fmt.Sprintf("it_%x_", time.Now().UnixNano())
+	t.Cleanup(func() {
+		for i := len(tableDefs) - 1; i >= 0; i-- {
+			tableName := sqldb.BuildTableName(prefix, tableDefs[i].name)
+			_, _ = db.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS `%s`", tableName))
+		}
+	})
+
+	svc := newSummaryIntegrationService(t, dsn, prefix)
+	require.NoError(t, svc.Close())
+	return prefix
+}
+
+func newSummaryIntegrationService(t *testing.T, dsn, prefix string) *Service {
+	t.Helper()
+	svc, err := NewService(
+		WithMySQLClientDSN(dsn),
+		WithTablePrefix(prefix),
+		WithSessionTTL(time.Hour),
+	)
+	require.NoError(t, err)
+	return svc
+}
+
+func replaceSummaryIndexWithLegacyUnique(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	prefix string,
+) {
+	t.Helper()
+	tableName := sqldb.BuildTableName(prefix, sqldb.TableNameSessionSummaries)
+	indexName := sqldb.BuildIndexName(
+		prefix, sqldb.TableNameSessionSummaries, sqldb.IndexSuffixUniqueActive,
+	)
+	_, err := db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE `%s` DROP INDEX `%s`", tableName, indexName))
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(
+		"ALTER TABLE `%s` ADD UNIQUE INDEX `%s` "+
+			"(app_name(191), user_id(191), session_id(191), filter_key(191), deleted_at)",
+		tableName, indexName,
+	))
+	require.NoError(t, err)
+}
+
+func replaceSummaryIndexWithLegacyLookup(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	prefix string,
+) {
+	t.Helper()
+	tableName := sqldb.BuildTableName(prefix, sqldb.TableNameSessionSummaries)
+	indexName := sqldb.BuildIndexName(
+		prefix, sqldb.TableNameSessionSummaries, sqldb.IndexSuffixUniqueActive,
+	)
+	_, err := db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE `%s` DROP INDEX `%s`", tableName, indexName))
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(
+		"ALTER TABLE `%s` ADD INDEX `%s_lookup` "+
+			"(app_name(191), user_id(191), session_id(191), deleted_at)",
+		tableName, indexName,
+	))
+	require.NoError(t, err)
+}
+
+func createSummaryIntegrationSession(
+	t *testing.T,
+	ctx context.Context,
+	svc *Service,
+) session.Key {
+	t.Helper()
+	key := session.Key{
+		AppName: "integration-app", UserID: "integration-user", SessionID: "integration-session",
+	}
+	_, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	return key
+}
+
+func insertSummaryIntegrationRow(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	tableName string,
+	key session.Key,
+	text string,
+	updatedAt time.Time,
+	deletedAt any,
+) {
+	t.Helper()
+	summaryBytes := marshalSummaryIntegration(t, text, updatedAt)
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		`INSERT INTO %s
+			(app_name, user_id, session_id, filter_key, summary, updated_at, expires_at, deleted_at)
+		VALUES (?, ?, ?, ?, ?, ?, NULL, ?)`, tableName,
+	), key.AppName, key.UserID, key.SessionID, "", string(summaryBytes), updatedAt, deletedAt)
+	require.NoError(t, err)
+}
+
+func marshalSummaryIntegration(t *testing.T, text string, updatedAt time.Time) []byte {
+	t.Helper()
+	summaryBytes, err := json.Marshal(&session.Summary{Summary: text, UpdatedAt: updatedAt})
+	require.NoError(t, err)
+	return summaryBytes
+}
+
+func requireSummaryIntegrationDeletedAtCount(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	tableName string,
+	key session.Key,
+	deletedAt time.Time,
+	want int,
+) {
+	t.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT COUNT(*) FROM %s
+		WHERE app_name = ? AND user_id = ? AND session_id = ? AND deleted_at = ?`, tableName,
+	), key.AppName, key.UserID, key.SessionID, deletedAt).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, want, count)
+}
+
+func requireSummaryIntegrationRows(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	tableName string,
+	key session.Key,
+	wantText string,
+	wantUpdatedAt time.Time,
+	wantRows int,
+) {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT summary, updated_at FROM %s
+		WHERE app_name = ? AND user_id = ? AND session_id = ? AND filter_key = ?
+		AND deleted_at IS NULL ORDER BY id`, tableName,
+	), key.AppName, key.UserID, key.SessionID, "")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var summaryBytes []byte
+		var updatedAt time.Time
+		require.NoError(t, rows.Scan(&summaryBytes, &updatedAt))
+		var sum session.Summary
+		require.NoError(t, json.Unmarshal(summaryBytes, &sum))
+		require.Equal(t, wantText, sum.Summary)
+		require.Equal(t, wantUpdatedAt, updatedAt)
+		count++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, wantRows, count)
+}

--- a/session/mysql/summary_test.go
+++ b/session/mysql/summary_test.go
@@ -52,6 +52,114 @@ func (m *mockSummarizerImpl) Metadata() map[string]any {
 	return map[string]any{}
 }
 
+func expectSummaryWrite(
+	mock sqlmock.Sqlmock,
+	sess *session.Session,
+	filterKey any,
+	active bool,
+	writeErr error,
+) {
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM session_states")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
+
+	summaryRows := sqlmock.NewRows([]string{"updated_at"})
+	if active {
+		summaryRows.AddRow(time.Unix(0, 0).UTC())
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT updated_at FROM session_summaries")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID, filterKey).
+		WillReturnRows(summaryRows)
+
+	var write *sqlmock.ExpectedExec
+	if active {
+		write = mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries")).
+			WithArgs(
+				sqlmock.AnyArg(), // summary
+				sqlmock.AnyArg(), // updated_at
+				sess.AppName,
+				sess.UserID,
+				sess.ID,
+				filterKey,
+			)
+	} else {
+		write = mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
+			WithArgs(
+				sess.AppName,
+				sess.UserID,
+				sess.ID,
+				filterKey,
+				sqlmock.AnyArg(), // summary
+				sqlmock.AnyArg(), // updated_at
+				sqlmock.AnyArg(), // expires_at
+			)
+	}
+	if writeErr != nil {
+		write.WillReturnError(writeErr)
+		mock.ExpectRollback()
+		return
+	}
+	write.WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+}
+
+func TestUpsertSessionSummarySkipsOlderCutoff(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	incomingUpdatedAt := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	persistedUpdatedAt := incomingUpdatedAt.Add(time.Minute)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM session_states")).
+		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT updated_at FROM session_summaries")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, "").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(persistedUpdatedAt))
+	mock.ExpectCommit()
+
+	err = s.upsertSessionSummary(
+		context.Background(), key, "", []byte(`{"summary":"older"}`), incomingUpdatedAt,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpsertSessionSummaryEqualCutoffLastWriteWins(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	updatedAt := time.Date(2026, time.August, 14, 8, 0, 0, 0, time.UTC)
+	summaryBytes := []byte(`{"summary":"regenerated"}`)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM session_states")).
+		WithArgs(key.AppName, key.UserID, key.SessionID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(1)))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT updated_at FROM session_summaries")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, "").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(updatedAt))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE session_summaries")).
+		WithArgs(
+			string(summaryBytes), updatedAt,
+			key.AppName, key.UserID, key.SessionID, "",
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err = s.upsertSessionSummary(context.Background(), key, "", summaryBytes, updatedAt)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestCreateSessionSummary_Success(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -69,22 +177,34 @@ func TestCreateSessionSummary_Success(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",               // filter_key
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	err = s.CreateSessionSummary(ctx, sess, "", true)
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateSessionSummary_MissingSession(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db, WithSummarizer(&fakeSummarizer{allow: true, out: "summary"}))
+	sess := &session.Session{
+		ID:      "session-123",
+		AppName: "test-app",
+		UserID:  "user-456",
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM session_states")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectRollback()
+
+	err = s.CreateSessionSummary(context.Background(), sess, "", true)
+	require.ErrorIs(t, err, errSessionNotFound)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestCreateSessionSummary_AlreadyExists(t *testing.T) {
@@ -131,18 +251,7 @@ func TestCreateSessionSummary_Force(t *testing.T) {
 	}
 
 	// With force=true, skip checking existing summary.
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",               // filter_key
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	err = s.CreateSessionSummary(ctx, sess, "", true)
 	assert.NoError(t, err)
@@ -237,7 +346,7 @@ func TestGetSessionSummaryText_Success(t *testing.T) {
 	summaryBytes, _ := json.Marshal(summary)
 
 	// Mock: Query summary
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary FROM session_summaries")).
+	mock.ExpectQuery(regexp.QuoteMeta("ORDER BY updated_at DESC, id DESC LIMIT 1")).
 		WithArgs(sess.AppName, sess.UserID, sess.ID, "", sqlmock.AnyArg(), sess.CreatedAt).
 		WillReturnRows(sqlmock.NewRows([]string{"summary"}).
 			AddRow(summaryBytes))
@@ -535,18 +644,7 @@ func TestEnqueueSummaryJob_Success(t *testing.T) {
 		Events:    []event.Event{{Timestamp: time.Now()}}, // Add event to trigger summary.
 	}
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",               // filter_key
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	err = s.EnqueueSummaryJob(ctx, sess, "", false)
 	assert.NoError(t, err)
@@ -603,18 +701,7 @@ func TestEnqueueSummaryJob_WithNotChan(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	err = s.EnqueueSummaryJob(ctx, sess, "", false)
 	assert.NoError(t, err)
@@ -681,18 +768,7 @@ func TestEnqueueSummaryJob_QueueFull(t *testing.T) {
 	sess.Events = []event.Event{{Timestamp: time.Now()}}
 
 	// Mock sync fallback processing.
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",               // filter_key
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	// Try to enqueue when queue is full - should fallback to sync.
 	err = s.EnqueueSummaryJob(ctx, sess, "", false)
@@ -739,20 +815,9 @@ func TestEnqueueSummaryJob_QueueFull_FallbackToSyncWithCascade(t *testing.T) {
 	// Total expected: "blocking", "user-messages", and "" (possibly twice).
 
 	// Use AnyArg for filterKey to match any call.
-	// We expect 2-4 INSERT calls depending on timing.
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
+	// We expect 2-4 writes depending on timing.
 	for i := 0; i < 4; i++ {
-		mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-			WithArgs(
-				sess.AppName,
-				sess.UserID,
-				sess.ID,
-				sqlmock.AnyArg(),
-				sqlmock.AnyArg(),
-				sqlmock.AnyArg(),
-				sqlmock.AnyArg(),
-			).
-			WillReturnResult(sqlmock.NewResult(1, 1))
+		expectSummaryWrite(mock, sess, sqlmock.AnyArg(), false, nil)
 	}
 
 	// Fill the queue by enqueueing a job first (queue size is 1).
@@ -806,33 +871,9 @@ func TestEnqueueSummaryJob_NoAsyncWorkers_FallbackToSyncWithCascade(t *testing.T
 	}}}
 	sess.Events = append(sess.Events, *e2)
 
-	// Mock sync processing for branch summary.
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"tool-usage",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-
-	// Mock sync processing for full-session summary (cascade).
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Mock sync processing for branch and full-session summaries.
+	expectSummaryWrite(mock, sess, "tool-usage", false, nil)
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	// EnqueueSummaryJob should fall back to sync processing with cascade.
 	err = s.EnqueueSummaryJob(ctx, sess, "tool-usage", false)
@@ -879,34 +920,9 @@ func TestEnqueueSummaryJob_SingleFilterKey_PersistsBothKeys(t *testing.T) {
 	}}}
 	sess.Events = append(sess.Events, *e2)
 
-	// Mock: First call persists filterKey="tool-usage" (LLM generates summary).
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"tool-usage",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-
-	// Mock: Second call persists filter_key="" (full-session, copied summary).
-	// This is the critical part - verifying that filter_key="" is also persisted!
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"", // filter_key="" must be persisted.
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Verify that both the filtered and full-session summaries are persisted.
+	expectSummaryWrite(mock, sess, "tool-usage", false, nil)
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	// EnqueueSummaryJob with filterKey should trigger single filterKey optimization
 	// and persist BOTH keys.
@@ -937,18 +953,7 @@ func TestEnqueueSummaryJob_FullSessionKey_NoCascade(t *testing.T) {
 	sess.Events = append(sess.Events, *e)
 
 	// Mock sync processing for full-session summary only (no cascade needed).
-	// INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	// EnqueueSummaryJob with empty filterKey should not cascade.
 	err = s.EnqueueSummaryJob(ctx, sess, "", false)
@@ -980,18 +985,7 @@ func TestCreateSessionSummary_WithFilterKey(t *testing.T) {
 
 	filterKey := "custom-filter"
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert) with custom filter key.
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			filterKey,
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, filterKey, false, nil)
 
 	err = s.CreateSessionSummary(ctx, sess, filterKey, false)
 	assert.NoError(t, err)
@@ -1041,19 +1035,8 @@ func TestCreateSessionSummary_ExistingButStale(t *testing.T) {
 	}
 	sess.Summaries = map[string]*session.Summary{"": existingSummary}
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	// ON DUPLICATE KEY UPDATE will update the existing record.
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",               // filter_key
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnResult(sqlmock.NewResult(0, 2)) // 2 rows affected indicates update.
+	// The compatibility write updates every active copy of this summary.
+	expectSummaryWrite(mock, sess, "", true, nil)
 
 	err = s.CreateSessionSummary(ctx, sess, "", false)
 	assert.NoError(t, err)
@@ -1103,18 +1086,7 @@ func TestCreateSessionSummary_UpsertError(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE fails.
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",               // filter_key
-			sqlmock.AnyArg(), // summary
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // expires_at
-		).
-		WillReturnError(fmt.Errorf("upsert error"))
+	expectSummaryWrite(mock, sess, "", false, fmt.Errorf("upsert error"))
 
 	// Use force=true to trigger upsert even with no events.
 	err = s.CreateSessionSummary(ctx, sess, "", true)
@@ -1341,18 +1313,7 @@ func TestEnqueueSummaryJob_AsyncProcessing(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	// Mock: INSERT ... ON DUPLICATE KEY UPDATE (atomic upsert).
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO session_summaries")).
-		WithArgs(
-			sess.AppName,
-			sess.UserID,
-			sess.ID,
-			"",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectSummaryWrite(mock, sess, "", false, nil)
 
 	err = s.EnqueueSummaryJob(ctx, sess, "", false)
 	require.NoError(t, err)

--- a/telemetry/langfuse/exporter.go
+++ b/telemetry/langfuse/exporter.go
@@ -120,7 +120,7 @@ func transformSpan(span *tracepb.Span) {
 
 func transformInvokeAgent(span *tracepb.Span) {
 	var newAttributes []*commonpb.KeyValue
-	var inputMessagesOTel, outputMessagesOTel *string
+	var inputMessages, inputMessagesOTel, outputMessages, outputMessagesOTel *string
 
 	newAttributes = append(newAttributes, &commonpb.KeyValue{
 		Key: observationType,
@@ -132,9 +132,11 @@ func transformInvokeAgent(span *tracepb.Span) {
 	for _, attr := range span.Attributes {
 		switch attr.Key {
 		case semconvtrace.KeyGenAIInputMessages:
+			inputMessages = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIInputMessagesOTel:
 			inputMessagesOTel = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIOutputMessages:
+			outputMessages = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIOutputMessagesOTel:
 			outputMessagesOTel = getStringPtr(attr.Value)
 			// Skip token usage attributes for InvokeAgent observations.
@@ -151,10 +153,10 @@ func transformInvokeAgent(span *tracepb.Span) {
 			newAttributes = append(newAttributes, attr)
 		}
 	}
-	if input := otelObservationInput(inputMessagesOTel); input != nil {
+	if input := preferredObservationInput(inputMessagesOTel, inputMessages); input != nil {
 		newAttributes = append(newAttributes, stringKV(observationInput, *input))
 	}
-	if output := otelObservationOutput(outputMessagesOTel); output != nil {
+	if output := preferredObservationOutput(outputMessagesOTel, outputMessages, nil); output != nil {
 		newAttributes = append(newAttributes, stringKV(observationOutput, *output))
 	}
 	span.Attributes = newAttributes
@@ -166,7 +168,9 @@ type llmSpanCollected struct {
 	sessionID          *commonpb.AnyValue
 	llmRequest         *string
 	llmResponse        *string
+	inputMessages      *string
 	inputMessagesOTel  *string
+	outputMessages     *string
 	outputMessagesOTel *string
 	toolDefinitions    *string
 	usage              usageDetails
@@ -222,9 +226,11 @@ func collectLLMSpanAttributes(attrs []*commonpb.KeyValue) llmSpanCollected {
 		case semconvtrace.KeyLLMRequest:
 			c.llmRequest = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIInputMessages:
+			c.inputMessages = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIInputMessagesOTel:
 			c.inputMessagesOTel = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIOutputMessages:
+			c.outputMessages = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIOutputMessagesOTel:
 			c.outputMessagesOTel = getStringPtr(attr.Value)
 		case semconvtrace.KeyGenAIRequestToolDefinitions:
@@ -254,6 +260,9 @@ func buildLLMObservationInput(c llmSpanCollected) string {
 	if c.inputMessagesOTel != nil && *c.inputMessagesOTel != "" {
 		return truncateObservationLLMInput(wrapWithToolsIfPresent(*c.inputMessagesOTel, c.toolDefinitions))
 	}
+	if c.inputMessages != nil && *c.inputMessages != "" {
+		return truncateObservationLLMInput(wrapWithToolsIfPresent(*c.inputMessages, c.toolDefinitions))
+	}
 	if c.llmRequest != nil && *c.llmRequest != "" {
 		if messagesJSON, ok := extractMessagesJSONFromRequestJSON(*c.llmRequest); ok && messagesJSON != "" {
 			return truncateObservationLLMInput(wrapWithToolsIfPresent(messagesJSON, c.toolDefinitions))
@@ -264,10 +273,37 @@ func buildLLMObservationInput(c llmSpanCollected) string {
 }
 
 func buildLLMObservationOutput(c llmSpanCollected) string {
-	if output := otelObservationOutput(c.outputMessagesOTel); output != nil {
+	if output := preferredObservationOutput(c.outputMessagesOTel, c.outputMessages, c.llmResponse); output != nil {
 		return *output
 	}
-	return truncateObservationLLMResponse(stringPtrValueOrNA(c.llmResponse))
+	return truncateObservationLLMResponse("N/A")
+}
+
+func preferredObservationInput(otelMessages, legacyMessages *string) *string {
+	if otelMessages != nil && *otelMessages != "" {
+		return otelObservationInput(otelMessages)
+	}
+	if legacyMessages != nil && *legacyMessages != "" {
+		value := truncateObservationLLMInput(*legacyMessages)
+		return &value
+	}
+	return nil
+}
+
+func preferredObservationOutput(otelMessages, legacyMessages, llmResponse *string) *string {
+	if otelMessages != nil && *otelMessages != "" {
+		return otelObservationOutput(otelMessages)
+	}
+	// Prefer conversation-shaped legacy output over the raw llm_response dump.
+	if legacyMessages != nil && *legacyMessages != "" {
+		value := truncateObservationLLMResponse(*legacyMessages)
+		return &value
+	}
+	if llmResponse != nil && *llmResponse != "" {
+		value := truncateObservationLLMResponse(*llmResponse)
+		return &value
+	}
+	return nil
 }
 
 func otelObservationInput(otelMessages *string) *string {
@@ -329,13 +365,6 @@ func getStringPtr(v *commonpb.AnyValue) *string {
 	}
 	s := v.GetStringValue()
 	return &s
-}
-
-func stringPtrValueOrNA(v *string) string {
-	if v == nil {
-		return "N/A"
-	}
-	return *v
 }
 
 func truncateObservationInputMessages(raw string) string {

--- a/telemetry/langfuse/exporter_test.go
+++ b/telemetry/langfuse/exporter_test.go
@@ -321,7 +321,7 @@ func TestTransformInvokeAgent(t *testing.T) {
 	}
 }
 
-func TestTransformInvokeAgent_UsesOnlyOTelMessages(t *testing.T) {
+func TestTransformInvokeAgent_PrefersOTelMessagesWithLegacyFallback(t *testing.T) {
 	legacyInput := `[{"role":"user","content":"legacy input"}]`
 	legacyOutput := `[{"index":0,"message":{"role":"assistant","content":"legacy output"},"finish_reason":"stop"}]`
 	otelInput := `[{"role":"user","parts":[{"type":"text","content":"otel input"}]}]`
@@ -363,8 +363,8 @@ func TestTransformInvokeAgent_UsesOnlyOTelMessages(t *testing.T) {
 		require.NotEqual(t, semconvtrace.KeyGenAIInputMessages, attr.Key)
 		require.NotEqual(t, semconvtrace.KeyGenAIOutputMessages, attr.Key)
 	}
-	require.NotContains(t, attrMap, observationInput)
-	require.NotContains(t, attrMap, observationOutput)
+	require.JSONEq(t, legacyInput, attrMap[observationInput])
+	require.JSONEq(t, legacyOutput, attrMap[observationOutput])
 }
 
 func TestTransformCallLLM(t *testing.T) {
@@ -479,7 +479,7 @@ func TestTransformCallLLM(t *testing.T) {
 	}
 }
 
-func TestTransformCallLLM_UsesOnlyOTelMessages(t *testing.T) {
+func TestTransformCallLLM_PrefersOTelMessagesWithLegacyFallback(t *testing.T) {
 	legacyInput := `[{"role":"user","content":"legacy input"}]`
 	legacyOutput := `[{"index":0,"message":{"role":"assistant","content":"legacy output"},"finish_reason":"stop"}]`
 	otelInput := `[{"role":"user","parts":[{"type":"text","content":"otel input"}]}]`
@@ -524,8 +524,8 @@ func TestTransformCallLLM_UsesOnlyOTelMessages(t *testing.T) {
 		require.NotEqual(t, semconvtrace.KeyGenAIInputMessages, attr.Key)
 		require.NotEqual(t, semconvtrace.KeyGenAIOutputMessages, attr.Key)
 	}
-	require.NotEqual(t, legacyInput, attrMap[observationInput])
-	require.JSONEq(t, `{"text":"raw response"}`, attrMap[observationOutput])
+	require.JSONEq(t, legacyInput, attrMap[observationInput])
+	require.JSONEq(t, legacyOutput, attrMap[observationOutput])
 }
 
 func TestTransformCallLLM_PromptWithTools(t *testing.T) {
@@ -1678,6 +1678,46 @@ func TestBuildLLMObservationInput_And_WrapWithToolsBranches(t *testing.T) {
 
 	out = buildLLMObservationInput(llmSpanCollected{})
 	require.Equal(t, "N/A", out)
+
+	legacyMsgs := `[{"role":"user","content":"legacy hello"}]`
+	withLegacy := llmSpanCollected{inputMessages: strPtr(legacyMsgs), toolDefinitions: strPtr(toolDefs)}
+	out = buildLLMObservationInput(withLegacy)
+	require.Contains(t, out, `"tools"`)
+	require.Contains(t, out, "legacy hello")
+
+	otelWins := llmSpanCollected{
+		inputMessagesOTel: strPtr(messages),
+		inputMessages:     strPtr(legacyMsgs),
+	}
+	out = buildLLMObservationInput(otelWins)
+	require.JSONEq(t, messages, out)
+}
+
+func TestBuildLLMObservationOutput_PrefersLegacyOverLLMResponse(t *testing.T) {
+	otelOutput := `[{"role":"assistant","parts":[{"type":"text","content":"otel output"}],"finish_reason":"stop"}]`
+	legacyOutput := `[{"index":0,"message":{"role":"assistant","content":"legacy output"},"finish_reason":"stop"}]`
+	llmResponse := `{"choices":[{"index":0,"message":{"role":"assistant","content":"from response"}}]}`
+
+	require.JSONEq(t, otelOutput, buildLLMObservationOutput(llmSpanCollected{
+		outputMessagesOTel: strPtr(otelOutput),
+		outputMessages:     strPtr(legacyOutput),
+		llmResponse:        strPtr(llmResponse),
+	}))
+
+	require.JSONEq(t, legacyOutput, buildLLMObservationOutput(llmSpanCollected{
+		outputMessages: strPtr(legacyOutput),
+		llmResponse:    strPtr(llmResponse),
+	}))
+
+	require.JSONEq(t, llmResponse, buildLLMObservationOutput(llmSpanCollected{
+		llmResponse: strPtr(llmResponse),
+	}))
+
+	require.Equal(t, `{"text":"raw"}`, buildLLMObservationOutput(llmSpanCollected{
+		llmResponse: strPtr(`{"text":"raw"}`),
+	}))
+
+	require.Equal(t, "N/A", buildLLMObservationOutput(llmSpanCollected{}))
 }
 
 func TestSanitizeSingleMessageForObservation_AndTruncateBytesHeadTail(t *testing.T) {


### PR DESCRIPTION
## What changed

Backport the following fixes from `main` to the `r1.11` maintenance branch:

| Original PR | Source commit | Outcome |
| --- | --- | --- |
| #2460 | `f12fc6a` | Deduplicate event persistence and automatic-summary triggering within one runner event loop. |
| #2469 | `44de8e2` | Align knowledge module requirements with released root-module versions. |
| #2476 | `3ef9ae8` | Share immutable invocation snapshots through private copy-on-write holders. |
| #2480 | `2b8fe39` | Serialize DeepSeek output limits as `max_tokens`. |
| #2474 | `ba4a78e` | Support legacy MySQL summary indexes and deterministic compatibility writes. |
| #2485 | `ca9d8e5` | Preserve compaction lineage across request transforms and invalidate stale summary bindings after provider tailoring. |
| #2486 | `7e90757` | Continue skill restaging when the best-effort chmod pass is denied. |
| #2477 | `8632c2a` | Restore Langfuse input/output fallback from legacy telemetry attributes. |

## Why

These changes address correctness, compatibility, and production regressions discovered after v1.11.1 while preserving the existing v1.11 public surface.

#2476 is included because #2485 builds its summary-view rebasing on the private copy-on-write holder introduced there. The #2479 benchmark-governance infrastructure is intentionally not backported. During the #2485 cherry-pick, `.github/benchmarks/agentloop/suites.txt` and `internal/state/summaryview/summaryview_bench_test.go` therefore remain absent from `r1.11`; all runtime code and unit tests from #2485 are retained.

## Testing

- `go build ./...`
- targeted affected-package tests across runner, summary state, request transformation, model providers, skill staging, Langfuse, and MySQL
- targeted race tests for summary rebasing, tool-call sanitization, token-tailoring observation, and LLM flow integration
- `cd test && go test ./...`
- `.github/scripts/check-examples.sh`
- `golangci-lint run --timeout=10m`
- `gofmt -r 'interface{} -> any' -l .`
- `goimports -l .`

The full root test suite was also run. Only unrelated macOS sandbox and Unix-socket environment tests failed locally; affected packages passed, and Linux CI provides the authoritative full-suite result.

## Notes for reviewers

- The branch is based on v1.11.1 (`03069cd2`).
- Every backport commit retains its original source SHA in a `cherry picked from commit` trailer.
- The 19 retained #2485 runtime and unit-test files match the upstream merge commit exactly.
- No release or v1.11.2 tag is created by this PR.
