### PR TITLE
codeexecutor/jupyter: bound readiness wait on silent websocket

### DIFF
--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -279,19 +280,23 @@ func (c *Client) waitForReady() (bool, error) {
 		return false, err
 	}
 
-	timeout := time.After(c.waitReadyTimeout)
+	if err := c.ws.SetReadDeadline(time.Now().Add(c.waitReadyTimeout)); err != nil {
+		return false, err
+	}
 	for {
-		select {
-		case <-timeout:
-			return false, fmt.Errorf("wait for kernel ready timeout")
-		default:
-		}
 		var message executionMessage
 		if err := c.ws.ReadJSON(&message); err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				return false, fmt.Errorf("wait for kernel ready timeout: %w", err)
+			}
 			return false, err
 		}
 
 		if message.Header.MsgType == "kernel_info_reply" && message.ParentHeader.MsgID == msgID {
+			if err := c.ws.SetReadDeadline(time.Time{}); err != nil {
+				return false, err
+			}
 			return true, nil
 		}
 	}

--- a/codeexecutor/jupyter/jupyter_client.go
+++ b/codeexecutor/jupyter/jupyter_client.go
@@ -274,6 +274,7 @@ func (c *Client) cleanupAfterStartupFailure(err error) error {
 	return err
 }
 
+// waitForReady waits for the kernel_info_reply message within the readiness timeout.
 func (c *Client) waitForReady() (bool, error) {
 	msgID, err := c.sendMessage(map[string]any{}, "shell", "kernel_info_request")
 	if err != nil {

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -332,6 +332,7 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	}
 }
 
+// TestNewClientTimesOutOnSilentWebsocket verifies that a silent readiness websocket is bounded by the timeout.
 func TestNewClientTimesOutOnSilentWebsocket(t *testing.T) {
 	clientClosed := make(chan struct{})
 	kernelDeleted := make(chan struct{})
@@ -420,6 +421,7 @@ func TestNewClientTimesOutOnSilentWebsocket(t *testing.T) {
 	}
 }
 
