### PR TITLE
session/mysql: order events by (created_at, id) to keep tool rounds intact

### DIFF
--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -291,10 +291,10 @@ func TestGetEventsList(t *testing.T) {
 		}
 		createdAts := []time.Time{time.Now().Add(-time.Hour)}
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", []byte("invalid-json"), time.Now())
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow("app1", "user1", "sess1", []byte("invalid-json"), time.Now(), int64(1))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -352,12 +352,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt1Bytes, now).
-			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt2Bytes, now).
-			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt1Bytes, now, int64(1)).
+			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt2Bytes, now, int64(2)).
+			AddRow(keys[0].AppName, keys[0].UserID, keys[0].SessionID, evt3Bytes, now, int64(3))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 			WithArgs(keys[0].AppName, keys[0].UserID, keys[0].SessionID, keys[0].UserID).
 			WillReturnRows(rows)
 
@@ -396,12 +396,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", evt1Bytes, now).
-			AddRow("app1", "user1", "sess1", evt2Bytes, now).
-			AddRow("app1", "user1", "sess1", evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow("app1", "user1", "sess1", evt1Bytes, now, int64(1)).
+			AddRow("app1", "user1", "sess1", evt2Bytes, now, int64(2)).
+			AddRow("app1", "user1", "sess1", evt3Bytes, now, int64(3))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -441,12 +441,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 		// DB returns newest-first; in-memory sort must produce oldest-first.
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", evt3Bytes, now).
-			AddRow("app1", "user1", "sess1", evt2Bytes, now.Add(-time.Minute)).
-			AddRow("app1", "user1", "sess1", evt1Bytes, now.Add(-2*time.Minute))
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow("app1", "user1", "sess1", evt3Bytes, now, int64(3)).
+			AddRow("app1", "user1", "sess1", evt2Bytes, now.Add(-time.Minute), int64(2)).
+			AddRow("app1", "user1", "sess1", evt1Bytes, now.Add(-2*time.Minute), int64(1))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -457,6 +457,53 @@ func TestGetEventsList(t *testing.T) {
 		assert.Equal(t, "inv-1", result[0][0].InvocationID)
 		assert.Equal(t, "inv-2", result[0][1].InvocationID)
 		assert.Equal(t, "inv-3", result[0][2].InvocationID)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("SortsRowsSharingCreatedAtByID", func(t *testing.T) {
+		// A tool call and its result are written milliseconds apart, so they
+		// share created_at whenever the column resolution is coarser than the
+		// write interval (e.g. a legacy TIMESTAMP(0) schema). created_at alone
+		// is then not a total order and the descending scan order would leak
+		// into conversation order, placing the tool result before its call and
+		// making both look orphaned to tool-call sanitization.
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		s := createTestService(t, db)
+		keys := []session.Key{
+			{AppName: "app1", UserID: "user1", SessionID: "sess1"},
+		}
+		createdAts := []time.Time{time.Now().Add(-time.Hour)}
+
+		first := event.NewResponseEvent("inv-first", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleUser, Content: "first"}}},
+		})
+		second := event.NewResponseEvent("inv-second", "author1", &model.Response{
+			Choices: []model.Choice{{Message: model.Message{Role: model.RoleAssistant, Content: "second"}}},
+		})
+
+		firstBytes, _ := json.Marshal(first)
+		secondBytes, _ := json.Marshal(second)
+		sameSecond := time.Now().Truncate(time.Second)
+
+		// Descending scan returns the larger id first; both share created_at.
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow("app1", "user1", "sess1", secondBytes, sameSecond, int64(2)).
+			AddRow("app1", "user1", "sess1", firstBytes, sameSecond, int64(1))
+
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
+			WithArgs("app1", "user1", "sess1", "user1").
+			WillReturnRows(rows)
+
+		got, err := s.getEventsList(context.Background(), keys, createdAts, 0, time.Time{}, nil)
+		assert.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Len(t, got[0], 2)
+		assert.Equal(t, "inv-first", got[0][0].InvocationID,
+			"rows sharing created_at must be ordered by ascending id")
+		assert.Equal(t, "inv-second", got[0][1].InvocationID)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
@@ -700,12 +747,12 @@ func TestGetEventsList(t *testing.T) {
 		evt3Bytes, _ := json.Marshal(evt3)
 		now := time.Now()
 
-		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow("app1", "user1", "sess1", evt1Bytes, now).
-			AddRow("app1", "user1", "sess1", evt2Bytes, now).
-			AddRow("app1", "user1", "sess1", evt3Bytes, now)
+		rows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow("app1", "user1", "sess1", evt1Bytes, now, int64(1)).
+			AddRow("app1", "user1", "sess1", evt2Bytes, now, int64(2)).
+			AddRow("app1", "user1", "sess1", evt3Bytes, now, int64(3))
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -733,7 +780,7 @@ func TestGetEventsList(t *testing.T) {
 		rows := sqlmock.NewRows([]string{"app_name", "user_id"}).
 			AddRow("app1", "user1")
 
-		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+		mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 			WithArgs("app1", "user1", "sess1", "user1").
 			WillReturnRows(rows)
 
@@ -808,10 +855,10 @@ func TestGetSessionEvents_DisabledLimitUsesLegacyList(t *testing.T) {
 	})
 	evtBytes, _ := json.Marshal(evt)
 
-	mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at FROM").
+	mock.ExpectQuery("SELECT app_name, user_id, session_id, event, created_at, id FROM").
 		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(key.AppName, key.UserID, key.SessionID, evtBytes, createdAt.Add(time.Minute)))
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow(key.AppName, key.UserID, key.SessionID, evtBytes, createdAt.Add(time.Minute), int64(1)))
 
 	result, err := s.getSessionEvents(context.Background(), key, createdAt, 0, time.Time{}, nil, time.Time{})
 	require.NoError(t, err)

