### PR TITLE
agent/weknora: preserve streaming response identity and completion

### DIFF
--- a/agent/weknora/go.mod
+++ b/agent/weknora/go.mod
@@ -6,6 +6,7 @@ replace trpc.group/trpc-go/trpc-agent-go => ../..
 
 require (
 	github.com/Tencent/WeKnora/client v0.0.0-20260324035655-62e6ae960f46
+	github.com/google/uuid v1.6.0
 	trpc.group/trpc-go/trpc-agent-go v1.7.0
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/agent/weknora/weknora_agent.go
+++ b/agent/weknora/weknora_agent.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Tencent/WeKnora/client"
+	"github.com/google/uuid"
 
 	"trpc.group/trpc-go/trpc-agent-go/agent"
 	"trpc.group/trpc-go/trpc-agent-go/event"
@@ -155,6 +156,8 @@ func (r *WeKnoraAgent) runStreaming(ctx context.Context, invocation *agent.Invoc
 	go func() {
 		defer close(eventChan)
 
+		// All chunks and the final completion belong to one response.
+		responseID := uuid.NewString()
 		var aggregatedContentBuilder strings.Builder
 		var aggregatedReasoningBuilder strings.Builder
 
@@ -181,6 +184,7 @@ func (r *WeKnoraAgent) runStreaming(ctx context.Context, invocation *agent.Invoc
 						invocation.InvocationID,
 						r.name,
 						event.WithResponse(&model.Response{
+							ID:        responseID,
 							Object:    model.ObjectTypeChatCompletionChunk,
 							Choices:   []model.Choice{{Delta: message}},
 							Timestamp: time.Now(),
@@ -205,7 +209,7 @@ func (r *WeKnoraAgent) runStreaming(ctx context.Context, invocation *agent.Invoc
 		}
 
 		// Send final aggregated event
-		r.sendFinalStreamingEvent(ctx, eventChan, invocation, aggregatedContentBuilder.String(), aggregatedReasoningBuilder.String())
+		r.sendFinalStreamingEvent(ctx, eventChan, invocation, responseID, aggregatedContentBuilder.String(), aggregatedReasoningBuilder.String())
 	}()
 
 	return eventChan, nil
@@ -216,6 +220,7 @@ func (r *WeKnoraAgent) sendFinalStreamingEvent(
 	ctx context.Context,
 	eventChan chan<- *event.Event,
 	invocation *agent.Invocation,
+	responseID string,
 	aggregatedContent string,
 	aggregatedReasoning string,
 ) {
@@ -223,6 +228,8 @@ func (r *WeKnoraAgent) sendFinalStreamingEvent(
 		invocation.InvocationID,
 		r.name,
 		event.WithResponse(&model.Response{
+			ID:        responseID,
+			Object:    model.ObjectTypeChatCompletion,
 			Done:      true,
 			IsPartial: false,
 			Timestamp: time.Now(),

--- a/agent/weknora/weknora_agent_test.go
+++ b/agent/weknora/weknora_agent_test.go
@@ -258,7 +258,7 @@ func TestWeKnoraAgent_SendFinalStreamingEvent(t *testing.T) {
 	}
 
 	eventChan := make(chan *event.Event, 1)
-	weknoraAgent.sendFinalStreamingEvent(context.Background(), eventChan, invocation, "aggregated content", "aggregated reasoning")
+	weknoraAgent.sendFinalStreamingEvent(context.Background(), eventChan, invocation, "test-response", "aggregated content", "aggregated reasoning")
 	close(eventChan)
 
 	evt := <-eventChan
@@ -699,4 +699,80 @@ func TestWeKnoraAgent_Run(t *testing.T) {
 			t.Error("expected nil event channel on error")
 		}
 	})
+}
+
+func TestWeKnoraAgent_RunResponseIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/sessions/default-session":
+			fmt.Fprint(w, `{"success":true,"data":{"id":"default-session"}}`)
+		case "/api/v1/agent-chat/default-session":
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"response_type\":\"thinking\",\"content\":\"thinking\"}\n\n")
+			fmt.Fprint(w, "data: {\"response_type\":\"answer\",\"content\":\"hello\"}\n\n")
+			fmt.Fprint(w, "data: {\"response_type\":\"answer\",\"content\":\" world\"}\n\n")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	weknoraAgent, err := New(WithName("test-agent"), WithBaseUrl(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	invocation := &agent.Invocation{
+		InvocationID: "test-inv",
+		Message:      model.Message{Content: "test query"},
+	}
+	var previousID string
+	// Repeated calls can share an invocation, but must not share a response ID.
+	for run := 0; run < 2; run++ {
+		events, err := weknoraAgent.Run(ctx, invocation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var responseID, content, reasoning string
+		var partials, finals int
+		for evt := range events {
+			rsp := evt.Response
+			if rsp == nil || rsp.Error != nil || len(rsp.Choices) != 1 {
+				t.Fatalf("unexpected response: %+v", rsp)
+			}
+			if rsp.ID == "" {
+				t.Error("response ID must not be empty")
+			}
+			if responseID == "" {
+				responseID = rsp.ID
+			}
+			if rsp.ID != responseID {
+				t.Errorf("response ID changed within a run: %q != %q", rsp.ID, responseID)
+			}
+			if rsp.IsPartial {
+				partials++
+				if finals != 0 || rsp.Done || rsp.Object != model.ObjectTypeChatCompletionChunk {
+					t.Errorf("invalid partial response: %+v", rsp)
+				}
+				content += rsp.Choices[0].Delta.Content
+				reasoning += rsp.Choices[0].Delta.ReasoningContent
+			} else {
+				finals++
+				if !rsp.Done || rsp.Object != model.ObjectTypeChatCompletion {
+					t.Errorf("invalid completion response: %+v", rsp)
+				}
+				msg := rsp.Choices[0].Message
+				if msg.Role != model.RoleAssistant || msg.Content != content || msg.ReasoningContent != reasoning {
+					t.Errorf("completion does not match streamed message: %+v", msg)
+				}
+			}
+		}
+		if partials != 3 || finals != 1 || content != "hello world" || reasoning != "thinking" {
+			t.Fatalf("unexpected stream: partials=%d finals=%d content=%q reasoning=%q", partials, finals, content, reasoning)
+		}
+		if run > 0 && responseID == previousID {
+			t.Error("separate runs must have distinct response IDs")
+		}
+		previousID = responseID
+	}
 }


### PR DESCRIPTION
## What changed

WeKnora streaming answers now carry a stable response ID and a final chat completion, allowing AG-UI to emit a complete text-message lifecycle without dropping chunks or repeating the aggregated answer.

Fixes #2584

## Why

The adapter emitted chunks without a response ID and a final response without an object type. AG-UI uses the response ID to correlate chunks and the completion object to close the message. Each Run now gets its own ID, shared by its chunks and final completion.

## Testing

- In `agent/weknora`: `go test ./...`, `go test -race ./...`, `go vet ./...`, and `go build ./...`.
- The new response-identity regression test failed before the fix and passes afterward; it covers reasoning and answer chunks, completion metadata, and distinct IDs across repeated runs.
- In `server/agui`: `go test ./...`.
- Additional local integration check using a mock WeKnora SSE server and the real AG-UI translator: serial and concurrent message modes each produce one start, the exact answer text, and one end; every emitted event passes protocol validation. This check is outside the submitted diff to avoid adding an AG-UI dependency to the WeKnora module.
- `gofmt`, `goimports`, and `git diff --check`.

## Notes for reviewers

No exported API changes. Response IDs are generated per Run rather than per chunk or invocation. The existing UUID dependency is now direct, without a version change.
