### PR TITLE
session: stop full summary cascade without branch summary

### DIFF
--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -774,19 +774,20 @@ func isSingleFilterKey(sess *session.Session, targetKey string) bool {
 
 // copySummaryToKey copies a summary from srcKey to dstKey within the session.
 // This avoids duplicate LLM calls when the summaries would be identical.
-// Sets UpdatedAt to zero to mark the summary as needing persistence.
-func copySummaryToKey(sess *session.Session, srcKey, dstKey string) {
+// Sets UpdatedAt to zero to mark the summary as needing persistence and reports
+// whether a source summary was available to copy.
+func copySummaryToKey(sess *session.Session, srcKey, dstKey string) bool {
 	if sess == nil {
-		return
+		return false
 	}
 	sess.SummariesMu.Lock()
 	defer sess.SummariesMu.Unlock()
 	if sess.Summaries == nil {
-		return
+		return false
 	}
 	src, ok := sess.Summaries[srcKey]
 	if !ok || src == nil {
-		return
+		return false
 	}
 	copied := src.Clone()
 	if boundary := copied.CutoffBoundary(); boundary != nil {
@@ -800,6 +801,7 @@ func copySummaryToKey(sess *session.Session, srcKey, dstKey string) {
 		copied.Topics = nil
 	}
 	sess.Summaries[dstKey] = copied
+	return true
 }
 
 // CreateSessionSummaryWithCascade creates one or more session summaries for the
@@ -837,8 +839,18 @@ func CreateSessionSummaryWithCascade(
 			return fmt.Errorf("create session summary for filterKey %q failed: %w",
 				filterKey, err)
 		}
-		// Copy to in-memory session for immediate access.
-		copySummaryToKey(sess, filterKey, session.SummaryFilterKeyAllContents)
+		// Copy to in-memory session for immediate access. A nil error from the
+		// backend may mean the branch summary was intentionally not updated. In
+		// that case there is no source to copy, so stop the cascade instead of
+		// independently generating a full-session summary that branch readers
+		// cannot consume.
+		if !copySummaryToKey(
+			sess,
+			filterKey,
+			session.SummaryFilterKeyAllContents,
+		) {
+			return nil
+		}
 		// Persist the full-session key to storage. SummarizeSession detects
 		// existing in-memory summary with empty delta and returns updated=true.
 		if err := createSummaryFunc(ctx, sess, session.SummaryFilterKeyAllContents, false); err != nil {

--- a/session/internal/summary/summary_test.go
+++ b/session/internal/summary/summary_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/internal/summarytrigger"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -2295,13 +2296,12 @@ func TestCopySummaryToKey(t *testing.T) {
 	now := time.Now()
 
 	t.Run("nil session", func(t *testing.T) {
-		// Should not panic.
-		copySummaryToKey(nil, "src", "dst")
+		require.False(t, copySummaryToKey(nil, "src", "dst"))
 	})
 
 	t.Run("nil summaries", func(t *testing.T) {
 		sess := &session.Session{ID: "s1"}
-		copySummaryToKey(sess, "src", "dst")
+		require.False(t, copySummaryToKey(sess, "src", "dst"))
 		require.Nil(t, sess.Summaries)
 	})
 
@@ -2312,7 +2312,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				"other": {Summary: "other summary", UpdatedAt: now},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.False(t, copySummaryToKey(sess, "src", "dst"))
 		_, ok := sess.Summaries["dst"]
 		require.False(t, ok)
 	})
@@ -2324,7 +2324,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				"src": nil,
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.False(t, copySummaryToKey(sess, "src", "dst"))
 		_, ok := sess.Summaries["dst"]
 		require.False(t, ok)
 	})
@@ -2336,7 +2336,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				"src": {Summary: "source summary", UpdatedAt: now},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.True(t, copySummaryToKey(sess, "src", "dst"))
 		require.NotNil(t, sess.Summaries["dst"])
 		require.Equal(t, "source summary", sess.Summaries["dst"].Summary)
 		// UpdatedAt is set to zero to mark as needing persistence.
