### PR TITLE
tool: keep pass-through AfterTool from skipping agent callbacks

### DIFF
--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -310,8 +310,10 @@ Some “after” hooks can override:
   earlier events).
 - **AfterModel** can return a custom response to replace the model response.
 - **AfterTool** can return a custom result to replace the tool result.
-  A non-nil `CustomResult` skips later Agent AfterTool callbacks. Omitting
-  AfterTool, or returning nil / an empty result, is a pass-through.
+  A non-nil `CustomResult` skips later Agent AfterTool callbacks; empty
+  maps, slices, and strings stored in that field are still replacements.
+  Omitting AfterTool, returning nil, or returning a result without
+  `CustomResult` is a pass-through.
 
 > **Caveats for multi-agent (ChainAgent, ParallelAgent, CycleAgent, Graph agent-nodes)**
 >

--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -310,6 +310,8 @@ Some “after” hooks can override:
   earlier events).
 - **AfterModel** can return a custom response to replace the model response.
 - **AfterTool** can return a custom result to replace the tool result.
+  A non-nil `CustomResult` skips later Agent AfterTool callbacks. Omitting
+  AfterTool, or returning nil / an empty result, is a pass-through.
 
 > **Caveats for multi-agent (ChainAgent, ParallelAgent, CycleAgent, Graph agent-nodes)**
 >
@@ -372,6 +374,7 @@ the appropriate time in the caller.
 - `BeforeTool`: runs before a tool is called, can modify the tool arguments
   (JavaScript Object Notation (JSON) bytes).
 - `AfterTool`: runs after a tool returns, can replace the result.
+  A non-nil `CustomResult` skips later Agent AfterTool callbacks.
 
 ### Event hook
 

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -341,7 +341,9 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 - **AfterAgent**：可以返回自定义响应，作为一条额外的“终态”响应事件**追加**到
   Agent 事件流末尾（不替换之前的事件）。
 - **AfterModel**：可以返回自定义响应，替换模型响应。
-- **AfterTool**：可以返回自定义结果，替换工具结果。
+- **AfterTool**：可以返回自定义结果，替换工具结果。非空的 `CustomResult`
+  会跳过后续 Agent AfterTool 回调。未实现 AfterTool，或返回 nil / 空结果，
+  都是透传，不会让 Agent 级 AfterTool 失效。
 
 > **多 Agent 场景下的注意事项（ChainAgent、ParallelAgent、CycleAgent、Graph Agent 节点）**
 >
@@ -394,7 +396,8 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 
 - `BeforeTool`：工具调用前，可以修改工具参数（JSON（JavaScript Object Notation）
   字节）
-- `AfterTool`：工具调用后，可以替换结果
+- `AfterTool`：工具调用后，可以替换结果。非空 `CustomResult` 会跳过后续
+  Agent AfterTool 回调。
 
 ### Event Hook 点
 

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -341,9 +341,9 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 - **AfterAgent**：可以返回自定义响应，作为一条额外的“终态”响应事件**追加**到
   Agent 事件流末尾（不替换之前的事件）。
 - **AfterModel**：可以返回自定义响应，替换模型响应。
-- **AfterTool**：可以返回自定义结果，替换工具结果。非空的 `CustomResult`
-  会跳过后续 Agent AfterTool 回调。未实现 AfterTool，或返回 nil / 空结果，
-  都是透传，不会让 Agent 级 AfterTool 失效。
+- **AfterTool**：可以返回自定义结果，替换工具结果。`CustomResult` 非 `nil`
+  时会跳过后续 Agent AfterTool 回调；空 map、空 slice、空字符串等非 `nil` 值
+  也属于替换结果。未实现 AfterTool，或未提供 `CustomResult`，都是透传。
 
 > **多 Agent 场景下的注意事项（ChainAgent、ParallelAgent、CycleAgent、Graph Agent 节点）**
 >
@@ -396,8 +396,8 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 
 - `BeforeTool`：工具调用前，可以修改工具参数（JSON（JavaScript Object Notation）
   字节）
