### PR TITLE
internal/state/summaryview: avoid cloning history on failed rebase

### DIFF
--- a/internal/state/summaryview/binding_test.go
+++ b/internal/state/summaryview/binding_test.go
@@ -187,6 +187,82 @@ func TestInvalidateBindingCopiesMetadataAndSharesImmutableItems(t *testing.T) {
 	)
 }
 
+func TestRebaseFailureCopiesMetadataAndSharesImmutableItems(t *testing.T) {
+	history := []model.Message{
+		model.NewUserMessage("first"),
+		model.NewAssistantMessage("second"),
+	}
+	tests := []struct {
+		name          string
+		after         []model.Message
+		sourceIndexes []int
+		reason        string
+	}{
+		{
+			name:   "transform provenance mismatch",
+			after:  []model.Message{model.NewUserMessage("compacted")},
+			reason: BindingReasonTransformMismatch,
+		},
+		{
+			name:          "rebase failure",
+			after:         []model.Message{history[0]},
+			sourceIndexes: []int{0},
+			reason:        BindingReasonRebaseFailed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			invocation := agent.NewInvocation()
+			AttachProjection(invocation, projectionFor(history, len(history)))
+			Finalize(invocation, &model.Request{Messages: history}, 128)
+			invocationView := invocation.View()
+
+			originalState, ok := agent.GetStateValue[*invocationState](
+				invocation,
+				stateKey,
+			)
+			require.True(t, ok)
+			viewState, ok := agent.GetStateValue[*invocationState](
+				invocationView,
+				stateKey,
+			)
+			require.True(t, ok)
+			require.Same(t, originalState, viewState)
+
+			require.False(t, RebaseAfterTransform(
+				invocationView,
+				history,
+				test.after,
+				test.sourceIndexes,
+			))
+
+			failedState, ok := agent.GetStateValue[*invocationState](
+				invocationView,
+				stateKey,
+			)
+			require.True(t, ok)
+			require.NotSame(t, originalState, failedState)
+			require.NotSame(t, originalState.view, failedState.view)
+			require.Same(
+				t,
+				&originalState.view.Items[0],
+				&failedState.view.Items[0],
+			)
+
+			require.True(t, originalState.view.Bound)
+			require.Equal(t, BindingReasonBound, originalState.view.BindingReason)
+			require.Equal(t, len(history), originalState.view.ContentRequestLength)
+			require.False(t, originalState.bindingInvalidated)
+
+			require.False(t, failedState.view.Bound)
+			require.Equal(t, test.reason, failedState.view.BindingReason)
+			require.Equal(t, len(test.after), failedState.view.ContentRequestLength)
+			require.True(t, failedState.bindingInvalidated)
+		})
+	}
+}
+
 func TestBindingFromContextReportsViewState(t *testing.T) {
 	history := []model.Message{
 		model.NewUserMessage("first"),

--- a/internal/state/summaryview/summaryview.go
+++ b/internal/state/summaryview/summaryview.go
@@ -185,9 +185,11 @@ func RebaseAfterTransform(
 		len(before),
 	)
 	if !boundBefore {
-		next := cloneView(state.view)
+		// A published view is immutable. This failure changes only binding
+		// metadata and the request length, so its read-only items can be shared.
+		next := *state.view
 		next.ContentRequestLength = len(after)
-		storeInvalidated(inv, next, BindingReasonTransformMismatch)
+		storeInvalidated(inv, &next, BindingReasonTransformMismatch)
 		return false
 	}
 	transformed, ok := rebaseItems(
@@ -197,9 +199,9 @@ func RebaseAfterTransform(
 		len(before),
 	)
 	if !ok {
-		next := cloneView(state.view)
+		next := *state.view
 		next.ContentRequestLength = len(after)
-		storeInvalidated(inv, next, BindingReasonRebaseFailed)
+		storeInvalidated(inv, &next, BindingReasonRebaseFailed)
 		return false
 	}
 	next := *state.view

--- a/internal/state/summaryview/summaryview_bench_test.go
+++ b/internal/state/summaryview/summaryview_bench_test.go
@@ -87,6 +87,57 @@ func BenchmarkRebaseAfterTransform(b *testing.B) {
 	}
 }
 
+func BenchmarkRebaseAfterTransformFailure(b *testing.B) {
+	const historySize = 64
+	for _, stateDeltaBytes := range []int{0, 1024, 64 * 1024} {
+		invocation, request := summaryViewBenchmarkInput(
+			historySize,
+			stateDeltaBytes,
+		)
+		originalState, ok := agent.GetStateValue[*invocationState](
+			invocation,
+			stateKey,
+		)
+		if !ok {
+			b.Fatal("summary view state is missing")
+		}
+		after := request.Messages[:len(request.Messages)-1]
+		identitySources := make([]int, len(after))
+		for i := range identitySources {
+			identitySources[i] = i
+		}
+		cases := []struct {
+			name          string
+			sourceIndexes []int
+		}{
+			{name: "transform_mismatch"},
+			{name: "rebase_failed", sourceIndexes: identitySources},
+		}
+		for _, benchCase := range cases {
+			b.Run(fmt.Sprintf(
+				"%s/history=%d/state_delta_bytes=%d",
+				benchCase.name,
+				historySize,
+				stateDeltaBytes,
+			), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					// A failure is sticky. Restore the original immutable holder so
+					// every iteration exercises the full failure path.
+					invocation.SetState(stateKey, originalState)
+					summaryViewBoolBenchmarkSink = RebaseAfterTransform(
+						invocation,
+						request.Messages,
+						after,
+						benchCase.sourceIndexes,
+					)
+				}
+			})
+		}
+	}
+}
+
 func BenchmarkRebaseItems(b *testing.B) {
 	for _, historySize := range []int{16, 256, 1024} {
 		b.Run(fmt.Sprintf("split/history=%d/state_delta_bytes=1024", historySize), func(b *testing.B) {


### PR DESCRIPTION
## What changed

Failed summary-view rebases no longer duplicate the complete model-visible history. Both transform-provenance mismatch and incomplete-output rebase failure preserve the existing binding behavior while making allocation independent of nested history payload size.

Regression coverage verifies copy-on-write isolation for both failure reasons, and a benchmark covers increasingly large event state payloads.

## Why

Both failure branches update only `ContentRequestLength`, `Bound`, `BindingReason`, and the private invalidation flag. The published invocation view is immutable: transform binding builds a separate item slice, rebase construction clones nested data before mutation, later mutators replace the holder, and exported readers return isolated copies. The failure branches can therefore share the read-only items safely instead of calling `cloneView`.

This extends the immutable-holder copy-on-write design used by #2476 and the explicit invalidation optimization merged in #2592.

For 64 history items with a 64 KiB state delta per item, the benchmark changes were:

| Failure | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Transform mismatch | 4,307,124 B/op, 453 allocs/op | 47,248 B/op, 131 allocs/op | 98.9% B/op |
| Rebase failed | 4,309,969 B/op, 457 allocs/op | 50,104 B/op, 135 allocs/op | 98.8% B/op |

The remaining allocations come from the message matching and provenance validation that must run before the failure is known.

## Testing

- `GOWORK=off go test ./...`
- `GOWORK=off go test -race ./internal/state/summaryview ./internal/flow/llmflow`
- `GOWORK=off go build ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -run '^$' -bench '^BenchmarkRebaseAfterTransformFailure$' -benchmem -benchtime=50x -count=1 ./internal/state/summaryview`

## Notes for reviewers

No public API, protocol, persistence format, or binding semantics change. The regression test asserts that the parent invocation retains its bound metadata, the failed child gets a distinct holder and view header, and both safely share the immutable item storage.
