### PR TITLE
model/provider: add orcarouter provider

### DIFF
--- a/examples/provider/main.go
+++ b/examples/provider/main.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	providerName        = flag.String("provider", "openai", "Name of the provider to use, openai/anthropic/ollama/hunyuan")
+	providerName        = flag.String("provider", "openai", "Name of the provider to use, openai/anthropic/ollama/hunyuan/orcarouter")
 	modelName           = flag.String("model", "deepseek-v4-flash", "Name of the model to use")
 	isStream            = flag.Bool("stream", true, "Whether to stream the response")
 	apiKey              = flag.String("api-key", "", "Override the provider API key")

--- a/model/openai/openai.go
+++ b/model/openai/openai.go
@@ -71,6 +71,11 @@ const (
 	defaultKimiBaseURL string = "https://api.moonshot.ai/v1"
 	kimiAPIHost        string = "api.moonshot.ai"
 	kimiCNAPIHost      string = "api.moonshot.cn"
+
+	//nolint:gosec
+	orcarouterAPIKeyName     string = "ORCAROUTER_API_KEY"
+	defaultOrcaRouterBaseURL string = "https://api.orcarouter.ai/v1"
+	orcaRouterAPIHost        string = "api.orcarouter.ai"
 )
 
 // Variant represents different model variants with specific behaviors.
@@ -95,6 +100,10 @@ const (
 	VariantMiniMax Variant = "minimax"
 	// VariantKimi is the Kimi OpenAI-compatible variant.
 	VariantKimi Variant = "kimi"
+	// VariantOrcaRouter is the OrcaRouter OpenAI-compatible gateway variant.
+	// OrcaRouter exposes a provider/model namespace like OpenRouter, with
+	// adaptive routing and failover behind the same endpoint.
+	VariantOrcaRouter Variant = "orcarouter"
 )
 
 // thinkingValueConvertor converts ThinkingEnabled bool to the variant-specific value.
@@ -397,6 +406,14 @@ var variantConfigs = map[Variant]variantConfig{
 		thinkingEnabledKey:        thinkingKey,
 		thinkingValueConvertor:    thinkingTypeValueConvertor,
 	},
+	VariantOrcaRouter: {
+		filePurpose:               openai.FilePurposeUserData,
+		fileDeletionMethod:        http.MethodDelete,
+		skipFileTypeInContent:     false,
+		fileDeletionBodyConvertor: defaultFileDeletionBodyConvertor,
+		apiKeyName:                orcarouterAPIKeyName,
+		defaultBaseURL:            defaultOrcaRouterBaseURL,
+	},
 }
 
 // Model implements the model.Model interface for OpenAI API.
@@ -536,6 +553,9 @@ func inferVariant(baseURL string) Variant {
 	if isKimiBaseURL(baseURL) {
 		return VariantKimi
 	}
+	if isOrcaRouterBaseURL(baseURL) {
+		return VariantOrcaRouter
+	}
 	return VariantOpenAI
 }
 
