### PR TITLE
examples/callbacks/timer: include AfterAgent in timing output

### DIFF
--- a/examples/callbacks/timer/README.md
+++ b/examples/callbacks/timer/README.md
@@ -49,22 +49,32 @@ Timer Example + OpenTelemetry Integration
 ## Timing Output Example
 
 ```
-⏱️  BeforeAgentCallback: tool-timer-assistant started at 11:05:53.759
+⏱️  BeforeAgentCallback: tool-timer-assistant started at 19:52:29.649
    InvocationID: invocation-...
    UserMsg: "calculate 10 + 20"
 
-⏱️  BeforeModelCallback: model started at 11:05:53.760
-   ModelKey: model_1754276753760058036
+⏱️  BeforeModelCallback: model started at 19:52:29.650
    Messages: 2
 
-⏱️  AfterModelCallback: model completed in 5.965324643s
+⏱️  AfterModelCallback: model completed in 20.719832265s
 
-⏱️  BeforeToolCallback: calculator started at 11:05:59.725
-   Args: {"a":10,"b":20,"operation":"add"}
+⏱️  BeforeToolCallback: calculator (call call_...) started at 19:52:50.370
+   Args: {"a": 10, "b": 20, "operation": "add"}
 
-⏱️  AfterToolCallback: calculator completed in 28.224µs
-   Result: {add 10 20 30}
+⏱️  AfterToolCallback: calculator (call call_...) completed in 44.939µs
+   Result: &{add 10 20 30}
+
+⏱️  BeforeModelCallback: model started at 19:52:50.371
+   Messages: 4
+
+⏱️  AfterModelCallback: model completed in 1.144983592s
+
+⏱️  AfterAgentCallback: tool-timer-assistant completed in 21.866556495s
 ```
+
+`AfterAgentCallback` prints after the full agent run finishes, including the
+follow-up model call that turns the tool result into the final answer. It
+reports the total agent duration.
 
 ## Telemetry Data
 

--- a/examples/callbacks/timer/main.go
+++ b/examples/callbacks/timer/main.go
@@ -192,9 +192,6 @@ func (e *toolTimerExample) runExample(ctx context.Context) error {
 			fmt.Printf("❌ Error: %v\n", err)
 			fmt.Println() // Add spacing after error.
 		}
-		// Wait briefly for AfterAgentCallback to complete its output.
-		// This ensures timing information appears before the next prompt.
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -233,11 +230,21 @@ func (e *toolTimerExample) startNewSession() {
 func (e *toolTimerExample) processResponse(eventChan <-chan *event.Event) error {
 	fmt.Print("🤖 Assistant: ")
 
+	// Drain the full event channel so AfterAgentCallback can finish
+	// printing before the next prompt. AfterAgent runs after remaining
+	// events are forwarded; returning on the first final response used
+	// to require a short sleep to wait for that log.
+	finalSeen := false
 	for event := range eventChan {
+		if finalSeen {
+			continue
+		}
+
 		// Handle errors.
 		if event.Error != nil {
 			fmt.Printf("\n❌ Error: %s\n", event.Error.Message)
-			return nil
+			finalSeen = true
+			continue
 		}
 
 		// Handle tool calls.
@@ -271,7 +278,7 @@ func (e *toolTimerExample) processResponse(eventChan <-chan *event.Event) error 
 		// Check if this is the final event.
 		if event.IsFinalResponse() {
 			fmt.Printf("\n")
-			break
+			finalSeen = true
 		}
 	}
 


### PR DESCRIPTION
## What changed

The timer example now documents the complete callback sequence, including the follow-up model call and `AfterAgentCallback` total duration. The example also drains the event channel so that AfterAgent log appears before the next prompt, instead of relying on a 50ms sleep.

## Why

The documented sample stopped after `AfterTool` even though AfterAgent has printed the total agent duration since the example was added. Live reproduction with a real model confirmed AfterAgent does fire after the second model call that turns the tool result into the final answer.

## Testing

- Reproduced `calculate 10 + 20` against an OpenAI-compatible GLM endpoint with both the previous break-plus-sleep consumer and the drain consumer; both printed AfterAgent, and the documented sequence now matches the live output.
- `gofmt` on `examples/callbacks/timer/main.go`.

## Notes for reviewers

No public API or framework callback contract change. This is an example and documentation update only.