### PR TITLE
tool/mcpbroker: support custom URL schemes for named servers

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1343,7 +1343,10 @@ compatible `HTTPReqHandler`. The broker does not check for that handler at
 configuration time. Ad-hoc URL selectors remain HTTP/HTTPS only.
 
 For custom-scheme named servers, unhandled operation errors are replaced with
-an endpoint-neutral message. Errors about the model's request, such as an
+an endpoint-neutral message. `context.Canceled` and `context.DeadlineExceeded`
+remain detectable with `errors.Is`, and host code can classify or inspect the
+cause with `errors.Is`, `errors.As`, or `errors.Unwrap`. The top-level error
+text remains endpoint-neutral. Errors about the model's request, such as an
 unknown tool or missing arguments, remain actionable. `WithErrorInterceptor`
 receives the underlying error and endpoint first, so hosts can still log,
 classify, or replace the error.
@@ -1351,10 +1354,12 @@ classify, or replace the error.
 #### One-Shot Clients and Server-Initiated Messages
 
 Every broker operation uses a single-use MCP client and does not consume
-server-initiated messages. Streamable HTTP clients therefore disable the
-background `GET` stream by default. Host options are applied afterward, so a
-host that needs the stream can opt back in with
-`tmcp.WithClientGetSSEEnabled(true)`.
+server-initiated messages. For code-configured named servers that use a
+custom URL scheme, streamable HTTP clients disable the background `GET`
+stream. Host options are applied afterward, so an internal host that needs
+the stream can opt back in with `tmcp.WithClientGetSSEEnabled(true)`.
+Named HTTP/HTTPS servers and ad-hoc HTTP/HTTPS targets keep the
+trpc-mcp-go default.
 
 #### Server Description
 

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1337,6 +1337,15 @@ agent := llmagent.New(
 )
 ```
 
+Named HTTP servers configured through `WithServers` may use a structurally
+valid absolute URL with a custom scheme, as long as the host installs a
+compatible `HTTPReqHandler` (for example through
+`WithClientOptionsProvider` and `tmcp.WithHTTPReqHandler`). The broker does
+not check that such a handler exists: without one, the server fails on
+first use instead of at configuration time, and the error the model sees
+contains the endpoint URL, so use `WithErrorInterceptor` to redact internal
+endpoints. Ad-hoc URL selectors remain HTTP/HTTPS only.
+
 #### Server Description
 
 The `Description` field on `ConnectionConfig` provides a capability

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -1338,13 +1338,23 @@ agent := llmagent.New(
 ```
 
 Named HTTP servers configured through `WithServers` may use a structurally
