### PR TITLE
session: add end-to-end summary diagnostics

### DIFF
--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -1690,8 +1690,9 @@ summary from generation to injection. All of them are emitted on the request
 or job context, so they share your existing trace correlation.
 
 **No record contains prompt text, summary text, event content, model output,
-raw error text, connection strings, or credentials.** User and session
-identifiers are never logged.
+raw error text, connection strings, or credentials.** Framework-owned user
+and session identifiers are never logged. Caller-supplied `filter_key` values
+are logged and are outside that guarantee.
 
 `EventFilterKey` / `filter_key` is a caller-supplied scope identifier. It must
 not contain credentials, secrets, or user-private data. Diagnostic records log
@@ -1738,7 +1739,7 @@ injection text, and compaction decisions stay on their existing code paths.
 
 | Record | Emitted when | Key fields |
 | --- | --- | --- |
-| `Session summary result` | Once per summary target, after generation and persistence | `schema_version`, `outcome`, `dispatch`, `target_kind`, `filter_key`, `filter_key_truncated`, `triggered`, `trigger`, `trigger_metric`, `trigger_value`, `trigger_threshold`, `threshold_ratio`, `context_window`, `summary_view_present`, `summary_view_bound`, `binding_reason`, `input_source`, `selection_reason`, `eligible_events`, `skip_recent_requested`, `skip_recent_applied`, `selected_events`, `model_call_status`, `updated`, `boundary_advanced`, `persist_result` |
+| `Session summary result` | Once per summary target, after the summary attempt completes | `schema_version`, `outcome`, `dispatch`, `target_kind`, `filter_key`, `filter_key_truncated`, `triggered`, `trigger`, `trigger_metric`, `trigger_value`, `trigger_threshold`, `threshold_ratio`, `context_window`, `summary_view_present`, `summary_view_bound`, `binding_reason`, `input_source`, `selection_reason`, `eligible_events`, `skip_recent_requested`, `skip_recent_applied`, `selected_events`, `model_call_status`, `updated`, `boundary_advanced`, `persist_result` |
 | `Session summary cascade result` | Once per cascade dispatch that fans a branch trigger out to the full-session target | `schema_version`, `outcome`, `mode`, `trigger_filter_key`, `trigger_filter_key_truncated`, `targets`, `source_materialized`, `action`, `invariant` |
 | `Session summary injection result` | Once per model request that uses session summaries, after the returned response sequence finishes or is stopped early; if the model call fails before returning a response sequence, the record is emitted immediately | `schema_version`, `outcome`, `agent`, `filter_key`, `filter_key_truncated`, `lookup_strategy`, `lookup_result`, `selected`, `selected_block_present`, `stored_summaries`, `matching_candidates`, `full_session_summary`, `session_events`, `history_messages`, `request_messages` |
 | `Pre-LLM context compaction result` | Once per synchronous compaction attempt before an LLM call | `schema_version`, `outcome`, `filter_key`, `filter_key_truncated`, `request_tokens`, `threshold`, `context_window`, `messages`, `summary_view_bound`, `binding_reason` |

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -1827,11 +1827,16 @@ callback:
 
 All four counts are `-1` when `selection_reason` is `custom` or `none`.
 
-`trigger` and `trigger_metric` are normalized to the framework's own vocabulary.
-Any other value, including one set by a custom summarizer or by a caller-supplied
-`summary.Report`, is reported as `custom`, so these fields stay bounded and never
-carry application strings. `trigger_value`, `trigger_threshold`,
-`threshold_ratio`, and `context_window` are reported unchanged.
+`trigger` and `trigger_metric` are taken only from this attempt's internal
+trigger recorder. Writing `summary.Report.Trigger` from a custom summarizer or
+a caller-supplied report is not an observation: a fired unpublished gate
+reports `triggered=true` with `trigger=none`, and an unfired unpublished gate
+reports `outcome=unobserved` and `trigger=none`. Leftover `Report.Trigger`
+values are never copied into the record. When a trigger observation is
+published, names and metrics outside the framework vocabulary are normalized
+to `custom`, so these fields stay bounded and never carry application
+strings. `trigger_value`, `trigger_threshold`, `threshold_ratio`, and
+`context_window` are reported unchanged.
 
 ### Tracing one incident
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -1567,6 +1567,11 @@ evt.FilterKey = "my-app/user-messages"
 evt.FilterKey = "user-messages"
 ```
 
+`EventFilterKey` / `filter_key` is a caller-supplied scope identifier. Do not
+put credentials, secrets, or user-private data in it. Diagnostic logs may
+include the original value, subject to the length limit described in
+[Diagnosing Summaries in Production](#diagnosing-summaries-in-production).
+
 ### Generating Summaries by Type
 
 ```go
@@ -1674,6 +1679,188 @@ sessionService, err := mysql.NewService(
 4. **Customize prompts**: Tailor summary prompts to your application needs. For example, if building a customer support Agent, focus on key issues and solutions
 5. **Balance word limits**: Set `WithMaxSummaryWords` to balance context preservation and token usage. Typical range is 100-300 words
 6. **Test trigger conditions**: Experiment with different `WithChecksAny` and `WithChecksAll` combinations to find the optimal balance between summary frequency and cost
+
+## Diagnosing Summaries in Production
+
+Summary generation and persistence diagnostics are not returned as the
+user-visible model response. Generation may run in a background async worker
+or synchronously inside a request, for example pre-LLM context compaction.
+The framework emits four stable log records that let you follow one session
+summary from generation to injection. All of them are emitted on the request
+or job context, so they share your existing trace correlation.
+
+**No record contains prompt text, summary text, event content, model output,
+raw error text, connection strings, or credentials.** User and session
+identifiers are never logged.
+
+`EventFilterKey` / `filter_key` is a caller-supplied scope identifier. It must
+not contain credentials, secrets, or user-private data. Diagnostic records log
+the original value (never hashed). The displayed value is at most 255 Unicode
+code points, matching the common `session_summaries.filter_key VARCHAR(255)`
+schema, and that budget includes the truncation marker. Keys within the limit
+are logged unchanged. Oversize keys keep a leading prefix so that prefix plus
+the `...` marker still totals 255 code points, and the record sets
+`filter_key_truncated=true` (or `trigger_filter_key_truncated=true` on cascade
+records). Empty keys stay visible as `filter_key=""`. Truncation affects
+diagnostic display only; stored keys and queries are unchanged.
+
+Every record starts with `schema_version=1` immediately after the record name
+so collectors can detect a later incompatible field change. The version stays
+at 1 until this diagnostic schema is formally published.
+
+These records observe generation, persistence, cascade, injection, and pre-LLM
+compaction. They do not add a public SessionService API and they do not add a
+diagnostics enable switch.
+
+Proven return contracts against the pre-diagnostics Redis path:
+
+- `CreateSessionSummary` still returns a nil error when the set-if-newer Lua
+  script itself succeeds, including when the reply is not `int64` 0 or 1. An
+  unrecognized reply is classified as `persist_result=unknown` /
+  `outcome=unknown_write` at Debug. It is not stored, stale, `success`, or
+  `persistence_error`, and it does not change the method's return value.
+- A real script, marshal, or expire failure still returns an error and is
+  reported as `persist_result=error` / `outcome=persistence_error`.
+
+Summary selection, cutoff, cascade call order, `force` values, error wrapping,
+injection text, and compaction decisions stay on their existing code paths.
+
+### Diagnostic cost
+
+- An ordinary summary-attempt record is constant-size metadata: counts, enums,
+  timings, and a truncated filter-key display. It does not copy events,
+  prompts, or summary text.
+- Checking whether a selected injection block is still present is
+  `O(total request message bytes)`. That scan runs only when session-summary
+  injection is enabled for the request. The request is not copied.
+
+### Record names and key fields
+
+| Record | Emitted when | Key fields |
+| --- | --- | --- |
+| `Session summary result` | Once per summary target, after generation and persistence | `schema_version`, `outcome`, `dispatch`, `target_kind`, `filter_key`, `filter_key_truncated`, `triggered`, `trigger`, `trigger_metric`, `trigger_value`, `trigger_threshold`, `threshold_ratio`, `context_window`, `summary_view_present`, `summary_view_bound`, `binding_reason`, `input_source`, `selection_reason`, `eligible_events`, `skip_recent_requested`, `skip_recent_applied`, `selected_events`, `model_call_status`, `updated`, `boundary_advanced`, `persist_result` |
+| `Session summary cascade result` | Once per cascade dispatch that fans a branch trigger out to the full-session target | `schema_version`, `outcome`, `mode`, `trigger_filter_key`, `trigger_filter_key_truncated`, `targets`, `source_materialized`, `action`, `invariant` |
+| `Session summary injection result` | Once per model request that uses session summaries, after `GenerateContent` returns | `schema_version`, `outcome`, `agent`, `filter_key`, `filter_key_truncated`, `lookup_strategy`, `lookup_result`, `selected`, `selected_block_present`, `stored_summaries`, `matching_candidates`, `full_session_summary`, `session_events`, `history_messages`, `request_messages` |
+| `Pre-LLM context compaction result` | Once per synchronous compaction attempt before an LLM call | `schema_version`, `outcome`, `filter_key`, `filter_key_truncated`, `request_tokens`, `threshold`, `context_window`, `messages`, `summary_view_bound`, `binding_reason` |
+
+`Session summary result` outcomes:
+
+| Outcome | Level | Meaning |
+| --- | --- | --- |
+| `success` | Info | A new summary was generated and the backend confirmed the write |
+| `copied` | Debug | A cascade reused an existing summary for this target without a model call |
+| `below_threshold` | Debug | A trigger check ran and stayed below its threshold |
+| `no_delta` | Debug | No event was appended after the recorded summary boundary |
+| `no_content` | Debug | No eligible content reached the summary model |
+| `cascade_suppressed` | Debug | A full-session target was skipped because it was only requested as a branch cascade |
+| `unsafe_view` | Warn | Content existed, but the model-visible view was not bound to the request the model answered, so nothing could be summarized safely |
+| `summary_error` | Warn | The summarization stage failed. `model_call_status` separates a failed model call from a pre-model build, a custom response, or an unobserved custom summarizer |
+| `context_error` | Warn | The summary context was canceled or expired |
+| `persistence_error` | Warn | The backend write failed |
+| `stale_write` | Debug | The backend skipped the write because a newer summary is already persisted. This is a successful set-if-newer no-op and can happen under normal concurrency |
+| `unknown_write` | Debug | The backend write finished without error, but the set-if-newer reply could not be classified as stored or stale. This is diagnostic uncertainty, not a business failure |
+| `not_stored` | Warn | A summary was generated but the backend neither stored nor rejected it |
+| `no_update` | Warn | A triggered attempt produced no summary to store |
+
+`model_call_status` is a closed three-state field. Do not treat
+`unobserved` as "the model was not called":
+
+| `model_call_status` | Meaning |
+| --- | --- |
+| `called` | The built-in summarizer reached the summary model (`standalone` or `cache_safe_fork`) |
+| `custom_response` | A before-model callback supplied the summary response, so the provider was not called |
+| `unobserved` | No `Report.Call.Mode` was published, so a model call cannot be proven. Typical of a custom summarizer that does not fill `summary.Report` |
+
+`Session summary injection result` outcomes:
+
+| Outcome | Level | Meaning |
+| --- | --- | --- |
+| `injected` | Debug | The original summary block is still present in the same framework `model.Request` after `GenerateContent` returns (`selected_block_present=true`). This does not describe a provider payload |
+| `not_selected` | Debug | The session stores no summary yet |
+| `lookup_miss` | Debug | Summaries exist for other branches, but none in this request's scope |
+| `scope_mismatch` | Debug | A branch-scoped request found nothing in scope while a full-session summary exists outside it. Because no in-scope summary was selected, this request's summary cutoff stays zero, so the raw scoped history is kept at this stage. That does not depend on whether the unused full-session summary has a boundary |
+| `selected_block_missing` | Warn | A summary was selected (`selected=true`), but the original summary block is not observable in the same framework `model.Request` after `GenerateContent` returns. This does not claim the provider's final payload, and it does not mean the summary was never written into the request. For built-in providers that mutate the shared request in place, including OpenAI, this is usually in-place token tailoring |
+
+### How much history reached the summary model
+
+When `outcome` is `no_content` or `unsafe_view`, `selection_reason` names the
+exact stage that emptied the input, which is otherwise indistinguishable from
+an idle session:
+
+| `selection_reason` | Meaning |
+| --- | --- |
+| `selected` | Events reached the summary model |
+| `no_candidates` | The stage had no candidate event to consider at all |
+| `skip_recent_all` | The `WithSkipRecent` callback asked to skip at least as many events as were available |
+| `unsafe_prefix` | Events remained after skip-recent, but the retained prefix had neither a user message nor a prepended previous summary to anchor the summary, so it was dropped |
+| `session_filter_empty` | Candidates survived skip-recent and were then all removed by the summary's branch scoping |
+| `unbound_view` | A model-visible view existed but was not bound to the request the model answered |
+| `boundary_unmapped` | Selected items had no structural mapping to a stored event, so the summary was dropped rather than advance the boundary past content that cannot be located again |
+| `custom` | The summary call did not publish the built-in event selection, so counts are unknown |
+| `none` | No summarizer ran, so no selection was observed |
+
+The accompanying counts describe the stage that receives the `WithSkipRecent`
+callback:
+
+- `eligible_events` is the number of candidate events handed to that stage,
+  counted before skip-recent runs. For a bound model-visible view it includes a
+  prepended previous summary; for an unbound view it is the number of view items
+  that were not considered.
+- `skip_recent_requested` is the raw count your callback returned, so a callback
+  returning a nonsensical value stays visible. It is `0` when no callback is
+  configured.
+- `skip_recent_applied` is how many events skip-recent itself removed:
+  `clamp(skip_recent_requested, 0, eligible_events)`. An unsafe retained prefix,
+  session scoping, or an unmapped boundary is named by `selection_reason` and
+  `selected_events`, not counted here. For example `eligible_events=3`,
+  `skip_recent_requested=1`, `unsafe_prefix` reports `skip_recent_applied=1` and
+  `selected_events=0`.
+- `selected_events` is what finally reached the summary model, after skip-recent,
+  branch scoping, and boundary mapping.
+
+All four counts are `-1` when `selection_reason` is `custom` or `none`.
+
+`trigger` and `trigger_metric` are normalized to the framework's own vocabulary.
+Any other value, including one set by a custom summarizer or by a caller-supplied
+`summary.Report`, is reported as `custom`, so these fields stay bounded and never
+carry application strings. `trigger_value`, `trigger_threshold`,
+`threshold_ratio`, and `context_window` are reported unchanged.
+
+### Tracing one incident
+
+Follow the records in this order for a single request or session:
+
+1. **`Session summary result`** answers whether a summary was produced at all.
+   `triggered` plus the `trigger*` fields explain the gate decision;
+   `input_source`, `selection_reason`, and the event counts explain how much
+   history reached the model and which stage removed the rest;
+   `binding_reason` explains an `unsafe_view`; `persist_result` distinguishes a
+   backend-confirmed store from a stale skip, an unclassified write, or a
+   failed write.
+2. **`Session summary cascade result`** explains how a branch trigger reached
+   the full-session target. A branch that is not updated in this pass stops the
+   cascade (`action=skipped`, `invariant=ok`). `mode=dependent` is a sequential
+   multi-filter cascade, not concurrent generation. `invariant=violation` is
+   reserved for a full-session target that advanced without this-pass branch
+   materialization.
+3. **`Session summary injection result`** answers whether a later request
+   still carries the stored summary in the framework `model.Request` after
+   `GenerateContent` returns. Compare `lookup_strategy` (the scope you
+   configured, driven by `WithBranchFilterMode`) with `lookup_result` (what
+   that scope found) and `full_session_summary`. `scope_mismatch` means a
+   full-session summary was unused, not that scoped history was dropped:
+   because nothing in scope was selected, this request's summary cutoff stays
+   zero and the raw scoped history is kept at this stage.
+4. **`Pre-LLM context compaction result`** and the token tailoring records
+   explain what happened to the request after injection. A
+   `selected_block_missing` record next to a tailoring record, for a built-in
+   provider that mutates the shared request in place, means the original
+   summary block is no longer observable in the framework `model.Request`. A
+   custom `Model` that copies the request may leave the framework copy
+   unchanged, so this record still does not describe the provider payload.
+
+Set the framework log level to `debug` to see the routine records; at the
+default level only the Warn and Info records above are emitted.
 
 ## Performance Considerations
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -1740,7 +1740,7 @@ injection text, and compaction decisions stay on their existing code paths.
 | --- | --- | --- |
 | `Session summary result` | Once per summary target, after generation and persistence | `schema_version`, `outcome`, `dispatch`, `target_kind`, `filter_key`, `filter_key_truncated`, `triggered`, `trigger`, `trigger_metric`, `trigger_value`, `trigger_threshold`, `threshold_ratio`, `context_window`, `summary_view_present`, `summary_view_bound`, `binding_reason`, `input_source`, `selection_reason`, `eligible_events`, `skip_recent_requested`, `skip_recent_applied`, `selected_events`, `model_call_status`, `updated`, `boundary_advanced`, `persist_result` |
 | `Session summary cascade result` | Once per cascade dispatch that fans a branch trigger out to the full-session target | `schema_version`, `outcome`, `mode`, `trigger_filter_key`, `trigger_filter_key_truncated`, `targets`, `source_materialized`, `action`, `invariant` |
-| `Session summary injection result` | Once per model request that uses session summaries, after `GenerateContent` returns | `schema_version`, `outcome`, `agent`, `filter_key`, `filter_key_truncated`, `lookup_strategy`, `lookup_result`, `selected`, `selected_block_present`, `stored_summaries`, `matching_candidates`, `full_session_summary`, `session_events`, `history_messages`, `request_messages` |
+| `Session summary injection result` | Once per model request that uses session summaries, after the returned response sequence finishes or is stopped early; if the model call fails before returning a response sequence, the record is emitted immediately | `schema_version`, `outcome`, `agent`, `filter_key`, `filter_key_truncated`, `lookup_strategy`, `lookup_result`, `selected`, `selected_block_present`, `stored_summaries`, `matching_candidates`, `full_session_summary`, `session_events`, `history_messages`, `request_messages` |
 | `Pre-LLM context compaction result` | Once per synchronous compaction attempt before an LLM call | `schema_version`, `outcome`, `filter_key`, `filter_key_truncated`, `request_tokens`, `threshold`, `context_window`, `messages`, `summary_view_bound`, `binding_reason` |
 
 `Session summary result` outcomes:
@@ -1775,11 +1775,11 @@ injection text, and compaction decisions stay on their existing code paths.
 
 | Outcome | Level | Meaning |
 | --- | --- | --- |
-| `injected` | Debug | The original summary block is still present in the same framework `model.Request` after `GenerateContent` returns (`selected_block_present=true`). This does not describe a provider payload |
+| `injected` | Debug | The original summary block is still present in the same framework `model.Request` after the returned response sequence finishes or is stopped early (`selected_block_present=true`). If the model call fails before returning a response sequence, this is observed immediately. This does not describe a provider payload |
 | `not_selected` | Debug | The session stores no summary yet |
 | `lookup_miss` | Debug | Summaries exist for other branches, but none in this request's scope |
 | `scope_mismatch` | Debug | A branch-scoped request found nothing in scope while a full-session summary exists outside it. Because no in-scope summary was selected, this request's summary cutoff stays zero, so the raw scoped history is kept at this stage. That does not depend on whether the unused full-session summary has a boundary |
-| `selected_block_missing` | Warn | A summary was selected (`selected=true`), but the original summary block is not observable in the same framework `model.Request` after `GenerateContent` returns. This does not claim the provider's final payload, and it does not mean the summary was never written into the request. For built-in providers that mutate the shared request in place, including OpenAI, this is usually in-place token tailoring |
+| `selected_block_missing` | Warn | A summary was selected (`selected=true`), but the original summary block is not observable in the same framework `model.Request` after the returned response sequence finishes or is stopped early. If the model call fails before returning a response sequence, this is observed immediately. This does not claim the provider's final payload, and it does not mean the summary was never written into the request. For built-in providers that mutate the shared request in place, including OpenAI, this is usually in-place token tailoring |
 
 ### How much history reached the summary model
 
@@ -1845,7 +1845,9 @@ Follow the records in this order for a single request or session:
    materialization.
 3. **`Session summary injection result`** answers whether a later request
    still carries the stored summary in the framework `model.Request` after
-   `GenerateContent` returns. Compare `lookup_strategy` (the scope you
+   the returned response sequence finishes or is stopped early. If the model
+   call fails before returning a response sequence, this is observed
+   immediately. Compare `lookup_strategy` (the scope you
    configured, driven by `WithBranchFilterMode`) with `lookup_result` (what
    that scope found) and `full_session_summary`. `scope_mismatch` means a
    full-session summary was unused, not that scoped history was dropped:
@@ -1859,8 +1861,9 @@ Follow the records in this order for a single request or session:
    custom `Model` that copies the request may leave the framework copy
    unchanged, so this record still does not describe the provider payload.
 
-Set the framework log level to `debug` to see the routine records; at the
-default level only the Warn and Info records above are emitted.
+Routine Debug records such as `injected`, healthy cascade results, `copied`,
+and `below_threshold` require the framework log level to be `debug`. At the
+normal Info level only the Info and Warn outcomes listed above are visible.
 
 ## Performance Considerations
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -577,7 +577,13 @@ For cache-safe forking, `report.Call.Mode` is `cache_safe_fork` and the request
 estimate is computed from the forked parent request plus the appended summary
 instruction. For standalone summary prompts, the mode is `standalone`. If a
 `BeforeModel` callback returns a custom response and no summary model request is
-sent, the mode is `custom_response` and the prompt estimate remains zero.
+sent for that attempt, the mode is `custom_response` and the prompt estimate
+remains zero. `Report.Call.Mode` describes the last summary attempt. In a mixed
+retry where an earlier attempt called the provider and the final attempt used a
+custom response, it is therefore `custom_response`; usage fields may still
+contain provider usage observed on the earlier attempt. The structured
+`model_call_status` diagnostic instead aggregates the whole summary operation
+and reports `called` when any attempt called the provider.
 
 Advanced integrations can attach a report before entering a higher-level
 summary flow with `summary.ContextWithReport(ctx, report)` and retrieve it with
@@ -1852,12 +1858,13 @@ Follow the records in this order for a single request or session:
 2. **`Session summary cascade result`** explains how a branch trigger reached
    the full-session target. `source_materialized` is this-pass branch
    materialization only. `action=copied` requires a successful copy;
-   `action=dependent` requires that the full-session target started. Otherwise
-   the cascade is `action=skipped` and `invariant=ok`, including a branch that
-   did not update and a materialized source that never copied or started the
-   dependent target. `mode=dependent` is a sequential multi-filter cascade, not
-   concurrent generation. `invariant=violation` is reserved for a full-session
-   target that advanced without this-pass branch materialization.
+   `action=dependent` requires that the full-session target started. Otherwise,
+   when the full-session target did not advance independently, the cascade is
+   `action=skipped` and `invariant=ok`, including a branch that did not update
+   and a materialized source that never copied or started the dependent target.
+   `mode=dependent` is a sequential multi-filter cascade, not concurrent
+   generation. `invariant=violation` is reserved for a full-session target that
+   advanced without this-pass branch materialization.
 3. **`Session summary injection result`** answers whether a later request
    still carries the stored summary in the framework `model.Request` after
    the returned response sequence finishes or is stopped early. If the model

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -1692,7 +1692,9 @@ or job context, so they share your existing trace correlation.
 **No record contains prompt text, summary text, event content, model output,
 raw error text, connection strings, or credentials.** Framework-owned user
 and session identifiers are never logged. Caller-supplied `filter_key` values
-are logged and are outside that guarantee.
+are logged and are outside that guarantee. Caller-supplied `agent` names are
+also logged. Do not put credentials, secrets, or user-private data in an agent
+name. The framework does not hash or redact these names.
 
 `EventFilterKey` / `filter_key` is a caller-supplied scope identifier. It must
 not contain credentials, secrets, or user-private data. Diagnostic records log
@@ -1703,7 +1705,8 @@ are logged unchanged. Oversize keys keep a leading prefix so that prefix plus
 the `...` marker still totals 255 code points, and the record sets
 `filter_key_truncated=true` (or `trigger_filter_key_truncated=true` on cascade
 records). Empty keys stay visible as `filter_key=""`. Truncation affects
-diagnostic display only; stored keys and queries are unchanged.
+diagnostic display only; stored keys and queries are unchanged. `agent` uses
+the same bounded `%q` display rules and an `agent_truncated` flag.
 
 Every record starts with `schema_version=1` immediately after the record name
 so collectors can detect a later incompatible field change. The version stays
@@ -1741,8 +1744,8 @@ injection text, and compaction decisions stay on their existing code paths.
 | --- | --- | --- |
 | `Session summary result` | Once per summary target, after the summary attempt completes | `schema_version`, `outcome`, `dispatch`, `target_kind`, `filter_key`, `filter_key_truncated`, `triggered`, `trigger`, `trigger_metric`, `trigger_value`, `trigger_threshold`, `threshold_ratio`, `context_window`, `summary_view_present`, `summary_view_bound`, `binding_reason`, `input_source`, `selection_reason`, `eligible_events`, `skip_recent_requested`, `skip_recent_applied`, `selected_events`, `model_call_status`, `updated`, `boundary_advanced`, `persist_result` |
 | `Session summary cascade result` | Once per cascade dispatch that fans a branch trigger out to the full-session target | `schema_version`, `outcome`, `mode`, `trigger_filter_key`, `trigger_filter_key_truncated`, `targets`, `source_materialized`, `action`, `invariant` |
-| `Session summary injection result` | Once per model request that uses session summaries, after the returned response sequence finishes or is stopped early; if the model call fails before returning a response sequence, the record is emitted immediately | `schema_version`, `outcome`, `agent`, `filter_key`, `filter_key_truncated`, `lookup_strategy`, `lookup_result`, `selected`, `selected_block_present`, `stored_summaries`, `matching_candidates`, `full_session_summary`, `session_events`, `history_messages`, `request_messages` |
-| `Pre-LLM context compaction result` | Once per synchronous compaction attempt before an LLM call | `schema_version`, `outcome`, `filter_key`, `filter_key_truncated`, `request_tokens`, `threshold`, `context_window`, `messages`, `summary_view_bound`, `binding_reason` |
+| `Session summary injection result` | Once per model request that uses session summaries, after the returned response sequence finishes or is stopped early; if the model call fails before returning a response sequence, the record is emitted immediately | `schema_version`, `outcome`, `agent`, `agent_truncated`, `filter_key`, `filter_key_truncated`, `lookup_strategy`, `lookup_result`, `selected`, `block_text_present`, `stored_summaries`, `matching_candidates`, `full_session_summary`, `session_events`, `history_messages`, `request_messages` |
+| `Pre-LLM context compaction result` | Once per synchronous compaction attempt before an LLM call | `schema_version`, `outcome`, `agent`, `agent_truncated`, `filter_key`, `filter_key_truncated`, `request_tokens`, `threshold`, `context_window`, `messages`, `summary_view_bound`, `binding_reason` |
 
 `Session summary result` outcomes:
 
@@ -1752,14 +1755,15 @@ injection text, and compaction decisions stay on their existing code paths.
 | `copied` | Debug | A cascade reused an existing summary for this target without a model call |
 | `below_threshold` | Debug | A trigger check ran and stayed below its threshold |
 | `no_delta` | Debug | No event was appended after the recorded summary boundary |
-| `no_content` | Debug | No eligible content reached the summary model |
+| `no_content` | Debug | The built-in summarizer published a trigger observation and no eligible content reached the summary model |
+| `unobserved` | Debug | The gate did not fire and this attempt published no trigger observation. This is diagnostic uncertainty, not `no_content` or `below_threshold` |
 | `cascade_suppressed` | Debug | A full-session target was skipped because it was only requested as a branch cascade |
 | `unsafe_view` | Warn | Content existed, but the model-visible view was not bound to the request the model answered, so nothing could be summarized safely |
 | `summary_error` | Warn | The summarization stage failed. `model_call_status` separates a failed model call from a pre-model build, a custom response, or an unobserved custom summarizer |
 | `context_error` | Warn | The summary context was canceled or expired |
 | `persistence_error` | Warn | The backend write failed |
-| `stale_write` | Debug | The backend skipped the write because a newer summary is already persisted. This is a successful set-if-newer no-op and can happen under normal concurrency |
-| `unknown_write` | Debug | The backend write finished without error, but the set-if-newer reply could not be classified as stored or stale. This is diagnostic uncertainty, not a business failure |
+| `stale_write` | Debug | The backend skipped the payload write because a newer summary is already persisted. This is a successful set-if-newer skip and can happen under normal concurrency. The Redis zset path may still refresh the summary key TTL; the hashidx path keeps the remaining TTL. TTL refresh is not a stored write |
+| `unknown_write` | Debug | The backend write finished without error, but the result could not be classified as stored or stale. This includes an unrecognized set-if-newer reply and a Mongo nil or zero-count UpdateResult. This is diagnostic uncertainty, not a business failure |
 | `not_stored` | Warn | A summary was generated but the backend neither stored nor rejected it |
 | `no_update` | Warn | A triggered attempt produced no summary to store |
 
@@ -1770,19 +1774,19 @@ injection text, and compaction decisions stay on their existing code paths.
 | --- | --- |
 | `called` | The built-in summarizer reached the summary model (`standalone` or `cache_safe_fork`) |
 | `custom_response` | A before-model callback supplied the summary response, so the provider was not called |
-| `unobserved` | No `Report.Call.Mode` was published, so a model call cannot be proven. Typical of a custom summarizer that does not fill `summary.Report` |
+| `unobserved` | This attempt's ModelCall recorder published no call mode, so a model call cannot be proven. Typical of a custom summarizer that does not publish the recorder. Do not treat a leftover `Report.Call.Mode` as this attempt's observation |
 
 `Session summary injection result` outcomes:
 
 | Outcome | Level | Meaning |
 | --- | --- | --- |
-| `injected` | Debug | The original summary block is still present in the same framework `model.Request` after the returned response sequence finishes or is stopped early (`selected_block_present=true`). If the model call fails before returning a response sequence, this is observed immediately. This does not describe a provider payload |
+| `block_text_present` | Debug | After the returned response sequence finishes or is stopped early, the recorded summary block text still appears as a substring of some message `Content` in the same framework `model.Request` (`block_text_present=true`). This does not prove the original injection slot is intact and does not describe a provider payload. If the model call fails before returning a response sequence, this is observed immediately |
 | `not_selected` | Debug | The session stores no summary yet |
 | `lookup_miss` | Debug | Summaries exist for other branches, but none in this request's scope |
 | `scope_mismatch` | Debug | A branch-scoped request found nothing in scope while a full-session summary exists outside it. Because no in-scope summary was selected, this request's summary cutoff stays zero, so the raw scoped history is kept at this stage. That does not depend on whether the unused full-session summary has a boundary |
-| `selected_block_missing` | Warn | A summary was selected (`selected=true`), but the original summary block is not observable in the same framework `model.Request` after the returned response sequence finishes or is stopped early. If the model call fails before returning a response sequence, this is observed immediately. This does not claim the provider's final payload, and it does not mean the summary was never written into the request. For built-in providers that mutate the shared request in place, including OpenAI, this is usually in-place token tailoring |
+| `block_text_missing` | Warn | A summary was selected (`selected=true`), but the recorded block text is not observable in any message `Content` of the same framework `model.Request` after the returned response sequence finishes or is stopped early. If the model call fails before returning a response sequence, this is observed immediately. This does not claim the provider's final payload, and it does not mean the summary was never written into the request. For built-in providers that mutate the shared request in place, including OpenAI, this is usually in-place token tailoring |
 
-### How much history reached the summary model
+### How much history was selected before the summary hook
 
 When `outcome` is `no_content` or `unsafe_view`, `selection_reason` names the
 exact stage that emptied the input, which is otherwise indistinguishable from
@@ -1790,7 +1794,7 @@ an idle session:
 
 | `selection_reason` | Meaning |
 | --- | --- |
-| `selected` | Events reached the summary model |
+| `selected` | Events were selected before the hook; this does not prove they were the later model payload |
 | `no_candidates` | The stage had no candidate event to consider at all |
 | `skip_recent_all` | The `WithSkipRecent` callback asked to skip at least as many events as were available |
 | `unsafe_prefix` | Events remained after skip-recent, but the retained prefix had neither a user message nor a prepended previous summary to anchor the summary, so it was dropped |
@@ -1816,8 +1820,10 @@ callback:
   `selected_events`, not counted here. For example `eligible_events=3`,
   `skip_recent_requested=1`, `unsafe_prefix` reports `skip_recent_applied=1` and
   `selected_events=0`.
-- `selected_events` is what finally reached the summary model, after skip-recent,
-  branch scoping, and boundary mapping.
+- `selected_events` is the event count chosen after skip-recent, branch
+  scoping, and boundary mapping, before a `PreSummaryHook` or before-model
+  callback may rewrite the prompt. It is not a count of the payload that later
+  reached the summary model.
 
 All four counts are `-1` when `selection_reason` is `custom` or `none`.
 
@@ -1834,7 +1840,7 @@ Follow the records in this order for a single request or session:
 1. **`Session summary result`** answers whether a summary was produced at all.
    `triggered` plus the `trigger*` fields explain the gate decision;
    `input_source`, `selection_reason`, and the event counts explain how much
-   history reached the model and which stage removed the rest;
+   history was selected before the hook and which stage removed the rest;
    `binding_reason` explains an `unsafe_view`; `persist_result` distinguishes a
    backend-confirmed store from a stale skip, an unclassified write, or a
    failed write.
@@ -1856,13 +1862,13 @@ Follow the records in this order for a single request or session:
    zero and the raw scoped history is kept at this stage.
 4. **`Pre-LLM context compaction result`** and the token tailoring records
    explain what happened to the request after injection. A
-   `selected_block_missing` record next to a tailoring record, for a built-in
+   `block_text_missing` record next to a tailoring record, for a built-in
    provider that mutates the shared request in place, means the original
    summary block is no longer observable in the framework `model.Request`. A
    custom `Model` that copies the request may leave the framework copy
    unchanged, so this record still does not describe the provider payload.
 
-Routine Debug records such as `injected`, healthy cascade results, `copied`,
+Routine Debug records such as `block_text_present`, healthy cascade results, `copied`,
 and `below_threshold` require the framework log level to be `debug`. At the
 normal Info level only the Info and Warn outcomes listed above are visible.
 

--- a/docs/mkdocs/en/session/summary.md
+++ b/docs/mkdocs/en/session/summary.md
@@ -1850,11 +1850,14 @@ Follow the records in this order for a single request or session:
    backend-confirmed store from a stale skip, an unclassified write, or a
    failed write.
 2. **`Session summary cascade result`** explains how a branch trigger reached
-   the full-session target. A branch that is not updated in this pass stops the
-   cascade (`action=skipped`, `invariant=ok`). `mode=dependent` is a sequential
-   multi-filter cascade, not concurrent generation. `invariant=violation` is
-   reserved for a full-session target that advanced without this-pass branch
-   materialization.
+   the full-session target. `source_materialized` is this-pass branch
+   materialization only. `action=copied` requires a successful copy;
+   `action=dependent` requires that the full-session target started. Otherwise
+   the cascade is `action=skipped` and `invariant=ok`, including a branch that
+   did not update and a materialized source that never copied or started the
+   dependent target. `mode=dependent` is a sequential multi-filter cascade, not
+   concurrent generation. `invariant=violation` is reserved for a full-session
+   target that advanced without this-pass branch materialization.
 3. **`Session summary injection result`** answers whether a later request
    still carries the stored summary in the framework `model.Request` after
    the returned response sequence finishes or is stopped early. If the model

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -1722,10 +1722,14 @@ SessionService API，也不新增诊断开关。
 
 当 `selection_reason` 为 `custom` 或 `none` 时，这四个计数均为 `-1`。
 
-`trigger` 与 `trigger_metric` 会被归一化到框架自身的取值集合。其他任何取值（包
-括自定义 summarizer 或调用方通过 `summary.Report` 设置的取值）都上报为
-`custom`，因此这两个字段始终有界，且不会携带应用侧字符串。`trigger_value`、
-`trigger_threshold`、`threshold_ratio` 与 `context_window` 原样上报。
+`trigger` 与 `trigger_metric` 只来自本轮 attempt 的内部 trigger recorder。
+自定义 summarizer 或调用方只写入 `summary.Report.Trigger` 不会被诊断采用：
+门控为 true 但未发布时上报 `triggered=true` 且 `trigger=none`；门控为 false
+且未发布时上报 `outcome=unobserved` 且 `trigger=none`。leftover
+`Report.Trigger` 不会被拷进记录。当内部 recorder 已发布触发观测时，框架词
+汇表之外的 name/metric 会归一化为 `custom`，因此这两个字段始终有界，且不
+会携带应用侧字符串。`trigger_value`、`trigger_threshold`、
+`threshold_ratio` 与 `context_window` 原样上报。
 
 ### 排查一次问题
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -1643,7 +1643,7 @@ SessionService API，也不新增诊断开关。
 | --- | --- | --- |
 | `Session summary result` | 每个摘要目标一条，在生成与持久化之后 | `schema_version`、`outcome`、`dispatch`、`target_kind`、`filter_key`、`filter_key_truncated`、`triggered`、`trigger`、`trigger_metric`、`trigger_value`、`trigger_threshold`、`threshold_ratio`、`context_window`、`summary_view_present`、`summary_view_bound`、`binding_reason`、`input_source`、`selection_reason`、`eligible_events`、`skip_recent_requested`、`skip_recent_applied`、`selected_events`、`model_call_status`、`updated`、`boundary_advanced`、`persist_result` |
 | `Session summary cascade result` | 分支触发扩散到全会话目标的每次级联一条 | `schema_version`、`outcome`、`mode`、`trigger_filter_key`、`trigger_filter_key_truncated`、`targets`、`source_materialized`、`action`、`invariant` |
-| `Session summary injection result` | 使用会话摘要的每个模型请求一条，在 `GenerateContent` 返回之后 | `schema_version`、`outcome`、`agent`、`filter_key`、`filter_key_truncated`、`lookup_strategy`、`lookup_result`、`selected`、`selected_block_present`、`stored_summaries`、`matching_candidates`、`full_session_summary`、`session_events`、`history_messages`、`request_messages` |
+| `Session summary injection result` | 使用会话摘要的每个模型请求一条，在返回的响应序列结束或被提前停止之后记录；若模型调用在返回响应序列之前失败，则立即记录 | `schema_version`、`outcome`、`agent`、`filter_key`、`filter_key_truncated`、`lookup_strategy`、`lookup_result`、`selected`、`selected_block_present`、`stored_summaries`、`matching_candidates`、`full_session_summary`、`session_events`、`history_messages`、`request_messages` |
 | `Pre-LLM context compaction result` | LLM 调用前的每次同步压缩尝试一条 | `schema_version`、`outcome`、`filter_key`、`filter_key_truncated`、`request_tokens`、`threshold`、`context_window`、`messages`、`summary_view_bound`、`binding_reason` |
 
 `Session summary result` 的 outcome：
@@ -1677,11 +1677,11 @@ SessionService API，也不新增诊断开关。
 
 | Outcome | 级别 | 含义 |
 | --- | --- | --- |
-| `injected` | Debug | `GenerateContent` 返回后，同一份框架 `model.Request` 中仍能找到原始摘要 block（`selected_block_present=true`）。这不描述 provider payload |
+| `injected` | Debug | 在返回的响应序列结束或被提前停止之后，同一份框架 `model.Request` 中仍能找到原始摘要 block（`selected_block_present=true`）。若模型调用在返回响应序列之前失败，则立即观察。这不描述 provider payload |
 | `not_selected` | Debug | 会话尚未存储任何摘要 |
 | `lookup_miss` | Debug | 其他分支存在摘要，但本次请求的作用域内没有 |
 | `scope_mismatch` | Debug | 分支作用域的请求在作用域内没有命中，而作用域之外存在全会话摘要。因为本次没有选中 in-scope 摘要，本次 summaryCutoff 保持为零，所以这一阶段仍会保留原始分支历史。这与作用域外的全会话摘要自身有没有 boundary/cutoff 无关 |
-| `selected_block_missing` | Warn | 摘要已选中（`selected=true`），但 `GenerateContent` 返回后，在同一份框架 `model.Request` 中观察不到原始摘要 block。这不表示 provider 的最终 payload，也不表示摘要从未写入请求。对会原地修改共享请求的内置 provider（包括 OpenAI），这通常是 token 裁剪导致的 |
+| `selected_block_missing` | Warn | 摘要已选中（`selected=true`），但在返回的响应序列结束或被提前停止之后，在同一份框架 `model.Request` 中观察不到原始摘要 block。若模型调用在返回响应序列之前失败，则立即观察。这不表示 provider 的最终 payload，也不表示摘要从未写入请求。对会原地修改共享请求的内置 provider（包括 OpenAI），这通常是 token 裁剪导致的 |
 
 ### 有多少历史进入了摘要模型
 
@@ -1736,8 +1736,9 @@ SessionService API，也不新增诊断开关。
    `mode=dependent` 表示多 filter 顺序级联，而不是并发生成。
    `invariant=violation` 仅表示全会话目标在本轮没有分支 materialization
    的情况下推进了。
-3. **`Session summary injection result`** 回答后续请求在 `GenerateContent`
-   返回后，框架这份 `model.Request` 里是否还带着已存储的摘要。对比
+3. **`Session summary injection result`** 回答后续请求在返回的响应序列
+   结束或被提前停止之后，框架这份 `model.Request` 里是否还带着已存储的摘要。
+   若模型调用在返回响应序列之前失败，则立即观察。对比
    `lookup_strategy`（由 `WithBranchFilterMode` 决定的配置作用域）与
    `lookup_result`（该作用域实际找到的结果）以及 `full_session_summary`。
    `scope_mismatch` 表示全会话摘要未被使用，并不表示分支历史已被丢弃：因为本
@@ -1749,8 +1750,9 @@ SessionService API，也不新增诊断开关。
    block。自定义 `Model` 如果复制了请求，框架这份拷贝可能不会反映它实际发送
    的内容，因此该记录仍然不描述 provider 最终 payload。
 
-将框架日志级别设为 `debug` 可看到常规记录；默认级别下只输出上表中的 Warn 与
-Info 记录。
+`injected`、healthy cascade、`copied`、`below_threshold` 等常规 Debug 记录
+需要把框架日志级别设为 `debug`。在正常的 Info 级别下，只能看到上表中的
+Info 与 Warn outcome。
 
 ## 性能考虑
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -1602,7 +1602,8 @@ sessionService, err := mysql.NewService(
 
 **任何记录都不包含提示词、摘要正文、事件内容、模型输出、原始错误文本、连接串
 或凭据。** 框架自身的用户 ID 和会话 ID 不会被记录。调用方提供的 `filter_key`
-会被记录，不在该保证范围内。
+会被记录，不在该保证范围内。调用方提供的 `agent` 名称同样会被记录，不应包含
+凭据、秘密或用户隐私。框架不会 hash 或脱敏这些名称。
 
 `EventFilterKey` / `filter_key` 是业务提供的作用域标识，不应包含凭据、秘密或
 用户隐私。诊断记录会记录原始值（不会 hash）。显示值最多 255 个 Unicode code
@@ -1610,7 +1611,8 @@ point，与常见的 `session_summaries.filter_key VARCHAR(255)` 一致，且该
 截断标记。未超限的 key 原样输出；超限时保留前缀，使前缀加上 `...` 标记总计仍
 为 255，并设置 `filter_key_truncated=true`（级联记录为
 `trigger_filter_key_truncated=true`）。空 key 仍清楚显示为 `filter_key=""`。截
-断只影响诊断显示，不会改变真实业务 key、数据库 key 或查询。
+断只影响诊断显示，不会改变真实业务 key、数据库 key 或查询。`agent` 使用同一
+套有界 `%q` 显示规则，并带 `agent_truncated`。
 
 每条记录都在记录名之后立即带上 `schema_version=1`，便于采集侧识别后续不兼容
 的字段变化。在该诊断 schema 正式发布之前，版本保持为 1。
@@ -1644,8 +1646,8 @@ SessionService API，也不新增诊断开关。
 | --- | --- | --- |
 | `Session summary result` | 每个摘要目标一条，摘要尝试完成之后 | `schema_version`、`outcome`、`dispatch`、`target_kind`、`filter_key`、`filter_key_truncated`、`triggered`、`trigger`、`trigger_metric`、`trigger_value`、`trigger_threshold`、`threshold_ratio`、`context_window`、`summary_view_present`、`summary_view_bound`、`binding_reason`、`input_source`、`selection_reason`、`eligible_events`、`skip_recent_requested`、`skip_recent_applied`、`selected_events`、`model_call_status`、`updated`、`boundary_advanced`、`persist_result` |
 | `Session summary cascade result` | 分支触发扩散到全会话目标的每次级联一条 | `schema_version`、`outcome`、`mode`、`trigger_filter_key`、`trigger_filter_key_truncated`、`targets`、`source_materialized`、`action`、`invariant` |
-| `Session summary injection result` | 使用会话摘要的每个模型请求一条，在返回的响应序列结束或被提前停止之后记录；若模型调用在返回响应序列之前失败，则立即记录 | `schema_version`、`outcome`、`agent`、`filter_key`、`filter_key_truncated`、`lookup_strategy`、`lookup_result`、`selected`、`selected_block_present`、`stored_summaries`、`matching_candidates`、`full_session_summary`、`session_events`、`history_messages`、`request_messages` |
-| `Pre-LLM context compaction result` | LLM 调用前的每次同步压缩尝试一条 | `schema_version`、`outcome`、`filter_key`、`filter_key_truncated`、`request_tokens`、`threshold`、`context_window`、`messages`、`summary_view_bound`、`binding_reason` |
+| `Session summary injection result` | 使用会话摘要的每个模型请求一条，在返回的响应序列结束或被提前停止之后记录；若模型调用在返回响应序列之前失败，则立即记录 | `schema_version`、`outcome`、`agent`、`agent_truncated`、`filter_key`、`filter_key_truncated`、`lookup_strategy`、`lookup_result`、`selected`、`block_text_present`、`stored_summaries`、`matching_candidates`、`full_session_summary`、`session_events`、`history_messages`、`request_messages` |
+| `Pre-LLM context compaction result` | LLM 调用前的每次同步压缩尝试一条 | `schema_version`、`outcome`、`agent`、`agent_truncated`、`filter_key`、`filter_key_truncated`、`request_tokens`、`threshold`、`context_window`、`messages`、`summary_view_bound`、`binding_reason` |
 
 `Session summary result` 的 outcome：
 
@@ -1655,14 +1657,15 @@ SessionService API，也不新增诊断开关。
 | `copied` | Debug | 级联复用已有摘要，未调用摘要模型 |
 | `below_threshold` | Debug | 触发检查已执行但未达到阈值 |
 | `no_delta` | Debug | 摘要边界之后没有新增事件 |
-| `no_content` | Debug | 没有可用内容进入摘要模型 |
+| `no_content` | Debug | 内建 summarizer 本轮发布了 trigger 观测，且没有可用内容进入摘要模型 |
+| `unobserved` | Debug | 本轮门控未触发，且没有发布 attempt-local trigger 观测。这是诊断不确定性，不能当成 `no_content` 或 `below_threshold` |
 | `cascade_suppressed` | Debug | 全会话目标仅因分支级联被请求，因此跳过 |
 | `unsafe_view` | Warn | 存在可摘要内容，但模型可见视图未绑定到模型真正回答的请求，无法安全摘要 |
 | `summary_error` | Warn | 摘要阶段失败；`model_call_status` 区分模型调用失败、模型调用前的构建失败、custom response，以及自定义 summarizer 未观测 |
 | `context_error` | Warn | 摘要 context 被取消或超时 |
 | `persistence_error` | Warn | 后端写入失败 |
-| `stale_write` | Debug | 已存在更新的摘要，后端跳过了本次写入。这是 set-if-newer 保护下的成功 no-op，正常并发下可能发生 |
-| `unknown_write` | Debug | 后端写入完成且没有 error，但 set-if-newer 回复无法判定为 stored 或 stale。这是诊断不确定性，不是业务失败 |
+| `stale_write` | Debug | 已存在更新的摘要，后端跳过了本次 payload 写入。这是 set-if-newer 保护下的成功跳过，正常并发下可能发生。Redis zset 路径仍可能刷新 summary key 的 TTL；hashidx 路径保留剩余 TTL。文档不把 TTL 续期写成写入成功 |
+| `unknown_write` | Debug | 后端写入完成且没有 error，但结果无法判定为 stored 或 stale。包括无法识别的 set-if-newer 回复，以及 Mongo nil / 零计数 UpdateResult。这是诊断不确定性，不是业务失败 |
 | `not_stored` | Warn | 摘要已生成，但后端既未写入也未拒绝 |
 | `no_update` | Warn | 已触发的尝试没有产出可存储的摘要 |
 
@@ -1672,26 +1675,26 @@ SessionService API，也不新增诊断开关。
 | --- | --- |
 | `called` | 内建 summarizer 真正调用了摘要模型（`standalone` 或 `cache_safe_fork`） |
 | `custom_response` | before-model callback 直接给出了摘要响应，因此没有调用 provider |
-| `unobserved` | 没有发布 `Report.Call.Mode`，无法证明是否发生模型调用。常见于未填写 `summary.Report` 的自定义 summarizer |
+| `unobserved` | 本轮 attempt-local ModelCall recorder 没有发布调用模式，无法证明是否发生模型调用。常见于未发布 recorder 的自定义 summarizer；不要把 leftover `Report.Call.Mode` 当成这一次观测 |
 
 `Session summary injection result` 的 outcome：
 
 | Outcome | 级别 | 含义 |
 | --- | --- | --- |
-| `injected` | Debug | 在返回的响应序列结束或被提前停止之后，同一份框架 `model.Request` 中仍能找到原始摘要 block（`selected_block_present=true`）。若模型调用在返回响应序列之前失败，则立即观察。这不描述 provider payload |
+| `block_text_present` | Debug | 在返回的响应序列结束或被提前停止之后，同一份框架 `model.Request` 的任意消息 `Content` 中仍能找到与记录 block 相同的文本（`block_text_present=true`）。这不能证明原注入位置还在，也不描述 provider payload。若模型调用在返回响应序列之前失败，则立即观察 |
 | `not_selected` | Debug | 会话尚未存储任何摘要 |
 | `lookup_miss` | Debug | 其他分支存在摘要，但本次请求的作用域内没有 |
 | `scope_mismatch` | Debug | 分支作用域的请求在作用域内没有命中，而作用域之外存在全会话摘要。因为本次没有选中 in-scope 摘要，本次 summaryCutoff 保持为零，所以这一阶段仍会保留原始分支历史。这与作用域外的全会话摘要自身有没有 boundary/cutoff 无关 |
-| `selected_block_missing` | Warn | 摘要已选中（`selected=true`），但在返回的响应序列结束或被提前停止之后，在同一份框架 `model.Request` 中观察不到原始摘要 block。若模型调用在返回响应序列之前失败，则立即观察。这不表示 provider 的最终 payload，也不表示摘要从未写入请求。对会原地修改共享请求的内置 provider（包括 OpenAI），这通常是 token 裁剪导致的 |
+| `block_text_missing` | Warn | 摘要已选中（`selected=true`），但在返回的响应序列结束或被提前停止之后，同一份框架 `model.Request` 的任意消息 `Content` 中都观察不到记录的 block 文本。这不表示 provider 的最终 payload，也不表示摘要从未写入请求。对会原地修改共享请求的内置 provider（包括 OpenAI），这通常是 token 裁剪导致的 |
 
-### 有多少历史进入了摘要模型
+### 有多少历史在 hook 前被选定
 
 当 `outcome` 为 `no_content` 或 `unsafe_view` 时，`selection_reason` 指出究竟是
 哪个阶段清空了输入，否则这与"会话本来就没有内容"无法区分：
 
 | `selection_reason` | 含义 |
 | --- | --- |
-| `selected` | 有事件进入了摘要模型 |
+| `selected` | hook 前选定了事件；这不证明这些事件就是后来送进模型的 payload |
 | `no_candidates` | 该阶段本来就没有候选事件 |
 | `skip_recent_all` | `WithSkipRecent` 回调要求跳过的数量不少于可用事件数 |
 | `unsafe_prefix` | skip-recent 之后仍有事件，但保留的前缀既没有用户消息也没有前置的历史摘要作为锚点，因此被丢弃 |
@@ -1713,8 +1716,9 @@ SessionService API，也不新增诊断开关。
   域或边界无法映射，由 `selection_reason` 与 `selected_events` 说明，不计入此字
   段。例如 `eligible_events=3`、`skip_recent_requested=1`、`unsafe_prefix` 时，
   `skip_recent_applied=1` 且 `selected_events=0`。
-- `selected_events`：经过 skip-recent、分支作用域与边界映射之后，最终进入摘要模
-  型的事件数。
+- `selected_events`：经过 skip-recent、分支作用域与边界映射之后，PreSummaryHook
+  运行前选定的事件数。它不是 hook 或 before-model callback 改写之后真正送进模型
+  的 payload 计数。
 
 当 `selection_reason` 为 `custom` 或 `none` 时，这四个计数均为 `-1`。
 
@@ -1729,7 +1733,7 @@ SessionService API，也不新增诊断开关。
 
 1. **`Session summary result`** 回答是否产出了摘要。`triggered` 与 `trigger*`
    字段解释门控判定；`input_source`、`selection_reason` 与各项事件计数说明有多
-   少历史进入了摘要模型，以及是哪个阶段移除了其余部分；
+   少历史在 hook 前被选定，以及是哪个阶段移除了其余部分；
    `binding_reason` 解释 `unsafe_view` 的成因；`persist_result` 区分后端确认写入、
    stale 跳过、无法分类的写入，以及写入失败。
 2. **`Session summary cascade result`** 解释分支触发如何到达全会话目标。
@@ -1746,12 +1750,12 @@ SessionService API，也不新增诊断开关。
    次没有选中 in-scope 摘要，本次 summaryCutoff 保持为零，这一阶段仍会保留原
    始分支历史。
 4. **`Pre-LLM context compaction result`** 与 token 裁剪记录解释注入之后请求
-   发生了什么。对会原地修改共享请求的内置 provider，`selected_block_missing`
+   发生了什么。对会原地修改共享请求的内置 provider，`block_text_missing`
    与裁剪记录同时出现，说明同一份框架 `model.Request` 里已经观察不到原始摘要
    block。自定义 `Model` 如果复制了请求，框架这份拷贝可能不会反映它实际发送
    的内容，因此该记录仍然不描述 provider 最终 payload。
 
-`injected`、healthy cascade、`copied`、`below_threshold` 等常规 Debug 记录
+`block_text_present`、healthy cascade、`copied`、`below_threshold` 等常规 Debug 记录
 需要把框架日志级别设为 `debug`。在正常的 Info 级别下，只能看到上表中的
 Info 与 Warn outcome。
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -1741,10 +1741,12 @@ SessionService API，也不新增诊断开关。
    `binding_reason` 解释 `unsafe_view` 的成因；`persist_result` 区分后端确认写入、
    stale 跳过、无法分类的写入，以及写入失败。
 2. **`Session summary cascade result`** 解释分支触发如何到达全会话目标。
-   本轮分支未更新会停止级联（`action=skipped`，`invariant=ok`）。
-   `mode=dependent` 表示多 filter 顺序级联，而不是并发生成。
-   `invariant=violation` 仅表示全会话目标在本轮没有分支 materialization
-   的情况下推进了。
+   `source_materialized` 只记录本轮分支是否物化。`action=copied` 需要 copy
+   成功；`action=dependent` 需要全会话目标实际开始。否则都是
+   `action=skipped` 且 `invariant=ok`，包括本轮分支未更新，以及源已物化但
+   copy 未成功或 dependent 目标未开始。`mode=dependent` 表示多 filter
+   顺序级联，而不是并发生成。`invariant=violation` 仅表示全会话目标在本轮
+   没有分支 materialization 的情况下推进了。
 3. **`Session summary injection result`** 回答后续请求在返回的响应序列
    结束或被提前停止之后，框架这份 `model.Request` 里是否还带着已存储的摘要。
    若模型调用在返回响应序列之前失败，则立即观察。对比

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -529,8 +529,12 @@ summarizer := summary.NewSummarizer(
 
 开启 cache-safe forking 时，`report.Call.Mode` 为 `cache_safe_fork`，请求估算值来自 fork
 后的父请求加上追加的 summary 指令。普通独立 summary prompt 模式下，mode 为 `standalone`。
-如果 `BeforeModel` callback 返回 custom response，实际没有发送 summary 模型请求，mode 为
-`custom_response`，prompt 估算值保持为 0。
+如果 `BeforeModel` callback 返回 custom response，该次尝试没有发送 summary 模型请求，
+mode 为 `custom_response`，prompt 估算值保持为 0。`Report.Call.Mode` 表示最后
+一次 summary 尝试的状态；若混合重试中较早一次已经调用 provider、最后一次改由
+callback 返回 custom response，它仍为 `custom_response`，usage 字段也可能保留
+较早一次 provider 调用的数据。结构化诊断字段 `model_call_status` 则聚合整次
+summary 操作：任意一次尝试调用过 provider，就上报为 `called`。
 
 高级集成如果要在高层 summary 流程前放入同一个 report，可以使用
 `summary.ContextWithReport(ctx, report)`，需要从 context 取出时使用
@@ -1742,11 +1746,12 @@ SessionService API，也不新增诊断开关。
    stale 跳过、无法分类的写入，以及写入失败。
 2. **`Session summary cascade result`** 解释分支触发如何到达全会话目标。
    `source_materialized` 只记录本轮分支是否物化。`action=copied` 需要 copy
-   成功；`action=dependent` 需要全会话目标实际开始。否则都是
-   `action=skipped` 且 `invariant=ok`，包括本轮分支未更新，以及源已物化但
-   copy 未成功或 dependent 目标未开始。`mode=dependent` 表示多 filter
-   顺序级联，而不是并发生成。`invariant=violation` 仅表示全会话目标在本轮
-   没有分支 materialization 的情况下推进了。
+   成功；`action=dependent` 需要全会话目标实际开始。否则，只有在全会话目标
+   没有独立推进时，才是 `action=skipped` 且 `invariant=ok`，包括本轮分支未
+   更新，以及源已物化但 copy 未成功或 dependent 目标未开始。
+   `mode=dependent` 表示多 filter 顺序级联，而不是并发生成。
+   `invariant=violation` 仅表示全会话目标在本轮没有分支 materialization 的
+   情况下推进了。
 3. **`Session summary injection result`** 回答后续请求在返回的响应序列
    结束或被提前停止之后，框架这份 `model.Request` 里是否还带着已存储的摘要。
    若模型调用在返回响应序列之前失败，则立即观察。对比

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -1490,6 +1490,10 @@ evt.FilterKey = "my-app/user-messages"
 evt.FilterKey = "user-messages"
 ```
 
+`EventFilterKey` / `filter_key` 是业务提供的作用域标识，不应包含凭据、秘密或
+用户隐私。诊断日志可能输出原始值，但会按
+[生产环境摘要诊断](#生产环境摘要诊断) 中的长度限制截断显示。
+
 ### 为不同类型生成摘要
 
 ```go
@@ -1588,6 +1592,165 @@ sessionService, err := mysql.NewService(
 4. **自定义提示词**：根据应用需求定制摘要提示词。例如，如果你正在构建客户支持 Agent，应关注关键问题和解决方案
 5. **平衡字数限制**：设置 `WithMaxSummaryWords` 以在保留上下文和减少 token 使用之间取得平衡。典型值范围为 100-300 字
 6. **测试触发条件**：尝试不同的 `WithChecksAny` 和 `WithChecksAll` 组合，找到摘要频率和成本之间的最佳平衡
+
+## 生产环境摘要诊断
+
+摘要的生成与持久化诊断结果不会作为用户可见的模型响应直接返回。处理可能在后台
+异步执行，也可能在请求内同步完成（例如 LLM 调用前的 context compaction）。框
+架会输出四条稳定的日志记录，让你可以从生成一路追踪到注入。这些记录都在请求或
+任务的 context 上输出，因此与你现有的 trace 关联方式一致。
+
+**任何记录都不包含提示词、摘要正文、事件内容、模型输出、原始错误文本、连接串
+或凭据。** 用户 ID 和会话 ID 不会被记录。
+
+`EventFilterKey` / `filter_key` 是业务提供的作用域标识，不应包含凭据、秘密或
+用户隐私。诊断记录会记录原始值（不会 hash）。显示值最多 255 个 Unicode code
+point，与常见的 `session_summaries.filter_key VARCHAR(255)` 一致，且该上限包含
+截断标记。未超限的 key 原样输出；超限时保留前缀，使前缀加上 `...` 标记总计仍
+为 255，并设置 `filter_key_truncated=true`（级联记录为
+`trigger_filter_key_truncated=true`）。空 key 仍清楚显示为 `filter_key=""`。截
+断只影响诊断显示，不会改变真实业务 key、数据库 key 或查询。
+
+每条记录都在记录名之后立即带上 `schema_version=1`，便于采集侧识别后续不兼容
+的字段变化。在该诊断 schema 正式发布之前，版本保持为 1。
+
+这些记录用于观察生成、持久化、级联、注入和 LLM 调用前压缩。它们不新增公开的
+SessionService API，也不新增诊断开关。
+
+相对加入诊断前的 Redis 路径，已验证的返回契约：
+
+- 当 set-if-newer Lua 脚本本身执行成功时，`CreateSessionSummary` 仍然返回
+  nil error，即使回复不是 `int64` 的 0 或 1。无法识别的回复会记为
+  `persist_result=unknown` / `outcome=unknown_write`（Debug）。它不会被当成
+  stored、stale、`success` 或 `persistence_error`，也不会改变该方法的返回值。
+- 真正的脚本、序列化或过期设置失败仍然返回 error，并记为
+  `persist_result=error` / `outcome=persistence_error`。
+
+摘要选择、cutoff、级联调用顺序、`force` 值、错误包装、注入文本和 compaction
+判定仍走原有代码路径。
+
+### 诊断开销
+
+- 一次普通的 summary attempt 记录是常数级元数据：计数、枚举、耗时，以及截断后
+  的 filter key 显示。它不会复制事件、提示词或摘要正文。
+- 检查选中的注入 block 是否仍在请求中，复杂度是
+  `O(请求消息总字节数)`。该扫描只在该请求启用了 session summary injection 时
+  执行。不会复制完整请求。
+
+### 记录名称与关键字段
+
+| 记录 | 输出时机 | 关键字段 |
+| --- | --- | --- |
+| `Session summary result` | 每个摘要目标一条，在生成与持久化之后 | `schema_version`、`outcome`、`dispatch`、`target_kind`、`filter_key`、`filter_key_truncated`、`triggered`、`trigger`、`trigger_metric`、`trigger_value`、`trigger_threshold`、`threshold_ratio`、`context_window`、`summary_view_present`、`summary_view_bound`、`binding_reason`、`input_source`、`selection_reason`、`eligible_events`、`skip_recent_requested`、`skip_recent_applied`、`selected_events`、`model_call_status`、`updated`、`boundary_advanced`、`persist_result` |
+| `Session summary cascade result` | 分支触发扩散到全会话目标的每次级联一条 | `schema_version`、`outcome`、`mode`、`trigger_filter_key`、`trigger_filter_key_truncated`、`targets`、`source_materialized`、`action`、`invariant` |
+| `Session summary injection result` | 使用会话摘要的每个模型请求一条，在 `GenerateContent` 返回之后 | `schema_version`、`outcome`、`agent`、`filter_key`、`filter_key_truncated`、`lookup_strategy`、`lookup_result`、`selected`、`selected_block_present`、`stored_summaries`、`matching_candidates`、`full_session_summary`、`session_events`、`history_messages`、`request_messages` |
+| `Pre-LLM context compaction result` | LLM 调用前的每次同步压缩尝试一条 | `schema_version`、`outcome`、`filter_key`、`filter_key_truncated`、`request_tokens`、`threshold`、`context_window`、`messages`、`summary_view_bound`、`binding_reason` |
+
+`Session summary result` 的 outcome：
+
+| Outcome | 级别 | 含义 |
+| --- | --- | --- |
+| `success` | Info | 生成了新摘要且后端确认写入 |
+| `copied` | Debug | 级联复用已有摘要，未调用摘要模型 |
+| `below_threshold` | Debug | 触发检查已执行但未达到阈值 |
+| `no_delta` | Debug | 摘要边界之后没有新增事件 |
+| `no_content` | Debug | 没有可用内容进入摘要模型 |
+| `cascade_suppressed` | Debug | 全会话目标仅因分支级联被请求，因此跳过 |
+| `unsafe_view` | Warn | 存在可摘要内容，但模型可见视图未绑定到模型真正回答的请求，无法安全摘要 |
+| `summary_error` | Warn | 摘要阶段失败；`model_call_status` 区分模型调用失败、模型调用前的构建失败、custom response，以及自定义 summarizer 未观测 |
+| `context_error` | Warn | 摘要 context 被取消或超时 |
+| `persistence_error` | Warn | 后端写入失败 |
+| `stale_write` | Debug | 已存在更新的摘要，后端跳过了本次写入。这是 set-if-newer 保护下的成功 no-op，正常并发下可能发生 |
+| `unknown_write` | Debug | 后端写入完成且没有 error，但 set-if-newer 回复无法判定为 stored 或 stale。这是诊断不确定性，不是业务失败 |
+| `not_stored` | Warn | 摘要已生成，但后端既未写入也未拒绝 |
+| `no_update` | Warn | 已触发的尝试没有产出可存储的摘要 |
+
+`model_call_status` 是稳定三态字段，不要把 `unobserved` 当成“模型未被调用”：
+
+| `model_call_status` | 含义 |
+| --- | --- |
+| `called` | 内建 summarizer 真正调用了摘要模型（`standalone` 或 `cache_safe_fork`） |
+| `custom_response` | before-model callback 直接给出了摘要响应，因此没有调用 provider |
+| `unobserved` | 没有发布 `Report.Call.Mode`，无法证明是否发生模型调用。常见于未填写 `summary.Report` 的自定义 summarizer |
+
+`Session summary injection result` 的 outcome：
+
+| Outcome | 级别 | 含义 |
+| --- | --- | --- |
+| `injected` | Debug | `GenerateContent` 返回后，同一份框架 `model.Request` 中仍能找到原始摘要 block（`selected_block_present=true`）。这不描述 provider payload |
+| `not_selected` | Debug | 会话尚未存储任何摘要 |
+| `lookup_miss` | Debug | 其他分支存在摘要，但本次请求的作用域内没有 |
+| `scope_mismatch` | Debug | 分支作用域的请求在作用域内没有命中，而作用域之外存在全会话摘要。因为本次没有选中 in-scope 摘要，本次 summaryCutoff 保持为零，所以这一阶段仍会保留原始分支历史。这与作用域外的全会话摘要自身有没有 boundary/cutoff 无关 |
+| `selected_block_missing` | Warn | 摘要已选中（`selected=true`），但 `GenerateContent` 返回后，在同一份框架 `model.Request` 中观察不到原始摘要 block。这不表示 provider 的最终 payload，也不表示摘要从未写入请求。对会原地修改共享请求的内置 provider（包括 OpenAI），这通常是 token 裁剪导致的 |
+
+### 有多少历史进入了摘要模型
+
+当 `outcome` 为 `no_content` 或 `unsafe_view` 时，`selection_reason` 指出究竟是
+哪个阶段清空了输入，否则这与"会话本来就没有内容"无法区分：
+
+| `selection_reason` | 含义 |
+| --- | --- |
+| `selected` | 有事件进入了摘要模型 |
+| `no_candidates` | 该阶段本来就没有候选事件 |
+| `skip_recent_all` | `WithSkipRecent` 回调要求跳过的数量不少于可用事件数 |
+| `unsafe_prefix` | skip-recent 之后仍有事件，但保留的前缀既没有用户消息也没有前置的历史摘要作为锚点，因此被丢弃 |
+| `session_filter_empty` | 候选事件通过了 skip-recent，随后被摘要的分支作用域全部过滤掉 |
+| `unbound_view` | 存在模型可见视图，但未绑定到模型真正回答的请求 |
+| `boundary_unmapped` | 选中的条目没有对应到已存储事件的结构映射，因此丢弃摘要，而不是让边界越过无法再次定位的内容 |
+| `custom` | 本次摘要调用没有发布内置事件选择，计数未知 |
+| `none` | 没有 summarizer 运行，未观测到任何选择 |
+
+配套的计数描述的是接收 `WithSkipRecent` 回调的那个阶段：
+
+- `eligible_events`：交给该阶段的候选事件数，在 skip-recent 执行之前统计。对已
+  绑定的模型可见视图，它包含前置的历史摘要；对未绑定视图，它是未被考虑的视图条
+  目数。
+- `skip_recent_requested`：回调返回的原始数值，因此回调返回异常值时依然可见。未
+  配置回调时为 `0`。
+- `skip_recent_applied`：skip-recent 自身实际移除的事件数，即
+  `clamp(skip_recent_requested, 0, eligible_events)`。后续的不安全前缀、分支作用
+  域或边界无法映射，由 `selection_reason` 与 `selected_events` 说明，不计入此字
+  段。例如 `eligible_events=3`、`skip_recent_requested=1`、`unsafe_prefix` 时，
+  `skip_recent_applied=1` 且 `selected_events=0`。
+- `selected_events`：经过 skip-recent、分支作用域与边界映射之后，最终进入摘要模
+  型的事件数。
+
+当 `selection_reason` 为 `custom` 或 `none` 时，这四个计数均为 `-1`。
+
+`trigger` 与 `trigger_metric` 会被归一化到框架自身的取值集合。其他任何取值（包
+括自定义 summarizer 或调用方通过 `summary.Report` 设置的取值）都上报为
+`custom`，因此这两个字段始终有界，且不会携带应用侧字符串。`trigger_value`、
+`trigger_threshold`、`threshold_ratio` 与 `context_window` 原样上报。
+
+### 排查一次问题
+
+针对同一个请求或会话，按以下顺序查看记录：
+
+1. **`Session summary result`** 回答是否产出了摘要。`triggered` 与 `trigger*`
+   字段解释门控判定；`input_source`、`selection_reason` 与各项事件计数说明有多
+   少历史进入了摘要模型，以及是哪个阶段移除了其余部分；
+   `binding_reason` 解释 `unsafe_view` 的成因；`persist_result` 区分后端确认写入、
+   stale 跳过、无法分类的写入，以及写入失败。
+2. **`Session summary cascade result`** 解释分支触发如何到达全会话目标。
+   本轮分支未更新会停止级联（`action=skipped`，`invariant=ok`）。
+   `mode=dependent` 表示多 filter 顺序级联，而不是并发生成。
+   `invariant=violation` 仅表示全会话目标在本轮没有分支 materialization
+   的情况下推进了。
+3. **`Session summary injection result`** 回答后续请求在 `GenerateContent`
+   返回后，框架这份 `model.Request` 里是否还带着已存储的摘要。对比
+   `lookup_strategy`（由 `WithBranchFilterMode` 决定的配置作用域）与
+   `lookup_result`（该作用域实际找到的结果）以及 `full_session_summary`。
+   `scope_mismatch` 表示全会话摘要未被使用，并不表示分支历史已被丢弃：因为本
+   次没有选中 in-scope 摘要，本次 summaryCutoff 保持为零，这一阶段仍会保留原
+   始分支历史。
+4. **`Pre-LLM context compaction result`** 与 token 裁剪记录解释注入之后请求
+   发生了什么。对会原地修改共享请求的内置 provider，`selected_block_missing`
+   与裁剪记录同时出现，说明同一份框架 `model.Request` 里已经观察不到原始摘要
+   block。自定义 `Model` 如果复制了请求，框架这份拷贝可能不会反映它实际发送
+   的内容，因此该记录仍然不描述 provider 最终 payload。
+
+将框架日志级别设为 `debug` 可看到常规记录；默认级别下只输出上表中的 Warn 与
+Info 记录。
 
 ## 性能考虑
 

--- a/docs/mkdocs/zh/session/summary.md
+++ b/docs/mkdocs/zh/session/summary.md
@@ -1601,7 +1601,8 @@ sessionService, err := mysql.NewService(
 任务的 context 上输出，因此与你现有的 trace 关联方式一致。
 
 **任何记录都不包含提示词、摘要正文、事件内容、模型输出、原始错误文本、连接串
-或凭据。** 用户 ID 和会话 ID 不会被记录。
+或凭据。** 框架自身的用户 ID 和会话 ID 不会被记录。调用方提供的 `filter_key`
+会被记录，不在该保证范围内。
 
 `EventFilterKey` / `filter_key` 是业务提供的作用域标识，不应包含凭据、秘密或
 用户隐私。诊断记录会记录原始值（不会 hash）。显示值最多 255 个 Unicode code
@@ -1641,7 +1642,7 @@ SessionService API，也不新增诊断开关。
 
 | 记录 | 输出时机 | 关键字段 |
 | --- | --- | --- |
-| `Session summary result` | 每个摘要目标一条，在生成与持久化之后 | `schema_version`、`outcome`、`dispatch`、`target_kind`、`filter_key`、`filter_key_truncated`、`triggered`、`trigger`、`trigger_metric`、`trigger_value`、`trigger_threshold`、`threshold_ratio`、`context_window`、`summary_view_present`、`summary_view_bound`、`binding_reason`、`input_source`、`selection_reason`、`eligible_events`、`skip_recent_requested`、`skip_recent_applied`、`selected_events`、`model_call_status`、`updated`、`boundary_advanced`、`persist_result` |
+| `Session summary result` | 每个摘要目标一条，摘要尝试完成之后 | `schema_version`、`outcome`、`dispatch`、`target_kind`、`filter_key`、`filter_key_truncated`、`triggered`、`trigger`、`trigger_metric`、`trigger_value`、`trigger_threshold`、`threshold_ratio`、`context_window`、`summary_view_present`、`summary_view_bound`、`binding_reason`、`input_source`、`selection_reason`、`eligible_events`、`skip_recent_requested`、`skip_recent_applied`、`selected_events`、`model_call_status`、`updated`、`boundary_advanced`、`persist_result` |
 | `Session summary cascade result` | 分支触发扩散到全会话目标的每次级联一条 | `schema_version`、`outcome`、`mode`、`trigger_filter_key`、`trigger_filter_key_truncated`、`targets`、`source_materialized`、`action`、`invariant` |
 | `Session summary injection result` | 使用会话摘要的每个模型请求一条，在返回的响应序列结束或被提前停止之后记录；若模型调用在返回响应序列之前失败，则立即记录 | `schema_version`、`outcome`、`agent`、`filter_key`、`filter_key_truncated`、`lookup_strategy`、`lookup_result`、`selected`、`selected_block_present`、`stored_summaries`、`matching_candidates`、`full_session_summary`、`session_events`、`history_messages`、`request_messages` |
 | `Pre-LLM context compaction result` | LLM 调用前的每次同步压缩尝试一条 | `schema_version`、`outcome`、`filter_key`、`filter_key_truncated`、`request_tokens`、`threshold`、`context_window`、`messages`、`summary_view_bound`、`binding_reason` |

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -209,6 +209,21 @@ func captureWarningLogs(t *testing.T) func() string {
 	}
 }
 
+func captureInfoLogs(t *testing.T) func() string {
+	t.Helper()
+	var infos []string
+	oldInfofContext := log.InfofContext
+	log.InfofContext = func(_ context.Context, format string, args ...any) {
+		infos = append(infos, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.InfofContext = oldInfofContext
+	})
+	return func() string {
+		return strings.Join(infos, "\n")
+	}
+}
+
 func TestSummarySnapshotAdvancedUsesBoundary(t *testing.T) {
 	cutoff := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	sess := &session.Session{
@@ -1158,6 +1173,90 @@ func TestRunContextCompactionReportsBindingReason(t *testing.T) {
 		"binding_reason="+summaryview.BindingReasonInvalidated)
 }
 
+// TestMaybeCompactContextBeforeLLM_SuccessLogsPostFinalizeBinding proves the
+// success record reads the invocation binding after rebuild Finalize, not the
+// snapshot frozen before summarization.
+func TestMaybeCompactContextBeforeLLM_SuccessLogsPostFinalizeBinding(t *testing.T) {
+	modelName := "compact-success-post-finalize-binding"
+	model.RegisterModelContextWindow(modelName, 10000)
+	infoLogs := captureInfoLogs(t)
+	warningLogs := captureWarningLogs(t)
+
+	baseSvc := inmemory.NewSessionService()
+	t.Cleanup(func() {
+		require.NoError(t, baseSvc.Close())
+	})
+
+	service := &summaryInjectingService{Service: baseSvc}
+	longContent := strings.Repeat("history ", 2000)
+	sess := &session.Session{
+		Events: []event.Event{{
+			RequestID: "req-old",
+			Timestamp: time.Now().Add(-time.Hour),
+			Response: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.NewUserMessage(longContent),
+				}},
+			},
+		}},
+	}
+
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationSessionService(service),
+		agent.WithInvocationMessage(model.NewUserMessage("current")),
+		agent.WithInvocationRunOptions(agent.RunOptions{RequestID: "req-current"}),
+		agent.WithInvocationModel(&compactingModel{name: modelName}),
+		agent.WithInvocationEventFilterKey("branch/test"),
+	)
+
+	f := New(
+		[]flow.RequestProcessor{
+			processor.NewContentRequestProcessor(
+				processor.WithAddSessionSummary(true),
+			),
+		},
+		nil,
+		Options{
+			EnableContextCompaction:         true,
+			ContextCompactionThresholdRatio: 0.2,
+		},
+	)
+
+	req := &model.Request{}
+	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+	summaryview.InvalidateBinding(inv)
+	preBinding := summaryview.BindingFromInvocation(inv)
+	require.False(t, preBinding.Bound)
+	require.Equal(t, summaryview.BindingReasonInvalidated, preBinding.Reason)
+
+	rebuilt := f.maybeCompactContextBeforeLLM(
+		context.Background(),
+		inv,
+		nil,
+		req,
+		rebuildPlan,
+	)
+
+	require.NotSame(t, req, rebuilt)
+	postBinding := summaryview.BindingFromInvocation(inv)
+	require.True(t, postBinding.Bound)
+	require.Equal(t, summaryview.BindingReasonBound, postBinding.Reason)
+	require.NotEqual(t, preBinding.Reason, postBinding.Reason)
+
+	logged := infoLogs()
+	require.Contains(t, logged, "outcome=success")
+	require.Contains(t, logged, "summary_view_bound=true")
+	require.Contains(t, logged,
+		"binding_reason="+summaryview.BindingReasonBound)
+	require.Contains(t, logged,
+		fmt.Sprintf("summary_view_items=%d", postBinding.Items))
+	require.NotContains(t, logged,
+		"binding_reason="+summaryview.BindingReasonInvalidated)
+	require.Empty(t, warningLogs())
+}
+
 func TestMaybeCompactContextBeforeLLM_RebuildsWithoutReplayingEarlierProcessors(t *testing.T) {
 	modelName := "compact-retry-safe-rebuild"
 	model.RegisterModelContextWindow(modelName, 10000)
@@ -1298,6 +1397,7 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenUnsafeTailProcessorPresent(t *tes
 func TestMaybeCompactContextBeforeLLM_RebuildsAfterPartialSummaryFailure(t *testing.T) {
 	modelName := "compact-retry-partial-summary-error"
 	model.RegisterModelContextWindow(modelName, 10000)
+	warningLogs := captureWarningLogs(t)
 
 	baseSvc := inmemory.NewSessionService()
 	t.Cleanup(func() {
@@ -1346,6 +1446,10 @@ func TestMaybeCompactContextBeforeLLM_RebuildsAfterPartialSummaryFailure(t *test
 
 	req := &model.Request{}
 	rebuildPlan := f.preprocess(context.Background(), inv, req, nil)
+	summaryview.InvalidateBinding(inv)
+	preBinding := summaryview.BindingFromInvocation(inv)
+	require.False(t, preBinding.Bound)
+	require.Equal(t, summaryview.BindingReasonInvalidated, preBinding.Reason)
 
 	rebuilt := f.maybeCompactContextBeforeLLM(
 		context.Background(),
@@ -1359,6 +1463,17 @@ func TestMaybeCompactContextBeforeLLM_RebuildsAfterPartialSummaryFailure(t *test
 	require.NotSame(t, req, rebuilt)
 	require.Contains(t, rebuilt.Messages[0].Content, "compressed despite persistence failure")
 	require.Equal(t, "current", rebuilt.Messages[1].Content)
+
+	postBinding := summaryview.BindingFromInvocation(inv)
+	require.True(t, postBinding.Bound)
+	require.Equal(t, summaryview.BindingReasonBound, postBinding.Reason)
+	logged := warningLogs()
+	require.Contains(t, logged, "outcome=persistence_error")
+	require.Contains(t, logged, "summary_view_bound=true")
+	require.Contains(t, logged,
+		"binding_reason="+summaryview.BindingReasonBound)
+	require.NotContains(t, logged,
+		"binding_reason="+summaryview.BindingReasonInvalidated)
 }
 
 func TestMaybeCompactContextBeforeLLM_RebuildPreservesPreContentRequestState(

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -1066,6 +1066,9 @@ func TestMaybeCompactContextBeforeLLM_SkipsWhenSummaryRefreshFails(t *testing.T)
 	require.Same(t, req, rebuilt)
 	logged := warningLogs()
 	require.Contains(t, logged, "outcome=summary_error")
+	require.Contains(t, logged, "schema_version=1")
+	require.Contains(t, logged, `filter_key="branch/test"`)
+	require.Contains(t, logged, "filter_key_truncated=false")
 	require.NotContains(t, logged, sensitiveErrorText)
 	require.NotContains(t, logged, "post_request_tokens=0")
 }
@@ -1101,7 +1104,58 @@ func TestRunContextCompactionLogsRebuildUnavailable(t *testing.T) {
 	require.Same(t, req, rebuilt)
 	logged := warningLogs()
 	require.Contains(t, logged, "outcome=rebuild_unavailable")
+	require.Contains(t, logged, "schema_version=1")
+	require.Contains(t, logged, `filter_key=""`)
+	require.Contains(t, logged, "filter_key_truncated=false")
 	require.Contains(t, logged, "post_request_tokens=3000")
+	require.Contains(t, logged, "binding_reason=absent")
+}
+
+// TestRunContextCompactionReportsBindingReason proves the compaction record
+// names the stage that broke the model-visible binding. A bare
+// summary_view_bound=false cannot be traced back to a cause after the fact.
+func TestRunContextCompactionReportsBindingReason(t *testing.T) {
+	warningLogs := captureWarningLogs(t)
+	service := &summaryInjectingService{}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{}),
+		agent.WithInvocationSessionService(service),
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("stable"),
+		model.NewUserMessage("history"),
+	}}
+	summaryview.AttachProjection(inv, &summaryview.View{
+		SessionID:            "session",
+		ContentRequestLength: 2,
+		Items: []summaryview.Item{{
+			Message:      model.NewUserMessage("history"),
+			RequestIndex: 1,
+		}},
+	})
+	// Provider-side token tailoring rewrote the request for the previous
+	// model call, so the projection is no longer proof of visibility.
+	summaryview.InvalidateBinding(inv)
+
+	new(Flow).runContextCompaction(
+		context.Background(),
+		inv,
+		nil,
+		req,
+		&contextCompactionRebuildPlan{},
+		contextCompactionDecision{
+			shouldCompact: true,
+			tokenCount:    3000,
+			threshold:     2000,
+			contextWindow: 4000,
+		},
+	)
+
+	logged := warningLogs()
+	require.Contains(t, logged, "summary_view_present=true")
+	require.Contains(t, logged, "summary_view_bound=false")
+	require.Contains(t, logged,
+		"binding_reason="+summaryview.BindingReasonInvalidated)
 }
 
 func TestMaybeCompactContextBeforeLLM_RebuildsWithoutReplayingEarlierProcessors(t *testing.T) {

--- a/internal/flow/llmflow/context_compact_test.go
+++ b/internal/flow/llmflow/context_compact_test.go
@@ -625,6 +625,11 @@ func TestMaybeCompactContextBeforeLLM_LogsPostCountError(t *testing.T) {
 	require.Contains(t, logged, "outcome=post_count_error")
 	require.Contains(t, logged, "post_request_tokens=-1")
 	require.NotContains(t, logged, "outcome=success")
+	binding := summaryview.BindingFromInvocation(inv)
+	require.Contains(t, logged, fmt.Sprintf("summary_view_present=%t", binding.Present))
+	require.Contains(t, logged, fmt.Sprintf("summary_view_bound=%t", binding.Bound))
+	require.Contains(t, logged, fmt.Sprintf("summary_view_items=%d", binding.Items))
+	require.Contains(t, logged, fmt.Sprintf("binding_reason=%s", binding.Reason))
 }
 
 func TestMaybeCompactContextBeforeLLM_SummarizesSanitizedOrphanToolCall(

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1735,12 +1735,19 @@ func (f *Flow) runContextCompaction(
 	if viewPresent {
 		summaryCtx = summaryview.ContextWithView(summaryCtx, view)
 	}
+	var viewFinalized bool
 	logResult := func(
 		outcome string,
 		result *model.Request,
 		postRequestTokens int,
 	) {
+		// After a post-rebuild Finalize the invocation holds the latest
+		// binding. Paths that never Finalize keep the snapshot frozen
+		// before summarization.
 		binding := summaryview.BindingFromContext(summaryCtx)
+		if viewFinalized {
+			binding = summaryview.BindingFromInvocation(invocation)
+		}
 		filterKeyDisplay, filterKeyTruncated :=
 			summarydiag.FormatFilterKey(filterKey)
 		format := "Pre-LLM context compaction result: schema_version=%d, " +
@@ -1855,6 +1862,7 @@ func (f *Flow) runContextCompaction(
 			postDecisionRequest,
 			postDecision.tokenCount,
 		)
+		viewFinalized = true
 	} else {
 		log.DebugfContext(
 			ctx,
@@ -2599,22 +2607,32 @@ func (f *Flow) callLLM(
 		},
 	)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
-	// Report against the same model.Request after GenerateContent returns.
-	// Built-in providers mutate it in place during token tailoring; a custom
-	// Model may copy it, so this is the final framework request, not a
-	// universal view of what a provider sent. Report on the error path too.
-	reportSummaryInjection(ctx, invocation, llmRequest)
 	if err != nil {
+		// generateContentSeq failed before returning a seq. Report once
+		// against the request as observed at that failure; do not also
+		// attach a seq finalizer.
+		reportSummaryInjection(ctx, invocation, llmRequest)
 		return ctx, nil, true, err
+	}
+	// Eager GenerateContent has already mutated llmRequest. A lazy
+	// IterModel may tailor or drop the selected summary only while the
+	// seq runs. Report once after the seq ends or is stopped early, and
+	// always attach that finalizer so a disabled call span cannot skip
+	// the record.
+	reportInjection := func() {
+		reportSummaryInjection(ctx, invocation, llmRequest)
 	}
 	if started {
 		finishSpanOnReturn = false
 		seq = withResponseSeqFinalizer(seq, func() {
+			reportInjection()
 			span.SetAttributes(
 				tokenTailoringAttrs(tailoringObserver.Snapshot())...,
 			)
 			finishCallSpan(nil)
 		})
+	} else {
+		seq = withResponseSeqFinalizer(seq, reportInjection)
 	}
 	return ctx, seq, true, nil
 }
@@ -2775,12 +2793,14 @@ func finalizeSummaryView(
 }
 
 // reportSummaryInjection reports whether the session summary selected while
-// building this request is still present in the same model.Request after
-// GenerateContent returns. Built-in providers, including the OpenAI adapter,
-// mutate that request in place during token tailoring, so the record then
-// reflects the tailored framework request. A custom Model may copy the
-// request, in which case the record does not claim to describe the payload
-// that Model sent. Requests that do not use session summaries report nothing.
+// building this request is still present in the same model.Request after the
+// model call has been observed. Eager GenerateContent mutates that request
+// before returning a seq; a lazy IterModel may mutate it only while the seq
+// runs. Built-in providers, including the OpenAI adapter, mutate the request
+// in place during token tailoring, so the record then reflects the tailored
+// framework request. A custom Model may copy the request, in which case the
+// record does not claim to describe the payload that Model sent. Requests
+// that do not use session summaries report nothing.
 func reportSummaryInjection(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -2825,8 +2845,8 @@ func reportSummaryInjection(
 	case summaryInjectionOutcomeSelectedBlockMissing:
 		// A selected summary whose original block is missing from the final
 		// framework request is the only injection defect that Warns. This is
-		// an observation of the same model.Request after GenerateContent
-		// returns; it does not claim what a provider sent, or that the
+		// an observation of the same model.Request after the model call has
+		// been observed; it does not claim what a provider sent, or that the
 		// summary was never written into the request.
 		log.WarnfContext(ctx, format, args...)
 	default:
@@ -2838,7 +2858,7 @@ func reportSummaryInjection(
 
 // summaryInjectionOutcome classifies one request's summary injection. A
 // selected summary whose original block is missing from the same framework
-// model.Request after GenerateContent returns is reported as
+// model.Request after the model call has been observed is reported as
 // selected_block_missing. That observation does not describe a provider's
 // final payload. A scope mismatch names the unused full-session summary; it
 // does not mean the scoped history was dropped from this request.

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -83,13 +83,13 @@ const (
 
 	// Session summary injection outcomes report whether a stored summary
 	// selected for this request is still observable in the same framework
-	// model.Request after GenerateContent returns. They do not describe a
-	// provider's final payload.
-	summaryInjectionOutcomeInjected             = "injected"
-	summaryInjectionOutcomeSelectedBlockMissing = "selected_block_missing"
-	summaryInjectionOutcomeNotSelected          = "not_selected"
-	summaryInjectionOutcomeLookupMiss           = "lookup_miss"
-	summaryInjectionOutcomeScopeMismatch        = "scope_mismatch"
+	// model.Request after the response sequence has been observed. They do
+	// not describe a provider's final payload.
+	summaryInjectionOutcomeBlockTextPresent = "block_text_present"
+	summaryInjectionOutcomeBlockTextMissing = "block_text_missing"
+	summaryInjectionOutcomeNotSelected      = "not_selected"
+	summaryInjectionOutcomeLookupMiss       = "lookup_miss"
+	summaryInjectionOutcomeScopeMismatch    = "scope_mismatch"
 )
 
 // InvocationHasFilteredUserTools reports whether the cached filtered tool
@@ -1735,31 +1735,35 @@ func (f *Flow) runContextCompaction(
 	if viewPresent {
 		summaryCtx = summaryview.ContextWithView(summaryCtx, view)
 	}
-	var viewFinalized bool
+	var usedRebuild bool
 	logResult := func(
 		outcome string,
 		result *model.Request,
 		postRequestTokens int,
 	) {
-		// After a post-rebuild Finalize the invocation holds the latest
-		// binding. Paths that never Finalize keep the snapshot frozen
-		// before summarization.
+		// After a rebuild, even when the post-rebuild token count fails,
+		// the invocation holds the latest view. Paths that never rebuild
+		// keep the snapshot frozen before summarization.
 		binding := summaryview.BindingFromContext(summaryCtx)
-		if viewFinalized {
+		if usedRebuild {
 			binding = summaryview.BindingFromInvocation(invocation)
 		}
 		filterKeyDisplay, filterKeyTruncated :=
 			summarydiag.FormatFilterKey(filterKey)
 		format := "Pre-LLM context compaction result: schema_version=%d, " +
-			"outcome=%s, agent=%s, filter_key=%q, filter_key_truncated=%t, " +
+			"outcome=%s, agent=%q, agent_truncated=%t, filter_key=%q, " +
+			"filter_key_truncated=%t, " +
 			"request_tokens=%d, threshold=%d, " +
 			"context_window=%d, messages=%d->%d, post_request_tokens=%d, " +
 			"summary_view_present=%t, summary_view_bound=%t, " +
 			"summary_view_items=%d, binding_reason=%s, duration_ms=%d"
+		agentName, agentTruncated :=
+			summarydiag.FormatAgentName(invocation.AgentName)
 		args := []any{
 			summarydiag.SchemaVersion,
 			outcome,
-			invocation.AgentName,
+			agentName,
+			agentTruncated,
 			filterKeyDisplay,
 			filterKeyTruncated,
 			decision.tokenCount,
@@ -1844,6 +1848,7 @@ func (f *Flow) runContextCompaction(
 		)
 		return req
 	}
+	usedRebuild = true
 	postDecisionRequest := requestWithCallLimitFinalizationMessage(
 		rebuilt,
 		rebuildPlan.callLimitFinalizationMessage,
@@ -1862,7 +1867,6 @@ func (f *Flow) runContextCompaction(
 			postDecisionRequest,
 			postDecision.tokenCount,
 		)
-		viewFinalized = true
 	} else {
 		log.DebugfContext(
 			ctx,
@@ -2542,12 +2546,21 @@ func (f *Flow) callLLM(
 	// Run before model callbacks if they exist.
 	ctx, customResp, err := f.runBeforeModelCallbacks(ctx, invocation, llmRequest)
 	if err != nil {
+		reportSummaryInjection(ctx, invocation, llmRequest)
 		return ctx, nil, false, err
 	}
 	if customResp != nil {
-		return ctx, func(yield func(*model.Response) bool) {
-			yield(customResp)
-		}, false, nil
+		// Keep the original callLLM return and span-on-return contract.
+		// The seq finalizer reports once on drain or early stop. An
+		// unused seq is never consumed, so it reports nothing.
+		return ctx, withResponseSeqFinalizer(
+			func(yield func(*model.Response) bool) {
+				yield(customResp)
+			},
+			func() {
+				reportSummaryInjection(ctx, invocation, llmRequest)
+			},
+		), false, nil
 	}
 	if llmRequest == nil || len(llmRequest.Messages) == 0 {
 		err = errors.New(errMsgNoLLMMessages)
@@ -2794,13 +2807,13 @@ func finalizeSummaryView(
 
 // reportSummaryInjection reports whether the session summary selected while
 // building this request is still present in the same model.Request after the
-// model call has been observed. Eager GenerateContent mutates that request
-// before returning a seq; a lazy IterModel may mutate it only while the seq
-// runs. Built-in providers, including the OpenAI adapter, mutate the request
-// in place during token tailoring, so the record then reflects the tailored
-// framework request. A custom Model may copy the request, in which case the
-// record does not claim to describe the payload that Model sent. Requests
-// that do not use session summaries report nothing.
+// response sequence has been observed. Eager GenerateContent mutates that
+// request before returning a seq; a lazy IterModel may mutate it only while
+// the seq runs. Built-in providers, including the OpenAI adapter, mutate the
+// request in place during token tailoring, so the record then reflects the
+// tailored framework request. A custom Model may copy the request, in which
+// case the record does not claim to describe the payload that Model sent.
+// Requests that do not use session summaries report nothing.
 func reportSummaryInjection(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -2817,16 +2830,20 @@ func reportSummaryInjection(
 	outcome := summaryInjectionOutcome(selection, blockPresent)
 	filterKey, filterKeyTruncated :=
 		summarydiag.FormatFilterKey(invocation.GetEventFilterKey())
+	agentName, agentTruncated :=
+		summarydiag.FormatAgentName(invocation.AgentName)
 	format := "Session summary injection result: schema_version=%d, " +
-		"outcome=%s, agent=%s, filter_key=%q, filter_key_truncated=%t, " +
-		"lookup_strategy=%s, lookup_result=%s, selected=%t, " +
-		"selected_block_present=%t, boundary_present=%t, stored_summaries=%d, " +
-		"matching_candidates=%d, full_session_summary=%t, session_events=%d, " +
-		"history_messages=%d, request_messages=%d"
+		"outcome=%s, agent=%q, agent_truncated=%t, filter_key=%q, " +
+		"filter_key_truncated=%t, lookup_strategy=%s, lookup_result=%s, " +
+		"selected=%t, block_text_present=%t, boundary_present=%t, " +
+		"stored_summaries=%d, matching_candidates=%d, " +
+		"full_session_summary=%t, session_events=%d, history_messages=%d, " +
+		"request_messages=%d"
 	args := []any{
 		summarydiag.SchemaVersion,
 		outcome,
-		invocation.AgentName,
+		agentName,
+		agentTruncated,
 		filterKey,
 		filterKeyTruncated,
 		selection.LookupStrategy,
@@ -2842,12 +2859,12 @@ func reportSummaryInjection(
 		len(req.Messages),
 	}
 	switch outcome {
-	case summaryInjectionOutcomeSelectedBlockMissing:
-		// A selected summary whose original block is missing from the final
-		// framework request is the only injection defect that Warns. This is
-		// an observation of the same model.Request after the model call has
-		// been observed; it does not claim what a provider sent, or that the
-		// summary was never written into the request.
+	case summaryInjectionOutcomeBlockTextMissing:
+		// A selected summary whose recorded block text is missing from every
+		// framework request message is the only injection defect that Warns.
+		// This is a substring observation of the same model.Request after
+		// the response sequence has been observed; it does not claim what
+		// a provider sent, or that the original injection slot is intact.
 		log.WarnfContext(ctx, format, args...)
 	default:
 		// Requests that found no in-scope summary, including a branch miss
@@ -2857,20 +2874,21 @@ func reportSummaryInjection(
 }
 
 // summaryInjectionOutcome classifies one request's summary injection. A
-// selected summary whose original block is missing from the same framework
-// model.Request after the model call has been observed is reported as
-// selected_block_missing. That observation does not describe a provider's
-// final payload. A scope mismatch names the unused full-session summary; it
-// does not mean the scoped history was dropped from this request.
+// selected summary whose recorded block text is missing from every message
+// Content in the same framework model.Request is reported as
+// block_text_missing. That observation does not describe a provider's
+// final payload or prove the original injection slot. A scope mismatch
+// names the unused full-session summary; it does not mean the scoped
+// history was dropped from this request.
 func summaryInjectionOutcome(
 	selection summaryinject.Selection,
 	blockPresent bool,
 ) string {
 	if selection.Selected {
 		if blockPresent {
-			return summaryInjectionOutcomeInjected
+			return summaryInjectionOutcomeBlockTextPresent
 		}
-		return summaryInjectionOutcomeSelectedBlockMissing
+		return summaryInjectionOutcomeBlockTextMissing
 	}
 	if selection.ScopeMismatch() {
 		return summaryInjectionOutcomeScopeMismatch

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -2515,6 +2515,7 @@ func (f *Flow) callLLM(
 	}()
 	if callModel == nil {
 		err = errors.New("no model available for LLM call")
+		reportSummaryInjection(ctx, invocation, llmRequest)
 		return ctx, nil, false, err
 	}
 	log.DebugfContext(
@@ -2526,6 +2527,7 @@ func (f *Flow) callLLM(
 	// configured (<= 0), this is a no-op and preserves existing behavior.
 	if err = invocation.IncLLMCallCount(); err != nil {
 		log.Errorf("LLM call limit exceeded for agent %s: %v", invocation.AgentName, err)
+		reportSummaryInjection(ctx, invocation, llmRequest)
 		return ctx, nil, false, err
 	}
 	llmLimitReached := calllimit.RecordLLMCall(
@@ -2564,6 +2566,7 @@ func (f *Flow) callLLM(
 	}
 	if llmRequest == nil || len(llmRequest.Messages) == 0 {
 		err = errors.New(errMsgNoLLMMessages)
+		reportSummaryInjection(ctx, invocation, llmRequest)
 		return ctx, nil, false, err
 	}
 	if invocation != nil && invocation.RunOptions.ExecutionTraceEnabled {

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -39,7 +39,9 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/responseusage"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/steer"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryfork"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryinject"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/internal/summarydiag"
 	itelemetry "trpc.group/trpc-go/trpc-agent-go/internal/telemetry"
 	itool "trpc.group/trpc-go/trpc-agent-go/internal/tool"
 	"trpc.group/trpc-go/trpc-agent-go/internal/toolcall"
@@ -78,6 +80,16 @@ const (
 	contextCompactionOutcomeRebuildUnavailable = "rebuild_unavailable"
 	contextCompactionOutcomePersistenceError   = "persistence_error"
 	contextCompactionOutcomePostCountError     = "post_count_error"
+
+	// Session summary injection outcomes report whether a stored summary
+	// selected for this request is still observable in the same framework
+	// model.Request after GenerateContent returns. They do not describe a
+	// provider's final payload.
+	summaryInjectionOutcomeInjected             = "injected"
+	summaryInjectionOutcomeSelectedBlockMissing = "selected_block_missing"
+	summaryInjectionOutcomeNotSelected          = "not_selected"
+	summaryInjectionOutcomeLookupMiss           = "lookup_miss"
+	summaryInjectionOutcomeScopeMismatch        = "scope_mismatch"
 )
 
 // InvocationHasFilteredUserTools reports whether the cached filtered tool
@@ -1728,30 +1740,31 @@ func (f *Flow) runContextCompaction(
 		result *model.Request,
 		postRequestTokens int,
 	) {
-		var viewBound bool
-		var viewItems int
-		if viewPresent && view != nil {
-			viewBound = view.Bound
-			viewItems = len(view.Items)
-		}
-		format := "Pre-LLM context compaction result: outcome=%s, agent=%s, " +
-			"filter_key=%q, request_tokens=%d, threshold=%d, " +
+		binding := summaryview.BindingFromContext(summaryCtx)
+		filterKeyDisplay, filterKeyTruncated :=
+			summarydiag.FormatFilterKey(filterKey)
+		format := "Pre-LLM context compaction result: schema_version=%d, " +
+			"outcome=%s, agent=%s, filter_key=%q, filter_key_truncated=%t, " +
+			"request_tokens=%d, threshold=%d, " +
 			"context_window=%d, messages=%d->%d, post_request_tokens=%d, " +
 			"summary_view_present=%t, summary_view_bound=%t, " +
-			"summary_view_items=%d, duration_ms=%d"
+			"summary_view_items=%d, binding_reason=%s, duration_ms=%d"
 		args := []any{
+			summarydiag.SchemaVersion,
 			outcome,
 			invocation.AgentName,
-			filterKey,
+			filterKeyDisplay,
+			filterKeyTruncated,
 			decision.tokenCount,
 			decision.threshold,
 			decision.contextWindow,
 			len(decisionRequest.Messages),
 			len(result.Messages),
 			postRequestTokens,
-			viewPresent,
-			viewBound,
-			viewItems,
+			binding.Present,
+			binding.Bound,
+			binding.Items,
+			binding.Reason,
 			time.Since(startedAt).Milliseconds(),
 		}
 		if outcome == contextCompactionOutcomeSuccess {
@@ -2586,6 +2599,11 @@ func (f *Flow) callLLM(
 		},
 	)
 	seq, err := f.generateContentSeq(ctx, invocation, llmRequest, callModel)
+	// Report against the same model.Request after GenerateContent returns.
+	// Built-in providers mutate it in place during token tailoring; a custom
+	// Model may copy it, so this is the final framework request, not a
+	// universal view of what a provider sent. Report on the error path too.
+	reportSummaryInjection(ctx, invocation, llmRequest)
 	if err != nil {
 		return ctx, nil, true, err
 	}
@@ -2754,6 +2772,93 @@ func finalizeSummaryView(
 		return
 	}
 	summaryview.Finalize(invocation, req, tokens)
+}
+
+// reportSummaryInjection reports whether the session summary selected while
+// building this request is still present in the same model.Request after
+// GenerateContent returns. Built-in providers, including the OpenAI adapter,
+// mutate that request in place during token tailoring, so the record then
+// reflects the tailored framework request. A custom Model may copy the
+// request, in which case the record does not claim to describe the payload
+// that Model sent. Requests that do not use session summaries report nothing.
+func reportSummaryInjection(
+	ctx context.Context,
+	invocation *agent.Invocation,
+	req *model.Request,
+) {
+	if invocation == nil || req == nil {
+		return
+	}
+	selection, ok := summaryinject.FromInvocation(invocation)
+	if !ok {
+		return
+	}
+	blockPresent := selection.BlockPresent(req.Messages)
+	outcome := summaryInjectionOutcome(selection, blockPresent)
+	filterKey, filterKeyTruncated :=
+		summarydiag.FormatFilterKey(invocation.GetEventFilterKey())
+	format := "Session summary injection result: schema_version=%d, " +
+		"outcome=%s, agent=%s, filter_key=%q, filter_key_truncated=%t, " +
+		"lookup_strategy=%s, lookup_result=%s, selected=%t, " +
+		"selected_block_present=%t, boundary_present=%t, stored_summaries=%d, " +
+		"matching_candidates=%d, full_session_summary=%t, session_events=%d, " +
+		"history_messages=%d, request_messages=%d"
+	args := []any{
+		summarydiag.SchemaVersion,
+		outcome,
+		invocation.AgentName,
+		filterKey,
+		filterKeyTruncated,
+		selection.LookupStrategy,
+		selection.LookupResult,
+		selection.Selected,
+		blockPresent,
+		selection.BoundaryPresent,
+		selection.StoredSummaries,
+		selection.MatchingCandidates,
+		selection.FullSessionPresent,
+		selection.SessionEvents,
+		selection.HistoryMessages,
+		len(req.Messages),
+	}
+	switch outcome {
+	case summaryInjectionOutcomeSelectedBlockMissing:
+		// A selected summary whose original block is missing from the final
+		// framework request is the only injection defect that Warns. This is
+		// an observation of the same model.Request after GenerateContent
+		// returns; it does not claim what a provider sent, or that the
+		// summary was never written into the request.
+		log.WarnfContext(ctx, format, args...)
+	default:
+		// Requests that found no in-scope summary, including a branch miss
+		// next to an unused full-session summary, are routine.
+		log.DebugfContext(ctx, format, args...)
+	}
+}
+
+// summaryInjectionOutcome classifies one request's summary injection. A
+// selected summary whose original block is missing from the same framework
+// model.Request after GenerateContent returns is reported as
+// selected_block_missing. That observation does not describe a provider's
+// final payload. A scope mismatch names the unused full-session summary; it
+// does not mean the scoped history was dropped from this request.
+func summaryInjectionOutcome(
+	selection summaryinject.Selection,
+	blockPresent bool,
+) string {
+	if selection.Selected {
+		if blockPresent {
+			return summaryInjectionOutcomeInjected
+		}
+		return summaryInjectionOutcomeSelectedBlockMissing
+	}
+	if selection.ScopeMismatch() {
+		return summaryInjectionOutcomeScopeMismatch
+	}
+	if selection.StoredSummaries > 0 {
+		return summaryInjectionOutcomeLookupMiss
+	}
+	return summaryInjectionOutcomeNotSelected
 }
 
 func (f *Flow) summaryViewTokenCounter() model.TokenCounter {

--- a/internal/flow/llmflow/summary_inject_test.go
+++ b/internal/flow/llmflow/summary_inject_test.go
@@ -659,6 +659,79 @@ func TestCallLLMReportsInjectionOnceOnBeforeModelError(t *testing.T) {
 	require.Contains(t, line, "block_text_present=true")
 }
 
+func TestCallLLMReportsInjectionOnceOnEarlyReturns(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T, *agent.Invocation) (model.Model, *model.Callbacks)
+	}{
+		{
+			name: "nil model",
+			setup: func(*testing.T, *agent.Invocation) (model.Model, *model.Callbacks) {
+				return nil, nil
+			},
+		},
+		{
+			name: "llm call limit",
+			setup: func(t *testing.T, inv *agent.Invocation) (model.Model, *model.Callbacks) {
+				t.Helper()
+				inv.MaxLLMCalls = 1
+				require.NoError(t, inv.IncLLMCallCount())
+				return &injectTailoringModel{}, nil
+			},
+		},
+		{
+			name: "empty messages after callback",
+			setup: func(*testing.T, *agent.Invocation) (model.Model, *model.Callbacks) {
+				callbacks := model.NewCallbacks()
+				callbacks.RegisterBeforeModel(func(
+					_ context.Context,
+					args *model.BeforeModelArgs,
+				) (*model.BeforeModelResult, error) {
+					args.Request.Messages = nil
+					return nil, nil
+				})
+				return &injectTailoringModel{}, callbacks
+			},
+		},
+	} {
+		t.Run(tc.name+"/selected", func(t *testing.T) {
+			logs := captureInjectionLogs(t)
+			inv, req := selectedSummaryInjectionInvocation(t)
+			callModel, callbacks := tc.setup(t, inv)
+			flow := New(nil, nil, Options{ModelCallbacks: callbacks})
+
+			_, seq, modelCalled, err := flow.callLLM(
+				context.Background(), inv, req, callModel,
+			)
+			require.Error(t, err)
+			require.Nil(t, seq)
+			require.False(t, modelCalled)
+			require.Len(t, logs.injectionLines(), 1)
+			_, line := logs.record(t)
+			requireInjectionRecord(t, line)
+		})
+		t.Run(tc.name+"/unselected", func(t *testing.T) {
+			logs := captureInjectionLogs(t)
+			inv := agent.NewInvocation(
+				agent.WithInvocationSession(&session.Session{ID: "no-summary"}),
+			)
+			inv.AgentName = "test-agent"
+			req := &model.Request{Messages: []model.Message{
+				model.NewUserMessage("current request"),
+			}}
+			callModel, callbacks := tc.setup(t, inv)
+			flow := New(nil, nil, Options{ModelCallbacks: callbacks})
+
+			_, seq, _, err := flow.callLLM(
+				context.Background(), inv, req, callModel,
+			)
+			require.Error(t, err)
+			require.Nil(t, seq)
+			require.Empty(t, logs.injectionLines())
+		})
+	}
+}
+
 func TestCallLLMReportsInjectionOnceOnBeforeModelCustomResponse(t *testing.T) {
 	logs := captureInjectionLogs(t)
 	inv, req := selectedSummaryInjectionInvocation(t)

--- a/internal/flow/llmflow/summary_inject_test.go
+++ b/internal/flow/llmflow/summary_inject_test.go
@@ -1,0 +1,435 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package llmflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	imodelrequest "trpc.group/trpc-go/trpc-agent-go/internal/modelrequest"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryinject"
+	"trpc.group/trpc-go/trpc-agent-go/internal/summarydiag"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const injectedSummaryBlock = "Session summary: SECRET-SUMMARY-CONTENT"
+
+// injectionLogs captures injection records emitted through the package logger.
+// The logger is process-global, so the recorder is synchronized.
+type injectionLogs struct {
+	mu    sync.Mutex
+	debug []string
+	warn  []string
+}
+
+func captureInjectionLogs(t *testing.T) *injectionLogs {
+	t.Helper()
+	logs := &injectionLogs{}
+	oldDebug, oldWarn := log.DebugfContext, log.WarnfContext
+	log.DebugfContext = func(_ context.Context, format string, args ...any) {
+		logs.append(&logs.debug, fmt.Sprintf(format, args...))
+	}
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		logs.append(&logs.warn, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.DebugfContext = oldDebug
+		log.WarnfContext = oldWarn
+	})
+	return logs
+}
+
+func (l *injectionLogs) append(level *[]string, line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	*level = append(*level, line)
+}
+
+func (l *injectionLogs) snapshot() (debug, warn []string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.debug...), append([]string(nil), l.warn...)
+}
+
+// record returns the single injection record captured at any level.
+func (l *injectionLogs) record(t *testing.T) (level, line string) {
+	t.Helper()
+	debug, warn := l.snapshot()
+	for _, candidate := range warn {
+		if strings.Contains(candidate, "injection result") {
+			requireInjectionRecord(t, candidate)
+			return "warn", candidate
+		}
+	}
+	for _, candidate := range debug {
+		if strings.Contains(candidate, "injection result") {
+			requireInjectionRecord(t, candidate)
+			return "debug", candidate
+		}
+	}
+	t.Fatalf("no injection record in %q %q", debug, warn)
+	return "", ""
+}
+
+func requireInjectionRecord(t *testing.T, line string) {
+	t.Helper()
+	require.True(t,
+		strings.HasPrefix(line, "Session summary injection result: schema_version=1,"),
+		"schema_version=1 must follow the record name in %q", line)
+}
+
+func injectionInvocation(
+	t *testing.T, selection summaryinject.Selection,
+) *agent.Invocation {
+	t.Helper()
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "SECRET-SESSION-ID"}),
+		agent.WithInvocationEventFilterKey("test-agent"),
+	)
+	inv.AgentName = "test-agent"
+	summaryinject.Record(inv, selection)
+	return inv
+}
+
+func TestReportSummaryInjectionReportsInjectedSummary(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:     summaryinject.LookupStrategyPrefix,
+		LookupResult:       summaryinject.LookupResultExact,
+		Selected:           true,
+		BoundaryPresent:    true,
+		StoredSummaries:    2,
+		MatchingCandidates: 1,
+		ScopedRequest:      true,
+		SessionEvents:      12,
+		HistoryMessages:    4,
+		Block:              injectedSummaryBlock,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("instructions\n\n" + injectedSummaryBlock),
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level,
+		"a correctly injected summary is routine")
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeInjected)
+	require.Contains(t, line, `filter_key="test-agent"`)
+	require.Contains(t, line, "filter_key_truncated=false")
+	require.Contains(t, line, "selected=true")
+	require.Contains(t, line, "selected_block_present=true")
+	require.NotContains(t, line, "injected=")
+	require.Contains(t, line, "boundary_present=true")
+	require.Contains(t, line, "stored_summaries=2")
+	require.Contains(t, line, "matching_candidates=1")
+	require.Contains(t, line, "lookup_strategy=prefix")
+	require.Contains(t, line, "lookup_result=exact")
+	require.Contains(t, line, "history_messages=4")
+	require.Contains(t, line, "request_messages=2")
+	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
+	require.NotContains(t, line, "SECRET-SESSION-ID")
+}
+
+// TestReportSummaryInjectionWarnsOnSelectedBlockMissing covers the only
+// injection state that Warns: a summary was selected, but the original
+// summary block is not observable in the same framework model.Request after
+// GenerateContent returns. That does not claim the provider payload.
+func TestReportSummaryInjectionWarnsOnSelectedBlockMissing(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyPrefix,
+		LookupResult:    summaryinject.LookupResultExact,
+		Selected:        true,
+		StoredSummaries: 1,
+		Block:           injectedSummaryBlock,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("instructions"),
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	level, line := logs.record(t)
+	require.Equal(t, "warn", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+	require.Contains(t, line, "selected=true")
+	require.Contains(t, line, "selected_block_present=false")
+	require.NotContains(t, line, "injected=")
+	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
+}
+
+// TestReportSummaryInjectionReportsLegitimateMiss covers a scoped request whose
+// branch has no summary yet while other branches do. That is normal and must
+// not add warning noise.
+func TestReportSummaryInjectionReportsLegitimateMiss(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyPrefix,
+		LookupResult:    summaryinject.LookupResultNone,
+		Selected:        false,
+		ScopedRequest:   true,
+		StoredSummaries: 3,
+		SessionEvents:   40,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeLookupMiss)
+	require.Contains(t, line, "stored_summaries=3")
+	require.Contains(t, line, "matching_candidates=0")
+	require.Contains(t, line, "session_events=40")
+}
+
+// TestReportSummaryInjectionReportsScopeMismatch covers a branch-scoped
+// request that finds nothing in scope while a full-session summary exists
+// outside it. That unused summary is diagnostic at Debug; it does not mean
+// the scoped history was dropped from this request.
+func TestReportSummaryInjectionReportsScopeMismatch(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:     summaryinject.LookupStrategyPrefix,
+		LookupResult:       summaryinject.LookupResultNone,
+		Selected:           false,
+		ScopedRequest:      true,
+		StoredSummaries:    1,
+		FullSessionPresent: true,
+		SessionEvents:      120,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeScopeMismatch)
+	require.Contains(t, line, "full_session_summary=true")
+	require.Contains(t, line, "matching_candidates=0")
+	require.NotContains(t, line, "SECRET-SESSION-ID")
+	_, warn := logs.snapshot()
+	require.Empty(t, warn,
+		"an unused full-session summary must not Warn")
+}
+
+func TestReportSummaryInjectionReportsNoStoredSummary(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy: summaryinject.LookupStrategyPrefix,
+		LookupResult:   summaryinject.LookupResultNone,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeNotSelected)
+	_, warn := logs.snapshot()
+	require.Empty(t, warn,
+		"sessions without a stored summary must stay quiet")
+}
+
+// injectTailoringModel simulates a built-in provider: it applies token tailoring to
+// the shared request while constructing the provider payload, then returns.
+type injectTailoringModel struct {
+	tailor func(*model.Request)
+}
+
+func (m *injectTailoringModel) Info() model.Info {
+	return model.Info{Name: "tailoring"}
+}
+
+func (m *injectTailoringModel) GenerateContent(
+	ctx context.Context,
+	req *model.Request,
+) (<-chan *model.Response, error) {
+	before := len(req.Messages)
+	m.tailor(req)
+	imodelrequest.RecordTokenTailoring(ctx, imodelrequest.TokenTailoringRecord{
+		Provider:       "tailoring",
+		MaxInputTokens: 16,
+		BeforeMessages: before,
+		AfterMessages:  len(req.Messages),
+	})
+	ch := make(chan *model.Response, 1)
+	ch <- &model.Response{Done: true}
+	close(ch)
+	return ch, nil
+}
+
+// TestCallLLMReportsInjectionAfterTokenTailoring pins the reporting boundary:
+// the injection record describes the same model.Request after GenerateContent
+// returns. Built-in providers mutate it in place, so a summary block missing
+// after their token tailoring is reported as selected_block_missing rather
+// than injected.
+func TestCallLLMReportsInjectionAfterTokenTailoring(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyPrefix,
+		LookupResult:    summaryinject.LookupResultExact,
+		Selected:        true,
+		StoredSummaries: 1,
+		Block:           injectedSummaryBlock,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("instructions\n\n" + injectedSummaryBlock),
+		model.NewUserMessage("older turn"),
+		model.NewUserMessage("current request"),
+	}}
+	tailored := &injectTailoringModel{tailor: func(r *model.Request) {
+		r.Messages = r.Messages[len(r.Messages)-1:]
+	}}
+
+	flow := New(nil, nil, Options{})
+	_, seq, _, err := flow.callLLM(context.Background(), inv, req, tailored)
+	require.NoError(t, err)
+	require.NotNil(t, seq)
+
+	level, line := logs.record(t)
+	require.Equal(t, "warn", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+	require.Contains(t, line, "selected=true")
+	require.Contains(t, line, "selected_block_present=false")
+	require.NotContains(t, line, "injected=")
+	require.Contains(t, line, "request_messages=1")
+	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
+}
+
+// TestCallLLMReportsInjectionWhenTailoringKeepsSummary is the counterpart:
+// tailoring that preserves the summary head still reports a real injection.
+func TestCallLLMReportsInjectionWhenTailoringKeepsSummary(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyPrefix,
+		LookupResult:    summaryinject.LookupResultExact,
+		Selected:        true,
+		StoredSummaries: 1,
+		Block:           injectedSummaryBlock,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("instructions\n\n" + injectedSummaryBlock),
+		model.NewUserMessage("older turn"),
+		model.NewUserMessage("current request"),
+	}}
+	tailored := &injectTailoringModel{tailor: func(r *model.Request) {
+		r.Messages = append(r.Messages[:1], r.Messages[len(r.Messages)-1])
+	}}
+
+	flow := New(nil, nil, Options{})
+	_, _, _, err := flow.callLLM(context.Background(), inv, req, tailored)
+	require.NoError(t, err)
+
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeInjected)
+	require.Contains(t, line, "selected_block_present=true")
+	require.NotContains(t, line, "injected=")
+	require.Contains(t, line, "request_messages=2")
+}
+
+// TestReportSummaryInjectionStaysSilentWithoutSelection verifies that requests
+// which never consult session summaries report nothing at all.
+func TestReportSummaryInjectionStaysSilentWithoutSelection(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "session"}),
+	)
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+	reportSummaryInjection(context.Background(), nil, req)
+	reportSummaryInjection(context.Background(), inv, nil)
+
+	debug, warn := logs.snapshot()
+	require.Empty(t, debug)
+	require.Empty(t, warn)
+}
+
+func TestReportSummaryInjectionLogsEmptyFilterKey(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "SECRET-SESSION-ID"}),
+	)
+	inv.AgentName = "test-agent"
+	summaryinject.Record(inv, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyAll,
+		LookupResult:    summaryinject.LookupResultNone,
+		Selected:        false,
+		StoredSummaries: 0,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	_, line := logs.record(t)
+	require.Contains(t, line, `filter_key=""`)
+	require.Contains(t, line, "filter_key_truncated=false")
+}
+
+func TestReportSummaryInjectionTruncatesLongFilterKey(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	key := strings.Repeat("支", summarydiag.FilterKeyMaxRunes+4)
+	display, truncated := summarydiag.FormatFilterKey(key)
+	require.True(t, truncated)
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(&session.Session{ID: "SECRET-SESSION-ID"}),
+		agent.WithInvocationEventFilterKey(key),
+	)
+	inv.AgentName = "test-agent"
+	summaryinject.Record(inv, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyExact,
+		LookupResult:    summaryinject.LookupResultNone,
+		Selected:        false,
+		ScopedRequest:   true,
+		StoredSummaries: 1,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	_, line := logs.record(t)
+	require.Contains(t, line, fmt.Sprintf("filter_key=%q", display))
+	require.Contains(t, line, "filter_key_truncated=true")
+	require.NotContains(t, line, key)
+	require.Equal(t, key, inv.GetEventFilterKey(),
+		"truncation must not change the invocation filter key")
+}

--- a/internal/flow/llmflow/summary_inject_test.go
+++ b/internal/flow/llmflow/summary_inject_test.go
@@ -67,6 +67,23 @@ func (l *injectionLogs) snapshot() (debug, warn []string) {
 }
 
 // record returns the single injection record captured at any level.
+func (l *injectionLogs) injectionLines() []string {
+	debug, warn := l.snapshot()
+	var lines []string
+	for _, candidate := range append(append([]string{}, warn...), debug...) {
+		if strings.Contains(candidate, "injection result") {
+			lines = append(lines, candidate)
+		}
+	}
+	return lines
+}
+
+func drainResponseSeq(t *testing.T, seq model.Seq[*model.Response]) {
+	t.Helper()
+	require.NotNil(t, seq)
+	seq(func(*model.Response) bool { return true })
+}
+
 func (l *injectionLogs) record(t *testing.T) (level, line string) {
 	t.Helper()
 	debug, warn := l.snapshot()
@@ -314,7 +331,7 @@ func TestCallLLMReportsInjectionAfterTokenTailoring(t *testing.T) {
 	flow := New(nil, nil, Options{})
 	_, seq, _, err := flow.callLLM(context.Background(), inv, req, tailored)
 	require.NoError(t, err)
-	require.NotNil(t, seq)
+	drainResponseSeq(t, seq)
 
 	level, line := logs.record(t)
 	require.Equal(t, "warn", level)
@@ -348,8 +365,9 @@ func TestCallLLMReportsInjectionWhenTailoringKeepsSummary(t *testing.T) {
 	}}
 
 	flow := New(nil, nil, Options{})
-	_, _, _, err := flow.callLLM(context.Background(), inv, req, tailored)
+	_, seq, _, err := flow.callLLM(context.Background(), inv, req, tailored)
 	require.NoError(t, err)
+	drainResponseSeq(t, seq)
 
 	level, line := logs.record(t)
 	require.Equal(t, "debug", level)
@@ -358,6 +376,144 @@ func TestCallLLMReportsInjectionWhenTailoringKeepsSummary(t *testing.T) {
 	require.Contains(t, line, "selected_block_present=true")
 	require.NotContains(t, line, "injected=")
 	require.Contains(t, line, "request_messages=2")
+}
+
+// injectLazyTailoringIterModel simulates a lazy IterModel: GenerateContentIter
+// returns a seq immediately, and token tailoring mutates the shared request
+// only while that seq runs.
+type injectLazyTailoringIterModel struct {
+	tailor func(*model.Request)
+	err    error
+}
+
+func (m *injectLazyTailoringIterModel) Info() model.Info {
+	return model.Info{Name: "lazy-tailoring"}
+}
+
+func (m *injectLazyTailoringIterModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	return nil, fmt.Errorf("unexpected GenerateContent call")
+}
+
+func (m *injectLazyTailoringIterModel) GenerateContentIter(
+	ctx context.Context,
+	req *model.Request,
+) (model.Seq[*model.Response], error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return func(yield func(*model.Response) bool) {
+		before := len(req.Messages)
+		if m.tailor != nil {
+			m.tailor(req)
+		}
+		imodelrequest.RecordTokenTailoring(ctx, imodelrequest.TokenTailoringRecord{
+			Provider:       "lazy-tailoring",
+			MaxInputTokens: 16,
+			BeforeMessages: before,
+			AfterMessages:  len(req.Messages),
+		})
+		yield(&model.Response{Done: true})
+	}, nil
+}
+
+func selectedSummaryInjectionInvocation(t *testing.T) (*agent.Invocation, *model.Request) {
+	t.Helper()
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyPrefix,
+		LookupResult:    summaryinject.LookupResultExact,
+		Selected:        true,
+		StoredSummaries: 1,
+		Block:           injectedSummaryBlock,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("instructions\n\n" + injectedSummaryBlock),
+		model.NewUserMessage("older turn"),
+		model.NewUserMessage("current request"),
+	}}
+	return inv, req
+}
+
+func dropAllButLastMessage(r *model.Request) {
+	r.Messages = r.Messages[len(r.Messages)-1:]
+}
+
+// TestCallLLMReportsInjectionAfterLazyIterTailoring is the lazy-IterModel
+// counterpart of TestCallLLMReportsInjectionAfterTokenTailoring: the seq is
+// returned before tailoring runs, so reporting immediately would falsely
+// record injected. The final record must be selected_block_missing, once.
+func TestCallLLMReportsInjectionAfterLazyIterTailoring(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv, req := selectedSummaryInjectionInvocation(t)
+	lazy := &injectLazyTailoringIterModel{tailor: dropAllButLastMessage}
+
+	flow := New(nil, nil, Options{})
+	_, seq, _, err := flow.callLLM(context.Background(), inv, req, lazy)
+	require.NoError(t, err)
+	require.NotNil(t, seq)
+	require.Empty(t, logs.injectionLines(),
+		"lazy IterModel must not report injected before the seq runs")
+
+	drainResponseSeq(t, seq)
+
+	require.Len(t, logs.injectionLines(), 1)
+	level, line := logs.record(t)
+	require.Equal(t, "warn", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+	require.Contains(t, line, "selected=true")
+	require.Contains(t, line, "selected_block_present=false")
+	require.NotContains(t, line, "injected=")
+	require.Contains(t, line, "request_messages=1")
+	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
+}
+
+// TestCallLLMReportsInjectionOnceWhenLazyIterStopsEarly proves the seq
+// finalizer still reports once when the consumer stops before draining.
+func TestCallLLMReportsInjectionOnceWhenLazyIterStopsEarly(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv, req := selectedSummaryInjectionInvocation(t)
+	lazy := &injectLazyTailoringIterModel{tailor: dropAllButLastMessage}
+
+	flow := New(nil, nil, Options{})
+	_, seq, _, err := flow.callLLM(context.Background(), inv, req, lazy)
+	require.NoError(t, err)
+	require.Empty(t, logs.injectionLines())
+
+	seq(func(*model.Response) bool { return false })
+
+	require.Len(t, logs.injectionLines(), 1)
+	level, line := logs.record(t)
+	require.Equal(t, "warn", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+	require.Contains(t, line, "selected_block_present=false")
+}
+
+// TestCallLLMReportsInjectionOnceWhenGenerateContentSeqFails covers the
+// error path: generateContentSeq returns an error, the injection record is
+// emitted immediately, and it is not repeated.
+func TestCallLLMReportsInjectionOnceWhenGenerateContentSeqFails(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv, req := selectedSummaryInjectionInvocation(t)
+	lazy := &injectLazyTailoringIterModel{
+		err: fmt.Errorf("generate content failed"),
+	}
+
+	flow := New(nil, nil, Options{})
+	_, seq, _, err := flow.callLLM(context.Background(), inv, req, lazy)
+	require.Error(t, err)
+	require.Nil(t, seq)
+
+	require.Len(t, logs.injectionLines(), 1)
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeInjected)
+	require.Contains(t, line, "selected_block_present=true")
+	require.Contains(t, line, "request_messages=3")
 }
 
 // TestReportSummaryInjectionStaysSilentWithoutSelection verifies that requests

--- a/internal/flow/llmflow/summary_inject_test.go
+++ b/internal/flow/llmflow/summary_inject_test.go
@@ -148,11 +148,13 @@ func TestReportSummaryInjectionReportsInjectedSummary(t *testing.T) {
 	require.Equal(t, "debug", level,
 		"a correctly injected summary is routine")
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeInjected)
+		"outcome="+summaryInjectionOutcomeBlockTextPresent)
+	require.Contains(t, line, `agent="test-agent"`)
+	require.Contains(t, line, "agent_truncated=false")
 	require.Contains(t, line, `filter_key="test-agent"`)
 	require.Contains(t, line, "filter_key_truncated=false")
 	require.Contains(t, line, "selected=true")
-	require.Contains(t, line, "selected_block_present=true")
+	require.Contains(t, line, "block_text_present=true")
 	require.NotContains(t, line, "injected=")
 	require.Contains(t, line, "boundary_present=true")
 	require.Contains(t, line, "stored_summaries=2")
@@ -168,7 +170,7 @@ func TestReportSummaryInjectionReportsInjectedSummary(t *testing.T) {
 // TestReportSummaryInjectionWarnsOnSelectedBlockMissing covers the only
 // injection state that Warns: a summary was selected, but the original
 // summary block is not observable in the same framework model.Request after
-// GenerateContent returns. That does not claim the provider payload.
+// the response sequence has been observed. That does not claim the provider payload.
 func TestReportSummaryInjectionWarnsOnSelectedBlockMissing(t *testing.T) {
 	logs := captureInjectionLogs(t)
 	inv := injectionInvocation(t, summaryinject.Selection{
@@ -188,9 +190,9 @@ func TestReportSummaryInjectionWarnsOnSelectedBlockMissing(t *testing.T) {
 	level, line := logs.record(t)
 	require.Equal(t, "warn", level)
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+		"outcome="+summaryInjectionOutcomeBlockTextMissing)
 	require.Contains(t, line, "selected=true")
-	require.Contains(t, line, "selected_block_present=false")
+	require.Contains(t, line, "block_text_present=false")
 	require.NotContains(t, line, "injected=")
 	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
 }
@@ -308,8 +310,8 @@ func (m *injectTailoringModel) GenerateContent(
 // TestCallLLMReportsInjectionAfterTokenTailoring pins the reporting boundary:
 // the injection record describes the same model.Request after GenerateContent
 // returns. Built-in providers mutate it in place, so a summary block missing
-// after their token tailoring is reported as selected_block_missing rather
-// than injected.
+// after their token tailoring is reported as block_text_missing rather
+// than block_text_present.
 func TestCallLLMReportsInjectionAfterTokenTailoring(t *testing.T) {
 	logs := captureInjectionLogs(t)
 	inv := injectionInvocation(t, summaryinject.Selection{
@@ -336,9 +338,9 @@ func TestCallLLMReportsInjectionAfterTokenTailoring(t *testing.T) {
 	level, line := logs.record(t)
 	require.Equal(t, "warn", level)
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+		"outcome="+summaryInjectionOutcomeBlockTextMissing)
 	require.Contains(t, line, "selected=true")
-	require.Contains(t, line, "selected_block_present=false")
+	require.Contains(t, line, "block_text_present=false")
 	require.NotContains(t, line, "injected=")
 	require.Contains(t, line, "request_messages=1")
 	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
@@ -372,8 +374,8 @@ func TestCallLLMReportsInjectionWhenTailoringKeepsSummary(t *testing.T) {
 	level, line := logs.record(t)
 	require.Equal(t, "debug", level)
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeInjected)
-	require.Contains(t, line, "selected_block_present=true")
+		"outcome="+summaryInjectionOutcomeBlockTextPresent)
+	require.Contains(t, line, "block_text_present=true")
 	require.NotContains(t, line, "injected=")
 	require.Contains(t, line, "request_messages=2")
 }
@@ -443,7 +445,7 @@ func dropAllButLastMessage(r *model.Request) {
 // TestCallLLMReportsInjectionAfterLazyIterTailoring is the lazy-IterModel
 // counterpart of TestCallLLMReportsInjectionAfterTokenTailoring: the seq is
 // returned before tailoring runs, so reporting immediately would falsely
-// record injected. The final record must be selected_block_missing, once.
+// record block_text_present. The final record must be block_text_missing, once.
 func TestCallLLMReportsInjectionAfterLazyIterTailoring(t *testing.T) {
 	logs := captureInjectionLogs(t)
 	inv, req := selectedSummaryInjectionInvocation(t)
@@ -462,9 +464,9 @@ func TestCallLLMReportsInjectionAfterLazyIterTailoring(t *testing.T) {
 	level, line := logs.record(t)
 	require.Equal(t, "warn", level)
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
+		"outcome="+summaryInjectionOutcomeBlockTextMissing)
 	require.Contains(t, line, "selected=true")
-	require.Contains(t, line, "selected_block_present=false")
+	require.Contains(t, line, "block_text_present=false")
 	require.NotContains(t, line, "injected=")
 	require.Contains(t, line, "request_messages=1")
 	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
@@ -488,8 +490,8 @@ func TestCallLLMReportsInjectionOnceWhenLazyIterStopsEarly(t *testing.T) {
 	level, line := logs.record(t)
 	require.Equal(t, "warn", level)
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeSelectedBlockMissing)
-	require.Contains(t, line, "selected_block_present=false")
+		"outcome="+summaryInjectionOutcomeBlockTextMissing)
+	require.Contains(t, line, "block_text_present=false")
 }
 
 // TestCallLLMReportsInjectionOnceWhenGenerateContentSeqFails covers the
@@ -511,8 +513,8 @@ func TestCallLLMReportsInjectionOnceWhenGenerateContentSeqFails(t *testing.T) {
 	level, line := logs.record(t)
 	require.Equal(t, "debug", level)
 	require.Contains(t, line,
-		"outcome="+summaryInjectionOutcomeInjected)
-	require.Contains(t, line, "selected_block_present=true")
+		"outcome="+summaryInjectionOutcomeBlockTextPresent)
+	require.Contains(t, line, "block_text_present=true")
 	require.Contains(t, line, "request_messages=3")
 }
 
@@ -588,4 +590,100 @@ func TestReportSummaryInjectionTruncatesLongFilterKey(t *testing.T) {
 	require.NotContains(t, line, key)
 	require.Equal(t, key, inv.GetEventFilterKey(),
 		"truncation must not change the invocation filter key")
+}
+
+func TestReportSummaryInjectionQuotesUnsafeAgentName(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy: summaryinject.LookupStrategyAll,
+		LookupResult:   summaryinject.LookupResultNone,
+	})
+	inv.AgentName = "agent\nextra,field=1"
+	display, truncated := summarydiag.FormatAgentName(inv.AgentName)
+	require.False(t, truncated)
+	req := &model.Request{Messages: []model.Message{
+		model.NewUserMessage("current request"),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	_, line := logs.record(t)
+	require.Contains(t, line, fmt.Sprintf("agent=%q", display))
+	require.Contains(t, line, "agent_truncated=false")
+	require.NotContains(t, line, "\n")
+}
+
+func TestReportSummaryInjectionTreatsUnrelatedCopyAsBlockTextPresent(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv := injectionInvocation(t, summaryinject.Selection{
+		LookupStrategy:  summaryinject.LookupStrategyPrefix,
+		LookupResult:    summaryinject.LookupResultExact,
+		Selected:        true,
+		StoredSummaries: 1,
+		Block:           injectedSummaryBlock,
+	})
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("instructions without the original block"),
+		model.NewUserMessage("unrelated copy:\n" + injectedSummaryBlock),
+	}}
+
+	reportSummaryInjection(context.Background(), inv, req)
+
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeBlockTextPresent)
+	require.Contains(t, line, "block_text_present=true")
+	require.NotContains(t, line, "SECRET-SUMMARY-CONTENT")
+}
+
+func TestCallLLMReportsInjectionOnceOnBeforeModelError(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv, req := selectedSummaryInjectionInvocation(t)
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		context.Context, *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		return nil, fmt.Errorf("before model failed")
+	})
+	flow := New(nil, nil, Options{ModelCallbacks: callbacks})
+
+	_, seq, modelCalled, err := flow.callLLM(
+		context.Background(), inv, req, &injectTailoringModel{},
+	)
+	require.Error(t, err)
+	require.Nil(t, seq)
+	require.False(t, modelCalled)
+	require.Len(t, logs.injectionLines(), 1)
+	_, line := logs.record(t)
+	require.Contains(t, line, "block_text_present=true")
+}
+
+func TestCallLLMReportsInjectionOnceOnBeforeModelCustomResponse(t *testing.T) {
+	logs := captureInjectionLogs(t)
+	inv, req := selectedSummaryInjectionInvocation(t)
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		context.Context, *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		return &model.BeforeModelResult{
+			CustomResponse: &model.Response{Done: true},
+		}, nil
+	})
+	flow := New(nil, nil, Options{ModelCallbacks: callbacks})
+
+	_, seq, modelCalled, err := flow.callLLM(
+		context.Background(), inv, req, &injectTailoringModel{},
+	)
+	require.NoError(t, err)
+	require.False(t, modelCalled)
+	require.Empty(t, logs.injectionLines())
+
+	seq(func(*model.Response) bool { return false })
+
+	require.Len(t, logs.injectionLines(), 1)
+	level, line := logs.record(t)
+	require.Equal(t, "debug", level)
+	require.Contains(t, line,
+		"outcome="+summaryInjectionOutcomeBlockTextPresent)
 }

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -30,6 +30,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/fileref"
 	iflow "trpc.group/trpc-go/trpc-agent-go/internal/flow"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/messageorigin"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryinject"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
 	"trpc.group/trpc-go/trpc-agent-go/internal/state/toolresultround"
 	"trpc.group/trpc-go/trpc-agent-go/internal/util/message"
@@ -694,6 +695,7 @@ func (p *ContentRequestProcessor) ProcessRequest(
 	}
 	invocation.DeleteState(contentHasCompactedToolResultsStateKey)
 	summaryview.Clear(invocation)
+	summaryinject.Clear(invocation)
 
 	cfg := p.runtimeConfigFromInvocation(invocation)
 	skipHistory := cfg.includeMode == "none"
@@ -783,14 +785,16 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 	}
 
 	var userContextBlocks []string
-	summaryText, summaryCutoff := p.sessionSummaryForRequest(invocation, skipHistory)
+	summarySelection := p.sessionSummaryForRequest(invocation, skipHistory)
+	summaryText := summarySelection.text
+	summaryCutoff := summarySelection.cutoff
 	userContextBlocks = p.appendPreloadMemoryContext(
 		ctx,
 		invocation,
 		req,
 		userContextBlocks,
 	)
-	userContextBlocks = p.appendSummaryContext(
+	userContextBlocks, summarySelection.block = p.appendSummaryContext(
 		invocation,
 		req,
 		summaryText,
@@ -829,6 +833,8 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 
 	messageStart := len(req.Messages)
 	req.Messages = append(req.Messages, messages...)
+	summarySelection.historyMessages = len(messages)
+	summarySelection.record(invocation)
 	view := modelVisibleHistoryView(
 		invocation,
 		history,
@@ -883,18 +889,69 @@ func modelVisibleHistoryView(
 	}
 }
 
+// requestSummarySelection is the per-request session summary selection and the
+// diagnostics needed to explain it at the final request boundary.
+type requestSummarySelection struct {
+	enabled         bool
+	text            string
+	cutoff          summaryHistoryCutoff
+	diagnostics     summarySelectionDiagnostics
+	block           string
+	historyMessages int
+	sessionEvents   int
+}
+
+// record publishes the selection so the final request boundary can report
+// whether the selected summary reached the model. Requests that do not use
+// session summaries publish nothing and stay silent.
+func (s requestSummarySelection) record(invocation *agent.Invocation) {
+	if !s.enabled {
+		return
+	}
+	summaryinject.Record(invocation, summaryinject.Selection{
+		LookupStrategy:     s.diagnostics.strategy,
+		LookupResult:       s.diagnostics.result,
+		Selected:           s.text != "",
+		BoundaryPresent:    !s.cutoff.IsZero(),
+		StoredSummaries:    s.diagnostics.storedSummaries,
+		MatchingCandidates: s.diagnostics.matchingCandidates,
+		FullSessionPresent: s.diagnostics.fullSessionPresent,
+		ScopedRequest:      s.diagnostics.scopedRequest,
+		SessionEvents:      s.sessionEvents,
+		HistoryMessages:    s.historyMessages,
+		Block:              s.block,
+	})
+}
+
 func (p *ContentRequestProcessor) sessionSummaryForRequest(
 	invocation *agent.Invocation,
 	skipHistory bool,
-) (string, summaryHistoryCutoff) {
+) requestSummarySelection {
 	// Skip session summary when include_contents=none, but still get current
 	// invocation's events (tool calls/results) to maintain ReAct loop context.
 	if skipHistory || !p.AddSessionSummary || p.TimelineFilterMode != TimelineFilterAll {
-		return "", summaryHistoryCutoff{}
+		return requestSummarySelection{}
 	}
 	// Fetch session summary early so we can insert it after other semi-stable
 	// system blocks (for example, preloaded memories).
-	return p.getSessionSummaryText(invocation)
+	text, cutoff, diagnostics := p.lookUpSessionSummary(invocation)
+	return requestSummarySelection{
+		enabled:       true,
+		text:          text,
+		cutoff:        cutoff,
+		diagnostics:   diagnostics,
+		sessionEvents: sessionEventCount(invocation),
+	}
+}
+
+// sessionEventCount reports how many events the session currently stores.
+func sessionEventCount(invocation *agent.Invocation) int {
+	if invocation == nil || invocation.Session == nil {
+		return 0
+	}
+	invocation.Session.EventMu.RLock()
+	defer invocation.Session.EventMu.RUnlock()
+	return len(invocation.Session.Events)
 }
 
 func (p *ContentRequestProcessor) appendPreloadMemoryContext(
@@ -918,28 +975,28 @@ func (p *ContentRequestProcessor) appendPreloadMemoryContext(
 	return userContextBlocks
 }
 
+// appendSummaryContext injects the selected summary and returns the formatted
+// block that was written into the request.
 func (p *ContentRequestProcessor) appendSummaryContext(
 	invocation *agent.Invocation,
 	req *model.Request,
 	summaryText string,
 	userContextBlocks []string,
-) []string {
+) ([]string, string) {
 	if summaryText == "" {
-		return userContextBlocks
+		return userContextBlocks, ""
 	}
 	invocation.SetState(contentHasSessionSummaryStateKey, true)
 	if p.SessionSummaryInjectionMode == SessionSummaryInjectionUser {
-		return appendUserContextBlock(
-			userContextBlocks,
-			p.formatSummaryForUser(summaryText),
-		)
+		block := p.formatSummaryForUser(summaryText)
+		return appendUserContextBlock(userContextBlocks, block), block
 	}
 	summaryMsg := model.Message{
 		Role:    model.RoleSystem,
 		Content: p.formatSummary(summaryText),
 	}
 	p.injectSystemContextMessage(req, summaryMsg)
-	return userContextBlocks
+	return userContextBlocks, summaryMsg.Content
 }
 
 func (p *ContentRequestProcessor) appendPreloadSessionRecallContext(
@@ -1138,8 +1195,33 @@ func (c eventHistoryCutoff) excludesEvent(index int, evt event.Event) bool {
 // cutoff for the current branch. It does not format or assign
 // a role — callers decide how to inject the text into the request.
 func (p *ContentRequestProcessor) getSessionSummaryText(inv *agent.Invocation) (string, summaryHistoryCutoff) {
+	text, cutoff, _ := p.lookUpSessionSummary(inv)
+	return text, cutoff
+}
+
+// summarySelectionDiagnostics reports how a stored summary lookup resolved. It
+// separates the configured scope from what that scope found, and carries only
+// counts and stable enum values, never summary text or filter keys.
+type summarySelectionDiagnostics struct {
+	strategy           string
+	result             string
+	storedSummaries    int
+	matchingCandidates int
+	fullSessionPresent bool
+	scopedRequest      bool
+}
+
+// lookUpSessionSummary selects the stored summary for the current request and
+// reports how the lookup resolved.
+func (p *ContentRequestProcessor) lookUpSessionSummary(
+	inv *agent.Invocation,
+) (string, summaryHistoryCutoff, summarySelectionDiagnostics) {
+	diagnostics := summarySelectionDiagnostics{
+		strategy: p.summaryLookupStrategy(),
+		result:   summaryinject.LookupResultNone,
+	}
 	if inv.Session == nil {
-		return "", summaryHistoryCutoff{}
+		return "", summaryHistoryCutoff{}, diagnostics
 	}
 
 	// Acquire read lock to protect Summaries access.
@@ -1147,25 +1229,99 @@ func (p *ContentRequestProcessor) getSessionSummaryText(inv *agent.Invocation) (
 	defer inv.Session.SummariesMu.RUnlock()
 
 	if inv.Session.Summaries == nil {
-		return "", summaryHistoryCutoff{}
+		return "", summaryHistoryCutoff{}, diagnostics
 	}
 	filter := inv.GetEventFilterKey()
 	// For BranchFilterModeAll, prefer the full-session summary under empty filter key.
 	if p.BranchFilterMode == BranchFilterModeAll {
 		filter = ""
 	}
+	diagnostics.scopedRequest = filter != ""
+	diagnostics.storedSummaries = countStoredSummaries(inv.Session.Summaries)
+	diagnostics.matchingCandidates = p.countMatchingSummaries(
+		inv.Session.Summaries, filter,
+	)
+	diagnostics.fullSessionPresent = hasStoredSummary(
+		inv.Session.Summaries, session.SummaryFilterKeyAllContents,
+	)
 
 	// Try exact match first.
 	sum := inv.Session.Summaries[filter]
 	if sum != nil && sum.Summary != "" {
-		return sum.Summary, summaryHistoryCutoffFromBoundary(sum.CutoffBoundary())
+		diagnostics.result = summaryinject.LookupResultExact
+		return sum.Summary,
+			summaryHistoryCutoffFromBoundary(sum.CutoffBoundary()),
+			diagnostics
 	}
 
 	// For BranchFilterModePrefix, aggregate summaries with matching prefix.
 	if p.BranchFilterMode == BranchFilterModePrefix && filter != "" {
-		return p.aggregatePrefixSummaries(inv.Session.Summaries, filter)
+		text, cutoff := p.aggregatePrefixSummaries(inv.Session.Summaries, filter)
+		if text != "" {
+			diagnostics.result = summaryinject.LookupResultPrefix
+		}
+		return text, cutoff, diagnostics
 	}
-	return "", summaryHistoryCutoff{}
+	return "", summaryHistoryCutoff{}, diagnostics
+}
+
+// summaryLookupStrategy reports the summary scope this processor searches.
+// Subtree and exact branch modes both look up only the request's own key.
+func (p *ContentRequestProcessor) summaryLookupStrategy() string {
+	switch p.BranchFilterMode {
+	case BranchFilterModeAll:
+		return summaryinject.LookupStrategyAll
+	case BranchFilterModePrefix:
+		return summaryinject.LookupStrategyPrefix
+	default:
+		return summaryinject.LookupStrategyExact
+	}
+}
+
+// countMatchingSummaries counts the non-empty summaries inside the configured
+// lookup scope. Callers must hold the session summaries read lock.
+func (p *ContentRequestProcessor) countMatchingSummaries(
+	summaries map[string]*session.Summary,
+	filter string,
+) int {
+	if p.BranchFilterMode == BranchFilterModePrefix && filter != "" {
+		count := 0
+		for key, sum := range summaries {
+			if sum == nil || sum.Summary == "" {
+				continue
+			}
+			if session.SummaryFilterKeyMatchesPrefix(key, filter) {
+				count++
+			}
+		}
+		return count
+	}
+	if hasStoredSummary(summaries, filter) {
+		return 1
+	}
+	return 0
+}
+
+// hasStoredSummary reports whether a non-empty summary is stored under key.
+// Callers must hold the session summaries read lock.
+func hasStoredSummary(
+	summaries map[string]*session.Summary,
+	key string,
+) bool {
+	sum := summaries[key]
+	return sum != nil && sum.Summary != ""
+}
+
+// countStoredSummaries counts non-empty summaries across all filter keys.
+// Callers must hold the session summaries read lock.
+func countStoredSummaries(summaries map[string]*session.Summary) int {
+	count := 0
+	for _, sum := range summaries {
+		if sum != nil && sum.Summary != "" {
+			count++
+		}
+	}
+	return count
 }
 
 // getSessionSummaryMessage returns the current-branch session summary as a

--- a/internal/flow/processor/content.go
+++ b/internal/flow/processor/content.go
@@ -823,6 +823,7 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 	// turn. If no such message exists, fall back to a trailing user message in
 	// req.Messages (for example, injected context) to avoid creating an extra
 	// adjacent user block.
+	summarySelection.historyMessages = len(messages)
 	if len(userContextBlocks) > 0 {
 		messages = prependUserContextMessage(
 			strings.Join(userContextBlocks, mergedUserSeparator),
@@ -833,7 +834,6 @@ func (p *ContentRequestProcessor) appendSessionMessages(
 
 	messageStart := len(req.Messages)
 	req.Messages = append(req.Messages, messages...)
-	summarySelection.historyMessages = len(messages)
 	summarySelection.record(invocation)
 	view := modelVisibleHistoryView(
 		invocation,

--- a/internal/flow/processor/content_summaryinject_test.go
+++ b/internal/flow/processor/content_summaryinject_test.go
@@ -297,3 +297,36 @@ func TestSummaryInjectionIsClearedBetweenRequests(t *testing.T) {
 	require.False(t, selection.Selected)
 	require.Zero(t, selection.StoredSummaries)
 }
+
+func TestSummaryInjectionHistoryMessagesExcludesSyntheticUserContext(t *testing.T) {
+	sess := &session.Session{
+		ID: "session",
+		Summaries: map[string]*session.Summary{
+			"test-agent": {
+				Summary:   injectSummaryText,
+				UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("test-agent"),
+	)
+	inv.AgentName = "test-agent"
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithSessionSummaryInjectionMode(SessionSummaryInjectionUser),
+	).ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.True(t, selection.Selected)
+	require.Zero(t, selection.HistoryMessages,
+		"a synthetic user-context message is not cutoff history")
+	require.GreaterOrEqual(t, len(req.Messages), 2,
+		"user-mode injection still prepends a synthetic context message")
+}

--- a/internal/flow/processor/content_summaryinject_test.go
+++ b/internal/flow/processor/content_summaryinject_test.go
@@ -1,0 +1,299 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package processor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryinject"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const injectSummaryText = "SUMMARY-CONTENT-THAT-MUST-REACH-THE-MODEL"
+
+func injectSession(summaries map[string]*session.Summary) *session.Session {
+	return &session.Session{
+		ID:        "session",
+		Summaries: summaries,
+		Events: []event.Event{{
+			Author:    "user",
+			Timestamp: time.Date(2023, 1, 1, 11, 0, 0, 0, time.UTC),
+			FilterKey: "test-agent",
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.NewUserMessage("earlier question"),
+			}}},
+		}},
+	}
+}
+
+func injectInvocation(sess *session.Session) *agent.Invocation {
+	inv := agent.NewInvocation(
+		agent.WithInvocationSession(sess),
+		agent.WithInvocationEventFilterKey("test-agent"),
+		agent.WithInvocationMessage(model.NewUserMessage("current request")),
+	)
+	inv.AgentName = "test-agent"
+	return inv
+}
+
+func TestSummaryInjectionRecordsExactSelection(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		"test-agent": {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(WithAddSessionSummary(true)).
+		ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.Equal(t, summaryinject.LookupStrategyPrefix, selection.LookupStrategy)
+	require.Equal(t, summaryinject.LookupResultExact, selection.LookupResult)
+	require.True(t, selection.Selected)
+	require.Equal(t, 1, selection.StoredSummaries)
+	require.Equal(t, 1, selection.MatchingCandidates)
+	require.Equal(t, 1, selection.SessionEvents)
+	require.True(t, selection.BlockPresent(req.Messages),
+		"the selected summary must be detected in the assembled request")
+}
+
+// TestSummaryInjectionDetectsDroppedSummary proves that the reported injection
+// state is derived from the request that will actually be sent, not from the
+// selection decision. A later stage that rewrites the request must be visible.
+func TestSummaryInjectionDetectsDroppedSummary(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		"test-agent": {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(WithAddSessionSummary(true)).
+		ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.True(t, selection.BlockPresent(req.Messages))
+
+	// A provider adapter or token tailoring rebuilds the request without the
+	// summary block.
+	tailored := []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+		model.NewUserMessage("current request"),
+	}
+	require.False(t, selection.BlockPresent(tailored))
+}
+
+func TestSummaryInjectionRecordsUserModeSelection(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		"test-agent": {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithSessionSummaryInjectionMode(SessionSummaryInjectionUser),
+	).ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.True(t, selection.Selected)
+	require.True(t, selection.BlockPresent(req.Messages),
+		"user-mode summaries are merged into a user message and must still be detected")
+}
+
+// TestSummaryInjectionRecordsLookupMiss covers a session that stores summaries
+// under keys this request does not read.
+func TestSummaryInjectionRecordsLookupMiss(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		"other-agent": {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(WithAddSessionSummary(true)).
+		ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.False(t, selection.Selected)
+	require.Equal(t, summaryinject.LookupResultNone, selection.LookupResult)
+	require.Equal(t, 1, selection.StoredSummaries,
+		"stored summaries under other keys must stay visible to operators")
+	require.Zero(t, selection.MatchingCandidates)
+	require.False(t, selection.FullSessionPresent)
+	require.False(t, selection.ScopeMismatch(),
+		"an unrelated branch summary is a legitimate miss, not a scope mismatch")
+	require.False(t, selection.BlockPresent(req.Messages))
+}
+
+// TestSummaryInjectionRecordsScopeMismatch covers a branch-scoped request that
+// finds nothing in its configured scope while a full-session summary exists
+// outside it. The unused summary is recorded; it does not mean the scoped
+// history was dropped from this request.
+func TestSummaryInjectionRecordsScopeMismatch(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		session.SummaryFilterKeyAllContents: {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(WithAddSessionSummary(true)).
+		ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.False(t, selection.Selected)
+	require.Equal(t, summaryinject.LookupStrategyPrefix, selection.LookupStrategy)
+	require.Equal(t, summaryinject.LookupResultNone, selection.LookupResult)
+	require.Equal(t, 1, selection.StoredSummaries)
+	require.Zero(t, selection.MatchingCandidates)
+	require.True(t, selection.FullSessionPresent)
+	require.True(t, selection.ScopedRequest)
+	require.True(t, selection.ScopeMismatch())
+}
+
+// TestSummaryInjectionReadsFullSessionSummaryInAllMode is the counterpart:
+// the same stored state is in scope when the request reads all contents, so
+// there is nothing to report.
+func TestSummaryInjectionReadsFullSessionSummaryInAllMode(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		session.SummaryFilterKeyAllContents: {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithBranchFilterMode(BranchFilterModeAll),
+	).ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.True(t, selection.Selected)
+	require.Equal(t, summaryinject.LookupStrategyAll, selection.LookupStrategy)
+	require.Equal(t, summaryinject.LookupResultExact, selection.LookupResult)
+	require.False(t, selection.ScopedRequest)
+	require.False(t, selection.ScopeMismatch())
+}
+
+// TestSummaryInjectionExactModeReportsScopeMismatch guards the exact-key
+// strategy, where a branch request cannot fall back to any other key.
+func TestSummaryInjectionExactModeReportsScopeMismatch(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		session.SummaryFilterKeyAllContents: {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(
+		WithAddSessionSummary(true),
+		WithBranchFilterMode(BranchFilterModeExact),
+	).ProcessRequest(context.Background(), inv, req, nil)
+
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.Equal(t, summaryinject.LookupStrategyExact, selection.LookupStrategy)
+	require.True(t, selection.ScopeMismatch())
+}
+
+func TestSummaryInjectionRecordsNothingWhenSummariesAreDisabled(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		"test-agent": {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	req := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+
+	NewContentRequestProcessor(WithAddSessionSummary(false)).
+		ProcessRequest(context.Background(), inv, req, nil)
+
+	_, ok := summaryinject.FromInvocation(inv)
+	require.False(t, ok,
+		"requests that do not use session summaries must report nothing")
+}
+
+// TestSummaryInjectionIsClearedBetweenRequests guards against a stale selection
+// from an earlier model request being reported for a later one.
+func TestSummaryInjectionIsClearedBetweenRequests(t *testing.T) {
+	sess := injectSession(map[string]*session.Summary{
+		"test-agent": {
+			Summary:   injectSummaryText,
+			UpdatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	})
+	inv := injectInvocation(sess)
+	processor := NewContentRequestProcessor(WithAddSessionSummary(true))
+
+	first := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+	processor.ProcessRequest(context.Background(), inv, first, nil)
+	selection, ok := summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.True(t, selection.Selected)
+
+	sess.Summaries = map[string]*session.Summary{}
+	second := &model.Request{Messages: []model.Message{
+		model.NewSystemMessage("existing system prompt"),
+	}}
+	processor.ProcessRequest(context.Background(), inv, second, nil)
+	selection, ok = summaryinject.FromInvocation(inv)
+	require.True(t, ok)
+	require.False(t, selection.Selected)
+	require.Zero(t, selection.StoredSummaries)
+}

--- a/internal/flow/processor/content_summarylookup_test.go
+++ b/internal/flow/processor/content_summarylookup_test.go
@@ -1,0 +1,254 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package processor
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+// TestGetSessionSummaryTextMatchesBaseLookup pins the text and cutoff returned
+// by getSessionSummaryText against the pre-diagnostics selection rules for
+// every BranchFilterMode, empty and non-empty summaries, and nil/present
+// boundaries. Diagnostics collected beside the lookup must not change those
+// two return values.
+func TestGetSessionSummaryTextMatchesBaseLookup(t *testing.T) {
+	branchAt := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	childAt := time.Date(2024, 6, 1, 13, 0, 0, 0, time.UTC)
+	fullAt := time.Date(2024, 6, 1, 11, 0, 0, 0, time.UTC)
+	branchBoundary := session.NewSummaryBoundaryWithEventID(
+		"test-agent", branchAt, "evt-branch",
+	)
+	childBoundary := session.NewSummaryBoundaryWithEventID(
+		"test-agent/child", childAt, "evt-child",
+	)
+	fullBoundary := session.NewSummaryBoundaryWithEventID(
+		"", fullAt, "evt-full",
+	)
+
+	populated := map[string]*session.Summary{
+		"test-agent": {
+			Summary:   "branch-summary",
+			UpdatedAt: branchAt,
+			Boundary:  branchBoundary,
+		},
+		"test-agent/child": {
+			Summary:   "child-summary",
+			UpdatedAt: childAt,
+			Boundary:  childBoundary,
+		},
+		"": {
+			Summary:   "full-summary",
+			UpdatedAt: fullAt,
+			Boundary:  fullBoundary,
+		},
+		"other-agent": {
+			Summary:   "other-summary",
+			UpdatedAt: branchAt,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		mode       string
+		filterKey  string
+		summaries  map[string]*session.Summary
+		nilSession bool
+	}{
+		{
+			name:       "nil session",
+			mode:       BranchFilterModePrefix,
+			filterKey:  "test-agent",
+			nilSession: true,
+		},
+		{
+			name:      "nil summaries map",
+			mode:      BranchFilterModePrefix,
+			filterKey: "test-agent",
+			summaries: nil,
+		},
+		{
+			name:      "empty summaries map",
+			mode:      BranchFilterModePrefix,
+			filterKey: "test-agent",
+			summaries: map[string]*session.Summary{},
+		},
+		{
+			name:      "nil summary pointer is a miss",
+			mode:      BranchFilterModeExact,
+			filterKey: "test-agent",
+			summaries: map[string]*session.Summary{"test-agent": nil},
+		},
+		{
+			name:      "empty summary text is a miss",
+			mode:      BranchFilterModeExact,
+			filterKey: "test-agent",
+			summaries: map[string]*session.Summary{
+				"test-agent": {Summary: "", UpdatedAt: branchAt, Boundary: branchBoundary},
+			},
+		},
+		{
+			name:      "exact hit with boundary",
+			mode:      BranchFilterModeExact,
+			filterKey: "test-agent",
+			summaries: populated,
+		},
+		{
+			name:      "exact miss keeps raw history",
+			mode:      BranchFilterModeExact,
+			filterKey: "missing",
+			summaries: populated,
+		},
+		{
+			name:      "subtree uses the request key only",
+			mode:      BranchFilterModeSubtree,
+			filterKey: "test-agent",
+			summaries: populated,
+		},
+		{
+			name:      "all mode reads the full-session key",
+			mode:      BranchFilterModeAll,
+			filterKey: "test-agent",
+			summaries: populated,
+		},
+		{
+			name:      "all mode with empty full-session summary",
+			mode:      BranchFilterModeAll,
+			filterKey: "test-agent",
+			summaries: map[string]*session.Summary{
+				"":           {Summary: ""},
+				"test-agent": populated["test-agent"],
+			},
+		},
+		{
+			name:      "prefix exact hit does not aggregate",
+			mode:      BranchFilterModePrefix,
+			filterKey: "test-agent",
+			summaries: populated,
+		},
+		{
+			name:      "prefix aggregate when exact key is empty",
+			mode:      BranchFilterModePrefix,
+			filterKey: "test-agent",
+			summaries: map[string]*session.Summary{
+				"test-agent":       {Summary: ""},
+				"test-agent/child": populated["test-agent/child"],
+				"":                 populated[""],
+			},
+		},
+		{
+			name:      "prefix empty filter does not aggregate",
+			mode:      BranchFilterModePrefix,
+			filterKey: "",
+			summaries: populated,
+		},
+		{
+			name:      "legacy updated_at cutoff when boundary is nil",
+			mode:      BranchFilterModeExact,
+			filterKey: "legacy",
+			summaries: map[string]*session.Summary{
+				"legacy": {Summary: "legacy-text", UpdatedAt: branchAt},
+			},
+		},
+		{
+			name:      "zero updated_at and nil boundary yield a zero cutoff",
+			mode:      BranchFilterModeExact,
+			filterKey: "test-agent",
+			summaries: map[string]*session.Summary{
+				"test-agent": {Summary: "no-cutoff"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sess *session.Session
+			if !tt.nilSession {
+				sess = &session.Session{ID: "session", Summaries: tt.summaries}
+			}
+			inv := agent.NewInvocation(
+				agent.WithInvocationSession(sess),
+				agent.WithInvocationEventFilterKey(tt.filterKey),
+			)
+			p := NewContentRequestProcessor(WithBranchFilterMode(tt.mode))
+
+			wantText, wantCutoff := baseSessionSummaryLookup(
+				tt.mode, tt.filterKey, tt.summaries, sess == nil,
+			)
+			gotText, gotCutoff := p.getSessionSummaryText(inv)
+			require.Equal(t, wantText, gotText)
+			require.Equal(t, wantCutoff, gotCutoff)
+
+			lookupText, lookupCutoff, _ := p.lookUpSessionSummary(inv)
+			require.Equal(t, wantText, lookupText,
+				"diagnostics lookup must return the same text")
+			require.Equal(t, wantCutoff, lookupCutoff,
+				"diagnostics lookup must return the same cutoff")
+		})
+	}
+}
+
+// baseSessionSummaryLookup is the pre-diagnostics selection oracle. Keep it
+// aligned with bcd0a567 getSessionSummaryText: exact key, then prefix
+// aggregate, otherwise empty.
+func baseSessionSummaryLookup(
+	mode, filterKey string,
+	summaries map[string]*session.Summary,
+	nilSession bool,
+) (string, summaryHistoryCutoff) {
+	if nilSession || summaries == nil {
+		return "", summaryHistoryCutoff{}
+	}
+	filter := filterKey
+	if mode == BranchFilterModeAll {
+		filter = ""
+	}
+	sum := summaries[filter]
+	if sum != nil && sum.Summary != "" {
+		return sum.Summary, summaryHistoryCutoffFromBoundary(sum.CutoffBoundary())
+	}
+	if mode == BranchFilterModePrefix && filter != "" {
+		return baseAggregatePrefixSummaries(summaries, filter)
+	}
+	return "", summaryHistoryCutoff{}
+}
+
+func baseAggregatePrefixSummaries(
+	summaries map[string]*session.Summary,
+	prefix string,
+) (string, summaryHistoryCutoff) {
+	var parts []string
+	keys := make([]string, 0, len(summaries))
+	for key := range summaries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		sum := summaries[key]
+		if sum == nil || sum.Summary == "" {
+			continue
+		}
+		if session.SummaryFilterKeyMatchesPrefix(key, prefix) {
+			parts = append(parts, sum.Summary)
+		}
+	}
+	if len(parts) == 0 {
+		return "", summaryHistoryCutoff{}
+	}
+	boundary, _ := session.SummaryPrefixBoundary(summaries, prefix)
+	return strings.Join(parts, "\n\n"), summaryHistoryCutoffFromBoundary(boundary)
+}

--- a/internal/state/summaryinject/summaryinject.go
+++ b/internal/state/summaryinject/summaryinject.go
@@ -1,0 +1,144 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+// Package summaryinject carries the session summary selected while building
+// one model request so the final request boundary can report whether the
+// selected summary is still present in the framework request after
+// GenerateContent returns.
+package summaryinject
+
+import (
+	"strings"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const stateKey = "trpc_agent.summary.injection"
+
+// Lookup strategies describe the scope a request was configured to search.
+// They are stable diagnostic values and never contain a filter key.
+const (
+	// LookupStrategyExact searches only the request's own filter key.
+	LookupStrategyExact = "exact"
+	// LookupStrategyPrefix searches the request's key and its hierarchical
+	// descendants.
+	LookupStrategyPrefix = "prefix"
+	// LookupStrategyAll searches the full-session summary regardless of the
+	// request's own filter key.
+	LookupStrategyAll = "all"
+	// LookupStrategyNone marks a request that does not use session summaries.
+	LookupStrategyNone = "none"
+)
+
+// Lookup results describe what the configured strategy actually found. They
+// are reported separately from the strategy so a miss keeps the scope that was
+// searched.
+const (
+	// LookupResultExact marks a summary found under the searched key.
+	LookupResultExact = "exact"
+	// LookupResultPrefix marks summaries aggregated from a key prefix.
+	LookupResultPrefix = "prefix"
+	// LookupResultNone marks a lookup that found nothing in scope.
+	LookupResultNone = "none"
+)
+
+// Selection records the session summary lookup performed for one model
+// request. It is request-scoped state, not a persisted or serialized contract.
+type Selection struct {
+	// LookupStrategy reports the scope the request was configured to search.
+	LookupStrategy string
+	// LookupResult reports what that scope found.
+	LookupResult string
+	// Selected reports whether a non-empty summary was found.
+	Selected bool
+	// BoundaryPresent reports whether the selected summary carries a usable
+	// history cutoff.
+	BoundaryPresent bool
+	// StoredSummaries is the number of non-empty stored summaries the session
+	// held at selection time, across all filter keys.
+	StoredSummaries int
+	// MatchingCandidates is the number of stored summaries inside the
+	// configured lookup scope.
+	MatchingCandidates int
+	// FullSessionPresent reports whether a non-empty full-session summary was
+	// stored, whether or not it was inside the configured scope.
+	FullSessionPresent bool
+	// ScopedRequest reports whether the request searched a non-empty branch
+	// key, so a miss can be separated from a full-session lookup.
+	ScopedRequest bool
+	// SessionEvents is the number of stored session events at selection time.
+	SessionEvents int
+	// HistoryMessages is the number of history messages that survived the
+	// summary cutoff and were appended to the request.
+	HistoryMessages int
+	// Block is the formatted summary block written into the request. It is
+	// retained only to detect the block in the assembled request and is never
+	// logged.
+	Block string
+}
+
+// ScopeMismatch reports a lookup miss that is still worth diagnosing: a
+// request scoped to a branch key found no summary in its configured scope
+// while the session holds a full-session summary outside that scope. This
+// does not mean history was dropped. Because no in-scope summary was
+// selected, this request's summary cutoff stays zero, so the raw scoped
+// history is kept at this stage. That does not depend on whether the
+// out-of-scope full-session summary has a boundary. Later token tailoring
+// may still trim the request.
+func (s Selection) ScopeMismatch() bool {
+	return !s.Selected && s.ScopedRequest && s.FullSessionPresent
+}
+
+// Record stores the selection made for the current model request, replacing
+// any previous record. A nil invocation is ignored.
+func Record(inv *agent.Invocation, selection Selection) {
+	if inv == nil {
+		return
+	}
+	inv.SetState(stateKey, &selection)
+}
+
+// Clear removes the selection recorded for the current model request.
+func Clear(inv *agent.Invocation) {
+	if inv == nil {
+		return
+	}
+	inv.DeleteState(stateKey)
+}
+
+// FromInvocation returns the selection recorded for the current model request.
+func FromInvocation(inv *agent.Invocation) (Selection, bool) {
+	stored, ok := agent.GetStateValue[*Selection](inv, stateKey)
+	if !ok || stored == nil {
+		return Selection{}, false
+	}
+	return *stored, true
+}
+
+// BlockPresent reports whether the recorded summary block is still present in
+// the assembled request. It only compares the recorded block against message
+// content and never derives anything else from the request. The scan is
+// O(total message bytes) and does not copy the request.
+func (s Selection) BlockPresent(messages []model.Message) bool {
+	if !s.Selected || s.Block == "" {
+		return false
+	}
+	block := s.Block
+	for i := range messages {
+		content := messages[i].Content
+		if len(content) < len(block) {
+			continue
+		}
+		if strings.Contains(content, block) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/state/summaryinject/summaryinject.go
+++ b/internal/state/summaryinject/summaryinject.go
@@ -9,7 +9,7 @@
 
 // Package summaryinject carries the session summary selected while building
 // one model request so the final request boundary can report whether the
-// selected summary is still present in the framework request after
+// recorded summary block text still appears in any message Content after
 // GenerateContent returns.
 package summaryinject
 
@@ -76,11 +76,12 @@ type Selection struct {
 	// SessionEvents is the number of stored session events at selection time.
 	SessionEvents int
 	// HistoryMessages is the number of history messages that survived the
-	// summary cutoff and were appended to the request.
+	// summary cutoff, counted before any synthetic user-context message is
+	// prepended.
 	HistoryMessages int
 	// Block is the formatted summary block written into the request. It is
-	// retained only to detect the block in the assembled request and is never
-	// logged.
+	// retained only to detect the same text in any message Content and is
+	// never logged.
 	Block string
 }
 
@@ -122,10 +123,11 @@ func FromInvocation(inv *agent.Invocation) (Selection, bool) {
 	return *stored, true
 }
 
-// BlockPresent reports whether the recorded summary block is still present in
-// the assembled request. It only compares the recorded block against message
-// content and never derives anything else from the request. The scan is
-// O(total message bytes) and does not copy the request.
+// BlockPresent reports whether the recorded summary block text still appears
+// as a substring of any message Content in the assembled request. A match
+// does not prove the original injection slot is intact and does not describe
+// a provider payload. The scan is O(total message bytes) and does not copy
+// the request.
 func (s Selection) BlockPresent(messages []model.Message) bool {
 	if !s.Selected || s.Block == "" {
 		return false

--- a/internal/state/summaryinject/summaryinject_bench_test.go
+++ b/internal/state/summaryinject/summaryinject_bench_test.go
@@ -1,0 +1,143 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summaryinject
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// Long-context stand-in: each message is several kilobytes so a miss walks
+// total request bytes rather than a handful of short strings.
+const benchMessageBytes = 4096
+
+func benchSummaryBlock() string {
+	return "Here is a brief summary of your previous interactions:\n\n" +
+		"<summary_of_previous_interactions>\n" +
+		strings.Repeat("topic-billing-refund-policy ", 12) +
+		"\n</summary_of_previous_interactions>\n"
+}
+
+func benchHistoryBody() string {
+	return strings.Repeat("user-and-assistant-turn-payload-", benchMessageBytes/32)
+}
+
+func benchMessages(n int, blockAtPrefix bool, block string) []model.Message {
+	body := benchHistoryBody()
+	messages := make([]model.Message, n)
+	for i := range messages {
+		content := body
+		if blockAtPrefix && i == 0 {
+			content = block + body
+		}
+		role := model.RoleUser
+		if i%2 == 0 {
+			role = model.RoleAssistant
+		}
+		if i == 0 {
+			role = model.RoleSystem
+		}
+		messages[i] = model.Message{Role: role, Content: content}
+	}
+	return messages
+}
+
+// blockPresentNoop is the diagnostics-off baseline: no request scan.
+func blockPresentNoop(Selection, []model.Message) bool { return false }
+
+// blockPresentNaive is strings.Contains with no length guard.
+func blockPresentNaive(s Selection, messages []model.Message) bool {
+	if !s.Selected || s.Block == "" {
+		return false
+	}
+	for i := range messages {
+		if strings.Contains(messages[i].Content, s.Block) {
+			return true
+		}
+	}
+	return false
+}
+
+// blockPresentPrefixThenContains is the discarded HasPrefix-then-Contains
+// candidate. It is kept here so benches can compare it with production.
+func blockPresentPrefixThenContains(s Selection, messages []model.Message) bool {
+	if !s.Selected || s.Block == "" {
+		return false
+	}
+	for i := range messages {
+		content := messages[i].Content
+		if len(content) < len(s.Block) {
+			continue
+		}
+		if strings.HasPrefix(content, s.Block) || strings.Contains(content, s.Block) {
+			return true
+		}
+	}
+	return false
+}
+
+func BenchmarkBlockPresent(b *testing.B) {
+	block := benchSummaryBlock()
+	selection := Selection{Selected: true, Block: block}
+
+	for _, n := range []int{16, 256} {
+		for _, loc := range []string{"prefix", "absent"} {
+			msgs := benchMessages(n, loc == "prefix", block)
+			name := fmt.Sprintf("%s/%d", loc, n)
+
+			b.Run("baseline_noop/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				var present bool
+				for i := 0; i < b.N; i++ {
+					present = blockPresentNoop(selection, msgs)
+				}
+				if present {
+					b.Fatal("noop baseline must not scan")
+				}
+			})
+			b.Run("naive_contains/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				want := loc == "prefix"
+				var present bool
+				for i := 0; i < b.N; i++ {
+					present = blockPresentNaive(selection, msgs)
+				}
+				if present != want {
+					b.Fatalf("naive present=%v want=%v", present, want)
+				}
+			})
+			b.Run("prefix_then_contains/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				want := loc == "prefix"
+				var present bool
+				for i := 0; i < b.N; i++ {
+					present = blockPresentPrefixThenContains(selection, msgs)
+				}
+				if present != want {
+					b.Fatalf("prefix_then_contains present=%v want=%v", present, want)
+				}
+			})
+			b.Run("current/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				want := loc == "prefix"
+				var present bool
+				for i := 0; i < b.N; i++ {
+					present = selection.BlockPresent(msgs)
+				}
+				if present != want {
+					b.Fatalf("current present=%v want=%v", present, want)
+				}
+			})
+		}
+	}
+}

--- a/internal/state/summaryinject/summaryinject_test.go
+++ b/internal/state/summaryinject/summaryinject_test.go
@@ -1,0 +1,172 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summaryinject
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+const summaryBlock = "Session summary:\nthe user asked about billing"
+
+func TestRecordAndFromInvocation(t *testing.T) {
+	inv := agent.NewInvocation()
+	_, ok := FromInvocation(inv)
+	require.False(t, ok, "an untouched invocation reports no selection")
+
+	Record(inv, Selection{
+		LookupStrategy:     LookupStrategyPrefix,
+		LookupResult:       LookupResultExact,
+		Selected:           true,
+		StoredSummaries:    2,
+		MatchingCandidates: 1,
+		Block:              summaryBlock,
+	})
+	selection, ok := FromInvocation(inv)
+	require.True(t, ok)
+	require.Equal(t, LookupStrategyPrefix, selection.LookupStrategy)
+	require.Equal(t, LookupResultExact, selection.LookupResult)
+	require.Equal(t, 2, selection.StoredSummaries)
+	require.Equal(t, 1, selection.MatchingCandidates)
+
+	Record(inv, Selection{
+		LookupStrategy: LookupStrategyPrefix,
+		LookupResult:   LookupResultNone,
+	})
+	selection, ok = FromInvocation(inv)
+	require.True(t, ok, "a later request replaces the previous selection")
+	require.Equal(t, LookupResultNone, selection.LookupResult)
+	require.False(t, selection.Selected)
+
+	Clear(inv)
+	_, ok = FromInvocation(inv)
+	require.False(t, ok)
+}
+
+func TestSelectionScopeMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		selection Selection
+		want      bool
+	}{
+		{
+			name: "scoped request misses an existing full-session summary",
+			selection: Selection{
+				ScopedRequest:      true,
+				FullSessionPresent: true,
+			},
+			want: true,
+		},
+		{
+			name: "unrelated branch summary is a legitimate miss",
+			selection: Selection{
+				ScopedRequest:   true,
+				StoredSummaries: 1,
+			},
+			want: false,
+		},
+		{
+			name: "full-session request cannot mismatch its own scope",
+			selection: Selection{
+				FullSessionPresent: true,
+			},
+			want: false,
+		},
+		{
+			name: "a selected summary is never a mismatch",
+			selection: Selection{
+				Selected:           true,
+				ScopedRequest:      true,
+				FullSessionPresent: true,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.selection.ScopeMismatch())
+		})
+	}
+}
+
+func TestRecordToleratesNilInvocation(t *testing.T) {
+	require.NotPanics(t, func() {
+		Record(nil, Selection{})
+		Clear(nil)
+		_, ok := FromInvocation(nil)
+		require.False(t, ok)
+	})
+}
+
+func TestSelectionBlockPresent(t *testing.T) {
+	tests := []struct {
+		name      string
+		selection Selection
+		messages  []model.Message
+		want      bool
+	}{
+		{
+			name:      "block is the whole message",
+			selection: Selection{Selected: true, Block: summaryBlock},
+			messages: []model.Message{
+				model.NewSystemMessage(summaryBlock),
+			},
+			want: true,
+		},
+		{
+			name:      "block merged behind other context",
+			selection: Selection{Selected: true, Block: summaryBlock},
+			messages: []model.Message{
+				model.NewSystemMessage("instructions"),
+				model.NewUserMessage("recalled memory\n\n" + summaryBlock),
+			},
+			want: true,
+		},
+		{
+			name:      "block dropped from the request",
+			selection: Selection{Selected: true, Block: summaryBlock},
+			messages: []model.Message{
+				model.NewSystemMessage("instructions"),
+				model.NewUserMessage("current question"),
+			},
+			want: false,
+		},
+		{
+			name:      "nothing was selected",
+			selection: Selection{Selected: false, Block: summaryBlock},
+			messages: []model.Message{
+				model.NewSystemMessage(summaryBlock),
+			},
+			want: false,
+		},
+		{
+			name:      "selected without a recorded block",
+			selection: Selection{Selected: true},
+			messages: []model.Message{
+				model.NewSystemMessage("instructions"),
+			},
+			want: false,
+		},
+		{
+			name:      "empty request",
+			selection: Selection{Selected: true, Block: summaryBlock},
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.selection.BlockPresent(tt.messages))
+		})
+	}
+}

--- a/internal/state/summaryview/binding_test.go
+++ b/internal/state/summaryview/binding_test.go
@@ -1,0 +1,228 @@
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summaryview
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+// projectionFor builds a two-item projection over the given history messages.
+func projectionFor(history []model.Message, requestLength int) *View {
+	items := make([]Item, len(history))
+	for i := range history {
+		items[i] = Item{
+			Message:      history[i],
+			Boundary:     Boundary{EventID: "event-" + string(rune('a'+i))},
+			RequestIndex: i,
+		}
+	}
+	return &View{
+		SessionID:            "session",
+		ContentRequestLength: requestLength,
+		Items:                items,
+	}
+}
+
+func TestBindingReasonRecordsStageThatDecidedBinding(t *testing.T) {
+	history := []model.Message{
+		model.NewUserMessage("first"),
+		model.NewAssistantMessage("second"),
+	}
+
+	t.Run("projection before finalize is not finalized", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.False(t, view.Bound)
+		require.Equal(t, BindingReasonNotFinalized, view.BindingReason)
+	})
+
+	t.Run("finalize against matching request binds", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		Finalize(invocation, &model.Request{Messages: history}, 128)
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.True(t, view.Bound)
+		require.Equal(t, BindingReasonBound, view.BindingReason)
+	})
+
+	t.Run("final request mismatch is reported as such", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		Finalize(invocation, &model.Request{Messages: []model.Message{
+			model.NewUserMessage("rewritten by a provider adapter"),
+		}}, 128)
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.False(t, view.Bound)
+		require.Equal(t, BindingReasonRequestMismatch, view.BindingReason)
+	})
+
+	t.Run("explicit invalidation survives finalize", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		InvalidateBinding(invocation)
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.Equal(t, BindingReasonInvalidated, view.BindingReason)
+
+		// Token tailoring invalidates before the request is finalized. The
+		// later finalize must not overwrite the recorded cause even though the
+		// projection would still match the request.
+		Finalize(invocation, &model.Request{Messages: history}, 128)
+		view, ok = Snapshot(invocation)
+		require.True(t, ok)
+		require.False(t, view.Bound)
+		require.Equal(t, BindingReasonInvalidated, view.BindingReason)
+	})
+
+	t.Run("transform provenance mismatch is reported as such", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+
+		after := []model.Message{model.NewUserMessage("compacted")}
+		require.False(t, RebaseAfterTransform(invocation, history, after, nil))
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.False(t, view.Bound)
+		require.Equal(t, BindingReasonTransformMismatch, view.BindingReason)
+	})
+
+	t.Run("rebase failure is distinguished from provenance mismatch", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+
+		// Provenance covers the transform output, but the second projected
+		// item has no output message, so the view cannot be rebased.
+		after := []model.Message{model.NewUserMessage("first")}
+		require.False(t, RebaseAfterTransform(
+			invocation, history, after, []int{0},
+		))
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.False(t, view.Bound)
+		require.Equal(t, BindingReasonRebaseFailed, view.BindingReason)
+	})
+
+	t.Run("successful rebase rebinds the view", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+
+		after := []model.Message{history[0], history[1]}
+		require.True(t, RebaseAfterTransform(
+			invocation, history, after, []int{0, 1},
+		))
+
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+		require.True(t, view.Bound)
+		require.Equal(t, BindingReasonBound, view.BindingReason)
+	})
+}
+
+func TestBindingFromContextReportsViewState(t *testing.T) {
+	history := []model.Message{
+		model.NewUserMessage("first"),
+		model.NewAssistantMessage("second"),
+	}
+
+	t.Run("absent view", func(t *testing.T) {
+		binding := BindingFromContext(context.Background())
+		require.False(t, binding.Present)
+		require.False(t, binding.Bound)
+		require.Equal(t, BindingReasonAbsent, binding.Reason)
+		require.Zero(t, binding.Items)
+	})
+
+	t.Run("nil context", func(t *testing.T) {
+		binding := BindingFromContext(nil)
+		require.False(t, binding.Present)
+		require.Equal(t, BindingReasonAbsent, binding.Reason)
+	})
+
+	t.Run("bound view", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		Finalize(invocation, &model.Request{Messages: history}, 4_096)
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+
+		binding := BindingFromContext(
+			ContextWithView(context.Background(), view),
+		)
+		require.True(t, binding.Present)
+		require.True(t, binding.Bound)
+		require.Equal(t, BindingReasonBound, binding.Reason)
+		require.Equal(t, 2, binding.Items)
+		require.Equal(t, 4_096, binding.RequestTokens)
+	})
+
+	t.Run("unbound view keeps request tokens", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		InvalidateBinding(invocation)
+		Finalize(invocation, &model.Request{Messages: history}, 4_096)
+		view, ok := Snapshot(invocation)
+		require.True(t, ok)
+
+		binding := BindingFromContext(
+			ContextWithView(context.Background(), view),
+		)
+		require.True(t, binding.Present)
+		require.False(t, binding.Bound)
+		require.Equal(t, BindingReasonInvalidated, binding.Reason)
+		require.Equal(t, 4_096, binding.RequestTokens)
+	})
+
+	t.Run("view built without a recorded reason", func(t *testing.T) {
+		// Views produced before a binding decision was recorded must not be
+		// reported with an empty reason.
+		binding := BindingFromContext(ContextWithView(
+			context.Background(),
+			&View{SessionID: "session", Items: []Item{{}}},
+		))
+		require.True(t, binding.Present)
+		require.Equal(t, BindingReasonNotFinalized, binding.Reason)
+	})
+}
+
+// TestBindingFromContextDoesNotCopyHistory guards the constraint that
+// diagnostics never duplicate model-visible history: the reported binding
+// carries counts only.
+func TestBindingFromContextDoesNotCopyHistory(t *testing.T) {
+	view := projectionFor([]model.Message{
+		model.NewUserMessage("secret user content"),
+	}, 1)
+	view.Bound = true
+	view.BindingReason = BindingReasonBound
+
+	binding := BindingFromContext(ContextWithView(context.Background(), view))
+	require.Equal(t, Binding{
+		Present:       true,
+		Bound:         true,
+		Reason:        BindingReasonBound,
+		Items:         1,
+		RequestTokens: 0,
+	}, binding)
+}

--- a/internal/state/summaryview/binding_test.go
+++ b/internal/state/summaryview/binding_test.go
@@ -226,3 +226,83 @@ func TestBindingFromContextDoesNotCopyHistory(t *testing.T) {
 		RequestTokens: 0,
 	}, binding)
 }
+
+func TestBindingFromInvocationReportsViewState(t *testing.T) {
+	history := []model.Message{
+		model.NewUserMessage("first"),
+		model.NewAssistantMessage("second"),
+	}
+
+	t.Run("absent view", func(t *testing.T) {
+		binding := BindingFromInvocation(agent.NewInvocation())
+		require.False(t, binding.Present)
+		require.False(t, binding.Bound)
+		require.Equal(t, BindingReasonAbsent, binding.Reason)
+		require.Zero(t, binding.Items)
+	})
+
+	t.Run("nil invocation", func(t *testing.T) {
+		binding := BindingFromInvocation(nil)
+		require.False(t, binding.Present)
+		require.Equal(t, BindingReasonAbsent, binding.Reason)
+	})
+
+	t.Run("bound view", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		Finalize(invocation, &model.Request{Messages: history}, 4_096)
+
+		binding := BindingFromInvocation(invocation)
+		require.True(t, binding.Present)
+		require.True(t, binding.Bound)
+		require.Equal(t, BindingReasonBound, binding.Reason)
+		require.Equal(t, 2, binding.Items)
+		require.Equal(t, 4_096, binding.RequestTokens)
+	})
+
+	t.Run("unbound view keeps request tokens", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+		InvalidateBinding(invocation)
+		Finalize(invocation, &model.Request{Messages: history}, 4_096)
+
+		binding := BindingFromInvocation(invocation)
+		require.True(t, binding.Present)
+		require.False(t, binding.Bound)
+		require.Equal(t, BindingReasonInvalidated, binding.Reason)
+		require.Equal(t, 4_096, binding.RequestTokens)
+	})
+
+	t.Run("projection before finalize is not finalized", func(t *testing.T) {
+		invocation := agent.NewInvocation()
+		AttachProjection(invocation, projectionFor(history, 2))
+
+		binding := BindingFromInvocation(invocation)
+		require.True(t, binding.Present)
+		require.False(t, binding.Bound)
+		require.Equal(t, BindingReasonNotFinalized, binding.Reason)
+	})
+}
+
+// TestBindingFromInvocationDoesNotCopyHistory guards the constraint that
+// diagnostics never duplicate model-visible history: the reported binding
+// carries counts only.
+func TestBindingFromInvocationDoesNotCopyHistory(t *testing.T) {
+	invocation := agent.NewInvocation()
+	view := projectionFor([]model.Message{
+		model.NewUserMessage("secret user content"),
+	}, 1)
+	AttachProjection(invocation, view)
+	Finalize(invocation, &model.Request{Messages: []model.Message{
+		model.NewUserMessage("secret user content"),
+	}}, 32)
+
+	binding := BindingFromInvocation(invocation)
+	require.Equal(t, Binding{
+		Present:       true,
+		Bound:         true,
+		Reason:        BindingReasonBound,
+		Items:         1,
+		RequestTokens: 32,
+	}, binding)
+}

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -25,6 +25,32 @@ import (
 
 const stateKey = "trpc_agent.summary.model_visible_view"
 
+// Binding reasons explain why a model-visible view is or is not bound to the
+// final model request. They are stable, low-cardinality diagnostic values
+// recorded where the binding decision is made, because a later reader cannot
+// reconstruct which stage invalidated the binding.
+const (
+	// BindingReasonBound marks a view bound to the model request.
+	BindingReasonBound = "bound"
+	// BindingReasonAbsent marks a missing model-visible view.
+	BindingReasonAbsent = "absent"
+	// BindingReasonNotFinalized marks a projection that has not yet been
+	// finalized against a model request.
+	BindingReasonNotFinalized = "not_finalized"
+	// BindingReasonInvalidated marks a view invalidated explicitly, for
+	// example after provider-side token tailoring rewrote the request.
+	BindingReasonInvalidated = "invalidated"
+	// BindingReasonRequestMismatch marks a view whose projected items could
+	// not all be located in the final model request.
+	BindingReasonRequestMismatch = "request_mismatch"
+	// BindingReasonTransformMismatch marks a view whose projected items or
+	// whose transform provenance did not match the transform input.
+	BindingReasonTransformMismatch = "transform_mismatch"
+	// BindingReasonRebaseFailed marks a view whose items could not be mapped
+	// onto the transform output.
+	BindingReasonRebaseFailed = "rebase_failed"
+)
+
 type contextKey struct{}
 
 // invocationState keeps an immutable snapshot opaque to Invocation.View's
@@ -68,6 +94,9 @@ type View struct {
 	RequestTokens          int
 	ContentRequestLength   int
 	Bound                  bool
+	// BindingReason explains the current value of Bound. It is set at every
+	// stage that decides or invalidates the binding.
+	BindingReason string
 }
 
 // AttachProjection stores the content processor's pre-finalization projection.
@@ -75,7 +104,22 @@ func AttachProjection(inv *agent.Invocation, view *View) {
 	if inv == nil || view == nil {
 		return
 	}
-	inv.SetState(stateKey, &invocationState{view: cloneView(view)})
+	next := cloneView(view)
+	setBindingReason(next, BindingReasonNotFinalized)
+	inv.SetState(stateKey, &invocationState{view: next})
+}
+
+// setBindingReason records why view is or is not bound. unbound is the reason
+// that applies when the binding attempt at this stage did not succeed.
+func setBindingReason(view *View, unbound string) {
+	if view == nil {
+		return
+	}
+	if view.Bound {
+		view.BindingReason = BindingReasonBound
+		return
+	}
+	view.BindingReason = unbound
 }
 
 // Clear removes the current projection and finalized view.
@@ -102,6 +146,11 @@ func Finalize(inv *agent.Invocation, req *model.Request, requestTokens int) {
 	next := cloneView(view)
 	next.RequestTokens = requestTokens
 	next.Bound = !state.bindingInvalidated && bindItems(next, req.Messages)
+	if !state.bindingInvalidated {
+		// An already invalidated view keeps the reason recorded by the stage
+		// that invalidated it.
+		setBindingReason(next, BindingReasonRequestMismatch)
+	}
 	inv.SetState(stateKey, &invocationState{
 		view:               next,
 		bindingInvalidated: state.bindingInvalidated,
@@ -137,9 +186,8 @@ func RebaseAfterTransform(
 	)
 	if !boundBefore {
 		next := cloneView(state.view)
-		next.Bound = false
 		next.ContentRequestLength = len(after)
-		storeInvalidated(inv, next)
+		storeInvalidated(inv, next, BindingReasonTransformMismatch)
 		return false
 	}
 	transformed, ok := rebaseItems(
@@ -150,15 +198,15 @@ func RebaseAfterTransform(
 	)
 	if !ok {
 		next := cloneView(state.view)
-		next.Bound = false
 		next.ContentRequestLength = len(after)
-		storeInvalidated(inv, next)
+		storeInvalidated(inv, next, BindingReasonRebaseFailed)
 		return false
 	}
 	next := *state.view
 	next.Items = transformed
 	next.ContentRequestLength = len(after)
 	next.Bound = true
+	next.BindingReason = BindingReasonBound
 	inv.SetState(stateKey, &invocationState{view: &next})
 	return true
 }
@@ -319,12 +367,12 @@ func InvalidateBinding(inv *agent.Invocation) {
 	if !ok || state == nil || state.view == nil {
 		return
 	}
-	next := cloneView(state.view)
-	next.Bound = false
-	storeInvalidated(inv, next)
+	storeInvalidated(inv, cloneView(state.view), BindingReasonInvalidated)
 }
 
-func storeInvalidated(inv *agent.Invocation, view *View) {
+func storeInvalidated(inv *agent.Invocation, view *View, reason string) {
+	view.Bound = false
+	view.BindingReason = reason
 	inv.SetState(stateKey, &invocationState{
 		view:               view,
 		bindingInvalidated: true,
@@ -361,6 +409,56 @@ func FromContext(ctx context.Context) (*View, bool) {
 		return nil, false
 	}
 	return cloneView(view), true
+}
+
+// Binding describes the model-visible view state used by summary diagnostics.
+// It carries only counts and stable reason values, never message content.
+type Binding struct {
+	// Present reports whether a model-visible view was available.
+	Present bool
+	// Bound reports whether the view items are proven to map to the model
+	// request that the model actually saw.
+	Bound bool
+	// Reason is the stable binding reason recorded by the stage that decided
+	// the binding. It is BindingReasonAbsent when no view is present.
+	Reason string
+	// Items is the number of model-visible history items in the view.
+	Items int
+	// RequestTokens is the token count recorded for the request the view was
+	// finalized against. It remains meaningful when Bound is false.
+	RequestTokens int
+}
+
+// BindingFromContext reports the binding state of the model-visible view
+// attached to ctx. It reads the stored snapshot without copying view items so
+// diagnostics never add a history copy. A missing view reports Present=false
+// with BindingReasonAbsent.
+func BindingFromContext(ctx context.Context) Binding {
+	if ctx == nil {
+		return Binding{Reason: BindingReasonAbsent}
+	}
+	view, ok := ctx.Value(contextKey{}).(*View)
+	if !ok || view == nil {
+		return Binding{Reason: BindingReasonAbsent}
+	}
+	return Binding{
+		Present:       true,
+		Bound:         view.Bound,
+		Reason:        view.bindingReason(),
+		Items:         len(view.Items),
+		RequestTokens: view.RequestTokens,
+	}
+}
+
+// bindingReason normalizes views built before a binding decision was recorded.
+func (v *View) bindingReason() string {
+	if v.Bound {
+		return BindingReasonBound
+	}
+	if v.BindingReason == "" {
+		return BindingReasonNotFinalized
+	}
+	return v.BindingReason
 }
 
 // Events returns the model-visible history as event-shaped callback input.

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -441,6 +441,30 @@ func BindingFromContext(ctx context.Context) Binding {
 	if !ok || view == nil {
 		return Binding{Reason: BindingReasonAbsent}
 	}
+	return bindingFromView(view)
+}
+
+// BindingFromInvocation reports the binding state stored on inv. GetStateValue
+// holds the invocation lock only while retrieving the immutable
+// invocationState pointer; field reads then use that snapshot, which is never
+// mutated in place. The result does not copy view items. A missing invocation
+// or view reports Present=false with BindingReasonAbsent. Reason is always one
+// of the closed binding-reason constants.
+func BindingFromInvocation(inv *agent.Invocation) Binding {
+	if inv == nil {
+		return Binding{Reason: BindingReasonAbsent}
+	}
+	state, ok := agent.GetStateValue[*invocationState](inv, stateKey)
+	if !ok || state == nil || state.view == nil {
+		return Binding{Reason: BindingReasonAbsent}
+	}
+	return bindingFromView(state.view)
+}
+
+func bindingFromView(view *View) Binding {
+	if view == nil {
+		return Binding{Reason: BindingReasonAbsent}
+	}
 	return Binding{
 		Present:       true,
 		Bound:         view.Bound,

--- a/internal/summarydiag/summarydiag.go
+++ b/internal/summarydiag/summarydiag.go
@@ -1,0 +1,65 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package summarydiag holds shared presentation helpers for the four stable
+// session-summary diagnostic records. The helpers format already-collected
+// metadata; they do not select, persist, cascade, inject, or compact summaries.
+package summarydiag
+
+import "unicode/utf8"
+
+const (
+	// SchemaVersion is the diagnostic record schema. Bump it when the field
+	// set or field semantics of a stable record name change incompatibly.
+	SchemaVersion = 1
+
+	// FilterKeyMaxRunes is the diagnostic display budget for a filter key,
+	// including the truncation marker when a key is shortened. It matches
+	// the VARCHAR(255) filter_key column used by the common
+	// session_summaries schema (Postgres, MySQL, and pgvector). Longer keys
+	// are truncated in logs only; stored keys and queries are unchanged.
+	FilterKeyMaxRunes = 255
+
+	// truncatedMarker is appended to a displayed filter key after truncation
+	// so the change is visible in the value itself. The accompanying
+	// *_truncated boolean is the authoritative signal.
+	truncatedMarker = "..."
+)
+
+// FormatFilterKey prepares a filter key for diagnostic display. The original
+// business key is not modified. Empty keys stay empty so logs still show
+// filter_key="". A key within FilterKeyMaxRunes is returned unchanged. A
+// longer key is cut at a UTF-8 rune boundary so the displayed value,
+// including truncatedMarker, stays within FilterKeyMaxRunes. truncated is
+// the authoritative signal that the logged value is not the original key.
+func FormatFilterKey(key string) (display string, truncated bool) {
+	prefixLimit := filterKeyPrefixLimit()
+	n := 0
+	prefixEnd := 0
+	for i := range key {
+		if n == prefixLimit {
+			prefixEnd = i
+		}
+		if n == FilterKeyMaxRunes {
+			return key[:prefixEnd] + truncatedMarker, true
+		}
+		n++
+	}
+	return key, false
+}
+
+// filterKeyPrefixLimit is how many original runes fit when the marker must
+// also be included in FilterKeyMaxRunes.
+func filterKeyPrefixLimit() int {
+	limit := FilterKeyMaxRunes - utf8.RuneCountInString(truncatedMarker)
+	if limit < 0 {
+		return 0
+	}
+	return limit
+}

--- a/internal/summarydiag/summarydiag.go
+++ b/internal/summarydiag/summarydiag.go
@@ -54,6 +54,15 @@ func FormatFilterKey(key string) (display string, truncated bool) {
 	return key, false
 }
 
+// FormatAgentName prepares a caller-supplied agent name for diagnostic
+// display. The rules match FormatFilterKey: UTF-8-safe truncation to
+// FilterKeyMaxRunes with a visible marker. Names are quoted by callers with
+// %q so unsafe bytes stay in a single field. This is safe quoting, not
+// privacy redaction, and it does not change the original business name.
+func FormatAgentName(name string) (display string, truncated bool) {
+	return FormatFilterKey(name)
+}
+
 // filterKeyPrefixLimit is how many original runes fit when the marker must
 // also be included in FilterKeyMaxRunes.
 func filterKeyPrefixLimit() int {

--- a/internal/summarydiag/summarydiag_test.go
+++ b/internal/summarydiag/summarydiag_test.go
@@ -1,0 +1,129 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package summarydiag
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatFilterKey(t *testing.T) {
+	markerRunes := utf8.RuneCountInString(truncatedMarker)
+	prefixLimit := filterKeyPrefixLimit()
+	require.GreaterOrEqual(t, prefixLimit, 0)
+	require.Equal(t, FilterKeyMaxRunes, prefixLimit+markerRunes,
+		"prefix plus marker must fill the display budget without a magic number")
+
+	longASCII := strings.Repeat("a", FilterKeyMaxRunes+1)
+	longCJK := strings.Repeat("摘", FilterKeyMaxRunes+1)
+	longEmoji := strings.Repeat("😀", FilterKeyMaxRunes+1)
+	exactASCII := strings.Repeat("b", FilterKeyMaxRunes)
+	exactCJK := strings.Repeat("要", FilterKeyMaxRunes)
+
+	tests := []struct {
+		name          string
+		key           string
+		wantDisplay   string
+		wantTruncated bool
+		wantUnchanged bool
+	}{
+		{
+			name:          "empty stays empty",
+			key:           "",
+			wantDisplay:   "",
+			wantTruncated: false,
+			wantUnchanged: true,
+		},
+		{
+			name:          "short ascii is unchanged",
+			key:           "branch/user",
+			wantDisplay:   "branch/user",
+			wantTruncated: false,
+			wantUnchanged: true,
+		},
+		{
+			name:          "exact ascii limit is unchanged",
+			key:           exactASCII,
+			wantDisplay:   exactASCII,
+			wantTruncated: false,
+			wantUnchanged: true,
+		},
+		{
+			name:          "oversize ascii is truncated",
+			key:           longASCII,
+			wantDisplay:   strings.Repeat("a", prefixLimit) + truncatedMarker,
+			wantTruncated: true,
+		},
+		{
+			name:          "short multibyte utf8 is unchanged",
+			key:           "应用/用户",
+			wantDisplay:   "应用/用户",
+			wantTruncated: false,
+			wantUnchanged: true,
+		},
+		{
+			name:          "exact multibyte limit is unchanged",
+			key:           exactCJK,
+			wantDisplay:   exactCJK,
+			wantTruncated: false,
+			wantUnchanged: true,
+		},
+		{
+			name:          "oversize multibyte utf8 is truncated on a rune boundary",
+			key:           longCJK,
+			wantDisplay:   strings.Repeat("摘", prefixLimit) + truncatedMarker,
+			wantTruncated: true,
+		},
+		{
+			name:          "oversize emoji is truncated on a rune boundary",
+			key:           longEmoji,
+			wantDisplay:   strings.Repeat("😀", prefixLimit) + truncatedMarker,
+			wantTruncated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			display, truncated := FormatFilterKey(tt.key)
+			require.Equal(t, tt.wantTruncated, truncated)
+			require.Equal(t, tt.wantDisplay, display)
+			require.True(t, utf8.ValidString(display))
+			require.LessOrEqual(t, utf8.RuneCountInString(display), FilterKeyMaxRunes)
+			if tt.wantUnchanged {
+				require.Equal(t, tt.key, display)
+				return
+			}
+			require.Equal(t, FilterKeyMaxRunes, utf8.RuneCountInString(display),
+				"truncated display must consume the full budget including the marker")
+			require.True(t, strings.HasSuffix(display, truncatedMarker))
+			prefix := strings.TrimSuffix(display, truncatedMarker)
+			require.Equal(t, prefixLimit, utf8.RuneCountInString(prefix))
+			require.True(t, strings.HasPrefix(tt.key, prefix),
+				"the displayed prefix must be the original key's leading runes")
+		})
+	}
+}
+
+func TestFormatFilterKeyDoesNotSplitMultibyteRune(t *testing.T) {
+	prefixLimit := filterKeyPrefixLimit()
+	// The last kept rune is a 4-byte emoji; the cut must keep it intact.
+	key := strings.Repeat("x", prefixLimit-1) + "😀" + strings.Repeat("y", FilterKeyMaxRunes)
+	display, truncated := FormatFilterKey(key)
+	require.True(t, truncated)
+	require.Equal(t,
+		strings.Repeat("x", prefixLimit-1)+"😀"+truncatedMarker,
+		display)
+	require.True(t, utf8.ValidString(display))
+	require.Equal(t, FilterKeyMaxRunes, utf8.RuneCountInString(display))
+	require.NotContains(t, display, "\xff")
+}

--- a/internal/summarydiag/summarydiag_test.go
+++ b/internal/summarydiag/summarydiag_test.go
@@ -10,6 +10,7 @@
 package summarydiag
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -126,4 +127,30 @@ func TestFormatFilterKeyDoesNotSplitMultibyteRune(t *testing.T) {
 	require.True(t, utf8.ValidString(display))
 	require.Equal(t, FilterKeyMaxRunes, utf8.RuneCountInString(display))
 	require.NotContains(t, display, "\xff")
+}
+
+func TestFormatAgentNameMatchesFilterKeyAndQuotesUnsafeInput(t *testing.T) {
+	display, truncated := FormatAgentName("agent\nextra,field=1")
+	require.False(t, truncated)
+	require.Equal(t, "agent\nextra,field=1", display)
+	require.Equal(t, `"agent\nextra,field=1"`, strconv.Quote(display))
+
+	long := strings.Repeat("名", FilterKeyMaxRunes+8)
+	display, truncated = FormatAgentName(long)
+	require.True(t, truncated)
+	require.Equal(t, FilterKeyMaxRunes, utf8.RuneCountInString(display))
+	keyDisplay, keyTruncated := FormatFilterKey(long)
+	require.Equal(t, keyDisplay, display)
+	require.Equal(t, keyTruncated, truncated)
+
+	invalid := "agent\x80name"
+	original := invalid
+	display, truncated = FormatAgentName(invalid)
+	require.False(t, truncated)
+	require.Equal(t, original, invalid,
+		"quoting must not change the original business name")
+	require.Equal(t, original, display)
+	quoted := strconv.Quote(display)
+	require.Contains(t, quoted, `\x80`)
+	require.NotContains(t, quoted, "\x80")
 }

--- a/session/clickhouse/summary.go
+++ b/session/clickhouse/summary.go
@@ -61,6 +61,10 @@ func (s *Service) CreateSessionSummary(
 	sess.SummariesMu.RLock()
 	summary := sess.Summaries[filterKey]
 	sess.SummariesMu.RUnlock()
+	if summary == nil {
+		att.Persisted(isummary.PersistNoSummary)
+		return nil
+	}
 	summaryBytes, err := json.Marshal(summary)
 	if err != nil {
 		return att.RecordWrite(fmt.Errorf("marshal summary failed: %w", err))

--- a/session/clickhouse/summary.go
+++ b/session/clickhouse/summary.go
@@ -56,8 +56,20 @@ func (s *Service) CreateSessionSummary(
 	if !updated {
 		return nil
 	}
+	return s.persistSessionSummary(ctx, att, key, sess, filterKey)
+}
 
-	// Persist only the updated filterKey summary with atomic set-if-newer to avoid late-write override.
+// persistSessionSummary reads the in-memory summary for filterKey after
+// generation and either persists it or classifies a nil summary as
+// PersistNoSummary. A nil summary must not insert, query for staleness, or
+// record a stored outcome.
+func (s *Service) persistSessionSummary(
+	ctx context.Context,
+	att *isummary.Attempt,
+	key session.Key,
+	sess *session.Session,
+	filterKey string,
+) error {
 	sess.SummariesMu.RLock()
 	summary := sess.Summaries[filterKey]
 	sess.SummariesMu.RUnlock()
@@ -65,6 +77,7 @@ func (s *Service) CreateSessionSummary(
 		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
+	// Persist only the updated filterKey summary with atomic set-if-newer to avoid late-write override.
 	summaryBytes, err := json.Marshal(summary)
 	if err != nil {
 		return att.RecordWrite(fmt.Errorf("marshal summary failed: %w", err))

--- a/session/clickhouse/summary.go
+++ b/session/clickhouse/summary.go
@@ -45,7 +45,11 @@ func (s *Service) CreateSessionSummary(
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(ctx, s.opts.summarizer, sess, filterKey, force)
+	att.Summarized(updated, err)
 	if err != nil {
 		return fmt.Errorf("summarize and persist failed: %w", err)
 	}
@@ -59,7 +63,7 @@ func (s *Service) CreateSessionSummary(
 	sess.SummariesMu.RUnlock()
 	summaryBytes, err := json.Marshal(summary)
 	if err != nil {
-		return fmt.Errorf("marshal summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("marshal summary failed: %w", err))
 	}
 	stale, err := s.summaryWriteIsStale(
 		ctx,
@@ -70,9 +74,10 @@ func (s *Service) CreateSessionSummary(
 		sess.Events,
 	)
 	if err != nil {
-		return fmt.Errorf("check existing summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("check existing summary failed: %w", err))
 	}
 	if stale {
+		att.Persisted(isummary.PersistStale)
 		return nil
 	}
 
@@ -86,9 +91,10 @@ func (s *Service) CreateSessionSummary(
 		key.AppName, key.UserID, key.SessionID, filterKey, string(summaryBytes), now, updatedAt, now, nil)
 
 	if err != nil {
-		return fmt.Errorf("upsert summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("upsert summary failed: %w", err))
 	}
 
+	att.Persisted(isummary.PersistStored)
 	return nil
 }
 

--- a/session/clickhouse/summary_compat_test.go
+++ b/session/clickhouse/summary_compat_test.go
@@ -104,10 +104,9 @@ func TestCreateSessionSummary_StaleWriteIsSkipped(t *testing.T) {
 }
 
 // TestCreateSessionSummary_WritesInMemorySummaryVerbatim pins that this backend
-// serializes whatever the session holds for the target filter key and always
-// reaches the staleness check and the insert. Unlike the other SQL backends it
-// has no nil-summary early return, so no stage may filter or normalize the
-// value between generation and the write.
+// serializes the non-nil in-memory summary for the target filter key and then
+// reaches the staleness check and the insert. A nil summary is rejected before
+// this path, matching the other backends.
 func TestCreateSessionSummary_WritesInMemorySummaryVerbatim(t *testing.T) {
 	sess := compatSession()
 	var staleChecked bool

--- a/session/clickhouse/summary_compat_test.go
+++ b/session/clickhouse/summary_compat_test.go
@@ -1,0 +1,150 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package clickhouse
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	storage "trpc.group/trpc-go/trpc-agent-go/storage/clickhouse"
+)
+
+func newCompatService(t *testing.T, mockCli *mockClient, sum *mockSummarizer) *Service {
+	t.Helper()
+	storage.SetClientBuilder(func(...storage.ClientBuilderOpt) (storage.Client, error) {
+		return &mockClient{}, nil
+	})
+	s, err := NewService(
+		WithSummarizer(sum),
+		WithSkipDBInit(true),
+		WithClickHouseDSN("clickhouse://localhost:9000"),
+	)
+	require.NoError(t, err)
+	s.chClient = mockCli
+	return s
+}
+
+func compatSession() *session.Session {
+	return &session.Session{
+		ID:        "sess1",
+		AppName:   "app1",
+		UserID:    "user1",
+		Summaries: make(map[string]*session.Summary),
+		Events: []event.Event{{
+			ID:        "1",
+			Timestamp: time.Now().Add(-time.Minute),
+		}},
+	}
+}
+
+// TestCreateSessionSummary_WrapsSummarizeError pins the error message this
+// backend has always returned for a failed summarization stage.
+func TestCreateSessionSummary_WrapsSummarizeError(t *testing.T) {
+	mockSum := &mockSummarizer{
+		summarizeFunc: func(context.Context, *session.Session) (string, error) {
+			return "", assert.AnError
+		},
+	}
+	s := newCompatService(t, &mockClient{}, mockSum)
+
+	err := s.CreateSessionSummary(context.Background(), compatSession(), "key", true)
+	require.Error(t, err)
+	assert.True(t,
+		strings.HasPrefix(err.Error(), "summarize and persist failed: "),
+		"unexpected error message: %s", err.Error())
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestCreateSessionSummary_StaleWriteIsSkipped pins the set-if-newer contract:
+// a summary that would move the boundary backwards is not written and the call
+// still succeeds.
+func TestCreateSessionSummary_StaleWriteIsSkipped(t *testing.T) {
+	sess := compatSession()
+	newer := session.Summary{
+		Summary:   "persisted",
+		UpdatedAt: time.Now(),
+		Boundary:  session.NewSummaryBoundary("1", time.Now().Add(time.Hour)),
+	}
+	newerBytes, err := json.Marshal(newer)
+	require.NoError(t, err)
+
+	execCalls := 0
+	mockCli := &mockClient{
+		queryFunc: func(context.Context, string, ...any) (driver.Rows, error) {
+			return newMockRows([][]any{{newerBytes}}), nil
+		},
+		execFunc: func(context.Context, string, ...any) error {
+			execCalls++
+			return nil
+		},
+	}
+	s := newCompatService(t, mockCli, &mockSummarizer{})
+
+	require.NoError(t,
+		s.CreateSessionSummary(context.Background(), sess, "key", true))
+	require.NotNil(t, sess.Summaries["key"],
+		"the summary must be generated before the staleness check runs")
+	assert.Zero(t, execCalls, "a stale summary must not be written")
+}
+
+// TestCreateSessionSummary_WritesInMemorySummaryVerbatim pins that this backend
+// serializes whatever the session holds for the target filter key and always
+// reaches the staleness check and the insert. Unlike the other SQL backends it
+// has no nil-summary early return, so no stage may filter or normalize the
+// value between generation and the write.
+func TestCreateSessionSummary_WritesInMemorySummaryVerbatim(t *testing.T) {
+	sess := compatSession()
+	var staleChecked bool
+	var written string
+	mockCli := &mockClient{
+		queryFunc: func(context.Context, string, ...any) (driver.Rows, error) {
+			staleChecked = true
+			return newMockRows(nil), nil
+		},
+		execFunc: func(_ context.Context, _ string, args ...any) error {
+			require.Len(t, args, 9)
+			written = args[4].(string)
+			return nil
+		},
+	}
+	s := newCompatService(t, mockCli, &mockSummarizer{})
+
+	require.NoError(t,
+		s.CreateSessionSummary(context.Background(), sess, "key", true))
+	assert.True(t, staleChecked, "the staleness check must always run")
+
+	want, err := json.Marshal(sess.Summaries["key"])
+	require.NoError(t, err)
+	assert.Equal(t, string(want), written)
+}
+
+// TestCreateSessionSummary_StaleCheckErrorIsWrapped pins the error message for
+// a failed set-if-newer check.
+func TestCreateSessionSummary_StaleCheckErrorIsWrapped(t *testing.T) {
+	mockCli := &mockClient{
+		queryFunc: func(context.Context, string, ...any) (driver.Rows, error) {
+			return nil, assert.AnError
+		},
+	}
+	s := newCompatService(t, mockCli, &mockSummarizer{})
+
+	err := s.CreateSessionSummary(context.Background(), compatSession(), "key", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check existing summary failed")
+}

--- a/session/clickhouse/summary_nil_persist_test.go
+++ b/session/clickhouse/summary_nil_persist_test.go
@@ -1,0 +1,155 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
+)
+
+type persistLogs struct {
+	mu    sync.Mutex
+	debug []string
+	info  []string
+	warn  []string
+}
+
+func capturePersistLogs(t *testing.T) *persistLogs {
+	t.Helper()
+	logs := &persistLogs{}
+	oldDebug, oldInfo, oldWarn :=
+		log.DebugfContext, log.InfofContext, log.WarnfContext
+	log.DebugfContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.debug, fmt.Sprintf(format, args...))
+	}
+	log.InfofContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.info, fmt.Sprintf(format, args...))
+	}
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.warn, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.DebugfContext = oldDebug
+		log.InfofContext = oldInfo
+		log.WarnfContext = oldWarn
+	})
+	return logs
+}
+
+func (l *persistLogs) add(level *[]string, line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	*level = append(*level, line)
+}
+
+func (l *persistLogs) summaryRecord(t *testing.T) (level, line string) {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, group := range []struct {
+		level string
+		lines []string
+	}{{"warn", l.warn}, {"info", l.info}, {"debug", l.debug}} {
+		for _, candidate := range group.lines {
+			if strings.HasPrefix(candidate, "Session summary result:") {
+				return group.level, candidate
+			}
+		}
+	}
+	t.Fatalf("no session summary record in %q %q %q", l.debug, l.info, l.warn)
+	return "", ""
+}
+
+func waitUntilStackContains(t *testing.T, needle string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	buf := make([]byte, 1<<20)
+	for time.Now().Before(deadline) {
+		n := runtime.Stack(buf, true)
+		if strings.Contains(string(buf[:n]), needle) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %q in goroutine stacks", needle)
+}
+
+// TestCreateSessionSummary_NilSummaryDoesNotInsert proves updated=true with
+// no in-memory summary matches the other backends: no INSERT, no stored
+// record, and persist_result=no_summary.
+func TestCreateSessionSummary_NilSummaryDoesNotInsert(t *testing.T) {
+	logs := capturePersistLogs(t)
+	execCalls := 0
+	queryCalls := 0
+	mockCli := &mockClient{
+		queryFunc: func(context.Context, string, ...any) (driver.Rows, error) {
+			queryCalls++
+			return newMockRows(nil), nil
+		},
+		execFunc: func(context.Context, string, ...any) error {
+			execCalls++
+			return nil
+		},
+	}
+	s := newCompatService(t, mockCli, &mockSummarizer{})
+
+	sess := &session.Session{
+		ID:      "nil-summary-sess",
+		AppName: "app1",
+		UserID:  "user1",
+		Summaries: map[string]*session.Summary{
+			"key": {Summary: "copied summary"},
+		},
+		Events: []event.Event{{
+			ID:        "1",
+			Timestamp: time.Now().Add(-time.Minute),
+		}},
+	}
+
+	// Hold EventMu so persistCopiedSummary blocks in computeDeltaSince after
+	// it has already decided updated=true. Clearing the entry then reproduces
+	// the generation/persist inconsistency every backend guards.
+	sess.EventMu.Lock()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.CreateSessionSummary(context.Background(), sess, "key", true)
+	}()
+	waitUntilStackContains(t, "computeDeltaSince")
+
+	sess.SummariesMu.Lock()
+	sess.Summaries["key"] = nil
+	sess.SummariesMu.Unlock()
+	sess.EventMu.Unlock()
+
+	require.NoError(t, <-errCh)
+	require.Zero(t, execCalls, "a nil summary must not INSERT")
+	require.Zero(t, queryCalls, "a nil summary must not reach the stale check")
+
+	level, line := logs.summaryRecord(t)
+	require.Equal(t, "warn", level)
+	require.Contains(t, line, "outcome=no_update")
+	require.Contains(t, line, "persist_result="+string(isummary.PersistNoSummary))
+	require.Contains(t, line, "updated=true")
+	require.NotContains(t, line, "persist_result=stored")
+	require.NotContains(t, line, "outcome=success")
+}

--- a/session/clickhouse/summary_nil_persist_test.go
+++ b/session/clickhouse/summary_nil_persist_test.go
@@ -12,16 +12,13 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/require"
 
-	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/session"
 	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
@@ -80,24 +77,11 @@ func (l *persistLogs) summaryRecord(t *testing.T) (level, line string) {
 	return "", ""
 }
 
-func waitUntilStackContains(t *testing.T, needle string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	buf := make([]byte, 1<<20)
-	for time.Now().Before(deadline) {
-		n := runtime.Stack(buf, true)
-		if strings.Contains(string(buf[:n]), needle) {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for %q in goroutine stacks", needle)
-}
-
-// TestCreateSessionSummary_NilSummaryDoesNotInsert proves updated=true with
-// no in-memory summary matches the other backends: no INSERT, no stored
-// record, and persist_result=no_summary.
-func TestCreateSessionSummary_NilSummaryDoesNotInsert(t *testing.T) {
+// TestPersistSessionSummary_NilSummaryDoesNotInsert proves the persist stage
+// classifies a nil in-memory summary as PersistNoSummary: no INSERT, no stale
+// query, and no stored outcome. CreateSessionSummary reaches this stage only
+// after SummarizeSession reports updated=true.
+func TestPersistSessionSummary_NilSummaryDoesNotInsert(t *testing.T) {
 	logs := capturePersistLogs(t)
 	execCalls := 0
 	queryCalls := 0
@@ -118,30 +102,16 @@ func TestCreateSessionSummary_NilSummaryDoesNotInsert(t *testing.T) {
 		AppName: "app1",
 		UserID:  "user1",
 		Summaries: map[string]*session.Summary{
-			"key": {Summary: "copied summary"},
+			"key": nil,
 		},
-		Events: []event.Event{{
-			ID:        "1",
-			Timestamp: time.Now().Add(-time.Minute),
-		}},
 	}
+	key := session.Key{AppName: sess.AppName, UserID: sess.UserID, SessionID: sess.ID}
+	ctx, att := isummary.BeginAttempt(context.Background(), sess, "key")
+	att.Summarized(true, nil)
 
-	// Hold EventMu so persistCopiedSummary blocks in computeDeltaSince after
-	// it has already decided updated=true. Clearing the entry then reproduces
-	// the generation/persist inconsistency every backend guards.
-	sess.EventMu.Lock()
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- s.CreateSessionSummary(context.Background(), sess, "key", true)
-	}()
-	waitUntilStackContains(t, "computeDeltaSince")
+	require.NoError(t, s.persistSessionSummary(ctx, att, key, sess, "key"))
+	att.Report()
 
-	sess.SummariesMu.Lock()
-	sess.Summaries["key"] = nil
-	sess.SummariesMu.Unlock()
-	sess.EventMu.Unlock()
-
-	require.NoError(t, <-errCh)
 	require.Zero(t, execCalls, "a nil summary must not INSERT")
 	require.Zero(t, queryCalls, "a nil summary must not reach the stale check")
 

--- a/session/inmemory/summary.go
+++ b/session/inmemory/summary.go
@@ -39,7 +39,11 @@ func (s *SessionService) CreateSessionSummary(ctx context.Context, sess *session
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(ctx, s.opts.summarizer, sess, filterKey, force)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -50,16 +54,17 @@ func (s *SessionService) CreateSessionSummary(ctx context.Context, sess *session
 	sess.SummariesMu.RUnlock()
 
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
 
 	// Get app to write summary. Session must exist in storage.
 	app, ok := s.getAppSessions(key.AppName)
 	if !ok {
-		return fmt.Errorf("session not found: %s", key.SessionID)
+		return att.RecordWrite(fmt.Errorf("session not found: %s", key.SessionID))
 	}
 
-	return s.writeSummaryUnderLock(app, key, filterKey, sum)
+	return att.RecordWrite(s.writeSummaryUnderLock(app, key, filterKey, sum))
 }
 
 // writeSummaryUnderLock writes a summary for a filterKey under app lock and refreshes TTL.

--- a/session/inmemory/summary_diagnostics_test.go
+++ b/session/inmemory/summary_diagnostics_test.go
@@ -1,0 +1,209 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const (
+	diagSummaryText = "SECRET-SUMMARY-CONTENT"
+	diagEventText   = "SECRET-EVENT-CONTENT"
+	diagSessionID   = "SECRET-SESSION-ID"
+	diagUserID      = "SECRET-USER-ID"
+)
+
+// diagLogs captures summary records emitted through the package logger. The
+// logger is process-global and summary work can run on worker goroutines, so
+// the recorder is synchronized.
+type diagLogs struct {
+	mu    sync.Mutex
+	debug []string
+	info  []string
+	warn  []string
+}
+
+func (l *diagLogs) add(level *[]string, line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	*level = append(*level, line)
+}
+
+func (l *diagLogs) snapshot() (debug, info, warn []string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.debug...),
+		append([]string(nil), l.info...),
+		append([]string(nil), l.warn...)
+}
+
+func (l *diagLogs) all() string {
+	debug, info, warn := l.snapshot()
+	return strings.Join(append(append(debug, info...), warn...), "\n")
+}
+
+// summaryRecord returns the async summary record captured at any level.
+func (l *diagLogs) summaryRecord(t *testing.T) (level, line string) {
+	t.Helper()
+	debug, info, warn := l.snapshot()
+	for _, group := range []struct {
+		level string
+		lines []string
+	}{{"warn", warn}, {"info", info}, {"debug", debug}} {
+		for _, candidate := range group.lines {
+			if strings.HasPrefix(candidate, "Session summary result:") {
+				return group.level, candidate
+			}
+		}
+	}
+	t.Fatalf("no session summary record in %q %q %q", debug, info, warn)
+	return "", ""
+}
+
+func captureDiagLogs(t *testing.T) *diagLogs {
+	t.Helper()
+	logs := &diagLogs{}
+	oldDebug, oldInfo, oldWarn :=
+		log.DebugfContext, log.InfofContext, log.WarnfContext
+	log.DebugfContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.debug, fmt.Sprintf(format, args...))
+	}
+	log.InfofContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.info, fmt.Sprintf(format, args...))
+	}
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.warn, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.DebugfContext = oldDebug
+		log.InfofContext = oldInfo
+		log.WarnfContext = oldWarn
+	})
+	return logs
+}
+
+type diagBackendSummarizer struct{ text string }
+
+func (s *diagBackendSummarizer) ShouldSummarize(*session.Session) bool {
+	return true
+}
+
+func (s *diagBackendSummarizer) Summarize(
+	context.Context, *session.Session,
+) (string, error) {
+	return s.text, nil
+}
+
+func (s *diagBackendSummarizer) FilterEventsForSummary(
+	events []event.Event,
+) []event.Event {
+	return events
+}
+
+func (s *diagBackendSummarizer) SetPrompt(string)         {}
+func (s *diagBackendSummarizer) SetModel(model.Model)     {}
+func (s *diagBackendSummarizer) Metadata() map[string]any { return nil }
+
+func diagBackendSession() *session.Session {
+	return &session.Session{
+		ID:      diagSessionID,
+		AppName: "app",
+		UserID:  diagUserID,
+		Events: []event.Event{{
+			Author:    "user",
+			Timestamp: time.Now().Add(-time.Minute),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: diagEventText,
+				},
+			}}},
+		}},
+	}
+}
+
+// TestCreateSessionSummaryReportsSuccess proves the in-memory backend reports
+// its persistence outcome through the shared diagnostics helper.
+func TestCreateSessionSummaryReportsSuccess(t *testing.T) {
+	logs := captureDiagLogs(t)
+	service := NewSessionService(
+		WithSummarizer(&diagBackendSummarizer{text: diagSummaryText}),
+	)
+	defer service.Close()
+
+	stored, err := service.CreateSession(context.Background(), session.Key{
+		AppName:   "app",
+		UserID:    diagUserID,
+		SessionID: diagSessionID,
+	}, nil)
+	require.NoError(t, err)
+	sess := diagBackendSession()
+	sess.ID = stored.ID
+
+	require.NoError(t, service.CreateSessionSummary(
+		context.Background(), sess, "", true,
+	))
+
+	level, line := logs.summaryRecord(t)
+	require.Equal(t, "info", level)
+	require.Contains(t, line, "schema_version=1")
+	require.Contains(t, line, "outcome=success")
+	require.Contains(t, line, `filter_key=""`)
+	require.Contains(t, line, "filter_key_truncated=false")
+	require.Contains(t, line, "persist_result=stored")
+	require.Contains(t, line, "boundary_advanced=true")
+	require.NotContains(t, logs.all(), diagSummaryText)
+	require.NotContains(t, logs.all(), diagEventText)
+	require.NotContains(t, logs.all(), diagUserID)
+
+	text, ok := service.GetSessionSummaryText(context.Background(), sess)
+	require.True(t, ok)
+	require.Equal(t, diagSummaryText, text,
+		"persistence behaviour must be unchanged")
+}
+
+// TestCreateSessionSummaryReportsPersistenceError covers a backend write that
+// fails because the session is not in storage. The backend error text carries
+// the session ID, which must never reach the diagnostic record.
+func TestCreateSessionSummaryReportsPersistenceError(t *testing.T) {
+	logs := captureDiagLogs(t)
+	service := NewSessionService(
+		WithSummarizer(&diagBackendSummarizer{text: diagSummaryText}),
+	)
+	defer service.Close()
+
+	sess := diagBackendSession()
+	err := service.CreateSessionSummary(context.Background(), sess, "", true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), diagSessionID,
+		"the backend error contract must be unchanged")
+
+	level, line := logs.summaryRecord(t)
+	require.Equal(t, "warn", level)
+	require.Contains(t, line, "schema_version=1")
+	require.Contains(t, line, "outcome=persistence_error")
+	require.Contains(t, line, "persist_result=error")
+	require.Contains(t, line, "updated=true")
+	require.NotContains(t, logs.all(), diagSessionID)
+	require.NotContains(t, logs.all(), diagSummaryText)
+	require.NotContains(t, logs.all(), diagUserID)
+}

--- a/session/inmemory/summary_trigger_external_test.go
+++ b/session/inmemory/summary_trigger_external_test.go
@@ -1,0 +1,222 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package inmemory_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/inmemory"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
+)
+
+const (
+	externalSecretTrigger = "tenant-42-escalation"
+	externalSummaryText   = "SECRET-SUMMARY-CONTENT"
+	externalEventText     = "SECRET-EVENT-CONTENT"
+	externalUserID        = "SECRET-USER-ID"
+)
+
+type externalDiagLogs struct {
+	mu    sync.Mutex
+	debug []string
+	info  []string
+	warn  []string
+}
+
+func (l *externalDiagLogs) add(level *[]string, line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	*level = append(*level, line)
+}
+
+func (l *externalDiagLogs) snapshot() (debug, info, warn []string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.debug...),
+		append([]string(nil), l.info...),
+		append([]string(nil), l.warn...)
+}
+
+func (l *externalDiagLogs) all() string {
+	debug, info, warn := l.snapshot()
+	return strings.Join(append(append(debug, info...), warn...), "\n")
+}
+
+func (l *externalDiagLogs) summaryRecord(t *testing.T) (level, line string) {
+	t.Helper()
+	debug, info, warn := l.snapshot()
+	for _, group := range []struct {
+		level string
+		lines []string
+	}{{"warn", warn}, {"info", info}, {"debug", debug}} {
+		for _, candidate := range group.lines {
+			if strings.HasPrefix(candidate, "Session summary result:") {
+				return group.level, candidate
+			}
+		}
+	}
+	t.Fatalf("no session summary record in %q %q %q", debug, info, warn)
+	return "", ""
+}
+
+func captureExternalDiagLogs(t *testing.T) *externalDiagLogs {
+	t.Helper()
+	logs := &externalDiagLogs{}
+	oldDebug, oldInfo, oldWarn :=
+		log.DebugfContext, log.InfofContext, log.WarnfContext
+	log.DebugfContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.debug, fmt.Sprintf(format, args...))
+	}
+	log.InfofContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.info, fmt.Sprintf(format, args...))
+	}
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		logs.add(&logs.warn, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.DebugfContext = oldDebug
+		log.InfofContext = oldInfo
+		log.WarnfContext = oldWarn
+	})
+	return logs
+}
+
+type reportOnlyGateSummarizer struct {
+	fired bool
+	name  string
+	text  string
+}
+
+func (s *reportOnlyGateSummarizer) ShouldSummarize(*session.Session) bool {
+	return s.fired
+}
+
+func (s *reportOnlyGateSummarizer) ShouldSummarizeWithContext(
+	ctx context.Context, _ *session.Session,
+) bool {
+	if report, ok := summary.ReportFromContext(ctx); ok {
+		report.Trigger.Fired = s.fired
+		report.Trigger.Name = s.name
+		report.Trigger.Metric = s.name
+		report.Trigger.Value = 7
+	}
+	return s.fired
+}
+
+func (s *reportOnlyGateSummarizer) Summarize(
+	context.Context, *session.Session,
+) (string, error) {
+	return s.text, nil
+}
+
+func (s *reportOnlyGateSummarizer) SetPrompt(string)         {}
+func (s *reportOnlyGateSummarizer) SetModel(model.Model)     {}
+func (s *reportOnlyGateSummarizer) Metadata() map[string]any { return nil }
+
+var _ summary.ContextAwareSummarizer = (*reportOnlyGateSummarizer)(nil)
+
+func externalSession(id string) *session.Session {
+	return &session.Session{
+		ID:      id,
+		AppName: "app",
+		UserID:  externalUserID,
+		Events: []event.Event{{
+			Author:    "user",
+			Timestamp: time.Now().Add(-time.Minute),
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: externalEventText,
+				},
+			}}},
+		}},
+	}
+}
+
+func TestCreateSessionSummaryIgnoresCallerReportTrigger(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		fired           bool
+		wantLevel       string
+		wantTriggered   string
+		wantOutcome     string
+		wantTrigger     string
+		createInStorage bool
+	}{
+		{
+			name:            "fired true stays unpublished none",
+			fired:           true,
+			wantLevel:       "info",
+			wantTriggered:   "true",
+			wantOutcome:     "success",
+			wantTrigger:     "none",
+			createInStorage: true,
+		},
+		{
+			name:            "fired false stays unobserved none",
+			fired:           false,
+			wantLevel:       "debug",
+			wantTriggered:   "false",
+			wantOutcome:     "unobserved",
+			wantTrigger:     "none",
+			createInStorage: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureExternalDiagLogs(t)
+			summarizer := &reportOnlyGateSummarizer{
+				fired: tc.fired,
+				name:  externalSecretTrigger,
+				text:  externalSummaryText,
+			}
+			service := inmemory.NewSessionService(inmemory.WithSummarizer(summarizer))
+			defer service.Close()
+
+			sess := externalSession("external-" + strings.ReplaceAll(tc.name, " ", "-"))
+			if tc.createInStorage {
+				stored, err := service.CreateSession(context.Background(), session.Key{
+					AppName:   sess.AppName,
+					UserID:    sess.UserID,
+					SessionID: sess.ID,
+				}, nil)
+				require.NoError(t, err)
+				sess.ID = stored.ID
+			}
+
+			report := &summary.Report{}
+			ctx := summary.ContextWithReport(context.Background(), report)
+			require.NoError(t, service.CreateSessionSummary(ctx, sess, "", false))
+
+			require.Equal(t, tc.fired, report.Trigger.Fired)
+			require.Equal(t, externalSecretTrigger, report.Trigger.Name)
+			require.Equal(t, externalSecretTrigger, report.Trigger.Metric)
+			require.Equal(t, 7, report.Trigger.Value)
+
+			level, line := logs.summaryRecord(t)
+			require.Equal(t, tc.wantLevel, level)
+			require.Contains(t, line, "triggered="+tc.wantTriggered)
+			require.Contains(t, line, "outcome="+tc.wantOutcome)
+			require.Contains(t, line, "trigger="+tc.wantTrigger)
+			require.NotContains(t, line, "trigger=custom")
+			require.NotContains(t, logs.all(), externalSecretTrigger)
+			require.NotContains(t, logs.all(), externalSummaryText)
+		})
+	}
+}

--- a/session/internal/summary/cascade_diagnostics_test.go
+++ b/session/internal/summary/cascade_diagnostics_test.go
@@ -1,0 +1,509 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package summary
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/summarydiag"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+)
+
+const cascadeBranchKey = "branch"
+
+// cascadeSession builds a session whose events all belong to cascadeBranchKey,
+// which selects the single-filter cascade path.
+func cascadeSession() *session.Session {
+	return &session.Session{
+		ID:      secretSessionID,
+		AppName: "app",
+		UserID:  secretUserID,
+		Events: []event.Event{{
+			Author:    "user",
+			Timestamp: time.Now().Add(-time.Minute),
+			FilterKey: cascadeBranchKey,
+			Version:   event.CurrentVersion,
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: secretEventText,
+				},
+			}}},
+		}},
+	}
+}
+
+func cascadePolicy() SummaryDispatchPolicy {
+	return NewSummaryDispatchPolicy(nil, true)
+}
+
+// cascadeLine returns the single cascade record captured at the given level.
+func cascadeLine(t *testing.T, logs *capturedLogs, level string) string {
+	t.Helper()
+	debug, _, warn := logs.snapshot()
+	lines := debug
+	if level == "warn" {
+		lines = warn
+	}
+	var found []string
+	for _, line := range lines {
+		if strings.Contains(line, "cascade result") {
+			found = append(found, line)
+		}
+	}
+	require.Lenf(t, found, 1, "expected one cascade record in %q", lines)
+	require.True(t,
+		strings.HasPrefix(found[0], "Session summary cascade result: schema_version=1,"),
+		"schema_version=1 must follow the record name in %q", found[0])
+	return found[0]
+}
+
+// requireNoCascadeWarning asserts that a healthy cascade stays quiet.
+func requireNoCascadeWarning(t *testing.T, logs *capturedLogs) {
+	t.Helper()
+	_, _, warn := logs.snapshot()
+	for _, line := range warn {
+		require.NotContainsf(t, line, "cascade result",
+			"healthy cascades must not warn")
+	}
+}
+
+func TestCascadeReportsCopiedSource(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			return summarizeAndPersist(
+				ctx,
+				&diagSummarizer{
+					fired:    true,
+					callMode: "standalone",
+					text:     secretSummaryText,
+				},
+				s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+		},
+	)
+	require.NoError(t, err)
+
+	line := cascadeLine(t, logs, "debug")
+	requireFields(t, line, map[string]string{
+		"outcome":                      cascadeOutcomeSuccess,
+		"mode":                         cascadeModeSingleFilter,
+		"source_materialized":          "true",
+		"action":                       cascadeActionCopied,
+		"invariant":                    cascadeInvariantOK,
+		"targets":                      "2",
+		"trigger_filter_key":           `"branch"`,
+		"trigger_filter_key_truncated": "false",
+	})
+	requireNoCascadeWarning(t, logs)
+	requireNoSensitiveText(t, logs.all())
+
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.Equal(t, secretSummaryText,
+		sess.Summaries[session.SummaryFilterKeyAllContents].Summary,
+		"cascade behaviour must be unchanged")
+}
+
+// TestCascadeReportsSkippedWhenBranchNotMaterialized observes the upstream
+// contract: a branch that does not update this pass stops the cascade. That
+// suppression is not an invariant violation.
+func TestCascadeReportsSkippedWhenBranchNotMaterialized(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			return summarizeAndPersist(
+				ctx,
+				&diagSummarizer{
+					fired:    fk == session.SummaryFilterKeyAllContents,
+					callMode: "standalone",
+					text:     secretSummaryText,
+				},
+				s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+		},
+	)
+	require.NoError(t, err)
+
+	line := cascadeLine(t, logs, "debug")
+	requireFields(t, line, map[string]string{
+		"outcome":             cascadeOutcomeSuccess,
+		"mode":                cascadeModeSingleFilter,
+		"source_materialized": "false",
+		"action":              cascadeActionSkipped,
+		"invariant":           cascadeInvariantOK,
+	})
+	requireNoCascadeWarning(t, logs)
+	requireNoSensitiveText(t, logs.all())
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents],
+		"a suppressed cascade must not persist an independent full summary")
+}
+
+// TestCascadeAttemptIndependentIsViolation keeps the classifier conservative:
+// if a full-session target is observed to advance without this-pass branch
+// materialization, that remains a violation even though the current cascade
+// path no longer produces that shape.
+func TestCascadeAttemptIndependentIsViolation(t *testing.T) {
+	logs := captureLogs(t)
+	c := beginCascade(cascadeModeSingleFilter, cascadeBranchKey, 2)
+	c.fullUpdated = true
+	c.report(context.Background())
+
+	line := cascadeLine(t, logs, "warn")
+	requireFields(t, line, map[string]string{
+		"source_materialized": "false",
+		"action":              cascadeActionIndependent,
+		"invariant":           cascadeInvariantViolation,
+	})
+}
+
+func TestCascadeReportsSkippedWhenNoTargetUpdates(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			return summarizeAndPersist(
+				ctx, &diagSummarizer{fired: false}, s, fk, force, nil,
+			)
+		},
+	)
+	require.NoError(t, err)
+
+	line := cascadeLine(t, logs, "debug")
+	requireFields(t, line, map[string]string{
+		"source_materialized": "false",
+		"action":              cascadeActionSkipped,
+		"invariant":           cascadeInvariantOK,
+	})
+	requireNoCascadeWarning(t, logs)
+}
+
+func TestCascadeReportsError(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+	cascadeErr := errors.New(secretErrorText)
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(context.Context, *session.Session, string, bool) error {
+			return cascadeErr
+		},
+	)
+	require.ErrorIs(t, err, cascadeErr)
+
+	line := cascadeLine(t, logs, "warn")
+	requireFields(t, line, map[string]string{
+		"outcome": cascadeOutcomeError,
+		"mode":    cascadeModeSingleFilter,
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestCascadeReportsDependentMode covers a session with mixed filter keys.
+// The branch target runs first; the full-session target runs only after this
+// pass materializes the branch. That is dependent generation, not reuse.
+func TestCascadeReportsDependentMode(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+	sess.Events = append(sess.Events, event.Event{
+		Author:    "user",
+		Timestamp: time.Now(),
+		FilterKey: "other",
+		Version:   event.CurrentVersion,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{
+				Role:    model.RoleUser,
+				Content: secretEventText,
+			},
+		}}},
+	})
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			return summarizeAndPersist(
+				ctx,
+				&diagSummarizer{
+					fired:    true,
+					callMode: "standalone",
+					text:     secretSummaryText,
+				},
+				s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+		},
+	)
+	require.NoError(t, err)
+
+	line := cascadeLine(t, logs, "debug")
+	requireFields(t, line, map[string]string{
+		"mode":                cascadeModeDependent,
+		"action":              cascadeActionDependent,
+		"source_materialized": "true",
+		"invariant":           cascadeInvariantOK,
+	})
+	requireNoCascadeWarning(t, logs)
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestCascadeReportsDependentSkippedWhenBranchNotMaterialized(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+	sess.Events = append(sess.Events, event.Event{
+		Author:    "user",
+		Timestamp: time.Now(),
+		FilterKey: "other",
+		Version:   event.CurrentVersion,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{
+				Role:    model.RoleUser,
+				Content: secretEventText,
+			},
+		}}},
+	})
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			return summarizeAndPersist(
+				ctx,
+				&diagSummarizer{
+					fired:    fk == session.SummaryFilterKeyAllContents,
+					callMode: "standalone",
+					text:     secretSummaryText,
+				},
+				s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+		},
+	)
+	require.NoError(t, err)
+
+	line := cascadeLine(t, logs, "debug")
+	requireFields(t, line, map[string]string{
+		"mode":                cascadeModeDependent,
+		"action":              cascadeActionSkipped,
+		"source_materialized": "false",
+		"invariant":           cascadeInvariantOK,
+	})
+	requireNoCascadeWarning(t, logs)
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents],
+		"a suppressed dependent cascade must not persist a full summary")
+}
+
+// TestCascadeMarksAsyncDispatch verifies that per-target summary records
+// dispatched through the cascade are attributed to the asynchronous pipeline,
+// so operators can separate them from summaries refreshed while building a
+// model request.
+func TestCascadeMarksAsyncDispatch(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+
+	require.NoError(t, CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false,
+		NewSummaryDispatchPolicy(nil, false),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			return summarizeAndPersist(
+				ctx,
+				&diagSummarizer{
+					fired:    true,
+					callMode: "standalone",
+					text:     secretSummaryText,
+				},
+				s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+		},
+	))
+
+	_, info, _ := logs.snapshot()
+	require.Len(t, info, 1)
+	requireFields(t, info[0], map[string]string{
+		"outcome":     outcomeSuccess,
+		"dispatch":    dispatchAsync,
+		"target_kind": targetKindBranch,
+	})
+}
+
+func TestCascadeTruncatesTriggerFilterKey(t *testing.T) {
+	logs := captureLogs(t)
+	key := strings.Repeat("b", summarydiag.FilterKeyMaxRunes+3)
+	display, truncated := summarydiag.FormatFilterKey(key)
+	require.True(t, truncated)
+
+	c := beginCascade(cascadeModeDependent, key, 2)
+	c.report(context.Background())
+
+	line := cascadeLine(t, logs, "debug")
+	require.Contains(t, line, fmt.Sprintf("trigger_filter_key=%q", display))
+	require.Contains(t, line, "trigger_filter_key_truncated=true")
+	require.NotContains(t, line, key)
+	require.Equal(t, key, c.filterKey,
+		"truncation must not change the cascade trigger filter key")
+}
+
+type cascadeCall struct {
+	filterKey  string
+	force      bool
+	fullCopied bool
+}
+
+func TestCascadeSingleFilterCallSequence(t *testing.T) {
+	branchErr := errors.New("branch failed")
+	persistErr := errors.New("persist failed")
+
+	tests := []struct {
+		name        string
+		force       bool
+		failOn      string
+		wantCalls   []cascadeCall
+		wantErr     error
+		wantWrap    string
+		seedSummary bool
+		attribute   bool
+	}{
+		{
+			name:        "force is preserved then full persist uses false after copy",
+			force:       true,
+			seedSummary: true,
+			attribute:   true,
+			wantCalls: []cascadeCall{
+				{filterKey: cascadeBranchKey, force: true, fullCopied: false},
+				{filterKey: "", force: false, fullCopied: true},
+			},
+		},
+		{
+			name:        "force false is passed through on the branch call",
+			force:       false,
+			seedSummary: true,
+			attribute:   true,
+			wantCalls: []cascadeCall{
+				{filterKey: cascadeBranchKey, force: false, fullCopied: false},
+				{filterKey: "", force: false, fullCopied: true},
+			},
+		},
+		{
+			name:   "branch error is wrapped and skips copy and persist",
+			force:  true,
+			failOn: cascadeBranchKey,
+			wantCalls: []cascadeCall{
+				{filterKey: cascadeBranchKey, force: true, fullCopied: false},
+			},
+			wantErr:  branchErr,
+			wantWrap: `create session summary for filterKey "branch" failed`,
+		},
+		{
+			name:        "persist error is wrapped after copy",
+			force:       true,
+			failOn:      "full",
+			seedSummary: true,
+			attribute:   true,
+			wantCalls: []cascadeCall{
+				{filterKey: cascadeBranchKey, force: true, fullCopied: false},
+				{filterKey: "", force: false, fullCopied: true},
+			},
+			wantErr:  persistErr,
+			wantWrap: "persist full-session summary failed",
+		},
+		{
+			name:        "unattributed branch seed does not copy or persist",
+			force:       true,
+			seedSummary: true,
+			wantCalls: []cascadeCall{
+				{filterKey: cascadeBranchKey, force: true, fullCopied: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := cascadeSession()
+			sess.Summaries = make(map[string]*session.Summary)
+			var calls []cascadeCall
+
+			err := CreateSessionSummaryWithCascade(
+				context.Background(), sess, cascadeBranchKey, tt.force,
+				cascadePolicy(),
+				func(ctx context.Context, s *session.Session, fk string, force bool) error {
+					s.SummariesMu.RLock()
+					_, copied := s.Summaries[session.SummaryFilterKeyAllContents]
+					s.SummariesMu.RUnlock()
+					calls = append(calls, cascadeCall{
+						filterKey:  fk,
+						force:      force,
+						fullCopied: copied,
+					})
+					if tt.seedSummary && fk == cascadeBranchKey {
+						s.SummariesMu.Lock()
+						s.Summaries[fk] = &session.Summary{
+							Summary:   secretSummaryText,
+							UpdatedAt: time.Now(),
+						}
+						s.SummariesMu.Unlock()
+						if tt.attribute {
+							recordSummaryMaterialized(ctx, fk)
+						}
+					}
+					if tt.failOn == cascadeBranchKey && fk == cascadeBranchKey {
+						return branchErr
+					}
+					if tt.failOn == "full" && fk == session.SummaryFilterKeyAllContents {
+						return persistErr
+					}
+					return nil
+				},
+			)
+
+			require.Equal(t, tt.wantCalls, calls)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Contains(t, err.Error(), tt.wantWrap)
+		})
+	}
+}

--- a/session/internal/summary/cascade_diagnostics_test.go
+++ b/session/internal/summary/cascade_diagnostics_test.go
@@ -54,6 +54,25 @@ func cascadePolicy() SummaryDispatchPolicy {
 	return NewSummaryDispatchPolicy(nil, true)
 }
 
+// cascadeMultiFilterSession adds a second filter key so the dependent
+// cascade path runs instead of the single-filter copy.
+func cascadeMultiFilterSession() *session.Session {
+	sess := cascadeSession()
+	sess.Events = append(sess.Events, event.Event{
+		Author:    "user",
+		Timestamp: time.Now(),
+		FilterKey: "other",
+		Version:   event.CurrentVersion,
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{
+				Role:    model.RoleUser,
+				Content: secretEventText,
+			},
+		}}},
+	})
+	return sess
+}
+
 // cascadeLine returns the single cascade record captured at the given level.
 func cascadeLine(t *testing.T, logs *capturedLogs, level string) string {
 	t.Helper()
@@ -241,6 +260,57 @@ func TestCascadeAttemptIndependentIsViolation(t *testing.T) {
 	})
 }
 
+func TestCascadeAttemptActionUsesCopyAndDependentStart(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		copied  bool
+		started bool
+		want    string
+	}{
+		{
+			name:   "copied only after successful copy",
+			mode:   cascadeModeSingleFilter,
+			copied: true,
+			want:   cascadeActionCopied,
+		},
+		{
+			name:    "dependent only after target started",
+			mode:    cascadeModeDependent,
+			started: true,
+			want:    cascadeActionDependent,
+		},
+		{
+			name: "materialized single-filter source without copy is skipped",
+			mode: cascadeModeSingleFilter,
+			want: cascadeActionSkipped,
+		},
+		{
+			name: "materialized dependent source without start is skipped",
+			mode: cascadeModeDependent,
+			want: cascadeActionSkipped,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureLogs(t)
+			c := beginCascade(tt.mode, cascadeBranchKey, 2)
+			c.sourceMaterialized = true
+			c.copied = tt.copied
+			c.dependentStarted = tt.started
+			c.report(context.Background())
+
+			line := cascadeLine(t, logs, "debug")
+			requireFields(t, line, map[string]string{
+				"source_materialized": "true",
+				"action":              tt.want,
+				"invariant":           cascadeInvariantOK,
+			})
+			requireNoCascadeWarning(t, logs)
+		})
+	}
+}
+
 func TestCascadeReportsSkippedWhenNoTargetUpdates(t *testing.T) {
 	logs := captureLogs(t)
 	sess := cascadeSession()
@@ -292,19 +362,7 @@ func TestCascadeReportsError(t *testing.T) {
 // pass materializes the branch. That is dependent generation, not reuse.
 func TestCascadeReportsDependentMode(t *testing.T) {
 	logs := captureLogs(t)
-	sess := cascadeSession()
-	sess.Events = append(sess.Events, event.Event{
-		Author:    "user",
-		Timestamp: time.Now(),
-		FilterKey: "other",
-		Version:   event.CurrentVersion,
-		Response: &model.Response{Choices: []model.Choice{{
-			Message: model.Message{
-				Role:    model.RoleUser,
-				Content: secretEventText,
-			},
-		}}},
-	})
+	sess := cascadeMultiFilterSession()
 
 	err := CreateSessionSummaryWithCascade(
 		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
@@ -338,19 +396,7 @@ func TestCascadeReportsDependentMode(t *testing.T) {
 
 func TestCascadeReportsDependentSkippedWhenBranchNotMaterialized(t *testing.T) {
 	logs := captureLogs(t)
-	sess := cascadeSession()
-	sess.Events = append(sess.Events, event.Event{
-		Author:    "user",
-		Timestamp: time.Now(),
-		FilterKey: "other",
-		Version:   event.CurrentVersion,
-		Response: &model.Response{Choices: []model.Choice{{
-			Message: model.Message{
-				Role:    model.RoleUser,
-				Content: secretEventText,
-			},
-		}}},
-	})
+	sess := cascadeMultiFilterSession()
 
 	err := CreateSessionSummaryWithCascade(
 		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
@@ -383,6 +429,123 @@ func TestCascadeReportsDependentSkippedWhenBranchNotMaterialized(t *testing.T) {
 	defer sess.SummariesMu.RUnlock()
 	require.Nil(t, sess.Summaries[session.SummaryFilterKeyAllContents],
 		"a suppressed dependent cascade must not persist a full summary")
+}
+
+// TestCascadeReportsSkippedWhenCopyLosesMaterializedSource covers a
+// single-filter branch that materialized this pass, then lost the source
+// summary before copy. Full must not run; action stays skipped.
+func TestCascadeReportsSkippedWhenCopyLosesMaterializedSource(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+	var fullCalls int
+
+	err := CreateSessionSummaryWithCascade(
+		context.Background(), sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			if fk == session.SummaryFilterKeyAllContents {
+				fullCalls++
+				return nil
+			}
+			err := summarizeAndPersist(
+				ctx,
+				&diagSummarizer{
+					fired:    true,
+					callMode: "standalone",
+					text:     secretSummaryText,
+				},
+				s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+			if err != nil {
+				return err
+			}
+			s.SummariesMu.Lock()
+			delete(s.Summaries, fk)
+			s.SummariesMu.Unlock()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Zero(t, fullCalls)
+
+	line := cascadeLine(t, logs, "debug")
+	requireFields(t, line, map[string]string{
+		"outcome":             cascadeOutcomeSuccess,
+		"mode":                cascadeModeSingleFilter,
+		"source_materialized": "true",
+		"action":              cascadeActionSkipped,
+		"invariant":           cascadeInvariantOK,
+	})
+	requireNoCascadeWarning(t, logs)
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestCascadeReportsSkippedWhenSourcePersistFailsAfterUpdate covers a
+// real SummarizeSession update whose persist callback fails. Full must
+// not run; the original persist error is returned.
+func TestCascadeReportsSkippedWhenSourcePersistFailsAfterUpdate(t *testing.T) {
+	persistErr := errors.New("injected persist error")
+	tests := []struct {
+		name string
+		sess *session.Session
+		mode string
+	}{
+		{
+			name: "single filter",
+			sess: cascadeSession(),
+			mode: cascadeModeSingleFilter,
+		},
+		{
+			name: "dependent multi filter",
+			sess: cascadeMultiFilterSession(),
+			mode: cascadeModeDependent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureLogs(t)
+			var fullCalls int
+
+			err := CreateSessionSummaryWithCascade(
+				context.Background(), tt.sess, cascadeBranchKey, false,
+				cascadePolicy(),
+				func(
+					ctx context.Context, s *session.Session, fk string, force bool,
+				) error {
+					if fk == session.SummaryFilterKeyAllContents {
+						fullCalls++
+						return nil
+					}
+					return summarizeAndPersist(
+						ctx,
+						&diagSummarizer{
+							fired:    true,
+							callMode: "standalone",
+							text:     secretSummaryText,
+						},
+						s, fk, force,
+						func(context.Context, *session.Summary) error {
+							return persistErr
+						},
+					)
+				},
+			)
+			require.ErrorIs(t, err, persistErr)
+			require.Zero(t, fullCalls)
+
+			line := cascadeLine(t, logs, "warn")
+			requireFields(t, line, map[string]string{
+				"outcome":             cascadeOutcomeError,
+				"mode":                tt.mode,
+				"source_materialized": "true",
+				"action":              cascadeActionSkipped,
+				"invariant":           cascadeInvariantOK,
+			})
+			requireNoSensitiveText(t, logs.all())
+		})
+	}
 }
 
 // TestCascadeMarksAsyncDispatch verifies that per-target summary records

--- a/session/internal/summary/cascade_diagnostics_test.go
+++ b/session/internal/summary/cascade_diagnostics_test.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/internal/summarydiag"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
 )
 
 const cascadeBranchKey = "branch"
@@ -126,6 +127,58 @@ func TestCascadeReportsCopiedSource(t *testing.T) {
 	require.Equal(t, secretSummaryText,
 		sess.Summaries[session.SummaryFilterKeyAllContents].Summary,
 		"cascade behaviour must be unchanged")
+}
+
+// TestCascadeSharedReportCopiedTargetIsNotCalled proves a caller-attached
+// Report reused across sequential CreateSessionSummary calls does not make
+// the copied full-session target look like a model call.
+func TestCascadeSharedReportCopiedTargetIsNotCalled(t *testing.T) {
+	logs := captureLogs(t)
+	sess := cascadeSession()
+	report := &summary.Report{}
+	ctx := summary.ContextWithReport(context.Background(), report)
+	summarizer := &diagSummarizer{
+		fired:    true,
+		callMode: callModeStandalone,
+		text:     secretSummaryText,
+	}
+
+	require.NoError(t, CreateSessionSummaryWithCascade(
+		ctx, sess, cascadeBranchKey, false, cascadePolicy(),
+		func(
+			ctx context.Context, s *session.Session, fk string, force bool,
+		) error {
+			got, ok := summary.ReportFromContext(ctx)
+			require.True(t, ok)
+			require.Same(t, report, got,
+				"sequential cascade targets must keep the caller-attached Report")
+			return summarizeAndPersist(
+				ctx, summarizer, s, fk, force,
+				func(context.Context, *session.Summary) error { return nil },
+			)
+		},
+	))
+	require.Equal(t, 1, summarizer.summarizeCalls,
+		"materializing a copied full-session summary must not call the model")
+	require.Equal(t, callModeStandalone, report.Call.Mode)
+
+	branchLevel, branchLine := sessionSummaryRecordByTarget(t, logs, targetKindBranch)
+	require.Equal(t, "info", branchLevel)
+	requireFields(t, branchLine, map[string]string{
+		"outcome":           outcomeSuccess,
+		"model_call_status": modelCallStatusCalled,
+		"target_kind":       targetKindBranch,
+	})
+
+	fullLevel, fullLine := sessionSummaryRecordByTarget(t, logs, targetKindFull)
+	require.Equal(t, "debug", fullLevel)
+	requireFields(t, fullLine, map[string]string{
+		"outcome":           outcomeCopied,
+		"model_call_status": modelCallStatusUnobserved,
+		"target_kind":       targetKindFull,
+	})
+	require.NotContains(t, fullLine, "model_call_status="+modelCallStatusCalled)
+	requireNoSensitiveText(t, logs.all())
 }
 
 // TestCascadeReportsSkippedWhenBranchNotMaterialized observes the upstream

--- a/session/internal/summary/diagnostics.go
+++ b/session/internal/summary/diagnostics.go
@@ -1,0 +1,678 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package summary
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/internal/summarydiag"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummarycontext "trpc.group/trpc-go/trpc-agent-go/session/internal/summarycontext"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
+)
+
+// Session summary outcomes are stable diagnostic values. They reuse the
+// synchronous context-compaction vocabulary where the same failure class
+// applies and add the outcomes that only exist for stored summaries.
+const (
+	// outcomeSuccess reports a newly generated summary that the backend
+	// confirmed stored.
+	outcomeSuccess = "success"
+	// outcomeCopied reports an existing summary that a cascade materialized
+	// for this target and persisted without a summary model call.
+	outcomeCopied = "copied"
+	// outcomeStaleWrite reports a generated summary that the backend refused
+	// to store because a newer summary was already persisted. This is a
+	// successful set-if-newer no-op and can happen under normal concurrency.
+	outcomeStaleWrite = "stale_write"
+	// outcomeNotStored reports a generated summary that the backend neither
+	// stored nor rejected, for example because the session row was missing.
+	outcomeNotStored = "not_stored"
+	// outcomeNoUpdate reports a triggered attempt whose summary model call
+	// produced no summary text.
+	outcomeNoUpdate = "no_update"
+	// outcomeNoDelta reports that no event was appended after the recorded
+	// summary boundary.
+	outcomeNoDelta = "no_delta"
+	// outcomeBelowThreshold reports that a configured trigger check ran and
+	// did not fire.
+	outcomeBelowThreshold = "below_threshold"
+	// outcomeCascadeSuppressed reports a full-session target that was skipped
+	// because it was only requested as a branch cascade.
+	outcomeCascadeSuppressed = "cascade_suppressed"
+	// outcomeNoContent reports that no eligible content reached the summary
+	// model, so the model was never called.
+	outcomeNoContent = "no_content"
+	// outcomeUnsafeView reports outcomeNoContent caused by a model-visible
+	// view that exists but is not bound to the request the model saw.
+	outcomeUnsafeView = "unsafe_view"
+	// outcomeSummaryError reports a failed summary model call.
+	outcomeSummaryError = "summary_error"
+	// outcomeContextError reports a canceled or expired summary context.
+	outcomeContextError = "context_error"
+	// outcomePersistenceError reports a generated summary that could not be
+	// persisted by the backend.
+	outcomePersistenceError = "persistence_error"
+	// outcomeUnknownWrite reports a generated summary whose backend write
+	// completed without error, but the set-if-newer reply could not be
+	// classified as stored or stale. This is diagnostic uncertainty, not a
+	// business failure.
+	outcomeUnknownWrite = "unknown_write"
+)
+
+// Summary targets are reported by kind so diagnostics stay low cardinality
+// even when the raw filter key is not usable for aggregation.
+const (
+	targetKindFull   = "full"
+	targetKindBranch = "branch"
+)
+
+// Dispatch values report how the attempt reached the session backend.
+const (
+	// dispatchAsync marks an attempt dispatched through the asynchronous
+	// summary pipeline, including its synchronous queue-full fallback.
+	dispatchAsync = "async"
+	// dispatchRequest marks an attempt made directly while building a model
+	// request, for example synchronous context compaction.
+	dispatchRequest = "request"
+)
+
+// Call modes that diagnostics can prove. Any other mode, including an unset
+// Report, is unobserved rather than reported as a negative model call.
+const (
+	callModeStandalone     = "standalone"
+	callModeCacheSafeFork  = "cache_safe_fork"
+	callModeCustomResponse = "custom_response"
+
+	modelCallStatusCalled         = "called"
+	modelCallStatusCustomResponse = "custom_response"
+	modelCallStatusUnobserved     = "unobserved"
+)
+
+// PersistResult reports what a backend persistence stage actually did. Values
+// are stable and low cardinality so operators can separate a backend-confirmed
+// store from a deliberate no-op.
+type PersistResult string
+
+const (
+	// PersistNotAttempted means no persistence stage ran for this attempt.
+	// It is the zero value.
+	PersistNotAttempted PersistResult = "not_attempted"
+	// PersistNoSummary means summarization reported an update but left no
+	// in-memory summary for the target filter key.
+	PersistNoSummary PersistResult = "no_summary"
+	// PersistStored means the backend confirmed the write.
+	PersistStored PersistResult = "stored"
+	// PersistStale means the backend deliberately skipped the write because a
+	// newer summary is already persisted.
+	PersistStale PersistResult = "stale"
+	// PersistUnknown means the backend write finished without error, but the
+	// reply could not be classified as stored or stale.
+	PersistUnknown PersistResult = "unknown"
+	// PersistError means the backend write failed.
+	PersistError PersistResult = "error"
+)
+
+// Attempt accumulates diagnostics for one session summary target and reports
+// exactly one record when the attempt completes.
+//
+// An Attempt is owned by the single goroutine running the attempt; cascade
+// forks create one attempt per target. All methods tolerate a nil receiver so
+// callers never need to branch on diagnostics being available.
+//
+// Diagnostics never include summary, prompt, event, or raw error text.
+type Attempt struct {
+	// ctx is the reporting context for this attempt. The Attempt owns it for
+	// the duration of one CreateSessionSummary call.
+	ctx       context.Context
+	startedAt time.Time
+	sess      *session.Session
+	filterKey string
+	before    summaryBoundaryMark
+	report    *summary.Report
+	selection isummarycontext.EventSelection
+
+	gate         summaryGate
+	skip         string
+	triggered    bool
+	updated      bool
+	copied       bool
+	summarizeErr error
+	persist      PersistResult
+	persistErr   error
+}
+
+// BeginAttempt starts diagnostics for one session summary target. The returned
+// context must be used for summarization so trigger, model-call, and event
+// selection details are observed. Callers report the attempt exactly once,
+// normally with defer.
+func BeginAttempt(
+	ctx context.Context,
+	sess *session.Session,
+	filterKey string,
+) (context.Context, *Attempt) {
+	att := &Attempt{
+		startedAt: time.Now(),
+		sess:      sess,
+		filterKey: filterKey,
+		before:    markSummaryBoundary(sess, filterKey),
+		// Until a summarizer publishes its selection, nothing is known about
+		// how much history would have reached the summary model.
+		selection: isummarycontext.UnknownSelection("", isummarycontext.ReasonNone),
+		persist:   PersistNotAttempted,
+	}
+	ctx = contextWithSummaryAttempt(ctx, att)
+	att.report, ctx = ensureSummaryReport(ctx)
+	ctx = isummarycontext.WithEventSelectionRecorder(ctx, &att.selection)
+	att.ctx = ctx
+	return ctx, att
+}
+
+// Summarized records the result of the summarization stage. Backends call it
+// with the values returned by SummarizeSession, before applying their own
+// error contract.
+func (a *Attempt) Summarized(updated bool, err error) {
+	if a == nil {
+		return
+	}
+	a.updated = updated
+	a.summarizeErr = err
+}
+
+// Persisted records what the backend persistence stage did.
+func (a *Attempt) Persisted(result PersistResult) {
+	if a == nil {
+		return
+	}
+	a.persist = result
+}
+
+// RecordWrite records a completed backend write and returns err unchanged so
+// backends can report and return in one statement.
+func (a *Attempt) RecordWrite(err error) error {
+	if a == nil {
+		return err
+	}
+	if err != nil {
+		a.persist = PersistError
+		a.persistErr = err
+		return err
+	}
+	a.persist = PersistStored
+	return nil
+}
+
+type summaryAttemptContextKey struct{}
+type summaryDispatchContextKey struct{}
+
+func contextWithSummaryAttempt(
+	ctx context.Context,
+	att *Attempt,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, summaryAttemptContextKey{}, att)
+}
+
+func summaryAttemptFromContext(ctx context.Context) *Attempt {
+	if ctx == nil {
+		return nil
+	}
+	att, _ := ctx.Value(summaryAttemptContextKey{}).(*Attempt)
+	return att
+}
+
+// contextWithAsyncSummaryDispatch marks work dispatched through the
+// asynchronous summary pipeline so diagnostics can separate it from summaries
+// refreshed while a model request is being built.
+func contextWithAsyncSummaryDispatch(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, summaryDispatchContextKey{}, dispatchAsync)
+}
+
+func summaryDispatch(ctx context.Context) string {
+	if ctx == nil {
+		return dispatchRequest
+	}
+	dispatch, ok := ctx.Value(summaryDispatchContextKey{}).(string)
+	if !ok || dispatch == "" {
+		return dispatchRequest
+	}
+	return dispatch
+}
+
+// recordSummarySkip records the stable gate outcome that stopped generation.
+func recordSummarySkip(ctx context.Context, skip string) {
+	if att := summaryAttemptFromContext(ctx); att != nil {
+		att.skip = skip
+	}
+}
+
+// summaryGate is the scalar part of a trigger decision. It excludes the
+// per-check slice so diagnostics keep a bounded, low-cardinality shape.
+type summaryGate struct {
+	name           string
+	metric         string
+	value          int
+	threshold      int
+	contextWindow  int
+	thresholdRatio float64
+}
+
+// recordSummaryGate records the trigger decision. When the gate did not fire,
+// the shape of trigger separates an evaluated check that stayed below its
+// threshold from a gate that produced no check result at all, which means no
+// eligible content reached the checks.
+func recordSummaryGate(
+	ctx context.Context,
+	fired bool,
+	trigger summary.Trigger,
+) {
+	att := summaryAttemptFromContext(ctx)
+	if att == nil {
+		return
+	}
+	att.triggered = fired
+	att.gate = summaryGate{
+		name:           trigger.Name,
+		metric:         trigger.Metric,
+		value:          trigger.Value,
+		threshold:      trigger.Threshold,
+		contextWindow:  trigger.ContextWindow,
+		thresholdRatio: trigger.ThresholdRatio,
+	}
+	if fired {
+		att.skip = ""
+		return
+	}
+	if trigger.Name == "" && trigger.Metric == "" && len(trigger.Checks) == 0 {
+		att.skip = outcomeNoContent
+		return
+	}
+	att.skip = outcomeBelowThreshold
+}
+
+// recordSummaryCopied records that an existing summary was materialized for
+// this target instead of being generated.
+func recordSummaryCopied(ctx context.Context) {
+	if att := summaryAttemptFromContext(ctx); att != nil {
+		att.copied = true
+	}
+}
+
+// ensureSummaryReport guarantees that a summary report is observable for this
+// attempt. Callers that already attached a report keep it, so hook behavior
+// and forked cascade reports are unchanged.
+func ensureSummaryReport(
+	ctx context.Context,
+) (*summary.Report, context.Context) {
+	if report, ok := summary.ReportFromContext(ctx); ok {
+		return report, ctx
+	}
+	report := &summary.Report{}
+	return report, summary.ContextWithReport(ctx, report)
+}
+
+// Report emits the single diagnostic record for this attempt.
+func (a *Attempt) Report() {
+	if a == nil {
+		return
+	}
+	ctx := a.ctx
+	binding := summaryview.BindingFromContext(ctx)
+	outcome := a.outcome(binding)
+	after := markSummaryBoundary(a.sess, a.filterKey)
+	filterKey, filterKeyTruncated := summarydiag.FormatFilterKey(a.filterKey)
+	format := "Session summary result: schema_version=%d, outcome=%s, " +
+		"dispatch=%s, target_kind=%s, filter_key=%q, " +
+		"filter_key_truncated=%t, triggered=%t, trigger=%s, " +
+		"trigger_metric=%s, trigger_value=%d, trigger_threshold=%d, " +
+		"threshold_ratio=%.2f, context_window=%d, request_tokens=%d, " +
+		"summary_view_present=%t, summary_view_bound=%t, binding_reason=%s, " +
+		"summary_view_items=%d, input_source=%s, selection_reason=%s, " +
+		"eligible_events=%d, skip_recent_requested=%d, " +
+		"skip_recent_applied=%d, selected_events=%d, model_call_status=%s, " +
+		"updated=%t, boundary_advanced=%t, persist_result=%s, duration_ms=%d"
+	args := []any{
+		summarydiag.SchemaVersion,
+		outcome,
+		summaryDispatch(ctx),
+		summaryTargetKind(a.filterKey),
+		filterKey,
+		filterKeyTruncated,
+		a.triggered,
+		normalizedTriggerName(a.gate.name),
+		normalizedTriggerMetric(a.gate.metric),
+		a.gate.value,
+		a.gate.threshold,
+		a.gate.thresholdRatio,
+		a.gate.contextWindow,
+		binding.RequestTokens,
+		binding.Present,
+		binding.Bound,
+		binding.Reason,
+		binding.Items,
+		diagnosticValue(a.selection.Source),
+		diagnosticValue(a.selection.Reason),
+		a.selection.Eligible,
+		a.selection.SkipRecentRequested,
+		a.selection.SkipRecentApplied,
+		a.selection.Selected,
+		summaryModelCallStatus(a.report),
+		a.updated,
+		after.advancedFrom(a.before),
+		a.persist,
+		time.Since(a.startedAt).Milliseconds(),
+	}
+	switch outcome {
+	case outcomeSuccess:
+		log.InfofContext(ctx, format, args...)
+	case outcomeCopied, outcomeNoDelta, outcomeBelowThreshold,
+		outcomeCascadeSuppressed, outcomeNoContent, outcomeStaleWrite,
+		outcomeUnknownWrite:
+		// Routine decisions that did no backend-confirmed write, including a
+		// set-if-newer skip when a newer summary is already stored.
+		log.DebugfContext(ctx, format, args...)
+	default:
+		log.WarnfContext(ctx, format, args...)
+	}
+}
+
+// outcome classifies the attempt. Errors are classified by the stage that
+// produced them: a non-context error from summarization is always a summary
+// error, whether or not the summary model was reached, and
+// model_call_status separates a failed model call from a pre-model build,
+// a custom response, or an unobserved custom summarizer.
+func (a *Attempt) outcome(binding summaryview.Binding) string {
+	switch {
+	case isSummaryContextError(a.summarizeErr) ||
+		isSummaryContextError(a.persistErr):
+		return outcomeContextError
+	case a.persistErr != nil:
+		return outcomePersistenceError
+	case a.summarizeErr != nil:
+		return outcomeSummaryError
+	case a.persist == PersistStale:
+		return outcomeStaleWrite
+	case a.persist == PersistUnknown:
+		// Classified before updated → success so an unobserved write is never
+		// reported as a backend-confirmed store.
+		return outcomeUnknownWrite
+	case a.persist == PersistNoSummary:
+		return outcomeNoUpdate
+	case a.persist == PersistNotAttempted && a.updated:
+		return outcomeNotStored
+	case a.copied:
+		return outcomeCopied
+	case a.updated:
+		return outcomeSuccess
+	case a.skip != "":
+		return unsafeViewOutcome(a.skip, binding)
+	}
+	return outcomeNoUpdate
+}
+
+// diagnosticValue keeps unset enum-like fields readable in log output.
+func diagnosticValue(value string) string {
+	if value == "" {
+		return diagnosticNone
+	}
+	return value
+}
+
+// diagnosticNone marks an unset enum-like diagnostic field.
+const diagnosticNone = "none"
+
+// diagnosticCustom is the sentinel reported for a trigger name or metric that
+// is not one of the framework's own values.
+const diagnosticCustom = "custom"
+
+// triggerNames and triggerMetrics are the framework's own trigger vocabulary.
+// summary.Trigger carries exported string fields that any caller can populate
+// through summary.ContextWithReport or a custom summary.SessionSummarizer, so
+// diagnostics must not log these strings verbatim.
+var (
+	triggerNames = map[string]struct{}{
+		"always":            {},
+		"custom":            {},
+		"event_threshold":   {},
+		"time_threshold":    {},
+		"token_threshold":   {},
+		"context_threshold": {},
+		"force":             {},
+		"manual":            {},
+	}
+	triggerMetrics = map[string]struct{}{
+		"custom":   {},
+		"duration": {},
+		"events":   {},
+		"tokens":   {},
+	}
+)
+
+// normalizedTriggerName reports a bounded trigger name. An unset name reports
+// none and any name outside the framework's vocabulary reports custom, so an
+// arbitrary caller-supplied string can never reach the log or inflate the
+// cardinality of this field.
+func normalizedTriggerName(name string) string {
+	return normalizedTriggerValue(name, triggerNames)
+}
+
+// normalizedTriggerMetric reports a bounded trigger metric under the same rules
+// as normalizedTriggerName.
+func normalizedTriggerMetric(metric string) string {
+	return normalizedTriggerValue(metric, triggerMetrics)
+}
+
+func normalizedTriggerValue(value string, known map[string]struct{}) string {
+	if value == "" {
+		return diagnosticNone
+	}
+	if _, ok := known[value]; ok {
+		return value
+	}
+	return diagnosticCustom
+}
+
+// unsafeViewOutcome refines a missing-content outcome when the request did
+// expose a model-visible view that could not be bound. Content was available
+// but was not proven visible to the model.
+func unsafeViewOutcome(outcome string, binding summaryview.Binding) string {
+	if outcome != outcomeNoContent || !binding.Present || binding.Bound {
+		return outcome
+	}
+	return outcomeUnsafeView
+}
+
+func isSummaryContextError(err error) bool {
+	return err != nil &&
+		(errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded))
+}
+
+func summaryModelCallStatus(report *summary.Report) string {
+	if report == nil {
+		return modelCallStatusUnobserved
+	}
+	switch report.Call.Mode {
+	case callModeStandalone, callModeCacheSafeFork:
+		return modelCallStatusCalled
+	case callModeCustomResponse:
+		return modelCallStatusCustomResponse
+	default:
+		return modelCallStatusUnobserved
+	}
+}
+
+func summaryTargetKind(filterKey string) string {
+	if filterKey == session.SummaryFilterKeyAllContents {
+		return targetKindFull
+	}
+	return targetKindBranch
+}
+
+// Cascade diagnostics describe how a branch-triggered summary reached the
+// full-session target.
+const (
+	// cascadeModeSingleFilter marks a session whose events all match the
+	// trigger filter key, so one generated summary is reused for both targets.
+	cascadeModeSingleFilter = "single_filter"
+	// cascadeModeDependent marks a multi-filter cascade that runs the branch
+	// target first and only then the dependent full-session target.
+	cascadeModeDependent = "dependent"
+
+	// cascadeActionCopied marks a materialized branch summary reused for the
+	// full-session target.
+	cascadeActionCopied = "copied"
+	// cascadeActionDependent marks a full-session target that ran only after
+	// this pass materialized the branch source.
+	cascadeActionDependent = "dependent"
+	// cascadeActionIndependent marks a full-session target updated without a
+	// materialized branch source.
+	cascadeActionIndependent = "independent"
+	// cascadeActionSkipped marks a cascade that updated no target, including
+	// a normal upstream stop when this pass did not materialize the branch.
+	cascadeActionSkipped = "skipped"
+
+	// cascadeInvariantOK marks a cascade whose full-session target is backed
+	// by a materialized branch summary or by nothing at all.
+	cascadeInvariantOK = "ok"
+	// cascadeInvariantViolation marks a full-session target that advanced
+	// while the branch target materialized no summary to reuse.
+	cascadeInvariantViolation = "violation"
+
+	cascadeOutcomeSuccess = "success"
+	cascadeOutcomeError   = "error"
+)
+
+// cascadeAttempt accumulates diagnostics for one cascade dispatch. It is owned
+// by the goroutine running the cascade; per-target work reports separately.
+type cascadeAttempt struct {
+	startedAt          time.Time
+	mode               string
+	filterKey          string
+	targets            int
+	sourceMaterialized bool
+	fullUpdated        bool
+	failed             bool
+}
+
+func beginCascade(mode, filterKey string, targets int) *cascadeAttempt {
+	return &cascadeAttempt{
+		startedAt: time.Now(),
+		mode:      mode,
+		filterKey: filterKey,
+		targets:   targets,
+	}
+}
+
+func (c *cascadeAttempt) action() string {
+	if c.sourceMaterialized {
+		if c.mode == cascadeModeDependent {
+			return cascadeActionDependent
+		}
+		return cascadeActionCopied
+	}
+	if c.fullUpdated {
+		return cascadeActionIndependent
+	}
+	return cascadeActionSkipped
+}
+
+func (c *cascadeAttempt) invariant() string {
+	if c.action() == cascadeActionIndependent {
+		return cascadeInvariantViolation
+	}
+	return cascadeInvariantOK
+}
+
+func (c *cascadeAttempt) report(ctx context.Context) {
+	outcome := cascadeOutcomeSuccess
+	if c.failed {
+		outcome = cascadeOutcomeError
+	}
+	invariant := c.invariant()
+	filterKey, filterKeyTruncated := summarydiag.FormatFilterKey(c.filterKey)
+	format := "Session summary cascade result: schema_version=%d, " +
+		"outcome=%s, mode=%s, trigger_filter_key=%q, " +
+		"trigger_filter_key_truncated=%t, targets=%d, " +
+		"source_materialized=%t, action=%s, invariant=%s, duration_ms=%d"
+	args := []any{
+		summarydiag.SchemaVersion,
+		outcome,
+		c.mode,
+		filterKey,
+		filterKeyTruncated,
+		c.targets,
+		c.sourceMaterialized,
+		c.action(),
+		invariant,
+		time.Since(c.startedAt).Milliseconds(),
+	}
+	if invariant == cascadeInvariantViolation || c.failed {
+		log.WarnfContext(ctx, format, args...)
+		return
+	}
+	log.DebugfContext(ctx, format, args...)
+}
+
+// summaryBoundaryMark is a comparable snapshot of a summary boundary. It holds
+// only structural cutoff metadata, never summary text.
+type summaryBoundaryMark struct {
+	present bool
+	cutoff  time.Time
+	eventID string
+}
+
+func markSummaryBoundary(
+	sess *session.Session,
+	filterKey string,
+) summaryBoundaryMark {
+	if sess == nil {
+		return summaryBoundaryMark{}
+	}
+	sess.SummariesMu.RLock()
+	defer sess.SummariesMu.RUnlock()
+	sum := sess.Summaries[filterKey]
+	if sum == nil {
+		return summaryBoundaryMark{}
+	}
+	mark := summaryBoundaryMark{present: true, cutoff: sum.UpdatedAt.UTC()}
+	if sum.Boundary == nil {
+		return mark
+	}
+	if !sum.Boundary.CutoffAt.IsZero() {
+		mark.cutoff = sum.Boundary.CutoffAt.UTC()
+	}
+	mark.eventID = sum.Boundary.LastEventID
+	return mark
+}
+
+// advancedFrom reports whether the boundary now covers more stored history
+// than prev did.
+func (m summaryBoundaryMark) advancedFrom(prev summaryBoundaryMark) bool {
+	if !m.present {
+		return false
+	}
+	if !prev.present {
+		return true
+	}
+	if m.cutoff.After(prev.cutoff) {
+		return true
+	}
+	return m.cutoff.Equal(prev.cutoff) && m.eventID != prev.eventID
+}

--- a/session/internal/summary/diagnostics.go
+++ b/session/internal/summary/diagnostics.go
@@ -51,9 +51,14 @@ const (
 	// outcomeCascadeSuppressed reports a full-session target that was skipped
 	// because it was only requested as a branch cascade.
 	outcomeCascadeSuppressed = "cascade_suppressed"
-	// outcomeNoContent reports that no eligible content reached the summary
-	// model, so the model was never called.
+	// outcomeNoContent reports that the built-in summarizer published a
+	// trigger observation with no eligible content, so the model was never
+	// called.
 	outcomeNoContent = "no_content"
+	// outcomeUnobserved reports that this attempt's gate did not fire and no
+	// trigger observation was published for this attempt. That is diagnostic
+	// uncertainty, not proof of missing content or a failed threshold check.
+	outcomeUnobserved = "unobserved"
 	// outcomeUnsafeView reports outcomeNoContent caused by a model-visible
 	// view that exists but is not bound to the request the model saw.
 	outcomeUnsafeView = "unsafe_view"
@@ -135,13 +140,14 @@ const (
 type Attempt struct {
 	// ctx is the reporting context for this attempt. The Attempt owns it for
 	// the duration of one CreateSessionSummary call.
-	ctx       context.Context
-	startedAt time.Time
-	sess      *session.Session
-	filterKey string
-	before    summaryBoundaryMark
-	selection isummarycontext.EventSelection
-	modelCall isummarycontext.ModelCall
+	ctx        context.Context
+	startedAt  time.Time
+	sess       *session.Session
+	filterKey  string
+	before     summaryBoundaryMark
+	selection  isummarycontext.EventSelection
+	modelCall  isummarycontext.ModelCall
+	triggerObs isummarycontext.TriggerObservation
 
 	gate         summaryGate
 	skip         string
@@ -176,6 +182,7 @@ func BeginAttempt(
 	_, ctx = ensureSummaryReport(ctx)
 	ctx = isummarycontext.WithEventSelectionRecorder(ctx, &att.selection)
 	ctx = isummarycontext.WithModelCallRecorder(ctx, &att.modelCall)
+	ctx = isummarycontext.WithTriggerRecorder(ctx, &att.triggerObs)
 	att.ctx = ctx
 	return ctx, att
 }
@@ -274,37 +281,65 @@ type summaryGate struct {
 	thresholdRatio float64
 }
 
-// recordSummaryGate records the trigger decision. When the gate did not fire,
-// the shape of trigger separates an evaluated check that stayed below its
-// threshold from a gate that produced no check result at all, which means no
-// eligible content reached the checks.
-func recordSummaryGate(
-	ctx context.Context,
-	fired bool,
-	trigger summary.Trigger,
-) {
+// recordAttemptGate records this attempt's gate from the attempt-local
+// trigger observation. A leftover caller Report.Trigger is never read here.
+// An unpublished observation cannot be classified as no_content or
+// below_threshold.
+func recordAttemptGate(ctx context.Context, fired bool) {
 	att := summaryAttemptFromContext(ctx)
 	if att == nil {
 		return
 	}
 	att.triggered = fired
+	obs := isummarycontext.TriggerFromContext(ctx)
+	if obs == nil || !obs.Published {
+		if fired {
+			att.skip = ""
+			return
+		}
+		att.skip = outcomeUnobserved
+		return
+	}
 	att.gate = summaryGate{
-		name:           trigger.Name,
-		metric:         trigger.Metric,
-		value:          trigger.Value,
-		threshold:      trigger.Threshold,
-		contextWindow:  trigger.ContextWindow,
-		thresholdRatio: trigger.ThresholdRatio,
+		name:           obs.Name,
+		metric:         obs.Metric,
+		value:          obs.Value,
+		threshold:      obs.Threshold,
+		contextWindow:  obs.ContextWindow,
+		thresholdRatio: obs.ThresholdRatio,
 	}
 	if fired {
 		att.skip = ""
 		return
 	}
-	if trigger.Name == "" && trigger.Metric == "" && len(trigger.Checks) == 0 {
+	if obs.Name == "" && obs.Metric == "" && obs.CheckCount == 0 {
 		att.skip = outcomeNoContent
 		return
 	}
 	att.skip = outcomeBelowThreshold
+}
+
+// recordPublishedTrigger publishes an attempt-local trigger observation and
+// records the gate from that observation. It does not mutate a caller Report.
+func recordPublishedTrigger(
+	ctx context.Context,
+	fired bool,
+	trigger summary.Trigger,
+) {
+	isummarycontext.RecordTrigger(ctx, triggerObservation(trigger))
+	recordAttemptGate(ctx, fired)
+}
+
+func triggerObservation(trigger summary.Trigger) isummarycontext.TriggerObservation {
+	return isummarycontext.TriggerObservation{
+		Name:           trigger.Name,
+		Metric:         trigger.Metric,
+		Value:          trigger.Value,
+		Threshold:      trigger.Threshold,
+		ContextWindow:  trigger.ContextWindow,
+		CheckCount:     len(trigger.Checks),
+		ThresholdRatio: trigger.ThresholdRatio,
+	}
 }
 
 // recordSummaryCopied records that an existing summary was materialized for
@@ -383,8 +418,8 @@ func (a *Attempt) Report() {
 	case outcomeSuccess:
 		log.InfofContext(ctx, format, args...)
 	case outcomeCopied, outcomeNoDelta, outcomeBelowThreshold,
-		outcomeCascadeSuppressed, outcomeNoContent, outcomeStaleWrite,
-		outcomeUnknownWrite:
+		outcomeCascadeSuppressed, outcomeNoContent, outcomeUnobserved,
+		outcomeStaleWrite, outcomeUnknownWrite:
 		// Routine decisions that did no backend-confirmed write, including a
 		// set-if-newer skip when a newer summary is already stored.
 		log.DebugfContext(ctx, format, args...)

--- a/session/internal/summary/diagnostics.go
+++ b/session/internal/summary/diagnostics.go
@@ -579,17 +579,19 @@ const (
 	// target first and only then the dependent full-session target.
 	cascadeModeDependent = "dependent"
 
-	// cascadeActionCopied marks a materialized branch summary reused for the
-	// full-session target.
+	// cascadeActionCopied marks a materialized branch summary that was
+	// successfully copied to the full-session target.
 	cascadeActionCopied = "copied"
-	// cascadeActionDependent marks a full-session target that ran only after
-	// this pass materialized the branch source.
+	// cascadeActionDependent marks a full-session target that actually
+	// started only after this pass materialized the branch source.
 	cascadeActionDependent = "dependent"
 	// cascadeActionIndependent marks a full-session target updated without a
 	// materialized branch source.
 	cascadeActionIndependent = "independent"
-	// cascadeActionSkipped marks a cascade that updated no target, including
-	// a normal upstream stop when this pass did not materialize the branch.
+	// cascadeActionSkipped marks a cascade that started no full-session
+	// action, including a normal upstream stop when this pass did not
+	// materialize the branch, a failed copy, or a source-side error that
+	// blocked the full target.
 	cascadeActionSkipped = "skipped"
 
 	// cascadeInvariantOK marks a cascade whose full-session target is backed
@@ -611,6 +613,8 @@ type cascadeAttempt struct {
 	filterKey          string
 	targets            int
 	sourceMaterialized bool
+	copied             bool
+	dependentStarted   bool
 	fullUpdated        bool
 	failed             bool
 }
@@ -625,11 +629,11 @@ func beginCascade(mode, filterKey string, targets int) *cascadeAttempt {
 }
 
 func (c *cascadeAttempt) action() string {
-	if c.sourceMaterialized {
-		if c.mode == cascadeModeDependent {
-			return cascadeActionDependent
-		}
+	if c.copied {
 		return cascadeActionCopied
+	}
+	if c.dependentStarted {
+		return cascadeActionDependent
 	}
 	if c.fullUpdated {
 		return cascadeActionIndependent

--- a/session/internal/summary/diagnostics.go
+++ b/session/internal/summary/diagnostics.go
@@ -140,8 +140,8 @@ type Attempt struct {
 	sess      *session.Session
 	filterKey string
 	before    summaryBoundaryMark
-	report    *summary.Report
 	selection isummarycontext.EventSelection
+	modelCall isummarycontext.ModelCall
 
 	gate         summaryGate
 	skip         string
@@ -173,8 +173,9 @@ func BeginAttempt(
 		persist:   PersistNotAttempted,
 	}
 	ctx = contextWithSummaryAttempt(ctx, att)
-	att.report, ctx = ensureSummaryReport(ctx)
+	_, ctx = ensureSummaryReport(ctx)
 	ctx = isummarycontext.WithEventSelectionRecorder(ctx, &att.selection)
+	ctx = isummarycontext.WithModelCallRecorder(ctx, &att.modelCall)
 	att.ctx = ctx
 	return ctx, att
 }
@@ -372,7 +373,7 @@ func (a *Attempt) Report() {
 		a.selection.SkipRecentRequested,
 		a.selection.SkipRecentApplied,
 		a.selection.Selected,
-		summaryModelCallStatus(a.report),
+		a.modelCallStatus(),
 		a.updated,
 		after.advancedFrom(a.before),
 		a.persist,
@@ -504,11 +505,19 @@ func isSummaryContextError(err error) bool {
 			errors.Is(err, context.DeadlineExceeded))
 }
 
-func summaryModelCallStatus(report *summary.Report) string {
-	if report == nil {
+// modelCallStatus reports this attempt's observed summary model call from the
+// attempt-local recorder. A caller-attached Report can retain Call.Mode from a
+// prior sequential target; leftover Report state is never treated as this
+// attempt's observation.
+func (a *Attempt) modelCallStatus() string {
+	if a == nil {
 		return modelCallStatusUnobserved
 	}
-	switch report.Call.Mode {
+	return summaryModelCallStatus(a.modelCall.Mode)
+}
+
+func summaryModelCallStatus(mode string) string {
+	switch mode {
 	case callModeStandalone, callModeCacheSafeFork:
 		return modelCallStatusCalled
 	case callModeCustomResponse:

--- a/session/internal/summary/diagnostics_test.go
+++ b/session/internal/summary/diagnostics_test.go
@@ -180,8 +180,19 @@ func (s *diagSummarizer) ShouldSummarize(*session.Session) bool { return s.fired
 func (s *diagSummarizer) ShouldSummarizeWithContext(
 	ctx context.Context, _ *session.Session,
 ) bool {
-	if report, ok := summary.ReportFromContext(ctx); ok && s.trigger != nil {
-		report.Trigger = *s.trigger
+	if s.trigger != nil {
+		if report, ok := summary.ReportFromContext(ctx); ok {
+			report.Trigger = *s.trigger
+		}
+		isummarycontext.RecordTrigger(ctx, isummarycontext.TriggerObservation{
+			Name:           s.trigger.Name,
+			Metric:         s.trigger.Metric,
+			Value:          s.trigger.Value,
+			Threshold:      s.trigger.Threshold,
+			ContextWindow:  s.trigger.ContextWindow,
+			CheckCount:     len(s.trigger.Checks),
+			ThresholdRatio: s.trigger.ThresholdRatio,
+		})
 	}
 	return s.fired
 }
@@ -700,10 +711,11 @@ func TestAttemptReportsBelowThresholdWithGateDetails(t *testing.T) {
 	requireNoSensitiveText(t, logs.all())
 }
 
-func TestAttemptReportsNoContentWhenGateSawNothing(t *testing.T) {
+func TestAttemptReportsUnobservedWhenCustomGateDoesNotPublish(t *testing.T) {
 	logs := captureLogs(t)
 	sess := diagSession(diagEvent(-time.Minute))
-	// A gate that publishes no check result never saw eligible content.
+	// A custom ShouldSummarize that returns false without publishing a
+	// trigger is not proof of missing content.
 	summarizer := &diagSummarizer{fired: false}
 
 	require.NoError(t, summarizeAndPersist(
@@ -712,9 +724,9 @@ func TestAttemptReportsNoContentWhenGateSawNothing(t *testing.T) {
 
 	level, line := logs.only(t)
 	require.Equal(t, "debug", level,
-		"a session with nothing to summarize is not an operator problem")
+		"an unpublished custom gate is diagnostic uncertainty, not an incident")
 	requireFields(t, line, map[string]string{
-		"outcome":              outcomeNoContent,
+		"outcome":              outcomeUnobserved,
 		"triggered":            "false",
 		"trigger":              "none",
 		"summary_view_present": "false",
@@ -725,7 +737,7 @@ func TestAttemptReportsNoContentWhenGateSawNothing(t *testing.T) {
 func TestAttemptReportsUnsafeViewForUnboundView(t *testing.T) {
 	logs := captureLogs(t)
 	sess := diagSession(diagEvent(-time.Minute))
-	summarizer := &diagSummarizer{fired: false}
+	summarizer := &diagSummarizer{fired: false, trigger: &summary.Trigger{}}
 	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
 		SessionID:     secretSessionID,
 		Items:         []summaryview.Item{{}, {}},
@@ -754,7 +766,7 @@ func TestAttemptReportsUnsafeViewForUnboundView(t *testing.T) {
 func TestAttemptKeepsNoContentForBoundView(t *testing.T) {
 	logs := captureLogs(t)
 	sess := diagSession(diagEvent(-time.Minute))
-	summarizer := &diagSummarizer{fired: false}
+	summarizer := &diagSummarizer{fired: false, trigger: &summary.Trigger{}}
 	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
 		SessionID:     secretSessionID,
 		Items:         []summaryview.Item{{}},
@@ -1465,4 +1477,210 @@ func TestSummaryTargetKindIsBounded(t *testing.T) {
 	require.Equal(t, targetKindFull,
 		summaryTargetKind(session.SummaryFilterKeyAllContents))
 	require.Equal(t, targetKindBranch, summaryTargetKind("app/branch-42"))
+}
+
+func TestAttemptIgnoresLeftoverCallerTriggerWhenCustomDoesNotPublish(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	report := &summary.Report{Trigger: summary.Trigger{
+		Fired:     true,
+		Name:      "token_threshold",
+		Metric:    "tokens",
+		Value:     99,
+		Threshold: 10,
+	}}
+	ctx := summary.ContextWithReport(context.Background(), report)
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, &diagSummarizer{fired: false}, sess, "", false, nil,
+	))
+	require.Equal(t, "token_threshold", report.Trigger.Name,
+		"diagnostics must not clear a leftover caller Report to hide reuse")
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":        outcomeUnobserved,
+		"triggered":      "false",
+		"trigger":        "none",
+		"trigger_metric": "none",
+		"trigger_value":  "0",
+	})
+}
+
+func TestAttemptPublishesBuiltInTriggerDespiteLeftoverCallerReport(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	report := &summary.Report{Trigger: summary.Trigger{
+		Name:   "token_threshold",
+		Metric: "tokens",
+		Value:  99,
+	}}
+	ctx := summary.ContextWithReport(context.Background(), report)
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithEventThreshold(1),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+	require.Equal(t, "event_threshold", report.Trigger.Name)
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":        outcomeSuccess,
+		"triggered":      "true",
+		"trigger":        "event_threshold",
+		"trigger_metric": "events",
+	})
+}
+
+func TestBuiltInSummarizerObservesModelCallAfterHookReturnsBackground(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithPreSummaryHook(func(in *summary.PreSummaryHookContext) error {
+			in.Ctx = context.Background()
+			return nil
+		}),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeSuccess,
+		"model_call_status": modelCallStatusCalled,
+	})
+}
+
+// TestBuiltInSummarizerReportsNoContentWhenSkipRecentLeavesNothing is the
+// built-in counterpart of TestAttemptReportsUnobservedWhenCustomGateDoesNotPublish:
+// events exist so the attempt is not no_delta, ShouldSummarize publishes an
+// empty trigger, and the outcome is no_content rather than unobserved.
+func TestBuiltInSummarizerReportsNoContentWhenSkipRecentLeavesNothing(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithEventThreshold(1),
+		summary.WithSkipRecent(func(events []event.Event) int {
+			return len(events)
+		}),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("built-in no-content must not persist")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":          outcomeNoContent,
+		"triggered":        "false",
+		"trigger":          "none",
+		"selection_reason": isummarycontext.ReasonSkipRecentAll,
+		"selected_events":  "0",
+	})
+}
+
+func TestBuiltInSummarizerObservesModelCallAfterBeforeModelReturnsBackground(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		_ context.Context,
+		_ *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		return &model.BeforeModelResult{Context: context.Background()}, nil
+	})
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithModelCallbacks(callbacks),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeSuccess,
+		"model_call_status": modelCallStatusCalled,
+	})
+}
+
+func TestBuiltInSummarizerObservesCustomResponseAfterBeforeModelReturnsBackground(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		_ context.Context,
+		_ *model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		return &model.BeforeModelResult{
+			Context: context.Background(),
+			CustomResponse: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.Message{Content: "callback summary"},
+				}},
+			},
+		}, nil
+	})
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithModelCallbacks(callbacks),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeSuccess,
+		"model_call_status": modelCallStatusCustomResponse,
+	})
+}
+
+func TestAttemptSelectedEventsStayPreHookCountAfterHookRewrite(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithPreSummaryHook(func(in *summary.PreSummaryHookContext) error {
+			in.Text = "hook replaced the selected conversation"
+			in.Events = nil
+			return nil
+		}),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":          outcomeSuccess,
+		"selection_reason": isummarycontext.ReasonSelected,
+		"selected_events":  "2",
+	})
 }

--- a/session/internal/summary/diagnostics_test.go
+++ b/session/internal/summary/diagnostics_test.go
@@ -94,6 +94,37 @@ func requireSessionSummaryRecord(t *testing.T, line string) {
 		"schema_version=1 must follow the record name in %q", line)
 }
 
+func sessionSummaryRecordByTarget(
+	t *testing.T, logs *capturedLogs, targetKind string,
+) (level, line string) {
+	t.Helper()
+	debug, info, warn := logs.snapshot()
+	var found []struct {
+		level string
+		line  string
+	}
+	for _, group := range []struct {
+		level string
+		lines []string
+	}{{"warn", warn}, {"info", info}, {"debug", debug}} {
+		for _, candidate := range group.lines {
+			if !strings.HasPrefix(candidate, "Session summary result:") {
+				continue
+			}
+			if field(t, candidate, "target_kind") == targetKind {
+				found = append(found, struct {
+					level string
+					line  string
+				}{group.level, candidate})
+			}
+		}
+	}
+	require.Lenf(t, found, 1, "expected one %s session summary record in %q",
+		targetKind, logs.all())
+	requireSessionSummaryRecord(t, found[0].line)
+	return found[0].level, found[0].line
+}
+
 func captureLogs(t *testing.T) *capturedLogs {
 	t.Helper()
 	captured := &capturedLogs{}
@@ -163,6 +194,7 @@ func (s *diagSummarizer) Summarize(
 		if report, ok := summary.ReportFromContext(ctx); ok {
 			report.Call.Mode = s.callMode
 		}
+		isummarycontext.RecordModelCall(ctx, s.callMode)
 	}
 	return s.text, s.err
 }
@@ -1020,6 +1052,59 @@ func TestAttemptPreservesCallerReport(t *testing.T) {
 	))
 	require.Equal(t, "token_threshold", report.Trigger.Name)
 	require.Equal(t, "standalone", report.Call.Mode)
+}
+
+// TestAttemptKeepsCallerCallWhenLaterAttemptErrorsBeforePublish proves a
+// later attempt that fails before publishing a call must not mutate the
+// caller-attached Report leftover from an earlier target.
+func TestAttemptKeepsCallerCallWhenLaterAttemptErrorsBeforePublish(t *testing.T) {
+	logs := captureLogs(t)
+	report := &summary.Report{}
+	ctx := summary.ContextWithReport(context.Background(), report)
+
+	require.NoError(t, summarizeAndPersist(
+		ctx,
+		&diagSummarizer{
+			fired:    true,
+			callMode: callModeStandalone,
+			text:     secretSummaryText,
+		},
+		diagSession(diagEvent(-time.Minute)),
+		"",
+		false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+	require.Equal(t, callModeStandalone, report.Call.Mode)
+
+	err := summarizeAndPersist(
+		ctx,
+		&diagSummarizer{
+			fired: true,
+			err:   errors.New(secretErrorText),
+		},
+		diagSession(diagEvent(-time.Minute)),
+		"",
+		false,
+		nil,
+	)
+	require.Error(t, err)
+	require.Equal(t, callModeStandalone, report.Call.Mode,
+		"an error before publishing a call must leave the caller Report unchanged")
+
+	_, info, warn := logs.snapshot()
+	require.Len(t, info, 1)
+	require.Len(t, warn, 1)
+	requireSessionSummaryRecord(t, info[0])
+	requireSessionSummaryRecord(t, warn[0])
+	requireFields(t, info[0], map[string]string{
+		"outcome":           outcomeSuccess,
+		"model_call_status": modelCallStatusCalled,
+	})
+	requireFields(t, warn[0], map[string]string{
+		"outcome":           outcomeSummaryError,
+		"model_call_status": modelCallStatusUnobserved,
+	})
+	requireNoSensitiveText(t, logs.all())
 }
 
 func TestAttemptTolerantOfNilInputs(t *testing.T) {

--- a/session/internal/summary/diagnostics_test.go
+++ b/session/internal/summary/diagnostics_test.go
@@ -1684,3 +1684,73 @@ func TestAttemptSelectedEventsStayPreHookCountAfterHookRewrite(t *testing.T) {
 		"selected_events":  "2",
 	})
 }
+
+type sequentialDiagModel struct {
+	calls     int
+	responses []*model.Response
+}
+
+func (m *sequentialDiagModel) Info() model.Info {
+	return model.Info{Name: "sequential-diag"}
+}
+
+func (m *sequentialDiagModel) GenerateContent(
+	context.Context,
+	*model.Request,
+) (<-chan *model.Response, error) {
+	m.calls++
+	ch := make(chan *model.Response, 1)
+	if m.calls > len(m.responses) {
+		close(ch)
+		return ch, nil
+	}
+	ch <- m.responses[m.calls-1]
+	close(ch)
+	return ch, nil
+}
+
+func TestBuiltInSummarizerRetryCustomResponseReportsCalled(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute), diagEvent(-30*time.Second))
+	m := &sequentialDiagModel{responses: []*model.Response{{Done: true}}}
+	var beforeCalls int
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		context.Context,
+		*model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		beforeCalls++
+		if beforeCalls == 1 {
+			return nil, nil
+		}
+		return &model.BeforeModelResult{
+			CustomResponse: &model.Response{
+				Done: true,
+				Choices: []model.Choice{{
+					Message: model.Message{Content: "callback summary"},
+				}},
+			},
+		}, nil
+	})
+	report := &summary.Report{}
+	ctx := summary.ContextWithReport(context.Background(), report)
+	summarizer := summary.NewSummarizer(
+		m,
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithModelCallbacks(callbacks),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	require.Equal(t, 1, m.calls)
+	require.Equal(t, 2, beforeCalls)
+	require.Equal(t, callModeCustomResponse, report.Call.Mode)
+	_, line := sessionSummaryRecordByTarget(t, logs, "full")
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeSuccess,
+		"model_call_status": modelCallStatusCalled,
+	})
+}

--- a/session/internal/summary/diagnostics_test.go
+++ b/session/internal/summary/diagnostics_test.go
@@ -1,0 +1,1383 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package summary
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/internal/state/summaryview"
+	"trpc.group/trpc-go/trpc-agent-go/internal/summarydiag"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummarycontext "trpc.group/trpc-go/trpc-agent-go/session/internal/summarycontext"
+	"trpc.group/trpc-go/trpc-agent-go/session/summary"
+)
+
+// Sensitive values that diagnostics must never reproduce.
+const (
+	secretSummaryText = "SECRET-SUMMARY-CONTENT"
+	secretEventText   = "SECRET-EVENT-CONTENT"
+	secretErrorText   = "SECRET-DSN=user:password@tcp(db:3306)/prod"
+	secretSessionID   = "SECRET-SESSION-ID"
+	secretUserID      = "SECRET-USER-ID"
+)
+
+// capturedLogs records every diagnostic line emitted during a test, keyed by
+// level, so tests can assert both the content and the severity of a record.
+// Cascade targets report concurrently, so the recorder is synchronized.
+type capturedLogs struct {
+	mu    sync.Mutex
+	debug []string
+	info  []string
+	warn  []string
+}
+
+func (c *capturedLogs) add(level *[]string, line string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	*level = append(*level, line)
+}
+
+func (c *capturedLogs) snapshot() (debug, info, warn []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.debug...),
+		append([]string(nil), c.info...),
+		append([]string(nil), c.warn...)
+}
+
+func (c *capturedLogs) all() string {
+	debug, info, warn := c.snapshot()
+	return strings.Join(append(append(debug, info...), warn...), "\n")
+}
+
+// only returns the single record emitted at any level, failing when the number
+// of emitted records is not exactly one.
+func (c *capturedLogs) only(t *testing.T) (level string, line string) {
+	t.Helper()
+	debug, info, warn := c.snapshot()
+	switch {
+	case len(debug) == 1 && len(info) == 0 && len(warn) == 0:
+		level, line = "debug", debug[0]
+	case len(info) == 1 && len(debug) == 0 && len(warn) == 0:
+		level, line = "info", info[0]
+	case len(warn) == 1 && len(debug) == 0 && len(info) == 0:
+		level, line = "warn", warn[0]
+	default:
+		t.Fatalf("expected exactly one record, got %q %q %q", debug, info, warn)
+	}
+	requireSessionSummaryRecord(t, line)
+	return level, line
+}
+
+func requireSessionSummaryRecord(t *testing.T, line string) {
+	t.Helper()
+	require.True(t,
+		strings.HasPrefix(line, "Session summary result: schema_version=1,"),
+		"schema_version=1 must follow the record name in %q", line)
+}
+
+func captureLogs(t *testing.T) *capturedLogs {
+	t.Helper()
+	captured := &capturedLogs{}
+	oldDebug, oldInfo, oldWarn :=
+		log.DebugfContext, log.InfofContext, log.WarnfContext
+	log.DebugfContext = func(_ context.Context, format string, args ...any) {
+		captured.add(&captured.debug, fmt.Sprintf(format, args...))
+	}
+	log.InfofContext = func(_ context.Context, format string, args ...any) {
+		captured.add(&captured.info, fmt.Sprintf(format, args...))
+	}
+	log.WarnfContext = func(_ context.Context, format string, args ...any) {
+		captured.add(&captured.warn, fmt.Sprintf(format, args...))
+	}
+	t.Cleanup(func() {
+		log.DebugfContext = oldDebug
+		log.InfofContext = oldInfo
+		log.WarnfContext = oldWarn
+	})
+	return captured
+}
+
+// requireNoSensitiveText asserts the shared redaction contract for every
+// diagnostic record produced by this package.
+func requireNoSensitiveText(t *testing.T, logged string) {
+	t.Helper()
+	for _, secret := range []string{
+		secretSummaryText,
+		secretEventText,
+		secretErrorText,
+		secretSessionID,
+		secretUserID,
+	} {
+		require.NotContains(t, logged, secret)
+	}
+}
+
+// diagSummarizer is a scriptable summarizer that reproduces every summary
+// outcome an operator has to distinguish.
+type diagSummarizer struct {
+	fired          bool
+	trigger        *summary.Trigger
+	callMode       string
+	text           string
+	err            error
+	summarizeCalls int
+}
+
+func (s *diagSummarizer) ShouldSummarize(*session.Session) bool { return s.fired }
+
+// ShouldSummarizeWithContext mirrors the built-in summarizer: it publishes the
+// evaluated trigger on the report before returning the gate decision.
+func (s *diagSummarizer) ShouldSummarizeWithContext(
+	ctx context.Context, _ *session.Session,
+) bool {
+	if report, ok := summary.ReportFromContext(ctx); ok && s.trigger != nil {
+		report.Trigger = *s.trigger
+	}
+	return s.fired
+}
+
+func (s *diagSummarizer) Summarize(
+	ctx context.Context, _ *session.Session,
+) (string, error) {
+	s.summarizeCalls++
+	if s.callMode != "" {
+		if report, ok := summary.ReportFromContext(ctx); ok {
+			report.Call.Mode = s.callMode
+		}
+	}
+	return s.text, s.err
+}
+
+func (s *diagSummarizer) FilterEventsForSummary(
+	events []event.Event,
+) []event.Event {
+	return events
+}
+
+func (s *diagSummarizer) SetPrompt(string)         {}
+func (s *diagSummarizer) SetModel(model.Model)     {}
+func (s *diagSummarizer) Metadata() map[string]any { return nil }
+
+func diagSession(events ...event.Event) *session.Session {
+	return &session.Session{
+		ID:      secretSessionID,
+		AppName: "app",
+		UserID:  secretUserID,
+		Events:  events,
+	}
+}
+
+func diagEvent(offset time.Duration) event.Event {
+	return event.Event{
+		Author:    "user",
+		Timestamp: time.Now().Add(offset),
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{
+				Role:    model.RoleUser,
+				Content: secretEventText,
+			},
+		}}},
+	}
+}
+
+// diagAssistantEvent builds summarizable history that carries no user message,
+// so a retained prefix built only from these events has no anchor.
+func diagAssistantEvent(offset time.Duration) event.Event {
+	return event.Event{
+		Author:    "assistant",
+		Timestamp: time.Now().Add(offset),
+		Response: &model.Response{Choices: []model.Choice{{
+			Message: model.Message{
+				Role:    model.RoleAssistant,
+				Content: secretEventText,
+			},
+		}}},
+	}
+}
+
+// diagScopedEvent builds a user event that belongs to one branch scope.
+func diagScopedEvent(offset time.Duration, filterKey string) event.Event {
+	e := diagEvent(offset)
+	e.FilterKey = filterKey
+	e.Version = event.CurrentVersion
+	return e
+}
+
+// field extracts one "key=value" field from a diagnostic record.
+func field(t *testing.T, line, key string) string {
+	t.Helper()
+	marker := key + "="
+	start := strings.Index(line, marker)
+	require.GreaterOrEqualf(t, start, 0, "field %q missing from %q", key, line)
+	rest := line[start+len(marker):]
+	if end := strings.Index(rest, ", "); end >= 0 {
+		rest = rest[:end]
+	}
+	return rest
+}
+
+func requireFields(t *testing.T, line string, want map[string]string) {
+	t.Helper()
+	for key, value := range want {
+		require.Equalf(t, value, field(t, line, key),
+			"field %q in %q", key, line)
+	}
+}
+
+// summarizeAndPersist mirrors the shape every built-in backend uses: begin an
+// attempt, summarize with the attempt context, then report what the
+// persistence stage actually did.
+func summarizeAndPersist(
+	ctx context.Context,
+	m summary.SessionSummarizer,
+	sess *session.Session,
+	filterKey string,
+	force bool,
+	persist func(context.Context, *session.Summary) error,
+) error {
+	ctx, att := BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
+	updated, err := SummarizeSession(ctx, m, sess, filterKey, force)
+	att.Summarized(updated, err)
+	if err != nil || !updated {
+		return err
+	}
+	var sum *session.Summary
+	if sess != nil {
+		sess.SummariesMu.RLock()
+		sum = sess.Summaries[filterKey]
+		sess.SummariesMu.RUnlock()
+	}
+	if sum == nil {
+		att.Persisted(PersistNoSummary)
+		return nil
+	}
+	if persist == nil {
+		att.Persisted(PersistStored)
+		return nil
+	}
+	return att.RecordWrite(persist(ctx, sum))
+}
+
+func TestAttemptReportsSuccess(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired: true,
+		trigger: &summary.Trigger{
+			Fired:          true,
+			Name:           "token_threshold",
+			Metric:         "tokens",
+			Value:          41_959,
+			Threshold:      32_768,
+			ContextWindow:  40_960,
+			ThresholdRatio: 0.8,
+		},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+
+	var persisted int
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(_ context.Context, sum *session.Summary) error {
+			persisted++
+			require.Equal(t, secretSummaryText, sum.Summary)
+			return nil
+		},
+	))
+	require.Equal(t, 1, persisted)
+	require.Equal(t, 1, summarizer.summarizeCalls)
+
+	level, line := logs.only(t)
+	require.Equal(t, "info", level)
+	requireFields(t, line, map[string]string{
+		"schema_version":       "1",
+		"outcome":              outcomeSuccess,
+		"target_kind":          targetKindFull,
+		"dispatch":             dispatchRequest,
+		"filter_key":           `""`,
+		"filter_key_truncated": "false",
+		"triggered":            "true",
+		"trigger":              "token_threshold",
+		"trigger_metric":       "tokens",
+		"trigger_value":        "41959",
+		"trigger_threshold":    "32768",
+		"threshold_ratio":      "0.80",
+		"context_window":       "40960",
+		"model_call_status":    modelCallStatusCalled,
+		"updated":              "true",
+		"boundary_advanced":    "true",
+		"persist_result":       string(PersistStored),
+		"summary_view_present": "false",
+		"binding_reason":       summaryview.BindingReasonAbsent,
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsStaleWrite covers backends such as MySQL and ClickHouse
+// that deliberately skip a write when a newer summary is already persisted.
+// The record must not claim a backend-confirmed store.
+func TestAttemptReportsStaleWrite(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+
+	ctx, att := BeginAttempt(context.Background(), sess, "")
+	updated, err := SummarizeSession(ctx, summarizer, sess, "", false)
+	att.Summarized(updated, err)
+	require.NoError(t, err)
+	require.True(t, updated)
+	att.Persisted(PersistStale)
+	att.Report()
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level,
+		"a set-if-newer skip is a successful no-op, not a persistence failure")
+	requireFields(t, line, map[string]string{
+		"outcome":        outcomeStaleWrite,
+		"updated":        "true",
+		"persist_result": string(PersistStale),
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsUnknownWrite covers a backend write that completed
+// without error but whose reply could not be classified as stored or stale.
+func TestAttemptReportsUnknownWrite(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+
+	ctx, att := BeginAttempt(context.Background(), sess, "")
+	updated, err := SummarizeSession(ctx, summarizer, sess, "", false)
+	att.Summarized(updated, err)
+	require.NoError(t, err)
+	require.True(t, updated)
+	att.Persisted(PersistUnknown)
+	att.Report()
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level,
+		"an unclassified reply is diagnostic uncertainty, not a failure")
+	requireFields(t, line, map[string]string{
+		"outcome":        outcomeUnknownWrite,
+		"updated":        "true",
+		"persist_result": string(PersistUnknown),
+	})
+	require.NotContains(t, line, "outcome=success")
+	require.NotContains(t, line, "outcome=persistence_error")
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsNotStored covers a backend that neither stored nor
+// rejected a generated summary, for example a missing session row.
+func TestAttemptReportsNotStored(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+
+	ctx, att := BeginAttempt(context.Background(), sess, "")
+	updated, err := SummarizeSession(ctx, summarizer, sess, "", false)
+	att.Summarized(updated, err)
+	require.NoError(t, err)
+	att.Report()
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":        outcomeNotStored,
+		"updated":        "true",
+		"persist_result": string(PersistNotAttempted),
+	})
+}
+
+func TestAttemptReportsNoSummaryPersistResult(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+
+	ctx, att := BeginAttempt(context.Background(), sess, "")
+	_ = ctx
+	att.Summarized(true, nil)
+	att.Persisted(PersistNoSummary)
+	att.Report()
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":        outcomeNoUpdate,
+		"persist_result": string(PersistNoSummary),
+	})
+}
+
+func TestAttemptReportsPersistenceError(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+	persistErr := errors.New(secretErrorText)
+
+	err := summarizeAndPersist(
+		context.Background(), summarizer, sess, "branch", false,
+		func(context.Context, *session.Summary) error { return persistErr },
+	)
+	require.ErrorIs(t, err, persistErr,
+		"backend persistence errors must be returned unchanged")
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomePersistenceError,
+		"target_kind":       targetKindBranch,
+		"model_call_status": modelCallStatusCalled,
+		"updated":           "true",
+		"persist_result":    string(PersistError),
+	})
+	require.Contains(t, line, `filter_key="branch"`)
+	require.Contains(t, line, "filter_key_truncated=false")
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptReportsModelError(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		err:      errors.New(secretErrorText),
+	}
+
+	var persisted int
+	err := summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			persisted++
+			return nil
+		},
+	)
+	require.Error(t, err)
+	require.Zero(t, persisted, "a failed summary must not be persisted")
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeSummaryError,
+		"triggered":         "true",
+		"model_call_status": modelCallStatusCalled,
+		"updated":           "false",
+		"boundary_advanced": "false",
+		"persist_result":    string(PersistNotAttempted),
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsSummaryErrorBeforeModelCall pins the error classification
+// contract: a non-context failure in the summarization stage is a summary
+// error even when the summary model was never reached. model_call_status
+// separates a failed provider call from a pre-model build, a custom
+// response, or an unobserved custom summarizer.
+func TestAttemptReportsSummaryErrorBeforeModelCall(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:   true,
+		trigger: &summary.Trigger{Fired: true, Name: "event_count"},
+		err:     errors.New(secretErrorText),
+	}
+
+	err := summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false, nil,
+	)
+	require.Error(t, err)
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeSummaryError,
+		"triggered":         "true",
+		"model_call_status": modelCallStatusUnobserved,
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptKeepsSummaryErrorForUnboundView guards the same classification
+// when a model-visible view is present but unbound: the error still wins over
+// the view-derived outcome.
+func TestAttemptKeepsSummaryErrorForUnboundView(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:   true,
+		trigger: &summary.Trigger{Fired: true, Name: "event_count"},
+		err:     errors.New(secretErrorText),
+	}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     secretSessionID,
+		Items:         []summaryview.Item{{}},
+		BindingReason: summaryview.BindingReasonRequestMismatch,
+	})
+
+	require.Error(t, summarizeAndPersist(ctx, summarizer, sess, "", false, nil))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":            outcomeSummaryError,
+		"summary_view_bound": "false",
+	})
+}
+
+func TestAttemptReportsContextError(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		err: fmt.Errorf("%s: %w",
+			secretErrorText, context.DeadlineExceeded),
+	}
+
+	err := summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeContextError,
+		"model_call_status": modelCallStatusCalled,
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptReportsEmptyModelResult(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+		callMode: "standalone",
+		text:     "",
+	}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("persist must not run without a summary")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level,
+		"a triggered attempt that produced nothing is an operator problem")
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeNoUpdate,
+		"triggered":         "true",
+		"model_call_status": modelCallStatusCalled,
+		"updated":           "false",
+		"boundary_advanced": "false",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptReportsBelowThresholdWithGateDetails(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired: false,
+		trigger: &summary.Trigger{
+			Name:           "context_threshold",
+			Metric:         "tokens",
+			Value:          3_120,
+			Threshold:      32_768,
+			ContextWindow:  40_960,
+			ThresholdRatio: 0.8,
+			Checks: []summary.Check{{
+				Name:      "context_threshold",
+				Passed:    false,
+				Metric:    "tokens",
+				Value:     3_120,
+				Threshold: 32_768,
+			}},
+		},
+	}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false, nil,
+	))
+	require.Zero(t, summarizer.summarizeCalls)
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level,
+		"routine below-threshold decisions must stay quiet by default")
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeBelowThreshold,
+		"triggered":         "false",
+		"trigger":           "context_threshold",
+		"trigger_metric":    "tokens",
+		"trigger_value":     "3120",
+		"trigger_threshold": "32768",
+		"threshold_ratio":   "0.80",
+		"context_window":    "40960",
+		"model_call_status": modelCallStatusUnobserved,
+		"updated":           "false",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptReportsNoContentWhenGateSawNothing(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	// A gate that publishes no check result never saw eligible content.
+	summarizer := &diagSummarizer{fired: false}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false, nil,
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level,
+		"a session with nothing to summarize is not an operator problem")
+	requireFields(t, line, map[string]string{
+		"outcome":              outcomeNoContent,
+		"triggered":            "false",
+		"trigger":              "none",
+		"summary_view_present": "false",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptReportsUnsafeViewForUnboundView(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{fired: false}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     secretSessionID,
+		Items:         []summaryview.Item{{}, {}},
+		RequestTokens: 41_959,
+		Bound:         false,
+		BindingReason: summaryview.BindingReasonRequestMismatch,
+	})
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false, nil,
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":              outcomeUnsafeView,
+		"summary_view_present": "true",
+		"summary_view_bound":   "false",
+		"binding_reason":       summaryview.BindingReasonRequestMismatch,
+		"summary_view_items":   "2",
+		"request_tokens":       "41959",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptKeepsNoContentForBoundView(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{fired: false}
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     secretSessionID,
+		Items:         []summaryview.Item{{}},
+		Bound:         true,
+		BindingReason: summaryview.BindingReasonBound,
+	})
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false, nil,
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":            outcomeNoContent,
+		"summary_view_bound": "true",
+		"binding_reason":     summaryview.BindingReasonBound,
+	})
+}
+
+func TestAttemptReportsNoDelta(t *testing.T) {
+	logs := captureLogs(t)
+	evt := diagEvent(-time.Minute)
+	sess := diagSession(evt)
+	sess.Summaries = map[string]*session.Summary{
+		"": {
+			Summary:   secretSummaryText,
+			UpdatedAt: time.Now(),
+			Boundary: session.NewSummaryBoundary(
+				"", time.Now().Add(time.Minute),
+			),
+		},
+	}
+	summarizer := &diagSummarizer{fired: true, text: "new"}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false, nil,
+	))
+	require.Zero(t, summarizer.summarizeCalls)
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeNoDelta,
+		"model_call_status": modelCallStatusUnobserved,
+		"updated":           "false",
+		"boundary_advanced": "false",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsCopiedSummary covers the cascade materialization path: an
+// existing summary is persisted for a second target without a model call.
+func TestAttemptReportsCopiedSummary(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	sess.Summaries = map[string]*session.Summary{
+		// Zero UpdatedAt marks a copied summary awaiting persistence.
+		"": {Summary: secretSummaryText},
+	}
+	summarizer := &diagSummarizer{fired: true, text: "unused"}
+
+	var persisted int
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			persisted++
+			return nil
+		},
+	))
+	require.Equal(t, 1, persisted)
+	require.Zero(t, summarizer.summarizeCalls,
+		"materializing a copied summary must not call the summary model")
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":           outcomeCopied,
+		"model_call_status": modelCallStatusUnobserved,
+		"updated":           "true",
+		"persist_result":    string(PersistStored),
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+func TestAttemptReportsModelCallStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		callMode string
+		want     string
+	}{
+		{
+			name:     "built-in standalone call",
+			callMode: callModeStandalone,
+			want:     modelCallStatusCalled,
+		},
+		{
+			name:     "built-in cache-safe fork call",
+			callMode: callModeCacheSafeFork,
+			want:     modelCallStatusCalled,
+		},
+		{
+			name:     "before-model custom response",
+			callMode: callModeCustomResponse,
+			want:     modelCallStatusCustomResponse,
+		},
+		{
+			name:     "custom summarizer left report unobserved",
+			callMode: "",
+			want:     modelCallStatusUnobserved,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureLogs(t)
+			sess := diagSession(diagEvent(-time.Minute))
+			summarizer := &diagSummarizer{
+				fired:    true,
+				trigger:  &summary.Trigger{Fired: true, Name: "event_count"},
+				callMode: tt.callMode,
+				text:     secretSummaryText,
+			}
+
+			require.NoError(t, summarizeAndPersist(
+				context.Background(), summarizer, sess, "", false,
+				func(context.Context, *session.Summary) error { return nil },
+			))
+
+			_, line := logs.only(t)
+			requireFields(t, line, map[string]string{
+				"outcome":           outcomeSuccess,
+				"model_call_status": tt.want,
+			})
+			require.NotContains(t, line, "model_called=")
+			requireNoSensitiveText(t, logs.all())
+		})
+	}
+}
+
+// TestAttemptTruncatesLongFilterKey proves diagnostic display is length-limited
+// without changing the business filter key used for storage.
+func TestAttemptTruncatesLongFilterKey(t *testing.T) {
+	logs := captureLogs(t)
+	key := strings.Repeat("a", summarydiag.FilterKeyMaxRunes+8)
+	display, truncated := summarydiag.FormatFilterKey(key)
+	require.True(t, truncated)
+	sess := diagSession(diagEvent(-time.Minute))
+
+	_, att := BeginAttempt(context.Background(), sess, key)
+	att.Report()
+
+	_, line := logs.only(t)
+	require.Contains(t, line, fmt.Sprintf("filter_key=%q", display))
+	require.Contains(t, line, "filter_key_truncated=true")
+	require.NotContains(t, line, key)
+	require.Equal(t, key, att.filterKey,
+		"truncation must not change the attempt's business filter key")
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsUnknownSelectionForCustomSummarizer documents that a
+// summarizer that does not publish the built-in event selection reports a
+// stable custom reason with unknown counts instead of guessing.
+func TestAttemptReportsUnknownSelectionForCustomSummarizer(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "event_threshold"},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"input_source":          "custom",
+		"selection_reason":      "custom",
+		"eligible_events":       "-1",
+		"skip_recent_requested": "-1",
+		"skip_recent_applied":   "-1",
+		"selected_events":       "-1",
+	})
+}
+
+// TestAttemptReportsNoSelectionWhenSummarizerNeverRuns proves that a gate which
+// stops before the summary call is reported as an unobserved selection rather
+// than as a custom summarizer.
+func TestAttemptReportsNoSelectionWhenSummarizerNeverRuns(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		trigger: &summary.Trigger{
+			Name:   "event_threshold",
+			Metric: "events",
+			Checks: []summary.Check{{Name: "event_threshold"}},
+		},
+	}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":          "below_threshold",
+		"input_source":     "none",
+		"selection_reason": "none",
+		"selected_events":  "-1",
+	})
+}
+
+// TestNormalizedTriggerValuesAreBounded proves that arbitrary trigger strings,
+// which any caller can supply through the exported summary.Trigger fields,
+// never reach the log and never inflate the cardinality of these fields.
+func TestNormalizedTriggerValuesAreBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name, metric string
+		wantName     string
+		wantMetric   string
+	}{
+		{"", "", "none", "none"},
+		{"event_threshold", "events", "event_threshold", "events"},
+		{"token_threshold", "tokens", "token_threshold", "tokens"},
+		{"time_threshold", "duration", "time_threshold", "duration"},
+		{"context_threshold", "tokens", "context_threshold", "tokens"},
+		{"force", "custom", "force", "custom"},
+		{"manual", "custom", "manual", "custom"},
+		{"always", "custom", "always", "custom"},
+		{"custom", "custom", "custom", "custom"},
+		{"tenant-42/user-secret", "user@example.com", "custom", "custom"},
+		{"event_count", "Events", "custom", "custom"},
+	} {
+		require.Equal(t, tc.wantName, normalizedTriggerName(tc.name),
+			"trigger name %q", tc.name)
+		require.Equal(t, tc.wantMetric, normalizedTriggerMetric(tc.metric),
+			"trigger metric %q", tc.metric)
+	}
+}
+
+// TestAttemptNeverLogsCustomTriggerStrings proves the normalization is applied
+// on the real reporting path, not only in the helper.
+func TestAttemptNeverLogsCustomTriggerStrings(t *testing.T) {
+	const secretTrigger = "tenant-42-escalation"
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired: true,
+		trigger: &summary.Trigger{
+			Fired:  true,
+			Name:   secretTrigger,
+			Metric: secretTrigger,
+			Value:  7,
+		},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	require.NotContains(t, line, secretTrigger)
+	requireFields(t, line, map[string]string{
+		"trigger":        "custom",
+		"trigger_metric": "custom",
+		"trigger_value":  "7",
+	})
+}
+
+// TestAttemptPreservesCallerReport verifies the diagnostics reuse the caller's
+// report instead of replacing it, so summary hooks keep observing the trigger
+// and usage they observed before.
+func TestAttemptPreservesCallerReport(t *testing.T) {
+	captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := &diagSummarizer{
+		fired:    true,
+		trigger:  &summary.Trigger{Fired: true, Name: "token_threshold"},
+		callMode: "standalone",
+		text:     secretSummaryText,
+	}
+	report := &summary.Report{}
+	ctx := summary.ContextWithReport(context.Background(), report)
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+	require.Equal(t, "token_threshold", report.Trigger.Name)
+	require.Equal(t, "standalone", report.Call.Mode)
+}
+
+func TestAttemptTolerantOfNilInputs(t *testing.T) {
+	logs := captureLogs(t)
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), nil, nil, "", false, nil,
+	))
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{"outcome": outcomeNoUpdate})
+
+	var missing *Attempt
+	missing.Summarized(true, nil)
+	missing.Persisted(PersistStored)
+	require.NoError(t, missing.RecordWrite(nil))
+	missing.Report()
+}
+
+// TestAttemptReportsUnsafeViewWithRealSummarizer is the end-to-end proof for
+// the incident signature: the built-in summarizer refuses to summarize content
+// it cannot prove the model saw, and the record names the stage that broke the
+// binding instead of reporting a bare "nothing to summarize".
+func TestAttemptReportsUnsafeViewWithRealSummarizer(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+	)
+
+	// The request that the model answered could not be matched, so the view
+	// exists but carries no proof of visibility.
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID:     secretSessionID,
+		Items:         []summaryview.Item{{}, {}, {}},
+		RequestTokens: 8_192,
+		BindingReason: summaryview.BindingReasonTransformMismatch,
+	})
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("unbound history must never be persisted as a summary")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "warn", level)
+	requireFields(t, line, map[string]string{
+		"outcome":              outcomeUnsafeView,
+		"triggered":            "false",
+		"model_call_status":    modelCallStatusUnobserved,
+		"summary_view_present": "true",
+		"summary_view_bound":   "false",
+		"binding_reason":       summaryview.BindingReasonTransformMismatch,
+		"request_tokens":       "8192",
+		"input_source":         isummarycontext.SourceUnboundView,
+		"selection_reason":     isummarycontext.ReasonUnboundView,
+		"eligible_events":      "3",
+		"selected_events":      "0",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptFallsBackWithoutView guards the preserved fallback: a session
+// with no model-visible view still summarizes from stored events.
+func TestAttemptFallsBackWithoutView(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(
+		diagEvent(-2*time.Minute),
+		diagEvent(-time.Minute),
+	)
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+	)
+
+	var persisted int
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			persisted++
+			return nil
+		},
+	))
+	require.Equal(t, 1, persisted)
+
+	level, line := logs.only(t)
+	require.Equal(t, "info", level)
+	requireFields(t, line, map[string]string{
+		"outcome":               outcomeSuccess,
+		"triggered":             "true",
+		"model_call_status":     modelCallStatusCalled,
+		"summary_view_present":  "false",
+		"binding_reason":        summaryview.BindingReasonAbsent,
+		"input_source":          isummarycontext.SourceSessionEvents,
+		"selection_reason":      isummarycontext.ReasonSelected,
+		"eligible_events":       "2",
+		"skip_recent_requested": "0",
+		"skip_recent_applied":   "0",
+		"selected_events":       "2",
+	})
+}
+
+// TestAttemptReportsSkipRecentSelectingSome shows the counts an operator needs
+// to see that skip-recent narrowed the summarized history.
+func TestAttemptReportsSkipRecentSelectingSome(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(
+		diagEvent(-3*time.Minute),
+		diagEvent(-2*time.Minute),
+		diagEvent(-time.Minute),
+	)
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithSkipRecent(func([]event.Event) int { return 1 }),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error { return nil },
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":               outcomeSuccess,
+		"input_source":          isummarycontext.SourceSessionEvents,
+		"selection_reason":      isummarycontext.ReasonSelected,
+		"eligible_events":       "3",
+		"skip_recent_requested": "1",
+		"skip_recent_applied":   "1",
+		"selected_events":       "2",
+	})
+}
+
+// TestAttemptReportsSkipRecentSelectingZero covers the case where skip-recent
+// leaves nothing to summarize: the record must show that candidates existed
+// but none were selected.
+func TestAttemptReportsSkipRecentSelectingZero(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(
+		diagEvent(-2*time.Minute),
+		diagEvent(-time.Minute),
+	)
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithSkipRecent(func(events []event.Event) int {
+			return len(events)
+		}),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("nothing was selected, so nothing may be persisted")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":               outcomeNoContent,
+		"input_source":          isummarycontext.SourceSessionEvents,
+		"selection_reason":      isummarycontext.ReasonSkipRecentAll,
+		"eligible_events":       "2",
+		"skip_recent_requested": "2",
+		"skip_recent_applied":   "2",
+		"selected_events":       "0",
+	})
+}
+
+// TestAttemptReportsUnsafePrefix covers the skip-recent outcome that is easiest
+// to mistake for "nothing to summarize": events remained after skip-recent, but
+// the retained prefix had no user message and no previous-summary anchor, so it
+// was dropped as unsafe. skip_recent_applied stays at the clamped callback
+// count; the extra drop is named by selection_reason, not attributed to
+// SkipRecent.
+func TestAttemptReportsUnsafePrefix(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(
+		diagAssistantEvent(-3*time.Minute),
+		diagAssistantEvent(-2*time.Minute),
+		diagEvent(-time.Minute),
+	)
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+		summary.WithSkipRecent(func([]event.Event) int { return 1 }),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("an unsafe prefix must never be summarized")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":               outcomeNoContent,
+		"input_source":          isummarycontext.SourceSessionEvents,
+		"selection_reason":      isummarycontext.ReasonUnsafePrefix,
+		"eligible_events":       "3",
+		"skip_recent_requested": "1",
+		"skip_recent_applied":   "1",
+		"selected_events":       "0",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsSessionFilterEmpty covers history that survives skip-recent
+// and is then removed entirely by the summary's branch scoping, which an
+// operator cannot otherwise tell apart from an empty session. Events on an
+// ancestor branch reach the delta but fall outside the narrower summary scope.
+func TestAttemptReportsSessionFilterEmpty(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(
+		diagScopedEvent(-2*time.Minute, "app"),
+		diagScopedEvent(-time.Minute, "app"),
+	)
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+	)
+
+	require.NoError(t, summarizeAndPersist(
+		context.Background(), summarizer, sess, "app/wanted", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("out-of-scope history must never be summarized")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":               outcomeNoContent,
+		"input_source":          isummarycontext.SourceSessionEvents,
+		"selection_reason":      isummarycontext.ReasonSessionFilterEmpty,
+		"eligible_events":       "2",
+		"skip_recent_requested": "0",
+		"skip_recent_applied":   "0",
+		"selected_events":       "0",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsBoundaryUnmapped covers a bound view whose items have no
+// stored-event boundary. The summary is dropped rather than advance the
+// persistence boundary past content that cannot be located again.
+func TestAttemptReportsBoundaryUnmapped(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+	)
+
+	// Items are bound to the request but carry zero boundaries, so no stored
+	// event corresponds to the summarized content.
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID: secretSessionID,
+		Bound:     true,
+		Items: []summaryview.Item{
+			{EffectiveEvent: diagEvent(-2 * time.Minute)},
+			{EffectiveEvent: diagEvent(-time.Minute)},
+		},
+	})
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("unmapped content must never advance persistence")
+			return nil
+		},
+	))
+
+	level, line := logs.only(t)
+	require.Equal(t, "debug", level)
+	requireFields(t, line, map[string]string{
+		"outcome":               outcomeNoContent,
+		"input_source":          isummarycontext.SourceModelVisible,
+		"selection_reason":      isummarycontext.ReasonBoundaryUnmapped,
+		"eligible_events":       "2",
+		"skip_recent_requested": "0",
+		"skip_recent_applied":   "0",
+		"selected_events":       "0",
+	})
+	requireNoSensitiveText(t, logs.all())
+}
+
+// TestAttemptReportsNoCandidates covers a bound view that carries no history at
+// all, which is distinct from history that was filtered away.
+func TestAttemptReportsNoCandidates(t *testing.T) {
+	logs := captureLogs(t)
+	sess := diagSession(diagEvent(-time.Minute))
+	summarizer := summary.NewSummarizer(
+		&reportModel{},
+		summary.WithChecksAny(summary.CheckEventThreshold(1)),
+	)
+
+	ctx := summaryview.ContextWithView(context.Background(), &summaryview.View{
+		SessionID: secretSessionID,
+		Bound:     true,
+	})
+
+	require.NoError(t, summarizeAndPersist(
+		ctx, summarizer, sess, "", false,
+		func(context.Context, *session.Summary) error {
+			t.Fatal("an empty view has nothing to summarize")
+			return nil
+		},
+	))
+
+	_, line := logs.only(t)
+	requireFields(t, line, map[string]string{
+		"outcome":          outcomeNoContent,
+		"input_source":     isummarycontext.SourceModelVisible,
+		"selection_reason": isummarycontext.ReasonNoCandidates,
+		"eligible_events":  "0",
+		"selected_events":  "0",
+	})
+}
+
+// TestSelectionReasonsAreBounded pins the closed set of selection reasons that
+// operators alert on.
+func TestSelectionReasonsAreBounded(t *testing.T) {
+	require.ElementsMatch(t, []string{
+		"none",
+		"custom",
+		"selected",
+		"no_candidates",
+		"skip_recent_all",
+		"unsafe_prefix",
+		"session_filter_empty",
+		"unbound_view",
+		"boundary_unmapped",
+	}, []string{
+		isummarycontext.ReasonNone,
+		isummarycontext.ReasonCustom,
+		isummarycontext.ReasonSelected,
+		isummarycontext.ReasonNoCandidates,
+		isummarycontext.ReasonSkipRecentAll,
+		isummarycontext.ReasonUnsafePrefix,
+		isummarycontext.ReasonSessionFilterEmpty,
+		isummarycontext.ReasonUnboundView,
+		isummarycontext.ReasonBoundaryUnmapped,
+	})
+}
+
+func TestSummaryTargetKindIsBounded(t *testing.T) {
+	require.Equal(t, targetKindFull,
+		summaryTargetKind(session.SummaryFilterKeyAllContents))
+	require.Equal(t, targetKindBranch, summaryTargetKind("app/branch-42"))
+}

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -957,24 +957,29 @@ func cascadeSingleFilterSummary(
 	defer func() { cascade.report(ctx) }()
 	branchCtx, materialization :=
 		contextWithSummaryMaterializationObserver(ctx, filterKey)
-	if err := createSummaryFunc(branchCtx, sess, filterKey, force); err != nil {
+	err := createSummaryFunc(branchCtx, sess, filterKey, force)
+	// Sample before any error return so a persist failure after
+	// SummarizeSession updated=true still records this-pass materialization.
+	cascade.sourceMaterialized = materialization.didMaterialize()
+	if err != nil {
 		cascade.failed = true
 		return fmt.Errorf("create session summary for filterKey %q failed: %w",
 			filterKey, err)
 	}
 	// A nil error may mean the branch summary was intentionally not updated.
 	// Stop here so the full-session target cannot advance independently.
-	cascade.sourceMaterialized = materialization.didMaterialize()
 	if !cascade.sourceMaterialized {
 		return nil
 	}
 	// Copy to in-memory session for immediate access. A concurrent removal is
-	// treated as a missing source and also stops the cascade.
-	if !copySummaryToKey(
+	// treated as a missing source and also stops the cascade. Copy success is
+	// recorded separately so a failed copy cannot be classified as copied.
+	cascade.copied = copySummaryToKey(
 		sess,
 		filterKey,
 		session.SummaryFilterKeyAllContents,
-	) {
+	)
+	if !cascade.copied {
 		return nil
 	}
 	fullBefore := markSummaryBoundary(sess, session.SummaryFilterKeyAllContents)
@@ -985,7 +990,7 @@ func cascadeSingleFilterSummary(
 		filterKey,
 		session.SummaryFilterKeyAllContents,
 	)
-	err := createSummaryFunc(fullCtx, sess, session.SummaryFilterKeyAllContents, false)
+	err = createSummaryFunc(fullCtx, sess, session.SummaryFilterKeyAllContents, false)
 	cascade.fullUpdated = markSummaryBoundary(
 		sess,
 		session.SummaryFilterKeyAllContents,
@@ -1016,7 +1021,11 @@ func cascadeDependentSummary(
 	)
 	branchCtx, materialization :=
 		contextWithSummaryMaterializationObserver(branchCtx, filterKey)
-	if err := createSummaryFunc(branchCtx, sess, filterKey, force); err != nil {
+	err := createSummaryFunc(branchCtx, sess, filterKey, force)
+	// Sample before any error return so a persist failure after
+	// SummarizeSession updated=true still records this-pass materialization.
+	cascade.sourceMaterialized = materialization.didMaterialize()
+	if err != nil {
 		cascade.failed = true
 		return fmt.Errorf(
 			"create session summary for filterKey %q failed: %w",
@@ -1024,7 +1033,6 @@ func cascadeDependentSummary(
 			err,
 		)
 	}
-	cascade.sourceMaterialized = materialization.didMaterialize()
 	if !cascade.sourceMaterialized {
 		return nil
 	}
@@ -1035,7 +1043,8 @@ func cascadeDependentSummary(
 		filterKey,
 		session.SummaryFilterKeyAllContents,
 	)
-	err := createSummaryFunc(
+	cascade.dependentStarted = true
+	err = createSummaryFunc(
 		fullCtx,
 		sess,
 		session.SummaryFilterKeyAllContents,

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -395,7 +395,7 @@ func shouldGenerateSummary(
 		if report != nil {
 			report.Trigger = trigger
 		}
-		recordSummaryGate(ctx, true, trigger)
+		recordPublishedTrigger(ctx, true, trigger)
 		return true
 	}
 	checkTmp := tmp
@@ -410,11 +410,7 @@ func shouldGenerateSummary(
 	}
 	attachRequestGapObservation(ctx, base, checkTmp, previousBoundary)
 	fired := ShouldSummarize(ctx, m, checkTmp)
-	if report != nil {
-		recordSummaryGate(ctx, fired, report.Trigger)
-		return fired
-	}
-	recordSummaryGate(ctx, fired, summary.Trigger{})
+	recordAttemptGate(ctx, fired)
 	return fired
 }
 

--- a/session/internal/summary/summary.go
+++ b/session/internal/summary/summary.go
@@ -199,6 +199,7 @@ func SummarizeSession(
 	prev := readPreviousSummary(base, filterKey)
 	if prev.needsPersistOnly {
 		persistCopiedSummary(base, filterKey)
+		recordSummaryCopied(ctx)
 		return true, nil
 	}
 	if m == nil {
@@ -209,6 +210,14 @@ func SummarizeSession(
 	if !ok {
 		return false, nil
 	}
+	// Default the observation to unknown for the summary call itself. The
+	// built-in summarizer republishes precise counts while it selects its
+	// input, so anything left here means this call did not publish a built-in
+	// event selection.
+	isummarycontext.RecordEventSelection(ctx, isummarycontext.UnknownSelection(
+		isummarycontext.SourceCustom,
+		isummarycontext.ReasonCustom,
+	))
 	text, err := m.Summarize(input.ctx, input.session)
 	if err != nil {
 		return false, fmt.Errorf("summarize session %s failed: %w", base.ID, err)
@@ -327,6 +336,7 @@ func buildSummaryInput(
 ) (summaryInput, bool) {
 	delta, latestBoundary := computeDeltaAfterBoundary(base, prev.boundary, filterKey)
 	if !force && len(delta) == 0 {
+		recordSummarySkip(ctx, outcomeNoDelta)
 		return summaryInput{}, false
 	}
 	input := prependPrevSummary(prev.text, delta, time.Now())
@@ -373,29 +383,39 @@ func shouldGenerateSummary(
 ) bool {
 	if force {
 		if shouldSkipBranchForkFullSessionCascade(ctx, m, tmp, filterKey) {
+			recordSummarySkip(ctx, outcomeCascadeSuppressed)
 			return false
 		}
-		if report != nil {
-			report.Trigger = summary.Trigger{
-				Fired:     true,
-				Name:      "force",
-				Metric:    "custom",
-				FilterKey: reportFilterKey(ctx, filterKey),
-			}
+		trigger := summary.Trigger{
+			Fired:     true,
+			Name:      "force",
+			Metric:    "custom",
+			FilterKey: reportFilterKey(ctx, filterKey),
 		}
+		if report != nil {
+			report.Trigger = trigger
+		}
+		recordSummaryGate(ctx, true, trigger)
 		return true
 	}
 	checkTmp := tmp
 	if filterKey == session.SummaryFilterKeyAllContents {
 		if triggerFilterKey := summaryTriggerFilterKeyFromContext(ctx); triggerFilterKey != "" {
 			if shouldSkipBranchForkFullSessionCascade(ctx, m, tmp, filterKey) {
+				recordSummarySkip(ctx, outcomeCascadeSuppressed)
 				return false
 			}
 			checkTmp = buildFilterSession(base, triggerFilterKey, input)
 		}
 	}
 	attachRequestGapObservation(ctx, base, checkTmp, previousBoundary)
-	return ShouldSummarize(ctx, m, checkTmp)
+	fired := ShouldSummarize(ctx, m, checkTmp)
+	if report != nil {
+		recordSummaryGate(ctx, fired, report.Trigger)
+		return fired
+	}
+	recordSummaryGate(ctx, fired, summary.Trigger{})
+	return fired
 }
 
 func attachRequestGapObservation(
@@ -895,6 +915,7 @@ func CreateSessionSummaryWithCascade(
 	if len(targets) == 0 {
 		return nil
 	}
+	ctx = contextWithAsyncSummaryDispatch(ctx)
 	if len(targets) == 1 {
 		target := targets[0]
 		ctx = contextForSummaryTarget(ctx, filterKey, target)
@@ -905,48 +926,93 @@ func CreateSessionSummaryWithCascade(
 	// would be identical to the full-session summary. Generate only once via LLM,
 	// then copy to memory and persist both keys.
 	if isSingleFilterKey(sess, filterKey) {
-		branchCtx, materialization :=
-			contextWithSummaryMaterializationObserver(ctx, filterKey)
-		if err := createSummaryFunc(
-			branchCtx,
+		return cascadeSingleFilterSummary(
+			ctx,
 			sess,
 			filterKey,
 			force,
-		); err != nil {
-			return fmt.Errorf("create session summary for filterKey %q failed: %w",
-				filterKey, err)
-		}
-		// A nil error may mean the branch summary was intentionally not updated.
-		// Stop here so the full-session target cannot advance independently.
-		if !materialization.didMaterialize() {
-			return nil
-		}
-		// Copy to in-memory session for immediate access. A concurrent removal is
-		// treated as a missing source and also stops the cascade.
-		if !copySummaryToKey(
-			sess,
-			filterKey,
-			session.SummaryFilterKeyAllContents,
-		) {
-			return nil
-		}
-		// Persist the full-session key to storage. SummarizeSession detects
-		// existing in-memory summary with empty delta and returns updated=true.
-		fullCtx := contextForCascadeTarget(
-			ctx,
-			filterKey,
-			session.SummaryFilterKeyAllContents,
+			len(targets),
+			createSummaryFunc,
 		)
-		if err := createSummaryFunc(fullCtx, sess, session.SummaryFilterKeyAllContents, false); err != nil {
-			return fmt.Errorf("persist full-session summary failed: %w", err)
-		}
-		return nil
 	}
 
-	// Multiple filter keys require distinct summaries. Run the branch target
-	// first because the full-session target is a dependent cascade, not an
-	// independent request. This also prevents a full summary when the branch
-	// gate declines to materialize a result.
+	return cascadeDependentSummary(
+		ctx,
+		sess,
+		filterKey,
+		force,
+		len(targets),
+		createSummaryFunc,
+	)
+}
+
+// cascadeSingleFilterSummary generates one summary for a session whose events
+// all match filterKey and reuses it for the full-session target only when this
+// pass materialized the branch source.
+func cascadeSingleFilterSummary(
+	ctx context.Context,
+	sess *session.Session,
+	filterKey string,
+	force bool,
+	targets int,
+	createSummaryFunc func(context.Context, *session.Session, string, bool) error,
+) error {
+	cascade := beginCascade(cascadeModeSingleFilter, filterKey, targets)
+	defer func() { cascade.report(ctx) }()
+	branchCtx, materialization :=
+		contextWithSummaryMaterializationObserver(ctx, filterKey)
+	if err := createSummaryFunc(branchCtx, sess, filterKey, force); err != nil {
+		cascade.failed = true
+		return fmt.Errorf("create session summary for filterKey %q failed: %w",
+			filterKey, err)
+	}
+	// A nil error may mean the branch summary was intentionally not updated.
+	// Stop here so the full-session target cannot advance independently.
+	cascade.sourceMaterialized = materialization.didMaterialize()
+	if !cascade.sourceMaterialized {
+		return nil
+	}
+	// Copy to in-memory session for immediate access. A concurrent removal is
+	// treated as a missing source and also stops the cascade.
+	if !copySummaryToKey(
+		sess,
+		filterKey,
+		session.SummaryFilterKeyAllContents,
+	) {
+		return nil
+	}
+	fullBefore := markSummaryBoundary(sess, session.SummaryFilterKeyAllContents)
+	// Persist the full-session key to storage. SummarizeSession detects
+	// existing in-memory summary with empty delta and returns updated=true.
+	fullCtx := contextForCascadeTarget(
+		ctx,
+		filterKey,
+		session.SummaryFilterKeyAllContents,
+	)
+	err := createSummaryFunc(fullCtx, sess, session.SummaryFilterKeyAllContents, false)
+	cascade.fullUpdated = markSummaryBoundary(
+		sess,
+		session.SummaryFilterKeyAllContents,
+	).advancedFrom(fullBefore)
+	if err != nil {
+		cascade.failed = true
+		return fmt.Errorf("persist full-session summary failed: %w", err)
+	}
+	return nil
+}
+
+// cascadeDependentSummary runs the branch target first, then the full-session
+// target only when this pass materialized the branch source.
+func cascadeDependentSummary(
+	ctx context.Context,
+	sess *session.Session,
+	filterKey string,
+	force bool,
+	targets int,
+	createSummaryFunc func(context.Context, *session.Session, string, bool) error,
+) error {
+	cascade := beginCascade(cascadeModeDependent, filterKey, targets)
+	defer func() { cascade.report(ctx) }()
 	branchCtx := contextForCascadeTarget(
 		contextWithIsolatedReport(ctx),
 		filterKey,
@@ -955,27 +1021,36 @@ func CreateSessionSummaryWithCascade(
 	branchCtx, materialization :=
 		contextWithSummaryMaterializationObserver(branchCtx, filterKey)
 	if err := createSummaryFunc(branchCtx, sess, filterKey, force); err != nil {
+		cascade.failed = true
 		return fmt.Errorf(
 			"create session summary for filterKey %q failed: %w",
 			filterKey,
 			err,
 		)
 	}
-	if !materialization.didMaterialize() {
+	cascade.sourceMaterialized = materialization.didMaterialize()
+	if !cascade.sourceMaterialized {
 		return nil
 	}
 
+	fullBefore := markSummaryBoundary(sess, session.SummaryFilterKeyAllContents)
 	fullCtx := contextForCascadeTarget(
 		contextWithIsolatedReport(ctx),
 		filterKey,
 		session.SummaryFilterKeyAllContents,
 	)
-	if err := createSummaryFunc(
+	err := createSummaryFunc(
 		fullCtx,
 		sess,
 		session.SummaryFilterKeyAllContents,
 		force,
-	); err != nil {
+	)
+	cascade.fullUpdated = markSummaryBoundary(
+		sess,
+		session.SummaryFilterKeyAllContents,
+	).advancedFrom(fullBefore)
+	if err != nil {
+		cascade.failed = true
 		return fmt.Errorf(
 			"create session summary for filterKey %q failed: %w",
 			session.SummaryFilterKeyAllContents,

--- a/session/internal/summarycontext/call.go
+++ b/session/internal/summarycontext/call.go
@@ -1,0 +1,47 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import "context"
+
+// ModelCall is the built-in summarizer's published call mode for one summary
+// attempt. It carries the stable mode string only, never prompt, usage, or
+// content. An empty Mode means this attempt did not publish a call.
+type ModelCall struct {
+	Mode string
+}
+
+type modelCallKey struct{}
+
+// WithModelCallRecorder attaches a recorder that the built-in summarizer
+// fills when it records a summary model call or custom response. A nil
+// recorder makes RecordModelCall a no-op.
+func WithModelCallRecorder(ctx context.Context, call *ModelCall) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if call == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, modelCallKey{}, call)
+}
+
+// RecordModelCall publishes the built-in summary call mode for the current
+// attempt, replacing any mode recorded earlier in the same attempt. It is a
+// no-op when no recorder is attached to ctx.
+func RecordModelCall(ctx context.Context, mode string) {
+	if ctx == nil {
+		return
+	}
+	recorder, ok := ctx.Value(modelCallKey{}).(*ModelCall)
+	if !ok || recorder == nil {
+		return
+	}
+	recorder.Mode = mode
+}

--- a/session/internal/summarycontext/call.go
+++ b/session/internal/summarycontext/call.go
@@ -33,8 +33,9 @@ func WithModelCallRecorder(ctx context.Context, call *ModelCall) context.Context
 }
 
 // RecordModelCall publishes the built-in summary call mode for the current
-// attempt, replacing any mode recorded earlier in the same attempt. It is a
-// no-op when no recorder is attached to ctx.
+// attempt. A provider-called mode (standalone or cache_safe_fork) is kept
+// once observed, so a later custom_response cannot hide that the provider
+// was reached. It is a no-op when no recorder is attached to ctx.
 func RecordModelCall(ctx context.Context, mode string) {
 	if ctx == nil {
 		return
@@ -43,7 +44,14 @@ func RecordModelCall(ctx context.Context, mode string) {
 	if recorder == nil {
 		return
 	}
+	if isProviderCalledMode(recorder.Mode) && !isProviderCalledMode(mode) {
+		return
+	}
 	recorder.Mode = mode
+}
+
+func isProviderCalledMode(mode string) bool {
+	return mode == "standalone" || mode == "cache_safe_fork"
 }
 
 // ModelCallFromContext returns the attempt-local model-call recorder, or nil
@@ -53,7 +61,7 @@ func ModelCallFromContext(ctx context.Context) *ModelCall {
 		return nil
 	}
 	recorder, ok := ctx.Value(modelCallKey{}).(*ModelCall)
-	if !ok {
+	if !ok || recorder == nil {
 		return nil
 	}
 	return recorder

--- a/session/internal/summarycontext/call.go
+++ b/session/internal/summarycontext/call.go
@@ -39,9 +39,22 @@ func RecordModelCall(ctx context.Context, mode string) {
 	if ctx == nil {
 		return
 	}
-	recorder, ok := ctx.Value(modelCallKey{}).(*ModelCall)
-	if !ok || recorder == nil {
+	recorder := ModelCallFromContext(ctx)
+	if recorder == nil {
 		return
 	}
 	recorder.Mode = mode
+}
+
+// ModelCallFromContext returns the attempt-local model-call recorder, or nil
+// when none is attached.
+func ModelCallFromContext(ctx context.Context) *ModelCall {
+	if ctx == nil {
+		return nil
+	}
+	recorder, ok := ctx.Value(modelCallKey{}).(*ModelCall)
+	if !ok {
+		return nil
+	}
+	return recorder
 }

--- a/session/internal/summarycontext/call_test.go
+++ b/session/internal/summarycontext/call_test.go
@@ -27,6 +27,17 @@ func TestRecordModelCall(t *testing.T) {
 	RecordModelCall(ctx, "cache_safe_fork")
 	require.Equal(t, "cache_safe_fork", call.Mode)
 
+	RecordModelCall(ctx, "custom_response")
+	require.Equal(t, "cache_safe_fork", call.Mode,
+		"a later custom_response must not hide a provider call")
+
+	var customFirst ModelCall
+	customCtx := WithModelCallRecorder(context.Background(), &customFirst)
+	RecordModelCall(customCtx, "custom_response")
+	RecordModelCall(customCtx, "standalone")
+	require.Equal(t, "standalone", customFirst.Mode,
+		"a later provider call upgrades custom_response to called")
+
 	RecordModelCall(WithModelCallRecorder(context.Background(), nil), "custom_response")
 	require.Equal(t, "cache_safe_fork", call.Mode)
 }

--- a/session/internal/summarycontext/call_test.go
+++ b/session/internal/summarycontext/call_test.go
@@ -1,0 +1,32 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordModelCall(t *testing.T) {
+	RecordModelCall(nil, "standalone")
+	RecordModelCall(context.Background(), "standalone")
+
+	var call ModelCall
+	ctx := WithModelCallRecorder(nil, &call)
+	RecordModelCall(ctx, "standalone")
+	require.Equal(t, "standalone", call.Mode)
+
+	RecordModelCall(ctx, "cache_safe_fork")
+	require.Equal(t, "cache_safe_fork", call.Mode)
+
+	RecordModelCall(WithModelCallRecorder(context.Background(), nil), "custom_response")
+	require.Equal(t, "cache_safe_fork", call.Mode)
+}

--- a/session/internal/summarycontext/inherit.go
+++ b/session/internal/summarycontext/inherit.go
@@ -1,0 +1,55 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import "context"
+
+// InheritModelCallRecorder returns next with the current attempt's model-call
+// recorder. A recorder already attached to next is replaced so a hook that
+// returns a cached previous context cannot publish this attempt onto that
+// earlier recorder. When current has no recorder, any recorder on next is
+// masked with a typed-nil value so later RecordModelCall is a no-op.
+func InheritModelCallRecorder(next, current context.Context) context.Context {
+	return inheritPointerValue(next, current, modelCallKey{}, ModelCallFromContext)
+}
+
+// InheritTriggerRecorder returns next with the current attempt's trigger
+// recorder, replacing or masking a recorder already attached to next under
+// the same rules as InheritModelCallRecorder.
+func InheritTriggerRecorder(next, current context.Context) context.Context {
+	return inheritPointerValue(next, current, triggerKey{}, TriggerFromContext)
+}
+
+// InheritEventSelectionRecorder returns next with the current attempt's
+// event-selection recorder, replacing or masking a recorder already attached
+// to next under the same rules as InheritModelCallRecorder.
+func InheritEventSelectionRecorder(next, current context.Context) context.Context {
+	return inheritPointerValue(
+		next,
+		current,
+		eventSelectionKey{},
+		EventSelectionFromContext,
+	)
+}
+
+func inheritPointerValue[T any](
+	next, current context.Context,
+	key any,
+	lookup func(context.Context) *T,
+) context.Context {
+	if next == nil {
+		next = context.Background()
+	}
+	recorder := lookup(current)
+	if recorder == lookup(next) {
+		return next
+	}
+	// recorder remains a typed pointer when nil, masking an older value.
+	return context.WithValue(next, key, recorder)
+}

--- a/session/internal/summarycontext/inherit_test.go
+++ b/session/internal/summarycontext/inherit_test.go
@@ -1,0 +1,110 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInheritRecordersPreferCurrentAndMaskStaleNext(t *testing.T) {
+	var nextCall, currentCall ModelCall
+	var nextTrigger, currentTrigger TriggerObservation
+	var nextSelection, currentSelection EventSelection
+	next := WithModelCallRecorder(context.Background(), &nextCall)
+	next = WithTriggerRecorder(next, &nextTrigger)
+	next = WithEventSelectionRecorder(next, &nextSelection)
+	current := WithModelCallRecorder(context.Background(), &currentCall)
+	current = WithTriggerRecorder(current, &currentTrigger)
+	current = WithEventSelectionRecorder(current, &currentSelection)
+
+	got := InheritModelCallRecorder(next, current)
+	got = InheritTriggerRecorder(got, current)
+	got = InheritEventSelectionRecorder(got, current)
+	require.Same(t, &currentCall, ModelCallFromContext(got))
+	require.Same(t, &currentTrigger, TriggerFromContext(got))
+	require.Same(t, &currentSelection, EventSelectionFromContext(got))
+
+	RecordModelCall(got, "standalone")
+	RecordTrigger(got, TriggerObservation{Name: "token_threshold"})
+	RecordEventSelection(got, EventSelection{Reason: ReasonSelected, Selected: 2})
+	require.Equal(t, "standalone", currentCall.Mode)
+	require.Equal(t, "token_threshold", currentTrigger.Name)
+	require.Equal(t, 2, currentSelection.Selected)
+	require.Empty(t, nextCall.Mode)
+	require.Empty(t, nextTrigger.Name)
+	require.Zero(t, nextSelection.Selected)
+}
+
+func TestInheritRecordersMaskNextWhenCurrentHasNone(t *testing.T) {
+	var nextCall ModelCall
+	var nextTrigger TriggerObservation
+	var nextSelection EventSelection
+	next := WithModelCallRecorder(context.Background(), &nextCall)
+	next = WithTriggerRecorder(next, &nextTrigger)
+	next = WithEventSelectionRecorder(next, &nextSelection)
+
+	got := InheritModelCallRecorder(next, context.Background())
+	got = InheritTriggerRecorder(got, context.Background())
+	got = InheritEventSelectionRecorder(got, context.Background())
+	require.Nil(t, ModelCallFromContext(got))
+	require.Nil(t, TriggerFromContext(got))
+	require.Nil(t, EventSelectionFromContext(got))
+
+	RecordModelCall(got, "standalone")
+	RecordTrigger(got, TriggerObservation{Name: "force"})
+	RecordEventSelection(got, EventSelection{Reason: ReasonSelected, Selected: 3})
+	require.Empty(t, nextCall.Mode)
+	require.Empty(t, nextTrigger.Name)
+	require.Zero(t, nextSelection.Selected)
+}
+
+func TestInheritRecordersReuseMatchingContext(t *testing.T) {
+	var call ModelCall
+	var trigger TriggerObservation
+	var selection EventSelection
+	current := WithModelCallRecorder(context.Background(), &call)
+	current = WithTriggerRecorder(current, &trigger)
+	current = WithEventSelectionRecorder(current, &selection)
+	for _, parent := range []context.Context{current, context.Background()} {
+		next, cancel := context.WithCancel(parent)
+		require.Same(t, next, InheritModelCallRecorder(next, parent))
+		require.Same(t, next, InheritTriggerRecorder(next, parent))
+		require.Same(t, next, InheritEventSelectionRecorder(next, parent))
+		cancel()
+	}
+}
+
+func TestInheritModelCallRecorderIsolatesConcurrentWrites(t *testing.T) {
+	var nextCall, currentCall ModelCall
+	next := WithModelCallRecorder(context.Background(), &nextCall)
+	current := WithModelCallRecorder(context.Background(), &currentCall)
+	inherited := InheritModelCallRecorder(next, current)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 64; i++ {
+			RecordModelCall(inherited, "standalone")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 64; i++ {
+			RecordModelCall(next, "custom_response")
+		}
+	}()
+	wg.Wait()
+	require.Equal(t, "standalone", currentCall.Mode)
+	require.Equal(t, "custom_response", nextCall.Mode)
+}

--- a/session/internal/summarycontext/selection.go
+++ b/session/internal/summarycontext/selection.go
@@ -147,7 +147,7 @@ func EventSelectionFromContext(ctx context.Context) *EventSelection {
 		return nil
 	}
 	recorder, ok := ctx.Value(eventSelectionKey{}).(*EventSelection)
-	if !ok {
+	if !ok || recorder == nil {
 		return nil
 	}
 	return recorder

--- a/session/internal/summarycontext/selection.go
+++ b/session/internal/summarycontext/selection.go
@@ -88,8 +88,9 @@ type EventSelection struct {
 	// retained prefix, session scoping, or an unmapped boundary are not
 	// counted here.
 	SkipRecentApplied int
-	// Selected is the number of events that reached the summary model after
-	// skip-recent filtering, session scoping, and safe-prefix mapping.
+	// Selected is the number of events chosen before a PreSummaryHook or
+	// before-model callback may rewrite the prompt. It is not a count of the
+	// payload that later reached the summary model.
 	Selected int
 }
 
@@ -137,4 +138,17 @@ func RecordEventSelection(ctx context.Context, selection EventSelection) {
 		return
 	}
 	*recorder = selection
+}
+
+// EventSelectionFromContext returns the attempt-local event-selection
+// recorder, or nil when none is attached.
+func EventSelectionFromContext(ctx context.Context) *EventSelection {
+	if ctx == nil {
+		return nil
+	}
+	recorder, ok := ctx.Value(eventSelectionKey{}).(*EventSelection)
+	if !ok {
+		return nil
+	}
+	return recorder
 }

--- a/session/internal/summarycontext/selection.go
+++ b/session/internal/summarycontext/selection.go
@@ -1,0 +1,140 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import "context"
+
+// Summary input sources describe where the summarizer took its candidate
+// events from. They are stable, low-cardinality diagnostic values.
+const (
+	// SourceModelVisible marks events taken from a bound model-visible view.
+	SourceModelVisible = "model_visible"
+	// SourceUnboundView marks a model-visible view that exists but is not
+	// bound to the request the model answered, so nothing may be summarized.
+	SourceUnboundView = "unbound_view"
+	// SourceSessionEvents marks the fallback that summarizes stored session
+	// events because no model-visible view was available.
+	SourceSessionEvents = "session_events"
+	// SourceCustom marks a summarizer that does not publish the built-in
+	// event selection, so counts for this call are unknown.
+	SourceCustom = "custom"
+)
+
+// Selection reasons form a closed set that explains why the summary model saw
+// the number of events it saw. Exactly one applies to a summary call.
+const (
+	// ReasonNone marks a call for which no selection was observed, because
+	// the attempt never reached a summarizer.
+	ReasonNone = "none"
+	// ReasonCustom marks a summarizer that does not publish the built-in
+	// event selection. Counts are unknown for this call.
+	ReasonCustom = "custom"
+	// ReasonSelected marks a selection that reached the summary model.
+	ReasonSelected = "selected"
+	// ReasonNoCandidates marks a selection whose stage had no candidate event
+	// to consider in the first place.
+	ReasonNoCandidates = "no_candidates"
+	// ReasonSkipRecentAll marks a skip-recent callback that asked to skip at
+	// least as many events as were available, leaving nothing to summarize.
+	ReasonSkipRecentAll = "skip_recent_all"
+	// ReasonUnsafePrefix marks a retained prefix that was dropped because it
+	// contained neither a user message nor a prepended previous summary, so
+	// it had no anchor to summarize against.
+	ReasonUnsafePrefix = "unsafe_prefix"
+	// ReasonSessionFilterEmpty marks candidates that survived skip-recent but
+	// were all removed by the session's branch scoping.
+	ReasonSessionFilterEmpty = "session_filter_empty"
+	// ReasonUnboundView marks a model-visible view that exists but is not
+	// bound to the request the model answered, so nothing may be summarized.
+	ReasonUnboundView = "unbound_view"
+	// ReasonBoundaryUnmapped marks selected items that have no structural
+	// mapping to a stored event, so the selection was dropped rather than
+	// advance the persistence boundary past unmapped content.
+	ReasonBoundaryUnmapped = "boundary_unmapped"
+)
+
+// UnknownEventCount marks a count that the configured summarizer did not
+// publish, for example a custom summarizer that does not use the built-in
+// event selection.
+const UnknownEventCount = -1
+
+// EventSelection reports how many events reached the summary model for one
+// summary call and why. It carries counts and stable reasons only, never event
+// content.
+type EventSelection struct {
+	// Source names where the candidate events came from.
+	Source string
+	// Reason is the closed-set explanation for Selected. It distinguishes a
+	// normal selection from each way a selection can end up empty.
+	Reason string
+	// Eligible is the number of candidate events at the stage that feeds the
+	// skip-recent callback, counted before skip-recent runs. For a bound
+	// model-visible view this includes any prepended previous summary; for an
+	// unbound view it is the number of view items that were not considered.
+	Eligible int
+	// SkipRecentRequested is the raw count returned by the configured
+	// WithSkipRecent callback for the slice it received at this stage. It is
+	// zero when no callback is configured, and is reported unchanged so a
+	// callback returning a nonsensical count stays visible.
+	SkipRecentRequested int
+	// SkipRecentApplied is how many events skip-recent itself removed:
+	// clamp(SkipRecentRequested, 0, Eligible). Later stages such as an unsafe
+	// retained prefix, session scoping, or an unmapped boundary are not
+	// counted here.
+	SkipRecentApplied int
+	// Selected is the number of events that reached the summary model after
+	// skip-recent filtering, session scoping, and safe-prefix mapping.
+	Selected int
+}
+
+// UnknownSelection returns the selection reported for a summary call whose
+// counts were never published.
+func UnknownSelection(source, reason string) EventSelection {
+	return EventSelection{
+		Source:              source,
+		Reason:              reason,
+		Eligible:            UnknownEventCount,
+		SkipRecentRequested: UnknownEventCount,
+		SkipRecentApplied:   UnknownEventCount,
+		Selected:            UnknownEventCount,
+	}
+}
+
+type eventSelectionKey struct{}
+
+// WithEventSelectionRecorder attaches a recorder that the summarizer fills in
+// while selecting summary input. The returned selection is written by
+// RecordEventSelection during the summary call and must not be read before it
+// returns. A nil recorder makes RecordEventSelection a no-op.
+func WithEventSelectionRecorder(
+	ctx context.Context,
+	selection *EventSelection,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if selection == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, eventSelectionKey{}, selection)
+}
+
+// RecordEventSelection publishes the summary input selection for the current
+// summary call, replacing any selection recorded earlier in the same call. It
+// is a no-op when no recorder is attached to ctx.
+func RecordEventSelection(ctx context.Context, selection EventSelection) {
+	if ctx == nil {
+		return
+	}
+	recorder, ok := ctx.Value(eventSelectionKey{}).(*EventSelection)
+	if !ok || recorder == nil {
+		return
+	}
+	*recorder = selection
+}

--- a/session/internal/summarycontext/trigger.go
+++ b/session/internal/summarycontext/trigger.go
@@ -62,7 +62,7 @@ func TriggerFromContext(ctx context.Context) *TriggerObservation {
 		return nil
 	}
 	recorder, ok := ctx.Value(triggerKey{}).(*TriggerObservation)
-	if !ok {
+	if !ok || recorder == nil {
 		return nil
 	}
 	return recorder

--- a/session/internal/summarycontext/trigger.go
+++ b/session/internal/summarycontext/trigger.go
@@ -1,0 +1,69 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import "context"
+
+// TriggerObservation is the built-in summarizer's published gate decision for
+// one summary attempt. Published distinguishes an empty observation that means
+// "no eligible content" from a custom summarizer that never published a
+// trigger. Leftover caller Report.Trigger values are never stored here.
+type TriggerObservation struct {
+	Published      bool
+	Name           string
+	Metric         string
+	Value          int
+	Threshold      int
+	ContextWindow  int
+	CheckCount     int
+	ThresholdRatio float64
+}
+
+type triggerKey struct{}
+
+// WithTriggerRecorder attaches a recorder that the built-in summarizer fills
+// when it publishes a trigger decision. A nil recorder makes RecordTrigger a
+// no-op.
+func WithTriggerRecorder(
+	ctx context.Context,
+	obs *TriggerObservation,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if obs == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, triggerKey{}, obs)
+}
+
+// RecordTrigger publishes the trigger observation for the current attempt,
+// replacing any observation recorded earlier in the same attempt. It is a
+// no-op when no recorder is attached to ctx.
+func RecordTrigger(ctx context.Context, obs TriggerObservation) {
+	recorder := TriggerFromContext(ctx)
+	if recorder == nil {
+		return
+	}
+	obs.Published = true
+	*recorder = obs
+}
+
+// TriggerFromContext returns the attempt-local trigger recorder, or nil when
+// none is attached.
+func TriggerFromContext(ctx context.Context) *TriggerObservation {
+	if ctx == nil {
+		return nil
+	}
+	recorder, ok := ctx.Value(triggerKey{}).(*TriggerObservation)
+	if !ok {
+		return nil
+	}
+	return recorder
+}

--- a/session/internal/summarycontext/trigger_test.go
+++ b/session/internal/summarycontext/trigger_test.go
@@ -1,0 +1,31 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package summarycontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordTrigger(t *testing.T) {
+	RecordTrigger(nil, TriggerObservation{Name: "token_threshold"})
+	RecordTrigger(context.Background(), TriggerObservation{Name: "token_threshold"})
+
+	var obs TriggerObservation
+	ctx := WithTriggerRecorder(nil, &obs)
+	RecordTrigger(ctx, TriggerObservation{Name: "event_threshold", CheckCount: 1})
+	require.True(t, obs.Published)
+	require.Equal(t, "event_threshold", obs.Name)
+	require.Equal(t, 1, obs.CheckCount)
+
+	RecordTrigger(WithTriggerRecorder(context.Background(), nil), TriggerObservation{Name: "force"})
+	require.Equal(t, "event_threshold", obs.Name)
+}

--- a/session/mongodb/summary.go
+++ b/session/mongodb/summary.go
@@ -115,14 +115,15 @@ func (s *Service) CreateSessionSummary(
 	return nil
 }
 
-// mongoPersistResult maps an upsert result to a persistence diagnostic. A
-// conditional upsert that matched nothing left the persisted summary in place.
+// mongoPersistResult maps an upsert result to a persistence diagnostic.
+// Acknowledged match or insert is stored. A nil or zero-count result cannot
+// prove stored or stale. Duplicate-key races are classified by the caller.
 func mongoPersistResult(result *mongo.UpdateResult) isummary.PersistResult {
 	if result == nil {
-		return isummary.PersistStored
+		return isummary.PersistUnknown
 	}
 	if result.MatchedCount == 0 && result.UpsertedCount == 0 {
-		return isummary.PersistStale
+		return isummary.PersistUnknown
 	}
 	return isummary.PersistStored
 }

--- a/session/mongodb/summary.go
+++ b/session/mongodb/summary.go
@@ -53,7 +53,11 @@ func (s *Service) CreateSessionSummary(
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(ctx, s.opts.summarizer, sess, filterKey, force)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -62,12 +66,13 @@ func (s *Service) CreateSessionSummary(
 	sum := sess.Summaries[filterKey]
 	sess.SummariesMu.RUnlock()
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
 
 	summaryBytes, err := json.Marshal(sum)
 	if err != nil {
-		return fmt.Errorf("marshal summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("marshal summary failed: %w", err))
 	}
 
 	now := time.Now()
@@ -95,14 +100,31 @@ func (s *Service) CreateSessionSummary(
 		},
 		"$unset": bson.M{"expires_at": ""},
 	}
-	if _, err := s.client.UpdateOne(ctx, s.database, s.collSessionSummaries, filter, update,
-		options.Update().SetUpsert(true)); err != nil {
+	result, err := s.client.UpdateOne(ctx, s.database, s.collSessionSummaries, filter, update,
+		options.Update().SetUpsert(true))
+	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
+			// The conditional filter did not match a newer persisted summary,
+			// so the upsert raced an existing row. The stored summary stays.
+			att.Persisted(isummary.PersistStale)
 			return nil
 		}
-		return fmt.Errorf("upsert summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("upsert summary failed: %w", err))
 	}
+	att.Persisted(mongoPersistResult(result))
 	return nil
+}
+
+// mongoPersistResult maps an upsert result to a persistence diagnostic. A
+// conditional upsert that matched nothing left the persisted summary in place.
+func mongoPersistResult(result *mongo.UpdateResult) isummary.PersistResult {
+	if result == nil {
+		return isummary.PersistStored
+	}
+	if result.MatchedCount == 0 && result.UpsertedCount == 0 {
+		return isummary.PersistStale
+	}
+	return isummary.PersistStored
 }
 
 // EnqueueSummaryJob enqueues a summary job for asynchronous processing.

--- a/session/mongodb/summary_test.go
+++ b/session/mongodb/summary_test.go
@@ -12,6 +12,8 @@ package mongodb
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +24,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
 	storage "trpc.group/trpc-go/trpc-agent-go/storage/mongodb"
 )
 
@@ -341,4 +345,75 @@ func TestNewService_WithSummarizerStartsAsyncWorker(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, s.asyncWorker)
 	require.NoError(t, s.Close())
+}
+
+func TestMongoPersistResultClassification(t *testing.T) {
+	require.Equal(t, isummary.PersistUnknown, mongoPersistResult(nil))
+	require.Equal(t, isummary.PersistUnknown, mongoPersistResult(&mongo.UpdateResult{}))
+	require.Equal(t, isummary.PersistStored, mongoPersistResult(&mongo.UpdateResult{MatchedCount: 1}))
+	require.Equal(t, isummary.PersistStored, mongoPersistResult(&mongo.UpdateResult{UpsertedCount: 1}))
+}
+
+func TestCreateSessionSummary_ReportsUnknownPersistOnNilResult(t *testing.T) {
+	line := persistResultFromCreate(t, nil, nil)
+	require.Contains(t, line, "persist_result=unknown")
+}
+
+func TestCreateSessionSummary_ReportsUnknownPersistOnEmptyResult(t *testing.T) {
+	line := persistResultFromCreate(t, &mongo.UpdateResult{}, nil)
+	require.Contains(t, line, "persist_result=unknown")
+}
+
+func TestCreateSessionSummary_ReportsStoredOnMatchedUpdate(t *testing.T) {
+	line := persistResultFromCreate(t, &mongo.UpdateResult{MatchedCount: 1, ModifiedCount: 1}, nil)
+	require.Contains(t, line, "persist_result=stored")
+}
+
+func TestCreateSessionSummary_ReportsStoredOnUpsertInsert(t *testing.T) {
+	line := persistResultFromCreate(t, &mongo.UpdateResult{UpsertedCount: 1}, nil)
+	require.Contains(t, line, "persist_result=stored")
+}
+
+func TestCreateSessionSummary_ReportsStaleOnDuplicateKey(t *testing.T) {
+	line := persistResultFromCreate(t, nil, mongo.WriteException{
+		WriteErrors: []mongo.WriteError{{Code: 11000}},
+	})
+	require.Contains(t, line, "persist_result=stale")
+}
+
+func persistResultFromCreate(
+	t *testing.T,
+	result *mongo.UpdateResult,
+	err error,
+) string {
+	t.Helper()
+	var logged []string
+	oldDebug, oldInfo, oldWarn :=
+		log.DebugfContext, log.InfofContext, log.WarnfContext
+	capture := func(_ context.Context, format string, args ...any) {
+		logged = append(logged, fmt.Sprintf(format, args...))
+	}
+	log.DebugfContext, log.InfofContext, log.WarnfContext = capture, capture, capture
+	t.Cleanup(func() {
+		log.DebugfContext, log.InfofContext, log.WarnfContext = oldDebug, oldInfo, oldWarn
+	})
+
+	mc := &mockClient{
+		updateOneFn: func(_, _ any, _ []*options.UpdateOptions) (*mongo.UpdateResult, error) {
+			return result, err
+		},
+	}
+	s := newServiceForTest(t, mc, func(o *serviceOpts) {
+		o.summarizer = &stubSummarizer{text: "hello"}
+	})
+	sess := newSessionForTest("app", "u", "s")
+	require.NoError(t, s.CreateSessionSummary(context.Background(), sess, "", true))
+
+	for _, line := range logged {
+		if strings.Contains(line, "Session summary result:") {
+			return line
+		}
+	}
+	t.Fatalf("no session summary record in %q", logged)
+	return ""
 }

--- a/session/mysql/summary.go
+++ b/session/mysql/summary.go
@@ -46,7 +46,11 @@ func (s *Service) CreateSessionSummary(
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(ctx, s.opts.summarizer, sess, filterKey, force)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -54,30 +58,42 @@ func (s *Service) CreateSessionSummary(
 	sess.SummariesMu.RLock()
 	sum := sess.Summaries[filterKey]
 	sess.SummariesMu.RUnlock()
-
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
 
 	summaryBytes, err := json.Marshal(sum)
 	if err != nil {
-		return fmt.Errorf("marshal summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("marshal summary failed: %w", err))
 	}
-
-	return s.upsertSessionSummary(ctx, key, filterKey, summaryBytes, sum.UpdatedAt)
+	result, err := s.upsertSessionSummary(
+		ctx,
+		key,
+		filterKey,
+		summaryBytes,
+		sum.UpdatedAt,
+	)
+	if err != nil {
+		return att.RecordWrite(err)
+	}
+	att.Persisted(result)
+	return nil
 }
 
 // upsertSessionSummary serializes summary persistence through the parent
 // session row. This keeps writes correct for both the current four-column
 // unique index and legacy schemas whose nullable deleted_at column does not
-// prevent duplicate active summaries.
+// prevent duplicate active summaries. It reports whether the write was
+// applied or deliberately skipped as stale.
 func (s *Service) upsertSessionSummary(
 	ctx context.Context,
 	key session.Key,
 	filterKey string,
 	summaryBytes []byte,
 	updatedAt time.Time,
-) error {
+) (isummary.PersistResult, error) {
+	result := isummary.PersistStored
 	err := s.mysqlClient.Transaction(ctx, func(tx *sql.Tx) error {
 		if err := s.lockActiveSessionForSummary(ctx, tx, key); err != nil {
 			return err
@@ -95,6 +111,7 @@ func (s *Service) upsertSessionSummary(
 			// committed summary. Equal cutoffs remain last-write-wins so callers
 			// can force regeneration for the same summarized history.
 			if persistedUpdatedAt.After(updatedAt) {
+				result = isummary.PersistStale
 				return nil
 			}
 
@@ -134,9 +151,9 @@ func (s *Service) upsertSessionSummary(
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("upsert summary failed: %w", err)
+		return isummary.PersistError, fmt.Errorf("upsert summary failed: %w", err)
 	}
-	return nil
+	return result, nil
 }
 
 func (s *Service) lockActiveSessionForSummary(

--- a/session/mysql/summary_integration_test.go
+++ b/session/mysql/summary_integration_test.go
@@ -179,7 +179,8 @@ func TestSessionSummarySchemaCompatibilityIntegration(t *testing.T) {
 		go func() {
 			defer close(olderDone)
 			close(olderStarted)
-			olderErr <- svc.upsertSessionSummary(ctx, key, "", olderBytes, olderUpdatedAt)
+			_, err := svc.upsertSessionSummary(ctx, key, "", olderBytes, olderUpdatedAt)
+			olderErr <- err
 		}()
 		<-olderStarted
 		select {
@@ -200,9 +201,10 @@ func TestSessionSummarySchemaCompatibilityIntegration(t *testing.T) {
 		requireSummaryIntegrationRows(t, ctx, db, tableName, key, "newer", newerUpdatedAt, 2)
 
 		regeneratedBytes := marshalSummaryIntegration(t, "regenerated", newerUpdatedAt)
-		require.NoError(t, svc.upsertSessionSummary(
+		_, err = svc.upsertSessionSummary(
 			ctx, key, "", regeneratedBytes, newerUpdatedAt,
-		))
+		)
+		require.NoError(t, err)
 		requireSummaryIntegrationRows(t, ctx, db, tableName, key, "regenerated", newerUpdatedAt, 2)
 	})
 }

--- a/session/mysql/summary_test.go
+++ b/session/mysql/summary_test.go
@@ -123,10 +123,12 @@ func TestUpsertSessionSummarySkipsOlderCutoff(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(persistedUpdatedAt))
 	mock.ExpectCommit()
 
-	err = s.upsertSessionSummary(
+	result, err := s.upsertSessionSummary(
 		context.Background(), key, "", []byte(`{"summary":"older"}`), incomingUpdatedAt,
 	)
 	require.NoError(t, err)
+	require.Equal(t, isummary.PersistStale, result,
+		"a skipped stale write must be reported as such")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -155,8 +157,9 @@ func TestUpsertSessionSummaryEqualCutoffLastWriteWins(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	err = s.upsertSessionSummary(context.Background(), key, "", summaryBytes, updatedAt)
+	result, err := s.upsertSessionSummary(context.Background(), key, "", summaryBytes, updatedAt)
 	require.NoError(t, err)
+	require.Equal(t, isummary.PersistStored, result)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/session/pgvector/summary.go
+++ b/session/pgvector/summary.go
@@ -52,10 +52,14 @@ func (s *Service) CreateSessionSummary(
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(
 		ctx, s.opts.summarizer,
 		sess, filterKey, force,
 	)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -65,14 +69,15 @@ func (s *Service) CreateSessionSummary(
 	sess.SummariesMu.RUnlock()
 
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
 
 	summaryBytes, err := json.Marshal(sum)
 	if err != nil {
-		return fmt.Errorf(
+		return att.RecordWrite(fmt.Errorf(
 			"marshal summary failed: %w", err,
-		)
+		))
 	}
 
 	_, err = s.pgClient.ExecContext(ctx,
@@ -96,10 +101,11 @@ func (s *Service) CreateSessionSummary(
 		sum.UpdatedAt, nil,
 	)
 	if err != nil {
-		return fmt.Errorf(
+		return att.RecordWrite(fmt.Errorf(
 			"upsert summary failed: %w", err,
-		)
+		))
 	}
+	att.Persisted(isummary.PersistStored)
 	return nil
 }
 

--- a/session/postgres/summary.go
+++ b/session/postgres/summary.go
@@ -46,7 +46,11 @@ func (s *Service) CreateSessionSummary(
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(ctx, s.opts.summarizer, sess, filterKey, force)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -57,12 +61,13 @@ func (s *Service) CreateSessionSummary(
 	sess.SummariesMu.RUnlock()
 
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
 
 	summaryBytes, err := json.Marshal(sum)
 	if err != nil {
-		return fmt.Errorf("marshal summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("marshal summary failed: %w", err))
 	}
 
 	// Note: expires_at is set to NULL - summaries are bound to session
@@ -81,9 +86,10 @@ func (s *Service) CreateSessionSummary(
 		sess.AppName, sess.UserID, sess.ID, filterKey, summaryBytes, sum.UpdatedAt, nil)
 
 	if err != nil {
-		return fmt.Errorf("upsert summary failed: %w", err)
+		return att.RecordWrite(fmt.Errorf("upsert summary failed: %w", err))
 	}
 
+	att.Persisted(isummary.PersistStored)
 	return nil
 }
 

--- a/session/redis/internal/hashidx/session_test.go
+++ b/session/redis/internal/hashidx/session_test.go
@@ -711,7 +711,8 @@ func TestClient_GetSession_WithTracksAndSummary(t *testing.T) {
 
 	// Create summary
 	sum := &session.Summary{Summary: "test-sum", UpdatedAt: time.Now().UTC()}
-	require.NoError(t, c.CreateSummary(ctx, key, "", sum, time.Hour))
+	_, summaryErr := c.CreateSummary(ctx, key, "", sum, time.Hour)
+	require.NoError(t, summaryErr)
 
 	// Full GetSession should return events, tracks, summary
 	sess, err := c.GetSession(ctx, key, 0, time.Time{})

--- a/session/redis/internal/hashidx/summary.go
+++ b/session/redis/internal/hashidx/summary.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
 )
 
 // =============================================================================
@@ -36,15 +37,19 @@ const summaryNilError = "summary is nil"
 // TTL is set atomically inside the Lua script to avoid orphan keys without expiry.
 // UpdatedAt is normalized to UTC before serialization so that the Lua-side
 // lexicographic comparison of ISO 8601 strings equals chronological order.
+//
+// It reports the set-if-newer classification. A successful script execution
+// never becomes a caller-visible error just because the reply is unrecognized;
+// that reply is classified as unknown instead of stored or stale.
 func (c *Client) CreateSummary(
 	ctx context.Context,
 	key session.Key,
 	filterKey string,
 	sum *session.Summary,
 	ttl time.Duration,
-) error {
+) (write util.SummaryWriteResult, err error) {
 	if sum == nil {
-		return errors.New(summaryNilError)
+		return util.SummaryWriteUnknown, errors.New(summaryNilError)
 	}
 	// Normalize to UTC so Lua string comparison of "updated_at" is correct.
 	normalized := sum.Clone()
@@ -52,7 +57,7 @@ func (c *Client) CreateSummary(
 
 	payload, err := json.Marshal(normalized)
 	if err != nil {
-		return fmt.Errorf("marshal summary failed: %w", err)
+		return util.SummaryWriteUnknown, fmt.Errorf("marshal summary failed: %w", err)
 	}
 
 	ttlSeconds := int64(0)
@@ -62,13 +67,13 @@ func (c *Client) CreateSummary(
 
 	sumKey := c.keys.SummaryKey(key)
 
-	if _, err := c.runScript(
+	result, err := c.runScript(
 		ctx, luaSummarySetIfNewer, []string{sumKey}, filterKey, string(payload), ttlSeconds,
-	).Result(); err != nil {
-		return fmt.Errorf("store summary failed: %w", err)
+	).Result()
+	if err != nil {
+		return util.SummaryWriteUnknown, fmt.Errorf("store summary failed: %w", err)
 	}
-
-	return nil
+	return util.ParseSummaryWriteResult(result), nil
 }
 
 // GetSummary retrieves all summaries for the session.

--- a/session/redis/internal/hashidx/summary_test.go
+++ b/session/redis/internal/hashidx/summary_test.go
@@ -14,9 +14,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
 )
 
 func TestClient_CreateSummary(t *testing.T) {
@@ -26,15 +28,18 @@ func TestClient_CreateSummary(t *testing.T) {
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum1"}
 
 	t.Run("nil summary returns error", func(t *testing.T) {
-		err := c.CreateSummary(ctx, key, "all", nil, time.Hour)
+		applied, err := c.CreateSummary(ctx, key, "all", nil, time.Hour)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, summaryNilError)
+		assert.False(t, applied.Applied())
 	})
 
 	t.Run("creates new summary", func(t *testing.T) {
 		now := time.Now()
 		sum := &session.Summary{Summary: "test summary", UpdatedAt: now}
-		require.NoError(t, c.CreateSummary(ctx, key, "all", sum, time.Hour))
+		applied, err := c.CreateSummary(ctx, key, "all", sum, time.Hour)
+		require.NoError(t, err)
+		assert.True(t, applied.Applied(), "a first write must report applied")
 
 		result, err := c.GetSummary(ctx, key)
 		require.NoError(t, err)
@@ -45,7 +50,9 @@ func TestClient_CreateSummary(t *testing.T) {
 	t.Run("updates with newer timestamp", func(t *testing.T) {
 		newer := time.Now().Add(time.Hour)
 		sum := &session.Summary{Summary: "updated", UpdatedAt: newer}
-		require.NoError(t, c.CreateSummary(ctx, key, "all", sum, time.Hour))
+		applied, err := c.CreateSummary(ctx, key, "all", sum, time.Hour)
+		require.NoError(t, err)
+		assert.True(t, applied.Applied(), "a newer summary must report applied")
 
 		result, err := c.GetSummary(ctx, key)
 		require.NoError(t, err)
@@ -55,7 +62,10 @@ func TestClient_CreateSummary(t *testing.T) {
 	t.Run("skips older timestamp", func(t *testing.T) {
 		older := time.Now().Add(-24 * time.Hour)
 		sum := &session.Summary{Summary: "old", UpdatedAt: older}
-		require.NoError(t, c.CreateSummary(ctx, key, "all", sum, time.Hour))
+		applied, err := c.CreateSummary(ctx, key, "all", sum, time.Hour)
+		require.NoError(t, err)
+		assert.False(t, applied.Applied(),
+			"a skipped stale write must not report applied")
 
 		result, err := c.GetSummary(ctx, key)
 		require.NoError(t, err)
@@ -66,8 +76,15 @@ func TestClient_CreateSummary(t *testing.T) {
 		key2 := session.Key{AppName: "app", UserID: "u1", SessionID: "sum2"}
 		now := time.Now()
 
-		require.NoError(t, c.CreateSummary(ctx, key2, "all", &session.Summary{Summary: "all-sum", UpdatedAt: now}, time.Hour))
-		require.NoError(t, c.CreateSummary(ctx, key2, "custom", &session.Summary{Summary: "custom-sum", UpdatedAt: now}, time.Hour))
+		applied, err := c.CreateSummary(
+			ctx, key2, "all", &session.Summary{Summary: "all-sum", UpdatedAt: now}, time.Hour)
+		require.NoError(t, err)
+		assert.True(t, applied.Applied())
+		applied, err = c.CreateSummary(
+			ctx, key2, "custom", &session.Summary{Summary: "custom-sum", UpdatedAt: now}, time.Hour)
+		require.NoError(t, err)
+		assert.True(t, applied.Applied(),
+			"a first write for a second filter key must report applied")
 
 		result, err := c.GetSummary(ctx, key2)
 		require.NoError(t, err)
@@ -90,6 +107,30 @@ func TestClient_GetSummary(t *testing.T) {
 	})
 }
 
+// TestClient_CreateSummary_EqualTimestampApplies pins that an equal cutoff is
+// last-write-wins, so it reports an applied write rather than a stale skip.
+func TestClient_CreateSummary_EqualTimestampApplies(t *testing.T) {
+	_, rdb := setupMiniredis(t)
+	c := NewClient(rdb, defaultConfig())
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum-equal"}
+	at := time.Now().UTC()
+
+	applied, err := c.CreateSummary(
+		ctx, key, "all", &session.Summary{Summary: "first", UpdatedAt: at}, 0)
+	require.NoError(t, err)
+	require.True(t, applied.Applied())
+
+	applied, err = c.CreateSummary(
+		ctx, key, "all", &session.Summary{Summary: "second", UpdatedAt: at}, 0)
+	require.NoError(t, err)
+	assert.True(t, applied.Applied(), "an equal cutoff must remain last-write-wins")
+
+	result, err := c.GetSummary(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, "second", result["all"].Summary)
+}
+
 func TestClient_CreateSummary_PreservesExistingTTLOnUpdate(t *testing.T) {
 	mr, rdb := setupMiniredis(t)
 	cfg := defaultConfig()
@@ -99,20 +140,22 @@ func TestClient_CreateSummary_PreservesExistingTTLOnUpdate(t *testing.T) {
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum-ttl"}
 
 	first := time.Now().UTC()
-	require.NoError(t, c.CreateSummary(ctx, key, "all", &session.Summary{
+	_, err := c.CreateSummary(ctx, key, "all", &session.Summary{
 		Summary:   "first",
 		UpdatedAt: first,
-	}, cfg.SessionTTL))
+	}, cfg.SessionTTL)
+	require.NoError(t, err)
 
 	sumKey := c.keys.SummaryKey(key)
 	assert.Equal(t, 10*time.Second, mr.TTL(sumKey))
 
 	mr.FastForward(4 * time.Second)
 
-	require.NoError(t, c.CreateSummary(ctx, key, "all", &session.Summary{
+	_, err = c.CreateSummary(ctx, key, "all", &session.Summary{
 		Summary:   "second",
 		UpdatedAt: first.Add(time.Second),
-	}, cfg.SessionTTL))
+	}, cfg.SessionTTL)
+	require.NoError(t, err)
 
 	assert.Equal(t, 6*time.Second, mr.TTL(sumKey))
 
@@ -120,4 +163,119 @@ func TestClient_CreateSummary_PreservesExistingTTLOnUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "second", result["all"].Summary)
+}
+
+// TestClient_CreateSummary_StaleWriteKeepsTTL pins that a skipped stale write
+// leaves the stored value and its TTL untouched.
+func TestClient_CreateSummary_StaleWriteKeepsTTL(t *testing.T) {
+	mr, rdb := setupMiniredis(t)
+	cfg := defaultConfig()
+	cfg.SessionTTL = 10 * time.Second
+	c := NewClient(rdb, cfg)
+	ctx := context.Background()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum-stale-ttl"}
+
+	at := time.Now().UTC()
+	_, err := c.CreateSummary(
+		ctx, key, "all", &session.Summary{Summary: "kept", UpdatedAt: at}, cfg.SessionTTL)
+	require.NoError(t, err)
+
+	sumKey := c.keys.SummaryKey(key)
+	require.Equal(t, 10*time.Second, mr.TTL(sumKey))
+
+	applied, err := c.CreateSummary(ctx, key, "all", &session.Summary{
+		Summary:   "stale",
+		UpdatedAt: at.Add(-time.Hour),
+	}, cfg.SessionTTL)
+	require.NoError(t, err)
+	assert.False(t, applied.Applied())
+	assert.Equal(t, 10*time.Second, mr.TTL(sumKey))
+
+	result, err := c.GetSummary(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, "kept", result["all"].Summary)
+}
+
+// TestClient_CreateSummary_LuaReplyContract restores the original Redis
+// contract: a successful script execution is never turned into a caller-visible
+// error just because the reply is unrecognized. Unknown replies stay unknown
+// rather than stored or stale.
+func TestClient_CreateSummary_LuaReplyContract(t *testing.T) {
+	orig := luaSummarySetIfNewer
+	t.Cleanup(func() { luaSummarySetIfNewer = orig })
+
+	sum := &session.Summary{Summary: "reply-contract", UpdatedAt: time.Now().UTC()}
+
+	t.Run("int64 1 is stored", func(t *testing.T) {
+		luaSummarySetIfNewer = orig
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-1"},
+			"all", sum, 0,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, util.SummaryWriteApplied, write)
+	})
+
+	t.Run("int64 0 is stale", func(t *testing.T) {
+		luaSummarySetIfNewer = orig
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		ctx := context.Background()
+		key := session.Key{AppName: "app", UserID: "u1", SessionID: "lua-0"}
+		at := time.Now().UTC()
+		_, err := c.CreateSummary(ctx, key, "all", &session.Summary{
+			Summary: "kept", UpdatedAt: at,
+		}, 0)
+		require.NoError(t, err)
+		write, err := c.CreateSummary(ctx, key, "all", &session.Summary{
+			Summary: "older", UpdatedAt: at.Add(-time.Hour),
+		}, 0)
+		require.NoError(t, err)
+		assert.Equal(t, util.SummaryWriteStale, write)
+	})
+
+	t.Run("unknown type does not add a business error", func(t *testing.T) {
+		luaSummarySetIfNewer = redis.NewScript(`return "1"`)
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-type"},
+			"all", sum, 0,
+		)
+		require.NoError(t, err, "script err=nil must stay a nil CreateSummary error")
+		assert.Equal(t, util.SummaryWriteUnknown, write)
+		assert.False(t, write.Applied())
+	})
+
+	t.Run("unknown value does not add a business error", func(t *testing.T) {
+		luaSummarySetIfNewer = redis.NewScript(`return 2`)
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-value"},
+			"all", sum, 0,
+		)
+		require.NoError(t, err, "script err=nil must stay a nil CreateSummary error")
+		assert.Equal(t, util.SummaryWriteUnknown, write)
+		assert.False(t, write.Applied())
+	})
+
+	t.Run("script error remains a store-summary error", func(t *testing.T) {
+		luaSummarySetIfNewer = redis.NewScript(`return redis.error_reply("boom")`)
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-err"},
+			"all", sum, 0,
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "store summary failed")
+		assert.False(t, write.Applied())
+	})
 }

--- a/session/redis/internal/hashidx/summary_test.go
+++ b/session/redis/internal/hashidx/summary_test.go
@@ -183,13 +183,17 @@ func TestClient_CreateSummary_StaleWriteKeepsTTL(t *testing.T) {
 	sumKey := c.keys.SummaryKey(key)
 	require.Equal(t, 10*time.Second, mr.TTL(sumKey))
 
+	mr.FastForward(4 * time.Second)
+	require.Equal(t, 6*time.Second, mr.TTL(sumKey))
+
 	applied, err := c.CreateSummary(ctx, key, "all", &session.Summary{
 		Summary:   "stale",
 		UpdatedAt: at.Add(-time.Hour),
 	}, cfg.SessionTTL)
 	require.NoError(t, err)
 	assert.False(t, applied.Applied())
-	assert.Equal(t, 10*time.Second, mr.TTL(sumKey))
+	assert.Equal(t, 6*time.Second, mr.TTL(sumKey),
+		"a skipped stale write must not refresh the TTL")
 
 	result, err := c.GetSummary(ctx, key)
 	require.NoError(t, err)

--- a/session/redis/internal/hashidx/summary_test.go
+++ b/session/redis/internal/hashidx/summary_test.go
@@ -191,7 +191,7 @@ func TestClient_CreateSummary_StaleWriteKeepsTTL(t *testing.T) {
 		UpdatedAt: at.Add(-time.Hour),
 	}, cfg.SessionTTL)
 	require.NoError(t, err)
-	assert.False(t, applied.Applied())
+	assert.Equal(t, util.SummaryWriteStale, applied)
 	assert.Equal(t, 6*time.Second, mr.TTL(sumKey),
 		"a skipped stale write must not refresh the TTL")
 

--- a/session/redis/internal/util/util.go
+++ b/session/redis/internal/util/util.go
@@ -30,6 +30,47 @@ const (
 	StorageTypeZset = "zset"
 )
 
+// SummaryWriteResult classifies a set-if-newer Lua reply for diagnostics.
+// A recognized or unrecognized reply after a successful script execution is
+// not a CreateSessionSummary failure; only the script/marshal/expire error
+// is returned to callers.
+type SummaryWriteResult string
+
+const (
+	// SummaryWriteApplied means the script replied int64(1).
+	SummaryWriteApplied SummaryWriteResult = "stored"
+	// SummaryWriteStale means the script replied int64(0).
+	SummaryWriteStale SummaryWriteResult = "stale"
+	// SummaryWriteUnknown means the script returned a reply that is neither
+	// int64 0 nor 1. Callers must not guess stored or stale.
+	SummaryWriteUnknown SummaryWriteResult = "unknown"
+)
+
+// Applied reports whether the write is known to have been stored.
+func (r SummaryWriteResult) Applied() bool {
+	return r == SummaryWriteApplied
+}
+
+// ParseSummaryWriteResult classifies a set-if-newer summary script reply.
+// Both storage layouts reply int64(1) when the write was applied and
+// int64(0) when the stored summary is newer and was deliberately kept.
+// Any other type or value is unknown: the original Redis contract does not
+// turn a successful script execution into a caller-visible error.
+func ParseSummaryWriteResult(result any) SummaryWriteResult {
+	value, ok := result.(int64)
+	if !ok {
+		return SummaryWriteUnknown
+	}
+	switch value {
+	case 1:
+		return SummaryWriteApplied
+	case 0:
+		return SummaryWriteStale
+	default:
+		return SummaryWriteUnknown
+	}
+}
+
 // ProcessStateCmd processes a HGetAll command result into a StateMap.
 func ProcessStateCmd(cmd *redis.MapStringStringCmd) (session.StateMap, error) {
 	bytes, err := cmd.Result()

--- a/session/redis/internal/util/util_test.go
+++ b/session/redis/internal/util/util_test.go
@@ -333,3 +333,20 @@ func TestProcessStateCmd_Error(t *testing.T) {
 		require.Error(t, err)
 	}
 }
+
+// TestParseSummaryWriteResult pins the set-if-newer reply classification
+// shared by both storage layouts. Only int64 0 and 1 are stored or stale;
+// anything else is unknown so callers never guess, and never turn a successful
+// script execution into an error.
+func TestParseSummaryWriteResult(t *testing.T) {
+	assert.Equal(t, SummaryWriteApplied, ParseSummaryWriteResult(int64(1)),
+		"1 means the write was applied")
+	assert.Equal(t, SummaryWriteStale, ParseSummaryWriteResult(int64(0)),
+		"0 means a stale write was skipped")
+
+	for _, result := range []any{int64(2), int64(-1), int(1), uint64(1), "1", nil} {
+		write := ParseSummaryWriteResult(result)
+		assert.Equal(t, SummaryWriteUnknown, write, "result %#v", result)
+		assert.False(t, write.Applied(), "an unrecognized reply must not report applied")
+	}
+}

--- a/session/redis/internal/zset/coverage_test.go
+++ b/session/redis/internal/zset/coverage_test.go
@@ -213,7 +213,7 @@ func TestCov_CreateSummary_LuaError(t *testing.T) {
 		Summary:   "test",
 		UpdatedAt: time.Now(),
 	}
-	err := c.CreateSummary(ctx, key, "", sum, time.Hour)
+	_, err := c.CreateSummary(ctx, key, "", sum, time.Hour)
 	require.Error(t, err)
 }
 
@@ -999,6 +999,6 @@ func TestCov_CreateSummary_ExpireTTLWithConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	// CreateSummary with TTL > 0 exercises the Expire branch
-	err = c.CreateSummary(ctx, key, "fk1", &session.Summary{Summary: "hello", UpdatedAt: time.Now()}, time.Hour)
+	_, err = c.CreateSummary(ctx, key, "fk1", &session.Summary{Summary: "hello", UpdatedAt: time.Now()}, time.Hour)
 	require.NoError(t, err)
 }

--- a/session/redis/internal/zset/session.go
+++ b/session/redis/internal/zset/session.go
@@ -1064,34 +1064,42 @@ func (c *Client) TrimConversations(ctx context.Context, key session.Key, count i
 
 // CreateSummary creates or updates a summary for the session.
 // Uses Lua script to atomically merge filterKey summary only if newer.
+//
+// It reports the set-if-newer classification. A successful script execution
+// never becomes a caller-visible error just because the reply is unrecognized;
+// that reply is classified as unknown instead of stored or stale. The TTL
+// refresh runs whenever the script itself succeeds, as it always has, because
+// the stored key stays live either way.
 func (c *Client) CreateSummary(
 	ctx context.Context,
 	key session.Key,
 	filterKey string,
 	sum *session.Summary,
 	ttl time.Duration,
-) error {
+) (write util.SummaryWriteResult, err error) {
 	payload, err := json.Marshal(sum)
 	if err != nil {
-		return fmt.Errorf("marshal summary failed: %w", err)
+		return util.SummaryWriteUnknown, fmt.Errorf("marshal summary failed: %w", err)
 	}
 
 	sumKey := c.sessionSummaryKey(key)
 	hashField := key.SessionID
 
-	if _, err := c.runScript(
+	result, err := c.runScript(
 		ctx, luaSummariesSetIfNewer, []string{sumKey}, hashField, filterKey, string(payload),
-	).Result(); err != nil {
-		return fmt.Errorf("store summary (lua) failed: %w", err)
+	).Result()
+	if err != nil {
+		return util.SummaryWriteUnknown, fmt.Errorf("store summary (lua) failed: %w", err)
 	}
+	write = util.ParseSummaryWriteResult(result)
 
 	if ttl > 0 {
 		if err := c.client.Expire(ctx, sumKey, ttl).Err(); err != nil {
-			return fmt.Errorf("expire summary failed: %w", err)
+			return write, fmt.Errorf("expire summary failed: %w", err)
 		}
 	}
 
-	return nil
+	return write, nil
 }
 
 // GetSummary retrieves summaries for the session.

--- a/session/redis/internal/zset/session_test.go
+++ b/session/redis/internal/zset/session_test.go
@@ -1079,8 +1079,9 @@ func TestSummary(t *testing.T) {
 			Summary:   "test summary",
 			UpdatedAt: time.Now().UTC(),
 		}
-		err := c.CreateSummary(ctx, key, "all", sum, time.Hour)
+		applied, err := c.CreateSummary(ctx, key, "all", sum, time.Hour)
 		require.NoError(t, err)
+		assert.True(t, applied.Applied(), "a first write must report applied")
 
 		summaries, err := c.GetSummary(ctx, key)
 		require.NoError(t, err)
@@ -1093,15 +1094,17 @@ func TestSummary(t *testing.T) {
 			Summary:   "old",
 			UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		}
-		err := c.CreateSummary(ctx, key, "filter1", oldSum, 0)
+		applied, err := c.CreateSummary(ctx, key, "filter1", oldSum, 0)
 		require.NoError(t, err)
+		assert.True(t, applied.Applied())
 
 		newSum := &session.Summary{
 			Summary:   "new",
 			UpdatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 		}
-		err = c.CreateSummary(ctx, key, "filter1", newSum, 0)
+		applied, err = c.CreateSummary(ctx, key, "filter1", newSum, 0)
 		require.NoError(t, err)
+		assert.True(t, applied.Applied(), "a newer summary must report applied")
 
 		summaries, err := c.GetSummary(ctx, key)
 		require.NoError(t, err)
@@ -1113,15 +1116,18 @@ func TestSummary(t *testing.T) {
 			Summary:   "newer",
 			UpdatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		}
-		err := c.CreateSummary(ctx, key, "filter2", newSum, 0)
+		applied, err := c.CreateSummary(ctx, key, "filter2", newSum, 0)
 		require.NoError(t, err)
+		assert.True(t, applied.Applied())
 
 		oldSum := &session.Summary{
 			Summary:   "older",
 			UpdatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 		}
-		err = c.CreateSummary(ctx, key, "filter2", oldSum, 0)
+		applied, err = c.CreateSummary(ctx, key, "filter2", oldSum, 0)
 		require.NoError(t, err)
+		assert.False(t, applied.Applied(),
+			"a skipped stale write must not report applied")
 
 		summaries, err := c.GetSummary(ctx, key)
 		require.NoError(t, err)
@@ -1133,8 +1139,10 @@ func TestSummary(t *testing.T) {
 		sum1 := &session.Summary{Summary: "sum-all", UpdatedAt: time.Now().UTC()}
 		sum2 := &session.Summary{Summary: "sum-branch", UpdatedAt: time.Now().UTC()}
 
-		require.NoError(t, c.CreateSummary(ctx, key2, "all", sum1, 0))
-		require.NoError(t, c.CreateSummary(ctx, key2, "branch1", sum2, 0))
+		_, err := c.CreateSummary(ctx, key2, "all", sum1, 0)
+		require.NoError(t, err)
+		_, err = c.CreateSummary(ctx, key2, "branch1", sum2, 0)
+		require.NoError(t, err)
 
 		summaries, err := c.GetSummary(ctx, key2)
 		require.NoError(t, err)
@@ -1444,7 +1452,7 @@ func TestClient_CreateSummary_Error(t *testing.T) {
 	mr.Close()
 
 	sum := &session.Summary{Summary: "test", UpdatedAt: time.Now().UTC()}
-	err := c.CreateSummary(ctx, key, "", sum, time.Hour)
+	_, err := c.CreateSummary(ctx, key, "", sum, time.Hour)
 	require.Error(t, err)
 }
 
@@ -1459,12 +1467,120 @@ func TestClient_CreateSummary_NoTTL(t *testing.T) {
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "sum-nottl"}
 
 	sum := &session.Summary{Summary: "test", UpdatedAt: time.Now().UTC()}
-	require.NoError(t, c.CreateSummary(ctx, key, "", sum, 0))
+	applied, err := c.CreateSummary(ctx, key, "", sum, 0)
+	require.NoError(t, err)
+	assert.True(t, applied.Applied())
 
 	summaries, err := c.GetSummary(ctx, key)
 	require.NoError(t, err)
 	require.NotNil(t, summaries)
 	assert.Equal(t, "test", summaries[""].Summary)
+}
+
+// TestClient_CreateSummary_LuaReplyContract restores the original Redis
+// contract: a successful script execution is never turned into a caller-visible
+// error just because the reply is unrecognized. Unknown replies still refresh
+// TTL, matching the pre-diagnostics Expire-after-script-success path.
+func TestClient_CreateSummary_LuaReplyContract(t *testing.T) {
+	orig := luaSummariesSetIfNewer
+	t.Cleanup(func() { luaSummariesSetIfNewer = orig })
+
+	sum := &session.Summary{Summary: "reply-contract", UpdatedAt: time.Now().UTC()}
+
+	t.Run("int64 1 is stored", func(t *testing.T) {
+		luaSummariesSetIfNewer = orig
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-1"},
+			"all", sum, 0,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, util.SummaryWriteApplied, write)
+	})
+
+	t.Run("int64 0 is stale", func(t *testing.T) {
+		luaSummariesSetIfNewer = orig
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		ctx := context.Background()
+		key := session.Key{AppName: "app", UserID: "u1", SessionID: "lua-0"}
+		_, err := c.CreateSummary(ctx, key, "filter1", &session.Summary{
+			Summary:   "kept",
+			UpdatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		}, 0)
+		require.NoError(t, err)
+		write, err := c.CreateSummary(ctx, key, "filter1", &session.Summary{
+			Summary:   "older",
+			UpdatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		}, 0)
+		require.NoError(t, err)
+		assert.Equal(t, util.SummaryWriteStale, write)
+	})
+
+	t.Run("unknown type does not add a business error", func(t *testing.T) {
+		luaSummariesSetIfNewer = redis.NewScript(`return "1"`)
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-type"},
+			"all", sum, 0,
+		)
+		require.NoError(t, err, "script err=nil must stay a nil CreateSummary error")
+		assert.Equal(t, util.SummaryWriteUnknown, write)
+		assert.False(t, write.Applied())
+	})
+
+	t.Run("unknown value does not add a business error", func(t *testing.T) {
+		luaSummariesSetIfNewer = redis.NewScript(`return 2`)
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-value"},
+			"all", sum, 0,
+		)
+		require.NoError(t, err, "script err=nil must stay a nil CreateSummary error")
+		assert.Equal(t, util.SummaryWriteUnknown, write)
+		assert.False(t, write.Applied())
+	})
+
+	t.Run("script error remains a store-summary error", func(t *testing.T) {
+		luaSummariesSetIfNewer = redis.NewScript(`return redis.error_reply("boom")`)
+		_, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		write, err := c.CreateSummary(
+			context.Background(),
+			session.Key{AppName: "app", UserID: "u1", SessionID: "lua-err"},
+			"all", sum, time.Hour,
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "store summary (lua) failed")
+		assert.False(t, write.Applied())
+	})
+
+	t.Run("unknown reply still refreshes TTL", func(t *testing.T) {
+		luaSummariesSetIfNewer = orig
+		mr, rdb := setupMiniredis(t)
+		c := NewClient(rdb, defaultConfig())
+		ctx := context.Background()
+		key := session.Key{AppName: "app", UserID: "u1", SessionID: "lua-ttl"}
+		_, err := c.CreateSummary(ctx, key, "all", sum, 10*time.Second)
+		require.NoError(t, err)
+		sumKey := c.sessionSummaryKey(key)
+		require.Equal(t, 10*time.Second, mr.TTL(sumKey))
+		mr.FastForward(4 * time.Second)
+		require.Equal(t, 6*time.Second, mr.TTL(sumKey))
+
+		luaSummariesSetIfNewer = redis.NewScript(`return "1"`)
+		write, err := c.CreateSummary(ctx, key, "all", sum, 10*time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, util.SummaryWriteUnknown, write)
+		assert.Equal(t, 10*time.Second, mr.TTL(sumKey),
+			"TTL must refresh whenever the script itself succeeds")
+	})
 }
 
 // =============================================================================

--- a/session/redis/service_test.go
+++ b/session/redis/service_test.go
@@ -1118,7 +1118,8 @@ func TestService_WithDisableScriptCache_ZSetSummary(t *testing.T) {
 	ctx := context.Background()
 	key := session.Key{AppName: "app", UserID: "u1", SessionID: "s1"}
 	sum := &session.Summary{Summary: "summary", UpdatedAt: time.Now().UTC()}
-	require.NoError(t, service.zsetClient.CreateSummary(ctx, key, "all", sum, 0))
+	_, err = service.zsetClient.CreateSummary(ctx, key, "all", sum, 0)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"eval"}, recorder.snapshot())
 }
 

--- a/session/redis/summary.go
+++ b/session/redis/summary.go
@@ -46,7 +46,11 @@ func (s *Service) CreateSessionSummary(ctx context.Context, sess *session.Sessio
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(ctx, s.opts.summarizer, sess, filterKey, force)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -57,17 +61,23 @@ func (s *Service) CreateSessionSummary(ctx context.Context, sess *session.Sessio
 	sess.SummariesMu.RUnlock()
 
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
+
+	// recordWrite reports the outcome of a set-if-newer summary write. Both
+	// storage routes deliberately skip a write whose stored summary is newer,
+	// so a nil error alone does not prove a durable write happened.
+	recordWrite := summaryWriteRecorder(att)
 
 	// Fast path: use version tag from session
 	switch ver := getSessionVersion(sess); ver {
 	case util.StorageTypeHashIdx:
 		s.recordStorageRoute(ctx, opCreateSessionSummary, util.StorageTypeHashIdx)
-		return s.hashidxClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL)
+		return recordWrite(s.hashidxClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL))
 	case util.StorageTypeZset:
 		s.recordStorageRoute(ctx, opCreateSessionSummary, util.StorageTypeZset)
-		return s.zsetClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL)
+		return recordWrite(s.zsetClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL))
 	}
 
 	// Slow path: check which storage has the session
@@ -78,15 +88,39 @@ func (s *Service) CreateSessionSummary(ctx context.Context, sess *session.Sessio
 
 	if s.compatEnabled() && zsetExists {
 		s.recordStorageRoute(ctx, opCreateSessionSummary, util.StorageTypeZset)
-		return s.zsetClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL)
+		return recordWrite(s.zsetClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL))
 	}
 	if hashidxExists {
 		s.recordStorageRoute(ctx, opCreateSessionSummary, util.StorageTypeHashIdx)
-		return s.hashidxClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL)
+		return recordWrite(s.hashidxClient.CreateSummary(ctx, key, filterKey, sum, s.opts.sessionTTL))
 	}
 
 	log.WarnfContext(ctx, "session not found when creating summary: %s/%s/%s", key.AppName, key.UserID, key.SessionID)
 	return nil
+}
+
+// summaryWriteRecorder returns a function that records the outcome of a
+// set-if-newer summary write on att and returns the write error unchanged. It
+// accepts the storage client result directly so callers can report and return
+// in one statement. A recognized 1 is stored, a recognized 0 is a deliberate
+// stale skip, and any other successful reply is unknown rather than guessed.
+func summaryWriteRecorder(
+	att *isummary.Attempt,
+) func(util.SummaryWriteResult, error) error {
+	return func(write util.SummaryWriteResult, err error) error {
+		if err != nil {
+			return att.RecordWrite(err)
+		}
+		switch write {
+		case util.SummaryWriteApplied:
+			att.Persisted(isummary.PersistStored)
+		case util.SummaryWriteStale:
+			att.Persisted(isummary.PersistStale)
+		default:
+			att.Persisted(isummary.PersistUnknown)
+		}
+		return nil
+	}
 }
 
 // GetSessionSummaryText returns the latest summary text from the session state if present.

--- a/session/redis/summary_diagnostics_test.go
+++ b/session/redis/summary_diagnostics_test.go
@@ -1,0 +1,235 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummary "trpc.group/trpc-go/trpc-agent-go/session/internal/summary"
+	"trpc.group/trpc-go/trpc-agent-go/session/redis/internal/util"
+)
+
+// summaryDiagLogs captures summary records emitted through the package logger.
+// The logger is process-global, so the recorder is synchronized.
+type summaryDiagLogs struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *summaryDiagLogs) add(line string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, line)
+}
+
+// record returns the single session summary record captured for the call.
+func (l *summaryDiagLogs) record(t *testing.T) string {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, line := range l.lines {
+		if strings.HasPrefix(line, "Session summary result:") {
+			return line
+		}
+	}
+	t.Fatalf("no session summary record in %q", l.lines)
+	return ""
+}
+
+func captureSummaryDiagLogs(t *testing.T) *summaryDiagLogs {
+	t.Helper()
+	logs := &summaryDiagLogs{}
+	oldDebug, oldInfo, oldWarn :=
+		log.DebugfContext, log.InfofContext, log.WarnfContext
+	capture := func(_ context.Context, format string, args ...any) {
+		logs.add(fmt.Sprintf(format, args...))
+	}
+	log.DebugfContext, log.InfofContext, log.WarnfContext =
+		capture, capture, capture
+	t.Cleanup(func() {
+		log.DebugfContext, log.InfofContext, log.WarnfContext =
+			oldDebug, oldInfo, oldWarn
+	})
+	return logs
+}
+
+// diagSummarizer writes a fixed summary with a caller-chosen cutoff so tests
+// can drive the set-if-newer decision in the storage layer.
+type diagSummarizer struct {
+	text string
+}
+
+func (s *diagSummarizer) ShouldSummarize(*session.Session) bool { return true }
+
+func (s *diagSummarizer) Summarize(
+	context.Context, *session.Session,
+) (string, error) {
+	return s.text, nil
+}
+
+func (s *diagSummarizer) SetPrompt(string)         {}
+func (s *diagSummarizer) SetModel(model.Model)     {}
+func (s *diagSummarizer) Metadata() map[string]any { return nil }
+
+// diagSummarySession builds a session whose single event carries the cutoff the
+// generated summary boundary will adopt.
+func diagSummarySession(t *testing.T, svc *Service, at time.Time) *session.Session {
+	t.Helper()
+	key := session.Key{AppName: "app", UserID: "u1", SessionID: "diag-sum"}
+	stored, err := svc.CreateSession(context.Background(), key, nil)
+	require.NoError(t, err)
+	return &session.Session{
+		ID:        stored.ID,
+		AppName:   key.AppName,
+		UserID:    key.UserID,
+		Summaries: make(map[string]*session.Summary),
+		Events: []event.Event{{
+			ID:        "e1",
+			Author:    "user",
+			Timestamp: at,
+			Response: &model.Response{Choices: []model.Choice{{
+				Message: model.Message{
+					Role:    model.RoleUser,
+					Content: "hello",
+				},
+			}}},
+		}},
+	}
+}
+
+// TestCreateSessionSummary_ReportsStoredWrite proves a durable Redis write is
+// reported as stored rather than assumed from a nil error.
+func TestCreateSessionSummary_ReportsStoredWrite(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	svc, err := NewService(
+		WithRedisClientURL(redisURL),
+		WithSummarizer(&diagSummarizer{text: "generated"}),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	logs := captureSummaryDiagLogs(t)
+	sess := diagSummarySession(t, svc, time.Now().UTC())
+
+	require.NoError(t,
+		svc.CreateSessionSummary(context.Background(), sess, "", true))
+
+	line := logs.record(t)
+	require.Contains(t, line, "schema_version=1")
+	require.Contains(t, line, "persist_result=stored")
+	require.Contains(t, line, "outcome=success")
+	require.Contains(t, line, `filter_key=""`)
+	require.Contains(t, line, "filter_key_truncated=false")
+}
+
+// TestCreateSessionSummary_ReportsStaleWrite proves that a Redis set-if-newer
+// script that deliberately skips the write is reported as stale instead of
+// being reported as a backend-confirmed store. This is the diagnostic that separates a
+// lost summary from a summary that was never generated.
+func TestCreateSessionSummary_ReportsStaleWrite(t *testing.T) {
+	redisURL, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	svc, err := NewService(
+		WithRedisClientURL(redisURL),
+		WithSummarizer(&diagSummarizer{text: "generated"}),
+	)
+	require.NoError(t, err)
+	defer svc.Close()
+
+	ctx := context.Background()
+	newer := time.Now().UTC()
+
+	// Persist a newer summary first so the second attempt is stale.
+	first := diagSummarySession(t, svc, newer)
+	require.NoError(t, svc.CreateSessionSummary(ctx, first, "", true))
+
+	logs := captureSummaryDiagLogs(t)
+	stale := diagSummarySession(t, svc, newer.Add(-time.Hour))
+	require.NoError(t, svc.CreateSessionSummary(ctx, stale, "", true),
+		"a skipped stale write must remain a successful call")
+
+	line := logs.record(t)
+	require.Contains(t, line, "schema_version=1")
+	require.Contains(t, line, "persist_result=stale")
+	require.Contains(t, line, "outcome=stale_write")
+
+	text, ok := svc.GetSessionSummaryText(ctx, &session.Session{
+		ID:      first.ID,
+		AppName: first.AppName,
+		UserID:  first.UserID,
+	})
+	require.True(t, ok)
+	require.Equal(t, "generated", text,
+		"the newer stored summary must be preserved")
+}
+
+// TestSummaryWriteRecorderMapsUnexpectedLuaReply proves an unrecognized
+// set-if-newer reply is diagnostic uncertainty, never stored/stale/success/
+// persistence_error, and does not become a CreateSessionSummary error.
+func TestSummaryWriteRecorderMapsUnexpectedLuaReply(t *testing.T) {
+	logs := captureSummaryDiagLogs(t)
+	sess := &session.Session{ID: "s", AppName: "app", UserID: "u1"}
+	_, att := isummary.BeginAttempt(context.Background(), sess, "")
+	att.Summarized(true, nil)
+
+	write := util.ParseSummaryWriteResult("1")
+	require.Equal(t, util.SummaryWriteUnknown, write)
+	err := summaryWriteRecorder(att)(write, nil)
+	require.NoError(t, err, "unknown reply must not add a business error")
+	att.Report()
+
+	line := logs.record(t)
+	require.Contains(t, line, "schema_version=1")
+	require.Contains(t, line, "persist_result=unknown")
+	require.Contains(t, line, "outcome=unknown_write")
+	require.NotContains(t, line, "persist_result=stored")
+	require.NotContains(t, line, "persist_result=stale")
+	require.NotContains(t, line, "persist_result=error")
+	require.NotContains(t, line, "outcome=success")
+	require.NotContains(t, line, "outcome=persistence_error")
+	require.NotContains(t, line, "unexpected set-if-newer")
+}
+
+// TestSummaryWriteRecorderMapsScriptError proves a real script failure still
+// surfaces as a persistence error.
+func TestSummaryWriteRecorderMapsScriptError(t *testing.T) {
+	logs := captureSummaryDiagLogs(t)
+	sess := &session.Session{ID: "s", AppName: "app", UserID: "u1"}
+	_, att := isummary.BeginAttempt(context.Background(), sess, "")
+	att.Summarized(true, nil)
+
+	err := summaryWriteRecorder(att)(
+		util.SummaryWriteUnknown,
+		fmt.Errorf("store summary failed: %w", errors.New("boom")),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "store summary failed")
+	att.Report()
+
+	line := logs.record(t)
+	require.Contains(t, line, "persist_result=error")
+	require.Contains(t, line, "outcome=persistence_error")
+	require.NotContains(t, line, "boom")
+}

--- a/session/sqlite/summary.go
+++ b/session/sqlite/summary.go
@@ -49,6 +49,9 @@ func (s *Service) CreateSessionSummary(
 		return nil
 	}
 
+	ctx, att := isummary.BeginAttempt(ctx, sess, filterKey)
+	defer att.Report()
+
 	updated, err := isummary.SummarizeSession(
 		ctx,
 		s.opts.summarizer,
@@ -56,6 +59,7 @@ func (s *Service) CreateSessionSummary(
 		filterKey,
 		force,
 	)
+	att.Summarized(updated, err)
 	if err != nil || !updated {
 		return err
 	}
@@ -64,12 +68,13 @@ func (s *Service) CreateSessionSummary(
 	sum := sess.Summaries[filterKey]
 	sess.SummariesMu.RUnlock()
 	if sum == nil {
+		att.Persisted(isummary.PersistNoSummary)
 		return nil
 	}
 
 	summaryBytes, err := json.Marshal(sum)
 	if err != nil {
-		return fmt.Errorf("marshal summary: %w", err)
+		return att.RecordWrite(fmt.Errorf("marshal summary: %w", err))
 	}
 
 	const insertSQL = `INSERT INTO %s (
@@ -94,8 +99,9 @@ ON CONFLICT(app_name, user_id, session_id, filter_key) DO UPDATE SET
 		nil,
 	)
 	if err != nil {
-		return fmt.Errorf("upsert summary: %w", err)
+		return att.RecordWrite(fmt.Errorf("upsert summary: %w", err))
 	}
+	att.Persisted(isummary.PersistStored)
 	return nil
 }
 

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -18,6 +18,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/event"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/session"
+	isummarycontext "trpc.group/trpc-go/trpc-agent-go/session/internal/summarycontext"
 )
 
 type reportModel struct {
@@ -140,7 +141,9 @@ func TestSessionSummarizer_ReportHookStandaloneCall(t *testing.T) {
 	)
 
 	report := &Report{}
+	var call isummarycontext.ModelCall
 	ctx := ContextWithReport(context.Background(), report)
+	ctx = isummarycontext.WithModelCallRecorder(ctx, &call)
 	contextual := s.(ContextAwareSummarizer)
 	require.True(t, contextual.ShouldSummarizeWithContext(ctx, newReportSession()))
 
@@ -151,6 +154,7 @@ func TestSessionSummarizer_ReportHookStandaloneCall(t *testing.T) {
 	require.Equal(t, 7, got.Trigger.Value)
 	require.Equal(t, 5, got.Trigger.Threshold)
 	require.Equal(t, callModeStandalone, got.Call.Mode)
+	require.Equal(t, callModeStandalone, call.Mode)
 	require.Equal(t, 7, got.Call.EstimatedPromptTokens)
 	require.Equal(t, 123, got.Call.PromptTokens)
 	require.Equal(t, 45, got.Call.CachedTokens)

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -259,7 +259,13 @@ type reportContextTestKey struct{}
 
 func TestInheritReportContext(t *testing.T) {
 	report := &Report{Trigger: Trigger{Name: checkNameTokenThreshold}}
+	var call isummarycontext.ModelCall
+	var trigger isummarycontext.TriggerObservation
+	var selection isummarycontext.EventSelection
 	current := ContextWithReport(context.Background(), report)
+	current = isummarycontext.WithModelCallRecorder(current, &call)
+	current = isummarycontext.WithTriggerRecorder(current, &trigger)
+	current = isummarycontext.WithEventSelectionRecorder(current, &selection)
 	next := context.WithValue(context.Background(), reportContextTestKey{}, "next")
 
 	got := inheritReportContext(next, current)
@@ -267,6 +273,9 @@ func TestInheritReportContext(t *testing.T) {
 	require.True(t, ok)
 	require.Same(t, report, inherited)
 	require.Equal(t, "next", got.Value(reportContextTestKey{}))
+	require.Same(t, &call, isummarycontext.ModelCallFromContext(got))
+	require.Same(t, &trigger, isummarycontext.TriggerFromContext(got))
+	require.Same(t, &selection, isummarycontext.EventSelectionFromContext(got))
 
 	existing := &Report{Trigger: Trigger{Name: checkNameContextThreshold}}
 	got = inheritReportContext(ContextWithReport(next, existing), current)

--- a/session/summary/report_test.go
+++ b/session/summary/report_test.go
@@ -282,6 +282,26 @@ func TestInheritReportContext(t *testing.T) {
 	inherited, ok = ReportFromContext(got)
 	require.True(t, ok)
 	require.Same(t, existing, inherited)
+	require.Same(t, &call, isummarycontext.ModelCallFromContext(got))
+	require.Same(t, &trigger, isummarycontext.TriggerFromContext(got))
+	require.Same(t, &selection, isummarycontext.EventSelectionFromContext(got))
+
+	var staleCall isummarycontext.ModelCall
+	var staleTrigger isummarycontext.TriggerObservation
+	var staleSelection isummarycontext.EventSelection
+	staleNext := isummarycontext.WithModelCallRecorder(next, &staleCall)
+	staleNext = isummarycontext.WithTriggerRecorder(staleNext, &staleTrigger)
+	staleNext = isummarycontext.WithEventSelectionRecorder(staleNext, &staleSelection)
+	got = inheritReportContext(staleNext, current)
+	require.Same(t, &call, isummarycontext.ModelCallFromContext(got))
+	isummarycontext.RecordModelCall(got, callModeStandalone)
+	require.Equal(t, callModeStandalone, call.Mode)
+	require.Empty(t, staleCall.Mode)
+
+	got = inheritReportContext(staleNext, context.Background())
+	require.Nil(t, isummarycontext.ModelCallFromContext(got))
+	isummarycontext.RecordModelCall(got, callModeStandalone)
+	require.Empty(t, staleCall.Mode)
 
 	got = inheritReportContext(nil, current)
 	inherited, ok = ReportFromContext(got)
@@ -388,4 +408,125 @@ func TestSessionSummarizer_ReportHookKeepsUsageFromEarlierResponse(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, "summary", text)
 	require.Equal(t, 21, got.Call.PromptTokens)
+}
+
+func TestSessionSummarizer_BeforeModelCachedContextWritesCurrentRecorder(t *testing.T) {
+	var currentCall, staleCall isummarycontext.ModelCall
+	staleReport := &Report{Trigger: Trigger{Name: "stale"}}
+	staleCtx := ContextWithReport(context.Background(), staleReport)
+	staleCtx = isummarycontext.WithModelCallRecorder(staleCtx, &staleCall)
+
+	currentReport := &Report{}
+	current := ContextWithReport(context.Background(), currentReport)
+	current = isummarycontext.WithModelCallRecorder(current, &currentCall)
+
+	callbacks := model.NewCallbacks()
+	callbacks.RegisterBeforeModel(func(
+		context.Context,
+		*model.BeforeModelArgs,
+	) (*model.BeforeModelResult, error) {
+		return &model.BeforeModelResult{Context: staleCtx}, nil
+	})
+	s := NewSummarizer(&reportModel{}, WithModelCallbacks(callbacks))
+
+	text, err := s.Summarize(current, newReportSession())
+	require.NoError(t, err)
+	require.Equal(t, "summary", text)
+	require.Equal(t, callModeStandalone, currentCall.Mode)
+	require.Empty(t, staleCall.Mode)
+	require.Equal(t, callModeStandalone, staleReport.Call.Mode)
+	require.Empty(t, currentReport.Call.Mode)
+}
+
+type sequentialReportModel struct {
+	calls     int
+	responses []*model.Response
+}
+
+func (m *sequentialReportModel) Info() model.Info {
+	return model.Info{Name: "sequential-report"}
+}
+
+func (m *sequentialReportModel) GenerateContent(
+	_ context.Context,
+	_ *model.Request,
+) (<-chan *model.Response, error) {
+	m.calls++
+	ch := make(chan *model.Response, 1)
+	if m.calls > len(m.responses) {
+		close(ch)
+		return ch, nil
+	}
+	ch <- m.responses[m.calls-1]
+	close(ch)
+	return ch, nil
+}
+
+func TestSessionSummarizer_RetryCustomResponseKeepsCalledObservation(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		firstResponse *model.Response
+	}{
+		{
+			name:          "empty summary",
+			firstResponse: &model.Response{Done: true},
+		},
+		{
+			name: "context overflow",
+			firstResponse: func() *model.Response {
+				code := "context_length_exceeded"
+				return &model.Response{
+					Done: true,
+					Error: &model.ResponseError{
+						Message: "maximum context length exceeded",
+						Code:    &code,
+					},
+				}
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &sequentialReportModel{responses: []*model.Response{tc.firstResponse}}
+			var beforeCalls int
+			callbacks := model.NewCallbacks()
+			callbacks.RegisterBeforeModel(func(
+				context.Context,
+				*model.BeforeModelArgs,
+			) (*model.BeforeModelResult, error) {
+				beforeCalls++
+				if beforeCalls == 1 {
+					return nil, nil
+				}
+				return &model.BeforeModelResult{
+					CustomResponse: &model.Response{
+						Done: true,
+						Choices: []model.Choice{{
+							Message: model.Message{Content: "callback summary"},
+						}},
+					},
+				}, nil
+			})
+			var got Report
+			var call isummarycontext.ModelCall
+			s := NewSummarizer(
+				m,
+				WithModelCallbacks(callbacks),
+				WithReportHook(func(_ context.Context, report Report) {
+					got = report
+				}),
+			)
+			report := &Report{}
+			ctx := ContextWithReport(context.Background(), report)
+			ctx = isummarycontext.WithModelCallRecorder(ctx, &call)
+
+			text, err := s.Summarize(ctx, newReportSession())
+			require.NoError(t, err)
+			require.Equal(t, "callback summary", text)
+			require.Equal(t, 1, m.calls)
+			require.Equal(t, 2, beforeCalls)
+			require.Equal(t, callModeCustomResponse, got.Call.Mode)
+			require.Equal(t, callModeCustomResponse, report.Call.Mode)
+			require.Equal(t, callModeStandalone, call.Mode)
+		})
+	}
 }

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -2190,12 +2190,11 @@ func (s *sessionSummarizer) recordReportCall(
 	request *model.Request,
 	mode string,
 ) {
-	report, ok := reportFromContext(ctx)
-	if !ok {
-		return
+	if report, ok := reportFromContext(ctx); ok {
+		report.Call.Mode = mode
+		report.Call.EstimatedPromptTokens = estimateRequestPromptTokens(ctx, request)
 	}
-	report.Call.Mode = mode
-	report.Call.EstimatedPromptTokens = estimateRequestPromptTokens(ctx, request)
+	isummarycontext.RecordModelCall(ctx, mode)
 }
 
 func (s *sessionSummarizer) recordReportUsage(

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -461,9 +461,14 @@ func (s *sessionSummarizer) selectSummaryEvents(
 ) summaryEventSelection {
 	view, ok := modelVisibleViewForSession(ctx, sess)
 	if !ok {
-		events := filterSummaryInputEventsForSession(
-			s.filterEventsForSummary(sess.Events),
-			sess,
+		retained, decision := s.filterEventsForSummaryObserved(sess.Events)
+		events := filterSummaryInputEventsForSession(retained, sess)
+		recordSelection(
+			ctx,
+			isummarycontext.SourceSessionEvents,
+			decision,
+			len(retained),
+			len(events),
 		)
 		return summaryEventSelection{events: events, sourceEvents: events}
 	}
@@ -472,6 +477,11 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		// projected items may differ from messages changed by later processors
 		// or before-model callbacks. Do not summarize or advance persistence
 		// from content that is not proven to have been visible to the model.
+		isummarycontext.RecordEventSelection(ctx, isummarycontext.EventSelection{
+			Source:   isummarycontext.SourceUnboundView,
+			Reason:   isummarycontext.ReasonUnboundView,
+			Eligible: len(view.Items),
+		})
 		return summaryEventSelection{effective: true}
 	}
 
@@ -499,7 +509,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		)
 		boundaries = append([]summaryview.Boundary{{}}, boundaries...)
 	}
-	events = s.filterEventsForSummary(events)
+	events, decision := s.filterEventsForSummaryObserved(events)
 	if len(boundaries) > len(events) {
 		boundaries = boundaries[:len(events)]
 	}
@@ -517,6 +527,7 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		boundaries:   boundaries,
 		effective:    true,
 	}
+	unmapped := false
 	if boundary, found := view.BoundaryForItems(itemIndexes); found {
 		selection.boundary = boundary
 		if source := sourceEventsThroughBoundary(sess.Events, boundary); len(source) > 0 {
@@ -530,8 +541,76 @@ func (s *sessionSummarizer) selectSummaryEvents(
 		selection.sourceEvents = nil
 		selection.itemIndexes = nil
 		selection.boundaries = nil
+		unmapped = true
+	}
+	if unmapped {
+		recordUnmappedSelection(ctx, decision)
+	} else {
+		recordSelection(
+			ctx,
+			isummarycontext.SourceModelVisible,
+			decision,
+			len(events),
+			len(selection.events),
+		)
 	}
 	return selection
+}
+
+// recordSelection publishes the observed summary input selection. retained is
+// the number of events that survived skip-recent, and selected is the number
+// that survived every later stage, so the two separate a skip-recent decision
+// from later session scoping.
+func recordSelection(
+	ctx context.Context,
+	source string,
+	decision skipRecentDecision,
+	retained int,
+	selected int,
+) {
+	isummarycontext.RecordEventSelection(ctx, isummarycontext.EventSelection{
+		Source:              source,
+		Reason:              selectionReason(decision, retained, selected),
+		Eligible:            decision.eligible,
+		SkipRecentRequested: decision.requested,
+		SkipRecentApplied:   decision.applied,
+		Selected:            selected,
+	})
+}
+
+// selectionReason names the stage that produced the final selected count.
+func selectionReason(
+	decision skipRecentDecision,
+	retained int,
+	selected int,
+) string {
+	if selected > 0 {
+		return isummarycontext.ReasonSelected
+	}
+	if decision.eligible == 0 {
+		return isummarycontext.ReasonNoCandidates
+	}
+	if decision.reason != "" {
+		return decision.reason
+	}
+	if retained > 0 {
+		// Events survived skip-recent and were then removed by the session's
+		// branch scoping.
+		return isummarycontext.ReasonSessionFilterEmpty
+	}
+	return isummarycontext.ReasonNoCandidates
+}
+
+// recordUnmappedSelection publishes a selection that was dropped because its
+// items had no structural mapping to a stored event.
+func recordUnmappedSelection(ctx context.Context, decision skipRecentDecision) {
+	isummarycontext.RecordEventSelection(ctx, isummarycontext.EventSelection{
+		Source:              isummarycontext.SourceModelVisible,
+		Reason:              isummarycontext.ReasonBoundaryUnmapped,
+		Eligible:            decision.eligible,
+		SkipRecentRequested: decision.requested,
+		SkipRecentApplied:   decision.applied,
+	})
 }
 
 func previousSummaryEvent(text string) event.Event {
@@ -923,35 +1002,79 @@ func (s *sessionSummarizer) buildCheckSessionWithSelection(
 	return checkSess
 }
 
+// skipRecentDecision records what one filterEventsForSummary call did. It holds
+// counts and a stable reason only, never event content.
+type skipRecentDecision struct {
+	// eligible is the number of events handed to the skip-recent callback.
+	eligible int
+	// requested is the raw callback return, or zero when none is configured.
+	requested int
+	// applied is how many events skip-recent itself removed:
+	// clamp(requested, 0, eligible). Later stages are not counted here.
+	applied int
+	// reason is empty when events survived, and otherwise names the closed-set
+	// cause that emptied the slice.
+	reason string
+}
+
 // filterEventsForSummary filters events for summarization, excluding recent events
 // and ensuring that retained events still have enough context to summarize.
 func (s *sessionSummarizer) filterEventsForSummary(events []event.Event) []event.Event {
+	filtered, _ := s.filterEventsForSummaryObserved(events)
+	return filtered
+}
+
+// filterEventsForSummaryObserved applies the same filtering as
+// filterEventsForSummary and additionally reports the decision it made, so
+// diagnostics can distinguish a skip-recent callback that consumed everything
+// from a retained prefix rejected as unsafe.
+func (s *sessionSummarizer) filterEventsForSummaryObserved(
+	events []event.Event,
+) ([]event.Event, skipRecentDecision) {
+	decision := skipRecentDecision{eligible: len(events)}
 	if s.skipRecentFunc == nil {
-		return events
+		return events, decision
 	}
 
 	skipCount := s.skipRecentFunc(events)
+	decision.requested = skipCount
+	decision.applied = skipRecentApplied(skipCount, len(events))
 	if skipCount <= 0 {
-		return events
+		return events, decision
 	}
 	if len(events) <= skipCount {
-		return []event.Event{}
+		decision.reason = isummarycontext.ReasonSkipRecentAll
+		return []event.Event{}, decision
 	}
 
 	filteredEvents := events[:len(events)-skipCount]
 
 	if hasUserMessageForSummary(filteredEvents) {
-		return filteredEvents
+		return filteredEvents, decision
 	}
 
 	// Delta summarization can prepend the previous summary as a synthetic
 	// system event. Preserve assistant/tool follow-ups when that summary is
 	// still present and at least one real event remains after it.
 	if s.hasPrependedSummaryContext(filteredEvents) {
-		return filteredEvents
+		return filteredEvents, decision
 	}
 
-	return []event.Event{}
+	decision.reason = isummarycontext.ReasonUnsafePrefix
+	return []event.Event{}, decision
+}
+
+// skipRecentApplied is the number of events the skip-recent callback itself
+// removed: clamp(requested, 0, eligible). It does not include later drops
+// from an unsafe prefix, session scoping, or an unmapped boundary.
+func skipRecentApplied(requested, eligible int) int {
+	if requested <= 0 {
+		return 0
+	}
+	if requested > eligible {
+		return eligible
+	}
+	return requested
 }
 
 func hasUserMessageForSummary(events []event.Event) bool {

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -348,6 +348,15 @@ func (s *sessionSummarizer) ShouldSummarizeWithContext(
 	if report, ok := reportFromContext(ctx); ok {
 		report.Trigger = trigger
 	}
+	isummarycontext.RecordTrigger(ctx, isummarycontext.TriggerObservation{
+		Name:           trigger.Name,
+		Metric:         trigger.Metric,
+		Value:          trigger.Value,
+		Threshold:      trigger.Threshold,
+		ContextWindow:  trigger.ContextWindow,
+		CheckCount:     len(trigger.Checks),
+		ThresholdRatio: trigger.ThresholdRatio,
+	})
 	return trigger.Fired
 }
 
@@ -558,9 +567,9 @@ func (s *sessionSummarizer) selectSummaryEvents(
 }
 
 // recordSelection publishes the observed summary input selection. retained is
-// the number of events that survived skip-recent, and selected is the number
-// that survived every later stage, so the two separate a skip-recent decision
-// from later session scoping.
+// the number of events that survived skip-recent, and selected is the
+// pre-hook count that survived every later built-in stage. A later hook or
+// callback may rewrite the prompt without changing this observation.
 func recordSelection(
 	ctx context.Context,
 	source string,
@@ -574,7 +583,9 @@ func recordSelection(
 		Eligible:            decision.eligible,
 		SkipRecentRequested: decision.requested,
 		SkipRecentApplied:   decision.applied,
-		Selected:            selected,
+		// Selected is the pre-hook event count. A later hook or callback
+		// may rewrite the prompt without changing this observation.
+		Selected: selected,
 	})
 }
 
@@ -2335,6 +2346,9 @@ func inheritReportContext(next context.Context, current context.Context) context
 	if next == nil {
 		return current
 	}
+	next = inheritModelCallRecorder(next, current)
+	next = inheritTriggerRecorder(next, current)
+	next = inheritEventSelectionRecorder(next, current)
 	report, ok := reportFromContext(current)
 	if !ok {
 		return next
@@ -2343,6 +2357,36 @@ func inheritReportContext(next context.Context, current context.Context) context
 		return next
 	}
 	return ContextWithReport(next, report)
+}
+
+func inheritModelCallRecorder(next, current context.Context) context.Context {
+	if isummarycontext.ModelCallFromContext(next) != nil {
+		return next
+	}
+	if call := isummarycontext.ModelCallFromContext(current); call != nil {
+		return isummarycontext.WithModelCallRecorder(next, call)
+	}
+	return next
+}
+
+func inheritTriggerRecorder(next, current context.Context) context.Context {
+	if isummarycontext.TriggerFromContext(next) != nil {
+		return next
+	}
+	if obs := isummarycontext.TriggerFromContext(current); obs != nil {
+		return isummarycontext.WithTriggerRecorder(next, obs)
+	}
+	return next
+}
+
+func inheritEventSelectionRecorder(next, current context.Context) context.Context {
+	if isummarycontext.EventSelectionFromContext(next) != nil {
+		return next
+	}
+	if selection := isummarycontext.EventSelectionFromContext(current); selection != nil {
+		return isummarycontext.WithEventSelectionRecorder(next, selection)
+	}
+	return next
 }
 
 func (s *sessionSummarizer) collectSummaryFromResponses(

--- a/session/summary/summarizer.go
+++ b/session/summary/summarizer.go
@@ -2346,9 +2346,9 @@ func inheritReportContext(next context.Context, current context.Context) context
 	if next == nil {
 		return current
 	}
-	next = inheritModelCallRecorder(next, current)
-	next = inheritTriggerRecorder(next, current)
-	next = inheritEventSelectionRecorder(next, current)
+	next = isummarycontext.InheritModelCallRecorder(next, current)
+	next = isummarycontext.InheritTriggerRecorder(next, current)
+	next = isummarycontext.InheritEventSelectionRecorder(next, current)
 	report, ok := reportFromContext(current)
 	if !ok {
 		return next
@@ -2357,36 +2357,6 @@ func inheritReportContext(next context.Context, current context.Context) context
 		return next
 	}
 	return ContextWithReport(next, report)
-}
-
-func inheritModelCallRecorder(next, current context.Context) context.Context {
-	if isummarycontext.ModelCallFromContext(next) != nil {
-		return next
-	}
-	if call := isummarycontext.ModelCallFromContext(current); call != nil {
-		return isummarycontext.WithModelCallRecorder(next, call)
-	}
-	return next
-}
-
-func inheritTriggerRecorder(next, current context.Context) context.Context {
-	if isummarycontext.TriggerFromContext(next) != nil {
-		return next
-	}
-	if obs := isummarycontext.TriggerFromContext(current); obs != nil {
-		return isummarycontext.WithTriggerRecorder(next, obs)
-	}
-	return next
-}
-
-func inheritEventSelectionRecorder(next, current context.Context) context.Context {
-	if isummarycontext.EventSelectionFromContext(next) != nil {
-		return next
-	}
-	if selection := isummarycontext.EventSelectionFromContext(current); selection != nil {
-		return isummarycontext.WithEventSelectionRecorder(next, selection)
-	}
-	return next
 }
 
 func (s *sessionSummarizer) collectSummaryFromResponses(

--- a/session/summary/summarizer_test.go
+++ b/session/summary/summarizer_test.go
@@ -2011,6 +2011,28 @@ func TestSessionSummarizer_FilterEventsForSummary(t *testing.T) {
 		assert.Len(t, filtered, 5)
 	})
 
+	t.Run("unsafe prefix does not attribute extra drops to skip-recent", func(t *testing.T) {
+		s := &sessionSummarizer{skipRecentFunc: func(_ []event.Event) int { return 1 }}
+		events := []event.Event{
+			{Author: "assistant", Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "a1"}}}}},
+			{Author: "assistant", Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "a2"}}}}},
+			{Author: "user", Response: &model.Response{Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "recent"}}}}},
+		}
+		filtered, decision := s.filterEventsForSummaryObserved(events)
+		assert.Empty(t, filtered)
+		assert.Equal(t, 3, decision.eligible)
+		assert.Equal(t, 1, decision.requested)
+		assert.Equal(t, 1, decision.applied)
+		assert.Equal(t, isummarycontext.ReasonUnsafePrefix, decision.reason)
+	})
+}
+
+func TestSkipRecentApplied(t *testing.T) {
+	assert.Equal(t, 0, skipRecentApplied(-3, 5))
+	assert.Equal(t, 0, skipRecentApplied(0, 5))
+	assert.Equal(t, 1, skipRecentApplied(1, 3))
+	assert.Equal(t, 3, skipRecentApplied(5, 3))
+	assert.Equal(t, 0, skipRecentApplied(1, 0))
 }
 
 func TestSummaryEventHelpers(t *testing.T) {


### PR DESCRIPTION
Add versioned diagnostic records for summary trigger decisions, event selection, model calls, backend-confirmed persistence, branch cascade, request injection, and pre-LLM context compaction.

Keep routine decisions at Debug, successful summary writes at Info, and actionable failures at Warn. Bound caller-supplied filter keys for display without changing storage keys, and avoid logging prompt, summary, event, model-output, identifier, or raw-error content.

Cover built-in and custom summarizers, summary-view binding, injection observation, cascade invariants, and persistence outcomes across the supported session backends. No public SessionService API, persistence format, or summary behavior changes.

Checks: affected root package tests; Redis module tests; race tests for summary diagnostics, summary orchestration, injection state, and LLM flow; gofmt; goimports; git diff --check.