### PR TITLE
memory/redis: enforce memory limit atomically

### DIFF
--- a/docs/mkdocs/en/memory/redis.md
+++ b/docs/mkdocs/en/memory/redis.md
@@ -28,12 +28,21 @@ if err != nil {
 
 **Note**: `WithRedisClientURL` takes priority over `WithRedisInstance`
 
-**Redis ACL requirement**: `UpdateMemory` uses a server-side Lua script to
-atomically validate and rotate memory IDs. ACL users must be allowed to run
-`EVALSHA` and `EVAL` (`EVAL` is required when the script is not yet cached), in
-addition to `HGET` and the script's `HEXISTS`, `HSET`, and `HDEL` commands and access to
-the configured memory-key pattern. Do not remove `EVAL` after warm-up because
-the Redis script cache can be cleared by a restart or `SCRIPT FLUSH`.
+**Redis ACL requirement**: The default per-user memory limit is `1000`. When the
+configured limit is positive, `AddMemory` uses a server-side Lua script to
+atomically check the capacity and write the memory. This script calls
+`HEXISTS`, `HLEN`, and `HSET`. `UpdateMemory` always uses a Lua script to
+atomically validate and rotate memory IDs; its update path uses `HGET`, and its
+script calls `HEXISTS`, `HSET`, and `HDEL`.
+
+ACL users must be allowed to run `EVALSHA` and `EVAL` (`EVAL` is required when
+a script is not yet cached), the commands used by both scripts, and access the
+configured memory-key pattern. Do not remove `EVAL` after warm-up because the
+Redis script cache can be cleared by a restart or `SCRIPT FLUSH`. Redis-compatible
+backends must support server-side Lua for these scripted paths.
+
+`WithMemoryLimit(0)` keeps `AddMemory` on the direct `HSET` path without a
+scripting dependency. `UpdateMemory` still uses Lua.
 
 **Key prefix example**:
 

--- a/docs/mkdocs/zh/memory/redis.md
+++ b/docs/mkdocs/zh/memory/redis.md
@@ -27,11 +27,19 @@ if err != nil {
 
 **注意**：`WithRedisClientURL` 优先级高于 `WithRedisInstance`
 
-**Redis ACL 要求**：`UpdateMemory` 使用服务端 Lua 脚本，以原子方式校验并
-轮换记忆 ID。除 `HGET`、脚本使用的 `HEXISTS`、`HSET`、`HDEL` 命令和对应记忆 key
-访问权限外，ACL 用户还必须具有 `EVALSHA` 和 `EVAL` 权限；脚本尚未缓存时
-需要 `EVAL`。Redis 重启或执行 `SCRIPT FLUSH` 后脚本缓存可能被清除，因此
-不能只在预热阶段临时授予 `EVAL`。
+**Redis ACL 要求**：默认的每用户记忆上限为 `1000`。配置的上限为正数时，
+`AddMemory` 使用服务端 Lua 脚本，以原子方式检查容量并写入记忆；该脚本使用
+`HEXISTS`、`HLEN` 和 `HSET`。`UpdateMemory` 始终使用 Lua 脚本，以原子方式
+校验并轮换记忆 ID；其更新路径使用 `HGET`，脚本使用 `HEXISTS`、`HSET` 和
+`HDEL`。
+
+ACL 用户必须具有 `EVALSHA` 和 `EVAL` 权限（脚本尚未缓存时需要 `EVAL`）、
+两份脚本所用命令的权限，以及对应记忆 key 的访问权限。Redis 重启或执行
+`SCRIPT FLUSH` 后脚本缓存可能被清除，因此不能只在预热阶段临时授予 `EVAL`。
+在这些脚本路径下使用 Redis 兼容后端时，必须确认后端支持服务端 Lua。
+
+`WithMemoryLimit(0)` 会让 `AddMemory` 保持直接执行 `HSET` 的路径，不依赖
+Lua 脚本；`UpdateMemory` 仍然使用 Lua。
 
 **Key 前缀示例**：
 

--- a/memory/redis/service.go
+++ b/memory/redis/service.go
@@ -31,12 +31,34 @@ const (
 	// defaultConnectionTimeout is the default timeout for Redis connection test.
 	defaultConnectionTimeout = 5 * time.Second
 
+	addMemoryResultSuccess = 0
+
 	updateMemoryResultNotFound = 0
 	updateMemoryResultSuccess  = 1
 	updateMemoryResultConflict = 2
 )
 
 var _ memory.Service = (*Service)(nil)
+
+// luaAddMemory atomically enforces the per-user limit for new memory IDs while
+// allowing an existing ID to be overwritten idempotently. A positive result is
+// the current memory count when the limit has been reached.
+var luaAddMemory = redis.NewScript(`
+local key = KEYS[1]
+local memoryID = ARGV[1]
+local entryJSON = ARGV[2]
+local memoryLimit = tonumber(ARGV[3])
+
+if redis.call('HEXISTS', key, memoryID) == 0 then
+    local count = redis.call('HLEN', key)
+    if count >= memoryLimit then
+        return count
+    end
+end
+
+redis.call('HSET', key, memoryID, entryJSON)
+return 0
+`)
 
 // luaUpdateMemory atomically updates a memory hash field and, when its
 // canonical ID changes, rejects an existing target before rotating the field.
@@ -156,17 +178,6 @@ func (s *Service) AddMemory(ctx context.Context, userKey memory.UserKey, memoryS
 	}
 	key := s.getUserMemKey(userKey)
 
-	if s.opts.memoryLimit > 0 {
-		count, err := s.redisClient.HLen(ctx, key).Result()
-		if err != nil && err != redis.Nil {
-			return fmt.Errorf("redis memory service check memory count failed: %w", err)
-		}
-		if int(count) >= s.opts.memoryLimit {
-			return fmt.Errorf("memory limit exceeded for user %s, limit: %d, current: %d",
-				userKey.UserID, s.opts.memoryLimit, count)
-		}
-	}
-
 	now := time.Now()
 	mem := &memory.Memory{
 		Memory:      memoryStr,
@@ -186,6 +197,28 @@ func (s *Service) AddMemory(ctx context.Context, userKey memory.UserKey, memoryS
 	bytes, err := json.Marshal(entry)
 	if err != nil {
 		return fmt.Errorf("marshal memory entry failed: %w", err)
+	}
+	if s.opts.memoryLimit > 0 {
+		scriptResult, err := luaAddMemory.Run(
+			ctx,
+			s.redisClient,
+			[]string{key},
+			entry.ID,
+			string(bytes),
+			s.opts.memoryLimit,
+		).Int()
+		if err != nil {
+			return fmt.Errorf("store memory entry failed: %w", err)
+		}
+		switch {
+		case scriptResult == addMemoryResultSuccess:
+			return nil
+		case scriptResult > addMemoryResultSuccess:
+			return fmt.Errorf("memory limit exceeded for user %s, limit: %d, current: %d",
+				userKey.UserID, s.opts.memoryLimit, scriptResult)
+		default:
+			return fmt.Errorf("add memory entry returned unexpected result %d", scriptResult)
+		}
 	}
 	if err := s.redisClient.HSet(ctx, key, entry.ID, bytes).Err(); err != nil {
 		return fmt.Errorf("store memory entry failed: %w", err)

--- a/memory/redis/service_test.go
+++ b/memory/redis/service_test.go
@@ -32,14 +32,58 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 )
 
+// memoryLimitRaceHook makes legacy top-level HLEN calls observe the same
+// pre-write count. The atomic Lua path does not issue top-level HLEN commands.
+type memoryLimitRaceHook struct {
+	expected int
+	mu       sync.Mutex
+	seen     int
+	ready    chan struct{}
+}
+
 type rotationRaceHook struct {
 	once   sync.Once
 	inject func()
 }
 
-type updateMemoryScriptHook struct {
+type memoryScriptHook struct {
 	result int64
 	err    error
+}
+
+func (h *memoryLimitRaceHook) DialHook(next goredis.DialHook) goredis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return next(ctx, network, addr)
+	}
+}
+
+func (h *memoryLimitRaceHook) ProcessHook(next goredis.ProcessHook) goredis.ProcessHook {
+	return func(ctx context.Context, cmd goredis.Cmder) error {
+		err := next(ctx, cmd)
+		if err != nil || cmd.Name() != "hlen" {
+			return err
+		}
+
+		h.mu.Lock()
+		h.seen++
+		if h.seen == h.expected {
+			close(h.ready)
+		}
+		h.mu.Unlock()
+
+		select {
+		case <-h.ready:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (h *memoryLimitRaceHook) ProcessPipelineHook(
+	next goredis.ProcessPipelineHook,
+) goredis.ProcessPipelineHook {
+	return next
 }
 
 func (h *rotationRaceHook) DialHook(next goredis.DialHook) goredis.DialHook {
@@ -73,13 +117,13 @@ func (h *rotationRaceHook) ProcessPipelineHook(next goredis.ProcessPipelineHook)
 	}
 }
 
-func (h *updateMemoryScriptHook) DialHook(next goredis.DialHook) goredis.DialHook {
+func (h *memoryScriptHook) DialHook(next goredis.DialHook) goredis.DialHook {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		return next(ctx, network, addr)
 	}
 }
 
-func (h *updateMemoryScriptHook) ProcessHook(next goredis.ProcessHook) goredis.ProcessHook {
+func (h *memoryScriptHook) ProcessHook(next goredis.ProcessHook) goredis.ProcessHook {
 	return func(ctx context.Context, cmd goredis.Cmder) error {
 		switch cmd.Name() {
 		case "eval", "evalsha":
@@ -98,7 +142,7 @@ func (h *updateMemoryScriptHook) ProcessHook(next goredis.ProcessHook) goredis.P
 	}
 }
 
-func (h *updateMemoryScriptHook) ProcessPipelineHook(
+func (h *memoryScriptHook) ProcessPipelineHook(
 	next goredis.ProcessPipelineHook,
 ) goredis.ProcessPipelineHook {
 	return next
@@ -630,7 +674,7 @@ func TestService_UpdateMemory_ScriptFailureLeavesResultUntouched(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 
-	svc.redisClient.AddHook(&updateMemoryScriptHook{
+	svc.redisClient.AddHook(&memoryScriptHook{
 		err: fmt.Errorf("script failed"),
 	})
 	result := &memory.UpdateResult{MemoryID: "unchanged"}
@@ -698,7 +742,7 @@ func TestService_UpdateMemory_UnexpectedScriptResult(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 
-	svc.redisClient.AddHook(&updateMemoryScriptHook{result: 99})
+	svc.redisClient.AddHook(&memoryScriptHook{result: 99})
 	result := &memory.UpdateResult{MemoryID: "unchanged"}
 	err = svc.UpdateMemory(
 		ctx,
@@ -779,10 +823,97 @@ func TestService_MemoryLimit(t *testing.T) {
 	ctx := context.Background()
 	userKey := memory.UserKey{AppName: "test-app", UserID: "u1"}
 
-	require.NoError(t, svc.AddMemory(ctx, userKey, "first", nil))
+	require.NoError(t, svc.AddMemory(ctx, userKey, "first", []string{"original"}))
+	require.NoError(t, svc.AddMemory(ctx, userKey, "first", []string{"updated"}))
+	entries, err := svc.ReadMemories(ctx, userKey, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, []string{"updated"}, entries[0].Memory.Topics)
+
 	err = svc.AddMemory(ctx, userKey, "second", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "memory limit exceeded")
+}
+
+func TestService_MemoryLimitConcurrentAddIsAtomic(t *testing.T) {
+	const concurrentAdds = 8
+
+	url, cleanup := setupTestRedis(t)
+	defer cleanup()
+	svc, err := NewService(WithRedisClientURL(url), WithMemoryLimit(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	svc.redisClient.AddHook(&memoryLimitRaceHook{
+		expected: concurrentAdds,
+		ready:    make(chan struct{}),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	userKey := memory.UserKey{AppName: "test-app", UserID: "concurrent-user"}
+	start := make(chan struct{})
+	errorsCh := make(chan error, concurrentAdds)
+	var waitGroup sync.WaitGroup
+	for i := 0; i < concurrentAdds; i++ {
+		waitGroup.Add(1)
+		go func(index int) {
+			defer waitGroup.Done()
+			<-start
+			errorsCh <- svc.AddMemory(ctx, userKey, fmt.Sprintf("memory-%d", index), nil)
+		}(i)
+	}
+	close(start)
+	waitGroup.Wait()
+	close(errorsCh)
+
+	var successes int
+	for err := range errorsCh {
+		if err == nil {
+			successes++
+			continue
+		}
+		require.ErrorContains(t, err, "memory limit exceeded")
+	}
+	require.Equal(t, 1, successes)
+
+	entries, err := svc.ReadMemories(ctx, userKey, concurrentAdds)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}
+
+func TestService_AddMemory_ScriptFailure(t *testing.T) {
+	url, cleanup := setupTestRedis(t)
+	defer cleanup()
+	svc, err := NewService(WithRedisClientURL(url), WithMemoryLimit(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	svc.redisClient.AddHook(&memoryScriptHook{err: fmt.Errorf("script failed")})
+	err = svc.AddMemory(
+		context.Background(),
+		memory.UserKey{AppName: "test-app", UserID: "u1"},
+		"memory",
+		nil,
+	)
+	require.ErrorContains(t, err, "store memory entry failed")
+}
+
+func TestService_AddMemory_UnexpectedScriptResult(t *testing.T) {
+	url, cleanup := setupTestRedis(t)
+	defer cleanup()
+	svc, err := NewService(WithRedisClientURL(url), WithMemoryLimit(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, svc.Close()) }()
+
+	svc.redisClient.AddHook(&memoryScriptHook{result: -1})
+	err = svc.AddMemory(
+		context.Background(),
+		memory.UserKey{AppName: "test-app", UserID: "u1"},
+		"memory",
+		nil,
+	)
+	require.ErrorContains(t, err, "unexpected result -1")
 }
 
 func TestService_Tools_DefaultEnabled(t *testing.T) {


### PR DESCRIPTION
## What changed

`AddMemory` now enforces the per-user memory limit atomically during concurrent writes.

Concurrent additions of different memory IDs cannot exceed the configured limit. Overwriting an existing memory ID remains idempotent and does not require additional capacity. The unlimited-memory path remains unchanged.

## Why

The previous implementation performed `HLEN` and `HSET` as separate Redis commands. Concurrent callers could observe the same available capacity, pass the limit check, and then write different entries, causing the final memory count to exceed the configured limit.

The capacity check and write are now performed in a single Lua script using `HEXISTS`, `HLEN`, and `HSET`.

## Testing

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Added a concurrent regression test with eight callers and a limit of one, verifying that only one new memory is stored.
- Verified that an existing memory ID can still be overwritten when the limit is full.
- Covered script execution errors and unexpected script results.

## Notes for reviewers

- No exported API, Redis key format, or serialized data format changes are introduced.
- The Lua script operates on a single Redis hash key.
- `WithMemoryLimit(0)` continues to bypass capacity enforcement.
- Existing memory IDs remain overwritable at full capacity.

Fixes #2532 