### PR TITLE
codeexecutor/jupyter: clean up startup failures

### DIFF
--- a/codeexecutor/jupyter/jupyter.go
+++ b/codeexecutor/jupyter/jupyter.go
@@ -220,6 +220,7 @@ func New(opts ...Option) (*CodeExecutor, error) {
 					WaitReadyTimeout: c.waitReadyTimeout,
 				})
 				if err != nil {
+					c.cleanup()
 					return nil, err
 				}
 				c.ws = localexec.NewRuntime("")

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -121,9 +121,11 @@ func NewClient(connectionInfo ConnectionInfo) (*Client, error) {
 	c.sessionID = uuid.New().String()
 	ready, err := c.waitForReady()
 	if err != nil {
+		_ = c.ws.Close()
 		return nil, err
 	}
 	if !ready {
+		_ = c.ws.Close()
 		return nil, fmt.Errorf("kernel not ready")
 	}
 

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -77,7 +77,10 @@ type executionMessage struct {
 	} `json:"parent_header"`
 }
 
-// NewClient creates a new Jupyter client
+// NewClient creates a new Jupyter client from connectionInfo.
+// If readiness fails after startup, NewClient attempts to delete the started
+// kernel and closes the websocket. The returned error may include both the
+// readiness error and any cleanup error.
 func NewClient(connectionInfo ConnectionInfo) (*Client, error) {
 	baseURL := fmt.Sprintf("http://%s:%d", connectionInfo.Host, connectionInfo.Port)
 	c := &Client{

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -121,10 +121,12 @@ func NewClient(connectionInfo ConnectionInfo) (*Client, error) {
 	c.sessionID = uuid.New().String()
 	ready, err := c.waitForReady()
 	if err != nil {
+		_ = c.deleteKernel()
 		_ = c.ws.Close()
 		return nil, err
 	}
 	if !ready {
+		_ = c.deleteKernel()
 		_ = c.ws.Close()
 		return nil, fmt.Errorf("kernel not ready")
 	}
@@ -242,6 +244,28 @@ func (c *Client) startKernel(kernelName string) (string, error) {
 	}
 
 	return kernelResp.ID, nil
+}
+
+func (c *Client) deleteKernel() error {
+	url := fmt.Sprintf("%s/api/kernels/%s", c.baseURL, c.kernelID)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if c.connectionInfo.Token != "" {
+		req.Header.Set("Authorization", "token "+c.connectionInfo.Token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete kernel: %s", resp.Status)
+	}
+	return nil
 }
 
 func (c *Client) waitForReady() (bool, error) {

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -121,14 +122,10 @@ func NewClient(connectionInfo ConnectionInfo) (*Client, error) {
 	c.sessionID = uuid.New().String()
 	ready, err := c.waitForReady()
 	if err != nil {
-		_ = c.deleteKernel()
-		_ = c.ws.Close()
-		return nil, err
+		return nil, c.cleanupAfterStartupFailure(err)
 	}
 	if !ready {
-		_ = c.deleteKernel()
-		_ = c.ws.Close()
-		return nil, fmt.Errorf("kernel not ready")
+		return nil, c.cleanupAfterStartupFailure(fmt.Errorf("kernel not ready"))
 	}
 
 	return c, nil
@@ -266,6 +263,14 @@ func (c *Client) deleteKernel() error {
 		return fmt.Errorf("failed to delete kernel: %s", resp.Status)
 	}
 	return nil
+}
+
+func (c *Client) cleanupAfterStartupFailure(err error) error {
+	if cleanupErr := c.deleteKernel(); cleanupErr != nil {
+		err = errors.Join(err, cleanupErr)
+	}
+	_ = c.ws.Close()
+	return err
 }
 
 func (c *Client) waitForReady() (bool, error) {

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -123,12 +123,9 @@ func NewClient(connectionInfo ConnectionInfo) (*Client, error) {
 
 	c.ws = ws
 	c.sessionID = uuid.New().String()
-	ready, err := c.waitForReady()
+	_, err = c.waitForReady()
 	if err != nil {
 		return nil, c.cleanupAfterStartupFailure(err)
-	}
-	if !ready {
-		return nil, c.cleanupAfterStartupFailure(fmt.Errorf("kernel not ready"))
 	}
 
 	return c, nil

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -371,7 +371,6 @@ func TestNewClientPreservesKernelCleanupError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to delete kernel")
 }
 
-
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -379,27 +378,27 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestDeleteKernelCoversRequestAndResponseBranches(t *testing.T) {
-	 t.Run("invalid request URL", func(t *testing.T) {
+	t.Run("invalid request URL", func(t *testing.T) {
 		client := &Client{
-			baseURL: "http://[::1",
-			kernelID: "123",
+			baseURL:    "http://[::1",
+			kernelID:   "123",
 			httpClient: &http.Client{},
 		}
-	assert.Error(t, client.deleteKernel())
+		assert.Error(t, client.deleteKernel())
 	})
 
-	 t.Run("transport error", func(t *testing.T) {
+	t.Run("transport error", func(t *testing.T) {
 		client := &Client{
-			baseURL: "http://jupyter.test",
+			baseURL:  "http://jupyter.test",
 			kernelID: "123",
 			httpClient: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
 				return nil, fmt.Errorf("transport failed")
 			})},
 		}
-	assert.ErrorContains(t, client.deleteKernel(), "transport failed")
+		assert.ErrorContains(t, client.deleteKernel(), "transport failed")
 	})
 
-	 t.Run("ok with token", func(t *testing.T) {
+	t.Run("ok with token", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "token secret", r.Header.Get("Authorization"))
 			assert.Equal(t, "/api/kernels/123", r.URL.Path)
@@ -408,10 +407,10 @@ func TestDeleteKernelCoversRequestAndResponseBranches(t *testing.T) {
 		}))
 		defer server.Close()
 		client := &Client{
-			baseURL: server.URL,
-			kernelID: "123",
-			httpClient: server.Client(),
-		 connectionInfo: ConnectionInfo{Token: "secret"},
+			baseURL:        server.URL,
+			kernelID:       "123",
+			httpClient:     server.Client(),
+			connectionInfo: ConnectionInfo{Token: "secret"},
 		}
 		assert.NoError(t, client.deleteKernel())
 	})

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -281,6 +281,11 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":"123"}`))
 		case "/api/kernels/123":
+			if r.Method != http.MethodDelete {
+				t.Errorf("kernel cleanup method = %s, want %s", r.Method, http.MethodDelete)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 			w.WriteHeader(http.StatusNoContent)
 			close(kernelDeleted)
 		case "/api/kernels/123/channels":
@@ -324,4 +329,44 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("kernel was not deleted after readiness failure")
 	}
+}
+
+func TestNewClientPreservesKernelCleanupError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/kernelspecs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+		case "/api/kernels":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123":
+			http.Error(w, "cleanup failed", http.StatusInternalServerError)
+		case "/api/kernels/123/channels":
+			ws, err := cstUpgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer ws.Close()
+			if _, _, err = ws.ReadMessage(); err != nil {
+				return
+			}
+			_ = ws.WriteMessage(websocket.TextMessage, []byte("{"))
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	assert.NoError(t, err)
+
+	_, err = NewClient(ConnectionInfo{
+		Host:             parsed.Hostname(),
+		Port:             port,
+		KernelName:       "python3",
+		WaitReadyTimeout: time.Second,
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to delete kernel")
 }

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -370,3 +370,49 @@ func TestNewClientPreservesKernelCleanupError(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to delete kernel")
 }
+
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDeleteKernelCoversRequestAndResponseBranches(t *testing.T) {
+	 t.Run("invalid request URL", func(t *testing.T) {
+		client := &Client{
+			baseURL: "http://[::1",
+			kernelID: "123",
+			httpClient: &http.Client{},
+		}
+	ssert.Error(t, client.deleteKernel())
+	})
+
+	 t.Run("transport error", func(t *testing.T) {
+		client := &Client{
+			baseURL: "http://jupyter.test",
+			kernelID: "123",
+			httpClient: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("transport failed")
+			})},
+		}
+	assert.ErrorContains(t, client.deleteKernel(), "transport failed")
+	})
+
+	 t.Run("ok with token", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "token secret", r.Header.Get("Authorization"))
+			assert.Equal(t, /api/kernels/123, r.URL.Path)
+			assert.Equal(t, http.MethodDelete, r.Method)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+		client := &Client{
+			baseURL: server.URL,
+			kernelID: "123",
+			httpClient: server.Client(),
+		 connectionInfo: ConnectionInfo{Token: "secret"},
+		}
+		assert.NoError(t, client.deleteKernel())
+	})
+}

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -385,7 +385,7 @@ func TestDeleteKernelCoversRequestAndResponseBranches(t *testing.T) {
 			kernelID: "123",
 			httpClient: &http.Client{},
 		}
