### PR TITLE
session/redis: bound hash-indexed event reads

### DIFF
--- a/session/redis/internal/hashidx/lua.go
+++ b/session/redis/internal/hashidx/lua.go
@@ -163,25 +163,23 @@ end
 return 1
 `)
 
-// luaLoadEvents loads events by time range.
+// luaLoadEvents loads one bounded batch of events in reverse chronological order.
 // KEYS[1] = evtdata key, KEYS[2] = evtidx:time key
-// ARGV[1] = offset, ARGV[2] = limit, ARGV[3] = reverse (1=latest first, 0=oldest first)
+// ARGV[1] = minScore, ARGV[2] = offset, ARGV[3] = batch size
+// The first returned element is the number of indexed IDs scanned. The remaining
+// elements are event JSON payloads; missing Hash fields are skipped.
 var luaLoadEvents = redis.NewScript(`
 local evtDataKey = KEYS[1]
 local evtTimeKey = KEYS[2]
-local offset = tonumber(ARGV[1])
-local limit = tonumber(ARGV[2])
-local reverse = tonumber(ARGV[3]) == 1
+local minScore = ARGV[1]
+local offset = tonumber(ARGV[2])
+local batchSize = math.min(tonumber(ARGV[3]), 512)
 
-local endIdx = limit < 0 and -1 or offset + limit - 1
-local eventIDs
-if reverse then
-    eventIDs = redis.call('ZREVRANGE', evtTimeKey, offset, endIdx)
-else
-    eventIDs = redis.call('ZRANGE', evtTimeKey, offset, endIdx)
-end
-
-local result = {}
+local eventIDs = redis.call(
+    'ZREVRANGEBYSCORE', evtTimeKey, '+inf', minScore,
+    'LIMIT', offset, batchSize
+)
+local result = {tostring(#eventIDs)}
 if #eventIDs > 0 then
     local dataList = redis.call('HMGET', evtDataKey, unpack(eventIDs))
     for _, data in ipairs(dataList) do
@@ -351,51 +349,33 @@ end
 return 0
 `)
 
-// luaLoadSessionData loads core session data in a single Lua call (except appState and tracks).
-// Tracks are loaded separately via pipeline (RT2) to avoid cjson empty-array quirks.
+// luaLoadSessionData loads user state and summary in a single Lua call.
+// Events are loaded separately in bounded batches, and tracks use their own loader.
 //
 // KEYS layout (all {userID}-scoped, same Redis Cluster slot):
 //
-//	KEYS[1] = evtdata key (HASH)
-//	KEYS[2] = evtidx:time key (ZSET)
-//	KEYS[3] = sessionMeta key (STRING)
-//	KEYS[4] = summaryKey (STRING, JSON map of filterKey -> Summary)
-//	KEYS[5] = userStateKey (HASH)
+//	KEYS[1] = summaryKey (STRING, JSON map of filterKey -> Summary)
+//	KEYS[2] = userStateKey (HASH)
 //
 // Returns: cjson-encoded table:
 //
 //	{
-//	  "events": [eventJSON, ...],                       -- all events in chronological order
 //	  "summary": "..." or nil,                          -- raw summary JSON string (entire map)
 //	  "userState": {"key": "value", ...} or nil,        -- user state map
 //	}
 var luaLoadSessionData = redis.NewScript(`
-local evtDataKey = KEYS[1]
-local evtTimeKey = KEYS[2]
-local sessionMetaKey = KEYS[3]
-local summaryKey = KEYS[4]
-local userStateKey = KEYS[5]
+local summaryKey = KEYS[1]
+local userStateKey = KEYS[2]
 
-local result = {}
+local result = {loaded = true}
 
--- 1. Load events (chronological order)
-local eventIDs = redis.call('ZRANGE', evtTimeKey, 0, -1)
-local events = {}
-if #eventIDs > 0 then
-    local dataList = redis.call('HMGET', evtDataKey, unpack(eventIDs))
-    for _, data in ipairs(dataList) do
-        if data then table.insert(events, data) end
-    end
-end
-result['events'] = events
-
--- 2. Load summary (String key containing entire JSON map)
+-- 1. Load summary (String key containing entire JSON map)
 local sumData = redis.call('GET', summaryKey)
 if sumData then
     result['summary'] = sumData
 end
 
--- 3. Load user state
+-- 2. Load user state
 local userState = redis.call('HGETALL', userStateKey)
 if #userState > 0 then
     local us = {}
@@ -611,10 +591,18 @@ end
 
 local result = {}
 if #eventIDs > 0 then
-    local dataList = redis.call('HMGET', dataKey, unpack(eventIDs))
-    for _, data in ipairs(dataList) do
-        if data then
-            table.insert(result, data)
+    local batchSize = 512
+    for startIdx = 1, #eventIDs, batchSize do
+        local batchIDs = {}
+        local endIdx = math.min(startIdx + batchSize - 1, #eventIDs)
+        for i = startIdx, endIdx do
+            table.insert(batchIDs, eventIDs[i])
+        end
+        local dataList = redis.call('HMGET', dataKey, unpack(batchIDs))
+        for _, data in ipairs(dataList) do
+            if data then
+                table.insert(result, data)
+            end
         end
     end
 end

--- a/session/redis/internal/hashidx/session.go
+++ b/session/redis/internal/hashidx/session.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,6 +22,11 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
+)
+
+const (
+	eventLoadBatchSize       = 512
+	userEventAnchorBatchSize = 64
 )
 
 // Config holds configuration for HashIdx session storage client.
@@ -176,11 +183,12 @@ func (c *Client) GetSession(
 // loadSessionComplete loads session data with all post-processing (matches zset behavior).
 // This includes: events, app/user state merge, track events, summaries.
 //
-// Uses 3 Redis round-trips:
+// Uses bounded Redis reads for events, followed by the existing state loaders:
 //
-//	RT1: luaLoadSessionData — events + userState + summary (same {userID} slot)
-//	RT2: pipeline ZRANGE for each track (same {userID} slot)
-//	RT3: pipeline HGETALL for appState (different {appName} slot)
+//   - luaLoadEvents — one or more bounded event batches (same {userID} slot)
+//   - luaLoadSessionData — userState + summary (same {userID} slot)
+//   - luaLoadTrackEvents for each track (same {userID} slot)
+//   - pipeline HGETALL for appState (different {appName} slot)
 func (c *Client) loadSessionComplete(
 	ctx context.Context,
 	key session.Key,
@@ -201,23 +209,18 @@ func (c *Client) loadSessionComplete(
 	// Parse track names from session state (pure memory, no Redis call)
 	tracks, _ := session.TracksFromState(meta.State)
 
-	// --- RT1: Lua script for events + userState + summary + TTL refresh ---
+	// Load events from the time index in bounded batches before materializing payloads.
+	events, err := c.loadSessionEvents(ctx, key, limit, afterTime)
+	if err != nil {
+		return nil, fmt.Errorf("load session data: %w", err)
+	}
+	sess.Events = events
+
+	// Load userState and summary.
 	sessionData, err := c.loadSessionDataViaLua(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("load session data: %w", err)
 	}
-
-	// Populate events
-	for _, evtJSON := range sessionData.parseEvents() {
-		var evt event.Event
-		if err := json.Unmarshal([]byte(evtJSON), &evt); err != nil {
-			continue
-		}
-		sess.Events = append(sess.Events, evt)
-	}
-
-	// Apply event filtering (matches zset behavior)
-	sess.ApplyEventFiltering(session.WithEventNum(limit), session.WithEventTime(afterTime))
 
 	// Merge user state from Lua result
 	for k, v := range sessionData.UserState {
@@ -232,10 +235,10 @@ func (c *Client) loadSessionComplete(
 		}
 	}
 
-	// --- RT2: load track events (same {userID} slot) ---
+	// Load track events (same {userID} slot).
 	c.loadAndAttachTrackEvents(ctx, key, sess, tracks, limit, afterTime)
 
-	// --- RT3: appState (different hash tag {appName}, cannot be in same Lua) ---
+	// Load appState (different hash tag {appName}, cannot be in the same Lua script).
 	c.loadAndMergeAppState(ctx, key, sess)
 
 	// Inject HashIdx version tag into ServiceMeta (not persisted, memory only)
@@ -245,39 +248,18 @@ func (c *Client) loadSessionComplete(
 }
 
 // sessionDataResult holds the decoded result from luaLoadSessionData.
-// Events use json.RawMessage because Lua cjson encodes empty arrays as {} (JSON objects).
-// Tracks are no longer in this result — they are loaded via a separate pipeline call.
 type sessionDataResult struct {
-	Events    json.RawMessage   `json:"events"`
 	Summary   string            `json:"summary"`
 	UserState map[string]string `json:"userState"`
 }
 
-// parseEvents parses the events field from the Lua result.
-// Handles Lua cjson's empty-array-as-object quirk for []string.
-func (r *sessionDataResult) parseEvents() []string {
-	if len(r.Events) == 0 {
-		return nil
-	}
-	var result []string
-	if err := json.Unmarshal(r.Events, &result); err == nil {
-		return result
-	}
-	// Empty object {} from cjson = empty array
-	return nil
-}
-
-// loadSessionDataViaLua executes luaLoadSessionData to load events, userState,
-// and summary in a single Redis round-trip (RT1).
-// Track events are loaded separately via pipeline (RT2).
+// loadSessionDataViaLua executes luaLoadSessionData to load userState and
+// summary in a single Redis round-trip.
 func (c *Client) loadSessionDataViaLua(
 	ctx context.Context,
 	key session.Key,
 ) (*sessionDataResult, error) {
 	keys := []string{
-		c.keys.EventDataKey(key),
-		c.keys.EventTimeIndexKey(key),
-		c.keys.SessionMetaKey(key),
 		c.keys.SummaryKey(key),
 		c.keys.UserStateKey(key.AppName, key.UserID),
 	}
@@ -292,6 +274,144 @@ func (c *Client) loadSessionDataViaLua(
 		return nil, fmt.Errorf("unmarshal lua result: %w", err)
 	}
 	return &result, nil
+}
+
+// loadSessionEvents loads the requested event window in fixed-size batches.
+// It preserves ApplyEventFiltering's behavior of adding the latest older user
+// event when the selected window does not contain a user message.
+func (c *Client) loadSessionEvents(
+	ctx context.Context,
+	key session.Key,
+	limit int,
+	afterTime time.Time,
+) ([]event.Event, error) {
+	events, err := c.loadRecentEvents(ctx, key, afterTime, limit)
+	if err != nil {
+		return nil, err
+	}
+	originalEvents := slices.Clone(events)
+	sess := &session.Session{Events: events}
+	sess.ApplyEventFiltering(session.WithEventNum(limit), session.WithEventTime(afterTime))
+	if len(sess.Events) > 0 {
+		return sess.Events, nil
+	}
+	if limit <= 0 && afterTime.IsZero() {
+		return sess.Events, nil
+	}
+
+	anchor, ok, err := c.loadLatestUserEvent(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return sess.Events, nil
+	}
+	sess.Events = append([]event.Event{anchor}, originalEvents...)
+	sess.ApplyEventFiltering(session.WithEventNum(limit), session.WithEventTime(afterTime))
+	return sess.Events, nil
+}
+
+func (c *Client) loadRecentEvents(
+	ctx context.Context,
+	key session.Key,
+	afterTime time.Time,
+	limit int,
+) ([]event.Event, error) {
+	minScore := "-inf"
+	if !afterTime.IsZero() {
+		minScore = fmt.Sprintf("%d", afterTime.UnixNano())
+	}
+
+	var events []event.Event
+	for offset := int64(0); ; {
+		batchSize := eventLoadBatchSize
+		if offset == 0 && limit > 0 && limit < batchSize {
+			batchSize = limit
+		}
+		if batchSize <= 0 {
+			break
+		}
+
+		rawEvents, scanned, err := c.loadEventBatch(ctx, key, minScore, offset, int64(batchSize))
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range rawEvents {
+			var evt event.Event
+			if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+				continue
+			}
+			if !afterTime.IsZero() && evt.Timestamp.Before(afterTime) {
+				continue
+			}
+			events = append(events, evt)
+			if limit > 0 && len(events) == limit {
+				break
+			}
+		}
+		offset += scanned
+		if scanned < int64(batchSize) || (limit > 0 && len(events) == limit) {
+			break
+		}
+	}
+	slices.Reverse(events)
+	return events, nil
+}
+
+func (c *Client) loadLatestUserEvent(
+	ctx context.Context,
+	key session.Key,
+) (event.Event, bool, error) {
+	for offset := int64(0); ; offset += userEventAnchorBatchSize {
+		rawEvents, scanned, err := c.loadEventBatch(
+			ctx, key, "-inf", offset, userEventAnchorBatchSize,
+		)
+		if err != nil {
+			return event.Event{}, false, err
+		}
+		for _, raw := range rawEvents {
+			var evt event.Event
+			if err := json.Unmarshal([]byte(raw), &evt); err != nil {
+				continue
+			}
+			if evt.IsUserMessage() {
+				return evt, true, nil
+			}
+		}
+		if scanned < userEventAnchorBatchSize {
+			return event.Event{}, false, nil
+		}
+	}
+}
+
+func (c *Client) loadEventBatch(
+	ctx context.Context,
+	key session.Key,
+	minScore string,
+	offset int64,
+	batchSize int64,
+) ([]string, int64, error) {
+	result, err := c.runScript(ctx, luaLoadEvents,
+		[]string{
+			c.keys.EventDataKey(key),
+			c.keys.EventTimeIndexKey(key),
+		},
+		minScore, offset, batchSize,
+	).StringSlice()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	if len(result) == 0 {
+		return nil, 0, nil
+	}
+	scanned, err := strconv.ParseInt(result[0], 10, 64)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parse scanned event count: %w", err)
+	}
+	return result[1:], scanned, nil
 }
 
 // loadAndMergeAppState loads and merges app state.
@@ -685,26 +805,11 @@ func (c *Client) loadSessionBasic(
 	sess.UpdatedAt = meta.UpdatedAt
 
 	if !listOnlyMeta {
-		result, err := c.runScript(ctx, luaLoadEvents,
-			[]string{
-				c.keys.EventDataKey(key),
-				c.keys.EventTimeIndexKey(key),
-			},
-			0, int64(-1), 0,
-		).StringSlice()
-		if err != nil && err != redis.Nil {
+		events, err := c.loadSessionEvents(ctx, key, limit, afterTime)
+		if err != nil {
 			return nil, fmt.Errorf("load events: %w", err)
 		}
-
-		for _, evtJSON := range result {
-			var evt event.Event
-			if err := json.Unmarshal([]byte(evtJSON), &evt); err != nil {
-				continue
-			}
-			sess.Events = append(sess.Events, evt)
-		}
-
-		sess.ApplyEventFiltering(session.WithEventNum(limit), session.WithEventTime(afterTime))
+		sess.Events = events
 	}
 
 	sess.ServiceMeta = map[string]string{util.ServiceMetaStorageTypeKey: util.StorageTypeHashIdx}

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -741,7 +741,145 @@ func TestClient_GetSession_WithEventLimit(t *testing.T) {
 	sess, err := c.GetSession(ctx, key, 2, time.Time{})
 	require.NoError(t, err)
 	require.NotNil(t, sess)
-	assert.Len(t, sess.Events, 2)
+	require.Len(t, sess.Events, 2)
+	assert.Equal(t, "e3", sess.Events[0].ID)
+	assert.Equal(t, "e4", sess.Events[1].ID)
+}
+
+func TestClient_GetSession_EventLimitPreservesUserAnchor(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "anchor1"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	baseTime := time.Now()
+	require.NoError(t, c.AppendEvent(ctx, key, makeTestEvent("e0", baseTime)))
+	for i := 1; i < 4; i++ {
+		evt := makeTestEvent(fmt.Sprintf("e%d", i), baseTime.Add(time.Duration(i)*time.Second))
+		evt.Response.Choices[0].Message.Role = model.RoleAssistant
+		require.NoError(t, c.AppendEvent(ctx, key, evt))
+	}
+
+	sess, err := c.GetSession(ctx, key, 2, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 3)
+	assert.Equal(t, []string{"e0", "e2", "e3"}, []string{
+		sess.Events[0].ID, sess.Events[1].ID, sess.Events[2].ID,
+	})
+}
+
+func TestClient_GetSession_AfterTimeAndLimitPreserveUserAnchor(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "anchor-after"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	baseTime := time.Now()
+	require.NoError(t, c.AppendEvent(ctx, key, makeTestEvent("e0", baseTime)))
+	for i := 1; i < 3; i++ {
+		evt := makeTestEvent(fmt.Sprintf("e%d", i), baseTime.Add(time.Duration(i)*time.Second))
+		evt.Response.Choices[0].Message.Role = model.RoleAssistant
+		require.NoError(t, c.AppendEvent(ctx, key, evt))
+	}
+
+	sess, err := c.GetSession(ctx, key, 2, baseTime.Add(time.Second))
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 3)
+	assert.Equal(t, []string{"e0", "e1", "e2"}, []string{
+		sess.Events[0].ID, sess.Events[1].ID, sess.Events[2].ID,
+	})
+}
+
+func TestClient_GetSession_EventLimitUsesIndexOrderForEqualTimestamps(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "same-time"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	timestamp := time.Now()
+	for _, id := range []string{"c", "a", "b"} {
+		require.NoError(t, c.AppendEvent(ctx, key, makeTestEvent(id, timestamp)))
+	}
+
+	sess, err := c.GetSession(ctx, key, 2, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 2)
+	assert.Equal(t, []string{"b", "c"}, []string{sess.Events[0].ID, sess.Events[1].ID})
+}
+
+func TestClient_GetSession_EventLimitBackfillsMissingPayload(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "missing-payload"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	baseTime := time.Now()
+	require.NoError(t, c.AppendEvent(ctx, key, makeTestEvent("e0", baseTime)))
+	require.NoError(t, rdb.ZAdd(ctx, c.keys.EventTimeIndexKey(key), redis.Z{
+		Score:  float64(baseTime.Add(time.Second).UnixNano()),
+		Member: "orphan",
+	}).Err())
+	require.NoError(t, c.AppendEvent(ctx, key, makeTestEvent("e2", baseTime.Add(2*time.Second))))
+
+	sess, err := c.GetSession(ctx, key, 2, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 2)
+	assert.Equal(t, []string{"e0", "e2"}, []string{sess.Events[0].ID, sess.Events[1].ID})
+}
+
+func TestClient_GetSession_EventLimitBeyondLuaStackLimit(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "large-history"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	const eventCount = 8200
+	baseTime := time.Unix(1_700_000_000, 0)
+	pipe := rdb.Pipeline()
+	for i := 0; i < eventCount; i++ {
+		id := fmt.Sprintf("e%05d", i)
+		evtJSON, err := json.Marshal(makeTestEvent(id, baseTime.Add(time.Duration(i)*time.Second)))
+		require.NoError(t, err)
+		pipe.HSet(ctx, c.keys.EventDataKey(key), id, evtJSON)
+		pipe.ZAdd(ctx, c.keys.EventTimeIndexKey(key), redis.Z{
+			Score:  float64(baseTime.Add(time.Duration(i) * time.Second).UnixNano()),
+			Member: id,
+		})
+	}
+	_, err = pipe.Exec(ctx)
+	require.NoError(t, err)
+
+	sess, err := c.GetSession(ctx, key, 200, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 200)
+	assert.Equal(t, "e08000", sess.Events[0].ID)
+	assert.Equal(t, "e08199", sess.Events[199].ID)
+
+	sess, err = c.GetSession(ctx, key, eventCount, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, eventCount)
+	assert.Equal(t, "e00000", sess.Events[0].ID)
+	assert.Equal(t, "e08199", sess.Events[eventCount-1].ID)
 }
 
 func TestClient_GetSession_WithAfterTime(t *testing.T) {
@@ -824,6 +962,33 @@ func TestClient_ListSessions_WithEventsAndAppState(t *testing.T) {
 	}
 }
 
+func TestClient_ListSessions_WithEventLimit(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	userKey := session.UserKey{AppName: "app", UserID: "u1"}
+	key := session.Key{AppName: userKey.AppName, UserID: userKey.UserID, SessionID: "list-limit"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	baseTime := time.Now()
+	for i := 0; i < 5; i++ {
+		require.NoError(t, c.AppendEvent(
+			ctx,
+			key,
+			makeTestEvent(fmt.Sprintf("e%d", i), baseTime.Add(time.Duration(i)*time.Second)),
+		))
+	}
+
+	sessions, err := c.ListSessions(ctx, userKey, 2, time.Time{}, false)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.Len(t, sessions[0].Events, 2)
+	assert.Equal(t, []string{"e3", "e4"}, []string{
+		sessions[0].Events[0].ID, sessions[0].Events[1].ID,
+	})
+}
+
 func TestClient_loadAndAttachTrackEvents_NilSession(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())
@@ -865,25 +1030,6 @@ func TestClient_loadAndMergeAppState_NilSession(t *testing.T) {
 
 	// Should not panic
 	c.loadAndMergeAppState(ctx, key, nil)
-}
-
-func Test_parseEvents_EmptyObject(t *testing.T) {
-	// Lua cjson encodes empty arrays as {} (JSON object)
-	r := &sessionDataResult{Events: json.RawMessage(`{}`)}
-	result := r.parseEvents()
-	assert.Nil(t, result)
-}
-
-func Test_parseEvents_EmptyInput(t *testing.T) {
-	r := &sessionDataResult{Events: nil}
-	result := r.parseEvents()
-	assert.Nil(t, result)
-}
-
-func Test_parseEvents_ValidArray(t *testing.T) {
-	r := &sessionDataResult{Events: json.RawMessage(`["a","b"]`)}
-	result := r.parseEvents()
-	assert.Equal(t, []string{"a", "b"}, result)
 }
 
 func TestClient_DeleteEvent_Error(t *testing.T) {

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -842,6 +842,87 @@ func TestClient_GetSession_EventLimitBackfillsMissingPayload(t *testing.T) {
 	assert.Equal(t, []string{"e0", "e2"}, []string{sess.Events[0].ID, sess.Events[1].ID})
 }
 
+func TestClient_GetSession_EventLimitWithoutUserAnchor(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "no-user-anchor"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	baseTime := time.Now()
+	for i := 0; i < 3; i++ {
+		evt := makeTestEvent(fmt.Sprintf("e%d", i), baseTime.Add(time.Duration(i)*time.Second))
+		evt.Response.Choices[0].Message.Role = model.RoleAssistant
+		require.NoError(t, c.AppendEvent(ctx, key, evt))
+	}
+
+	sess, err := c.GetSession(ctx, key, 2, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Empty(t, sess.Events)
+}
+
+func TestClient_GetSession_EventLimitSkipsCorruptedAnchorPayload(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "bad-anchor"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	baseTime := time.Now()
+	require.NoError(t, c.AppendEvent(ctx, key, makeTestEvent("e0", baseTime)))
+	require.NoError(t, rdb.HSet(ctx, c.keys.EventDataKey(key), "bad", "not-json").Err())
+	require.NoError(t, rdb.ZAdd(ctx, c.keys.EventTimeIndexKey(key), redis.Z{
+		Score:  float64(baseTime.Add(time.Second).UnixNano()),
+		Member: "bad",
+	}).Err())
+	for i := 2; i < 4; i++ {
+		evt := makeTestEvent(fmt.Sprintf("e%d", i), baseTime.Add(time.Duration(i)*time.Second))
+		evt.Response.Choices[0].Message.Role = model.RoleAssistant
+		require.NoError(t, c.AppendEvent(ctx, key, evt))
+	}
+
+	sess, err := c.GetSession(ctx, key, 2, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 3)
+	assert.Equal(t, []string{"e0", "e2", "e3"}, []string{
+		sess.Events[0].ID, sess.Events[1].ID, sess.Events[2].ID,
+	})
+}
+
+func TestClient_GetSession_AfterTimeBackfillsScoreCandidate(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "after-time-backfill"}
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	baseTime := time.Unix(1_700_000_000, 0)
+	afterTime := baseTime.Add(time.Second)
+	valid := makeTestEvent("valid", afterTime)
+	stale := makeTestEvent("stale", baseTime)
+	validJSON, err := json.Marshal(valid)
+	require.NoError(t, err)
+	staleJSON, err := json.Marshal(stale)
+	require.NoError(t, err)
+	require.NoError(t, rdb.HSet(ctx, c.keys.EventDataKey(key),
+		valid.ID, validJSON, stale.ID, staleJSON).Err())
+	require.NoError(t, rdb.ZAdd(ctx, c.keys.EventTimeIndexKey(key),
+		redis.Z{Score: float64(afterTime.UnixNano()), Member: valid.ID},
+		redis.Z{Score: float64(afterTime.Add(time.Second).UnixNano()), Member: stale.ID},
+	).Err())
+
+	sess, err := c.GetSession(ctx, key, 1, afterTime)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, sess.Events, 1)
+	assert.Equal(t, valid.ID, sess.Events[0].ID)
+}
+
 func TestClient_GetSession_EventLimitBeyondLuaStackLimit(t *testing.T) {
 	_, rdb := setupMiniredis(t)
 	c := NewClient(rdb, defaultConfig())
@@ -1131,6 +1212,30 @@ func TestLoadSessionComplete_LuaError(t *testing.T) {
 	_, err = c.loadSessionComplete(ctx, key, metaJSON, 0, time.Time{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "load session data")
+}
+
+func TestLoadSessionDataViaLua_RedisError(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "state-lua-err"}
+
+	mr.Close()
+
+	_, err := c.loadSessionDataViaLua(ctx, key)
+	require.Error(t, err)
+}
+
+func TestLoadLatestUserEvent_RedisError(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "anchor-lua-err"}
+
+	mr.Close()
+
+	_, _, err := c.loadLatestUserEvent(ctx, key)
+	require.Error(t, err)
 }
 
 func TestGetSession_WithUserState(t *testing.T) {

--- a/session/redis/internal/hashidx/track_test.go
+++ b/session/redis/internal/hashidx/track_test.go
@@ -12,6 +12,7 @@ package hashidx
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -216,6 +217,50 @@ func TestClient_GetTrackEvents(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, result["nonexistent"])
 	})
+}
+
+func TestClient_GetTrackEvents_BeyondLuaStackLimit(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "large-track"}
+	track := session.Track("beta")
+
+	_, err := c.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+
+	const eventCount = 8200
+	baseTime := time.Unix(1_700_000_000, 0)
+	pipe := rdb.Pipeline()
+	for i := 0; i < eventCount; i++ {
+		id := fmt.Sprintf("e%05d", i)
+		trackEvent := session.TrackEvent{
+			Track:     track,
+			Payload:   json.RawMessage(fmt.Sprintf(`%d`, i)),
+			Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+		}
+		eventJSON, err := json.Marshal(trackEvent)
+		require.NoError(t, err)
+		pipe.HSet(ctx, c.keys.TrackDataKey(key, track), id, eventJSON)
+		pipe.ZAdd(ctx, c.keys.TrackTimeIndexKey(key, track), redis.Z{
+			Score:  float64(trackEvent.Timestamp.UnixNano()),
+			Member: id,
+		})
+	}
+	_, err = pipe.Exec(ctx)
+	require.NoError(t, err)
+
+	result, err := c.GetTrackEvents(ctx, key, []session.Track{track}, 200, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, result[track], 200)
+	assert.JSONEq(t, `8000`, string(result[track][0].Payload))
+	assert.JSONEq(t, `8199`, string(result[track][199].Payload))
+
+	result, err = c.GetTrackEvents(ctx, key, []session.Track{track}, 0, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, result[track], eventCount)
+	assert.JSONEq(t, `0`, string(result[track][0].Payload))
+	assert.JSONEq(t, `8199`, string(result[track][eventCount-1].Payload))
 }
 
 func TestClient_ListTracksForSession(t *testing.T) {

--- a/session/redis/service_event_test.go
+++ b/session/redis/service_event_test.go
@@ -298,6 +298,7 @@ func TestService_SessionEventLimit_TrimsOldest(t *testing.T) {
 	service, err := NewService(
 		WithRedisClientURL(redisURL),
 		WithSessionEventLimit(limit),
+		WithCompatMode(CompatModeNone),
 	)
 	require.NoError(t, err)
 	defer service.Close()

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -1065,7 +1065,8 @@ func TestService_WithDisableScriptCache(t *testing.T) {
 	// WithDisableScriptCache forces every Lua script to run via EVAL instead of
 	// the default EVALSHA-first Script.Run. Exercise a full session round-trip to
 	// make sure the EVAL path is functionally identical: AppendEvent runs
-	// luaAppendEvent and GetSession runs luaLoadSessionData, both via EVAL here.
+	// luaAppendEvent, while GetSession runs the bounded event loader and
+	// luaLoadSessionData, all via EVAL here.
 	service, err := NewService(
 		WithRedisClientURL(redisURL),
 		WithDisableScriptCache(true),
@@ -1097,7 +1098,7 @@ func TestService_WithDisableScriptCache(t *testing.T) {
 	sessions, err := service.ListSessions(ctx, session.UserKey{AppName: "app", UserID: "u1"})
 	require.NoError(t, err)
 	assert.Len(t, sessions, 1)
-	assert.Equal(t, []string{"eval", "eval", "eval"}, recorder.snapshot())
+	assert.Equal(t, []string{"eval", "eval", "eval", "eval"}, recorder.snapshot())
 }
 
 func TestService_WithDisableScriptCache_ZSetSummary(t *testing.T) {


### PR DESCRIPTION
## What changed

Hash-indexed Redis sessions now materialize event payloads from bounded time-index windows instead of reading the complete index before applying the requested event limit. Large or explicitly unbounded reads remain supported through fixed-size batches. ListSessions uses the same bounded event path, and hash-indexed track payloads are also fetched in fixed-size HMGET batches.

## Why

The previous session loader expanded every event ID into one HMGET call. At roughly 8,000 stored events, Redis Lua exceeded its argument stack and failed with `too many results to unpack`, even when callers requested only a small recent window.

The new path pushes the time and count window into the sorted-set query and caps each HMGET at 512 fields. It preserves chronological ordering, missing-payload backfill, exact event-time filtering, and the existing user-message anchor behavior.

## Testing

- `cd session/redis && GOWORK=off go test ./... -count=1`
- Manually seeded 8,200 hash-indexed events in Redis 8.10.1 and verified a 200-event session read completes without the Lua unpack error.
- Verified an unbounded 8,200-event hash-indexed track read completes through batched HMGET calls.

## Notes for reviewers

- This change is limited to HashIdx storage; the legacy zset implementation is unchanged.
- There are no public API or persistence schema changes.
- Existing event filtering may return `N+1` events when an older user message is required as the conversation anchor; that behavior is intentionally preserved.