@@ -2355,7 +2355,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				"dst": {Summary: "old summary", UpdatedAt: oldTime},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.True(t, copySummaryToKey(sess, "src", "dst"))
 		require.Equal(t, "new summary", sess.Summaries["dst"].Summary)
 		// UpdatedAt is set to zero to mark as needing persistence.
 		require.True(t, sess.Summaries["dst"].UpdatedAt.IsZero())
@@ -2372,7 +2372,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.True(t, copySummaryToKey(sess, "src", "dst"))
 		require.NotNil(t, sess.Summaries["dst"])
 		require.Equal(t, "summary with topics", sess.Summaries["dst"].Summary)
 		require.Equal(t, []string{"topic1", "topic2", "topic3"}, sess.Summaries["dst"].Topics)
@@ -2396,7 +2396,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.True(t, copySummaryToKey(sess, "src", "dst"))
 		require.NotNil(t, sess.Summaries["dst"])
 		require.NotNil(t, sess.Summaries["dst"].Boundary)
 		require.Equal(t, "dst", sess.Summaries["dst"].Boundary.FilterKey)
@@ -2410,7 +2410,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				"src": {Summary: "summary without topics", UpdatedAt: now},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.True(t, copySummaryToKey(sess, "src", "dst"))
 		require.NotNil(t, sess.Summaries["dst"])
 		require.Equal(t, "summary without topics", sess.Summaries["dst"].Summary)
 		require.Nil(t, sess.Summaries["dst"].Topics)
@@ -2423,7 +2423,7 @@ func TestCopySummaryToKey(t *testing.T) {
 				"src": {Summary: "summary with empty topics", Topics: []string{}, UpdatedAt: now},
 			},
 		}
-		copySummaryToKey(sess, "src", "dst")
+		require.True(t, copySummaryToKey(sess, "src", "dst"))
 		require.NotNil(t, sess.Summaries["dst"])
 		require.Equal(t, "summary with empty topics", sess.Summaries["dst"].Summary)
 		require.Nil(t, sess.Summaries["dst"].Topics) // Empty slice becomes nil.
@@ -2736,6 +2736,74 @@ func TestCreateSessionSummaryWithCascade_SingleFilterKeyOptimization(t *testing.
 		require.Equal(t, sess.Summaries["app/math"].Summary, sess.Summaries[""].Summary)
 	})
 
