### PR TITLE
{runner, docs}: add global runner after-run hooks

### DIFF
--- a/docs/mkdocs/en/plugin.md
+++ b/docs/mkdocs/en/plugin.md
@@ -383,6 +383,41 @@ the appropriate time in the caller.
 - `OnEvent`: runs for every event emitted by Runner (including runner completion
   events). You can mutate the event in place or return a replacement event.
 
+### Runner completion hooks
+
+- `Registry.AfterRun`: observes the finalized Runner completion event after its
+  execution trace input and output have been populated. It runs once for the
+  root Runner run, not once per sub-agent invocation. The hook receives a
+  completion-event snapshot, so mutations do not affect Runner output. Hook
+  errors are logged and do not fail the run.
+- `runner.RegisterGlobalAfterRunHook`: registers the same completion hook for
+  every Runner run in the process. This entry point is intended for
+  process-wide infrastructure integrations that cannot add
+  `runner.WithPlugins(...)` to every Runner. Registration is permanent for the
+  process lifetime; names must be unique, hooks must be safe for concurrent
+  use, and Runner does not own or close hook resources. Hooks execute
+  synchronously and should hand blocking export work to their own bounded
+  queue.
+
+Global AfterRun hooks run after Runner-scoped and per-run plugin AfterRun hooks.
+Their context is detached from run cancellation and carries the root
+`invoke_agent` SpanContext when framework tracing captured a recording root
+span. Otherwise, the context contains an invalid SpanContext instead of
+inheriting an unrelated caller span.
+
+```go
+err := runner.RegisterGlobalAfterRunHook(
+	"audit-exporter",
+	func(ctx context.Context, args *plugin.AfterRunArgs) error {
+		// Enqueue the completion snapshot without blocking Runner shutdown.
+		return enqueue(ctx, args.CompletionEvent)
+	},
+)
+if err != nil {
+	return err
+}
+```
+
 ### Graph node hooks (StateGraph / GraphAgent)
 
 Runner plugins intentionally do **not** expose a `BeforeNode` / `AfterNode`

