### PR TITLE
agent/weknora: retain upstream response IDs in event metadata

### DIFF
--- a/agent/weknora/README.md
+++ b/agent/weknora/README.md
@@ -1,0 +1,24 @@
+# WeKnora streaming metadata
+
+Each streaming run uses a generated `model.Response.ID` shared by its text
+chunks and final completion. The upstream WeKnora ID never replaces this ID.
+
+When WeKnora supplies a non-empty `AgentStreamResponse.ID`, subsequent emitted
+text events and the final completion or stream error include a snapshot in
+`Event.Extensions`:
+
+```json
+{"weknora":{"version":1,"response_id":"upstream-id"}}
+```
+
+`response_id` is the most recently observed non-empty upstream ID at the time
+of emission. Empty IDs do not clear it. IDs on chunks without text are also
+recorded. If upstream IDs change, later events reflect the new ID while earlier
+events retain their original metadata. The extension is omitted until an ID
+is available, and its state is scoped to one run.
+
+Event consumers can read `evt.Extensions["weknora"]` and log the upstream
+`response_id` alongside `evt.Response.ID` on text events to correlate downstream
+messages with WeKnora logs. This is framework event metadata; it does not add
+metadata to the AG-UI wire protocol. No upstream ID is invented when WeKnora
+omits it. Error events retain their existing response identity behavior.

