### PR TITLE
{server/agui, docs}: add best-effort history snapshots

### DIFF
--- a/docs/mkdocs/en/agui/history.md
+++ b/docs/mkdocs/en/agui/history.md
@@ -277,3 +277,27 @@ server, err := agui.New(
 ```
 
 For the complete example, see [examples/agui/server/follow](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/follow). For the frontend, see [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat).
+
+## Best-Effort History Loading
+
+By default, messages snapshots strictly validate pairing relationships between persisted AG-UI events. For example, `TEXT_MESSAGE_CONTENT` must be preceded by `TEXT_MESSAGE_START` for the same message, and `TOOL_CALL_RESULT` must match a tool call whose argument stream has completed. If historical data contains missing, out-of-order, or duplicate events, the snapshot route tries to return the `MESSAGES_SNAPSHOT` restored before the failure point, and then returns `RUN_ERROR`.
+
+If production history data may contain a small number of incomplete events because of connection interruptions, frontend tool-call fallback, storage write failures, or version switches, enable best-effort loading:
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+)
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotBestEffortEnabled(true),
+)
+```
+
+After this is enabled, messages snapshots skip individual AG-UI events that cannot be decoded or paired while restoring history, and continue processing subsequent events. Skipped events are only written to warn logs and do not make the current `/history` request return `RUN_ERROR`. If later events can still form complete messages, they continue to appear in `MESSAGES_SNAPSHOT.messages`. This mode only affects history snapshot restoration. It does not change the real-time conversation route execution behavior, and it cannot restore historical event content that has already been lost.
+
+Best-effort loading only handles cases where event content can be read but cannot be restored as a valid message. If session storage reads fail, `SessionService` returns an error, or the messages snapshot route cannot locate the session, the server still returns `RUN_ERROR`.

--- a/docs/mkdocs/zh/agui/history.md
+++ b/docs/mkdocs/zh/agui/history.md
@@ -277,3 +277,27 @@ server, err := agui.New(
 ```
 
 完整示例可参考 [examples/agui/server/follow](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/server/follow)，前端可参考 [examples/agui/client/tdesign-chat](https://github.com/trpc-group/trpc-agent-go/tree/main/examples/agui/client/tdesign-chat)。
+
+## 尽力加载历史
+
+默认情况下，消息快照会严格校验已持久化 AG-UI 事件之间的配对关系。比如 `TEXT_MESSAGE_CONTENT` 需要先看到同一条消息的 `TEXT_MESSAGE_START`，`TOOL_CALL_RESULT` 需要匹配已经完成参数流的工具调用。如果历史数据中存在缺失、乱序或重复事件，快照路由会尽量返回出错位置之前已经还原出的 `MESSAGES_SNAPSHOT`，随后返回 `RUN_ERROR`。
+
+如果线上历史数据可能因为连接中断、前端工具调用降级、存储写入失败或版本切换而出现少量不完整事件，可以开启尽力加载模式：
+
+```go
+import (
+	"trpc.group/trpc-go/trpc-agent-go/server/agui"
+)
+
+server, err := agui.New(
+    runner,
+    agui.WithAppName(appName),
+    agui.WithSessionService(sessionService),
+    agui.WithMessagesSnapshotEnabled(true),
+    agui.WithMessagesSnapshotBestEffortEnabled(true),
+)
+```
+
+开启后，消息快照在还原历史时会跳过无法识别或无法配对的单条 AG-UI event，并继续处理后续事件。被跳过的事件只会写入 warn 日志，不会让本次 `/history` 请求返回 `RUN_ERROR`；如果后续事件仍然能组成完整消息，它们会继续出现在 `MESSAGES_SNAPSHOT.messages` 中。该模式只影响历史快照还原，不改变实时对话路由的执行行为，也不会修复已经缺失的历史事件内容。
+
+尽力加载只处理事件内容可读取但无法还原为合法消息的情况。如果会话存储读取失败、`SessionService` 返回错误，或者消息快照路由无法定位会话，服务端仍会返回 `RUN_ERROR`。

--- a/server/agui/internal/reduce/options.go
+++ b/server/agui/internal/reduce/options.go
@@ -14,6 +14,7 @@ type Option func(*options)
 
 type options struct {
 	includeRunLifecycleEvents bool
+	bestEffort                bool
 }
 
 // WithRunLifecycleEvents controls whether RUN_* lifecycle events are included in the
@@ -21,5 +22,13 @@ type options struct {
 func WithRunLifecycleEvents(include bool) Option {
 	return func(o *options) {
 		o.includeRunLifecycleEvents = include
+	}
+}
+
+// WithBestEffort controls whether malformed track events are skipped while
+// reducing a message snapshot.
+func WithBestEffort(enabled bool) Option {
+	return func(o *options) {
+		o.bestEffort = enabled
 	}
 }

--- a/server/agui/internal/reduce/reduce.go
+++ b/server/agui/internal/reduce/reduce.go
@@ -17,6 +17,7 @@ import (
 
 	aguievents "github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/events"
 	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+	"trpc.group/trpc-go/trpc-agent-go/log"
 	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/server/agui/internal/multimodal"
 	"trpc.group/trpc-go/trpc-agent-go/session"
@@ -99,6 +100,11 @@ func Reduce(appName, userID string, events []session.TrackEvent, opt ...Option) 
 	for _, trackEvent := range events {
 		if err = r.reduce(trackEvent); err != nil {
 			err = fmt.Errorf("reduce: %w", err)
+			if opts.bestEffort {
+				log.Warnf("agui reduce: skip malformed track event: err=%v", err)
+				err = nil
+				continue
+			}
 			break
 		}
 	}

--- a/server/agui/internal/reduce/reduce_test.go
+++ b/server/agui/internal/reduce/reduce_test.go
@@ -275,6 +275,53 @@ func TestReduceReturnsMessagesOnReduceError(t *testing.T) {
 	assert.Equal(t, "hello", content)
 }
 
+func TestReduceBestEffortSkipsMalformedEvents(t *testing.T) {
+	t.Run("text event without start", func(t *testing.T) {
+		events := trackEventsFrom(
+			aguievents.NewTextMessageStartEvent("user-1", aguievents.WithRole("user")),
+			aguievents.NewTextMessageContentEvent("user-1", "hello"),
+			aguievents.NewTextMessageEndEvent("user-1"),
+			aguievents.NewTextMessageContentEvent("user-1", "!"),
+			aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+			aguievents.NewTextMessageContentEvent("assistant-1", "after"),
+			aguievents.NewTextMessageEndEvent("assistant-1"),
+		)
+
+		msgs, err := Reduce(testAppName, testUserID, events, WithBestEffort(true))
+
+		require.NoError(t, err)
+		require.Len(t, msgs, 2)
+		content, ok := msgs[0].ContentString()
+		require.True(t, ok)
+		assert.Equal(t, "hello", content)
+		content, ok = msgs[1].ContentString()
+		require.True(t, ok)
+		assert.Equal(t, "after", content)
+	})
+
+	t.Run("tool result without completed call", func(t *testing.T) {
+		events := trackEventsFrom(
+			aguievents.NewTextMessageStartEvent("user-1", aguievents.WithRole("user")),
+			aguievents.NewTextMessageContentEvent("user-1", "hello"),
+			aguievents.NewTextMessageEndEvent("user-1"),
+			aguievents.NewToolCallResultEvent("tool-msg-1", "missing-call", "orphan"),
+			aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant")),
+			aguievents.NewTextMessageContentEvent("assistant-1", "after"),
+			aguievents.NewTextMessageEndEvent("assistant-1"),
+		)
+
+		msgs, err := Reduce(testAppName, testUserID, events, WithBestEffort(true))
+
+		require.NoError(t, err)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, types.RoleUser, msgs[0].Role)
+		assert.Equal(t, types.RoleAssistant, msgs[1].Role)
+		content, ok := msgs[1].ContentString()
+		require.True(t, ok)
+		assert.Equal(t, "after", content)
+	})
+}
+
 func TestReduceAllowsUnclosedTextMessage(t *testing.T) {
 	events := trackEventsFrom(
 		aguievents.NewTextMessageStartEvent("user-1", aguievents.WithRole("user")),

--- a/server/agui/options.go
+++ b/server/agui/options.go
@@ -304,6 +304,14 @@ func WithMessagesSnapshotRunLifecycleEventsEnabled(enabled bool) Option {
 	}
 }
 
+// WithMessagesSnapshotBestEffortEnabled controls whether malformed history
+// track events are skipped while building MESSAGES_SNAPSHOT.
+func WithMessagesSnapshotBestEffortEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.aguiRunnerOptions = append(o.aguiRunnerOptions, aguirunner.WithMessagesSnapshotBestEffortEnabled(enabled))
+	}
+}
+
 // WithAppName sets the app name.
 func WithAppName(n string) Option {
 	return func(o *options) {

--- a/server/agui/options_test.go
+++ b/server/agui/options_test.go
@@ -207,6 +207,12 @@ func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {
 	assert.True(t, ro.MessagesSnapshotRunLifecycleEventsEnabled)
 }
 
+func TestWithMessagesSnapshotBestEffortEnabled(t *testing.T) {
+	opts := newOptions(WithMessagesSnapshotBestEffortEnabled(true))
+	ro := aguirunner.NewOptions(opts.aguiRunnerOptions...)
+	assert.True(t, ro.MessagesSnapshotBestEffortEnabled)
+}
+
 func TestWithCancelEnabled(t *testing.T) {
 	opts := newOptions(WithCancelEnabled(true))
 	assert.True(t, opts.cancelEnabled)

--- a/server/agui/runner/messagessnapshot.go
+++ b/server/agui/runner/messagessnapshot.go
@@ -151,6 +151,7 @@ func (r *runner) getMessagesSnapshotEvent(ctx context.Context,
 		sessionKey.UserID,
 		eventsForReduce,
 		reduce.WithRunLifecycleEvents(r.messagesSnapshotRunLifecycleEventsEnabled),
+		reduce.WithBestEffort(r.messagesSnapshotBestEffortEnabled),
 	)
 	if err != nil {
 		err = fmt.Errorf("reduce track events: %w", err)

--- a/server/agui/runner/messagessnapshot_test.go
+++ b/server/agui/runner/messagessnapshot_test.go
@@ -1161,6 +1161,44 @@ func TestMessagesSnapshotReduceErrorEmitsSnapshotThenError(t *testing.T) {
 	assert.Contains(t, errEvt.Message, "reduce track events")
 }
 
+func TestMessagesSnapshotBestEffortSkipsReduceError(t *testing.T) {
+	svc := &testSessionService{
+		trackEvents: []session.TrackEvent{
+			newUserMessageTrackEvent(t, "user-1", "hello"),
+			newTrackEvent(t, aguievents.NewTextMessageContentEvent("user-1", "!")),
+			newTrackEvent(t, aguievents.NewTextMessageStartEvent("assistant-1", aguievents.WithRole("assistant"))),
+			newTrackEvent(t, aguievents.NewTextMessageContentEvent("assistant-1", "after")),
+			newTrackEvent(t, aguievents.NewTextMessageEndEvent("assistant-1")),
+		},
+	}
+	tracker, err := track.New(svc)
+	require.NoError(t, err)
+	r := &runner{
+		runner:                            noopBaseRunner{},
+		userIDResolver:                    NewOptions().UserIDResolver,
+		runAgentInputHook:                 NewOptions().RunAgentInputHook,
+		appName:                           "demo",
+		tracker:                           tracker,
+		messagesSnapshotBestEffortEnabled: true,
+	}
+
+	stream, err := r.MessagesSnapshot(context.Background(), &adapter.RunAgentInput{ThreadID: "thread", RunID: "run"})
+	require.NoError(t, err)
+	collected := collectAGUIEvents(t, stream)
+	require.Len(t, collected, 3)
+	require.IsType(t, (*aguievents.RunStartedEvent)(nil), collected[0])
+	snapshot, ok := collected[1].(*aguievents.MessagesSnapshotEvent)
+	require.True(t, ok)
+	require.Len(t, snapshot.Messages, 2)
+	userContent, ok := snapshot.Messages[0].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "hello", userContent)
+	assistantContent, ok := snapshot.Messages[1].ContentString()
+	require.True(t, ok)
+	assert.Equal(t, "after", assistantContent)
+	require.IsType(t, (*aguievents.RunFinishedEvent)(nil), collected[2])
+}
+
 func TestMessagesSnapshotFollowUntilTerminalEvent(t *testing.T) {
 	base := time.Now().Add(-time.Second)
 	initial := &session.TrackEvents{

--- a/server/agui/runner/options.go
+++ b/server/agui/runner/options.go
@@ -57,6 +57,7 @@ type Options struct {
 	MessagesSnapshotFollowEnabled             bool                  // MessagesSnapshotFollowEnabled enables tailing persisted AG-UI track events after MESSAGES_SNAPSHOT.
 	MessagesSnapshotFollowMaxDuration         time.Duration         // MessagesSnapshotFollowMaxDuration bounds how long tailing can run before emitting RUN_ERROR.
 	MessagesSnapshotRunLifecycleEventsEnabled bool                  // MessagesSnapshotRunLifecycleEventsEnabled includes persisted RUN_* events as activity messages in MESSAGES_SNAPSHOT.
+	MessagesSnapshotBestEffortEnabled         bool                  // MessagesSnapshotBestEffortEnabled skips malformed track events while reducing history snapshots.
 	StartSpan                                 StartSpan             // StartSpan starts a span for an AG-UI run.
 	PostRunFinalizationTimeout                time.Duration         // PostRunFinalizationTimeout bounds how long post-run finalization is allowed to take.
 	TrackPersistenceTimeout                   time.Duration         // TrackPersistenceTimeout bounds how long AG-UI track persistence is allowed to take.
@@ -234,6 +235,14 @@ func WithMessagesSnapshotFollowMaxDuration(d time.Duration) Option {
 func WithMessagesSnapshotRunLifecycleEventsEnabled(enabled bool) Option {
 	return func(o *Options) {
 		o.MessagesSnapshotRunLifecycleEventsEnabled = enabled
+	}
+}
+
+// WithMessagesSnapshotBestEffortEnabled controls whether malformed history
+// track events are skipped while building MESSAGES_SNAPSHOT.
+func WithMessagesSnapshotBestEffortEnabled(enabled bool) Option {
+	return func(o *Options) {
+		o.MessagesSnapshotBestEffortEnabled = enabled
 	}
 }
 

--- a/server/agui/runner/options_test.go
+++ b/server/agui/runner/options_test.go
@@ -85,6 +85,7 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.StreamingToolResultActivityEnabled)
 	assert.True(t, opts.ConcurrentMessageStreamsEnabled)
 	assert.False(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
+	assert.False(t, opts.MessagesSnapshotBestEffortEnabled)
 	assert.False(t, opts.DistributedCancelEnabled)
 	assert.Equal(t, time.Second, opts.DistributedCancelPollInterval)
 }
@@ -203,6 +204,11 @@ func TestWithConcurrentMessageStreamsEnabled(t *testing.T) {
 func TestWithMessagesSnapshotRunLifecycleEventsEnabled(t *testing.T) {
 	opts := NewOptions(WithMessagesSnapshotRunLifecycleEventsEnabled(true))
 	assert.True(t, opts.MessagesSnapshotRunLifecycleEventsEnabled)
+}
+
+func TestWithMessagesSnapshotBestEffortEnabled(t *testing.T) {
+	opts := NewOptions(WithMessagesSnapshotBestEffortEnabled(true))
+	assert.True(t, opts.MessagesSnapshotBestEffortEnabled)
 }
 
 func TestWithPostRunFinalizationTimeout(t *testing.T) {

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -102,6 +102,7 @@ func New(r trunner.Runner, opt ...Option) Runner {
 		messagesSnapshotFollowEnabled:          opts.MessagesSnapshotFollowEnabled,
 		messagesSnapshotFollowMaxDuration:      opts.MessagesSnapshotFollowMaxDuration,
 		messagesSnapshotRunLifecycleEventsEnabled: opts.MessagesSnapshotRunLifecycleEventsEnabled,
+		messagesSnapshotBestEffortEnabled:         opts.MessagesSnapshotBestEffortEnabled,
 		toolResultInputTranslationEnabled:         opts.ToolResultInputTranslationEnabled,
 		toolCallDeltaStreamingEnabled:             opts.ToolCallDeltaStreamingEnabled,
 		streamingToolResultActivityEnabled:        opts.StreamingToolResultActivityEnabled,
@@ -142,6 +143,7 @@ type runner struct {
 	messagesSnapshotFollowEnabled             bool
 	messagesSnapshotFollowMaxDuration         time.Duration
 	messagesSnapshotRunLifecycleEventsEnabled bool
+	messagesSnapshotBestEffortEnabled         bool
 	toolResultInputTranslationEnabled         bool
 	toolCallDeltaStreamingEnabled             bool
 	streamingToolResultActivityEnabled        bool


### PR DESCRIPTION
Persisted AG-UI history can contain missing, out-of-order, or duplicate events after connection interruptions, frontend tool-call fallback, storage write failures, or version switches, which currently makes message snapshot replay stop at the first malformed event and return RUN_ERROR. This adds an opt-in best-effort messages snapshot mode that logs malformed events, skips them during reduction, and continues restoring later messages while preserving strict mode by default, with bilingual documentation for the new option.