-	ssert.Error(t, client.deleteKernel())
+	assert.Error(t, client.deleteKernel())
 	})
 
 	 t.Run("transport error", func(t *testing.T) {
@@ -402,7 +402,7 @@ func TestDeleteKernelCoversRequestAndResponseBranches(t *testing.T) {
 	 t.Run("ok with token", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "token secret", r.Header.Get("Authorization"))
-			assert.Equal(t, /api/kernels/123, r.URL.Path)
+			assert.Equal(t, "/api/kernels/123", r.URL.Path)
 			assert.Equal(t, http.MethodDelete, r.Method)
 			w.WriteHeader(http.StatusOK)
 		}))

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -271,6 +271,7 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	clientClosed := make(chan struct{})
+	kernelDeleted := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/kernelspecs":
@@ -279,6 +280,9 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 		case "/api/kernels":
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123":
+			w.WriteHeader(http.StatusNoContent)
+			close(kernelDeleted)
 		case "/api/kernels/123/channels":
 			ws, err := cstUpgrader.Upgrade(w, r, nil)
 			if err != nil {
@@ -314,5 +318,10 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	case <-clientClosed:
 	case <-time.After(time.Second):
 		t.Fatal("websocket was not closed after readiness failure")
+	}
+	select {
+	case <-kernelDeleted:
+	case <-time.After(time.Second):
+		t.Fatal("kernel was not deleted after readiness failure")
 	}
 }

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -268,3 +268,51 @@ func TestNewClient(t *testing.T) {
 	})
 	assert.NoError(t, err)
 }