--- a/session/mysql/service_edge_test.go
+++ b/session/mysql/service_edge_test.go
@@ -1026,6 +1026,23 @@ func TestLimitedEventHelpers_ErrorsAndBoundaries(t *testing.T) {
 		assert.Equal(t, now.Add(-time.Minute), oldest.createdAt)
 	})
 
+	t.Run("OldestRefBreaksTiesBySmallestID", func(t *testing.T) {
+		// The result is used as an exclusive keyset cursor. When several refs
+		// share the boundary timestamp, returning anything but the smallest id
+		// leaves the lower ids behind the cursor, so the next batch replays
+		// them. Descending scan order is reproduced here on purpose.
+		now := time.Now()
+		oldest := oldestEventRef([]eventRef{
+			{id: 12, createdAt: now},
+			{id: 10, createdAt: now.Add(-time.Minute)},
+			{id: 9, createdAt: now.Add(-time.Minute)},
+			{id: 8, createdAt: now.Add(-time.Minute)},
+		})
+		assert.Equal(t, now.Add(-time.Minute), oldest.createdAt)
+		assert.Equal(t, int64(8), oldest.id,
+			"cursor must advance past the whole boundary timestamp")
+	})
+
 	t.Run("TimestampFilterAndLoadedAnchor", func(t *testing.T) {
 		afterTime := time.Now()
 		user := event.NewResponseEvent("inv-user", "author1", &model.Response{

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -1129,11 +1129,16 @@ func filterRefsByEventTimestamp(refs []eventRef, afterTime time.Time) []eventRef
 	return filtered
 }
 
-// oldestEventRef returns the earliest ref in the current bounded event window.
+// oldestEventRef returns the earliest ref in the current bounded event window,
+// ordered by the (created_at, id) composite key. Callers use the result as an
+// exclusive keyset cursor, so ties must resolve to the smallest id: comparing
+// created_at alone would leave the lower ids of a boundary timestamp behind the
+// cursor and replay them in the next batch.
 func oldestEventRef(refs []eventRef) eventRef {
 	oldest := refs[0]
 	for _, ref := range refs[1:] {
-		if ref.createdAt.Before(oldest.createdAt) {
+		c := ref.createdAt.Compare(oldest.createdAt)
+		if c < 0 || (c == 0 && ref.id < oldest.id) {
 			oldest = ref
 		}
 	}

--- a/session/mysql/service_helper.go
+++ b/session/mysql/service_helper.go
@@ -10,6 +10,7 @@
 package mysql
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -660,7 +661,7 @@ func (s *Service) getEventsList(
 
 	// TDSQL proxy cannot extract shardkey from tuple comparison;
 	// add explicit user_id for shard routing. Harmless on MySQL.
-	query := fmt.Sprintf(`SELECT app_name, user_id, session_id, event, created_at FROM %s
+	query := fmt.Sprintf(`SELECT app_name, user_id, session_id, event, created_at, id FROM %s
 		WHERE (app_name, user_id, session_id) IN (%s)
 		AND user_id = ?
 		AND deleted_at IS NULL`,
@@ -676,6 +677,7 @@ func (s *Service) getEventsList(
 	type eventWithOrder struct {
 		evt       event.Event
 		createdAt time.Time
+		id        int64
 	}
 	eventsMap := make(map[string][]eventWithOrder)
 
@@ -683,7 +685,8 @@ func (s *Service) getEventsList(
 		var appName, userID, sessionID string
 		var eventBytes []byte
 		var eventCreatedAt time.Time
-		if err := rows.Scan(&appName, &userID, &sessionID, &eventBytes, &eventCreatedAt); err != nil {
+		var eventID int64
+		if err := rows.Scan(&appName, &userID, &sessionID, &eventBytes, &eventCreatedAt, &eventID); err != nil {
 			return err
 		}
 		keyStr := fmt.Sprintf("%s:%s:%s", appName, userID, sessionID)
@@ -698,7 +701,7 @@ func (s *Service) getEventsList(
 		if err := json.Unmarshal(eventBytes, &evt); err != nil {
 			return fmt.Errorf("unmarshal event failed: %w", err)
 		}
-		eventsMap[keyStr] = append(eventsMap[keyStr], eventWithOrder{evt: evt, createdAt: eventCreatedAt})
+		eventsMap[keyStr] = append(eventsMap[keyStr], eventWithOrder{evt: evt, createdAt: eventCreatedAt, id: eventID})
 		return nil
 	}, query, args...)
 
@@ -711,7 +714,10 @@ func (s *Service) getEventsList(
 		keyStr := fmt.Sprintf("%s:%s:%s", key.AppName, key.UserID, key.SessionID)
 		items := eventsMap[keyStr]
 		slices.SortFunc(items, func(a, b eventWithOrder) int {
-			return a.createdAt.Compare(b.createdAt)
+			if c := a.createdAt.Compare(b.createdAt); c != 0 {
+				return c
+			}
+			return cmp.Compare(a.id, b.id)
 		})
 		events := make([]event.Event, len(items))
 		for j, item := range items {
@@ -852,7 +858,7 @@ func (s *Service) getRecentEventRefs(
 		WHERE app_name = ? AND user_id = ? AND session_id = ?
 		AND created_at >= ?
 		AND deleted_at IS NULL
-		ORDER BY created_at DESC
+		ORDER BY created_at DESC, id DESC
 		LIMIT ?`,
 		s.tableSessionEvents)
 
@@ -949,8 +955,15 @@ func (s *Service) getEventsByRefs(
 		return nil, fmt.Errorf("batch get events failed: %w", err)
 	}
 
+	// Tie-break on id: created_at alone is not a total order. A tool call and
+	// its result are written milliseconds apart and collide whenever the column
+	// resolution is coarser than the write interval, which would otherwise let
+	// the descending scan order survive into conversation order.
 	slices.SortFunc(refs, func(a, b eventRef) int {
-		return a.createdAt.Compare(b.createdAt)
+		if c := a.createdAt.Compare(b.createdAt); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.id, b.id)
 	})
 	events := make([]event.Event, 0, len(refs))
 	for _, ref := range refs {
@@ -1028,13 +1041,15 @@ func (s *Service) getPreviousEventRefs(
 		s.tableSessionEvents)
 	args := []any{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	if before != nil {
-		// Keyset cursor: rows sharing the exact same microsecond created_at as
-		// the cursor boundary may be skipped. TIMESTAMP(6) makes this rare in
-		// practice and we accept the tradeoff to avoid filesort on the index.
-		query += ` AND created_at < ?`
-		args = append(args, before.createdAt)
+		// Composite keyset cursor on (created_at, id). Comparing created_at
+		// alone drops every remaining row that shares the boundary timestamp,
+		// which is common when the column resolution is coarser than the write
+		// interval. Written as an expanded OR rather than a tuple comparison
+		// because the TDSQL proxy cannot extract the shardkey from tuples.
+		query += ` AND (created_at < ? OR (created_at = ? AND id < ?))`
+		args = append(args, before.createdAt, before.createdAt, before.id)
 	}
-	query += ` ORDER BY created_at DESC LIMIT ?`
+	query += ` ORDER BY created_at DESC, id DESC LIMIT ?`
 	args = append(args, userAnchorSearchBatchSize)
 
 	refs := make([]eventRef, 0, userAnchorSearchBatchSize)
@@ -1068,13 +1083,12 @@ func (s *Service) getEventRefsWithTimestamp(
 	)
 	args := []any{key.AppName, key.UserID, key.SessionID, afterTime}
 	if before != nil {
-		// Keyset cursor: rows sharing the exact same microsecond created_at as
-		// the cursor boundary may be skipped. TIMESTAMP(6) makes this rare in
-		// practice and we accept the tradeoff to avoid filesort on the index.
-		query += ` AND created_at < ?`
-		args = append(args, before.createdAt)
+		// Composite keyset cursor on (created_at, id); see getPreviousEventRefs
+		// for why this is an expanded OR instead of a tuple comparison.
+		query += ` AND (created_at < ? OR (created_at = ? AND id < ?))`
+		args = append(args, before.createdAt, before.createdAt, before.id)
 	}
-	query += ` ORDER BY created_at DESC LIMIT ?`
+	query += ` ORDER BY created_at DESC, id DESC LIMIT ?`
 	args = append(args, limit)
 
 	refs := make([]eventRef, 0, limit)
@@ -1183,7 +1197,7 @@ func (s *Service) getPagedEvents(
 		WHERE app_name = ? AND user_id = ? AND session_id = ?
 		AND created_at >= ?
 		AND deleted_at IS NULL
-		ORDER BY created_at DESC
+		ORDER BY created_at DESC, id DESC
 		LIMIT ? OFFSET ?`,
 		s.tableSessionEvents)
 
@@ -1265,7 +1279,7 @@ func (s *Service) getTrackEventsByTrackLists(
 				args = append(args, afterTime)
 			}
 			query += `
-					ORDER BY created_at DESC`
+					ORDER BY created_at DESC, id DESC`
 			if limit > 0 {
 				query += `
 					LIMIT ?`

--- a/session/mysql/service_helper_test.go
+++ b/session/mysql/service_helper_test.go
@@ -501,7 +501,8 @@ func TestGetSession_SummaryAwareRestoreBoundsAnchorSearch(t *testing.T) {
 		mock,
 		key,
 		sessState.CreatedAt,
-		assistantCreatedAt,
+		// Composite keyset cursor binds (created_at, created_at, id).
+		assistantCreatedAt, assistantCreatedAt, int64(2),
 	)
 
 	sess, err := s.GetSession(ctx, key)
@@ -903,8 +904,8 @@ func TestListSessions_Success(t *testing.T) {
 			AddRow("session-1", stateBytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events (empty)
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at, id FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}))
 
 	// Mock: Batch load summaries (empty)
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -956,8 +957,8 @@ func TestListSessions_WithTrackEvents(t *testing.T) {
 			AddRow("session-1", stateBytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events (empty).
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at, id FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}))
 
 	// Mock: Batch load summaries (empty).
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -1071,8 +1072,8 @@ func TestListSessions_WithMultipleSessions(t *testing.T) {
 			AddRow("session-2", state2Bytes, time.Now(), time.Now()))
 
 	// Mock: Batch load events
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at, id FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}))
 
 	// Mock: Batch load summaries
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
@@ -1115,8 +1116,8 @@ func TestListSessions_WithListSessionPage(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"session_id", "state", "created_at", "updated_at"}).
 			AddRow("session-2", stateBytes, time.Now(), time.Now()))
 
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at, id FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, filter_key, summary, updated_at FROM session_summaries")).
 		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "filter_key", "summary", "updated_at"}))
 

