### PR TITLE
tool/file: stream search through large files and report unsearchable ones; serve ranged reads past the read limit

### DIFF
--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -405,9 +405,21 @@ func (f *fileToolSet) readLargeFileRange(
 		lineNo++
 		inRange := lineNo >= start &&
 			(req.NumLines == nil || len(lines) < *req.NumLines)
+		// The head check saw only the first 512 bytes; a NUL anywhere the
+		// scan passes over makes the file not text, as it does for a whole
+		// read. Bytes past the range are not scanned.
+		if err := rejectNonText(segment, ""); err != nil {
+			rsp.Message = fmt.Sprintf("Error: %v", notTextFileErr(mimeType))
+			return notTextFileErr(mimeType)
+		}
 		if inRange {
 			line := strings.TrimSuffix(segment, "\n")
-			collected += int64(len(line)) + 1
+			// What is returned is the lines joined by "\n": a separator
+			// between lines, none after the last.
+			if len(lines) > 0 {
+				collected++
+			}
+			collected += int64(len(line))
 			if collected > f.maxFileSize {
 				err := fmt.Errorf(
 					"selected range is larger than %d bytes; "+

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -247,7 +247,7 @@ func (f *fileToolSet) readFileFromDiskOrCache(
 	}
 	if stat.Size() > f.maxFileSize {
 		if req.StartLine != nil || req.NumLines != nil {
-			return f.readLargeFileRange(req, rsp, filePath)
+			return f.readLargeFileRange(ctx, req, rsp, filePath)
 		}
 		rsp.Message = fmt.Sprintf(
 			"Error: file is too large: %d > %d. Pass start_line/"+
@@ -355,8 +355,11 @@ func (f *fileToolSet) readFileFromCache(
 // readLargeFileRange serves a ranged read of a file too large to read whole.
 // It streams the file line by line, so memory holds only the requested range,
 // which itself must stay within maxFileSize — the limit protects what is
-// returned to the model, not what the tool may look at.
+// returned to the model, not what the tool may look at. Once num_lines is
+// satisfied the read stops rather than scanning to EOF for an exact line
+// count, so the message then reports the total as a lower bound.
 func (f *fileToolSet) readLargeFileRange(
+	ctx context.Context,
 	req *readFileRequest,
 	rsp *readFileResponse,
 	filePath string,
@@ -383,7 +386,14 @@ func (f *fileToolSet) readLargeFileRange(
 	var collected int64
 	lineNo := 0
 	endLine := 0
+	rangeSatisfied := false
 	for {
+		if lineNo&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				rsp.Message = fmt.Sprintf("Error: %v", err)
+				return err
+			}
+		}
 		segment, rerr := reader.ReadString('\n')
 		atEOF := errors.Is(rerr, io.EOF)
 		if rerr != nil && !atEOF {
@@ -409,13 +419,17 @@ func (f *fileToolSet) readLargeFileRange(
 			}
 			lines = append(lines, line)
 			endLine = lineNo
+			if req.NumLines != nil && len(lines) == *req.NumLines {
+				rangeSatisfied = !atEOF
+				break
+			}
 		}
 		if atEOF {
 			break
 		}
 	}
 	total := lineNo
-	if start > total {
+	if !rangeSatisfied && start > total {
 		err := fmt.Errorf(
 			"start line is out of range, start line: %d, "+
 				"total lines: %d",
@@ -432,13 +446,17 @@ func (f *fileToolSet) readLargeFileRange(
 	}
 	chunk, replaced := sanitizeText(chunk)
 	rsp.Contents = chunk
+	totalDesc := fmt.Sprintf("%d", total)
+	if rangeSatisfied {
+		totalDesc = fmt.Sprintf("at least %d", total)
+	}
 	rsp.Message = fmt.Sprintf(
 		"Successfully read %s, start line: %d, "+
-			"end line: %d, total lines: %d",
+			"end line: %d, total lines: %s",
 		req.FileName,
 		start,
 		endLine,
-		total,
+		totalDesc,
 	)
 	if replaced {
 		rsp.Message += invalidUTF8Note

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -428,34 +428,64 @@ func (f *fileToolSet) readLargeFileRange(
 			break
 		}
 	}
-	total := lineNo
-	if !rangeSatisfied && start > total {
+	return finishLargeFileRange(req, rsp, collectedRange{
+		lines:          lines,
+		start:          start,
+		end:            endLine,
+		total:          lineNo,
+		rangeSatisfied: rangeSatisfied,
+		mimeType:       mimeType,
+	})
+}
+
+// collectedRange is what streaming a ranged read gathered: the lines in the
+// requested range, where it started and ended, how many lines were seen, and
+// whether the read stopped once the range was satisfied — in which case total
+// is a lower bound.
+type collectedRange struct {
+	lines          []string
+	start          int
+	end            int
+	total          int
+	rangeSatisfied bool
+	mimeType       string
+}
+
+// finishLargeFileRange validates the collected range and fills the response:
+// the range must exist, the text must be text, and invalid UTF-8 is replaced
+// and noted, as for a whole-file read.
+func finishLargeFileRange(
+	req *readFileRequest,
+	rsp *readFileResponse,
+	collected collectedRange,
+) error {
+	if !collected.rangeSatisfied && collected.start > collected.total {
 		err := fmt.Errorf(
 			"start line is out of range, start line: %d, "+
 				"total lines: %d",
-			start,
-			total,
+			collected.start,
+			collected.total,
 		)
 		rsp.Message = "Error: " + err.Error()
 		return err
 	}
-	chunk := strings.Join(lines, "\n")
-	if err := rejectNonText(chunk, mimeType); err != nil {
+	chunk := strings.Join(collected.lines, "\n")
+	if err := rejectNonText(chunk, collected.mimeType); err != nil {
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return err
 	}
 	chunk, replaced := sanitizeText(chunk)
 	rsp.Contents = chunk
-	totalDesc := fmt.Sprintf("%d", total)
-	if rangeSatisfied {
-		totalDesc = fmt.Sprintf("at least %d", total)
+	totalDesc := fmt.Sprintf("%d", collected.total)
+	if collected.rangeSatisfied {
+		totalDesc = fmt.Sprintf("at least %d", collected.total)
 	}
 	rsp.Message = fmt.Sprintf(
 		"Successfully read %s, start line: %d, "+
 			"end line: %d, total lines: %s",
 		req.FileName,
-		start,
-		endLine,
+		collected.start,
+		collected.end,
 		totalDesc,
 	)
 	if replaced {

--- a/tool/file/readfile.go
+++ b/tool/file/readfile.go
@@ -11,9 +11,11 @@
 package file
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -244,8 +246,13 @@ func (f *fileToolSet) readFileFromDiskOrCache(
 		)
 	}
 	if stat.Size() > f.maxFileSize {
+		if req.StartLine != nil || req.NumLines != nil {
+			return f.readLargeFileRange(req, rsp, filePath)
+		}
 		rsp.Message = fmt.Sprintf(
-			"Error: file is too large: %d > %d",
+			"Error: file is too large: %d > %d. Pass start_line/"+
+				"num_lines to read a slice of it, or use "+
+				"search_content to find the lines you need",
 			stat.Size(),
 			f.maxFileSize,
 		)
@@ -345,11 +352,106 @@ func (f *fileToolSet) readFileFromCache(
 	return true, nil
 }
 
+// readLargeFileRange serves a ranged read of a file too large to read whole.
+// It streams the file line by line, so memory holds only the requested range,
+// which itself must stay within maxFileSize — the limit protects what is
+// returned to the model, not what the tool may look at.
+func (f *fileToolSet) readLargeFileRange(
+	req *readFileRequest,
+	rsp *readFileResponse,
+	filePath string,
+) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		rsp.Message = fmt.Sprintf("Error: cannot read file: %v", err)
+		return fmt.Errorf("reading file: %w", err)
+	}
+	defer file.Close()
+	reader := bufio.NewReaderSize(file, 64*1024)
+	head, _ := reader.Peek(512)
+	mimeType := http.DetectContentType(head)
+	if err := rejectNonText(string(head), mimeType); err != nil {
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return err
+	}
+
+	start := 1
+	if req.StartLine != nil {
+		start = *req.StartLine
+	}
+	var lines []string
+	var collected int64
+	lineNo := 0
+	endLine := 0
+	for {
+		segment, rerr := reader.ReadString('\n')
+		atEOF := errors.Is(rerr, io.EOF)
+		if rerr != nil && !atEOF {
+			rsp.Message = fmt.Sprintf("Error: cannot read file: %v", rerr)
+			return fmt.Errorf("reading file: %w", rerr)
+		}
+		// Mirror strings.Split semantics: every segment is a line, including
+		// the empty final segment after a trailing newline.
+		lineNo++
+		inRange := lineNo >= start &&
+			(req.NumLines == nil || len(lines) < *req.NumLines)
+		if inRange {
+			line := strings.TrimSuffix(segment, "\n")
+			collected += int64(len(line)) + 1
+			if collected > f.maxFileSize {
+				err := fmt.Errorf(
+					"selected range is larger than %d bytes; "+
+						"request fewer lines",
+					f.maxFileSize,
+				)
+				rsp.Message = "Error: " + err.Error()
+				return err
+			}
+			lines = append(lines, line)
+			endLine = lineNo
+		}
+		if atEOF {
+			break
+		}
+	}
+	total := lineNo
+	if start > total {
+		err := fmt.Errorf(
+			"start line is out of range, start line: %d, "+
+				"total lines: %d",
+			start,
+			total,
+		)
+		rsp.Message = "Error: " + err.Error()
+		return err
+	}
+	chunk := strings.Join(lines, "\n")
+	if err := rejectNonText(chunk, mimeType); err != nil {
+		rsp.Message = fmt.Sprintf("Error: %v", err)
+		return err
+	}
+	chunk, replaced := sanitizeText(chunk)
+	rsp.Contents = chunk
+	rsp.Message = fmt.Sprintf(
+		"Successfully read %s, start line: %d, "+
+			"end line: %d, total lines: %d",
+		req.FileName,
+		start,
+		endLine,
+		total,
+	)
+	if replaced {
+		rsp.Message += invalidUTF8Note
+	}
+	return nil
+}
+
 func (f *fileToolSet) sliceReadFile(
 	req *readFileRequest,
 	content string,
 ) (string, int, int, int, bool, error) {
-	if int64(len(content)) > f.maxFileSize {
+	wholeFile := req.StartLine == nil && req.NumLines == nil
+	if wholeFile && int64(len(content)) > f.maxFileSize {
 		return "", 0, 0, 0, false, fmt.Errorf(
 			"file size is beyond of max file size, "+
 				"file size: %d, max file size: %d",
@@ -365,7 +467,17 @@ func (f *fileToolSet) sliceReadFile(
 		req.StartLine,
 		req.NumLines,
 	)
-	return chunk, start, end, total, false, err
+	if err != nil {
+		return "", 0, 0, 0, false, err
+	}
+	if int64(len(chunk)) > f.maxFileSize {
+		return "", 0, 0, 0, false, fmt.Errorf(
+			"selected range is larger than %d bytes; "+
+				"request fewer lines",
+			f.maxFileSize,
+		)
+	}
+	return chunk, start, end, total, false, nil
 }
 
 func sliceTextByLines(

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -13,6 +13,7 @@ package file
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1071,4 +1072,133 @@ func TestFileTool_ReadFile_InvalidUTF8AtMaxFileSize(t *testing.T) {
 			"total lines: 1 (invalid UTF-8 replaced with U+FFFD)",
 		rsp.Message,
 	)
+}
+
+func TestFileTool_ReadFile_RangedReadOfLargeFile(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(64),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	var b strings.Builder
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	assert.Greater(t, int64(b.Len()), int64(64))
+	err = os.WriteFile(filepath.Join(tempDir, "big.txt"), []byte(b.String()), 0644)
+	assert.NoError(t, err)
+
+	start := 42
+	num := 3
+	rsp, err := fts.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "big.txt", StartLine: &start, NumLines: &num},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "line-42\nline-43\nline-44", rsp.Contents)
+	assert.Equal(
+		t,
+		"Successfully read big.txt, start line: 42, end line: 44, "+
+			"total lines: 101",
+		rsp.Message,
+	)
+}
+
+func TestFileTool_ReadFile_RangedReadOfLargeFileRangeTooBig(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(16),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	content := strings.Repeat("0123456789\n", 10)
+	err = os.WriteFile(filepath.Join(tempDir, "big.txt"), []byte(content), 0644)
+	assert.NoError(t, err)
+
+	start := 1
+	num := 5
+	rsp, err := fts.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "big.txt", StartLine: &start, NumLines: &num},
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "request fewer lines")
+}
+
+func TestFileTool_ReadFile_RangedReadOfLargeFileStartBeyondEOF(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(16),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	content := strings.Repeat("0123456789\n", 10)
+	err = os.WriteFile(filepath.Join(tempDir, "big.txt"), []byte(content), 0644)
+	assert.NoError(t, err)
+
+	start := 500
+	rsp, err := fts.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "big.txt", StartLine: &start},
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "start line is out of range")
+}
+
+func TestFileTool_ReadFile_WholeFileTooLargeSuggestsRange(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(16),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	content := strings.Repeat("0123456789\n", 10)
+	err = os.WriteFile(filepath.Join(tempDir, "big.txt"), []byte(content), 0644)
+	assert.NoError(t, err)
+
+	rsp, err := fts.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "big.txt"},
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file is too large")
+	assert.Contains(t, rsp.Message, "start_line/num_lines")
+	assert.Contains(t, rsp.Message, "search_content")
+}
+
+func TestFileTool_ReadFile_RangedReadOfLargeBinaryRejected(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(16),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	content := append([]byte{0x00, 0x01, 0x02}, []byte(strings.Repeat("x", 100))...)
+	err = os.WriteFile(filepath.Join(tempDir, "blob.bin"), content, 0644)
+	assert.NoError(t, err)
+
+	start := 1
+	num := 1
+	rsp, err := fts.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "blob.bin", StartLine: &start, NumLines: &num},
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "not a UTF-8 text file")
 }

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -1103,9 +1103,67 @@ func TestFileTool_ReadFile_RangedReadOfLargeFile(t *testing.T) {
 	assert.Equal(
 		t,
 		"Successfully read big.txt, start line: 42, end line: 44, "+
+			"total lines: at least 44",
+		rsp.Message,
+	)
+}
+
+func TestFileTool_ReadFile_RangedReadOfLargeFileToEOFCountsExactly(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(64),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	var b strings.Builder
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	err = os.WriteFile(filepath.Join(tempDir, "big.txt"), []byte(b.String()), 0644)
+	assert.NoError(t, err)
+
+	start := 99
+	rsp, err := fts.readFile(
+		context.Background(),
+		&readFileRequest{FileName: "big.txt", StartLine: &start},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "line-99\nline-100\n", rsp.Contents)
+	assert.Equal(
+		t,
+		"Successfully read big.txt, start line: 99, end line: 101, "+
 			"total lines: 101",
 		rsp.Message,
 	)
+}
+
+func TestFileTool_ReadFile_RangedReadOfLargeFileCancelled(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(
+		WithBaseDir(tempDir),
+		WithMaxFileSize(16),
+	)
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	content := strings.Repeat("0123456789\n", 10)
+	err = os.WriteFile(filepath.Join(tempDir, "big.txt"), []byte(content), 0644)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := 1
+	num := 1
+	rsp, err := fts.readFile(
+		ctx,
+		&readFileRequest{FileName: "big.txt", StartLine: &start, NumLines: &num},
+	)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, rsp.Message, "context canceled")
 }
 
 func TestFileTool_ReadFile_RangedReadOfLargeFileRangeTooBig(t *testing.T) {

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -1260,3 +1260,102 @@ func TestFileTool_ReadFile_RangedReadOfLargeBinaryRejected(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, rsp.Message, "not a UTF-8 text file")
 }
+
+// A ranged read of a large file whose head looks like text but whose requested
+// range carries a NUL byte is rejected on the range, not just on the head.
+func TestFileTool_ReadFile_RangedReadOfLargeFileRejectsNonTextRange(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(64))
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	var b strings.Builder
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	b.WriteString("bin\x00ary\n")
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "mixed.txt"), []byte(b.String()), 0o644))
+
+	start, num := 101, 1
+	rsp, err := fts.readFile(context.Background(),
+		&readFileRequest{FileName: "mixed.txt", StartLine: &start, NumLines: &num})
+
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "not a UTF-8 text file")
+}
+
+// Invalid UTF-8 inside the requested range of a large file is replaced and
+// noted, exactly as it is for a whole-file read.
+func TestFileTool_ReadFile_RangedReadOfLargeFileInvalidUTF8(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(64))
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	var b strings.Builder
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	b.WriteString("caf\xffe\n")
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "latin.txt"), []byte(b.String()), 0o644))
+
+	start, num := 101, 1
+	rsp, err := fts.readFile(context.Background(),
+		&readFileRequest{FileName: "latin.txt", StartLine: &start, NumLines: &num})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "caf�e", rsp.Contents)
+	assert.Contains(t, rsp.Message, invalidUTF8Note)
+}
+
+// A large file the process cannot open reports the open error rather than an
+// empty range.
+func TestFileTool_ReadFile_RangedReadOfLargeFileUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read a mode-0 file")
+	}
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(8))
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	path := filepath.Join(tempDir, "locked.txt")
+	assert.NoError(t, os.WriteFile(path, []byte(strings.Repeat("line\n", 20)), 0o644))
+	assert.NoError(t, os.Chmod(path, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	start, num := 1, 1
+	rsp, err := fts.readFile(context.Background(),
+		&readFileRequest{FileName: "locked.txt", StartLine: &start, NumLines: &num})
+
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "cannot read file")
+}
+
+// The in-memory slicer applies the same range-aware limit as the streaming
+// read: a cached file beyond the read limit still serves a small range and
+// still refuses one larger than the limit.
+func TestFileTool_ReadFile_FromCache_RangeLargerThanMaxFileSize(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(12))
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{{
+		Name:     "out/big.txt",
+		Content:  strings.Repeat("0123456789\n", 4),
+		MIMEType: "text/plain",
+	}})
+
+	start, num := 2, 1
+	rsp, err := fts.readFile(ctx, &readFileRequest{FileName: "out/big.txt", StartLine: &start, NumLines: &num})
+	assert.NoError(t, err)
+	assert.Equal(t, "0123456789", rsp.Contents)
+
+	num = 3
+	rsp, err = fts.readFile(ctx, &readFileRequest{FileName: "out/big.txt", StartLine: &start, NumLines: &num})
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "selected range is larger than 12 bytes")
+}

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -1311,6 +1311,9 @@ func TestFileTool_ReadFile_RangedReadOfLargeFileInvalidUTF8(t *testing.T) {
 // A large file the process cannot open reports the open error rather than an
 // empty range.
 func TestFileTool_ReadFile_RangedReadOfLargeFileUnreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0 does not deny reads on Windows")
+	}
 	if os.Geteuid() == 0 {
 		t.Skip("root can read a mode-0 file")
 	}
