### PR TITLE
{server/agui, docs}: support framework-supplied assistant messages

### DIFF
--- a/docs/mkdocs/en/agui/chat.md
+++ b/docs/mkdocs/en/agui/chat.md
@@ -23,7 +23,7 @@ type RunAgentInput struct {
 	RunID          string          // Run ID, used to correlate run lifecycle events.
 	ParentRunID    *string         // Parent run ID. Optional.
 	State          any             // Arbitrary state; object-shaped values are merged into RuntimeState by default.
-	Messages       []Message       // Message list used to pass the current user input or external tool results.
+	Messages       []Message       // Message list used to pass user input, external tool results, or framework-supplied assistant messages.
 	Tools          []Tool          // Tool definitions. Protocol field. Optional.
 	Context        []Context       // Context list. Protocol field. Optional.
 	ForwardedProps any             // Arbitrary forwarded fields, usually for business-specific parameters.
@@ -156,6 +156,12 @@ After the previous event stream returns a tool call that needs external executio
 ```
 
 Each `role=tool` message corresponds to one tool call result. `toolCallId` associates the result with the tool call from the previous event stream, `name` is the tool name, and `content` carries the tool output as a string. `id` becomes the message id when the server returns the `TOOL_CALL_RESULT` event.
+
+### Framework-supplied Assistant Messages
+
+When the backend has already generated the final reply and no model call is needed, the tail message in `messages` can use `role=assistant` with non-empty string `content`. The Runner appends it to an existing session that already contains a real `role=user` message, persists it to the session transcript and AG-UI track, and does not invoke the underlying Agent. On success, SSE returns only `RUN_STARTED` and `RUN_FINISHED`; persistence failures return `RUN_STARTED` and `RUN_ERROR`.
+
+An assistant-only new session fails instead of fabricating a user message, so the history start boundary remains the first real user message.
 
 ## RunAgentInput Hook
 

--- a/docs/mkdocs/zh/agui/chat.md
+++ b/docs/mkdocs/zh/agui/chat.md
@@ -23,7 +23,7 @@ type RunAgentInput struct {
 	RunID          string          // 本次运行 ID，用于关联运行生命周期事件。
 	ParentRunID    *string         // 父运行 ID，可选。
 	State          any             // 任意状态；对象类型的值默认会合并到 RuntimeState。
-	Messages       []Message       // 消息列表，用于传递本次用户输入或外部工具结果。
+	Messages       []Message       // 消息列表，用于传递本次用户输入、外部工具结果或框架下发的 assistant 消息。
 	Tools          []Tool          // 工具定义列表，协议字段，可选。
 	Context        []Context       // 上下文列表，协议字段，可选。
 	ForwardedProps any             // 任意透传字段，通常用于携带业务自定义参数。
@@ -156,6 +156,12 @@ DATA 请求体示例：
 ```
 
 每条 `role=tool` 消息对应一个工具调用结果。`toolCallId` 用于关联上一轮事件流中的工具调用，`name` 表示工具名，`content` 使用字符串承载工具执行结果；`id` 会作为返回 `TOOL_CALL_RESULT` 事件时的 message id。
+
+### 框架下发的 Assistant 消息
+
+后台已经生成最终回复、无需再次调用大模型时，可以把 `messages` 尾部消息设为 `role=assistant`，并使用非空字符串 `content`。Runner 会将该消息追加到已有且包含真实 `role=user` 消息的会话，写入 session transcript 和 AG-UI track，不会调用底层 Agent。成功时 SSE 只返回 `RUN_STARTED` 和 `RUN_FINISHED`；持久化失败时返回 `RUN_STARTED` 和 `RUN_ERROR`。
+
+assistant-only 的新会话会失败，不会伪造 user 消息；因此 history 的起点逻辑仍然从真实 user 消息开始。
 
 ## RunAgentInput Hook
 

--- a/server/agui/runner/runner.go
+++ b/server/agui/runner/runner.go
@@ -212,11 +212,30 @@ func inputMessagesFromRunAgentInput(input *adapter.RunAgentInput) (*runAgentMess
 		return nil, errors.New("no messages provided")
 	}
 	lastMessage := input.Messages[len(input.Messages)-1]
-	if lastMessage.Role != types.RoleUser && lastMessage.Role != types.RoleTool {
-		return nil, errors.New("last message role must be user or tool")
+	if lastMessage.Role != types.RoleUser &&
+		lastMessage.Role != types.RoleTool &&
+		lastMessage.Role != types.RoleAssistant {
+		return nil, errors.New("last message role must be user, assistant or tool")
 	}
 	if lastMessage.Role == types.RoleTool {
 		return toolMessagesFromRunAgentInput(input.Messages)
+	}
+	if lastMessage.Role == types.RoleAssistant {
+		content, ok := lastMessage.ContentString()
+		if !ok {
+			return nil, errors.New("assistant message content is not a string")
+		}
+		if content == "" {
+			return nil, errors.New("assistant message content is empty")
+		}
+		inputMessage := model.Message{
+			Role:    model.RoleAssistant,
+			Content: content,
+		}
+		return &runAgentMessages{
+			inputMessage: &inputMessage,
+			inputID:      lastMessage.ID,
+		}, nil
 	}
 	if content, ok := lastMessage.ContentString(); ok {
 		inputMessage := model.Message{
@@ -517,6 +536,10 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 	if !r.emitStartupEvent(ctx, events, aguievents.NewRunStartedEvent(threadID, runID), input) {
 		return
 	}
+	if input.messages.inputMessage.Role == model.RoleAssistant {
+		r.runExternalAssistantMessage(ctx, events, input)
+		return
+	}
 	if input.messages.inputMessage.Role == model.RoleTool {
 		if !r.emitToolResultEvents(ctx, events, input) {
 			return
@@ -544,6 +567,103 @@ func (r *runner) run(ctx context.Context, cancel context.CancelCauseFunc, key se
 	cancel(nil)
 	waitForRunHooks(hookDone, hookRemaining)
 	<-agentRunDone
+}
+
+// runExternalAssistantMessage records an assistant message supplied by the
+// caller without invoking the underlying model runner. This is intended for
+// framework/backend notifications that need to become part of an existing
+// conversation transcript.
+func (r *runner) runExternalAssistantMessage(
+	ctx context.Context,
+	events chan<- aguievents.Event,
+	input *runInput,
+) {
+	if err := r.persistExternalAssistantMessage(ctx, input); err != nil {
+		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(
+			fmt.Sprintf("persist assistant message: %v", err),
+			aguievents.WithRunID(input.runID),
+		), input)
+		return
+	}
+	// Persist the assistant message before notifying the caller that the run
+	// finished. closeTrack in the run defer flushes the terminal lifecycle event.
+	if err := r.flushTrack(ctx, input.key); err != nil {
+		r.emitEvent(ctx, events, aguievents.NewRunErrorEvent(
+			fmt.Sprintf("flush assistant track events: %v", err),
+			aguievents.WithRunID(input.runID),
+		), input)
+		return
+	}
+	if !r.emitEvent(ctx, events, aguievents.NewRunFinishedEvent(input.threadID, input.runID), input) {
+		return
+	}
+}
+
+// persistExternalAssistantMessage appends the supplied assistant message to
+// the core session transcript and AG-UI track. Assistant-only runs must target
+// an existing user-anchored session; creating a new assistant-only session
+// would be discarded by session history filtering and would violate the
+// history contract.
+func (r *runner) persistExternalAssistantMessage(ctx context.Context, input *runInput) error {
+	if r.sessionService == nil {
+		return errors.New("session service is nil")
+	}
+	if r.tracker == nil {
+		return errors.New("track service is not configured")
+	}
+	message := *input.messages.inputMessage
+	persistCtx, cancel := r.newTrackPersistenceContext(ctx)
+	defer cancel()
+	sess, err := r.sessionService.GetSession(persistCtx, input.key)
+	if err != nil {
+		return fmt.Errorf("get session: %w", err)
+	}
+	if sess == nil {
+		return errors.New("assistant message requires an existing user session")
+	}
+	hasUserMessage := false
+	for _, evt := range sess.Events {
+		if evt.IsUserMessage() {
+			hasUserMessage = true
+			break
+		}
+	}
+	if !hasUserMessage {
+		return errors.New("assistant message requires an existing user message")
+	}
+	messageID := input.messages.inputID
+	if messageID == "" {
+		messageID = uuid.NewString()
+		input.messages.inputID = messageID
+	}
+	evt := event.NewResponseEvent(
+		input.runID,
+		input.key.AppName,
+		&model.Response{
+			ID:     messageID,
+			Object: model.ObjectTypeChatCompletion,
+			Done:   true,
+			Choices: []model.Choice{{
+				Index:   0,
+				Message: message,
+			}},
+		},
+	)
+	evt.RequestID = input.runID
+	if err := r.sessionService.AppendEvent(persistCtx, sess, evt); err != nil {
+		return fmt.Errorf("append session event: %w", err)
+	}
+	trackEvents := []aguievents.Event{
+		aguievents.NewTextMessageStartEvent(messageID, aguievents.WithRole(model.RoleAssistant.String())),
+		aguievents.NewTextMessageContentEvent(messageID, message.Content),
+		aguievents.NewTextMessageEndEvent(messageID),
+	}
+	for _, trackEvent := range trackEvents {
+		if err := r.recordTrackEvent(ctx, input.key, trackEvent); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *runner) runEventLoop(

--- a/server/agui/runner/runner_test.go
+++ b/server/agui/runner/runner_test.go
@@ -1719,7 +1719,7 @@ func TestRunUserIDResolverError(t *testing.T) {
 	assert.Equal(t, 0, underlying.calls)
 }
 
-func TestRunLastMessageNotUser(t *testing.T) {
+func TestRunLastMessageUnsupportedRole(t *testing.T) {
 	underlying := &fakeRunner{}
 	fakeTrans := &fakeTranslator{}
 	r := &runner{
@@ -1734,12 +1734,328 @@ func TestRunLastMessageNotUser(t *testing.T) {
 	input := &adapter.RunAgentInput{
 		ThreadID: "thread",
 		RunID:    "run",
-		Messages: []types.Message{{Role: types.RoleAssistant, Content: "bot"}},
+		Messages: []types.Message{{Role: types.RoleSystem, Content: "system"}},
 	}
 	eventsCh, err := r.Run(context.Background(), input)
 	assert.Nil(t, eventsCh)
 	assert.ErrorContains(t, err, "build input message")
-	assert.ErrorContains(t, err, "last message role must be user or tool")
+	assert.ErrorContains(t, err, "last message role must be user, assistant or tool")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessagePersistsWithoutInvokingRunner(t *testing.T) {
+	ctx := context.Background()
+	service := inmemory.NewSessionService()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	sess, err := service.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	userEvent := agentevent.NewResponseEvent("seed", "user", &model.Response{
+		Choices: []model.Choice{{
+			Message: model.Message{Role: model.RoleUser, Content: "hello"},
+		}},
+	})
+	require.NoError(t, service.AppendEvent(ctx, sess, userEvent))
+
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	)
+	eventsCh, err := r.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{
+			ID:      "assistant-1",
+			Role:    types.RoleAssistant,
+			Content: "后台通知",
+		}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.IsType(t, (*aguievents.RunFinishedEvent)(nil), events[1])
+	assert.Equal(t, 0, underlying.calls)
+
+	stored, err := service.GetSession(ctx, key)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	var assistantFound bool
+	for _, event := range stored.Events {
+		if len(event.Choices) == 0 {
+			continue
+		}
+		message := event.Choices[0].Message
+		if message.Role == model.RoleAssistant && message.Content == "后台通知" {
+			assistantFound = true
+			break
+		}
+	}
+	assert.True(t, assistantFound)
+
+	trackEvents, err := service.GetTrackEvents(ctx, key, aguitrack.TrackAGUI)
+	require.NoError(t, err)
+	var trackAssistantFound bool
+	for _, trackEvent := range trackEvents.Events {
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(trackEvent.Payload, &payload))
+		if payload["type"] == string(aguievents.EventTypeTextMessageStart) &&
+			payload["messageId"] == "assistant-1" && payload["role"] == "assistant" {
+			trackAssistantFound = true
+		}
+	}
+	assert.True(t, trackAssistantFound)
+}
+
+func TestInputMessagesFromRunAgentInputAcceptsAssistantText(t *testing.T) {
+	got, err := inputMessagesFromRunAgentInput(&adapter.RunAgentInput{
+		Messages: []types.Message{{
+			ID:      "assistant-1",
+			Role:    types.RoleAssistant,
+			Content: "通知",
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.inputMessage)
+	assert.Equal(t, model.RoleAssistant, got.inputMessage.Role)
+	assert.Equal(t, "通知", got.inputMessage.Content)
+	assert.Equal(t, "assistant-1", got.inputID)
+	assert.Nil(t, got.userMessage)
+}
+
+func TestInputMessagesFromRunAgentInputRejectsInvalidAssistantContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content any
+		errText string
+	}{
+		{name: "empty string", content: "", errText: "assistant message content is empty"},
+		{name: "non-string", content: []any{"通知"}, errText: "assistant message content is not a string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := inputMessagesFromRunAgentInput(&adapter.RunAgentInput{
+				Messages: []types.Message{{
+					Role:    types.RoleAssistant,
+					Content: tt.content,
+				}},
+			})
+			assert.ErrorContains(t, err, tt.errText)
+		})
+	}
+}
+
+func TestRunAssistantMessageWithoutExistingUserSessionReturnsRunError(t *testing.T) {
+	service := inmemory.NewSessionService()
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	)
+	eventsCh, err := r.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.IsType(t, (*aguievents.RunErrorEvent)(nil), events[1])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "existing user session")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageWithoutSessionServiceReturnsRunError(t *testing.T) {
+	underlying := &fakeRunner{}
+	r := New(underlying, WithAppName("app"), WithFlushInterval(0))
+	eventsCh, err := r.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "session service is nil")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageWithoutTrackServiceReturnsRunError(t *testing.T) {
+	service := inmemory.NewSessionService()
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(nonTrackSessionService{Service: service}),
+		WithFlushInterval(0),
+	)
+	eventsCh, err := r.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "track service is not configured")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageWithoutExistingUserMessageReturnsRunError(t *testing.T) {
+	ctx := context.Background()
+	service := inmemory.NewSessionService()
+	_, err := service.CreateSession(ctx, session.Key{
+		AppName: "app", UserID: "user", SessionID: "thread",
+	}, nil)
+	require.NoError(t, err)
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	)
+	eventsCh, err := r.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "existing user message")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageGetSessionErrorReturnsRunError(t *testing.T) {
+	getErr := errors.New("get session failed")
+	service := inmemory.NewSessionService(inmemory.WithGetSessionHook(
+		func(_ *session.GetSessionContext, _ func() (*session.Session, error)) (*session.Session, error) {
+			return nil, getErr
+		},
+	))
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	)
+	eventsCh, err := r.Run(context.Background(), &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "get session failed")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageAppendErrorReturnsRunError(t *testing.T) {
+	ctx := context.Background()
+	appendErr := errors.New("append session failed")
+	service := inmemory.NewSessionService(inmemory.WithAppendEventHook(
+		func(eventCtx *session.AppendEventContext, next func() error) error {
+			if eventCtx.Event != nil && eventCtx.Event.RequestID == "run" {
+				return appendErr
+			}
+			return next()
+		},
+	))
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	sess, err := service.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	userEvent := agentevent.NewResponseEvent("seed", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "hello"}}},
+	})
+	userEvent.RequestID = "seed"
+	require.NoError(t, service.AppendEvent(ctx, sess, userEvent))
+
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	)
+	eventsCh, err := r.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "append session event")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageTrackErrorReturnsRunError(t *testing.T) {
+	ctx := context.Background()
+	service := inmemory.NewSessionService()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	sess, err := service.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	userEvent := agentevent.NewResponseEvent("seed", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "hello"}}},
+	})
+	require.NoError(t, service.AppendEvent(ctx, sess, userEvent))
+
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	).(*runner)
+	r.tracker = &errorTracker{appendErr: errors.New("append track failed")}
+	eventsCh, err := r.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "append track failed")
+	assert.Equal(t, 0, underlying.calls)
+}
+
+func TestRunAssistantMessageFlushErrorReturnsRunError(t *testing.T) {
+	ctx := context.Background()
+	service := inmemory.NewSessionService()
+	key := session.Key{AppName: "app", UserID: "user", SessionID: "thread"}
+	sess, err := service.CreateSession(ctx, key, nil)
+	require.NoError(t, err)
+	userEvent := agentevent.NewResponseEvent("seed", "user", &model.Response{
+		Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "hello"}}},
+	})
+	require.NoError(t, service.AppendEvent(ctx, sess, userEvent))
+
+	underlying := &fakeRunner{}
+	r := New(underlying,
+		WithAppName("app"),
+		WithSessionService(service),
+		WithFlushInterval(0),
+	).(*runner)
+	r.tracker = &errorTracker{flushErr: errors.New("flush assistant track failed")}
+	eventsCh, err := r.Run(ctx, &adapter.RunAgentInput{
+		ThreadID: "thread",
+		RunID:    "run",
+		Messages: []types.Message{{Role: types.RoleAssistant, Content: "通知"}},
+	})
+	require.NoError(t, err)
+	events := collectEvents(t, eventsCh)
+	require.Len(t, events, 2)
+	assert.IsType(t, (*aguievents.RunStartedEvent)(nil), events[0])
+	assert.Contains(t, events[1].(*aguievents.RunErrorEvent).Message, "flush assistant track events")
 	assert.Equal(t, 0, underlying.calls)
 }
 


### PR DESCRIPTION
## Summary

- Accept a tail `role=assistant` text message as a framework-supplied external result.
- Persist the assistant message to the existing user-anchored session and AG-UI track without invoking the underlying runner.
- Emit `RUN_STARTED` followed by `RUN_FINISHED` on success or `RUN_ERROR` on persistence failure.
- Preserve existing user/tool handling and the user-start history boundary; no `PushMessage` API is added.

## Notes

Assistant-only new sessions are rejected rather than fabricating a user message. The assistant text is persisted for history and is not streamed as text events in this run.

## Tests

- `go test ./...` (from `server/agui)`
- `go test -race ./runner -run 'Assistant|LastMessageUnsupportedRole'`