### PR TITLE
internal/state/summaryview: avoid cloning history on invalidation

### DIFF
--- a/internal/state/summaryview/binding_test.go
+++ b/internal/state/summaryview/binding_test.go
@@ -141,6 +141,52 @@ func TestBindingReasonRecordsStageThatDecidedBinding(t *testing.T) {
 	})
 }
 
+func TestInvalidateBindingCopiesMetadataAndSharesImmutableItems(t *testing.T) {
+	history := []model.Message{
+		model.NewUserMessage("first"),
+		model.NewAssistantMessage("second"),
+	}
+	invocation := agent.NewInvocation()
+	AttachProjection(invocation, projectionFor(history, len(history)))
+	Finalize(invocation, &model.Request{Messages: history}, 128)
+	invocationView := invocation.View()
+
+	originalState, ok := agent.GetStateValue[*invocationState](
+		invocation,
+		stateKey,
+	)
+	require.True(t, ok)
+	viewState, ok := agent.GetStateValue[*invocationState](
+		invocationView,
+		stateKey,
+	)
+	require.True(t, ok)
+	require.Same(t, originalState, viewState)
+
+	InvalidateBinding(invocationView)
+
+	invalidatedState, ok := agent.GetStateValue[*invocationState](
+		invocationView,
+		stateKey,
+	)
+	require.True(t, ok)
+	require.NotSame(t, originalState, invalidatedState)
+	require.NotSame(t, originalState.view, invalidatedState.view)
+	require.Same(
+		t,
+		&originalState.view.Items[0],
+		&invalidatedState.view.Items[0],
+	)
+	require.True(t, originalState.view.Bound)
+	require.Equal(t, BindingReasonBound, originalState.view.BindingReason)
+	require.False(t, invalidatedState.view.Bound)
+	require.Equal(
+		t,
+		BindingReasonInvalidated,
+		invalidatedState.view.BindingReason,
+	)
+}
+
 func TestBindingFromContextReportsViewState(t *testing.T) {
 	history := []model.Message{
 		model.NewUserMessage("first"),

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -367,7 +367,11 @@ func InvalidateBinding(inv *agent.Invocation) {
 	if !ok || state == nil || state.view == nil {
 		return
 	}
-	storeInvalidated(inv, cloneView(state.view), BindingReasonInvalidated)
+	// The holder owns an immutable view, so invalidation only needs a new view
+	// header for the binding metadata. Keep sharing the read-only items instead
+	// of copying the complete model-visible history.
+	next := *state.view
+	storeInvalidated(inv, &next, BindingReasonInvalidated)
 }
 
 func storeInvalidated(inv *agent.Invocation, view *View, reason string) {

--- a/internal/state/summaryview/summaryview_bench_test.go
+++ b/internal/state/summaryview/summaryview_bench_test.go
@@ -56,6 +56,19 @@ func BenchmarkFinalize(b *testing.B) {
 	}
 }
 
+func BenchmarkInvalidateBinding(b *testing.B) {
+	for _, historySize := range []int{16, 256, 1024} {
+		b.Run(fmt.Sprintf("history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {
+			invocation, _ := summaryViewBenchmarkInput(historySize, 1024)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				InvalidateBinding(invocation)
+			}
+		})
+	}
+}
+
 func BenchmarkRebaseAfterTransform(b *testing.B) {
 	for _, historySize := range []int{16, 256, 1024} {
 		b.Run(fmt.Sprintf("implicit_identity/history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {


### PR DESCRIPTION
## What changed

Explicit summary-view invalidation now has constant allocation cost regardless
of model-visible history size, while derived invocation views continue to keep
independent binding metadata. The change includes a regression test for the
copy-on-write boundary and a benchmark covering increasing history sizes.

## Why

`InvalidateBinding` changes only `Bound`, `BindingReason`, and the private
`bindingInvalidated` flag. It nevertheless called `cloneView`, recursively
copying every message and event in the complete model-visible history.

Summary views are already published as immutable snapshots by #2476. A new
top-level `View` value is therefore enough to isolate the binding metadata;
its read-only `Items` backing storage can be shared safely. Public read
boundaries still return deep copies, and every internal path that changes
items either deep-copies the view first or installs a newly built item slice.

Median results from five 1-second runs on linux/amd64:

| History items | Before | After |
| ---: | ---: | ---: |
| 16 | 10,464 ns/op, 33,936 B/op, 83 allocs/op | 108.5 ns/op, 144 B/op, 2 allocs/op |
| 256 | 268,904 ns/op, 524,446 B/op, 1,283 allocs/op | 116.1 ns/op, 144 B/op, 2 allocs/op |
| 1,024 | 1,080,694 ns/op, 2,080,943 B/op, 5,124 allocs/op | 120.6 ns/op, 144 B/op, 2 allocs/op |

## Testing

- `go build ./...`
- `go test ./...`
- `(cd test && go test ./...)`
- `go test -race ./internal/state/summaryview ./internal/flow/llmflow`
- `go vet ./internal/state/summaryview`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=10m ./internal/state/summaryview/...`
- `go run golang.org/x/tools/cmd/goimports@v0.36.0 -l internal/state/summaryview/summaryview.go internal/state/summaryview/binding_test.go internal/state/summaryview/summaryview_bench_test.go`
- `go test ./internal/state/summaryview -run '^$' -bench '^BenchmarkInvalidateBinding$' -benchmem -benchtime=1s -count=5`

## Notes for reviewers

This does not change a public API, persistence format, or binding decision.
It preserves the existing immutable-holder concurrency model: published view
objects are never mutated in place, and invalidation replaces the holder in
the target invocation only.
