### PR TITLE
internal/tool: support enum constraints for array items

### DIFF
--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -226,6 +226,7 @@ For Function Tools, the input `req` is automatically converted into a JSON Schem
 
 - **Field name**: use `json:"..."` as the schema property name.
 - **Field description (recommended)**: use `jsonschema:"description=..."` to populate `properties.<field>.description`.
+- **Enum constraints**: use `jsonschema:"enum=foo,enum=bar,enum=baz"` on a scalar field or a slice/array such as `Values []string`. For slices and arrays, the enum applies to `items` (the innermost items for nested arrays), not to the entire array. Pointer fields/elements are dereferenced, and numeric and boolean values retain their JSON types.
 - **String pattern constraint**: use `jsonschema:"pattern=^[a-z0-9_-]+$"` to populate `properties.<field>.pattern`.
 - **Manual schemas**: when constructing `tool.Schema` directly, set `Pattern: "^[a-z0-9_-]+$"` to emit the JSON Schema `pattern` keyword.
 - **Note**: the `jsonschema` tag uses comma `,` as the separator, so **the description value must not contain `,`**; otherwise it will be parsed as multiple tag items.

--- a/docs/mkdocs/en/tool.md
+++ b/docs/mkdocs/en/tool.md
@@ -226,7 +226,7 @@ For Function Tools, the input `req` is automatically converted into a JSON Schem
 
 - **Field name**: use `json:"..."` as the schema property name.
 - **Field description (recommended)**: use `jsonschema:"description=..."` to populate `properties.<field>.description`.
-- **Enum constraints**: use `jsonschema:"enum=foo,enum=bar,enum=baz"` on a scalar field or a slice/array such as `Values []string`. For slices and arrays, the enum applies to `items` (the innermost items for nested arrays), not to the entire array. Pointer fields/elements are dereferenced, and numeric and boolean values retain their JSON types.
+- **Enum constraints**: use `jsonschema:"enum=foo,enum=bar,enum=baz"` on a scalar field or a slice/array such as `Values []string`. For slices and arrays, the enum applies to `items` (the innermost items for nested arrays), not to the entire array. Pointer fields/elements are dereferenced, and numeric and boolean values retain their JSON types. Unsigned integer enums accept the full range of their Go type; negative and out-of-range values are rejected during tag parsing.
 - **String pattern constraint**: use `jsonschema:"pattern=^[a-z0-9_-]+$"` to populate `properties.<field>.pattern`.
 - **Manual schemas**: when constructing `tool.Schema` directly, set `Pattern: "^[a-z0-9_-]+$"` to emit the JSON Schema `pattern` keyword.
 - **Note**: the `jsonschema` tag uses comma `,` as the separator, so **the description value must not contain `,`**; otherwise it will be parsed as multiple tag items.

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -213,7 +213,7 @@ Function Tool 的入参 `req` 会自动生成对应的 JSON Schema（用于模�
 
 - **字段名**：使用 `json:"..."` 作为 schema 的字段名。
 - **字段描述（推荐）**：使用 `jsonschema:"description=..."` 写入 schema 的 `properties.<field>.description`。
-- **枚举约束**：在标量字段或 `Values []string` 这样的切片/数组字段上使用 `jsonschema:"enum=foo,enum=bar,enum=baz"`。切片和数组的枚举约束会写入 `items`（嵌套数组为最内层元素），而不是约束整个数组。支持指针字段和指针元素，数值和布尔值会保留对应的 JSON 类型。
+- **枚举约束**：在标量字段或 `Values []string` 这样的切片/数组字段上使用 `jsonschema:"enum=foo,enum=bar,enum=baz"`。切片和数组的枚举约束会写入 `items`（嵌套数组为最内层元素），而不是约束整个数组。支持指针字段和指针元素，数值和布尔值会保留对应的 JSON 类型。 无符号整数枚举支持对应 Go 类型的完整取值范围；负数和越界值会在标签解析时被拒绝。
 - **字符串正则约束**：使用 `jsonschema:"pattern=^[a-z0-9_-]+$"` 写入 schema 的 `properties.<field>.pattern`。
 - **手写 schema**：如果直接构造 `tool.Schema`，可设置 `Pattern: "^[a-z0-9_-]+$"` 输出 JSON Schema 的 `pattern` 关键字。
 - **注意**：`jsonschema` tag 内部使用英文逗号 `,` 作为分隔符，因此 **description 内容中不能包含 `,`**，否则会被误解析成多个 tag。

