### PR TITLE
ci: pin external consumers to module Go versions

### DIFF
--- a/.github/scripts/check-external-consumer.sh
+++ b/.github/scripts/check-external-consumer.sh
@@ -120,6 +120,23 @@ module_path_from_go_mod() {
 	return 1
 }
 
+minimum_go_version_from_go_mod() {
+	local mod_file="$1"
+	local directive go_version _
+	while read -r directive go_version _; do
+		if [[ "${directive}" == "go" ]]; then
+			if [[ -z "${go_version}" ]]; then
+				echo "empty Go version in ${mod_file}" >&2
+				return 1
+			fi
+			printf '%s\n' "${go_version}"
+			return 0
+		fi
+	done <"${mod_file}"
+	echo "unable to read Go version from ${mod_file}" >&2
+	return 1
+}
+
 is_external_importable_path() {
 	local import_path="$1"
 	[[ "${import_path}" != */internal ]] && [[ "${import_path}" != */internal/* ]]
@@ -177,14 +194,16 @@ add_repository_replaces() {
 
 check_module_as_external_consumer() {
 	local mod_file="$1"
-	local mod_dir module_path readable package_file consumer_dir status
+	local mod_dir module_path go_version readable package_file consumer_dir status
 	mod_dir="$(cd "$(dirname "${mod_file}")" && pwd)"
 	readable="$(module_readable_name "${mod_file}")"
 	module_path="$(module_path_from_go_mod "${mod_file}")"
+	go_version="$(minimum_go_version_from_go_mod "${mod_file}")"
 
 	echo "::group::External consumer: ${readable}"
 	echo "module path: ${module_path}"
 	echo "module dir: ${mod_dir}"
+	echo "minimum Go version: ${go_version}"
 
 	package_file="$(mktemp "${tmp_root}/importable-packages.XXXXXX")"
 	if ! list_importable_packages "${mod_dir}" "${package_file}"; then
@@ -206,6 +225,9 @@ check_module_as_external_consumer() {
 	(
 		cd "${consumer_dir}"
 		go mod init example.com/trpc-agent-go-external-consumer
+		# Select the target module's minimum toolchain before resolving its
+		# replacement instead of letting an older runner select the latest Go.
+		go mod edit -go="${go_version}"
 		add_repository_replaces
 		write_consumer_test "${package_file}" "${consumer_dir}/consumer_test.go"
 		go mod tidy


### PR DESCRIPTION
## What changed

External-consumer checks now create each temporary consumer with the target
module's declared minimum Go version. Checks continue to validate every
importable package through local module replacements, but no longer select an
unrelated latest Go release while resolving those replacements.

## Why

The external-consumer jobs start with Go 1.21. For a module such as
`artifact/s3`, whose `go.mod` declares Go 1.22.2, listing its packages first
selects Go 1.22.2. The temporary consumer was then initialized with Go 1.21.
When `go mod tidy` discovered the replaced module's higher requirement,
automatic toolchain selection chose the latest available Go release instead
of the target module's minimum.

This caused the external-consumer check in #2592 to attempt a second download,
for Go 1.26.8. A connection reset during that unnecessary download left the
temporary module without its required dependency and produced the secondary
`replaced but not required` error.

Setting the temporary consumer's `go` directive before adding replacements
makes toolchain selection deterministic, avoids the extra latest-toolchain
download, and tests compatibility at the version declared by the target
module.

## Testing

- `bash -n .github/scripts/check-external-consumer.sh`
- `git diff --check`
- `GOWORK=off GOTOOLCHAIN=go1.21.13+auto bash .github/scripts/check-external-consumer.sh --module artifact/s3/go.mod`
- `GOWORK=off GOTOOLCHAIN=go1.21.13+auto bash .github/scripts/check-external-consumer.sh --module go.mod`

## Notes for reviewers

The failure was unrelated to the `summaryview` changes in #2592. Its only
failed job was the external-consumer check for `artifact/s3`; all source,
build, test, race, lint, API, and benchmark checks passed.

This change affects CI tooling only and does not modify production packages or
module requirements.
