### PR TITLE
session/postgres: preserve summary freshness across time zones

### DIFF
--- a/session/postgres/service_edge_test.go
+++ b/session/postgres/service_edge_test.go
@@ -1087,7 +1087,7 @@ func TestGetSummariesList_FiltersStaleAndPreservesBoundary(t *testing.T) {
 		"updated_at",
 	}).
 		AddRow("sess1", "filter1", freshBytes, cutoffAt).
-		AddRow("sess1", "filter2", staleBytes, createdAt.Add(-time.Minute))
+		AddRow("sess1", "filter2", staleBytes, createdAt.Add(time.Hour))
 
 	mock.ExpectQuery(
 		"SELECT session_id, filter_key, summary, updated_at FROM session_summaries",

--- a/session/postgres/service_edge_test.go
+++ b/session/postgres/service_edge_test.go
@@ -1086,8 +1086,9 @@ func TestGetSummariesList_FiltersStaleAndPreservesBoundary(t *testing.T) {
 		"summary",
 		"updated_at",
 	}).
-		AddRow("sess1", "filter1", freshBytes, cutoffAt).
-		AddRow("sess1", "filter2", staleBytes, createdAt.Add(time.Hour))
+		AddRow("sess1", "filter1", freshBytes, createdAt.Add(-time.Hour)).
+		AddRow("sess1", "filter2", staleBytes, createdAt.Add(time.Hour)).
+		AddRow("unknown", "filter3", []byte("invalid-json"), cutoffAt)
 
 	mock.ExpectQuery(
 		"SELECT session_id, filter_key, summary, updated_at FROM session_summaries",
@@ -1106,6 +1107,41 @@ func TestGetSummariesList_FiltersStaleAndPreservesBoundary(t *testing.T) {
 	assert.Equal(t, "fresh", result[0]["filter1"].Summary)
 	assert.Equal(t, "event-fresh", result[0]["filter1"].Boundary.LastEventID)
 	assert.Nil(t, result[0]["filter2"])
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSummariesList_CurrentInvalidSummaryReturnsError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := createTestService(t, db)
+	key := session.Key{
+		AppName:   "app1",
+		UserID:    "user1",
+		SessionID: "sess1",
+	}
+	createdAt := time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(
+		"SELECT session_id, filter_key, summary, updated_at FROM session_summaries",
+	).
+		WithArgs("app1", "user1", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"session_id",
+			"filter_key",
+			"summary",
+			"updated_at",
+		}).AddRow("sess1", "filter1", []byte("invalid-json"), createdAt))
+
+	result, err := s.getSummariesList(
+		context.Background(),
+		[]session.Key{key},
+		[]time.Time{createdAt},
+	)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "unmarshal summary failed")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -646,11 +646,14 @@ func applySessionStateTimestamps(
 	updatedAt time.Time,
 ) {
 	// PostgreSQL TIMESTAMP columns preserve wall-clock fields but discard the
-	// original offset. The JSON envelope retains the creation instant.
+	// original offset. Prefer the absolute instants retained in the JSON
+	// envelope, and use the columns only for legacy payloads.
 	if state.CreatedAt.IsZero() {
 		state.CreatedAt = createdAt
 	}
-	state.UpdatedAt = updatedAt
+	if state.UpdatedAt.IsZero() {
+		state.UpdatedAt = updatedAt
+	}
 }
 
 // getEventsList batch loads events for multiple sessions.
