### PR TITLE
{session, server/agui, docs}: add paginated message snapshots

### DIFF
--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -812,6 +812,7 @@ The `MESSAGES_SNAPSHOT` event returned by the message snapshot route can also ca
       "assistant-1": {
         "eventId": "evt-assistant",
         "author": "member-a",
+        "runId": "run-1",
         "invocationId": "inv-1",
         "branch": "root.member-a",
         "timestamp": 1781258400000
@@ -821,6 +822,7 @@ The `MESSAGES_SNAPSHOT` event returned by the message snapshot route can also ca
       "tool-call-1": {
         "eventId": "evt-tool-call",
         "author": "member-a",
+        "runId": "run-1",
         "invocationId": "inv-1",
         "parentMetadata": {
           "triggerType": "tool_call",
@@ -844,7 +846,7 @@ The `MESSAGES_SNAPSHOT` event returned by the message snapshot route can also ca
 }
 ```
 
-When restoring historical messages, use `rawEvent.messages[messageId]` to get the message source and timestamp, or `rawEvent.toolCalls[toolCallId]` to get the tool call source and timestamp. To restore request-level `forwardedProps`, read `rawEvent.runs[runId].forwardedProps`. The indexed `timestamp` first reuses the top-level `timestamp` from the historical real-time event; only old data without an event `timestamp` falls back to the persisted track event time. Source information in the index uses the same fields as `rawEvent` in real-time events, so the frontend can reuse those field semantics to restore grouping state.
+When restoring historical messages, use `rawEvent.messages[messageId]` to get the message source, `runId`, and timestamp, or `rawEvent.toolCalls[toolCallId]` to get the tool call source, `runId`, and timestamp. To restore request-level `forwardedProps`, first read the `runId` from the message or tool-call metadata, then read `rawEvent.runs[runId].forwardedProps`. The indexed `timestamp` first reuses the top-level `timestamp` from the historical real-time event; only old data without an event `timestamp` falls back to the persisted track event time. Source information in the index uses the same fields as `rawEvent` in real-time events, so the frontend can reuse those field semantics to restore grouping state.
 
 ## External Tools
 

--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -283,11 +283,13 @@ For the complete example, see [examples/agui/server/follow](https://github.com/t
 
 By default, `/history` restores the complete persisted AG-UI history for the requested session. For long-running conversations, returning the whole history in one response can increase storage reads, server-side reduction work, and network traffic. In that case, configure `agui.WithMessagesSnapshotSessionPageResolver` to let each snapshot request load one page of persisted events.
 
-Pagination is resolved at the session layer. The AG-UI server does not define its own public cursor field or fixed request parameter names. Instead, the resolver receives the original `RunAgentInput` and the resolved `session.Key`, then returns a session page request. Applications can choose where the cursor and limit come from, such as `forwardedProps`, request metadata mapped by the gateway, or another application-specific input source.
+Pagination is resolved at the session layer. The AG-UI server does not define its own public cursor field or fixed request parameter names. Instead, the resolver receives the `RunAgentInput` and the resolved `session.Key`, then returns a session page request. Applications can choose where the cursor and limit come from, such as `forwardedProps`, request metadata mapped by the gateway, or another application-specific input source.
 
 The resolver returns `*aguirunner.MessagesSnapshotPageRequest`. `Cursor` is an opaque value returned by a previous snapshot page; an empty cursor asks the session service for the latest page. `EventLimit` limits the number of persisted AG-UI track events read from session storage. It is an event limit, not a message or turn limit, because a single displayed message may be restored from several persisted AG-UI events.
 
 Pagination is used only when the configured session service implements `session.TrackEventPageService`. If the service does not provide that capability, `/history` keeps the existing full-snapshot behavior.
+
+A non-nil page request makes the snapshot response one-shot. Even when message snapshot follow mode is enabled, `/history` emits the paginated `MESSAGES_SNAPSHOT` and then finishes the stream.
 
 ```go
 import (

--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -201,7 +201,7 @@ server, err := agui.New(
 )
 ```
 
-After this is enabled, when the real-time conversation request persists the user input event, it writes the `forwardedProps` field from the AG-UI request body to the user input event's `rawEvent.forwardedProps`; in the Go API, that field corresponds to `RunAgentInput.ForwardedProps`. When reading history, the message snapshot route aggregates it into `MESSAGES_SNAPSHOT.rawEvent.runs[runId].forwardedProps`:
+After this is enabled, when the real-time conversation request persists the user input event, it writes the `forwardedProps` field from the AG-UI request body to the user input event's `rawEvent.forwardedProps`; in the Go API, that field corresponds to `RunAgentInput.ForwardedProps`. When reading history, the message snapshot route aggregates it into `MESSAGES_SNAPSHOT.rawEvent.runs[runId].forwardedProps`, and writes `runId` into message metadata when the message can be associated with a run:
 
 ```json
 {
@@ -232,6 +232,7 @@ After this is enabled, when the real-time conversation request persists the user
     "messages": {
       "user-1": {
         "author": "demo-user",
+        "runId": "run-1",
         "timestamp": 1781258400000
       }
     }
@@ -277,3 +278,71 @@ server, err := agui.New(
 ```
 
 For the complete example, see [examples/agui/server/follow](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/follow). For the frontend, see [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
+
+## Paginated Messages Snapshots
+
+By default, `/history` restores the complete persisted AG-UI history for the requested session. For long-running conversations, returning the whole history in one response can increase storage reads, server-side reduction work, and network traffic. In that case, configure `agui.WithMessagesSnapshotSessionPageResolver` to let each snapshot request load one page of persisted events.
+
+Pagination is resolved at the session layer. The AG-UI server does not define its own public cursor field or fixed request parameter names. Instead, the resolver receives the original `RunAgentInput` and the resolved `session.Key`, then returns a session page request. Applications can choose where the cursor and limit come from, such as `forwardedProps`, request metadata mapped by the gateway, or another application-specific input source.
+
+The resolver returns `*aguirunner.MessagesSnapshotPageRequest`. `Cursor` is an opaque value returned by a previous snapshot page; an empty cursor asks the session service for the latest page. `EventLimit` limits the number of persisted AG-UI track events read from session storage. It is an event limit, not a message or turn limit, because a single displayed message may be restored from several persisted AG-UI events.
+
+Pagination is used only when the configured session service implements `session.TrackEventPageService`. If the service does not provide that capability, `/history` keeps the existing full-snapshot behavior.
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName("demo-app"),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotSessionPageResolver(
+        func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*aguirunner.MessagesSnapshotPageRequest, error) {
+            forwardedProps, _ := input.ForwardedProps.(map[string]any)
+            cursor, _ := forwardedProps["cursor"].(string)
+            return &aguirunner.MessagesSnapshotPageRequest{
+                Cursor:     cursor,
+                EventLimit: 200,
+            }, nil
+        },
+    ),
+)
+```
+
+For a paginated snapshot, the response still uses the standard `MESSAGES_SNAPSHOT` event. Page information is attached to `MESSAGES_SNAPSHOT.rawEvent.page`:
+
+```json
+{
+  "type": "MESSAGES_SNAPSHOT",
+  "messages": [
+    {
+      "id": "user-1",
+      "role": "user",
+      "content": "Hello"
+    },
+    {
+      "id": "assistant-1",
+      "role": "assistant",
+      "content": "Hello. How can I help?"
+    }
+  ],
+  "rawEvent": {
+    "page": {
+      "cursor": "opaque-cursor-for-the-page-boundary",
+      "hasMore": true
+    }
+  }
+}
+```
+
+The returned `cursor` should be sent with the next snapshot request to load older history. Treat it as an opaque token: do not parse, compare, or construct it in application code.
+
+`hasMore=true` means the client has not received all older history yet. This can be because the session store still has older events, or because the AG-UI layer trimmed part of the fetched page before returning it. The trimming is intentional: message snapshots are returned from a user-message boundary, so the frontend does not receive the trailing half of an earlier turn.
+
+If the fetched page does not contain a user-message boundary, `/history` returns an empty `messages` array, keeps the requested cursor in `rawEvent.page.cursor`, and sets `hasMore=true`. The client can then retry with the same cursor and a larger `EventLimit` to ask the session service for a wider event window.

--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -347,4 +347,4 @@ The returned `cursor` should be sent with the next snapshot request to load olde
 
 `hasMore=true` means the client has not received all older history yet. This can be because the session store still has older events, or because the AG-UI layer trimmed part of the fetched page before returning it. The trimming is intentional: message snapshots are returned from a user-message boundary, so the frontend does not receive the trailing half of an earlier turn.
 
-If the fetched page does not contain a user-message boundary, `/history` returns an empty `messages` array, keeps the requested cursor in `rawEvent.page.cursor`, and sets `hasMore=true`. The client can then retry with the same cursor and a larger `EventLimit` to ask the session service for a wider event window.
+If the fetched page does not contain a user-message boundary, `/history` returns an empty `messages` array and advances `rawEvent.page.cursor` to the oldest event inspected in that page. `hasMore` follows the session service result, so the client can keep loading older pages without repeating the same empty page.

--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -347,4 +347,4 @@ The returned `cursor` should be sent with the next snapshot request to load olde
 
 `hasMore=true` means the client has not received all older history yet. This can be because the session store still has older events, or because the AG-UI layer trimmed part of the fetched page before returning it. The trimming is intentional: message snapshots are returned from a user-message boundary, so the frontend does not receive the trailing half of an earlier turn.
 
-If the fetched page does not contain a user-message boundary, `/history` returns an empty `messages` array and advances `rawEvent.page.cursor` to the oldest event inspected in that page. `hasMore` follows the session service result, so the client can keep loading older pages without repeating the same empty page.
+If the fetched page does not contain a user-message boundary, `/history` returns an empty `messages` array, keeps the requested cursor in `rawEvent.page.cursor`, and sets `hasMore=true`. The client can then retry with the same cursor and a larger `EventLimit` to ask the session service for a wider event window.

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -812,6 +812,7 @@ server, err := agui.New(
       "assistant-1": {
         "eventId": "evt-assistant",
         "author": "member-a",
+        "runId": "run-1",
         "invocationId": "inv-1",
         "branch": "root.member-a",
         "timestamp": 1781258400000
@@ -821,6 +822,7 @@ server, err := agui.New(
       "tool-call-1": {
         "eventId": "evt-tool-call",
         "author": "member-a",
+        "runId": "run-1",
         "invocationId": "inv-1",
         "parentMetadata": {
           "triggerType": "tool_call",
@@ -844,7 +846,7 @@ server, err := agui.New(
 }
 ```
 
-恢复历史消息时，可以通过 `rawEvent.messages[messageId]` 获取消息来源和时间戳，也可以通过 `rawEvent.toolCalls[toolCallId]` 获取工具调用来源和时间戳；如果需要恢复请求级 `forwardedProps`，可以读取 `rawEvent.runs[runId].forwardedProps`。索引中的 `timestamp` 优先复用历史实时事件顶层的 `timestamp`；只有旧数据缺少事件 `timestamp` 时，才回退使用持久化 track event 的时间。索引中的来源信息与实时事件里的 `rawEvent` 使用同一组字段，前端可以沿用这些字段含义恢复分组状态。
+恢复历史消息时，可以通过 `rawEvent.messages[messageId]` 获取消息来源、`runId` 和时间戳，也可以通过 `rawEvent.toolCalls[toolCallId]` 获取工具调用来源、`runId` 和时间戳；如果需要恢复请求级 `forwardedProps`，可以先读取消息或工具调用元数据中的 `runId`，再读取 `rawEvent.runs[runId].forwardedProps`。索引中的 `timestamp` 优先复用历史实时事件顶层的 `timestamp`；只有旧数据缺少事件 `timestamp` 时，才回退使用持久化 track event 的时间。索引中的来源信息与实时事件里的 `rawEvent` 使用同一组字段，前端可以沿用这些字段含义恢复分组状态。
 
 ## 外部工具
 

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -201,7 +201,7 @@ server, err := agui.New(
 )
 ```
 
-开启后，实时对话请求在持久化用户输入事件时，会把 AG-UI 请求体中的 `forwardedProps` 字段写入该用户输入事件的 `rawEvent.forwardedProps`；在 Go API 中，该字段对应 `RunAgentInput.ForwardedProps`。读取历史时，消息快照路由会把它聚合到 `MESSAGES_SNAPSHOT.rawEvent.runs[runId].forwardedProps`：
+开启后，实时对话请求在持久化用户输入事件时，会把 AG-UI 请求体中的 `forwardedProps` 字段写入该用户输入事件的 `rawEvent.forwardedProps`；在 Go API 中，该字段对应 `RunAgentInput.ForwardedProps`。读取历史时，消息快照路由会把它聚合到 `MESSAGES_SNAPSHOT.rawEvent.runs[runId].forwardedProps`，并在可关联到运行的消息元数据中写入 `runId`：
 
 ```json
 {
@@ -232,6 +232,7 @@ server, err := agui.New(
     "messages": {
       "user-1": {
         "author": "demo-user",
+        "runId": "run-1",
         "timestamp": 1781258400000
       }
     }
@@ -277,3 +278,71 @@ server, err := agui.New(
 ```
 
 完整示例可参考 [examples/agui/server/follow](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/follow)，前端可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
+
+## 分页消息快照
+
+默认情况下，`/history` 会一次性还原当前会话中全部已持久化的 AG-UI 历史。对于较长的对话，这会增加会话存储读取、服务端事件还原以及网络传输的成本。此时可以配置 `agui.WithMessagesSnapshotSessionPageResolver`，让每次消息快照请求只读取一页已持久化事件。
+
+分页能力由 session 层提供。AG-UI 服务端不会额外定义顶层 cursor 字段，也不约定固定的请求参数名称；resolver 会拿到原始 `RunAgentInput` 和已经解析出的 `session.Key`，再返回一次 session 分页请求。业务可以自行决定 cursor 和 limit 的来源，例如从 `forwardedProps`、网关映射后的请求元数据，或其它业务输入中读取。
+
+resolver 返回 `*aguirunner.MessagesSnapshotPageRequest`。`Cursor` 是上一页返回的 opaque cursor，空 cursor 表示读取最新一页。`EventLimit` 表示从会话存储中读取的 AG-UI track event 数量；它限制的是事件数，不是消息数或对话轮数，因为一条最终展示的消息可能由多条已持久化 AG-UI 事件还原而来。
+
+只有配置的 session service 实现了 `session.TrackEventPageService` 时，消息快照路由才会使用分页读取。若当前 session service 不支持该能力，`/history` 会保持原有的全量快照行为。
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
+	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName("demo-app"),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotSessionPageResolver(
+        func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*aguirunner.MessagesSnapshotPageRequest, error) {
+            forwardedProps, _ := input.ForwardedProps.(map[string]any)
+            cursor, _ := forwardedProps["cursor"].(string)
+            return &aguirunner.MessagesSnapshotPageRequest{
+                Cursor:     cursor,
+                EventLimit: 200,
+            }, nil
+        },
+    ),
+)
+```
+
+分页快照的响应仍然使用标准的 `MESSAGES_SNAPSHOT` 事件。分页信息会写入 `MESSAGES_SNAPSHOT.rawEvent.page`：
+
+```json
+{
+  "type": "MESSAGES_SNAPSHOT",
+  "messages": [
+    {
+      "id": "user-1",
+      "role": "user",
+      "content": "你好"
+    },
+    {
+      "id": "assistant-1",
+      "role": "assistant",
+      "content": "你好，有什么可以帮你？"
+    }
+  ],
+  "rawEvent": {
+    "page": {
+      "cursor": "opaque-cursor-for-the-page-boundary",
+      "hasMore": true
+    }
+  }
+}
+```
+
+下一次请求更早历史时，客户端应把返回的 `cursor` 原样传回 resolver 所读取的位置。cursor 是 opaque token，业务代码不应解析、比较或自行构造。
+
+`hasMore=true` 表示客户端还没有收到全部更早历史。原因可能是 session 存储中仍有更早事件，也可能是 AG-UI 层在返回前裁剪了当前页。这个裁剪是有意的：消息快照会从 user message 边界开始返回，避免前端收到上一轮对话的后半段。
+
+如果本次读取到的事件页中找不到 user message 边界，`/history` 会返回空 `messages`，并在 `rawEvent.page.cursor` 中保留本次请求传入的 cursor，同时设置 `hasMore=true`。客户端可以使用同一个 cursor，并调大 `EventLimit` 后重试，从 session 层请求更大的事件窗口。

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -347,4 +347,4 @@ server, err := agui.New(
 
 `hasMore=true` 表示客户端还没有收到全部更早历史。原因可能是 session 存储中仍有更早事件，也可能是 AG-UI 层在返回前裁剪了当前页。这个裁剪是有意的：消息快照会从 user message 边界开始返回，避免前端收到上一轮对话的后半段。
 
-如果本次读取到的事件页中找不到 user message 边界，`/history` 会返回空 `messages`，并在 `rawEvent.page.cursor` 中保留本次请求传入的 cursor，同时设置 `hasMore=true`。客户端可以使用同一个 cursor，并调大 `EventLimit` 后重试，从 session 层请求更大的事件窗口。
+如果本次读取到的事件页中找不到 user message 边界，`/history` 会返回空 `messages`，并把 `rawEvent.page.cursor` 推进到本页已检查到的最老事件。`hasMore` 保持 session service 返回的结果，因此客户端可以继续请求更早分页，而不会重复请求同一个空页。

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -347,4 +347,4 @@ server, err := agui.New(
 
 `hasMore=true` 表示客户端还没有收到全部更早历史。原因可能是 session 存储中仍有更早事件，也可能是 AG-UI 层在返回前裁剪了当前页。这个裁剪是有意的：消息快照会从 user message 边界开始返回，避免前端收到上一轮对话的后半段。
 
-如果本次读取到的事件页中找不到 user message 边界，`/history` 会返回空 `messages`，并把 `rawEvent.page.cursor` 推进到本页已检查到的最老事件。`hasMore` 保持 session service 返回的结果，因此客户端可以继续请求更早分页，而不会重复请求同一个空页。
+如果本次读取到的事件页中找不到 user message 边界，`/history` 会返回空 `messages`，并在 `rawEvent.page.cursor` 中保留本次请求传入的 cursor，同时设置 `hasMore=true`。客户端可以使用同一个 cursor，并调大 `EventLimit` 后重试，从 session 层请求更大的事件窗口。

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -283,11 +283,13 @@ server, err := agui.New(
 
 默认情况下，`/history` 会一次性还原当前会话中全部已持久化的 AG-UI 历史。对于较长的对话，这会增加会话存储读取、服务端事件还原以及网络传输的成本。此时可以配置 `agui.WithMessagesSnapshotSessionPageResolver`，让每次消息快照请求只读取一页已持久化事件。
 
-分页能力由 session 层提供。AG-UI 服务端不会额外定义顶层 cursor 字段，也不约定固定的请求参数名称；resolver 会拿到原始 `RunAgentInput` 和已经解析出的 `session.Key`，再返回一次 session 分页请求。业务可以自行决定 cursor 和 limit 的来源，例如从 `forwardedProps`、网关映射后的请求元数据，或其它业务输入中读取。
+分页能力由 session 层提供。AG-UI 服务端不会额外定义顶层 cursor 字段，也不约定固定的请求参数名称；resolver 会拿到 `RunAgentInput` 和已经解析出的 `session.Key`，再返回一次 session 分页请求。业务可以自行决定 cursor 和 limit 的来源，例如从 `forwardedProps`、网关映射后的请求元数据，或其它业务输入中读取。
 
 resolver 返回 `*aguirunner.MessagesSnapshotPageRequest`。`Cursor` 是上一页返回的 opaque cursor，空 cursor 表示读取最新一页。`EventLimit` 表示从会话存储中读取的 AG-UI track event 数量；它限制的是事件数，不是消息数或对话轮数，因为一条最终展示的消息可能由多条已持久化 AG-UI 事件还原而来。
 
 只有配置的 session service 实现了 `session.TrackEventPageService` 时，消息快照路由才会使用分页读取。若当前 session service 不支持该能力，`/history` 会保持原有的全量快照行为。
+
+只要 resolver 返回非空 page request，本次消息快照就是一次性的。即使启用了 message snapshot follow 模式，`/history` 也会在发送分页 `MESSAGES_SNAPSHOT` 后结束流。
 
 ```go
 import (

--- a/internal/session/externalization/service.go
+++ b/internal/session/externalization/service.go
@@ -415,6 +415,19 @@ func wrapStateInitializationInterface(
 	wrapped session.Service,
 	initializer session.StateInitializationService,
 ) session.Service {
+	if service := wrapPageStateInitializationInterface(wrapped, initializer); service != nil {
+		return service
+	}
+	if service := wrapReaderStateInitializationInterface(wrapped, initializer); service != nil {
+		return service
+	}
+	return wrapBaseStateInitializationInterface(wrapped, initializer)
+}
+
+func wrapPageStateInitializationInterface(
+	wrapped session.Service,
+	initializer session.StateInitializationService,
+) session.Service {
 	switch service := wrapped.(type) {
 	case *searchableWindowTrackReaderPageService:
 		return &stateInitializingSearchableWindowTrackReaderPageService{
@@ -456,6 +469,16 @@ func wrapStateInitializationInterface(
 			trackPageService:           service,
 			StateInitializationService: initializer,
 		}
+	default:
+		return nil
+	}
+}
+
+func wrapReaderStateInitializationInterface(
+	wrapped session.Service,
+	initializer session.StateInitializationService,
+) session.Service {
+	switch service := wrapped.(type) {
 	case *searchableWindowTrackReaderService:
 		return &stateInitializingSearchableWindowTrackReaderService{
 			searchableWindowTrackReaderService: service,
@@ -476,6 +499,16 @@ func wrapStateInitializationInterface(
 			windowTrackReaderService:   service,
 			StateInitializationService: initializer,
 		}
+	default:
+		return nil
+	}
+}
+
+func wrapBaseStateInitializationInterface(
+	wrapped session.Service,
+	initializer session.StateInitializationService,
+) session.Service {
+	switch service := wrapped.(type) {
 	case *searchableWindowService:
 		return &stateInitializingSearchableWindowService{
 			searchableWindowService:    service,
@@ -521,6 +554,18 @@ func wrapStateInitializationInterface(
 	}
 }
 
+type trackOptionalInterfaces struct {
+	base       *Service
+	searchable session.SearchableService
+	window     session.WindowService
+	track      session.TrackService
+	reader     trackEventReader
+	pager      session.TrackEventPageService
+	hasWindow  bool
+	hasReader  bool
+	hasPager   bool
+}
+
 func wrapTrackOptionalInterfaces(
 	base *Service,
 	searchable session.SearchableService,
@@ -533,135 +578,174 @@ func wrapTrackOptionalInterfaces(
 	pager session.TrackEventPageService,
 	hasPager bool,
 ) session.Service {
-	switch {
-	case hasSearch && hasWindow && hasReader && hasPager:
-		return &searchableWindowTrackReaderPageService{
-			searchableWindowTrackReaderService: &searchableWindowTrackReaderService{
-				Service:           base,
-				SearchableService: searchable,
-				WindowService:     window,
-				TrackService:      track,
-				trackEventReader:  reader,
-			},
-			TrackEventPageService: pager,
+	opts := trackOptionalInterfaces{
+		base:       base,
+		searchable: searchable,
+		window:     window,
+		track:      track,
+		reader:     reader,
+		pager:      pager,
+		hasWindow:  hasWindow,
+		hasReader:  hasReader,
+		hasPager:   hasPager,
+	}
+	if hasSearch {
+		return wrapSearchTrackOptionalInterfaces(opts)
+	}
+	if hasWindow {
+		return wrapWindowTrackOptionalInterfaces(opts)
+	}
+	return wrapBaseTrackOptionalInterfaces(opts)
+}
+
+func wrapSearchTrackOptionalInterfaces(opts trackOptionalInterfaces) session.Service {
+	if opts.hasWindow {
+		return wrapSearchWindowTrackOptionalInterfaces(opts)
+	}
+	if opts.hasReader {
+		if opts.hasPager {
+			return &searchableTrackReaderPageService{
+				searchableTrackReaderService: &searchableTrackReaderService{
+					Service:           opts.base,
+					SearchableService: opts.searchable,
+					TrackService:      opts.track,
+					trackEventReader:  opts.reader,
+				},
+				TrackEventPageService: opts.pager,
+			}
 		}
-	case hasSearch && hasWindow && hasReader:
-		return &searchableWindowTrackReaderService{
-			Service:           base,
-			SearchableService: searchable,
-			WindowService:     window,
-			TrackService:      track,
-			trackEventReader:  reader,
-		}
-	case hasSearch && hasWindow && hasPager:
-		return &searchableWindowTrackPageService{
-			searchableWindowTrackService: &searchableWindowTrackService{
-				Service:           base,
-				SearchableService: searchable,
-				WindowService:     window,
-				TrackService:      track,
-			},
-			TrackEventPageService: pager,
-		}
-	case hasSearch && hasWindow:
-		return &searchableWindowTrackService{
-			Service:           base,
-			SearchableService: searchable,
-			WindowService:     window,
-			TrackService:      track,
-		}
-	case hasSearch && hasReader && hasPager:
-		return &searchableTrackReaderPageService{
-			searchableTrackReaderService: &searchableTrackReaderService{
-				Service:           base,
-				SearchableService: searchable,
-				TrackService:      track,
-				trackEventReader:  reader,
-			},
-			TrackEventPageService: pager,
-		}
-	case hasSearch && hasReader:
 		return &searchableTrackReaderService{
-			Service:           base,
-			SearchableService: searchable,
-			TrackService:      track,
-			trackEventReader:  reader,
+			Service:           opts.base,
+			SearchableService: opts.searchable,
+			TrackService:      opts.track,
+			trackEventReader:  opts.reader,
 		}
-	case hasSearch && hasPager:
+	}
+	if opts.hasPager {
 		return &searchableTrackPageService{
 			searchableTrackService: &searchableTrackService{
-				Service:           base,
-				SearchableService: searchable,
-				TrackService:      track,
+				Service:           opts.base,
+				SearchableService: opts.searchable,
+				TrackService:      opts.track,
 			},
-			TrackEventPageService: pager,
+			TrackEventPageService: opts.pager,
 		}
-	case hasSearch:
-		return &searchableTrackService{
-			Service:           base,
-			SearchableService: searchable,
-			TrackService:      track,
+	}
+	return &searchableTrackService{
+		Service:           opts.base,
+		SearchableService: opts.searchable,
+		TrackService:      opts.track,
+	}
+}
+
+func wrapSearchWindowTrackOptionalInterfaces(opts trackOptionalInterfaces) session.Service {
+	if opts.hasReader {
+		if opts.hasPager {
+			return &searchableWindowTrackReaderPageService{
+				searchableWindowTrackReaderService: &searchableWindowTrackReaderService{
+					Service:           opts.base,
+					SearchableService: opts.searchable,
+					WindowService:     opts.window,
+					TrackService:      opts.track,
+					trackEventReader:  opts.reader,
+				},
+				TrackEventPageService: opts.pager,
+			}
 		}
-	case hasWindow && hasReader && hasPager:
-		return &windowTrackReaderPageService{
-			windowTrackReaderService: &windowTrackReaderService{
-				Service:          base,
-				WindowService:    window,
-				TrackService:     track,
-				trackEventReader: reader,
+		return &searchableWindowTrackReaderService{
+			Service:           opts.base,
+			SearchableService: opts.searchable,
+			WindowService:     opts.window,
+			TrackService:      opts.track,
+			trackEventReader:  opts.reader,
+		}
+	}
+	if opts.hasPager {
+		return &searchableWindowTrackPageService{
+			searchableWindowTrackService: &searchableWindowTrackService{
+				Service:           opts.base,
+				SearchableService: opts.searchable,
+				WindowService:     opts.window,
+				TrackService:      opts.track,
 			},
-			TrackEventPageService: pager,
+			TrackEventPageService: opts.pager,
 		}
-	case hasWindow && hasReader:
+	}
+	return &searchableWindowTrackService{
+		Service:           opts.base,
+		SearchableService: opts.searchable,
+		WindowService:     opts.window,
+		TrackService:      opts.track,
+	}
+}
+
+func wrapWindowTrackOptionalInterfaces(opts trackOptionalInterfaces) session.Service {
+	if opts.hasReader {
+		if opts.hasPager {
+			return &windowTrackReaderPageService{
+				windowTrackReaderService: &windowTrackReaderService{
+					Service:          opts.base,
+					WindowService:    opts.window,
+					TrackService:     opts.track,
+					trackEventReader: opts.reader,
+				},
+				TrackEventPageService: opts.pager,
+			}
+		}
 		return &windowTrackReaderService{
-			Service:          base,
-			WindowService:    window,
-			TrackService:     track,
-			trackEventReader: reader,
+			Service:          opts.base,
+			WindowService:    opts.window,
+			TrackService:     opts.track,
+			trackEventReader: opts.reader,
 		}
-	case hasWindow && hasPager:
+	}
+	if opts.hasPager {
 		return &windowTrackPageService{
 			windowTrackService: &windowTrackService{
-				Service:       base,
-				WindowService: window,
-				TrackService:  track,
+				Service:       opts.base,
+				WindowService: opts.window,
+				TrackService:  opts.track,
 			},
-			TrackEventPageService: pager,
+			TrackEventPageService: opts.pager,
 		}
-	case hasWindow:
-		return &windowTrackService{
-			Service:       base,
-			WindowService: window,
-			TrackService:  track,
+	}
+	return &windowTrackService{
+		Service:       opts.base,
+		WindowService: opts.window,
+		TrackService:  opts.track,
+	}
+}
+
+func wrapBaseTrackOptionalInterfaces(opts trackOptionalInterfaces) session.Service {
+	if opts.hasReader {
+		if opts.hasPager {
+			return &trackReaderPageService{
+				trackReaderService: &trackReaderService{
+					Service:          opts.base,
+					TrackService:     opts.track,
+					trackEventReader: opts.reader,
+				},
+				TrackEventPageService: opts.pager,
+			}
 		}
-	case hasReader && hasPager:
-		return &trackReaderPageService{
-			trackReaderService: &trackReaderService{
-				Service:          base,
-				TrackService:     track,
-				trackEventReader: reader,
-			},
-			TrackEventPageService: pager,
-		}
-	case hasReader:
 		return &trackReaderService{
-			Service:          base,
-			TrackService:     track,
-			trackEventReader: reader,
+			Service:          opts.base,
+			TrackService:     opts.track,
+			trackEventReader: opts.reader,
 		}
-	case hasPager:
+	}
+	if opts.hasPager {
 		return &trackPageService{
 			trackService: &trackService{
-				Service:      base,
-				TrackService: track,
+				Service:      opts.base,
+				TrackService: opts.track,
 			},
-			TrackEventPageService: pager,
+			TrackEventPageService: opts.pager,
 		}
-	default:
-		return &trackService{
-			Service:      base,
-			TrackService: track,
-		}
+	}
+	return &trackService{
+		Service:      opts.base,
+		TrackService: opts.track,
 	}
 }
 

--- a/internal/session/externalization/service.go
+++ b/internal/session/externalization/service.go
@@ -104,6 +104,11 @@ type trackService struct {
 	session.TrackService
 }
 
+type trackPageService struct {
+	*trackService
+	session.TrackEventPageService
+}
+
 type trackEventReader interface {
 	GetTrackEvents(ctx context.Context, key session.Key, track session.Track, opts ...session.Option) (*session.TrackEvents, error)
 }
@@ -134,6 +139,11 @@ type searchableTrackService struct {
 	session.TrackService
 }
 
+type searchableTrackPageService struct {
+	*searchableTrackService
+	session.TrackEventPageService
+}
+
 func (s *searchableTrackService) SearchEvents(
 	ctx context.Context,
 	req session.EventSearchRequest,
@@ -145,6 +155,11 @@ type windowTrackService struct {
 	*Service
 	session.WindowService
 	session.TrackService
+}
+
+type windowTrackPageService struct {
+	*windowTrackService
+	session.TrackEventPageService
 }
 
 func (s *windowTrackService) GetEventWindow(
@@ -160,11 +175,21 @@ type trackReaderService struct {
 	trackEventReader
 }
 
+type trackReaderPageService struct {
+	*trackReaderService
+	session.TrackEventPageService
+}
+
 type searchableWindowTrackService struct {
 	*Service
 	session.SearchableService
 	session.WindowService
 	session.TrackService
+}
+
+type searchableWindowTrackPageService struct {
+	*searchableWindowTrackService
+	session.TrackEventPageService
 }
 
 func (s *searchableWindowTrackService) SearchEvents(
@@ -189,6 +214,11 @@ type searchableWindowTrackReaderService struct {
 	trackEventReader
 }
 
+type searchableWindowTrackReaderPageService struct {
+	*searchableWindowTrackReaderService
+	session.TrackEventPageService
+}
+
 func (s *searchableWindowTrackReaderService) SearchEvents(
 	ctx context.Context,
 	req session.EventSearchRequest,
@@ -210,6 +240,11 @@ type searchableTrackReaderService struct {
 	trackEventReader
 }
 
+type searchableTrackReaderPageService struct {
+	*searchableTrackReaderService
+	session.TrackEventPageService
+}
+
 func (s *searchableTrackReaderService) SearchEvents(
 	ctx context.Context,
 	req session.EventSearchRequest,
@@ -222,6 +257,11 @@ type windowTrackReaderService struct {
 	session.WindowService
 	session.TrackService
 	trackEventReader
+}
+
+type windowTrackReaderPageService struct {
+	*windowTrackReaderService
+	session.TrackEventPageService
 }
 
 func (s *windowTrackReaderService) GetEventWindow(
@@ -251,6 +291,11 @@ type stateInitializingTrackService struct {
 	session.StateInitializationService
 }
 
+type stateInitializingTrackPageService struct {
+	*trackPageService
+	session.StateInitializationService
+}
+
 type stateInitializingSearchableWindowService struct {
 	*searchableWindowService
 	session.StateInitializationService
@@ -261,8 +306,18 @@ type stateInitializingSearchableTrackService struct {
 	session.StateInitializationService
 }
 
+type stateInitializingSearchableTrackPageService struct {
+	*searchableTrackPageService
+	session.StateInitializationService
+}
+
 type stateInitializingWindowTrackService struct {
 	*windowTrackService
+	session.StateInitializationService
+}
+
+type stateInitializingWindowTrackPageService struct {
+	*windowTrackPageService
 	session.StateInitializationService
 }
 
@@ -271,8 +326,18 @@ type stateInitializingTrackReaderService struct {
 	session.StateInitializationService
 }
 
+type stateInitializingTrackReaderPageService struct {
+	*trackReaderPageService
+	session.StateInitializationService
+}
+
 type stateInitializingSearchableWindowTrackService struct {
 	*searchableWindowTrackService
+	session.StateInitializationService
+}
+
+type stateInitializingSearchableWindowTrackPageService struct {
+	*searchableWindowTrackPageService
 	session.StateInitializationService
 }
 
@@ -281,13 +346,28 @@ type stateInitializingSearchableWindowTrackReaderService struct {
 	session.StateInitializationService
 }
 
+type stateInitializingSearchableWindowTrackReaderPageService struct {
+	*searchableWindowTrackReaderPageService
+	session.StateInitializationService
+}
+
 type stateInitializingSearchableTrackReaderService struct {
 	*searchableTrackReaderService
 	session.StateInitializationService
 }
 
+type stateInitializingSearchableTrackReaderPageService struct {
+	*searchableTrackReaderPageService
+	session.StateInitializationService
+}
+
 type stateInitializingWindowTrackReaderService struct {
 	*windowTrackReaderService
+	session.StateInitializationService
+}
+
+type stateInitializingWindowTrackReaderPageService struct {
+	*windowTrackReaderPageService
 	session.StateInitializationService
 }
 
@@ -305,8 +385,9 @@ func wrapExistingOptionalInterfaces(base *Service, inner session.Service) sessio
 	window, hasWindow := inner.(session.WindowService)
 	track, hasTrack := inner.(session.TrackService)
 	reader, hasReader := inner.(trackEventReader)
+	pager, hasPager := inner.(session.TrackEventPageService)
 	if hasTrack {
-		return wrapTrackOptionalInterfaces(base, searchable, hasSearch, window, hasWindow, track, reader, hasReader)
+		return wrapTrackOptionalInterfaces(base, searchable, hasSearch, window, hasWindow, track, reader, hasReader, pager, hasPager)
 	}
 	switch {
 	case hasSearch && hasWindow:
@@ -335,6 +416,46 @@ func wrapStateInitializationInterface(
 	initializer session.StateInitializationService,
 ) session.Service {
 	switch service := wrapped.(type) {
+	case *searchableWindowTrackReaderPageService:
+		return &stateInitializingSearchableWindowTrackReaderPageService{
+			searchableWindowTrackReaderPageService: service,
+			StateInitializationService:             initializer,
+		}
+	case *searchableWindowTrackPageService:
+		return &stateInitializingSearchableWindowTrackPageService{
+			searchableWindowTrackPageService: service,
+			StateInitializationService:       initializer,
+		}
+	case *searchableTrackReaderPageService:
+		return &stateInitializingSearchableTrackReaderPageService{
+			searchableTrackReaderPageService: service,
+			StateInitializationService:       initializer,
+		}
+	case *windowTrackReaderPageService:
+		return &stateInitializingWindowTrackReaderPageService{
+			windowTrackReaderPageService: service,
+			StateInitializationService:   initializer,
+		}
+	case *trackReaderPageService:
+		return &stateInitializingTrackReaderPageService{
+			trackReaderPageService:     service,
+			StateInitializationService: initializer,
+		}
+	case *searchableTrackPageService:
+		return &stateInitializingSearchableTrackPageService{
+			searchableTrackPageService: service,
+			StateInitializationService: initializer,
+		}
+	case *windowTrackPageService:
+		return &stateInitializingWindowTrackPageService{
+			windowTrackPageService:     service,
+			StateInitializationService: initializer,
+		}
+	case *trackPageService:
+		return &stateInitializingTrackPageService{
+			trackPageService:           service,
+			StateInitializationService: initializer,
+		}
 	case *searchableWindowTrackReaderService:
 		return &stateInitializingSearchableWindowTrackReaderService{
 			searchableWindowTrackReaderService: service,
@@ -409,8 +530,21 @@ func wrapTrackOptionalInterfaces(
 	track session.TrackService,
 	reader trackEventReader,
 	hasReader bool,
+	pager session.TrackEventPageService,
+	hasPager bool,
 ) session.Service {
 	switch {
+	case hasSearch && hasWindow && hasReader && hasPager:
+		return &searchableWindowTrackReaderPageService{
+			searchableWindowTrackReaderService: &searchableWindowTrackReaderService{
+				Service:           base,
+				SearchableService: searchable,
+				WindowService:     window,
+				TrackService:      track,
+				trackEventReader:  reader,
+			},
+			TrackEventPageService: pager,
+		}
 	case hasSearch && hasWindow && hasReader:
 		return &searchableWindowTrackReaderService{
 			Service:           base,
@@ -419,12 +553,32 @@ func wrapTrackOptionalInterfaces(
 			TrackService:      track,
 			trackEventReader:  reader,
 		}
+	case hasSearch && hasWindow && hasPager:
+		return &searchableWindowTrackPageService{
+			searchableWindowTrackService: &searchableWindowTrackService{
+				Service:           base,
+				SearchableService: searchable,
+				WindowService:     window,
+				TrackService:      track,
+			},
+			TrackEventPageService: pager,
+		}
 	case hasSearch && hasWindow:
 		return &searchableWindowTrackService{
 			Service:           base,
 			SearchableService: searchable,
 			WindowService:     window,
 			TrackService:      track,
+		}
+	case hasSearch && hasReader && hasPager:
+		return &searchableTrackReaderPageService{
+			searchableTrackReaderService: &searchableTrackReaderService{
+				Service:           base,
+				SearchableService: searchable,
+				TrackService:      track,
+				trackEventReader:  reader,
+			},
+			TrackEventPageService: pager,
 		}
 	case hasSearch && hasReader:
 		return &searchableTrackReaderService{
@@ -433,11 +587,30 @@ func wrapTrackOptionalInterfaces(
 			TrackService:      track,
 			trackEventReader:  reader,
 		}
+	case hasSearch && hasPager:
+		return &searchableTrackPageService{
+			searchableTrackService: &searchableTrackService{
+				Service:           base,
+				SearchableService: searchable,
+				TrackService:      track,
+			},
+			TrackEventPageService: pager,
+		}
 	case hasSearch:
 		return &searchableTrackService{
 			Service:           base,
 			SearchableService: searchable,
 			TrackService:      track,
+		}
+	case hasWindow && hasReader && hasPager:
+		return &windowTrackReaderPageService{
+			windowTrackReaderService: &windowTrackReaderService{
+				Service:          base,
+				WindowService:    window,
+				TrackService:     track,
+				trackEventReader: reader,
+			},
+			TrackEventPageService: pager,
 		}
 	case hasWindow && hasReader:
 		return &windowTrackReaderService{
@@ -446,17 +619,43 @@ func wrapTrackOptionalInterfaces(
 			TrackService:     track,
 			trackEventReader: reader,
 		}
+	case hasWindow && hasPager:
+		return &windowTrackPageService{
+			windowTrackService: &windowTrackService{
+				Service:       base,
+				WindowService: window,
+				TrackService:  track,
+			},
+			TrackEventPageService: pager,
+		}
 	case hasWindow:
 		return &windowTrackService{
 			Service:       base,
 			WindowService: window,
 			TrackService:  track,
 		}
+	case hasReader && hasPager:
+		return &trackReaderPageService{
+			trackReaderService: &trackReaderService{
+				Service:          base,
+				TrackService:     track,
+				trackEventReader: reader,
+			},
+			TrackEventPageService: pager,
+		}
 	case hasReader:
 		return &trackReaderService{
 			Service:          base,
 			TrackService:     track,
 			trackEventReader: reader,
+		}
+	case hasPager:
+		return &trackPageService{
+			trackService: &trackService{
+				Service:      base,
+				TrackService: track,
+			},
+			TrackEventPageService: pager,
 		}
 	default:
 		return &trackService{

--- a/internal/session/externalization/service_optional_test.go
+++ b/internal/session/externalization/service_optional_test.go
@@ -83,6 +83,60 @@ func TestWrapStateInitializationInterfacePreservesOptionalCombinations(
 			wrapped:  &windowTrackReaderService{Service: base},
 			expected: &stateInitializingWindowTrackReaderService{},
 		},
+		{
+			name:     "track page",
+			wrapped:  &trackPageService{trackService: &trackService{Service: base}},
+			expected: &stateInitializingTrackPageService{},
+		},
+		{
+			name: "searchable track page",
+			wrapped: &searchableTrackPageService{
+				searchableTrackService: &searchableTrackService{Service: base},
+			},
+			expected: &stateInitializingSearchableTrackPageService{},
+		},
+		{
+			name: "window track page",
+			wrapped: &windowTrackPageService{
+				windowTrackService: &windowTrackService{Service: base},
+			},
+			expected: &stateInitializingWindowTrackPageService{},
+		},
+		{
+			name: "track reader page",
+			wrapped: &trackReaderPageService{
+				trackReaderService: &trackReaderService{Service: base},
+			},
+			expected: &stateInitializingTrackReaderPageService{},
+		},
+		{
+			name: "searchable window track page",
+			wrapped: &searchableWindowTrackPageService{
+				searchableWindowTrackService: &searchableWindowTrackService{Service: base},
+			},
+			expected: &stateInitializingSearchableWindowTrackPageService{},
+		},
+		{
+			name: "searchable track reader page",
+			wrapped: &searchableTrackReaderPageService{
+				searchableTrackReaderService: &searchableTrackReaderService{Service: base},
+			},
+			expected: &stateInitializingSearchableTrackReaderPageService{},
+		},
+		{
+			name: "window track reader page",
+			wrapped: &windowTrackReaderPageService{
+				windowTrackReaderService: &windowTrackReaderService{Service: base},
+			},
+			expected: &stateInitializingWindowTrackReaderPageService{},
+		},
+		{
+			name: "searchable window track reader page",
+			wrapped: &searchableWindowTrackReaderPageService{
+				searchableWindowTrackReaderService: &searchableWindowTrackReaderService{Service: base},
+			},
+			expected: &stateInitializingSearchableWindowTrackReaderPageService{},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -100,6 +154,137 @@ func TestWrapStateInitializationInterfacePreservesOptionalCombinations(
 			require.NoError(t, err)
 			require.True(t, didInitialize)
 			require.Equal(t, "value", string(value))
+		})
+	}
+}
+
+func TestWrapTrackOptionalInterfacesPreservesOptionalCombinations(t *testing.T) {
+	base := &Service{}
+	searchable := searchableStub{}
+	window := windowStub{}
+	track := trackStub{}
+	reader := readerStub{}
+	pager := pagerStub{}
+	tests := []struct {
+		name      string
+		hasSearch bool
+		hasWindow bool
+		hasReader bool
+		hasPager  bool
+		expected  session.Service
+	}{
+		{
+			name:      "searchable window reader page",
+			hasSearch: true,
+			hasWindow: true,
+			hasReader: true,
+			hasPager:  true,
+			expected:  &searchableWindowTrackReaderPageService{},
+		},
+		{
+			name:      "searchable window reader",
+			hasSearch: true,
+			hasWindow: true,
+			hasReader: true,
+			expected:  &searchableWindowTrackReaderService{},
+		},
+		{
+			name:      "searchable window page",
+			hasSearch: true,
+			hasWindow: true,
+			hasPager:  true,
+			expected:  &searchableWindowTrackPageService{},
+		},
+		{
+			name:      "searchable window",
+			hasSearch: true,
+			hasWindow: true,
+			expected:  &searchableWindowTrackService{},
+		},
+		{
+			name:      "searchable reader page",
+			hasSearch: true,
+			hasReader: true,
+			hasPager:  true,
+			expected:  &searchableTrackReaderPageService{},
+		},
+		{
+			name:      "searchable reader",
+			hasSearch: true,
+			hasReader: true,
+			expected:  &searchableTrackReaderService{},
+		},
+		{
+			name:      "searchable page",
+			hasSearch: true,
+			hasPager:  true,
+			expected:  &searchableTrackPageService{},
+		},
+		{
+			name:      "searchable",
+			hasSearch: true,
+			expected:  &searchableTrackService{},
+		},
+		{
+			name:      "window reader page",
+			hasWindow: true,
+			hasReader: true,
+			hasPager:  true,
+			expected:  &windowTrackReaderPageService{},
+		},
+		{
+			name:      "window reader",
+			hasWindow: true,
+			hasReader: true,
+			expected:  &windowTrackReaderService{},
+		},
+		{
+			name:      "window page",
+			hasWindow: true,
+			hasPager:  true,
+			expected:  &windowTrackPageService{},
+		},
+		{
+			name:      "window",
+			hasWindow: true,
+			expected:  &windowTrackService{},
+		},
+		{
+			name:      "reader page",
+			hasReader: true,
+			hasPager:  true,
+			expected:  &trackReaderPageService{},
+		},
+		{
+			name:      "reader",
+			hasReader: true,
+			expected:  &trackReaderService{},
+		},
+		{
+			name:     "page",
+			hasPager: true,
+			expected: &trackPageService{},
+		},
+		{
+			name:     "track",
+			expected: &trackService{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wrapped := wrapTrackOptionalInterfaces(
+				base,
+				searchable,
+				test.hasSearch,
+				window,
+				test.hasWindow,
+				track,
+				reader,
+				test.hasReader,
+				pager,
+				test.hasPager,
+			)
+			require.Equal(t, reflect.TypeOf(test.expected), reflect.TypeOf(wrapped))
 		})
 	}
 }
@@ -128,4 +313,53 @@ func (stateInitializationStub) LoadOrInitializeSessionState(
 
 type unknownOptionalService struct {
 	session.Service
+}
+
+type searchableStub struct{}
+
+func (searchableStub) SearchEvents(
+	context.Context,
+	session.EventSearchRequest,
+) ([]session.EventSearchResult, error) {
+	return nil, nil
+}
+
+type windowStub struct{}
+
+func (windowStub) GetEventWindow(
+	context.Context,
+	session.EventWindowRequest,
+) (*session.EventWindow, error) {
+	return nil, nil
+}
+
+type trackStub struct{}
+
+func (trackStub) AppendTrackEvent(
+	context.Context,
+	*session.Session,
+	*session.TrackEvent,
+	...session.Option,
+) error {
+	return nil
+}
+
+type readerStub struct{}
+
+func (readerStub) GetTrackEvents(
+	context.Context,
+	session.Key,
+	session.Track,
+	...session.Option,
+) (*session.TrackEvents, error) {
+	return nil, nil
+}
+
+type pagerStub struct{}
+
+func (pagerStub) GetTrackEventPage(
+	context.Context,
+	session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	return nil, nil
 }

--- a/server/agui/internal/source/metadata.go
+++ b/server/agui/internal/source/metadata.go
@@ -27,8 +27,10 @@ const (
 
 // Metadata is the compact source metadata exposed to AG-UI consumers.
 type Metadata struct {
-	EventID            string `json:"eventId,omitempty"`
-	Author             string `json:"author,omitempty"`
+	EventID string `json:"eventId,omitempty"`
+	Author  string `json:"author,omitempty"`
+	// RunID identifies the AG-UI run associated with this metadata.
+	RunID              string `json:"runId,omitempty"`
 	InvocationID       string `json:"invocationId,omitempty"`
 	ParentInvocationID string `json:"parentInvocationId,omitempty"`
 	// ParentMetadata describes how the invocation was triggered by its
@@ -48,7 +50,14 @@ type SnapshotMetadata struct {
 	// Runs stores run-scoped metadata keyed by run ID. It is populated from
 	// persisted user-input forwardedProps metadata and is not a general run
 	// event source index.
-	Runs map[string]Metadata `json:"runs,omitempty"`
+	Runs map[string]Metadata   `json:"runs,omitempty"`
+	Page *SnapshotPageMetadata `json:"page,omitempty"`
+}
+
+// SnapshotPageMetadata describes the loaded message snapshot page.
+type SnapshotPageMetadata struct {
+	Cursor  string `json:"cursor"`  // Cursor is the opaque cursor for loading older history.
+	HasMore bool   `json:"hasMore"` // HasMore reports whether the client is missing older history.
 }
 
 // SnapshotMetadataOption configures how snapshot metadata is built.
@@ -70,6 +79,7 @@ func WithRunLifecycleEvents(include bool) SnapshotMetadataOption {
 func (m Metadata) IsZero() bool {
 	return m.EventID == "" &&
 		m.Author == "" &&
+		m.RunID == "" &&
 		m.InvocationID == "" &&
 		m.ParentInvocationID == "" &&
 		m.ParentMetadata == nil &&
@@ -80,7 +90,7 @@ func (m Metadata) IsZero() bool {
 
 // IsZero reports whether the snapshot metadata is empty.
 func (m SnapshotMetadata) IsZero() bool {
-	return len(m.Messages) == 0 && len(m.ToolCalls) == 0 && len(m.Runs) == 0
+	return len(m.Messages) == 0 && len(m.ToolCalls) == 0 && len(m.Runs) == 0 && m.Page == nil
 }
 
 // FromEvent resolves source metadata from an agent event.
@@ -140,6 +150,7 @@ func FromRawEvent(raw any) (Metadata, bool) {
 		metadata := Metadata{
 			EventID:            stringFromMap(v, "eventId"),
 			Author:             stringFromMap(v, "author"),
+			RunID:              stringFromMap(v, "runId"),
 			InvocationID:       stringFromMap(v, "invocationId"),
 			ParentInvocationID: stringFromMap(v, "parentInvocationId"),
 			Branch:             stringFromMap(v, "branch"),
@@ -184,6 +195,7 @@ func BuildSnapshotMetadata(
 		ToolCalls: make(map[string]Metadata),
 		Runs:      make(map[string]Metadata),
 	}
+	currentRunID := ""
 	for _, trackEvent := range events {
 		if len(trackEvent.Payload) == 0 {
 			continue
@@ -196,7 +208,14 @@ func BuildSnapshotMetadata(
 		if base == nil {
 			continue
 		}
+		lifecycleRunID, lifecycleStarted, lifecycleTerminal := runLifecycleRunInfo(evt)
+		if lifecycleStarted {
+			currentRunID = lifecycleRunID
+		}
 		if !options.includeRunLifecycleEvents && isRunLifecycleEvent(evt) {
+			if lifecycleTerminal {
+				currentRunID = ""
+			}
 			continue
 		}
 		sourceMetadata, ok := FromRawEvent(base.RawEvent)
@@ -210,14 +229,31 @@ func BuildSnapshotMetadata(
 		if !ok && sourceMetadata.Timestamp == nil {
 			continue
 		}
-		runID := runIDFromRawEvent(base.RawEvent)
-		recordRunMetadata(metadata.Runs, runID, sourceMetadata)
+		if sourceMetadata.RunID == "" {
+			sourceMetadata.RunID = lifecycleRunID
+		}
+		if sourceMetadata.RunID == "" {
+			sourceMetadata.RunID = currentRunID
+		}
+		if sourceMetadata.RunID == "" {
+			sourceMetadata.RunID = runIDFromRawEvent(base.RawEvent)
+		}
+		runID := sourceMetadata.RunID
+		runMetadata := sourceMetadata
+		runMetadata.RunID = ""
+		recordRunMetadata(metadata.Runs, runID, runMetadata)
 		sourceMetadata.ForwardedProps = nil
 		if sourceMetadata.IsZero() {
+			if lifecycleTerminal {
+				currentRunID = ""
+			}
 			continue
 		}
 		recordSnapshotMetadata(metadata.Messages, metadata.ToolCalls,
 			evt, sourceMetadata)
+		if lifecycleTerminal {
+			currentRunID = ""
+		}
 	}
 	if len(metadata.Messages) == 0 {
 		metadata.Messages = nil
@@ -229,6 +265,19 @@ func BuildSnapshotMetadata(
 		metadata.Runs = nil
 	}
 	return metadata
+}
+
+func runLifecycleRunInfo(evt aguievents.Event) (runID string, started bool, terminal bool) {
+	switch e := evt.(type) {
+	case *aguievents.RunStartedEvent:
+		return e.RunID(), true, false
+	case *aguievents.RunFinishedEvent:
+		return e.RunID(), false, true
+	case *aguievents.RunErrorEvent:
+		return e.RunID(), false, true
+	default:
+		return "", false, false
+	}
 }
 
 func isRunLifecycleEvent(evt aguievents.Event) bool {
@@ -433,6 +482,9 @@ func mergeMetadata(existing Metadata, incoming Metadata) Metadata {
 	}
 	if incoming.Author != "" {
 		merged.Author = incoming.Author
+	}
+	if incoming.RunID != "" {
+		merged.RunID = incoming.RunID
 	}
 	if incoming.InvocationID != "" {
 		merged.InvocationID = incoming.InvocationID

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -713,6 +713,31 @@ func TestBuildSnapshotMetadataIndexesCurrentRunID(t *testing.T) {
 	assert.Empty(t, metadata.Messages["assistant-2"].RunID)
 }
 
+func TestBuildSnapshotMetadataRunErrorClearsCurrentRunID(t *testing.T) {
+	runStarted := aguievents.NewRunStartedEvent("thread", "run-1")
+	inRun := aguievents.NewTextMessageStartEvent(
+		"assistant-1",
+		aguievents.WithRole("assistant"),
+	)
+	runError := aguievents.NewRunErrorEvent("boom", aguievents.WithRunID("run-1"))
+	afterRun := aguievents.NewTextMessageStartEvent(
+		"assistant-2",
+		aguievents.WithRole("assistant"),
+	)
+
+	metadata := BuildSnapshotMetadata([]session.TrackEvent{
+		newTrackEvent(t, runStarted),
+		newTrackEvent(t, inRun),
+		newTrackEvent(t, runError),
+		newTrackEvent(t, afterRun),
+	})
+
+	require.Contains(t, metadata.Messages, "assistant-1")
+	assert.Equal(t, "run-1", metadata.Messages["assistant-1"].RunID)
+	require.Contains(t, metadata.Messages, "assistant-2")
+	assert.Empty(t, metadata.Messages["assistant-2"].RunID)
+}
+
 func TestBuildSnapshotMetadataFallsBackToToolResultSource(t *testing.T) {
 	timestampTime := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
 	toolMetadata := Metadata{

--- a/server/agui/internal/source/metadata_test.go
+++ b/server/agui/internal/source/metadata_test.go
@@ -37,6 +37,7 @@ const (
 func TestMetadataIsZero(t *testing.T) {
 	assert.True(t, Metadata{}.IsZero())
 	assert.False(t, testMetadata("evt-1").IsZero())
+	assert.False(t, Metadata{RunID: "run-1"}.IsZero())
 	assert.False(t, Metadata{ForwardedProps: map[string]any{}}.IsZero())
 }
 
@@ -167,6 +168,7 @@ func TestFromRawEventSupportsMapPayload(t *testing.T) {
 	metadata, ok := FromRawEvent(map[string]any{
 		"eventId":            "evt-1",
 		"author":             "member-a",
+		"runId":              "run-1",
 		"invocationId":       "inv-1",
 		"parentInvocationId": "parent-1",
 		"branch":             "root.member-a",
@@ -177,6 +179,7 @@ func TestFromRawEventSupportsMapPayload(t *testing.T) {
 	assert.Equal(t, Metadata{
 		EventID:            "evt-1",
 		Author:             "member-a",
+		RunID:              "run-1",
 		InvocationID:       "inv-1",
 		ParentInvocationID: "parent-1",
 		Branch:             "root.member-a",
@@ -679,6 +682,37 @@ func TestBuildSnapshotMetadataIncludesRunLifecycleEventsWhenEnabled(t *testing.T
 	assert.Equal(t, timestampTime.UnixMilli(), *got.Timestamp)
 }
 
+func TestBuildSnapshotMetadataIndexesCurrentRunID(t *testing.T) {
+	runStarted := aguievents.NewRunStartedEvent("thread", "run-1")
+	assistantStart := aguievents.NewTextMessageStartEvent(
+		"assistant-1",
+		aguievents.WithRole("assistant"),
+	)
+	toolStart := aguievents.NewToolCallStartEvent(
+		"call-1",
+		"search",
+		aguievents.WithParentMessageID("assistant-1"),
+	)
+	runFinished := aguievents.NewRunFinishedEvent("thread", "run-1")
+	afterRun := aguievents.NewTextMessageStartEvent(
+		"assistant-2",
+		aguievents.WithRole("assistant"),
+	)
+	metadata := BuildSnapshotMetadata([]session.TrackEvent{
+		newTrackEvent(t, runStarted),
+		newTrackEvent(t, assistantStart),
+		newTrackEvent(t, toolStart),
+		newTrackEvent(t, runFinished),
+		newTrackEvent(t, afterRun),
+	})
+	require.Contains(t, metadata.Messages, "assistant-1")
+	assert.Equal(t, "run-1", metadata.Messages["assistant-1"].RunID)
+	require.Contains(t, metadata.ToolCalls, "call-1")
+	assert.Equal(t, "run-1", metadata.ToolCalls["call-1"].RunID)
+	require.Contains(t, metadata.Messages, "assistant-2")
+	assert.Empty(t, metadata.Messages["assistant-2"].RunID)
+}
+
 func TestBuildSnapshotMetadataFallsBackToToolResultSource(t *testing.T) {
 	timestampTime := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
 	toolMetadata := Metadata{
@@ -812,9 +846,11 @@ func TestBuildSnapshotMetadataIndexesForwardedPropsByRunID(t *testing.T) {
 	require.NotNil(t, gotRun.Timestamp)
 	assert.Equal(t, timestampTime.UnixMilli(), *gotRun.Timestamp)
 	assert.Equal(t, "demo-user", gotRun.Author)
+	assert.Empty(t, gotRun.RunID)
 	assert.Equal(t, forwardedProps, gotRun.ForwardedProps)
 	require.Contains(t, metadata.Messages, "user-1")
 	gotMessage := metadata.Messages["user-1"]
+	assert.Equal(t, "run-1", gotMessage.RunID)
 	assert.Nil(t, gotMessage.ForwardedProps)
 }
 
@@ -837,6 +873,9 @@ func TestBuildSnapshotMetadataIndexesRunOnlyForwardedProps(t *testing.T) {
 		})),
 	})
 	assert.Equal(t, SnapshotMetadata{
+		Messages: map[string]Metadata{
+			"user-1": {RunID: "run-1"},
+		},
 		Runs: map[string]Metadata{
 			"run-1": {ForwardedProps: forwardedProps},
 		},

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -10,9 +10,11 @@
 package agui
 
 import (
+	"context"
 	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/runner"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service/sse"
@@ -231,6 +233,22 @@ func WithEventSourceMetadataEnabled(enabled bool) Option {
 		o.aguiRunnerOptions = append(
 			o.aguiRunnerOptions,
 			aguirunner.WithEventSourceMetadataEnabled(enabled),
+		)
+	}
+}
+
+// WithMessagesSnapshotSessionPageResolver sets optional session pagination for message snapshots.
+func WithMessagesSnapshotSessionPageResolver(
+	resolver func(
+		ctx context.Context,
+		input *adapter.RunAgentInput,
+		key session.Key,
+	) (*aguirunner.MessagesSnapshotPageRequest, error),
+) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(
+			o.aguiRunnerOptions,
+			aguirunner.WithMessagesSnapshotSessionPageResolver(resolver),
 		)
 	}
 }

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	aguirunner "trpc.group/trpc-go/trpc-agent-go/server/agui/runner"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/service"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
 func TestNewOptionsDefaults(t *testing.T) {
@@ -205,6 +206,24 @@ func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {
 	opts := newOptions(WithMessagesSnapshotRunLifecycleEventsEnabled(true))
 	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
 	assert.True(t, ro.MessagesSnapshotRunLifecycleEventsEnabled)
+}
+
+func TestWithMessagesSnapshotSessionPageResolver(t *testing.T) {
+	resolver := func(
+		context.Context,
+		*adapter.RunAgentInput,
+		session.Key,
+	) (*aguirunner.MessagesSnapshotPageRequest, error) {
+		return &aguirunner.MessagesSnapshotPageRequest{Cursor: "cursor", EventLimit: 3}, nil
+	}
+
+	opts := newOptions(WithMessagesSnapshotSessionPageResolver(resolver))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	require.NotNil(t, ro.MessagesSnapshotSessionPageResolver)
+
+	req, err := ro.MessagesSnapshotSessionPageResolver(context.Background(), &adapter.RunAgentInput{}, session.Key{})
+	require.NoError(t, err)
+	assert.Equal(t, &aguirunner.MessagesSnapshotPageRequest{Cursor: "cursor", EventLimit: 3}, req)
 }
 
 func TestWithCancelEnabled(t *testing.T) {

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -288,7 +288,7 @@ func trimTrackEventPageEntriesToHistoryStart(
 	for i, entry := range entries {
 		if isUserMessageTrackEvent(entry.Event) {
 			page.Cursor = entry.Cursor
-			page.HasMore = sessionHasMore || i > 0
+			page.HasMore = sessionHasMore
 			events := make([]session.TrackEvent, 0, len(entries)-i)
 			for _, kept := range entries[i:] {
 				events = append(events, kept.Event)
@@ -296,7 +296,8 @@ func trimTrackEventPageEntriesToHistoryStart(
 			return events, page
 		}
 	}
-	page.HasMore = true
+	page.Cursor = entries[0].Cursor
+	page.HasMore = sessionHasMore
 	return nil, page
 }
 

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/reduce"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/source"
+	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/track"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
@@ -75,10 +76,11 @@ func (r *runner) MessagesSnapshot(ctx context.Context,
 			UserID:    userID,
 			SessionID: runAgentInput.ThreadID,
 		},
-		threadID:    runAgentInput.ThreadID,
-		runID:       runAgentInput.RunID,
-		userID:      userID,
-		enableTrack: false,
+		threadID:      runAgentInput.ThreadID,
+		runID:         runAgentInput.RunID,
+		userID:        userID,
+		enableTrack:   false,
+		runAgentInput: runAgentInput,
 	}
 	events := make(chan aguievents.Event)
 	runCtx := agent.CloneContext(ctx)
@@ -96,7 +98,22 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 		return
 	}
 
-	messagesSnapshotEvent, trackEvents, err := r.getMessagesSnapshotEvent(ctx, input.key)
+	pageReq, err := r.resolveMessagesSnapshotSessionPage(ctx, input)
+	if err != nil {
+		log.ErrorfContext(ctx, "agui messages snapshot: threadID: %s, runID: %s, resolve page: %v",
+			threadID, runID, err)
+		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(fmt.Sprintf("resolve page: %v", err),
+			aguievents.WithRunID(runID)), input)
+		return
+	}
+	// Unsupported session pagers keep the existing full snapshot behavior.
+	if pageReq != nil {
+		if _, ok := r.sessionService.(session.TrackEventPageService); !ok {
+			pageReq = nil
+		}
+	}
+	input.messagesSnapshotPage = pageReq
+	messagesSnapshotEvent, trackEvents, err := r.getMessagesSnapshotEvent(ctx, input.key, input.messagesSnapshotPage)
 	if err != nil {
 		log.ErrorfContext(
 			ctx,
@@ -123,7 +140,7 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 		return
 	}
 
-	if r.messagesSnapshotFollowEnabled && r.shouldFollowMessagesSnapshot(input.key, trackEvents) {
+	if input.messagesSnapshotPage == nil && r.messagesSnapshotFollowEnabled && r.shouldFollowMessagesSnapshot(input.key, trackEvents) {
 		r.messagesSnapshotFollow(ctx, input, events, trackEvents)
 		return
 	}
@@ -133,10 +150,46 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 	}
 }
 
+func (r *runner) resolveMessagesSnapshotSessionPage(
+	ctx context.Context,
+	input *runInput,
+) (*MessagesSnapshotPageRequest, error) {
+	if r.messagesSnapshotSessionPageResolver == nil {
+		return nil, nil
+	}
+	req, err := r.messagesSnapshotSessionPageResolver(ctx, input.runAgentInput, input.key)
+	if err != nil {
+		return nil, err
+	}
+	if req == nil {
+		return nil, nil
+	}
+	if req.EventLimit <= 0 {
+		return nil, errors.New("messages snapshot session page requires eventLimit > 0")
+	}
+	copied := *req
+	return &copied, nil
+}
+
 // getMessagesSnapshotEvent loads AG-UI track events and converts them to an AG-UI MessagesSnapshotEvent.
 // In order to fetch the history messages as much as possible, still return the messages even if there is an error.
-func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
-	sessionKey session.Key) (*aguievents.MessagesSnapshotEvent, *session.TrackEvents, error) {
+func (r *runner) getMessagesSnapshotEvent(
+	ctx context.Context,
+	sessionKey session.Key,
+	pageReq *MessagesSnapshotPageRequest,
+) (*aguievents.MessagesSnapshotEvent, *session.TrackEvents, error) {
+	if pageReq != nil {
+		if pager, ok := r.sessionService.(session.TrackEventPageService); ok {
+			return r.getMessagesSnapshotPageEvent(ctx, sessionKey, pageReq, pager)
+		}
+	}
+	return r.getMessagesSnapshotFullEvent(ctx, sessionKey)
+}
+
+func (r *runner) getMessagesSnapshotFullEvent(
+	ctx context.Context,
+	sessionKey session.Key,
+) (*aguievents.MessagesSnapshotEvent, *session.TrackEvents, error) {
 	trackEvents, err := r.tracker.GetEvents(ctx, sessionKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get track events: %w", err)
@@ -158,19 +211,95 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 	log.DebugfContext(ctx, "agui messages snapshot: app=%s, user=%s, session=%s, trackEvents=%d, eventsForReduce=%d, safeForFollow=%t, messages=%d, reduceErr=%v",
 		sessionKey.AppName, sessionKey.UserID, sessionKey.SessionID, len(trackEvents.Events), len(eventsForReduce), safeForFollow, len(messages), err)
 	event := aguievents.NewMessagesSnapshotEvent(messages)
-	if r.eventSourceMetadataEnabled {
-		metadata := source.BuildSnapshotMetadata(
-			eventsForReduce,
-			source.WithRunLifecycleEvents(r.messagesSnapshotRunLifecycleEventsEnabled),
-		)
-		if !metadata.IsZero() {
-			event.GetBaseEvent().RawEvent = metadata
-		}
-	}
+	r.attachMessagesSnapshotRawEvent(event, eventsForReduce, nil)
 	if !safeForFollow {
 		trackEvents = nil
 	}
 	return event, trackEvents, err
+}
+
+func (r *runner) getMessagesSnapshotPageEvent(
+	ctx context.Context,
+	sessionKey session.Key,
+	pageReq *MessagesSnapshotPageRequest,
+	pager session.TrackEventPageService,
+) (*aguievents.MessagesSnapshotEvent, *session.TrackEvents, error) {
+	page, err := pager.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        sessionKey,
+		Track:      track.TrackAGUI,
+		Cursor:     pageReq.Cursor,
+		EventLimit: pageReq.EventLimit,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("get track event page: %w", err)
+	}
+	eventsForReduce, pageMetadata := trimTrackEventPageEntriesToHistoryStart(
+		page.Entries,
+		pageReq.Cursor,
+		page.HasMore,
+	)
+	messages, err := reduce.Reduce(
+		sessionKey.AppName,
+		sessionKey.UserID,
+		eventsForReduce,
+		reduce.WithRunLifecycleEvents(r.messagesSnapshotRunLifecycleEventsEnabled),
+	)
+	if err != nil {
+		err = fmt.Errorf("reduce track events: %w", err)
+	}
+	log.DebugfContext(ctx, "agui messages snapshot page: app=%s, user=%s, session=%s, pageEntries=%d, eventsForReduce=%d, hasMore=%t, messages=%d, reduceErr=%v",
+		sessionKey.AppName, sessionKey.UserID, sessionKey.SessionID, len(page.Entries), len(eventsForReduce), pageMetadata.HasMore, len(messages), err)
+	event := aguievents.NewMessagesSnapshotEvent(messages)
+	r.attachMessagesSnapshotRawEvent(event, eventsForReduce, &pageMetadata)
+	return event, nil, err
+}
+
+func (r *runner) attachMessagesSnapshotRawEvent(
+	event *aguievents.MessagesSnapshotEvent,
+	events []session.TrackEvent,
+	page *source.SnapshotPageMetadata,
+) {
+	metadata := source.SnapshotMetadata{}
+	if r.eventSourceMetadataEnabled {
+		metadata = source.BuildSnapshotMetadata(
+			events,
+			source.WithRunLifecycleEvents(r.messagesSnapshotRunLifecycleEventsEnabled),
+		)
+	}
+	if page != nil {
+		pageCopy := *page
+		metadata.Page = &pageCopy
+	}
+	if !metadata.IsZero() {
+		event.GetBaseEvent().RawEvent = metadata
+	}
+}
+
+func trimTrackEventPageEntriesToHistoryStart(
+	entries []session.TrackEventPageEntry,
+	requestCursor string,
+	sessionHasMore bool,
+) ([]session.TrackEvent, source.SnapshotPageMetadata) {
+	page := source.SnapshotPageMetadata{
+		Cursor:  requestCursor,
+		HasMore: sessionHasMore,
+	}
+	if len(entries) == 0 {
+		return nil, page
+	}
+	for i, entry := range entries {
+		if isUserMessageTrackEvent(entry.Event) {
+			page.Cursor = entry.Cursor
+			page.HasMore = sessionHasMore || i > 0
+			events := make([]session.TrackEvent, 0, len(entries)-i)
+			for _, kept := range entries[i:] {
+				events = append(events, kept.Event)
+			}
+			return events, page
+		}
+	}
+	page.HasMore = true
+	return nil, page
 }
 
 func trimTrackEventsToHistoryStart(events []session.TrackEvent) ([]session.TrackEvent, bool) {

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -98,18 +98,16 @@ func (r *runner) messagesSnapshot(ctx context.Context, input *runInput, events c
 		return
 	}
 
-	pageReq, err := r.resolveMessagesSnapshotSessionPage(ctx, input)
-	if err != nil {
-		log.ErrorfContext(ctx, "agui messages snapshot: threadID: %s, runID: %s, resolve page: %v",
-			threadID, runID, err)
-		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(fmt.Sprintf("resolve page: %v", err),
-			aguievents.WithRunID(runID)), input)
-		return
-	}
-	// Unsupported session pagers keep the existing full snapshot behavior.
-	if pageReq != nil {
-		if _, ok := r.sessionService.(session.TrackEventPageService); !ok {
-			pageReq = nil
+	var pageReq *MessagesSnapshotPageRequest
+	if _, ok := r.sessionService.(session.TrackEventPageService); ok {
+		var err error
+		pageReq, err = r.resolveMessagesSnapshotSessionPage(ctx, input)
+		if err != nil {
+			log.ErrorfContext(ctx, "agui messages snapshot: threadID: %s, runID: %s, resolve page: %v",
+				threadID, runID, err)
+			r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(fmt.Sprintf("resolve page: %v", err),
+				aguievents.WithRunID(runID)), input)
+			return
 		}
 	}
 	input.messagesSnapshotPage = pageReq

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -288,7 +288,7 @@ func trimTrackEventPageEntriesToHistoryStart(
 	for i, entry := range entries {
 		if isUserMessageTrackEvent(entry.Event) {
 			page.Cursor = entry.Cursor
-			page.HasMore = sessionHasMore
+			page.HasMore = sessionHasMore || i > 0
 			events := make([]session.TrackEvent, 0, len(entries)-i)
 			for _, kept := range entries[i:] {
 				events = append(events, kept.Event)
@@ -296,8 +296,7 @@ func trimTrackEventPageEntriesToHistoryStart(
 			return events, page
 		}
 	}
-	page.Cursor = entries[0].Cursor
-	page.HasMore = sessionHasMore
+	page.HasMore = true
 	return nil, page
 }
 

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -453,6 +453,7 @@ func TestMessagesSnapshotPageAttachesMetadataAndTrimsToUserBoundary(t *testing.T
 				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")), "assistant-content-cursor"),
 				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-1")), "assistant-end-cursor"),
 			},
+			HasMore: true,
 		},
 	}
 	tracker, err := track.New(svc)
@@ -494,7 +495,7 @@ func TestMessagesSnapshotPageAttachesMetadataAndTrimsToUserBoundary(t *testing.T
 	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
 }
 
-func TestMessagesSnapshotPageWithoutUserBoundaryKeepsCursor(t *testing.T) {
+func TestMessagesSnapshotPageWithoutUserBoundaryAdvancesCursor(t *testing.T) {
 	svc := &testSessionService{
 		trackPage: &session.TrackEventPage{
 			Track: track.TrackAGUI,
@@ -527,8 +528,47 @@ func TestMessagesSnapshotPageWithoutUserBoundaryKeepsCursor(t *testing.T) {
 	raw, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
 	require.True(t, ok)
 	require.NotNil(t, raw.Page)
-	assert.Equal(t, "request-cursor", raw.Page.Cursor)
-	assert.True(t, raw.Page.HasMore)
+	assert.Equal(t, "assistant-start-cursor", raw.Page.Cursor)
+	assert.False(t, raw.Page.HasMore)
+}
+
+func TestMessagesSnapshotPageOldestUserBoundaryDoesNotForceHasMore(t *testing.T) {
+	svc := &testSessionService{
+		trackPage: &session.TrackEventPage{
+			Track: track.TrackAGUI,
+			Entries: []session.TrackEventPageEntry{
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("old-assistant", "orphan")), "orphan-cursor"),
+				newTrackPageEntry(t, newUserMessageTrackEvent(t, "user-1", "hi"), "user-cursor"),
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))), "assistant-start-cursor"),
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")), "assistant-content-cursor"),
+			},
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		sessionService:    svc,
+		tracker:           tracker,
+		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
+			return &MessagesSnapshotPageRequest{Cursor: "request-cursor", EventLimit: 4}, nil
+		},
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 2)
+	raw, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
+	require.True(t, ok)
+	require.NotNil(t, raw.Page)
+	assert.Equal(t, "user-cursor", raw.Page.Cursor)
+	assert.False(t, raw.Page.HasMore)
 }
 
 func TestMessagesSnapshotPageResolverErrorEmitsRunError(t *testing.T) {

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -558,6 +558,7 @@ func TestMessagesSnapshotPageResolverErrorEmitsRunError(t *testing.T) {
 
 func TestMessagesSnapshotPageFallsBackToFullSnapshotWhenUnsupported(t *testing.T) {
 	baseTime := time.Now().Add(-time.Second)
+	resolverCalled := false
 	tracker := &sequenceTracker{
 		first: &session.TrackEvents{
 			Track: track.TrackAGUI,
@@ -582,7 +583,8 @@ func TestMessagesSnapshotPageFallsBackToFullSnapshotWhenUnsupported(t *testing.T
 		messagesSnapshotFollowEnabled:     true,
 		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
 		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
-			return &MessagesSnapshotPageRequest{Cursor: "request-cursor", EventLimit: 1}, nil
+			resolverCalled = true
+			return nil, errors.New("resolver should be skipped")
 		},
 	}
 	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
@@ -598,6 +600,7 @@ func TestMessagesSnapshotPageFallsBackToFullSnapshotWhenUnsupported(t *testing.T
 	calls := tracker.calls
 	tracker.mu.Unlock()
 	assert.Equal(t, 2, calls)
+	assert.False(t, resolverCalled)
 }
 
 func TestMessagesSnapshotUsesResolvedAppName(t *testing.T) {

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -438,7 +438,166 @@ func TestMessagesSnapshotAttachesForwardedPropsRunMetadata(t *testing.T) {
 	assert.Equal(t, forwardedProps, gotRun.ForwardedProps)
 	assertSnapshotMetadataTimestamp(t, gotRun, baseTime)
 	require.Contains(t, gotRawEvent.Messages, "user-1")
+	assert.Equal(t, "real-run", gotRawEvent.Messages["user-1"].RunID)
 	assert.Nil(t, gotRawEvent.Messages["user-1"].ForwardedProps)
+}
+
+func TestMessagesSnapshotPageAttachesMetadataAndTrimsToUserBoundary(t *testing.T) {
+	svc := &testSessionService{
+		trackPage: &session.TrackEventPage{
+			Track: track.TrackAGUI,
+			Entries: []session.TrackEventPageEntry{
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("old-assistant", "orphan")), "orphan-cursor"),
+				newTrackPageEntry(t, newUserMessageTrackEvent(t, "user-1", "hi"), "user-cursor"),
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))), "assistant-start-cursor"),
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")), "assistant-content-cursor"),
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-1")), "assistant-end-cursor"),
+			},
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		sessionService:    svc,
+		tracker:           tracker,
+		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
+			return &MessagesSnapshotPageRequest{Cursor: "request-cursor", EventLimit: 5}, nil
+		},
+		messagesSnapshotFollowEnabled: true,
+		flushInterval:                 time.Millisecond,
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 2)
+	assert.Equal(t, types.RoleUser, snapshot.Messages[0].Role)
+	assert.Equal(t, "user-1", snapshot.Messages[0].ID)
+	assert.Equal(t, types.RoleAssistant, snapshot.Messages[1].Role)
+	raw, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
+	require.True(t, ok)
+	require.NotNil(t, raw.Page)
+	assert.Equal(t, "user-cursor", raw.Page.Cursor)
+	assert.True(t, raw.Page.HasMore)
+	assert.Equal(t, session.TrackEventPageRequest{
+		Key:        session.Key{AppName: "demo", UserID: "user", SessionID: "thread"},
+		Track:      track.TrackAGUI,
+		Cursor:     "request-cursor",
+		EventLimit: 5,
+	}, svc.lastTrackPageReq)
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+}
+
+func TestMessagesSnapshotPageWithoutUserBoundaryKeepsCursor(t *testing.T) {
+	svc := &testSessionService{
+		trackPage: &session.TrackEventPage{
+			Track: track.TrackAGUI,
+			Entries: []session.TrackEventPageEntry{
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))), "assistant-start-cursor"),
+				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")), "assistant-content-cursor"),
+			},
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		sessionService:    svc,
+		tracker:           tracker,
+		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
+			return &MessagesSnapshotPageRequest{Cursor: "request-cursor", EventLimit: 2}, nil
+		},
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Empty(t, snapshot.Messages)
+	raw, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
+	require.True(t, ok)
+	require.NotNil(t, raw.Page)
+	assert.Equal(t, "request-cursor", raw.Page.Cursor)
+	assert.True(t, raw.Page.HasMore)
+}
+
+func TestMessagesSnapshotPageResolverErrorEmitsRunError(t *testing.T) {
+	svc := &testSessionService{}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:            noopBaseRunner{},
+		userIDResolver:    NewOptions().UserIDResolver,
+		runAgentInputHook: NewOptions().RunAgentInputHook,
+		appName:           "demo",
+		sessionService:    svc,
+		tracker:           tracker,
+		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
+			return nil, errors.New("bad page")
+		},
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 2)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	runErr, ok := collected[1].(*aguievents.RunErrorEvent)
+	require.True(t, ok)
+	assert.Contains(t, runErr.Message, "bad page")
+}
+
+func TestMessagesSnapshotPageFallsBackToFullSnapshotWhenUnsupported(t *testing.T) {
+	baseTime := time.Now().Add(-time.Second)
+	tracker := &sequenceTracker{
+		first: &session.TrackEvents{
+			Track: track.TrackAGUI,
+			Events: []session.TrackEvent{
+				newUserMessageTrackEventAt(t, "user-1", "hi", baseTime),
+			},
+		},
+		second: &session.TrackEvents{
+			Track: track.TrackAGUI,
+			Events: []session.TrackEvent{
+				newTrackEventAt(t, aguievents.NewRunFinishedEvent("thread", "real-run"), baseTime.Add(time.Millisecond)),
+			},
+		},
+	}
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           tracker,
+		flushInterval:                     time.Millisecond,
+		messagesSnapshotFollowEnabled:     true,
+		messagesSnapshotFollowMaxDuration: 100 * time.Millisecond,
+		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
+			return &MessagesSnapshotPageRequest{Cursor: "request-cursor", EventLimit: 1}, nil
+		},
+	}
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 1)
+	assert.Nil(t, snapshot.GetBaseEvent().RawEvent)
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+	tracker.mu.Lock()
+	calls := tracker.calls
+	tracker.mu.Unlock()
+	assert.Equal(t, 2, calls)
 }
 
 func TestMessagesSnapshotUsesResolvedAppName(t *testing.T) {
@@ -1875,6 +2034,7 @@ func assertSnapshotSourceMetadata(
 	t.Helper()
 	assert.Equal(t, want.EventID, got.EventID)
 	assert.Equal(t, want.Author, got.Author)
+	assert.Equal(t, want.RunID, got.RunID)
 	assert.Equal(t, want.InvocationID, got.InvocationID)
 	assert.Equal(t, want.ParentInvocationID, got.ParentInvocationID)
 	assert.Equal(t, want.Branch, got.Branch)
@@ -1927,6 +2087,18 @@ func newTrackEventAt(t *testing.T, evt aguievents.Event, ts time.Time) session.T
 		Track:     track.TrackAGUI,
 		Payload:   append([]byte(nil), payload...),
 		Timestamp: ts,
+	}
+}
+
+func newTrackPageEntry(
+	t *testing.T,
+	event session.TrackEvent,
+	cursor string,
+) session.TrackEventPageEntry {
+	t.Helper()
+	return session.TrackEventPageEntry{
+		Event:  event,
+		Cursor: cursor,
 	}
 }
 
@@ -2142,11 +2314,14 @@ func (t *emptyTrackThenTerminalTracker) Close(ctx context.Context, key session.K
 }
 
 type testSessionService struct {
-	trackEvents   []session.TrackEvent
-	getErr        error
-	returnNil     bool
-	lastGetKey    session.Key
-	appendTrackFn func(ctx context.Context, sess *session.Session,
+	trackEvents      []session.TrackEvent
+	trackPage        *session.TrackEventPage
+	trackPageErr     error
+	getErr           error
+	returnNil        bool
+	lastGetKey       session.Key
+	lastTrackPageReq session.TrackEventPageRequest
+	appendTrackFn    func(ctx context.Context, sess *session.Session,
 		evt *session.TrackEvent, opts ...session.Option) error
 }
 
@@ -2260,6 +2435,20 @@ func (s *testSessionService) AppendTrackEvent(ctx context.Context, sess *session
 		s.trackEvents = append(s.trackEvents, *evt)
 	}
 	return nil
+}
+
+func (s *testSessionService) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	s.lastTrackPageReq = req
+	if s.trackPageErr != nil {
+		return nil, s.trackPageErr
+	}
+	if s.trackPage != nil {
+		return s.trackPage, nil
+	}
+	return &session.TrackEventPage{Track: req.Track}, nil
 }
 
 func (s *testSessionService) CreateSessionSummary(ctx context.Context, sess *session.Session, summary string,

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -453,7 +453,6 @@ func TestMessagesSnapshotPageAttachesMetadataAndTrimsToUserBoundary(t *testing.T
 				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")), "assistant-content-cursor"),
 				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-1")), "assistant-end-cursor"),
 			},
-			HasMore: true,
 		},
 	}
 	tracker, err := track.New(svc)
@@ -495,7 +494,7 @@ func TestMessagesSnapshotPageAttachesMetadataAndTrimsToUserBoundary(t *testing.T
 	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
 }
 
-func TestMessagesSnapshotPageWithoutUserBoundaryAdvancesCursor(t *testing.T) {
+func TestMessagesSnapshotPageWithoutUserBoundaryKeepsCursor(t *testing.T) {
 	svc := &testSessionService{
 		trackPage: &session.TrackEventPage{
 			Track: track.TrackAGUI,
@@ -528,47 +527,8 @@ func TestMessagesSnapshotPageWithoutUserBoundaryAdvancesCursor(t *testing.T) {
 	raw, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
 	require.True(t, ok)
 	require.NotNil(t, raw.Page)
-	assert.Equal(t, "assistant-start-cursor", raw.Page.Cursor)
-	assert.False(t, raw.Page.HasMore)
-}
-
-func TestMessagesSnapshotPageOldestUserBoundaryDoesNotForceHasMore(t *testing.T) {
-	svc := &testSessionService{
-		trackPage: &session.TrackEventPage{
-			Track: track.TrackAGUI,
-			Entries: []session.TrackEventPageEntry{
-				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("old-assistant", "orphan")), "orphan-cursor"),
-				newTrackPageEntry(t, newUserMessageTrackEvent(t, "user-1", "hi"), "user-cursor"),
-				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))), "assistant-start-cursor"),
-				newTrackPageEntry(t, newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "hello")), "assistant-content-cursor"),
-			},
-		},
-	}
-	tracker, err := track.New(svc)
-	require.NoError(t, err)
-	r := &runner{
-		runner:            noopBaseRunner{},
-		userIDResolver:    NewOptions().UserIDResolver,
-		runAgentInputHook: NewOptions().RunAgentInputHook,
-		appName:           "demo",
-		sessionService:    svc,
-		tracker:           tracker,
-		messagesSnapshotSessionPageResolver: func(ctx context.Context, input *adapter.RunAgentInput, key session.Key) (*MessagesSnapshotPageRequest, error) {
-			return &MessagesSnapshotPageRequest{Cursor: "request-cursor", EventLimit: 4}, nil
-		},
-	}
-	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
-	require.NoError(t, err)
-	collected := collectAGUIEvents(t, stream)
-	require.Len(t, collected, 3)
-	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
-	require.True(t, ok)
-	require.Len(t, snapshot.Messages, 2)
-	raw, ok := snapshot.GetBaseEvent().RawEvent.(source.SnapshotMetadata)
-	require.True(t, ok)
-	require.NotNil(t, raw.Page)
-	assert.Equal(t, "user-cursor", raw.Page.Cursor)
-	assert.False(t, raw.Page.HasMore)
+	assert.Equal(t, "request-cursor", raw.Page.Cursor)
+	assert.True(t, raw.Page.HasMore)
 }
 
 func TestMessagesSnapshotPageResolverErrorEmitsRunError(t *testing.T) {

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -248,7 +248,9 @@ type MessagesSnapshotPageRequest struct {
 //
 // Returning nil uses the existing full-history snapshot behavior. Returning a
 // non-nil request asks the session service for a cursor page of AG-UI track
-// events before AG-UI reduces those events into messages.
+// events before AG-UI reduces those events into messages. A non-nil request
+// disables snapshot follow mode for that request, so the stream finishes after
+// the paginated snapshot. The input has already passed through RunAgentInputHook.
 type MessagesSnapshotSessionPageResolver func(
 	ctx context.Context,
 	input *adapter.RunAgentInput,

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -41,38 +41,39 @@ const (
 
 // Options holds the options for the runner.
 type Options struct {
-	TranslatorFactory                         TranslatorFactory     // TranslatorFactory creates a translator for an AG-UI run.
-	UserIDResolver                            UserIDResolver        // UserIDResolver derives the user identifier for an AG-UI run.
-	TranslateCallbacks                        *translator.Callbacks // TranslateCallbacks translates the run events to AG-UI events.
-	RunAgentInputHook                         RunAgentInputHook     // RunAgentInputHook allows modifying the run input before processing.
-	RunHooks                                  []RunHook             // RunHooks observe an AG-UI run and may emit run-scoped UI events.
-	AppName                                   string                // AppName is the name of the application.
-	AppNameResolver                           AppNameResolver       // AppNameResolver derives the app name for an AG-UI run.
-	SessionService                            session.Service       // SessionService is the session service.
-	StateResolver                             StateResolver         // StateResolver resolves runtime state for an AG-UI run.
-	RunOptionResolver                         RunOptionResolver     // RunOptionResolver resolves the runner options for an AG-UI run.
-	AggregatorFactory                         aggregator.Factory    // AggregatorFactory builds an aggregator for each run.
-	AggregationOption                         []aggregator.Option   // AggregationOption is the aggregation options for each run.
-	FlushInterval                             time.Duration         // FlushInterval controls how often buffered AG-UI events are flushed for a session.
-	MessagesSnapshotFollowEnabled             bool                  // MessagesSnapshotFollowEnabled enables tailing persisted AG-UI track events after MESSAGES_SNAPSHOT.
-	MessagesSnapshotFollowMaxDuration         time.Duration         // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
-	MessagesSnapshotRunLifecycleEventsEnabled bool                  // MessagesSnapshotRunLifecycleEventsEnabled includes persisted RUN_* events as activity messages in MESSAGES_SNAPSHOT.
-	StartSpan                                 StartSpan             // StartSpan starts a span for an AG-UI run.
-	PostRunFinalizationTimeout                time.Duration         // PostRunFinalizationTimeout bounds how long post-run finalization is allowed to take.
-	TrackPersistenceTimeout                   time.Duration         // TrackPersistenceTimeout bounds how long AG-UI track persistence is allowed to take.
-	Timeout                                   time.Duration         // Timeout controls how long a run is allowed to execute.
-	CancelOnContextDoneEnabled                bool                  // CancelOnContextDoneEnabled cancels the run when the parent context is done.
-	GraphNodeLifecycleActivityEnabled         bool                  // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
-	GraphNodeInterruptActivityEnabled         bool                  // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
-	GraphNodeInterruptActivityTopLevelOnly    bool                  // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
-	ReasoningContentEnabled                   bool                  // ReasoningContentEnabled controls whether reasoning content events are emitted.
-	EventSourceMetadataEnabled                bool                  // EventSourceMetadataEnabled attaches source metadata to AG-UI rawEvent fields.
-	ToolResultInputTranslationEnabled         bool                  // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
-	ToolCallDeltaStreamingEnabled             bool                  // ToolCallDeltaStreamingEnabled streams partial tool-call arguments.
-	StreamingToolResultActivityEnabled        bool                  // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
-	ConcurrentMessageStreamsEnabled           bool                  // ConcurrentMessageStreamsEnabled keeps multiple message streams open by message ID.
-	DistributedCancelEnabled                  bool                  // DistributedCancelEnabled enables best-effort cancel signaling through SessionState.
-	DistributedCancelPollInterval             time.Duration         // DistributedCancelPollInterval controls how often owner runs poll cancel markers.
+	TranslatorFactory                         TranslatorFactory                   // TranslatorFactory creates a translator for an AG-UI run.
+	UserIDResolver                            UserIDResolver                      // UserIDResolver derives the user identifier for an AG-UI run.
+	TranslateCallbacks                        *translator.Callbacks               // TranslateCallbacks translates the run events to AG-UI events.
+	RunAgentInputHook                         RunAgentInputHook                   // RunAgentInputHook allows modifying the run input before processing.
+	RunHooks                                  []RunHook                           // RunHooks observe an AG-UI run and may emit run-scoped UI events.
+	AppName                                   string                              // AppName is the name of the application.
+	AppNameResolver                           AppNameResolver                     // AppNameResolver derives the app name for an AG-UI run.
+	SessionService                            session.Service                     // SessionService is the session service.
+	StateResolver                             StateResolver                       // StateResolver resolves runtime state for an AG-UI run.
+	RunOptionResolver                         RunOptionResolver                   // RunOptionResolver resolves the runner options for an AG-UI run.
+	AggregatorFactory                         aggregator.Factory                  // AggregatorFactory builds an aggregator for each run.
+	AggregationOption                         []aggregator.Option                 // AggregationOption is the aggregation options for each run.
+	FlushInterval                             time.Duration                       // FlushInterval controls how often buffered AG-UI events are flushed for a session.
+	MessagesSnapshotFollowEnabled             bool                                // MessagesSnapshotFollowEnabled enables tailing persisted AG-UI track events after MESSAGES_SNAPSHOT.
+	MessagesSnapshotFollowMaxDuration         time.Duration                       // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
+	MessagesSnapshotRunLifecycleEventsEnabled bool                                // MessagesSnapshotRunLifecycleEventsEnabled includes persisted RUN_* events as activity messages in MESSAGES_SNAPSHOT.
+	MessagesSnapshotSessionPageResolver       MessagesSnapshotSessionPageResolver // MessagesSnapshotSessionPageResolver resolves optional session track-event pagination for MESSAGES_SNAPSHOT.
+	StartSpan                                 StartSpan                           // StartSpan starts a span for an AG-UI run.
+	PostRunFinalizationTimeout                time.Duration                       // PostRunFinalizationTimeout bounds how long post-run finalization is allowed to take.
+	TrackPersistenceTimeout                   time.Duration                       // TrackPersistenceTimeout bounds how long AG-UI track persistence is allowed to take.
+	Timeout                                   time.Duration                       // Timeout controls how long a run is allowed to execute.
+	CancelOnContextDoneEnabled                bool                                // CancelOnContextDoneEnabled cancels the run when the parent context is done.
+	GraphNodeLifecycleActivityEnabled         bool                                // GraphNodeLifecycleActivityEnabled enables graph node lifecycle activity events.
+	GraphNodeInterruptActivityEnabled         bool                                // GraphNodeInterruptActivityEnabled enables graph interrupt activity events.
+	GraphNodeInterruptActivityTopLevelOnly    bool                                // GraphNodeInterruptActivityTopLevelOnly drops nested graph interrupt activity events.
+	ReasoningContentEnabled                   bool                                // ReasoningContentEnabled controls whether reasoning content events are emitted.
+	EventSourceMetadataEnabled                bool                                // EventSourceMetadataEnabled attaches source metadata to AG-UI rawEvent fields.
+	ToolResultInputTranslationEnabled         bool                                // ToolResultInputTranslationEnabled controls whether tool-result inputs are translated before emission.
+	ToolCallDeltaStreamingEnabled             bool                                // ToolCallDeltaStreamingEnabled streams partial tool-call arguments.
+	StreamingToolResultActivityEnabled        bool                                // StreamingToolResultActivityEnabled rewrites partial tool results as activity events.
+	ConcurrentMessageStreamsEnabled           bool                                // ConcurrentMessageStreamsEnabled keeps multiple message streams open by message ID.
+	DistributedCancelEnabled                  bool                                // DistributedCancelEnabled enables best-effort cancel signaling through SessionState.
+	DistributedCancelPollInterval             time.Duration                       // DistributedCancelPollInterval controls how often owner runs poll cancel markers.
 }
 
 // NewOptions creates a new options instance.
@@ -234,6 +235,30 @@ func WithMessagesSnapshotFollowMaxDuration(d time.Duration) Option {
 func WithMessagesSnapshotRunLifecycleEventsEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.MessagesSnapshotRunLifecycleEventsEnabled = enabled
+	}
+}
+
+// MessagesSnapshotPageRequest configures one session track-event page for MESSAGES_SNAPSHOT.
+type MessagesSnapshotPageRequest struct {
+	Cursor     string // Cursor is the opaque cursor from the previous snapshot page, or empty for the latest page.
+	EventLimit int    // EventLimit is the maximum number of session track events to fetch and must be greater than zero.
+}
+
+// MessagesSnapshotSessionPageResolver resolves optional session pagination for a MESSAGES_SNAPSHOT request.
+//
+// Returning nil uses the existing full-history snapshot behavior. Returning a
+// non-nil request asks the session service for a cursor page of AG-UI track
+// events before AG-UI reduces those events into messages.
+type MessagesSnapshotSessionPageResolver func(
+	ctx context.Context,
+	input *adapter.RunAgentInput,
+	key session.Key,
+) (*MessagesSnapshotPageRequest, error)
+
+// WithMessagesSnapshotSessionPageResolver sets the optional page resolver for MESSAGES_SNAPSHOT.
+func WithMessagesSnapshotSessionPageResolver(r MessagesSnapshotSessionPageResolver) Option {
+	return func(o *Options) {
+		o.MessagesSnapshotSessionPageResolver = r
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/adapter"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/aggregator"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/translator"
+	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
 )
 
@@ -203,6 +204,25 @@ func TestWithConcurrentMessageStreamsEnabled(t *testing.T) {
 func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {
 	opts := NewOptions(WithMessagesSnapshotRunLifecycleEventsEnabled(true))
 	assert.True(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
+}
+
+func TestWithMessagesSnapshotSessionPageResolver(t *testing.T) {
+	called := false
+	resolver := func(
+		context.Context,
+		*adapter.RunAgentInput,
+		session.Key,
+	) (*MessagesSnapshotPageRequest, error) {
+		called = true
+		return &MessagesSnapshotPageRequest{Cursor: "cursor", EventLimit: 3}, nil
+	}
+
+	opts := NewOptions(WithMessagesSnapshotSessionPageResolver(resolver))
+	require.NotNil(t, opts.MessagesSnapshotSessionPageResolver)
+	req, err := opts.MessagesSnapshotSessionPageResolver(context.Background(), &adapter.RunAgentInput{}, session.Key{})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, &MessagesSnapshotPageRequest{Cursor: "cursor", EventLimit: 3}, req)
 }
 
 func TestWithPostRunFinalizationTimeout(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -102,6 +102,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		messagesSnapshotFollowEnabled:          opts.MessagesSnapshotFollowEnabled,
 		messagesSnapshotFollowMaxDuration:      opts.MessagesSnapshotFollowMaxDuration,
 		messagesSnapshotRunLifecycleEventsEnabled: opts.MessagesSnapshotRunLifecycleEventsEnabled,
+		messagesSnapshotSessionPageResolver:       opts.MessagesSnapshotSessionPageResolver,
 		toolResultInputTranslationEnabled:         opts.ToolResultInputTranslationEnabled,
 		toolCallDeltaStreamingEnabled:             opts.ToolCallDeltaStreamingEnabled,
 		streamingToolResultActivityEnabled:        opts.StreamingToolResultActivityEnabled,
@@ -142,6 +143,7 @@ type runner struct {
 	messagesSnapshotFollowEnabled             bool
 	messagesSnapshotFollowMaxDuration         time.Duration
 	messagesSnapshotRunLifecycleEventsEnabled bool
+	messagesSnapshotSessionPageResolver       MessagesSnapshotSessionPageResolver
 	toolResultInputTranslationEnabled         bool
 	toolCallDeltaStreamingEnabled             bool
 	streamingToolResultActivityEnabled        bool
@@ -158,21 +160,22 @@ type sessionContext struct {
 }
 
 type runInput struct {
-	key             session.Key
-	threadID        string
-	runID           string
-	userID          string
-	messages        *runAgentMessages
-	runOption       []agent.RunOption
-	translator      translator.Translator
-	enableTrack     bool
-	startTrackFlush func()
-	span            trace.Span
-	resume          *resumeInfo
-	terminalEmitted bool
-	runAgentInput   *adapter.RunAgentInput
-	done            chan struct{}
-	consumerDone    <-chan struct{}
+	key                  session.Key
+	threadID             string
+	runID                string
+	userID               string
+	messages             *runAgentMessages
+	runOption            []agent.RunOption
+	translator           translator.Translator
+	enableTrack          bool
+	startTrackFlush      func()
+	span                 trace.Span
+	resume               *resumeInfo
+	terminalEmitted      bool
+	runAgentInput        *adapter.RunAgentInput
+	messagesSnapshotPage *MessagesSnapshotPageRequest
+	done                 chan struct{}
+	consumerDone         <-chan struct{}
 }
 
 type runAgentResult struct {

--- a/session/inmemory/service.go
+++ b/session/inmemory/service.go
@@ -462,12 +462,11 @@ func (s *SessionService) GetTrackEventPage(
 	if history == nil || len(history.Events) == 0 {
 		return &session.TrackEventPage{Track: req.Track}, nil
 	}
-	return inMemoryTrackEventPage(req, sess.CreatedAt, history.Events)
+	return inMemoryTrackEventPage(req, history.Events)
 }
 
 func inMemoryTrackEventPage(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	events []session.TrackEvent,
 ) (*session.TrackEventPage, error) {
 	end := len(events)
@@ -476,7 +475,7 @@ func inMemoryTrackEventPage(
 		if err != nil {
 			return nil, err
 		}
-		if err := trackpage.ValidateBinding(cursor, "inmemory", req.Key, req.Track, sessionCreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, "inmemory", req.Key, req.Track); err != nil {
 			return nil, err
 		}
 		index, err := strconv.Atoi(cursor.ID)
@@ -500,7 +499,6 @@ func inMemoryTrackEventPage(
 			"inmemory",
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			trackpage.TimeToUnixNano(events[i].Timestamp),
 			strconv.Itoa(i),
 		)

--- a/session/inmemory/service.go
+++ b/session/inmemory/service.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/internal/sessionopt"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
 	sessionwindow "trpc.group/trpc-go/trpc-agent-go/session/internal/window"
 )
 
@@ -40,9 +42,10 @@ type sessionWithTTL struct {
 }
 
 var (
-	_ session.Service       = (*SessionService)(nil)
-	_ session.TrackService  = (*SessionService)(nil)
-	_ session.WindowService = (*SessionService)(nil)
+	_ session.Service               = (*SessionService)(nil)
+	_ session.TrackService          = (*SessionService)(nil)
+	_ session.TrackEventPageService = (*SessionService)(nil)
+	_ session.WindowService         = (*SessionService)(nil)
 
 	_ session.StateInitializationService = (*SessionService)(nil)
 )
@@ -438,6 +441,82 @@ func (s *SessionService) GetEventWindow(
 		return sessionwindow.EventWindowFromOrderedEvents(req.Key, nil, req)
 	}
 	return sessionwindow.EventWindowFromOrderedEvents(req.Key, sess.Events, req)
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *SessionService) GetTrackEventPage(
+	_ context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sess, err := s.getRawSession(req.Key)
+	if err != nil {
+		return nil, err
+	}
+	if sess == nil || sess.Tracks == nil {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	history := sess.Tracks[req.Track]
+	if history == nil || len(history.Events) == 0 {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	return inMemoryTrackEventPage(req, sess.CreatedAt, history.Events)
+}
+
+func inMemoryTrackEventPage(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	events []session.TrackEvent,
+) (*session.TrackEventPage, error) {
+	end := len(events)
+	if req.Cursor != "" {
+		cursor, err := trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		if err := trackpage.ValidateBinding(cursor, "inmemory", req.Key, req.Track, sessionCreatedAt); err != nil {
+			return nil, err
+		}
+		index, err := strconv.Atoi(cursor.ID)
+		if err != nil || index < 0 || index > len(events) {
+			return nil, fmt.Errorf("invalid track event page cursor")
+		}
+		end = index
+	}
+	start := 0
+	scanned := end
+	if scanned > req.EventLimit+1 {
+		start = scanned - req.EventLimit - 1
+	}
+	hasMore := end-start > req.EventLimit
+	if hasMore {
+		start++
+	}
+	entries := make([]session.TrackEventPageEntry, 0, end-start)
+	for i := start; i < end; i++ {
+		cursor, err := trackpage.CursorForUnixNano(
+			"inmemory",
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			trackpage.TimeToUnixNano(events[i].Timestamp),
+			strconv.Itoa(i),
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  events[i],
+			Cursor: cursor,
+		})
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
 }
 
 // ListSessions returns all sessions for a given app and user.

--- a/session/inmemory/service_test.go
+++ b/session/inmemory/service_test.go
@@ -1529,6 +1529,63 @@ func TestSessionServiceGetTrackEvents(t *testing.T) {
 	require.Empty(t, missing.Events)
 }
 
+func TestSessionServiceGetTrackEventPage(t *testing.T) {
+	service := NewSessionService()
+	defer service.Close()
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "track-app",
+		UserID:    "track-user",
+		SessionID: "track-session",
+	}
+	sess, err := service.CreateSession(ctx, key, session.StateMap{})
+	require.NoError(t, err)
+	base := time.Now().Add(-time.Hour)
+	for i := 1; i <= 4; i++ {
+		require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+			Track:     "alpha",
+			Payload:   json.RawMessage(fmt.Sprintf(`"a%d"`, i)),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		}))
+	}
+	latest, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, session.Track("alpha"), latest.Track)
+	require.Len(t, latest.Entries, 2)
+	assert.Equal(t, json.RawMessage(`"a3"`), latest.Entries[0].Event.Payload)
+	assert.Equal(t, json.RawMessage(`"a4"`), latest.Entries[1].Event.Payload)
+	assert.True(t, latest.HasMore)
+	older, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     latest.Entries[0].Cursor,
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, older.Entries, 2)
+	assert.Equal(t, json.RawMessage(`"a1"`), older.Entries[0].Event.Payload)
+	assert.Equal(t, json.RawMessage(`"a2"`), older.Entries[1].Event.Payload)
+	assert.False(t, older.HasMore)
+	missing, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "missing",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, session.Track("missing"), missing.Track)
+	require.Empty(t, missing.Entries)
+	_, err = service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:   key,
+		Track: "alpha",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "eventLimit")
+}
+
 func TestSessionServiceGetTrackEventsEmptyAndErrors(t *testing.T) {
 	service := NewSessionService()
 	defer service.Close()

--- a/session/inmemory/service_test.go
+++ b/session/inmemory/service_test.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
 )
 
 func TestNewSessionService(t *testing.T) {
@@ -1584,6 +1585,81 @@ func TestSessionServiceGetTrackEventPage(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "eventLimit")
+}
+
+func TestSessionServiceGetTrackEventPageErrorPaths(t *testing.T) {
+	service := NewSessionService()
+	defer service.Close()
+	ctx := context.Background()
+	key := session.Key{
+		AppName:   "track-app",
+		UserID:    "track-user",
+		SessionID: "track-session-errors",
+	}
+
+	missing, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, session.Track("alpha"), missing.Track)
+	assert.Empty(t, missing.Entries)
+
+	sess, err := service.CreateSession(ctx, key, session.StateMap{})
+	require.NoError(t, err)
+	empty, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, session.Track("alpha"), empty.Track)
+	assert.Empty(t, empty.Entries)
+
+	require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"a1"`),
+		Timestamp: time.Now(),
+	}))
+
+	_, err = service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     "bad cursor",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+
+	wrongTrack, err := trackpage.CursorForUnixNano("inmemory", key, "beta", 1, "0")
+	require.NoError(t, err)
+	_, err = service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     wrongTrack,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+
+	badIndex, err := trackpage.CursorForUnixNano("inmemory", key, "alpha", 1, "bad")
+	require.NoError(t, err)
+	_, err = service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     badIndex,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+
+	outOfRange, err := trackpage.CursorForUnixNano("inmemory", key, "alpha", 1, "2")
+	require.NoError(t, err)
+	_, err = service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     outOfRange,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
 }
 
 func TestSessionServiceGetTrackEventsEmptyAndErrors(t *testing.T) {

--- a/session/internal/trackpage/cursor.go
+++ b/session/internal/trackpage/cursor.go
@@ -24,15 +24,14 @@ const version = 1
 
 // Cursor is the internal wire shape for backend-generated track page cursors.
 type Cursor struct {
-	Version          int    `json:"v"`
-	Kind             string `json:"kind"`
-	AppName          string `json:"appName"`
-	UserID           string `json:"userID"`
-	SessionID        string `json:"sessionID"`
-	Track            string `json:"track"`
-	SessionCreatedAt int64  `json:"sessionCreatedAt"`
-	CreatedAt        int64  `json:"createdAt"`
-	ID               string `json:"id"`
+	Version   int    `json:"v"`
+	Kind      string `json:"kind"`
+	AppName   string `json:"appName"`
+	UserID    string `json:"userID"`
+	SessionID string `json:"sessionID"`
+	Track     string `json:"track"`
+	CreatedAt int64  `json:"createdAt"`
+	ID        string `json:"id"`
 }
 
 // ValidateRequest validates a track event page request.
@@ -78,7 +77,6 @@ func ValidateBinding(
 	kind string,
 	key session.Key,
 	track session.Track,
-	sessionCreatedAt time.Time,
 ) error {
 	if c.Kind != kind {
 		return fmt.Errorf("cursor kind mismatch")
@@ -88,9 +86,6 @@ func ValidateBinding(
 	}
 	if c.Track != string(track) {
 		return fmt.Errorf("cursor track mismatch")
-	}
-	if c.SessionCreatedAt != TimeToUnixNano(sessionCreatedAt) {
-		return fmt.Errorf("cursor session generation mismatch")
 	}
 	return nil
 }
@@ -108,19 +103,17 @@ func CursorFor(
 	kind string,
 	key session.Key,
 	track session.Track,
-	sessionCreatedAt time.Time,
 	createdAt time.Time,
 	id string,
 ) (string, error) {
 	return Encode(Cursor{
-		Kind:             kind,
-		AppName:          key.AppName,
-		UserID:           key.UserID,
-		SessionID:        key.SessionID,
-		Track:            string(track),
-		SessionCreatedAt: TimeToUnixNano(sessionCreatedAt),
-		CreatedAt:        TimeToUnixNano(createdAt),
-		ID:               id,
+		Kind:      kind,
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		SessionID: key.SessionID,
+		Track:     string(track),
+		CreatedAt: TimeToUnixNano(createdAt),
+		ID:        id,
 	})
 }
 
@@ -129,19 +122,17 @@ func CursorForUnixNano(
 	kind string,
 	key session.Key,
 	track session.Track,
-	sessionCreatedAt time.Time,
 	createdAt int64,
 	id string,
 ) (string, error) {
 	return Encode(Cursor{
-		Kind:             kind,
-		AppName:          key.AppName,
-		UserID:           key.UserID,
-		SessionID:        key.SessionID,
-		Track:            string(track),
-		SessionCreatedAt: TimeToUnixNano(sessionCreatedAt),
-		CreatedAt:        createdAt,
-		ID:               id,
+		Kind:      kind,
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		SessionID: key.SessionID,
+		Track:     string(track),
+		CreatedAt: createdAt,
+		ID:        id,
 	})
 }
 

--- a/session/internal/trackpage/cursor.go
+++ b/session/internal/trackpage/cursor.go
@@ -1,0 +1,155 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package trackpage provides internal cursor helpers for track event pagination.
+package trackpage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const version = 1
+
+// Cursor is the internal wire shape for backend-generated track page cursors.
+type Cursor struct {
+	Version          int    `json:"v"`
+	Kind             string `json:"kind"`
+	AppName          string `json:"appName"`
+	UserID           string `json:"userID"`
+	SessionID        string `json:"sessionID"`
+	Track            string `json:"track"`
+	SessionCreatedAt int64  `json:"sessionCreatedAt"`
+	CreatedAt        int64  `json:"createdAt"`
+	ID               string `json:"id"`
+}
+
+// ValidateRequest validates a track event page request.
+func ValidateRequest(req session.TrackEventPageRequest) error {
+	if err := req.Key.CheckSessionKey(); err != nil {
+		return err
+	}
+	if req.EventLimit <= 0 {
+		return fmt.Errorf("track event page requires eventLimit > 0")
+	}
+	return nil
+}
+
+// Encode encodes a cursor as an opaque URL-safe string.
+func Encode(c Cursor) (string, error) {
+	c.Version = version
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("marshal cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// Decode decodes an opaque cursor string.
+func Decode(raw string) (Cursor, error) {
+	var c Cursor
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return Cursor{}, fmt.Errorf("decode cursor: %w", err)
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Cursor{}, fmt.Errorf("unmarshal cursor: %w", err)
+	}
+	if c.Version != version {
+		return Cursor{}, fmt.Errorf("unsupported cursor version: %d", c.Version)
+	}
+	return c, nil
+}
+
+// ValidateBinding validates that a cursor belongs to the requested session track.
+func ValidateBinding(
+	c Cursor,
+	kind string,
+	key session.Key,
+	track session.Track,
+	sessionCreatedAt time.Time,
+) error {
+	if c.Kind != kind {
+		return fmt.Errorf("cursor kind mismatch")
+	}
+	if c.AppName != key.AppName || c.UserID != key.UserID || c.SessionID != key.SessionID {
+		return fmt.Errorf("cursor session mismatch")
+	}
+	if c.Track != string(track) {
+		return fmt.Errorf("cursor track mismatch")
+	}
+	if c.SessionCreatedAt != TimeToUnixNano(sessionCreatedAt) {
+		return fmt.Errorf("cursor session generation mismatch")
+	}
+	return nil
+}
+
+// TimeToUnixNano normalizes a time value before storing it in a cursor.
+func TimeToUnixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UTC().UnixNano()
+}
+
+// CursorFor returns a cursor bound to a specific track event storage entry.
+func CursorFor(
+	kind string,
+	key session.Key,
+	track session.Track,
+	sessionCreatedAt time.Time,
+	createdAt time.Time,
+	id string,
+) (string, error) {
+	return Encode(Cursor{
+		Kind:             kind,
+		AppName:          key.AppName,
+		UserID:           key.UserID,
+		SessionID:        key.SessionID,
+		Track:            string(track),
+		SessionCreatedAt: TimeToUnixNano(sessionCreatedAt),
+		CreatedAt:        TimeToUnixNano(createdAt),
+		ID:               id,
+	})
+}
+
+// CursorForUnixNano returns a cursor for storage that keeps timestamps as unix nanoseconds.
+func CursorForUnixNano(
+	kind string,
+	key session.Key,
+	track session.Track,
+	sessionCreatedAt time.Time,
+	createdAt int64,
+	id string,
+) (string, error) {
+	return Encode(Cursor{
+		Kind:             kind,
+		AppName:          key.AppName,
+		UserID:           key.UserID,
+		SessionID:        key.SessionID,
+		Track:            string(track),
+		SessionCreatedAt: TimeToUnixNano(sessionCreatedAt),
+		CreatedAt:        createdAt,
+		ID:               id,
+	})
+}
+
+// ParseIntID parses a cursor id that was encoded from an integer identifier.
+func ParseIntID(id string) (int64, error) {
+	value, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse cursor id: %w", err)
+	}
+	return value, nil
+}

--- a/session/internal/trackpage/cursor_test.go
+++ b/session/internal/trackpage/cursor_test.go
@@ -1,0 +1,63 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package trackpage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+func TestCursorDoesNotBindSessionGeneration(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	createdAt := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+
+	raw, err := CursorFor("test", key, "alpha", createdAt, "event-1")
+	require.NoError(t, err)
+
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+	assert.NotContains(t, payload, "sessionCreatedAt")
+
+	cursor, err := Decode(raw)
+	require.NoError(t, err)
+	assert.NoError(t, ValidateBinding(cursor, "test", key, "alpha"))
+	assert.Equal(t, TimeToUnixNano(createdAt), cursor.CreatedAt)
+	assert.Equal(t, "event-1", cursor.ID)
+}
+
+func TestValidateBindingRejectsWrongRequestBinding(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor := Cursor{
+		Version:   version,
+		Kind:      "test",
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		SessionID: key.SessionID,
+		Track:     "alpha",
+		CreatedAt: 1,
+		ID:        "event-1",
+	}
+
+	assert.Error(t, ValidateBinding(cursor, "other", key, "alpha"))
+	assert.Error(t, ValidateBinding(cursor, "test", session.Key{
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		SessionID: "other-session",
+	}, "alpha"))
+	assert.Error(t, ValidateBinding(cursor, "test", key, "beta"))
+}

--- a/session/internal/trackpage/cursor_test.go
+++ b/session/internal/trackpage/cursor_test.go
@@ -61,3 +61,58 @@ func TestValidateBindingRejectsWrongRequestBinding(t *testing.T) {
 	}, "alpha"))
 	assert.Error(t, ValidateBinding(cursor, "test", key, "beta"))
 }
+
+func TestValidateRequest(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+
+	assert.NoError(t, ValidateRequest(session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	}))
+	assert.Error(t, ValidateRequest(session.TrackEventPageRequest{
+		Key:        session.Key{UserID: key.UserID, SessionID: key.SessionID},
+		Track:      "alpha",
+		EventLimit: 1,
+	}))
+	assert.Error(t, ValidateRequest(session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 0,
+	}))
+}
+
+func TestDecodeRejectsMalformedCursor(t *testing.T) {
+	_, err := Decode("not base64!")
+	assert.Error(t, err)
+
+	_, err = Decode(base64.RawURLEncoding.EncodeToString([]byte("{")))
+	assert.Error(t, err)
+
+	raw, err := json.Marshal(Cursor{Version: 2})
+	require.NoError(t, err)
+	_, err = Decode(base64.RawURLEncoding.EncodeToString(raw))
+	assert.Error(t, err)
+}
+
+func TestCursorForUnixNanoAndParseIntID(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	raw, err := CursorForUnixNano("test", key, "alpha", 123, "42")
+	require.NoError(t, err)
+
+	cursor, err := Decode(raw)
+	require.NoError(t, err)
+	assert.Equal(t, int64(123), cursor.CreatedAt)
+	assert.Equal(t, "42", cursor.ID)
+
+	id, err := ParseIntID(cursor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), id)
+
+	_, err = ParseIntID("bad")
+	assert.Error(t, err)
+}
+
+func TestTimeToUnixNanoZero(t *testing.T) {
+	assert.Equal(t, int64(0), TimeToUnixNano(time.Time{}))
+}

--- a/session/mongodb/service.go
+++ b/session/mongodb/service.go
@@ -36,6 +36,7 @@ import (
 // Compile-time interface assertion.
 var _ session.Service = (*Service)(nil)
 var _ session.TrackService = (*Service)(nil)
+var _ session.TrackEventPageService = (*Service)(nil)
 
 var errSessionNotFound = errors.New("session not found")
 

--- a/session/mongodb/track_page.go
+++ b/session/mongodb/track_page.go
@@ -12,13 +12,11 @@ package mongodb
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
@@ -34,18 +32,11 @@ func (s *Service) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	docs, hasMore, err := s.queryTrackEventPageDocs(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("mongodb session service get track event page failed: %w", err)
 	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
-	}
-	docs, hasMore, err := s.queryTrackEventPageDocs(ctx, req, sessionCreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("mongodb session service get track event page failed: %w", err)
-	}
-	entries, err := mongoTrackEventPageEntries(req, sessionCreatedAt, docs)
+	entries, err := mongoTrackEventPageEntries(req, docs)
 	if err != nil {
 		return nil, fmt.Errorf("mongodb session service get track event page failed: %w", err)
 	}
@@ -56,26 +47,9 @@ func (s *Service) GetTrackEventPage(
 	}, nil
 }
 
-func (s *Service) getTrackEventPageSessionCreatedAt(
-	ctx context.Context,
-	key session.Key,
-) (time.Time, bool, error) {
-	var doc sessionStateDoc
-	err := s.client.FindOne(ctx, s.database, s.collSessionStates,
-		activeFilter(time.Now(), sessionKeyFilter(key))).Decode(&doc)
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return time.Time{}, false, nil
-	}
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
-	}
-	return doc.CreatedAt, true, nil
-}
-
 func (s *Service) queryTrackEventPageDocs(
 	ctx context.Context,
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 ) ([]sessionTrackDoc, bool, error) {
 	now := time.Now()
 	filter := sessionKeyFilter(req.Key)
@@ -90,7 +64,7 @@ func (s *Service) queryTrackEventPageDocs(
 		if err != nil {
 			return nil, false, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindMongoDB, req.Key, req.Track, sessionCreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindMongoDB, req.Key, req.Track); err != nil {
 			return nil, false, err
 		}
 		oid, err := primitive.ObjectIDFromHex(cursor.ID)
@@ -135,7 +109,6 @@ func (s *Service) queryTrackEventPageDocs(
 
 func mongoTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	docs []sessionTrackDoc,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(docs))
@@ -148,7 +121,6 @@ func mongoTrackEventPageEntries(
 			trackEventPageCursorKindMongoDB,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			doc.CreatedAt,
 			doc.ID.Hex(),
 		)

--- a/session/mongodb/track_page.go
+++ b/session/mongodb/track_page.go
@@ -1,0 +1,164 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mongodb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindMongoDB = "mongodb"
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *Service) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	if err != nil {
+		return nil, fmt.Errorf("mongodb session service get track event page failed: %w", err)
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	docs, hasMore, err := s.queryTrackEventPageDocs(ctx, req, sessionCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("mongodb session service get track event page failed: %w", err)
+	}
+	entries, err := mongoTrackEventPageEntries(req, sessionCreatedAt, docs)
+	if err != nil {
+		return nil, fmt.Errorf("mongodb session service get track event page failed: %w", err)
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (s *Service) getTrackEventPageSessionCreatedAt(
+	ctx context.Context,
+	key session.Key,
+) (time.Time, bool, error) {
+	var doc sessionStateDoc
+	err := s.client.FindOne(ctx, s.database, s.collSessionStates,
+		activeFilter(time.Now(), sessionKeyFilter(key))).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
+	}
+	return doc.CreatedAt, true, nil
+}
+
+func (s *Service) queryTrackEventPageDocs(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+) ([]sessionTrackDoc, bool, error) {
+	now := time.Now()
+	filter := sessionKeyFilter(req.Key)
+	filter["track"] = req.Track
+	filter["deleted_at"] = nil
+	conditions := bson.A{bson.M{"$or": bson.A{
+		bson.M{"expires_at": bson.M{"$exists": false}},
+		bson.M{"expires_at": bson.M{"$gt": now}},
+	}}}
+	if req.Cursor != "" {
+		cursor, err := trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindMongoDB, req.Key, req.Track, sessionCreatedAt); err != nil {
+			return nil, false, err
+		}
+		oid, err := primitive.ObjectIDFromHex(cursor.ID)
+		if err != nil {
+			return nil, false, fmt.Errorf("parse cursor id: %w", err)
+		}
+		cursorCreatedAt := time.Unix(0, cursor.CreatedAt).UTC()
+		conditions = append(conditions, bson.M{"$or": bson.A{
+			bson.M{"created_at": bson.M{"$lt": cursorCreatedAt}},
+			bson.M{"created_at": cursorCreatedAt, "_id": bson.M{"$lt": oid}},
+		}})
+	}
+	filter["$and"] = conditions
+	findOpts := options.Find().
+		SetSort(bson.D{{Key: "created_at", Value: -1}, {Key: "_id", Value: -1}}).
+		SetLimit(int64(req.EventLimit + 1))
+	cursorRows, err := s.client.Find(ctx, s.database, s.collSessionTracks, filter, findOpts)
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page: %w", err)
+	}
+	defer cursorRows.Close(ctx)
+	docs := make([]sessionTrackDoc, 0, req.EventLimit+1)
+	for cursorRows.Next(ctx) {
+		var doc sessionTrackDoc
+		if err := cursorRows.Decode(&doc); err != nil {
+			return nil, false, fmt.Errorf("decode track event page: %w", err)
+		}
+		docs = append(docs, doc)
+	}
+	if err := cursorRows.Err(); err != nil {
+		return nil, false, fmt.Errorf("iterate track event page: %w", err)
+	}
+	hasMore := len(docs) > req.EventLimit
+	if hasMore {
+		docs = docs[:req.EventLimit]
+	}
+	for i, j := 0, len(docs)-1; i < j; i, j = i+1, j-1 {
+		docs[i], docs[j] = docs[j], docs[i]
+	}
+	return docs, hasMore, nil
+}
+
+func mongoTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	docs []sessionTrackDoc,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(docs))
+	for _, doc := range docs {
+		var trackEvent session.TrackEvent
+		if err := json.Unmarshal(doc.Event, &trackEvent); err != nil {
+			return nil, fmt.Errorf("unmarshal track event: %w", err)
+		}
+		cursor, err := trackpage.CursorFor(
+			trackEventPageCursorKindMongoDB,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			doc.CreatedAt,
+			doc.ID.Hex(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  trackEvent,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}

--- a/session/mongodb/track_page_test.go
+++ b/session/mongodb/track_page_test.go
@@ -12,6 +12,7 @@ package mongodb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -112,6 +113,86 @@ func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Empty(t, mc.recorded())
+}
+
+func TestGetTrackEventPageRejectsInvalidRequest(t *testing.T) {
+	mc := &mockClient{}
+	s := newServiceForTest(t, mc)
+	_, err := s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:   session.Key{AppName: "app", UserID: "user", SessionID: "session"},
+		Track: "alpha",
+	})
+	require.Error(t, err)
+	assert.Empty(t, mc.recorded())
+}
+
+func TestGetTrackEventPageRejectsInvalidCursorID(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mc := &mockClient{}
+	s := newServiceForTest(t, mc)
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindMongoDB,
+		key,
+		"alpha",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"bad",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Empty(t, mc.recorded())
+}
+
+func TestGetTrackEventPageWrapsQueryError(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mc := &mockClient{
+		findFn: func(_ any) (*mongo.Cursor, error) {
+			return nil, errors.New("find failed")
+		},
+	}
+	s := newServiceForTest(t, mc)
+
+	_, err := s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mongodb session service get track event page failed")
+}
+
+func TestGetTrackEventPageRejectsMalformedEvent(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mc := &mockClient{
+		findFn: func(_ any) (*mongo.Cursor, error) {
+			return docsCursor([]any{
+				sessionTrackDoc{
+					ID:        primitive.NewObjectID(),
+					AppName:   key.AppName,
+					UserID:    key.UserID,
+					SessionID: key.SessionID,
+					Track:     "alpha",
+					Event:     []byte("{"),
+					CreatedAt: time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+				},
+			})
+		},
+	}
+	s := newServiceForTest(t, mc)
+
+	_, err := s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal track event")
 }
 
 func mongoTrackPageDoc(

--- a/session/mongodb/track_page_test.go
+++ b/session/mongodb/track_page_test.go
@@ -1,0 +1,142 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mongodb
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestGetTrackEventPagePaginatesDocs(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	ids := []primitive.ObjectID{
+		primitive.NewObjectIDFromTimestamp(baseTime),
+		primitive.NewObjectIDFromTimestamp(baseTime.Add(time.Second)),
+		primitive.NewObjectIDFromTimestamp(baseTime.Add(2 * time.Second)),
+	}
+	findCalls := 0
+	mc := &mockClient{
+		findFn: func(_ any) (*mongo.Cursor, error) {
+			findCalls++
+			if findCalls == 1 {
+				return docsCursor([]any{
+					mongoTrackPageDoc(t, key, ids[2], "newest", baseTime.Add(2*time.Second)),
+					mongoTrackPageDoc(t, key, ids[1], "middle", baseTime.Add(time.Second)),
+					mongoTrackPageDoc(t, key, ids[0], "oldest", baseTime),
+				})
+			}
+			return docsCursor([]any{
+				mongoTrackPageDoc(t, key, ids[0], "oldest", baseTime),
+			})
+		},
+	}
+	s := newServiceForTest(t, mc)
+	ctx := context.Background()
+
+	page, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Entries, 2)
+	assert.True(t, page.HasMore)
+	assert.Equal(t, session.Track("alpha"), page.Track)
+	assert.Equal(t, json.RawMessage(`"middle"`), page.Entries[0].Event.Payload)
+	assert.Equal(t, json.RawMessage(`"newest"`), page.Entries[1].Event.Payload)
+
+	cursor, err := trackpage.Decode(page.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.Equal(t, trackEventPageCursorKindMongoDB, cursor.Kind)
+	assert.Equal(t, ids[1].Hex(), cursor.ID)
+	assert.Equal(t, trackpage.TimeToUnixNano(baseTime.Add(time.Second)), cursor.CreatedAt)
+
+	next, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     page.Entries[0].Cursor,
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next.Entries, 1)
+	assert.False(t, next.HasMore)
+	assert.Equal(t, json.RawMessage(`"oldest"`), next.Entries[0].Event.Payload)
+	assert.Equal(t, 2, findCalls)
+
+	ops := mc.recorded()
+	require.Len(t, ops, 2)
+	firstFilter, ok := ops[0].filter.(bson.M)
+	require.True(t, ok)
+	assert.Equal(t, session.Track("alpha"), firstFilter["track"])
+	secondFilter, ok := ops[1].filter.(bson.M)
+	require.True(t, ok)
+	assert.Contains(t, secondFilter, "$and")
+}
+
+func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mc := &mockClient{}
+	s := newServiceForTest(t, mc)
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindMongoDB,
+		key,
+		"beta",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		primitive.NewObjectID().Hex(),
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Empty(t, mc.recorded())
+}
+
+func mongoTrackPageDoc(
+	t *testing.T,
+	key session.Key,
+	id primitive.ObjectID,
+	payload string,
+	createdAt time.Time,
+) sessionTrackDoc {
+	t.Helper()
+	event := session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"` + payload + `"`),
+		Timestamp: createdAt,
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return sessionTrackDoc{
+		ID:        id,
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		SessionID: key.SessionID,
+		Track:     "alpha",
+		Event:     data,
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+	}
+}

--- a/session/mysql/service.go
+++ b/session/mysql/service.go
@@ -33,6 +33,7 @@ import (
 
 var _ session.Service = (*Service)(nil)
 var _ session.TrackService = (*Service)(nil)
+var _ session.TrackEventPageService = (*Service)(nil)
 
 var errSessionNotFound = errors.New("session not found")
 

--- a/session/mysql/track_page.go
+++ b/session/mysql/track_page.go
@@ -1,0 +1,170 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindMySQL = "mysql"
+
+type trackEventPageRow struct {
+	id        int64
+	event     session.TrackEvent
+	createdAt time.Time
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *Service) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	if err != nil {
+		return nil, fmt.Errorf("mysql session service get track event page failed: %w", err)
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("mysql session service get track event page failed: %w", err)
+	}
+	entries, err := mysqlTrackEventPageEntries(req, sessionCreatedAt, rows)
+	if err != nil {
+		return nil, fmt.Errorf("mysql session service get track event page failed: %w", err)
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (s *Service) getTrackEventPageSessionCreatedAt(
+	ctx context.Context,
+	key session.Key,
+) (time.Time, bool, error) {
+	var createdAt time.Time
+	err := s.mysqlClient.QueryRow(
+		ctx,
+		[]any{&createdAt},
+		fmt.Sprintf(`SELECT created_at FROM %s
+			WHERE app_name = ? AND user_id = ? AND session_id = ?
+			AND (expires_at IS NULL OR expires_at > ?)
+			AND deleted_at IS NULL`, s.tableSessionStates),
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		time.Now(),
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
+	}
+	return createdAt, true, nil
+}
+
+func (s *Service) queryTrackEventPageRows(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+) ([]trackEventPageRow, bool, error) {
+	query := fmt.Sprintf(`SELECT id, event, created_at FROM %s
+		WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
+		AND (expires_at IS NULL OR expires_at > ?)
+		AND deleted_at IS NULL`, s.tableSessionTracks)
+	args := []any{req.Key.AppName, req.Key.UserID, req.Key.SessionID, req.Track, time.Now()}
+	if req.Cursor != "" {
+		cursor, err := trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindMySQL, req.Key, req.Track, sessionCreatedAt); err != nil {
+			return nil, false, err
+		}
+		cursorID, err := trackpage.ParseIntID(cursor.ID)
+		if err != nil {
+			return nil, false, err
+		}
+		cursorCreatedAt := time.Unix(0, cursor.CreatedAt).UTC()
+		query += `
+		AND (created_at < ? OR (created_at = ? AND id < ?))`
+		args = append(args, cursorCreatedAt, cursorCreatedAt, cursorID)
+	}
+	query += `
+		ORDER BY created_at DESC, id DESC
+		LIMIT ?`
+	args = append(args, req.EventLimit+1)
+	rows := make([]trackEventPageRow, 0, req.EventLimit+1)
+	err := s.mysqlClient.Query(ctx, func(sqlRows *sql.Rows) error {
+		var row trackEventPageRow
+		var eventBytes []byte
+		if err := sqlRows.Scan(&row.id, &eventBytes, &row.createdAt); err != nil {
+			return err
+		}
+		if err := json.Unmarshal(eventBytes, &row.event); err != nil {
+			return fmt.Errorf("unmarshal track event: %w", err)
+		}
+		rows = append(rows, row)
+		return nil
+	}, query, args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page: %w", err)
+	}
+	hasMore := len(rows) > req.EventLimit
+	if hasMore {
+		rows = rows[:req.EventLimit]
+	}
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	return rows, hasMore, nil
+}
+
+func mysqlTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	rows []trackEventPageRow,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(rows))
+	for _, row := range rows {
+		cursor, err := trackpage.CursorFor(
+			trackEventPageCursorKindMySQL,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			row.createdAt,
+			strconv.FormatInt(row.id, 10),
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  row.event,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}

--- a/session/mysql/track_page.go
+++ b/session/mysql/track_page.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -38,18 +37,11 @@ func (s *Service) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("mysql session service get track event page failed: %w", err)
 	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
-	}
-	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("mysql session service get track event page failed: %w", err)
-	}
-	entries, err := mysqlTrackEventPageEntries(req, sessionCreatedAt, rows)
+	entries, err := mysqlTrackEventPageEntries(req, rows)
 	if err != nil {
 		return nil, fmt.Errorf("mysql session service get track event page failed: %w", err)
 	}
@@ -60,36 +52,9 @@ func (s *Service) GetTrackEventPage(
 	}, nil
 }
 
-func (s *Service) getTrackEventPageSessionCreatedAt(
-	ctx context.Context,
-	key session.Key,
-) (time.Time, bool, error) {
-	var createdAt time.Time
-	err := s.mysqlClient.QueryRow(
-		ctx,
-		[]any{&createdAt},
-		fmt.Sprintf(`SELECT created_at FROM %s
-			WHERE app_name = ? AND user_id = ? AND session_id = ?
-			AND (expires_at IS NULL OR expires_at > ?)
-			AND deleted_at IS NULL`, s.tableSessionStates),
-		key.AppName,
-		key.UserID,
-		key.SessionID,
-		time.Now(),
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return time.Time{}, false, nil
-	}
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
-	}
-	return createdAt, true, nil
-}
-
 func (s *Service) queryTrackEventPageRows(
 	ctx context.Context,
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 ) ([]trackEventPageRow, bool, error) {
 	query := fmt.Sprintf(`SELECT id, event, created_at FROM %s
 		WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
@@ -101,7 +66,7 @@ func (s *Service) queryTrackEventPageRows(
 		if err != nil {
 			return nil, false, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindMySQL, req.Key, req.Track, sessionCreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindMySQL, req.Key, req.Track); err != nil {
 			return nil, false, err
 		}
 		cursorID, err := trackpage.ParseIntID(cursor.ID)
@@ -145,7 +110,6 @@ func (s *Service) queryTrackEventPageRows(
 
 func mysqlTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	rows []trackEventPageRow,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
@@ -154,7 +118,6 @@ func mysqlTrackEventPageEntries(
 			trackEventPageCursorKindMySQL,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			row.createdAt,
 			strconv.FormatInt(row.id, 10),
 		)

--- a/session/mysql/track_page_test.go
+++ b/session/mysql/track_page_test.go
@@ -1,0 +1,120 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package mysql
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestGetTrackEventPagePaginatesRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+
+	rows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(3), mysqlTrackPageEventBytes(t, "newest", baseTime.Add(2*time.Second)), baseTime.Add(2*time.Second)).
+		AddRow(int64(2), mysqlTrackPageEventBytes(t, "middle", baseTime.Add(time.Second)), baseTime.Add(time.Second)).
+		AddRow(int64(1), mysqlTrackPageEventBytes(t, "oldest", baseTime), baseTime)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 3).
+		WillReturnRows(rows)
+
+	page, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Entries, 2)
+	assert.True(t, page.HasMore)
+	assert.Equal(t, session.Track("alpha"), page.Track)
+	assert.Equal(t, json.RawMessage(`"middle"`), page.Entries[0].Event.Payload)
+	assert.Equal(t, json.RawMessage(`"newest"`), page.Entries[1].Event.Payload)
+
+	cursor, err := trackpage.Decode(page.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.Equal(t, trackEventPageCursorKindMySQL, cursor.Kind)
+	assert.Equal(t, "2", cursor.ID)
+	assert.Equal(t, trackpage.TimeToUnixNano(baseTime.Add(time.Second)), cursor.CreatedAt)
+
+	nextRows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(1), mysqlTrackPageEventBytes(t, "oldest", baseTime), baseTime)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(
+			key.AppName, key.UserID, key.SessionID, session.Track("alpha"),
+			sqlmock.AnyArg(), baseTime.Add(time.Second), baseTime.Add(time.Second), int64(2), 3,
+		).
+		WillReturnRows(nextRows)
+
+	next, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     page.Entries[0].Cursor,
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next.Entries, 1)
+	assert.False(t, next.HasMore)
+	assert.Equal(t, json.RawMessage(`"oldest"`), next.Entries[0].Event.Payload)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindMySQL,
+		key,
+		"beta",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"1",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func mysqlTrackPageEventBytes(t *testing.T, payload string, ts time.Time) []byte {
+	t.Helper()
+	event := session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"` + payload + `"`),
+		Timestamp: ts,
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return data
+}

--- a/session/mysql/track_page_test.go
+++ b/session/mysql/track_page_test.go
@@ -107,6 +107,91 @@ func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetTrackEventPageRejectsInvalidRequest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:   session.Key{AppName: "app", UserID: "user", SessionID: "session"},
+		Track: "alpha",
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsNonNumericCursorID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindMySQL,
+		key,
+		"alpha",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"bad",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageWrapsQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 2).
+		WillReturnError(assert.AnError)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mysql session service get track event page failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsMalformedEvent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	createdAt := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(1), []byte("{"), createdAt)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 2).
+		WillReturnRows(rows)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal track event")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func mysqlTrackPageEventBytes(t *testing.T, payload string, ts time.Time) []byte {
 	t.Helper()
 	event := session.TrackEvent{

--- a/session/pgvector/service.go
+++ b/session/pgvector/service.go
@@ -32,6 +32,7 @@ import (
 // Compile-time interface checks.
 var _ session.Service = (*Service)(nil)
 var _ session.TrackService = (*Service)(nil)
+var _ session.TrackEventPageService = (*Service)(nil)
 var _ session.SearchableService = (*Service)(nil)
 
 var errServiceClosing = errors.New("service is closing")

--- a/session/pgvector/track_page.go
+++ b/session/pgvector/track_page.go
@@ -37,18 +37,11 @@ func (s *Service) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("pgvector session service get track event page failed: %w", err)
 	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
-	}
-	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("pgvector session service get track event page failed: %w", err)
-	}
-	entries, err := pgvectorTrackEventPageEntries(req, sessionCreatedAt, rows)
+	entries, err := pgvectorTrackEventPageEntries(req, rows)
 	if err != nil {
 		return nil, fmt.Errorf("pgvector session service get track event page failed: %w", err)
 	}
@@ -59,30 +52,9 @@ func (s *Service) GetTrackEventPage(
 	}, nil
 }
 
-func (s *Service) getTrackEventPageSessionCreatedAt(
-	ctx context.Context,
-	key session.Key,
-) (time.Time, bool, error) {
-	var createdAt time.Time
-	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-		if !rows.Next() {
-			return nil
-		}
-		return rows.Scan(&createdAt)
-	}, fmt.Sprintf(`SELECT created_at FROM %s
-		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
-		AND (expires_at IS NULL OR expires_at > $4)
-		AND deleted_at IS NULL`, s.tableSessionStates), key.AppName, key.UserID, key.SessionID, time.Now())
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
-	}
-	return createdAt, !createdAt.IsZero(), nil
-}
-
 func (s *Service) queryTrackEventPageRows(
 	ctx context.Context,
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 ) ([]trackEventPageRow, bool, error) {
 	query := fmt.Sprintf(`SELECT id, event, created_at FROM %s
 		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND track = $4
@@ -94,7 +66,7 @@ func (s *Service) queryTrackEventPageRows(
 		if err != nil {
 			return nil, false, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindPGVector, req.Key, req.Track, sessionCreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindPGVector, req.Key, req.Track); err != nil {
 			return nil, false, err
 		}
 		cursorID, err := trackpage.ParseIntID(cursor.ID)
@@ -144,7 +116,6 @@ func (s *Service) queryTrackEventPageRows(
 
 func pgvectorTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	rows []trackEventPageRow,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
@@ -153,7 +124,6 @@ func pgvectorTrackEventPageEntries(
 			trackEventPageCursorKindPGVector,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			row.createdAt,
 			strconv.FormatInt(row.id, 10),
 		)

--- a/session/pgvector/track_page.go
+++ b/session/pgvector/track_page.go
@@ -1,0 +1,169 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package pgvector
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindPGVector = "pgvector"
+
+type trackEventPageRow struct {
+	id        int64
+	event     session.TrackEvent
+	createdAt time.Time
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *Service) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	if err != nil {
+		return nil, fmt.Errorf("pgvector session service get track event page failed: %w", err)
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("pgvector session service get track event page failed: %w", err)
+	}
+	entries, err := pgvectorTrackEventPageEntries(req, sessionCreatedAt, rows)
+	if err != nil {
+		return nil, fmt.Errorf("pgvector session service get track event page failed: %w", err)
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (s *Service) getTrackEventPageSessionCreatedAt(
+	ctx context.Context,
+	key session.Key,
+) (time.Time, bool, error) {
+	var createdAt time.Time
+	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
+		if !rows.Next() {
+			return nil
+		}
+		return rows.Scan(&createdAt)
+	}, fmt.Sprintf(`SELECT created_at FROM %s
+		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
+		AND (expires_at IS NULL OR expires_at > $4)
+		AND deleted_at IS NULL`, s.tableSessionStates), key.AppName, key.UserID, key.SessionID, time.Now())
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
+	}
+	return createdAt, !createdAt.IsZero(), nil
+}
+
+func (s *Service) queryTrackEventPageRows(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+) ([]trackEventPageRow, bool, error) {
+	query := fmt.Sprintf(`SELECT id, event, created_at FROM %s
+		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND track = $4
+		AND (expires_at IS NULL OR expires_at > $5)
+		AND deleted_at IS NULL`, s.tableSessionTracks)
+	args := []any{req.Key.AppName, req.Key.UserID, req.Key.SessionID, req.Track, time.Now()}
+	if req.Cursor != "" {
+		cursor, err := trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindPGVector, req.Key, req.Track, sessionCreatedAt); err != nil {
+			return nil, false, err
+		}
+		cursorID, err := trackpage.ParseIntID(cursor.ID)
+		if err != nil {
+			return nil, false, err
+		}
+		cursorCreatedAt := time.Unix(0, cursor.CreatedAt).UTC()
+		query += `
+		AND (created_at < $6 OR (created_at = $7 AND id < $8))`
+		args = append(args, cursorCreatedAt, cursorCreatedAt, cursorID)
+		query += `
+		ORDER BY created_at DESC, id DESC
+		LIMIT $9`
+	} else {
+		query += `
+		ORDER BY created_at DESC, id DESC
+		LIMIT $6`
+	}
+	args = append(args, req.EventLimit+1)
+	rows := make([]trackEventPageRow, 0, req.EventLimit+1)
+	err := s.pgClient.Query(ctx, func(sqlRows *sql.Rows) error {
+		for sqlRows.Next() {
+			var row trackEventPageRow
+			var eventBytes []byte
+			if err := sqlRows.Scan(&row.id, &eventBytes, &row.createdAt); err != nil {
+				return err
+			}
+			if err := json.Unmarshal(eventBytes, &row.event); err != nil {
+				return fmt.Errorf("unmarshal track event: %w", err)
+			}
+			rows = append(rows, row)
+		}
+		return sqlRows.Err()
+	}, query, args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page: %w", err)
+	}
+	hasMore := len(rows) > req.EventLimit
+	if hasMore {
+		rows = rows[:req.EventLimit]
+	}
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	return rows, hasMore, nil
+}
+
+func pgvectorTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	rows []trackEventPageRow,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(rows))
+	for _, row := range rows {
+		cursor, err := trackpage.CursorFor(
+			trackEventPageCursorKindPGVector,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			row.createdAt,
+			strconv.FormatInt(row.id, 10),
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  row.event,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}

--- a/session/pgvector/track_page_test.go
+++ b/session/pgvector/track_page_test.go
@@ -103,6 +103,83 @@ func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetTrackEventPageRejectsInvalidRequest(t *testing.T) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	_, err := s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:   session.Key{AppName: "app", UserID: "user", SessionID: "session"},
+		Track: "alpha",
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsNonNumericCursorID(t *testing.T) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindPGVector,
+		key,
+		"alpha",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"bad",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageWrapsQueryError(t *testing.T) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 2).
+		WillReturnError(assert.AnError)
+
+	_, err := s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pgvector session service get track event page failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsMalformedEvent(t *testing.T) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	createdAt := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(1), []byte("{"), createdAt)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 2).
+		WillReturnRows(rows)
+
+	_, err := s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal track event")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func pgvectorTrackPageEventBytes(t *testing.T, payload string, ts time.Time) []byte {
 	t.Helper()
 	event := session.TrackEvent{

--- a/session/pgvector/track_page_test.go
+++ b/session/pgvector/track_page_test.go
@@ -1,0 +1,116 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package pgvector
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestGetTrackEventPagePaginatesRows(t *testing.T) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+
+	rows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(3), pgvectorTrackPageEventBytes(t, "newest", baseTime.Add(2*time.Second)), baseTime.Add(2*time.Second)).
+		AddRow(int64(2), pgvectorTrackPageEventBytes(t, "middle", baseTime.Add(time.Second)), baseTime.Add(time.Second)).
+		AddRow(int64(1), pgvectorTrackPageEventBytes(t, "oldest", baseTime), baseTime)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 3).
+		WillReturnRows(rows)
+
+	page, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Entries, 2)
+	assert.True(t, page.HasMore)
+	assert.Equal(t, session.Track("alpha"), page.Track)
+	assert.Equal(t, json.RawMessage(`"middle"`), page.Entries[0].Event.Payload)
+	assert.Equal(t, json.RawMessage(`"newest"`), page.Entries[1].Event.Payload)
+
+	cursor, err := trackpage.Decode(page.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.Equal(t, trackEventPageCursorKindPGVector, cursor.Kind)
+	assert.Equal(t, "2", cursor.ID)
+	assert.Equal(t, trackpage.TimeToUnixNano(baseTime.Add(time.Second)), cursor.CreatedAt)
+
+	nextRows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(1), pgvectorTrackPageEventBytes(t, "oldest", baseTime), baseTime)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(
+			key.AppName, key.UserID, key.SessionID, session.Track("alpha"),
+			sqlmock.AnyArg(), baseTime.Add(time.Second), baseTime.Add(time.Second), int64(2), 3,
+		).
+		WillReturnRows(nextRows)
+
+	next, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     page.Entries[0].Cursor,
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next.Entries, 1)
+	assert.False(t, next.HasMore)
+	assert.Equal(t, json.RawMessage(`"oldest"`), next.Entries[0].Event.Payload)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
+	s, mock, db := newTestService(t, nil)
+	defer db.Close()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindPGVector,
+		key,
+		"beta",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"1",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func pgvectorTrackPageEventBytes(t *testing.T, payload string, ts time.Time) []byte {
+	t.Helper()
+	event := session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"` + payload + `"`),
+		Timestamp: ts,
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return data
+}

--- a/session/postgres/service.go
+++ b/session/postgres/service.go
@@ -32,6 +32,7 @@ import (
 
 var _ session.Service = (*Service)(nil)
 var _ session.TrackService = (*Service)(nil)
+var _ session.TrackEventPageService = (*Service)(nil)
 
 var errSessionNotFound = errors.New("session not found")
 

--- a/session/postgres/track_page.go
+++ b/session/postgres/track_page.go
@@ -1,0 +1,169 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindPostgres = "postgres"
+
+type trackEventPageRow struct {
+	id        int64
+	event     session.TrackEvent
+	createdAt time.Time
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *Service) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	if err != nil {
+		return nil, fmt.Errorf("postgres session service get track event page failed: %w", err)
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("postgres session service get track event page failed: %w", err)
+	}
+	entries, err := postgresTrackEventPageEntries(req, sessionCreatedAt, rows)
+	if err != nil {
+		return nil, fmt.Errorf("postgres session service get track event page failed: %w", err)
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (s *Service) getTrackEventPageSessionCreatedAt(
+	ctx context.Context,
+	key session.Key,
+) (time.Time, bool, error) {
+	var createdAt time.Time
+	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
+		if !rows.Next() {
+			return nil
+		}
+		return rows.Scan(&createdAt)
+	}, fmt.Sprintf(`SELECT created_at FROM %s
+		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
+		AND (expires_at IS NULL OR expires_at > $4)
+		AND deleted_at IS NULL`, s.tableSessionStates), key.AppName, key.UserID, key.SessionID, time.Now())
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
+	}
+	return createdAt, !createdAt.IsZero(), nil
+}
+
+func (s *Service) queryTrackEventPageRows(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+) ([]trackEventPageRow, bool, error) {
+	query := fmt.Sprintf(`SELECT id, event, created_at FROM %s
+		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND track = $4
+		AND (expires_at IS NULL OR expires_at > $5)
+		AND deleted_at IS NULL`, s.tableSessionTracks)
+	args := []any{req.Key.AppName, req.Key.UserID, req.Key.SessionID, req.Track, time.Now()}
+	if req.Cursor != "" {
+		cursor, err := trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindPostgres, req.Key, req.Track, sessionCreatedAt); err != nil {
+			return nil, false, err
+		}
+		cursorID, err := trackpage.ParseIntID(cursor.ID)
+		if err != nil {
+			return nil, false, err
+		}
+		cursorCreatedAt := time.Unix(0, cursor.CreatedAt).UTC()
+		query += `
+		AND (created_at < $6 OR (created_at = $7 AND id < $8))`
+		args = append(args, cursorCreatedAt, cursorCreatedAt, cursorID)
+		query += `
+		ORDER BY created_at DESC, id DESC
+		LIMIT $9`
+	} else {
+		query += `
+		ORDER BY created_at DESC, id DESC
+		LIMIT $6`
+	}
+	args = append(args, req.EventLimit+1)
+	rows := make([]trackEventPageRow, 0, req.EventLimit+1)
+	err := s.pgClient.Query(ctx, func(sqlRows *sql.Rows) error {
+		for sqlRows.Next() {
+			var row trackEventPageRow
+			var eventBytes []byte
+			if err := sqlRows.Scan(&row.id, &eventBytes, &row.createdAt); err != nil {
+				return err
+			}
+			if err := json.Unmarshal(eventBytes, &row.event); err != nil {
+				return fmt.Errorf("unmarshal track event: %w", err)
+			}
+			rows = append(rows, row)
+		}
+		return sqlRows.Err()
+	}, query, args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page: %w", err)
+	}
+	hasMore := len(rows) > req.EventLimit
+	if hasMore {
+		rows = rows[:req.EventLimit]
+	}
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	return rows, hasMore, nil
+}
+
+func postgresTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	rows []trackEventPageRow,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(rows))
+	for _, row := range rows {
+		cursor, err := trackpage.CursorFor(
+			trackEventPageCursorKindPostgres,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			row.createdAt,
+			strconv.FormatInt(row.id, 10),
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  row.event,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}

--- a/session/postgres/track_page.go
+++ b/session/postgres/track_page.go
@@ -37,18 +37,11 @@ func (s *Service) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("postgres session service get track event page failed: %w", err)
 	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
-	}
-	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("postgres session service get track event page failed: %w", err)
-	}
-	entries, err := postgresTrackEventPageEntries(req, sessionCreatedAt, rows)
+	entries, err := postgresTrackEventPageEntries(req, rows)
 	if err != nil {
 		return nil, fmt.Errorf("postgres session service get track event page failed: %w", err)
 	}
@@ -59,30 +52,9 @@ func (s *Service) GetTrackEventPage(
 	}, nil
 }
 
-func (s *Service) getTrackEventPageSessionCreatedAt(
-	ctx context.Context,
-	key session.Key,
-) (time.Time, bool, error) {
-	var createdAt time.Time
-	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-		if !rows.Next() {
-			return nil
-		}
-		return rows.Scan(&createdAt)
-	}, fmt.Sprintf(`SELECT created_at FROM %s
-		WHERE app_name = $1 AND user_id = $2 AND session_id = $3
-		AND (expires_at IS NULL OR expires_at > $4)
-		AND deleted_at IS NULL`, s.tableSessionStates), key.AppName, key.UserID, key.SessionID, time.Now())
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
-	}
-	return createdAt, !createdAt.IsZero(), nil
-}
-
 func (s *Service) queryTrackEventPageRows(
 	ctx context.Context,
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 ) ([]trackEventPageRow, bool, error) {
 	query := fmt.Sprintf(`SELECT id, event, created_at FROM %s
 		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND track = $4
@@ -94,7 +66,7 @@ func (s *Service) queryTrackEventPageRows(
 		if err != nil {
 			return nil, false, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindPostgres, req.Key, req.Track, sessionCreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindPostgres, req.Key, req.Track); err != nil {
 			return nil, false, err
 		}
 		cursorID, err := trackpage.ParseIntID(cursor.ID)
@@ -144,7 +116,6 @@ func (s *Service) queryTrackEventPageRows(
 
 func postgresTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	rows []trackEventPageRow,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
@@ -153,7 +124,6 @@ func postgresTrackEventPageEntries(
 			trackEventPageCursorKindPostgres,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			row.createdAt,
 			strconv.FormatInt(row.id, 10),
 		)

--- a/session/postgres/track_page_test.go
+++ b/session/postgres/track_page_test.go
@@ -107,6 +107,91 @@ func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetTrackEventPageRejectsInvalidRequest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:   session.Key{AppName: "app", UserID: "user", SessionID: "session"},
+		Track: "alpha",
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsNonNumericCursorID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindPostgres,
+		key,
+		"alpha",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"bad",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageWrapsQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 2).
+		WillReturnError(assert.AnError)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "postgres session service get track event page failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsMalformedEvent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	createdAt := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(1), []byte("{"), createdAt)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 2).
+		WillReturnRows(rows)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal track event")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func postgresTrackPageEventBytes(t *testing.T, payload string, ts time.Time) []byte {
 	t.Helper()
 	event := session.TrackEvent{

--- a/session/postgres/track_page_test.go
+++ b/session/postgres/track_page_test.go
@@ -1,0 +1,120 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestGetTrackEventPagePaginatesRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+
+	rows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(3), postgresTrackPageEventBytes(t, "newest", baseTime.Add(2*time.Second)), baseTime.Add(2*time.Second)).
+		AddRow(int64(2), postgresTrackPageEventBytes(t, "middle", baseTime.Add(time.Second)), baseTime.Add(time.Second)).
+		AddRow(int64(1), postgresTrackPageEventBytes(t, "oldest", baseTime), baseTime)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(key.AppName, key.UserID, key.SessionID, session.Track("alpha"), sqlmock.AnyArg(), 3).
+		WillReturnRows(rows)
+
+	page, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Entries, 2)
+	assert.True(t, page.HasMore)
+	assert.Equal(t, session.Track("alpha"), page.Track)
+	assert.Equal(t, json.RawMessage(`"middle"`), page.Entries[0].Event.Payload)
+	assert.Equal(t, json.RawMessage(`"newest"`), page.Entries[1].Event.Payload)
+
+	cursor, err := trackpage.Decode(page.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.Equal(t, trackEventPageCursorKindPostgres, cursor.Kind)
+	assert.Equal(t, "2", cursor.ID)
+	assert.Equal(t, trackpage.TimeToUnixNano(baseTime.Add(time.Second)), cursor.CreatedAt)
+
+	nextRows := sqlmock.NewRows([]string{"id", "event", "created_at"}).
+		AddRow(int64(1), postgresTrackPageEventBytes(t, "oldest", baseTime), baseTime)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, event, created_at FROM session_track_events")).
+		WithArgs(
+			key.AppName, key.UserID, key.SessionID, session.Track("alpha"),
+			sqlmock.AnyArg(), baseTime.Add(time.Second), baseTime.Add(time.Second), int64(2), 3,
+		).
+		WillReturnRows(nextRows)
+
+	next, err := s.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     page.Entries[0].Cursor,
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next.Entries, 1)
+	assert.False(t, next.HasMore)
+	assert.Equal(t, json.RawMessage(`"oldest"`), next.Entries[0].Event.Payload)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorFor(
+		trackEventPageCursorKindPostgres,
+		key,
+		"beta",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC),
+		"1",
+	)
+	require.NoError(t, err)
+
+	_, err = s.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func postgresTrackPageEventBytes(t *testing.T, payload string, ts time.Time) []byte {
+	t.Helper()
+	event := session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"` + payload + `"`),
+		Timestamp: ts,
+	}
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	return data
+}

--- a/session/redis/internal/hashidx/track_page.go
+++ b/session/redis/internal/hashidx/track_page.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -30,6 +31,7 @@ type trackEventPageRow struct {
 
 type scoredTrackEventID struct {
 	id    string
+	seq   int64
 	score int64
 }
 
@@ -74,8 +76,16 @@ func (c *Client) queryTrackEventPageRows(
 	cursor trackpage.Cursor,
 	hasCursor bool,
 ) ([]trackEventPageRow, bool, error) {
-	selected := make([]scoredTrackEventID, 0, req.EventLimit+1)
+	candidates := make([]scoredTrackEventID, 0, req.EventLimit+1)
 	batchLimit := int64(req.EventLimit + 1)
+	var cursorSeq int64
+	if hasCursor {
+		var err error
+		cursorSeq, err = trackpage.ParseIntID(cursor.ID)
+		if err != nil {
+			return nil, false, err
+		}
+	}
 	var offset int64
 	for {
 		rangeBy := &redis.ZRangeBy{
@@ -91,25 +101,31 @@ func (c *Client) queryTrackEventPageRows(
 		if err != nil {
 			return nil, false, fmt.Errorf("query track event page index: %w", err)
 		}
-		for _, z := range zs {
-			id := fmt.Sprint(z.Member)
-			score := int64(z.Score)
-			if hasCursor && !redisTrackPageOlder(score, id, cursor.CreatedAt, cursor.ID) {
-				continue
-			}
-			selected = append(selected, scoredTrackEventID{id: id, score: score})
-			if len(selected) >= req.EventLimit+1 {
-				break
-			}
-		}
-		if len(selected) >= req.EventLimit+1 {
+		if len(zs) == 0 {
 			break
 		}
-		if !hasCursor || int64(len(zs)) < batchLimit {
+		for _, z := range zs {
+			id := fmt.Sprint(z.Member)
+			seq, err := trackpage.ParseIntID(id)
+			if err != nil {
+				return nil, false, err
+			}
+			score := int64(z.Score)
+			if hasCursor && !redisTrackPageOlder(score, seq, cursor.CreatedAt, cursorSeq) {
+				continue
+			}
+			candidates = append(candidates, scoredTrackEventID{id: id, seq: seq, score: score})
+		}
+		sortScoredTrackEventIDs(candidates)
+		if len(candidates) >= req.EventLimit+1 && int64(zs[len(zs)-1].Score) < candidates[req.EventLimit].score {
+			break
+		}
+		if int64(len(zs)) < batchLimit {
 			break
 		}
 		offset += int64(len(zs))
 	}
+	selected := candidates
 	hasMore := len(selected) > req.EventLimit
 	if hasMore {
 		selected = selected[:req.EventLimit]
@@ -171,9 +187,18 @@ func hashIdxTrackEventPageEntries(
 	return entries, nil
 }
 
-func redisTrackPageOlder(score int64, id string, cursorScore int64, cursorID string) bool {
+func sortScoredTrackEventIDs(items []scoredTrackEventID) {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].score != items[j].score {
+			return items[i].score > items[j].score
+		}
+		return items[i].seq > items[j].seq
+	})
+}
+
+func redisTrackPageOlder(score int64, seq int64, cursorScore int64, cursorSeq int64) bool {
 	if score < cursorScore {
 		return true
 	}
-	return score == cursorScore && id < cursorID
+	return score == cursorScore && seq < cursorSeq
 }

--- a/session/redis/internal/hashidx/track_page.go
+++ b/session/redis/internal/hashidx/track_page.go
@@ -20,7 +20,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
 )
 
-const trackEventPageCursorKindHashIdx = "redis-hashidx"
+// TrackEventPageCursorKind is the cursor kind emitted by hash-index track pages.
+const TrackEventPageCursorKind = "redis-hashidx"
 
 type trackEventPageRow struct {
 	id    string
@@ -55,7 +56,7 @@ func (c *Client) GetTrackEventPage(
 		if err != nil {
 			return nil, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindHashIdx, req.Key, req.Track, meta.CreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, TrackEventPageCursorKind, req.Key, req.Track, meta.CreatedAt); err != nil {
 			return nil, err
 		}
 	}
@@ -98,31 +99,41 @@ func (c *Client) queryTrackEventPageRows(
 	cursor trackpage.Cursor,
 	hasCursor bool,
 ) ([]trackEventPageRow, bool, error) {
-	rangeBy := &redis.ZRangeBy{
-		Min: "-inf",
-		Max: "+inf",
-	}
-	if hasCursor {
-		rangeBy.Max = fmt.Sprintf("%d", cursor.CreatedAt)
-	} else {
-		rangeBy.Offset = 0
-		rangeBy.Count = int64(req.EventLimit + 1)
-	}
-	zs, err := c.client.ZRevRangeByScoreWithScores(ctx, c.keys.TrackTimeIndexKey(req.Key, req.Track), rangeBy).Result()
-	if err != nil {
-		return nil, false, fmt.Errorf("query track event page index: %w", err)
-	}
 	selected := make([]scoredTrackEventID, 0, req.EventLimit+1)
-	for _, z := range zs {
-		id := fmt.Sprint(z.Member)
-		score := int64(z.Score)
-		if hasCursor && !redisTrackPageOlder(score, id, cursor.CreatedAt, cursor.ID) {
-			continue
+	batchLimit := int64(req.EventLimit + 1)
+	var offset int64
+	for {
+		rangeBy := &redis.ZRangeBy{
+			Min:    "-inf",
+			Max:    "+inf",
+			Offset: offset,
+			Count:  batchLimit,
 		}
-		selected = append(selected, scoredTrackEventID{id: id, score: score})
+		if hasCursor {
+			rangeBy.Max = fmt.Sprintf("%d", cursor.CreatedAt)
+		}
+		zs, err := c.client.ZRevRangeByScoreWithScores(ctx, c.keys.TrackTimeIndexKey(req.Key, req.Track), rangeBy).Result()
+		if err != nil {
+			return nil, false, fmt.Errorf("query track event page index: %w", err)
+		}
+		for _, z := range zs {
+			id := fmt.Sprint(z.Member)
+			score := int64(z.Score)
+			if hasCursor && !redisTrackPageOlder(score, id, cursor.CreatedAt, cursor.ID) {
+				continue
+			}
+			selected = append(selected, scoredTrackEventID{id: id, score: score})
+			if len(selected) >= req.EventLimit+1 {
+				break
+			}
+		}
 		if len(selected) >= req.EventLimit+1 {
 			break
 		}
+		if !hasCursor || int64(len(zs)) < batchLimit {
+			break
+		}
+		offset += int64(len(zs))
 	}
 	hasMore := len(selected) > req.EventLimit
 	if hasMore {
@@ -169,7 +180,7 @@ func hashIdxTrackEventPageEntries(
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
 	for _, row := range rows {
 		cursor, err := trackpage.CursorForUnixNano(
-			trackEventPageCursorKindHashIdx,
+			TrackEventPageCursorKind,
 			req.Key,
 			req.Track,
 			sessionCreatedAt,

--- a/session/redis/internal/hashidx/track_page.go
+++ b/session/redis/internal/hashidx/track_page.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -42,21 +41,15 @@ func (c *Client) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	meta, ok, err := c.getTrackEventPageSessionMeta(ctx, req.Key)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
-	}
 	var cursor trackpage.Cursor
 	hasCursor := req.Cursor != ""
 	if hasCursor {
+		var err error
 		cursor, err = trackpage.Decode(req.Cursor)
 		if err != nil {
 			return nil, err
 		}
-		if err := trackpage.ValidateBinding(cursor, TrackEventPageCursorKind, req.Key, req.Track, meta.CreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, TrackEventPageCursorKind, req.Key, req.Track); err != nil {
 			return nil, err
 		}
 	}
@@ -64,7 +57,7 @@ func (c *Client) GetTrackEventPage(
 	if err != nil {
 		return nil, err
 	}
-	entries, err := hashIdxTrackEventPageEntries(req, meta.CreatedAt, rows)
+	entries, err := hashIdxTrackEventPageEntries(req, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -73,24 +66,6 @@ func (c *Client) GetTrackEventPage(
 		Entries: entries,
 		HasMore: hasMore,
 	}, nil
-}
-
-func (c *Client) getTrackEventPageSessionMeta(
-	ctx context.Context,
-	key session.Key,
-) (sessionMeta, bool, error) {
-	metaJSON, err := c.client.Get(ctx, c.keys.SessionMetaKey(key)).Bytes()
-	if err == redis.Nil {
-		return sessionMeta{}, false, nil
-	}
-	if err != nil {
-		return sessionMeta{}, false, fmt.Errorf("get session meta: %w", err)
-	}
-	var meta sessionMeta
-	if err := json.Unmarshal(metaJSON, &meta); err != nil {
-		return sessionMeta{}, false, fmt.Errorf("unmarshal session meta: %w", err)
-	}
-	return meta, true, nil
 }
 
 func (c *Client) queryTrackEventPageRows(
@@ -174,7 +149,6 @@ func (c *Client) queryTrackEventPageRows(
 
 func hashIdxTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	rows []trackEventPageRow,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
@@ -183,7 +157,6 @@ func hashIdxTrackEventPageEntries(
 			TrackEventPageCursorKind,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			row.score,
 			row.id,
 		)

--- a/session/redis/internal/hashidx/track_page.go
+++ b/session/redis/internal/hashidx/track_page.go
@@ -1,0 +1,195 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package hashidx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindHashIdx = "redis-hashidx"
+
+type trackEventPageRow struct {
+	id    string
+	score int64
+	event session.TrackEvent
+}
+
+type scoredTrackEventID struct {
+	id    string
+	score int64
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (c *Client) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	meta, ok, err := c.getTrackEventPageSessionMeta(ctx, req.Key)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	var cursor trackpage.Cursor
+	hasCursor := req.Cursor != ""
+	if hasCursor {
+		cursor, err = trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindHashIdx, req.Key, req.Track, meta.CreatedAt); err != nil {
+			return nil, err
+		}
+	}
+	rows, hasMore, err := c.queryTrackEventPageRows(ctx, req, cursor, hasCursor)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := hashIdxTrackEventPageEntries(req, meta.CreatedAt, rows)
+	if err != nil {
+		return nil, err
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (c *Client) getTrackEventPageSessionMeta(
+	ctx context.Context,
+	key session.Key,
+) (sessionMeta, bool, error) {
+	metaJSON, err := c.client.Get(ctx, c.keys.SessionMetaKey(key)).Bytes()
+	if err == redis.Nil {
+		return sessionMeta{}, false, nil
+	}
+	if err != nil {
+		return sessionMeta{}, false, fmt.Errorf("get session meta: %w", err)
+	}
+	var meta sessionMeta
+	if err := json.Unmarshal(metaJSON, &meta); err != nil {
+		return sessionMeta{}, false, fmt.Errorf("unmarshal session meta: %w", err)
+	}
+	return meta, true, nil
+}
+
+func (c *Client) queryTrackEventPageRows(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	cursor trackpage.Cursor,
+	hasCursor bool,
+) ([]trackEventPageRow, bool, error) {
+	rangeBy := &redis.ZRangeBy{
+		Min: "-inf",
+		Max: "+inf",
+	}
+	if hasCursor {
+		rangeBy.Max = fmt.Sprintf("%d", cursor.CreatedAt)
+	} else {
+		rangeBy.Offset = 0
+		rangeBy.Count = int64(req.EventLimit + 1)
+	}
+	zs, err := c.client.ZRevRangeByScoreWithScores(ctx, c.keys.TrackTimeIndexKey(req.Key, req.Track), rangeBy).Result()
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page index: %w", err)
+	}
+	selected := make([]scoredTrackEventID, 0, req.EventLimit+1)
+	for _, z := range zs {
+		id := fmt.Sprint(z.Member)
+		score := int64(z.Score)
+		if hasCursor && !redisTrackPageOlder(score, id, cursor.CreatedAt, cursor.ID) {
+			continue
+		}
+		selected = append(selected, scoredTrackEventID{id: id, score: score})
+		if len(selected) >= req.EventLimit+1 {
+			break
+		}
+	}
+	hasMore := len(selected) > req.EventLimit
+	if hasMore {
+		selected = selected[:req.EventLimit]
+	}
+	if len(selected) == 0 {
+		return nil, hasMore, nil
+	}
+	ids := make([]string, 0, len(selected))
+	for _, item := range selected {
+		ids = append(ids, item.id)
+	}
+	rawEvents, err := c.client.HMGet(ctx, c.keys.TrackDataKey(req.Key, req.Track), ids...).Result()
+	if err != nil {
+		return nil, false, fmt.Errorf("load track event page data: %w", err)
+	}
+	rows := make([]trackEventPageRow, 0, len(rawEvents))
+	for i, raw := range rawEvents {
+		text, ok := raw.(string)
+		if !ok || text == "" {
+			continue
+		}
+		var event session.TrackEvent
+		if err := json.Unmarshal([]byte(text), &event); err != nil {
+			return nil, false, fmt.Errorf("unmarshal track event: %w", err)
+		}
+		rows = append(rows, trackEventPageRow{
+			id:    selected[i].id,
+			score: selected[i].score,
+			event: event,
+		})
+	}
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	return rows, hasMore, nil
+}
+
+func hashIdxTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	rows []trackEventPageRow,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(rows))
+	for _, row := range rows {
+		cursor, err := trackpage.CursorForUnixNano(
+			trackEventPageCursorKindHashIdx,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			row.score,
+			row.id,
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  row.event,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}
+
+func redisTrackPageOlder(score int64, id string, cursorScore int64, cursorID string) bool {
+	if score < cursorScore {
+		return true
+	}
+	return score == cursorScore && id < cursorID
+}

--- a/session/redis/internal/hashidx/track_page_test.go
+++ b/session/redis/internal/hashidx/track_page_test.go
@@ -101,6 +101,7 @@ func TestClient_GetTrackEventPageOrdersDoubleDigitSameScore(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, page.Entries)
+		require.LessOrEqual(t, len(page.Entries), 5)
 
 		payloads := make([]string, 0, len(page.Entries))
 		for _, entry := range page.Entries {

--- a/session/redis/internal/hashidx/track_page_test.go
+++ b/session/redis/internal/hashidx/track_page_test.go
@@ -1,0 +1,94 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package hashidx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestClient_GetTrackEventPageContinuesSameScore(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "page-hashidx-same-score"}
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	tracksJSON, err := json.Marshal([]session.Track{"alpha"})
+	require.NoError(t, err)
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+			Track:     "alpha",
+			Payload:   json.RawMessage(fmt.Sprintf(`"payload-%d"`, i)),
+			Timestamp: baseTime,
+		}, tracksJSON))
+	}
+
+	first, err := c.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, first.Entries, 1)
+	assert.True(t, first.HasMore)
+	cursor, err := trackpage.Decode(first.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.Equal(t, TrackEventPageCursorKind, cursor.Kind)
+	assert.Equal(t, trackpage.TimeToUnixNano(baseTime), cursor.CreatedAt)
+
+	second, err := c.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     first.Entries[0].Cursor,
+		EventLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, second.Entries, 2)
+	assert.False(t, second.HasMore)
+
+	seen := map[string]bool{string(first.Entries[0].Event.Payload): true}
+	for _, entry := range second.Entries {
+		assert.False(t, seen[string(entry.Event.Payload)])
+		seen[string(entry.Event.Payload)] = true
+	}
+}
+
+func TestClient_GetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "page-hashidx-wrong-cursor"}
+	cursor, err := trackpage.CursorForUnixNano(
+		TrackEventPageCursorKind,
+		key,
+		"beta",
+		time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC).UnixNano(),
+		"1",
+	)
+	require.NoError(t, err)
+
+	_, err = c.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+}

--- a/session/redis/internal/hashidx/track_page_test.go
+++ b/session/redis/internal/hashidx/track_page_test.go
@@ -71,6 +71,66 @@ func TestClient_GetTrackEventPageContinuesSameScore(t *testing.T) {
 	}
 }
 
+func TestClient_GetTrackEventPageOrdersDoubleDigitSameScore(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "page-hashidx-double-digit"}
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	tracksJSON, err := json.Marshal([]session.Track{"alpha"})
+	require.NoError(t, err)
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 12; i++ {
+		require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+			Track:     "alpha",
+			Payload:   json.RawMessage(fmt.Sprintf(`"payload-%02d"`, i)),
+			Timestamp: baseTime,
+		}, tracksJSON))
+	}
+
+	var cursor string
+	var all []string
+	for {
+		page, err := c.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+			Key:        key,
+			Track:      "alpha",
+			Cursor:     cursor,
+			EventLimit: 5,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, page.Entries)
+
+		payloads := make([]string, 0, len(page.Entries))
+		for _, entry := range page.Entries {
+			var payload string
+			require.NoError(t, json.Unmarshal(entry.Event.Payload, &payload))
+			payloads = append(payloads, payload)
+		}
+		all = append(payloads, all...)
+		if !page.HasMore {
+			break
+		}
+		cursor = page.Entries[0].Cursor
+	}
+
+	require.Equal(t, []string{
+		"payload-00",
+		"payload-01",
+		"payload-02",
+		"payload-03",
+		"payload-04",
+		"payload-05",
+		"payload-06",
+		"payload-07",
+		"payload-08",
+		"payload-09",
+		"payload-10",
+		"payload-11",
+	}, all)
+}
+
 func TestClient_GetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())

--- a/session/redis/internal/zset/track_page.go
+++ b/session/redis/internal/zset/track_page.go
@@ -15,7 +15,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -44,22 +43,15 @@ func (c *Client) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	sessState, ok, err := c.getTrackEventPageSessionState(ctx, req.Key)
-	if err != nil {
-		return nil, err
-	}
-	var sessionCreatedAt time.Time
-	if ok {
-		sessionCreatedAt = sessState.CreatedAt
-	}
 	var cursor trackpage.Cursor
 	hasCursor := req.Cursor != ""
 	if hasCursor {
+		var err error
 		cursor, err = trackpage.Decode(req.Cursor)
 		if err != nil {
 			return nil, err
 		}
-		if err := validateTrackEventPageCursorBinding(cursor, req.Key, req.Track, sessionCreatedAt, ok); err != nil {
+		if err := trackpage.ValidateBinding(cursor, TrackEventPageCursorKind, req.Key, req.Track); err != nil {
 			return nil, err
 		}
 	}
@@ -67,7 +59,7 @@ func (c *Client) GetTrackEventPage(
 	if err != nil {
 		return nil, err
 	}
-	entries, err := zsetTrackEventPageEntries(req, sessionCreatedAt, rows)
+	entries, err := zsetTrackEventPageEntries(req, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -76,24 +68,6 @@ func (c *Client) GetTrackEventPage(
 		Entries: entries,
 		HasMore: hasMore,
 	}, nil
-}
-
-func (c *Client) getTrackEventPageSessionState(
-	ctx context.Context,
-	key session.Key,
-) (*SessionState, bool, error) {
-	raw, err := c.client.HGet(ctx, c.sessionStateKey(key), key.SessionID).Bytes()
-	if err == redis.Nil {
-		return nil, false, nil
-	}
-	if err != nil {
-		return nil, false, fmt.Errorf("get session state: %w", err)
-	}
-	var sessState SessionState
-	if err := json.Unmarshal(raw, &sessState); err != nil {
-		return nil, false, fmt.Errorf("unmarshal session state: %w", err)
-	}
-	return &sessState, true, nil
 }
 
 func (c *Client) queryTrackEventPageRows(
@@ -163,7 +137,6 @@ func (c *Client) queryTrackEventPageRows(
 
 func zsetTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	rows []trackEventPageRow,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
@@ -172,7 +145,6 @@ func zsetTrackEventPageEntries(
 			TrackEventPageCursorKind,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			row.score,
 			zsetTrackPageCursorID(row.member),
 		)
@@ -185,28 +157,6 @@ func zsetTrackEventPageEntries(
 		})
 	}
 	return entries, nil
-}
-
-func validateTrackEventPageCursorBinding(
-	c trackpage.Cursor,
-	key session.Key,
-	track session.Track,
-	sessionCreatedAt time.Time,
-	hasSessionState bool,
-) error {
-	if hasSessionState {
-		return trackpage.ValidateBinding(c, TrackEventPageCursorKind, key, track, sessionCreatedAt)
-	}
-	if c.Kind != TrackEventPageCursorKind {
-		return fmt.Errorf("cursor kind mismatch")
-	}
-	if c.AppName != key.AppName || c.UserID != key.UserID || c.SessionID != key.SessionID {
-		return fmt.Errorf("cursor session mismatch")
-	}
-	if c.Track != string(track) {
-		return fmt.Errorf("cursor track mismatch")
-	}
-	return nil
 }
 
 func zsetTrackPageOlder(score int64, member string, cursor trackpage.Cursor, cursorSeen *bool) bool {

--- a/session/redis/internal/zset/track_page.go
+++ b/session/redis/internal/zset/track_page.go
@@ -1,0 +1,180 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package zset
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindZSet = "redis-zset"
+
+type trackEventPageRow struct {
+	member string
+	score  int64
+	event  session.TrackEvent
+}
+
+type scoredTrackEventMember struct {
+	member string
+	score  int64
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (c *Client) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sessState, ok, err := c.getTrackEventPageSessionState(ctx, req.Key)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	var cursor trackpage.Cursor
+	hasCursor := req.Cursor != ""
+	if hasCursor {
+		cursor, err = trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindZSet, req.Key, req.Track, sessState.CreatedAt); err != nil {
+			return nil, err
+		}
+	}
+	rows, hasMore, err := c.queryTrackEventPageRows(ctx, req, cursor, hasCursor)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := zsetTrackEventPageEntries(req, sessState.CreatedAt, rows)
+	if err != nil {
+		return nil, err
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (c *Client) getTrackEventPageSessionState(
+	ctx context.Context,
+	key session.Key,
+) (*SessionState, bool, error) {
+	raw, err := c.client.HGet(ctx, c.sessionStateKey(key), key.SessionID).Bytes()
+	if err == redis.Nil {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("get session state: %w", err)
+	}
+	var sessState SessionState
+	if err := json.Unmarshal(raw, &sessState); err != nil {
+		return nil, false, fmt.Errorf("unmarshal session state: %w", err)
+	}
+	return &sessState, true, nil
+}
+
+func (c *Client) queryTrackEventPageRows(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	cursor trackpage.Cursor,
+	hasCursor bool,
+) ([]trackEventPageRow, bool, error) {
+	rangeBy := &redis.ZRangeBy{
+		Min: "-inf",
+		Max: "+inf",
+	}
+	if hasCursor {
+		rangeBy.Max = fmt.Sprintf("%d", cursor.CreatedAt)
+	} else {
+		rangeBy.Offset = 0
+		rangeBy.Count = int64(req.EventLimit + 1)
+	}
+	zs, err := c.client.ZRevRangeByScoreWithScores(ctx, c.trackKey(req.Key, req.Track), rangeBy).Result()
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page index: %w", err)
+	}
+	selected := make([]scoredTrackEventMember, 0, req.EventLimit+1)
+	for _, z := range zs {
+		member := fmt.Sprint(z.Member)
+		score := int64(z.Score)
+		if hasCursor && !redisTrackPageOlder(score, member, cursor.CreatedAt, cursor.ID) {
+			continue
+		}
+		selected = append(selected, scoredTrackEventMember{member: member, score: score})
+		if len(selected) >= req.EventLimit+1 {
+			break
+		}
+	}
+	hasMore := len(selected) > req.EventLimit
+	if hasMore {
+		selected = selected[:req.EventLimit]
+	}
+	rows := make([]trackEventPageRow, 0, len(selected))
+	for _, item := range selected {
+		var event session.TrackEvent
+		if err := json.Unmarshal([]byte(item.member), &event); err != nil {
+			return nil, false, fmt.Errorf("unmarshal track event: %w", err)
+		}
+		rows = append(rows, trackEventPageRow{
+			member: item.member,
+			score:  item.score,
+			event:  event,
+		})
+	}
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	return rows, hasMore, nil
+}
+
+func zsetTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	rows []trackEventPageRow,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(rows))
+	for _, row := range rows {
+		cursor, err := trackpage.CursorForUnixNano(
+			trackEventPageCursorKindZSet,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			row.score,
+			row.member,
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  row.event,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}
+
+func redisTrackPageOlder(score int64, id string, cursorScore int64, cursorID string) bool {
+	if score < cursorScore {
+		return true
+	}
+	return score == cursorScore && id < cursorID
+}

--- a/session/redis/internal/zset/track_page.go
+++ b/session/redis/internal/zset/track_page.go
@@ -11,6 +11,8 @@ package zset
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -20,7 +22,8 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
 )
 
-const trackEventPageCursorKindZSet = "redis-zset"
+// TrackEventPageCursorKind is the cursor kind emitted by zset track pages.
+const TrackEventPageCursorKind = "redis-zset"
 
 type trackEventPageRow struct {
 	member string
@@ -45,8 +48,9 @@ func (c *Client) GetTrackEventPage(
 	if err != nil {
 		return nil, err
 	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
+	var sessionCreatedAt time.Time
+	if ok {
+		sessionCreatedAt = sessState.CreatedAt
 	}
 	var cursor trackpage.Cursor
 	hasCursor := req.Cursor != ""
@@ -55,7 +59,7 @@ func (c *Client) GetTrackEventPage(
 		if err != nil {
 			return nil, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindZSet, req.Key, req.Track, sessState.CreatedAt); err != nil {
+		if err := validateTrackEventPageCursorBinding(cursor, req.Key, req.Track, sessionCreatedAt, ok); err != nil {
 			return nil, err
 		}
 	}
@@ -63,7 +67,7 @@ func (c *Client) GetTrackEventPage(
 	if err != nil {
 		return nil, err
 	}
-	entries, err := zsetTrackEventPageEntries(req, sessState.CreatedAt, rows)
+	entries, err := zsetTrackEventPageEntries(req, sessionCreatedAt, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -98,31 +102,42 @@ func (c *Client) queryTrackEventPageRows(
 	cursor trackpage.Cursor,
 	hasCursor bool,
 ) ([]trackEventPageRow, bool, error) {
-	rangeBy := &redis.ZRangeBy{
-		Min: "-inf",
-		Max: "+inf",
-	}
-	if hasCursor {
-		rangeBy.Max = fmt.Sprintf("%d", cursor.CreatedAt)
-	} else {
-		rangeBy.Offset = 0
-		rangeBy.Count = int64(req.EventLimit + 1)
-	}
-	zs, err := c.client.ZRevRangeByScoreWithScores(ctx, c.trackKey(req.Key, req.Track), rangeBy).Result()
-	if err != nil {
-		return nil, false, fmt.Errorf("query track event page index: %w", err)
-	}
 	selected := make([]scoredTrackEventMember, 0, req.EventLimit+1)
-	for _, z := range zs {
-		member := fmt.Sprint(z.Member)
-		score := int64(z.Score)
-		if hasCursor && !redisTrackPageOlder(score, member, cursor.CreatedAt, cursor.ID) {
-			continue
+	batchLimit := int64(req.EventLimit + 1)
+	var offset int64
+	cursorSeen := false
+	for {
+		rangeBy := &redis.ZRangeBy{
+			Min:    "-inf",
+			Max:    "+inf",
+			Offset: offset,
+			Count:  batchLimit,
 		}
-		selected = append(selected, scoredTrackEventMember{member: member, score: score})
+		if hasCursor {
+			rangeBy.Max = fmt.Sprintf("%d", cursor.CreatedAt)
+		}
+		zs, err := c.client.ZRevRangeByScoreWithScores(ctx, c.trackKey(req.Key, req.Track), rangeBy).Result()
+		if err != nil {
+			return nil, false, fmt.Errorf("query track event page index: %w", err)
+		}
+		for _, z := range zs {
+			member := fmt.Sprint(z.Member)
+			score := int64(z.Score)
+			if hasCursor && !zsetTrackPageOlder(score, member, cursor, &cursorSeen) {
+				continue
+			}
+			selected = append(selected, scoredTrackEventMember{member: member, score: score})
+			if len(selected) >= req.EventLimit+1 {
+				break
+			}
+		}
 		if len(selected) >= req.EventLimit+1 {
 			break
 		}
+		if !hasCursor || int64(len(zs)) < batchLimit {
+			break
+		}
+		offset += int64(len(zs))
 	}
 	hasMore := len(selected) > req.EventLimit
 	if hasMore {
@@ -154,12 +169,12 @@ func zsetTrackEventPageEntries(
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
 	for _, row := range rows {
 		cursor, err := trackpage.CursorForUnixNano(
-			trackEventPageCursorKindZSet,
+			TrackEventPageCursorKind,
 			req.Key,
 			req.Track,
 			sessionCreatedAt,
 			row.score,
-			row.member,
+			zsetTrackPageCursorID(row.member),
 		)
 		if err != nil {
 			return nil, err
@@ -172,9 +187,45 @@ func zsetTrackEventPageEntries(
 	return entries, nil
 }
 
-func redisTrackPageOlder(score int64, id string, cursorScore int64, cursorID string) bool {
-	if score < cursorScore {
+func validateTrackEventPageCursorBinding(
+	c trackpage.Cursor,
+	key session.Key,
+	track session.Track,
+	sessionCreatedAt time.Time,
+	hasSessionState bool,
+) error {
+	if hasSessionState {
+		return trackpage.ValidateBinding(c, TrackEventPageCursorKind, key, track, sessionCreatedAt)
+	}
+	if c.Kind != TrackEventPageCursorKind {
+		return fmt.Errorf("cursor kind mismatch")
+	}
+	if c.AppName != key.AppName || c.UserID != key.UserID || c.SessionID != key.SessionID {
+		return fmt.Errorf("cursor session mismatch")
+	}
+	if c.Track != string(track) {
+		return fmt.Errorf("cursor track mismatch")
+	}
+	return nil
+}
+
+func zsetTrackPageOlder(score int64, member string, cursor trackpage.Cursor, cursorSeen *bool) bool {
+	if score < cursor.CreatedAt {
 		return true
 	}
-	return score == cursorScore && id < cursorID
+	if score != cursor.CreatedAt {
+		return false
+	}
+	if *cursorSeen {
+		return true
+	}
+	if zsetTrackPageCursorID(member) == cursor.ID {
+		*cursorSeen = true
+	}
+	return false
+}
+
+func zsetTrackPageCursorID(member string) string {
+	sum := sha256.Sum256([]byte(member))
+	return hex.EncodeToString(sum[:])
 }

--- a/session/redis/internal/zset/track_page_test.go
+++ b/session/redis/internal/zset/track_page_test.go
@@ -1,0 +1,69 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package zset
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestClient_GetTrackEventPageCursorUsesDigestAndContinuesSameScore(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "page-zset-same-score"}
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, c.AppendTrackEvent(ctx, key, &session.TrackEvent{
+			Track:     "alpha",
+			Payload:   json.RawMessage(fmt.Sprintf(`"secret-%d"`, i)),
+			Timestamp: baseTime,
+		}))
+	}
+
+	first, err := c.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, first.Entries, 1)
+	require.True(t, first.HasMore)
+	cursor, err := trackpage.Decode(first.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.NotContains(t, cursor.ID, "secret")
+
+	second, err := c.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     first.Entries[0].Cursor,
+		EventLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, second.Entries, 2)
+	require.False(t, second.HasMore)
+
+	seen := map[string]bool{string(first.Entries[0].Event.Payload): true}
+	for _, entry := range second.Entries {
+		assert.False(t, seen[string(entry.Event.Payload)])
+		seen[string(entry.Event.Payload)] = true
+	}
+}

--- a/session/redis/service.go
+++ b/session/redis/service.go
@@ -34,8 +34,9 @@ import (
 )
 
 var (
-	_ session.Service      = (*Service)(nil)
-	_ session.TrackService = (*Service)(nil)
+	_ session.Service               = (*Service)(nil)
+	_ session.TrackService          = (*Service)(nil)
+	_ session.TrackEventPageService = (*Service)(nil)
 
 	_ session.StateInitializationService = (*Service)(nil)
 )

--- a/session/redis/service_track_test.go
+++ b/session/redis/service_track_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/hashidx"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/zset"
 )
@@ -186,6 +187,54 @@ func TestService_GetTrackEvents_ReadsTrackStorageWithoutSessionState(t *testing.
 			require.JSONEq(t, `"persisted"`, string(got.Events[0].Payload))
 		})
 	}
+}
+
+func TestService_GetTrackEventPage_ReadsLegacyZSetWithoutSessionState(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+	trackTTL := time.Duration(0)
+	service, err := NewService(
+		WithRedisClientURL(redisURL),
+		WithCompatMode(CompatModeTransition),
+		WithTrackEventTTL(trackTTL),
+	)
+	require.NoError(t, err)
+	defer service.Close()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "session-page-track-only"}
+	sess, err := service.CreateSession(ctx, key, session.StateMap{})
+	require.NoError(t, err)
+	baseTime := time.Now().Add(-time.Minute)
+	require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"older"`),
+		Timestamp: baseTime,
+	}))
+	require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"secret-newer"`),
+		Timestamp: baseTime.Add(time.Second),
+	}))
+
+	client := buildRedisClient(t, redisURL)
+	defer client.Close()
+	require.NoError(t, client.HDel(ctx, zset.GetSessionStateKey(key), key.SessionID).Err())
+
+	page, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, session.Track("alpha"), page.Track)
+	require.Len(t, page.Entries, 1)
+	require.JSONEq(t, `"secret-newer"`, string(page.Entries[0].Event.Payload))
+	assert.True(t, page.HasMore)
+
+	cursor, err := trackpage.Decode(page.Entries[0].Cursor)
+	require.NoError(t, err)
+	assert.NotContains(t, cursor.ID, "secret-newer")
 }
 
 func TestService_GetTrackEvents_EmptyAndErrors(t *testing.T) {

--- a/session/redis/service_track_test.go
+++ b/session/redis/service_track_test.go
@@ -237,6 +237,94 @@ func TestService_GetTrackEventPage_ReadsLegacyZSetWithoutSessionState(t *testing
 	assert.NotContains(t, cursor.ID, "secret-newer")
 }
 
+func TestService_GetTrackEventPageRoutesCursorByKind(t *testing.T) {
+	tests := []struct {
+		name string
+		mode CompatMode
+	}{
+		{name: "hashidx", mode: CompatModeNone},
+		{name: "zset", mode: CompatModeTransition},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redisURL, cleanup := setupTestRedis(t)
+			defer cleanup()
+			service, err := NewService(
+				WithRedisClientURL(redisURL),
+				WithCompatMode(tt.mode),
+			)
+			require.NoError(t, err)
+			defer service.Close()
+
+			ctx := context.Background()
+			key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "session-page-route"}
+			sess, err := service.CreateSession(ctx, key, session.StateMap{})
+			require.NoError(t, err)
+			baseTime := time.Now().Add(-time.Minute)
+			require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+				Track:     "alpha",
+				Payload:   json.RawMessage(`"older"`),
+				Timestamp: baseTime,
+			}))
+			require.NoError(t, service.AppendTrackEvent(ctx, sess, &session.TrackEvent{
+				Track:     "alpha",
+				Payload:   json.RawMessage(`"newer"`),
+				Timestamp: baseTime.Add(time.Second),
+			}))
+
+			page, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+				Key:        key,
+				Track:      "alpha",
+				EventLimit: 1,
+			})
+			require.NoError(t, err)
+			require.Len(t, page.Entries, 1)
+			assert.True(t, page.HasMore)
+			require.JSONEq(t, `"newer"`, string(page.Entries[0].Event.Payload))
+
+			next, err := service.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+				Key:        key,
+				Track:      "alpha",
+				Cursor:     page.Entries[0].Cursor,
+				EventLimit: 1,
+			})
+			require.NoError(t, err)
+			require.Len(t, next.Entries, 1)
+			assert.False(t, next.HasMore)
+			require.JSONEq(t, `"older"`, string(next.Entries[0].Event.Payload))
+		})
+	}
+}
+
+func TestService_GetTrackEventPageRejectsUnknownCursorKind(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+	service, err := NewService(WithRedisClientURL(redisURL))
+	require.NoError(t, err)
+	defer service.Close()
+
+	key := session.Key{AppName: "testapp", UserID: "user123", SessionID: "session-page-route"}
+	cursor, err := trackpage.Encode(trackpage.Cursor{
+		Kind:      "unknown",
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		SessionID: key.SessionID,
+		Track:     "alpha",
+		CreatedAt: time.Now().UnixNano(),
+		ID:        "1",
+	})
+	require.NoError(t, err)
+
+	_, err = service.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cursor kind mismatch")
+}
+
 func TestService_GetTrackEvents_EmptyAndErrors(t *testing.T) {
 	t.Run("invalid key", func(t *testing.T) {
 		redisURL, cleanup := setupTestRedis(t)

--- a/session/redis/track_service.go
+++ b/session/redis/track_service.go
@@ -15,6 +15,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
 )
 
@@ -92,6 +93,37 @@ func (s *Service) GetTrackEvents(
 		}
 	}
 	return s.getHashIdxTrackEvents(ctx, key, track, opt)
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *Service) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	ctx, span := s.startSpan(ctx, "get_track_event_page", req.Key)
+	defer span.End()
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	zsetExists, hashidxExists, err := s.checkSessionExists(ctx, req.Key)
+	if err != nil {
+		return nil, fmt.Errorf("check session exists: %w", err)
+	}
+	if s.compatEnabled() && zsetExists {
+		page, err := s.zsetClient.GetTrackEventPage(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("get track event page (zset): %w", err)
+		}
+		return page, nil
+	}
+	if hashidxExists {
+		page, err := s.hashidxClient.GetTrackEventPage(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("get track event page (hashidx): %w", err)
+		}
+		return page, nil
+	}
+	return &session.TrackEventPage{Track: req.Track}, nil
 }
 
 func (s *Service) getZSetTrackEvents(

--- a/session/redis/track_service.go
+++ b/session/redis/track_service.go
@@ -16,7 +16,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/hashidx"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
+	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/zset"
 )
 
 // AppendTrackEvent appends a protocol-specific track event to a session.
@@ -105,6 +107,9 @@ func (s *Service) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
+	if req.Cursor != "" {
+		return s.getTrackEventPageForCursor(ctx, req)
+	}
 	zsetExists, hashidxExists, err := s.checkSessionExists(ctx, req.Key)
 	if err != nil {
 		return nil, fmt.Errorf("check session exists: %w", err)
@@ -123,7 +128,42 @@ func (s *Service) GetTrackEventPage(
 		}
 		return page, nil
 	}
+	if s.compatEnabled() {
+		page, err := s.zsetClient.GetTrackEventPage(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("get track event page (zset): %w", err)
+		}
+		if len(page.Entries) > 0 || page.HasMore {
+			return page, nil
+		}
+	}
 	return &session.TrackEventPage{Track: req.Track}, nil
+}
+
+func (s *Service) getTrackEventPageForCursor(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	cursor, err := trackpage.Decode(req.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	switch cursor.Kind {
+	case zset.TrackEventPageCursorKind:
+		page, err := s.zsetClient.GetTrackEventPage(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("get track event page (zset): %w", err)
+		}
+		return page, nil
+	case hashidx.TrackEventPageCursorKind:
+		page, err := s.hashidxClient.GetTrackEventPage(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("get track event page (hashidx): %w", err)
+		}
+		return page, nil
+	default:
+		return nil, fmt.Errorf("cursor kind mismatch")
+	}
 }
 
 func (s *Service) getZSetTrackEvents(

--- a/session/sqlite/service.go
+++ b/session/sqlite/service.go
@@ -31,6 +31,7 @@ import (
 
 var _ session.Service = (*Service)(nil)
 var _ session.TrackService = (*Service)(nil)
+var _ session.TrackEventPageService = (*Service)(nil)
 
 // SessionState is the state of a session.
 type SessionState struct {

--- a/session/sqlite/track_page.go
+++ b/session/sqlite/track_page.go
@@ -11,9 +11,7 @@ package sqlite
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -38,18 +36,11 @@ func (s *Service) GetTrackEventPage(
 	if err := trackpage.ValidateRequest(req); err != nil {
 		return nil, err
 	}
-	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite session service get track event page failed: %w", err)
 	}
-	if !ok {
-		return &session.TrackEventPage{Track: req.Track}, nil
-	}
-	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("sqlite session service get track event page failed: %w", err)
-	}
-	entries, err := sqliteTrackEventPageEntries(req, sessionCreatedAt, rows)
+	entries, err := sqliteTrackEventPageEntries(req, rows)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite session service get track event page failed: %w", err)
 	}
@@ -60,38 +51,9 @@ func (s *Service) GetTrackEventPage(
 	}, nil
 }
 
-func (s *Service) getTrackEventPageSessionCreatedAt(
-	ctx context.Context,
-	key session.Key,
-) (time.Time, bool, error) {
-	var createdNs int64
-	err := s.db.QueryRowContext(
-		ctx,
-		fmt.Sprintf(
-			`SELECT created_at FROM %s
-WHERE app_name = ? AND user_id = ? AND session_id = ?
-AND (expires_at IS NULL OR expires_at > ?)
-AND deleted_at IS NULL`,
-			s.tableSessionStates,
-		),
-		key.AppName,
-		key.UserID,
-		key.SessionID,
-		time.Now().UTC().UnixNano(),
-	).Scan(&createdNs)
-	if errors.Is(err, sql.ErrNoRows) {
-		return time.Time{}, false, nil
-	}
-	if err != nil {
-		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
-	}
-	return unixNanoToTime(createdNs), true, nil
-}
-
 func (s *Service) queryTrackEventPageRows(
 	ctx context.Context,
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 ) ([]trackEventPageRow, bool, error) {
 	query := fmt.Sprintf(
 		`SELECT id, event, created_at FROM %s
@@ -106,7 +68,7 @@ AND deleted_at IS NULL`,
 		if err != nil {
 			return nil, false, err
 		}
-		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindSQLite, req.Key, req.Track, sessionCreatedAt); err != nil {
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindSQLite, req.Key, req.Track); err != nil {
 			return nil, false, err
 		}
 		cursorID, err := trackpage.ParseIntID(cursor.ID)
@@ -153,7 +115,6 @@ LIMIT ?`
 
 func sqliteTrackEventPageEntries(
 	req session.TrackEventPageRequest,
-	sessionCreatedAt time.Time,
 	rows []trackEventPageRow,
 ) ([]session.TrackEventPageEntry, error) {
 	entries := make([]session.TrackEventPageEntry, 0, len(rows))
@@ -162,7 +123,6 @@ func sqliteTrackEventPageEntries(
 			trackEventPageCursorKindSQLite,
 			req.Key,
 			req.Track,
-			sessionCreatedAt,
 			row.createdAt,
 			strconv.FormatInt(row.id, 10),
 		)

--- a/session/sqlite/track_page.go
+++ b/session/sqlite/track_page.go
@@ -1,0 +1,178 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+const trackEventPageCursorKindSQLite = "sqlite"
+
+type trackEventPageRow struct {
+	id        int64
+	event     session.TrackEvent
+	createdAt int64
+}
+
+// GetTrackEventPage returns a cursor page of persisted track events.
+func (s *Service) GetTrackEventPage(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+) (*session.TrackEventPage, error) {
+	if err := trackpage.ValidateRequest(req); err != nil {
+		return nil, err
+	}
+	sessionCreatedAt, ok, err := s.getTrackEventPageSessionCreatedAt(ctx, req.Key)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite session service get track event page failed: %w", err)
+	}
+	if !ok {
+		return &session.TrackEventPage{Track: req.Track}, nil
+	}
+	rows, hasMore, err := s.queryTrackEventPageRows(ctx, req, sessionCreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite session service get track event page failed: %w", err)
+	}
+	entries, err := sqliteTrackEventPageEntries(req, sessionCreatedAt, rows)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite session service get track event page failed: %w", err)
+	}
+	return &session.TrackEventPage{
+		Track:   req.Track,
+		Entries: entries,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (s *Service) getTrackEventPageSessionCreatedAt(
+	ctx context.Context,
+	key session.Key,
+) (time.Time, bool, error) {
+	var createdNs int64
+	err := s.db.QueryRowContext(
+		ctx,
+		fmt.Sprintf(
+			`SELECT created_at FROM %s
+WHERE app_name = ? AND user_id = ? AND session_id = ?
+AND (expires_at IS NULL OR expires_at > ?)
+AND deleted_at IS NULL`,
+			s.tableSessionStates,
+		),
+		key.AppName,
+		key.UserID,
+		key.SessionID,
+		time.Now().UTC().UnixNano(),
+	).Scan(&createdNs)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("query session created_at: %w", err)
+	}
+	return unixNanoToTime(createdNs), true, nil
+}
+
+func (s *Service) queryTrackEventPageRows(
+	ctx context.Context,
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+) ([]trackEventPageRow, bool, error) {
+	query := fmt.Sprintf(
+		`SELECT id, event, created_at FROM %s
+WHERE app_name = ? AND user_id = ? AND session_id = ? AND track = ?
+AND (expires_at IS NULL OR expires_at > ?)
+AND deleted_at IS NULL`,
+		s.tableSessionTracks,
+	)
+	args := []any{req.Key.AppName, req.Key.UserID, req.Key.SessionID, req.Track, time.Now().UTC().UnixNano()}
+	if req.Cursor != "" {
+		cursor, err := trackpage.Decode(req.Cursor)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := trackpage.ValidateBinding(cursor, trackEventPageCursorKindSQLite, req.Key, req.Track, sessionCreatedAt); err != nil {
+			return nil, false, err
+		}
+		cursorID, err := trackpage.ParseIntID(cursor.ID)
+		if err != nil {
+			return nil, false, err
+		}
+		query += `
+AND (created_at < ? OR (created_at = ? AND id < ?))`
+		args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursorID)
+	}
+	query += `
+ORDER BY created_at DESC, id DESC
+LIMIT ?`
+	args = append(args, req.EventLimit+1)
+	sqlRows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, false, fmt.Errorf("query track event page: %w", err)
+	}
+	defer sqlRows.Close()
+	rows := make([]trackEventPageRow, 0, req.EventLimit+1)
+	for sqlRows.Next() {
+		var row trackEventPageRow
+		var eventBytes []byte
+		if err := sqlRows.Scan(&row.id, &eventBytes, &row.createdAt); err != nil {
+			return nil, false, fmt.Errorf("scan track event page: %w", err)
+		}
+		if err := json.Unmarshal(eventBytes, &row.event); err != nil {
+			return nil, false, fmt.Errorf("unmarshal track event: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	if err := sqlRows.Err(); err != nil {
+		return nil, false, fmt.Errorf("iterate track event page: %w", err)
+	}
+	hasMore := len(rows) > req.EventLimit
+	if hasMore {
+		rows = rows[:req.EventLimit]
+	}
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+	return rows, hasMore, nil
+}
+
+func sqliteTrackEventPageEntries(
+	req session.TrackEventPageRequest,
+	sessionCreatedAt time.Time,
+	rows []trackEventPageRow,
+) ([]session.TrackEventPageEntry, error) {
+	entries := make([]session.TrackEventPageEntry, 0, len(rows))
+	for _, row := range rows {
+		cursor, err := trackpage.CursorForUnixNano(
+			trackEventPageCursorKindSQLite,
+			req.Key,
+			req.Track,
+			sessionCreatedAt,
+			row.createdAt,
+			strconv.FormatInt(row.id, 10),
+		)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, session.TrackEventPageEntry{
+			Event:  row.event,
+			Cursor: cursor,
+		})
+	}
+	return entries, nil
+}

--- a/session/sqlite/track_page_test.go
+++ b/session/sqlite/track_page_test.go
@@ -95,6 +95,73 @@ func TestSessionSQLite_GetTrackEventPageRejectsWrongCursorBinding(t *testing.T) 
 	require.Error(t, err)
 }
 
+func TestSessionSQLite_GetTrackEventPageRejectsInvalidRequest(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	_, err = svc.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:   session.Key{AppName: "app", UserID: "user", SessionID: "session"},
+		Track: "alpha",
+	})
+	require.Error(t, err)
+}
+
+func TestSessionSQLite_GetTrackEventPageRejectsNonNumericCursorID(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorForUnixNano(
+		trackEventPageCursorKindSQLite,
+		key,
+		"alpha",
+		trackpage.TimeToUnixNano(time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)),
+		"bad",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+}
+
+func TestSessionSQLite_GetTrackEventPageRejectsMalformedEvent(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, sqliteTrackPageEvent("bad", time.Now())))
+
+	_, err = svc.db.ExecContext(ctx, "UPDATE "+svc.tableSessionTracks+" SET event = ?", []byte("{"))
+	require.NoError(t, err)
+
+	_, err = svc.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+}
+
 func sqliteTrackPageEvent(payload string, ts time.Time) *session.TrackEvent {
 	return &session.TrackEvent{
 		Track:     "alpha",

--- a/session/sqlite/track_page_test.go
+++ b/session/sqlite/track_page_test.go
@@ -1,0 +1,104 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/internal/trackpage"
+)
+
+func TestSessionSQLite_GetTrackEventPagePaginatesRows(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	sess, err := svc.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	baseTime := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, sqliteTrackPageEvent("oldest", baseTime)))
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, sqliteTrackPageEvent("middle", baseTime.Add(time.Second))))
+	require.NoError(t, svc.AppendTrackEvent(ctx, sess, sqliteTrackPageEvent("newest", baseTime.Add(2*time.Second))))
+
+	page, err := svc.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Entries, 2)
+	require.True(t, page.HasMore)
+	require.Equal(t, session.Track("alpha"), page.Track)
+	require.Equal(t, json.RawMessage(`"middle"`), page.Entries[0].Event.Payload)
+	require.Equal(t, json.RawMessage(`"newest"`), page.Entries[1].Event.Payload)
+
+	cursor, err := trackpage.Decode(page.Entries[0].Cursor)
+	require.NoError(t, err)
+	require.Equal(t, trackEventPageCursorKindSQLite, cursor.Kind)
+	require.Equal(t, trackpage.TimeToUnixNano(baseTime.Add(time.Second)), cursor.CreatedAt)
+
+	next, err := svc.GetTrackEventPage(ctx, session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     page.Entries[0].Cursor,
+		EventLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next.Entries, 1)
+	require.False(t, next.HasMore)
+	require.Equal(t, json.RawMessage(`"oldest"`), next.Entries[0].Event.Payload)
+}
+
+func TestSessionSQLite_GetTrackEventPageRejectsWrongCursorBinding(t *testing.T) {
+	db, _, cleanup := openTempSQLiteDB(t)
+	defer cleanup()
+
+	svc, err := NewService(db)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "session"}
+	cursor, err := trackpage.CursorForUnixNano(
+		trackEventPageCursorKindSQLite,
+		key,
+		"beta",
+		trackpage.TimeToUnixNano(time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)),
+		"1",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.GetTrackEventPage(context.Background(), session.TrackEventPageRequest{
+		Key:        key,
+		Track:      "alpha",
+		Cursor:     cursor,
+		EventLimit: 1,
+	})
+	require.Error(t, err)
+}
+
+func sqliteTrackPageEvent(payload string, ts time.Time) *session.TrackEvent {
+	return &session.TrackEvent{
+		Track:     "alpha",
+		Payload:   json.RawMessage(`"` + payload + `"`),
+		Timestamp: ts,
+	}
+}

--- a/session/track.go
+++ b/session/track.go
@@ -27,6 +27,12 @@ type TrackService interface {
 	AppendTrackEvent(ctx context.Context, sess *Session, event *TrackEvent, opts ...Option) error
 }
 
+// TrackEventPageService provides cursor pagination for persisted track events.
+type TrackEventPageService interface {
+	// GetTrackEventPage returns a page of persisted track events for one session track.
+	GetTrackEventPage(ctx context.Context, req TrackEventPageRequest) (*TrackEventPage, error)
+}
+
 // Track represents a logical track that stores track events.
 type Track string
 
@@ -41,6 +47,36 @@ type TrackEvent struct {
 type TrackEvents struct {
 	Track  Track        `json:"track"`
 	Events []TrackEvent `json:"events"`
+}
+
+// TrackEventPageRequest identifies one page of persisted track events.
+//
+// An empty Cursor loads the latest page. A non-empty Cursor loads events older
+// than the cursor. EventLimit must be greater than zero. Cursor values are
+// backend-generated opaque tokens and callers must not parse or modify them.
+type TrackEventPageRequest struct {
+	Key        Key    // Key identifies the session that owns the requested track.
+	Track      Track  // Track identifies the persisted track to page.
+	Cursor     string // Cursor is an opaque backend-generated page cursor, or empty for the latest page.
+	EventLimit int    // EventLimit is the maximum number of events to return and must be greater than zero.
+}
+
+// TrackEventPageEntry is one event plus the cursor anchored at that event.
+//
+// Passing Cursor on a later request loads events older than Event.
+type TrackEventPageEntry struct {
+	Event  TrackEvent // Event is the persisted track event for this entry.
+	Cursor string     // Cursor is the opaque cursor anchored at Event.
+}
+
+// TrackEventPage is a chronological page of track events.
+//
+// Entries are ordered oldest to newest. HasMore reports whether older events
+// exist before Entries[0].Cursor.
+type TrackEventPage struct {
+	Track   Track                 // Track identifies the persisted track returned by this page.
+	Entries []TrackEventPageEntry // Entries contains events ordered oldest to newest.
+	HasMore bool                  // HasMore reports whether older events exist before the first entry.
 }
 
 // TracksFromState returns the tracks stored in the session state.


### PR DESCRIPTION
This adds session-layer cursor pagination for persisted track events and wires it into AG-UI messages snapshots through an application-provided resolver. Paginated snapshots return standard MESSAGES_SNAPSHOT events with page metadata in rawEvent.page, trim results to a user-message boundary, fall back to the existing full-snapshot behavior when the session service lacks pagination support, and implement the capability for the supported session backends with documentation for cursor handling and page loading.