+
+func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
+	clientClosed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/kernelspecs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+		case "/api/kernels":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123/channels":
+			ws, err := cstUpgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			if _, _, err = ws.ReadMessage(); err != nil {
+				return
+			}
+			if err = ws.WriteMessage(websocket.TextMessage, []byte("{")); err != nil {
+				return
+			}
+			if _, _, err = ws.ReadMessage(); err != nil {
+				close(clientClosed)
+			}
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	assert.NoError(t, err)
+
+	_, err = NewClient(ConnectionInfo{
+		Host:             parsed.Hostname(),
+		Port:             port,
+		KernelName:       "python3",
+		WaitReadyTimeout: time.Second,
+	})
+	assert.Error(t, err)
+
+	select {
+	case <-clientClosed:
+	case <-time.After(time.Second):
+		t.Fatal("websocket was not closed after readiness failure")
+	}
+}

--- a/codeexecutor/jupyter/jupyter_test.go
+++ b/codeexecutor/jupyter/jupyter_test.go
@@ -702,6 +702,16 @@ func main() {
 	}, time.Second, 10*time.Millisecond) {
 		return
 	}
+	t.Cleanup(func() {
+		if !processRunning(pid) {
+			return
+		}
+		process, findErr := os.FindProcess(pid)
+		if findErr == nil {
+			_ = process.Kill()
+			_, _ = process.Wait()
+		}
+	})
 	assert.Eventually(t, func() bool {
 		return !processRunning(pid)
 	}, time.Second, 10*time.Millisecond)

