### PR TITLE
hostexec: add WithSpawnHook to customize the command before start

### DIFF
--- a/tool/hostexec/hostexec.go
+++ b/tool/hostexec/hostexec.go
@@ -98,9 +98,18 @@ func WithBaseEnv(env map[string]string) Option {
 }
 
 // WithSpawnHook sets a function that is called on every command right before
-// it is started, after the tool set has applied its own process attributes.
-// The hook may change Path, Args and SysProcAttr to wrap the command, for
-// example in a namespace or under a sandbox; an error aborts the call.
+// it is started, after the tool set has applied its own process attributes
+// and before any pipe or PTY is allocated. The hook may change Path, Args and
+// SysProcAttr to wrap the command, for example in a namespace or under a
+// sandbox; it must not start the command or touch its stdio. The process
+// group attributes the tool set owns (Setsid, Setpgid, Pdeathsig) are
+// reapplied after the hook returns, so replacing SysProcAttr cannot detach
+// the command from the cleanup that signals its process group. An error
+// aborts the call: nothing is started and no session is registered.
+//
+// A nil hook keeps the default behaviour. Commands can start concurrently,
+// so the hook may be invoked concurrently and must synchronize any state it
+// shares between calls.
 func WithSpawnHook(hook func(*exec.Cmd) error) Option {
 	return func(c *config) {
 		c.spawnHook = hook

--- a/tool/hostexec/hostexec.go
+++ b/tool/hostexec/hostexec.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -43,11 +44,12 @@ const (
 )
 
 type config struct {
-	baseDir  string
-	name     string
-	maxLines int
-	jobTTL   time.Duration
-	baseEnv  map[string]string
+	baseDir   string
+	name      string
+	maxLines  int
+	jobTTL    time.Duration
+	baseEnv   map[string]string
+	spawnHook func(*exec.Cmd) error
 }
 
 // Option configures the hostexec tool set.
@@ -95,6 +97,16 @@ func WithBaseEnv(env map[string]string) Option {
 	}
 }
 
+// WithSpawnHook sets a function that is called on every command right before
+// it is started, after the tool set has applied its own process attributes.
+// The hook may change Path, Args and SysProcAttr to wrap the command, for
+// example in a namespace or under a sandbox; an error aborts the call.
+func WithSpawnHook(hook func(*exec.Cmd) error) Option {
+	return func(c *config) {
+		c.spawnHook = hook
+	}
+}
+
 func defaultConfig() config {
 	return config{
 		baseDir: defaultBaseDir,
@@ -126,6 +138,7 @@ func NewToolSet(opts ...Option) (tool.ToolSet, error) {
 	if len(cfg.baseEnv) > 0 {
 		mgr.baseEnv = cloneEnvMap(cfg.baseEnv)
 	}
+	mgr.spawnHook = cfg.spawnHook
 
 	set := &toolSet{
 		name:    strings.TrimSpace(cfg.name),

--- a/tool/hostexec/hostexec_spawnhook_unix_test.go
+++ b/tool/hostexec/hostexec_spawnhook_unix_test.go
@@ -14,6 +14,7 @@ package hostexec
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -186,4 +187,72 @@ func TestSpawnHook_NilIsNoop(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "original", outputField(out.(map[string]any)))
+}
+
+func TestSpawnHook_ReplacedSysProcAttrKeepsProcessGroup(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet(WithSpawnHook(func(cmd *exec.Cmd) error {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		return nil
+	}))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, mgr := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command":    "sleep 30",
+			"background": true,
+		}),
+	)
+	require.NoError(t, err)
+
+	sessionID := out.(map[string]any)["session_id"].(string)
+	mgr.mu.Lock()
+	sess := mgr.sessions[sessionID]
+	mgr.mu.Unlock()
+	require.NotNil(t, sess)
+	require.True(t, sess.cmd.SysProcAttr.Setpgid)
+	require.Equal(t, sess.cmd.Process.Pid, sess.processGroupID)
+	require.NoError(t, mgr.kill(sessionID))
+	pollUntilExited(t, mgr, sessionID)
+	require.False(t, processTreeAlive(sess.cmd.Process, sess.processGroupID))
+}
+
+func TestSpawnHook_ErrorOpensNoPipes(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet(WithSpawnHook(func(*exec.Cmd) error {
+		return errors.New("hook refused")
+	}))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	before := openFDCount(t)
+	for i := 0; i < 32; i++ {
+		_, err := execTool.Call(
+			context.Background(),
+			mustJSON(t, map[string]any{"command": "echo never", "yieldMs": 0}),
+		)
+		require.Error(t, err)
+	}
+	require.LessOrEqual(t, openFDCount(t), before+2)
+}
+
+func openFDCount(t *testing.T) int {
+	t.Helper()
+
+	dir, err := os.Open("/dev/fd")
+	require.NoError(t, err)
+	defer dir.Close()
+	names, err := dir.Readdirnames(-1)
+	require.NoError(t, err)
+	return len(names)
 }

--- a/tool/hostexec/hostexec_spawnhook_unix_test.go
+++ b/tool/hostexec/hostexec_spawnhook_unix_test.go
@@ -1,0 +1,189 @@
+//go:build !windows
+
+//
+// Tencent is pleased to support the open source community by making
+// trpc-agent-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+
+package hostexec
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteToEcho replaces whatever command the tool set built with a shell
+// that prints a marker, so a test can tell the hook's rewrite was what ran.
+func rewriteToEcho(t *testing.T, marker string) func(*exec.Cmd) error {
+	t.Helper()
+
+	sh, err := exec.LookPath("sh")
+	require.NoError(t, err)
+	return func(cmd *exec.Cmd) error {
+		cmd.Path = sh
+		cmd.Args = []string{"sh", "-c", "echo " + marker}
+		return nil
+	}
+}
+
+func TestSpawnHook_RewritesForegroundCommand(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	var seen *syscall.SysProcAttr
+	rewrite := rewriteToEcho(t, "hooked-foreground")
+	set, err := NewToolSet(WithSpawnHook(func(cmd *exec.Cmd) error {
+		seen = cmd.SysProcAttr
+		return rewrite(cmd)
+	}))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command": "echo original",
+			"yieldMs": 0,
+		}),
+	)
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	require.Equal(t, programStatusExited, res["status"])
+	require.Equal(t, "hooked-foreground", outputField(res))
+	require.EqualValues(t, 0, res["exit_code"])
+	require.NotNil(t, seen)
+	require.True(t, seen.Setsid)
+	require.False(t, seen.Setpgid)
+}
+
+func TestSpawnHook_RewritesBackgroundCommand(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	var seen *syscall.SysProcAttr
+	rewrite := rewriteToEcho(t, "hooked-background")
+	set, err := NewToolSet(WithSpawnHook(func(cmd *exec.Cmd) error {
+		seen = cmd.SysProcAttr
+		return rewrite(cmd)
+	}))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, mgr := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command":    "echo original",
+			"background": true,
+		}),
+	)
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	sessionID := res["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+	all := outputField(res) + pollUntilExited(t, mgr, sessionID)
+	require.Contains(t, all, "hooked-background")
+	require.NotContains(t, all, "original")
+	require.NotNil(t, seen)
+	require.True(t, seen.Setpgid)
+	require.False(t, seen.Setsid)
+}
+
+func TestSpawnHook_RewritesPTYCommand(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	called := false
+	rewrite := rewriteToEcho(t, "hooked-pty")
+	set, err := NewToolSet(WithSpawnHook(func(cmd *exec.Cmd) error {
+		called = true
+		return rewrite(cmd)
+	}))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, mgr := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command": "echo original",
+			"tty":     true,
+			"yieldMs": 0,
+		}),
+	)
+	if err != nil && !called {
+		t.Skip(err.Error())
+	}
+	require.NoError(t, err)
+
+	res := out.(map[string]any)
+	all := outputField(res)
+	if sessionID, _ := res["session_id"].(string); sessionID != "" {
+		all += pollUntilExited(t, mgr, sessionID)
+	}
+	require.Contains(t, all, "hooked-pty")
+	require.NotContains(t, all, "original")
+}
+
+func TestSpawnHook_ErrorAbortsWithoutSession(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	hookErr := errors.New("hook refused")
+	set, err := NewToolSet(WithSpawnHook(func(*exec.Cmd) error {
+		return hookErr
+	}))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, mgr := toolSetTools(t, set)
+	for _, args := range []map[string]any{
+		{"command": "echo never", "yieldMs": 0},
+		{"command": "echo never", "background": true},
+		{"command": "echo never", "tty": true},
+	} {
+		_, err := execTool.Call(context.Background(), mustJSON(t, args))
+		require.ErrorIs(t, err, hookErr)
+	}
+
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	require.Empty(t, mgr.sessions)
+}
+
+func TestSpawnHook_NilIsNoop(t *testing.T) {
+	if _, _, err := shellSpec(); err != nil {
+		t.Skip(err.Error())
+	}
+
+	set, err := NewToolSet(WithSpawnHook(nil))
+	require.NoError(t, err)
+	defer set.Close()
+
+	execTool, _, _, _ := toolSetTools(t, set)
+	out, err := execTool.Call(
+		context.Background(),
+		mustJSON(t, map[string]any{
+			"command": "echo original",
+			"yieldMs": 0,
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "original", outputField(out.(map[string]any)))
+}

--- a/tool/hostexec/hostexec_test.go
+++ b/tool/hostexec/hostexec_test.go
@@ -618,6 +618,7 @@ func TestRunForeground_ContextCancel(t *testing.T) {
 		5*time.Second,
 		nil,
 		defaultMaxLines,
+		nil,
 	)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Empty(t, output)
@@ -835,6 +836,7 @@ func TestToolSet_MetadataAndOptions(t *testing.T) {
 		WithMaxLines(7),
 		WithJobTTL(time.Second),
 		WithBaseEnv(baseEnv),
+		WithSpawnHook(func(*exec.Cmd) error { return nil }),
 	)
 	require.NoError(t, err)
 	defer set.Close()
@@ -844,6 +846,7 @@ func TestToolSet_MetadataAndOptions(t *testing.T) {
 	require.Len(t, typed.Tools(context.Background()), 3)
 	require.Equal(t, 7, typed.mgr.maxLines)
 	require.Equal(t, time.Second, typed.mgr.jobTTL)
+	require.NotNil(t, typed.mgr.spawnHook)
 	require.Equal(
 		t,
 		map[string]string{"HOSTEXEC_ONE": "1"},
@@ -1207,12 +1210,16 @@ func TestStartPTY_ErrorBranches(t *testing.T) {
 		t.Skip("pty is not supported on windows")
 	}
 
-	_, _, err := startPTY(nil)
+	_, _, err := startPTY(nil, nil)
 	require.EqualError(t, err, "nil command")
 
 	cmd := exec.Command("definitely-missing-binary")
-	_, _, err = startPTY(cmd)
+	_, _, err = startPTY(cmd, nil)
 	require.Error(t, err)
+
+	hookErr := errors.New("hook refused")
+	_, _, err = startPTY(cmd, func(*exec.Cmd) error { return hookErr })
+	require.ErrorIs(t, err, hookErr)
 }
 
 type testWriteCloser struct {

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -41,9 +41,10 @@ type manager struct {
 	mu       sync.Mutex
 	sessions map[string]*session
 
-	maxLines int
-	jobTTL   time.Duration
-	baseEnv  map[string]string
+	maxLines  int
+	jobTTL    time.Duration
+	baseEnv   map[string]string
+	spawnHook func(*exec.Cmd) error
 
 	clock func() time.Time
 }
@@ -106,6 +107,7 @@ func (m *manager) exec(
 			timeout,
 			m.baseEnv,
 			m.maxLines,
+			m.spawnHook,
 		)
 		if err != nil {
 			return execResult{}, err
@@ -176,6 +178,7 @@ func runForeground(
 	timeout time.Duration,
 	baseEnv map[string]string,
 	maxLines int,
+	hook func(*exec.Cmd) error,
 ) (string, int, error) {
 	// A foreground session is never registered with the manager, so write_stdin
 	// can never reach it and no caller can answer a prompt it raises. Detach it
@@ -190,6 +193,7 @@ func runForeground(
 		timeout,
 		baseEnv,
 		maxLines,
+		hook,
 		detachStdin,
 	)
 	if err != nil {
@@ -205,6 +209,16 @@ func runForeground(
 
 	out, code := sess.allOutput()
 	return out, code, nil
+}
+
+func applySpawnHook(
+	cmd *exec.Cmd,
+	hook func(*exec.Cmd) error,
+) error {
+	if hook == nil {
+		return nil
+	}
+	return hook(cmd)
 }
 
 func timeoutDuration(timeoutS int) time.Duration {
@@ -298,6 +312,7 @@ func (m *manager) startBackground(
 		timeout,
 		m.baseEnv,
 		m.maxLines,
+		m.spawnHook,
 		keepStdin,
 	)
 	if err != nil {
@@ -323,6 +338,7 @@ func startSession(
 	timeout time.Duration,
 	baseEnv map[string]string,
 	maxLines int,
+	hook func(*exec.Cmd) error,
 	detach bool,
 ) (*session, error) {
 	runCtx, cancel := context.WithTimeout(
@@ -342,7 +358,7 @@ func startSession(
 	sess.cmd = cmd
 
 	if params.Pty {
-		master, closeIO, err := startPTY(cmd)
+		master, closeIO, err := startPTY(cmd, hook)
 		if err != nil {
 			cancel()
 			return nil, err
@@ -370,6 +386,11 @@ func startSession(
 			_ = stdout.Close()
 			_ = stderr.Close()
 			return nil
+		}
+		if err := applySpawnHook(cmd, hook); err != nil {
+			cancel()
+			_ = sess.closeIO()
+			return nil, err
 		}
 		if err := cmd.Start(); err != nil {
 			cancel()

--- a/tool/hostexec/manager.go
+++ b/tool/hostexec/manager.go
@@ -211,6 +211,8 @@ func runForeground(
 	return out, code, nil
 }
 
+// applySpawnHook runs the caller's spawn hook, if any, on a fully prepared
+// command. A nil hook is a no-op.
 func applySpawnHook(
 	cmd *exec.Cmd,
 	hook func(*exec.Cmd) error,
@@ -372,12 +374,23 @@ func startSession(
 			sess.readFrom(master)
 		}()
 	} else {
+		// The hook runs before any pipe exists: a rejection then leaves nothing
+		// to close, whereas after startPipes the child ends would stay open
+		// until garbage collection. It also runs after preparePipeCommand so
+		// it sees the process attributes, which are reapplied afterwards
+		// because a hook that replaces SysProcAttr must not be able to drop
+		// the group leadership terminateProcessTree relies on.
+		preparePipeCommand(cmd, detach)
+		if err := applySpawnHook(cmd, hook); err != nil {
+			cancel()
+			return nil, err
+		}
+		preparePipeCommand(cmd, detach)
 		stdin, stdout, stderr, err := startPipes(cmd, detach)
 		if err != nil {
 			cancel()
 			return nil, err
 		}
-		preparePipeCommand(cmd, detach)
 		sess.stdin = stdin
 		sess.closeIO = func() error {
 			if stdin != nil {
@@ -386,11 +399,6 @@ func startSession(
 			_ = stdout.Close()
 			_ = stderr.Close()
 			return nil
-		}
-		if err := applySpawnHook(cmd, hook); err != nil {
-			cancel()
-			_ = sess.closeIO()
-			return nil, err
 		}
 		if err := cmd.Start(); err != nil {
 			cancel()

--- a/tool/hostexec/pty_unix.go
+++ b/tool/hostexec/pty_unix.go
@@ -19,12 +19,18 @@ import (
 	"github.com/creack/pty"
 )
 
-func startPTY(cmd *exec.Cmd) (*os.File, func() error, error) {
+func startPTY(
+	cmd *exec.Cmd,
+	hook func(*exec.Cmd) error,
+) (*os.File, func() error, error) {
 	if cmd == nil {
 		return nil, nil, errors.New("nil command")
 	}
 
 	preparePTYCommand(cmd)
+	if err := applySpawnHook(cmd, hook); err != nil {
+		return nil, nil, err
+	}
 	master, err := pty.Start(cmd)
 	if err != nil {
 		return nil, nil, err

--- a/tool/hostexec/pty_unix.go
+++ b/tool/hostexec/pty_unix.go
@@ -31,6 +31,7 @@ func startPTY(
 	if err := applySpawnHook(cmd, hook); err != nil {
 		return nil, nil, err
 	}
+	preparePTYCommand(cmd)
 	master, err := pty.Start(cmd)
 	if err != nil {
 		return nil, nil, err

--- a/tool/hostexec/pty_windows.go
+++ b/tool/hostexec/pty_windows.go
@@ -17,7 +17,11 @@ import (
 	"os/exec"
 )
 
-func startPTY(cmd *exec.Cmd) (*os.File, func() error, error) {
+func startPTY(
+	cmd *exec.Cmd,
+	hook func(*exec.Cmd) error,
+) (*os.File, func() error, error) {
 	_ = cmd
+	_ = hook
 	return nil, nil, errors.New("pty is not supported on windows")
 }


### PR DESCRIPTION
Adds `hostexec.WithSpawnHook(func(*exec.Cmd) error)`, an option whose hook runs on every command right before it is started, after the tool set has applied its own process attributes (`Setsid` for a detached foreground command, `Setpgid` for a background session, `Pdeathsig` on Linux, and the PTY attributes on the tty path).

Use case: isolating spawned commands. A host that runs untrusted repository scripts wants to wrap each command in a PID/mount namespace or under a seccomp filter, which needs control over `Path`, `Args` and `SysProcAttr` after the tool set has set them and before `Start`. Today there is no way to reach the `exec.Cmd`; this hook is the smallest surface that allows it. Returning an error aborts the call and no session is registered.

Both spawn paths take the hook: the pipe path (`startSession`, before `cmd.Start`) and the PTY path (`startPTY`, before `pty.Start`). A nil hook is a no-op, so existing callers are unchanged.

Tests: the hook's rewritten argv is what runs for foreground, background and tty commands; the hook observes the attributes the tool set set (`Setsid` foreground, `Setpgid` background); a hook error surfaces from `exec_command` with no session left behind; `WithSpawnHook(nil)` is a no-op; `startPTY` propagates a hook error.