### PR TITLE
{evaluation, docs}: expose inference stats

### DIFF
--- a/docs/mkdocs/en/blog/evaluation.md
+++ b/docs/mkdocs/en/blog/evaluation.md
@@ -1832,14 +1832,14 @@ type EvaluationResult struct {
 	EvalSetID     string                  // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus       // OverallStatus is the overall status.
 	ExecutionTime time.Duration           // ExecutionTime is the execution duration.
-	InferenceDuration time.Duration      // InferenceDuration is actual agent inference time.
+	InferenceStats *evalresult.InferenceStats // InferenceStats contains actual agent inference resource usage.
 	EvalCases     []*EvaluationCaseResult // EvalCases is the list of case results.
 }
 
 type EvaluationCaseResult struct {
 	EvalCaseID         string                         // EvalCaseID is the case identifier.
 	OverallStatus      status.EvalStatus              // OverallStatus is the aggregated status of this case.
-	InferenceDuration time.Duration                  // InferenceDuration is actual agent inference time across runs for this case.
+	InferenceStats *evalresult.InferenceStats         // InferenceStats contains actual agent inference resource usage across runs for this case.
 	EvalCaseResults    []*evalresult.EvalCaseResult   // EvalCaseResults is the case result for each run.
 	MetricResults      []*evalresult.EvalMetricResult // MetricResults is the aggregated metric results.
 }

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -24,6 +24,7 @@ type EvaluationResult struct {
 	OverallStatus status.EvalStatus         // OverallStatus is the overall status.
 	ExecutionTime time.Duration             // ExecutionTime is the execution duration.
 	InferenceDuration time.Duration        // InferenceDuration is actual agent inference time.
+	InferenceTokenUsage *model.Usage       // InferenceTokenUsage is actual agent token usage.
 	EvalCases     []*EvaluationCaseResult   // EvalCases are the list of case results.
 	EvalResult    *evalresult.EvalSetResult // EvalResult is the persisted EvalSetResult.
 }
@@ -32,6 +33,7 @@ type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID is the case identifier.
 	OverallStatus   status.EvalStatus              // OverallStatus is the aggregated status for this case.
 	InferenceDuration time.Duration              // InferenceDuration is actual agent inference time across runs for this case.
+	InferenceTokenUsage *model.Usage             // InferenceTokenUsage is actual agent token usage across runs for this case.
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults are the per-run case results.
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults are the aggregated metric results.
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails are optional per-run inference details.
@@ -48,12 +50,15 @@ type EvaluationInferenceDetails struct {
 	Status          status.EvalStatus     // Status records inference status.
 	ErrorMessage    string                // ErrorMessage records inference failure when present.
 	InferenceDuration time.Duration      // InferenceDuration is actual agent inference time for this run.
+	InferenceTokenUsage *model.Usage     // InferenceTokenUsage is actual agent token usage for this run.
 	Inferences      []*evalset.Invocation // Inferences stores invocation outputs.
 	ExecutionTraces []*trace.Trace        // ExecutionTraces stores execution traces.
 }
 ```
 
 `EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. The set-level `InferenceDuration` is returned on `EvaluationResult`; persisted EvalSetResult values retain case/run durations, so no database schema change is required. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
+
+`InferenceTokenUsage` follows the same aggregation levels: `EvaluationInferenceDetails` contains one run's usage, `EvaluationCaseResult` sums usage across runs for one case, and `EvaluationResult` sums usage across cases. It reports token usage from the target Agent only; evaluator, expected-runner, and trace-replay usage are not included. The persisted EvalSetResult keeps usage in its case/run results and does not add a set-level field.
 
 `ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceDuration` sums actual agent inference time across cases and runs. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
 

--- a/docs/mkdocs/en/evaluation/agentevaluator.md
+++ b/docs/mkdocs/en/evaluation/agentevaluator.md
@@ -23,8 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID is the evaluation set identifier.
 	OverallStatus status.EvalStatus         // OverallStatus is the overall status.
 	ExecutionTime time.Duration             // ExecutionTime is the execution duration.
-	InferenceDuration time.Duration        // InferenceDuration is actual agent inference time.
-	InferenceTokenUsage *model.Usage       // InferenceTokenUsage is actual agent token usage.
+	InferenceStats *evalresult.InferenceStats // InferenceStats contains actual agent inference resource usage.
 	EvalCases     []*EvaluationCaseResult   // EvalCases are the list of case results.
 	EvalResult    *evalresult.EvalSetResult // EvalResult is the persisted EvalSetResult.
 }