--- a/session/mysql/service_test.go
+++ b/session/mysql/service_test.go
@@ -176,11 +176,11 @@ func expectFullSessionEventsList(
 	key session.Key,
 	rows ...limitedEventRow,
 ) *sqlmock.ExpectedQuery {
-	sqlRows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"})
-	for _, row := range rows {
-		sqlRows.AddRow(key.AppName, key.UserID, key.SessionID, row.event, row.createdAt)
+	sqlRows := sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"})
+	for i, row := range rows {
+		sqlRows.AddRow(key.AppName, key.UserID, key.SessionID, row.event, row.createdAt, int64(i+1))
 	}
-	return mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
+	return mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at, id FROM")).
 		WithArgs(key.AppName, key.UserID, key.SessionID, key.UserID).
 		WillReturnRows(sqlRows)
 }
@@ -222,7 +222,8 @@ func expectPreviousEventRefs(
 ) *sqlmock.ExpectedQuery {
 	args := []driver.Value{key.AppName, key.UserID, key.SessionID, sessionCreatedAt}
 	if before != nil {
-		args = append(args, before.createdAt)
+		// Composite keyset cursor binds (created_at, created_at, id).
+		args = append(args, before.createdAt, before.createdAt, before.id)
 	}
 	args = append(args, userAnchorSearchBatchSize)
 	rows := sqlmock.NewRows([]string{"id", "created_at"})
@@ -2415,9 +2416,9 @@ func TestListSessions_WithEvents(t *testing.T) {
 	eventBytes, _ := json.Marshal(evt)
 
 	// Mock: Batch load events with data
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at FROM")).
-		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at"}).
-			AddRow(userKey.AppName, userKey.UserID, "session-1", eventBytes, time.Now()))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT app_name, user_id, session_id, event, created_at, id FROM")).
+		WillReturnRows(sqlmock.NewRows([]string{"app_name", "user_id", "session_id", "event", "created_at", "id"}).
+			AddRow(userKey.AppName, userKey.UserID, "session-1", eventBytes, time.Now(), int64(1)))
 
 	// Prepare mock summary
 	summary := session.Summary{Summary: "test summary", Topics: []string{}}
@@ -2606,7 +2607,7 @@ func TestGetTrackEvents_ZeroAfterTimeOmitsCreatedAtFilter(t *testing.T) {
 		`WHERE app_name = \? AND user_id = \? AND session_id = \? AND track = \?\s+`+
 		`AND \(expires_at IS NULL OR expires_at > \?\)\s+`+
 		`AND deleted_at IS NULL\s+`+
-		`ORDER BY created_at DESC$`).
+		`ORDER BY created_at DESC, id DESC$`).
 		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg()).
 		WillReturnRows(rows)
 