--- a/agent/weknora/weknora_agent.go
+++ b/agent/weknora/weknora_agent.go
@@ -62,10 +62,11 @@ func New(opts ...Option) (*WeKnoraAgent, error) {
 
 // sendErrorEvent sends an error event to the event channel
 func (r *WeKnoraAgent) sendErrorEvent(ctx context.Context, eventChan chan<- *event.Event,
-	invocation *agent.Invocation, errorMessage string) {
+	invocation *agent.Invocation, errorMessage, upstreamID string) {
 	agent.EmitEvent(ctx, invocation, eventChan, event.New(
 		invocation.InvocationID,
 		r.name,
+		withUpstreamResponseID(upstreamID),
 		event.WithResponse(&model.Response{
 			Error: &model.ResponseError{
 				Message: errorMessage,
@@ -158,12 +159,17 @@ func (r *WeKnoraAgent) runStreaming(ctx context.Context, invocation *agent.Invoc
 
 		// All chunks and the final completion belong to one response.
 		responseID := uuid.NewString()
+		var upstreamID string
 		var aggregatedContentBuilder strings.Builder
 		var aggregatedReasoningBuilder strings.Builder
 
 		err := r.weknoraClient.AgentQAStreamWithRequest(ctx, sessionID, req, func(resp *client.AgentStreamResponse) error {
 			if err := agent.CheckContextCancelled(ctx); err != nil {
 				return err
+			}
+
+			if resp.ID != "" {
+				upstreamID = resp.ID
 			}
 
 			if resp.ResponseType == client.AgentResponseTypeAnswer || resp.ResponseType == client.AgentResponseTypeThinking {
@@ -193,6 +199,7 @@ func (r *WeKnoraAgent) runStreaming(ctx context.Context, invocation *agent.Invoc
 							Done:      false,
 						}),
 						event.WithObject(model.ObjectTypeChatCompletionChunk),
+						withUpstreamResponseID(upstreamID),
 					)
 					agent.EmitEvent(ctx, invocation, eventChan, evt)
 				}
@@ -204,12 +211,12 @@ func (r *WeKnoraAgent) runStreaming(ctx context.Context, invocation *agent.Invoc
 		})
 
 		if err != nil {
-			r.sendErrorEvent(ctx, eventChan, invocation, err.Error())
+			r.sendErrorEvent(ctx, eventChan, invocation, err.Error(), upstreamID)
 			return
 		}
 
 		// Send final aggregated event
-		r.sendFinalStreamingEvent(ctx, eventChan, invocation, responseID, aggregatedContentBuilder.String(), aggregatedReasoningBuilder.String())
+		r.sendFinalStreamingEvent(ctx, eventChan, invocation, responseID, aggregatedContentBuilder.String(), aggregatedReasoningBuilder.String(), upstreamID)
 	}()
 
 	return eventChan, nil
@@ -223,10 +230,12 @@ func (r *WeKnoraAgent) sendFinalStreamingEvent(
 	responseID string,
 	aggregatedContent string,
 	aggregatedReasoning string,
+	upstreamID string,
 ) {
 	agent.EmitEvent(ctx, invocation, eventChan, event.New(
 		invocation.InvocationID,
 		r.name,
+		withUpstreamResponseID(upstreamID),
 		event.WithResponse(&model.Response{
 			ID:        responseID,
 			Object:    model.ObjectTypeChatCompletion,
@@ -288,4 +297,18 @@ func (r *WeKnoraAgent) getWeKnoraClient(
 
 func genSessionKey(sessionID string) string {
 	return fmt.Sprintf("weknora_session_%s", sessionID)
+}
+
+// withUpstreamResponseID snapshots the latest non-empty upstream ID without
+// changing the stable response identity used by downstream message consumers.
+func withUpstreamResponseID(upstreamID string) event.Option {
+	return func(evt *event.Event) {
+		if upstreamID == "" {
+			return
+		}
+		event.WithExtension("weknora", struct {
+			Version    int    `json:"version"`
+			ResponseID string `json:"response_id"`
+		}{Version: 1, ResponseID: upstreamID})(evt)
+	}
 }

--- a/agent/weknora/weknora_agent_test.go
+++ b/agent/weknora/weknora_agent_test.go
@@ -11,6 +11,7 @@ package weknora
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -224,7 +225,7 @@ func TestWeKnoraAgent_SendErrorEvent(t *testing.T) {
 	}
 
 	eventChan := make(chan *event.Event, 1)
-	weknoraAgent.sendErrorEvent(context.Background(), eventChan, invocation, "test error message")
+	weknoraAgent.sendErrorEvent(context.Background(), eventChan, invocation, "test error message", "")
 	close(eventChan)
 
 	evt := <-eventChan
@@ -258,7 +259,7 @@ func TestWeKnoraAgent_SendFinalStreamingEvent(t *testing.T) {
 	}
 
 	eventChan := make(chan *event.Event, 1)
-	weknoraAgent.sendFinalStreamingEvent(context.Background(), eventChan, invocation, "test-response", "aggregated content", "aggregated reasoning")
+	weknoraAgent.sendFinalStreamingEvent(context.Background(), eventChan, invocation, "test-response", "aggregated content", "aggregated reasoning", "")
 	close(eventChan)
 
 	evt := <-eventChan
@@ -774,5 +775,123 @@ func TestWeKnoraAgent_RunResponseIdentity(t *testing.T) {
 			t.Error("separate runs must have distinct response IDs")
 		}
 		previousID = responseID
+	}
+}
+
+func TestWeKnoraAgent_RunUpstreamResponseMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		chunks    []string
+		wantIDs   []string
+		wantError bool
+	}{
+		{name: "missing IDs", chunks: []string{`{"response_type":"answer","content":"a"}`}, wantIDs: []string{"", ""}},
+		{name: "stable ID", chunks: []string{`{"id":"upstream","response_type":"thinking","content":"hmm"}`, `{"id":"upstream","response_type":"answer","content":"a"}`}, wantIDs: []string{"upstream", "upstream", "upstream"}},
+		{name: "late and changing IDs", chunks: []string{`{"response_type":"answer","content":"a"}`, `{"id":"first","response_type":"answer","content":"b"}`, `{"response_type":"answer","content":"c"}`, `{"id":"last","response_type":"answer","content":"d"}`}, wantIDs: []string{"", "first", "first", "last", "last"}},
+		{name: "ID only on empty chunk", chunks: []string{`{"id":"upstream","response_type":"answer","content":""}`, `{"response_type":"answer","content":"a"}`}, wantIDs: []string{"upstream", "upstream"}},
+		{name: "ID on terminal chunk", chunks: []string{`{"response_type":"answer","content":"a"}`, `{"id":"terminal","response_type":"answer","done":true}`}, wantIDs: []string{"", "terminal"}},
+		{name: "upstream error", chunks: []string{`{"id":"answer","response_type":"answer","content":"a"}`, `{"id":"failure","response_type":"error","content":"failed"}`}, wantIDs: []string{"answer", "failure"}, wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v1/sessions/default-session":
+					fmt.Fprint(w, `{"success":true,"data":{"id":"default-session"}}`)
+				case "/api/v1/agent-chat/default-session":
+					w.Header().Set("Content-Type", "text/event-stream")
+					requests++
+					for _, chunk := range tt.chunks {
+						if requests > 1 {
+							var payload map[string]any
+							if err := json.Unmarshal([]byte(chunk), &payload); err != nil {
+								t.Error(err)
+								return
+							}
+							delete(payload, "id")
+							data, err := json.Marshal(payload)
+							if err != nil {
+								t.Error(err)
+								return
+							}
+							chunk = string(data)
+						}
+						fmt.Fprintf(w, "data: %s\n\n", chunk)
+					}
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			a, err := New(WithName("test-agent"), WithBaseUrl(server.URL))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			var previousID string
+			for run := 0; run < 2; run++ {
+				stream, err := a.Run(ctx, &agent.Invocation{InvocationID: "inv", Message: model.Message{Content: "query"}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				var events []*event.Event
+				for evt := range stream {
+					events = append(events, evt)
+				}
+				if len(events) != len(tt.wantIDs) {
+					t.Fatalf("got %d events, want %d", len(events), len(tt.wantIDs))
+				}
+				responseID := events[0].Response.ID
+				if responseID == "" || responseID == previousID {
+					t.Fatalf("invalid run identity %q", responseID)
+				}
+				previousID = responseID
+				// Inspect after draining to detect accidental mutation of earlier metadata.
+				for i, evt := range events {
+					data, err := json.Marshal(evt)
+					if err != nil {
+						t.Fatal(err)
+					}
+					var decoded event.Event
+					if err := json.Unmarshal(data, &decoded); err != nil {
+						t.Fatal(err)
+					}
+					var metadata struct {
+						Version    int    `json:"version"`
+						ResponseID string `json:"response_id"`
+					}
+					raw, exists := decoded.Extensions["weknora"]
+					wantID := tt.wantIDs[i]
+					if run > 0 {
+						wantID = ""
+					} // A new run must not inherit upstream metadata.
+					if wantID == "" {
+						if exists {
+							t.Fatalf("unexpected metadata: %s", raw)
+						}
+					} else {
+						if err := json.Unmarshal(raw, &metadata); err != nil {
+							t.Fatal(err)
+						}
+						if metadata.Version != 1 || metadata.ResponseID != wantID {
+							t.Fatalf("event %d metadata: %+v", i, metadata)
+						}
+					}
+					if i == len(events)-1 && tt.wantError {
+						if evt.Response.Error == nil {
+							t.Fatal("expected error event")
+						}
+						continue
+					}
+					if evt.Response.Error != nil || evt.Response.ID != responseID {
+						t.Fatalf("unexpected response: %+v", evt.Response)
+					}
+					if i == len(events)-1 && (!evt.Response.Done || evt.Response.IsPartial || evt.Response.Object != model.ObjectTypeChatCompletion) {
+						t.Fatal("invalid completion")
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What changed

WeKnora streaming events now retain the latest non-empty upstream response ID in versioned `weknora` event metadata. Event consumers can log it alongside the generated response ID to correlate downstream messages with WeKnora logs.

## Why

Follow-up to the non-blocking observability suggestion in https://github.com/trpc-group/trpc-agent-go/pull/2591#discussion_r3990476675. The generated UUID remains the stable message identity, including when upstream IDs are missing or change during a stream.

## Testing

- In `agent/weknora`: `go test ./...`, `go test -race ./...`, `go vet ./...`, and `go build ./...`.
- Regression tests cover missing, stable, late, changing, empty-content and terminal-chunk IDs, upstream errors, JSON round trips, earlier-event snapshots, and isolation across successive runs. The new metadata test fails against the original implementation and passes with this change.
- In `server/agui`: `go test ./...`.
- `gofmt`, `goimports`, and `git diff --check`.

## Notes for reviewers

No exported API or AG-UI wire protocol changes. The additive event extension is omitted until an upstream ID is observed. Final completion and stream error events retain the latest observed ID. This does not assume upstream IDs are stable and does not change existing error response identity behavior.