--- a/docs/mkdocs/zh/tool.md
+++ b/docs/mkdocs/zh/tool.md
@@ -213,6 +213,7 @@ Function Tool 的入参 `req` 会自动生成对应的 JSON Schema（用于模�
 
 - **字段名**：使用 `json:"..."` 作为 schema 的字段名。
 - **字段描述（推荐）**：使用 `jsonschema:"description=..."` 写入 schema 的 `properties.<field>.description`。
+- **枚举约束**：在标量字段或 `Values []string` 这样的切片/数组字段上使用 `jsonschema:"enum=foo,enum=bar,enum=baz"`。切片和数组的枚举约束会写入 `items`（嵌套数组为最内层元素），而不是约束整个数组。支持指针字段和指针元素，数值和布尔值会保留对应的 JSON 类型。
 - **字符串正则约束**：使用 `jsonschema:"pattern=^[a-z0-9_-]+$"` 写入 schema 的 `properties.<field>.pattern`。
 - **手写 schema**：如果直接构造 `tool.Schema`，可设置 `Pattern: "^[a-z0-9_-]+$"` 输出 JSON Schema 的 `pattern` 关键字。
 - **注意**：`jsonschema` tag 内部使用英文逗号 `,` 作为分隔符，因此 **description 内容中不能包含 `,`**，否则会被误解析成多个 tag。

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -241,7 +241,15 @@ func isStringFieldType(fieldType reflect.Type) bool {
 }
 
 // appendEnumValue parses and appends a typed enum value to the schema.