@@ -549,6 +569,10 @@ func isMiniMaxBaseURL(raw string) bool {
 
 func isKimiBaseURL(raw string) bool {
 	return baseURLMatchesHost(raw, kimiAPIHost, kimiCNAPIHost)
+}
+
+func isOrcaRouterBaseURL(raw string) bool {
+	return baseURLMatchesHost(raw, orcaRouterAPIHost)
 }
 
 func baseURLMatchesHost(raw string, hosts ...string) bool {

--- a/model/openai/openai_test.go
+++ b/model/openai/openai_test.go
@@ -61,6 +61,7 @@ func TestNew(t *testing.T) {
 	t.Setenv(deepSeekAPIKeyName, testKey)
 	t.Setenv(miniMaxAPIKeyName, testKey)
 	t.Setenv(kimiAPIKeyName, testKey)
+	t.Setenv(orcarouterAPIKeyName, testKey)
 	tests := []struct {
 		name       string
 		modelName  string
@@ -137,6 +138,37 @@ func TestNew(t *testing.T) {
 				WithAPIKey(testKey),
 			},
 			expectOpts: nil,
+		},
+		{
+			name:      "variant orcarouter",
+			modelName: "auto",
+			opts: []Option{
+				WithVariant(VariantOrcaRouter),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL(defaultOrcaRouterBaseURL),
+			},
+		},
+		{
+			name:      "does not infer orcarouter from official model name",
+			modelName: "auto",
+			opts: []Option{
+				WithAPIKey(testKey),
+			},
+			expectOpts: nil,
+		},
+		{
+			name:      "infers orcarouter from official api base url",
+			modelName: "auto",
+			opts: []Option{
+				WithBaseURL("https://api.orcarouter.ai/v1"),
+			},
+			expectOpts: []Option{
+				WithAPIKey(testKey),
+				WithBaseURL("https://api.orcarouter.ai/v1"),
+				WithVariant(VariantOrcaRouter),
+			},
 		},
 		{
 			name:      "infers minimax from international api base url",
@@ -398,6 +430,46 @@ func TestIsKimiBaseURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isKimiBaseURL(tt.rawURL))
+		})
+	}
+}
+
+func TestIsOrcaRouterBaseURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   bool
+	}{
+		{
+			name:   "matches official api host",
+			rawURL: "https://api.orcarouter.ai/v1",
+			want:   true,
+		},
+		{
+			name:   "matches official api host after trim and lowercase",
+			rawURL: " HTTPS://API.ORCAROUTER.AI/V1 ",
+			want:   true,
+		},
+		{
+			name:   "does not match website host",
+			rawURL: "https://www.orcarouter.ai",
+			want:   false,
+		},
+		{
+			name:   "does not match custom proxy host",
+			rawURL: "https://orcarouter-proxy.internal/v1",
+			want:   false,
+		},
+		{
+			name:   "parse error does not fall back to substring match",
+			rawURL: "https://api.orcarouter.ai/%zz",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isOrcaRouterBaseURL(tt.rawURL))
 		})
 	}
 }

--- a/model/provider/provider.go
+++ b/model/provider/provider.go
@@ -29,6 +29,7 @@ func init() {
 	Register("gemini", geminiProvider)
 	Register("ollama", ollamaProvider)
 	Register("hunyuan", hunyuanProvider)
+	Register("orcarouter", orcaRouterProvider)
 }
 
 // Provider builds a model.Model instance.
@@ -135,6 +136,17 @@ func openaiProvider(opts *Options) (model.Model, error) {
 	}
 	res = append(res, opts.OpenAIOption...)
 	return openai.New(opts.ModelName, res...), nil
+}
+
+// orcaRouterProvider builds an OrcaRouter model instance using the resolved options.
+// OrcaRouter is an OpenAI-compatible gateway (https://www.orcarouter.ai) that
+// serves many models through the same endpoint; it behaves like the OpenAI
+// provider with a fixed default base URL and API key name.
+func orcaRouterProvider(opts *Options) (model.Model, error) {
+	if opts.Variant == "" {
+		opts.Variant = string(openai.VariantOrcaRouter)
+	}
+	return openaiProvider(opts)
 }
 
 // anthropicProvider builds an Anthropic-compatible model instance using the resolved options.

--- a/model/provider/provider_test.go
+++ b/model/provider/provider_test.go
@@ -118,6 +118,63 @@ func TestOpenAIFactoryAppliesOptions(t *testing.T) {
 	assert.NotNil(t, readInterfaceField(openaiModel, "chatStreamCompleteCallback"))
 }
 
