### PR TITLE
internal/flow/processor: return replacement responses instead of mutating published ones

### DIFF
--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -33,6 +33,10 @@ type RequestProcessor interface {
 
 // ResponseProcessor processes LLM responses after they are received from the model.
 type ResponseProcessor interface {
-	// ProcessResponse processes the response and sends events directly to the provided channel.
-	ProcessResponse(ctx context.Context, invocation *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event)
+	// ProcessResponse processes the response and sends events directly to the
+	// provided channel. It returns the response to be used by later processing
+	// stages. Processors that need to alter the response must return a
+	// replacement instead of mutating the shared response, which may already be
+	// published inside an emitted event and read concurrently.
+	ProcessResponse(ctx context.Context, invocation *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) *model.Response
 }

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -1003,7 +1003,7 @@ func (p *streamingResponseProcessor) process(
 		responseErr = err
 		return false
 	}
-	p.flow.postprocessWithLatencySpans(
+	response = p.flow.postprocessWithLatencySpans(
 		p.ctx,
 		eventInvocation,
 		p.llmRequest,
@@ -3016,7 +3016,7 @@ func (f *Flow) postprocess(
 	llmResponse *model.Response,
 	eventChan chan<- *event.Event,
 ) {
-	f.postprocessWithLatencySpans(
+	llmResponse = f.postprocessWithLatencySpans(
 		ctx,
 		invocation,
 		llmRequest,
@@ -3033,7 +3033,7 @@ func (f *Flow) postprocessWithLatencySpans(
 	llmResponse *model.Response,
 	eventChan chan<- *event.Event,
 	traceDetails bool,
-) {
+) *model.Response {
 	if !traceDetails {
 		for _, processor := range f.responseProcessors {
 			llmResponse = processor.ProcessResponse(
@@ -3044,7 +3044,7 @@ func (f *Flow) postprocessWithLatencySpans(
 				eventChan,
 			)
 		}
-		return
+		return llmResponse
 	}
 	ctx, span, started := startLatencySpan(
 		ctx,
@@ -3064,7 +3064,7 @@ func (f *Flow) postprocessWithLatencySpans(
 		finishLatencySpan(span, started, nil)
 	}()
 	if llmResponse == nil {
-		return
+		return nil
 	}
 
 	// Run response processors - they send events directly to the channel.
@@ -3090,6 +3090,7 @@ func (f *Flow) postprocessWithLatencySpans(
 		)
 		finishLatencySpan(stageSpan, stageStarted, nil)
 	}
+	return llmResponse
 }
 
 // WaitEventTimeout returns the remaining time until the context deadline.

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -3009,14 +3009,15 @@ func normalizeResponseID(resp *model.Response, currentID *string) *model.Respons
 }
 
 // postprocess handles post-LLM call processing using response processors.
+// It returns the (possibly replaced) response produced by the processors.
 func (f *Flow) postprocess(
 	ctx context.Context,
 	invocation *agent.Invocation,
 	llmRequest *model.Request,
 	llmResponse *model.Response,
 	eventChan chan<- *event.Event,
-) {
-	llmResponse = f.postprocessWithLatencySpans(
+) *model.Response {
+	return f.postprocessWithLatencySpans(
 		ctx,
 		invocation,
 		llmRequest,

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -3036,7 +3036,7 @@ func (f *Flow) postprocessWithLatencySpans(
 ) {
 	if !traceDetails {
 		for _, processor := range f.responseProcessors {
-			processor.ProcessResponse(
+			llmResponse = processor.ProcessResponse(
 				ctx,
 				invocation,
 				llmRequest,
@@ -3081,7 +3081,7 @@ func (f *Flow) postprocessWithLatencySpans(
 				latencyProcessorName(processor),
 			),
 		)
-		processor.ProcessResponse(
+		llmResponse = processor.ProcessResponse(
 			stageCtx,
 			invocation,
 			llmRequest,

--- a/internal/flow/llmflow/llmflow.go
+++ b/internal/flow/llmflow/llmflow.go
@@ -3027,6 +3027,9 @@ func (f *Flow) postprocess(
 	)
 }
 
+// postprocessWithLatencySpans runs response processors, optionally wrapping each
+// in a latency-tracking span. It returns the (possibly replaced) response
+// produced by the last processor in the chain.
 func (f *Flow) postprocessWithLatencySpans(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/llmflow/llmflow_endinvocation_test.go
+++ b/internal/flow/llmflow/llmflow_endinvocation_test.go
@@ -96,6 +96,8 @@ func (m *twoChunkModel) GenerateContent(ctx context.Context, req *model.Request)
 // endOnFirstChunkProcessor sets EndInvocation on the first response.
 type endOnFirstChunkProcessor struct{ done bool }
 
+// ProcessResponse sets EndInvocation on the first call and returns the
+// original response unchanged.
 func (p *endOnFirstChunkProcessor) ProcessResponse(ctx context.Context, inv *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) *model.Response {
 	if !p.done {
 		inv.EndInvocation = true

--- a/internal/flow/llmflow/llmflow_endinvocation_test.go
+++ b/internal/flow/llmflow/llmflow_endinvocation_test.go
@@ -96,11 +96,12 @@ func (m *twoChunkModel) GenerateContent(ctx context.Context, req *model.Request)
 // endOnFirstChunkProcessor sets EndInvocation on the first response.
 type endOnFirstChunkProcessor struct{ done bool }
 
-func (p *endOnFirstChunkProcessor) ProcessResponse(ctx context.Context, inv *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) {
+func (p *endOnFirstChunkProcessor) ProcessResponse(ctx context.Context, inv *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) *model.Response {
 	if !p.done {
 		inv.EndInvocation = true
 		p.done = true
 	}
+	return rsp
 }
 
 func TestStreaming_BreaksWhenEndInvocationSet(t *testing.T) {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -4611,6 +4611,21 @@ done:
 	require.Equal(t, 1, count)
 }
 
+func TestFlow_Postprocess_NilResponse(t *testing.T) {
+	f := New(nil, []flow.ResponseProcessor{&mockResponseProcessor{}}, Options{})
+
+	ctx := context.Background()
+	inv := agent.NewInvocation()
+	req := &model.Request{}
+	eventCh := make(chan *event.Event, 2)
+
+	// Should not panic and should not emit events when the response is nil.
+	require.NotPanics(t, func() {
+		f.postprocess(ctx, inv, req, nil, eventCh)
+	})
+	require.Empty(t, eventCh)
+}
+
 // Test that when RunOptions.Resume is enabled and the latest session event
 // is an assistant tool_call response, the flow executes the pending tool
 // before issuing a new LLM request.

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -2791,13 +2791,14 @@ func (m *mockResponseProcessor) ProcessResponse(
 	req *model.Request,
 	resp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	evt := event.New(invocation.InvocationID, invocation.AgentName)
 	evt.Object = "postprocessing"
 	select {
 	case ch <- evt:
 	default:
 	}
+	return resp
 }
 
 type cancelResponseProcessor struct {
@@ -2810,8 +2811,9 @@ func (c *cancelResponseProcessor) ProcessResponse(
 	req *model.Request,
 	resp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	c.cancel()
+	return resp
 }
 
 type endInvocationResponseProcessor struct{}
@@ -2822,10 +2824,11 @@ func (p *endInvocationResponseProcessor) ProcessResponse(
 	req *model.Request,
 	resp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	if invocation != nil {
 		invocation.EndInvocation = true
 	}
+	return resp
 }
 
 func TestFlow_Interface(t *testing.T) {

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -2785,6 +2785,7 @@ func (p *panicRequestProcessor) ProcessRequest(
 // mockResponseProcessor implements flow.ResponseProcessor
 type mockResponseProcessor struct{}
 
+// ProcessResponse emits a "postprocessing" event and returns the original response.
 func (m *mockResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -2801,10 +2802,13 @@ func (m *mockResponseProcessor) ProcessResponse(
 	return resp
 }
 
+// cancelResponseProcessor is a test stub that cancels the context during
+// response processing to exercise cancellation paths.
 type cancelResponseProcessor struct {
 	cancel context.CancelFunc
 }
 
+// ProcessResponse cancels the associated context and returns the original response.
 func (c *cancelResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,
@@ -2816,8 +2820,11 @@ func (c *cancelResponseProcessor) ProcessResponse(
 	return resp
 }
 
+// endInvocationResponseProcessor is a test stub that sets EndInvocation on
+// each response to terminate the flow after the first postprocessing step.
 type endInvocationResponseProcessor struct{}
 
+// ProcessResponse sets invocation.EndInvocation and returns the original response.
 func (p *endInvocationResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/llmflow/llmflow_test.go
+++ b/internal/flow/llmflow/llmflow_test.go
@@ -4595,7 +4595,7 @@ func TestFlow_Postprocess_WithProcessor(t *testing.T) {
 	}
 	eventCh := make(chan *event.Event, 2)
 
-	f.postprocess(ctx, inv, req, resp, eventCh)
+	got := f.postprocess(ctx, inv, req, resp, eventCh)
 
 	var count int
 	for {
@@ -4609,6 +4609,7 @@ func TestFlow_Postprocess_WithProcessor(t *testing.T) {
 
 done:
 	require.Equal(t, 1, count)
+	require.Same(t, resp, got)
 }
 
 func TestFlow_Postprocess_NilResponse(t *testing.T) {
@@ -4620,9 +4621,11 @@ func TestFlow_Postprocess_NilResponse(t *testing.T) {
 	eventCh := make(chan *event.Event, 2)
 
 	// Should not panic and should not emit events when the response is nil.
+	var got *model.Response
 	require.NotPanics(t, func() {
-		f.postprocess(ctx, inv, req, nil, eventCh)
+		got = f.postprocess(ctx, inv, req, nil, eventCh)
 	})
+	require.Nil(t, got)
 	require.Empty(t, eventCh)
 }
 

--- a/internal/flow/processor/codeexecution.go
+++ b/internal/flow/processor/codeexecution.go
@@ -50,7 +50,9 @@ func NewCodeExecutionResponseProcessor() *CodeExecutionResponseProcessor {
 }
 
 // ProcessResponse processes the model response, extracts code blocks, executes them,
-// and emits events for the code execution result.
+// and emits events for the code execution result. It returns a cleared-content
+// clone of the response when execution succeeds (to avoid mutating the shared
+// response), or the original response unchanged when execution is skipped or fails.
 func (p *CodeExecutionResponseProcessor) ProcessResponse(
 	ctx context.Context, invocation *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) *model.Response {
 	if invocation == nil || rsp == nil || rsp.IsPartial {

--- a/internal/flow/processor/codeexecution.go
+++ b/internal/flow/processor/codeexecution.go
@@ -52,20 +52,20 @@ func NewCodeExecutionResponseProcessor() *CodeExecutionResponseProcessor {
 // ProcessResponse processes the model response, extracts code blocks, executes them,
 // and emits events for the code execution result.
 func (p *CodeExecutionResponseProcessor) ProcessResponse(
-	ctx context.Context, invocation *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) {
+	ctx context.Context, invocation *agent.Invocation, req *model.Request, rsp *model.Response, ch chan<- *event.Event) *model.Response {
 	if invocation == nil || rsp == nil || rsp.IsPartial {
-		return
+		return rsp
 	}
 	if calllimit.Active(invocation) {
-		return
+		return rsp
 	}
 	e := codeExecutorForInvocation(invocation)
 	if e == nil {
-		return
+		return rsp
 	}
 
 	if len(rsp.Choices) == 0 {
-		return
+		return rsp
 	}
 
 	content := rsp.Choices[0].Message.Content
@@ -74,7 +74,7 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 		e.CodeBlockDelimiter(),
 	)
 	if len(codeBlocks) == 0 {
-		return
+		return rsp
 	}
 	truncatedContent := content // todo: truncate the content
 
@@ -111,7 +111,7 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 			event.WithObject(model.ObjectTypePostprocessingCodeExecution),
 			event.WithTag(event.CodeExecutionResultTag), // Add tag for error result
 		))
-		return
+		return rsp
 	}
 	agent.EmitEvent(ctx, invocation, ch, event.New(
 		invocation.InvocationID,
@@ -127,7 +127,14 @@ func (p *CodeExecutionResponseProcessor) ProcessResponse(
 		event.WithTag(event.CodeExecutionResultTag),
 	))
 	//  [Step 3] Skip processing the original model response to continue code generation loop.
-	rsp.Choices[0].Message.Content = ""
+	// Do not mutate the shared response in place: it is already published inside
+	// the emitted LLM response event and may be read concurrently by telemetry
+	// trackers. Return a cleared clone for downstream stages instead.
+	cleared := rsp.Clone()
+	if len(cleared.Choices) > 0 {
+		cleared.Choices[0].Message.Content = ""
+	}
+	return cleared
 }
 
 func codeExecutorForInvocation(

--- a/internal/flow/processor/codeexecution_test.go
+++ b/internal/flow/processor/codeexecution_test.go
@@ -338,8 +338,11 @@ func (a *testAgent) FindSubAgent(name string) agent.Agent { return nil }
 
 func (a *testAgent) CodeExecutor() codeexecutor.CodeExecutor { return a.exec }
 
+// errExec is a test stub whose ExecuteCode always returns an error.
+// It records the number of times it has been called in calls.
 type errExec struct{ calls int }
 
+// ExecuteCode increments the call counter and returns a fixed error.
 func (e *errExec) ExecuteCode(
 	ctx context.Context, input codeexecutor.CodeExecutionInput,
 ) (codeexecutor.CodeExecutionResult, error) {
@@ -347,6 +350,7 @@ func (e *errExec) ExecuteCode(
 	return codeexecutor.CodeExecutionResult{}, errors.New("exec failed")
 }
 
+// CodeBlockDelimiter returns the default triple-backtick code block delimiter.
 func (e *errExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
 	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
 }

--- a/internal/flow/processor/codeexecution_test.go
+++ b/internal/flow/processor/codeexecution_test.go
@@ -397,4 +397,5 @@ func TestCodeExecutionResponseProcessor_ExecutionErrorReturnsOriginal(t *testing
 	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 2))
 	require.Same(t, rsp, got)
 	require.Equal(t, content, rsp.Choices[0].Message.Content)
+	require.Equal(t, 1, exec.calls)
 }

--- a/internal/flow/processor/codeexecution_test.go
+++ b/internal/flow/processor/codeexecution_test.go
@@ -12,6 +12,7 @@ package processor_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -336,3 +337,64 @@ func (a *testAgent) SubAgents() []agent.Agent             { return nil }
 func (a *testAgent) FindSubAgent(name string) agent.Agent { return nil }
 
 func (a *testAgent) CodeExecutor() codeexecutor.CodeExecutor { return a.exec }
+
+type errExec struct{ calls int }
+
+func (e *errExec) ExecuteCode(
+	ctx context.Context, input codeexecutor.CodeExecutionInput,
+) (codeexecutor.CodeExecutionResult, error) {
+	e.calls++
+	return codeexecutor.CodeExecutionResult{}, errors.New("exec failed")
+}
+
+func (e *errExec) CodeBlockDelimiter() codeexecutor.CodeBlockDelimiter {
+	return codeexecutor.CodeBlockDelimiter{Start: "```", End: "```"}
+}
+
+func TestCodeExecutionResponseProcessor_NilInvocation(t *testing.T) {
+	proc := iprocessor.NewCodeExecutionResponseProcessor()
+	rsp := &model.Response{Choices: []model.Choice{{Message: model.Message{Content: "x"}}}}
+	got := proc.ProcessResponse(context.Background(), nil, nil, rsp, make(chan *event.Event, 1))
+	require.Same(t, rsp, got)
+}
+
+func TestCodeExecutionResponseProcessor_NoExecutorConfigured(t *testing.T) {
+	proc := iprocessor.NewCodeExecutionResponseProcessor()
+	inv := &agent.Invocation{
+		Agent:     &testAgent{exec: nil},
+		Session:   &session.Session{ID: "s"},
+		AgentName: "test-agent",
+	}
+	rsp := &model.Response{Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "```bash\necho hi\n```"}}}}
+	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 1))
+	require.Same(t, rsp, got)
+}
+
+func TestCodeExecutionResponseProcessor_EmptyChoices(t *testing.T) {
+	proc := iprocessor.NewCodeExecutionResponseProcessor()
+	exec := &stubExec{}
+	inv := &agent.Invocation{
+		Agent:     &testAgent{exec: exec},
+		Session:   &session.Session{ID: "s"},
+		AgentName: "test-agent",
+	}
+	rsp := &model.Response{}
+	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 1))
+	require.Same(t, rsp, got)
+	require.Zero(t, exec.calls)
+}
+
+func TestCodeExecutionResponseProcessor_ExecutionErrorReturnsOriginal(t *testing.T) {
+	proc := iprocessor.NewCodeExecutionResponseProcessor()
+	exec := &errExec{}
+	inv := &agent.Invocation{
+		Agent:     &testAgent{exec: exec},
+		Session:   &session.Session{ID: "s"},
+		AgentName: "test-agent",
+	}
+	content := "```bash\necho hi\n```"
+	rsp := &model.Response{Done: true, Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: content}}}}
+	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 2))
+	require.Same(t, rsp, got)
+	require.Equal(t, content, rsp.Choices[0].Message.Content)
+}

--- a/internal/flow/processor/codeexecution_test.go
+++ b/internal/flow/processor/codeexecution_test.go
@@ -47,10 +47,14 @@ func TestCodeExecutionResponseProcessor_EmitsCodeAndResultEvents(t *testing.T) {
 	}
 
 	ch := make(chan *event.Event, 4)
-	proc.ProcessResponse(ctx, inv, &model.Request{}, rsp, ch)
+	cleared := proc.ProcessResponse(ctx, inv, &model.Request{}, rsp, ch)
 
-	if assert.NotEmpty(t, rsp.Choices) {
-		assert.Equal(t, "", rsp.Choices[0].Message.Content)
+	// The shared response must stay intact: it may already be published in an
+	// emitted event and read by telemetry trackers. The cleared replacement is
+	// returned for downstream processing stages instead.
+	assert.Equal(t, "```bash\necho hello\n```", rsp.Choices[0].Message.Content)
+	if assert.NotNil(t, cleared) && assert.NotEmpty(t, cleared.Choices) {
+		assert.Equal(t, "", cleared.Choices[0].Message.Content)
 	}
 	var evts []*event.Event
 	for len(ch) > 0 {

--- a/internal/flow/processor/conditional.go
+++ b/internal/flow/processor/conditional.go
@@ -71,7 +71,9 @@ func NewConditionalResponseProcessor(
 	}
 }
 
-// ProcessResponse runs the wrapped response processor only when enabled for this invocation.
+// ProcessResponse runs the wrapped response processor only when enabled for
+// this invocation. It returns the (possibly replaced) response from the
+// delegate, or the original response when the predicate is false.
 func (p *ConditionalResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/conditional.go
+++ b/internal/flow/processor/conditional.go
@@ -78,12 +78,12 @@ func (p *ConditionalResponseProcessor) ProcessResponse(
 	req *model.Request,
 	rsp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	if p == nil || p.delegate == nil {
-		return
+		return rsp
 	}
 	if p.predicate != nil && !p.predicate(ctx, invocation) {
-		return
+		return rsp
 	}
-	p.delegate.ProcessResponse(ctx, invocation, req, rsp, ch)
+	return p.delegate.ProcessResponse(ctx, invocation, req, rsp, ch)
 }

--- a/internal/flow/processor/conditional_test.go
+++ b/internal/flow/processor/conditional_test.go
@@ -31,10 +31,13 @@ func (p *conditionalRequestProcessorStub) ProcessRequest(
 	p.called = true
 }
 
+// conditionalResponseProcessorStub is a test stub that records whether
+// ProcessResponse was invoked.
 type conditionalResponseProcessorStub struct {
 	called bool
 }
 
+// ProcessResponse marks the stub as called and returns the original response.
 func (p *conditionalResponseProcessorStub) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/conditional_test.go
+++ b/internal/flow/processor/conditional_test.go
@@ -41,8 +41,9 @@ func (p *conditionalResponseProcessorStub) ProcessResponse(
 	req *model.Request,
 	rsp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	p.called = true
+	return rsp
 }
 
 func TestConditionalRequestProcessor_ProcessRequest(t *testing.T) {

--- a/internal/flow/processor/conditional_test.go
+++ b/internal/flow/processor/conditional_test.go
@@ -109,3 +109,18 @@ func TestConditionalResponseProcessor_ProcessResponse(t *testing.T) {
 		t.Fatalf("expected delegate to run when predicate allows invocation")
 	}
 }
+
+func TestConditionalResponseProcessor_NilDelegateReturnsOriginal(t *testing.T) {
+	proc := &ConditionalResponseProcessor{}
+	rsp := &model.Response{}
+	got := proc.ProcessResponse(
+		context.Background(),
+		&agent.Invocation{},
+		&model.Request{},
+		rsp,
+		make(chan *event.Event, 1),
+	)
+	if got != rsp {
+		t.Fatalf("expected original response to be returned, got %v", got)
+	}
+}

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -289,8 +289,9 @@ func NewFunctionCallResponseProcessor(
 }
 
 // ProcessResponse implements the flow.ResponseProcessor interface.
-// It checks for transfer requests and handles agent handoffs by actually calling
-// the target agent's Run method.
+// It dispatches any pending tool calls, emits the corresponding events, and
+// returns the original response unchanged (tool-call dispatch does not replace
+// the published LLM response).
 func (p *FunctionCallResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -297,9 +297,9 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 	req *model.Request,
 	rsp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	if invocation == nil || rsp == nil || rsp.IsPartial || !rsp.IsToolCallResponse() {
-		return
+		return rsp
 	}
 	if calllimit.Active(invocation) {
 		invocation.EndInvocation = true
@@ -309,7 +309,7 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 			ch,
 			"tool calls are disabled during call limit finalization",
 		)
-		return
+		return rsp
 	}
 
 	// Enforce optional per-invocation tool iteration limit. A "tool iteration"
@@ -332,7 +332,7 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 				invocation.MaxToolIterations,
 			),
 		)
-		return
+		return rsp
 	}
 	toolLimitReached := calllimit.RecordToolIteration(
 		invocation,
@@ -347,7 +347,7 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 	)
 	if deferred && !executable && !unknown {
 		invocation.EndInvocation = true
-		return
+		return rsp
 	}
 
 	functioncallResponseEvent, err := p.handleFunctionCallsAndSendEventWithRequest(ctx, invocation, req, rsp, ch)
@@ -364,7 +364,7 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 	// Allow users to intervene in error handling through callbacks.
 	if _, ok := agent.AsStopError(err); ok {
 		invocation.EndInvocation = true
-		return
+		return rsp
 	}
 
 	if deferred {
@@ -372,19 +372,20 @@ func (p *FunctionCallResponseProcessor) ProcessResponse(
 	}
 
 	if err != nil || functioncallResponseEvent == nil {
-		return
+		return rsp
 	}
 
 	if invocation.EndInvocation {
-		return
+		return rsp
 	}
 
 	// If the tool indicates skipping outer summarization, mark the invocation to end
 	// after this tool response so the flow does not perform an extra LLM call.
 	if functioncallResponseEvent.Actions != nil && functioncallResponseEvent.Actions.SkipSummarization {
 		invocation.EndInvocation = true
-		return
+		return rsp
 	}
+	return rsp
 }
 
 func emitToolIterationLimitError(

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -12169,3 +12169,16 @@ func TestFunctionCallResponseProcessor_ToolConcurrencyScopeLimitsCalls(
 	}
 	require.Equal(t, int64(2), blocking.max.Load())
 }
+
+func TestFunctionCallResponseProcessor_NilInvocationReturnsOriginal(t *testing.T) {
+	proc := &FunctionCallResponseProcessor{}
+	rsp := &model.Response{}
+	got := proc.ProcessResponse(
+		context.Background(),
+		nil,
+		&model.Request{},
+		rsp,
+		make(chan *event.Event, 1),
+	)
+	require.Same(t, rsp, got)
+}

--- a/internal/flow/processor/output.go
+++ b/internal/flow/processor/output.go
@@ -45,17 +45,17 @@ func (p *OutputResponseProcessor) ProcessResponse(
 	req *model.Request,
 	rsp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	if invocation == nil || rsp == nil || !rsp.IsFinalResponse() ||
 		(invocation.StructuredOutput == nil && invocation.StructuredOutputType == nil &&
 			p.outputKey == "" && p.outputSchema == nil) {
-		return
+		return rsp
 	}
 	// Only process complete (non-partial) responses.
 	// Extract text content from the response.
 	content, ok := p.extractFinalContent(rsp)
 	if !ok {
-		return
+		return rsp
 	}
 	jsonObject, ok := extractFirstJSONObject(content)
 
@@ -66,6 +66,7 @@ func (p *OutputResponseProcessor) ProcessResponse(
 
 	// 2) Handle output_key functionality (raw persistence, optional schema validation).
 	p.handleOutputKey(ctx, invocation, content, jsonObject, ch)
+	return rsp
 }
 
 // extractFinalContent returns the final text content if response is complete.

--- a/internal/flow/processor/output.go
+++ b/internal/flow/processor/output.go
@@ -37,8 +37,10 @@ func NewOutputResponseProcessor(
 	}
 }
 
-// ProcessResponse processes the model response and handles output_key and output_schema functionality.
-// This mimics the behavior of adk-python's output processing using event.actions.state_delta pattern.
+// ProcessResponse processes the model response and handles output_key and
+// output_schema functionality, following adk-python's state_delta pattern.
+// It returns the original response unchanged (output extraction does not
+// replace the published response).
 func (p *OutputResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/output_test.go
+++ b/internal/flow/processor/output_test.go
@@ -395,8 +395,14 @@ func TestOutputResponseProcessor_EmptyFinalContentReturnsOriginal(t *testing.T) 
 	proc := &OutputResponseProcessor{outputKey: "out"}
 	inv := &agent.Invocation{}
 	rsp := &model.Response{Done: true, Error: &model.ResponseError{Message: "boom"}}
-	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 1))
+	eventCh := make(chan *event.Event, 1)
+	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, eventCh)
 	if got != rsp {
 		t.Fatalf("expected original response to be returned, got %v", got)
+	}
+	select {
+	case evt := <-eventCh:
+		t.Fatalf("unexpected event: %#v", evt)
+	default:
 	}
 }

--- a/internal/flow/processor/output_test.go
+++ b/internal/flow/processor/output_test.go
@@ -390,3 +390,13 @@ func TestOutputResponseProcessor_ExtractFinalContent(t *testing.T) {
 		t.Fatalf("expected ok content")
 	}
 }
+
+func TestOutputResponseProcessor_EmptyFinalContentReturnsOriginal(t *testing.T) {
+	proc := &OutputResponseProcessor{outputKey: "out"}
+	inv := &agent.Invocation{}
+	rsp := &model.Response{Done: true, Error: &model.ResponseError{Message: "boom"}}
+	got := proc.ProcessResponse(context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 1))
+	if got != rsp {
+		t.Fatalf("expected original response to be returned, got %v", got)
+	}
+}

--- a/internal/flow/processor/planning.go
+++ b/internal/flow/processor/planning.go
@@ -138,7 +138,9 @@ func NewPlanningResponseProcessor(p planner.Planner) *PlanningResponseProcessor 
 }
 
 // ProcessResponse implements the flow.ResponseProcessor interface.
-// It processes planning responses using the configured planner.
+// It processes planning responses using the configured planner and returns
+// the planner's replacement response when one is produced, or the original
+// response otherwise.
 func (p *PlanningResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/planning.go
+++ b/internal/flow/processor/planning.go
@@ -145,23 +145,23 @@ func (p *PlanningResponseProcessor) ProcessResponse(
 	req *model.Request,
 	rsp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	if invocation == nil || rsp == nil || rsp.IsPartial {
-		return
+		return rsp
 	}
 	if p.Planner == nil {
 		log.DebugContext(
 			ctx,
 			"Planning response processor: no planner configured",
 		)
-		return
+		return rsp
 	}
 	if len(rsp.Choices) == 0 {
 		log.DebugContext(
 			ctx,
 			"Planning response processor: no choices in response",
 		)
-		return
+		return rsp
 	}
 
 	log.DebugfContext(
@@ -173,8 +173,6 @@ func (p *PlanningResponseProcessor) ProcessResponse(
 	// Process the response using the planner.
 	processedResponse := p.Planner.ProcessPlanningResponse(ctx, invocation, rsp)
 	if processedResponse != nil {
-		// Update the original response with processed content.
-		*rsp = *processedResponse
 		log.DebugContext(
 			ctx,
 			"Planning response processor: processed response successfully",
@@ -200,4 +198,10 @@ func (p *PlanningResponseProcessor) ProcessResponse(
 			"Planning response processor: context cancelled",
 		)
 	}
+	if processedResponse != nil {
+		// Return the processed response instead of overwriting the shared
+		// response, which may already be published in an emitted event.
+		return processedResponse
+	}
+	return rsp
 }

--- a/internal/flow/processor/planning_test.go
+++ b/internal/flow/processor/planning_test.go
@@ -211,3 +211,31 @@ func TestPlanningResponseProcessor_EmitEventError(t *testing.T) {
 		// Expected - no event sent due to error
 	}
 }
+
+type nilPlanner struct{}
+
+func (nilPlanner) BuildPlanningInstruction(
+	ctx context.Context, inv *agent.Invocation, req *model.Request,
+) string {
+	return ""
+}
+
+func (nilPlanner) ProcessPlanningResponse(
+	ctx context.Context, inv *agent.Invocation, rsp *model.Response,
+) *model.Response {
+	return nil
+}
+
+func TestPlanningResponseProcessor_PlannerReturnsNil(t *testing.T) {
+	proc := NewPlanningResponseProcessor(nilPlanner{})
+	ch := make(chan *event.Event, 2)
+	rsp := &model.Response{ID: "orig", Choices: []model.Choice{{}}}
+	got := proc.ProcessResponse(
+		context.Background(),
+		&agent.Invocation{AgentName: "a", InvocationID: "i1"},
+		nil,
+		rsp,
+		ch,
+	)
+	require.Same(t, rsp, got)
+}

--- a/internal/flow/processor/planning_test.go
+++ b/internal/flow/processor/planning_test.go
@@ -212,14 +212,19 @@ func TestPlanningResponseProcessor_EmitEventError(t *testing.T) {
 	}
 }
 
+// nilPlanner is a test stub whose ProcessPlanningResponse always returns nil,
+// used to verify that the processor falls back to returning the original response.
 type nilPlanner struct{}
 
+// BuildPlanningInstruction returns an empty string (no planning instruction).
 func (nilPlanner) BuildPlanningInstruction(
 	ctx context.Context, inv *agent.Invocation, req *model.Request,
 ) string {
 	return ""
 }
 
+// ProcessPlanningResponse always returns nil, simulating a planner that
+// produces no replacement response.
 func (nilPlanner) ProcessPlanningResponse(
 	ctx context.Context, inv *agent.Invocation, rsp *model.Response,
 ) *model.Response {

--- a/internal/flow/processor/planning_test.go
+++ b/internal/flow/processor/planning_test.go
@@ -96,10 +96,14 @@ func TestPlanningResponseProcessor_AllBranches(t *testing.T) {
 	pr2 := NewPlanningResponseProcessor(&fakePlanner{})
 	pr2.ProcessResponse(ctx, &agent.Invocation{AgentName: "a"}, nil, &model.Response{}, ch)
 
-	// 5) process with choices and verify replacement
+	// 5) process with choices and verify the replacement is returned.
 	rsp := &model.Response{ID: "orig", Choices: []model.Choice{{}}}
-	pr2.ProcessResponse(ctx, &agent.Invocation{AgentName: "a", InvocationID: "i1"}, nil, rsp, ch)
-	assert.Equal(t, "processed", rsp.ID)
+	processed := pr2.ProcessResponse(ctx, &agent.Invocation{AgentName: "a", InvocationID: "i1"}, nil, rsp, ch)
+	// The shared response stays intact; the replacement carries the update.
+	assert.Equal(t, "orig", rsp.ID)
+	if assert.NotNil(t, processed) {
+		assert.Equal(t, "processed", processed.ID)
+	}
 
 	// Verify that the postprocessing event is marked as partial
 	select {
@@ -191,10 +195,14 @@ func TestPlanningResponseProcessor_EmitEventError(t *testing.T) {
 	rsp := &model.Response{ID: "test", Choices: []model.Choice{{}}}
 
 	// This should trigger the error path in agent.EmitEvent
-	pr.ProcessResponse(ctx, &agent.Invocation{AgentName: "a", InvocationID: "i1"}, nil, rsp, ch)
+	processed := pr.ProcessResponse(ctx, &agent.Invocation{AgentName: "a", InvocationID: "i1"}, nil, rsp, ch)
 
-	// Should have processed the response but failed to emit event
-	assert.Equal(t, "processed", rsp.ID)
+	// Should have processed the response but failed to emit event. The
+	// replacement carries the planner output; the shared response is intact.
+	assert.Equal(t, "test", rsp.ID)
+	if assert.NotNil(t, processed) {
+		assert.Equal(t, "processed", processed.ID)
+	}
 	// Channel should be empty due to EmitEvent error
 	select {
 	case <-ch:

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -46,8 +46,9 @@ func NewTransferResponseProcessor(endInvocation bool) *TransferResponseProcessor
 }
 
 // ProcessResponse implements the flow.ResponseProcessor interface.
-// It checks for transfer requests and handles agent handoffs by actually calling
-// the target agent's Run method.
+// It checks for a pending transfer request and, when present, invokes the
+// target agent's Run method to perform the handoff. It returns the original
+// response unchanged (agent transfer does not replace the published response).
 func (p *TransferResponseProcessor) ProcessResponse(
 	ctx context.Context,
 	invocation *agent.Invocation,

--- a/internal/flow/processor/transfer.go
+++ b/internal/flow/processor/transfer.go
@@ -54,9 +54,9 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	req *model.Request,
 	rsp *model.Response,
 	ch chan<- *event.Event,
-) {
+) *model.Response {
 	if invocation == nil || rsp == nil || rsp.IsPartial {
-		return
+		return rsp
 	}
 	if calllimit.Active(invocation) {
 		// Finalization is a bounded, tool-free terminal step. Discard any
@@ -64,7 +64,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 		// not retried after the model has produced its final response.
 		invocation.TransferInfo = nil
 		invocation.EndInvocation = true
-		return
+		return rsp
 	}
 
 	log.DebugfContext(
@@ -76,7 +76,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	// Check if there's a pending transfer in the invocation.
 	if invocation.TransferInfo == nil {
 		// No transfer requested, continue normally.
-		return
+		return rsp
 	}
 
 	transferInfo := invocation.TransferInfo
@@ -106,7 +106,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			model.ErrorTypeFlowError,
 			"Transfer failed: target agent '"+targetAgentName+"' not found",
 		))
-		return
+		return rsp
 	}
 
 	if controller, ok := agent.GetRuntimeStateValue[agent.TransferController](
@@ -129,7 +129,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 					err,
 				),
 			))
-			return
+			return rsp
 		}
 		nodeTimeout = targetTimeout
 		transferCustomizer = transferInvocationCustomizerFor(controller)
@@ -152,7 +152,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			model.ErrorTypeFlowError,
 			fmt.Sprintf("Transfer customization rejected: %v", err),
 		))
-		return
+		return rsp
 	}
 	// Create transfer event to notify about the handoff.
 	transferEvent := event.New(
@@ -179,7 +179,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	}
 	// Send transfer event after customization succeeds.
 	if err := agent.EmitEvent(ctx, invocation, ch, transferEvent); err != nil {
-		return
+		return rsp
 	}
 	if shouldEmitTransferMessageEcho(
 		transferInfo.Message != "",
@@ -231,7 +231,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 			model.ErrorTypeFlowError,
 			"Transfer failed: "+err.Error(),
 		))
-		return
+		return rsp
 	}
 
 	if !forwardTransferTargetEvents(
@@ -244,7 +244,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 		transferCompletionHandler,
 		transferTerminalErrorHandler,
 	) {
-		return
+		return rsp
 	}
 
 	// Clear the transfer info and end the original invocation to stop further LLM calls.
@@ -257,6 +257,7 @@ func (p *TransferResponseProcessor) ProcessResponse(
 	)
 	invocation.TransferInfo = nil
 	invocation.EndInvocation = p.endInvocationAfterTransfer
+	return rsp
 }
 
 type transferForwardResult struct {

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -1334,16 +1334,16 @@ type cancelOnRunAgent struct {
 }
 
 // Info returns a fixed agent.Info with Name "child".
-func (a *cancelOnRunAgent) Info() agent.Info                { return agent.Info{Name: "child"} }
+func (a *cancelOnRunAgent) Info() agent.Info { return agent.Info{Name: "child"} }
 
 // SubAgents returns nil (no sub-agents).
-func (a *cancelOnRunAgent) SubAgents() []agent.Agent        { return nil }
+func (a *cancelOnRunAgent) SubAgents() []agent.Agent { return nil }
 
 // FindSubAgent always returns nil.
 func (a *cancelOnRunAgent) FindSubAgent(string) agent.Agent { return nil }
 
 // Tools returns nil (no tools).
-func (a *cancelOnRunAgent) Tools() []tool.Tool              { return nil }
+func (a *cancelOnRunAgent) Tools() []tool.Tool { return nil }
 
 // Run increments the call counter, cancels the context, and returns a single
 // completion event before closing the channel.

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -1325,7 +1325,10 @@ func TestTransferResponseProc_DoesNotInheritParentMetadataFromSource(t *testing.
 			"that edge has no representable ParentMetadata (must be nil, not inherited)")
 }
 
-type cancelOnRunAgent struct{ cancel context.CancelFunc }
+type cancelOnRunAgent struct {
+	cancel context.CancelFunc
+	calls  int
+}
 
 func (a *cancelOnRunAgent) Info() agent.Info                { return agent.Info{Name: "child"} }
 func (a *cancelOnRunAgent) SubAgents() []agent.Agent        { return nil }
@@ -1334,6 +1337,7 @@ func (a *cancelOnRunAgent) Tools() []tool.Tool              { return nil }
 func (a *cancelOnRunAgent) Run(
 	ctx context.Context, inv *agent.Invocation,
 ) (<-chan *event.Event, error) {
+	a.calls++
 	a.cancel()
 	ch := make(chan *event.Event, 1)
 	ch <- event.New(inv.InvocationID, a.Info().Name)
@@ -1363,7 +1367,7 @@ func TestTransferResponseProc_NoPendingTransferReturnsOriginal(t *testing.T) {
 }
 
 func TestTransferResponseProc_CancelledContextReturnsOriginal(t *testing.T) {
-	target := &mockAgent{name: "child", emit: true}
+	target := &runErrorAgent{name: "child"}
 	parent := &parentAgent{child: target}
 	inv := &agent.Invocation{
 		Agent:        parent,
@@ -1378,6 +1382,7 @@ func TestTransferResponseProc_CancelledContextReturnsOriginal(t *testing.T) {
 		ctx, inv, &model.Request{}, rsp, make(chan *event.Event, 4),
 	)
 	require.Same(t, rsp, got)
+	require.Zero(t, target.calls)
 }
 
 func TestTransferResponseProc_ForwardFailureReturnsOriginal(t *testing.T) {
@@ -1396,4 +1401,5 @@ func TestTransferResponseProc_ForwardFailureReturnsOriginal(t *testing.T) {
 		ctx, inv, &model.Request{}, rsp, make(chan *event.Event, 4),
 	)
 	require.Same(t, rsp, got)
+	require.Equal(t, 1, target.calls)
 }

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -1325,15 +1325,28 @@ func TestTransferResponseProc_DoesNotInheritParentMetadataFromSource(t *testing.
 			"that edge has no representable ParentMetadata (must be nil, not inherited)")
 }
 
+// cancelOnRunAgent is a test stub that cancels the provided context when Run is
+// called. It records the number of invocations in calls so tests can assert
+// that the target agent was (or was not) reached.
 type cancelOnRunAgent struct {
 	cancel context.CancelFunc
 	calls  int
 }
 
+// Info returns a fixed agent.Info with Name "child".
 func (a *cancelOnRunAgent) Info() agent.Info                { return agent.Info{Name: "child"} }
+
+// SubAgents returns nil (no sub-agents).
 func (a *cancelOnRunAgent) SubAgents() []agent.Agent        { return nil }
+
+// FindSubAgent always returns nil.
 func (a *cancelOnRunAgent) FindSubAgent(string) agent.Agent { return nil }
+
+// Tools returns nil (no tools).
 func (a *cancelOnRunAgent) Tools() []tool.Tool              { return nil }
+
+// Run increments the call counter, cancels the context, and returns a single
+// completion event before closing the channel.
 func (a *cancelOnRunAgent) Run(
 	ctx context.Context, inv *agent.Invocation,
 ) (<-chan *event.Event, error) {

--- a/internal/flow/processor/transfer_test.go
+++ b/internal/flow/processor/transfer_test.go
@@ -1324,3 +1324,76 @@ func TestTransferResponseProc_DoesNotInheritParentMetadataFromSource(t *testing.
 			"the transfer is itself the new parent edge, and absent a ToolCallID, "+
 			"that edge has no representable ParentMetadata (must be nil, not inherited)")
 }
+
+type cancelOnRunAgent struct{ cancel context.CancelFunc }
+
+func (a *cancelOnRunAgent) Info() agent.Info                { return agent.Info{Name: "child"} }
+func (a *cancelOnRunAgent) SubAgents() []agent.Agent        { return nil }
+func (a *cancelOnRunAgent) FindSubAgent(string) agent.Agent { return nil }
+func (a *cancelOnRunAgent) Tools() []tool.Tool              { return nil }
+func (a *cancelOnRunAgent) Run(
+	ctx context.Context, inv *agent.Invocation,
+) (<-chan *event.Event, error) {
+	a.cancel()
+	ch := make(chan *event.Event, 1)
+	ch <- event.New(inv.InvocationID, a.Info().Name)
+	close(ch)
+	return ch, nil
+}
+
+func TestTransferResponseProc_NilInvocationReturnsOriginal(t *testing.T) {
+	rsp := &model.Response{}
+	got := NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(), nil, nil, rsp, make(chan *event.Event, 1),
+	)
+	require.Same(t, rsp, got)
+}
+
+func TestTransferResponseProc_NoPendingTransferReturnsOriginal(t *testing.T) {
+	inv := &agent.Invocation{
+		Agent:        &parentAgent{},
+		AgentName:    "parent",
+		InvocationID: "inv",
+	}
+	rsp := &model.Response{ID: "r", Created: time.Now().Unix(), Model: "m"}
+	got := NewTransferResponseProcessor(true).ProcessResponse(
+		context.Background(), inv, &model.Request{}, rsp, make(chan *event.Event, 1),
+	)
+	require.Same(t, rsp, got)
+}
+
+func TestTransferResponseProc_CancelledContextReturnsOriginal(t *testing.T) {
+	target := &mockAgent{name: "child", emit: true}
+	parent := &parentAgent{child: target}
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv",
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child", Message: "hi"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rsp := &model.Response{ID: "r1", Created: time.Now().Unix(), Model: "m"}
+	got := NewTransferResponseProcessor(true).ProcessResponse(
+		ctx, inv, &model.Request{}, rsp, make(chan *event.Event, 4),
+	)
+	require.Same(t, rsp, got)
+}
+
+func TestTransferResponseProc_ForwardFailureReturnsOriginal(t *testing.T) {
+	target := &cancelOnRunAgent{}
+	parent := &parentAgent{child: target}
+	ctx, cancel := context.WithCancel(context.Background())
+	target.cancel = cancel
+	inv := &agent.Invocation{
+		Agent:        parent,
+		AgentName:    "parent",
+		InvocationID: "inv",
+		TransferInfo: &agent.TransferInfo{TargetAgentName: "child", Message: "hi"},
+	}
+	rsp := &model.Response{ID: "r1", Created: time.Now().Unix(), Model: "m"}
+	got := NewTransferResponseProcessor(true).ProcessResponse(
+		ctx, inv, &model.Request{}, rsp, make(chan *event.Event, 4),
+	)
+	require.Same(t, rsp, got)
+}


### PR DESCRIPTION
## What changed

Change the internal `ResponseProcessor.ProcessResponse` contract to **return the response used by later processing stages** instead of mutating the shared response in place:

- `CodeExecutionResponseProcessor` no longer clears `rsp.Choices[0].Message.Content` on the shared response; it returns a cleared clone for downstream stages.
- `PlanningResponseProcessor` no longer overwrites the shared response (`*rsp = *processedResponse`); it returns the processed response.
- All other processors return the input response unchanged (signature-only change).

## Why

`go test -race -run TestLLMAgent_EnableCodeExecutionResponseProcessor ./agent/llmagent/` reports a data race on `main`: the code-execution processor writes `rsp.Choices[0].Message.Content = ""` after the same `*model.Response` pointer was already published in the emitted LLM response event, racing the telemetry tracker's `Response.IsValidContent()` read. The in-place clearing also makes the already-emitted event non-deterministic for downstream consumers (session persistence, AGUI, event plugins).

The `content.go` in-place writes were already clone-first, so they are left untouched.

## Testing

- `go test -race -count=5 -run TestLLMAgent_EnableCodeExecutionResponseProcessor ./agent/llmagent/` — the reproducer from #2539, now passes (fails on `main` with the reported race).
- `go test -race -count=1 ./internal/flow/...` — all green.
- `go test -count=1 ./agent/... ./internal/telemetry/...` — all green.
- `go build ./...`, `go vet ./internal/flow/...`, `gofmt` — clean.

Fixes #2539
