### PR TITLE
{evaluation, server/promptiter, docs}: add no-loss stop

### DIFF
--- a/docs/mkdocs/en/promptiter.md
+++ b/docs/mkdocs/en/promptiter.md
@@ -1138,17 +1138,20 @@ type StopPolicy struct {
 	MaxRoundsWithoutAcceptance int
 	// TargetScore is the target validation score after which the run can stop. nil means disabled.
 	TargetScore *float64
+	// StopOnNoTrainLosses stops after training-set evaluation produces no extracted losses.
+	StopOnNoTrainLosses bool
 }
 ```
 
 Stop decisions are executed in the following order.
 
-1. Stop when the current round reaches `MaxRounds`.
-2. Stop when consecutive non-accepted rounds reach `MaxRoundsWithoutAcceptance`.
-3. Stop when the current baseline validation score reaches `TargetScore`.
-4. Otherwise, continue to the next round.
+1. Stop before Backward when `StopOnNoTrainLosses` is enabled and the current training-set evaluation produces no extracted losses.
+2. Stop when the current round reaches `MaxRounds`.
+3. Stop when consecutive non-accepted rounds reach `MaxRoundsWithoutAcceptance`.
+4. Stop when the current baseline validation score reaches `TargetScore`.
+5. Otherwise, continue to the next round.
 
-`MaxRounds` itself is a required constraint in `RunRequest` and must be greater than 0. When `TargetScore` is `nil`, the target-score stop condition is not enabled.
+`MaxRounds` itself is a required constraint in `RunRequest` and must be greater than 0. When `TargetScore` is `nil`, the target-score stop condition is not enabled. `StopOnNoTrainLosses` defaults to `false`, preserving the historical behavior where empty-loss rounds continue through no-op candidate validation.
 
 ### RunRequest
 
@@ -1258,6 +1261,8 @@ type OptimizerOptions struct {
 ```
 
 `RunRequest` first specifies training sets and validation sets. `Train` is used to produce optimization signals, and `Validation` is used for acceptance decisions. Both must be non-empty. Each `EvalSetInput` can point to a complete evaluation set or use `EvalCaseIDs` to run only part of its evaluation cases. `LossHints` and `LossTargets` only serve the training set. They respectively supplement known business-side problem reasons and specify trace nodes where failed metric losses start backward propagation.
+
+`StopPolicy.StopOnNoTrainLosses` ends a run early when training-set evaluation no longer produces usable optimization signals. When it triggers, the round result keeps `Train`, `Losses`, and `Stop`, but does not write `Backward`, `Aggregation`, `Patches`, `OutputProfile`, `Validation`, or `Acceptance`.
 
 `InitialProfile` specifies the starting Profile of this iteration. If it is not passed, PromptIter uses the original surface values in the structure snapshot as the initial baseline. If `InitialProfile` is passed and `StructureID` is non-empty, it must match the current structure snapshot ID.
 

--- a/docs/mkdocs/zh/promptiter.md
+++ b/docs/mkdocs/zh/promptiter.md
@@ -1145,17 +1145,20 @@ type StopPolicy struct {
 	MaxRoundsWithoutAcceptance int
 	// TargetScore 是达到后即可停止的目标验证分数，nil 表示不启用。
 	TargetScore                *float64
+	// StopOnNoTrainLosses 在训练集评估未提取出 loss 时停止。
+	StopOnNoTrainLosses        bool
 }
 ```
 
 停止判定按以下顺序执行。
 
-1. 当前轮数达到 `MaxRounds`，停止
-2. 连续未接受轮数达到 `MaxRoundsWithoutAcceptance`，停止
-3. 当前基准的验证分数达到 `TargetScore`，停止
-4. 否则继续下一轮
+1. 启用 `StopOnNoTrainLosses` 且本轮训练集评估未提取出 loss，在 Backward 前停止
+2. 当前轮数达到 `MaxRounds`，停止
+3. 连续未接受轮数达到 `MaxRoundsWithoutAcceptance`，停止
+4. 当前基准的验证分数达到 `TargetScore`，停止
+5. 否则继续下一轮
 
-`MaxRounds` 本身是 `RunRequest` 的必填约束，必须大于 0。`TargetScore` 为 `nil` 时不会触发目标分数停止条件。
+`MaxRounds` 本身是 `RunRequest` 的必填约束，必须大于 0。`TargetScore` 为 `nil` 时不会触发目标分数停止条件。`StopOnNoTrainLosses` 默认为 `false`，保持空 loss 轮次继续执行 no-op 候选验证的历史行为。
 
 ### RunRequest
 
@@ -1265,6 +1268,8 @@ type OptimizerOptions struct {
 ```
 
 `RunRequest` 首先指定训练集和验证集。`Train` 用于产生优化信号，`Validation` 用于接受判定，二者均不能为空。每个 `EvalSetInput` 可以指向完整评估集，也可以通过 `EvalCaseIDs` 只运行其中部分评估用例。`LossHints` 和 `LossTargets` 只服务于训练集，分别用于补充业务侧已知的问题原因，以及指定失败指标 loss 开始反向传播的 trace 节点。
