### PR TITLE
codeexecutor/jupyter: delete a started kernel when websocket dialing fails

### DIFF
--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -118,7 +118,7 @@ func NewClient(connectionInfo ConnectionInfo) (*Client, error) {
 	}
 	ws, _, err := websocket.DefaultDialer.Dial(wsUrl, reqHeader)
 	if err != nil {
-		return nil, err
+		return nil, c.cleanupAfterStartupFailure(err)
 	}
 
 	c.ws = ws
@@ -269,7 +269,9 @@ func (c *Client) cleanupAfterStartupFailure(err error) error {
 	if cleanupErr := c.deleteKernel(); cleanupErr != nil {
 		err = errors.Join(err, cleanupErr)
 	}
-	_ = c.ws.Close()
+	if c.ws != nil {
+		_ = c.ws.Close()
+	}
 	return err
 }
 

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -265,6 +265,7 @@ func (c *Client) deleteKernel() error {
 	return nil
 }
 
+// cleanupAfterStartupFailure deletes the started kernel and closes the websocket after startup fails.
 func (c *Client) cleanupAfterStartupFailure(err error) error {
 	if cleanupErr := c.deleteKernel(); cleanupErr != nil {
 		err = errors.Join(err, cleanupErr)

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -331,6 +331,7 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	}
 }
 
+// TestNewClientDeletesKernelWhenWebsocketDialFails verifies cleanup after a websocket dial failure.
 func TestNewClientDeletesKernelWhenWebsocketDialFails(t *testing.T) {
 	const token = "secret"
 	kernelDeleted := make(chan struct{})
@@ -376,6 +377,7 @@ func TestNewClientDeletesKernelWhenWebsocketDialFails(t *testing.T) {
 	}
 }
 
+// TestNewClientPreservesWebsocketDialAndKernelCleanupErrors verifies that both startup and cleanup errors are retained.
 func TestNewClientPreservesWebsocketDialAndKernelCleanupErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -331,6 +331,86 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	}
 }
 
+func TestNewClientDeletesKernelWhenWebsocketDialFails(t *testing.T) {
+	const token = "secret"
+	kernelDeleted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/kernelspecs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+		case "/api/kernels":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123":
+			assert.Equal(t, token, strings.TrimPrefix(r.Header.Get("Authorization"), "token "))
+			assert.Equal(t, http.MethodDelete, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+			close(kernelDeleted)
+		case "/api/kernels/123/channels":
+			http.Error(w, "websocket unavailable", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	assert.NoError(t, err)
+
+	_, err = NewClient(ConnectionInfo{
+		Host:             parsed.Hostname(),
+		Port:             port,
+		Token:            token,
+		KernelName:       "python3",
+		WaitReadyTimeout: time.Second,
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "websocket: bad handshake")
+	select {
+	case <-kernelDeleted:
+	case <-time.After(time.Second):
+		t.Fatal("kernel was not deleted after websocket dial failure")
+	}
+}
+
+func TestNewClientPreservesWebsocketDialAndKernelCleanupErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/kernelspecs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+		case "/api/kernels":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123":
+			http.Error(w, "cleanup failed", http.StatusInternalServerError)
+		case "/api/kernels/123/channels":
+			http.Error(w, "websocket unavailable", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	assert.NoError(t, err)
+
+	_, err = NewClient(ConnectionInfo{
+		Host:             parsed.Hostname(),
+		Port:             port,
+		KernelName:       "python3",
+		WaitReadyTimeout: time.Second,
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "websocket: bad handshake")
+	assert.ErrorContains(t, err, "failed to delete kernel")
+}
+
 func TestNewClientPreservesKernelCleanupError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Problem

`NewClient` starts a kernel before dialing its channels websocket. When the websocket handshake fails, the kernel could remain running because the dial error was returned without cleanup. This is especially visible when connecting to an existing or shared Jupyter gateway.

## Changes

- Route websocket dial failures through the existing startup cleanup path.
- Delete the started kernel while preserving both the dial error and any cleanup error.
- Make startup cleanup safe when no websocket connection was established.
- Add regression coverage for kernel deletion, authentication, and combined dial/cleanup errors.

## Tests

- `GOWORK=off go test ./...` in `codeexecutor/jupyter` (Linux pre-PR validation: passed; coverage 88.9%).
- `GOWORK=off go test -race . -run 'TestNewClient(DeletesKernelWhenWebsocketDialFails|PreservesWebsocketDialAndKernelCleanupErrors|ClosesWebsocketWhenReadyFails|PreservesKernelCleanupError)$' -count=3` (passed).
- `GOWORK=off go vet ./...` and `gofmt -l .` (passed).
- `git diff --check` (passed).

## Compatibility / Known limitations

No exported API or successful-startup behavior changes. The full package race suite still reports pre-existing races in fake-Python gateway tests that are outside this change. On Windows, the existing `TestWorkspaceDelegates` path failure and the lack of a local C compiler prevent an equivalent full race run.

Fixes #2598