--- a/codeexecutor/jupyter/jupyter_test.go
+++ b/codeexecutor/jupyter/jupyter_test.go
@@ -11,10 +11,14 @@ package jupyter
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -634,6 +638,85 @@ func TestNewWithFakePythonError(t *testing.T) {
 		WithLogFile(filepath.Join(tmp, "k.log")),
 	)
 	assert.Error(t, err)
+}
+
+func TestNewCleansUpGatewayOnClientError(t *testing.T) {
+	tmp := t.TempDir()
+	pidFile := filepath.Join(tmp, "gateway.pid")
+	fake := filepath.Join(tmp, "python")
+	if runtime.GOOS == "windows" {
+		fake += ".exe"
+	}
+	const fakeGatewaySource = `package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	for _, arg := range os.Args[1:] {
+		if arg == "--version" {
+			return
+		}
+	}
+	if pidFile := os.Getenv("FAKE_JUPYTER_PID_FILE"); pidFile != "" {
+		_ = os.WriteFile(pidFile, []byte(fmt.Sprint(os.Getpid())), 0o644)
+	}
+	fmt.Fprintln(os.Stderr, "is available at http://127.0.0.1:8888")
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+`
+	source := filepath.Join(tmp, "fake_gateway.go")
+	if err := os.WriteFile(source, []byte(fakeGatewaySource), 0o644); err != nil {
+		t.Fatalf("write fake gateway: %v", err)
+	}
+	if output, err := exec.Command("go", "build", "-o", fake, source).CombinedOutput(); err != nil {
+		t.Fatalf("build fake gateway: %v\n%s", err, output)
+	}
+	oldPath := os.Getenv("PATH")
+	_ = os.Setenv("PATH", tmp+string(os.PathListSeparator)+oldPath)
+	oldPIDFile := os.Getenv("FAKE_JUPYTER_PID_FILE")
+	_ = os.Setenv("FAKE_JUPYTER_PID_FILE", pidFile)
+	defer os.Setenv("PATH", oldPath)
+	defer os.Setenv("FAKE_JUPYTER_PID_FILE", oldPIDFile)
+
+	_, err := New(
+		WithPort(0),
+		WithStartTimeout(2*time.Second),
+		WithWaitReadyTimeout(100*time.Millisecond),
+	)
+	assert.Error(t, err)
+
+	var pid int
+	if !assert.Eventually(t, func() bool {
+		data, readErr := os.ReadFile(pidFile)
+		if readErr != nil {
+			return false
+		}
+		pid, readErr = strconv.Atoi(strings.TrimSpace(string(data)))
+		return readErr == nil
+	}, time.Second, 10*time.Millisecond) {
+		return
+	}
+	assert.Eventually(t, func() bool {
+		return !processRunning(pid)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func processRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		output, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH").Output()
+		return err == nil && strings.Contains(string(output), strconv.Itoa(pid))
+	}
+	return process.Signal(syscall.Signal(0)) == nil
 }
 
 // Timeout path: child stays alive, but we hit startup timeout first.


### PR DESCRIPTION
## What changed

- Clean up the Jupyter gateway subprocess when `NewClient` fails during executor startup.
- Delete the started kernel and close the websocket when the kernel readiness handshake fails.

## Why

Executor startup can launch a gateway before client initialization. Returning the client error without cleanup leaves the gateway process running with no executor handle available to close it. A failed readiness handshake also left the started kernel and established websocket open.

## Testing

- `go test . -run 'TestNew(CleansUpGatewayOnClientError|ClientClosesWebsocketWhenReadyFails)$' -count=3`
- `go test . -run '^$'`
- `go vet .`
- `golangci-lint run ./... --timeout=10m --new-from-rev=origin/main`
- `gofmt` and `git diff --check`

The full package test command currently has one unrelated Windows failure in the existing `TestWorkspaceDelegates` test. Its failure is in `codeexecutor/local.Runtime.Collect`, which uses `os.DirFS("/")` with Windows drive-letter paths; no local runtime files are changed here.

Fixes #2551