+
+`StopPolicy.StopOnNoTrainLosses` 用于在训练集评估已经没有可用优化信号时提前结束。触发时，本轮结果会保留 `Train`、`Losses` 和 `Stop`，但不会写入 `Backward`、`Aggregation`、`Patches`、`OutputProfile`、`Validation` 或 `Acceptance`。
 
 `InitialProfile` 用于指定本次迭代的起始 Profile。未传入时，PromptIter 使用结构快照中的原始 surface 值作为起始基线。传入 `InitialProfile` 时，如果 `StructureID` 非空，需要与当前结构快照 ID 一致。
 

--- a/evaluation/workflow/promptiter/engine/engine.go
+++ b/evaluation/workflow/promptiter/engine/engine.go
@@ -287,20 +287,24 @@ func (e *engine) run(
 		if err != nil {
 			return nil, err
 		}
-		if roundResult.Acceptance.Accepted {
-			acceptedProfile = roundResult.OutputProfile
-			acceptedValidationScore = effectiveScore
-			roundsWithoutAcceptance = 0
-		} else {
-			roundsWithoutAcceptance++
+		if roundResult.Acceptance != nil {
+			if roundResult.Acceptance.Accepted {
+				acceptedProfile = roundResult.OutputProfile
+				acceptedValidationScore = effectiveScore
+				roundsWithoutAcceptance = 0
+			} else {
+				roundsWithoutAcceptance++
+			}
 		}
-		roundResult.Stop = e.stop(
-			roundNumber,
-			request.MaxRounds,
-			request.StopPolicy,
-			roundsWithoutAcceptance,
-			effectiveScore,
-		)
+		if roundResult.Stop == nil {
+			roundResult.Stop = e.stop(
+				roundNumber,
+				request.MaxRounds,
+				request.StopPolicy,
+				roundsWithoutAcceptance,
+				effectiveScore,
+			)
+		}
 		accepted := roundResult.Acceptance != nil && roundResult.Acceptance.Accepted
 		acceptanceReason := ""
 		scoreDelta := 0.0
@@ -430,6 +434,10 @@ func (e *engine) executeRound(
 	roundResult.Losses = losses
 	if err := appendRunEvent(ctx, observer, EventKindRoundLosses, roundNumber, losses); err != nil {
 		return nil, 0, err
+	}
+	if decision := stopOnNoTrainLosses(request.StopPolicy, len(losses)); decision != nil {
+		roundResult.Stop = decision
+		return roundResult, acceptedValidationScore, nil
 	}
 	backwardResult, err := e.backward(
 		ctx,

--- a/evaluation/workflow/promptiter/engine/engine_test.go
+++ b/evaluation/workflow/promptiter/engine/engine_test.go
@@ -520,6 +520,107 @@ func TestRunAcceptsFirstRoundAndStopsAfterRejectedNextRound(t *testing.T) {
 	assert.Equal(t, "accepted prompt", *backward.requests[1].Surfaces[0].Value.Text)
 }
 
+func TestRunStopsBeforeBackwardWhenTrainLossesAreEmpty(t *testing.T) {
+	evalService := newScriptedEvalService(func(evalSetID string, profileValue string) scriptedEvalOutcome {
+		_ = evalSetID
+		_ = profileValue
+		return scriptedEvalOutcome{
+			score:             0.8,
+			metricStatus:      status.EvalStatusPassed,
+			appliedSurfaceIDs: []string{testSurfaceID},
+		}
+	})
+	engineInstance, err := New(
+		context.Background(),
+		WithAgentEvaluator(newTestAgentEvaluator(t, evalService)),
+		WithBackwarder(&fakeBackwarder{}),
+		WithAggregator(&fakeAggregator{}),
+		WithOptimizer(&fakeOptimizer{}),
+		WithAgent(testTargetAgent()),
+	)
+	require.NoError(t, err)
+	observedKinds := make([]EventKind, 0)
+	result, err := engineInstance.Run(context.Background(), &RunRequest{
+		Train:          testEvalSetInputs("train"),
+		Validation:     testEvalSetInputs("validation"),
+		InitialProfile: runtimeProfileFromSnapshot(t, testStructureSnapshot(t)),
+		StopPolicy: StopPolicy{
+			StopOnNoTrainLosses: true,
+		},
+		MaxRounds:        5,
+		TargetSurfaceIDs: []string{testSurfaceID},
+	}, WithObserver(func(ctx context.Context, event *Event) error {
+		_ = ctx
+		observedKinds = append(observedKinds, event.Kind)
+		return nil
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"base prompt", "base prompt"}, evalService.profiles)
+	require.Len(t, result.Rounds, 1)
+	round := result.Rounds[0]
+	assert.Empty(t, round.Losses)
+	assert.Nil(t, round.Backward)
+	assert.Nil(t, round.Aggregation)
+	assert.Nil(t, round.Patches)
+	assert.Nil(t, round.OutputProfile)
+	assert.Nil(t, round.Validation)
+	assert.Nil(t, round.Acceptance)
+	require.NotNil(t, round.Stop)
+	assert.True(t, round.Stop.ShouldStop)
+	assert.Equal(t, "no train losses extracted", round.Stop.Reason)
+	assert.Equal(t, []EventKind{
+		EventKindBaselineValidation,
+		EventKindRoundStarted,
+		EventKindRoundTrainEvaluation,
+		EventKindRoundLosses,
+		EventKindRoundCompleted,
+	}, observedKinds)
+}
+
+func TestRunContinuesOnEmptyTrainLossesWhenPolicyDisabled(t *testing.T) {
+	evalService := newScriptedEvalService(func(evalSetID string, profileValue string) scriptedEvalOutcome {
+		_ = evalSetID
+		_ = profileValue
+		return scriptedEvalOutcome{
+			score:             0.8,
+			metricStatus:      status.EvalStatusPassed,
+			appliedSurfaceIDs: []string{testSurfaceID},
+		}
+	})
+	engineInstance, err := New(
+		context.Background(),
+		WithAgentEvaluator(newTestAgentEvaluator(t, evalService)),
+		WithBackwarder(&fakeBackwarder{}),
+		WithAggregator(&fakeAggregator{}),
+		WithOptimizer(&fakeOptimizer{}),
+		WithAgent(testTargetAgent()),
+	)
+	require.NoError(t, err)
+	result, err := engineInstance.Run(context.Background(), &RunRequest{
+		Train:            testEvalSetInputs("train"),
+		Validation:       testEvalSetInputs("validation"),
+		InitialProfile:   runtimeProfileFromSnapshot(t, testStructureSnapshot(t)),
+		MaxRounds:        1,
+		TargetSurfaceIDs: []string{testSurfaceID},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"base prompt", "base prompt", "base prompt"}, evalService.profiles)
+	require.Len(t, result.Rounds, 1)
+	round := result.Rounds[0]
+	assert.Empty(t, round.Losses)
+	assert.NotNil(t, round.Backward)
+	assert.NotNil(t, round.Aggregation)
+	assert.NotNil(t, round.Patches)
+	assert.NotNil(t, round.OutputProfile)
+	assert.NotNil(t, round.Validation)
+	require.NotNil(t, round.Acceptance)
+	assert.True(t, round.Acceptance.Accepted)
+	require.NotNil(t, round.Stop)
+	assert.Equal(t, "max rounds reached", round.Stop.Reason)
+}
+
 func TestRunAllowsToolSurfaceInTraceWhenTargetingInstruction(t *testing.T) {
 	backward := &fakeBackwarder{
 		fn: func(ctx context.Context, request *backwarder.Request) (*backwarder.Result, error) {

--- a/evaluation/workflow/promptiter/engine/stop.go
+++ b/evaluation/workflow/promptiter/engine/stop.go
@@ -15,6 +15,8 @@ type StopPolicy struct {
 	MaxRoundsWithoutAcceptance int
 	// TargetScore, when set, stops the run after this score is reached or exceeded.
 	TargetScore *float64
+	// StopOnNoTrainLosses stops after train evaluation produces no extracted losses.
+	StopOnNoTrainLosses bool
 }
 
 // StopDecision records whether the engine should terminate and why.
@@ -49,4 +51,14 @@ func (e *engine) stop(
 		decision.Reason = "continue optimization"
 	}
 	return decision
+}
+
+func stopOnNoTrainLosses(policy StopPolicy, lossCount int) *StopDecision {
+	if !policy.StopOnNoTrainLosses || lossCount > 0 {
+		return nil
+	}
+	return &StopDecision{
+		ShouldStop: true,
+		Reason:     "no train losses extracted",
+	}
 }

--- a/evaluation/workflow/promptiter/manager/manager_test.go
+++ b/evaluation/workflow/promptiter/manager/manager_test.go
@@ -738,6 +738,68 @@ func TestRunObserverBuildsIncrementalRun(t *testing.T) {
 	assert.Equal(t, "structure_1", current.AcceptedProfile.StructureID)
 }
 
+func TestRunObserverPreservesSkippedAcceptance(t *testing.T) {
+	managerInstance, err := New("demo-app", &fakePromptIterEngine{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, managerInstance.Close())
+	})
+	concreteManager, ok := managerInstance.(*manager)
+	require.True(t, ok)
+	run := &promptiterengine.RunResult{
+		AppName:         "demo-app",
+		ID:              "run-1",
+		Status:          promptiterengine.RunStatusRunning,
+		AcceptedProfile: &promptiter.Profile{StructureID: "structure_1"},
+	}
+	require.NoError(t, concreteManager.store.Create(context.Background(), "demo-app", run))
+	observer := &observer{
+		manager: concreteManager,
+		run:     run,
+	}
+	require.NoError(t, observer.append(context.Background(), &promptiterengine.Event{
+		Kind:    promptiterengine.EventKindBaselineValidation,
+		Payload: newEvaluationResult(0.55),
+	}))
+	require.NoError(t, observer.append(context.Background(), &promptiterengine.Event{
+		Kind:  promptiterengine.EventKindRoundStarted,
+		Round: 1,
+	}))
+	require.NoError(t, observer.append(context.Background(), &promptiterengine.Event{
+		Kind:    promptiterengine.EventKindRoundTrainEvaluation,
+		Round:   1,
+		Payload: newEvaluationResult(0.80),
+	}))
+	require.NoError(t, observer.append(context.Background(), &promptiterengine.Event{
+		Kind:    promptiterengine.EventKindRoundLosses,
+		Round:   1,
+		Payload: []promptiter.CaseLoss{},
+	}))
+	require.NoError(t, observer.append(context.Background(), &promptiterengine.Event{
+		Kind:  promptiterengine.EventKindRoundCompleted,
+		Round: 1,
+		Payload: &promptiterengine.RoundCompleted{
+			ShouldStop: true,
+			StopReason: "no train losses extracted",
+		},
+	}))
+	current, err := concreteManager.Get(context.Background(), run.ID)
+	require.NoError(t, err)
+	require.Len(t, current.Rounds, 1)
+	round := current.Rounds[0]
+	assert.Nil(t, round.Backward)
+	assert.Nil(t, round.Aggregation)
+	assert.Nil(t, round.Patches)
+	assert.Nil(t, round.OutputProfile)
+	assert.Nil(t, round.Validation)
+	assert.Nil(t, round.Acceptance)
+	require.NotNil(t, round.Stop)
+	assert.True(t, round.Stop.ShouldStop)
+	assert.Equal(t, "no train losses extracted", round.Stop.Reason)
+	require.NotNil(t, current.AcceptedProfile)
+	assert.Equal(t, "structure_1", current.AcceptedProfile.StructureID)
+}
+
 func TestRunObserverPassesContextToStoreUpdate(t *testing.T) {
 	store := &recordingStore{}
 	managerInstance, err := New("demo-app", &fakePromptIterEngine{}, WithStore(store))

--- a/evaluation/workflow/promptiter/manager/observer.go
+++ b/evaluation/workflow/promptiter/manager/observer.go
@@ -150,10 +150,14 @@ func (o *observer) applyRoundCompleted(event *engine.Event) error {
 		return invalidEventPayloadError(event.Kind)
 	}
 	round := o.ensureRound(event.Round)
-	round.Acceptance = &engine.AcceptanceDecision{
-		Accepted:   payload.Accepted,
-		ScoreDelta: payload.ScoreDelta,
-		Reason:     payload.AcceptanceReason,
+	if roundCompletedHasAcceptance(round, payload) {
+		round.Acceptance = &engine.AcceptanceDecision{
+			Accepted:   payload.Accepted,
+			ScoreDelta: payload.ScoreDelta,
+			Reason:     payload.AcceptanceReason,
+		}
+	} else {
+		round.Acceptance = nil
 	}
 	round.Stop = &engine.StopDecision{
 		ShouldStop: payload.ShouldStop,
@@ -163,6 +167,13 @@ func (o *observer) applyRoundCompleted(event *engine.Event) error {
 		o.run.AcceptedProfile = round.OutputProfile
 	}
 	return nil
+}
+
+func roundCompletedHasAcceptance(round *engine.RoundResult, payload *engine.RoundCompleted) bool {
+	return round != nil && (round.OutputProfile != nil || round.Validation != nil) ||
+		payload.Accepted ||
+		payload.AcceptanceReason != "" ||
+		payload.ScoreDelta != 0
 }
 
 func invalidEventPayloadError(kind engine.EventKind) error {

--- a/server/promptiter/server_test.go
+++ b/server/promptiter/server_test.go
@@ -575,6 +575,38 @@ func TestHandleRunsPassesTargetSurfaceIDsWithoutDescribe(t *testing.T) {
 	assert.Equal(t, []string{"unknown#instruction"}, captured.TargetSurfaceIDs)
 }
 
+func TestHandleRunsPassesStopOnNoTrainLossesPolicy(t *testing.T) {
+	var captured *enginepkg.RunRequest
+	srv := newTestServer(t,
+		WithEngine(&fakeEngine{
+			run: func(ctx context.Context, request *enginepkg.RunRequest, opts ...enginepkg.Option) (*enginepkg.RunResult, error) {
+				_ = ctx
+				_ = opts
+				captured = request
+				return &enginepkg.RunResult{Status: enginepkg.RunStatusSucceeded}, nil
+			},
+		}),
+	)
+	body, err := json.Marshal(&RunRequest{
+		Run: &enginepkg.RunRequest{
+			Train:      testEvalSetInputs("train"),
+			Validation: testEvalSetInputs("validation"),
+			StopPolicy: enginepkg.StopPolicy{
+				StopOnNoTrainLosses: true,
+			},
+			TargetSurfaceIDs: []string{"candidate#instruction"},
+			MaxRounds:        1,
+		},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, srv.RunsPath(), bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, captured)
+	assert.True(t, captured.StopPolicy.StopOnNoTrainLosses)
+}
+
 func TestHandleAsyncRunsIsNotExposedWithoutManager(t *testing.T) {
 	srv := newTestServer(t)
 	req := httptest.NewRequest(http.MethodPost, srv.AsyncRunsPath(), bytes.NewBufferString(`{"run":null}`))


### PR DESCRIPTION
Adds an opt-in PromptIter stop policy that ends a run after training evaluation produces no extracted losses, avoiding empty backward, optimization, validation, and later rounds when there is no actionable training signal. The change keeps default behavior unchanged, preserves skipped stage fields as nil in run results, and documents the new HTTP-visible policy.