-valid absolute URL with a custom scheme, as long as the host installs a
-compatible `HTTPReqHandler` (for example through
-`WithClientOptionsProvider` and `tmcp.WithHTTPReqHandler`). The broker does
-not check that such a handler exists: without one, the server fails on
-first use instead of at configuration time, and the error the model sees
-contains the endpoint URL, so use `WithErrorInterceptor` to redact internal
-endpoints. Ad-hoc URL selectors remain HTTP/HTTPS only.
+valid absolute URL with a custom scheme when the host runtime provides a
+compatible `HTTPReqHandler`. The broker does not check for that handler at
+configuration time. Ad-hoc URL selectors remain HTTP/HTTPS only.
+
+For custom-scheme named servers, unhandled operation errors are replaced with
+an endpoint-neutral message. Errors about the model's request, such as an
+unknown tool or missing arguments, remain actionable. `WithErrorInterceptor`
+receives the underlying error and endpoint first, so hosts can still log,
+classify, or replace the error.
+
+#### One-Shot Clients and Server-Initiated Messages
+
+Every broker operation uses a single-use MCP client and does not consume
+server-initiated messages. Streamable HTTP clients therefore disable the
+background `GET` stream by default. Host options are applied afterward, so a
+host that needs the stream can opt back in with
+`tmcp.WithClientGetSSEEnabled(true)`.
 
 #### Server Description
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1290,15 +1290,20 @@ agent := llmagent.New(
 在配置阶段检查该 handler 是否存在。运行时直接传入的 URL 仍然只允许 HTTP/HTTPS。
 
 对于自定义 scheme 的命名 server，未被 interceptor 处理的操作错误会替换成不含
-endpoint 的固定错误。工具不存在、缺少必填参数等模型请求错误仍会照常返回，便于
-模型自纠。`WithErrorInterceptor` 会先收到原始错误和 endpoint，宿主仍可记录、
-分类或替换错误。
+endpoint 的固定错误。`context.Canceled` 和 `context.DeadlineExceeded` 仍可通过
+`errors.Is` 识别；宿主代码也可以通过 `errors.Is`、`errors.As` 或 `errors.Unwrap`
+分类或检查 cause，但顶层错误文本仍不包含 endpoint。工具不存在、缺少必填参数等
+模型请求错误仍会照常返回，便于模型自纠。`WithErrorInterceptor` 会先收到原始错误
+和 endpoint，宿主仍可记录、分类或替换错误。
 
 #### 一次性客户端与服务端主动消息
 
-每次 broker 操作都会使用一个一次性 MCP client，且不会消费服务端主动消息，因此
-streamable HTTP client 默认关闭后台 `GET` 流。宿主 option 会在 broker 默认值之后
-应用；确实需要该流时，可以通过 `tmcp.WithClientGetSSEEnabled(true)` 重新开启。
+每次 broker 操作都会使用一个一次性 MCP client，且不会消费服务端主动消息。
+对于代码配置的、使用自定义 scheme 的命名 server，streamable HTTP client
+会关闭后台 `GET` 流。宿主 option 会在 broker 默认值之后应用；内部宿主
+确实需要该流时，可以通过 `tmcp.WithClientGetSSEEnabled(true)` 重新开启。
+既有的 HTTP/HTTPS 命名 server 和 ad-hoc HTTP/HTTPS 目标继续沿用
+trpc-mcp-go 的默认行为。
 
 #### Server Description（服务描述）
 

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1285,6 +1285,14 @@ agent := llmagent.New(
 )
 ```
 
+通过 `WithServers` 配置的 named HTTP server 可以使用带自定义 scheme 的、
+结构合法的绝对 URL，前提是宿主安装了兼容的 `HTTPReqHandler`（例如通过
+`WithClientOptionsProvider` 与 `tmcp.WithHTTPReqHandler`）。broker 不会检查
+这样的 handler 是否存在：缺少 handler 时，该 server 会在首次使用时失败而不是
+在配置阶段失败，并且模型看到的错误里会带上 endpoint URL，因此需要用
+`WithErrorInterceptor` 对内部 endpoint 做脱敏。ad-hoc URL selector 仍然只允许
+HTTP/HTTPS。
+
 #### Server Description（服务描述）
 
 `ConnectionConfig` 上的 `Description` 字段为 MCP server 提供一段能力摘要，

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -1286,12 +1286,19 @@ agent := llmagent.New(
 ```
 
 通过 `WithServers` 配置的 named HTTP server 可以使用带自定义 scheme 的、
-结构合法的绝对 URL，前提是宿主安装了兼容的 `HTTPReqHandler`（例如通过
-`WithClientOptionsProvider` 与 `tmcp.WithHTTPReqHandler`）。broker 不会检查
-这样的 handler 是否存在：缺少 handler 时，该 server 会在首次使用时失败而不是
-在配置阶段失败，并且模型看到的错误里会带上 endpoint URL，因此需要用
-`WithErrorInterceptor` 对内部 endpoint 做脱敏。ad-hoc URL selector 仍然只允许
-HTTP/HTTPS。
+结构合法的绝对 URL，前提是宿主运行时提供兼容的 `HTTPReqHandler`。broker 不会
+在配置阶段检查该 handler 是否存在。运行时直接传入的 URL 仍然只允许 HTTP/HTTPS。
+
+对于自定义 scheme 的命名 server，未被 interceptor 处理的操作错误会替换成不含
+endpoint 的固定错误。工具不存在、缺少必填参数等模型请求错误仍会照常返回，便于
+模型自纠。`WithErrorInterceptor` 会先收到原始错误和 endpoint，宿主仍可记录、
+分类或替换错误。
+
+#### 一次性客户端与服务端主动消息
+
+每次 broker 操作都会使用一个一次性 MCP client，且不会消费服务端主动消息，因此
+streamable HTTP client 默认关闭后台 `GET` 流。宿主 option 会在 broker 默认值之后
+应用；确实需要该流时，可以通过 `tmcp.WithClientGetSSEEnabled(true)` 重新开启。
 
 #### Server Description（服务描述）
 

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -30,6 +30,11 @@
 //     downstream prompts and tool chains.
 //   - Use WithErrorInterceptor to redact internal-topology details from MCP
 //     server errors that would otherwise reach the model.
+//
+// Errors from custom-scheme named servers are endpoint-neutral by default.
+// WithErrorInterceptor still receives the underlying error first and can
+// classify or replace it. Errors about the model's own request, such as an
+// unknown tool or missing arguments, remain available for self-correction.
 package mcpbroker
 
 import (
@@ -162,10 +167,11 @@ type ClientOptionsRequest struct {
 // ClientOptions carries optional HTTP and stdio client options. HTTP applies to SSE and streamable
 // transports; Stdio applies to stdio transports.
 //
-// Default broker headers are applied first; options here follow and may override or extend
-// behavior intentionally (see trpc-mcp-go ClientOption / StdioClientOption). For example, a host
-// can use tmcp.WithHTTPBeforeRequest to rewrite an Authorization header set earlier by
-// WithHTTPHeaderInjector. nil entries in HTTP / Stdio are filtered out before being applied.
+// Broker defaults are applied first; options here follow and may override or extend behavior
+// intentionally (see trpc-mcp-go ClientOption / StdioClientOption). For example, a host can use
+// tmcp.WithHTTPBeforeRequest to rewrite an Authorization header set earlier by
+// WithHTTPHeaderInjector. Streamable clients disable the background GET stream by default;
+// tmcp.WithClientGetSSEEnabled(true) opts back in. nil entries are filtered out.
 type ClientOptions struct {
 	HTTP  []tmcp.ClientOption
 	Stdio []tmcp.StdioClientOption
@@ -203,9 +209,14 @@ type HeaderInjectRequest struct {
 }
 
 // ErrorInterceptor lets business code classify and transform MCP HTTP errors.
+//
+// The interceptor runs before broker-side redaction. A handled decision
+// replaces the broker's endpoint-neutral error, so the host owns the disclosure
+// policy for the replacement.
 type ErrorInterceptor func(context.Context, *BrokerErrorRequest) (*BrokerErrorDecision, error)
 
-// BrokerErrorRequest describes an MCP HTTP operation error.
+// BrokerErrorRequest describes an MCP HTTP operation error. Err and BaseURL
+// contain the underlying details before broker-side redaction.
 type BrokerErrorRequest struct {
 	Selector  string
 	BaseURL   string
@@ -248,9 +259,11 @@ func New(opts ...Option) *Broker {
 // scheme and host. Custom schemes are allowed so a host-supplied
 // tmcp.HTTPReqHandler can resolve them; the broker does not check that such a
 // handler is installed, so an unresolvable scheme fails when the server is
-// first used rather than at configuration time, and the resulting error - which
-// the broker forwards to the model - contains the endpoint URL. Use
-// WithErrorInterceptor to redact internal endpoints.
+// first used rather than at configuration time.
+//
+// Errors from custom-scheme named servers are endpoint-neutral by default;
+// errors about the model's own request remain unchanged. WithErrorInterceptor
+// observes the underlying error first.
 //
 // Model-controlled ad-hoc URL selectors remain restricted to http and https;
 // see WithAllowAdHocHTTP.
@@ -408,7 +421,8 @@ func WithClientOptionsProvider(fn ClientOptionsProvider) Option {
 	}
 }
 
-// WithErrorInterceptor intercepts HTTP MCP execution errors and may translate them for model consumption.
+// WithErrorInterceptor intercepts HTTP MCP execution errors before broker-side redaction and
+// may translate them for model consumption.
 func WithErrorInterceptor(fn ErrorInterceptor) Option {
 	return func(opts *brokerOptions) {
 		opts.errorInterceptor = fn

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -33,8 +33,10 @@
 //
 // Errors from custom-scheme named servers are endpoint-neutral by default.
 // WithErrorInterceptor still receives the underlying error first and can
-// classify or replace it. Errors about the model's own request, such as an
-// unknown tool or missing arguments, remain available for self-correction.
+// classify or replace it. The top-level error text omits endpoint details,
+// while host code can still classify the cause with errors.Is/errors.As or
+// inspect it with errors.Unwrap. Errors about the model's own request, such as
+// an unknown tool or missing arguments, remain available for self-correction.
 package mcpbroker
 
 import (
@@ -170,8 +172,10 @@ type ClientOptionsRequest struct {
 // Broker defaults are applied first; options here follow and may override or extend behavior
 // intentionally (see trpc-mcp-go ClientOption / StdioClientOption). For example, a host can use
 // tmcp.WithHTTPBeforeRequest to rewrite an Authorization header set earlier by
-// WithHTTPHeaderInjector. Streamable clients disable the background GET stream by default;
-// tmcp.WithClientGetSSEEnabled(true) opts back in. nil entries are filtered out.
+// WithHTTPHeaderInjector. For code-configured named custom-scheme servers, streamable
+// clients disable the background GET stream; tmcp.WithClientGetSSEEnabled(true) opts
+// back in. Existing HTTP/HTTPS named and ad-hoc targets keep the trpc-mcp-go default.
+// nil entries are filtered out.
 type ClientOptions struct {
 	HTTP  []tmcp.ClientOption
 	Stdio []tmcp.StdioClientOption
@@ -263,7 +267,9 @@ func New(opts ...Option) *Broker {
 //
 // Errors from custom-scheme named servers are endpoint-neutral by default;
 // errors about the model's own request remain unchanged. WithErrorInterceptor
-// observes the underlying error first.
+// observes the underlying error first. The top-level error text omits endpoint
+// details, while host code can still classify the cause with errors.Is/errors.As
+// or inspect it with errors.Unwrap.
 //
 // Model-controlled ad-hoc URL selectors remain restricted to http and https;
 // see WithAllowAdHocHTTP.

--- a/tool/mcpbroker/broker.go
+++ b/tool/mcpbroker/broker.go
@@ -243,6 +243,17 @@ func New(opts ...Option) *Broker {
 }
 
 // WithServers adds named MCP server configurations provided by code.
+//
+// HTTP named servers accept a structurally valid absolute endpoint URL with a
+// scheme and host. Custom schemes are allowed so a host-supplied
+// tmcp.HTTPReqHandler can resolve them; the broker does not check that such a
+// handler is installed, so an unresolvable scheme fails when the server is
+// first used rather than at configuration time, and the resulting error - which
+// the broker forwards to the model - contains the endpoint URL. Use
+// WithErrorInterceptor to redact internal endpoints.
+//
+// Model-controlled ad-hoc URL selectors remain restricted to http and https;
+// see WithAllowAdHocHTTP.
 func WithServers(servers map[string]mcpcfg.ConnectionConfig) Option {
 	return func(opts *brokerOptions) {
 		if len(servers) == 0 {

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -1388,6 +1388,189 @@ func TestErrorInterceptorBranches(t *testing.T) {
 	require.Contains(t, err.Error(), "returned no wrapped error")
 }
 
+const internalEndpointURL = "internal-scheme://svc-account:s3cr3t-pass@mcp.internal.corp:8443/private/tenant-42/mcp?token=tok-abc123"
+
+var internalEndpointSecrets = []string{
+	"internal-scheme",
+	"svc-account",
+	"s3cr3t-pass",
+	"mcp.internal.corp",
+	"8443",
+	"private",
+	"tenant-42",
+	"token",
+	"tok-abc123",
+}
+
+func requireEndpointNeutralError(t *testing.T, err error, serverName string) {
+	t.Helper()
+	require.Error(t, err)
+	message := err.Error()
+	for _, secret := range internalEndpointSecrets {
+		require.NotContains(t, message, secret, "model-visible error leaked endpoint detail")
+	}
+	require.Contains(t, message, serverName)
+	require.Nil(t, errors.Unwrap(err))
+}
+
+func TestNamedCustomSchemeError_IsEndpointNeutral(t *testing.T) {
+	broker := New(WithServers(map[string]legacymcp.ConnectionConfig{
+		"internal_named": {
+			ServerURL: internalEndpointURL,
+			Transport: "streamable_http",
+			Timeout:   5 * time.Second,
+		},
+	}))
+	ctx := context.Background()
+
+	_, err := broker.listTools(ctx, listToolsInput{Selector: "internal_named"})
+	requireEndpointNeutralError(t, err, "internal_named")
+
+	_, err = broker.inspectTools(ctx, inspectToolsInput{
+		Selector: "internal_named",
+		Tools:    []string{"echo"},
+	})
+	requireEndpointNeutralError(t, err, "internal_named")
+
+	_, err = broker.callTool(ctx, callToolInput{
+		Selector:  "internal_named.echo",
+		Arguments: map[string]any{"text": "hello"},
+	})
+	requireEndpointNeutralError(t, err, "internal_named")
+}
+
+func TestNamedCustomSchemeError_InterceptorSeesRawError(t *testing.T) {
+	var (
+		calls   int
+		rawErr  error
+		baseURL string
+		isAdHoc bool
+	)
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"internal_named": {
+				ServerURL: internalEndpointURL,
+				Transport: "streamable_http",
+				Timeout:   5 * time.Second,
+			},
+		}),
+		WithErrorInterceptor(func(ctx context.Context, req *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+			calls++
+			rawErr = req.Err
+			baseURL = req.BaseURL
+			isAdHoc = req.IsAdHoc
+			return &BrokerErrorDecision{Handled: false}, nil
+		}),
+	)
+
+	_, err := broker.listTools(context.Background(), listToolsInput{Selector: "internal_named"})
+	requireEndpointNeutralError(t, err, "internal_named")
+
+	require.Equal(t, 1, calls)
+	require.False(t, isAdHoc)
+	require.Equal(t, internalEndpointURL, baseURL)
+	require.Error(t, rawErr)
+	require.Contains(t, rawErr.Error(), "mcp.internal.corp")
+}
+
+func TestNamedCustomSchemeError_InterceptorDecisionWins(t *testing.T) {
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"internal_named": {
+				ServerURL: internalEndpointURL,
+				Transport: "streamable_http",
+				Timeout:   5 * time.Second,
+			},
+		}),
+		WithErrorInterceptor(func(ctx context.Context, req *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+			return &BrokerErrorDecision{
+				Handled:   true,
+				WrapError: fmt.Errorf("ask the host to enable this provider"),
+			}, nil
+		}),
+	)
+
+	_, err := broker.listTools(context.Background(), listToolsInput{Selector: "internal_named"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ask the host to enable this provider")
+}
+
+func TestNamedCustomSchemeError_KeepsModelRequestErrors(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	handler := &rewriteHTTPReqHandler{dest: server.URL}
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"custom_named": {
+				ServerURL: "custom://service/mcp",
+				Transport: "streamable_http",
+				Timeout:   5 * time.Second,
+			},
+		}),
+		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
+			return &ClientOptions{
+				HTTP: []tmcp.ClientOption{tmcp.WithHTTPReqHandler(handler)},
+			}, nil
+		}),
+	)
+	ctx := context.Background()
+
+	_, err := broker.callTool(ctx, callToolInput{
+		Selector:  "custom_named.echo",
+		Arguments: map[string]any{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing required arguments")
+	require.Contains(t, err.Error(), "text")
+
+	_, err = broker.callTool(ctx, callToolInput{
+		Selector:  "custom_named.absent_tool",
+		Arguments: map[string]any{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `MCP tool "absent_tool" not found`)
+}
+
+func TestNamedHTTPError_KeepsUnderlyingDetail(t *testing.T) {
+	server := startBrokerHTTPServerWithOptions(t, brokerHTTPServerOptions{
+		RequiredAuth: "Bearer missing-token",
+	})
+	defer server.Close()
+
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"http_named": {
+				ServerURL: server.URL,
+				Timeout:   5 * time.Second,
+			},
+		}),
+	)
+	ctx := context.Background()
+
+	_, err := broker.listTools(ctx, listToolsInput{Selector: "http_named"})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "failure details are withheld")
+
+	_, err = broker.listTools(ctx, listToolsInput{Selector: server.URL})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "failure details are withheld")
+}
+
+func TestHasCustomEndpointScheme(t *testing.T) {
+	require.False(t, hasCustomEndpointScheme("http://example.com/mcp"))
+	require.False(t, hasCustomEndpointScheme(" https://example.com/mcp "))
+	require.False(t, hasCustomEndpointScheme("HTTP://example.com/mcp"))
+	require.False(t, hasCustomEndpointScheme("HTTPS://example.com/mcp"))
+	require.True(t, hasCustomEndpointScheme("internal-scheme://service/mcp"))
+	// A URL without a scheme cannot be a custom-scheme endpoint, while one that
+	// does not parse is treated as custom so no endpoint is disclosed.
+	require.False(t, hasCustomEndpointScheme(""))
+	require.False(t, hasCustomEndpointScheme("example.com/mcp"))
+	require.True(t, hasCustomEndpointScheme("http://exa mple.com/\x7f"))
+}
+
 func TestSchemaHelpers(t *testing.T) {
 	require.Equal(t, "unknown", schemaTypeName(nil))
 	require.Equal(t, "unknown", schemaTypeName(map[string]any{}))
@@ -1562,17 +1745,19 @@ func TestCreateClientRevalidatesOriginScheme(t *testing.T) {
 // rewriteHTTPReqHandler resolves a custom endpoint scheme by redirecting the
 // request to a real HTTP test server. trpc-mcp-go can invoke Handle from
 // background goroutines (for example the GET SSE stream), so the recorded
-// schemes are mutex-guarded.
+// requests are mutex-guarded.
 type rewriteHTTPReqHandler struct {
 	dest string
 
 	mu      sync.Mutex
 	schemes []string
+	methods []string
 }
 
 func (h *rewriteHTTPReqHandler) Handle(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 	h.mu.Lock()
 	h.schemes = append(h.schemes, req.URL.Scheme)
+	h.methods = append(h.methods, req.Method)
 	h.mu.Unlock()
 
 	dest, err := url.Parse(h.dest)
@@ -1592,6 +1777,12 @@ func (h *rewriteHTTPReqHandler) Schemes() []string {
 	return append([]string(nil), h.schemes...)
 }
 
+func (h *rewriteHTTPReqHandler) Methods() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.methods...)
+}
+
 func TestNamedServerCustomScheme_ReachesHTTPReqHandler(t *testing.T) {
 	server := startBrokerHTTPServer(t)
 	defer server.Close()
@@ -1608,13 +1799,7 @@ func TestNamedServerCustomScheme_ReachesHTTPReqHandler(t *testing.T) {
 		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
 			require.Equal(t, "custom://service/mcp", req.BaseURL)
 			return &ClientOptions{
-				HTTP: []tmcp.ClientOption{
-					tmcp.WithHTTPReqHandler(handler),
-					// GET SSE stays disabled so this operation is a single
-					// request/response exchange: the background GET stream
-					// races with trpc-mcp-go's own session-ID bookkeeping.
-					tmcp.WithClientGetSSEEnabled(false),
-				},
+				HTTP: []tmcp.ClientOption{tmcp.WithHTTPReqHandler(handler)},
 			}, nil
 		}),
 	)
@@ -1623,6 +1808,9 @@ func TestNamedServerCustomScheme_ReachesHTTPReqHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, output.Tools, 2)
 	require.Contains(t, handler.Schemes(), "custom")
+	methods := handler.Methods()
+	require.NotEmpty(t, methods)
+	require.NotContains(t, methods, http.MethodGet)
 }
 
 // TestAdHocSelectorRejectsCustomScheme pins the model-facing half of the trust

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -1410,7 +1410,7 @@ func requireEndpointNeutralError(t *testing.T, err error, serverName string) {
 		require.NotContains(t, message, secret, "model-visible error leaked endpoint detail")
 	}
 	require.Contains(t, message, serverName)
-	require.Nil(t, errors.Unwrap(err))
+	require.Error(t, errors.Unwrap(err))
 }
 
 func TestNamedCustomSchemeError_IsEndpointNeutral(t *testing.T) {
@@ -1437,6 +1437,22 @@ func TestNamedCustomSchemeError_IsEndpointNeutral(t *testing.T) {
 		Arguments: map[string]any{"text": "hello"},
 	})
 	requireEndpointNeutralError(t, err, "internal_named")
+}
+
+func TestNamedCustomSchemeError_PreservesTypedCause(t *testing.T) {
+	cause := &url.Error{
+		Op:  http.MethodPost,
+		URL: internalEndpointURL,
+		Err: context.DeadlineExceeded,
+	}
+	err := newNamedServerOperationError("internal_named", cause)
+
+	requireEndpointNeutralError(t, err, "internal_named")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	var urlErr *url.Error
+	require.ErrorAs(t, err, &urlErr)
+	require.Same(t, cause, urlErr)
 }
 
 func TestNamedCustomSchemeError_InterceptorSeesRawError(t *testing.T) {
@@ -1530,6 +1546,129 @@ func TestNamedCustomSchemeError_KeepsModelRequestErrors(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `MCP tool "absent_tool" not found`)
+}
+
+func TestNamedCustomSchemeError_PreservesOperationContextIdentity(t *testing.T) {
+	t.Run("caller_cancel", func(t *testing.T) {
+		handler := &waitForContextHandler{started: make(chan struct{})}
+		var rawErr error
+		var baseURL string
+		broker := newNamedCustomSchemeWaitBroker(t, 0, handler, &rawErr, &baseURL)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := broker.listTools(ctx, listToolsInput{Selector: "internal_named"})
+			errCh <- err
+		}()
+
+		select {
+		case <-handler.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("HTTPReqHandler did not start")
+		}
+		cancel()
+
+		select {
+		case err := <-errCh:
+			requireNamedCustomSchemeContextError(t, err, rawErr, context.Canceled, context.DeadlineExceeded)
+			require.Equal(t, internalEndpointURL, baseURL)
+		case <-time.After(2 * time.Second):
+			t.Fatal("listTools did not return after cancellation")
+		}
+	})
+
+	t.Run("broker_deadline", func(t *testing.T) {
+		handler := &waitForContextHandler{}
+		var rawErr error
+		var baseURL string
+		broker := newNamedCustomSchemeWaitBroker(t, 25*time.Millisecond, handler, &rawErr, &baseURL)
+
+		_, err := broker.listTools(context.Background(), listToolsInput{Selector: "internal_named"})
+		requireNamedCustomSchemeContextError(t, err, rawErr, context.DeadlineExceeded, context.Canceled)
+		require.Equal(t, internalEndpointURL, baseURL)
+	})
+}
+
+func newNamedCustomSchemeWaitBroker(
+	t *testing.T,
+	timeout time.Duration,
+	handler tmcp.HTTPReqHandler,
+	rawErr *error,
+	baseURL *string,
+) *Broker {
+	t.Helper()
+	return New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"internal_named": {
+				ServerURL: internalEndpointURL,
+				Transport: "streamable_http",
+				Timeout:   timeout,
+			},
+		}),
+		WithErrorInterceptor(func(ctx context.Context, req *BrokerErrorRequest) (*BrokerErrorDecision, error) {
+			*rawErr = req.Err
+			*baseURL = req.BaseURL
+			return &BrokerErrorDecision{Handled: false}, nil
+		}),
+		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
+			return &ClientOptions{
+				HTTP: []tmcp.ClientOption{tmcp.WithHTTPReqHandler(handler)},
+			}, nil
+		}),
+	)
+}
+
+func requireNamedCustomSchemeContextError(t *testing.T, err, rawErr, sentinel, other error) {
+	t.Helper()
+	requireEndpointNeutralError(t, err, "internal_named")
+	require.True(t, errors.Is(err, sentinel))
+	require.False(t, errors.Is(err, other))
+	require.True(t, errors.Is(err, tmcp.ErrHTTPRequestFailed))
+
+	var operationErr *operationContextError
+	require.True(t, errors.As(err, &operationErr))
+	require.NotNil(t, operationErr)
+
+	require.Error(t, rawErr)
+	require.NotEqual(t, err.Error(), rawErr.Error())
+	require.Equal(t, rawErr, errors.Unwrap(err))
+	require.Contains(t, rawErr.Error(), "HTTP request failed")
+	require.True(t, errors.Is(rawErr, tmcp.ErrHTTPRequestFailed))
+	require.True(t, errors.Is(rawErr, sentinel))
+}
+
+func TestStreamableClientOptions_DisablesGetSSEOnlyForNamedCustomScheme(t *testing.T) {
+	require.Empty(t, streamableClientOptions(legacymcp.ConnectionConfig{
+		ServerURL: "https://example.com/mcp",
+	}, false, nil))
+
+	require.Empty(t, streamableClientOptions(legacymcp.ConnectionConfig{
+		ServerURL: "http://example.com/mcp",
+	}, true, nil))
+
+	namedCustom := streamableClientOptions(legacymcp.ConnectionConfig{
+		ServerURL: "custom://service/mcp",
+	}, false, nil)
+	require.Len(t, namedCustom, 1)
+
+	var hostCalls int
+	hostOpt := func(*tmcp.Client) { hostCalls++ }
+	opts := streamableClientOptions(legacymcp.ConnectionConfig{
+		ServerURL: "custom://service/mcp",
+	}, false, []tmcp.ClientOption{hostOpt})
+	require.Len(t, opts, 2)
+
+	client := &tmcp.Client{}
+	hostWasLast := false
+	for _, opt := range opts {
+		before := hostCalls
+		opt(client)
+		hostWasLast = hostCalls > before
+	}
+	require.Equal(t, 1, hostCalls)
+	require.True(t, hostWasLast)
 }
 
 func TestNamedHTTPError_KeepsUnderlyingDetail(t *testing.T) {
@@ -1742,6 +1881,24 @@ func TestCreateClientRevalidatesOriginScheme(t *testing.T) {
 	require.Contains(t, err.Error(), "requires http or https")
 }
 
+// waitForContextHandler blocks until the request context is done and then
+// returns ctx.Err. It is used to exercise cancellation and deadline identity
+// through the real trpc-mcp-go HTTPReqHandler path.
+type waitForContextHandler struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (h *waitForContextHandler) Handle(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	h.once.Do(func() {
+		if h.started != nil {
+			close(h.started)
+		}
+	})
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 // rewriteHTTPReqHandler resolves a custom endpoint scheme by redirecting the
 // request to a real HTTP test server. trpc-mcp-go can invoke Handle from
 // background goroutines (for example the GET SSE stream), so the recorded
@@ -1808,6 +1965,8 @@ func TestNamedServerCustomScheme_ReachesHTTPReqHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, output.Tools, 2)
 	require.Contains(t, handler.Schemes(), "custom")
+	// Named custom-scheme streamable clients disable GET-SSE unless the host
+	// opts back in after the broker default.
 	methods := handler.Methods()
 	require.NotEmpty(t, methods)
 	require.NotContains(t, methods, http.MethodGet)

--- a/tool/mcpbroker/broker_test.go
+++ b/tool/mcpbroker/broker_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -1269,6 +1270,10 @@ func TestResolveTargetValidation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, OriginAdhoc, target.Origin)
 	require.Equal(t, targetTypeHTTP, target.TargetType)
