### PR TITLE
tool/duckduckgo: capture loop variable in parallel table test

### DIFF
--- a/tool/duckduckgo/duckduckgo_test.go
+++ b/tool/duckduckgo/duckduckgo_test.go
@@ -1476,6 +1476,7 @@ func TestDuckDuckGoTool_FilterSearchResponse(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## What changed

`TestDuckDuckGoTool_FilterSearchResponse` declares four table-driven cases, but only the last one was
actually asserted. All four now assert their own case.

## Why

The root module targets Go 1.21, where a `range` loop reuses a single iteration variable. The subtests
call `t.Parallel()`, so they suspend until the parent test function returns — by which point the loop
has finished and `tc` holds the final case. Every subtest then reads that same value, so the
`no patterns`, `no results` and `no matches` inputs were never verified and the `empty summary` case was
verified four times.

This is invisible in test output because `t.Run(tc.name, ...)` evaluates the name eagerly, while `tc`
is only dereferenced inside the parallel closure. All four subtests are reported by their correct names
and pass.

`go vet ./...` reports it on the root module:

```text
tool/duckduckgo/duckduckgo_test.go:1482:11: loop variable tc captured by func literal
tool/duckduckgo/duckduckgo_test.go:1482:40: loop variable tc captured by func literal
tool/duckduckgo/duckduckgo_test.go:1483:21: loop variable tc captured by func literal
```

CI does not surface this: `.golangci.yml` enables `govet`, but `issues.exclude-files` excludes
`.*_test.go`, so the `loopclosure` analyzer never reports on test files.

## Testing

`go vet ./tool/duckduckgo/` and `go vet ./...` on the root module both exit non-zero before this change
and clean afterwards. `go test ./tool/duckduckgo/ -run TestDuckDuckGo` passes.

To confirm the cases were not being asserted, I temporarily replaced the expected `Summary` of the first
case (`no patterns`) with a value that cannot match. Before the fix the subtest still passed; with
`tc := tc` in place the same sabotage fails as expected:

```text
--- FAIL: TestDuckDuckGoTool_FilterSearchResponse/no_patterns
    expected: ... Summary:"DELIBERATELY-WRONG-MUST-FAIL"
```

The temporary change was reverted; this PR contains only the one-line fix.

I also ran `go vet ./...` in every module that still declares a pre-1.22 Go version, and this was the
only occurrence.

Note: `TestNewDefaultHTTPClient_UsesTransportNetwork` fails on my macOS machine with
`bind: invalid argument` because the temporary unix socket path exceeds the platform limit. It fails
identically on an unmodified checkout, so it is unrelated to this change.

## Notes for reviewers

Test-only change; no production code, exported API or behavior is affected. `tc := tc` is the
compatible fix while the module targets Go 1.21 — the shadow becomes redundant once the module moves to
Go 1.22 or later, but it is harmless there.

Separately, `.golangci.yml` excludes `.*_test.go` from all linters, which is why `govet` did not catch
this. Removing that exclusion would likely surface findings across many test files, so I have not
touched it here — happy to open an issue to discuss it if that is useful.