@@ -1358,4 +1361,55 @@ func TestFileTool_ReadFile_FromCache_RangeLargerThanMaxFileSize(t *testing.T) {
 	rsp, err = fts.readFile(ctx, &readFileRequest{FileName: "out/big.txt", StartLine: &start, NumLines: &num})
 	assert.Error(t, err)
 	assert.Contains(t, rsp.Message, "selected range is larger than 12 bytes")
+}
+
+// A NUL byte the scan passes over — beyond the first 512 bytes and before the
+// requested range — makes the file not text, as it does for a whole-file read.
+func TestFileTool_ReadFile_RangedReadOfLargeFileRejectsNULBeforeRange(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(64))
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+
+	var b strings.Builder
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	b.WriteString("bin\x00ary\n")
+	for i := 102; i <= 120; i++ {
+		fmt.Fprintf(&b, "line-%d\n", i)
+	}
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "mixed.txt"), []byte(b.String()), 0o644))
+
+	start, num := 110, 2
+	rsp, err := fts.readFile(context.Background(),
+		&readFileRequest{FileName: "mixed.txt", StartLine: &start, NumLines: &num})
+
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "not a UTF-8 text file")
+}
+
+// The range limit is the size of what is returned: the lines joined by "\n",
+// with no separator after the last. A range of exactly maxFileSize bytes is
+// served; one byte more is refused.
+func TestFileTool_ReadFile_RangedReadOfLargeFileExactLimit(t *testing.T) {
+	tempDir := t.TempDir()
+	toolSet, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(11))
+	assert.NoError(t, err)
+	fts := toolSet.(*fileToolSet)
+	// Lines of five bytes: two joined are exactly 11, three are 17.
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "five.txt"),
+		[]byte(strings.Repeat("abcde\n", 10)), 0o644))
+
+	start, num := 3, 2
+	rsp, err := fts.readFile(context.Background(),
+		&readFileRequest{FileName: "five.txt", StartLine: &start, NumLines: &num})
+	assert.NoError(t, err)
+	assert.Equal(t, "abcde\nabcde", rsp.Contents)
+
+	num = 3
+	rsp, err = fts.readFile(context.Background(),
+		&readFileRequest{FileName: "five.txt", StartLine: &start, NumLines: &num})
+	assert.Error(t, err)
+	assert.Contains(t, rsp.Message, "selected range is larger than 11 bytes")
 }

