### PR TITLE
skill: secure url root downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ tools := []tool.Tool{
 `NewFSRepository` also accepts an HTTP(S) URL (for example, a `.zip` or
 `.tar.gz` archive). The payload is downloaded and cached locally (set
 `SKILLS_CACHE_DIR` to override the cache location). Remote downloads time
-out after 30 seconds and reject private, loopback, and link-local targets,
-including redirects. Use the literal `localhost` hostname for intentional
-local development; redirects must remain on the same origin.
+out after 30 seconds, follow at most 10 redirects, and reject private,
+loopback, and link-local destinations for both initial URLs and redirects.
+Use the literal `localhost` hostname for intentional local development; in
+that case, redirects must remain on the same origin.
 
 `NewFSRepository` also accepts multiple roots, which is useful for
 combining shared skills with user-private skills. In a long-lived

--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ tools := []tool.Tool{
 
 `NewFSRepository` also accepts an HTTP(S) URL (for example, a `.zip` or
 `.tar.gz` archive). The payload is downloaded and cached locally (set
-`SKILLS_CACHE_DIR` to override the cache location).
+`SKILLS_CACHE_DIR` to override the cache location). Remote downloads time
+out after 30 seconds and reject private, loopback, and link-local targets,
+including redirects. Use the literal `localhost` hostname for intentional
+local development; redirects must remain on the same origin.
 
 `NewFSRepository` also accepts multiple roots, which is useful for
 combining shared skills with user-private skills. In a long-lived

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ tools := []tool.Tool{
 out after 30 seconds, follow at most 10 redirects, and reject private,
 loopback, and link-local destinations for both initial URLs and redirects.
 Use the literal `localhost` hostname for intentional local development; in
-that case, redirects must remain on the same origin.
+that case, redirects must remain on the same origin. Remote skill downloads
+connect directly instead of using environment HTTP proxies so address
+validation applies to the actual dial target.
 
 `NewFSRepository` also accepts multiple roots, which is useful for
 combining shared skills with user-private skills. In a long-lived

--- a/skill/repository_test.go
+++ b/skill/repository_test.go
@@ -722,7 +722,7 @@ func TestFSRepository_URLRoot_ZipDownloadAndCache(t *testing.T) {
 	))
 	defer srv.Close()
 
-	urlRoot := srv.URL + "/skills.zip"
+	urlRoot := localhostServerURL(t, srv.URL) + "/skills.zip"
 	repo, err := NewFSRepository(urlRoot)
 	require.NoError(t, err)
 
@@ -752,7 +752,7 @@ func TestFSRepository_URLRoot_TarGZDownload(t *testing.T) {
 	))
 	defer srv.Close()
 
-	urlRoot := srv.URL + "/skills.tgz"
+	urlRoot := localhostServerURL(t, srv.URL) + "/skills.tgz"
 	repo, err := NewFSRepository(urlRoot)
 	require.NoError(t, err)
 	_, err = repo.Path("beta")
@@ -773,7 +773,7 @@ func TestFSRepository_URLRoot_SingleSkillFile(t *testing.T) {
 	))
 	defer srv.Close()
 
-	urlRoot := srv.URL + "/" + skillFile
+	urlRoot := localhostServerURL(t, srv.URL) + "/" + skillFile
 	repo, err := NewFSRepository(urlRoot)
 	require.NoError(t, err)
 	_, err = repo.Path("gamma")
@@ -796,7 +796,9 @@ func TestFSRepository_URLRoot_BadArchivePathRejected(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err := NewFSRepository(srv.URL + "/skills.zip")
+	_, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.zip",
+	)
 	require.Error(t, err)
 }
 
@@ -874,7 +876,9 @@ func TestFSRepository_URLRoot_TarDownload(t *testing.T) {
 	))
 	defer srv.Close()
 
-	repo, err := NewFSRepository(srv.URL + "/skills.tar")
+	repo, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.tar",
+	)
 	require.NoError(t, err)
 	_, err = repo.Path("delta")
 	require.NoError(t, err)
@@ -896,7 +900,9 @@ func TestFSRepository_URLRoot_DetectArchiveKind_Zip(t *testing.T) {
 	))
 	defer srv.Close()
 
-	repo, err := NewFSRepository(srv.URL + "/skills")
+	repo, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills",
+	)
 	require.NoError(t, err)
 	_, err = repo.Path("epsilon")
 	require.NoError(t, err)