@@ -32,8 +31,7 @@ type EvaluationResult struct {
 type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID is the case identifier.
 	OverallStatus   status.EvalStatus              // OverallStatus is the aggregated status for this case.
-	InferenceDuration time.Duration              // InferenceDuration is actual agent inference time across runs for this case.
-	InferenceTokenUsage *model.Usage             // InferenceTokenUsage is actual agent token usage across runs for this case.
+	InferenceStats *evalresult.InferenceStats     // InferenceStats contains actual agent inference resource usage across runs for this case.
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults are the per-run case results.
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults are the aggregated metric results.
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails are optional per-run inference details.
@@ -49,18 +47,17 @@ type EvaluationInferenceDetails struct {
 	UserID          string                // UserID identifies the user used for this run.
 	Status          status.EvalStatus     // Status records inference status.
 	ErrorMessage    string                // ErrorMessage records inference failure when present.
-	InferenceDuration time.Duration      // InferenceDuration is actual agent inference time for this run.
-	InferenceTokenUsage *model.Usage     // InferenceTokenUsage is actual agent token usage for this run.
+	InferenceStats   *evalresult.InferenceStats // InferenceStats contains actual agent inference resource usage for this run.
 	Inferences      []*evalset.Invocation // Inferences stores invocation outputs.
 	ExecutionTraces []*trace.Trace        // ExecutionTraces stores execution traces.
 }
 ```
 
-`EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. The set-level `InferenceDuration` is returned on `EvaluationResult`; persisted EvalSetResult values retain case/run durations, so no database schema change is required. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
+`EvalResult` contains the aggregated EvalSetResult that can be persisted by EvalResultManager. The set-level `InferenceStats` is returned on `EvaluationResult`; persisted EvalSetResult values retain case/run statistics, so no database schema change is required. `RunDetails` is filled only when run details are enabled, and each item is associated with a specific run ID.
 
-`InferenceTokenUsage` follows the same aggregation levels: `EvaluationInferenceDetails` contains one run's usage, `EvaluationCaseResult` sums usage across runs for one case, and `EvaluationResult` sums usage across cases. It reports token usage from the target Agent only; evaluator, expected-runner, and trace-replay usage are not included. The persisted EvalSetResult keeps usage in its case/run results and does not add a set-level field.
+`InferenceStats` follows the same aggregation levels: `EvaluationInferenceDetails` contains one run's statistics, `EvaluationCaseResult` sums statistics across runs for one case, and `EvaluationResult` sums statistics across cases. It reports usage from the target Agent only; evaluator, expected-runner, and trace-replay usage are not included. The persisted EvalSetResult keeps statistics in its case/run results and does not add a set-level field.
 
-`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceDuration` sums actual agent inference time across cases and runs. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
+`ExecutionTime` covers the complete evaluation flow, including inference and metric evaluation. `InferenceStats.Duration` sums actual agent inference time across cases and runs. With run-level parallelism, it can exceed the end-to-end wall-clock duration.
 
 By default, `evaluation.New` creates AgentEvaluator and uses in-memory EvalSetManager, MetricManager, EvalResultManager, and the default Registry, and also creates a local Service. If you want to read EvalSet and metric configuration from local files and write results to files, you need to inject Local Managers explicitly.
 

--- a/docs/mkdocs/en/evaluation/evalresult.md
+++ b/docs/mkdocs/en/evaluation/evalresult.md
@@ -37,8 +37,12 @@ type EvalCaseResult struct {
 	EvalMetricResultPerInvocation []*EvalMetricResultPerInvocation // EvalMetricResultPerInvocation is the list of per-turn metric results.
 	SessionID                     string                           // SessionID is the session identifier.
 	UserID                        string                           // UserID is the user identifier.
-	InferenceDuration            time.Duration                    // InferenceDuration is the actual agent inference time for this case run.
-	InferenceTokenUsage          *model.Usage                      // InferenceTokenUsage is the actual agent token usage for this case run.
+	InferenceStats               *InferenceStats                   // InferenceStats contains actual agent inference resource usage for this case run.
+}
+
+type InferenceStats struct {
+	Duration   time.Duration // Duration is the actual agent inference time.
+	TokenUsage *model.Usage  // TokenUsage is the actual agent token usage.
 }
 
 // EvalMetricResult represents the result of one evaluation metric.
@@ -74,11 +78,11 @@ type RubricScore struct {
 }
 ```
 
-Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, `inferenceDuration` is the actual agent inference time for this case run, and `inferenceTokenUsage` is the token usage reported by the actual agent for this case run. Both score and status are computed by the Service case result aggregator.
+Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `inferenceStats` contains the actual agent inference time and token usage for this case run. Both score and status are computed by the Service case result aggregator.
 
-When encoded with Go's standard JSON encoder, `inferenceDuration` is an integer number of nanoseconds; for example, `1.2s` is encoded as `1200000000`. The persisted EvalSetResult does not contain a separate set-level `inferenceDuration`; sum the case-level values when needed.
+When encoded with Go's standard JSON encoder, `inferenceStats.duration` is an integer number of nanoseconds; for example, `1.2s` is encoded as `1200000000`. The persisted EvalSetResult does not contain a separate set-level `inferenceStats`; sum the case-level values when needed.
 
-`inferenceTokenUsage` uses the provider-agnostic `model.Usage` shape, including `prompt_tokens`, `completion_tokens`, `total_tokens`, and provider-reported token details. It is omitted when the model does not report usage. The persisted EvalSetResult keeps this value in each case/run result; it does not add a separate set-level field.
+`inferenceStats.tokenUsage` uses the provider-agnostic `model.Usage` shape, including `prompt_tokens`, `completion_tokens`, `total_tokens`, and provider-reported token details. It is omitted when the model does not report usage. The persisted EvalSetResult keeps this value in each case/run result; it does not add a separate set-level field.
 
 `details.value` in metric details is typed score detail. It does not replace `score` and does not participate in the framework's default threshold checks. The default pass logic is still determined by the evaluator's numeric `score` and `threshold`. If `details.value` is present, `kind` selects the corresponding field to read; an omitted `details.value` means the evaluator did not provide typed detail. Numeric zero and boolean false are valid values. Typed values are intended for per-turn metric details; overall metric details keep aggregated numeric results and do not aggregate typed values by default. Platforms that need to distinguish numeric scores, boolean conclusions, or categorical labels can read `details.value.kind` and the corresponding field:
 
@@ -100,11 +104,13 @@ Below is an example result file snippet.
   "evalCaseResults": [
     {
       "evalId": "calc_add",
-      "inferenceDuration": 120000000,
-      "inferenceTokenUsage": {
-        "prompt_tokens": 42,
-        "completion_tokens": 8,
-        "total_tokens": 50
+      "inferenceStats": {
+        "duration": 120000000,
+        "tokenUsage": {
+          "prompt_tokens": 42,
+          "completion_tokens": 8,
+          "total_tokens": 50
+        }
       },
       "score": 1,
       "finalEvalStatus": "passed",

--- a/docs/mkdocs/en/evaluation/evalresult.md
+++ b/docs/mkdocs/en/evaluation/evalresult.md
@@ -1,6 +1,6 @@
 # EvalResult
 
-EvalResult holds evaluation output. One evaluation run produces an EvalSetResult, organizes results by EvalCase, and records each metric's score, status, and per-turn details. Persisted EvalSetResult values keep inference duration at case/run level; sum the case results when a set-level total is needed.
+EvalResult holds evaluation output. One evaluation run produces an EvalSetResult, organizes results by EvalCase, and records each metric's score, status, per-turn details, and actual-agent token usage. Persisted EvalSetResult values keep inference duration and token usage at case/run level; sum the case results when a set-level total is needed.
 
 ## Structure Definition
 
@@ -38,6 +38,7 @@ type EvalCaseResult struct {
 	SessionID                     string                           // SessionID is the session identifier.
 	UserID                        string                           // UserID is the user identifier.
 	InferenceDuration            time.Duration                    // InferenceDuration is the actual agent inference time for this case run.
+	InferenceTokenUsage          *model.Usage                      // InferenceTokenUsage is the actual agent token usage for this case run.
 }
 
 // EvalMetricResult represents the result of one evaluation metric.
@@ -73,9 +74,11 @@ type RubricScore struct {
 }
 ```
 
-Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, and `inferenceDuration` is the actual agent inference time for this case run. Both score and status are computed by the Service case result aggregator.
+Overall results write each metric output into `overallEvalMetricResults`. Per-turn details are written into `evalMetricResultPerInvocation` and retain both `actualInvocation` and `expectedInvocation` traces for troubleshooting. `EvalCaseResult.score` is the evaluation case-level aggregated score, `finalEvalStatus` is the evaluation case-level final status, `inferenceDuration` is the actual agent inference time for this case run, and `inferenceTokenUsage` is the token usage reported by the actual agent for this case run. Both score and status are computed by the Service case result aggregator.
 
 When encoded with Go's standard JSON encoder, `inferenceDuration` is an integer number of nanoseconds; for example, `1.2s` is encoded as `1200000000`. The persisted EvalSetResult does not contain a separate set-level `inferenceDuration`; sum the case-level values when needed.
+
+`inferenceTokenUsage` uses the provider-agnostic `model.Usage` shape, including `prompt_tokens`, `completion_tokens`, `total_tokens`, and provider-reported token details. It is omitted when the model does not report usage. The persisted EvalSetResult keeps this value in each case/run result; it does not add a separate set-level field.
 
 `details.value` in metric details is typed score detail. It does not replace `score` and does not participate in the framework's default threshold checks. The default pass logic is still determined by the evaluator's numeric `score` and `threshold`. If `details.value` is present, `kind` selects the corresponding field to read; an omitted `details.value` means the evaluator did not provide typed detail. Numeric zero and boolean false are valid values. Typed values are intended for per-turn metric details; overall metric details keep aggregated numeric results and do not aggregate typed values by default. Platforms that need to distinguish numeric scores, boolean conclusions, or categorical labels can read `details.value.kind` and the corresponding field:
 
@@ -98,6 +101,11 @@ Below is an example result file snippet.
     {
       "evalId": "calc_add",
       "inferenceDuration": 120000000,
+      "inferenceTokenUsage": {
+        "prompt_tokens": 42,
+        "completion_tokens": 8,
+        "total_tokens": 50
+      },
       "score": 1,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [

--- a/docs/mkdocs/en/evaluation/service.md
+++ b/docs/mkdocs/en/evaluation/service.md
@@ -41,6 +41,7 @@ type InferenceResult struct {
 	Status       status.EvalStatus     // Status is the inference status.
 	ErrorMessage string                // ErrorMessage is the inference failure reason.
 	InferenceDuration time.Duration   // InferenceDuration is actual agent inference time.
+	InferenceTokenUsage *model.Usage    // InferenceTokenUsage is actual agent token usage.
 }
 
 // EvaluateRequest is the evaluation request.
@@ -61,6 +62,7 @@ type EvalSetRunResult struct {
 	AppName         string                       // AppName is the application name.
 	EvalSetID       string                       // EvalSetID is the evaluation set identifier.
 	InferenceDuration time.Duration             // InferenceDuration is actual agent inference time for this run.
+	InferenceTokenUsage *model.Usage            // InferenceTokenUsage is actual agent token usage for this run.
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults are the evaluation case results.
 }
 
@@ -95,6 +97,8 @@ The inference phase is handled by `Inference`. It reads EvalSet, filters cases b
 When `evalMode` is empty, the inference phase chooses the input source from the EvalCase: if `conversationScenario` is configured, UserSimulation generates each user turn dynamically; otherwise it runs the Runner turn by turn based on `conversation` and writes actual Invocations into `Inferences`.
 
 When `evalMode` is `trace`, it does not run the Runner. If `actualConversation` is configured, it returns that as the actual trace; otherwise it treats `conversation` as the actual trace.
+
+`InferenceResult.InferenceTokenUsage` records the token usage reported by the target Agent during inference. `EvalSetRunResult.InferenceTokenUsage` aggregates this value across cases for the run. These fields cover the target Agent only; evaluator, expected-runner, and trace-replay token usage are not included. If the model does not report usage, the value is nil.
 
 The local implementation supports EvalCase-level concurrent inference. When enabled, multiple cases are run in parallel, while turns within a case remain sequential.
 

--- a/docs/mkdocs/en/evaluation/service.md
+++ b/docs/mkdocs/en/evaluation/service.md
@@ -40,8 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID is the inference user identifier.
 	Status       status.EvalStatus     // Status is the inference status.
 	ErrorMessage string                // ErrorMessage is the inference failure reason.
-	InferenceDuration time.Duration   // InferenceDuration is actual agent inference time.
-	InferenceTokenUsage *model.Usage    // InferenceTokenUsage is actual agent token usage.
+	InferenceStats *evalresult.InferenceStats // InferenceStats contains actual agent inference resource usage.
 }
 
 // EvaluateRequest is the evaluation request.
@@ -61,8 +60,7 @@ type EvaluateConfig struct {
 type EvalSetRunResult struct {
 	AppName         string                       // AppName is the application name.
 	EvalSetID       string                       // EvalSetID is the evaluation set identifier.
-	InferenceDuration time.Duration             // InferenceDuration is actual agent inference time for this run.
-	InferenceTokenUsage *model.Usage            // InferenceTokenUsage is actual agent token usage for this run.
+	InferenceStats *evalresult.InferenceStats   // InferenceStats contains actual agent inference resource usage for this run.
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults are the evaluation case results.
 }
 
@@ -98,7 +96,7 @@ When `evalMode` is empty, the inference phase chooses the input source from the 
 
 When `evalMode` is `trace`, it does not run the Runner. If `actualConversation` is configured, it returns that as the actual trace; otherwise it treats `conversation` as the actual trace.
 
-`InferenceResult.InferenceTokenUsage` records the token usage reported by the target Agent during inference. `EvalSetRunResult.InferenceTokenUsage` aggregates this value across cases for the run. These fields cover the target Agent only; evaluator, expected-runner, and trace-replay token usage are not included. If the model does not report usage, the value is nil.
+`InferenceStats` contains the duration and token usage reported by the target Agent during inference. `InferenceResult.InferenceStats` records one case, and `EvalSetRunResult.InferenceStats` aggregates this value across cases for the run. These fields cover the target Agent only; evaluator, expected-runner, and trace-replay usage are not included. If the model does not report token usage, `TokenUsage` is nil.
 
 The local implementation supports EvalCase-level concurrent inference. When enabled, multiple cases are run in parallel, while turns within a case remain sequential.
 

--- a/docs/mkdocs/zh/blog/evaluation.md
+++ b/docs/mkdocs/zh/blog/evaluation.md
@@ -1833,14 +1833,14 @@ type EvaluationResult struct {
 	EvalSetID     string                  // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus       // OverallStatus 是整体状态
 	ExecutionTime time.Duration           // ExecutionTime 是执行耗时
-	InferenceDuration time.Duration      // InferenceDuration 是实际 agent 推理耗时
+	InferenceStats *evalresult.InferenceStats // InferenceStats 包含实际 agent 推理资源消耗
 	EvalCases     []*EvaluationCaseResult // EvalCases 是用例结果列表
 }
 
 type EvaluationCaseResult struct {
 	EvalCaseID         string                         // EvalCaseID 是用例标识
 	OverallStatus      status.EvalStatus              // OverallStatus 是该用例的聚合状态
-	InferenceDuration time.Duration                  // InferenceDuration 是该用例所有 run 的实际 agent 推理耗时
+	InferenceStats *evalresult.InferenceStats         // InferenceStats 包含该用例所有 run 的实际 agent 推理资源消耗
 	EvalCaseResults    []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
 	MetricResults      []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 }

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -23,8 +23,7 @@ type EvaluationResult struct {
 	EvalSetID     string                    // EvalSetID 是评估集标识
 	OverallStatus status.EvalStatus         // OverallStatus 是整体状态
 	ExecutionTime time.Duration             // ExecutionTime 是执行耗时
-	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时
-	InferenceTokenUsage *model.Usage       // InferenceTokenUsage 是实际 agent token 消耗
+	InferenceStats *evalresult.InferenceStats // InferenceStats 包含实际 agent 推理资源消耗
 	EvalCases     []*EvaluationCaseResult   // EvalCases 是用例结果列表
 	EvalResult    *evalresult.EvalSetResult // EvalResult 是持久化的 EvalSetResult
 }
@@ -32,8 +31,7 @@ type EvaluationResult struct {
 type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID 是用例标识
 	OverallStatus   status.EvalStatus              // OverallStatus 是该用例的聚合状态
-	InferenceDuration time.Duration              // InferenceDuration 是该用例所有 run 的实际 agent 推理耗时
-	InferenceTokenUsage *model.Usage             // InferenceTokenUsage 是该用例所有 run 的实际 agent token 消耗
+	InferenceStats *evalresult.InferenceStats     // InferenceStats 包含该用例所有 run 的实际 agent 推理资源消耗
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails 是可选的逐 run 推理详情
@@ -49,18 +47,17 @@ type EvaluationInferenceDetails struct {
 	UserID          string                // UserID 是本次运行使用的用户标识
 	Status          status.EvalStatus     // Status 是推理状态
 	ErrorMessage    string                // ErrorMessage 是推理失败信息
-	InferenceDuration time.Duration      // InferenceDuration 是本次 run 的实际 agent 推理耗时
-	InferenceTokenUsage *model.Usage     // InferenceTokenUsage 是本次 run 的实际 agent token 消耗
+	InferenceStats   *evalresult.InferenceStats // InferenceStats 包含本次 run 的实际 agent 推理资源消耗
 	Inferences      []*evalset.Invocation // Inferences 是推理输出
 	ExecutionTraces []*trace.Trace        // ExecutionTraces 是执行轨迹
 }
 ```
 
-`EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。集合级 `InferenceDuration` 通过 `EvaluationResult` 返回；持久化的 EvalSetResult 保留 case/run 级耗时，因此不需要修改数据库结构。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
+`EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。集合级 `InferenceStats` 通过 `EvaluationResult` 返回；持久化的 EvalSetResult 保留 case/run 级统计，因此不需要修改数据库结构。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
 
-`InferenceTokenUsage` 与耗时采用相同的聚合层级：`EvaluationInferenceDetails` 记录单次 run 的 token 消耗，`EvaluationCaseResult` 汇总一个用例的多次 run，`EvaluationResult` 汇总所有用例。它只统计目标 Agent 上报的 token，不包含评估器、预期 runner 或 trace 回放的消耗；持久化的 EvalSetResult 只在 case/run 结果中保留该字段，不增加集合级字段。
+`InferenceStats` 与耗时采用相同的聚合层级：`EvaluationInferenceDetails` 记录单次 run 的统计，`EvaluationCaseResult` 汇总一个用例的多次 run，`EvaluationResult` 汇总所有用例。它只统计目标 Agent 的推理消耗，不包含评估器、预期 runner 或 trace 回放的消耗；持久化的 EvalSetResult 只在 case/run 结果中保留该字段，不增加集合级字段。
 
-`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceDuration` 按所有 case/run 累加实际 agent 推理耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
+`ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceStats.Duration` 按所有 case/run 累加实际 agent 推理耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
 
 默认情况下，`evaluation.New` 会创建 AgentEvaluator 并使用 InMemory 的 EvalSetManager、MetricManager、EvalResultManager 与默认 Registry，同时创建本地 Service。若希望从本地文件读取 EvalSet 与指标配置，并将结果写入文件，需要显式注入 Local Manager。
 

--- a/docs/mkdocs/zh/evaluation/agentevaluator.md
+++ b/docs/mkdocs/zh/evaluation/agentevaluator.md
@@ -24,6 +24,7 @@ type EvaluationResult struct {
 	OverallStatus status.EvalStatus         // OverallStatus 是整体状态
 	ExecutionTime time.Duration             // ExecutionTime 是执行耗时
 	InferenceDuration time.Duration        // InferenceDuration 是实际 agent 推理耗时
+	InferenceTokenUsage *model.Usage       // InferenceTokenUsage 是实际 agent token 消耗
 	EvalCases     []*EvaluationCaseResult   // EvalCases 是用例结果列表
 	EvalResult    *evalresult.EvalSetResult // EvalResult 是持久化的 EvalSetResult
 }
@@ -32,6 +33,7 @@ type EvaluationCaseResult struct {
 	EvalCaseID      string                         // EvalCaseID 是用例标识
 	OverallStatus   status.EvalStatus              // OverallStatus 是该用例的聚合状态
 	InferenceDuration time.Duration              // InferenceDuration 是该用例所有 run 的实际 agent 推理耗时
+	InferenceTokenUsage *model.Usage             // InferenceTokenUsage 是该用例所有 run 的实际 agent token 消耗
 	EvalCaseResults []*evalresult.EvalCaseResult   // EvalCaseResults 是每次运行的用例结果
 	MetricResults   []*evalresult.EvalMetricResult // MetricResults 是聚合后的指标结果
 	RunDetails      []*EvaluationCaseRunDetails    // RunDetails 是可选的逐 run 推理详情
@@ -48,12 +50,15 @@ type EvaluationInferenceDetails struct {
 	Status          status.EvalStatus     // Status 是推理状态
 	ErrorMessage    string                // ErrorMessage 是推理失败信息
 	InferenceDuration time.Duration      // InferenceDuration 是本次 run 的实际 agent 推理耗时
+	InferenceTokenUsage *model.Usage     // InferenceTokenUsage 是本次 run 的实际 agent token 消耗
 	Inferences      []*evalset.Invocation // Inferences 是推理输出
 	ExecutionTraces []*trace.Trace        // ExecutionTraces 是执行轨迹
 }
 ```
 
 `EvalResult` 包含可由 EvalResultManager 持久化的聚合 EvalSetResult。集合级 `InferenceDuration` 通过 `EvaluationResult` 返回；持久化的 EvalSetResult 保留 case/run 级耗时，因此不需要修改数据库结构。`RunDetails` 只会在开启 run details 后填充，每条明细都对应一次具体运行。
+
+`InferenceTokenUsage` 与耗时采用相同的聚合层级：`EvaluationInferenceDetails` 记录单次 run 的 token 消耗，`EvaluationCaseResult` 汇总一个用例的多次 run，`EvaluationResult` 汇总所有用例。它只统计目标 Agent 上报的 token，不包含评估器、预期 runner 或 trace 回放的消耗；持久化的 EvalSetResult 只在 case/run 结果中保留该字段，不增加集合级字段。
 
 `ExecutionTime` 是完整评测流程耗时，包含推理和指标评估；`InferenceDuration` 按所有 case/run 累加实际 agent 推理耗时。开启 run 级并发时，它可能大于端到端的墙钟耗时。
 

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -1,6 +1,6 @@
 # 评估结果 EvalResult
 
-EvalResult 用于承载评估输出。一次评估运行会生成一个 EvalSetResult，按 EvalCase 组织结果，并记录每条评估指标的分数、状态与逐轮明细。持久化的 EvalSetResult 保留 case/run 级别的推理耗时；如需集合级总耗时，可对各 case 结果求和。
+EvalResult 用于承载评估输出。一次评估运行会生成一个 EvalSetResult，按 EvalCase 组织结果，并记录每条评估指标的分数、状态、逐轮明细和实际 Agent 的 token 消耗。持久化的 EvalSetResult 保留 case/run 级别的推理耗时与 token 消耗；如需集合级总量，可对各 case 结果求和。
 
 ## 结构定义
 
@@ -38,6 +38,7 @@ type EvalCaseResult struct {
 	SessionID                     string                           // SessionID 是会话标识
 	UserID                        string                           // UserID 是用户标识
 	InferenceDuration            time.Duration                    // InferenceDuration 是本次用例运行的实际 agent 推理耗时
+	InferenceTokenUsage          *model.Usage                      // InferenceTokenUsage 是本次用例运行的实际 agent token 消耗
 }
 
 // EvalMetricResult 表示单条评估指标的结果
@@ -73,9 +74,11 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时；分数和状态由 Service 的用例结果聚合器计算。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时，`inferenceTokenUsage` 表示本次用例运行中实际 agent 上报的 token 消耗；分数和状态由 Service 的用例结果聚合器计算。
 
 通过 Go 标准 JSON 编码时，`inferenceDuration` 表示为纳秒整数，例如 `1.2s` 编码为 `1200000000`。持久化的 EvalSetResult 不包含独立的集合级 `inferenceDuration`；如需集合级总耗时，可对各 case 级耗时求和。
+
+`inferenceTokenUsage` 使用与模型无关的 `model.Usage` 结构，包含 `prompt_tokens`、`completion_tokens`、`total_tokens` 以及模型上报的 token 明细。如果模型没有上报 usage，则省略该字段。持久化的 EvalSetResult 会在每个 case/run 结果中保留该字段，不增加独立的集合级字段。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 
@@ -98,6 +101,11 @@ type RubricScore struct {
     {
       "evalId": "calc_add",
       "inferenceDuration": 120000000,
+      "inferenceTokenUsage": {
+        "prompt_tokens": 42,
+        "completion_tokens": 8,
+        "total_tokens": 50
+      },
       "score": 1,
       "finalEvalStatus": "passed",
       "overallEvalMetricResults": [

--- a/docs/mkdocs/zh/evaluation/evalresult.md
+++ b/docs/mkdocs/zh/evaluation/evalresult.md
@@ -37,8 +37,12 @@ type EvalCaseResult struct {
 	EvalMetricResultPerInvocation []*EvalMetricResultPerInvocation // EvalMetricResultPerInvocation 是逐轮指标结果列表
 	SessionID                     string                           // SessionID 是会话标识
 	UserID                        string                           // UserID 是用户标识
-	InferenceDuration            time.Duration                    // InferenceDuration 是本次用例运行的实际 agent 推理耗时
-	InferenceTokenUsage          *model.Usage                      // InferenceTokenUsage 是本次用例运行的实际 agent token 消耗
+	InferenceStats               *InferenceStats                   // InferenceStats 包含本次用例运行的实际 agent 推理资源消耗
+}
+
+type InferenceStats struct {
+	Duration   time.Duration // Duration 是实际 agent 推理耗时
+	TokenUsage *model.Usage  // TokenUsage 是实际 agent token 消耗
 }
 
 // EvalMetricResult 表示单条评估指标的结果
@@ -74,11 +78,11 @@ type RubricScore struct {
 }
 ```
 
-整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceDuration` 表示本次用例运行的实际 agent 推理耗时，`inferenceTokenUsage` 表示本次用例运行中实际 agent 上报的 token 消耗；分数和状态由 Service 的用例结果聚合器计算。
+整体结果会将每个指标的输出写入 `overallEvalMetricResults`，逐轮明细会写入 `evalMetricResultPerInvocation` 并保留 `actualInvocation` 与 `expectedInvocation` 两侧轨迹，便于问题定位。`EvalCaseResult.score` 表示评估用例级别的聚合分数，`finalEvalStatus` 表示评估用例级别的最终状态，`inferenceStats` 包含本次用例运行的实际 agent 推理耗时和 token 消耗；分数和状态由 Service 的用例结果聚合器计算。
 
-通过 Go 标准 JSON 编码时，`inferenceDuration` 表示为纳秒整数，例如 `1.2s` 编码为 `1200000000`。持久化的 EvalSetResult 不包含独立的集合级 `inferenceDuration`；如需集合级总耗时，可对各 case 级耗时求和。
+通过 Go 标准 JSON 编码时，`inferenceStats.duration` 表示为纳秒整数，例如 `1.2s` 编码为 `1200000000`。持久化的 EvalSetResult 不包含独立的集合级 `inferenceStats`；如需集合级统计，可对各 case 级统计求和。
 
-`inferenceTokenUsage` 使用与模型无关的 `model.Usage` 结构，包含 `prompt_tokens`、`completion_tokens`、`total_tokens` 以及模型上报的 token 明细。如果模型没有上报 usage，则省略该字段。持久化的 EvalSetResult 会在每个 case/run 结果中保留该字段，不增加独立的集合级字段。
+`inferenceStats.tokenUsage` 使用与模型无关的 `model.Usage` 结构，包含 `prompt_tokens`、`completion_tokens`、`total_tokens` 以及模型上报的 token 明细。如果模型没有上报 usage，则省略该字段。持久化的 EvalSetResult 会在每个 case/run 结果中保留该字段，不增加独立的集合级字段。
 
 指标明细中的 `details.value` 表示类型化分数明细。它不替代 `score`，也不参与框架默认的阈值判断；默认通过逻辑仍然由评估器产出的数值 `score` 与 `threshold` 决定。`details.value` 存在时，由 `kind` 决定读取哪个字段；没有 `details.value` 表示评估器没有提供类型化明细。数值 0 和布尔值 false 都是有效值。类型化分数主要用于逐轮指标明细；整体指标明细保留聚合后的数值结果，不默认聚合类型化分数。平台如果需要区分“数值分”“布尔结论”或“分类标签”，可以读取 `details.value.kind` 与对应字段：
 
@@ -100,11 +104,13 @@ type RubricScore struct {
   "evalCaseResults": [
     {
       "evalId": "calc_add",
-      "inferenceDuration": 120000000,
-      "inferenceTokenUsage": {
-        "prompt_tokens": 42,
-        "completion_tokens": 8,
-        "total_tokens": 50
+      "inferenceStats": {
+        "duration": 120000000,
+        "tokenUsage": {
+          "prompt_tokens": 42,
+          "completion_tokens": 8,
+          "total_tokens": 50
+        }
       },
       "score": 1,
       "finalEvalStatus": "passed",

--- a/docs/mkdocs/zh/evaluation/service.md
+++ b/docs/mkdocs/zh/evaluation/service.md
@@ -41,6 +41,7 @@ type InferenceResult struct {
 	Status       status.EvalStatus     // Status 是推理状态
 	ErrorMessage string                // ErrorMessage 是推理失败原因
 	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时
+	InferenceTokenUsage *model.Usage  // InferenceTokenUsage 是实际 agent token 消耗
 }
 
 // EvaluateRequest 是评估请求
@@ -61,6 +62,7 @@ type EvalSetRunResult struct {
 	AppName         string                       // AppName 是应用名
 	EvalSetID       string                       // EvalSetID 是评估集标识
 	InferenceDuration time.Duration             // InferenceDuration 是本次 run 的实际 agent 推理耗时
+	InferenceTokenUsage *model.Usage            // InferenceTokenUsage 是本次 run 的实际 agent token 消耗
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults 是评估用例结果
 }
 
@@ -95,6 +97,8 @@ type EvalCaseResultAggregationResult struct {
 当 `evalMode` 为空值时，推理阶段会根据用例配置选择输入来源：若配置了 `conversationScenario`，则由 UserSimulation 动态生成每轮用户输入；否则按 `conversation` 的轮次依次调用 Runner，并把每轮采集到的实际 Invocation 写入 `Inferences`。
 
 当 `evalMode` 为 `trace` 时，推理阶段不会运行 Runner；若配置了 `actualConversation`，则直接将其作为实际轨迹返回，否则会将 `conversation` 视为实际轨迹返回。
+
+`InferenceResult.InferenceTokenUsage` 记录推理过程中目标 Agent 上报的 token 消耗，`EvalSetRunResult.InferenceTokenUsage` 汇总本次 run 中各用例的该值。这里只统计目标 Agent，不包含评估器、预期 runner 或 trace 回放产生的 token；如果模型没有上报 usage，则该字段为 nil。
 
 Local 实现支持 EvalCase 级并发推理。开启后会并行运行多个用例，单个用例内部仍按轮次顺序执行。
 

--- a/docs/mkdocs/zh/evaluation/service.md
+++ b/docs/mkdocs/zh/evaluation/service.md
@@ -40,8 +40,7 @@ type InferenceResult struct {
 	UserID       string                // UserID 是推理阶段用户标识
 	Status       status.EvalStatus     // Status 是推理状态
 	ErrorMessage string                // ErrorMessage 是推理失败原因
-	InferenceDuration time.Duration   // InferenceDuration 是实际 agent 推理耗时
-	InferenceTokenUsage *model.Usage  // InferenceTokenUsage 是实际 agent token 消耗
+	InferenceStats *evalresult.InferenceStats // InferenceStats 包含实际 agent 推理资源消耗
 }
 
 // EvaluateRequest 是评估请求
@@ -61,8 +60,7 @@ type EvaluateConfig struct {
 type EvalSetRunResult struct {
 	AppName         string                       // AppName 是应用名
 	EvalSetID       string                       // EvalSetID 是评估集标识
-	InferenceDuration time.Duration             // InferenceDuration 是本次 run 的实际 agent 推理耗时
-	InferenceTokenUsage *model.Usage            // InferenceTokenUsage 是本次 run 的实际 agent token 消耗
+	InferenceStats *evalresult.InferenceStats   // InferenceStats 包含本次 run 的实际 agent 推理资源消耗
 	EvalCaseResults []*evalresult.EvalCaseResult // EvalCaseResults 是评估用例结果
 }
 
@@ -98,7 +96,7 @@ type EvalCaseResultAggregationResult struct {
 
 当 `evalMode` 为 `trace` 时，推理阶段不会运行 Runner；若配置了 `actualConversation`，则直接将其作为实际轨迹返回，否则会将 `conversation` 视为实际轨迹返回。
 
-`InferenceResult.InferenceTokenUsage` 记录推理过程中目标 Agent 上报的 token 消耗，`EvalSetRunResult.InferenceTokenUsage` 汇总本次 run 中各用例的该值。这里只统计目标 Agent，不包含评估器、预期 runner 或 trace 回放产生的 token；如果模型没有上报 usage，则该字段为 nil。
+`InferenceStats` 包含推理过程中目标 Agent 上报的耗时和 token 消耗。`InferenceResult.InferenceStats` 记录单个用例，`EvalSetRunResult.InferenceStats` 汇总本次 run 中各用例的该值。这里只统计目标 Agent，不包含评估器、预期 runner 或 trace 回放产生的消耗；如果模型没有上报 token usage，则 `TokenUsage` 为 nil。
 
 Local 实现支持 EvalCase 级并发推理。开启后会并行运行多个用例，单个用例内部仍按轮次顺序执行。
 

--- a/evaluation/evalresult/evalresult.go
+++ b/evaluation/evalresult/evalresult.go
@@ -38,6 +38,15 @@ type EvalSetResult struct {
 	CreationTimestamp *epochtime.EpochTime `json:"creationTimestamp,omitempty"`
 }
 
+// InferenceStats contains resource measurements for the actual agent
+// inference that produced an evaluation result.
+type InferenceStats struct {
+	// Duration is the total time spent executing the actual agent.
+	Duration time.Duration `json:"duration,omitempty"`
+	// TokenUsage is the total token usage reported by the actual agent.
+	TokenUsage *model.Usage `json:"tokenUsage,omitempty"`
+}
+
 // EvalCaseResult represents the result of a single evaluation case.
 type EvalCaseResult struct {
 	// EvalSetID identifies the eval set.
@@ -60,10 +69,8 @@ type EvalCaseResult struct {
 	SessionID string `json:"sessionId,omitempty"`
 	// UserID is the user id used during inferencing stage of the eval.
 	UserID string `json:"userId,omitempty"`
-	// InferenceDuration is the total time spent executing the actual agent for this eval case run.
-	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
-	// InferenceTokenUsage is the total token usage reported by the actual agent for this eval case run.
-	InferenceTokenUsage *model.Usage `json:"inferenceTokenUsage,omitempty"`
+	// InferenceStats contains resource measurements for the actual agent for this eval case run.
+	InferenceStats *InferenceStats `json:"inferenceStats,omitempty"`
 }
 
 // EvalMetricResult represents the result of a single metric evaluation.

--- a/evaluation/evalresult/evalresult.go
+++ b/evaluation/evalresult/evalresult.go
@@ -19,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/score"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // EvalSetResult represents the evaluation result for an entire eval set.
@@ -61,6 +62,8 @@ type EvalCaseResult struct {
 	UserID string `json:"userId,omitempty"`
 	// InferenceDuration is the total time spent executing the actual agent for this eval case run.
 	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
+	// InferenceTokenUsage is the total token usage reported by the actual agent for this eval case run.
+	InferenceTokenUsage *model.Usage `json:"inferenceTokenUsage,omitempty"`
 }
 
 // EvalMetricResult represents the result of a single metric evaluation.

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -36,7 +36,6 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service/local"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/usersimulation"
-	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
@@ -151,25 +150,23 @@ type agentEvaluator struct {
 
 // EvaluationResult contains the aggregated outcome of running an evaluation across multiple runs.
 type EvaluationResult struct {
-	AppName             string                    `json:"appName"`             // AppName identifies the agent being evaluated.
-	EvalSetID           string                    `json:"evalSetId"`           // EvalSetID identifies the evaluation set used in this run.
-	OverallStatus       status.EvalStatus         `json:"overallStatus"`       // OverallStatus summarizes the aggregated evaluation status across cases.
-	ExecutionTime       time.Duration             `json:"executionTime"`       // ExecutionTime records the total latency for the evaluation run.
-	InferenceDuration   time.Duration             `json:"inferenceDuration"`   // InferenceDuration records summed actual agent time across cases and runs.
-	InferenceTokenUsage *model.Usage              `json:"inferenceTokenUsage"` // InferenceTokenUsage records summed actual agent token usage across cases and runs.
-	EvalCases           []*EvaluationCaseResult   `json:"evalCases"`           // EvalCases contains aggregated results for each evaluation case.
-	EvalResult          *evalresult.EvalSetResult `json:"evalSetResult"`       // EvalSetResult contains the aggregated results of the evaluation set.
+	AppName        string                     `json:"appName"`        // AppName identifies the agent being evaluated.
+	EvalSetID      string                     `json:"evalSetId"`      // EvalSetID identifies the evaluation set used in this run.
+	OverallStatus  status.EvalStatus          `json:"overallStatus"`  // OverallStatus summarizes the aggregated evaluation status across cases.
+	ExecutionTime  time.Duration              `json:"executionTime"`  // ExecutionTime records the total latency for the evaluation run.
+	InferenceStats *evalresult.InferenceStats `json:"inferenceStats"` // InferenceStats records summed actual agent resource usage across cases and runs.
+	EvalCases      []*EvaluationCaseResult    `json:"evalCases"`      // EvalCases contains aggregated results for each evaluation case.
+	EvalResult     *evalresult.EvalSetResult  `json:"evalSetResult"`  // EvalSetResult contains the aggregated results of the evaluation set.
 }
 
 // EvaluationCaseResult aggregates the outcome of a single eval case across multiple runs.
 type EvaluationCaseResult struct {
-	EvalCaseID          string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
-	OverallStatus       status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
-	InferenceDuration   time.Duration                  `json:"inferenceDuration"`    // InferenceDuration is the total actual agent time across runs for this case.
-	InferenceTokenUsage *model.Usage                   `json:"inferenceTokenUsage"`  // InferenceTokenUsage is the total actual agent token usage across runs for this case.
-	EvalCaseResults     []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
-	MetricResults       []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
-	RunDetails          []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
+	EvalCaseID      string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
+	OverallStatus   status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
+	InferenceStats  *evalresult.InferenceStats     `json:"inferenceStats"`       // InferenceStats is the total actual agent resource usage across runs for this case.
+	EvalCaseResults []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
+	MetricResults   []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
+	RunDetails      []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
 }
 
 // EvaluationCaseRunDetails contains caller-facing details for a single run of an eval case.
@@ -180,14 +177,13 @@ type EvaluationCaseRunDetails struct {
 
 // EvaluationInferenceDetails contains caller-facing inference details for a single eval case run.
 type EvaluationInferenceDetails struct {
-	SessionID           string                `json:"sessionId,omitempty"`           // SessionID identifies the inference session used for this run.
-	UserID              string                `json:"userId,omitempty"`              // UserID identifies the user used for this run.
-	Status              status.EvalStatus     `json:"status,omitempty"`              // Status records the inference status for this run.
-	ErrorMessage        string                `json:"errorMessage,omitempty"`        // ErrorMessage records the inference failure message when present.
-	InferenceDuration   time.Duration         `json:"inferenceDuration,omitempty"`   // InferenceDuration records the actual agent time for this run.
-	InferenceTokenUsage *model.Usage          `json:"inferenceTokenUsage,omitempty"` // InferenceTokenUsage records the actual agent token usage for this run.
-	Inferences          []*evalset.Invocation `json:"inferences,omitempty"`          // Inferences stores the invocation outputs captured during this run.
-	ExecutionTraces     []*trace.Trace        `json:"executionTraces,omitempty"`     // ExecutionTraces stores the execution traces captured during this run.
+	SessionID       string                     `json:"sessionId,omitempty"`       // SessionID identifies the inference session used for this run.
+	UserID          string                     `json:"userId,omitempty"`          // UserID identifies the user used for this run.
+	Status          status.EvalStatus          `json:"status,omitempty"`          // Status records the inference status for this run.
+	ErrorMessage    string                     `json:"errorMessage,omitempty"`    // ErrorMessage records the inference failure message when present.
+	InferenceStats  *evalresult.InferenceStats `json:"inferenceStats,omitempty"`  // InferenceStats records the actual agent resource usage for this run.
+	Inferences      []*evalset.Invocation      `json:"inferences,omitempty"`      // Inferences stores the invocation outputs captured during this run.
+	ExecutionTraces []*trace.Trace             `json:"executionTraces,omitempty"` // ExecutionTraces stores the execution traces captured during this run.
 }
 
 type runDetailsCollector struct {
@@ -217,14 +213,13 @@ func (a *agentEvaluator) Evaluate(ctx context.Context, evalSetID string, opt ...
 		return nil, fmt.Errorf("summarize overall status: %w", err)
 	}
 	return &EvaluationResult{
-		AppName:             a.appName,
-		EvalSetID:           evalSetID,
-		OverallStatus:       status,
-		ExecutionTime:       time.Since(start),
-		InferenceDuration:   callOpts.inferenceDurationValue(),
-		InferenceTokenUsage: callOpts.inferenceTokenUsageValue(),
-		EvalCases:           evalCases,
-		EvalResult:          evalSetResult,
+		AppName:        a.appName,
+		EvalSetID:      evalSetID,
+		OverallStatus:  status,
+		ExecutionTime:  time.Since(start),
+		InferenceStats: callOpts.inferenceStatsValue(),
+		EvalCases:      evalCases,
+		EvalResult:     evalSetResult,
 	}, nil
 }
 
@@ -328,8 +323,7 @@ func (a *agentEvaluator) collectCaseResults(ctx context.Context, evalSetID strin
 		}
 		for _, run := range runs {
 			if run != nil {
-				evalCaseResult.InferenceDuration += run.InferenceDuration
-				evalCaseResult.InferenceTokenUsage = usage.Add(evalCaseResult.InferenceTokenUsage, run.InferenceTokenUsage)
+				evalCaseResult.InferenceStats = addInferenceStats(evalCaseResult.InferenceStats, run.InferenceStats)
 			}
 		}
 		evalCaseResults = append(evalCaseResults, evalCaseResult)
@@ -495,7 +489,11 @@ func (a *agentEvaluator) runEvaluationOnce(
 	if err != nil {
 		return nil, fmt.Errorf("run %d inference: %w", runID, err)
 	}
-	inferenceDuration := inferenceDurationForInferenceResults(runInferenceResults)
+	inferenceStats := inferenceStatsForInferenceResults(runInferenceResults)
+	var inferenceDuration time.Duration
+	if inferenceStats != nil {
+		inferenceDuration = inferenceStats.Duration
+	}
 	if opts.runDetailsCollector != nil {
 		opts.runDetailsCollector.add(runID, runInferenceResults)
 	}
@@ -541,55 +539,56 @@ func (a *agentEvaluator) runEvaluationOnce(
 		return nil, errors.New("eval set run result is nil")
 	}
 	caseResults := make([]*evalresult.EvalCaseResult, 0, len(runResult.EvalCaseResults))
-	inferenceDurations := make(map[string]time.Duration)
-	inferenceTokenUsages := make(map[string]*model.Usage)
+	inferenceStatsByCaseID := make(map[string]*evalresult.InferenceStats)
 	for _, inferenceResult := range runInferenceResults {
 		if inferenceResult == nil || inferenceResult.EvalCaseID == "" {
 			continue
 		}
-		inferenceDurations[inferenceResult.EvalCaseID] += inferenceDurationForInferenceResult(inferenceResult)
-		inferenceTokenUsages[inferenceResult.EvalCaseID] = usage.Add(
-			inferenceTokenUsages[inferenceResult.EvalCaseID],
-			inferenceTokenUsageForInferenceResult(inferenceResult),
+		inferenceStatsByCaseID[inferenceResult.EvalCaseID] = addInferenceStats(
+			inferenceStatsByCaseID[inferenceResult.EvalCaseID],
+			inferenceStatsForInferenceResult(inferenceResult),
 		)
 	}
-	mergedCaseDuration := time.Duration(0)
-	var mergedCaseTokenUsage *model.Usage
+	var mergedCaseStats *evalresult.InferenceStats
 	for _, caseResult := range runResult.EvalCaseResults {
 		if caseResult == nil {
 			continue
 		}
 		caseResult.RunID = runID
-		if elapsed, ok := inferenceDurations[caseResult.EvalID]; ok && elapsed > 0 {
-			caseResult.InferenceDuration = elapsed
+		if stats, ok := inferenceStatsByCaseID[caseResult.EvalID]; ok && stats != nil {
+			if caseResult.InferenceStats == nil {
+				caseResult.InferenceStats = &evalresult.InferenceStats{}
+			}
+			if stats.Duration > 0 {
+				caseResult.InferenceStats.Duration = stats.Duration
+			}
+			if stats.TokenUsage != nil {
+				caseResult.InferenceStats.TokenUsage = usage.Clone(stats.TokenUsage)
+			}
 		}
-		if tokenUsage, ok := inferenceTokenUsages[caseResult.EvalID]; ok && tokenUsage != nil {
-			caseResult.InferenceTokenUsage = tokenUsage
-		}
-		delete(inferenceDurations, caseResult.EvalID)
-		delete(inferenceTokenUsages, caseResult.EvalID)
-		mergedCaseDuration += caseResult.InferenceDuration
-		mergedCaseTokenUsage = usage.Add(mergedCaseTokenUsage, caseResult.InferenceTokenUsage)
+		delete(inferenceStatsByCaseID, caseResult.EvalID)
+		mergedCaseStats = addInferenceStats(mergedCaseStats, caseResult.InferenceStats)
 		caseResults = append(caseResults, caseResult)
 	}
-	for _, elapsed := range inferenceDurations {
-		mergedCaseDuration += elapsed
+	for _, stats := range inferenceStatsByCaseID {
+		mergedCaseStats = addInferenceStats(mergedCaseStats, stats)
 	}
-	for _, tokenUsage := range inferenceTokenUsages {
-		mergedCaseTokenUsage = usage.Add(mergedCaseTokenUsage, tokenUsage)
+	runInferenceStats := &evalresult.InferenceStats{}
+	if mergedCaseStats != nil {
+		*runInferenceStats = *mergedCaseStats
+		runInferenceStats.TokenUsage = usage.Clone(mergedCaseStats.TokenUsage)
 	}
-	runInferenceDuration := mergedCaseDuration
-	if runResult.InferenceDuration > runInferenceDuration {
-		runInferenceDuration = runResult.InferenceDuration
+	if runResult.InferenceStats != nil && runResult.InferenceStats.Duration > runInferenceStats.Duration {
+		runInferenceStats.Duration = runResult.InferenceStats.Duration
 	}
-	if inferenceDuration > runInferenceDuration {
-		runInferenceDuration = inferenceDuration
+	if inferenceDuration > runInferenceStats.Duration {
+		runInferenceStats.Duration = inferenceDuration
 	}
-	opts.addInferenceDuration(runInferenceDuration)
-	if runResult.InferenceTokenUsage != nil {
-		opts.addInferenceTokenUsage(runResult.InferenceTokenUsage)
-	} else {
-		opts.addInferenceTokenUsage(mergedCaseTokenUsage)
+	if runResult.InferenceStats != nil && runResult.InferenceStats.TokenUsage != nil {
+		runInferenceStats.TokenUsage = usage.Clone(runResult.InferenceStats.TokenUsage)
+	}
+	if runInferenceStats.Duration > 0 || runInferenceStats.TokenUsage != nil {
+		opts.addInferenceStats(runInferenceStats)
 	}
 	return caseResults, nil
 }
@@ -702,18 +701,17 @@ func newEvaluationInferenceDetails(inferenceResult *service.InferenceResult) *Ev
 		return nil
 	}
 	return &EvaluationInferenceDetails{
-		SessionID:           inferenceResult.SessionID,
-		UserID:              inferenceResult.UserID,
-		Status:              inferenceResult.Status,
-		ErrorMessage:        inferenceResult.ErrorMessage,
-		InferenceDuration:   inferenceDurationForInferenceResult(inferenceResult),
-		InferenceTokenUsage: inferenceTokenUsageForInferenceResult(inferenceResult),
-		Inferences:          append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
-		ExecutionTraces:     append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
+		SessionID:       inferenceResult.SessionID,
+		UserID:          inferenceResult.UserID,
+		Status:          inferenceResult.Status,
+		ErrorMessage:    inferenceResult.ErrorMessage,
+		InferenceStats:  inferenceStatsForInferenceResult(inferenceResult),
+		Inferences:      append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
+		ExecutionTraces: append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
 	}
 }
 
-func inferenceTokenUsageForInferenceResult(inferenceResult *service.InferenceResult) *model.Usage {
+func inferenceStatsForInferenceResult(inferenceResult *service.InferenceResult) *evalresult.InferenceStats {
 	if inferenceResult == nil {
 		return nil
 	}
@@ -721,48 +719,52 @@ func inferenceTokenUsageForInferenceResult(inferenceResult *service.InferenceRes
 	if inferenceResult.EvalMode == evalset.EvalModeTrace {
 		return nil
 	}
-	if inferenceResult.InferenceTokenUsage != nil {
-		return usage.Add(nil, inferenceResult.InferenceTokenUsage)
+	stats := &evalresult.InferenceStats{}
+	if inferenceResult.InferenceStats != nil {
+		stats.Duration = inferenceResult.InferenceStats.Duration
+		stats.TokenUsage = usage.Clone(inferenceResult.InferenceStats.TokenUsage)
 	}
-	var total *model.Usage
-	for _, executionTrace := range inferenceResult.ExecutionTraces {
-		if executionTrace == nil {
-			continue
+	if stats.Duration <= 0 {
+		for _, executionTrace := range inferenceResult.ExecutionTraces {
+			if executionTrace == nil || executionTrace.StartedAt.IsZero() || executionTrace.EndedAt.IsZero() {
+				continue
+			}
+			if duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt); duration > 0 {
+				stats.Duration += duration
+			}
 		}
-		total = usage.Add(total, executionTrace.Usage)
+	}
+	if stats.TokenUsage == nil {
+		for _, executionTrace := range inferenceResult.ExecutionTraces {
+			if executionTrace != nil {
+				stats.TokenUsage = usage.Add(stats.TokenUsage, executionTrace.Usage)
+			}
+		}
+	}
+	if stats.Duration <= 0 && stats.TokenUsage == nil {
+		return nil
+	}
+	return stats
+}
+
+func inferenceStatsForInferenceResults(inferenceResults []*service.InferenceResult) *evalresult.InferenceStats {
+	var total *evalresult.InferenceStats
+	for _, inferenceResult := range inferenceResults {
+		total = addInferenceStats(total, inferenceStatsForInferenceResult(inferenceResult))
 	}
 	return total
 }
 
-func inferenceDurationForInferenceResult(inferenceResult *service.InferenceResult) time.Duration {
-	if inferenceResult == nil {
-		return 0
+func addInferenceStats(total, stats *evalresult.InferenceStats) *evalresult.InferenceStats {
+	if stats == nil {
+		return total
 	}
-	// Trace-mode cases replay recorded invocations without executing the agent.
-	if inferenceResult.EvalMode == evalset.EvalModeTrace {
-		return 0
+	if total == nil {
+		total = &evalresult.InferenceStats{}
 	}
-	if inferenceResult.InferenceDuration > 0 {
-		return inferenceResult.InferenceDuration
-	}
-	var elapsed time.Duration
-	for _, executionTrace := range inferenceResult.ExecutionTraces {
-		if executionTrace == nil || executionTrace.StartedAt.IsZero() || executionTrace.EndedAt.IsZero() {
-			continue
-		}
-		if duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt); duration > 0 {
-			elapsed += duration
-		}
-	}
-	return elapsed
-}
-
-func inferenceDurationForInferenceResults(inferenceResults []*service.InferenceResult) time.Duration {
-	var elapsed time.Duration
-	for _, inferenceResult := range inferenceResults {
-		elapsed += inferenceDurationForInferenceResult(inferenceResult)
-	}
-	return elapsed
+	total.Duration += stats.Duration
+	total.TokenUsage = usage.Add(total.TokenUsage, stats.TokenUsage)
+	return total
 }
 
 func newRunDetailsCollector() *runDetailsCollector {

--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -27,6 +27,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/multirun"
 	istatus "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/status"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/usage"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	metricllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -35,6 +36,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service/local"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/usersimulation"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
@@ -149,23 +151,25 @@ type agentEvaluator struct {
 
 // EvaluationResult contains the aggregated outcome of running an evaluation across multiple runs.
 type EvaluationResult struct {
-	AppName           string                    `json:"appName"`           // AppName identifies the agent being evaluated.
-	EvalSetID         string                    `json:"evalSetId"`         // EvalSetID identifies the evaluation set used in this run.
-	OverallStatus     status.EvalStatus         `json:"overallStatus"`     // OverallStatus summarizes the aggregated evaluation status across cases.
-	ExecutionTime     time.Duration             `json:"executionTime"`     // ExecutionTime records the total latency for the evaluation run.
-	InferenceDuration time.Duration             `json:"inferenceDuration"` // InferenceDuration records summed actual agent time across cases and runs.
-	EvalCases         []*EvaluationCaseResult   `json:"evalCases"`         // EvalCases contains aggregated results for each evaluation case.
-	EvalResult        *evalresult.EvalSetResult `json:"evalSetResult"`     // EvalSetResult contains the aggregated results of the evaluation set.
+	AppName             string                    `json:"appName"`             // AppName identifies the agent being evaluated.
+	EvalSetID           string                    `json:"evalSetId"`           // EvalSetID identifies the evaluation set used in this run.
+	OverallStatus       status.EvalStatus         `json:"overallStatus"`       // OverallStatus summarizes the aggregated evaluation status across cases.
+	ExecutionTime       time.Duration             `json:"executionTime"`       // ExecutionTime records the total latency for the evaluation run.
+	InferenceDuration   time.Duration             `json:"inferenceDuration"`   // InferenceDuration records summed actual agent time across cases and runs.
+	InferenceTokenUsage *model.Usage              `json:"inferenceTokenUsage"` // InferenceTokenUsage records summed actual agent token usage across cases and runs.
+	EvalCases           []*EvaluationCaseResult   `json:"evalCases"`           // EvalCases contains aggregated results for each evaluation case.
+	EvalResult          *evalresult.EvalSetResult `json:"evalSetResult"`       // EvalSetResult contains the aggregated results of the evaluation set.
 }
 
 // EvaluationCaseResult aggregates the outcome of a single eval case across multiple runs.
 type EvaluationCaseResult struct {
-	EvalCaseID        string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
-	OverallStatus     status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
-	InferenceDuration time.Duration                  `json:"inferenceDuration"`    // InferenceDuration is the total actual agent time across runs for this case.
-	EvalCaseResults   []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
-	MetricResults     []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
-	RunDetails        []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
+	EvalCaseID          string                         `json:"evalId"`               // EvalCaseID identifies the evaluation case.
+	OverallStatus       status.EvalStatus              `json:"overallStatus"`        // OverallStatus summarizes the overall status of case across runs.
+	InferenceDuration   time.Duration                  `json:"inferenceDuration"`    // InferenceDuration is the total actual agent time across runs for this case.
+	InferenceTokenUsage *model.Usage                   `json:"inferenceTokenUsage"`  // InferenceTokenUsage is the total actual agent token usage across runs for this case.
+	EvalCaseResults     []*evalresult.EvalCaseResult   `json:"evalCaseResults"`      // EvalCaseResults stores the per-run results for this case.
+	MetricResults       []*evalresult.EvalMetricResult `json:"metricResults"`        // MetricResults lists aggregated metric outcomes across runs.
+	RunDetails          []*EvaluationCaseRunDetails    `json:"runDetails,omitempty"` // RunDetails stores optional per-run inference details for this case.
 }
 
 // EvaluationCaseRunDetails contains caller-facing details for a single run of an eval case.
@@ -176,13 +180,14 @@ type EvaluationCaseRunDetails struct {
 
 // EvaluationInferenceDetails contains caller-facing inference details for a single eval case run.
 type EvaluationInferenceDetails struct {
-	SessionID         string                `json:"sessionId,omitempty"`         // SessionID identifies the inference session used for this run.
-	UserID            string                `json:"userId,omitempty"`            // UserID identifies the user used for this run.
-	Status            status.EvalStatus     `json:"status,omitempty"`            // Status records the inference status for this run.
-	ErrorMessage      string                `json:"errorMessage,omitempty"`      // ErrorMessage records the inference failure message when present.
-	InferenceDuration time.Duration         `json:"inferenceDuration,omitempty"` // InferenceDuration records the actual agent time for this run.
-	Inferences        []*evalset.Invocation `json:"inferences,omitempty"`        // Inferences stores the invocation outputs captured during this run.
-	ExecutionTraces   []*trace.Trace        `json:"executionTraces,omitempty"`   // ExecutionTraces stores the execution traces captured during this run.
+	SessionID           string                `json:"sessionId,omitempty"`           // SessionID identifies the inference session used for this run.
+	UserID              string                `json:"userId,omitempty"`              // UserID identifies the user used for this run.
+	Status              status.EvalStatus     `json:"status,omitempty"`              // Status records the inference status for this run.
+	ErrorMessage        string                `json:"errorMessage,omitempty"`        // ErrorMessage records the inference failure message when present.
+	InferenceDuration   time.Duration         `json:"inferenceDuration,omitempty"`   // InferenceDuration records the actual agent time for this run.
+	InferenceTokenUsage *model.Usage          `json:"inferenceTokenUsage,omitempty"` // InferenceTokenUsage records the actual agent token usage for this run.
+	Inferences          []*evalset.Invocation `json:"inferences,omitempty"`          // Inferences stores the invocation outputs captured during this run.
+	ExecutionTraces     []*trace.Trace        `json:"executionTraces,omitempty"`     // ExecutionTraces stores the execution traces captured during this run.
 }
 
 type runDetailsCollector struct {
@@ -212,13 +217,14 @@ func (a *agentEvaluator) Evaluate(ctx context.Context, evalSetID string, opt ...
 		return nil, fmt.Errorf("summarize overall status: %w", err)
 	}
 	return &EvaluationResult{
-		AppName:           a.appName,
-		EvalSetID:         evalSetID,
-		OverallStatus:     status,
-		ExecutionTime:     time.Since(start),
-		InferenceDuration: callOpts.inferenceDurationValue(),
-		EvalCases:         evalCases,
-		EvalResult:        evalSetResult,
+		AppName:             a.appName,
+		EvalSetID:           evalSetID,
+		OverallStatus:       status,
+		ExecutionTime:       time.Since(start),
+		InferenceDuration:   callOpts.inferenceDurationValue(),
+		InferenceTokenUsage: callOpts.inferenceTokenUsageValue(),
+		EvalCases:           evalCases,
+		EvalResult:          evalSetResult,
 	}, nil
 }
 
@@ -323,6 +329,7 @@ func (a *agentEvaluator) collectCaseResults(ctx context.Context, evalSetID strin
 		for _, run := range runs {
 			if run != nil {
 				evalCaseResult.InferenceDuration += run.InferenceDuration
+				evalCaseResult.InferenceTokenUsage = usage.Add(evalCaseResult.InferenceTokenUsage, run.InferenceTokenUsage)
 			}
 		}
 		evalCaseResults = append(evalCaseResults, evalCaseResult)
@@ -535,13 +542,19 @@ func (a *agentEvaluator) runEvaluationOnce(
 	}
 	caseResults := make([]*evalresult.EvalCaseResult, 0, len(runResult.EvalCaseResults))
 	inferenceDurations := make(map[string]time.Duration)
+	inferenceTokenUsages := make(map[string]*model.Usage)
 	for _, inferenceResult := range runInferenceResults {
 		if inferenceResult == nil || inferenceResult.EvalCaseID == "" {
 			continue
 		}
 		inferenceDurations[inferenceResult.EvalCaseID] += inferenceDurationForInferenceResult(inferenceResult)
+		inferenceTokenUsages[inferenceResult.EvalCaseID] = usage.Add(
+			inferenceTokenUsages[inferenceResult.EvalCaseID],
+			inferenceTokenUsageForInferenceResult(inferenceResult),
+		)
 	}
 	mergedCaseDuration := time.Duration(0)
+	var mergedCaseTokenUsage *model.Usage
 	for _, caseResult := range runResult.EvalCaseResults {
 		if caseResult == nil {
 			continue
@@ -550,12 +563,20 @@ func (a *agentEvaluator) runEvaluationOnce(
 		if elapsed, ok := inferenceDurations[caseResult.EvalID]; ok && elapsed > 0 {
 			caseResult.InferenceDuration = elapsed
 		}
+		if tokenUsage, ok := inferenceTokenUsages[caseResult.EvalID]; ok && tokenUsage != nil {
+			caseResult.InferenceTokenUsage = tokenUsage
+		}
 		delete(inferenceDurations, caseResult.EvalID)
+		delete(inferenceTokenUsages, caseResult.EvalID)
 		mergedCaseDuration += caseResult.InferenceDuration
+		mergedCaseTokenUsage = usage.Add(mergedCaseTokenUsage, caseResult.InferenceTokenUsage)
 		caseResults = append(caseResults, caseResult)
 	}
 	for _, elapsed := range inferenceDurations {
 		mergedCaseDuration += elapsed
+	}
+	for _, tokenUsage := range inferenceTokenUsages {
+		mergedCaseTokenUsage = usage.Add(mergedCaseTokenUsage, tokenUsage)
 	}
 	runInferenceDuration := mergedCaseDuration
 	if runResult.InferenceDuration > runInferenceDuration {
@@ -565,6 +586,11 @@ func (a *agentEvaluator) runEvaluationOnce(
 		runInferenceDuration = inferenceDuration
 	}
 	opts.addInferenceDuration(runInferenceDuration)
+	if runResult.InferenceTokenUsage != nil {
+		opts.addInferenceTokenUsage(runResult.InferenceTokenUsage)
+	} else {
+		opts.addInferenceTokenUsage(mergedCaseTokenUsage)
+	}
 	return caseResults, nil
 }
 
@@ -676,14 +702,36 @@ func newEvaluationInferenceDetails(inferenceResult *service.InferenceResult) *Ev
 		return nil
 	}
 	return &EvaluationInferenceDetails{
-		SessionID:         inferenceResult.SessionID,
-		UserID:            inferenceResult.UserID,
-		Status:            inferenceResult.Status,
-		ErrorMessage:      inferenceResult.ErrorMessage,
-		InferenceDuration: inferenceDurationForInferenceResult(inferenceResult),
-		Inferences:        append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
-		ExecutionTraces:   append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
+		SessionID:           inferenceResult.SessionID,
+		UserID:              inferenceResult.UserID,
+		Status:              inferenceResult.Status,
+		ErrorMessage:        inferenceResult.ErrorMessage,
+		InferenceDuration:   inferenceDurationForInferenceResult(inferenceResult),
+		InferenceTokenUsage: inferenceTokenUsageForInferenceResult(inferenceResult),
+		Inferences:          append([]*evalset.Invocation(nil), inferenceResult.Inferences...),
+		ExecutionTraces:     append([]*trace.Trace(nil), inferenceResult.ExecutionTraces...),
 	}
+}
+
+func inferenceTokenUsageForInferenceResult(inferenceResult *service.InferenceResult) *model.Usage {
+	if inferenceResult == nil {
+		return nil
+	}
+	// Trace-mode cases replay recorded invocations without executing the agent.
+	if inferenceResult.EvalMode == evalset.EvalModeTrace {
+		return nil
+	}
+	if inferenceResult.InferenceTokenUsage != nil {
+		return usage.Add(nil, inferenceResult.InferenceTokenUsage)
+	}
+	var total *model.Usage
+	for _, executionTrace := range inferenceResult.ExecutionTraces {
+		if executionTrace == nil {
+			continue
+		}
+		total = usage.Add(total, executionTrace.Usage)
+	}
+	return total
 }
 
 func inferenceDurationForInferenceResult(inferenceResult *service.InferenceResult) time.Duration {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1435,31 +1435,35 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 			{
 				nil,
 				{
-					AppName:           appName,
-					EvalSetID:         evalSetID,
-					EvalCaseID:        caseID,
-					Inferences:        []*evalset.Invocation{{InvocationID: "inv-1"}},
-					SessionID:         "session-1",
-					UserID:            "user-1",
-					Status:            status.EvalStatusPassed,
-					InferenceDuration: 3 * time.Second,
-					InferenceTokenUsage: &model.Usage{
-						PromptTokens: 10, CompletionTokens: 4, TotalTokens: 14,
+					AppName:    appName,
+					EvalSetID:  evalSetID,
+					EvalCaseID: caseID,
+					Inferences: []*evalset.Invocation{{InvocationID: "inv-1"}},
+					SessionID:  "session-1",
+					UserID:     "user-1",
+					Status:     status.EvalStatusPassed,
+					InferenceStats: &evalresult.InferenceStats{
+						Duration: 3 * time.Second,
+						TokenUsage: &model.Usage{
+							PromptTokens: 10, CompletionTokens: 4, TotalTokens: 14,
+						},
 					},
 					ExecutionTraces: []*agenttrace.Trace{runOneTrace},
 				},
 			},
 			{{
-				AppName:           appName,
-				EvalSetID:         evalSetID,
-				EvalCaseID:        caseID,
-				Inferences:        []*evalset.Invocation{{InvocationID: "inv-2"}},
-				SessionID:         "session-2",
-				UserID:            "user-2",
-				Status:            status.EvalStatusPassed,
-				InferenceDuration: 5 * time.Second,
-				InferenceTokenUsage: &model.Usage{
-					PromptTokens: 20, CompletionTokens: 6, TotalTokens: 26,
+				AppName:    appName,
+				EvalSetID:  evalSetID,
+				EvalCaseID: caseID,
+				Inferences: []*evalset.Invocation{{InvocationID: "inv-2"}},
+				SessionID:  "session-2",
+				UserID:     "user-2",
+				Status:     status.EvalStatusPassed,
+				InferenceStats: &evalresult.InferenceStats{
+					Duration: 5 * time.Second,
+					TokenUsage: &model.Usage{
+						PromptTokens: 20, CompletionTokens: 6, TotalTokens: 26,
+					},
 				},
 				ExecutionTraces: []*agenttrace.Trace{runTwoTrace},
 			}},
@@ -1499,25 +1503,29 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	}()
 	evaluationResult, err := ae.Evaluate(ctx, evalSetID, WithRunDetailsEnabled(true))
 	assert.NoError(t, err)
-	assert.Equal(t, 8*time.Second, evaluationResult.InferenceDuration)
-	require.NotNil(t, evaluationResult.InferenceTokenUsage)
-	assert.Equal(t, 30, evaluationResult.InferenceTokenUsage.PromptTokens)
-	assert.Equal(t, 10, evaluationResult.InferenceTokenUsage.CompletionTokens)
-	assert.Equal(t, 40, evaluationResult.InferenceTokenUsage.TotalTokens)
+	require.NotNil(t, evaluationResult.InferenceStats)
+	assert.Equal(t, 8*time.Second, evaluationResult.InferenceStats.Duration)
+	require.NotNil(t, evaluationResult.InferenceStats.TokenUsage)
+	assert.Equal(t, 30, evaluationResult.InferenceStats.TokenUsage.PromptTokens)
+	assert.Equal(t, 10, evaluationResult.InferenceStats.TokenUsage.CompletionTokens)
+	assert.Equal(t, 40, evaluationResult.InferenceStats.TokenUsage.TotalTokens)
 	if !assert.Len(t, evaluationResult.EvalCases, 1) {
 		return
 	}
 	caseResult := evaluationResult.EvalCases[0]
-	assert.Equal(t, 8*time.Second, caseResult.InferenceDuration)
-	require.NotNil(t, caseResult.InferenceTokenUsage)
-	assert.Equal(t, 30, caseResult.InferenceTokenUsage.PromptTokens)
-	assert.Equal(t, 10, caseResult.InferenceTokenUsage.CompletionTokens)
-	assert.Equal(t, 40, caseResult.InferenceTokenUsage.TotalTokens)
+	require.NotNil(t, caseResult.InferenceStats)
+	assert.Equal(t, 8*time.Second, caseResult.InferenceStats.Duration)
+	require.NotNil(t, caseResult.InferenceStats.TokenUsage)
+	assert.Equal(t, 30, caseResult.InferenceStats.TokenUsage.PromptTokens)
+	assert.Equal(t, 10, caseResult.InferenceStats.TokenUsage.CompletionTokens)
+	assert.Equal(t, 40, caseResult.InferenceStats.TokenUsage.TotalTokens)
 	if assert.Len(t, caseResult.EvalCaseResults, 2) {
-		require.NotNil(t, caseResult.EvalCaseResults[0].InferenceTokenUsage)
-		assert.Equal(t, 10, caseResult.EvalCaseResults[0].InferenceTokenUsage.PromptTokens)
-		require.NotNil(t, caseResult.EvalCaseResults[1].InferenceTokenUsage)
-		assert.Equal(t, 20, caseResult.EvalCaseResults[1].InferenceTokenUsage.PromptTokens)
+		require.NotNil(t, caseResult.EvalCaseResults[0].InferenceStats)
+		require.NotNil(t, caseResult.EvalCaseResults[0].InferenceStats.TokenUsage)
+		assert.Equal(t, 10, caseResult.EvalCaseResults[0].InferenceStats.TokenUsage.PromptTokens)
+		require.NotNil(t, caseResult.EvalCaseResults[1].InferenceStats)
+		require.NotNil(t, caseResult.EvalCaseResults[1].InferenceStats.TokenUsage)
+		assert.Equal(t, 20, caseResult.EvalCaseResults[1].InferenceStats.TokenUsage.PromptTokens)
 	}
 	if !assert.Len(t, caseResult.RunDetails, 2) {
 		return
@@ -1528,9 +1536,10 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 		assert.Equal(t, "session-1", caseResult.RunDetails[0].Inference.SessionID)
 		assert.Equal(t, "user-1", caseResult.RunDetails[0].Inference.UserID)
 		assert.Equal(t, status.EvalStatusPassed, caseResult.RunDetails[0].Inference.Status)
-		assert.Equal(t, 3*time.Second, caseResult.RunDetails[0].Inference.InferenceDuration)
-		require.NotNil(t, caseResult.RunDetails[0].Inference.InferenceTokenUsage)
-		assert.Equal(t, 10, caseResult.RunDetails[0].Inference.InferenceTokenUsage.PromptTokens)
+		require.NotNil(t, caseResult.RunDetails[0].Inference.InferenceStats)
+		assert.Equal(t, 3*time.Second, caseResult.RunDetails[0].Inference.InferenceStats.Duration)
+		require.NotNil(t, caseResult.RunDetails[0].Inference.InferenceStats.TokenUsage)
+		assert.Equal(t, 10, caseResult.RunDetails[0].Inference.InferenceStats.TokenUsage.PromptTokens)
 		if assert.Len(t, caseResult.RunDetails[0].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-1", caseResult.RunDetails[0].Inference.Inferences[0].InvocationID)
 		}
@@ -1544,9 +1553,10 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	if assert.NotNil(t, caseResult.RunDetails[1].Inference) {
 		assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.SessionID)
 		assert.Equal(t, "user-2", caseResult.RunDetails[1].Inference.UserID)
-		assert.Equal(t, 5*time.Second, caseResult.RunDetails[1].Inference.InferenceDuration)
-		require.NotNil(t, caseResult.RunDetails[1].Inference.InferenceTokenUsage)
-		assert.Equal(t, 20, caseResult.RunDetails[1].Inference.InferenceTokenUsage.PromptTokens)
+		require.NotNil(t, caseResult.RunDetails[1].Inference.InferenceStats)
+		assert.Equal(t, 5*time.Second, caseResult.RunDetails[1].Inference.InferenceStats.Duration)
+		require.NotNil(t, caseResult.RunDetails[1].Inference.InferenceStats.TokenUsage)
+		assert.Equal(t, 20, caseResult.RunDetails[1].Inference.InferenceStats.TokenUsage.PromptTokens)
 		if assert.Len(t, caseResult.RunDetails[1].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-2", caseResult.RunDetails[1].Inference.Inferences[0].InvocationID)
 		}
@@ -1557,50 +1567,54 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
+func TestInferenceStatsForInferenceResultDurationFallbacks(t *testing.T) {
 	start := time.Now()
-	assert.Zero(t, inferenceDurationForInferenceResult(nil))
-	assert.Equal(t, 42*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
-		InferenceDuration: 42 * time.Millisecond,
-	}))
-	assert.Zero(t, inferenceDurationForInferenceResult(&service.InferenceResult{
-		EvalMode:          evalset.EvalModeTrace,
-		InferenceDuration: 42 * time.Millisecond,
+	assert.Nil(t, inferenceStatsForInferenceResult(nil))
+	assert.Equal(t, 42*time.Millisecond, inferenceStatsForInferenceResult(&service.InferenceResult{
+		InferenceStats: &evalresult.InferenceStats{Duration: 42 * time.Millisecond},
+	}).Duration)
+	assert.Nil(t, inferenceStatsForInferenceResult(&service.InferenceResult{
+		EvalMode:       evalset.EvalModeTrace,
+		InferenceStats: &evalresult.InferenceStats{Duration: 42 * time.Millisecond},
 		ExecutionTraces: []*agenttrace.Trace{{
 			StartedAt: start,
 			EndedAt:   start.Add(time.Second),
 		}},
 	}))
-	assert.Equal(t, 5*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
+	assert.Equal(t, 5*time.Millisecond, inferenceStatsForInferenceResult(&service.InferenceResult{
 		ExecutionTraces: []*agenttrace.Trace{
 			nil,
 			{},
 			{StartedAt: start, EndedAt: start.Add(5 * time.Millisecond)},
 			{StartedAt: start.Add(10 * time.Millisecond), EndedAt: start.Add(5 * time.Millisecond)},
 		},
-	}))
+	}).Duration)
 }
 
-func TestAgentEvaluatorPreservesServiceCaseInferenceDuration(t *testing.T) {
+func TestAgentEvaluatorPreservesServiceCaseInferenceStats(t *testing.T) {
 	const (
 		appName   = "app"
 		evalSetID = "set"
 		caseID    = "case"
 	)
 	serviceCaseDuration := 7 * time.Second
+	serviceCaseUsage := &model.Usage{PromptTokens: 9, CompletionTokens: 3, TotalTokens: 12}
 	svc := &fakeService{
 		inferenceResults: [][]*service.InferenceResult{{{
 			AppName:    appName,
 			EvalSetID:  evalSetID,
 			EvalCaseID: caseID,
+			InferenceStats: &evalresult.InferenceStats{
+				Duration: serviceCaseDuration,
+			},
 		}}},
 		evaluateResults: []*service.EvalSetRunResult{{
 			AppName:   appName,
 			EvalSetID: evalSetID,
 			EvalCaseResults: []*evalresult.EvalCaseResult{{
-				EvalSetID:         evalSetID,
-				EvalID:            caseID,
-				InferenceDuration: serviceCaseDuration,
+				EvalSetID:      evalSetID,
+				EvalID:         caseID,
+				InferenceStats: &evalresult.InferenceStats{TokenUsage: serviceCaseUsage},
 			}},
 		}},
 	}
@@ -1611,18 +1625,20 @@ func TestAgentEvaluatorPreservesServiceCaseInferenceDuration(t *testing.T) {
 	results, err := ae.runEvaluationOnce(context.Background(), evalSetID, opts, nil, 1)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, serviceCaseDuration, results[0].InferenceDuration)
-	assert.Equal(t, serviceCaseDuration, opts.inferenceDurationValue())
+	assert.Equal(t, serviceCaseDuration, results[0].InferenceStats.Duration)
+	assert.Equal(t, serviceCaseUsage, results[0].InferenceStats.TokenUsage)
+	assert.Equal(t, serviceCaseDuration, opts.inferenceStatsValue().Duration)
+	assert.Equal(t, serviceCaseUsage, opts.inferenceStatsValue().TokenUsage)
 }
 
-func TestAgentEvaluatorMergesMixedCaseInferenceDurations(t *testing.T) {
+func TestAgentEvaluatorMergesMixedCaseInferenceStats(t *testing.T) {
 	const (
 		appName   = "app"
 		evalSetID = "set"
 	)
 	svc := &fakeService{
 		inferenceResults: [][]*service.InferenceResult{{
-			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-a", InferenceDuration: 2 * time.Second},
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-a", InferenceStats: &evalresult.InferenceStats{Duration: 2 * time.Second}},
 			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-b"},
 		}},
 		evaluateResults: []*service.EvalSetRunResult{{
@@ -1630,7 +1646,7 @@ func TestAgentEvaluatorMergesMixedCaseInferenceDurations(t *testing.T) {
 			EvalSetID: evalSetID,
 			EvalCaseResults: []*evalresult.EvalCaseResult{
 				{EvalSetID: evalSetID, EvalID: "case-a"},
-				{EvalSetID: evalSetID, EvalID: "case-b", InferenceDuration: 3 * time.Second},
+				{EvalSetID: evalSetID, EvalID: "case-b", InferenceStats: &evalresult.InferenceStats{Duration: 3 * time.Second}},
 			},
 		}},
 	}
@@ -1641,28 +1657,28 @@ func TestAgentEvaluatorMergesMixedCaseInferenceDurations(t *testing.T) {
 	results, err := ae.runEvaluationOnce(context.Background(), evalSetID, opts, nil, 1)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
-	assert.Equal(t, 2*time.Second, results[0].InferenceDuration)
-	assert.Equal(t, 3*time.Second, results[1].InferenceDuration)
-	assert.Equal(t, 5*time.Second, opts.inferenceDurationValue())
+	assert.Equal(t, 2*time.Second, results[0].InferenceStats.Duration)
+	assert.Equal(t, 3*time.Second, results[1].InferenceStats.Duration)
+	assert.Equal(t, 5*time.Second, opts.inferenceStatsValue().Duration)
 }
 
-func TestAgentEvaluatorMergesInferenceDurationForMissingCaseResult(t *testing.T) {
+func TestAgentEvaluatorMergesInferenceStatsForMissingCaseResult(t *testing.T) {
 	const (
 		appName   = "app"
 		evalSetID = "set"
 	)
 	svc := &fakeService{
 		inferenceResults: [][]*service.InferenceResult{{
-			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-a", InferenceDuration: 2 * time.Second},
-			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-b", InferenceDuration: 3 * time.Second},
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-a", InferenceStats: &evalresult.InferenceStats{Duration: 2 * time.Second}},
+			{AppName: appName, EvalSetID: evalSetID, EvalCaseID: "case-b", InferenceStats: &evalresult.InferenceStats{Duration: 3 * time.Second}},
 		}},
 		evaluateResults: []*service.EvalSetRunResult{{
 			AppName:   appName,
 			EvalSetID: evalSetID,
 			EvalCaseResults: []*evalresult.EvalCaseResult{{
-				EvalSetID:         evalSetID,
-				EvalID:            "case-b",
-				InferenceDuration: 3 * time.Second,
+				EvalSetID:      evalSetID,
+				EvalID:         "case-b",
+				InferenceStats: &evalresult.InferenceStats{Duration: 3 * time.Second},
 			}},
 		}},
 	}
@@ -1674,8 +1690,8 @@ func TestAgentEvaluatorMergesInferenceDurationForMissingCaseResult(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "case-b", results[0].EvalID)
-	assert.Equal(t, 3*time.Second, results[0].InferenceDuration)
-	assert.Equal(t, 5*time.Second, opts.inferenceDurationValue())
+	assert.Equal(t, 3*time.Second, results[0].InferenceStats.Duration)
+	assert.Equal(t, 5*time.Second, opts.inferenceStatsValue().Duration)
 }
 
 func TestAgentEvaluatorEvaluateInferenceError(t *testing.T) {

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -1443,7 +1443,10 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 					UserID:            "user-1",
 					Status:            status.EvalStatusPassed,
 					InferenceDuration: 3 * time.Second,
-					ExecutionTraces:   []*agenttrace.Trace{runOneTrace},
+					InferenceTokenUsage: &model.Usage{
+						PromptTokens: 10, CompletionTokens: 4, TotalTokens: 14,
+					},
+					ExecutionTraces: []*agenttrace.Trace{runOneTrace},
 				},
 			},
 			{{
@@ -1455,7 +1458,10 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 				UserID:            "user-2",
 				Status:            status.EvalStatusPassed,
 				InferenceDuration: 5 * time.Second,
-				ExecutionTraces:   []*agenttrace.Trace{runTwoTrace},
+				InferenceTokenUsage: &model.Usage{
+					PromptTokens: 20, CompletionTokens: 6, TotalTokens: 26,
+				},
+				ExecutionTraces: []*agenttrace.Trace{runTwoTrace},
 			}},
 		},
 		evaluateResults: []*service.EvalSetRunResult{
@@ -1494,11 +1500,25 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 	evaluationResult, err := ae.Evaluate(ctx, evalSetID, WithRunDetailsEnabled(true))
 	assert.NoError(t, err)
 	assert.Equal(t, 8*time.Second, evaluationResult.InferenceDuration)
+	require.NotNil(t, evaluationResult.InferenceTokenUsage)
+	assert.Equal(t, 30, evaluationResult.InferenceTokenUsage.PromptTokens)
+	assert.Equal(t, 10, evaluationResult.InferenceTokenUsage.CompletionTokens)
+	assert.Equal(t, 40, evaluationResult.InferenceTokenUsage.TotalTokens)
 	if !assert.Len(t, evaluationResult.EvalCases, 1) {
 		return
 	}
 	caseResult := evaluationResult.EvalCases[0]
 	assert.Equal(t, 8*time.Second, caseResult.InferenceDuration)
+	require.NotNil(t, caseResult.InferenceTokenUsage)
+	assert.Equal(t, 30, caseResult.InferenceTokenUsage.PromptTokens)
+	assert.Equal(t, 10, caseResult.InferenceTokenUsage.CompletionTokens)
+	assert.Equal(t, 40, caseResult.InferenceTokenUsage.TotalTokens)
+	if assert.Len(t, caseResult.EvalCaseResults, 2) {
+		require.NotNil(t, caseResult.EvalCaseResults[0].InferenceTokenUsage)
+		assert.Equal(t, 10, caseResult.EvalCaseResults[0].InferenceTokenUsage.PromptTokens)
+		require.NotNil(t, caseResult.EvalCaseResults[1].InferenceTokenUsage)
+		assert.Equal(t, 20, caseResult.EvalCaseResults[1].InferenceTokenUsage.PromptTokens)
+	}
 	if !assert.Len(t, caseResult.RunDetails, 2) {
 		return
 	}
@@ -1509,6 +1529,8 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 		assert.Equal(t, "user-1", caseResult.RunDetails[0].Inference.UserID)
 		assert.Equal(t, status.EvalStatusPassed, caseResult.RunDetails[0].Inference.Status)
 		assert.Equal(t, 3*time.Second, caseResult.RunDetails[0].Inference.InferenceDuration)
+		require.NotNil(t, caseResult.RunDetails[0].Inference.InferenceTokenUsage)
+		assert.Equal(t, 10, caseResult.RunDetails[0].Inference.InferenceTokenUsage.PromptTokens)
 		if assert.Len(t, caseResult.RunDetails[0].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-1", caseResult.RunDetails[0].Inference.Inferences[0].InvocationID)
 		}
@@ -1523,6 +1545,8 @@ func TestAgentEvaluatorEvaluateIncludesRunDetailsWhenEnabled(t *testing.T) {
 		assert.Equal(t, "session-2", caseResult.RunDetails[1].Inference.SessionID)
 		assert.Equal(t, "user-2", caseResult.RunDetails[1].Inference.UserID)
 		assert.Equal(t, 5*time.Second, caseResult.RunDetails[1].Inference.InferenceDuration)
+		require.NotNil(t, caseResult.RunDetails[1].Inference.InferenceTokenUsage)
+		assert.Equal(t, 20, caseResult.RunDetails[1].Inference.InferenceTokenUsage.PromptTokens)
 		if assert.Len(t, caseResult.RunDetails[1].Inference.Inferences, 1) {
 			assert.Equal(t, "inv-2", caseResult.RunDetails[1].Inference.Inferences[0].InvocationID)
 		}

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -733,9 +733,11 @@ func TestCloneEvalSetResult_DeepCopy(t *testing.T) {
 				EvalSetID: "set-1",
 				EvalID:    "case-1",
 				RunID:     1,
-				InferenceTokenUsage: &model.Usage{
-					PromptTokens: 10,
-					TimingInfo:   &model.TimingInfo{FirstTokenDuration: time.Millisecond},
+				InferenceStats: &evalresult.InferenceStats{
+					TokenUsage: &model.Usage{
+						PromptTokens: 10,
+						TimingInfo:   &model.TimingInfo{FirstTokenDuration: time.Millisecond},
+					},
 				},
 				OverallEvalMetricResults: []*evalresult.EvalMetricResult{
 					{
@@ -853,10 +855,10 @@ func TestCloneEvalSetResult_DeepCopy(t *testing.T) {
 	dst.EvalCaseResults[0].EvalMetricResultPerInvocation[0].ActualInvocation.Tools[0].Arguments.(map[string]any)["k"] = "changed"
 	assert.Equal(t, "v", src.EvalCaseResults[0].EvalMetricResultPerInvocation[0].ActualInvocation.Tools[0].Arguments.(map[string]any)["k"])
 
-	dst.EvalCaseResults[0].InferenceTokenUsage.PromptTokens = 20
-	dst.EvalCaseResults[0].InferenceTokenUsage.TimingInfo.FirstTokenDuration = 2 * time.Millisecond
-	assert.Equal(t, 10, src.EvalCaseResults[0].InferenceTokenUsage.PromptTokens)
-	assert.Equal(t, time.Millisecond, src.EvalCaseResults[0].InferenceTokenUsage.TimingInfo.FirstTokenDuration)
+	dst.EvalCaseResults[0].InferenceStats.TokenUsage.PromptTokens = 20
+	dst.EvalCaseResults[0].InferenceStats.TokenUsage.TimingInfo.FirstTokenDuration = 2 * time.Millisecond
+	assert.Equal(t, 10, src.EvalCaseResults[0].InferenceStats.TokenUsage.PromptTokens)
+	assert.Equal(t, time.Millisecond, src.EvalCaseResults[0].InferenceStats.TokenUsage.TimingInfo.FirstTokenDuration)
 
 	dst.Summary.RunStatusCounts.Passed = 2
 	assert.Equal(t, 1, src.Summary.RunStatusCounts.Passed)

--- a/evaluation/internal/clone/clone_test.go
+++ b/evaluation/internal/clone/clone_test.go
@@ -733,6 +733,10 @@ func TestCloneEvalSetResult_DeepCopy(t *testing.T) {
 				EvalSetID: "set-1",
 				EvalID:    "case-1",
 				RunID:     1,
+				InferenceTokenUsage: &model.Usage{
+					PromptTokens: 10,
+					TimingInfo:   &model.TimingInfo{FirstTokenDuration: time.Millisecond},
+				},
 				OverallEvalMetricResults: []*evalresult.EvalMetricResult{
 					{
 						MetricName: "metric-1",
@@ -848,6 +852,11 @@ func TestCloneEvalSetResult_DeepCopy(t *testing.T) {
 
 	dst.EvalCaseResults[0].EvalMetricResultPerInvocation[0].ActualInvocation.Tools[0].Arguments.(map[string]any)["k"] = "changed"
 	assert.Equal(t, "v", src.EvalCaseResults[0].EvalMetricResultPerInvocation[0].ActualInvocation.Tools[0].Arguments.(map[string]any)["k"])
+
+	dst.EvalCaseResults[0].InferenceTokenUsage.PromptTokens = 20
+	dst.EvalCaseResults[0].InferenceTokenUsage.TimingInfo.FirstTokenDuration = 2 * time.Millisecond
+	assert.Equal(t, 10, src.EvalCaseResults[0].InferenceTokenUsage.PromptTokens)
+	assert.Equal(t, time.Millisecond, src.EvalCaseResults[0].InferenceTokenUsage.TimingInfo.FirstTokenDuration)
 
 	dst.Summary.RunStatusCounts.Passed = 2
 	assert.Equal(t, 1, src.Summary.RunStatusCounts.Passed)

--- a/evaluation/internal/clone/evalresult.go
+++ b/evaluation/internal/clone/evalresult.go
@@ -11,6 +11,7 @@ package clone
 
 import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
+	tokenusage "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/usage"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/score"
 )
 
@@ -50,6 +51,7 @@ func cloneEvalCaseResult(src *evalresult.EvalCaseResult) (*evalresult.EvalCaseRe
 		return nil, nil
 	}
 	copied := *src
+	copied.InferenceTokenUsage = tokenusage.Clone(src.InferenceTokenUsage)
 	overallMetrics, err := cloneEvalMetricResults(src.OverallEvalMetricResults)
 	if err != nil {
 		return nil, err

--- a/evaluation/internal/clone/evalresult.go
+++ b/evaluation/internal/clone/evalresult.go
@@ -51,7 +51,12 @@ func cloneEvalCaseResult(src *evalresult.EvalCaseResult) (*evalresult.EvalCaseRe
 		return nil, nil
 	}
 	copied := *src
-	copied.InferenceTokenUsage = tokenusage.Clone(src.InferenceTokenUsage)
+	if src.InferenceStats != nil {
+		copied.InferenceStats = &evalresult.InferenceStats{
+			Duration:   src.InferenceStats.Duration,
+			TokenUsage: tokenusage.Clone(src.InferenceStats.TokenUsage),
+		}
+	}
 	overallMetrics, err := cloneEvalMetricResults(src.OverallEvalMetricResults)
 	if err != nil {
 		return nil, err

--- a/evaluation/internal/usage/usage.go
+++ b/evaluation/internal/usage/usage.go
@@ -1,0 +1,63 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License 2.0.
+//
+
+// Package usage contains helpers for aggregating model token usage.
+package usage
+
+import "trpc.group/trpc-go/trpc-agent-go/model"
+
+// Add adds src to dst and returns the resulting usage. A nil or zero-token
+// source is ignored, and the first non-zero source is copied so aggregators do
+// not mutate source results. Timing information is intentionally not
+// accumulated because it describes an individual model request rather than
+// token consumption.
+func Add(dst, src *model.Usage) *model.Usage {
+	if !hasTokens(src) {
+		return dst
+	}
+	if dst == nil {
+		dst = Clone(src)
+		dst.TimingInfo = nil
+		return dst
+	}
+	dst.TimingInfo = nil
+	dst.PromptTokens += src.PromptTokens
+	dst.CompletionTokens += src.CompletionTokens
+	dst.TotalTokens += src.TotalTokens
+	dst.PromptTokensDetails.CachedTokens += src.PromptTokensDetails.CachedTokens
+	dst.PromptTokensDetails.CacheCreationTokens += src.PromptTokensDetails.CacheCreationTokens
+	dst.PromptTokensDetails.CacheReadTokens += src.PromptTokensDetails.CacheReadTokens
+	dst.CompletionTokensDetails.ReasoningTokens += src.CompletionTokensDetails.ReasoningTokens
+	return dst
+}
+
+func hasTokens(usage *model.Usage) bool {
+	if usage == nil {
+		return false
+	}
+	return usage.PromptTokens != 0 ||
+		usage.CompletionTokens != 0 ||
+		usage.TotalTokens != 0 ||
+		usage.PromptTokensDetails.CachedTokens != 0 ||
+		usage.PromptTokensDetails.CacheCreationTokens != 0 ||
+		usage.PromptTokensDetails.CacheReadTokens != 0 ||
+		usage.CompletionTokensDetails.ReasoningTokens != 0
+}
+
+// Clone returns a deep copy of src.
+func Clone(src *model.Usage) *model.Usage {
+	if src == nil {
+		return nil
+	}
+	copied := *src
+	if src.TimingInfo != nil {
+		timingInfo := *src.TimingInfo
+		copied.TimingInfo = &timingInfo
+	}
+	return &copied
+}

--- a/evaluation/internal/usage/usage.go
+++ b/evaluation/internal/usage/usage.go
@@ -3,7 +3,7 @@
 //
 // Copyright (C) 2025 Tencent.  All rights reserved.
 //
-// trpc-agent-go is licensed under the Apache License 2.0.
+// trpc-agent-go is licensed under the Apache License Version 2.0.
 //
 
 // Package usage contains helpers for aggregating model token usage.

--- a/evaluation/internal/usage/usage_test.go
+++ b/evaluation/internal/usage/usage_test.go
@@ -3,7 +3,7 @@
 //
 // Copyright (C) 2025 Tencent.  All rights reserved.
 //
-// trpc-agent-go is licensed under the Apache License 2.0.
+// trpc-agent-go is licensed under the Apache License Version 2.0.
 //
 
 package usage

--- a/evaluation/internal/usage/usage_test.go
+++ b/evaluation/internal/usage/usage_test.go
@@ -1,0 +1,59 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License 2.0.
+//
+
+package usage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-agent-go/model"
+)
+
+func TestAdd(t *testing.T) {
+	src := &model.Usage{
+		PromptTokens:     2,
+		CompletionTokens: 3,
+		TotalTokens:      5,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens:        1,
+			CacheCreationTokens: 2,
+			CacheReadTokens:     3,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{ReasoningTokens: 4},
+		TimingInfo:              &model.TimingInfo{},
+	}
+	got := Add(nil, src)
+	require.Equal(t, &model.Usage{
+		PromptTokens:     2,
+		CompletionTokens: 3,
+		TotalTokens:      5,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens:        1,
+			CacheCreationTokens: 2,
+			CacheReadTokens:     3,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{ReasoningTokens: 4},
+	}, got)
+	require.NotSame(t, src, got)
+	require.NotSame(t, src.TimingInfo, got.TimingInfo)
+
+	Add(got, &model.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18})
+	require.Equal(t, 9, got.PromptTokens)
+	require.Equal(t, 14, got.CompletionTokens)
+	require.Equal(t, 23, got.TotalTokens)
+	require.Same(t, got, Add(got, &model.Usage{TimingInfo: &model.TimingInfo{}}))
+}
+
+func TestClone(t *testing.T) {
+	original := &model.Usage{TimingInfo: &model.TimingInfo{FirstTokenDuration: 1}}
+	cloned := Clone(original)
+	require.Equal(t, original, cloned)
+	require.NotSame(t, original, cloned)
+	require.NotSame(t, original.TimingInfo, cloned.TimingInfo)
+}

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -20,11 +20,13 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	evalsetinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
+	tokenusage "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/usage"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	metricinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/inmemory"
 	metricregistry "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/usersimulation"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
@@ -57,6 +59,8 @@ type options struct {
 	runOptions                        []agent.RunOption
 	inferenceDuration                 time.Duration
 	inferenceDurationMu               sync.Mutex
+	inferenceTokenUsage               *model.Usage
+	inferenceTokenUsageMu             sync.Mutex
 }
 
 // newOptions creates a new options with the default values.
@@ -279,4 +283,22 @@ func (o *options) inferenceDurationValue() time.Duration {
 	o.inferenceDurationMu.Lock()
 	defer o.inferenceDurationMu.Unlock()
 	return o.inferenceDuration
+}
+
+func (o *options) addInferenceTokenUsage(usage *model.Usage) {
+	if o == nil || usage == nil {
+		return
+	}
+	o.inferenceTokenUsageMu.Lock()
+	o.inferenceTokenUsage = tokenusage.Add(o.inferenceTokenUsage, usage)
+	o.inferenceTokenUsageMu.Unlock()
+}
+
+func (o *options) inferenceTokenUsageValue() *model.Usage {
+	if o == nil {
+		return nil
+	}
+	o.inferenceTokenUsageMu.Lock()
+	defer o.inferenceTokenUsageMu.Unlock()
+	return tokenusage.Clone(o.inferenceTokenUsage)
 }

--- a/evaluation/options.go
+++ b/evaluation/options.go
@@ -12,7 +12,6 @@ package evaluation
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
@@ -26,7 +25,6 @@ import (
 	metricregistry "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/usersimulation"
-	"trpc.group/trpc-go/trpc-agent-go/model"
 	"trpc.group/trpc-go/trpc-agent-go/runner"
 )
 
@@ -57,10 +55,8 @@ type options struct {
 	runDetailsEnabled                 bool
 	runDetailsCollector               *runDetailsCollector
 	runOptions                        []agent.RunOption
-	inferenceDuration                 time.Duration
-	inferenceDurationMu               sync.Mutex
-	inferenceTokenUsage               *model.Usage
-	inferenceTokenUsageMu             sync.Mutex
+	inferenceStats                    *evalresult.InferenceStats
+	inferenceStatsMu                  sync.Mutex
 }
 
 // newOptions creates a new options with the default values.
@@ -267,38 +263,30 @@ func (o *options) validate(requireEvalService bool) error {
 	return nil
 }
 
-func (o *options) addInferenceDuration(elapsed time.Duration) {
-	if o == nil || elapsed <= 0 {
+func (o *options) addInferenceStats(stats *evalresult.InferenceStats) {
+	if o == nil || stats == nil || (stats.Duration <= 0 && stats.TokenUsage == nil) {
 		return
 	}
-	o.inferenceDurationMu.Lock()
-	o.inferenceDuration += elapsed
-	o.inferenceDurationMu.Unlock()
-}
-
-func (o *options) inferenceDurationValue() time.Duration {
-	if o == nil {
-		return 0
+	o.inferenceStatsMu.Lock()
+	defer o.inferenceStatsMu.Unlock()
+	if o.inferenceStats == nil {
+		o.inferenceStats = &evalresult.InferenceStats{}
 	}
-	o.inferenceDurationMu.Lock()
-	defer o.inferenceDurationMu.Unlock()
-	return o.inferenceDuration
+	o.inferenceStats.Duration += stats.Duration
+	o.inferenceStats.TokenUsage = tokenusage.Add(o.inferenceStats.TokenUsage, stats.TokenUsage)
 }
 
-func (o *options) addInferenceTokenUsage(usage *model.Usage) {
-	if o == nil || usage == nil {
-		return
-	}
-	o.inferenceTokenUsageMu.Lock()
-	o.inferenceTokenUsage = tokenusage.Add(o.inferenceTokenUsage, usage)
-	o.inferenceTokenUsageMu.Unlock()
-}
-
-func (o *options) inferenceTokenUsageValue() *model.Usage {
+func (o *options) inferenceStatsValue() *evalresult.InferenceStats {
 	if o == nil {
 		return nil
 	}
-	o.inferenceTokenUsageMu.Lock()
-	defer o.inferenceTokenUsageMu.Unlock()
-	return tokenusage.Clone(o.inferenceTokenUsage)
+	o.inferenceStatsMu.Lock()
+	defer o.inferenceStatsMu.Unlock()
+	if o.inferenceStats == nil {
+		return nil
+	}
+	return &evalresult.InferenceStats{
+		Duration:   o.inferenceStats.Duration,
+		TokenUsage: tokenusage.Clone(o.inferenceStats.TokenUsage),
+	}
 }

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -23,6 +23,7 @@ import (
 	metricregistry "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/service"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/usersimulation"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 type stubService struct{}
@@ -88,6 +89,18 @@ func TestOptionsInferenceDuration(t *testing.T) {
 	var nilOpts *options
 	nilOpts.addInferenceDuration(time.Second)
 	assert.Zero(t, nilOpts.inferenceDurationValue())
+}
+
+func TestOptionsInferenceTokenUsage(t *testing.T) {
+	opts := newOptions()
+	opts.addInferenceTokenUsage(&model.Usage{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5})
+	opts.addInferenceTokenUsage(&model.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18})
+	got := opts.inferenceTokenUsageValue()
+	assert.Equal(t, &model.Usage{PromptTokens: 9, CompletionTokens: 14, TotalTokens: 23}, got)
+
+	var nilOpts *options
+	nilOpts.addInferenceTokenUsage(&model.Usage{TotalTokens: 1})
+	assert.Nil(t, nilOpts.inferenceTokenUsageValue())
 }
 
 func TestWithEvalSetManager(t *testing.T) {

--- a/evaluation/options_test.go
+++ b/evaluation/options_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	evalresultinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult/inmemory"
 	evalsetinmemory "trpc.group/trpc-go/trpc-agent-go/evaluation/evalset/inmemory"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
@@ -78,29 +79,23 @@ func TestNewOptionsDefaults(t *testing.T) {
 	assert.False(t, opts.runDetailsEnabled)
 }
 
-func TestOptionsInferenceDuration(t *testing.T) {
+func TestOptionsInferenceStats(t *testing.T) {
 	opts := newOptions()
-	opts.addInferenceDuration(2 * time.Second)
-	opts.addInferenceDuration(3 * time.Second)
-	opts.addInferenceDuration(0)
-	opts.addInferenceDuration(-time.Second)
-	assert.Equal(t, 5*time.Second, opts.inferenceDurationValue())
+	opts.addInferenceStats(&evalresult.InferenceStats{Duration: 2 * time.Second})
+	opts.addInferenceStats(&evalresult.InferenceStats{Duration: 3 * time.Second})
+	opts.addInferenceStats(&evalresult.InferenceStats{})
+	got := opts.inferenceStatsValue()
+	assert.Equal(t, 5*time.Second, got.Duration)
 
 	var nilOpts *options
-	nilOpts.addInferenceDuration(time.Second)
-	assert.Zero(t, nilOpts.inferenceDurationValue())
-}
+	nilOpts.addInferenceStats(&evalresult.InferenceStats{Duration: time.Second})
+	assert.Nil(t, nilOpts.inferenceStatsValue())
 
-func TestOptionsInferenceTokenUsage(t *testing.T) {
-	opts := newOptions()
-	opts.addInferenceTokenUsage(&model.Usage{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5})
-	opts.addInferenceTokenUsage(&model.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18})
-	got := opts.inferenceTokenUsageValue()
-	assert.Equal(t, &model.Usage{PromptTokens: 9, CompletionTokens: 14, TotalTokens: 23}, got)
-
-	var nilOpts *options
-	nilOpts.addInferenceTokenUsage(&model.Usage{TotalTokens: 1})
-	assert.Nil(t, nilOpts.inferenceTokenUsageValue())
+	opts = newOptions()
+	opts.addInferenceStats(&evalresult.InferenceStats{TokenUsage: &model.Usage{PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5}})
+	opts.addInferenceStats(&evalresult.InferenceStats{TokenUsage: &model.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18}})
+	got = opts.inferenceStatsValue()
+	assert.Equal(t, &model.Usage{PromptTokens: 9, CompletionTokens: 14, TotalTokens: 23}, got.TokenUsage)
 }
 
 func TestWithEvalSetManager(t *testing.T) {

--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -20,6 +20,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	itoolmock "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/toolmock"
 	tokenusage "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/usage"
@@ -35,10 +36,8 @@ import (
 type Result struct {
 	Invocations     []*evalset.Invocation
 	ExecutionTraces []*trace.Trace
-	// InferenceDuration is the total time spent executing the target agent.
-	InferenceDuration time.Duration
-	// InferenceTokenUsage is the total token usage reported by the target agent.
-	InferenceTokenUsage *model.Usage
+	// InferenceStats contains resource measurements for the target agent.
+	InferenceStats *evalresult.InferenceStats
 }
 
 // Inference executes the agent against the provided invocations.
@@ -61,37 +60,33 @@ func Inference(
 	// Accumulate each invocation response.
 	responseInvocations := make([]*evalset.Invocation, 0, len(invocations))
 	executionTraces := make([]*trace.Trace, 0, len(invocations))
-	var inferenceDuration time.Duration
-	var inferenceTokenUsage *model.Usage
+	inferenceStats := &evalresult.InferenceStats{}
 	for _, invocation := range invocations {
 		startTime := time.Now()
 		responseInvocation, executionTrace, invocationTokenUsage, err := inferenceInvocationWithUsage(ctx, runner, sessionID, initialSession, invocation, runOptions, opts)
-		inferenceDuration += time.Since(startTime)
-		inferenceTokenUsage = tokenusage.Add(inferenceTokenUsage, invocationTokenUsage)
+		inferenceStats.Duration += time.Since(startTime)
+		inferenceStats.TokenUsage = tokenusage.Add(inferenceStats.TokenUsage, invocationTokenUsage)
 		if err != nil && responseInvocation == nil && executionTrace == nil {
 			return &Result{
-				Invocations:         responseInvocations,
-				ExecutionTraces:     executionTraces,
-				InferenceDuration:   inferenceDuration,
-				InferenceTokenUsage: inferenceTokenUsage,
+				Invocations:     responseInvocations,
+				ExecutionTraces: executionTraces,
+				InferenceStats:  inferenceStats,
 			}, err
 		}
 		responseInvocations = append(responseInvocations, responseInvocation)
 		executionTraces = append(executionTraces, executionTrace)
 		if err != nil {
 			return &Result{
-				Invocations:         responseInvocations,
-				ExecutionTraces:     executionTraces,
-				InferenceDuration:   inferenceDuration,
-				InferenceTokenUsage: inferenceTokenUsage,
+				Invocations:     responseInvocations,
+				ExecutionTraces: executionTraces,
+				InferenceStats:  inferenceStats,
 			}, err
 		}
 	}
 	return &Result{
-		Invocations:         responseInvocations,
-		ExecutionTraces:     executionTraces,
-		InferenceDuration:   inferenceDuration,
-		InferenceTokenUsage: inferenceTokenUsage,
+		Invocations:     responseInvocations,
+		ExecutionTraces: executionTraces,
+		InferenceStats:  inferenceStats,
 	}, nil
 }
 
@@ -130,12 +125,10 @@ func InferenceWithConversationScenario(
 	if conversation == nil {
 		return nil, errors.New("user simulator conversation is nil")
 	}
-	var inferenceDuration time.Duration
-	var inferenceTokenUsage *model.Usage
+	inferenceStats := &evalresult.InferenceStats{}
 	defer func() {
 		if result != nil {
-			result.InferenceDuration = inferenceDuration
-			result.InferenceTokenUsage = inferenceTokenUsage
+			result.InferenceStats = inferenceStats
 		}
 		closeErr := conversation.Close()
 		if closeErr != nil {
@@ -145,6 +138,7 @@ func InferenceWithConversationScenario(
 	result = &Result{
 		Invocations:     make([]*evalset.Invocation, 0),
 		ExecutionTraces: make([]*trace.Trace, 0),
+		InferenceStats:  inferenceStats,
 	}
 	var lastTargetResponse *model.Message
 	for {
@@ -172,8 +166,8 @@ func InferenceWithConversationScenario(
 		responseInvocation, executionTrace, invocationTokenUsage, nextErr := inferenceInvocationWithUsage(ctx, r, sessionID, initialSession, &evalset.Invocation{
 			UserContent: &userMessage,
 		}, runOptions, nil)
-		inferenceDuration += time.Since(startTime)
-		inferenceTokenUsage = tokenusage.Add(inferenceTokenUsage, invocationTokenUsage)
+		inferenceStats.Duration += time.Since(startTime)
+		inferenceStats.TokenUsage = tokenusage.Add(inferenceStats.TokenUsage, invocationTokenUsage)
 		if nextErr != nil {
 			return result, nextErr
 		}
@@ -183,7 +177,6 @@ func InferenceWithConversationScenario(
 		result.Invocations = append(result.Invocations, responseInvocation)
 		result.ExecutionTraces = append(result.ExecutionTraces, executionTrace)
 		lastTargetResponse = responseInvocation.FinalResponse
-		result.InferenceDuration = inferenceDuration
 	}
 }
 

--- a/evaluation/service/internal/inference/inference.go
+++ b/evaluation/service/internal/inference/inference.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	itoolmock "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/toolmock"
+	tokenusage "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/usage"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/toolmock"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/usersimulation"
 	"trpc.group/trpc-go/trpc-agent-go/event"
@@ -36,6 +37,8 @@ type Result struct {
 	ExecutionTraces []*trace.Trace
 	// InferenceDuration is the total time spent executing the target agent.
 	InferenceDuration time.Duration
+	// InferenceTokenUsage is the total token usage reported by the target agent.
+	InferenceTokenUsage *model.Usage
 }
 
 // Inference executes the agent against the provided invocations.
@@ -59,31 +62,36 @@ func Inference(
 	responseInvocations := make([]*evalset.Invocation, 0, len(invocations))
 	executionTraces := make([]*trace.Trace, 0, len(invocations))
 	var inferenceDuration time.Duration
+	var inferenceTokenUsage *model.Usage
 	for _, invocation := range invocations {
 		startTime := time.Now()
-		responseInvocation, executionTrace, err := inferenceInvocation(ctx, runner, sessionID, initialSession, invocation, runOptions, opts)
+		responseInvocation, executionTrace, invocationTokenUsage, err := inferenceInvocationWithUsage(ctx, runner, sessionID, initialSession, invocation, runOptions, opts)
 		inferenceDuration += time.Since(startTime)
+		inferenceTokenUsage = tokenusage.Add(inferenceTokenUsage, invocationTokenUsage)
 		if err != nil && responseInvocation == nil && executionTrace == nil {
 			return &Result{
-				Invocations:       responseInvocations,
-				ExecutionTraces:   executionTraces,
-				InferenceDuration: inferenceDuration,
+				Invocations:         responseInvocations,
+				ExecutionTraces:     executionTraces,
+				InferenceDuration:   inferenceDuration,
+				InferenceTokenUsage: inferenceTokenUsage,
 			}, err
 		}
 		responseInvocations = append(responseInvocations, responseInvocation)
 		executionTraces = append(executionTraces, executionTrace)
 		if err != nil {
 			return &Result{
-				Invocations:       responseInvocations,
-				ExecutionTraces:   executionTraces,
-				InferenceDuration: inferenceDuration,
+				Invocations:         responseInvocations,
+				ExecutionTraces:     executionTraces,
+				InferenceDuration:   inferenceDuration,
+				InferenceTokenUsage: inferenceTokenUsage,
 			}, err
 		}
 	}
 	return &Result{
-		Invocations:       responseInvocations,
-		ExecutionTraces:   executionTraces,
-		InferenceDuration: inferenceDuration,
+		Invocations:         responseInvocations,
+		ExecutionTraces:     executionTraces,
+		InferenceDuration:   inferenceDuration,
+		InferenceTokenUsage: inferenceTokenUsage,
 	}, nil
 }
 
@@ -123,9 +131,11 @@ func InferenceWithConversationScenario(
 		return nil, errors.New("user simulator conversation is nil")
 	}
 	var inferenceDuration time.Duration
+	var inferenceTokenUsage *model.Usage
 	defer func() {
 		if result != nil {
 			result.InferenceDuration = inferenceDuration
+			result.InferenceTokenUsage = inferenceTokenUsage
 		}
 		closeErr := conversation.Close()
 		if closeErr != nil {
@@ -159,10 +169,11 @@ func InferenceWithConversationScenario(
 			return result, fmt.Errorf("simulate next turn: invalid message role %q", userMessage.Role)
 		}
 		startTime := time.Now()
-		responseInvocation, executionTrace, nextErr := inferenceInvocation(ctx, r, sessionID, initialSession, &evalset.Invocation{
+		responseInvocation, executionTrace, invocationTokenUsage, nextErr := inferenceInvocationWithUsage(ctx, r, sessionID, initialSession, &evalset.Invocation{
 			UserContent: &userMessage,
 		}, runOptions, nil)
 		inferenceDuration += time.Since(startTime)
+		inferenceTokenUsage = tokenusage.Add(inferenceTokenUsage, invocationTokenUsage)
 		if nextErr != nil {
 			return result, nextErr
 		}
@@ -186,19 +197,34 @@ func inferenceInvocation(
 	runOptions []agent.RunOption,
 	opts *options,
 ) (*evalset.Invocation, *trace.Trace, error) {
+	responseInvocation, executionTrace, _, err := inferenceInvocationWithUsage(
+		ctx, r, sessionID, initialSession, invocation, runOptions, opts,
+	)
+	return responseInvocation, executionTrace, err
+}
+
+func inferenceInvocationWithUsage(
+	ctx context.Context,
+	r runner.Runner,
+	sessionID string,
+	initialSession *evalset.SessionInput,
+	invocation *evalset.Invocation,
+	runOptions []agent.RunOption,
+	opts *options,
+) (*evalset.Invocation, *trace.Trace, *model.Usage, error) {
 	if invocation.UserContent == nil {
-		return nil, nil, fmt.Errorf("invocation user content is nil for eval case invocation %q", invocation.InvocationID)
+		return nil, nil, nil, fmt.Errorf("invocation user content is nil for eval case invocation %q", invocation.InvocationID)
 	}
 	mergedOpts := make([]agent.RunOption, 0, 1+len(runOptions))
 	mergedOpts = append(mergedOpts, runOptions...)
 	toolMockEntries, err := selectToolMockEntries(invocation, opts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if len(toolMockEntries) > 0 {
 		toolMockPlugin, err := buildToolMockPlugin(toolMockEntries, opts.toolMockRunner)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		mergedOpts = append(mergedOpts, plugin.WithPlugins(toolMockPlugin))
 	}
@@ -213,22 +239,26 @@ func inferenceInvocation(
 		mergedOpts...,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("runner run: %w", err)
+		return nil, nil, nil, fmt.Errorf("runner run: %w", err)
 	}
 	// Capture the invocation ID, final response, tool uses, and tool responses.
 	var (
-		invocationID   string
-		finalResponse  *model.Message
-		finalByInvID   = make(map[string]*model.Message)
-		fallbackFinal  *model.Message
-		executionTrace *trace.Trace
-		eventErr       error
-		tools          = make([]*evalset.Tool, 0)
-		toolIDIdx      = make(map[string]int)
+		invocationID        string
+		finalResponse       *model.Message
+		finalByInvID        = make(map[string]*model.Message)
+		fallbackFinal       *model.Message
+		executionTrace      *trace.Trace
+		inferenceTokenUsage *model.Usage
+		eventErr            error
+		tools               = make([]*evalset.Tool, 0)
+		toolIDIdx           = make(map[string]int)
 	)
 	for event := range events {
 		if event == nil {
 			continue
+		}
+		if event.Response != nil && !event.Response.IsPartial {
+			inferenceTokenUsage = tokenusage.Add(inferenceTokenUsage, event.Response.Usage)
 		}
 		if event.IsRunnerCompletion() {
 			if event.InvocationID != "" {
@@ -286,6 +316,9 @@ func inferenceInvocation(
 	if finalResponse == nil {
 		finalResponse = fallbackFinal
 	}
+	if inferenceTokenUsage == nil && executionTrace != nil {
+		inferenceTokenUsage = tokenusage.Add(nil, executionTrace.Usage)
+	}
 	result := &evalset.Invocation{
 		InvocationID:  invocationID,
 		UserContent:   invocation.UserContent,
@@ -293,9 +326,9 @@ func inferenceInvocation(
 		Tools:         tools,
 	}
 	if eventErr != nil {
-		return result, executionTrace, eventErr
+		return result, executionTrace, inferenceTokenUsage, eventErr
 	}
-	return result, executionTrace, nil
+	return result, executionTrace, inferenceTokenUsage, nil
 }
 
 func buildToolMockPlugin(entries []*toolmock.Tool, toolMockRunner runner.Runner) (plugin.Plugin, error) {

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -612,6 +612,64 @@ func TestInferenceTracksInferenceDuration(t *testing.T) {
 	assert.GreaterOrEqual(t, result.InferenceDuration, delay)
 }
 
+func TestInferenceCollectsInferenceTokenUsage(t *testing.T) {
+	usage1 := &model.Usage{
+		PromptTokens:     11,
+		CompletionTokens: 7,
+		TotalTokens:      18,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CachedTokens: 3,
+		},
+		CompletionTokensDetails: model.CompletionTokensDetails{
+			ReasoningTokens: 2,
+		},
+	}
+	usage2 := &model.Usage{
+		PromptTokens:     13,
+		CompletionTokens: 5,
+		TotalTokens:      18,
+		PromptTokensDetails: model.PromptTokensDetails{
+			CacheReadTokens: 4,
+		},
+	}
+	r := &fakeRunner{
+		eventRuns: [][]*event.Event{
+			{makePartialEventWithUsage(usage1), makeFinalEventWithUsage("answer-1", usage1), makeRunnerCompletionEvent("generated-inv-1", nil)},
+			{makeFinalEventWithUsage("answer-2", usage2), makeRunnerCompletionEvent("generated-inv-2", nil)},
+		},
+	}
+	result, err := Inference(context.Background(), r, []*evalset.Invocation{
+		{UserContent: &model.Message{Role: model.RoleUser, Content: "question-1"}},
+		{UserContent: &model.Message{Role: model.RoleUser, Content: "question-2"}},
+	}, &evalset.SessionInput{UserID: "user"}, "session", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.InferenceTokenUsage)
+	assert.Equal(t, 24, result.InferenceTokenUsage.PromptTokens)
+	assert.Equal(t, 12, result.InferenceTokenUsage.CompletionTokens)
+	assert.Equal(t, 36, result.InferenceTokenUsage.TotalTokens)
+	assert.Equal(t, 3, result.InferenceTokenUsage.PromptTokensDetails.CachedTokens)
+	assert.Equal(t, 4, result.InferenceTokenUsage.PromptTokensDetails.CacheReadTokens)
+	assert.Equal(t, 2, result.InferenceTokenUsage.CompletionTokensDetails.ReasoningTokens)
+}
+
+func TestInferenceFallsBackToExecutionTraceTokenUsage(t *testing.T) {
+	traceUsage := &model.Usage{PromptTokens: 4, CompletionTokens: 3, TotalTokens: 7}
+	r := &fakeRunner{
+		eventRuns: [][]*event.Event{{
+			makeFinalEvent("answer"),
+			makeRunnerCompletionEvent("generated-inv", &trace.Trace{Usage: traceUsage}),
+		}},
+	}
+	result, err := Inference(context.Background(), r, []*evalset.Invocation{{
+		UserContent: &model.Message{Role: model.RoleUser, Content: "question"},
+	}}, &evalset.SessionInput{UserID: "user"}, "session", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, traceUsage, result.InferenceTokenUsage)
+	require.NotSame(t, traceUsage, result.InferenceTokenUsage)
+}
+
 func TestInference_CollectsExecutionTracesInInvocationOrder(t *testing.T) {
 	trace1 := &trace.Trace{RootInvocationID: "root-1", RootAgentName: "assistant-1"}
 	trace2 := &trace.Trace{RootInvocationID: "root-2", RootAgentName: "assistant-2"}
@@ -1492,6 +1550,16 @@ func makeFinalEvent(content string) *event.Event {
 			},
 		},
 	}
+}
+
+func makeFinalEventWithUsage(content string, usage *model.Usage) *event.Event {
+	event := makeFinalEvent(content)
+	event.Response.Usage = usage
+	return event
+}
+
+func makePartialEventWithUsage(usage *model.Usage) *event.Event {
+	return &event.Event{Response: &model.Response{IsPartial: true, Usage: usage}}
 }
 
 func makeRunnerCompletionEvent(invocationID string, executionTrace *trace.Trace) *event.Event {

--- a/evaluation/service/internal/inference/inference_test.go
+++ b/evaluation/service/internal/inference/inference_test.go
@@ -609,7 +609,7 @@ func TestInferenceTracksInferenceDuration(t *testing.T) {
 	}}, &evalset.SessionInput{UserID: "user"}, "session", nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.GreaterOrEqual(t, result.InferenceDuration, delay)
+	assert.GreaterOrEqual(t, result.InferenceStats.Duration, delay)
 }
 
 func TestInferenceCollectsInferenceTokenUsage(t *testing.T) {
@@ -644,13 +644,14 @@ func TestInferenceCollectsInferenceTokenUsage(t *testing.T) {
 	}, &evalset.SessionInput{UserID: "user"}, "session", nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.NotNil(t, result.InferenceTokenUsage)
-	assert.Equal(t, 24, result.InferenceTokenUsage.PromptTokens)
-	assert.Equal(t, 12, result.InferenceTokenUsage.CompletionTokens)
-	assert.Equal(t, 36, result.InferenceTokenUsage.TotalTokens)
-	assert.Equal(t, 3, result.InferenceTokenUsage.PromptTokensDetails.CachedTokens)
-	assert.Equal(t, 4, result.InferenceTokenUsage.PromptTokensDetails.CacheReadTokens)
-	assert.Equal(t, 2, result.InferenceTokenUsage.CompletionTokensDetails.ReasoningTokens)
+	require.NotNil(t, result.InferenceStats)
+	require.NotNil(t, result.InferenceStats.TokenUsage)
+	assert.Equal(t, 24, result.InferenceStats.TokenUsage.PromptTokens)
+	assert.Equal(t, 12, result.InferenceStats.TokenUsage.CompletionTokens)
+	assert.Equal(t, 36, result.InferenceStats.TokenUsage.TotalTokens)
+	assert.Equal(t, 3, result.InferenceStats.TokenUsage.PromptTokensDetails.CachedTokens)
+	assert.Equal(t, 4, result.InferenceStats.TokenUsage.PromptTokensDetails.CacheReadTokens)
+	assert.Equal(t, 2, result.InferenceStats.TokenUsage.CompletionTokensDetails.ReasoningTokens)
 }
 
 func TestInferenceFallsBackToExecutionTraceTokenUsage(t *testing.T) {
@@ -666,8 +667,9 @@ func TestInferenceFallsBackToExecutionTraceTokenUsage(t *testing.T) {
 	}}, &evalset.SessionInput{UserID: "user"}, "session", nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, traceUsage, result.InferenceTokenUsage)
-	require.NotSame(t, traceUsage, result.InferenceTokenUsage)
+	require.NotNil(t, result.InferenceStats)
+	require.Equal(t, traceUsage, result.InferenceStats.TokenUsage)
+	require.NotSame(t, traceUsage, result.InferenceStats.TokenUsage)
 }
 
 func TestInference_CollectsExecutionTracesInInvocationOrder(t *testing.T) {
@@ -1284,7 +1286,7 @@ func TestInferenceWithConversationScenarioInferenceError(t *testing.T) {
 	)
 	assert.Error(t, err)
 	require.NotNil(t, result)
-	assert.GreaterOrEqual(t, result.InferenceDuration, delay)
+	assert.GreaterOrEqual(t, result.InferenceStats.Duration, delay)
 	assert.True(t, conv.closed)
 }
 

--- a/evaluation/service/local/inference.go
+++ b/evaluation/service/local/inference.go
@@ -277,6 +277,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 			result.Inferences = inferenceResult.Invocations
 			result.ExecutionTraces = inferenceResult.ExecutionTraces
 			result.InferenceDuration = inferenceResult.InferenceDuration
+			result.InferenceTokenUsage = inferenceResult.InferenceTokenUsage
 		}
 		attachContextMessages(expectedInferences, evalCase.ContextMessages)
 		result.ExpectedInferences = expectedInferences
@@ -319,6 +320,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 	if inferenceResult != nil {
 		result.ExecutionTraces = inferenceResult.ExecutionTraces
 		result.InferenceDuration = inferenceResult.InferenceDuration
+		result.InferenceTokenUsage = inferenceResult.InferenceTokenUsage
 		attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 		result.Inferences = inferenceResult.Invocations
 	}

--- a/evaluation/service/local/inference.go
+++ b/evaluation/service/local/inference.go
@@ -276,8 +276,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 			attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 			result.Inferences = inferenceResult.Invocations
 			result.ExecutionTraces = inferenceResult.ExecutionTraces
-			result.InferenceDuration = inferenceResult.InferenceDuration
-			result.InferenceTokenUsage = inferenceResult.InferenceTokenUsage
+			result.InferenceStats = inferenceResult.InferenceStats
 		}
 		attachContextMessages(expectedInferences, evalCase.ContextMessages)
 		result.ExpectedInferences = expectedInferences
@@ -319,8 +318,7 @@ func (s *local) inferenceEvalCase(ctx context.Context, req *service.InferenceReq
 	)
 	if inferenceResult != nil {
 		result.ExecutionTraces = inferenceResult.ExecutionTraces
-		result.InferenceDuration = inferenceResult.InferenceDuration
-		result.InferenceTokenUsage = inferenceResult.InferenceTokenUsage
+		result.InferenceStats = inferenceResult.InferenceStats
 		attachContextMessages(inferenceResult.Invocations, evalCase.ContextMessages)
 		result.Inferences = inferenceResult.Invocations
 	}

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -256,55 +256,23 @@ func (s *local) Evaluate(ctx context.Context, req *service.EvaluateRequest, opt 
 		return nil, fmt.Errorf("evaluate case results (app=%s, evalSetID=%s): %w", req.AppName, req.EvalSetID, err)
 	}
 	runResult = &service.EvalSetRunResult{
-		AppName:             req.AppName,
-		EvalSetID:           req.EvalSetID,
-		InferenceDuration:   inferenceDurationForInferenceResults(req.InferenceResults),
-		InferenceTokenUsage: inferenceTokenUsageForInferenceResults(req.InferenceResults),
-		EvalCaseResults:     evalCaseResults,
+		AppName:         req.AppName,
+		EvalSetID:       req.EvalSetID,
+		InferenceStats:  inferenceStatsForInferenceResults(req.InferenceResults),
+		EvalCaseResults: evalCaseResults,
 	}
 	return runResult, nil
 }
 
-func inferenceDurationForInferenceResults(results []*service.InferenceResult) time.Duration {
-	var elapsed time.Duration
+func inferenceStatsForInferenceResults(results []*service.InferenceResult) *evalresult.InferenceStats {
+	var total *evalresult.InferenceStats
 	for _, result := range results {
-		elapsed += inferenceDurationForInferenceResult(result)
-	}
-	return elapsed
-}
-
-func inferenceDurationForInferenceResult(result *service.InferenceResult) time.Duration {
-	if result == nil {
-		return 0
-	}
-	// Trace-mode cases replay recorded invocations without executing the agent.
-	if result.EvalMode == evalset.EvalModeTrace {
-		return 0
-	}
-	if result.InferenceDuration > 0 {
-		return result.InferenceDuration
-	}
-	var elapsed time.Duration
-	for _, executionTrace := range result.ExecutionTraces {
-		if executionTrace == nil || executionTrace.StartedAt.IsZero() || executionTrace.EndedAt.IsZero() {
-			continue
-		}
-		if duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt); duration > 0 {
-			elapsed += duration
-		}
-	}
-	return elapsed
-}
-
-func inferenceTokenUsageForInferenceResults(results []*service.InferenceResult) *model.Usage {
-	var total *model.Usage
-	for _, result := range results {
-		total = tokenusage.Add(total, inferenceTokenUsageForInferenceResult(result))
+		total = addInferenceStats(total, inferenceStatsForInferenceResult(result))
 	}
 	return total
 }
 
-func inferenceTokenUsageForInferenceResult(result *service.InferenceResult) *model.Usage {
+func inferenceStatsForInferenceResult(result *service.InferenceResult) *evalresult.InferenceStats {
 	if result == nil {
 		return nil
 	}
@@ -312,16 +280,43 @@ func inferenceTokenUsageForInferenceResult(result *service.InferenceResult) *mod
 	if result.EvalMode == evalset.EvalModeTrace {
 		return nil
 	}
-	if result.InferenceTokenUsage != nil {
-		return tokenusage.Add(nil, result.InferenceTokenUsage)
+	stats := &evalresult.InferenceStats{}
+	if result.InferenceStats != nil {
+		stats.Duration = result.InferenceStats.Duration
+		stats.TokenUsage = tokenusage.Clone(result.InferenceStats.TokenUsage)
 	}
-	var total *model.Usage
-	for _, executionTrace := range result.ExecutionTraces {
-		if executionTrace == nil {
-			continue
+	if stats.Duration <= 0 {
+		for _, executionTrace := range result.ExecutionTraces {
+			if executionTrace == nil || executionTrace.StartedAt.IsZero() || executionTrace.EndedAt.IsZero() {
+				continue
+			}
+			if duration := executionTrace.EndedAt.Sub(executionTrace.StartedAt); duration > 0 {
+				stats.Duration += duration
+			}
 		}
-		total = tokenusage.Add(total, executionTrace.Usage)
 	}
+	if stats.TokenUsage == nil {
+		for _, executionTrace := range result.ExecutionTraces {
+			if executionTrace != nil {
+				stats.TokenUsage = tokenusage.Add(stats.TokenUsage, executionTrace.Usage)
+			}
+		}
+	}
+	if stats.Duration <= 0 && stats.TokenUsage == nil {
+		return nil
+	}
+	return stats
+}
+
+func addInferenceStats(total, stats *evalresult.InferenceStats) *evalresult.InferenceStats {
+	if stats == nil {
+		return total
+	}
+	if total == nil {
+		total = &evalresult.InferenceStats{}
+	}
+	total.Duration += stats.Duration
+	total.TokenUsage = tokenusage.Add(total.TokenUsage, stats.TokenUsage)
 	return total
 }
 
@@ -437,14 +432,13 @@ func (s *local) evaluateCase(ctx context.Context, req *service.EvaluateRequest, 
 
 func (s *local) failedEvalCaseResult(evalSetID string, inferenceResult *service.InferenceResult, errorMessage string) *evalresult.EvalCaseResult {
 	return &evalresult.EvalCaseResult{
-		EvalSetID:           evalSetID,
-		EvalID:              inferenceResult.EvalCaseID,
-		FinalEvalStatus:     evalstatus.EvalStatusFailed,
-		ErrorMessage:        errorMessage,
-		SessionID:           inferenceResult.SessionID,
-		UserID:              inferenceResult.UserID,
-		InferenceDuration:   inferenceDurationForInferenceResult(inferenceResult),
-		InferenceTokenUsage: inferenceTokenUsageForInferenceResult(inferenceResult),
+		EvalSetID:       evalSetID,
+		EvalID:          inferenceResult.EvalCaseID,
+		FinalEvalStatus: evalstatus.EvalStatusFailed,
+		ErrorMessage:    errorMessage,
+		SessionID:       inferenceResult.SessionID,
+		UserID:          inferenceResult.UserID,
+		InferenceStats:  inferenceStatsForInferenceResult(inferenceResult),
 	}
 }
 
@@ -605,8 +599,7 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 		EvalMetricResultPerInvocation: perInvocation,
 		SessionID:                     inferenceResult.SessionID,
 		UserID:                        inputs.userID,
-		InferenceDuration:             inferenceDurationForInferenceResult(inferenceResult),
-		InferenceTokenUsage:           inferenceTokenUsageForInferenceResult(inferenceResult),
+		InferenceStats:                inferenceStatsForInferenceResult(inferenceResult),
 	}, nil
 }
 

--- a/evaluation/service/local/local.go
+++ b/evaluation/service/local/local.go
@@ -30,6 +30,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evaluator/registry"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/callback"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/internal/clone"
+	tokenusage "trpc.group/trpc-go/trpc-agent-go/evaluation/internal/usage"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion"
 	criterionllm "trpc.group/trpc-go/trpc-agent-go/evaluation/metric/criterion/llm"
@@ -255,10 +256,11 @@ func (s *local) Evaluate(ctx context.Context, req *service.EvaluateRequest, opt 
 		return nil, fmt.Errorf("evaluate case results (app=%s, evalSetID=%s): %w", req.AppName, req.EvalSetID, err)
 	}
 	runResult = &service.EvalSetRunResult{
-		AppName:           req.AppName,
-		EvalSetID:         req.EvalSetID,
-		InferenceDuration: inferenceDurationForInferenceResults(req.InferenceResults),
-		EvalCaseResults:   evalCaseResults,
+		AppName:             req.AppName,
+		EvalSetID:           req.EvalSetID,
+		InferenceDuration:   inferenceDurationForInferenceResults(req.InferenceResults),
+		InferenceTokenUsage: inferenceTokenUsageForInferenceResults(req.InferenceResults),
+		EvalCaseResults:     evalCaseResults,
 	}
 	return runResult, nil
 }
@@ -292,6 +294,35 @@ func inferenceDurationForInferenceResult(result *service.InferenceResult) time.D
 		}
 	}
 	return elapsed
+}
+
+func inferenceTokenUsageForInferenceResults(results []*service.InferenceResult) *model.Usage {
+	var total *model.Usage
+	for _, result := range results {
+		total = tokenusage.Add(total, inferenceTokenUsageForInferenceResult(result))
+	}
+	return total
+}
+
+func inferenceTokenUsageForInferenceResult(result *service.InferenceResult) *model.Usage {
+	if result == nil {
+		return nil
+	}
+	// Trace-mode cases replay recorded invocations without executing the agent.
+	if result.EvalMode == evalset.EvalModeTrace {
+		return nil
+	}
+	if result.InferenceTokenUsage != nil {
+		return tokenusage.Add(nil, result.InferenceTokenUsage)
+	}
+	var total *model.Usage
+	for _, executionTrace := range result.ExecutionTraces {
+		if executionTrace == nil {
+			continue
+		}
+		total = tokenusage.Add(total, executionTrace.Usage)
+	}
+	return total
 }
 
 func (s *local) resolveMetricExtensions(
@@ -406,13 +437,14 @@ func (s *local) evaluateCase(ctx context.Context, req *service.EvaluateRequest, 
 
 func (s *local) failedEvalCaseResult(evalSetID string, inferenceResult *service.InferenceResult, errorMessage string) *evalresult.EvalCaseResult {
 	return &evalresult.EvalCaseResult{
-		EvalSetID:         evalSetID,
-		EvalID:            inferenceResult.EvalCaseID,
-		FinalEvalStatus:   evalstatus.EvalStatusFailed,
-		ErrorMessage:      errorMessage,
-		SessionID:         inferenceResult.SessionID,
-		UserID:            inferenceResult.UserID,
-		InferenceDuration: inferenceDurationForInferenceResult(inferenceResult),
+		EvalSetID:           evalSetID,
+		EvalID:              inferenceResult.EvalCaseID,
+		FinalEvalStatus:     evalstatus.EvalStatusFailed,
+		ErrorMessage:        errorMessage,
+		SessionID:           inferenceResult.SessionID,
+		UserID:              inferenceResult.UserID,
+		InferenceDuration:   inferenceDurationForInferenceResult(inferenceResult),
+		InferenceTokenUsage: inferenceTokenUsageForInferenceResult(inferenceResult),
 	}
 }
 
@@ -574,6 +606,7 @@ func (s *local) evaluatePerCase(ctx context.Context, inferenceResult *service.In
 		SessionID:                     inferenceResult.SessionID,
 		UserID:                        inputs.userID,
 		InferenceDuration:             inferenceDurationForInferenceResult(inferenceResult),
+		InferenceTokenUsage:           inferenceTokenUsageForInferenceResult(inferenceResult),
 	}, nil
 }
 

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -1700,6 +1700,7 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	actual := makeActualInvocation("generated", "calc add 1 2", "calc result: 3")
 	inference := makeInferenceResult(appName, evalSetID, caseID, "session-xyz", []*evalset.Invocation{actual})
 	inference.InferenceDuration = 42 * time.Millisecond
+	inference.InferenceTokenUsage = &model.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
 	req := &service.EvaluateRequest{
 		AppName:          appName,
 		EvalSetID:        evalSetID,
@@ -1716,9 +1717,11 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, evalSetID, result.EvalSetID)
 	assert.Len(t, result.EvalCaseResults, 1)
 	assert.Equal(t, 42*time.Millisecond, result.InferenceDuration)
+	assert.Equal(t, inference.InferenceTokenUsage, result.InferenceTokenUsage)
 
 	caseResult := result.EvalCaseResults[0]
 	assert.Equal(t, 42*time.Millisecond, caseResult.InferenceDuration)
+	assert.Equal(t, inference.InferenceTokenUsage, caseResult.InferenceTokenUsage)
 	assert.Equal(t, caseID, caseResult.EvalID)
 	assert.Equal(t, status.EvalStatusPassed, caseResult.FinalEvalStatus)
 	assert.Len(t, caseResult.OverallEvalMetricResults, 1)
@@ -1757,6 +1760,34 @@ func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
 			{StartedAt: start.Add(10 * time.Millisecond), EndedAt: start.Add(5 * time.Millisecond)},
 		},
 	}))
+}
+
+func TestInferenceTokenUsageForInferenceResultFallbacks(t *testing.T) {
+	assert.Nil(t, inferenceTokenUsageForInferenceResult(nil))
+	explicit := &model.Usage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5}
+	got := inferenceTokenUsageForInferenceResult(&service.InferenceResult{
+		InferenceTokenUsage: explicit,
+	})
+	assert.Equal(t, explicit, got)
+	assert.NotSame(t, explicit, got)
+
+	assert.Nil(t, inferenceTokenUsageForInferenceResult(&service.InferenceResult{
+		EvalMode: evalset.EvalModeTrace,
+		InferenceTokenUsage: &model.Usage{
+			TotalTokens: 5,
+		},
+	}))
+
+	got = inferenceTokenUsageForInferenceResult(&service.InferenceResult{
+		ExecutionTraces: []*agenttrace.Trace{
+			{Usage: &model.Usage{PromptTokens: 4, CompletionTokens: 1, TotalTokens: 5}},
+			{Usage: &model.Usage{PromptTokens: 6, CompletionTokens: 2, TotalTokens: 8}},
+		},
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, 10, got.PromptTokens)
+	assert.Equal(t, 3, got.CompletionTokens)
+	assert.Equal(t, 13, got.TotalTokens)
 }
 
 func TestLocalEvaluateParallelEvaluationPreservesOrder(t *testing.T) {

--- a/evaluation/service/local/local_test.go
+++ b/evaluation/service/local/local_test.go
@@ -1699,8 +1699,10 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	svc := newLocalService(t, &fakeRunner{}, mgr, reg, "session-xyz")
 	actual := makeActualInvocation("generated", "calc add 1 2", "calc result: 3")
 	inference := makeInferenceResult(appName, evalSetID, caseID, "session-xyz", []*evalset.Invocation{actual})
-	inference.InferenceDuration = 42 * time.Millisecond
-	inference.InferenceTokenUsage = &model.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
+	inference.InferenceStats = &evalresult.InferenceStats{
+		Duration:   42 * time.Millisecond,
+		TokenUsage: &model.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+	}
 	req := &service.EvaluateRequest{
 		AppName:          appName,
 		EvalSetID:        evalSetID,
@@ -1716,12 +1718,12 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, appName, result.AppName)
 	assert.Equal(t, evalSetID, result.EvalSetID)
 	assert.Len(t, result.EvalCaseResults, 1)
-	assert.Equal(t, 42*time.Millisecond, result.InferenceDuration)
-	assert.Equal(t, inference.InferenceTokenUsage, result.InferenceTokenUsage)
+	assert.Equal(t, 42*time.Millisecond, result.InferenceStats.Duration)
+	assert.Equal(t, inference.InferenceStats, result.InferenceStats)
 
 	caseResult := result.EvalCaseResults[0]
-	assert.Equal(t, 42*time.Millisecond, caseResult.InferenceDuration)
-	assert.Equal(t, inference.InferenceTokenUsage, caseResult.InferenceTokenUsage)
+	assert.Equal(t, 42*time.Millisecond, caseResult.InferenceStats.Duration)
+	assert.Equal(t, inference.InferenceStats, caseResult.InferenceStats)
 	assert.Equal(t, caseID, caseResult.EvalID)
 	assert.Equal(t, status.EvalStatusPassed, caseResult.FinalEvalStatus)
 	assert.Len(t, caseResult.OverallEvalMetricResults, 1)
@@ -1738,56 +1740,57 @@ func TestLocalEvaluateSuccess(t *testing.T) {
 	assert.Equal(t, "demo-user", caseResult.UserID)
 }
 
-func TestInferenceDurationForInferenceResultFallbacks(t *testing.T) {
+func TestInferenceStatsForInferenceResultDurationFallbacks(t *testing.T) {
 	start := time.Now()
-	assert.Zero(t, inferenceDurationForInferenceResult(nil))
-	assert.Equal(t, 42*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
-		InferenceDuration: 42 * time.Millisecond,
-	}))
-	assert.Zero(t, inferenceDurationForInferenceResult(&service.InferenceResult{
-		EvalMode:          evalset.EvalModeTrace,
-		InferenceDuration: 42 * time.Millisecond,
+	assert.Nil(t, inferenceStatsForInferenceResult(nil))
+	assert.Equal(t, 42*time.Millisecond, inferenceStatsForInferenceResult(&service.InferenceResult{
+		InferenceStats: &evalresult.InferenceStats{Duration: 42 * time.Millisecond},
+	}).Duration)
+	assert.Nil(t, inferenceStatsForInferenceResult(&service.InferenceResult{
+		EvalMode:       evalset.EvalModeTrace,
+		InferenceStats: &evalresult.InferenceStats{Duration: 42 * time.Millisecond},
 		ExecutionTraces: []*agenttrace.Trace{{
 			StartedAt: start,
 			EndedAt:   start.Add(time.Second),
 		}},
 	}))
-	assert.Equal(t, 5*time.Millisecond, inferenceDurationForInferenceResult(&service.InferenceResult{
+	assert.Equal(t, 5*time.Millisecond, inferenceStatsForInferenceResult(&service.InferenceResult{
 		ExecutionTraces: []*agenttrace.Trace{
 			nil,
 			{},
 			{StartedAt: start, EndedAt: start.Add(5 * time.Millisecond)},
 			{StartedAt: start.Add(10 * time.Millisecond), EndedAt: start.Add(5 * time.Millisecond)},
 		},
-	}))
+	}).Duration)
 }
 
-func TestInferenceTokenUsageForInferenceResultFallbacks(t *testing.T) {
-	assert.Nil(t, inferenceTokenUsageForInferenceResult(nil))
+func TestInferenceStatsForInferenceResultTokenUsageFallbacks(t *testing.T) {
+	assert.Nil(t, inferenceStatsForInferenceResult(nil))
 	explicit := &model.Usage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5}
-	got := inferenceTokenUsageForInferenceResult(&service.InferenceResult{
-		InferenceTokenUsage: explicit,
+	got := inferenceStatsForInferenceResult(&service.InferenceResult{
+		InferenceStats: &evalresult.InferenceStats{TokenUsage: explicit},
 	})
-	assert.Equal(t, explicit, got)
-	assert.NotSame(t, explicit, got)
+	assert.Equal(t, explicit, got.TokenUsage)
+	assert.NotSame(t, explicit, got.TokenUsage)
 
-	assert.Nil(t, inferenceTokenUsageForInferenceResult(&service.InferenceResult{
+	assert.Nil(t, inferenceStatsForInferenceResult(&service.InferenceResult{
 		EvalMode: evalset.EvalModeTrace,
-		InferenceTokenUsage: &model.Usage{
+		InferenceStats: &evalresult.InferenceStats{TokenUsage: &model.Usage{
 			TotalTokens: 5,
+		},
 		},
 	}))
 
-	got = inferenceTokenUsageForInferenceResult(&service.InferenceResult{
+	got = inferenceStatsForInferenceResult(&service.InferenceResult{
 		ExecutionTraces: []*agenttrace.Trace{
 			{Usage: &model.Usage{PromptTokens: 4, CompletionTokens: 1, TotalTokens: 5}},
 			{Usage: &model.Usage{PromptTokens: 6, CompletionTokens: 2, TotalTokens: 8}},
 		},
 	})
 	require.NotNil(t, got)
-	assert.Equal(t, 10, got.PromptTokens)
-	assert.Equal(t, 3, got.CompletionTokens)
-	assert.Equal(t, 13, got.TotalTokens)
+	assert.Equal(t, 10, got.TokenUsage.PromptTokens)
+	assert.Equal(t, 3, got.TokenUsage.CompletionTokens)
+	assert.Equal(t, 13, got.TokenUsage.TotalTokens)
 }
 
 func TestLocalEvaluateParallelEvaluationPreservesOrder(t *testing.T) {

--- a/evaluation/service/service.go
+++ b/evaluation/service/service.go
@@ -19,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // Service defines the interface that an evaluation service must satisfy.
@@ -68,6 +69,8 @@ type InferenceResult struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 	// InferenceDuration is the total time spent executing the actual agent for this eval case.
 	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
+	// InferenceTokenUsage is the total token usage reported by the actual agent for this eval case.
+	InferenceTokenUsage *model.Usage `json:"inferenceTokenUsage,omitempty"`
 	// ExecutionTraces contains the per-run execution traces collected during inference.
 	ExecutionTraces []*trace.Trace `json:"-"`
 }
@@ -98,6 +101,8 @@ type EvalSetRunResult struct {
 	EvalSetID string `json:"evalSetId,omitempty"`
 	// InferenceDuration is the total time spent executing the actual agent for this run.
 	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
+	// InferenceTokenUsage is the total token usage reported by the actual agent for this run.
+	InferenceTokenUsage *model.Usage `json:"inferenceTokenUsage,omitempty"`
 	// EvalCaseResults are the evaluation results produced in this run.
 	EvalCaseResults []*evalresult.EvalCaseResult `json:"evalCaseResults,omitempty"`
 }

--- a/evaluation/service/service.go
+++ b/evaluation/service/service.go
@@ -12,14 +12,12 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent/trace"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
-	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 // Service defines the interface that an evaluation service must satisfy.
@@ -67,10 +65,8 @@ type InferenceResult struct {
 	Status status.EvalStatus `json:"status,omitempty"`
 	// ErrorMessage contains the error message if inference failed.
 	ErrorMessage string `json:"errorMessage,omitempty"`
-	// InferenceDuration is the total time spent executing the actual agent for this eval case.
-	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
-	// InferenceTokenUsage is the total token usage reported by the actual agent for this eval case.
-	InferenceTokenUsage *model.Usage `json:"inferenceTokenUsage,omitempty"`
+	// InferenceStats contains resource measurements for the actual agent for this eval case.
+	InferenceStats *evalresult.InferenceStats `json:"inferenceStats,omitempty"`
 	// ExecutionTraces contains the per-run execution traces collected during inference.
 	ExecutionTraces []*trace.Trace `json:"-"`
 }
@@ -99,10 +95,8 @@ type EvalSetRunResult struct {
 	AppName string `json:"appName,omitempty"`
 	// EvalSetID is the ID of the eval set.
 	EvalSetID string `json:"evalSetId,omitempty"`
-	// InferenceDuration is the total time spent executing the actual agent for this run.
-	InferenceDuration time.Duration `json:"inferenceDuration,omitempty"`
-	// InferenceTokenUsage is the total token usage reported by the actual agent for this run.
-	InferenceTokenUsage *model.Usage `json:"inferenceTokenUsage,omitempty"`
+	// InferenceStats contains resource measurements for the actual agent for this run.
+	InferenceStats *evalresult.InferenceStats `json:"inferenceStats,omitempty"`
 	// EvalCaseResults are the evaluation results produced in this run.
 	EvalCaseResults []*evalresult.EvalCaseResult `json:"evalCaseResults,omitempty"`
 }

--- a/evaluation/service/service_test.go
+++ b/evaluation/service/service_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalresult"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
@@ -52,11 +53,13 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 		UserID:             "user-123",
 		Status:             status.EvalStatusPassed,
 		ErrorMessage:       "",
-		InferenceDuration:  42 * time.Millisecond,
-		InferenceTokenUsage: &model.Usage{
-			PromptTokens:     10,
-			CompletionTokens: 5,
-			TotalTokens:      15,
+		InferenceStats: &evalresult.InferenceStats{
+			Duration: 42 * time.Millisecond,
+			TokenUsage: &model.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
 		},
 	}
 
@@ -64,7 +67,9 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	var payload map[string]json.RawMessage
 	assert.NoError(t, json.Unmarshal(data, &payload))
-	assert.Contains(t, payload, "inferenceDuration")
+	assert.Contains(t, payload, "inferenceStats")
+	assert.NotContains(t, payload, "inferenceDuration")
+	assert.NotContains(t, payload, "inferenceTokenUsage")
 	assert.NotContains(t, payload, "agentExecutionTime")
 
 	var decoded InferenceResult
@@ -77,8 +82,7 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, result.SessionID, decoded.SessionID)
 	assert.Equal(t, result.UserID, decoded.UserID)
 	assert.Equal(t, result.Status, decoded.Status)
-	assert.Equal(t, result.InferenceDuration, decoded.InferenceDuration)
-	assert.Equal(t, result.InferenceTokenUsage, decoded.InferenceTokenUsage)
+	assert.Equal(t, result.InferenceStats, decoded.InferenceStats)
 	assert.Len(t, decoded.Inferences, 1)
 	if len(decoded.Inferences) == 1 {
 		assert.Equal(t, "inv-1", decoded.Inferences[0].InvocationID)

--- a/evaluation/service/service_test.go
+++ b/evaluation/service/service_test.go
@@ -19,6 +19,7 @@ import (
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/evalset"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/metric"
 	"trpc.group/trpc-go/trpc-agent-go/evaluation/status"
+	"trpc.group/trpc-go/trpc-agent-go/model"
 )
 
 func TestInferenceRequestJSONRoundTrip(t *testing.T) {
@@ -52,6 +53,11 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 		Status:             status.EvalStatusPassed,
 		ErrorMessage:       "",
 		InferenceDuration:  42 * time.Millisecond,
+		InferenceTokenUsage: &model.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
 	}
 
 	data, err := json.Marshal(result)
@@ -72,6 +78,7 @@ func TestInferenceResultJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, result.UserID, decoded.UserID)
 	assert.Equal(t, result.Status, decoded.Status)
 	assert.Equal(t, result.InferenceDuration, decoded.InferenceDuration)
+	assert.Equal(t, result.InferenceTokenUsage, decoded.InferenceTokenUsage)
 	assert.Len(t, decoded.Inferences, 1)
 	if len(decoded.Inferences) == 1 {
 		assert.Equal(t, "inv-1", decoded.Inferences[0].InvocationID)

--- a/server/evaluation/openapi.yaml
+++ b/server/evaluation/openapi.yaml
@@ -336,12 +336,8 @@ components:
         executionTime:
           type: integer
           description: Nanoseconds encoded by Go duration JSON marshaling.
-        inferenceDuration:
-          type: integer
-          format: int64
-          description: Nanoseconds encoded by Go duration JSON marshaling.
-        inferenceTokenUsage:
-          $ref: "#/components/schemas/TokenUsage"
+        inferenceStats:
+          $ref: "#/components/schemas/InferenceStats"
         evalCases:
           type: array
           items:
@@ -355,12 +351,8 @@ components:
           type: string
         overallStatus:
           $ref: "#/components/schemas/EvalStatus"
-        inferenceDuration:
-          type: integer
-          format: int64
-          description: Nanoseconds encoded by Go duration JSON marshaling.
-        inferenceTokenUsage:
-          $ref: "#/components/schemas/TokenUsage"
+        inferenceStats:
+          $ref: "#/components/schemas/InferenceStats"
         evalCaseResults:
           type: array
           items:
@@ -629,11 +621,16 @@ components:
           type: string
         userId:
           type: string
-        inferenceDuration:
+        inferenceStats:
+          $ref: "#/components/schemas/InferenceStats"
+    InferenceStats:
+      type: object
+      properties:
+        duration:
           type: integer
           format: int64
           description: Nanoseconds encoded by Go duration JSON marshaling.
-        inferenceTokenUsage:
+        tokenUsage:
           $ref: "#/components/schemas/TokenUsage"
     TokenUsage:
       type: object

--- a/server/evaluation/openapi.yaml
+++ b/server/evaluation/openapi.yaml
@@ -340,6 +340,8 @@ components:
           type: integer
           format: int64
           description: Nanoseconds encoded by Go duration JSON marshaling.
+        inferenceTokenUsage:
+          $ref: "#/components/schemas/TokenUsage"
         evalCases:
           type: array
           items:
@@ -357,6 +359,8 @@ components:
           type: integer
           format: int64
           description: Nanoseconds encoded by Go duration JSON marshaling.
+        inferenceTokenUsage:
+          $ref: "#/components/schemas/TokenUsage"
         evalCaseResults:
           type: array
           items:
@@ -629,6 +633,31 @@ components:
           type: integer
           format: int64
           description: Nanoseconds encoded by Go duration JSON marshaling.
+        inferenceTokenUsage:
+          $ref: "#/components/schemas/TokenUsage"
+    TokenUsage:
+      type: object
+      properties:
+        prompt_tokens:
+          type: integer
+        completion_tokens:
+          type: integer
+        total_tokens:
+          type: integer
+        prompt_tokens_details:
+          type: object
+          properties:
+            cached_tokens:
+              type: integer
+            cache_creation_tokens:
+              type: integer
+            cache_read_tokens:
+              type: integer
+        completion_tokens_details:
+          type: object
+          properties:
+            reasoning_tokens:
+              type: integer
     EvalMetricResult:
       type: object
       properties:

--- a/server/evaluation/openapi_test.go
+++ b/server/evaluation/openapi_test.go
@@ -24,7 +24,7 @@ func TestOpenAPISpecIsValid(t *testing.T) {
 	require.NoError(t, doc.Validate(context.Background()))
 }
 
-func TestOpenAPISpecDocumentsInferenceDuration(t *testing.T) {
+func TestOpenAPISpecDocumentsInferenceStats(t *testing.T) {
 	loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: false}
 	doc, err := loader.LoadFromFile(filepath.Join(".", "openapi.yaml"))
 	require.NoError(t, err)
@@ -33,34 +33,30 @@ func TestOpenAPISpecDocumentsInferenceDuration(t *testing.T) {
 		schemaRef, ok := doc.Components.Schemas[schemaName]
 		require.Truef(t, ok, "schema %s is missing", schemaName)
 		require.NotNil(t, schemaRef.Value)
-		property, ok := schemaRef.Value.Properties["inferenceDuration"]
-		require.Truef(t, ok, "schema %s does not document inferenceDuration", schemaName)
+		property, ok := schemaRef.Value.Properties["inferenceStats"]
+		require.Truef(t, ok, "schema %s does not document inferenceStats", schemaName)
 		require.NotNil(t, property.Value)
-		require.True(t, property.Value.Type.Is("integer"))
-		require.Equal(t, "int64", property.Value.Format)
+		require.Equal(t, "#/components/schemas/InferenceStats", property.Ref)
 	}
 
 	evalSetResult := doc.Components.Schemas["EvalSetResult"]
 	require.NotNil(t, evalSetResult)
 	require.NotNil(t, evalSetResult.Value)
-	_, hasSetDuration := evalSetResult.Value.Properties["inferenceDuration"]
-	require.False(t, hasSetDuration, "EvalSetResult should not expose a persisted set-level inferenceDuration")
-}
+	_, hasSetStats := evalSetResult.Value.Properties["inferenceStats"]
+	require.False(t, hasSetStats, "EvalSetResult should not expose a persisted set-level inferenceStats")
 
-func TestOpenAPISpecDocumentsInferenceTokenUsage(t *testing.T) {
-	loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: false}
-	doc, err := loader.LoadFromFile(filepath.Join(".", "openapi.yaml"))
-	require.NoError(t, err)
-
-	for _, schemaName := range []string{"EvaluationResult", "EvaluationCaseResult", "EvalCaseResult"} {
-		schemaRef, ok := doc.Components.Schemas[schemaName]
-		require.Truef(t, ok, "schema %s is missing", schemaName)
-		require.NotNil(t, schemaRef.Value)
-		property, ok := schemaRef.Value.Properties["inferenceTokenUsage"]
-		require.Truef(t, ok, "schema %s does not document inferenceTokenUsage", schemaName)
-		require.NotNil(t, property.Value)
-		require.Equal(t, "#/components/schemas/TokenUsage", property.Ref)
-	}
+	statsSchema := doc.Components.Schemas["InferenceStats"]
+	require.NotNil(t, statsSchema)
+	require.NotNil(t, statsSchema.Value)
+	duration, ok := statsSchema.Value.Properties["duration"]
+	require.True(t, ok)
+	require.NotNil(t, duration.Value)
+	require.True(t, duration.Value.Type.Is("integer"))
+	require.Equal(t, "int64", duration.Value.Format)
+	tokenUsage, ok := statsSchema.Value.Properties["tokenUsage"]
+	require.True(t, ok)
+	require.NotNil(t, tokenUsage.Value)
+	require.Equal(t, "#/components/schemas/TokenUsage", tokenUsage.Ref)
 
 	usageSchema := doc.Components.Schemas["TokenUsage"]
 	require.NotNil(t, usageSchema)

--- a/server/evaluation/openapi_test.go
+++ b/server/evaluation/openapi_test.go
@@ -46,3 +46,29 @@ func TestOpenAPISpecDocumentsInferenceDuration(t *testing.T) {
 	_, hasSetDuration := evalSetResult.Value.Properties["inferenceDuration"]
 	require.False(t, hasSetDuration, "EvalSetResult should not expose a persisted set-level inferenceDuration")
 }
+
+func TestOpenAPISpecDocumentsInferenceTokenUsage(t *testing.T) {
+	loader := &openapi3.Loader{Context: context.Background(), IsExternalRefsAllowed: false}
+	doc, err := loader.LoadFromFile(filepath.Join(".", "openapi.yaml"))
+	require.NoError(t, err)
+
+	for _, schemaName := range []string{"EvaluationResult", "EvaluationCaseResult", "EvalCaseResult"} {
+		schemaRef, ok := doc.Components.Schemas[schemaName]
+		require.Truef(t, ok, "schema %s is missing", schemaName)
+		require.NotNil(t, schemaRef.Value)
+		property, ok := schemaRef.Value.Properties["inferenceTokenUsage"]
+		require.Truef(t, ok, "schema %s does not document inferenceTokenUsage", schemaName)
+		require.NotNil(t, property.Value)
+		require.Equal(t, "#/components/schemas/TokenUsage", property.Ref)
+	}
+
+	usageSchema := doc.Components.Schemas["TokenUsage"]
+	require.NotNil(t, usageSchema)
+	require.NotNil(t, usageSchema.Value)
+	for _, propertyName := range []string{"prompt_tokens", "completion_tokens", "total_tokens"} {
+		property, ok := usageSchema.Value.Properties[propertyName]
+		require.Truef(t, ok, "TokenUsage does not document %s", propertyName)
+		require.NotNil(t, property.Value)
+		require.True(t, property.Value.Type.Is("integer"))
+	}
+}


### PR DESCRIPTION
## What changed
- Group target Agent inference duration and token usage into `InferenceStats` across inference, case/run, persisted case, and overall evaluation results.
- Aggregate `InferenceStats.Duration` and `InferenceStats.TokenUsage` across invocations, cases, and repeated runs.
- Preserve the existing target-Agent-only accounting boundaries: evaluator, expected-runner, and trace-replay usage are excluded.
- Keep persistence additive at the JSON blob level without adding database columns.
- Update tests, OpenAPI, and evaluation documentation.

## Why
Inference duration and token usage are two dimensions of the same inference resource measurement. Grouping them before the first release keeps the public API cohesive and leaves room for future inference statistics without proliferating top-level fields. `ExecutionTime` remains separate because it measures the complete evaluation flow.

## Testing
- `cd evaluation && go test ./...`
- `cd evaluation && go test -race ./...`
- `cd server/evaluation && go test ./...`
- `go build ./...`

The root `go test ./...` was also exercised; it has two unrelated environment/flakiness failures in `session/inmemory/TestLoadOrInitializeSessionStateCloseWakesWaiter` and `tool/duckduckgo/TestNewDefaultHTTPClient_UsesTransportNetwork`.