+// TestNewClientClearsReadDeadlineAfterReady verifies that later execution is not limited by the readiness deadline.
 func TestNewClientClearsReadDeadlineAfterReady(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -491,6 +493,7 @@ type readDeadlineErrorConn struct {
 	calls  int
 }
 
+// SetReadDeadline returns a controlled error on the configured call for testing.
 func (c *readDeadlineErrorConn) SetReadDeadline(deadline time.Time) error {
 	c.calls++
 	if c.calls == c.failOn {
@@ -499,6 +502,7 @@ func (c *readDeadlineErrorConn) SetReadDeadline(deadline time.Time) error {
 	return c.Conn.SetReadDeadline(deadline)
 }
 
+// TestNewClientHandlesReadDeadlineErrors verifies cleanup when setting or clearing the deadline fails.
 func TestNewClientHandlesReadDeadlineErrors(t *testing.T) {
 	for _, test := range []struct {
 		name   string

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -331,6 +331,159 @@ func TestNewClientClosesWebsocketWhenReadyFails(t *testing.T) {
 	}
 }
 
+func TestNewClientTimesOutOnSilentWebsocket(t *testing.T) {
+	clientClosed := make(chan struct{})
+	kernelDeleted := make(chan struct{})
+	wsConnected := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/kernelspecs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+		case "/api/kernels":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123":
+			if r.Method != http.MethodDelete {
+				t.Errorf("kernel cleanup method = %s, want %s", r.Method, http.MethodDelete)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			close(kernelDeleted)
+		case "/api/kernels/123/channels":
+			ws, err := cstUpgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			wsConnected <- ws
+			defer ws.Close()
+			if _, _, err = ws.ReadMessage(); err != nil {
+				close(clientClosed)
+				return
+			}
+			if _, _, err = ws.ReadMessage(); err != nil {
+				close(clientClosed)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	assert.NoError(t, err)
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := NewClient(ConnectionInfo{
+			Host:             parsed.Hostname(),
+			Port:             port,
+			KernelName:       "python3",
+			WaitReadyTimeout: 50 * time.Millisecond,
+		})
+		result <- err
+	}()
+
+	var newClientErr error
+	select {
+	case newClientErr = <-result:
+	case <-time.After(500 * time.Millisecond):
+		select {
+		case ws := <-wsConnected:
+			_ = ws.Close()
+		case <-time.After(time.Second):
+			t.Fatal("websocket was not established")
+		}
+		select {
+		case <-result:
+		case <-time.After(time.Second):
+			t.Fatal("NewClient did not return after the websocket was closed")
+		}
+		t.Fatal("NewClient did not respect WaitReadyTimeout for a silent websocket")
+	}
+	assert.Error(t, newClientErr)
+	assert.ErrorContains(t, newClientErr, "wait for kernel ready timeout")
+
+	select {
+	case <-kernelDeleted:
+	case <-time.After(time.Second):
+		t.Fatal("kernel was not deleted after readiness timeout")
+	}
+	select {
+	case <-clientClosed:
+	case <-time.After(time.Second):
+		t.Fatal("websocket was not closed after readiness timeout")
+	}
+}
+
+func TestNewClientClearsReadDeadlineAfterReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/kernelspecs":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+		case "/api/kernels":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"123"}`))
+		case "/api/kernels/123/channels":
+			ws, err := cstUpgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer ws.Close()
+
+			var message executionMessage
+			if err := ws.ReadJSON(&message); err != nil {
+				return
+			}
+			_ = ws.WriteJSON(map[string]any{
+				"header":        map[string]any{"msg_type": "kernel_info_reply"},
+				"parent_header": map[string]any{"msg_id": message.Header.MsgID},
+			})
+
+			for {
+				if err := ws.ReadJSON(&message); err != nil {
+					return
+				}
+				if message.Header.MsgType == "execute_request" {
+					_ = ws.WriteJSON(map[string]any{
+						"header":        map[string]any{"msg_type": "status"},
+						"parent_header": map[string]any{"msg_id": message.Header.MsgID},
+						"content":       map[string]any{"execution_state": "idle"},
+					})
+					return
+				}
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	assert.NoError(t, err)
+
+	client, err := NewClient(ConnectionInfo{
+		Host:             parsed.Hostname(),
+		Port:             port,
+		KernelName:       "python3",
+		WaitReadyTimeout: 100 * time.Millisecond,
+	})
+	if !assert.NoError(t, err) || !assert.NotNil(t, client) {
+		return
+	}
+	defer client.Close()
+
+	time.Sleep(200 * time.Millisecond)
+	_, err = client.runCode("pass")
+	assert.NoError(t, err)
+}
+
 func TestNewClientPreservesKernelCleanupError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/codeexecutor/jupyter/jupyter_client_test.go
+++ b/codeexecutor/jupyter/jupyter_client_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -482,6 +483,94 @@ func TestNewClientClearsReadDeadlineAfterReady(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	_, err = client.runCode("pass")
 	assert.NoError(t, err)
+}
+
+type readDeadlineErrorConn struct {
+	net.Conn
+	failOn int
+	calls  int
+}
+
+func (c *readDeadlineErrorConn) SetReadDeadline(deadline time.Time) error {
+	c.calls++
+	if c.calls == c.failOn {
+		return fmt.Errorf("read deadline failed")
+	}
+	return c.Conn.SetReadDeadline(deadline)
+}
+
+func TestNewClientHandlesReadDeadlineErrors(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		failOn int
+	}{
+		{name: "setting readiness deadline", failOn: 1},
+		{name: "clearing readiness deadline", failOn: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			kernelDeleted := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/kernelspecs":
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"kernelspecs":{"python3":{"name":"python3"}}}`))
+				case "/api/kernels":
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte(`{"id":"123"}`))
+				case "/api/kernels/123":
+					w.WriteHeader(http.StatusNoContent)
+					close(kernelDeleted)
+				case "/api/kernels/123/channels":
+					ws, err := cstUpgrader.Upgrade(w, r, nil)
+					if err != nil {
+						return
+					}
+					defer ws.Close()
+					var message executionMessage
+					if err := ws.ReadJSON(&message); err != nil {
+						return
+					}
+					_ = ws.WriteJSON(map[string]any{
+						"header":        map[string]any{"msg_type": "kernel_info_reply"},
+						"parent_header": map[string]any{"msg_id": message.Header.MsgID},
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			originalNetDialContext := websocket.DefaultDialer.NetDialContext
+			defer func() {
+				websocket.DefaultDialer.NetDialContext = originalNetDialContext
+			}()
+			websocket.DefaultDialer.NetDialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+				conn, err := (&net.Dialer{}).DialContext(ctx, network, address)
+				if err != nil {
+					return nil, err
+				}
+				return &readDeadlineErrorConn{Conn: conn, failOn: test.failOn}, nil
+			}
+
+			parsed, err := url.Parse(server.URL)
+			assert.NoError(t, err)
+			port, err := strconv.Atoi(parsed.Port())
+			assert.NoError(t, err)
+			_, err = NewClient(ConnectionInfo{
+				Host:             parsed.Hostname(),
+				Port:             port,
+				KernelName:       "python3",
+				WaitReadyTimeout: time.Second,
+			})
+			assert.ErrorContains(t, err, "read deadline failed")
+
+			select {
+			case <-kernelDeleted:
+			case <-time.After(time.Second):
+				t.Fatal("kernel was not deleted after a read deadline error")
+			}
+		})
+	}
 }
 
 func TestNewClientPreservesKernelCleanupError(t *testing.T) {


### PR DESCRIPTION
## Problem

During the `NewClient` readiness handshake, `waitForReady` checked the timeout only before calling the blocking websocket read. If the websocket stayed open but the kernel sent no message, `WaitReadyTimeout` was not enforced and startup cleanup could not run.

## Changes

- Set a read deadline for the readiness handshake.
- Convert a websocket read timeout into a readiness-timeout error while preserving the underlying cause.
- Clear the read deadline after a successful `kernel_info_reply` so it does not affect later code execution.
- Add regression coverage for silent websocket timeout, kernel cleanup, websocket closure, and post-startup execution.

## Tests

- `GOWORK=off go test ./...` in `codeexecutor/jupyter` via the Linux pre-PR runner (passed; coverage 88.3%).
- `GOWORK=off go test -race . -run 'TestNewClient(HandlesReadDeadlineErrors|TimesOutOnSilentWebsocket|ClearsReadDeadlineAfterReady|ClosesWebsocketWhenReadyFails|PreservesKernelCleanupError)$' -count=3` via the Linux pre-PR runner (passed).
- `GOWORK=off go test . -skip '^TestWorkspaceDelegates$'` on Windows (passed).
- `GOWORK=off go test . -run 'TestNewClient(TimesOutOnSilentWebsocket|ClearsReadDeadlineAfterReady)$' -count=10` on Windows (passed).
- `GOWORK=off go vet .`, gofmt, and `git diff --check` (passed).

## Compatibility / Known limitations

No exported API changes. Successful startup clears the temporary readiness deadline before returning. The full package test on Windows still has the pre-existing `TestWorkspaceDelegates` path failure, and the local Windows environment has no C compiler for an equivalent full race run.

Fixes #2599