@@ -948,6 +951,8 @@ func (s *Service) getSummariesList(
 			var sessionID, filterKey string
 			var summaryBytes []byte
 			var updatedAt time.Time
+			var sessionCreatedAt time.Time
+			checkFreshness := false
 			if sessionCreatedAtMap == nil {
 				if err := rows.Scan(&sessionID, &filterKey, &summaryBytes); err != nil {
 					return err
@@ -961,17 +966,27 @@ func (s *Service) getSummariesList(
 				); err != nil {
 					return err
 				}
+				var exists bool
+				sessionCreatedAt, exists = sessionCreatedAtMap[sessionID]
+				if !exists {
+					continue
+				}
+				checkFreshness = true
 			}
 
 			var sum session.Summary
 			if err := json.Unmarshal(summaryBytes, &sum); err != nil {
-				return fmt.Errorf("unmarshal summary failed: %w", err)
-			}
-			if sessionCreatedAtMap != nil {
-				createdAt, exists := sessionCreatedAtMap[sessionID]
-				if !exists || !summaryIsCurrentForSession(&sum, updatedAt, createdAt) {
+				if checkFreshness && updatedAt.Before(sessionCreatedAt) {
 					continue
 				}
+				return fmt.Errorf("unmarshal summary failed: %w", err)
+			}
+			if checkFreshness && !summaryIsCurrentForSession(
+				&sum,
+				updatedAt,
+				sessionCreatedAt,
+			) {
+				continue
 			}
 
 			if summariesMap[sessionID] == nil {

--- a/session/postgres/service_helper.go
+++ b/session/postgres/service_helper.go
@@ -48,8 +48,7 @@ func (s *Service) getSession(
 			if err := json.Unmarshal(stateBytes, sessState); err != nil {
 				return fmt.Errorf("unmarshal session state failed: %w", err)
 			}
-			sessState.CreatedAt = createdAt
-			sessState.UpdatedAt = updatedAt
+			applySessionStateTimestamps(sessState, createdAt, updatedAt)
 		}
 		return nil
 	}, stateQuery, stateArgs...)
@@ -171,8 +170,7 @@ func (s *Service) listSessions(
 				return fmt.Errorf("unmarshal session state failed: %w", err)
 			}
 			state.ID = sessionID
-			state.CreatedAt = createdAt
-			state.UpdatedAt = updatedAt
+			applySessionStateTimestamps(&state, createdAt, updatedAt)
 			sessStates = append(sessStates, &state)
 		}
 		return nil
@@ -642,6 +640,19 @@ func applyOptions(opts ...session.Option) *session.Options {
 	return opt
 }
 
+func applySessionStateTimestamps(
+	state *SessionState,
+	createdAt time.Time,
+	updatedAt time.Time,
+) {
+	// PostgreSQL TIMESTAMP columns preserve wall-clock fields but discard the
+	// original offset. The JSON envelope retains the creation instant.
+	if state.CreatedAt.IsZero() {
+		state.CreatedAt = createdAt
+	}
+	state.UpdatedAt = updatedAt
+}
+
 // getEventsList batch loads events for multiple sessions.
 //
 // When page is nil (context-window mode), time filtering and user-message
@@ -936,12 +947,12 @@ func (s *Service) getSummariesList(
 		for rows.Next() {
 			var sessionID, filterKey string
 			var summaryBytes []byte
+			var updatedAt time.Time
 			if sessionCreatedAtMap == nil {
 				if err := rows.Scan(&sessionID, &filterKey, &summaryBytes); err != nil {
 					return err
 				}
 			} else {
-				var updatedAt time.Time
 				if err := rows.Scan(
 					&sessionID,
 					&filterKey,
@@ -950,15 +961,17 @@ func (s *Service) getSummariesList(
 				); err != nil {
 					return err
 				}
-				createdAt, exists := sessionCreatedAtMap[sessionID]
-				if !exists || updatedAt.Before(createdAt) {
-					continue
-				}
 			}
 
 			var sum session.Summary
 			if err := json.Unmarshal(summaryBytes, &sum); err != nil {
 				return fmt.Errorf("unmarshal summary failed: %w", err)
+			}
+			if sessionCreatedAtMap != nil {
+				createdAt, exists := sessionCreatedAtMap[sessionID]
+				if !exists || !summaryIsCurrentForSession(&sum, updatedAt, createdAt) {
+					continue
+				}
 			}
 
 			if summariesMap[sessionID] == nil {

--- a/session/postgres/service_helper_test.go
+++ b/session/postgres/service_helper_test.go
@@ -20,6 +20,65 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/session"
 )
 
+func TestApplySessionStateTimestamps(t *testing.T) {
+	location := time.FixedZone("UTC+8", 8*60*60)
+	jsonCreatedAt := time.Date(2026, 8, 25, 17, 0, 0, 0, location)
+	jsonUpdatedAt := jsonCreatedAt.Add(time.Minute)
+	databaseCreatedAt := time.Date(2026, 8, 25, 17, 0, 0, 0, time.UTC)
+	databaseUpdatedAt := databaseCreatedAt.Add(time.Minute)
+
+	tests := []struct {
+		name          string
+		state         SessionState
+		wantCreatedAt time.Time
+		wantUpdatedAt time.Time
+	}{
+		{
+			name: "prefer JSON timestamps",
+			state: SessionState{
+				CreatedAt: jsonCreatedAt,
+				UpdatedAt: jsonUpdatedAt,
+			},
+			wantCreatedAt: jsonCreatedAt,
+			wantUpdatedAt: jsonUpdatedAt,
+		},
+		{
+			name:          "fall back for legacy payload",
+			state:         SessionState{},
+			wantCreatedAt: databaseCreatedAt,
+			wantUpdatedAt: databaseUpdatedAt,
+		},
+		{
+			name: "fall back only for missing creation time",
+			state: SessionState{
+				UpdatedAt: jsonUpdatedAt,
+			},
+			wantCreatedAt: databaseCreatedAt,
+			wantUpdatedAt: jsonUpdatedAt,
+		},
+		{
+			name: "fall back only for missing update time",
+			state: SessionState{
+				CreatedAt: jsonCreatedAt,
+			},
+			wantCreatedAt: jsonCreatedAt,
+			wantUpdatedAt: databaseUpdatedAt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applySessionStateTimestamps(
+				&tt.state,
+				databaseCreatedAt,
+				databaseUpdatedAt,
+			)
+			assert.True(t, tt.state.CreatedAt.Equal(tt.wantCreatedAt))
+			assert.True(t, tt.state.UpdatedAt.Equal(tt.wantUpdatedAt))
+		})
+	}
+}
+
 func TestGetTrackEventsByTrackLists_EmptyAndMismatch(t *testing.T) {
 	db, _, err := sqlmock.New()
 	require.NoError(t, err)

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -641,14 +641,23 @@ func TestGetSession_Success(t *testing.T) {
 		SessionID: "test-session",
 	}
 
-	// Mock session state
+	location := time.FixedZone("UTC+8", 8*60*60)
+	createdAt := time.Date(2026, 8, 25, 17, 0, 0, 0, location)
+	updatedAt := createdAt.Add(time.Minute)
+	databaseCreatedAt := time.Date(2026, 8, 25, 17, 0, 0, 0, time.UTC)
+	databaseUpdatedAt := databaseCreatedAt.Add(time.Minute)
+
+	// Mock session state. PostgreSQL TIMESTAMP scans the original wall-clock
+	// fields as UTC, while the JSON envelope preserves the original offset.
 	sessState := &SessionState{
-		ID:    "test-session",
-		State: session.StateMap{"key1": []byte("value1")},
+		ID:        "test-session",
+		State:     session.StateMap{"key1": []byte("value1")},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
 	}
 	stateBytes, _ := json.Marshal(sessState)
 	stateRows := sqlmock.NewRows([]string{"state", "created_at", "updated_at"}).
-		AddRow(stateBytes, time.Now(), time.Now())
+		AddRow(stateBytes, databaseCreatedAt, databaseUpdatedAt)
 
 	mock.ExpectQuery("SELECT state, created_at, updated_at FROM session_states").
 		WithArgs("test-app", "test-user", "test-session", sqlmock.AnyArg()).
@@ -696,6 +705,8 @@ func TestGetSession_Success(t *testing.T) {
 	assert.Equal(t, []byte("value1"), sess.State["key1"])
 	assert.Equal(t, 1, len(sess.Events))
 	assert.Equal(t, "Hello, world!", sess.Events[0].Response.Choices[0].Message.Content)
+	assert.True(t, sess.CreatedAt.Equal(createdAt))
+	assert.True(t, sess.UpdatedAt.Equal(databaseUpdatedAt))
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/session/postgres/service_test.go
+++ b/session/postgres/service_test.go
@@ -696,7 +696,8 @@ func TestGetSession_Success(t *testing.T) {
 
 	// Mock: Batch load summaries with data
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary, updated_at FROM session_summaries")).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}).
+			AddRow(key.SessionID, "legacy", nil, createdAt.Add(-time.Hour)))
 
 	sess, err := s.GetSession(context.Background(), key)
 	require.NoError(t, err)
@@ -706,7 +707,7 @@ func TestGetSession_Success(t *testing.T) {
 	assert.Equal(t, 1, len(sess.Events))
 	assert.Equal(t, "Hello, world!", sess.Events[0].Response.Choices[0].Message.Content)
 	assert.True(t, sess.CreatedAt.Equal(createdAt))
-	assert.True(t, sess.UpdatedAt.Equal(databaseUpdatedAt))
+	assert.True(t, sess.UpdatedAt.Equal(updatedAt))
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -1016,10 +1017,18 @@ func TestListSessions_Success(t *testing.T) {
 		UserID:  "user-123",
 	}
 
-	// Prepare session state
+	location := time.FixedZone("UTC+8", 8*60*60)
+	createdAt := time.Date(2026, 8, 25, 17, 0, 0, 0, location)
+	updatedAt := createdAt.Add(time.Minute)
+	databaseCreatedAt := time.Date(2026, 8, 25, 17, 0, 0, 0, time.UTC)
+	databaseUpdatedAt := databaseCreatedAt.Add(time.Minute)
+
+	// Prepare session state. The JSON timestamps preserve the original offset.
 	sessState := SessionState{
-		ID:    "session-1",
-		State: session.StateMap{"key1": []byte(`"value1"`)},
+		ID:        "session-1",
+		State:     session.StateMap{"key1": []byte(`"value1"`)},
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
 	}
 	stateBytes, _ := json.Marshal(sessState)
 
@@ -1037,7 +1046,7 @@ func TestListSessions_Success(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, state, created_at, updated_at FROM session_states")).
 		WithArgs(userKey.AppName, userKey.UserID, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "state", "created_at", "updated_at"}).
-			AddRow("session-1", stateBytes, time.Now(), time.Now()))
+			AddRow("session-1", stateBytes, databaseCreatedAt, databaseUpdatedAt))
 
 	// Mock: Batch load events (empty)
 	evt := event.NewResponseEvent("inv-1", "author", &model.Response{
@@ -1056,9 +1065,10 @@ func TestListSessions_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "event"}).
 			AddRow("session-1", eventBytes))
 
-	// Mock: Batch load summaries (empty)
+	// Mock: A stale incompatible summary must not fail the session listing.
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT session_id, filter_key, summary, updated_at FROM session_summaries")).
-		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}))
+		WillReturnRows(sqlmock.NewRows([]string{"session_id", "filter_key", "summary", "updated_at"}).
+			AddRow("session-1", "legacy", []byte("invalid json"), createdAt.Add(-time.Hour)))
 
 	sessions, err := s.ListSessions(ctx, userKey)
 	require.NoError(t, err)
