### PR TITLE
agent/llmagent: skip hidden child trace entries

### DIFF
--- a/agent/llmagent/llm_agent.go
+++ b/agent/llmagent/llm_agent.go
@@ -1532,21 +1532,22 @@ func (a *LLMAgent) Run(ctx context.Context, invocation *agent.Invocation) (e <-c
 	a.setupInvocation(invocation)
 	var traceLease tracecapture.StepLease
 	if invocation.RunOptions.ExecutionTraceEnabled {
-		traceNodeID := agent.InvocationTraceNodeID(invocation)
-		traceCtx := agent.NewInvocationContext(ctx, invocation)
-		traceLease = tracecapture.EnsureInvocationStep(
-			traceCtx,
-			func() string {
-				return agent.StartExecutionTraceStep(
-					invocation,
-					traceNodeID,
-					llmAgentTraceInputSnapshot(invocation),
-					nil,
-				)
-			},
-		)
-		if traceLease.Owns {
-			tracecapture.SetStepNodeType(traceCtx, traceLease.StepID, "agent")
+		if traceNodeID := executionTraceStepNodeID(invocation); traceNodeID != "" {
+			traceCtx := agent.NewInvocationContext(ctx, invocation)
+			traceLease = tracecapture.EnsureInvocationStep(
+				traceCtx,
+				func() string {
+					return agent.StartExecutionTraceStep(
+						invocation,
+						traceNodeID,
+						llmAgentTraceInputSnapshot(invocation),
+						nil,
+					)
+				},
+			)
+			if traceLease.Owns {
+				tracecapture.SetStepNodeType(traceCtx, traceLease.StepID, "agent")
+			}
 		}
 	}
 	ctx = a.withWorkspace(ctx, invocation)

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -10,6 +10,7 @@ package llmagent
 
 import (
 	"context"
+	"strings"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	astructure "trpc.group/trpc-go/trpc-agent-go/agent/structure"
@@ -222,7 +223,7 @@ func (a *LLMAgent) skillToolFlagsForInvocation(
 
 // ExecutionTraceAppliedSurfaceIDs reports the effective surfaces that affected one invocation step.
 func (a *LLMAgent) ExecutionTraceAppliedSurfaceIDs(inv *agent.Invocation) []string {
-	nodeID := agent.InvocationSurfaceRootNodeID(inv)
+	nodeID := executionTraceSurfaceNodeID(inv)
 	if nodeID == "" {
 		return nil
 	}
@@ -269,6 +270,57 @@ func (a *LLMAgent) ExecutionTraceAppliedSurfaceIDs(inv *agent.Invocation) []stri
 		appliedSurfaceIDs = append(appliedSurfaceIDs, astructure.SurfaceID(nodeID, astructure.SurfaceTypeSkill))
 	}
 	return appliedSurfaceIDs
+}
+
+// executionTraceSurfaceNodeID returns the node id that can safely publish applied surfaces.
+func executionTraceSurfaceNodeID(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	nodeID := agent.InvocationSurfaceRootNodeID(inv)
+	if nodeID == "" {
+		return ""
+	}
+	if inv.GetParentInvocation() != nil {
+		if !executionTraceNodeIsUnderParent(inv) {
+			return ""
+		}
+	}
+	return nodeID
+}
+
+// executionTraceStepNodeID returns the static trace node id for an LLM step.
+func executionTraceStepNodeID(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	nodeID := agent.InvocationTraceNodeID(inv)
+	if nodeID == "" {
+		return ""
+	}
+	if inv.GetParentInvocation() != nil {
+		if !executionTraceNodeIsUnderParent(inv) {
+			return ""
+		}
+	}
+	return nodeID
+}
+
+// executionTraceNodeIsUnderParent reports whether the invocation maps to a static child node.
+func executionTraceNodeIsUnderParent(inv *agent.Invocation) bool {
+	parent := inv.GetParentInvocation()
+	if parent == nil {
+		return false
+	}
+	parentNodeID := agent.InvocationTraceNodeID(parent)
+	nodeID := agent.InvocationTraceNodeID(inv)
+	if parentNodeID == "" || nodeID == "" || nodeID == parentNodeID {
+		return false
+	}
+	if rootNodeID := agent.InvocationTeamMemberTraceRoot(inv); rootNodeID != "" {
+		return nodeID == rootNodeID || strings.HasPrefix(nodeID, rootNodeID+"/")
+	}
+	return strings.HasPrefix(nodeID, parentNodeID+"/")
 }
 
 // InvocationToolSurface returns the invocation-scoped tool surface and user tool names.

--- a/agent/llmagent/surface_runtime.go
+++ b/agent/llmagent/surface_runtime.go
@@ -222,6 +222,7 @@ func (a *LLMAgent) skillToolFlagsForInvocation(
 }
 
 // ExecutionTraceAppliedSurfaceIDs reports the effective surfaces that affected one invocation step.
+// It returns nil when a shared-trace child invocation does not map to a static child node.
 func (a *LLMAgent) ExecutionTraceAppliedSurfaceIDs(inv *agent.Invocation) []string {
 	nodeID := executionTraceSurfaceNodeID(inv)
 	if nodeID == "" {
@@ -281,10 +282,8 @@ func executionTraceSurfaceNodeID(inv *agent.Invocation) string {
 	if nodeID == "" {
 		return ""
 	}
-	if inv.GetParentInvocation() != nil {
-		if !executionTraceNodeIsUnderParent(inv) {
-			return ""
-		}
+	if executionTraceUsesParentCapture(inv) && !executionTraceNodeIsUnderParent(inv) {
+		return ""
 	}
 	return nodeID
 }
@@ -298,12 +297,18 @@ func executionTraceStepNodeID(inv *agent.Invocation) string {
 	if nodeID == "" {
 		return ""
 	}
-	if inv.GetParentInvocation() != nil {
-		if !executionTraceNodeIsUnderParent(inv) {
-			return ""
-		}
+	if executionTraceUsesParentCapture(inv) && !executionTraceNodeIsUnderParent(inv) {
+		return ""
 	}
 	return nodeID
+}
+
+// executionTraceUsesParentCapture reports whether an invocation participates in its parent's trace.
+func executionTraceUsesParentCapture(inv *agent.Invocation) bool {
+	parent := inv.GetParentInvocation()
+	return parent != nil &&
+		inv.RunOptions.ExecutionTraceEnabled &&
+		parent.RunOptions.ExecutionTraceEnabled
 }
 
 // executionTraceNodeIsUnderParent reports whether the invocation maps to a static child node.

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -197,6 +197,36 @@ func TestLLMAgent_Run_NonStaticChildInvocationDoesNotCreateTraceStep(t *testing.
 	require.Empty(t, trace.Steps)
 }
 
+func TestLLMAgent_Run_ChildWithOwnTraceCaptureReportsTraceStep(t *testing.T) {
+	m := &captureModel{}
+	agt := New(
+		"router_intent_parser",
+		WithModel(m),
+		WithInstruction("route intent"),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+		agent.WithInvocationMessage(model.NewUserMessage("hello")),
+	)
+	child := parent.Clone(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+		agent.WithInvocationMessage(model.NewUserMessage("route")),
+	)
+	ch, err := agt.Run(context.Background(), child)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotNil(t, m.got)
+	require.Nil(t, agent.BuildExecutionTrace(parent, atrace.TraceStatusCompleted))
+	trace := agent.BuildExecutionTrace(child, atrace.TraceStatusCompleted)
+	require.NotNil(t, trace)
+	require.Len(t, trace.Steps, 1)
+	require.Equal(t, "router_intent_parser", trace.Steps[0].NodeID)
+	require.Contains(t, trace.Steps[0].AppliedSurfaceIDs, "router_intent_parser#instruction")
+}
+
 func TestLLMAgent_Run_StaticChildInvocationReportsTraceStep(t *testing.T) {
 	m := &captureModel{}
 	agt := New(

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -304,6 +304,57 @@ func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesTeamMemberStaticInvocation
 	)
 }
 
+func TestExecutionTraceNodeIDHelpers_GuardAndStaticChildBranches(t *testing.T) {
+	require.Empty(t, executionTraceSurfaceNodeID(nil))
+	require.Empty(t, executionTraceStepNodeID(nil))
+	empty := agent.NewInvocation()
+	require.Empty(t, executionTraceSurfaceNodeID(empty))
+	require.Empty(t, executionTraceStepNodeID(empty))
+	require.False(t, executionTraceNodeIsUnderParent(empty))
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	sameNodeChild := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+	)
+	require.Empty(t, executionTraceSurfaceNodeID(sameNodeChild))
+	require.Empty(t, executionTraceStepNodeID(sameNodeChild))
+	staticChild := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/classify/router"),
+	)
+	require.Equal(t, "workflow/classify/router", executionTraceSurfaceNodeID(staticChild))
+	require.Equal(t, "workflow/classify/router", executionTraceStepNodeID(staticChild))
+	require.True(t, executionTraceNodeIsUnderParent(staticChild))
+	parentWithoutNode := agent.NewInvocation(
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	childWithoutParentNode := parentWithoutNode.Clone(
+		agent.WithInvocationTraceNodeID("workflow/classify/router"),
+	)
+	require.False(t, executionTraceNodeIsUnderParent(childWithoutParentNode))
+	memberChild := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/team/member"),
+	)
+	agent.SetInvocationTeamMemberTraceRoot(memberChild, "workflow/team")
+	require.True(t, executionTraceNodeIsUnderParent(memberChild))
+	require.Equal(t, "workflow/team/member", executionTraceStepNodeID(memberChild))
+	memberRootChild := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/team"),
+	)
+	agent.SetInvocationTeamMemberTraceRoot(memberRootChild, "workflow/team")
+	require.True(t, executionTraceNodeIsUnderParent(memberRootChild))
+	otherMemberChild := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/other/member"),
+	)
+	agent.SetInvocationTeamMemberTraceRoot(otherMemberChild, "workflow/team")
+	require.False(t, executionTraceNodeIsUnderParent(otherMemberChild))
+}
+
 func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesFilteredToolNames(t *testing.T) {
 	agt := New(
 		"test-agent",

--- a/agent/llmagent/surface_runtime_test.go
+++ b/agent/llmagent/surface_runtime_test.go
@@ -151,6 +151,129 @@ func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs(t *testing.T) {
 	)
 }
 
+func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_SkipsNonStaticChildInvocation(t *testing.T) {
+	agt := New(
+		"router_intent_parser",
+		WithModel(newDummyModel()),
+		WithInstruction("route intent"),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	agent.SetInvocationSurfaceRootNodeID(parent, "workflow/classify")
+	child := parent.Clone()
+	agt.setupInvocation(child)
+	require.Equal(t, "workflow/classify", agent.InvocationSurfaceRootNodeID(child))
+	require.Nil(t, agt.ExecutionTraceAppliedSurfaceIDs(child))
+}
+
+func TestLLMAgent_Run_NonStaticChildInvocationDoesNotCreateTraceStep(t *testing.T) {
+	m := &captureModel{}
+	agt := New(
+		"router_intent_parser",
+		WithModel(m),
+		WithInstruction("route intent"),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+		agent.WithInvocationMessage(model.NewUserMessage("hello")),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	child := parent.Clone(
+		agent.WithInvocationMessage(model.NewUserMessage("route")),
+	)
+	ch, err := agt.Run(context.Background(), child)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotNil(t, m.got)
+	trace := agent.BuildExecutionTrace(parent, atrace.TraceStatusCompleted)
+	require.NotNil(t, trace)
+	require.Empty(t, trace.Steps)
+}
+
+func TestLLMAgent_Run_StaticChildInvocationReportsTraceStep(t *testing.T) {
+	m := &captureModel{}
+	agt := New(
+		"router_intent_parser",
+		WithModel(m),
+		WithInstruction("route intent"),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+		agent.WithInvocationMessage(model.NewUserMessage("hello")),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	child := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/classify/router"),
+		agent.WithInvocationMessage(model.NewUserMessage("route")),
+	)
+	ch, err := agt.Run(context.Background(), child)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.NotNil(t, m.got)
+	trace := agent.BuildExecutionTrace(parent, atrace.TraceStatusCompleted)
+	require.NotNil(t, trace)
+	require.Len(t, trace.Steps, 1)
+	require.Equal(t, "workflow/classify/router", trace.Steps[0].NodeID)
+	require.Contains(t, trace.Steps[0].AppliedSurfaceIDs, "workflow/classify/router#instruction")
+}
+
+func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesStaticChildInvocation(t *testing.T) {
+	agt := New(
+		"router_intent_parser",
+		WithModel(newDummyModel()),
+		WithInstruction("route intent"),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("workflow/classify"),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	child := parent.Clone(
+		agent.WithInvocationTraceNodeID("workflow/classify/router"),
+	)
+	agt.setupInvocation(child)
+	require.Contains(
+		t,
+		agt.ExecutionTraceAppliedSurfaceIDs(child),
+		"workflow/classify/router#instruction",
+	)
+}
+
+func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesTeamMemberStaticInvocation(t *testing.T) {
+	agt := New(
+		"beta",
+		WithModel(newDummyModel()),
+		WithInstruction("member instruction"),
+	)
+	parent := agent.NewInvocation(
+		agent.WithInvocationTraceNodeID("swarm/alpha"),
+		agent.WithInvocationRunOptions(agent.NewRunOptions(
+			agent.WithExecutionTraceEnabled(true),
+		)),
+	)
+	agent.SetInvocationTeamMemberTraceRoot(parent, "swarm")
+	child := parent.Clone(
+		agent.WithInvocationTraceNodeID("swarm/beta"),
+	)
+	agt.setupInvocation(child)
+	require.Contains(
+		t,
+		agt.ExecutionTraceAppliedSurfaceIDs(child),
+		"swarm/beta#instruction",
+	)
+}
+
 func TestLLMAgent_ExecutionTraceAppliedSurfaceIDs_UsesFilteredToolNames(t *testing.T) {
 	agt := New(
 		"test-agent",

--- a/internal/teamtrace/teamtrace.go
+++ b/internal/teamtrace/teamtrace.go
@@ -10,11 +10,72 @@
 package teamtrace
 
 import (
+	"context"
+
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	istructure "trpc.group/trpc-go/trpc-agent-go/internal/structure"
 )
 
 const memberTraceRootConfigsKey = "__trpc_agent_internal_team_member_trace_root__"
+
+const memberSurfaceRootStateKey = "__trpc_agent_internal_team_member_surface_root_state__"
+
+type memberMountContextKey struct{}
+
+// CoordinatorLayout describes static coordinator-team node ids under one root.
+type CoordinatorLayout struct {
+	CoordinatorNodeID string
+	MemberNodeIDs     []string
+}
+
+// MemberMount carries the concrete node ids for one mounted Team member call.
+type MemberMount struct {
+	TraceNodeID       string
+	SurfaceRootNodeID string
+}
+
+// NewCoordinatorLayout allocates coordinator and member node ids like static export.
+func NewCoordinatorLayout(rootNodeID string, members []agent.Agent) CoordinatorLayout {
+	allocator := istructure.NewPathAllocator(rootNodeID)
+	layout := CoordinatorLayout{
+		CoordinatorNodeID: allocator.Next("coordinator"),
+	}
+	if len(members) == 0 {
+		return layout
+	}
+	layout.MemberNodeIDs = make([]string, 0, len(members))
+	for _, member := range members {
+		memberName := ""
+		if member != nil {
+			memberName = member.Info().Name
+		}
+		layout.MemberNodeIDs = append(layout.MemberNodeIDs, allocator.Next(memberName))
+	}
+	return layout
+}
+
+// ContextWithMemberMount stores one mounted Team member path in ctx.
+func ContextWithMemberMount(ctx context.Context, mount MemberMount) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if mount.TraceNodeID == "" || mount.SurfaceRootNodeID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, memberMountContextKey{}, mount)
+}
+
+// MemberMountFromContext returns one mounted Team member path from ctx.
+func MemberMountFromContext(ctx context.Context) (MemberMount, bool) {
+	if ctx == nil {
+		return MemberMount{}, false
+	}
+	mount, ok := ctx.Value(memberMountContextKey{}).(MemberMount)
+	if !ok || mount.TraceNodeID == "" || mount.SurfaceRootNodeID == "" {
+		return MemberMount{}, false
+	}
+	return mount, true
+}
 
 // RootNodeID returns the mounted surface lookup root node id for one team invocation.
 func RootNodeID(inv *agent.Invocation, teamName string) string {
@@ -46,7 +107,7 @@ func MemberNodeID(rootNodeID string, memberName string) string {
 	return istructure.JoinNodeID(rootNodeID, memberName)
 }
 
-// WithMemberTraceRoot stores the mounted team root in custom configs.
+// WithMemberTraceRoot stores the mounted execution-trace root in custom configs.
 func WithMemberTraceRoot(cfgs map[string]any, rootNodeID string) map[string]any {
 	if rootNodeID == "" {
 		return cfgs
@@ -56,7 +117,7 @@ func WithMemberTraceRoot(cfgs map[string]any, rootNodeID string) map[string]any 
 	return out
 }
 
-// MemberTraceRoot returns the mounted team root from custom configs.
+// MemberTraceRoot returns the mounted execution-trace root from custom configs.
 func MemberTraceRoot(cfgs map[string]any) string {
 	if cfgs == nil {
 		return ""
@@ -69,7 +130,7 @@ func MemberTraceRoot(cfgs map[string]any) string {
 	return rootNodeID
 }
 
-// SetMemberTraceRootForInvocation stores the mounted team root on one invocation.
+// SetMemberTraceRootForInvocation stores the mounted execution-trace root.
 func SetMemberTraceRootForInvocation(
 	inv *agent.Invocation,
 	rootNodeID string,
@@ -77,12 +138,40 @@ func SetMemberTraceRootForInvocation(
 	agent.SetInvocationTeamMemberTraceRoot(inv, rootNodeID)
 }
 
-// ClearMemberTraceRootForInvocation removes the mounted team root from one invocation.
+// ClearMemberTraceRootForInvocation removes the mounted execution-trace root.
 func ClearMemberTraceRootForInvocation(inv *agent.Invocation) {
 	agent.ClearInvocationTeamMemberTraceRoot(inv)
 }
 
-// MemberTraceRootForInvocation returns the mounted team root for one invocation.
+// SetMemberSurfaceRootForInvocation stores the mounted Team member surface root.
+func SetMemberSurfaceRootForInvocation(
+	inv *agent.Invocation,
+	rootNodeID string,
+) {
+	if inv == nil || rootNodeID == "" {
+		return
+	}
+	inv.SetState(memberSurfaceRootStateKey, rootNodeID)
+}
+
+// ClearMemberSurfaceRootForInvocation removes the mounted Team member surface root.
+func ClearMemberSurfaceRootForInvocation(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	inv.DeleteState(memberSurfaceRootStateKey)
+}
+
+// MemberSurfaceRootForInvocation returns the mounted Team member surface root.
+func MemberSurfaceRootForInvocation(inv *agent.Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	rootNodeID, _ := agent.GetStateValue[string](inv, memberSurfaceRootStateKey)
+	return rootNodeID
+}
+
+// MemberTraceRootForInvocation returns the mounted execution-trace root.
 func MemberTraceRootForInvocation(inv *agent.Invocation) string {
 	if inv == nil {
 		return ""

--- a/internal/teamtrace/teamtrace_test.go
+++ b/internal/teamtrace/teamtrace_test.go
@@ -9,12 +9,62 @@
 package teamtrace
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/internal/surfacepatch"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+type layoutAgent string
+
+func (a layoutAgent) Run(
+	context.Context,
+	*agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (a layoutAgent) Tools() []tool.Tool { return nil }
+
+func (a layoutAgent) Info() agent.Info { return agent.Info{Name: string(a)} }
+
+func (a layoutAgent) SubAgents() []agent.Agent { return nil }
+
+func (a layoutAgent) FindSubAgent(string) agent.Agent { return nil }
+
+func TestNewCoordinatorLayout_UsesStaticExportOrder(t *testing.T) {
+	layout := NewCoordinatorLayout(
+		"workflow/team",
+		[]agent.Agent{
+			layoutAgent("member/one"),
+			layoutAgent("member~two"),
+		},
+	)
+	require.Equal(t, "workflow/team/coordinator", layout.CoordinatorNodeID)
+	require.Equal(t, []string{
+		"workflow/team/member~1one",
+		"workflow/team/member~0two",
+	}, layout.MemberNodeIDs)
+}
+
+func TestMemberMountContextHelpers(t *testing.T) {
+	mount := MemberMount{
+		TraceNodeID:       "trace/team/member",
+		SurfaceRootNodeID: "surface/team/member",
+	}
+	ctx := ContextWithMemberMount(context.Background(), mount)
+	got, ok := MemberMountFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, mount, got)
+	_, ok = MemberMountFromContext(context.Background())
+	require.False(t, ok)
+}
 
 func TestRootNodeID_PrefersMountedSurfaceRoot(t *testing.T) {
 	inv := agent.NewInvocation(
@@ -80,6 +130,21 @@ func TestMemberTraceRootForInvocation_PrefersInvocationStateAndFallsBackToConfig
 
 	ClearMemberTraceRootForInvocation(inv)
 	require.Equal(t, "workflow/team/config", MemberTraceRootForInvocation(inv))
+}
+
+func TestMemberSurfaceRootForInvocation_StateHelpers(t *testing.T) {
+	var nilInv *agent.Invocation
+	SetMemberSurfaceRootForInvocation(nilInv, "workflow/team")
+	ClearMemberSurfaceRootForInvocation(nilInv)
+	require.Empty(t, MemberSurfaceRootForInvocation(nilInv))
+	inv := agent.NewInvocation()
+	require.Empty(t, MemberSurfaceRootForInvocation(inv))
+	SetMemberSurfaceRootForInvocation(inv, "workflow/team")
+	require.Equal(t, "workflow/team", MemberSurfaceRootForInvocation(inv))
+	SetMemberSurfaceRootForInvocation(inv, "")
+	require.Equal(t, "workflow/team", MemberSurfaceRootForInvocation(inv))
+	ClearMemberSurfaceRootForInvocation(inv)
+	require.Empty(t, MemberSurfaceRootForInvocation(inv))
 }
 
 func TestMemberTraceRootForInvocation_NilAndEmptyInput(t *testing.T) {

--- a/internal/teamtrace/teamtrace_test.go
+++ b/internal/teamtrace/teamtrace_test.go
@@ -53,6 +53,23 @@ func TestNewCoordinatorLayout_UsesStaticExportOrder(t *testing.T) {
 	}, layout.MemberNodeIDs)
 }
 
+func TestNewCoordinatorLayout_HandlesEmptyAndNilMembers(t *testing.T) {
+	empty := NewCoordinatorLayout("workflow/team", nil)
+	require.Equal(t, "workflow/team/coordinator", empty.CoordinatorNodeID)
+	require.Empty(t, empty.MemberNodeIDs)
+	layout := NewCoordinatorLayout(
+		"workflow/team",
+		[]agent.Agent{
+			nil,
+			layoutAgent(""),
+		},
+	)
+	require.Equal(t, []string{
+		"workflow/team/_",
+		"workflow/team/_~2",
+	}, layout.MemberNodeIDs)
+}
+
 func TestMemberMountContextHelpers(t *testing.T) {
 	mount := MemberMount{
 		TraceNodeID:       "trace/team/member",
@@ -62,7 +79,24 @@ func TestMemberMountContextHelpers(t *testing.T) {
 	got, ok := MemberMountFromContext(ctx)
 	require.True(t, ok)
 	require.Equal(t, mount, got)
+	ctx = ContextWithMemberMount(nil, mount)
+	got, ok = MemberMountFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, mount, got)
+	ctx = ContextWithMemberMount(context.Background(), MemberMount{
+		TraceNodeID: "trace/team/member",
+	})
+	_, ok = MemberMountFromContext(ctx)
+	require.False(t, ok)
+	_, ok = MemberMountFromContext(context.WithValue(
+		context.Background(),
+		memberMountContextKey{},
+		MemberMount{TraceNodeID: "trace/team/member"},
+	))
+	require.False(t, ok)
 	_, ok = MemberMountFromContext(context.Background())
+	require.False(t, ok)
+	_, ok = MemberMountFromContext(nil)
 	require.False(t, ok)
 }
 

--- a/team/structure_export.go
+++ b/team/structure_export.go
@@ -15,6 +15,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/structure"
 	istructure "trpc.group/trpc-go/trpc-agent-go/internal/structure"
+	"trpc.group/trpc-go/trpc-agent-go/internal/teamtrace"
 )
 
 // Export exports the static structure of the team.
@@ -76,15 +77,14 @@ func exportCoordinatorTeam(
 	if coordinator == nil {
 		return snapshot, nil
 	}
-	memberAllocator := istructure.NewPathAllocator(rootNodeID)
+	layout := teamtrace.NewCoordinatorLayout(rootNodeID, members)
 	coordinatorSnapshot, err := exportChild(ctx, coordinator)
 	if err != nil {
 		return nil, err
 	}
-	coordinatorPath := memberAllocator.Next("coordinator")
 	rebasedCoordinator, err := istructure.RebaseSnapshot(
 		coordinatorSnapshot,
-		coordinatorPath,
+		layout.CoordinatorNodeID,
 	)
 	if err != nil {
 		return nil, err
@@ -96,12 +96,12 @@ func exportCoordinatorTeam(
 		FromNodeID: rootNodeID,
 		ToNodeID:   rebasedCoordinator.EntryNodeID,
 	})
-	for _, member := range members {
+	for i, member := range members {
 		memberSnapshot, exportErr := exportChild(ctx, member)
 		if exportErr != nil {
 			return nil, exportErr
 		}
-		memberPath := memberAllocator.Next(member.Info().Name)
+		memberPath := layout.MemberNodeIDs[i]
 		rebasedMember, rebaseErr := istructure.RebaseSnapshot(memberSnapshot, memberPath)
 		if rebaseErr != nil {
 			return nil, rebaseErr

--- a/team/team.go
+++ b/team/team.go
@@ -198,18 +198,27 @@ func (t *Team) runCoordinator(
 	ctx context.Context,
 	invocation *agent.Invocation,
 ) (<-chan *event.Event, error) {
-	if t.coordinator == nil {
+	t.mu.RLock()
+	name := t.name
+	coordinator := t.coordinator
+	members := append([]agent.Agent(nil), t.members...)
+	t.mu.RUnlock()
+	if coordinator == nil {
 		return nil, errors.New("coordinator is nil")
 	}
-	rootNodeID := teamtrace.RootNodeID(invocation, t.name)
-	teamtrace.SetMemberTraceRootForInvocation(invocation, rootNodeID)
+	traceRootNodeID := teamtrace.TraceRootNodeID(invocation, name)
+	surfaceRootNodeID := teamtrace.RootNodeID(invocation, name)
+	surfaceLayout := teamtrace.NewCoordinatorLayout(surfaceRootNodeID, members)
+	teamtrace.SetMemberTraceRootForInvocation(invocation, traceRootNodeID)
+	teamtrace.SetMemberSurfaceRootForInvocation(invocation, surfaceRootNodeID)
 	agent.SetInvocationSurfaceRootNodeID(
 		invocation,
-		teamtrace.CoordinatorNodeID(rootNodeID),
+		surfaceLayout.CoordinatorNodeID,
 	)
-	coordinatorEventCh, err := t.coordinator.Run(ctx, invocation)
+	coordinatorEventCh, err := coordinator.Run(ctx, invocation)
 	if err != nil {
 		agent.ClearInvocationSurfaceRootNodeID(invocation)
+		teamtrace.ClearMemberSurfaceRootForInvocation(invocation)
 		teamtrace.ClearMemberTraceRootForInvocation(invocation)
 		return nil, err
 	}
@@ -223,13 +232,20 @@ func wrapCoordinatorInvocationState(
 	invocation *agent.Invocation,
 	src <-chan *event.Event,
 ) <-chan *event.Event {
-	if invocation == nil || src == nil {
+	if invocation == nil {
 		return src
+	}
+	if src == nil {
+		agent.ClearInvocationSurfaceRootNodeID(invocation)
+		teamtrace.ClearMemberSurfaceRootForInvocation(invocation)
+		teamtrace.ClearMemberTraceRootForInvocation(invocation)
+		return nil
 	}
 	out := make(chan *event.Event)
 	go func() {
 		defer close(out)
 		defer teamtrace.ClearMemberTraceRootForInvocation(invocation)
+		defer teamtrace.ClearMemberSurfaceRootForInvocation(invocation)
 		defer agent.ClearInvocationSurfaceRootNodeID(invocation)
 		for evt := range src {
 			out <- evt
@@ -476,15 +492,21 @@ func newMemberToolSet(
 	members []agent.Agent,
 ) tool.ToolSet {
 	scope := agentToolHistoryScope(cfg.historyScope)
+	memberList := append([]agent.Agent(nil), members...)
 	tools := make([]tool.Tool, 0, len(members))
-	for _, m := range members {
-		tools = append(tools, agenttool.NewTool(
+	for i, m := range members {
+		agentTool := agenttool.NewTool(
 			m,
 			agenttool.WithSkipSummarization(cfg.skipSummarization),
 			agenttool.WithStreamInner(cfg.streamInner),
 			agenttool.WithInnerTextMode(cfg.innerTextMode),
 			agenttool.WithHistoryScope(scope),
-		))
+		)
+		tools = append(tools, &mountedMemberTool{
+			Tool:        agentTool,
+			memberIndex: i,
+			members:     memberList,
+		})
 	}
 	return &staticToolSet{name: cfg.name, tools: tools}
 }
@@ -517,6 +539,57 @@ func (s *staticToolSet) Tools(context.Context) []tool.Tool {
 func (s *staticToolSet) Close() error { return nil }
 
 func (s *staticToolSet) Name() string { return s.name }
+
+type mountedMemberTool struct {
+	*agenttool.Tool
+	memberIndex int
+	members     []agent.Agent
+}
+
+func (t *mountedMemberTool) Call(ctx context.Context, jsonArgs []byte) (any, error) {
+	return t.Tool.Call(t.mountContext(ctx), jsonArgs)
+}
+
+func (t *mountedMemberTool) StreamableCall(
+	ctx context.Context,
+	jsonArgs []byte,
+) (*tool.StreamReader, error) {
+	return t.Tool.StreamableCall(t.mountContext(ctx), jsonArgs)
+}
+
+func (t *mountedMemberTool) mountContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	mount, ok := t.memberMount(ctx)
+	if !ok {
+		return ctx
+	}
+	return teamtrace.ContextWithMemberMount(ctx, mount)
+}
+
+func (t *mountedMemberTool) memberMount(ctx context.Context) (teamtrace.MemberMount, bool) {
+	parentInv, ok := agent.InvocationFromContext(ctx)
+	if !ok || parentInv == nil {
+		return teamtrace.MemberMount{}, false
+	}
+	traceRootNodeID := teamtrace.MemberTraceRootForInvocation(parentInv)
+	surfaceRootNodeID := teamtrace.MemberSurfaceRootForInvocation(parentInv)
+	if traceRootNodeID == "" || surfaceRootNodeID == "" {
+		return teamtrace.MemberMount{}, false
+	}
+	traceLayout := teamtrace.NewCoordinatorLayout(traceRootNodeID, t.members)
+	surfaceLayout := teamtrace.NewCoordinatorLayout(surfaceRootNodeID, t.members)
+	if t.memberIndex < 0 ||
+		t.memberIndex >= len(traceLayout.MemberNodeIDs) ||
+		t.memberIndex >= len(surfaceLayout.MemberNodeIDs) {
+		return teamtrace.MemberMount{}, false
+	}
+	return teamtrace.MemberMount{
+		TraceNodeID:       traceLayout.MemberNodeIDs[t.memberIndex],
+		SurfaceRootNodeID: surfaceLayout.MemberNodeIDs[t.memberIndex],
+	}, true
+}
 
 func wireSwarmRoster(members []agent.Agent) error {
 	setters := make([]agent.SubAgentSetter, 0, len(members))

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -13,6 +13,7 @@ package team
 import (
 	"context"
 	"errors"
+	"io"
 	"regexp"
 	"strings"
 	"sync"
@@ -977,6 +978,72 @@ func TestWrapCoordinatorInvocationState_Guards(t *testing.T) {
 	var recvOnly <-chan *event.Event = src
 	require.Equal(t, recvOnly, wrapCoordinatorInvocationState(nil, src))
 	require.Nil(t, wrapCoordinatorInvocationState(agent.NewInvocation(), nil))
+}
+
+func TestMountedMemberTool_MemberMountGuards(t *testing.T) {
+	member := testAgent{name: testMemberNameOne}
+	wrapped := &mountedMemberTool{
+		memberIndex: 0,
+		members:     []agent.Agent{member},
+	}
+	ctx := wrapped.mountContext(nil)
+	require.NotNil(t, ctx)
+	_, ok := teamtrace.MemberMountFromContext(ctx)
+	require.False(t, ok)
+	parent := agent.NewInvocation()
+	ctx = agent.NewInvocationContext(context.Background(), parent)
+	_, ok = wrapped.memberMount(ctx)
+	require.False(t, ok)
+	teamtrace.SetMemberTraceRootForInvocation(parent, "trace/team")
+	_, ok = wrapped.memberMount(ctx)
+	require.False(t, ok)
+	teamtrace.SetMemberSurfaceRootForInvocation(parent, "surface/team")
+	mount, ok := wrapped.memberMount(ctx)
+	require.True(t, ok)
+	require.Equal(t, "trace/team/member_one", mount.TraceNodeID)
+	require.Equal(t, "surface/team/member_one", mount.SurfaceRootNodeID)
+	outOfRange := &mountedMemberTool{
+		memberIndex: 1,
+		members:     []agent.Agent{member},
+	}
+	_, ok = outOfRange.memberMount(ctx)
+	require.False(t, ok)
+	negative := &mountedMemberTool{
+		memberIndex: -1,
+		members:     []agent.Agent{member},
+	}
+	_, ok = negative.memberMount(ctx)
+	require.False(t, ok)
+}
+
+func TestMountedMemberTool_StreamableCallAppliesMemberMount(t *testing.T) {
+	member := &traceRecordingAgent{name: testMemberNameOne}
+	wrapped := &mountedMemberTool{
+		Tool: agenttool.NewTool(
+			member,
+			agenttool.WithStreamInner(true),
+		),
+		memberIndex: 0,
+		members:     []agent.Agent{member},
+	}
+	parent := agent.NewInvocation(
+		agent.WithInvocationSession(session.NewSession(testAppName, testUserID, testSessionID)),
+	)
+	teamtrace.SetMemberTraceRootForInvocation(parent, "trace/team")
+	teamtrace.SetMemberSurfaceRootForInvocation(parent, "surface/team")
+	ctx := agent.NewInvocationContext(context.Background(), parent)
+	reader, err := wrapped.StreamableCall(ctx, []byte(testToolArgs))
+	require.NoError(t, err)
+	defer reader.Close()
+	for {
+		_, err = reader.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+	require.Equal(t, "trace/team/member_one", member.gotTraceNodeID)
+	require.Equal(t, "surface/team/member_one", member.gotSurfaceRootNodeID)
 }
 
 func TestTeam_RunSwarm_PreservesRunStructuredOutput(t *testing.T) {

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -895,7 +895,7 @@ func TestTeam_RunCoordinator_MemberToolUsesMemberSurfaceRootNodeID(t *testing.T)
 	}
 	require.Equal(t, "workflow/team", coordinator.gotTraceNodeID)
 	require.Equal(t, "workflow/team/coordinator", coordinator.gotSurfaceRootNodeID)
-	require.Equal(t, testMemberNameOne, member.gotTraceNodeID)
+	require.Equal(t, "workflow/team/member_one", member.gotTraceNodeID)
 	require.Equal(t, "workflow/team/member_one", member.gotSurfaceRootNodeID)
 }
 
@@ -2182,6 +2182,7 @@ func TestRunnerRun_WithSurfacePatchForNode_AppliesCoordinatorAndMemberPatches(
 		"user-team",
 		"session-team",
 		model.NewUserMessage("team input"),
+		agent.WithExecutionTraceEnabled(true),
 		agent.WithSurfacePatchForNode(coordinatorNodeID, coordinatorPatch),
 		agent.WithSurfacePatchForNode(memberNodeID, memberPatch),
 	)
@@ -2202,6 +2203,21 @@ func TestRunnerRun_WithSurfacePatchForNode_AppliesCoordinatorAndMemberPatches(
 		t,
 		teamFirstSystemMessageContent(memberPatched.LatestRequest().messages),
 		"member patched instruction",
+	)
+	require.NotNil(t, completion.ExecutionTrace)
+	var memberStepSurfaces []string
+	for _, step := range completion.ExecutionTrace.Steps {
+		if step.NodeID != memberNodeID {
+			continue
+		}
+		memberStepSurfaces = step.AppliedSurfaceIDs
+		break
+	}
+	require.NotNil(t, memberStepSurfaces)
+	require.Contains(
+		t,
+		memberStepSurfaces,
+		structure.SurfaceID(memberNodeID, structure.SurfaceTypeInstruction),
 	)
 }
 

--- a/team/team_test.go
+++ b/team/team_test.go
@@ -860,7 +860,7 @@ func TestTeam_RunCoordinator_PreservesCustomInvocationState(t *testing.T) {
 	require.Equal(t, "value", value)
 }
 
-func TestTeam_RunCoordinator_MemberToolUsesMemberSurfaceRootNodeID(t *testing.T) {
+func TestTeam_RunCoordinator_MemberToolSeparatesTraceAndSurfaceRoots(t *testing.T) {
 	member := &traceRecordingAgent{name: testMemberNameOne}
 	coordinator := &testCoordinator{name: testCoordinatorName}
 	coordinator.runFunc = func(
@@ -885,6 +885,53 @@ func TestTeam_RunCoordinator_MemberToolUsesMemberSurfaceRootNodeID(t *testing.T)
 	inv := agent.NewInvocation(
 		agent.WithInvocationAgent(tm),
 		agent.WithInvocationSession(session.NewSession(testAppName, testUserID, testSessionID)),
+		agent.WithInvocationTraceNodeID("workflow/trace/team"),
+		agent.WithInvocationRunOptions(agent.RunOptions{
+			CustomAgentConfigs: surfacepatch.WithRootNodeID(
+				nil,
+				"workflow/surface/team",
+			),
+		}),
+		agent.WithInvocationMessage(model.NewUserMessage(testUserMessage)),
+	)
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	ch, err := tm.Run(ctx, inv)
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.Equal(t, "workflow/trace/team", coordinator.gotTraceNodeID)
+	require.Equal(t, "workflow/surface/team/coordinator", coordinator.gotSurfaceRootNodeID)
+	require.Equal(t, "workflow/trace/team/member_one", member.gotTraceNodeID)
+	require.Equal(t, "workflow/surface/team/member_one", member.gotSurfaceRootNodeID)
+}
+
+func TestTeam_RunCoordinator_DoesNotMountOrdinaryAgentToolAsMember(t *testing.T) {
+	member := &traceRecordingAgent{name: testMemberNameOne}
+	helper := &traceRecordingAgent{name: "helper"}
+	helperTool := agenttool.NewTool(helper)
+	coordinator := &testCoordinator{name: testCoordinatorName}
+	coordinator.runFunc = func(
+		ctx context.Context,
+		_ *agent.Invocation,
+		toolSets []tool.ToolSet,
+	) (<-chan *event.Event, error) {
+		_, err := helperTool.Call(ctx, []byte(testToolArgs))
+		require.NoError(t, err)
+		tools := itool.NewNamedToolSet(toolSets[0]).Tools(ctx)
+		_, err = tools[0].(tool.CallableTool).Call(ctx, []byte(testToolArgs))
+		require.NoError(t, err)
+		ch := make(chan *event.Event, 1)
+		go func() {
+			defer close(ch)
+			ch <- event.New("done", coordinator.name)
+		}()
+		return ch, nil
+	}
+	tm, err := New(coordinator, []agent.Agent{member})
+	require.NoError(t, err)
+	inv := agent.NewInvocation(
+		agent.WithInvocationAgent(tm),
+		agent.WithInvocationSession(session.NewSession(testAppName, testUserID, testSessionID)),
 		agent.WithInvocationTraceNodeID("workflow/team"),
 		agent.WithInvocationMessage(model.NewUserMessage(testUserMessage)),
 	)
@@ -893,10 +940,8 @@ func TestTeam_RunCoordinator_MemberToolUsesMemberSurfaceRootNodeID(t *testing.T)
 	require.NoError(t, err)
 	for range ch {
 	}
-	require.Equal(t, "workflow/team", coordinator.gotTraceNodeID)
-	require.Equal(t, "workflow/team/coordinator", coordinator.gotSurfaceRootNodeID)
+	require.Equal(t, "helper", helper.gotTraceNodeID)
 	require.Equal(t, "workflow/team/member_one", member.gotTraceNodeID)
-	require.Equal(t, "workflow/team/member_one", member.gotSurfaceRootNodeID)
 }
 
 func TestTeam_RunCoordinator_ClearsMountedRootsOnCoordinatorError(t *testing.T) {
@@ -908,6 +953,7 @@ func TestTeam_RunCoordinator_ClearsMountedRootsOnCoordinatorError(t *testing.T) 
 	) (<-chan *event.Event, error) {
 		require.Equal(t, "workflow/team/coordinator", agent.InvocationSurfaceRootNodeID(inv))
 		require.Equal(t, "workflow/team", teamtrace.MemberTraceRootForInvocation(inv))
+		require.Equal(t, "workflow/team", teamtrace.MemberSurfaceRootForInvocation(inv))
 		return nil, errors.New("coordinator failed")
 	}
 	tm, err := New(coordinator, []agent.Agent{testAgent{name: testMemberNameOne}})
@@ -923,6 +969,7 @@ func TestTeam_RunCoordinator_ClearsMountedRootsOnCoordinatorError(t *testing.T) 
 	require.EqualError(t, err, "coordinator failed")
 	require.Equal(t, "workflow/team", agent.InvocationSurfaceRootNodeID(inv))
 	require.Empty(t, teamtrace.MemberTraceRootForInvocation(inv))
+	require.Empty(t, teamtrace.MemberSurfaceRootForInvocation(inv))
 }
 
 func TestWrapCoordinatorInvocationState_Guards(t *testing.T) {

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -565,19 +565,6 @@ func parentInvocationWithLiveSession(
 	return view
 }
 
-func (at *Tool) memberNodeIDForParentInvocation(
-	parentInv *agent.Invocation,
-) string {
-	if parentInv == nil || at.agent == nil {
-		return ""
-	}
-	rootNodeID := teamtrace.MemberTraceRootForInvocation(parentInv)
-	if rootNodeID == "" {
-		return ""
-	}
-	return teamtrace.MemberNodeID(rootNodeID, at.agent.Info().Name)
-}
-
 func (at *Tool) childInvocationOptions(
 	ctx context.Context,
 	parentInv *agent.Invocation,
@@ -638,12 +625,12 @@ func (at *Tool) childInvocationOptions(
 			inv.RunOptions = runOptions
 		})
 	}
-	if memberNodeID := at.memberNodeIDForParentInvocation(parentInv); memberNodeID != "" {
+	if mount, ok := teamtrace.MemberMountFromContext(ctx); ok {
 		invocationOpts = append(
 			invocationOpts,
-			agent.WithInvocationTraceNodeID(memberNodeID),
+			agent.WithInvocationTraceNodeID(mount.TraceNodeID),
 			func(inv *agent.Invocation) {
-				agent.SetInvocationSurfaceRootNodeID(inv, memberNodeID)
+				agent.SetInvocationSurfaceRootNodeID(inv, mount.SurfaceRootNodeID)
 			},
 		)
 	}

--- a/tool/agent/agent_tool.go
+++ b/tool/agent/agent_tool.go
@@ -565,7 +565,7 @@ func parentInvocationWithLiveSession(
 	return view
 }
 
-func (at *Tool) surfaceRootNodeIDForParentInvocation(
+func (at *Tool) memberNodeIDForParentInvocation(
 	parentInv *agent.Invocation,
 ) string {
 	if parentInv == nil || at.agent == nil {
@@ -638,11 +638,12 @@ func (at *Tool) childInvocationOptions(
 			inv.RunOptions = runOptions
 		})
 	}
-	if surfaceRootNodeID := at.surfaceRootNodeIDForParentInvocation(parentInv); surfaceRootNodeID != "" {
+	if memberNodeID := at.memberNodeIDForParentInvocation(parentInv); memberNodeID != "" {
 		invocationOpts = append(
 			invocationOpts,
+			agent.WithInvocationTraceNodeID(memberNodeID),
 			func(inv *agent.Invocation) {
-				agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
+				agent.SetInvocationSurfaceRootNodeID(inv, memberNodeID)
 			},
 		)
 	}

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -3683,20 +3683,18 @@ func TestTool_StreamableCall_FlushesParentSession(t *testing.T) {
 	}
 }
 
-func TestTool_StreamableCall_PropagatesSurfaceRootNodeID(t *testing.T) {
+func TestTool_StreamableCall_AppliesMemberMountFromContext(t *testing.T) {
 	sa := &streamingMockAgent{name: "stream-agent"}
 	at := NewTool(sa, WithStreamInner(true))
 	parent := agent.NewInvocation(
 		agent.WithInvocationSession(session.NewSession("app", "user", "session")),
 		agent.WithInvocationEventFilterKey("parent-agent"),
-		agent.WithInvocationRunOptions(agent.RunOptions{
-			CustomAgentConfigs: teamtrace.WithMemberTraceRoot(
-				nil,
-				"workflow/team",
-			),
-		}),
 	)
-	ctx := agent.NewInvocationContext(context.Background(), parent)
+	var ctx context.Context = agent.NewInvocationContext(context.Background(), parent)
+	ctx = teamtrace.ContextWithMemberMount(ctx, teamtrace.MemberMount{
+		TraceNodeID:       "workflow/team/stream-agent",
+		SurfaceRootNodeID: "workflow/surface/team/stream-agent",
+	})
 	reader, err := at.StreamableCall(ctx, []byte(`{"request":"hi"}`))
 	require.NoError(t, err)
 	defer reader.Close()
@@ -3708,7 +3706,7 @@ func TestTool_StreamableCall_PropagatesSurfaceRootNodeID(t *testing.T) {
 		require.NoError(t, recvErr)
 	}
 	require.Equal(t, "workflow/team/stream-agent", sa.seenTraceNodeID)
-	require.Equal(t, "workflow/team/stream-agent", sa.seenSurfaceRootNodeID)
+	require.Equal(t, "workflow/surface/team/stream-agent", sa.seenSurfaceRootNodeID)
 }
 
 func TestTool_StreamableCall_NotifiesCompletion(t *testing.T) {

--- a/tool/agent/agent_tool_test.go
+++ b/tool/agent/agent_tool_test.go
@@ -2512,12 +2512,14 @@ type streamingMockAgent struct {
 	name string
 	// capture the event filter key seen by Run for assertion.
 	seenFilterKey         string
+	seenTraceNodeID       string
 	seenSurfaceRootNodeID string
 }
 
 func (m *streamingMockAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
 	// record the filter key used so tests can assert it equals agent name.
 	m.seenFilterKey = inv.GetEventFilterKey()
+	m.seenTraceNodeID = agent.InvocationTraceNodeID(inv)
 	m.seenSurfaceRootNodeID = agent.InvocationSurfaceRootNodeID(inv)
 	ch := make(chan *event.Event, 3)
 	go func() {
@@ -3705,6 +3707,7 @@ func TestTool_StreamableCall_PropagatesSurfaceRootNodeID(t *testing.T) {
 		}
 		require.NoError(t, recvErr)
 	}
+	require.Equal(t, "workflow/team/stream-agent", sa.seenTraceNodeID)
 	require.Equal(t, "workflow/team/stream-agent", sa.seenSurfaceRootNodeID)
 }
 


### PR DESCRIPTION
This keeps LLM execution trace reporting aligned with the exported static structure by only creating child invocation trace steps and applied surface IDs when the invocation maps to a static child node, while preserving static child and team member traces.