+// For arrays and slices, enum tags constrain the innermost item schema.
 func appendEnumValue(fieldType reflect.Type, value string, schema *tool.Schema) error {
+	switch fieldType.Kind() {
+	case reflect.Ptr:
+		return appendEnumValue(fieldType.Elem(), value, schema)
+	case reflect.Array, reflect.Slice:
+		return appendEnumValue(fieldType.Elem(), value, schema.Items)
+	}
+
 	if schema.Enum == nil {
 		schema.Enum = make([]any, 0)
 	}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -256,11 +256,16 @@ func appendEnumValue(fieldType reflect.Type, value string, schema *tool.Schema) 
 	switch fieldType.Kind() {
 	case reflect.String:
 		schema.Enum = append(schema.Enum, value)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return fmt.Errorf("parse enum value %v to int64 failed: %w", value, err)
+		}
+		schema.Enum = append(schema.Enum, v)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := strconv.ParseUint(value, 10, fieldType.Bits())
+		if err != nil {
+			return fmt.Errorf("parse enum value %v to %v failed: %w", value, fieldType, err)
 		}
 		schema.Enum = append(schema.Enum, v)
 	case reflect.Float32, reflect.Float64:

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -1129,6 +1129,7 @@ func TestGenerateJSONSchema_DefSchemaIsolation(t *testing.T) {
 	require.Contains(t, defNode.Required, "value")
 }
 
+// TestGenerateJSONSchema_ArrayItemEnum verifies enum placement and typed values across containers.
 func TestGenerateJSONSchema_ArrayItemEnum(t *testing.T) {
 	type status string
 	tests := []struct {
@@ -1141,6 +1142,12 @@ func TestGenerateJSONSchema_ArrayItemEnum(t *testing.T) {
 	}{
 		{"strings", reflect.TypeOf([]string{}), "enum=foo,enum=bar,enum=baz", "string", []any{"foo", "bar", "baz"}, 1},
 		{"fixed array", reflect.TypeOf([2]int{}), "enum=1,enum=2", "integer", []any{int64(1), int64(2)}, 1},
+		{"uint64 maximum", reflect.TypeOf([]uint64{}), "enum=18446744073709551615", "integer", []any{uint64(18446744073709551615)}, 1},
+		{"uint8 maximum", reflect.TypeOf([]uint8{}), "enum=255", "integer", []any{uint64(255)}, 1},
+		{"unsigned negative", reflect.TypeOf([]uint64{}), "enum=-1", "integer", []any{}, 1},
+		{"unsigned overflow", reflect.TypeOf([]uint8{}), "enum=256", "integer", []any{}, 1},
+		{"uint64 overflow", reflect.TypeOf([]uint64{}), "enum=18446744073709551616", "integer", []any{}, 1},
+		{"unsigned scalar", reflect.TypeOf(uint64(0)), "enum=18446744073709551615", "integer", []any{uint64(18446744073709551615)}, 0},
 		{"numbers", reflect.TypeOf([]float64{}), "enum=1.5,enum=2.5", "number", []any{1.5, 2.5}, 1},
 		{"booleans", reflect.TypeOf([]bool{}), "enum=true,enum=false", "boolean", []any{true, false}, 1},
 		{"named strings", reflect.TypeOf([]status{}), "enum=foo,enum=bar", "string", []any{"foo", "bar"}, 1},

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -1128,3 +1128,44 @@ func TestGenerateJSONSchema_DefSchemaIsolation(t *testing.T) {
 	require.Equal(t, "#/$defs/node", defNode.Properties["next"].Ref)
 	require.Contains(t, defNode.Required, "value")
 }
+
+func TestGenerateJSONSchema_ArrayItemEnum(t *testing.T) {
+	type status string
+	tests := []struct {
+		name      string
+		fieldType reflect.Type
+		tag       string
+		itemType  string
+		want      []any
+		depth     int
+	}{
+		{"strings", reflect.TypeOf([]string{}), "enum=foo,enum=bar,enum=baz", "string", []any{"foo", "bar", "baz"}, 1},
+		{"fixed array", reflect.TypeOf([2]int{}), "enum=1,enum=2", "integer", []any{int64(1), int64(2)}, 1},
+		{"numbers", reflect.TypeOf([]float64{}), "enum=1.5,enum=2.5", "number", []any{1.5, 2.5}, 1},
+		{"booleans", reflect.TypeOf([]bool{}), "enum=true,enum=false", "boolean", []any{true, false}, 1},
+		{"named strings", reflect.TypeOf([]status{}), "enum=foo,enum=bar", "string", []any{"foo", "bar"}, 1},
+		{"pointer elements", reflect.TypeOf([]*string{}), "enum=foo,enum=bar", "string", []any{"foo", "bar"}, 1},
+		{"pointer slice", reflect.TypeOf((*[]string)(nil)), "enum=foo,enum=bar", "string", []any{"foo", "bar"}, 1},
+		{"nested arrays", reflect.TypeOf([][2]string{}), "enum=foo,enum=bar", "string", []any{"foo", "bar"}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typ := reflect.StructOf([]reflect.StructField{{
+				Name: "Values", Type: tt.fieldType,
+				Tag: reflect.StructTag(`json:"values" jsonschema:"description=Allowed values,required,` + tt.tag + `"`),
+			}})
+			schema := GenerateJSONSchema(typ)
+			require.Contains(t, schema.Required, "values")
+			field := schema.Properties["values"]
+			require.Equal(t, "Allowed values", field.Description)
+			for i := 0; i < tt.depth; i++ {
+				require.Equal(t, "array", field.Type)
+				require.Empty(t, field.Enum, "enum must constrain items rather than the whole array")
+				require.NotNil(t, field.Items)
+				field = field.Items
+			}
+			require.Equal(t, tt.itemType, field.Type)
+			require.Equal(t, tt.want, field.Enum)
+		})
+	}
+}

--- a/tool/function/function_tool_test.go
+++ b/tool/function/function_tool_test.go
@@ -1047,3 +1047,36 @@ func TestStreamableFunctionTool_WithBothCustomSchemas(t *testing.T) {
 		t.Errorf("expected output schema type 'object', got %q", decl.OutputSchema.Type)
 	}
 }
+
+func TestFunctionTool_ArrayItemEnumSchema(t *testing.T) {
+	type args struct {
+		Values []string `json:"values" jsonschema:"enum=foo,enum=bar,enum=baz"`
+	}
+	fn := func(_ context.Context, input args) (args, error) { return input, nil }
+	fTool := function.NewFunctionTool(fn, function.WithName("array_enum"))
+	declaration := fTool.Declaration()
+	for _, schema := range []*tool.Schema{declaration.InputSchema, declaration.OutputSchema} {
+		encoded, err := json.Marshal(schema.Properties["values"])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var actual map[string]any
+		if err := json.Unmarshal(encoded, &actual); err != nil {
+			t.Fatal(err)
+		}
+		if actual["type"] != "array" {
+			t.Fatalf("expected array schema, got %s", encoded)
+		}
+		if _, ok := actual["enum"]; ok {
+			t.Fatalf("enum must not constrain the whole array: %s", encoded)
+		}
+		items, ok := actual["items"].(map[string]any)
+		if !ok || items["type"] != "string" {
+			t.Fatalf("expected string items, got %s", encoded)
+		}
+		enums, ok := items["enum"].([]any)
+		if !ok || len(enums) != 3 || enums[0] != "foo" || enums[1] != "bar" || enums[2] != "baz" {
+			t.Fatalf("expected foo/bar/baz item enum, got %s", encoded)
+		}
+	}
+}

--- a/tool/function/function_tool_test.go
+++ b/tool/function/function_tool_test.go
@@ -1048,14 +1048,31 @@ func TestStreamableFunctionTool_WithBothCustomSchemas(t *testing.T) {
 	}
 }
 
+// TestFunctionTool_ArrayItemEnumSchema verifies item constraints survive declaration serialization.
 func TestFunctionTool_ArrayItemEnumSchema(t *testing.T) {
 	type args struct {
 		Values []string `json:"values" jsonschema:"enum=foo,enum=bar,enum=baz"`
+		IDs    []uint64 `json:"ids" jsonschema:"enum=18446744073709551615"`
 	}
 	fn := func(_ context.Context, input args) (args, error) { return input, nil }
 	fTool := function.NewFunctionTool(fn, function.WithName("array_enum"))
 	declaration := fTool.Declaration()
 	for _, schema := range []*tool.Schema{declaration.InputSchema, declaration.OutputSchema} {
+		ids, err := json.Marshal(schema.Properties["ids"])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var idSchema struct {
+			Items struct {
+				Enum []uint64 `json:"enum"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(ids, &idSchema); err != nil {
+			t.Fatal(err)
+		}
+		if len(idSchema.Items.Enum) != 1 || idSchema.Items.Enum[0] != ^uint64(0) {
+			t.Fatalf("expected exact uint64 maximum item enum, got %s", ids)
+		}
 		encoded, err := json.Marshal(schema.Properties["values"])
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## What changed

`jsonschema:"enum=..."` now constrains slice and array items, including nested arrays and pointer elements. Unsigned integer enums support their full Go type range, including the maximum `uint64`, and reject negative or out-of-range values during tag parsing.

## Why

Enum parsing previously received the container type and omitted item constraints. The shared integer parser also treated unsigned values as `int64`, rejecting valid large values and accepting invalid unsigned values.

Fixes #2596.

## Testing

- Added generator regression coverage for containers, typed values, unsigned limits, negative values, and overflow.
- Added function-tool input/output declaration coverage, including exact JSON serialization of the maximum `uint64`.
- `go test -race ./internal/tool ./tool/function`
- `go build ./...`
- `golangci-lint run --timeout=10m`
- Root `go test ./...` did not pass locally: `internal/skillstage` and `tool/duckduckgo` failed, and the stalled `agent/llmagent` test process was interrupted after about three minutes.
- Changed Go files pass `goimports`, `gofmt`, and `git diff --check`.

## Notes for reviewers

No exported API or schema field is added. Signed integer parsing remains unchanged. Unsigned enums now use `uint64` values in `Schema.Enum`; valid existing values retain the same JSON representation. Invalid enum tags continue to follow the existing log-and-continue behavior.
