### PR TITLE
tool: add a youcom web search ToolSet

### DIFF
--- a/docs/mkdocs/en/blog/openclaw.md
+++ b/docs/mkdocs/en/blog/openclaw.md
@@ -567,7 +567,7 @@ After Gateway, `openclaw` directly reuses the existing execution system in tRPC-
 - Session backend: `inmemory`, `redis`, `sqlite`, `mysql`, `postgres`, `clickhouse`
 - Memory backend: `inmemory`, `redis`, `mysql`, `postgres`, `pgvector`
 - Tool providers: `duckduckgo`, `webfetch_http`
-- ToolSet providers: `mcp`, `file`, `openapi`, `google`, `wikipedia`, `arxivsearch`, `email`
+- ToolSet providers: `mcp`, `file`, `openapi`, `google`, `wikipedia`, `arxivsearch`, `email`, `youcom`
 - Skills: skill directories based on `SKILL.md`
 
 In addition, `openclaw` adds several kinds of tools that are closer to long-running scenarios:

--- a/docs/mkdocs/en/openclaw-runtime.md
+++ b/docs/mkdocs/en/openclaw-runtime.md
@@ -648,7 +648,7 @@ capabilities:
   `postgres`, `pgvector`
 - Tool providers: `duckduckgo`, `webfetch_http`
 - ToolSet providers: `mcp`, `file`, `openapi`, `google`,
-  `wikipedia`, `arxivsearch`, `email`
+  `wikipedia`, `arxivsearch`, `email`, `youcom`
 - Skills: skill directories driven by `SKILL.md`
 
 On top of that, `openclaw` adds several tools that are especially

--- a/docs/mkdocs/zh/blog/openclaw.md
+++ b/docs/mkdocs/zh/blog/openclaw.md
@@ -572,7 +572,7 @@ Gateway 之后，`openclaw` 直接复用 tRPC-Agent-Go 现有的执行体系。�
 - Memory backend：`inmemory`、`redis`、`mysql`、`postgres`、`pgvector`
 - Tool providers：`duckduckgo`、`webfetch_http`
 - ToolSet providers：`mcp`、`file`、`openapi`、`google`、
-  `wikipedia`、`arxivsearch`、`email`
+  `wikipedia`、`arxivsearch`、`email`、`youcom`
 - Skills：基于 `SKILL.md` 的技能目录
 
 除此之外，`openclaw` 还补充了几类更贴近长期运行场景的工具：

--- a/docs/mkdocs/zh/openclaw-runtime.md
+++ b/docs/mkdocs/zh/openclaw-runtime.md
@@ -604,7 +604,7 @@ Gateway 之后，`openclaw` 直接复用 tRPC-Agent-Go 现有的执行体系。
   `postgres`、`pgvector`
 - Tool providers：`duckduckgo`、`webfetch_http`
 - ToolSet providers：`mcp`、`file`、`openapi`、`google`、
-  `wikipedia`、`arxivsearch`、`email`
+  `wikipedia`、`arxivsearch`、`email`、`youcom`
 - Skills：基于 `SKILL.md` 的技能目录
 
 除此之外，`openclaw` 还补充了几类更贴近长期运行场景的工具：

--- a/openclaw/INTEGRATIONS.md
+++ b/openclaw/INTEGRATIONS.md
@@ -1336,7 +1336,10 @@ the credentialed `google` toolset.
 
 Requires a You.com API key. Set `api_key` in the config or export
 `YDC_API_KEY` (config wins when both are present). Keys are available at