+
+	_, err = New(WithAllowAdHocHTTP(true)).resolveTarget(targetInput{URL: "custom://service/mcp"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires http or https")
 }
 
 func TestSplitNamedToolSelectorBranches(t *testing.T) {
@@ -1458,9 +1463,29 @@ func TestNormalizeConnectionConfigValidation(t *testing.T) {
 
 	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
 		ServerURL: "ftp://example.com/mcp",
-	}, false)
+	}, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requires http or https")
+
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "example.com/mcp",
+	}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute server_url")
+
+	// "host:port/path" parses as an opaque URL, so it must be reported as a
+	// missing absolute URL rather than as a missing host.
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "localhost:3000/mcp",
+	}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute server_url")
+
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "custom:///mcp",
+	}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires URL host")
 
 	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
 		ServerURL: "https://example.com/mcp",
@@ -1485,6 +1510,156 @@ func TestNormalizeConnectionConfigValidation(t *testing.T) {
 	}, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ad-hoc MCP only supports HTTP")
+}
+
+func TestNormalizeNamedServerAllowsCustomScheme(t *testing.T) {
+	cfg, kind, err := normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "custom://service/mcp",
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, transportStreamable, kind)
+	// The endpoint must reach the transport verbatim: re-serializing it could
+	// rewrite a scheme that only the host-supplied handler understands.
+	require.Equal(t, "custom://service/mcp", cfg.ServerURL)
+
+	server, err := normalizeNamedServer("custom_named", legacymcp.ConnectionConfig{
+		ServerURL: "custom://service/mcp",
+		Transport: "sse",
+	}, originCode)
+	require.NoError(t, err)
+	require.Equal(t, targetTypeHTTP, server.TargetType)
+	require.Equal(t, "sse", server.Config.Transport)
+	require.Equal(t, "custom://service/mcp", server.Config.ServerURL)
+
+	// The same URL stays rejected for model-supplied ad-hoc targets.
+	_, _, err = normalizeConnectionConfig(legacymcp.ConnectionConfig{
+		ServerURL: "custom://service/mcp",
+	}, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires http or https")
+}
+
+// TestCreateClientRevalidatesOriginScheme covers the defensive revalidation in
+// createClient: it must keep applying the scheme policy of the origin the
+// config was resolved from, so a custom scheme cannot reach the transport on
+// behalf of an ad-hoc target.
+func TestCreateClientRevalidatesOriginScheme(t *testing.T) {
+	cfg := legacymcp.ConnectionConfig{
+		Transport: "streamable",
+		ServerURL: "custom://service/mcp",
+	}
+
+	client, err := createClient(cfg, false, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NoError(t, client.Close())
+
+	_, err = createClient(cfg, true, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires http or https")
+}
+
+// rewriteHTTPReqHandler resolves a custom endpoint scheme by redirecting the
+// request to a real HTTP test server. trpc-mcp-go can invoke Handle from
+// background goroutines (for example the GET SSE stream), so the recorded
+// schemes are mutex-guarded.
+type rewriteHTTPReqHandler struct {
+	dest string
+
+	mu      sync.Mutex
+	schemes []string
+}
+
+func (h *rewriteHTTPReqHandler) Handle(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	h.mu.Lock()
+	h.schemes = append(h.schemes, req.URL.Scheme)
+	h.mu.Unlock()
+
+	dest, err := url.Parse(h.dest)
+	if err != nil {
+		return nil, err
+	}
+	clone := req.Clone(ctx)
+	clone.URL = dest
+	clone.Host = dest.Host
+	clone.RequestURI = ""
+	return client.Do(clone)
+}
+
+func (h *rewriteHTTPReqHandler) Schemes() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.schemes...)
+}
+
+func TestNamedServerCustomScheme_ReachesHTTPReqHandler(t *testing.T) {
+	server := startBrokerHTTPServer(t)
+	defer server.Close()
+
+	handler := &rewriteHTTPReqHandler{dest: server.URL}
+	broker := New(
+		WithServers(map[string]legacymcp.ConnectionConfig{
+			"custom_named": {
+				ServerURL: "custom://service/mcp",
+				Transport: "streamable_http",
+				Timeout:   5 * time.Second,
+			},
+		}),
+		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
+			require.Equal(t, "custom://service/mcp", req.BaseURL)
+			return &ClientOptions{
+				HTTP: []tmcp.ClientOption{
+					tmcp.WithHTTPReqHandler(handler),
+					// GET SSE stays disabled so this operation is a single
+					// request/response exchange: the background GET stream
+					// races with trpc-mcp-go's own session-ID bookkeeping.
+					tmcp.WithClientGetSSEEnabled(false),
+				},
+			}, nil
+		}),
+	)
+
+	output, err := broker.listTools(context.Background(), listToolsInput{Selector: "custom_named"})
+	require.NoError(t, err)
+	require.Len(t, output.Tools, 2)
+	require.Contains(t, handler.Schemes(), "custom")
+}
+
+// TestAdHocSelectorRejectsCustomScheme pins the model-facing half of the trust
+// boundary: only http and https selectors may become ad-hoc targets, so a
+// custom scheme must never open a connection even when ad-hoc HTTP is enabled.
+func TestAdHocSelectorRejectsCustomScheme(t *testing.T) {
+	providerCalls := 0
+	broker := New(
+		WithAllowAdHocHTTP(true),
+		WithClientOptionsProvider(func(ctx context.Context, req *ClientOptionsRequest) (*ClientOptions, error) {
+			providerCalls++
+			return nil, nil
+		}),
+	)
+
+	for _, selector := range []string{"custom://service/mcp", "ftp://example.com/mcp"} {
+		_, err := broker.listTools(context.Background(), listToolsInput{Selector: selector})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown MCP server")
+
+		_, err = broker.inspectTools(context.Background(), inspectToolsInput{
+			Selector: selector,
+			Tools:    []string{"echo"},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown MCP server")
+
+		_, err = broker.callTool(context.Background(), callToolInput{
+			Selector:  selector + ".echo",
+			Arguments: map[string]any{},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown MCP server")
+	}
+
+	// Resolution must fail before any client is built for these selectors.
+	require.Zero(t, providerCalls)
 }
 
 // =============================================================================

--- a/tool/mcpbroker/client.go
+++ b/tool/mcpbroker/client.go
@@ -169,6 +169,8 @@ func canonicalizeHeaders(headers map[string]string) map[string]string {
 
 // resolveOperationError lets the host intercept the underlying error, then
 // hides endpoint details for custom-scheme named servers by default.
+// The top-level error text stays endpoint-neutral while the cause remains
+// available to host code through errors.Is, errors.As, and errors.Unwrap.
 func (b *Broker) resolveOperationError(
 	ctx context.Context,
 	target resolvedTarget,
@@ -183,7 +185,7 @@ func (b *Broker) resolveOperationError(
 		return resolved
 	}
 	if isNamedCustomSchemeTarget(target) && !isModelRequestError(err) {
-		return namedServerOperationError(target.Name)
+		return newNamedServerOperationError(target.Name, err)
 	}
 	return resolved
 }
@@ -217,13 +219,30 @@ func isNamedCustomSchemeTarget(target resolvedTarget) bool {
 		hasCustomEndpointScheme(target.Config.ServerURL)
 }
 
-// namedServerOperationError returns an endpoint-neutral error with no cause.
-func namedServerOperationError(serverName string) error {
+// namedServerOperationError is an endpoint-neutral error for a named
+// custom-scheme server. Its Error text omits endpoint details while Unwrap
+// preserves the original cause for host-side classification.
+type namedServerOperationError struct {
+	msg   string
+	cause error
+}
+
+func (e *namedServerOperationError) Error() string { return e.msg }
+
+func (e *namedServerOperationError) Unwrap() error { return e.cause }
+
+// newNamedServerOperationError returns an endpoint-neutral error whose text
+// names only the server while preserving cause for host-side classification.
+func newNamedServerOperationError(serverName string, cause error) error {
 	serverName = strings.TrimSpace(serverName)
-	if serverName == "" {
-		return errors.New("MCP server request failed; failure details are withheld")
+	msg := "MCP server request failed; failure details are withheld"
+	if serverName != "" {
+		msg = fmt.Sprintf("MCP server %q request failed; failure details are withheld", serverName)
 	}
-	return fmt.Errorf("MCP server %q request failed; failure details are withheld", serverName)
+	return &namedServerOperationError{
+		msg:   msg,
+		cause: cause,
+	}
 }
 
 func interceptHTTPOperationError(
@@ -377,7 +396,7 @@ func createClient(
 		opts = append(opts, extraHTTP...)
 		return tmcp.NewSSEClient(cfg.ServerURL, clientInfo, opts...)
 	case transportStreamable:
-		return tmcp.NewClient(cfg.ServerURL, clientInfo, streamableClientOptions(cfg, extraHTTP)...)
+		return tmcp.NewClient(cfg.ServerURL, clientInfo, streamableClientOptions(cfg, adHoc, extraHTTP)...)
 	default:
 		return nil, fmt.Errorf("unsupported transport: %s", cfg.Transport)
 	}
@@ -401,15 +420,20 @@ func httpHeaderOptions(headers map[string]string) []tmcp.ClientOption {
 
 // streamableClientOptions builds the option list for a streamable client.
 //
-// Broker operations use single-use clients and do not consume server-initiated
-// messages, so the background GET stream is disabled by default. Host options
-// are applied last and can opt back in.
+// Existing named HTTP/HTTPS and ad-hoc HTTP/HTTPS targets keep the
+// trpc-mcp-go GET-SSE default. Code-configured named custom-scheme targets
+// disable the background GET stream because broker operations use single-use
+// clients and do not consume server-initiated messages. Host options are
+// applied last so an internal host can opt back in.
 func streamableClientOptions(
 	cfg mcpcfg.ConnectionConfig,
+	adHoc bool,
 	extraHTTP []tmcp.ClientOption,
 ) []tmcp.ClientOption {
 	opts := httpHeaderOptions(cfg.Headers)
-	opts = append(opts, tmcp.WithClientGetSSEEnabled(false))
+	if !adHoc && hasCustomEndpointScheme(cfg.ServerURL) {
+		opts = append(opts, tmcp.WithClientGetSSEEnabled(false))
+	}
 	return append(opts, extraHTTP...)
 }
 
@@ -446,10 +470,65 @@ func withOneShotClient[T any](
 		return zero, err
 	}
 	defer client.Close()
+	preserveContextIdentity := !adHoc && hasCustomEndpointScheme(cfg.ServerURL)
 
 	if _, err := client.Initialize(ctx, &tmcp.InitializeRequest{}); err != nil {
-		return zero, fmt.Errorf("initialize MCP client: %w", err)
+		err = fmt.Errorf("initialize MCP client: %w", err)
+		if preserveContextIdentity {
+			err = preserveOperationContextError(ctx, err)
+		}
+		return zero, err
 	}
 
-	return fn(ctx, client)
+	result, err := fn(ctx, client)
+	if preserveContextIdentity {
+		err = preserveOperationContextError(ctx, err)
+	}
+	return result, err
+}
+
+// operationContextError keeps the original error text and unwrap chain while
+// restoring cancellation or deadline identity from the active operation
+// context. trpc-mcp-go formats some HTTPReqHandler failures with %v, which
+// otherwise drops errors.Is matches for those sentinels.
+type operationContextError struct {
+	err      error
+	canceled bool
+	deadline bool
+}
+
+func (e *operationContextError) Error() string { return e.err.Error() }
+
+func (e *operationContextError) Unwrap() error { return e.err }
+
+func (e *operationContextError) Is(target error) bool {
+	return (e.canceled && target == context.Canceled) ||
+		(e.deadline && target == context.DeadlineExceeded)
+}
+
+// preserveOperationContextError records the operation context's cancellation
+// or deadline identity when Initialize or the operation callback fails and
+// that context is already done. The original error text is unchanged.
+func preserveOperationContextError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	ctxErr := ctx.Err()
+	if ctxErr == nil {
+		return err
+	}
+	canceled := errors.Is(ctxErr, context.Canceled)
+	deadline := errors.Is(ctxErr, context.DeadlineExceeded)
+	if !canceled && !deadline {
+		return err
+	}
+	if (!canceled || errors.Is(err, context.Canceled)) &&
+		(!deadline || errors.Is(err, context.DeadlineExceeded)) {
+		return err
+	}
+	return &operationContextError{
+		err:      err,
+		canceled: canceled,
+		deadline: deadline,
+	}
 }

--- a/tool/mcpbroker/client.go
+++ b/tool/mcpbroker/client.go
@@ -11,6 +11,7 @@ package mcpbroker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -166,6 +167,65 @@ func canonicalizeHeaders(headers map[string]string) map[string]string {
 	return result
 }
 
+// resolveOperationError lets the host intercept the underlying error, then
+// hides endpoint details for custom-scheme named servers by default.
+func (b *Broker) resolveOperationError(
+	ctx context.Context,
+	target resolvedTarget,
+	meta operationMetadata,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+	handled, resolved := interceptHTTPOperationError(ctx, b, target, meta, err)
+	if handled {
+		return resolved
+	}
+	if isNamedCustomSchemeTarget(target) && !isModelRequestError(err) {
+		return namedServerOperationError(target.Name)
+	}
+	return resolved
+}
+
+// modelRequestError marks a safe error about the model's own request so it
+// remains available for self-correction after endpoint redaction.
+type modelRequestError struct {
+	err error
+}
+
+func (e *modelRequestError) Error() string { return e.err.Error() }
+
+func (e *modelRequestError) Unwrap() error { return e.err }
+
+// newModelRequestError marks err as describing the model's request.
+func newModelRequestError(err error) error {
+	return &modelRequestError{err: err}
+}
+
+// isModelRequestError reports whether err was raised about the model's request.
+func isModelRequestError(err error) bool {
+	var marker *modelRequestError
+	return errors.As(err, &marker)
+}
+
+// isNamedCustomSchemeTarget reports whether target is a code-configured HTTP
+// server whose endpoint uses a scheme only a host-supplied handler can resolve.
+func isNamedCustomSchemeTarget(target resolvedTarget) bool {
+	return target.Origin == OriginCode &&
+		target.TargetType == targetTypeHTTP &&
+		hasCustomEndpointScheme(target.Config.ServerURL)
+}
+
+// namedServerOperationError returns an endpoint-neutral error with no cause.
+func namedServerOperationError(serverName string) error {
+	serverName = strings.TrimSpace(serverName)
+	if serverName == "" {
+		return errors.New("MCP server request failed; failure details are withheld")
+	}
+	return fmt.Errorf("MCP server %q request failed; failure details are withheld", serverName)
+}
+
 func interceptHTTPOperationError(
 	ctx context.Context,
 	b *Broker,
@@ -317,9 +377,7 @@ func createClient(
 		opts = append(opts, extraHTTP...)
 		return tmcp.NewSSEClient(cfg.ServerURL, clientInfo, opts...)
 	case transportStreamable:
-		opts := httpHeaderOptions(cfg.Headers)
-		opts = append(opts, extraHTTP...)
-		return tmcp.NewClient(cfg.ServerURL, clientInfo, opts...)
+		return tmcp.NewClient(cfg.ServerURL, clientInfo, streamableClientOptions(cfg, extraHTTP)...)
 	default:
 		return nil, fmt.Errorf("unsupported transport: %s", cfg.Transport)
 	}
@@ -339,6 +397,20 @@ func httpHeaderOptions(headers map[string]string) []tmcp.ClientOption {
 		httpHeaders.Set(http.CanonicalHeaderKey(trimmed), value)
 	}
 	return []tmcp.ClientOption{tmcp.WithHTTPHeaders(httpHeaders)}
+}
+
+// streamableClientOptions builds the option list for a streamable client.
+//
+// Broker operations use single-use clients and do not consume server-initiated
+// messages, so the background GET stream is disabled by default. Host options
+// are applied last and can opt back in.
+func streamableClientOptions(
+	cfg mcpcfg.ConnectionConfig,
+	extraHTTP []tmcp.ClientOption,
+) []tmcp.ClientOption {
+	opts := httpHeaderOptions(cfg.Headers)
+	opts = append(opts, tmcp.WithClientGetSSEEnabled(false))
+	return append(opts, extraHTTP...)
 }
 
 func withTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/tool/mcpbroker/client.go
+++ b/tool/mcpbroker/client.go
@@ -283,13 +283,22 @@ func filterNilStdioClientOptions(opts []tmcp.StdioClientOption) []tmcp.StdioClie
 	return result
 }
 
-func createClient(cfg mcpcfg.ConnectionConfig, extraHTTP []tmcp.ClientOption, extraStdio []tmcp.StdioClientOption) (tmcp.Connector, error) {
+// createClient revalidates cfg before building the underlying MCP client. adHoc
+// must describe the origin the config was resolved from so this second pass
+// applies the same scheme policy as resolution: ad-hoc URLs stay restricted to
+// http and https, while named servers may use custom schemes.
+func createClient(
+	cfg mcpcfg.ConnectionConfig,
+	adHoc bool,
+	extraHTTP []tmcp.ClientOption,
+	extraStdio []tmcp.StdioClientOption,
+) (tmcp.Connector, error) {
 	clientInfo := cfg.ClientInfo
 	if clientInfo.Name == "" {
 		clientInfo = defaultClientInfo
 	}
 
-	_, kind, err := normalizeConnectionConfig(cfg, false)
+	_, kind, err := normalizeConnectionConfig(cfg, adHoc)
 	if err != nil {
 		return nil, err
 	}
@@ -346,6 +355,7 @@ func withTimeoutContext(ctx context.Context, timeout time.Duration) (context.Con
 func withOneShotClient[T any](
 	ctx context.Context,
 	cfg mcpcfg.ConnectionConfig,
+	adHoc bool,
 	extraHTTP []tmcp.ClientOption,
 	extraStdio []tmcp.StdioClientOption,
 	fn func(context.Context, tmcp.Connector) (T, error),
@@ -359,7 +369,7 @@ func withOneShotClient[T any](
 	ctx, cancel := withTimeoutContext(ctx, cfg.Timeout)
 	defer cancel()
 
-	client, err := createClient(cfg, extraHTTP, extraStdio)
+	client, err := createClient(cfg, adHoc, extraHTTP, extraStdio)
 	if err != nil {
 		return zero, err
 	}

--- a/tool/mcpbroker/config.go
+++ b/tool/mcpbroker/config.go
@@ -123,6 +123,21 @@ func validateHTTPServerURL(serverURL string, adHoc bool) error {
 	return nil
 }
 
+// hasCustomEndpointScheme reports whether serverURL uses a scheme other than
+// http or https, which only named servers may do. An endpoint that fails to
+// parse is reported as custom: normalization already rejects such URLs, so the
+// remaining callers prefer withholding an endpoint over disclosing one.
+func hasCustomEndpointScheme(serverURL string) bool {
+	parsedURL, err := url.Parse(strings.TrimSpace(serverURL))
+	if err != nil {
+		return true
+	}
+	scheme := parsedURL.Scheme
+	return scheme != "" &&
+		!strings.EqualFold(scheme, "http") &&
+		!strings.EqualFold(scheme, "https")
+}
+
 func normalizeTransport(raw string, hasCommand, hasURL, adHoc bool) (string, transportKind, error) {
 	value := strings.ToLower(strings.TrimSpace(raw))
 	if value == "" {

--- a/tool/mcpbroker/config.go
+++ b/tool/mcpbroker/config.go
@@ -79,15 +79,8 @@ func normalizeConnectionConfig(cfg mcpcfg.ConnectionConfig, adHoc bool) (mcpcfg.
 		if command != "" {
 			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP cannot specify command")
 		}
-		parsedURL, parseErr := url.Parse(serverURL)
-		if parseErr != nil {
-			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("invalid server_url %q: %w", serverURL, parseErr)
-		}
-		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP requires http or https URL")
-		}
-		if parsedURL.Host == "" {
-			return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("HTTP MCP requires URL host")
+		if err := validateHTTPServerURL(serverURL, adHoc); err != nil {
+			return mcpcfg.ConnectionConfig{}, "", err
 		}
 	default:
 		return mcpcfg.ConnectionConfig{}, "", fmt.Errorf("unsupported transport")
@@ -103,6 +96,31 @@ func normalizeConnectionConfig(cfg mcpcfg.ConnectionConfig, adHoc bool) (mcpcfg.
 		Description: strings.TrimSpace(cfg.Description),
 		ClientInfo:  cfg.ClientInfo,
 	}, kind, nil
+}
+
+// validateHTTPServerURL checks a streamable/SSE endpoint URL.
+//
+// Named servers (adHoc == false) accept any structurally valid absolute URL
+// with a scheme and host so host code can register custom endpoint schemes.
+// Ad-hoc URLs stay restricted to http and https.
+func validateHTTPServerURL(serverURL string, adHoc bool) error {
+	parsedURL, parseErr := url.Parse(serverURL)
+	if parseErr != nil {
+		return fmt.Errorf("invalid server_url %q: %w", serverURL, parseErr)
+	}
+	if adHoc && parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("HTTP MCP requires http or https URL")
+	}
+	// A rootless URL such as "host:port/path" parses with the host as its
+	// scheme and no authority, so report both shapes as a missing absolute URL
+	// instead of claiming the host is missing.
+	if parsedURL.Scheme == "" || parsedURL.Opaque != "" {
+		return fmt.Errorf("HTTP MCP requires an absolute server_url like scheme://host/path")
+	}
+	if parsedURL.Host == "" {
+		return fmt.Errorf("HTTP MCP requires URL host")
+	}
+	return nil
 }
 
 func normalizeTransport(raw string, hasCommand, hasURL, adHoc bool) (string, transportKind, error) {

--- a/tool/mcpbroker/tools.go
+++ b/tool/mcpbroker/tools.go
@@ -142,7 +142,7 @@ func (b *Broker) listTools(ctx context.Context, input listToolsInput) (listTools
 		return listToolsOutput{}, err
 	}
 
-	mcpTools, err := withOneShotClient(ctx, cfg, httpExtra, stdioExtra, func(opCtx context.Context, client tmcp.Connector) ([]tmcp.Tool, error) {
+	mcpTools, err := withOneShotClient(ctx, cfg, target.Origin == OriginAdhoc, httpExtra, stdioExtra, func(opCtx context.Context, client tmcp.Connector) ([]tmcp.Tool, error) {
 		result, listErr := client.ListTools(opCtx, &tmcp.ListToolsRequest{})
 		if listErr != nil {
 			return nil, fmt.Errorf("list MCP tools: %w", listErr)
@@ -207,7 +207,7 @@ func (b *Broker) inspectTools(ctx context.Context, input inspectToolsInput) (ins
 		return inspectToolsOutput{}, err
 	}
 
-	mcpTools, err := withOneShotClient(ctx, cfg, httpExtra, stdioExtra, func(opCtx context.Context, client tmcp.Connector) ([]tmcp.Tool, error) {
+	mcpTools, err := withOneShotClient(ctx, cfg, target.Origin == OriginAdhoc, httpExtra, stdioExtra, func(opCtx context.Context, client tmcp.Connector) ([]tmcp.Tool, error) {
 		result, listErr := client.ListTools(opCtx, &tmcp.ListToolsRequest{})
 		if listErr != nil {
 			return nil, fmt.Errorf("list MCP tools: %w", listErr)
@@ -279,7 +279,7 @@ func (b *Broker) callTool(ctx context.Context, input callToolInput) (callToolOut
 		return callToolOutput{}, err
 	}
 
-	result, err := withOneShotClient(ctx, cfg, httpExtra, stdioExtra, func(opCtx context.Context, client tmcp.Connector) (*tmcp.CallToolResult, error) {
+	result, err := withOneShotClient(ctx, cfg, target.Origin == OriginAdhoc, httpExtra, stdioExtra, func(opCtx context.Context, client tmcp.Connector) (*tmcp.CallToolResult, error) {
 		if validateErr := validateCallToolArguments(opCtx, client, toolName, input.Arguments); validateErr != nil {
 			return nil, validateErr
 		}

--- a/tool/mcpbroker/tools.go
+++ b/tool/mcpbroker/tools.go
@@ -150,14 +150,11 @@ func (b *Broker) listTools(ctx context.Context, input listToolsInput) (listTools
 		return result.Tools, nil
 	})
 	if err != nil {
-		if handled, interceptErr := interceptHTTPOperationError(ctx, b, target, operationMetadata{
+		return listToolsOutput{}, b.resolveOperationError(ctx, target, operationMetadata{
 			Selector: input.Selector,
 			BaseURL:  target.Config.ServerURL,
 			Phase:    PhaseListTools,
-		}, err); handled {
-			return listToolsOutput{}, interceptErr
-		}
-		return listToolsOutput{}, err
+		}, err)
 	}
 
 	sort.Slice(mcpTools, func(i, j int) bool {
@@ -215,14 +212,11 @@ func (b *Broker) inspectTools(ctx context.Context, input inspectToolsInput) (ins
 		return result.Tools, nil
 	})
 	if err != nil {
-		if handled, interceptErr := interceptHTTPOperationError(ctx, b, target, operationMetadata{
+		return inspectToolsOutput{}, b.resolveOperationError(ctx, target, operationMetadata{
 			Selector: input.Selector,
 			BaseURL:  target.Config.ServerURL,
 			Phase:    PhaseInspectTools,
-		}, err); handled {
-			return inspectToolsOutput{}, interceptErr
-		}
-		return inspectToolsOutput{}, err
+		}, err)
 	}
 
 	selectedTools, err := selectToolsForInspection(mcpTools, input.Tools)
@@ -295,15 +289,12 @@ func (b *Broker) callTool(ctx context.Context, input callToolInput) (callToolOut
 		return callResult, nil
 	})
 	if err != nil {
-		if handled, interceptErr := interceptHTTPOperationError(ctx, b, target, operationMetadata{
+		return callToolOutput{}, b.resolveOperationError(ctx, target, operationMetadata{
 			Selector: input.Selector,
 			BaseURL:  target.Config.ServerURL,
 			ToolName: toolName,
 			Phase:    PhaseCallTool,
-		}, err); handled {
-			return callToolOutput{}, interceptErr
-		}
-		return callToolOutput{}, err
+		}, err)
 	}
 
 	output := callToolOutput{
@@ -338,7 +329,7 @@ func validateCallToolArguments(
 		}
 	}
 	if target == nil {
-		return fmt.Errorf("MCP tool %q not found", toolName)
+		return newModelRequestError(fmt.Errorf("MCP tool %q not found", toolName))
 	}
 
 	if target.InputSchema == nil || len(target.InputSchema.Required) == 0 {
@@ -357,7 +348,9 @@ func validateCallToolArguments(
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
-		return fmt.Errorf("missing required arguments for MCP tool %q: %s", toolName, strings.Join(missing, ", "))
+		return newModelRequestError(
+			fmt.Errorf("missing required arguments for MCP tool %q: %s", toolName, strings.Join(missing, ", ")),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## What changed

- Allow code-configured named HTTP MCP servers to use structurally valid custom URL schemes.
- Keep model-controlled ad-hoc URL selectors restricted to HTTP and HTTPS during both target resolution and client creation.
- Let host-provided `HTTPReqHandler` implementations resolve custom schemes without adding internal transport knowledge to `mcpbroker`.
- Improve diagnostics for malformed absolute URLs and document handler/error behavior in English and Chinese.
- Add coverage for named custom schemes, model-facing rejection, client revalidation, and concurrent request-handler recording.

## Why

Named servers are trusted host configuration, while runtime URL selectors are model-controlled input. Treating both sources identically prevented internal hosts from reusing an existing custom-scheme transport such as service discovery, even when the host had already installed a compatible request handler.

This change makes that trust boundary explicit: named servers may use any absolute URL with a valid scheme and host, while ad-hoc selectors remain HTTP/HTTPS only. The public implementation stays transport-neutral and does not depend on any internal scheme or service-discovery package.

## Testing

- `go test ./tool/mcpbroker/ ./tool/mcp/`
- Focused `-race` tests for custom-scheme validation, model-facing rejection, client revalidation, and handler recording
- `go vet ./tool/mcpbroker/ ./tool/mcp/`
- `go build ./...`
- `gofmt`, `goimports`, and `git diff --check`

## Notes for reviewers

- The broker validates URL structure but does not verify that a handler for a custom scheme is installed. Without one, the named server fails on first use.
- Connection errors can contain the endpoint URL; hosts can use `WithErrorInterceptor` to redact internal endpoints before errors reach the model.
- The repository currently uses `trpc-mcp-go v0.0.10`. The latest available `v0.0.18` remains API-compatible but still reproduces the existing streamable-client and stdio races, so this PR does not include an unrelated dependency upgrade.
- Full-package race failures reproduce on an unmodified `upstream/main`; all new and changed tests pass under the race detector.