### PR TITLE
runner: fix data races on session events and invocation telemetry

### DIFF
--- a/agent/await_user_reply.go
+++ b/agent/await_user_reply.go
@@ -162,7 +162,11 @@ func (r AwaitUserReplyRoute) AttachEvent(evt *event.Event) error {
 	)
 }
 
-func attachAwaitUserReplyRoute(inv *Invocation, evt *event.Event) {
+// attachAwaitUserReplyRoute attaches a pending await-user-reply route to the
+// event. agentName is passed explicitly so callers that captured the name
+// before the invocation could be mutated concurrently can avoid reading
+// inv.AgentName.
+func attachAwaitUserReplyRoute(inv *Invocation, evt *event.Event, agentName string) {
 	if inv == nil || evt == nil || evt.Response == nil {
 		return
 	}
@@ -180,7 +184,7 @@ func attachAwaitUserReplyRoute(inv *Invocation, evt *event.Event) {
 	if err := route.AttachEvent(evt); err != nil {
 		log.Warnf(
 			"attach await_user_reply route failed for agent %q: %v",
-			inv.AgentName,
+			agentName,
 			err,
 		)
 	}

--- a/agent/await_user_reply_test.go
+++ b/agent/await_user_reply_test.go
@@ -384,7 +384,7 @@ func TestAttachAwaitUserReplyRoute_WithoutPendingRoute(t *testing.T) {
 		},
 	)
 
-	attachAwaitUserReplyRoute(inv, evt)
+	attachAwaitUserReplyRoute(inv, evt, inv.AgentName)
 
 	sess := session.NewSession("app", "user", "sess")
 	sess.ApplyEventStateDelta(evt)

--- a/agent/execution_trace.go
+++ b/agent/execution_trace.go
@@ -246,7 +246,36 @@ func BuildExecutionTrace(
 	return capture.Build(status, time.Now())
 }
 
+// BuildExecutionTraceWithAgentName is like BuildExecutionTrace but never reads
+// inv.AgentName, using agentName instead. Callers that captured the agent name
+// before the invocation could be mutated concurrently (for example the runner
+// completion path after cancellation before the first agent event) must use
+// this variant to avoid racing the agent goroutine's asynchronous invocation
+// setup.
+func BuildExecutionTraceWithAgentName(
+	inv *Invocation,
+	status trace.TraceStatus,
+	agentName string,
+) *trace.Trace {
+	if inv == nil {
+		return nil
+	}
+	inv.initializeExecutionTraceWithAgentName(agentName)
+	capture := inv.executionTraceCapture()
+	if capture == nil {
+		return nil
+	}
+	inv.ensureTraceCaptureMetadataWithAgentName(agentName)
+	return capture.Build(status, time.Now())
+}
+
 func (inv *Invocation) initializeExecutionTrace() {
+	inv.initializeExecutionTraceWithAgentName(invocationAgentName(inv))
+}
+
+// initializeExecutionTraceWithAgentName lazily initializes the execution trace
+// capture using the caller-provided agentName without reading inv.AgentName.
+func (inv *Invocation) initializeExecutionTraceWithAgentName(agentName string) {
 	if inv == nil || !inv.RunOptions.ExecutionTraceEnabled {
 		return
 	}
@@ -255,13 +284,13 @@ func (inv *Invocation) initializeExecutionTrace() {
 	if inv.traceCapture != nil {
 		return
 	}
-	inv.ensureTraceNodeIDLocked()
+	inv.ensureTraceNodeIDLockedWithAgentName(agentName)
 	sessionID := ""
 	if inv.Session != nil {
 		sessionID = inv.Session.ID
 	}
 	inv.traceCapture = tracecapture.New(
-		inv.AgentName,
+		agentName,
 		inv.InvocationID,
 		sessionID,
 		time.Now(),
@@ -269,6 +298,12 @@ func (inv *Invocation) initializeExecutionTrace() {
 }
 
 func (inv *Invocation) ensureTraceCaptureMetadata() {
+	inv.ensureTraceCaptureMetadataWithAgentName(invocationAgentName(inv))
+}
+
+// ensureTraceCaptureMetadataWithAgentName refreshes the capture metadata using
+// the caller-provided agentName without reading inv.AgentName.
+func (inv *Invocation) ensureTraceCaptureMetadataWithAgentName(agentName string) {
 	if inv == nil {
 		return
 	}
@@ -278,8 +313,7 @@ func (inv *Invocation) ensureTraceCaptureMetadata() {
 		inv.traceMu.Unlock()
 		return
 	}
-	inv.ensureTraceNodeIDLocked()
-	agentName := inv.AgentName
+	inv.ensureTraceNodeIDLockedWithAgentName(agentName)
 	sessionID := ""
 	if inv.Session != nil {
 		sessionID = inv.Session.ID
@@ -301,10 +335,17 @@ func (inv *Invocation) ensureTraceNodeID() {
 }
 
 func (inv *Invocation) ensureTraceNodeIDLocked() {
-	if inv == nil || inv.traceNodeID != "" || inv.AgentName == "" {
+	inv.ensureTraceNodeIDLockedWithAgentName(invocationAgentName(inv))
+}
+
+// ensureTraceNodeIDLockedWithAgentName derives the trace node id using the
+// caller-provided agentName without reading inv.AgentName. The caller must hold
+// inv.traceMu.
+func (inv *Invocation) ensureTraceNodeIDLockedWithAgentName(agentName string) {
+	if inv == nil || inv.traceNodeID != "" || agentName == "" {
 		return
 	}
-	inv.traceNodeID = escapeTraceLocalName(inv.AgentName)
+	inv.traceNodeID = escapeTraceLocalName(agentName)
 }
 
 func (inv *Invocation) executionTraceCapture() *tracecapture.Capture {

--- a/agent/execution_trace_test.go
+++ b/agent/execution_trace_test.go
@@ -413,3 +413,30 @@ func TestInvocationTeamMemberTraceRoot_LifecycleAndNilGuards(t *testing.T) {
 	ClearInvocationTeamMemberTraceRoot(inv)
 	require.Empty(t, InvocationTeamMemberTraceRoot(inv))
 }
+
+func TestBuildExecutionTraceWithAgentName_NilAndDisabled(t *testing.T) {
+	// Nil invocation returns nil without touching anything.
+	require.Nil(t, BuildExecutionTraceWithAgentName(nil, atrace.TraceStatusCompleted, "agent"))
+
+	// Execution trace disabled returns nil without creating a capture.
+	inv := NewInvocation(
+		WithInvocationAgent(&mockAgent{name: "agent"}),
+		WithInvocationMessage(model.NewUserMessage("hello")),
+	)
+	require.Nil(t, BuildExecutionTraceWithAgentName(inv, atrace.TraceStatusCompleted, "agent"))
+}
+
+func TestBuildExecutionTraceWithAgentName_UsesProvidedName(t *testing.T) {
+	// No agent name is set on the invocation, so the capture is created with an
+	// empty root agent name and the caller-provided name must fill it in.
+	inv := NewInvocation(
+		WithInvocationSession(&session.Session{ID: "session-1"}),
+		WithInvocationRunOptions(RunOptions{ExecutionTraceEnabled: true}),
+		WithInvocationMessage(model.NewUserMessage("hello")),
+	)
+	built := BuildExecutionTraceWithAgentName(inv, atrace.TraceStatusCompleted, "provided-name")
+	require.NotNil(t, built)
+	// The trace root agent name must come from the caller-provided name, not
+	// from the live invocation.
+	require.Equal(t, "provided-name", built.RootAgentName)
+}

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -2071,14 +2071,31 @@ func InjectIntoEvent(inv *Invocation, e *event.Event) {
 // EmitEvent inject invocation information into event and emit it to channel.
 func EmitEvent(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
 	e *event.Event) error {
+	return emitEvent(ctx, inv, ch, e, invocationAgentName(inv))
+}
+
+// EmitEventWithAgentName is like EmitEvent but takes the agent name explicitly
+// instead of reading inv.AgentName. Callers that captured the agent name before
+// the invocation could be mutated concurrently (for example the runner
+// completion path after cancellation before the first agent event) must use
+// this variant to avoid racing the agent goroutine's asynchronous invocation
+// setup.
+func EmitEventWithAgentName(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
+	e *event.Event, agentName string) error {
+	return emitEvent(ctx, inv, ch, e, agentName)
+}
+
+// emitEvent injects invocation information into the event and emits it to the
+// channel using the caller-provided agentName instead of reading inv.AgentName.
+func emitEvent(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
+	e *event.Event, agentName string) error {
 	if ch == nil || e == nil {
 		return nil
 	}
-	attachAwaitUserReplyRoute(inv, e)
+	attachAwaitUserReplyRoute(inv, e, agentName)
 	InjectIntoEvent(inv, e)
-	var agentName, requestID string
+	var requestID string
 	if inv != nil {
-		agentName = inv.AgentName
 		requestID = inv.RunOptions.RequestID
 	}
 	log.Tracef(
@@ -2091,6 +2108,15 @@ func EmitEvent(ctx context.Context, inv *Invocation, ch chan<- *event.Event,
 		agentName,
 	)
 	return event.EmitEvent(ctx, ch, e)
+}
+
+// invocationAgentName returns the invocation's agent name, or an empty string
+// for a nil invocation.
+func invocationAgentName(inv *Invocation) string {
+	if inv == nil {
+		return ""
+	}
+	return inv.AgentName
 }
 
 // GetAppendEventNoticeKey get append event notice key.

--- a/agent/invocation.go
+++ b/agent/invocation.go
@@ -1703,6 +1703,30 @@ func (inv *Invocation) SyncView(view *Invocation) {
 	inv.stateMu.Unlock()
 }
 
+// RefreshViewState copies the view-visible state from src into inv, replacing
+// inv's current state snapshot. Only the state map is updated; identity and
+// structural fields (AgentName, Agent, Session, …) are left unchanged.
+//
+// This is used by the runner to refresh the pre-run completion-plugin snapshot
+// after RunWithPlugins returns: BeforeAgent hooks run synchronously inside
+// RunWithPlugins and may write invocation state (billing markers, audit flags,
+// timing data, etc.). RefreshViewState captures those writes without touching
+// the bare fields that the agent goroutine may already be mutating
+// concurrently.
+//
+// Both src.stateMu (read) and inv.stateMu (write) are held during the copy,
+// so the operation is race-free even when src is the live invocation and a
+// concurrent SetState call is in flight.
+func (inv *Invocation) RefreshViewState(src *Invocation) {
+	if inv == nil || src == nil || inv == src {
+		return
+	}
+	snapshot := src.cloneViewState() // holds src.stateMu.RLock internally
+	inv.stateMu.Lock()
+	inv.state = snapshot
+	inv.stateMu.Unlock()
+}
+
 func (inv *Invocation) cloneState() map[string]any {
 	return inv.cloneStateByFilter(isCloneStateKey, keepStateValue)
 }

--- a/agent/invocation_test.go
+++ b/agent/invocation_test.go
@@ -1673,3 +1673,97 @@ func TestWithUserMessageRewriter(t *testing.T) {
 		model.NewUserMessage("rewritten"),
 	}, msgs)
 }
+
+// TestInvocation_RefreshViewState_Guards verifies that RefreshViewState is a
+// no-op when the receiver or source is nil, or when both point to the same
+// Invocation, and that it never panics or deadlocks in those cases.
+func TestInvocation_RefreshViewState_Guards(t *testing.T) {
+	live := NewInvocation()
+	live.SetState("key", "original")
+
+	// nil receiver must not panic
+	var nilInv *Invocation
+	nilInv.RefreshViewState(live)
+
+	// nil src must not panic; dst state must be unchanged
+	snapshot := live.View()
+	snapshot.RefreshViewState(nil)
+	v, ok := snapshot.GetState("key")
+	require.True(t, ok, "state must be unchanged after nil-src RefreshViewState")
+	require.Equal(t, "original", v)
+
+	// self must not panic or deadlock; state must be unchanged
+	live.RefreshViewState(live)
+	v, ok = live.GetState("key")
+	require.True(t, ok, "state must be unchanged after self RefreshViewState")
+	require.Equal(t, "original", v)
+}
+
+// TestInvocation_RefreshViewState_CopiesStateFromSrc verifies that
+// RefreshViewState replaces the destination's state map with a deep copy of
+// the source's view-visible state, leaving identity fields (AgentName, etc.)
+// untouched.
+func TestInvocation_RefreshViewState_CopiesStateFromSrc(t *testing.T) {
+	src := NewInvocation(WithInvocationAgent(&mockAgent{name: "src-agent"}))
+	src.AgentName = "src-agent"
+	src.SetState("billing", "charged")
+	src.SetState("audit", "logged")
+
+	dst := src.View()
+	// Overwrite dst state to simulate snapshot taken before BeforeAgent ran.
+	dst.stateMu.Lock()
+	dst.state = nil
+	dst.stateMu.Unlock()
+
+	dst.AgentName = "dst-agent" // identity must survive the refresh
+
+	dst.RefreshViewState(src)
+
+	// State from src must be visible in dst.
+	v, ok := dst.GetState("billing")
+	require.True(t, ok)
+	require.Equal(t, "charged", v)
+
+	v, ok = dst.GetState("audit")
+	require.True(t, ok)
+	require.Equal(t, "logged", v)
+
+	// Identity fields must be unchanged.
+	require.Equal(t, "dst-agent", dst.AgentName,
+		"RefreshViewState must not overwrite identity fields")
+
+	// Mutation of dst state must not affect src (deep copy).
+	dst.SetState("billing", "refunded")
+	v, _ = src.GetState("billing")
+	require.Equal(t, "charged", v,
+		"RefreshViewState must produce an independent copy, not a shared reference")
+}
+
+// TestInvocation_RefreshViewState_RaceWithConcurrentSetState checks that
+// RefreshViewState is race-free when the source receives concurrent SetState
+// calls while the copy is in progress.
+func TestInvocation_RefreshViewState_RaceWithConcurrentSetState(t *testing.T) {
+	src := NewInvocation()
+	dst := src.View()
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			src.SetState("counter", i)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			dst.RefreshViewState(src)
+		}
+	}()
+
+	wg.Wait()
+	// No assertion beyond "did not race" — the race detector enforces that.
+}

--- a/runner/diagnostics.go
+++ b/runner/diagnostics.go
@@ -119,13 +119,17 @@ func runnerRunAttrs(
 	}
 }
 
-func runnerInvocationAttrs(inv *agent.Invocation) []attribute.KeyValue {
+// runnerInvocationAttrs builds invocation telemetry attributes. agentName must
+// be the pre-run snapshot captured before agent.Run: agents mutate
+// invocation.AgentName from their own goroutine (setupInvocation), so reading
+// the live field can race the agent after it has started.
+func runnerInvocationAttrs(inv *agent.Invocation, agentName string) []attribute.KeyValue {
 	if inv == nil {
 		return nil
 	}
 	return []attribute.KeyValue{
 		attribute.String("runner.invocation_id", inv.InvocationID),
-		attribute.String("runner.agent", inv.AgentName),
+		attribute.String("runner.agent", agentName),
 		attribute.String("runner.request_id", inv.RunOptions.RequestID),
 	}
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -819,6 +819,18 @@ func (r *runner) Run(
 		invocation.CleanupNotice(execCtx)
 		return nil, err
 	}
+
+	// BeforeAgent ran synchronously inside RunWithPlugins and may have written
+	// invocation state (billing markers, audit flags, timing data, etc.).
+	// Refresh only the state snapshot so those writes are visible to completion
+	// plugin callbacks on the timeout-degraded path (completionPluginsDegraded).
+	//
+	// We deliberately do NOT re-snapshot bare fields (AgentName, Agent, …):
+	// the agent goroutine launched inside ag.Run may already be mutating them
+	// via setupInvocation, and those fields have no lock protection.
+	// AgentName is already correctly set to the pre-run value captured above.
+	completionInvocationView.RefreshViewState(invocation)
+
 	executionTraceInput = resolveExecutionTraceInvocationInputSnapshot(invocation, executionTraceInput)
 
 	// Process the agent events and emit them to the output channel.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -775,11 +775,16 @@ func (r *runner) Run(
 	barrier.Enable(invocation)
 
 	// Run the agent and get the event channel.
+	// Snapshot the invocation telemetry attributes before the agent starts:
+	// agents mutate the invocation from their own goroutine (for example
+	// setupInvocation writes AgentName), so the event loop goroutine must not
+	// read those fields after agent.Run.
+	invocationAttrs := runnerInvocationAttrs(invocation)
 	startCtx, startSpan, startStarted := startRunnerLatencySpan(
 		execCtx,
 		invocation,
 		runnerLatencySpanStartAgent,
-		runnerInvocationAttrs(invocation)...,
+		invocationAttrs...,
 	)
 	agentEventCh, err := agent.RunWithPlugins(startCtx, invocation, ag)
 	finishRunnerLatencySpan(startSpan, startStarted, err)
@@ -803,6 +808,7 @@ func (r *runner) Run(
 		handle,
 		executionTraceInput,
 		globalAfterRun,
+		invocationAttrs,
 	), nil
 }
 
@@ -1324,22 +1330,25 @@ func (r *runner) getOrCreateSession(
 
 // eventLoopContext bundles all channels and state required by the event loop.
 type eventLoopContext struct {
-	sess                               *session.Session
-	invocation                         *agent.Invocation
-	agentEventCh                       <-chan *event.Event
-	flushChan                          chan *flush.FlushRequest
-	processedEventCh                   chan *event.Event
-	runHandle                          *runHandle
-	baselineFinalResponseID            string
-	priorAssistantResponseIDs          map[string]struct{}
-	finalStateDelta                    map[string][]byte
-	finalChoices                       []model.Choice
-	fallbackChoices                    []model.Choice
-	fallbackResponseID                 string
-	fallbackStateDelta                 map[string][]byte
-	finalError                         *model.ResponseError
-	executionTraceInput                *trace.Snapshot
-	globalAfterRun                     *globalAfterRunState
+	sess                      *session.Session
+	invocation                *agent.Invocation
+	agentEventCh              <-chan *event.Event
+	flushChan                 chan *flush.FlushRequest
+	processedEventCh          chan *event.Event
+	runHandle                 *runHandle
+	baselineFinalResponseID   string
+	priorAssistantResponseIDs map[string]struct{}
+	finalStateDelta           map[string][]byte
+	finalChoices              []model.Choice
+	fallbackChoices           []model.Choice
+	fallbackResponseID        string
+	fallbackStateDelta        map[string][]byte
+	finalError                *model.ResponseError
+	executionTraceInput       *trace.Snapshot
+	globalAfterRun            *globalAfterRunState
+	// invocationAttrs is a snapshot of the invocation telemetry attributes
+	// captured before the agent goroutine starts mutating the invocation.
+	invocationAttrs                    []attribute.KeyValue
 	graphCompletionSeen                bool
 	freshAssistantContentProduced      bool
 	persistedAssistantResponseIDs      map[string]struct{}
@@ -1467,6 +1476,7 @@ func (r *runner) processAgentEvents(
 	handle *runHandle,
 	executionTraceInput *trace.Snapshot,
 	globalAfterRun *globalAfterRunState,
+	invocationAttrs []attribute.KeyValue,
 ) chan *event.Event {
 	processedEventCh := make(chan *event.Event, cap(agentEventCh))
 	loop := &eventLoopContext{
@@ -1478,6 +1488,7 @@ func (r *runner) processAgentEvents(
 		runHandle:                 handle,
 		executionTraceInput:       executionTraceInput,
 		globalAfterRun:            globalAfterRun,
+		invocationAttrs:           invocationAttrs,
 		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
 		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
 		streamFilter: graph.NewStreamModeFilter(
@@ -1496,7 +1507,7 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 		ctx,
 		loop.invocation,
 		runnerLatencySpanEventLoop,
-		runnerInvocationAttrs(loop.invocation)...,
+		loop.invocationAttrs...,
 	)
 	defer func() {
 		if started {
@@ -3826,7 +3837,14 @@ func baselineFinalResponseID(sess *session.Session, runtimeState map[string]any)
 }
 
 func collectPriorAssistantResponseIDs(sess *session.Session) map[string]struct{} {
-	if sess == nil || len(sess.Events) == 0 {
+	if sess == nil {
+		return nil
+	}
+	// The agent goroutine appends to sess.Events concurrently during a run,
+	// so reads must hold EventMu like every other Events access.
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	if len(sess.Events) == 0 {
 		return nil
 	}
 	var responseIDs map[string]struct{}
@@ -3863,7 +3881,12 @@ func collectPriorAssistantResponseIDsForLineage(
 	sess *session.Session,
 	lineageKey string,
 ) map[string]struct{} {
-	if sess == nil || len(sess.Events) == 0 {
+	if sess == nil {
+		return nil
+	}
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	if len(sess.Events) == 0 {
 		return nil
 	}
 	var responseIDs map[string]struct{}
@@ -3899,7 +3922,12 @@ func collectPriorAssistantResponseIDsForLineage(
 }
 
 func collectPriorAssistantChoiceSignatures(sess *session.Session) map[string]struct{} {
-	if sess == nil || len(sess.Events) == 0 {
+	if sess == nil {
+		return nil
+	}
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	if len(sess.Events) == 0 {
 		return nil
 	}
 	var signatures map[string]struct{}
@@ -3932,7 +3960,12 @@ func collectPriorAssistantChoiceSignaturesForLineage(
 	sess *session.Session,
 	lineageKey string,
 ) map[string]struct{} {
-	if sess == nil || len(sess.Events) == 0 {
+	if sess == nil {
+		return nil
+	}
+	sess.EventMu.RLock()
+	defer sess.EventMu.RUnlock()
+	if len(sess.Events) == 0 {
 		return nil
 	}
 	var signatures map[string]struct{}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -710,11 +710,17 @@ func (r *runner) Run(
 	queuedUserMessages := steer.NewQueue()
 	steer.Attach(invocation, queuedUserMessages)
 
+	// Capture the agent name before agent.Run: agents mutate
+	// invocation.AgentName from their own goroutine (setupInvocation), so
+	// runner-owned paths that run concurrently with the agent must use this
+	// pre-run snapshot instead of reading the live invocation.
+	agentName := ag.Info().Name
+
 	registerCtx, registerSpan, registerStarted := startRunnerLatencySpan(
 		execCtx,
 		invocation,
 		runnerLatencySpanRegisterRun,
-		runnerInvocationAttrs(invocation)...,
+		runnerInvocationAttrs(invocation, agentName)...,
 	)
 	handle, err := r.registerRun(
 		ro.RequestID,
@@ -779,7 +785,7 @@ func (r *runner) Run(
 	// agents mutate the invocation from their own goroutine (for example
 	// setupInvocation writes AgentName), so the event loop goroutine must not
 	// read those fields after agent.Run.
-	invocationAttrs := runnerInvocationAttrs(invocation)
+	invocationAttrs := runnerInvocationAttrs(invocation, agentName)
 	startCtx, startSpan, startStarted := startRunnerLatencySpan(
 		execCtx,
 		invocation,
@@ -809,6 +815,7 @@ func (r *runner) Run(
 		executionTraceInput,
 		globalAfterRun,
 		invocationAttrs,
+		agentName,
 	), nil
 }
 
@@ -1348,7 +1355,12 @@ type eventLoopContext struct {
 	globalAfterRun            *globalAfterRunState
 	// invocationAttrs is a snapshot of the invocation telemetry attributes
 	// captured before the agent goroutine starts mutating the invocation.
-	invocationAttrs                    []attribute.KeyValue
+	invocationAttrs []attribute.KeyValue
+	// agentName is the agent name captured before agent.Run. The runner
+	// completion path uses it instead of reading invocation.AgentName, which
+	// the agent goroutine mutates asynchronously (setupInvocation), so that
+	// cancellation before the first agent event cannot race that write.
+	agentName                          string
 	graphCompletionSeen                bool
 	freshAssistantContentProduced      bool
 	persistedAssistantResponseIDs      map[string]struct{}
@@ -1477,6 +1489,7 @@ func (r *runner) processAgentEvents(
 	executionTraceInput *trace.Snapshot,
 	globalAfterRun *globalAfterRunState,
 	invocationAttrs []attribute.KeyValue,
+	agentName string,
 ) chan *event.Event {
 	processedEventCh := make(chan *event.Event, cap(agentEventCh))
 	loop := &eventLoopContext{
@@ -1489,6 +1502,7 @@ func (r *runner) processAgentEvents(
 		executionTraceInput:       executionTraceInput,
 		globalAfterRun:            globalAfterRun,
 		invocationAttrs:           invocationAttrs,
+		agentName:                 agentName,
 		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
 		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
 		streamFilter: graph.NewStreamModeFilter(
@@ -3170,9 +3184,10 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 		)
 	}
 	executionTraceStatus := resolveExecutionTraceStatus(loop, ctx.Err())
-	runnerCompletionEvent.ExecutionTrace = agent.BuildExecutionTrace(
+	runnerCompletionEvent.ExecutionTrace = agent.BuildExecutionTraceWithAgentName(
 		loop.invocation,
 		executionTraceStatus,
+		loop.agentName,
 	)
 	if runnerCompletionEvent.ExecutionTrace != nil {
 		traceSnapshotOnly := graph.CompletionSnapshotOnlyFromStateDelta(
@@ -3237,8 +3252,8 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 			time.Second,
 		)
 		defer emitCancel()
-		if err := agent.EmitEvent(
-			emitCtx, loop.invocation, loop.processedEventCh, runnerCompletionEvent,
+		if err := agent.EmitEventWithAgentName(
+			emitCtx, loop.invocation, loop.processedEventCh, runnerCompletionEvent, loop.agentName,
 		); err != nil {
 			log.Errorf("Failed to emit runner completion event: %v", err)
 		}
@@ -3251,7 +3266,7 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 	r.enqueueEvolutionLearningJob(ctx, loop.sess)
 
 	// Enqueue external session ingestion if configured.
-	r.enqueueSessionIngest(ctx, loop.sess, loop.invocation)
+	r.enqueueSessionIngest(ctx, loop.sess, loop.agentName)
 }
 
 func graphCompletionSessionStateDelta(stateDelta map[string][]byte) map[string][]byte {
@@ -4488,12 +4503,12 @@ func (r *runner) enqueueEvolutionLearningJob(ctx context.Context, sess *session.
 func (r *runner) enqueueSessionIngest(
 	ctx context.Context,
 	sess *session.Session,
-	inv *agent.Invocation,
+	agentName string,
 ) {
 	if r.ingestor == nil || sess == nil {
 		return
 	}
-	opts := r.defaultIngestOptions(sess, inv)
+	opts := r.defaultIngestOptions(sess, agentName)
 	if err := r.ingestor.IngestSession(ctx, sess, opts...); err != nil {
 		log.DebugfContext(ctx, "Session ingest skipped or failed: %v", err)
 	}
@@ -4504,17 +4519,17 @@ func (r *runner) enqueueSessionIngest(
 // session ID through as run_id and the active invocation's agent name through
 // as agent_id, giving downstream backends (e.g. mem0) natural grouping keys
 // without requiring callers to construct options manually.
+//
+// agentName must be the pre-run snapshot captured before agent.Run; reading
+// invocation.AgentName here would race the agent goroutine's asynchronous
+// invocation setup when the run is cancelled before the first agent event.
 func (r *runner) defaultIngestOptions(
 	sess *session.Session,
-	inv *agent.Invocation,
+	agentName string,
 ) []session.IngestOption {
 	var opts []session.IngestOption
 	if sess != nil && sess.ID != "" {
 		opts = append(opts, session.WithIngestRunID(sess.ID))
-	}
-	agentName := ""
-	if inv != nil {
-		agentName = inv.AgentName
 	}
 	if agentName == "" {
 		agentName = r.defaultAgentName

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -64,13 +64,15 @@ const (
 	interruptedAssistantFinishReason   = "cancelled"
 	interruptedAssistantExtensionKey   = "trpc_agent.runner.interrupted_assistant"
 	cancelledSessionPersistenceTimeout = time.Second
-
-	// cancelledAgentStreamCloseTimeout bounds how long the event loop waits
-	// for the agent event stream to close before running completion
-	// callbacks after an early cancellation, so agents that ignore
-	// cancellation cannot hang the runner.
-	cancelledAgentStreamCloseTimeout = 5 * time.Second
 )
+
+// cancelledAgentStreamCloseTimeout bounds how long the event loop waits for the
+// agent event stream to close before emitting the completion event after an
+// early cancellation. Agents that do not close their stream within this window
+// get degraded completion callbacks: completion plugins are skipped instead of
+// receiving the live invocation while the agent goroutine may still mutate it.
+// It is a variable so tests can shrink it.
+var cancelledAgentStreamCloseTimeout = 5 * time.Second
 
 var (
 	// ErrRunNotFound indicates that the request ID is not active anymore.
@@ -1366,7 +1368,12 @@ type eventLoopContext struct {
 	// completion path uses it instead of reading invocation.AgentName, which
 	// the agent goroutine mutates asynchronously (setupInvocation), so that
 	// cancellation before the first agent event cannot race that write.
-	agentName                          string
+	agentName string
+	// completionPluginsDegraded is set when the agent event stream did not
+	// close within the drain grace period. The completion path then skips
+	// plugin callbacks rather than handing them the live invocation while
+	// the agent goroutine may still be mutating it.
+	completionPluginsDegraded          bool
 	graphCompletionSeen                bool
 	freshAssistantContentProduced      bool
 	persistedAssistantResponseIDs      map[string]struct{}
@@ -2702,29 +2709,33 @@ func sessionPersistenceContext(ctx context.Context) (context.Context, context.Ca
 	)
 }
 
-// waitForAgentStreamClose drains the agent event stream until it closes when
-// the event loop exits without having processed any agent event. On
-// cancellation before the first event there is no channel happens-before edge
-// with the agent goroutine, so the completion path must not hand the live
-// invocation to plugin callbacks while the agent goroutine may still be
-// writing it (setupInvocation writes Invocation.AgentName). Draining until
-// close establishes that edge. The wait is bounded so agents that ignore
-// cancellation cannot hang the runner.
+// waitForAgentStreamClose drains the agent event stream until it closes before
+// the completion path runs. When the event loop exits with the stream still
+// open there is no channel happens-before edge with the agent goroutine, so
+// completion callbacks must not receive the live invocation while the agent
+// goroutine may still be writing it (setupInvocation writes
+// Invocation.AgentName). Draining until close establishes that edge. The wait
+// is bounded: agents that ignore cancellation degrade the completion plugins
+// instead of hanging the runner or racing.
 func waitForAgentStreamClose(loop *eventLoopContext) {
-	if loop.processedEventCount > 0 {
-		// A processed agent event already established a happens-before edge
-		// with the agent goroutine's setup writes.
-		return
-	}
-	streamClosed := make(chan struct{})
-	go func() {
-		for range loop.agentEventCh {
+	timer := time.NewTimer(cancelledAgentStreamCloseTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case _, ok := <-loop.agentEventCh:
+			if !ok {
+				// The stream is closed, so the agent goroutine finished and
+				// completion callbacks may safely read the invocation.
+				return
+			}
+		case <-timer.C:
+			// The agent ignored cancellation and did not close its stream
+			// within the grace period. Degrade the completion plugin
+			// callbacks instead of handing them the live invocation while
+			// the agent goroutine may still be mutating it.
+			loop.completionPluginsDegraded = true
+			return
 		}
-		close(streamClosed)
-	}()
-	select {
-	case <-streamClosed:
-	case <-time.After(cancelledAgentStreamCloseTimeout):
 	}
 }
 
@@ -3183,9 +3194,16 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 	}
 
 	agent.InjectIntoEvent(loop.invocation, runnerCompletionEvent)
+	// When the agent ignored cancellation and its stream never closed, skip
+	// plugin callbacks rather than handing them the live invocation while
+	// the agent goroutine may still be mutating it.
+	pluginInvocation := loop.invocation
+	if loop.completionPluginsDegraded {
+		pluginInvocation = nil
+	}
 	runnerCompletionEvent = r.applyEventPlugins(
 		ctx,
-		loop.invocation,
+		pluginInvocation,
 		runnerCompletionEvent,
 	)
 
@@ -3244,11 +3262,11 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 			traceSnapshotOnly,
 		)
 	}
-	r.applyAfterRunPlugins(ctx, loop.invocation, runnerCompletionEvent)
+	r.applyAfterRunPlugins(ctx, pluginInvocation, runnerCompletionEvent)
 	applyGlobalAfterRunHooks(
 		ctx,
 		loop.globalAfterRun,
-		loop.invocation,
+		pluginInvocation,
 		runnerCompletionEvent,
 	)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -64,6 +64,12 @@ const (
 	interruptedAssistantFinishReason   = "cancelled"
 	interruptedAssistantExtensionKey   = "trpc_agent.runner.interrupted_assistant"
 	cancelledSessionPersistenceTimeout = time.Second
+
+	// cancelledAgentStreamCloseTimeout bounds how long the event loop waits
+	// for the agent event stream to close before running completion
+	// callbacks after an early cancellation, so agents that ignore
+	// cancellation cannot hang the runner.
+	cancelledAgentStreamCloseTimeout = 5 * time.Second
 )
 
 var (
@@ -1557,6 +1563,13 @@ func (r *runner) runEventLoop(ctx context.Context, loop *eventLoopContext) {
 			log.Errorf(log.PanicPrefix+" panic in runner event loop: %v\n%s", rr, string(debug.Stack()))
 		}
 		// Agent event stream completed.
+		//
+		// On cancellation before the first agent event the event loop has no
+		// channel happens-before edge with the agent goroutine. Drain the
+		// stream until it closes so completion callbacks cannot race the
+		// invocation writes the agent performs at setup (e.g.
+		// Invocation.AgentName in setupInvocation).
+		waitForAgentStreamClose(loop)
 		steer.Close(loop.invocation)
 		r.safePersistInterruptedAssistant(ctx, loop)
 		r.safeEmitRunnerCompletion(ctx, loop)
@@ -2687,6 +2700,32 @@ func sessionPersistenceContext(ctx context.Context) (context.Context, context.Ca
 		context.WithoutCancel(ctx),
 		cancelledSessionPersistenceTimeout,
 	)
+}
+
+// waitForAgentStreamClose drains the agent event stream until it closes when
+// the event loop exits without having processed any agent event. On
+// cancellation before the first event there is no channel happens-before edge
+// with the agent goroutine, so the completion path must not hand the live
+// invocation to plugin callbacks while the agent goroutine may still be
+// writing it (setupInvocation writes Invocation.AgentName). Draining until
+// close establishes that edge. The wait is bounded so agents that ignore
+// cancellation cannot hang the runner.
+func waitForAgentStreamClose(loop *eventLoopContext) {
+	if loop.processedEventCount > 0 {
+		// A processed agent event already established a happens-before edge
+		// with the agent goroutine's setup writes.
+		return
+	}
+	streamClosed := make(chan struct{})
+	go func() {
+		for range loop.agentEventCh {
+		}
+		close(streamClosed)
+	}()
+	select {
+	case <-streamClosed:
+	case <-time.After(cancelledAgentStreamCloseTimeout):
+	}
 }
 
 // safeEmitRunnerCompletion guards emitRunnerCompletion against panics from session services.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -724,6 +724,15 @@ func (r *runner) Run(
 	// pre-run snapshot instead of reading the live invocation.
 	agentName := ag.Info().Name
 
+	// Capture a stable invocation view before agent.Run for completion plugin
+	// callbacks. When the agent ignores cancellation and its stream never
+	// closes, the degraded completion path hands plugins this snapshot instead
+	// of the live invocation, which the agent goroutine may still be mutating.
+	// The view preserves identity and carries the plugin manager captured
+	// before the agent starts.
+	completionInvocationView := invocation.View()
+	completionInvocationView.AgentName = agentName
+
 	registerCtx, registerSpan, registerStarted := startRunnerLatencySpan(
 		execCtx,
 		invocation,
@@ -823,6 +832,7 @@ func (r *runner) Run(
 		executionTraceInput,
 		globalAfterRun,
 		invocationAttrs,
+		completionInvocationView,
 		agentName,
 	), nil
 }
@@ -1370,10 +1380,15 @@ type eventLoopContext struct {
 	// cancellation before the first agent event cannot race that write.
 	agentName string
 	// completionPluginsDegraded is set when the agent event stream did not
-	// close within the drain grace period. The completion path then skips
-	// plugin callbacks rather than handing them the live invocation while
-	// the agent goroutine may still be mutating it.
-	completionPluginsDegraded          bool
+	// close within the drain grace period. The completion path then hands
+	// plugin callbacks the pre-run invocation snapshot instead of the live
+	// invocation, which the agent goroutine may still be mutating.
+	completionPluginsDegraded bool
+	// completionInvocationView is a stable snapshot of the invocation
+	// captured before agent.Run. The degraded completion path passes it to
+	// plugin callbacks so the completion OnEvent and AfterRun hooks still
+	// run with safe, pre-run state.
+	completionInvocationView           *agent.Invocation
 	graphCompletionSeen                bool
 	freshAssistantContentProduced      bool
 	persistedAssistantResponseIDs      map[string]struct{}
@@ -1502,6 +1517,7 @@ func (r *runner) processAgentEvents(
 	executionTraceInput *trace.Snapshot,
 	globalAfterRun *globalAfterRunState,
 	invocationAttrs []attribute.KeyValue,
+	completionInvocationView *agent.Invocation,
 	agentName string,
 ) chan *event.Event {
 	processedEventCh := make(chan *event.Event, cap(agentEventCh))
@@ -1516,6 +1532,7 @@ func (r *runner) processAgentEvents(
 		globalAfterRun:            globalAfterRun,
 		invocationAttrs:           invocationAttrs,
 		agentName:                 agentName,
+		completionInvocationView:  completionInvocationView,
 		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
 		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
 		streamFilter: graph.NewStreamModeFilter(
@@ -2715,8 +2732,8 @@ func sessionPersistenceContext(ctx context.Context) (context.Context, context.Ca
 // completion callbacks must not receive the live invocation while the agent
 // goroutine may still be writing it (setupInvocation writes
 // Invocation.AgentName). Draining until close establishes that edge. The wait
-// is bounded: agents that ignore cancellation degrade the completion plugins
-// instead of hanging the runner or racing.
+// is bounded: agents that ignore cancellation degrade the completion callbacks
+// to the pre-run invocation snapshot instead of hanging the runner or racing.
 func waitForAgentStreamClose(loop *eventLoopContext) {
 	timer := time.NewTimer(cancelledAgentStreamCloseTimeout)
 	defer timer.Stop()
@@ -2730,9 +2747,9 @@ func waitForAgentStreamClose(loop *eventLoopContext) {
 			}
 		case <-timer.C:
 			// The agent ignored cancellation and did not close its stream
-			// within the grace period. Degrade the completion plugin
-			// callbacks instead of handing them the live invocation while
-			// the agent goroutine may still be mutating it.
+			// within the grace period. Mark the completion as degraded so
+			// plugin callbacks receive the pre-run invocation snapshot
+			// instead of racing the agent's setup writes.
 			loop.completionPluginsDegraded = true
 			return
 		}
@@ -3194,12 +3211,14 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 	}
 
 	agent.InjectIntoEvent(loop.invocation, runnerCompletionEvent)
-	// When the agent ignored cancellation and its stream never closed, skip
-	// plugin callbacks rather than handing them the live invocation while
-	// the agent goroutine may still be mutating it.
+	// When the agent ignored cancellation and its stream never closed, hand
+	// plugin callbacks the pre-run invocation snapshot instead of the live
+	// invocation, which the agent goroutine may still be mutating. The
+	// snapshot carries the plugin manager and a stable AgentName, so the
+	// completion OnEvent and AfterRun hooks keep their public contract.
 	pluginInvocation := loop.invocation
 	if loop.completionPluginsDegraded {
-		pluginInvocation = nil
+		pluginInvocation = loop.completionInvocationView
 	}
 	runnerCompletionEvent = r.applyEventPlugins(
 		ctx,

--- a/runner/runner_completion_cancel_test.go
+++ b/runner/runner_completion_cancel_test.go
@@ -11,12 +11,51 @@ package runner
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/chainagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
+
+// cancellationIgnoringAgent ignores cancellation: its event stream is never
+// closed, and it writes Invocation.AgentName late, mimicking setupInvocation of
+// a misbehaving agent. It exercises the drain timeout path of the completion
+// cleanup.
+type cancellationIgnoringAgent struct {
+	name string
+}
+
+func (a *cancellationIgnoringAgent) Info() agent.Info { return agent.Info{Name: a.name} }
+func (a *cancellationIgnoringAgent) SubAgents() []agent.Agent {
+	return nil
+}
+func (a *cancellationIgnoringAgent) FindSubAgent(name string) agent.Agent {
+	return nil
+}
+func (a *cancellationIgnoringAgent) Tools() []tool.Tool { return nil }
+func (a *cancellationIgnoringAgent) Run(
+	ctx context.Context,
+	inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	ch := make(chan *event.Event)
+	// Capture the delay before spawning the goroutine: the test restores the
+	// timeout variable when it finishes, which would race a read inside the
+	// goroutine.
+	delay := cancelledAgentStreamCloseTimeout / 2
+	go func() {
+		// Write the agent name after the runner starts draining, without any
+		// synchronization, so a completion callback reading the live
+		// invocation would race this write under -race.
+		time.Sleep(delay)
+		inv.AgentName = "late-agent"
+	}()
+	return ch, nil
+}
 
 // TestRunnerCompletionCancelledBeforeFirstEventNoRace guards against a data
 // race between the agent goroutine's asynchronous invocation setup (which
@@ -58,5 +97,23 @@ func TestRunnerCompletionCancelledBeforeFirstEventNoRace(t *testing.T) {
 		// an event is emitted, exercising the plugin-interface path of the
 		// pre-first-event cancellation race.
 		runCancelled(t, WithPlugins(debuglog.New(debuglog.WithEventEnabled(true))))
+	})
+	t.Run("agent ignores cancellation", func(t *testing.T) {
+		// Shrink the drain grace period so the timeout path is exercised.
+		oldTimeout := cancelledAgentStreamCloseTimeout
+		cancelledAgentStreamCloseTimeout = 50 * time.Millisecond
+		defer func() { cancelledAgentStreamCloseTimeout = oldTimeout }()
+
+		ag := &cancellationIgnoringAgent{name: "ignore-cancel"}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		r := NewRunner("app", ag, WithPlugins(debuglog.New(debuglog.WithEventEnabled(true))))
+		ch, err := r.Run(ctx, "user", "session", model.NewUserMessage("hi"))
+		require.NoError(t, err)
+		events := 0
+		for range ch {
+			events++
+		}
+		require.NotZero(t, events, "runner completion must still be emitted when the agent never closes its stream")
 	})
 }

--- a/runner/runner_completion_cancel_test.go
+++ b/runner/runner_completion_cancel_test.go
@@ -1,9 +1,18 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
 package runner
 
 import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent/chainagent"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 )
@@ -18,6 +27,7 @@ import (
 // agent.EmitEvent's read of inv.AgentName.
 func TestRunnerCompletionCancelledBeforeFirstEventNoRace(t *testing.T) {
 	ag := chainagent.New("chain")
+	successful := 0
 	for i := 0; i < 100; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -26,7 +36,11 @@ func TestRunnerCompletionCancelledBeforeFirstEventNoRace(t *testing.T) {
 		if err != nil {
 			continue
 		}
+		successful++
 		for range ch {
 		}
 	}
+	// Require at least one run to reach the event loop so the completion
+	// cleanup path is actually exercised.
+	require.NotZero(t, successful)
 }

--- a/runner/runner_completion_cancel_test.go
+++ b/runner/runner_completion_cancel_test.go
@@ -178,3 +178,91 @@ func TestRunnerCompletionTimeoutPathRunsAfterRunPlugins(t *testing.T) {
 	require.Equal(t, "ignore-cancel", counter.invocationAgentName(),
 		"AfterRun hook must receive the stable pre-run agent name")
 }
+
+// stateWritingPlugin writes a marker into the invocation state during
+// BeforeAgent so the AfterRun hook can assert the state is visible on the
+// timeout-degraded completion path.
+type stateWritingPlugin struct {
+	stateKey   string
+	stateValue string
+
+	mu            sync.Mutex
+	afterRunSaw   string // value observed in AfterRun
+	afterRunCalls int
+}
+
+func (p *stateWritingPlugin) Name() string { return "state-writer" }
+
+func (p *stateWritingPlugin) Register(r *plugin.Registry) {
+	key := p.stateKey
+	value := p.stateValue
+
+	r.BeforeAgent(func(_ context.Context, args *agent.BeforeAgentArgs) (*agent.BeforeAgentResult, error) {
+		if args.Invocation != nil {
+			args.Invocation.SetState(key, value)
+		}
+		return nil, nil
+	})
+
+	r.AfterRun(func(_ context.Context, args *plugin.AfterRunArgs) error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.afterRunCalls++
+		if args.Invocation != nil {
+			if v, ok := args.Invocation.GetState(key); ok {
+				if s, ok2 := v.(string); ok2 {
+					p.afterRunSaw = s
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func (p *stateWritingPlugin) observedValue() (string, int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.afterRunSaw, p.afterRunCalls
+}
+
+// TestRunnerTimeoutPathAfterRunSeesBeforeAgentState is the P2 regression test.
+//
+// It guards against the completion-plugin snapshot being captured before
+// RunWithPlugins executes BeforeAgent: on the timeout-degraded path the
+// snapshot passed to AfterRun must reflect state written by BeforeAgent hooks
+// (billing markers, audit flags, etc.) so plugins see a consistent view of
+// the run.
+//
+// The test registers a plugin that writes an invocation state key in
+// BeforeAgent and then reads it back in AfterRun on the timeout path.
+func TestRunnerTimeoutPathAfterRunSeesBeforeAgentState(t *testing.T) {
+	oldTimeout := cancelledAgentStreamCloseTimeout
+	cancelledAgentStreamCloseTimeout = 50 * time.Millisecond
+	defer func() { cancelledAgentStreamCloseTimeout = oldTimeout }()
+
+	const (
+		stateKey   = "billing_marker"
+		stateValue = "charged"
+	)
+
+	plug := &stateWritingPlugin{stateKey: stateKey, stateValue: stateValue}
+	ag := &cancellationIgnoringAgent{name: "ignore-cancel"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := NewRunner("app", ag, WithPlugins(plug))
+	ch, err := r.Run(ctx, "user", "session", model.NewUserMessage("hi"))
+	require.NoError(t, err)
+	for range ch {
+	}
+
+	got, calls := plug.observedValue()
+	require.Equal(t, 1, calls,
+		"AfterRun hook must be called exactly once on the timeout path")
+	require.Equal(t, stateValue, got,
+		"AfterRun hook must see the invocation state written by BeforeAgent "+
+			"(got %q, want %q); snapshot was likely captured before BeforeAgent ran",
+		got, stateValue,
+	)
+}

--- a/runner/runner_completion_cancel_test.go
+++ b/runner/runner_completion_cancel_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent/chainagent"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
 )
 
 // TestRunnerCompletionCancelledBeforeFirstEventNoRace guards against a data
@@ -24,23 +25,38 @@ import (
 // runEventLoop returns via ctx.Done() with no channel happens-before edge
 // against the agent goroutine, so the cleanup must not read the live
 // invocation. Run with -race; the previous implementation raced inside
-// agent.EmitEvent's read of inv.AgentName.
+// agent.EmitEvent's read of inv.AgentName, and a second window remained
+// reachable through plugin callbacks (the built-in debug-log event hook reads
+// Invocation.AgentName when an event is emitted).
 func TestRunnerCompletionCancelledBeforeFirstEventNoRace(t *testing.T) {
-	ag := chainagent.New("chain")
-	successful := 0
-	for i := 0; i < 100; i++ {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		r := NewRunner("app", ag)
-		ch, err := r.Run(ctx, "user", "session", model.NewUserMessage("hi"))
-		if err != nil {
-			continue
+	runCancelled := func(t *testing.T, opts ...Option) {
+		t.Helper()
+		ag := chainagent.New("chain")
+		successful := 0
+		for i := 0; i < 100; i++ {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			r := NewRunner("app", ag, opts...)
+			ch, err := r.Run(ctx, "user", "session", model.NewUserMessage("hi"))
+			if err != nil {
+				continue
+			}
+			successful++
+			for range ch {
+			}
 		}
-		successful++
-		for range ch {
-		}
+		// Require at least one run to reach the event loop so the completion
+		// cleanup path is actually exercised.
+		require.NotZero(t, successful)
 	}
-	// Require at least one run to reach the event loop so the completion
-	// cleanup path is actually exercised.
-	require.NotZero(t, successful)
+
+	t.Run("default plugins", func(t *testing.T) {
+		runCancelled(t)
+	})
+	t.Run("debuglog event hook", func(t *testing.T) {
+		// The built-in debug-log event hook reads Invocation.AgentName when
+		// an event is emitted, exercising the plugin-interface path of the
+		// pre-first-event cancellation race.
+		runCancelled(t, WithPlugins(debuglog.New(debuglog.WithEventEnabled(true))))
+	})
 }

--- a/runner/runner_completion_cancel_test.go
+++ b/runner/runner_completion_cancel_test.go
@@ -10,6 +10,7 @@ package runner
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/chainagent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
 	"trpc.group/trpc-go/trpc-agent-go/plugin/debuglog"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
@@ -55,6 +57,41 @@ func (a *cancellationIgnoringAgent) Run(
 		inv.AgentName = "late-agent"
 	}()
 	return ch, nil
+}
+
+// afterRunCountingPlugin registers only an AfterRun hook and records each
+// invocation so tests can assert the completion plugin lifecycle still runs
+// on the degraded timeout path.
+type afterRunCountingPlugin struct {
+	mu      sync.Mutex
+	calls   int
+	invName string
+}
+
+func (p *afterRunCountingPlugin) Name() string { return "after-run-counter" }
+
+func (p *afterRunCountingPlugin) Register(r *plugin.Registry) {
+	r.AfterRun(func(ctx context.Context, args *plugin.AfterRunArgs) error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.calls++
+		if args.Invocation != nil {
+			p.invName = args.Invocation.AgentName
+		}
+		return nil
+	})
+}
+
+func (p *afterRunCountingPlugin) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func (p *afterRunCountingPlugin) invocationAgentName() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.invName
 }
 
 // TestRunnerCompletionCancelledBeforeFirstEventNoRace guards against a data
@@ -116,4 +153,28 @@ func TestRunnerCompletionCancelledBeforeFirstEventNoRace(t *testing.T) {
 		}
 		require.NotZero(t, events, "runner completion must still be emitted when the agent never closes its stream")
 	})
+}
+
+// TestRunnerCompletionTimeoutPathRunsAfterRunPlugins guards the completion
+// plugin lifecycle on the drain-timeout path: when an agent ignores
+// cancellation and never closes its stream, completion callbacks must still
+// run with the pre-run invocation snapshot instead of being silently skipped.
+func TestRunnerCompletionTimeoutPathRunsAfterRunPlugins(t *testing.T) {
+	oldTimeout := cancelledAgentStreamCloseTimeout
+	cancelledAgentStreamCloseTimeout = 50 * time.Millisecond
+	defer func() { cancelledAgentStreamCloseTimeout = oldTimeout }()
+
+	counter := &afterRunCountingPlugin{}
+	ag := &cancellationIgnoringAgent{name: "ignore-cancel"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := NewRunner("app", ag, WithPlugins(counter))
+	ch, err := r.Run(ctx, "user", "session", model.NewUserMessage("hi"))
+	require.NoError(t, err)
+	for range ch {
+	}
+	require.Equal(t, 1, counter.callCount(),
+		"AfterRun hook must run on the timeout path")
+	require.Equal(t, "ignore-cancel", counter.invocationAgentName(),
+		"AfterRun hook must receive the stable pre-run agent name")
 }

--- a/runner/runner_completion_cancel_test.go
+++ b/runner/runner_completion_cancel_test.go
@@ -1,0 +1,32 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent/chainagent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// TestRunnerCompletionCancelledBeforeFirstEventNoRace guards against a data
+// race between the agent goroutine's asynchronous invocation setup (which
+// writes Invocation.AgentName via setupInvocation) and the runner completion
+// cleanup. When the context is cancelled before the first agent event arrives,
+// runEventLoop returns via ctx.Done() with no channel happens-before edge
+// against the agent goroutine, so the cleanup must not read the live
+// invocation. Run with -race; the previous implementation raced inside
+// agent.EmitEvent's read of inv.AgentName.
+func TestRunnerCompletionCancelledBeforeFirstEventNoRace(t *testing.T) {
+	ag := chainagent.New("chain")
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		r := NewRunner("app", ag)
+		ch, err := r.Run(ctx, "user", "session", model.NewUserMessage("hi"))
+		if err != nil {
+			continue
+		}
+		for range ch {
+		}
+	}
+}

--- a/runner/runner_memory_test.go
+++ b/runner/runner_memory_test.go
@@ -286,11 +286,11 @@ func TestRunner_DefaultIngestOptions_PrefersInvocationAgent(t *testing.T) {
 	r := &runner{defaultAgentName: "fallback-agent"}
 	sess := session.NewSession("app", "user", "sess-id")
 
-	withInv := resolveIngestOpts(r.defaultIngestOptions(sess, &agent.Invocation{AgentName: "live-agent"})...)
+	withInv := resolveIngestOpts(r.defaultIngestOptions(sess, "live-agent")...)
 	require.Equal(t, "sess-id", withInv.RunID)
 	require.Equal(t, "live-agent", withInv.AgentID)
 
-	withoutInv := resolveIngestOpts(r.defaultIngestOptions(sess, nil)...)
+	withoutInv := resolveIngestOpts(r.defaultIngestOptions(sess, "")...)
 	require.Equal(t, "sess-id", withoutInv.RunID)
 	require.Equal(t, "fallback-agent", withoutInv.AgentID)
 }

--- a/runner/runner_persistence_dedupe_test.go
+++ b/runner/runner_persistence_dedupe_test.go
@@ -37,8 +37,8 @@ func TestRunnerDeduplicatesEventPersistence(t *testing.T) {
 
 	require.NoError(t, r.processSingleAgentEvent(context.Background(), loop, evt))
 	require.NoError(t, r.processSingleAgentEvent(context.Background(), loop, evt))
-	require.Len(t, service.appendEventCalls, 1)
-	require.Len(t, service.enqueueSummaryJobCalls, 1)
+	require.Len(t, service.appendEventCallsSnapshot(), 1)
+	require.Len(t, service.enqueueSummaryJobCallsSnapshot(), 1)
 }
 
 func TestRunnerDoesNotDeduplicateAcrossEventLoops(t *testing.T) {
@@ -62,8 +62,8 @@ func TestRunnerDoesNotDeduplicateAcrossEventLoops(t *testing.T) {
 		evt,
 		&eventPersistenceDeduper{},
 	))
-	require.Len(t, service.appendEventCalls, 2)
-	require.Len(t, service.enqueueSummaryJobCalls, 2)
+	require.Len(t, service.appendEventCallsSnapshot(), 2)
+	require.Len(t, service.enqueueSummaryJobCallsSnapshot(), 2)
 }
 
 func TestRunnerReleasesCompletedEventPersistenceRecord(t *testing.T) {
@@ -206,8 +206,8 @@ func TestRunnerDoesNotDeduplicateEmptyEventID(t *testing.T) {
 	require.True(t, r.handleEventPersistenceOnce(
 		context.Background(), invocation, sess, sess, evt, deduper,
 	))
-	require.Len(t, service.appendEventCalls, 2)
-	require.Len(t, service.enqueueSummaryJobCalls, 2)
+	require.Len(t, service.appendEventCallsSnapshot(), 2)
+	require.Len(t, service.enqueueSummaryJobCallsSnapshot(), 2)
 }
 
 func newPersistenceDedupTestInput() (

--- a/runner/runner_summary_test.go
+++ b/runner/runner_summary_test.go
@@ -11,6 +11,7 @@ package runner
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,8 +60,8 @@ func TestRunnerEnqueuesModelVisibleSummaryView(t *testing.T) {
 		sess,
 		evt,
 	))
-	require.Len(t, service.enqueueSummaryJobCalls, 1)
-	view, ok := summaryview.FromContext(service.enqueueSummaryJobCalls[0].ctx)
+	require.Len(t, service.enqueueSummaryJobCallsSnapshot(), 1)
+	view, ok := summaryview.FromContext(service.enqueueSummaryJobCallsSnapshot()[0].ctx)
 	require.True(t, ok)
 	require.Equal(t, 13_310, view.RequestTokens)
 }
@@ -88,8 +89,8 @@ func TestRunnerPersistsErrorEventWithoutEnqueuingSummary(t *testing.T) {
 		sess,
 		errorEvent,
 	))
-	require.Len(t, service.appendEventCalls, 1)
-	require.Empty(t, service.enqueueSummaryJobCalls)
+	require.Len(t, service.appendEventCallsSnapshot(), 1)
+	require.Empty(t, service.enqueueSummaryJobCallsSnapshot())
 }
 
 func TestRunner_EnqueueSummaryJob_Calls(t *testing.T) {
@@ -117,10 +118,10 @@ func TestRunner_EnqueueSummaryJob_Calls(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify EnqueueSummaryJob was called once; worker cascades full-session internally.
-		require.Len(t, mockSessionService.enqueueSummaryJobCalls, 1, "Should call EnqueueSummaryJob once")
+		require.Len(t, mockSessionService.enqueueSummaryJobCallsSnapshot(), 1, "Should call EnqueueSummaryJob once")
 
 		// Check the only call
-		onlyCall := mockSessionService.enqueueSummaryJobCalls[0]
+		onlyCall := mockSessionService.enqueueSummaryJobCallsSnapshot()[0]
 		assert.Equal(t, "", onlyCall.filterKey, "Call should use default empty FilterKey from mock agent")
 		assert.False(t, onlyCall.force, "Call should not force")
 		assert.NotNil(t, onlyCall.sess, "Call should have session")
@@ -150,7 +151,7 @@ func TestRunner_EnqueueSummaryJob_Calls(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify EnqueueSummaryJob was not called
-		assert.Len(t, mockSessionService.enqueueSummaryJobCalls, 0, "Should not call EnqueueSummaryJob for non-qualifying events")
+		assert.Len(t, mockSessionService.enqueueSummaryJobCallsSnapshot(), 0, "Should not call EnqueueSummaryJob for non-qualifying events")
 	})
 
 	t.Run("does not call EnqueueSummaryJob for events with state delta only", func(t *testing.T) {
@@ -178,7 +179,7 @@ func TestRunner_EnqueueSummaryJob_Calls(t *testing.T) {
 
 		// Verify EnqueueSummaryJob was NOT called for state delta only events
 		// because the new logic only triggers summary for assistant responses
-		require.Len(t, mockSessionService.enqueueSummaryJobCalls, 0, "Should not call EnqueueSummaryJob for state delta only events")
+		require.Len(t, mockSessionService.enqueueSummaryJobCallsSnapshot(), 0, "Should not call EnqueueSummaryJob for state delta only events")
 	})
 
 	t.Run("handles EnqueueSummaryJob errors gracefully", func(t *testing.T) {
@@ -207,7 +208,7 @@ func TestRunner_EnqueueSummaryJob_Calls(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Verify EnqueueSummaryJob was still called once despite error
-		assert.Len(t, errorSessionService.enqueueSummaryJobCalls, 1, "Should still call EnqueueSummaryJob once even when it returns error")
+		assert.Len(t, errorSessionService.enqueueSummaryJobCallsSnapshot(), 1, "Should still call EnqueueSummaryJob once even when it returns error")
 	})
 }
 
@@ -384,7 +385,7 @@ func TestRunner_PerToolCallResultEventsFailedIntermediatePersistenceUsesStandalo
 	for range events {
 	}
 
-	require.Len(t, capture.enqueueSummaryJobCalls, 1)
+	require.Len(t, capture.enqueueSummaryJobCallsSnapshot(), 1)
 	require.False(t, capture.capturedOK)
 	require.Nil(t, capture.capturedParent)
 }
@@ -796,11 +797,28 @@ func (m *cacheSafeForkToolResultMockAgent) Run(
 }
 
 // mockSessionService implements the session.Service interface for testing EnqueueSummaryJob calls.
+// The runner persists events on background goroutines, so all recorded-call
+// fields are guarded by mu and must be read through the snapshot accessors.
 type mockSessionService struct {
+	mu                     sync.Mutex
 	enqueueSummaryJobCalls []enqueueSummaryJobCall
 	appendEventCalls       []appendEventCall
 	createSessionCalls     []createSessionCall
 	getSessionCalls        []getSessionCall
+}
+
+// enqueueSummaryJobCallsSnapshot returns a copy of the recorded EnqueueSummaryJob calls.
+func (m *mockSessionService) enqueueSummaryJobCallsSnapshot() []enqueueSummaryJobCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]enqueueSummaryJobCall(nil), m.enqueueSummaryJobCalls...)
+}
+
+// appendEventCallsSnapshot returns a copy of the recorded AppendEvent calls.
+func (m *mockSessionService) appendEventCallsSnapshot() []appendEventCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]appendEventCall(nil), m.appendEventCalls...)
 }
 
 type enqueueSummaryJobCall struct {
@@ -894,6 +912,8 @@ func (m *mockSessionService) UpdateSessionState(ctx context.Context, key session
 }
 
 func (m *mockSessionService) AppendEvent(ctx context.Context, session *session.Session, event *event.Event, options ...session.Option) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.appendEventCalls = append(m.appendEventCalls, appendEventCall{session, event, options})
 	return nil
 }
@@ -903,6 +923,8 @@ func (m *mockSessionService) CreateSessionSummary(ctx context.Context, sess *ses
 }
 
 func (m *mockSessionService) EnqueueSummaryJob(ctx context.Context, sess *session.Session, filterKey string, force bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.enqueueSummaryJobCalls = append(m.enqueueSummaryJobCalls, enqueueSummaryJobCall{
 		ctx:       ctx,
 		sess:      sess,
@@ -1209,7 +1231,7 @@ func TestRunner_SyncSummaryIntraRun_SkipsIntermediateButAllowsFinal(
 	// turn end.
 	require.Len(
 		t,
-		svc.enqueueSummaryJobCalls,
+		svc.enqueueSummaryJobCallsSnapshot(),
 		1,
 		"final response should trigger EnqueueSummaryJob "+
 			"even with sync intra-run summary active",
@@ -1242,7 +1264,7 @@ func TestRunner_EnqueueSummaryJob_ToolResultTrigger(t *testing.T) {
 			// skipped.
 			require.Len(
 				t,
-				svc.enqueueSummaryJobCalls,
+				svc.enqueueSummaryJobCallsSnapshot(),
 				2,
 				"tool result + final text should each "+
 					"trigger EnqueueSummaryJob",
@@ -1274,7 +1296,7 @@ func TestRunner_EnqueueSummaryJob_ToolResultTrigger(t *testing.T) {
 
 			assert.Len(
 				t,
-				svc.enqueueSummaryJobCalls,
+				svc.enqueueSummaryJobCallsSnapshot(),
 				0,
 				"SkipSummarization should prevent "+
 					"EnqueueSummaryJob",

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -5310,10 +5310,10 @@ func TestRunnerLatencyDiagnosticHelpers(t *testing.T) {
 	require.True(t, runnerHasAttr(runAttrs, "runner.message.has_payload", true))
 	require.True(t, runnerHasAttr(runAttrs, "runner.options.seed_messages", 1))
 
-	invAttrs := runnerInvocationAttrs(inv)
+	invAttrs := runnerInvocationAttrs(inv, "a")
 	require.True(t, runnerHasAttr(invAttrs, "runner.agent", "a"))
 	require.True(t, runnerHasAttr(invAttrs, "runner.request_id", "req-latency"))
-	require.Nil(t, runnerInvocationAttrs(nil))
+	require.Nil(t, runnerInvocationAttrs(nil, ""))
 
 	sess := session.NewSession("app", "user", "sess")
 	sess.SetState("state-key", []byte("value"))
@@ -9788,7 +9788,7 @@ func TestProcessAgentEvents_EmitEventErrorBranch_Direct(t *testing.T) {
 
 	agentCh := make(chan *event.Event)
 	flushCh := make(chan *flush.FlushRequest)
-	processed := rr.processAgentEvents(ctx, sess, inv, agentCh, flushCh, nil, nil, nil, runnerInvocationAttrs(inv))
+	processed := rr.processAgentEvents(ctx, sess, inv, agentCh, flushCh, nil, nil, nil, runnerInvocationAttrs(inv, "a"), "a")
 	// Send one event, then close agentCh
 	go func() {
 		agentCh <- &event.Event{Response: &model.Response{Done: true, Choices: []model.Choice{{Index: 0, Message: model.NewAssistantMessage("x")}}}}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -9788,7 +9788,7 @@ func TestProcessAgentEvents_EmitEventErrorBranch_Direct(t *testing.T) {
 
 	agentCh := make(chan *event.Event)
 	flushCh := make(chan *flush.FlushRequest)
-	processed := rr.processAgentEvents(ctx, sess, inv, agentCh, flushCh, nil, nil, nil, runnerInvocationAttrs(inv, "a"), "a")
+	processed := rr.processAgentEvents(ctx, sess, inv, agentCh, flushCh, nil, nil, nil, runnerInvocationAttrs(inv, "a"), inv.View(), "a")
 	// Send one event, then close agentCh
 	go func() {
 		agentCh <- &event.Event{Response: &model.Response{Done: true, Choices: []model.Choice{{Index: 0, Message: model.NewAssistantMessage("x")}}}}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -4888,7 +4888,7 @@ func (s *panicAppendSessionService) AppendEvent(ctx context.Context, sess *sessi
 type appendErrorSessionService struct{ *mockSessionService }
 
 func (s *appendErrorSessionService) AppendEvent(ctx context.Context, sess *session.Session, e *event.Event, _ ...session.Option) error {
-	s.mockSessionService.appendEventCalls = append(s.mockSessionService.appendEventCalls, appendEventCall{sess, e, nil})
+	s.mockSessionService.AppendEvent(ctx, sess, e)
 	return errors.New("append error")
 }
 
@@ -5441,7 +5441,7 @@ func TestHandleEventPersistence_AppendErrorSkipsSummarize(t *testing.T) {
 	for range ch {
 	}
 	// Append failed -> EnqueueSummaryJob should not be called.
-	require.Len(t, base.enqueueSummaryJobCalls, 0)
+	require.Len(t, base.enqueueSummaryJobCallsSnapshot(), 0)
 }
 
 func TestEmitRunnerCompletion_AppendErrorStillEmits(t *testing.T) {
@@ -8132,9 +8132,9 @@ func TestRunner_RoutedSessionPersistsInterruptedPartialAssistant(t *testing.T) {
 		getInterruptedAssistantAccumulator(loop, routedSess),
 	))
 	rr.persistInterruptedAssistant(cancelled, loop)
-	require.Len(t, svc.appendEventCalls, 1)
-	require.Same(t, routedSess, svc.appendEventCalls[0].sess)
-	require.Equal(t, "member text", svc.appendEventCalls[0].event.Choices[0].Message.Content)
+	require.Len(t, svc.appendEventCallsSnapshot(), 1)
+	require.Same(t, routedSess, svc.appendEventCallsSnapshot()[0].sess)
+	require.Equal(t, "member text", svc.appendEventCallsSnapshot()[0].event.Choices[0].Message.Content)
 }
 
 func TestRunner_InterruptedAssistantPreservesSourceEventIdentity(t *testing.T) {
@@ -8677,9 +8677,9 @@ func TestInterruptedAssistantDeltaSeparatesSameResponseIDByLineage(t *testing.T)
 	cancel()
 	rr.persistInterruptedAssistant(cancelled, loop)
 
-	require.Len(t, svc.appendEventCalls, 2)
+	require.Len(t, svc.appendEventCallsSnapshot(), 2)
 	persisted := map[string]string{}
-	for _, call := range svc.appendEventCalls {
+	for _, call := range svc.appendEventCallsSnapshot() {
 		require.Equal(t, "shared-response", call.event.Response.ID)
 		require.Equal(t, "shared-invocation", call.event.InvocationID)
 		persisted[call.event.Branch] = call.event.Choices[0].Message.Content
@@ -8742,9 +8742,9 @@ func TestPersistInterruptedAssistantPersistsInterleavedBuffers(t *testing.T) {
 	cancel()
 	rr.persistInterruptedAssistant(cancelled, loop)
 
-	require.Len(t, svc.appendEventCalls, 2)
+	require.Len(t, svc.appendEventCallsSnapshot(), 2)
 	persisted := map[string]string{}
-	for _, call := range svc.appendEventCalls {
+	for _, call := range svc.appendEventCallsSnapshot() {
 		require.Same(t, sess, call.sess)
 		require.Len(t, call.event.Choices, 1)
 		persisted[call.event.Response.ID] = call.event.Choices[0].Message.Content
@@ -8807,11 +8807,11 @@ func TestPersistInterruptedAssistantPreservesFirstSeenOrder(t *testing.T) {
 	cancel()
 	rr.persistInterruptedAssistant(cancelled, loop)
 
-	require.Len(t, svc.appendEventCalls, 2)
-	require.Equal(t, "z-response", svc.appendEventCalls[0].event.Response.ID)
-	require.Equal(t, "first", svc.appendEventCalls[0].event.Choices[0].Message.Content)
-	require.Equal(t, "a-response", svc.appendEventCalls[1].event.Response.ID)
-	require.Equal(t, "second", svc.appendEventCalls[1].event.Choices[0].Message.Content)
+	require.Len(t, svc.appendEventCallsSnapshot(), 2)
+	require.Equal(t, "z-response", svc.appendEventCallsSnapshot()[0].event.Response.ID)
+	require.Equal(t, "first", svc.appendEventCallsSnapshot()[0].event.Choices[0].Message.Content)
+	require.Equal(t, "a-response", svc.appendEventCallsSnapshot()[1].event.Response.ID)
+	require.Equal(t, "second", svc.appendEventCallsSnapshot()[1].event.Choices[0].Message.Content)
 }
 
 func TestPersistInterruptedAssistantDedupeAfterEventPlugin(t *testing.T) {
@@ -8867,14 +8867,14 @@ func TestPersistInterruptedAssistantDedupeAfterEventPlugin(t *testing.T) {
 	)
 	final.RequestID = requestID
 	require.NoError(t, rr.processSingleAgentEvent(context.Background(), loop, final))
-	require.Len(t, svc.appendEventCalls, 1)
-	require.Equal(t, "hello!", svc.appendEventCalls[0].event.Choices[0].Message.Content)
+	require.Len(t, svc.appendEventCallsSnapshot(), 1)
+	require.Equal(t, "hello!", svc.appendEventCallsSnapshot()[0].event.Choices[0].Message.Content)
 
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
 	rr.persistInterruptedAssistant(cancelled, loop)
 
-	require.Len(t, svc.appendEventCalls, 1)
+	require.Len(t, svc.appendEventCallsSnapshot(), 1)
 }
 
 func TestPersistInterruptedAssistantEnqueuesSummary(t *testing.T) {
@@ -8913,11 +8913,11 @@ func TestPersistInterruptedAssistantEnqueuesSummary(t *testing.T) {
 	cancel()
 	rr.persistInterruptedAssistant(cancelled, loop)
 
-	require.Len(t, svc.appendEventCalls, 1)
-	require.Len(t, svc.enqueueSummaryJobCalls, 1)
-	require.Same(t, sess, svc.enqueueSummaryJobCalls[0].sess)
-	require.Equal(t, "summary/filter", svc.enqueueSummaryJobCalls[0].filterKey)
-	require.False(t, svc.enqueueSummaryJobCalls[0].force)
+	require.Len(t, svc.appendEventCallsSnapshot(), 1)
+	require.Len(t, svc.enqueueSummaryJobCallsSnapshot(), 1)
+	require.Same(t, sess, svc.enqueueSummaryJobCallsSnapshot()[0].sess)
+	require.Equal(t, "summary/filter", svc.enqueueSummaryJobCallsSnapshot()[0].filterKey)
+	require.False(t, svc.enqueueSummaryJobCallsSnapshot()[0].force)
 }
 
 func TestInterruptedAssistantDeltaGeneratesFallbackResponseID(t *testing.T) {
@@ -9418,7 +9418,7 @@ func TestPersistInterruptedAssistantSkipTargetsAndTieBreaker(t *testing.T) {
 			"no-session": {sequence: 1, choiceContent: builderMap("no session")},
 		},
 	})
-	require.Empty(t, emptySvc.appendEventCalls)
+	require.Empty(t, emptySvc.appendEventCallsSnapshot())
 
 	svc := &mockSessionService{}
 	rr = &runner{sessionService: svc}
@@ -9431,10 +9431,10 @@ func TestPersistInterruptedAssistantSkipTargetsAndTieBreaker(t *testing.T) {
 			"a": {sequence: 1, choiceContent: builderMap("first")},
 		},
 	})
-	require.Len(t, svc.appendEventCalls, 2)
-	require.Same(t, sess, svc.appendEventCalls[0].sess)
-	require.Equal(t, "first", svc.appendEventCalls[0].event.Choices[0].Message.Content)
-	require.Equal(t, "second", svc.appendEventCalls[1].event.Choices[0].Message.Content)
+	require.Len(t, svc.appendEventCallsSnapshot(), 2)
+	require.Same(t, sess, svc.appendEventCallsSnapshot()[0].sess)
+	require.Equal(t, "first", svc.appendEventCallsSnapshot()[0].event.Choices[0].Message.Content)
+	require.Equal(t, "second", svc.appendEventCallsSnapshot()[1].event.Choices[0].Message.Content)
 }
 
 func TestCollectPriorAssistantChoiceSignaturesSkipsAndCollects(t *testing.T) {
@@ -9683,7 +9683,7 @@ func TestPersistInterruptedAssistantGuardBranches(t *testing.T) {
 		},
 	), nil)
 	appendErrRunner.persistInterruptedAssistant(cancelled, loop)
-	require.Len(t, base.appendEventCalls, 1)
+	require.Len(t, base.appendEventCallsSnapshot(), 1)
 }
 
 func TestContextDoneReason(t *testing.T) {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -9788,16 +9788,7 @@ func TestProcessAgentEvents_EmitEventErrorBranch_Direct(t *testing.T) {
 
 	agentCh := make(chan *event.Event)
 	flushCh := make(chan *flush.FlushRequest)
-	processed := rr.processAgentEvents(
-		ctx,
-		sess,
-		inv,
-		agentCh,
-		flushCh,
-		nil,
-		nil,
-		nil,
-	)
+	processed := rr.processAgentEvents(ctx, sess, inv, agentCh, flushCh, nil, nil, nil, runnerInvocationAttrs(inv))
 	// Send one event, then close agentCh
 	go func() {
 		agentCh <- &event.Event{Response: &model.Response{Done: true, Choices: []model.Choice{{Index: 0, Message: model.NewAssistantMessage("x")}}}}


### PR DESCRIPTION
## What changed

Fixes the two production data races reported in #2516, plus three follow-up
races surfaced during review.

1. **Telemetry** — the runner captures the agent name from `ag.Info().Name`
   before `agent.Run`; every completion-path read uses this runner-owned value
   instead of `Invocation.AgentName`.
2. **Session** — the four `collectPriorAssistant*` helpers now hold
   `session.EventMu` while iterating `sess.Events`, matching every other
   `Events` access.
3. **Cancellation before first event** (review follow-up) —
   `waitForAgentStreamClose` drains the agent stream until close, establishing
   the happens-before edge before any completion plugin callback runs.
4. **Timeout path** (review follow-up) — the drain runs in the caller goroutine
   with a timer (no detached goroutine, no leak). When the stream misses the
   grace period, plugins receive a stable invocation view, preserving the
   public `AfterRun` contract.
5. **State fidelity** (review follow-up) — `Invocation.RefreshViewState` syncs
   the view's state map after `BeforeAgent`, so billing/audit/timing state
   written in `BeforeAgent` stays visible to `AfterRun` on the degraded path.

## New exported API — rationale

Three helpers were added to `agent`. They are exported because `runner` lives in
a different package and must pass a pre-run agent name:

| API | Purpose |
|---|---|
| `EmitEventWithAgentName` | completion event delivery |
| `BuildExecutionTraceWithAgentName` | execution-trace root metadata |
| `RefreshViewState` | refresh a runner-owned view after `BeforeAgent` |

Existing `EmitEvent` / `BuildExecutionTrace` delegate to shared helpers, so
current callers are unaffected.

**Open question for maintainers:** if you'd prefer to keep these out of the
public surface, I'm happy to move them into an internal package or expose them
as options — please let me know which you prefer.

## Scope

- **Option 2** (agents operate on a copy) is superseded by the runner-owned
  snapshot approach in this PR — no longer needed.
- **Option 5** (`-race` in CI) is intentionally deferred: it cannot go green
  until the code-execution race (#2539 / #2543) lands. Better as a separate PR.

## Testing

Rebased onto `main` (9f7e561), no conflicts.

- `go test -race -count=1 ./runner/` — clean
- `go test -race -count=1 ./agent/` — clean
- Cancellation/timeout regressions at `-count=5` under `-race` — clean
- #2516 reproducer `TestRunnerCompletion_ChainAndParallelPropagatePredecessorsToRealChildSteps` — passes
- `go build ./...`, `go vet ./runner/ ./agent/` — clean

Fixes #2516