@@ -1066,6 +1076,8 @@ func TestListSessions_Success(t *testing.T) {
 	assert.Equal(t, "session-1", sessions[0].ID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 	assert.Equal(t, "hello", sessions[0].Events[0].Choices[0].Message.Content)
+	assert.True(t, sessions[0].CreatedAt.Equal(createdAt))
+	assert.True(t, sessions[0].UpdatedAt.Equal(updatedAt))
 }
 
 func TestListSessions_WithListSessionOnlyMeta(t *testing.T) {
@@ -1109,6 +1121,8 @@ func TestListSessions_WithListSessionOnlyMeta(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 	assert.Equal(t, "session-1", sessions[0].ID)
+	assert.True(t, sessions[0].CreatedAt.Equal(now))
+	assert.True(t, sessions[0].UpdatedAt.Equal(now))
 	assert.Empty(t, sessions[0].Events)
 	assert.Nil(t, sessions[0].Tracks)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/session/postgres/summary.go
+++ b/session/postgres/summary.go
@@ -147,26 +147,7 @@ func (s *Service) GetSessionSummaryText(
 	// Query database with specified filterKey.
 	filterKey := isummary.GetFilterKeyFromOptions(opts...)
 
-	var summaryText string
-	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-		if rows.Next() {
-			var summaryBytes []byte
-			if err := rows.Scan(&summaryBytes); err != nil {
-				return err
-			}
-			var sum session.Summary
-			if err := json.Unmarshal(summaryBytes, &sum); err != nil {
-				return fmt.Errorf("unmarshal summary failed: %w", err)
-			}
-			summaryText = sum.Summary
-		}
-		return nil
-	}, fmt.Sprintf(`SELECT summary FROM %s
-		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND filter_key = $4
-		AND (expires_at IS NULL OR expires_at > $5)
-		AND updated_at >= $6
-		AND deleted_at IS NULL`, s.tableSessionSummaries),
-		key.AppName, key.UserID, key.SessionID, filterKey, time.Now(), sess.CreatedAt)
+	summaryText, err := s.getSessionSummaryText(ctx, key, filterKey, sess.CreatedAt)
 
 	if err == nil && summaryText != "" {
 		return summaryText, true
@@ -174,29 +155,65 @@ func (s *Service) GetSessionSummaryText(
 
 	// If requested filterKey not found, try fallback to full-session summary.
 	if filterKey != session.SummaryFilterKeyAllContents {
-		err = s.pgClient.Query(ctx, func(rows *sql.Rows) error {
-			if rows.Next() {
-				var summaryBytes []byte
-				if err := rows.Scan(&summaryBytes); err != nil {
-					return err
-				}
-				var sum session.Summary
-				if err := json.Unmarshal(summaryBytes, &sum); err != nil {
-					return fmt.Errorf("unmarshal summary failed: %w", err)
-				}
-				summaryText = sum.Summary
-			}
-			return nil
-		}, fmt.Sprintf(`SELECT summary FROM %s
-			WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND filter_key = $4
-			AND (expires_at IS NULL OR expires_at > $5)
-			AND updated_at >= $6
-			AND deleted_at IS NULL`, s.tableSessionSummaries),
-			key.AppName, key.UserID, key.SessionID, session.SummaryFilterKeyAllContents, time.Now(), sess.CreatedAt)
+		summaryText, err = s.getSessionSummaryText(
+			ctx,
+			key,
+			session.SummaryFilterKeyAllContents,
+			sess.CreatedAt,
+		)
 		if err == nil && summaryText != "" {
 			return summaryText, true
 		}
 	}
 
 	return "", false
+}
+
+func (s *Service) getSessionSummaryText(
+	ctx context.Context,
+	key session.Key,
+	filterKey string,
+	sessionCreatedAt time.Time,
+) (string, error) {
+	var summaryText string
+	err := s.pgClient.Query(ctx, func(rows *sql.Rows) error {
+		if !rows.Next() {
+			return nil
+		}
+
+		var summaryBytes []byte
+		var updatedAt time.Time
+		if err := rows.Scan(&summaryBytes, &updatedAt); err != nil {
+			return err
+		}
+		var sum session.Summary
+		if err := json.Unmarshal(summaryBytes, &sum); err != nil {
+			return fmt.Errorf("unmarshal summary failed: %w", err)
+		}
+		if !summaryIsCurrentForSession(&sum, updatedAt, sessionCreatedAt) {
+			return nil
+		}
+		summaryText = sum.Summary
+		return nil
+	}, fmt.Sprintf(`SELECT summary, updated_at FROM %s
+		WHERE app_name = $1 AND user_id = $2 AND session_id = $3 AND filter_key = $4
+		AND (expires_at IS NULL OR expires_at > $5)
+		AND deleted_at IS NULL`, s.tableSessionSummaries),
+		key.AppName, key.UserID, key.SessionID, filterKey, time.Now())
+	return summaryText, err
+}
+
+func summaryIsCurrentForSession(
+	sum *session.Summary,
+	storedUpdatedAt time.Time,
+	sessionCreatedAt time.Time,
+) bool {
+	if sessionCreatedAt.IsZero() {
+		return true
+	}
+	updatedAt := sum.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = storedUpdatedAt
+	}
+	return !updatedAt.Before(sessionCreatedAt)
 }

--- a/session/postgres/summary_test.go
+++ b/session/postgres/summary_test.go
@@ -429,6 +429,115 @@ func TestGetSessionSummaryText_AcrossTimeZones(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetSessionSummaryText_StaleSummary(t *testing.T) {
+	s, mock, db := setupMockService(t, nil)
+	defer db.Close()
+
+	createdAt := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+	summaryBytes, err := json.Marshal(session.Summary{
+		Summary:   "stale summary",
+		UpdatedAt: createdAt.Add(-time.Nanosecond),
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}).
+			AddRow(summaryBytes, createdAt.Add(time.Hour)))
+
+	text, err := s.getSessionSummaryText(
+		context.Background(),
+		session.Key{
+			AppName:   "test-app",
+			UserID:    "test-user",
+			SessionID: "test-session",
+		},
+		"",
+		createdAt,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, text)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSessionSummaryText_ScanError(t *testing.T) {
+	s, mock, db := setupMockService(t, nil)
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}).
+			AddRow([]byte(`{"summary":"text"}`), nil))
+
+	text, err := s.getSessionSummaryText(
+		context.Background(),
+		session.Key{
+			AppName:   "test-app",
+			UserID:    "test-user",
+			SessionID: "test-session",
+		},
+		"",
+		time.Now(),
+	)
+	require.Error(t, err)
+	assert.Empty(t, text)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSummaryIsCurrentForSession(t *testing.T) {
+	createdAt := time.Date(2026, 8, 25, 9, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		summaryUpdatedAt time.Time
+		storedUpdatedAt  time.Time
+		sessionCreatedAt time.Time
+		want             bool
+	}{
+		{
+			name: "zero session creation time disables filtering",
+			want: true,
+		},
+		{
+			name:             "payload timestamp takes precedence when fresh",
+			summaryUpdatedAt: createdAt,
+			storedUpdatedAt:  createdAt.Add(-time.Hour),
+			sessionCreatedAt: createdAt,
+			want:             true,
+		},
+		{
+			name:             "payload timestamp takes precedence when stale",
+			summaryUpdatedAt: createdAt.Add(-time.Hour),
+			storedUpdatedAt:  createdAt.Add(time.Hour),
+			sessionCreatedAt: createdAt,
+			want:             false,
+		},
+		{
+			name:             "legacy payload falls back to current column timestamp",
+			storedUpdatedAt:  createdAt,
+			sessionCreatedAt: createdAt,
+			want:             true,
+		},
+		{
+			name:             "legacy payload falls back to stale column timestamp",
+			storedUpdatedAt:  createdAt.Add(-time.Nanosecond),
+			sessionCreatedAt: createdAt,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summaryIsCurrentForSession(
+				&session.Summary{UpdatedAt: tt.summaryUpdatedAt},
+				tt.storedUpdatedAt,
+				tt.sessionCreatedAt,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetSessionSummaryText_NoSummary(t *testing.T) {
 	s, mock, db := setupMockService(t, &TestServiceOpts{summarizer: &mockSummarizerImpl{shouldSummarize: false}})
 	defer db.Close()

--- a/session/postgres/summary_test.go
+++ b/session/postgres/summary_test.go
@@ -371,11 +371,11 @@ func TestGetSessionSummaryText_Success(t *testing.T) {
 	}
 	summaryBytes, _ := json.Marshal(summary)
 
-	rows := sqlmock.NewRows([]string{"summary"}).
-		AddRow(summaryBytes)
+	rows := sqlmock.NewRows([]string{"summary", "updated_at"}).
+		AddRow(summaryBytes, time.Now())
 
-	mock.ExpectQuery("SELECT summary FROM session_summaries").
-		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg(), sess.CreatedAt).
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
 	text, ok := s.GetSessionSummaryText(context.Background(), sess)
@@ -399,6 +399,36 @@ func TestGetSessionSummaryText_Success(t *testing.T) {
 	assert.Equal(t, "summary text", text)
 }
 
+func TestGetSessionSummaryText_AcrossTimeZones(t *testing.T) {
+	s, mock, db := setupMockService(t, nil)
+	defer db.Close()
+
+	location := time.FixedZone("UTC+8", 8*60*60)
+	createdAt := time.Date(2026, 8, 25, 17, 0, 0, 0, location)
+	sess := &session.Session{
+		ID:        "test-session",
+		AppName:   "test-app",
+		UserID:    "test-user",
+		CreatedAt: createdAt,
+	}
+	summary := session.Summary{
+		Summary:   "timezone-safe summary",
+		UpdatedAt: createdAt.UTC(),
+	}
+	summaryBytes, err := json.Marshal(summary)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}).
+			AddRow(summaryBytes, createdAt.UTC()))
+
+	text, ok := s.GetSessionSummaryText(context.Background(), sess)
+	require.True(t, ok)
+	assert.Equal(t, "timezone-safe summary", text)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestGetSessionSummaryText_NoSummary(t *testing.T) {
 	s, mock, db := setupMockService(t, &TestServiceOpts{summarizer: &mockSummarizerImpl{shouldSummarize: false}})
 	defer db.Close()
@@ -411,9 +441,9 @@ func TestGetSessionSummaryText_NoSummary(t *testing.T) {
 	}
 
 	// Mock empty result
-	rows := sqlmock.NewRows([]string{"summary"})
-	mock.ExpectQuery("SELECT summary FROM session_summaries").
-		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg(), sess.CreatedAt).
+	rows := sqlmock.NewRows([]string{"summary", "updated_at"})
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
 	text, ok := s.GetSessionSummaryText(context.Background(), sess)
@@ -456,8 +486,8 @@ func TestGetSessionSummaryText_QueryError(t *testing.T) {
 	}
 
 	// Mock query error
-	mock.ExpectQuery("SELECT summary FROM session_summaries").
-		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg(), sess.CreatedAt).
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
 		WillReturnError(fmt.Errorf("database error"))
 
 	text, ok := s.GetSessionSummaryText(context.Background(), sess)
@@ -485,11 +515,11 @@ func TestGetSessionSummaryText_EmptySummaryText(t *testing.T) {
 	}
 	summaryBytes, _ := json.Marshal(summary)
 
-	rows := sqlmock.NewRows([]string{"summary"}).
-		AddRow(summaryBytes)
+	rows := sqlmock.NewRows([]string{"summary", "updated_at"}).
+		AddRow(summaryBytes, time.Now())
 
-	mock.ExpectQuery("SELECT summary FROM session_summaries").
-		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg(), sess.CreatedAt).
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
 	text, ok := s.GetSessionSummaryText(context.Background(), sess)
@@ -572,11 +602,11 @@ func TestGetSessionSummaryText_UnmarshalError(t *testing.T) {
 	}
 
 	// Mock summary with invalid JSON
-	rows := sqlmock.NewRows([]string{"summary"}).
-		AddRow([]byte("invalid json"))
+	rows := sqlmock.NewRows([]string{"summary", "updated_at"}).
+		AddRow([]byte("invalid json"), time.Now())
 
-	mock.ExpectQuery("SELECT summary FROM session_summaries").
-		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg(), sess.CreatedAt).
+	mock.ExpectQuery("SELECT summary, updated_at FROM session_summaries").
+		WithArgs("test-app", "test-user", "test-session", "", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
 	text, ok := s.GetSessionSummaryText(context.Background(), sess)
@@ -609,10 +639,10 @@ func TestGetSessionSummaryText_WithFilterKey(t *testing.T) {
 	summaryBytes, _ := json.Marshal(summary)
 
 	// Mock: Query summary with specific filter key
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary FROM session_summaries")).
-		WithArgs(sess.AppName, sess.UserID, sess.ID, filterKey, sqlmock.AnyArg(), sess.CreatedAt).
-		WillReturnRows(sqlmock.NewRows([]string{"summary"}).
-			AddRow(summaryBytes))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary, updated_at FROM session_summaries")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID, filterKey, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}).
+			AddRow(summaryBytes, time.Now()))
 
 	text, found := s.GetSessionSummaryText(ctx, sess, session.WithSummaryFilterKey(filterKey))
 	assert.True(t, found)
@@ -635,16 +665,16 @@ func TestGetSessionSummaryText_FallbackToFullSession(t *testing.T) {
 	}
 
 	// First query for specific filter key returns no rows.
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary FROM session_summaries")).
-		WithArgs(sess.AppName, sess.UserID, sess.ID, "missing-key", sqlmock.AnyArg(), sess.CreatedAt).
-		WillReturnRows(sqlmock.NewRows([]string{"summary"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary, updated_at FROM session_summaries")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID, "missing-key", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}))
 
 	// Fallback query for full-session summary returns data.
 	fullSummary := session.Summary{Summary: "full summary text"}
 	fullBytes, _ := json.Marshal(fullSummary)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary FROM session_summaries")).
-		WithArgs(sess.AppName, sess.UserID, sess.ID, session.SummaryFilterKeyAllContents, sqlmock.AnyArg(), sess.CreatedAt).
-		WillReturnRows(sqlmock.NewRows([]string{"summary"}).AddRow(fullBytes))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary, updated_at FROM session_summaries")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID, session.SummaryFilterKeyAllContents, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}).AddRow(fullBytes, time.Now()))
 
 	text, found := s.GetSessionSummaryText(ctx, sess, session.WithSummaryFilterKey("missing-key"))
 	assert.True(t, found)
@@ -667,13 +697,13 @@ func TestGetSessionSummaryText_FallbackQueryError(t *testing.T) {
 	}
 
 	// First query for specific filter key returns no rows.
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary FROM session_summaries")).
-		WithArgs(sess.AppName, sess.UserID, sess.ID, "missing-key", sqlmock.AnyArg(), sess.CreatedAt).
-		WillReturnRows(sqlmock.NewRows([]string{"summary"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary, updated_at FROM session_summaries")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID, "missing-key", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"summary", "updated_at"}))
 
 	// Fallback query fails.
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary FROM session_summaries")).
-		WithArgs(sess.AppName, sess.UserID, sess.ID, session.SummaryFilterKeyAllContents, sqlmock.AnyArg(), sess.CreatedAt).
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT summary, updated_at FROM session_summaries")).
+		WithArgs(sess.AppName, sess.UserID, sess.ID, session.SummaryFilterKeyAllContents, sqlmock.AnyArg()).
 		WillReturnError(fmt.Errorf("fallback query error"))
 
 	text, found := s.GetSessionSummaryText(ctx, sess, session.WithSummaryFilterKey("missing-key"))


### PR DESCRIPTION
## What changed

Persisted session summaries remain available after a session is reloaded in a non-UTC environment. Freshness checks continue to reject summaries created before the current session instance.

## Why

PostgreSQL stores session and summary timestamps in `TIMESTAMP WITHOUT TIME ZONE` columns. Session creation timestamps use local wall-clock time, while summary cutoff timestamps are normalized to UTC. Because pgx discards timezone offsets when encoding these columns, the SQL freshness comparison can incorrectly classify an existing summary as stale.

The comparison now uses the absolute timestamps retained in the JSON payloads, with database-column timestamps retained as a fallback for legacy payloads. This avoids a schema migration and does not restore the global UTC conversion previously removed in #623.

## Testing

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Verified against PostgreSQL 16 with `Asia/Shanghai` as the client timezone.
- Verified summary creation and retrieval across two independent service connections after reloading the session.

## Notes for reviewers

- No exported API or database schema changes are introduced.
- Existing `TIMESTAMP WITHOUT TIME ZONE` schemas remain supported.
- Payloads without embedded timestamps fall back to the corresponding database columns.
- The regression tests cover timezone-offset preservation, stale-summary filtering, and the database-column fallback.

Fixes #2530 