+func TestOrcaRouterFactoryAppliesOptions(t *testing.T) {
+	cb := Callbacks{
+		OpenAIChatRequest:  openai.ChatRequestCallbackFunc(func(context.Context, *openaisdk.ChatCompletionNewParams) {}),
+		OpenAIChatResponse: openai.ChatResponseCallbackFunc(func(context.Context, *openaisdk.ChatCompletionNewParams, *openaisdk.ChatCompletion) {}),
+		OpenAIChatChunk:    openai.ChatChunkCallbackFunc(func(context.Context, *openaisdk.ChatCompletionNewParams, *openaisdk.ChatCompletionChunk) {}),
+		OpenAIStreamComplete: openai.ChatStreamCompleteCallbackFunc(func(context.Context, *openaisdk.ChatCompletionNewParams, *openaisdk.ChatCompletionAccumulator, error) {
+		}),
+	}
+
+	opts := &Options{ModelName: "openai/gpt-5"}
+	WithAPIKey("orcarouter-key")(opts)
+	WithBaseURL("https://api.orcarouter.ai/v1")(opts)
+	WithCallbacks(cb)(opts)
+
+	modelInstance, err := orcaRouterProvider(opts)
+	assert.NoError(t, err)
+
+	openaiModel, ok := modelInstance.(*openai.Model)
+	assert.True(t, ok)
+
+	assert.Equal(t, "openai/gpt-5", modelInstance.Info().Name)
+	assert.Equal(t, "https://api.orcarouter.ai/v1", readStringField(openaiModel, "baseURL"))
+	assert.Equal(t, "orcarouter-key", readStringField(openaiModel, "apiKey"))
+	assert.Equal(t, openai.VariantOrcaRouter, readInterfaceField(openaiModel, "variant"))
+	assert.NotNil(t, readInterfaceField(openaiModel, "chatRequestCallback"))
+	assert.NotNil(t, readInterfaceField(openaiModel, "chatResponseCallback"))
+	assert.NotNil(t, readInterfaceField(openaiModel, "chatChunkCallback"))
+	assert.NotNil(t, readInterfaceField(openaiModel, "chatStreamCompleteCallback"))
+}
+
+func TestOrcaRouterFactoryDefaultsToVariantWhenNoBaseURL(t *testing.T) {
+	opts := &Options{ModelName: "auto"}
+	WithAPIKey("orcarouter-key")(opts)
+
+	modelInstance, err := orcaRouterProvider(opts)
+	assert.NoError(t, err)
+
+	openaiModel, ok := modelInstance.(*openai.Model)
+	assert.True(t, ok)
+
+	assert.Equal(t, "auto", modelInstance.Info().Name)
+	assert.Equal(t, "orcarouter-key", readStringField(openaiModel, "apiKey"))
+	assert.Equal(t, openai.VariantOrcaRouter, readInterfaceField(openaiModel, "variant"))
+}
+
+func TestModelOrcaRouter(t *testing.T) {
+	modelInstance, err := Model("orcarouter", "auto", WithAPIKey("key"))
+	assert.NoError(t, err)
+
+	openaiModel, ok := modelInstance.(*openai.Model)
+	assert.True(t, ok)
+
+	assert.Equal(t, "auto", modelInstance.Info().Name)
+	assert.Equal(t, "key", readStringField(openaiModel, "apiKey"))
+	assert.Equal(t, openai.VariantOrcaRouter, readInterfaceField(openaiModel, "variant"))
+}
+
 func TestAnthropicFactoryAppliesOptions(t *testing.T) {
 	cb := Callbacks{
 		AnthropicChatRequest:    anthropic.ChatRequestCallbackFunc(func(context.Context, *anthropicsdk.MessageNewParams) {}),


### PR DESCRIPTION
## What changed

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class provider in `model/provider`, mirroring the existing `openai`/`anthropic`/`gemini`/`ollama`/`hunyuan` entries: `provider.Model("orcarouter", ...)` now resolves `https://api.orcarouter.ai/v1` and `ORCAROUTER_API_KEY` automatically. OrcaRouter is an OpenAI-compatible AI gateway that, like OpenRouter, exposes a provider/model namespace across many models — while also combining adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint, plus gateway-level zero-trust security for AI agents (screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes).

## Why

OpenRouter is already referenced in this repo's model metadata; registering OrcaRouter the same way beats forcing users through an anonymous custom base URL.

## Testing

- `go build ./...`, `go vet`, `go test ./model/...`, gofmt/goimports, `golangci-lint` all pass.
- Live check: a real `provider.Model("orcarouter", ...)` completion against `api.orcarouter.ai` returned `pong` (HTTP 200).

## Notes for reviewers

The factory delegates to `openaiProvider` with `VariantOrcaRouter` preset, inheriting all existing OpenAI-compatible behavior. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