@@ -2647,7 +2648,7 @@ func TestGetTrackEvents_AfterTimeBindsCreatedAtFilter(t *testing.T) {
 		`AND \(expires_at IS NULL OR expires_at > \?\)\s+`+
 		`AND deleted_at IS NULL\s+`+
 		`AND created_at > \?\s+`+
-		`ORDER BY created_at DESC$`).
+		`ORDER BY created_at DESC, id DESC$`).
 		WithArgs("test-app", "test-user", "session-1", "alpha", sqlmock.AnyArg(), afterTime).
 		WillReturnRows(sqlmock.NewRows([]string{"event"}))
 


### PR DESCRIPTION
## What changed

Session events are now ordered by `(created_at, id)` instead of `created_at`
alone, in both the SQL queries and the in-memory sorts that restore conversation
order. The keyset cursors were widened to the same composite key.

This keeps a tool call adjacent to its tool result when both rows share a
`created_at` value, so tool call sanitization no longer downgrades correctly
paired rounds to user text.

## Why

`created_at` is not a total order. A tool call and its result are persisted
milliseconds apart and therefore share a timestamp whenever the column resolution
is coarser than the write interval — for example on a database whose tables
predate the `TIMESTAMP(6)` schema, since `CREATE TABLE IF NOT EXISTS` never
migrates existing tables.

