### PR TITLE
model/anthropic: emit empty properties for object tools

### DIFF
--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -1087,9 +1087,16 @@ func convertTools(tools map[string]tool.Tool) []anthropic.ToolUnionParam {
 	var result []anthropic.ToolUnionParam
 	for _, t := range toolorder.SortedTools(tools) {
 		declaration := t.Declaration()
+		effectiveSchemaType := declaration.InputSchema.Type
+		// The Anthropic SDK marshals an empty type as "object". Use that
+		// effective type when normalizing properties so a typed nil map does
+		// not become JSON null for an implicit object schema.
+		if effectiveSchemaType == "" {
+			effectiveSchemaType = "object"
+		}
 		properties := declaration.InputSchema.Properties
 		// Some Anthropic-compatible endpoints reject null properties for object schemas.
-		if declaration.InputSchema.Type == "object" && properties == nil {
+		if effectiveSchemaType == "object" && properties == nil {
 			properties = map[string]*tool.Schema{}
 		}
 		result = append(result, anthropic.ToolUnionParam{

--- a/model/anthropic/anthropic.go
+++ b/model/anthropic/anthropic.go
@@ -1087,13 +1087,18 @@ func convertTools(tools map[string]tool.Tool) []anthropic.ToolUnionParam {
 	var result []anthropic.ToolUnionParam
 	for _, t := range toolorder.SortedTools(tools) {
 		declaration := t.Declaration()
+		properties := declaration.InputSchema.Properties
+		// Some Anthropic-compatible endpoints reject null properties for object schemas.
+		if declaration.InputSchema.Type == "object" && properties == nil {
+			properties = map[string]*tool.Schema{}
+		}
 		result = append(result, anthropic.ToolUnionParam{
 			OfTool: &anthropic.ToolParam{
 				Name:        declaration.Name,
 				Description: anthropic.String(buildToolDescription(declaration)),
 				InputSchema: anthropic.ToolInputSchemaParam{
 					Type:       constant.Object(declaration.InputSchema.Type),
-					Properties: declaration.InputSchema.Properties,
+					Properties: properties,
 					Required:   declaration.InputSchema.Required,
 				},
 			},

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -359,6 +359,20 @@ func Test_convertTools(t *testing.T) {
 	assert.Equal(t, "t1", params[0].OfTool.Name)
 }
 
+func Test_convertTools_NoArgObjectSchemaUsesEmptyProperties(t *testing.T) {
+	params := convertTools(map[string]tool.Tool{
+		"no_arg_tool": stubTool{decl: &tool.Declaration{
+			Name:        "no_arg_tool",
+			InputSchema: &tool.Schema{Type: "object"},
+		}},
+	})
+
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"properties":{}`)
+	require.NotContains(t, string(body), `"properties":null`)
+}
+
 func Test_buildToolDescription_AppendsOutputSchema(t *testing.T) {
 	schema := &tool.Schema{
 		Type: "object",

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -360,17 +360,38 @@ func Test_convertTools(t *testing.T) {
 }
 
 func Test_convertTools_NoArgObjectSchemaUsesEmptyProperties(t *testing.T) {
-	params := convertTools(map[string]tool.Tool{
-		"no_arg_tool": stubTool{decl: &tool.Declaration{
-			Name:        "no_arg_tool",
-			InputSchema: &tool.Schema{Type: "object"},
-		}},
-	})
+	tests := []struct {
+		name        string
+		inputSchema *tool.Schema
+	}{
+		{
+			name:        "explicit object type",
+			inputSchema: &tool.Schema{Type: "object"},
+		},
+		{
+			name:        "implicit SDK object type",
+			inputSchema: &tool.Schema{},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			params := convertTools(map[string]tool.Tool{
+				"no_arg_tool": stubTool{decl: &tool.Declaration{
+					Name:        "no_arg_tool",
+					InputSchema: tt.inputSchema,
+				}},
+			})
 
-	body, err := json.Marshal(params)
-	require.NoError(t, err)
-	require.Contains(t, string(body), `"properties":{}`)
-	require.NotContains(t, string(body), `"properties":null`)
+			body, err := json.Marshal(params)
+			require.NoError(t, err)
+			require.Contains(t, string(body), `"properties":{}`)
+			require.NotContains(t, string(body), `"properties":null`)
+			require.Contains(t, string(body), `"type":"object"`)
+			require.Equal(t, tt.inputSchema.Type, string(params[0].OfTool.InputSchema.Type))
+			require.Nil(t, tt.inputSchema.Properties)
+		})
+	}
 }
 
 func Test_buildToolDescription_AppendsOutputSchema(t *testing.T) {

--- a/model/anthropic/anthropic_test.go
+++ b/model/anthropic/anthropic_test.go
@@ -361,16 +361,27 @@ func Test_convertTools(t *testing.T) {
 
 func Test_convertTools_NoArgObjectSchemaUsesEmptyProperties(t *testing.T) {
 	tests := []struct {
-		name        string
-		inputSchema *tool.Schema
+		name                string
+		inputSchema         *tool.Schema
+		wantEmptyProperties bool
+		wantSerializedType  string
 	}{
 		{
-			name:        "explicit object type",
-			inputSchema: &tool.Schema{Type: "object"},
+			name:                "explicit object type",
+			inputSchema:         &tool.Schema{Type: "object"},
+			wantEmptyProperties: true,
+			wantSerializedType:  "object",
 		},
 		{
-			name:        "implicit SDK object type",
-			inputSchema: &tool.Schema{},
+			name:                "implicit SDK object type",
+			inputSchema:         &tool.Schema{},
+			wantEmptyProperties: true,
+			wantSerializedType:  "object",
+		},
+		{
+			name:               "non-object type",
+			inputSchema:        &tool.Schema{Type: "array"},
+			wantSerializedType: "array",
 		},
 	}
 	for _, tt := range tests {
@@ -385,9 +396,14 @@ func Test_convertTools_NoArgObjectSchemaUsesEmptyProperties(t *testing.T) {
 
 			body, err := json.Marshal(params)
 			require.NoError(t, err)
-			require.Contains(t, string(body), `"properties":{}`)
-			require.NotContains(t, string(body), `"properties":null`)
-			require.Contains(t, string(body), `"type":"object"`)
+			if tt.wantEmptyProperties {
+				require.Contains(t, string(body), `"properties":{}`)
+				require.NotContains(t, string(body), `"properties":null`)
+			} else {
+				require.Contains(t, string(body), `"properties":null`)
+				require.NotContains(t, string(body), `"properties":{}`)
+			}
+			require.Contains(t, string(body), `"type":"`+tt.wantSerializedType+`"`)
 			require.Equal(t, tt.inputSchema.Type, string(params[0].OfTool.InputSchema.Type))
 			require.Nil(t, tt.inputSchema.Properties)
 		})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Write the pull request title and description in English.

The title must identify the primary affected package or repository area.

Preferred form:
  package: lowercase summary

For multiple equally affected packages:
  {package/a, package/b}: lowercase summary

For a coherent cross-cutting change spanning many packages with no primary
package:
  lsc: lowercase summary
-->

## What changed

Ensure Anthropic tool definitions serialize no-argument object schemas with
`properties: {}` instead of `properties: null`.

This covers both schemas that explicitly use the object type and schemas whose
empty type defaults to object during Anthropic SDK serialization. Existing
non-empty properties and non-object schemas remain unchanged.

## Why

### Reproduction

1. Configure the Anthropic model adapter with
   `https://api.deepseek.com/anthropic` as the base URL.
2. Attach an MCP server containing a no-argument tool, such as
   `chrome-devtools-mcp`'s `list_pages`.
3. Send any model request.

Before this change, the tool schema is serialized as:

```json
{
  "type": "object",
  "properties": null
}
```

DeepSeek rejects the request:

```text
400 Bad Request: Invalid schema for function 'list_pages':
null is not of type "object"
```

The expected schema is:

```json
{
  "type": "object",
  "properties": {}
}
```

### Root cause

An empty MCP `properties` object can become a nil
`tool.Schema.Properties` map during schema conversion.

`convertTools` passes that typed nil map to
`anthropic.ToolInputSchemaParam.Properties`, whose type is `any`. The
Anthropic SDK consequently serializes it as JSON `null`.

The SDK also serializes an empty `ToolInputSchemaParam.Type` as `"object"`.
Without using that effective type during normalization, a zero-value
`&tool.Schema{}` still produces `"properties":null`.

The fix derives the SDK-effective schema type before normalizing nil properties
for object schemas. It preserves the original type in callback-visible SDK
parameters.

## Testing

- Added regression coverage verifying that:
  - explicit object schemas with nil properties serialize as `"properties":{}`;
  - zero-value schemas serialize as `"type":"object"` with `"properties":{}`;
  - non-object schemas with nil properties retain `"properties":null`.
- Ran `go test . -count=1` in `model/anthropic`.
- Ran `go vet .` in `model/anthropic`.
- Manually verified a minimal zero-value no-argument tool request:
  - The framework input schema was `{}` with nil properties.
  - The outgoing Anthropic schema was
    `{"properties":{},"type":"object"}`.
  - DeepSeek's Anthropic-compatible endpoint accepted the request without the
    previous 400 response.
- Ran a manual `chrome-devtools-mcp@1.7.0` integration check:
  - Started the MCP server through the stdio transport.
  - Launched an isolated headless Chrome instance.
  - Successfully called the real `list_pages` tool and received
    `about:blank [selected]`.
  - Confirmed the MCP schema was converted from an object schema with nil
    properties to an Anthropic input schema containing `properties: {}`.
  - Sent a real request containing the converted tool definition to DeepSeek's
    Anthropic-compatible endpoint, which accepted it.

## Notes for reviewers

No public Go API changes. The wire-format change is limited to replacing
`properties: null` with `properties: {}` for explicit or SDK-defaulted object
schemas whose properties map is nil.

Non-object schemas and existing non-empty properties remain unchanged. The
original schema type remains unchanged in callback-visible SDK parameters.

Fixes #2500