--- a/tool/file/readfile_test.go
+++ b/tool/file/readfile_test.go
@@ -1296,7 +1296,7 @@ func TestFileTool_ReadFile_RangedReadOfLargeFileInvalidUTF8(t *testing.T) {
 	for i := 1; i <= 100; i++ {
 		fmt.Fprintf(&b, "line-%d\n", i)
 	}
-	b.WriteString("caf\xffe\n")
+	b.WriteString("bad\xffbyte\n")
 	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "latin.txt"), []byte(b.String()), 0o644))
 
 	start, num := 101, 1
@@ -1304,7 +1304,7 @@ func TestFileTool_ReadFile_RangedReadOfLargeFileInvalidUTF8(t *testing.T) {
 		&readFileRequest{FileName: "latin.txt", StartLine: &start, NumLines: &num})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "caf�e", rsp.Contents)
+	assert.Equal(t, "bad�byte", rsp.Contents)
 	assert.Contains(t, rsp.Message, invalidUTF8Note)
 }
 

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -12,9 +12,11 @@ package file
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,8 +46,13 @@ const (
 	maxSearchLineSize = 4 * 1024 * 1024
 )
 
-// searchSizeCap is the largest file search will stream through.
+// searchSizeCap is the largest file search will stream through. It saturates
+// rather than overflows: a read limit large enough that scaling it would wrap
+// means no file is too large to search.
 func (f *fileToolSet) searchSizeCap() int64 {
+	if f.maxFileSize > math.MaxInt64/searchSizeCapMultiple {
+		return math.MaxInt64
+	}
 	return f.maxFileSize * searchSizeCapMultiple
 }
 
@@ -72,8 +79,10 @@ type searchContentResponse struct {
 	FilePattern    string       `json:"file_pattern"`
 	ContentPattern string       `json:"content_pattern"`
 	FileMatches    []*fileMatch `json:"file_matches"`
-	// SkippedFiles names files that matched the file pattern but exceed the
-	// search-size cap and were therefore not searched.
+	// SkippedFiles names files that matched the file pattern but were not
+	// searched: they exceed the search-size cap, or their scan failed partway
+	// on a line the scanner cannot hold. Never silent, so a zero-match result
+	// is distinguishable from a file the tool refused.
 	SkippedFiles []string `json:"skipped_files,omitempty"`
 	Message      string   `json:"message"`
 }
@@ -151,14 +160,15 @@ func (f *fileToolSet) searchContent(
 }
 
 // searchResultMessage summarizes a search, naming any file that matched the