`getEventsByRefs` receives rows from `ORDER BY created_at DESC` and re-sorts them
ascending by `createdAt` only, so rows sharing a timestamp keep their descending
order and a tool result is placed before its own tool call. Sanitization pairs
strictly adjacent messages, so both are treated as orphans and downgraded.

In one session of 329 events, 25 of 99 tool rounds shared a `created_at` value and
a single model request emitted 40 `downgraded orphan tool call to user message`
warnings, even though every affected call had a correctly paired result in the
database. Fast tools are hit disproportionately: `skill_load` returns in
milliseconds and collided in every deployment we inspected, which leaves
`SkillsToolResultRequestProcessor` unable to find the `skill_load` tool message
and permanently falling back to a second system message.

`verifyColumns` already reports precision mismatches as errors, noting they "may
cause incorrect time comparisons or ordering". Raising the precision only helps
new rows, because existing rows are padded to `.000000` and keep colliding. A
secondary sort key repairs existing data as well, so the read path should not
depend on the schema alone.

The keyset cursor is written as an expanded `OR` rather than a tuple comparison
because the TDSQL proxy cannot extract the shardkey from tuples, as noted in the
surrounding code.

## Testing

- `go test ./...` in `session/mysql` passes.
- `go build ./...` and `go vet ./...` pass in `session/mysql`.
- `gofmt` reports no diffs.
- Added `TestGetEventsList/SortsRowsSharingCreatedAtByID`, which feeds two events
  that share `created_at` in descending id order (mirroring a descending scan) and
  asserts ascending id order in the result. The test was verified to fail when the
  tie-break is removed and to pass with it in place.
- Existing mock expectations were updated for the added `id` column, the new
  ordering clause, and the composite cursor bindings.
- Verified end to end against a deployment with `DATETIME_PRECISION = 0`, where a
  session that previously degraded on every turn behaves correctly after the
  change.

## Notes for reviewers

- `session/mysql/window.go` carries the same single-column cursor in
  `queryWindowNeighborBatch`, including the same comment about `TIMESTAMP(6)`. It
  belongs to the `GetEventWindow` path and would require threading `id` through
  `persistedWindowEntry` and `scanWindowRow`. It is intentionally left out to keep
  this change reviewable, and can follow in a separate pull request.
- The batch query in `getEventsList` now selects `id` in addition to the existing
  columns, so mocks and any custom `session.Service` wrappers exercising that
  query need the extra column.
- No public API or persisted format changes; only query shape and ordering.

Fixes #2578 