### PR TITLE
model/openai: parse batch JSONL lines longer than 64KiB

### DIFF
--- a/model/openai/batch.go
+++ b/model/openai/batch.go
@@ -378,7 +378,8 @@ func (m *Model) ParseBatchOutput(text string) ([]BatchRequestOutput, error) {
 		if err := json.Unmarshal([]byte(line), &out); err != nil {
 			return nil, fmt.Errorf("failed to parse jsonl line: %w", err)
 		}
-		out.RawLine = line
+		// Clone so a retained entry does not pin the entire JSONL input.
+		out.RawLine = strings.Clone(line)
 		entries = append(entries, out)
 	}
 	return entries, nil

--- a/model/openai/batch.go
+++ b/model/openai/batch.go
@@ -10,7 +10,6 @@
 package openai
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -360,26 +359,27 @@ type BatchResponse struct {
 
 // ParseBatchOutput parses output JSONL into OpenAI-aligned structures.
 func (m *Model) ParseBatchOutput(text string) ([]BatchRequestOutput, error) {
-	scanner := bufio.NewScanner(strings.NewReader(text))
-	// Pre-allocate with reasonable default capacity to avoid frequent reallocations.
+	// Split on newlines directly. bufio.Scanner rejects tokens larger than
+	// 64KiB by default, and a batch output line contains a full ChatCompletion
+	// JSON object that routinely exceeds that limit.
 	var entries []BatchRequestOutput
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+	for remaining := text; remaining != ""; {
+		line, rest, found := strings.Cut(remaining, "\n")
+		if found {
+			remaining = rest
+		} else {
+			remaining = ""
+		}
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		// Unmarshal the line into a BatchRequestOutput.
 		var out BatchRequestOutput
 		if err := json.Unmarshal([]byte(line), &out); err != nil {
 			return nil, fmt.Errorf("failed to parse jsonl line: %w", err)
 		}
-		// Store the original line for debugging purposes.
 		out.RawLine = line
-		// Append the entry to the slice.
 		entries = append(entries, out)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan jsonl: %w", err)
 	}
 	return entries, nil
 }

--- a/model/openai/batch_test.go
+++ b/model/openai/batch_test.go
@@ -10,6 +10,7 @@
 package openai
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -743,6 +744,25 @@ func TestParseBatchOutput_EdgeCases(t *testing.T) {
 {"custom_id":"test2","response":{"status_code":400,"body":{"model":"gpt-4o-mini"}}}`)
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
+}
+
+func TestParseBatchOutput_LongLine(t *testing.T) {
+	m := &Model{}
+	content := strings.Repeat("x", bufio.MaxScanTokenSize)
+	jsonl := fmt.Sprintf(
+		`{"custom_id":"long","response":{"status_code":200,"body":{"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"%s"}}]}}}`,
+		content,
+	)
+	require.Greater(t, len(jsonl), bufio.MaxScanTokenSize)
+
+	results, err := m.ParseBatchOutput(jsonl)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "long", results[0].CustomID)
+	assert.Equal(t, 200, results[0].Response.StatusCode)
+	require.NotEmpty(t, results[0].Response.Body.Choices)
+	assert.Equal(t, content, results[0].Response.Body.Choices[0].Message.Content)
+	assert.Greater(t, len(results[0].RawLine), bufio.MaxScanTokenSize)
 }
 
 // Helper functions to create pointers.


### PR DESCRIPTION
## What changed

`ParseBatchOutput` now accepts batch JSONL lines longer than 64KiB. A single ChatCompletion output line no longer fails with `bufio.Scanner: token too long`.

## Why

The parser used `bufio.NewScanner` without `scanner.Buffer`. Scanner's default token limit is 64KiB. Batch output JSONL stores a full ChatCompletion object per line, so long completions and tool-call payloads routinely exceed that limit.

Raising Scanner's max would still leave a hard cap. The input is already a complete string, so splitting on newlines avoids the token limit without changing the public API.

## Testing

- [x] `go test ./model/openai -run 'TestParseBatchOutput' -count=1`
- [x] `TestParseBatchOutput_LongLine`: a line larger than `bufio.MaxScanTokenSize` parses successfully

## Notes for reviewers

`RawLine` is cloned with `strings.Clone`, so a retained entry does not pin the original JSONL backing array. The previous `failed to scan jsonl` error is no longer returned for oversize lines; JSON parse errors are unchanged.