### PR TITLE
tool: fix misleading mergeArrays doc comment and typo

### DIFF
--- a/tool/merge.go
+++ b/tool/merge.go
@@ -164,14 +164,18 @@ func mergeSlices[T any](ts []T) T {
 	return result.Interface().(T)
 }
 
-// mergeArrays concatenates array values into a new array
+// mergeArrays returns the first array element. Arrays have a fixed length, so
+// multiple arrays cannot be concatenated into a single array of the same type
+// without changing the result's length; the remaining elements are therefore
+// intentionally discarded. Use slices instead when a variable-length result is
+// required.
 func mergeArrays[T any](ts []T) T {
 	if len(ts) == 0 {
 		var zero T
 		return zero
 	}
 	// Note: Arrays are fixed size, so we assume all arrays in ts are of the same type and size.
-	// Plsease use slices if you need dynamic size.
+	// Please use slices if you need dynamic size.
 	return ts[0]
 }
 

--- a/tool/merge.go
+++ b/tool/merge.go
@@ -164,11 +164,11 @@ func mergeSlices[T any](ts []T) T {
 	return result.Interface().(T)
 }
 
-// mergeArrays returns the first array element. Arrays have a fixed length, so
-// multiple arrays cannot be concatenated into a single array of the same type
-// without changing the result's length; the remaining elements are therefore
-// intentionally discarded. Use slices instead when a variable-length result is
-// required.
+// mergeArrays returns the first array in ts when ts is non-empty, or the zero
+// value of T otherwise. Arrays have a fixed length, so multiple arrays cannot
+// be concatenated into a single array of the same type without changing the
+// result's length; the remaining input arrays are therefore intentionally
+// discarded. Use slices instead when a variable-length result is required.
 func mergeArrays[T any](ts []T) T {
 	if len(ts) == 0 {
 		var zero T


### PR DESCRIPTION
The mergeArrays doc comment claimed the function concatenates array values into a new array, but the implementation returns only the first element. Correct the comment to describe the actual behavior and fix the 'Plsease' typo.

<!-- markdownlint-disable MD041 -->

<!--
Write the pull request title and description in English.

The title must identify the primary affected package or repository area.

Preferred form:
  package: lowercase summary

For multiple equally affected packages:
  {package/a, package/b}: lowercase summary

For a coherent cross-cutting change spanning many packages with no primary
package:
  lsc: lowercase summary
-->

## What changed

Summarize the outcome and its user or developer impact. Do not restate the
implementation or enumerate changed files.

## Why

Explain the problem and any non-obvious design rationale.

## Testing

List the automated and manual validation that was actually performed. If a
check is not applicable, explain why.

## Notes for reviewers

Optionally call out risks or design decisions that are not obvious from the
diff, such as public API, compatibility, concurrency, persistence, protocol, or
security concerns.