-[you.com/platform/api-keys](https://you.com/platform/api-keys).
+[you.com/platform/api-keys](https://you.com/platform/api-keys). The toolset
+calls the documented Web Search API endpoint
+(`https://ydc-index.io/v1/search`); `base_url` exists for testing and must
+be HTTPS.
 
 ```yaml
 tools:

--- a/openclaw/INTEGRATIONS.md
+++ b/openclaw/INTEGRATIONS.md
@@ -1328,6 +1328,41 @@ tools:
         num_retries: 3
 ```
 
+### ToolSet: youcom
+
+You.com Web Search toolset. Live web search with URLs, titles, and
+snippets; good general-purpose companion to the `duckduckgo` provider and
+the credentialed `google` toolset.
+
+Requires a You.com API key. Set `api_key` in the config or export
+`YDC_API_KEY` (config wins when both are present). Keys are available at
+[you.com/platform/api-keys](https://you.com/platform/api-keys).
+
+```yaml
+tools:
+  refresh_toolsets_on_run: true
+  toolsets:
+    - type: "youcom"
+      name: "youcom"
+      config:
+        # api_key: "..."  # or use the YDC_API_KEY env var
+        num_results: 5
+        country: "US"
+        safe_search: "moderate"
+        timeout: "30s"
+```
+
+Config fields:
+
+- `api_key` (or environment `YDC_API_KEY`)
+- optional: `num_results` (default 10, max 10), `country`, `safe_search`
+  (`strict` / `moderate` / `off`), `base_url`, `user_agent`, `timeout`
+
+The search tool is named `search` and is automatically namespaced under
+the toolset `name` (for example `youcom_search` when the toolset is named
+`youcom`). Per-call request fields `num_results`, `country`, and
+`safe_search` override the configured defaults.
+
 ### ToolSet: email
 
 Email sending toolset.

--- a/openclaw/app/tooling_builtins.go
+++ b/openclaw/app/tooling_builtins.go
@@ -31,6 +31,7 @@ import (
 	openapitool "trpc.group/trpc-go/trpc-agent-go/tool/openapi"
 	httpfetch "trpc.group/trpc-go/trpc-agent-go/tool/webfetch/httpfetch"
 	"trpc.group/trpc-go/trpc-agent-go/tool/wikipedia"
+	youcomsearch "trpc.group/trpc-go/trpc-agent-go/tool/youcom"
 
 	ocbrowser "trpc.group/trpc-go/trpc-agent-go/openclaw/internal/browser"
 	"trpc.group/trpc-go/trpc-agent-go/openclaw/internal/imageinspect"
@@ -50,11 +51,13 @@ const (
 	toolSetProviderWiki    = "wikipedia"
 	toolSetProviderArxiv   = "arxivsearch"
 	toolSetProviderEmail   = "email"
+	toolSetProviderYouCom  = "youcom"
 
 	defaultHTTPTimeout = 30 * time.Second
 
 	envGoogleAPIKey   = "GOOGLE_API_KEY"
 	envGoogleEngineID = "GOOGLE_SEARCH_ENGINE_ID"
+	envYouComAPIKey   = "YDC_API_KEY"
 
 	mcpTransportStdio      = "stdio"
 	mcpTransportSSE        = "sse"
@@ -108,6 +111,10 @@ func init() {
 	must(registry.RegisterToolSetProvider(
 		toolSetProviderEmail,
 		newEmailToolSet,
+	))
+	must(registry.RegisterToolSetProvider(
+		toolSetProviderYouCom,
+		newYouComToolSet,
 	))
 }
 
@@ -787,6 +794,58 @@ func newEmailToolSet(
 	spec registry.PluginSpec,
 ) (tool.ToolSet, error) {
 	ts, err := email.NewToolSet()
+	if err != nil {
+		return nil, err
+	}
+	return overrideToolSetName(ts, spec.Name), nil
+}
+
+type youComToolSetConfig struct {
+	APIKey     string        `yaml:"api_key,omitempty"`
+	BaseURL    string        `yaml:"base_url,omitempty"`
+	NumResults int           `yaml:"num_results,omitempty"`
+	Country    string        `yaml:"country,omitempty"`
+	SafeSearch string        `yaml:"safe_search,omitempty"`
+	UserAgent  string        `yaml:"user_agent,omitempty"`
+	Timeout    time.Duration `yaml:"timeout,omitempty"`
+}
+
+func newYouComToolSet(
+	_ registry.ToolSetProviderDeps,
+	spec registry.PluginSpec,
+) (tool.ToolSet, error) {
+	var cfg youComToolSetConfig
+	if err := registry.DecodeStrict(spec.Config, &cfg); err != nil {
+		return nil, err
+	}
+
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	if apiKey == "" {
+		apiKey = strings.TrimSpace(os.Getenv(envYouComAPIKey))
+	}
+
+	options := make([]youcomsearch.Option, 0, 6)
+	options = append(options, youcomsearch.WithAPIKey(apiKey))
+	if baseURL := strings.TrimSpace(cfg.BaseURL); baseURL != "" {
+		options = append(options, youcomsearch.WithBaseURL(baseURL))
+	}
+	if cfg.NumResults > 0 {
+		options = append(options, youcomsearch.WithNumResults(cfg.NumResults))
+	}
+	if country := strings.TrimSpace(cfg.Country); country != "" {
+		options = append(options, youcomsearch.WithCountry(country))
+	}
+	if safeSearch := strings.TrimSpace(cfg.SafeSearch); safeSearch != "" {
+		options = append(options, youcomsearch.WithSafeSearch(safeSearch))
+	}
+	if ua := strings.TrimSpace(cfg.UserAgent); ua != "" {
+		options = append(options, youcomsearch.WithUserAgent(ua))
+	}
+	if cfg.Timeout > 0 {
+		options = append(options, youcomsearch.WithTimeout(cfg.Timeout))
+	}
+
+	ts, err := youcomsearch.NewToolSet(options...)
 	if err != nil {
 		return nil, err
 	}

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -1147,6 +1147,60 @@ func TestNewEmailToolSet_NameOverride(t *testing.T) {
 	require.NotEmpty(t, ts.Tools(context.Background()))
 }
 
+func TestNewYouComToolSet_RequiresAPIKey(t *testing.T) {
+	t.Setenv(envYouComAPIKey, "")
+
+	_, err := newYouComToolSet(
+		registry.ToolSetProviderDeps{},
+		registry.PluginSpec{},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "api key is required")
+}
+
+func TestNewYouComToolSet_EnvFallbackAndNameOverride(t *testing.T) {
+	t.Setenv(envYouComAPIKey, "k")
+
+	cfg := yamlNode(t, `
+num_results: 5
+country: "US"
+safe_search: "moderate"
+timeout: 200ms
+`)
+	ts, err := newYouComToolSet(
+		registry.ToolSetProviderDeps{},
+		registry.PluginSpec{Name: "yc", Config: cfg},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+	require.Equal(t, "yc", ts.Name())
+	tools := ts.Tools(context.Background())
+	require.NotEmpty(t, tools)
+	require.Contains(
+		t,
+		tools[0].Declaration().Description,
+		"YOU.COM WEB SEARCH",
+	)
+}
+
+func TestNewYouComToolSet_ConfigAPIKeyWins(t *testing.T) {
+	t.Setenv(envYouComAPIKey, "from-env")
+
+	cfg := yamlNode(t, `
+api_key: "from-config"
+base_url: "https://example.invalid"
+num_results: 3
+`)
+	ts, err := newYouComToolSet(
+		registry.ToolSetProviderDeps{},
+		registry.PluginSpec{Name: "yc", Config: cfg},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+	require.Equal(t, "yc", ts.Name())
+	require.NotEmpty(t, ts.Tools(context.Background()))
+}
+
 func mcpConn(
 	transport, urlStr, command string,
 	args []string,

--- a/openclaw/app/tooling_builtins_test.go
+++ b/openclaw/app/tooling_builtins_test.go
@@ -11,8 +11,10 @@ package app
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -24,6 +26,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1186,11 +1189,32 @@ timeout: 200ms
 func TestNewYouComToolSet_ConfigAPIKeyWins(t *testing.T) {
 	t.Setenv(envYouComAPIKey, "from-env")
 
-	cfg := yamlNode(t, `
+	// The tool set builds its own HTTP client on top of http.DefaultTransport;
+	// point a cloned transport at the self-signed test cert for this test.
+	oldTransport := http.DefaultTransport
+	testTransport := oldTransport.(*http.Transport).Clone()
+	testTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test-only
+	http.DefaultTransport = testTransport
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+
+	var mu sync.Mutex
+	var gotKey string
+	srv := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			gotKey = r.Header.Get("X-API-Key")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":{"web":[],"news":[]}}`))
+		},
+	))
+	defer srv.Close()
+
+	cfg := yamlNode(t, fmt.Sprintf(`
 api_key: "from-config"
-base_url: "https://example.invalid"
+base_url: %q
 num_results: 3
-`)
+`, srv.URL))
 	ts, err := newYouComToolSet(
 		registry.ToolSetProviderDeps{},
 		registry.PluginSpec{Name: "yc", Config: cfg},
@@ -1198,7 +1222,23 @@ num_results: 3
 	require.NoError(t, err)
 	require.NotNil(t, ts)
 	require.Equal(t, "yc", ts.Name())
-	require.NotEmpty(t, ts.Tools(context.Background()))
+	tools := ts.Tools(context.Background())
+	require.NotEmpty(t, tools)
+
+	// The configured key must win over the environment variable: assert it
+	// through an actual search request rather than construction alone.
+	searchTool, ok := tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	require.True(t, ok)
+	reqJSON, err := json.Marshal(map[string]string{"query": "precedence"})
+	require.NoError(t, err)
+	_, err = searchTool.Call(context.Background(), reqJSON)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "from-config", gotKey)
 }
 
 func mcpConn(

--- a/tool/youcom/youcom_search.go
+++ b/tool/youcom/youcom_search.go
@@ -235,14 +235,27 @@ func NewToolSet(opts ...Option) (*ToolSet, error) {
 	httpClient := resolveHTTPClient(cfg)
 	// Guard against the API key leaking through redirects: drop X-API-Key
 	// whenever a redirect would carry the request to a different origin.
+	// A caller-supplied CheckRedirect is preserved: the wrapper invokes the
+	// caller hook (if any) so custom allowlists/denial rules and limits stay
+	// in effect, and only applies the default 10-redirect limit itself when
+	// no caller hook was provided.
 	baseOrigin := base
+	callerRedirect := httpClient.CheckRedirect
 	clonedClient := *httpClient
 	clonedClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 10 {
-			return fmt.Errorf("stopped after 10 redirects")
-		}
+		// Credential protection is owned by the ToolSet and always applies,
+		// regardless of the caller's redirect policy.
 		if !sameOrigin(baseOrigin, req.URL) {
 			req.Header.Del("X-API-Key")
+		}
+		if callerRedirect != nil {
+			// The caller hook decides whether (and how many times) the
+			// redirect is followed. http.ErrUseLastResponse stops here and
+			// returns the redirect response to the caller.
+			return callerRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
 		}
 		return nil
 	}

--- a/tool/youcom/youcom_search.go
+++ b/tool/youcom/youcom_search.go
@@ -1,0 +1,416 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+// Package youcom provides You.com Web Search API tools for AI agents.
+package youcom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-agent-go/tool"
+	"trpc.group/trpc-go/trpc-agent-go/tool/function"
+)
+
+// Default configuration constants.
+const (
+	// defaultBaseURL is the default endpoint for the You.com Web Search API.
+	defaultBaseURL = "https://api.you.com/api/search"
+	// defaultUserAgent is the default user agent for HTTP requests.
+	defaultUserAgent = "trpc-agent-go-youcom/1.0"
+	// defaultTimeout is the default timeout for HTTP requests.
+	defaultTimeout = 30 * time.Second
+	// maxResults is the maximum number of search results to return.
+	maxResults = 10
+	// defaultName is the default tool set name.
+	defaultName = "youcom"
+	// maxSnippetLength caps each returned snippet so a single result cannot
+	// dominate the model context.
+	maxSnippetLength = 500
+)
+
+// config holds the configuration for the You.com search tool set.
+type config struct {
+	apiKey     string
+	baseURL    string
+	userAgent  string
+	httpClient *http.Client
+	// timeout, when non-nil, overrides the HTTP client's request timeout
+	// via shallow copy. A non-nil zero value explicitly disables the timeout.
+	timeout    *time.Duration
+	numResults int
+	country    string
+	safeSearch string
+}
+
+// Option is a functional option for configuring the You.com tool set.
+type Option func(*config)
+
+// WithAPIKey sets the You.com API key used to authenticate requests. The
+// You.com Web Search API requires an API key; it can also be provided through
+// the YDC_API_KEY environment variable at the call site.
+func WithAPIKey(apiKey string) Option {
+	return func(c *config) {
+		c.apiKey = strings.TrimSpace(apiKey)
+	}
+}
+
+// WithBaseURL sets the base URL for the You.com Web Search API.
+func WithBaseURL(baseURL string) Option {
+	return func(c *config) {
+		c.baseURL = strings.TrimSpace(baseURL)
+	}
+}
+
+// WithUserAgent sets the User-Agent string for requests.
+func WithUserAgent(userAgent string) Option {
+	return func(c *config) {
+		c.userAgent = strings.TrimSpace(userAgent)
+	}
+}
+
+// WithNumResults sets the default number of search results to return.
+// Values outside 1..maxResults are clamped when the tool set is created.
+func WithNumResults(numResults int) Option {
+	return func(c *config) {
+		c.numResults = clampNumResults(numResults)
+	}
+}
+
+// WithCountry sets the country code used to bias search results
+// (for example "US" or "DE").
+func WithCountry(country string) Option {
+	return func(c *config) {
+		c.country = strings.TrimSpace(strings.ToUpper(country))
+	}
+}
+
+// WithSafeSearch sets the safe search strictness: "strict", "moderate",
+// or "off".
+func WithSafeSearch(safeSearch string) Option {
+	return func(c *config) {
+		c.safeSearch = normalizeSafeSearch(safeSearch)
+	}
+}
+
+// WithHTTPClient sets the HTTP client used to call the You.com API.
+// When combined with WithTimeout, the caller's *http.Client is never
+// mutated - a shallow copy is used to apply timeout overrides, preserving
+// custom Transport/Proxy/Jar settings. Passing nil falls back to a default
+// client with the default 30s timeout.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *config) {
+		c.httpClient = httpClient
+	}
+}
+
+// WithTimeout sets the HTTP request timeout. When combined with
+// WithHTTPClient, the custom client's Transport/Proxy/Jar settings are
+// preserved via shallow copy - the caller's original *http.Client is never
+// mutated. Passing 0 explicitly disables the default 30s timeout (Go
+// http.Client treats Timeout==0 as "no timeout"). Negative values are
+// ignored.
+func WithTimeout(timeout time.Duration) Option {
+	return func(c *config) {
+		if timeout < 0 {
+			return
+		}
+		c.timeout = &timeout
+	}
+}
+
+// resolveHTTPClient builds the final *http.Client from config, applying
+// nil fallback and timeout override via shallow copy - the caller's
+// original client is never mutated.
+func resolveHTTPClient(cfg *config) *http.Client {
+	httpClient := cfg.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultTimeout}
+	}
+	if cfg.timeout != nil {
+		cloned := *httpClient
+		cloned.Timeout = *cfg.timeout
+		httpClient = &cloned
+	}
+	return httpClient
+}
+
+func clampNumResults(n int) int {
+	if n <= 0 {
+		return maxResults
+	}
+	if n > maxResults {
+		return maxResults
+	}
+	return n
+}
+
+func normalizeSafeSearch(safeSearch string) string {
+	switch strings.ToLower(strings.TrimSpace(safeSearch)) {
+	case "strict":
+		return "strict"
+	case "moderate":
+		return "moderate"
+	case "off":
+		return "off"
+	default:
+		return ""
+	}
+}
+
+// ToolSet implements the ToolSet interface for You.com search.
+type ToolSet struct {
+	tools []tool.Tool
+}
+
+// Tools implements the ToolSet interface.
+func (y *ToolSet) Tools(_ context.Context) []tool.Tool {
+	return y.tools
+}
+
+// Name implements the ToolSet interface.
+func (y *ToolSet) Name() string {
+	return defaultName
+}
+
+// Close implements the ToolSet interface.
+func (y *ToolSet) Close() error {
+	// No resources to clean up for You.com tools.
+	return nil
+}
+
+// NewToolSet creates a new You.com search tool set with the given options.
+// It returns an error when no API key is configured, so callers cannot
+// silently build a tool set that fails on every request.
+func NewToolSet(opts ...Option) (*ToolSet, error) {
+	cfg := &config{
+		baseURL:    defaultBaseURL,
+		userAgent:  defaultUserAgent,
+		numResults: maxResults,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.baseURL == "" {
+		cfg.baseURL = defaultBaseURL
+	}
+	if cfg.numResults <= 0 {
+		cfg.numResults = maxResults
+	}
+	if cfg.apiKey == "" {
+		return nil, fmt.Errorf("youcom: api key is required")
+	}
+
+	searcher := &youcomSearcher{
+		cfg:        cfg,
+		httpClient: resolveHTTPClient(cfg),
+	}
+
+	return &ToolSet{
+		tools: []tool.Tool{function.NewFunctionTool(
+			searcher.search,
+			function.WithName("search"),
+			function.WithDescription(fmt.Sprintf(
+				"🌐 YOU.COM WEB SEARCH - Search the live web via the You.com Search API "+
+					"and return current results with URLs, titles, and snippets. "+
+					"Use when: you need up-to-date information beyond your knowledge cutoff, "+
+					"current events, recent releases or docs, or any question where a live "+
+					"web source should be cited. Default limit: %d results. "+
+					"Follow up with a web fetch tool to read a selected result in full.",
+				cfg.numResults)),
+		)},
+	}, nil
+}
+
+// youcomSearcher performs requests against the You.com Web Search API.
+type youcomSearcher struct {
+	cfg        *config
+	httpClient *http.Client
+}
+
+// searchRequest represents the input for the You.com search tool.
+type searchRequest struct {
+	Query      string `json:"query" jsonschema:"description=The search query to execute on You.com"`
+	NumResults int    `json:"num_results,omitempty" jsonschema:"description=Maximum number of results to return (default: 10, max: 10)"`
+	Country    string `json:"country,omitempty" jsonschema:"description=Country code used to bias results (e.g. US, DE)"`
+	SafeSearch string `json:"safe_search,omitempty" jsonschema:"description=Safe search strictness: strict, moderate, or off"`
+}
+
+// searchResponse represents the output from the You.com search tool.
+type searchResponse struct {
+	Query      string       `json:"query"`                 // Query is the original query string
+	Results    []resultItem `json:"results"`               // Results is the list of search results
+	SearchTime string       `json:"search_time,omitempty"` // SearchTime is the time taken for the search
+	Error      string       `json:"error,omitempty"`       // Error is a human-readable error description
+}
+
+// resultItem represents a single You.com search result.
+type resultItem struct {
+	URL          string   `json:"url"`                     // URL is the address of the result
+	Title        string   `json:"title"`                   // Title is the title of the result
+	Snippets     []string `json:"snippets,omitempty"`      // Snippets are text excerpts from the result
+	ThumbnailURL string   `json:"thumbnail_url,omitempty"` // ThumbnailURL is a preview image, when available
+}
+
+// youcomAPIResult mirrors a single result in the You.com Web Search API
+// response. Unknown fields are ignored so new upstream fields do not break
+// decoding.
+type youcomAPIResult struct {
+	URL          string   `json:"url"`
+	Title        string   `json:"title"`
+	Snippets     []string `json:"snippets"`
+	ThumbnailURL string   `json:"thumbnail_url"`
+}
+
+type youcomAPIResponse struct {
+	Results []youcomAPIResult `json:"results"`
+}
+
+// search executes a search query on You.com and returns the results.
+func (s *youcomSearcher) search(ctx context.Context, req searchRequest) (searchResponse, error) {
+	query := strings.TrimSpace(req.Query)
+	if query == "" {
+		return searchResponse{
+			Query:   req.Query,
+			Results: []resultItem{},
+			Error:   "empty search query provided",
+		}, fmt.Errorf("empty search query provided")
+	}
+
+	numResults := s.cfg.numResults
+	if req.NumResults > 0 {
+		numResults = clampNumResults(req.NumResults)
+	}
+	country := s.cfg.country
+	if c := strings.TrimSpace(strings.ToUpper(req.Country)); c != "" {
+		country = c
+	}
+	safeSearch := s.cfg.safeSearch
+	if ss := normalizeSafeSearch(req.SafeSearch); ss != "" {
+		safeSearch = ss
+	}
+
+	startTime := time.Now()
+	results, err := s.query(ctx, query, numResults, country, safeSearch)
+	searchDuration := time.Since(startTime)
+
+	if err != nil {
+		return searchResponse{
+			Query:   query,
+			Results: []resultItem{},
+			Error:   err.Error(),
+		}, fmt.Errorf("youcom search failed: %w", err)
+	}
+
+	return searchResponse{
+		Query:      query,
+		Results:    results,
+		SearchTime: fmt.Sprintf("%.2fms", float64(searchDuration.Microseconds())/1000.0),
+	}, nil
+}
+
+// query calls the You.com Web Search API and maps the response to result
+// items.
+func (s *youcomSearcher) query(
+	ctx context.Context,
+	query string,
+	numResults int,
+	country string,
+	safeSearch string,
+) ([]resultItem, error) {
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("num_results", fmt.Sprintf("%d", numResults))
+	if country != "" {
+		params.Set("country", country)
+	}
+	if safeSearch != "" {
+		params.Set("safesearch", safeSearch)
+	}
+
+	requestURL := s.cfg.baseURL
+	if strings.ContainsRune(requestURL, '?') {
+		requestURL += "&" + params.Encode()
+	} else {
+		requestURL += "?" + params.Encode()
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("X-API-Key", s.cfg.apiKey)
+	if s.cfg.userAgent != "" {
+		httpReq.Header.Set("User-Agent", s.cfg.userAgent)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf(
+			"unexpected status %d: %s",
+			resp.StatusCode,
+			strings.TrimSpace(string(body)),
+		)
+	}
+
+	var apiResp youcomAPIResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	results := make([]resultItem, 0, len(apiResp.Results))
+	for _, r := range apiResp.Results {
+		item := resultItem{
+			URL:          r.URL,
+			Title:        r.Title,
+			Snippets:     trimSnippets(r.Snippets),
+			ThumbnailURL: r.ThumbnailURL,
+		}
+		if item.URL == "" && item.Title == "" {
+			continue
+		}
+		results = append(results, item)
+	}
+	return results, nil
+}
+
+// trimSnippets drops empty snippets and caps each snippet length.
+func trimSnippets(snippets []string) []string {
+	trimmed := make([]string, 0, len(snippets))
+	for _, snippet := range snippets {
+		snippet = strings.TrimSpace(snippet)
+		if snippet == "" {
+			continue
+		}
+		if len(snippet) > maxSnippetLength {
+			snippet = snippet[:maxSnippetLength] + "…"
+		}
+		trimmed = append(trimmed, snippet)
+	}
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return trimmed
+}

--- a/tool/youcom/youcom_search.go
+++ b/tool/youcom/youcom_search.go
@@ -11,6 +11,7 @@
 package youcom
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"trpc.group/trpc-go/trpc-agent-go/tool"
 	"trpc.group/trpc-go/trpc-agent-go/tool/function"
@@ -26,8 +28,10 @@ import (
 
 // Default configuration constants.
 const (
-	// defaultBaseURL is the default endpoint for the You.com Web Search API.
-	defaultBaseURL = "https://api.you.com/api/search"
+	// defaultBaseURL is the documented endpoint for the You.com Web Search
+	// API: POST https://ydc-index.io/v1/search (see
+	// https://you.com/docs/api-reference/search/v1-search).
+	defaultBaseURL = "https://ydc-index.io/v1/search"
 	// defaultUserAgent is the default user agent for HTTP requests.
 	defaultUserAgent = "trpc-agent-go-youcom/1.0"
 	// defaultTimeout is the default timeout for HTTP requests.
@@ -147,6 +151,11 @@ func resolveHTTPClient(cfg *config) *http.Client {
 	return httpClient
 }
 
+// sameOrigin reports whether two URLs share scheme, host, and port.
+func sameOrigin(a, b *url.URL) bool {
+	return a.Scheme == b.Scheme && a.Host == b.Host
+}
+
 func clampNumResults(n int) int {
 	if n <= 0 {
 		return maxResults
@@ -212,10 +221,33 @@ func NewToolSet(opts ...Option) (*ToolSet, error) {
 	if cfg.apiKey == "" {
 		return nil, fmt.Errorf("youcom: api key is required")
 	}
+	base, err := url.Parse(cfg.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("youcom: invalid base URL %q: %w", cfg.baseURL, err)
+	}
+	if base.Scheme != "https" {
+		return nil, fmt.Errorf("youcom: base URL must be HTTPS, got %q", cfg.baseURL)
+	}
+
+	httpClient := resolveHTTPClient(cfg)
+	// Guard against the API key leaking through redirects: drop X-API-Key
+	// whenever a redirect would carry the request to a different origin.
+	baseOrigin := base
+	clonedClient := *httpClient
+	clonedClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if !sameOrigin(baseOrigin, req.URL) {
+			req.Header.Del("X-API-Key")
+		}
+		return nil
+	}
+	httpClient = &clonedClient
 
 	searcher := &youcomSearcher{
 		cfg:        cfg,
-		httpClient: resolveHTTPClient(cfg),
+		httpClient: httpClient,
 	}
 
 	return &ToolSet{
@@ -265,17 +297,27 @@ type resultItem struct {
 }
 
 // youcomAPIResult mirrors a single result in the You.com Web Search API
-// response. Unknown fields are ignored so new upstream fields do not break
-// decoding.
+// response. Results appear in two sections — `results.web` and
+// `results.news` — with slightly different field sets; `description` is
+// present on both, so it is kept alongside `snippets`. Unknown fields are
+// ignored so new upstream fields do not break decoding.
 type youcomAPIResult struct {
 	URL          string   `json:"url"`
 	Title        string   `json:"title"`
+	Description  string   `json:"description"`
 	Snippets     []string `json:"snippets"`
 	ThumbnailURL string   `json:"thumbnail_url"`
 }
 
+// youcomAPISections models the nested `results` object of the You.com Web
+// Search API response, which groups results into `web` and `news`.
+type youcomAPISections struct {
+	Web  []youcomAPIResult `json:"web"`
+	News []youcomAPIResult `json:"news"`
+}
+
 type youcomAPIResponse struct {
-	Results []youcomAPIResult `json:"results"`
+	Results youcomAPISections `json:"results"`
 }
 
 // search executes a search query on You.com and returns the results.
@@ -322,7 +364,9 @@ func (s *youcomSearcher) search(ctx context.Context, req searchRequest) (searchR
 }
 
 // query calls the You.com Web Search API and maps the response to result
-// items.
+// items. The API is documented as POST https://ydc-index.io/v1/search with a
+// JSON body; the base URL may be overridden for testing, but only HTTPS
+// endpoints are accepted so the API key is never sent in cleartext.
 func (s *youcomSearcher) query(
 	ctx context.Context,
 	query string,
@@ -330,24 +374,32 @@ func (s *youcomSearcher) query(
 	country string,
 	safeSearch string,
 ) ([]resultItem, error) {
-	params := url.Values{}
-	params.Set("query", query)
-	params.Set("num_results", fmt.Sprintf("%d", numResults))
-	if country != "" {
-		params.Set("country", country)
+	base, err := url.Parse(s.cfg.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL %q: %w", s.cfg.baseURL, err)
 	}
-	if safeSearch != "" {
-		params.Set("safesearch", safeSearch)
+	if base.Scheme != "https" {
+		return nil, fmt.Errorf("youcom: base URL must be HTTPS, got %q", s.cfg.baseURL)
 	}
 
-	requestURL := s.cfg.baseURL
-	if strings.ContainsRune(requestURL, '?') {
-		requestURL += "&" + params.Encode()
-	} else {
-		requestURL += "?" + params.Encode()
+	payload := struct {
+		Query      string `json:"query"`
+		Count      int    `json:"count"`
+		Country    string `json:"country,omitempty"`
+		SafeSearch string `json:"safesearch,omitempty"`
+	}{
+		Query:      query,
+		Count:      numResults,
+		Country:    country,
+		SafeSearch: safeSearch,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	httpReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, base.String(), bytes.NewReader(payloadBytes))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -356,6 +408,7 @@ func (s *youcomSearcher) query(
 		httpReq.Header.Set("User-Agent", s.cfg.userAgent)
 	}
 	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.httpClient.Do(httpReq)
 	if err != nil {
@@ -380,13 +433,23 @@ func (s *youcomSearcher) query(
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 
-	results := make([]resultItem, 0, len(apiResp.Results))
-	for _, r := range apiResp.Results {
+	// Flatten the web and news sections, preserving API order within each
+	// section (web results first, matching the API response layout).
+	flat := make([]youcomAPIResult, 0, len(apiResp.Results.Web)+len(apiResp.Results.News))
+	flat = append(flat, apiResp.Results.Web...)
+	flat = append(flat, apiResp.Results.News...)
+
+	results := make([]resultItem, 0, len(flat))
+	for _, r := range flat {
 		item := resultItem{
 			URL:          r.URL,
 			Title:        r.Title,
 			Snippets:     trimSnippets(r.Snippets),
 			ThumbnailURL: r.ThumbnailURL,
+		}
+		// News results often carry a description instead of snippets.
+		if len(item.Snippets) == 0 && r.Description != "" {
+			item.Snippets = trimSnippets([]string{r.Description})
 		}
 		if item.URL == "" && item.Title == "" {
 			continue
@@ -405,7 +468,11 @@ func trimSnippets(snippets []string) []string {
 			continue
 		}
 		if len(snippet) > maxSnippetLength {
-			snippet = snippet[:maxSnippetLength] + "…"
+			cut := maxSnippetLength
+			for cut > 0 && !utf8.RuneStart(snippet[cut]) {
+				cut--
+			}
+			snippet = snippet[:cut] + "…"
 		}
 		trimmed = append(trimmed, snippet)
 	}

--- a/tool/youcom/youcom_search.go
+++ b/tool/youcom/youcom_search.go
@@ -228,6 +228,9 @@ func NewToolSet(opts ...Option) (*ToolSet, error) {
 	if base.Scheme != "https" {
 		return nil, fmt.Errorf("youcom: base URL must be HTTPS, got %q", cfg.baseURL)
 	}
+	if base.Host == "" {
+		return nil, fmt.Errorf("youcom: base URL must include a host, got %q", cfg.baseURL)
+	}
 
 	httpClient := resolveHTTPClient(cfg)
 	// Guard against the API key leaking through redirects: drop X-API-Key
@@ -273,11 +276,14 @@ type youcomSearcher struct {
 }
 
 // searchRequest represents the input for the You.com search tool.
+// Note: the framework splits jsonschema tags on every comma, so the
+// descriptions below deliberately avoid commas; enum values are declared
+// with separate enum= entries.
 type searchRequest struct {
 	Query      string `json:"query" jsonschema:"description=The search query to execute on You.com"`
-	NumResults int    `json:"num_results,omitempty" jsonschema:"description=Maximum number of results to return (default: 10, max: 10)"`
-	Country    string `json:"country,omitempty" jsonschema:"description=Country code used to bias results (e.g. US, DE)"`
-	SafeSearch string `json:"safe_search,omitempty" jsonschema:"description=Safe search strictness: strict, moderate, or off"`
+	NumResults int    `json:"num_results,omitempty" jsonschema:"description=Maximum number of results to return (default 10 max 10)"`
+	Country    string `json:"country,omitempty" jsonschema:"description=Country code used to bias results (e.g. US or DE)"`
+	SafeSearch string `json:"safe_search,omitempty" jsonschema:"description=Safe search strictness,enum=strict,enum=moderate,enum=off"`
 }
 
 // searchResponse represents the output from the You.com search tool.
@@ -434,28 +440,34 @@ func (s *youcomSearcher) query(
 	}
 
 	// Flatten the web and news sections, preserving API order within each
-	// section (web results first, matching the API response layout).
-	flat := make([]youcomAPIResult, 0, len(apiResp.Results.Web)+len(apiResp.Results.News))
-	flat = append(flat, apiResp.Results.Web...)
-	flat = append(flat, apiResp.Results.News...)
-
-	results := make([]resultItem, 0, len(flat))
-	for _, r := range flat {
-		item := resultItem{
-			URL:          r.URL,
-			Title:        r.Title,
-			Snippets:     trimSnippets(r.Snippets),
-			ThumbnailURL: r.ThumbnailURL,
+	// section (web results first, matching the API response layout). The
+	// API treats `count` as a per-section limit, so the sections are
+	// truncated once the combined list reaches numResults to honor the
+	// tool's result-count contract.
+	results := make([]resultItem, 0, numResults)
+	appendSection := func(section []youcomAPIResult) {
+		for _, r := range section {
+			if len(results) == numResults {
+				return
+			}
+			item := resultItem{
+				URL:          r.URL,
+				Title:        r.Title,
+				Snippets:     trimSnippets(r.Snippets),
+				ThumbnailURL: r.ThumbnailURL,
+			}
+			// News results often carry a description instead of snippets.
+			if len(item.Snippets) == 0 && r.Description != "" {
+				item.Snippets = trimSnippets([]string{r.Description})
+			}
+			if item.URL == "" && item.Title == "" {
+				continue
+			}
+			results = append(results, item)
 		}
-		// News results often carry a description instead of snippets.
-		if len(item.Snippets) == 0 && r.Description != "" {
-			item.Snippets = trimSnippets([]string{r.Description})
-		}
-		if item.URL == "" && item.Title == "" {
-			continue
-		}
-		results = append(results, item)
 	}
+	appendSection(apiResp.Results.Web)
+	appendSection(apiResp.Results.News)
 	return results, nil
 }
 

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -578,6 +578,120 @@ func TestSearchToolStripsAPIKeyOnCrossOriginRedirect(t *testing.T) {
 	}
 }
 
+func TestSearchToolPreservesCallerRedirectPolicy(t *testing.T) {
+	var mu sync.Mutex
+	hookCalled := false
+	var gotKeys []string
+	final := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			gotKeys = append(gotKeys, r.Header.Get("X-API-Key"))
+			mu.Unlock()
+		},
+	))
+	defer final.Close()
+
+	origin := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, final.URL+"/v1/search", http.StatusFound)
+		},
+	))
+	defer origin.Close()
+
+	base := fakeTLSClient()
+	base.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		mu.Lock()
+		hookCalled = true
+		mu.Unlock()
+		// Caller policy: never follow redirects.
+		return http.ErrUseLastResponse
+	}
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("secret-key"),
+		WithBaseURL(origin.URL),
+		WithHTTPClient(base),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+	reqJSON, err := json.Marshal(searchRequest{Query: "redirect test"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	// The redirect response (302) is returned as an error by the tool since
+	// it is a non-2xx status; the caller hook must have prevented the
+	// redirect from being followed.
+	_, callErr := searchTool.Call(context.Background(), reqJSON)
+	if callErr == nil {
+		t.Fatal("expected an error from the 302 response returned by ErrUseLastResponse")
+	}
+	if !strings.Contains(callErr.Error(), "302") {
+		t.Errorf("expected 302 status error from unfollowed redirect, got %v", callErr)
+	}
+	mu.Lock()
+	called, keys := hookCalled, append([]string(nil), gotKeys...)
+	mu.Unlock()
+	if !called {
+		t.Error("caller CheckRedirect hook was not invoked")
+	}
+	if len(keys) != 0 {
+		t.Errorf("expected 0 requests at final origin (redirect must not be followed), got %d", len(keys))
+	}
+}
+
+func TestSearchToolDefaultRedirectLimit(t *testing.T) {
+	redirects := 0
+	final := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	defer final.Close()
+
+	// origin responds with an endless same-origin redirect loop.
+	origin := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			redirects++
+			http.Redirect(w, r, r.URL.String(), http.StatusFound)
+		},
+	))
+	defer origin.Close()
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("secret-key"),
+		WithBaseURL(origin.URL),
+		WithHTTPClient(fakeTLSClient()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+	reqJSON, err := json.Marshal(searchRequest{Query: "redirect loop"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if _, callErr := searchTool.Call(context.Background(), reqJSON); callErr == nil {
+		t.Fatal("expected an error from the redirect loop")
+	}
+	if redirects > 10 {
+		t.Errorf("expected the default 10-redirect limit to remain effective, followed %d redirects", redirects)
+	}
+}
+
 func TestTrimSnippetsRuneBoundary(t *testing.T) {
 	// 501 bytes whose 500th byte falls inside a multi-byte rune.
 	cjk := strings.Repeat("界", 200) // 600 bytes of 3-byte runes

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,6 +26,13 @@ import (
 	"time"
 	"unicode/utf8"
 )
+
+// roundTripperFunc adapts a function to the http.RoundTripper interface.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
 
 func TestOption(t *testing.T) {
 	type testCase struct {
@@ -689,11 +697,17 @@ func TestNormalizeSafeSearchOff(t *testing.T) {
 }
 
 func TestSearchToolUnreachableEndpoint(t *testing.T) {
-	// A URL that cannot be resolved ensures the request-execution error
-	// path is exercised.
+	// A RoundTripper returning a fixed error keeps the request-execution
+	// error path deterministic — no DNS or proxy configuration involved.
+	boom := errors.New("boom: transport failure")
 	toolSet, err := NewToolSet(
 		WithAPIKey("key-123"),
-		WithBaseURL("https://invalid.invalid.test/v1/search"),
+		WithBaseURL("https://example.com/v1/search"),
+		WithHTTPClient(&http.Client{
+			Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return nil, boom
+			}),
+		}),
 	)
 	if err != nil {
 		t.Fatalf("failed to create tool set: %v", err)

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -515,10 +515,13 @@ func TestNewToolSetRejectsNonHTTPSBaseURL(t *testing.T) {
 }
 
 func TestSearchToolStripsAPIKeyOnCrossOriginRedirect(t *testing.T) {
+	var mu sync.Mutex
 	var gotKeys []string
 	final := httptest.NewTLSServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
 			gotKeys = append(gotKeys, r.Header.Get("X-API-Key"))
+			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"results":{"web":[],"news":[]}}`))
 		},
@@ -555,11 +558,14 @@ func TestSearchToolStripsAPIKeyOnCrossOriginRedirect(t *testing.T) {
 	if _, err := searchTool.Call(context.Background(), reqJSON); err != nil {
 		t.Fatalf("search call failed: %v", err)
 	}
-	if len(gotKeys) != 1 {
-		t.Fatalf("expected 1 request at final origin, got %d", len(gotKeys))
+	mu.Lock()
+	keys := append([]string(nil), gotKeys...)
+	mu.Unlock()
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 request at final origin, got %d", len(keys))
 	}
-	if gotKeys[0] != "" {
-		t.Errorf("expected X-API-Key stripped on cross-origin redirect, got %q", gotKeys[0])
+	if keys[0] != "" {
+		t.Errorf("expected X-API-Key stripped on cross-origin redirect, got %q", keys[0])
 	}
 }
 

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -10,14 +10,19 @@
 package youcom
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestOption(t *testing.T) {
@@ -186,27 +191,52 @@ func TestClose(t *testing.T) {
 	}
 }
 
-// newFakeYoucomAPI returns an httptest server that emits the given results
-// as a You.com Web Search API response and records the latest request.
-func newFakeYoucomAPI(t *testing.T, results []youcomAPIResult) (*httptest.Server, **http.Request) {
+// newFakeYoucomAPI returns an httptest TLS server that emits the given
+// results as a You.com Web Search API response and records the latest
+// request. The captured request is guarded by a mutex and accessed through
+// the returned function so the test does not race with the HTTP handler.
+func newFakeYoucomAPI(t *testing.T, web, news []youcomAPIResult) (*httptest.Server, func() *http.Request) {
 	t.Helper()
+	var mu sync.Mutex
 	var captured *http.Request
-	srv := httptest.NewServer(http.HandlerFunc(
+	srv := httptest.NewTLSServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			captured = r
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+			}
+			mu.Lock()
+			captured = r.Clone(r.Context())
+			// r.Clone shares the original (already consumed) body; replace it
+			// with a fresh reader so tests can decode it afterwards.
+			captured.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
-			resp := youcomAPIResponse{Results: results}
+			resp := youcomAPIResponse{Results: youcomAPISections{Web: web, News: news}}
 			if err := json.NewEncoder(w).Encode(resp); err != nil {
 				t.Errorf("encode fake response: %v", err)
 			}
 		},
 	))
 	t.Cleanup(srv.Close)
-	return srv, &captured
+	return srv, func() *http.Request {
+		mu.Lock()
+		defer mu.Unlock()
+		return captured
+	}
+}
+
+// fakeTLSClient returns an HTTP client that trusts the httptest TLS server.
+func fakeTLSClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only
+		},
+	}
 }
 
 func TestSearchTool(t *testing.T) {
-	fakeResults := []youcomAPIResult{
+	fakeWeb := []youcomAPIResult{
 		{
 			URL:      "https://example.com/go",
 			Title:    "Example Go page",
@@ -223,11 +253,19 @@ func TestSearchTool(t *testing.T) {
 			Snippets: []string{"orphan snippet"},
 		},
 	}
-	srv, captured := newFakeYoucomAPI(t, fakeResults)
+	fakeNews := []youcomAPIResult{
+		{
+			URL:         "https://example.com/news",
+			Title:       "News item with description only",
+			Description: "A news description used as fallback snippet.",
+		},
+	}
+	srv, captured := newFakeYoucomAPI(t, fakeWeb, fakeNews)
 
 	toolSet, err := NewToolSet(
 		WithAPIKey("key-123"),
 		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
 		WithNumResults(5),
 		WithCountry("US"),
 		WithSafeSearch("moderate"),
@@ -259,8 +297,8 @@ func TestSearchTool(t *testing.T) {
 	if resp.Query != "golang testing" {
 		t.Errorf("expected query 'golang testing', got %q", resp.Query)
 	}
-	if len(resp.Results) != 2 {
-		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	if len(resp.Results) != 3 {
+		t.Fatalf("expected 3 results (2 web + 1 news), got %d", len(resp.Results))
 	}
 	if resp.Results[0].URL != "https://example.com/go" {
 		t.Errorf("unexpected URL: %q", resp.Results[0].URL)
@@ -276,23 +314,47 @@ func TestSearchTool(t *testing.T) {
 	if resp.Results[1].ThumbnailURL != "https://example.com/thumb.png" {
 		t.Errorf("unexpected thumbnail URL: %q", resp.Results[1].ThumbnailURL)
 	}
+	// News results carry a description instead of snippets; it must be used
+	// as a fallback snippet.
+	if resp.Results[2].URL != "https://example.com/news" {
+		t.Fatalf("expected news result last, got %q", resp.Results[2].URL)
+	}
+	if len(resp.Results[2].Snippets) != 1 ||
+		resp.Results[2].Snippets[0] != "A news description used as fallback snippet." {
+		t.Errorf("unexpected news snippets: %#v", resp.Results[2].Snippets)
+	}
 	if resp.Error != "" {
 		t.Errorf("unexpected error field: %q", resp.Error)
 	}
 
 	// Verify the request reached the fake API with the expected parameters.
-	req := *captured
-	if got := req.URL.Query().Get("query"); got != "golang testing" {
-		t.Errorf("expected query param 'golang testing', got %q", got)
+	req := captured()
+	if req == nil {
+		t.Fatalf("no request was captured")
 	}
-	if got := req.URL.Query().Get("num_results"); got != "5" {
-		t.Errorf("expected num_results param '5', got %q", got)
+	if req.Method != http.MethodPost {
+		t.Errorf("expected POST request, got %s", req.Method)
 	}
-	if got := req.URL.Query().Get("country"); got != "US" {
-		t.Errorf("expected country param 'US', got %q", got)
+	var body struct {
+		Query      string `json:"query"`
+		Count      int    `json:"count"`
+		Country    string `json:"country"`
+		SafeSearch string `json:"safesearch"`
 	}
-	if got := req.URL.Query().Get("safesearch"); got != "moderate" {
-		t.Errorf("expected safesearch param 'moderate', got %q", got)
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if body.Query != "golang testing" {
+		t.Errorf("expected query 'golang testing', got %q", body.Query)
+	}
+	if body.Count != 5 {
+		t.Errorf("expected count '5', got %d", body.Count)
+	}
+	if body.Country != "US" {
+		t.Errorf("expected country 'US', got %q", body.Country)
+	}
+	if body.SafeSearch != "moderate" {
+		t.Errorf("expected safesearch 'moderate', got %q", body.SafeSearch)
 	}
 	if got := req.Header.Get("X-API-Key"); got != "key-123" {
 		t.Errorf("expected X-API-Key header, got %q", got)
@@ -302,11 +364,12 @@ func TestSearchTool(t *testing.T) {
 func TestSearchToolRequestOverrides(t *testing.T) {
 	srv, captured := newFakeYoucomAPI(t, []youcomAPIResult{
 		{URL: "https://example.com/1", Title: "One"},
-	})
+	}, nil)
 
 	toolSet, err := NewToolSet(
 		WithAPIKey("key-123"),
 		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
 	)
 	if err != nil {
 		t.Fatalf("failed to create tool set: %v", err)
@@ -332,24 +395,36 @@ func TestSearchToolRequestOverrides(t *testing.T) {
 		t.Fatalf("search call failed: %v", err)
 	}
 
-	req := *captured
-	if got := req.URL.Query().Get("num_results"); got != "2" {
-		t.Errorf("expected num_results param '2', got %q", got)
+	req := captured()
+	if req == nil {
+		t.Fatalf("no request was captured")
 	}
-	if got := req.URL.Query().Get("country"); got != "DE" {
-		t.Errorf("expected country param 'DE', got %q", got)
+	var body struct {
+		Count      int    `json:"count"`
+		Country    string `json:"country"`
+		SafeSearch string `json:"safesearch"`
 	}
-	if got := req.URL.Query().Get("safesearch"); got != "strict" {
-		t.Errorf("expected safesearch param 'strict', got %q", got)
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if body.Count != 2 {
+		t.Errorf("expected count '2', got %d", body.Count)
+	}
+	if body.Country != "DE" {
+		t.Errorf("expected country 'DE', got %q", body.Country)
+	}
+	if body.SafeSearch != "strict" {
+		t.Errorf("expected safesearch 'strict', got %q", body.SafeSearch)
 	}
 }
 
 func TestSearchToolEmptyQuery(t *testing.T) {
-	srv, _ := newFakeYoucomAPI(t, nil)
+	srv, _ := newFakeYoucomAPI(t, nil, nil)
 
 	toolSet, err := NewToolSet(
 		WithAPIKey("key-123"),
 		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
 	)
 	if err != nil {
 		t.Fatalf("failed to create tool set: %v", err)
@@ -383,7 +458,7 @@ func TestSearchToolEmptyQuery(t *testing.T) {
 }
 
 func TestSearchToolServerError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(
+	srv := httptest.NewTLSServer(http.HandlerFunc(
 		func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 		},
@@ -393,6 +468,7 @@ func TestSearchToolServerError(t *testing.T) {
 	toolSet, err := NewToolSet(
 		WithAPIKey("key-123"),
 		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
 	)
 	if err != nil {
 		t.Fatalf("failed to create tool set: %v", err)
@@ -422,5 +498,79 @@ func TestSearchToolServerError(t *testing.T) {
 	}
 	if len(resp.Results) != 0 {
 		t.Errorf("expected 0 results, got %d", len(resp.Results))
+	}
+}
+
+func TestNewToolSetRejectsNonHTTPSBaseURL(t *testing.T) {
+	_, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL("http://api.you.com/api/search"),
+	)
+	if err == nil {
+		t.Fatalf("expected error for http base URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTPS") {
+		t.Errorf("expected HTTPS error, got %v", err)
+	}
+}
+
+func TestSearchToolStripsAPIKeyOnCrossOriginRedirect(t *testing.T) {
+	var gotKeys []string
+	final := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotKeys = append(gotKeys, r.Header.Get("X-API-Key"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":{"web":[],"news":[]}}`))
+		},
+	))
+	defer final.Close()
+
+	origin := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// Cross-origin redirect: the API key must not follow.
+			http.Redirect(w, r, final.URL+"/v1/search", http.StatusFound)
+		},
+	))
+	defer origin.Close()
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("secret-key"),
+		WithBaseURL(origin.URL),
+		WithHTTPClient(fakeTLSClient()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+	reqJSON, err := json.Marshal(searchRequest{Query: "redirect test"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if _, err := searchTool.Call(context.Background(), reqJSON); err != nil {
+		t.Fatalf("search call failed: %v", err)
+	}
+	if len(gotKeys) != 1 {
+		t.Fatalf("expected 1 request at final origin, got %d", len(gotKeys))
+	}
+	if gotKeys[0] != "" {
+		t.Errorf("expected X-API-Key stripped on cross-origin redirect, got %q", gotKeys[0])
+	}
+}
+
+func TestTrimSnippetsRuneBoundary(t *testing.T) {
+	// 501 bytes whose 500th byte falls inside a multi-byte rune.
+	cjk := strings.Repeat("界", 200) // 600 bytes of 3-byte runes
+	got := trimSnippets([]string{cjk})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 snippet, got %d", len(got))
+	}
+	if !utf8.ValidString(got[0]) {
+		t.Errorf("truncated snippet is not valid UTF-8: %q", got[0])
 	}
 }

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -774,3 +774,177 @@ func TestSearchToolInvalidJSONResponse(t *testing.T) {
 		t.Errorf("expected decode response error, got %v", err)
 	}
 }
+
+func TestSearchToolCapsCombinedSections(t *testing.T) {
+	// The API treats `count` as a per-section limit, so both sections can
+	// each return up to `count` entries. The tool must cap the combined
+	// list at numResults so the result-count contract holds.
+	web := make([]youcomAPIResult, 0, 4)
+	for i := 0; i < 4; i++ {
+		web = append(web, youcomAPIResult{
+			URL:   fmt.Sprintf("https://example.com/web/%d", i),
+			Title: fmt.Sprintf("Web %d", i),
+		})
+	}
+	news := make([]youcomAPIResult, 0, 4)
+	for i := 0; i < 4; i++ {
+		news = append(news, youcomAPIResult{
+			URL:         fmt.Sprintf("https://example.com/news/%d", i),
+			Title:       fmt.Sprintf("News %d", i),
+			Description: fmt.Sprintf("News description %d", i),
+		})
+	}
+	srv, _ := newFakeYoucomAPI(t, web, news)
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
+		WithNumResults(5),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "sections"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	result, err := searchTool.Call(context.Background(), reqJSON)
+	if err != nil {
+		t.Fatalf("search call failed: %v", err)
+	}
+	resp, ok := result.(searchResponse)
+	if !ok {
+		t.Fatalf("expected searchResponse type, got %T", result)
+	}
+	if len(resp.Results) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(resp.Results))
+	}
+	// Web results come first, then news up to the cap.
+	for i, item := range resp.Results[:4] {
+		if want := fmt.Sprintf("Web %d", i); item.Title != want {
+			t.Errorf("result %d: expected title %q, got %q", i, want, item.Title)
+		}
+	}
+	if resp.Results[4].Title != "News 0" {
+		t.Errorf("result 4: expected title %q, got %q", "News 0", resp.Results[4].Title)
+	}
+}
+
+func TestSearchToolCapsCombinedSectionsWithInvalidEntries(t *testing.T) {
+	// Entries without a URL or title are dropped and do not consume the
+	// result budget, so the cap applies to valid entries only.
+	web := []youcomAPIResult{
+		{URL: "https://example.com/web/0", Title: "Web 0"},
+		{}, // invalid: no URL and no title
+		{URL: "https://example.com/web/1", Title: "Web 1"},
+	}
+	news := []youcomAPIResult{
+		{URL: "https://example.com/news/0", Title: "News 0", Description: "d0"},
+		{}, // invalid: no URL and no title
+		{URL: "https://example.com/news/1", Title: "News 1", Description: "d1"},
+	}
+	srv, _ := newFakeYoucomAPI(t, web, news)
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
+		WithNumResults(2),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "invalid entries"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	result, err := searchTool.Call(context.Background(), reqJSON)
+	if err != nil {
+		t.Fatalf("search call failed: %v", err)
+	}
+	resp, ok := result.(searchResponse)
+	if !ok {
+		t.Fatalf("expected searchResponse type, got %T", result)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+	if resp.Results[0].Title != "Web 0" || resp.Results[1].Title != "Web 1" {
+		t.Errorf("unexpected results: %q, %q", resp.Results[0].Title, resp.Results[1].Title)
+	}
+}
+
+func TestNewToolSetRejectsHostlessBaseURL(t *testing.T) {
+	for _, raw := range []string{
+		"https://",
+		"https:foo",
+		"https:///v1/search",
+	} {
+		_, err := NewToolSet(
+			WithAPIKey("key-123"),
+			WithBaseURL(raw),
+		)
+		if err == nil {
+			t.Errorf("expected error for hostless base URL %q, got nil", raw)
+			continue
+		}
+		if !strings.Contains(err.Error(), "host") {
+			t.Errorf("expected host error for %q, got %v", raw, err)
+		}
+	}
+}
+
+func TestToolDeclarationSchema(t *testing.T) {
+	toolSet, err := NewToolSet(WithAPIKey("key-123"))
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	decl := toolSet.tools[0].Declaration()
+	if decl == nil {
+		t.Fatalf("expected non-nil declaration")
+	}
+	if decl.Name != "search" {
+		t.Errorf("expected tool name %q, got %q", "search", decl.Name)
+	}
+	props := decl.InputSchema.Properties
+	if len(props) != 4 {
+		t.Fatalf("expected 4 properties, got %d", len(props))
+	}
+	if props["query"] == nil {
+		t.Fatalf("missing query property")
+	}
+	if got, want := props["num_results"].Description, "Maximum number of results to return (default 10 max 10)"; got != want {
+		t.Errorf("num_results description: got %q, want %q", got, want)
+	}
+	if got, want := props["country"].Description, "Country code used to bias results (e.g. US or DE)"; got != want {
+		t.Errorf("country description: got %q, want %q", got, want)
+	}
+	safe := props["safe_search"]
+	if safe == nil {
+		t.Fatalf("missing safe_search property")
+	}
+	if got, want := safe.Description, "Safe search strictness"; got != want {
+		t.Errorf("safe_search description: got %q, want %q", got, want)
+	}
+	if len(safe.Enum) != 3 || safe.Enum[0] != "strict" || safe.Enum[1] != "moderate" || safe.Enum[2] != "off" {
+		t.Errorf("safe_search enum: got %v, want [strict moderate off]", safe.Enum)
+	}
+}

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -1,0 +1,426 @@
+//
+// Tencent is pleased to support the open source community by making trpc-agent-go available.
+//
+// Copyright (C) 2026 Tencent.  All rights reserved.
+//
+// trpc-agent-go is licensed under the Apache License Version 2.0.
+//
+//
+
+package youcom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestOption(t *testing.T) {
+	type testCase struct {
+		name    string
+		opts    []Option
+		wantCfg config
+	}
+
+	testCases := []testCase{
+		{
+			name:    "empty",
+			opts:    nil,
+			wantCfg: config{},
+		},
+		{
+			name: "with options",
+			opts: []Option{
+				WithAPIKey("key-123"),
+				WithBaseURL("https://example.com/api/search"),
+				WithUserAgent("custom-agent/2.0"),
+				WithNumResults(5),
+				WithCountry("de"),
+				WithSafeSearch("strict"),
+			},
+			wantCfg: config{
+				apiKey:     "key-123",
+				baseURL:    "https://example.com/api/search",
+				userAgent:  "custom-agent/2.0",
+				numResults: 5,
+				country:    "DE",
+				safeSearch: "strict",
+			},
+		},
+		{
+			name: "num results clamped to max",
+			opts: []Option{
+				WithNumResults(50),
+			},
+			wantCfg: config{
+				numResults: maxResults,
+			},
+		},
+		{
+			name: "num results clamped to default",
+			opts: []Option{
+				WithNumResults(-3),
+			},
+			wantCfg: config{
+				numResults: maxResults,
+			},
+		},
+		{
+			name: "invalid safe search ignored",
+			opts: []Option{
+				WithSafeSearch("bogus"),
+			},
+			wantCfg: config{
+				safeSearch: "",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config{}
+			for _, opt := range tc.opts {
+				opt(cfg)
+			}
+			if !reflect.DeepEqual(*cfg, tc.wantCfg) {
+				t.Errorf("got config %+v, want %+v", *cfg, tc.wantCfg)
+			}
+		})
+	}
+}
+
+func TestNewToolSet(t *testing.T) {
+	type testCase struct {
+		name      string
+		opts      []Option
+		wantErr   bool
+		wantTools int
+	}
+
+	testCases := []testCase{
+		{
+			name:    "missing api key",
+			opts:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty api key",
+			opts: []Option{
+				WithAPIKey("   "),
+			},
+			wantErr: true,
+		},
+		{
+			name: "with api key",
+			opts: []Option{
+				WithAPIKey("key-123"),
+			},
+			wantErr:   false,
+			wantTools: 1,
+		},
+		{
+			name: "with api key and base url",
+			opts: []Option{
+				WithAPIKey("key-123"),
+				WithBaseURL("https://example.com/api/search"),
+				WithNumResults(5),
+				WithCountry("US"),
+				WithSafeSearch("moderate"),
+			},
+			wantErr:   false,
+			wantTools: 1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			toolSet, err := NewToolSet(tc.opts...)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if len(toolSet.tools) != tc.wantTools {
+				t.Errorf("got %d tools, want %d", len(toolSet.tools), tc.wantTools)
+			}
+		})
+	}
+}
+
+func TestTools(t *testing.T) {
+	toolSet, err := NewToolSet(WithAPIKey("key-123"))
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+	tools := toolSet.Tools(context.Background())
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tools))
+	}
+}
+
+func TestName(t *testing.T) {
+	toolSet, err := NewToolSet(WithAPIKey("key-123"))
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+	if toolSet.Name() != "youcom" {
+		t.Fatalf("got name %s, want youcom", toolSet.Name())
+	}
+}
+
+func TestClose(t *testing.T) {
+	toolSet, err := NewToolSet(WithAPIKey("key-123"))
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+	if err := toolSet.Close(); err != nil {
+		t.Fatalf("failed to close tool set: %v", err)
+	}
+}
+
+// newFakeYoucomAPI returns an httptest server that emits the given results
+// as a You.com Web Search API response and records the latest request.
+func newFakeYoucomAPI(t *testing.T, results []youcomAPIResult) (*httptest.Server, **http.Request) {
+	t.Helper()
+	var captured *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			captured = r
+			w.Header().Set("Content-Type", "application/json")
+			resp := youcomAPIResponse{Results: results}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Errorf("encode fake response: %v", err)
+			}
+		},
+	))
+	t.Cleanup(srv.Close)
+	return srv, &captured
+}
+
+func TestSearchTool(t *testing.T) {
+	fakeResults := []youcomAPIResult{
+		{
+			URL:      "https://example.com/go",
+			Title:    "Example Go page",
+			Snippets: []string{" An excerpt about Go. ", ""},
+		},
+		{
+			URL:          "https://example.com/preview",
+			Title:        "Example with thumbnail",
+			Snippets:     []string{"Another excerpt."},
+			ThumbnailURL: "https://example.com/thumb.png",
+		},
+		{
+			// No URL and no title: must be dropped from output.
+			Snippets: []string{"orphan snippet"},
+		},
+	}
+	srv, captured := newFakeYoucomAPI(t, fakeResults)
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+		WithNumResults(5),
+		WithCountry("US"),
+		WithSafeSearch("moderate"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "golang testing"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	result, err := searchTool.Call(context.Background(), reqJSON)
+	if err != nil {
+		t.Fatalf("search call failed: %v", err)
+	}
+
+	resp, ok := result.(searchResponse)
+	if !ok {
+		t.Fatalf("expected searchResponse type, got %T", result)
+	}
+	if resp.Query != "golang testing" {
+		t.Errorf("expected query 'golang testing', got %q", resp.Query)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+	if resp.Results[0].URL != "https://example.com/go" {
+		t.Errorf("unexpected URL: %q", resp.Results[0].URL)
+	}
+	if resp.Results[0].Title != "Example Go page" {
+		t.Errorf("unexpected title: %q", resp.Results[0].Title)
+	}
+	// Empty snippets must be dropped, non-empty kept.
+	if len(resp.Results[0].Snippets) != 1 ||
+		resp.Results[0].Snippets[0] != "An excerpt about Go." {
+		t.Errorf("unexpected snippets: %#v", resp.Results[0].Snippets)
+	}
+	if resp.Results[1].ThumbnailURL != "https://example.com/thumb.png" {
+		t.Errorf("unexpected thumbnail URL: %q", resp.Results[1].ThumbnailURL)
+	}
+	if resp.Error != "" {
+		t.Errorf("unexpected error field: %q", resp.Error)
+	}
+
+	// Verify the request reached the fake API with the expected parameters.
+	req := *captured
+	if got := req.URL.Query().Get("query"); got != "golang testing" {
+		t.Errorf("expected query param 'golang testing', got %q", got)
+	}
+	if got := req.URL.Query().Get("num_results"); got != "5" {
+		t.Errorf("expected num_results param '5', got %q", got)
+	}
+	if got := req.URL.Query().Get("country"); got != "US" {
+		t.Errorf("expected country param 'US', got %q", got)
+	}
+	if got := req.URL.Query().Get("safesearch"); got != "moderate" {
+		t.Errorf("expected safesearch param 'moderate', got %q", got)
+	}
+	if got := req.Header.Get("X-API-Key"); got != "key-123" {
+		t.Errorf("expected X-API-Key header, got %q", got)
+	}
+}
+
+func TestSearchToolRequestOverrides(t *testing.T) {
+	srv, captured := newFakeYoucomAPI(t, []youcomAPIResult{
+		{URL: "https://example.com/1", Title: "One"},
+	})
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{
+		Query:      "override test",
+		NumResults: 2,
+		Country:    "de",
+		SafeSearch: "strict",
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if _, err := searchTool.Call(context.Background(), reqJSON); err != nil {
+		t.Fatalf("search call failed: %v", err)
+	}
+
+	req := *captured
+	if got := req.URL.Query().Get("num_results"); got != "2" {
+		t.Errorf("expected num_results param '2', got %q", got)
+	}
+	if got := req.URL.Query().Get("country"); got != "DE" {
+		t.Errorf("expected country param 'DE', got %q", got)
+	}
+	if got := req.URL.Query().Get("safesearch"); got != "strict" {
+		t.Errorf("expected safesearch param 'strict', got %q", got)
+	}
+}
+
+func TestSearchToolEmptyQuery(t *testing.T) {
+	srv, _ := newFakeYoucomAPI(t, nil)
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "   "})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	result, err := searchTool.Call(context.Background(), reqJSON)
+	if err == nil {
+		t.Fatalf("expected error for empty query, got nil")
+	}
+	resp, ok := result.(searchResponse)
+	if !ok {
+		t.Fatalf("expected searchResponse type, got %T", result)
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(resp.Results))
+	}
+	if !strings.Contains(resp.Error, "empty search query") {
+		t.Errorf("unexpected error field: %q", resp.Error)
+	}
+}
+
+func TestSearchToolServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		},
+	))
+	defer srv.Close()
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "anything"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	result, err := searchTool.Call(context.Background(), reqJSON)
+	if err == nil {
+		t.Fatalf("expected error on 401, got nil")
+	}
+	if !strings.Contains(fmt.Sprintf("%v", err), "401") {
+		t.Errorf("expected 401 in error, got: %v", err)
+	}
+	resp, ok := result.(searchResponse)
+	if !ok {
+		t.Fatalf("expected searchResponse type, got %T", result)
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(resp.Results))
+	}
+}

--- a/tool/youcom/youcom_search_test.go
+++ b/tool/youcom/youcom_search_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -578,5 +579,184 @@ func TestTrimSnippetsRuneBoundary(t *testing.T) {
 	}
 	if !utf8.ValidString(got[0]) {
 		t.Errorf("truncated snippet is not valid UTF-8: %q", got[0])
+	}
+}
+
+func TestNewToolSetInvalidBaseURL(t *testing.T) {
+	_, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL("://not a url"),
+	)
+	if err == nil {
+		t.Fatalf("expected error for invalid base URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid base URL") {
+		t.Errorf("expected invalid base URL error, got %v", err)
+	}
+}
+
+func TestNewToolSetEmptyBaseURLFallsBackToDefault(t *testing.T) {
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL("   "),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if toolSet == nil {
+		t.Fatal("expected tool set, got nil")
+	}
+	// The default base URL is HTTPS and valid, so construction must succeed;
+	// an invalid scheme would have failed above.
+	if len(toolSet.tools) != 1 {
+		t.Errorf("expected 1 tool after empty base URL fallback, got %d", len(toolSet.tools))
+	}
+}
+
+func TestWithTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		timeout time.Duration
+		wantNil bool
+	}{
+		{"positive", 5 * time.Second, false},
+		{"zero disables", 0, false},
+		{"negative ignored", -1 * time.Second, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config{}
+			WithTimeout(tc.timeout)(cfg)
+			if tc.wantNil {
+				if cfg.timeout != nil {
+					t.Errorf("expected nil timeout, got %v", *cfg.timeout)
+				}
+				return
+			}
+			if cfg.timeout == nil {
+				t.Fatalf("expected timeout %v, got nil", tc.timeout)
+			}
+			if *cfg.timeout != tc.timeout {
+				t.Errorf("expected timeout %v, got %v", tc.timeout, *cfg.timeout)
+			}
+		})
+	}
+}
+
+func TestResolveHTTPClientTimeoutOverride(t *testing.T) {
+	// Default client: timeout override must be applied.
+	cfg := &config{timeout: durationPtr(7 * time.Second)}
+	client := resolveHTTPClient(cfg)
+	if client.Timeout != 7*time.Second {
+		t.Errorf("expected 7s timeout, got %v", client.Timeout)
+	}
+
+	// Custom client: the caller's client must not be mutated, and custom
+	// Transport settings must survive the shallow copy.
+	custom := &http.Client{
+		Timeout:   time.Second,
+		Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
+	}
+	cfg = &config{httpClient: custom, timeout: durationPtr(9 * time.Second)}
+	client = resolveHTTPClient(cfg)
+	if client == custom {
+		t.Fatal("expected a cloned client, got the caller's instance")
+	}
+	if client.Timeout != 9*time.Second {
+		t.Errorf("expected 9s timeout on clone, got %v", client.Timeout)
+	}
+	if custom.Timeout != time.Second {
+		t.Errorf("caller's client was mutated: timeout %v", custom.Timeout)
+	}
+	if client.Transport != custom.Transport {
+		t.Error("expected custom Transport preserved on clone")
+	}
+
+	// nil timeout: caller's timeout stays untouched.
+	cfg = &config{httpClient: custom}
+	client = resolveHTTPClient(cfg)
+	if client != custom {
+		t.Error("expected the caller's client returned unchanged")
+	}
+}
+
+func durationPtr(d time.Duration) *time.Duration { return &d }
+
+func TestNormalizeSafeSearchOff(t *testing.T) {
+	if got := normalizeSafeSearch(" OFF "); got != "off" {
+		t.Errorf("expected 'off', got %q", got)
+	}
+}
+
+func TestSearchToolUnreachableEndpoint(t *testing.T) {
+	// A URL that cannot be resolved ensures the request-execution error
+	// path is exercised.
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL("https://invalid.invalid.test/v1/search"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "unreachable"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	result, err := searchTool.Call(context.Background(), reqJSON)
+	if err == nil {
+		t.Fatalf("expected error for unreachable endpoint, got nil")
+	}
+	resp, ok := result.(searchResponse)
+	if !ok {
+		t.Fatalf("expected searchResponse type, got %T", result)
+	}
+	if !strings.Contains(resp.Error, "execute request") {
+		t.Errorf("unexpected error field: %q", resp.Error)
+	}
+}
+
+func TestSearchToolInvalidJSONResponse(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":`)) // truncated JSON
+		},
+	))
+	defer srv.Close()
+
+	toolSet, err := NewToolSet(
+		WithAPIKey("key-123"),
+		WithBaseURL(srv.URL),
+		WithHTTPClient(fakeTLSClient()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create tool set: %v", err)
+	}
+
+	searchTool, ok := toolSet.tools[0].(interface {
+		Call(context.Context, []byte) (any, error)
+	})
+	if !ok {
+		t.Fatalf("tool does not implement Call")
+	}
+
+	reqJSON, err := json.Marshal(searchRequest{Query: "anything"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	_, err = searchTool.Call(context.Background(), reqJSON)
+	if err == nil {
+		t.Fatalf("expected decode error, got nil")
+	}
+	if !strings.Contains(err.Error(), "decode response") {
+		t.Errorf("expected decode response error, got %v", err)
 	}
 }


### PR DESCRIPTION
## What changed

Adds an opt-in You.com web search ToolSet, so agents can use a hosted web search API (URLs, titles, snippets) alongside the existing `duckduckgo`, `google`, `wikipedia`, and `arxivsearch` search surfaces. Nothing changes for existing configs — the new provider is only used when listed under `tools.toolsets`.

## Why

The current general-web options are DuckDuckGo scraping backends (rate-limited / challenge-prone) or a Google Custom Search Engine (requires creating a CSE plus two credentials). A You.com toolset adds a plain hosted Search API that needs only one API key, following the same ToolSet abstraction the project already uses for search. It fits the same slot as `google`: credentialed, opt-in, general web search, with the same env-var fallback pattern (`YDC_API_KEY`, mirroring `GOOGLE_API_KEY`).

Design notes:

- `tool/youcom` lives in the root module, same placement as `tool/duckduckgo`, so no new `go.mod` wiring is needed.
- Construction fails fast with a clear error when neither `api_key` nor `YDC_API_KEY` is set, so a misconfigured toolset surfaces at startup rather than on the first tool call.
- The search tool is named `search` and gets the standard ToolSet namespace prefix at runtime (e.g. `youcom_search`). Per-call request fields (`num_results`, `country`, `safe_search`) override configured defaults.
- Standard `net/http` only — no new dependencies. Snippets are trimmed and capped so a single result cannot dominate the model context.
- I noticed the runtime also supports remote MCP servers via the `mcp` ToolSet, but a native ToolSet keeps the search tool first-class in the toolset registry (visible in `-list` output, standard name override, per-toolset config), so I went with the native abstraction. Happy to drop it to a docs-only MCP example instead if that shape is preferred.

## Testing

- `go test ./tool/youcom/ -count=1` — new unit tests: option application and clamping, construction error on missing key, toolset name/tools/close, end-to-end `Call` against an `httptest` fake API (query params, `X-API-Key` header, snippet trimming, orphan-result dropping), per-call overrides, empty-query error, and non-2xx error mapping.
- `go test ./openclaw/app/ -run 'TestNewYouCom' -count=1` — factory tests: missing-key error, `YDC_API_KEY` env fallback, config key precedence, spec name override.
- `go build ./...` in both the root module and `openclaw/`; `gofmt` clean on all changed Go files.
- Full `go test ./tool/...` passes. Two pre-existing failures in `openclaw/app` (`TestNewFileToolSet_RuntimeReadDirsRejectSymlinkedBrowserArtifacts`, `TestInProcGatewayClient_ForgetUser_DeleteMemoryFilesErrorPreservesStorageScopeIndex`) also fail on the pristine `main` tree in this environment and are unrelated to this change.
- Live API validation requires credentials; with a key: `YDC_API_KEY=... ` then add the `youcom` toolset to an `openclaw.yaml` per `openclaw/INTEGRATIONS.md`.

## Notes for reviewers

- Public API addition: `tool/youcom` exports `NewToolSet`, `ToolSet`, and `Option` constructors, mirroring `tool/wikipedia`.
- No new module or dependency: `openclaw` already replaces the root module, so the import resolves without `go.mod` changes.
- Docs updated in `openclaw/INTEGRATIONS.md` and the en/zh mkdocs runtime docs + blog ToolSet provider lists.

Updates #2585.