+	t.Run("single filterKey - missing branch summary stops full cascade", func(t *testing.T) {
+		var calls []string
+		sess := &session.Session{
+			ID:      "test-session",
+			AppName: "test-app",
+			UserID:  "test-user",
+			Events: []event.Event{
+				makeEvent("e1", now, "app/math"),
+			},
+			Summaries: make(map[string]*session.Summary),
+		}
+
+		err := CreateSessionSummaryWithCascade(
+			context.Background(),
+			sess,
+			"app/math",
+			false,
+			NewSummaryDispatchPolicy(nil, true),
+			func(_ context.Context, _ *session.Session, target string, _ bool) error {
+				calls = append(calls, target)
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{"app/math"}, calls)
+		require.Empty(t, sess.Summaries)
+	})
+
+	t.Run("single filterKey - existing branch summary can backfill full key", func(t *testing.T) {
+		var calls []string
+		oldSummary := &session.Summary{
+			Summary:   "existing branch summary",
+			UpdatedAt: now.Add(-time.Minute),
+		}
+		sess := &session.Session{
+			ID:      "test-session",
+			AppName: "test-app",
+			UserID:  "test-user",
+			Events: []event.Event{
+				makeEvent("e1", now, "app/math"),
+			},
+			Summaries: map[string]*session.Summary{
+				"app/math": oldSummary,
+			},
+		}
+
+		err := CreateSessionSummaryWithCascade(
+			context.Background(),
+			sess,
+			"app/math",
+			false,
+			NewSummaryDispatchPolicy(nil, true),
+			func(_ context.Context, s *session.Session, target string, _ bool) error {
+				calls = append(calls, target)
+				if target == session.SummaryFilterKeyAllContents {
+					s.SummariesMu.Lock()
+					s.Summaries[target].UpdatedAt = now
+					s.SummariesMu.Unlock()
+				}
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{"app/math", ""}, calls)
+		require.Equal(t, oldSummary.Summary, sess.Summaries[""].Summary)
+		require.Equal(t, now, sess.Summaries[""].UpdatedAt)
+	})
+
 	t.Run("multiple filterKeys - two LLM calls", func(t *testing.T) {
 		var calls []string
 		var callsMu sync.Mutex
@@ -2878,4 +2946,69 @@ func TestCreateSessionSummaryWithCascade_SingleFilterKeyOptimization(t *testing.
 		require.NoError(t, err)
 		require.Equal(t, 1, callCount)
 	})
+}
+
+func TestCreateSessionSummaryWithCascade_UnboundBranchStopsCascade(
+	t *testing.T,
+) {
+	const filterKey = "agent_skill"
+	now := time.Now()
+	sess := &session.Session{
+		ID:      "production-session",
+		AppName: filterKey,
+		UserID:  "production-user",
+		Events: []event.Event{
+			makeEvent("event-1", now, filterKey),
+		},
+		Summaries: make(map[string]*session.Summary),
+	}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     sess.ID,
+		FilterKey:     filterKey,
+		RequestTokens: 64_000,
+		Bound:         false,
+		Items: []summaryview.Item{{
+			EffectiveEvent: sess.Events[0],
+			Boundary: summaryview.Boundary{
+				EventID:   sess.Events[0].ID,
+				Timestamp: sess.Events[0].Timestamp,
+			},
+		}},
+	})
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithTokenThreshold(1),
+	)
+	var targets []string
+
+	err := CreateSessionSummaryWithCascade(
+		ctx,
+		sess,
+		filterKey,
+		false,
+		NewSummaryDispatchPolicy(nil, true),
+		func(
+			ctx context.Context,
+			sess *session.Session,
+			target string,
+			force bool,
+		) error {
+			targets = append(targets, target)
+			_, err := SummarizeSession(
+				ctx,
+				summarizer,
+				sess,
+				target,
+				force,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{filterKey}, targets)
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.Nil(t, sess.Summaries[filterKey])
+	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents])
 }


### PR DESCRIPTION
## What changed

Prevent the single-filter session summary cascade from creating a full-session summary when the branch summary was not materialized.

A successful branch summary still cascades to the full-session key as before. Multi-filter summary generation is unchanged.

## Why

A branch summary attempt may intentionally finish without an error and without updating the session, for example when the summary view is not bound to a safe event prefix.

Previously, the optimized single-filter cascade treated the nil error as proof that a branch summary existed. When no source summary was available, the in-memory copy silently did nothing, but the cascade continued and independently generated a full-session summary under the all-contents key.

Branch readers look up summaries by their exact filter key. This could therefore leave a full-session boundary without a consumable branch summary, creating inconsistent summary state and contributing to apparent history loss.

The cascade now stops when there is no branch summary to reuse.

## Testing

- Added coverage for nil sessions, missing source summaries, successful copies, topic cloning, and boundary filter-key rewriting.
- Added a regression test that verifies a missing branch summary stops the full-session cascade.
- Added compatibility coverage showing that an existing branch summary still backfills and persists the full-session key.
- Added a production-shaped regression test for an unbound `agent_skill` view with a 64,000-token request.
- Reproduced the previous empty-key summary behavior against the pre-change code and verified that this change prevents it.
- Ran `go build ./...`.
- Ran the repository test suites, including `go test ./...`.
- Ran `go test -race ./session/internal/summary/`.

## Notes for reviewers

- No public API is changed; the modified helper is internal to the session summary package.
- The observable behavior change is limited to the missing-source case: the full-session summary is no longer refreshed when the branch summary was not produced. This is intentional because there is no equivalent branch summary to cascade.
- Successful single-filter cascades, error propagation, and multi-filter generation retain their existing behavior.
- This change is deliberately scoped to a missing source summary. It does not change existing cascade policy when a source summary already exists.