-// file pattern but was too large to search so a zero-match result is never
-// mistaken for proof of absence.
+// file pattern but could not be searched — too large, or a scan that failed —
+// so a zero-match result is never mistaken for proof of absence.
 func (f *fileToolSet) searchResultMessage(matched int, skipped []string) string {
 	msg := fmt.Sprintf("Found %v files matching", matched)
 	if len(skipped) > 0 {
 		msg += fmt.Sprintf(
-			"; %d file(s) matched the file pattern but exceed the "+
-				"%d-byte search cap and were NOT searched: %s",
+			"; %d file(s) matched the file pattern but were NOT searched "+
+				"(beyond the %d-byte search cap, or a line the scanner "+
+				"cannot hold): %s",
 			len(skipped),
 			f.searchSizeCap(),
 			strings.Join(skipped, ", "),
@@ -269,20 +279,20 @@ func (f *fileToolSet) searchContentLocal(
 		return nil, nil, fmt.Errorf("accessing path '%s': %w", reqPath, err)
 	}
 	if !stat.IsDir() {
-		match, tooLarge, ok := f.searchSingleLocalFile(ctx, targetPath, reqPath, re)
+		match, unsearchable, ok := f.searchSingleLocalFile(ctx, targetPath, reqPath, re)
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		if ok {
-			if tooLarge {
-				return []*fileMatch{}, []string{reqPath}, nil
-			}
-			return match, nil, nil
+		if !ok {
+			return nil, nil, fmt.Errorf(
+				"target path '%s' is a file, not a directory",
+				reqPath,
+			)
 		}
-		return nil, nil, fmt.Errorf(
-			"target path '%s' is a file, not a directory",
-			reqPath,
-		)
+		if unsearchable {
+			return []*fileMatch{}, []string{reqPath}, nil
+		}
+		return match, nil, nil
 	}
 
 	files, err := f.matchFiles(
@@ -322,7 +332,16 @@ func (f *fileToolSet) searchContentLocal(
 		go func() {
 			defer wg.Done()
 			match, err := searchFileContent(ctx, fullPath, re)
-			if err != nil || len(match.Matches) == 0 {
+			if err != nil {
+				// A file the scan could not finish — a line beyond the
+				// scanner's buffer, or one it could not read — is reported
+				// beside the oversized ones rather than as a miss.
+				mu.Lock()
+				skipped = append(skipped, relPath)
+				mu.Unlock()
+				return
+			}
+			if len(match.Matches) == 0 {
 				return
 			}
 			match.FilePath = relPath
@@ -386,6 +405,10 @@ func (f *fileToolSet) searchSinglePath(
 	return []*fileMatch{match}, true
 }
 
+// searchSingleLocalFile searches one local file. The second result reports a
+// file that exists but could not be searched — beyond the search cap, or a scan
+// that failed partway — so the caller names it rather than reporting a miss.
+// The third is false when fullPath is not a file at all.
 func (f *fileToolSet) searchSingleLocalFile(
 	ctx context.Context,
 	fullPath string,
@@ -403,11 +426,14 @@ func (f *fileToolSet) searchSingleLocalFile(
 		return []*fileMatch{}, true, true
 	}
 	match, err := searchFileContent(ctx, fullPath, re)
-	if err != nil || len(match.Matches) == 0 {
-		if err == nil {
-			return []*fileMatch{}, false, true
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, false, true
 		}
-		return nil, false, false
+		return []*fileMatch{}, true, true
+	}
+	if len(match.Matches) == 0 {
+		return []*fileMatch{}, false, true
 	}
 	match.FilePath = reqPath
 	match.Message = fileMatchMessage(match, reqPath)
@@ -598,6 +624,22 @@ func regexCompile(
 	return re, nil
 }
 
+// scanLinesKeepCR splits on "\n" alone, so a CRLF line keeps its "\r" exactly as
+// strings.Split(content, "\n") in searchTextContent leaves it: the two backends
+// must report the same line content and match the same patterns.
+func scanLinesKeepCR(data []byte, atEOF bool) (int, []byte, error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		return i + 1, data[:i], nil
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
 // searchFileContent searches for content matches in a single file. It streams
 // the file line by line, so its memory use is bounded by the longest line, not
 // the file size — this is what lets search look inside files far larger than
@@ -616,6 +658,7 @@ func searchFileContent(
 	fileMatches := &fileMatch{Matches: []*lineMatch{}}
 	sc := bufio.NewScanner(file)
 	sc.Buffer(make([]byte, 64*1024), maxSearchLineSize)
+	sc.Split(scanLinesKeepCR)
 	lineNum := 0
 	for sc.Scan() {
 		lineNum++

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -324,7 +324,11 @@ func (f *fileToolSet) searchContentLocal(
 			continue
 		}
 		if stat.Size() > f.searchSizeCap() {
+			// Goroutines for earlier files may be appending scan failures
+			// to the same slice, so this append takes the lock too.
+			mu.Lock()
 			skipped = append(skipped, relPath)
+			mu.Unlock()
 			continue
 		}
 

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -228,6 +228,9 @@ func (f *fileToolSet) searchContentByPath(
 	case fileref.SchemeWorkspace:
 		path := fileref.WorkspaceRef(pathRef.Path)
 		matches := f.searchWorkspaceContent(ctx, pathRef.Path, req, re)
+		if err := ctx.Err(); err != nil {
+			return path, nil, nil, err
+		}
 		return path, matches, nil, nil
 	default:
 		reqPath := normalizeToolPath(f.baseDir, pathRef.Path)
@@ -266,7 +269,10 @@ func (f *fileToolSet) searchContentLocal(
 		return nil, nil, fmt.Errorf("accessing path '%s': %w", reqPath, err)
 	}
 	if !stat.IsDir() {
-		match, tooLarge, ok := f.searchSingleLocalFile(targetPath, reqPath, re)
+		match, tooLarge, ok := f.searchSingleLocalFile(ctx, targetPath, reqPath, re)
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		if ok {
 			if tooLarge {
 				return []*fileMatch{}, []string{reqPath}, nil
@@ -295,6 +301,9 @@ func (f *fileToolSet) searchContentLocal(
 		skipped     []string
 	)
 	for _, file := range files {
+		if ctx.Err() != nil {
+			break
+		}
 		fullPath := filepath.Join(targetPath, file)
 		relPath := filepath.Join(reqPath, file)
 		stat, err := os.Stat(fullPath)
@@ -312,7 +321,7 @@ func (f *fileToolSet) searchContentLocal(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			match, err := searchFileContent(fullPath, re)
+			match, err := searchFileContent(ctx, fullPath, re)
 			if err != nil || len(match.Matches) == 0 {
 				return
 			}
@@ -324,6 +333,9 @@ func (f *fileToolSet) searchContentLocal(
 		}()
 	}
 	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	slices.Sort(skipped)
 	return fileMatches, skipped, nil
 }
@@ -375,6 +387,7 @@ func (f *fileToolSet) searchSinglePath(
 }
 
 func (f *fileToolSet) searchSingleLocalFile(
+	ctx context.Context,
 	fullPath string,
 	reqPath string,
 	re *regexp.Regexp,
@@ -389,7 +402,7 @@ func (f *fileToolSet) searchSingleLocalFile(
 	if st.Size() > f.searchSizeCap() {
 		return []*fileMatch{}, true, true
 	}
-	match, err := searchFileContent(fullPath, re)
+	match, err := searchFileContent(ctx, fullPath, re)
 	if err != nil || len(match.Matches) == 0 {
 		if err == nil {
 			return []*fileMatch{}, false, true
@@ -479,6 +492,9 @@ func (f *fileToolSet) searchWorkspaceContent(
 
 	var out []*fileMatch
 	for _, entry := range fileref.WorkspaceFiles(ctx) {
+		if ctx.Err() != nil {
+			break
+		}
 		full := filepath.Clean(strings.TrimSpace(entry.Name))
 		if full == "" || full == "." {
 			continue
@@ -585,8 +601,10 @@ func regexCompile(
 // searchFileContent searches for content matches in a single file. It streams
 // the file line by line, so its memory use is bounded by the longest line, not
 // the file size — this is what lets search look inside files far larger than
-// the read limit.
+// the read limit. A cancelled context aborts the scan rather than letting an
+// abandoned request keep burning I/O on a huge file.
 func searchFileContent(
+	ctx context.Context,
 	filePath string,
 	re *regexp.Regexp,
 ) (*fileMatch, error) {
@@ -601,6 +619,11 @@ func searchFileContent(
 	lineNum := 0
 	for sc.Scan() {
 		lineNum++
+		if lineNum&1023 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		if line := sc.Text(); re.MatchString(line) {
 			if len(fileMatches.Matches) >= maxMatchesPerFile {
 				fileMatches.Truncated = true

--- a/tool/file/searchcontent.go
+++ b/tool/file/searchcontent.go
@@ -11,6 +11,7 @@
 package file
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -26,6 +27,27 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
 )
+
+const (
+	// searchSizeCapMultiple scales maxFileSize into the search-size cap. The
+	// read limit protects the model's context from whole-file dumps; search
+	// returns only matching lines, so it can safely look inside files far
+	// larger than a read may return whole. Files above even this cap are
+	// reported by name, never skipped silently: a zero-match result must be
+	// distinguishable from a file the tool refused to open.
+	searchSizeCapMultiple = 64
+	// maxMatchesPerFile bounds how many matching lines one file contributes,
+	// so an overly broad pattern on a huge file cannot flood the result.
+	maxMatchesPerFile = 500
+	// maxSearchLineSize bounds a single scanned line during streaming search;
+	// a line longer than this fails the file's scan rather than the process.
+	maxSearchLineSize = 4 * 1024 * 1024
+)
+
+// searchSizeCap is the largest file search will stream through.
+func (f *fileToolSet) searchSizeCap() int64 {
+	return f.maxFileSize * searchSizeCapMultiple
+}
 
 // searchContentRequest represents the input for the search content operation.
 type searchContentRequest struct {
@@ -50,14 +72,20 @@ type searchContentResponse struct {
 	FilePattern    string       `json:"file_pattern"`
 	ContentPattern string       `json:"content_pattern"`
 	FileMatches    []*fileMatch `json:"file_matches"`
-	Message        string       `json:"message"`
+	// SkippedFiles names files that matched the file pattern but exceed the
+	// search-size cap and were therefore not searched.
+	SkippedFiles []string `json:"skipped_files,omitempty"`
+	Message      string   `json:"message"`
 }
 
 // fileMatch represents all matches within a single file.
 type fileMatch struct {
 	FilePath string       `json:"file_path"`
 	Matches  []*lineMatch `json:"matches"`
-	Message  string       `json:"message"`
+	// Truncated reports that the file had more matching lines than
+	// maxMatchesPerFile and only the first ones are listed.
+	Truncated bool   `json:"truncated,omitempty"`
+	Message   string `json:"message"`
 }
 
 // lineMatch represents a single line match within a file.
@@ -110,15 +138,33 @@ func (f *fileToolSet) searchContent(
 		return rsp, nil
 	}
 
-	path, matches, err := f.searchContentByPath(ctx, req, re)
+	path, matches, skipped, err := f.searchContentByPath(ctx, req, re)
 	if err != nil {
 		rsp.Message = fmt.Sprintf("Error: %v", err)
 		return rsp, err
 	}
 	rsp.Path = path
 	rsp.FileMatches = matches
-	rsp.Message = fmt.Sprintf("Found %v files matching", len(matches))
+	rsp.SkippedFiles = skipped
+	rsp.Message = f.searchResultMessage(len(matches), skipped)
 	return rsp, nil
+}
+
+// searchResultMessage summarizes a search, naming any file that matched the
+// file pattern but was too large to search so a zero-match result is never
+// mistaken for proof of absence.
+func (f *fileToolSet) searchResultMessage(matched int, skipped []string) string {
+	msg := fmt.Sprintf("Found %v files matching", matched)
+	if len(skipped) > 0 {
+		msg += fmt.Sprintf(
+			"; %d file(s) matched the file pattern but exceed the "+
+				"%d-byte search cap and were NOT searched: %s",
+			len(skipped),
+			f.searchSizeCap(),
+			strings.Join(skipped, ", "),
+		)
+	}
+	return msg
 }
 
 func (f *fileToolSet) searchContentByFilePatternRef(
@@ -136,12 +182,12 @@ func (f *fileToolSet) searchContentByFilePatternRef(
 	if err != nil {
 		return nil, true, err
 	}
-	if int64(len(content)) > f.maxFileSize {
+	if int64(len(content)) > f.searchSizeCap() {
 		return nil, true, fmt.Errorf(
-			"file size is beyond of max file size, "+
-				"file size: %d, max file size: %d",
+			"file size is beyond of max search size, "+
+				"file size: %d, max search size: %d",
 			len(content),
-			f.maxFileSize,
+			f.searchSizeCap(),
 		)
 	}
 
@@ -166,27 +212,27 @@ func (f *fileToolSet) searchContentByPath(
 	ctx context.Context,
 	req *searchContentRequest,
 	re *regexp.Regexp,
-) (string, []*fileMatch, error) {
+) (string, []*fileMatch, []string, error) {
 	if req == nil || re == nil {
-		return "", nil, errors.New("request cannot be nil")
+		return "", nil, nil, errors.New("request cannot be nil")
 	}
 	pathRef, err := fileref.Parse(req.Path)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	switch pathRef.Scheme {
 	case fileref.SchemeArtifact:
-		return "", nil, fmt.Errorf(
+		return "", nil, nil, fmt.Errorf(
 			"searching artifact:// path is not supported",
 		)
 	case fileref.SchemeWorkspace:
 		path := fileref.WorkspaceRef(pathRef.Path)
 		matches := f.searchWorkspaceContent(ctx, pathRef.Path, req, re)
-		return path, matches, nil
+		return path, matches, nil, nil
 	default:
 		reqPath := normalizeToolPath(f.baseDir, pathRef.Path)
-		matches, err := f.searchContentLocal(ctx, reqPath, req, re)
-		return reqPath, matches, err
+		matches, skipped, err := f.searchContentLocal(ctx, reqPath, req, re)
+		return reqPath, matches, skipped, err
 	}
 }
 
@@ -195,36 +241,39 @@ func (f *fileToolSet) searchContentLocal(
 	reqPath string,
 	req *searchContentRequest,
 	re *regexp.Regexp,
-) ([]*fileMatch, error) {
+) ([]*fileMatch, []string, error) {
 	// When path is a file (or a cached workspace output file), search directly
 	// within that single file. Models commonly pass a file path in "path"
 	// together with a glob file_pattern like "*", which would otherwise be
 	// treated as a directory and fail.
 	if matches, ok := f.searchSinglePath(ctx, reqPath, re); ok {
-		return matches, nil
+		return matches, nil, nil
 	}
 	// Fast path: if the requested file exists only as a skill_run output_files
 	// entry, search against the cached content instead of the host filesystem.
 	// This avoids model loops where a workspace-relative skill output path is
 	// passed to file tools whose base directory is different.
 	if matches, ok := f.searchSkillCache(ctx, reqPath, req, re); ok {
-		return matches, nil
+		return matches, nil, nil
 	}
 
 	targetPath, err := f.resolvePath(reqPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	stat, err := os.Stat(targetPath)
 	if err != nil {
-		return nil, fmt.Errorf("accessing path '%s': %w", reqPath, err)
+		return nil, nil, fmt.Errorf("accessing path '%s': %w", reqPath, err)
 	}
 	if !stat.IsDir() {
-		match, ok := f.searchSingleLocalFile(targetPath, reqPath, re)
+		match, tooLarge, ok := f.searchSingleLocalFile(targetPath, reqPath, re)
 		if ok {
-			return match, nil
+			if tooLarge {
+				return []*fileMatch{}, []string{reqPath}, nil
+			}
+			return match, nil, nil
 		}
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"target path '%s' is a file, not a directory",
 			reqPath,
 		)
@@ -236,13 +285,14 @@ func (f *fileToolSet) searchContentLocal(
 		req.FileCaseSensitive,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var (
 		wg          sync.WaitGroup
 		mu          sync.Mutex
 		fileMatches []*fileMatch
+		skipped     []string
 	)
 	for _, file := range files {
 		fullPath := filepath.Join(targetPath, file)
@@ -251,7 +301,11 @@ func (f *fileToolSet) searchContentLocal(
 		if err != nil {
 			continue
 		}
-		if stat.IsDir() || stat.Size() > f.maxFileSize {
+		if stat.IsDir() {
+			continue
+		}
+		if stat.Size() > f.searchSizeCap() {
+			skipped = append(skipped, relPath)
 			continue
 		}
 
@@ -263,18 +317,33 @@ func (f *fileToolSet) searchContentLocal(
 				return
 			}
 			match.FilePath = relPath
-			match.Message = fmt.Sprintf(
-				"Found %d matches in file '%s'",
-				len(match.Matches),
-				relPath,
-			)
+			match.Message = fileMatchMessage(match, relPath)
 			mu.Lock()
 			fileMatches = append(fileMatches, match)
 			mu.Unlock()
 		}()
 	}
 	wg.Wait()
-	return fileMatches, nil
+	slices.Sort(skipped)
+	return fileMatches, skipped, nil
+}
+
+// fileMatchMessage summarizes one file's matches, noting when the list was
+// truncated at maxMatchesPerFile.
+func fileMatchMessage(m *fileMatch, path string) string {
+	if m.Truncated {
+		return fmt.Sprintf(
+			"Found %d matches in file '%s' (stopped at the first %d)",
+			len(m.Matches),
+			path,
+			maxMatchesPerFile,
+		)
+	}
+	return fmt.Sprintf(
+		"Found %d matches in file '%s'",
+		len(m.Matches),
+		path,
+	)
 }
 
 func (f *fileToolSet) searchSinglePath(
@@ -309,31 +378,27 @@ func (f *fileToolSet) searchSingleLocalFile(
 	fullPath string,
 	reqPath string,
 	re *regexp.Regexp,
-) ([]*fileMatch, bool) {
+) ([]*fileMatch, bool, bool) {
 	if strings.TrimSpace(fullPath) == "" || re == nil {
-		return nil, false
+		return nil, false, false
 	}
 	st, err := os.Stat(fullPath)
 	if err != nil || st.IsDir() {
-		return nil, false
+		return nil, false, false
 	}
-	if st.Size() > f.maxFileSize {
-		return []*fileMatch{}, true
+	if st.Size() > f.searchSizeCap() {
+		return []*fileMatch{}, true, true
 	}
 	match, err := searchFileContent(fullPath, re)
 	if err != nil || len(match.Matches) == 0 {
 		if err == nil {
-			return []*fileMatch{}, true
+			return []*fileMatch{}, false, true
 		}
-		return nil, false
+		return nil, false, false
 	}
 	match.FilePath = reqPath
-	match.Message = fmt.Sprintf(
-		"Found %d matches in file '%s'",
-		len(match.Matches),
-		reqPath,
-	)
-	return []*fileMatch{match}, true
+	match.Message = fileMatchMessage(match, reqPath)
+	return []*fileMatch{match}, false, true
 }
 
 func normalizeToolPath(baseDir string, p string) string {
@@ -430,9 +495,6 @@ func (f *fileToolSet) searchWorkspaceContent(
 		if err != nil || !ok {
 			continue
 		}
-		if int64(len(entry.Content)) > f.maxFileSize {
-			continue
-		}
 		path := fileref.WorkspaceRef(full)
 		match := searchTextContent(path, entry.Content, re)
 		if len(match.Matches) == 0 {
@@ -520,25 +582,38 @@ func regexCompile(
 	return re, nil
 }
 
-// searchFileContent searches for content matches in a single file.
+// searchFileContent searches for content matches in a single file. It streams
+// the file line by line, so its memory use is bounded by the longest line, not
+// the file size — this is what lets search look inside files far larger than
+// the read limit.
 func searchFileContent(
 	filePath string,
 	re *regexp.Regexp,
 ) (*fileMatch, error) {
-	content, err := os.ReadFile(filePath)
+	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
-	lines := strings.Split(string(content), "\n")
+	defer file.Close()
 	fileMatches := &fileMatch{Matches: []*lineMatch{}}
-	// Search each line for matches.
-	for lineNum, line := range lines {
-		if re.MatchString(line) {
+	sc := bufio.NewScanner(file)
+	sc.Buffer(make([]byte, 64*1024), maxSearchLineSize)
+	lineNum := 0
+	for sc.Scan() {
+		lineNum++
+		if line := sc.Text(); re.MatchString(line) {
+			if len(fileMatches.Matches) >= maxMatchesPerFile {
+				fileMatches.Truncated = true
+				return fileMatches, nil
+			}
 			fileMatches.Matches = append(fileMatches.Matches, &lineMatch{
-				LineNumber:  lineNum + 1, // Line numbers are 1-based.
+				LineNumber:  lineNum, // Line numbers are 1-based.
 				LineContent: line,
 			})
 		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
 	}
 	return fileMatches, nil
 }

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -13,6 +13,7 @@ package file
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -761,23 +762,71 @@ func TestSearchContent_PathIsFile(t *testing.T) {
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
-	t.Run("a file that cannot be scanned is an error", func(t *testing.T) {
+	t.Run("a file the scanner cannot finish is reported, not a miss", func(t *testing.T) {
 		// A line longer than the scanner tolerates makes the scan fail, which
-		// is the one way a readable file is not searchable.
+		// is the one way a readable file is not searchable. It is named
+		// beside the oversized files rather than reported as zero matches.
 		long := filepath.Join(tempDir, "long.txt")
 		assert.NoError(t, os.WriteFile(long, []byte("foo "+strings.Repeat("x", maxSearchLineSize+1)+"\n"), 0o644))
 		t.Cleanup(func() { _ = os.Remove(long) })
-		big := set.(*fileToolSet)
-		big.maxFileSize = int64(maxSearchLineSize * 2)
-		t.Cleanup(func() { big.maxFileSize = 8 })
+		fts.maxFileSize = int64(maxSearchLineSize * 2)
+		t.Cleanup(func() { fts.maxFileSize = 8 })
 
-		_, err := fts.searchContent(context.Background(), &searchContentRequest{
+		rsp, err := fts.searchContent(context.Background(), &searchContentRequest{
 			Path:           "long.txt",
 			FilePattern:    "*",
 			ContentPattern: "foo",
 		})
-		assert.ErrorContains(t, err, "long.txt")
+		assert.NoError(t, err)
+		assert.Empty(t, rsp.FileMatches)
+		assert.Equal(t, []string{"long.txt"}, rsp.SkippedFiles)
+		assert.Contains(t, rsp.Message, "NOT searched")
+
+		// The same file reached through a pattern is reported the same way.
+		rsp, err = fts.searchContent(context.Background(), &searchContentRequest{
+			FilePattern:    "long.txt",
+			ContentPattern: "foo",
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, rsp.FileMatches)
+		assert.Equal(t, []string{"long.txt"}, rsp.SkippedFiles)
 	})
+}
+
+// A CRLF line keeps its "\r" in line_content, as it does when the same file is
+// searched from the workspace cache, so both backends match the same patterns.
+func TestSearchContent_KeepsCarriageReturns(t *testing.T) {
+	tempDir := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "dos.txt"), []byte("foo\r\nbar\r\nfoo"), 0o644))
+
+	rsp, err := fts.searchContent(context.Background(), &searchContentRequest{
+		FilePattern:    "dos.txt",
+		ContentPattern: "foo\r$",
+	})
+	assert.NoError(t, err)
+	assert.Len(t, rsp.FileMatches, 1)
+	assert.Len(t, rsp.FileMatches[0].Matches, 1)
+	assert.Equal(t, "foo\r", rsp.FileMatches[0].Matches[0].LineContent)
+	assert.Equal(t, 1, rsp.FileMatches[0].Matches[0].LineNumber)
+
+	cached := searchTextContent("dos.txt", "foo\r\nbar\r\nfoo", regexp.MustCompile("foo\r$"))
+	assert.Equal(t, rsp.FileMatches[0].Matches, cached.Matches,
+		"the local and cached backends must agree on line content")
+}
+
+// A read limit large enough that scaling it would overflow saturates, so no
+// file is turned away as too large.
+func TestSearchSizeCap_Saturates(t *testing.T) {
+	set, err := NewToolSet(WithBaseDir(t.TempDir()), WithMaxFileSize(math.MaxInt64/searchSizeCapMultiple+1))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(math.MaxInt64), set.(*fileToolSet).searchSizeCap())
+
+	set, err = NewToolSet(WithBaseDir(t.TempDir()), WithMaxFileSize(10))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10*searchSizeCapMultiple), set.(*fileToolSet).searchSizeCap())
 }
 
 // Streaming search stops listing a file's matches at maxMatchesPerFile, says so

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -536,33 +536,33 @@ func TestSearchSingleLocalFile_Branches(t *testing.T) {
 
 	re := regexp.MustCompile("foo")
 
-	matches, tooLarge, ok := fts.searchSingleLocalFile("", "", re)
+	matches, tooLarge, ok := fts.searchSingleLocalFile(context.Background(), "", "", re)
 	assert.False(t, ok)
 	assert.False(t, tooLarge)
 	assert.Nil(t, matches)
 
-	matches, tooLarge, ok = fts.searchSingleLocalFile(base, "", re)
+	matches, tooLarge, ok = fts.searchSingleLocalFile(context.Background(), base, "", re)
 	assert.False(t, ok)
 	assert.False(t, tooLarge)
 	assert.Nil(t, matches)
 
 	withinCap := filepath.Join(base, "big.txt")
 	assert.NoError(t, os.WriteFile(withinCap, []byte("123\nfoo"), 0o644))
-	matches, tooLarge, ok = fts.searchSingleLocalFile(withinCap, "big.txt", re)
+	matches, tooLarge, ok = fts.searchSingleLocalFile(context.Background(), withinCap, "big.txt", re)
 	assert.True(t, ok)
 	assert.False(t, tooLarge)
 	assert.Len(t, matches, 1)
 
 	tooBig := filepath.Join(base, "huge.txt")
 	assert.NoError(t, os.WriteFile(tooBig, []byte(strings.Repeat("foo\n", 100)), 0o644))
-	matches, tooLarge, ok = fts.searchSingleLocalFile(tooBig, "huge.txt", re)
+	matches, tooLarge, ok = fts.searchSingleLocalFile(context.Background(), tooBig, "huge.txt", re)
 	assert.True(t, ok)
 	assert.True(t, tooLarge)
 	assert.Empty(t, matches)
 
 	noMatch := filepath.Join(base, "nomatch.txt")
 	assert.NoError(t, os.WriteFile(noMatch, []byte("bar"), 0o644))
-	matches, tooLarge, ok = fts.searchSingleLocalFile(noMatch, "nomatch.txt", re)
+	matches, tooLarge, ok = fts.searchSingleLocalFile(context.Background(), noMatch, "nomatch.txt", re)
 	assert.True(t, ok)
 	assert.False(t, tooLarge)
 	assert.Empty(t, matches)
@@ -659,4 +659,28 @@ func TestSearchContent_WorkspaceContent_SortsAndSkips(t *testing.T) {
 		rsp.FileMatches[0].FilePath)
 	assert.Equal(t, fileref.WorkspaceRef("dir1/b.txt"),
 		rsp.FileMatches[1].FilePath)
+}
+
+func TestSearchContent_CancelledContext(t *testing.T) {
+	tempDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(
+		filepath.Join(tempDir, "a.txt"),
+		[]byte("foo\nbar\n"),
+		0o644,
+	))
+	set, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := searchContentRequest{
+		Path:           "",
+		FilePattern:    "*.txt",
+		ContentPattern: "foo",
+	}
+	rsp, err := fts.searchContent(ctx, &req)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotNil(t, rsp)
+	assert.Contains(t, rsp.Message, "context canceled")
 }

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -31,13 +31,14 @@ func TestSearchContent(t *testing.T) {
 	tempDir := t.TempDir()
 	// Create test directory structure with files.
 	testFiles := map[string]string{
-		"a.txt":     "hello foo\nnope\nfoo bar foo\n",
-		"b.txt":     "bar\nFooBar\nbaz\n",
-		"foo.txt":   "hit\n",
-		"x.txt":     "ToDo\n",
-		"big.log":   "this-is-a-big-file-with-foo",
-		"small.log": "foo\n",
-		"sub/c.txt": "foo\n",
+		"a.txt":       "hello foo\nnope\nfoo bar foo\n",
+		"b.txt":       "bar\nFooBar\nbaz\n",
+		"foo.txt":     "hit\n",
+		"x.txt":       "ToDo\n",
+		"big.log":     "this-is-a-big-file-with-foo",
+		"small.log":   "foo\n",
+		"beyond.huge": strings.Repeat("padding padding foo\n", 32),
+		"sub/c.txt":   "foo\n",
 	}
 	// Create directories and files.
 	for filePath, content := range testFiles {
@@ -52,11 +53,12 @@ func TestSearchContent(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	tests := []struct {
-		name      string
-		opts      []Option
-		req       searchContentRequest
-		wantErr   bool
-		wantFiles map[string][]int // relative path -> line numbers.
+		name        string
+		opts        []Option
+		req         searchContentRequest
+		wantErr     bool
+		wantFiles   map[string][]int // relative path -> line numbers.
+		wantSkipped []string
 	}{
 		{
 			name: "empty file pattern",
@@ -134,7 +136,7 @@ func TestSearchContent(t *testing.T) {
 			},
 		},
 		{
-			name: "skip large files by maxFileSize",
+			name: "files above maxFileSize are still searched",
 			opts: []Option{WithMaxFileSize(5)},
 			req: searchContentRequest{
 				Path:           "",
@@ -143,7 +145,19 @@ func TestSearchContent(t *testing.T) {
 			},
 			wantFiles: map[string][]int{
 				"small.log": {1},
+				"big.log":   {1},
 			},
+		},
+		{
+			name: "files above the search cap are reported, not silently skipped",
+			opts: []Option{WithMaxFileSize(5)},
+			req: searchContentRequest{
+				Path:           "",
+				FilePattern:    "*.huge",
+				ContentPattern: "foo",
+			},
+			wantFiles:   map[string][]int{},
+			wantSkipped: []string{"beyond.huge"},
 		},
 		{
 			name: "not found",
@@ -216,6 +230,13 @@ func TestSearchContent(t *testing.T) {
 				}
 			}
 			assert.Equal(t, tc.wantFiles, actual)
+			assert.Equal(t, tc.wantSkipped, rsp.SkippedFiles)
+			if len(tc.wantSkipped) > 0 {
+				assert.Contains(t, rsp.Message, "were NOT searched")
+				for _, name := range tc.wantSkipped {
+					assert.Contains(t, rsp.Message, name)
+				}
+			}
 		})
 	}
 }
@@ -407,7 +428,7 @@ func TestSearchContent_FilePatternRef_NotExported(t *testing.T) {
 	assert.Contains(t, rsp.Message, "workspace file is not exported")
 }
 
-func TestSearchContent_FilePatternRef_TooLarge(t *testing.T) {
+func TestSearchContent_FilePatternRef_AboveReadLimitStillSearched(t *testing.T) {
 	set, err := NewToolSet(
 		WithBaseDir(t.TempDir()),
 		WithMaxFileSize(3),
@@ -431,9 +452,39 @@ func TestSearchContent_FilePatternRef_TooLarge(t *testing.T) {
 		ContentPattern: "1",
 	}
 	rsp, err := fts.searchContent(ctx, &req)
+	assert.NoError(t, err)
+	assert.NotNil(t, rsp)
+	assert.Len(t, rsp.FileMatches, 1)
+	assert.Equal(t, 1, rsp.FileMatches[0].Matches[0].LineNumber)
+}
+
+func TestSearchContent_FilePatternRef_TooLarge(t *testing.T) {
+	set, err := NewToolSet(
+		WithBaseDir(t.TempDir()),
+		WithMaxFileSize(3),
+	)
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	inv := agent.NewInvocation()
+	ctx := agent.NewInvocationContext(context.Background(), inv)
+	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{
+		{
+			Name:     "out/a.txt",
+			Content:  strings.Repeat("1", 200),
+			MIMEType: "text/plain",
+		},
+	})
+
+	req := searchContentRequest{
+		Path:           "",
+		FilePattern:    "workspace://out/a.txt",
+		ContentPattern: "1",
+	}
+	rsp, err := fts.searchContent(ctx, &req)
 	assert.Error(t, err)
 	assert.NotNil(t, rsp)
-	assert.Contains(t, rsp.Message, "file size is beyond")
+	assert.Contains(t, rsp.Message, "max search size")
 }
 
 func TestSearchContent_FilePatternRef_NoMatches(t *testing.T) {
@@ -485,24 +536,35 @@ func TestSearchSingleLocalFile_Branches(t *testing.T) {
 
 	re := regexp.MustCompile("foo")
 
-	matches, ok := fts.searchSingleLocalFile("", "", re)
+	matches, tooLarge, ok := fts.searchSingleLocalFile("", "", re)
 	assert.False(t, ok)
+	assert.False(t, tooLarge)
 	assert.Nil(t, matches)
 
-	matches, ok = fts.searchSingleLocalFile(base, "", re)
+	matches, tooLarge, ok = fts.searchSingleLocalFile(base, "", re)
 	assert.False(t, ok)
+	assert.False(t, tooLarge)
 	assert.Nil(t, matches)
 
-	tooBig := filepath.Join(base, "big.txt")
-	assert.NoError(t, os.WriteFile(tooBig, []byte("123"), 0o644))
-	matches, ok = fts.searchSingleLocalFile(tooBig, "big.txt", re)
+	withinCap := filepath.Join(base, "big.txt")
+	assert.NoError(t, os.WriteFile(withinCap, []byte("123\nfoo"), 0o644))
+	matches, tooLarge, ok = fts.searchSingleLocalFile(withinCap, "big.txt", re)
 	assert.True(t, ok)
+	assert.False(t, tooLarge)
+	assert.Len(t, matches, 1)
+
+	tooBig := filepath.Join(base, "huge.txt")
+	assert.NoError(t, os.WriteFile(tooBig, []byte(strings.Repeat("foo\n", 100)), 0o644))
+	matches, tooLarge, ok = fts.searchSingleLocalFile(tooBig, "huge.txt", re)
+	assert.True(t, ok)
+	assert.True(t, tooLarge)
 	assert.Empty(t, matches)
 
 	noMatch := filepath.Join(base, "nomatch.txt")
 	assert.NoError(t, os.WriteFile(noMatch, []byte("bar"), 0o644))
-	matches, ok = fts.searchSingleLocalFile(noMatch, "nomatch.txt", re)
+	matches, tooLarge, ok = fts.searchSingleLocalFile(noMatch, "nomatch.txt", re)
 	assert.True(t, ok)
+	assert.False(t, tooLarge)
 	assert.Empty(t, matches)
 }
 

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -12,6 +12,7 @@ package file
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -683,4 +684,159 @@ func TestSearchContent_CancelledContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.NotNil(t, rsp)
 	assert.Contains(t, rsp.Message, "context canceled")
+}
+
+func TestSearchContentByPath_Guards(t *testing.T) {
+	set, err := NewToolSet(WithBaseDir(t.TempDir()))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+	re := regexp.MustCompile("foo")
+
+	_, _, _, err = fts.searchContentByPath(context.Background(), nil, nil)
+	assert.EqualError(t, err, "request cannot be nil")
+
+	_, _, _, err = fts.searchContentByPath(context.Background(),
+		&searchContentRequest{Path: "ftp://host/dir"}, re)
+	assert.ErrorContains(t, err, "unsupported file ref scheme")
+}
+
+// A cancelled context stops a workspace search before it reads any file, and
+// is reported rather than returned as an empty result.
+func TestSearchContent_WorkspaceRef_CancelledContext(t *testing.T) {
+	set, err := NewToolSet(WithBaseDir(t.TempDir()))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	inv := agent.NewInvocation()
+	ctx, cancel := context.WithCancel(agent.NewInvocationContext(context.Background(), inv))
+	cancel()
+	toolcache.StoreSkillRunOutputFiles(inv, []codeexecutor.File{{
+		Name:     "out/transcript.txt",
+		Content:  "foo\n",
+		MIMEType: "text/plain",
+	}})
+
+	rsp, err := fts.searchContent(ctx, &searchContentRequest{
+		Path:           "workspace://",
+		FilePattern:    "**/*.txt",
+		ContentPattern: "foo",
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotNil(t, rsp)
+	assert.Empty(t, rsp.FileMatches)
+}
+
+// Searching a single file by path, rather than a directory with a pattern,
+// goes through the same size and cancellation rules.
+func TestSearchContent_PathIsFile(t *testing.T) {
+	tempDir := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(8))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "small.txt"), []byte("foo\nbar\n"), 0o644))
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "huge.txt"),
+		[]byte(strings.Repeat("foo\n", 1000)), 0o644))
+
+	t.Run("a file beyond the search cap is reported, not searched", func(t *testing.T) {
+		rsp, err := fts.searchContent(context.Background(), &searchContentRequest{
+			Path:           "huge.txt",
+			FilePattern:    "*",
+			ContentPattern: "foo",
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, rsp.FileMatches)
+		assert.Equal(t, []string{"huge.txt"}, rsp.SkippedFiles)
+		assert.Contains(t, rsp.Message, "huge.txt")
+	})
+
+	t.Run("a cancelled context is reported", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := fts.searchContent(ctx, &searchContentRequest{
+			Path:           "small.txt",
+			FilePattern:    "*",
+			ContentPattern: "foo",
+		})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("a file that cannot be scanned is an error", func(t *testing.T) {
+		// A line longer than the scanner tolerates makes the scan fail, which
+		// is the one way a readable file is not searchable.
+		long := filepath.Join(tempDir, "long.txt")
+		assert.NoError(t, os.WriteFile(long, []byte("foo "+strings.Repeat("x", maxSearchLineSize+1)+"\n"), 0o644))
+		t.Cleanup(func() { _ = os.Remove(long) })
+		big := set.(*fileToolSet)
+		big.maxFileSize = int64(maxSearchLineSize * 2)
+		t.Cleanup(func() { big.maxFileSize = 8 })
+
+		_, err := fts.searchContent(context.Background(), &searchContentRequest{
+			Path:           "long.txt",
+			FilePattern:    "*",
+			ContentPattern: "foo",
+		})
+		assert.ErrorContains(t, err, "long.txt")
+	})
+}
+
+// Streaming search stops listing a file's matches at maxMatchesPerFile, says so
+// in the message, and checks for cancellation as it scans.
+func TestSearchContent_StreamingLimits(t *testing.T) {
+	tempDir := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(tempDir))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "many.txt"),
+		[]byte(strings.Repeat("foo\n", maxMatchesPerFile+50)), 0o644))
+	// sparse.txt is long enough to reach the periodic cancellation check but
+	// matches too rarely to hit the per-file cap first.
+	assert.NoError(t, os.WriteFile(filepath.Join(tempDir, "sparse.txt"),
+		[]byte(strings.Repeat("bar\n", 2000)+"foo\n"), 0o644))
+	assert.NoError(t, os.Mkdir(filepath.Join(tempDir, "dir.txt"), 0o755))
+
+	t.Run("matches per file are capped", func(t *testing.T) {
+		rsp, err := fts.searchContent(context.Background(), &searchContentRequest{
+			FilePattern:    "*.txt",
+			ContentPattern: "foo",
+		})
+		assert.NoError(t, err)
+		assert.Len(t, rsp.FileMatches, 2, "the directory matching the pattern is skipped")
+		for _, m := range rsp.FileMatches {
+			if m.FilePath == "many.txt" {
+				assert.Len(t, m.Matches, maxMatchesPerFile)
+				assert.True(t, m.Truncated)
+			} else {
+				assert.False(t, m.Truncated)
+			}
+		}
+	})
+
+	t.Run("a single file searched by path is capped the same way", func(t *testing.T) {
+		rsp, err := fts.searchContent(context.Background(), &searchContentRequest{
+			Path:           "many.txt",
+			FilePattern:    "*",
+			ContentPattern: "foo",
+		})
+		assert.NoError(t, err)
+		assert.Len(t, rsp.FileMatches, 1)
+		assert.Len(t, rsp.FileMatches[0].Matches, maxMatchesPerFile)
+		assert.True(t, rsp.FileMatches[0].Truncated)
+	})
+
+	t.Run("the per-file message says where it stopped", func(t *testing.T) {
+		assert.Contains(t,
+			fileMatchMessage(&fileMatch{Truncated: true, Matches: make([]*lineMatch, maxMatchesPerFile)}, "many.txt"),
+			fmt.Sprintf("stopped at the first %d", maxMatchesPerFile))
+		assert.Equal(t, "Found 1 matches in file 'a.txt'",
+			fileMatchMessage(&fileMatch{Matches: make([]*lineMatch, 1)}, "a.txt"))
+	})
+
+	t.Run("cancellation is noticed mid-scan", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := searchFileContent(ctx, filepath.Join(tempDir, "sparse.txt"), regexp.MustCompile("foo"))
+		assert.ErrorIs(t, err, context.Canceled)
+	})
 }

--- a/tool/file/searchcontent_test.go
+++ b/tool/file/searchcontent_test.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -888,4 +890,43 @@ func TestSearchContent_StreamingLimits(t *testing.T) {
 		_, err := searchFileContent(ctx, filepath.Join(tempDir, "sparse.txt"), regexp.MustCompile("foo"))
 		assert.ErrorIs(t, err, context.Canceled)
 	})
+}
+
+// Oversized files are recorded by the walking loop while goroutines for
+// earlier files may be recording scan failures; both must reach skipped_files.
+// Run with -race, this is the regression for the unguarded append.
+func TestSearchContent_SkippedFilesFromBothPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0 does not deny reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root can read a mode-0 file")
+	}
+	tempDir := t.TempDir()
+	set, err := NewToolSet(WithBaseDir(tempDir), WithMaxFileSize(8))
+	assert.NoError(t, err)
+	fts := set.(*fileToolSet)
+
+	var want []string
+	for i := 0; i < 8; i++ {
+		// Under the cap but unreadable: its goroutine records a scan failure.
+		locked := fmt.Sprintf("a-locked-%d.txt", i)
+		path := filepath.Join(tempDir, locked)
+		assert.NoError(t, os.WriteFile(path, []byte("foo\n"), 0o644))
+		assert.NoError(t, os.Chmod(path, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+		// Over the cap: the walking loop records it.
+		huge := fmt.Sprintf("b-huge-%d.txt", i)
+		assert.NoError(t, os.WriteFile(filepath.Join(tempDir, huge),
+			[]byte(strings.Repeat("foo\n", 1000)), 0o644))
+		want = append(want, locked, huge)
+	}
+	rsp, err := fts.searchContent(context.Background(), &searchContentRequest{
+		FilePattern:    "*.txt",
+		ContentPattern: "foo",
+	})
+	assert.NoError(t, err)
+	assert.Empty(t, rsp.FileMatches)
+	slices.Sort(want)
+	assert.Equal(t, want, rsp.SkippedFiles)
 }


### PR DESCRIPTION
search_content silently skips any file larger than max_file_size in three of its four paths: a glob that matches only a large file returns "Found 0 files matching", indistinguishable from the file not existing. An agent reading that result can mistake an unsearched file for evidence of absence.

This change makes search stream files line by line (bufio.Scanner), so memory use is bounded by the longest line rather than the file size, and files above the read limit become searchable up to a 64x cap. Files beyond even that cap, and files whose scan fails partway on a line the scanner cannot hold, are named in a new skipped_files response field and called out in the message, never dropped silently. Lines are split on "\n" alone, so a CRLF line keeps its "\r" as it does through the cached and workspace backends. Per-file output is bounded at 500 matching lines, noted when truncated.

read_file gains the complementary fix: a start_line/num_lines read of an over-limit file now streams to the requested range and applies max_file_size to the returned slice instead of the whole file, since the limit exists to bound what is returned, not what the tool may look at. Whole-file reads of over-limit files keep failing, with a message that points at ranged reads and search_content. The limit is the size of what is returned, the lines joined by "\n". The in-memory slicer applies the same range-aware limit; line numbering and out-of-range errors keep their existing semantics, and every segment the streaming read passes over is checked for NUL bytes, as a whole-file read checks the whole file.

Tests updated to assert the reporting (the previous suite codified the silent skip) plus new coverage for streamed search, capped matches, ranged reads of large files, oversized ranges, and binary rejection.
