### PR TITLE
internal/flow/llmflow: snapshot completed response events

### DIFF
--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1321,10 +1321,14 @@ func (f *Flow) createLLMResponseEvent(
 		invocationID = eventInvocation.InvocationID
 		agentName = eventInvocation.AgentName
 	}
+	eventResponse := response
+	if !response.IsPartial {
+		eventResponse = response.Clone()
+	}
 	llmResponseEvent := event.New(
 		invocationID,
 		agentName,
-		event.WithResponse(response),
+		event.WithResponse(eventResponse),
 	)
 	applyPartialEventMetadataOverrides(
 		llmResponseEvent,

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -467,6 +467,19 @@ func TestCreateLLMResponseEvent_LongRunningIDs(t *testing.T) {
 	require.Contains(t, evt.LongRunningToolIDs, "x")
 }
 
+func TestCreateLLMResponseEvent_PreservesPublishedCompletedResponse(t *testing.T) {
+	f := New(nil, nil, Options{})
+	inv := agent.NewInvocation()
+	rsp := &model.Response{Choices: []model.Choice{{Message: model.Message{
+		Content: "published response",
+	}}}}
+
+	evt := f.createLLMResponseEvent(inv, inv, rsp, &model.Request{})
+	rsp.Choices[0].Message.Content = "mutated after publication"
+
+	require.Equal(t, "published response", evt.Response.Choices[0].Message.Content)
+}
+
 func TestMaybeConsumeQueuedUserMessages_NoQueue(t *testing.T) {
 	f := New(nil, nil, Options{})
 	inv := agent.NewInvocation()


### PR DESCRIPTION
## What changed

Completed LLM response events now retain a snapshot of the response that was published. Later response processors can still update the original response for internal flow control, but cannot mutate the already-emitted event.

## Why

`CodeExecutionResponseProcessor` clears completed response content after the response event is emitted. The event and asynchronous telemetry previously shared the same `*model.Response`, making downstream event content non-deterministic and racing telemetry reads.

Cloning only completed responses at the publication boundary keeps partial streaming events on their existing allocation path.

Fixes #2539

## Testing

- `go test -count=1 ./internal/flow/llmflow`
- `go test -count=1 -run TestLLMAgent_EnableCodeExecutionResponseProcessor ./agent/llmagent/`
- `go vet ./internal/flow/llmflow ./agent/llmagent`
- `go build ./...`
- `gofmt -l internal/flow/llmflow/llmflow.go internal/flow/llmflow/llmflow_test.go`
- `git diff --check HEAD^ HEAD`

The full repository suite has pre-existing Windows environment-dependent failures; a representative workspace failure was reproduced on a clean upstream baseline. The local environment has no CGO C compiler, so the race detector was not available.

## Notes for reviewers

No exported API, persistence format, or protocol behavior changes. The regression test verifies that a completed response event remains unchanged after the original response is subsequently mutated.