### PR TITLE
docs: fix A2A interaction guide links

### DIFF
--- a/docs/mkdocs/zh/a2a.md
+++ b/docs/mkdocs/zh/a2a.md
@@ -916,7 +916,7 @@ subAgent, _ := a2aagent.New(
 
 关于 A2A 协议中工具调用、代码执行、思考内容等事件的传递规范，以及 Metadata 字段定义、ADK 兼容模式、分布式追踪等详细说明，请参考独立文档：
 
-**[A2A 协议交互规范](a2a-interaction.md)**
+**[A2A 协议交互规范](https://trpc-group.github.io/trpc-agent-go/zh/a2a-interaction/)**
 
 该文档定义了 trpc-agent-go 在 A2A 协议之上的扩展规范，是 Client 和 Server 实现的标准参考。
 

--- a/docs/mkdocs/zh/a2a_v1.md
+++ b/docs/mkdocs/zh/a2a_v1.md
@@ -572,7 +572,7 @@ W3C trace context 会自动通过 HTTP header 传播。生产环境仍应通过�
 
 旧版包还保留 `WithProcessorBuilder`、`WithTaskManagerBuilder`、`WithStreamingEventType`、`WithStreamingRespHandler` 和 `WithStructuredTaskErrors` 等兼容扩展点。它们用于维持既有 v0 应用行为，不代表 v1 的推荐设计；新代码应优先使用 v1 的统一 MessageProcessor、TaskManager 和 converter 扩展边界。
 
-工具调用、代码执行、reasoning 和 `state_delta` 使用的共享 metadata extension 见 [A2A 协议交互规范](a2a-interaction.md)。其中的 metadata key 与交互规范版本同时适用于旧版和 v1 包；`TextPart`、`DataPart`、小写 method 和流式 envelope 示例描述的是 v0.2.x wire model，v1 则通过统一 Part、Message、Artifact 和 Task update event 承载这些共享 metadata。
+工具调用、代码执行、reasoning 和 `state_delta` 使用的共享 metadata extension 见 [A2A 协议交互规范](https://trpc-group.github.io/trpc-agent-go/zh/a2a-interaction/)。其中的 metadata key 与交互规范版本同时适用于旧版和 v1 包；`TextPart`、`DataPart`、小写 method 和流式 envelope 示例描述的是 v0.2.x wire model，v1 则通过统一 Part、Message、Artifact 和 Task update event 承载这些共享 metadata。
 
 ### v0 Task 管理边界
 


### PR DESCRIPTION
## What changed

Updated the A2A documentation links in the Chinese legacy and v1 guides to use the published interaction guide URL, so the links remain accessible after the source Markdown is synchronized to iWiki.

## Why

The relative links work within the MkDocs source tree but cannot be resolved from the synchronized iWiki pages because the standalone interaction guide is not published as a corresponding iWiki page.

## Testing

- `mkdocs build --strict -f docs/mkdocs.yml`
- Verified that the published A2A interaction guide URL returns HTTP 200.
- Verified that the built legacy and v1 pages contain the published guide URL.

## Notes for reviewers

Documentation-only change; no public API or runtime behavior changes.