### PR TITLE
llmflow: surface context compaction outcomes

### DIFF
--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -170,6 +170,21 @@ func (s *summaryPartialFailureService) Calls() int {
 	return s.calls
 }
 
+func captureWarningLogs(t *testing.T) func() string {
+	t.Helper()
+	var warnings []string
+	oldWarnfContext := log.WarnfContext
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.WarnfContext = oldWarnfContext
+	})
+	return func() string {
+		return strings.Join(warnings, "\n")
+	}
+}
+
 func TestSummarySnapshotAdvancedUsesBoundary(t *testing.T) {
 	cutoff := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	sess := &session.Session{
@@ -909,14 +924,7 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T)
 	modelName := "compact-retry-summary-error"
 	model.RegisterModelContextWindow(modelName, 10000)
 	const sensitiveErrorText = "sensitive summary provider content"
-	var warnings []string
-	oldWarnfContext := log.WarnfContext
-	log.WarnfContext = func(_ context.Context, format string, args ...any) {
-		warnings = append(warnings, fmt.Sprintf(format, args...))
-	}
-	t.Cleanup(func() {
-		log.WarnfContext = oldWarnfContext
-	})
+	warningLogs := captureWarningLogs(t)
 
 	baseSvc := inmemory.NewSessionService()
 	t.Cleanup(func() {
@@ -978,10 +986,44 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T)
 
 	require.Equal(t, 1, service.Calls())
 	require.Same(t, req, rebuilt)
-	logged := strings.Join(warnings, "\n")
+	logged := warningLogs()
 	require.Contains(t, logged, "outcome=summary_error")
 	require.NotContains(t, logged, sensitiveErrorText)
 	require.NotContains(t, logged, "post_request_tokens=0")
+}
+
+func TestRunContextCompactionLogsRebuildUnavailable(t *testing.T) {
+	warningLogs := captureWarningLogs(t)
+	service := &summaryInjectingService{}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationSessionService(service),
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("history"),
+		model.NewUserMessage("current"),
+	}}
+	decision := contextCompactionDecision{
+		shouldCompact: true,
+		tokenCount:    3000,
+		threshold:     2000,
+		contextWindow: 4000,
+	}
+
+	rebuilt := new(Flow).runContextCompaction(
+		context.Background(),
+		inv,
+		nil,
+		req,
+		&contextCompactionRebuildPlan{},
+		decision,
+	)
+
+	require.Same(t, req, rebuilt)
+	logged := warningLogs()
+	require.Contains(t, logged, "outcome=rebuild_unavailable")
+	require.Contains(t, logged, "post_request_tokens=3000")
 }
 
 func TestMaybeCompactContextBeforeLLM_RebuildsWithoutReplayingEarlierProcessors(t *testing.T) {

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -170,6 +170,30 @@ func (s *summaryPartialFailureService) Calls() int {
 	return s.calls
 }
 
+type postRebuildFailingTokenCounter struct {
+	rangeCalls int
+}
+
+func (c *postRebuildFailingTokenCounter) CountTokens(
+	context.Context,
+	model.Message,
+) (int, error) {
+	return 1, nil
+}
+
+func (c *postRebuildFailingTokenCounter) CountTokensRange(
+	context.Context,
+	[]model.Message,
+	int,
+	int,
+) (int, error) {
+	c.rangeCalls++
+	if c.rangeCalls == 1 {
+		return 3000, nil
+	}
+	return 0, errors.New("post-rebuild token count failed")
+}
+
 func captureWarningLogs(t *testing.T) func() string {
 	t.Helper()
 	var warnings []string
@@ -532,6 +556,60 @@ func TestMaybeCompactContextBeforeLLM_RebuildsRequestWithSummary(t *testing.T) {
 	require.Equal(t, "completed", doneDiagnostic.Status)
 	require.NotNil(t, doneDiagnostic.Updated)
 	require.True(t, *doneDiagnostic.Updated)
+}
+
+func TestMaybeCompactContextBeforeLLM_LogsPostCountError(t *testing.T) {
+	modelName := "compact-retry-post-count-error"
+	model.RegisterModelContextWindow(modelName, 10000)
+	warningLogs := captureWarningLogs(t)
+	service := &summaryInjectingService{}
+	sess := &session.Session{Events: []event.Event{{
+		RequestID: "req-old",
+		Timestamp: time.Now().Add(-time.Hour),
+		Response: &model.Response{
+			Done: true,
+			Choices: []model.Choice{{
+				Message: model.NewUserMessage("history"),
+			}},
+		},
+	}}}
+	counter := &postRebuildFailingTokenCounter{}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+	)
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+				processor.WithContextCompactionTokenCounter(counter),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		nil,
+		req,
+		rebuildPlan,
+	)
+
+	require.NotSame(t, req, rebuilt)
+	require.Equal(t, 2, counter.rangeCalls)
+	logged := warningLogs()
+	require.Contains(t, logged, "outcome=post_count_error")
+	require.Contains(t, logged, "post_request_tokens=-1")
+	require.NotContains(t, logged, "outcome=success")
 }
 
 func TestMaybeCompactContextBeforeLLM_SummarizesSanitizedOrphanToolCall(

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -11,6 +11,7 @@ package llmflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/calllimit"
 	"trpc.group/trpc-go/trpc-agent-go/internal/flow/processor"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
@@ -906,6 +908,15 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryInjectionDisabled(t *testi
 func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T) {
 	modelName := "compact-retry-summary-error"
 	model.RegisterModelContextWindow(modelName, 10000)
+	const sensitiveErrorText = "sensitive summary provider content"
+	var warnings []string
+	oldWarnfContext := log.WarnfContext
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.WarnfContext = oldWarnfContext
+	})
 
 	baseSvc := inmemory.NewSessionService()
 	t.Cleanup(func() {
@@ -914,7 +925,7 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T)
 
 	service := &summaryFailingService{
 		Service: baseSvc,
-		err:     context.DeadlineExceeded,
+		err:     errors.New(sensitiveErrorText),
 	}
 	longContent := strings.Repeat("history ", 2000)
 	sess := &session.Session{
@@ -967,6 +978,10 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T)
 
 	require.Equal(t, 1, service.Calls())
 	require.Same(t, req, rebuilt)
+	logged := strings.Join(warnings, "\n")
+	require.Contains(t, logged, "outcome=summary_error")
+	require.NotContains(t, logged, sensitiveErrorText)
+	require.NotContains(t, logged, "post_request_tokens=0")
 }
 
 func TestMaybeCompactContextBeforeLLM_RebuildsWithoutReplayingEarlierProcessors(t *testing.T) {

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1726,7 +1726,6 @@ func (f *Flow) runContextCompaction(
 		outcome string,
 		result *model.Request,
 		postRequestTokens int,
-		err error,
 	) {
 		var viewBound bool
 		var viewItems int
@@ -1734,15 +1733,11 @@ func (f *Flow) runContextCompaction(
 			viewBound = view.Bound
 			viewItems = len(view.Items)
 		}
-		var errText string
-		if err != nil {
-			errText = err.Error()
-		}
 		format := "Pre-LLM context compaction result: outcome=%s, agent=%s, " +
 			"filter_key=%q, request_tokens=%d, threshold=%d, " +
 			"context_window=%d, messages=%d->%d, post_request_tokens=%d, " +
 			"summary_view_present=%t, summary_view_bound=%t, " +
-			"summary_view_items=%d, duration_ms=%d, error=%q"
+			"summary_view_items=%d, duration_ms=%d"
 		args := []any{
 			outcome,
 			invocation.AgentName,
@@ -1757,7 +1752,6 @@ func (f *Flow) runContextCompaction(
 			viewBound,
 			viewItems,
 			time.Since(startedAt).Milliseconds(),
-			errText,
 		}
 		if outcome == contextCompactionOutcomeSuccess {
 			log.InfofContext(ctx, format, args...)
@@ -1803,7 +1797,7 @@ func (f *Flow) runContextCompaction(
 		if err != nil {
 			outcome = contextCompactionOutcomeSummaryError
 		}
-		logResult(outcome, decisionRequest, 0, err)
+		logResult(outcome, decisionRequest, decision.tokenCount)
 		return req
 	}
 
@@ -1825,8 +1819,7 @@ func (f *Flow) runContextCompaction(
 		logResult(
 			contextCompactionOutcomeRebuildUnavailable,
 			decisionRequest,
-			0,
-			nil,
+			decision.tokenCount,
 		)
 		return req
 	}
@@ -1861,7 +1854,6 @@ func (f *Flow) runContextCompaction(
 			contextCompactionOutcomePersistenceError,
 			postDecisionRequest,
 			postDecision.tokenCount,
-			err,
 		)
 		return rebuilt
 	}
@@ -1870,7 +1862,6 @@ func (f *Flow) runContextCompaction(
 		contextCompactionOutcomeSuccess,
 		postDecisionRequest,
 		postDecision.tokenCount,
-		nil,
 	)
 	return rebuilt
 }

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -77,6 +77,7 @@ const (
 	contextCompactionOutcomeSummaryError       = "summary_error"
 	contextCompactionOutcomeRebuildUnavailable = "rebuild_unavailable"
 	contextCompactionOutcomePersistenceError   = "persistence_error"
+	contextCompactionOutcomePostCountError     = "post_count_error"
 )
 
 // InvocationHasFilteredUserTools reports whether the cached filtered tool
@@ -1834,6 +1835,7 @@ func (f *Flow) runContextCompaction(
 		f.contextCompactionThresholdRatio,
 		rebuildPlan.contentProcessor.ContextCompactionConfig.TokenCounter,
 	)
+	postRequestTokens := postDecision.tokenCount
 	if postDecision.err == nil {
 		summaryview.Finalize(
 			invocation,
@@ -1847,22 +1849,23 @@ func (f *Flow) runContextCompaction(
 			invocation.AgentName,
 			postDecision.err,
 		)
+		postRequestTokens = -1
 	}
 
 	if err != nil {
 		logResult(
 			contextCompactionOutcomePersistenceError,
 			postDecisionRequest,
-			postDecision.tokenCount,
+			postRequestTokens,
 		)
 		return rebuilt
 	}
 
-	logResult(
-		contextCompactionOutcomeSuccess,
-		postDecisionRequest,
-		postDecision.tokenCount,
-	)
+	outcome := contextCompactionOutcomeSuccess
+	if postDecision.err != nil {
+		outcome = contextCompactionOutcomePostCountError
+	}
+	logResult(outcome, postDecisionRequest, postRequestTokens)
 	return rebuilt
 }
 

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -71,6 +71,12 @@ const (
 	defaultContextCompactionThresholdRatio = 0.7
 	contextCompactionFallbackWindow        = 8192
 	contextCompactionMinTokens             = 2000
+
+	contextCompactionOutcomeSuccess            = "success"
+	contextCompactionOutcomeNoUpdate           = "no_update"
+	contextCompactionOutcomeSummaryError       = "summary_error"
+	contextCompactionOutcomeRebuildUnavailable = "rebuild_unavailable"
+	contextCompactionOutcomePersistenceError   = "persistence_error"
 )
 
 // InvocationHasFilteredUserTools reports whether the cached filtered tool
@@ -1682,6 +1688,7 @@ func (f *Flow) runContextCompaction(
 	rebuildPlan *contextCompactionRebuildPlan,
 	decision contextCompactionDecision,
 ) *model.Request {
+	startedAt := time.Now()
 	decisionRequest := requestWithCallLimitFinalizationMessage(
 		req,
 		rebuildPlan.callLimitFinalizationMessage,
@@ -1711,8 +1718,52 @@ func (f *Flow) runContextCompaction(
 		contextCompactionAttrs(decision, decisionRequest)...,
 	)
 	summaryCtx = summary.ContextWithCacheSafeForkRequest(summaryCtx, req)
-	if view, ok := summaryview.Snapshot(invocation); ok {
+	view, viewPresent := summaryview.Snapshot(invocation)
+	if viewPresent {
 		summaryCtx = summaryview.ContextWithView(summaryCtx, view)
+	}
+	logResult := func(
+		outcome string,
+		result *model.Request,
+		postRequestTokens int,
+		err error,
+	) {
+		var viewBound bool
+		var viewItems int
+		if viewPresent && view != nil {
+			viewBound = view.Bound
+			viewItems = len(view.Items)
+		}
+		var errText string
+		if err != nil {
+			errText = err.Error()
+		}
+		format := "Pre-LLM context compaction result: outcome=%s, agent=%s, " +
+			"filter_key=%q, request_tokens=%d, threshold=%d, " +
+			"context_window=%d, messages=%d->%d, post_request_tokens=%d, " +
+			"summary_view_present=%t, summary_view_bound=%t, " +
+			"summary_view_items=%d, duration_ms=%d, error=%q"
+		args := []any{
+			outcome,
+			invocation.AgentName,
+			filterKey,
+			decision.tokenCount,
+			decision.threshold,
+			decision.contextWindow,
+			len(decisionRequest.Messages),
+			len(result.Messages),
+			postRequestTokens,
+			viewPresent,
+			viewBound,
+			viewItems,
+			time.Since(startedAt).Milliseconds(),
+			errText,
+		}
+		if outcome == contextCompactionOutcomeSuccess {
+			log.InfofContext(ctx, format, args...)
+			return
+		}
+		log.WarnfContext(ctx, format, args...)
 	}
 	err := invocation.SessionService.CreateSessionSummary(
 		summaryCtx,
@@ -1748,14 +1799,11 @@ func (f *Flow) runContextCompaction(
 		},
 	)
 	if !updated {
+		outcome := contextCompactionOutcomeNoUpdate
 		if err != nil {
-			log.DebugfContext(
-				ctx,
-				"Pre-LLM context compaction skipped for agent %s: %v",
-				invocation.AgentName,
-				err,
-			)
+			outcome = contextCompactionOutcomeSummaryError
 		}
+		logResult(outcome, decisionRequest, 0, err)
 		return req
 	}
 
@@ -1774,10 +1822,11 @@ func (f *Flow) runContextCompaction(
 	}
 	finishLatencySpan(rebuildSpan, rebuildStarted, nil)
 	if rebuilt == nil {
-		log.DebugfContext(
-			ctx,
-			"Pre-LLM context compaction skipped for agent %s: safe rebuild unavailable",
-			invocation.AgentName,
+		logResult(
+			contextCompactionOutcomeRebuildUnavailable,
+			decisionRequest,
+			0,
+			nil,
 		)
 		return req
 	}
@@ -1808,19 +1857,20 @@ func (f *Flow) runContextCompaction(
 	}
 
 	if err != nil {
-		log.WarnfContext(
-			ctx,
-			"Pre-LLM context compaction rebuilt request for agent %s after in-memory summary update; persistence failed: %v",
-			invocation.AgentName,
+		logResult(
+			contextCompactionOutcomePersistenceError,
+			postDecisionRequest,
+			postDecision.tokenCount,
 			err,
 		)
 		return rebuilt
 	}
 
-	log.DebugfContext(
-		ctx,
-		"Pre-LLM context compaction rebuilt request for agent %s",
-		invocation.AgentName,
+	logResult(
+		contextCompactionOutcomeSuccess,
+		postDecisionRequest,
+		postDecision.tokenCount,
+		nil,
 	)
 	return rebuilt
 }
@@ -2518,6 +2568,18 @@ func (f *Flow) callLLM(
 		func(record imodelrequest.TokenTailoringRecord) {
 			summaryview.InvalidateBinding(invocation)
 			summaryfork.Invalidate(invocation)
+			if tokenTailoringCollapsedHistory(record) {
+				log.WarnfContext(
+					ctx,
+					"Model request token tailoring collapsed history: "+
+						"provider=%s, max_input_tokens=%d, messages=%d->%d",
+					record.Provider,
+					record.MaxInputTokens,
+					record.BeforeMessages,
+					record.AfterMessages,
+				)
+				return
+			}
 			log.DebugfContext(
 				ctx,
 				"Model request token tailoring applied: provider=%s, "+
@@ -2543,6 +2605,12 @@ func (f *Flow) callLLM(
 		})
 	}
 	return ctx, seq, true, nil
+}
+
+func tokenTailoringCollapsedHistory(
+	record imodelrequest.TokenTailoringRecord,
+) bool {
+	return record.BeforeMessages > 2 && record.AfterMessages <= 2
 }
 
 func withResponseSeqFinalizer(

--- a/internal/flow/llmflow/llmflow_bench_test.go
+++ b/internal/flow/llmflow/llmflow_bench_test.go
@@ -16,8 +16,10 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	imodelrequest "trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
@@ -69,6 +71,35 @@ func (m *benchIterModel) GenerateContentIter(ctx context.Context, request *model
 
 func (m *benchIterModel) Info() model.Info {
 	return model.Info{Name: "benchIterModel"}
+}
+
+type benchTailoringIterModel struct {
+	record *imodelrequest.TokenTailoringRecord
+}
+
+func (m *benchTailoringIterModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	ch := make(chan *model.Response)
+	close(ch)
+	return ch, nil
+}
+
+func (m *benchTailoringIterModel) GenerateContentIter(
+	ctx context.Context,
+	_ *model.Request,
+) (model.Seq[*model.Response], error) {
+	if m.record != nil {
+		imodelrequest.RecordTokenTailoring(ctx, *m.record)
+	}
+	return func(yield func(*model.Response) bool) {
+		yield(&model.Response{Done: true})
+	}, nil
+}
+
+func (m *benchTailoringIterModel) Info() model.Info {
+	return model.Info{Name: "benchTailoringIterModel"}
 }
 
 func makeBenchResponses(n int) []*model.Response {
@@ -185,5 +216,78 @@ func BenchmarkStreamingResponseProcessorUpdateMetricsState(b *testing.B) {
 				processor.updateMetricsState()
 			}
 		})
+	}
+}
+
+func BenchmarkCallLLMTokenTailoringDiagnostics(b *testing.B) {
+	oldDebugfContext := log.DebugfContext
+	oldInfofContext := log.InfofContext
+	oldWarnfContext := log.WarnfContext
+	log.DebugfContext = func(context.Context, string, ...any) {}
+	log.InfofContext = func(context.Context, string, ...any) {}
+	log.WarnfContext = func(context.Context, string, ...any) {}
+	b.Cleanup(func() {
+		log.DebugfContext = oldDebugfContext
+		log.InfofContext = oldInfofContext
+		log.WarnfContext = oldWarnfContext
+	})
+
+	for _, messageCount := range []int{16, 256} {
+		messages := make([]model.Message, messageCount)
+		items := make([]summaryview.Item, 0, messageCount-2)
+		for i := range messages {
+			messages[i] = model.NewUserMessage("benchmark model-visible history")
+			if i > 0 && i < messageCount-1 {
+				items = append(items, summaryview.Item{
+					Message:      messages[i],
+					RequestIndex: i,
+				})
+			}
+		}
+		request := &model.Request{Messages: messages}
+
+		for _, tc := range []struct {
+			name   string
+			record *imodelrequest.TokenTailoringRecord
+		}{
+			{name: "Unchanged"},
+			{
+				name: "Collapsed",
+				record: &imodelrequest.TokenTailoringRecord{
+					Provider:       "bench.Model",
+					MaxInputTokens: 1024,
+					BeforeMessages: messageCount,
+					AfterMessages:  2,
+				},
+			},
+		} {
+			b.Run(fmt.Sprintf("%s/Messages=%d", tc.name, messageCount), func(b *testing.B) {
+				ctx := context.Background()
+				callModel := &benchTailoringIterModel{record: tc.record}
+				invocation := agent.NewInvocation(
+					agent.WithInvocationModel(callModel),
+				)
+				summaryview.AttachProjection(invocation, &summaryview.View{
+					ContentRequestLength: len(messages),
+					Items:                items,
+				})
+				f := new(Flow)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, seq, _, err := f.callLLM(
+						ctx,
+						invocation,
+						request,
+						callModel,
+					)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchCountSink, benchRespSink = consumeSeq(seq)
+				}
+			})
+		}
 	}
 }

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -1060,6 +1060,7 @@ func TestCallLLM_TokenTailoringInvalidatesSummarySnapshots(t *testing.T) {
 	req := &model.Request{Messages: []model.Message{
 		model.NewSystemMessage("stable"),
 		model.NewUserMessage("history"),
+		model.NewUserMessage("current"),
 	}}
 	summaryview.AttachProjection(inv, &summaryview.View{
 		ContentRequestLength: len(req.Messages),

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -1095,6 +1095,7 @@ func TestTokenTailoringCollapsedHistory(t *testing.T) {
 	}{
 		{name: "many messages collapse to two", before: 16, after: 2, want: true},
 		{name: "many messages collapse to one", before: 16, after: 1, want: true},
+		{name: "three messages collapse to two", before: 3, after: 2, want: true},
 		{name: "two messages remain one", before: 2, after: 1, want: false},
 		{name: "history remains", before: 16, after: 3, want: false},
 	}

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -1086,6 +1086,30 @@ func TestCallLLM_TokenTailoringInvalidatesSummarySnapshots(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestTokenTailoringCollapsedHistory(t *testing.T) {
+	tests := []struct {
+		name   string
+		before int
+		after  int
+		want   bool
+	}{
+		{name: "many messages collapse to two", before: 16, after: 2, want: true},
+		{name: "many messages collapse to one", before: 16, after: 1, want: true},
+		{name: "two messages remain one", before: 2, after: 1, want: false},
+		{name: "history remains", before: 16, after: 3, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := imodelrequest.TokenTailoringRecord{
+				BeforeMessages: tt.before,
+				AfterMessages:  tt.after,
+			}
+			require.Equal(t, tt.want, tokenTailoringCollapsedHistory(record))
+		})
+	}
+}
+
 func TestCallLLM_LazyTokenTailoringFinalizesDiagnosticsAfterIteration(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## What changed

Surface synchronous pre-LLM context-compaction outcomes at the default log level and warn when provider token tailoring collapses a multi-message history to at most two messages.

Compaction logs report stable outcome values (`success`, `no_update`, `summary_error`, `rebuild_unavailable`, `persistence_error`, and `post_count_error`) together with counts and summary-view state. An unavailable post-compaction token count is reported as `-1`. Logs do not include message, summary, or raw error content. Successful compactions use Info; non-success outcomes and severe history collapse use Warn. Ordinary token tailoring remains Debug.

## Why

Synchronous context compaction could previously fail or produce no summary with only Debug output, while a later provider-side request rewrite could make a multi-turn conversation look like a first query. Operators could not distinguish these stages without enabling latency diagnostics. These logs make the result observable without changing application options or adding hooks.

The normal no-compaction path remains log-free. The compaction result log runs only after the compaction threshold has triggered, and the new tailoring warning runs only when a provider reports an actual collapse to at most two messages.

## Testing

- `go build ./...`
- `go test ./internal/flow/llmflow -count=1`
- `go test -race ./internal/flow/llmflow -count=1`
- `golangci-lint run --timeout=10m ./internal/flow/llmflow/...`
- `go test ./internal/flow/llmflow -run '^$' -bench '^BenchmarkCallLLMTokenTailoringDiagnostics$' -benchmem -count=5 -benchtime=200ms`
- `go test ./... -count=1` completed with 10,109 passing tests and 14 environment-dependent sandbox failures because the available bubblewrap 0.3.3 does not support the required options.
- Codecov patch coverage: 100% (target: 85%).

The benchmark was first run against `upstream/main` and then after the logging change. Allocation results were unchanged in every case:

| Scenario | `upstream/main` | This PR |
| --- | --- | --- |
| Unchanged, 16 messages | 31,951 B/op, 125 allocs/op | 31,951 B/op, 125 allocs/op |
| Collapsed, 16 messages | 29,848 B/op, 91 allocs/op | 29,848 B/op, 91 allocs/op |
| Unchanged, 256 messages | ~546.9 KB/op, 1,804 allocs/op | ~546.9 KB/op, 1,804 allocs/op |
| Collapsed, 256 messages | ~508.1 KB/op, 1,052 allocs/op | ~508.1 KB/op, 1,052 allocs/op |

Runtime measurements remained within run-to-run noise.

## Notes for reviewers

No public API, default option, persistence format, or protocol behavior changes. The existing summary-view snapshot is reused; no additional request or history copy is introduced.
