### PR TITLE
{evaluation, docs}: expose inference duration

### DIFF
--- a/docs/mkdocs/en/blog/evaluation.md
+++ b/docs/mkdocs/en/blog/evaluation.md
@@ -1832,14 +1832,16 @@ type EvaluationResult struct {
 	EvalSetID     string                  // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus       // OverallStatus is the overall status.
 	ExecutionTime time.Duration           // ExecutionTime is the execution duration.
+	AgentExecutionTime time.Duration      // AgentExecutionTime is actual agent inference time.
 	EvalCases     []*EvaluationCaseResult // EvalCases is the list of case results.
 }
 
 type EvaluationCaseResult struct {
-	EvalCaseID      string                         // EvalCaseID is the case identifier.
-	OverallStatus   status.EvalStatus              // OverallStatus is the aggregated status of this case.
-	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults is the case result for each run.
-	MetricResults   []*evalresult.EvalMetricResult // MetricResults is the aggregated metric results.
+	EvalCaseID         string                         // EvalCaseID is the case identifier.
+	OverallStatus      status.EvalStatus              // OverallStatus is the aggregated status of this case.
+	AgentExecutionTime time.Duration                  // AgentExecutionTime is actual agent inference time across runs for this case.
+	EvalCaseResults    []*evalresult.EvalCaseResult   // EvalCaseResults is the case result for each run.
+	MetricResults      []*evalresult.EvalMetricResult // MetricResults is the aggregated metric results.
 }
 ```
 

--- a/docs/mkdocs/en/blog/evaluation.md
+++ b/docs/mkdocs/en/blog/evaluation.md
@@ -1832,14 +1832,14 @@ type EvaluationResult struct {
 	EvalSetID     string                  // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus       // OverallStatus is the overall status.
 	ExecutionTime time.Duration           // ExecutionTime is the execution duration.
-	AgentExecutionTime time.Duration      // AgentExecutionTime is actual agent inference time.
+	InferenceDuration time.Duration      // InferenceDuration is actual agent inference time.
 	EvalCases     []*EvaluationCaseResult // EvalCases is the list of case results.
 }
 
 type EvaluationCaseResult struct {
 	EvalCaseID         string                         // EvalCaseID is the case identifier.
 	OverallStatus      status.EvalStatus              // OverallStatus is the aggregated status of this case.
-	AgentExecutionTime time.Duration                  // AgentExecutionTime is actual agent inference time across runs for this case.
+	InferenceDuration time.Duration                  // InferenceDuration is actual agent inference time across runs for this case.
 	EvalCaseResults    []*evalresult.EvalCaseResult   // EvalCaseResults is the case result for each run.
 	MetricResults      []*evalresult.EvalMetricResult // MetricResults is the aggregated metric results.
 }

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -55,7 +55,7 @@ type EvaluationInferenceDetails struct {
 
 `EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
 
-`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceDuration` sums only actual agent inference time across cases and runs, excluding evaluator and expected-runner work. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
+`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceDuration` sums actual agent inference time across cases and runs. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
 
 By default, `evaluation.New` creates AgentEvaluator and uses in-memory EvalSetManager, MetricManager, EvalResultManager, and the default Registry, and also creates a local Service. If you want to read EvalSet and metric configuration from local files and write results to files, you need to inject Local Managers explicitly.
 

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -23,7 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus         // OverallStatus is the overall status.
 	ExecutionTime time.Duration             // ExecutionTime is the execution duration.
-	AgentExecutionTime time.Duration        // AgentExecutionTime is actual agent inference time (excluding evaluation and expected-runner work).
+	InferenceDuration time.Duration        // InferenceDuration is actual agent inference time (excluding evaluation and expected-runner work).
 	EvalCases     []*EvaluationCaseResult   // EvalCases are the list of case results.
 	EvalResult    *evalresult.EvalSetResult // EvalResult is the persisted EvalSetResult.
 }
@@ -31,7 +31,7 @@ type EvaluationResult struct {
 type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID is the case identifier.
 	OverallStatus   status.EvalStatus              // OverallStatus is the aggregated status for this case.
-	AgentExecutionTime time.Duration              // AgentExecutionTime is actual agent inference time across runs for this case.
+	InferenceDuration time.Duration              // InferenceDuration is actual agent inference time across runs for this case.
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults are the per-run case results.
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults are the aggregated metric results.
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails are optional per-run inference details.
@@ -47,7 +47,7 @@ type EvaluationInferenceDetails struct {
 	UserID          string                // UserID identifies the user used for this run.
 	Status          status.EvalStatus     // Status records inference status.
 	ErrorMessage    string                // ErrorMessage records inference failure when present.
-	AgentExecutionTime time.Duration      // AgentExecutionTime is actual agent inference time for this run.
+	InferenceDuration time.Duration      // InferenceDuration is actual agent inference time for this run.
 	Inferences      []*evalset.Invocation // Inferences stores invocation outputs.
 	ExecutionTraces []*trace.Trace        // ExecutionTraces stores execution traces.
 }
@@ -55,7 +55,7 @@ type EvaluationInferenceDetails struct {
 
 `EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
 
-`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `AgentExecutionTime` sums only actual agent inference time across cases and runs, excluding evaluator and expected-runner work. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
+`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceDuration` sums only actual agent inference time across cases and runs, excluding evaluator and expected-runner work. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
 
 By default, `evaluation.New` creates AgentEvaluator and uses in-memory EvalSetManager, MetricManager, EvalResultManager, and the default Registry, and also creates a local Service. If you want to read EvalSet and metric configuration from local files and write results to files, you need to inject Local Managers explicitly.
 

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -23,7 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus         // OverallStatus is the overall status.
 	ExecutionTime time.Duration             // ExecutionTime is the execution duration.
-	InferenceDuration time.Duration        // InferenceDuration is actual agent inference time (excluding evaluation and expected-runner work).
+	InferenceDuration time.Duration        // InferenceDuration is actual agent inference time.
 	EvalCases     []*EvaluationCaseResult   // EvalCases are the list of case results.
 	EvalResult    *evalresult.EvalSetResult // EvalResult is the persisted EvalSetResult.
 }

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -23,6 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus         // OverallStatus is the overall status.
 	ExecutionTime time.Duration             // ExecutionTime is the execution duration.
+	AgentExecutionTime time.Duration        // AgentExecutionTime is actual agent inference time (excluding evaluation and expected-runner work).
 	EvalCases     []*EvaluationCaseResult   // EvalCases are the list of case results.
 	EvalResult    *evalresult.EvalSetResult // EvalResult is the persisted EvalSetResult.
 }
@@ -30,6 +31,7 @@ type EvaluationResult struct {
 type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID is the case identifier.
 	OverallStatus   status.EvalStatus              // OverallStatus is the aggregated status for this case.
+	AgentExecutionTime time.Duration              // AgentExecutionTime is actual agent inference time across runs for this case.
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults are the per-run case results.
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults are the aggregated metric results.
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails are optional per-run inference details.
@@ -45,12 +47,15 @@ type EvaluationInferenceDetails struct {
 	UserID          string                // UserID identifies the user used for this run.
 	Status          status.EvalStatus     // Status records inference status.
 	ErrorMessage    string                // ErrorMessage records inference failure when present.
+	AgentExecutionTime time.Duration      // AgentExecutionTime is actual agent inference time for this run.
 	Inferences      []*evalset.Invocation // Inferences stores invocation outputs.
 	ExecutionTraces []*trace.Trace        // ExecutionTraces stores execution traces.
 }
 ```
 
 `EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
+
+`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `AgentExecutionTime` sums only actual agent inference time across cases and runs, excluding evaluator and expected-runner work. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
 
 By default, `evaluation.New` creates AgentEvaluator and uses in-memory EvalSetManager, MetricManager, EvalResultManager, and the default Registry, and also creates a local Service. If you want to read EvalSet and metric configuration from local files and write results to files, you need to inject Local Managers explicitly.
 

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -53,7 +53,7 @@ type EvaluationInferenceDetails struct {
 }
 ```
 
-`EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
+`EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. The set-level `InferenceDuration` is returned on `EvaluationResult`; persisted EvalSetResult values retain case/run durations, so no database schema change is required. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
 
 `ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceDuration` sums actual agent inference time across cases and runs. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
 

--- a/docs/mkdocs/en/evaluation/evalresult.md
+++ b/docs/mkdocs/en/evaluation/evalresult.md
@@ -74,7 +74,9 @@ type RubricScore struct {
 }
 ```
 
-Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `inferenceDuration` is the actual agent inference time for this case run (excluding evaluation and expected-runner work). Both score and status are computed by the Service case result aggregator.
+Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `inferenceDuration` is the actual agent inference time for this case run. Both score and status are computed by the Service case result aggregator.
+
+When encoded with Go's standard JSON encoder, `inferenceDuration` is an integer number of nanoseconds; for example, `1.2s` is encoded as `1200000000`.
 
 `details.value` in metric details is typed score detail. It does not replace `score` and does not participate in the framework's default threshold checks. The default pass logic is still determined by the evaluator's numeric `score` and `threshold`. If `details.value` is present, `kind` selects the corresponding field to read; an omitted `details.value` means the evaluator did not provide typed detail. Numeric zero and boolean false are valid values. Typed values are intended for per-turn metric details; overall metric details keep aggregated numeric results and do not aggregate typed values by default. Platforms that need to distinguish numeric scores, boolean conclusions, or categorical labels can read `details.value.kind` and the corresponding field:
 
@@ -93,9 +95,11 @@ Below is an example result file snippet.
 {
   "evalSetResultId": "math-eval-app_math-basic_xxx",
   "evalSetId": "math-basic",
+  "inferenceDuration": 1200000000,
   "evalCaseResults": [
     {
       "evalId": "calc_add",
+      "inferenceDuration": 120000000,
       "score": 1,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [

--- a/docs/mkdocs/en/evaluation/evalresult.md
+++ b/docs/mkdocs/en/evaluation/evalresult.md
@@ -1,6 +1,6 @@
 # EvalResult
 
-EvalResult holds evaluation output. One evaluation run produces an EvalSetResult, organizes results by EvalCase, and records each metric's score, status, and per-turn details.
+EvalResult holds evaluation output. One evaluation run produces an EvalSetResult, organizes results by EvalCase, and records each metric's score, status, and per-turn details. Persisted EvalSetResult values keep inference duration at case/run level; sum the case results when a set-level total is needed.
 
 ## Structure Definition
 
@@ -21,7 +21,6 @@ type EvalSetResult struct {
 	EvalSetResultID   string               // EvalSetResultID is the result identifier.
 	EvalSetResultName string               // EvalSetResultName is the result name.
 	EvalSetID         string               // EvalSetID is the evaluation set identifier.
-	InferenceDuration time.Duration      // InferenceDuration is the total actual agent inference time across all cases and runs.
 	EvalCaseResults   []*EvalCaseResult    // EvalCaseResults is the list of case results.
 	CreationTimestamp *epochtime.EpochTime // CreationTimestamp is the creation timestamp.
 }
@@ -76,7 +75,7 @@ type RubricScore struct {
 
 Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `inferenceDuration` is the actual agent inference time for this case run. Both score and status are computed by the Service case result aggregator.
 
-When encoded with Go's standard JSON encoder, `inferenceDuration` is an integer number of nanoseconds; for example, `1.2s` is encoded as `1200000000`.
+When encoded with Go's standard JSON encoder, `inferenceDuration` is an integer number of nanoseconds; for example, `1.2s` is encoded as `1200000000`. The persisted EvalSetResult does not contain a separate set-level `inferenceDuration`; sum the case-level values when needed.
 
 `details.value` in metric details is typed score detail. It does not replace `score` and does not participate in the framework's default threshold checks. The default pass logic is still determined by the evaluator's numeric `score` and `threshold`. If `details.value` is present, `kind` selects the corresponding field to read; an omitted `details.value` means the evaluator did not provide typed detail. Numeric zero and boolean false are valid values. Typed values are intended for per-turn metric details; overall metric details keep aggregated numeric results and do not aggregate typed values by default. Platforms that need to distinguish numeric scores, boolean conclusions, or categorical labels can read `details.value.kind` and the corresponding field:
 
@@ -95,7 +94,6 @@ Below is an example result file snippet.
 {
   "evalSetResultId": "math-eval-app_math-basic_xxx",
   "evalSetId": "math-basic",
-  "inferenceDuration": 1200000000,
   "evalCaseResults": [
     {
       "evalId": "calc_add",

--- a/docs/mkdocs/en/evaluation/evalresult.md
+++ b/docs/mkdocs/en/evaluation/evalresult.md
@@ -8,6 +8,7 @@ The EvalSetResult structure is defined as follows.
 
 ```go
 import (
+	"time"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/epochtime"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
@@ -20,6 +21,7 @@ type EvalSetResult struct {
 	EvalSetResultID   string               // EvalSetResultID is the result identifier.
 	EvalSetResultName string               // EvalSetResultName is the result name.
 	EvalSetID         string               // EvalSetID is the evaluation set identifier.
+	AgentExecutionTime time.Duration      // AgentExecutionTime is the total actual agent inference time across all cases and runs.
 	EvalCaseResults   []*EvalCaseResult    // EvalCaseResults is the list of case results.
 	CreationTimestamp *epochtime.EpochTime // CreationTimestamp is the creation timestamp.
 }
@@ -36,6 +38,7 @@ type EvalCaseResult struct {
 	EvalMetricResultPerInvocation []*EvalMetricResultPerInvocation // EvalMetricResultPerInvocation is the list of per-turn metric results.
 	SessionID                     string                           // SessionID is the session identifier.
 	UserID                        string                           // UserID is the user identifier.
+	AgentExecutionTime            time.Duration                    // AgentExecutionTime is the actual agent inference time for this case run.
 }
 
 // EvalMetricResult represents the result of one evaluation metric.
@@ -71,7 +74,7 @@ type RubricScore struct {
 }
 ```
 
-Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, and `finalEvalStatus` is the evaluation case-level final status. Both are computed by the Service case result aggregator.
+Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `agentExecutionTime` is the actual agent inference time for this case run (excluding evaluation and expected-runner work). Both score and status are computed by the Service case result aggregator.
 
 `details.value` in metric details is typed score detail. It does not replace `score` and does not participate in the framework's default threshold checks. The default pass logic is still determined by the evaluator's numeric `score` and `threshold`. If `details.value` is present, `kind` selects the corresponding field to read; an omitted `details.value` means the evaluator did not provide typed detail. Numeric zero and boolean false are valid values. Typed values are intended for per-turn metric details; overall metric details keep aggregated numeric results and do not aggregate typed values by default. Platforms that need to distinguish numeric scores, boolean conclusions, or categorical labels can read `details.value.kind` and the corresponding field:
 

--- a/docs/mkdocs/en/evaluation/evalresult.md
+++ b/docs/mkdocs/en/evaluation/evalresult.md
@@ -21,7 +21,7 @@ type EvalSetResult struct {
 	EvalSetResultID   string               // EvalSetResultID is the result identifier.
 	EvalSetResultName string               // EvalSetResultName is the result name.
 	EvalSetID         string               // EvalSetID is the evaluation set identifier.
-	AgentExecutionTime time.Duration      // AgentExecutionTime is the total actual agent inference time across all cases and runs.
+	InferenceDuration time.Duration      // InferenceDuration is the total actual agent inference time across all cases and runs.
 	EvalCaseResults   []*EvalCaseResult    // EvalCaseResults is the list of case results.
 	CreationTimestamp *epochtime.EpochTime // CreationTimestamp is the creation timestamp.
 }
@@ -38,7 +38,7 @@ type EvalCaseResult struct {
 	EvalMetricResultPerInvocation []*EvalMetricResultPerInvocation // EvalMetricResultPerInvocation is the list of per-turn metric results.
 	SessionID                     string                           // SessionID is the session identifier.
 	UserID                        string                           // UserID is the user identifier.
-	AgentExecutionTime            time.Duration                    // AgentExecutionTime is the actual agent inference time for this case run.
+	InferenceDuration            time.Duration                    // InferenceDuration is the actual agent inference time for this case run.
 }
 
 // EvalMetricResult represents the result of one evaluation metric.
@@ -74,7 +74,7 @@ type RubricScore struct {
 }
 ```
 
-Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `agentExecutionTime` is the actual agent inference time for this case run (excluding evaluation and expected-runner work). Both score and status are computed by the Service case result aggregator.
+Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `inferenceDuration` is the actual agent inference time for this case run (excluding evaluation and expected-runner work). Both score and status are computed by the Service case result aggregator.
 
 `details.value` in metric details is typed score detail. It does not replace `score` and does not participate in the framework's default threshold checks. The default pass logic is still determined by the evaluator's numeric `score` and `threshold`. If `details.value` is present, `kind` selects the corresponding field to read; an omitted `details.value` means the evaluator did not provide typed detail. Numeric zero and boolean false are valid values. Typed values are intended for per-turn metric details; overall metric details keep aggregated numeric results and do not aggregate typed values by default. Platforms that need to distinguish numeric scores, boolean conclusions, or categorical labels can read `details.value.kind` and the corresponding field:
 

--- a/docs/mkdocs/en/evaluation/service.md
+++ b/docs/mkdocs/en/evaluation/service.md
@@ -40,7 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID is the inference user identifier.
 	Status       status.EvalStatus     // Status is the inference status.
 	ErrorMessage string                // ErrorMessage is the inference failure reason.
-	InferenceDuration time.Duration   // InferenceDuration is actual agent inference time (excluding evaluation and expected-runner work).
+	InferenceDuration time.Duration   // InferenceDuration is actual agent inference time.
 }
 
 // EvaluateRequest is the evaluation request.

--- a/docs/mkdocs/en/evaluation/service.md
+++ b/docs/mkdocs/en/evaluation/service.md
@@ -40,6 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID is the inference user identifier.
 	Status       status.EvalStatus     // Status is the inference status.
 	ErrorMessage string                // ErrorMessage is the inference failure reason.
+	AgentExecutionTime time.Duration   // AgentExecutionTime is actual agent inference time (excluding evaluation and expected-runner work).
 }
 
 // EvaluateRequest is the evaluation request.
