### PR TITLE
tool: return the first value instead of panicking when merging a nil interface

### DIFF
--- a/tool/merge.go
+++ b/tool/merge.go
@@ -101,6 +101,11 @@ func mergeInts[T any](ts []T) T {
 	var sum int64
 	for _, t := range ts {
 		val := reflect.ValueOf(t)
+		// Skip nil interface elements: they carry no numeric value to merge,
+		// and reflecting on them would panic.
+		if !val.IsValid() {
+			continue
+		}
 		sum += val.Int()
 	}
 
@@ -114,6 +119,11 @@ func mergeUints[T any](ts []T) T {
 	var sum uint64
 	for _, t := range ts {
 		val := reflect.ValueOf(t)
+		// Skip nil interface elements: they carry no numeric value to merge,
+		// and reflecting on them would panic.
+		if !val.IsValid() {
+			continue
+		}
 		sum += val.Uint()
 	}
 
@@ -127,6 +137,11 @@ func mergeFloats[T any](ts []T) T {
 	var sum float64
 	for _, t := range ts {
 		val := reflect.ValueOf(t)
+		// Skip nil interface elements: they carry no numeric value to merge,
+		// and reflecting on them would panic.
+		if !val.IsValid() {
+			continue
+		}
 		sum += val.Float()
 	}
 

--- a/tool/merge.go
+++ b/tool/merge.go
@@ -35,6 +35,12 @@ func Merge[T any](ts []T) T {
 	// Handle the first element to determine the type and operation
 	first := ts[0]
 	firstValue := reflect.ValueOf(first)
+	// A nil interface value carries no reflect type to drive merging, so return
+	// it unchanged instead of panicking. This matches how a nil pointer field
+	// keeps the first value rather than adopting a later non-nil one.
+	if !firstValue.IsValid() {
+		return first
+	}
 	firstType := firstValue.Type()
 
 	// Check if type implements Mergeable interface

--- a/tool/merge_test.go
+++ b/tool/merge_test.go
@@ -605,6 +605,13 @@ func TestMerge_NilInterfaceElement(t *testing.T) {
 		{name: "leading nil", input: []any{nil, "str"}, want: nil},
 		{name: "trailing nil", input: []any{"str", nil}, want: "str"},
 		{name: "all nil", input: []any{nil, nil}, want: nil},
+		{name: "int with trailing nil", input: []any{1, nil}, want: 1},
+		{name: "int with middle nil", input: []any{1, nil, 2}, want: 3},
+		{name: "int with leading nil", input: []any{nil, 1}, want: nil},
+		{name: "float with trailing nil", input: []any{1.5, nil}, want: 1.5},
+		{name: "uint with trailing nil", input: []any{uint(7), nil}, want: uint(7)},
+		{name: "slice with trailing nil", input: []any{[]int{1}, nil}, want: []int{1}},
+		{name: "map with trailing nil", input: []any{map[string]int{"a": 1}, nil}, want: map[string]int{"a": 1}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var got any
@@ -638,6 +645,58 @@ func TestMerge_Structs_NilInterfaceField(t *testing.T) {
 	// Consistent with TestMerge_Structs_PointerField: the first value is kept.
 	if result.Meta != nil {
 		t.Errorf("Interface field: Expected nil (first value retained), got %+v", result.Meta)
+	}
+}
+
+// TestMerge_Structs_NumericThenNilInterfaceField covers the reversed order of
+// TestMerge_Structs_NilInterfaceField: a numeric any field followed by nil must
+// not panic inside numeric reflection and must merge the non-nil values only.
+func TestMerge_Structs_NumericThenNilInterfaceField(t *testing.T) {
+	type structWithAny struct {
+		Meta  any
+		Score int
+	}
+
+	for _, tt := range []struct {
+		name      string
+		structs   []structWithAny
+		wantMeta  any
+		wantScore int
+	}{
+		{
+			name:      "int field then nil field",
+			structs:   []structWithAny{{Meta: 1, Score: 10}, {Meta: nil, Score: 20}},
+			wantMeta:  1,
+			wantScore: 30,
+		},
+		{
+			name:      "float field then nil field",
+			structs:   []structWithAny{{Meta: 1.5, Score: 10}, {Meta: nil, Score: 20}},
+			wantMeta:  1.5,
+			wantScore: 30,
+		},
+		{
+			name:      "uint field then nil field",
+			structs:   []structWithAny{{Meta: uint(7), Score: 10}, {Meta: nil, Score: 20}},
+			wantMeta:  uint(7),
+			wantScore: 30,
+		},
+		{
+			name:      "int field, nil field, int field",
+			structs:   []structWithAny{{Meta: 1, Score: 10}, {Meta: nil, Score: 20}, {Meta: 2, Score: 30}},
+			wantMeta:  3,
+			wantScore: 60,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var result structWithAny
+			require.NotPanics(t, func() {
+				result = Merge(tt.structs)
+			}, "Merge should not panic when a numeric any field is followed by nil")
+
+			require.Equal(t, tt.wantMeta, result.Meta)
+			require.Equal(t, tt.wantScore, result.Score)
+		})
 	}
 }
 

--- a/tool/merge_test.go
+++ b/tool/merge_test.go
@@ -597,22 +597,23 @@ func TestMerge_NilHandling(t *testing.T) {
 }
 
 func TestMerge_NilInterfaceElement(t *testing.T) {
-	require.NotPanics(t, func() {
-		if got := Merge([]any{nil, "str"}); got != nil {
-			t.Errorf("Leading nil: Expected nil, got %v", got)
-		}
-	}, "Merge should not panic when the first element is a nil interface")
-
-	// Trailing nil already returned the first value; keep it as a regression guard.
-	if got := Merge([]any{"str", nil}); got != "str" {
-		t.Errorf("Trailing nil: Expected \"str\", got %v", got)
+	for _, tt := range []struct {
+		name  string
+		input []any
+		want  any
+	}{
+		{name: "leading nil", input: []any{nil, "str"}, want: nil},
+		{name: "trailing nil", input: []any{"str", nil}, want: "str"},
+		{name: "all nil", input: []any{nil, nil}, want: nil},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var got any
+			require.NotPanics(t, func() {
+				got = Merge(tt.input)
+			}, "Merge should not panic on a nil interface element")
+			require.Equal(t, tt.want, got)
+		})
 	}
-
-	require.NotPanics(t, func() {
-		if got := Merge([]any{nil, nil}); got != nil {
-			t.Errorf("All nil: Expected nil, got %v", got)
-		}
-	}, "Merge should not panic when every element is a nil interface")
 }
 
 func TestMerge_Structs_NilInterfaceField(t *testing.T) {

--- a/tool/merge_test.go
+++ b/tool/merge_test.go
@@ -596,6 +596,50 @@ func TestMerge_NilHandling(t *testing.T) {
 	}
 }
 
+func TestMerge_NilInterfaceElement(t *testing.T) {
+	require.NotPanics(t, func() {
+		if got := Merge([]any{nil, "str"}); got != nil {
+			t.Errorf("Leading nil: Expected nil, got %v", got)
+		}
+	}, "Merge should not panic when the first element is a nil interface")
+
+	// Trailing nil already returned the first value; keep it as a regression guard.
+	if got := Merge([]any{"str", nil}); got != "str" {
+		t.Errorf("Trailing nil: Expected \"str\", got %v", got)
+	}
+
+	require.NotPanics(t, func() {
+		if got := Merge([]any{nil, nil}); got != nil {
+			t.Errorf("All nil: Expected nil, got %v", got)
+		}
+	}, "Merge should not panic when every element is a nil interface")
+}
+
+func TestMerge_Structs_NilInterfaceField(t *testing.T) {
+	type structWithAny struct {
+		Meta  any
+		Score int
+	}
+
+	structs := []structWithAny{
+		{Meta: nil, Score: 10},
+		{Meta: "second", Score: 20},
+	}
+
+	var result structWithAny
+	require.NotPanics(t, func() {
+		result = Merge(structs)
+	}, "Merge should not panic on a nil interface field")
+
+	if result.Score != 30 {
+		t.Errorf("Score: Expected 30, got %d", result.Score)
+	}
+	// Consistent with TestMerge_Structs_PointerField: the first value is kept.
+	if result.Meta != nil {
+		t.Errorf("Interface field: Expected nil (first value retained), got %+v", result.Meta)
+	}
+}
+
 // Helper function for floating point comparison
 func abs64(x float64) float64 {
 	if x < 0 {


### PR DESCRIPTION
Supersedes #2514 — same branch and same fix. That PR had to be closed because the branch was force-pushed (to rewrite commit author emails to GitHub's noreply format), which makes a closed PR non-reopenable. The original review discussion is preserved there.

Fixes #2513.

## What

- `Merge` returns the first value unchanged when it is a nil interface, instead of panicking inside `reflect.Value.Type`. This matches the existing contract that a nil pointer field keeps the first value rather than adopting a later non-nil one.
- Fixed the same panic through the `mergeStructs` recursion when a struct's `any` field is nil in the first element.
- Follow-up to @Rememorio's P1 review in #2514: `mergeInts`/`mergeUints`/`mergeFloats` now skip nil (invalid) interface elements instead of panicking when a numeric first value is followed by nil — e.g. `Merge([]any{1, nil})`, including via an `any`-typed struct field — consistent with how `mergeStrings`/`mergeSlices`/`mergeMaps` already skip non-matching elements.

## Tests

- `TestMerge_NilInterfaceElement` (table-driven): leading nil, trailing nil, all nil, int/float/uint with trailing nil, middle nil (`{1, nil, 2}` -> 3), slice and map control cases.
- `TestMerge_Structs_NilInterfaceField`: nil `any` field keeps the first value.
- `TestMerge_Structs_NumericThenNilInterfaceField`: reversed order (numeric-then-nil) via `any` struct fields for int/float/uint, plus a three-element `{1, nil, 2}` case.

Out of scope (pre-existing, unchanged): heterogeneous element types like `Merge([]any{1, "str"})` still panic at the dispatch in merge.go, and the `tool/duckduckgo` test failure exists on an unpatched tree.

`go test ./tool/ -run TestMerge -count=1`, `gofmt`, and `go build ./...` all pass.