-- `AfterTool`：工具调用后，可以替换结果。非空 `CustomResult` 会跳过后续
-  Agent AfterTool 回调。
+- `AfterTool`：工具调用后，可以替换结果。非 `nil` 的 `CustomResult` 会跳过
+  后续 Agent AfterTool 回调。
 
 ### Event Hook 点
 

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -4236,6 +4236,9 @@ func runAfterToolPluginCallbacks(
 	if errors.As(runErr, &interruptErr) {
 		return ctx, nil, runErr
 	}
+	// A non-nil CustomResult is an explicit plugin replacement and skips
+	// node AfterTool callbacks. Pass-through plugins must leave
+	// CustomResult nil so those node callbacks still run.
 	if afterResult != nil && afterResult.CustomResult != nil {
 		if err != nil {
 			return ctx, afterResult.CustomResult,

--- a/graph/state_graph.go
+++ b/graph/state_graph.go
@@ -4213,7 +4213,7 @@ func runAfterToolPluginCallbacks(
 	}
 
 	callbacks := invocation.Plugins.ToolCallbacks()
-	if callbacks == nil {
+	if callbacks == nil || len(callbacks.AfterTool) == 0 {
 		return ctx, nil, nil
 	}
 
@@ -4236,9 +4236,10 @@ func runAfterToolPluginCallbacks(
 	if errors.As(runErr, &interruptErr) {
 		return ctx, nil, runErr
 	}
-	// A non-nil CustomResult is an explicit plugin replacement and skips
-	// node AfterTool callbacks. Pass-through plugins must leave
-	// CustomResult nil so those node callbacks still run.
+	// A non-nil CustomResult from a registered AfterTool hook is an explicit
+	// plugin replacement and skips node AfterTool callbacks. An empty
+	// AfterTool list is skipped above so the released no-callback echo of
+	// args.Result is not treated as an override.
 	if afterResult != nil && afterResult.CustomResult != nil {
 		if err != nil {
 			return ctx, afterResult.CustomResult,

--- a/graph/state_graph_ends_test.go
+++ b/graph/state_graph_ends_test.go
@@ -647,6 +647,54 @@ func TestRunTool_PluginPassThroughStillRunsLocalAfterTool(t *testing.T) {
 	}
 }
 
+func TestRunTool_PluginEmptyCustomResultSkipsLocalAfterTool(t *testing.T) {
+	const (
+		pluginName = "p"
+		callID     = "call-1"
+		toolName   = "t"
+	)
+	localAfterCalled := false
+	local := tool.NewCallbacks().RegisterAfterTool(func(
+		context.Context,
+		string,
+		*tool.Declaration,
+		[]byte,
+		any,
+		error,
+	) (any, error) {
+		localAfterCalled = true
+		return nil, nil
+	})
+	empty := map[string]any{}
+	pm := plugin.MustNewManager(&hookPlugin{
+		name: pluginName,
+		reg: func(r *plugin.Registry) {
+			r.AfterTool(func(
+				context.Context,
+				*tool.AfterToolArgs,
+			) (*tool.AfterToolResult, error) {
+				return &tool.AfterToolResult{CustomResult: empty}, nil
+			})
+		},
+	})
+	inv := &agent.Invocation{Plugins: pm}
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	tl := &captureTool{name: toolName, result: "x"}
+	tc := model.ToolCall{
+		ID: callID,
+		Function: model.FunctionDefinitionParam{
+			Name:      toolName,
+			Arguments: []byte(`{}`),
+		},
+	}
+
+	_, got, _, err := runTool(ctx, tc, local, tl, State{})
+	require.NoError(t, err)
+	require.Equal(t, empty, got)
+	require.True(t, tl.called)
+	require.False(t, localAfterCalled)
+}
+
 func TestRunTool_PluginBeforeTool_CustomResultWithError(t *testing.T) {
 	const (
 		callID   = "call-1"

--- a/graph/state_graph_ends_test.go
+++ b/graph/state_graph_ends_test.go
@@ -567,6 +567,86 @@ func TestRunTool_PluginAfterToolOverridesError(t *testing.T) {
 	require.False(t, localAfterCalled)
 }
 
+func TestRunTool_PluginPassThroughStillRunsLocalAfterTool(t *testing.T) {
+	const (
+		pluginName = "p"
+		callID     = "call-1"
+		toolName   = "t"
+	)
+	tests := []struct {
+		name string
+		reg  func(r *plugin.Registry)
+	}{
+		{
+			name: "before tool only",
+			reg: func(r *plugin.Registry) {
+				r.BeforeTool(func(
+					context.Context,
+					*tool.BeforeToolArgs,
+				) (*tool.BeforeToolResult, error) {
+					return nil, nil
+				})
+			},
+		},
+		{
+			name: "after tool returns nil",
+			reg: func(r *plugin.Registry) {
+				r.AfterTool(func(
+					context.Context,
+					*tool.AfterToolArgs,
+				) (*tool.AfterToolResult, error) {
+					return nil, nil
+				})
+			},
+		},
+		{
+			name: "after tool returns empty result",
+			reg: func(r *plugin.Registry) {
+				r.AfterTool(func(
+					context.Context,
+					*tool.AfterToolArgs,
+				) (*tool.AfterToolResult, error) {
+					return &tool.AfterToolResult{}, nil
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localAfterCalled := false
+			local := tool.NewCallbacks().RegisterAfterTool(func(
+				context.Context,
+				string,
+				*tool.Declaration,
+				[]byte,
+				any,
+				error,
+			) (any, error) {
+				localAfterCalled = true
+				return nil, nil
+			})
+
+			pm := plugin.MustNewManager(&hookPlugin{name: pluginName, reg: tt.reg})
+			inv := &agent.Invocation{Plugins: pm}
+			ctx := agent.NewInvocationContext(context.Background(), inv)
+			tl := &captureTool{name: toolName, result: "x"}
+			tc := model.ToolCall{
+				ID: callID,
+				Function: model.FunctionDefinitionParam{
+					Name:      toolName,
+					Arguments: []byte(`{}`),
+				},
+			}
+
+			_, got, _, err := runTool(ctx, tc, local, tl, State{})
+			require.NoError(t, err)
+			require.Equal(t, "x", got)
+			require.True(t, tl.called)
+			require.True(t, localAfterCalled)
+		})
+	}
+}
+
 func TestRunTool_PluginBeforeTool_CustomResultWithError(t *testing.T) {
 	const (
 		callID   = "call-1"

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -3373,7 +3373,7 @@ func (p *FunctionCallResponseProcessor) runAfterToolPluginCallbacks(
 	}
 
 	callbacks := invocation.Plugins.ToolCallbacks()
-	if callbacks == nil {
+	if callbacks == nil || len(callbacks.AfterTool) == 0 {
 		return ctx, toolResult, false, false, nil
 	}
 
@@ -3402,9 +3402,10 @@ func (p *FunctionCallResponseProcessor) runAfterToolPluginCallbacks(
 	}
 	skipSummarization := afterResult != nil &&
 		afterResult.SkipSummarization
-	// A non-nil CustomResult is an explicit plugin replacement and skips
-	// agent AfterTool callbacks. Pass-through plugins must leave
-	// CustomResult nil so those agent callbacks still run.
+	// A non-nil CustomResult from a registered AfterTool hook is an explicit
+	// plugin replacement and skips agent AfterTool callbacks. An empty
+	// AfterTool list is skipped above so the released no-callback echo of
+	// args.Result is not treated as an override.
 	if afterResult != nil && afterResult.CustomResult != nil {
 		if afterResult.SkipResultFormatter {
 			ctx = withUndeclaredToolResult(

--- a/internal/flow/processor/functioncall.go
+++ b/internal/flow/processor/functioncall.go
@@ -3402,6 +3402,9 @@ func (p *FunctionCallResponseProcessor) runAfterToolPluginCallbacks(
 	}
 	skipSummarization := afterResult != nil &&
 		afterResult.SkipSummarization
+	// A non-nil CustomResult is an explicit plugin replacement and skips
+	// agent AfterTool callbacks. Pass-through plugins must leave
+	// CustomResult nil so those agent callbacks still run.
 	if afterResult != nil && afterResult.CustomResult != nil {
 		if afterResult.SkipResultFormatter {
 			ctx = withUndeclaredToolResult(

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -10056,6 +10056,89 @@ func TestExecuteToolWithCallbacks_PluginAfterToolOverrides(t *testing.T) {
 	require.Equal(t, map[string]any{"p": true}, res)
 }
 
+func TestExecuteToolWithCallbacks_PluginPassThroughStillRunsLocalAfterTool(t *testing.T) {
+	tests := []struct {
+		name string
+		reg  func(r *plugin.Registry)
+	}{
+		{
+			name: "before tool only",
+			reg: func(r *plugin.Registry) {
+				r.BeforeTool(func(
+					context.Context,
+					*tool.BeforeToolArgs,
+				) (*tool.BeforeToolResult, error) {
+					return nil, nil
+				})
+			},
+		},
+		{
+			name: "after tool returns nil",
+			reg: func(r *plugin.Registry) {
+				r.AfterTool(func(
+					context.Context,
+					*tool.AfterToolArgs,
+				) (*tool.AfterToolResult, error) {
+					return nil, nil
+				})
+			},
+		},
+		{
+			name: "after tool returns empty result",
+			reg: func(r *plugin.Registry) {
+				r.AfterTool(func(
+					context.Context,
+					*tool.AfterToolArgs,
+				) (*tool.AfterToolResult, error) {
+					return &tool.AfterToolResult{}, nil
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localAfterCalled := false
+			local := tool.NewCallbacks()
+			local.RegisterAfterTool(func(
+				context.Context,
+				string,
+				*tool.Declaration,
+				[]byte,
+				any,
+				error,
+			) (any, error) {
+				localAfterCalled = true
+				return nil, nil
+			})
+
+			pm := plugin.MustNewManager(&hookPlugin{name: "p", reg: tt.reg})
+			proc := NewFunctionCallResponseProcessor(false, local)
+			inv := &agent.Invocation{Plugins: pm}
+			tl := &mockCallableTool{
+				declaration: &tool.Declaration{Name: "t"},
+				callFn: func(_ context.Context, _ []byte) (any, error) {
+					return "x", nil
+				},
+			}
+			toolCall := model.ToolCall{
+				ID:       "call-1",
+				Function: model.FunctionDefinitionParam{Name: "t"},
+			}
+
+			_, res, _, _, _, err := proc.executeToolWithCallbacks(
+				context.Background(),
+				inv,
+				toolCall,
+				tl,
+				nil,
+			)
+			require.NoError(t, err)
+			require.True(t, localAfterCalled)
+			require.Equal(t, "x", res)
+		})
+	}
+}
+
 func TestExecuteToolWithCallbacks_AfterToolReceivesNormalizedResultAndMeta(t *testing.T) {
 	var (
 		gotResult any

--- a/internal/flow/processor/functioncall_test.go
+++ b/internal/flow/processor/functioncall_test.go
@@ -10139,6 +10139,58 @@ func TestExecuteToolWithCallbacks_PluginPassThroughStillRunsLocalAfterTool(t *te
 	}
 }
 
+func TestExecuteToolWithCallbacks_PluginEmptyCustomResultSkipsLocalAfterTool(
+	t *testing.T,
+) {
+	localAfterCalled := false
+	local := tool.NewCallbacks()
+	local.RegisterAfterTool(func(
+		context.Context,
+		string,
+		*tool.Declaration,
+		[]byte,
+		any,
+		error,
+	) (any, error) {
+		localAfterCalled = true
+		return nil, nil
+	})
+
+	empty := map[string]any{}
+	pm := plugin.MustNewManager(&hookPlugin{
+		name: "p",
+		reg: func(r *plugin.Registry) {
+			r.AfterTool(func(
+				context.Context,
+				*tool.AfterToolArgs,
+			) (*tool.AfterToolResult, error) {
+				return &tool.AfterToolResult{CustomResult: empty}, nil
+			})
+		},
+	})
+	proc := NewFunctionCallResponseProcessor(false, local)
+	inv := &agent.Invocation{Plugins: pm}
+	tl := &mockCallableTool{
+		declaration: &tool.Declaration{Name: "t"},
+		callFn: func(_ context.Context, _ []byte) (any, error) {
+			return "x", nil
+		},
+	}
+	_, res, _, _, _, err := proc.executeToolWithCallbacks(
+		context.Background(),
+		inv,
+		model.ToolCall{
+			ID:       "call-1",
+			Function: model.FunctionDefinitionParam{Name: "t"},
+		},
+		tl,
+		nil,
+	)
+	require.NoError(t, err)
+	require.False(t, localAfterCalled)
+	require.Equal(t, empty, res)
+}
+
 func TestExecuteToolWithCallbacks_AfterToolReceivesNormalizedResultAndMeta(t *testing.T) {
 	var (
 		gotResult any

--- a/openclaw/app/blocked_route_tool_callback_test.go
+++ b/openclaw/app/blocked_route_tool_callback_test.go
@@ -550,11 +550,7 @@ func TestBlockedRouteToolCallback_DoesNotPersistMergeMetadata(
 			},
 		)
 		require.NoError(t, err, tc.name)
-		response := decodeBlockedRouteCustomResult(
-			t,
-			freshResult.CustomResult,
-		)
-		require.Len(t, response.Results, 1, tc.name)
+		require.Nil(t, freshResult.CustomResult, tc.name)
 	}
 }
 

--- a/plugin/toolerror/plugin_test.go
+++ b/plugin/toolerror/plugin_test.go
@@ -597,7 +597,7 @@ func TestAfterToolLeavesSuccessfulResultUntouched(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, original, result.CustomResult)
+	require.Nil(t, result.CustomResult)
 }
 
 func TestAfterToolResolverClassifiesBusinessFailure(t *testing.T) {

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -522,10 +522,13 @@ func (c *Callbacks) processAfterToolResult(
 }
 
 // finalizeAfterToolResult determines the final return value for after tool callbacks.
+//
+// CustomResult is only an explicit replacement. If no callback produced a
+// result, CustomResult stays nil so callers keep the original tool result
+// instead of treating a pass-through as an override.
 func (c *Callbacks) finalizeAfterToolResult(
 	lastResult *AfterToolResult,
 	firstErr error,
-	args *AfterToolArgs,
 ) (*AfterToolResult, error) {
 	if lastResult != nil && lastResult.CustomResult != nil {
 		if c.continueOnError && firstErr != nil {
@@ -537,11 +540,6 @@ func (c *Callbacks) finalizeAfterToolResult(
 		return lastResult, firstErr
 	}
 	if lastResult == nil {
-		if args.Result != nil {
-			return &AfterToolResult{
-				CustomResult: args.Result,
-			}, nil
-		}
 		return &AfterToolResult{}, nil
 	}
 	return lastResult, nil
@@ -593,6 +591,8 @@ func normalizeAfterToolArgsResult(args *AfterToolArgs) func() {
 // RunAfterTool runs all after tool callbacks in order.
 // This method uses the new structured callback interface.
 // If a callback returns a non-nil Context in the result, it will be used for subsequent callbacks.
+// If no callback returns a CustomResult, CustomResult is nil and callers should
+// keep using the original tool result.
 func (c *Callbacks) RunAfterTool(
 	ctx context.Context,
 	args *AfterToolArgs,
@@ -615,5 +615,5 @@ func (c *Callbacks) RunAfterTool(
 		}
 	}
 
-	return c.finalizeAfterToolResult(lastResult, firstErr, args)
+	return c.finalizeAfterToolResult(lastResult, firstErr)
 }

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -122,6 +122,7 @@ type AfterToolResult struct {
 	// Context if not nil, will be used by the framework for subsequent operations.
 	Context context.Context
 	// CustomResult if not nil, will replace the original result.
+	// Empty maps, slices, and strings are still replacements.
 	CustomResult any
 	// SkipResultFormatter requests default JSON serialization for CustomResult
 	// instead of applying the tool's configured result formatter. It is ignored

--- a/tool/callbacks.go
+++ b/tool/callbacks.go
@@ -524,12 +524,14 @@ func (c *Callbacks) processAfterToolResult(
 
 // finalizeAfterToolResult determines the final return value for after tool callbacks.
 //
-// CustomResult is only an explicit replacement. If no callback produced a
-// result, CustomResult stays nil so callers keep the original tool result
-// instead of treating a pass-through as an override.
+// When no AfterTool callbacks are registered, CustomResult is args.Result so
+// direct callers keep the released no-callback contract. When callbacks ran
+// but none produced a CustomResult, CustomResult stays nil so plugin
+// dispatchers treat that as pass-through rather than an override.
 func (c *Callbacks) finalizeAfterToolResult(
 	lastResult *AfterToolResult,
 	firstErr error,
+	args *AfterToolArgs,
 ) (*AfterToolResult, error) {
 	if lastResult != nil && lastResult.CustomResult != nil {
 		if c.continueOnError && firstErr != nil {
@@ -541,6 +543,11 @@ func (c *Callbacks) finalizeAfterToolResult(
 		return lastResult, firstErr
 	}
 	if lastResult == nil {
+		if len(c.AfterTool) == 0 && args != nil && args.Result != nil {
+			return &AfterToolResult{
+				CustomResult: args.Result,
+			}, nil
+		}
 		return &AfterToolResult{}, nil
 	}
 	return lastResult, nil
@@ -592,8 +599,9 @@ func normalizeAfterToolArgsResult(args *AfterToolArgs) func() {
 // RunAfterTool runs all after tool callbacks in order.
 // This method uses the new structured callback interface.
 // If a callback returns a non-nil Context in the result, it will be used for subsequent callbacks.
-// If no callback returns a CustomResult, CustomResult is nil and callers should
-// keep using the original tool result.
+// If no AfterTool callbacks are registered, CustomResult is args.Result.
+// If callbacks ran but none returned a CustomResult, CustomResult is nil and
+// callers should keep using the original tool result.
 func (c *Callbacks) RunAfterTool(
 	ctx context.Context,
 	args *AfterToolArgs,
@@ -616,5 +624,5 @@ func (c *Callbacks) RunAfterTool(
 		}
 	}
 
-	return c.finalizeAfterToolResult(lastResult, firstErr)
+	return c.finalizeAfterToolResult(lastResult, firstErr, args)
 }

--- a/tool/callbacks_test.go
+++ b/tool/callbacks_test.go
@@ -490,7 +490,7 @@ func TestRunAfterTool_Empty(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, originalResult, result.CustomResult)
+	require.Nil(t, result.CustomResult)
 }
 
 func TestRunAfterTool_PanicRecovery(t *testing.T) {
@@ -915,7 +915,7 @@ func TestRunAfterTool_NoCallbacksPreservesOriginalResultShape(t *testing.T) {
 	result, err := callbacks.RunAfterTool(context.Background(), afterArgs)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Same(t, rawResult, result.CustomResult)
+	require.Nil(t, result.CustomResult)
 	require.Same(t, rawResult, afterArgs.Result)
 }
 
@@ -1148,7 +1148,8 @@ func TestToolCallbacks_ContextPropagation(t *testing.T) {
 }
 
 // TestToolCallbacks_After_NoCallbacks_WithResult tests that when no callbacks
-// are registered and args.Result is not nil, RunAfterTool returns the original result.
+// are registered, RunAfterTool does not treat the original result as a custom
+// replacement.
 func TestToolCallbacks_After_NoCallbacks_WithResult(t *testing.T) {
 	callbacks := tool.NewCallbacks()
 	originalResult := map[string]string{"key": "value"}
@@ -1162,7 +1163,7 @@ func TestToolCallbacks_After_NoCallbacks_WithResult(t *testing.T) {
 	result, err := callbacks.RunAfterTool(context.Background(), args)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, originalResult, result.CustomResult)
+	require.Nil(t, result.CustomResult)
 }
 
 // TestToolCallbacks_After_NoCallbacks_WithoutResult tests that when no callbacks
@@ -1174,6 +1175,27 @@ func TestToolCallbacks_After_NoCallbacks_WithoutResult(t *testing.T) {
 		Declaration: &tool.Declaration{Name: "test-tool"},
 		Arguments:   []byte(`{}`),
 		Result:      nil,
+		Error:       nil,
+	}
+	result, err := callbacks.RunAfterTool(context.Background(), args)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.CustomResult)
+}
+
+// TestToolCallbacks_After_NilResultDoesNotEchoOriginal tests that a pass-through
+// AfterTool callback does not wrap args.Result as CustomResult.
+func TestToolCallbacks_After_NilResultDoesNotEchoOriginal(t *testing.T) {
+	callbacks := tool.NewCallbacks()
+	callbacks.RegisterAfterTool(func(ctx context.Context, args *tool.AfterToolArgs) (*tool.AfterToolResult, error) {
+		return nil, nil
+	})
+	originalResult := map[string]string{"original": "result"}
+	args := &tool.AfterToolArgs{
+		ToolName:    "test-tool",
+		Declaration: &tool.Declaration{Name: "test-tool"},
+		Arguments:   []byte(`{}`),
+		Result:      originalResult,
 		Error:       nil,
 	}
 	result, err := callbacks.RunAfterTool(context.Background(), args)

--- a/tool/callbacks_test.go
+++ b/tool/callbacks_test.go
@@ -490,7 +490,7 @@ func TestRunAfterTool_Empty(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Nil(t, result.CustomResult)
+	require.Equal(t, originalResult, result.CustomResult)
 }
 
 func TestRunAfterTool_PanicRecovery(t *testing.T) {
@@ -915,7 +915,7 @@ func TestRunAfterTool_NoCallbacksPreservesOriginalResultShape(t *testing.T) {
 	result, err := callbacks.RunAfterTool(context.Background(), afterArgs)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Nil(t, result.CustomResult)
+	require.Same(t, rawResult, result.CustomResult)
 	require.Same(t, rawResult, afterArgs.Result)
 }
 
@@ -1148,8 +1148,7 @@ func TestToolCallbacks_ContextPropagation(t *testing.T) {
 }
 
 // TestToolCallbacks_After_NoCallbacks_WithResult tests that when no callbacks
-// are registered, RunAfterTool does not treat the original result as a custom
-// replacement.
+// are registered and args.Result is not nil, RunAfterTool returns the original result.
 func TestToolCallbacks_After_NoCallbacks_WithResult(t *testing.T) {
 	callbacks := tool.NewCallbacks()
 	originalResult := map[string]string{"key": "value"}
@@ -1163,7 +1162,7 @@ func TestToolCallbacks_After_NoCallbacks_WithResult(t *testing.T) {
 	result, err := callbacks.RunAfterTool(context.Background(), args)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Nil(t, result.CustomResult)
+	require.Equal(t, originalResult, result.CustomResult)
 }
 
 // TestToolCallbacks_After_NoCallbacks_WithoutResult tests that when no callbacks

--- a/tool/callbacks_test.go
+++ b/tool/callbacks_test.go
@@ -1204,6 +1204,24 @@ func TestToolCallbacks_After_NilResultDoesNotEchoOriginal(t *testing.T) {
 	require.Nil(t, result.CustomResult)
 }
 
+func TestRunAfterTool_EmptyMapCustomResultIsReplacement(t *testing.T) {
+	callbacks := tool.NewCallbacks()
+	empty := map[string]any{}
+	callbacks.RegisterAfterTool(func(
+		context.Context,
+		*tool.AfterToolArgs,
+	) (*tool.AfterToolResult, error) {
+		return &tool.AfterToolResult{CustomResult: empty}, nil
+	})
+	result, err := callbacks.RunAfterTool(
+		context.Background(),
+		&tool.AfterToolArgs{Result: map[string]any{"original": true}},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, empty, result.CustomResult)
+}
+
 // TestToolCallbacks_After_NilResult tests that when a callback returns
 // nil result, RunAfterTool continues to the next callback.
 func TestToolCallbacks_After_NilResult(t *testing.T) {


### PR DESCRIPTION
## What changed

Plugin AfterTool hooks that do not replace the tool result no longer skip Agent or graph-node AfterTool callbacks. A plugin such as ToolSearch can implement only BeforeTool, and Agent-level AfterTool still runs.

## Why

The plugin layer treats a non-nil `CustomResult` as an override. When a plugin registers BeforeTool but no AfterTool, `RunAfterTool` still echoes `args.Result` as `CustomResult` for direct callers. Dispatchers now skip an empty AfterTool list so that echo is not treated as a plugin override.

Registered AfterTool callbacks that return nil keep `CustomResult` nil, so observer plugins such as debuglog do not skip later Agent AfterTool hooks.

## Testing

- [x] `go test ./tool ./plugin/toolerror ./internal/flow/processor ./graph -count=1`
- [x] Regression: no AfterTool callbacks still echo `args.Result` as `CustomResult`
- [x] Regression: plugin with only BeforeTool, or AfterTool returning nil / empty result, still invokes local AfterTool
- [x] Regression: empty-map `CustomResult` skips local AfterTool

## Notes for reviewers

`RunAfterTool` keeps the released no-callback contract (`CustomResult = args.Result` when no AfterTool hooks are registered). Direct callers that inspect `CustomResult` after a registered pass-through callback (`nil` / no `CustomResult`) should keep using the original tool result.