### PR TITLE
internal/flow/processor: isolate transfer target run-scoped tool surface

### DIFF
--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -373,6 +373,18 @@ func prepareTransferTargetInvocation(
 				agent.SetInvocationSurfaceRootNodeID(inv, surfaceRootNodeID)
 			}
 		},
+		// Isolate the target invocation from the source run's tool surface.
+		// Invocation.Clone copies RunOptions verbatim, so run-scoped tool
+		// fields (ExternalTools, AdditionalTools, ExternalToolNames,
+		// ToolFilter) would otherwise leak into the target agent's model
+		// requests, mirroring the AgentTool boundary fix for #2219. The
+		// TransferController customizer runs after Clone and keeps the last
+		// word, so controllers can still re-attach a scoped tool surface.
+		func(inv *agent.Invocation) {
+			runOptions := inv.RunOptions
+			clearInheritedToolRunOptions(&runOptions)
+			inv.RunOptions = runOptions
+		},
 	}
 	// Override the inherited ParentMetadata: target invocation came from a
 	// transfer, so its ParentMetadata must describe the transfer (not
@@ -414,6 +426,20 @@ func prepareTransferTargetInvocation(
 		return nil, model.Message{}, err
 	}
 	return targetInvocation, beforeCustomize, nil
+}
+
+// clearInheritedToolRunOptions removes run-scoped tool surface fields from
+// the given RunOptions. These fields describe the source run's tool surface
+// and must not cross an agent boundary into a child/target invocation; the
+// target agent should only see its own registered tools by default.
+func clearInheritedToolRunOptions(runOptions *agent.RunOptions) {
+	if runOptions == nil {
+		return
+	}
+	runOptions.ToolFilter = nil
+	runOptions.AdditionalTools = nil
+	runOptions.ExternalTools = nil
+	runOptions.ExternalToolNames = nil
 }
 
 func shouldEmitTransferMessageEcho(

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -375,11 +375,16 @@ func prepareTransferTargetInvocation(
 		},
 		// Isolate the target invocation from the source run's tool surface.
 		// Invocation.Clone copies RunOptions verbatim, so run-scoped tool
-		// fields (ExternalTools, AdditionalTools, ExternalToolNames,
-		// ToolFilter) would otherwise leak into the target agent's model
-		// requests, mirroring the AgentTool boundary fix for #2219. The
+		// surface fields (ExternalTools, AdditionalTools,
+		// ExternalToolNames) would otherwise leak into the target agent's
+		// model requests. ToolFilter is deliberately NOT cleared: it is a
+		// run-scoped visibility predicate applied against whichever agent
+		// builds the surface, not a description of the source run's tool
+		// surface, so user/session/tenant-level visibility policies keep
+		// applying across the transfer boundary (fail-closed). The
 		// TransferController customizer runs after Clone and keeps the last
-		// word, so controllers can still re-attach a scoped tool surface.
+		// word, so controllers can still re-scope or clear the filter for
+		// the target invocation.
 		func(inv *agent.Invocation) {
 			runOptions := inv.RunOptions
 			clearInheritedToolRunOptions(&runOptions)
@@ -432,11 +437,18 @@ func prepareTransferTargetInvocation(
 // the given RunOptions. These fields describe the source run's tool surface
 // and must not cross an agent boundary into a child/target invocation; the
 // target agent should only see its own registered tools by default.
+//
+// ToolFilter is intentionally preserved: unlike the other fields it is a
+// run-scoped predicate applied against whichever agent builds the surface,
+// not a description of the source agent's tools. Clearing it would silently
+// widen visibility after a transfer (fail-open), dropping user/session/tenant
+// visibility policies the run started with. Transfer controllers that want a
+// target-scoped filter can re-attach one in their customizer, which runs
+// after this cleanup and keeps the last word.
 func clearInheritedToolRunOptions(runOptions *agent.RunOptions) {
 	if runOptions == nil {
 		return
 	}
-	runOptions.ToolFilter = nil
 	runOptions.AdditionalTools = nil
 	runOptions.ExternalTools = nil
 	runOptions.ExternalToolNames = nil

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -40,13 +40,14 @@ type mockAgent struct {
 	gotSurfaceRoot    string
 	gotMessage        model.Message
 	gotParentMetadata *agent.ParentInvocationMetadata
+	tools             []tool.Tool
 	invoked           bool
 }
 
 func (m *mockAgent) Info() agent.Info                { return agent.Info{Name: m.name} }
 func (m *mockAgent) SubAgents() []agent.Agent        { return nil }
 func (m *mockAgent) FindSubAgent(string) agent.Agent { return nil }
-func (m *mockAgent) Tools() []tool.Tool              { return nil }
+func (m *mockAgent) Tools() []tool.Tool              { return m.tools }
 func (m *mockAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
 	ch := make(chan *event.Event, 1)
 	go func() {

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -44,10 +44,20 @@ type mockAgent struct {
 	invoked           bool
 }
 
-func (m *mockAgent) Info() agent.Info                { return agent.Info{Name: m.name} }
-func (m *mockAgent) SubAgents() []agent.Agent        { return nil }
+// Info returns the mock agent's configured name.
+func (m *mockAgent) Info() agent.Info { return agent.Info{Name: m.name} }
+
+// SubAgents reports no sub-agents; transfer targets are resolved through
+// the parent agent instead.
+func (m *mockAgent) SubAgents() []agent.Agent { return nil }
+
+// FindSubAgent always reports no match, as expected for a leaf agent.
 func (m *mockAgent) FindSubAgent(string) agent.Agent { return nil }
-func (m *mockAgent) Tools() []tool.Tool              { return m.tools }
+
+// Tools returns the mock agent's registered tools.
+func (m *mockAgent) Tools() []tool.Tool { return m.tools }
+
+// Run records invocation observations and optionally emits a single event.
 func (m *mockAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
 	ch := make(chan *event.Event, 1)
 	go func() {
@@ -69,30 +79,50 @@ func (m *mockAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *eve
 // parentAgent implements FindSubAgent
 type parentAgent struct{ child agent.Agent }
 
-func (p *parentAgent) Info() agent.Info         { return agent.Info{Name: "parent"} }
+// Info returns the fixed parent agent name.
+func (p *parentAgent) Info() agent.Info { return agent.Info{Name: "parent"} }
+
+// SubAgents reports the single configured child agent.
 func (p *parentAgent) SubAgents() []agent.Agent { return []agent.Agent{p.child} }
+
+// FindSubAgent returns the child agent when its name matches.
 func (p *parentAgent) FindSubAgent(name string) agent.Agent {
 	if p.child != nil && p.child.Info().Name == name {
 		return p.child
 	}
 	return nil
 }
+
+// Tools returns no tools for the parent agent.
 func (p *parentAgent) Tools() []tool.Tool { return nil }
+
+// Run completes immediately without emitting any events.
 func (p *parentAgent) Run(ctx context.Context, inv *agent.Invocation) (<-chan *event.Event, error) {
 	ch := make(chan *event.Event)
 	close(ch)
 	return ch, nil
 }
 
+// runErrorAgent is an agent whose Run always fails, used to exercise the
+// target-run error path of transfer handling.
 type runErrorAgent struct {
 	name  string
 	calls int
 }
 
-func (a *runErrorAgent) Info() agent.Info                { return agent.Info{Name: a.name} }
-func (a *runErrorAgent) SubAgents() []agent.Agent        { return nil }
+// Info returns the agent's configured name.
+func (a *runErrorAgent) Info() agent.Info { return agent.Info{Name: a.name} }
+
+// SubAgents reports no sub-agents.
+func (a *runErrorAgent) SubAgents() []agent.Agent { return nil }
+
+// FindSubAgent always reports no match.
 func (a *runErrorAgent) FindSubAgent(string) agent.Agent { return nil }
-func (a *runErrorAgent) Tools() []tool.Tool              { return nil }
+
+// Tools returns no tools.
+func (a *runErrorAgent) Tools() []tool.Tool { return nil }
+
+// Run counts the call and returns a fixed error.
 func (a *runErrorAgent) Run(
 	context.Context,
 	*agent.Invocation,

--- a/internal/flow/processor/transfer_tool_surface_test.go
+++ b/internal/flow/processor/transfer_tool_surface_test.go
@@ -22,6 +22,7 @@ import (
 // run-scoped tool surface across transfer_to_agent boundaries.
 type surfaceTool struct{ name string }
 
+// Declaration returns the minimal tool declaration for the surface tool.
 func (st surfaceTool) Declaration() *tool.Declaration {
 	return &tool.Declaration{Name: st.name}
 }
@@ -97,12 +98,22 @@ func TestTransferTargetInvocationKeepsCustomizerLastWord(t *testing.T) {
 	require.Equal(t, []tool.Tool{keepExternal}, targetInv.RunOptions.ExternalTools)
 }
 
+// TestClearInheritedToolRunOptionsNil verifies the defensive nil guard: a nil
+// RunOptions pointer is a no-op instead of a panic.
+func TestClearInheritedToolRunOptionsNil(t *testing.T) {
+	require.NotPanics(t, func() {
+		clearInheritedToolRunOptions(nil)
+	})
+}
+
 // invocationCustomizerFunc adapts a function to the internal
 // itransfer.InvocationCustomizer interface. It is kept minimal to avoid
 // leaking the internal interface into test assertions.
 type invocationCustomizerFunc func(
 	ctx context.Context, source, target *agent.Invocation) error
 
+// CustomizeTransferInvocation delegates to the wrapped function so tests can
+// attach scoped run options without importing the internal transfer package.
 func (f invocationCustomizerFunc) CustomizeTransferInvocation(
 	ctx context.Context,
 	source *agent.Invocation,

--- a/internal/flow/processor/transfer_tool_surface_test.go
+++ b/internal/flow/processor/transfer_tool_surface_test.go
@@ -103,6 +103,9 @@ func TestTransferTargetToolSurfaceAppliesInheritedFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, child, targetInv.Agent)
 
+	// Effective's second return value classifies user tools (nil for
+	// mockAgent, which does not implement user-tool tracking); it is not
+	// an error, so there is no error to assert here.
 	surface, _ := toolsurface.Effective(context.Background(), targetInv)
 	names := make([]string, 0, len(surface))
 	for _, tl := range surface {

--- a/internal/flow/processor/transfer_tool_surface_test.go
+++ b/internal/flow/processor/transfer_tool_surface_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/internal/toolsurface"
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
@@ -71,6 +72,43 @@ func TestTransferTargetInvocationIsolatesRunScopedToolSurface(t *testing.T) {
 		require.True(t, targetInv.RunOptions.ToolFilter(
 			context.Background(), surfaceTool{name: "allowed"}))
 	})
+}
+
+// TestTransferTargetToolSurfaceAppliesInheritedFilter exercises the tool
+// surface construction path (the same one the LLM flow uses to build model
+// requests) to prove the preserved ToolFilter is actually consumed, not
+// merely stored on RunOptions.
+func TestTransferTargetToolSurfaceAppliesInheritedFilter(t *testing.T) {
+	inv := &agent.Invocation{
+		Agent:        &parentAgent{child: &mockAgent{name: "child"}},
+		AgentName:    "parent",
+		InvocationID: "inv",
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child", Message: "hi"},
+		RunOptions: agent.RunOptions{
+			ToolFilter: func(ctx context.Context, t tool.Tool) bool {
+				return t.Declaration().Name != "blocked"
+			},
+		},
+	}
+
+	child := &mockAgent{
+		name: "child",
+		tools: []tool.Tool{
+			surfaceTool{name: "blocked"},
+			surfaceTool{name: "allowed"},
+		},
+	}
+	targetInv, _, err := prepareTransferTargetInvocation(
+		context.Background(), inv, child, inv.TransferInfo, nil)
+	require.NoError(t, err)
+	require.Equal(t, child, targetInv.Agent)
+
+	surface, _ := toolsurface.Effective(context.Background(), targetInv)
+	names := make([]string, 0, len(surface))
+	for _, tl := range surface {
+		names = append(names, tl.Declaration().Name)
+	}
+	require.ElementsMatch(t, []string{"allowed"}, names)
 }
 
 // TestTransferTargetInvocationKeepsCustomizerLastWord verifies that the

--- a/internal/flow/processor/transfer_tool_surface_test.go
+++ b/internal/flow/processor/transfer_tool_surface_test.go
@@ -103,10 +103,14 @@ func TestTransferTargetToolSurfaceAppliesInheritedFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, child, targetInv.Agent)
 
-	// Effective's second return value classifies user tools (nil for
-	// mockAgent, which does not implement user-tool tracking); it is not
-	// an error, so there is no error to assert here.
-	surface, _ := toolsurface.Effective(context.Background(), targetInv)
+	// Effective's second return value classifies user tools rather than
+	// carrying an error: mockAgent implements neither user-tool tracking
+	// nor user-tool registration, so the classification must be nil.
+	// Capture and assert it instead of discarding the value.
+	surface, userToolNames := toolsurface.Effective(context.Background(), targetInv)
+	require.Nil(t, userToolNames)
+	// The inherited ToolFilter must be applied during target surface
+	// construction: "blocked" is excluded and "allowed" survives.
 	names := make([]string, 0, len(surface))
 	for _, tl := range surface {
 		names = append(names, tl.Declaration().Name)

--- a/internal/flow/processor/transfer_tool_surface_test.go
+++ b/internal/flow/processor/transfer_tool_surface_test.go
@@ -1,0 +1,112 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package processor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+)
+
+// surfaceTool is a minimal tool implementation used to assert the
+// run-scoped tool surface across transfer_to_agent boundaries.
+type surfaceTool struct{ name string }
+
+func (st surfaceTool) Declaration() *tool.Declaration {
+	return &tool.Declaration{Name: st.name}
+}
+
+// TestTransferTargetInvocationIsolatesRunScopedToolSurface verifies that a
+// transfer_to_agent target invocation does not inherit the source run's
+// tool surface fields (refs #2219). Invocation.Clone copies RunOptions
+// verbatim, so without boundary cleanup the target agent would see the
+// parent run's external tools, additional tools, and tool filter.
+func TestTransferTargetInvocationIsolatesRunScopedToolSurface(t *testing.T) {
+	inv := &agent.Invocation{
+		Agent:        &parentAgent{child: &mockAgent{name: "child"}},
+		AgentName:    "parent",
+		InvocationID: "inv",
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child", Message: "hi"},
+		RunOptions: agent.RunOptions{
+			ExternalTools:     []tool.Tool{surfaceTool{name: "external"}},
+			AdditionalTools:   []tool.Tool{surfaceTool{name: "additional"}},
+			ExternalToolNames: map[string]bool{"external": true},
+			ToolFilter: func(ctx context.Context, t tool.Tool) bool {
+				return true
+			},
+		},
+	}
+
+	targetInv, _, err := prepareTransferTargetInvocation(
+		context.Background(), inv, &mockAgent{name: "child"}, inv.TransferInfo, nil)
+	require.NoError(t, err)
+
+	t.Run("external tools should not leak into target", func(t *testing.T) {
+		require.Empty(t, targetInv.RunOptions.ExternalTools)
+	})
+	t.Run("additional tools should not leak into target", func(t *testing.T) {
+		require.Empty(t, targetInv.RunOptions.AdditionalTools)
+	})
+	t.Run("external tool names should not leak into target", func(t *testing.T) {
+		require.Empty(t, targetInv.RunOptions.ExternalToolNames)
+	})
+	t.Run("tool filter should not leak into target", func(t *testing.T) {
+		require.Nil(t, targetInv.RunOptions.ToolFilter)
+	})
+}
+
+// TestTransferTargetInvocationKeepsCustomizerLastWord verifies that the
+// TransferController customizer runs after the tool surface cleanup and can
+// re-attach a scoped tool surface for the target invocation.
+func TestTransferTargetInvocationKeepsCustomizerLastWord(t *testing.T) {
+	inv := &agent.Invocation{
+		Agent:        &parentAgent{child: &mockAgent{name: "child"}},
+		AgentName:    "parent",
+		InvocationID: "inv",
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child"},
+		RunOptions: agent.RunOptions{
+			ExternalTools: []tool.Tool{surfaceTool{name: "external"}},
+		},
+	}
+
+	keepExternal := surfaceTool{name: "scoped-external"}
+	targetInv, _, err := prepareTransferTargetInvocation(
+		context.Background(),
+		inv,
+		&mockAgent{name: "child"},
+		inv.TransferInfo,
+		invocationCustomizerFunc(func(
+			ctx context.Context,
+			source, target *agent.Invocation,
+		) error {
+			target.RunOptions.ExternalTools = []tool.Tool{keepExternal}
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []tool.Tool{keepExternal}, targetInv.RunOptions.ExternalTools)
+}
+
+// invocationCustomizerFunc adapts a function to the internal
+// itransfer.InvocationCustomizer interface. It is kept minimal to avoid
+// leaking the internal interface into test assertions.
+type invocationCustomizerFunc func(
+	ctx context.Context, source, target *agent.Invocation) error
+
+func (f invocationCustomizerFunc) CustomizeTransferInvocation(
+	ctx context.Context,
+	source *agent.Invocation,
+	target *agent.Invocation,
+) error {
+	return f(ctx, source, target)
+}

--- a/internal/flow/processor/transfer_tool_surface_test.go
+++ b/internal/flow/processor/transfer_tool_surface_test.go
@@ -31,7 +31,10 @@ func (st surfaceTool) Declaration() *tool.Declaration {
 // transfer_to_agent target invocation does not inherit the source run's
 // tool surface fields (refs #2219). Invocation.Clone copies RunOptions
 // verbatim, so without boundary cleanup the target agent would see the
-// parent run's external tools, additional tools, and tool filter.
+// parent run's external tools and additional tools. The run-scoped
+// ToolFilter is deliberately preserved: it is a visibility predicate over
+// whichever agent builds the surface, so user/session/tenant policies keep
+// applying after the transfer.
 func TestTransferTargetInvocationIsolatesRunScopedToolSurface(t *testing.T) {
 	inv := &agent.Invocation{
 		Agent:        &parentAgent{child: &mockAgent{name: "child"}},
@@ -43,7 +46,7 @@ func TestTransferTargetInvocationIsolatesRunScopedToolSurface(t *testing.T) {
 			AdditionalTools:   []tool.Tool{surfaceTool{name: "additional"}},
 			ExternalToolNames: map[string]bool{"external": true},
 			ToolFilter: func(ctx context.Context, t tool.Tool) bool {
-				return true
+				return t.Declaration().Name != "blocked"
 			},
 		},
 	}
@@ -61,8 +64,12 @@ func TestTransferTargetInvocationIsolatesRunScopedToolSurface(t *testing.T) {
 	t.Run("external tool names should not leak into target", func(t *testing.T) {
 		require.Empty(t, targetInv.RunOptions.ExternalToolNames)
 	})
-	t.Run("tool filter should not leak into target", func(t *testing.T) {
-		require.Nil(t, targetInv.RunOptions.ToolFilter)
+	t.Run("tool filter persists and applies to target tools", func(t *testing.T) {
+		require.NotNil(t, targetInv.RunOptions.ToolFilter)
+		require.False(t, targetInv.RunOptions.ToolFilter(
+			context.Background(), surfaceTool{name: "blocked"}))
+		require.True(t, targetInv.RunOptions.ToolFilter(
+			context.Background(), surfaceTool{name: "allowed"}))
 	})
 }
 


### PR DESCRIPTION
## What

Isolate the transfer_to_agent target invocation from the source run's tool surface. The target RunOptions is cloned verbatim, so run-scoped tool fields leak into the target agent's model requests:

- ExternalTools
- AdditionalTools
- ExternalToolNames
- ToolFilter

This mirrors the AgentTool boundary fix in #2220 and closes the transfer_to_agent path tracked in #2219.

## Why

#2219 identified that ordinary AgentTool child invocations were fixed by #2220, but transfer_to_agent still inherits the parent RunOptions verbatim. A sub-agent reached via transfer sees tools that were injected for the source run only.

## How verified

- New regression test `TestTransferTargetInvocationIsolatesRunScopedToolSurface` asserts all four fields are cleared. Confirmed it fails on the current main baseline and passes with this change.
- `TestTransferTargetInvocationKeepsCustomizerLastWord` verifies the TransferController customizer can still re-attach a scoped tool surface.
- `go test ./internal/flow/... ./agent/llmagent/ ./tool/transfer/ ./agent/... ./graph/...` passes.

## Related

Refs #2219