@@ -59,6 +60,7 @@ type EvaluateConfig struct {
 type EvalSetRunResult struct {
 	AppName         string                       // AppName is the application name.
 	EvalSetID       string                       // EvalSetID is the evaluation set identifier.
+	AgentExecutionTime time.Duration             // AgentExecutionTime is actual agent inference time for this run.
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults are the evaluation case results.
 }
 

--- a/docs/mkdocs/en/evaluation/service.md
+++ b/docs/mkdocs/en/evaluation/service.md
@@ -40,7 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID is the inference user identifier.
 	Status       status.EvalStatus     // Status is the inference status.
 	ErrorMessage string                // ErrorMessage is the inference failure reason.
-	AgentExecutionTime time.Duration   // AgentExecutionTime is actual agent inference time (excluding evaluation and expected-runner work).
+	InferenceDuration time.Duration   // InferenceDuration is actual agent inference time (excluding evaluation and expected-runner work).
 }
 
 // EvaluateRequest is the evaluation request.
@@ -60,7 +60,7 @@ type EvaluateConfig struct {
 type EvalSetRunResult struct {
 	AppName         string                       // AppName is the application name.
 	EvalSetID       string                       // EvalSetID is the evaluation set identifier.
-	AgentExecutionTime time.Duration             // AgentExecutionTime is actual agent inference time for this run.
+	InferenceDuration time.Duration             // InferenceDuration is actual agent inference time for this run.
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults are the evaluation case results.
 }
 

--- a/docs/mkdocs/zh/blog/evaluation.md
+++ b/docs/mkdocs/zh/blog/evaluation.md
@@ -1833,14 +1833,16 @@ type EvaluationResult struct {
 	EvalSetID     string                  // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus       // OverallStatus 是整体状态
 	ExecutionTime time.Duration           // ExecutionTime 是执行耗时
+	AgentExecutionTime time.Duration      // AgentExecutionTime 是实际 agent 推理耗时
 	EvalCases     []*EvaluationCaseResult // EvalCases 是用例结果列表
 }
 
 type EvaluationCaseResult struct {
-	EvalCaseID      string                         // EvalCaseID 是用例标识
-	OverallStatus   status.EvalStatus              // OverallStatus 是该用例的聚合状态
-	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
-	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
+	EvalCaseID         string                         // EvalCaseID 是用例标识
+	OverallStatus      status.EvalStatus              // OverallStatus 是该用例的聚合状态
+	AgentExecutionTime time.Duration                  // AgentExecutionTime 是该用例所有 run 的实际 agent 推理耗时
+	EvalCaseResults    []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
+	MetricResults      []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 }
 ```
 

--- a/docs/mkdocs/zh/blog/evaluation.md
+++ b/docs/mkdocs/zh/blog/evaluation.md
@@ -1833,14 +1833,14 @@ type EvaluationResult struct {
 	EvalSetID     string                  // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus       // OverallStatus 是整体状态
 	ExecutionTime time.Duration           // ExecutionTime 是执行耗时
-	AgentExecutionTime time.Duration      // AgentExecutionTime 是实际 agent 推理耗时
+	InferenceDuration time.Duration      // InferenceDuration 是实际 agent 推理耗时
 	EvalCases     []*EvaluationCaseResult // EvalCases 是用例结果列表
 }
 
 type EvaluationCaseResult struct {
 	EvalCaseID         string                         // EvalCaseID 是用例标识
 	OverallStatus      status.EvalStatus              // OverallStatus 是该用例的聚合状态
-	AgentExecutionTime time.Duration                  // AgentExecutionTime 是该用例所有 run 的实际 agent 推理耗时
+	InferenceDuration time.Duration                  // InferenceDuration 是该用例所有 run 的实际 agent 推理耗时
 	EvalCaseResults    []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
 	MetricResults      []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 }

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -53,7 +53,7 @@ type EvaluationInferenceDetails struct {
 }
 ```
 
-`EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
+`EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。集合级 `InferenceDuration` 通过 `EvaluationResult` 返回；持久化的 EvalSetResult 保留 case/run 级耗时，因此不需要修改数据库结构。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
 
 `ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceDuration` 按所有 case/run 累加实际 agent 推理耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
 

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -23,7 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus         // OverallStatus 是整体状态
 	ExecutionTime time.Duration             // ExecutionTime 是执行耗时
-	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时，不含评估和预期 runner
+	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时
 	EvalCases     []*EvaluationCaseResult   // EvalCases 是用例结果列表
 	EvalResult    *evalresult.EvalSetResult // EvalResult 是持久化的 EvalSetResult
 }

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -55,7 +55,7 @@ type EvaluationInferenceDetails struct {
 
 `EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
 
-`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceDuration` 只统计实际 agent 推理耗时，并按所有 case/run 累加，不包含评估器或预期 runner 的耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
+`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceDuration` 按所有 case/run 累加实际 agent 推理耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
 
 默认情况下，`evaluation.New` 会创建 AgentEvaluator 并使用 InMemory 的 EvalSetManager、MetricManager、EvalResultManager 与默认 Registry，同时创建本地 Service。若希望从本地文件读取 EvalSet 与指标配置，并将结果写入文件，需要显式注入 Local Manager。
 

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -23,7 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus         // OverallStatus 是整体状态
 	ExecutionTime time.Duration             // ExecutionTime 是执行耗时
-	AgentExecutionTime time.Duration        // AgentExecutionTime 是实际 agent 推理耗时（不含评估和预期 runner）
+	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时（不含评估和预期 runner）
 	EvalCases     []*EvaluationCaseResult   // EvalCases 是用例结果列表
 	EvalResult    *evalresult.EvalSetResult // EvalResult 是持久化的 EvalSetResult
 }
@@ -31,7 +31,7 @@ type EvaluationResult struct {
 type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID 是用例标识
 	OverallStatus   status.EvalStatus              // OverallStatus 是该用例的聚合状态
-	AgentExecutionTime time.Duration              // AgentExecutionTime 是该用例所有 run 的实际 agent 推理耗时
+	InferenceDuration time.Duration              // InferenceDuration 是该用例所有 run 的实际 agent 推理耗时
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails 是可选的逐 run 推理详情
@@ -47,7 +47,7 @@ type EvaluationInferenceDetails struct {
 	UserID          string                // UserID 是本次运行使用的用户标识
 	Status          status.EvalStatus     // Status 是推理状态
 	ErrorMessage    string                // ErrorMessage 是推理失败信息
-	AgentExecutionTime time.Duration      // AgentExecutionTime 是本次 run 的实际 agent 推理耗时
+	InferenceDuration time.Duration      // InferenceDuration 是本次 run 的实际 agent 推理耗时
 	Inferences      []*evalset.Invocation // Inferences 是推理输出
 	ExecutionTraces []*trace.Trace        // ExecutionTraces 是执行轨迹
 }
@@ -55,7 +55,7 @@ type EvaluationInferenceDetails struct {
 
 `EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
 
-`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`AgentExecutionTime` 只统计实际 agent 推理耗时，并按所有 case/run 累加，不包含评估器或预期 runner 的耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
+`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceDuration` 只统计实际 agent 推理耗时，并按所有 case/run 累加，不包含评估器或预期 runner 的耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
 
 默认情况下，`evaluation.New` 会创建 AgentEvaluator 并使用 InMemory 的 EvalSetManager、MetricManager、EvalResultManager 与默认 Registry，同时创建本地 Service。若希望从本地文件读取 EvalSet 与指标配置，并将结果写入文件，需要显式注入 Local Manager。
 

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -23,6 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus         // OverallStatus 是整体状态
 	ExecutionTime time.Duration             // ExecutionTime 是执行耗时
+	AgentExecutionTime time.Duration        // AgentExecutionTime 是实际 agent 推理耗时（不含评估和预期 runner）
 	EvalCases     []*EvaluationCaseResult   // EvalCases 是用例结果列表
 	EvalResult    *evalresult.EvalSetResult // EvalResult 是持久化的 EvalSetResult
 }
@@ -30,6 +31,7 @@ type EvaluationResult struct {
 type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID 是用例标识
 	OverallStatus   status.EvalStatus              // OverallStatus 是该用例的聚合状态
+	AgentExecutionTime time.Duration              // AgentExecutionTime 是该用例所有 run 的实际 agent 推理耗时
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails 是可选的逐 run 推理详情
@@ -45,12 +47,15 @@ type EvaluationInferenceDetails struct {
 	UserID          string                // UserID 是本次运行使用的用户标识
 	Status          status.EvalStatus     // Status 是推理状态
 	ErrorMessage    string                // ErrorMessage 是推理失败信息
+	AgentExecutionTime time.Duration      // AgentExecutionTime 是本次 run 的实际 agent 推理耗时
 	Inferences      []*evalset.Invocation // Inferences 是推理输出
 	ExecutionTraces []*trace.Trace        // ExecutionTraces 是执行轨迹
 }
 ```
 
 `EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
+
+`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`AgentExecutionTime` 只统计实际 agent 推理耗时，并按所有 case/run 累加，不包含评估器或预期 runner 的耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
 
 默认情况下，`evaluation.New` 会创建 AgentEvaluator 并使用 InMemory 的 EvalSetManager、MetricManager、EvalResultManager 与默认 Registry，同时创建本地 Service。若希望从本地文件读取 EvalSet 与指标配置，并将结果写入文件，需要显式注入 Local Manager。
 

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -23,7 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus         // OverallStatus 是整体状态
 	ExecutionTime time.Duration             // ExecutionTime 是执行耗时
-	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时（不含评估和预期 runner）
+	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时，不含评估和预期 runner
 	EvalCases     []*EvaluationCaseResult   // EvalCases 是用例结果列表
 	EvalResult    *evalresult.EvalSetResult // EvalResult 是持久化的 EvalSetResult
 }

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -74,7 +74,9 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时，不含评估和预期 runner；分数和状态由 Service 的用例结果聚合器计算。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时；分数和状态由 Service 的用例结果聚合器计算。
+
+通过 Go 标准 JSON 编码时，`inferenceDuration` 表示为纳秒整数，例如 `1.2s` 编码为 `1200000000`。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 
@@ -93,9 +95,11 @@ type RubricScore struct {
 {
   "evalSetResultId": "math-eval-app_math-basic_xxx",
   "evalSetId": "math-basic",
+  "inferenceDuration": 1200000000,
   "evalCaseResults": [
     {
       "evalId": "calc_add",
+      "inferenceDuration": 120000000,
       "score": 1,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -74,7 +74,7 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时（不含评估和预期 runner）；分数和状态由 Service 的用例结果聚合器计算。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时，不含评估和预期 runner；分数和状态由 Service 的用例结果聚合器计算。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -1,6 +1,6 @@
 # 评估结果 EvalResult
 
-EvalResult 用于承载评估输出。一次评估运行会生成一个 EvalSetResult，按 EvalCase 组织结果，并记录每条评估指标的分数、状态与逐轮明细。
+EvalResult 用于承载评估输出。一次评估运行会生成一个 EvalSetResult，按 EvalCase 组织结果，并记录每条评估指标的分数、状态与逐轮明细。持久化的 EvalSetResult 保留 case/run 级别的推理耗时；如需集合级总耗时，可对各 case 结果求和。
 
 ## 结构定义
 
@@ -21,7 +21,6 @@ type EvalSetResult struct {
 	EvalSetResultID   string               // EvalSetResultID 是结果标识
 	EvalSetResultName string               // EvalSetResultName 是结果名称
 	EvalSetID         string               // EvalSetID 是评估集标识
-	InferenceDuration time.Duration      // InferenceDuration 是所有 case/run 的实际 agent 推理总耗时
 	EvalCaseResults   []*EvalCaseResult    // EvalCaseResults 是用例结果列表
 	CreationTimestamp *epochtime.EpochTime // CreationTimestamp 是创建时间戳
 }
@@ -76,7 +75,7 @@ type RubricScore struct {
 
 整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时；分数和状态由 Service 的用例结果聚合器计算。
 
-通过 Go 标准 JSON 编码时，`inferenceDuration` 表示为纳秒整数，例如 `1.2s` 编码为 `1200000000`。
+通过 Go 标准 JSON 编码时，`inferenceDuration` 表示为纳秒整数，例如 `1.2s` 编码为 `1200000000`。持久化的 EvalSetResult 不包含独立的集合级 `inferenceDuration`；如需集合级总耗时，可对各 case 级耗时求和。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 
@@ -95,7 +94,6 @@ type RubricScore struct {
 {
   "evalSetResultId": "math-eval-app_math-basic_xxx",
   "evalSetId": "math-basic",
-  "inferenceDuration": 1200000000,
   "evalCaseResults": [
     {
       "evalId": "calc_add",

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -8,6 +8,7 @@ EvalSetResult 的结构定义如下。
 
 ```go
 import (
+	"time"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/epochtime"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
@@ -20,6 +21,7 @@ type EvalSetResult struct {
 	EvalSetResultID   string               // EvalSetResultID 是结果标识
 	EvalSetResultName string               // EvalSetResultName 是结果名称
 	EvalSetID         string               // EvalSetID 是评估集标识
+	AgentExecutionTime time.Duration      // AgentExecutionTime 是所有 case/run 的实际 agent 推理总耗时
 	EvalCaseResults   []*EvalCaseResult    // EvalCaseResults 是用例结果列表
 	CreationTimestamp *epochtime.EpochTime // CreationTimestamp 是创建时间戳
 }
@@ -36,6 +38,7 @@ type EvalCaseResult struct {
 	EvalMetricResultPerInvocation []*EvalMetricResultPerInvocation // EvalMetricResultPerInvocation 是逐轮指标结果列表
 	SessionID                     string                           // SessionID 是会话标识
 	UserID                        string                           // UserID 是用户标识
+	AgentExecutionTime            time.Duration                    // AgentExecutionTime 是本次用例运行的实际 agent 推理耗时
 }
 
 // EvalMetricResult 表示单条评估指标的结果
@@ -71,7 +74,7 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态；它们由 Service 的用例结果聚合器计算。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`agentExecutionTime` 表示本次用例运行的实际 agent 推理耗时（不含评估和预期 runner）；分数和状态由 Service 的用例结果聚合器计算。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -21,7 +21,7 @@ type EvalSetResult struct {
 	EvalSetResultID   string               // EvalSetResultID 是结果标识
 	EvalSetResultName string               // EvalSetResultName 是结果名称
 	EvalSetID         string               // EvalSetID 是评估集标识
-	AgentExecutionTime time.Duration      // AgentExecutionTime 是所有 case/run 的实际 agent 推理总耗时
+	InferenceDuration time.Duration      // InferenceDuration 是所有 case/run 的实际 agent 推理总耗时
 	EvalCaseResults   []*EvalCaseResult    // EvalCaseResults 是用例结果列表
 	CreationTimestamp *epochtime.EpochTime // CreationTimestamp 是创建时间戳
 }
@@ -38,7 +38,7 @@ type EvalCaseResult struct {
 	EvalMetricResultPerInvocation []*EvalMetricResultPerInvocation // EvalMetricResultPerInvocation 是逐轮指标结果列表
 	SessionID                     string                           // SessionID 是会话标识
 	UserID                        string                           // UserID 是用户标识
-	AgentExecutionTime            time.Duration                    // AgentExecutionTime 是本次用例运行的实际 agent 推理耗时
+	InferenceDuration            time.Duration                    // InferenceDuration 是本次用例运行的实际 agent 推理耗时
 }
 
 // EvalMetricResult 表示单条评估指标的结果
@@ -74,7 +74,7 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`agentExecutionTime` 表示本次用例运行的实际 agent 推理耗时（不含评估和预期 runner）；分数和状态由 Service 的用例结果聚合器计算。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时（不含评估和预期 runner）；分数和状态由 Service 的用例结果聚合器计算。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 

--- a/docs/mkdocs/zh/evaluation/service.md
+++ b/docs/mkdocs/zh/evaluation/service.md
@@ -40,7 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID 是推理阶段用户标识
 	Status       status.EvalStatus     // Status 是推理状态
 	ErrorMessage string                // ErrorMessage 是推理失败原因
-	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时，不含评估和预期 runner
+	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时
 }
 
 // EvaluateRequest 是评估请求

--- a/docs/mkdocs/zh/evaluation/service.md
+++ b/docs/mkdocs/zh/evaluation/service.md
@@ -40,7 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID 是推理阶段用户标识
 	Status       status.EvalStatus     // Status 是推理状态
 	ErrorMessage string                // ErrorMessage 是推理失败原因
-	AgentExecutionTime time.Duration   // AgentExecutionTime 是实际 agent 推理耗时（不含评估和预期 runner）
+	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时（不含评估和预期 runner）
 }
 
 // EvaluateRequest 是评估请求
@@ -60,7 +60,7 @@ type EvaluateConfig struct {
 type EvalSetRunResult struct {
 	AppName         string                       // AppName 是应用名
 	EvalSetID       string                       // EvalSetID 是评估集标识
-	AgentExecutionTime time.Duration             // AgentExecutionTime 是本次 run 的实际 agent 推理耗时
+	InferenceDuration time.Duration             // InferenceDuration 是本次 run 的实际 agent 推理耗时
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults 是评估用例结果
 }
 

--- a/docs/mkdocs/zh/evaluation/service.md
+++ b/docs/mkdocs/zh/evaluation/service.md
@@ -40,6 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID 是推理阶段用户标识
 	Status       status.EvalStatus     // Status 是推理状态
 	ErrorMessage string                // ErrorMessage 是推理失败原因
+	AgentExecutionTime time.Duration   // AgentExecutionTime 是实际 agent 推理耗时（不含评估和预期 runner）
 }
 
 // EvaluateRequest 是评估请求
@@ -59,6 +60,7 @@ type EvaluateConfig struct {
 type EvalSetRunResult struct {
 	AppName         string                       // AppName 是应用名
 	EvalSetID       string                       // EvalSetID 是评估集标识
+	AgentExecutionTime time.Duration             // AgentExecutionTime 是本次 run 的实际 agent 推理耗时
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults 是评估用例结果
 }
 

--- a/docs/mkdocs/zh/evaluation/service.md
+++ b/docs/mkdocs/zh/evaluation/service.md
@@ -40,7 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID 是推理阶段用户标识
 	Status       status.EvalStatus     // Status 是推理状态
 	ErrorMessage string                // ErrorMessage 是推理失败原因
-	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时（不含评估和预期 runner）
+	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时，不含评估和预期 runner
 }
 
 // EvaluateRequest 是评估请求

--- a/evaluation/evalresult/evalresult.go
+++ b/evaluation/evalresult/evalresult.go
@@ -12,6 +12,7 @@ package evalresult
 
 import (
 	"context"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/epochtime"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
@@ -28,6 +29,8 @@ type EvalSetResult struct {
 	EvalSetResultName string `json:"evalSetResultName,omitempty"`
 	// EvalSetID identifies the eval set.
 	EvalSetID string `json:"evalSetId,omitempty"`
+	// AgentExecutionTime is the total time spent executing the actual agent across all cases and runs.
+	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
 	// EvalCaseResults contains results for each eval case.
 	EvalCaseResults []*EvalCaseResult `json:"evalCaseResults,omitempty"`
 	// Summary provides aggregated statistics for multi-run results.
@@ -58,6 +61,8 @@ type EvalCaseResult struct {
 	SessionID string `json:"sessionId,omitempty"`
 	// UserID is the user id used during inferencing stage of the eval.
 	UserID string `json:"userId,omitempty"`
+	// AgentExecutionTime is the total time spent executing the actual agent for this eval case run.
+	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
 }
 
 // EvalMetricResult represents the result of a single metric evaluation.

--- a/evaluation/evalresult/evalresult.go
+++ b/evaluation/evalresult/evalresult.go
@@ -29,8 +29,6 @@ type EvalSetResult struct {
 	EvalSetResultName string `json:"evalSetResultName,omitempty"`
 	// EvalSetID identifies the eval set.
 	EvalSetID string `json:"evalSetId,omitempty"`
-	// InferenceDuration is the total time spent executing the actual agent across all cases and runs.
-	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
 	// EvalCaseResults contains results for each eval case.
 	EvalCaseResults []*EvalCaseResult `json:"evalCaseResults,omitempty"`
 	// Summary provides aggregated statistics for multi-run results.

--- a/evaluation/evalresult/evalresult.go
+++ b/evaluation/evalresult/evalresult.go
@@ -29,8 +29,8 @@ type EvalSetResult struct {
 	EvalSetResultName string `json:"evalSetResultName,omitempty"`
 	// EvalSetID identifies the eval set.
 	EvalSetID string `json:"evalSetId,omitempty"`
-	// AgentExecutionTime is the total time spent executing the actual agent across all cases and runs.
-	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
+	// InferenceDuration is the total time spent executing the actual agent across all cases and runs.
+	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
 	// EvalCaseResults contains results for each eval case.
 	EvalCaseResults []*EvalCaseResult `json:"evalCaseResults,omitempty"`
 	// Summary provides aggregated statistics for multi-run results.
@@ -61,8 +61,8 @@ type EvalCaseResult struct {
 	SessionID string `json:"sessionId,omitempty"`
 	// UserID is the user id used during inferencing stage of the eval.
 	UserID string `json:"userId,omitempty"`
-	// AgentExecutionTime is the total time spent executing the actual agent for this eval case run.
-	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
+	// InferenceDuration is the total time spent executing the actual agent for this eval case run.
+	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
 }
 
 // EvalMetricResult represents the result of a single metric evaluation.

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -149,23 +149,23 @@ type agentEvaluator struct {
 
 // EvaluationResult contains the aggregated outcome of running an evaluation across multiple runs.
 type EvaluationResult struct {
-	AppName            string                    `json:"appName"`            // AppName identifies the agent being evaluated.
-	EvalSetID          string                    `json:"evalSetId"`          // EvalSetID identifies the evaluation set used in this run.
-	OverallStatus      status.EvalStatus         `json:"overallStatus"`      // OverallStatus summarizes the aggregated evaluation status across cases.
-	ExecutionTime      time.Duration             `json:"executionTime"`      // ExecutionTime records the total latency for the evaluation run.
-	AgentExecutionTime time.Duration             `json:"agentExecutionTime"` // AgentExecutionTime records summed actual agent time across cases and runs.
-	EvalCases          []*EvaluationCaseResult   `json:"evalCases"`          // EvalCases contains aggregated results for each evaluation case.
-	EvalResult         *evalresult.EvalSetResult `json:"evalSetResult"`      // EvalSetResult contains the aggregated results of the evaluation set.
+	AppName           string                    `json:"appName"`           // AppName identifies the agent being evaluated.
+	EvalSetID         string                    `json:"evalSetId"`         // EvalSetID identifies the evaluation set used in this run.
+	OverallStatus     status.EvalStatus         `json:"overallStatus"`     // OverallStatus summarizes the aggregated evaluation status across cases.
+	ExecutionTime     time.Duration             `json:"executionTime"`     // ExecutionTime records the total latency for the evaluation run.
+	InferenceDuration time.Duration             `json:"inferenceDuration"` // InferenceDuration records summed actual agent time across cases and runs.
+	EvalCases         []*EvaluationCaseResult   `json:"evalCases"`         // EvalCases contains aggregated results for each evaluation case.
+	EvalResult        *evalresult.EvalSetResult `json:"evalSetResult"`     // EvalSetResult contains the aggregated results of the evaluation set.
 }
 
 // EvaluationCaseResult aggregates the outcome of a single eval case across multiple runs.
 type EvaluationCaseResult struct {
-	EvalCaseID         string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
-	OverallStatus      status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
-	AgentExecutionTime time.Duration                  `json:"agentExecutionTime"`   // AgentExecutionTime is the total actual agent time across runs for this case.
-	EvalCaseResults    []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
-	MetricResults      []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
-	RunDetails         []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
+	EvalCaseID        string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
+	OverallStatus     status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
+	InferenceDuration time.Duration                  `json:"inferenceDuration"`    // InferenceDuration is the total actual agent time across runs for this case.
+	EvalCaseResults   []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
+	MetricResults     []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
+	RunDetails        []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
 }
 
 // EvaluationCaseRunDetails contains caller-facing details for a single run of an eval case.
@@ -176,13 +176,13 @@ type EvaluationCaseRunDetails struct {
 
 // EvaluationInferenceDetails contains caller-facing inference details for a single eval case run.
 type EvaluationInferenceDetails struct {
-	SessionID          string                `json:"sessionId,omitempty"`          // SessionID identifies the inference session used for this run.
-	UserID             string                `json:"userId,omitempty"`             // UserID identifies the user used for this run.
-	Status             status.EvalStatus     `json:"status,omitempty"`             // Status records the inference status for this run.
-	ErrorMessage       string                `json:"errorMessage,omitempty"`       // ErrorMessage records the inference failure message when present.
-	AgentExecutionTime time.Duration         `json:"agentExecutionTime,omitempty"` // AgentExecutionTime records the actual agent time for this run.
-	Inferences         []*evalset.Invocation `json:"inferences,omitempty"`         // Inferences stores the invocation outputs captured during this run.
-	ExecutionTraces    []*trace.Trace        `json:"executionTraces,omitempty"`    // ExecutionTraces stores the execution traces captured during this run.
+	SessionID         string                `json:"sessionId,omitempty"`         // SessionID identifies the inference session used for this run.
+	UserID            string                `json:"userId,omitempty"`            // UserID identifies the user used for this run.
+	Status            status.EvalStatus     `json:"status,omitempty"`            // Status records the inference status for this run.
+	ErrorMessage      string                `json:"errorMessage,omitempty"`      // ErrorMessage records the inference failure message when present.
+	InferenceDuration time.Duration         `json:"inferenceDuration,omitempty"` // InferenceDuration records the actual agent time for this run.
+	Inferences        []*evalset.Invocation `json:"inferences,omitempty"`        // Inferences stores the invocation outputs captured during this run.
+	ExecutionTraces   []*trace.Trace        `json:"executionTraces,omitempty"`   // ExecutionTraces stores the execution traces captured during this run.
 }
 
 type runDetailsCollector struct {
@@ -212,13 +212,13 @@ func (a *agentEvaluator) Evaluate(ctx context.Context, evalSetID string, opt ...
 		return nil, fmt.Errorf("summarize overall status: %w", err)
 	}
 	return &EvaluationResult{
-		AppName:            a.appName,
-		EvalSetID:          evalSetID,
-		OverallStatus:      status,
-		ExecutionTime:      time.Since(start),
-		AgentExecutionTime: callOpts.agentExecutionTimeValue(),
-		EvalCases:          evalCases,
-		EvalResult:         evalSetResult,
+		AppName:           a.appName,
+		EvalSetID:         evalSetID,
+		OverallStatus:     status,
+		ExecutionTime:     time.Since(start),
+		InferenceDuration: callOpts.inferenceDurationValue(),
+		EvalCases:         evalCases,
+		EvalResult:        evalSetResult,
 	}, nil
 }
 
@@ -322,7 +322,7 @@ func (a *agentEvaluator) collectCaseResults(ctx context.Context, evalSetID strin
 		}
 		for _, run := range runs {
 			if run != nil {
-				evalCaseResult.AgentExecutionTime += run.AgentExecutionTime
+				evalCaseResult.InferenceDuration += run.InferenceDuration
 			}
 		}
 		evalCaseResults = append(evalCaseResults, evalCaseResult)
@@ -392,9 +392,9 @@ func (a *agentEvaluator) runEvaluation(ctx context.Context, evalSetID string, op
 		allCaseResults = append(allCaseResults, caseResults...)
 	}
 	evalSetResult := &evalresult.EvalSetResult{
-		EvalSetID:          evalSetID,
-		AgentExecutionTime: opts.agentExecutionTimeValue(),
-		EvalCaseResults:    allCaseResults,
+		EvalSetID:         evalSetID,
+		InferenceDuration: opts.inferenceDurationValue(),
+		EvalCaseResults:   allCaseResults,
 	}
 	if err := multirun.SummarizeMultiRun(evalSetResult, opts.numRuns); err != nil {
 		return nil, fmt.Errorf("summarize eval set result: %w", err)
@@ -489,8 +489,8 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if err != nil {
 		return nil, fmt.Errorf("run %d inference: %w", runID, err)
 	}
-	inferenceAgentExecutionTime := agentExecutionTimeForInferenceResults(runInferenceResults)
-	opts.addAgentExecutionDuration(inferenceAgentExecutionTime)
+	inferenceDuration := inferenceDurationForInferenceResults(runInferenceResults)
+	opts.addInferenceDuration(inferenceDuration)
 	if opts.runDetailsCollector != nil {
 		opts.runDetailsCollector.add(runID, runInferenceResults)
 	}
@@ -535,32 +535,32 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if runResult == nil {
 		return nil, errors.New("eval set run result is nil")
 	}
-	if inferenceAgentExecutionTime == 0 {
-		runAgentExecutionTime := runResult.AgentExecutionTime
-		if runAgentExecutionTime == 0 {
+	if inferenceDuration == 0 {
+		runInferenceDuration := runResult.InferenceDuration
+		if runInferenceDuration == 0 {
 			for _, caseResult := range runResult.EvalCaseResults {
 				if caseResult != nil {
-					runAgentExecutionTime += caseResult.AgentExecutionTime
+					runInferenceDuration += caseResult.InferenceDuration
 				}
 			}
 		}
-		opts.addAgentExecutionDuration(runAgentExecutionTime)
+		opts.addInferenceDuration(runInferenceDuration)
 	}
 	caseResults := make([]*evalresult.EvalCaseResult, 0, len(runResult.EvalCaseResults))
-	agentExecutionTimes := make(map[string]time.Duration)
+	inferenceDurations := make(map[string]time.Duration)
 	for _, inferenceResult := range runInferenceResults {
 		if inferenceResult == nil || inferenceResult.EvalCaseID == "" {
 			continue
 		}
-		agentExecutionTimes[inferenceResult.EvalCaseID] += agentExecutionTimeForInferenceResult(inferenceResult)
+		inferenceDurations[inferenceResult.EvalCaseID] += inferenceDurationForInferenceResult(inferenceResult)
 	}
 	for _, caseResult := range runResult.EvalCaseResults {
 		if caseResult == nil {
 			continue
 		}
 		caseResult.RunID = runID
-		if elapsed, ok := agentExecutionTimes[caseResult.EvalID]; ok {
-			caseResult.AgentExecutionTime = elapsed
+		if elapsed, ok := inferenceDurations[caseResult.EvalID]; ok {
+			caseResult.InferenceDuration = elapsed
 		}
 		caseResults = append(caseResults, caseResult)
 	}
@@ -675,22 +675,22 @@ func newEvaluationInferenceDetails(inferenceResult *service.InferenceResult) *Ev
 		return nil
 	}
 	return &EvaluationInferenceDetails{
-		SessionID:          inferenceResult.SessionID,
-		UserID:             inferenceResult.UserID,
-		Status:             inferenceResult.Status,
-		ErrorMessage:       inferenceResult.ErrorMessage,
-		AgentExecutionTime: agentExecutionTimeForInferenceResult(inferenceResult),
-		Inferences:         append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
-		ExecutionTraces:    append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
+		SessionID:         inferenceResult.SessionID,
+		UserID:            inferenceResult.UserID,
+		Status:            inferenceResult.Status,
+		ErrorMessage:      inferenceResult.ErrorMessage,
+		InferenceDuration: inferenceDurationForInferenceResult(inferenceResult),
+		Inferences:        append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
+		ExecutionTraces:   append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
 	}
 }
 
-func agentExecutionTimeForInferenceResult(inferenceResult *service.InferenceResult) time.Duration {
+func inferenceDurationForInferenceResult(inferenceResult *service.InferenceResult) time.Duration {
 	if inferenceResult == nil {
 		return 0
 	}
-	if inferenceResult.AgentExecutionTime > 0 {
-		return inferenceResult.AgentExecutionTime
+	if inferenceResult.InferenceDuration > 0 {
+		return inferenceResult.InferenceDuration
 	}
 	// Trace-mode cases replay recorded invocations without executing the agent.
 	if inferenceResult.EvalMode == evalset.EvalModeTrace {
@@ -708,10 +708,10 @@ func agentExecutionTimeForInferenceResult(inferenceResult *service.InferenceResu
 	return elapsed
 }
 
-func agentExecutionTimeForInferenceResults(inferenceResults []*service.InferenceResult) time.Duration {
+func inferenceDurationForInferenceResults(inferenceResults []*service.InferenceResult) time.Duration {
 	var elapsed time.Duration
 	for _, inferenceResult := range inferenceResults {
-		elapsed += agentExecutionTimeForInferenceResult(inferenceResult)
+		elapsed += inferenceDurationForInferenceResult(inferenceResult)
 	}
 	return elapsed
 }

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -392,9 +392,8 @@ func (a *agentEvaluator) runEvaluation(ctx context.Context, evalSetID string, op
 		allCaseResults = append(allCaseResults, caseResults...)
 	}
 	evalSetResult := &evalresult.EvalSetResult{
-		EvalSetID:         evalSetID,
-		InferenceDuration: opts.inferenceDurationValue(),
-		EvalCaseResults:   allCaseResults,
+		EvalSetID:       evalSetID,
+		EvalCaseResults: allCaseResults,
 	}
 	if err := multirun.SummarizeMultiRun(evalSetResult, opts.numRuns); err != nil {
 		return nil, fmt.Errorf("summarize eval set result: %w", err)
@@ -490,7 +489,6 @@ func (a *agentEvaluator) runEvaluationOnce(
 		return nil, fmt.Errorf("run %d inference: %w", runID, err)
 	}
 	inferenceDuration := inferenceDurationForInferenceResults(runInferenceResults)
-	opts.addInferenceDuration(inferenceDuration)
 	if opts.runDetailsCollector != nil {
 		opts.runDetailsCollector.add(runID, runInferenceResults)
 	}
@@ -535,17 +533,6 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if runResult == nil {
 		return nil, errors.New("eval set run result is nil")
 	}
-	if inferenceDuration == 0 {
-		runInferenceDuration := runResult.InferenceDuration
-		if runInferenceDuration == 0 {
-			for _, caseResult := range runResult.EvalCaseResults {
-				if caseResult != nil {
-					runInferenceDuration += caseResult.InferenceDuration
-				}
-			}
-		}
-		opts.addInferenceDuration(runInferenceDuration)
-	}
 	caseResults := make([]*evalresult.EvalCaseResult, 0, len(runResult.EvalCaseResults))
 	inferenceDurations := make(map[string]time.Duration)
 	for _, inferenceResult := range runInferenceResults {
@@ -554,6 +541,7 @@ func (a *agentEvaluator) runEvaluationOnce(
 		}
 		inferenceDurations[inferenceResult.EvalCaseID] += inferenceDurationForInferenceResult(inferenceResult)
 	}
+	mergedCaseDuration := time.Duration(0)
 	for _, caseResult := range runResult.EvalCaseResults {
 		if caseResult == nil {
 			continue
@@ -562,8 +550,21 @@ func (a *agentEvaluator) runEvaluationOnce(
 		if elapsed, ok := inferenceDurations[caseResult.EvalID]; ok && elapsed > 0 {
 			caseResult.InferenceDuration = elapsed
 		}
+		delete(inferenceDurations, caseResult.EvalID)
+		mergedCaseDuration += caseResult.InferenceDuration
 		caseResults = append(caseResults, caseResult)
 	}
+	for _, elapsed := range inferenceDurations {
+		mergedCaseDuration += elapsed
+	}
+	runInferenceDuration := mergedCaseDuration
+	if runResult.InferenceDuration > runInferenceDuration {
+		runInferenceDuration = runResult.InferenceDuration
+	}
+	if inferenceDuration > runInferenceDuration {
+		runInferenceDuration = inferenceDuration
+	}
+	opts.addInferenceDuration(runInferenceDuration)
 	return caseResults, nil
 }
 

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -149,21 +149,23 @@ type agentEvaluator struct {
 
 // EvaluationResult contains the aggregated outcome of running an evaluation across multiple runs.
 type EvaluationResult struct {
-	AppName       string                    `json:"appName"`       // AppName identifies the agent being evaluated.
-	EvalSetID     string                    `json:"evalSetId"`     // EvalSetID identifies the evaluation set used in this run.
-	OverallStatus status.EvalStatus         `json:"overallStatus"` // OverallStatus summarizes the aggregated evaluation status across cases.
-	ExecutionTime time.Duration             `json:"executionTime"` // ExecutionTime records the total latency for the evaluation run.
-	EvalCases     []*EvaluationCaseResult   `json:"evalCases"`     // EvalCases contains aggregated results for each evaluation case.
-	EvalResult    *evalresult.EvalSetResult `json:"evalSetResult"` // EvalSetResult contains the aggregated results of the evaluation set.
+	AppName            string                    `json:"appName"`            // AppName identifies the agent being evaluated.
+	EvalSetID          string                    `json:"evalSetId"`          // EvalSetID identifies the evaluation set used in this run.
+	OverallStatus      status.EvalStatus         `json:"overallStatus"`      // OverallStatus summarizes the aggregated evaluation status across cases.
+	ExecutionTime      time.Duration             `json:"executionTime"`      // ExecutionTime records the total latency for the evaluation run.
+	AgentExecutionTime time.Duration             `json:"agentExecutionTime"` // AgentExecutionTime records summed actual agent time across cases and runs.
+	EvalCases          []*EvaluationCaseResult   `json:"evalCases"`          // EvalCases contains aggregated results for each evaluation case.
+	EvalResult         *evalresult.EvalSetResult `json:"evalSetResult"`      // EvalSetResult contains the aggregated results of the evaluation set.
 }
 
 // EvaluationCaseResult aggregates the outcome of a single eval case across multiple runs.
 type EvaluationCaseResult struct {
-	EvalCaseID      string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
-	OverallStatus   status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
-	EvalCaseResults []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
-	MetricResults   []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
-	RunDetails      []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
+	EvalCaseID         string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
+	OverallStatus      status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
+	AgentExecutionTime time.Duration                  `json:"agentExecutionTime"`   // AgentExecutionTime is the total actual agent time across runs for this case.
+	EvalCaseResults    []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
+	MetricResults      []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
+	RunDetails         []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
 }
 
 // EvaluationCaseRunDetails contains caller-facing details for a single run of an eval case.
@@ -174,12 +176,13 @@ type EvaluationCaseRunDetails struct {
 
 // EvaluationInferenceDetails contains caller-facing inference details for a single eval case run.
 type EvaluationInferenceDetails struct {
-	SessionID       string                `json:"sessionId,omitempty"`       // SessionID identifies the inference session used for this run.
-	UserID          string                `json:"userId,omitempty"`          // UserID identifies the user used for this run.
-	Status          status.EvalStatus     `json:"status,omitempty"`          // Status records the inference status for this run.
-	ErrorMessage    string                `json:"errorMessage,omitempty"`    // ErrorMessage records the inference failure message when present.
-	Inferences      []*evalset.Invocation `json:"inferences,omitempty"`      // Inferences stores the invocation outputs captured during this run.
-	ExecutionTraces []*trace.Trace        `json:"executionTraces,omitempty"` // ExecutionTraces stores the execution traces captured during this run.
+	SessionID          string                `json:"sessionId,omitempty"`          // SessionID identifies the inference session used for this run.
+	UserID             string                `json:"userId,omitempty"`             // UserID identifies the user used for this run.
+	Status             status.EvalStatus     `json:"status,omitempty"`             // Status records the inference status for this run.
+	ErrorMessage       string                `json:"errorMessage,omitempty"`       // ErrorMessage records the inference failure message when present.
+	AgentExecutionTime time.Duration         `json:"agentExecutionTime,omitempty"` // AgentExecutionTime records the actual agent time for this run.
+	Inferences         []*evalset.Invocation `json:"inferences,omitempty"`         // Inferences stores the invocation outputs captured during this run.
+	ExecutionTraces    []*trace.Trace        `json:"executionTraces,omitempty"`    // ExecutionTraces stores the execution traces captured during this run.
 }
 
 type runDetailsCollector struct {
@@ -209,12 +212,13 @@ func (a *agentEvaluator) Evaluate(ctx context.Context, evalSetID string, opt ...
 		return nil, fmt.Errorf("summarize overall status: %w", err)
 	}
 	return &EvaluationResult{
-		AppName:       a.appName,
-		EvalSetID:     evalSetID,
-		OverallStatus: status,
-		ExecutionTime: time.Since(start),
-		EvalCases:     evalCases,
-		EvalResult:    evalSetResult,
+		AppName:            a.appName,
+		EvalSetID:          evalSetID,
+		OverallStatus:      status,
+		ExecutionTime:      time.Since(start),
+		AgentExecutionTime: callOpts.agentExecutionTimeValue(),
+		EvalCases:          evalCases,
+		EvalResult:         evalSetResult,
 	}, nil
 }
 
@@ -316,6 +320,11 @@ func (a *agentEvaluator) collectCaseResults(ctx context.Context, evalSetID strin
 		if opts.runDetailsEnabled {
 			evalCaseResult.RunDetails = collectRunDetails(runs, opts.runDetailsCollector.caseRunDetails(caseID))
 		}
+		for _, run := range runs {
+			if run != nil {
+				evalCaseResult.AgentExecutionTime += run.AgentExecutionTime
+			}
+		}
 		evalCaseResults = append(evalCaseResults, evalCaseResult)
 	}
 	sort.SliceStable(evalCaseResults, func(i, j int) bool {
@@ -383,8 +392,9 @@ func (a *agentEvaluator) runEvaluation(ctx context.Context, evalSetID string, op
 		allCaseResults = append(allCaseResults, caseResults...)
 	}
 	evalSetResult := &evalresult.EvalSetResult{
-		EvalSetID:       evalSetID,
-		EvalCaseResults: allCaseResults,
+		EvalSetID:          evalSetID,
+		AgentExecutionTime: opts.agentExecutionTimeValue(),
+		EvalCaseResults:    allCaseResults,
 	}
 	if err := multirun.SummarizeMultiRun(evalSetResult, opts.numRuns); err != nil {
 		return nil, fmt.Errorf("summarize eval set result: %w", err)
@@ -479,6 +489,8 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if err != nil {
 		return nil, fmt.Errorf("run %d inference: %w", runID, err)
 	}
+	inferenceAgentExecutionTime := agentExecutionTimeForInferenceResults(runInferenceResults)
+	opts.addAgentExecutionDuration(inferenceAgentExecutionTime)
 	if opts.runDetailsCollector != nil {
 		opts.runDetailsCollector.add(runID, runInferenceResults)
 	}
@@ -523,12 +535,33 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if runResult == nil {
 		return nil, errors.New("eval set run result is nil")
 	}
+	if inferenceAgentExecutionTime == 0 {
+		runAgentExecutionTime := runResult.AgentExecutionTime
+		if runAgentExecutionTime == 0 {
+			for _, caseResult := range runResult.EvalCaseResults {
+				if caseResult != nil {
+					runAgentExecutionTime += caseResult.AgentExecutionTime
+				}
+			}
+		}
+		opts.addAgentExecutionDuration(runAgentExecutionTime)
+	}
 	caseResults := make([]*evalresult.EvalCaseResult, 0, len(runResult.EvalCaseResults))
+	agentExecutionTimes := make(map[string]time.Duration)
+	for _, inferenceResult := range runInferenceResults {
+		if inferenceResult == nil || inferenceResult.EvalCaseID == "" {
+			continue
+		}
+		agentExecutionTimes[inferenceResult.EvalCaseID] += agentExecutionTimeForInferenceResult(inferenceResult)
+	}
 	for _, caseResult := range runResult.EvalCaseResults {
 		if caseResult == nil {
 			continue
 		}
 		caseResult.RunID = runID
+		if elapsed, ok := agentExecutionTimes[caseResult.EvalID]; ok {
+			caseResult.AgentExecutionTime = elapsed
+		}
 		caseResults = append(caseResults, caseResult)
 	}
 	return caseResults, nil
@@ -642,13 +675,45 @@ func newEvaluationInferenceDetails(inferenceResult *service.InferenceResult) *Ev
 		return nil
 	}
 	return &EvaluationInferenceDetails{
-		SessionID:       inferenceResult.SessionID,
-		UserID:          inferenceResult.UserID,
-		Status:          inferenceResult.Status,
-		ErrorMessage:    inferenceResult.ErrorMessage,
-		Inferences:      append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
-		ExecutionTraces: append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
+		SessionID:          inferenceResult.SessionID,
+		UserID:             inferenceResult.UserID,
+		Status:             inferenceResult.Status,
+		ErrorMessage:       inferenceResult.ErrorMessage,
+		AgentExecutionTime: agentExecutionTimeForInferenceResult(inferenceResult),
+		Inferences:         append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
+		ExecutionTraces:    append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
 	}
+}
+
+func agentExecutionTimeForInferenceResult(inferenceResult *service.InferenceResult) time.Duration {
+	if inferenceResult == nil {
+		return 0
+	}
+	if inferenceResult.AgentExecutionTime > 0 {
+		return inferenceResult.AgentExecutionTime
+	}
+	// Trace-mode cases replay recorded invocations without executing the agent.
+	if inferenceResult.EvalMode == evalset.EvalModeTrace {
+		return 0
+	}
+	var elapsed time.Duration
+	for _, executionTrace := range inferenceResult.ExecutionTraces {
+		if executionTrace == nil || executionTrace.StartedAt.IsZero() || executionTrace.EndedAt.IsZero() {
+			continue
+		}
+		if duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt); duration > 0 {
+			elapsed += duration
+		}
+	}
+	return elapsed
+}
+
+func agentExecutionTimeForInferenceResults(inferenceResults []*service.InferenceResult) time.Duration {
+	var elapsed time.Duration
+	for _, inferenceResult := range inferenceResults {
+		elapsed += agentExecutionTimeForInferenceResult(inferenceResult)
+	}
+	return elapsed
 }
 
 func newRunDetailsCollector() *runDetailsCollector {

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -559,7 +559,7 @@ func (a *agentEvaluator) runEvaluationOnce(
 			continue
 		}
 		caseResult.RunID = runID
-		if elapsed, ok := inferenceDurations[caseResult.EvalID]; ok {
+		if elapsed, ok := inferenceDurations[caseResult.EvalID]; ok && elapsed > 0 {
 			caseResult.InferenceDuration = elapsed
 		}
 		caseResults = append(caseResults, caseResult)
@@ -689,12 +689,12 @@ func inferenceDurationForInferenceResult(inferenceResult *service.InferenceResul
 	if inferenceResult == nil {
 		return 0
 	}
-	if inferenceResult.InferenceDuration > 0 {
-		return inferenceResult.InferenceDuration
-	}
 	// Trace-mode cases replay recorded invocations without executing the agent.
 	if inferenceResult.EvalMode == evalset.EvalModeTrace {
 		return 0
+	}
+	if inferenceResult.InferenceDuration > 0 {
+		return inferenceResult.InferenceDuration
 	}
 	var elapsed time.Duration
 	for _, executionTrace := range inferenceResult.ExecutionTraces {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1432,17 +1432,20 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	runTwoTrace := &agenttrace.Trace{RootInvocationID: "root-2", SessionID: "session-2", Status: agenttrace.TraceStatusCompleted}
 	svc := &fakeService{
 		inferenceResults: [][]*service.InferenceResult{
-			{{
-				AppName:           appName,
-				EvalSetID:         evalSetID,
-				EvalCaseID:        caseID,
-				Inferences:        []*evalset.Invocation{{InvocationID: "inv-1"}},
-				SessionID:         "session-1",
-				UserID:            "user-1",
-				Status:            status.EvalStatusPassed,
-				InferenceDuration: 3 * time.Second,
-				ExecutionTraces:   []*agenttrace.Trace{runOneTrace},
-			}},
+			{
+				nil,
+				{
+					AppName:           appName,
+					EvalSetID:         evalSetID,
+					EvalCaseID:        caseID,
+					Inferences:        []*evalset.Invocation{{InvocationID: "inv-1"}},
+					SessionID:         "session-1",
+					UserID:            "user-1",
+					Status:            status.EvalStatusPassed,
+					InferenceDuration: 3 * time.Second,
+					ExecutionTraces:   []*agenttrace.Trace{runOneTrace},
+				},
+			},
 			{{
 				AppName:           appName,
 				EvalSetID:         evalSetID,
@@ -1529,6 +1532,29 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 			assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.ExecutionTraces[0].SessionID)
 		}
 	}
+}
+
+func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
+	start := time.Now()
+	assert.Zero(t, inferenceDurationForInferenceResult(nil))
+	assert.Equal(t, 42*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
+		InferenceDuration: 42 * time.Millisecond,
+	}))
+	assert.Zero(t, inferenceDurationForInferenceResult(&service.InferenceResult{
+		EvalMode: evalset.EvalModeTrace,
+		ExecutionTraces: []*agenttrace.Trace{{
+			StartedAt: start,
+			EndedAt:   start.Add(time.Second),
+		}},
+	}))
+	assert.Equal(t, 5*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
+		ExecutionTraces: []*agenttrace.Trace{
+			nil,
+			{},
+			{StartedAt: start, EndedAt: start.Add(5 * time.Millisecond)},
+			{StartedAt: start.Add(10 * time.Millisecond), EndedAt: start.Add(5 * time.Millisecond)},
+		},
+	}))
 }
 
 func TestAgentEvaluatorEvaluateInferenceError(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1433,24 +1433,26 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	svc := &fakeService{
 		inferenceResults: [][]*service.InferenceResult{
 			{{
-				AppName:         appName,
-				EvalSetID:       evalSetID,
-				EvalCaseID:      caseID,
-				Inferences:      []*evalset.Invocation{{InvocationID: "inv-1"}},
-				SessionID:       "session-1",
-				UserID:          "user-1",
-				Status:          status.EvalStatusPassed,
-				ExecutionTraces: []*agenttrace.Trace{runOneTrace},
+				AppName:            appName,
+				EvalSetID:          evalSetID,
+				EvalCaseID:         caseID,
+				Inferences:         []*evalset.Invocation{{InvocationID: "inv-1"}},
+				SessionID:          "session-1",
+				UserID:             "user-1",
+				Status:             status.EvalStatusPassed,
+				AgentExecutionTime: 3 * time.Second,
+				ExecutionTraces:    []*agenttrace.Trace{runOneTrace},
 			}},
 			{{
-				AppName:         appName,
-				EvalSetID:       evalSetID,
-				EvalCaseID:      caseID,
-				Inferences:      []*evalset.Invocation{{InvocationID: "inv-2"}},
-				SessionID:       "session-2",
-				UserID:          "user-2",
-				Status:          status.EvalStatusPassed,
-				ExecutionTraces: []*agenttrace.Trace{runTwoTrace},
+				AppName:            appName,
+				EvalSetID:          evalSetID,
+				EvalCaseID:         caseID,
+				Inferences:         []*evalset.Invocation{{InvocationID: "inv-2"}},
+				SessionID:          "session-2",
+				UserID:             "user-2",
+				Status:             status.EvalStatusPassed,
+				AgentExecutionTime: 5 * time.Second,
+				ExecutionTraces:    []*agenttrace.Trace{runTwoTrace},
 			}},
 		},
 		evaluateResults: []*service.EvalSetRunResult{
@@ -1488,10 +1490,13 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	}()
 	evaluationResult, err := ae.Evaluate(ctx, evalSetID, WithRunDetailsEnabled(true))
 	assert.NoError(t, err)
+	assert.Equal(t, 8*time.Second, evaluationResult.AgentExecutionTime)
+	assert.Equal(t, 8*time.Second, evaluationResult.EvalResult.AgentExecutionTime)
 	if !assert.Len(t, evaluationResult.EvalCases, 1) {
 		return
 	}
 	caseResult := evaluationResult.EvalCases[0]
+	assert.Equal(t, 8*time.Second, caseResult.AgentExecutionTime)
 	if !assert.Len(t, caseResult.RunDetails, 2) {
 		return
 	}
@@ -1501,6 +1506,7 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 		assert.Equal(t, "session-1", caseResult.RunDetails[0].Inference.SessionID)
 		assert.Equal(t, "user-1", caseResult.RunDetails[0].Inference.UserID)
 		assert.Equal(t, status.EvalStatusPassed, caseResult.RunDetails[0].Inference.Status)
+		assert.Equal(t, 3*time.Second, caseResult.RunDetails[0].Inference.AgentExecutionTime)
 		if assert.Len(t, caseResult.RunDetails[0].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-1", caseResult.RunDetails[0].Inference.Inferences[0].InvocationID)
 		}
@@ -1514,6 +1520,7 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	if assert.NotNil(t, caseResult.RunDetails[1].Inference) {
 		assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.SessionID)
 		assert.Equal(t, "user-2", caseResult.RunDetails[1].Inference.UserID)
+		assert.Equal(t, 5*time.Second, caseResult.RunDetails[1].Inference.AgentExecutionTime)
 		if assert.Len(t, caseResult.RunDetails[1].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-2", caseResult.RunDetails[1].Inference.Inferences[0].InvocationID)
 		}

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1494,7 +1494,6 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	evaluationResult, err := ae.Evaluate(ctx, evalSetID, WithRunDetailsEnabled(true))
 	assert.NoError(t, err)
 	assert.Equal(t, 8*time.Second, evaluationResult.InferenceDuration)
-	assert.Equal(t, 8*time.Second, evaluationResult.EvalResult.InferenceDuration)
 	if !assert.Len(t, evaluationResult.EvalCases, 1) {
 		return
 	}
@@ -1590,6 +1589,69 @@ func TestAgentEvaluatorPreservesServiceCaseInferenceDuration(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, serviceCaseDuration, results[0].InferenceDuration)
 	assert.Equal(t, serviceCaseDuration, opts.inferenceDurationValue())
+}
+
+func TestAgentEvaluatorMergesMixedCaseInferenceDurations(t *testing.T) {
+	const (
+		appName   = "app"
+		evalSetID = "set"
+	)
+	svc := &fakeService{
+		inferenceResults: [][]*service.InferenceResult{{
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-a", InferenceDuration: 2 * time.Second},
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-b"},
+		}},
+		evaluateResults: []*service.EvalSetRunResult{{
+			AppName:   appName,
+			EvalSetID: evalSetID,
+			EvalCaseResults: []*evalresult.EvalCaseResult{
+				{EvalSetID: evalSetID, EvalID: "case-a"},
+				{EvalSetID: evalSetID, EvalID: "case-b", InferenceDuration: 3 * time.Second},
+			},
+		}},
+	}
+	opts := newOptions()
+	opts.evalService = svc
+	ae := &agentEvaluator{appName: appName, evalService: svc}
+
+	results, err := ae.runEvaluationOnce(context.Background(), evalSetID, opts, nil, 1)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, 2*time.Second, results[0].InferenceDuration)
+	assert.Equal(t, 3*time.Second, results[1].InferenceDuration)
+	assert.Equal(t, 5*time.Second, opts.inferenceDurationValue())
+}
+
+func TestAgentEvaluatorMergesInferenceDurationForMissingCaseResult(t *testing.T) {
+	const (
+		appName   = "app"
+		evalSetID = "set"
+	)
+	svc := &fakeService{
+		inferenceResults: [][]*service.InferenceResult{{
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-a", InferenceDuration: 2 * time.Second},
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-b", InferenceDuration: 3 * time.Second},
+		}},
+		evaluateResults: []*service.EvalSetRunResult{{
+			AppName:   appName,
+			EvalSetID: evalSetID,
+			EvalCaseResults: []*evalresult.EvalCaseResult{{
+				EvalSetID:         evalSetID,
+				EvalID:            "case-b",
+				InferenceDuration: 3 * time.Second,
+			}},
+		}},
+	}
+	opts := newOptions()
+	opts.evalService = svc
+	ae := &agentEvaluator{appName: appName, evalService: svc}
+
+	results, err := ae.runEvaluationOnce(context.Background(), evalSetID, opts, nil, 1)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "case-b", results[0].EvalID)
+	assert.Equal(t, 3*time.Second, results[0].InferenceDuration)
+	assert.Equal(t, 5*time.Second, opts.inferenceDurationValue())
 }
 
 func TestAgentEvaluatorEvaluateInferenceError(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1541,7 +1541,8 @@ func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
 		InferenceDuration: 42 * time.Millisecond,
 	}))
 	assert.Zero(t, inferenceDurationForInferenceResult(&service.InferenceResult{
-		EvalMode: evalset.EvalModeTrace,
+		EvalMode:          evalset.EvalModeTrace,
+		InferenceDuration: 42 * time.Millisecond,
 		ExecutionTraces: []*agenttrace.Trace{{
 			StartedAt: start,
 			EndedAt:   start.Add(time.Second),
@@ -1555,6 +1556,40 @@ func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
 			{StartedAt: start.Add(10 * time.Millisecond), EndedAt: start.Add(5 * time.Millisecond)},
 		},
 	}))
+}
+
+func TestAgentEvaluatorPreservesServiceCaseInferenceDuration(t *testing.T) {
+	const (
+		appName   = "app"
+		evalSetID = "set"
+		caseID    = "case"
+	)
+	serviceCaseDuration := 7 * time.Second
+	svc := &fakeService{
+		inferenceResults: [][]*service.InferenceResult{{{
+			AppName:    appName,
+			EvalSetID:  evalSetID,
+			EvalCaseID: caseID,
+		}}},
+		evaluateResults: []*service.EvalSetRunResult{{
+			AppName:   appName,
+			EvalSetID: evalSetID,
+			EvalCaseResults: []*evalresult.EvalCaseResult{{
+				EvalSetID:         evalSetID,
+				EvalID:            caseID,
+				InferenceDuration: serviceCaseDuration,
+			}},
+		}},
+	}
+	opts := newOptions()
+	opts.evalService = svc
+	ae := &agentEvaluator{appName: appName, evalService: svc}
+
+	results, err := ae.runEvaluationOnce(context.Background(), evalSetID, opts, nil, 1)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, serviceCaseDuration, results[0].InferenceDuration)
+	assert.Equal(t, serviceCaseDuration, opts.inferenceDurationValue())
 }
 
 func TestAgentEvaluatorEvaluateInferenceError(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1433,26 +1433,26 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	svc := &fakeService{
 		inferenceResults: [][]*service.InferenceResult{
 			{{
-				AppName:            appName,
-				EvalSetID:          evalSetID,
-				EvalCaseID:         caseID,
-				Inferences:         []*evalset.Invocation{{InvocationID: "inv-1"}},
-				SessionID:          "session-1",
-				UserID:             "user-1",
-				Status:             status.EvalStatusPassed,
-				AgentExecutionTime: 3 * time.Second,
-				ExecutionTraces:    []*agenttrace.Trace{runOneTrace},
+				AppName:           appName,
+				EvalSetID:         evalSetID,
+				EvalCaseID:        caseID,
+				Inferences:        []*evalset.Invocation{{InvocationID: "inv-1"}},
+				SessionID:         "session-1",
+				UserID:            "user-1",
+				Status:            status.EvalStatusPassed,
+				InferenceDuration: 3 * time.Second,
+				ExecutionTraces:   []*agenttrace.Trace{runOneTrace},
 			}},
 			{{
-				AppName:            appName,
-				EvalSetID:          evalSetID,
-				EvalCaseID:         caseID,
-				Inferences:         []*evalset.Invocation{{InvocationID: "inv-2"}},
-				SessionID:          "session-2",
-				UserID:             "user-2",
-				Status:             status.EvalStatusPassed,
-				AgentExecutionTime: 5 * time.Second,
-				ExecutionTraces:    []*agenttrace.Trace{runTwoTrace},
+				AppName:           appName,
+				EvalSetID:         evalSetID,
+				EvalCaseID:        caseID,
+				Inferences:        []*evalset.Invocation{{InvocationID: "inv-2"}},
+				SessionID:         "session-2",
+				UserID:            "user-2",
+				Status:            status.EvalStatusPassed,
+				InferenceDuration: 5 * time.Second,
+				ExecutionTraces:   []*agenttrace.Trace{runTwoTrace},
 			}},
 		},
 		evaluateResults: []*service.EvalSetRunResult{
@@ -1490,13 +1490,13 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	}()
 	evaluationResult, err := ae.Evaluate(ctx, evalSetID, WithRunDetailsEnabled(true))
 	assert.NoError(t, err)
-	assert.Equal(t, 8*time.Second, evaluationResult.AgentExecutionTime)
-	assert.Equal(t, 8*time.Second, evaluationResult.EvalResult.AgentExecutionTime)
+	assert.Equal(t, 8*time.Second, evaluationResult.InferenceDuration)
+	assert.Equal(t, 8*time.Second, evaluationResult.EvalResult.InferenceDuration)
 	if !assert.Len(t, evaluationResult.EvalCases, 1) {
 		return
 	}
 	caseResult := evaluationResult.EvalCases[0]
-	assert.Equal(t, 8*time.Second, caseResult.AgentExecutionTime)
+	assert.Equal(t, 8*time.Second, caseResult.InferenceDuration)
 	if !assert.Len(t, caseResult.RunDetails, 2) {
 		return
 	}
@@ -1506,7 +1506,7 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 		assert.Equal(t, "session-1", caseResult.RunDetails[0].Inference.SessionID)
 		assert.Equal(t, "user-1", caseResult.RunDetails[0].Inference.UserID)
 		assert.Equal(t, status.EvalStatusPassed, caseResult.RunDetails[0].Inference.Status)
-		assert.Equal(t, 3*time.Second, caseResult.RunDetails[0].Inference.AgentExecutionTime)
+		assert.Equal(t, 3*time.Second, caseResult.RunDetails[0].Inference.InferenceDuration)
 		if assert.Len(t, caseResult.RunDetails[0].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-1", caseResult.RunDetails[0].Inference.Inferences[0].InvocationID)
 		}
@@ -1520,7 +1520,7 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	if assert.NotNil(t, caseResult.RunDetails[1].Inference) {
 		assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.SessionID)
 		assert.Equal(t, "user-2", caseResult.RunDetails[1].Inference.UserID)
-		assert.Equal(t, 5*time.Second, caseResult.RunDetails[1].Inference.AgentExecutionTime)
+		assert.Equal(t, 5*time.Second, caseResult.RunDetails[1].Inference.InferenceDuration)
 		if assert.Len(t, caseResult.RunDetails[1].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-2", caseResult.RunDetails[1].Inference.Inferences[0].InvocationID)
 		}

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -11,6 +11,8 @@ package evaluation
 
 import (
 	"errors"
+	"sync"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
@@ -53,6 +55,8 @@ type options struct {
 	runDetailsEnabled                 bool
 	runDetailsCollector               *runDetailsCollector
 	runOptions                        []agent.RunOption
+	agentExecutionTime                time.Duration
+	agentExecutionTimeMu              sync.Mutex
 }
 
 // newOptions creates a new options with the default values.
@@ -257,4 +261,22 @@ func (o *options) validate(requireEvalService bool) error {
 		return errors.New("eval service is nil")
 	}
 	return nil
+}
+
+func (o *options) addAgentExecutionDuration(elapsed time.Duration) {
+	if o == nil || elapsed <= 0 {
+		return
+	}
+	o.agentExecutionTimeMu.Lock()
+	o.agentExecutionTime += elapsed
+	o.agentExecutionTimeMu.Unlock()
+}
+
+func (o *options) agentExecutionTimeValue() time.Duration {
+	if o == nil {
+		return 0
+	}
+	o.agentExecutionTimeMu.Lock()
+	defer o.agentExecutionTimeMu.Unlock()
+	return o.agentExecutionTime
 }

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -55,8 +55,8 @@ type options struct {
 	runDetailsEnabled                 bool
 	runDetailsCollector               *runDetailsCollector
 	runOptions                        []agent.RunOption
-	agentExecutionTime                time.Duration
-	agentExecutionTimeMu              sync.Mutex
+	inferenceDuration                 time.Duration
+	inferenceDurationMu               sync.Mutex
 }
 
 // newOptions creates a new options with the default values.
@@ -263,20 +263,20 @@ func (o *options) validate(requireEvalService bool) error {
 	return nil
 }
 
-func (o *options) addAgentExecutionDuration(elapsed time.Duration) {
+func (o *options) addInferenceDuration(elapsed time.Duration) {
 	if o == nil || elapsed <= 0 {
 		return
 	}
-	o.agentExecutionTimeMu.Lock()
-	o.agentExecutionTime += elapsed
-	o.agentExecutionTimeMu.Unlock()
+	o.inferenceDurationMu.Lock()
+	o.inferenceDuration += elapsed
+	o.inferenceDurationMu.Unlock()
 }
 
-func (o *options) agentExecutionTimeValue() time.Duration {
+func (o *options) inferenceDurationValue() time.Duration {
 	if o == nil {
 		return 0
 	}
-	o.agentExecutionTimeMu.Lock()
-	defer o.agentExecutionTimeMu.Unlock()
-	return o.agentExecutionTime
+	o.inferenceDurationMu.Lock()
+	defer o.inferenceDurationMu.Unlock()
+	return o.inferenceDuration
 }

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -80,9 +80,10 @@ func TestNewOptionsDefaults(t *testing.T) {
 func TestOptionsInferenceDuration(t *testing.T) {
 	opts := newOptions()
 	opts.addInferenceDuration(2 * time.Second)
+	opts.addInferenceDuration(3 * time.Second)
 	opts.addInferenceDuration(0)
 	opts.addInferenceDuration(-time.Second)
-	assert.Equal(t, 2*time.Second, opts.inferenceDurationValue())
+	assert.Equal(t, 5*time.Second, opts.inferenceDurationValue())
 
 	var nilOpts *options
 	nilOpts.addInferenceDuration(time.Second)

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -12,6 +12,7 @@ package evaluation
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -74,6 +75,18 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.Nil(t, opts.evalCaseParallelInferenceEnabled)
 	assert.Nil(t, opts.evalCaseParallelEvaluationEnabled)
 	assert.False(t, opts.runDetailsEnabled)
+}
+
+func TestOptionsInferenceDuration(t *testing.T) {
+	opts := newOptions()
+	opts.addInferenceDuration(2 * time.Second)
+	opts.addInferenceDuration(0)
+	opts.addInferenceDuration(-time.Second)
+	assert.Equal(t, 2*time.Second, opts.inferenceDurationValue())
+
+	var nilOpts *options
+	nilOpts.addInferenceDuration(time.Second)
+	assert.Zero(t, nilOpts.inferenceDurationValue())
 }
 
 func TestWithEvalSetManager(t *testing.T) {

--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -34,8 +34,8 @@ import (
 type Result struct {
 	Invocations     []*evalset.Invocation
 	ExecutionTraces []*trace.Trace
-	// AgentExecutionTime is the total time spent executing the target agent.
-	AgentExecutionTime time.Duration
+	// InferenceDuration is the total time spent executing the target agent.
+	InferenceDuration time.Duration
 }
 
 // Inference executes the agent against the provided invocations.
@@ -58,32 +58,32 @@ func Inference(
 	// Accumulate each invocation response.
 	responseInvocations := make([]*evalset.Invocation, 0, len(invocations))
 	executionTraces := make([]*trace.Trace, 0, len(invocations))
-	var agentExecutionTime time.Duration
+	var inferenceDuration time.Duration
 	for _, invocation := range invocations {
 		startTime := time.Now()
 		responseInvocation, executionTrace, err := inferenceInvocation(ctx, runner, sessionID, initialSession, invocation, runOptions, opts)
-		agentExecutionTime += time.Since(startTime)
+		inferenceDuration += time.Since(startTime)
 		if err != nil && responseInvocation == nil && executionTrace == nil {
 			return &Result{
-				Invocations:        responseInvocations,
-				ExecutionTraces:    executionTraces,
-				AgentExecutionTime: agentExecutionTime,
+				Invocations:       responseInvocations,
+				ExecutionTraces:   executionTraces,
+				InferenceDuration: inferenceDuration,
 			}, err
 		}
 		responseInvocations = append(responseInvocations, responseInvocation)
 		executionTraces = append(executionTraces, executionTrace)
 		if err != nil {
 			return &Result{
-				Invocations:        responseInvocations,
-				ExecutionTraces:    executionTraces,
-				AgentExecutionTime: agentExecutionTime,
+				Invocations:       responseInvocations,
+				ExecutionTraces:   executionTraces,
+				InferenceDuration: inferenceDuration,
 			}, err
 		}
 	}
 	return &Result{
-		Invocations:        responseInvocations,
-		ExecutionTraces:    executionTraces,
-		AgentExecutionTime: agentExecutionTime,
+		Invocations:       responseInvocations,
+		ExecutionTraces:   executionTraces,
+		InferenceDuration: inferenceDuration,
 	}, nil
 }
 
@@ -132,7 +132,7 @@ func InferenceWithConversationScenario(
 		Invocations:     make([]*evalset.Invocation, 0),
 		ExecutionTraces: make([]*trace.Trace, 0),
 	}
-	var agentExecutionTime time.Duration
+	var inferenceDuration time.Duration
 	var lastTargetResponse *model.Message
 	for {
 		decision, nextErr := conversation.Next(ctx, &usersimulation.TurnRequest{LastTargetResponse: lastTargetResponse})
@@ -159,9 +159,9 @@ func InferenceWithConversationScenario(
 		responseInvocation, executionTrace, nextErr := inferenceInvocation(ctx, r, sessionID, initialSession, &evalset.Invocation{
 			UserContent: &userMessage,
 		}, runOptions, nil)
-		agentExecutionTime += time.Since(startTime)
+		inferenceDuration += time.Since(startTime)
 		if nextErr != nil {
-			result.AgentExecutionTime = agentExecutionTime
+			result.InferenceDuration = inferenceDuration
 			return nil, nextErr
 		}
 		if responseInvocation.FinalResponse == nil {
@@ -170,7 +170,7 @@ func InferenceWithConversationScenario(
 		result.Invocations = append(result.Invocations, responseInvocation)
 		result.ExecutionTraces = append(result.ExecutionTraces, executionTrace)
 		lastTargetResponse = responseInvocation.FinalResponse
-		result.AgentExecutionTime = agentExecutionTime
+		result.InferenceDuration = inferenceDuration
 	}
 }
 

--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
@@ -33,6 +34,8 @@ import (
 type Result struct {
 	Invocations     []*evalset.Invocation
 	ExecutionTraces []*trace.Trace
+	// AgentExecutionTime is the total time spent executing the target agent.
+	AgentExecutionTime time.Duration
 }
 
 // Inference executes the agent against the provided invocations.
@@ -55,26 +58,32 @@ func Inference(
 	// Accumulate each invocation response.
 	responseInvocations := make([]*evalset.Invocation, 0, len(invocations))
 	executionTraces := make([]*trace.Trace, 0, len(invocations))
+	var agentExecutionTime time.Duration
 	for _, invocation := range invocations {
+		startTime := time.Now()
 		responseInvocation, executionTrace, err := inferenceInvocation(ctx, runner, sessionID, initialSession, invocation, runOptions, opts)
+		agentExecutionTime += time.Since(startTime)
 		if err != nil && responseInvocation == nil && executionTrace == nil {
 			return &Result{
-				Invocations:     responseInvocations,
-				ExecutionTraces: executionTraces,
+				Invocations:        responseInvocations,
+				ExecutionTraces:    executionTraces,
+				AgentExecutionTime: agentExecutionTime,
 			}, err
 		}
 		responseInvocations = append(responseInvocations, responseInvocation)
 		executionTraces = append(executionTraces, executionTrace)
 		if err != nil {
 			return &Result{
-				Invocations:     responseInvocations,
-				ExecutionTraces: executionTraces,
+				Invocations:        responseInvocations,
+				ExecutionTraces:    executionTraces,
+				AgentExecutionTime: agentExecutionTime,
 			}, err
 		}
 	}
 	return &Result{
-		Invocations:     responseInvocations,
-		ExecutionTraces: executionTraces,
+		Invocations:        responseInvocations,
+		ExecutionTraces:    executionTraces,
+		AgentExecutionTime: agentExecutionTime,
 	}, nil
 }
 
@@ -123,6 +132,7 @@ func InferenceWithConversationScenario(
 		Invocations:     make([]*evalset.Invocation, 0),
 		ExecutionTraces: make([]*trace.Trace, 0),
 	}
+	var agentExecutionTime time.Duration
 	var lastTargetResponse *model.Message
 	for {
 		decision, nextErr := conversation.Next(ctx, &usersimulation.TurnRequest{LastTargetResponse: lastTargetResponse})
@@ -145,10 +155,13 @@ func InferenceWithConversationScenario(
 		if userMessage.Role != model.RoleUser {
 			return nil, fmt.Errorf("simulate next turn: invalid message role %q", userMessage.Role)
 		}
+		startTime := time.Now()
 		responseInvocation, executionTrace, nextErr := inferenceInvocation(ctx, r, sessionID, initialSession, &evalset.Invocation{
 			UserContent: &userMessage,
 		}, runOptions, nil)
+		agentExecutionTime += time.Since(startTime)
 		if nextErr != nil {
+			result.AgentExecutionTime = agentExecutionTime
 			return nil, nextErr
 		}
 		if responseInvocation.FinalResponse == nil {
@@ -157,6 +170,7 @@ func InferenceWithConversationScenario(
 		result.Invocations = append(result.Invocations, responseInvocation)
 		result.ExecutionTraces = append(result.ExecutionTraces, executionTrace)
 		lastTargetResponse = responseInvocation.FinalResponse
+		result.AgentExecutionTime = agentExecutionTime
 	}
 }
 

--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -122,7 +122,11 @@ func InferenceWithConversationScenario(
 	if conversation == nil {
 		return nil, errors.New("user simulator conversation is nil")
 	}
+	var inferenceDuration time.Duration
 	defer func() {
+		if result != nil {
+			result.InferenceDuration = inferenceDuration
+		}
 		closeErr := conversation.Close()
 		if closeErr != nil {
 			err = errors.Join(err, fmt.Errorf("close user simulator conversation: %w", closeErr))
@@ -132,28 +136,27 @@ func InferenceWithConversationScenario(
 		Invocations:     make([]*evalset.Invocation, 0),
 		ExecutionTraces: make([]*trace.Trace, 0),
 	}
-	var inferenceDuration time.Duration
 	var lastTargetResponse *model.Message
 	for {
 		decision, nextErr := conversation.Next(ctx, &usersimulation.TurnRequest{LastTargetResponse: lastTargetResponse})
 		if nextErr != nil {
-			return nil, fmt.Errorf("simulate next turn: %w", nextErr)
+			return result, fmt.Errorf("simulate next turn: %w", nextErr)
 		}
 		if decision == nil {
-			return nil, errors.New("simulate next turn: decision is nil")
+			return result, errors.New("simulate next turn: decision is nil")
 		}
 		if decision.Stop {
 			return result, nil
 		}
 		if decision.Message == nil {
-			return nil, errors.New("simulate next turn: message is nil")
+			return result, errors.New("simulate next turn: message is nil")
 		}
 		userMessage := *decision.Message
 		if userMessage.Role == "" {
 			userMessage.Role = model.RoleUser
 		}
 		if userMessage.Role != model.RoleUser {
-			return nil, fmt.Errorf("simulate next turn: invalid message role %q", userMessage.Role)
+			return result, fmt.Errorf("simulate next turn: invalid message role %q", userMessage.Role)
 		}
 		startTime := time.Now()
 		responseInvocation, executionTrace, nextErr := inferenceInvocation(ctx, r, sessionID, initialSession, &evalset.Invocation{
@@ -161,11 +164,10 @@ func InferenceWithConversationScenario(
 		}, runOptions, nil)
 		inferenceDuration += time.Since(startTime)
 		if nextErr != nil {
-			result.InferenceDuration = inferenceDuration
-			return nil, nextErr
+			return result, nextErr
 		}
 		if responseInvocation.FinalResponse == nil {
-			return nil, errors.New("target final response is nil")
+			return result, errors.New("target final response is nil")
 		}
 		result.Invocations = append(result.Invocations, responseInvocation)
 		result.ExecutionTraces = append(result.ExecutionTraces, executionTrace)

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -1207,6 +1207,27 @@ func TestInferenceWithConversationScenarioSuccess(t *testing.T) {
 	}
 }
 
+func TestInferenceWithConversationScenarioInferenceError(t *testing.T) {
+	conv := &stubScenarioConversation{
+		decisions: []*usersimulation.Decision{{
+			Message: &model.Message{Role: model.RoleUser, Content: "Hello"},
+		}},
+	}
+	result, err := InferenceWithConversationScenario(
+		context.Background(),
+		&scenarioRunner{runErr: errors.New("runner failed")},
+		&stubScenarioSimulator{conversation: conv},
+		"case-1",
+		&evalset.ConversationScenario{ConversationPlan: "Finish the task."},
+		&evalset.SessionInput{UserID: "target-user"},
+		"session-1",
+		nil,
+	)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.True(t, conv.closed)
+}
+
 func TestInferenceWithConversationScenarioValidation(t *testing.T) {
 	initialSession := &evalset.SessionInput{UserID: "target-user"}
 	scenario := &evalset.ConversationScenario{ConversationPlan: "Continue until done."}

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -598,7 +598,7 @@ func TestInferenceValidation(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestInferenceTracksAgentExecutionTime(t *testing.T) {
+func TestInferenceTracksInferenceDuration(t *testing.T) {
 	delay := 20 * time.Millisecond
 	r := &delayedRunner{
 		fakeRunner: &fakeRunner{events: []*event.Event{makeFinalEvent("answer")}},
@@ -609,7 +609,7 @@ func TestInferenceTracksAgentExecutionTime(t *testing.T) {
 	}}, &evalset.SessionInput{UserID: "user"}, "session", nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.GreaterOrEqual(t, result.AgentExecutionTime, delay)
+	assert.GreaterOrEqual(t, result.InferenceDuration, delay)
 }
 
 func TestInference_CollectsExecutionTracesInInvocationOrder(t *testing.T) {

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -1208,6 +1208,7 @@ func TestInferenceWithConversationScenarioSuccess(t *testing.T) {
 }
 
 func TestInferenceWithConversationScenarioInferenceError(t *testing.T) {
+	delay := 20 * time.Millisecond
 	conv := &stubScenarioConversation{
 		decisions: []*usersimulation.Decision{{
 			Message: &model.Message{Role: model.RoleUser, Content: "Hello"},
@@ -1215,7 +1216,7 @@ func TestInferenceWithConversationScenarioInferenceError(t *testing.T) {
 	}
 	result, err := InferenceWithConversationScenario(
 		context.Background(),
-		&scenarioRunner{runErr: errors.New("runner failed")},
+		&delayedRunner{fakeRunner: &fakeRunner{runErr: errors.New("runner failed")}, delay: delay},
 		&stubScenarioSimulator{conversation: conv},
 		"case-1",
 		&evalset.ConversationScenario{ConversationPlan: "Finish the task."},
@@ -1224,7 +1225,8 @@ func TestInferenceWithConversationScenarioInferenceError(t *testing.T) {
 		nil,
 	)
 	assert.Error(t, err)
-	assert.Nil(t, result)
+	require.NotNil(t, result)
+	assert.GreaterOrEqual(t, result.InferenceDuration, delay)
 	assert.True(t, conv.closed)
 }
 

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +38,16 @@ type fakeRunner struct {
 	lastInjectedContextMessages []model.Message
 	lastInstruction             string
 	lastRuntimeState            map[string]any
+}
+
+type delayedRunner struct {
+	*fakeRunner
+	delay time.Duration
+}
+
+func (r *delayedRunner) Run(ctx context.Context, userID string, sessionID string, message model.Message, runOpts ...agent.RunOption) (<-chan *event.Event, error) {
+	time.Sleep(r.delay)
+	return r.fakeRunner.Run(ctx, userID, sessionID, message, runOpts...)
 }
 
 func (f *fakeRunner) Run(ctx context.Context, userID string, sessionID string, message model.Message, runOpts ...agent.RunOption) (<-chan *event.Event, error) {
@@ -585,6 +596,20 @@ func TestInferenceValidation(t *testing.T) {
 	}
 	_, err = Inference(context.Background(), &fakeRunner{runErr: errors.New("boom")}, input, &evalset.SessionInput{UserID: "user"}, "session", nil)
 	assert.Error(t, err)
+}
+
+func TestInferenceTracksAgentExecutionTime(t *testing.T) {
+	delay := 20 * time.Millisecond
+	r := &delayedRunner{
+		fakeRunner: &fakeRunner{events: []*event.Event{makeFinalEvent("answer")}},
+		delay:      delay,
+	}
+	result, err := Inference(context.Background(), r, []*evalset.Invocation{{
+		UserContent: &model.Message{Role: model.RoleUser, Content: "question"},
+	}}, &evalset.SessionInput{UserID: "user"}, "session", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.GreaterOrEqual(t, result.AgentExecutionTime, delay)
 }
 
 func TestInference_CollectsExecutionTracesInInvocationOrder(t *testing.T) {

--- a/evaluation/service/local/inference.go
+++ b/evaluation/service/local/inference.go
@@ -519,7 +519,7 @@ func (s *local) inferScenarioConversation(
 			runOptions,
 		)
 		if err != nil {
-			return nil, nil, err
+			return inferenceResult, nil, err
 		}
 		if !evalCase.ExpectedRunnerEnabled {
 			return inferenceResult, nil, nil

--- a/evaluation/service/local/inference.go
+++ b/evaluation/service/local/inference.go
@@ -276,6 +276,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 			attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 			result.Inferences = inferenceResult.Invocations
 			result.ExecutionTraces = inferenceResult.ExecutionTraces
+			result.AgentExecutionTime = inferenceResult.AgentExecutionTime
 		}
 		attachContextMessages(expectedInferences, evalCase.ContextMessages)
 		result.ExpectedInferences = expectedInferences
@@ -317,6 +318,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 	)
 	if inferenceResult != nil {
 		result.ExecutionTraces = inferenceResult.ExecutionTraces
+		result.AgentExecutionTime = inferenceResult.AgentExecutionTime
 		attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 		result.Inferences = inferenceResult.Invocations
 	}

--- a/evaluation/service/local/inference.go
+++ b/evaluation/service/local/inference.go
@@ -276,7 +276,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 			attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 			result.Inferences = inferenceResult.Invocations
 			result.ExecutionTraces = inferenceResult.ExecutionTraces
-			result.AgentExecutionTime = inferenceResult.AgentExecutionTime
+			result.InferenceDuration = inferenceResult.InferenceDuration
 		}
 		attachContextMessages(expectedInferences, evalCase.ContextMessages)
 		result.ExpectedInferences = expectedInferences
@@ -318,7 +318,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 	)
 	if inferenceResult != nil {
 		result.ExecutionTraces = inferenceResult.ExecutionTraces
-		result.AgentExecutionTime = inferenceResult.AgentExecutionTime
+		result.InferenceDuration = inferenceResult.InferenceDuration
 		attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 		result.Inferences = inferenceResult.Invocations
 	}

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -255,28 +255,28 @@ func (s *local) Evaluate(ctx context.Context, req *service.EvaluateRequest, opt 
 		return nil, fmt.Errorf("evaluate case results (app=%s, evalSetID=%s): %w", req.AppName, req.EvalSetID, err)
 	}
 	runResult = &service.EvalSetRunResult{
-		AppName:            req.AppName,
-		EvalSetID:          req.EvalSetID,
-		AgentExecutionTime: agentExecutionTimeForInferenceResults(req.InferenceResults),
-		EvalCaseResults:    evalCaseResults,
+		AppName:           req.AppName,
+		EvalSetID:         req.EvalSetID,
+		InferenceDuration: inferenceDurationForInferenceResults(req.InferenceResults),
+		EvalCaseResults:   evalCaseResults,
 	}
 	return runResult, nil
 }
 
-func agentExecutionTimeForInferenceResults(results []*service.InferenceResult) time.Duration {
+func inferenceDurationForInferenceResults(results []*service.InferenceResult) time.Duration {
 	var elapsed time.Duration
 	for _, result := range results {
-		elapsed += agentExecutionTimeForInferenceResult(result)
+		elapsed += inferenceDurationForInferenceResult(result)
 	}
 	return elapsed
 }
 
-func agentExecutionTimeForInferenceResult(result *service.InferenceResult) time.Duration {
+func inferenceDurationForInferenceResult(result *service.InferenceResult) time.Duration {
 	if result == nil {
 		return 0
 	}
-	if result.AgentExecutionTime > 0 {
-		return result.AgentExecutionTime
+	if result.InferenceDuration > 0 {
+		return result.InferenceDuration
 	}
 	// Trace-mode cases replay recorded invocations without executing the agent.
 	if result.EvalMode == evalset.EvalModeTrace {
@@ -406,13 +406,13 @@ func (s *local) evaluateCase(ctx context.Context, req *service.EvaluateRequest, 
 
 func (s *local) failedEvalCaseResult(evalSetID string, inferenceResult *service.InferenceResult, errorMessage string) *evalresult.EvalCaseResult {
 	return &evalresult.EvalCaseResult{
-		EvalSetID:          evalSetID,
-		EvalID:             inferenceResult.EvalCaseID,
-		FinalEvalStatus:    evalstatus.EvalStatusFailed,
-		ErrorMessage:       errorMessage,
-		SessionID:          inferenceResult.SessionID,
-		UserID:             inferenceResult.UserID,
-		AgentExecutionTime: agentExecutionTimeForInferenceResult(inferenceResult),
+		EvalSetID:         evalSetID,
+		EvalID:            inferenceResult.EvalCaseID,
+		FinalEvalStatus:   evalstatus.EvalStatusFailed,
+		ErrorMessage:      errorMessage,
+		SessionID:         inferenceResult.SessionID,
+		UserID:            inferenceResult.UserID,
+		InferenceDuration: inferenceDurationForInferenceResult(inferenceResult),
 	}
 }
 
@@ -573,7 +573,7 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 		EvalMetricResultPerInvocation: perInvocation,
 		SessionID:                     inferenceResult.SessionID,
 		UserID:                        inputs.userID,
-		AgentExecutionTime:            agentExecutionTimeForInferenceResult(inferenceResult),
+		InferenceDuration:             inferenceDurationForInferenceResult(inferenceResult),
 	}, nil
 }
 

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -255,11 +255,43 @@ func (s *local) Evaluate(ctx context.Context, req *service.EvaluateRequest, opt 
 		return nil, fmt.Errorf("evaluate case results (app=%s, evalSetID=%s): %w", req.AppName, req.EvalSetID, err)
 	}
 	runResult = &service.EvalSetRunResult{
-		AppName:         req.AppName,
-		EvalSetID:       req.EvalSetID,
-		EvalCaseResults: evalCaseResults,
+		AppName:            req.AppName,
+		EvalSetID:          req.EvalSetID,
+		AgentExecutionTime: agentExecutionTimeForInferenceResults(req.InferenceResults),
+		EvalCaseResults:    evalCaseResults,
 	}
 	return runResult, nil
+}
+
+func agentExecutionTimeForInferenceResults(results []*service.InferenceResult) time.Duration {
+	var elapsed time.Duration
+	for _, result := range results {
+		elapsed += agentExecutionTimeForInferenceResult(result)
+	}
+	return elapsed
+}
+
+func agentExecutionTimeForInferenceResult(result *service.InferenceResult) time.Duration {
+	if result == nil {
+		return 0
+	}
+	if result.AgentExecutionTime > 0 {
+		return result.AgentExecutionTime
+	}
+	// Trace-mode cases replay recorded invocations without executing the agent.
+	if result.EvalMode == evalset.EvalModeTrace {
+		return 0
+	}
+	var elapsed time.Duration
+	for _, executionTrace := range result.ExecutionTraces {
+		if executionTrace == nil || executionTrace.StartedAt.IsZero() || executionTrace.EndedAt.IsZero() {
+			continue
+		}
+		if duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt); duration > 0 {
+			elapsed += duration
+		}
+	}
+	return elapsed
 }
 
 func (s *local) resolveMetricExtensions(
@@ -374,12 +406,13 @@ func (s *local) evaluateCase(ctx context.Context, req *service.EvaluateRequest, 
 
 func (s *local) failedEvalCaseResult(evalSetID string, inferenceResult *service.InferenceResult, errorMessage string) *evalresult.EvalCaseResult {
 	return &evalresult.EvalCaseResult{
-		EvalSetID:       evalSetID,
-		EvalID:          inferenceResult.EvalCaseID,
-		FinalEvalStatus: evalstatus.EvalStatusFailed,
-		ErrorMessage:    errorMessage,
-		SessionID:       inferenceResult.SessionID,
-		UserID:          inferenceResult.UserID,
+		EvalSetID:          evalSetID,
+		EvalID:             inferenceResult.EvalCaseID,
+		FinalEvalStatus:    evalstatus.EvalStatusFailed,
+		ErrorMessage:       errorMessage,
+		SessionID:          inferenceResult.SessionID,
+		UserID:             inferenceResult.UserID,
+		AgentExecutionTime: agentExecutionTimeForInferenceResult(inferenceResult),
 	}
 }
 
@@ -540,6 +573,7 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 		EvalMetricResultPerInvocation: perInvocation,
 		SessionID:                     inferenceResult.SessionID,
 		UserID:                        inputs.userID,
+		AgentExecutionTime:            agentExecutionTimeForInferenceResult(inferenceResult),
 	}, nil
 }
 

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -275,12 +275,12 @@ func inferenceDurationForInferenceResult(result *service.InferenceResult) time.D
 	if result == nil {
 		return 0
 	}
-	if result.InferenceDuration > 0 {
-		return result.InferenceDuration
-	}
 	// Trace-mode cases replay recorded invocations without executing the agent.
 	if result.EvalMode == evalset.EvalModeTrace {
 		return 0
+	}
+	if result.InferenceDuration > 0 {
+		return result.InferenceDuration
 	}
 	var elapsed time.Duration
 	for _, executionTrace := range result.ExecutionTraces {

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -1699,7 +1699,7 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-xyz")
 	actual := makeActualInvocation("generated", "calc add 1 2", "calc result: 3")
 	inference := makeInferenceResult(appName, evalSetID, caseID, "session-xyz", []*evalset.Invocation{actual})
-	inference.AgentExecutionTime = 42 * time.Millisecond
+	inference.InferenceDuration = 42 * time.Millisecond
 	req := &service.EvaluateRequest{
 		AppName:          appName,
 		EvalSetID:        evalSetID,
@@ -1715,10 +1715,10 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, appName, result.AppName)
 	assert.Equal(t, evalSetID, result.EvalSetID)
 	assert.Len(t, result.EvalCaseResults, 1)
-	assert.Equal(t, 42*time.Millisecond, result.AgentExecutionTime)
+	assert.Equal(t, 42*time.Millisecond, result.InferenceDuration)
 
 	caseResult := result.EvalCaseResults[0]
-	assert.Equal(t, 42*time.Millisecond, caseResult.AgentExecutionTime)
+	assert.Equal(t, 42*time.Millisecond, caseResult.InferenceDuration)
 	assert.Equal(t, caseID, caseResult.EvalID)
 	assert.Equal(t, status.EvalStatusPassed, caseResult.FinalEvalStatus)
 	assert.Len(t, caseResult.OverallEvalMetricResults, 1)

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -1735,6 +1735,29 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, "demo-user", caseResult.UserID)
 }
 
+func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
+	start := time.Now()
+	assert.Zero(t, inferenceDurationForInferenceResult(nil))
+	assert.Equal(t, 42*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
+		InferenceDuration: 42 * time.Millisecond,
+	}))
+	assert.Zero(t, inferenceDurationForInferenceResult(&service.InferenceResult{
+		EvalMode: evalset.EvalModeTrace,
+		ExecutionTraces: []*agenttrace.Trace{{
+			StartedAt: start,
+			EndedAt:   start.Add(time.Second),
+		}},
+	}))
+	assert.Equal(t, 5*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
+		ExecutionTraces: []*agenttrace.Trace{
+			nil,
+			{},
+			{StartedAt: start, EndedAt: start.Add(5 * time.Millisecond)},
+			{StartedAt: start.Add(10 * time.Millisecond), EndedAt: start.Add(5 * time.Millisecond)},
+		},
+	}))
+}
+
 func TestLocalEvaluateParallelEvaluationPreservesOrder(t *testing.T) {
 	ctx := context.Background()
 	appName := "app"

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -1699,6 +1699,7 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-xyz")
 	actual := makeActualInvocation("generated", "calc add 1 2", "calc result: 3")
 	inference := makeInferenceResult(appName, evalSetID, caseID, "session-xyz", []*evalset.Invocation{actual})
+	inference.AgentExecutionTime = 42 * time.Millisecond
 	req := &service.EvaluateRequest{
 		AppName:          appName,
 		EvalSetID:        evalSetID,
@@ -1714,8 +1715,10 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, appName, result.AppName)
 	assert.Equal(t, evalSetID, result.EvalSetID)
 	assert.Len(t, result.EvalCaseResults, 1)
+	assert.Equal(t, 42*time.Millisecond, result.AgentExecutionTime)
 
 	caseResult := result.EvalCaseResults[0]
+	assert.Equal(t, 42*time.Millisecond, caseResult.AgentExecutionTime)
 	assert.Equal(t, caseID, caseResult.EvalID)
 	assert.Equal(t, status.EvalStatusPassed, caseResult.FinalEvalStatus)
 	assert.Len(t, caseResult.OverallEvalMetricResults, 1)

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -1742,7 +1742,8 @@ func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
 		InferenceDuration: 42 * time.Millisecond,
 	}))
 	assert.Zero(t, inferenceDurationForInferenceResult(&service.InferenceResult{
-		EvalMode: evalset.EvalModeTrace,
+		EvalMode:          evalset.EvalModeTrace,
+		InferenceDuration: 42 * time.Millisecond,
 		ExecutionTraces: []*agenttrace.Trace{{
 			StartedAt: start,
 			EndedAt:   start.Add(time.Second),

--- a/evaluation/service/service.go
+++ b/evaluation/service/service.go
@@ -12,6 +12,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
@@ -65,6 +66,9 @@ type InferenceResult struct {
 	Status status.EvalStatus `json:"status,omitempty"`
 	// ErrorMessage contains the error message if inference failed.
 	ErrorMessage string `json:"errorMessage,omitempty"`
+	// AgentExecutionTime is the total time spent executing the actual agent for this eval case.
+	// It excludes evaluation and expected-runner work.
+	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
 	// ExecutionTraces contains the per-run execution traces collected during inference.
 	ExecutionTraces []*trace.Trace `json:"-"`
 }
@@ -93,6 +97,8 @@ type EvalSetRunResult struct {
 	AppName string `json:"appName,omitempty"`
 	// EvalSetID is the ID of the eval set.
 	EvalSetID string `json:"evalSetId,omitempty"`
+	// AgentExecutionTime is the total time spent executing the actual agent for this run.
+	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
 	// EvalCaseResults are the evaluation results produced in this run.
 	EvalCaseResults []*evalresult.EvalCaseResult `json:"evalCaseResults,omitempty"`
 }

--- a/evaluation/service/service.go
+++ b/evaluation/service/service.go
@@ -66,9 +66,9 @@ type InferenceResult struct {
 	Status status.EvalStatus `json:"status,omitempty"`
 	// ErrorMessage contains the error message if inference failed.
 	ErrorMessage string `json:"errorMessage,omitempty"`
-	// AgentExecutionTime is the total time spent executing the actual agent for this eval case.
+	// InferenceDuration is the total time spent executing the actual agent for this eval case.
 	// It excludes evaluation and expected-runner work.
-	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
+	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
 	// ExecutionTraces contains the per-run execution traces collected during inference.
 	ExecutionTraces []*trace.Trace `json:"-"`
 }
@@ -97,8 +97,8 @@ type EvalSetRunResult struct {
 	AppName string `json:"appName,omitempty"`
 	// EvalSetID is the ID of the eval set.
 	EvalSetID string `json:"evalSetId,omitempty"`
-	// AgentExecutionTime is the total time spent executing the actual agent for this run.
-	AgentExecutionTime time.Duration `json:"agentExecutionTime,omitempty"`
+	// InferenceDuration is the total time spent executing the actual agent for this run.
+	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
 	// EvalCaseResults are the evaluation results produced in this run.
 	EvalCaseResults []*evalresult.EvalCaseResult `json:"evalCaseResults,omitempty"`
 }

--- a/evaluation/service/service.go
+++ b/evaluation/service/service.go
@@ -67,7 +67,6 @@ type InferenceResult struct {
 	// ErrorMessage contains the error message if inference failed.
 	ErrorMessage string `json:"errorMessage,omitempty"`
 	// InferenceDuration is the total time spent executing the actual agent for this eval case.
-	// It excludes evaluation and expected-runner work.
 	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
 	// ExecutionTraces contains the per-run execution traces collected during inference.
 	ExecutionTraces []*trace.Trace `json:"-"`

--- a/evaluation/service/service_test.go
+++ b/evaluation/service/service_test.go
@@ -56,6 +56,10 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 
 	data, err := json.Marshal(result)
 	assert.NoError(t, err)
+	var payload map[string]json.RawMessage
+	assert.NoError(t, json.Unmarshal(data, &payload))
+	assert.Contains(t, payload, "inferenceDuration")
+	assert.NotContains(t, payload, "agentExecutionTime")
 
 	var decoded InferenceResult
 	err = json.Unmarshal(data, &decoded)

--- a/evaluation/service/service_test.go
+++ b/evaluation/service/service_test.go
@@ -51,7 +51,7 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 		UserID:             "user-123",
 		Status:             status.EvalStatusPassed,
 		ErrorMessage:       "",
-		AgentExecutionTime: 42 * time.Millisecond,
+		InferenceDuration:  42 * time.Millisecond,
 	}
 
 	data, err := json.Marshal(result)
@@ -67,7 +67,7 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, result.SessionID, decoded.SessionID)
 	assert.Equal(t, result.UserID, decoded.UserID)
 	assert.Equal(t, result.Status, decoded.Status)
-	assert.Equal(t, result.AgentExecutionTime, decoded.AgentExecutionTime)
+	assert.Equal(t, result.InferenceDuration, decoded.InferenceDuration)
 	assert.Len(t, decoded.Inferences, 1)
 	if len(decoded.Inferences) == 1 {
 		assert.Equal(t, "inv-1", decoded.Inferences[0].InvocationID)

--- a/evaluation/service/service_test.go
+++ b/evaluation/service/service_test.go
@@ -12,6 +12,7 @@ package service
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -50,6 +51,7 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 		UserID:             "user-123",
 		Status:             status.EvalStatusPassed,
 		ErrorMessage:       "",
+		AgentExecutionTime: 42 * time.Millisecond,
 	}
 
 	data, err := json.Marshal(result)
@@ -65,6 +67,7 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, result.SessionID, decoded.SessionID)
 	assert.Equal(t, result.UserID, decoded.UserID)
 	assert.Equal(t, result.Status, decoded.Status)
+	assert.Equal(t, result.AgentExecutionTime, decoded.AgentExecutionTime)
 	assert.Len(t, decoded.Inferences, 1)
 	if len(decoded.Inferences) == 1 {
 		assert.Equal(t, "inv-1", decoded.Inferences[0].InvocationID)

--- a/server/evaluation/openapi.yaml
+++ b/server/evaluation/openapi.yaml
@@ -336,6 +336,10 @@ components:
         executionTime:
           type: integer
           description: Nanoseconds encoded by Go duration JSON marshaling.
+        inferenceDuration:
+          type: integer
+          format: int64
+          description: Nanoseconds encoded by Go duration JSON marshaling.
         evalCases:
           type: array
           items:
@@ -349,6 +353,10 @@ components:
           type: string
         overallStatus:
           $ref: "#/components/schemas/EvalStatus"
+        inferenceDuration:
+          type: integer
+          format: int64
+          description: Nanoseconds encoded by Go duration JSON marshaling.
         evalCaseResults:
           type: array
           items:
@@ -617,6 +625,10 @@ components:
           type: string
         userId:
           type: string
+        inferenceDuration:
+          type: integer
+          format: int64
+          description: Nanoseconds encoded by Go duration JSON marshaling.
     EvalMetricResult:
       type: object
       properties:

--- a/server/evaluation/openapi_test.go
+++ b/server/evaluation/openapi_test.go
@@ -23,3 +23,26 @@ func TestOpenAPISpecIsValid(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, doc.Validate(context.Background()))
 }
+
+func TestOpenAPISpecDocumentsInferenceDuration(t *testing.T) {
+	loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: false}
+	doc, err := loader.LoadFromFile(filepath.Join(".", "openapi.yaml"))
+	require.NoError(t, err)
+
+	for _, schemaName := range []string{"EvaluationResult", "EvaluationCaseResult", "EvalCaseResult"} {
+		schemaRef, ok := doc.Components.Schemas[schemaName]
+		require.Truef(t, ok, "schema %s is missing", schemaName)
+		require.NotNil(t, schemaRef.Value)
+		property, ok := schemaRef.Value.Properties["inferenceDuration"]
+		require.Truef(t, ok, "schema %s does not document inferenceDuration", schemaName)
+		require.NotNil(t, property.Value)
+		require.True(t, property.Value.Type.Is("integer"))
+		require.Equal(t, "int64", property.Value.Format)
+	}
+
+	evalSetResult := doc.Components.Schemas["EvalSetResult"]
+	require.NotNil(t, evalSetResult)
+	require.NotNil(t, evalSetResult.Value)
+	_, hasSetDuration := evalSetResult.Value.Properties["inferenceDuration"]
+	require.False(t, hasSetDuration, "EvalSetResult should not expose a persisted set-level inferenceDuration")
+}


### PR DESCRIPTION
## Summary
- Expose InferenceDuration in evaluation results without changing the persisted database schema.
- Measure actual agent inference duration across invocations, cases, and runs.
- Return the set-level aggregate on EvaluationResult and retain case/run durations in persisted EvalSetResult data.
- Merge duration sources per case so mixed inference and service-provided durations are not undercounted.
- Exclude evaluator, expected-runner, and trace replay time from the actual-agent metric.

## Validation
- cd evaluation && go test ./...
- cd evaluation && go test -race ./...
- cd server/evaluation && go test ./...