### PR TITLE
docs: remove stale link to deleted filetoolset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,6 @@ Not sure where to start? Pick a path by what you want to build:
 - [examples/agenttool](examples/agenttool) – Wrap agents as callable tools.
 - [examples/multitools](examples/multitools) – Multiple tools orchestration.
 - [examples/duckduckgo](examples/duckduckgo) – Web search tool integration.
-- [examples/filetoolset](examples/filetoolset) – File operations as tools.
 - [examples/fileinput](examples/fileinput) – Provide files as inputs.
 - [examples/agenttool](examples/agenttool) shows streaming and non-streaming
   patterns.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -508,7 +508,6 @@ _ = mr.Cancel(requestID)
 - [examples/agenttool](examples/agenttool) – 将 agent 封装为可调用的 tool。
 - [examples/multitools](examples/multitools) – 多工具编排。
 - [examples/duckduckgo](examples/duckduckgo) – Web 搜索工具集成。
-- [examples/filetoolset](examples/filetoolset) – 文件操作作为工具。
 - [examples/fileinput](examples/fileinput) – 以文件作为输入。
 - [examples/agenttool](examples/agenttool) 展示了流式与非流式模式。
 


### PR DESCRIPTION
## What changed

Removed the `examples/filetoolset` entry from the example list in `README.md` and `README.zh_CN.md`.

## Why

The `examples/filetoolset` directory was removed in #349, but the README links to it were left behind and now point to a non-existent path.

## Testing

- `grep -rn filetoolset README.md README.zh_CN.md` returns no matches.
- Verified the surrounding list structure remains well-formed in both files.

## Notes for reviewers

Trivial docs cleanup; no issue associated (per CONTRIBUTING guidance for trivial changes).