@@ -918,7 +924,9 @@ func TestFSRepository_URLRoot_DetectArchiveKind_TarGZ(t *testing.T) {
 	))
 	defer srv.Close()
 
-	repo, err := NewFSRepository(srv.URL + "/skills")
+	repo, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills",
+	)
 	require.NoError(t, err)
 	_, err = repo.Path("zeta")
 	require.NoError(t, err)
@@ -935,7 +943,9 @@ func TestFSRepository_URLRoot_DownloadNon2xxFails(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err := NewFSRepository(srv.URL + "/skills.zip")
+	_, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.zip",
+	)
 	require.Error(t, err)
 }
 
@@ -951,7 +961,9 @@ func TestFSRepository_URLRoot_UnsupportedPayloadFails(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err := NewFSRepository(srv.URL + "/skills.bin")
+	_, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.bin",
+	)
 	require.Error(t, err)
 }
 
@@ -1022,7 +1034,7 @@ func TestURLRootHelpers(t *testing.T) {
 	))
 	defer srv.Close()
 
-	u, err := url.Parse(srv.URL)
+	u, err := url.Parse(localhostServerURL(t, srv.URL))
 	require.NoError(t, err)
 	err = downloadURLToFile(
 		u,
@@ -1103,7 +1115,9 @@ func TestFSRepository_URLRoot_RejectsZipSymlinkEntry(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err = NewFSRepository(srv.URL + "/skills.zip")
+	_, err = NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.zip",
+	)
 	require.Error(t, err)
 }
 
@@ -1137,7 +1151,9 @@ func TestFSRepository_URLRoot_RejectsTarSymlinkEntry(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err = NewFSRepository(srv.URL + "/skills.tar")
+	_, err = NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.tar",
+	)
 	require.Error(t, err)
 }
 