--- a/docs/mkdocs/zh/plugin.md
+++ b/docs/mkdocs/zh/plugin.md
@@ -404,6 +404,28 @@ if toolCallID, ok := tool.ToolCallIDFromContext(ctx); ok {
 - `OnEvent`：Runner 发出每一个事件时都会调用（包括 runner completion 事件）。你可以
   原地修改事件，或者返回一个新的事件作为替代。
 
+### Runner 完成 Hook
+
+- `Registry.AfterRun`：在 ExecutionTrace 的输入、输出完成填充后观测最终 Runner
+  completion event。它只对根 Runner run 调用一次，不会对每个子 Agent invocation
+  调用。Hook 收到独立快照，修改不会影响 Runner 输出；错误只记录日志，不会让运行失败。
+- `runner.RegisterGlobalAfterRunHook`：为进程内所有 Runner 注册相同的完成 Hook，适合
+  无法向每个 Runner 注入 `runner.WithPlugins(...)` 的基础设施集成。注册在进程生命周期
+  内永久有效且名称唯一；Hook 必须并发安全，并将阻塞式导出交给自身的有界队列。
+
+全局 AfterRun Hook 在 Runner 级和单次 Run 插件的 AfterRun 之后同步执行。它收到的
+context 已脱离运行取消；框架 tracing 捕获到 recording 的根 `invoke_agent` span 时，
+context 携带该 SpanContext，否则显式携带无效 SpanContext，不会错误继承调用方的 span。
+
+```go
+err := runner.RegisterGlobalAfterRunHook(
+	"audit-exporter",
+	func(ctx context.Context, args *plugin.AfterRunArgs) error {
+		return enqueue(ctx, args.CompletionEvent)
+	},
+)
+```
+
 ### Graph 节点 Hook（StateGraph / GraphAgent）
 
 Runner 插件**不会**提供 `BeforeNode` / `AfterNode` 这类“节点级”的 Hook 点。

--- a/runner/global_after_run.go
+++ b/runner/global_after_run.go
@@ -160,10 +160,7 @@ func applyGlobalAfterRunHooks(
 		state.spanContext.load(),
 	)
 	for _, registered := range state.hooks {
-		completionSnapshot := completionEvent.Clone()
-		if completionSnapshot != nil {
-			completionSnapshot.ID = completionEvent.ID
-		}
+		completionSnapshot := cloneAfterRunCompletionEvent(completionEvent)
 		invokeGlobalAfterRunHook(
 			hookCtx,
 			registered,

--- a/runner/global_after_run.go
+++ b/runner/global_after_run.go
@@ -1,0 +1,202 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/log"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+)
+
+var (
+	errGlobalAfterRunHookNameEmpty = errors.New(
+		"runner: global after-run hook name is empty",
+	)
+	errGlobalAfterRunHookNil = errors.New(
+		"runner: global after-run hook is nil",
+	)
+)
+
+type namedGlobalAfterRunHook struct {
+	name string
+	hook plugin.AfterRunHook
+}
+
+var globalAfterRunHooks = struct {
+	sync.RWMutex
+	hooks []namedGlobalAfterRunHook
+	names map[string]struct{}
+}{}
+
+// RegisterGlobalAfterRunHook registers a process-wide hook that observes
+// completed Runner runs.
+//
+// Hooks are identified by a non-empty, process-unique name. Registration is
+// permanent for the process lifetime and affects runs that start after the
+// registration completes, including runs on existing Runner instances. A hook
+// must be safe for concurrent use and must treat the supplied Invocation as
+// read-only. Each hook receives its own snapshot of the finalized completion
+// event. Process-wide hooks run after Runner-scoped and per-run plugin AfterRun
+// hooks. Runner invokes hooks synchronously, so they must return promptly and
+// move blocking work to infrastructure they own. Hook errors and panics are
+// logged and do not change Runner output.
+//
+// The hook context is detached from run cancellation and contains the root
+// invoke_agent SpanContext when framework tracing captured a recording root
+// span. When no root SpanContext was captured, the context contains an invalid
+// SpanContext rather than inheriting an unrelated caller span.
+//
+// The registering component owns the hook and any resources it uses. Runner
+// does not close process-wide hooks. RegisterGlobalAfterRunHook returns an
+// error for an empty name, a nil hook, or a duplicate name.
+func RegisterGlobalAfterRunHook(
+	name string,
+	hook plugin.AfterRunHook,
+) error {
+	if name == "" {
+		return errGlobalAfterRunHookNameEmpty
+	}
+	if hook == nil {
+		return errGlobalAfterRunHookNil
+	}
+
+	globalAfterRunHooks.Lock()
+	defer globalAfterRunHooks.Unlock()
+	if globalAfterRunHooks.names == nil {
+		globalAfterRunHooks.names = make(map[string]struct{})
+	}
+	if _, ok := globalAfterRunHooks.names[name]; ok {
+		return fmt.Errorf("runner: duplicate global after-run hook %q", name)
+	}
+	globalAfterRunHooks.names[name] = struct{}{}
+	globalAfterRunHooks.hooks = append(
+		globalAfterRunHooks.hooks,
+		namedGlobalAfterRunHook{name: name, hook: hook},
+	)
+	return nil
+}
+
+func snapshotGlobalAfterRunHooks() []namedGlobalAfterRunHook {
+	globalAfterRunHooks.RLock()
+	defer globalAfterRunHooks.RUnlock()
+	return append([]namedGlobalAfterRunHook(nil), globalAfterRunHooks.hooks...)
+}
+
+type globalAfterRunState struct {
+	hooks       []namedGlobalAfterRunHook
+	spanContext rootSpanContextCapture
+}
+
+func prepareGlobalAfterRunState() *globalAfterRunState {
+	hooks := snapshotGlobalAfterRunHooks()
+	if len(hooks) == 0 {
+		return nil
+	}
+	return &globalAfterRunState{hooks: hooks}
+}
+
+func (s *globalAfterRunState) attach(invocation *agent.Invocation) {
+	if s == nil || invocation == nil {
+		return
+	}
+	invocation.RunOptions.TraceStartedCallbacks = append(
+		invocation.RunOptions.TraceStartedCallbacks,
+		s.spanContext.store,
+	)
+}
+
+type rootSpanContextCapture struct {
+	mu          sync.RWMutex
+	spanContext oteltrace.SpanContext
+}
+
+func (c *rootSpanContextCapture) store(spanContext oteltrace.SpanContext) {
+	if c == nil || !spanContext.IsValid() {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.spanContext.IsValid() {
+		return
+	}
+	c.spanContext = spanContext
+}
+
+func (c *rootSpanContextCapture) load() oteltrace.SpanContext {
+	if c == nil {
+		return oteltrace.SpanContext{}
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.spanContext
+}
+
+func applyGlobalAfterRunHooks(
+	ctx context.Context,
+	state *globalAfterRunState,
+	invocation *agent.Invocation,
+	completionEvent *event.Event,
+) {
+	if state == nil || invocation == nil || completionEvent == nil {
+		return
+	}
+	hookCtx := oteltrace.ContextWithSpanContext(
+		context.WithoutCancel(ctx),
+		state.spanContext.load(),
+	)
+	for _, registered := range state.hooks {
+		completionSnapshot := completionEvent.Clone()
+		if completionSnapshot != nil {
+			completionSnapshot.ID = completionEvent.ID
+		}
+		invokeGlobalAfterRunHook(
+			hookCtx,
+			registered,
+			&plugin.AfterRunArgs{
+				Invocation:      invocation,
+				CompletionEvent: completionSnapshot,
+			},
+		)
+	}
+}
+
+func invokeGlobalAfterRunHook(
+	ctx context.Context,
+	registered namedGlobalAfterRunHook,
+	args *plugin.AfterRunArgs,
+) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.ErrorfContext(
+				ctx,
+				log.PanicPrefix+" global after-run hook %q panicked: %v\n%s",
+				registered.name,
+				recovered,
+				string(debug.Stack()),
+			)
+		}
+	}()
+	if err := registered.hook(ctx, args); err != nil {
+		log.ErrorfContext(
+			ctx,
+			"global after-run hook %q failed: %v",
+			registered.name,
+			err,
+		)
+	}
+}

--- a/runner/global_after_run_test.go
+++ b/runner/global_after_run_test.go
@@ -261,6 +261,61 @@ func TestGlobalAfterRunHooksIsolateNestedCompletionData(t *testing.T) {
 	)
 }
 
+func TestGlobalAfterRunHooksIsolateResponseErrorPointers(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+
+	param := "original-param"
+	code := "original-code"
+	completion := event.NewResponseEvent(
+		"invocation",
+		"runner",
+		&model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Error: &model.ResponseError{
+				Type:    model.ErrorTypeRunError,
+				Message: "original-message",
+				Param:   &param,
+				Code:    &code,
+			},
+		},
+	)
+	var (
+		secondParam string
+		secondCode  string
+	)
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"mutator",
+		func(_ context.Context, args *plugin.AfterRunArgs) error {
+			*args.CompletionEvent.Response.Error.Param = "mutated-param"
+			*args.CompletionEvent.Response.Error.Code = "mutated-code"
+			return nil
+		},
+	))
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"observer",
+		func(_ context.Context, args *plugin.AfterRunArgs) error {
+			err := args.CompletionEvent.Response.Error
+			secondParam = *err.Param
+			secondCode = *err.Code
+			return nil
+		},
+	))
+
+	applyGlobalAfterRunHooks(
+		context.Background(),
+		prepareGlobalAfterRunState(),
+		agent.NewInvocation(),
+		completion,
+	)
+
+	assert.Equal(t, "original-param", secondParam)
+	assert.Equal(t, "original-code", secondCode)
+	require.NotNil(t, completion.Response)
+	require.NotNil(t, completion.Response.Error)
+	assert.Equal(t, "original-param", *completion.Response.Error.Param)
+	assert.Equal(t, "original-code", *completion.Response.Error.Code)
+}
+
 func TestGlobalAfterRunHookFailuresDoNotAffectCompletion(t *testing.T) {
 	isolateGlobalAfterRunHooks(t)
 	installGlobalAfterRunTestTracer(t)

--- a/runner/global_after_run_test.go
+++ b/runner/global_after_run_test.go
@@ -188,6 +188,79 @@ func TestGlobalAfterRunHooksObserveCompletedRun(t *testing.T) {
 	assert.True(t, matchedRootSpan)
 }
 
+func TestGlobalAfterRunHooksIsolateNestedCompletionData(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+
+	text := "original"
+	arguments := []byte(`{"value":"original"}`)
+	completion := event.NewResponseEvent(
+		"invocation",
+		"runner",
+		&model.Response{
+			Object: model.ObjectTypeRunnerCompletion,
+			Choices: []model.Choice{{
+				Message: model.Message{
+					ContentParts: []model.ContentPart{
+						{Type: model.ContentTypeText, Text: &text},
+						{Type: model.ContentTypeImage, Image: &model.Image{Data: []byte("image")}},
+					},
+					ToolCalls: []model.ToolCall{{
+						Function: model.FunctionDefinitionParam{Arguments: arguments},
+						ExtraFields: map[string]any{
+							"nested": map[string]any{"key": "original"},
+						},
+					}},
+				},
+			}},
+		},
+	)
+	var (
+		secondText      string
+		secondArguments string
+		secondExtra     string
+	)
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"mutator",
+		func(_ context.Context, args *plugin.AfterRunArgs) error {
+			choice := args.CompletionEvent.Choices[0]
+			*choice.Message.ContentParts[0].Text = "mutated"
+			choice.Message.ContentParts[1].Image.Data[0] = 'X'
+			choice.Message.ToolCalls[0].Function.Arguments[0] = '['
+			choice.Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"] = "mutated"
+			return nil
+		},
+	))
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"observer",
+		func(_ context.Context, args *plugin.AfterRunArgs) error {
+			choice := args.CompletionEvent.Choices[0]
+			secondText = *choice.Message.ContentParts[0].Text
+			secondArguments = string(choice.Message.ToolCalls[0].Function.Arguments)
+			secondExtra = choice.Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"].(string)
+			return nil
+		},
+	))
+
+	applyGlobalAfterRunHooks(
+		context.Background(),
+		prepareGlobalAfterRunState(),
+		agent.NewInvocation(),
+		completion,
+	)
+
+	assert.Equal(t, "original", secondText)
+	assert.Equal(t, `{"value":"original"}`, secondArguments)
+	assert.Equal(t, "original", secondExtra)
+	assert.Equal(t, "original", *completion.Choices[0].Message.ContentParts[0].Text)
+	assert.Equal(t, []byte("image"), completion.Choices[0].Message.ContentParts[1].Image.Data)
+	assert.Equal(t, `{"value":"original"}`, string(completion.Choices[0].Message.ToolCalls[0].Function.Arguments))
+	assert.Equal(
+		t,
+		"original",
+		completion.Choices[0].Message.ToolCalls[0].ExtraFields["nested"].(map[string]any)["key"],
+	)
+}
+
 func TestGlobalAfterRunHookFailuresDoNotAffectCompletion(t *testing.T) {
 	isolateGlobalAfterRunHooks(t)
 	installGlobalAfterRunTestTracer(t)

--- a/runner/global_after_run_test.go
+++ b/runner/global_after_run_test.go
@@ -1,0 +1,422 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"trpc.group/trpc-go/trpc-agent-go/agent"
+	"trpc.group/trpc-go/trpc-agent-go/agent/llmagent"
+	"trpc.group/trpc-go/trpc-agent-go/event"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+	"trpc.group/trpc-go/trpc-agent-go/plugin"
+	telemetrytrace "trpc.group/trpc-go/trpc-agent-go/telemetry/trace"
+)
+
+func TestRegisterGlobalAfterRunHookValidatesRegistration(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	hook := func(context.Context, *plugin.AfterRunArgs) error { return nil }
+
+	require.ErrorIs(
+		t,
+		RegisterGlobalAfterRunHook("", hook),
+		errGlobalAfterRunHookNameEmpty,
+	)
+	require.ErrorIs(
+		t,
+		RegisterGlobalAfterRunHook("nil", nil),
+		errGlobalAfterRunHookNil,
+	)
+	require.NoError(t, RegisterGlobalAfterRunHook("observer", hook))
+	require.EqualError(
+		t,
+		RegisterGlobalAfterRunHook("observer", hook),
+		`runner: duplicate global after-run hook "observer"`,
+	)
+
+	hooks := snapshotGlobalAfterRunHooks()
+	require.Len(t, hooks, 1)
+	assert.Equal(t, "observer", hooks[0].name)
+}
+
+func TestRegisterGlobalAfterRunHookIsConcurrentSafe(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	hook := func(context.Context, *plugin.AfterRunArgs) error { return nil }
+
+	const uniqueHooks = 32
+	results := make(chan error, uniqueHooks)
+	var wg sync.WaitGroup
+	for i := 0; i < uniqueHooks; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			results <- RegisterGlobalAfterRunHook(
+				fmt.Sprintf("observer-%d", index),
+				hook,
+			)
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+	for err := range results {
+		require.NoError(t, err)
+	}
+
+	const duplicateRegistrations = 16
+	results = make(chan error, duplicateRegistrations)
+	for i := 0; i < duplicateRegistrations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- RegisterGlobalAfterRunHook("shared", hook)
+		}()
+	}
+	wg.Wait()
+	close(results)
+	var successfulDuplicates int
+	for err := range results {
+		if err == nil {
+			successfulDuplicates++
+		}
+	}
+	assert.Equal(t, 1, successfulDuplicates)
+	assert.Len(t, snapshotGlobalAfterRunHooks(), uniqueHooks+1)
+}
+
+func TestGlobalAfterRunHooksObserveCompletedRun(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	exporter := installGlobalAfterRunTestTracer(t)
+	agt := llmagent.New(
+		"root-agent",
+		llmagent.WithModel(&staticModel{name: "test-model", content: "done"}),
+	)
+	r := NewRunner("test-app", agt)
+
+	var (
+		calls             []string
+		firstSpanContext  oteltrace.SpanContext
+		secondSpanContext oteltrace.SpanContext
+		firstHadTrace     bool
+		secondHadTrace    bool
+		secondTag         string
+		secondInput       string
+	)
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"first",
+		func(ctx context.Context, args *plugin.AfterRunArgs) error {
+			calls = append(calls, "first")
+			firstSpanContext = oteltrace.SpanContextFromContext(ctx)
+			if args == nil || args.CompletionEvent == nil ||
+				args.CompletionEvent.ExecutionTrace == nil {
+				return nil
+			}
+			firstHadTrace = true
+			args.CompletionEvent.Tag = "mutated"
+			if args.CompletionEvent.ExecutionTrace.Input != nil {
+				args.CompletionEvent.ExecutionTrace.Input.Text = "mutated"
+			}
+			return nil
+		},
+	))
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"second",
+		func(ctx context.Context, args *plugin.AfterRunArgs) error {
+			calls = append(calls, "second")
+			secondSpanContext = oteltrace.SpanContextFromContext(ctx)
+			if args == nil || args.CompletionEvent == nil ||
+				args.CompletionEvent.ExecutionTrace == nil {
+				return nil
+			}
+			secondHadTrace = true
+			secondTag = args.CompletionEvent.Tag
+			if args.CompletionEvent.ExecutionTrace.Input != nil {
+				secondInput = args.CompletionEvent.ExecutionTrace.Input.Text
+			}
+			return nil
+		},
+	))
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+		agent.WithExecutionTraceEnabled(true),
+	)
+	require.NoError(t, err)
+	var completion *event.Event
+	for evt := range events {
+		if evt != nil && evt.IsRunnerCompletion() {
+			completion = evt
+		}
+	}
+
+	require.NotNil(t, completion)
+	require.NotNil(t, completion.ExecutionTrace)
+	assert.Equal(t, []string{"first", "second"}, calls)
+	assert.True(t, firstHadTrace)
+	assert.True(t, secondHadTrace)
+	assert.Empty(t, secondTag)
+	assert.NotEmpty(t, secondInput)
+	assert.NotEqual(t, "mutated", secondInput)
+	require.True(t, firstSpanContext.IsValid())
+	assert.Equal(t, firstSpanContext, secondSpanContext)
+
+	var matchedRootSpan bool
+	for _, span := range exporter.GetSpans() {
+		if span.SpanContext.SpanID() == firstSpanContext.SpanID() {
+			matchedRootSpan = true
+			break
+		}
+	}
+	assert.True(t, matchedRootSpan)
+}
+
+func TestGlobalAfterRunHookFailuresDoNotAffectCompletion(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	installGlobalAfterRunTestTracer(t)
+
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"error",
+		func(context.Context, *plugin.AfterRunArgs) error {
+			return errors.New("failed")
+		},
+	))
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"panic",
+		func(context.Context, *plugin.AfterRunArgs) error {
+			panic("failed")
+		},
+	))
+	var (
+		lastCalled   bool
+		lastHadTrace bool
+		spanContext  oteltrace.SpanContext
+	)
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"last",
+		func(ctx context.Context, args *plugin.AfterRunArgs) error {
+			lastCalled = true
+			spanContext = oteltrace.SpanContextFromContext(ctx)
+			lastHadTrace = args != nil && args.CompletionEvent != nil &&
+				args.CompletionEvent.ExecutionTrace != nil
+			return nil
+		},
+	))
+
+	outerCtx, outerSpan := telemetrytrace.Tracer.Start(
+		context.Background(),
+		"outer",
+	)
+	r := NewRunner("test-app", &mockAgent{name: "test-agent"})
+	events, err := r.Run(
+		outerCtx,
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	var completion *event.Event
+	for evt := range events {
+		if evt != nil && evt.IsRunnerCompletion() {
+			completion = evt
+		}
+	}
+	outerSpan.End()
+
+	require.NotNil(t, completion)
+	assert.True(t, lastCalled)
+	assert.False(t, lastHadTrace)
+	assert.False(t, spanContext.IsValid())
+}
+
+func TestGlobalAfterRunHookDisabledTracingHasInvalidSpanContext(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	installGlobalAfterRunTestTracer(t)
+
+	var (
+		called      bool
+		hadTrace    bool
+		spanContext oteltrace.SpanContext
+	)
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"disabled-tracing",
+		func(ctx context.Context, args *plugin.AfterRunArgs) error {
+			called = true
+			spanContext = oteltrace.SpanContextFromContext(ctx)
+			hadTrace = args != nil && args.CompletionEvent != nil &&
+				args.CompletionEvent.ExecutionTrace != nil
+			return nil
+		},
+	))
+	agt := llmagent.New(
+		"root-agent",
+		llmagent.WithModel(&staticModel{name: "test-model", content: "done"}),
+	)
+	r := NewRunner("test-app", agt)
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+		agent.WithDisableTracing(true),
+		agent.WithExecutionTraceEnabled(true),
+	)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	assert.True(t, called)
+	assert.True(t, hadTrace)
+	assert.False(t, spanContext.IsValid())
+}
+
+func TestGlobalAfterRunHooksRunAfterRunnerPlugins(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	var calls []string
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"global",
+		func(context.Context, *plugin.AfterRunArgs) error {
+			calls = append(calls, "global")
+			return nil
+		},
+	))
+	runnerPlugin := &testPlugin{
+		name: "runner",
+		reg: func(registry *plugin.Registry) {
+			registry.AfterRun(func(
+				context.Context,
+				*plugin.AfterRunArgs,
+			) error {
+				calls = append(calls, "runner")
+				return nil
+			})
+		},
+	}
+	r := NewRunner(
+		"test-app",
+		&mockAgent{name: "test-agent"},
+		WithPlugins(runnerPlugin),
+	)
+
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	for range events {
+	}
+
+	assert.Equal(t, []string{"runner", "global"}, calls)
+}
+
+func TestGlobalAfterRunHooksAreSnapshottedAtRunStart(t *testing.T) {
+	isolateGlobalAfterRunHooks(t)
+	var firstCalled, lateCalled bool
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"first",
+		func(context.Context, *plugin.AfterRunArgs) error {
+			firstCalled = true
+			return nil
+		},
+	))
+
+	release := make(chan struct{})
+	r := NewRunner("test-app", &blockingGlobalAfterRunAgent{
+		mockAgent: &mockAgent{name: "test-agent"},
+		release:   release,
+	})
+	events, err := r.Run(
+		context.Background(),
+		"user",
+		"session",
+		model.NewUserMessage("hello"),
+	)
+	require.NoError(t, err)
+	require.NoError(t, RegisterGlobalAfterRunHook(
+		"late",
+		func(context.Context, *plugin.AfterRunArgs) error {
+			lateCalled = true
+			return nil
+		},
+	))
+	close(release)
+	for range events {
+	}
+
+	assert.True(t, firstCalled)
+	assert.False(t, lateCalled)
+}
+
+type blockingGlobalAfterRunAgent struct {
+	*mockAgent
+	release <-chan struct{}
+}
+
+func (a *blockingGlobalAfterRunAgent) Run(
+	_ context.Context,
+	_ *agent.Invocation,
+) (<-chan *event.Event, error) {
+	events := make(chan *event.Event)
+	go func() {
+		defer close(events)
+		<-a.release
+	}()
+	return events, nil
+}
+
+func isolateGlobalAfterRunHooks(t *testing.T) {
+	t.Helper()
+	globalAfterRunHooks.Lock()
+	previousHooks := append(
+		[]namedGlobalAfterRunHook(nil),
+		globalAfterRunHooks.hooks...,
+	)
+	previousNames := make(map[string]struct{}, len(globalAfterRunHooks.names))
+	for name := range globalAfterRunHooks.names {
+		previousNames[name] = struct{}{}
+	}
+	globalAfterRunHooks.hooks = nil
+	globalAfterRunHooks.names = nil
+	globalAfterRunHooks.Unlock()
+	t.Cleanup(func() {
+		globalAfterRunHooks.Lock()
+		globalAfterRunHooks.hooks = previousHooks
+		globalAfterRunHooks.names = previousNames
+		globalAfterRunHooks.Unlock()
+	})
+}
+
+func installGlobalAfterRunTestTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	originalProvider := telemetrytrace.TracerProvider
+	originalTracer := telemetrytrace.Tracer
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	telemetrytrace.TracerProvider = provider
+	telemetrytrace.Tracer = provider.Tracer("global-after-run-test")
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+		telemetrytrace.TracerProvider = originalProvider
+		telemetrytrace.Tracer = originalTracer
+	})
+	return exporter
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2002,6 +2002,9 @@ func cloneAfterRunCompletionEvent(completionEvent *event.Event) *event.Event {
 		completionSnapshot.Response.Choices = cloneChoices(
 			completionEvent.Response.Choices,
 		)
+		completionSnapshot.Response.Error = cloneResponseError(
+			completionEvent.Response.Error,
+		)
 	}
 	return completionSnapshot
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1975,10 +1975,7 @@ func (r *runner) applyAfterRunPlugins(
 	if !ok {
 		return
 	}
-	completionSnapshot := completionEvent.Clone()
-	if completionSnapshot != nil {
-		completionSnapshot.ID = completionEvent.ID
-	}
+	completionSnapshot := cloneAfterRunCompletionEvent(completionEvent)
 	args := &plugin.AfterRunArgs{
 		Invocation:      invocation,
 		CompletionEvent: completionSnapshot,
@@ -1986,6 +1983,27 @@ func (r *runner) applyAfterRunPlugins(
 	if err := hooks.AfterRun(context.WithoutCancel(ctx), args); err != nil {
 		log.ErrorfContext(ctx, "plugin AfterRun failed: %v", err)
 	}
+}
+
+// cloneAfterRunCompletionEvent returns an observer-owned copy of a finalized
+// completion event. Event.Clone deep-copies the event envelope and execution
+// trace, while cloneChoices covers nested response message/tool data that is
+// mutable through slices, pointers, and maps.
+func cloneAfterRunCompletionEvent(completionEvent *event.Event) *event.Event {
+	if completionEvent == nil {
+		return nil
+	}
+	completionSnapshot := completionEvent.Clone()
+	if completionSnapshot == nil {
+		return nil
+	}
+	completionSnapshot.ID = completionEvent.ID
+	if completionEvent.Response != nil {
+		completionSnapshot.Response.Choices = cloneChoices(
+			completionEvent.Response.Choices,
+		)
+	}
+	return completionSnapshot
 }
 
 func backfillEventMetadata(dst *event.Event, src *event.Event) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -568,6 +568,7 @@ func (r *runner) Run(
 		ro.RequestID = uuid.NewString()
 	}
 	r.applyRunnerRunDefaults(&ro)
+	globalAfterRun := prepareGlobalAfterRunState()
 	var executionTraceInput *trace.Snapshot
 	if ro.ExecutionTraceEnabled {
 		executionTraceInput = executionTraceInputSnapshot(message, ro)
@@ -694,6 +695,7 @@ func (r *runner) Run(
 		awaitUserReplyRootName,
 		awaitUserReplyLookupPath,
 	)
+	globalAfterRun.attach(invocation)
 	currentTurnSession, err := sessionroute.ResolveCurrentTurnSession(
 		execCtx,
 		r.sessionService,
@@ -800,6 +802,7 @@ func (r *runner) Run(
 		flushChan,
 		handle,
 		executionTraceInput,
+		globalAfterRun,
 	), nil
 }
 
@@ -1336,6 +1339,7 @@ type eventLoopContext struct {
 	fallbackStateDelta                 map[string][]byte
 	finalError                         *model.ResponseError
 	executionTraceInput                *trace.Snapshot
+	globalAfterRun                     *globalAfterRunState
 	graphCompletionSeen                bool
 	freshAssistantContentProduced      bool
 	persistedAssistantResponseIDs      map[string]struct{}
@@ -1462,6 +1466,7 @@ func (r *runner) processAgentEvents(
 	flushChan chan *flush.FlushRequest,
 	handle *runHandle,
 	executionTraceInput *trace.Snapshot,
+	globalAfterRun *globalAfterRunState,
 ) chan *event.Event {
 	processedEventCh := make(chan *event.Event, cap(agentEventCh))
 	loop := &eventLoopContext{
@@ -1472,6 +1477,7 @@ func (r *runner) processAgentEvents(
 		processedEventCh:          processedEventCh,
 		runHandle:                 handle,
 		executionTraceInput:       executionTraceInput,
+		globalAfterRun:            globalAfterRun,
 		baselineFinalResponseID:   baselineFinalResponseID(sess, invocation.RunOptions.RuntimeState),
 		priorAssistantResponseIDs: collectPriorAssistantResponseIDs(sess),
 		streamFilter: graph.NewStreamModeFilter(
@@ -3153,6 +3159,12 @@ func (r *runner) emitRunnerCompletion(ctx context.Context, loop *eventLoopContex
 		)
 	}
 	r.applyAfterRunPlugins(ctx, loop.invocation, runnerCompletionEvent)
+	applyGlobalAfterRunHooks(
+		ctx,
+		loop.globalAfterRun,
+		loop.invocation,
+		runnerCompletionEvent,
+	)
 
 	// Append runner completion event to session.
 	persistRunnerCompletionEvent := runnerCompletionEvent

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -9796,6 +9796,7 @@ func TestProcessAgentEvents_EmitEventErrorBranch_Direct(t *testing.T) {
 		flushCh,
 		nil,
 		nil,
+		nil,
 	)
 	// Send one event, then close agentCh
 	go func() {


### PR DESCRIPTION
## Summary

- add process-wide `runner.RegisterGlobalAfterRunHook` using the existing `plugin.AfterRunHook` interface;
- capture the root `invoke_agent` `SpanContext` and expose it to completion hooks;
- give each global hook an independent finalized completion snapshot;
- isolate hook errors and panics from Runner results;
- document lifecycle and ordering semantics in English and Chinese.

## Design

The hook runs synchronously after the Runner has finalized its completion event and existing per-run AfterRun plugins. Hooks are registered under a unique process-wide name and each run snapshots the registry, so concurrent runs observe a stable hook set. The hook receives a detached context carrying the root `invoke_agent` span context; no new span or span schema is introduced.

This PR intentionally contains only the core hook capability. Runner-wide ExecutionTrace opt-in is proposed separately, so Prompt Engine can enable tracing per run independently.

## Tests

- `go test ./runner ./agent/graphagent ./graph ./internal/telemetry ./internal/trace ./session/summary`
- `go test -race ./runner -run 'Test(RegisterGlobalAfterRunHook|GlobalAfterRunHooks)'`