--- a/skill/url_root.go
+++ b/skill/url_root.go
@@ -14,16 +14,19 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -41,7 +44,9 @@ const (
 
 	bytesPerMiB = 1 << 20
 
-	maxDownloadBytes = 64 * bytesPerMiB
+	maxDownloadBytes          = 64 * bytesPerMiB
+	skillsRootDownloadTimeout = 30 * time.Second
+	maxSkillsRootRedirects    = 10
 
 	maxExtractFileBytes  = 64 * bytesPerMiB
 	maxExtractTotalBytes = 256 * bytesPerMiB
@@ -142,9 +147,64 @@ func skillsCacheDir() string {
 }
 
 func downloadURLToFile(u *url.URL, path string) error {
-	resp, err := http.Get(u.String())
+	return downloadURLToFileWithTimeout(
+		u,
+		path,
+		skillsRootDownloadTimeout,
+	)
+}
+
+func downloadURLToFileWithTimeout(
+	u *url.URL,
+	path string,
+	timeout time.Duration,
+) error {
+	if timeout <= 0 {
+		return fmt.Errorf("download skills root: timeout must be positive")
+	}
+	allowLocalhost := isLocalhostURL(u)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := validateSkillsRootURL(ctx, u, allowLocalhost); err != nil {
+		return fmt.Errorf("download skills root: %w", err)
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(
+			req *http.Request,
+			via []*http.Request,
+		) error {
+			if len(via) >= maxSkillsRootRedirects {
+				return fmt.Errorf(
+					"stopped after %d redirects",
+					maxSkillsRootRedirects,
+				)
+			}
+			allowRedirectLocalhost := allowLocalhost &&
+				sameURLOrigin(u, req.URL)
+			if err := validateSkillsRootURL(
+				req.Context(),
+				req.URL,
+				allowRedirectLocalhost,
+			); err != nil {
+				return fmt.Errorf("unsafe redirect: %w", err)
+			}
+			return nil
+		},
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		u.String(),
+		nil,
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("download skills root: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download skills root: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK ||
@@ -168,6 +228,104 @@ func downloadURLToFile(u *url.URL, path string) error {
 		return fmt.Errorf("download skills root: too large")
 	}
 	return nil
+}
+
+func validateSkillsRootURL(
+	ctx context.Context,
+	u *url.URL,
+	allowLocalhost bool,
+) error {
+	return validateSkillsRootURLWithResolver(
+		ctx,
+		u,
+		allowLocalhost,
+		net.DefaultResolver,
+	)
+}
+
+type skillsRootIPResolver interface {
+	LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
+}
+
+func validateSkillsRootURLWithResolver(
+	ctx context.Context,
+	u *url.URL,
+	allowLocalhost bool,
+	resolver skillsRootIPResolver,
+) error {
+	if u == nil {
+		return fmt.Errorf("URL is nil")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q", u.Scheme)
+	}
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	if host == "" {
+		return fmt.Errorf("URL host is required")
+	}
+	if host == "localhost" {
+		if allowLocalhost {
+			return nil
+		}
+		return fmt.Errorf("private or local address is not allowed: %s", host)
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return validateSkillsRootIP(ip)
+	}
+
+	addresses, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return fmt.Errorf("resolve URL host %q: %w", host, err)
+	}
+	if len(addresses) == 0 {
+		return fmt.Errorf("URL host %q resolved to no addresses", host)
+	}
+	for _, address := range addresses {
+		if err := validateSkillsRootIP(address.IP); err != nil {
+			return fmt.Errorf("URL host %q: %w", host, err)
+		}
+	}
+	return nil
+}
+
+func validateSkillsRootIP(ip net.IP) error {
+	if ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() {
+		return fmt.Errorf("private or local address is not allowed: %s", ip)
+	}
+	return nil
+}
+
+func isLocalhostURL(u *url.URL) bool {
+	// A literal localhost hostname is the explicit local-development escape
+	// hatch. Numeric loopback and other private addresses remain blocked.
+	return u != nil && strings.EqualFold(
+		strings.TrimSuffix(u.Hostname(), "."),
+		"localhost",
+	)
+}
+
+func sameURLOrigin(left *url.URL, right *url.URL) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		effectiveURLPort(left) == effectiveURLPort(right)
+}
+
+func effectiveURLPort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(u.Scheme, "https") {
+		return "443"
+	}
+	return "80"
 }
 
 func extractURLPayload(u *url.URL, srcPath string, destDir string) error {

--- a/skill/url_root.go
+++ b/skill/url_root.go
@@ -165,34 +165,17 @@ func downloadURLToFileWithTimeout(
 	allowLocalhost := isLocalhostURL(u)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	if err := validateSkillsRootURL(ctx, u, allowLocalhost); err != nil {
+	if err := validateSkillsRootURL(u, allowLocalhost); err != nil {
 		return fmt.Errorf("download skills root: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(
-			req *http.Request,
-			via []*http.Request,
-		) error {
-			if len(via) >= maxSkillsRootRedirects {
-				return fmt.Errorf(
-					"stopped after %d redirects",
-					maxSkillsRootRedirects,
-				)
-			}
-			allowRedirectLocalhost := allowLocalhost &&
-				sameURLOrigin(u, req.URL)
-			if err := validateSkillsRootURL(
-				req.Context(),
-				req.URL,
-				allowRedirectLocalhost,
-			); err != nil {
-				return fmt.Errorf("unsafe redirect: %w", err)
-			}
-			return nil
-		},
-	}
+	client := newSkillsRootHTTPClient(
+		u,
+		timeout,
+		net.DefaultResolver,
+		&net.Dialer{Timeout: timeout, KeepAlive: 30 * time.Second},
+	)
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
@@ -230,29 +213,160 @@ func downloadURLToFileWithTimeout(
 	return nil
 }
 
-func validateSkillsRootURL(
-	ctx context.Context,
-	u *url.URL,
-	allowLocalhost bool,
-) error {
-	return validateSkillsRootURLWithResolver(
-		ctx,
-		u,
-		allowLocalhost,
-		net.DefaultResolver,
-	)
+type skillsRootNetworkDialer interface {
+	DialContext(context.Context, string, string) (net.Conn, error)
+}
+
+func newSkillsRootHTTPClient(
+	initialURL *url.URL,
+	timeout time.Duration,
+	resolver skillsRootIPResolver,
+	dialer skillsRootNetworkDialer,
+) *http.Client {
+	allowedLocalhost := ""
+	if isLocalhostURL(initialURL) {
+		allowedLocalhost = net.JoinHostPort(
+			"localhost",
+			effectiveURLPort(initialURL),
+		)
+	}
+	transport := &http.Transport{
+		// A proxy would resolve the target outside the guarded dial path.
+		Proxy: nil,
+		DialContext: func(
+			ctx context.Context,
+			network string,
+			address string,
+		) (net.Conn, error) {
+			return dialSkillsRootAddress(
+				ctx,
+				network,
+				address,
+				allowedLocalhost,
+				resolver,
+				dialer,
+			)
+		},
+		ForceAttemptHTTP2: true,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(
+			req *http.Request,
+			via []*http.Request,
+		) error {
+			if len(via) >= maxSkillsRootRedirects {
+				return fmt.Errorf(
+					"stopped after %d redirects",
+					maxSkillsRootRedirects,
+				)
+			}
+			allowRedirectLocalhost := isLocalhostURL(initialURL) &&
+				sameURLOrigin(initialURL, req.URL)
+			if err := validateSkillsRootURL(
+				req.URL,
+				allowRedirectLocalhost,
+			); err != nil {
+				return fmt.Errorf("unsafe redirect: %w", err)
+			}
+			return nil
+		},
+	}
 }
 
 type skillsRootIPResolver interface {
 	LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
 }
 
-func validateSkillsRootURLWithResolver(
+func dialSkillsRootAddress(
 	ctx context.Context,
-	u *url.URL,
-	allowLocalhost bool,
+	network string,
+	address string,
+	allowedLocalhost string,
 	resolver skillsRootIPResolver,
-) error {
+	dialer skillsRootNetworkDialer,
+) (net.Conn, error) {
+	addresses, err := resolveSkillsRootDialAddresses(
+		ctx,
+		address,
+		allowedLocalhost,
+		resolver,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var lastErr error
+	for _, vettedAddress := range addresses {
+		conn, err := dialer.DialContext(ctx, network, vettedAddress)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("dial skills root %q: %w", address, lastErr)
+}
+
+func resolveSkillsRootDialAddresses(
+	ctx context.Context,
+	address string,
+	allowedLocalhost string,
+	resolver skillsRootIPResolver,
+) ([]string, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("parse dial address %q: %w", address, err)
+	}
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "" {
+		return nil, fmt.Errorf("dial host is required")
+	}
+	allowLocalhost := allowedLocalhost != "" && strings.EqualFold(
+		net.JoinHostPort(host, port),
+		allowedLocalhost,
+	)
+	if host == "localhost" && !allowLocalhost {
+		return nil, fmt.Errorf(
+			"private or local address is not allowed: %s",
+			host,
+		)
+	}
+
+	var resolved []net.IPAddr
+	if ip := net.ParseIP(host); ip != nil {
+		resolved = []net.IPAddr{{IP: ip}}
+	} else {
+		resolved, err = resolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("resolve dial host %q: %w", host, err)
+		}
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("dial host %q resolved to no addresses", host)
+	}
+
+	addresses := make([]string, 0, len(resolved))
+	for _, resolvedAddress := range resolved {
+		if allowLocalhost {
+			if !resolvedAddress.IP.IsLoopback() {
+				return nil, fmt.Errorf(
+					"localhost resolved to a non-loopback address: %s",
+					resolvedAddress.IP,
+				)
+			}
+		} else if err := validateSkillsRootIP(resolvedAddress.IP); err != nil {
+			return nil, fmt.Errorf("dial host %q: %w", host, err)
+		}
+		dialHost := resolvedAddress.IP.String()
+		if resolvedAddress.Zone != "" {
+			dialHost += "%" + resolvedAddress.Zone
+		}
+		addresses = append(addresses, net.JoinHostPort(dialHost, port))
+	}
+	return addresses, nil
+}
+
+func validateSkillsRootURL(u *url.URL, allowLocalhost bool) error {
 	if u == nil {
 		return fmt.Errorf("URL is nil")
 	}
@@ -272,24 +386,12 @@ func validateSkillsRootURLWithResolver(
 	if ip := net.ParseIP(host); ip != nil {
 		return validateSkillsRootIP(ip)
 	}
-
-	addresses, err := resolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return fmt.Errorf("resolve URL host %q: %w", host, err)
-	}
-	if len(addresses) == 0 {
-		return fmt.Errorf("URL host %q resolved to no addresses", host)
-	}
-	for _, address := range addresses {
-		if err := validateSkillsRootIP(address.IP); err != nil {
-			return fmt.Errorf("URL host %q: %w", host, err)
-		}
-	}
 	return nil
 }
 
 func validateSkillsRootIP(ip net.IP) error {
-	if ip.IsLoopback() ||
+	if ip == nil ||
+		ip.IsLoopback() ||
 		ip.IsPrivate() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||

--- a/skill/url_root_test.go
+++ b/skill/url_root_test.go
@@ -118,6 +118,12 @@ func TestDownloadURLToFile_Errors(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("request", func(t *testing.T) {
+		u := &url.URL{Scheme: "http", Host: "example.com:bad"}
+		err := downloadURLToFile(u, filepath.Join(t.TempDir(), "x"))
+		require.Error(t, err)
+	})
+
 	t.Run("create", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(
 			func(w http.ResponseWriter, _ *http.Request) {
@@ -300,6 +306,7 @@ func TestValidateSkillsRootURL(t *testing.T) {
 		{name: "multicast", rawURL: "http://[ff02::1]", wantErr: true},
 		{name: "unspecified", rawURL: "http://[::]", wantErr: true},
 		{name: "public", rawURL: "https://8.8.8.8"},
+		{name: "hostname", rawURL: "https://skills.example.test"},
 	}
 
 	for _, tt := range tests {
@@ -310,11 +317,7 @@ func TestValidateSkillsRootURL(t *testing.T) {
 				u, err = url.Parse(tt.rawURL)
 				require.NoError(t, err)
 			}
-			err := validateSkillsRootURL(
-				context.Background(),
-				u,
-				tt.allowLocalhost,
-			)
+			err := validateSkillsRootURL(u, tt.allowLocalhost)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -324,55 +327,155 @@ func TestValidateSkillsRootURL(t *testing.T) {
 	}
 }
 
-func TestValidateSkillsRootURL_HostnameResolution(t *testing.T) {
+func TestResolveSkillsRootDialAddresses(t *testing.T) {
 	tests := []struct {
-		name       string
-		addresses  []net.IPAddr
-		resolveErr error
-		wantErr    bool
+		name             string
+		address          string
+		allowedLocalhost string
+		addresses        []net.IPAddr
+		resolveErr       error
+		want             []string
+		wantErr          bool
 	}{
 		{
+			name:    "invalid-address",
+			address: "skills.example.test",
+			wantErr: true,
+		},
+		{name: "empty-host", address: ":443", wantErr: true},
+		{
 			name:       "resolve-error",
+			address:    "skills.example.test:443",
 			resolveErr: errors.New("lookup failed"),
 			wantErr:    true,
 		},
-		{name: "no-addresses", wantErr: true},
 		{
-			name: "private-address",
+			name:    "no-addresses",
+			address: "skills.example.test:443",
+			wantErr: true,
+		},
+		{
+			name:    "private-address",
+			address: "skills.example.test:443",
 			addresses: []net.IPAddr{
 				{IP: net.ParseIP("192.168.1.10")},
 			},
 			wantErr: true,
 		},
 		{
-			name: "public-address",
+			name:    "public-addresses",
+			address: "skills.example.test:443",
 			addresses: []net.IPAddr{
 				{IP: net.ParseIP("8.8.8.8")},
 				{IP: net.ParseIP("2001:4860:4860::8888")},
 			},
+			want: []string{
+				"8.8.8.8:443",
+				"[2001:4860:4860::8888]:443",
+			},
+		},
+		{
+			name:             "localhost-allowed",
+			address:          "localhost:8080",
+			allowedLocalhost: "localhost:8080",
+			addresses: []net.IPAddr{
+				{IP: net.ParseIP("127.0.0.1")},
+			},
+			want: []string{"127.0.0.1:8080"},
+		},
+		{
+			name:             "localhost-wrong-port",
+			address:          "localhost:8081",
+			allowedLocalhost: "localhost:8080",
+			wantErr:          true,
+		},
+		{
+			name:             "localhost-must-remain-loopback",
+			address:          "localhost:8080",
+			allowedLocalhost: "localhost:8080",
+			addresses: []net.IPAddr{
+				{IP: net.ParseIP("8.8.8.8")},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "public-ip-literal",
+			address: "8.8.4.4:80",
+			want:    []string{"8.8.4.4:80"},
+		},
+		{
+			name:    "ipv6-zone",
+			address: "skills.example.test:443",
+			addresses: []net.IPAddr{
+				{
+					IP:   net.ParseIP("2001:4860:4860::8888"),
+					Zone: "eth0",
+				},
+			},
+			want: []string{"[2001:4860:4860::8888%eth0]:443"},
 		},
 	}
 
-	u, err := url.Parse("https://skills.example.test/archive.zip")
-	require.NoError(t, err)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSkillsRootURLWithResolver(
+			resolver := &stubSkillsRootIPResolver{
+				addresses: tt.addresses,
+				err:       tt.resolveErr,
+			}
+			got, err := resolveSkillsRootDialAddresses(
 				context.Background(),
-				u,
-				false,
-				stubSkillsRootIPResolver{
-					addresses: tt.addresses,
-					err:       tt.resolveErr,
-				},
+				tt.address,
+				tt.allowedLocalhost,
+				resolver,
 			)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSkillsRootHTTPClient_DialsValidatedIP(t *testing.T) {
+	u, err := url.Parse("http://skills.example.test/archive.zip")
+	require.NoError(t, err)
+
+	t.Run("public", func(t *testing.T) {
+		resolver := &stubSkillsRootIPResolver{
+			addresses: []net.IPAddr{{IP: net.ParseIP("8.8.8.8")}},
+		}
+		dialErr := errors.New("stop after vetted dial")
+		dialer := &stubSkillsRootNetworkDialer{err: dialErr}
+		client := newSkillsRootHTTPClient(u, time.Second, resolver, dialer)
+		defer client.CloseIdleConnections()
+
+		_, err := client.Get(u.String())
+		require.ErrorIs(t, err, dialErr)
+		require.Equal(t, 1, resolver.calls)
+		require.Equal(t, []string{"8.8.8.8:80"}, dialer.addresses)
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.Nil(t, transport.Proxy)
+	})
+
+	t.Run("rebound-private", func(t *testing.T) {
+		resolver := &stubSkillsRootIPResolver{
+			addresses: []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}},
+		}
+		dialer := &stubSkillsRootNetworkDialer{
+			err: errors.New("must not dial"),
+		}
+		client := newSkillsRootHTTPClient(u, time.Second, resolver, dialer)
+		defer client.CloseIdleConnections()
+
+		_, err := client.Get(u.String())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "private or local")
+		require.Equal(t, 1, resolver.calls)
+		require.Empty(t, dialer.addresses)
+	})
 }
 
 func TestSameURLOrigin(t *testing.T) {
@@ -398,13 +501,29 @@ func TestSameURLOrigin(t *testing.T) {
 type stubSkillsRootIPResolver struct {
 	addresses []net.IPAddr
 	err       error
+	calls     int
 }
 
-func (r stubSkillsRootIPResolver) LookupIPAddr(
+func (r *stubSkillsRootIPResolver) LookupIPAddr(
 	context.Context,
 	string,
 ) ([]net.IPAddr, error) {
+	r.calls++
 	return r.addresses, r.err
+}
+
+type stubSkillsRootNetworkDialer struct {
+	addresses []string
+	err       error
+}
+
+func (d *stubSkillsRootNetworkDialer) DialContext(
+	_ context.Context,
+	_ string,
+	address string,
+) (net.Conn, error) {
+	d.addresses = append(d.addresses, address)
+	return nil, d.err
 }
 
 func localhostServerURL(t *testing.T, raw string) string {

--- a/skill/url_root_test.go
+++ b/skill/url_root_test.go
@@ -14,12 +14,16 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"bytes"
+	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +44,7 @@ func TestCacheURLRoot_RemoveAllError(t *testing.T) {
 	))
 	defer srv.Close()
 
-	urlRoot := srv.URL + "/skills.zip"
+	urlRoot := localhostServerURL(t, srv.URL) + "/skills.zip"
 	key := sha256Hex(urlRoot)
 	destDir := filepath.Join(cacheDir, key)
 	require.NoError(t, os.MkdirAll(destDir, dirPerm))
@@ -70,7 +74,9 @@ func TestCacheURLRoot_CacheDirIsFileFails(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err := NewFSRepository(srv.URL + "/skills.zip")
+	_, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.zip",
+	)
 	require.Error(t, err)
 }
 
@@ -88,11 +94,24 @@ func TestCacheURLRoot_CacheDirNoWriteFails(t *testing.T) {
 	))
 	defer srv.Close()
 
-	_, err := NewFSRepository(srv.URL + "/skills.zip")
+	_, err := NewFSRepository(
+		localhostServerURL(t, srv.URL) + "/skills.zip",
+	)
 	require.Error(t, err)
 }
 
 func TestDownloadURLToFile_Errors(t *testing.T) {
+	t.Run("timeout", func(t *testing.T) {
+		u, err := url.Parse("http://localhost/skills.zip")
+		require.NoError(t, err)
+		err = downloadURLToFileWithTimeout(
+			u,
+			filepath.Join(t.TempDir(), "x"),
+			0,
+		)
+		require.Error(t, err)
+	})
+
 	t.Run("http-get", func(t *testing.T) {
 		u := &url.URL{Scheme: "http"}
 		err := downloadURLToFile(u, filepath.Join(t.TempDir(), "x"))
@@ -108,7 +127,7 @@ func TestDownloadURLToFile_Errors(t *testing.T) {
 		))
 		defer srv.Close()
 
-		u, err := url.Parse(srv.URL)
+		u, err := url.Parse(localhostServerURL(t, srv.URL))
 		require.NoError(t, err)
 		require.Error(t, downloadURLToFile(u, ""))
 	})
@@ -123,11 +142,277 @@ func TestDownloadURLToFile_Errors(t *testing.T) {
 		))
 		defer srv.Close()
 
-		u, err := url.Parse(srv.URL)
+		u, err := url.Parse(localhostServerURL(t, srv.URL))
 		require.NoError(t, err)
 		err = downloadURLToFile(u, filepath.Join(t.TempDir(), "x"))
 		require.Error(t, err)
 	})
+}
+
+func TestDownloadURLToFile_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		},
+	))
+	defer srv.Close()
+
+	u, err := url.Parse(localhostServerURL(t, srv.URL))
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = downloadURLToFileWithTimeout(
+		u,
+		filepath.Join(t.TempDir(), "skills.zip"),
+		50*time.Millisecond,
+	)
+	require.Error(t, err)
+	require.Less(t, time.Since(start), time.Second)
+}
+
+func TestDownloadURLToFile_RedirectPolicy(t *testing.T) {
+	t.Run("cross-origin-loopback", func(t *testing.T) {
+		targetHit := make(chan struct{}, 1)
+		target := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, _ *http.Request) {
+				targetHit <- struct{}{}
+				_, _ = w.Write([]byte("skills"))
+			},
+		))
+		defer target.Close()
+		targetURL := localhostServerURL(t, target.URL)
+
+		redirector := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(
+					w,
+					r,
+					targetURL,
+					http.StatusFound,
+				)
+			},
+		))
+		defer redirector.Close()
+
+		u, err := url.Parse(localhostServerURL(t, redirector.URL))
+		require.NoError(t, err)
+		err = downloadURLToFileWithTimeout(
+			u,
+			filepath.Join(t.TempDir(), "skills.zip"),
+			time.Second,
+		)
+		require.Error(t, err)
+
+		select {
+		case <-targetHit:
+			t.Fatal("redirect target received a request")
+		default:
+		}
+	})
+
+	t.Run("same-origin-loopback", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/skills.zip", http.StatusFound)
+		})
+		mux.HandleFunc("/skills.zip", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("skills"))
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		u, err := url.Parse(
+			localhostServerURL(t, srv.URL) + "/start",
+		)
+		require.NoError(t, err)
+		path := filepath.Join(t.TempDir(), "skills.zip")
+		require.NoError(t, downloadURLToFileWithTimeout(
+			u,
+			path,
+			time.Second,
+		))
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, []byte("skills"), got)
+	})
+
+	t.Run("too-many", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "/loop", http.StatusFound)
+			},
+		))
+		defer srv.Close()
+
+		u, err := url.Parse(localhostServerURL(t, srv.URL) + "/loop")
+		require.NoError(t, err)
+		err = downloadURLToFileWithTimeout(
+			u,
+			filepath.Join(t.TempDir(), "skills.zip"),
+			time.Second,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "stopped after 10 redirects")
+	})
+}
+
+func TestDownloadURLToFile_RejectsPrivateAddress(t *testing.T) {
+	for _, host := range []string{
+		"127.0.0.1",
+		"10.0.0.1",
+		"169.254.169.254",
+	} {
+		t.Run(host, func(t *testing.T) {
+			u, err := url.Parse("http://" + host + "/skills.zip")
+			require.NoError(t, err)
+
+			err = downloadURLToFileWithTimeout(
+				u,
+				filepath.Join(t.TempDir(), "skills.zip"),
+				time.Second,
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "private or local")
+		})
+	}
+}
+
+func TestValidateSkillsRootURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		rawURL         string
+		allowLocalhost bool
+		wantErr        bool
+	}{
+		{name: "nil", wantErr: true},
+		{name: "scheme", rawURL: "ftp://example.com", wantErr: true},
+		{name: "host", rawURL: "http:///skills.zip", wantErr: true},
+		{name: "localhost-blocked", rawURL: "http://localhost", wantErr: true},
+		{
+			name:           "localhost-allowed",
+			rawURL:         "http://localhost",
+			allowLocalhost: true,
+		},
+		{name: "loopback", rawURL: "http://[::1]", wantErr: true},
+		{name: "private", rawURL: "http://[fc00::1]", wantErr: true},
+		{name: "link-local", rawURL: "http://[fe80::1]", wantErr: true},
+		{name: "multicast", rawURL: "http://[ff02::1]", wantErr: true},
+		{name: "unspecified", rawURL: "http://[::]", wantErr: true},
+		{name: "public", rawURL: "https://8.8.8.8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var u *url.URL
+			if tt.rawURL != "" {
+				var err error
+				u, err = url.Parse(tt.rawURL)
+				require.NoError(t, err)
+			}
+			err := validateSkillsRootURL(
+				context.Background(),
+				u,
+				tt.allowLocalhost,
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateSkillsRootURL_HostnameResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		addresses  []net.IPAddr
+		resolveErr error
+		wantErr    bool
+	}{
+		{
+			name:       "resolve-error",
+			resolveErr: errors.New("lookup failed"),
+			wantErr:    true,
+		},
+		{name: "no-addresses", wantErr: true},
+		{
+			name: "private-address",
+			addresses: []net.IPAddr{
+				{IP: net.ParseIP("192.168.1.10")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "public-address",
+			addresses: []net.IPAddr{
+				{IP: net.ParseIP("8.8.8.8")},
+				{IP: net.ParseIP("2001:4860:4860::8888")},
+			},
+		},
+	}
+
+	u, err := url.Parse("https://skills.example.test/archive.zip")
+	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSkillsRootURLWithResolver(
+				context.Background(),
+				u,
+				false,
+				stubSkillsRootIPResolver{
+					addresses: tt.addresses,
+					err:       tt.resolveErr,
+				},
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSameURLOrigin(t *testing.T) {
+	httpsURL, err := url.Parse("https://example.com/skills.zip")
+	require.NoError(t, err)
+	explicitHTTPSURL, err := url.Parse(
+		"https://EXAMPLE.com:443/redirected.zip",
+	)
+	require.NoError(t, err)
+	otherPortURL, err := url.Parse("https://example.com:8443/skills.zip")
+	require.NoError(t, err)
+	httpURL, err := url.Parse("http://example.com/skills.zip")
+	require.NoError(t, err)
+	explicitHTTPURL, err := url.Parse("http://example.com:80/skills.zip")
+	require.NoError(t, err)
+
+	require.True(t, sameURLOrigin(httpsURL, explicitHTTPSURL))
+	require.True(t, sameURLOrigin(httpURL, explicitHTTPURL))
+	require.False(t, sameURLOrigin(httpsURL, otherPortURL))
+	require.False(t, sameURLOrigin(nil, httpsURL))
+}
+
+type stubSkillsRootIPResolver struct {
+	addresses []net.IPAddr
+	err       error
+}
+
+func (r stubSkillsRootIPResolver) LookupIPAddr(
+	context.Context,
+	string,
+) ([]net.IPAddr, error) {
+	return r.addresses, r.err
+}
+
+func localhostServerURL(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	u.Host = "localhost:" + u.Port()
+	return u.String()
 }
 
 func TestExtractZipFile_Errors(t *testing.T) {


### PR DESCRIPTION
## Summary

- bound URL-based skill root downloads to a 30-second overall timeout
- resolve destinations inside a guarded `DialContext`, reject unsafe addresses, and dial the vetted IP directly to prevent DNS rebinding
- validate every redirect, cap redirect chains at 10 hops, and keep literal `localhost` available only for same-origin local development
- bypass environment HTTP proxies so destination resolution cannot escape the guarded dial path
- document the network policy and preserve the existing download and extraction size limits

## Testing

- `go test ./skill -count=1`
- `go test -race ./skill -count=1`
- `go vet ./skill`
- `go build ./...`

Fixes #2537